### PR TITLE
fix(inline): never inline a variadic callee (#1098)

### DIFF
--- a/src/lang/me/pass/inline.mach
+++ b/src/lang/me/pass/inline.mach
@@ -128,10 +128,23 @@ fun should_inline(m: *ir.Module, caller_ix: u32, callee_ix: u32, caller: *ir.Fun
     if (callee_ix == caller_ix) { ret false; }      # direct self-recursion
     if (callee.block_count == 0) { ret false; }      # no body to inline
     if (callee_has_asm(callee)) { ret false; }       # inline asm is never inlined
+    if (callee_is_variadic(m, callee)) { ret false; } # variadic body is not inlinable
     if ((callee.flags & ir.FN_FLAG_INLINE) != 0) { ret true; }
     if (callee_instr_count(callee) < INLINE_INSTR_THRESHOLD) { ret true; }
     if (call_count(m, callee_ix) == 1) { ret true; }
     ret false;
+}
+
+# true when the callee is variadic. its va_start / va_arg read the callee's own
+# register-save-area prologue, which a non-variadic caller never reserves;
+# cloning the body into the caller would reference a save area that does not
+# exist (the backend rejects va_start in a non-variadic function outright).
+fun callee_is_variadic(m: *ir.Module, callee: *ir.Function) bool {
+    val it: Option[*ir_type.IrType] = ir_type.get(?m.types, callee.sig);
+    if (is_none[*ir_type.IrType](it)) { ret false; }
+    val t: *ir_type.IrType = unwrap[*ir_type.IrType](it);
+    if (t.kind != ir_type.IRT_FN) { ret false; }
+    ret t.data.fn.varargs;
 }
 
 # true when the callee contains any OP_ASM instruction in its pool. clone copies


### PR DESCRIPTION
## Summary

`va_arg` used inside a loop with an inner conditional was reported (#1098) to miscompile. Root-causing it showed the va_arg lowering itself is correct at `-O0` for GP, FP, and mixed args (verified against the pre-#1089 compiler too). The actual defect surfaces in the **optimization pipeline**: the inliner had no guard against inlining a **variadic** callee.

A variadic function's `va_start` / `va_arg` read the callee's own register-save-area prologue, which a non-variadic caller never reserves. When the inliner cloned a variadic body into a non-variadic caller (e.g. `main`), the backend rejected the relocated `va_start` with `va_start in a non-variadic function` at `-O2`; even without the hard error the inlined `va_arg` would read a nonexistent save area. The "loop + inner-if" framing in the report was the structure the reporter happened to exercise under differential (`-O0` vs `-O2`) testing — the trigger is any inlinable variadic callee (small, or called exactly once).

## Fix

Add a `callee_is_variadic` guard to `should_inline` (reading the signature's `varargs` flag, mirroring the backend's `fn_sig_is_variadic`). A variadic body is never inlined and stays a real call.

## Verification

- Repro (straight-line, simple-loop, loop+inner-if; GP / FP / mixed int+float) now returns the correct value at **both** `-O0` and `-O2`; the `-O2` "va_start in a non-variadic function" build error is gone.
- `make clean && make` exits 0.
- Self-host fixpoint intact: `out/bin/mach build . -o out/bin/mach2 --artifacts m2 && cmp -s out/bin/mach out/bin/mach2` is byte-identical.
- `tools/test/differential.sh` passes (10 inputs, `-O0`==`-O2`, smach==mach).

Closes #1098
