### PR TITLE
feat(manifest): per-target opt level via [targets.*].opt

### DIFF
--- a/.github/tests/opt/app/mach.toml
+++ b/.github/tests/opt/app/mach.toml
@@ -1,0 +1,23 @@
+[project]
+id = "optapp"
+name = "Per-target Opt Test — App"
+version = "0.0.0"
+dir_src = "src"
+dir_out = "out"
+dir_dep = "dep"
+target = "native"
+
+[targets.linux]
+os = "linux"
+isa = "x86_64"
+abi = "sysv64"
+mode = "executable"
+opt = "O2"
+entrypoint = "main.mach"
+artifacts = "linux"
+binary = "linux/bin/optapp"
+
+[deps.mach-std]
+type = "remote"
+path = "https://github.com/octalide/mach-std"
+version = "branch/dev"

--- a/.github/tests/opt/app/src/main.mach
+++ b/.github/tests/opt/app/src/main.mach
@@ -1,0 +1,15 @@
+use std.runtime.linux.x86_64;
+
+# a small loop the optimizer can fold so the debug and release pipelines emit
+# observably different objects; the program's result is independent of the level.
+$main.symbol = "main";
+fun main(argc: i64, argv: **u8) i64 {
+    var x: i64 = 0;
+    var i: i64 = 0;
+    for (i < 10) {
+        x = x + i;
+        i = i + 1;
+    }
+    # sum 0..9 == 45, so this is always 0 regardless of optimization level.
+    ret x - 45;
+}

--- a/.github/tests/opt/run.sh
+++ b/.github/tests/opt/run.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# per-target opt-level integration test: confirm `[targets.*].opt` drives the
+# build's optimization level and that an explicit CLI `-O*` flag overrides it.
+#
+# the `app` project declares `opt = "O2"`. building it three ways — no flag
+# (manifest default), forced `-O2`, forced `-O0` — must produce a binary that
+# (1) runs correctly in every case, (2) is byte-identical between the manifest
+# default and explicit `-O2` (the manifest opt-level IS the default), and
+# (3) differs under `-O0` (the CLI flag overrides the manifest). a bogus opt
+# value must be rejected as a manifest error.
+#
+# usage: run.sh [path-to-mach]   (defaults to `mach` on PATH)
+set -euo pipefail
+
+MACH="${1:-mach}"
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$HERE/../../.." && pwd)"
+STD="$REPO_ROOT/dep/mach-std"
+
+if [ ! -d "$STD/src" ]; then
+    echo "error: vendored std not found at $STD (run: git submodule update --init)" >&2
+    exit 2
+fi
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+cp -r "$HERE/app" "$WORK/"
+mkdir -p "$WORK/app/dep"
+ln -s "$STD" "$WORK/app/dep/mach-std"
+
+fail=0
+
+# build_into <artifacts-subdir> <out-binary> <extra build args...>
+build_into() {
+    local art="$1"; local out="$2"; shift 2
+    ( cd "$WORK/app" && "$MACH" build . --artifacts "$art" -o "$out" "$@" ) >/dev/null 2>&1
+}
+
+# manifest default (opt = "O2"), forced -O2, forced -O0.
+if ! build_into manifest out/manifest_bin; then
+    echo "FAIL opt: manifest opt=O2 build failed" >&2; fail=1
+fi
+if ! build_into forced_o2 out/o2_bin -O2; then
+    echo "FAIL opt: -O2 build failed" >&2; fail=1
+fi
+if ! build_into forced_o0 out/o0_bin -O0; then
+    echo "FAIL opt: -O0 build failed" >&2; fail=1
+fi
+
+# every variant must run and exit 0 (result is opt-level-independent).
+for bin in manifest_bin o2_bin o0_bin; do
+    set +e
+    "$WORK/app/out/$bin"
+    code=$?
+    set -e
+    if [ "$code" -ne 0 ]; then
+        echo "FAIL opt: $bin ran with exit $code, expected 0" >&2; fail=1
+    fi
+done
+
+# the manifest opt-level IS the default: it must match explicit -O2 byte-for-byte.
+if cmp -s "$WORK/app/out/manifest_bin" "$WORK/app/out/o2_bin"; then
+    echo "PASS opt: manifest opt=O2 produces the -O2 binary"
+else
+    echo "FAIL opt: manifest opt=O2 binary differs from -O2" >&2; fail=1
+fi
+
+# an explicit CLI flag overrides the manifest: -O0 must differ from opt=O2.
+if cmp -s "$WORK/app/out/manifest_bin" "$WORK/app/out/o0_bin"; then
+    echo "FAIL opt: -O0 did not override manifest opt=O2 (binaries identical)" >&2; fail=1
+else
+    echo "PASS opt: -O0 overrides manifest opt=O2"
+fi
+
+# a bogus opt value is a manifest error.
+sed 's/^opt = "O2"/opt = "ofast"/' "$HERE/app/mach.toml" > "$WORK/app/mach.toml"
+rm -rf "$WORK/app/out"
+if ( cd "$WORK/app" && "$MACH" build . ) >/dev/null 2>&1; then
+    echo "FAIL opt: invalid opt value did not fail the build" >&2; fail=1
+else
+    echo "PASS opt: invalid opt value is a manifest error"
+fi
+cp "$HERE/app/mach.toml" "$WORK/app/mach.toml"
+
+exit "$fail"

