### PR TITLE
feat(diagnostics): note: lines and "did you mean" suggestions (refs #1046)

### DIFF
--- a/src/cli/cmd/build.mach
+++ b/src/cli/cmd/build.mach
@@ -1062,6 +1062,12 @@ fun flush_diagnostics(s: *sess.Session, list: *diag.DiagList) {
             os.write(os.STDERR_FD, d.message::*u8, slen(d.message::*u8));
             emit("\n");
         }
+
+        if (d.note != nil) {
+            emit("  note: ");
+            os.write(os.STDERR_FD, d.note::*u8, slen(d.note::*u8));
+            emit("\n");
+        }
         i = i + 1;
     }
 }

--- a/src/lang/diagnostic.mach
+++ b/src/lang/diagnostic.mach
@@ -8,7 +8,9 @@ use std.types.bool.bool;
 use std.types.bool.true;
 use std.types.bool.false;
 use std.types.size.usize;
+use std.types.char.char;
 use std.types.string.str;
+use std.types.string.str_len;
 use std.text.string.str_dup;
 use std.text.string.str_free;
 use std.types.result.Result;
@@ -44,11 +46,13 @@ pub val SEVERITY_HELP:    Severity = 3;
 # file_id:  identifier of the file the span points into
 # span:     byte range being reported on
 # message:  owned human-readable message
+# note:     owned secondary "note:" line, or nil when absent
 pub rec Diagnostic {
     severity: Severity;
     file_id:  src.FileId;
     span:     token.Span;
     message:  str;
+    note:     str;
 }
 
 # DiagList: owning list of diagnostics collected during one or more phases.
