### PR TITLE
feat(abi): implement the win64 (x86_64 Windows) calling convention

### DIFF
--- a/src/lang/target/abi/win64.mach
+++ b/src/lang/target/abi/win64.mach
@@ -1,16 +1,16 @@
-# mach.lang.target.abi.win64: Microsoft x64 (win64) calling-convention stub.
+# mach.lang.target.abi.win64: Microsoft x64 (win64) calling convention.
 #
-# Supplies a correctly-shaped `AbiVTable` for the Windows x64 ABI — 16-byte
-# stack alignment, no red zone, the three type-erased classify/arg/ret function
-# pointers, and the three register-file accessors (gp_arg_regs / fp_arg_regs /
-# callee_saved) — so target.select can compose a Windows target descriptor. The
-# win64 parameter classification logic is not yet implemented: each
-# classify/arg/ret operation signals "unsupported" by returning a CLASS_STACK
-# sentinel slot (reg -1) rather than a silent register placement, and each
-# register-file accessor returns 0 registers rather than presenting a foreign
-# bank. the operations mirror the sysv signatures exactly so the erased-pointer
-# cast-back is sound. `register` interns the strings, installs the operations,
-# and is idempotent.
+# Implements `abi.AbiVTable` and self-registers under `abi.ABI_WIN64` at startup.
+# Owns the Microsoft x64 classification of parameters and return values — the
+# unified positional argument slots (RCX/RDX/R8/R9 paired with XMM0–XMM3, where
+# argument N takes the Nth register of whichever bank it belongs to), the
+# 1/2/4/8-byte by-value / otherwise by-reference aggregate rule, the hidden sret
+# pointer in RCX, the 32-byte shadow space, and the win64 callee-saved set —
+# plus the GP/FP/callee-saved register files and the 16-byte stack alignment. The
+# three `classify`/`arg_passing`/`ret_passing` vtable function pointers are
+# type-erased (`*u8`); a consumer casts each back to the concrete signature
+# declared in `sysv` (`ClassifyFn`, `ArgPassingFn`, `RetPassingFn`, `RegFileFn`)
+# — those signatures are shared, so the cast-back is sound across both ABIs.
 
 use std.types.result.Result;
 use std.types.result.ok;
@@ -31,31 +31,211 @@ use intern: mach.lang.intern;
 use isa:    mach.lang.target.isa;
 use abi:    mach.lang.target.abi;
 
-# win64_classify: classify a value's passing class under the win64 ABI.
+# canonical x86-64 register numbers (DWARF / encoding order) used by the win64
+# convention. these are the same physical-register ids the x86_64 ISA exposes;
+# they are fixed by the architecture, so the ABI carries them directly rather
+# than depending on the ISA implementation being registered first.
+pub val REG_RAX: i32 = 0;
+pub val REG_RCX: i32 = 1;
+pub val REG_RDX: i32 = 2;
+pub val REG_RBX: i32 = 3;
+pub val REG_RSP: i32 = 4;
+pub val REG_RBP: i32 = 5;
+pub val REG_RSI: i32 = 6;
+pub val REG_RDI: i32 = 7;
+pub val REG_R8:  i32 = 8;
+pub val REG_R9:  i32 = 9;
+pub val REG_R10: i32 = 10;
+pub val REG_R11: i32 = 11;
+pub val REG_R12: i32 = 12;
+pub val REG_R13: i32 = 13;
+pub val REG_R14: i32 = 14;
+pub val REG_R15: i32 = 15;
+
+# the first vector argument register (XMM0). a physical register id is composite
+# — the SSE class tag in the high byte, the within-bank index in the low byte
+# (`isa.regid_make`) — so a float pre-coloring is self-describing and the encoder
+# picks the SSE machine form rather than aliasing the GP register of the same
+# index. XMM0 is `(REG_CLASS_ID_XMM << 8) | 0 = 0x0100`.
+pub val REG_XMM0: i32 = (1 << 8) | 0;
+
+# number of argument-passing register slots. win64 passes the first four
+# arguments in registers — integers/pointers in RCX, RDX, R8, R9 and floats in
+# XMM0–XMM3 — and crucially uses ONE positional slot per argument shared across
+# the two banks: argument N takes the Nth integer register OR the Nth XMM
+# register (never both banks filling independently as under SysV). everything
+# past the fourth argument spills to the stack.
+pub val PARAM_SLOT_COUNT: i32 = 4;
+# number of general-purpose argument registers (RCX, RDX, R8, R9). equal to
+# `PARAM_SLOT_COUNT` because the GP and XMM banks share the positional slots.
+pub val GP_PARAM_COUNT: i32 = 4;
+# number of floating-point argument registers (XMM0–XMM3). equal to
+# `PARAM_SLOT_COUNT` for the same reason.
+pub val FP_PARAM_COUNT: i32 = 4;
+# the register whose low byte (AL) a variadic caller sets to the number of vector
+# registers used. win64 does not encode a vector count in AL (its variadic floats
+# are duplicated into the matching integer register instead — see
+# `float_dup_gp_reg`), but the field is named for parity with the SysV vtable
+# consumers and points at RAX, the scratch return register.
+pub val VA_VECTOR_COUNT_REG: i32 = REG_RAX;
+# number of callee-saved general-purpose registers (RBX, RBP, RDI, RSI, RSP,
+# R12–R15). RSP is preserved by the standard frame discipline; it is listed so
+# the regalloc complement never treats it as caller-saved scratch.
+pub val CALLEE_SAVED_GP_COUNT: i32 = 9;
+# number of callee-saved vector registers (XMM6–XMM15). under win64 the low half
+# of every callee-saved XMM register (its 64 low bits) must be preserved.
+pub val CALLEE_SAVED_XMM_COUNT: i32 = 10;
+# total number of callee-saved registers the register file reports.
+pub val CALLEE_SAVED_COUNT: i32 = CALLEE_SAVED_GP_COUNT + CALLEE_SAVED_XMM_COUNT;
+
+# required stack alignment in bytes at a call boundary under win64.
+pub val STACK_ALIGN: u32 = 16;
+# win64 has no leaf-function red zone.
+pub val RED_ZONE: u32 = 0;
+# bytes of shadow space the caller reserves above the return address — one
+# 8-byte slot per argument register (4 * 8) — into which the callee may spill its
+# four register arguments. it sits below the first stack argument and is always
+# reserved, even for a call that passes no arguments in registers.
+pub val SHADOW_SPACE: u64 = 32;
+# largest aggregate size in bytes that may be passed or returned in a single
+# register by value. an aggregate of exactly 1, 2, 4, or 8 bytes rides in one
+# register; any other size (3, 5, 6, 7, or >8) is passed by hidden reference
+# (arguments) or via an sret pointer (returns).
+pub val MAX_REG_AGG: u64 = 8;
+
+# is_by_value_size: report whether an aggregate of `size` bytes is passed or
+# returned by value in a single register under win64.
 #
