### PR TITLE
fix(lower): fold a constant cast in a global initialiser

### DIFF
--- a/src/lang/me/lower/decl.mach
+++ b/src/lang/me/lower/decl.mach
@@ -443,10 +443,10 @@ fun terminate_orphan_blocks(ctx: *lower.LowerContext) Result[bool, str] {
     ret ok[bool, str](true);
 }
 
-# lowers a module-level `val` / `var` into an IR `Global`. a comptime-
-# evaluable initialiser becomes a constant `Value`; a non-comptime
-# initialiser is emitted as logic into the module's lazily created init
-# function, with the global holding a zero placeholder until then.
+# lowers a module-level `val` / `var` into an IR `Global`. the initialiser is
+# folded to a constant `Value` by `fold_global_init`; a global with no
+# initialiser holds a zero placeholder. a present-but-non-constant initialiser
+# is a hard error — there is no runtime init-synthesis pass to fill it later.
 # ---
 # ctx:    the context
 # did:    the binding's DeclId
@@ -468,55 +468,9 @@ pub fun lower_global(ctx: *lower.LowerContext, did: aid.DeclId, d: *adecl.Decl, 
 
     var init_val: value.Value = value.const_int(0, gty);
     if (d.data.bind.init != aid.EXPR_NIL) {
-        # a struct / array / `str`-into-pointer initializer is a compile-time
-        # constant aggregate the frontend `comptime.eval` cannot fold to a
-        # scalar: its bytes (and the relocations for its pointer leaves) are laid
-        # out here and emitted as initialized data, never a zeroed .bss slot.
-        # tried before the scalar path so a `val X: str = "..."` becomes a real
-        # pointer-with-relocation instead of the bytes inline.
-        val agg: Result[Option[value.Value], str] = constagg.try_const_aggregate(ctx, d.data.bind.init, gty);
-        if (is_err[Option[value.Value], str](agg)) { ret err[bool, str](unwrap_err[Option[value.Value], str](agg)); }
-        val agg_opt: Option[value.Value] = unwrap_ok[Option[value.Value], str](agg);
-
-        if (is_some[value.Value](agg_opt)) {
-            init_val = unwrap[value.Value](agg_opt);
-        } or {
-            # the aggregate folder did not apply; try the scalar comptime fold.
-            # only evaluated here (not unconditionally above) so a folded aggregate
-            # never pays for a wasted comptime.eval pass.
-            val cv: Option[comptime.CTValue] = try_comptime(ctx, d.data.bind.init);
-            if (is_some[comptime.CTValue](cv)) {
-                val vr: Result[value.Value, str] = expr.const_value_of(ctx, d.data.bind.init, unwrap[comptime.CTValue](cv));
-                if (is_err[value.Value, str](vr)) { ret err[bool, str](unwrap_err[value.Value, str](vr)); }
-                init_val = unwrap_ok[value.Value, str](vr);
-            } or {
-                # a type-introspection intrinsic ($size_of/$align_of/$offset_of) is a
-                # comptime constant the frontend `comptime.eval` cannot fold — record
-                # layout is backend-owned. fold it here via the same path function
-                # bodies use, so `val X = $size_of(T)` becomes a real .rodata constant
-                # instead of a zero placeholder the read-only global can never receive.
-                val ie_opt: Option[*aexpr.Expr] = ast.get_expr(ctx.a, d.data.bind.init);
-                if (is_some[*aexpr.Expr](ie_opt)) {
-                    val ie: *aexpr.Expr = unwrap[*aexpr.Expr](ie_opt);
-                    if (ie.kind == aexpr.EXPR_KIND_CALL) {
-                        val intr: Option[Result[value.Value, str]] =
-                            expr.try_lower_comptime_intrinsic(ctx, d.data.bind.init, ie);
-                        if (is_some[Result[value.Value, str]](intr)) {
-                            val ir2: Result[value.Value, str] = unwrap[Result[value.Value, str]](intr);
-                            if (is_err[value.Value, str](ir2)) { ret err[bool, str](unwrap_err[value.Value, str](ir2)); }
-                            init_val = unwrap_ok[value.Value, str](ir2);
-                        }
-                    }
-                }
-            }
-        }
-        # an initialiser that none of the paths above could fold stays a zero
-        # placeholder and lands in `.bss`. there is no runtime init-synthesis pass
-        # to fill it later (`ir.Module.init_fn` is never populated), so any
-        # initialiser that must carry data — a struct / array / `str` aggregate,
-        # or a const-address pointer (`?G`, a function name) — is deliberately
-        # routed through `constagg.try_const_aggregate` above to be emitted as
-        # initialised data instead of reaching this fall-through.
+        val fr: Result[value.Value, str] = fold_global_init(ctx, d.data.bind.init, gty);
+        if (is_err[value.Value, str](fr)) { ret err[bool, str](unwrap_err[value.Value, str](fr)); }
+        init_val = unwrap_ok[value.Value, str](fr);
     }
 
     var g: ir.Global;
@@ -531,6 +485,59 @@ pub fun lower_global(ctx: *lower.LowerContext, did: aid.DeclId, d: *adecl.Decl, 
     val ai: Result[u32, str] = append_global(ctx, g);
     if (is_err[u32, str](ai)) { ret err[bool, str](unwrap_err[u32, str](ai)); }
     ret ok[bool, str](true);
+}
+
+# folds a global initialiser to the constant `Value` the global is emitted
+# with. a global must be a constant expression: there is no runtime
+# init-synthesis pass (`ir.Module.init_fn` is never populated), so an
+# initialiser that no constant path can fold is a hard error rather than a
+# silent zero placeholder. the folders are tried in turn:
+#   1. an aggregate (struct / array / `str`-into-pointer) whose bytes and
+#      pointer relocations are laid out as initialised data; tried first so a
+#      `val X: str = "..."` becomes a pointer-with-relocation, not inline bytes.
+#   2. a scalar comptime constant the frontend `comptime.eval` folds.
+#   3. a `nil` pointer initialiser, materialised as the null constant.
+#   4. a constant scalar cast (`<const>::T`, including chains), folded with the
+#      same width / sign semantics `lower_cast` lowers.
+#   5. a type-introspection intrinsic (`$size_of` / `$align_of` / `$offset_of`)
+#      whose layout is backend-owned, folded via the path function bodies use.
+# ---
+# ctx: the context
+# eid: the initialiser expression
+# gty: the global's IR type
+# ret: the constant initialiser Value, or an error
+fun fold_global_init(ctx: *lower.LowerContext, eid: aid.ExprId, gty: ir_type.IrTypeId) Result[value.Value, str] {
+    val agg: Result[Option[value.Value], str] = constagg.try_const_aggregate(ctx, eid, gty);
+    if (is_err[Option[value.Value], str](agg)) { ret err[value.Value, str](unwrap_err[Option[value.Value], str](agg)); }
+    val agg_opt: Option[value.Value] = unwrap_ok[Option[value.Value], str](agg);
+    if (is_some[value.Value](agg_opt)) { ret ok[value.Value, str](unwrap[value.Value](agg_opt)); }
+
+    # the aggregate folder did not apply; try the scalar comptime fold. only
+    # evaluated here (not unconditionally above) so a folded aggregate never pays
+    # for a wasted comptime.eval pass.
+    val cv: Option[comptime.CTValue] = try_comptime(ctx, eid);
+    if (is_some[comptime.CTValue](cv)) {
+        ret expr.const_value_of(ctx, eid, unwrap[comptime.CTValue](cv));
+    }
+
+    val ie_opt: Option[*aexpr.Expr] = ast.get_expr(ctx.a, eid);
+    if (is_none[*aexpr.Expr](ie_opt)) { ret err[value.Value, str]("lower: global initialiser expression out of range"); }
+    val ie: *aexpr.Expr = unwrap[*aexpr.Expr](ie_opt);
+
+    # a `nil` pointer initialiser is a constant null. `comptime.eval` has no
+    # CTValue for nil and the aggregate folder routes it here, so materialise it
+    # as the null constant the global is emitted with.
+    if (ie.kind == aexpr.EXPR_KIND_LIT_NIL) { ret ok[value.Value, str](value.const_null(gty)); }
+
+    val cast: Option[Result[value.Value, str]] = expr.try_lower_comptime_cast(ctx, eid, ie);
+    if (is_some[Result[value.Value, str]](cast)) { ret unwrap[Result[value.Value, str]](cast); }
+
+    if (ie.kind == aexpr.EXPR_KIND_CALL) {
+        val intr: Option[Result[value.Value, str]] = expr.try_lower_comptime_intrinsic(ctx, eid, ie);
+        if (is_some[Result[value.Value, str]](intr)) { ret unwrap[Result[value.Value, str]](intr); }
+    }
+
+    ret err[value.Value, str]("lower: a global initialiser must be a constant expression");
 }
 
 # lowers a decl-scope `$if` chain: evaluates each arm's condition and

--- a/src/lang/me/lower/expr.mach
+++ b/src/lang/me/lower/expr.mach
@@ -764,6 +764,116 @@ pub fun try_lower_comptime_intrinsic(ctx: *lower.LowerContext, eid: aid.ExprId, 
     ret some[Result[value.Value, str]](ok[value.Value, str](value.const_int(n::u64, rt)));
 }
 
+# folds a constant scalar cast expression (`<const>::T`, including chains like
+# `(-11)::i32::u32`) to a constant Value at the cast's IR type. a cast of a
+# constant operand is itself a constant the frontend `comptime.eval` rejects
+# (it has no type resolution to model width/sign); this folds it here via the
+# same trunc/extend/convert semantics `lower_cast` emits, so a global
+# initialiser `val X: T = <const>::U` becomes a real constant instead of the
+# zero placeholder a read-only global can never receive. returns none when the
+# expression is not a cast or its operand is not a foldable scalar constant.
+pub fun try_lower_comptime_cast(ctx: *lower.LowerContext, eid: aid.ExprId, e: *aexpr.Expr) Option[Result[value.Value, str]] {
+    if (e.kind != aexpr.EXPR_KIND_CAST) { ret none[Result[value.Value, str]](); }
+    val folded: Option[Result[comptime.CTValue, str]] = fold_const_scalar(ctx, eid);
+    if (is_none[Result[comptime.CTValue, str]](folded)) { ret none[Result[value.Value, str]](); }
+    val cv_r: Result[comptime.CTValue, str] = unwrap[Result[comptime.CTValue, str]](folded);
+    if (is_err[comptime.CTValue, str](cv_r)) {
+        ret some[Result[value.Value, str]](err[value.Value, str](unwrap_err[comptime.CTValue, str](cv_r)));
+    }
+    ret some[Result[value.Value, str]](const_value_of(ctx, eid, unwrap_ok[comptime.CTValue, str](cv_r)));
+}
+
+# folds a constant scalar expression to its comptime value. a non-cast leaf is
+# delegated to `comptime.eval`; a cast recurses on its operand and applies the
+# same value-conversion `lower_cast` lowers (int trunc/extend by width and
+# signedness, int<->float convert, float trunc/extend, and `:~` reinterpret).
+# returns none when the expression is not a foldable scalar constant.
+fun fold_const_scalar(ctx: *lower.LowerContext, eid: aid.ExprId) Option[Result[comptime.CTValue, str]] {
+    val e_opt: Option[*aexpr.Expr] = ast.get_expr(ctx.a, eid);
+    if (is_none[*aexpr.Expr](e_opt)) { ret none[Result[comptime.CTValue, str]](); }
+    val e: *aexpr.Expr = unwrap[*aexpr.Expr](e_opt);
+
+    if (e.kind != aexpr.EXPR_KIND_CAST) {
+        val ev: Result[comptime.CTValue, str] =
+            comptime.eval(ctx.ctx, ctx.a, lower.module_source(ctx), eid, ?ctx.s.interner);
+        if (is_err[comptime.CTValue, str](ev)) { ret none[Result[comptime.CTValue, str]](); }
+        ret some[Result[comptime.CTValue, str]](ok[comptime.CTValue, str](unwrap_ok[comptime.CTValue, str](ev)));
+    }
+
+    val op_r: Option[Result[comptime.CTValue, str]] = fold_const_scalar(ctx, e.data.cast.value);
+    if (is_none[Result[comptime.CTValue, str]](op_r)) { ret none[Result[comptime.CTValue, str]](); }
+    val opv_r: Result[comptime.CTValue, str] = unwrap[Result[comptime.CTValue, str]](op_r);
+    if (is_err[comptime.CTValue, str](opv_r)) { ret some[Result[comptime.CTValue, str]](opv_r); }
+    val opv: comptime.CTValue = unwrap_ok[comptime.CTValue, str](opv_r);
+
+    val from_ty: ty.TypeId = lower.expr_type_of(ctx, e.data.cast.value);
+    val to_ty:   ty.TypeId = lower.type_resolved_of(ctx, e.data.cast.ty);
+    ret some[Result[comptime.CTValue, str]](convert_const_scalar(ctx, opv, from_ty, to_ty, e.data.cast.reinterpret));
+}
+
+# applies a `::` value conversion (or `:~` reinterpret) to a folded scalar
+# constant, matching `lower_cast`'s instruction selection: integer
+# truncate/sign-/zero-extend by the destination width, int<->float convert, and
+# float truncate/extend. the folded integer is held in an `i64` already
+# canonicalised to its source type's representation, so a conversion to an
+# integer target is exactly "take the low `to_bits` bits, then sign- or
+# zero-extend to 64 by the target's signedness".
+fun convert_const_scalar(
+    ctx:         *lower.LowerContext,
+    v:           comptime.CTValue,
+    from_ty:     ty.TypeId,
+    to_ty:       ty.TypeId,
+    reinterpret: bool
+) Result[comptime.CTValue, str] {
+    val from_float: bool = is_float_type(ctx, from_ty);
+    val to_float:   bool = is_float_type(ctx, to_ty);
+    val to_signed:  bool = is_signed_type(ctx, to_ty);
+    val to_bits:    u32  = scalar_bits(ctx, to_ty);
+
+    # `:~` reinterprets the raw bits; the value is sema-validated as equal size,
+    # so the comptime payload already carries those bits unchanged.
+    if (reinterpret) { ret ok[comptime.CTValue, str](v); }
+
+    if (from_float && to_float) { ret float_ct(v.data.f); }
+    if (from_float && !to_float) {
+        # float -> int truncates toward zero into the target representation.
+        ret int_ct(rerepresent_int(v.data.f::i64, to_bits, to_signed));
+    }
+    if (!from_float && to_float) {
+        # int -> float yields the integer's real value as an f64.
+        ret float_ct(v.data.i::f64);
+    }
+
+    ret int_ct(rerepresent_int(v.data.i, to_bits, to_signed));
+}
+
+# canonicalises an integer to a `to_bits`-wide target's representation in an
+# `i64`: takes the low `to_bits` bits then sign- or zero-extends to 64. a
+# `to_bits` of 0 (a non-scalar or pointer-width target) or >= 64 leaves the
+# value unchanged.
+fun rerepresent_int(x: i64, to_bits: u32, to_signed: bool) i64 {
+    if (to_bits == 0 || to_bits >= 64) { ret x; }
+    val shift: u64 = (64 - to_bits)::u64;
+    val masked: u64 = (x::u64 << shift) >> shift;
+    if (!to_signed) { ret masked::i64; }
+    # arithmetic right shift sign-extends from the target's high bit.
+    ret (masked::i64 << shift) >> shift;
+}
+
+fun int_ct(i: i64) Result[comptime.CTValue, str] {
+    var v: comptime.CTValue;
+    v.kind   = comptime.CT_KIND_INT;
+    v.data.i = i;
+    ret ok[comptime.CTValue, str](v);
+}
+
+fun float_ct(f: f64) Result[comptime.CTValue, str] {
+    var v: comptime.CTValue;
+    v.kind   = comptime.CT_KIND_FLOAT;
+    v.data.f = f;
+    ret ok[comptime.CTValue, str](v);
+}
+
 # lowers a variadic intrinsic call (`va_start`/`va_arg`/`va_end`) to its
 # dedicated IR opcode. the single value argument is the `*va_list` pointer; for
 # `va_arg` the call expression's lowered type is the fetched value's type. returns


### PR DESCRIPTION
Closes #1206.

## Problem

A module-level `val`/`var` initialised from a scalar cast was silently emitted as **0**:

```mach
val NEG: u32 = (-11)::i32::u32;  # should be 0xFFFFFFF5, was 0
```

`comptime.eval` rejects casts (it has no type resolution to model width/sign) and `lower_global` had no path for one, so the initialiser fell through to a zero placeholder — a silent miscompile on every target. It blocks the native Windows port (the std stdio handles `STD_OUTPUT_HANDLE = (-11)::i32::u32` etc. all became 0 → `GetStdHandle(0)` → all file I/O fails with `EBADF`).

## Fix

**1. Fold a constant cast at the lower layer.** `try_lower_comptime_cast` (in `me/lower/expr.mach`) recurses on the cast operand — delegating non-cast leaves to `comptime.eval`, recursing on chained casts — then applies the *same* conversion `lower_cast` lowers: integer truncate / sign- / zero-extend by destination width and signedness, int↔float convert, float trunc/ext, and `:~` reinterpret. The fold uses the identical type source (`lower.expr_type_of` on the operand) the runtime path uses, so a folded global matches the runtime cast **bit-for-bit**. Mirrors the existing `try_lower_comptime_intrinsic` precedent for `$size_of` etc.

**2. Remove the silent zero fallback.** A present global initialiser that no constant path can fold is now a hard error (*a global initialiser must be a constant expression*) — no defensive zero placeholder. `fold_global_init` collects the aggregate / comptime / `nil` / cast / intrinsic folders behind one entry point. A `nil` pointer initialiser folds to the null constant (it was previously a deliberate zero placeholder).

## Verification

- Repro `val NEG: u32 = (-11)::i32::u32` reads **245** (`& 0xFF`); exact-value parity confirmed with the runtime (local-variable) cast path across `(-1)::i32::u32`=0xFFFFFFFF, `(256)::i32::u8`=0, `(-11)::i32::u64`=0x…FFF5, `(200)::i32::i8`=-56, `(-1)::i64::u16`=0xFFFF.
- The std stdio handle globals fold to their correct unsigned values.
- **Byte-identical Linux self-host fixpoint holds** (seed→a→b→c, `cmp b c` identical) and `mach test .` corpus passes (226).

## Surfaced latent bug

Removing the silent fallback surfaced **`THREAD_CLONE_FLAGS`** in std — a `|` chain over module-qualified `shared.CLONE_*` member paths (not comptime-evaluable) that silently lowered to **0**, breaking Linux `thread_spawn` (clone(2) with no flags). Fixed in **octalide/mach-std#193** (folds to 0x50F00, verified). This PR's submodule bump pulls in that fix; re-point to the merged std dev tip once #193 lands.
