### PR TITLE
feat(sema): TypeId renderer for expected/found diagnostics

### DIFF
--- a/src/lang/fe/sema/check.mach
+++ b/src/lang/fe/sema/check.mach
@@ -24,18 +24,32 @@ use std.types.option.none;
 use std.types.option.is_some;
 use std.types.option.is_none;
 use std.types.option.unwrap;
+use std.types.char.char;
 use std.types.string.str;
+use std.types.string.str_len;
 use std.types.size.usize;
+use std.types.result.Result;
+use std.types.result.ok;
+use std.types.result.err;
+use std.types.result.is_err;
+use std.types.result.is_ok;
+use std.types.result.unwrap_ok;
+use std.types.result.unwrap_err;
+
+use std.allocator.allocate;
+use std.allocator.deallocate;
 
 use ty:    mach.lang.type;
 use diag:  mach.lang.diagnostic;
 use intern: mach.lang.intern;
+use sess:   mach.lang.session;
 use token: mach.lang.fe.token;
 use ast:   mach.lang.fe.ast;
 use id:    mach.lang.fe.ast.id;
 use expr:  mach.lang.fe.ast.expr;
 use sema:  mach.lang.fe.sema.context;
 use coerce: mach.lang.fe.sema.coerce;
+use generics: mach.lang.fe.sema.generics;
 
 # check_assignable: checks that a value of type `actual` may flow into a slot of type `expected`; callers coerce literals themselves before delegating here, so this is a pure type relation (identity first, then the structural assignability rule from `coerce`), recording a `type mismatch:` diagnostic against `span` on failure.
 # ---
