### PR TITLE
fix(comptime): coerce value-context $mach.* integer paths like int literals

### DIFF
--- a/src/lang/fe/comptime.mach
+++ b/src/lang/fe/comptime.mach
@@ -711,6 +711,32 @@ fun eval_ident(
     ret ok[CTValue, str](unwrap[*NamedConst](nc_opt).value);
 }
 
+# reports whether `e` is a comptime path expression: a bare COMPTIME_IDENT
+# (`$foo`) or a chain of MEMBER expressions whose leftmost root is a
+# COMPTIME_IDENT (`$mach.target.os`). a path is comptime-evaluable in form
+# regardless of whether it resolves to a recognized `$mach.*` value; callers
+# fold it via `eval` to obtain the value and learn whether it resolves.
+# ---
+# a: the ast that owns `e`
+# e: expression id to test
+# ret: true when `e` is structurally a comptime path
+pub fun is_comptime_path(a: *ast.Ast, e: id.ExprId) bool {
+    var cur: id.ExprId = e;
+    for (true) {
+        if (cur == id.EXPR_NIL) { ret false; }
+        val n_opt: Option[*expr.Expr] = ast.get_expr(a, cur);
+        if (is_none[*expr.Expr](n_opt)) { ret false; }
+        val node: *expr.Expr = unwrap[*expr.Expr](n_opt);
+        if (node.kind == expr.EXPR_KIND_COMPTIME_IDENT) { ret true; }
+        if (node.kind == expr.EXPR_KIND_MEMBER) {
+            cur = node.data.member.object;
+            cnt;
+        }
+        ret false;
+    }
+    ret false;
+}
+
 # resolves a `$mach.<...>` path expression. the path may bottom out at a
 # COMPTIME_IDENT (single-segment, e.g. `$foo`) or be a chain of MEMBER
 # expressions whose leftmost root is a COMPTIME_IDENT.

--- a/src/lang/fe/sema/coerce.mach
+++ b/src/lang/fe/sema/coerce.mach
@@ -22,17 +22,22 @@ use std.types.bool.bool;
 use std.types.size.usize;
 use std.types.bool.true;
 use std.types.bool.false;
+use std.types.string.str;
 use std.types.option.Option;
 use std.types.option.some;
 use std.types.option.none;
 use std.types.option.is_none;
 use std.types.option.unwrap;
+use std.types.result.Result;
+use std.types.result.is_err;
+use std.types.result.unwrap_ok;
 
-use ty:   mach.lang.type;
-use ast:  mach.lang.fe.ast;
-use id:   mach.lang.fe.ast.id;
-use expr: mach.lang.fe.ast.expr;
-use sema: mach.lang.fe.sema.context;
+use ty:       mach.lang.type;
+use ast:      mach.lang.fe.ast;
+use id:       mach.lang.fe.ast.id;
+use expr:     mach.lang.fe.ast.expr;
+use comptime: mach.lang.fe.comptime;
+use sema:     mach.lang.fe.sema.context;
 
 # attempts to fix an untyped literal expression to a requested destination
 # type. only literal expressions whose form admits the destination are
@@ -99,6 +104,9 @@ fun coerce_to(sc: *sema.SemaContext, eid: id.ExprId, to: ty.TypeId, negated: boo
         if (!is_pointer(sc, to)) { ret none[ty.TypeId](); }
         ret commit(sc, eid, to);
     }
+    if (e.kind == expr.EXPR_KIND_COMPTIME_IDENT || e.kind == expr.EXPR_KIND_MEMBER) {
+        ret coerce_comptime_int_path(sc, eid, to, negated);
+    }
     if (e.kind == expr.EXPR_KIND_UNARY) {
         ret coerce_unary(sc, eid, ?e.data.unary, to, negated);
     }
@@ -107,6 +115,22 @@ fun coerce_to(sc: *sema.SemaContext, eid: id.ExprId, to: ty.TypeId, negated: boo
     }
 
     ret none[ty.TypeId]();
