### PR TITLE
feat(x64): distinct register id-spaces for GP and XMM banks

### DIFF
--- a/examples/11_casts/main.mach
+++ b/examples/11_casts/main.mach
@@ -76,3 +76,37 @@ test "reinterpret `:~` round-trips a pointer through usize" {
     if (@p2 != 99) { ret 1; }
     ret 0;
 }
+
+# `:~` round-trips a bit pattern i64 -> f64 -> i64 even when register pressure
+# spills the float operand: 20 simultaneously-live f64 reinterprets exceed the
+# XMM bank, so several cross-bank bitcasts hit their spilled `[rbp + off]` form.
+# the bits must survive bit-exactly (a memory operand is bank-agnostic, so a
+# spilled cross-bank reinterpret is a plain sized move, not a lost MOVQ).
+fun bitcast_under_pressure(seed: i64) i64 {
+    val a0: f64 = (seed + 0) :~ f64;   val a1: f64 = (seed + 1) :~ f64;
+    val a2: f64 = (seed + 2) :~ f64;   val a3: f64 = (seed + 3) :~ f64;
+    val a4: f64 = (seed + 4) :~ f64;   val a5: f64 = (seed + 5) :~ f64;
+    val a6: f64 = (seed + 6) :~ f64;   val a7: f64 = (seed + 7) :~ f64;
+    val a8: f64 = (seed + 8) :~ f64;   val a9: f64 = (seed + 9) :~ f64;
+    val b0: f64 = (seed + 10) :~ f64;  val b1: f64 = (seed + 11) :~ f64;
+    val b2: f64 = (seed + 12) :~ f64;  val b3: f64 = (seed + 13) :~ f64;
+    val b4: f64 = (seed + 14) :~ f64;  val b5: f64 = (seed + 15) :~ f64;
+    val b6: f64 = (seed + 16) :~ f64;  val b7: f64 = (seed + 17) :~ f64;
+    val b8: f64 = (seed + 18) :~ f64;  val b9: f64 = (seed + 19) :~ f64;
+    var acc: i64 = 0;
+    acc = acc + (a0 :~ i64) + (a1 :~ i64) + (a2 :~ i64) + (a3 :~ i64) + (a4 :~ i64);
+    acc = acc + (a5 :~ i64) + (a6 :~ i64) + (a7 :~ i64) + (a8 :~ i64) + (a9 :~ i64);
+    acc = acc + (b0 :~ i64) + (b1 :~ i64) + (b2 :~ i64) + (b3 :~ i64) + (b4 :~ i64);
+    acc = acc + (b5 :~ i64) + (b6 :~ i64) + (b7 :~ i64) + (b8 :~ i64) + (b9 :~ i64);
+    ret acc;
+}
+
+test "reinterpret `:~` round-trips bits through f64 under spill pressure" {
+    val seed: i64 = 1000003;
+    if (bitcast_under_pressure(seed) != 20 * seed + 190) { ret 1; }
+    # a real IEEE-754 bit pattern (pi) survives the same spilled round trip.
+    val pi_bits: i64 = 4614256656552045848;
+    val f: f64 = pi_bits :~ f64;
+    if ((f :~ i64) != pi_bits) { ret 1; }
+    ret 0;
+}

--- a/src/lang/be/codegen/mir.mach
+++ b/src/lang/be/codegen/mir.mach
@@ -3097,16 +3097,16 @@ fun emit_mov(ctx: *LowerCtx, mb: *MirBlock, dst: MirOperand, src: MirOperand) Re
     ret push_instr(ctx, mb, mi);
 }
 
-# emit_fmov: append a scalar floating-point register copy `MIR_FMOV (dst) <- (src)`
+# emit_fmov: append a scalar floating-point register copy `MIR_MOV (dst) <- (src)`
 # at the given float width (4 for f32, 8 for f64). used for the CLASS_FP ABI
 # pre-coloring moves — a float argument / return / parameter that pairs an XMM
