### PR TITLE
fix(driver,resolve): allow lib fwd re-export of same-package sibling modules

### DIFF
--- a/src/lang/driver.mach
+++ b/src/lang/driver.mach
@@ -1274,6 +1274,9 @@ fun walk_one_decl_for_load(p: *Project, mid: sess.ModuleId, did: id.DeclId) Resu
     if (d.kind == decl.DECL_KIND_USE) {
         ret walk_use_for_load(p, mid, ?d.data.use_);
     }
+    if (d.kind == decl.DECL_KIND_FWD) {
+        ret walk_fwd_for_load(p, mid, ?d.data.fwd_);
+    }
     if (d.kind == decl.DECL_KIND_VAL) {
         ret register_val_for_load(p, mid, d, did);
     }
@@ -1350,6 +1353,36 @@ fun walk_use_for_load(p: *Project, mid: sess.ModuleId, du: *decl.DeclUse) Result
     }
 
     ret merge_pub_consts(p, mid, dep_mid, ut.leaf);
+}
+
+# walk_fwd_for_load: handle one `fwd` re-export during the load walk. a `fwd
+# PATH;` whose PATH is a bare FQN re-publishes a pub symbol of the module that
+# FQN names — a dependency edge on that module exactly like `use`. the load walk
+# must DFS-load the target and record the edge so the resolver's dep-set check
+# sees it; without this a library entrypoint that only `fwd`-re-exports its
+# sibling modules never loads them and resolve rejects the re-export as not in
+# the dep set. a PATH whose prefix is instead a local `use`-alias (e.g.
+# `fwd map.hash_str;`) is left untouched: the alias's own `use` already loaded
+# the module and recorded the edge, and `resolve_use_target` — which only
+# resolves real `.mach` files — correctly reports such a prefix as no module,
+# the resolver's scope-first prefix lookup handling it later. unlike `use`, a
+# `fwd` brings nothing into bare comptime scope, so no pub consts are merged.
+fun walk_fwd_for_load(p: *Project, mid: sess.ModuleId, df: *decl.DeclFwd) Result[bool, str] {
+    if (df.path.len == 0) { ret ok[bool, str](true); }
+    val m: *ModuleEntry = ?p.modules[mid::u32];
+    val src_opt: Option[*src.SourceFile] = src.get(?p.s.sources, m.file_id);
+    if (is_none[*src.SourceFile](src_opt)) { ret err[bool, str]("module file_id not found in SourceMap"); }
+    val source: str = unwrap[*src.SourceFile](src_opt).text;
+
+    val tgt_r: Result[UseTarget, str] = resolve_use_target(p, source, df.path);
+    if (is_err[UseTarget, str](tgt_r)) { ret ok[bool, str](true); }
+    val ut: UseTarget = unwrap_ok[UseTarget, str](tgt_r);
+
+    val dep_r: Result[sess.ModuleId, str] = dfs_load(p, ut.module_fqn);
+    if (is_err[sess.ModuleId, str](dep_r)) { ret err[bool, str](unwrap_err[sess.ModuleId, str](dep_r)); }
+    val dep_mid: sess.ModuleId = unwrap_ok[sess.ModuleId, str](dep_r);
+
+    ret record_dep(p, mid, dep_mid);
 }
 
 # UseTarget: the resolution of a `use` path into the module to load plus

--- a/src/lang/fe/resolve.mach
+++ b/src/lang/fe/resolve.mach
@@ -1089,6 +1089,22 @@ fun bind_fwd(rc: *ResolveContext, decl_id: id.DeclId, df: *decl.DeclFwd, flags: 
         ret ok[bool, str](true);
     }
 
