### PR TITLE
fix(mir): lower a GEP with a constant-address base (-O2 std.print crash)

### DIFF
--- a/src/lang/be/codegen/mir.mach
+++ b/src/lang/be/codegen/mir.mach
@@ -2810,9 +2810,29 @@ fun is_sib_scale(s: u64) bool {
 # a value-vreg base carries the index in the SIB position; a symbol base with only a
 # constant offset folds into `sym_off` (a pure `[rip+sym+off]` reference), and a
 # symbol base with a runtime index LEA-materializes the symbol address into a value
-# vreg first (`addr_to_vreg`) so the scaled index has a register base to ride.
+# vreg first (`addr_to_vreg`) so the scaled index has a register base to ride. a
+# constant-address base (a null or integer pointer, e.g. a `null` argument inlined
+# into a pointer parameter the callee GEPs) materializes the constant into a value
+# vreg and indexes `[base + idx*scale + disp]` off it.
 fun fold_gep_mem(ctx: *LowerCtx, mb: *MirBlock, base: MirOperand, idx_vreg: u32, idx_scale: u8, disp: i64) Result[MirOperand, str] {
     var o: MirOperand = base;
+    if (base.kind == MIR_OP_IMM) {
+        # the base is a compile-time address; MOV it into a value vreg so the LEA /
+        # load / store has a register base to fold the constant displacement and the
+        # optional scaled index against.
+        val vr: Result[u32, str] = new_vreg(ctx, REG_CLASS_GP);
+        if (is_err[u32, str](vr)) { ret err[MirOperand, str](unwrap_err[u32, str](vr)); }
+        val vbase: u32 = unwrap_ok[u32, str](vr);
+        val mv: Result[bool, str] = emit_mov(ctx, mb, op_vreg(vbase), op_imm(base.imm));
+        if (is_err[bool, str](mv)) { ret err[MirOperand, str](unwrap_err[bool, str](mv)); }
+        var m: MirOperand = op_mem_value(vbase, disp);
+        if (idx_vreg != MIR_VREG_NIL) {
+            m.index         = idx_vreg;
+            m.scale         = idx_scale;
+            m.index_is_preg = false;
+        }
+        ret ok[MirOperand, str](m);
+    }
     if (base.kind == MIR_OP_MEM) {
         # a value-pointer / physical-register / frame-slot-key base all fold the
         # constant displacement into `imm`; the encoder resolves a slot key to


### PR DESCRIPTION
## Problem

Building any `std.print` program at `-O2` failed with:

```
error: mir.lower_ir: gep base is neither a memory nor a symbol reference
```

`-O0` built fine. This red the differential CI gate's `-O2` arm on `dev`, blocking the gate for unrelated PRs.

## Root cause

The pass that introduces the bad IR is the **inliner**. A std-library test such as `path: is_abs with nil` calls `is_abs(null)`. The inliner substitutes the `null` actual argument for the callee's pointer parameter (`remap_clone_operands`: `VAL_PARAM -> actual arg`). `is_abs` GEPs that pointer to read its first byte — in a block that is only reachable on the *non-null* branch, i.e. dead when the argument is null. But the inliner runs before the late constfold/dce that could prune it, and constfold does not fold `null == null` (it only folds `VAL_CONST_INT`), so the dead branch survives and the GEP-on-`null` reaches MIR lowering.

`fold_gep_mem` only handled a memory (vreg/slot/preg) base or a symbol base; an `MIR_OP_IMM` base (what `null`/an integer pointer lowers to) hit the final error.

## Fix

A constant-address GEP base is valid IR — a GEP computes an address, and the base being a compile-time address (a null or integer pointer) is well-formed. `fold_gep_mem` now lowers it: materialize the constant into a value vreg (`MOV vreg <- imm`) and index `[base + idx*scale + disp]` off that register, mirroring the existing symbol-with-runtime-index path. No pass is disabled or neutered.

Emitted code for the inlined null-base GEP:
```
mov   rcx, 0
lea   rdx, qword [rcx]
movzx eax, byte [rdx]
```

## Verification

- `println("hi")` minimal repro builds at both `-O0` and `-O2` and prints `hi`.
- `tools/test/differential.sh`: all 10 examples PASS at `-O0` **and** `-O2` (the previously-red `-O2` arm is green); smach-vs-mach arm green.
- `make clean && make` exits 0; FIXPOINT byte-identical (`cmp -s out/bin/mach out/bin/mach2`).
- `mach test --cwd .`: 194 pass, 0 fail.
- `-O2` still optimizes (release binary differs from `-O0`; inline/constfold/algebraic/cse/dce still fire).

Closes #1125
