### PR TITLE
fix(driver): error on missing required [targets.*] keys instead of segfaulting

### DIFF
--- a/src/lang/driver.mach
+++ b/src/lang/driver.mach
@@ -605,15 +605,15 @@ fun parse_targets_table(p: *Project, t: *toml.Table) Result[bool, str] {
         if (is_err[intern.StrId, str](rn)) { ret err[bool, str](unwrap_err[intern.StrId, str](rn)); }
         entry.name = unwrap_ok[intern.StrId, str](rn);
 
-        val ros: Result[intern.StrId, str] = intern.intern(?p.s.interner, toml.get_str(sub, "os"));
+        val ros: Result[intern.StrId, str] = intern_required(?p.s.interner, toml.get_str(sub, "os"), "mach.toml: a [targets.*] entry is missing required key 'os'");
         if (is_err[intern.StrId, str](ros)) { ret err[bool, str](unwrap_err[intern.StrId, str](ros)); }
         entry.os_name = unwrap_ok[intern.StrId, str](ros);
 
-        val ris: Result[intern.StrId, str] = intern.intern(?p.s.interner, toml.get_str(sub, "isa"));
+        val ris: Result[intern.StrId, str] = intern_required(?p.s.interner, toml.get_str(sub, "isa"), "mach.toml: a [targets.*] entry is missing required key 'isa'");
         if (is_err[intern.StrId, str](ris)) { ret err[bool, str](unwrap_err[intern.StrId, str](ris)); }
         entry.isa_name = unwrap_ok[intern.StrId, str](ris);
 
-        val rep: Result[intern.StrId, str] = intern.intern(?p.s.interner, toml.get_str(sub, "entrypoint"));
+        val rep: Result[intern.StrId, str] = intern_required(?p.s.interner, toml.get_str(sub, "entrypoint"), "mach.toml: a [targets.*] entry is missing required key 'entrypoint'");
         if (is_err[intern.StrId, str](rep)) { ret err[bool, str](unwrap_err[intern.StrId, str](rep)); }
         entry.entrypoint = unwrap_ok[intern.StrId, str](rep);
 
@@ -621,7 +621,7 @@ fun parse_targets_table(p: *Project, t: *toml.Table) Result[bool, str] {
         if (is_err[intern.StrId, str](rart)) { ret err[bool, str](unwrap_err[intern.StrId, str](rart)); }
         entry.artifacts = unwrap_ok[intern.StrId, str](rart);
 
-        val rbin: Result[intern.StrId, str] = intern.intern(?p.s.interner, toml.get_str(sub, "binary"));
+        val rbin: Result[intern.StrId, str] = intern_required(?p.s.interner, toml.get_str(sub, "binary"), "mach.toml: a [targets.*] entry is missing required key 'binary'");
         if (is_err[intern.StrId, str](rbin)) { ret err[bool, str](unwrap_err[intern.StrId, str](rbin)); }
         entry.binary = unwrap_ok[intern.StrId, str](rbin);
 
@@ -753,6 +753,15 @@ fun intern_or(i: *intern.Interner, text: str, default: str) Result[intern.StrId,
     var t: str = text;
     if (str_empty(t)) { t = default; }
     ret intern.intern(i, t);
+}
+
+# intern_required: intern a required manifest value, erroring with `missing`
+# when the value is nil/empty. get_str returns a nil str for an absent key,
+# and interning a nil str dereferences NULL; this guards that for keys with
+# no default (a [targets.*] entry's os/isa/entrypoint/binary).
+fun intern_required(i: *intern.Interner, text: str, missing: str) Result[intern.StrId, str] {
+    if (str_empty(text)) { ret err[intern.StrId, str](missing); }
+    ret intern.intern(i, text);
 }
 
 # find_target: resolve a target selector against the config's [targets.*]


### PR DESCRIPTION
Closes #1073.

Follow-up to #1071. `toml.get_str` returns a nil `str` for an absent key, and interning a nil `str` dereferences NULL. The required `[targets.<name>]` keys `os`, `isa`, `entrypoint`, and `binary` fed `get_str` straight into `intern.intern`, so a target table missing any of them SIGSEGV'd during mach.toml parsing — the same nil-str/NULL-deref class #1071 fixed for `[project]`.

## Change
- Add `intern_required` in `src/lang/driver.mach`: errors with a clear `missing required key` diagnostic when the value is nil/empty, otherwise interns.
- Route the four required target keys (`os`, `isa`, `entrypoint`, `binary`) through it. Optional keys (`artifacts`, `mode`) keep their nil-safe `intern_or`/`str_equals` handling.

A malformed manifest now fails the load gracefully (exit 1) with a message instead of crashing. No silent fallback — an absent required key is a user error and is reported.

## Audit
All `get_str` -> intern/deref sites in driver.mach were reviewed: `[project].id` (str_empty-guarded, #1071), `dir_src`/`dir_dep`/`dir_out`/`out`/`target`/`artifacts` (defaulted via nil-safe `intern_or`), and `mode` (nil-safe `str_equals`) were already safe. Only the four required target keys were unguarded.

## Before / after (target table missing a required key)
```
# before
$ mach build .   -> SIGSEGV (exit 139)
# after
$ mach build .   -> error: mach.toml: a [targets.*] entry is missing required key 'binary'  (exit 1)
```

## Verify
- `make clean && make`: exit 0.
- Missing `os`/`isa`/`entrypoint`/`binary` each print a clear diagnostic, exit 1, no segfault.
- Valid manifest parses and compiles.
- Fixpoint: `--artifacts da` vs `db` obj `diff -rq` 0 diffs; `mach` vs `mach2` `cmp` identical.
