### PR TITLE
fix(run): back run/test builds with an arena to keep output_path mapped

### DIFF
--- a/src/cli/cmd/run.mach
+++ b/src/cli/cmd/run.mach
@@ -19,9 +19,9 @@ use std.types.result.unwrap_ok;
 
 use std.allocator.Allocator;
 use std.allocator.allocate;
-use std.allocator.deallocate;
 
-use page: std.allocator.page;
+use page:  std.allocator.page;
+use arena: std.allocator.arena;
 
 use os:   std.system.os;
 use exec: std.process.exec;
@@ -86,18 +86,38 @@ pub fun run(argc: usize, argv: **u8) i64 {
         ret 1;
     }
 
+    # back the build with an arena over a page allocator, matching `mach
+    # build`. the build's internal teardown (`sess.dnit`/`dnit_project`)
+    # frees through this allocator; the page allocator would munmap each
+    # block individually, unmapping the page `output_path` lives in before
+    # we exec it. the arena defers all reclamation to a single `arena.dnit`,
+    # so `output_path` stays mapped until we are done with the child.
+    var backing: Allocator;
+    if (is_some[str](page.make(?backing))) {
+        emit("error: failed to initialise allocator\n");
+        ret 2;
+    }
+
+    var ar: arena.Arena;
+    if (is_some[str](arena.init(?ar, ?backing, 0))) {
+        emit("error: failed to initialise allocator\n");
+        ret 2;
+    }
+
     var alloc: Allocator;
