### PR TITLE
docs(skills): make .github/skills portable for end-user projects

### DIFF
--- a/.github/skills/README.md
+++ b/.github/skills/README.md
@@ -2,26 +2,39 @@
 
 Authoring skills for the Mach (`.mach`) language. Each skill is a fast path for
 one slice of the language; together they cover writing correct Mach without
-reaching for the full reference on every line.
+reaching for the full reference on every line. They are reference/usage guides
+for **writing Mach programs**, not for working on the compiler.
 
 ## Skills
 
 | Skill | Purpose | Triggers when |
 |---|---|---|
-| [writing-mach](writing-mach/SKILL.md) | Core language: project/module structure, `use`/`fwd`, the shadow-module pattern, every declaration form, the type grammar, literals, operators, statements, expressions, docstrings. | Writing, editing, or reviewing any `.mach` source. The default entry point. |
+| [writing-mach](writing-mach/SKILL.md) | Core language: project/module structure, `use`/`fwd`, the shadow-module pattern, every declaration form, the type grammar, literals, operators, statements, expressions, docstrings, and the entrypoint / `std.print` idioms. | Writing, editing, or reviewing any `.mach` source. The default entry point. |
 | [mach-comptime](mach-comptime/SKILL.md) | The comptime channel (`$`): `$mach.*` reads, `$sym.attr` symbol attributes, the closed intrinsic set, `$if`/`$or` control flow, and `$name: T` comptime parameters. | Code touches `$` — conditional compilation, target/build queries, attributes, intrinsics, or comptime params. |
-| [mach-lowlevel](mach-lowlevel/SKILL.md) | Inline assembly (`asm <isa> { ... }` with `{name}` substitution, multi-arch dispatch, inferred operands/clobbers) and the compiler-vs-stdlib placement policy. | Writing/reviewing inline `asm`, or deciding whether an operation belongs in the compiler or stdlib. |
+| [mach-lowlevel](mach-lowlevel/SKILL.md) | Inline assembly (`asm <isa> { ... }` with `{name}` substitution, multi-arch dispatch, inferred operands/clobbers) and when to write `asm` versus call the standard library. | Writing/reviewing inline `asm`, syscalls, or other target-specific code. |
 
 Scope is partitioned: core language lives in **writing-mach**, the `$` channel in
-**mach-comptime**, and `asm` plus the placement policy in **mach-lowlevel**.
-writing-mach carries a one-paragraph summary of the `$` channel and defers the
-rest to mach-comptime; the low-level skill restates a few core gotchas as
-reminders and points back to writing-mach for the full rules.
+**mach-comptime**, and `asm` in **mach-lowlevel**. writing-mach carries a
+one-paragraph summary of the `$` channel and defers the rest to mach-comptime;
+the low-level skill restates a few core gotchas as reminders and points back to
+writing-mach for the full rules.
 
-## Authoritative references
+## Adopting these skills
 
