### PR TITLE
feat(emit): restore --emit-asm / --emit-ir debug artifacts

### DIFF
--- a/src/cli/cmd/build.mach
+++ b/src/cli/cmd/build.mach
@@ -44,6 +44,8 @@ use arena: std.allocator.arena;
 use os: std.system.os;
 use fs: std.filesystem;
 
+use writer: std.io.writer;
+
 use intern: mach.lang.intern;
 use sess:   mach.lang.session;
 use src:    mach.lang.source;
@@ -54,6 +56,7 @@ use sema:    mach.lang.fe.sema;
 use token:   mach.lang.fe.token;
 
 use ir:         mach.lang.me.ir;
+use ir_printer: mach.lang.me.ir.printer;
 use lower:      mach.lang.me.lower;
 use testrunner: mach.lang.me.lower.testrunner;
 use pipeline:   mach.lang.me.pipeline;
@@ -75,6 +78,21 @@ use cfg: mach.cli.config;
 pub rec BuildResult {
     code:        i64;
     output_path: *u8;
+}
+
+# EmitArtifacts: the debug-artifact emission settings threaded into the per-module
+# compile loop. `base` is the resolved `<root>/<out>/<artifacts>` prefix the `asm/`
+# and `ir/` trees hang off (a borrowed pointer into the caller's path buffer, valid
+# for the compile); `want_asm` / `want_ir` toggle each text artifact (`--emit-asm` /
+# `--emit-ir`). when both flags are off `base` is unused.
+# ---
+# base: resolved `<root>/<out>/<artifacts>` directory prefix (borrowed)
+# want_asm: emit per-module `.s` assembly text
+# want_ir:  emit per-module `.ir` SSA IR text
+rec EmitArtifacts {
+    base:     *u8;
+    want_asm: bool;
+    want_ir:  bool;
 }
 
 # eq: byte-wise equality of two null-terminated `*u8` strings.