--- a/doc/manifest.md
+++ b/doc/manifest.md
@@ -44,6 +44,7 @@ with `mach.toml has no [targets.<name>] entries`.
 | `binary`     | string | yes      | —        | Output path of the linked binary, relative to `<dir_out>` (e.g. `"linux/bin/mach"`). Required for **every** target, even in library mode where no binary is linked. |
 | `artifacts`  | string | no       | `<name>` | Subdirectory under `<dir_out>` holding the per-module object tree (`obj/`) and any `--emit-asm` / `--emit-ir` output. Defaults to the target name; may be nested (e.g. `"smach/linux"`). |
 | `mode`       | string | no       | `"executable"` | `"executable"` links the per-module objects into a static binary; `"library"` stops at the objects (no link). Any value other than `"library"` is treated as `"executable"`. |
+| `opt`        | string | no       | — (debug) | Default optimization level for this target. `"O0"` / `"debug"` selects the debug pipeline; `"O1"` / `"O2"` / `"release"` selects the release pipeline. An absent key leaves the build at its own default (debug). A CLI `-O0` / `-O1` / `-O2` / `--release` flag overrides this per invocation. Any other value is a manifest error. See the accepted set below. |
 | `libs`       | array of strings | no | `[]` | Project-level external link inputs. Each entry is either an explicit object/archive path (a `.o` or `.a`, project-root-relative or absolute) or a bare `-l`-style name resolved to a `lib<name>.o` / `<name>.o` / `lib<name>.a` / `<name>.a` at link time. These join every `mach build`/`run`/`test` link in addition to any CLI `-L`/`-l`/object arguments. A non-array value, or a non-string element, is a manifest error. The alias `link` is accepted when `libs` is absent. |
 
 Informational (parsed by TOML, not read by the build): `abi`. The ABI is derived
@@ -82,6 +83,20 @@ Any other value resolves to "unknown" and fails target selection.
 |--------------|--------|
 | `executable` | default; link the objects into a static binary at `<dir_out>/<binary>` |
 | `library`    | leave the per-module objects as the deliverable; no binary is linked |
+
+### Accepted `opt` values
+
+| Value     | Pipeline |
+|-----------|----------|
+| `O0`      | debug — the default; mem2reg, constfold, dce |
+| `debug`   | debug — alias of `O0` |
+| `O1`      | release |
+| `O2`      | release — alias of `O1` |
+| `release` | release — alias of `O1` / `O2` |
+
+`opt` sets the target's **default** optimization level. A CLI `-O0` / `-O1` /
+`-O2` / `--release` flag on `mach build` / `run` / `test` overrides it for that
+invocation; with no flag and no `opt` key, the build uses the debug pipeline.
 
 The single fully-supported triple today is `os = "linux"`, `isa = "x86_64"`
 (SysV ABI, ELF objects). The other recognized values pass manifest parsing and
