### PR TITLE
docs: accuracy fixes — grammar, skills, README

### DIFF
--- a/.github/skills/mach-lowlevel/SKILL.md
+++ b/.github/skills/mach-lowlevel/SKILL.md
@@ -86,7 +86,8 @@ For anything that maps to a named stdlib function — atomics, fences, traps, bi
 
 - **Atomics** — load/store/cas/RMW, per arch × per ordering.
 - **Memory fences and CPU hints** — pause, prefetch.
-- **Traps / unreachable** — `trap()` with per-arch `asm { ud2 / brk 0 / ... }`.
+- **Traps / unreachable** — `trap()` with per-arch ISA-tagged blocks
+  (`asm x86_64 { ud2 }` / `asm aarch64 { brk 0 }`).
 - **Syscalls** — per-platform ABI wrappers.
 - **Bit manipulation** — popcount, clz, ctz, bswap.
 - **SIMD long tail** — shuffles, reductions, gather/scatter, saturating arithmetic, specialized math (once SIMD types land).
@@ -114,7 +115,7 @@ Vector types follow `<u|i|f><width>x<count>`: `f32x4`, `i32x8`, `u8x16`. Higher 
 
 - **No type inference.** Every binding declares its type: `var result: i64 = 0;`. The `asm` block does not infer the result type from usage.
 - **No compiler-known type aliases.** `usize`, `str` are stdlib `def`s, not built-ins. `$size_of`/`$align_of`/`$offset_of` resolve to comptime constant unsigned integers stored in whatever type the binding declares.
-- **Strings are `"..."` → `*u8`, null-terminated** in the data segment. Backtick is **reserved and unused** — never use it for an `asm` body or anything else.
+- **Strings are `"..."` → `*u8`, null-terminated** in the data segment. Backtick has **no role**: the lexer treats it as an unexpected character (a lex error) — never use it for an `asm` body or anything else.
 - **`ext fun` is the only body-less function form.** No forward declarations; body-less signatures are reserved for C-ABI externals. Symbol rename via `$NAME.symbol = "real_name";`.
 - **`fwd` is bare** (no `pub fwd`) and **always publishes** — it re-exports a symbol through a surface file, used by both topical splits (all impls forwarded unconditionally) and multiplatform splits (one impl forwarded per target).
 - **No tagged unions, no `match`.** Discriminated values are a `rec` carrying a discriminator plus a `uni` payload (`rec{ kind: ValueKind; data: uni{...} }`); consumers branch with `if`/`or`. The compiler does not enforce kind/payload consistency.

--- a/.github/skills/writing-mach/SKILL.md
+++ b/.github/skills/writing-mach/SKILL.md
@@ -15,14 +15,16 @@ Reference section) is the exhaustive source of truth.
 - **No type inference.** Every binding declares its type. `val x = 42;` is an
   error; write `val x: i64 = 42;`.
 - **No compiler-known type aliases.** `bool`, `usize`, `str`, etc. are *stdlib*
-  `def`s, not built-ins. The compiler ships only `ptr` and the numeric/SIMD
-  family. Import the alias from stdlib before using it. `bool` is `def bool: u8;`;
-  `true`/`false` are stdlib `val`s (`1`/`0`). Comparison and logical operators
-  produce `u8`.
+  `def`s, not built-ins. The compiler ships only `ptr`, `va_list`, and the
+  numeric/SIMD family. Import the alias from stdlib before using it. `bool` is
+  `def bool: u8;`; `true`/`false` are stdlib `val`s (`1`/`0`). Comparison and
+  logical operators produce `u8`.
 - **Strings are `*u8`.** `"hello"` produces a `*u8` pointing at null-terminated