-# stub: win64 classification is not yet implemented. always returns a
-# CLASS_STACK sentinel slot (reg -1) as the honest "unsupported" signal. the
-# signature mirrors sysv's ClassifyFn exactly; it is type-erased to *u8 in the
-# vtable and cast back to that one concrete signature by consumers.
+# win64 admits exactly the power-of-two sizes 1, 2, 4, and 8: a 1/2/4/8-byte
+# record fits one register, while 3/5/6/7-byte and >8-byte records are passed by
+# hidden reference and returned through an sret pointer.
+# ---
+# size: aggregate size in bytes
+# ret:  true if the aggregate rides in one register by value
+pub fun is_by_value_size(size: u64) bool {
+    ret size == 1 || size == 2 || size == 4 || size == 8;
+}
+
+# slot_gp_reg: the integer argument register for a given positional slot.
+# returns -1 when the slot is past the four register slots.
+# ---
+# index: zero-based positional argument slot
+# ret:   the physical register id, or -1 if out of range
+pub fun slot_gp_reg(index: i32) i32 {
+    if (index == 0) { ret REG_RCX; }
+    if (index == 1) { ret REG_RDX; }
+    if (index == 2) { ret REG_R8; }
+    if (index == 3) { ret REG_R9; }
+    ret -1;
+}
+
+# slot_fp_reg: the vector argument register (XMM0–XMM3) for a positional slot.
+# the returned id is composite (the SSE class tag in the high byte) so a float
+# pre-coloring carries its bank. returns -1 past slot 3.
+# ---
+# index: zero-based positional argument slot
+# ret:   the composite XMM register id, or -1 if out of range
+pub fun slot_fp_reg(index: i32) i32 {
+    if (index < 0) { ret -1; }
+    if (index >= FP_PARAM_COUNT) { ret -1; }
+    ret isa.regid_make(isa.REG_CLASS_ID_XMM, index);
+}
+
+# float_dup_gp_reg: the integer register a VARIADIC float argument is duplicated
+# into, in addition to its XMM register, under win64.
+#
+# a win64 variadic float is passed in BOTH the matching XMM register and the
+# matching integer register so a callee reading the argument through `va_arg`
+# (which only knows the integer registers) sees it. the duplicate rides the
+# integer register of the SAME positional slot. returns -1 past the four slots.
+# the fixed-argument classifier cannot know an argument's variadic-ness (its
+# signature carries no variadic flag), so the variadic call lowering consults
+# this helper directly for tail floats.
+# ---
+# index: zero-based positional argument slot
+# ret:   the duplicate integer register id, or -1 if out of range
+pub fun float_dup_gp_reg(index: i32) i32 {
+    ret slot_gp_reg(index);
+}
+
+# unsupported_slot: the honest "unsupported architecture" sentinel returned by
+# this AMD64-only classifier when handed a non-x86_64 arch_id.
+#
+# the vtable classify/arg/ret signatures return a plain `ParamSlot` (not a
+# `Result`), so an out-of-scope architecture cannot surface a `str` error here.
+# instead this returns a structurally impossible placement — CLASS_STACK with
+# offset = -1 and size = 0 — that no real win64 placement ever produces (a genuine
+# stack slot always carries its true byte size and offset 0). a consumer can
+# reject it with `is_unsupported_slot`; it must never be treated as a valid
+# placement on another architecture. it shares the exact shape of the SysV
+# sentinel so a consumer can test either ABI's slots with one predicate.
+# ---
+# ret: the unsupported-architecture sentinel slot
+pub fun unsupported_slot() abi.ParamSlot {
+    ret abi.make_slot(abi.CLASS_STACK, -1, -1, -1, 0);
+}
+
+# is_unsupported_slot: report whether a ParamSlot is the unsupported sentinel.
+#
+# consumers casting the classify/arg/ret pointers back to their concrete
+# signatures must call this before trusting a placement, so the AMD64-only
+# fallback is rejected rather than mistaken for a real stack slot.
+# ---
+# slot: the placement decision to test
+# ret:  true if `slot` is the `unsupported_slot` sentinel
+pub fun is_unsupported_slot(slot: abi.ParamSlot) bool {
+    ret slot.class == abi.CLASS_STACK && slot.offset == -1 && slot.size == 0;
+}
+
+# slot_index: the positional argument slot from the running GP/FP usage counters.
+#
+# win64 shares one positional slot per argument across both register banks, so
+# the slot of the next argument is the total number of register-passed arguments
+# so far — `gp_used + fp_used`. every register-passed argument advances exactly
+# one of the two counters by one (a float advances `fp_used`, an integer / by-ref
+# aggregate / sret reservation advances `gp_used`; win64 never splits an argument
+# across two registers), so the sum tracks the positional index exactly as the
+# generic signature walk in `mir.classify_signature` maintains it.
+# ---
+# gp_used: GP argument registers already consumed
+# fp_used: FP argument registers already consumed
+# ret:     the zero-based positional slot of the next argument
+fun slot_index(gp_used: i32, fp_used: i32) i32 {
+    ret gp_used + fp_used;
+}
+
+# classify: classify one value into a win64 placement decision.
+#
+# this is the body behind the erased `AbiVTable.classify` pointer; it treats the
+# value as the first argument and routes through `classify_arg`. returns are
+# routed separately through `classify_return`.
 # ---
 # arch_id:      architecture id (one of isa.ARCH_*)
 # size:         value size in bytes
 # align:        value alignment in bytes
