### PR TITLE
feat: algebraic simplification + local CSE passes

### DIFF
--- a/src/lang/me/pass/algebraic.mach
+++ b/src/lang/me/pass/algebraic.mach
@@ -1,0 +1,360 @@
+# mach.lang.me.pass.algebraic: algebraic simplification (peephole identities).
+#
+# A forward pass that rewrites a pure arithmetic / bitwise / shift instruction
+# whose result is fixed by an algebraic identity into the operand (or constant)
+# the identity yields, without evaluating any non-constant operand. It
+# complements constfold: constfold collapses all-constant expressions, while
+# this pass simplifies an expression one of whose operands is a constant
+# identity element, or whose two operands are the same SSA value.
+#
+# The mechanism mirrors constfold's substitution table. For each instruction a
+# replacement Value may be recorded (instruction id -> Value); `apply` then
+# rewrites every operand naming a simplified instruction to its replacement, and
+# the now-dead instructions are left for dce. Because a replacement can name an
+# instruction result, the table is iterated to a fixpoint so a chain collapses.
+#
+# CORRECTNESS CONTRACT: every rewrite must preserve the exact runtime value for
+# all operand values. The pass is INTEGER-ONLY where float semantics differ:
+#
+#   - `x + 0`, `0 + x`, `x - 0`           -> x          (int only; float +0.0/-0.0)
+#   - `x * 1`, `1 * x`                    -> x          (int only)
+#   - `x * 0`, `0 * x`                    -> 0          (int only; float NaN/inf)
+#   - `x - x`                             -> 0          (int only; float NaN)
+#   - `x & x`, `x | x`                    -> x
+#   - `x ^ x`                             -> 0
+#   - `x & 0`, `0 & x`                    -> 0
+#   - `x | 0`, `0 | x`, `x ^ 0`, `0 ^ x`  -> x
+#   - `x & ~0`, `~0 & x`                  -> x          (all-ones mask)
+#   - `x | ~0`, `~0 | x`                  -> ~0
+#   - `x << 0`, `x >> 0`                  -> x
+#   - `0 << c`, `0 >> c`                  -> 0
+#   - `x / 1` (signed/unsigned)           -> x
+#   - `x % 1` (signed/unsigned)           -> 0
+#   - `-(-x)`, `~(~x)`                    -> x          (double negation)
+#
+# Float operands are never simplified: `x + 0.0` is not `x` for `x == -0.0`,
+# `x * 0.0` is NaN for `x` infinite/NaN, and `x - x` is NaN for `x == NaN`. The
+# integer/float opcodes overlap, so each rewrite first confirms the result type
+# resolves to an IRT_INT (`is_int`); a float-typed instruction is left untouched.
+# Division/remainder by a non-one constant is never simplified; only the exact
+# identities `/ 1` and `% 1` fire (never `/ 0`, which traps at runtime).
+
+use std.types.bool.bool;
+use std.types.bool.true;
+use std.types.bool.false;
+use std.types.size.usize;
+use std.types.string.str;
+use std.types.option.Option;
+use std.types.option.is_none;
+use std.types.option.unwrap;
+use std.types.result.Result;
+use std.types.result.ok;
+use std.types.result.err;
+use std.types.result.is_err;
+use std.types.result.unwrap_ok;
+use std.types.result.unwrap_err;
+
+use std.allocator.allocate;
+use std.allocator.deallocate;
+
+use ir:      mach.lang.me.ir;
+use instr:   mach.lang.me.ir.instruction;
+use value:   mach.lang.me.ir.value;
+use ir_type: mach.lang.me.ir.type;
+
+# Pass entry. Simplifies every non-extern function in the module in place.
+# ---
+# m:   module to mutate in place
+# ret: ok(true) on a successful pass, or the first allocation error
+pub fun run(m: *ir.Module) Result[bool, str] {
+    var f: u32 = 0;
+    for (f < m.function_len) {
+        val fn: *ir.Function = ?m.functions[f];
+        if ((fn.flags & ir.FN_FLAG_EXTERN) == 0) {
+            val r: Result[bool, str] = simplify_function(m, fn);
+            if (is_err[bool, str](r)) { ret r; }
+        }
+        f = f + 1;
+    }
+    ret ok[bool, str](true);
+}
+
+# simplifies one function. A per-instruction substitution table maps a
+# simplified instruction id to its replacement Value; `has_sub` marks live
+# entries. Simplification repeats until no instruction changes (operands are
+# resolved through the table first, so a chain collapses across sweeps); the
+# substitutions are then applied to every operand.
+fun simplify_function(m: *ir.Module, fn: *ir.Function) Result[bool, str] {
+    val ilen: u32 = fn.instr_len;
+    if (ilen == 0) { ret ok[bool, str](true); }
+
+    val rs: Result[*value.Value, str] = allocate[value.Value](m.alloc, ilen::usize);
+    if (is_err[*value.Value, str](rs)) { ret err[bool, str](unwrap_err[*value.Value, str](rs)); }
+    val subst: *value.Value = unwrap_ok[*value.Value, str](rs);
+
+    val rh: Result[*bool, str] = allocate[bool](m.alloc, ilen::usize);
+    if (is_err[*bool, str](rh)) {
+        deallocate[value.Value](m.alloc, subst, ilen::usize);
+        ret err[bool, str](unwrap_err[*bool, str](rh));
+    }
+    val has_sub: *bool = unwrap_ok[*bool, str](rh);
+    var i: u32 = 0;
+    for (i < ilen) { has_sub[i] = false; i = i + 1; }
+
+    simplify_to_fixpoint(m, fn, subst, has_sub, ilen);
+    apply_substitutions(fn, subst, has_sub, ilen);
+
+    deallocate[value.Value](m.alloc, subst, ilen::usize);
+    deallocate[bool](m.alloc, has_sub, ilen::usize);
+    ret ok[bool, str](true);
+}
+
+# repeatedly sweeps the instruction pool, simplifying every instruction whose
+# (resolved) operands now match an identity, until a sweep changes nothing.
+fun simplify_to_fixpoint(m: *ir.Module, fn: *ir.Function,
+                         subst: *value.Value, has_sub: *bool, ilen: u32) {
+    var changed: bool = true;
+    for (changed) {
+        changed = false;
+        var k: u32 = 0;
+        for (k < ilen) {
+            if (has_sub[k] == false) {
+                val inst: *instr.Instruction = ?fn.instrs[k];
+                var out: value.Value;
+                if (try_simplify(m, fn, inst, subst, has_sub, ilen, ?out)) {
+                    subst[k]   = out;
+                    has_sub[k] = true;
+                    changed    = true;
+                }
+            }
+            k = k + 1;
+        }
+    }
+}
+
+# resolves an operand through the substitution table, following chains: a
+# VAL_INSTR naming a simplified instruction becomes that instruction's
+# replacement, and if that replacement also names a simplified instruction it is
+# followed again, up to `ilen` hops (the table is acyclic, so this is a guard
+# only). The result carries the original operand's type. Non-instruction
+# operands pass through unchanged.
+fun resolve(v: value.Value, subst: *value.Value, has_sub: *bool, ilen: u32) value.Value {
+    var cur: value.Value = v;
+    var hops: u32 = 0;
+    for (cur.kind == value.VAL_INSTR && hops <= ilen) {
+        val iid: u32 = cur.data.instr::u32;
+        if (iid >= ilen || has_sub[iid] == false) { ret value.retype(cur, v.ty); }
+        cur  = subst[iid];
+        hops = hops + 1;
+    }
+    ret value.retype(cur, v.ty);
+}
+
+# attempts to simplify one instruction via an algebraic identity. Writes the
+# replacement Value into `out` and returns true on a successful rewrite. Only
+# integer-typed pure arithmetic / bitwise / shift opcodes are considered; the
+# unary double-negation forms handle OP_NEG / OP_NOT.
+fun try_simplify(m: *ir.Module, fn: *ir.Function, inst: *instr.Instruction,
+                 subst: *value.Value, has_sub: *bool, ilen: u32, out: *value.Value) bool {
+    val k: instr.InstrKind = inst.kind;
+
+    # unary double-negation: -(-x) -> x, ~(~x) -> x. integer only; float
+    # negation flips the sign bit, observable on -0.0, so it is never collapsed.
+    if ((k == instr.OP_NEG || k == instr.OP_NOT) && inst.operand_count == 1) {
+        if (is_int(m, inst.ty) == false) { ret false; }
+        val a: value.Value = resolve(inst.operands[0], subst, has_sub, ilen);
+        if (a.kind != value.VAL_INSTR) { ret false; }
+        val inner_opt: Option[*instr.Instruction] = ir.get_instruction(fn, a.data.instr);
+        if (is_none[*instr.Instruction](inner_opt)) { ret false; }
+        val inner: *instr.Instruction = unwrap[*instr.Instruction](inner_opt);
+        # the inner op must be the same negation and integer-typed; then its
+        # operand is the original value, returned with this result's type.
+        if (inner.kind == k && inner.operand_count == 1 && is_int(m, inner.ty)) {
+            val src: value.Value = resolve(inner.operands[0], subst, has_sub, ilen);
+            @out = value.retype(src, inst.ty);
+            ret true;
+        }
+        ret false;
+    }
+
+    # binary identities: [lhs, rhs]. integer result types only.
+    if (is_simplifiable_binary(k) && inst.operand_count == 2) {
+        if (is_int(m, inst.ty) == false) { ret false; }
+        val a: value.Value = resolve(inst.operands[0], subst, has_sub, ilen);
+        val b: value.Value = resolve(inst.operands[1], subst, has_sub, ilen);
+        ret simplify_binary(m, k, a, b, inst.ty, out);
+    }
+
+    ret false;
+}
+
+# true for the binary opcodes this pass recognises identities for.
+fun is_simplifiable_binary(k: instr.InstrKind) bool {
+    if (k == instr.OP_ADD || k == instr.OP_SUB || k == instr.OP_MUL)     { ret true; }
+    if (k == instr.OP_DIV_S || k == instr.OP_DIV_U)                      { ret true; }
+    if (k == instr.OP_REM_S || k == instr.OP_REM_U)                      { ret true; }
+    if (k == instr.OP_AND || k == instr.OP_OR || k == instr.OP_XOR)      { ret true; }
+    if (k == instr.OP_SHL || k == instr.OP_SHR_S || k == instr.OP_SHR_U) { ret true; }
+    ret false;
+}
+
+# applies the binary identities for opcode `k` on resolved operands a, b with
+# integer result type `res_ty`. Writes the replacement into `out` and returns
+# true on a rewrite. The replacement is one of the operands (the surviving
+# operand) or a fresh integer constant (0 / all-ones).
+fun simplify_binary(m: *ir.Module, k: instr.InstrKind, a: value.Value, b: value.Value,
+                    res_ty: ir_type.IrTypeId, out: *value.Value) bool {
+    val bits: u32 = int_bits(m, res_ty);
+    if (bits == 0) { ret false; }
+
+    val a_zero: bool = is_int_zero(a);
+    val b_zero: bool = is_int_zero(b);
+    val a_one:  bool = is_int_one(a);
+    val b_one:  bool = is_int_one(b);
+    val a_ones: bool = is_int_all_ones(a, bits);
+    val b_ones: bool = is_int_all_ones(b, bits);
+    val same:   bool = same_value(a, b);
+
+    if (k == instr.OP_ADD) {
+        # x + 0 -> x, 0 + x -> x
+        if (b_zero) { @out = value.retype(a, res_ty); ret true; }
+        if (a_zero) { @out = value.retype(b, res_ty); ret true; }
+        ret false;
+    }
+    if (k == instr.OP_SUB) {
+        # x - 0 -> x, x - x -> 0
+        if (b_zero) { @out = value.retype(a, res_ty); ret true; }
+        if (same)   { @out = value.const_int(0, res_ty); ret true; }
+        ret false;
+    }
+    if (k == instr.OP_MUL) {
+        # x * 1 -> x, 1 * x -> x, x * 0 -> 0, 0 * x -> 0
+        if (b_one)  { @out = value.retype(a, res_ty); ret true; }
+        if (a_one)  { @out = value.retype(b, res_ty); ret true; }
+        if (b_zero) { @out = value.const_int(0, res_ty); ret true; }
+        if (a_zero) { @out = value.const_int(0, res_ty); ret true; }
+        ret false;
+    }
+    if (k == instr.OP_DIV_S || k == instr.OP_DIV_U) {
+        # x / 1 -> x (division by zero is never an identity and traps).
+        if (b_one) { @out = value.retype(a, res_ty); ret true; }
+        ret false;
+    }
+    if (k == instr.OP_REM_S || k == instr.OP_REM_U) {
+        # x % 1 -> 0 (every integer is divisible by one).
+        if (b_one) { @out = value.const_int(0, res_ty); ret true; }
+        ret false;
+    }
+    if (k == instr.OP_AND) {
+        # x & x -> x, x & 0 -> 0, x & ~0 -> x
+        if (same)   { @out = value.retype(a, res_ty); ret true; }
+        if (b_zero) { @out = value.const_int(0, res_ty); ret true; }
+        if (a_zero) { @out = value.const_int(0, res_ty); ret true; }
+        if (b_ones) { @out = value.retype(a, res_ty); ret true; }
+        if (a_ones) { @out = value.retype(b, res_ty); ret true; }
+        ret false;
+    }
+    if (k == instr.OP_OR) {
+        # x | x -> x, x | 0 -> x, x | ~0 -> ~0
+        if (same)   { @out = value.retype(a, res_ty); ret true; }
+        if (b_zero) { @out = value.retype(a, res_ty); ret true; }
+        if (a_zero) { @out = value.retype(b, res_ty); ret true; }
+        if (b_ones) { @out = value.const_int(all_ones(bits), res_ty); ret true; }
+        if (a_ones) { @out = value.const_int(all_ones(bits), res_ty); ret true; }
+        ret false;
+    }
+    if (k == instr.OP_XOR) {
+        # x ^ x -> 0, x ^ 0 -> x
+        if (same)   { @out = value.const_int(0, res_ty); ret true; }
+        if (b_zero) { @out = value.retype(a, res_ty); ret true; }
+        if (a_zero) { @out = value.retype(b, res_ty); ret true; }
+        ret false;
+    }
+    if (k == instr.OP_SHL || k == instr.OP_SHR_S || k == instr.OP_SHR_U) {
+        # x << 0 -> x, x >> 0 -> x, 0 << c -> 0, 0 >> c -> 0
+        if (b_zero) { @out = value.retype(a, res_ty); ret true; }
+        if (a_zero) { @out = value.const_int(0, res_ty); ret true; }
+        ret false;
+    }
+    ret false;
+}
+
+# true when `v` is the integer constant 0 (the additive / xor / or identity and
+# the multiplicative / and annihilator).
+fun is_int_zero(v: value.Value) bool {
+    ret v.kind == value.VAL_CONST_INT && v.data.int_lit == 0;
+}
+
+# true when `v` is the integer constant 1 (the multiplicative identity).
+fun is_int_one(v: value.Value) bool {
+    ret v.kind == value.VAL_CONST_INT && v.data.int_lit == 1;
+}
+
+# true when `v` is the all-ones constant for a `bits`-wide integer (the bitwise
+# `and` identity / `or` annihilator), comparing only the low `bits` bits.
+fun is_int_all_ones(v: value.Value, bits: u32) bool {
+    if (v.kind != value.VAL_CONST_INT) { ret false; }
+    ret mask(v.data.int_lit, bits) == all_ones(bits);
+}
+
+# the all-ones bit pattern for a `bits`-wide integer.
+fun all_ones(bits: u32) u64 {
+    if (bits >= 64) { ret 0xFFFFFFFFFFFFFFFF; }
+    ret (1::u64 << bits::u64) - 1;
+}
+
+# masks `v` to its low `bits` bits (a 64-bit value passes through unchanged).
+fun mask(v: u64, bits: u32) u64 {
+    if (bits >= 64) { ret v; }
+    val m: u64 = (1::u64 << bits::u64) - 1;
+    ret v & m;
+}
+
+# true when two resolved operands name the exact same SSA value, so they are
+# guaranteed to evaluate identically at runtime. Only instruction results and
+# parameters are treated as "same"; an all-constant expression is constfold's
+# job. Two VAL_INSTR match iff they name the same instruction id; two VAL_PARAM
+# iff the same parameter index.
+fun same_value(a: value.Value, b: value.Value) bool {
+    if (a.kind != b.kind) { ret false; }
+    if (a.kind == value.VAL_INSTR) { ret a.data.instr == b.data.instr; }
+    if (a.kind == value.VAL_PARAM) { ret a.data.param_ix == b.data.param_ix; }
+    ret false;
+}
+
+# true when `tid` resolves to an IRT_INT type (the only types simplified here).
+fun is_int(m: *ir.Module, tid: ir_type.IrTypeId) bool {
+    ret int_bits(m, tid) != 0;
+}
+
+# returns the bit width of an IRT_INT type, or 0 when the id does not resolve to
+# an integer type (the caller declines to simplify).
+fun int_bits(m: *ir.Module, tid: ir_type.IrTypeId) u32 {
+    val got: Option[*ir_type.IrType] = ir_type.get(?m.types, tid);
+    if (is_none[*ir_type.IrType](got)) { ret 0; }
+    val t: *ir_type.IrType = unwrap[*ir_type.IrType](got);
+    if (t.kind != ir_type.IRT_INT) { ret 0; }
+    ret t.data.bits;
+}
+
+# rewrites every operand of every instruction that names a simplified
+# instruction to its replacement. Operands are resolved transitively through the
+# table (via `resolve`) so a chain of simplifications collapses fully.
+fun apply_substitutions(fn: *ir.Function, subst: *value.Value, has_sub: *bool, ilen: u32) {
+    var i: u32 = 0;
+    for (i < fn.instr_len) {
+        val inst: *instr.Instruction = ?fn.instrs[i];
+        var o: u32 = 0;
+        for (o < inst.operand_count) {
+            val op: value.Value = inst.operands[o];
+            if (op.kind == value.VAL_INSTR) {
+                val iid: u32 = op.data.instr::u32;
+                if (iid < ilen && has_sub[iid]) {
+                    inst.operands[o] = resolve(op, subst, has_sub, ilen);
+                }
+            }
+            o = o + 1;
+        }
+        i = i + 1;
+    }
+}