-# physical register with a value vreg or a float-constant immediate. emitting the
-# dedicated MIR_FMOV (rather than MIR_MOV) is mandatory when EITHER side is a bare
-# XMM physical register or a float-constant immediate, because neither carries an
-# FP register class for isel to recover: a plain MIR_MOV would select to a
-# general-purpose MOV and move the GP register that aliases the XMM id (XMM0 ==
-# RAX), placing the float in the wrong register file. the encoder materializes the
-# MOVSS / MOVSD (or, for an immediate, MOVABS + MOVQ) byte form from MIR_FMOV.
+# physical register with a value vreg or a float-constant immediate. a float copy
+# is a plain MIR_MOV; the encoder dispatches the move family on operand register
+# CLASS — an XMM-bank operand selects MOVSS / MOVSD (or MOVABS + MOVQ for an
+# immediate), a cross-bank pair MOVD / MOVQ — so a float can never be encoded as a
+# move of the GP register that aliases its XMM index (XMM0 == RAX). the float width
+# (4 / 8) is carried on the move so the encoder picks the single- vs double-
+# precision SSE form; it is preserved across register allocation.
 fun emit_fmov(ctx: *LowerCtx, mb: *MirBlock, dst: MirOperand, src: MirOperand, w: u8) Result[bool, str] {
     val r: Result[*MirOperand, str] = allocate[MirOperand](ctx.alloc, 2::usize);
     if (is_err[*MirOperand, str](r)) { ret err[bool, str](unwrap_err[*MirOperand, str](r)); }
@@ -3114,7 +3114,7 @@ fun emit_fmov(ctx: *LowerCtx, mb: *MirBlock, dst: MirOperand, src: MirOperand, w
     ops[0] = dst;
     ops[1] = src;
     var mi: MirInstr;
-    mi.opcode        = MIR_FMOV;
+    mi.opcode        = MIR_MOV;
     mi.operands      = ops;
     mi.operand_count = 2;
     mi.width         = w;

--- a/src/lang/be/codegen/mir.mach
+++ b/src/lang/be/codegen/mir.mach
@@ -303,17 +303,13 @@ pub val MIR_FDIV:      MirOpcode = 0x1117;
 # the condition code (one of CC_*) rides on `mi.src_width`'s companion field via a
 # dedicated `fcc` carrier set by lowering.
 pub val MIR_FCMP:      MirOpcode = 0x1118;
-# MIR_FMOV: a scalar float register copy (MOVSS / MOVSD), operands [dst, src]. it
-# is the float-domain analogue of MIR_MOV: a plain MIR_MOV between XMM-classed
-# operands would mis-select to a general-purpose MOV, which — because the GP and
-# XMM register id spaces overlap (XMM0 == RAX, XMM1 == RCX, ...) — would silently
-# move the aliased GP register's bytes instead of the float value. isel retags a
-# float MIR_MOV (an operand is an FP-class vreg) to MIR_FMOV using the function's
-# vreg classes; like the float arith ops it then survives selection so regalloc
-# routes a spilled float operand to its frame slot (MOVSS / MOVSD read and write
-# memory directly) and the encoder materializes the SSE move. the width (4 for
-# f32, 8 for f64) selects MOVSS vs MOVSD.
-pub val MIR_FMOV:      MirOpcode = 0x1119;
+# a scalar float register copy is a plain MIR_MOV: with disjoint GP / XMM register
+# id spaces (a physical register id carries its class) the encoder dispatches the
+# move family on operand register CLASS — an XMM-bank operand selects MOVSS / MOVSD,
+# a GP<->XMM pair MOVD / MOVQ — so a float copy needs no dedicated opcode and can
+# never mis-select to a move of the GP register that aliases an XMM index. the float
+# width (4 / 8) rides on the move so the encoder picks the single- vs double-
+# precision form.
 # MIR_FNEG: scalar float negation, operands [dst, src]. a float negate flips the
 # IEEE-754 sign bit, which an integer MIR_NEG (two's-complement of the whole bit
 # pattern) would not produce; this dedicated opcode survives selection and the
@@ -336,19 +332,13 @@ pub val MIR_FNEG:      MirOpcode = 0x111B;
 # a prologue param-capture vreg colored to RAX would clobber the count before the
 # read (the entry `mov %rdi,%rax` regression). the encoder ignores operand 2.
 pub val MIR_VA_FP_SAVE: MirOpcode = 0x111A;
-# MIR_BITCAST_CROSS: a domain-crossing bit reinterpret (`:~`), operands [dst, src].
-# a same-class MIR_BITCAST (GP<->GP or FP<->FP) moves bits within one register bank
-# and selects to a plain MOV / MIR_FMOV. a `:~` between a float and an integer of
-# equal size reinterprets bits ACROSS the GP and XMM banks, which neither a GP MOV
-# nor an SSE MOVSS/MOVSD can express. isel retags such a bitcast (its two operands'
-# vreg classes differ) to this opcode using the function's vreg classes; like the
-# float ops it survives selection so regalloc routes a spilled operand to its frame
-# slot, and the encoder materializes the GP<->XMM MOVD / MOVQ. the byte width rides
-# on `width` (4 selects MOVD, 8 selects MOVQ); `src_width` carries the direction
-# discriminant isel stamps while vreg classes are still readable (1 = destination is
-# the float side, GP -> XMM; 0 = source is the float side, XMM -> GP), since regalloc
-# clears an operand's vreg class when it assigns a physical register.
-pub val MIR_BITCAST_CROSS: MirOpcode = 0x111C;
+# a bit reinterpret (`:~`) is a plain MIR_BITCAST in every direction. a same-bank
+# reinterpret (GP<->GP or XMM<->XMM) is a register copy; a `:~` between a float and
+# an equal-size integer crosses the GP and XMM banks. both select to a plain MOV:
+# the encoder dispatches the move family on operand register CLASS — a same-bank XMM
+# pair emits MOVSS / MOVSD, a register-register GP<->XMM pair emits MOVD / MOVQ, and
+# a spilled side is moved through memory at byte width — so no dedicated cross opcode
+# is needed and the bank can never be lost across register allocation.
 
 # float-comparison condition codes carried on a MIR_FCMP. a UCOMISD sets CF/ZF/PF
 # (an UNORDERED result sets all three), so the float compare maps to UNSIGNED
@@ -2303,9 +2293,9 @@ fun lower_float_op(ctx: *LowerCtx, mb: *MirBlock, inst: *instr.Instruction, iid:
 # the dedicated MIR_FNEG opcode. the opcode survives instruction selection and the
 # encoder flips the IEEE-754 sign bit on the XMM value (XORPS with a width-selected
 # sign mask) rather than the integer MIR_NEG, which would two's-complement the whole
-# bit pattern and produce garbage. operand layout is `[dst, src]` like MIR_FMOV; the
-# operation width (4 for f32, 8 for f64) rides on `mi.width` so the encoder selects
-# the f32 vs f64 sign-bit mask.
+# bit pattern and produce garbage. operand layout is `[dst, src]` like a float MOV;
+# the operation width (4 for f32, 8 for f64) rides on `mi.width` so the encoder
+# selects the f32 vs f64 sign-bit mask.
 fun lower_float_neg(ctx: *LowerCtx, mb: *MirBlock, inst: *instr.Instruction, iid: id.InstructionId) Result[bool, str] {
     if (inst.operand_count < 1) {
         ret err[bool, str]("mir.lower_ir: float negate missing operand");
@@ -2426,10 +2416,10 @@ fun lower_alloca(ctx: *LowerCtx, mb: *MirBlock, inst: *instr.Instruction, iid: i
 # symbol / immediate pointer is left as a plain operand for the encoder to form
 # its own reference. the result vreg is the loaded value.
 #
-# a FLOAT load is retagged to MIR_FMOV by isel and emitted through the SSE
-# operand-routing encoder, which materializes a MOVSS / MOVSD off the resolved
-# operand WITHOUT recording a symbol relocation (it has no patch-site hook). a
-# global / function symbol pointer must therefore be LEA-materialized into a GP
+# a FLOAT load is a plain MIR_MOV whose result is an XMM-class vreg; the encoder
+# dispatches it on operand class and materializes a MOVSS / MOVSD off the resolved
+# operand WITHOUT recording a symbol relocation (that path has no patch-site hook).
+# a global / function symbol pointer must therefore be LEA-materialized into a GP
 # base vreg first (the LEA carries the relocation through the generic path), so the
 # float load addresses `[base]` rather than an unrelocated `[rip+sym]` that would
 # read the wrong address. an integer load keeps the symbol operand: its generic
@@ -2498,11 +2488,12 @@ fun lower_store(ctx: *LowerCtx, mb: *MirBlock, inst: *instr.Instruction) Result[
         if (is_err[bool, str](ar)) { ret ar; }
         stored = op_vreg(addr);
     }
-    # a FLOAT store is retagged to MIR_FMOV and emitted through the SSE encoder,
-    # which records no symbol relocation for its destination MEM. a global symbol
-    # destination must therefore be LEA-materialized into a GP base vreg first (so
-    # the store addresses `[base]`), mirroring the float-load path; an integer store
-    # keeps the symbol destination and relocates through the generic encoding.
+    # a FLOAT store is a plain MIR_MOV whose stored value is an XMM-class vreg; the
+    # encoder dispatches it on operand class and records no symbol relocation for its
+    # destination MEM. a global symbol destination must therefore be LEA-materialized
+    # into a GP base vreg first (so the store addresses `[base]`), mirroring the
+    # float-load path; an integer store keeps the symbol destination and relocates
+    # through the generic encoding.
     var dest: MirOperand = mem_operand_of(ctx, inst.operands[1]);
     if (dest.kind == MIR_OP_SYM && value_is_float(ctx, inst.operands[0].ty)) {
         var dbase: u32 = MIR_VREG_NIL;
@@ -3614,9 +3605,10 @@ fun emit_arg_slot(ctx: *LowerCtx, mb: *MirBlock, slot: abi.ParamSlot, argop: Mir
         ret emit_mov(ctx, mb, op_preg(slot.reg::u32), op_mem_value(base, 0));
     }
     # single FP register scalar argument: a float copy into the XMM argument
-    # register. emitted as MIR_FMOV so a float-constant immediate or the bare XMM
-    # preg (neither of which carries an FP register class) still selects to the SSE
-    # move rather than a general-purpose MOV of the GP register aliasing the XMM id.
+    # register. the XMM argument preg carries the SSE class, so the encoder
+    # dispatches the move on operand class and emits MOVSS / MOVSD (or MOVABS + MOVQ
+    # for a float-constant immediate) rather than a general-purpose MOV of the GP
+    # register that aliases the XMM index.
     if (slot.class == abi.CLASS_FP) {
         ret emit_fmov(ctx, mb, op_preg(slot.reg::u32), argop, fp_move_width(size));
     }
@@ -4580,9 +4572,10 @@ fun lower_ret(ctx: *LowerCtx, mb: *MirBlock, inst: *instr.Instruction) Result[bo
         val mr: Result[bool, str] = emit_mov(ctx, mb, op_preg(slot.reg::u32), op_mem_value(base, 0));
         if (is_err[bool, str](mr)) { ret mr; }
     } or (slot.class == abi.CLASS_FP) {
-        # scalar float return: a float copy into XMM0. emitted as MIR_FMOV so a
-        # float-constant immediate or the bare XMM0 preg still selects to the SSE
-        # move rather than a general-purpose MOV of RAX (which aliases XMM0's id).
+        # scalar float return: a float copy into XMM0. the XMM0 return preg carries
+        # the SSE class, so the encoder dispatches the move on operand class and emits
+        # MOVSS / MOVSD (or MOVABS + MOVQ for a float-constant immediate) rather than a
+        # general-purpose MOV of RAX, which aliases XMM0's index.
         val mr: Result[bool, str] = emit_fmov(ctx, mb, op_preg(slot.reg::u32), rvop, fp_move_width(rsz));
         if (is_err[bool, str](mr)) { ret mr; }
     } or (slot.reg >= 0) {

--- a/src/lang/be/codegen/regalloc.mach
+++ b/src/lang/be/codegen/regalloc.mach
@@ -1462,15 +1462,18 @@ fun expire_active(ctx: *AllocCtx, current_start: i64) {
     ctx.active_count = write;
 }
 
-# free_assigned: return a vreg's assigned register to its bank's free pool.
+# free_assigned: return a vreg's assigned register to its bank's free pool. the
+# assigned id is a composite register id (class tag + within-bank index); the busy
+# array is keyed on the within-bank index, so the index is extracted from it.
 fun free_assigned(ctx: *AllocCtx, v: u32) {
     val mv: *mir.MirVReg = ?ctx.f.vregs[v];
     if (mv.assigned == mir.MIR_VREG_NIL) { ret; }
     val lr: *LiveRange = ?ctx.ranges[v];
+    val index: u32 = isa.regid_index(mv.assigned::i32)::u32;
     if (lr.reg_class == REG_CLASS_GP) {
-        if (mv.assigned < ctx.gp_count) { ctx.gp_busy[mv.assigned] = false; }
+        if (index < ctx.gp_count) { ctx.gp_busy[index] = false; }
     } or {
-        if (mv.assigned < ctx.fp_count) { ctx.fp_busy[mv.assigned] = false; }
+        if (index < ctx.fp_count) { ctx.fp_busy[index] = false; }
     }
 }
 
@@ -1485,7 +1488,7 @@ fun pick_gp(ctx: *AllocCtx, crosses_call: bool) i32 {
         for (ci < ctx.gp_count) {
             if (gp_available(ctx, ci) && ctx.callee_saved[ci] && !ctx.reserved[ci]) {
                 ctx.gp_busy[ci] = true;
-                ret ci::i32;
+                ret isa.regid_make(isa.REG_CLASS_ID_GP, ci::i32);
             }
             ci = ci + 1;
         }
@@ -1495,7 +1498,7 @@ fun pick_gp(ctx: *AllocCtx, crosses_call: bool) i32 {
         for (ci < ctx.gp_count) {
             if (gp_available(ctx, ci) && !ctx.callee_saved[ci] && !ctx.reserved[ci]) {
                 ctx.gp_busy[ci] = true;
-                ret ci::i32;
+                ret isa.regid_make(isa.REG_CLASS_ID_GP, ci::i32);
             }
             ci = ci + 1;
         }
@@ -1505,7 +1508,7 @@ fun pick_gp(ctx: *AllocCtx, crosses_call: bool) i32 {
     for (ci < ctx.gp_count) {
         if (gp_available(ctx, ci) && !ctx.reserved[ci]) {
             ctx.gp_busy[ci] = true;
-            ret ci::i32;
+            ret isa.regid_make(isa.REG_CLASS_ID_GP, ci::i32);
         }
         ci = ci + 1;
     }
@@ -1547,21 +1550,38 @@ fun gp_available(ctx: *AllocCtx, id: u32) bool {
     ret true;
 }
 
-# pick_fp: choose a free floating-point register, or -1 when none is free.
+# pick_fp: choose a free floating-point register, or -1 when none is free. the
+# chosen within-bank index is composed with the SSE class tag so the returned id
+# carries its bank — the allocation ORDER is unchanged, only the representation of
+# the assigned id.
 fun pick_fp(ctx: *AllocCtx) i32 {
     var fi: u32 = 0;
     for (fi < ctx.fp_count) {
         if (!ctx.fp_busy[fi]) {
             ctx.fp_busy[fi] = true;
-            ret fi::i32;
+            ret isa.regid_make(isa.REG_CLASS_ID_XMM, fi::i32);
         }
         fi = fi + 1;
     }
     ret -1;
 }
 
-# assign: record a physical register for a vreg and add it to the active set.
+# assign: record a physical register for a vreg and add it to the active set. the
+# assigned id's class tag must match the vreg's register class — a mismatch is an
+# allocator bug (a float vreg handed a GP register or vice versa) and fails loudly
+# rather than silently mis-encoding, the correctness backstop the disjoint id
+# spaces make checkable.
 fun assign(ctx: *AllocCtx, v: u32, preg: u32, reg_class: u32) {
+    val preg_class: i32 = isa.regid_class(preg::i32);
+    if (reg_class == REG_CLASS_GP) {
+        if (preg_class != isa.REG_CLASS_ID_GP) {
+            panic("regalloc: GP vreg assigned a non-GP register\n");
+        }
+    } or {
+        if (preg_class != isa.REG_CLASS_ID_XMM) {
+            panic("regalloc: float vreg assigned a non-XMM register\n");
+        }
+    }
     ctx.f.vregs[v].assigned = preg;
     ctx.active[ctx.active_count] = v;
     ctx.active_count = ctx.active_count + 1;
@@ -1606,12 +1626,14 @@ fun spill_on_pressure(ctx: *AllocCtx, v: u32) Result[bool, str] {
 }
 
 # free_assigned_id: return a specific physical register of a class to its free
-# pool (used after a victim has been spilled and its `assigned` cleared).
+# pool (used after a victim has been spilled and its `assigned` cleared). `preg`
+# is a composite register id; the busy array is keyed on the within-bank index.
 fun free_assigned_id(ctx: *AllocCtx, v: u32, reg_class: u32, preg: u32) {
+    val index: u32 = isa.regid_index(preg::i32)::u32;
     if (reg_class == REG_CLASS_GP) {
-        if (preg < ctx.gp_count) { ctx.gp_busy[preg] = false; }
+        if (index < ctx.gp_count) { ctx.gp_busy[index] = false; }
     } or {
-        if (preg < ctx.fp_count) { ctx.fp_busy[preg] = false; }
+        if (index < ctx.fp_count) { ctx.fp_busy[index] = false; }
     }
 }
 

--- a/src/lang/be/codegen/regalloc.mach
+++ b/src/lang/be/codegen/regalloc.mach
@@ -1894,19 +1894,6 @@ fun is_spilled(ctx: *AllocCtx, v: u32) bool {
     ret ctx.f.vregs[v].spill_slot >= 0;
 }
 
-# is_float_op_mir: true for a surviving scalar float arithmetic / comparison / move
-# / negate op (MIR_FADD / FSUB / FMUL / FDIV / FCMP / FMOV / FNEG) or a domain-
-# crossing bit reinterpret (MIR_BITCAST_CROSS). the encoder expands these through a
-# fixed scratch register, so a spilled FLOAT operand / result is left as a frame-slot
-# MEM operand for it rather than reloaded into a GP temp. a MIR_BITCAST_CROSS also
-# has a GP-class operand; that side is not `is_fp_vreg`, so it still reloads into a
-# GP temp normally — only the float side rides the MEM path.
-fun is_float_op_mir(op: mir.MirOpcode) bool {
-    ret op == mir.MIR_FADD || op == mir.MIR_FSUB || op == mir.MIR_FMUL ||
-        op == mir.MIR_FDIV || op == mir.MIR_FCMP || op == mir.MIR_FMOV ||
-        op == mir.MIR_FNEG || op == mir.MIR_BITCAST_CROSS;
-}
-
 # is_fp_vreg: true when a vreg belongs to the float / vector register class, so a
 # spilled instance is addressed and loaded as a float rather than reloaded through
 # a GP temp. the MIR_FCMP result is GP-classed (the i8 boolean) and is excluded.

--- a/src/lang/be/codegen/regalloc.mach
+++ b/src/lang/be/codegen/regalloc.mach
@@ -1955,16 +1955,16 @@ fun rewrite_instr(tgt: *target.Target, ctx: *AllocCtx, mi: *mir.MirInstr,
     var store_dst_vreg: u32 = mir.MIR_VREG_NIL;
     var store_dst_tmp: i32 = -1;
 
-    # a float arithmetic / comparison instruction (MIR_FADD / FSUB / FMUL / FDIV /
-    # FCMP) is expanded by the encoder through a fixed XMM scratch pair, reading each
-    # float operand from wherever it lives — an XMM register or a `[rbp + off]` frame
-    # slot — and writing the result the same way. so a SPILLED float operand or
-    # destination is left as a frame-slot MEM operand for the encoder rather than
-    # reloaded into a GP temp (which would copy float bits through a GP register and
-    # then be misread as an XMM register by the float encoder). an XMM-resident float
-    # operand still rewrites to its assigned XMM preg below.
-    val is_float: bool = is_float_op_mir(mi.opcode);
-
+    # a float operand is read and written by the encoder through a fixed XMM scratch
+    # — the float arithmetic / comparison ops (MIR_FADD / FSUB / FMUL / FDIV / FCMP)
+    # and the class-dispatched float MOV / cross bitcast all reach each float operand
+    # wherever it lives, an XMM register or a `[rbp + off]` frame slot. so a SPILLED
+    # FLOAT operand or destination is left as a frame-slot MEM operand for the encoder
+    # rather than reloaded into a GP temp (which would copy float bits through a GP
+    # register and then be misread as an XMM register). the float side is identified
+    # by the operand's vreg register CLASS, never the opcode, so a folded float MOV is
+    # routed the same as a dedicated float op. an XMM-resident float operand still
+    # rewrites to its assigned XMM preg below.
     var k: u32 = 0;
     for (k < n) {
         val op: *mir.MirOperand = ?ops[k];
@@ -1972,7 +1972,7 @@ fun rewrite_instr(tgt: *target.Target, ctx: *AllocCtx, mi: *mir.MirInstr,
             val v: u32 = op.vreg;
             if (has_def && k == 0) {
                 # a destination vreg.
-                if (is_float && is_fp_vreg(ctx, v) && is_spilled(ctx, v)) {
+                if (is_fp_vreg(ctx, v) && is_spilled(ctx, v)) {
                     # the float result is stored directly into its slot by the encoder.
                     ops[k] = mir.op_mem_slot(v, 0);
                 } or (is_spilled(ctx, v)) {
@@ -1986,7 +1986,7 @@ fun rewrite_instr(tgt: *target.Target, ctx: *AllocCtx, mi: *mir.MirInstr,
                     ops[k] = preg_of(ctx, v);
                 }
             } or {
-                if (is_float && is_fp_vreg(ctx, v) && is_spilled(ctx, v)) {
+                if (is_fp_vreg(ctx, v) && is_spilled(ctx, v)) {
                     # the float operand is loaded from its slot by the encoder.
                     ops[k] = mir.op_mem_slot(v, 0);
                 } or (store_dst_tmp >= 0 && v == store_dst_vreg) {

--- a/src/lang/target/abi/sysv.mach
+++ b/src/lang/target/abi/sysv.mach
@@ -47,10 +47,13 @@ pub val REG_R13: i32 = 13;
 pub val REG_R14: i32 = 14;
 pub val REG_R15: i32 = 15;
 
-# floating-point / vector register numbers (XMM0–XMM15). XMM ids share the
-# numeric space 0..15 but live in a distinct register class.
-pub val REG_XMM0: i32 = 0;
-pub val REG_XMM1: i32 = 1;
+# floating-point / vector register numbers (XMM0–XMM15). a physical register id
+# is composite — the SSE class tag in the high byte, the within-bank index in the
+# low byte (`isa.regid_make`) — so a float pre-coloring is self-describing and the
+# encoder picks the SSE machine form rather than aliasing the GP register of the
+# same index. XMM0 is `(REG_CLASS_ID_XMM << 8) | 0 = 0x0100`, XMM1 `0x0101`.
+pub val REG_XMM0: i32 = (1 << 8) | 0;
+pub val REG_XMM1: i32 = (1 << 8) | 1;
 
 # number of general-purpose registers available for argument passing
 # (RDI, RSI, RDX, RCX, R8, R9).
@@ -141,14 +144,16 @@ pub fun gp_param_reg(index: i32) i32 {
 }
 
 # fp_param_reg: the FP argument register for a given argument-register index.
-# XMM registers are numbered identically to their index. returns -1 past XMM7.
+# XMM registers are numbered identically to their index within the SSE bank; the
+# returned id is composite (the SSE class tag in the high byte) so a float
+# pre-coloring carries its bank. returns -1 past XMM7.
 # ---
 # index: zero-based FP argument-register index
-# ret:   the physical XMM register id, or -1 if out of range
+# ret:   the composite XMM register id, or -1 if out of range
 pub fun fp_param_reg(index: i32) i32 {
     if (index < 0) { ret -1; }
     if (index >= FP_PARAM_COUNT) { ret -1; }
-    ret index;
+    ret isa.regid_make(isa.REG_CLASS_ID_XMM, index);
 }
 
 # unsupported_slot: the honest "unsupported architecture" sentinel returned by
@@ -343,7 +348,7 @@ pub fun gp_param_regs(out: *isa.Register) i32 {
 pub fun fp_param_regs(out: *isa.Register) i32 {
     var i: i32 = 0;
     for (i < FP_PARAM_COUNT) {
-        out[i].id   = i;
+        out[i].id   = isa.regid_make(isa.REG_CLASS_ID_XMM, i);
         out[i].size = 16;
         i = i + 1;
     }

--- a/src/lang/target/isa.mach
+++ b/src/lang/target/isa.mach
@@ -379,6 +379,42 @@ pub fun buf_dnit(buf: *InstBuf) {
     buf.cap   = 0;
 }
 
+# a physical register id is a COMPOSITE value that encodes both the register
+# CLASS and the within-bank INDEX: `regid = (class_id << 8) | index`. the class
+# id occupies the high byte, the within-bank index the low byte. this makes a
+# post-register-allocation register operand self-describing — the encoder reads
+# the class straight off the id to pick the GP versus SSE machine form, so a float
+# value can never be silently encoded as a move of the GP register that aliases
+# its XMM index (XMM0 and RAX both index 0). the general-purpose bank is class 0,
+# so a GP id is numerically identical to its raw index (0..15) and every GP-keyed
+# table, mask, and comparison in the back end is unchanged; only the wider
+# register classes (XMM = class 1, ids 0x0100..0x010F) gain the high-byte tag.
+
+# REG_CLASS_ID_GP: the composite-register-id class tag for the general-purpose
+# bank. zero by construction so a GP id equals its raw within-bank index.
+pub val REG_CLASS_ID_GP: i32 = 0;
+
+# REG_CLASS_ID_XMM: the composite-register-id class tag for the SSE / vector bank.
+pub val REG_CLASS_ID_XMM: i32 = 1;
+
+# regid_make: compose a physical register id from a class tag and within-bank
+# index. the inverse of `regid_class` / `regid_index`.
+pub fun regid_make(class_id: i32, index: i32) i32 {
+    ret ((class_id & 0xFF) << 8) | (index & 0xFF);
+}
+
+# regid_class: the class tag encoded in a composite register id (its high byte).
+pub fun regid_class(regid: i32) i32 {
+    ret (regid >> 8) & 0xFF;
+}
+
+# regid_index: the within-bank register index encoded in a composite register id
+# (its low byte). every machine-encoding helper reads the index through this so a
+# class-tagged id encodes to the same ModRM / REX bits as its raw index did.
+pub fun regid_index(regid: i32) i32 {
+    ret regid & 0xFF;
+}
+
 # make_reg: build a register operand.
 # ---
 # id:   register number

--- a/src/lang/target/isa.mach
+++ b/src/lang/target/isa.mach
@@ -417,7 +417,8 @@ pub fun regid_index(regid: i32) i32 {
 
 # make_reg: build a register operand.
 # ---
-# id:   register number
+# id:   composite register id (`regid_make`): the class tag in the high byte, the
+#       within-bank index in the low byte. a GP id is its raw index (class 0).
 # size: width in bytes
 # ret:  Operand with kind=OPK_REG
 pub fun make_reg(id: i32, size: u8) Operand {
@@ -457,9 +458,10 @@ pub fun make_imm(value: i64, size: u8) Operand {
 
 # make_mem: build a memory operand (base + index*scale + disp).
 # ---
-# base:  base register id (-1 if none)
+# base:  base register id (-1 if none); a general-purpose composite id (no SSE
+#        addressing form exists, so the encoder rejects a non-GP base)
 # disp:  displacement
-# index: index register id (-1 if none)
+# index: index register id (-1 if none); likewise general-purpose
 # scale: index scale (1, 2, 4, or 8)
 # size:  access width in bytes
 # ret:   Operand with kind=OPK_MEM

--- a/src/lang/target/isa/x64.mach
+++ b/src/lang/target/isa/x64.mach
@@ -81,10 +81,13 @@ pub val FRAME_REG: i32 = 5;
 # scratch registers the back end reserves for materializing addresses, spilled
 # reloads, and the 16-byte-return / varargs lowering sequences. `SCRATCH_REG`
 # (R11) and `SCRATCH_REG2` (R10) are caller-saved and excluded from allocation;
-# `FP_SCRATCH_REG` (XMM15) plays the same role in the SSE file.
+# `FP_SCRATCH_REG` (XMM15) plays the same role in the SSE file. a physical
+# register id is composite (the class tag in the high byte, the within-bank index
+# in the low byte): a GP scratch keeps its raw index (class 0), the SSE scratch
+# carries the SSE class tag (`(REG_CLASS_ID_XMM << 8) | 15 = 0x010F`).
 pub val SCRATCH_REG:    i32 = 11;
 pub val SCRATCH_REG2:   i32 = 10;
-pub val FP_SCRATCH_REG: i32 = 15;
+pub val FP_SCRATCH_REG: i32 = (1 << 8) | 15;
 
 # code alignment for function entry points, in bytes.
 pub val CODE_ALIGN: u32 = 16;
@@ -486,9 +489,10 @@ pub fun reg_name(ctx: ptr, id: i32, size: u8) str {
 
 # fp_reg_name: the assembly mnemonic for an SSE register.
 # ---
-# id:  XMM register number (0–15)
+# id:  composite XMM register id (the within-bank index is extracted)
 # ret: the register mnemonic, or "???" for an out-of-range id
-pub fun fp_reg_name(id: i32) str {
+pub fun fp_reg_name(cid: i32) str {
+    val id: i32 = isa.regid_index(cid);
     if (id == 0)  { ret "xmm0"; }
     if (id == 1)  { ret "xmm1"; }
     if (id == 2)  { ret "xmm2"; }

--- a/src/lang/target/isa/x64/encode.mach
+++ b/src/lang/target/isa/x64/encode.mach
@@ -143,20 +143,27 @@ fun emit_u64(buf: *ByteBuf, value: u64) {
     emit_u32(buf, ((value >> 32) & 0xFFFFFFFF)::u32);
 }
 
-# reg_bits: low 3 bits of a register id for encoding.
+# reg_bits: low 3 bits of a register id for encoding. the id is a composite
+# register id (class tag in the high byte); the within-bank index drives the
+# ModRM/REX encoding, so the index is extracted before masking to 3 bits. a GP id
+# is its own index (class 0), so this is unchanged for general-purpose registers.
 fun reg_bits(id: i32) u8 {
-    ret (id & 7)::u8;
+    ret (isa.regid_index(id) & 7)::u8;
 }
 
-# needs_rex: true if register id uses the extended range (r8-r15).
+# needs_rex: true if register id uses the extended range (r8-r15 / xmm8-xmm15).
+# reads the within-bank index from the composite register id.
 fun needs_rex(id: i32) bool {
-    ret id >= 8 && id <= 15;
+    val index: i32 = isa.regid_index(id);
+    ret index >= 8 && index <= 15;
 }
 
 # needs_rex_byte: true if a byte operand on this register requires a REX prefix
-# (regs 4-15: SPL/BPL/SIL/DIL plus the extended set).
+# (regs 4-15: SPL/BPL/SIL/DIL plus the extended set). reads the within-bank index
+# from the composite register id.
 fun needs_rex_byte(id: i32) bool {
-    ret id >= 4 && id <= 15;
+    val index: i32 = isa.regid_index(id);
+    ret index >= 4 && index <= 15;
 }
 
 # encode_rex: build a REX prefix byte.
@@ -168,8 +175,10 @@ fun needs_rex_byte(id: i32) bool {
 fun encode_rex(w: u8, reg: i32, rm: i32) u8 {
     var rex: u8 = 0x40;
     if (w != 0) { rex = rex | 0x08; }
-    if (reg >= 8 && reg <= 15) { rex = rex | 0x04; }
-    if (rm >= 8 && rm <= 15) { rex = rex | 0x01; }
+    val reg_i: i32 = isa.regid_index(reg);
+    val rm_i: i32 = isa.regid_index(rm);
+    if (reg_i >= 8 && reg_i <= 15) { rex = rex | 0x04; }
+    if (rm_i >= 8 && rm_i <= 15) { rex = rex | 0x01; }
     ret rex;
 }
 
@@ -183,9 +192,12 @@ fun encode_rex(w: u8, reg: i32, rm: i32) u8 {
 fun encode_rex_sib(w: u8, reg: i32, index: i32, base: i32) u8 {
     var rex: u8 = 0x40;
     if (w != 0) { rex = rex | 0x08; }
-    if (reg >= 8 && reg <= 15) { rex = rex | 0x04; }
-    if (index >= 8 && index <= 15) { rex = rex | 0x02; }
-    if (base >= 8 && base <= 15) { rex = rex | 0x01; }
+    val reg_i: i32 = isa.regid_index(reg);
+    val index_i: i32 = isa.regid_index(index);
+    val base_i: i32 = isa.regid_index(base);
+    if (reg_i >= 8 && reg_i <= 15) { rex = rex | 0x04; }
+    if (index_i >= 8 && index_i <= 15) { rex = rex | 0x02; }
+    if (base_i >= 8 && base_i <= 15) { rex = rex | 0x01; }
     ret rex;
 }
 
@@ -216,18 +228,23 @@ fun size_to_w(size: u8, flags: u16) u8 {
     ret 0;
 }
 
-# needs_any_rex: true if this instruction requires a REX prefix at all.
+# needs_any_rex: true if this instruction requires a REX prefix at all. reads the
+# within-bank index from each composite register id.
 fun needs_any_rex(w: u8, reg: i32, rm: i32) bool {
     if (w != 0) { ret true; }
-    if (reg >= 8 && reg <= 15) { ret true; }
-    if (rm >= 8 && rm <= 15) { ret true; }
+    val reg_i: i32 = isa.regid_index(reg);
+    val rm_i: i32 = isa.regid_index(rm);
+    if (reg_i >= 8 && reg_i <= 15) { ret true; }
+    if (rm_i >= 8 && rm_i <= 15) { ret true; }
     ret false;
 }
 
 # needs_rex_for_byte_reg: true if a byte operand on this register would alias a
-# high byte register (AH/CH/DH/BH) unless a REX prefix is present.
+# high byte register (AH/CH/DH/BH) unless a REX prefix is present. reads the
+# within-bank index from the composite register id.
 fun needs_rex_for_byte_reg(reg: i32) bool {
-    ret reg >= 4 && reg <= 7;
+    val index: i32 = isa.regid_index(reg);
+    ret index >= 4 && index <= 7;
 }
 
 # encode_mem_operand: emit ModR/M + optional SIB + displacement for a memory
@@ -242,6 +259,17 @@ fun encode_mem_operand(buf: *ByteBuf, reg: i32, op: *isa.Operand) {
     val index: i32 = op.index;
     val disp: i32 = op.disp;
     val has_index: bool = index >= 0;
+
+    # a memory base / scaled index is always a general-purpose register: x86-64 has
+    # no SSE-register addressing form. an XMM-class base or index reaching here is a
+    # register-allocation / lowering bug (it would silently encode the GP register
+    # that aliases the XMM index), rejected loudly rather than mis-encoded.
+    if (base != -1 && isa.regid_class(base) != isa.REG_CLASS_ID_GP) {
+        panic("encode: memory base register is not general-purpose\n");
+    }
+    if (has_index && isa.regid_class(index) != isa.REG_CLASS_ID_GP) {
+        panic("encode: memory index register is not general-purpose\n");
+    }
 
     if (base == -1 && !has_index) {
         emit_byte(buf, encode_modrm(0, reg_bits(reg), 5));
@@ -1286,7 +1314,7 @@ fun encode_xorps(mi: *isa.Inst, buf: *ByteBuf) i32 {
     val dst: *isa.Operand = ?mi.dst;
     val src1: *isa.Operand = ?mi.src1;
     if (dst.kind == isa.OPK_REG && src1.kind == isa.OPK_REG) {
-        if (dst.reg >= 8 || src1.reg >= 8) {
+        if (needs_rex(dst.reg) || needs_rex(src1.reg)) {
             emit_byte(buf, encode_rex(0, dst.reg, src1.reg));
         }
         emit_byte(buf, 0x0F);

--- a/src/lang/target/isa/x64/encode.mach
+++ b/src/lang/target/isa/x64/encode.mach
@@ -527,13 +527,68 @@ fun is_sse_alu(opcode: u16) bool {
     ret opcode >= x64.ADDSS && opcode <= x64.DIVSD;
 }
 
-# encode_mov: encode MOV in all register/immediate/memory forms.
+# reg_is_xmm: true when an operand is a physical register in the SSE / vector
+# bank. reads the class straight off the composite register id, the seam that lets
+# the move family pick the GP versus SSE machine form from the operands alone.
+fun reg_is_xmm(op: *isa.Operand) bool {
+    ret op.kind == isa.OPK_REG && isa.regid_class(op.reg) == isa.REG_CLASS_ID_XMM;
+}
+
+# encode_fp_mov: encode a MOV whose operands name SSE registers, dispatched here by
+# operand register CLASS rather than a float-specific opcode — a float register
+# copy, a scalar float load / store, a same-bank float bitcast, and a cross-bank
+# `:~` bitcast all arrive as a plain MOV and are realized from the operand banks.
+#
+# a register-to-register move between DIFFERENT banks (one GP, one XMM) is a
+# domain-crossing bit reinterpret: MOVD (4-byte) / MOVQ (8-byte) transfers the raw
+# bits across the banks. every other shape — XMM<->XMM, XMM<->memory, or a float
+# constant immediate — is a same-bank float move routed through the fixed float
+# scratch (the SSE analogue of the GP mem-mem split), so a spilled `[rbp + off]`
+# slot or an immediate on either side encodes uniformly without an SSE mem-mem
+# form (which x86-64 has none of). a float spilled on BOTH sides carries no
+# register operand, so it never reaches here — it is a bit-exact GP mem-mem copy.
+# `mi.size` is the float width (4 -> MOVSS / MOVD, 8 -> MOVSD / MOVQ).
+fun encode_fp_mov(mi: *isa.Inst, buf: *ByteBuf) i32 {
+    val start: usize = buf.len;
+    val dst: *isa.Operand = ?mi.dst;
+    val src1: *isa.Operand = ?mi.src1;
+    var w: u8 = mi.size;
+    if (w != 4 && w != 8) { w = 8; }
+
+    # a register-register move across banks reinterprets bits with MOVD / MOVQ.
+    if (dst.kind == isa.OPK_REG && src1.kind == isa.OPK_REG &&
+        reg_is_xmm(dst) != reg_is_xmm(src1)) {
+        if (reg_is_xmm(dst)) {
+            emit_movd_movq_reg(src1.reg, dst.reg, w, true, buf);
+        } or {
+            emit_movd_movq_reg(dst.reg, src1.reg, w, false, buf);
+        }
+        ret (buf.len - start)::i32;
+    }
+
+    # a same-bank float move: load the source into the float scratch and store it to
+    # the destination, so every register / frame-slot / immediate shape encodes.
+    val ld: Result[bool, str] = emit_float_load(@src1, FLOAT_SCRATCH0, w, buf);
+    if (is_err[bool, str](ld)) { ret 0; }
+    val st: Result[bool, str] = emit_float_store(@dst, FLOAT_SCRATCH0, w, buf);
+    if (is_err[bool, str](st)) { ret 0; }
+    ret (buf.len - start)::i32;
+}
+
+# encode_mov: encode MOV in all register/immediate/memory forms. a MOV naming an
+# SSE register on either side is a float move dispatched to `encode_fp_mov` by
+# operand class — the seam that makes "wrong register bank" unrepresentable rather
+# than a hazard guarded by a float-specific opcode.
 fun encode_mov(mi: *isa.Inst, buf: *ByteBuf) i32 {
     val start: usize = buf.len;
     val dst: *isa.Operand = ?mi.dst;
     val src1: *isa.Operand = ?mi.src1;
     val size: u8 = mi.size;
     val flags: u16 = mi.flags;
+
+    if (reg_is_xmm(dst) || reg_is_xmm(src1)) {
+        ret encode_fp_mov(mi, buf);
+    }
 
     if (dst.kind == isa.OPK_REG && src1.kind == isa.OPK_REG) {
         val w: u8 = size_to_w(size, flags);
@@ -2512,12 +2567,6 @@ fun encode_mir_instr(st: *EncodeState, f: *mir.MirFunction, fn_base: u32, mi: *m
     if (mi.opcode == mir.MIR_FCMP) {
         ret encode_float_cmp(f, mi, ?st.buf);
     }
-    # a float register copy survives selection keeping its MIR_FMOV opcode; the
-    # encoder materializes its MOVSS / MOVSD byte form here, routing the value
-    # through the float scratch so any spilled-operand shape encodes correctly.
-    if (mi.opcode == mir.MIR_FMOV) {
-        ret encode_float_mov(f, mi, ?st.buf);
-    }
     # a float negate survives selection keeping its MIR_FNEG opcode; the encoder
     # materializes the sign-bit XOR byte sequence here (the float value loaded into
     # the XMM scratch, XORPS against a width-selected sign mask, the result stored
@@ -2525,13 +2574,11 @@ fun encode_mir_instr(st: *EncodeState, f: *mir.MirFunction, fn_base: u32, mi: *m
     if (mi.opcode == mir.MIR_FNEG) {
         ret encode_float_neg(f, mi, ?st.buf);
     }
-    # a domain-crossing bit reinterpret survives selection keeping its
-    # MIR_BITCAST_CROSS opcode; the encoder materializes the GP<->XMM MOVD / MOVQ
-    # here, routing the float side through the XMM scratch and the integer side
-    # through the GP scratch so any spilled-operand shape encodes.
-    if (mi.opcode == mir.MIR_BITCAST_CROSS) {
-        ret encode_bitcast_cross(f, mi, ?st.buf);
-    }
+    # a float register copy, a scalar float load / store, and a same-bank or
+    # cross-bank bitcast all arrive as a plain MOV; the encoder dispatches the move
+    # family on operand register CLASS in `encode_mov` (MOVSS / MOVSD for an SSE
+    # operand, MOVD / MOVQ across banks), so they fall through to `mir_to_inst` /
+    # `encode_inst` below with no dedicated opcode.
 
     # a float conversion survives selection keeping its dedicated MIR_FP_* opcode;
     # the encoder materializes the SSE conversion byte sequence here, routing the
@@ -2922,34 +2969,6 @@ fun encode_float_arith(f: *mir.MirFunction, mi: *mir.MirInstr, buf: *ByteBuf) Re
     ret emit_float_store(dst, FLOAT_SCRATCH0, w, buf);
 }
 
-# encode_float_mov: materialize a fully-resolved float register copy
-# `MIR_FMOV [dst, src]` into its SSE byte sequence. routes the value through the
-# fixed FLOAT_SCRATCH0 register exactly as `encode_float_arith` does, so every
-# operand shape regalloc can produce — an XMM register, a spilled `[rbp + off]`
-# frame slot on either side, or a float-constant immediate source — is handled
-# uniformly without a mem-to-mem SSE form (which x86-64 has no encoding for). the
-# width (`mi.width`: 4 for f32, 8 for f64) selects MOVSS vs MOVSD throughout.
-fun encode_float_mov(f: *mir.MirFunction, mi: *mir.MirInstr, buf: *ByteBuf) Result[bool, str] {
-    if (mi.operand_count < 2) {
-        ret err[bool, str]("encode: float move missing operands");
-    }
-    val w: u8 = mi.width;
-    if (w != 4 && w != 8) {
-        ret err[bool, str]("encode: float move has a non-float operand width");
-    }
-
-    val rd: Result[isa.Operand, str] = mir_to_operand(f, ?mi.operands[0], 16);
-    if (is_err[isa.Operand, str](rd)) { ret err[bool, str](unwrap_err[isa.Operand, str](rd)); }
-    val dst: isa.Operand = unwrap_ok[isa.Operand, str](rd);
-    val rs: Result[isa.Operand, str] = mir_to_operand(f, ?mi.operands[1], w);
-    if (is_err[isa.Operand, str](rs)) { ret err[bool, str](unwrap_err[isa.Operand, str](rs)); }
-    val src: isa.Operand = unwrap_ok[isa.Operand, str](rs);
-
-    val ld: Result[bool, str] = emit_float_load(src, FLOAT_SCRATCH0, w, buf);
-    if (is_err[bool, str](ld)) { ret ld; }
-    ret emit_float_store(dst, FLOAT_SCRATCH0, w, buf);
-}
-
 # float_sign_mask: the IEEE-754 sign-bit mask for a float of byte width `w` — the
 # single high bit (0x8000_0000 for an f32, 0x8000_0000_0000_0000 for an f64). XORing
 # the value against it flips the sign, which is exactly a float negation; a wider
@@ -3173,45 +3192,6 @@ fun emit_movd_movq_reg(gp: i32, xmm: i32, w: u8, gp_to_xmm: bool, buf: *ByteBuf)
         mq.src1 = isa.make_reg(xmm, 16);
     }
     encode_inst(?mq, buf);
-}
-
-# encode_bitcast_cross: materialize a domain-crossing bit reinterpret
-# `MIR_BITCAST_CROSS [dst, src]` (a `:~` between a float and an equal-size integer)
-# into its GP<->XMM byte sequence. the operand's raw bits are transferred between
-# the register banks with MOVD (4-byte) or MOVQ (8-byte) — no numeric conversion —
-# routing each side through a fixed scratch register so any spilled frame-slot or
-# physical-register operand shape encodes. `mi.width` is the equal byte size; isel
-# stamped the direction onto `mi.src_width` (1 = destination is the float side,
-# GP -> XMM; 0 = source is the float side, XMM -> GP).
-fun encode_bitcast_cross(f: *mir.MirFunction, mi: *mir.MirInstr, buf: *ByteBuf) Result[bool, str] {
-    if (mi.operand_count < 2) {
-        ret err[bool, str]("encode: cross bitcast missing operands");
-    }
-    val w: u8 = mi.width;
-    val dst_is_float: bool = mi.src_width == 1;
-
-    val rd: Result[isa.Operand, str] = mir_to_operand(f, ?mi.operands[0], w);
-    if (is_err[isa.Operand, str](rd)) { ret err[bool, str](unwrap_err[isa.Operand, str](rd)); }
-    val dst: isa.Operand = unwrap_ok[isa.Operand, str](rd);
-    val rs: Result[isa.Operand, str] = mir_to_operand(f, ?mi.operands[1], w);
-    if (is_err[isa.Operand, str](rs)) { ret err[bool, str](unwrap_err[isa.Operand, str](rs)); }
-    val src: isa.Operand = unwrap_ok[isa.Operand, str](rs);
-
-    # GP -> XMM: the integer source loads into the GP scratch, the bits move to the
-    # float scratch via MOVD/MOVQ, and the float scratch stores to the float dest.
-    if (dst_is_float) {
-        val ld: Result[bool, str] = emit_gp_load(src, x64.SCRATCH_REG, w, buf);
-        if (is_err[bool, str](ld)) { ret ld; }
-        emit_movd_movq_reg(x64.SCRATCH_REG, FLOAT_SCRATCH0, w, true, buf);
-        ret emit_float_store(dst, FLOAT_SCRATCH0, w, buf);
-    }
-
-    # XMM -> GP: the float source loads into the float scratch, the bits move to the
-    # GP scratch via MOVD/MOVQ, and the GP scratch stores to the integer dest.
-    val ld: Result[bool, str] = emit_float_load(src, FLOAT_SCRATCH0, w, buf);
-    if (is_err[bool, str](ld)) { ret ld; }
-    emit_movd_movq_reg(x64.SCRATCH_REG, FLOAT_SCRATCH0, w, false, buf);
-    ret emit_gp_store(dst, x64.SCRATCH_REG, w, buf);
 }
 
 # encode_va_fp_save: materialize the AL-guarded variadic FP-register spill

--- a/src/lang/target/isa/x64/encode.mach
+++ b/src/lang/target/isa/x64/encode.mach
@@ -2766,9 +2766,11 @@ fun encode_compare(f: *mir.MirFunction, mi: *mir.MirInstr, buf: *ByteBuf) Result
 # (the SSE analogue of R10/R11 for the GP encoder scratch). regalloc never assigns
 # them — the xmm bank exposes only XMM0–XMM13 — so a live float vreg can never
 # occupy one. FLOAT_SCRATCH0 holds the left operand and the running result;
-# FLOAT_SCRATCH1 holds the right operand.
-val FLOAT_SCRATCH0: i32 = 14;
-val FLOAT_SCRATCH1: i32 = 15;
+# FLOAT_SCRATCH1 holds the right operand. these are composite register ids (the
+# SSE class tag in the high byte): XMM14 = `(REG_CLASS_ID_XMM << 8) | 14 = 0x010E`,
+# XMM15 = `0x010F`, so an operand built on them carries its bank to the encoder.
+val FLOAT_SCRATCH0: i32 = (1 << 8) | 14;
+val FLOAT_SCRATCH1: i32 = (1 << 8) | 15;
 
 # is_mir_float_arith: true when a post-isel opcode is a surviving scalar float
 # arithmetic op (MIR_FADD / FSUB / FMUL / FDIV). these keep their dedicated opcode
@@ -3268,7 +3270,7 @@ fun encode_va_fp_save(f: *mir.MirFunction, mi: *mir.MirInstr, buf: *ByteBuf) Res
         zero_inst(?st);
         st.opcode = x64.MOVSD;
         st.dst    = isa.make_mem(base.base, (base.disp::i64 + i * 16)::i32, base.index, base.scale, 8);
-        st.src1   = isa.make_reg(i::i32, 16);
+        st.src1   = isa.make_reg(isa.regid_make(isa.REG_CLASS_ID_XMM, i::i32), 16);
         st.size   = 8;
         encode_inst(?st, buf);
         i = i + 1;

--- a/src/lang/target/isa/x64/isel.mach
+++ b/src/lang/target/isa/x64/isel.mach
@@ -128,15 +128,6 @@ pub fun select(alloc: *Allocator, tgt: *target.Target, fn: *mir.MirFunction) Res
     if (tgt == nil)   { ret err[bool, str]("isel: nil target"); }
     if (fn == nil)    { ret err[bool, str]("isel: nil mir function"); }
 
-    # retag every float register copy / scalar load / scalar store to MIR_FMOV
-    # before selection, while the operands are still vregs whose register class the
-    # function records. a plain MIR_MOV / MIR_LOAD / MIR_STORE on an XMM-classed
-    # value would otherwise select to a general-purpose MOV and move the aliased GP
-    # register (XMM register ids overlap GP ids — XMM0 == RAX) instead of the float,
-    # and the GP register allocator would then reuse that "free" GP register for an
-    # unrelated value, clobbering the float.
-    retag_float_moves(fn);
-
     var bi: u32 = 0;
     for (bi < fn.block_count) {
         val r: Result[bool, str] = select_block(alloc, ?fn.blocks[bi]);
@@ -145,79 +136,6 @@ pub fun select(alloc: *Allocator, tgt: *target.Target, fn: *mir.MirFunction) Res
     }
 
     ret ok[bool, str](true);
-}
-
-# retags every float register copy / scalar load / scalar store to MIR_FMOV. the
-# operation moves a floating-point value when an operand names an FP-class vreg —
-# a MIR_MOV's value vreg (the ABI pre-coloring and phi copies pair an XMM physical
-# register with an FP-class value vreg), a MIR_LOAD's result vreg, or a MIR_STORE's
-# stored value vreg. retagging to the dedicated MIR_FMOV opcode (which survives
-# selection like the float arith ops) makes regalloc route a spilled float operand
-# to its frame slot and the encoder emit MOVSS / MOVSD; the alias-free SSE form
-# also keeps the GP allocator from reusing the float's (GP-id-aliased) register.
-# a same-width float-to-float MIR_BITCAST (`f64::f64`, `f32::f32`, or a `:~` between
-# equal-size floats) is likewise a float register copy — its `[dst, src]` operands
-# are both FP-class — so it joins the retag rather than selecting to an aliased GP
-# MOV that would corrupt the value. a `:~` DOMAIN-CROSSING bitcast (one operand FP,
-# the other GP, e.g. `f64 :~ u64`) is instead retagged to MIR_BITCAST_CROSS, whose
-# encoder emits the GP<->XMM MOVD / MOVQ; routing it to MIR_FMOV would emit an SSE
-# move within the float bank and never cross to the GP register. run before
-# selection so isel's integer MIR_MOV / MIR_LOAD / MIR_STORE arms only ever see
-# integer/pointer operations.
-fun retag_float_moves(fn: *mir.MirFunction) {
-    var bi: u32 = 0;
-    for (bi < fn.block_count) {
-        val b: *mir.MirBlock = ?fn.blocks[bi];
-        var ii: u32 = 0;
-        for (ii < b.instr_count) {
-            val mi: *mir.MirInstr = ?b.instrs[ii];
-            if (mi.opcode == mir.MIR_BITCAST && bitcast_is_cross(fn, mi)) {
-                mi.opcode = mir.MIR_BITCAST_CROSS;
-                # stamp the direction onto src_width while the vreg classes are still
-                # readable: 1 = destination is the float side (GP -> XMM), 0 = source
-                # is the float side (XMM -> GP). the byte width stays in `width`. after
-                # regalloc rewrites the operands to pregs their class is no longer
-                # recoverable, so the encoder reads this discriminant instead.
-                mi.src_width = 0;
-                if (mir.vreg_is_fp(fn, mi.operands[0].vreg)) { mi.src_width = 1; }
-            } or (
-                (mi.opcode == mir.MIR_MOV || mi.opcode == mir.MIR_LOAD ||
-                 mi.opcode == mir.MIR_STORE || mi.opcode == mir.MIR_BITCAST) &&
-                move_is_float(fn, mi)) {
-                mi.opcode = mir.MIR_FMOV;
-            }
-            ii = ii + 1;
-        }
-        bi = bi + 1;
-    }
-}
-
-# true when a `MIR_BITCAST [dst, src]` reinterprets bits across the GP and XMM banks
-# — its destination and source vregs belong to different register classes (one a
-# float, one an integer/pointer of equal size). such a bitcast cannot be a plain MOV
-# (GP) or MOVSS/MOVSD (SSE); it needs the GP<->XMM MOVD/MOVQ the MIR_BITCAST_CROSS
-# encoder emits. a same-class bitcast (both GP or both FP) returns false.
-fun bitcast_is_cross(fn: *mir.MirFunction, mi: *mir.MirInstr) bool {
-    if (mi.operand_count < 2) { ret false; }
-    val d: *mir.MirOperand = ?mi.operands[0];
-    val s: *mir.MirOperand = ?mi.operands[1];
-    if (d.kind != mir.MIR_OP_VREG || s.kind != mir.MIR_OP_VREG) { ret false; }
-    ret mir.vreg_is_fp(fn, d.vreg) != mir.vreg_is_fp(fn, s.vreg);
-}
-
-# true when an operation moves a floating-point value: an operand is a
-# MIR_OP_VREG whose function-recorded register class is the FP/vector bank. a
-# memory operand's pointer base vreg is general-purpose, so a MIR_LOAD's result
-# (operand 0) and a MIR_STORE's stored value (operand 1) identify the float
-# domain without the address operand interfering.
-fun move_is_float(fn: *mir.MirFunction, mi: *mir.MirInstr) bool {
-    var k: u32 = 0;
-    for (k < mi.operand_count) {
-        val op: *mir.MirOperand = ?mi.operands[k];
-        if (op.kind == mir.MIR_OP_VREG && mir.vreg_is_fp(fn, op.vreg)) { ret true; }
-        k = k + 1;
-    }
-    ret false;
 }
 
 # select concrete instructions for one block. instructions that map 1:1 to a
@@ -333,12 +251,13 @@ fun is_simple(o: mir.MirOpcode) bool {
     # dividend high-half setup + IDIV / DIV byte sequence from the surviving opcode.
     if (o == mir.MIR_DIV_S || o == mir.MIR_REM_S ||
         o == mir.MIR_DIV_U || o == mir.MIR_REM_U) { ret true; }
+    # an integer width / representation conversion, and a BITCAST in any direction,
+    # select to a single concrete move. a same-bank float bitcast and a cross-bank
+    # `:~` reinterpret both select to a plain MOV: the encoder dispatches the move
+    # family on operand register CLASS — same-bank XMM emits MOVSS / MOVSD, a
+    # GP<->XMM pair emits MOVD / MOVQ — so no dedicated cross opcode is needed.
     if (o == mir.MIR_TRUNC || o == mir.MIR_SEXT || o == mir.MIR_ZEXT ||
         o == mir.MIR_BITCAST) { ret true; }
-    # a domain-crossing bit reinterpret survives selection keeping its dedicated
-    # MIR_BITCAST_CROSS opcode (like MIR_FMOV): regalloc routes a spilled operand to
-    # its frame slot, and the encoder materializes the GP<->XMM MOVD / MOVQ.
-    if (o == mir.MIR_BITCAST_CROSS) { ret true; }
     if (o == mir.MIR_FP_TRUNC || o == mir.MIR_FP_EXT ||
         o == mir.MIR_FP_TO_SI || o == mir.MIR_FP_TO_UI ||
         o == mir.MIR_SI_TO_FP || o == mir.MIR_UI_TO_FP) { ret true; }
@@ -350,11 +269,6 @@ fun is_simple(o: mir.MirOpcode) bool {
     # the surviving opcode.
     if (o == mir.MIR_FADD || o == mir.MIR_FSUB || o == mir.MIR_FMUL ||
         o == mir.MIR_FDIV || o == mir.MIR_FCMP) { ret true; }
-    # a float register copy survives selection keeping its dedicated MIR_FMOV
-    # opcode (like the float arith ops): regalloc routes a spilled float operand to
-    # its frame slot from the surviving opcode, and the encoder materializes the
-    # MOVSS / MOVSD byte form.
-    if (o == mir.MIR_FMOV) { ret true; }
     # a float negate survives selection keeping its dedicated MIR_FNEG opcode (like
     # the float arith ops): the encoder materializes the sign-bit XOR byte sequence.
     if (o == mir.MIR_FNEG) { ret true; }
@@ -515,16 +429,6 @@ fun rewrite_simple(mi: *mir.MirInstr) Result[bool, str] {
     # to disambiguate), and the encoder materializes their SSE byte sequence from it.
     if (o == mir.MIR_FADD || o == mir.MIR_FSUB || o == mir.MIR_FMUL ||
         o == mir.MIR_FDIV || o == mir.MIR_FCMP) { ret ok[bool, str](true); }
-
-    # a float register copy survives selection unchanged, like the float arith ops;
-    # the encoder materializes its MOVSS / MOVSD byte form. `retag_float_moves` set
-    # the opcode before this pass from the function's vreg classes.
-    if (o == mir.MIR_FMOV) { ret ok[bool, str](true); }
-
-    # a domain-crossing bit reinterpret survives selection unchanged; the encoder
-    # materializes its GP<->XMM MOVD / MOVQ. `retag_float_moves` set the opcode
-    # before this pass from the function's differing operand vreg classes.
-    if (o == mir.MIR_BITCAST_CROSS) { ret ok[bool, str](true); }
 
     # a float negate survives selection unchanged; the encoder materializes its
     # sign-bit XOR byte sequence (XORPS with a width-selected sign mask).

--- a/src/lang/target/isa/x64/printer.mach
+++ b/src/lang/target/isa/x64/printer.mach
@@ -375,9 +375,13 @@ fun frame_slot_offset(f: *mir.MirFunction, v: u32) Option[i64] {
     ret none[i64]();
 }
 
-# wreg: write a register name — XMM (`fp`) or GP at the given byte width.
+# wreg: write a register name — XMM or GP at the given byte width. a register id is
+# self-describing (its class rides in the composite id), so an SSE-bank id prints
+# an XMM name regardless of the opcode hint; the `fp` opcode hint covers a float
+# instruction whose operand was already resolved to an XMM scratch. memory base /
+# index ids are always general-purpose, so they print GP names.
 fun wreg(out: *writer.Writer, id: i32, width: u8, fp: bool) Result[bool, str] {
-    if (fp) { ret ws(out, x64.fp_reg_name(id)); }
+    if (fp || isa.regid_class(id) == isa.REG_CLASS_ID_XMM) { ret ws(out, x64.fp_reg_name(id)); }
     ret ws(out, x64.reg_name(nil, id, width));
 }
 


### PR DESCRIPTION
Closes #1144

Gives float (XMM) and GP registers DISTINCT register id-spaces in the x64 backend, eliminating the shared-id aliasing (XMM0 == RAX) that was the root of the #1053 fixpoint break and the float-bug cluster (f32 read-back, FP conversions, `:~` bitcast-to-GP, float negation). Pure backend refactor: zero language semantics, invisible to any Mach program.

## Design — composite RegId, class-driven encoding

A physical register id is a **composite** `(class_id << 8) | index`: the class tag in the high byte, the within-bank index in the low byte (`isa.regid_make` / `regid_class` / `regid_index`). The general-purpose bank is class 0, so a GP id is numerically identical to its raw index (0..15) and **every GP-keyed table, mask, comparison, and the prologue is unchanged**; only the SSE bank (class 1, ids `0x0100..0x010F`) gains the high-byte tag. This carries the bank into every post-regalloc `isa.Inst` operand, so a register operand is self-describing.

The encoder dispatches the **move family on operand register CLASS**, not a float-specific opcode: `encode_mov` routes any MOV naming an SSE register to `encode_fp_mov`, which emits MOVSS/MOVSD for a same-bank float move (reg / frame slot / float-constant immediate, routed through the float scratch) and MOVD/MOVQ for a register-register cross-bank bit reinterpret. A float spilled on both sides is a bit-exact GP mem-mem copy.

`retag_float_moves` (and `move_is_float` / `bitcast_is_cross`) is **deleted**, along with the `MIR_FMOV` and `MIR_BITCAST_CROSS` opcodes and their dedicated encoders. A float register copy / load / store is a plain `MIR_MOV`; a same-bank or cross-bank bitcast is a plain `MIR_BITCAST` — all selecting to `x64.MOV`. This makes "wrong register bank" **unrepresentable**: a missed retag can no longer silently miscompile, because the encoder reads the bank off the id. Spill/reload routing is derived from the operand's vreg CLASS, never the opcode.

### Deviations from the brief's reference spec
- Kept `MirOperand.preg` / `MirVReg.assigned` as `u32` (the spec suggested `u16`). Composite ids fit in `u32`, `MIR_VREG_NIL` (`0xFFFFFFFF`) never collides with an XMM id (`0x010X`), and avoiding the type churn / sentinel rework is strictly lower-risk and behavior-neutral — honoring the brief's "only the representation of the assigned id changes".
- Followed the brief over the spec on `retag_float_moves`: **deleted** it in favor of class-driven encoding (the spec wanted to keep it).

## Backstops
- `assign()` asserts the assigned id's class matches the vreg's register class (never fires in self-host — a loud allocator-bug check, not a silent fallback).
- `encode_mem_operand` asserts a memory base / index is general-purpose (no SSE addressing form exists).
- The disassembler prints an XMM name whenever a register id carries the SSE class tag, so a folded float MOV disassembles correctly.

## Gate — all pass
- `make clean && make` (cmach→imach→smach→mach) exits 0
- **Byte-identical self-host fixpoint**: `mach == mach2` IDENTICAL (and `smach == mach`)
- `tools/test/differential.sh`: 11 inputs, all consistent (-O0/-O2, smach/mach)
- `mach test --cwd .`: 200/0
- `examples/06_comptime`: 132/0 · `examples/11_casts`: 128/0
- objdump-verified: float copies/neg/bitcast emit MOVSS/MOVSD/MOVQ/XORPS on XMM regs with correct REX; no SSE move ever names a GP register; mixed GP+XMM args route correctly