-  bytes. There is no fat-pointer string type. Length-aware strings are a stdlib
-  type (`std.types.string.str` is itself `def str: *u8;`). Backtick `` ` `` is
-  reserved and currently unused — never emit it.
+  bytes. There is no fat-pointer string type — `std.types.string.str` is itself
+  `def str: *char;` (a null-terminated pointer, not length-aware). The
+  length-aware view is the stdlib record `std.types.string.StrView`
+  (`{ data: *char; len: usize; }`). Backtick `` ` `` has no role: the lexer
+  treats it as an unexpected character (a lex error) — never emit it.
 - **`fwd` is bare and always public.** No `pub fwd`. `ext fun` is the *only*
   body-less function form — there are no forward declarations of regular
   functions.
@@ -71,13 +73,15 @@ There is no built-in `print`. Use the standard library, which returns a
 use std.print;
 
 fun greet() {
-    std.print.println("hello, mach");
+    print.println("hello, mach");
 }
 ```
 
-`std.print` exposes `print` / `println` (stdout), `eprint` / `eprintln`
-(stderr), and formatting variants. Each returns `Result[usize, str]` — bytes
-written, or an error.
+`use std.print;` binds the leaf name `print` (the module), so members are
+reached qualified as `print.<member>` — `std` is not itself in scope, so
+`std.print.println(...)` would not resolve. The `print` module exposes
+`print` / `println` (stdout), `eprint` / `eprintln` (stderr), and formatting
+variants. Each returns `Result[usize, str]` — bytes written, or an error.
 
 ## `use` — private import
 
@@ -190,9 +194,11 @@ pub fun identity[T](value: T) T { ret value; }
   positionally like a runtime arg). This form is **function parameters only** —
   never record fields.
 - Variadic via trailing `...`; access through `va_list` / `va_start` /
-  `va_arg[T]` / `va_end` (C convention). Partially implemented: call sites and
-  the trailing `...` parse, but the callee-side `va_*` machinery is not yet
-  fully seeded — check your toolchain before relying on it.
+  `va_arg[T]` / `va_end` (C convention). The `va_list` builtin type and the
+  `va_*` intrinsics are compiler-seeded — typed in sema and lowered to
+  dedicated IR opcodes against the SysV register-save area. The limitation is
+  ABI completeness at the edges (e.g. passing/fetching large by-value
+  aggregates as variadic arguments); scalar and pointer varargs work.
 
 ### `ext fun` — external function
 
@@ -220,6 +226,8 @@ Primitives follow `<u|i|f><width>(x<count>)*`.
 
 - Scalars: `u8 u16 u32 u64`, `i8 i16 i32 i64`, `f32 f64`.
 - Untyped pointer: `ptr`. (`bool` is a stdlib `def` for `u8`, not a built-in.)
+- Variadic cursor: `va_list` — the compiler-seeded register-save struct used
+  with `va_start` / `va_arg[T]` / `va_end` (see Variadics under `fun`).
 - SIMD vectors: append `x<count>` — `f32x4`, `i32x8`, `u8x16`. **Planned, not
   yet implemented**: vector type names do not resolve as types today. Higher
   dims (`f32x4x4`) are grammatically legal. Atomic/volatile live outside the
@@ -256,8 +264,9 @@ Untyped numeric literals are *checked* against the surrounding declared type;
 they do not infer it. If context does not constrain the type, use a suffix
 (`42i64`). `nil` types as `*u8` with no context and coerces to any pointer;
 relate function pointers to `nil` via `==` / `!=`, not assignment. Char escapes:
-`\n \t \r \\ \' \0 \xHH`. String escapes: same plus `\"`. Strings are
-single-line (use `\n`; no multi-line syntax).
+`\n \t \r \\ \' \0 \xHH`. String escapes: same plus `\"`. A string literal may
+span multiple lines — the lexer scans to the next unescaped `"`, so a raw
+newline inside the quotes is part of the literal.
 
 ## Operators
 

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ use          std.runtime;
 use print:   std.print;
 
 $main.symbol = "main";