--- a/src/lang/me/pass/cse.mach
+++ b/src/lang/me/pass/cse.mach
@@ -1,0 +1,248 @@
+# mach.lang.me.pass.cse: local common-subexpression elimination.
+#
+# A forward pass that, within each basic block, replaces a redundant pure
+# instruction — one whose opcode, flags, result type, auxiliary type, and
+# operand list exactly match an earlier instruction in the same block — with a
+# reference to that earlier result. The redundant instruction is left in the
+# pool with its uses rewritten away; dce then removes it.
+#
+# The transform is LOCAL: an expression is only reused within the single block
+# that first computed it. Within one block there is no intervening control flow,
+# so two instructions with identical (resolved) operands provably compute the
+# same value. Operands are compared after applying the running substitution, so
+# `b = a + 1; c = a + 1; d = b + c` canonicalises `c` to `b` and then matches
+# the two `b` operands of `d`.
+#
+# CORRECTNESS CONTRACT: only PURE, value-producing opcodes are candidates
+# (`instr.is_pure`). This excludes loads (an intervening store may change the
+# loaded value), stores, calls, alloca, phis, terminators, inline asm, and the
+# variadic intrinsics. Two candidates are equal only when their opcode, flag
+# word, result type, auxiliary type, operand count, and every (resolved) operand
+# match exactly — so a no-signed-wrap add never merges with a wrapping add, and
+# a GEP only merges with a GEP walking the same source pointee type. Division
+# and remainder ARE pure, but CSE of two identical divisions is value-preserving
+# (a trap on division by zero happens identically for both, and merging removes
+# only the second, still-trapping, computation if the first is reached); a
+# divide-by-zero never miscompiles because the surviving instruction performs
+# the same operation. Because matching is by exact value identity, a substitution
+# never changes which value an operand names — it only shares an equal one.
+
+use std.types.bool.bool;
+use std.types.bool.true;
+use std.types.bool.false;
+use std.types.size.usize;
+use std.types.string.str;
+use std.types.option.Option;
+use std.types.option.is_some;
+use std.types.option.unwrap;
+use std.types.result.Result;
+use std.types.result.ok;
+use std.types.result.err;
+use std.types.result.is_err;
+use std.types.result.unwrap_ok;
+use std.types.result.unwrap_err;
+
+use std.allocator.allocate;
+use std.allocator.deallocate;
+
+use ir:    mach.lang.me.ir;
+use instr: mach.lang.me.ir.instruction;
+use value: mach.lang.me.ir.value;
+use id:    mach.lang.me.ir.id;
+
+# Pass entry. Runs local CSE on every non-extern function in the module.
+# ---
+# m:   module to mutate in place
+# ret: ok(true) on a successful pass, or the first allocation error
+pub fun run(m: *ir.Module) Result[bool, str] {
+    var f: u32 = 0;
+    for (f < m.function_len) {
+        val fn: *ir.Function = ?m.functions[f];
+        if ((fn.flags & ir.FN_FLAG_EXTERN) == 0) {
+            val r: Result[bool, str] = cse_function(m, fn);
+            if (is_err[bool, str](r)) { ret r; }
+        }
+        f = f + 1;
+    }
+    ret ok[bool, str](true);
+}
+
+# runs local CSE on one function. A per-instruction substitution table maps a
+# redundant instruction id to the canonical (earlier) instruction's result
+# Value; `has_sub` marks live entries. Each block is processed independently:
+# instructions are visited in program order, and a candidate that matches an
+# earlier in-block candidate records a substitution. After every block the
+# substitutions are applied to every operand in the function.
+fun cse_function(m: *ir.Module, fn: *ir.Function) Result[bool, str] {
+    val ilen: u32 = fn.instr_len;
+    if (ilen == 0) { ret ok[bool, str](true); }
+
+    val rs: Result[*value.Value, str] = allocate[value.Value](m.alloc, ilen::usize);
+    if (is_err[*value.Value, str](rs)) { ret err[bool, str](unwrap_err[*value.Value, str](rs)); }
+    val subst: *value.Value = unwrap_ok[*value.Value, str](rs);
+
+    val rh: Result[*bool, str] = allocate[bool](m.alloc, ilen::usize);
+    if (is_err[*bool, str](rh)) {
+        deallocate[value.Value](m.alloc, subst, ilen::usize);
+        ret err[bool, str](unwrap_err[*bool, str](rh));
+    }
+    val has_sub: *bool = unwrap_ok[*bool, str](rh);
+
+    # `seen` collects the canonical (kept) candidate instruction ids of the block
+    # currently being processed; it is reused per block.
+    val rw: Result[*id.InstructionId, str] = allocate[id.InstructionId](m.alloc, ilen::usize);
+    if (is_err[*id.InstructionId, str](rw)) {
+        deallocate[value.Value](m.alloc, subst, ilen::usize);
+        deallocate[bool](m.alloc, has_sub, ilen::usize);
+        ret err[bool, str](unwrap_err[*id.InstructionId, str](rw));
+    }
+    val seen: *id.InstructionId = unwrap_ok[*id.InstructionId, str](rw);
+
+    var i: u32 = 0;
+    for (i < ilen) { has_sub[i] = false; i = i + 1; }
+
+    var any: bool = false;
+    var b: u32 = 0;
+    for (b < fn.block_count) {
+        if (cse_block(m, fn, ?fn.blocks[b], subst, has_sub, ilen, seen)) { any = true; }
+        b = b + 1;
+    }
+    if (any) { apply_substitutions(fn, subst, has_sub, ilen); }
+
+    deallocate[value.Value](m.alloc, subst, ilen::usize);
+    deallocate[bool](m.alloc, has_sub, ilen::usize);
+    deallocate[id.InstructionId](m.alloc, seen, ilen::usize);
+    ret ok[bool, str](true);
+}
+
+# processes one block: walks its instruction list in order, and for each pure
+# candidate either matches it against an already-seen canonical candidate (and
+# records a substitution to that candidate's result) or records it as a new
+# canonical candidate. Returns true if any substitution was recorded.
+fun cse_block(m: *ir.Module, fn: *ir.Function, blk: *ir.Block,
+              subst: *value.Value, has_sub: *bool, ilen: u32, seen: *id.InstructionId) bool {
+    var any: bool = false;
+    var seen_count: u32 = 0;
+    var ix: u32 = 0;
+    for (ix < blk.instr_count) {
+        val iid: id.InstructionId = blk.instructions[ix];
+        val inst_opt: Option[*instr.Instruction] = ir.get_instruction(fn, iid);
+        if (is_some[*instr.Instruction](inst_opt)) {
+            val inst: *instr.Instruction = unwrap[*instr.Instruction](inst_opt);
+            if (is_candidate(inst)) {
+                # search the canonical candidates already seen in this block.
+                var matched: bool = false;
+                var s: u32 = 0;
+                for (s < seen_count && matched == false) {
+                    val cid: id.InstructionId = seen[s];
+                    val cand_opt: Option[*instr.Instruction] = ir.get_instruction(fn, cid);
+                    if (is_some[*instr.Instruction](cand_opt)) {
+                        val cand: *instr.Instruction = unwrap[*instr.Instruction](cand_opt);
+                        if (instrs_equal(inst, cand, subst, has_sub, ilen)) {
+                            # redundant: reuse the canonical candidate's result.
+                            subst[iid::u32]   = value.instr_value(cid, inst.ty);
+                            has_sub[iid::u32] = true;
+                            matched           = true;
+                            any               = true;
+                        }
+                    }
+                    s = s + 1;
+                }
+                if (matched == false) {
+                    seen[seen_count] = iid;
+                    seen_count       = seen_count + 1;
+                }
+            }
+        }
+        ix = ix + 1;
+    }
+    ret any;
+}
+
+# true when an instruction is a CSE candidate: a pure, value-producing opcode
+# with no volatile flag. Pure already excludes loads/stores/calls/alloca/phi/
+# terminators/asm/va_*; the volatile guard is belt-and-braces (volatile rides on
+# loads/stores, which are not pure, but the check costs nothing).
+fun is_candidate(inst: *instr.Instruction) bool {
+    if (instr.is_pure(inst.kind) == false) { ret false; }
+    if ((inst.flags & instr.INSTR_FLAG_VOLATILE) != 0) { ret false; }
+    ret true;
+}
+
+# true when two candidate instructions compute the same value: identical opcode,
+# flag word, result type, auxiliary type, operand count, and every operand equal
+# by value identity after resolving each through the substitution table. The
+# substitution resolution canonicalises operands that were themselves CSE'd, so
+# transitively-equal expressions match.
+fun instrs_equal(a: *instr.Instruction, b: *instr.Instruction,
+                 subst: *value.Value, has_sub: *bool, ilen: u32) bool {
+    if (a.kind != b.kind) { ret false; }
+    if (a.flags != b.flags) { ret false; }
+    if (a.ty != b.ty) { ret false; }
+    if (a.aux_ty != b.aux_ty) { ret false; }
+    if (a.operand_count != b.operand_count) { ret false; }
+    var o: u32 = 0;
+    for (o < a.operand_count) {
+        val va: value.Value = resolve(a.operands[o], subst, has_sub, ilen);
+        val vb: value.Value = resolve(b.operands[o], subst, has_sub, ilen);
+        if (values_equal(va, vb) == false) { ret false; }
+        o = o + 1;
+    }
+    ret true;
+}
+
+# true when two operand values are the exact same SSA value or the same constant
+# literal. Instruction results match by id; parameters by index; integer / null
+# / float constants by payload; globals / functions by index. Byte-blob
+# constants are conservatively treated as unequal (a pointer-identity match on a
+# borrowed blob is not worth the risk). The carried IR type need not match — two
+# operands naming the same value through differently-typed slots still denote it.
+fun values_equal(a: value.Value, b: value.Value) bool {
+    if (a.kind != b.kind) { ret false; }
+    if (a.kind == value.VAL_INSTR)       { ret a.data.instr == b.data.instr; }
+    if (a.kind == value.VAL_PARAM)       { ret a.data.param_ix == b.data.param_ix; }
+    if (a.kind == value.VAL_CONST_INT)   { ret a.data.int_lit == b.data.int_lit; }
+    if (a.kind == value.VAL_CONST_NULL)  { ret true; }
+    if (a.kind == value.VAL_CONST_FLOAT) { ret a.data.float_lit == b.data.float_lit; }
+    if (a.kind == value.VAL_GLOBAL)      { ret a.data.global_ix == b.data.global_ix; }
+    if (a.kind == value.VAL_FN)          { ret a.data.fn_ix == b.data.fn_ix; }
+    ret false;
+}
+
+# resolves an operand through the substitution table, following chains: a
+# VAL_INSTR naming a CSE'd instruction becomes the canonical instruction's
+# result, followed again if that canonical was itself merged, up to `ilen` hops
+# (the table is acyclic; the bound is a guard). Non-instruction operands pass
+# through unchanged. The result carries the original operand's type.
+fun resolve(v: value.Value, subst: *value.Value, has_sub: *bool, ilen: u32) value.Value {
+    var cur: value.Value = v;
+    var hops: u32 = 0;
+    for (cur.kind == value.VAL_INSTR && hops <= ilen) {
+        val iid: u32 = cur.data.instr::u32;
+        if (iid >= ilen || has_sub[iid] == false) { ret value.retype(cur, v.ty); }
+        cur  = subst[iid];
+        hops = hops + 1;
+    }
+    ret value.retype(cur, v.ty);
+}
+
+# rewrites every operand naming a CSE'd instruction to its canonical result,
+# resolved transitively so a chain of merges collapses fully.
+fun apply_substitutions(fn: *ir.Function, subst: *value.Value, has_sub: *bool, ilen: u32) {
+    var i: u32 = 0;
+    for (i < fn.instr_len) {
+        val inst: *instr.Instruction = ?fn.instrs[i];
+        var o: u32 = 0;
+        for (o < inst.operand_count) {
+            val op: value.Value = inst.operands[o];
+            if (op.kind == value.VAL_INSTR) {
+                val iid: u32 = op.data.instr::u32;
+                if (iid < ilen && has_sub[iid]) {
+                    inst.operands[o] = resolve(op, subst, has_sub, ilen);
+                }
+            }
+            o = o + 1;
+        }
+        i = i + 1;
+    }
+}

