### PR TITLE
feat(linker): link static `.a` archives

### DIFF
--- a/.github/tests/extlink/run.sh
+++ b/.github/tests/extlink/run.sh
@@ -1,13 +1,16 @@
 #!/usr/bin/env bash
-# extlink integration test: link a Mach program against an external precompiled
-# `.o` and confirm it builds and runs with the correct result.
+# extlink integration test: link a Mach program against external precompiled
+# code — a loose `.o` object and a static `.a` archive — and confirm it builds
+# and runs with the correct result.
 #
 # builds a tiny library (`extlib`) to a loose object exporting `mach_ext_add`,
 # then links a consumer (`app`) — which declares that symbol `ext` and calls it
 # — against the object via each supported surface (explicit path, `-L`/`-l`, and
-# the `[targets.*].libs` manifest field). the program returns `mach_ext_add(20,
-# 21)` which must be 42. a build with no external input must fail on the
-# undefined `ext` symbol, proving the link is what supplies the definition.
+# the `[targets.*].libs` manifest field). the same surfaces are then exercised
+# against a `.a` archive of that object (built with `ar`, skipped when `ar` is
+# absent). the program returns `mach_ext_add(20, 21)` which must be 42. a build
+# with no external input must fail on the undefined `ext` symbol, proving the
+# link is what supplies the definition.
 #
 # usage: run.sh [path-to-mach]   (defaults to `mach` on PATH)
 set -euo pipefail
@@ -34,9 +37,18 @@ ln -s "$STD" "$WORK/app/dep/mach-std"
 OBJ="$WORK/extlib/out/linux/obj/extlib/ext.o"
 test -f "$OBJ" || { echo "error: library object not produced at $OBJ" >&2; exit 1; }
 
-# a `lib<name>.o` copy so `-L`/`-l` resolution has something to find.
+# a `lib<name>.o` copy so `-L`/`-l` resolution has a loose object to find.
 mkdir -p "$WORK/libs"
 cp "$OBJ" "$WORK/libs/libextadd.o"
+
+# a static archive of the object, in its own dir so `-l` resolves it as a `.a`
+# (a loose `.o` in the search path would otherwise win first).
+AR=""
+if command -v ar >/dev/null 2>&1; then
+    mkdir -p "$WORK/alibs"
+    ar rcs "$WORK/alibs/libextadd.a" "$OBJ"
+    AR="$WORK/alibs/libextadd.a"
+fi
 
 fail=0
 
@@ -62,6 +74,7 @@ expect_42() {
     echo "PASS extlink: $desc"
 }
 
+# loose `.o` surfaces.
 expect_42 "explicit object path" . "$OBJ"
 expect_42 "-L dir -l name"       . -L "$WORK/libs" -l extadd
 # a `./`-style path positional is the project root, not an object input — it
@@ -71,9 +84,21 @@ expect_42 "project-path positional skipped" ./ -L "$WORK/libs" -l extadd
 # manifest libs: point `[targets.linux].libs` at the object by absolute path.
 sed "s|^binary = \"linux/bin/extapp\"|&\nlibs = [\"$OBJ\"]|" "$HERE/app/mach.toml" > "$WORK/app/mach.toml"
 expect_42 "[targets.*].libs manifest" .
+cp "$HERE/app/mach.toml" "$WORK/app/mach.toml"
+
+# static `.a` archive surfaces — the archive's member object supplies the
+# definition exactly as the loose object does.
+if [ -n "$AR" ]; then
+    expect_42 "explicit archive path"        . "$AR"
+    expect_42 "-L dir -l name (.a)"          . -L "$WORK/alibs" -l extadd
+    sed "s|^binary = \"linux/bin/extapp\"|&\nlibs = [\"$AR\"]|" "$HERE/app/mach.toml" > "$WORK/app/mach.toml"
+    expect_42 "[targets.*].libs manifest (.a)" .
+    cp "$HERE/app/mach.toml" "$WORK/app/mach.toml"
+else
+    echo "SKIP extlink: .a archive cases — 'ar' not available"
+fi
 
 # no external input: the undefined `ext` symbol must make the link fail.
-cp "$HERE/app/mach.toml" "$WORK/app/mach.toml"
 rm -rf "$WORK/app/out"
 if ( cd "$WORK/app" && "$MACH" build . ) >/dev/null 2>&1; then
     echo "FAIL extlink: missing input did not fail the link" >&2

--- a/doc/cli.md
+++ b/doc/cli.md
@@ -66,9 +66,9 @@ objects are the deliverable and nothing is linked.
 | `-O1`          | —              | select the release pipeline |
 | `-O2`          | —              | select the release pipeline |
 | `--emit <kind>`| `obj`\|`exe`   | `obj` stops at the relocatable objects; `exe` (default) links a binary |
-| `-L <dir>`     | dir            | add a search directory for `-l`-resolved objects; repeatable |
-| `-l <name>`    | name           | link a named loose object, resolved through the `-L` dirs (see below); repeatable |
-| *(positional)* | object path    | a bare argument that contains `/` or ends in `.o` is linked verbatim |
+| `-L <dir>`     | dir            | add a search directory for `-l`-resolved inputs; repeatable |
+| `-l <name>`    | name           | link a named object or archive, resolved through the `-L` dirs (see below); repeatable |
+| *(positional)* | input path     | a bare argument that contains `/` or ends in `.o` / `.a` is linked verbatim |
 
 Plus the global flags above. The `-O<n>` flags override `--release` when both
 are present; absent any optimisation flag the build uses the debug pipeline
@@ -78,24 +78,27 @@ release pipeline.
 ### External link inputs
 
 `ext fun` declarations are forward references whose definitions are supplied at
-link time by external precompiled objects. Those objects come from the
-command line and from the target's `[targets.*].libs` manifest field (see
-[manifest.md](manifest.md)); both sets are linked. An input that resolves to no
-existing file is a hard error, so a typo never silently drops a dependency.
+link time by external precompiled code — a loose `.o` object or a static `.a`
+archive. Those inputs come from the command line and from the target's
+`[targets.*].libs` manifest field (see [manifest.md](manifest.md)); both sets are
+linked. An input that resolves to no existing file is a hard error, so a typo
+never silently drops a dependency.
 
-- **Explicit object path** — a bare (non-flag) argument that contains a `/` or
-  ends in `.o` is treated as an object path. The first non-flag positional after
-  `build` is the project root and is skipped; remaining object-path positionals
-  are link inputs. A relative path is tried verbatim against the working
-  directory first, then rooted at the project root.
-- **`-l <name>`** — resolves to a loose object. Each `-L <dir>` is searched for
-  `<dir>/lib<name>.o`, then `<dir>/<name>.o`; if none hit, `lib<name>.o` then
-  `<name>.o` relative to the working directory are tried.
+- **Explicit input path** — a bare (non-flag) argument that contains a `/` or
+  ends in `.o` (object) or `.a` (archive) is treated as an input path. The first
+  non-flag positional after `build` is the project root and is skipped; remaining
+  input-path positionals are link inputs. A relative path is tried verbatim
+  against the working directory first, then rooted at the project root.
+- **`-l <name>`** — resolves to an object or archive. Each `-L <dir>` is searched
+  for `<dir>/lib<name>.o`, `<dir>/<name>.o`, `<dir>/lib<name>.a`, then
+  `<dir>/<name>.a`; if none hit, the same four candidates relative to the working
+  directory are tried. Loose objects are preferred over archives.
 - **`-L <dir>`** — adds a search directory for the `-l` resolution above. Both
   `-L` and `-l` may be repeated.
 
