### PR TITLE
fix(lower): call through a function-typed global via the stored pointer

### DIFF
--- a/src/lang/me/lower/expr.mach
+++ b/src/lang/me/lower/expr.mach
@@ -370,10 +370,13 @@ fun symbol_reference(ctx: *lower.LowerContext, eid: aid.ExprId, sid: resolve.Sym
     val link: intern.StrId = unwrap_ok[intern.StrId, str](ln_r);
 
     # a function reference: a local function resolves to its module index; a
-    # function imported from another module (kind SYM_IMPORTED, function-typed)
-    # resolves through a signature-only extern declaration so the back end emits
-    # a name-based call relocation the linker binds to the defining object.
-    if (sym.kind == resolve.SYM_FUN || references_function(ctx, eid)) {
+    # function imported from another module (kind SYM_IMPORTED, naming a function
+    # decl) resolves through a signature-only extern declaration so the back end
+    # emits a name-based call relocation the linker binds to the defining object.
+    # a `val`/`var` binding whose type is a function pointer is NOT a function
+    # reference — it falls through to the global-load path below, so a call
+    # through it loads the stored pointer and dispatches indirectly.
+    if (names_function(ctx, sym)) {
         val fi: Option[u32] = find_function(ctx, link);
         if (is_some[u32](fi)) {
             ret ok[value.Value, str](value.fn_value(unwrap[u32](fi), vty));
@@ -426,6 +429,28 @@ pub fun references_function(ctx: *lower.LowerContext, eid: aid.ExprId) bool {
     val t_opt: Option[*ty.Type] = ty.get(?ctx.s.types, tid);
     if (is_none[*ty.Type](t_opt)) { ret false; }
     ret unwrap[*ty.Type](t_opt).kind == ty.TYPE_FUN;
+}
+
+# true when an identifier names a function DECLARATION (so a reference to it is the
+# function's code symbol — a direct call / PC32-relative reference), rather than a
+# `val`/`var` binding whose type merely happens to be a function pointer (storage
+# holding a pointer — a load, then an indirect call). the discriminator is the
+# referent's nature, not its type: a `SYM_FUN` is a function; a `SYM_VAL`/`SYM_VAR`
+# is always a binding; an imported symbol resolves by reading the origin decl's
+# kind from its module AST. used by call/rvalue lowering — `references_function`
+# (type-based) cannot tell `f` from a `val P: fun(...)... = f` binding.
+fun names_function(ctx: *lower.LowerContext, sym: *resolve.Symbol) bool {
+    if (sym.kind == resolve.SYM_FUN) { ret true; }
+    if (sym.kind == resolve.SYM_VAL || sym.kind == resolve.SYM_VAR
+        || sym.kind == resolve.SYM_PARAM) { ret false; }
+    if (sym.kind != resolve.SYM_IMPORTED) { ret false; }
+    # an imported symbol carries only SYM_IMPORTED; recover whether it names a
+    # function by reading its origin decl's kind from the defining module's AST.
+    val ga: *ast.Ast = sess.module_ast(ctx.s, sym.origin);
+    if (ga == nil) { ret false; }
+    val d_opt: Option[*adecl.Decl] = ast.get_decl(ga, sym.decl);
+    if (is_none[*adecl.Decl](d_opt)) { ret false; }
+    ret unwrap[*adecl.Decl](d_opt).kind == adecl.DECL_KIND_FUN;
 }
 
 # the storage pointer of a module-level binding `sid`: a global defined in this


### PR DESCRIPTION
## Summary

Calling through a function-typed global — `val P: fun(i64) i64 = f; ... P(5);` — segfaulted: the call site lowered `P` as a direct PC32 reference to the global's symbol (calling the *address of the global's storage*) instead of LOADING the 8-byte function pointer stored in the global and dispatching indirectly. The data side was already correct (#1106/#1108 — the global holds a relocation to `f`); this fixes the call/rvalue side.

## Root cause

`symbol_reference` (rvalue lowering of a module-level identifier) chose between a direct function reference and a global load with:

```
if (sym.kind == resolve.SYM_FUN || references_function(ctx, eid)) { ... direct fn ref ... }
```

`references_function` is **type-based**: it returns true for *any* expression of function type. A function-typed `val`/`var` global (`SYM_VAL`) IS of function type, so it was wrongly treated as a direct function declaration reference (`VAL_FN`) — the call then emitted a PC32-direct call to the symbol's address. The discriminator must be the referent's *nature*, not its type.

## Fix

Introduce `names_function(ctx, sym)`, a **symbol-based** predicate:

- `SYM_FUN` → a function (direct reference / PC32-direct call)
- `SYM_VAL` / `SYM_VAR` / `SYM_PARAM` → always a binding → fall through to the global-load path, which loads the stored pointer (`IRT_FN`, pointer-width) and the call dispatches indirectly through the resulting vreg
- `SYM_IMPORTED` → recover the referent's kind by reading the origin decl from the defining module's AST (`DECL_KIND_FUN` ⇒ function)

The data-side `references_function` (constant-aggregate function-pointer leaves in `constagg.mach`) is intentionally unchanged — there the type-based question is the correct one.

## Verification

- Repro `val P: fun(i64) i64 = f; ret P(5);` now returns 105 at both `-O0` and `-O2` (was SIGSEGV / exit 139).
- Direct call `f(5)`, `*fun` local pointer call, and fn-pointer struct field call all still work (they were already correct — verified).
- Reading a function-typed global into a local and **mutating it at runtime** (`P = g; P(5)`) now works — function-typed globals are genuine first-class mutable function pointers.
- `make clean && make` exits 0; bootstrap fixpoint is byte-identical (`cmp -s out/bin/mach out/bin/mach2`).
- Corpus gate `out/bin/mach test --cwd .` passes (194 PASS, 0 FAIL).
- Differential smach-vs-mach: all 10 examples PASS. (The `-O2` differential half BUILD-FAILs on a pre-existing, unrelated `gep base is neither a memory nor a symbol reference` error present on `dev` before this change — flagged separately, out of scope.)

Closes #1119
