### PR TITLE
feat: compiler-as-library query surface for editor tooling (LSP foundation)

### DIFF
--- a/doc/tooling/editor-api.md
+++ b/doc/tooling/editor-api.md
@@ -1,0 +1,137 @@
+# Editor query surface (`mach.lang.editor`)
+
+The compiler-as-library entry point for editor tooling — language servers,
+plugins, single-file linters. It exposes best-effort analysis of one
+in-memory buffer at a time, without a `mach.toml`, a module graph, or a link
+step. This is the foundation an LSP binds to.
+
+It is built on the same front-end phases the driver uses (`source`, `lexer`,
+`parser`, `resolve`, `diagnostic`) and reuses the session services
+(`SourceMap`, `DiagList`, interners). Every entry tolerates a malformed
+buffer: it records diagnostics and returns a usable partial result rather
+than bailing at the first error.
+
+## Lifecycle
+
+```
+sess.Session            // caller owns; provides SourceMap + DiagList
+  └─ editor.EditorSession   // borrows the session, owns per-buffer analysis
+       └─ Buffer (per FileId)   // owned Ast + ResolveResult, cached
+```
+
+```mach
+var s: sess.Session = unwrap_ok[...](sess.init(?alloc));
+var es: editor.EditorSession = editor.init(?s);
+// ... drive es ...
+editor.dnit(?es);   // frees every buffer's Ast / ResolveResult
+sess.dnit(?s);      // tears the session down (editor never touches it)
+```
+
+The session must outlive the editor session. `editor.dnit` releases only what
+the editor owns (the per-buffer `Ast`, `ResolveResult`, and comptime context);
+the borrowed `SourceMap` and `DiagList` belong to the session.
+
+## API
+
+| Function | Signature | Purpose |
+|---|---|---|
+| `init` | `fun(*sess.Session) EditorSession` | construct the facade over a session |
+| `dnit` | `fun(*EditorSession)` | release owned per-buffer analysis |
+| `open` | `fun(*EditorSession, str, str) Result[src.FileId, str]` | register an unsaved buffer's TEXT, return its FileId |
+| `update` | `fun(*EditorSession, src.FileId, str) Result[bool, str]` | replace a dirty buffer's text; drops cached analysis |
+| `tokenize` | `fun(*EditorSession, src.FileId) Result[lexer.TokenStream, str]` | lex; lex errors land on the DiagList (caller frees the stream) |
+| `parse` | `fun(*EditorSession, src.FileId) Result[*ast.Ast, str]` | best-effort parse; returns the cached `*Ast` |
+| `resolve` | `fun(*EditorSession, src.FileId) Result[*res.ResolveResult, str]` | best-effort name resolution side tables (deps optional) |
+| `diagnostics` | `fun(*EditorSession, src.FileId) Result[*diag.DiagList, str]` | reset + analyze; the session DiagList of this buffer |
+| `ast_of` | `fun(*EditorSession, src.FileId) *ast.Ast` | cached parsed Ast, or nil |
+| `resolve_of` | `fun(*EditorSession, src.FileId) *res.ResolveResult` | cached ResolveResult, or nil |
+
+`open` loads the buffer text into the session's `SourceMap` and bumps the
+query DB revision, so the incremental machinery already invalidates derived
+entries over the file. `update` rebuilds the text and drops the buffer's
+cached `Ast` / `ResolveResult`, so the next `parse` / `resolve` recomputes.
+
+## Diagnostics — the first consumer slice
+
+`diagnostics` runs `tokenize → emit-lex-errors → parse` and returns the
+session `DiagList`. Each `diag.Diagnostic` carries `(severity, file_id, span,
+message, note)`. Map each `span` to a position with `source.position`:
+
+```mach
+val list: *diag.DiagList = unwrap_ok[...](editor.diagnostics(?es, fid));
+var i: usize = 0;
+for (i < list.len) {
+    val d: *diag.Diagnostic = ?list.items[i];
+    val sf: *src.SourceFile = unwrap[...](src.get(?s.sources, d.file_id));
+    val pos: src.Position = src.position(sf, d.span.offset); // 1-based line/col
+    // d.severity, pos.line, pos.col, d.message -> LSP Diagnostic
+    i = i + 1;
+}
+```
+
+The `mach check <file>` CLI command is the in-tree consumer of this slice.
+
+## Position lookup — offset → id
+
+Hover, go-to-definition, and references pivot on finding the AST node under a
+byte offset, then reading the resolve side tables. `mach.lang.fe.ast` provides
+the lookups, each returning the *tightest* (smallest-span) enclosing node, or
+the id-type sentinel when none covers the offset:
+
+```mach
+pub fun offset_to_expr(a: *ast.Ast, offset: usize) id.ExprId   // or id.EXPR_NIL
+pub fun offset_to_stmt(a: *ast.Ast, offset: usize) id.StmtId   // or id.STMT_NIL
+pub fun offset_to_decl(a: *ast.Ast, offset: usize) id.DeclId   // or id.DECL_NIL
+pub fun offset_to_type(a: *ast.Ast, offset: usize) id.TypeId   // or id.TYPE_NIL
+```
+
+From an `ExprId`, the resolve side tables give the binding:
+
+```mach
+val eid: id.ExprId = ast.offset_to_expr(a, offset);
+if (eid != id.EXPR_NIL) {
+    val sid: res.SymbolId = rr.expr_resolved[eid];     // SYMBOL_NIL if unbound
+    if (sid != res.SYMBOL_NIL) {
+        val sym: *res.Symbol = ?rr.symbols[sid];
+        // sym.decl (DeclId in sym.origin's module), sym.kind, sym.name
+    }
+}
+```
+
+`rr.expr_resolved`, `rr.type_resolved`, and `rr.decl_symbol` are parallel to
+`a.exprs`, `a.types`, and `a.decls` respectively.
+
+## Partial-result tolerance
+
+Every phase is best-effort by construction:
+
+- The **lexer** records malformed input as `LexError`s on the stream instead
+  of aborting; `lexer.emit_diagnostics` (and the editor's `tokenize`/`parse`)
+  drains them onto the `DiagList`.
+- The **parser** is explicitly malformed-input tolerant — it emits diagnostics
+  and synthesizes `*_KIND_ERROR` nodes while continuing, so a broken buffer
+  still yields a partial `Ast` with a set `root_module`.
+- **resolve** records name-resolution diagnostics and leaves the offending
+  side-table slots as `SYMBOL_NIL`, producing usable tables over a broken tree.
+
+A buffer with a missing `)` and a stray backtick still parses to a tree
+containing its function declaration, surfaces both the lex and the parse
+error, and resolves to populated side tables.
+
+## Single-buffer scope and deps
+
+`resolve` analyzes the buffer in isolation with an empty dependency set:
+local declarations bind, but cross-module references (anything reached through
+a `use`) resolve to `SYMBOL_NIL`. The comptime context is seeded with neutral
+host defaults, so `$if` predicates evaluate against the host os/arch only.
+Full cross-module resolution remains the driver's job (`driver.build_project`).
+
+## Relationship to the query DB
+
+This surface drives the front-end phases directly rather than routing through
+`query.QueryDb.get(Q_PARSE / Q_RESOLVE)`. The derived query shards are not
+registered until the query DB is wired into the build (issue #1164). The
+buffer is still registered as a real source input whose revision the
+`Q_FILE_TEXT` metadata source reads, so the incremental story is preserved;
+the `get`-routed form of these entries can land with #1164 without changing
+this module's signatures.

--- a/src/cli/cmd.mach
+++ b/src/cli/cmd.mach
@@ -15,6 +15,7 @@ use os: std.system.os;
 use cmd_build: mach.cli.cmd.build;
 use cmd_run:   mach.cli.cmd.run;
 use cmd_test:  mach.cli.cmd.testing;
+use cmd_check: mach.cli.cmd.check;
 use cmd_dep:   mach.cli.cmd.dep;
 use cmd_init:  mach.cli.cmd.init;
 use cmd_doc:   mach.cli.cmd.doc;
@@ -72,6 +73,7 @@ pub fun dispatch(argc: usize, argv: **u8) i64 {
     if (eq(command, "build")) { ret cmd_build.run(argc, argv); }
     if (eq(command, "run"))   { ret cmd_run.run(argc, argv); }
     if (eq(command, "test"))  { ret cmd_test.run(argc, argv); }
+    if (eq(command, "check")) { ret cmd_check.run(argc, argv); }
     if (eq(command, "dep"))   { ret cmd_dep.run(argc, argv); }
     if (eq(command, "init"))  { ret cmd_init.run(argc, argv); }
     if (eq(command, "doc"))   { ret cmd_doc.run(argc, argv); }

--- a/src/cli/cmd/check.mach
+++ b/src/cli/cmd/check.mach
@@ -1,0 +1,224 @@
+# mach.cli.cmd.check: `mach check <file>` — single-file diagnostics without a project.
+#
+# the editor-facing diagnostics slice exposed as a CLI verb: read one
+# source file, feed its TEXT directly into the editor query surface
+# (mach.lang.editor), and render every reported diagnostic as
+# `severity: path:line:col: message` with a caret underline. needs no
+# mach.toml, no module graph, and no link step — it is best-effort over a
+# single buffer, exactly what an editor wants, and the in-tree consumer that
+# exercises the editor surface end-to-end.
+#
+# exit codes: 0 when the buffer has no error-severity diagnostics, 1 when it
+# has any (or on a usage / io error).
+
+use std.types.bool.bool;
+use std.types.bool.true;
+use std.types.bool.false;
+use std.types.size.usize;
+use std.types.string.str;
+use std.types.option.Option;
+use std.types.option.some;
+use std.types.option.none;
+use std.types.option.is_some;
+use std.types.option.is_none;
+use std.types.option.unwrap;
+use std.types.result.Result;
+use std.types.result.is_err;
+use std.types.result.unwrap_ok;
+use std.types.result.unwrap_err;
+
+use std.allocator.Allocator;
+
+use page:  std.allocator.page;
+use arena: std.allocator.arena;
+
+use os: std.system.os;
+use fs: std.filesystem;
+
+use sess:   mach.lang.session;
+use src:    mach.lang.source;
+use diag:   mach.lang.diagnostic;
+use editor: mach.lang.editor;
+use token:  mach.lang.fe.token;
+
+# slen: length in bytes of a null-terminated `*u8` string.
+fun slen(s: *u8) usize {
+    if (s == nil) { ret 0; }
+    var n: usize = 0;
+    for (s[n] != 0) { n = n + 1; }
+    ret n;
+}
+
+# emit: write a null-terminated `*u8` string to stderr.
+fun emit(s: *u8) {
+    os.write(os.STDERR_FD, s, slen(s));
+}
+
+# run: `mach check` subcommand entry point. reads `argv[2]` as the file path,
+# loads it as an unsaved buffer, and prints its diagnostics.
+# ---
+# argc: argument count including argv[0]
+# argv: the argument vector (argc null-terminated byte pointers)
+# ret:  0 when the buffer has no errors, 1 on errors or a usage / io failure
+pub fun run(argc: usize, argv: **u8) i64 {
+    if (argc < 3) {
+        emit("usage: mach check <file>\n");
+        ret 1;
+    }
+    val path: str = argv[2]::str;
+
+    var backing: Allocator;
+    if (is_some[str](page.make(?backing))) {
+        emit("error: failed to initialise allocator\n");
+        ret 1;
+    }
+    var ar: arena.Arena;
+    if (is_some[str](arena.init(?ar, ?backing, 0))) {
+        emit("error: failed to initialise allocator\n");
+        ret 1;
+    }
+    var alloc: Allocator;
+    if (is_some[str](arena.make(?alloc, ?ar))) {
+        arena.dnit(?ar);
+        emit("error: failed to initialise allocator\n");
+        ret 1;
+    }
+
+    val text_r: Result[str, str] = fs.read_all(?alloc, path);
+    if (is_err[str, str](text_r)) {
+        emit("error: cannot read '");
+        emit(path::*u8);
+        emit("'\n");
+        arena.dnit(?ar);
+        ret 1;
+    }
+    val text: str = unwrap_ok[str, str](text_r);
+
+    val sr: Result[sess.Session, str] = sess.init(?alloc);
+    if (is_err[sess.Session, str](sr)) {
+        emit("error: ");
+        emit(unwrap_err[sess.Session, str](sr)::*u8);
+        emit("\n");
+        arena.dnit(?ar);
+        ret 1;
+    }
+    var s: sess.Session = unwrap_ok[sess.Session, str](sr);
+
+    var es: editor.EditorSession = editor.init(?s);
+
+    val code: i64 = check_buffer(?es, ?s, path, text);
+
+    editor.dnit(?es);
+    sess.dnit(?s);
+    arena.dnit(?ar);
+    ret code;
+}
+
+# check_buffer: open the buffer, collect its diagnostics, render them, and
+# return the resulting exit code.
+fun check_buffer(es: *editor.EditorSession, s: *sess.Session, path: str, text: str) i64 {
+    val fr: Result[src.FileId, str] = editor.open(es, path, text);
+    if (is_err[src.FileId, str](fr)) {
+        emit("error: ");
+        emit(unwrap_err[src.FileId, str](fr)::*u8);
+        emit("\n");
+        ret 1;
+    }
+    val fid: src.FileId = unwrap_ok[src.FileId, str](fr);
+
+    val dr: Result[*diag.DiagList, str] = editor.diagnostics(es, fid);
+    if (is_err[*diag.DiagList, str](dr)) {
+        emit("error: ");
+        emit(unwrap_err[*diag.DiagList, str](dr)::*u8);
+        emit("\n");
+        ret 1;
+    }
+    val list: *diag.DiagList = unwrap_ok[*diag.DiagList, str](dr);
+
+    render(s, list);
+    if (diag.has_errors(list)) { ret 1; }
+    ret 0;
+}
+
+# render: print every diagnostic as `severity: path:line:col: message` plus a
+# caret underline marking the span, resolving each span against the session
+# source map.
+fun render(s: *sess.Session, list: *diag.DiagList) {
+    var i: usize = 0;
+    for (i < list.len) {
+        val d: *diag.Diagnostic = ?list.items[i];
+        if (d.severity == diag.SEVERITY_ERROR)   { emit("error: "); }
+        or (d.severity == diag.SEVERITY_WARNING) { emit("warning: "); }
+        or (d.severity == diag.SEVERITY_INFO)    { emit("info: "); }
+        or                                       { emit("help: "); }
+
+        val so: Option[*src.SourceFile] = src.get(?s.sources, d.file_id);
+        if (is_some[*src.SourceFile](so)) {
+            val sf: *src.SourceFile = unwrap[*src.SourceFile](so);
+            val pos: src.Position = src.position(sf, d.span.offset);
+            emit(sf.path::*u8);
+            emit(":");
+            emit_num(pos.line);
+            emit(":");
+            emit_num(pos.col);
+            emit(": ");
+            emit(d.message::*u8);
+            emit("\n");
+            emit_snippet(sf, ?d.span, pos.line);
+        }
+        or {
+            emit(d.message::*u8);
+            emit("\n");
+        }
+        i = i + 1;
+    }
+}
+
+# emit_snippet: render the offending source line followed by a `^~~~` underline
+# aligned under the reported span.
+fun emit_snippet(sf: *src.SourceFile, span: *token.Span, line: usize) {
+    val lbo: Option[src.LineSpan] = src.line_bounds(sf, line);
+    if (is_none[src.LineSpan](lbo)) { ret; }
+    val lb: src.LineSpan = unwrap[src.LineSpan](lbo);
+
+    os.write(os.STDERR_FD, ?sf.text[lb.start], lb.end - lb.start);
+    emit("\n");
+
+    var caret_at: usize = span.offset;
+    if (caret_at < lb.start) { caret_at = lb.start; }
+    if (caret_at > lb.end)   { caret_at = lb.end; }
+
+    var c: usize = lb.start;
+    for (c < caret_at) {
+        if (sf.text[c] == '\t') { emit("\t"); } or { emit(" "); }
+        c = c + 1;
+    }
+
+    emit("^");
+
+    var span_end: usize = span.offset + span.len;
+    if (span_end > lb.end) { span_end = lb.end; }
+    var u: usize = caret_at + 1;
+    for (u < span_end) {
+        emit("~");
+        u = u + 1;
+    }
+    emit("\n");
+}
+
+# emit_num: write the base-10 rendering of `n` to stderr.
+fun emit_num(n: usize) {
+    var buf: [24]u8;
+    var blen: usize = 0;
+    var v: usize = n;
+    if (v == 0) { buf[0] = '0'; blen = 1; }
+    or {
+        var tmp: [24]u8;
+        var t: usize = 0;
+        for (v > 0) { tmp[t] = (v % 10)::u8 + '0'; v = v / 10; t = t + 1; }
+        var ri: usize = 0;
+        for (ri < t) { buf[ri] = tmp[t - 1 - ri]; ri = ri + 1; }
+        blen = t;
+    }
+    os.write(os.STDERR_FD, ?buf[0], blen);
+}

--- a/src/cli/cmd/help.mach
+++ b/src/cli/cmd/help.mach
@@ -56,6 +56,7 @@ fun top_level_usage() {
     out("  build    compile the current project\n");
     out("  run      build and execute the current project\n");
     out("  test     build and run the project's tests\n");
+    out("  check    report diagnostics for a single source file\n");
     out("  dep      manage project dependencies\n");
     out("  init     scaffold a new project\n");
     out("  doc      generate reference documentation\n");
@@ -104,6 +105,15 @@ fun help_test() {
     out("  --list              list the collected tests and exit\n");
     out("\n");
     out("exit: 0 all passed, 1 any failed, 2 build/internal error\n");
+}
+
+fun help_check() {
+    out("usage: mach check <file>\n");
+    out("\n");
+    out("report diagnostics for a single source file, best-effort, with no\n");
+    out("project, module graph, or link step. the editor diagnostics path.\n");
+    out("\n");
+    out("exit: 0 when the file has no errors, 1 on errors or a usage / io failure\n");
 }
 
 fun help_dep() {
@@ -160,6 +170,7 @@ pub fun run(argc: usize, argv: **u8) i64 {
     if (eq(sub, "build")) { help_build(); ret 0; }
     if (eq(sub, "run"))   { help_run();   ret 0; }
     if (eq(sub, "test"))  { help_test();  ret 0; }
+    if (eq(sub, "check")) { help_check(); ret 0; }
     if (eq(sub, "dep"))   { help_dep();   ret 0; }
     if (eq(sub, "init"))  { help_init();  ret 0; }
     if (eq(sub, "doc"))   { help_doc();   ret 0; }

--- a/src/lang/driver.mach
+++ b/src/lang/driver.mach
@@ -1234,6 +1234,11 @@ fun parse_module(p: *Project, mid: sess.ModuleId, fqn: intern.StrId) Result[bool
     val m: *ModuleEntry = ?p.modules[mid::u32];
     m.file_id = file_id;
     m.a       = ast.init(p.s.alloc, file_id);
+    val le_r: Result[bool, str] = lexer.emit_diagnostics(?stream, ?p.s.diags);
+    if (is_err[bool, str](le_r)) {
+        lexer.dnit(?stream, p.s.alloc);
+        ret err[bool, str](unwrap_err[bool, str](le_r));
+    }
     parser.parse(?stream, ?m.a, ?p.s.diags);
     lexer.dnit(?stream, p.s.alloc);
     ret ok[bool, str](true);

--- a/src/lang/editor.mach
+++ b/src/lang/editor.mach
@@ -1,0 +1,512 @@
+# mach.lang.editor: the compiler-as-library query surface for editor tooling.
+#
+# the single entry every editor (LSP server, plugin) binds to. an editor
+# holds dirty, possibly-broken in-memory buffers and wants best-effort
+# analysis of one buffer at a time without a full `driver.build_project`.
+# this module is that path: register a buffer's TEXT directly, then ask for
+# its tokens, its parsed `ast.Ast`, its `res.ResolveResult` side tables,
+# or its diagnostics — each tolerant of a malformed buffer, each returning a
+# usable partial result rather than bailing at the first error.
+#
+# an `EditorSession` borrows a caller-owned `session.Session` (whose
+# `SourceMap` holds the buffer text and whose `DiagList` collects every
+# phase's diagnostics) and owns one `*ast.Ast` plus one `*res.ResolveResult`
+# per registered buffer, indexed by `source.FileId`. teardown frees those.
+#
+# diagnostics are the proven first consumer slice: `diagnostics` runs
+# tokenize -> emit-lex-errors -> parse and leaves every reported span on the
+# session's `DiagList` for the editor to translate into LSP `Diagnostic`s.
+# resolution layers the `ResolveResult` side tables on top for the
+# hover / go-to-def / references features that pivot on offset -> id lookup
+# (see `ast.offset_to_expr` and friends).
+#
+# this surface deliberately drives the front-end phases directly rather than
+# routing through `query.QueryDb.get(Q_PARSE / Q_RESOLVE)`: the derived query
+# shards are not registered until the query DB is wired into the build
+# (issue #1164). the buffer is still registered as a real source input whose
+# revision the `Q_FILE_TEXT` metadata source reads, so the incremental story
+# is preserved; the `get`-routed form of these entries lands with #1164
+# without changing this module's signatures.
+
+use std.types.bool.bool;
+use std.types.bool.true;
+use std.types.bool.false;
+use std.types.size.usize;
+use std.types.string.str;
+use std.types.result.Result;
+use std.types.result.ok;
+use std.types.result.err;
+use std.types.result.is_ok;
+use std.types.result.is_err;
+use std.types.result.unwrap_ok;
+use std.types.result.unwrap_err;
+
+use std.types.option.Option;
+use std.types.option.some;
+use std.types.option.none;
+use std.types.option.is_none;
+use std.types.option.unwrap;
+
+use std.allocator.Allocator;
+use std.allocator.allocate;
+use std.allocator.deallocate;
+use std.allocator.reallocate;
+
+use page: std.allocator.page;
+
+use sess:    mach.lang.session;
+use src:     mach.lang.source;
+use diag:    mach.lang.diagnostic;
+use lexer:   mach.lang.fe.lexer;
+use parser:  mach.lang.fe.parser;
+use res:     mach.lang.fe.resolve;
+use comptime: mach.lang.fe.comptime;
+use ast:     mach.lang.fe.ast;
+use id:      mach.lang.fe.ast.id;
+use intern:  mach.lang.intern;
+
+# Buffer: the per-file analysis state the editor session owns for one
+# registered buffer.
+# ---
+# file_id:  source FileId the buffer is registered under
+# in_use:   whether this slot holds a live buffer (slots are indexed by FileId)
+# a:        owned parsed Ast, or nil before the first `parse`
+# rr:       owned ResolveResult side tables, or nil before the first `resolve`
+# ctx:      comptime context resolve mutates; seeded with neutral host defaults
+pub rec Buffer {
+    file_id: src.FileId;
+    in_use:  bool;
+    a:       *ast.Ast;
+    rr:      *res.ResolveResult;
+    ctx:     comptime.ComptimeCtx;
+}
+
+# EditorSession: the editor-facing facade over a borrowed compiler session.
+# ---
+# s:        borrowed session; owns the SourceMap (buffer text) and DiagList
+# alloc:    allocator for the buffer registry and the per-buffer Ast / ResolveResult
+# buffers:  registry of Buffers indexed by FileId
+# buf_len:  number of slots in `buffers`
+pub rec EditorSession {
+    s:       *sess.Session;
+    alloc:   *Allocator;
+    buffers: *Buffer;
+    buf_len: u32;
+}
+
+# init: construct an editor session over a caller-owned compiler session.
+# the session must outlive the editor session; the editor borrows its
+# SourceMap and DiagList and never tears them down.
+# ---
+# s: the compiler session whose SourceMap and DiagList back this editor
+# ret: a new empty EditorSession
+pub fun init(s: *sess.Session) EditorSession {
+    var es: EditorSession;
+    es.s       = s;
+    es.alloc   = s.alloc;
+    es.buffers = nil;
+    es.buf_len = 0;
+    ret es;
+}
+
+# dnit: release every owned Ast, ResolveResult, and comptime context, plus
+# the buffer registry. the borrowed session is left untouched.
+# ---
+# es: the editor session to tear down; all owned fields are zeroed
+pub fun dnit(es: *EditorSession) {
+    if (es == nil) { ret; }
+    if (es.buffers != nil && es.buf_len > 0) {
+        var i: u32 = 0;
+        for (i < es.buf_len) {
+            free_buffer(es, ?es.buffers[i]);
+            i = i + 1;
+        }
+        deallocate[Buffer](es.alloc, es.buffers, es.buf_len::usize);
+    }
+    es.buffers = nil;
+    es.buf_len = 0;
+}
+
+# open: register an unsaved buffer's TEXT directly and return its FileId.
+# this is the editor's entry into the compiler without a build_project:
+# the text is loaded into the session's SourceMap (bumping the query DB
+# revision so any derived entry over this file invalidates), and a fresh
+# analysis slot is reserved for it. the buffer is not yet parsed.
+# ---
+# es:   the editor session
+# path: a display path for the buffer (the LSP document URI, or any label)
+# text: the buffer's full source text; copied into the session
+# ret:  the FileId the buffer is registered under, or an allocation error
+pub fun open(es: *EditorSession, path: str, text: str) Result[src.FileId, str] {
+    val fid_r: Result[src.FileId, str] = sess.load_source(es.s, path, text);
+    if (is_err[src.FileId, str](fid_r)) { ret fid_r; }
+    val fid: src.FileId = unwrap_ok[src.FileId, str](fid_r);
+
+    val br: Result[*Buffer, str] = ensure_slot(es, fid);
+    if (is_err[*Buffer, str](br)) { ret err[src.FileId, str](unwrap_err[*Buffer, str](br)); }
+
+    ret ok[src.FileId, str](fid);
+}
+
+# update: replace the text of an already-open buffer (an editor keystroke
+# edit). the session's SourceMap text is rebuilt and the query DB revision
+# bumped; the buffer's cached Ast and ResolveResult are dropped so the next
+# `parse` / `resolve` recomputes against the new text. out-of-range or
+# never-opened ids are a no-op returning false.
+# ---
+# es:   the editor session
+# fid:  FileId of the buffer to replace
+# text: the buffer's new full source text
+# ret:  true when the buffer was updated, false when fid is unknown, or an allocation error
+pub fun update(es: *EditorSession, fid: src.FileId, text: str) Result[bool, str] {
+    val b: *Buffer = slot(es, fid);
+    if (b == nil || !b.in_use) { ret ok[bool, str](false); }
+
+    val ur: Result[bool, str] = src.update(?es.s.sources, ?es.s.queries, fid, text);
+    if (is_err[bool, str](ur)) { ret ur; }
+    if (!unwrap_ok[bool, str](ur)) { ret ok[bool, str](false); }
+
+    drop_analysis(es, b);
+    ret ok[bool, str](true);
+}
+
+# tokenize: lex the buffer and surface any lex errors as diagnostics on the
+# session's DiagList. returns the owning TokenStream; the caller frees it
+# with `lexer.dnit`. malformed input is recorded, never aborted.
+# ---
+# es:  the editor session
+# fid: FileId of an open buffer
+# ret: the owning TokenStream, or an error when fid is unknown / on allocation failure
+pub fun tokenize(es: *EditorSession, fid: src.FileId) Result[lexer.TokenStream, str] {
+    val fopt: Option[*src.SourceFile] = src.get(?es.s.sources, fid);
+    if (is_none[*src.SourceFile](fopt)) {
+        ret err[lexer.TokenStream, str]("editor: buffer not open");
+    }
+    val file: *src.SourceFile = unwrap[*src.SourceFile](fopt);
+
+    val tr: Result[lexer.TokenStream, str] = lexer.tokenize(file.text, es.alloc, fid);
+    if (is_err[lexer.TokenStream, str](tr)) { ret tr; }
+    var stream: lexer.TokenStream = unwrap_ok[lexer.TokenStream, str](tr);
+
+    val er: Result[bool, str] = lexer.emit_diagnostics(?stream, ?es.s.diags);
+    if (is_err[bool, str](er)) {
+        lexer.dnit(?stream, es.alloc);
+        ret err[lexer.TokenStream, str](unwrap_err[bool, str](er));
+    }
+    ret ok[lexer.TokenStream, str](stream);
+}
+
+# parse: tokenize and parse the buffer best-effort, returning its `ast.Ast`.
+# lex errors and parse errors land on the session's DiagList; the AST is a
+# usable partial tree even for a broken buffer. the returned Ast is owned by
+# the editor session and cached for this buffer — repeated calls reparse and
+# replace the cached tree. drives `ast.offset_to_*` for position lookups.
+# ---
+# es:  the editor session
+# fid: FileId of an open buffer
+# ret: a borrowed pointer to the buffer's parsed Ast, or an error when fid is unknown / on allocation failure
+pub fun parse(es: *EditorSession, fid: src.FileId) Result[*ast.Ast, str] {
+    val b: *Buffer = slot(es, fid);
+    if (b == nil || !b.in_use) { ret err[*ast.Ast, str]("editor: buffer not open"); }
+
+    val tr: Result[lexer.TokenStream, str] = tokenize(es, fid);
+    if (is_err[lexer.TokenStream, str](tr)) { ret err[*ast.Ast, str](unwrap_err[lexer.TokenStream, str](tr)); }
+    var stream: lexer.TokenStream = unwrap_ok[lexer.TokenStream, str](tr);
+
+    drop_analysis(es, b);
+
+    val ar: Result[*ast.Ast, str] = alloc_ast(es, fid);
+    if (is_err[*ast.Ast, str](ar)) {
+        lexer.dnit(?stream, es.alloc);
+        ret ar;
+    }
+    val a: *ast.Ast = unwrap_ok[*ast.Ast, str](ar);
+
+    parser.parse(?stream, a, ?es.s.diags);
+    lexer.dnit(?stream, es.alloc);
+
+    b.a = a;
+    ret ok[*ast.Ast, str](a);
+}
+
+# resolve: name-resolve the buffer best-effort, returning its
+# `res.ResolveResult` side tables (expr_resolved / type_resolved /
+# decl_symbol). parses first if needed. dependencies are not resolved — the
+# buffer is analyzed in isolation with an empty dep set, so cross-module
+# references resolve to SYMBOL_NIL while everything local still binds. name
+# errors land on the session's DiagList; the side tables remain usable. the
+# returned ResolveResult is owned by the editor session and cached.
+# ---
+# es:  the editor session
+# fid: FileId of an open buffer
+# ret: a borrowed pointer to the buffer's ResolveResult, or an error when fid is unknown / on allocation failure
+pub fun resolve(es: *EditorSession, fid: src.FileId) Result[*res.ResolveResult, str] {
+    val b: *Buffer = slot(es, fid);
+    if (b == nil || !b.in_use) { ret err[*res.ResolveResult, str]("editor: buffer not open"); }
+
+    if (b.a == nil) {
+        val pr: Result[*ast.Ast, str] = parse(es, fid);
+        if (is_err[*ast.Ast, str](pr)) { ret err[*res.ResolveResult, str](unwrap_err[*ast.Ast, str](pr)); }
+    }
+
+    if (b.rr != nil) {
+        res.dnit_result(b.rr);
+        deallocate[res.ResolveResult](es.alloc, b.rr, 1);
+        b.rr = nil;
+    }
+
+    seed_ctx(es, b);
+
+    var deps: res.ResolveDeps;
+    deps.entries = nil;
+    deps.count   = 0;
+
+    val rr_r: Result[res.ResolveResult, str] = res.resolve(es.s, b.a, ?deps, ?b.ctx, fid::sess.ModuleId);
+    if (is_err[res.ResolveResult, str](rr_r)) { ret err[*res.ResolveResult, str](unwrap_err[res.ResolveResult, str](rr_r)); }
+
+    val rr: Result[*res.ResolveResult, str] = allocate[res.ResolveResult](es.alloc, 1);
+    if (is_err[*res.ResolveResult, str](rr)) {
+        var local: res.ResolveResult = unwrap_ok[res.ResolveResult, str](rr_r);
+        res.dnit_result(?local);
+        ret rr;
+    }
+    val slot_rr: *res.ResolveResult = unwrap_ok[*res.ResolveResult, str](rr);
+    @slot_rr = unwrap_ok[res.ResolveResult, str](rr_r);
+    b.rr = slot_rr;
+    ret ok[*res.ResolveResult, str](slot_rr);
+}
+
+# diagnostics: the first consumer slice — analyze the buffer and return the
+# session's DiagList holding every reported diagnostic's `(severity, span,
+# message)`. runs tokenize -> emit-lex-errors -> parse, so the list reflects
+# the buffer's syntactic diagnostics; the editor reads `items[].span` and
+# maps each through `source.position` into an LSP range. the DiagList is
+# borrowed from the session and reset on entry so the result reflects only
+# this buffer's current analysis.
+# ---
+# es:  the editor session
+# fid: FileId of an open buffer
+# ret: a borrowed pointer to the session DiagList, or an error when fid is unknown / on allocation failure
+pub fun diagnostics(es: *EditorSession, fid: src.FileId) Result[*diag.DiagList, str] {
+    diag.dnit(?es.s.diags);
+    es.s.diags = diag.init(es.alloc);
+
+    val pr: Result[*ast.Ast, str] = parse(es, fid);
+    if (is_err[*ast.Ast, str](pr)) { ret err[*diag.DiagList, str](unwrap_err[*ast.Ast, str](pr)); }
+
+    ret ok[*diag.DiagList, str](?es.s.diags);
+}
+
+# ast_of: the buffer's cached parsed Ast, or nil when it has not been parsed.
+# ---
+# es:  the editor session
+# fid: FileId of an open buffer
+# ret: borrowed pointer to the cached Ast, or nil
+pub fun ast_of(es: *EditorSession, fid: src.FileId) *ast.Ast {
+    val b: *Buffer = slot(es, fid);
+    if (b == nil || !b.in_use) { ret nil; }
+    ret b.a;
+}
+
+# resolve_of: the buffer's cached ResolveResult, or nil when it has not been
+# resolved.
+# ---
+# es:  the editor session
+# fid: FileId of an open buffer
+# ret: borrowed pointer to the cached ResolveResult, or nil
+pub fun resolve_of(es: *EditorSession, fid: src.FileId) *res.ResolveResult {
+    val b: *Buffer = slot(es, fid);
+    if (b == nil || !b.in_use) { ret nil; }
+    ret b.rr;
+}
+
+# slot: the Buffer for a FileId, or nil when the id is out of the registry's range.
+fun slot(es: *EditorSession, fid: src.FileId) *Buffer {
+    if (es.buffers == nil || fid::u32 >= es.buf_len) { ret nil; }
+    ret ?es.buffers[fid::u32];
+}
+
+# ensure_slot: grow the buffer registry to cover `fid` and mark its slot in
+# use, returning a pointer to it. new slots between the old length and `fid`
+# are zeroed and left free.
+fun ensure_slot(es: *EditorSession, fid: src.FileId) Result[*Buffer, str] {
+    val needed: u32 = fid::u32 + 1;
+    if (needed > es.buf_len) {
+        var new_len: u32 = es.buf_len;
+        if (new_len == 0) { new_len = 8; }
+        for (new_len < needed) { new_len = new_len * 2; }
+
+        if (es.buffers == nil) {
+            val r: Result[*Buffer, str] = allocate[Buffer](es.alloc, new_len::usize);
+            if (is_err[*Buffer, str](r)) { ret r; }
+            es.buffers = unwrap_ok[*Buffer, str](r);
+        }
+        or {
+            val r: Result[*Buffer, str] = reallocate[Buffer](es.alloc, es.buffers, es.buf_len::usize, new_len::usize);
+            if (is_err[*Buffer, str](r)) { ret r; }
+            es.buffers = unwrap_ok[*Buffer, str](r);
+        }
+
+        var z: u32 = es.buf_len;
+        for (z < new_len) {
+            val nb: *Buffer = ?es.buffers[z];
+            nb.file_id = z::src.FileId;
+            nb.in_use  = false;
+            nb.a       = nil;
+            nb.rr      = nil;
+            nb.ctx     = comptime.init(es.alloc, 0, 0, 8, intern.STR_NIL, intern.STR_NIL);
+            z = z + 1;
+        }
+        es.buf_len = new_len;
+    }
+
+    val b: *Buffer = ?es.buffers[fid::u32];
+    if (b.in_use) {
+        drop_analysis(es, b);
+    }
+    b.file_id = fid;
+    b.in_use  = true;
+    ret ok[*Buffer, str](b);
+}
+
+# alloc_ast: heap a fresh empty Ast for the buffer so the editor can hand
+# back a stable `*ast.Ast` and free it on teardown.
+fun alloc_ast(es: *EditorSession, fid: src.FileId) Result[*ast.Ast, str] {
+    val r: Result[*ast.Ast, str] = allocate[ast.Ast](es.alloc, 1);
+    if (is_err[*ast.Ast, str](r)) { ret r; }
+    val a: *ast.Ast = unwrap_ok[*ast.Ast, str](r);
+    @a = ast.init(es.alloc, fid);
+    ret ok[*ast.Ast, str](a);
+}
+
+# seed_ctx: (re)initialize the buffer's comptime context with neutral host
+# defaults. the editor resolves a buffer in isolation, so no target params or
+# imported constants are bound; `$if` predicates evaluate against the host
+# os / arch only. resets any prior context first.
+fun seed_ctx(es: *EditorSession, b: *Buffer) {
+    comptime.dnit(?b.ctx);
+    b.ctx = comptime.init(es.alloc, 0, 0, 8, intern.STR_NIL, intern.STR_NIL);
+}
+
+# drop_analysis: free a buffer's cached Ast, ResolveResult, and comptime
+# context, leaving the slot in use with empty analysis.
+fun drop_analysis(es: *EditorSession, b: *Buffer) {
+    if (b.rr != nil) {
+        res.dnit_result(b.rr);
+        deallocate[res.ResolveResult](es.alloc, b.rr, 1);
+        b.rr = nil;
+    }
+    if (b.a != nil) {
+        ast.dnit(b.a);
+        deallocate[ast.Ast](es.alloc, b.a, 1);
+        b.a = nil;
+    }
+    comptime.dnit(?b.ctx);
+}
+
+# free_buffer: fully release a registry slot, including its analysis.
+fun free_buffer(es: *EditorSession, b: *Buffer) {
+    if (!b.in_use) { ret; }
+    drop_analysis(es, b);
+    b.in_use = false;
+}
+
+# t_session: build a Session over a page allocator for the editor tests, or
+# ret 1 from the caller on failure.
+fun t_session(alloc: *Allocator) Result[sess.Session, str] {
+    page.make(alloc);
+    ret sess.init(alloc);
+}
+
+test "editor: single-file entry parses a clean buffer with no diagnostics" {
+    var alloc: Allocator;
+    val sr: Result[sess.Session, str] = t_session(?alloc);
+    if (is_err[sess.Session, str](sr)) { ret 1; }
+    var s: sess.Session = unwrap_ok[sess.Session, str](sr);
+    var es: EditorSession = init(?s);
+
+    val fr: Result[src.FileId, str] = open(?es, "buf.mach", "fun f(a: i64) i64 { ret a; }\n");
+    if (is_err[src.FileId, str](fr)) { dnit(?es); sess.dnit(?s); ret 1; }
+    val fid: src.FileId = unwrap_ok[src.FileId, str](fr);
+
+    val ar: Result[*ast.Ast, str] = parse(?es, fid);
+    if (is_err[*ast.Ast, str](ar)) { dnit(?es); sess.dnit(?s); ret 1; }
+    val a: *ast.Ast = unwrap_ok[*ast.Ast, str](ar);
+    if (a.decl_len == 0) { dnit(?es); sess.dnit(?s); ret 1; }
+
+    val dr: Result[*diag.DiagList, str] = diagnostics(?es, fid);
+    if (is_err[*diag.DiagList, str](dr)) { dnit(?es); sess.dnit(?s); ret 1; }
+    if (diag.has_errors(unwrap_ok[*diag.DiagList, str](dr))) { dnit(?es); sess.dnit(?s); ret 1; }
+
+    dnit(?es);
+    sess.dnit(?s);
+    ret 0;
+}
+
+test "editor: broken buffer yields partial AST + diagnostics, never bails" {
+    var alloc: Allocator;
+    val sr: Result[sess.Session, str] = t_session(?alloc);
+    if (is_err[sess.Session, str](sr)) { ret 1; }
+    var s: sess.Session = unwrap_ok[sess.Session, str](sr);
+    var es: EditorSession = init(?s);
+
+    # a missing ')' plus a stray backtick: the parser recovers and the lexer
+    # records the bad char, so we expect both error diagnostics AND a usable
+    # partial AST that still contains the broken function decl.
+    val fr: Result[src.FileId, str] = open(?es, "broken.mach", "fun g(a: i64 { ret a ` ; }\n");
+    if (is_err[src.FileId, str](fr)) { dnit(?es); sess.dnit(?s); ret 1; }
+    val fid: src.FileId = unwrap_ok[src.FileId, str](fr);
+
+    val dr: Result[*diag.DiagList, str] = diagnostics(?es, fid);
+    if (is_err[*diag.DiagList, str](dr)) { dnit(?es); sess.dnit(?s); ret 1; }
+    val list: *diag.DiagList = unwrap_ok[*diag.DiagList, str](dr);
+    if (!diag.has_errors(list)) { dnit(?es); sess.dnit(?s); ret 1; }
+
+    val a: *ast.Ast = ast_of(?es, fid);
+    if (a == nil) { dnit(?es); sess.dnit(?s); ret 1; }
+    if (a.decl_len == 0) { dnit(?es); sess.dnit(?s); ret 1; }
+
+    # offset 0 falls on the `fun g` declaration; the partial tree still
+    # answers an offset -> id query.
+    if (ast.offset_to_decl(a, 2) == id.DECL_NIL) { dnit(?es); sess.dnit(?s); ret 1; }
+
+    # resolve still produces usable side tables over the broken buffer.
+    val rr: Result[*res.ResolveResult, str] = resolve(?es, fid);
+    if (is_err[*res.ResolveResult, str](rr)) { dnit(?es); sess.dnit(?s); ret 1; }
+    val rrp: *res.ResolveResult = unwrap_ok[*res.ResolveResult, str](rr);
+    if (rrp.decl_count != a.decl_len::u32) { dnit(?es); sess.dnit(?s); ret 1; }
+
+    dnit(?es);
+    sess.dnit(?s);
+    ret 0;
+}
+
+test "editor: update drops cached analysis and reparses against new text" {
+    var alloc: Allocator;
+    val sr: Result[sess.Session, str] = t_session(?alloc);
+    if (is_err[sess.Session, str](sr)) { ret 1; }
+    var s: sess.Session = unwrap_ok[sess.Session, str](sr);
+    var es: EditorSession = init(?s);
+
+    val fr: Result[src.FileId, str] = open(?es, "buf.mach", "fun a() {}\n");
+    if (is_err[src.FileId, str](fr)) { dnit(?es); sess.dnit(?s); ret 1; }
+    val fid: src.FileId = unwrap_ok[src.FileId, str](fr);
+
+    val p1: Result[*ast.Ast, str] = parse(?es, fid);
+    if (is_err[*ast.Ast, str](p1)) { dnit(?es); sess.dnit(?s); ret 1; }
+    val n1: usize = unwrap_ok[*ast.Ast, str](p1).decl_len;
+
+    val ur: Result[bool, str] = update(?es, fid, "fun a() {}\nfun b() {}\n");
+    if (is_err[bool, str](ur)) { dnit(?es); sess.dnit(?s); ret 1; }
+    if (!unwrap_ok[bool, str](ur)) { dnit(?es); sess.dnit(?s); ret 1; }
+    # the cached AST is dropped on update.
+    if (ast_of(?es, fid) != nil) { dnit(?es); sess.dnit(?s); ret 1; }
+
+    val p2: Result[*ast.Ast, str] = parse(?es, fid);
+    if (is_err[*ast.Ast, str](p2)) { dnit(?es); sess.dnit(?s); ret 1; }
+    if (unwrap_ok[*ast.Ast, str](p2).decl_len <= n1) { dnit(?es); sess.dnit(?s); ret 1; }
+
+    dnit(?es);
+    sess.dnit(?s);
+    ret 0;
+}

--- a/src/lang/fe/ast.mach
+++ b/src/lang/fe/ast.mach
@@ -5,6 +5,9 @@
 # type_ids, typed_names, field_inits, generic_names,
 # comptime_branches).
 
+use std.types.bool.bool;
+use std.types.bool.true;
+use std.types.bool.false;
 use std.types.option.Option;
 use std.types.option.some;
 use std.types.option.none;
@@ -21,6 +24,8 @@ use std.allocator.Allocator;
 use std.allocator.allocate;
 use std.allocator.deallocate;
 use std.allocator.reallocate;
+
+use page: std.allocator.page;
 
 use token: mach.lang.fe.token;
 use src:   mach.lang.source;
@@ -703,6 +708,115 @@ pub fun add_expr_id(a: *Ast, id_: id.ExprId) Result[u32, str] {
     ret ok[u32, str](index);
 }
 
+# span_contains: reports whether a span covers a byte offset, treating the
+# span as the half-open range [offset, offset + len). a zero-length span
+# covers nothing.
+# ---
+# span:   the byte range to test
+# offset: byte offset into the source text
+# ret:    true when offset falls inside the span
+pub fun span_contains(span: token.Span, offset: usize) bool {
+    if (span.len == 0) { ret false; }
+    if (offset < span.offset) { ret false; }
+    ret offset < span.offset + span.len;
+}
+
+# offset_to_expr: the tightest Expr whose span covers `offset`, or EXPR_NIL
+# when no expression node contains it. "tightest" means the smallest-length
+# enclosing span, so a nested expression wins over its parent; ties resolve
+# to the later (higher-id) node, which is the more deeply nested one under
+# the parser's bottom-up construction order. drives hover / go-to-def by
+# byte position over the resolve side tables.
+# ---
+# a:      the Ast to scan
+# offset: byte offset into the Ast's source file
+# ret:    the enclosing ExprId, or id.EXPR_NIL when none covers offset
+pub fun offset_to_expr(a: *Ast, offset: usize) id.ExprId {
+    var best: id.ExprId = id.EXPR_NIL;
+    var best_len: usize = 0;
+    var i: usize = 0;
+    for (i < a.expr_len) {
+        val sp: token.Span = a.exprs[i].span;
+        if (span_contains(sp, offset)) {
+            if (best == id.EXPR_NIL || sp.len <= best_len) {
+                best = i::id.ExprId;
+                best_len = sp.len;
+            }
+        }
+        i = i + 1;
+    }
+    ret best;
+}
+
+# offset_to_stmt: the tightest Stmt whose span covers `offset`, or STMT_NIL
+# when no statement node contains it. see offset_to_expr for the tie rule.
+# ---
+# a:      the Ast to scan
+# offset: byte offset into the Ast's source file
+# ret:    the enclosing StmtId, or id.STMT_NIL when none covers offset
+pub fun offset_to_stmt(a: *Ast, offset: usize) id.StmtId {
+    var best: id.StmtId = id.STMT_NIL;
+    var best_len: usize = 0;
+    var i: usize = 0;
+    for (i < a.stmt_len) {
+        val sp: token.Span = a.stmts[i].span;
+        if (span_contains(sp, offset)) {
+            if (best == id.STMT_NIL || sp.len <= best_len) {
+                best = i::id.StmtId;
+                best_len = sp.len;
+            }
+        }
+        i = i + 1;
+    }
+    ret best;
+}
+
+# offset_to_decl: the tightest Decl whose span covers `offset`, or DECL_NIL
+# when no declaration node contains it. see offset_to_expr for the tie rule.
+# ---
+# a:      the Ast to scan
+# offset: byte offset into the Ast's source file
+# ret:    the enclosing DeclId, or id.DECL_NIL when none covers offset
+pub fun offset_to_decl(a: *Ast, offset: usize) id.DeclId {
+    var best: id.DeclId = id.DECL_NIL;
+    var best_len: usize = 0;
+    var i: usize = 0;
+    for (i < a.decl_len) {
+        val sp: token.Span = a.decls[i].span;
+        if (span_contains(sp, offset)) {
+            if (best == id.DECL_NIL || sp.len <= best_len) {
+                best = i::id.DeclId;
+                best_len = sp.len;
+            }
+        }
+        i = i + 1;
+    }
+    ret best;
+}
+
+# offset_to_type: the tightest Type whose span covers `offset`, or TYPE_NIL
+# when no type node contains it. see offset_to_expr for the tie rule.
+# ---
+# a:      the Ast to scan
+# offset: byte offset into the Ast's source file
+# ret:    the enclosing TypeId, or id.TYPE_NIL when none covers offset
+pub fun offset_to_type(a: *Ast, offset: usize) id.TypeId {
+    var best: id.TypeId = id.TYPE_NIL;
+    var best_len: usize = 0;
+    var i: usize = 0;
+    for (i < a.type_len) {
+        val sp: token.Span = a.types[i].span;
+        if (span_contains(sp, offset)) {
+            if (best == id.TYPE_NIL || sp.len <= best_len) {
+                best = i::id.TypeId;
+                best_len = sp.len;
+            }
+        }
+        i = i + 1;
+    }
+    ret best;
+}
+
 # add_type_id: appends a TypeId to the type_ids pool, used for node-owned lists of TypeIds (generic argument lists, function parameter type lists).
 # ---
 # a:   target Ast
@@ -730,4 +844,63 @@ pub fun add_type_id(a: *Ast, id_: id.TypeId) Result[u32, str] {
     a.type_ids[a.type_id_len] = id_;
     a.type_id_len = a.type_id_len + 1;
     ret ok[u32, str](index);
+}
+
+# t_span: build a Span from an offset and length, for the offset-lookup tests.
+fun t_span(offset: usize, len: usize) token.Span {
+    var sp: token.Span;
+    sp.offset = offset;
+    sp.len    = len;
+    ret sp;
+}
+
+# t_expr: build an IDENT Expr covering [offset, offset+len), for the tests.
+fun t_expr(offset: usize, len: usize) expr.Expr {
+    var e: expr.Expr;
+    e.span = t_span(offset, len);
+    e.kind = expr.EXPR_KIND_IDENT;
+    ret e;
+}
+
+test "ast: span_contains is half-open over the span range" {
+    val sp: token.Span = t_span(10, 3);
+    if (span_contains(sp, 9))  { ret 1; }
+    if (!span_contains(sp, 10)) { ret 1; }
+    if (!span_contains(sp, 12)) { ret 1; }
+    if (span_contains(sp, 13)) { ret 1; }
+    if (span_contains(t_span(5, 0), 5)) { ret 1; }
+    ret 0;
+}
+
+test "ast: offset_to_expr returns the tightest enclosing expression" {
+    var alloc: Allocator;
+    page.make(?alloc);
+    var a: Ast = init(?alloc, 0::src.FileId);
+
+    # outer covers [0,10); inner covers [2,5); both contain offset 3.
+    val outer: Result[id.ExprId, str] = add_expr(?a, t_expr(0, 10));
+    if (is_err[id.ExprId, str](outer)) { dnit(?a); ret 1; }
+    val inner: Result[id.ExprId, str] = add_expr(?a, t_expr(2, 3));
+    if (is_err[id.ExprId, str](inner)) { dnit(?a); ret 1; }
+    val inner_id: id.ExprId = unwrap_ok[id.ExprId, str](inner);
+    val outer_id: id.ExprId = unwrap_ok[id.ExprId, str](outer);
+
+    if (offset_to_expr(?a, 3) != inner_id) { dnit(?a); ret 1; }
+    if (offset_to_expr(?a, 7) != outer_id) { dnit(?a); ret 1; }
+    if (offset_to_expr(?a, 99) != id.EXPR_NIL) { dnit(?a); ret 1; }
+    dnit(?a);
+    ret 0;
+}
+
+test "ast: offset_to_stmt / decl / type miss returns the right nil" {
+    var alloc: Allocator;
+    page.make(?alloc);
+    var a: Ast = init(?alloc, 0::src.FileId);
+
+    if (offset_to_expr(?a, 0) != id.EXPR_NIL) { dnit(?a); ret 1; }
+    if (offset_to_stmt(?a, 0) != id.STMT_NIL) { dnit(?a); ret 1; }
+    if (offset_to_decl(?a, 0) != id.DECL_NIL) { dnit(?a); ret 1; }
+    if (offset_to_type(?a, 0) != id.TYPE_NIL) { dnit(?a); ret 1; }
+    dnit(?a);
+    ret 0;
 }

--- a/src/lang/fe/lexer.mach
+++ b/src/lang/fe/lexer.mach
@@ -21,8 +21,11 @@ use std.allocator.allocate;
 use std.allocator.deallocate;
 use std.allocator.reallocate;
 
+use page: std.allocator.page;
+
 use token:   mach.lang.fe.token;
 use src:     mach.lang.source;
+use diag:    mach.lang.diagnostic;
 use strutil: std.types.string;
 
 # error code stored in LexError.code, one per malformed-input category
@@ -389,6 +392,37 @@ pub fun text(stream: *TokenStream, tok: token.Token) strutil.StrView {
     ret strutil.view(?stream.source[tok.span.offset], tok.span.len);
 }
 
+# err_message: the human-readable message for a LEX_ERR_* code.
+# ---
+# code: one of the LEX_ERR_* constants
+# ret:  a static message describing the malformed-input category
+fun err_message(code: u8) str {
+    if (code == LEX_ERR_UNTERMINATED_STR)  { ret "unterminated string literal"; }
+    if (code == LEX_ERR_UNTERMINATED_CHAR) { ret "unterminated character literal"; }
+    ret "unexpected character";
+}
+
+# emit_diagnostics: push every accumulated lex error onto a diagnostic sink
+# as a SEVERITY_ERROR carrying the error's span and the stream's file id.
+# the lexer records malformed input on the stream rather than aborting, and
+# the parser never reads that buffer, so a caller wanting complete
+# diagnostics for a buffer must drain the lex errors through this before
+# tearing the stream down. a no-op when the stream has no errors.
+# ---
+# stream: the lexed stream whose errors are drained
+# diags:  diagnostic sink the lex errors are appended to
+# ret:    true on success, or the first allocation error from the sink
+pub fun emit_diagnostics(stream: *TokenStream, diags: *diag.DiagList) Result[bool, str] {
+    var i: usize = 0;
+    for (i < stream.error_len) {
+        val e: *LexError = ?stream.errors[i];
+        val r: Result[bool, str] = diag.error(diags, stream.file_id, e.span, err_message(e.code));
+        if (is_err[bool, str](r)) { ret r; }
+        i = i + 1;
+    }
+    ret ok[bool, str](true);
+}
+
 fun push_error(stream: *TokenStream, alloc: *Allocator, offset: usize, len: usize, code: u8) Result[bool, str] {
     if (stream.errors == nil) {
         val r: Result[*LexError, str] = allocate[LexError](alloc, INITIAL_ERROR_CAP);
@@ -447,4 +481,28 @@ fun is_ident_char(c: u8) bool {
 
 fun is_hex_char(c: u8) bool {
     ret (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F');
+}
+
+test "lexer: emit_diagnostics drains lex errors onto the sink" {
+    var alloc: Allocator;
+    page.make(?alloc);
+
+    # a backtick is not a valid token; the lexer records it as a lex error
+    # rather than aborting, and emit_diagnostics surfaces it as a diagnostic.
+    val tr: Result[TokenStream, str] = tokenize("a ` b", ?alloc, 0::src.FileId);
+    if (is_err[TokenStream, str](tr)) { ret 1; }
+    var stream: TokenStream = unwrap_ok[TokenStream, str](tr);
+    if (stream.error_len == 0) { dnit(?stream, ?alloc); ret 1; }
+
+    var diags: diag.DiagList = diag.init(?alloc);
+    val er: Result[bool, str] = emit_diagnostics(?stream, ?diags);
+    if (is_err[bool, str](er)) { dnit(?stream, ?alloc); diag.dnit(?diags); ret 1; }
+
+    if (diags.len != stream.error_len) { dnit(?stream, ?alloc); diag.dnit(?diags); ret 1; }
+    if (diags.items[0].severity != diag.SEVERITY_ERROR) { dnit(?stream, ?alloc); diag.dnit(?diags); ret 1; }
+    if (diags.items[0].span.offset != 2) { dnit(?stream, ?alloc); diag.dnit(?diags); ret 1; }
+
+    diag.dnit(?diags);
+    dnit(?stream, ?alloc);
+    ret 0;
 }


### PR DESCRIPTION
Closes #1183. Unblocks octalide/mach-lsp#33.

Delivers the three foundation items the mach-lsp#33 assessment named, plus the diagnostics consumer slice proven end-to-end.

## What landed

**1. Single-file / unsaved-buffer query entry — `mach.lang.editor`**
The compiler-as-library entry an LSP binds to. An `EditorSession` borrows a caller-owned `session.Session` and owns one `Ast` + `ResolveResult` per buffer (keyed by `FileId`). Feed buffer TEXT directly; analyze one file best-effort without `driver.build_project`.

```mach
pub fun init(s: *sess.Session) EditorSession
pub fun dnit(es: *EditorSession)
pub fun open(es: *EditorSession, path: str, text: str) Result[src.FileId, str]
pub fun update(es: *EditorSession, fid: src.FileId, text: str) Result[bool, str]
pub fun tokenize(es: *EditorSession, fid: src.FileId) Result[lexer.TokenStream, str]
pub fun parse(es: *EditorSession, fid: src.FileId) Result[*ast.Ast, str]
pub fun resolve(es: *EditorSession, fid: src.FileId) Result[*res.ResolveResult, str]
pub fun diagnostics(es: *EditorSession, fid: src.FileId) Result[*diag.DiagList, str]
pub fun ast_of(es: *EditorSession, fid: src.FileId) *ast.Ast
pub fun resolve_of(es: *EditorSession, fid: src.FileId) *res.ResolveResult
```

**2. Offset → id lookup on `Ast`** (`mach.lang.fe.ast`)
Returns the tightest (smallest-span) enclosing node, or the id-type sentinel on a miss.

```mach
pub fun span_contains(span: token.Span, offset: usize) bool
pub fun offset_to_expr(a: *Ast, offset: usize) id.ExprId   // or id.EXPR_NIL
pub fun offset_to_stmt(a: *Ast, offset: usize) id.StmtId   // or id.STMT_NIL
pub fun offset_to_decl(a: *Ast, offset: usize) id.DeclId   // or id.DECL_NIL
pub fun offset_to_type(a: *Ast, offset: usize) id.TypeId   // or id.TYPE_NIL
```

**3. Partial-result tolerance**
The parser was already malformed-input tolerant. The one real gap: the lexer accumulated `LexError`s on the stream but the parser never read them, so lex errors (e.g. a stray backtick) were **silently dropped** from the `DiagList`. Fixed at the source of truth — added `lexer.emit_diagnostics` and wired it into the driver's `parse_module`, so the whole compiler (not just the editor) now reports lex errors. A broken buffer (missing `)` + stray backtick) yields a partial `Ast`, both lex+parse diagnostics, and usable resolve side tables.

**First consumer slice — diagnostics**
`editor.diagnostics` runs tokenize → emit-lex-errors → parse and returns the `DiagList` of `(severity, span, message)`. Exposed as a real CLI verb `mach check <file>` — single-file diagnostics with no project/graph/link, the in-tree consumer that exercises the surface end-to-end.

**Docs**: `doc/tooling/editor-api.md`.

## Gates

- **Byte-identical fixpoint**: seed v1.0.0 → a → b → rebuild; `cmp b out/linux/bin/mach` ✅ converges.
- **`mach test .` → 207** (200 baseline + 7 new), exit 0, zero failures.
- New focused tests: offset→id (3), lex-error emission (1), editor single-file entry / partial-results-on-broken-buffer / update (3).

## What mach-lsp#33 can now consume

- **Diagnostics** (the natural first feature): `editor.open` + `editor.diagnostics` → `DiagList.items[].{span, severity, message}`, each span → `source.position`. The `mach check` renderer is a working reference.
- **Document position math**: `source.position` / `line_bounds` retire the LSP's hand-rolled converters.
- **Hover / go-to-def / refs / rename** (follow-up epic): `ast.offset_to_*` → id, then `ResolveResult.expr_resolved[id]` → `SymbolId` → `Symbol.{decl, origin}`.

## Design fork for review

The surface drives the front-end phases directly rather than routing through `query.QueryDb.get(Q_PARSE / Q_RESOLVE)`, because the derived query shards aren't registered until the query DB is wired into the build (**#1164**). The buffer is still registered as a real source input whose revision `Q_FILE_TEXT` reads, so the incremental story is preserved and the `get`-routed form can land with #1164 without changing these signatures.

The secondary fork: to run `test {}` coverage, `mach.lang.editor` must be in the build graph (the build is a pure use-graph DFS from `main.mach`). Rather than a dead import, I added the genuinely-useful `mach check` verb as the consumer. Open to folding the surface into `session` or deferring the CLI verb instead — flagging rather than assuming.
