### PR TITLE
feat(linker): dynamic-import/bind abstraction + ELF LINK_SHARED (first slice of #1159)

### DIFF
--- a/.github/tests/dynlink/app/mach.toml
+++ b/.github/tests/dynlink/app/mach.toml
@@ -1,0 +1,22 @@
+[project]
+id = "dynapp"
+name = "Dynamic Link Test — App"
+version = "0.0.0"
+dir_src = "src"
+dir_out = "out"
+dir_dep = "dep"
+target = "native"
+
+[targets.linux]
+os = "linux"
+isa = "x86_64"
+abi = "sysv64"
+mode = "executable"
+entrypoint = "main.mach"
+artifacts = "linux"
+binary = "linux/bin/dynapp"
+
+[deps.mach-std]
+type = "remote"
+path = "https://github.com/octalide/mach-std"
+version = "branch/dev"

--- a/.github/tests/dynlink/app/src/main.mach
+++ b/.github/tests/dynlink/app/src/main.mach
@@ -1,0 +1,15 @@
+use std.runtime.linux.x86_64;
+
+# bound at link time against libc's getpid through a dynamic import: no in-graph
+# definition exists, so the dynamic linker resolves it from libc.so.6 at run
+# time via the PLT the linker emitted.
+ext fun getpid() i32;
+
+$main.symbol = "main";
+fun main(argc: i64, argv: **u8) i64 {
+    # every real process has a positive pid; a successful dynamic call returns it.
+    # exit 0 proves the import resolved and the PLT call returned a sane value.
+    val pid: i32 = getpid();
+    if (pid > 0) { ret 0; }
+    ret 1;
+}

--- a/.github/tests/dynlink/run.sh
+++ b/.github/tests/dynlink/run.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# dynlink integration test: dynamically link a Mach program against a shared
+# library (libc) and confirm it builds, loads, and runs with the right result.
+#
+# the consumer (`app`) declares libc's `getpid` `ext` and calls it; no in-graph
+# definition exists, so the symbol can only be satisfied by a dynamic import. it
+# is linked against `libc` (which resolves to `libc.so.6`) through each supported
+# surface — `-l c` and the `[targets.*].libs` manifest field — producing a
+# dynamically-linked ELF (PT_INTERP + .dynamic/PLT/GOT). the program returns 0
+# only when `getpid()` returns a positive pid, proving the import resolved and
+# the PLT call ran at load time. a build with no shared dependency must fail on
+# the undefined `ext`, proving the dynamic link is what supplies the binding.
+#
+# usage: run.sh [path-to-mach]   (defaults to `mach` on PATH)
+set -euo pipefail
+
+MACH="${1:-mach}"
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$HERE/../../.." && pwd)"
+STD="$REPO_ROOT/dep/mach-std"
+
+if [ ! -d "$STD/src" ]; then
+    echo "error: vendored std not found at $STD (run: git submodule update --init)" >&2
+    exit 2
+fi
+
+# the linux dynamic loader and libc must be present for a dynamic link to run.
+if [ ! -e /lib64/ld-linux-x86-64.so.2 ] && [ ! -e /usr/lib64/ld-linux-x86-64.so.2 ]; then
+    echo "SKIP dynlink: no /lib64/ld-linux-x86-64.so.2 dynamic loader"
+    exit 0
+fi
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+cp -r "$HERE/app" "$WORK/"
+mkdir -p "$WORK/app/dep"
+ln -s "$STD" "$WORK/app/dep/mach-std"
+
+fail=0
+
+# expect_0 <desc> <build args...> — the build args are passed verbatim; each case
+# supplies its own project-path positional (`.`).
+expect_0() {
+    local desc="$1"; shift
+    rm -rf "$WORK/app/out"
+    if ! ( cd "$WORK/app" && "$MACH" build "$@" ) >/dev/null 2>&1; then
+        echo "FAIL dynlink: $desc — build failed" >&2
+        fail=1
+        return
+    fi
+    local bin="$WORK/app/out/linux/bin/dynapp"
+    # confirm the binary is actually dynamically linked (has an interpreter).
+    if command -v readelf >/dev/null 2>&1; then
+        if ! readelf -l "$bin" 2>/dev/null | grep -q "program interpreter"; then
+            echo "FAIL dynlink: $desc — produced a static binary (no PT_INTERP)" >&2
+            fail=1
+            return
+        fi
+    fi
+    set +e
+    "$bin"
+    local code=$?
+    set -e
+    if [ "$code" -ne 0 ]; then
+        echo "FAIL dynlink: $desc — ran with exit $code, expected 0" >&2
+        fail=1
+        return
+    fi
+    echo "PASS dynlink: $desc"
+}
+
+# `-l c` resolves libc.so.6 and binds getpid dynamically.
+expect_0 "-l c (libc.so.6)" . -l c
+
+# manifest libs: `[targets.linux].libs = ["c"]` resolves the same shared lib.
+sed 's|^binary = "linux/bin/dynapp"|&\nlibs = ["c"]|' "$HERE/app/mach.toml" > "$WORK/app/mach.toml"
+expect_0 "[targets.*].libs manifest" .
+cp "$HERE/app/mach.toml" "$WORK/app/mach.toml"
+
+# no shared dependency: the undefined `ext getpid` must make the link fail.
+rm -rf "$WORK/app/out"
+if ( cd "$WORK/app" && "$MACH" build . ) >/dev/null 2>&1; then
+    echo "FAIL dynlink: missing -l c did not fail the link on undefined getpid" >&2
+    fail=1
+else
+    echo "PASS dynlink: missing shared dependency fails the link"
+fi
+
+exit "$fail"

--- a/doc/cli.md
+++ b/doc/cli.md
@@ -67,8 +67,8 @@ objects are the deliverable and nothing is linked.
 | `-O2`          | —              | select the release pipeline |
 | `--emit <kind>`| `obj`\|`exe`   | `obj` stops at the relocatable objects; `exe` (default) links a binary |
 | `-L <dir>`     | dir            | add a search directory for `-l`-resolved inputs; repeatable |
-| `-l <name>`    | name           | link a named object or archive, resolved through the `-L` dirs (see below); repeatable |
-| *(positional)* | input path     | a bare argument that contains `/` or ends in `.o` / `.a` is linked verbatim |
+| `-l <name>`    | name           | link a named object, archive, or shared library, resolved through the `-L` dirs (see below); repeatable |
+| *(positional)* | input path     | a bare argument that contains `/`, ends in `.o` / `.a`, or names a `.so` is linked verbatim |
 
 Plus the global flags above. The `-O<n>` flags override `--release` when both
 are present; absent any optimisation flag the build uses the debug pipeline
@@ -78,28 +78,53 @@ release pipeline.
 ### External link inputs
 
 `ext fun` declarations are forward references whose definitions are supplied at
-link time by external precompiled code — a loose `.o` object or a static `.a`
-archive. Those inputs come from the command line and from the target's
-`[targets.*].libs` manifest field (see [manifest.md](manifest.md)); both sets are
-linked. An input that resolves to no existing file is a hard error, so a typo
-never silently drops a dependency.
+link time by external precompiled code — a loose `.o` object, a static `.a`
+archive, or a shared `.so` library. Those inputs come from the command line and
+from the target's `[targets.*].libs` manifest field (see
+[manifest.md](manifest.md)); both sets are linked. An input that resolves to no
+existing file is a hard error, so a typo never silently drops a dependency.
 
-- **Explicit input path** — a bare (non-flag) argument that contains a `/` or
-  ends in `.o` (object) or `.a` (archive) is treated as an input path. The first
-  non-flag positional after `build` is the project root and is skipped; remaining
-  input-path positionals are link inputs. A relative path is tried verbatim
-  against the working directory first, then rooted at the project root.
-- **`-l <name>`** — resolves to an object or archive. Each `-L <dir>` is searched
-  for `<dir>/lib<name>.o`, `<dir>/<name>.o`, `<dir>/lib<name>.a`, then
-  `<dir>/<name>.a`; if none hit, the same four candidates relative to the working
-  directory are tried. Loose objects are preferred over archives.
+- **Explicit input path** — a bare (non-flag) argument that contains a `/`, ends
+  in `.o` (object) or `.a` (archive), or names a `.so` (shared library) is
+  treated as an input path. The first non-flag positional after `build` is the
+  project root and is skipped; remaining input-path positionals are link inputs.
+  A relative path is tried verbatim against the working directory first, then
+  rooted at the project root.
+- **`-l <name>`** — resolves to an object, archive, or shared library. Each
+  `-L <dir>` is searched for `<dir>/lib<name>.o`, `<dir>/<name>.o`,
+  `<dir>/lib<name>.a`, then `<dir>/<name>.a`; if none hit, the same four
+  candidates relative to the working directory are tried. Only if no static
+  object or archive is found does resolution fall back to a shared
+  `lib<name>.so` (searched in the `-L` dirs, the target OS's default library
+  directory, then the common system library directories `/lib64`, `/usr/lib64`,
+  the multiarch dirs, `/usr/lib`, `/lib`).
 - **`-L <dir>`** — adds a search directory for the `-l` resolution above. Both
   `-L` and `-l` may be repeated.
 
-A static `.a` archive contributes every one of its member objects to the link
-(all members are pulled, not just those satisfying an undefined symbol). Shared
-libraries (`.so`) are not supported. Manifest `libs` are resolved before the CLI
-inputs, giving a stable, deterministic link order.
+#### Static vs dynamic resolution
+
+How an input resolves decides whether the link is static or dynamic:
+
+- A loose **`.o`** object or static **`.a`** archive is a **static** input,
+  merged into the executable at link time. An `.a` contributes every one of its
+  member objects (all members are pulled, not just those satisfying an undefined
+  symbol). With only static inputs the output is a fully static binary, and any
+  undefined `ext` that no input defines is a hard error.
+- A shared **`.so`** library is a **dynamic** dependency. Its `DT_SONAME` (read
+  from the library, e.g. `libc.so.6` for `-l c`) is recorded as a run-time
+  dependency, and any undefined `ext` left after merging is bound against it at
+  load time through a PLT the linker emits — producing a dynamically-linked ELF
+  with a `PT_INTERP` (the OS dynamic loader) and a `.dynamic`/PLT/GOT. A static
+  definition of a symbol always wins over a dynamic import of the same name.
+
+`-l <name>` prefers a static `.o`/`.a` over a shared `.so`, so an `-l name`
+that has a local object is resolved statically exactly as before; the `.so`
+fallback only applies when no static candidate exists (the common case for
+system libraries like libc). Manifest `libs` are resolved before the CLI inputs,
+giving a stable, deterministic link order.
+
+> Dynamic linking is currently implemented for the ELF (Linux) target; the PE
+> (Windows) and Mach-O (Darwin) import paths are in progress.
 
 Exit codes: `0` ok, `1` user error (no `mach.toml`, unknown target, compile
 errors, an unresolvable link input), `2` internal error.

--- a/doc/language/ext-fun.md
+++ b/doc/language/ext-fun.md
@@ -42,40 +42,50 @@ Common reasons to rename:
 ## Linking external objects
 
 An `ext fun` is only a forward reference — its definition must be supplied at
-link time by an external precompiled object. Provide those objects to
+link time, either **statically** by an external precompiled object/archive or
+**dynamically** by a shared library bound at load time. Provide those inputs to
 `mach build` either on the command line or through the project manifest. An
-undefined `ext` symbol with no object supplying it is a link error.
+undefined `ext` symbol that no static object defines and no shared library can
+bind is a link error.
 
 ### Command line
 
 C-toolchain-style flags, consumed by `mach build`:
 
 ```sh
-# explicit object / archive path
+# explicit object / archive / shared-library path
 mach build . path/to/libfoo.o
 mach build . path/to/libfoo.a
+mach build . path/to/libfoo.so
 
-# search dir + library name: resolves lib<name>.o / <name>.o / lib<name>.a / <name>.a in each -L dir
+# search dir + library name: resolves lib<name>.o / <name>.o / lib<name>.a / <name>.a, then lib<name>.so
 mach build . -L build/libs -l foo
+
+# link against a system shared library (libc) dynamically
+mach build . -l c
 ```
 
-- A bare argument that contains a `/` or ends in `.o` (object) or `.a` (archive)
-  is treated as an explicit input path. A relative path is tried first against the
-  working directory, then against the project root.
-- `-l <name>` resolves to an object or archive: each `-L <dir>` is searched for
-  `lib<name>.o`, `<name>.o`, `lib<name>.a`, then `<name>.a`; finally the working
-  directory is searched for the same four names (loose objects preferred over
-  archives). `-L` and `-l` may each be repeated.
+- A bare argument that contains a `/`, ends in `.o` (object) or `.a` (archive),
+  or names a `.so` (shared library) is treated as an explicit input path. A
+  relative path is tried first against the working directory, then against the
+  project root.
+- `-l <name>` resolves to an object, archive, or shared library: each `-L <dir>`
+  is searched for `lib<name>.o`, `<name>.o`, `lib<name>.a`, then `<name>.a`;
+  finally the working directory is searched for the same four names (loose
+  objects preferred over archives). Only if no static candidate exists does it
+  fall back to a shared `lib<name>.so` (in the `-L` dirs and the system library
+  directories). `-L` and `-l` may each be repeated.
 
 ### Manifest
 
 `[targets.*].libs` lists project-level link inputs, each an explicit object /
-archive path (project-relative or absolute) or a bare `-l`-style name:
+archive / shared-library path (project-relative or absolute) or a bare
+`-l`-style name:
 
 ```toml
 [targets.linux]
 # ...
-libs = ["build/libs/libfoo.a", "bar"]
+libs = ["build/libs/libfoo.a", "bar", "c"]
 ```
 
 `link` is accepted as an alias for `libs`. Manifest inputs and command-line
@@ -84,10 +94,14 @@ error.
 
 ### Scope
 
-Loose `.o` relocatable objects and static `.a` archives are linked; a `.a`
-contributes every one of its member objects (all members are pulled, not just
-those satisfying an undefined symbol). Shared libraries (`.so`) are not yet
-supported — wait on the dynamic-linker work.
+Loose `.o` relocatable objects and static `.a` archives are linked **statically**
+(a `.a` contributes every one of its member objects — all members are pulled, not
+just those satisfying an undefined symbol). A shared `.so` library is a **dynamic**
+dependency: its `DT_SONAME` is recorded and undefined `ext` symbols are bound
+against it at load time through a `PT_INTERP`/PLT in the produced binary. A
+static definition always wins over a same-named dynamic import. Dynamic linking
+is currently implemented for the ELF (Linux) target; the PE (Windows) and Mach-O
+(Darwin) import paths are in progress.
 
 ## See also
 

--- a/doc/manifest.md
+++ b/doc/manifest.md
@@ -45,17 +45,22 @@ with `mach.toml has no [targets.<name>] entries`.
 | `artifacts`  | string | no       | `<name>` | Subdirectory under `<dir_out>` holding the per-module object tree (`obj/`) and any `--emit-asm` / `--emit-ir` output. Defaults to the target name; may be nested (e.g. `"smach/linux"`). |
 | `mode`       | string | no       | `"executable"` | `"executable"` links the per-module objects into a static binary; `"library"` stops at the objects (no link). Any value other than `"library"` is treated as `"executable"`. |
 | `opt`        | string | no       | — (debug) | Default optimization level for this target. `"O0"` / `"debug"` selects the debug pipeline; `"O1"` / `"O2"` / `"release"` selects the release pipeline. An absent key leaves the build at its own default (debug). A CLI `-O0` / `-O1` / `-O2` / `--release` flag overrides this per invocation. Any other value is a manifest error. See the accepted set below. |
-| `libs`       | array of strings | no | `[]` | Project-level external link inputs. Each entry is either an explicit object/archive path (a `.o` or `.a`, project-root-relative or absolute) or a bare `-l`-style name resolved to a `lib<name>.o` / `<name>.o` / `lib<name>.a` / `<name>.a` at link time. These join every `mach build`/`run`/`test` link in addition to any CLI `-L`/`-l`/object arguments. A non-array value, or a non-string element, is a manifest error. The alias `link` is accepted when `libs` is absent. |
+| `libs`       | array of strings | no | `[]` | Project-level external link inputs. Each entry is either an explicit path (a `.o` object, a `.a` archive, or a `.so` shared library, project-root-relative or absolute) or a bare `-l`-style name resolved to a `lib<name>.o` / `<name>.o` / `lib<name>.a` / `<name>.a`, then a shared `lib<name>.so`, at link time. These join every `mach build`/`run`/`test` link in addition to any CLI `-L`/`-l`/object arguments. A non-array value, or a non-string element, is a manifest error. The alias `link` is accepted when `libs` is absent. |
 
 Informational (parsed by TOML, not read by the build): `abi`. The ABI is derived
 from `os` (Linux/macOS → SysV, Windows → Win64), so the key documents intent but
 does not change the build.
 