@@ -89,6 +93,7 @@ pub fun dnit(list: *DiagList) {
     for (i < list.len) {
         val d: *Diagnostic = ?list.items[i];
         str_free(list.alloc, d.message);
+        if (d.note != nil) { str_free(list.alloc, d.note); }
         i = i + 1;
     }
 
@@ -192,8 +197,56 @@ fun emit(list: *DiagList, severity: Severity, file_id: src.FileId, span: token.S
     d.file_id  = file_id;
     d.span     = span;
     d.message  = owned;
+    d.note     = nil;
     list.items[list.len] = d;
     list.len = list.len + 1;
 
     ret ok[bool, str](true);
+}
+
+# attach_note: attach an owned secondary "note:" line to the most recently
+# recorded diagnostic. a no-op when the list is empty or the last diagnostic
+# already carries a note. allocation failures are swallowed so a missing note
+# never aborts a pass.
+# ---
+# list: diagnostic list whose last entry receives the note
+# note: human-readable secondary message (copied)
+pub fun attach_note(list: *DiagList, note: str) {
+    if (list == nil || list.len == 0) { ret; }
+    val d: *Diagnostic = ?list.items[list.len - 1];
+    if (d.note != nil) { ret; }
+    val r: Result[str, str] = str_dup(list.alloc, note);
+    if (is_err[str, str](r)) { ret; }
+    d.note = unwrap_ok[str, str](r);
+}
+
+# build_suggestion: allocate an owned `did you mean `<name>`?` note string,
+# returning nil on allocation failure (the caller treats nil as "no note").
+# the result is owned by `alloc`; the caller frees the temporary with str_free
+# after passing it to attach_note (which dups it into the list allocator).
+# ---
+# alloc: allocator backing the returned string
+# name:  candidate identifier to suggest
+# ret:   the owned note string, or nil on failure
+pub fun build_suggestion(alloc: *Allocator, name: str) str {
+    val prefix: str = "did you mean `";
+    val suffix: str = "`?";
+    val pn: usize = str_len(prefix);
+    val nn: usize = str_len(name);
+    val sn: usize = str_len(suffix);
+    val total: usize = pn + nn + sn;
+
+    val r: Result[*char, str] = allocate[char](alloc, total + 1);
+    if (is_err[*char, str](r)) { ret nil; }
+    val buf: str = unwrap_ok[*char, str](r);
+
+    var w: usize = 0;
+    var i: usize = 0;
+    for (i < pn) { buf[w] = prefix[i]; w = w + 1; i = i + 1; }
+    i = 0;
+    for (i < nn) { buf[w] = name[i]; w = w + 1; i = i + 1; }
+    i = 0;
+    for (i < sn) { buf[w] = suffix[i]; w = w + 1; i = i + 1; }
+    buf[w] = 0;
+    ret buf;
 }

--- a/src/lang/fe/resolve.mach
+++ b/src/lang/fe/resolve.mach
@@ -28,6 +28,8 @@ use std.types.option.is_some;
 use std.types.option.unwrap;
 use std.types.size.usize;
 use std.types.string.str;
+use std.types.string.str_len;
+use std.text.string.str_free;
 use std.types.result.Result;
 use std.types.result.ok;
 use std.types.result.err;
@@ -543,6 +545,7 @@ fun declare(
     val existing: SymbolId = scope_lookup_local(rc, scope, name_id);
     if (existing != SYMBOL_NIL) {
         diag.error(?rc.s.diags, rc.a.file_id, name, "duplicate definition in this scope");
+        diag.attach_note(?rc.s.diags, "a name with this spelling is already bound here");
         ret ok[SymbolId, str](SYMBOL_NIL);
     }
 
@@ -1463,12 +1466,115 @@ fun bind_ident(rc: *ResolveContext, eid: id.ExprId, span: token.Span) Result[boo
     val sid: SymbolId = scope_lookup_chain(rc, rc.current_scope, name);
     if (sid == SYMBOL_NIL) {
         diag.error(?rc.s.diags, rc.a.file_id, span, "unresolved identifier");
+        attach_suggestion(rc, name);
     }
     or {
         if (rc.expr_resolved != nil) { rc.expr_resolved[eid] = sid; }
     }
     ret ok[bool, str](true);
 }
+
+# attach_suggestion: scan the visible scope chain for the in-scope name
+# closest to the unresolved `target` and, when one is near enough, attach a
+# `did you mean `<name>`?` note to the just-reported diagnostic. names within
+# edit distance MAX_SUGGEST_DISTANCE (and no further than half the target's
+# length) qualify; the nearest qualifying name wins. a no-op when nothing is
+# close enough.
+fun attach_suggestion(rc: *ResolveContext, target: intern.StrId) {
+    val to: Option[str] = intern.lookup(?rc.s.interner, target);
+    if (is_none[str](to)) { ret; }
+    val tname: str = unwrap[str](to);
+    val tlen: usize = str_len(tname);
+    if (tlen == 0) { ret; }
+
+    var best_sym:  SymbolId = SYMBOL_NIL;
+    var best_dist: usize = MAX_SUGGEST_DISTANCE + 1;
+    var max_dist:  usize = tlen / 2;
+    if (max_dist > MAX_SUGGEST_DISTANCE) { max_dist = MAX_SUGGEST_DISTANCE; }
+
+    var cur: ScopeId = rc.current_scope;
+    for (cur != SCOPE_NIL) {
+        val sc: *Scope = ?rc.scopes[cur];
+        var i: u32 = 0;
+        for (i < sc.len) {
+            val cname_id: intern.StrId = sc.entries[i].name;
+            if (cname_id != target) {
+                val co: Option[str] = intern.lookup(?rc.s.interner, cname_id);
+                if (is_some[str](co)) {
+                    val cname: str = unwrap[str](co);
+                    val dist: usize = edit_distance(tname, cname, best_dist);
+                    if (dist <= max_dist && dist < best_dist) {
+                        best_dist = dist;
+                        best_sym  = sc.entries[i].sym;
+                    }
+                }
+            }
+            i = i + 1;
+        }
+        cur = rc.scopes[cur].parent;
+    }
+
+    if (best_sym == SYMBOL_NIL) { ret; }
+    val bo: Option[str] = intern.lookup(?rc.s.interner, rc.symbols[best_sym].name);
+    if (is_none[str](bo)) { ret; }
+    val bname: str = unwrap[str](bo);
+
+    val note: str = diag.build_suggestion(rc.s.alloc, bname);
+    if (note == nil) { ret; }
+    diag.attach_note(?rc.s.diags, note);
+    str_free(rc.s.alloc, note);
+}
+
+# MAX_SUGGEST_DISTANCE: largest edit distance a "did you mean" candidate may
+# differ from the unresolved name by.
+val MAX_SUGGEST_DISTANCE: usize = 2;
+
+# edit_distance: Levenshtein distance between `a` and `b`, capped so the search
+# can abandon a candidate early. returns a value strictly greater than `cap`
+# (specifically `cap + 1`) the moment every cell in a row exceeds `cap`,
+# letting callers prune candidates that cannot beat the current best.
+fun edit_distance(a: str, b: str, cap: usize) usize {
+    val la: usize = str_len(a);
+    val lb: usize = str_len(b);
+    if (la == 0) { ret lb; }
+    if (lb == 0) { ret la; }
+
+    var prev: [128]usize;
+    var curr: [128]usize;
+    if (lb + 1 > SUGGEST_ROW) { ret cap + 1; }
+
+    var j: usize = 0;
+    for (j <= lb) { prev[j] = j; j = j + 1; }
+
+    var i: usize = 1;
+    for (i <= la) {
+        curr[0] = i;
+        var row_min: usize = i;
+        var k: usize = 1;
+        for (k <= lb) {
+            var cost: usize = 1;
+            if (a[i - 1] == b[k - 1]) { cost = 0; }
+            var m: usize = prev[k] + 1;
+            val del: usize = curr[k - 1] + 1;
+            if (del < m) { m = del; }
+            val sub: usize = prev[k - 1] + cost;
+            if (sub < m) { m = sub; }
+            curr[k] = m;
+            if (m < row_min) { row_min = m; }
+            k = k + 1;
+        }
+        if (row_min > cap) { ret cap + 1; }
+        var t: usize = 0;
+        for (t <= lb) { prev[t] = curr[t]; t = t + 1; }
+        i = i + 1;
+    }
+    ret prev[lb];
+}
+
+# SUGGEST_ROW: capacity of the edit-distance DP rows (matches the literal row
+# array length); candidates whose length reaches this bound are skipped, since
+# their distance cannot be small anyway.
+val SUGGEST_ROW: usize = 128;
 
 # classifies a call's callee as a comptime value intrinsic by its name: 1 for
 # `$size_of`/`$align_of` (one type argument), 2 for `$offset_of` (a type plus a
@@ -1681,6 +1787,7 @@ fun resolve_type_path(rc: *ResolveContext, named: *atype.TypeNamed, full: token.
 
         if (current_sym == SYMBOL_NIL) {
             diag.error(?rc.s.diags, rc.a.file_id, full, "unresolved type name");
+            if (seg_start == path.offset && seg_end >= end) { attach_suggestion(rc, seg_name); }
             ret SYMBOL_NIL;
         }
 

--- a/src/lang/fe/sema/check.mach
+++ b/src/lang/fe/sema/check.mach
@@ -50,7 +50,8 @@ pub fun check_assignable(sc: *sema.SemaContext, expected: ty.TypeId, actual: ty.
 
     if (coerce.is_assignable(sc, actual, expected)) { ret true; }
 
-    report(sc, span, "type mismatch: incompatible types in assignment");
+    report_note(sc, span, "type mismatch: incompatible types in assignment",
+        "mach has no implicit widening; cast the value with `value::Type`");
     ret false;
 }
 
@@ -219,7 +220,8 @@ pub fun check_cast(sc: *sema.SemaContext, from: ty.TypeId, to: ty.TypeId, span: 
         ret some[ty.TypeId](to);
     }
 
-    report(sc, span, "cast: conversion is invalid");
+    report_note(sc, span, "cast: conversion is invalid",
+        "`::` casts numeric types or reinterprets equal-size values only");
     ret none[ty.TypeId]();
 }
 
@@ -259,7 +261,8 @@ pub fun check_return(sc: *sema.SemaContext, fn_ret: ty.TypeId, value: ty.TypeId,
 pub fun check_condition(sc: *sema.SemaContext, cond: ty.TypeId, span: token.Span) bool {
     if (cond == ty.TYPE_ERROR) { ret true; }
     if (is_integer(cond)) { ret true; }
-    report(sc, span, "type mismatch: condition must be an integer");
+    report_note(sc, span, "type mismatch: condition must be an integer",
+        "mach has no `bool` type; comparisons yield an integer truth value");
     ret false;
 }
 
@@ -375,4 +378,10 @@ fun expr_span_of(sc: *sema.SemaContext, eid: id.ExprId, fallback: token.Span) to
 # diagnostic append cannot itself be reported, and sema never halts on it.
 fun report(sc: *sema.SemaContext, span: token.Span, message: str) {
     diag.error(?sc.s.diags, sc.a.file_id, span, message);
+}
+
+# report_note: report plus a static clarifying `note:` line on the same diagnostic.
+fun report_note(sc: *sema.SemaContext, span: token.Span, message: str, note: str) {
+    diag.error(?sc.s.diags, sc.a.file_id, span, message);
+    diag.attach_note(?sc.s.diags, note);
 }

--- a/src/lang/fe/sema/context.mach
+++ b/src/lang/fe/sema/context.mach
@@ -252,6 +252,18 @@ pub fun report(sc: *SemaContext, span: token.Span, message: str) {
     diag.error(?sc.s.diags, sc.a.file_id, span, message);
 }
 
+# report_note: like report, but also attaches a static secondary `note:` line
+# clarifying the error; allocation failures in the sink are swallowed.
+# ---
+# sc:      sema context
+# span:    source span the diagnostic refers to
+# message: human-readable error text
+# note:    secondary clarifying message rendered on a `note:` line
+pub fun report_note(sc: *SemaContext, span: token.Span, message: str, note: str) {
+    diag.error(?sc.s.diags, sc.a.file_id, span, message);
+    diag.attach_note(?sc.s.diags, note);
+}
+
 # field_table_begin: begins a new field table for nominal `ty`, returning the index of the table; fields are appended with `field_table_push`, and since a nominal type interns to a stable TypeId a table is built once per pass.
 # ---
 # sc:  sema context


### PR DESCRIPTION
## Summary

Continues the diagnostics-quality pass (#1046) after the source-line + caret work (#1068). Adds secondary `note:` lines and "did you mean" suggestions.

### Implemented

- **`note:` secondary lines.** `Diagnostic` gains an owned `note` field; `attach_note` pins a note onto the last-recorded diagnostic and the build renderer prints it on an indented `note:` line under the snippet. Freed in `dnit`.
- **"did you mean" suggestions.** On an unresolved identifier or single-segment type name, resolve scans the visible scope chain by capped Levenshtein distance (≤ 2, and ≤ half the target length) and attaches a `did you mean \`x\`?` note for the nearest candidate. Far typos produce no suggestion (no garbage).
- **Clarifying notes at high-value sema sites.** Assignment type mismatch, non-integer condition, and invalid cast now carry a static note explaining the rule (no implicit widening, no `bool` type, cast semantics). Duplicate-definition notes the prior binding.

### Checked, already good

- **Multi-error recovery already works.** A program with several independent errors (unresolved idents, type mismatches, bad conditions) reports all of them across the resolve and sema passes before aborting, exit 1. No change needed.

### Deferred (still open under #1046)

- **Expected-vs-found types in the mismatch note.** Requires a general TypeId→string renderer (primitives, pointers, arrays, nominals, functions, generics) that does not yet exist; out of scope for this bounded pass. Tracked as remaining work.
- **Full clarity audit** of every `report()` message string.

## Before / after

Broken program (typo'd type + fn, string→i64, string condition):

Before (origin/dev): bare diagnostics, no notes or suggestions.

After:
```
error: main.mach:5:12: unresolved type name
       val p: Poin = nil;
              ^~~~
  note: did you mean `Point`?
error: main.mach:6:22: unresolved identifier
       val count: i64 = helpr();
                        ^~~~~
  note: did you mean `helper`?
error: main.mach:7:5: type mismatch: incompatible types in assignment
       val a: i64 = "hello";
       ^~~~~~~~~~~~~~~~~~~~~
  note: mach has no implicit widening; cast the value with `value::Type`
error: main.mach:8:5: type mismatch: condition must be an integer
       if ("nope") { ret 1; }
       ^~~~~~~~~~~~~~~~~~~~~~
  note: mach has no `bool` type; comparisons yield an integer truth value
```

## Verification

- `make clean && make` full bootstrap: exit 0.
- FIXPOINT: `da`/`db` obj artifacts byte-identical (`diff -rq`, 0 diffs); self-compiled `mach2` identical to `mach` (`cmp`).

Refs #1046
