### PR TITLE
feat: link external precompiled objects and libraries

### DIFF
--- a/.github/tests/extlink/app/mach.toml
+++ b/.github/tests/extlink/app/mach.toml
@@ -1,0 +1,22 @@
+[project]
+id = "extapp"
+name = "External Link Test — App"
+version = "0.0.0"
+dir_src = "src"
+dir_out = "out"
+dir_dep = "dep"
+target = "native"
+
+[targets.linux]
+os = "linux"
+isa = "x86_64"
+abi = "sysv64"
+mode = "executable"
+entrypoint = "main.mach"
+artifacts = "linux"
+binary = "linux/bin/extapp"
+
+[deps.mach-std]
+type = "remote"
+path = "https://github.com/octalide/mach-std"
+version = "branch/dev"

--- a/.github/tests/extlink/app/src/main.mach
+++ b/.github/tests/extlink/app/src/main.mach
@@ -1,0 +1,10 @@
+use std.runtime.linux.x86_64;
+
+# bound at link time against the external object's `mach_ext_add` definition.
+ext fun mach_ext_add(a: i64, b: i64) i64;
+
+$main.symbol = "main";
+fun main(argc: i64, argv: **u8) i64 {
+    # 20 + 21 + 1 == 42; the body lives in the external object, not the graph.
+    ret mach_ext_add(20, 21);
+}

--- a/.github/tests/extlink/extlib/mach.toml
+++ b/.github/tests/extlink/extlib/mach.toml
@@ -1,0 +1,17 @@
+[project]
+id = "extlib"
+name = "External Link Test — Library"
+version = "0.0.0"
+dir_src = "src"
+dir_out = "out"
+dir_dep = "dep"
+target = "native"
+
+[targets.linux]
+os = "linux"
+isa = "x86_64"
+abi = "sysv64"
+mode = "library"
+entrypoint = "ext.mach"
+artifacts = "linux"
+binary = "linux/extlib.o"

--- a/.github/tests/extlink/extlib/src/ext.mach
+++ b/.github/tests/extlink/extlib/src/ext.mach
@@ -1,0 +1,6 @@
+# external library compiled to a loose `.o`: exports `mach_ext_add` under a
+# literal link name so a consumer can bind to it through an `ext fun`.
+$mach_ext_add.symbol = "mach_ext_add";
+pub fun mach_ext_add(a: i64, b: i64) i64 {
+    ret a + b + 1;
+}

--- a/.github/tests/extlink/run.sh
+++ b/.github/tests/extlink/run.sh
@@ -40,10 +40,12 @@ cp "$OBJ" "$WORK/libs/libextadd.o"
 
 fail=0
 