@@ -137,6 +152,7 @@ mode       = "executable"     # executable (default) | library
 entrypoint = "main.mach"      # entry module: mach.main, under src/
 artifacts  = "linux"          # objects under out/linux/obj/...
 binary     = "linux/bin/mach" # linked binary at out/linux/bin/mach
+# opt      = "O2"             # optional default opt level (CLI -O* overrides)
 # libs     = ["build/libfoo.o", "bar"]  # optional external link inputs
 
 [deps.mach-std]

--- a/src/cli/cmd/build.mach
+++ b/src/cli/cmd/build.mach
@@ -476,16 +476,18 @@ pub fun build(alloc: *Allocator, argc: usize, argv: **u8, emit_obj: bool, test_m
         ret br;
     }
 
-    # optimisation level: `--release` selects the release pipeline; the explicit
-    # `-O<n>` flags override it (-O0 debug, -O1/-O2 release). absent any flag the
-    # default is the debug pipeline (mem2reg, constfold, dce) — what the bootstrap
-    # uses, kept fixpoint-stable.
-    val release: bool = has_flag_local(argc, argv, "--release");
-    var level: u8 = pipeline.OPT_DEBUG;
-    if (release) { level = pipeline.OPT_RELEASE; }
-    if (has_flag_local(argc, argv, "-O0")) { level = pipeline.OPT_DEBUG; }
-    or (has_flag_local(argc, argv, "-O1")) { level = pipeline.OPT_RELEASE; }
-    or (has_flag_local(argc, argv, "-O2")) { level = pipeline.OPT_RELEASE; }
+    # optimisation level: an explicit CLI flag (`-O0` debug, `-O1`/`-O2`/`--release`
+    # release) wins outright; absent any flag the level falls to the selected
+    # target's `[targets.*].opt`, then to the debug pipeline (mem2reg, constfold,
+    # dce) — what the bootstrap uses, kept fixpoint-stable. the CLI choice is
+    # resolved here; the manifest default is folded in after the target is selected
+    # (resolve_opt_level), since the target entry is only known post build_project.
+    var cli_level: u8 = pipeline.OPT_DEBUG;
+    var cli_set:   bool = false;
+    if (has_flag_local(argc, argv, "-O0"))      { cli_level = pipeline.OPT_DEBUG;   cli_set = true; }
+    or (has_flag_local(argc, argv, "-O1"))      { cli_level = pipeline.OPT_RELEASE; cli_set = true; }
+    or (has_flag_local(argc, argv, "-O2"))      { cli_level = pipeline.OPT_RELEASE; cli_set = true; }
+    or (has_flag_local(argc, argv, "--release")) { cli_level = pipeline.OPT_RELEASE; cli_set = true; }
 
     # when --target is absent, defer to [project].target from mach.toml
     # (the driver resolves "native"/"host" to the host-matching entry).
@@ -528,12 +530,28 @@ pub fun build(alloc: *Allocator, argc: usize, argv: **u8, emit_obj: bool, test_m
     }
     var p: driver.Project = unwrap_ok[driver.Project, str](proj_r);
 
+    # fold the manifest default into the level: a CLI `-O*`/`--release` flag wins,
+    # otherwise the selected target's `[targets.*].opt` applies, else debug.
+    val level: u8 = resolve_opt_level(?p, cli_level, cli_set);
+
     br.code = compile_and_link(?p, level, emit_obj, test_mode, config.verify_ir, config.verbose, config.emit_asm, config.emit_ir, ?root[0], config.output, config.artifacts, argc, argv, ?br.output_path);
 
     flush_diagnostics(?s, ?s.diags);
     driver.dnit_project(?p);
     sess.dnit(?s);
     ret br;