-    val mk: Option[str] = page.make(?alloc);
-    if (is_some[str](mk)) {
+    if (is_some[str](arena.make(?alloc, ?ar))) {
+        arena.dnit(?ar);
         emit("error: failed to initialise allocator\n");
         ret 2;
     }
 
     val br: build.BuildResult = build.build(?alloc, argc, argv, false);
     if (br.code != 0) {
+        arena.dnit(?ar);
         ret br.code;
     }
     if (br.output_path == nil) {
+        arena.dnit(?ar);
         emit("error: build produced no executable\n");
         ret 2;
     }
@@ -110,7 +130,7 @@ pub fun run(argc: usize, argv: **u8) i64 {
     val total: usize = 1 + fwd_count + 1;
     val cv_r: Result[**u8, str] = allocate[*u8](?alloc, total);
     if (is_err[**u8, str](cv_r)) {
-        deallocate[u8](?alloc, br.output_path, (slen(br.output_path) + 1));
+        arena.dnit(?ar);
         emit("error: out of memory\n");
         ret 2;
     }
@@ -124,15 +144,14 @@ pub fun run(argc: usize, argv: **u8) i64 {
     child_argv[1 + fwd_count] = nil;
 
     val exec_r: Result[exec.ExitStatus, str] = exec.run(br.output_path, child_argv, nil);
-    deallocate[*u8](?alloc, child_argv, total);
 
     if (is_err[exec.ExitStatus, str](exec_r)) {
-        deallocate[u8](?alloc, br.output_path, (slen(br.output_path) + 1));
+        arena.dnit(?ar);
         emit("error: failed to execute the built binary\n");
         ret 1;
     }
     val status: exec.ExitStatus = unwrap_ok[exec.ExitStatus, str](exec_r);
-    deallocate[u8](?alloc, br.output_path, (slen(br.output_path) + 1));
+    arena.dnit(?ar);
 
     if (exec.exited(status)) {
         ret exec.code(status)::i64;

--- a/src/cli/cmd/testing.mach
+++ b/src/cli/cmd/testing.mach
@@ -23,9 +23,9 @@ use std.types.result.unwrap_ok;
 
 use std.allocator.Allocator;
 use std.allocator.allocate;
-use std.allocator.deallocate;
 
-use page: std.allocator.page;
+use page:  std.allocator.page;
+use arena: std.allocator.arena;
 
 use os:   std.system.os;
 use exec: std.process.exec;
@@ -100,18 +100,37 @@ pub fun run(argc: usize, argv: **u8) i64 {
     val filter_opt: Option[*u8] = get_value(argc, argv, "--filter");
     val list:       bool        = has_flag(argc, argv, "--list");
 
+    # back the build with an arena over a page allocator, matching `mach
+    # build`. the build's internal teardown frees through this allocator;
+    # the page allocator would munmap each block individually, unmapping the
+    # page `output_path` lives in before we exec it. the arena defers all
+    # reclamation to a single `arena.dnit`, keeping `output_path` mapped.
+    var backing: Allocator;
+    if (is_some[str](page.make(?backing))) {
+        emit("error: failed to initialise allocator\n");
+        ret 2;
+    }
+
+    var ar: arena.Arena;
+    if (is_some[str](arena.init(?ar, ?backing, 0))) {
+        emit("error: failed to initialise allocator\n");
+        ret 2;
+    }
+
     var alloc: Allocator;
-    val mk: Option[str] = page.make(?alloc);
-    if (is_some[str](mk)) {
+    if (is_some[str](arena.make(?alloc, ?ar))) {
+        arena.dnit(?ar);
         emit("error: failed to initialise allocator\n");
         ret 2;
     }
 
     val br: build.BuildResult = build.build(?alloc, argc, argv, false);
     if (br.code != 0) {
+        arena.dnit(?ar);
         ret 2;
     }
     if (br.output_path == nil) {
+        arena.dnit(?ar);
         emit("error: build produced no test binary\n");
         ret 2;
     }
@@ -124,7 +143,7 @@ pub fun run(argc: usize, argv: **u8) i64 {
     val total: usize = 1 + extra + 1;
     val cv_r: Result[**u8, str] = allocate[*u8](?alloc, total);
     if (is_err[**u8, str](cv_r)) {
-        deallocate[u8](?alloc, br.output_path, (slen(br.output_path) + 1));
+        arena.dnit(?ar);
         emit("error: out of memory\n");
         ret 2;
     }
@@ -139,14 +158,14 @@ pub fun run(argc: usize, argv: **u8) i64 {
     child_argv[k] = nil;
 
     val exec_r: Result[exec.ExitStatus, str] = exec.run(br.output_path, child_argv, nil);
-    deallocate[*u8](?alloc, child_argv, total);
-    deallocate[u8](?alloc, br.output_path, (slen(br.output_path) + 1));
 
     if (is_err[exec.ExitStatus, str](exec_r)) {
+        arena.dnit(?ar);
         emit("error: failed to execute the test binary\n");
         ret 2;
     }
     val status: exec.ExitStatus = unwrap_ok[exec.ExitStatus, str](exec_r);
+    arena.dnit(?ar);
     if (exec.exited(status)) {
         ret exec.code(status)::i64;
     }


### PR DESCRIPTION
Closes #1064

## Root cause

`mach run` segfaulted (exit 139) in the **parent** process — before any `fork`/`execve` for the child. The binary ran fine when invoked directly, so build + link were correct; the fault was in `run`'s build→exec handoff.

`cmd.run` and `cmd.test` backed `build.build()` with a **bare page allocator**. The build's internal teardown (`sess.dnit` / `dnit_project`) frees through that allocator, and the page allocator `munmap`s each block individually. The artifact path `output_path` returned by `build` is allocated through the same allocator, so its page was unmapped during teardown. The subsequent `slen(output_path)` (in the cleanup deallocate path) then dereferenced a freed, unmapped page — SIGSEGV.

`mach build` already backs the build with an **arena over a page allocator**, whose `deallocate` is a no-op so nothing returns to the OS until a single `arena.dnit`. `run`/`test` diverged from that pattern.

## Fix

Mirror `cmd.build`'s allocator setup in `cmd.run` and `cmd.test`: page allocator → arena → arena-backed `Allocator`. `output_path` and the child argv now stay mapped through `exec`, and everything is reclaimed in one `arena.dnit`. The per-allocation `deallocate` calls (no-ops under an arena, and the trigger for the fault under the page allocator) are removed.

## Verification

- `make clean && make` full bootstrap (cmach→imach→smach→mach): exit 0.
- Trivial `fun main() i64 { ret 42; }`: `mach run` now exits **42** (was **139**).
- Printing program: stdout passes through, exit 0.
- Exit-code propagation: program returning `argc` exits 1 with no args, 4 with `-- a b c` (also confirms `--` argv forwarding). Deterministic across repeated runs.
- `mach test` exec path: no segfault, `--list` and normal runs exit cleanly.
