### PR TITLE
docs(examples): print via std.print instead of std.system.os.write

### DIFF
--- a/examples/01_hello/main.mach
+++ b/examples/01_hello/main.mach
@@ -2,17 +2,14 @@
 #
 # `use std.runtime;` links the platform entrypoint that decodes argc/argv
 # and calls `main`. `$main.symbol = "main";` names the entry function.
-# the message is written straight to stdout via the OS write wrapper.
-# `main` returns the process exit code; 0 means success.
+# the message is written to stdout with `std.print.println`, which appends a
+# trailing newline. `main` returns the process exit code; 0 means success.
 
 use std.runtime;
-use std.types.string.str;
-use std.types.string.str_len;
-use os: std.system.os;
+use std.print.println;
 
 $main.symbol = "main";
 fun main(argc: i64, argv: **u8) i64 {
-    val msg: str = "hello, mach\n";
-    os.write(os.STDOUT_FD, msg::*u8, str_len(msg));
+    println("hello, mach");
     ret 0;
 }

--- a/examples/02_control_flow/main.mach
+++ b/examples/02_control_flow/main.mach
@@ -2,61 +2,34 @@
 #
 # demonstrates the `if {} or {} or {}` chain, the single `for (cond)` loop,
 # and the `brk` / `cnt` loop-control keywords. results are printed to stdout
-# through a small write helper so the behavior is visible when run.
+# with `std.print`, which formats numbers via `%d`.
 
 use std.runtime;
-use std.types.size.usize;
 use std.types.string.str;
-use std.types.string.str_len;
-use os: std.system.os;
+use std.print.println;
+use std.print.printlnf;
 
 $main.symbol = "main";
 
