### PR TITLE
fix(cli): scaffold a complete, buildable project from 'mach init'

### DIFF
--- a/src/cli/cmd/help.mach
+++ b/src/cli/cmd/help.mach
@@ -127,8 +127,7 @@ fun help_init() {
     out("options:\n");
     out("  --name <name>  project id (default: directory name)\n");
     out("  --force        scaffold into a non-empty directory\n");
-    out("  --bin          binary project layout (default)\n");
-    out("  --lib          library project layout\n");
+    out("  --lib          library project layout (default: binary)\n");
 }
 
 fun help_doc() {

--- a/src/cli/cmd/init.mach
+++ b/src/cli/cmd/init.mach
@@ -1,11 +1,12 @@
 # mach.cli.cmd.init: `mach init` — scaffolds a new project.
 #
-# writes a minimal mach.toml with a `[project]` block and a
+# writes a minimal mach.toml with a `[project]` block and a complete
 # `[targets.host]` entry matching the running compiler, a starter
 # `src/main.mach` (or `src/lib.mach` with `--lib`), and an empty `dep/`
-# directory. refuses to scaffold into a non-empty directory unless
-# `--force` is given. the project id defaults to the directory name and is
-# overridable with `--name <name>`.
+# directory. the scaffolded project is self-contained — it depends on no
+# library and builds and runs out of the box. refuses to scaffold into a
+# non-empty directory unless `--force` is given. the project id defaults to
+# the directory name and is overridable with `--name <name>`.
 
 use std.types.bool.bool;
 use std.types.bool.true;
@@ -230,9 +231,10 @@ pub fun run(argc: usize, argv: **u8) i64 {
 }
 
 # write_manifest: write the mach.toml manifest at `path` with project id
-# `id`, embedding a `[targets.host]` entry matching the running compiler.
-# a library project omits the `entrypoint` key. returns false on a write
-# error.
+# `id`, embedding a complete `[targets.host]` entry matching the running
+# compiler. the entry carries every key the driver requires (os, isa,
+# entrypoint, binary); a library project additionally sets `mode = "library"`
+# and roots its entrypoint at `lib.mach`. returns false on a write error.
 fun write_manifest(path: *u8, id: *u8, is_lib: bool) bool {
     var buf: [1024]u8;
     var off: usize = 0;
@@ -250,8 +252,18 @@ fun write_manifest(path: *u8, id: *u8, is_lib: bool) bool {
     off = put(?buf[0], 1024, off, "isa = \"");
     off = put(?buf[0], 1024, off, host_isa());
     off = put(?buf[0], 1024, off, "\"\n");
-    if (!is_lib) {
+    if (is_lib) {
+        off = put(?buf[0], 1024, off, "mode = \"library\"\n");
+        off = put(?buf[0], 1024, off, "entrypoint = \"lib.mach\"\n");
+        off = put(?buf[0], 1024, off, "binary = \"lib/");
+        off = put(?buf[0], 1024, off, id);
+        off = put(?buf[0], 1024, off, ".o\"\n");
+    }
+    or {
         off = put(?buf[0], 1024, off, "entrypoint = \"main.mach\"\n");
+        off = put(?buf[0], 1024, off, "binary = \"bin/");
+        off = put(?buf[0], 1024, off, id);
+        off = put(?buf[0], 1024, off, "\"\n");
     }
 
     val r: Result[bool, str] = fs.write_file(path, ?buf[0], off, 420);
@@ -265,12 +277,35 @@ fun write_source(path: *u8, content: *u8) bool {
     ret !is_err[bool, str](r);
 }
 
-# main_template: the starter binary entry module written by a default `mach init`.
+# main_template: the starter binary entry module written by a default
+# `mach init`. the scaffolded project is self-contained — it depends on no
+# library, so it carries its own `_start`, the ELF/Mach-O entry symbol the
+# linker requires. `_start` decodes argc/argv from the initial stack, calls
+# `main`, and exits with its return code. the `_start` body matches the host
+# the compiler runs on, since that is the project's default build target.
 fun main_template() *u8 {
-    ret "fun main(argc: usize, argv: **u8) i64 {\n    ret 0;\n}\n";
+    $if ($mach.target.os == $mach.os.darwin && $mach.target.arch == $mach.arch.x86_64) {
+        ret darwin_x86_64_template();
+    }
+    $or {
+        ret linux_x86_64_template();
+    }
+}
+
+# linux_x86_64_template: the self-contained binary entry module for linux
+# x86_64 — the compiler's own default host.
+fun linux_x86_64_template() *u8 {
+    ret "# program entry point. the linker calls `_start`; `_start` decodes\n# argc/argv from the initial stack, calls `main`, and exits with its\n# return code. this project depends on no library, so it carries its own\n# entry point.\n$_start.symbol = \"_start\";\npub fun _start() {\n    asm x86_64 {\n        mov rax, rsp\n        mov rdi, [rax]\n        lea rsi, [rax+8]\n        and rsp, -16\n        sub rsp, 8\n        call main\n        mov rdi, rax\n        mov rax, 60\n        syscall\n    }\n}\n\n# main: program entry. returns the process exit code.\n$main.symbol = \"main\";\nfun main(argc: i64, argv: **u8) i64 {\n    ret 0;\n}\n";
+}
+
+# darwin_x86_64_template: the self-contained binary entry module for darwin
+# x86_64. identical to the linux form but for the BSD `SYS_exit` number.
+fun darwin_x86_64_template() *u8 {
+    ret "# program entry point. the linker calls `_start`; `_start` decodes\n# argc/argv from the initial stack, calls `main`, and exits with its\n# return code. this project depends on no library, so it carries its own\n# entry point.\n$_start.symbol = \"_start\";\npub fun _start() {\n    asm x86_64 {\n        mov rax, rsp\n        mov rdi, [rax]\n        lea rsi, [rax+8]\n        and rsp, -16\n        sub rsp, 8\n        call main\n        mov rdi, rax\n        mov rax, 0x2000001\n        syscall\n    }\n}\n\n# main: program entry. returns the process exit code.\n$main.symbol = \"main\";\nfun main(argc: i64, argv: **u8) i64 {\n    ret 0;\n}\n";
 }
 
 # lib_template: the starter library root module written by `mach init --lib`.
+# library builds stop at per-module objects, so the root needs no entry point.
 fun lib_template() *u8 {
     ret "# library root module.\n";
 }


### PR DESCRIPTION
Closes #1182.

## Problem
A freshly `mach init`'d project did not build:
- the scaffolded `mach.toml` target entry omitted **`binary`** (and, for `--lib`, **`entrypoint`**), both required by the driver (`intern_required` in `src/lang/driver.mach`).
- even with those keys, the binary starter `main.mach` used `usize` (a `std` type) with no `std` dependency, and a static-linked executable needs the `_start` symbol the linker requires — neither resolvable in a dependency-free scaffold.
- `mach help init` advertised a `--bin` flag `init.mach` never reads.

## Fix
- `write_manifest` now emits a complete `[targets.host]` entry: `binary = "bin/<id>"` for executables; `mode = "library"` + `entrypoint = "lib.mach"` + `binary = "lib/<id>.o"` for libraries.
- The binary starter `main.mach` is now **self-contained**: it carries its own host-matched `_start` (linux/darwin x86_64) and a `main` using only builtin types (`i64`, `**u8`), so `mach init && mach build .` builds and runs out of the box. This matches the README's promise that `mach init` scaffolds a *standalone* starting point (and `mach dep` cannot vendor `std` today, so a `std`-dependent scaffold could never build).
- The library scaffold needs no `_start` (library mode stops at per-module objects).
- Dropped the phantom `--bin` from `mach help init`.

## Verification
- **binary mode:** `mach init` → `mach build .` → runs, exit 0.
- **library mode:** `mach init --lib` → `mach build .` → emits `out/host/obj/<id>/lib.o`.
- **self-host fixpoint:** seed v1.0.0 → build (stage1) → rebuild (stage2) → `cmp` **byte-identical**.
- **corpus:** `mach test .` → **200 PASS, 0 FAIL** (exit 0).