-Loose `.o` relocatable objects and static `.a` archives are linked; a `.a`
-contributes every member object. Shared libraries (`.so`) are not yet supported.
-See [language/ext-fun.md](language/ext-fun.md#linking-external-objects) for the
-`ext fun` workflow that consumes these inputs, and [cli.md](cli.md#external-link-inputs)
-for the equivalent command-line flags.
+Loose `.o` relocatable objects and static `.a` archives are linked **statically**
+(a `.a` contributes every member object); a shared `.so` library is recorded as a
+**dynamic** dependency (its `DT_SONAME`), bound against undefined `ext` symbols at
+load time through a `PT_INTERP`/PLT in the produced binary. A `-l <name>` prefers
+a static `.o`/`.a` and only falls back to a shared `lib<name>.so` when none is
+found. Dynamic linking is currently implemented for the ELF (Linux) target. See
+[cli.md](cli.md#static-vs-dynamic-resolution) for the full resolution rules,
+[language/ext-fun.md](language/ext-fun.md#linking-external-objects) for the
+`ext fun` workflow that consumes these inputs, and
+[cli.md](cli.md#external-link-inputs) for the equivalent command-line flags.
 
 ### Accepted `os` values
 

--- a/src/cli/cmd/build.mach
+++ b/src/cli/cmd/build.mach
@@ -766,20 +766,30 @@ fun link_artifact(p: *driver.Project, emit_obj: bool, test_mode: bool, have_runn
     }
 
     # append every external link input — manifest `[targets.*].libs` plus the
-    # `-L`/`-l`/explicit-object CLI flags — as extra input paths. each resolves to
-    # a loose `.o` object or a static `.a` archive on disk that joins the link so
-    # undefined `ext` / in-graph symbols bind against its definitions (an archive
-    # contributes its member objects). `paths` is grown and re-bound here.
-    val ext_code: i64 = append_external_objects(p, root, argc, argv, ?paths, ?count);
+    # `-L`/`-l`/explicit-object CLI flags. each resolves either STATICALLY to a
+    # loose `.o` object or `.a` archive on disk (appended to `paths`, an archive
+    # contributing its member objects), or DYNAMICALLY to a shared library `.so`
+    # (recorded as a soname in `sonames`, a DT_NEEDED dependency bound at run
+    # time). `paths` and `sonames` are grown and re-bound here.
+    var sonames: *intern.StrId = nil;
+    var soname_count: u32 = 0;
+    val ext_code: i64 = append_external_inputs(p, root, argc, argv, ?paths, ?count, ?sonames, ?soname_count);
     if (ext_code != 0) {
         free_paths(p.s.alloc, paths, count, count);
+        free_sonames(p.s.alloc, sonames, soname_count);
         ret ext_code;
     }
 
     if (verbose) {
         emit("link ");
         emit_num(count::usize);
-        emit(" object(s)\n");
+        emit(" object(s)");
+        if (soname_count > 0) {
+            emit(", ");
+            emit_num(soname_count::usize);
+            emit(" shared lib(s)");
+        }
+        emit("\n");
     }
 
     # the executable path: `-o` overrides it with a path rooted directly at
@@ -792,12 +802,14 @@ fun link_artifact(p: *driver.Project, emit_obj: bool, test_mode: bool, have_runn
         val out_opt: Option[str] = intern.lookup(?p.s.interner, p.config.out);
         if (is_none[str](out_opt)) {
             free_paths(p.s.alloc, paths, count, count);
+            free_sonames(p.s.alloc, sonames, soname_count);
             emit("error: project out dir not interned\n");
             ret 2;
         }
         val bin_opt: Option[str] = intern.lookup(?p.s.interner, te.binary);
         if (is_none[str](bin_opt) || slen(unwrap[str](bin_opt)::*u8) == 0) {
             free_paths(p.s.alloc, paths, count, count);
+            free_sonames(p.s.alloc, sonames, soname_count);
             emit("error: target has no binary path configured\n");
             ret 1;
         }
@@ -806,12 +818,15 @@ fun link_artifact(p: *driver.Project, emit_obj: bool, test_mode: bool, have_runn
     }
     if (!ensure_parents(?artifact[0])) {
         free_paths(p.s.alloc, paths, count, count);
+        free_sonames(p.s.alloc, sonames, soname_count);
         emit("error: failed to create binary directory\n");
         ret 2;
     }
 
-    val link_r: Result[bool, str] = linker.link(p.s, ?p.target, paths, count, ?artifact[0], linker.LINK_EXE);
+    val link_r: Result[bool, str] =
+        linker.link(p.s, ?p.target, paths, count, sonames, soname_count, ?artifact[0], linker.LINK_EXE);
     free_paths(p.s.alloc, paths, count, count);
+    free_sonames(p.s.alloc, sonames, soname_count);
     if (is_err[bool, str](link_r)) {
         emit("error: ");
         emit(unwrap_err[bool, str](link_r));
@@ -971,18 +986,22 @@ fun is_value_flag(a: *u8) bool {
         eq(a, "--artifacts") || eq(a, "--emit") || eq(a, "--filter");
 }
 
-# append_external_objects: resolve every external link input (manifest
-# `[targets.*].libs` plus the CLI `-L`/`-l`/explicit-object flags) to a loose
-# `.o` object or static `.a` archive on disk and append each as an extra input
-# path. `*paths` is grown from `*count` to `*count + extra` and re-bound; on
-# success `*count` becomes the total input count (every slot resolved). an input
-# that resolves to no existing file is a hard error so a typo never silently
-# drops a link dependency. the grown tail is nil-initialized up front and
-# `*count` is set to the full grown capacity on every exit, so the caller's
-# `free_paths(.., count, count)` frees the array at its true size and skips the
-# unfilled nil slots. returns 0 on success, or a non-zero exit code.
-fun append_external_objects(p: *driver.Project, root: *u8, argc: usize, argv: **u8,
-                            paths: ***u8, count: *u32) i64 {
+# append_external_inputs: resolve every external link input (manifest
+# `[targets.*].libs` plus the CLI `-L`/`-l`/explicit-object flags) and classify
+# each as STATIC (a loose `.o` or static `.a`, appended to `*paths`) or DYNAMIC
+# (a shared `.so`, whose soname is interned and appended to `*sonames`).
+#
+# `*paths` is pre-grown by the token count (the worst case where every input is
+# an object) and then shrunk to the true object count `*count`, so the array is
+# dense (no nil holes) and `free_paths(.., count, count)` frees it correctly.
+# `*sonames` grows one slot per shared dependency. an input that resolves to no
+# existing file is a hard error so a typo never silently drops a dependency.
+# returns 0 on success, or a non-zero exit code.
+fun append_external_inputs(p: *driver.Project, root: *u8, argc: usize, argv: **u8,
+                           paths: ***u8, count: *u32,
+                           sonames: **intern.StrId, soname_count: *u32) i64 {
+    @sonames = nil;
+    @soname_count = 0;
     val extra: u32 = count_external_tokens(p, argc, argv);
     if (extra == 0) { ret 0; }
 
@@ -992,8 +1011,6 @@ fun append_external_objects(p: *driver.Project, root: *u8, argc: usize, argv: **
     if (is_err[**u8, str](gr)) { emit("error: out of memory\n"); ret 2; }
     @paths = unwrap_ok[**u8, str](gr);
 
-    # nil-init the freshly grown tail so every early exit leaves the array fully
-    # initialized and `free_paths` (which skips nil) can free it at `grown`.
     var z: u32 = base;
     for (z < grown) { (@paths)[z] = nil; z = z + 1; }
     @count = grown;
@@ -1010,8 +1027,9 @@ fun append_external_objects(p: *driver.Project, root: *u8, argc: usize, argv: **
             val lib_opt: Option[str] = intern.lookup(?p.s.interner, te.libs[li]);
             if (is_none[str](lib_opt)) { ret 2; }
             val tok: *u8 = unwrap[str](lib_opt)::*u8;
-            val code: i64 = resolve_and_store(p, tok, root, argc, argv, ?buf[0], 4096, @paths, ?written);
-            if (code != 0) { ret code; }
+            val code: i64 = resolve_and_store_input(p, tok, root, argc, argv, ?buf[0], 4096,
+                                                    @paths, ?written, sonames, soname_count);
+            if (code != 0) { shrink_paths(p, paths, count, written, grown); ret code; }
             li = li + 1;
         }
     }
@@ -1021,34 +1039,112 @@ fun append_external_objects(p: *driver.Project, root: *u8, argc: usize, argv: **
     for (i < argc) {
         val a: *u8 = argv[i];
         if (eq(a, "-l") && i + 1 < argc) {
-            val code: i64 = resolve_and_store(p, argv[i + 1], root, argc, argv, ?buf[0], 4096, @paths, ?written);
-            if (code != 0) { ret code; }
+            val code: i64 = resolve_and_store_input(p, argv[i + 1], root, argc, argv, ?buf[0], 4096,
+                                                    @paths, ?written, sonames, soname_count);
+            if (code != 0) { shrink_paths(p, paths, count, written, grown); ret code; }
             i = i + 2; cnt;
         }
         if (is_value_flag(a) && i + 1 < argc) { i = i + 2; cnt; }
         if (i > 1 && i != proj_ix && a != nil && a[0] != '-' && is_object_path(a)) {
-            val code: i64 = resolve_and_store(p, a, root, argc, argv, ?buf[0], 4096, @paths, ?written);
-            if (code != 0) { ret code; }
+            val code: i64 = resolve_and_store_input(p, a, root, argc, argv, ?buf[0], 4096,
+                                                    @paths, ?written, sonames, soname_count);
+            if (code != 0) { shrink_paths(p, paths, count, written, grown); ret code; }
         }
         i = i + 1;
     }
 
+    shrink_paths(p, paths, count, written, grown);
     ret 0;
 }
 
-# resolve_and_store: resolve one link-input token to an on-disk object and store
-# its owned path into `paths[*written]`, advancing `*written`. an explicit
-# relative object path is first tried verbatim, then rooted at the project root;
-# a bare name is resolved through `resolve_input_into`. an unresolvable input is
-# a hard error. returns 0 on success or a non-zero exit code.
-fun resolve_and_store(p: *driver.Project, tok: *u8, root: *u8, argc: usize, argv: **u8,
-                      buf: *u8, cap: usize, paths: **u8, written: *u32) i64 {
+# shrink_paths: shrink the over-grown object-path array to its true object count
+# `written` and set `*count` to it, so the array is dense and frees at its size.
+# a shrink failure leaves the array at its grown size, which `free_paths` still
+# frees correctly (the unfilled tail slots are nil).
+fun shrink_paths(p: *driver.Project, paths: ***u8, count: *u32, written: u32, grown: u32) {
+    if (written < grown) {
+        val sr: Result[**u8, str] = reallocate[*u8](p.s.alloc, @paths, grown::usize, written::usize);
+        if (is_ok[**u8, str](sr)) { @paths = unwrap_ok[**u8, str](sr); @count = written; ret; }
+    }
+    @count = grown;
+}
+
+# append_soname: intern a shared library's soname and append it to the dynamic
+# dependency list, growing it one slot at a time. returns 0 on success or a
+# non-zero exit code.
+fun append_soname(p: *driver.Project, name: *u8, sonames: **intern.StrId, soname_count: *u32) i64 {
+    val ir: Result[intern.StrId, str] = intern.intern(?p.s.interner, cstr_str(name));
+    if (is_err[intern.StrId, str](ir)) { emit("error: out of memory\n"); ret 2; }
+    val id: intern.StrId = unwrap_ok[intern.StrId, str](ir);
+
+    val old: u32 = @soname_count;
+    val gr: Result[*intern.StrId, str] =
+        reallocate[intern.StrId](p.s.alloc, @sonames, old::usize, (old + 1)::usize);
+    if (is_err[*intern.StrId, str](gr)) { emit("error: out of memory\n"); ret 2; }
+    @sonames = unwrap_ok[*intern.StrId, str](gr);
+    (@sonames)[old] = id;
+    @soname_count = old + 1;
+    ret 0;
+}
+
+# free_sonames: release the dynamic-dependency soname array.
+fun free_sonames(alloc: *Allocator, sonames: *intern.StrId, soname_count: u32) {
+    if (sonames != nil && soname_count > 0) {
+        deallocate[intern.StrId](alloc, sonames, soname_count::usize);
+    }
+}
+
+# store_shared: record an explicit shared-library `.so` file as a dynamic
+# dependency under its DT_SONAME, falling back to the path's basename when the
+# object carries none. the soname is the canonical run-time dependency name.
+fun store_shared(p: *driver.Project, path: *u8, sonames: **intern.StrId, soname_count: *u32) i64 {
+    var sname: [4096]u8;
+    if (read_so_soname(p, path, ?sname[0], 4096)) {
+        ret append_soname(p, ?sname[0], sonames, soname_count);
+    }
+    ret append_soname(p, soname_basename(path), sonames, soname_count);
+}
+
+# resolve_and_store_input: resolve one link-input token and route it to the right
+# bucket. a `.o`/`.a` object or archive is stored into `paths[*written]` (a static
+# input); a shared `.so` library has its soname recorded in `*sonames` (a dynamic
+# dependency). a bare `-l` name prefers a static `.o`/`.a` (so existing object
+# resolution is unchanged), then falls back to a shared `lib<name>.so`. an
+# unresolvable input is a hard error. returns 0 on success or a non-zero code.
+fun resolve_and_store_input(p: *driver.Project, tok: *u8, root: *u8, argc: usize, argv: **u8,
+                            buf: *u8, cap: usize, paths: **u8, written: *u32,
+                            sonames: **intern.StrId, soname_count: *u32) i64 {
     var found: bool = resolve_input_into(tok, argc, argv, buf, cap);
 
     # a relative explicit path that misses the working directory is retried
     # rooted at the project root, so manifest `libs` paths are project-relative.
-    if (!found && is_object_path(tok) && tok[0] != '/') {
+    if (!found && (is_object_path(tok) || is_shared_path(tok)) && tok[0] != '/') {
         if (join_into(buf, cap, root, tok) > 0 && fs.is_file(cstr_str(buf))) { found = true; }
+    }
+
+    # a resolved input that is a shared object (an explicit `.so` path, or an
+    # archive/object search that landed on one) is a dynamic dependency: record
+    # its DT_SONAME (or basename) instead of adding it as a static object.
+    if (found && is_shared_path(buf)) {
+        ret store_shared(p, buf, sonames, soname_count);
+    }
+
+    # an explicit `.so` token taken verbatim (it has no '/' so `is_object_path`
+    # skipped it) — resolve it as a file and record its soname.
+    if (!found && is_shared_path(tok)) {
+        if (fs.is_file(cstr_str(tok))) {
+            ret store_shared(p, tok, sonames, soname_count);
+        }
+    }
+
+    # a bare `-l` name with no static `.o`/`.a` falls back to a shared
+    # `lib<name>.so` in the `-L` dirs and the system library directories;
+    # `resolve_shared_into` writes the library's own soname into `buf`.
+    if (!found && !is_object_path(tok) && !is_shared_path(tok)) {
+        var sname: [4096]u8;
+        if (resolve_shared_into(p, tok, argc, argv, ?sname[0], 4096)) {
+            ret append_soname(p, ?sname[0], sonames, soname_count);
+        }
     }
 
     if (!found) {
@@ -1063,6 +1159,192 @@ fun resolve_and_store(p: *driver.Project, tok: *u8, root: *u8, argc: usize, argv
     paths[@written] = dup;
     @written = @written + 1;
     ret 0;
+}
+
+# read a u16 little-endian from a buffer.
+fun rd_u16(buf: *u8, off: usize) u16 {
+    ret buf[off]::u16 | (buf[off + 1]::u16 << 8);
+}
+
+# read a u32 little-endian from a buffer.
+fun rd_u32(buf: *u8, off: usize) u32 {
+    ret buf[off]::u32 | (buf[off + 1]::u32 << 8) | (buf[off + 2]::u32 << 16) | (buf[off + 3]::u32 << 24);
+}
+
+# read a u64 little-endian from a buffer.
+fun rd_u64(buf: *u8, off: usize) u64 {
+    ret rd_u32(buf, off)::u64 | (rd_u32(buf, off + 4)::u64 << 32);
+}
+
+# read_so_soname: read a shared object's DT_SONAME and write it (null-terminated)
+# into `out`. parses the ELF64 dynamic section: finds the SHT_DYNAMIC section, its
+# linked string table, and the DT_SONAME (tag 14) entry, then copies the soname.
+# returns true on a real ELF64 shared/dynamic object carrying a DT_SONAME; false
+# for a non-ELF file (e.g. a GNU ld linker script) or one with no DT_SONAME, so
+# the caller falls back to the file's basename. this is the canonical
+# dependency name the loader resolves, so a versioned `libc.so.6` is recorded
+# even when the probe matched an unversioned `libc.so` symlink.
+fun read_so_soname(p: *driver.Project, path: *u8, out: *u8, cap: usize) bool {
+    val rb: Result[fs.Buffer, str] = fs.read_all_sized(p.s.alloc, cstr_str(path));
+    if (is_err[fs.Buffer, str](rb)) { ret false; }
+    val b: fs.Buffer = unwrap_ok[fs.Buffer, str](rb);
+    var ok_res: bool = false;
+    if (b.len >= 64 && b.data[0] == 0x7F && b.data[1] == 0x45 && b.data[2] == 0x4C && b.data[3] == 0x46) {
+        ok_res = extract_soname(b.data, b.len, out, cap);
+    }
+    if (b.data != nil) { deallocate[u8](p.s.alloc, b.data, b.len + 1); }
+    ret ok_res;
+}
+
+# extract_soname: locate the DT_SONAME string in a parsed ELF64 image and copy it
+# into `out`. returns false when there is no dynamic section or DT_SONAME.
+fun extract_soname(buf: *u8, len: usize, out: *u8, cap: usize) bool {
+    val e_shoff:     usize = rd_u64(buf, 40)::usize;
+    val e_shentsize: usize = rd_u16(buf, 58)::usize;
+    val e_shnum:     usize = rd_u16(buf, 60)::usize;
+    if (e_shoff == 0 || e_shnum == 0) { ret false; }
+
+    # find SHT_DYNAMIC (type 6); its sh_link names the dynamic string table.
+    var dyn_off: usize = 0;
+    var dyn_size: usize = 0;
+    var dynstr_off: usize = 0;
+    var sh: usize = 0;
+    for (sh < e_shnum) {
+        val so: usize = e_shoff + sh * e_shentsize;
+        if (so + 64 > len) { ret false; }
+        if (rd_u32(buf, so + 4) == 6) {
+            dyn_off  = rd_u64(buf, so + 24)::usize;
+            dyn_size = rd_u64(buf, so + 32)::usize;
+            val link: usize = rd_u32(buf, so + 40)::usize;
+            if (link < e_shnum) {
+                val lo: usize = e_shoff + link * e_shentsize;
+                if (lo + 64 <= len) { dynstr_off = rd_u64(buf, lo + 24)::usize; }
+            }
+        }
+        sh = sh + 1;
+    }
+    if (dyn_off == 0 || dynstr_off == 0) { ret false; }
+
+    # walk the Elf64_Dyn array for DT_SONAME (tag 14).
+    var d: usize = 0;
+    for (d + 16 <= dyn_size) {
+        val eo: usize = dyn_off + d;
+        if (eo + 16 > len) { ret false; }
+        val tag: u64 = rd_u64(buf, eo);
+        if (tag == 0) { ret false; }
+        if (tag == 14) {
+            val str_at: usize = dynstr_off + rd_u64(buf, eo + 8)::usize;
+            var k: usize = 0;
+            for (str_at + k < len && buf[str_at + k] != 0 && k + 1 < cap) {
+                out[k] = buf[str_at + k];
+                k = k + 1;
+            }
+            out[k] = 0;
+            ret k > 0;
+        }
+        d = d + 16;
+    }
+    ret false;
+}
+
+# is_shared_path: whether a path/token names a shared library — it contains a
+# `.so` segment followed by end-of-string or a `.<version>` suffix (e.g. an
+# explicit `libc.so.6` or `path/to/libfoo.so`).
+fun is_shared_path(tok: *u8) bool {
+    if (tok == nil) { ret false; }
+    val n: usize = slen(tok);
+    if (n < 3) { ret false; }
+    var i: usize = 0;
+    for (i + 3 <= n) {
+        if (tok[i] == '.' && tok[i + 1] == 's' && tok[i + 2] == 'o') {
+            val after: usize = i + 3;
+            if (after == n || tok[after] == '.') { ret true; }
+        }
+        i = i + 1;
+    }
+    ret false;
+}
+
+# soname_basename: the final path component of a shared-library path — the soname
+# the loader resolves (e.g. `/usr/lib/libc.so.6` -> `libc.so.6`). returns the
+# pointer to the component within `path` (no copy); the caller interns it.
+fun soname_basename(path: *u8) *u8 {
+    val n: usize = slen(path);
+    var last: usize = 0;
+    var i: usize = 0;
+    for (i < n) {
+        if (path[i] == '/') { last = i + 1; }
+        i = i + 1;
+    }
+    ret (path::usize + last)::*u8;
+}
+
+# resolve_shared_into: resolve a bare `-l` name to a shared library `lib<name>.so`
+# (or a `.so.<version>`), searching each `-L <dir>`, then the OS default library
+# directory, then the common system library directories. writes the soname to
+# record for DT_NEEDED (the library's own DT_SONAME) into `buf`. returns true once
+# a real ELF shared library is found. a non-ELF match (a GNU ld linker script at
+# `lib<name>.so`) is skipped so a versioned `lib<name>.so.N` is preferred.
+fun resolve_shared_into(p: *driver.Project, name: *u8, argc: usize, argv: **u8, buf: *u8, cap: usize) bool {
+    var li: usize = 0;
+    for (li < argc) {
+        if (eq(argv[li], "-L") && li + 1 < argc) {
+            if (try_shared_in_dir(p, argv[li + 1], name, buf, cap)) { ret true; }
+        }
+        li = li + 1;
+    }
+    # the OS default library directory from the target vtable.
+    if (p.target.os != nil) {
+        val ld: Option[str] = intern.lookup(?p.s.interner, p.target.os.libdir);
+        if (is_some[str](ld)) {
+            if (try_shared_in_dir(p, unwrap[str](ld)::*u8, name, buf, cap)) { ret true; }
+        }
+    }
+    # the common multiarch/system library directories.
+    if (try_shared_in_dir(p, "/lib64"::*u8, name, buf, cap)) { ret true; }
+    if (try_shared_in_dir(p, "/usr/lib64"::*u8, name, buf, cap)) { ret true; }
+    if (try_shared_in_dir(p, "/lib/x86_64-linux-gnu"::*u8, name, buf, cap)) { ret true; }
+    if (try_shared_in_dir(p, "/usr/lib/x86_64-linux-gnu"::*u8, name, buf, cap)) { ret true; }
+    if (try_shared_in_dir(p, "/usr/lib"::*u8, name, buf, cap)) { ret true; }
+    if (try_shared_in_dir(p, "/lib"::*u8, name, buf, cap)) { ret true; }
+    ret false;
+}
+
+# try_shared_in_dir: probe `<dir>/lib<name>.so` then the common SONAME-bearing
+# `lib<name>.so.<N>` files for `N` in 6..0, accepting the first that is a real
+# ELF shared object (skipping a linker-script `lib<name>.so`). on a hit, writes
+# the library's own DT_SONAME (the canonical DT_NEEDED name) into `buf`.
+fun try_shared_in_dir(p: *driver.Project, dir: *u8, name: *u8, buf: *u8, cap: usize) bool {
+    var cand: [4096]u8;
+    if (write_named_candidate(dir, "lib", name, "so", ?cand[0], 4096) && accept_shared(p, ?cand[0], buf, cap)) { ret true; }
+    var v: i64 = 6;
+    for (v >= 0) {
+        if (write_named_versioned(dir, name, v::u32, ?cand[0], 4096) && accept_shared(p, ?cand[0], buf, cap)) { ret true; }
+        v = v - 1;
+    }
+    ret false;
+}
+
+# accept_shared: accept `cand` as a shared dependency if it is an existing real
+# ELF shared object, writing its DT_SONAME (or, lacking one, its basename) into
+# `buf`. returns false for a missing file or a non-ELF match (a linker script).
+fun accept_shared(p: *driver.Project, cand: *u8, buf: *u8, cap: usize) bool {
+    if (!fs.is_file(cstr_str(cand))) { ret false; }
+    if (read_so_soname(p, cand, buf, cap)) { ret true; }
+    ret false;
+}
+
+# write_named_versioned: compose `<dir>/lib<name>.so.<v>` into `buf`,
+# null-terminated. returns false if it would not fit or `v` exceeds one digit.
+fun write_named_versioned(dir: *u8, name: *u8, v: u32, buf: *u8, cap: usize) bool {
+    if (v > 9) { ret false; }
+    if (!write_named_candidate(dir, "lib", name, "so", buf, cap)) { ret false; }
+    val n: usize = slen(buf);
+    if (n + 3 > cap) { ret false; }
+    buf[n] = '.';
+    buf[n + 1] = ('0'::u32 + v)::u8;
+    buf[n + 2] = 0;
+    ret true;
 }
 
 # join_into_str: join `dir` and the fat-string `leaf` with a single '/'

--- a/src/cli/cmd/build.mach
+++ b/src/cli/cmd/build.mach
@@ -1095,14 +1095,19 @@ fun free_sonames(alloc: *Allocator, sonames: *intern.StrId, soname_count: u32) {
 }
 
 # store_shared: record an explicit shared-library `.so` file as a dynamic
-# dependency under its DT_SONAME, falling back to the path's basename when the
-# object carries none. the soname is the canonical run-time dependency name.
+# dependency under its DT_SONAME (or basename when the object carries none). the
+# file must be a loadable ELF shared object; a non-loadable `.so` (a GNU ld
+# linker script, or a non-ELF/non-shared file) is a hard error rather than a
+# silently-recorded DT_NEEDED that would make the binary fail to exec.
 fun store_shared(p: *driver.Project, path: *u8, sonames: **intern.StrId, soname_count: *u32) i64 {
     var sname: [4096]u8;
     if (read_so_soname(p, path, ?sname[0], 4096)) {
         ret append_soname(p, ?sname[0], sonames, soname_count);
     }
-    ret append_soname(p, soname_basename(path), sonames, soname_count);
+    emit("error: '");
+    emit(path);
+    emit("' is not a loadable ELF shared object (an ld script or unsupported '.so')\n");
+    ret 1;
 }
 
 # resolve_and_store_input: resolve one link-input token and route it to the right
@@ -1177,27 +1182,42 @@ fun rd_u64(buf: *u8, off: usize) u64 {
 }
 
 # read_so_soname: read a shared object's DT_SONAME and write it (null-terminated)
-# into `out`. parses the ELF64 dynamic section: finds the SHT_DYNAMIC section, its
-# linked string table, and the DT_SONAME (tag 14) entry, then copies the soname.
-# returns true on a real ELF64 shared/dynamic object carrying a DT_SONAME; false
-# for a non-ELF file (e.g. a GNU ld linker script) or one with no DT_SONAME, so
-# the caller falls back to the file's basename. this is the canonical
-# dependency name the loader resolves, so a versioned `libc.so.6` is recorded
-# even when the probe matched an unversioned `libc.so` symlink.
+# into `out`. accepts only a real ELF64 shared object (magic + ET_DYN): it writes
+# the object's DT_SONAME (tag 14, parsed from the SHT_DYNAMIC section and its
+# linked string table) when present, else the path's basename, and returns true.
+# returns false for anything that is NOT a loadable ELF shared object — a non-ELF
+# file (e.g. a GNU ld linker script like `libc.so` on some distros) or a
+# non-ET_DYN object — so a caller never records a DT_NEEDED for something the
+# loader cannot map. the DT_SONAME is the canonical dependency name, so a
+# versioned `libc.so.6` is recorded even when the probe matched a `libc.so` link.
 fun read_so_soname(p: *driver.Project, path: *u8, out: *u8, cap: usize) bool {
     val rb: Result[fs.Buffer, str] = fs.read_all_sized(p.s.alloc, cstr_str(path));
     if (is_err[fs.Buffer, str](rb)) { ret false; }
     val b: fs.Buffer = unwrap_ok[fs.Buffer, str](rb);
     var ok_res: bool = false;
-    if (b.len >= 64 && b.data[0] == 0x7F && b.data[1] == 0x45 && b.data[2] == 0x4C && b.data[3] == 0x46) {
-        ok_res = extract_soname(b.data, b.len, out, cap);
+    # ELF64 magic and e_type == ET_DYN (3) — a loadable shared object.
+    if (b.len >= 64 && b.data[0] == 0x7F && b.data[1] == 0x45 && b.data[2] == 0x4C
+        && b.data[3] == 0x46 && rd_u16(b.data, 16) == 3) {
+        if (!extract_soname(b.data, b.len, out, cap)) {
+            # a loadable shared object with no DT_SONAME: the basename is the
+            # canonical dependency name.
+            val base: *u8 = soname_basename(path);
+            val bl: usize = slen(base);
+            if (bl + 1 <= cap) {
+                var k: usize = 0;
+                for (k < bl) { out[k] = base[k]; k = k + 1; }
+                out[bl] = 0;
+            }
+        }
+        ok_res = true;
     }
     if (b.data != nil) { deallocate[u8](p.s.alloc, b.data, b.len + 1); }
     ret ok_res;
 }
 
 # extract_soname: locate the DT_SONAME string in a parsed ELF64 image and copy it
-# into `out`. returns false when there is no dynamic section or DT_SONAME.
+# into `out`. returns false when there is no dynamic section or DT_SONAME, so the
+# caller substitutes the file's basename.
 fun extract_soname(buf: *u8, len: usize, out: *u8, cap: usize) bool {
     val e_shoff:     usize = rd_u64(buf, 40)::usize;
     val e_shentsize: usize = rd_u16(buf, 58)::usize;

--- a/src/lang/be/linker.mach
+++ b/src/lang/be/linker.mach
@@ -1053,10 +1053,13 @@ fun patch_relocations(s: *sess.Session, out_img: *of.ObjectImage,
                 }
                 or {
                     # not defined anywhere: a dynamic import, or a hard error. a
-                    # pc-relative call to an import is deferred to the writer; any
-                    # other unresolved reference is rejected.
+                    # pc-relative call to a FUNCTION import is deferred to the
+                    # writer (only function imports get a PLT stub); any other
+                    # unresolved reference — including a call kind against a data
+                    # import (deferred) — is rejected as undefined.
                     val imp: Result[u32, str] = dynstate_import_index(dyn, r.symbol);
-                    if (is_ok[u32, str](imp) && is_call_kind(?kinds, r.kind)) {
+                    if (is_ok[u32, str](imp) && is_call_kind(?kinds, r.kind)
+                        && dynstate_import_is_func(dyn, unwrap_ok[u32, str](imp))) {
                         val rec_r: Result[bool, str] = dynstate_add_fixup(s, dyn,
                             segment_index_for(out_img, out_ix), patch_off,
                             unwrap_ok[u32, str](imp), patch_va, r.addend);
@@ -1223,6 +1226,14 @@ fun dynstate_import_index(dyn: *DynState, name: intern.StrId) Result[u32, str] {
     val g: Result[*u32, str] = map.get[intern.StrId, u32](?dyn.import_map, ?name);
     if (is_err[*u32, str](g)) { ret err[u32, str]("not an import"); }
     ret ok[u32, str](@unwrap_ok[*u32, str](g));
+}
+
+# dynstate_import_is_func: whether the plan import at `idx` is a function import —
+# only these get a PLT call-thunk, so only a call site targeting one is recorded
+# as a fixup. a data import (or an out-of-range index) is not.
+fun dynstate_import_is_func(dyn: *DynState, idx: u32) bool {
+    if (idx >= dyn.info.import_count) { ret false; }
+    ret dyn.info.imports[idx].is_func;
 }
 
 # is_call_kind: whether an abstract relocation kind is a pc-relative call/branch

--- a/src/lang/be/linker.mach
+++ b/src/lang/be/linker.mach
@@ -112,6 +112,27 @@ rec SymbolLoc {
     vaddr: u64;
 }
 
+# the linker's mutable dynamic-link state: the format-neutral plan (`of.DynamicInfo`)
+# being assembled plus the import call-site fixups (`of.PltFixup`) collected during
+# relocation patching, and the map from an imported symbol name to its index in the
+# plan's import array. empty for a static link; the writer consumes `info` + the
+# fixups. owns the `info.libs` / `info.imports` arrays and the fixup array.
+# ---
+# info:        the dynamic-link plan handed to `emit_dyn_exec`
+# import_map:  imported symbol name -> index into `info.imports`, for the patch pass
+# fixups:      collected import call-site fixups
+# fixup_count: number of fixups
+# fixup_cap:   capacity of the fixup array
+# active:      true once `build_dynamic_info` populated the plan (a dynamic link)
+rec DynState {
+    info:        of.DynamicInfo;
+    import_map:  map.Map[intern.StrId, u32];
+    fixups:      *of.PltFixup;
+    fixup_count: u32;
+    fixup_cap:   u32;
+    active:      bool;
+}
+
 # link: read the input object files from disk and combine them into the
 # requested artifact.
 #
@@ -120,18 +141,30 @@ rec SymbolLoc {
 # definitions), lays out the concatenated sections, and either (executable)
 # assigns virtual addresses, patches relocations, and writes page-aligned load
 # segments through `tgt.of.emit_exec`, or (library / relocatable) carries the
-# input relocations forward and writes a single merged object through
-# `obj.emit`. `LINK_SHARED` is not yet supported.
+# input relocations forward and writes a single merged object through `obj.emit`.
+#
+# DYNAMIC vs STATIC resolution of an undefined `ext` symbol: when no shared
+# dependencies are supplied (`soname_count == 0`) every undefined `ext` must be
+# satisfied by an input object/archive or the link fails — the fully static path,
+# emitted byte-for-byte as before through `emit_exec`. when shared dependencies
+# are supplied, any `ext` left undefined after merging is taken as a DYNAMIC
+# import bound at run time against those libraries, and the executable is emitted
+# through the format's `emit_dyn_exec` (ELF: PT_INTERP + .dynamic/PLT/GOT). a
+# static input definition always wins over a dynamic import of the same name.
+# `LINK_SHARED` (producing a shared object) is not yet supported.
 # ---
-# s:         shared session (allocator, interner, diagnostics)
-# tgt:       active target — selects OS base address, entry symbol, and writers
-# obj_paths: array of null-terminated paths to the per-module object files
-# obj_count: number of input object files
-# out_path:  null-terminated output file path
-# mode:      executable, relocatable (library), or shared
-# ret:       true once the artifact is written, or an error string
+# s:            shared session (allocator, interner, diagnostics)
+# tgt:          active target — selects OS base address, entry symbol, and writers
+# obj_paths:    array of null-terminated paths to the per-module object files
+# obj_count:    number of input object files
+# sonames:      interned shared-library sonames to depend on dynamically (or nil)
+# soname_count: number of shared-library dependencies
+# out_path:     null-terminated output file path
+# mode:         executable, relocatable (library), or shared
+# ret:          true once the artifact is written, or an error string
 pub fun link(s: *sess.Session, tgt: *target.Target, obj_paths: **u8,
-             obj_count: u32, out_path: *u8, mode: LinkMode) Result[bool, str] {
+             obj_count: u32, sonames: *intern.StrId, soname_count: u32,
+             out_path: *u8, mode: LinkMode) Result[bool, str] {
     if (s == nil)   { ret err[bool, str]("link: nil session"); }
     if (tgt == nil) { ret err[bool, str]("link: nil target"); }
     if (tgt.of == nil) { ret err[bool, str]("link: target has no object-format vtable"); }
@@ -142,6 +175,9 @@ pub fun link(s: *sess.Session, tgt: *target.Target, obj_paths: **u8,
     if (obj_paths == nil || obj_count == 0) {
         ret err[bool, str]("link: no input objects");
     }
+    # a dynamic link is requested when shared dependencies are present and the
+    # output is an executable; libraries/relocatables ignore dependencies.
+    val dynamic: bool = (mode == LINK_EXE) && (soname_count > 0);
 
     val alloc: *Allocator = s.alloc;
 
@@ -244,9 +280,29 @@ pub fun link(s: *sess.Session, tgt: *target.Target, obj_paths: **u8,
     # executable: resolve+patch relocations into the merged bytes, then write the
     # page-aligned load segments through the format's executable writer.
     if (mode == LINK_EXE) {
+        # the dynamic-link plan. for a static link `dyn` stays empty and every
+        # undefined `ext` must resolve against an input object, exactly as before;
+        # for a dynamic link the unresolved externs become imports and a relocation
+        # targeting one is recorded as a `PltFixup` instead of erroring.
+        var dyn: DynState;
+        init_dynstate(?dyn);
+        if (dynamic) {
+            val dr: Result[bool, str] =
+                build_dynamic_info(s, tgt, ?dyn, modules, module_count, ?sym_locs, sonames, soname_count);
+            if (is_err[bool, str](dr)) {
+                free_dynstate(alloc, ?dyn);
+                obj.dnit(?out_img);
+                map.dnit[intern.StrId, SymbolLoc](?sym_locs);
+                free_scratch(alloc, placements, sec_total, sec_base, module_count);
+                free_modules(alloc, modules, module_count);
+                ret err[bool, str](unwrap_err[bool, str](dr));
+            }
+        }
+
         val patch_r: Result[bool, str] =
-            patch_relocations(s, ?out_img, modules, module_count, placements, sec_base, ?sym_locs);
+            patch_relocations(s, ?out_img, modules, module_count, placements, sec_base, ?sym_locs, ?dyn);
         if (is_err[bool, str](patch_r)) {
+            free_dynstate(alloc, ?dyn);
             obj.dnit(?out_img);
             map.dnit[intern.StrId, SymbolLoc](?sym_locs);
             free_scratch(alloc, placements, sec_total, sec_base, module_count);
@@ -254,9 +310,15 @@ pub fun link(s: *sess.Session, tgt: *target.Target, obj_paths: **u8,
             ret err[bool, str](unwrap_err[bool, str](patch_r));
         }
 
-        val emit_r: Result[bool, str] =
-            emit_executable(s, tgt, ?out_img, ?merged[0], ?sym_locs, out_path);
+        var emit_r: Result[bool, str] = ok[bool, str](true);
+        if (dynamic) {
+            emit_r = emit_dynamic_executable(s, tgt, ?out_img, ?merged[0], ?sym_locs, ?dyn, out_path);
+        }
+        or {
+            emit_r = emit_executable(s, tgt, ?out_img, ?merged[0], ?sym_locs, out_path);
+        }
 
+        free_dynstate(alloc, ?dyn);
         obj.dnit(?out_img);
         map.dnit[intern.StrId, SymbolLoc](?sym_locs);
         free_scratch(alloc, placements, sec_total, sec_base, module_count);
@@ -527,32 +589,111 @@ fun emit_executable(s: *sess.Session, tgt: *target.Target, out_img: *of.ObjectIm
 
     val alloc: *Allocator = s.alloc;
 
-    # resolve the program entry point to the OS entry symbol's virtual address.
+    val er: Result[u64, str] = entry_vaddr(s, tgt, sym_locs);
+    if (is_err[u64, str](er)) { ret err[bool, str](unwrap_err[u64, str](er)); }
+    val entry: u64 = unwrap_ok[u64, str](er);
+
+    var seg_count: u32 = 0;
+    val sr: Result[*of.LoadSegment, str] = build_load_segments(alloc, out_img, merged, ?seg_count);
+    if (is_err[*of.LoadSegment, str](sr)) { ret err[bool, str](unwrap_err[*of.LoadSegment, str](sr)); }
+    val segs: *of.LoadSegment = unwrap_ok[*of.LoadSegment, str](sr);
+
+    val emit_r: Result[bool, str] =
+        tgt.of.emit_exec(alloc, tgt.arch, segs, seg_count, entry, out_path);
+
+    deallocate[of.LoadSegment](alloc, segs, seg_count::usize);
+
+    if (is_err[bool, str](emit_r)) {
+        ret err[bool, str](unwrap_err[bool, str](emit_r));
+    }
+    ret ok[bool, str](true);
+}
+
+# emit_dynamic_executable: lay the merged sections out as load segments and write
+# the dynamically-linked executable through the format's `emit_dyn_exec`,
+# handing it the dynamic plan and the import call-site fixups so it can frame the
+# format's dynamic-linking structures (ELF PT_INTERP/.dynamic/PLT/GOT) and
+# redirect each fixup to its import's call-thunk. the segment layout and entry
+# resolution are identical to the static path; only the writer differs. an
+# object format with no dynamic-link writer is rejected.
+# ---
+# s:        shared session (allocator, interner)
+# tgt:      active target — supplies the entry symbol and dynamic-exec writer
+# out_img:  the merged image holding the patched section bytes
+# merged:   the per-kind merged-section accumulators (carry vaddrs and lengths)
+# sym_locs: resolved symbol table, for the entry address
+# dyn:      the dynamic-link plan + collected import call-site fixups
+# out_path: null-terminated output file path
+# ret:      true once the executable is written, or an error string
+fun emit_dynamic_executable(s: *sess.Session, tgt: *target.Target, out_img: *of.ObjectImage,
+                            merged: *MergedSection, sym_locs: *map.Map[intern.StrId, SymbolLoc],
+                            dyn: *DynState, out_path: *u8) Result[bool, str] {
+    if (tgt.of.emit_dyn_exec == nil) {
+        ret err[bool, str]("link: object format cannot write dynamically-linked executables");
+    }
+    if (tgt.os == nil) {
+        ret err[bool, str]("link: target has no operating-system vtable");
+    }
+
+    val alloc: *Allocator = s.alloc;
+
+    val er: Result[u64, str] = entry_vaddr(s, tgt, sym_locs);
+    if (is_err[u64, str](er)) { ret err[bool, str](unwrap_err[u64, str](er)); }
+    val entry: u64 = unwrap_ok[u64, str](er);
+
+    var seg_count: u32 = 0;
+    val sr: Result[*of.LoadSegment, str] = build_load_segments(alloc, out_img, merged, ?seg_count);
+    if (is_err[*of.LoadSegment, str](sr)) { ret err[bool, str](unwrap_err[*of.LoadSegment, str](sr)); }
+    val segs: *of.LoadSegment = unwrap_ok[*of.LoadSegment, str](sr);
+
+    val emit_r: Result[bool, str] =
+        tgt.of.emit_dyn_exec(alloc, tgt.arch, segs, seg_count, entry,
+                             ?dyn.info, dyn.fixups, dyn.fixup_count, out_path);
+
+    deallocate[of.LoadSegment](alloc, segs, seg_count::usize);
+
+    if (is_err[bool, str](emit_r)) {
+        ret err[bool, str](unwrap_err[bool, str](emit_r));
+    }
+    ret ok[bool, str](true);
+}
+
+# entry_vaddr: resolve the program entry point to the OS entry symbol's virtual
+# address. an undefined or missing entry symbol is an error.
+fun entry_vaddr(s: *sess.Session, tgt: *target.Target,
+                sym_locs: *map.Map[intern.StrId, SymbolLoc]) Result[u64, str] {
     val entry_name: intern.StrId = tgt.os.entry_symbol;
     val el: Result[*SymbolLoc, str] =
         map.get[intern.StrId, SymbolLoc](sym_locs, ?entry_name);
     if (is_err[*SymbolLoc, str](el)) {
-        ret err[bool, str](entry_message(s, entry_name));
+        ret err[u64, str](entry_message(s, entry_name));
     }
-    val entry: u64 = unwrap_ok[*SymbolLoc, str](el).vaddr;
+    ret ok[u64, str](unwrap_ok[*SymbolLoc, str](el).vaddr);
+}
 
-    # one load segment per used loadable merged kind, in canonical
-    # (ascending-vaddr) order.
-    var seg_count: u32 = 0;
+# build_load_segments: build one `of.LoadSegment` per used loadable merged kind
+# (text, rodata, data, bss — debug is non-allocated and excluded), in canonical
+# (ascending-vaddr) order, writing the segment count through `seg_count`. each
+# segment's bytes are the already-patched merged-section content, its vaddr the
+# kind's assigned base, its permissions derived from the kind; bss carries memory
+# but no file bytes. the caller frees the returned array by `seg_count`.
+fun build_load_segments(alloc: *Allocator, out_img: *of.ObjectImage, merged: *MergedSection,
+                        seg_count: *u32) Result[*of.LoadSegment, str] {
+    var count: u32 = 0;
     var k: u32 = 0;
     for (k < MERGED_KIND_COUNT) {
         if (is_loadable_kind(merged[k].kind) && merged[k].used && merged[k].len > 0) {
-            seg_count = seg_count + 1;
+            count = count + 1;
         }
         k = k + 1;
     }
-    if (seg_count == 0) {
-        ret err[bool, str]("link: no loadable sections");
+    if (count == 0) {
+        ret err[*of.LoadSegment, str]("link: no loadable sections");
     }
 
-    val sr: Result[*of.LoadSegment, str] = zallocate[of.LoadSegment](alloc, seg_count::usize);
+    val sr: Result[*of.LoadSegment, str] = zallocate[of.LoadSegment](alloc, count::usize);
     if (is_err[*of.LoadSegment, str](sr)) {
-        ret err[bool, str](unwrap_err[*of.LoadSegment, str](sr));
+        ret err[*of.LoadSegment, str](unwrap_err[*of.LoadSegment, str](sr));
     }
     val segs: *of.LoadSegment = unwrap_ok[*of.LoadSegment, str](sr);
 
@@ -577,15 +718,8 @@ fun emit_executable(s: *sess.Session, tgt: *target.Target, out_img: *of.ObjectIm
         k = k + 1;
     }
 
-    val emit_r: Result[bool, str] =
-        tgt.of.emit_exec(alloc, tgt.arch, segs, seg_count, entry, out_path);
-
-    deallocate[of.LoadSegment](alloc, segs, seg_count::usize);
-
-    if (is_err[bool, str](emit_r)) {
-        ret err[bool, str](unwrap_err[bool, str](emit_r));
-    }
-    ret ok[bool, str](true);
+    @seg_count = count;
+    ret ok[*of.LoadSegment, str](segs);
 }
 
 # is_loadable_kind: whether a merged section kind becomes a loadable executable
@@ -866,7 +1000,10 @@ fun build_merged_image(s: *sess.Session, out_img: *of.ObjectImage,
 # patch_relocations: resolve each input relocation to its target symbol's final
 # virtual address and write the patched value into the merged section bytes.
 # absolute kinds store `sym + addend`; pc-relative kinds store
-# `sym + addend - patch_addr`. an undefined target symbol is an error.
+# `sym + addend - patch_addr`. an undefined target symbol is an error UNLESS it is
+# a dynamic import (`dyn.active`), in which case a pc-relative call site is
+# recorded as a `PltFixup` for the writer to redirect to the import's PLT stub
+# and patching is deferred.
 #
 # a relocation in module `m` references its target symbol by name, but a LOCAL
 # (object-private) target is resolved against module `m`'s own definition — never
@@ -876,7 +1013,8 @@ fun build_merged_image(s: *sess.Session, out_img: *of.ObjectImage,
 fun patch_relocations(s: *sess.Session, out_img: *of.ObjectImage,
                      modules: *of.ObjectImage, module_count: u32,
                      placements: *Placement, sec_base: *u32,
-                     sym_locs: *map.Map[intern.StrId, SymbolLoc]) Result[bool, str] {
+                     sym_locs: *map.Map[intern.StrId, SymbolLoc],
+                     dyn: *DynState) Result[bool, str] {
     # intern the abstract relocation-kind names once for fast comparison.
     val kinds: RelocKindIds = intern_reloc_kinds(s);
 
@@ -886,6 +1024,17 @@ fun patch_relocations(s: *sess.Session, out_img: *of.ObjectImage,
         for (ri < modules[m].reloc_count) {
             val r: *of.Relocation = ?modules[m].relocations[ri];
             if (r.section >= modules[m].section_count) { ri = ri + 1; cnt; }
+
+            # the patch site's location in the merged image. the placement's
+            # merged_index is a section *kind*; map it to the output-section index.
+            val flat: u32 = sec_base[m] + r.section;
+            val pl: *Placement = ?placements[flat];
+            val patch_va: u64 = pl.vaddr + r.offset::u64;
+            val out_ix: u32 = out_section_for_merged(out_img, pl.merged_index);
+            if (out_ix == 0xFFFFFFFF) { ri = ri + 1; cnt; }
+            val dst: *u8 = out_img.sections[out_ix].bytes;
+            if (dst == nil) { ri = ri + 1; cnt; }
+            val patch_off: u32 = pl.offset + r.offset;
 
             # locate the target symbol's final virtual address. a LOCAL target is
             # private to module `m`; resolve it against `m`'s own definition.
@@ -899,23 +1048,24 @@ fun patch_relocations(s: *sess.Session, out_img: *of.ObjectImage,
             or {
                 val sl: Result[*SymbolLoc, str] =
                     map.get[intern.StrId, SymbolLoc](sym_locs, ?r.symbol);
-                if (is_err[*SymbolLoc, str](sl)) {
+                if (is_ok[*SymbolLoc, str](sl)) {
+                    sym_va = unwrap_ok[*SymbolLoc, str](sl).vaddr;
+                }
+                or {
+                    # not defined anywhere: a dynamic import, or a hard error. a
+                    # pc-relative call to an import is deferred to the writer; any
+                    # other unresolved reference is rejected.
+                    val imp: Result[u32, str] = dynstate_import_index(dyn, r.symbol);
+                    if (is_ok[u32, str](imp) && is_call_kind(?kinds, r.kind)) {
+                        val rec_r: Result[bool, str] = dynstate_add_fixup(s, dyn,
+                            segment_index_for(out_img, out_ix), patch_off,
+                            unwrap_ok[u32, str](imp), patch_va, r.addend);
+                        if (is_err[bool, str](rec_r)) { ret err[bool, str](unwrap_err[bool, str](rec_r)); }
+                        ri = ri + 1; cnt;
+                    }
                     ret err[bool, str](undef_message(s, r.symbol));
                 }
-                sym_va = unwrap_ok[*SymbolLoc, str](sl).vaddr;
             }
-
-            # compute the patch site's virtual address and its byte location in
-            # the merged image. the placement's merged_index is a section *kind*;
-            # map it to the compacted output-section index.
-            val flat: u32 = sec_base[m] + r.section;
-            val pl: *Placement = ?placements[flat];
-            val patch_va: u64 = pl.vaddr + r.offset::u64;
-            val out_ix: u32 = out_section_for_merged(out_img, pl.merged_index);
-            if (out_ix == 0xFFFFFFFF) { ri = ri + 1; cnt; }
-            val dst: *u8 = out_img.sections[out_ix].bytes;
-            if (dst == nil) { ri = ri + 1; cnt; }
-            val patch_off: u32 = pl.offset + r.offset;
 
             val pr: Result[bool, str] =
                 apply_one(s, ?kinds, r.kind, dst, patch_off, out_img.sections[out_ix].len, sym_va, r.addend, patch_va, m, r.offset);
@@ -927,6 +1077,193 @@ fun patch_relocations(s: *sess.Session, out_img: *of.ObjectImage,
         }
         m = m + 1;
     }
+    ret ok[bool, str](true);
+}
+
+# init_dynstate: reset a DynState to the empty (static-link) state. its plan and
+# fixup array are populated only when a dynamic link is requested.
+fun init_dynstate(dyn: *DynState) {
+    dyn.info.libs         = nil;
+    dyn.info.lib_count    = 0;
+    dyn.info.imports      = nil;
+    dyn.info.import_count = 0;
+    dyn.info.interp       = intern.STR_NIL;
+    dyn.fixups            = nil;
+    dyn.fixup_count       = 0;
+    dyn.fixup_cap         = 0;
+    dyn.active            = false;
+}
+
+# free_dynstate: release the plan arrays, the fixup array, and the import map. a
+# no-op on the empty (static) state.
+fun free_dynstate(alloc: *Allocator, dyn: *DynState) {
+    if (dyn.info.libs != nil && dyn.info.lib_count > 0) {
+        deallocate[of.DynLib](alloc, dyn.info.libs, dyn.info.lib_count::usize);
+    }
+    if (dyn.info.imports != nil && dyn.info.import_count > 0) {
+        deallocate[of.DynImport](alloc, dyn.info.imports, dyn.info.import_count::usize);
+    }
+    if (dyn.fixups != nil && dyn.fixup_cap > 0) {
+        deallocate[of.PltFixup](alloc, dyn.fixups, dyn.fixup_cap::usize);
+    }
+    if (dyn.active) {
+        map.dnit[intern.StrId, u32](?dyn.import_map);
+    }
+    init_dynstate(dyn);
+}
+
+# build_dynamic_info: assemble the dynamic-link plan from the shared dependencies
+# and the undefined `ext` symbols left after symbol merging.
+#
+# every soname becomes a `DynLib` (a DT_NEEDED dependency, in input order). every
+# global `ext` symbol that no input object defines (not in `sym_locs`) becomes a
+# function `DynImport`, deduplicated by name through `import_map`; a relocation
+# targeting it is later bound to its PLT stub. the loader's global search resolves
+# each import against the dependencies, so imports are not pinned to a specific
+# library (`DYNLIB_ANY`). the interpreter path comes from the OS vtable; without
+# one the OS has no dynamic-link support and the link is rejected.
+fun build_dynamic_info(s: *sess.Session, tgt: *target.Target, dyn: *DynState,
+                       modules: *of.ObjectImage, module_count: u32,
+                       sym_locs: *map.Map[intern.StrId, SymbolLoc],
+                       sonames: *intern.StrId, soname_count: u32) Result[bool, str] {
+    val alloc: *Allocator = s.alloc;
+
+    val interp: intern.StrId = tgt.os.dynamic_linker;
+    if (interp == intern.STR_NIL) {
+        ret err[bool, str]("link: target OS has no dynamic loader for a dynamic link");
+    }
+    dyn.info.interp = interp;
+
+    # one DynLib per soname, in input order.
+    if (soname_count > 0) {
+        val lr: Result[*of.DynLib, str] = zallocate[of.DynLib](alloc, soname_count::usize);
+        if (is_err[*of.DynLib, str](lr)) { ret err[bool, str](unwrap_err[*of.DynLib, str](lr)); }
+        dyn.info.libs = unwrap_ok[*of.DynLib, str](lr);
+        var i: u32 = 0;
+        for (i < soname_count) {
+            dyn.info.libs[i].soname = sonames[i];
+            i = i + 1;
+        }
+        dyn.info.lib_count = soname_count;
+    }
+
+    dyn.import_map = map.init[intern.StrId, u32](alloc, maphash.hash_u32, maphash.eq_u32);
+    dyn.active = true;
+
+    # count distinct undefined externs first so the import array is sized exactly.
+    var seen: map.Map[intern.StrId, u32] =
+        map.init[intern.StrId, u32](alloc, maphash.hash_u32, maphash.eq_u32);
+    var n_imports: u32 = 0;
+    var m: u32 = 0;
+    for (m < module_count) {
+        var sy: u32 = 0;
+        for (sy < modules[m].symbol_count) {
+            val sym: *of.Symbol = ?modules[m].symbols[sy];
+            if (!is_undefined_extern(sym)) { sy = sy + 1; cnt; }
+            if (is_ok[*SymbolLoc, str](map.get[intern.StrId, SymbolLoc](sym_locs, ?sym.name))) { sy = sy + 1; cnt; }
+            if (is_ok[*u32, str](map.get[intern.StrId, u32](?seen, ?sym.name))) { sy = sy + 1; cnt; }
+            val ins: Result[bool, str] = map.insert[intern.StrId, u32](?seen, sym.name, n_imports);
+            if (is_err[bool, str](ins)) { map.dnit[intern.StrId, u32](?seen); ret err[bool, str](unwrap_err[bool, str](ins)); }
+            n_imports = n_imports + 1;
+            sy = sy + 1;
+        }
+        m = m + 1;
+    }
+    map.dnit[intern.StrId, u32](?seen);
+
+    if (n_imports == 0) { ret ok[bool, str](true); }
+
+    val ir: Result[*of.DynImport, str] = zallocate[of.DynImport](alloc, n_imports::usize);
+    if (is_err[*of.DynImport, str](ir)) { ret err[bool, str](unwrap_err[*of.DynImport, str](ir)); }
+    dyn.info.imports = unwrap_ok[*of.DynImport, str](ir);
+
+    # populate the imports and the name->index map (dedup by name).
+    m = 0;
+    for (m < module_count) {
+        var sy: u32 = 0;
+        for (sy < modules[m].symbol_count) {
+            val sym: *of.Symbol = ?modules[m].symbols[sy];
+            if (!is_undefined_extern(sym)) { sy = sy + 1; cnt; }
+            if (is_ok[*SymbolLoc, str](map.get[intern.StrId, SymbolLoc](sym_locs, ?sym.name))) { sy = sy + 1; cnt; }
+            if (is_ok[*u32, str](map.get[intern.StrId, u32](?dyn.import_map, ?sym.name))) { sy = sy + 1; cnt; }
+
+            val idx: u32 = dyn.info.import_count;
+            dyn.info.imports[idx].symbol    = sym.name;
+            dyn.info.imports[idx].lib_index = of.DYNLIB_ANY;
+            # every undefined extern reaches the linker as a code symbol today
+            # (an `ext fun`); data imports would clear this once supported.
+            dyn.info.imports[idx].is_func   = true;
+            val ins: Result[bool, str] = map.insert[intern.StrId, u32](?dyn.import_map, sym.name, idx);
+            if (is_err[bool, str](ins)) { ret err[bool, str](unwrap_err[bool, str](ins)); }
+            dyn.info.import_count = idx + 1;
+
+            sy = sy + 1;
+        }
+        m = m + 1;
+    }
+    ret ok[bool, str](true);
+}
+
+# is_undefined_extern: whether an object symbol is an undefined external — a
+# reference the owning object does not define. these are the candidates for a
+# dynamic import when no input object supplies the definition.
+fun is_undefined_extern(sym: *of.Symbol) bool {
+    if (sym.section != of.SECTION_EXTERNAL) { ret false; }
+    if ((sym.flags & of.SYM_OBJ_FLAG_GLOBAL) == 0) { ret false; }
+    ret true;
+}
+
+# dynstate_import_index: the plan import index for symbol `name`, or err when it
+# is not a dynamic import (so the caller falls through to the undefined-symbol
+# error).
+fun dynstate_import_index(dyn: *DynState, name: intern.StrId) Result[u32, str] {
+    if (!dyn.active) { ret err[u32, str]("not dynamic"); }
+    val g: Result[*u32, str] = map.get[intern.StrId, u32](?dyn.import_map, ?name);
+    if (is_err[*u32, str](g)) { ret err[u32, str]("not an import"); }
+    ret ok[u32, str](@unwrap_ok[*u32, str](g));
+}
+
+# is_call_kind: whether an abstract relocation kind is a pc-relative call/branch
+# that can be redirected through a PLT stub. only these are bound to an import's
+# thunk; an absolute reference to an import is unsupported and stays an error.
+fun is_call_kind(kinds: *RelocKindIds, kind: intern.StrId) bool {
+    ret kind == kinds.pc32 || kind == kinds.plt32;
+}
+
+# segment_index_for: the load-segment index a merged output section maps to in the
+# writer's segment array. the writer builds one segment per loadable used section
+# in output order, so the index is the count of loadable sections before `out_ix`.
+fun segment_index_for(out_img: *of.ObjectImage, out_ix: u32) u32 {
+    var seg: u32 = 0;
+    var i: u32 = 0;
+    for (i < out_ix && i < out_img.section_count) {
+        if (is_loadable_kind(out_img.sections[i].kind)) { seg = seg + 1; }
+        i = i + 1;
+    }
+    ret seg;
+}
+
+# dynstate_add_fixup: append an import call-site fixup, growing the array
+# geometrically. the writer redirects each to its import's PLT stub.
+fun dynstate_add_fixup(s: *sess.Session, dyn: *DynState, seg_index: u32, seg_offset: u32,
+                       import_index: u32, patch_vaddr: u64, addend: i64) Result[bool, str] {
+    val alloc: *Allocator = s.alloc;
+    if (dyn.fixup_count == dyn.fixup_cap) {
+        var new_cap: u32 = dyn.fixup_cap * 2;
+        if (new_cap == 0) { new_cap = 4; }
+        val gr: Result[*of.PltFixup, str] =
+            reallocate[of.PltFixup](alloc, dyn.fixups, dyn.fixup_cap::usize, new_cap::usize);
+        if (is_err[*of.PltFixup, str](gr)) { ret err[bool, str](unwrap_err[*of.PltFixup, str](gr)); }
+        dyn.fixups = unwrap_ok[*of.PltFixup, str](gr);
+        dyn.fixup_cap = new_cap;
+    }
+    val ix: u32 = dyn.fixup_count;
+    dyn.fixups[ix].seg_index    = seg_index;
+    dyn.fixups[ix].seg_offset   = seg_offset;
+    dyn.fixups[ix].import_index = import_index;
+    dyn.fixups[ix].patch_vaddr  = patch_vaddr;
+    dyn.fixups[ix].addend       = addend;
+    dyn.fixup_count = ix + 1;
     ret ok[bool, str](true);
 }
 

--- a/src/lang/be/linker.mach
+++ b/src/lang/be/linker.mach
@@ -1190,9 +1190,11 @@ fun build_dynamic_info(s: *sess.Session, tgt: *target.Target, dyn: *DynState,
             val idx: u32 = dyn.info.import_count;
             dyn.info.imports[idx].symbol    = sym.name;
             dyn.info.imports[idx].lib_index = of.DYNLIB_ANY;
-            # every undefined extern reaches the linker as a code symbol today
-            # (an `ext fun`); data imports would clear this once supported.
-            dyn.info.imports[idx].is_func   = true;
+            # a function import gets a PLT call-thunk; a data import (no FUNCTION
+            # flag) is recorded but not yet bound — its abs reference still hits
+            # the undefined-symbol error in patch_relocations, since data imports
+            # (GLOB_DAT) are deferred.
+            dyn.info.imports[idx].is_func   = (sym.flags & of.SYM_OBJ_FLAG_FUNCTION) != 0;
             val ins: Result[bool, str] = map.insert[intern.StrId, u32](?dyn.import_map, sym.name, idx);
             if (is_err[bool, str](ins)) { ret err[bool, str](unwrap_err[bool, str](ins)); }
             dyn.info.import_count = idx + 1;

--- a/src/lang/target/of.mach
+++ b/src/lang/target/of.mach
@@ -157,6 +157,81 @@ pub rec ObjectImage {
     reloc_count:   u32;
 }
 
+# one dynamic dependency of a linked image: a shared library that must be loaded
+# at run time (ELF `DT_NEEDED`, PE import-directory DLL, Mach-O `LC_LOAD_DYLIB`).
+# the linker collects one per shared-library link input; the format writer emits
+# it into the format's dependency list. format-neutral so PE/Mach-O reuse it.
+# ---
+# soname: interned shared-object name the loader resolves (e.g. "libc.so.6")
+pub rec DynLib {
+    soname: intern.StrId;
+}
+
+# one dynamic import: an undefined symbol satisfied at run time by a shared
+# library rather than by an in-graph definition. the linker creates one per
+# unresolved `ext` symbol when shared dependencies are present, instead of
+# erroring. the format writer turns each into a binding record (ELF
+# `.rela.plt`/`.dynsym`, PE `.idata` IAT slot, Mach-O dyld bind opcode) and, for
+# a function import, a call-thunk (ELF PLT stub) the linker points call sites at.
+# format-neutral so PE `.idata` and Mach-O dyld bind reuse the same model.
+# ---
+# symbol:    interned imported symbol name (the `ext` name, e.g. "getpid")
+# lib_index: index into the image's `DynLib` list of the providing library, or
+#            DYNLIB_ANY when the binding is left to the loader's global search
+# is_func:   true for a code (call) import needing a call-thunk; false for data
+pub rec DynImport {
+    symbol:    intern.StrId;
+    lib_index: u32;
+    is_func:   bool;
+}
+
+# sentinel `DynImport.lib_index` marking an import not pinned to a specific
+# dependency — the loader resolves it through its global symbol search.
+pub val DYNLIB_ANY: u32 = 0xFFFFFFFF;
+
+# the complete format-neutral plan for a dynamically-linked image: the shared
+# dependencies to record and the imports to bind. the linker builds this from the
+# unresolved `ext` symbols and the shared-library link inputs; a format's
+# `emit_dyn_exec` consumes it to lay out the format's dynamic-linking structures
+# (ELF `.dynamic`/PLT/GOT, PE `.idata`, Mach-O dyld info). when `lib_count` and
+# `import_count` are both zero the link is fully static and `emit_exec` is used.
+# ---
+# libs:         array of shared dependencies (DT_NEEDED order)
+# lib_count:    number of dependencies
+# imports:      array of imports to bind
+# import_count: number of imports
+# interp:       interned dynamic-loader path for PT_INTERP (e.g. the ELF interp),
+#               or intern.STR_NIL when the format embeds the loader differently
+pub rec DynamicInfo {
+    libs:         *DynLib;
+    lib_count:    u32;
+    imports:      *DynImport;
+    import_count: u32;
+    interp:       intern.StrId;
+}
+
+# one pc-relative call site the linker located that targets a dynamic import, to
+# be redirected to the import's call-thunk by `emit_dyn_exec`. the linker cannot
+# resolve it during relocation patching because the thunk's address is part of
+# the format's dynamic layout (ELF PLT), which the writer owns; it instead
+# records the patch site here and the writer fills in `S + A - P` once the thunk
+# is placed. `S` is the thunk vaddr; `A`/`P` are carried so the writer reproduces
+# the exact pc-relative displacement. format-neutral: PE/Mach-O reuse it to point
+# a call at an IAT/stub.
+# ---
+# seg_index:    index into the writer's segment array of the patched segment
+# seg_offset:   byte offset of the 4-byte pc-relative field within that segment
+# import_index: index into `DynamicInfo.imports` of the targeted import
+# patch_vaddr:  virtual address of the patch site (the `P` in `S + A - P`)
+# addend:       relocation addend (the `A`)
+pub rec PltFixup {
+    seg_index:    u32;
+    seg_offset:   u32;
+    import_index: u32;
+    patch_vaddr:  u64;
+    addend:       i64;
+}
+
 # one loadable segment of a static executable, in the format-neutral terms the
 # linker lays out and a format's `emit_exec` consumes. each segment maps a
 # contiguous run of bytes at a page-aligned virtual address; `memsz` exceeds
@@ -231,11 +306,35 @@ pub def ParserFn: fun(*Allocator, *u8, usize, *ObjectImage) Result[bool, str];
 # ret:   true on success, or an error string
 pub def ExecFn: fun(*Allocator, *isa.IsaVTable, *LoadSegment, u32, u64, *u8) Result[bool, str];
 
+# a dynamically-linked-executable writer: serializes the linker's laid-out load
+# segments into a dynamically-linked executable, framing the format's
+# dynamic-linking structures (ELF `PT_INTERP`/`.dynamic`/`.dynsym`/PLT/GOT, PE
+# `.idata`, Mach-O dyld info) around them. takes the same segments and entry as
+# `ExecFn` plus the `DynamicInfo` plan (dependencies + imports) and the call-site
+# fixups the linker could not resolve. the writer places each import's call-thunk
+# (ELF PLT stub) in its own layout, then patches every `PltFixup` to point at the
+# matching thunk. like the other writers it takes the `IsaVTable`, not the full
+# Target, to break the target↔object-format import cycle. used in place of
+# `emit_exec` when `DynamicInfo` carries any dependency or import.
+# ---
+# arg 0: allocator backing the writer's output buffer
+# arg 1: the instruction-set vtable describing the machine
+# arg 2: the loadable segments, in ascending virtual-address order
+# arg 3: number of load segments
+# arg 4: program entry-point virtual address
+# arg 5: the dynamic-link plan (dependencies, imports, interpreter)
+# arg 6: the import call-site fixups to redirect to call-thunks
+# arg 7: number of fixups
+# arg 8: null-terminated output file path
+# ret:   true on success, or an error string
+pub def DynExecFn: fun(*Allocator, *isa.IsaVTable, *LoadSegment, u32, u64,
+                       *DynamicInfo, *PltFixup, u32, *u8) Result[bool, str];
+
 # the object-format runtime-dispatch interface. exactly one of these exists
 # per format; the back end serializes through `emit_object`, the linker reads
-# through `parse_object` and writes executables through `emit_exec`, and all
-# consult `relocation_kinds` to map abstract relocations. it never branches on
-# `id`.
+# through `parse_object` and writes executables through `emit_exec` (or
+# `emit_dyn_exec` for a dynamic link), and all consult `relocation_kinds` to map
+# abstract relocations. it never branches on `id`.
 # ---
 # id:               object-format id (one of OF_*)
 # name:             interned format name ("elf", "coff", "macho")
@@ -243,6 +342,8 @@ pub def ExecFn: fun(*Allocator, *isa.IsaVTable, *LoadSegment, u32, u64, *u8) Res
 # emit_object:      serializes an ObjectImage to a relocatable object file
 # parse_object:     reads a relocatable object file into an ObjectImage
 # emit_exec:        serializes laid-out load segments into a static executable
+# emit_dyn_exec:    serializes them into a dynamically-linked executable, or nil
+#                   when the format has no dynamic-link writer yet
 # relocation_kinds: array mapping abstract RK_* kinds to machine types
 # relocation_count: number of relocation-kind entries
 pub rec OfVTable {
@@ -252,6 +353,7 @@ pub rec OfVTable {
     emit_object:      WriterFn;
     parse_object:     ParserFn;
     emit_exec:        ExecFn;
+    emit_dyn_exec:    DynExecFn;
     relocation_kinds: *RelocationKind;
     relocation_count: u32;
 }

--- a/src/lang/target/of/coff.mach
+++ b/src/lang/target/of/coff.mach
@@ -153,6 +153,8 @@ pub fun register_coff(alloc: *Allocator, i: *intern.Interner) Result[bool, str] 
     coff_vtable.emit_object      = coff_emit_object;
     coff_vtable.parse_object     = coff_parse_object;
     coff_vtable.emit_exec        = coff_emit_exec;
+    # PE `.idata` import-table emission is unimplemented (#1175).
+    coff_vtable.emit_dyn_exec    = nil::of.DynExecFn;
     coff_vtable.relocation_kinds = ?coff_reloc_kinds[0];
     coff_vtable.relocation_count = 4;
 

--- a/src/lang/target/of/elf.mach
+++ b/src/lang/target/of/elf.mach
@@ -998,8 +998,8 @@ fun dynstr_name_len(id: intern.StrId) usize {
 # above the linker's segments: a read-only metadata segment, a read+execute .plt
 # segment, and a read+write .got.plt/.dynamic segment. each call site the linker
 # could not resolve (a `PltFixup`) is patched to its import's PLT stub. the image
-# is ET_DYN (a PIE-form dynamic executable) so the loader maps it; the static
-# `emit_exec` ET_EXEC path is untouched.
+# is ET_EXEC (a fixed-address dynamic executable, not a PIE) so the linker's
+# absolute virtual addresses stay valid; the static `emit_exec` path is untouched.
 # ---
 # alloc:       allocator for the output buffer and layout scratch
 # tgt_isa:     instruction-set vtable selecting the ELF machine and JUMP_SLOT type
@@ -1128,10 +1128,18 @@ fun emit_dyn_exec(alloc: *Allocator, tgt_isa: *isa.IsaVTable, segs: *of.LoadSegm
 
     # write the synthesized structures, then patch the import call sites.
     write_dyn_structures(buf, ?lay, dyn, nimp, tgt_isa.id, imp_str, lib_str);
-    patch_plt_fixups(buf, ?lay, dyn, fixups, fixup_count, seg_offsets, segs, seg_count, nimp);
+    val fx_r: Result[bool, str] =
+        patch_plt_fixups(buf, ?lay, dyn, fixups, fixup_count, seg_offsets, segs, seg_count, nimp);
 
     if (imp_str != nil) { deallocate[usize](alloc, imp_str, dyn.import_count::usize); }
     if (lib_str != nil) { deallocate[usize](alloc, lib_str, dyn.lib_count::usize); }
+
+    # an out-of-range call-site fixup fails the link rather than corrupting bytes.
+    if (is_err[bool, str](fx_r)) {
+        if (seg_offsets != nil) { deallocate[usize](alloc, seg_offsets, seg_count::usize); }
+        deallocate[u8](alloc, buf, total_size);
+        ret err[bool, str](unwrap_err[bool, str](fx_r));
+    }
 
     # program headers: leading header-cover PT_LOAD, PT_INTERP, the linker
     # segments, the RO/PLT/RW synthesized segments, then PT_DYNAMIC.
@@ -1445,10 +1453,15 @@ fun write_plt_stub(buf: *u8, lay: *DynLayout, n: u32) {
 # not resolve) to a pc-relative call to the import's PLT stub. the fixup records
 # the segment + offset of the 4-byte displacement field and the patch-site vaddr;
 # the stub vaddr is `S` and the patched value is `S + A - P`.
+#
+# because the linker deferred this site, `apply_one`'s pc32 range/bounds checks
+# never ran for it, so they are enforced here: the 4-byte field must lie within
+# the segment's file bytes and the displacement must fit a signed 32-bit value. a
+# violation fails the link rather than writing out of bounds or truncating.
 fun patch_plt_fixups(buf: *u8, lay: *DynLayout, dyn: *of.DynamicInfo,
                      fixups: *of.PltFixup, fixup_count: u32, seg_offsets: *usize,
-                     segs: *of.LoadSegment, seg_count: u32, nimp: u32) {
-    if (nimp == 0) { ret; }
+                     segs: *of.LoadSegment, seg_count: u32, nimp: u32) Result[bool, str] {
+    if (nimp == 0) { ret ok[bool, str](true); }
     var i: u32 = 0;
     for (i < fixup_count) {
         val fx: *of.PltFixup = ?fixups[i];
@@ -1456,12 +1469,25 @@ fun patch_plt_fixups(buf: *u8, lay: *DynLayout, dyn: *of.DynamicInfo,
         # the func-import ordinal of this fixup's target import (its PLT slot).
         val n: u32 = func_ordinal(dyn, fx.import_index);
         if (n == 0xFFFFFFFF) { i = i + 1; cnt; }
+
+        # the 4-byte displacement field must lie fully within the segment's file
+        # bytes; the writer placed those bytes at `seg_offsets[seg_index]`.
+        val seg_filesz: usize = segs[fx.seg_index].filesz;
+        if (fx.seg_offset::usize + 4 > seg_filesz) {
+            ret err[bool, str]("elf: dynamic call-site fixup offset out of range");
+        }
+
         val stub_va: u64 = lay.plt_va + (n + 1)::u64 * PLT_ENTRY_SIZE::u64;
         val disp: i64 = (stub_va::i64) + fx.addend - (fx.patch_vaddr::i64);
+        if (disp > 2147483647 || disp < -2147483648) {
+            ret err[bool, str]("elf: dynamic call-site displacement overflows 32 bits");
+        }
+
         val file_off: usize = seg_offsets[fx.seg_index] + fx.seg_offset::usize;
         write_u32_le(buf, file_off, (disp::u64)::u32);
         i = i + 1;
     }
+    ret ok[bool, str](true);
 }
 
 # func_ordinal: the PLT slot index (0-based among function imports) for the

--- a/src/lang/target/of/elf.mach
+++ b/src/lang/target/of/elf.mach
@@ -102,10 +102,36 @@ val R_AARCH64_PREL32: u32 = 261;
 val R_AARCH64_CALL26: u32 = 283;
 
 # ELF program header types and flags.
-val PT_LOAD: u32 = 1;
+val PT_LOAD:    u32 = 1;
+val PT_DYNAMIC: u32 = 2;
+val PT_INTERP:  u32 = 3;
+val PT_PHDR:    u32 = 6;
 val PF_X: u32 = 1;
 val PF_W: u32 = 2;
 val PF_R: u32 = 4;
+
+# ELF PLT/GOT dynamic relocation types.
+val R_X86_64_JUMP_SLOT: u32 = 7;
+val R_AARCH64_JUMP_SLOT: u32 = 1026;
+
+# ELF `.dynamic` tag ids consumed by the loader. only the tags a minimal
+# dynamically-linked PLT image needs are listed.
+val DT_NULL:     u64 = 0;
+val DT_NEEDED:   u64 = 1;
+val DT_PLTRELSZ: u64 = 2;
+val DT_PLTGOT:   u64 = 3;
+val DT_HASH:     u64 = 4;
+val DT_STRTAB:   u64 = 5;
+val DT_SYMTAB:   u64 = 6;
+val DT_STRSZ:    u64 = 10;
+val DT_SYMENT:   u64 = 11;
+val DT_PLTREL:   u64 = 20;
+val DT_JMPREL:   u64 = 23;
+
+# fixed on-disk sizes of the dynamic-link structures (ELF64).
+val DYN_SIZE: usize = 16;
+val GOT_ENTRY_SIZE: usize = 8;
+val PLT_ENTRY_SIZE: usize = 16;
 
 # fixed on-disk structure sizes for ELF64.
 val ELF_HEADER_SIZE: usize = 64;
@@ -171,6 +197,12 @@ fun write_str(buf: *u8, offset: usize, s: str) usize {
 
 # align a usize up to the given power-of-two alignment.
 fun align_up(value: usize, alignment: usize) usize {
+    if (alignment == 0) { ret value; }
+    ret (value + alignment - 1) & ~(alignment - 1);
+}
+
+# align a u64 virtual address up to the given power-of-two alignment.
+fun align_up_u64(value: u64, alignment: u64) u64 {
     if (alignment == 0) { ret value; }
     ret (value + alignment - 1) & ~(alignment - 1);
 }
@@ -756,6 +788,7 @@ pub fun register(i: *intern.Interner) Result[bool, str] {
     elf_vtable.emit_object      = emit_object;
     elf_vtable.parse_object     = parse_object;
     elf_vtable.emit_exec        = emit_exec;
+    elf_vtable.emit_dyn_exec    = emit_dyn_exec;
     elf_vtable.relocation_kinds = ?elf_reloc_kinds[0];
     elf_vtable.relocation_count = 5;
 
@@ -895,6 +928,634 @@ fun emit_exec(alloc: *Allocator, tgt_isa: *isa.IsaVTable, segs: *of.LoadSegment,
 
     if (is_err[usize, str](res_write)) { ret err[bool, str]("elf: exec write failed"); }
     ret ok[bool, str](true);
+}
+
+# the ELF machine JUMP_SLOT (PLT) relocation type for an ISA. defaults to the
+# x86-64 type for unknown ISAs (the dynamic writer is x86-64-only for now).
+fun jump_slot_for(arch_id: u32) u32 {
+    if (arch_id == isa.ARCH_AARCH64) { ret R_AARCH64_JUMP_SLOT; }
+    ret R_X86_64_JUMP_SLOT;
+}
+
+# the resolved layout of every synthesized dynamic-link structure, computed once
+# from the import/dependency counts and the address the structures start at, then
+# consumed by the write pass. every `*_off` is a file offset; every `*_va` is the
+# matching virtual address. the RO group (.interp/.dynsym/.dynstr/.hash/.rela.plt)
+# shares one page-aligned load segment, .plt its own R+X segment, and
+# .got.plt/.dynamic a final R+W segment.
+# ---
+# ro_off/ro_va/ro_size:       read-only metadata segment span
+# interp_off/interp_va:       PT_INTERP string
+# dynsym_off/dynsym_va:       .dynsym (Elf64_Sym[1 + import_count])
+# dynstr_off/dynstr_va/size:  .dynstr (NUL + names + sonames)
+# hash_off/hash_va:           .hash (SysV: nbucket,nchain,buckets,chain)
+# relaplt_off/relaplt_va/sz:  .rela.plt (Elf64_Rela[func_import_count])
+# plt_off/plt_va/plt_size:    .plt (R+X), header + one stub per func import
+# rw_off/rw_va/rw_size:       writable segment span (.got.plt + .dynamic)
+# gotplt_off/gotplt_va:       .got.plt (GOT[0..2] reserved + one per func import)
+# dynamic_off/dynamic_va/sz:  .dynamic (Elf64_Dyn array)
+rec DynLayout {
+    ro_off: usize;       ro_va: u64;        ro_size: usize;
+    interp_off: usize;   interp_va: u64;    interp_size: usize;
+    dynsym_off: usize;   dynsym_va: u64;
+    dynstr_off: usize;   dynstr_va: u64;    dynstr_size: usize;
+    hash_off: usize;     hash_va: u64;      hash_size: usize;
+    relaplt_off: usize;  relaplt_va: u64;   relaplt_size: usize;
+    plt_off: usize;      plt_va: u64;       plt_size: usize;
+    rw_off: usize;       rw_va: u64;        rw_size: usize;
+    gotplt_off: usize;   gotplt_va: u64;    gotplt_size: usize;
+    dynamic_off: usize;  dynamic_va: u64;   dynamic_size: usize;
+}
+
+# count the function imports in a dynamic plan — only these get a PLT stub, a
+# GOT.PLT slot, and a `.rela.plt` JUMP_SLOT entry. data imports (none emitted
+# today) would bind through a GLOB_DAT relocation instead.
+fun func_import_count(dyn: *of.DynamicInfo) u32 {
+    var n: u32 = 0;
+    var i: u32 = 0;
+    for (i < dyn.import_count) {
+        if (dyn.imports[i].is_func) { n = n + 1; }
+        i = i + 1;
+    }
+    ret n;
+}
+
+# the byte length of an interned name (its text plus the NUL terminator).
+fun dynstr_name_len(id: intern.StrId) usize {
+    val s: str = resolve(id);
+    if (s == nil) { ret 1; }
+    ret str_len(s) + 1;
+}
+
+# emit_dyn_exec: write a dynamically-linked ET_DYN ELF executable. installed in
+# the ELF `of.OfVTable` as its `of.DynExecFn`.
+#
+# frames the linker's laid-out load segments with the ELF dynamic-linking
+# structures: a PT_INTERP naming the run-time loader, a .dynamic table listing a
+# DT_NEEDED per shared dependency, the .dynsym/.dynstr/.hash dynamic symbol
+# tables, and a PLT/GOT with a `.rela.plt` JUMP_SLOT relocation per imported
+# function. the synthesized structures occupy three new load segments placed
+# above the linker's segments: a read-only metadata segment, a read+execute .plt
+# segment, and a read+write .got.plt/.dynamic segment. each call site the linker
+# could not resolve (a `PltFixup`) is patched to its import's PLT stub. the image
+# is ET_DYN (a PIE-form dynamic executable) so the loader maps it; the static
+# `emit_exec` ET_EXEC path is untouched.
+# ---
+# alloc:       allocator for the output buffer and layout scratch
+# tgt_isa:     instruction-set vtable selecting the ELF machine and JUMP_SLOT type
+# segs:        the linker's loadable segments, ascending virtual-address order
+# seg_count:   number of segments
+# entry:       program entry-point virtual address
+# dyn:         the dynamic-link plan (dependencies, imports, interpreter path)
+# fixups:      import call-site fixups to redirect to PLT stubs
+# fixup_count: number of fixups
+# path:        null-terminated output file path
+# ret:         ok(true) on success, or an error string
+fun emit_dyn_exec(alloc: *Allocator, tgt_isa: *isa.IsaVTable, segs: *of.LoadSegment,
+                  seg_count: u32, entry: u64, dyn: *of.DynamicInfo,
+                  fixups: *of.PltFixup, fixup_count: u32, path: *u8) Result[bool, str] {
+    if (tgt_isa == nil) { ret err[bool, str]("elf: nil dyn-exec isa"); }
+    if (path == nil)    { ret err[bool, str]("elf: nil dyn-exec path"); }
+    if (dyn == nil)     { ret err[bool, str]("elf: nil dynamic plan"); }
+    if (elf_interner == nil) { ret err[bool, str]("elf: no interner registered for dyn-exec"); }
+
+    val nimp: u32 = func_import_count(dyn);
+
+    # the highest virtual address the linker's segments reach; the synthesized
+    # dynamic structures are placed page-aligned above it so the linker's segment
+    # vaddrs (and the patched call sites' targets) stay valid.
+    var hi_va: u64 = 0;
+    var li: u32 = 0;
+    for (li < seg_count) {
+        val end: u64 = segs[li].vaddr + segs[li].memsz::u64;
+        if (end > hi_va) { hi_va = end; }
+        li = li + 1;
+    }
+
+    # the program-header table sits right after the ELF header; its size depends
+    # on the segment count (PT_PHDR + PT_INTERP + the linker segments + the 3
+    # synthesized + PT_DYNAMIC). the first linker segment also maps the ELF
+    # header + phdrs, so no separate header-covering PT_LOAD is needed.
+    val phdr_count: u32 = seg_count + 6;
+    val phdr_offset: usize = ELF_HEADER_SIZE;
+    val phdr_table_size: usize = phdr_count::usize * PHDR_SIZE;
+
+    # the file offset where the synthesized structures begin: after the linker's
+    # segment file bytes, page-aligned. the linker segments are written at file
+    # offsets matching their vaddr page (`offset % page == vaddr % page`).
+    var struct_file: usize = align_up(phdr_offset + phdr_table_size, EXEC_PAGE_SIZE::usize);
+    var seg_offsets: *usize = nil;
+    if (seg_count > 0) {
+        val ro: Result[*usize, str] = zallocate[usize](alloc, seg_count::usize);
+        if (is_err[*usize, str](ro)) { ret err[bool, str]("elf: dyn-exec seg-offset alloc failed"); }
+        seg_offsets = unwrap_ok[*usize, str](ro);
+        li = 0;
+        for (li < seg_count) {
+            struct_file = align_up(struct_file, EXEC_PAGE_SIZE::usize);
+            seg_offsets[li] = struct_file;
+            struct_file = struct_file + segs[li].filesz;
+            li = li + 1;
+        }
+    }
+
+    var lay: DynLayout;
+    compute_dyn_layout(?lay, dyn, nimp, align_up(struct_file, EXEC_PAGE_SIZE::usize),
+                       align_up_u64(hi_va, EXEC_PAGE_SIZE));
+
+    val total_size: usize = lay.rw_off + lay.rw_size;
+
+    val res_buf: Result[*u8, str] = zallocate[u8](alloc, total_size);
+    if (is_err[*u8, str](res_buf)) {
+        if (seg_offsets != nil) { deallocate[usize](alloc, seg_offsets, seg_count::usize); }
+        ret err[bool, str]("elf: dyn-exec buffer alloc failed");
+    }
+    var buf: *u8 = unwrap_ok[*u8, str](res_buf);
+
+    # ELF header. a fixed-address (ET_EXEC) dynamically-linked executable: the
+    # linker assigned absolute virtual addresses from the OS base and the back end
+    # emits absolute addressing, so the image must map at those fixed addresses
+    # (an ET_DYN/PIE would be relocated by a load bias and invalidate them). glibc
+    # loads an ET_EXEC carrying PT_INTERP/PT_DYNAMIC as a classic non-PIE dynamic
+    # binary and still resolves the PLT.
+    buf[0] = 0x7F; buf[1] = 0x45; buf[2] = 0x4C; buf[3] = 0x46;
+    buf[4] = ELFCLASS64; buf[5] = ELFDATA2LSB; buf[6] = EV_CURRENT; buf[7] = ELFOSABI_NONE;
+    write_u16_le(buf, 16, ET_EXEC);
+    write_u16_le(buf, 18, machine_for(tgt_isa.id));
+    write_u32_le(buf, 20, 1);
+    write_u64_le(buf, 24, entry);
+    write_u64_le(buf, 32, phdr_offset::u64);
+    write_u64_le(buf, 40, 0);
+    write_u32_le(buf, 48, 0);
+    write_u16_le(buf, 52, ELF_HEADER_SIZE::u16);
+    write_u16_le(buf, 54, PHDR_SIZE::u16);
+    write_u16_le(buf, 56, phdr_count::u16);
+    write_u16_le(buf, 58, SHDR_SIZE::u16);
+    write_u16_le(buf, 60, 0);
+    write_u16_le(buf, 62, 0);
+
+    # copy the linker's segment bytes into their file offsets.
+    li = 0;
+    for (li < seg_count) {
+        if (segs[li].bytes != nil && segs[li].filesz > 0) {
+            mem.raw_copy((buf::usize + seg_offsets[li])::ptr, segs[li].bytes::ptr, segs[li].filesz);
+        }
+        li = li + 1;
+    }
+
+    # per-name offsets into .dynstr, indexed by raw import / lib index. allocated
+    # here (not a fixed-size scratch) so any number of imports/dependencies works.
+    var imp_str: *usize = nil;
+    if (dyn.import_count > 0) {
+        val ri: Result[*usize, str] = zallocate[usize](alloc, dyn.import_count::usize);
+        if (is_err[*usize, str](ri)) {
+            if (seg_offsets != nil) { deallocate[usize](alloc, seg_offsets, seg_count::usize); }
+            deallocate[u8](alloc, buf, total_size);
+            ret err[bool, str]("elf: dyn-exec import-name table alloc failed");
+        }
+        imp_str = unwrap_ok[*usize, str](ri);
+    }
+    var lib_str: *usize = nil;
+    if (dyn.lib_count > 0) {
+        val rl: Result[*usize, str] = zallocate[usize](alloc, dyn.lib_count::usize);
+        if (is_err[*usize, str](rl)) {
+            if (imp_str != nil) { deallocate[usize](alloc, imp_str, dyn.import_count::usize); }
+            if (seg_offsets != nil) { deallocate[usize](alloc, seg_offsets, seg_count::usize); }
+            deallocate[u8](alloc, buf, total_size);
+            ret err[bool, str]("elf: dyn-exec lib-name table alloc failed");
+        }
+        lib_str = unwrap_ok[*usize, str](rl);
+    }
+
+    # write the synthesized structures, then patch the import call sites.
+    write_dyn_structures(buf, ?lay, dyn, nimp, tgt_isa.id, imp_str, lib_str);
+    patch_plt_fixups(buf, ?lay, dyn, fixups, fixup_count, seg_offsets, segs, seg_count, nimp);
+
+    if (imp_str != nil) { deallocate[usize](alloc, imp_str, dyn.import_count::usize); }
+    if (lib_str != nil) { deallocate[usize](alloc, lib_str, dyn.lib_count::usize); }
+
+    # program headers: leading header-cover PT_LOAD, PT_INTERP, the linker
+    # segments, the RO/PLT/RW synthesized segments, then PT_DYNAMIC.
+    write_dyn_phdrs(buf, phdr_offset, ?lay, segs, seg_offsets, seg_count);
+
+    if (seg_offsets != nil) { deallocate[usize](alloc, seg_offsets, seg_count::usize); }
+
+    val res_file: Result[fs.File, str] = fs.create(path, 0o755);
+    if (is_err[fs.File, str](res_file)) {
+        deallocate[u8](alloc, buf, total_size);
+        ret err[bool, str]("elf: could not create dynamic executable file");
+    }
+    var f: fs.File = unwrap_ok[fs.File, str](res_file);
+    val res_write: Result[usize, str] = fs.write(?f, buf, total_size);
+    fs.close(?f);
+    deallocate[u8](alloc, buf, total_size);
+
+    if (is_err[usize, str](res_write)) { ret err[bool, str]("elf: dyn-exec write failed"); }
+    ret ok[bool, str](true);
+}
+
+# compute_dyn_layout: place every synthesized dynamic structure at a file offset
+# and virtual address, given the file offset (`struct_file`) and virtual address
+# (`struct_va`) the structures start at. the RO group, .plt, and the RW group
+# each occupy their own page-aligned load segment so they get distinct loader
+# permissions. file offset and vaddr advance in lockstep within a segment so the
+# loader's `offset % page == vaddr % page` invariant holds.
+fun compute_dyn_layout(lay: *DynLayout, dyn: *of.DynamicInfo, nimp: u32,
+                       struct_file: usize, struct_va: u64) {
+    val page: usize = EXEC_PAGE_SIZE::usize;
+
+    # read-only metadata segment.
+    lay.ro_off = struct_file;
+    lay.ro_va  = struct_va;
+
+    var off: usize = struct_file;
+    var va:  u64   = struct_va;
+
+    # .interp: the dynamic-loader path (NUL-terminated).
+    lay.interp_off  = off;
+    lay.interp_va   = va;
+    lay.interp_size = dynstr_name_len(dyn.interp);
+    off = off + lay.interp_size;
+    va  = va  + lay.interp_size::u64;
+
+    # .dynsym: index 0 reserved-null, then one entry per function import.
+    off = align_up(off, 8);
+    va  = align_up_u64(va, 8);
+    lay.dynsym_off = off;
+    lay.dynsym_va  = va;
+    val dynsym_size: usize = (nimp + 1)::usize * SYM_SIZE;
+    off = off + dynsym_size;
+    va  = va  + dynsym_size::u64;
+
+    # .dynstr: leading NUL, the interp path, each import name, each soname.
+    lay.dynstr_off = off;
+    lay.dynstr_va  = va;
+    var dynstr_size: usize = 1;
+    dynstr_size = dynstr_size + dynstr_name_len(dyn.interp);
+    var i: u32 = 0;
+    for (i < dyn.import_count) {
+        if (dyn.imports[i].is_func) { dynstr_size = dynstr_size + dynstr_name_len(dyn.imports[i].symbol); }
+        i = i + 1;
+    }
+    i = 0;
+    for (i < dyn.lib_count) { dynstr_size = dynstr_size + dynstr_name_len(dyn.libs[i].soname); i = i + 1; }
+    lay.dynstr_size = dynstr_size;
+    off = off + dynstr_size;
+    va  = va  + dynstr_size::u64;
+
+    # .hash: SysV hash (nbucket, nchain, buckets[nbucket], chain[nchain]). a
+    # single bucket keeps the table valid with a trivial (linear-chain) layout.
+    off = align_up(off, 8);
+    va  = align_up_u64(va, 8);
+    lay.hash_off = off;
+    lay.hash_va  = va;
+    val nchain: usize = (nimp + 1)::usize;
+    lay.hash_size = 8 + 4 + nchain * 4;
+    off = off + lay.hash_size;
+    va  = va  + lay.hash_size::u64;
+
+    # .rela.plt: one JUMP_SLOT relocation per function import.
+    off = align_up(off, 8);
+    va  = align_up_u64(va, 8);
+    lay.relaplt_off  = off;
+    lay.relaplt_va   = va;
+    lay.relaplt_size = nimp::usize * RELA_SIZE;
+    off = off + lay.relaplt_size;
+    va  = va  + lay.relaplt_size::u64;
+
+    lay.ro_size = off - lay.ro_off;
+
+    # .plt: read+execute, its own page-aligned segment. header stub + one per
+    # import. empty (size 0) when there are no function imports.
+    off = align_up(off, page);
+    va  = align_up_u64(va, page::u64);
+    lay.plt_off = off;
+    lay.plt_va  = va;
+    if (nimp > 0) { lay.plt_size = PLT_ENTRY_SIZE * (nimp + 1)::usize; } or { lay.plt_size = 0; }
+    off = off + lay.plt_size;
+    va  = va  + lay.plt_size::u64;
+
+    # .got.plt + .dynamic: read+write, its own page-aligned segment.
+    off = align_up(off, page);
+    va  = align_up_u64(va, page::u64);
+    lay.rw_off = off;
+    lay.rw_va  = va;
+
+    lay.gotplt_off  = off;
+    lay.gotplt_va   = va;
+    lay.gotplt_size = (nimp + 3)::usize * GOT_ENTRY_SIZE;
+    off = off + lay.gotplt_size;
+    va  = va  + lay.gotplt_size::u64;
+
+    off = align_up(off, 8);
+    va  = align_up_u64(va, 8);
+    lay.dynamic_off = off;
+    lay.dynamic_va  = va;
+    # DT_NEEDED per lib + HASH,STRTAB,SYMTAB,STRSZ,SYMENT + (PLT tags when imports)
+    # + DT_NULL.
+    var dyn_entries: u32 = dyn.lib_count + 6;
+    if (nimp > 0) { dyn_entries = dyn_entries + 4; }
+    lay.dynamic_size = dyn_entries::usize * DYN_SIZE;
+    off = off + lay.dynamic_size;
+    va  = va  + lay.dynamic_size::u64;
+
+    lay.rw_size = off - lay.rw_off;
+}
+
+# write_dyn_structures: serialize every synthesized dynamic structure into `buf`
+# at its laid-out offset — .interp, .dynsym, .dynstr, .hash, .rela.plt, the PLT
+# stubs, the GOT.PLT slots, and the .dynamic table. the loader reads these to
+# resolve the imports at run time. the .dynstr offsets computed here are recorded
+# into `imp_str` (per raw import index) and `lib_str` (per dependency) for reuse
+# by the .dynsym / .dynamic writers, so the string table is laid out first.
+fun write_dyn_structures(buf: *u8, lay: *DynLayout, dyn: *of.DynamicInfo, nimp: u32,
+                         arch_id: u32, imp_str: *usize, lib_str: *usize) {
+    # .interp: the loader path.
+    write_str(buf, lay.interp_off, resolve(dyn.interp));
+
+    # .dynstr and the offset of every name within it, recorded for .dynsym /
+    # .dynamic. the interp path is included so the table is self-contained.
+    buf[lay.dynstr_off] = 0;
+    var str_pos: usize = 1;
+    str_pos = str_pos + write_str(buf, lay.dynstr_off + str_pos, resolve(dyn.interp));
+
+    var i: u32 = 0;
+    for (i < dyn.import_count) {
+        if (dyn.imports[i].is_func) {
+            imp_str[i] = str_pos;
+            str_pos = str_pos + write_str(buf, lay.dynstr_off + str_pos, resolve(dyn.imports[i].symbol));
+        } or {
+            imp_str[i] = 0;
+        }
+        i = i + 1;
+    }
+    i = 0;
+    for (i < dyn.lib_count) {
+        lib_str[i] = str_pos;
+        str_pos = str_pos + write_str(buf, lay.dynstr_off + str_pos, resolve(dyn.libs[i].soname));
+        i = i + 1;
+    }
+
+    # .dynsym: index 0 reserved-null, then one GLOBAL/UNDEF entry per function
+    # import. st_name points into .dynstr; st_shndx 0 (SHN_UNDEF) marks it
+    # imported.
+    var sym_off: usize = lay.dynsym_off + SYM_SIZE;
+    i = 0;
+    for (i < dyn.import_count) {
+        if (dyn.imports[i].is_func) {
+            write_u32_le(buf, sym_off, imp_str[i]::u32);
+            buf[sym_off + 4] = (STB_GLOBAL << 4) | (STT_FUNC & 0xF);
+            buf[sym_off + 5] = 0;
+            write_u16_le(buf, sym_off + 6, 0);
+            write_u64_le(buf, sym_off + 8, 0);
+            write_u64_le(buf, sym_off + 16, 0);
+            sym_off = sym_off + SYM_SIZE;
+        }
+        i = i + 1;
+    }
+
+    # .hash: a single-bucket SysV table — bucket[0] points at dynsym index 1 and
+    # the chain links 1->2->...->n->0. with one bucket the loader walks the whole
+    # chain, which is correct (if not fast) for the small import sets here.
+    val nchain: u32 = nimp + 1;
+    write_u32_le(buf, lay.hash_off, 1);
+    write_u32_le(buf, lay.hash_off + 4, nchain);
+    if (nimp > 0) { write_u32_le(buf, lay.hash_off + 8, 1); } or { write_u32_le(buf, lay.hash_off + 8, 0); }
+    var c: u32 = 0;
+    for (c < nchain) {
+        var next: u32 = c + 1;
+        if (next >= nchain) { next = 0; }
+        write_u32_le(buf, lay.hash_off + 12 + c::usize * 4, next);
+        c = c + 1;
+    }
+
+    # GOT.PLT: GOT[0] = &.dynamic, GOT[1]/GOT[2] = 0 (filled by the loader with
+    # the link_map and the lazy-resolver). GOT[3+n] points at the push in PLT[n]
+    # so the first call triggers lazy resolution.
+    write_u64_le(buf, lay.gotplt_off, lay.dynamic_va);
+    write_u64_le(buf, lay.gotplt_off + 8, 0);
+    write_u64_le(buf, lay.gotplt_off + 16, 0);
+
+    # .plt and .rela.plt, per function import.
+    if (nimp > 0) {
+        write_plt_header(buf, lay);
+        var rela_off: usize = lay.relaplt_off;
+        var n: u32 = 0;
+        var sym_index: u32 = 1;
+        i = 0;
+        for (i < dyn.import_count) {
+            if (dyn.imports[i].is_func) {
+                write_plt_stub(buf, lay, n);
+
+                # GOT[3+n] -> PLT[n] + 6 (the `push` after the indirect jump).
+                val got_slot_off: usize = lay.gotplt_off + (3 + n)::usize * GOT_ENTRY_SIZE;
+                val plt_stub_va: u64 = lay.plt_va + (n + 1)::u64 * PLT_ENTRY_SIZE::u64;
+                write_u64_le(buf, got_slot_off, plt_stub_va + 6);
+
+                # .rela.plt JUMP_SLOT: r_offset = &GOT[3+n], r_sym = dynsym slot.
+                val got_slot_va: u64 = lay.gotplt_va + (3 + n)::u64 * GOT_ENTRY_SIZE::u64;
+                write_u64_le(buf, rela_off, got_slot_va);
+                val r_info: u64 = (sym_index::u64 << 32) | jump_slot_for(arch_id)::u64;
+                write_u64_le(buf, rela_off + 8, r_info);
+                write_u64_le(buf, rela_off + 16, 0);
+                rela_off = rela_off + RELA_SIZE;
+
+                n = n + 1;
+                sym_index = sym_index + 1;
+            }
+            i = i + 1;
+        }
+    }
+
+    # .dynamic: the table the loader walks. DT_NEEDED per dependency, then the
+    # table pointers, then the PLT tags (when there are imports), then DT_NULL.
+    var dpos: usize = lay.dynamic_off;
+    i = 0;
+    for (i < dyn.lib_count) {
+        dpos = write_dyn_entry(buf, dpos, DT_NEEDED, lib_str[i]::u64);
+        i = i + 1;
+    }
+    dpos = write_dyn_entry(buf, dpos, DT_HASH,   lay.hash_va);
+    dpos = write_dyn_entry(buf, dpos, DT_STRTAB, lay.dynstr_va);
+    dpos = write_dyn_entry(buf, dpos, DT_SYMTAB, lay.dynsym_va);
+    dpos = write_dyn_entry(buf, dpos, DT_STRSZ,  lay.dynstr_size::u64);
+    dpos = write_dyn_entry(buf, dpos, DT_SYMENT, SYM_SIZE::u64);
+    if (nimp > 0) {
+        dpos = write_dyn_entry(buf, dpos, DT_PLTGOT,   lay.gotplt_va);
+        dpos = write_dyn_entry(buf, dpos, DT_PLTRELSZ, lay.relaplt_size::u64);
+        dpos = write_dyn_entry(buf, dpos, DT_PLTREL,   DT_RELA_TAG);
+        dpos = write_dyn_entry(buf, dpos, DT_JMPREL,   lay.relaplt_va);
+    }
+    dpos = write_dyn_entry(buf, dpos, DT_NULL, 0);
+}
+
+# DT_PLTREL value declaring the PLT relocations use the RELA (addend-bearing)
+# form — the only form this writer emits.
+val DT_RELA_TAG: u64 = 7;
+
+# write_dyn_entry: write one Elf64_Dyn (d_tag, d_un) at `off`, returning the next
+# offset.
+fun write_dyn_entry(buf: *u8, off: usize, tag: u64, value: u64) usize {
+    write_u64_le(buf, off, tag);
+    write_u64_le(buf, off + 8, value);
+    ret off + DYN_SIZE;
+}
+
+# write_plt_header: write PLT[0], the lazy-resolution trampoline. it pushes
+# GOT[1] (the link_map) and jumps through GOT[2] (the resolver), both filled by
+# the loader. the rip-relative displacements reach GOT.PLT from each instruction's
+# end.
+fun write_plt_header(buf: *u8, lay: *DynLayout) {
+    val p: usize = lay.plt_off;
+    # push qword [rip + d1]  (FF 35 d1) -> GOT[1]
+    buf[p] = 0xFF; buf[p + 1] = 0x35;
+    val next1: u64 = lay.plt_va + 6;
+    val got1:  u64 = lay.gotplt_va + 8;
+    write_u32_le(buf, p + 2, (got1 - next1)::u32);
+    # jmp qword [rip + d2]   (FF 25 d2) -> GOT[2]
+    buf[p + 6] = 0xFF; buf[p + 7] = 0x25;
+    val next2: u64 = lay.plt_va + 12;
+    val got2:  u64 = lay.gotplt_va + 16;
+    write_u32_le(buf, p + 8, (got2 - next2)::u32);
+    # padding nop (0F 1F 40 00).
+    buf[p + 12] = 0x0F; buf[p + 13] = 0x1F; buf[p + 14] = 0x40; buf[p + 15] = 0x00;
+}
+
+# write_plt_stub: write PLT[n+1], the per-import stub. it jumps through GOT[3+n]
+# (initially pointing back at the stub's push, triggering resolution), pushes the
+# relocation index, and jumps to PLT[0].
+fun write_plt_stub(buf: *u8, lay: *DynLayout, n: u32) {
+    val stub_off: usize = lay.plt_off + (n + 1)::usize * PLT_ENTRY_SIZE;
+    val stub_va:  u64   = lay.plt_va + (n + 1)::u64 * PLT_ENTRY_SIZE::u64;
+    # jmp qword [rip + d]  (FF 25 d) -> GOT[3+n]
+    buf[stub_off] = 0xFF; buf[stub_off + 1] = 0x25;
+    val next: u64 = stub_va + 6;
+    val got:  u64 = lay.gotplt_va + (3 + n)::u64 * GOT_ENTRY_SIZE::u64;
+    write_u32_le(buf, stub_off + 2, (got - next)::u32);
+    # push <reloc index n>  (68 imm32)
+    buf[stub_off + 6] = 0x68;
+    write_u32_le(buf, stub_off + 7, n);
+    # jmp PLT[0]  (E9 rel32)
+    buf[stub_off + 11] = 0xE9;
+    val plt0: u64 = lay.plt_va;
+    val after: u64 = stub_va + 16;
+    write_u32_le(buf, stub_off + 12, (plt0 - after)::u32);
+}
+
+# patch_plt_fixups: rewrite each import call site (a `PltFixup` the linker could
+# not resolve) to a pc-relative call to the import's PLT stub. the fixup records
+# the segment + offset of the 4-byte displacement field and the patch-site vaddr;
+# the stub vaddr is `S` and the patched value is `S + A - P`.
+fun patch_plt_fixups(buf: *u8, lay: *DynLayout, dyn: *of.DynamicInfo,
+                     fixups: *of.PltFixup, fixup_count: u32, seg_offsets: *usize,
+                     segs: *of.LoadSegment, seg_count: u32, nimp: u32) {
+    if (nimp == 0) { ret; }
+    var i: u32 = 0;
+    for (i < fixup_count) {
+        val fx: *of.PltFixup = ?fixups[i];
+        if (fx.seg_index >= seg_count) { i = i + 1; cnt; }
+        # the func-import ordinal of this fixup's target import (its PLT slot).
+        val n: u32 = func_ordinal(dyn, fx.import_index);
+        if (n == 0xFFFFFFFF) { i = i + 1; cnt; }
+        val stub_va: u64 = lay.plt_va + (n + 1)::u64 * PLT_ENTRY_SIZE::u64;
+        val disp: i64 = (stub_va::i64) + fx.addend - (fx.patch_vaddr::i64);
+        val file_off: usize = seg_offsets[fx.seg_index] + fx.seg_offset::usize;
+        write_u32_le(buf, file_off, (disp::u64)::u32);
+        i = i + 1;
+    }
+}
+
+# func_ordinal: the PLT slot index (0-based among function imports) for the
+# import at raw index `import_index`, or 0xFFFFFFFF if it is not a function
+# import. the PLT, GOT.PLT, and .rela.plt are laid out in func-import order, so
+# this maps a raw import index onto that ordering.
+fun func_ordinal(dyn: *of.DynamicInfo, import_index: u32) u32 {
+    if (import_index >= dyn.import_count) { ret 0xFFFFFFFF; }
+    if (!dyn.imports[import_index].is_func) { ret 0xFFFFFFFF; }
+    var n: u32 = 0;
+    var i: u32 = 0;
+    for (i < import_index) {
+        if (dyn.imports[i].is_func) { n = n + 1; }
+        i = i + 1;
+    }
+    ret n;
+}
+
+# write_dyn_phdrs: write the program-header table for a dynamic executable.
+#
+# unlike the static writer — which adds a separate header-covering PT_LOAD that
+# overlaps the text segment's page (the kernel tolerates it, but the dynamic
+# loader rejects two PT_LOADs over one page) — the first linker segment is
+# extended DOWN one page to file offset 0 so a single PT_LOAD covers the ELF
+# header, the program headers, and the segment's own bytes with no overlap. the
+# header page maps one page below the segment's base (`vaddr ≡ offset (mod page)`
+# still holds), keeping every assigned virtual address unchanged. a leading
+# PT_PHDR locates the table, PT_INTERP names the loader, each remaining linker
+# segment and each synthesized segment (RO, PLT, RW) is a PT_LOAD, and PT_DYNAMIC
+# points at the .dynamic table.
+fun write_dyn_phdrs(buf: *u8, phdr_offset: usize, lay: *DynLayout,
+                    segs: *of.LoadSegment, seg_offsets: *usize, seg_count: u32) {
+    var pos: usize = phdr_offset;
+
+    # the page the ELF header + phdrs map at: one page below the first segment's
+    # base, so extending the first segment down to file offset 0 covers them.
+    var hdr_vaddr: u64 = 0;
+    if (seg_count > 0) { hdr_vaddr = (segs[0].vaddr & ~(EXEC_PAGE_SIZE - 1)) - EXEC_PAGE_SIZE; }
+
+    # PT_PHDR -> the program-header table, so the dynamic loader can locate the
+    # program's own headers. it lies within the first (header+text) PT_LOAD.
+    pos = write_phdr(buf, pos, PT_PHDR, PF_R, phdr_offset, hdr_vaddr + phdr_offset::u64,
+                     phdr_count_bytes(seg_count), phdr_count_bytes(seg_count), 8);
+
+    # PT_INTERP -> the .interp string.
+    pos = write_phdr(buf, pos, PT_INTERP, PF_R, lay.interp_off, lay.interp_va,
+                     lay.interp_size, lay.interp_size, 1);
+
+    # one PT_LOAD per linker segment; the first extends down to file offset 0 so
+    # it also maps the ELF header + program headers (no overlapping page).
+    var li: u32 = 0;
+    for (li < seg_count) {
+        if (li == 0) {
+            val first_filesz: usize = seg_offsets[0] + segs[0].filesz;
+            val first_memsz:  usize = seg_offsets[0] + segs[0].memsz;
+            pos = write_phdr(buf, pos, PT_LOAD, pf_flags_for(segs[0].flags), 0,
+                             hdr_vaddr, first_filesz, first_memsz, EXEC_PAGE_SIZE);
+        }
+        or {
+            pos = write_phdr(buf, pos, PT_LOAD, pf_flags_for(segs[li].flags), seg_offsets[li],
+                             segs[li].vaddr, segs[li].filesz, segs[li].memsz, EXEC_PAGE_SIZE);
+        }
+        li = li + 1;
+    }
+
+    # RO metadata, PLT (R+X), RW (R+W) synthesized segments.
+    pos = write_phdr(buf, pos, PT_LOAD, PF_R, lay.ro_off, lay.ro_va, lay.ro_size, lay.ro_size, EXEC_PAGE_SIZE);
+    pos = write_phdr(buf, pos, PT_LOAD, PF_R | PF_X, lay.plt_off, lay.plt_va, lay.plt_size, lay.plt_size, EXEC_PAGE_SIZE);
+    pos = write_phdr(buf, pos, PT_LOAD, PF_R | PF_W, lay.rw_off, lay.rw_va, lay.rw_size, lay.rw_size, EXEC_PAGE_SIZE);
+
+    # PT_DYNAMIC -> the .dynamic table.
+    pos = write_phdr(buf, pos, PT_DYNAMIC, PF_R | PF_W, lay.dynamic_off, lay.dynamic_va,
+                     lay.dynamic_size, lay.dynamic_size, 8);
+}
+
+# phdr_count_bytes: the byte size of the program-header table for a dynamic image
+# with `seg_count` linker segments: PT_PHDR + PT_INTERP + the linker segments +
+# the 3 synthesized segments + PT_DYNAMIC.
+fun phdr_count_bytes(seg_count: u32) usize {
+    ret (seg_count + 6)::usize * PHDR_SIZE;
+}
+
+# write_phdr: write one Elf64_Phdr at `pos`, returning the next phdr offset.
+fun write_phdr(buf: *u8, pos: usize, p_type: u32, flags: u32, off: usize, vaddr: u64,
+               filesz: usize, memsz: usize, align: u64) usize {
+    write_u32_le(buf, pos, p_type);
+    write_u32_le(buf, pos + 4, flags);
+    write_u64_le(buf, pos + 8, off::u64);
+    write_u64_le(buf, pos + 16, vaddr);
+    write_u64_le(buf, pos + 24, vaddr);
+    write_u64_le(buf, pos + 32, filesz::u64);
+    write_u64_le(buf, pos + 40, memsz::u64);
+    write_u64_le(buf, pos + 48, align);
+    ret pos + PHDR_SIZE;
 }
 
 # parse_object: parse a relocatable ELF64 object into an ObjectImage.

--- a/src/lang/target/of/elf.mach
+++ b/src/lang/target/of/elf.mach
@@ -987,7 +987,7 @@ fun dynstr_name_len(id: intern.StrId) usize {
     ret str_len(s) + 1;
 }
 
-# emit_dyn_exec: write a dynamically-linked ET_DYN ELF executable. installed in
+# emit_dyn_exec: write a dynamically-linked ET_EXEC ELF executable. installed in
 # the ELF `of.OfVTable` as its `of.DynExecFn`.
 #
 # frames the linker's laid-out load segments with the ELF dynamic-linking

--- a/src/lang/target/of/elf.mach
+++ b/src/lang/target/of/elf.mach
@@ -1019,6 +1019,14 @@ fun emit_dyn_exec(alloc: *Allocator, tgt_isa: *isa.IsaVTable, segs: *of.LoadSegm
     if (dyn == nil)     { ret err[bool, str]("elf: nil dynamic plan"); }
     if (elf_interner == nil) { ret err[bool, str]("elf: no interner registered for dyn-exec"); }
 
+    # the PLT/GOT stubs below are raw x86-64 instruction bytes, so this writer is
+    # x86-64-only; another ISA needs its own per-arch PLT writer. reject it loudly
+    # rather than emit invalid code (e.g. a JUMP_SLOT type is mapped for aarch64
+    # but the stub encoding is not).
+    if (tgt_isa.id != isa.ARCH_X86_64) {
+        ret err[bool, str]("elf: dynamic linking is only implemented for x86-64");
+    }
+
     val nimp: u32 = func_import_count(dyn);
 
     # the highest virtual address the linker's segments reach; the synthesized
@@ -1458,6 +1466,12 @@ fun write_plt_stub(buf: *u8, lay: *DynLayout, n: u32) {
 # never ran for it, so they are enforced here: the 4-byte field must lie within
 # the segment's file bytes and the displacement must fit a signed 32-bit value. a
 # violation fails the link rather than writing out of bounds or truncating.
+#
+# the linker only records a fixup for a function import in a real segment, so an
+# out-of-range segment index or a non-function target is an internal consistency
+# failure (a linker/writer bug), not a recoverable case — it is a hard error
+# rather than a silent skip that would leave a call site unpatched in a written
+# binary, which is far harder to diagnose.
 fun patch_plt_fixups(buf: *u8, lay: *DynLayout, dyn: *of.DynamicInfo,
                      fixups: *of.PltFixup, fixup_count: u32, seg_offsets: *usize,
                      segs: *of.LoadSegment, seg_count: u32, nimp: u32) Result[bool, str] {
@@ -1465,10 +1479,15 @@ fun patch_plt_fixups(buf: *u8, lay: *DynLayout, dyn: *of.DynamicInfo,
     var i: u32 = 0;
     for (i < fixup_count) {
         val fx: *of.PltFixup = ?fixups[i];
-        if (fx.seg_index >= seg_count) { i = i + 1; cnt; }
-        # the func-import ordinal of this fixup's target import (its PLT slot).
+        if (fx.seg_index >= seg_count) {
+            ret err[bool, str]("elf: dynamic call-site fixup references an out-of-range segment");
+        }
+        # the func-import ordinal of this fixup's target import (its PLT slot). a
+        # non-function target should never reach here (the linker filters them).
         val n: u32 = func_ordinal(dyn, fx.import_index);
-        if (n == 0xFFFFFFFF) { i = i + 1; cnt; }
+        if (n == 0xFFFFFFFF) {
+            ret err[bool, str]("elf: dynamic call-site fixup targets a non-function import");
+        }
 
         # the 4-byte displacement field must lie fully within the segment's file
         # bytes; the writer placed those bytes at `seg_offsets[seg_index]`.

--- a/src/lang/target/of/macho.mach
+++ b/src/lang/target/of/macho.mach
@@ -153,6 +153,8 @@ pub fun register_macho(alloc: *Allocator, i: *intern.Interner) Result[bool, str]
     macho_vtable.emit_object      = macho_emit_object;
     macho_vtable.parse_object     = macho_parse_object;
     macho_vtable.emit_exec        = macho_emit_exec;
+    # dyld bind/rebase (LC_LOAD_DYLINKER + LC_LOAD_DYLIB) is unimplemented (#1176).
+    macho_vtable.emit_dyn_exec    = nil::of.DynExecFn;
     macho_vtable.relocation_kinds = ?macho_reloc_kinds[0];
     macho_vtable.relocation_count = 4;
 

--- a/src/lang/target/os.mach
+++ b/src/lang/target/os.mach
@@ -27,23 +27,27 @@ pub val OS_WINDOWS: u32 = 3;
 # per OS; the driver and linker read the entry symbol, library directory, and
 # executable load parameters through it and never branch on the numeric `id`.
 # ---
-# id:            operating-system id (one of OS_*)
-# name:          interned os name ("linux", "darwin", "windows")
-# entry_symbol:  interned program entry-point symbol ("_start", "_main", ...)
-# syscall_layer: interned syscall-layer name selecting the runtime backend
-# libdir:        interned default system library directory
-# base_addr:     base virtual address the first loadable segment maps at; the
-#                linker assigns section vaddrs upward from it
-# page_size:     virtual-memory page size in bytes the linker page-aligns segment
-#                virtual addresses to
+# id:              operating-system id (one of OS_*)
+# name:            interned os name ("linux", "darwin", "windows")
+# entry_symbol:    interned program entry-point symbol ("_start", "_main", ...)
+# syscall_layer:   interned syscall-layer name selecting the runtime backend
+# libdir:          interned default system library directory
+# dynamic_linker:  interned run-time dynamic-loader path the linker writes into a
+#                  dynamically-linked image's interpreter record (ELF PT_INTERP),
+#                  or intern.STR_NIL when the OS has no dynamic-link support yet
+# base_addr:       base virtual address the first loadable segment maps at; the
+#                  linker assigns section vaddrs upward from it
+# page_size:       virtual-memory page size in bytes the linker page-aligns
+#                  segment virtual addresses to
 pub rec OsVTable {
-    id:            u32;
-    name:          intern.StrId;
-    entry_symbol:  intern.StrId;
-    syscall_layer: intern.StrId;
-    libdir:        intern.StrId;
-    base_addr:     u64;
-    page_size:     u64;
+    id:             u32;
+    name:           intern.StrId;
+    entry_symbol:   intern.StrId;
+    syscall_layer:  intern.StrId;
+    libdir:         intern.StrId;
+    dynamic_linker: intern.StrId;
+    base_addr:      u64;
+    page_size:      u64;
 }
 
 val OS_REGISTRY_CAP: u32 = 8;

--- a/src/lang/target/os.mach
+++ b/src/lang/target/os.mach
@@ -33,8 +33,11 @@ pub val OS_WINDOWS: u32 = 3;
 # syscall_layer:   interned syscall-layer name selecting the runtime backend
 # libdir:          interned default system library directory
 # dynamic_linker:  interned run-time dynamic-loader path the linker writes into a
-#                  dynamically-linked image's interpreter record (ELF PT_INTERP),
-#                  or intern.STR_NIL when the OS has no dynamic-link support yet
+#                  dynamically-linked image's interpreter record (the ELF
+#                  PT_INTERP), or intern.STR_NIL when no fixed interpreter-path
+#                  record applies — PE and Mach-O still support dynamic linking,
+#                  but load imports through their own mechanisms (the import
+#                  directory, LC_LOAD_DYLINKER) rather than a PT_INTERP path
 # base_addr:       base virtual address the first loadable segment maps at; the
 #                  linker assigns section vaddrs upward from it
 # page_size:       virtual-memory page size in bytes the linker page-aligns

--- a/src/lang/target/os/darwin.mach
+++ b/src/lang/target/os/darwin.mach
@@ -63,13 +63,15 @@ pub fun register_darwin(alloc: *Allocator, i: *intern.Interner) Result[bool, str
     val rl: Result[intern.StrId, str] = intern.intern(i, "/usr/lib");
     if (is_err[intern.StrId, str](rl)) { ret err[bool, str](unwrap_err[intern.StrId, str](rl)); }
 
-    darwin_vtable.id            = os.OS_DARWIN;
-    darwin_vtable.name          = unwrap_ok[intern.StrId, str](rn);
-    darwin_vtable.entry_symbol  = unwrap_ok[intern.StrId, str](re);
-    darwin_vtable.syscall_layer = unwrap_ok[intern.StrId, str](rs);
-    darwin_vtable.libdir        = unwrap_ok[intern.StrId, str](rl);
-    darwin_vtable.base_addr     = DARWIN_BASE_ADDR;
-    darwin_vtable.page_size     = DARWIN_PAGE_SIZE;
+    darwin_vtable.id             = os.OS_DARWIN;
+    darwin_vtable.name           = unwrap_ok[intern.StrId, str](rn);
+    darwin_vtable.entry_symbol   = unwrap_ok[intern.StrId, str](re);
+    darwin_vtable.syscall_layer  = unwrap_ok[intern.StrId, str](rs);
+    darwin_vtable.libdir         = unwrap_ok[intern.StrId, str](rl);
+    # dyld linkage (LC_LOAD_DYLINKER) is unimplemented (#1176).
+    darwin_vtable.dynamic_linker = intern.STR_NIL;
+    darwin_vtable.base_addr      = DARWIN_BASE_ADDR;
+    darwin_vtable.page_size      = DARWIN_PAGE_SIZE;
 
     os.register(?darwin_vtable);
     darwin_registered = true;

--- a/src/lang/target/os/darwin.mach
+++ b/src/lang/target/os/darwin.mach
@@ -68,7 +68,8 @@ pub fun register_darwin(alloc: *Allocator, i: *intern.Interner) Result[bool, str
     darwin_vtable.entry_symbol   = unwrap_ok[intern.StrId, str](re);
     darwin_vtable.syscall_layer  = unwrap_ok[intern.StrId, str](rs);
     darwin_vtable.libdir         = unwrap_ok[intern.StrId, str](rl);
-    # dyld linkage (LC_LOAD_DYLINKER) is unimplemented (#1176).
+    # Mach-O loads imports through LC_LOAD_DYLINKER + dyld bind, not a PT_INTERP
+    # path, so no interpreter-path record applies; the writer is deferred (#1176).
     darwin_vtable.dynamic_linker = intern.STR_NIL;
     darwin_vtable.base_addr      = DARWIN_BASE_ADDR;
     darwin_vtable.page_size      = DARWIN_PAGE_SIZE;

--- a/src/lang/target/os/linux.mach
+++ b/src/lang/target/os/linux.mach
@@ -32,9 +32,13 @@ pub val LINUX_BASE_ADDR: u64 = 0x400000;
 # virtual-memory page size in bytes; segment vaddrs are page-aligned to it.
 pub val LINUX_PAGE_SIZE: u64 = 4096;
 
-# the x86-64 glibc dynamic loader. a dynamically-linked Linux ELF names it in
-# PT_INTERP so the kernel hands control to it to resolve shared dependencies
-# before the program entry runs. this is the canonical path on glibc systems.
+# the default x86-64 glibc dynamic loader. a dynamically-linked Linux ELF names
+# it in PT_INTERP so the kernel hands control to it to resolve shared
+# dependencies before the program entry runs. this is the FHS x86-64 glibc path;
+# other toolchains and layouts differ (musl uses /lib/ld-musl-x86_64.so.1, a
+# non-FHS sysroot relocates it), so this default may need to become a
+# target/sysroot-configurable setting to avoid emitting an ELF whose interpreter
+# is absent at exec time.
 pub val LINUX_DYNAMIC_LINKER: str = "/lib64/ld-linux-x86-64.so.2";
 
 # the Linux OS vtable. populated by register on first call and handed out as a

--- a/src/lang/target/os/linux.mach
+++ b/src/lang/target/os/linux.mach
@@ -32,6 +32,11 @@ pub val LINUX_BASE_ADDR: u64 = 0x400000;
 # virtual-memory page size in bytes; segment vaddrs are page-aligned to it.
 pub val LINUX_PAGE_SIZE: u64 = 4096;
 
+# the x86-64 glibc dynamic loader. a dynamically-linked Linux ELF names it in
+# PT_INTERP so the kernel hands control to it to resolve shared dependencies
+# before the program entry runs. this is the canonical path on glibc systems.
+pub val LINUX_DYNAMIC_LINKER: str = "/lib64/ld-linux-x86-64.so.2";
+
 # the Linux OS vtable. populated by register on first call and handed out as a
 # borrowed pointer to the registry; remains valid for the process lifetime.
 var linux_vtable: os.OsVTable;
@@ -63,13 +68,17 @@ pub fun register_linux(alloc: *Allocator, i: *intern.Interner) Result[bool, str]
     val rl: Result[intern.StrId, str] = intern.intern(i, "/usr/lib");
     if (is_err[intern.StrId, str](rl)) { ret err[bool, str](unwrap_err[intern.StrId, str](rl)); }
 
-    linux_vtable.id            = os.OS_LINUX;
-    linux_vtable.name          = unwrap_ok[intern.StrId, str](rn);
-    linux_vtable.entry_symbol  = unwrap_ok[intern.StrId, str](re);
-    linux_vtable.syscall_layer = unwrap_ok[intern.StrId, str](rs);
-    linux_vtable.libdir        = unwrap_ok[intern.StrId, str](rl);
-    linux_vtable.base_addr     = LINUX_BASE_ADDR;
-    linux_vtable.page_size     = LINUX_PAGE_SIZE;
+    val rd: Result[intern.StrId, str] = intern.intern(i, LINUX_DYNAMIC_LINKER);
+    if (is_err[intern.StrId, str](rd)) { ret err[bool, str](unwrap_err[intern.StrId, str](rd)); }
+
+    linux_vtable.id             = os.OS_LINUX;
+    linux_vtable.name           = unwrap_ok[intern.StrId, str](rn);
+    linux_vtable.entry_symbol   = unwrap_ok[intern.StrId, str](re);
+    linux_vtable.syscall_layer  = unwrap_ok[intern.StrId, str](rs);
+    linux_vtable.libdir         = unwrap_ok[intern.StrId, str](rl);
+    linux_vtable.dynamic_linker = unwrap_ok[intern.StrId, str](rd);
+    linux_vtable.base_addr      = LINUX_BASE_ADDR;
+    linux_vtable.page_size      = LINUX_PAGE_SIZE;
 
     os.register(?linux_vtable);
     linux_registered = true;

--- a/src/lang/target/os/windows.mach
+++ b/src/lang/target/os/windows.mach
@@ -63,13 +63,16 @@ pub fun register_windows(alloc: *Allocator, i: *intern.Interner) Result[bool, st
     val rl: Result[intern.StrId, str] = intern.intern(i, "C:\\Windows\\System32");
     if (is_err[intern.StrId, str](rl)) { ret err[bool, str](unwrap_err[intern.StrId, str](rl)); }
 
-    windows_vtable.id            = os.OS_WINDOWS;
-    windows_vtable.name          = unwrap_ok[intern.StrId, str](rn);
-    windows_vtable.entry_symbol  = unwrap_ok[intern.StrId, str](re);
-    windows_vtable.syscall_layer = unwrap_ok[intern.StrId, str](rs);
-    windows_vtable.libdir        = unwrap_ok[intern.StrId, str](rl);
-    windows_vtable.base_addr     = WINDOWS_BASE_ADDR;
-    windows_vtable.page_size     = WINDOWS_PAGE_SIZE;
+    windows_vtable.id             = os.OS_WINDOWS;
+    windows_vtable.name           = unwrap_ok[intern.StrId, str](rn);
+    windows_vtable.entry_symbol   = unwrap_ok[intern.StrId, str](re);
+    windows_vtable.syscall_layer  = unwrap_ok[intern.StrId, str](rs);
+    windows_vtable.libdir         = unwrap_ok[intern.StrId, str](rl);
+    # PE imports load through the import directory, not a PT_INTERP-style path; the
+    # `.idata` import table is unimplemented (#1175).
+    windows_vtable.dynamic_linker = intern.STR_NIL;
+    windows_vtable.base_addr      = WINDOWS_BASE_ADDR;
+    windows_vtable.page_size      = WINDOWS_PAGE_SIZE;
 
     os.register(?windows_vtable);
     windows_registered = true;


### PR DESCRIPTION
First slice of the linker dynamic-import/bind epic (#1159): the format-agnostic
import/bind abstraction plus the **ELF dynamic-link case**, proven end-to-end on
Linux. PE `.idata` (#1175) and Mach-O dyld bind (#1176) plug into the same
abstraction in follow-ups.

## Done

- **Import/bind abstraction** (`src/lang/target/of.mach`): format-neutral
  `DynLib` (a DT_NEEDED-style dependency), `DynImport` (imported symbol + lib +
  func/data), `DynamicInfo` (the full plan: deps, imports, interpreter), and
  `PltFixup` (a call site to redirect to an import call-thunk), plus the
  `DynExecFn` / `emit_dyn_exec` vtable slot. COFF/Mach-O set it `nil`; ELF wires it.
- **`OsVTable.dynamic_linker`**: the PT_INTERP loader path; set for Linux
  (`/lib64/ld-linux-x86-64.so.2`), `STR_NIL` for darwin/windows.
- **ELF `emit_dyn_exec`** (`src/lang/target/of/elf.mach`): an ET_EXEC carrying
  PT_INTERP + PT_PHDR + PT_DYNAMIC, `.dynamic` (DT_NEEDED per lib + the table
  tags), `.dynsym`/`.dynstr`/`.hash`, and an x86-64 lazy-binding PLT/GOT with one
  `R_X86_64_JUMP_SLOT` per imported function. Three synthesized load segments are
  placed above the linker's segments; each `PltFixup` call site is patched to its
  PLT stub. The first PT_LOAD is extended down one page to map the ehdr+phdrs in a
  single non-overlapping segment (the dynamic loader rejects the static writer's
  overlapping header-cover layout). The static `emit_exec` path is untouched.
- **Linker** (`src/lang/be/linker.mach`): `link()` takes shared-lib sonames; an
  undefined `ext` left after merging becomes a dynamic import instead of a hard
  error, and a pc-relative call to one is recorded as a `PltFixup`. With no
  sonames the link is fully static and byte-identical to before; a static
  definition always wins over a same-named import.
- **Surface** (`src/cli/cmd/build.mach`): `-l <name>` / explicit `.so` paths /
  `[targets.*].libs` resolve to a dynamic dependency by the library's own
  `DT_SONAME` (parsed from the ELF), preferring a static `.o`/`.a` first.
- **Test** (`.github/tests/dynlink/`): a Mach `ext fun getpid()` linked `-l c`
  (libc.so.6) dynamically — runs on Linux, returns 0 (a valid pid via the PLT),
  and a build with no `-l c` fails on the undefined `ext`.
- **Docs**: static-vs-dynamic resolution in cli.md / manifest.md / ext-fun.md.

## Verification

- Byte-identical self-host fixpoint: **holds** (seed → build → rebuild → cmp).
- `mach test .` corpus: **223 PASS**.
- `dynlink` integration test: 3/3 PASS (libc getpid runs, exit 0).
- `extlink` (static `.o`/`.a`) integration test: 8/8 PASS (no regression).

## Deferred (for the follow-ups to consume)

- **PE `.idata` / IAT** — #1175: implement `emit_dyn_exec` in `coff.mach` against
  this `DynamicInfo`/`PltFixup` model (imports → import directory + IAT thunks).
- **Mach-O dyld bind** — #1176: implement `emit_dyn_exec` in `macho.mach`
  (LC_LOAD_DYLINKER + LC_LOAD_DYLIB per `DynLib` + bind opcodes per `DynImport`).
- **Data imports (GLOB_DAT)**: only function imports get a PLT today; a data
  `ext` still errors (the abstraction already carries `DynImport.is_func`).
- **Configurable interpreter path** (musl / non-FHS sysroots) — noted in
  `linux.mach`.

Closes #1159 (the abstraction + ELF case); PE/Mach-O tracked by #1175/#1176.