-Only loose `.o` relocatable objects are supported — static archives (`.a`) and
-shared libraries (`.so`) are not. Manifest `libs` are resolved before the CLI
+A static `.a` archive contributes every one of its member objects to the link
+(all members are pulled, not just those satisfying an undefined symbol). Shared
+libraries (`.so`) are not supported. Manifest `libs` are resolved before the CLI
 inputs, giving a stable, deterministic link order.
 
 Exit codes: `0` ok, `1` user error (no `mach.toml`, unknown target, compile

--- a/doc/language/ext-fun.md
+++ b/doc/language/ext-fun.md
@@ -51,29 +51,31 @@ undefined `ext` symbol with no object supplying it is a link error.
 C-toolchain-style flags, consumed by `mach build`:
 
 ```sh
-# explicit object-file path
+# explicit object / archive path
 mach build . path/to/libfoo.o
+mach build . path/to/libfoo.a
 
-# search dir + library name: resolves `lib<name>.o` then `<name>.o` in each -L dir
+# search dir + library name: resolves lib<name>.o / <name>.o / lib<name>.a / <name>.a in each -L dir
 mach build . -L build/libs -l foo
 ```
 
-- A bare argument that contains a `/` or ends in `.o` is treated as an explicit
-  object path. A relative path is tried first against the working directory,
-  then against the project root.
-- `-l <name>` resolves to a loose object: each `-L <dir>` is searched for
-  `lib<name>.o`, then `<name>.o`; finally the working directory is searched for
-  the same two names. `-L` and `-l` may each be repeated.
+- A bare argument that contains a `/` or ends in `.o` (object) or `.a` (archive)
+  is treated as an explicit input path. A relative path is tried first against the
+  working directory, then against the project root.
+- `-l <name>` resolves to an object or archive: each `-L <dir>` is searched for
+  `lib<name>.o`, `<name>.o`, `lib<name>.a`, then `<name>.a`; finally the working
+  directory is searched for the same four names (loose objects preferred over
+  archives). `-L` and `-l` may each be repeated.
 
 ### Manifest
 
-`[targets.*].libs` lists project-level link inputs, each an explicit object
-path (project-relative or absolute) or a bare `-l`-style name:
+`[targets.*].libs` lists project-level link inputs, each an explicit object /
+archive path (project-relative or absolute) or a bare `-l`-style name:
 
 ```toml
 [targets.linux]
 # ...
-libs = ["build/libs/libfoo.o", "bar"]
+libs = ["build/libs/libfoo.a", "bar"]
 ```
 
 `link` is accepted as an alias for `libs`. Manifest inputs and command-line
@@ -82,9 +84,10 @@ error.
 
 ### Scope
 
-Only loose `.o` relocatable objects are linked. Static archives (`.a`) and
-shared libraries (`.so`) are not yet supported — extract or recompile the
-member objects you need, or wait on the dynamic-linker work.
+Loose `.o` relocatable objects and static `.a` archives are linked; a `.a`
+contributes every one of its member objects (all members are pulled, not just
+those satisfying an undefined symbol). Shared libraries (`.so`) are not yet
+supported — wait on the dynamic-linker work.
 
 ## See also
 

--- a/doc/manifest.md
+++ b/doc/manifest.md
@@ -44,15 +44,15 @@ with `mach.toml has no [targets.<name>] entries`.
 | `binary`     | string | yes      | —        | Output path of the linked binary, relative to `<dir_out>` (e.g. `"linux/bin/mach"`). Required for **every** target, even in library mode where no binary is linked. |
 | `artifacts`  | string | no       | `<name>` | Subdirectory under `<dir_out>` holding the per-module object tree (`obj/`) and any `--emit-asm` / `--emit-ir` output. Defaults to the target name; may be nested (e.g. `"smach/linux"`). |
 | `mode`       | string | no       | `"executable"` | `"executable"` links the per-module objects into a static binary; `"library"` stops at the objects (no link). Any value other than `"library"` is treated as `"executable"`. |
-| `libs`       | array of strings | no | `[]` | Project-level external link inputs. Each entry is either an explicit object-file path (project-root-relative or absolute) or a bare `-l`-style name resolved to a loose `lib<name>.o` / `<name>.o` at link time. These join every `mach build`/`run`/`test` link in addition to any CLI `-L`/`-l`/object arguments. A non-array value, or a non-string element, is a manifest error. The alias `link` is accepted when `libs` is absent. |
+| `libs`       | array of strings | no | `[]` | Project-level external link inputs. Each entry is either an explicit object/archive path (a `.o` or `.a`, project-root-relative or absolute) or a bare `-l`-style name resolved to a `lib<name>.o` / `<name>.o` / `lib<name>.a` / `<name>.a` at link time. These join every `mach build`/`run`/`test` link in addition to any CLI `-L`/`-l`/object arguments. A non-array value, or a non-string element, is a manifest error. The alias `link` is accepted when `libs` is absent. |
 
 Informational (parsed by TOML, not read by the build): `abi`. The ABI is derived
 from `os` (Linux/macOS → SysV, Windows → Win64), so the key documents intent but
 does not change the build.
 
-Only loose `.o` relocatable objects are linked — static archives (`.a`) and
-shared libraries (`.so`) are not yet supported. See
-[language/ext-fun.md](language/ext-fun.md#linking-external-objects) for the
+Loose `.o` relocatable objects and static `.a` archives are linked; a `.a`
+contributes every member object. Shared libraries (`.so`) are not yet supported.
+See [language/ext-fun.md](language/ext-fun.md#linking-external-objects) for the
 `ext fun` workflow that consumes these inputs, and [cli.md](cli.md#external-link-inputs)
 for the equivalent command-line flags.
 

--- a/src/cli/cmd/build.mach
+++ b/src/cli/cmd/build.mach
@@ -748,9 +748,10 @@ fun link_artifact(p: *driver.Project, emit_obj: bool, test_mode: bool, have_runn
     }
 
     # append every external link input — manifest `[targets.*].libs` plus the
-    # `-L`/`-l`/explicit-object CLI flags — as extra object paths. each resolves
-    # to a loose `.o` on disk that joins the link so undefined `ext` / in-graph
-    # symbols bind against its definitions. `paths` is grown and re-bound here.
+    # `-L`/`-l`/explicit-object CLI flags — as extra input paths. each resolves to
+    # a loose `.o` object or a static `.a` archive on disk that joins the link so
+    # undefined `ext` / in-graph symbols bind against its definitions (an archive
+    # contributes its member objects). `paths` is grown and re-bound here.
     val ext_code: i64 = append_external_objects(p, root, argc, argv, ?paths, ?count);
     if (ext_code != 0) {
         free_paths(p.s.alloc, paths, count, count);
@@ -810,9 +811,10 @@ fun link_artifact(p: *driver.Project, emit_obj: bool, test_mode: bool, have_runn
     ret 0;
 }
 
-# is_object_path: whether a link-input token denotes an explicit object-file
+# is_object_path: whether a link-input token denotes an explicit link-input file
 # path rather than a bare `-l`-style library name. a token is treated as a path
-# when it contains a '/' (any directory component) or ends in `.o`.
+# when it contains a '/' (any directory component) or ends in `.o` (a loose
+# object) or `.a` (a static archive).
 fun is_object_path(tok: *u8) bool {
     if (tok == nil) { ret false; }
     val n: usize = slen(tok);
@@ -822,17 +824,18 @@ fun is_object_path(tok: *u8) bool {
         if (tok[i] == '/') { ret true; }
         i = i + 1;
     }
-    if (n >= 2 && tok[n - 2] == '.' && tok[n - 1] == 'o') { ret true; }
+    if (n >= 2 && tok[n - 2] == '.' && (tok[n - 1] == 'o' || tok[n - 1] == 'a')) { ret true; }
     ret false;
 }
 
-# resolve_input_into: resolve one link-input token to an existing object file,
-# writing the absolute-or-relative path into `buf`. an explicit object path
-# (`is_object_path`) is taken verbatim. a bare `-l`-style name is searched in
-# each `-L <dir>` as `<dir>/lib<name>.o` then `<dir>/<name>.o`, then as
-# `lib<name>.o` and `<name>.o` relative to the working directory. returns true
-# once an existing file is found and written; false when nothing resolves.
-# `.a`/`.so` archives are not handled — only loose `.o` objects.
+# resolve_input_into: resolve one link-input token to an existing input file,
+# writing the absolute-or-relative path into `buf`. an explicit object/archive
+# path (`is_object_path`, i.e. a `.o` or `.a`) is taken verbatim. a bare
+# `-l`-style name is searched in each `-L <dir>` as `<dir>/lib<name>.o`,
+# `<dir>/<name>.o`, `<dir>/lib<name>.a`, `<dir>/<name>.a`, then the same four
+# candidates relative to the working directory. returns true once an existing
+# file is found and written; false when nothing resolves. `.so` shared libraries
+# are not handled — only loose `.o` objects and static `.a` archives.
 fun resolve_input_into(tok: *u8, argc: usize, argv: **u8, buf: *u8, cap: usize) bool {
     if (tok == nil || slen(tok) == 0) { ret false; }
 
@@ -858,26 +861,31 @@ fun resolve_input_into(tok: *u8, argc: usize, argv: **u8, buf: *u8, cap: usize) 
     ret false;
 }
 
-# try_named_object: probe `<dir>/lib<name>.o` then `<dir>/<name>.o` for an
-# existing file, writing the first hit into `buf`. a nil `dir` probes the bare
-# `lib<name>.o` / `<name>.o` relative to the working directory. returns true on
+# try_named_object: probe the `lib<name>` / `<name>` candidates with a `.o`
+# (loose object) then `.a` (static archive) extension, writing the first existing
+# hit into `buf`. a nil `dir` probes them relative to the working directory; a
+# non-nil `dir` roots them under it. loose objects are preferred over archives so
+# resolution is unchanged for an `-l` name that has a loose `.o`. returns true on
 # the first existing candidate.
 fun try_named_object(dir: *u8, name: *u8, buf: *u8, cap: usize) bool {
-    if (write_named_candidate(dir, "lib", name, buf, cap) && fs.is_file(cstr_str(buf))) { ret true; }
-    if (write_named_candidate(dir, "", name, buf, cap) && fs.is_file(cstr_str(buf)))    { ret true; }
+    if (write_named_candidate(dir, "lib", name, "o", buf, cap) && fs.is_file(cstr_str(buf))) { ret true; }
+    if (write_named_candidate(dir, "", name, "o", buf, cap) && fs.is_file(cstr_str(buf)))    { ret true; }
+    if (write_named_candidate(dir, "lib", name, "a", buf, cap) && fs.is_file(cstr_str(buf))) { ret true; }
+    if (write_named_candidate(dir, "", name, "a", buf, cap) && fs.is_file(cstr_str(buf)))    { ret true; }
     ret false;
 }
 
-# write_named_candidate: compose `<dir>/<prefix><name>.o` (or `<prefix><name>.o`
-# when `dir` is nil) into `buf`, null-terminated. returns false if it would not
-# fit. `prefix` is "lib" or "".
-fun write_named_candidate(dir: *u8, prefix: *u8, name: *u8, buf: *u8, cap: usize) bool {
+# write_named_candidate: compose `<dir>/<prefix><name>.<ext>` (or
+# `<prefix><name>.<ext>` when `dir` is nil) into `buf`, null-terminated. returns
+# false if it would not fit. `prefix` is "lib" or ""; `ext` is "o" or "a".
+fun write_named_candidate(dir: *u8, prefix: *u8, name: *u8, ext: *u8, buf: *u8, cap: usize) bool {
     val dl: usize = slen(dir);
     val pl: usize = slen(prefix);
     val nl: usize = slen(name);
+    val el: usize = slen(ext);
     var need: usize = dl;
     if (dl > 0) { need = need + 1; }
-    need = need + pl + nl + 2 + 1;
+    need = need + pl + nl + 1 + el + 1;
     if (need > cap) { ret false; }
 
     var k: usize = 0;
@@ -891,7 +899,8 @@ fun write_named_candidate(dir: *u8, prefix: *u8, name: *u8, buf: *u8, cap: usize
     i = 0;
     for (i < nl) { buf[k] = name[i]; k = k + 1; i = i + 1; }
     buf[k] = '.'; k = k + 1;
-    buf[k] = 'o'; k = k + 1;
+    i = 0;
+    for (i < el) { buf[k] = ext[i]; k = k + 1; i = i + 1; }
     buf[k] = 0;
     ret true;
 }
@@ -946,12 +955,12 @@ fun is_value_flag(a: *u8) bool {
 
 # append_external_objects: resolve every external link input (manifest
 # `[targets.*].libs` plus the CLI `-L`/`-l`/explicit-object flags) to a loose
-# `.o` on disk and append each as an extra object path. `*paths` is grown from
-# `*count` to `*count + extra` and re-bound; on success `*count` becomes the
-# total object count (every slot resolved). an input that resolves to no
-# existing file is a hard error so a typo never silently drops a link
-# dependency. the grown tail is nil-initialized up front and `*count` is set to
-# the full grown capacity on every exit, so the caller's
+# `.o` object or static `.a` archive on disk and append each as an extra input
+# path. `*paths` is grown from `*count` to `*count + extra` and re-bound; on
+# success `*count` becomes the total input count (every slot resolved). an input
+# that resolves to no existing file is a hard error so a typo never silently
+# drops a link dependency. the grown tail is nil-initialized up front and
+# `*count` is set to the full grown capacity on every exit, so the caller's
 # `free_paths(.., count, count)` frees the array at its true size and skips the
 # unfilled nil slots. returns 0 on success, or a non-zero exit code.
 fun append_external_objects(p: *driver.Project, root: *u8, argc: usize, argv: **u8,

--- a/src/lang/be/linker.mach
+++ b/src/lang/be/linker.mach
@@ -44,6 +44,7 @@ use std.types.size.usize;
 use std.allocator.Allocator;
 use std.allocator.allocate;
 use std.allocator.zallocate;
+use std.allocator.reallocate;
 use std.allocator.deallocate;
 
 use mem: std.memory;
@@ -55,6 +56,7 @@ use sess:   mach.lang.session;
 use intern: mach.lang.intern;
 use target: mach.lang.target;
 use of:     mach.lang.target.of;
+use ar:     mach.lang.target.of.ar;
 use obj:    mach.lang.be.obj;
 
 # link mode: what kind of artifact `link` produces.
@@ -144,14 +146,17 @@ pub fun link(s: *sess.Session, tgt: *target.Target, obj_paths: **u8,
     val alloc: *Allocator = s.alloc;
 
     # read and parse every input object file into an in-memory image array. the
-    # array and each populated image are torn down on every exit path below.
+    # array and each populated image are torn down on every exit path below. an
+    # `.a` archive input expands into one image per member object, so the parsed
+    # image count can exceed the input-path count — `read_objects` reports the
+    # true module count through `module_count`.
     var modules: *of.ObjectImage = nil;
-    val read_r: Result[*of.ObjectImage, str] = read_objects(s, tgt, obj_paths, obj_count);
+    var module_count: u32 = 0;
+    val read_r: Result[*of.ObjectImage, str] = read_objects(s, tgt, obj_paths, obj_count, ?module_count);
     if (is_err[*of.ObjectImage, str](read_r)) {
         ret err[bool, str](unwrap_err[*of.ObjectImage, str](read_r));
     }
     modules = unwrap_ok[*of.ObjectImage, str](read_r);
-    val module_count: u32 = obj_count;
 
     # build the merged-section accumulators, one per kind, in canonical order.
     var merged: [5]MergedSection;
@@ -280,37 +285,39 @@ pub fun link(s: *sess.Session, tgt: *target.Target, obj_paths: **u8,
     ret ok[bool, str](true);
 }
 
-# read_objects: read and parse every input object file into a fresh image array.
+# read_objects: read and parse every input file into a fresh image array.
 #
-# allocates an `obj_count`-long `of.ObjectImage` array, then for each path reads
-# the whole file (`fs.read_all`) and parses it through the active format's
-# `parse_object`. on any failure every image parsed so far and the array itself
-# are released before returning the error, so the caller never inherits a
-# partial array. the read buffer is freed after parse — `parse_object` copies
-# the section bytes it keeps into the image.
+# grows an `of.ObjectImage` array one slot at a time. for each path it reads the
+# whole file (`fs.read_all_sized`) and either parses it directly through the
+# active format's `parse_object` (a loose `.o`) or, when the file opens with the
+# `ar` magic, expands every ordinary member object of the archive into its own
+# image. an `.a` therefore contributes one module per member, so the final image
+# count — written through `module_count` — can exceed `obj_count`. on any failure
+# every image parsed so far and the array itself are released before returning the
+# error, so the caller never inherits a partial array. each read buffer is freed
+# after its objects are parsed — `parse_object` copies the section bytes it keeps.
 # ---
-# s:         shared session (allocator, interner)
-# tgt:       active target — supplies the format parser
-# obj_paths: array of null-terminated object-file paths
-# obj_count: number of paths
-# ret:       the populated image array, or an error string
+# s:            shared session (allocator, interner)
+# tgt:          active target — supplies the format parser
+# obj_paths:    array of null-terminated input-file paths
+# obj_count:    number of paths
+# module_count: out — the number of images produced (>= obj_count with archives)
+# ret:          the populated image array, or an error string
 fun read_objects(s: *sess.Session, tgt: *target.Target, obj_paths: **u8,
-                 obj_count: u32) Result[*of.ObjectImage, str] {
+                 obj_count: u32, module_count: *u32) Result[*of.ObjectImage, str] {
+    @module_count = 0;
     if (tgt.of.parse_object == nil) {
         ret err[*of.ObjectImage, str]("link: object format has no parser");
     }
     val alloc: *Allocator = s.alloc;
 
-    val ar: Result[*of.ObjectImage, str] = zallocate[of.ObjectImage](alloc, obj_count::usize);
-    if (is_err[*of.ObjectImage, str](ar)) {
-        ret err[*of.ObjectImage, str](unwrap_err[*of.ObjectImage, str](ar));
-    }
-    val modules: *of.ObjectImage = unwrap_ok[*of.ObjectImage, str](ar);
+    var modules: *of.ObjectImage = nil;
+    var count: u32 = 0;
 
     var i: u32 = 0;
     for (i < obj_count) {
         if (obj_paths[i] == nil) {
-            free_modules_to(alloc, modules, i, obj_count);
+            free_modules_to(alloc, modules, count, count);
             ret err[*of.ObjectImage, str]("link: nil object path");
         }
 
@@ -323,25 +330,134 @@ fun read_objects(s: *sess.Session, tgt: *target.Target, obj_paths: **u8,
         # mis-parse the object.
         val rb: Result[fs.Buffer, str] = fs.read_all_sized(alloc, path);
         if (is_err[fs.Buffer, str](rb)) {
-            free_modules_to(alloc, modules, i, obj_count);
+            free_modules_to(alloc, modules, count, count);
             ret err[*of.ObjectImage, str](read_message(s, path, unwrap_err[fs.Buffer, str](rb)));
         }
         val buf: fs.Buffer = unwrap_ok[fs.Buffer, str](rb);
 
-        val pr: Result[bool, str] =
-            tgt.of.parse_object(alloc, buf.data, buf.len, ?modules[i]);
+        var input_r: Result[bool, str] = ok[bool, str](true);
+        if (ar.is_archive(buf.data, buf.len)) {
+            input_r = parse_archive(s, tgt, path, buf.data, buf.len, ?modules, ?count);
+        }
+        or {
+            input_r = parse_loose(alloc, tgt, buf.data, buf.len, ?modules, ?count);
+        }
+
         # the parser copies any bytes it keeps; the file buffer is no longer
         # needed regardless of success. read_all_sized over-allocates by one nul byte.
         if (buf.data != nil) { deallocate[u8](alloc, buf.data, buf.len + 1); }
-        if (is_err[bool, str](pr)) {
-            free_modules_to(alloc, modules, i, obj_count);
-            ret err[*of.ObjectImage, str](unwrap_err[bool, str](pr));
+        if (is_err[bool, str](input_r)) {
+            free_modules_to(alloc, modules, count, count);
+            ret err[*of.ObjectImage, str](unwrap_err[bool, str](input_r));
         }
 
         i = i + 1;
     }
 
+    @module_count = count;
     ret ok[*of.ObjectImage, str](modules);
+}
+
+# grow_modules: append one empty image slot to the module array, growing it by
+# one and zero-initializing the new tail.
+#
+# the new slot is fully zeroed so a later parse failure (or an unparsed slot left
+# behind by a partial read) tears down cleanly through `obj.dnit`, which reads the
+# nil section/symbol/relocation pointers as empty. on success `*modules` is rebound
+# to the grown array and `*count` advanced; the new slot's index is the old count.
+# ---
+# alloc:   allocator backing the array
+# modules: in/out — the image array, rebound after growth
+# count:   in/out — current image count, incremented on success
+# ret:     index of the appended slot, or an allocation error
+fun grow_modules(alloc: *Allocator, modules: **of.ObjectImage, count: *u32) Result[u32, str] {
+    val old: u32 = @count;
+    val gr: Result[*of.ObjectImage, str] =
+        reallocate[of.ObjectImage](alloc, @modules, old::usize, (old + 1)::usize);
+    if (is_err[*of.ObjectImage, str](gr)) {
+        ret err[u32, str](unwrap_err[*of.ObjectImage, str](gr));
+    }
+    @modules = unwrap_ok[*of.ObjectImage, str](gr);
+
+    val arr: *of.ObjectImage = @modules;
+    val slot: *of.ObjectImage = ?arr[old];
+    slot.alloc         = alloc;
+    slot.name          = intern.STR_NIL;
+    slot.sections      = nil;
+    slot.section_count = 0;
+    slot.symbols       = nil;
+    slot.symbol_count  = 0;
+    slot.relocations   = nil;
+    slot.reloc_count   = 0;
+
+    @count = old + 1;
+    ret ok[u32, str](old);
+}
+
+# parse_loose: parse a single loose object file's bytes into a new image slot.
+#
+# appends an image and parses `buf` into it through the active format's
+# `parse_object`. the appended slot stays in the array on parse failure (zeroed,
+# so the caller's teardown frees it cleanly) and the error is propagated.
+# ---
+# alloc:   allocator backing the image arrays
+# tgt:     active target — supplies the format parser
+# buf:     the object file bytes
+# buf_len: length of `buf`
+# modules: in/out — the image array, rebound on growth
+# count:   in/out — current image count
+# ret:     ok(true) on success, or an error string
+fun parse_loose(alloc: *Allocator, tgt: *target.Target, buf: *u8, buf_len: usize,
+                modules: **of.ObjectImage, count: *u32) Result[bool, str] {
+    val gr: Result[u32, str] = grow_modules(alloc, modules, count);
+    if (is_err[u32, str](gr)) { ret err[bool, str](unwrap_err[u32, str](gr)); }
+    val ix: u32 = unwrap_ok[u32, str](gr);
+    val arr: *of.ObjectImage = @modules;
+    ret tgt.of.parse_object(alloc, buf, buf_len, ?arr[ix]);
+}
+
+# parse_archive: expand every ordinary member of an `ar` archive into the image
+# array.
+#
+# walks the archive members (`ar.next_member`), skipping the bookkeeping members
+# (`ar.is_special`), and parses each remaining member's object bytes into a new
+# image slot through the active format's `parse_object`. the member slices borrow
+# the archive buffer, which the caller keeps alive across this call. a malformed
+# member header is a hard error. this implements the v1 member-selection policy:
+# every object member is pulled (see `of.ar`).
+# ---
+# s:       shared session (diagnostics)
+# tgt:     active target — supplies the format parser
+# path:    archive path, for the diagnostic on a malformed member
+# buf:     the archive bytes
+# buf_len: length of `buf`
+# modules: in/out — the image array, rebound on growth
+# count:   in/out — current image count
+# ret:     ok(true) once every member is parsed, or an error string
+fun parse_archive(s: *sess.Session, tgt: *target.Target, path: str, buf: *u8, buf_len: usize,
+                  modules: **of.ObjectImage, count: *u32) Result[bool, str] {
+    val alloc: *Allocator = s.alloc;
+    var pos: usize = ar.first_member();
+    for (true) {
+        val st: ar.Step = ar.next_member(buf, buf_len, pos);
+        if (!st.ok) {
+            ret err[bool, str](read_message(s, path, "malformed archive member header"));
+        }
+        if (st.done) { ret ok[bool, str](true); }
+
+        if (!ar.is_special(buf, pos)) {
+            val gr: Result[u32, str] = grow_modules(alloc, modules, count);
+            if (is_err[u32, str](gr)) { ret err[bool, str](unwrap_err[u32, str](gr)); }
+            val ix: u32 = unwrap_ok[u32, str](gr);
+            val arr: *of.ObjectImage = @modules;
+            val pr: Result[bool, str] =
+                tgt.of.parse_object(alloc, st.member.data, st.member.len, ?arr[ix]);
+            if (is_err[bool, str](pr)) { ret err[bool, str](unwrap_err[bool, str](pr)); }
+        }
+
+        pos = st.next;
+    }
+    ret ok[bool, str](true);
 }
 
 # emit_executable: lay the merged sections out as load segments and write the

--- a/src/lang/be/linker.mach
+++ b/src/lang/be/linker.mach
@@ -319,13 +319,18 @@ fun read_objects(s: *sess.Session, tgt: *target.Target, obj_paths: **u8,
     }
     val alloc: *Allocator = s.alloc;
 
+    # the image array grows geometrically (capacity doubles) so appending one
+    # image per object/member stays amortized O(1) even for a large archive; it
+    # is shrunk to exactly `count` before returning so the rest of the linker's
+    # "array length == module count" invariant holds.
     var modules: *of.ObjectImage = nil;
     var count: u32 = 0;
+    var cap:   u32 = 0;
 
     var i: u32 = 0;
     for (i < obj_count) {
         if (obj_paths[i] == nil) {
-            free_modules_to(alloc, modules, count, count);
+            free_modules_to(alloc, modules, count, cap);
             ret err[*of.ObjectImage, str]("link: nil object path");
         }
 
@@ -338,54 +343,77 @@ fun read_objects(s: *sess.Session, tgt: *target.Target, obj_paths: **u8,
         # mis-parse the object.
         val rb: Result[fs.Buffer, str] = fs.read_all_sized(alloc, path);
         if (is_err[fs.Buffer, str](rb)) {
-            free_modules_to(alloc, modules, count, count);
+            free_modules_to(alloc, modules, count, cap);
             ret err[*of.ObjectImage, str](read_message(s, path, unwrap_err[fs.Buffer, str](rb)));
         }
         val buf: fs.Buffer = unwrap_ok[fs.Buffer, str](rb);
 
         var input_r: Result[bool, str] = ok[bool, str](true);
         if (ar.is_archive(buf.data, buf.len)) {
-            input_r = parse_archive(s, tgt, path, buf.data, buf.len, ?modules, ?count);
+            input_r = parse_archive(s, tgt, path, buf.data, buf.len, ?modules, ?count, ?cap);
         }
         or {
-            input_r = parse_loose(alloc, tgt, buf.data, buf.len, ?modules, ?count);
+            input_r = parse_loose(alloc, tgt, buf.data, buf.len, ?modules, ?count, ?cap);
         }
 
         # the parser copies any bytes it keeps; the file buffer is no longer
         # needed regardless of success. read_all_sized over-allocates by one nul byte.
         if (buf.data != nil) { deallocate[u8](alloc, buf.data, buf.len + 1); }
         if (is_err[bool, str](input_r)) {
-            free_modules_to(alloc, modules, count, count);
+            free_modules_to(alloc, modules, count, cap);
             ret err[*of.ObjectImage, str](unwrap_err[bool, str](input_r));
         }
 
         i = i + 1;
     }
 
+    # shrink the over-allocated capacity back to the live count so the rest of
+    # the linker (and `free_modules`) sees `array length == module count`. on the
+    # (practically impossible) shrink failure the whole array is released and the
+    # error surfaced rather than leaving a capacity/count mismatch behind.
+    if (cap > count) {
+        val sr: Result[*of.ObjectImage, str] =
+            reallocate[of.ObjectImage](alloc, modules, cap::usize, count::usize);
+        if (is_err[*of.ObjectImage, str](sr)) {
+            free_modules_to(alloc, modules, count, cap);
+            ret err[*of.ObjectImage, str](unwrap_err[*of.ObjectImage, str](sr));
+        }
+        modules = unwrap_ok[*of.ObjectImage, str](sr);
+    }
+
     @module_count = count;
     ret ok[*of.ObjectImage, str](modules);
 }
 
-# grow_modules: append one empty image slot to the module array, growing it by
-# one and zero-initializing the new tail.
+# grow_modules: append one empty image slot to the module array, doubling the
+# backing capacity when it is exhausted and zero-initializing the new tail.
 #
-# the new slot is fully zeroed so a later parse failure (or an unparsed slot left
-# behind by a partial read) tears down cleanly through `obj.dnit`, which reads the
-# nil section/symbol/relocation pointers as empty. on success `*modules` is rebound
-# to the grown array and `*count` advanced; the new slot's index is the old count.
+# the array grows geometrically — capacity doubles (from 1) when `count` reaches
+# `cap` — so a long archive's per-member appends stay amortized O(1). the new slot
+# is fully zeroed so a later parse failure (or an unparsed slot left behind by a
+# partial read) tears down cleanly through `obj.dnit`, which reads the nil
+# section/symbol/relocation pointers as empty. on success `*modules` is rebound to
+# the grown array, `*cap` updated, and `*count` advanced; the slot's index is the
+# old count.
 # ---
 # alloc:   allocator backing the array
-# modules: in/out — the image array, rebound after growth
+# modules: in/out — the image array, rebound when the capacity grows
 # count:   in/out — current image count, incremented on success
+# cap:     in/out — current backing capacity, updated when it grows
 # ret:     index of the appended slot, or an allocation error
-fun grow_modules(alloc: *Allocator, modules: **of.ObjectImage, count: *u32) Result[u32, str] {
+fun grow_modules(alloc: *Allocator, modules: **of.ObjectImage, count: *u32, cap: *u32) Result[u32, str] {
     val old: u32 = @count;
-    val gr: Result[*of.ObjectImage, str] =
-        reallocate[of.ObjectImage](alloc, @modules, old::usize, (old + 1)::usize);
-    if (is_err[*of.ObjectImage, str](gr)) {
-        ret err[u32, str](unwrap_err[*of.ObjectImage, str](gr));
+    if (old == @cap) {
+        var new_cap: u32 = @cap * 2;
+        if (new_cap == 0) { new_cap = 1; }
+        val gr: Result[*of.ObjectImage, str] =
+            reallocate[of.ObjectImage](alloc, @modules, (@cap)::usize, new_cap::usize);
+        if (is_err[*of.ObjectImage, str](gr)) {
+            ret err[u32, str](unwrap_err[*of.ObjectImage, str](gr));
+        }
+        @modules = unwrap_ok[*of.ObjectImage, str](gr);
+        @cap = new_cap;
     }
-    @modules = unwrap_ok[*of.ObjectImage, str](gr);
 
     val arr: *of.ObjectImage = @modules;
     val slot: *of.ObjectImage = ?arr[old];
@@ -414,10 +442,11 @@ fun grow_modules(alloc: *Allocator, modules: **of.ObjectImage, count: *u32) Resu
 # buf_len: length of `buf`
 # modules: in/out — the image array, rebound on growth
 # count:   in/out — current image count
+# cap:     in/out — current backing capacity
 # ret:     ok(true) on success, or an error string
 fun parse_loose(alloc: *Allocator, tgt: *target.Target, buf: *u8, buf_len: usize,
-                modules: **of.ObjectImage, count: *u32) Result[bool, str] {
-    val gr: Result[u32, str] = grow_modules(alloc, modules, count);
+                modules: **of.ObjectImage, count: *u32, cap: *u32) Result[bool, str] {
+    val gr: Result[u32, str] = grow_modules(alloc, modules, count, cap);
     if (is_err[u32, str](gr)) { ret err[bool, str](unwrap_err[u32, str](gr)); }
     val ix: u32 = unwrap_ok[u32, str](gr);
     val arr: *of.ObjectImage = @modules;
@@ -441,9 +470,10 @@ fun parse_loose(alloc: *Allocator, tgt: *target.Target, buf: *u8, buf_len: usize
 # buf_len: length of `buf`
 # modules: in/out — the image array, rebound on growth
 # count:   in/out — current image count
+# cap:     in/out — current backing capacity
 # ret:     ok(true) once every member is parsed, or an error string
 fun parse_archive(s: *sess.Session, tgt: *target.Target, path: str, buf: *u8, buf_len: usize,
-                  modules: **of.ObjectImage, count: *u32) Result[bool, str] {
+                  modules: **of.ObjectImage, count: *u32, cap: *u32) Result[bool, str] {
     val alloc: *Allocator = s.alloc;
     var pos: usize = ar.first_member();
     for (true) {
@@ -454,7 +484,7 @@ fun parse_archive(s: *sess.Session, tgt: *target.Target, path: str, buf: *u8, bu
         if (st.done) { ret ok[bool, str](true); }
 
         if (!ar.is_special(buf, pos)) {
-            val gr: Result[u32, str] = grow_modules(alloc, modules, count);
+            val gr: Result[u32, str] = grow_modules(alloc, modules, count, cap);
             if (is_err[u32, str](gr)) { ret err[bool, str](unwrap_err[u32, str](gr)); }
             val ix: u32 = unwrap_ok[u32, str](gr);
             val arr: *of.ObjectImage = @modules;

--- a/src/lang/be/linker.mach
+++ b/src/lang/be/linker.mach
@@ -158,6 +158,14 @@ pub fun link(s: *sess.Session, tgt: *target.Target, obj_paths: **u8,
     }
     modules = unwrap_ok[*of.ObjectImage, str](read_r);
 
+    # every input resolved to zero modules (e.g. an empty archive or one holding
+    # only bookkeeping members) — there is nothing to link, so reject rather than
+    # emit an empty artifact.
+    if (module_count == 0) {
+        free_modules(alloc, modules, module_count);
+        ret err[bool, str]("link: no input objects");
+    }
+
     # build the merged-section accumulators, one per kind, in canonical order.
     var merged: [5]MergedSection;
     init_merged(?merged[0]);

--- a/src/lang/driver.mach
+++ b/src/lang/driver.mach
@@ -93,7 +93,7 @@ pub val MODE_LIBRARY:    BuildMode = 1;
 # libs:       interned project-level link inputs from `[targets.*].libs` —
 #             each entry is either an explicit `.o` object / `.a` archive path
 #             (relative to the project root, or absolute) or a bare `-l`-style
-#             name resolved against the link search dirs; nil when none declared
+#             name resolved against the link search dirs; nil when none are declared
 # lib_count:  number of entries in `libs`
 pub rec TargetEntry {
     name:       intern.StrId;

--- a/src/lang/driver.mach
+++ b/src/lang/driver.mach
@@ -91,9 +91,9 @@ pub val MODE_LIBRARY:    BuildMode = 1;
 # binary:     interned final-binary path under `out` (e.g. "linux/bin/mach")
 # mode:       whether the build links an executable or stops at the objects
 # libs:       interned project-level link inputs from `[targets.*].libs` —
-#             each entry is either an explicit object-file path (relative to the
-#             project root, or absolute) or a bare `-l`-style name resolved
-#             against the link search dirs; nil when none are declared
+#             each entry is either an explicit `.o` object / `.a` archive path
+#             (relative to the project root, or absolute) or a bare `-l`-style
+#             name resolved against the link search dirs; nil when none declared
 # lib_count:  number of entries in `libs`
 pub rec TargetEntry {
     name:       intern.StrId;

--- a/src/lang/target/of/ar.mach
+++ b/src/lang/target/of/ar.mach
@@ -203,20 +203,24 @@ fun name_has_prefix(buf: *u8, pos: usize, pre: *u8) bool {
     ret true;
 }
 
-# parse_size: decode the right-space-padded decimal-ASCII size field at `at`.
+# parse_size: decode the space-padded decimal-ASCII size field at `at`.
 #
-# the `ar` size field is `SIZE_LEN` bytes of decimal digits padded with trailing
-# spaces. non-digit bytes (the padding) terminate the scan. a field with no
-# leading digit is malformed — `ok` is set false and the return value is unused.
+# the `ar` size field is `SIZE_LEN` bytes holding a decimal count. it is normally
+# left-justified with trailing spaces, but leading spaces are tolerated too; the
+# scan skips leading spaces, reads the digit run, and stops at the first non-digit
+# (the trailing padding). a field with no digit at all is malformed — `ok` is set
+# false and the return value is unused.
 # ---
 # buf: the archive bytes
 # at:  offset of the size field
-# ok:  out — true if at least one leading digit was decoded
+# ok:  out — true if at least one digit was decoded
 # ret: the decoded member size in bytes
 fun parse_size(buf: *u8, at: usize, ok: *bool) usize {
     var v: usize = 0;
     var n: usize = 0;
     var i: usize = 0;
+    # skip any leading spaces before the digit run.
+    for (i < SIZE_LEN && buf[at + i] == ' ') { i = i + 1; }
     for (i < SIZE_LEN) {
         val c: u8 = buf[at + i];
         if (c < '0' || c > '9') {

--- a/src/lang/target/of/ar.mach
+++ b/src/lang/target/of/ar.mach
@@ -91,12 +91,13 @@ pub fun first_member() usize {
 
 # next_member: read the member header at `pos` and yield its content slice.
 #
-# parses the 60-byte header, decodes the decimal-ASCII size, and returns the
-# member's `(data, len)` slice plus the offset of the following header (the
-# member is padded to an even boundary). a truncated or non-numeric header is a
-# hard stop (`ok` false). reaching the end of the buffer ends iteration
-# (`done` true). bookkeeping members (`/`, `//`, `__.SYMDEF`) are still yielded
-# here — the caller filters them via `is_special` — so offsets stay exact.
+# parses the 60-byte header, validates the `\x60\n` terminator, decodes the
+# decimal-ASCII size, and returns the member's `(data, len)` slice plus the
+# offset of the following header (the member is padded to an even boundary).
+# `pos == len` is the clean end of iteration (`done` true); a truncated header,
+# missing terminator, non-numeric size, out-of-bounds body, or missing pad byte
+# is a hard stop (`ok` false). bookkeeping members are still yielded here — the
+# caller filters them via `is_special` — so offsets stay exact.
 # ---
 # buf: the archive bytes
 # len: length of `buf`
@@ -110,9 +111,14 @@ pub fun next_member(buf: *u8, len: usize, pos: usize) Step {
     st.done        = false;
     st.ok          = true;
 
-    # no room for another header: clean end of archive.
-    if (pos >= len || len - pos < HEADER_LEN) {
+    # exactly at the end: clean end of archive.
+    if (pos == len) {
         st.done = true;
+        ret st;
+    }
+    # trailing bytes too short for a header: a truncated archive, not a clean end.
+    if (pos > len || len - pos < HEADER_LEN) {
+        st.ok = false;
         ret st;
     }
 
@@ -122,9 +128,18 @@ pub fun next_member(buf: *u8, len: usize, pos: usize) Step {
         ret st;
     }
 
-    val size: usize = parse_size(buf, pos + SIZE_OFFSET);
+    # the size field must be a non-empty run of decimal digits.
+    var ok_size: bool = false;
+    val size: usize = parse_size(buf, pos + SIZE_OFFSET, ?ok_size);
+    if (!ok_size) {
+        st.ok = false;
+        ret st;
+    }
+
+    # the member body must fit; check against the remaining bytes so the sum
+    # cannot overflow `usize`.
     val data_start: usize = pos + HEADER_LEN;
-    if (data_start + size > len) {
+    if (size > len - data_start) {
         st.ok = false;
         ret st;
     }
@@ -132,50 +147,86 @@ pub fun next_member(buf: *u8, len: usize, pos: usize) Step {
     st.member.data = (buf::usize + data_start)::*u8;
     st.member.len  = size;
 
-    # members are padded to an even byte boundary with a trailing `\n`.
+    # members are padded to an even byte boundary with a trailing `\n`; an
+    # odd-sized member that runs to the very end is missing its pad — truncated.
     var after: usize = data_start + size;
-    if ((size & 1) == 1) { after = after + 1; }
+    if ((size & 1) == 1) {
+        if (after >= len) {
+            st.ok = false;
+            ret st;
+        }
+        after = after + 1;
+    }
     st.next = after;
     ret st;
 }
 
 # is_special: whether a member is archive bookkeeping rather than an object.
 #
-# an archiver prepends a symbol directory (`/` under GNU ar, `__.SYMDEF` under
-# BSD ar) and, under GNU ar, a long-name table (`//`); neither is an object and
-# both must be skipped. the member name is the first 16 bytes of its header,
-# space-padded; this matches the special names by their leading bytes.
+# an archiver prepends a symbol directory and, under GNU ar, a long-name table;
+# neither is an object and both must be skipped. the member name is the first 16
+# bytes of the header, space-padded. the recognized bookkeeping names are:
+#   `/`       — GNU symbol table (header: `/` then spaces)
+#   `/SYM64/` — GNU 64-bit symbol table
+#   `//`      — GNU long-name table
+#   `__.SYMDEF`, `__.SYMDEF SORTED` — BSD symbol table
+# a `/<digits>` name is a long-name *reference* for a real object, so a `/`
+# followed by a digit is deliberately not treated as special.
 # ---
 # buf: the archive bytes
 # pos: offset of the member header
-# ret: true if the member is a symbol directory or name table
+# ret: true if the member is a symbol table or long-name table
 pub fun is_special(buf: *u8, pos: usize) bool {
     val c0: u8 = buf[pos];
     val c1: u8 = buf[pos + 1];
-    # "/ " or "//" — GNU symbol directory / long-name table.
-    if (c0 == '/' && (c1 == ' ' || c1 == '/')) { ret true; }
-    # "__.SYMDEF" — BSD symbol directory.
-    if (c0 == '_' && c1 == '_' && buf[pos + 2] == '.') { ret true; }
+    if (c0 == '/') {
+        # "/ " GNU symbol table, "//" long-name table, "/SYM64/" 64-bit table.
+        # a "/<digit>" name is an object's long-name reference, not special.
+        if (c1 == ' ' || c1 == '/') { ret true; }
+        if (name_has_prefix(buf, pos, "/SYM64/")) { ret true; }
+        ret false;
+    }
+    # BSD symbol table, matched by its exact name prefix.
+    if (name_has_prefix(buf, pos, "__.SYMDEF")) { ret true; }
     ret false;
+}
+
+# name_has_prefix: whether the member name at `pos` begins with the literal
+# `pre`. the name occupies the first 16 header bytes; this compares only `pre`'s
+# bytes, so a longer name sharing the prefix (e.g. `__.SYMDEF SORTED`) matches.
+fun name_has_prefix(buf: *u8, pos: usize, pre: *u8) bool {
+    var i: usize = 0;
+    for (pre[i] != 0) {
+        if (buf[pos + i] != pre[i]) { ret false; }
+        i = i + 1;
+    }
+    ret true;
 }
 
 # parse_size: decode the right-space-padded decimal-ASCII size field at `at`.
 #
 # the `ar` size field is `SIZE_LEN` bytes of decimal digits padded with trailing
-# spaces. non-digit bytes (the padding) terminate the scan. returns the decoded
-# byte count.
+# spaces. non-digit bytes (the padding) terminate the scan. a field with no
+# leading digit is malformed — `ok` is set false and the return value is unused.
 # ---
 # buf: the archive bytes
 # at:  offset of the size field
+# ok:  out — true if at least one leading digit was decoded
 # ret: the decoded member size in bytes
-fun parse_size(buf: *u8, at: usize) usize {
+fun parse_size(buf: *u8, at: usize, ok: *bool) usize {
     var v: usize = 0;
+    var n: usize = 0;
     var i: usize = 0;
     for (i < SIZE_LEN) {
         val c: u8 = buf[at + i];
-        if (c < '0' || c > '9') { ret v; }
+        if (c < '0' || c > '9') {
+            @ok = (n > 0);
+            ret v;
+        }
         v = v * 10 + (c - '0')::usize;
+        n = n + 1;
         i = i + 1;
     }
+    @ok = (n > 0);
     ret v;
 }

--- a/src/lang/target/of/ar.mach
+++ b/src/lang/target/of/ar.mach
@@ -1,0 +1,181 @@
+# mach.lang.target.of.ar: Unix `ar` static-archive reader.
+#
+# A static library (`.a`) is a flat `ar` archive: the 8-byte magic `!<arch>\n`
+# followed by a sequence of members, each a 60-byte fixed header (name, mtime,
+# uid, gid, mode, decimal-ASCII size, and the `\x60\n` terminator) immediately
+# followed by `size` content bytes, padded with a single `\n` to an even
+# boundary. The reader is format-agnostic: it only frames the archive and yields
+# each ordinary member as a `(data, len)` byte slice into the original buffer.
+# The linker hands each slice to the active object format's `parse_object`, so an
+# archive joins the link as the same `of.ObjectImage` stream a loose `.o` does.
+#
+# Member-selection policy (v1): every ordinary member is pulled, not just the
+# ones that satisfy an undefined symbol. Classic `ar` semantics — consult the
+# archive symbol table and pull only needed members — is a deliberate non-goal
+# here; the linker already rejects only duplicate *strong* definitions, and an
+# archive's members rarely collide, so pulling all members links correctly at the
+# cost of carrying unreferenced ones. The reader skips the bookkeeping members an
+# archiver inserts (the `/` symbol directory and the `//` long-name table), since
+# those are not objects.
+
+use std.types.bool.bool;
+use std.types.bool.true;
+use std.types.bool.false;
+use std.types.size.usize;
+
+# the 8-byte archive magic that opens every `ar` file.
+val MAGIC_LEN: usize = 8;
+# fixed size of a member header, in bytes.
+val HEADER_LEN: usize = 60;
+# byte offset of the decimal-ASCII size field within a member header.
+val SIZE_OFFSET: usize = 48;
+# width of the size field, in bytes.
+val SIZE_LEN: usize = 10;
+
+# one archive member yielded by the cursor: a byte slice into the archive buffer.
+# the slice is borrowed — it points into the caller's buffer and is valid only
+# while that buffer lives.
+# ---
+# data: pointer to the member's first content byte
+# len:  member content length in bytes
+pub rec Member {
+    data: *u8;
+    len:  usize;
+}
+
+# the result of advancing the cursor: the member found (when `ok` and not `done`)
+# and the buffer offset just past it. iteration ends when `done` is true; a
+# malformed header sets `ok` false so the caller can reject the archive.
+# ---
+# member: the member yielded (valid only when ok && !done)
+# next:   buffer offset of the following member header
+# done:   true once no more members remain
+# ok:     false if the header at the cursor was malformed
+pub rec Step {
+    member: Member;
+    next:   usize;
+    done:   bool;
+    ok:     bool;
+}
+
+# is_archive: whether `buf` opens with the `!<arch>\n` magic.
+#
+# the cheap discriminant the linker uses to route an input file to the archive
+# reader instead of the object parser.
+# ---
+# buf: the file bytes
+# len: length of `buf`
+# ret: true if `buf` is an `ar` archive
+pub fun is_archive(buf: *u8, len: usize) bool {
+    if (buf == nil || len < MAGIC_LEN) { ret false; }
+    if (buf[0] != '!') { ret false; }
+    if (buf[1] != '<') { ret false; }
+    if (buf[2] != 'a') { ret false; }
+    if (buf[3] != 'r') { ret false; }
+    if (buf[4] != 'c') { ret false; }
+    if (buf[5] != 'h') { ret false; }
+    if (buf[6] != '>') { ret false; }
+    if (buf[7] != 0x0A) { ret false; }
+    ret true;
+}
+
+# first_member: the buffer offset where member iteration begins.
+#
+# always just past the 8-byte magic. paired with `next_member` to walk an
+# archive: `for (var pos = first_member(); !step.done; pos = step.next)`.
+# ---
+# ret: the offset of the first member header
+pub fun first_member() usize {
+    ret MAGIC_LEN;
+}
+
+# next_member: read the member header at `pos` and yield its content slice.
+#
+# parses the 60-byte header, decodes the decimal-ASCII size, and returns the
+# member's `(data, len)` slice plus the offset of the following header (the
+# member is padded to an even boundary). a truncated or non-numeric header is a
+# hard stop (`ok` false). reaching the end of the buffer ends iteration
+# (`done` true). bookkeeping members (`/`, `//`, `__.SYMDEF`) are still yielded
+# here — the caller filters them via `is_special` — so offsets stay exact.
+# ---
+# buf: the archive bytes
+# len: length of `buf`
+# pos: offset of the member header to read
+# ret: a `Step` describing the member and the next position
+pub fun next_member(buf: *u8, len: usize, pos: usize) Step {
+    var st: Step;
+    st.member.data = nil;
+    st.member.len  = 0;
+    st.next        = pos;
+    st.done        = false;
+    st.ok          = true;
+
+    # no room for another header: clean end of archive.
+    if (pos >= len || len - pos < HEADER_LEN) {
+        st.done = true;
+        ret st;
+    }
+
+    # the header must end with the `\x60\n` magic; reject anything else.
+    if (buf[pos + 58] != 0x60 || buf[pos + 59] != 0x0A) {
+        st.ok = false;
+        ret st;
+    }
+
+    val size: usize = parse_size(buf, pos + SIZE_OFFSET);
+    val data_start: usize = pos + HEADER_LEN;
+    if (data_start + size > len) {
+        st.ok = false;
+        ret st;
+    }
+
+    st.member.data = (buf::usize + data_start)::*u8;
+    st.member.len  = size;
+
+    # members are padded to an even byte boundary with a trailing `\n`.
+    var after: usize = data_start + size;
+    if ((size & 1) == 1) { after = after + 1; }
+    st.next = after;
+    ret st;
+}
+
+# is_special: whether a member is archive bookkeeping rather than an object.
+#
+# an archiver prepends a symbol directory (`/` under GNU ar, `__.SYMDEF` under
+# BSD ar) and, under GNU ar, a long-name table (`//`); neither is an object and
+# both must be skipped. the member name is the first 16 bytes of its header,
+# space-padded; this matches the special names by their leading bytes.
+# ---
+# buf: the archive bytes
+# pos: offset of the member header
+# ret: true if the member is a symbol directory or name table
+pub fun is_special(buf: *u8, pos: usize) bool {
+    val c0: u8 = buf[pos];
+    val c1: u8 = buf[pos + 1];
+    # "/ " or "//" — GNU symbol directory / long-name table.
+    if (c0 == '/' && (c1 == ' ' || c1 == '/')) { ret true; }
+    # "__.SYMDEF" — BSD symbol directory.
+    if (c0 == '_' && c1 == '_' && buf[pos + 2] == '.') { ret true; }
+    ret false;
+}
+
+# parse_size: decode the right-space-padded decimal-ASCII size field at `at`.
+#
+# the `ar` size field is `SIZE_LEN` bytes of decimal digits padded with trailing
+# spaces. non-digit bytes (the padding) terminate the scan. returns the decoded
+# byte count.
+# ---
+# buf: the archive bytes
+# at:  offset of the size field
+# ret: the decoded member size in bytes
+fun parse_size(buf: *u8, at: usize) usize {
+    var v: usize = 0;
+    var i: usize = 0;
+    for (i < SIZE_LEN) {
+        val c: u8 = buf[at + i];
+        if (c < '0' || c > '9') { ret v; }
+        v = v * 10 + (c - '0')::usize;
+        i = i + 1;
+    }
+    ret v;
+}


### PR DESCRIPTION
Closes #1166.

Extends external linking (#1165) to static `ar` archives: a `.a` joins the link as the same `of.ObjectImage` stream a loose `.o` does, so it resolves undefined `ext` / in-graph symbols exactly like a loose object.

## Changes

- **`src/lang/target/of/ar.mach`** (new): a Unix `ar` reader. `is_archive` detects the `!<arch>\n` magic; a member cursor (`first_member` / `next_member`) decodes the 60-byte headers and yields each member as a `(data, len)` slice into the archive buffer; `is_special` filters the `/` symbol directory (GNU), `//` long-name table, and `__.SYMDEF` (BSD). Format-agnostic — it only frames the archive.
- **`src/lang/be/linker.mach`**: `read_objects` now grows the image array one slot per parsed object and, when an input file opens with the `ar` magic, expands it into one image per member object via the active format's `parse_object`. The true module count (≥ input-path count) flows back to `link`. Member slices borrow the archive buffer, which is kept alive across parsing.
- **`src/cli/cmd/build.mach`**: `is_object_path` accepts a `.a` suffix; `-l <name>` resolution probes `lib<name>.a` / `<name>.a` after the existing `lib<name>.o` / `<name>.o` candidates (loose objects still win first, so `.o` resolution is unchanged). Explicit `.a` path arguments and `[targets.*].libs` archive entries flow through the existing resolution path.
- **`src/lang/driver.mach`**: doc-only — the `libs` field now documents `.a` archives alongside `.o` objects.

## Member-selection policy (v1)

Every object member of an archive is pulled, not only the ones that satisfy an undefined symbol. The linker already rejects only duplicate **strong** definitions, so pulling all members links correctly; on-demand member selection (consulting the archive symbol table) is a documented non-goal for v1. A consequence verified in testing: an archive with two members that strongly define the same symbol correctly fails the link with `multiple definition`.

## Test

`.github/tests/extlink/run.sh` is extended to build the `extlib` object into a `.a` (via `ar rcs`) and link the `app` consumer against it through each supported surface — explicit `.a` path, `-L`/`-l`, and `[targets.*].libs` — asserting it runs and returns 42.

## Gates

- Byte-identical self-host fixpoint: seed `mach build .` → rebuild with the result → `cmp` byte-identical.
- `mach test .` → 200 pass, 0 fail.
