### PR TITLE
fix(inline): keep phis consistent when splitting the call block

### DIFF
--- a/src/lang/me/pass/inline.mach
+++ b/src/lang/me/pass/inline.mach
@@ -6,6 +6,9 @@
 # split, the callee's blocks are cloned in with fresh ids, each callee return
 # becomes a branch to the continuation, and the call's result is replaced by a
 # phi over the return values (or the single return value when there is one).
+# Because the call block's original terminator (and thus its outgoing edges)
+# moves to the continuation, any phi in a successor that named the call block as
+# an incoming predecessor is re-keyed to the continuation block.
 #
 # The inliner deliberately produces mechanical, un-cleaned output — the release
 # pipeline re-runs mem2reg and dce afterward to tidy it. Recursive functions and
@@ -483,6 +486,13 @@ fun split_call_block(cx: *InlineCtx, call_bi: u32, call_ii: u32) Result[bool, st
         set_instr_block(caller, cont.terminator, cx.cont_blk);
     }
 
+    # the continuation inherits the call block's outgoing edges, so every
+    # successor of the moved terminator now reaches that edge from `cont`, not
+    # the call block. any phi in a successor that names the call block as its
+    # incoming predecessor must be re-keyed to the continuation before preds are
+    # rebuilt, or the phi would name a block that no longer branches to it.
+    rekey_successor_phis(caller, cont, call_bi::id.BlockId, cx.cont_blk);
+
     # truncate the call block to the instructions strictly before the call.
     blk.instr_count = call_ii;
 
@@ -491,10 +501,45 @@ fun split_call_block(cx: *InlineCtx, call_bi: u32, call_ii: u32) Result[bool, st
     if (is_err[id.InstructionId, str](rbr)) { ret err[bool, str](unwrap_err[id.InstructionId, str](rbr)); }
     blk.terminator = unwrap_ok[id.InstructionId, str](rbr);
 
-    # the continuation inherits the call block's outgoing edges: every successor
-    # of the original terminator now lists `cont` as a predecessor instead of
-    # the call block. rebuild predecessors wholesale after wiring (below).
     ret ok[bool, str](true);
+}
+
+# re-keys phi incomings in the successors of `cont`'s terminator from the old
+# call-block id to the continuation id. After the call block is split, control to
+# each successor flows through `cont`, so a phi incoming keyed on the call block
+# now names a non-predecessor; rewriting it to `cont` keeps the phi consistent
+# with the rebuilt predecessor list.
+fun rekey_successor_phis(caller: *ir.Function, cont: *ir.Block, old_blk: id.BlockId, new_blk: id.BlockId) {
+    var s0: id.BlockId = id.BLOCK_NIL;
+    var s1: id.BlockId = id.BLOCK_NIL;
+    val sn: u32 = ir.block_successors(caller, cont, ?s0, ?s1);
+    if (sn >= 1) { rekey_block_phis(caller, s0, old_blk, new_blk); }
+    if (sn >= 2 && s1 != s0) { rekey_block_phis(caller, s1, old_blk, new_blk); }
+}
+
+# rewrites every phi-incoming block slot in block `bid` that names `old_blk` to
+# name `new_blk`. Phi operands are [block0, val0, block1, val1, …] with block ids
+# riding in the block-target const_int encoding (even slots).
+fun rekey_block_phis(caller: *ir.Function, bid: id.BlockId, old_blk: id.BlockId, new_blk: id.BlockId) {
+    if (bid::u32 >= caller.block_count) { ret; }
+    val blk: *ir.Block = ?caller.blocks[bid::u32];
+    var pi: u32 = 0;
+    for (pi < blk.phi_count) {
+        val opt: Option[*instr.Instruction] = ir.get_instruction(caller, blk.phis[pi]);
+        if (is_some[*instr.Instruction](opt)) {
+            val phi: *instr.Instruction = unwrap[*instr.Instruction](opt);
+            if (phi.kind == instr.OP_PHI) {
+                var o: u32 = 0;
+                for (o + 1 < phi.operand_count) {
+                    if (ir.block_target(phi.operands[o]) == old_blk) {
+                        phi.operands[o].data.int_lit = new_blk::u64;
+                    }
+                    o = o + 2;
+                }
+            }
+        }
+        pi = pi + 1;
+    }
 }
 
 # emits a fresh OP_BR terminator (in block `in_blk`) targeting `target` and
@@ -544,9 +589,7 @@ fun finish_returns(cx: *InlineCtx, call_id: id.InstructionId) Result[bool, str] 
     # gather (clone-block, return-value) for each cloned ret, converting it to a
     # branch to the continuation in place.
     var phi_id: id.InstructionId = id.INSTR_NIL;
