### PR TITLE
fix(x64): preserve win64 callee-saved RDI/RSI across calls (#1204)

### DIFF
--- a/src/lang/target/abi/win64.mach
+++ b/src/lang/target/abi/win64.mach
@@ -30,6 +30,7 @@ use std.allocator.Allocator;
 use intern: mach.lang.intern;
 use isa:    mach.lang.target.isa;
 use abi:    mach.lang.target.abi;
+use x64:    mach.lang.target.isa.x64;
 
 # canonical x86-64 register numbers (DWARF / encoding order) used by the win64
 # convention. these are the same physical-register ids the x86_64 ISA exposes;
@@ -702,5 +703,37 @@ test "win64: a non-x86_64 arch yields the unsupported sentinel" {
     if (!is_unsupported_slot(s)) { ret 1; }
     val r: abi.ParamSlot = classify_return(isa.ARCH_AARCH64, 8, 8, false, false);
     if (!is_unsupported_slot(r)) { ret 1; }
+    ret 0;
+}
+
+test "win64: the prologue's GP callee-saved set includes RDI/RSI (#1204)" {
+    # the x64 prologue/epilogue spill exactly `x64.callee_saved_gp_list` of the
+    # active ABI. under win64 that must include RDI and RSI: a caller may hold a
+    # value live across a call in either (both are callee-saved here, unlike SysV),
+    # so a callee that omits saving them corrupts it. this is the #1204 regression
+    # — drive the list from a vtable whose callee-saved file is win64's own.
+    var vt: abi.AbiVTable;
+    vt.callee_saved = callee_saved::*u8;
+
+    var list: [16]i32;
+    val n: i32 = x64.callee_saved_gp_list(?vt, ?list[0]);
+
+    # the seven saveable GP registers, in file order minus RSP/RBP (the frame
+    # discipline preserves those): RBX, RDI, RSI, R12, R13, R14, R15.
+    if (n != 7)              { ret 1; }
+    if (list[0] != REG_RBX)  { ret 1; }
+    if (list[1] != REG_RDI)  { ret 1; }
+    if (list[2] != REG_RSI)  { ret 1; }
+    if (list[3] != REG_R12)  { ret 1; }
+    if (list[6] != REG_R15)  { ret 1; }
+
+    # RSP and RBP are never in the spill list, and no vector register leaks in.
+    var i: i32 = 0;
+    for (i < n) {
+        if (list[i] == REG_RSP) { ret 1; }
+        if (list[i] == REG_RBP) { ret 1; }
+        if (isa.regid_class(list[i]) != isa.REG_CLASS_ID_GP) { ret 1; }
+        i = i + 1;
+    }
     ret 0;
 }

--- a/src/lang/target/isa/x64.mach
+++ b/src/lang/target/isa/x64.mach
@@ -29,6 +29,8 @@ use std.allocator.allocate;
 
 use intern: mach.lang.intern;
 use isa:    mach.lang.target.isa;
+use abi:    mach.lang.target.abi;
+use sysv:   mach.lang.target.abi.sysv;
 
 # general-purpose register ids. these are the canonical x86-64 GP register
 # numbers (matching the ModRM/REX encoding), used directly as `Operand.reg`
@@ -512,19 +514,63 @@ pub fun fp_reg_name(cid: i32) str {
     ret "???";
 }
 
-# count_callee_saved: number of callee-saved GP registers set in a clobber
-# mask. the SysV callee-saved GP set the back end may preserve is
-# {RBX, R12, R13, R14, R15} (RBP is handled by the frame pointer chain).
+# CALLEE_SAVED_GP_MAX: upper bound on the saveable GP callee-saved register list —
+# the whole GP file, so `callee_saved_gp_list`'s `out` buffer never overruns.
+pub val CALLEE_SAVED_GP_MAX: i32 = GP_COUNT;
+
+# callee_saved_gp_list: the ordered GP registers the prologue must spill, drawn
+# from the active ABI's callee-saved register file.
+#
+# reads the convention's callee-saved set through `abi.callee_saved` (SysV's
+# RBX/RBP/R12–R15, win64's wider RBX/RBP/RDI/RSI/RSP/R12–R15) and keeps only the
+# GP registers the frame must spill: RSP and RBP are excluded (the stack/frame
+# pointer chain preserves them) and the vector set is ignored. the result drives
+# the prologue stores, the epilogue reloads, and the callee-save frame sizing so
+# all three preserve exactly the registers the calling convention demands —
+# nothing about the SysV set is hard-coded here, so the win64 RSI/RDI registers
+# are saved when the allocator uses them. `out` must hold `CALLEE_SAVED_GP_MAX`.
 # ---
-# mask: bitmask of physical registers (bit N = register N)
-# ret:  count of callee-saved registers present in the mask
-fun count_callee_saved(mask: u32) i32 {
+# abi_vt: the active calling-convention vtable (its `callee_saved` file is read)
+# out:    caller-owned buffer of at least CALLEE_SAVED_GP_MAX register ids
+# ret:    the number of GP callee-saved register ids written
+pub fun callee_saved_gp_list(abi_vt: *abi.AbiVTable, out: *i32) i32 {
+    var file: [32]isa.Register;
+    val fill: sysv.RegFileFn = abi_vt.callee_saved::sysv.RegFileFn;
+    val total: i32 = fill(?file[0]);
+
     var n: i32 = 0;
-    if ((mask & (1 << RBX::u32)) != 0) { n = n + 1; }
-    if ((mask & (1 << R12::u32)) != 0) { n = n + 1; }
-    if ((mask & (1 << R13::u32)) != 0) { n = n + 1; }
-    if ((mask & (1 << R14::u32)) != 0) { n = n + 1; }
-    if ((mask & (1 << R15::u32)) != 0) { n = n + 1; }
+    var i: i32 = 0;
+    for (i < total && i < 32) {
+        val id: i32 = file[i].id;
+        # GP-only (raw 0–15 ids, class tag 0); the stack/frame pointers are spilled
+        # by the push-rbp / rsp-rbp frame discipline, never into a home slot.
+        if (isa.regid_class(id) == isa.REG_CLASS_ID_GP &&
+            id >= 0 && id < GP_COUNT &&
+            id != STACK_REG && id != FRAME_REG) {
+            out[n] = id;
+            n = n + 1;
+        }
+        i = i + 1;
+    }
+    ret n;
+}
+
+# count_callee_saved: number of callee-saved GP registers the `mask` selects from
+# the active ABI's saveable set (`callee_saved_gp_list`). used to size the
+# callee-save home area in the prologue. driven by the ABI, never a hard-coded set.
+# ---
+# abi_vt: the active calling-convention vtable
+# mask:   bitmask of physical registers (bit N = register N)
+# ret:    count of callee-saved registers present in the mask
+fun count_callee_saved(abi_vt: *abi.AbiVTable, mask: u32) i32 {
+    var list: [16]i32;
+    val ln: i32 = callee_saved_gp_list(abi_vt, ?list[0]);
+    var n: i32 = 0;
+    var i: i32 = 0;
+    for (i < ln) {
+        if ((mask & (1::u32 << list[i]::u32)) != 0) { n = n + 1; }
+        i = i + 1;
+    }
     ret n;
 }
 
@@ -568,14 +614,15 @@ fun emit_frame_load(buf: *isa.InstBuf, reg: i32, base: i32, disp: i32) {
 #
 # pushes RBP, establishes the frame pointer (`mov rbp, rsp`), reserves the
 # frame and callee-saved spill space rounded up to 16-byte alignment, then
-# stores each preserved callee-saved register (RBX, R12–R15) into a
-# frame-pointer-relative home slot below the locals.
+# stores each preserved callee-saved register (the ABI's saveable GP set —
+# `callee_saved_gp_list`) into a frame-pointer-relative home slot below the locals.
 # ---
 # ctx:         ISA backend context (unused; accepted for call-site uniformity)
+# abi_vt:      active calling-convention vtable; supplies the callee-saved set
 # buf:         instruction buffer to append the prologue into
 # frame_size:  size of the local frame in bytes
 # callee_mask: bitmask of callee-saved registers to preserve
-pub fun emit_prologue(ctx: ptr, buf: *isa.InstBuf, frame_size: usize, callee_mask: u32) {
+pub fun emit_prologue(ctx: ptr, abi_vt: *abi.AbiVTable, buf: *isa.InstBuf, frame_size: usize, callee_mask: u32) {
     var push_rbp: isa.Inst;
     zero_inst(?push_rbp);
     push_rbp.opcode = PUSH;
@@ -592,7 +639,7 @@ pub fun emit_prologue(ctx: ptr, buf: *isa.InstBuf, frame_size: usize, callee_mas
     mov_rbp.flags  = FLAG_REX_W;
     isa.buf_append(buf, mov_rbp);
 
-    val callee_space: usize = count_callee_saved(callee_mask)::usize * 8;
+    val callee_space: usize = count_callee_saved(abi_vt, callee_mask)::usize * 8;
     var total: usize = frame_size + callee_space;
     if (total > 0 && (total & 15) != 0) { total = (total + 15) & ~15::usize; }
     if (total > 0) {
@@ -606,12 +653,17 @@ pub fun emit_prologue(ctx: ptr, buf: *isa.InstBuf, frame_size: usize, callee_mas
         isa.buf_append(buf, sub_rsp);
     }
 
+    var list: [16]i32;
+    val ln: i32 = callee_saved_gp_list(abi_vt, ?list[0]);
     var coff: i32 = frame_size::i32 + 8;
-    if ((callee_mask & (1 << RBX::u32)) != 0) { emit_frame_store(buf, RBX, FRAME_REG, -coff); coff = coff + 8; }
-    if ((callee_mask & (1 << R12::u32)) != 0) { emit_frame_store(buf, R12, FRAME_REG, -coff); coff = coff + 8; }
-    if ((callee_mask & (1 << R13::u32)) != 0) { emit_frame_store(buf, R13, FRAME_REG, -coff); coff = coff + 8; }
-    if ((callee_mask & (1 << R14::u32)) != 0) { emit_frame_store(buf, R14, FRAME_REG, -coff); coff = coff + 8; }
-    if ((callee_mask & (1 << R15::u32)) != 0) { emit_frame_store(buf, R15, FRAME_REG, -coff); coff = coff + 8; }
+    var i: i32 = 0;
+    for (i < ln) {
+        if ((callee_mask & (1::u32 << list[i]::u32)) != 0) {
+            emit_frame_store(buf, list[i], FRAME_REG, -coff);
+            coff = coff + 8;
+        }
+        i = i + 1;
+    }
 }
 
 # emit_epilogue: emit the standard x86-64 function epilogue.
@@ -621,16 +673,22 @@ pub fun emit_prologue(ctx: ptr, buf: *isa.InstBuf, frame_size: usize, callee_mas
 # `ret` after this sequence.
 # ---
 # ctx:         ISA backend context (unused; accepted for call-site uniformity)
+# abi_vt:      active calling-convention vtable; supplies the callee-saved set
 # buf:         instruction buffer to append the epilogue into
 # frame_size:  size of the local frame in bytes (matching the prologue)
 # callee_mask: bitmask of callee-saved registers that were preserved
-pub fun emit_epilogue(ctx: ptr, buf: *isa.InstBuf, frame_size: usize, callee_mask: u32) {
+pub fun emit_epilogue(ctx: ptr, abi_vt: *abi.AbiVTable, buf: *isa.InstBuf, frame_size: usize, callee_mask: u32) {
+    var list: [16]i32;
+    val ln: i32 = callee_saved_gp_list(abi_vt, ?list[0]);
     var coff: i32 = frame_size::i32 + 8;
-    if ((callee_mask & (1 << RBX::u32)) != 0) { emit_frame_load(buf, RBX, FRAME_REG, -coff); coff = coff + 8; }
-    if ((callee_mask & (1 << R12::u32)) != 0) { emit_frame_load(buf, R12, FRAME_REG, -coff); coff = coff + 8; }
-    if ((callee_mask & (1 << R13::u32)) != 0) { emit_frame_load(buf, R13, FRAME_REG, -coff); coff = coff + 8; }
-    if ((callee_mask & (1 << R14::u32)) != 0) { emit_frame_load(buf, R14, FRAME_REG, -coff); coff = coff + 8; }
-    if ((callee_mask & (1 << R15::u32)) != 0) { emit_frame_load(buf, R15, FRAME_REG, -coff); coff = coff + 8; }
+    var i: i32 = 0;
+    for (i < ln) {
+        if ((callee_mask & (1::u32 << list[i]::u32)) != 0) {
+            emit_frame_load(buf, list[i], FRAME_REG, -coff);
+            coff = coff + 8;
+        }
+        i = i + 1;
+    }
 
     var mov_rsp: isa.Inst;
     zero_inst(?mov_rsp);

--- a/src/lang/target/isa/x64/encode.mach
+++ b/src/lang/target/isa/x64/encode.mach
@@ -56,6 +56,7 @@ use intern: mach.lang.intern;
 use isa:    mach.lang.target.isa;
 use x64:    mach.lang.target.isa.x64;
 use target: mach.lang.target.resolved;
+use abi:    mach.lang.target.abi;
 use of:     mach.lang.target.of;
 use mir:    mach.lang.be.codegen.mir;
 use enc:    mach.lang.be.codegen.encode;
@@ -2026,15 +2027,19 @@ pub fun encode_inst(mi: *isa.Inst, buf: *ByteBuf) i32 {
     ret 0;
 }
 
-# count_callee_saved: count how many callee-saved GPRs the mask selects (used to
-# size the callee-save spill area in the prologue).
-fun count_callee_saved(mask: u32) i32 {
+# count_callee_saved: count how many callee-saved GPRs the mask selects from the
+# active ABI's saveable set (`x64.callee_saved_gp_list`), used to size the
+# callee-save spill area in the prologue. ABI-driven, so win64's wider set
+# (RDI/RSI) is sized correctly, not just the SysV {RBX, R12–R15}.
+fun count_callee_saved(abi_vt: *abi.AbiVTable, mask: u32) i32 {
+    var list: [16]i32;
+    val ln: i32 = x64.callee_saved_gp_list(abi_vt, ?list[0]);
     var n: i32 = 0;
-    if ((mask & (1 << x64.RBX::u32)) != 0) { n = n + 1; }
-    if ((mask & (1 << x64.R12::u32)) != 0) { n = n + 1; }
-    if ((mask & (1 << x64.R13::u32)) != 0) { n = n + 1; }
-    if ((mask & (1 << x64.R14::u32)) != 0) { n = n + 1; }
-    if ((mask & (1 << x64.R15::u32)) != 0) { n = n + 1; }
+    var i: i32 = 0;
+    for (i < ln) {
+        if ((mask & (1::u32 << list[i]::u32)) != 0) { n = n + 1; }
+        i = i + 1;
+    }
     ret n;
 }
 
@@ -2049,8 +2054,8 @@ fun count_callee_saved(mask: u32) i32 {
 # the outgoing region as the bottommost slice puts its base exactly at the new
 # RSP, so a caller's `[rsp + off]` argument store lands in it, and keeping every
 # addend 16-aligned holds RSP 16-byte aligned at each call boundary.
-fun frame_total(frame_size: u32, callee_mask: u32, outgoing_size: u32) usize {
-    val callee_space: usize = count_callee_saved(callee_mask)::usize * 8;
+fun frame_total(abi_vt: *abi.AbiVTable, frame_size: u32, callee_mask: u32, outgoing_size: u32) usize {
+    val callee_space: usize = count_callee_saved(abi_vt, callee_mask)::usize * 8;
     var base: usize = frame_size::usize + callee_space;
     if (base > 0 && (base & 15) != 0) { base = (base + 15) & ~15::usize; }
     ret base + outgoing_size::usize;
@@ -2089,14 +2094,17 @@ fun emit_frame_load(st: *EncodeState, reg: i32, disp: i32) {
     emit_inst(st, ?mi);
 }
 
-# emit_prologue: encode the standard System V x86-64 function prologue into the
-# `.text` byte sink.
+# emit_prologue: encode the standard x86-64 function prologue into the `.text`
+# byte sink.
 #
 # pushes RBP, sets RBP = RSP, subtracts the 16-byte-aligned local frame plus
 # callee-save space plus the outgoing-argument region from RSP, and stores each
 # selected callee-saved register in the region just below the local slots
-# (`[rbp - (frame_size + 8*k)]`). the callee-save offsets are frame_size-relative
-# and so are unaffected by the outgoing region reserved below them.
+# (`[rbp - (frame_size + 8*k)]`). the registers saved are exactly the active ABI's
+# saveable GP set (`x64.callee_saved_gp_list`) the allocator used — under win64
+# this includes RDI/RSI, which a caller may legitimately hold a value in across
+# the call. the callee-save offsets are frame_size-relative and so are unaffected
+# by the outgoing region reserved below them.
 # ---
 # st:            encoder state whose byte sink the prologue bytes are appended to
 # frame_size:    size of the local frame in bytes (locals + va-save; pre callee-save)
@@ -2120,7 +2128,7 @@ fun emit_prologue(st: *EncodeState, frame_size: u32, callee_mask: u32, outgoing_
     mov_rbp.flags  = x64.FLAG_REX_W;
     emit_inst(st, ?mov_rbp);
 
-    val total: usize = frame_total(frame_size, callee_mask, outgoing_size);
+    val total: usize = frame_total(st.abi, frame_size, callee_mask, outgoing_size);
     if (total > 0) {
         var sub_rsp: isa.Inst;
         zero_inst(?sub_rsp);
@@ -2132,30 +2140,43 @@ fun emit_prologue(st: *EncodeState, frame_size: u32, callee_mask: u32, outgoing_
         emit_inst(st, ?sub_rsp);
     }
 
+    var list: [16]i32;
+    val ln: i32 = x64.callee_saved_gp_list(st.abi, ?list[0]);
     var coff: i32 = frame_size::i32 + 8;
-    if ((callee_mask & (1 << x64.RBX::u32)) != 0) { emit_frame_store(st, x64.RBX, -coff); coff = coff + 8; }
-    if ((callee_mask & (1 << x64.R12::u32)) != 0) { emit_frame_store(st, x64.R12, -coff); coff = coff + 8; }
-    if ((callee_mask & (1 << x64.R13::u32)) != 0) { emit_frame_store(st, x64.R13, -coff); coff = coff + 8; }
-    if ((callee_mask & (1 << x64.R14::u32)) != 0) { emit_frame_store(st, x64.R14, -coff); coff = coff + 8; }
-    if ((callee_mask & (1 << x64.R15::u32)) != 0) { emit_frame_store(st, x64.R15, -coff); coff = coff + 8; }
+    var i: i32 = 0;
+    for (i < ln) {
+        if ((callee_mask & (1::u32 << list[i]::u32)) != 0) {
+            emit_frame_store(st, list[i], -coff);
+            coff = coff + 8;
+        }
+        i = i + 1;
+    }
 }
 
-# emit_epilogue: encode the standard System V x86-64 function epilogue into the
-# `.text` byte sink, before a RET.
+# emit_epilogue: encode the standard x86-64 function epilogue into the `.text`
+# byte sink, before a RET.
 #
 # restores each selected callee-saved register, resets RSP = RBP, and pops RBP.
-# the RET itself is encoded from the MIR_RET instruction that follows.
+# the registers and their frame offsets mirror `emit_prologue` exactly (the same
+# forward `x64.callee_saved_gp_list` order at the same frame-size-relative slots),
+# so each is reloaded from the slot it was saved into. the RET itself is encoded
+# from the MIR_RET instruction that follows.
 # ---
 # st:          encoder state whose byte sink the epilogue bytes are appended to
 # frame_size:  size of the local frame in bytes (locals + va-save; pre callee-save)
 # callee_mask: bitmask of callee-saved GP registers regalloc assigned
 fun emit_epilogue(st: *EncodeState, frame_size: u32, callee_mask: u32) {
+    var list: [16]i32;
+    val ln: i32 = x64.callee_saved_gp_list(st.abi, ?list[0]);
     var coff: i32 = frame_size::i32 + 8;
-    if ((callee_mask & (1 << x64.RBX::u32)) != 0) { emit_frame_load(st, x64.RBX, -coff); coff = coff + 8; }
-    if ((callee_mask & (1 << x64.R12::u32)) != 0) { emit_frame_load(st, x64.R12, -coff); coff = coff + 8; }
-    if ((callee_mask & (1 << x64.R13::u32)) != 0) { emit_frame_load(st, x64.R13, -coff); coff = coff + 8; }
-    if ((callee_mask & (1 << x64.R14::u32)) != 0) { emit_frame_load(st, x64.R14, -coff); coff = coff + 8; }
-    if ((callee_mask & (1 << x64.R15::u32)) != 0) { emit_frame_load(st, x64.R15, -coff); coff = coff + 8; }
+    var i: i32 = 0;
+    for (i < ln) {
+        if ((callee_mask & (1::u32 << list[i]::u32)) != 0) {
+            emit_frame_load(st, list[i], -coff);
+            coff = coff + 8;
+        }
+        i = i + 1;
+    }
 
     var mov_rsp: isa.Inst;
     zero_inst(?mov_rsp);
@@ -2364,6 +2385,7 @@ rec EncodeState {
     rk_abs64:    intern.StrId;
     rk_addr32nb: intern.StrId;
     interner:    *intern.Interner;
+    abi:         *abi.AbiVTable;
 }
 
 # encode_x64: encode a fully-resolved MIR module into `.text` bytes, symbol
@@ -2406,6 +2428,7 @@ pub fun encode_x64(alloc: *Allocator, tgt: *target.Target, m: *mir.MirModule) Re
     st.rk_abs64    = reloc_kind_name(tgt, of.RK_ABS64);
     st.rk_addr32nb = reloc_kind_name(tgt, of.RK_ADDR32NB);
     st.interner    = m.interner;
+    st.abi         = tgt.abi;
 
     var fi: u32 = 0;
     for (fi < m.function_len) {

--- a/src/lang/target/isa/x64/printer.mach
+++ b/src/lang/target/isa/x64/printer.mach
@@ -43,6 +43,7 @@ use intern:  mach.lang.intern;
 use isa:     mach.lang.target.isa;
 use x64:     mach.lang.target.isa.x64;
 use target:  mach.lang.target.resolved;
+use abi:     mach.lang.target.abi;
 use mir:     mach.lang.be.codegen.mir;
 
 # print_asm_x64: format a fully-resolved MIR module as Intel-syntax assembly text.
@@ -65,7 +66,7 @@ pub fun print_asm_x64(tgt: *target.Target, m: *mir.MirModule, out: *writer.Write
 
     var fi: u32 = 0;
     for (fi < m.function_len) {
-        val rf: Result[bool, str] = print_function(out, m, ?m.functions[fi]);
+        val rf: Result[bool, str] = print_function(tgt.abi, out, m, ?m.functions[fi]);
         if (is_err[bool, str](rf)) { ret rf; }
         fi = fi + 1;
     }
@@ -76,11 +77,12 @@ pub fun print_asm_x64(tgt: *target.Target, m: *mir.MirModule, out: *writer.Write
 # every block (each preceded by a `.<id>:` local label), and epilogue. a body-less
 # (extern) function emits nothing.
 # ---
-# out: destination writer
-# m:   the owning module (its interner resolves the function / symbol names)
-# f:   the function to render
-# ret: true on success, or the first write error
-fun print_function(out: *writer.Writer, m: *mir.MirModule, f: *mir.MirFunction) Result[bool, str] {
+# abi_vt: active calling-convention vtable; sizes the callee-saved reservation
+# out:    destination writer
+# m:      the owning module (its interner resolves the function / symbol names)
+# f:      the function to render
+# ret:    true on success, or the first write error
+fun print_function(abi_vt: *abi.AbiVTable, out: *writer.Writer, m: *mir.MirModule, f: *mir.MirFunction) Result[bool, str] {
     if (f.block_count == 0) { ret ok[bool, str](true); }
 
     val r1: Result[bool, str] = ws(out, "# ");
@@ -92,7 +94,7 @@ fun print_function(out: *writer.Writer, m: *mir.MirModule, f: *mir.MirFunction) 
 
     val naked: bool = function_is_naked(f);
     if (!naked) {
-        val rp: Result[bool, str] = print_prologue(out, f);
+        val rp: Result[bool, str] = print_prologue(abi_vt, out, f);
         if (is_err[bool, str](rp)) { ret rp; }
     }
 
@@ -128,13 +130,13 @@ fun print_function(out: *writer.Writer, m: *mir.MirModule, f: *mir.MirFunction) 
 # the frame shape is visible without re-deriving it. mirrors `x64.emit_prologue`:
 # the frame-pointer setup, the rounded stack reservation, and each preserved
 # callee-saved register's home store.
-fun print_prologue(out: *writer.Writer, f: *mir.MirFunction) Result[bool, str] {
+fun print_prologue(abi_vt: *abi.AbiVTable, out: *writer.Writer, f: *mir.MirFunction) Result[bool, str] {
     val r1: Result[bool, str] = ws(out, "  push  rbp                  # prologue\n");
     if (is_err[bool, str](r1)) { ret r1; }
     val r2: Result[bool, str] = ws(out, "  mov   rbp, rsp\n");
     if (is_err[bool, str](r2)) { ret r2; }
 
-    val total: usize = prologue_reserve(f);
+    val total: usize = prologue_reserve(abi_vt, f);
     if (total > 0) {
         val r3: Result[bool, str] = ws(out, "  sub   rsp, ");
         if (is_err[bool, str](r3)) { ret r3; }
@@ -156,22 +158,25 @@ fun print_epilogue(out: *writer.Writer, f: *mir.MirFunction) Result[bool, str] {
 # prologue_reserve: the rounded stack-reservation byte count the prologue subtracts
 # from RSP — the local frame plus the callee-saved home area, rounded up to the
 # 16-byte ABI alignment. mirrors the size `x64.emit_prologue` computes.
-fun prologue_reserve(f: *mir.MirFunction) usize {
-    val callee_space: usize = count_callee_saved(f.callee_mask)::usize * 8;
+fun prologue_reserve(abi_vt: *abi.AbiVTable, f: *mir.MirFunction) usize {
+    val callee_space: usize = count_callee_saved(abi_vt, f.callee_mask)::usize * 8;
     var total: usize = f.frame.size::usize + callee_space;
     if (total > 0 && (total & 15) != 0) { total = (total + 15) & ~15::usize; }
     ret total;
 }
 
-# count_callee_saved: number of callee-saved GP registers set in `mask`. the SysV
-# callee-saved GP set the back end preserves is {RBX, R12, R13, R14, R15}.
-fun count_callee_saved(mask: u32) i32 {
+# count_callee_saved: number of callee-saved GP registers the `mask` selects from
+# the active ABI's saveable set (`x64.callee_saved_gp_list`). ABI-driven, so it
+# matches the encoder's win64 set (RDI/RSI), not just the SysV {RBX, R12–R15}.
+fun count_callee_saved(abi_vt: *abi.AbiVTable, mask: u32) i32 {
+    var list: [16]i32;
+    val ln: i32 = x64.callee_saved_gp_list(abi_vt, ?list[0]);
     var n: i32 = 0;
-    if ((mask & (1 << x64.RBX::u32)) != 0) { n = n + 1; }
-    if ((mask & (1 << x64.R12::u32)) != 0) { n = n + 1; }
-    if ((mask & (1 << x64.R13::u32)) != 0) { n = n + 1; }
-    if ((mask & (1 << x64.R14::u32)) != 0) { n = n + 1; }
-    if ((mask & (1 << x64.R15::u32)) != 0) { n = n + 1; }
+    var i: i32 = 0;
+    for (i < ln) {
+        if ((mask & (1::u32 << list[i]::u32)) != 0) { n = n + 1; }
+        i = i + 1;
+    }
     ret n;
 }
 


### PR DESCRIPTION
Closes #1204

## Problem
On the win64 target a value held live across a call in **RDI or RSI** was corrupted whenever the called function used that register as a local. The x86-64 prologue/epilogue and callee-save frame sizing hard-coded the **SysV** callee-saved GP set `{RBX, R12–R15}`, so a callee never saved RDI/RSI. Under win64 those registers *are* callee-saved, and register allocation correctly placed cross-call values in them — but frame emission then failed to preserve them in the callee.

Repro (build for `x86_64-windows`, run under wine): the value `b`, held in RSI across a 7-argument `add7` call, came back wrong — exit `12` instead of `42`. SysV/linux was always correct.

## Fix
Make the callee-saved register set **ABI-driven** instead of a hard-coded SysV constant:

- New `x64.callee_saved_gp_list(abi_vt, out)` reads the active ABI's callee-saved register file and returns the ordered GP registers the frame must spill, excluding RSP/RBP (preserved by the frame-pointer discipline) and the vector set.
- The encoder's `count_callee_saved` / `frame_total` / `emit_prologue` / `emit_epilogue` now source the saved set from this list via the ABI vtable carried on `EncodeState`. The asm printer and the (currently unused) `x64.mach` InstBuf prologue/epilogue are routed through the same single source of truth.

Under SysV the list is exactly `{RBX, R12–R15}` in the same order, so output is byte-identical; under win64 it additionally includes RDI/RSI.

## Verification
- **wine repro exits 42** (a/b/c all correct); a broader 5-value / 5–9-arg stress case also passes. Disassembly confirms `add7` now saves/restores RDI/RSI in its prologue/epilogue.
- **SysV/linux unaffected:** the linux repro binary is byte-identical built by the released seed vs. the fixed compiler; the **byte-identical self-host fixpoint holds** (seed→a→b→c, `cmp b c` identical); `mach test .` corpus passes (226, including the new regression test).
