### PR TITLE
test: differential and fuzz testing harnesses

### DIFF
--- a/tools/test/README.md
+++ b/tools/test/README.md
@@ -1,0 +1,86 @@
+# Compiler test harnesses
+
+Two scripts that stress the Mach compiler beyond the unit tests: a differential
+harness that catches optimization miscompiles, and a fuzzer that catches
+compiler crashes. Both are pure shell plus a small `awk` generator and depend
+only on a built compiler (`make`) and coreutils.
+
+Run everything from the repository root after `make`.
+
+## `differential.sh` — optimization-level differential testing
+
+For every runnable program in the corpus (the numbered `examples/`), the harness
+compiles and runs it at `-O0` and at `-O2`, then asserts the program's **exit
+code and stdout are identical** across the two levels. Any divergence is an
+optimization miscompile: the program's observable behavior must not depend on
+the optimization level.
+
+It optionally also diffs the same programs compiled by `smach` against `mach` at
+`-O0` (a cross-compiler check that the bootstrap's last two stages agree).
+
+```sh
+tools/test/differential.sh             # full run (both checks)
+tools/test/differential.sh --no-smach  # only the -O0 vs -O2 check
+tools/test/differential.sh --examples path/to/corpus
+```
+
+Output is a per-input PASS/FAIL table. On a `FAIL` the script prints the
+diverging exit codes and, when stdout differs, both outputs side by side. The
+script exits `0` only if every input is consistent, `1` on any mismatch or build
+failure, `2` on a setup error.
+
+Each example is copied (with symlinks dereferenced) into a throwaway temp dir
+before building, so `examples/` is never written to.
+
+## `fuzz.sh` + `gen.awk` — crash fuzzing
+
+`gen.awk` is a deterministic generator of small, mostly-valid Mach programs. It
+emits a `main` returning `i64` built from a constrained grammar of **safe**
+constructs: `i64` locals, integer arithmetic, `if {} or {}` chains, bounded
+`for` loops, a `rec` with field access, and a helper function call. Safety guards
+(non-zero constant divisors, statically-bounded loops, declare-before-use) keep
+programs valid and runtime-safe so the focus stays on the compiler.
+
+Randomness is a seeded Park–Miller LCG, so a given seed always produces the same
+program:
+
+```sh
+awk -v seed=42 -f tools/test/gen.awk      # print one program for seed 42
+```
+
+`fuzz.sh` generates `N` programs (iteration `i` uses `seed = base + i`) and
+compiles each with `mach`. It is looking for **compiler crashes** — an internal
+error abort (exit `2`) or a fatal signal (segfault / exit `>= 128`) — not for
+every random program to compile. Exit `0` (compiled) and exit `1` (rejected with
+a normal diagnostic) are both expected, healthy outcomes.
+
+```sh
+tools/test/fuzz.sh                       # 100 iterations, random base seed
+tools/test/fuzz.sh -n 500 -s 1000        # 500 iterations from a fixed seed
+tools/test/fuzz.sh -n 200 --keep         # also keep non-crashing sources
+```
+
+A clean run reports `no compiler crashes found` and exits `0`. When a crash is
+found the script saves the offending source and the compiler's stderr under
+`tmp/fuzz-crashes/` (override with `--out`) and exits `1`. Because the base seed
+is fixed and reported, any crash reproduces exactly:
+
+```sh
+awk -v seed=<S> -f tools/test/gen.awk      # regenerate the crashing program
+```
+
+### Seeding notes
+
+`$RANDOM` (the bash default base seed) is fine for ad-hoc runs, but pass an
+explicit `-s` for reproducible CI runs. The generator avoids `Math.random` /
+floating point entirely so it behaves identically across sandboxes.
+
+## Interpreting results
+
+- **differential FAIL** — a real `-O0` vs `-O2` divergence (or `smach` vs `mach`
+  divergence). This is a miscompile or a pass that breaks the IR; file it.
+- **fuzz CRASH** — the compiler aborted or faulted on a mostly-valid program.
+  The saved `crash_seed_<S>.mach` is a reproducer; file it.
+
+Neither harness modifies the compiler, `mach.toml`, `dep/mach-std`, or
+`examples/`; all builds happen in temp dirs that are cleaned up on exit.

--- a/tools/test/differential.sh
+++ b/tools/test/differential.sh
@@ -1,0 +1,164 @@
+#!/usr/bin/env bash
+#
+# differential.sh — optimization-level differential testing of the Mach compiler.
+#
+# for each input program in the corpus (the numbered `examples/`), compile and
+# run it at -O0 and at -O2 and assert the program's exit code AND stdout are
+# identical across the two levels. a mismatch means an optimization miscompile.
+# optionally also diffs the same program compiled by `smach` against `mach`.
+#
+# usage:
+#   tools/test/differential.sh [options]
+#
+# options:
+#   --mach <path>     compiler under test       (default: out/bin/mach)
+#   --smach <path>    second compiler to diff   (default: out/bin/smach, if present)
+#   --examples <dir>  corpus directory          (default: examples)
+#   --no-smach        skip the smach-vs-mach cross-compiler diff
+#   -h, --help        show this message
+#
+# exit: 0 if every input matches across levels (and compilers), 1 on any mismatch
+# or build failure, 2 on a usage/setup error.
+
+set -u
+
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo="$(cd "$here/../.." && pwd)"
+
+MACH="$repo/out/bin/mach"
+SMACH="$repo/out/bin/smach"
+EXAMPLES="$repo/examples"
+DO_SMACH=1
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --mach) MACH="$2"; shift 2 ;;
+        --smach) SMACH="$2"; shift 2 ;;
+        --examples) EXAMPLES="$2"; shift 2 ;;
+        --no-smach) DO_SMACH=0; shift ;;
+        -h|--help) sed -n '2,21p' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+        *) echo "error: unknown option '$1'" >&2; exit 2 ;;
+    esac
+done
+
+if [ ! -x "$MACH" ]; then
+    echo "error: mach compiler not found at '$MACH' (run 'make' first)" >&2
+    exit 2
+fi
+if [ "$DO_SMACH" = 1 ] && [ ! -x "$SMACH" ]; then
+    DO_SMACH=0
+fi
+
+work="$(mktemp -d "${TMPDIR:-/tmp}/mach-diff.XXXXXX")"
+trap 'rm -rf "$work"' EXIT
+
+# build <compiler> <project-dir> <O-level>; on success echoes the binary path,
+# else echoes nothing. all build output is discarded.
+build_one() {
+    local cc="$1" proj="$2" olevel="$3"
+    if ! "$cc" build "$olevel" --cwd "$proj" >/dev/null 2>&1; then
+        return 1
+    fi
+    local bin
+    bin="$(find "$proj/out" -type f -path '*/bin/*' 2>/dev/null | head -1)"
+    [ -n "$bin" ] && printf '%s' "$bin"
+}
+
+# run <binary>; sets globals RUN_CODE and RUN_OUT.
+run_one() {
+    RUN_OUT="$("$1" 2>/dev/null)"
+    RUN_CODE=$?
+}
+
+total=0
+fail=0
+
+printf '%-22s %-14s %-14s %-8s\n' "INPUT" "-O0 (code)" "-O2 (code)" "RESULT"
+printf '%s\n' "------------------------------------------------------------"
+
+for proj in "$EXAMPLES"/*/; do
+    name="$(basename "$proj")"
+    # skip non-runnable fixtures: a project must have a mach.toml with an
+    # executable target. `full` is a syntax fixture, not a program.
+    [ -f "$proj/mach.toml" ] || continue
+    [ "$name" = "full" ] && continue
+
+    total=$((total + 1))
+
+    # isolated, dereferenced copy so examples/ is never written to and the
+    # symlinked std dep travels with the project.
+    sandbox="$work/$name"
+    cp -rL "$proj" "$sandbox" 2>/dev/null
+
+    if ! bin0="$(build_one "$MACH" "$sandbox" -O0)" || [ -z "$bin0" ]; then
+        printf '%-22s %-14s %-14s %-8s\n' "$name" "BUILD-FAIL" "-" "FAIL"
+        fail=$((fail + 1)); continue
+    fi
+    run_one "$bin0"; code0=$RUN_CODE; out0="$RUN_OUT"
+    rm -rf "$sandbox/out"
+
+    if ! bin2="$(build_one "$MACH" "$sandbox" -O2)" || [ -z "$bin2" ]; then
+        printf '%-22s %-14s %-14s %-8s\n' "$name" "$code0" "BUILD-FAIL" "FAIL"
+        fail=$((fail + 1)); continue
+    fi
+    run_one "$bin2"; code2=$RUN_CODE; out2="$RUN_OUT"
+    rm -rf "$sandbox/out"
+
+    result="PASS"
+    if [ "$code0" != "$code2" ] || [ "$out0" != "$out2" ]; then
+        result="FAIL"
+        fail=$((fail + 1))
+    fi
+    printf '%-22s %-14s %-14s %-8s\n' "$name" "$code0" "$code2" "$result"
+
+    if [ "$result" = "FAIL" ]; then
+        echo "  -> -O0 vs -O2 divergence (exit $code0 vs $code2)"
+        if [ "$out0" != "$out2" ]; then
+            echo "  -O0 stdout:"; printf '%s\n' "$out0" | sed 's/^/    | /'
+            echo "  -O2 stdout:"; printf '%s\n' "$out2" | sed 's/^/    | /'
+        fi
+    fi
+done
+
+# optional cross-compiler diff: smach vs mach at -O0.
+if [ "$DO_SMACH" = 1 ]; then
+    echo
+    printf '%-22s %-14s %-14s %-8s\n' "INPUT (smach/mach)" "smach (code)" "mach (code)" "RESULT"
+    printf '%s\n' "------------------------------------------------------------"
+    for proj in "$EXAMPLES"/*/; do
+        name="$(basename "$proj")"
+        [ -f "$proj/mach.toml" ] || continue
+        [ "$name" = "full" ] && continue
+
+        sandbox="$work/x_$name"
+        cp -rL "$proj" "$sandbox" 2>/dev/null
+
+        if ! bs="$(build_one "$SMACH" "$sandbox" -O0)" || [ -z "$bs" ]; then
+            printf '%-22s %-14s %-14s %-8s\n' "$name" "BUILD-FAIL" "-" "FAIL"
+            fail=$((fail + 1)); rm -rf "$sandbox"; continue
+        fi
+        run_one "$bs"; cs=$RUN_CODE; os=$RUN_OUT
+        rm -rf "$sandbox/out"
+
+        if ! bm="$(build_one "$MACH" "$sandbox" -O0)" || [ -z "$bm" ]; then
+            printf '%-22s %-14s %-14s %-8s\n' "$name" "$cs" "BUILD-FAIL" "FAIL"
+            fail=$((fail + 1)); rm -rf "$sandbox"; continue
+        fi
+        run_one "$bm"; cm=$RUN_CODE; om=$RUN_OUT
+        rm -rf "$sandbox"
+
+        result="PASS"
+        if [ "$cs" != "$cm" ] || [ "$os" != "$om" ]; then
+            result="FAIL"; fail=$((fail + 1))
+        fi
+        printf '%-22s %-14s %-14s %-8s\n' "$name" "$cs" "$cm" "$result"
+    done
+fi
+
+echo
+if [ "$fail" -eq 0 ]; then
+    echo "differential: $total input(s), all consistent"
+    exit 0
+fi
+echo "differential: $fail mismatch(es) across $total input(s)"
+exit 1