-The skills are the fast path, not the contract. For exhaustive detail, see
-[`doc/language/`](../../doc/language/README.md) — the complete per-feature
-reference and source of truth. Each skill links the relevant files in its own
-Reference section. When a skill and the reference disagree, the reference wins,
-and the skill is the bug.
+Drop the `.github/skills/` tree into your own Mach project's tooling directory
+(for an agent or assistant that reads skills, the conventional location is
+`.github/skills/`). The skills are self-contained — they reference only the
+language itself and the public Mach standard library (`std.*`), with no
+dependency on this or any other particular repository's internals.
+
+Keep them current with your toolchain: when the locked language or the standard
+library moves, update the affected skill in step. When a skill and the official
+language reference disagree, the reference wins and the skill is the bug.
+
+## Authoritative reference
+
+The skills are the fast path, not the contract. The complete, per-feature
+language reference — grammar, semantics, and implementation status — lives in
+the Mach repository under
+[`doc/language/`](https://github.com/octalide/mach/tree/dev/doc/language). Each
+skill points there for exhaustive detail.

--- a/.github/skills/mach-comptime/SKILL.md
+++ b/.github/skills/mach-comptime/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: mach-comptime
-description: Use when writing or reviewing Mach code that touches the comptime channel: the $ namespace, conditional compilation, target/build/project/source queries ($mach.*), symbol attributes ($sym.attr), compiler intrinsics ($size_of/$align_of/$offset_of/$error/$assert), $if/$or comptime control flow, and comptime function parameters ($name: T).
+description: Use when writing or reviewing Mach code that touches the comptime channel: the $ namespace, conditional compilation, target/compiler/build/project/source queries ($mach.*), symbol attributes ($sym.attr), compiler intrinsics ($size_of/$align_of/$offset_of/$error/$assert), $if/$or comptime control flow, and comptime function parameters ($name: T).
 ---
 
 # Mach comptime channel
@@ -26,8 +26,11 @@ All reads, all comptime constants. Closed tree. Subtrees:
 ```mach
 $mach.target.os                 # compare against $mach.os.* tags
 $mach.target.arch               # compare against $mach.arch.* tags
-$mach.target.abi
 $mach.target.pointer_width      # integer byte count
+$mach.target.abi
+
+$mach.compiler.name
+$mach.compiler.version
 
 $mach.build.mode
 $mach.build.timestamp
@@ -48,6 +51,12 @@ $mach.os.linux $mach.os.darwin $mach.os.windows $mach.os.freestanding
 $mach.arch.x86_64 $mach.arch.aarch64
 ```
 
+> **Implementation status.** Only a subset resolves today:
+> `$mach.target.{os,arch,pointer_width}`, `$mach.os.*`, `$mach.arch.*`, and
+> `$mach.compiler.{name,version}`. The `$mach.target.abi`, `$mach.build.*`,
+> `$mach.project.*`, and `$mach.source.*` paths are reserved stubs — reading one
+> is a compile error. Prefer the live reads in real code.
+
 Tag comparison is path-value — no `.id` suffix, no unwrapping:
 
 ```mach
@@ -61,7 +70,7 @@ type inference — the binding still declares its type):
 
 ```mach
 pub val IS_LINUX: u8  = $mach.target.os == $mach.os.linux;
-pub val VERSION:  *u8 = $mach.project.version;
+pub val COMPILER: *u8 = $mach.compiler.name;
 ```
 
 ## Symbol attributes — `$sym.attr`
@@ -100,6 +109,13 @@ Closed attribute set:
 | `.section` | functions, vars | `*u8` literal | linker section name |
 | `.packed` | records, unions | `u8` flag | disable field padding |
 
+> **Implementation status.** Any well-formed attribute write parses, but only
+> `.symbol` currently changes compiler output (the linker name). The rest are
+> accepted and ignored — layout uses the natural C-style rule regardless of
+> `.align` / `.packed`, and `.noreturn` / `.inline` / `.section` do not yet
+> feed codegen. Flag attributes take a `u8`; `true` and `1` are equivalent when
+> stdlib `bool` is in scope.
+
 The `ext fun` rename uses `.symbol`:
 
 ```mach
@@ -135,6 +151,10 @@ $assert(cond, "msg")    # sugar: $if (!cond) { $error("msg"); }
 $assert($size_of(i64) == 8, "expected 64-bit i64");
 ```
 
+> **Implementation status.** `$error` / `$assert` parse but are not yet
+> evaluated — a failing directive is currently accepted rather than aborting the
+> build. The shapes above describe the intended behavior.
+
 Runtime-instruction emitters (`trap`, `fence`, `pause`, …) are **not**
 intrinsics — they live in stdlib as functions with per-arch `asm` bodies. The
 intrinsic set is closed; new ones need a compiler patch.
@@ -152,15 +172,14 @@ type-checked, or emitted — names inside them are never looked up. This is what
 makes per-arch `asm` blocks safe: the untaken block may reference registers a
 backend doesn't know.
 
-`cond` must be comptime: `$mach.*` reads, comparisons of comptime constants, or
-comptime function parameters.
+`cond` must be comptime: `$mach.*` reads, or comparisons of comptime constants.
 
 ```mach
 $if ($mach.target.os == $mach.os.linux) {
-    use full.os.linux;
+    use std.runtime.linux;
 }
 $or ($mach.target.os == $mach.os.windows) {
-    use full.os.windows;
+    use std.runtime.windows;
 }
 $or {
     $error("unsupported OS");
@@ -174,9 +193,8 @@ arch-block construct.
 
 A comptime value parameter sits in the regular paren list as `$name: T`. The
 caller must pass a comptime-evaluable value; the compiler enforces it at the
-call site. Inside the body, reference it by bare `name` (no `$`) — `$if` then
-dispatches on it. This is the idiom for passing memory orderings and similar
-variants into stdlib.
+call site. Inside the body, reference it by bare `name` (no `$`). This is the
+idiom for passing memory orderings and similar variants into stdlib wrappers.
 
 ```mach
 pub fun load($order: Order, ptr: *i64) i64 {
@@ -194,6 +212,13 @@ pub fun load($order: Order, ptr: *i64) i64 {
     ret result;
 }
 ```
+
+> **Implementation status.** The `$name: T` parameter is accepted in a
+> signature, but it is not yet usable as a comptime constant inside the body —
+> `$if (order == RELAXED)` reports that the identifier is not a comptime
+> constant in scope. Per-call-site dispatch requires monomorphizing the body per
+> distinct value, which is not yet done. Until it lands, branch on such a
+> parameter with a runtime `if`.
 
 The `$name: T` form applies to **function parameters only** — not record
 fields, not generic-bracket contexts. Generic *type* parameters use `[T]`
@@ -214,7 +239,7 @@ brackets and are a separate mechanism.
 - **Value intrinsics are unsigned constants with no implicit type.** The binding
   declares the storage type (Mach has no type inference and no `usize`).
 - **Comptime param is referenced bare in the body.** Declared `$order: Order`,
-  used as `order` inside `$if`.
+  used as `order`.
 - **Not in the channel:** no `$<Type>.*` reflection subtree (types aren't
   first-class comptime values), no comptime function definitions, no comptime
   loops.
@@ -224,9 +249,8 @@ brackets and are a separate mechanism.
 
 ## Reference
 
-- [doc/language/comptime.md](../../../doc/language/comptime.md) — channel overview, four shapes
-- [doc/language/comptime-mach.md](../../../doc/language/comptime-mach.md) — `$mach.*` namespace
-- [doc/language/comptime-attrs.md](../../../doc/language/comptime-attrs.md) — symbol attributes
-- [doc/language/comptime-intrinsics.md](../../../doc/language/comptime-intrinsics.md) — intrinsics
-- [doc/language/comptime-control.md](../../../doc/language/comptime-control.md) — `$if` / `$or`
-- [doc/language/](../../../doc/language/README.md) — full language reference index
+The authoritative comptime reference lives in the Mach repository under
+[`doc/language/`](https://github.com/octalide/mach/tree/dev/doc/language) —
+`comptime.md`, `comptime-mach.md`, `comptime-attrs.md`,
+`comptime-intrinsics.md`, and `comptime-control.md`. When a skill and the
+reference disagree, the reference wins.

--- a/.github/skills/mach-lowlevel/SKILL.md
+++ b/.github/skills/mach-lowlevel/SKILL.md
@@ -1,11 +1,12 @@
 ---
 name: mach-lowlevel
-description: Use when writing or reviewing Mach inline assembly or deciding whether functionality belongs in the compiler or the stdlib. Covers the asm <isa> { ... } form with {name} operand substitution, multi-arch dispatch via $if on $mach.target.arch, the compiler-infers-operands-and-clobbers model, and the compiler-vs-stdlib boundary policy (SIMD operators and asm encoding in the compiler; atomics, fences, syscalls, SIMD long-tail in stdlib).
+description: Use when writing or reviewing Mach inline assembly, syscalls, or other target-specific code. Covers the asm <isa> { ... } form with {name} operand substitution, multi-arch dispatch via $if on $mach.target.arch, the compiler-infers-operands-and-clobbers model, and when to write asm versus call a standard-library wrapper.
 ---
 
 # Mach low-level layer
 
-Inline assembly and the compiler-vs-stdlib boundary. Two concerns: how to write an `asm` block correctly, and where a low-level operation belongs.
+Inline assembly and target-specific code. Two concerns: how to write an `asm`
+block correctly, and when to reach for `asm` versus a stdlib wrapper.
 
 ## The `asm` form
 
@@ -81,33 +82,16 @@ $or {
 
 Write `asm` only for truly target-specific operations with no 1:1 stdlib wrapper: raw syscalls, special-register reads, stack-frame surgery.
 
-For anything that maps to a named stdlib function — atomics, fences, traps, bit ops, the SIMD long-tail — **call the stdlib API**. Those wrappers already contain the arch-dispatched `asm`; reimplementing them inline duplicates the dispatch and loses the encapsulation.
+For anything that maps to a named stdlib function — atomics, fences, traps, bit ops, the SIMD long-tail — **call the stdlib API**. Those wrappers already contain the arch-dispatched `asm`; reimplementing them inline duplicates the dispatch and loses the encapsulation. The standard library covers, among others:
 
-## Compiler vs stdlib boundary
-
-> Compiler handles things that need to **feel like the language**. Stdlib handles things that map **1:1 to specific instruction sequences** with predictable lowerings.
-
-**Compiler** (intrinsic, language-level):
-- Type system, control flow (`if`/`or`, `for`, `ret`, `brk`, `cnt`, `fin`).
-- **SIMD operators on primitive vector types** — arithmetic (`+ - * / %`), bitwise (`& | ^ ~ << >>`), comparison, lane indexing, vector literals. One CPU instruction per operator per ISA.
-- **`asm` parsing, encoding, and operand allocation** per ISA.
-- The comptime channel — `$mach.*` reads, attribute writes, the closed intrinsic set, `$if`/`$or`.
-- Comptime function-parameter dispatch (`$name: T`).
-
-**Stdlib** (1:1 instruction sequences, built on `asm`):
 - **Atomics** — load/store/cas/RMW, per arch × per ordering.
 - **Memory fences and CPU hints** — pause, prefetch.
 - **Traps / unreachable** — `trap()` with per-arch `asm { ud2 / brk 0 / ... }`.
 - **Syscalls** — per-platform ABI wrappers.
-- **CPU feature detection** — CPUID-style runtime reads.
-- **SIMD long tail** — shuffles, reductions, gather/scatter, saturating arithmetic, specialized math. Functions over the compiler-known SIMD types.
 - **Bit manipulation** — popcount, clz, ctz, bswap.
-- **Formatting, parsing, math, allocators** — pure Mach over the primitives.
+- **SIMD long tail** — shuffles, reductions, gather/scatter, saturating arithmetic, specialized math (once SIMD types land).
 
-Decision rule for placement:
-- Does it need to feel like the language (an operator, a type, control flow)? Compiler.
-- Does it map to a fixed instruction sequence per arch with a predictable lowering? Stdlib, via `$if ($mach.target.arch == ...)` → `asm <isa> { ... }`.
-- The compiler grows **only** when something genuinely cannot be expressed as a 1:1 instruction sequence per arch (autovectorization, 128-bit arithmetic needing context-dependent lowering). Default is stdlib.
+Rule of thumb: if the operation maps to a fixed instruction sequence per arch, there is (or should be) a stdlib wrapper — prefer it. Reach for raw `asm` only when no such wrapper exists.
 
 ## Variant parameters in stdlib wrappers
 
@@ -117,9 +101,14 @@ Memory orderings and similar runtime-relevant variants are passed as **comptime 
 fun atomic_load[T](ptr: *T, $order: Order) T { ... }
 ```
 
+> **Implementation status.** A `$name: T` parameter is accepted in a signature
+> but is not yet usable as a comptime constant inside the body (`$if (order ==
+> RELAXED)` is not yet supported). Until it lands, branch on such a parameter
+> with a runtime `if`.
+
 ## SIMD type spelling
 
-Vector types follow `<u|i|f><width>x<count>`: `f32x4`, `i32x8`, `u8x16`. Higher dimensions are grammatically legal (`f32x4x4`) and populated as backends accelerate. The set is compiler-shipped and closed per target. Operators on these types are compiler intrinsics; everything beyond the basic operator set is stdlib.
+Vector types follow `<u|i|f><width>x<count>`: `f32x4`, `i32x8`, `u8x16`. Higher dimensions are grammatically legal (`f32x4x4`). **Planned, not yet implemented** — these names do not resolve as types today. Once seeded, the basic operators on them are compiler intrinsics and everything beyond is stdlib.
 
 ## Mach gotchas that bite in low-level code
 
@@ -133,8 +122,9 @@ Vector types follow `<u|i|f><width>x<count>`: `f32x4`, `i32x8`, `u8x16`. Higher 
 
 ## Reference
 
-- [doc/language/asm.md](../../../doc/language/asm.md) — the `asm` form, operand substitution, inferred clobbers, multi-arch dispatch.
-- [doc/language/policy.md](../../../doc/language/policy.md) — the compiler-vs-stdlib boundary in full.
-- [doc/language/comptime-control.md](../../../doc/language/comptime-control.md) — `$if`/`$or` over `$mach.target.arch`.
-- [doc/language/comptime-intrinsics.md](../../../doc/language/comptime-intrinsics.md) — what is a compiler intrinsic vs deferred to stdlib.
-- [doc/language/](../../../doc/language/README.md) — full language reference index.
+The authoritative low-level reference lives in the Mach repository under
+[`doc/language/`](https://github.com/octalide/mach/tree/dev/doc/language) —
+`asm.md` (the `asm` form, operand substitution, inferred clobbers, multi-arch
+dispatch), `comptime-control.md` (`$if`/`$or` over `$mach.target.arch`), and
+`policy.md` (the full compiler-vs-stdlib boundary). When a skill and the
+reference disagree, the reference wins.

--- a/.github/skills/writing-mach/SKILL.md
+++ b/.github/skills/writing-mach/SKILL.md
@@ -1,27 +1,28 @@
 ---
 name: writing-mach
-description: Use when writing, editing, or reviewing Mach (.mach) source files. Covers project/module structure, use/fwd imports and re-exports, the shadow-module pattern, all declaration forms (pub/ext, def, rec, uni, fun, ext fun, val/var), the type grammar (primitives, SIMD vectors, pointers, arrays, function types), literals, operators, statements (if/or, for, ret, brk/cnt, fin, blocks), expressions, and docstring conventions.
+description: Use when writing, editing, or reviewing Mach (.mach) source files. Covers project/module structure, use/fwd imports and re-exports, the shadow-module pattern, all declaration forms (pub/ext, def, rec, uni, fun, ext fun, val/var), the type grammar (primitives, SIMD vectors, pointers, arrays, function types), literals, operators, statements (if/or, for, ret, brk/cnt, fin, blocks), expressions, docstring conventions, and the executable entrypoint and std.print output idioms.
 ---
 
 # Writing Mach
 
 Mach is a low-level, explicitly-typed language. No type inference, no garbage
 collection, no hidden control flow. Files use the `.mach` extension. This skill
-is the fast path for authoring correct Mach; `doc/language/*.md` is the
-exhaustive reference.
+is the fast path for authoring correct Mach; the language reference (see the
+Reference section) is the exhaustive source of truth.
 
 ## Hard rules — get these right
 
 - **No type inference.** Every binding declares its type. `val x = 42;` is an
   error; write `val x: i64 = 42;`.
 - **No compiler-known type aliases.** `bool`, `usize`, `str`, etc. are *stdlib*
-  `def`s, not built-ins. The compiler ships only `ptr`, `va_list`, and the
-  numeric/SIMD family. Import the alias from stdlib before using it. `bool` is
-  `def bool: u8;`; `true`/`false` are stdlib `val`s (`1`/`0`). Comparison and
-  logical operators produce `u8`.
+  `def`s, not built-ins. The compiler ships only `ptr` and the numeric/SIMD
+  family. Import the alias from stdlib before using it. `bool` is `def bool: u8;`;
+  `true`/`false` are stdlib `val`s (`1`/`0`). Comparison and logical operators
+  produce `u8`.
 - **Strings are `*u8`.** `"hello"` produces a `*u8` pointing at null-terminated
   bytes. There is no fat-pointer string type. Length-aware strings are a stdlib
-  record. Backtick `` ` `` is reserved and currently unused — never emit it.
+  type (`std.types.string.str` is itself `def str: *u8;`). Backtick `` ` `` is
+  reserved and currently unused — never emit it.
 - **`fwd` is bare and always public.** No `pub fwd`. `ext fun` is the *only*
   body-less function form — there are no forward declarations of regular
   functions.
@@ -33,15 +34,50 @@ exhaustive reference.
 ## File and module structure
 
 A project has a `mach.toml` at its root whose `[project] id` is the root of
-every module path. A file at `src/foo/bar.mach` in project `myproj` is the
-module `myproj.foo.bar`. Path separator is `.`. There is **no `this.`
+every module path. A file at `src/foo/bar.mach` in a project with `id = "myproj"`
+is the module `myproj.foo.bar`. Path separator is `.`. There is **no `this.`
 self-prefix** — always reference modules by full project-rooted path.
 
 Entrypoints by convention: `lib.mach` (library, no executable), `main.mach`
-(executable, defines `fun main()`).
+(executable). The dominant role is set by the target's `mode` / `entrypoint` in
+`mach.toml`.
 
 A file begins with a module docstring (see Docstrings), then `use`/`fwd` lines,
 then declarations.
+
+## Executable entrypoint
+
+The standard library provides the platform `_start` symbol that calls your
+`main`. Pull it in with `use std.runtime;`, tag `main` with the `.symbol`
+attribute so the linker finds it, and return an exit code:
+
+```mach
+use std.runtime;
+
+$main.symbol = "main";
+fun main(argc: i64, argv: **u8) i64 {
+    ret 0;
+}
+```
+
+`use std.runtime;` is what links the entrypoint into the binary.
+
+## Output — `std.print`
+
+There is no built-in `print`. Use the standard library, which returns a
+`Result` (output can fail):
+
+```mach
+use std.print;
+
+fun greet() {
+    std.print.println("hello, mach");
+}
+```
+
+`std.print` exposes `print` / `println` (stdout), `eprint` / `eprintln`
+(stderr), and formatting variants. Each returns `Result[usize, str]` — bytes
+written, or an error.
 
 ## `use` — private import
 
@@ -119,14 +155,17 @@ pub uni Maybe[T] { some: T; none: u8; }     # generic
 A `rec` lays fields out with padding; a `uni` overlaps all fields in one slot
 (size of largest field). The compiler does not track which `uni` field is live.
 
-Discriminated value (the only sum-type idiom):
+Discriminated value (the only sum-type idiom) — this is exactly how the stdlib
+`Result[T, E]` is built:
 
 ```mach
-rec Value {
-    kind: ValueKind;
-    data: uni { i: i64; f: f64; }
+rec Result[T, E] {
+    tag:   bool;
+    value: uni { ok: T; err: E; }
 }
 ```
+
+Read the discriminator, then access the matching payload field with `if`/`or`.
 
 ### `fun` — function
 
@@ -148,10 +187,12 @@ pub fun identity[T](value: T) T { ret value; }
   `identity[i64](42)`.
 - Comptime value params use `$name: T` *in the regular paren list*; the caller
   passes a comptime-evaluable value (enforced at the call site, passed
-  positionally like a runtime arg). Body can branch on it via `$if`. This form
-  is **function parameters only** — never record fields.
+  positionally like a runtime arg). This form is **function parameters only** —
+  never record fields.
 - Variadic via trailing `...`; access through `va_list` / `va_start` /
-  `va_arg[T]` / `va_end` (C convention).
+  `va_arg[T]` / `va_end` (C convention). Partially implemented: call sites and
+  the trailing `...` parse, but the callee-side `va_*` machinery is not yet
+  fully seeded — check your toolchain before relying on it.
 
 ### `ext fun` — external function
 
@@ -178,11 +219,11 @@ Work at module top level (`pub val` / `pub var` export) and in function bodies.
 Primitives follow `<u|i|f><width>(x<count>)*`.
 
 - Scalars: `u8 u16 u32 u64`, `i8 i16 i32 i64`, `f32 f64`.
-- Compiler-shipped concrete: `ptr`, `va_list`. (`bool` is a stdlib `def` for
-  `u8`, not a built-in.)
-- SIMD vectors: append `x<count>` — `f32x4`, `i32x8`, `u8x16`. Higher dims
-  (`f32x4x4`) are grammatically legal but only populated as backends accelerate.
-  No bare-letter modifiers (atomic/volatile live outside the type name).
+- Untyped pointer: `ptr`. (`bool` is a stdlib `def` for `u8`, not a built-in.)
+- SIMD vectors: append `x<count>` — `f32x4`, `i32x8`, `u8x16`. **Planned, not
+  yet implemented**: vector type names do not resolve as types today. Higher
+  dims (`f32x4x4`) are grammatically legal. Atomic/volatile live outside the
+  type name (no bare-letter modifiers).
 
 Compound:
 
@@ -193,6 +234,7 @@ fun(T1, T2) R   # function-pointer type
 ```
 
 ```mach
+var x: i64 = 9;
 var p: *i64 = ?x;     # address-of yields *i64
 val v: i64  = @p;     # dereference
 val a: [4]i64 = [4]i64{1, 2, 3, 4};
@@ -208,24 +250,30 @@ def BinOp: fun(i64, i64) i64;
 | Typed suffix | `7i64` `255u8` `2.5f64` | typed by suffix |
 | Char | `'M'` | `u8` |
 | String | `"hi\n"` | `*u8`, null-terminated |
+| `nil` | `nil` | null-address literal; coerces to any pointer type |
 
 Untyped numeric literals are *checked* against the surrounding declared type;
 they do not infer it. If context does not constrain the type, use a suffix
-(`42i64`). Char escapes: `\n \t \r \\ \' \0 \xHH`. String escapes: same plus
-`\"`. Strings are single-line (use `\n`; no multi-line syntax).
+(`42i64`). `nil` types as `*u8` with no context and coerces to any pointer;
+relate function pointers to `nil` via `==` / `!=`, not assignment. Char escapes:
+`\n \t \r \\ \' \0 \xHH`. String escapes: same plus `\"`. Strings are
+single-line (use `\n`; no multi-line syntax).
 
 ## Operators
 
-- Arithmetic: `+ - * / %` — int/float scalars and SIMD vectors (lane-wise).
-- Bitwise: `& | ^ ~ << >>` — integer scalars and integer vectors.
-- Comparison: `== != < > <= >=` → `u8` (`1`/`0`; mask vector on SIMD).
+- Arithmetic: `+ - * / %` — int/float scalars (and lane-wise on planned SIMD
+  vectors).
+- Bitwise: `& | ^ ~ << >>` — integer scalars (and planned integer vectors).
+- Comparison: `== != < > <= >=` → `u8` (`1`/`0`). A pointer may be compared
+  against `nil`.
 - Logical: `&& || !` — short-circuiting; `u8` operands (`0` false, nonzero
   true) → `u8`.
 - Unary: `-` negate, `~` bitwise NOT, `!` logical NOT.
 - Pointer: `?expr` address-of, `@ptr` dereference (also `@p = x;` to write).
 - Cast: `expr::Type` — explicit width/sign/pointer conversion.
 
-Precedence follows C-family conventions.
+Precedence follows C-family conventions. There is no compound assignment
+(`+=`, `-=`, … do not exist).
 
 ## Statements
 
@@ -253,11 +301,13 @@ core.add                             # module-qualified
 Point{ x: 1, y: 2 }                  # record literal
 [3]i64{10, 20, 30}                   # array literal
 Number{ i: 99 }                      # union literal
-f32x4{1.0, 2.0, 3.0, 4.0}            # vector literal
 Pair[i64, u8]{ left: 5, right: 6u8 } # generic literal: type args before body
-p.x   a[0]   v[2]                    # field / index / lane access
+p.x   a[0]                           # field / index access
 add(2, 3)   identity[i64](42)        # call / generic call
 ```
+
+Vector literals (`f32x4{ ... }`) follow the same shape but depend on the SIMD
+vector types, which are not yet implemented.
 
 ## Docstrings
 
@@ -295,26 +345,12 @@ attribute (write-once, before the decl, same module). Closed attribute set:
 `$if (C) {} $or (C) {} $or {}` — only the taken branch compiles. Value
 intrinsics `$size_of(T) $align_of(T) $offset_of(T, f)` yield comptime unsigned
 integers; `$error("msg")` / `$assert(C, "msg")` are diagnostics. The full
-comptime/asm grammar is out of scope here — see the comptime docs under
-[doc/language/](../../../doc/language/README.md).
+comptime/asm grammar is out of scope here — see the **mach-comptime** skill.
 
 ## Reference
 
-- [doc/language/files.md](../../../doc/language/files.md) — `mach.toml`, entrypoints
-- [doc/language/modules.md](../../../doc/language/modules.md) — module paths, shadow-module pattern
-- [doc/language/use.md](../../../doc/language/use.md) — imports
-- [doc/language/fwd.md](../../../doc/language/fwd.md) — re-exports
-- [doc/language/visibility.md](../../../doc/language/visibility.md) — `pub`, `ext`
-- [doc/language/def.md](../../../doc/language/def.md) — type aliases
-- [doc/language/rec.md](../../../doc/language/rec.md) — records
-- [doc/language/uni.md](../../../doc/language/uni.md) — unions
-- [doc/language/fun.md](../../../doc/language/fun.md) — functions, generics, comptime params, variadics
-- [doc/language/ext-fun.md](../../../doc/language/ext-fun.md) — external functions
-- [doc/language/val-var.md](../../../doc/language/val-var.md) — bindings
-- [doc/language/literals.md](../../../doc/language/literals.md) — literal forms
-- [doc/language/types.md](../../../doc/language/types.md) — type grammar
-- [doc/language/operators.md](../../../doc/language/operators.md) — operators
-- [doc/language/statements.md](../../../doc/language/statements.md) — statement forms
-- [doc/language/expressions.md](../../../doc/language/expressions.md) — expression forms
-- [doc/language/documentation.md](../../../doc/language/documentation.md) — docstring conventions
-- [doc/language/](../../../doc/language/README.md) — full language reference index
+The authoritative per-feature language reference lives in the Mach repository
+under
+[`doc/language/`](https://github.com/octalide/mach/tree/dev/doc/language),
+including the EBNF in `grammar.md`. When a skill and the reference disagree, the
+reference wins.


### PR DESCRIPTION
Closes #1102.

Makes the three Mach language skills (writing-mach, mach-comptime, mach-lowlevel) and their README portable: an end user can drop the `.github/skills/` tree into their own Mach project and use them as language reference/usage guides, with no dangling references to this compiler repo.

## Decoupling
- Replaced every relative `doc/language/*.md` link (all pointing into this repo's tree) with the canonical online reference `https://github.com/octalide/mach/tree/dev/doc/language`.
- Reframed **mach-lowlevel** from a compiler-contributor "where should this live in the toolchain" placement policy to end-user "when do I write `asm` vs call a stdlib wrapper" guidance.
- Reframed the README around how an end user adopts the skill set, and that the skills depend only on the language and the public `std.*` library.

## Currency with the locked language (cross-checked against `doc/language/`)
- **writing-mach:** added the executable entrypoint idiom (`use std.runtime;` + `$main.symbol = "main";`), `std.print` output (returns `Result[usize, str]`), grounded the discriminated-value idiom in the real stdlib `Result[T, E]`, added the `nil` literal, noted no compound assignment, and flagged SIMD/variadics as planned/partial.
- **mach-comptime:** added the live `$mach.compiler.*` subtree (and used it in the live-read example instead of the `$mach.project.*` stub), and added implementation-status notes for `$mach.*` stubs, the attribute set (only `.symbol` honored), `$error`/`$assert` (not yet evaluated), and comptime-parameter body dispatch (not yet supported).
- **mach-lowlevel:** flagged SIMD types and comptime-parameter body dispatch as not-yet-implemented.

## Verification
- Docs only — no compiler source, `mach.toml`, or `dep/` touched.
- grep confirms no `src/lang`, `out/bin`, `dep/mach-std`, imach/smach/cmach/isel/regalloc/MIR/bootstrap, "in this repo", or `../..` references remain; inline `asm`/syscall/atomics content is kept as it is a user-facing language feature.
- Every code snippet checked by hand against `doc/language/grammar.md` (EBNF + reserved keywords) and the real stdlib sources (`std.print`, `std.runtime`, `Result`, `Option`).