-# is_float:     true if the value is a floating-point scalar
+# is_float:     true if the value is FP-eligible
 # is_aggregate: true if the value is an aggregate
 # gp_used:      GP registers already consumed
 # fp_used:      FP registers already consumed
-# ret:          a CLASS_STACK sentinel ParamSlot (reg -1) marking "unsupported"
-fun win64_classify(arch_id: u32, size: u64, align: u64, is_float: bool,
-                   is_aggregate: bool, gp_used: i32, fp_used: i32) abi.ParamSlot {
-    ret abi.make_slot(abi.CLASS_STACK, -1, -1, 0, size);
+# ret:          the placement decision
+pub fun classify(arch_id: u32, size: u64, align: u64, is_float: bool,
+                 is_aggregate: bool, gp_used: i32, fp_used: i32) abi.ParamSlot {
+    ret classify_arg(arch_id, 0, size, align, is_float, is_aggregate, gp_used, fp_used);
 }
 
-# win64_arg_passing: assign an argument's register or stack slot under win64.
+# classify_arg: assign a register or stack slot for one argument (win64).
 #
-# stub: not yet implemented. always returns a CLASS_STACK sentinel slot (reg -1)
-# as the honest "unsupported" signal. the signature mirrors sysv's ArgPassingFn
-# exactly so the erased-pointer cast-back is sound.
+# win64 places at most the first four arguments in registers, one positional
+# slot per argument shared across the integer (RCX/RDX/R8/R9) and vector
+# (XMM0–XMM3) banks: argument N takes the Nth register of its bank. an aggregate
+# of 1/2/4/8 bytes rides one integer register by value; any other aggregate is
+# passed by hidden reference (CLASS_BYREF) — a caller-allocated copy whose
+# pointer occupies the slot's integer register. a float takes the slot's XMM
+# register; an integer or pointer takes the slot's integer register. once the
+# four slots are exhausted the argument spills to the stack by value (a by-ref
+# aggregate spills its 8-byte pointer). this classifier is AMD64-only: a
+# non-x86_64 arch_id yields the `unsupported_slot` sentinel, which callers must
+# reject -- it is never a valid placement on the requested architecture.
 # ---
 # arch_id:      architecture id (one of isa.ARCH_*)
 # index:        zero-based logical argument position
@@ -65,60 +245,200 @@ fun win64_classify(arch_id: u32, size: u64, align: u64, is_float: bool,
 # is_aggregate: true if the argument is an aggregate
 # gp_used:      GP registers already consumed
 # fp_used:      FP registers already consumed
-# ret:          a CLASS_STACK sentinel ParamSlot (reg -1) marking "unsupported"
-fun win64_arg_passing(arch_id: u32, index: i32, size: u64, align: u64,
-                      is_float: bool, is_aggregate: bool,
-                      gp_used: i32, fp_used: i32) abi.ParamSlot {
+# ret:          the placement decision
+pub fun classify_arg(arch_id: u32, index: i32, size: u64, align: u64,
+                     is_float: bool, is_aggregate: bool,
+                     gp_used: i32, fp_used: i32) abi.ParamSlot {
+    if (arch_id != isa.ARCH_X86_64) {
+        ret unsupported_slot();
+    }
+
+    val slot: i32 = slot_index(gp_used, fp_used);
+
+    if (is_aggregate) {
+        # 1/2/4/8-byte aggregates ride one integer register by value; all other
+        # sizes are passed by reference (a pointer to a caller-allocated copy).
+        if (is_by_value_size(size)) {
+            if (slot < PARAM_SLOT_COUNT) {
+                ret abi.make_slot(abi.CLASS_GP, slot_gp_reg(slot), -1, 0, size);
+            }
+            ret abi.make_slot(abi.CLASS_STACK, -1, -1, 0, size);
+        }
+        if (slot < PARAM_SLOT_COUNT) {
+            ret abi.make_slot(abi.CLASS_BYREF, slot_gp_reg(slot), -1, 0, 8);
+        }
+        # no register slot remains: spill the hidden pointer (8 bytes) to the stack.
+        ret abi.make_slot(abi.CLASS_STACK, -1, -1, 0, 8);
+    }
+
+    if (is_float) {
+        if (slot < PARAM_SLOT_COUNT) {
+            ret abi.make_slot(abi.CLASS_FP, slot_fp_reg(slot), -1, 0, size);
+        }
+        ret abi.make_slot(abi.CLASS_STACK, -1, -1, 0, size);
+    }
+
+    if (slot < PARAM_SLOT_COUNT) {
+        ret abi.make_slot(abi.CLASS_GP, slot_gp_reg(slot), -1, 0, size);
+    }
     ret abi.make_slot(abi.CLASS_STACK, -1, -1, 0, size);
 }
 
-# win64_ret_passing: assign the return value's register or sret under win64.
+# classify_return: assign a register or sret pointer for a return value (win64).
 #
-# stub: not yet implemented. always returns a CLASS_STACK sentinel slot (reg -1)
-# as the honest "unsupported" signal. the signature mirrors sysv's RetPassingFn
-# exactly so the erased-pointer cast-back is sound.
+# a zero-size (void) return yields CLASS_GP with reg=-1. an aggregate of
+# 1/2/4/8 bytes returns in RAX (or XMM0 when all-float); any other aggregate is
+# returned through a hidden struct-return pointer that the caller passes in RCX
+# (consuming the first positional argument slot, shifting the real arguments) and
+# the callee returns in RAX (CLASS_SRET, reg=RAX). scalars return in RAX, or XMM0
+# for floats. this classifier is AMD64-only: a non-x86_64 arch_id yields the
+# `unsupported_slot` sentinel, which callers must reject rather than treat as a
+# valid placement.
 # ---
 # arch_id:      architecture id (one of isa.ARCH_*)
 # size:         return-value size in bytes
 # align:        return-value alignment in bytes
 # is_float:     true if the value is returned in FP registers
 # is_aggregate: true if the value is an aggregate
-# ret:          a CLASS_STACK sentinel ParamSlot (reg -1) marking "unsupported"
-fun win64_ret_passing(arch_id: u32, size: u64, align: u64,
-                      is_float: bool, is_aggregate: bool) abi.ParamSlot {
-    ret abi.make_slot(abi.CLASS_STACK, -1, -1, 0, size);
+# ret:          the placement decision
+pub fun classify_return(arch_id: u32, size: u64, align: u64,
+                        is_float: bool, is_aggregate: bool) abi.ParamSlot {
+    if (arch_id != isa.ARCH_X86_64) {
+        ret unsupported_slot();
+    }
+
+    if (size == 0) {
+        ret abi.make_slot(abi.CLASS_GP, -1, -1, 0, 0);
+    }
+
+    if (is_aggregate) {
+        if (is_by_value_size(size)) {
+            if (is_float) {
+                ret abi.make_slot(abi.CLASS_FP, REG_XMM0, -1, 0, size);
+            }
+            ret abi.make_slot(abi.CLASS_GP, REG_RAX, -1, 0, size);
+        }
+        # the hidden result-storage pointer rides RCX in and is returned in RAX.
+        ret abi.make_slot(abi.CLASS_SRET, REG_RAX, -1, 0, 8);
+    }
+
+    if (is_float) {
+        ret abi.make_slot(abi.CLASS_FP, REG_XMM0, -1, 0, size);
+    }
+
+    ret abi.make_slot(abi.CLASS_GP, REG_RAX, -1, 0, size);
 }
 
-# win64_reg_file: the honest "unsupported" register-file accessor under win64.
+# gp_param_regs: the integer argument registers, in passing order.
 #
-# stub: win64 register banks are not yet enumerated. writes nothing to `out` and
-# returns 0 — no registers known — rather than silently presenting a SysV bank.
-# the signature mirrors sysv's RegFileFn exactly so the erased-pointer cast-back
-# is sound; it backs the gp_arg_regs / fp_arg_regs / callee_saved vtable slots.
+# fills `out[0..GP_PARAM_COUNT)` with RCX, RDX, R8, R9 (each 8 bytes wide). the
+# caller owns `out`, which must hold at least `GP_PARAM_COUNT` registers; the
+# count is returned so the call composes with `RegisterFile`.
 # ---
-# out: caller-owned buffer (left untouched)
-# ret: 0 (no registers written)
-fun win64_reg_file(out: *isa.Register) i32 {
-    ret 0;
+# out: caller-owned buffer of at least GP_PARAM_COUNT registers
+# ret: the number of registers written (GP_PARAM_COUNT)
+pub fun gp_param_regs(out: *isa.Register) i32 {
+    var i: i32 = 0;
+    for (i < GP_PARAM_COUNT) {
+        out[i].id   = slot_gp_reg(i);
+        out[i].size = 8;
+        i = i + 1;
+    }
+    ret GP_PARAM_COUNT;
 }
 
-# required stack alignment in bytes at a call boundary under win64.
-pub val WIN64_STACK_ALIGN: u32 = 16;
+# fp_param_regs: the vector argument registers, in passing order.
+#
+# fills `out[0..FP_PARAM_COUNT)` with XMM0–XMM3 (each 16 bytes wide). the caller
+# owns `out`, which must hold at least `FP_PARAM_COUNT` registers.
+# ---
+# out: caller-owned buffer of at least FP_PARAM_COUNT registers
+# ret: the number of registers written (FP_PARAM_COUNT)
+pub fun fp_param_regs(out: *isa.Register) i32 {
+    var i: i32 = 0;
+    for (i < FP_PARAM_COUNT) {
+        out[i].id   = isa.regid_make(isa.REG_CLASS_ID_XMM, i);
+        out[i].size = 16;
+        i = i + 1;
+    }
+    ret FP_PARAM_COUNT;
+}
 
-# win64 has no leaf-function red zone.
-pub val WIN64_RED_ZONE: u32 = 0;
+# callee_saved: the callee-saved registers a win64 function must preserve.
+#
+# fills `out[0..CALLEE_SAVED_COUNT)` with the integer set (RBX, RBP, RDI, RSI,
+# RSP, R12–R15, each 8 bytes wide) followed by the vector set (XMM6–XMM15, each
+# 16 bytes wide — only their 64 low bits are architecturally callee-saved, but
+# the register file reports whole registers). a callee that touches any of these
+# must preserve it across the call. the caller owns `out`, which must hold at
+# least `CALLEE_SAVED_COUNT` registers.
+# ---
+# out: caller-owned buffer of at least CALLEE_SAVED_COUNT registers
+# ret: the number of registers written (CALLEE_SAVED_COUNT)
+pub fun callee_saved(out: *isa.Register) i32 {
+    out[0].id = REG_RBX; out[0].size = 8;
+    out[1].id = REG_RBP; out[1].size = 8;
+    out[2].id = REG_RDI; out[2].size = 8;
+    out[3].id = REG_RSI; out[3].size = 8;
+    out[4].id = REG_RSP; out[4].size = 8;
+    out[5].id = REG_R12; out[5].size = 8;
+    out[6].id = REG_R13; out[6].size = 8;
+    out[7].id = REG_R14; out[7].size = 8;
+    out[8].id = REG_R15; out[8].size = 8;
 
-# the win64 ABI vtable. populated by register on first call and handed out as a
-# borrowed pointer to the registry.
+    var i: i32 = 0;
+    for (i < CALLEE_SAVED_XMM_COUNT) {
+        out[CALLEE_SAVED_GP_COUNT + i].id   = isa.regid_make(isa.REG_CLASS_ID_XMM, 6 + i);
+        out[CALLEE_SAVED_GP_COUNT + i].size = 16;
+        i = i + 1;
+    }
+    ret CALLEE_SAVED_COUNT;
+}
+
+# stack_align: required stack alignment in bytes at a call boundary (16).
+# ---
+# ret: the alignment in bytes
+pub fun stack_align() u32 {
+    ret STACK_ALIGN;
+}
+
+# red_zone: size in bytes of the leaf-function red zone (0 — win64 has none).
+# ---
+# ret: the red-zone size in bytes
+pub fun red_zone() u32 {
+    ret RED_ZONE;
+}
+
+# shadow_space: bytes of shadow / home space the caller reserves above the
+# return address for the four register arguments (32).
+# ---
+# ret: the shadow-space size in bytes
+pub fun shadow_space() u64 {
+    ret SHADOW_SPACE;
+}
+
+# max_reg_agg: largest aggregate size in bytes passable / returnable by value in
+# one register (8). only the sizes 1, 2, 4, and 8 qualify — see
+# `is_by_value_size`.
+# ---
+# ret: the maximum by-value aggregate size in bytes
+pub fun max_reg_agg() u64 {
+    ret MAX_REG_AGG;
+}
+
+# the win64 ABI vtable. populated by register_win64 on first call and handed out
+# as a borrowed pointer to the registry. its three classify/arg/ret function
+# pointers are stored type-erased (`*u8`); consumers cast them back to the
+# shared `sysv.ClassifyFn` / `sysv.ArgPassingFn` / `sysv.RetPassingFn`.
 var win64_vtable: abi.AbiVTable;
 var win64_registered: bool = false;
 
 # register_win64: build and install the win64 AbiVTable.
 #
-# interns the convention name, wires the type-erased classify/arg/ret operation
-# pointers and the gp_arg_regs / fp_arg_regs / callee_saved register-file
-# accessors, sets the stack alignment (16) and red-zone size (0), and
-# self-registers it into the process-global ABI registry under abi.ABI_WIN64.
+# interns the convention name ("win64"), wires the type-erased classify/arg/ret
+# operation pointers and the gp_arg_regs / fp_arg_regs / callee_saved register-
+# file accessors, sets the stack alignment (16) and red-zone size (0), and self-
+# registers it into the process-global ABI registry under abi.ABI_WIN64.
 # write-once: a second call is a no-op. must be invoked at compiler startup
 # before target.select requests a Windows target.
 # ---
@@ -133,16 +453,207 @@ pub fun register_win64(alloc: *Allocator, i: *intern.Interner) Result[bool, str]
 
     win64_vtable.id           = abi.ABI_WIN64;
     win64_vtable.name         = unwrap_ok[intern.StrId, str](rn);
-    win64_vtable.classify     = win64_classify::*u8;
-    win64_vtable.arg_passing  = win64_arg_passing::*u8;
-    win64_vtable.ret_passing  = win64_ret_passing::*u8;
-    win64_vtable.gp_arg_regs  = win64_reg_file::*u8;
-    win64_vtable.fp_arg_regs  = win64_reg_file::*u8;
-    win64_vtable.callee_saved = win64_reg_file::*u8;
-    win64_vtable.stack_align  = WIN64_STACK_ALIGN;
-    win64_vtable.red_zone     = WIN64_RED_ZONE;
+    win64_vtable.classify     = classify::*u8;
+    win64_vtable.arg_passing  = classify_arg::*u8;
+    win64_vtable.ret_passing  = classify_return::*u8;
+    win64_vtable.gp_arg_regs  = gp_param_regs::*u8;
+    win64_vtable.fp_arg_regs  = fp_param_regs::*u8;
+    win64_vtable.callee_saved = callee_saved::*u8;
+    win64_vtable.stack_align  = STACK_ALIGN;
+    win64_vtable.red_zone     = RED_ZONE;
 
     abi.register(?win64_vtable);
     win64_registered = true;
     ret ok[bool, str](true);
+}
+
+test "win64: scalar integer args take RCX, RDX, R8, R9 then spill" {
+    val a: u32 = isa.ARCH_X86_64;
+    val s0: abi.ParamSlot = classify_arg(a, 0, 8, 8, false, false, 0, 0);
+    if (s0.class != abi.CLASS_GP) { ret 1; }
+    if (s0.reg != REG_RCX)        { ret 1; }
+
+    val s1: abi.ParamSlot = classify_arg(a, 1, 8, 8, false, false, 1, 0);
+    if (s1.reg != REG_RDX) { ret 1; }
+    val s2: abi.ParamSlot = classify_arg(a, 2, 8, 8, false, false, 2, 0);
+    if (s2.reg != REG_R8) { ret 1; }
+    val s3: abi.ParamSlot = classify_arg(a, 3, 8, 8, false, false, 3, 0);
+    if (s3.reg != REG_R9) { ret 1; }
+
+    # the fifth argument has no register slot and spills to the stack by value.
+    val s4: abi.ParamSlot = classify_arg(a, 4, 8, 8, false, false, 4, 0);
+    if (s4.class != abi.CLASS_STACK) { ret 1; }
+    if (s4.reg != -1)                { ret 1; }
+    if (s4.size != 8)                { ret 1; }
+    ret 0;
+}
+
+test "win64: float args take XMM0–XMM3 then spill" {
+    val a: u32 = isa.ARCH_X86_64;
+    val f0: abi.ParamSlot = classify_arg(a, 0, 8, 8, true, false, 0, 0);
+    if (f0.class != abi.CLASS_FP)                          { ret 1; }
+    if (f0.reg != isa.regid_make(isa.REG_CLASS_ID_XMM, 0)) { ret 1; }
+
+    val f3: abi.ParamSlot = classify_arg(a, 3, 4, 4, true, false, 0, 3);
+    if (f3.class != abi.CLASS_FP)                          { ret 1; }
+    if (f3.reg != isa.regid_make(isa.REG_CLASS_ID_XMM, 3)) { ret 1; }
+
+    # the fifth positional argument (slot 4) spills regardless of bank.
+    val f4: abi.ParamSlot = classify_arg(a, 4, 8, 8, true, false, 0, 4);
+    if (f4.class != abi.CLASS_STACK) { ret 1; }
+    ret 0;
+}
+
+test "win64: int and float share one positional slot per argument" {
+    val a: u32 = isa.ARCH_X86_64;
+    # argument 0 is an integer (slot 0 -> RCX). argument 1 is a float; under
+    # win64 it takes the SECOND positional slot -> XMM1, not XMM0, because the
+    # integer already consumed slot 0.
+    val i0: abi.ParamSlot = classify_arg(a, 0, 8, 8, false, false, 0, 0);
+    if (i0.reg != REG_RCX) { ret 1; }
+    val f1: abi.ParamSlot = classify_arg(a, 1, 8, 8, true, false, 1, 0);
+    if (f1.class != abi.CLASS_FP)                          { ret 1; }
+    if (f1.reg != isa.regid_make(isa.REG_CLASS_ID_XMM, 1)) { ret 1; }
+
+    # the reverse: a float (slot 0 -> XMM0) followed by an integer (slot 1 -> RDX).
+    val g0: abi.ParamSlot = classify_arg(a, 0, 8, 8, true, false, 0, 0);
+    if (g0.reg != isa.regid_make(isa.REG_CLASS_ID_XMM, 0)) { ret 1; }
+    val g1: abi.ParamSlot = classify_arg(a, 1, 8, 8, false, false, 0, 1);
+    if (g1.class != abi.CLASS_GP) { ret 1; }
+    if (g1.reg != REG_RDX)        { ret 1; }
+    ret 0;
+}
+
+test "win64: a variadic float duplicates into the matching integer register" {
+    # the variadic float at positional slot 2 rides XMM2 and is also duplicated
+    # into the slot's integer register R8 so a va_arg reader sees it.
+    if (slot_fp_reg(2) != isa.regid_make(isa.REG_CLASS_ID_XMM, 2)) { ret 1; }
+    if (float_dup_gp_reg(2) != REG_R8) { ret 1; }
+    if (float_dup_gp_reg(0) != REG_RCX) { ret 1; }
+    if (float_dup_gp_reg(4) != -1) { ret 1; }
+    ret 0;
+}
+
+test "win64: 1/2/4/8-byte aggregates ride one register, others go by reference" {
+    val a: u32 = isa.ARCH_X86_64;
+    # an 8-byte aggregate rides RCX by value.
+    val by_val: abi.ParamSlot = classify_arg(a, 0, 8, 8, false, true, 0, 0);
+    if (by_val.class != abi.CLASS_GP) { ret 1; }
+    if (by_val.reg != REG_RCX)        { ret 1; }
+    if (by_val.size != 8)             { ret 1; }
+
+    # a 4-byte aggregate also rides by value.
+    val four: abi.ParamSlot = classify_arg(a, 0, 4, 4, false, true, 0, 0);
+    if (four.class != abi.CLASS_GP) { ret 1; }
+
+    # a 3-byte aggregate is not a by-value size: passed by hidden reference, the
+    # pointer (8 bytes) in RCX.
+    val by_ref3: abi.ParamSlot = classify_arg(a, 0, 3, 1, false, true, 0, 0);
+    if (by_ref3.class != abi.CLASS_BYREF) { ret 1; }
+    if (by_ref3.reg != REG_RCX)           { ret 1; }
+    if (by_ref3.size != 8)                { ret 1; }
+
+    # a 16-byte aggregate is also by reference.
+    val by_ref16: abi.ParamSlot = classify_arg(a, 0, 16, 8, false, true, 0, 0);
+    if (by_ref16.class != abi.CLASS_BYREF) { ret 1; }
+    if (by_ref16.reg != REG_RCX)           { ret 1; }
+    ret 0;
+}
+
+test "win64: an exhausted by-reference aggregate spills its pointer to the stack" {
+    val a: u32 = isa.ARCH_X86_64;
+    # all four positional slots are taken; a 16-byte by-ref aggregate spills the
+    # 8-byte hidden pointer to the stack, not the full aggregate.
+    val s: abi.ParamSlot = classify_arg(a, 4, 16, 8, false, true, 4, 0);
+    if (s.class != abi.CLASS_STACK) { ret 1; }
+    if (s.size != 8)                { ret 1; }
+    ret 0;
+}
+
+test "win64: scalar returns use RAX / XMM0, void returns reg=-1" {
+    val a: u32 = isa.ARCH_X86_64;
+    val voidr: abi.ParamSlot = classify_return(a, 0, 0, false, false);
+    if (voidr.class != abi.CLASS_GP) { ret 1; }
+    if (voidr.reg != -1)             { ret 1; }
+
+    val ir: abi.ParamSlot = classify_return(a, 8, 8, false, false);
+    if (ir.class != abi.CLASS_GP) { ret 1; }
+    if (ir.reg != REG_RAX)        { ret 1; }
+
+    val fr: abi.ParamSlot = classify_return(a, 8, 8, true, false);
+    if (fr.class != abi.CLASS_FP) { ret 1; }
+    if (fr.reg != REG_XMM0)       { ret 1; }
+    ret 0;
+}
+
+test "win64: aggregate returns are RAX by value or an sret pointer" {
+    val a: u32 = isa.ARCH_X86_64;
+    # an 8-byte aggregate returns in RAX.
+    val small: abi.ParamSlot = classify_return(a, 8, 8, false, true);
+    if (small.class != abi.CLASS_GP) { ret 1; }
+    if (small.reg != REG_RAX)        { ret 1; }
+
+    # a small all-float aggregate returns in XMM0.
+    val fsmall: abi.ParamSlot = classify_return(a, 8, 8, true, true);
+    if (fsmall.class != abi.CLASS_FP) { ret 1; }
+    if (fsmall.reg != REG_XMM0)       { ret 1; }
+
+    # a 12-byte aggregate is not a by-value size: returned via an sret pointer,
+    # which the callee yields in RAX.
+    val big: abi.ParamSlot = classify_return(a, 12, 4, false, true);
+    if (big.class != abi.CLASS_SRET) { ret 1; }
+    if (big.reg != REG_RAX)          { ret 1; }
+    ret 0;
+}
+
+test "win64: an sret return reserves the first positional slot, shifting args" {
+    val a: u32 = isa.ARCH_X86_64;
+    # a 24-byte aggregate return is sret. classify_signature seeds gp_used=1 for
+    # the hidden RCX pointer, so the first real integer argument lands in RDX.
+    val ret_slot: abi.ParamSlot = classify_return(a, 24, 8, false, true);
+    if (ret_slot.class != abi.CLASS_SRET) { ret 1; }
+    val first_arg: abi.ParamSlot = classify_arg(a, 0, 8, 8, false, false, 1, 0);
+    if (first_arg.class != abi.CLASS_GP) { ret 1; }
+    if (first_arg.reg != REG_RDX)        { ret 1; }
+    ret 0;
+}
+
+test "win64: shadow space is 32 bytes, no red zone, 16-byte stack align" {
+    if (shadow_space() != 32) { ret 1; }
+    if (red_zone() != 0)      { ret 1; }
+    if (stack_align() != 16)  { ret 1; }
+    ret 0;
+}
+
+test "win64: register files report the win64 banks" {
+    var gp: [4]isa.Register;
+    if (gp_param_regs(?gp[0]) != GP_PARAM_COUNT) { ret 1; }
+    if (gp[0].id != REG_RCX) { ret 1; }
+    if (gp[1].id != REG_RDX) { ret 1; }
+    if (gp[2].id != REG_R8)  { ret 1; }
+    if (gp[3].id != REG_R9)  { ret 1; }
+
+    var fp: [4]isa.Register;
+    if (fp_param_regs(?fp[0]) != FP_PARAM_COUNT) { ret 1; }
+    if (fp[0].id != isa.regid_make(isa.REG_CLASS_ID_XMM, 0)) { ret 1; }
+    if (fp[3].id != isa.regid_make(isa.REG_CLASS_ID_XMM, 3)) { ret 1; }
+
+    var cs: [19]isa.Register;
+    if (callee_saved(?cs[0]) != CALLEE_SAVED_COUNT) { ret 1; }
+    if (cs[0].id != REG_RBX) { ret 1; }
+    if (cs[2].id != REG_RDI) { ret 1; }
+    if (cs[3].id != REG_RSI) { ret 1; }
+    if (cs[8].id != REG_R15) { ret 1; }
+    # the vector set begins right after the nine integer registers, at XMM6.
+    if (cs[CALLEE_SAVED_GP_COUNT].id != isa.regid_make(isa.REG_CLASS_ID_XMM, 6)) { ret 1; }
+    if (cs[CALLEE_SAVED_COUNT - 1].id != isa.regid_make(isa.REG_CLASS_ID_XMM, 15)) { ret 1; }
+    ret 0;
+}
+
+test "win64: a non-x86_64 arch yields the unsupported sentinel" {
+    val s: abi.ParamSlot = classify_arg(isa.ARCH_AARCH64, 0, 8, 8, false, false, 0, 0);
+    if (!is_unsupported_slot(s)) { ret 1; }
+    val r: abi.ParamSlot = classify_return(isa.ARCH_AARCH64, 8, 8, false, false);
+    if (!is_unsupported_slot(r)) { ret 1; }
+    ret 0;
 }


### PR DESCRIPTION
Implements the Microsoft x64 (win64) calling convention in `src/lang/target/abi/win64.mach`, replacing the CLASS_STACK/0-reg stub. Modeled on the working SysV impl; no backend changes.

## win64 rules implemented
- **Args**: integers/pointers in RCX, RDX, R8, R9; floats in XMM0–XMM3 — sharing **one positional slot per argument** (arg N takes the Nth register of its bank, never both banks filling independently as under SysV). The slot index is derived as `gp_used + fp_used`, so the generic `mir.classify_signature` walk stays positionally correct unchanged.
- **Aggregates**: 1/2/4/8 bytes by value in one integer register; any other size (3/5/6/7 or >8) by hidden reference (pointer in the slot’s integer register; spills the 8-byte pointer, not the aggregate, once the four slots are exhausted).
- **Returns**: RAX (or XMM0 for floats) for 1/2/4/8 bytes; otherwise an sret pointer (RCX in, RAX out) that reserves the first positional slot, shifting the real arguments.
- **Frame**: 32-byte shadow space, no red zone, 16-byte stack alignment.
- **Callee-saved**: RBX, RBP, RDI, RSI, RSP, R12–R15 and XMM6–XMM15.
- **Variadic floats**: documented `float_dup_gp_reg` helper for the int-register duplication a `va_arg` reader needs (the fixed-arg classifier has no variadic flag, so the variadic call lowering consults it directly).

Wires the classify/arg/ret + register-file accessors into the vtable that `register_win64` installs under `ABI_WIN64`; `target.canonical_abi` already maps `OS_WINDOWS → ABI_WIN64`.

## Tests
Adds 12 `test {}` cases covering int/float/aggregate args and returns, the shared positional slot (int↔float interleave), shadow space / no-red-zone / 16-byte align, the by-ref and exhausted-by-ref-pointer-spill rules, sret reservation, the GP/FP/callee-saved register files, and the non-x86_64 unsupported sentinel.

## Gates
- **SysV (x86_64-linux) unaffected**: the native build uses `abi = "sysv64"`; win64 is a new, unselected ABI.
- **Byte-identical fixpoint holds**: seed → `a`, `a` → `b`, `cmp` identical (converges at stage 2).
- **`mach test .` → 221 PASS, 0 FAIL** (209 baseline + 12 win64).

## Not yet end-to-end
A Windows binary still needs COFF (#1175), the linker (#1159), and the Windows OS layer (#1177); this PR verifies the ABI logic structurally and via the classifier tests.

### Downstream consumers
- **#1175 (COFF)** / **#1177 (Windows OS layer)**: once registered, `target.select(OS_WINDOWS, ARCH_X86_64)` composes a full Windows target — this ABI vtable supplies the parameter classification (`classify`/`arg_passing`/`ret_passing`) and the GP/FP/callee-saved register files the existing generic backend (`mir.classify_signature`, regalloc’s caller/callee-saved partition) already consumes through the erased vtable pointers.
- The frame/prologue lowering will read `shadow_space()` (32) and the win64 callee-saved set; the variadic call path will read `float_dup_gp_reg`.

Closes #1173
