### PR TITLE
feat: variadic intrinsics (va_list / va_start / va_arg / va_end)

### DIFF
--- a/src/lang/be/codegen/mir.mach
+++ b/src/lang/be/codegen/mir.mach
@@ -845,6 +845,21 @@ rec LowerCtx {
     # GP argument register in `lower_params`; MIR_VREG_NIL otherwise. `lower_ret`
     # copies the returned aggregate into this storage and returns it in RAX.
     sret_vreg:   u32;
+    # va_save_vreg: slot-key vreg owning the variadic register-save area (a
+    # SLOT_ALLOCA frame slot) for a variadic function definition; MIR_VREG_NIL for
+    # a non-variadic function. the entry prologue spills the incoming GP/FP
+    # argument registers into it and `lower_va_start` points the va_list there.
+    va_save_vreg: u32;
+    # va_named_gp / va_named_fp: GP and FP argument registers consumed by the
+    # function's fixed (named) parameters, so `va_start` seeds gp_offset / fp_offset
+    # past them. captured from the signature layout in the entry prologue.
+    va_named_gp: i32;
+    va_named_fp: i32;
+    # va_overflow_off: the `[rbp + off]` displacement of the first stack-passed
+    # argument (the overflow area `va_start` points overflow_arg_area at). it is the
+    # base of the incoming stack-argument region, 16 plus the fixed params' stack
+    # bytes.
+    va_overflow_off: i64;
 }
 
 # lowers one IR function into a MirFunction. allocates the vreg table and the
@@ -878,12 +893,9 @@ fun lower_function(tgt: *target.Target, m: *ir.Module, fn: *ir.Function, interne
         ret ok[MirFunction, str](mf);
     }
 
