### PR TITLE
fix(x64): correct f32 single-precision runtime load/store/convert

### DIFF
--- a/src/lang/be/codegen/mir.mach
+++ b/src/lang/be/codegen/mir.mach
@@ -61,6 +61,7 @@ use std.system.panic.panic;
 
 use map: std.collections.map;
 
+use float:   mach.lang.float;
 use intern:  mach.lang.intern;
 use target:  mach.lang.target.resolved;
 use abi:     mach.lang.target.abi;
@@ -2094,16 +2095,14 @@ fun lower_generic(ctx: *LowerCtx, mb: *MirBlock, inst: *instr.Instruction, iid: 
 #     0, so the encoder's MOVZX / MOVSX selects the narrow / wide source form;
 #   - a comparison (CMP_*) yields an i8 result but the CMP operates at the compared
 #     operand width, so both widths come from operand 0;
-#   - the float conversions (FP_TO_SI / SI_TO_FP family) and other FP ops ride at the
-#     word width: their integer-vs-float operand widths are handled by the float
-#     encoders, outside this base-width carrier, so the prior word-sized behavior is
-#     preserved unchanged;
+#   - the float conversions (FP_TO_SI / SI_TO_FP family) carry their true result and
+#     operand-0 widths so the SSE conversion encoder selects the SS-vs-SD float form
+#     from the float side and sizes the GP integer side for REX.W (`set_conv_widths`);
 #   - a void-result terminator / branch has no natural width and rides at the word
 #     width, which only sizes its address-sized fields.
 fun set_generic_widths(ctx: *LowerCtx, inst: *instr.Instruction, mi: *MirInstr) {
     if (is_float_kind(ctx, inst)) {
-        mi.width     = WORD_WIDTH;
-        mi.src_width = WORD_WIDTH;
+        set_conv_widths(ctx, inst, mi);
         ret;
     }
     if (is_compare_kind(inst.kind) && inst.operand_count >= 1) {
@@ -2124,6 +2123,22 @@ fun set_generic_widths(ctx: *LowerCtx, inst: *instr.Instruction, mi: *MirInstr) 
     if (is_int_conversion_kind(inst.kind) && inst.operand_count >= 1) {
         sw = op_width_of(ctx, inst.operands[0].ty);
     }
+    mi.width     = dw;
+    mi.src_width = sw;
+}
+
+# set_conv_widths: stamp the destination and source widths of a float conversion
+# (FP_TO_SI / FP_TO_UI / SI_TO_FP / UI_TO_FP / FP_TRUNC / FP_EXT). `mi.width` is the
+# result-type width and `mi.src_width` is operand 0's width. the SSE conversion
+# encoder reads the FLOAT side of the pair (the side whose type is f32 / f64,
+# determined from the concrete opcode) to pick the single-precision SS vs double SD
+# form, and sizes the GP integer side from its own width for REX.W. an FP_TRUNC /
+# FP_EXT has float on both sides; its single opcode needs no width selection, so the
+# carried widths only document the operand sizes.
+fun set_conv_widths(ctx: *LowerCtx, inst: *instr.Instruction, mi: *MirInstr) {
+    var dw: u8 = op_width_of(ctx, inst.ty);
+    var sw: u8 = dw;
+    if (inst.operand_count >= 1) { sw = op_width_of(ctx, inst.operands[0].ty); }
     mi.width     = dw;
     mi.src_width = sw;
 }
@@ -2348,6 +2363,15 @@ fun lower_alloca(ctx: *LowerCtx, mb: *MirBlock, inst: *instr.Instruction, iid: i
 # address resolves to `[rbp + offset]` and a runtime pointer to `[reg]`), while a
 # symbol / immediate pointer is left as a plain operand for the encoder to form
 # its own reference. the result vreg is the loaded value.
+#
+# a FLOAT load is retagged to MIR_FMOV by isel and emitted through the SSE
+# operand-routing encoder, which materializes a MOVSS / MOVSD off the resolved
+# operand WITHOUT recording a symbol relocation (it has no patch-site hook). a
+# global / function symbol pointer must therefore be LEA-materialized into a GP
+# base vreg first (the LEA carries the relocation through the generic path), so the
+# float load addresses `[base]` rather than an unrelocated `[rip+sym]` that would
+# read the wrong address. an integer load keeps the symbol operand: its generic
+# encoding records the relocation directly.
 fun lower_load(ctx: *LowerCtx, mb: *MirBlock, inst: *instr.Instruction, iid: id.InstructionId) Result[bool, str] {
     if (inst.operand_count == 0) {
         ret err[bool, str]("mir.lower_ir: load with no pointer operand");
@@ -2356,11 +2380,18 @@ fun lower_load(ctx: *LowerCtx, mb: *MirBlock, inst: *instr.Instruction, iid: id.
     if (dst == MIR_VREG_NIL) {
         ret err[bool, str]("mir.lower_ir: load defines no result vreg");
     }
+    var mem: MirOperand = mem_operand_of(ctx, inst.operands[0]);
+    if (mem.kind == MIR_OP_SYM && value_is_float(ctx, inst.ty)) {
+        var base: u32 = MIR_VREG_NIL;
+        val ar: Result[bool, str] = addr_to_vreg(ctx, mb, mem, ?base);
+        if (is_err[bool, str](ar)) { ret err[bool, str](unwrap_err[bool, str](ar)); }
+        mem = op_mem_value(base, 0);
+    }
     val r: Result[*MirOperand, str] = allocate[MirOperand](ctx.alloc, 2::usize);
     if (is_err[*MirOperand, str](r)) { ret err[bool, str](unwrap_err[*MirOperand, str](r)); }
     val ops: *MirOperand = unwrap_ok[*MirOperand, str](r);
     ops[0] = op_vreg(dst);
-    ops[1] = mem_operand_of(ctx, inst.operands[0]);
+    ops[1] = mem;
     var mi: MirInstr;
     mi.opcode        = MIR_LOAD;
     mi.operands      = ops;
@@ -2405,10 +2436,22 @@ fun lower_store(ctx: *LowerCtx, mb: *MirBlock, inst: *instr.Instruction) Result[
         if (is_err[bool, str](ar)) { ret ar; }
         stored = op_vreg(addr);
     }
+    # a FLOAT store is retagged to MIR_FMOV and emitted through the SSE encoder,
+    # which records no symbol relocation for its destination MEM. a global symbol
+    # destination must therefore be LEA-materialized into a GP base vreg first (so
+    # the store addresses `[base]`), mirroring the float-load path; an integer store
+    # keeps the symbol destination and relocates through the generic encoding.
+    var dest: MirOperand = mem_operand_of(ctx, inst.operands[1]);
+    if (dest.kind == MIR_OP_SYM && value_is_float(ctx, inst.operands[0].ty)) {
+        var dbase: u32 = MIR_VREG_NIL;
+        val dr: Result[bool, str] = addr_to_vreg(ctx, mb, dest, ?dbase);
+        if (is_err[bool, str](dr)) { ret err[bool, str](unwrap_err[bool, str](dr)); }
+        dest = op_mem_value(dbase, 0);
+    }
     val r: Result[*MirOperand, str] = allocate[MirOperand](ctx.alloc, 2::usize);
     if (is_err[*MirOperand, str](r)) { ret err[bool, str](unwrap_err[*MirOperand, str](r)); }
     val ops: *MirOperand = unwrap_ok[*MirOperand, str](r);
-    ops[0] = mem_operand_of(ctx, inst.operands[1]);
+    ops[0] = dest;
     ops[1] = stored;
     var mi: MirInstr;
     mi.opcode        = MIR_STORE;
@@ -4456,6 +4499,15 @@ fun lower_value(ctx: *LowerCtx, v: value.Value) MirOperand {
         ret op_imm(0);
     }
     if (v.kind == value.VAL_CONST_FLOAT) {
+        # the constant carries its comptime f64 bit pattern (the `int_lit` /
+        # `float_lit` union alias). an f32 constant must materialize its
+        # single-precision pattern so the low 32 bits an SS-form load / op reads
+        # are the f32 value, not the low half of the f64 representation. narrow
+        # with the shared round-to-nearest-even conversion, matching the global
+        # initializer emission.
+        if (op_width_of(ctx, v.ty) == 4) {
+            ret op_imm(float.f64_to_f32_bits(v.data.int_lit)::i64);
+        }
         ret op_imm(v.data.int_lit::i64);
     }
     if (v.kind == value.VAL_GLOBAL) {

--- a/src/lang/target/isa/x64/encode.mach
+++ b/src/lang/target/isa/x64/encode.mach
@@ -2473,6 +2473,15 @@ fun encode_mir_instr(st: *EncodeState, f: *mir.MirFunction, fn_base: u32, mi: *m
         ret encode_float_mov(f, mi, ?st.buf);
     }
 
+    # a float conversion survives selection keeping its dedicated MIR_FP_* opcode;
+    # the encoder materializes the SSE conversion byte sequence here, routing the
+    # float side through the XMM scratch and the integer side through the GP scratch
+    # so any spilled frame-slot operand encodes (the reg-reg-only `encode_cvt` path
+    # cannot) and selecting the SS vs SD form from the carried float-side width.
+    if (is_mir_float_conv(mi.opcode)) {
+        ret encode_float_conv(f, mi, ?st.buf);
+    }
+
     # the AL-guarded variadic FP-register spill survives selection keeping its
     # MIR_VA_FP_SAVE opcode; the encoder materializes its self-contained TEST ; JZ ;
     # MOVSD sequence here (the conditional skip is intra-instruction, so no block
@@ -2877,6 +2886,144 @@ fun encode_float_mov(f: *mir.MirFunction, mi: *mir.MirInstr, buf: *ByteBuf) Resu
     val ld: Result[bool, str] = emit_float_load(src, FLOAT_SCRATCH0, w, buf);
     if (is_err[bool, str](ld)) { ret ld; }
     ret emit_float_store(dst, FLOAT_SCRATCH0, w, buf);
+}
+
+# is_mir_float_conv: true when a post-isel opcode is a surviving float conversion
+# (FP_TRUNC / FP_EXT / FP_TO_SI / FP_TO_UI / SI_TO_FP / UI_TO_FP). these keep their
+# dedicated MIR opcode through selection; the encoder materializes the SSE byte
+# sequence here.
+fun is_mir_float_conv(op: mir.MirOpcode) bool {
+    ret op == mir.MIR_FP_TRUNC || op == mir.MIR_FP_EXT ||
+        op == mir.MIR_FP_TO_SI || op == mir.MIR_FP_TO_UI ||
+        op == mir.MIR_SI_TO_FP || op == mir.MIR_UI_TO_FP;
+}
+
+# emit_gp_load: load a GP integer operand into the GP scratch register `gp` at byte
+# width `w`. the operand resolves after register allocation to a physical register
+# (a plain MOV), a frame slot (a `MOV reg, [rbp + off]` reload), or an immediate (a
+# `MOV reg, imm`). a float-bank operand would mean the allocator placed an integer
+# value in the wrong bank — rejected loudly. mirrors `emit_float_load` for the GP
+# side of a conversion.
+fun emit_gp_load(op: isa.Operand, gp: i32, w: u8, buf: *ByteBuf) Result[bool, str] {
+    if (op.kind == isa.OPK_REG || op.kind == isa.OPK_MEM || op.kind == isa.OPK_IMM) {
+        var ld: isa.Inst;
+        zero_inst(?ld);
+        ld.opcode = x64.MOV;
+        ld.dst    = isa.make_reg(gp, w);
+        ld.src1   = op;
+        ld.size   = w;
+        ld.flags  = width_flags(w);
+        encode_inst(?ld, buf);
+        ret ok[bool, str](true);
+    }
+    ret err[bool, str]("encode: conversion integer operand is not a register, frame slot, or immediate");
+}
+
+# emit_gp_store: store the GP scratch register `gp` to a conversion's integer
+# destination at byte width `w` — a physical register (a plain MOV) or a frame slot
+# (a `MOV [rbp + off], reg` spill). a float-bank destination is a backend bug,
+# rejected loudly. mirrors `emit_float_store` for the GP side of a conversion.
+fun emit_gp_store(dst: isa.Operand, gp: i32, w: u8, buf: *ByteBuf) Result[bool, str] {
+    if (dst.kind == isa.OPK_REG || dst.kind == isa.OPK_MEM) {
+        var st: isa.Inst;
+        zero_inst(?st);
+        st.opcode = x64.MOV;
+        st.dst    = dst;
+        st.src1   = isa.make_reg(gp, w);
+        st.size   = w;
+        st.flags  = width_flags(w);
+        encode_inst(?st, buf);
+        ret ok[bool, str](true);
+    }
+    ret err[bool, str]("encode: conversion integer destination is not a register or frame slot");
+}
+
+# emit_cvt_reg: emit one register-register SSE conversion `cvt_op dst_reg, src_reg`
+# at the given integer-side byte width (sizes REX.W for the GP operand of a
+# CVTSI2SS/SD / CVTTSS2SI/SD; a float-to-float CVTSS2SD / CVTSD2SS ignores it).
+fun emit_cvt_reg(cvt_op: u16, dst_reg: i32, src_reg: i32, int_w: u8, buf: *ByteBuf) {
+    var cvt: isa.Inst;
+    zero_inst(?cvt);
+    cvt.opcode = cvt_op;
+    cvt.dst    = isa.make_reg(dst_reg, 16);
+    cvt.src1   = isa.make_reg(src_reg, 16);
+    cvt.size   = int_w;
+    cvt.flags  = width_flags(int_w);
+    encode_inst(?cvt, buf);
+}
+
+# encode_float_conv: materialize a fully-resolved float conversion into its SSE byte
+# sequence, routing operands through the fixed scratch registers (XMM FLOAT_SCRATCH0
+# for the float side, the GP SCRATCH_REG for the integer side) exactly as
+# `encode_float_arith` does — so every operand shape regalloc can produce (a
+# register, a spilled `[rbp + off]` frame slot, or an immediate) encodes without the
+# reg-reg-only `encode_cvt` path. the carried widths (`mi.width` = result type,
+# `mi.src_width` = operand-0 type, both from `set_conv_widths`) select the
+# single-precision SS vs double SD form on the float side and size the GP integer
+# side for REX.W. operand layout is `[dst, src]`.
+#
+# FP_TO_SI / FP_TO_UI map to the signed CVTTSS2SI / CVTTSD2SI: a full unsigned
+# 64-bit conversion needs a range-fixup sequence x86-64 lacks a single instruction
+# for; the signed form is correct for every value in signed range, which is what the
+# language's reachable conversions produce, and matches the prior selection.
+fun encode_float_conv(f: *mir.MirFunction, mi: *mir.MirInstr, buf: *ByteBuf) Result[bool, str] {
+    if (mi.operand_count < 2) {
+        ret err[bool, str]("encode: float conversion missing operands");
+    }
+    val op: mir.MirOpcode = mi.opcode;
+    val dst_w: u8 = mi.width;
+    val src_w: u8 = mi.src_width;
+
+    # FP_TRUNC (f64 -> f32) and FP_EXT (f32 -> f64): float on both sides.
+    if (op == mir.MIR_FP_TRUNC || op == mir.MIR_FP_EXT) {
+        val rd: Result[isa.Operand, str] = mir_to_operand(f, ?mi.operands[0], 16);
+        if (is_err[isa.Operand, str](rd)) { ret err[bool, str](unwrap_err[isa.Operand, str](rd)); }
+        val dst: isa.Operand = unwrap_ok[isa.Operand, str](rd);
+        val rs: Result[isa.Operand, str] = mir_to_operand(f, ?mi.operands[1], src_w);
+        if (is_err[isa.Operand, str](rs)) { ret err[bool, str](unwrap_err[isa.Operand, str](rs)); }
+        val src: isa.Operand = unwrap_ok[isa.Operand, str](rs);
+
+        val ld: Result[bool, str] = emit_float_load(src, FLOAT_SCRATCH0, src_w, buf);
+        if (is_err[bool, str](ld)) { ret ld; }
+        var cvt_op: u16 = x64.CVTSD2SS;
+        if (op == mir.MIR_FP_EXT) { cvt_op = x64.CVTSS2SD; }
+        emit_cvt_reg(cvt_op, FLOAT_SCRATCH0, FLOAT_SCRATCH0, 0, buf);
+        ret emit_float_store(dst, FLOAT_SCRATCH0, dst_w, buf);
+    }
+
+    # SI_TO_FP / UI_TO_FP (int -> float): dst is float (dst_w picks SS / SD), src is
+    # an integer (src_w sizes the GP load + REX.W of the CVTSI2SS/SD).
+    if (op == mir.MIR_SI_TO_FP || op == mir.MIR_UI_TO_FP) {
+        val rd: Result[isa.Operand, str] = mir_to_operand(f, ?mi.operands[0], 16);
+        if (is_err[isa.Operand, str](rd)) { ret err[bool, str](unwrap_err[isa.Operand, str](rd)); }
+        val dst: isa.Operand = unwrap_ok[isa.Operand, str](rd);
+        val rs: Result[isa.Operand, str] = mir_to_operand(f, ?mi.operands[1], src_w);
+        if (is_err[isa.Operand, str](rs)) { ret err[bool, str](unwrap_err[isa.Operand, str](rs)); }
+        val src: isa.Operand = unwrap_ok[isa.Operand, str](rs);
+
+        val ld: Result[bool, str] = emit_gp_load(src, x64.SCRATCH_REG, src_w, buf);
+        if (is_err[bool, str](ld)) { ret ld; }
+        var cvt_op: u16 = x64.CVTSI2SD;
+        if (dst_w == 4) { cvt_op = x64.CVTSI2SS; }
+        emit_cvt_reg(cvt_op, FLOAT_SCRATCH0, x64.SCRATCH_REG, src_w, buf);
+        ret emit_float_store(dst, FLOAT_SCRATCH0, dst_w, buf);
+    }
+
+    # FP_TO_SI / FP_TO_UI (float -> int): src is float (src_w picks SS / SD), dst is
+    # an integer (dst_w sizes the GP store + REX.W of the CVTTSS/SD2SI).
+    val rd: Result[isa.Operand, str] = mir_to_operand(f, ?mi.operands[0], dst_w);
+    if (is_err[isa.Operand, str](rd)) { ret err[bool, str](unwrap_err[isa.Operand, str](rd)); }
+    val dst: isa.Operand = unwrap_ok[isa.Operand, str](rd);
+    val rs: Result[isa.Operand, str] = mir_to_operand(f, ?mi.operands[1], 16);
+    if (is_err[isa.Operand, str](rs)) { ret err[bool, str](unwrap_err[isa.Operand, str](rs)); }
+    val src: isa.Operand = unwrap_ok[isa.Operand, str](rs);
+
+    val ld: Result[bool, str] = emit_float_load(src, FLOAT_SCRATCH0, src_w, buf);
+    if (is_err[bool, str](ld)) { ret ld; }
+    var cvt_op: u16 = x64.CVTTSD2SI;
+    if (src_w == 4) { cvt_op = x64.CVTTSS2SI; }
+    emit_cvt_reg(cvt_op, x64.SCRATCH_REG, FLOAT_SCRATCH0, dst_w, buf);
+    ret emit_gp_store(dst, x64.SCRATCH_REG, dst_w, buf);
 }
 
 # encode_va_fp_save: materialize the AL-guarded variadic FP-register spill

--- a/src/lang/target/isa/x64/isel.mach
+++ b/src/lang/target/isa/x64/isel.mach
@@ -394,13 +394,17 @@ fun rewrite_simple(mi: *mir.MirInstr) Result[bool, str] {
     if (o == mir.MIR_ZEXT)    { mi.opcode = x64.MOVZX::u32;  ret ok[bool, str](true); }
     if (o == mir.MIR_BITCAST) { mi.opcode = x64.MOV::u32;    ret ok[bool, str](true); }
 
-    # float conversions.
-    if (o == mir.MIR_FP_TRUNC) { mi.opcode = x64.CVTSD2SS::u32;  ret ok[bool, str](true); }
-    if (o == mir.MIR_FP_EXT)   { mi.opcode = x64.CVTSS2SD::u32;  ret ok[bool, str](true); }
-    if (o == mir.MIR_FP_TO_SI) { mi.opcode = x64.CVTTSD2SI::u32; ret ok[bool, str](true); }
-    if (o == mir.MIR_FP_TO_UI) { mi.opcode = x64.CVTTSD2SI::u32; ret ok[bool, str](true); }
-    if (o == mir.MIR_SI_TO_FP) { mi.opcode = x64.CVTSI2SD::u32;  ret ok[bool, str](true); }
-    if (o == mir.MIR_UI_TO_FP) { mi.opcode = x64.CVTSI2SD::u32;  ret ok[bool, str](true); }
+    # float conversions survive selection keeping their dedicated MIR_FP_* opcode
+    # (like the float arith ops): the encoder materializes the SSE byte sequence,
+    # routing the float operand through the XMM scratch and the integer operand
+    # through the GP scratch so any spilled frame-slot operand shape encodes (the
+    # CVT instructions have no mem operand support in this backend's encoder), and
+    # selecting the single-precision SS vs double SD form from the carried float-side
+    # width. retagging here to a concrete CVT opcode would force the reg-reg-only
+    # `encode_cvt` path, which cannot read a spilled operand and is width-blind.
+    if (o == mir.MIR_FP_TRUNC || o == mir.MIR_FP_EXT ||
+        o == mir.MIR_FP_TO_SI || o == mir.MIR_FP_TO_UI ||
+        o == mir.MIR_SI_TO_FP || o == mir.MIR_UI_TO_FP) { ret ok[bool, str](true); }
 
     # memory.
     if (o == mir.MIR_ALLOCA) { mi.opcode = x64.LEA::u32; ret ok[bool, str](true); }


### PR DESCRIPTION
Closes #1118.

## Problem
Reading an `f32` value back at runtime produced wrong values. Emitting f32 global *initializer bytes* was already correct (#1106), but loading/storing/operating on an f32 at runtime was broken. Investigation found three distinct single-precision backend gaps (two f32-specific, one affecting f64 globals too).

## Root causes & fixes

1. **f32 constant materialization** (`lower_value`): a `VAL_CONST_FLOAT` carried its comptime **f64** bit pattern as the immediate. For an f32, an SS-form load/op reads the low 32 bits of the XMM — which were the low half of the f64 representation (e.g. `3.5f` materialized as `0.0f`). Now narrowed to the single-precision pattern via the shared `f64_to_f32_bits`, matching the global-init path.

2. **FP conversions** (`isel` + `encode`): `FP_TO_SI/UI`, `SI_TO_FP/UI`, `FP_TRUNC/EXT` were selected to fixed double-form CVT opcodes and routed through the reg-reg-only `encode_cvt`, which is width-blind and cannot read a spilled frame-slot operand — a hard `produced no bytes` error (broken for **both** f32 and f64). They now survive selection keeping their `MIR_FP_*` opcode and are emitted by a new `encode_float_conv` that routes the float side through the XMM scratch (XMM14) and the integer side through the GP scratch (R11), selecting SS vs SD from the carried float-side width. `set_conv_widths` stamps the true result/operand widths instead of word width.

3. **Float global load/store relocation**: a float value loaded from / stored to a global symbol was retagged to `MIR_FMOV` and emitted by the SSE encoder, which records **no symbol relocation**, addressing an unrelocated `[rip+0]` (pre-existing, also broke f64 globals). Float global load/store now LEA-materialize the symbol address into a GP base vreg first (the LEA carries the reloc) and address `[base]`.

## Verification
- 17-case repro (f32 + f64 across local / global / param / struct-field / store-back / FP_TO_SI / SI_TO_FP round-trip / f32↔f64 convert / compare / add / mul, plus single-precision-rounding distinctness) — all pass.
- f64 regressions — all pass.
- `make clean && make` exits 0; **byte-identical fixpoint** (`cmp smach mach`) holds.
- `mach test --cwd .` — 194 PASS, exit 0.
- `differential.sh` smach-vs-mach cross-compiler diff — all PASS. (The `-O2` build-fail rows are a pre-existing release-pipeline `gep` error on clean `dev`, unrelated to this change.)

## Out of scope (surfaced separately)
Runtime **float negation** (`-x`) is unsupported in the backend: `OP_NEG` on a float lowers to integer `MIR_NEG`, miscompiling for both f32 and f64. A negative float literal currently routes through this for f32 (f64 literals are constfolded). This is a distinct gap — not f32 load/read-back — and should be tracked in its own issue.
