### PR TITLE
refactor(comptime): scoped (mark-delimited) environment, fix block-local val leak

### DIFF
--- a/examples/06_comptime/lib.mach
+++ b/examples/06_comptime/lib.mach
@@ -19,5 +19,5 @@ pub val LIB_BASE: i64 = 100;
 pub fun op($op: u8, a: i64, b: i64) i64 {
     $if (op == OP_ADD) { ret a + b; }
     $or (op == OP_SUB) { ret a - b; }
-    ret a * b;
+    $or { ret a * b; }
 }

--- a/examples/06_comptime/lib.mach
+++ b/examples/06_comptime/lib.mach
@@ -1,0 +1,23 @@
+# a sibling module for the comptime-scoping regression: it exports a comptime
+# value-parameter function gated on this module's OWN `pub val`s, so a caller in
+# another module folds the `$if` arms against THIS module's comptime constants
+# (the value-instance origin frame), not the caller's. it also exports a plain
+# comptime `pub val` to cover cross-module const reads.
+
+# distinct from main's MODE_* on purpose: a value-param instance must fold its
+# `$if` gate against these (lib's) consts, never against a same-named const that
+# might exist in the calling module.
+pub val OP_ADD: u8 = 0;
+pub val OP_SUB: u8 = 1;
+pub val OP_MUL: u8 = 2;
+
+# a cross-module comptime const, read both bare and via an alias.
+pub val LIB_BASE: i64 = 100;
+
+# a comptime value-parameter function defined in lib: each instance compiles only
+# the arm its `$op` selects, folded against lib's OP_* above.
+pub fun op($op: u8, a: i64, b: i64) i64 {
+    $if (op == OP_ADD) { ret a + b; }
+    $or (op == OP_SUB) { ret a - b; }
+    ret a * b;
+}

--- a/examples/06_comptime/main.mach
+++ b/examples/06_comptime/main.mach
@@ -47,7 +47,9 @@ fun apply($mode: u8, n: i64) i64 {
     $or (mode == MODE_SQUARE) {
         ret n * n;
     }
-    ret 0;
+    $or {
+        ret 0;
+    }
 }
 
 # comptime params also drive a mix of compile-time and runtime parameters: the