--- a/src/lang/me/pipeline.mach
+++ b/src/lang/me/pipeline.mach
@@ -25,6 +25,8 @@ use ir:        mach.lang.me.ir;
 use verify:    mach.lang.me.ir.verify;
 use mem2reg:   mach.lang.me.pass.mem2reg;
 use constfold: mach.lang.me.pass.constfold;
+use algebraic: mach.lang.me.pass.algebraic;
+use cse:       mach.lang.me.pass.cse;
 use dce:       mach.lang.me.pass.dce;
 use inline:    mach.lang.me.pass.inline;
 use target:    mach.lang.target;
@@ -35,8 +37,9 @@ pub def OptLevel: u8;
 # debug optimisation (`-O0`): the always-on sequence — mem2reg, constfold, dce.
 # Default for `mach build`.
 pub val OPT_DEBUG:   OptLevel = 0;
-# release optimisation (`-O1`+): the always-on sequence plus inline and a late
-# constfold/dce sweep over the inlined bodies.
+# release optimisation (`-O1`+): the always-on sequence plus inline, then a late
+# algebraic-simplification / local-CSE / constfold / dce sweep over the inlined
+# bodies.
 pub val OPT_RELEASE: OptLevel = 1;
 
 # Drives the middle-end pipeline over `m` at the requested level. Always runs