+}
+
+# coerces a comptime path that folds to an integer (`$mach.target.os`, ...)
+# to a destination integer type, mirroring an integer literal: the folded
+# value is range-checked against the destination width/signedness, and on a
+# fit the path's expr_type slot is committed to `to`. a path that is not a
+# comptime path or does not fold to an integer yields none, so it is treated
+# as an ordinary (non-coercible) expression.
+fun coerce_comptime_int_path(sc: *sema.SemaContext, eid: id.ExprId, to: ty.TypeId, negated: bool) Option[ty.TypeId] {
+    if (!comptime.is_comptime_path(sc.a, eid)) { ret none[ty.TypeId](); }
+    val ev: Result[comptime.CTValue, str] = comptime.eval(sc.ctx, sc.a, sc.source, eid, ?sc.s.interner);
+    if (is_err[comptime.CTValue, str](ev)) { ret none[ty.TypeId](); }
+    val cv: comptime.CTValue = unwrap_ok[comptime.CTValue, str](ev);
+    if (cv.kind != comptime.CT_KIND_INT) { ret none[ty.TypeId](); }
+    if (!int_literal_fits(cv.data.i::u64, to, negated)) { ret none[ty.TypeId](); }
+    ret commit(sc, eid, to);
 }
 
 # coerces a unary `-`/`~` node by coercing its operand to `to`; `+`-domain

--- a/src/lang/fe/sema/infer.mach
+++ b/src/lang/fe/sema/infer.mach
@@ -214,8 +214,11 @@ pub fun infer_expr(sc: *sema.SemaContext, eid: id.ExprId) type.TypeId {
         t = infer_ident(sc, eid);
     }
     or (e.kind == expr.EXPR_KIND_COMPTIME_IDENT) {
-        sema.report(sc, e.span, "cannot infer type: comptime identifier in value context");
-        t = type.TYPE_ERROR;
+        t = infer_comptime_int_path(sc, eid);
+        if (t == type.TYPE_NIL) {
+            sema.report(sc, e.span, "cannot infer type: comptime identifier in value context");
+            t = type.TYPE_ERROR;
+        }
     }
     or (e.kind == expr.EXPR_KIND_BINARY) {
         t = infer_binary(sc, eid, ?e.data.binary, e.span);
@@ -532,6 +535,12 @@ fun infer_member(sc: *sema.SemaContext, eid: id.ExprId, m: *expr.ExprMember, spa
         ret sema.decl_type_for(sc, unwrap[*resolve.Symbol](qsym_opt));
     }
 
+    # a `$mach.*` member chain (rooted at a `$` comptime ident) is a comptime
+    # path, not a field access; its object is not a real record value. fold it
+    # to a comptime-int type when it resolves to an integer.
+    val cti: type.TypeId = infer_comptime_int_path(sc, eid);
+    if (cti != type.TYPE_NIL) { ret cti; }
+
     val ot: type.TypeId = infer_expr(sc, m.object);
     if (ot == type.TYPE_ERROR || ot == type.TYPE_NIL) { ret type.TYPE_ERROR; }
 
@@ -541,6 +550,21 @@ fun infer_member(sc: *sema.SemaContext, eid: id.ExprId, m: *expr.ExprMember, spa
     val r: Option[type.TypeId] = check.check_member(sc, ot, name_id, span);
     if (is_none[type.TypeId](r)) { ret type.TYPE_ERROR; }
     ret unwrap[type.TypeId](r);
+}
+
+# types a value-context comptime path (`$mach.target.os`, `$mach.os.linux`,
+# `$mach.target.pointer_width`, ...) that folds to an integer. such a path
+# takes the default concrete comptime-int type (TYPE_I64) and then narrows to
+# the usage-site type via `coerce.try_coerce_literal`, exactly like an integer
+# literal. returns TYPE_NIL when `eid` is not a comptime path or the path does
+# not fold to an integer, so the caller falls back to its normal handling.
+fun infer_comptime_int_path(sc: *sema.SemaContext, eid: id.ExprId) type.TypeId {
+    if (!comptime.is_comptime_path(sc.a, eid)) { ret type.TYPE_NIL; }
+    val ev: Result[comptime.CTValue, str] = comptime.eval(sc.ctx, sc.a, sc.source, eid, ?sc.s.interner);
+    if (is_err[comptime.CTValue, str](ev)) { ret type.TYPE_NIL; }
+    val cv: comptime.CTValue = unwrap_ok[comptime.CTValue, str](ev);
+    if (cv.kind != comptime.CT_KIND_INT) { ret type.TYPE_NIL; }
+    ret prim_or_error(sc, type.TYPE_I64);
 }
 
 # materializes the field layout of `tid` (and, if `tid` is a pointer, its

--- a/src/lang/me/lower/expr.mach
+++ b/src/lang/me/lower/expr.mach
@@ -457,6 +457,12 @@ fun lower_member_rvalue(ctx: *lower.LowerContext, eid: aid.ExprId, e: *aexpr.Exp
         ret symbol_reference(ctx, eid, qsid);
     }
 
+    # a `$mach.*` member chain (rooted at a `$` comptime ident) is a comptime
+    # path, not a field access; fold it to the constant the evaluator produces.
+    if (comptime.is_comptime_path(ctx.a, eid)) {
+        ret lower_comptime_path(ctx, eid);
+    }
+
     val ptr_r: Result[value.Value, str] = lower_member_lvalue(ctx, eid, e);
     if (is_err[value.Value, str](ptr_r)) { ret ptr_r; }
     val tr: Result[ir_type.IrTypeId, str] = ir_type_of_expr(ctx, eid);
@@ -1020,6 +1026,16 @@ fun lower_comptime_ident(ctx: *lower.LowerContext, eid: aid.ExprId, e: *aexpr.Ex
         ret err[value.Value, str]("lower: comptime identifier not folded");
     }
     ret const_value_of(ctx, eid, unwrap[*comptime.NamedConst](nc).value);
+}
+
+# folds a value-context comptime path (`$mach.target.os`, `$mach.os.linux`, ...)
+# to its constant value via the comptime evaluator and materializes it at the
+# expression's IR type. used for `$mach.*` member chains in rvalue position,
+# whose semantic type was set to the usage-site type during coercion.
+fun lower_comptime_path(ctx: *lower.LowerContext, eid: aid.ExprId) Result[value.Value, str] {
+    val ev: Result[comptime.CTValue, str] = comptime.eval(ctx.ctx, ctx.a, module_source(ctx), eid, ?ctx.s.interner);
+    if (is_err[comptime.CTValue, str](ev)) { ret err[value.Value, str](unwrap_err[comptime.CTValue, str](ev)); }
+    ret const_value_of(ctx, eid, unwrap_ok[comptime.CTValue, str](ev));
 }
 
 # lowers an array literal into an alloca plus a per-element store through a


