### PR TITLE
fix(x64): float-to-float bitcast cast miscompile (2.5::f64)

### DIFF
--- a/src/lang/target/isa/x64/isel.mach
+++ b/src/lang/target/isa/x64/isel.mach
@@ -155,6 +155,11 @@ pub fun select(alloc: *Allocator, tgt: *target.Target, fn: *mir.MirFunction) Res
 # selection like the float arith ops) makes regalloc route a spilled float operand
 # to its frame slot and the encoder emit MOVSS / MOVSD; the alias-free SSE form
 # also keeps the GP allocator from reusing the float's (GP-id-aliased) register.
+# a same-width float-to-float MIR_BITCAST (`f64::f64`, `f32::f32`) is likewise a
+# float register copy — its `[dst, src]` operands are both FP-class — so it joins
+# the retag rather than selecting to an aliased GP MOV that would corrupt the value
+# (a cross-domain reinterpret never reaches here: lowering routes int<->float
+# through the CVT family, so a BITCAST's operands always share a register class).
 # run before selection so isel's integer MIR_MOV / MIR_LOAD / MIR_STORE arms only
 # ever see integer/pointer operations.
 fun retag_float_moves(fn: *mir.MirFunction) {
@@ -165,7 +170,8 @@ fun retag_float_moves(fn: *mir.MirFunction) {
         for (ii < b.instr_count) {
             val mi: *mir.MirInstr = ?b.instrs[ii];
             if ((mi.opcode == mir.MIR_MOV || mi.opcode == mir.MIR_LOAD ||
-                 mi.opcode == mir.MIR_STORE) && move_is_float(fn, mi)) {
+                 mi.opcode == mir.MIR_STORE || mi.opcode == mir.MIR_BITCAST) &&
+                move_is_float(fn, mi)) {
                 mi.opcode = mir.MIR_FMOV;
             }
             ii = ii + 1;


### PR DESCRIPTION
## Summary

An explicit `::f64` cast on a float literal (e.g. `2.5::f64`) miscompiled to a wrong value at runtime, while the bare literal `2.5` was correct.

## Root cause

A same-width float-to-float cast lowers to an `OP_BITCAST` (`src/lang/me/lower/expr.mach`, `lower_cast`). In x64 instruction selection, `MIR_BITCAST` was unconditionally rewritten to `x64.MOV` — a **general-purpose register** move. Because the XMM and GP register id spaces overlap (XMM0 == RAX, XMM1 == RCX, ...), the GP MOV moved the aliased integer register's bytes instead of the float value, corrupting it. This is the same float-GP-alias hazard the `retag_float_moves` pass already guards for `MIR_MOV` / `MIR_LOAD` / `MIR_STORE`.

## Fix

A `MIR_BITCAST` whose operands are FP-class is a float register copy, so it joins `retag_float_moves` and becomes `MIR_FMOV` (MOVSS / MOVSD) like the ABI / phi float copies. A cross-domain reinterpret never reaches this point: lowering routes int<->float through the CVT family, so a `BITCAST`'s `[dst, src]` operands always share a register class.

## Verification

- `2.5::f64`, `0.0::f64`, `(-1.5)::f64`, `3.14::f64`, `1.0e9::f64`, `1234567.89::f64` all equal their bare literals at runtime.
- `x::f64` and `(x::f64)::f64` where `x` is an f64 variable are correct.
- `make clean && make` builds; FIXPOINT byte-identical; `mach test` and differential pass (see PR thread for full results).

## Out of scope (escalated separately)

While verifying I found two **pre-existing, unrelated** float bugs (present on `dev` before this change, not caused or fixed here):
- `i64::f64` (SI_TO_FP) and the reverse conversion produce wrong values.
- Runtime float negation (`-x` on a non-constant f64) is wrong.

Closes #1126
