### PR TITLE
fix(lower): sign-extend a signed sub-word operand in a mixed-width compare

### DIFF
--- a/src/lang/me/lower/expr.mach
+++ b/src/lang/me/lower/expr.mach
@@ -811,13 +811,27 @@ fun lower_binary(ctx: *lower.LowerContext, eid: aid.ExprId, e: *aexpr.Expr) Resu
 
     val lr: Result[value.Value, str] = lower_rvalue(ctx, e.data.binary.lhs);
     if (is_err[value.Value, str](lr)) { ret lr; }
-    val lhs: value.Value = unwrap_ok[value.Value, str](lr);
+    var lhs: value.Value = unwrap_ok[value.Value, str](lr);
 
     val rr: Result[value.Value, str] = lower_rvalue(ctx, e.data.binary.rhs);
     if (is_err[value.Value, str](rr)) { ret rr; }
-    val rhs: value.Value = unwrap_ok[value.Value, str](rr);
+    var rhs: value.Value = unwrap_ok[value.Value, str](rr);
 
-    val signed: bool = is_signed_type(ctx, lower.expr_type_of(ctx, e.data.binary.lhs));
+    val lty: ty.TypeId = lower.expr_type_of(ctx, e.data.binary.lhs);
+    val rty: ty.TypeId = lower.expr_type_of(ctx, e.data.binary.rhs);
+    val signed: bool = is_signed_type(ctx, lty);
+
+    # a mixed-width integer comparison reads both operands at one width (the
+    # back end sizes the CMP from operand 0), so a narrower operand must be
+    # extended to the wider operand's width here, where signedness is known:
+    # sign-extension for a signed narrower operand (i8/i16), zero-extension for
+    # an unsigned one. the IR type carries no signedness, so the back end could
+    # not make this choice. non-comparison integer ops share the operand type
+    # via sema, so they need no unification.
+    if (is_compare_binop(op)) {
+        val ur: Result[bool, str] = unify_int_compare_widths(ctx, ?lhs, lty, ?rhs, rty);
+        if (is_err[bool, str](ur)) { ret err[value.Value, str](unwrap_err[bool, str](ur)); }
+    }
 
     if (op == aexpr.BIN_ADD) { ret builder.emit_add(?ctx.builder, lhs, rhs); }
     if (op == aexpr.BIN_SUB) { ret builder.emit_sub(?ctx.builder, lhs, rhs); }
@@ -861,6 +875,45 @@ fun lower_binary(ctx: *lower.LowerContext, eid: aid.ExprId, e: *aexpr.Expr) Resu
     }
 
     ret err[value.Value, str]("lower: unsupported binary operator");
+}
+
+# true for the comparison binary operators, whose operands are read at a single
+# unified width by the back end (so a mixed-width integer pair must be extended).
+fun is_compare_binop(op: aexpr.BinOp) bool {
+    ret op == aexpr.BIN_EQ  || op == aexpr.BIN_NEQ ||
+        op == aexpr.BIN_LT  || op == aexpr.BIN_LEQ ||
+        op == aexpr.BIN_GT  || op == aexpr.BIN_GEQ;
+}
+
+# extends the narrower operand of a mixed-width integer comparison up to the
+# wider operand's bit width, in place, so the back end's single-width CMP reads
+# two correctly-extended values. a signed narrower operand is sign-extended, an
+# unsigned one zero-extended (the IR type carries no signedness, so this choice
+# must be made here from the semantic types). float and equal-width / non-scalar
+# pairs are left untouched. the narrower operand takes on the wider operand's
+# own IR type, the width the back end already sizes the CMP from.
+fun unify_int_compare_widths(ctx: *lower.LowerContext, lhs: *value.Value, lty: ty.TypeId, rhs: *value.Value, rty: ty.TypeId) Result[bool, str] {
+    if (is_float_type(ctx, lty) || is_float_type(ctx, rty)) { ret ok[bool, str](true); }
+    val lw: u32 = scalar_bits(ctx, lty);
+    val rw: u32 = scalar_bits(ctx, rty);
+    if (lw == 0 || rw == 0 || lw == rw) { ret ok[bool, str](true); }
+    if (lw < rw) {
+        val xr: Result[value.Value, str] = extend_int_value(ctx, @lhs, lty, rhs.ty);
+        if (is_err[value.Value, str](xr)) { ret err[bool, str](unwrap_err[value.Value, str](xr)); }
+        @lhs = unwrap_ok[value.Value, str](xr);
+        ret ok[bool, str](true);
+    }
+    val xr: Result[value.Value, str] = extend_int_value(ctx, @rhs, rty, lhs.ty);
+    if (is_err[value.Value, str](xr)) { ret err[bool, str](unwrap_err[value.Value, str](xr)); }
+    @rhs = unwrap_ok[value.Value, str](xr);
+    ret ok[bool, str](true);
+}
+
+# extends an integer value to the wider IR type `to`, sign-extending when its
+# semantic type `from` is signed and zero-extending otherwise.
+fun extend_int_value(ctx: *lower.LowerContext, v: value.Value, from: ty.TypeId, to: ir_type.IrTypeId) Result[value.Value, str] {
+    if (is_signed_type(ctx, from)) { ret builder.emit_sext(?ctx.builder, v, to); }
+    ret builder.emit_zext(?ctx.builder, v, to);
 }
 
 # lowers an assignment expression `lhs = rhs`: evaluate the RHS, store it


### PR DESCRIPTION
Closes #1035

## Root cause

A mixed-width integer comparison reads both operands at one width (the back end sizes the `CMP` from operand 0). #1033 made sub-word scalar *loads* zero-extend so the upper register bits are defined — correct for an unsigned narrower operand, but wrong for a signed one: a signed `i8` `-1` (`0xFF`) zero-extended to 32 bits reads as `255`, so a signed compare against a wider operand gives the wrong result.

The IR type carries no signedness (it defers signedness to the consuming instruction), so the back end cannot pick the right extension at the load.

## Fix

`lower_binary` now width-unifies a comparison's operands before emitting it, in the lowering pass where signedness is known from the semantic types: the narrower operand is extended to the wider operand's IR type — **sign**-extension when its semantic type is signed (`i8`/`i16`), **zero**-extension when unsigned (`u8`/`u16`). Float and equal-width pairs are left untouched. The unsigned path #1033 fixed is preserved.

Generic in the mid-end lowering (`OP_SEXT`/`OP_ZEXT`); no target-specific code.

## Verification

Repro (`i8` `-1` forced through a memory load, compared against a wider signed integer):

```mach
fun ld8(p: *i8) i8 { ret p[0]; }
fun main() i64 {
    var x: i8 = 0 - 1; var px: *i8 = ?x; var lx: i8 = ld8(px);
    var y: i32 = 0;
    if (y < lx) { ret 1; }   # 0 < -1 is FALSE => expect 0
    ret 0;
}
```

- Before: returns `1` (wrong — `lx` zero-extended to `255`, so `0 < 255` true). Generated `cmp` after a plain `movzbl`.
- After: returns `0` (correct). Generated `movsbl %cl,%eax` before the `cmp`.

A 13-case matrix (i8/i16 negative vs wider signed; signed-vs-signed and signed-vs-unsigned mixed widths; `==`/`<`/`<=`; and unsigned `u8`/`u16` regression guards plus positive cases) returns `0` (all pass) on the fixed compiler and fails at case 2 on the pre-fix compiler.

- `make clean && make`: full bootstrap exit 0.
- Determinism (`da` vs `db` obj dirs): 0 differences.
- Fixpoint: `mach` == `mach2` byte-identical.