--- a/tools/test/fuzz.sh
+++ b/tools/test/fuzz.sh
@@ -1,0 +1,144 @@
+#!/usr/bin/env bash
+#
+# fuzz.sh — crash fuzzer for the Mach compiler.
+#
+# generates N small, mostly-valid Mach programs from a constrained grammar of
+# SAFE constructs (see gen.awk) and compiles each with `mach`. the goal is to
+# surface compiler CRASHES — an internal-error abort (exit 2) or a fatal signal
+# (segfault / exit >= 128) — NOT to require that every random program compile.
+# a clean run finds no crashes.
+#
+# usage:
+#   tools/test/fuzz.sh [options]
+#
+# options:
+#   -n, --iterations <N>   number of programs to generate   (default: 100)
+#   -s, --seed <N>         base seed for the generator       (default: $RANDOM)
+#   --mach <path>          compiler under test               (default: out/bin/mach)
+#   --keep                 keep generated sources even when they don't crash
+#   --out <dir>            directory for crash artifacts      (default: tmp/fuzz-crashes)
+#   -h, --help             show this message
+#
+# each iteration uses seed = base + i, so a reported crash is reproducible with
+# `awk -v seed=<S> -f tools/test/gen.awk`. crashing sources are saved under the
+# crash directory along with the compiler's stderr.
+#
+# exit: 0 if no crash was found, 1 if any input crashed the compiler, 2 on a
+# usage/setup error.
+
+set -u
+
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo="$(cd "$here/../.." && pwd)"
+
+MACH="$repo/out/bin/mach"
+GEN="$here/gen.awk"
+ITERS=100
+BASE_SEED="$RANDOM"
+KEEP=0
+CRASH_DIR="$repo/tmp/fuzz-crashes"
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        -n|--iterations) ITERS="$2"; shift 2 ;;
+        -s|--seed) BASE_SEED="$2"; shift 2 ;;
+        --mach) MACH="$2"; shift 2 ;;
+        --keep) KEEP=1; shift ;;
+        --out) CRASH_DIR="$2"; shift 2 ;;
+        -h|--help) sed -n '2,27p' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+        *) echo "error: unknown option '$1'" >&2; exit 2 ;;
+    esac
+done
+
+if [ ! -x "$MACH" ]; then
+    echo "error: mach compiler not found at '$MACH' (run 'make' first)" >&2
+    exit 2
+fi
+if [ ! -f "$GEN" ]; then
+    echo "error: generator not found at '$GEN'" >&2
+    exit 2
+fi
+
+work="$(mktemp -d "${TMPDIR:-/tmp}/mach-fuzz.XXXXXX")"
+trap 'rm -rf "$work"' EXIT
+
+# a single throwaway project reused across iterations: only main.mach changes.
+proj="$work/proj"
+mkdir -p "$proj/dep"
+cp -rL "$repo/dep/mach-std" "$proj/dep/mach-std"
+cat > "$proj/mach.toml" <<'EOF'
+[project]
+id = "fuzz"
+name = "fuzz"
+version = "0.1.0"
+src = "."
+dep = "dep"
+out = "out"
+dir_src = "."
+dir_dep = "dep"
+dir_out = "out"
+target = "native"
+
+[targets.linux]
+os = "linux"
+isa = "x86_64"
+abi = "sysv64"
+mode = "executable"
+entrypoint = "main.mach"
+artifacts = "linux"
+binary = "linux/bin/fuzz"
+EOF
+# append the std dependency table the build resolves locally.
+{
+    echo
+    echo "[deps.mach-std]"
+    echo 'type = "local"'
+    echo 'path = "dep/mach-std"'
+    echo 'version = "local"'
+} >> "$proj/mach.toml"
+
+echo "fuzz: $ITERS iteration(s), base seed $BASE_SEED, compiler $MACH"
+
+crashes=0
+ok=0
+rejected=0
+
+i=0
+while [ "$i" -lt "$ITERS" ]; do
+    seed=$((BASE_SEED + i))
+    src="$proj/main.mach"
+    awk -v seed="$seed" -f "$GEN" > "$src"
+
+    err="$work/stderr.txt"
+    "$MACH" build -O0 --cwd "$proj" >/dev/null 2>"$err"
+    code=$?
+    rm -rf "$proj/out"
+
+    # exit 0 = compiled, 1 = rejected (user error, not a bug). exit 2 = internal
+    # error, >= 128 = fatal signal: both are compiler crashes worth reporting.
+    if [ "$code" -eq 2 ] || [ "$code" -ge 128 ]; then
+        crashes=$((crashes + 1))
+        mkdir -p "$CRASH_DIR"
+        dst="$CRASH_DIR/crash_seed_${seed}.mach"
+        cp "$src" "$dst"
+        cp "$err" "$CRASH_DIR/crash_seed_${seed}.stderr"
+        echo "CRASH seed=$seed exit=$code -> $dst"
+        sed 's/^/    /' "$err" | head -5
+    elif [ "$code" -eq 0 ]; then
+        ok=$((ok + 1))
+        [ "$KEEP" = 1 ] && cp "$src" "$work/ok_seed_${seed}.mach"
+    else
+        rejected=$((rejected + 1))
+    fi
+
+    i=$((i + 1))
+done
+
+echo
+echo "fuzz: compiled=$ok rejected=$rejected crashed=$crashes (of $ITERS)"
+if [ "$crashes" -eq 0 ]; then
+    echo "fuzz: no compiler crashes found"
+    exit 0
+fi
+echo "fuzz: $crashes crashing input(s) saved under $CRASH_DIR"
+exit 1