@@ -109,7 +112,37 @@ pub fun run(m: *ir.Module, tgt: *target.Target, level: OptLevel, verify_ir: bool
             if (is_err[bool, str](rvc1)) { ret rvc1; }
         }
 
-        # late dce: sweep up now-dead calls and branches from inlining.
+        # algebraic simplification: peephole identities (x+0, x*1, x&x, x^x, …)
+        # the all-constant cases constfold cannot reach. value-preserving by
+        # construction (integer-only where float semantics differ).
+        val ra: Result[bool, str] = algebraic.run(m);
+        if (is_err[bool, str](ra)) { ret ra; }
+        if (verify_ir) {
+            val rva: Result[bool, str] = run_verify(m, false, true);
+            if (is_err[bool, str](rva)) { ret rva; }
+        }
+
+        # local CSE: within each block, share a redundant pure computation with
+        # the earlier identical one. inlining frequently duplicates address /
+        # arithmetic expressions across a call boundary, which this collapses.
+        val rcs: Result[bool, str] = cse.run(m);
+        if (is_err[bool, str](rcs)) { ret rcs; }
+        if (verify_ir) {
+            val rvcs: Result[bool, str] = run_verify(m, false, true);
+            if (is_err[bool, str](rvcs)) { ret rvcs; }
+        }
+
+        # second constfold: algebra/CSE expose constants (e.g. x*0 -> 0) and may
+        # feed a constant condition to a branch; fold and simplify before dce.
+        val rcf2: Result[bool, str] = constfold.run(m);
+        if (is_err[bool, str](rcf2)) { ret rcf2; }
+        if (verify_ir) {
+            val rvc2: Result[bool, str] = run_verify(m, false, true);
+            if (is_err[bool, str](rvc2)) { ret rvc2; }
+        }
+
+        # late dce: sweep up now-dead calls, branches, and the instructions left
+        # dead by simplification / CSE.
         val rd1: Result[bool, str] = dce.run(m);
         if (is_err[bool, str](rd1)) { ret rd1; }
         if (verify_ir) {


### PR DESCRIPTION
Advances the optimization story (#1049) by adding two value-preserving mid-end passes that run in the release (`-O1`/`-O2`) pipeline after inlining and the late constfold.

## Passes added

### Algebraic simplification (`me/pass/algebraic.mach`)
Peephole identities on **integer** IR with exact semantics, recorded via a substitution table (same model as constfold) and applied across the function; dead instructions are left for dce:

- `x+0` / `0+x` / `x-0` -> `x`
- `x*1` / `1*x` -> `x`; `x*0` / `0*x` -> `0`
- `x-x` -> `0`; `x^x` -> `0`
- `x&x` / `x|x` -> `x`; `x&0` -> `0`; `x|0` / `x^0` -> `x`
- `x & ~0` -> `x`; `x | ~0` -> `~0` (all-ones masks)
- `x<<0` / `x>>0` -> `x`; `0<<c` / `0>>c` -> `0`
- `x/1` -> `x`; `x%1` -> `0`
- `-(-x)` / `~(~x)` -> `x` (double negation)

**Integer-only where float semantics differ** — every rewrite first confirms the result type resolves to `IRT_INT`, so float ops (signed zero, NaN, inf cases) are never touched. Division/remainder is only simplified for the exact `/1` and `%1` identities (never `/0`, which traps).

### Local CSE (`me/pass/cse.mach`)
Within each block, a redundant **pure** instruction (matching opcode, flag word, result type, aux type, and resolved operands) is replaced by a reference to the earlier identical one. Conservative: only pure, non-volatile, value-producing opcodes are candidates (loads/stores/calls/phis/terminators excluded). Earlier-in-block matching guarantees the canonical def dominates the redundant use; operands are compared after applying the running substitution so transitively-equal expressions match.

## Pipeline
Release block is now: `inline -> constfold -> algebraic -> cse -> constfold -> dce`. The default/bootstrap pipeline (`-O0`) is unchanged, preserving the byte-identical self-host fixpoint.

## Verification
- `make clean && make`: full bootstrap exit 0.
- `tools/test/differential.sh`: **all 10 examples identical at -O0 vs -O2**, smach vs mach consistent.
- Fixpoint: `out/da/obj` vs `out/db/obj` 0 diffs; self-host `mach` vs `mach2` byte-identical (`cmp` exit 0).
- Spot-check program exercising every identity and a 4-way CSE: correct results at both levels; asm confirms `x*0` eliminated and four duplicate `x*3+7` computations collapsed to one.

## Deliberately left out for correctness
- No float algebraic identities (semantics differ).
- No `x*2 -> x<<1` strength reduction (optional; omitted to keep the pass purely value-identity-based, no benefit on this target).
- No global/cross-block CSE (requires dominance analysis to be correct; local CSE is provably safe within a block).
- Compare identities (`x==x`) skipped (the int/float compare opcodes overlap; not worth the float-safety gymnastics).

Refs #1049