@@ -50,7 +64,7 @@ pub fun check_assignable(sc: *sema.SemaContext, expected: ty.TypeId, actual: ty.
 
     if (coerce.is_assignable(sc, actual, expected)) { ret true; }
 
-    report_note(sc, span, "type mismatch: incompatible types in assignment",
+    report_mismatch(sc, span, expected, actual,
         "mach has no implicit widening; cast the value with `value::Type`");
     ret false;
 }
@@ -357,6 +371,294 @@ pub fun format_type(sc: *sema.SemaContext, t: ty.TypeId) str {
     ret "<type>";
 }
 
+# type_to_str: render `t` to an owned, human-readable spelling for diagnostics.
+# primitives render to their keyword (`i64`, `f32`, `ptr`); a pointer to `*T`;
+# an array to `[N]T`; a record / union / generic parameter to its declared
+# name; a function to `fun(A, B) R`; and a generic instance to `Name[Arg, ...]`.
+# composite forms recurse over their components; an unknown or unnamed type
+# renders to a `<error>` / `<anon>` placeholder. the result is allocated from
+# the session allocator and must be released with type_str_free.
+# ---
+# sc: the active sema context (type universe, interner, AST registry)
+# t:  the type to render
+# ret: an owned, null-terminated spelling, or an allocation error
+pub fun type_to_str(sc: *sema.SemaContext, t: ty.TypeId) Result[str, str] {
+    val n: usize = type_str_len(sc, t);
+    val r: Result[*char, str] = allocate[char](sc.s.alloc, n + 1);
+    if (is_err[*char, str](r)) { ret err[str, str](unwrap_err[*char, str](r)); }
+    val buf: str = unwrap_ok[*char, str](r);
+    val w: usize = write_type_str(sc, buf, 0, t);
+    buf[w] = 0;
+    ret ok[str, str](buf);
+}
+
+# type_str_free: release a string returned by type_to_str.
+# ---
+# sc: the sema context whose allocator backed the string
+# s:  the owned string to free (nil is a no-op)
+pub fun type_str_free(sc: *sema.SemaContext, s: str) {
+    if (s == nil) { ret; }
+    deallocate[char](sc.s.alloc, s, str_len(s) + 1);
+}
+
+# type_str_len: the byte length type_to_str will write for `t`, excluding the
+# null terminator. mirrors write_type_str branch-for-branch so the single
+# allocation in type_to_str is sized exactly.
+fun type_str_len(sc: *sema.SemaContext, t: ty.TypeId) usize {
+    if (t == ty.TYPE_U8)  { ret 2; }
+    if (t == ty.TYPE_U16) { ret 3; }
+    if (t == ty.TYPE_U32) { ret 3; }
+    if (t == ty.TYPE_U64) { ret 3; }
+    if (t == ty.TYPE_I8)  { ret 2; }
+    if (t == ty.TYPE_I16) { ret 3; }
+    if (t == ty.TYPE_I32) { ret 3; }
+    if (t == ty.TYPE_I64) { ret 3; }
+    if (t == ty.TYPE_F32) { ret 3; }
+    if (t == ty.TYPE_F64) { ret 3; }
+    if (t == ty.TYPE_PTR) { ret 3; }
+    if (t == ty.TYPE_ERROR || t == ty.TYPE_NIL) { ret 7; }
+
+    val t_opt: Option[*ty.Type] = ty.get(?sc.s.types, t);
+    if (is_none[*ty.Type](t_opt)) { ret 7; }
+    val tp: *ty.Type = unwrap[*ty.Type](t_opt);
+    val k: ty.TypeKind = tp.kind;
+
+    if (k == ty.TYPE_VA_LIST) { ret 7; }
+    if (k == ty.TYPE_POINTER) {
+        ret 1 + type_str_len(sc, tp.data.pointer.base);
+    }
+    if (k == ty.TYPE_ARRAY) {
+        ret 1 + decimal_len(tp.data.array.count::usize) + 1 + type_str_len(sc, tp.data.array.base);
+    }
+    if (k == ty.TYPE_REC || k == ty.TYPE_UNI) {
+        ret name_str_len(sc, tp.data.nominal.name);
+    }
+    if (k == ty.TYPE_GENERIC_PARAM) {
+        ret name_str_len(sc, tp.data.generic_param.name);
+    }
+    if (k == ty.TYPE_INSTANCE) {
+        ret instance_str_len(sc, tp);
+    }
+    if (k == ty.TYPE_FUN) {
+        ret fun_str_len(sc, tp);
+    }
+    ret 7;
+}
+
+# write_type_str: write type_to_str's spelling for `t` into `buf` at offset
+# `k`, returning the offset just past it.
+fun write_type_str(sc: *sema.SemaContext, buf: str, k: usize, t: ty.TypeId) usize {
+    if (t == ty.TYPE_U8)  { ret write_kw(buf, k, "u8"); }
+    if (t == ty.TYPE_U16) { ret write_kw(buf, k, "u16"); }
+    if (t == ty.TYPE_U32) { ret write_kw(buf, k, "u32"); }
+    if (t == ty.TYPE_U64) { ret write_kw(buf, k, "u64"); }
+    if (t == ty.TYPE_I8)  { ret write_kw(buf, k, "i8"); }
+    if (t == ty.TYPE_I16) { ret write_kw(buf, k, "i16"); }
+    if (t == ty.TYPE_I32) { ret write_kw(buf, k, "i32"); }
+    if (t == ty.TYPE_I64) { ret write_kw(buf, k, "i64"); }
+    if (t == ty.TYPE_F32) { ret write_kw(buf, k, "f32"); }
+    if (t == ty.TYPE_F64) { ret write_kw(buf, k, "f64"); }
+    if (t == ty.TYPE_PTR) { ret write_kw(buf, k, "ptr"); }
+    if (t == ty.TYPE_ERROR || t == ty.TYPE_NIL) { ret write_kw(buf, k, "<error>"); }
+
+    val t_opt: Option[*ty.Type] = ty.get(?sc.s.types, t);
+    if (is_none[*ty.Type](t_opt)) { ret write_kw(buf, k, "<error>"); }
+    val tp: *ty.Type = unwrap[*ty.Type](t_opt);
+    val kk: ty.TypeKind = tp.kind;
+
+    if (kk == ty.TYPE_VA_LIST) { ret write_kw(buf, k, "va_list"); }
+    if (kk == ty.TYPE_POINTER) {
+        buf[k] = '*';
+        ret write_type_str(sc, buf, k + 1, tp.data.pointer.base);
+    }
+    if (kk == ty.TYPE_ARRAY) {
+        buf[k] = '[';
+        var w: usize = write_decimal(buf, k + 1, tp.data.array.count::usize);
+        buf[w] = ']'; w = w + 1;
+        ret write_type_str(sc, buf, w, tp.data.array.base);
+    }
+    if (kk == ty.TYPE_REC || kk == ty.TYPE_UNI) {
+        ret write_name(sc, buf, k, tp.data.nominal.name);
+    }
+    if (kk == ty.TYPE_GENERIC_PARAM) {
+        ret write_name(sc, buf, k, tp.data.generic_param.name);
+    }
+    if (kk == ty.TYPE_INSTANCE) {
+        ret write_instance(sc, buf, k, tp);
+    }
+    if (kk == ty.TYPE_FUN) {
+        ret write_fun(sc, buf, k, tp);
+    }
+    ret write_kw(buf, k, "<error>");
+}
+
+# instance_str_len / write_instance: a generic instance renders as
+# `Name[Arg, ...]`, the name recovered from the generic declaration via
+# generics.generic_nominal_of and the arguments rendered recursively.
+fun instance_str_len(sc: *sema.SemaContext, tp: *ty.Type) usize {
+    var total: usize = instance_name_len(sc, tp);
+    total = total + 1;
+    val astart: u32 = tp.data.instance.args_start;
+    val alen:   u32 = tp.data.instance.args_len;
+    var i: u32 = 0;
+    for (i < alen) {
+        if (i > 0) { total = total + 2; }
+        total = total + type_str_len(sc, instance_arg(sc, astart + i));
+        i = i + 1;
+    }
+    total = total + 1;
+    ret total;
+}
+
+fun write_instance(sc: *sema.SemaContext, buf: str, k: usize, tp: *ty.Type) usize {
+    var w: usize = write_instance_name(sc, buf, k, tp);
+    buf[w] = '['; w = w + 1;
+    val astart: u32 = tp.data.instance.args_start;
+    val alen:   u32 = tp.data.instance.args_len;
+    var i: u32 = 0;
+    for (i < alen) {
+        if (i > 0) { buf[w] = ','; w = w + 1; buf[w] = ' '; w = w + 1; }
+        w = write_type_str(sc, buf, w, instance_arg(sc, astart + i));
+        i = i + 1;
+    }
+    buf[w] = ']'; w = w + 1;
+    ret w;
+}
+
+# instance_arg: the concrete argument TypeId at pool slot `idx`, or TYPE_ERROR
+# when out of range so rendering stays total.
+fun instance_arg(sc: *sema.SemaContext, idx: u32) ty.TypeId {
+    val a_opt: Option[ty.TypeId] = ty.get_param(?sc.s.types, idx);
+    if (is_none[ty.TypeId](a_opt)) { ret ty.TYPE_ERROR; }
+    ret unwrap[ty.TypeId](a_opt);
+}
+
+# instance_name_len / write_instance_name: the generic's declared name,
+# recovered through generics.generic_nominal_of (which re-interns the name the
+# declaring module used). falls back to `<anon>` when the declaration cannot be
+# reached.
+fun instance_name_len(sc: *sema.SemaContext, tp: *ty.Type) usize {
+    val gnom: ty.TypeId = generics.generic_nominal_of(sc.s, tp.data.instance.target_origin, tp.data.instance.target_decl);
+    val nm: intern.StrId = nominal_name_of(sc, gnom);
+    if (nm == intern.STR_NIL) { ret 6; }
+    ret name_str_len(sc, nm);
+}
+
+fun write_instance_name(sc: *sema.SemaContext, buf: str, k: usize, tp: *ty.Type) usize {
+    val gnom: ty.TypeId = generics.generic_nominal_of(sc.s, tp.data.instance.target_origin, tp.data.instance.target_decl);
+    val nm: intern.StrId = nominal_name_of(sc, gnom);
+    if (nm == intern.STR_NIL) { ret write_kw(buf, k, "<anon>"); }
+    ret write_name(sc, buf, k, nm);
+}
+
+# nominal_name_of: the `name` StrId of a nominal TypeId, or STR_NIL when `t` is
+# not a registered nominal.
+fun nominal_name_of(sc: *sema.SemaContext, t: ty.TypeId) intern.StrId {
+    if (t == ty.TYPE_ERROR || t == ty.TYPE_NIL) { ret intern.STR_NIL; }
+    val t_opt: Option[*ty.Type] = ty.get(?sc.s.types, t);
+    if (is_none[*ty.Type](t_opt)) { ret intern.STR_NIL; }
+    val tp: *ty.Type = unwrap[*ty.Type](t_opt);
+    if (tp.kind != ty.TYPE_REC && tp.kind != ty.TYPE_UNI) { ret intern.STR_NIL; }
+    ret tp.data.nominal.name;
+}
+
+# fun_str_len / write_fun: a function type renders as `fun(A, B) R`, with a void
+# return rendered as the bare `fun(A, B)` (no trailing type).
+fun fun_str_len(sc: *sema.SemaContext, tp: *ty.Type) usize {
+    var total: usize = 4;
+    val pstart: u32 = tp.data.fn.params_start;
+    val plen:   u32 = tp.data.fn.params_len;
+    var i: u32 = 0;
+    for (i < plen) {
+        if (i > 0) { total = total + 2; }
+        total = total + type_str_len(sc, instance_arg(sc, pstart + i));
+        i = i + 1;
+    }
+    if (tp.data.fn.variadic) {
+        if (plen > 0) { total = total + 2; }
+        total = total + 3;
+    }
+    total = total + 1;
+    if (tp.data.fn.ret_ty != ty.TYPE_NIL) {
+        total = total + 1 + type_str_len(sc, tp.data.fn.ret_ty);
+    }
+    ret total;
+}
+
+fun write_fun(sc: *sema.SemaContext, buf: str, k: usize, tp: *ty.Type) usize {
+    var w: usize = write_kw(buf, k, "fun");
+    buf[w] = '('; w = w + 1;
+    val pstart: u32 = tp.data.fn.params_start;
+    val plen:   u32 = tp.data.fn.params_len;
+    var i: u32 = 0;
+    for (i < plen) {
+        if (i > 0) { buf[w] = ','; w = w + 1; buf[w] = ' '; w = w + 1; }
+        w = write_type_str(sc, buf, w, instance_arg(sc, pstart + i));
+        i = i + 1;
+    }
+    if (tp.data.fn.variadic) {
+        if (plen > 0) { buf[w] = ','; w = w + 1; buf[w] = ' '; w = w + 1; }
+        w = write_kw(buf, w, "...");
+    }
+    buf[w] = ')'; w = w + 1;
+    if (tp.data.fn.ret_ty != ty.TYPE_NIL) {
+        buf[w] = ' '; w = w + 1;
+        w = write_type_str(sc, buf, w, tp.data.fn.ret_ty);
+    }
+    ret w;
+}
+
+# name_str_len / write_name: an interned identifier, falling back to `<anon>`
+# when the StrId is nil or unresolvable.
+fun name_str_len(sc: *sema.SemaContext, name: intern.StrId) usize {
+    val no: Option[str] = intern.lookup(?sc.s.interner, name);
+    if (is_none[str](no)) { ret 6; }
+    val nm: str = unwrap[str](no);
+    if (str_len(nm) == 0) { ret 6; }
+    ret str_len(nm);
+}
+
+fun write_name(sc: *sema.SemaContext, buf: str, k: usize, name: intern.StrId) usize {
+    val no: Option[str] = intern.lookup(?sc.s.interner, name);
+    if (is_none[str](no)) { ret write_kw(buf, k, "<anon>"); }
+    val nm: str = unwrap[str](no);
+    if (str_len(nm) == 0) { ret write_kw(buf, k, "<anon>"); }
+    ret write_kw(buf, k, nm);
+}
+
+# write_kw: copy a string's bytes into `buf` at offset `k`, returning the new
+# offset.
+fun write_kw(buf: str, k: usize, s: str) usize {
+    val n: usize = str_len(s);
+    var w: usize = k;
+    var i: usize = 0;
+    for (i < n) { buf[w] = s[i]; w = w + 1; i = i + 1; }
+    ret w;
+}
+
+# decimal_len: number of base-10 digits in `n` (1 for 0).
+fun decimal_len(n: usize) usize {
+    if (n == 0) { ret 1; }
+    var len: usize = 0;
+    var v: usize = n;
+    for (v > 0) { len = len + 1; v = v / 10; }
+    ret len;
+}
+
+# write_decimal: write the base-10 digits of `n` into `buf` at offset `k`,
+# returning the new offset.
+fun write_decimal(buf: str, k: usize, n: usize) usize {
+    if (n == 0) { buf[k] = '0'; ret k + 1; }
+    var tmp: [24]char;
+    var t: usize = 0;
+    var v: usize = n;
+    for (v > 0) { tmp[t] = (v % 10)::char + '0'; v = v / 10; t = t + 1; }
+    var w: usize = k;
+    var ri: usize = 0;
+    for (ri < t) { buf[w] = tmp[t - 1 - ri]; w = w + 1; ri = ri + 1; }
+    ret w;
+}
+
 # reads expr_type[eid] from the parallel array, returning TYPE_ERROR for an
 # out-of-range or nil id so callers never read past the array.
 fun expr_type_of(sc: *sema.SemaContext, eid: id.ExprId) ty.TypeId {
@@ -384,4 +686,47 @@ fun report(sc: *sema.SemaContext, span: token.Span, message: str) {
 fun report_note(sc: *sema.SemaContext, span: token.Span, message: str, note: str) {
     diag.error(?sc.s.diags, sc.a.file_id, span, message);
     diag.attach_note(?sc.s.diags, note);
+}
+
+# report_mismatch: report a `type mismatch: expected <X>, found <Y>` diagnostic
+# with the two types rendered via type_to_str, plus a static clarifying note.
+# the assembled message and both type spellings are owned only for the duration
+# of the call (the diagnostic sink copies them) and freed before returning. any
+# allocation failure degrades to the static, type-free message so a mismatch is
+# always reported.
+fun report_mismatch(sc: *sema.SemaContext, span: token.Span, expected: ty.TypeId, actual: ty.TypeId, note: str) {
+    val ex_r: Result[str, str] = type_to_str(sc, expected);
+    val ac_r: Result[str, str] = type_to_str(sc, actual);
+    if (is_err[str, str](ex_r) || is_err[str, str](ac_r)) {
+        report_note(sc, span, "type mismatch: incompatible types in assignment", note);
+        if (is_ok[str, str](ex_r)) { type_str_free(sc, unwrap_ok[str, str](ex_r)); }
+        if (is_ok[str, str](ac_r)) { type_str_free(sc, unwrap_ok[str, str](ac_r)); }
+        ret;
+    }
+    val ex: str = unwrap_ok[str, str](ex_r);
+    val ac: str = unwrap_ok[str, str](ac_r);
+
+    val prefix: str = "type mismatch: expected ";
+    val mid:    str = ", found ";
+    val total:  usize = str_len(prefix) + str_len(ex) + str_len(mid) + str_len(ac);
+
+    val r: Result[*char, str] = allocate[char](sc.s.alloc, total + 1);
+    if (is_err[*char, str](r)) {
+        report_note(sc, span, "type mismatch: incompatible types in assignment", note);
+        type_str_free(sc, ex);
+        type_str_free(sc, ac);
+        ret;
+    }
+    val msg: str = unwrap_ok[*char, str](r);
+    var w: usize = write_kw(msg, 0, prefix);
+    w = write_kw(msg, w, ex);
+    w = write_kw(msg, w, mid);
+    w = write_kw(msg, w, ac);
+    msg[w] = 0;
+
+    report_note(sc, span, msg, note);
+
+    deallocate[char](sc.s.alloc, msg, total + 1);
+    type_str_free(sc, ex);
+    type_str_free(sc, ac);
 }

--- a/src/lang/fe/sema/generics.mach
+++ b/src/lang/fe/sema/generics.mach
@@ -117,14 +117,20 @@ pub fun ensure_fields(s: *sess.Session, tid: ty.TypeId) {
     build_instance_table(s, tid, gnom);
 }
 
-# resolves the generic nominal TypeId that instance `(origin, gdecl)`
-# specializes, so its unsubstituted field table can be read. the nominal's
-# display name and rec/uni kind are recovered from the declaration in its
-# origin module's AST (reached through the session registry), then re-interned
-# — `intern_nominal` is keyed by `(origin, decl)`, so this returns exactly the
-# id the declaring module tabled its fields against. returns TYPE_ERROR when
-# the origin AST or declaration is unavailable.
-fun generic_nominal_of(s: *sess.Session, origin: sess.ModuleId, gdecl: id.DeclId) ty.TypeId {
+# generic_nominal_of: resolves the generic nominal TypeId that instance
+# `(origin, gdecl)` specializes, so its unsubstituted field table can be read
+# and its display name recovered. the nominal's name and rec/uni kind are read
+# from the declaration in its origin module's AST (reached through the session
+# registry), then re-interned — `intern_nominal` is keyed by `(origin, decl)`,
+# so this returns exactly the id the declaring module tabled its fields against
+# (and whose `name` StrId diagnostics render). returns TYPE_ERROR when the
+# origin AST or declaration is unavailable.
+# ---
+# s:      the shared session (type universe, AST registry, sources)
+# origin: module that declared the generic
+# gdecl:  the generic declaration in origin's AST
+# ret:    the generic's nominal TypeId, or TYPE_ERROR when unavailable
+pub fun generic_nominal_of(s: *sess.Session, origin: sess.ModuleId, gdecl: id.DeclId) ty.TypeId {
     val ga: *ast.Ast = sess.module_ast(s, origin);
     if (ga == nil) { ret ty.TYPE_ERROR; }
     val d_opt: Option[*decl.Decl] = ast.get_decl(ga, gdecl);


### PR DESCRIPTION
Closes #1094.

## What

Adds `type_to_str`, a general `TypeId` -> human-readable-string renderer, and wires it into the type-mismatch diagnostics so they show concrete `expected X, found Y` instead of the prior generic `incompatible types in assignment` message.

## Renderer

`pub fun type_to_str(sc: *sema.SemaContext, t: ty.TypeId) Result[str, str]` in `src/lang/fe/sema/check.mach` (alongside the existing `format_type`). Forms produced:

- primitives -> keyword (`i64`, `f32`, `ptr`, ...)
- pointer -> `*T`
- array -> `[N]T`
- record / union / generic parameter -> declared name
- function -> `fun(A, B) R` (void return omits the trailing type; variadics render `...`)
- generic instance -> `Name[Arg, ...]`

Composite forms recurse over their components. It uses the codebase's idiomatic two-pass measure-then-write approach (mirroring `mangle.mach`), so each render is one exactly-sized allocation; the owned string is released with `type_str_free`. Generic-instance names are recovered through `generics.generic_nominal_of`, made public in this PR so the AST walk is reused rather than duplicated.

## Diagnostic sites

All three requested sites funnel through `check.check_assignable`, the single chokepoint:

- assignment (`val x: i64 = ...;` via `check_binding`)
- return (`check_return`)
- argument / call (`check_call`)

Enriching `check_assignable`'s diagnostic covers all three with no duplication.

## Before / after

```
# before
error: ...: type mismatch: incompatible types in assignment

# after
error: ...: type mismatch: expected i64, found u8            # val x: i64 = true;
error: ...: type mismatch: expected [4]i64, found [4]i32     # array element type
error: ...: type mismatch: expected i64, found Option[i32]   # generic instance
error: ...: type mismatch: expected i32, found Box[i64]      # custom generic
error: ...: type mismatch: expected i32, found *i64          # argument
error: ...: type mismatch: expected i64, found fun(i32, *u8) i64  # function value
```

The `mach has no implicit widening; cast the value with \`value::Type\`` note is preserved.

## Verification

- `make clean && make` exits 0 (full four-stage bootstrap).
- Fixpoint: `mach` and `mach2` (mach compiling itself) are byte-identical. The compiler binary itself grows by the renderer's code, but self-compilation remains stable.
- `tools/test/differential.sh`: all 10 inputs consistent across -O0/-O2 and smach/mach.
- `mach test`: 106 pass, 0 fail.