--- a/tools/test/gen.awk
+++ b/tools/test/gen.awk
@@ -1,0 +1,167 @@
+# gen.awk — deterministic generator of small, mostly-valid Mach programs.
+#
+# emits one complete program (a `main` returning i64) built from a constrained
+# grammar of SAFE constructs: i64 locals, integer arithmetic, `if {} or {}`
+# chains, bounded `for` loops, a `rec` with field access, and a helper call.
+# randomness comes from a seeded LCG so a given seed always yields the same
+# program; pass it with `-v seed=<n>`.
+#
+# safety guards keep programs mostly-valid and crash-free at runtime:
+#   - division/modulo always use a non-zero constant divisor
+#   - `for` loops run a fixed, statically-bounded number of iterations
+#   - every local is declared and initialised before use
+# the point is to exercise the compiler, not to require every program compile.
+
+BEGIN {
+    if (seed == "") { seed = 1 }
+    state = seed % 2147483647
+    if (state <= 0) { state += 2147483646 }
+
+    nlocals = 0
+    emit_header()
+    emit_record()
+    emit_helper()
+    emit_main()
+}
+
+# park-miller minimal-standard LCG; returns a value in [0, 2147483646].
+function rnd() {
+    state = (state * 16807) % 2147483647
+    return state
+}
+
+# uniform integer in [lo, hi].
+function rint(lo, hi) {
+    return lo + (rnd() % (hi - lo + 1))
+}
+
+function emit_header() {
+    print "use std.runtime;"
+    print "$main.symbol = \"main\";"
+    print ""
+}
+
+# a small record so generated programs exercise aggregate layout + field access.
+function emit_record() {
+    print "rec Box {"
+    print "    a: i64;"
+    print "    b: i64;"
+    print "}"
+    print ""
+}
+
+# a pure helper taking two i64 and returning one, called from main.
+function emit_helper() {
+    print "fun mix(p: i64, q: i64) i64 {"
+    print "    var r: i64 = p;"
+    emit_arith_stmt("    ", "r", "p", "q")
+    print "    ret r;"
+    print "}"
+    print ""
+}
+
+# choose a random already-declared local name, or a small constant literal.
+function rand_operand(   pick) {
+    if (nlocals > 0 && rint(0, 2) > 0) {
+        pick = rint(0, nlocals - 1)
+        return locals[pick]
+    }
+    return rint(1, 9) ""
+}
+
+# emit `dst = <op> <binop> <op>;` using only safe divisors.
+function emit_arith_stmt(ind, dst, lhs, rhs,   op, l, r) {
+    op = rint(0, 4)
+    l = (lhs == "") ? rand_operand() : lhs
+    r = (rhs == "") ? rand_operand() : rhs
+    if (op == 0) { print ind dst " = " l " + " r ";" }
+    else if (op == 1) { print ind dst " = " l " - " r ";" }
+    else if (op == 2) { print ind dst " = " l " * " r ";" }
+    else if (op == 3) { print ind dst " = " l " / " rint(1, 9) ";" }  # nonzero divisor
+    else { print ind dst " = " l " % " rint(1, 9) ";" }              # nonzero modulus
+}
+
+# emit a boolean condition over a declared local and a constant.
+function rand_cond(   v, cmp, k) {
+    v = (nlocals > 0) ? locals[rint(0, nlocals - 1)] : "0"
+    cmp = rint(0, 5)
+    k = rint(0, 20)
+    if (cmp == 0) return v " < " k
+    if (cmp == 1) return v " > " k
+    if (cmp == 2) return v " <= " k
+    if (cmp == 3) return v " >= " k
+    if (cmp == 4) return v " == " k
+    return v " != " k
+}
+
+function emit_main(   nstmts, i, kind, name, lim, idx, target) {
+    print "fun main(argc: i64, argv: **u8) i64 {"
+
+    # always seed a couple of locals so later statements have operands.
+    declare_local("    ", "x", rint(0, 9))
+    declare_local("    ", "y", rint(0, 9))
+
+    nstmts = rint(4, 9)
+    for (i = 0; i < nstmts; i++) {
+        kind = rint(0, 5)
+        if (kind == 0) {
+            # new local from arithmetic
+            name = "v" i
+            declare_local("    ", name, 0)
+            emit_arith_stmt("    ", name, "", "")
+        } else if (kind == 1) {
+            # reassign an existing local
+            if (nlocals > 0) {
+                target = locals[rint(0, nlocals - 1)]
+                emit_arith_stmt("    ", target, "", "")
+            }
+        } else if (kind == 2) {
+            # if {} or {} chain
+            target = (nlocals > 0) ? locals[rint(0, nlocals - 1)] : "x"
+            print "    if (" rand_cond() ") {"
+            emit_arith_stmt("        ", target, "", "")
+            print "    }"
+            print "    or {"
+            emit_arith_stmt("        ", target, "", "")
+            print "    }"
+        } else if (kind == 3) {
+            # bounded for loop: fixed iteration count, mutates a local
+            target = (nlocals > 0) ? locals[rint(0, nlocals - 1)] : "x"
+            idx = "i" i
+            lim = rint(1, 6)
+            print "    var " idx ": i64 = 0;"
+            print "    for (" idx " < " lim ") {"
+            emit_arith_stmt("        ", target, "", "")
+            print "        " idx " = " idx " + 1;"
+            print "    }"
+        } else if (kind == 4) {
+            # record construction + field access
+            name = "box" i
+            print "    var " name ": Box = Box{ a: " rint(0, 9) ", b: " rint(0, 9) " };"
+            target = (nlocals > 0) ? locals[rint(0, nlocals - 1)] : "x"
+            if (rint(0, 1) == 0) { print "    " target " = " name ".a;" }
+            else { print "    " target " = " name ".b;" }
+        } else {
+            # call the helper with two operands
+            name = "c" i
+            declare_local("    ", name, 0)
+            print "    " name " = mix(" rand_operand() ", " rand_operand() ");"
+        }
+    }
+
+    # return a value derived from a declared local, masked into the 0..255
+    # exit-code range so the differential check compares a stable byte.
+    target = (nlocals > 0) ? locals[rint(0, nlocals - 1)] : "0"
+    print "    var ret_code: i64 = " target ";"
+    print "    if (ret_code < 0) { ret_code = -ret_code; }"
+    print "    ret_code = ret_code % 256;"
+    print "    ret ret_code;"
+    print "}"
+}
+
+# declare `var <name>: i64 = <init>;` and record it as available.
+function declare_local(ind, name, init) {
+    print ind "var " name ": i64 = " init ";"
+    locals[nlocals] = name
+    nlocals++
+}