-    var single_val: value.Value;
-    var single_set: bool = false;
-    var ret_sites: u32 = 0;
+    var phi_incomings: u32 = 0;
 
     # pre-create the phi (empty) so we can append incomings as we walk rets.
     if (returns_value) {
@@ -572,13 +615,11 @@ fun finish_returns(cx: *InlineCtx, call_id: id.InstructionId) Result[bool, str] 
             if (is_some[*instr.Instruction](topt)) {
                 val term: *instr.Instruction = unwrap[*instr.Instruction](topt);
                 if (term.kind == instr.OP_RET) {
-                    ret_sites = ret_sites + 1;
                     if (returns_value && term.operand_count >= 1) {
-                        single_val = term.operands[0];
-                        single_set = true;
                         # append (clone_bid, ret_value) to the phi.
                         val pa: Result[bool, str] = phi_append(cx, phi_id, clone_bid, term.operands[0]);
                         if (is_err[bool, str](pa)) { ret pa; }
+                        phi_incomings = phi_incomings + 1;
                     }
                     # rewrite this ret into a branch to the continuation.
                     val rconv: Result[bool, str] = convert_ret_to_br(cx, term);
@@ -589,22 +630,21 @@ fun finish_returns(cx: *InlineCtx, call_id: id.InstructionId) Result[bool, str] 
         cb = cb + 1;
     }
 
-    # determine the replacement value for the call's result.
-    if (returns_value && ret_sites >= 1) {
-        var replacement: value.Value;
-        if (ret_sites == 1 && single_set) {
-            # single return: use its value directly. the one-incoming phi is left
-            # dangling but unreferenced — dce reclaims it.
-            replacement = single_val;
-        } or {
-            replacement = value.instr_value(phi_id, cx.ret_ty);
-        }
+    # register the result phi in the continuation and replace the call's result
+    # with it. The phi carries exactly one incoming per returning predecessor, so
+    # it covers every predecessor of the continuation; it must live in the block's
+    # phi list for the back end (and verifier) to see it.
+    if (returns_value && phi_incomings >= 1) {
+        val cont: *ir.Block = ?caller.blocks[cx.cont_blk::u32];
+        val ap: Result[bool, str] = ir.block_append_phi(m, cont, phi_id);
+        if (is_err[bool, str](ap)) { ret ap; }
+        val replacement: value.Value = value.instr_value(phi_id, cx.ret_ty);
         replace_value_uses(caller, call_id, replacement);
     }
 
-    # finally drop the original call instruction from its block (already done by
-    # truncation in split_call_block — the call sat at call_ii and the block was
-    # truncated to call_ii, so it is no longer listed). nothing more to do.
+    # the original call instruction is already unlinked: it sat at call_ii and
+    # split_call_block truncated the call block to call_ii, so it is no longer
+    # listed in any block. nothing more to do.
     ret ok[bool, str](true);
 }
 


### PR DESCRIPTION
## Summary

Fixes the `-O2`/release pipeline miscompile from #1085. Two phi-consistency bugs in the function inliner (`src/lang/me/pass/inline.mach`) — both rooted in how it splits the call block and moves its terminator into the continuation — produced incorrect IR that only the release pipeline (which adds the inline pass) exercised.

### Root causes & fixes

1. **Successor phis not re-keyed.** When the call block is split, its original terminator (and its outgoing edges) moves to the continuation. Any successor block whose phi named the *call block* as an incoming predecessor was never updated, so after `rebuild_preds` the phi named a block that no longer branched to it while the real new predecessor (the continuation) had no incoming. This tripped the verifier's `phi coverage: phi does not cover every predecessor` check and failed the `-O2` build of `02_control_flow`.
   *Fix:* `rekey_successor_phis` rewrites phi incomings in the moved terminator's successors from the call block to the continuation, before preds are rebuilt.

2. **Result phi orphaned.** The phi over the callee's return values was created in the instruction pool (`add_instruction`) but never appended to the continuation block's `phis` list. The back end and verifier only walk `block.phis`, so the phi was never materialized — the call's result was garbage. This made `factorial(5)` and `apply(DOUBLE,21)`/`apply(SQUARE,9)` return `0`, and segfaulted `07_errors`.
   *Fix:* register the result phi in the continuation with `block_append_phi` and use it uniformly as the call-result replacement (dropping the unsound single-return short-circuit that left the phi dangling).

`constfold` was investigated and found correct; the `phi coverage` error it surfaced was pre-existing inliner-produced inconsistency that only became visible once the late `constfold` rebuilt preds and re-verified.

### Verification

**`tools/test/differential.sh` — all consistent (`-O0` vs `-O2`, and smach vs mach):**
```
01_hello … 10_lowlevel    -O0=… -O2=…    PASS
differential: 10 input(s), all consistent
```
All four originally-failing examples (`02_control_flow`, `03_functions`, `06_comptime`, `07_errors`) now match at `-O2`.

**Default fixpoint holds (no regression):**
- `make clean && make` — exit 0
- `mach build . --artifacts da` / `--artifacts db`, `diff -rq out/da/obj out/db/obj` — 0 diffs
- `mach build . -o out/bin/mach2 --artifacts m2`, `cmp out/bin/mach out/bin/mach2` — identical

Closes #1085
