### PR TITLE
fix(driver): accept dir_*-only mach.toml without null-deref

### DIFF
--- a/src/lang/driver.mach
+++ b/src/lang/driver.mach
@@ -20,6 +20,7 @@ use std.types.char.char;
 
 use std.types.string.str;
 use std.types.string.str_len;
+use std.types.string.str_empty;
 use std.text.string.str_dup;
 use std.text.string.str_free;
 use std.types.string.StrView;
@@ -118,7 +119,8 @@ pub rec DepEntry {
 # id:           interned `[project].id`
 # dir_src:      interned `[project].dir_src` (default "src")
 # dir_dep:      interned `[project].dir_dep` (default "dep")
-# out:          interned output root directory under `[project]` (default "out")
+# out:          interned `[project].dir_out` output root, with legacy `out`
+#               fallback (default "out")
 # project_root: interned absolute filesystem path of the project root
 # target:       interned `[project].target` default selector (default "native")
 # targets:      flat array of TargetEntry records
@@ -548,7 +550,7 @@ fun load_project_config(p: *Project, project_root: str) Result[bool, str] {
     var t: toml.Table = unwrap_ok[toml.Table, str](toml_r);
 
     val id_str: str = toml.get_str(?t, "project.id");
-    if (str_len(id_str) == 0) { ret err[bool, str]("mach.toml is missing [project].id"); }
+    if (str_empty(id_str)) { ret err[bool, str]("mach.toml is missing [project].id"); }
     val id_iv: Result[intern.StrId, str] = intern.intern(?p.s.interner, id_str);
     if (is_err[intern.StrId, str](id_iv)) { ret err[bool, str](unwrap_err[intern.StrId, str](id_iv)); }
     p.config.id = unwrap_ok[intern.StrId, str](id_iv);
@@ -561,7 +563,9 @@ fun load_project_config(p: *Project, project_root: str) Result[bool, str] {
     if (is_err[intern.StrId, str](dir_dep_r)) { ret err[bool, str](unwrap_err[intern.StrId, str](dir_dep_r)); }
     p.config.dir_dep = unwrap_ok[intern.StrId, str](dir_dep_r);
 
-    val out_r: Result[intern.StrId, str] = intern_or(?p.s.interner, toml.get_str(?t, "project.out"), "out");
+    var out_key: str = toml.get_str(?t, "project.dir_out");
+    if (str_empty(out_key)) { out_key = toml.get_str(?t, "project.out"); }
+    val out_r: Result[intern.StrId, str] = intern_or(?p.s.interner, out_key, "out");
     if (is_err[intern.StrId, str](out_r)) { ret err[bool, str](unwrap_err[intern.StrId, str](out_r)); }
     p.config.out = unwrap_ok[intern.StrId, str](out_r);
 
@@ -688,7 +692,7 @@ fun resolve_dep(s: *sess.Session, alias: str, project_root: str, dir_dep: str) R
     var t: toml.Table = unwrap_ok[toml.Table, str](tr);
 
     val id_str: str = toml.get_str(?t, "project.id");
-    if (str_len(id_str) == 0) {
+    if (str_empty(id_str)) {
         str_free(s.alloc, dep_dir);
         ret err[DepEntry, str]("dep mach.toml is missing [project].id");
     }
@@ -747,7 +751,7 @@ fun parse_toml_file(alloc: *Allocator, path: str) Result[toml.Table, str] {
 
 fun intern_or(i: *intern.Interner, text: str, default: str) Result[intern.StrId, str] {
     var t: str = text;
-    if (str_len(t) == 0) { t = default; }
+    if (str_empty(t)) { t = default; }
     ret intern.intern(i, t);
 }
 


### PR DESCRIPTION
Closes #1071

## Root cause
`toml.get_str` returns a **nil** `str` for a missing key (not an empty string). `intern_or` and the `[project].id` guards tested `str_len(...) == 0`, and `str_len` dereferences `s[0]` with no nil check — so a missing key SIGSEGVs (NULL deref).

A `[project]` table using only the `dir_*` keys (the form `mach init` now generates) omits the legacy `out`/`dir_out` key, so the output-root read hit `str_len(nil)` and crashed during `load_project_config`.

## Fix
- `intern_or` and both `[project].id` guards now use the nil-safe `str_empty`, so a missing key defaults / errors cleanly instead of dereferencing NULL.
- The output root is read from `[project].dir_out` (consistent with `dir_src`/`dir_dep`), falling back to the legacy `[project].out`, then the `"out"` default — so both the modern `dir_*` form and the legacy form parse.

No defensive masking: the parse simply detects an absent key correctly.

## Repro
Standalone project with a `dir_*`-only `[project]` (no `out`/`dir_out`):
- **Before:** `mach build .` → exit 139 (SIGSEGV during mach.toml parse).
- **After:** parses cleanly; a real project depending on `mach-std` builds and the binary runs (exit code matches `main`).

## Verification
- `make clean && make` → exit 0.
- Fixpoint: `--artifacts da`/`db` obj diff → 0 diffs; self-recompiled `mach2` `cmp`-identical to `mach`.
