### PR TITLE
feat(diagnostics): render source line with caret underline under the error span

### DIFF
--- a/src/cli/cmd/build.mach
+++ b/src/cli/cmd/build.mach
@@ -50,6 +50,7 @@ use diag:   mach.lang.diagnostic;
 use driver: mach.lang.driver;
 
 use sema:    mach.lang.fe.sema;
+use token:   mach.lang.fe.token;
 
 use ir:       mach.lang.me.ir;
 use lower:    mach.lang.me.lower;
@@ -776,8 +777,9 @@ fun free_paths(alloc: *Allocator, paths: **u8, n: u32, cap: u32) {
 }
 
 # flush_diagnostics: render every diagnostic to stderr as
-# `severity: path:line:col: message`, resolving each span against the session
-# source map. an unknown file id degrades to `severity: message`.
+# `severity: path:line:col: message`, followed by the offending source line and
+# a `^~~~` underline under the reported span. resolving each span against the
+# session source map. an unknown file id degrades to `severity: message`.
 fun flush_diagnostics(s: *sess.Session, list: *diag.DiagList) {
     var i: usize = 0;
     for (i < list.len) {
@@ -797,11 +799,51 @@ fun flush_diagnostics(s: *sess.Session, list: *diag.DiagList) {
             emit(":");
             emit_num(pos.col);
             emit(": ");
+            os.write(os.STDERR_FD, d.message::*u8, slen(d.message::*u8));
+            emit("\n");
+            emit_snippet(sf, ?d.span, pos.line);
         }
-        os.write(os.STDERR_FD, d.message::*u8, slen(d.message::*u8));
-        emit("\n");
+        or {
+            os.write(os.STDERR_FD, d.message::*u8, slen(d.message::*u8));
+            emit("\n");
+        }
         i = i + 1;
     }
+}
+
+# emit_snippet: render the source line containing `span` followed by a caret
+# underline marking the span. the underline mirrors the line's leading bytes
+# (whitespace kept verbatim, other bytes shown as spaces) so the caret aligns
+# under tabs and multibyte text; the span is marked with a leading `^` and
+# trailing `~` for each remaining byte. a zero-length span underlines one column.
+fun emit_snippet(sf: *src.SourceFile, span: *token.Span, line: usize) {
+    val lbo: Option[src.LineSpan] = src.line_bounds(sf, line);
+    if (is_none[src.LineSpan](lbo)) { ret; }
+    val lb: src.LineSpan = unwrap[src.LineSpan](lbo);
+
+    os.write(os.STDERR_FD, ?sf.text[lb.start], lb.end - lb.start);
+    emit("\n");
+
+    var caret_at: usize = span.offset;
+    if (caret_at < lb.start) { caret_at = lb.start; }
+    if (caret_at > lb.end)   { caret_at = lb.end; }
+
+    var c: usize = lb.start;
+    for (c < caret_at) {
+        if (sf.text[c] == '\t') { emit("\t"); } or { emit(" "); }
+        c = c + 1;
+    }
+
+    emit("^");
+
+    var span_end: usize = span.offset + span.len;
+    if (span_end > lb.end) { span_end = lb.end; }
+    var u: usize = caret_at + 1;
+    for (u < span_end) {
+        emit("~");
+        u = u + 1;
+    }
+    emit("\n");
 }
 
 # emit_num: write the base-10 rendering of `n` to stderr.

--- a/src/lang/source.mach
+++ b/src/lang/source.mach
@@ -306,3 +306,37 @@ pub fun line_start(file: *SourceFile, line: usize) Option[usize] {
     if (line == 0 || line > file.line_len) { ret none[usize](); }
     ret some[usize](file.line_starts[line - 1]);
 }
+
+# LineSpan: the byte range of a single source line, trailing newline excluded.
+# ---
+# start: byte offset where the line begins
+# end:   byte offset just past the last non-newline byte of the line
+pub rec LineSpan {
+    start: usize;
+    end:   usize;
+}
+
+# line_bounds: return the [start, end) byte range of a 1-based line, with any
+# trailing '\n' or '\r' excluded so callers can render the line verbatim.
+# ---
+# file: the source file being queried
+# line: 1-based line number
+# ret:  some(LineSpan) for a valid line, none when line is outside [1, line_len]
+pub fun line_bounds(file: *SourceFile, line: usize) Option[LineSpan] {
+    if (line == 0 || line > file.line_len) { ret none[LineSpan](); }
+
+    val start: usize = file.line_starts[line - 1];
+    val text_len: usize = str_len(file.text);
+
+    var end: usize = text_len;
+    if (line < file.line_len) { end = file.line_starts[line]; }
+
+    for (end > start && (file.text[end - 1] == '\n' || file.text[end - 1] == '\r')) {
+        end = end - 1;
+    }
+
+    var ls: LineSpan;
+    ls.start = start;
+    ls.end   = end;
+    ret some[LineSpan](ls);
+}


### PR DESCRIPTION
## Summary

First focused pass on issue #1046 (diagnostics quality): every located diagnostic now renders the **offending source line plus a caret/underline** under the reported span, instead of just the `path:line:col: severity: message` header.

This is the single highest-impact missing piece — the data model already carried `(FileId, Span)` and the source map already resolved offsets to `(line, col)`, but nothing rendered the snippet.

### Before
```
error: main.mach:5:18: unresolved identifier
```
```
error: main.mach:8:5: type mismatch: incompatible types in assignment
```

### After
```
error: main.mach:5:18: unresolved identifier
    val x: i64 = undefined_thing + 1;
                 ^~~~~~~~~~~~~~~
```
```
error: main.mach:8:5: type mismatch: incompatible types in assignment
    val n: i64 = flag;
    ^~~~~~~~~~~~~~~~~~
```

## Changes
- `src/lang/source.mach`: add `LineSpan` record and `line_bounds()` — resolves a 1-based line to its `[start, end)` byte range with any trailing `\n`/`\r` excluded.
- `src/cli/cmd/build.mach`: `flush_diagnostics` emits the source line after the header, then `emit_snippet` draws the underline. The underline mirrors the line's leading **tabs verbatim** (other bytes shown as spaces) so the caret aligns regardless of tab width; multi-line / out-of-line spans are clamped to the current line. Unknown file ids still degrade to the bare message.

## Verification
- `make clean && make` full bootstrap: exit 0.
- Fixpoint guards (no regression to byte-identical reproduction):
  - `build . --artifacts da/db` then `diff -rq out/da/obj out/db/obj`: **0 diffs**.
  - `build . -o mach2 --artifacts m2` then `cmp out/bin/mach out/bin/mach2`: **identical**.
- Tab-indented source verified to align (underline begins with the same leading tab bytes as the line).

## Scope / remaining (issue #1046)
This PR delivers the source-line + caret rendering. Still open under #1046 and intentionally out of scope here: note/help secondary lines plumbed through the data model, "did you mean" suggestions, multi-error recovery, and a clarity audit of existing `report()` messages.

Refs #1046
