### PR TITLE
refactor: name-based target composition (name-keyed registries, drop canonical_*)

### DIFF
--- a/src/lang/be/codegen/regalloc.mach
+++ b/src/lang/be/codegen/regalloc.mach
@@ -64,7 +64,6 @@ use mach.lang.intern;
 use mach.lang.target;
 use mach.lang.target.abi;
 use mach.lang.target.isa;
-use mach.lang.target.os;
 
 # index of the general-purpose register bank in `reg_classes`.
 # `lower_ir` assigns this class to every non-float vreg.
@@ -2740,7 +2739,7 @@ test "mach.lang.be.codegen.regalloc.seed_reserved:aarch64_reserved_and_fp_bank" 
     val rr: R.Result[bool, str] = target.register_all(?reg);
     if (R.is_err[bool, str](rr)) { ret 1; }
 
-    val ts: R.Result[target.Target, str] = target.select(?reg, os.OS_LINUX, isa.ARCH_AARCH64);
+    val ts: R.Result[target.Target, str] = target.select(?reg, "aarch64", "linux", "aapcs64");
     if (R.is_err[target.Target, str](ts)) { ret 1; }
     var t: target.Target = R.unwrap_ok[target.Target, str](ts);
 

--- a/src/lang/driver.mach
+++ b/src/lang/driver.mach
@@ -614,13 +614,17 @@ fun populate_union_tuples(p: *Project, m: *manifest.Manifest) R.Result[bool, str
         val td: *manifest.TargetDef = ?m.targets[k];
         val os_opt:  O.Option[str] = intern.lookup(?p.s.interner, td.os);
         val isa_opt: O.Option[str] = intern.lookup(?p.s.interner, td.isa);
-        if (O.is_none[str](os_opt) || O.is_none[str](isa_opt)) {
+        val abi_opt: O.Option[str] = intern.lookup(?p.s.interner, td.abi);
+        if (O.is_none[str](os_opt) || O.is_none[str](isa_opt) || O.is_none[str](abi_opt)) {
             A.deallocate[TargetTuple](p.s.alloc, tuples, n::usize);
             ret R.err[bool, str]("internal: union target tuple name not interned");
         }
-        val os_id:   u32 = os.os_id_for(O.unwrap[str](os_opt));
-        val arch_id: u32 = isa.arch_id_for(O.unwrap[str](isa_opt));
-        val sr: R.Result[target.Target, str] = target.select(?p.s.registry, os_id, arch_id);
+        val os_name:  str = O.unwrap[str](os_opt);
+        val isa_name: str = O.unwrap[str](isa_opt);
+        val abi_name: str = O.unwrap[str](abi_opt);
+        val os_id:   u32 = os.os_id_for(os_name);
+        val arch_id: u32 = isa.arch_id_for(isa_name);
+        val sr: R.Result[target.Target, str] = target.select(?p.s.registry, isa_name, os_name, abi_name);
         if (R.is_err[target.Target, str](sr)) {
             A.deallocate[TargetTuple](p.s.alloc, tuples, n::usize);
             ret R.err[bool, str](R.unwrap_err[target.Target, str](sr));
@@ -1654,11 +1658,11 @@ fun intern_or(i: *intern.Interner, text: str, default: str) R.Result[intern.StrI
 }
 
 # resolve the selected TargetEntry into a composed
-# target.Target. maps the entry's os/isa names to canonical ids, calls
-# target.select to compose the isa/abi/os/of vtables, and stores the
-# result on Project. an unknown os/arch pair has no canonical mapping and
-# fails the build through target.select. pointer width is not stored here -
-# consumers read it through p.target.arch.
+# target.Target. passes the entry's isa/os/abi names to target.select, which
+# composes the isa/abi/os/of vtables by name and stores the result on Project. an
+# unknown os/isa name is reported with a precise diagnostic before select runs; an
+# unregistered substrate fails through target.select. pointer width is not stored
+# here - consumers read it through p.target.arch.
 fun select_target(p: *Project, t: *TargetEntry) R.Result[bool, str] {
     val os_opt: O.Option[str] = intern.lookup(?p.s.interner, t.os_name);
     if (O.is_none[str](os_opt)) { ret R.err[bool, str]("target os name not interned"); }
@@ -1668,17 +1672,18 @@ fun select_target(p: *Project, t: *TargetEntry) R.Result[bool, str] {
     if (O.is_none[str](isa_opt)) { ret R.err[bool, str]("target isa name not interned"); }
     val isa_name: str = O.unwrap[str](isa_opt);
 
-    val os_id:   u32 = os.os_id_for(os_name);
-    val arch_id: u32 = isa.arch_id_for(isa_name);
+    val abi_opt: O.Option[str] = intern.lookup(?p.s.interner, t.abi_name);
+    if (O.is_none[str](abi_opt)) { ret R.err[bool, str]("target abi name not interned"); }
+    val abi_name: str = O.unwrap[str](abi_opt);
 
-    if (os_id == os.OS_UNKNOWN) {
+    if (os.os_id_for(os_name) == os.OS_UNKNOWN) {
         ret R.err[bool, str](diag_join_named(p.s, "unknown target os name '", t.os_name, "' (expected: linux, darwin, windows)", "unknown target os name"));
     }
-    if (arch_id == isa.ARCH_UNKNOWN) {
+    if (isa.arch_id_for(isa_name) == isa.ARCH_UNKNOWN) {
         ret R.err[bool, str](diag_join_named(p.s, "unknown target isa name '", t.isa_name, "' (expected: x86_64, aarch64)", "unknown target isa name"));
     }
 
-    val tr: R.Result[target.Target, str] = target.select(?p.s.registry, os_id, arch_id);
+    val tr: R.Result[target.Target, str] = target.select(?p.s.registry, isa_name, os_name, abi_name);
     if (R.is_err[target.Target, str](tr)) { ret R.err[bool, str](R.unwrap_err[target.Target, str](tr)); }
     p.target = R.unwrap_ok[target.Target, str](tr);
 

--- a/src/lang/target.mach
+++ b/src/lang/target.mach
@@ -2,13 +2,16 @@
 #
 # A `Target` bundles the four orthogonal target dimensions - instruction set,
 # ABI, operating system, and object format - as borrowed vtable pointers plus
-# their comptime identity ids. The middle end and back end dispatch through the
-# vtables and never branch on the ids.
+# their derived comptime identity ids. The middle end and back end dispatch
+# through the vtables and never branch on the ids.
 #
 # A `TargetRegistry` bundles the four per-dimension registries; the session (or
 # driver) owns one, `register_all` installs every implementation into it, and
-# `select` composes a Target from it, choosing the canonical ABI and object
-# format for the requested (os, arch) pair.
+# `select` composes a Target from it by name: it looks up the isa, os, and abi
+# vtables under the names the manifest spells and resolves the object format
+# through the chosen os's `default_of`. The legacy os/arch/abi/of ids are derived
+# from the resolved vtables' `.id` fields and kept on the Target, so the id
+# readers and the comptime tag space are unaffected by the name-based composition.
 
 use std.types.bool.bool;
 use std.types.bool.true;
@@ -81,55 +84,20 @@ pub fun host_pointer_width() u32 {
     ret ($mach.build.pointer_width)::u32;
 }
 
-# the canonical abi id for the host os/arch pair.
+# the abi id of the host this compiler binary was built for.
 #
-# lets the editor's neutral comptime context resolve `$mach.build.abi` against
-# the running compiler's own convention rather than a placeholder.
+# folds the `$mach.build.abi` comptime read into the matching `abi.ABI_*` id, so
+# the editor's neutral comptime context resolves `$mach.build.abi` against the
+# running compiler's own convention rather than a placeholder. parallels
+# `host_os_id` / `host_arch_id`: a pure host fact read from the build, not an
+# (os, arch) -> abi composition switch.
 # ---
-# ret: the canonical abi id (one of abi.ABI_*) for the host
+# ret: the host abi id, in the same space as abi.ABI_*
 pub fun host_abi_id() u32 {
-    ret canonical_abi(host_os_id(), host_arch_id());
-}
-
-# the canonical abi id for an (operating system, architecture) pair.
-#
-# the convention depends on both dimensions: x86-64 uses SysV on Linux/Darwin
-# and Win64 on Windows, while AArch64 uses AAPCS64 everywhere (the Apple and
-# Microsoft variants reduce to AAPCS64 for selection). a pair with no canonical
-# mapping yields `abi.ABI_UNKNOWN`, which makes `select` fail loudly rather than
-# composing the wrong convention - so `select(OS_LINUX, ARCH_AARCH64)` never
-# silently builds the x86-64 SysV vtable.
-# ---
-# os_id:   operating-system id (one of os.OS_*)
-# arch_id: architecture id (one of isa.ARCH_*)
-# ret:     the canonical abi id, or abi.ABI_UNKNOWN if the pair is unsupported
-fun canonical_abi(os_id: u32, arch_id: u32) u32 {
-    if (arch_id == isa.ARCH_X86_64) {
-        if (os_id == os.OS_LINUX)   { ret abi.ABI_SYSV; }
-        if (os_id == os.OS_DARWIN)  { ret abi.ABI_SYSV; }
-        if (os_id == os.OS_WINDOWS) { ret abi.ABI_WIN64; }
-        ret abi.ABI_UNKNOWN;
-    }
-    if (arch_id == isa.ARCH_AARCH64) {
-        if (os_id == os.OS_LINUX)   { ret abi.ABI_AAPCS64; }
-        if (os_id == os.OS_DARWIN)  { ret abi.ABI_AAPCS64; }
-        if (os_id == os.OS_WINDOWS) { ret abi.ABI_AAPCS64; }
-        ret abi.ABI_UNKNOWN;
-    }
-    ret abi.ABI_UNKNOWN;
-}
-
-# the canonical object-format id for an operating system.
-#
-# ELF on Linux, Mach-O on Darwin, COFF on Windows. independent of architecture.
-# ---
-# os_id: operating-system id (one of os.OS_*)
-# ret:   the canonical object-format id, or of.OF_UNKNOWN if the os is unknown
-fun canonical_of(os_id: u32) u32 {
-    if (os_id == os.OS_LINUX)   { ret of.OF_ELF; }
-    if (os_id == os.OS_DARWIN)  { ret of.OF_MACHO; }
-    if (os_id == os.OS_WINDOWS) { ret of.OF_COFF; }
-    ret of.OF_UNKNOWN;
+    $if ($mach.build.abi == $mach.abi.sysv)    { ret abi.ABI_SYSV; }
+    $or ($mach.build.abi == $mach.abi.win64)   { ret abi.ABI_WIN64; }
+    $or ($mach.build.abi == $mach.abi.aapcs64) { ret abi.ABI_AAPCS64; }
+    $or                                        { ret abi.ABI_UNKNOWN; }
 }
 
 # the session/driver-owned bundle of the four per-dimension registries.
@@ -206,53 +174,51 @@ pub fun register_all(reg: *TargetRegistry) R.Result[bool, str] {
     ret R.ok[bool, str](true);
 }
 
-# compose a Target for an (os, arch) pair from `reg`.
+# compose a Target from `reg` by name.
 #
-# resolves the canonical ABI for the (os, arch) pair and the object format for
-# the operating system, then looks up all four vtables from `reg`. allocates
-# nothing - every vtable pointer is borrowed. fails if the pair has no canonical
-# mapping or if any required implementation is not registered in `reg`.
+# looks up the isa, os, and abi vtables under their names, resolves the object
+# format through the chosen os's `default_of` name, and derives the legacy
+# os/arch/abi/of ids from the resolved vtables' `.id` fields. allocates nothing -
+# every vtable pointer is borrowed. fails if any required implementation is not
+# registered in `reg` under the requested name.
 # ---
-# reg:     the target registry populated by register_all
-# os_id:   operating-system id (one of os.OS_*)
-# arch_id: architecture id (one of isa.ARCH_*)
-# ret:     the composed Target, or an error describing the missing piece
-pub fun select(reg: *TargetRegistry, os_id: u32, arch_id: u32) R.Result[resolved.Target, str] {
-    val abi_id: u32 = canonical_abi(os_id, arch_id);
-    if (abi_id == abi.ABI_UNKNOWN) {
-        ret R.err[resolved.Target, str]("unsupported (operating system, architecture) pair");
-    }
-    val of_id: u32 = canonical_of(os_id);
-    if (of_id == of.OF_UNKNOWN) {
-        ret R.err[resolved.Target, str]("unsupported operating system");
-    }
-
-    val opt_os_vt: O.Option[*os.OsVTable] = os.lookup(?reg.os, os_id);
+# reg:      the target registry populated by register_all
+# isa_name: instruction-set name (e.g. "x86_64", "aarch64")
+# os_name:  operating-system name (e.g. "linux", "windows")
+# abi_name: calling-convention name (e.g. "sysv64", "win64", "aapcs64")
+# ret:      the composed Target, or an error describing the missing piece
+pub fun select(reg: *TargetRegistry, isa_name: str, os_name: str, abi_name: str) R.Result[resolved.Target, str] {
+    val opt_os_vt: O.Option[*os.OsVTable] = os.lookup(?reg.os, os_name);
     if (O.is_none[*os.OsVTable](opt_os_vt)) {
-        ret R.err[resolved.Target, str]("no os implementation registered");
+        ret R.err[resolved.Target, str]("no os implementation registered for the requested name");
     }
-    val opt_arch_vt: O.Option[*isa.IsaVTable] = isa.lookup(?reg.isa, arch_id);
+    val os_vt: *os.OsVTable = O.unwrap[*os.OsVTable](opt_os_vt);
+
+    val opt_arch_vt: O.Option[*isa.IsaVTable] = isa.lookup(?reg.isa, isa_name);
     if (O.is_none[*isa.IsaVTable](opt_arch_vt)) {
-        ret R.err[resolved.Target, str]("no isa implementation registered");
+        ret R.err[resolved.Target, str]("no isa implementation registered for the requested name");
     }
-    val opt_abi_vt: O.Option[*abi.AbiVTable] = abi.lookup(?reg.abi, abi_id);
+    val opt_abi_vt: O.Option[*abi.AbiVTable] = abi.lookup(?reg.abi, abi_name);
     if (O.is_none[*abi.AbiVTable](opt_abi_vt)) {
-        ret R.err[resolved.Target, str]("no abi implementation registered");
+        ret R.err[resolved.Target, str]("no abi implementation registered for the requested name");
     }
-    val opt_of_vt: O.Option[*of.OfVTable] = of.lookup(?reg.of, of_id);
+    val opt_of_vt: O.Option[*of.OfVTable] = of.lookup(?reg.of, os_vt.default_of);
     if (O.is_none[*of.OfVTable](opt_of_vt)) {
-        ret R.err[resolved.Target, str]("no object-format implementation registered");
+        ret R.err[resolved.Target, str]("no object-format implementation registered for the os default");
     }
 
     var t: resolved.Target;
-    t.os_id   = os_id;
-    t.arch_id = arch_id;
-    t.abi_id  = abi_id;
-    t.of_id   = of_id;
-    t.os      = O.unwrap[*os.OsVTable](opt_os_vt);
+    t.os      = os_vt;
     t.arch    = O.unwrap[*isa.IsaVTable](opt_arch_vt);
     t.abi     = O.unwrap[*abi.AbiVTable](opt_abi_vt);
     t.of      = O.unwrap[*of.OfVTable](opt_of_vt);
+
+    # derive the legacy identity ids from the resolved vtables; the ~89 id-readers
+    # and the comptime tag space keep reading these unchanged.
+    t.os_id   = t.os.id;
+    t.arch_id = t.arch.id;
+    t.abi_id  = t.abi.id;
+    t.of_id   = t.of.id;
 
     # assemble the machine model: copy the isa's model template by value, then
     # overlay the selected abi's stack scalars (these vary by convention - sysv vs
@@ -267,7 +233,7 @@ pub fun select(reg: *TargetRegistry, os_id: u32, arch_id: u32) R.Result[resolved
 }
 
 # enumeration helpers (registered_count / registered) must agree with the
-# id-keyed lookups after register_all, and report none past the count. the
+# name-keyed lookups after register_all, and report none past the count. the
 # `mach info` capability surface reads the registries through exactly this pair.
 test "mach.lang.target:registry_enumeration_agrees_with_lookup" {
     var reg: TargetRegistry = registry_init();
@@ -280,14 +246,14 @@ test "mach.lang.target:registry_enumeration_agrees_with_lookup" {
     if (abi.registered_count(?reg.abi) < 2) { ret 1; }
     if (of.registered_count(?reg.of)   < 3) { ret 1; }
 
-    # every enumerated isa slot is present and agrees with id-keyed lookup;
+    # every enumerated isa entry is present and agrees with name-keyed lookup;
     # one past the count, enumeration reports none.
     var i: u32 = 0;
     val isa_len: u32 = isa.registered_count(?reg.isa);
     for (i < isa_len) {
         val opt_vt: O.Option[*isa.IsaVTable] = isa.registered(?reg.isa, i);
-        if (!O.is_some[*isa.IsaVTable](opt_vt))                                                    { ret 1; }
-        if (!O.is_some[*isa.IsaVTable](isa.lookup(?reg.isa, O.unwrap[*isa.IsaVTable](opt_vt).id))) { ret 1; }
+        if (!O.is_some[*isa.IsaVTable](opt_vt))                                                      { ret 1; }
+        if (!O.is_some[*isa.IsaVTable](isa.lookup(?reg.isa, O.unwrap[*isa.IsaVTable](opt_vt).name))) { ret 1; }
         i = i + 1;
     }
     if (O.is_some[*isa.IsaVTable](isa.registered(?reg.isa, isa_len))) { ret 1; }
@@ -307,7 +273,7 @@ test "mach.lang.target.select:linux_aarch64" {
     # the AAPCS64 registration brings the ABI registry to three conventions.
     if (abi.registered_count(?reg.abi) != 3) { ret 1; }
 
-    val res_target: R.Result[resolved.Target, str] = select(?reg, os.OS_LINUX, isa.ARCH_AARCH64);
+    val res_target: R.Result[resolved.Target, str] = select(?reg, "aarch64", "linux", "aapcs64");
     if (R.is_err[resolved.Target, str](res_target)) { ret 1; }
     val t: resolved.Target = R.unwrap_ok[resolved.Target, str](res_target);
 

--- a/src/lang/target/abi.mach
+++ b/src/lang/target/abi.mach
@@ -2,7 +2,7 @@
 #
 # Defines the target-agnostic parameter-passing model (`ParamClass`, `ParamSlot`)
 # and the `AbiVTable` runtime-dispatch interface, backed by an `AbiRegistry` -- a
-# session/driver-owned table of vtables indexed by convention id. The
+# session/driver-owned table of vtables keyed by convention name. The
 # classification and register-assignment logic lives in the per-ABI
 # implementations (sysv, win64, aapcs64), which install their vtables into a
 # registry at startup. The classify/arg/ret function pointers are type-erased
@@ -17,6 +17,7 @@
 
 use std.types.bool.bool;
 use std.types.string.str;
+use std.types.string.str_equals;
 
 use O: std.types.option;
 
@@ -171,7 +172,8 @@ pub def VaModelFn: fun() VaModel;
 # signature declared above.
 # ---
 # id:                         calling-convention id (one of ABI_*)
-# name:                       interned convention name ("sysv", "win64")
+# name:                       interned convention name ("sysv64", "win64",
+#                             "aapcs64"); the registry key and the manifest spelling
 # classify:                   erased fn ptr -- classify a value's class (ClassifyFn)
 # arg_passing:                erased fn ptr -- assign arg regs/stack slots (ArgPassingFn)
 # ret_passing:                erased fn ptr -- assign return regs/sret (RetPassingFn)
@@ -210,16 +212,19 @@ pub rec AbiVTable {
     va_model:                   *u8;
 }
 
-# number of registry slots; sized to hold every ABI_* convention id.
+# maximum number of ABI implementations an AbiRegistry holds
 val ABI_REGISTRY_CAP: u32 = 8;
 
-# a session/driver-owned table of ABI vtables, indexed by convention id. bundled
+# a session/driver-owned table of ABI vtables, keyed by convention name. bundled
 # into `target.TargetRegistry`; per-ABI implementations are installed through
-# `register` at startup. a slot stays nil until its implementation registers.
+# `register` at startup, which appends the vtable and keys it by its `name`.
+# `target.select` resolves a convention by the name the manifest spells.
 # ---
-# slots: vtable pointers indexed by convention id (ABI_*)
+# entries: densely-packed registered vtable pointers, in registration order
+# count:   number of registered vtables
 pub rec AbiRegistry {
-    slots: [8]*AbiVTable;
+    entries: [8]*AbiVTable;
+    count:   u32;
 }
 
 # whole-signature ABI layout: the placement of a function's return value and each
@@ -285,53 +290,54 @@ pub fun registry_init() AbiRegistry {
     var r: AbiRegistry;
     var i: u32 = 0;
     for (i < ABI_REGISTRY_CAP) {
-        r.slots[i] = nil;
+        r.entries[i] = nil;
         i = i + 1;
     }
+    r.count = 0;
     ret r;
 }
 
 # install an ABI vtable into `reg`.
 #
-# write-once per convention id: a second registration for the same id is ignored,
-# so the first implementation to initialize wins deterministically.
+# write-once per convention name: a second registration under a name already
+# present is ignored, so the first implementation to initialize wins
+# deterministically. a nil vtable, or one past the registry's capacity, is
+# ignored.
 # ---
 # reg: the registry to install into
-# vt:  the ABI vtable to register; its `id` selects the slot
+# vt:  the ABI vtable to register; its `name` is the key
 pub fun register(reg: *AbiRegistry, vt: *AbiVTable) {
-    if (vt == nil)                 { ret; }
-    if (vt.id >= ABI_REGISTRY_CAP) { ret; }
-    if (reg.slots[vt.id] != nil)   { ret; }
-    reg.slots[vt.id] = vt;
+    if (vt == nil)                                   { ret; }
+    if (O.is_some[*AbiVTable](lookup(reg, vt.name))) { ret; }
+    if (reg.count >= ABI_REGISTRY_CAP)               { ret; }
+    reg.entries[reg.count] = vt;
+    reg.count = reg.count + 1;
 }
 
-# find the ABI vtable registered for a convention id in `reg`.
+# find the ABI vtable registered under a convention name in `reg`.
 # ---
-# reg:    the registry to read
-# abi_id: calling-convention id (one of ABI_*)
-# ret:    the registered vtable, or none if no implementation is registered
-pub fun lookup(reg: *AbiRegistry, abi_id: u32) O.Option[*AbiVTable] {
-    if (abi_id >= ABI_REGISTRY_CAP) { ret O.none[*AbiVTable](); }
-    if (reg.slots[abi_id] == nil)   { ret O.none[*AbiVTable](); }
-    ret O.some[*AbiVTable](reg.slots[abi_id]);
+# reg:  the registry to read
+# name: calling-convention name ("sysv64", "win64", "aapcs64")
+# ret:  the registered vtable, or none if no implementation is registered
+pub fun lookup(reg: *AbiRegistry, name: str) O.Option[*AbiVTable] {
+    var i: u32 = 0;
+    for (i < reg.count) {
+        if (str_equals(reg.entries[i].name, name)) { ret O.some[*AbiVTable](reg.entries[i]); }
+        i = i + 1;
+    }
+    ret O.none[*AbiVTable]();
 }
 
 # count the ABI implementations registered in `reg`.
 # ---
 # reg: the registry to read
-# ret: number of non-empty registry slots
+# ret: number of registered vtables
 pub fun registered_count(reg: *AbiRegistry) u32 {
-    var n: u32 = 0;
-    var i: u32 = 0;
-    for (i < ABI_REGISTRY_CAP) {
-        if (reg.slots[i] != nil) { n = n + 1; }
-        i = i + 1;
-    }
-    ret n;
+    ret reg.count;
 }
 
-# the ABI vtable at enumeration index `idx` (0-based, in id order) in `reg`,
-# skipping empty slots.
+# the ABI vtable at enumeration index `idx` (0-based, in registration order) in
+# `reg`.
 #
 # Pairs with registered_count to walk the registry.
 # ---
@@ -339,16 +345,8 @@ pub fun registered_count(reg: *AbiRegistry) u32 {
 # idx: enumeration index in [0, registered_count)
 # ret: the vtable at that index, or none when idx is out of range
 pub fun registered(reg: *AbiRegistry, idx: u32) O.Option[*AbiVTable] {
-    var n: u32 = 0;
-    var i: u32 = 0;
-    for (i < ABI_REGISTRY_CAP) {
-        if (reg.slots[i] != nil) {
-            if (n == idx) { ret O.some[*AbiVTable](reg.slots[i]); }
-            n = n + 1;
-        }
-        i = i + 1;
-    }
-    ret O.none[*AbiVTable]();
+    if (idx >= reg.count) { ret O.none[*AbiVTable](); }
+    ret O.some[*AbiVTable](reg.entries[idx]);
 }
 
 # build a single-register or stack `ParamSlot`. `reg_count` is 1 and `reg_width`

--- a/src/lang/target/abi/sysv.mach
+++ b/src/lang/target/abi/sysv.mach
@@ -386,17 +386,19 @@ var sysv_vtable: abi.AbiVTable;
 
 # build the SysV AMD64 AbiVTable and install it into `reg`
 #
-# Sets the convention name ("sysv"), wires the type-erased classify / arg / ret
-# operation pointers and the GP/FP argument-register and callee-saved register
-# file accessors, sets the 16-byte stack alignment and 128-byte red zone, and
-# registers it under `abi.ABI_SYSV` so `target.select` can find it through
-# `abi.lookup`. Idempotent: the registry entry is write-once.
+# Sets the convention name ("sysv64", matching the name the manifest spells),
+# wires the type-erased classify / arg / ret operation pointers and the GP/FP
+# argument-register and callee-saved register file accessors, sets the 16-byte
+# stack alignment and 128-byte red zone, and registers it under the "sysv64" key
+# so `target.select` can find it through `abi.lookup`. The `id` (abi.ABI_SYSV)
+# survives as the comptime tag value and the derived `resolved.Target.abi_id`.
+# Idempotent: the registry entry is write-once.
 # ---
 # reg: the ABI registry to install the vtable into
 # ret: ok(true) on success
 pub fun register(reg: *abi.AbiRegistry) R.Result[bool, str] {
     sysv_vtable.id           = abi.ABI_SYSV;
-    sysv_vtable.name         = "sysv";
+    sysv_vtable.name         = "sysv64";
     sysv_vtable.classify     = classify::*u8;
     sysv_vtable.arg_passing  = classify_arg::*u8;
     sysv_vtable.ret_passing  = classify_return::*u8;

--- a/src/lang/target/isa.mach
+++ b/src/lang/target/isa.mach
@@ -1,11 +1,12 @@
-# instruction-set interface and target id registry
+# instruction-set interface and target registry
 #
 # Defines the target-agnostic machine model - operands, instructions, and
 # instruction buffers - plus the `IsaVTable` runtime-dispatch interface and an
-# `IsaRegistry` (a session/driver-owned table of vtables indexed by architecture
-# id) that per-arch implementations install into at startup. The numeric `ARCH_*`
-# ids are stable across compiler versions and drive comptime conditional
-# compilation via `$mach.arch.<name>`.
+# `IsaRegistry` (a session/driver-owned table of vtables keyed by architecture
+# name) that per-arch implementations install into at startup. The numeric
+# `ARCH_*` ids are stable across compiler versions and drive comptime conditional
+# compilation via `$mach.arch.<name>`; the registry keys on the vtable name the
+# manifest spells, not the id.
 
 use std.allocator.page;
 use std.types.bool.bool;
@@ -413,18 +414,21 @@ pub rec IsaVTable {
     model:                *MachineModel;
 }
 
-# number of architecture slots in an IsaRegistry, indexed by ARCH_* id
+# maximum number of ISA implementations an IsaRegistry holds
 val ISA_REGISTRY_CAP: u32 = 8;
 
-# a session/driver-owned table of ISA vtables, indexed by architecture id
+# a session/driver-owned table of ISA vtables, keyed by architecture name
 #
 # Bundled into `target.TargetRegistry`; per-arch implementations are installed
-# through `register` at startup. A slot stays nil until its implementation
-# registers.
+# through `register` at startup, which appends the vtable and keys it by its
+# `name`. `target.select` resolves an architecture by the name the manifest
+# spells.
 # ---
-# slots: vtable pointers indexed by architecture id (ARCH_*)
+# entries: densely-packed registered vtable pointers, in registration order
+# count:   number of registered vtables
 pub rec IsaRegistry {
-    slots: [8]*IsaVTable;
+    entries: [8]*IsaVTable;
+    count:   u32;
 }
 
 # map a target isa name to its canonical architecture id
@@ -606,70 +610,63 @@ pub fun registry_init() IsaRegistry {
     var reg: IsaRegistry;
     var i: u32 = 0;
     for (i < ISA_REGISTRY_CAP) {
-        reg.slots[i] = nil;
+        reg.entries[i] = nil;
         i = i + 1;
     }
+    reg.count = 0;
     ret reg;
 }
 
 # install an ISA vtable into a registry
 #
-# Write-once per architecture id: a second registration for the same id is
-# ignored, so the first implementation to initialize wins deterministically. A
-# nil vtable or an out-of-range id is ignored.
+# Write-once per architecture name: a second registration under a name already
+# present is ignored, so the first implementation to initialize wins
+# deterministically. A nil vtable, or one past the registry's capacity, is
+# ignored.
 # ---
 # reg: the registry to install into
-# vt:  the ISA vtable to register; its `id` selects the slot
+# vt:  the ISA vtable to register; its `name` is the key
 pub fun register(reg: *IsaRegistry, vt: *IsaVTable) {
-    if (vt == nil)                 { ret; }
-    if (vt.id >= ISA_REGISTRY_CAP) { ret; }
-    if (reg.slots[vt.id] != nil)   { ret; }
-    reg.slots[vt.id] = vt;
+    if (vt == nil)                                   { ret; }
+    if (O.is_some[*IsaVTable](lookup(reg, vt.name))) { ret; }
+    if (reg.count >= ISA_REGISTRY_CAP)               { ret; }
+    reg.entries[reg.count] = vt;
+    reg.count = reg.count + 1;
 }
 
-# find the ISA vtable registered for an architecture id
+# find the ISA vtable registered under an architecture name
 # ---
-# reg:     the registry to read
-# arch_id: architecture id (one of ARCH_*)
-# ret:     the registered vtable, or none if no implementation is registered
-pub fun lookup(reg: *IsaRegistry, arch_id: u32) O.Option[*IsaVTable] {
-    if (arch_id >= ISA_REGISTRY_CAP) { ret O.none[*IsaVTable](); }
-    if (reg.slots[arch_id] == nil)   { ret O.none[*IsaVTable](); }
-    ret O.some[*IsaVTable](reg.slots[arch_id]);
+# reg:  the registry to read
+# name: architecture name ("x86_64", "aarch64")
+# ret:  the registered vtable, or none if no implementation is registered
+pub fun lookup(reg: *IsaRegistry, name: str) O.Option[*IsaVTable] {
+    var i: u32 = 0;
+    for (i < reg.count) {
+        if (str_equals(reg.entries[i].name, name)) { ret O.some[*IsaVTable](reg.entries[i]); }
+        i = i + 1;
+    }
+    ret O.none[*IsaVTable]();
 }
 
 # the number of ISA implementations registered in a registry
 # ---
 # reg: the registry to read
-# ret: the count of non-empty registry slots
+# ret: the count of registered vtables
 pub fun registered_count(reg: *IsaRegistry) u32 {
-    var n: u32 = 0;
-    var i: u32 = 0;
-    for (i < ISA_REGISTRY_CAP) {
-        if (reg.slots[i] != nil) { n = n + 1; }
-        i = i + 1;
-    }
-    ret n;
+    ret reg.count;
 }
 
-# the ISA vtable at enumeration index `idx`, skipping empty slots
+# the ISA vtable at enumeration index `idx`
 #
-# Enumerates in id order; pairs with `registered_count` to walk the registry.
+# Enumerates in registration order; pairs with `registered_count` to walk the
+# registry.
 # ---
 # reg: the registry to read
 # idx: enumeration index in [0, registered_count)
 # ret: the vtable at that index, or none when idx is out of range
 pub fun registered(reg: *IsaRegistry, idx: u32) O.Option[*IsaVTable] {
-    var n: u32 = 0;
-    var i: u32 = 0;
-    for (i < ISA_REGISTRY_CAP) {
-        if (reg.slots[i] != nil) {
-            if (n == idx) { ret O.some[*IsaVTable](reg.slots[i]); }
-            n = n + 1;
-        }
-        i = i + 1;
-    }
-    ret O.none[*IsaVTable]();
+    if (idx >= reg.count) { ret O.none[*IsaVTable](); }
+    ret O.some[*IsaVTable](reg.entries[idx]);
 }
 
 # a blank operand of the given kind and width, with all payload fields cleared
@@ -745,22 +742,24 @@ test "mach.lang.target.isa.register:write_once_and_enumerate" {
     if (registered_count(?reg) != 0) { ret 1; }
 
     var vt: IsaVTable;
-    vt.id = ARCH_X86_64;
+    vt.id   = ARCH_X86_64;
+    vt.name = "x86_64";
     register(?reg, ?vt);
     if (registered_count(?reg) != 1) { ret 1; }
 
-    val opt_vt: O.Option[*IsaVTable] = lookup(?reg, ARCH_X86_64);
+    val opt_vt: O.Option[*IsaVTable] = lookup(?reg, "x86_64");
     if (!O.is_some[*IsaVTable](opt_vt))      { ret 1; }
     if (O.unwrap[*IsaVTable](opt_vt) != ?vt) { ret 1; }
 
-    # write-once: a second registration for the same id is ignored
+    # write-once: a second registration under the same name is ignored
     var vt2: IsaVTable;
-    vt2.id = ARCH_X86_64;
+    vt2.id   = ARCH_X86_64;
+    vt2.name = "x86_64";
     register(?reg, ?vt2);
-    if (O.unwrap[*IsaVTable](lookup(?reg, ARCH_X86_64)) != ?vt) { ret 1; }
+    if (O.unwrap[*IsaVTable](lookup(?reg, "x86_64")) != ?vt) { ret 1; }
 
-    # an unregistered id misses
-    if (O.is_some[*IsaVTable](lookup(?reg, ARCH_AARCH64))) { ret 1; }
+    # an unregistered name misses
+    if (O.is_some[*IsaVTable](lookup(?reg, "aarch64"))) { ret 1; }
 
     # enumeration yields the single installed vtable and nothing past it
     if (O.unwrap[*IsaVTable](registered(?reg, 0)) != ?vt) { ret 1; }

--- a/src/lang/target/of.mach
+++ b/src/lang/target/of.mach
@@ -4,7 +4,7 @@
 # end (which builds an image) and the format writer (which serializes it) - so
 # it lives here rather than in be.obj to avoid an import cycle. The `OfVTable`
 # runtime-dispatch interface plus an `OfRegistry` (a session/driver-owned table
-# of vtables indexed by format id) let per-format implementations (elf, coff,
+# of vtables keyed by format name) let per-format implementations (elf, coff,
 # macho) be installed at startup. The back end emits relocations using the
 # abstract `RK_*` kinds; each format maps those to its own machine relocation
 # types internally with a plain integer compare.
@@ -12,6 +12,7 @@
 use std.types.bool.bool;
 use std.types.size.usize;
 use std.types.string.str;
+use std.types.string.str_equals;
 
 use A: std.allocator;
 use O: std.types.option;
@@ -410,18 +411,21 @@ pub rec OfVTable {
     emit_dyn_exec: DynExecFn;
 }
 
-# fixed slot count of an OfRegistry; OF_* ids index in [0, OF_REGISTRY_CAP)
+# maximum number of object-format implementations an OfRegistry holds
 val OF_REGISTRY_CAP: u32 = 8;
 
-# a session/driver-owned table of object-format vtables, indexed by format id
+# a session/driver-owned table of object-format vtables, keyed by format name
 #
 # Bundled into `target.TargetRegistry`; per-format implementations are installed
-# through `register` at startup. A slot stays nil until its implementation
-# registers.
+# through `register` at startup, which appends the vtable and keys it by its
+# `name`. `target.select` resolves the object format through the chosen os's
+# `default_of` name.
 # ---
-# slots: vtable pointers indexed by format id (OF_*)
+# entries: densely-packed registered vtable pointers, in registration order
+# count:   number of registered vtables
 pub rec OfRegistry {
-    slots: [8]*OfVTable;
+    entries: [8]*OfVTable;
+    count:   u32;
 }
 
 # construct a fresh object-format registry with every slot empty
@@ -431,53 +435,53 @@ pub fun registry_init() OfRegistry {
     var reg: OfRegistry;
     var i:   u32 = 0;
     for (i < OF_REGISTRY_CAP) {
-        reg.slots[i] = nil;
+        reg.entries[i] = nil;
         i = i + 1;
     }
+    reg.count = 0;
     ret reg;
 }
 
 # install an object-format vtable into `reg`
 #
-# Write-once per format id: a second registration for the same id is ignored so
-# the first implementation to initialize wins deterministically.
+# Write-once per format name: a second registration under a name already present
+# is ignored so the first implementation to initialize wins deterministically. a
+# nil vtable, or one past the registry's capacity, is ignored.
 # ---
 # reg: the registry to install into
-# vt:  the object-format vtable to register; its `id` selects the slot
+# vt:  the object-format vtable to register; its `name` is the key
 pub fun register(reg: *OfRegistry, vt: *OfVTable) {
-    if (vt == nil)                { ret; }
-    if (vt.id >= OF_REGISTRY_CAP) { ret; }
-    if (reg.slots[vt.id] != nil)  { ret; }
-    reg.slots[vt.id] = vt;
+    if (vt == nil)                                  { ret; }
+    if (O.is_some[*OfVTable](lookup(reg, vt.name))) { ret; }
+    if (reg.count >= OF_REGISTRY_CAP)               { ret; }
+    reg.entries[reg.count] = vt;
+    reg.count = reg.count + 1;
 }
 
-# find the object-format vtable registered for a format id in `reg`
+# find the object-format vtable registered under a format name in `reg`
 # ---
-# reg:   the registry to read
-# of_id: object-format id (one of OF_*)
-# ret:   the registered vtable, or none if no implementation is registered
-pub fun lookup(reg: *OfRegistry, of_id: u32) O.Option[*OfVTable] {
-    if (of_id >= OF_REGISTRY_CAP) { ret O.none[*OfVTable](); }
-    if (reg.slots[of_id] == nil)  { ret O.none[*OfVTable](); }
-    ret O.some[*OfVTable](reg.slots[of_id]);
+# reg:  the registry to read
+# name: object-format name ("elf", "coff", "macho")
+# ret:  the registered vtable, or none if no implementation is registered
+pub fun lookup(reg: *OfRegistry, name: str) O.Option[*OfVTable] {
+    var i: u32 = 0;
+    for (i < reg.count) {
+        if (str_equals(reg.entries[i].name, name)) { ret O.some[*OfVTable](reg.entries[i]); }
+        i = i + 1;
+    }
+    ret O.none[*OfVTable]();
 }
 
 # count the object-format implementations registered in `reg`
 # ---
 # reg: the registry to read
-# ret: number of non-empty registry slots
+# ret: number of registered vtables
 pub fun registered_count(reg: *OfRegistry) u32 {
-    var n: u32 = 0;
-    var i: u32 = 0;
-    for (i < OF_REGISTRY_CAP) {
-        if (reg.slots[i] != nil) { n = n + 1; }
-        i = i + 1;
-    }
-    ret n;
+    ret reg.count;
 }
 
-# the object-format vtable at enumeration index `idx` (0-based, in id order) in
-# `reg`, skipping empty slots
+# the object-format vtable at enumeration index `idx` (0-based, in registration
+# order) in `reg`
 #
 # Pairs with registered_count to walk the registry.
 # ---
@@ -485,16 +489,8 @@ pub fun registered_count(reg: *OfRegistry) u32 {
 # idx: enumeration index in [0, registered_count)
 # ret: the vtable at that index, or none when idx is out of range
 pub fun registered(reg: *OfRegistry, idx: u32) O.Option[*OfVTable] {
-    var n: u32 = 0;
-    var i: u32 = 0;
-    for (i < OF_REGISTRY_CAP) {
-        if (reg.slots[i] != nil) {
-            if (n == idx) { ret O.some[*OfVTable](reg.slots[i]); }
-            n = n + 1;
-        }
-        i = i + 1;
-    }
-    ret O.none[*OfVTable]();
+    if (idx >= reg.count) { ret O.none[*OfVTable](); }
+    ret O.some[*OfVTable](reg.entries[idx]);
 }
 
 # the stable, format-independent name of an abstract relocation kind, for

--- a/src/lang/target/of/coff.mach
+++ b/src/lang/target/of/coff.mach
@@ -2763,7 +2763,7 @@ test "mach.lang.target.of.coff:emit_parse_round_trip" {
     val rr: R.Result[bool, str] = register_coff(?of_reg);
     if (R.is_err[bool, str](rr)) { ret 1; }
 
-    val vt_o: O.Option[*of.OfVTable] = of.lookup(?of_reg, of.OF_COFF);
+    val vt_o: O.Option[*of.OfVTable] = of.lookup(?of_reg, "coff");
     if (!O.is_some[*of.OfVTable](vt_o)) { ret 1; }
 
     # a minimal isa vtable: the writer reads only its `id`.
@@ -3023,7 +3023,7 @@ test "mach.lang.target.of.coff.coff_emit_object:unresolved_reloc_symbol" {
     val rr: R.Result[bool, str] = register_coff(?of_reg);
     if (R.is_err[bool, str](rr)) { ret 1; }
 
-    val vt_o: O.Option[*of.OfVTable] = of.lookup(?of_reg, of.OF_COFF);
+    val vt_o: O.Option[*of.OfVTable] = of.lookup(?of_reg, "coff");
     if (!O.is_some[*of.OfVTable](vt_o)) { ret 1; }
 
     var isa_vt: isa.IsaVTable;
@@ -3082,7 +3082,7 @@ test "mach.lang.target.of.coff:defined_weak_comdat_round_trip" {
     val rr: R.Result[bool, str] = register_coff(?of_reg);
     if (R.is_err[bool, str](rr)) { ret 1; }
 
-    val vt_o: O.Option[*of.OfVTable] = of.lookup(?of_reg, of.OF_COFF);
+    val vt_o: O.Option[*of.OfVTable] = of.lookup(?of_reg, "coff");
     if (!O.is_some[*of.OfVTable](vt_o)) { ret 1; }
 
     var isa_vt: isa.IsaVTable;
@@ -3377,7 +3377,7 @@ test "mach.lang.target.of.coff:call_target_import_function_flag" {
     val rr: R.Result[bool, str] = register_coff(?of_reg);
     if (R.is_err[bool, str](rr)) { ret 1; }
 
-    val vt_o: O.Option[*of.OfVTable] = of.lookup(?of_reg, of.OF_COFF);
+    val vt_o: O.Option[*of.OfVTable] = of.lookup(?of_reg, "coff");
     if (!O.is_some[*of.OfVTable](vt_o)) { ret 1; }
 
     var isa_vt: isa.IsaVTable;
@@ -3455,7 +3455,7 @@ test "mach.lang.target.of.coff.infer_extern_function_flags_from_calls:foreign_ca
     val rr: R.Result[bool, str] = register_coff(?of_reg);
     if (R.is_err[bool, str](rr)) { ret 1; }
 
-    val vt_o: O.Option[*of.OfVTable] = of.lookup(?of_reg, of.OF_COFF);
+    val vt_o: O.Option[*of.OfVTable] = of.lookup(?of_reg, "coff");
     if (!O.is_some[*of.OfVTable](vt_o)) { ret 1; }
 
     var isa_vt: isa.IsaVTable;
@@ -3875,7 +3875,7 @@ test "mach.lang.target.of.coff.coff_parse_object:rejects_addr32" {
     val rr: R.Result[bool, str] = register_coff(?of_reg);
     if (R.is_err[bool, str](rr)) { ret 1; }
 
-    val vt_o: O.Option[*of.OfVTable] = of.lookup(?of_reg, of.OF_COFF);
+    val vt_o: O.Option[*of.OfVTable] = of.lookup(?of_reg, "coff");
     if (!O.is_some[*of.OfVTable](vt_o)) { ret 1; }
 
     var isa_vt: isa.IsaVTable;
@@ -3942,7 +3942,7 @@ test "mach.lang.target.of.coff.coff_emit_object:reloc_count_overflow" {
     val rr: R.Result[bool, str] = register_coff(?of_reg);
     if (R.is_err[bool, str](rr)) { ret 1; }
 
-    val vt_o: O.Option[*of.OfVTable] = of.lookup(?of_reg, of.OF_COFF);
+    val vt_o: O.Option[*of.OfVTable] = of.lookup(?of_reg, "coff");
     if (!O.is_some[*of.OfVTable](vt_o)) { ret 1; }
 
     var isa_vt: isa.IsaVTable;

--- a/src/lang/target/of/macho.mach
+++ b/src/lang/target/of/macho.mach
@@ -109,7 +109,7 @@ test "mach.lang.target.of.macho.register:installs_stub_vtable" {
     val res_register: R.Result[bool, str] = register_macho(?reg);
     if (R.is_err[bool, str](res_register)) { ret 1; }
 
-    val opt_vt: O.Option[*of.OfVTable] = of.lookup(?reg, of.OF_MACHO);
+    val opt_vt: O.Option[*of.OfVTable] = of.lookup(?reg, "macho");
     if (!O.is_some[*of.OfVTable](opt_vt)) { ret 1; }
 
     var isa_vt: isa.IsaVTable;

--- a/src/lang/target/os.mach
+++ b/src/lang/target/os.mach
@@ -1,11 +1,11 @@
-# operating-system interface and id registry
+# operating-system interface and registry
 #
 # Defines the `OsVTable` runtime-dispatch interface backed by an `OsRegistry` (a
-# session/driver-owned table of vtables indexed by os id), plus the stable
+# session/driver-owned table of vtables keyed by os name), plus the stable
 # numeric `OS_*` ids that drive comptime conditional compilation via
 # `$mach.os.<name>`. Per-OS implementations (linux, darwin, windows) supply the
-# entry-point symbol, syscall layer, and default library directory, and are
-# installed into a registry at startup.
+# entry-point symbol, the default object format, and the default library
+# directory, and are installed into a registry at startup.
 
 use std.types.bool.bool;
 use std.types.string.str;
@@ -57,6 +57,10 @@ pub val OS_LIBDIR_MAX: u32 = 8;
 # ---
 # id:             operating-system id (one of OS_*)
 # name:           os name ("linux", "darwin", "windows")
+# default_of:     name of the object format this os defaults to ("elf", "macho",
+#                 "coff"); `target.select` resolves the `of` axis through it, so
+#                 the default object format is a per-os datum rather than a
+#                 central switch
 # entry_symbol:   program entry-point symbol ("_start", "_main", ...); the linker
 #                 interns it where it keys the symbol table
 # libdirs:        ordered system library directories the CLI link path probes for
@@ -84,6 +88,7 @@ pub val OS_LIBDIR_MAX: u32 = 8;
 pub rec OsVTable {
     id:             u32;
     name:           str;
+    default_of:     str;
     entry_symbol:   str;
     libdirs:        [OS_LIBDIR_MAX]str;
     libdir_len:     u32;
@@ -93,18 +98,20 @@ pub rec OsVTable {
     stack_probe:    bool;
 }
 
-# slot capacity of an OsRegistry; must exceed the largest OS_* id
+# maximum number of OS implementations an OsRegistry holds
 val OS_REGISTRY_CAP: u32 = 8;
 
-# a session/driver-owned table of OS vtables, indexed by os id
+# a session/driver-owned table of OS vtables, keyed by os name
 #
 # Bundled into `target.TargetRegistry`; per-OS implementations are installed
-# through `register` at startup. A slot stays nil until its implementation
-# registers.
+# through `register` at startup, which appends the vtable and keys it by its
+# `name`. `target.select` resolves an os by the name the manifest spells.
 # ---
-# slots: vtable pointers indexed by os id (OS_*)
+# entries: densely-packed registered vtable pointers, in registration order
+# count:   number of registered vtables
 pub rec OsRegistry {
-    slots: [8]*OsVTable;
+    entries: [8]*OsVTable;
+    count:   u32;
 }
 
 # construct a fresh OS registry with every slot empty
@@ -114,53 +121,53 @@ pub fun registry_init() OsRegistry {
     var r: OsRegistry;
     var i: u32 = 0;
     for (i < OS_REGISTRY_CAP) {
-        r.slots[i] = nil;
+        r.entries[i] = nil;
         i = i + 1;
     }
+    r.count = 0;
     ret r;
 }
 
 # install an OS vtable into `reg`
 #
-# Write-once per os id: a second registration for the same id is ignored so the
-# first implementation to initialize wins deterministically.
+# Write-once per os name: a second registration under a name already present is
+# ignored so the first implementation to initialize wins deterministically. a nil
+# vtable, or one past the registry's capacity, is ignored.
 # ---
 # reg: the registry to install into
-# vt:  the OS vtable to register; its `id` selects the slot
+# vt:  the OS vtable to register; its `name` is the key
 pub fun register(reg: *OsRegistry, vt: *OsVTable) {
-    if (vt == nil)                { ret; }
-    if (vt.id >= OS_REGISTRY_CAP) { ret; }
-    if (reg.slots[vt.id] != nil)  { ret; }
-    reg.slots[vt.id] = vt;
+    if (vt == nil)                                  { ret; }
+    if (O.is_some[*OsVTable](lookup(reg, vt.name))) { ret; }
+    if (reg.count >= OS_REGISTRY_CAP)               { ret; }
+    reg.entries[reg.count] = vt;
+    reg.count = reg.count + 1;
 }
 
-# find the OS vtable registered for an os id in `reg`
+# find the OS vtable registered under an os name in `reg`
 # ---
-# reg:   the registry to read
-# os_id: operating-system id (one of OS_*)
-# ret:   the registered vtable, or none if no implementation is registered
-pub fun lookup(reg: *OsRegistry, os_id: u32) O.Option[*OsVTable] {
-    if (os_id >= OS_REGISTRY_CAP) { ret O.none[*OsVTable](); }
-    if (reg.slots[os_id] == nil)  { ret O.none[*OsVTable](); }
-    ret O.some[*OsVTable](reg.slots[os_id]);
+# reg:  the registry to read
+# name: operating-system name ("linux", "darwin", "windows")
+# ret:  the registered vtable, or none if no implementation is registered
+pub fun lookup(reg: *OsRegistry, name: str) O.Option[*OsVTable] {
+    var i: u32 = 0;
+    for (i < reg.count) {
+        if (str_equals(reg.entries[i].name, name)) { ret O.some[*OsVTable](reg.entries[i]); }
+        i = i + 1;
+    }
+    ret O.none[*OsVTable]();
 }
 
 # the number of OS implementations registered in `reg`
 # ---
 # reg: the registry to read
-# ret: count of non-empty registry slots
+# ret: count of registered vtables
 pub fun registered_count(reg: *OsRegistry) u32 {
-    var n: u32 = 0;
-    var i: u32 = 0;
-    for (i < OS_REGISTRY_CAP) {
-        if (reg.slots[i] != nil) { n = n + 1; }
-        i = i + 1;
-    }
-    ret n;
+    ret reg.count;
 }
 
-# the OS vtable at enumeration index `idx` (0-based, in id order) in `reg`,
-# skipping empty slots
+# the OS vtable at enumeration index `idx` (0-based, in registration order) in
+# `reg`
 #
 # Pairs with registered_count to walk the registry.
 # ---
@@ -168,14 +175,6 @@ pub fun registered_count(reg: *OsRegistry) u32 {
 # idx: enumeration index in [0, registered_count)
 # ret: the vtable at that index, or none when idx is out of range
 pub fun registered(reg: *OsRegistry, idx: u32) O.Option[*OsVTable] {
-    var n: u32 = 0;
-    var i: u32 = 0;
-    for (i < OS_REGISTRY_CAP) {
-        if (reg.slots[i] != nil) {
-            if (n == idx) { ret O.some[*OsVTable](reg.slots[i]); }
-            n = n + 1;
-        }
-        i = i + 1;
-    }
-    ret O.none[*OsVTable]();
+    if (idx >= reg.count) { ret O.none[*OsVTable](); }
+    ret O.some[*OsVTable](reg.entries[idx]);
 }

--- a/src/lang/target/os/darwin.mach
+++ b/src/lang/target/os/darwin.mach
@@ -31,18 +31,19 @@ var darwin_vtable: os.OsVTable;
 
 # build and install the Darwin OsVTable
 #
-# Sets the os name, entry symbol ("_main"), syscall layer, and default library
-# directory as plain str constants, fills the module-level vtable (including the
-# 0x100000000 base address and 4096-byte page), and installs it into reg under
-# os.OS_DARWIN. The vtable strings are not interned here; the linker interns the
-# ones it needs at the point of use. Must be invoked at startup before
-# target.select requests a Darwin target.
+# Sets the os name, default object format ("macho"), entry symbol ("_main"), and
+# default library directory as plain str constants, fills the module-level vtable
+# (including the 0x100000000 base address and 4096-byte page), and installs it
+# into reg under the "darwin" key. The vtable strings are not interned here; the
+# linker interns the ones it needs at the point of use. Must be invoked at startup
+# before target.select requests a Darwin target.
 # ---
 # reg: the OS registry to install the vtable into
 # ret: ok(true) always; the Result return is kept for registrar-signature parity
 pub fun register_darwin(reg: *os.OsRegistry) R.Result[bool, str] {
     darwin_vtable.id             = os.OS_DARWIN;
     darwin_vtable.name           = "darwin";
+    darwin_vtable.default_of     = "macho";
     darwin_vtable.entry_symbol   = "_main";
     darwin_vtable.libdirs[0]     = "/usr/lib";
     darwin_vtable.libdirs[1]     = "/usr/local/lib";

--- a/src/lang/target/os/linux.mach
+++ b/src/lang/target/os/linux.mach
@@ -39,18 +39,19 @@ var linux_vtable: os.OsVTable;
 
 # build and install the Linux OsVTable
 #
-# Sets the os name, entry symbol ("_start"), syscall layer, and system library
-# directories as plain str constants, fills the module-level vtable (including the
-# 0x400000 base address and 4096-byte page), and installs it into `reg` under
-# os.OS_LINUX. The vtable strings are not interned here; the linker interns the
-# ones it needs at its own point of use. Must be invoked at startup before
-# target.select requests a Linux target.
+# Sets the os name, default object format ("elf"), entry symbol ("_start"), and
+# system library directories as plain str constants, fills the module-level vtable
+# (including the 0x400000 base address and 4096-byte page), and installs it into
+# `reg` under the "linux" key. The vtable strings are not interned here; the
+# linker interns the ones it needs at its own point of use. Must be invoked at
+# startup before target.select requests a Linux target.
 # ---
 # reg: the OS registry to install the vtable into
 # ret: true (always; the Result return is kept for registrar-signature parity)
 pub fun register_linux(reg: *os.OsRegistry) R.Result[bool, str] {
     linux_vtable.id             = os.OS_LINUX;
     linux_vtable.name           = "linux";
+    linux_vtable.default_of     = "elf";
     linux_vtable.entry_symbol   = "_start";
     linux_vtable.libdirs[0]     = "/lib64";
     linux_vtable.libdirs[1]     = "/usr/lib64";

--- a/src/lang/target/os/windows.mach
+++ b/src/lang/target/os/windows.mach
@@ -34,17 +34,19 @@ var windows_vtable: os.OsVTable;
 
 # build and install the Windows OsVTable
 #
-# Sets the os name, entry symbol ("mainCRTStartup"), syscall layer, and default
-# library directories as plain str constants, fills the module-level vtable, and
-# installs it into `reg` under os.OS_WINDOWS. The vtable strings are not interned
-# here - the linker interns the ones it needs at the point of use. Must be invoked
-# at startup before target.select requests a Windows target.
+# Sets the os name, default object format ("coff"), entry symbol
+# ("mainCRTStartup"), and default library directories as plain str constants,
+# fills the module-level vtable, and installs it into `reg` under the "windows"
+# key. The vtable strings are not interned here - the linker interns the ones it
+# needs at the point of use. Must be invoked at startup before target.select
+# requests a Windows target.
 # ---
 # reg: the OS registry to install the vtable into
 # ret: true (always; the Result return is kept for registrar-signature parity)
 pub fun register_windows(reg: *os.OsRegistry) R.Result[bool, str] {
     windows_vtable.id             = os.OS_WINDOWS;
     windows_vtable.name           = "windows";
+    windows_vtable.default_of     = "coff";
     windows_vtable.entry_symbol   = "mainCRTStartup";
     windows_vtable.libdirs[0]     = "C:\\Windows\\System32";
     windows_vtable.libdir_len     = 1;


### PR DESCRIPTION
The composition tier of the retargeting epic (#1600): targets compose by name instead of through the central `canonical_abi`/`canonical_of` id-derivation switch.

## Registry change
The four substrate registries (`IsaRegistry`/`AbiRegistry`/`OfRegistry`/`OsRegistry`) become NAME-KEYED. `register(reg, vt)` keys by `vt.name`; `lookup(reg, name: str)` linear-scans the registered vtables (2-4 entries). The id-indexed fixed-cap slot array becomes a dense `entries`/`count` pair. Each vtable keeps its `.id` field — it survives as the comptime tag value and as a derived convenience on the resolved target. `registered`/`registered_count` are preserved (enumeration order is unchanged, so `mach info` is unaffected aside from the rename below).

## Naming alignment
The sysv abi vtable `.name` was "sysv" but the manifest spells it "sysv64"; renamed `sysv_vtable.name` to "sysv64" so name-lookup matches. isa ("x86_64"/"aarch64"), os ("linux"/"darwin"/"windows"), win64, and aapcs64 already matched the manifest.

## os default_of
`OsVTable` gains `default_of: str`, set per-os: linux->"elf", darwin->"macho", windows->"coff". This replaces `canonical_of`.

## select + derived ids
`select(reg, isa_name, os_name, abi_name)` resolves the isa/os/abi vtables by the names the manifest already carries, resolves `of` from the looked-up os's `default_of`, builds `resolved.Target`, and DERIVES the legacy `os_id`/`arch_id`/`abi_id`/`of_id` from the resolved vtables' `.id` fields. The ~89 internal id-readers and the comptime evaluator's tag logic are untouched — that conversion is a separate later PR.

`canonical_abi`/`canonical_of` are deleted. `host_abi_id` is reimplemented as a `$mach.build.abi` comptime fold, parallel to `host_os_id`/`host_arch_id` (a pure host fact, not an (os,arch)->abi switch). Callers updated: `driver.select_target` (keeps the precise unknown-os/isa diagnostics, then passes names), `driver.populate_union_tuples`, and the regalloc aarch64 test.

## Zero behavior change
The three real targets (x86_64-linux, x86_64-windows, aarch64-linux) and the native host resolve to the EXACT SAME vtables (verified by pointer identity) and the same os_id/arch_id/abi_id/of_id as before — confirmed with a temporary identity test (added, run, removed). `mach build .` exits 0; suite is 606 passed, 0 failed, 606 total.

Part of #1600.