-fun main(argc: i64, argv: &&u8) i64 {
+fun main(argc: i64, argv: **u8) i64 {
     print.println("Hello, World!");
     ret 0;
 }
@@ -116,7 +116,7 @@ fun fibr(n: u64) u64 {
 }
 
 $main.symbol = "main";
-fun main(argc: i64, argv: &&u8) i64 {
+fun main(argc: i64, argv: **u8) i64 {
     print.printf("fib(%d) = %d\n", 10::i64, fibr(10));
     ret 0;
 }
@@ -137,7 +137,7 @@ fun fact(n: u64) u64 {
 }
 
 $main.symbol = "main";
-fun main(argc: i64, argv: &&u8) i64 {
+fun main(argc: i64, argv: **u8) i64 {
     print.printf("fact(%d) = %d\n", 10::i64, fact(10));
     ret 0;
 }

--- a/doc/language/grammar.md
+++ b/doc/language/grammar.md
@@ -46,6 +46,7 @@ token ::= IDENT
         | punctuation
         | operator
         | EOF
+        | ERROR    (* emitted for an unexpected character, see below *)
 
 punctuation ::= "(" | ")" | "{" | "}" | "[" | "]"
               | ";" | ":" | "," | "." | "?" | "@" | "$"
@@ -69,6 +70,11 @@ Notes:
 - The lexer recognizes the standalone characters `=`, `!`, `<`, `>`, `&`,
   `|` and the two-character forms above. There is no `+=`, `-=`, etc. —
   compound assignment does not exist.
+- `ERROR` (`KIND_ERROR`) is a real token kind the lexer emits for an
+  unexpected character: the input is recorded as a `LEX_ERR_UNEXPECTED_CHAR`
+  in the sibling error buffer, a one-byte `ERROR` token is pushed, and
+  lexing continues. `EOF` (`KIND_EOF`) terminates every stream. Neither
+  appears in a well-formed production; they are listed here for completeness.
 
 ### Identifiers and keywords
 
@@ -98,9 +104,9 @@ keywords — they are ordinary identifiers resolved by name later.
 LIT_INT  ::= dec-int | hex-int | bin-int | oct-int
 
 dec-int  ::= digit { digit | "_" } [ int-suffix ]
-hex-int  ::= "0x" hex-digit { hex-digit | "_" }
-bin-int  ::= "0b" ( "0" | "1" ) { "0" | "1" | "_" }
-oct-int  ::= "0o" oct-digit { oct-digit | "_" }
+hex-int  ::= "0x" hex-digit { hex-digit | "_" } [ int-suffix ]
+bin-int  ::= "0b" ( "0" | "1" ) { "0" | "1" | "_" } [ int-suffix ]
+oct-int  ::= "0o" oct-digit { oct-digit | "_" } [ int-suffix ]
 
 int-suffix ::= ( "u" | "i" ) { digit }   (* e.g. u8, i64 — width digits *)
 
@@ -109,9 +115,11 @@ hex-digit ::= digit | 'a'..'f' | 'A'..'F'
 oct-digit ::= '0'..'7'
 ```
 
-A leading `0x` / `0b` / `0o` selects the base; the suffix (`u`/`i` + width
-digits) is only scanned on a non-float decimal literal. Underscores are
-permitted as digit separators in every base.
+A leading `0x` / `0b` / `0o` selects the base; the `u`/`i` width suffix is
+scanned on any non-float integer literal regardless of base (the lexer
+scans the digit run, then — when the token is not a float — accepts a
+trailing `u`/`i` followed by width digits). Underscores are permitted as
+digit separators in every base.
 
 ### Float literals
 
@@ -147,8 +155,11 @@ char escapes:   \n  \t  \r  \\  \'  \0  \xHH
 string escapes: (char escapes) + \"
 ```
 
-A string literal is single-line; there is no multi-line string form. An
-unterminated `'` or `"` is a lexer error but still produces a token span.
+A string literal may span multiple lines: the lexer scans from the opening
+`"` to the next unescaped `"` or to EOF, and a newline in between is just
+another body byte (it does not terminate the literal). A char literal scans
+likewise to the next `'` or EOF. An unterminated `'` or `"` (the scan hits
+EOF first) is a lexer error but still produces a token span.
 
 ### Comments and whitespace
 
@@ -161,11 +172,13 @@ whitespace ::= " " | "\t" | "\n" | "\r"
 newline. There is no block-comment form. Whitespace and comments separate
 tokens and are otherwise discarded.
 
-### Reserved, no role
+### Unexpected characters
 
-The backtick `` ` `` is reserved as a literal/quote-class character but has
-no assigned syntactic role and is not currently lexable in normal source
-(an unexpected character produces a lex error).
+The lexer has no fall-through quote or reserved class: any byte that begins
+none of the token forms above — the backtick `` ` `` among them — is an
+**unexpected character**. The lexer records a `LEX_ERR_UNEXPECTED_CHAR`,
+emits a one-byte `ERROR` token (`KIND_ERROR`) for it, and continues. The
+backtick carries no special role; it is just one such character.
 
 
 ## Module


### PR DESCRIPTION
Docs-only accuracy fixes flagged by Copilot's review of #1104 (grammar) and #1116 (skills), plus light README cleanup requested by the maintainer. No compiler source, `mach.toml`, or dependency changed. Each correction was verified against the live lexer/parser/std source.

Closes #1137

## doc/language/grammar.md
- **ERROR token** — added the `ERROR` (`KIND_ERROR`) kind to the `token` production and a note describing unexpected-char handling. Confirmed `KIND_ERROR: Kind = 255` (`token.mach:62`), emitted at `lexer.mach:319` with `LEX_ERR_UNEXPECTED_CHAR`.
- **Int suffix on all bases** — `hex-int`/`bin-int`/`oct-int` now allow `[ int-suffix ]`; corrected the "decimal-only" note. The lexer scans the digit run then applies the `u`/`i` suffix in the shared non-float branch (`lexer.mach:301-309`), independent of base.
- **Multi-line strings** — the string scan loop stops only on `"` or EOF, never on `\n` (`lexer.mach:209-215`); corrected the "single-line" claim for both string and char literals.
- **Backtick** — replaced the "reserved/quote-class" description with observable behavior: the backtick hits the default `or {}` arm and emits `KIND_ERROR` (`lexer.mach:318-319`); there is no backtick case anywhere in the lexer.

## .github/skills
- **writing-mach** — added the compiler-seeded `va_list` to the primitives sentence and the concrete-types list (`resolve.mach:584` seeds it alongside `u8..f64, ptr`); repointed "length-aware strings" at `std.types.string.StrView` (`{ data: *char; len: usize; }`, `string.mach:537`) since `str` is `def str: *char` (`string.mach:18`); fixed the `std.print` snippet to call via the bound leaf name `print.println(...)`; rephrased the variadics note to the real ABI-completeness limitation (`va_*` are typed in `sema/infer.mach` and lowered to dedicated IR opcodes); corrected the single-line-string and backtick claims.
- **mach-lowlevel** — replaced the bare `asm { ud2 / brk 0 }` example with ISA-tagged blocks; corrected the backtick claim.

## README.md
- Fixed the non-existent `&` pointer operator: `argv: &&u8` → `argv: **u8` in the Hello World, Fibonacci, and Factorial snippets (matches `examples/01_hello`).
- **Verified by building + running** each snippet against the freshly built `out/bin/mach` with the real mach-std:
  - Hello World → `Hello, World!`
  - Fibonacci → `fib(10) = 55`
  - Factorial → `fact(10) = 3628800`

  The `use print: std.print;` alias, `print.println`/`print.printf`, `$main.symbol`, and the `10::i64` cast all compile and run. README CLI commands/flags (`build run test dep init help`, `dep list|add|remove|sync|vendor`, `--target --release --emit obj -o --verbose --quiet`) were cross-checked against `src/cli/cmd/` and match.
