### PR TITLE
fix(sema): validate array literal element count against declared length

### DIFF
--- a/src/lang/fe/sema/infer.mach
+++ b/src/lang/fe/sema/infer.mach
@@ -676,14 +676,22 @@ fun infer_cast(sc: *sema.SemaContext, c: *expr.ExprCast, span: token.Span) type.
 }
 
 # ARRAY_LIT: result is [count]elem of the declared array type; every element
-# is checked against the element type via check.check_assignable.
+# is checked against the element type via check.check_assignable, and the
+# element count must match the declared length exactly (`[N]T` holds exactly
+# N values — see doc/language/types.md).
 fun infer_array_lit(sc: *sema.SemaContext, al: *expr.ExprArrayLit, span: token.Span) type.TypeId {
     val arr_ty: type.TypeId = sema.resolved_type_of(sc, al.ty);
     var elem_ty: type.TypeId = type.TYPE_ERROR;
+    var has_count: bool = false;
+    var decl_count: u32 = 0;
     val at_opt: Option[*type.Type] = type.get(?sc.s.types, arr_ty);
     if (is_some[*type.Type](at_opt)) {
         val at: *type.Type = unwrap[*type.Type](at_opt);
-        if (at.kind == type.TYPE_ARRAY) { elem_ty = at.data.array.base; }
+        if (at.kind == type.TYPE_ARRAY) {
+            elem_ty = at.data.array.base;
+            decl_count = at.data.array.count;
+            has_count = true;
+        }
     }
 
     var i: u32 = 0;
@@ -696,6 +704,12 @@ fun infer_array_lit(sc: *sema.SemaContext, al: *expr.ExprArrayLit, span: token.S
             check.check_assignable(sc, elem_ty, et, span);
         }
         i = i + 1;
+    }
+
+    if (has_count && al.elems_len > decl_count) {
+        sema.report(sc, span, "array literal: too many elements for declared length");
+    } or (has_count && al.elems_len < decl_count) {
+        sema.report(sc, span, "array literal: too few elements for declared length");
     }
     ret arr_ty;
 }


### PR DESCRIPTION
Closes #1113

## Problem

`infer_array_lit` typed each element via `check.check_assignable` but never compared the literal's element count to the declared `[N]T` length. As a result `val A: [2]u8 = [2]u8{1, 2, 3};` type-checked and (per the #1108 review) drove a heap out-of-bounds write in the const-aggregate folder.

## Semantics: exact count

`doc/language/types.md` states `[N]T` is "an array of **exactly** N values of type T". Every array literal in `dep/mach-std` supplies exactly `N` elements — including the large tables (`[64]u32` sha256 K, `[80]u64` sha512 K, `[64]u8`/`[256]u8` base64 tables, all filled precisely). There is no empty `{}` array literal, no partial-init or zero-fill feature documented, exercised, or tested anywhere. So the language is exact-count: both too-many and too-few are rejected.

## Fix

In `infer_array_lit`, after resolving the declared `count` from the array type and typing every element, compare `elems_len` against `count` and emit a span'd diagnostic (pointed at the array literal) on mismatch:

- `array literal: too many elements for declared length`
- `array literal: too few elements for declared length`

Message style mirrors the existing call-argument (`check_call`) and generic-argument (`check_generic_arg_count`) arity checks. The const-aggregate folder OOB defensive bound (#1108) is intentionally untouched — this is the upstream sema fix.

## Verification

- `[2]u8{1,2,3}` (over-long): clean span'd sema error, exit 1 — no crash, not silent.
- Large over-long `[4]u8{1..8}`: clean span'd sema error, exit 1.
- Exact `[3]u8{10,20,30}`: compiles and runs (program exit 60).
- Under-long `[3]u8{10,20}`: clean span'd sema error (exact-count), exit 1.
- `make clean && make`: exit 0 — compiler + std build clean (no std literal trips the check).
- Fixpoint: `mach build . -o mach2` byte-identical to `mach`.
- `bash tools/test/differential.sh`: all 10 inputs pass at -O0/-O2 and smach/mach.