-# write a null-terminated string to stdout.
-fun out(s: str) {
-    os.write(os.STDOUT_FD, s::*u8, str_len(s));
-}
-
-# write a small non-negative integer followed by a newline.
-fun out_num(n: i64) {
-    var buf: [24]u8;
-    var idx: i64 = 23;
-    var x:   i64 = n;
-    buf[idx] = '\n';
-    if (x == 0) {
-        idx = idx - 1;
-        buf[idx] = '0';
-    }
-    or {
-        for (x > 0) {
-            idx = idx - 1;
-            buf[idx] = (x % 10)::u8 + '0';
-            x = x / 10;
-        }
-    }
-    os.write(os.STDOUT_FD, ?buf[idx], (24 - idx)::usize);
-}
-
 fun classify(n: i64) str {
     if (n < 0) {
-        ret "negative\n";
+        ret "negative";
     }
     or (n == 0) {
-        ret "zero\n";
+        ret "zero";
     }
     or {
-        ret "positive\n";
+        ret "positive";
     }
 }
 
 fun main(argc: i64, argv: **u8) i64 {
-    out(classify(-5));
-    out(classify(0));
-    out(classify(42));
+    println(classify(-5));
+    println(classify(0));
+    println(classify(42));
 
     # sum the even numbers in [0, 10), skipping odds with `cnt` and
     # stopping early once the running total passes 12 with `brk`.
-    out("sum of evens until > 12: ");
     var total: i64 = 0;
     var i:     i64 = 0;
     for (i < 10) {
@@ -68,7 +41,7 @@ fun main(argc: i64, argv: **u8) i64 {
         if (total > 12) { brk; }
         i = i + 1;
     }
-    out_num(total);
+    printlnf("sum of evens until > 12: %d", total);
 
     ret 0;
 }

--- a/examples/03_functions/main.mach
+++ b/examples/03_functions/main.mach
@@ -4,41 +4,16 @@
 # even/odd pair, and a module-level constant. results print to stdout.
 
 use std.runtime;
-use std.types.size.usize;
 use std.types.bool.bool;
 use std.types.bool.true;
 use std.types.bool.false;
-use std.types.string.str;
-use std.types.string.str_len;
-use os: std.system.os;
+use std.print.println;
+use std.print.printlnf;
 
 $main.symbol = "main";
 
 # module-level constant, visible to every function in this file.
 val MAX_N: i64 = 10;
-
-fun out(s: str) {
-    os.write(os.STDOUT_FD, s::*u8, str_len(s));
-}
-
-fun out_num(n: i64) {
-    var buf: [24]u8;
-    var idx: i64 = 23;
-    var x:   i64 = n;
-    buf[idx] = '\n';
-    if (x == 0) {
-        idx = idx - 1;
-        buf[idx] = '0';
-    }
-    or {
-        for (x > 0) {
-            idx = idx - 1;
-            buf[idx] = (x % 10)::u8 + '0';
-            x = x / 10;
-        }
-    }
-    os.write(os.STDOUT_FD, ?buf[idx], (24 - idx)::usize);
-}
 
 # direct recursion.
 fun factorial(n: i64) i64 {
@@ -58,15 +33,13 @@ fun is_odd(n: i64) bool {
 }
 
 fun main(argc: i64, argv: **u8) i64 {
-    out("factorial(5) = ");
-    out_num(factorial(5));
+    printlnf("factorial(5) = %d", factorial(5));
 
-    out("MAX_N is even: ");
     if (is_even(MAX_N)) {
-        out("yes\n");
+        println("MAX_N is even: yes");
     }
     or {
-        out("no\n");
+        println("MAX_N is even: no");
     }
 
     ret 0;

--- a/examples/04_structs_unions/main.mach
+++ b/examples/04_structs_unions/main.mach
@@ -5,35 +5,10 @@
 # pairs a discriminant with a union payload to model a small variant value.
 
 use std.runtime;
-use std.types.size.usize;
-use std.types.string.str;
-use std.types.string.str_len;
-use os: std.system.os;
+use std.print.println;
+use std.print.printlnf;
 
 $main.symbol = "main";
-
-fun out(s: str) {
-    os.write(os.STDOUT_FD, s::*u8, str_len(s));
-}
-
-fun out_num(n: i64) {
-    var buf: [24]u8;
-    var idx: i64 = 23;
-    var x:   i64 = n;
-    buf[idx] = '\n';
-    if (x == 0) {
-        idx = idx - 1;
-        buf[idx] = '0';
-    }
-    or {
-        for (x > 0) {
-            idx = idx - 1;
-            buf[idx] = (x % 10)::u8 + '0';
-            x = x / 10;
-        }
-    }
-    os.write(os.STDOUT_FD, ?buf[idx], (24 - idx)::usize);
-}
 
 # a record: distinct fields, each at its own offset.
 rec Point {
@@ -68,8 +43,7 @@ fun manhattan(p: Point) i64 {
 fun main(argc: i64, argv: **u8) i64 {
     var p: Point = Point{ x: 3, y: -4 };
     p.x = p.x + 1;
-    out("manhattan distance: ");
-    out_num(manhattan(p));
+    printlnf("manhattan distance: %d", manhattan(p));
 
     # build an int-tagged value, then read its payload back through the
     # matching union arm.
@@ -77,13 +51,11 @@ fun main(argc: i64, argv: **u8) i64 {
     v.tag        = TAG_INT;
     v.payload.i  = 99;
 
-    out("tagged value is int: ");
     if (v.tag == TAG_INT) {
-        out("yes -> ");
-        out_num(v.payload.i);
+        printlnf("tagged value is int: yes -> %d", v.payload.i);
     }
     or {
-        out("no\n");
+        println("tagged value is int: no");
     }
 
     ret 0;

--- a/examples/05_generics/main.mach
+++ b/examples/05_generics/main.mach
@@ -5,35 +5,9 @@
 # brackets, e.g. `identity[i64](x)` or `Pair[i64, u8]{ ... }`.
 
 use std.runtime;
-use std.types.size.usize;
-use std.types.string.str;
-use std.types.string.str_len;
-use os: std.system.os;
+use std.print.printlnf;
 
 $main.symbol = "main";
-
-fun out(s: str) {
-    os.write(os.STDOUT_FD, s::*u8, str_len(s));
-}
-
-fun out_num(n: i64) {
-    var buf: [24]u8;
-    var idx: i64 = 23;
-    var x:   i64 = n;
-    buf[idx] = '\n';
-    if (x == 0) {
-        idx = idx - 1;
-        buf[idx] = '0';
-    }
-    or {
-        for (x > 0) {
-            idx = idx - 1;
-            buf[idx] = (x % 10)::u8 + '0';
-            x = x / 10;
-        }
-    }
-    os.write(os.STDOUT_FD, ?buf[idx], (24 - idx)::usize);
-}
 
 # a generic record over two independent type parameters.
 rec Pair[A, B] {
@@ -59,15 +33,12 @@ fun main(argc: i64, argv: **u8) i64 {
     val n: i64 = identity[i64](7);
     val c: u8  = identity[u8]('Z');
 
-    out("identity[i64](7) = ");
-    out_num(n);
+    printlnf("identity[i64](7) = %d", n);
 
     # a Pair[i64, u8]; read both fields back.
     val pr: Pair[i64, u8] = make_pair[i64, u8](100, c);
-    out("pair.first = ");
-    out_num(pr.first);
-    out("pair.second (as int) = ");
-    out_num(pr.second::i64);
+    printlnf("pair.first = %d", pr.first);
+    printlnf("pair.second (as int) = %d", pr.second::i64);
 
     ret 0;
 }

--- a/examples/06_comptime/main.mach
+++ b/examples/06_comptime/main.mach
@@ -6,35 +6,10 @@
 # `$mode` parameter is a compile-time-known argument fixed per call site.
 
 use std.runtime;
-use std.types.size.usize;
-use std.types.string.str;
-use std.types.string.str_len;
-use os: std.system.os;
+use std.print.println;
+use std.print.printlnf;
 
 $main.symbol = "main";
-
-fun out(s: str) {
-    os.write(os.STDOUT_FD, s::*u8, str_len(s));
-}
-
-fun out_num(n: i64) {
-    var buf: [24]u8;
-    var idx: i64 = 23;
-    var x:   i64 = n;
-    buf[idx] = '\n';
-    if (x == 0) {
-        idx = idx - 1;
-        buf[idx] = '0';
-    }
-    or {
-        for (x > 0) {
-            idx = idx - 1;
-            buf[idx] = (x % 10)::u8 + '0';
-            x = x / 10;
-        }
-    }
-    os.write(os.STDOUT_FD, ?buf[idx], (24 - idx)::usize);
-}
 
 rec Point {
     x: i32;
@@ -65,34 +40,29 @@ fun apply($mode: u8, n: i64) i64 {
 }
 
 fun main(argc: i64, argv: **u8) i64 {
-    out("sizeof(Point): ");
-    out_num(POINT_SIZE::i64);
-    out("alignof(Point): ");
-    out_num(POINT_ALIGN::i64);
-    out("sizeof(Pair): ");
-    out_num(PAIR_SIZE::i64);
+    printlnf("sizeof(Point): %u", POINT_SIZE);
+    printlnf("alignof(Point): %u", POINT_ALIGN);
+    printlnf("sizeof(Pair): %u", PAIR_SIZE);
 
-    out("apply(DOUBLE, 21): ");
-    out_num(apply(MODE_DOUBLE, 21));
-    out("apply(SQUARE, 9): ");
-    out_num(apply(MODE_SQUARE, 9));
+    printlnf("apply(DOUBLE, 21): %d", apply(MODE_DOUBLE, 21));
+    printlnf("apply(SQUARE, 9): %d", apply(MODE_SQUARE, 9));
 
     # target-conditional code: only the taken branch is compiled and emitted.
     $if ($mach.target.os == $mach.os.linux) {
-        out("target os: linux\n");
+        println("target os: linux");
     }
     $or ($mach.target.os == $mach.os.darwin) {
-        out("target os: darwin\n");
+        println("target os: darwin");
     }
     $or {
-        out("target os: other\n");
+        println("target os: other");
     }
 
     $if ($mach.target.arch == $mach.arch.x86_64) {
-        out("target arch: x86_64\n");
+        println("target arch: x86_64");
     }
     $or {
-        out("target arch: other\n");
+        println("target arch: other");
     }
 
     ret 0;

--- a/examples/07_errors/main.mach
+++ b/examples/07_errors/main.mach
@@ -6,9 +6,7 @@
 # pass their type arguments explicitly, e.g. ok[i64, str](...).
 
 use std.runtime;
-use std.types.size.usize;
 use std.types.string.str;
-use std.types.string.str_len;
 
 use std.types.result.Result;
 use std.types.result.ok;
@@ -24,41 +22,10 @@ use std.types.option.is_some;
 use std.types.option.unwrap;
 use std.types.option.unwrap_or;
 
-use os: std.system.os;
+use std.print.println;
+use std.print.printlnf;
 
 $main.symbol = "main";
-
-fun out(s: str) {
-    os.write(os.STDOUT_FD, s::*u8, str_len(s));
-}
-
-fun out_num(n: i64) {
-    var buf: [24]u8;
-    var idx: i64 = 23;
-    var neg: u8  = 0;
-    var x:   i64 = n;
-    buf[idx] = '\n';
-    if (x < 0) {
-        neg = 1;
-        x   = -x;
-    }
-    if (x == 0) {
-        idx = idx - 1;
-        buf[idx] = '0';
-    }
-    or {
-        for (x > 0) {
-            idx = idx - 1;
-            buf[idx] = (x % 10)::u8 + '0';
-            x = x / 10;
-        }
-    }
-    if (neg == 1) {
-        idx = idx - 1;
-        buf[idx] = '-';
-    }
-    os.write(os.STDOUT_FD, ?buf[idx], (24 - idx)::usize);
-}
 
 # integer divide that reports the divide-by-zero case as an error rather
 # than trapping.
@@ -80,32 +47,27 @@ fun nth(data: *i64, len: i64, i: i64) Option[i64] {
 fun main(argc: i64, argv: **u8) i64 {
     val good: Result[i64, str] = checked_div(84, 2);
     if (is_ok[i64, str](good)) {
-        out("84 / 2 = ");
-        out_num(unwrap_ok[i64, str](good));
+        printlnf("84 / 2 = %d", unwrap_ok[i64, str](good));
     }
 
     val bad: Result[i64, str] = checked_div(1, 0);
     if (is_ok[i64, str](bad)) {
-        out("unexpected ok\n");
+        println("unexpected ok");
     }
     or {
-        out("1 / 0 failed: ");
-        out(unwrap_err[i64, str](bad));
-        out("\n");
+        printlnf("1 / 0 failed: %s", unwrap_err[i64, str](bad));
     }
 
     var nums: [3]i64 = [3]i64{ 10, 20, 30 };
 
     val present: Option[i64] = nth(?nums[0], 3, 1);
     if (is_some[i64](present)) {
-        out("nums[1] = ");
-        out_num(unwrap[i64](present));
+        printlnf("nums[1] = %d", unwrap[i64](present));
     }
 
     # out-of-range read falls back to a default via unwrap_or.
     val missing: Option[i64] = nth(?nums[0], 3, 9);
-    out("nums[9] or -1 = ");
-    out_num(unwrap_or[i64](missing, -1));
+    printlnf("nums[9] or -1 = %d", unwrap_or[i64](missing, -1));
 
     ret 0;
 }

--- a/examples/08_strings/main.mach
+++ b/examples/08_strings/main.mach
@@ -12,56 +12,24 @@ use std.types.string.str_len;
 use std.types.string.str_equals;
 use std.types.string.str_starts_with;
 use std.types.string.str_contains;
-use os: std.system.os;
+use std.print.printlnf;
 
 $main.symbol = "main";
 
-fun out(s: str) {
-    os.write(os.STDOUT_FD, s::*u8, str_len(s));
-}
-
-fun out_num(n: i64) {
-    var buf: [24]u8;
-    var idx: i64 = 23;
-    var x:   i64 = n;
-    buf[idx] = '\n';
-    if (x == 0) {
-        idx = idx - 1;
-        buf[idx] = '0';
-    }
-    or {
-        for (x > 0) {
-            idx = idx - 1;
-            buf[idx] = (x % 10)::u8 + '0';
-            x = x / 10;
-        }
-    }
-    os.write(os.STDOUT_FD, ?buf[idx], (24 - idx)::usize);
-}
-
-fun out_bool(b: bool) {
-    if (b) { out("true\n"); }
-    or { out("false\n"); }
+# render a bool as its literal text for %s formatting.
+fun bool_str(b: bool) str {
+    if (b) { ret "true"; }
+    ret "false";
 }
 
 fun main(argc: i64, argv: **u8) i64 {
     val greeting: str = "hello, mach";
 
-    out("greeting: ");
-    out(greeting);
-    out("\n");
-
-    out("length: ");
-    out_num(str_len(greeting)::i64);
-
-    out("equals \"hello, mach\": ");
-    out_bool(str_equals(greeting, "hello, mach"));
-
-    out("starts with \"hello\": ");
-    out_bool(str_starts_with(greeting, "hello"));
-
-    out("contains \"mach\": ");
-    out_bool(str_contains(greeting, "mach"));
+    printlnf("greeting: %s", greeting);
+    printlnf("length: %d", str_len(greeting)::i64);
+    printlnf("equals \"hello, mach\": %s", bool_str(str_equals(greeting, "hello, mach")));
+    printlnf("starts with \"hello\": %s", bool_str(str_starts_with(greeting, "hello")));
+    printlnf("contains \"mach\": %s", bool_str(str_contains(greeting, "mach")));
 
     # build an uppercased copy by walking the source one byte at a time.
     var upper: [32]u8;
@@ -76,9 +44,7 @@ fun main(argc: i64, argv: **u8) i64 {
     }
     upper[i] = 0;
 
-    out("uppercased: ");
-    out((?upper[0])::str);
-    out("\n");
+    printlnf("uppercased: %s", (?upper[0])::str);
 
     ret 0;
 }

--- a/examples/09_collections/main.mach
+++ b/examples/09_collections/main.mach
@@ -6,10 +6,8 @@
 # with the page allocator and stores i64 keys.
 
 use std.runtime;
-use std.types.size.usize;
 use std.types.bool.bool;
 use std.types.string.str;
-use std.types.string.str_len;
 
 use allocator: std.allocator;
 use page:      std.allocator.page;
@@ -21,36 +19,14 @@ use std.types.result.Result;
 use std.types.result.is_ok;
 use std.types.result.unwrap_ok;
 
-use os: std.system.os;
+use std.print.printlnf;
 
 $main.symbol = "main";
 
-fun out(s: str) {
-    os.write(os.STDOUT_FD, s::*u8, str_len(s));
-}
-
-fun out_num(n: i64) {
-    var buf: [24]u8;
-    var idx: i64 = 23;
-    var x:   i64 = n;
-    buf[idx] = '\n';
-    if (x == 0) {
-        idx = idx - 1;
-        buf[idx] = '0';
-    }
-    or {
-        for (x > 0) {
-            idx = idx - 1;
-            buf[idx] = (x % 10)::u8 + '0';
-            x = x / 10;
-        }
-    }
-    os.write(os.STDOUT_FD, ?buf[idx], (24 - idx)::usize);
-}
-
-fun out_bool(b: bool) {
-    if (b) { out("true\n"); }
-    or { out("false\n"); }
+# render a bool as its literal text for %s formatting.
+fun bool_str(b: bool) str {
+    if (b) { ret "true"; }
+    ret "false";
 }
 
 fun main(argc: i64, argv: **u8) i64 {
@@ -67,23 +43,19 @@ fun main(argc: i64, argv: **u8) i64 {
         k = k + 1;
     }
 
-    out("map length: ");
-    out_num(map.length[i64, i64](squares)::i64);
+    printlnf("map length: %d", map.length[i64, i64](squares)::i64);
 
     var key: i64 = 3;
     val lookup: Result[*i64, str] = map.get[i64, i64](?squares, ?key);
     if (is_ok[*i64, str](lookup)) {
-        out("squares[3] = ");
-        out_num(@unwrap_ok[*i64, str](lookup));
+        printlnf("squares[3] = %d", @unwrap_ok[*i64, str](lookup));
     }
 
-    out("map contains 4: ");
     key = 4;
-    out_bool(map.contains[i64, i64](?squares, ?key));
+    printlnf("map contains 4: %s", bool_str(map.contains[i64, i64](?squares, ?key)));
 
-    out("map contains 9: ");
     key = 9;
-    out_bool(map.contains[i64, i64](?squares, ?key));
+    printlnf("map contains 9: %s", bool_str(map.contains[i64, i64](?squares, ?key)));
 
     # Set[i64]: dedupe a sequence with repeats.
     var seen: set.Set[i64] = set.init[i64](?alloc, map.hash_i64, map.eq_i64);
@@ -95,12 +67,10 @@ fun main(argc: i64, argv: **u8) i64 {
         i = i + 1;
     }
 
-    out("set length (unique values): ");
-    out_num(set.length[i64](seen)::i64);
+    printlnf("set length (unique values): %d", set.length[i64](seen)::i64);
 
     key = 7;
-    out("set contains 7: ");
-    out_bool(set.contains[i64](?seen, ?key));
+    printlnf("set contains 7: %s", bool_str(set.contains[i64](?seen, ?key)));
 
     map.dnit[i64, i64](?squares);
     set.dnit[i64](?seen);

--- a/examples/10_lowlevel/main.mach
+++ b/examples/10_lowlevel/main.mach
@@ -9,6 +9,7 @@ use std.runtime;
 use std.types.size.usize;
 use std.types.string.str;
 use std.types.string.str_len;
+use std.print.printlnf;
 
 $main.symbol = "main";
 
@@ -38,34 +39,14 @@ fun raw_write(fd: i64, buf: *u8, len: usize) i64 {
     ret ret_val;
 }
 
-fun out(s: str) {
-    raw_write(1, s::*u8, str_len(s));
-}
-
-fun out_num(n: i64) {
-    var buf: [24]u8;
-    var idx: i64 = 23;
-    var x:   i64 = n;
-    buf[idx] = '\n';
-    if (x == 0) {
-        idx = idx - 1;
-        buf[idx] = '0';
-    }
-    or {
-        for (x > 0) {
-            idx = idx - 1;
-            buf[idx] = (x % 10)::u8 + '0';
-            x = x / 10;
-        }
-    }
-    raw_write(1, ?buf[idx], (24 - idx)::usize);
-}
-
 fun main(argc: i64, argv: **u8) i64 {
-    out("written via raw syscall, no stdlib write\n");
+    # the raw syscall is the point of this example: write straight to fd 1
+    # with no stdlib wrapper.
+    val msg: str = "written via raw syscall, no stdlib write\n";
+    raw_write(1, msg::*u8, str_len(msg));
 
-    out("add_asm(40, 2) = ");
-    out_num(add_asm(40, 2));
+    # the inline-asm result is ordinary data, so print it with std.print.
+    printlnf("add_asm(40, 2) = %d", add_asm(40, 2));
 
     ret 0;
 }

--- a/examples/README.md
+++ b/examples/README.md
@@ -38,8 +38,9 @@ the repository's `dep/mach-std`. The build resolves it as a local dependency.
 It is a reference for the language surface, not a runnable program against the
 current compiler.
 
-## Output helpers
+## Output
 
-Several examples include a small local `out` / `out_num` pair that writes to
-stdout via `std.system.os.write`. They are written out in full in each file so
-every example reads top to bottom without cross-references.
+Examples print through `std.print`: `println` for a line of text and
+`printlnf` for formatted output (`%d` signed, `%u` unsigned, `%s` string).
+`10_lowlevel` is the exception — it writes its first line with a hand-issued
+`write` syscall, since the raw syscall is the point of that example.


### PR DESCRIPTION
Switches every example program (`01_hello` .. `10_lowlevel`) to print through `std.print` instead of `std.system.os.write` plus a local `out` / `out_num` helper. This was previously blocked by the aggregate-global-init codegen bug (#1106), now fixed and merged, so `std.print` (which depends on `fs.stdout`) works.

## What changed
- Replaced the per-example `out` / `out_num` boilerplate with `std.print` `println` / `printlnf` (`%d` signed, `%u` unsigned, `%s` string).
- Removed the now-dead local helpers and their unused imports (`std.system.os`, `str_len`, `usize`, ...), keeping only imports each example still needs.
- Each example's demonstrated concept is unchanged; output matches the previous helper-based output byte for byte.
- `08_strings` / `09_collections` add a tiny `bool_str` helper to render booleans for `%s`.
- `10_lowlevel` keeps its hand-issued `write` syscall for the line that demonstrates the raw syscall (the point of the example) and prints its inline-asm result through `std.print`.
- Updated `examples/README.md`'s output note to describe `std.print`.

## Verification
All ten examples build (`mach build`) and run with output identical to the previous versions:

| Example | Output |
| --- | --- |
| 01_hello | `hello, mach` |
| 02_control_flow | `negative` / `zero` / `positive` / `sum of evens until > 12: 20` |
| 03_functions | `factorial(5) = 120` / `MAX_N is even: yes` |
| 04_structs_unions | `manhattan distance: 8` / `tagged value is int: yes -> 99` |
| 05_generics | `identity[i64](7) = 7` / `pair.first = 100` / `pair.second (as int) = 90` |
| 06_comptime | `sizeof(Point): 16` ... `target os: linux` / `target arch: x86_64` |
| 07_errors | `84 / 2 = 42` / `1 / 0 failed: divide by zero` / `nums[1] = 20` / `nums[9] or -1 = -1` |
| 08_strings | `greeting: hello, mach` ... `uppercased: HELLO, MACH` |
| 09_collections | `map length: 4` ... `set contains 7: true` |
| 10_lowlevel | `written via raw syscall, no stdlib write` / `add_asm(40, 2) = 42` |

Closes #1100