+    # PATH ends at a module: re-export it as a public module alias (the explicit
+    # alias, or the path's leaf segment). mirrors `collect_use`'s module branch
+    # but publishes the alias. a library surface that re-exports whole sibling
+    # submodules (`fwd std.types.bool;`) takes this path; the prefix+symbol split
+    # below would otherwise misread the module leaf as a symbol of a non-module
+    # prefix.
+    val r_full: Result[intern.StrId, str] = intern.intern_span(?rc.s.interner, rc.source, df.path);
+    if (is_err[intern.StrId, str](r_full)) {
+        ret err[bool, str](unwrap_err[intern.StrId, str](r_full));
+    }
+    val full_id: intern.StrId = unwrap_ok[intern.StrId, str](r_full);
+    val full_mx: *ModuleExports = find_module_exports(rc, full_id);
+    if (full_mx != nil) {
+        ret bind_fwd_module(rc, decl_id, df, full_mx.module);
+    }
+
     val leaf: token.Span = leaf_span(rc, df.path);
     val prefix: token.Span = prefix_span(rc, df.path);
     if (prefix.len == 0 || leaf.len == 0) {
@@ -1139,6 +1155,36 @@ fun bind_fwd(rc: *ResolveContext, decl_id: id.DeclId, df: *decl.DeclFwd, flags: 
     if (is_err[bool, str](r_add)) { ret r_add; }
     if (rc.decl_symbol != nil) {
         rc.decl_symbol[decl_id] = sid;
+    }
+    ret ok[bool, str](true);
+}
+
+# re-exports module `mid` as a public module alias under a `fwd`'s alias (or the
+# path's leaf segment when none is written). a SYM_USE bound at module scope whose
+# slot names the target module, but carrying SYM_FLAG_PUB so it joins this
+# module's pub surface — the public counterpart of `collect_use`'s module branch.
+fun bind_fwd_module(rc: *ResolveContext, decl_id: id.DeclId, df: *decl.DeclFwd, mid: sess.ModuleId) Result[bool, str] {
+    var alias_span: token.Span = df.alias;
+    if (alias_span.len == 0) {
+        alias_span = leaf_span(rc, df.path);
+    }
+
+    val r_name: Result[intern.StrId, str] = intern.intern_span(?rc.s.interner, rc.source, alias_span);
+    if (is_err[intern.StrId, str](r_name)) {
+        ret err[bool, str](unwrap_err[intern.StrId, str](r_name));
+    }
+    val name_id: intern.StrId = unwrap_ok[intern.StrId, str](r_name);
+
+    val existing: SymbolId = scope_lookup_local(rc, rc.module_scope, name_id);
+    if (existing != SYMBOL_NIL) {
+        diag.error(?rc.s.diags, rc.a.file_id, alias_span, "re-exported name already defined in this scope");
+        ret ok[bool, str](true);
+    }
+
+    val r: Result[SymbolId, str] = declare(rc, SYM_USE, SYM_FLAG_PUB, alias_span, decl_id, mid::u32, rc.own_module, rc.module_scope);
+    if (is_err[SymbolId, str](r)) { ret err[bool, str](unwrap_err[SymbolId, str](r)); }
+    if (rc.decl_symbol != nil) {
+        rc.decl_symbol[decl_id] = unwrap_ok[SymbolId, str](r);
     }
     ret ok[bool, str](true);
 }


### PR DESCRIPTION
Fixes the compiler lib-build `fwd` re-export bug behind octalide/mach-std#186 (cross-repo, won't auto-close).

Closes #1185.

## Problem

Building a `mode = "library"` project **standalone** fails when its entrypoint `fwd`-re-exports its own sibling submodules. mach-std's `mach build .` errors on every `fwd std.types.*;` (and the rest) in `src/lib.mach`:

```
error: src/lib.mach:1:5: re-exported module is not in the dep set
fwd std.types.bool;
```

mach-std builds fine **as a dependency** of the compiler — only its standalone lib build is red — because the compiler `use`s those `std.*` submodules directly, loading them anyway and masking the bug.

## Root cause

Two coupled gaps, both only reachable when a library entrypoint that is *only* `fwd` lines is itself compiled:

1. The driver's module-load walk (`walk_one_decl_for_load`) handled `use` but not `fwd`, so a `fwd`-re-exported module was never DFS-loaded nor recorded as a dependency edge — the resolver's dep-set lookup then rejected the re-export.
2. `bind_fwd` only handled `fwd PREFIX.symbol;` (a symbol of a module), never `fwd MODULE;` (a whole sibling module). It split the path at the last dot and looked the leaf up as a symbol of the prefix, so `fwd std.types.bool;` (where `std.types.bool` *is* the module) failed even once loaded.

## Fix

- **`src/lang/driver.mach`** — `walk_fwd_for_load`: a bare-FQN `fwd` target is DFS-loaded and its dep edge recorded, exactly like `use`. An alias-qualified `fwd` (`fwd map.hash_str;`, where `map` is a local `use`-alias) is left untouched — the alias's own `use` already loaded the module and recorded the edge.
- **`src/lang/fe/resolve.mach`** — `bind_fwd` now first checks whether the whole path names a dep module and, if so, re-exports it as a public module alias via `bind_fwd_module` (mirroring `collect_use`'s module branch, with `SYM_FLAG_PUB`).

Validation of genuine external re-exports is **not** weakened: a `fwd` whose prefix names no real file and no in-scope alias still surfaces the "re-exported module is not in the dep set" diagnostic at resolve, now with a proper source location.

## Verification (dev-built compiler)

- **mach-std standalone** `mach build .`: all `re-exported module is not in the dep set` errors are gone. (A separate, pre-existing mach-std *source* bug remains — `input + start` pointer arithmetic on `str` in `types/semver.mach`, dating to the original stdlib commit; the standalone build never reached that module before. Out of scope here; should be fixed in mach-std.)
- **Self-host fixpoint**: seed v1.0.0 → build → rebuild → rebuild, all three stages **byte-identical** (`cmp` clean).
- **Test corpus**: `mach test .` → **200 pass, 0 fail**.

> mach-std's CI uses the v1.0.0 *release* as its build seed, so it stays red until a release ships this fix — expected. Verified here with the dev-built compiler.
