### PR TITLE
fix(x64): materialize an out-of-imm32 imul constant into a register

### DIFF
--- a/src/lang/target/isa/x64/encode.mach
+++ b/src/lang/target/isa/x64/encode.mach
@@ -1160,6 +1160,32 @@ fun encode_imul(mi: *isa.Inst, buf: *ByteBuf) i32 {
 
     if (dst.kind == isa.OPK_REG && src1.kind == isa.OPK_IMM) {
         val imm: i64 = src1.imm;
+        # the imm forms here -- `imul r64, r/m64, imm8` (6B) and `imul r64, r/m64,
+        # imm32` (69) -- carry at most a 32-bit field that the CPU sign-extends to
+        # the operand width; x86-64 has no `imul r64, imm64`. a 64-bit immediate
+        # outside signed-imm32 range cannot be encoded directly without corrupting
+        # its value, so it is materialized into the reserved R11 scratch and
+        # re-encoded as the two-operand register form `imul dst, r11` (dst = dst *
+        # r11), mirroring the same split in encode_alu_imm.
+        if (size == 8 && (imm < -2147483648 || imm > 2147483647)) {
+            val scratch: i32 = x64.R11;
+            var ld: isa.Inst;
+            zero_inst(?ld);
+            ld.opcode = x64.MOV;
+            ld.dst    = isa.make_reg(scratch, 8);
+            ld.src1   = isa.make_imm(imm, 8);
+            ld.size   = 8;
+            encode_mov(?ld, buf);
+            var rr: isa.Inst;
+            zero_inst(?rr);
+            rr.opcode = x64.IMUL;
+            rr.dst    = isa.make_reg(dst.reg, size);
+            rr.src1   = isa.make_reg(scratch, size);
+            rr.size   = size;
+            rr.flags  = flags;
+            encode_imul(?rr, buf);
+            ret (buf.len - start)::i32;
+        }
         if ((flags & x64.FLAG_16BIT::u16) != 0) { emit_byte(buf, 0x66); }
         emit_rex_if_needed(buf, w, dst.reg, dst.reg);
         if (imm >= -128 && imm <= 127) {


### PR DESCRIPTION
## Root cause

`encode_imul`'s `reg, imm` path (`src/lang/target/isa/x64/encode.mach`) emitted the `imul r64, r/m64, imm32` form (opcode `69`) for any immediate outside imm8 range. x86-64 has no `imul r64, imm64`; that imm32 field is sign-extended to the operand width, so a 64-bit multiplier outside signed-imm32 range was **silently truncated to its low 32 bits**.

The SWAR `popcount(v: u64)` ends with `(x * 0x0101010101010101) >> 56`. The multiplier `0x0101010101010101` was truncated to `0x01010101`, so the byte-sum-via-multiply summed only 4 of the 8 byte lanes — `popcount(0xFFFFFFFFFFFFFFFF)` returned **32** instead of **64**, `popcount(0x1)` returned 0, etc. (Not a spill/reload width bug as first hypothesized — the immediate never survived encoding at full width.)

### Before / after (disassembly of the multiply step)

```
; before — low 32 bits of the constant only
imul rcx, rcx, 0x1010101

; after — full 64-bit constant via the scratch register
movabs r11, 0x0101010101010101
imul   rcx, r11
```

## Fix

Mirror the established `encode_alu_imm` pattern: when the operand is 8 bytes and the immediate is outside signed-imm32 range, materialize it into the reserved R11 scratch (`MOV r11, imm64` → `movabs`) and re-encode as the two-operand register form `imul dst, r11`. The in-imm32 fast paths (`6B`/`69`) are unchanged.

## Verification

- Repro returns 64; `popcount(0x1)`→1, `popcount(0xFF)`→8, `popcount(0x8000000000000000)`→1, `popcount(0)`→0, `popcount(0xAAAA…)`→32.
- Direct `imul` by an out-of-imm32 constant (incl. an unsigned value `> 0x7FFFFFFF` that the old code sign-extended wrongly) now correct; imm8/imm32 fast paths unaffected.
- **Byte-identical self-host fixpoint holds** (`b == c`).
- `mach test .` corpus: **223 passed, 0 failed**.
- mach-std (dev tip) bits suite: `popcount` / `ctz` / `clz` / `bitset count` all pass — the dependent `ctz` and bitset failures are fixed too. (Two unrelated failures remain: `env: get PATH`, `ip: ipv4_format` — environment/formatting, not integer codegen.)

Closes #1198