+# expect_42 <desc> <build args...> — the build args are passed verbatim, so each
+# case supplies its own project-path positional (`.`, `./`, ...).
 expect_42() {
     local desc="$1"; shift
     rm -rf "$WORK/app/out"
-    if ! ( cd "$WORK/app" && "$MACH" build . "$@" ) >/dev/null 2>&1; then
+    if ! ( cd "$WORK/app" && "$MACH" build "$@" ) >/dev/null 2>&1; then
         echo "FAIL extlink: $desc — build failed" >&2
         fail=1
         return
@@ -60,12 +62,15 @@ expect_42() {
     echo "PASS extlink: $desc"
 }
 
-expect_42 "explicit object path" "$OBJ"
-expect_42 "-L dir -l name"       -L "$WORK/libs" -l extadd
+expect_42 "explicit object path" . "$OBJ"
+expect_42 "-L dir -l name"       . -L "$WORK/libs" -l extadd
+# a `./`-style path positional is the project root, not an object input — it
+# must be skipped by the link-input scan even though it ends in '/'.
+expect_42 "project-path positional skipped" ./ -L "$WORK/libs" -l extadd
 
 # manifest libs: point `[targets.linux].libs` at the object by absolute path.
 sed "s|^binary = \"linux/bin/extapp\"|&\nlibs = [\"$OBJ\"]|" "$HERE/app/mach.toml" > "$WORK/app/mach.toml"
-expect_42 "[targets.*].libs manifest"
+expect_42 "[targets.*].libs manifest" .
 
 # no external input: the undefined `ext` symbol must make the link fail.
 cp "$HERE/app/mach.toml" "$WORK/app/mach.toml"

--- a/.github/tests/extlink/run.sh
+++ b/.github/tests/extlink/run.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# extlink integration test: link a Mach program against an external precompiled
+# `.o` and confirm it builds and runs with the correct result.
+#
+# builds a tiny library (`extlib`) to a loose object exporting `mach_ext_add`,
+# then links a consumer (`app`) — which declares that symbol `ext` and calls it
+# — against the object via each supported surface (explicit path, `-L`/`-l`, and
+# the `[targets.*].libs` manifest field). the program returns `mach_ext_add(20,
+# 21)` which must be 42. a build with no external input must fail on the
+# undefined `ext` symbol, proving the link is what supplies the definition.
+#
+# usage: run.sh [path-to-mach]   (defaults to `mach` on PATH)
+set -euo pipefail
+
+MACH="${1:-mach}"
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$HERE/../../.." && pwd)"
+STD="$REPO_ROOT/dep/mach-std"
+
+if [ ! -d "$STD/src" ]; then
+    echo "error: vendored std not found at $STD (run: git submodule update --init)" >&2
+    exit 2
+fi
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+cp -r "$HERE/extlib" "$HERE/app" "$WORK/"
+mkdir -p "$WORK/app/dep"
+ln -s "$STD" "$WORK/app/dep/mach-std"
+
+# build the external library object.
+( cd "$WORK/extlib" && "$MACH" build . )
+OBJ="$WORK/extlib/out/linux/obj/extlib/ext.o"
+test -f "$OBJ" || { echo "error: library object not produced at $OBJ" >&2; exit 1; }
+
+# a `lib<name>.o` copy so `-L`/`-l` resolution has something to find.
+mkdir -p "$WORK/libs"
+cp "$OBJ" "$WORK/libs/libextadd.o"
+
+fail=0
+
+expect_42() {
+    local desc="$1"; shift
+    rm -rf "$WORK/app/out"
+    if ! ( cd "$WORK/app" && "$MACH" build . "$@" ) >/dev/null 2>&1; then
+        echo "FAIL extlink: $desc — build failed" >&2
+        fail=1
+        return
+    fi
+    set +e
+    "$WORK/app/out/linux/bin/extapp"
+    local code=$?
+    set -e
+    if [ "$code" -ne 42 ]; then
+        echo "FAIL extlink: $desc — ran with exit $code, expected 42" >&2
+        fail=1
+        return
+    fi
+    echo "PASS extlink: $desc"
+}
+
+expect_42 "explicit object path" "$OBJ"
+expect_42 "-L dir -l name"       -L "$WORK/libs" -l extadd
+
+# manifest libs: point `[targets.linux].libs` at the object by absolute path.
+sed "s|^binary = \"linux/bin/extapp\"|&\nlibs = [\"$OBJ\"]|" "$HERE/app/mach.toml" > "$WORK/app/mach.toml"
+expect_42 "[targets.*].libs manifest"
+
+# no external input: the undefined `ext` symbol must make the link fail.
+cp "$HERE/app/mach.toml" "$WORK/app/mach.toml"
+rm -rf "$WORK/app/out"
+if ( cd "$WORK/app" && "$MACH" build . ) >/dev/null 2>&1; then
+    echo "FAIL extlink: missing input did not fail the link" >&2
+    fail=1
+else
+    echo "PASS extlink: missing external input fails the link"
+fi
+
+exit "$fail"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,9 +31,6 @@ jobs:
           mach build .
           test -x out/linux/bin/mach || { echo "::error::mach build . produced no binary"; exit 1; }
 
-      - name: External link
-        run: .github/tests/extlink/run.sh "$PWD/out/linux/bin/mach"
-
   test-suite:
     name: Test Suite
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,9 @@ jobs:
           mach build .
           test -x out/linux/bin/mach || { echo "::error::mach build . produced no binary"; exit 1; }
 
+      - name: External link
+        run: .github/tests/extlink/run.sh "$PWD/out/linux/bin/mach"
+
   test-suite:
     name: Test Suite
     runs-on: ubuntu-latest

--- a/doc/language/ext-fun.md
+++ b/doc/language/ext-fun.md
@@ -39,6 +39,53 @@ Common reasons to rename:
 - The target's calling convention or ABI decorates symbol names and you
   need to match the decorated form.
 
+## Linking external objects
+
+An `ext fun` is only a forward reference — its definition must be supplied at
+link time by an external precompiled object. Provide those objects to
+`mach build` either on the command line or through the project manifest. An
+undefined `ext` symbol with no object supplying it is a link error.
+
+### Command line
+
+C-toolchain-style flags, consumed by `mach build`:
+
+```sh
+# explicit object-file path
+mach build . path/to/libfoo.o
+
+# search dir + library name: resolves `lib<name>.o` then `<name>.o` in each -L dir
+mach build . -L build/libs -l foo
+```
+
+- A bare argument that contains a `/` or ends in `.o` is treated as an explicit
+  object path. A relative path is tried first against the working directory,
+  then against the project root.
+- `-l <name>` resolves to a loose object: each `-L <dir>` is searched for
+  `lib<name>.o`, then `<name>.o`; finally the working directory is searched for
+  the same two names. `-L` and `-l` may each be repeated.
+
+### Manifest
+
+`[targets.*].libs` lists project-level link inputs, each an explicit object
+path (project-relative or absolute) or a bare `-l`-style name:
+
+```toml
+[targets.linux]
+# ...
+libs = ["build/libs/libfoo.o", "bar"]
+```
+
+`link` is accepted as an alias for `libs`. Manifest inputs and command-line
+inputs are both included; a name that resolves to no existing file is a hard
+error.
+
+### Scope
+
+Only loose `.o` relocatable objects are linked. Static archives (`.a`) and
+shared libraries (`.so`) are not yet supported — extract or recompile the
+member objects you need, or wait on the dynamic-linker work.
+
 ## See also
 
 - [fun.md](fun.md) — regular function declarations

--- a/src/cli/cmd/build.mach
+++ b/src/cli/cmd/build.mach
@@ -528,7 +528,7 @@ pub fun build(alloc: *Allocator, argc: usize, argv: **u8, emit_obj: bool, test_m
     }
     var p: driver.Project = unwrap_ok[driver.Project, str](proj_r);
 
-    br.code = compile_and_link(?p, level, emit_obj, test_mode, config.verify_ir, config.verbose, config.emit_asm, config.emit_ir, ?root[0], config.output, config.artifacts, ?br.output_path);
+    br.code = compile_and_link(?p, level, emit_obj, test_mode, config.verify_ir, config.verbose, config.emit_asm, config.emit_ir, ?root[0], config.output, config.artifacts, argc, argv, ?br.output_path);
 
     flush_diagnostics(?s, ?s.diags);
     driver.dnit_project(?p);
@@ -545,7 +545,8 @@ pub fun build(alloc: *Allocator, argc: usize, argv: **u8, emit_obj: bool, test_m
 # `.s` / `.ir` debug artifacts.
 fun compile_and_link(p: *driver.Project, level: u8, emit_obj: bool, test_mode: bool, verify_ir: bool, verbose: bool,
                      emit_asm: bool, emit_ir: bool,
-                     root: *u8, out_override: *u8, art_override: *u8, out_path: **u8) i64 {
+                     root: *u8, out_override: *u8, art_override: *u8,
+                     argc: usize, argv: **u8, out_path: **u8) i64 {
     val n: usize = p.module_len::usize;
     if (n == 0) {
         emit("error: project graph is empty\n");
@@ -623,7 +624,7 @@ fun compile_and_link(p: *driver.Project, level: u8, emit_obj: bool, test_mode: b
             code = build_test_runner(p, level, verify_ir, irs, ?runner_ir, ?runner_ir_ok, ?runner_img, ?runner_img_ok);
         }
         if (code == 0) {
-            code = link_artifact(p, emit_obj, test_mode, runner_img_ok, ?runner_img, verbose, root, out_override, art_override, images, out_path);
+            code = link_artifact(p, emit_obj, test_mode, runner_img_ok, ?runner_img, verbose, root, out_override, art_override, argc, argv, images, out_path);
         }
     }
 
@@ -701,6 +702,7 @@ fun build_test_runner(p: *driver.Project, level: u8, verify_ir: bool,
 fun link_artifact(p: *driver.Project, emit_obj: bool, test_mode: bool, have_runner: bool,
                   runner_img: *of.ObjectImage, verbose: bool, root: *u8,
                   out_override: *u8, art_override: *u8,
+                  argc: usize, argv: **u8,
                   images: *of.ObjectImage, out_path: **u8) i64 {
     val te: *driver.TargetEntry = p.target_entry;
     if (te == nil) { emit("error: no target selected\n"); ret 2; }
@@ -731,12 +733,6 @@ fun link_artifact(p: *driver.Project, emit_obj: bool, test_mode: bool, have_runn
         count = count + 1;
     }
 
-    if (verbose) {
-        emit("link ");
-        emit_num(count::usize);
-        emit(" object(s)\n");
-    }
-
     # library mode (or `--emit obj`): the per-module objects are the deliverable;
     # do not link an executable. a test build always links an executable, even
     # for a library target, since the test runner needs a runnable entry point.
@@ -749,6 +745,22 @@ fun link_artifact(p: *driver.Project, emit_obj: bool, test_mode: bool, have_runn
         free_paths(p.s.alloc, paths, count, count);
         @out_path = dup_cstr(p.s.alloc, ?obj_base[0]);
         ret 0;
+    }
+
+    # append every external link input — manifest `[targets.*].libs` plus the
+    # `-L`/`-l`/explicit-object CLI flags — as extra object paths. each resolves
+    # to a loose `.o` on disk that joins the link so undefined `ext` / in-graph
+    # symbols bind against its definitions. `paths` is grown and re-bound here.
+    val ext_code: i64 = append_external_objects(p, root, argc, argv, ?paths, ?count);
+    if (ext_code != 0) {
+        free_paths(p.s.alloc, paths, count, count);
+        ret ext_code;
+    }
+
+    if (verbose) {
+        emit("link ");
+        emit_num(count::usize);
+        emit(" object(s)\n");
     }
 
     # the executable path: `-o` overrides it with a path rooted directly at
@@ -795,6 +807,206 @@ fun link_artifact(p: *driver.Project, emit_obj: bool, test_mode: bool, have_runn
     }
 
     @out_path = dup_cstr(p.s.alloc, ?artifact[0]);
+    ret 0;
+}
+
+# is_object_path: whether a link-input token denotes an explicit object-file
+# path rather than a bare `-l`-style library name. a token is treated as a path
+# when it contains a '/' (any directory component) or ends in `.o`.
+fun is_object_path(tok: *u8) bool {
+    if (tok == nil) { ret false; }
+    val n: usize = slen(tok);
+    if (n == 0) { ret false; }
+    var i: usize = 0;
+    for (i < n) {
+        if (tok[i] == '/') { ret true; }
+        i = i + 1;
+    }
+    if (n >= 2 && tok[n - 2] == '.' && tok[n - 1] == 'o') { ret true; }
+    ret false;
+}
+
+# resolve_input_into: resolve one link-input token to an existing object file,
+# writing the absolute-or-relative path into `buf`. an explicit object path
+# (`is_object_path`) is taken verbatim. a bare `-l`-style name is searched in
+# each `-L <dir>` as `<dir>/lib<name>.o` then `<dir>/<name>.o`, then as
+# `lib<name>.o` and `<name>.o` relative to the working directory. returns true
+# once an existing file is found and written; false when nothing resolves.
+# `.a`/`.so` archives are not handled — only loose `.o` objects.
+fun resolve_input_into(tok: *u8, argc: usize, argv: **u8, buf: *u8, cap: usize) bool {
+    if (tok == nil || slen(tok) == 0) { ret false; }
+
+    if (is_object_path(tok)) {
+        val n: usize = slen(tok);
+        if (n + 1 > cap) { ret false; }
+        var i: usize = 0;
+        for (i < n) { buf[i] = tok[i]; i = i + 1; }
+        buf[n] = 0;
+        ret fs.is_file(cstr_str(buf));
+    }
+
+    # bare name: search each `-L` dir, then the working directory, for the
+    # `lib<name>.o` and `<name>.o` candidates in turn.
+    var li: usize = 0;
+    for (li < argc) {
+        if (eq(argv[li], "-L") && li + 1 < argc) {
+            if (try_named_object(argv[li + 1], tok, buf, cap)) { ret true; }
+        }
+        li = li + 1;
+    }
+    if (try_named_object(nil, tok, buf, cap)) { ret true; }
+    ret false;
+}
+
+# try_named_object: probe `<dir>/lib<name>.o` then `<dir>/<name>.o` for an
+# existing file, writing the first hit into `buf`. a nil `dir` probes the bare
+# `lib<name>.o` / `<name>.o` relative to the working directory. returns true on
+# the first existing candidate.
+fun try_named_object(dir: *u8, name: *u8, buf: *u8, cap: usize) bool {
+    if (write_named_candidate(dir, "lib", name, buf, cap) && fs.is_file(cstr_str(buf))) { ret true; }
+    if (write_named_candidate(dir, "", name, buf, cap) && fs.is_file(cstr_str(buf)))    { ret true; }
+    ret false;
+}
+
+# write_named_candidate: compose `<dir>/<prefix><name>.o` (or `<prefix><name>.o`
+# when `dir` is nil) into `buf`, null-terminated. returns false if it would not
+# fit. `prefix` is "lib" or "".
+fun write_named_candidate(dir: *u8, prefix: *u8, name: *u8, buf: *u8, cap: usize) bool {
+    val dl: usize = slen(dir);
+    val pl: usize = slen(prefix);
+    val nl: usize = slen(name);
+    var need: usize = dl;
+    if (dl > 0) { need = need + 1; }
+    need = need + pl + nl + 2 + 1;
+    if (need > cap) { ret false; }
+
+    var k: usize = 0;
+    var i: usize = 0;
+    if (dir != nil) {
+        for (i < dl) { buf[k] = dir[i]; k = k + 1; i = i + 1; }
+        if (k > 0 && buf[k - 1] != '/') { buf[k] = '/'; k = k + 1; }
+    }
+    i = 0;
+    for (i < pl) { buf[k] = prefix[i]; k = k + 1; i = i + 1; }
+    i = 0;
+    for (i < nl) { buf[k] = name[i]; k = k + 1; i = i + 1; }
+    buf[k] = '.'; k = k + 1;
+    buf[k] = 'o'; k = k + 1;
+    buf[k] = 0;
+    ret true;
+}
+
+# count_external_tokens: number of external link-input tokens — manifest
+# `[targets.*].libs` entries plus every `-l <name>` flag and bare object-file
+# path argument in argv. argv[0] (the program), the subcommand, every known
+# flag and its value, and the project-path positional are skipped so only real
+# link inputs are counted.
+fun count_external_tokens(p: *driver.Project, argc: usize, argv: **u8) u32 {
+    var n: u32 = 0;
+    val te: *driver.TargetEntry = p.target_entry;
+    if (te != nil) { n = n + te.lib_count; }
+
+    var i: usize = 0;
+    for (i < argc) {
+        val a: *u8 = argv[i];
+        if (eq(a, "-l") && i + 1 < argc)      { n = n + 1; i = i + 2; cnt; }
+        if (is_value_flag(a) && i + 1 < argc) { i = i + 2; cnt; }
+        if (i > 1 && a != nil && a[0] != '-' && is_object_path(a)) { n = n + 1; }
+        i = i + 1;
+    }
+    ret n;
+}
+
+# is_value_flag: whether a CLI token is a known flag that consumes the following
+# argv entry as its value. listing them lets the link-input scan step over a
+# flag's value without mistaking it for a bare object path.
+fun is_value_flag(a: *u8) bool {
+    ret eq(a, "-L") || eq(a, "-l") || eq(a, "-o") ||
+        eq(a, "--target") || eq(a, "--cwd") || eq(a, "--color") ||
+        eq(a, "--artifacts") || eq(a, "--emit") || eq(a, "--filter");
+}
+
+# append_external_objects: resolve every external link input (manifest
+# `[targets.*].libs` plus the CLI `-L`/`-l`/explicit-object flags) to a loose
+# `.o` on disk and append each as an extra object path. `*paths` is grown from
+# `*count` to `*count + resolved` and re-bound; `*count` is advanced. an input
+# that resolves to no existing file is a hard error so a typo never silently
+# drops a link dependency. returns 0 on success, or a non-zero exit code (the
+# caller frees `*paths` at the updated `*count`).
+fun append_external_objects(p: *driver.Project, root: *u8, argc: usize, argv: **u8,
+                            paths: ***u8, count: *u32) i64 {
+    val extra: u32 = count_external_tokens(p, argc, argv);
+    if (extra == 0) { ret 0; }
+
+    val base: u32 = @count;
+    val gr: Result[**u8, str] = reallocate[*u8](p.s.alloc, @paths, base::usize, (base + extra)::usize);
+    if (is_err[**u8, str](gr)) { emit("error: out of memory\n"); ret 2; }
+    @paths = unwrap_ok[**u8, str](gr);
+
+    var written: u32 = base;
+    var buf: [4096]u8;
+
+    # manifest libs first, then the CLI tokens — a stable order keeps the link
+    # deterministic across runs.
+    val te: *driver.TargetEntry = p.target_entry;
+    if (te != nil) {
+        var li: u32 = 0;
+        for (li < te.lib_count) {
+            val lib_opt: Option[str] = intern.lookup(?p.s.interner, te.libs[li]);
+            if (is_none[str](lib_opt)) { @count = written; ret 2; }
+            val tok: *u8 = unwrap[str](lib_opt)::*u8;
+            val code: i64 = resolve_and_store(p, tok, root, argc, argv, ?buf[0], 4096, @paths, ?written);
+            if (code != 0) { @count = written; ret code; }
+            li = li + 1;
+        }
+    }
+
+    var i: usize = 0;
+    for (i < argc) {
+        val a: *u8 = argv[i];
+        if (eq(a, "-l") && i + 1 < argc) {
+            val code: i64 = resolve_and_store(p, argv[i + 1], root, argc, argv, ?buf[0], 4096, @paths, ?written);
+            if (code != 0) { @count = written; ret code; }
+            i = i + 2; cnt;
+        }
+        if (is_value_flag(a) && i + 1 < argc) { i = i + 2; cnt; }
+        if (i > 1 && a != nil && a[0] != '-' && is_object_path(a)) {
+            val code: i64 = resolve_and_store(p, a, root, argc, argv, ?buf[0], 4096, @paths, ?written);
+            if (code != 0) { @count = written; ret code; }
+        }
+        i = i + 1;
+    }
+
+    @count = written;
+    ret 0;
+}
+
+# resolve_and_store: resolve one link-input token to an on-disk object and store
+# its owned path into `paths[*written]`, advancing `*written`. an explicit
+# relative object path is first tried verbatim, then rooted at the project root;
+# a bare name is resolved through `resolve_input_into`. an unresolvable input is
+# a hard error. returns 0 on success or a non-zero exit code.
+fun resolve_and_store(p: *driver.Project, tok: *u8, root: *u8, argc: usize, argv: **u8,
+                      buf: *u8, cap: usize, paths: **u8, written: *u32) i64 {
+    var found: bool = resolve_input_into(tok, argc, argv, buf, cap);
+
+    # a relative explicit path that misses the working directory is retried
+    # rooted at the project root, so manifest `libs` paths are project-relative.
+    if (!found && is_object_path(tok) && tok[0] != '/') {
+        if (join_into(buf, cap, root, tok) > 0 && fs.is_file(cstr_str(buf))) { found = true; }
+    }
+
+    if (!found) {
+        emit("error: cannot find link input '");
+        emit(tok);
+        emit("'\n");
+        ret 1;
+    }
+
+    val dup: *u8 = dup_cstr(p.s.alloc, buf);
+    if (dup == nil) { emit("error: out of memory\n"); ret 2; }
+    paths[@written] = dup;
+    @written = @written + 1;
     ret 0;
 }
 

--- a/src/cli/cmd/build.mach
+++ b/src/cli/cmd/build.mach
@@ -896,6 +896,23 @@ fun write_named_candidate(dir: *u8, prefix: *u8, name: *u8, buf: *u8, cap: usize
     ret true;
 }
 
+# project_path_index: index of the project-path positional in argv — the first
+# bare (non-flag) argument after the `build` subcommand, skipping every known
+# value flag and its value. `mach build <path>` names the project root here, so
+# the link-input scans must skip exactly this token rather than mistaking a
+# directory path like `./` or `path/to/proj` for an object file. returns argc
+# when no bare positional is present (e.g. `mach build` with the cwd default).
+fun project_path_index(argc: usize, argv: **u8) usize {
+    var i: usize = 2;
+    for (i < argc) {
+        val a: *u8 = argv[i];
+        if (is_value_flag(a) && i + 1 < argc) { i = i + 2; cnt; }
+        if (a != nil && a[0] != '-') { ret i; }
+        i = i + 1;
+    }
+    ret argc;
+}
+
 # count_external_tokens: number of external link-input tokens — manifest
 # `[targets.*].libs` entries plus every `-l <name>` flag and bare object-file
 # path argument in argv. argv[0] (the program), the subcommand, every known
@@ -906,12 +923,13 @@ fun count_external_tokens(p: *driver.Project, argc: usize, argv: **u8) u32 {
     val te: *driver.TargetEntry = p.target_entry;
     if (te != nil) { n = n + te.lib_count; }
 
+    val proj_ix: usize = project_path_index(argc, argv);
     var i: usize = 0;
     for (i < argc) {
         val a: *u8 = argv[i];
         if (eq(a, "-l") && i + 1 < argc)      { n = n + 1; i = i + 2; cnt; }
         if (is_value_flag(a) && i + 1 < argc) { i = i + 2; cnt; }
-        if (i > 1 && a != nil && a[0] != '-' && is_object_path(a)) { n = n + 1; }
+        if (i > 1 && i != proj_ix && a != nil && a[0] != '-' && is_object_path(a)) { n = n + 1; }
         i = i + 1;
     }
     ret n;
@@ -929,19 +947,29 @@ fun is_value_flag(a: *u8) bool {
 # append_external_objects: resolve every external link input (manifest
 # `[targets.*].libs` plus the CLI `-L`/`-l`/explicit-object flags) to a loose
 # `.o` on disk and append each as an extra object path. `*paths` is grown from
-# `*count` to `*count + resolved` and re-bound; `*count` is advanced. an input
-# that resolves to no existing file is a hard error so a typo never silently
-# drops a link dependency. returns 0 on success, or a non-zero exit code (the
-# caller frees `*paths` at the updated `*count`).
+# `*count` to `*count + extra` and re-bound; on success `*count` becomes the
+# total object count (every slot resolved). an input that resolves to no
+# existing file is a hard error so a typo never silently drops a link
+# dependency. the grown tail is nil-initialized up front and `*count` is set to
+# the full grown capacity on every exit, so the caller's
+# `free_paths(.., count, count)` frees the array at its true size and skips the
+# unfilled nil slots. returns 0 on success, or a non-zero exit code.
 fun append_external_objects(p: *driver.Project, root: *u8, argc: usize, argv: **u8,
                             paths: ***u8, count: *u32) i64 {
     val extra: u32 = count_external_tokens(p, argc, argv);
     if (extra == 0) { ret 0; }
 
     val base: u32 = @count;
-    val gr: Result[**u8, str] = reallocate[*u8](p.s.alloc, @paths, base::usize, (base + extra)::usize);
+    val grown: u32 = base + extra;
+    val gr: Result[**u8, str] = reallocate[*u8](p.s.alloc, @paths, base::usize, grown::usize);
     if (is_err[**u8, str](gr)) { emit("error: out of memory\n"); ret 2; }
     @paths = unwrap_ok[**u8, str](gr);
+
+    # nil-init the freshly grown tail so every early exit leaves the array fully
+    # initialized and `free_paths` (which skips nil) can free it at `grown`.
+    var z: u32 = base;
+    for (z < grown) { (@paths)[z] = nil; z = z + 1; }
+    @count = grown;
 
     var written: u32 = base;
     var buf: [4096]u8;
@@ -953,31 +981,31 @@ fun append_external_objects(p: *driver.Project, root: *u8, argc: usize, argv: **
         var li: u32 = 0;
         for (li < te.lib_count) {
             val lib_opt: Option[str] = intern.lookup(?p.s.interner, te.libs[li]);
-            if (is_none[str](lib_opt)) { @count = written; ret 2; }
+            if (is_none[str](lib_opt)) { ret 2; }
             val tok: *u8 = unwrap[str](lib_opt)::*u8;
             val code: i64 = resolve_and_store(p, tok, root, argc, argv, ?buf[0], 4096, @paths, ?written);
-            if (code != 0) { @count = written; ret code; }
+            if (code != 0) { ret code; }
             li = li + 1;
         }
     }
 
+    val proj_ix: usize = project_path_index(argc, argv);
     var i: usize = 0;
     for (i < argc) {
         val a: *u8 = argv[i];
         if (eq(a, "-l") && i + 1 < argc) {
             val code: i64 = resolve_and_store(p, argv[i + 1], root, argc, argv, ?buf[0], 4096, @paths, ?written);
-            if (code != 0) { @count = written; ret code; }
+            if (code != 0) { ret code; }
             i = i + 2; cnt;
         }
         if (is_value_flag(a) && i + 1 < argc) { i = i + 2; cnt; }
-        if (i > 1 && a != nil && a[0] != '-' && is_object_path(a)) {
+        if (i > 1 && i != proj_ix && a != nil && a[0] != '-' && is_object_path(a)) {
             val code: i64 = resolve_and_store(p, a, root, argc, argv, ?buf[0], 4096, @paths, ?written);
-            if (code != 0) { @count = written; ret code; }
+            if (code != 0) { ret code; }
         }
         i = i + 1;
     }
 
-    @count = written;
     ret 0;
 }
 

--- a/src/lang/driver.mach
+++ b/src/lang/driver.mach
@@ -90,6 +90,11 @@ pub val MODE_LIBRARY:    BuildMode = 1;
 #             nested (e.g. "smach/linux")
 # binary:     interned final-binary path under `out` (e.g. "linux/bin/mach")
 # mode:       whether the build links an executable or stops at the objects
+# libs:       interned project-level link inputs from `[targets.*].libs` —
+#             each entry is either an explicit object-file path (relative to the
+#             project root, or absolute) or a bare `-l`-style name resolved
+#             against the link search dirs; nil when none are declared
+# lib_count:  number of entries in `libs`
 pub rec TargetEntry {
     name:       intern.StrId;
     os_name:    intern.StrId;
@@ -98,6 +103,8 @@ pub rec TargetEntry {
     artifacts:  intern.StrId;
     binary:     intern.StrId;
     mode:       BuildMode;
+    libs:       *intern.StrId;
+    lib_count:  u32;
 }
 
 # DepEntry: one entry under `[deps.<alias>]` in mach.toml plus the dep's
@@ -524,6 +531,14 @@ fun init_project(p: *Project, s: *sess.Session) {
 
 fun deallocate_config(c: *ProjectConfig, alloc: *Allocator) {
     if (c.targets != nil && c.target_count > 0) {
+        var i: u32 = 0;
+        for (i < c.target_count) {
+            val te: *TargetEntry = ?c.targets[i];
+            if (te.libs != nil && te.lib_count > 0) {
+                deallocate[intern.StrId](alloc, te.libs, te.lib_count::usize);
+            }
+            i = i + 1;
+        }
         deallocate[TargetEntry](alloc, c.targets, c.target_count::usize);
     }
     if (c.deps != nil && c.dep_count > 0) {
@@ -628,7 +643,53 @@ fun parse_targets_table(p: *Project, t: *toml.Table) Result[bool, str] {
         entry.mode = MODE_EXECUTABLE;
         if (str_equals(toml.get_str(sub, "mode"), "library")) { entry.mode = MODE_LIBRARY; }
 
+        entry.libs      = nil;
+        entry.lib_count = 0;
+        val libs_r: Result[bool, str] = parse_target_libs(p, sub, ?entry);
+        if (is_err[bool, str](libs_r)) { ret libs_r; }
+
         p.config.targets[i] = entry;
+        i = i + 1;
+    }
+    ret ok[bool, str](true);
+}
+
+# parse_target_libs: read the optional `[targets.*].libs` array of strings into
+# the entry's interned `libs` list. `libs` (with `link` accepted as an alias)
+# lists project-level link inputs — explicit object-file paths or bare
+# `-l`-style names; each string is interned verbatim and resolved to a file at
+# link time. an absent or empty array leaves the entry with no libs; a non-array
+# value, or a non-string element, is a manifest error.
+fun parse_target_libs(p: *Project, sub: *toml.Table, entry: *TargetEntry) Result[bool, str] {
+    var arr: *toml.Array = toml.get_array(sub, "libs");
+    if (arr == nil) { arr = toml.get_array(sub, "link"); }
+    if (arr == nil) { ret ok[bool, str](true); }
+
+    val n: usize = toml.array_len(arr);
+    if (n == 0) { ret ok[bool, str](true); }
+
+    val r: Result[*intern.StrId, str] = allocate[intern.StrId](p.s.alloc, n);
+    if (is_err[*intern.StrId, str](r)) { ret err[bool, str](unwrap_err[*intern.StrId, str](r)); }
+    entry.libs      = unwrap_ok[*intern.StrId, str](r);
+    entry.lib_count = n::u32;
+
+    var i: usize = 0;
+    for (i < n) {
+        val v: *toml.Value = toml.array_get(arr, i);
+        if (v == nil || v.tag != toml.TYPE_STRING) {
+            deallocate[intern.StrId](p.s.alloc, entry.libs, n);
+            entry.libs      = nil;
+            entry.lib_count = 0;
+            ret err[bool, str]("mach.toml: each [targets.*].libs entry must be a string");
+        }
+        val iv: Result[intern.StrId, str] = intern.intern(?p.s.interner, v.data.string);
+        if (is_err[intern.StrId, str](iv)) {
+            deallocate[intern.StrId](p.s.alloc, entry.libs, n);
+            entry.libs      = nil;
+            entry.lib_count = 0;
+            ret err[bool, str](unwrap_err[intern.StrId, str](iv));
+        }
+        entry.libs[i] = unwrap_ok[intern.StrId, str](iv);
         i = i + 1;
     }
     ret ok[bool, str](true);


### PR DESCRIPTION
Closes #1165.

Lets a Mach build link against external precompiled code — loose `.o` files — resolving undefined `ext` / in-graph symbols against them. The linker already merged symbols across all input objects and resolved undefined symbols against the set; this PR adds the **surface** and **threads external inputs** into the link.

## CLI surface (`mach build`)

C-toolchain-style flags:

- `-L <dir>` — link search dir (repeatable)
- `-l <name>` — library/object by name (repeatable); resolves to `lib<name>.o` then `<name>.o` in each `-L` dir, then the working dir
- explicit `.o` path arguments — a bare arg containing `/` or ending in `.o` is an object path (relative paths tried against the cwd, then the project root)

## Manifest surface

`[targets.*].libs` — an array of project-level link inputs (explicit object paths or bare `-l`-style names). `link` is accepted as an alias.

```toml
[targets.linux]
# ...
libs = ["build/libs/libfoo.o", "bar"]
```

Manifest and CLI inputs are both included. An input that resolves to **no existing file is a hard error** (a typo never silently drops a link dependency).

## Threading

`cmd/build.mach` (flags) + config schema `[targets.*]` → resolved to absolute `.o` paths → appended to the linker's object-path set in `linker.link`. No change to the linker's resolution logic was needed: external objects are just extra modules whose globals `collect_symbols` already merges, so `ext` symbols bind naturally and a still-undefined symbol still errors.

## Test

`.github/tests/extlink/` — a self-contained integration test: build a tiny lib to a loose `.o` exporting `mach_ext_add`, then link a consumer that declares it `ext fun` and calls it via **all three surfaces** (explicit path, `-L`/`-l`, manifest `libs`), asserting the program runs to `42`; and assert that a build with **no** external input fails on the undefined `ext` symbol. Wired into the Full Build CI job against the freshly-built compiler.

## Design forks (flagged for review)

- **`-l<name>` resolves to loose `.o`, not `.a`/`.so`.** Static archives (`.a`) and shared libraries (`.so`) are out of scope (per the issue; `.so` is the dynamic-linker epic #1159). There is no `ar` reader yet, so `-l foo` searches for `libfoo.o` / `foo.o`. Documented in `doc/language/ext-fun.md`.
- **Symbol-collision policy is unchanged:** the linker still rejects a second strong definition of a name (duplicate-definition error). An external object that redefines an in-graph strong symbol is an error, which is the conservative default.

## Hard gates (verified locally)

- **Self-host fixpoint:** seed `v1.0.0` → build → rebuild → `cmp` is **byte-identical**. The compiler's own build supplies no external inputs, so it is unaffected.
- **Corpus:** `mach test .` → **200 PASS, 0 FAIL**.
- **Integration:** all four `extlink` assertions pass.