-    # a variadic function definition would need a register-argument save area for
-    # `va_arg`, which is not yet implemented; fail loudly rather than miscompile.
-    # calls INTO variadic functions are unaffected (handled by lower_call).
-    if (fn_sig_is_variadic(m, fn)) {
-        ret err[MirFunction, str]("mir.lower_ir: variadic function definitions not yet supported");
-    }
+    # a variadic function definition reserves a register-save area in its entry
+    # prologue (see `emit_va_save_prologue`) so `va_arg` can read the GP/FP
+    # argument registers; calls INTO variadic functions are handled by lower_call.
 
     val rv: Result[*MirVReg, str] = allocate[MirVReg](m.alloc, INITIAL_VREG_CAP::usize);
     if (is_err[*MirVReg, str](rv)) {
@@ -906,6 +918,10 @@ fun lower_function(tgt: *target.Target, m: *ir.Module, fn: *ir.Function, interne
     ctx.instr_count = fn.instr_len;
     ctx.interner    = interner;
     ctx.sret_vreg   = MIR_VREG_NIL;
+    ctx.va_save_vreg = MIR_VREG_NIL;
+    ctx.va_named_gp  = 0;
+    ctx.va_named_fp  = 0;
+    ctx.va_overflow_off = 0;
 
     val setup: Result[bool, str] = ctx_setup(?ctx, tgt, fn);
     if (is_err[bool, str](setup)) {
@@ -1139,6 +1155,14 @@ fun lower_block(ctx: *LowerCtx, fn: *ir.Function, blk: *ir.Block, is_entry: bool
     if (is_entry) {
         val lp: Result[bool, str] = lower_params(ctx, mb);
         if (is_err[bool, str](lp)) { ret lp; }
+        # a variadic definition spills its incoming GP/FP argument registers into a
+        # register-save area so `va_arg` can read them. emitted after the named-
+        # parameter pre-coloring so the save area dumps the FULL argument-register
+        # file (the named params still read their own registers above).
+        if (fn_sig_is_variadic(ctx.m, fn)) {
+            val vp: Result[bool, str] = emit_va_save_prologue(ctx, mb);
+            if (is_err[bool, str](vp)) { ret vp; }
+        }
     }
 
     var ii: u32 = 0;
@@ -1615,6 +1639,15 @@ fun lower_instr(ctx: *LowerCtx, fn: *ir.Function, mb: *MirBlock, iid: id.Instruc
     }
     if (inst.kind == instr.OP_MEMZERO) {
         ret lower_memzero(ctx, mb, inst);
+    }
+    if (inst.kind == instr.OP_VA_START) {
+        ret lower_va_start(ctx, mb, inst);
+    }
+    if (inst.kind == instr.OP_VA_ARG) {
+        ret lower_va_arg(ctx, mb, inst, iid);
+    }
+    if (inst.kind == instr.OP_VA_END) {
+        ret ok[bool, str](true);
     }
     if (inst.kind == instr.OP_GEP) {
         ret lower_gep(ctx, mb, inst, iid);
@@ -3684,6 +3717,385 @@ fun emit_lea_preg(ctx: *LowerCtx, mb: *MirBlock, dst: u32, base_preg: u32, disp:
     # the address materialization selects to a pointer-sized LEA.
     mi.width         = WORD_WIDTH;
     mi.src_width     = WORD_WIDTH;
+    ret push_instr(ctx, mb, mi);
+}
+
+# emit_lea_slot: materialize a frame-slot-relative address `[slot + disp]` into a
+# value vreg via `MIR_GEP (out) <- [slot]` (selected to LEA). used to point the
+# va_list reg_save_area / overflow_arg_area at the register-save slot and the
+# incoming stack-argument region.
+fun emit_lea_slot(ctx: *LowerCtx, mb: *MirBlock, mem: MirOperand, out: *u32) Result[bool, str] {
+    val vr: Result[u32, str] = new_vreg(ctx, REG_CLASS_GP);
+    if (is_err[u32, str](vr)) { ret err[bool, str](unwrap_err[u32, str](vr)); }
+    val v: u32 = unwrap_ok[u32, str](vr);
+    val r: Result[*MirOperand, str] = allocate[MirOperand](ctx.alloc, 2::usize);
+    if (is_err[*MirOperand, str](r)) { ret err[bool, str](unwrap_err[*MirOperand, str](r)); }
+    val ops: *MirOperand = unwrap_ok[*MirOperand, str](r);
+    ops[0] = op_vreg(v);
+    ops[1] = mem;
+    var mi: MirInstr;
+    mi.opcode        = MIR_GEP;
+    mi.operands      = ops;
+    mi.operand_count = 2;
+    mi.width         = WORD_WIDTH;
+    mi.src_width     = WORD_WIDTH;
+    val p: Result[bool, str] = push_instr(ctx, mb, mi);
+    if (is_err[bool, str](p)) { ret p; }
+    @out = v;
+    ret ok[bool, str](true);
+}
+
+# emit_load_w: load `width` bytes from `mem` into a fresh GP vreg, returned in
+# `out`. a sub-word load zero-extends into the full register (clamped width), so
+# the upper bits are clean for a wider downstream use.
+fun emit_load_w(ctx: *LowerCtx, mb: *MirBlock, mem: MirOperand, width: u8, out: *u32) Result[bool, str] {
+    val vr: Result[u32, str] = new_vreg(ctx, REG_CLASS_GP);
+    if (is_err[u32, str](vr)) { ret err[bool, str](unwrap_err[u32, str](vr)); }
+    val v: u32 = unwrap_ok[u32, str](vr);
+    val r: Result[*MirOperand, str] = allocate[MirOperand](ctx.alloc, 2::usize);
+    if (is_err[*MirOperand, str](r)) { ret err[bool, str](unwrap_err[*MirOperand, str](r)); }
+    val ops: *MirOperand = unwrap_ok[*MirOperand, str](r);
+    ops[0] = op_vreg(v);
+    ops[1] = mem;
+    var mi: MirInstr;
+    mi.opcode        = MIR_LOAD;
+    mi.operands      = ops;
+    mi.operand_count = 2;
+    mi.src_width     = width;
+    mi.width         = clamp_alu_width(width);
+    val p: Result[bool, str] = push_instr(ctx, mb, mi);
+    if (is_err[bool, str](p)) { ret p; }
+    @out = v;
+    ret ok[bool, str](true);
+}
+
+# emit_alu3: emit a three-address ALU op `MIR_<op> (out) <- (a) , (b)` at `width`,
+# returning the destination vreg in `out`. operand layout matches `lower_generic`
+# (dst, lhs, rhs); used to build the va_arg address arithmetic and branchless
+# select.
+fun emit_alu3(ctx: *LowerCtx, mb: *MirBlock, op: MirOpcode, a: MirOperand, b: MirOperand,
+              width: u8, out: *u32) Result[bool, str] {
+    val vr: Result[u32, str] = new_vreg(ctx, REG_CLASS_GP);
+    if (is_err[u32, str](vr)) { ret err[bool, str](unwrap_err[u32, str](vr)); }
+    val v: u32 = unwrap_ok[u32, str](vr);
+    val r: Result[*MirOperand, str] = allocate[MirOperand](ctx.alloc, 3::usize);
+    if (is_err[*MirOperand, str](r)) { ret err[bool, str](unwrap_err[*MirOperand, str](r)); }
+    val ops: *MirOperand = unwrap_ok[*MirOperand, str](r);
+    ops[0] = op_vreg(v);
+    ops[1] = a;
+    ops[2] = b;
+    var mi: MirInstr;
+    mi.opcode        = op;
+    mi.operands      = ops;
+    mi.operand_count = 3;
+    mi.width         = width;
+    mi.src_width     = width;
+    val p: Result[bool, str] = push_instr(ctx, mb, mi);
+    if (is_err[bool, str](p)) { ret p; }
+    @out = v;
+    ret ok[bool, str](true);
+}
+
+# emit_va_save_prologue: reserve the variadic register-save area and spill the
+# incoming GP/FP argument registers into it so `va_arg` can read them. the save
+# area is a SLOT_ALLOCA frame slot keyed on a fresh slot-key vreg (`va_save_vreg`),
+# sized by the active ABI's `va_save_size`. the six GP argument registers are
+# stored at offsets 0,8,..,40 and the eight FP argument registers at
+# `va_fp_save_offset()` + i*16 — matching the AMD64 `__va_list_tag` register-save
+# layout the `va_arg` field offsets index. the named-parameter GP/FP usage and the
+# first stack-argument offset are captured from the signature layout so
+# `va_start` can seed the cursors. all SysV register-file / layout facts are read
+# through `sysv` (its erased vtable casts and layout helpers), keeping the
+# expansion mechanism generic and the numbers in the ABI.
+fun emit_va_save_prologue(ctx: *LowerCtx, mb: *MirBlock) Result[bool, str] {
+    val rok: Result[bool, str] = require_abi(ctx.tgt);
+    if (is_err[bool, str](rok)) { ret rok; }
+
+    # the register-save area: one addressed alloca slot keyed on a slot-key vreg.
+    val skr: Result[u32, str] = new_vreg(ctx, REG_CLASS_GP);
+    if (is_err[u32, str](skr)) { ret err[bool, str](unwrap_err[u32, str](skr)); }
+    val sk: u32 = unwrap_ok[u32, str](skr);
+    val ar: Result[bool, str] = add_alloca_slot(ctx, sk, sysv.va_save_size(), 8);
+    if (is_err[bool, str](ar)) { ret ar; }
+    ctx.va_save_vreg = sk;
+
+    # capture the named-parameter register usage and overflow base from the
+    # signature layout (the same oracle `lower_params` walks).
+    val ret_ty: ir_type.IrTypeId = fn_return_type(ctx);
+    var layout: abi.SigLayout;
+    val cls: Result[bool, str] = classify_signature(ctx, ctx.fn.sig, ret_ty, ?layout);
+    if (is_err[bool, str](cls)) { ret cls; }
+    ctx.va_named_gp     = layout.gp_used;
+    ctx.va_named_fp     = layout.fp_used;
+    ctx.va_overflow_off = 16 + layout.stack_off;
+    sig_layout_free(ctx, ?layout);
+
+    # spill every GP argument register into its fixed save-area slot (0,8,..).
+    var gi: i32 = 0;
+    for (gi < sysv.GP_PARAM_COUNT) {
+        var greg: i32 = 0;
+        val gr: Result[bool, str] = abi_gp_arg_reg(ctx.tgt, gi, ?greg);
+        if (is_err[bool, str](gr)) { ret gr; }
+        val off: i64 = gi::i64 * 8;
+        val st: Result[bool, str] = emit_store_to(ctx, mb, op_mem_slot(sk, off), op_preg(greg::u32));
+        if (is_err[bool, str](st)) { ret st; }
+        gi = gi + 1;
+    }
+
+    # the FP argument registers (XMM0–7) are NOT spilled: `va_arg` of a floating-
+    # point type is not yet supported (it errors loudly in `lower_va_arg`), so the
+    # FP region of the save area is never read. dumping XMM to the save area — and
+    # the AL-guarded conditional spill a full implementation needs — is a follow-up.
+    ret ok[bool, str](true);
+}
+
+# lower_va_start: expand `OP_VA_START [ap]` into the AMD64 `__va_list_tag`
+# initialization. with `ap` the va_list storage pointer, it writes:
+#   gp_offset         = named GP regs * 8   (cursor past the fixed params)
+#   fp_offset         = GP area size + named FP regs * 16
+#   reg_save_area     = &register-save slot
+#   overflow_arg_area = &first incoming stack argument (`[rbp + overflow_off]`)
+# all four fields at the SysV `VA_*` offsets the lowering and `va_arg` share.
+fun lower_va_start(ctx: *LowerCtx, mb: *MirBlock, inst: *instr.Instruction) Result[bool, str] {
+    if (inst.operand_count == 0) {
+        ret err[bool, str]("mir.lower_ir: va_start with no va_list operand");
+    }
+    if (ctx.va_save_vreg == MIR_VREG_NIL) {
+        ret err[bool, str]("mir.lower_ir: va_start in a non-variadic function");
+    }
+    # base address of the va_list struct (the `ap` pointer operand).
+    val apbase: MirOperand = mem_operand_of(ctx, inst.operands[0]);
+
+    # gp_offset = named GP regs * 8.
+    val gp_init: i64 = ctx.va_named_gp::i64 * 8;
+    val sg: Result[bool, str] = emit_store_imm(ctx, mb, va_field_mem(apbase, sysv.VA_GP_OFFSET), gp_init, 4);
+    if (is_err[bool, str](sg)) { ret sg; }
+
+    # fp_offset = GP area size + named FP regs * 16.
+    val fp_init: i64 = sysv.va_fp_save_offset()::i64 + ctx.va_named_fp::i64 * 16;
+    val sf: Result[bool, str] = emit_store_imm(ctx, mb, va_field_mem(apbase, sysv.VA_FP_OFFSET), fp_init, 4);
+    if (is_err[bool, str](sf)) { ret sf; }
+
+    # reg_save_area = &register-save slot.
+    var rsa: u32 = MIR_VREG_NIL;
+    val lr: Result[bool, str] = emit_lea_slot(ctx, mb, op_mem_slot(ctx.va_save_vreg, 0), ?rsa);
+    if (is_err[bool, str](lr)) { ret lr; }
+    val sr: Result[bool, str] = emit_store_to(ctx, mb, va_field_mem(apbase, sysv.VA_REG_SAVE_AREA), op_vreg(rsa));
+    if (is_err[bool, str](sr)) { ret sr; }
+
+    # overflow_arg_area = &first incoming stack argument (`[rbp + overflow_off]`).
+    val fp: u32 = ctx.tgt.arch.frame_ptr_reg::u32;
+    var ovf: u32 = MIR_VREG_NIL;
+    val lo: Result[bool, str] = emit_lea_slot(ctx, mb, op_mem_preg(fp, ctx.va_overflow_off), ?ovf);
+    if (is_err[bool, str](lo)) { ret lo; }
+    ret emit_store_to(ctx, mb, va_field_mem(apbase, sysv.VA_OVERFLOW_ARG_AREA), op_vreg(ovf));
+}
+
+# va_field_mem: form a memory operand addressing field `field_off` of a va_list
+# whose base operand is `apbase`. the base is the `ap` pointer; a value-vreg base
+# becomes `[base + field_off]`, a slot base keeps its slot key.
+fun va_field_mem(apbase: MirOperand, field_off: u32) MirOperand {
+    var o: MirOperand = apbase;
+    o.imm = o.imm + field_off::i64;
+    ret o;
+}
+
+# emit_store_imm: store the immediate `imm` at `width` bytes to `mem`. x86-64 can
+# store an immediate to memory directly; a width-typed `MIR_STORE` carries it.
+fun emit_store_imm(ctx: *LowerCtx, mb: *MirBlock, mem: MirOperand, imm: i64, width: u8) Result[bool, str] {
+    val r: Result[*MirOperand, str] = allocate[MirOperand](ctx.alloc, 2::usize);
+    if (is_err[*MirOperand, str](r)) { ret err[bool, str](unwrap_err[*MirOperand, str](r)); }
+    val ops: *MirOperand = unwrap_ok[*MirOperand, str](r);
+    ops[0] = mem;
+    ops[1] = op_imm(imm);
+    var mi: MirInstr;
+    mi.opcode        = MIR_STORE;
+    mi.operands      = ops;
+    mi.operand_count = 2;
+    mi.width         = width;
+    mi.src_width     = width;
+    ret push_instr(ctx, mb, mi);
+}
+
+# lower_va_arg: expand `OP_VA_ARG [ap]` for a GP-class scalar / pointer result.
+# per SysV, the next argument is taken from the register-save area while a GP slot
+# remains (gp_offset < 48), else from the overflow area; the matching cursor
+# advances. the register-vs-overflow choice is realized branch-free with a 0/-1
+# mask so the expansion needs no extra basic blocks:
+#   in_reg = gp_offset < gp_offset_max
+#   mask   = 0 - in_reg                      (i64: all-ones when in_reg else 0)
+#   reg_ad = reg_save_area + gp_offset
+#   addr   = (reg_ad & mask) | (overflow & ~mask)
+#   gp_offset       += (8 & mask32)          (only when a register was used)
+#   overflow_arg_area += (8 & ~mask)         (only when overflow was used)
+#   result = load.T [addr]
+# FP-class (float) and >16-byte by-value arguments are not handled here — only the
+# scalar / pointer GP cases `std.format` needs; a float va_arg errors loudly
+# rather than miscompiling. fp_offset / fp register-save reads are a documented
+# follow-up.
+fun lower_va_arg(ctx: *LowerCtx, mb: *MirBlock, inst: *instr.Instruction, iid: id.InstructionId) Result[bool, str] {
+    if (inst.operand_count == 0) {
+        ret err[bool, str]("mir.lower_ir: va_arg with no va_list operand");
+    }
+    val dst: u32 = result_vreg(ctx, iid);
+    if (dst == MIR_VREG_NIL) {
+        ret err[bool, str]("mir.lower_ir: va_arg defines no result vreg");
+    }
+    if (value_is_float(ctx, inst.ty)) {
+        ret err[bool, str]("mir.lower_ir: va_arg of a floating-point type is not yet supported");
+    }
+    if (value_is_aggregate(ctx, inst.ty)) {
+        ret err[bool, str]("mir.lower_ir: va_arg of an aggregate type is not yet supported");
+    }
+
+    val apbase: MirOperand = mem_operand_of(ctx, inst.operands[0]);
+
+    # gp = load.i32 [ap + gp_offset]; gp64 = zext gp.
+    var gp: u32 = MIR_VREG_NIL;
+    val lg: Result[bool, str] = emit_load_w(ctx, mb, va_field_mem(apbase, sysv.VA_GP_OFFSET), 4, ?gp);
+    if (is_err[bool, str](lg)) { ret lg; }
+
+    # in_reg = gp < gp_offset_max  (u32 compare -> i8 boolean).
+    var in_reg: u32 = MIR_VREG_NIL;
+    val cr: Result[bool, str] = emit_alu3(ctx, mb, MIR_CMP_LT_U, op_vreg(gp),
+        op_imm(sysv.va_gp_offset_max()::i64), 4, ?in_reg);
+    if (is_err[bool, str](cr)) { ret cr; }
+
+    # mask = 0 - zext(in_reg)  -> 0 or 0xFFFFFFFFFFFFFFFF (64-bit).
+    var inz: u32 = MIR_VREG_NIL;
+    val zr: Result[bool, str] = emit_zext_to(ctx, mb, op_vreg(in_reg), 1, ?inz);
+    if (is_err[bool, str](zr)) { ret zr; }
+    var mask: u32 = MIR_VREG_NIL;
+    val mr: Result[bool, str] = emit_alu3(ctx, mb, MIR_SUB, op_imm(0), op_vreg(inz), 8, ?mask);
+    if (is_err[bool, str](mr)) { ret mr; }
+    var nmask: u32 = MIR_VREG_NIL;
+    val nr: Result[bool, str] = emit_not_to(ctx, mb, op_vreg(mask), 8, ?nmask);
+    if (is_err[bool, str](nr)) { ret nr; }
+
+    # reg_addr = reg_save_area + zext(gp).
+    var rsa: u32 = MIR_VREG_NIL;
+    val lr: Result[bool, str] = emit_load_w(ctx, mb, va_field_mem(apbase, sysv.VA_REG_SAVE_AREA), 8, ?rsa);
+    if (is_err[bool, str](lr)) { ret lr; }
+    var gp64: u32 = MIR_VREG_NIL;
+    val gzr: Result[bool, str] = emit_zext_to(ctx, mb, op_vreg(gp), 4, ?gp64);
+    if (is_err[bool, str](gzr)) { ret gzr; }
+    var reg_addr: u32 = MIR_VREG_NIL;
+    val rar: Result[bool, str] = emit_alu3(ctx, mb, MIR_ADD, op_vreg(rsa), op_vreg(gp64), 8, ?reg_addr);
+    if (is_err[bool, str](rar)) { ret rar; }
+
+    # ovf = overflow_arg_area.
+    var ovf: u32 = MIR_VREG_NIL;
+    val lo: Result[bool, str] = emit_load_w(ctx, mb, va_field_mem(apbase, sysv.VA_OVERFLOW_ARG_AREA), 8, ?ovf);
+    if (is_err[bool, str](lo)) { ret lo; }
+
+    # addr = (reg_addr & mask) | (ovf & ~mask).
+    var ra_m: u32 = MIR_VREG_NIL;
+    val r1: Result[bool, str] = emit_alu3(ctx, mb, MIR_AND, op_vreg(reg_addr), op_vreg(mask), 8, ?ra_m);
+    if (is_err[bool, str](r1)) { ret r1; }
+    var ov_m: u32 = MIR_VREG_NIL;
+    val r2: Result[bool, str] = emit_alu3(ctx, mb, MIR_AND, op_vreg(ovf), op_vreg(nmask), 8, ?ov_m);
+    if (is_err[bool, str](r2)) { ret r2; }
+    var addr: u32 = MIR_VREG_NIL;
+    val r3: Result[bool, str] = emit_alu3(ctx, mb, MIR_OR, op_vreg(ra_m), op_vreg(ov_m), 8, ?addr);
+    if (is_err[bool, str](r3)) { ret r3; }
+
+    # gp_offset += (8 & mask32): advance only when a register slot was used.
+    var step_gp: u32 = MIR_VREG_NIL;
+    val sg: Result[bool, str] = emit_alu3(ctx, mb, MIR_AND, op_imm(8), op_vreg(mask), 4, ?step_gp);
+    if (is_err[bool, str](sg)) { ret sg; }
+    var new_gp: u32 = MIR_VREG_NIL;
+    val ng: Result[bool, str] = emit_alu3(ctx, mb, MIR_ADD, op_vreg(gp), op_vreg(step_gp), 4, ?new_gp);
+    if (is_err[bool, str](ng)) { ret ng; }
+    val wg: Result[bool, str] = emit_store_to_w(ctx, mb, va_field_mem(apbase, sysv.VA_GP_OFFSET), op_vreg(new_gp), 4);
+    if (is_err[bool, str](wg)) { ret wg; }
+
+    # overflow_arg_area += (8 & ~mask): advance only when the overflow area was used.
+    var step_ov: u32 = MIR_VREG_NIL;
+    val so: Result[bool, str] = emit_alu3(ctx, mb, MIR_AND, op_imm(8), op_vreg(nmask), 8, ?step_ov);
+    if (is_err[bool, str](so)) { ret so; }
+    var new_ov: u32 = MIR_VREG_NIL;
+    val no: Result[bool, str] = emit_alu3(ctx, mb, MIR_ADD, op_vreg(ovf), op_vreg(step_ov), 8, ?new_ov);
+    if (is_err[bool, str](no)) { ret no; }
+    val wo: Result[bool, str] = emit_store_to_w(ctx, mb, va_field_mem(apbase, sysv.VA_OVERFLOW_ARG_AREA), op_vreg(new_ov), 8);
+    if (is_err[bool, str](wo)) { ret wo; }
+
+    # result = load.T [addr], at the result type's width.
+    val w: u8 = op_width_of(ctx, inst.ty);
+    val r: Result[*MirOperand, str] = allocate[MirOperand](ctx.alloc, 2::usize);
+    if (is_err[*MirOperand, str](r)) { ret err[bool, str](unwrap_err[*MirOperand, str](r)); }
+    val ops: *MirOperand = unwrap_ok[*MirOperand, str](r);
+    ops[0] = op_vreg(dst);
+    ops[1] = op_mem_value(addr, 0);
+    var mi: MirInstr;
+    mi.opcode        = MIR_LOAD;
+    mi.operands      = ops;
+    mi.operand_count = 2;
+    mi.src_width     = w;
+    mi.width         = clamp_alu_width(w);
+    ret push_instr(ctx, mb, mi);
+}
+
+# emit_zext_to: zero-extend `src` (`src_w` bytes) into a fresh 8-byte GP vreg,
+# returned in `out`. used to widen the va_arg gp_offset / boolean to the pointer
+# width for the address arithmetic and select mask.
+fun emit_zext_to(ctx: *LowerCtx, mb: *MirBlock, src: MirOperand, src_w: u8, out: *u32) Result[bool, str] {
+    val vr: Result[u32, str] = new_vreg(ctx, REG_CLASS_GP);
+    if (is_err[u32, str](vr)) { ret err[bool, str](unwrap_err[u32, str](vr)); }
+    val v: u32 = unwrap_ok[u32, str](vr);
+    val r: Result[*MirOperand, str] = allocate[MirOperand](ctx.alloc, 2::usize);
+    if (is_err[*MirOperand, str](r)) { ret err[bool, str](unwrap_err[*MirOperand, str](r)); }
+    val ops: *MirOperand = unwrap_ok[*MirOperand, str](r);
+    ops[0] = op_vreg(v);
+    ops[1] = src;
+    var mi: MirInstr;
+    mi.opcode        = MIR_ZEXT;
+    mi.operands      = ops;
+    mi.operand_count = 2;
+    mi.width         = 8;
+    mi.src_width     = src_w;
+    val p: Result[bool, str] = push_instr(ctx, mb, mi);
+    if (is_err[bool, str](p)) { ret p; }
+    @out = v;
+    ret ok[bool, str](true);
+}
+
+# emit_not_to: bitwise-complement `src` at `width` into a fresh GP vreg (`out`).
+fun emit_not_to(ctx: *LowerCtx, mb: *MirBlock, src: MirOperand, width: u8, out: *u32) Result[bool, str] {
+    val vr: Result[u32, str] = new_vreg(ctx, REG_CLASS_GP);
+    if (is_err[u32, str](vr)) { ret err[bool, str](unwrap_err[u32, str](vr)); }
+    val v: u32 = unwrap_ok[u32, str](vr);
+    val r: Result[*MirOperand, str] = allocate[MirOperand](ctx.alloc, 2::usize);
+    if (is_err[*MirOperand, str](r)) { ret err[bool, str](unwrap_err[*MirOperand, str](r)); }
+    val ops: *MirOperand = unwrap_ok[*MirOperand, str](r);
+    ops[0] = op_vreg(v);
+    ops[1] = src;
+    var mi: MirInstr;
+    mi.opcode        = MIR_NOT;
+    mi.operands      = ops;
+    mi.operand_count = 2;
+    mi.width         = width;
+    mi.src_width     = width;
+    val p: Result[bool, str] = push_instr(ctx, mb, mi);
+    if (is_err[bool, str](p)) { ret p; }
+    @out = v;
+    ret ok[bool, str](true);
+}
+
+# emit_store_to_w: store `src` to `mem` at an explicit `width` (vs `emit_store_to`'s
+# machine-word default). used to write the 4-byte gp_offset and the 8-byte
+# overflow_arg_area back into the va_list.
+fun emit_store_to_w(ctx: *LowerCtx, mb: *MirBlock, mem: MirOperand, src: MirOperand, width: u8) Result[bool, str] {
+    val r: Result[*MirOperand, str] = allocate[MirOperand](ctx.alloc, 2::usize);
+    if (is_err[*MirOperand, str](r)) { ret err[bool, str](unwrap_err[*MirOperand, str](r)); }
+    val ops: *MirOperand = unwrap_ok[*MirOperand, str](r);
+    ops[0] = mem;
+    ops[1] = src;
+    var mi: MirInstr;
+    mi.opcode        = MIR_STORE;
+    mi.operands      = ops;
+    mi.operand_count = 2;
+    mi.width         = width;
+    mi.src_width     = width;
     ret push_instr(ctx, mb, mi);
 }
 

--- a/src/lang/fe/resolve.mach
+++ b/src/lang/fe/resolve.mach
@@ -187,12 +187,13 @@ rec ResolveContext {
     module_scope:  ScopeId;
     current_scope: ScopeId;
 
-    # primitive type registry: the SYM_PRIM symbols for u8..f64 / ptr, keyed
-    # by interned name. primitives are recognised in type position only (never
-    # bound into a value scope), so a module may declare a value named `u32`
-    # without colliding with the primitive type spelling.
-    prim_names: [11]intern.StrId;
-    prim_syms:  [11]SymbolId;
+    # primitive type registry: the SYM_PRIM symbols for u8..f64 / ptr plus the
+    # builtin `va_list`, keyed by interned name. primitives are recognised in
+    # type position only (never bound into a value scope), so a module may
+    # declare a value named `u32` without colliding with the primitive type
+    # spelling. `va_list` carries the TYPE_VA_LIST kind ordinal in its slot.
+    prim_names: [12]intern.StrId;
+    prim_syms:  [12]SymbolId;
 
     # caches (origin << 32 | decl) -> SymbolId for already-created
     # SYM_IMPORTED entries, so repeated `print.println` use-sites share one
@@ -200,8 +201,8 @@ rec ResolveContext {
     imported_cache: map.Map[u64, SymbolId];
 }
 
-# number of primitive type names (u8..f64, ptr).
-val PRIM_COUNT: u32 = 11;
+# number of primitive type names (u8..f64, ptr, va_list).
+val PRIM_COUNT: u32 = 12;
 
 # ResolveResult: the contract resolve produces for sema and the driver's export step.
 # ---
@@ -575,6 +576,9 @@ fun seed_primitives(rc: *ResolveContext) Result[bool, str] {
     val r8:  Result[bool, str] = seed_one_primitive(rc, 8,  "f32", type.TYPE_F32::u32); if (is_err[bool, str](r8))  { ret r8; }
     val r9:  Result[bool, str] = seed_one_primitive(rc, 9,  "f64", type.TYPE_F64::u32); if (is_err[bool, str](r9))  { ret r9; }
     val r10: Result[bool, str] = seed_one_primitive(rc, 10, "ptr", type.TYPE_PTR::u32); if (is_err[bool, str](r10)) { ret r10; }
+    # `va_list` is a builtin type spelling (the variadic register-save struct),
+    # resolved in type position like a primitive but mapping to TYPE_VA_LIST.
+    val r11: Result[bool, str] = seed_one_primitive(rc, 11, "va_list", type.TYPE_VA_LIST::u32); if (is_err[bool, str](r11)) { ret r11; }
     ret ok[bool, str](true);
 }
 
@@ -1386,8 +1390,15 @@ fun bind_expr(rc: *ResolveContext, eid: id.ExprId) Result[bool, str] {
         val intr: Option[Result[bool, str]] = bind_comptime_intrinsic_call(rc, ?e.data.call);
         if (is_some[Result[bool, str]](intr)) { ret unwrap[Result[bool, str]](intr); }
 
-        val rc_e: Result[bool, str] = bind_expr(rc, e.data.call.callee);
-        if (is_err[bool, str](rc_e)) { ret rc_e; }
+        # the variadic intrinsics (`va_start`/`va_arg`/`va_end`) are builtin
+        # callees declared nowhere; binding their callee ident would report an
+        # "unresolved identifier". skip the callee bind for them and bind only
+        # the value arguments. `va_arg[T]`'s type argument binds below as usual.
+        val is_va: bool = is_va_intrinsic_callee(rc, e.data.call.callee);
+        if (!is_va) {
+            val rc_e: Result[bool, str] = bind_expr(rc, e.data.call.callee);
+            if (is_err[bool, str](rc_e)) { ret rc_e; }
+        }
         var ti: u32 = 0;
         for (ti < e.data.call.type_args_len) {
             val arg_id: id.TypeId = rc.a.type_ids[e.data.call.type_args_start + ti];
@@ -1547,6 +1558,23 @@ fun interned_literal(rc: *ResolveContext, text: str) intern.StrId {
     val r: Result[intern.StrId, str] = intern.intern(?rc.s.interner, text);
     if (is_err[intern.StrId, str](r)) { ret intern.STR_NIL; }
     ret unwrap_ok[intern.StrId, str](r);
+}
+
+# true when a call's callee is a bare-identifier variadic intrinsic
+# (`va_start` / `va_arg` / `va_end`). these are builtins recognised by name and
+# expanded by the backend, so their callee ident must not bind to a value.
+fun is_va_intrinsic_callee(rc: *ResolveContext, callee: id.ExprId) bool {
+    val ce_opt: Option[*expr.Expr] = ast.get_expr(rc.a, callee);
+    if (is_none[*expr.Expr](ce_opt)) { ret false; }
+    val ce: *expr.Expr = unwrap[*expr.Expr](ce_opt);
+    if (ce.kind != expr.EXPR_KIND_IDENT) { ret false; }
+    val r: Result[intern.StrId, str] = intern.intern_span(?rc.s.interner, rc.source, ce.span);
+    if (is_err[intern.StrId, str](r)) { ret false; }
+    val name: intern.StrId = unwrap_ok[intern.StrId, str](r);
+    if (name == interned_literal(rc, "va_start")) { ret true; }
+    if (name == interned_literal(rc, "va_arg"))   { ret true; }
+    if (name == interned_literal(rc, "va_end"))   { ret true; }
+    ret false;
 }
 
 fun bind_type(rc: *ResolveContext, tid: id.TypeId) Result[bool, str] {

--- a/src/lang/fe/sema/infer.mach
+++ b/src/lang/fe/sema/infer.mach
@@ -375,6 +375,12 @@ fun infer_call(sc: *sema.SemaContext, c: *expr.ExprCall, span: token.Span) type.
     val intr: type.TypeId = infer_comptime_intrinsic(sc, c, span);
     if (intr != type.TYPE_NIL) { ret intr; }
 
+    # the variadic intrinsics are typed specially: `va_start`/`va_end` are
+    # void `(*va_list)`, `va_arg[T]` yields T from a `*va_list`. handled before
+    # normal callee inference, whose bare ident would not resolve.
+    val va: Option[type.TypeId] = infer_va_intrinsic(sc, c, span);
+    if (is_some[type.TypeId](va)) { ret unwrap[type.TypeId](va); }
+
     val ct: type.TypeId = infer_expr(sc, c.callee);
     # infer argument types so their expr_type slots are populated
     var ai: u32 = 0;
@@ -442,6 +448,54 @@ fun infer_comptime_intrinsic(sc: *sema.SemaContext, c: *expr.ExprCall, span: tok
     set_expr_type(sc, arg0, op_ty);
     if (op_ty == type.TYPE_ERROR) { ret type.TYPE_ERROR; }
     ret prim_or_error(sc, type.TYPE_U64);
+}
+
+# types a variadic intrinsic call. `va_start(ap)` / `va_end(ap)` take one
+# `*va_list` argument and yield void (TYPE_NIL); `va_arg[T](ap)` takes one
+# `*va_list` and yields T (its single type argument). returns none when the
+# callee is not a variadic intrinsic, so `infer_call` proceeds normally; some
+# (TYPE_NIL) for the void intrinsics, distinguished from the none sentinel.
+fun infer_va_intrinsic(sc: *sema.SemaContext, c: *expr.ExprCall, span: token.Span) Option[type.TypeId] {
+    val ce_opt: Option[*expr.Expr] = ast.get_expr(sc.a, c.callee);
+    if (is_none[*expr.Expr](ce_opt)) { ret none[type.TypeId](); }
+    val ce: *expr.Expr = unwrap[*expr.Expr](ce_opt);
+    if (ce.kind != expr.EXPR_KIND_IDENT) { ret none[type.TypeId](); }
+
+    val name: intern.StrId = intern_span_or_nil(sc, ce.span);
+    if (name == intern.STR_NIL) { ret none[type.TypeId](); }
+    val is_start: bool = name == interned(sc, "va_start");
+    val is_arg:   bool = name == interned(sc, "va_arg");
+    val is_end:   bool = name == interned(sc, "va_end");
+    if (!is_start && !is_arg && !is_end) { ret none[type.TypeId](); }
+
+    if (c.args_len != 1) {
+        sema.report(sc, span, "va intrinsic: expected one va_list pointer argument");
+        ret some[type.TypeId](type.TYPE_ERROR);
+    }
+
+    # the argument is a `*va_list`; infer it so its expr_type slot populates and
+    # require a pointer (the va_list address `va_start(?ap)` / the `ap: *va_list`
+    # parameter passed through).
+    val arg_eid: id.ExprId = sc.a.expr_ids[c.args_start];
+    val arg_ty: type.TypeId = infer_expr(sc, arg_eid);
+    if (arg_ty != type.TYPE_ERROR) {
+        val at_opt: Option[*type.Type] = type.get(?sc.s.types, arg_ty);
+        if (is_some[*type.Type](at_opt) && unwrap[*type.Type](at_opt).kind != type.TYPE_POINTER) {
+            sema.report(sc, span, "va intrinsic: argument must be a va_list pointer");
+        }
+    }
+
+    if (is_arg) {
+        if (c.type_args_len != 1) {
+            sema.report(sc, span, "va_arg: expected one type argument `va_arg[T](ap)`");
+            ret some[type.TypeId](type.TYPE_ERROR);
+        }
+        val targ: id.TypeId = sc.a.type_ids[c.type_args_start];
+        ret some[type.TypeId](resolve_type_ref(sc, targ));
+    }
+
+    # `va_start` / `va_end` yield void.
+    ret some[type.TypeId](type.TYPE_NIL);
 }
 
 # resolves a comptime intrinsic's type-naming argument to its semantic type.
@@ -954,8 +1008,14 @@ fun pointee_of(sc: *sema.SemaContext, ty: type.TypeId, span: token.Span) type.Ty
 }
 
 # fetches a primitive TypeId by kind; returns TYPE_ERROR when the kind is not
-# a primitive (a compiler-internal misuse).
+# a primitive (a compiler-internal misuse). the builtin `va_list` spelling is
+# seeded as a SYM_PRIM carrying TYPE_VA_LIST, so it is interned on demand here.
 fun prim_or_error(sc: *sema.SemaContext, kind: type.TypeKind) type.TypeId {
+    if (kind == type.TYPE_VA_LIST) {
+        val r: Result[type.TypeId, str] = type.intern_va_list(?sc.s.types);
+        if (is_err[type.TypeId, str](r)) { ret type.TYPE_ERROR; }
+        ret unwrap_ok[type.TypeId, str](r);
+    }
     val p: Option[type.TypeId] = type.prim(?sc.s.types, kind);
     if (is_none[type.TypeId](p)) { ret type.TYPE_ERROR; }
     ret unwrap[type.TypeId](p);

--- a/src/lang/me/ir/builder.mach
+++ b/src/lang/me/ir/builder.mach
@@ -509,6 +509,56 @@ pub fun emit_memzero(b: *Builder, ptr: value.Value, pointee_ty: ir_type.IrTypeId
     ret ok[bool, str](true);
 }
 
+# emits an `OP_VA_START` initializing the va_list at `ap_ptr`. produces no value;
+# the backend fills in the register-save-area cursor / pointers.
+# ---
+# b:      the builder
+# ap_ptr: pointer to the va_list storage
+# ret:    ok(true) on success, or an error
+pub fun emit_va_start(b: *Builder, ap_ptr: value.Value) Result[bool, str] {
+    val vr: Result[ir_type.IrTypeId, str] = void_type(b);
+    if (is_err[ir_type.IrTypeId, str](vr)) { ret err[bool, str](unwrap_err[ir_type.IrTypeId, str](vr)); }
+    val vty: ir_type.IrTypeId = unwrap_ok[ir_type.IrTypeId, str](vr);
+
+    var ops: [1]value.Value;
+    ops[0] = ap_ptr;
+    val r: Result[id.InstructionId, str] = emit_raw(b, instr.OP_VA_START, vty, ?ops[0], 1);
+    if (is_err[id.InstructionId, str](r)) { ret err[bool, str](unwrap_err[id.InstructionId, str](r)); }
+    ret ok[bool, str](true);
+}
+
+# emits an `OP_VA_ARG` fetching the next variadic argument of type `ty` from the
+# va_list at `ap_ptr`. the result is a value of type `ty`; the backend advances
+# the va_list cursor.
+# ---
+# b:      the builder
+# ap_ptr: pointer to the va_list storage
+# ty:     type of the argument to fetch
+# ret:    a value of type `ty`, or an error
+pub fun emit_va_arg(b: *Builder, ap_ptr: value.Value, ty: ir_type.IrTypeId) Result[value.Value, str] {
+    var ops: [1]value.Value;
+    ops[0] = ap_ptr;
+    ret emit_value_instr(b, instr.OP_VA_ARG, ty, ?ops[0], 1);
+}
+
+# emits an `OP_VA_END` finalizing the va_list at `ap_ptr`. produces no value (a
+# no-op on SysV).
+# ---
+# b:      the builder
+# ap_ptr: pointer to the va_list storage
+# ret:    ok(true) on success, or an error
+pub fun emit_va_end(b: *Builder, ap_ptr: value.Value) Result[bool, str] {
+    val vr: Result[ir_type.IrTypeId, str] = void_type(b);
+    if (is_err[ir_type.IrTypeId, str](vr)) { ret err[bool, str](unwrap_err[ir_type.IrTypeId, str](vr)); }
+    val vty: ir_type.IrTypeId = unwrap_ok[ir_type.IrTypeId, str](vr);
+
+    var ops: [1]value.Value;
+    ops[0] = ap_ptr;
+    val r: Result[id.InstructionId, str] = emit_raw(b, instr.OP_VA_END, vty, ?ops[0], 1);
+    if (is_err[id.InstructionId, str](r)) { ret err[bool, str](unwrap_err[id.InstructionId, str](r)); }
+    ret ok[bool, str](true);
+}
+
 # emits an address computation: `base` adjusted by the given indices. the
 # result is a pointer. operand order is [base, idx0, idx1, ...]. the index walk
 # follows the standard getelementptr model: index 0 strides over the source

--- a/src/lang/me/ir/instruction.mach
+++ b/src/lang/me/ir/instruction.mach
@@ -19,8 +19,9 @@
 # (DIV_S vs DIV_U, CMP_LT_S vs CMP_LT_U, ...). Comparisons produce an 8-bit
 # IRT_INT result.
 #
-# Variadic intrinsics (`va_start`/`va_arg`/`va_end`) are NOT opcodes; they are
-# ordinary OP_CALL targets that the backend expands during MIR lowering.
+# Variadic intrinsics are dedicated opcodes (`OP_VA_START`/`OP_VA_ARG`/
+# `OP_VA_END`), each taking a single va_list-pointer operand, expanded by the
+# backend during MIR lowering using the active ABI's register-save layout.
 
 use std.types.bool.bool;
 use std.types.bool.true;
@@ -136,6 +137,17 @@ pub val OP_ASM:         InstrKind = 43;
 # opcode is reserved for record / union / array slots.
 pub val OP_MEMZERO:     InstrKind = 44;
 
+# initialize a `va_list`; operand [ap_ptr]; produces no value. the backend
+# expands it to the SysV register-save-area setup (gp_offset / fp_offset,
+# reg_save_area, overflow_arg_area). `ap_ptr` points at the va_list storage.
+pub val OP_VA_START:    InstrKind = 45;
+# fetch the next variadic argument; operand [ap_ptr]; result is the value of the
+# instruction's result type. the backend pulls the argument from the register-
+# save area or the overflow area per the active ABI and advances the cursor.
+pub val OP_VA_ARG:      InstrKind = 46;
+# finalize a `va_list`; operand [ap_ptr]; produces no value. a no-op on SysV.
+pub val OP_VA_END:      InstrKind = 47;
+
 # no-signed-wrap: the result is poison if signed overflow occurs.
 pub val INSTR_FLAG_NSW:      u16 = 0x01;
 # no-unsigned-wrap: the result is poison if unsigned overflow occurs.
@@ -200,5 +212,10 @@ pub fun is_pure(k: InstrKind) bool {
     if (k == OP_ALLOCA)   { ret false; }
     if (k == OP_ASM)      { ret false; }
     if (k == OP_PHI)      { ret false; }
+    # the variadic intrinsics mutate the va_list cursor / save area; they must
+    # not be eliminated or reordered.
+    if (k == OP_VA_START) { ret false; }
+    if (k == OP_VA_ARG)   { ret false; }
+    if (k == OP_VA_END)   { ret false; }
     ret true;
 }

--- a/src/lang/me/lower/context.mach
+++ b/src/lang/me/lower/context.mach
@@ -522,6 +522,14 @@ pub fun lower_type(lc: *LowerContext, tid: ty.TypeId) Result[ir_type.IrTypeId, s
     if (k == ty.TYPE_PTR)                     { ret ir_type.intern_ptr(?lc.m.types); }
     if (k == ty.TYPE_POINTER)                 { ret ir_type.intern_ptr(?lc.m.types); }
 
+    # `va_list` is the AMD64 `__va_list_tag` register-save struct:
+    # { gp_offset: u32, fp_offset: u32, overflow_arg_area: ptr, reg_save_area: ptr }
+    # (size 24, align 8). it lowers to that concrete IR struct so storage sizing,
+    # field addressing, and by-address flow reuse the ordinary aggregate path.
+    if (k == ty.TYPE_VA_LIST) {
+        ret lower_va_list(lc);
+    }
+
     if (k == ty.TYPE_ARRAY) {
         val er: Result[ir_type.IrTypeId, str] = lower_type(lc, t.data.array.base);
         if (is_err[ir_type.IrTypeId, str](er)) { ret er; }
@@ -600,18 +608,38 @@ fun lower_nominal(lc: *LowerContext, tid: ty.TypeId, is_union: bool) Result[ir_t
     ret sr;
 }
 
-# lowers a TYPE_FUN semantic type into an IRT_FN. parameter types come from
-# the type interner's param pool; the IR function type is non-variadic here
-# (variadic functions carry the flag on their declaration, handled by the
-# decl lowerer).
+# lowers the builtin `va_list` type to the AMD64 `__va_list_tag` IR struct:
+# { i32 gp_offset, i32 fp_offset, ptr overflow_arg_area, ptr reg_save_area }.
+# the field order and types match `target.abi.sysv`'s VA_* offset constants, so
+# the backend's `va_start` / `va_arg` expansion GEPs the right field offsets.
+fun lower_va_list(lc: *LowerContext) Result[ir_type.IrTypeId, str] {
+    var buf: [4]ir_type.IrTypeId;
+    val i32r: Result[ir_type.IrTypeId, str] = ir_type.intern_int(?lc.m.types, 32);
+    if (is_err[ir_type.IrTypeId, str](i32r)) { ret i32r; }
+    val i32t: ir_type.IrTypeId = unwrap_ok[ir_type.IrTypeId, str](i32r);
+    val ptrr: Result[ir_type.IrTypeId, str] = ir_type.intern_ptr(?lc.m.types);
+    if (is_err[ir_type.IrTypeId, str](ptrr)) { ret ptrr; }
+    val ptrt: ir_type.IrTypeId = unwrap_ok[ir_type.IrTypeId, str](ptrr);
+    buf[0] = i32t;
+    buf[1] = i32t;
+    buf[2] = ptrt;
+    buf[3] = ptrt;
+    ret ir_type.intern_struct(?lc.m.types, ?buf[0], 4);
+}
+
+# lowers a TYPE_FUN semantic type into an IRT_FN, propagating the semantic
+# `variadic` flag so the back end recognizes variadic definitions (the
+# register-save prologue) and variadic calls (the tail-argument ABI walk).
+# parameter types come from the type interner's param pool.
 fun lower_function_type(lc: *LowerContext, t: *ty.Type) Result[ir_type.IrTypeId, str] {
+    val variadic: bool = t.data.fn.variadic;
     val ret_r: Result[ir_type.IrTypeId, str] = lower_type(lc, t.data.fn.ret_ty);
     if (is_err[ir_type.IrTypeId, str](ret_r)) { ret ret_r; }
     val ir_ret: ir_type.IrTypeId = unwrap_ok[ir_type.IrTypeId, str](ret_r);
 
     val count: u32 = t.data.fn.params_len;
     if (count == 0) {
-        ret ir_type.intern_fn(?lc.m.types, ir_ret, nil, 0, false);
+        ret ir_type.intern_fn(?lc.m.types, ir_ret, nil, 0, variadic);
     }
 
     val buf_r: Result[*ir_type.IrTypeId, str] = allocate[ir_type.IrTypeId](lc.s.alloc, count::usize);
@@ -634,7 +662,7 @@ fun lower_function_type(lc: *LowerContext, t: *ty.Type) Result[ir_type.IrTypeId,
         i = i + 1;
     }
 
-    val fr: Result[ir_type.IrTypeId, str] = ir_type.intern_fn(?lc.m.types, ir_ret, buf, count, false);
+    val fr: Result[ir_type.IrTypeId, str] = ir_type.intern_fn(?lc.m.types, ir_ret, buf, count, variadic);
     deallocate[ir_type.IrTypeId](lc.s.alloc, buf, count::usize);
     ret fr;
 }

--- a/src/lang/me/lower/expr.mach
+++ b/src/lang/me/lower/expr.mach
@@ -674,6 +674,58 @@ pub fun try_lower_comptime_intrinsic(ctx: *lower.LowerContext, eid: aid.ExprId, 
     ret some[Result[value.Value, str]](ok[value.Value, str](value.const_int(n::u64, rt)));
 }
 
+# lowers a variadic intrinsic call (`va_start`/`va_arg`/`va_end`) to its
+# dedicated IR opcode. the single value argument is the `*va_list` pointer; for
+# `va_arg` the call expression's lowered type is the fetched value's type. returns
+# none when the callee is not a variadic intrinsic, leaving the caller to lower a
+# normal call. va_start / va_end yield a void-typed placeholder value (discarded
+# by the expression-statement lowerer).
+pub fun try_lower_va_intrinsic(ctx: *lower.LowerContext, eid: aid.ExprId, e: *aexpr.Expr) Option[Result[value.Value, str]] {
+    val ce_opt: Option[*aexpr.Expr] = ast.get_expr(ctx.a, e.data.call.callee);
+    if (is_none[*aexpr.Expr](ce_opt)) { ret none[Result[value.Value, str]](); }
+    val ce: *aexpr.Expr = unwrap[*aexpr.Expr](ce_opt);
+    if (ce.kind != aexpr.EXPR_KIND_IDENT) { ret none[Result[value.Value, str]](); }
+
+    val name_r: Result[intern.StrId, str] = intern.intern_span(?ctx.s.interner, module_source(ctx), ce.span);
+    if (is_err[intern.StrId, str](name_r)) {
+        ret some[Result[value.Value, str]](err[value.Value, str](unwrap_err[intern.StrId, str](name_r)));
+    }
+    val name: intern.StrId = unwrap_ok[intern.StrId, str](name_r);
+    val is_start: bool = name == interned_literal(ctx, "va_start");
+    val is_arg:   bool = name == interned_literal(ctx, "va_arg");
+    val is_end:   bool = name == interned_literal(ctx, "va_end");
+    if (!is_start && !is_arg && !is_end) { ret none[Result[value.Value, str]](); }
+
+    if (e.data.call.args_len != 1) {
+        ret some[Result[value.Value, str]](err[value.Value, str]("lower: va intrinsic expects one va_list pointer argument"));
+    }
+    val arg_eid: aid.ExprId = ctx.a.expr_ids[e.data.call.args_start];
+    val apr: Result[value.Value, str] = lower_rvalue(ctx, arg_eid);
+    if (is_err[value.Value, str](apr)) { ret some[Result[value.Value, str]](apr); }
+    val ap: value.Value = unwrap_ok[value.Value, str](apr);
+
+    if (is_arg) {
+        val rt_r: Result[ir_type.IrTypeId, str] = ir_type_of_expr(ctx, eid);
+        if (is_err[ir_type.IrTypeId, str](rt_r)) {
+            ret some[Result[value.Value, str]](err[value.Value, str](unwrap_err[ir_type.IrTypeId, str](rt_r)));
+        }
+        val rt: ir_type.IrTypeId = unwrap_ok[ir_type.IrTypeId, str](rt_r);
+        ret some[Result[value.Value, str]](builder.emit_va_arg(?ctx.builder, ap, rt));
+    }
+
+    var sr: Result[bool, str];
+    if (is_start) { sr = builder.emit_va_start(?ctx.builder, ap); }
+    or           { sr = builder.emit_va_end(?ctx.builder, ap); }
+    if (is_err[bool, str](sr)) {
+        ret some[Result[value.Value, str]](err[value.Value, str](unwrap_err[bool, str](sr)));
+    }
+    val vr: Result[ir_type.IrTypeId, str] = ir_type.intern_void(?ctx.m.types);
+    if (is_err[ir_type.IrTypeId, str](vr)) {
+        ret some[Result[value.Value, str]](err[value.Value, str](unwrap_err[ir_type.IrTypeId, str](vr)));
+    }
+    ret some[Result[value.Value, str]](ok[value.Value, str](value.const_null(unwrap_ok[ir_type.IrTypeId, str](vr))));
+}
+
 # lowers a call: the callee rvalue followed by each argument rvalue, then an
 # OP_CALL. ABI classification (which args ride in registers vs the stack) is
 # deferred to isel against the target ABI; lowering emits the flat operand
@@ -683,6 +735,11 @@ pub fun try_lower_comptime_intrinsic(ctx: *lower.LowerContext, eid: aid.ExprId, 
 fun lower_call(ctx: *lower.LowerContext, eid: aid.ExprId, e: *aexpr.Expr) Result[value.Value, str] {
     val intr: Option[Result[value.Value, str]] = try_lower_comptime_intrinsic(ctx, eid, e);
     if (is_some[Result[value.Value, str]](intr)) { ret unwrap[Result[value.Value, str]](intr); }
+
+    # the variadic intrinsics expand to dedicated IR opcodes the backend lowers,
+    # not to an OP_CALL of a named function.
+    val va: Option[Result[value.Value, str]] = try_lower_va_intrinsic(ctx, eid, e);
+    if (is_some[Result[value.Value, str]](va)) { ret unwrap[Result[value.Value, str]](va); }
 
     val callee_r: Result[value.Value, str] = lower_callee(ctx, eid, e);
     if (is_err[value.Value, str](callee_r)) { ret callee_r; }

--- a/src/lang/me/lower/mangle.mach
+++ b/src/lang/me/lower/mangle.mach
@@ -209,6 +209,9 @@ fun encoded_type_len(s: *sess.Session, tid: ty.TypeId) usize {
     if (k == ty.TYPE_U64 || k == ty.TYPE_I64) { ret 4; }
     if (k == ty.TYPE_F32 || k == ty.TYPE_F64) { ret 4; }
     if (k == ty.TYPE_PTR)                     { ret 4; }
+    # `va_list` mangles as a distinct builtin token ("7va_list") so a function
+    # taking `*va_list` never collides with one taking another unencoded type.
+    if (k == ty.TYPE_VA_LIST)                 { ret 8; }
 
     if (k == ty.TYPE_POINTER) {
         ret 1 + encoded_type_len(s, t.data.pointer.base);
@@ -246,6 +249,7 @@ fun write_encoded_type(s: *sess.Session, buf: *u8, k: usize, tid: ty.TypeId) usi
     if (kk == ty.TYPE_F32) { ret write_kw(buf, k, "3f32"); }
     if (kk == ty.TYPE_F64) { ret write_kw(buf, k, "3f64"); }
     if (kk == ty.TYPE_PTR) { ret write_kw(buf, k, "3ptr"); }
+    if (kk == ty.TYPE_VA_LIST) { ret write_kw(buf, k, "7va_list"); }
 
     if (kk == ty.TYPE_POINTER) {
         buf[k] = 'P';

--- a/src/lang/target/abi/sysv.mach
+++ b/src/lang/target/abi/sysv.mach
@@ -427,6 +427,24 @@ pub fun va_fp_save_offset() u64 {
     ret GP_PARAM_COUNT::u64 * 8;
 }
 
+# va_gp_offset_max: the gp_offset value at which the GP register-save area is
+# exhausted (all six GP argument registers consumed). a `va_arg` of a GP-class
+# value whose gp_offset has reached this falls through to the overflow area.
+# ---
+# ret: the exhausted gp_offset (48)
+pub fun va_gp_offset_max() u32 {
+    ret GP_PARAM_COUNT::u32 * 8;
+}
+
+# va_fp_offset_max: the fp_offset value at which the FP register-save area is
+# exhausted (all eight FP argument registers consumed). the FP dump begins after
+# the GP dump, so the max is the GP area size plus eight 16-byte FP slots.
+# ---
+# ret: the exhausted fp_offset (176)
+pub fun va_fp_offset_max() u32 {
+    ret GP_PARAM_COUNT::u32 * 8 + FP_PARAM_COUNT::u32 * 16;
+}
+
 # the SysV AMD64 ABI vtable. populated by register on first call and handed out
 # as a borrowed pointer to the registry. its three classify/arg/ret function
 # pointers are stored type-erased (`*u8`); consumers cast them back to

--- a/src/lang/type.mach
+++ b/src/lang/type.mach
@@ -82,6 +82,10 @@ pub val TYPE_REC:           TypeKind = 14;
 pub val TYPE_UNI:           TypeKind = 15;
 pub val TYPE_GENERIC_PARAM: TypeKind = 16;
 pub val TYPE_INSTANCE:      TypeKind = 17;
+# the AMD64 `__va_list_tag` builtin: a payload-free aggregate the backend
+# lowers to the four-field register-save struct. used by the variadic
+# intrinsics (`va_list` / `va_start` / `va_arg` / `va_end`).
+pub val TYPE_VA_LIST:       TypeKind = 18;
 
 val PRIM_COUNT: u32 = 11;
 
@@ -464,6 +468,17 @@ pub fun intern_array(ti: *TypeInterner, base: TypeId, count: u32) Result[TypeId,
     t.kind = TYPE_ARRAY;
     t.data.array.base  = base;
     t.data.array.count = count;
+    ret intern_dedup(ti, t);
+}
+
+# intern_va_list: intern the builtin `va_list` type. payload-free, so it
+# dedups by kind alone (one shared TypeId per interner).
+# ---
+# ti:  the interner
+# ret: the TypeId for `va_list`, or an allocation error
+pub fun intern_va_list(ti: *TypeInterner) Result[TypeId, str] {
+    var t: Type;
+    t.kind = TYPE_VA_LIST;
     ret intern_dedup(ti, t);
 }
 


### PR DESCRIPTION
Implements the variadic intrinsics on SysV x86-64, unblocking `std.format`.

Closes #1028

## What works
- **Front end**: `va_list` resolves as a builtin type (the AMD64 `__va_list_tag` register-save struct: `{ gp_offset: u32, fp_offset: u32, overflow_arg_area: ptr, reg_save_area: ptr }`, size 24 / align 8), seeded in the primitive registry so it resolves in type position. `va_start(ap)` / `va_arg[T](ap)` / `va_end(ap)` are recognized as builtin intrinsic calls in resolve + sema (`va_start`/`va_end` are void `(*va_list)`, `va_arg[T]` yields T).
- **IR**: dedicated opcodes `OP_VA_START` / `OP_VA_ARG` / `OP_VA_END` (each a single `*va_list` operand), expanded by the backend. `va_list` lowers to a concrete `IRT_STRUCT`. The semantic `variadic` flag now propagates onto the IR function type (previously hardcoded non-variadic), so the back end recognizes both variadic definitions and variadic calls.
- **Backend (SysV)**: variadic definitions emit a register-save-area prologue spilling the incoming GP argument registers into a frame slot. `va_start` initializes the four `__va_list_tag` fields; `va_arg` fetches the next **GP-class scalar / pointer** argument branch-free via a register-save-vs-overflow mask select, advancing the matching cursor (handles both the in-register and the overflow-area cases). `va_end` is a no-op. All SysV layout numbers stay in `target/abi/sysv.mach`; the expansion mechanism lives in the generic backend.

## Scope / follow-up
- `va_arg` of a **floating-point** type and of a **>16-byte by-value aggregate** are not yet handled — they error loudly rather than miscompile. The FP register-save spill and the AL-guarded conditional spill are the corresponding follow-up. These cover exactly the GP scalar/pointer cases `std.format` uses (`str`, `i64`, `u64`, `u8`, `ptr`); no float varargs appear there.

## Verification
- **Standalone variadic tests** (exit-code checked):
  - `sum_i64(8, 1..8)` → 36 — exercises both the register-save area (args 1–6) and the **overflow area** (args 7–8).
  - mixed `u64` + `ptr` va_arg → correct.
  - `sum_lens(4, "ab","cdef","g","hijklmno")` → 15 — `va_arg[str]`.
- **`std.format` compiles and runs**: a program that `use`s `std.format` and calls `format(?w, "fmt: %s %d %u %x %c\n", "hello", -7, 42, 255, 'Z')` prints `fmt: hello -7 42 ff Z` (exercises `vformat` → `va_arg[str/i64/u64/u8]` through a `*va_list` parameter and a variadic-into-variadic call). The previous `va_list` typecheck errors are gone.
- **Full bootstrap** `make clean && make` → exit 0 (cmach→imach→smach→mach).
- **Fixpoint holds**: `mach build . --artifacts da` / `--artifacts db` → `diff -rq` 0 diffs; the rebuilt `mach` binary is byte-identical. The compiler does not use variadics, so the bootstrap is unperturbed.