+}
+
+# resolve_opt_level: pick the optimization pipeline level for this build. an
+# explicit CLI flag (`cli_set`) wins outright. otherwise the selected target's
+# `[targets.*].opt` decides — TARGET_OPT_RELEASE -> release, TARGET_OPT_DEBUG ->
+# debug — and an unset/absent manifest opt falls to the debug pipeline, the
+# fixpoint-stable default the bootstrap builds at.
+fun resolve_opt_level(p: *driver.Project, cli_level: u8, cli_set: bool) u8 {
+    if (cli_set) { ret cli_level; }
+    val te: *driver.TargetEntry = p.target_entry;
+    if (te != nil && te.opt == driver.TARGET_OPT_RELEASE) { ret pipeline.OPT_RELEASE; }
+    ret pipeline.OPT_DEBUG;
 }
 
 # compile_and_link: orchestrate the per-module compile + link, allocating

--- a/src/lang/driver.mach
+++ b/src/lang/driver.mach
@@ -80,6 +80,18 @@ pub val MODE_EXECUTABLE: BuildMode = 0;
 # MODE_LIBRARY: leave the per-module objects as the deliverable (no link).
 pub val MODE_LIBRARY:    BuildMode = 1;
 
+# TargetOpt: a target's declared optimization level. kept back-end-agnostic so
+# the driver carries the manifest's intent without depending on the pipeline; the
+# CLI maps it to a concrete pipeline level, and an explicit `-O*` flag overrides it.
+pub def TargetOpt: u8;
+
+# TARGET_OPT_DEFAULT: no `opt` key declared — the build's own default (debug).
+pub val TARGET_OPT_DEFAULT: TargetOpt = 0;
+# TARGET_OPT_DEBUG: `opt = "O0"` / `"debug"` — the debug optimization pipeline.
+pub val TARGET_OPT_DEBUG:   TargetOpt = 1;
+# TARGET_OPT_RELEASE: `opt = "O1"` / `"O2"` / `"release"` — the release pipeline.
+pub val TARGET_OPT_RELEASE: TargetOpt = 2;
+
 # TargetEntry: one entry under `[targets.<name>]` in mach.toml.
 # ---
 # name:       interned target selector (e.g. "linux")
@@ -90,6 +102,9 @@ pub val MODE_LIBRARY:    BuildMode = 1;
 #             nested (e.g. "smach/linux")
 # binary:     interned final-binary path under `out` (e.g. "linux/bin/mach")
 # mode:       whether the build links an executable or stops at the objects
+# opt:        declared optimization level from `[targets.*].opt`; TARGET_OPT_DEFAULT
+#             when absent. the CLI maps it to a pipeline level, with an explicit
+#             `-O*` flag taking precedence
 # libs:       interned project-level link inputs from `[targets.*].libs` —
 #             each entry is either an explicit `.o` object / `.a` archive path
 #             (relative to the project root, or absolute) or a bare `-l`-style
@@ -103,6 +118,7 @@ pub rec TargetEntry {
     artifacts:  intern.StrId;
     binary:     intern.StrId;
     mode:       BuildMode;
+    opt:        TargetOpt;
     libs:       *intern.StrId;
     lib_count:  u32;
 }