### PR DESCRIPTION
Adds two compiler stress harnesses under `tools/test/`, scripts + a generator only — no compiler source, `mach.toml`, `dep/mach-std`, or `examples/` changes.

## What's here
- `gen.awk` — deterministic, seedable generator of small, mostly-valid Mach programs (safe constructs only: i64 locals, integer arithmetic, `if {} or {}`, bounded `for`, a `rec` with field access, a helper call).
- `fuzz.sh` — compiles N generated programs with `mach` and flags compiler **crashes** (internal-error exit 2 / fatal signal); saves crashing source + stderr. Default 100 iterations, `-s` seedable.
- `differential.sh` — compiles+runs each numbered example at `-O0` and `-O2` and asserts exit code + stdout are identical across levels (an optimization miscompile otherwise). Also diffs `smach` vs `mach` at `-O0`.
- `README.md` — how to run, what each checks, how to seed/interpret.

Both harnesses build into throwaway temp dirs and clean up; `examples/` is never written to.

## Differential result — found real `-O2` miscompiles
The `-O0` vs `-O2` check surfaced genuine bugs in the release (`-O1`/`-O2`) pipeline (inline + late constfold), which the bootstrap intentionally does not use:

| example | -O0 | -O2 | issue |
| --- | --- | --- | --- |
| `02_control_flow` | ok | build fails | internal error: `phi coverage: phi does not cover every predecessor` |
| `03_functions` | `factorial(5)=120` | `factorial(5)=0` | wrong result |
| `06_comptime` | `apply(...)=42/81` | `apply(...)=0` | function-value/inline miscompile |
| `07_errors` | ok | exit 139 | segfault at runtime |

The `smach` vs `mach` cross-compiler diff at `-O0` is all PASS (the bootstrap is fixpoint-stable at `-O0`). These `-O2` failures are pre-existing release-pipeline bugs, surfaced by the harness — not introduced here. They should be filed separately.

## Fuzz result — clean
250 generated programs across two seeds (`-s 1000 -n 100`, `-s 50000 -n 150`) all compiled at `-O0`; **no compiler crashes found**. Crash detection itself is verified (a stub exiting 139 is correctly flagged and its source saved).

Closes #1047