@@ -289,8 +307,10 @@ fun free_sema_deps(alloc: *Allocator, deps: *sema.SemaDeps) {
 # codegen passes off a semantically broken AST. `images` (caller-owned, sized
 # to p.module_len) is filled in topo order. on failure the partial images and
 # IR modules are torn down by the caller via `free_modules`. when `verbose`
-# is set, each module's stage transitions are written to stderr.
-fun compile_modules(p: *driver.Project, level: u8, test_mode: bool, verify_ir: bool, verbose: bool,
+# is set, each module's stage transitions are written to stderr. `ea` requests
+# the per-module `.ir` (written right after lowering) and `.s` (written from the
+# fully-resolved MIR inside codegen) debug artifacts.
+fun compile_modules(p: *driver.Project, level: u8, test_mode: bool, verify_ir: bool, verbose: bool, ea: *EmitArtifacts,
                     results: *sema.SemaResult, ready: *bool,
                     irs: *ir.Module, ir_ready: *bool,
                     images: *of.ObjectImage, image_ready: *bool) Result[bool, str] {
@@ -340,6 +360,22 @@ fun compile_modules(p: *driver.Project, level: u8, test_mode: bool, verify_ir: b
         irs[mid::u32]     = unwrap_ok[ir.Module, str](lower_r);
         ir_ready[mid::u32] = true;
 
+        # textual SSA IR, rendered straight after lowering.
+        if (ea.want_ir) {
+            val fqn_opt: Option[str] = intern.lookup(?p.s.interner, m.fqn);
+            if (is_none[str](fqn_opt)) { ret err[bool, str]("module FQN not interned"); }
+            val fqn: str = unwrap[str](fqn_opt);
+
+            var irf: fs.File;
+            var irw: writer.Writer;
+            val oir: Result[bool, str] = open_artifact(ea.base, "ir", fqn, "ir", ?irf, ?irw);
+            if (is_err[bool, str](oir)) { ret err[bool, str](unwrap_err[bool, str](oir)); }
+            val pir: Result[bool, str] = ir_printer.print_module(?irw, ?irs[mid::u32], ?p.s.interner);
+            val cir: Result[bool, str] = fs.close(?irf);
+            if (is_err[bool, str](pir)) { ret err[bool, str](unwrap_err[bool, str](pir)); }
+            if (is_err[bool, str](cir)) { ret err[bool, str](unwrap_err[bool, str](cir)); }
+        }
+
         val opt_r: Result[bool, str] = pipeline.run(?irs[mid::u32], ?p.target, level, verify_ir);
         if (is_err[bool, str](opt_r)) { ret err[bool, str](unwrap_err[bool, str](opt_r)); }
 
@@ -358,7 +394,25 @@ fun compile_modules(p: *driver.Project, level: u8, test_mode: bool, verify_ir: b
 
         if (verbose) { emit_stage(p, "codegen", m.fqn); }
 
-        val cg_r: Result[of.ObjectImage, str] = codegen.codegen_module(p.s, ?p.target, ?irs[mid::u32]);
+        # codegen, optionally rendering the resolved MIR to a `.s` artifact.
+        var asmf: fs.File;
+        var asmw: writer.Writer;
+        var asm_out: *writer.Writer = nil;
+        if (ea.want_asm) {
+            val fqn_opt: Option[str] = intern.lookup(?p.s.interner, m.fqn);
+            if (is_none[str](fqn_opt)) { ret err[bool, str]("module FQN not interned"); }
+            val fqn: str = unwrap[str](fqn_opt);
+            val oas: Result[bool, str] = open_artifact(ea.base, "asm", fqn, "s", ?asmf, ?asmw);
+            if (is_err[bool, str](oas)) { ret err[bool, str](unwrap_err[bool, str](oas)); }
+            asm_out = ?asmw;
+        }
+        val cg_r: Result[of.ObjectImage, str] = codegen.codegen_module(p.s, ?p.target, ?irs[mid::u32], asm_out);
+        if (ea.want_asm) {
+            val cas: Result[bool, str] = fs.close(?asmf);
+            if (is_ok[of.ObjectImage, str](cg_r) && is_err[bool, str](cas)) {
+                ret err[bool, str](unwrap_err[bool, str](cas));
+            }
+        }
         if (is_err[of.ObjectImage, str](cg_r)) { ret err[bool, str](unwrap_err[of.ObjectImage, str](cg_r)); }
         images[mid::u32]      = unwrap_ok[of.ObjectImage, str](cg_r);
         image_ready[mid::u32] = true;
@@ -469,7 +523,7 @@ pub fun build(alloc: *Allocator, argc: usize, argv: **u8, emit_obj: bool, test_m
     }
     var p: driver.Project = unwrap_ok[driver.Project, str](proj_r);
 
-    br.code = compile_and_link(?p, level, emit_obj, test_mode, config.verify_ir, config.verbose, ?root[0], config.output, config.artifacts, ?br.output_path);
+    br.code = compile_and_link(?p, level, emit_obj, test_mode, config.verify_ir, config.verbose, config.emit_asm, config.emit_ir, ?root[0], config.output, config.artifacts, ?br.output_path);
 
     flush_diagnostics(?s, ?s.diags);
     driver.dnit_project(?p);
@@ -482,8 +536,10 @@ pub fun build(alloc: *Allocator, argc: usize, argv: **u8, emit_obj: bool, test_m
 # sets `*out_path` to the produced artifact path on success. `out_override`
 # (-o) and `art_override` (--artifacts), when non-nil, replace the target's
 # configured binary and artifacts paths. when `verbose` is set, per-stage
-# progress is written to stderr.
+# progress is written to stderr. `emit_asm` / `emit_ir` request the per-module
+# `.s` / `.ir` debug artifacts.
 fun compile_and_link(p: *driver.Project, level: u8, emit_obj: bool, test_mode: bool, verify_ir: bool, verbose: bool,
+                     emit_asm: bool, emit_ir: bool,
                      root: *u8, out_override: *u8, art_override: *u8, out_path: **u8) i64 {
     val n: usize = p.module_len::usize;
     if (n == 0) {
@@ -492,6 +548,20 @@ fun compile_and_link(p: *driver.Project, level: u8, emit_obj: bool, test_mode: b
     }
 
     if (verbose) { emit_target(p); }
+
+    # resolve the `<root>/<out>/<artifacts>` prefix the text-artifact trees hang
+    # off once, up front, so each module writes its `.s` / `.ir` next to its `.o`.
+    var art_base: [4096]u8;
+    var ea: EmitArtifacts;
+    ea.base = ?art_base[0];
+    ea.want_asm = emit_asm;
+    ea.want_ir  = emit_ir;
+    if (emit_asm || emit_ir) {
+        if (!resolve_art_base(p, root, art_override, ?art_base[0], 4096)) {
+            emit("error: project out / artifacts dir not interned\n");
+            ret 2;
+        }
+    }
 
     val rr: Result[*sema.SemaResult, str] = allocate[sema.SemaResult](p.s.alloc, n);
     if (is_err[*sema.SemaResult, str](rr)) { emit("error: out of memory\n"); ret 2; }
@@ -533,7 +603,7 @@ fun compile_and_link(p: *driver.Project, level: u8, emit_obj: bool, test_mode: b
     var runner_img_ok: bool = false;
 
     var code: i64 = 0;
-    val comp_r: Result[bool, str] = compile_modules(p, level, test_mode, verify_ir, verbose, results, ready, irs, ir_ready, images, image_ready);
+    val comp_r: Result[bool, str] = compile_modules(p, level, test_mode, verify_ir, verbose, ?ea, results, ready, irs, ir_ready, images, image_ready);
     if (is_err[bool, str](comp_r)) {
         emit("error: ");
         emit(unwrap_err[bool, str](comp_r));
@@ -597,7 +667,7 @@ fun build_test_runner(p: *driver.Project, level: u8, verify_ir: bool,
         ret 2;
     }
 
-    val cg_r: Result[of.ObjectImage, str] = codegen.codegen_module(p.s, ?p.target, runner_ir);
+    val cg_r: Result[of.ObjectImage, str] = codegen.codegen_module(p.s, ?p.target, runner_ir, nil);
     if (is_err[of.ObjectImage, str](cg_r)) {
         emit("error: ");
         emit(unwrap_err[of.ObjectImage, str](cg_r));
@@ -630,20 +700,12 @@ fun link_artifact(p: *driver.Project, emit_obj: bool, test_mode: bool, have_runn
     val te: *driver.TargetEntry = p.target_entry;
     if (te == nil) { emit("error: no target selected\n"); ret 2; }
 
-    val out_opt: Option[str] = intern.lookup(?p.s.interner, p.config.out);
-    if (is_none[str](out_opt)) { emit("error: project out dir not interned\n"); ret 2; }
-    val art_opt: Option[str] = intern.lookup(?p.s.interner, te.artifacts);
-    if (is_none[str](art_opt)) { emit("error: target artifacts dir not interned\n"); ret 2; }
-
     # <root>/<out>/<artifacts>/obj — the per-module object tree root.
     # --artifacts overrides <artifacts>.
     var obj_base: [4096]u8;
-    join_into_str(?obj_base[0], 4096, root, unwrap[str](out_opt));
-    if (art_override != nil) {
-        join_into(?obj_base[0], 4096, ?obj_base[0], art_override);
-    }
-    or {
-        join_into_str(?obj_base[0], 4096, ?obj_base[0], unwrap[str](art_opt));
+    if (!resolve_art_base(p, root, art_override, ?obj_base[0], 4096)) {
+        emit("error: project out / artifacts dir not interned\n");
+        ret 2;
     }
     join_into(?obj_base[0], 4096, ?obj_base[0], "obj");
 
@@ -691,6 +753,12 @@ fun link_artifact(p: *driver.Project, emit_obj: bool, test_mode: bool, have_runn
         join_into(?artifact[0], 4096, root, out_override);
     }
     or {
+        val out_opt: Option[str] = intern.lookup(?p.s.interner, p.config.out);
+        if (is_none[str](out_opt)) {
+            free_paths(p.s.alloc, paths, count, count);
+            emit("error: project out dir not interned\n");
+            ret 2;
+        }
         val bin_opt: Option[str] = intern.lookup(?p.s.interner, te.binary);
         if (is_none[str](bin_opt) || slen(unwrap[str](bin_opt)::*u8) == 0) {
             free_paths(p.s.alloc, paths, count, count);
@@ -743,6 +811,30 @@ fun join_into_str(buf: *u8, cap: usize, dir: *u8, leaf: str) usize {
     for (i < ll) { buf[k] = leaf[i]; k = k + 1; i = i + 1; }
     buf[k] = 0;
     ret k;
+}
+
+# resolve_art_base: write `<root>/<out>/<artifacts>` into `buf`, the directory the
+# per-module artifact trees (`obj/`, `asm/`, `ir/`) hang off. `<out>` is the
+# project out dir; `<artifacts>` is `art_override` (--artifacts) when non-nil, else
+# the target's configured artifacts dir. returns true on success; false when either
+# the out or artifacts dir is not interned. the caller appends the per-tree leaf.
+fun resolve_art_base(p: *driver.Project, root: *u8, art_override: *u8, buf: *u8, cap: usize) bool {
+    val te: *driver.TargetEntry = p.target_entry;
+    if (te == nil) { ret false; }
+
+    val out_opt: Option[str] = intern.lookup(?p.s.interner, p.config.out);
+    if (is_none[str](out_opt)) { ret false; }
+    val art_opt: Option[str] = intern.lookup(?p.s.interner, te.artifacts);
+    if (is_none[str](art_opt)) { ret false; }
+
+    join_into_str(buf, cap, root, unwrap[str](out_opt));
+    if (art_override != nil) {
+        join_into(buf, cap, buf, art_override);
+    }
+    or {
+        join_into_str(buf, cap, buf, unwrap[str](art_opt));
+    }
+    ret true;
 }
 
 # ensure_dir: create the directory at `path` if it does not already exist.
@@ -803,7 +895,7 @@ fun write_objects(p: *driver.Project, images: *of.ObjectImage,
         }
 
         var path: [4096]u8;
-        mirror_fqn(?path[0], 4096, obj_base, unwrap[str](fqn_opt));
+        mirror_fqn(?path[0], 4096, obj_base, unwrap[str](fqn_opt), "o");
 
         if (!ensure_parents(?path[0])) {
             free_paths(p.s.alloc, paths, ti, count);
@@ -864,18 +956,20 @@ fun append_runner_object(p: *driver.Project, runner_img: *of.ObjectImage,
     ret 0;
 }
 
-# mirror_fqn: write `<obj_base>/<rel>.o` into `buf`, where `<rel>` is the module
-# FQN with every '.' replaced by '/'. returns the byte length written
-# (excluding the terminator), or 0 if it would not fit.
-fun mirror_fqn(buf: *u8, cap: usize, obj_base: *u8, fqn: str) usize {
-    val bl: usize = slen(obj_base);
+# mirror_fqn: write `<base>/<rel>.<ext>` into `buf`, where `<rel>` is the module
+# FQN with every '.' replaced by '/' (so `a.b.c` with ext `o` becomes
+# `<base>/a/b/c.o`). returns the byte length written (excluding the terminator),
+# or 0 if it would not fit.
+fun mirror_fqn(buf: *u8, cap: usize, base: *u8, fqn: str, suffix: str) usize {
+    val bl: usize = slen(base);
     val fl: usize = slen(fqn::*u8);
-    var need: usize = bl + 1 + fl + 2 + 1;
+    val el: usize = slen(suffix::*u8);
+    var need: usize = bl + 1 + fl + 1 + el + 1;
     if (need > cap) { ret 0; }
 
     var k: usize = 0;
     var i: usize = 0;
-    for (i < bl) { buf[k] = obj_base[i]; k = k + 1; i = i + 1; }
+    for (i < bl) { buf[k] = base[i]; k = k + 1; i = i + 1; }
     if (k > 0 && buf[k - 1] != '/') { buf[k] = '/'; k = k + 1; }
 
     i = 0;
@@ -886,10 +980,37 @@ fun mirror_fqn(buf: *u8, cap: usize, obj_base: *u8, fqn: str) usize {
         k = k + 1;
         i = i + 1;
     }
-    buf[k]     = '.';
-    buf[k + 1] = 'o';
-    buf[k + 2] = 0;
-    ret k + 2;
+    buf[k] = '.';
+    k = k + 1;
+
+    i = 0;
+    for (i < el) { buf[k] = suffix[i]; k = k + 1; i = i + 1; }
+    buf[k] = 0;
+    ret k;
+}
+
+# open_artifact: create `<base>/<sub>/<rel>.<ext>` (making any parent directories)
+# and wire `w` to stream into it through the returned `file`. the FQN is mapped to
+# `<rel>` exactly as the object tree is. the caller owns `file` and must close it
+# once writing is done — the Writer borrows the File and must not outlive it.
+fun open_artifact(base: *u8, sub: str, fqn: str, suffix: str,
+                  file: *fs.File, w: *writer.Writer) Result[bool, str] {
+    var sub_base: [4096]u8;
+    join_into(?sub_base[0], 4096, base, sub::*u8);
+
+    var path: [4096]u8;
+    if (mirror_fqn(?path[0], 4096, ?sub_base[0], fqn, suffix) == 0) {
+        ret err[bool, str]("artifact path too long");
+    }
+    if (!ensure_parents(?path[0])) {
+        ret err[bool, str]("failed to create artifact directory");
+    }
+
+    val cr: Result[fs.File, str] = fs.create(cstr_str(?path[0]), 0o644);
+    if (is_err[fs.File, str](cr)) { ret err[bool, str](unwrap_err[fs.File, str](cr)); }
+    @file = unwrap_ok[fs.File, str](cr);
+    fs.get_writer(file, w);
+    ret ok[bool, str](true);
 }
 
 # free_paths: release the first `n` owned path strings of a path array and the

--- a/src/cli/config.mach
+++ b/src/cli/config.mach
@@ -41,6 +41,10 @@ pub val COLOR_NEVER:  ColorMode = 2;
 #            root (nil = use the target's `binary` from mach.toml)
 # artifacts: --artifacts override for the per-module object directory, rooted
 #            at <root>/<out> (nil = use the target's `artifacts` from mach.toml)
+# emit_asm:  --emit-asm was passed; emit per-module human-readable assembly text
+#            (`.s`) alongside each object, for debugging / transparency
+# emit_ir:   --emit-ir was passed; emit per-module human-readable SSA IR text
+#            (`.ir`) alongside each object, for debugging / transparency
 pub rec Config {
     color:     ColorMode;
     verbose:   bool;
@@ -50,6 +54,8 @@ pub rec Config {
     target:    *u8;
     output:    *u8;
     artifacts: *u8;
+    emit_asm:  bool;
+    emit_ir:   bool;
 }
 
 # eq: byte-wise equality of two null-terminated `*u8` strings.
@@ -86,6 +92,8 @@ pub fun parse(argc: usize, argv: **u8) Option[Config] {
     c.target    = nil;
     c.output    = nil;
     c.artifacts = nil;
+    c.emit_asm  = false;
+    c.emit_ir   = false;
 
     val verbose: bool = args.has_flag(argc, argv, "--verbose") || args.has_flag(argc, argv, "-v");
     val quiet:   bool = args.has_flag(argc, argv, "--quiet")   || args.has_flag(argc, argv, "-q");
@@ -95,6 +103,8 @@ pub fun parse(argc: usize, argv: **u8) Option[Config] {
     c.verbose = verbose;
     c.quiet   = quiet;
     c.verify_ir = args.has_flag(argc, argv, "--verify-ir");
+    c.emit_asm  = args.has_flag(argc, argv, "--emit-asm");
+    c.emit_ir   = args.has_flag(argc, argv, "--emit-ir");
 
     val color_opt: Option[*u8] = args.get_value(argc, argv, "--color");
     if (is_some[*u8](color_opt)) {

--- a/src/lang/be/codegen.mach
+++ b/src/lang/be/codegen.mach
@@ -25,6 +25,8 @@ use std.types.result.unwrap_err;
 use std.types.size.usize;
 use std.allocator.allocate;
 
+use writer: std.io.writer;
+
 use sess:   mach.lang.session;
 use intern: mach.lang.intern;
 use target: mach.lang.target;
@@ -79,13 +81,20 @@ pub rec CodegenContext {
 # stages 2–4 mutate the MIR in place (each `run` returns a status, not a fresh
 # module); the encoder reads it without mutating it. the returned image owns
 # its section / symbol / relocation arrays and is freed with `obj.dnit`.
+#
+# `asm_out`, when non-nil, receives the fully-resolved MIR rendered as
+# human-readable assembly text (the `--emit-asm` debug artifact). it is written
+# after frame layout — the same fully-resolved MIR the encoder consumes — through
+# the active ISA's `emit_asm` hook, so a `.s` reflects exactly what becomes the
+# `.o`. a nil writer skips it; an ISA with no printer is a clean no-op.
 # ---
 # s:   shared session; supplies the allocator and interner
 # tgt:   resolved compilation target
 # irmod: optimised SSA IR module to generate code for
+# asm_out: optional writer for the per-module assembly-text artifact (nil = none)
 # ret:   the populated object image, or an error string from any pipeline stage
 pub fun codegen_module(s: *sess.Session, tgt: *target.Target,
-                       irmod: *ir.Module) Result[of.ObjectImage, str] {
+                       irmod: *ir.Module, asm_out: *writer.Writer) Result[of.ObjectImage, str] {
     if (s == nil)     { ret err[of.ObjectImage, str]("codegen: nil session"); }
     if (tgt == nil)   { ret err[of.ObjectImage, str]("codegen: nil target"); }
     if (irmod == nil) { ret err[of.ObjectImage, str]("codegen: nil ir module"); }
@@ -109,6 +118,13 @@ pub fun codegen_module(s: *sess.Session, tgt: *target.Target,
     val rfr: Result[bool, str] = frame.run(tgt, ?m);
     if (is_err[bool, str](rfr)) {
         ret err[of.ObjectImage, str](unwrap_err[bool, str](rfr));
+    }
+
+    if (asm_out != nil) {
+        val ras: Result[bool, str] = encode.print_asm(tgt, ?m, asm_out);
+        if (is_err[bool, str](ras)) {
+            ret err[of.ObjectImage, str](unwrap_err[bool, str](ras));
+        }
     }
 
     val renc: Result[encode.EncoderOutput, str] = encode.run(tgt, ?m);

--- a/src/lang/be/codegen/encode.mach
+++ b/src/lang/be/codegen/encode.mach
@@ -17,6 +17,7 @@
 # ISA agree on one common output without depending on any specific architecture.
 
 use std.types.bool.bool;
+use std.types.bool.true;
 use std.types.string.str;
 
 use std.types.result.Result;
@@ -24,6 +25,8 @@ use std.types.result.ok;
 use std.types.result.err;
 
 use std.allocator.Allocator;
+
+use writer: std.io.writer;
 
 use intern: mach.lang.intern;
 use target: mach.lang.target.resolved;
@@ -120,4 +123,47 @@ pub fun run(tgt: *target.Target, m: *mir.MirModule) Result[EncoderOutput, str] {
 
     val encode: EncodeFn = tgt.arch.encode::EncodeFn;
     ret encode(m.alloc, tgt, m);
+}
+
+# PrintAsmFn: the concrete signature the erased `isa.IsaVTable.emit_asm` pointer is
+# cast back to before it is called. The vtable stores `emit_asm` type-erased
+# (`*u8`) for the same import-cycle reason as `encode`: its signature names
+# `target.Target` and `mir.MirModule`, both of which import `isa`. This dispatcher
+# already imports `target` and `mir`, so it declares the cast-back type locally and
+# casts the erased pointer to it, exactly as `run` casts `encode` back to `EncodeFn`.
+# The per-arch printer formats every function of the module as Intel-syntax
+# assembly text into the writer; it is a debug-only artifact, byte-exactness is not
+# its contract.
+# ---
+# tgt: resolved compilation target
+# m:   the fully-resolved MIR module (post isel / regalloc / frame)
+# out: destination writer the assembly text is written into
+# ret: true on success, or an error string from a write failure
+pub def PrintAsmFn: fun(*target.Target, *mir.MirModule, *writer.Writer) Result[bool, str];
+
+# print_asm: format a fully-resolved MIR module as human-readable assembly text.
+#
+# dispatches the whole module to the active ISA's `emit_asm` operation, reached
+# through `tgt.arch.emit_asm`. carries no architecture-specific knowledge — the
+# per-arch printer owns the mnemonic, register, and operand formatting. an ISA that
+# registered no `emit_asm` printer (an arch with no debug-asm support) is a clean
+# no-op rather than an error, so `--emit-asm` simply produces no file for it.
+# ---
+# tgt: resolved compilation target; its `arch` vtable supplies the printer
+# m:   the fully-resolved MIR module to format
+# out: destination writer
+# ret: true on success (including the no-printer no-op), or an error string
+pub fun print_asm(tgt: *target.Target, m: *mir.MirModule, out: *writer.Writer) Result[bool, str] {
+    if (tgt == nil) { ret err[bool, str]("print_asm: nil target"); }
+    if (m == nil)   { ret err[bool, str]("print_asm: nil mir module"); }
+    if (out == nil) { ret err[bool, str]("print_asm: nil writer"); }
+    if (tgt.arch == nil) {
+        ret err[bool, str]("print_asm: target has no ISA vtable");
+    }
+    if (tgt.arch.emit_asm == nil) {
+        ret ok[bool, str](true);
+    }
+
+    val emit_asm: PrintAsmFn = tgt.arch.emit_asm::PrintAsmFn;
+    ret emit_asm(tgt, m, out);
 }

--- a/src/lang/target/isa.mach
+++ b/src/lang/target/isa.mach
@@ -182,17 +182,19 @@ pub rec RegClass {
 # and the arch-specific operation entry points through it and never branches on
 # the numeric `id`.
 #
-# `select` and `encode` are the two target-specific backend operations. they are
-# stored type-erased (`*u8`) for the same reason the ABI vtable erases its
+# `select`, `encode`, and `emit_asm` are the target-specific backend operations.
+# they are stored type-erased (`*u8`) for the same reason the ABI vtable erases its
 # classify/arg/ret pointers and the object-format `WriterFn` takes an
 # `*IsaVTable` rather than the full `Target`: their concrete signatures name
-# `target.Target`, `mir.MirFunction`, and the encoder's `EncoderOutput`, every
+# `target.Target`, `mir.MirModule`, and the encoder's output / a writer, every
 # one of which imports `isa`. a typed field here would invert that dependency
-# and form an import cycle. each consumer — the shared `isel.run` / `encode.run`
-# dispatchers, which already import `mir` and `target` — casts the erased
-# pointer back to the concrete `SelectFn` / `EncodeFn` signature declared in the
-# per-arch implementation file (e.g. `target/isa/x64`), exactly as `mir` casts
-# `abi.arg_passing` back to `sysv.ArgPassingFn`.
+# and form an import cycle. each consumer — the shared `isel.run` / `encode.run` /
+# `encode.print_asm` dispatchers, which already import `mir` and `target` — casts
+# the erased pointer back to the concrete `SelectFn` / `EncodeFn` / `PrintAsmFn`
+# signature declared in the per-arch implementation file (e.g. `target/isa/x64`),
+# exactly as `mir` casts `abi.arg_passing` back to `sysv.ArgPassingFn`. `emit_asm`
+# is an optional debug hook: an ISA that supplies no human-readable assembly
+# printer leaves it nil and the `print_asm` dispatcher no-ops.
 #
 # `reserved_regs`, `scratch_reg`, `scratch_reg2`, `fp_scratch_reg`,
 # `frame_ptr_reg`, `stack_ptr_reg`, `div_reg`, `div_hi_reg`, and
@@ -222,6 +224,10 @@ pub rec RegClass {
 #                     bytes + relocations + symbol marks (cast back to the arch's
 #                     `EncodeFn`); owns prologue/epilogue emission, local-label
 #                     rel32 fixups, and relocation offsets for this ISA
+# emit_asm:           erased fn ptr — format one fully-resolved MirModule as
+#                     human-readable assembly text into a writer (cast back to the
+#                     arch's `PrintAsmFn`); a debug-only artifact hook, nil when the
+#                     ISA supplies no printer
 # reserved_regs:      registers the allocator must never assign (stack/frame
 #                     pointers); owned by the per-arch impl for the process
 #                     lifetime
@@ -257,6 +263,7 @@ pub rec IsaVTable {
     reg_class_count:    u32;
     select:             *u8;
     encode:             *u8;
+    emit_asm:           *u8;
     reserved_regs:      *Register;
     reserved_reg_count: i32;
     reload_scratch_regs:  *Register;

--- a/src/lang/target/isa/arm64.mach
+++ b/src/lang/target/isa/arm64.mach
@@ -114,6 +114,7 @@ pub fun register_arm64(alloc: *Allocator, i: *intern.Interner) Result[bool, str]
     arm64_vtable.reg_class_count    = 3;
     arm64_vtable.select             = nil;
     arm64_vtable.encode             = nil;
+    arm64_vtable.emit_asm           = nil;
     arm64_vtable.reserved_regs      = ?arm64_reserved_regs[0];
     arm64_vtable.reserved_reg_count = 2;
     # the AArch64 backend has no encoder yet; it wires no reload-scratch pool.

--- a/src/lang/target/isa/x64/printer.mach
+++ b/src/lang/target/isa/x64/printer.mach
@@ -1,0 +1,560 @@
+# mach.lang.target.isa.x64.printer: x86-64 assembly text printer — the x64 ISA's `emit_asm` entry point.
+#
+# This is the x86-64 implementation of the ISA vtable's `emit_asm` operation,
+# reached only through `tgt.arch.emit_asm` by the shared `be.codegen.encode.print_asm`
+# dispatcher. It formats a fully-resolved (post-isel, post-regalloc, post-frame)
+# `mir.MirModule` as human-readable Intel-syntax assembly text into a writer — a
+# debug / transparency artifact paralleling the `.o` the encoder emits from the
+# same MIR.
+#
+# Unlike the encoder this is NOT byte-exact: it renders the MIR instruction stream
+# at the level the allocator left it (a three-address ALU op prints as a single
+# `add dst, lhs, rhs`, a comparison as one `cmp dst, lhs, rhs`), so a `.s` line maps
+# to a MIR instruction rather than to the exact machine bytes the encoder expands it
+# into. A `# <symbol>:` header introduces each function and the prologue / epilogue
+# are rendered as comment-flagged `push rbp` / `mov rbp, rsp` / `leave` lines so the
+# frame shape is visible.
+#
+# The x86-64 opcode, register, and encoding namespace is owned by this module's
+# parent `mach.lang.target.isa.x64`, imported here as `x64`; register names come
+# from its `reg_name` / `fp_reg_name`. FP-ness is inferred from the opcode exactly
+# as the encoder infers it (`x64.is_fp_opcode` plus the MIR_F* family).
+
+use std.types.bool.bool;
+use std.types.bool.true;
+use std.types.bool.false;
+use std.types.size.usize;
+use std.types.string.str;
+use std.types.result.Result;
+use std.types.result.ok;
+use std.types.result.err;
+use std.types.result.is_err;
+use std.types.result.unwrap_err;
+use std.types.option.Option;
+use std.types.option.some;
+use std.types.option.none;
+use std.types.option.is_some;
+use std.types.option.unwrap;
+
+use writer: std.io.writer;
+use fmt:    std.format;
+
+use intern:  mach.lang.intern;
+use isa:     mach.lang.target.isa;
+use x64:     mach.lang.target.isa.x64;
+use target:  mach.lang.target.resolved;
+use mir:     mach.lang.be.codegen.mir;
+
+# print_asm_x64: format a fully-resolved MIR module as Intel-syntax assembly text.
+#
+# the `emit_asm` entry point the x64 ISA registers; matches `enc.PrintAsmFn`. emits
+# a `.intel_syntax` header then each function in turn, each introduced by a
+# `# <symbol>:` label and its rendered prologue / body / epilogue. an extern /
+# body-less function (no blocks) contributes nothing, mirroring the encoder.
+# ---
+# tgt: resolved compilation target (its interner resolves symbol names)
+# m:   the fully-resolved MIR module to format
+# out: destination writer
+# ret: true on success, or the first write error
+pub fun print_asm_x64(tgt: *target.Target, m: *mir.MirModule, out: *writer.Writer) Result[bool, str] {
+    if (m == nil)   { ret err[bool, str]("print_asm_x64: nil mir module"); }
+    if (out == nil) { ret err[bool, str]("print_asm_x64: nil writer"); }
+
+    val rh: Result[bool, str] = ws(out, ".intel_syntax noprefix\n\n");
+    if (is_err[bool, str](rh)) { ret rh; }
+
+    var fi: u32 = 0;
+    for (fi < m.function_len) {
+        val rf: Result[bool, str] = print_function(out, m, ?m.functions[fi]);
+        if (is_err[bool, str](rf)) { ret rf; }
+        fi = fi + 1;
+    }
+    ret ok[bool, str](true);
+}
+
+# print_function: render one MIR function — its `# <symbol>:` header, prologue,
+# every block (each preceded by a `.<id>:` local label), and epilogue. a body-less
+# (extern) function emits nothing.
+# ---
+# out: destination writer
+# m:   the owning module (its interner resolves the function / symbol names)
+# f:   the function to render
+# ret: true on success, or the first write error
+fun print_function(out: *writer.Writer, m: *mir.MirModule, f: *mir.MirFunction) Result[bool, str] {
+    if (f.block_count == 0) { ret ok[bool, str](true); }
+
+    val r1: Result[bool, str] = ws(out, "# ");
+    if (is_err[bool, str](r1)) { ret r1; }
+    val r2: Result[bool, str] = wname(out, m.interner, f.name);
+    if (is_err[bool, str](r2)) { ret r2; }
+    val r3: Result[bool, str] = ws(out, ":\n");
+    if (is_err[bool, str](r3)) { ret r3; }
+
+    val naked: bool = function_is_naked(f);
+    if (!naked) {
+        val rp: Result[bool, str] = print_prologue(out, f);
+        if (is_err[bool, str](rp)) { ret rp; }
+    }
+
+    var bi: u32 = 0;
+    for (bi < f.block_count) {
+        val blk: *mir.MirBlock = ?f.blocks[bi];
+
+        val rl: Result[bool, str] = ws(out, ".");
+        if (is_err[bool, str](rl)) { ret rl; }
+        val rlid: Result[bool, str] = wu(out, blk.id::u64);
+        if (is_err[bool, str](rlid)) { ret rlid; }
+        val rlc: Result[bool, str] = ws(out, ":\n");
+        if (is_err[bool, str](rlc)) { ret rlc; }
+
+        var ii: u32 = 0;
+        for (ii < blk.instr_count) {
+            val mi: *mir.MirInstr = ?blk.instrs[ii];
+            if (mi.opcode == mir.MIR_RET && !naked) {
+                val re: Result[bool, str] = print_epilogue(out, f);
+                if (is_err[bool, str](re)) { ret re; }
+            }
+            val ri: Result[bool, str] = print_instr(out, m, f, mi);
+            if (is_err[bool, str](ri)) { ret ri; }
+            ii = ii + 1;
+        }
+        bi = bi + 1;
+    }
+
+    ret ws(out, "\n");
+}
+
+# print_prologue: render the standard x86-64 prologue as comment-flagged lines so
+# the frame shape is visible without re-deriving it. mirrors `x64.emit_prologue`:
+# the frame-pointer setup, the rounded stack reservation, and each preserved
+# callee-saved register's home store.
+fun print_prologue(out: *writer.Writer, f: *mir.MirFunction) Result[bool, str] {
+    val r1: Result[bool, str] = ws(out, "  push  rbp                  # prologue\n");
+    if (is_err[bool, str](r1)) { ret r1; }
+    val r2: Result[bool, str] = ws(out, "  mov   rbp, rsp\n");
+    if (is_err[bool, str](r2)) { ret r2; }
+
+    val total: usize = prologue_reserve(f);
+    if (total > 0) {
+        val r3: Result[bool, str] = ws(out, "  sub   rsp, ");
+        if (is_err[bool, str](r3)) { ret r3; }
+        val r4: Result[bool, str] = wu(out, total::u64);
+        if (is_err[bool, str](r4)) { ret r4; }
+        val r5: Result[bool, str] = ws(out, "\n");
+        if (is_err[bool, str](r5)) { ret r5; }
+    }
+    ret ok[bool, str](true);
+}
+
+# print_epilogue: render the standard x86-64 epilogue as a comment-flagged line.
+# mirrors `x64.emit_epilogue` (callee-saved restores then frame teardown), rendered
+# compactly as `leave` since this artifact need not be byte-exact.
+fun print_epilogue(out: *writer.Writer, f: *mir.MirFunction) Result[bool, str] {
+    ret ws(out, "  leave                       # epilogue\n");
+}
+
+# prologue_reserve: the rounded stack-reservation byte count the prologue subtracts
+# from RSP — the local frame plus the callee-saved home area, rounded up to the
+# 16-byte ABI alignment. mirrors the size `x64.emit_prologue` computes.
+fun prologue_reserve(f: *mir.MirFunction) usize {
+    val callee_space: usize = count_callee_saved(f.callee_mask)::usize * 8;
+    var total: usize = f.frame.size::usize + callee_space;
+    if (total > 0 && (total & 15) != 0) { total = (total + 15) & ~15::usize; }
+    ret total;
+}
+
+# count_callee_saved: number of callee-saved GP registers set in `mask`. the SysV
+# callee-saved GP set the back end preserves is {RBX, R12, R13, R14, R15}.
+fun count_callee_saved(mask: u32) i32 {
+    var n: i32 = 0;
+    if ((mask & (1 << x64.RBX::u32)) != 0) { n = n + 1; }
+    if ((mask & (1 << x64.R12::u32)) != 0) { n = n + 1; }
+    if ((mask & (1 << x64.R13::u32)) != 0) { n = n + 1; }
+    if ((mask & (1 << x64.R14::u32)) != 0) { n = n + 1; }
+    if ((mask & (1 << x64.R15::u32)) != 0) { n = n + 1; }
+    ret n;
+}
+
+# function_is_naked: true when an asm-carrying function needs no frame (no locals,
+# no callee-saved registers, no outgoing-argument area) so its inline asm owns the
+# stack and gets no compiler prologue / epilogue. mirrors the encoder's predicate.
+fun function_is_naked(f: *mir.MirFunction) bool {
+    if (f.frame.size != 0) { ret false; }
+    if (f.callee_mask != 0) { ret false; }
+    if (f.frame.outgoing_size != 0) { ret false; }
+
+    var bi: u32 = 0;
+    for (bi < f.block_count) {
+        val blk: *mir.MirBlock = ?f.blocks[bi];
+        var ii: u32 = 0;
+        for (ii < blk.instr_count) {
+            if (blk.instrs[ii].opcode::u16 == x64.ISA_ASM_BLOCK::u16) { ret true; }
+            ii = ii + 1;
+        }
+        bi = bi + 1;
+    }
+    ret false;
+}
+
+# print_instr: render one fully-resolved MIR instruction. the lowering-only pseudos
+# that emit no bytes (PCOPY / USE / LABEL fences, the CALL_RES / ARG liveness
+# markers) are skipped. an inline-asm block prints a `# <inline asm>` marker rather
+# than its expanded body. every other instruction prints `<mnemonic> <op0>, <op1>,
+# ...` with operands resolved through the same frame layout the encoder reads.
+fun print_instr(out: *writer.Writer, m: *mir.MirModule, f: *mir.MirFunction, mi: *mir.MirInstr) Result[bool, str] {
+    val opcode: u16 = mi.opcode::u16;
+
+    if (mi.opcode == isa.ISA_PCOPY || mi.opcode == isa.ISA_PCOPY_FENCE ||
+        mi.opcode == isa.ISA_USE || mi.opcode == isa.ISA_LABEL ||
+        mi.opcode == mir.MIR_CALL_RES || mi.opcode == mir.MIR_ARG) {
+        ret ok[bool, str](true);
+    }
+
+    if (opcode == x64.ISA_ASM_BLOCK::u16) {
+        ret ws(out, "  # <inline asm>\n");
+    }
+
+    val r1: Result[bool, str] = ws(out, "  ");
+    if (is_err[bool, str](r1)) { ret r1; }
+    val r2: Result[bool, str] = ws(out, mnemonic(mi.opcode));
+    if (is_err[bool, str](r2)) { ret r2; }
+
+    val fp: bool = is_fp_instr(mi.opcode);
+    var oi: u32 = 0;
+    for (oi < mi.operand_count) {
+        if (oi == 0) {
+            val rs: Result[bool, str] = ws(out, " ");
+            if (is_err[bool, str](rs)) { ret rs; }
+        }
+        or {
+            val rc: Result[bool, str] = ws(out, ", ");
+            if (is_err[bool, str](rc)) { ret rc; }
+        }
+        val width: u8 = operand_width(mi, oi);
+        val ro: Result[bool, str] = print_operand(out, m, f, ?mi.operands[oi], width, fp);
+        if (is_err[bool, str](ro)) { ret ro; }
+        oi = oi + 1;
+    }
+    ret ws(out, "\n");
+}
+
+# operand_width: the byte width an operand renders at. the destination (operand 0)
+# rides the instruction's operation width; the sources ride its source width (they
+# differ only for the width-changing conversions). a 0 width falls back to the
+# machine word so an address-sized pseudo still names full-width registers.
+fun operand_width(mi: *mir.MirInstr, idx: u32) u8 {
+    var w: u8 = mi.src_width;
+    if (idx == 0) { w = mi.width; }
+    if (w == 0) { ret 8; }
+    ret w;
+}
+
+# print_operand: render one MIR operand in Intel syntax. a register names its
+# physical register (GP or XMM, by `fp`); an immediate prints its value; a memory
+# operand resolves a frame-slot base to `[rbp + off]` and a physical base to
+# `[preg + disp]`, folding any scaled index; a symbol prints `<name>` (with a
+# `+off` addend); a block prints its `.bb<id>` local-label target. a surviving
+# virtual register is a regalloc bug and prints `<vreg N>` so the artifact stays
+# legible rather than failing the whole dump.
+fun print_operand(out: *writer.Writer, m: *mir.MirModule, f: *mir.MirFunction,
+                  op: *mir.MirOperand, width: u8, fp: bool) Result[bool, str] {
+    if (op.kind == mir.MIR_OP_PREG) {
+        ret wreg(out, op.preg::i32, width, fp);
+    }
+    if (op.kind == mir.MIR_OP_VREG) {
+        val rv: Result[bool, str] = ws(out, "<vreg ");
+        if (is_err[bool, str](rv)) { ret rv; }
+        val rn: Result[bool, str] = wu(out, op.vreg::u64);
+        if (is_err[bool, str](rn)) { ret rn; }
+        ret ws(out, ">");
+    }
+    if (op.kind == mir.MIR_OP_IMM) {
+        ret wi(out, op.imm);
+    }
+    if (op.kind == mir.MIR_OP_MEM) {
+        ret print_mem(out, f, op, width);
+    }
+    if (op.kind == mir.MIR_OP_SYM) {
+        val rs: Result[bool, str] = wname(out, m.interner, op.sym);
+        if (is_err[bool, str](rs)) { ret rs; }
+        if (op.sym_off != 0) {
+            val rp: Result[bool, str] = ws(out, "+");
+            if (is_err[bool, str](rp)) { ret rp; }
+            ret wi(out, op.sym_off::i64);
+        }
+        ret ok[bool, str](true);
+    }
+    if (op.kind == mir.MIR_OP_BLOCK) {
+        val rb: Result[bool, str] = ws(out, ".");
+        if (is_err[bool, str](rb)) { ret rb; }
+        ret wu(out, op.imm::u64);
+    }
+    ret ws(out, "?");
+}
+
+# print_mem: render a memory operand as `<size> [base + index*scale + disp]`. a
+# frame-slot-key base (`vreg != MIR_VREG_NIL`) resolves to `[rbp + slot.offset +
+# imm]`; a physical-register base (`vreg == MIR_VREG_NIL`) forms `[preg + imm]`. a
+# scaled index is appended when present. a slot key owning no slot prints
+# `[<vreg N>]` so a regalloc leak stays legible rather than aborting the dump.
+fun print_mem(out: *writer.Writer, f: *mir.MirFunction, op: *mir.MirOperand, width: u8) Result[bool, str] {
+    val rp: Result[bool, str] = ws(out, size_prefix(width));
+    if (is_err[bool, str](rp)) { ret rp; }
+    val ro: Result[bool, str] = ws(out, "[");
+    if (is_err[bool, str](ro)) { ret ro; }
+
+    var disp: i64 = op.imm;
+    var has_base: bool = false;
+    if (op.vreg != mir.MIR_VREG_NIL) {
+        val slot: Option[i64] = frame_slot_offset(f, op.vreg);
+        if (is_some[i64](slot)) {
+            val rb: Result[bool, str] = ws(out, "rbp");
+            if (is_err[bool, str](rb)) { ret rb; }
+            disp = unwrap[i64](slot) + op.imm;
+            has_base = true;
+        }
+        or {
+            val rb: Result[bool, str] = ws(out, "<vreg ");
+            if (is_err[bool, str](rb)) { ret rb; }
+            val rn: Result[bool, str] = wu(out, op.vreg::u64);
+            if (is_err[bool, str](rn)) { ret rn; }
+            val re: Result[bool, str] = ws(out, ">");
+            if (is_err[bool, str](re)) { ret re; }
+            has_base = true;
+            disp = 0;
+        }
+    }
+    or {
+        val rb: Result[bool, str] = wreg(out, op.preg::i32, 8, false);
+        if (is_err[bool, str](rb)) { ret rb; }
+        has_base = true;
+    }
+
+    if (op.index != mir.MIR_VREG_NIL && op.index_is_preg) {
+        if (has_base) {
+            val rs: Result[bool, str] = ws(out, " + ");
+            if (is_err[bool, str](rs)) { ret rs; }
+        }
+        val ri: Result[bool, str] = wreg(out, op.index::i32, 8, false);
+        if (is_err[bool, str](ri)) { ret ri; }
+        if (op.scale > 1) {
+            val rsc: Result[bool, str] = ws(out, "*");
+            if (is_err[bool, str](rsc)) { ret rsc; }
+            val rscn: Result[bool, str] = wu(out, op.scale::u64);
+            if (is_err[bool, str](rscn)) { ret rscn; }
+        }
+    }
+
+    if (disp != 0) {
+        if (disp > 0) {
+            val rd: Result[bool, str] = ws(out, " + ");
+            if (is_err[bool, str](rd)) { ret rd; }
+            val rdn: Result[bool, str] = wi(out, disp);
+            if (is_err[bool, str](rdn)) { ret rdn; }
+        }
+        or {
+            val rd: Result[bool, str] = ws(out, " - ");
+            if (is_err[bool, str](rd)) { ret rd; }
+            val rdn: Result[bool, str] = wi(out, 0 - disp);
+            if (is_err[bool, str](rdn)) { ret rdn; }
+        }
+    }
+    ret ws(out, "]");
+}
+
+# frame_slot_offset: the frame-pointer offset of the slot a MIR value owns, or none
+# when it owns no slot. mirrors the encoder's lookup over the laid-out frame.
+fun frame_slot_offset(f: *mir.MirFunction, v: u32) Option[i64] {
+    val frame: *mir.MirFrame = ?f.frame;
+    if (frame.slots == nil) { ret none[i64](); }
+    var i: u32 = 0;
+    for (i < frame.slot_count) {
+        if (frame.slots[i].value == v) { ret some[i64](frame.slots[i].offset); }
+        i = i + 1;
+    }
+    ret none[i64]();
+}
+
+# wreg: write a register name — XMM (`fp`) or GP at the given byte width.
+fun wreg(out: *writer.Writer, id: i32, width: u8, fp: bool) Result[bool, str] {
+    if (fp) { ret ws(out, x64.fp_reg_name(id)); }
+    ret ws(out, x64.reg_name(nil, id, width));
+}
+
+# size_prefix: the Intel operand-size keyword for a memory access width.
+fun size_prefix(width: u8) str {
+    if (width == 1) { ret "byte "; }
+    if (width == 2) { ret "word "; }
+    if (width == 4) { ret "dword "; }
+    if (width == 8) { ret "qword "; }
+    ret "";
+}
+
+# is_fp_instr: true when an instruction operates on the SSE register file, so its
+# register operands name XMM registers. covers both the concrete SSE opcodes
+# (`x64.is_fp_opcode`) and the surviving MIR scalar-float family.
+fun is_fp_instr(op: mir.MirOpcode) bool {
+    if (op == mir.MIR_FADD || op == mir.MIR_FSUB ||
+        op == mir.MIR_FMUL || op == mir.MIR_FDIV || op == mir.MIR_FCMP) { ret true; }
+    if (op >= mir.MIR_SEL_ADD) { ret false; }
+    ret x64.is_fp_opcode(op::u16);
+}
+
+# mnemonic: the assembly mnemonic for a fully-resolved MIR opcode. the surviving
+# generic / selection-output sentinels (the three-address ALU, divide, compare,
+# float, and branch families plus the MOV / CALL / RET pseudos) map to their
+# natural mnemonic; everything else is a concrete x64 opcode named by `x64_mnemonic`.
+fun mnemonic(op: mir.MirOpcode) str {
+    if (op == mir.MIR_MOV)      { ret "mov"; }
+    if (op == mir.MIR_CALL)     { ret "call"; }
+    if (op == mir.MIR_RET)      { ret "ret"; }
+    if (op == mir.MIR_BR)       { ret "jmp"; }
+
+    if (op == mir.MIR_SEL_ADD)  { ret "add"; }
+    if (op == mir.MIR_SEL_SUB)  { ret "sub"; }
+    if (op == mir.MIR_SEL_MUL)  { ret "imul"; }
+    if (op == mir.MIR_SEL_AND)  { ret "and"; }
+    if (op == mir.MIR_SEL_OR)   { ret "or"; }
+    if (op == mir.MIR_SEL_XOR)  { ret "xor"; }
+    if (op == mir.MIR_SEL_SHL)  { ret "shl"; }
+    if (op == mir.MIR_SEL_SHR_U) { ret "shr"; }
+    if (op == mir.MIR_SEL_SHR_S) { ret "sar"; }
+    if (op == mir.MIR_SEL_DIV_S) { ret "idiv"; }
+    if (op == mir.MIR_SEL_DIV_U) { ret "div"; }
+    if (op == mir.MIR_SEL_REM_S) { ret "idiv"; }
+    if (op == mir.MIR_SEL_REM_U) { ret "div"; }
+
+    if (op == mir.MIR_SEL_CMP_EQ)   { ret "cmp.eq"; }
+    if (op == mir.MIR_SEL_CMP_NE)   { ret "cmp.ne"; }
+    if (op == mir.MIR_SEL_CMP_LT_S) { ret "cmp.lt_s"; }
+    if (op == mir.MIR_SEL_CMP_LT_U) { ret "cmp.lt_u"; }
+    if (op == mir.MIR_SEL_CMP_LE_S) { ret "cmp.le_s"; }
+    if (op == mir.MIR_SEL_CMP_LE_U) { ret "cmp.le_u"; }
+    if (op == mir.MIR_SEL_CBR)      { ret "cbr"; }
+
+    if (op == mir.MIR_FADD) { ret "fadd"; }
+    if (op == mir.MIR_FSUB) { ret "fsub"; }
+    if (op == mir.MIR_FMUL) { ret "fmul"; }
+    if (op == mir.MIR_FDIV) { ret "fdiv"; }
+    if (op == mir.MIR_FCMP) { ret "fcmp"; }
+
+    ret x64_mnemonic(op::u16);
+}
+
+# x64_mnemonic: the Intel mnemonic for a concrete x86-64 opcode.
+fun x64_mnemonic(op: u16) str {
+    if (op == x64.NOP)       { ret "nop"; }
+    if (op == x64.MOV)       { ret "mov"; }
+    if (op == x64.LEA)       { ret "lea"; }
+    if (op == x64.PUSH)      { ret "push"; }
+    if (op == x64.POP)       { ret "pop"; }
+    if (op == x64.ADD)       { ret "add"; }
+    if (op == x64.SUB)       { ret "sub"; }
+    if (op == x64.IMUL)      { ret "imul"; }
+    if (op == x64.IDIV)      { ret "idiv"; }
+    if (op == x64.DIV)       { ret "div"; }
+    if (op == x64.AND)       { ret "and"; }
+    if (op == x64.OR)        { ret "or"; }
+    if (op == x64.XOR)       { ret "xor"; }
+    if (op == x64.SHL)       { ret "shl"; }
+    if (op == x64.SHR)       { ret "shr"; }
+    if (op == x64.SAR)       { ret "sar"; }
+    if (op == x64.CMP)       { ret "cmp"; }
+    if (op == x64.TEST)      { ret "test"; }
+    if (op == x64.JMP)       { ret "jmp"; }
+    if (op == x64.CALL)      { ret "call"; }
+    if (op == x64.RET)       { ret "ret"; }
+    if (op == x64.JE)        { ret "je"; }
+    if (op == x64.JNE)       { ret "jne"; }
+    if (op == x64.JL)        { ret "jl"; }
+    if (op == x64.JLE)       { ret "jle"; }
+    if (op == x64.JG)        { ret "jg"; }
+    if (op == x64.JGE)       { ret "jge"; }
+    if (op == x64.JB)        { ret "jb"; }
+    if (op == x64.JBE)       { ret "jbe"; }
+    if (op == x64.JA)        { ret "ja"; }
+    if (op == x64.JAE)       { ret "jae"; }
+    if (op == x64.SETE)      { ret "sete"; }
+    if (op == x64.SETNE)     { ret "setne"; }
+    if (op == x64.SETL)      { ret "setl"; }
+    if (op == x64.SETLE)     { ret "setle"; }
+    if (op == x64.SETG)      { ret "setg"; }
+    if (op == x64.SETGE)     { ret "setge"; }
+    if (op == x64.SETB)      { ret "setb"; }
+    if (op == x64.SETBE)     { ret "setbe"; }
+    if (op == x64.SETA)      { ret "seta"; }
+    if (op == x64.SETAE)     { ret "setae"; }
+    if (op == x64.MOVSS)     { ret "movss"; }
+    if (op == x64.MOVSD)     { ret "movsd"; }
+    if (op == x64.ADDSS)     { ret "addss"; }
+    if (op == x64.ADDSD)     { ret "addsd"; }
+    if (op == x64.SUBSS)     { ret "subss"; }
+    if (op == x64.SUBSD)     { ret "subsd"; }
+    if (op == x64.MULSS)     { ret "mulss"; }
+    if (op == x64.MULSD)     { ret "mulsd"; }
+    if (op == x64.DIVSS)     { ret "divss"; }
+    if (op == x64.DIVSD)     { ret "divsd"; }
+    if (op == x64.SYSCALL)   { ret "syscall"; }
+    if (op == x64.MOVABS)    { ret "movabs"; }
+    if (op == x64.UD2)       { ret "ud2"; }
+    if (op == x64.PAUSE)     { ret "pause"; }
+    if (op == x64.CDQ)       { ret "cdq"; }
+    if (op == x64.CQO)       { ret "cqo"; }
+    if (op == x64.MOVSX)     { ret "movsx"; }
+    if (op == x64.MOVZX)     { ret "movzx"; }
+    if (op == x64.MOVSXD)    { ret "movsxd"; }
+    if (op == x64.CVTSI2SS)  { ret "cvtsi2ss"; }
+    if (op == x64.CVTSI2SD)  { ret "cvtsi2sd"; }
+    if (op == x64.CVTSS2SD)  { ret "cvtss2sd"; }
+    if (op == x64.CVTSD2SS)  { ret "cvtsd2ss"; }
+    if (op == x64.CVTTSS2SI) { ret "cvttss2si"; }
+    if (op == x64.CVTTSD2SI) { ret "cvttsd2si"; }
+    if (op == x64.UCOMISS)   { ret "ucomiss"; }
+    if (op == x64.UCOMISD)   { ret "ucomisd"; }
+    if (op == x64.MOVSB)     { ret "movsb"; }
+    if (op == x64.MFENCE)    { ret "mfence"; }
+    if (op == x64.CBW)       { ret "cbw"; }
+    if (op == x64.CWD)       { ret "cwd"; }
+    if (op == x64.MOVQ)      { ret "movq"; }
+    if (op == x64.XORPS)     { ret "xorps"; }
+    if (op == x64.NEG)       { ret "neg"; }
+    if (op == x64.NOT)       { ret "not"; }
+    if (op == x64.INC)       { ret "inc"; }
+    if (op == x64.DEC)       { ret "dec"; }
+    if (op == x64.HLT)       { ret "hlt"; }
+    if (op == x64.XCHG)      { ret "xchg"; }
+    if (op == x64.XADD)      { ret "xadd"; }
+    if (op == x64.CMPXCHG)   { ret "cmpxchg"; }
+    if (op == x64.RAW_BYTE)  { ret ".byte"; }
+    ret "???";
+}
+
+# ws: write a string, mapping a format error to the bool/str result shape.
+fun ws(out: *writer.Writer, s: str) Result[bool, str] {
+    val r: Result[usize, str] = fmt.write_str(out, s);
+    if (is_err[usize, str](r)) { ret err[bool, str](unwrap_err[usize, str](r)); }
+    ret ok[bool, str](true);
+}
+
+# wu: write an unsigned integer.
+fun wu(out: *writer.Writer, n: u64) Result[bool, str] {
+    val r: Result[usize, str] = fmt.write_u64(out, n);
+    if (is_err[usize, str](r)) { ret err[bool, str](unwrap_err[usize, str](r)); }
+    ret ok[bool, str](true);
+}
+
+# wi: write a signed integer.
+fun wi(out: *writer.Writer, n: i64) Result[bool, str] {
+    val r: Result[usize, str] = fmt.write_i64(out, n);
+    if (is_err[usize, str](r)) { ret err[bool, str](unwrap_err[usize, str](r)); }
+    ret ok[bool, str](true);
+}
+
+# wname: write an interned name, or `<?name>` when the id does not resolve.
+fun wname(out: *writer.Writer, interner: *intern.Interner, id_: intern.StrId) Result[bool, str] {
+    val got: Option[str] = intern.lookup(interner, id_);
+    if (is_some[str](got)) {
+        ret ws(out, unwrap[str](got));
+    }
+    ret ws(out, "<?name>");
+}

--- a/src/lang/target/isa/x64/register.mach
+++ b/src/lang/target/isa/x64/register.mach
@@ -27,6 +27,7 @@ use isa:    mach.lang.target.isa;
 use x64:        mach.lang.target.isa.x64;
 use x64isel:    mach.lang.target.isa.x64.isel;
 use x64encode:  mach.lang.target.isa.x64.encode;
+use x64printer: mach.lang.target.isa.x64.printer;
 
 # process-global storage for the x86-64 vtable and its register classes. written
 # once by `register_x64` and referenced (borrowed) by the vtable installed into
@@ -141,6 +142,7 @@ pub fun register_x64(alloc: *Allocator, interner: *intern.Interner) Result[bool,
     x64_vtable.reg_class_count    = 3;
     x64_vtable.select             = x64isel.select::*u8;
     x64_vtable.encode             = x64encode.encode_x64::*u8;
+    x64_vtable.emit_asm           = x64printer.print_asm_x64::*u8;
     x64_vtable.reserved_regs      = ?x64_reserved_regs[0];
     x64_vtable.reserved_reg_count = 2;
     x64_vtable.reload_scratch_regs  = ?x64_reload_scratch_regs[0];


### PR DESCRIPTION
Restores the `--emit-asm` / `--emit-ir` debug-artifact flags, re-integrated onto current `dev`.

The feature was parked on `feat/1021-emit-asm-ir` (blocked on variadics). Variadics landed (#1028), so `std.format` compiles and the x64 printer is unblocked. This branch re-integrates the parked work on top of tonight's `build.mach` changes (verbose #1038, test_mode #1078, `-O` #1080), keeping all of them.

## What it does
- `--emit-ir` writes per-module textual SSA IR (`.ir`), rendered straight after lowering.
- `--emit-asm` writes per-module Intel-syntax assembly text (`.s`), rendered from the fully-resolved MIR the encoder consumes.
- Both mirror the `obj/` tree under `<artifacts>/ir/` and `<artifacts>/asm/` (FQN `a.b.c` → `ir/a/b/c.ir`).
- A new ISA-vtable `emit_asm` hook dispatched by `encode.print_asm`; arm64 (no printer) is a clean no-op.
- The x64 printer uses `std.format`'s non-variadic `write_*` helpers (compiles under cmach and self-compiles).

## Implementation
- `src/cli/config.mach`: parse `--emit-asm` / `--emit-ir`.
- `src/lang/target/isa.mach`: `emit_asm` vtable op.
- `src/lang/target/isa/x64/printer.mach` (new): the Intel-syntax MIR printer.
- `src/lang/target/isa/x64/register.mach`, `src/lang/target/isa/arm64.mach`: register the printer / nil for arm64.
- `src/lang/be/codegen.mach`: `codegen_module` takes an `asm_out` writer.
- `src/lang/be/codegen/encode.mach`: the `print_asm` dispatcher.
- `src/cli/cmd/build.mach`: per-module `.s`/`.ir` writer loop (`open_artifact`, `mirror_fqn` generalized to any extension, `ir_printer.print_module`).

## Verification
- `make clean && make` full bootstrap (cmach→imach→smach→mach) exit 0.
- Emit produces well-formed `.s` / `.ir` (verified on an example and the full compiler: 120 `.s` + 120 `.ir`, every `.s` carries the `.intel_syntax noprefix` header).
- `mach build .` with no flags produces zero `.s`/`.ir` and no `asm/`/`ir/` dirs.
- Fixpoint: two default object builds are byte-identical (`diff -rq`, 0 diffs); `mach` builds a byte-identical `mach2` (`cmp` identical).

Closes #1021
