### PR TITLE
fix(comptime): $size_of/$align_of on primitives + $offset_of fields

### DIFF
--- a/doc/language/comptime-control.md
+++ b/doc/language/comptime-control.md
@@ -22,8 +22,7 @@ $or {
 The condition must be a comptime expression. Common shapes:
 
 - `$mach.*` reads for target / build conditions
-- Comparisons of comptime constants
-- Comptime function parameters
+- Comparisons of comptime constants (`pub val` declarations)
 
 ## Examples
 
@@ -42,6 +41,14 @@ $or {
 ```
 
 ### Dispatch on a comptime function parameter
+
+> **Not yet supported.** A comptime function parameter (`$order: Order`) is
+> accepted in a signature, but it is *not* yet usable as a comptime constant
+> inside the body — `$if (order == RELAXED)` reports `identifier is not a
+> comptime constant in scope`. Per-call-site dispatch on a comptime value
+> parameter requires monomorphizing the body per distinct argument value,
+> which the compiler does not yet do. The shape below describes the intended
+> behavior; until it lands, branch on such a parameter with a runtime `if`.
 
 ```mach
 pub fun load($order: Order, ptr: *i64) i64 {

--- a/src/lang/fe/resolve.mach
+++ b/src/lang/fe/resolve.mach
@@ -21,7 +21,10 @@ use std.types.bool.bool;
 use std.types.bool.true;
 use std.types.bool.false;
 use std.types.option.Option;
+use std.types.option.some;
+use std.types.option.none;
 use std.types.option.is_none;
+use std.types.option.is_some;
 use std.types.option.unwrap;
 use std.types.size.usize;
 use std.types.string.str;
@@ -1377,6 +1380,12 @@ fun bind_expr(rc: *ResolveContext, eid: id.ExprId) Result[bool, str] {
         ret bind_expr(rc, e.data.unary.operand);
     }
     if (e.kind == expr.EXPR_KIND_CALL) {
+        # a comptime value intrinsic (`$size_of`/`$align_of`/`$offset_of`) takes
+        # a type-naming first argument (and, for `$offset_of`, a bare field name)
+        # rather than value expressions, so it binds its arguments specially.
+        val intr: Option[Result[bool, str]] = bind_comptime_intrinsic_call(rc, ?e.data.call);
+        if (is_some[Result[bool, str]](intr)) { ret unwrap[Result[bool, str]](intr); }
+
         val rc_e: Result[bool, str] = bind_expr(rc, e.data.call.callee);
         if (is_err[bool, str](rc_e)) { ret rc_e; }
         var ti: u32 = 0;
@@ -1448,6 +1457,96 @@ fun bind_ident(rc: *ResolveContext, eid: id.ExprId, span: token.Span) Result[boo
         if (rc.expr_resolved != nil) { rc.expr_resolved[eid] = sid; }
     }
     ret ok[bool, str](true);
+}
+
+# classifies a call's callee as a comptime value intrinsic by its name: 1 for
+# `$size_of`/`$align_of` (one type argument), 2 for `$offset_of` (a type plus a
+# field), or 0 when the callee is not one of these. recognizing the intrinsic
+# in the bind pass lets its type-naming argument resolve through the primitive
+# registry (so `$size_of(i64)` works) and lets `$offset_of`'s bare field name
+# escape value-scope lookup.
+fun comptime_intrinsic_kind(rc: *ResolveContext, callee: id.ExprId) u8 {
+    val ce_opt: Option[*expr.Expr] = ast.get_expr(rc.a, callee);
+    if (is_none[*expr.Expr](ce_opt)) { ret 0; }
+    val ce: *expr.Expr = unwrap[*expr.Expr](ce_opt);
+    if (ce.kind != expr.EXPR_KIND_COMPTIME_IDENT) { ret 0; }
+    if (ce.span.len <= 1) { ret 0; }
+
+    var ns: token.Span = ce.span;
+    ns.offset = ns.offset + 1;
+    ns.len    = ns.len - 1;
+    val r: Result[intern.StrId, str] = intern.intern_span(?rc.s.interner, rc.source, ns);
+    if (is_err[intern.StrId, str](r)) { ret 0; }
+    val name: intern.StrId = unwrap_ok[intern.StrId, str](r);
+
+    if (name == interned_literal(rc, "size_of"))   { ret 1; }
+    if (name == interned_literal(rc, "align_of"))  { ret 1; }
+    if (name == interned_literal(rc, "offset_of")) { ret 2; }
+    ret 0;
+}
+
+# binds a comptime value intrinsic call's arguments. the first argument names a
+# type, so it resolves as a type spelling (primitive registry first, then the
+# value scope for user types) rather than as a value reference; `$offset_of`'s
+# second argument is a bare field name resolved against the record at lowering
+# time and is left unbound here. returns none when the call is not an intrinsic,
+# letting the caller fall back to ordinary call binding.
+fun bind_comptime_intrinsic_call(rc: *ResolveContext, c: *expr.ExprCall) Option[Result[bool, str]] {
+    val kind: u8 = comptime_intrinsic_kind(rc, c.callee);
+    if (kind == 0) { ret none[Result[bool, str]](); }
+    if (c.args_len < 1) { ret some[Result[bool, str]](ok[bool, str](true)); }
+
+    val arg0: id.ExprId = rc.a.expr_ids[c.args_start];
+    ret some[Result[bool, str]](bind_intrinsic_type_arg(rc, arg0));
+}
+
+# resolves an intrinsic's type-naming argument expression. a bare single
+# identifier resolves to a primitive (`i64`, `bool`, `ptr`, ...) before the
+# value scope, mirroring `resolve_type_path`; a `module.Type` member chain
+# resolves through the module's exports. the resolved SymbolId is recorded in
+# `expr_resolved` so sema can recover the operand type.
+fun bind_intrinsic_type_arg(rc: *ResolveContext, eid: id.ExprId) Result[bool, str] {
+    if (eid == id.EXPR_NIL) { ret ok[bool, str](true); }
+    val e_opt: Option[*expr.Expr] = ast.get_expr(rc.a, eid);
+    if (is_none[*expr.Expr](e_opt)) { ret ok[bool, str](true); }
+    val e: *expr.Expr = unwrap[*expr.Expr](e_opt);
+
+    if (e.kind == expr.EXPR_KIND_IDENT) {
+        val r: Result[intern.StrId, str] = intern.intern_span(?rc.s.interner, rc.source, e.span);
+        if (is_err[intern.StrId, str](r)) { ret err[bool, str](unwrap_err[intern.StrId, str](r)); }
+        val name: intern.StrId = unwrap_ok[intern.StrId, str](r);
+
+        var sid: SymbolId = prim_symbol_for(rc, name);
+        if (sid == SYMBOL_NIL) { sid = scope_lookup_chain(rc, rc.current_scope, name); }
+        if (sid == SYMBOL_NIL) {
+            diag.error(?rc.s.diags, rc.a.file_id, e.span, "unresolved type name");
+        }
+        or {
+            if (rc.expr_resolved != nil) { rc.expr_resolved[eid] = sid; }
+        }
+        ret ok[bool, str](true);
+    }
+
+    if (e.kind == expr.EXPR_KIND_MEMBER) {
+        # a qualified `module.Type` argument: bind the object alias first, then
+        # resolve the leaf against the module's exports (reuses the qualified
+        # member machinery used for value-position module references).
+        val ro: Result[bool, str] = bind_expr(rc, e.data.member.object);
+        if (is_err[bool, str](ro)) { ret ro; }
+        ret bind_member_qualified(rc, eid, ?e.data.member);
+    }
+
+    # any other argument shape is not a type spelling; bind it as a normal
+    # expression so a diagnostic surfaces the misuse.
+    ret bind_expr(rc, eid);
+}
+
+# interns a static literal in the session interner, returning its StrId or
+# STR_NIL on allocation failure (a STR_NIL never matches a real span name).
+fun interned_literal(rc: *ResolveContext, text: str) intern.StrId {
+    val r: Result[intern.StrId, str] = intern.intern(?rc.s.interner, text);
+    if (is_err[intern.StrId, str](r)) { ret intern.STR_NIL; }
+    ret unwrap_ok[intern.StrId, str](r);
 }
 
 fun bind_type(rc: *ResolveContext, tid: id.TypeId) Result[bool, str] {

--- a/src/lang/fe/sema/infer.mach
+++ b/src/lang/fe/sema/infer.mach
@@ -431,11 +431,39 @@ fun infer_comptime_intrinsic(sc: *sema.SemaContext, c: *expr.ExprCall, span: tok
         ret type.TYPE_ERROR;
     }
 
-    # the first argument names the operand type; infer it so its type slot is
-    # set (the lowerer reads this to compute the size/alignment/offset). the
-    # offset field argument is a field reference and is left untyped here.
-    infer_expr(sc, sc.a.expr_ids[c.args_start]);
+    # the first argument names the operand type, so it is resolved as a type
+    # spelling rather than a value: a primitive (`i64`, `bool`, `ptr`, ...), a
+    # user record/union/def, or a `module.Type`. the resolved operand type is
+    # written into the argument's expr_type slot, which the lowerer reads to
+    # fold the size / alignment / offset. the `$offset_of` field argument is a
+    # bare field name resolved against the record at lowering time, not here.
+    val arg0: id.ExprId = sc.a.expr_ids[c.args_start];
+    val op_ty: type.TypeId = intrinsic_operand_type(sc, arg0, span);
+    set_expr_type(sc, arg0, op_ty);
+    if (op_ty == type.TYPE_ERROR) { ret type.TYPE_ERROR; }
     ret prim_or_error(sc, type.TYPE_U64);
+}
+
+# resolves a comptime intrinsic's type-naming argument to its semantic type.
+# the argument is a name expression bound in the resolve pass: a single IDENT
+# (primitive or user type) or a `module.Type` member chain. both carry their
+# resolved SymbolId on the argument expression, mapped to a type by
+# `type_for_symbol` (which handles primitives, records, unions, and defs).
+fun intrinsic_operand_type(sc: *sema.SemaContext, eid: id.ExprId, span: token.Span) type.TypeId {
+    val sym_opt: Option[*resolve.Symbol] = sema.symbol_for_expr(sc, eid);
+    if (is_none[*resolve.Symbol](sym_opt)) {
+        # resolve already reported the unresolved name; absorb silently
+        ret type.TYPE_ERROR;
+    }
+    ret type_for_symbol(sc, unwrap[*resolve.Symbol](sym_opt), span);
+}
+
+# writes `ty` into an expression's expr_type slot, the parallel array sema fills
+# for the lowerer. out-of-range ids are ignored, matching `infer_expr`.
+fun set_expr_type(sc: *sema.SemaContext, eid: id.ExprId, ty: type.TypeId) {
+    if (sc.expr_type == nil) { ret; }
+    if (eid >= sc.a.expr_len::u32) { ret; }
+    sc.expr_type[eid] = ty;
 }
 
 # interns the identifier text of a `$ident` comptime ident, with the leading


### PR DESCRIPTION
Refs #1066. Fixes two of the three comptime-intrinsic gaps; documents the third as not-yet-supported.

## (a) `$size_of` / `$align_of` on primitive types — fixed
`$size_of(i64)`, `$align_of(u16)`, `$size_of(ptr)`, etc. now fold to the target's layout. Previously the type-naming argument was bound as a *value* identifier, so primitive spellings (which live in a type-position-only registry) failed with "unresolved identifier". The argument is now bound as a type spelling: primitive registry first, then the value scope for user types, plus `module.Type` member chains through module exports. Sema maps the resolved symbol to its operand type via `type_for_symbol` (handles primitives) and writes it into the `expr_type` slot the lowerer already folds.

`bool` is a std `def` (not a compiler primitive), so `$size_of(bool)` resolves it as a user type and requires `bool` to be in scope — which is correct.

## (b) `$offset_of(T, field)` — fixed
The field-name argument was bound as a value identifier and always errored with "unresolved identifier". It is now left unbound in resolve and resolved against the record's field table at lowering time (existing `field_index_in_type` → `byte_offset`). Works for primitive-field records and `module.Type` arguments.

## (c) `$if` on a comptime function parameter — documented as unsupported (out of scope)
`$if (mode == ...)` on a `$mode`-style comptime param fails with "identifier is not a comptime constant in scope". Making it work requires monomorphizing the function body per distinct comptime-argument value (the body is currently lowered once and shared across call sites, and the param is an ordinary runtime value). That is a new feature, not a bug fix, so per the issue's "either work or be clearly documented as unsupported" guidance it is documented as not-yet-supported in `doc/language/comptime-control.md`. The diagnostic is already clear and accurate.

## Verification
- (a) `$size_of(i64)==8`, `$align_of(u16)==2`, `$size_of(bool)==1`, `$size_of(ptr)==8`, `$align_of(i64)==8` — all pass (runtime exit code).
- (b) `rec R { a: u8; b: u64; }` → `$offset_of(R,a)==0`, `$offset_of(R,b)==8`; mixed-align record offsets (0/4/8) all correct.
- No regression: user-type `$size_of`/`$align_of`/`$offset_of` (incl. in `pub val` initializers), `06_comptime` example, `$mach.*` value coercion (#1015), all 10 numbered examples build.
- Full bootstrap `make clean && make` exits 0.
- Fixpoint: `da`/`db` obj artifacts identical (0 diffs); `mach` rebuilds a byte-identical `mach2`.

## Files
- `src/lang/fe/resolve.mach` — bind intrinsic type/field arguments specially
- `src/lang/fe/sema/infer.mach` — resolve operand type via the symbol, write expr_type
- `doc/language/comptime-control.md` — mark comptime-param dispatch not-yet-supported