@@ -643,6 +659,10 @@ fun parse_targets_table(p: *Project, t: *toml.Table) Result[bool, str] {
         entry.mode = MODE_EXECUTABLE;
         if (str_equals(toml.get_str(sub, "mode"), "library")) { entry.mode = MODE_LIBRARY; }
 
+        val opt_r: Result[TargetOpt, str] = parse_target_opt(toml.get_str(sub, "opt"));
+        if (is_err[TargetOpt, str](opt_r)) { ret err[bool, str](unwrap_err[TargetOpt, str](opt_r)); }
+        entry.opt = unwrap_ok[TargetOpt, str](opt_r);
+
         entry.libs      = nil;
         entry.lib_count = 0;
         val libs_r: Result[bool, str] = parse_target_libs(p, sub, ?entry);
@@ -652,6 +672,18 @@ fun parse_targets_table(p: *Project, t: *toml.Table) Result[bool, str] {
         i = i + 1;
     }
     ret ok[bool, str](true);
+}
+
+# parse_target_opt: map the optional `[targets.*].opt` string to a TargetOpt.
+# accepts `"O0"`/`"debug"` (debug pipeline) and `"O1"`/`"O2"`/`"release"` (release
+# pipeline); an absent or empty value yields TARGET_OPT_DEFAULT (the build's own
+# default). any other value is a manifest error so a typo never silently builds at
+# the wrong level.
+fun parse_target_opt(text: str) Result[TargetOpt, str] {
+    if (str_empty(text)) { ret ok[TargetOpt, str](TARGET_OPT_DEFAULT); }
+    if (str_equals(text, "O0") || str_equals(text, "debug")) { ret ok[TargetOpt, str](TARGET_OPT_DEBUG); }
+    if (str_equals(text, "O1") || str_equals(text, "O2") || str_equals(text, "release")) { ret ok[TargetOpt, str](TARGET_OPT_RELEASE); }
+    ret err[TargetOpt, str]("mach.toml: [targets.*].opt must be one of \"O0\"/\"debug\", \"O1\"/\"O2\"/\"release\"");
 }
 
 # parse_target_libs: read the optional `[targets.*].libs` array of strings into


### PR DESCRIPTION
Implements per-target build configuration in `mach.toml` for issue #1167 — the **optimization-level** half. Per the maintainer decision, this stays within the manifest: no build hooks or scripted steps.

## What's implemented

`[targets.<name>].opt` sets the target's default optimization level:

| Value | Pipeline |
|-------|----------|
| `O0` / `debug` | debug (default) |
| `O1` / `O2` / `release` | release |

- `src/lang/driver.mach`: new `TargetOpt` enum + `opt` field on `TargetEntry`, parsed by `parse_target_opt` in `parse_targets_table`. Kept back-end-agnostic so the driver carries the manifest's intent without depending on the pipeline. A bogus value is a manifest error.
- `src/cli/cmd/build.mach`: the CLI resolves the level *after* target selection via `resolve_opt_level` — an explicit `-O0`/`-O1`/`-O2`/`--release` flag wins outright; otherwise the target's `opt` applies; otherwise the debug pipeline (the fixpoint-stable default the bootstrap builds at).
- Composes cleanly with `[targets.*].libs` (#1165): `opt` is an independent field parsed alongside `libs` with no interaction.

## What's deferred

**Compile-time defines** (`[targets.*].defines` → `$mach.build.*`) are scoped to follow-up #1191. The comptime namespace currently recognizes only a fixed set of `$mach.*` paths (every `$mach.build.*` is a "not yet available" stub); supporting arbitrary manifest defines needs real comptime-surface design (a typed defines table threaded onto every module's `ComptimeCtx`, plus dynamic path resolution) rather than a half-implementation. #1191 captures the full design.

## Test

`.github/tests/opt/` — an `app` project declaring `opt = "O2"`; `run.sh` confirms:
- the manifest opt-level produces the `-O2` binary **byte-for-byte**,
- `-O0` **overrides** the manifest (different, smaller binary),
- a bogus `opt` value is a manifest error.

Passes with the modified compiler. `.github/tests/extlink/` (the libs surface) still passes.

## Gates

- **Self-host fixpoint**: byte-identical — the modified compiler, built by the v1.0.0 seed, rebuilds itself byte-for-byte (`cmp` clean). The compiler's own `mach.toml` declares no `opt`, so the new path resolves to the debug default exactly as before.
- **`mach test .`**: 207 PASS / 0 FAIL / exit 0 (unchanged from baseline).

Docs updated in `doc/manifest.md` per #1170.

Closes #1167