### PR DESCRIPTION
Closes #1015

## Problem

A `$mach.*` comptime path in *value* position (`val X: u32 = $mach.target.os;`) was rejected. In value context it hit the "comptime identifier in value context" error in `infer.mach` and typed as `TYPE_ERROR`, so it could not flow into an annotated integer slot the way an integer literal does. Only plain integer literals got coerced to the destination type, leaving the asymmetry #1014 worked around with `$if` helpers.

## Fix

An integer-valued `$mach.*` path now types and coerces exactly like an integer literal, across three coordinated phases plus one shared helper:

- **`comptime.is_comptime_path`** (new, `comptime.mach`): centralizes structural detection of a `COMPTIME_IDENT`-rooted path (bare `$foo` or a `MEMBER` chain rooted at `$mach`).
- **infer** (`infer.mach`): a value-context comptime path that folds to an integer takes the default concrete comptime-int type (`TYPE_I64`), so it can narrow via `try_coerce_literal`. Wired into both the `COMPTIME_IDENT` case and `infer_member` (a `$mach.*` chain is a comptime path, not a field access).
- **coerce** (`coerce.mach`): `coerce_to` narrows a comptime-foldable integer path to the destination integer type, range-checked like a literal, committing the path's `expr_type` slot.
- **lower** (`expr.mach`): a `$mach.*` member chain in rvalue position folds via the comptime evaluator to a `const_int` at the expression's IR type.

Scoped to integer-valued paths. Non-integer and stubbed `$mach.*` paths keep their existing diagnostics; `$if` condition-context evaluation is unchanged.

## Verification

A test program binding several `$mach.*` integer paths in value position with explicit annotations, then checking each folded value at runtime via the process exit code (linux/x86_64 target):

```mach
val OS:    u32 = $mach.target.os;            # 1
val LINUX: u32 = $mach.os.linux;             # 1
val ARCH:  u32 = $mach.target.arch;          # 1
val X86:   u32 = $mach.arch.x86_64;          # 1
val PTRW:  u64 = $mach.target.pointer_width; # 8
val OS_I8: i8  = $mach.target.os;            # narrow signed coercion
val SUM:   u32 = $mach.target.os + $mach.target.arch; # in-expression use
```

- Build exit 0; program exit 0 (all checks pass).
- Negative controls confirm the values are genuinely folded: breaking the `pointer_width` expectation yields exit 5, and asserting `OS == 1` yields its branch code — the test isn't a false negative.
- `$if ($mach.target.os == $mach.os.linux)` still evaluates correctly (no regression).
- The integer `$mach.*` lines from `examples/full/core/comptime.mach` (`$mach.target.os == $mach.os.linux`, `$mach.target.arch == $mach.arch.x86_64`, `$mach.target.pointer_width`) now compile and run (build/run exit 0), where they previously errored.

Full `make clean && make` bootstrap (cmach→imach→smach→mach) exits 0.