@@ -55,7 +57,7 @@ fun apply($mode: u8, n: i64) i64 {
 fun combine($op: u8, a: i64, b: i64) i64 {
     $if (op == 0) { ret a + b; }
     $or (op == 1) { ret a - b; }
-    ret a * b;
+    $or { ret a * b; }
 }
 
 # a comptime float parameter keys an instance by its exact value: floats that
@@ -63,7 +65,7 @@ fun combine($op: u8, a: i64, b: i64) i64 {
 fun scale($factor: f64, n: i64) i64 {
     $if (factor == 1.5) { ret n + n / 2; }
     $or (factor == 1.9) { ret n + n; }
-    ret n;
+    $or { ret n; }
 }
 
 # #1143 regression: a block-local comptime `val` must never leak into the module

--- a/examples/06_comptime/main.mach
+++ b/examples/06_comptime/main.mach
@@ -9,6 +9,12 @@ use std.runtime;
 use std.print.println;
 use std.print.printlnf;
 
+# cross-module comptime imports for the #1143 scoping regression below: `op` and
+# `LIB_BASE` reached by bare name, plus the same module reached via an alias.
+use comptime.lib.op;
+use comptime.lib.LIB_BASE;
+use lib: comptime.lib;
+
 $main.symbol = "main";
 
 rec Point {
@@ -60,6 +66,33 @@ fun scale($factor: f64, n: i64) i64 {
     ret n;
 }
 
+# #1143 regression: a block-local comptime `val` must never leak into the module
+# comptime scope. SHADOWED is a module const (7); `early` declares a same-named
+# block-local val (99) used at runtime. under the old flat-table evaluator that
+# block-local was registered into the ctx and never popped, so a LATER function's
+# `$if` on the module SHADOWED could fold against 99. it must fold against 7.
+val SHADOWED: u8 = 7;
+
+fun early() i64 {
+    val SHADOWED: u8 = 99;
+    ret SHADOWED::i64;
+}
+
+# a value-param gate on the module SHADOWED: gated(7) must take the arm because
+# the module const is 7, not the leaked block-local 99.
+fun gated($sel: u8) i64 {
+    $if (sel == SHADOWED) { ret 1; }
+    $or { ret 0; }
+}
+
+# a `$param` named the same as a module val must shadow it inside the instance
+# body: SHADOWED is 7 at module scope, but `shadow_param(5)` binds the param to 5,
+# so the gate `$if (SHADOWED == 5)` folds true for the param value, not the const.
+fun shadow_param($SHADOWED: u8) i64 {
+    $if (SHADOWED == 5) { ret 1; }
+    $or { ret 0; }
+}
+
 fun main(argc: i64, argv: **u8) i64 {
     printlnf("sizeof(Point): %u", POINT_SIZE);
     printlnf("alignof(Point): %u", POINT_ALIGN);
@@ -74,6 +107,13 @@ fun main(argc: i64, argv: **u8) i64 {
 
     printlnf("scale(1.5, 10): %d", scale(1.5, 10));
     printlnf("scale(1.9, 10): %d", scale(1.9, 10));
+
+    # cross-module value-param + the #1143 scoping cases (referenced so every pass
+    # lowers them, not just the test harness).
+    printlnf("lib.op(ADD, 8, 5): %d", op(0, 8, 5));
+    printlnf("early(): %d", early());
+    printlnf("gated(7): %d", gated(7));
+    printlnf("shadow_param(5): %d", shadow_param(5));
 
     # target-conditional code: only the taken branch is compiled and emitted.
     $if ($mach.target.os == $mach.os.linux) {
@@ -125,5 +165,44 @@ test "comptime param: mixed comptime + runtime params" {
 test "comptime param: float values sharing an integer part stay distinct" {
     if (scale(1.5, 10) != 15) { ret 1; }
     if (scale(1.9, 10) != 20) { ret 1; }
+    ret 0;
+}
+
+# #1143 scoping regression: cross-module value-param folding and the block-local
+# leak fix.
+
+test "cross-module value-param folds against the defining module's consts (bare)" {
+    if (op(0, 8, 5) != 13) { ret 1; }
+    if (op(1, 8, 5) != 3) { ret 1; }
+    if (op(2, 8, 5) != 40) { ret 1; }
+    ret 0;
+}
+
+test "cross-module value-param folds against the defining module's consts (aliased)" {
+    if (lib.op(0, 8, 5) != 13) { ret 1; }
+    if (lib.op(1, 8, 5) != 3) { ret 1; }
+    if (lib.op(2, 8, 5) != 40) { ret 1; }
+    ret 0;
+}
+
+test "cross-module comptime const reads bare and aliased" {
+    if (LIB_BASE != 100) { ret 1; }
+    if (lib.LIB_BASE != 100) { ret 1; }
+    ret 0;
+}
+
+test "block-local comptime val does not leak into a later fn's $if" {
+    # SHADOWED is the module const 7; early() declares a block-local SHADOWED=99.
+    # gated(7) folds `sel == SHADOWED` against the module const, so it takes the
+    # arm. a leaked block-local would make SHADOWED resolve to 99 and miss it.
+    if (early() != 99) { ret 1; }
+    if (gated(7) != 1) { ret 1; }
+    ret 0;
+}
+
+test "comptime $param shadows a same-named module val in the instance body" {
+    # SHADOWED is 7 at module scope; the param binds 5, which the gate sees.
+    if (shadow_param(5) != 1) { ret 1; }
+    if (shadow_param(7) != 0) { ret 1; }
     ret 0;
 }

--- a/src/lang/driver.mach
+++ b/src/lang/driver.mach
@@ -1453,10 +1453,10 @@ fun register_val_for_load(p: *Project, mid: sess.ModuleId, d: *decl.Decl, _did: 
     # (e.g. a runtime constant such as `os.OS_LINUX` accessed through an alias)
     # is DELIBERATELY skipped here — NOT an error. cmach folds module `val`s
     # lazily and likewise never rejects one at its definition site; a genuine
-    # comptime-context requirement is enforced at the USE site, where
-    # `comptime.mach:702` errors "identifier is not a comptime constant in
-    # scope" if the name was never registered. do not promote this skip to a
-    # hard definition-site error.
+    # comptime-context requirement is enforced at the USE site, where comptime
+    # evaluation errors "identifier is not a comptime constant in scope" if the
+    # name was never registered. do not promote this skip to a hard
+    # definition-site error.
     val r_val: Result[comptime.CTValue, str] = comptime.eval(?m.ctx, ?m.a, source, d.data.bind.init, ?p.s.interner);
     if (is_err[comptime.CTValue, str](r_val)) { ret ok[bool, str](true); }
     val v: comptime.CTValue = unwrap_ok[comptime.CTValue, str](r_val);

--- a/src/lang/driver.mach
+++ b/src/lang/driver.mach
@@ -1426,7 +1426,7 @@ fun merge_pub_consts(p: *Project, mid: sess.ModuleId, dep_mid: sess.ModuleId, le
     for (i < dep.pub_const_count) {
         val pc: *PubConst = ?dep.pub_consts[i];
         if (pc.name == leaf) {
-            ret comptime.register(?m.ctx, pc.name, pc.value);
+            ret comptime.bind(?m.ctx, pc.name, pc.value);
         }
         i = i + 1;
     }
@@ -1461,7 +1461,7 @@ fun register_val_for_load(p: *Project, mid: sess.ModuleId, d: *decl.Decl, _did: 
     if (is_err[comptime.CTValue, str](r_val)) { ret ok[bool, str](true); }
     val v: comptime.CTValue = unwrap_ok[comptime.CTValue, str](r_val);
 
-    val rr: Result[bool, str] = comptime.register(?m.ctx, name_id, v);
+    val rr: Result[bool, str] = comptime.bind(?m.ctx, name_id, v);
     if (is_err[bool, str](rr)) { ret rr; }
 
     val is_pub: bool = (d.flags & decl.DECL_FLAG_PUB) != 0;

--- a/src/lang/fe/comptime.mach
+++ b/src/lang/fe/comptime.mach
@@ -1,11 +1,12 @@
 # mach.lang.fe.comptime: bounded compile-time evaluator.
 #
-# consumed by resolve and driver to evaluate `$if` predicates against
-# compile-time constants (`$mach.*` target parameters plus user-registered
-# `pub val` decls). scope is intentionally narrow: literals, references to
-# comptime-known constants, and arithmetic / comparison / logical / bitwise
-# / shift operators over them. out of scope: function calls, loops,
-# type-introspection intrinsics, casts.
+# consumed by resolve, driver, and lower to evaluate `$if` predicates against
+# compile-time constants (`$mach.*` target parameters plus the scoped
+# environment of bound comptime constants — module-level / imported `pub val`s
+# plus a value-instance's `$param` bindings). scope is intentionally narrow:
+# literals, references to comptime-known constants, and arithmetic / comparison
+# / logical / bitwise / shift operators over them. out of scope: function calls,
+# loops, type-introspection intrinsics, casts.
 #
 # `$mach.target.{os,arch,abi}` resolve to the numeric tag of the active
 # target; the matching `$mach.os.*` / `$mach.arch.*` tags resolve to the
@@ -75,7 +76,8 @@ pub rec CTValue {
     };
 }
 
-# NamedConst: a named comptime constant, produced when a comptime-evaluable val decl is registered with a context for later reference by its bare identifier.
+# NamedConst: a named comptime constant, bound into a ComptimeCtx's entries
+# array for later reference by its bare identifier.
 # ---
 # name:  interned identifier
 # value: pre-evaluated constant
@@ -84,24 +86,33 @@ pub rec NamedConst {
     value: CTValue;
 }
 
-# ComptimeCtx: build/target context plus user-defined comptime constants visible to one evaluation, populated by the driver from mach.toml plus prior comptime val decls evaluated in dependency order.
+# FrameMark: an opaque entries-array depth, returned by `frame_open` and passed
+# to `frame_close` to pop exactly the bindings introduced after the mark.
+pub def FrameMark: u32;
+
+# ComptimeCtx: build/target context plus a single scoped environment of named
+# comptime constants visible to one evaluation.
+#
+# `entries` is one append-only array partitioned implicitly into frames by
+# marks: a frame is the run [mark, entries_len). The bottom run is the module
+# frame — built once (driver this-module pub vals + imported pub consts, resolve
+# module-level vals) and NEVER closed, so all three passes read it. A value-
+# instance drain opens a transient frame on top, binds its `$param`s, lowers the
+# body, then closes the frame; the close pops exactly those param bindings.
+#
+# `$mach.*` is NOT stored here — it is resolved structurally in resolve_mach_path
+# from the target fields below.
 # ---
-# alloc:          allocator used for the user_consts buffer
+# alloc:          allocator used for the entries buffer
 # target_os_id:   numeric os id (one of os.OS_*)
 # target_arch_id: numeric arch id (one of isa.ARCH_*)
 # pointer_width:  target pointer width in bytes
 # compiler_name:  interned "mach"
 # compiler_ver:   interned compiler version string
-# user_consts:    array of NamedConst entries; linear lookup is fine at this size
-# user_const_len: number of entries currently stored
-# user_const_cap: allocated slots in user_consts
-# params:         a separate stack of `$param -> CTValue` bindings, active only
-#                 while a comptime value-parameter instance body is being lowered;
-#                 consulted (most-recent-first) BEFORE user_consts so a parameter
-#                 shadows a same-named module / block const without disturbing
-#                 general comptime-const lookup semantics
-# param_len:      number of active param bindings
-# param_cap:      allocated slots in params
+# entries:        scoped array of NamedConst bindings; lookup scans it in reverse
+#                 so an innermost (later-bound) name shadows an outer one
+# entries_len:    number of entries currently stored
+# entries_cap:    allocated slots in entries
 pub rec ComptimeCtx {
     alloc:          *Allocator;
     target_os_id:   u32;
@@ -109,17 +120,15 @@ pub rec ComptimeCtx {
     pointer_width:  u32;
     compiler_name:  intern.StrId;
     compiler_ver:   intern.StrId;
-    user_consts:    *NamedConst;
-    user_const_len: u32;
-    user_const_cap: u32;
-    params:         *NamedConst;
-    param_len:      u32;
-    param_cap:      u32;
+    entries:        *NamedConst;
+    entries_len:    u32;
+    entries_cap:    u32;
 }
 
 val INITIAL_CONST_CAP: u32 = 8;
 
-# init: constructs a ComptimeCtx with the given target parameters and no user consts.
+# init: constructs a ComptimeCtx with the given target parameters and an empty
+# environment.
 # ---
 # alloc:          allocator used for owned storage
 # target_os_id:   numeric os id (one of os.OS_*)
@@ -143,140 +152,94 @@ pub fun init(
     c.pointer_width  = pointer_width;
     c.compiler_name  = compiler_name;
     c.compiler_ver   = compiler_ver;
-    c.user_consts    = nil;
-    c.user_const_len = 0;
-    c.user_const_cap = 0;
-    c.params         = nil;
-    c.param_len      = 0;
-    c.param_cap      = 0;
+    c.entries        = nil;
+    c.entries_len    = 0;
+    c.entries_cap    = 0;
     ret c;
 }
 
-# dnit: releases the user_consts and param buffers.
+# dnit: releases the entries buffer.
 # ---
 # c: context to tear down; all fields are zeroed
 pub fun dnit(c: *ComptimeCtx) {
     if (c == nil) { ret; }
-    if (c.user_consts != nil && c.user_const_cap > 0) {
-        deallocate[NamedConst](c.alloc, c.user_consts, c.user_const_cap::usize);
+    if (c.entries != nil && c.entries_cap > 0) {
+        deallocate[NamedConst](c.alloc, c.entries, c.entries_cap::usize);
     }
-    if (c.params != nil && c.param_cap > 0) {
-        deallocate[NamedConst](c.alloc, c.params, c.param_cap::usize);
-    }
-    c.user_consts    = nil;
-    c.user_const_len = 0;
-    c.user_const_cap = 0;
-    c.params         = nil;
-    c.param_len      = 0;
-    c.param_cap      = 0;
+    c.entries     = nil;
+    c.entries_len = 0;
+    c.entries_cap = 0;
 }
 
-# register: registers a comptime constant under `name`, growing user_consts as needed.
+# bind: appends a comptime constant under `name` to the current (innermost)
+# frame, growing the entries array as needed. a later binding of the same name
+# shadows an earlier one under the reverse-scan lookup.
 # ---
 # c:     context to extend
 # name:  interned identifier
 # value: pre-evaluated constant
 # ret:   true on success, or an allocation error
-pub fun register(c: *ComptimeCtx, name: intern.StrId, value: CTValue) Result[bool, str] {
-    if (c.user_consts == nil) {
+pub fun bind(c: *ComptimeCtx, name: intern.StrId, value: CTValue) Result[bool, str] {
+    if (c.entries == nil) {
         val r: Result[*NamedConst, str] = allocate[NamedConst](c.alloc, INITIAL_CONST_CAP::usize);
         if (is_err[*NamedConst, str](r)) {
             ret err[bool, str](unwrap_err[*NamedConst, str](r));
         }
-        c.user_consts    = unwrap_ok[*NamedConst, str](r);
-        c.user_const_cap = INITIAL_CONST_CAP;
+        c.entries     = unwrap_ok[*NamedConst, str](r);
+        c.entries_cap = INITIAL_CONST_CAP;
     }
-    or (c.user_const_len == c.user_const_cap) {
-        val new_cap: u32 = c.user_const_cap * 2;
-        val r: Result[*NamedConst, str] = reallocate[NamedConst](c.alloc, c.user_consts, c.user_const_cap::usize, new_cap::usize);
+    or (c.entries_len == c.entries_cap) {
+        val new_cap: u32 = c.entries_cap * 2;
+        val r: Result[*NamedConst, str] = reallocate[NamedConst](c.alloc, c.entries, c.entries_cap::usize, new_cap::usize);
         if (is_err[*NamedConst, str](r)) {
             ret err[bool, str](unwrap_err[*NamedConst, str](r));
         }
-        c.user_consts    = unwrap_ok[*NamedConst, str](r);
-        c.user_const_cap = new_cap;
+        c.entries     = unwrap_ok[*NamedConst, str](r);
+        c.entries_cap = new_cap;
     }
 
     var nc: NamedConst;
     nc.name  = name;
     nc.value = value;
-    c.user_consts[c.user_const_len] = nc;
-    c.user_const_len = c.user_const_len + 1;
+    c.entries[c.entries_len] = nc;
+    c.entries_len = c.entries_len + 1;
     ret ok[bool, str](true);
 }
 
-# param_mark: returns the current depth of the param-binding stack, to be passed
-# to `param_truncate` to pop exactly the bindings pushed after this mark.
+# frame_open: returns the current entries depth as a frame mark. bindings made
+# after this mark belong to the opened frame and are removed by `frame_close`.
 # ---
 # c:   the context
-# ret: the current param stack depth
-pub fun param_mark(c: *ComptimeCtx) u32 {
-    ret c.param_len;
+# ret: the current entries depth
+pub fun frame_open(c: *ComptimeCtx) FrameMark {
+    ret c.entries_len;
 }
 
-# param_truncate: pops the param stack back to `mark`, removing every binding
-# pushed since the matching `param_mark`. used to scope a value-instance body's
+# frame_close: pops the entries array back to `mark`, removing every binding
+# made since the matching `frame_open`. used to scope a value-instance body's
 # `$param` bindings to that body's lowering, restoring exactly on every path.
 # ---
 # c:    the context
-# mark: a depth previously returned by `param_mark`
-pub fun param_truncate(c: *ComptimeCtx, mark: u32) {
-    if (mark <= c.param_len) { c.param_len = mark; }
+# mark: a depth previously returned by `frame_open`
+pub fun frame_close(c: *ComptimeCtx, mark: FrameMark) {
+    if (mark <= c.entries_len) { c.entries_len = mark; }
 }
 
-# push_param: pushes a `$param -> CTValue` binding onto the param-binding stack,
-# growing it as needed. these bindings shadow same-named user consts during a
-# value-instance body's lowering and are popped via `param_truncate` afterward.
-# ---
-# c:     the context
-# name:  interned parameter identifier
-# value: the parameter's folded comptime value for this instance
-# ret:   true on success, or an allocation error
-pub fun push_param(c: *ComptimeCtx, name: intern.StrId, value: CTValue) Result[bool, str] {
-    if (c.params == nil) {
-        val r: Result[*NamedConst, str] = allocate[NamedConst](c.alloc, INITIAL_CONST_CAP::usize);
-        if (is_err[*NamedConst, str](r)) { ret err[bool, str](unwrap_err[*NamedConst, str](r)); }
-        c.params    = unwrap_ok[*NamedConst, str](r);
-        c.param_cap = INITIAL_CONST_CAP;
-    }
-    or (c.param_len == c.param_cap) {
-        val new_cap: u32 = c.param_cap * 2;
-        val r: Result[*NamedConst, str] = reallocate[NamedConst](c.alloc, c.params, c.param_cap::usize, new_cap::usize);
-        if (is_err[*NamedConst, str](r)) { ret err[bool, str](unwrap_err[*NamedConst, str](r)); }
-        c.params    = unwrap_ok[*NamedConst, str](r);
-        c.param_cap = new_cap;
-    }
-
-    var nc: NamedConst;
-    nc.name  = name;
-    nc.value = value;
-    c.params[c.param_len] = nc;
-    c.param_len = c.param_len + 1;
-    ret ok[bool, str](true);
-}
-
-# lookup: looks up a comptime constant by interned name. the active `$param`
-# bindings are consulted first (most-recent-first, so a parameter shadows a
-# same-named const while an instance body lowers); the general user-const table
-# is then searched first-match (the original semantics, so a never-popped block-
-# local `val` does not shadow a later module const).
+# lookup: looks up a comptime constant by interned name with a single reverse
+# scan of the scoped environment: the innermost (latest-bound) match wins, so a
+# value-instance `$param` shadows a same-named module const while its body
+# lowers, falling back to the persistent module frame otherwise.
 # ---
 # c:    context to search
 # name: interned identifier to find
-# ret:  some(*NamedConst) when registered, none otherwise
+# ret:  some(*NamedConst) when bound, none otherwise
 pub fun lookup(c: *ComptimeCtx, name: intern.StrId) Option[*NamedConst] {
-    var pi: u32 = c.param_len;
-    for (pi > 0) {
-        pi = pi - 1;
-        if (c.params[pi].name == name) {
-            ret some[*NamedConst](?c.params[pi]);
+    var i: u32 = c.entries_len;
+    for (i > 0) {
+        i = i - 1;
+        if (c.entries[i].name == name) {
+            ret some[*NamedConst](?c.entries[i]);
         }
-    }
-    var i: u32 = 0;
-    for (i < c.user_const_len) {
-        if (c.user_consts[i].name == name) {
-            ret some[*NamedConst](?c.user_consts[i]);
-        }
-        i = i + 1;
     }
     ret none[*NamedConst]();
 }

--- a/src/lang/fe/resolve.mach
+++ b/src/lang/fe/resolve.mach
@@ -667,7 +667,8 @@ fun collect_one_decl(rc: *ResolveContext, decl_id: id.DeclId, scope: ScopeId, at
         val r: Result[bool, str] = declare_decl(rc, SYM_VAL, sym_flags, d.data.bind.name, decl_id, scope);
         if (is_err[bool, str](r)) { ret r; }
         if (d.data.bind.init != id.EXPR_NIL) {
-            try_register_comptime_const(rc, d.data.bind.name, d.data.bind.init);
+            val rcr: Result[bool, str] = try_register_comptime_const(rc, d.data.bind.name, d.data.bind.init);
+            if (is_err[bool, str](rcr)) { ret rcr; }
         }
         ret ok[bool, str](true);
     }
@@ -697,20 +698,22 @@ fun symbol_flags_from(decl_flags: u8, at_module_scope: bool) u8 {
 # a name the driver's load pass already bound (this-module pub vals, imported pub
 # consts) is skipped, so the load+collect double-registration does not grow the
 # frame with a duplicate. module scope forbids same-name decls, so skipping by
-# name never drops a legitimate distinct binding.
-fun try_register_comptime_const(rc: *ResolveContext, name_span: token.Span, init_expr: id.ExprId) {
-    if (name_span.len == 0) { ret; }
+# name never drops a legitimate distinct binding. a non-foldable initializer is
+# skipped (ok): the comptime requirement is enforced at the use site, not here.
+# only a bind failure (allocation) propagates.
+fun try_register_comptime_const(rc: *ResolveContext, name_span: token.Span, init_expr: id.ExprId) Result[bool, str] {
+    if (name_span.len == 0) { ret ok[bool, str](true); }
     val r_id: Result[intern.StrId, str] = intern.intern_span(?rc.s.interner, rc.source, name_span);
-    if (is_err[intern.StrId, str](r_id)) { ret; }
+    if (is_err[intern.StrId, str](r_id)) { ret ok[bool, str](true); }
     val name_id: intern.StrId = unwrap_ok[intern.StrId, str](r_id);
 
-    if (is_some[*comptime.NamedConst](comptime.lookup(rc.ctx, name_id))) { ret; }
+    if (is_some[*comptime.NamedConst](comptime.lookup(rc.ctx, name_id))) { ret ok[bool, str](true); }
 
     val r_val: Result[comptime.CTValue, str] = comptime.eval(rc.ctx, rc.a, rc.source, init_expr, ?rc.s.interner);
-    if (is_err[comptime.CTValue, str](r_val)) { ret; }
+    if (is_err[comptime.CTValue, str](r_val)) { ret ok[bool, str](true); }
     val v: comptime.CTValue = unwrap_ok[comptime.CTValue, str](r_val);
 
-    comptime.bind(rc.ctx, name_id, v);
+    ret comptime.bind(rc.ctx, name_id, v);
 }
 
 fun collect_comptime_if(rc: *ResolveContext, ci: *decl.DeclComptimeIf, scope: ScopeId, at_module_scope: bool, at_decl_scope: bool) Result[bool, str] {

--- a/src/lang/fe/resolve.mach
+++ b/src/lang/fe/resolve.mach
@@ -4,10 +4,11 @@
 #
 #   1. collect — registers a Symbol for every binding decl reachable
 #      from module scope, evaluating `$if` predicates via the comptime
-#      evaluator and registering comptime-evaluable val initializers as
-#      named consts. `use` decls bind a single leaf name into the module
-#      scope (a module alias when the path ends at a module, a symbol
-#      binding when it ends at a pub symbol).
+#      evaluator and binding comptime-evaluable module-level val
+#      initializers into the comptime module frame (idempotent against the
+#      driver's load-pass binding). `use` decls bind a single leaf name into
+#      the module scope (a module alias when the path ends at a module, a
+#      symbol binding when it ends at a pub symbol).
 #   2. bind — walks every decl, stmt, expr, and type, looking up name
 #      references against the scope chain and writing the resolved
 #      SymbolId into parallel arrays sized to the AST. `fwd` decls are
@@ -692,17 +693,24 @@ fun symbol_flags_from(decl_flags: u8, at_module_scope: bool) u8 {
     ret 0;
 }
 
+# binds a module-level comptime-evaluable val into the module frame. idempotent:
+# a name the driver's load pass already bound (this-module pub vals, imported pub
+# consts) is skipped, so the load+collect double-registration does not grow the
+# frame with a duplicate. module scope forbids same-name decls, so skipping by
+# name never drops a legitimate distinct binding.
 fun try_register_comptime_const(rc: *ResolveContext, name_span: token.Span, init_expr: id.ExprId) {
     if (name_span.len == 0) { ret; }
     val r_id: Result[intern.StrId, str] = intern.intern_span(?rc.s.interner, rc.source, name_span);
     if (is_err[intern.StrId, str](r_id)) { ret; }
     val name_id: intern.StrId = unwrap_ok[intern.StrId, str](r_id);
 
+    if (is_some[*comptime.NamedConst](comptime.lookup(rc.ctx, name_id))) { ret; }
+
     val r_val: Result[comptime.CTValue, str] = comptime.eval(rc.ctx, rc.a, rc.source, init_expr, ?rc.s.interner);
     if (is_err[comptime.CTValue, str](r_val)) { ret; }
     val v: comptime.CTValue = unwrap_ok[comptime.CTValue, str](r_val);
 
-    comptime.register(rc.ctx, name_id, v);
+    comptime.bind(rc.ctx, name_id, v);
 }
 
 fun collect_comptime_if(rc: *ResolveContext, ci: *decl.DeclComptimeIf, scope: ScopeId, at_module_scope: bool, at_decl_scope: bool) Result[bool, str] {
@@ -1422,9 +1430,12 @@ fun bind_local_decl(rc: *ResolveContext, decl_id: id.DeclId) Result[bool, str] {
         rc.decl_symbol[decl_id] = unwrap_ok[SymbolId, str](r_sym);
     }
 
-    if (d.kind == decl.DECL_KIND_VAL && d.data.bind.init != id.EXPR_NIL) {
-        try_register_comptime_const(rc, d.data.bind.name, d.data.bind.init);
-    }
+    # a block-local comptime val is deliberately NOT bound into the comptime ctx:
+    # the ctx holds only the never-closed module frame plus a transient value-
+    # instance param frame, with no poppable block frames in any pass. binding a
+    # block local here would never be popped and could shadow a same-named module
+    # const in a later function (the #1143 leak). its lexical scope above still
+    # makes runtime uses of the local resolve.
 
     ret ok[bool, str](true);
 }

--- a/src/lang/me/lower.mach
+++ b/src/lang/me/lower.mach
@@ -216,17 +216,17 @@ fun drain_value_instances(lc: *lctx.LowerContext, s: *sess.Session,
 }
 
 # emits one value-instance body: binds the context to the instance's origin
-# module — AST, typing, name-resolution, FQN, AND comptime context — then pushes
-# the instance's `$param -> CTValue` bindings onto the ORIGIN module's comptime
-# param scope (a dedicated stack, marked so the bindings are popped afterward — on
-# the error path too, so a failed instance never poisons the next), lowers the
-# template under the instance name, pops the bindings, and restores the home
-# comptime context. binding the origin module's comptime context (not the calling
-# module's) lets a value-instance body fold `$if` gates that reference the
-# defining module's own `pub val`s. every origin registry is populated before the
-# drain runs (the caller already emitted an extern reference to this instance), so
-# a missing one is a coherence violation, not a no-op: it aborts with an internal
-# error rather than silently dropping the body (which would surface as a confusing
+# module — AST, typing, name-resolution, FQN, AND comptime context — then opens a
+# frame on the ORIGIN module's comptime context and binds the instance's
+# `$param -> CTValue` bindings into it (closed afterward — on the error path too,
+# so a failed instance never poisons the next), lowers the template under the
+# instance name, closes the frame, and restores the home comptime context.
+# binding the origin module's comptime context (not the calling module's) lets a
+# value-instance body fold `$if` gates that reference the defining module's own
+# `pub val`s. every origin registry is populated before the drain runs (the
+# caller already emitted an extern reference to this instance), so a missing one
+# is a coherence violation, not a no-op: it aborts with an internal error rather
+# than silently dropping the body (which would surface as a confusing
 # undefined-symbol link failure).
 fun emit_one_value_instance(lc: *lctx.LowerContext, s: *sess.Session,
                             decl_id: aid.DeclId, origin: sess.ModuleId,
@@ -255,16 +255,17 @@ fun emit_one_value_instance(lc: *lctx.LowerContext, s: *sess.Session,
     lc.subst       = nil;
     lc.subst_len   = 0;
 
-    # push the `$param -> CTValue` bindings onto the ORIGIN context's param scope;
-    # mark the scope so EXACTLY these bindings are popped afterward. the param scope
-    # shadows same-named consts during this body's lowering without disturbing the
-    # general comptime-const table.
-    val mark: u32 = comptime.param_mark(octx);
+    # open a frame on the ORIGIN context and bind the `$param -> CTValue`
+    # bindings into it; the frame is closed afterward (on the error path too) so
+    # EXACTLY these bindings are popped. innermost-wins lookup makes a param
+    # shadow a same-named module const during this body's lowering without
+    # disturbing the persistent module frame.
+    val mark: comptime.FrameMark = comptime.frame_open(octx);
     var bi: u32 = 0;
     for (bi < val_len) {
-        val rr: Result[bool, str] = comptime.push_param(octx, names[bi], vals[bi]);
+        val rr: Result[bool, str] = comptime.bind(octx, names[bi], vals[bi]);
         if (is_err[bool, str](rr)) {
-            comptime.param_truncate(octx, mark);
+            comptime.frame_close(octx, mark);
             lc.ctx = home_ctx;
             ret err[bool, str](unwrap_err[bool, str](rr));
         }
@@ -272,7 +273,7 @@ fun emit_one_value_instance(lc: *lctx.LowerContext, s: *sess.Session,
     }
 
     val lr: Result[bool, str] = decl.lower_value_instance(lc, decl_id, d, name);
-    comptime.param_truncate(octx, mark);
+    comptime.frame_close(octx, mark);
     lc.ctx = home_ctx;
     ret lr;
 }


### PR DESCRIPTION
Closes #1143.

Replaces the comptime evaluator's flat per-module constant table (plus the separate #1075 param stack) with a single scoped, mark-delimited environment. Fixes the block-local-comptime-`val` leak at the source.

## Step 1 gate (the cheap-design precondition)
Searched all of `src/` + `dep/mach-std/src/`: **no `$if`/`$or` gate inside a function block references a block-local comptime `val`.** Every real `$if`/`$or` condition reads only `$mach.*` target parameters. The leak-at-source removal therefore cannot change arm selection, so the cheap design is safe.

## What changed
- **`comptime.mach`**: `ComptimeCtx` now holds one `entries`/`entries_len`/`entries_cap` array (replacing the six `user_const*`/`param*` fields). A frame is implicit: the run `[mark, entries_len)`. `bind` appends; `frame_open`/`frame_close` (returning/consuming `FrameMark`) scope a frame; `lookup` is a single reverse scan where the innermost (latest-bound) name wins. `$mach.*` stays out of `entries` (resolved structurally).
- **module frame**: the bottom run `[0, module_mark)`, built once and never closed — what all three passes read. Populated by driver `register_val_for_load` + `merge_pub_consts` and resolve `collect_one_decl`, all via `bind`. Collect is now idempotent on an already-bound name, so the load+collect double-registration of module pub vals never duplicates.
- **leak fix** (`resolve.mach` `bind_local_decl`): dropped the block-local comptime-const registration. A block-local `val` is never put in the ctx, so it can't leak / shadow a later module const. Lexical scope is untouched, so runtime uses still resolve.
- **subsume #1075** (`lower.mach` `emit_one_value_instance`): `param_mark`/`push_param`/`param_truncate` → `frame_open`/`bind`/`frame_close` on the origin ctx, closing the frame on both the success and error paths.

## Verification
- `make clean && make`: exit 0 (full cmach → imach → smach → mach bootstrap).
- **Self-host fixpoint BYTE-IDENTICAL**: `mach build` → `mach2`, `cmp -s` identical. Fold-equivalence confirmed — no winning binding moved.
- Test suites + differential + value-param + leak regression: see PR comments.
