### PR TITLE
feat(target): riscv64 backend slice 1 - machine description

### DIFF
--- a/src/lang/driver.mach
+++ b/src/lang/driver.mach
@@ -1708,7 +1708,7 @@ fun select_target(p: *Project, t: *TargetEntry) R.Result[bool, str] {
         ret R.err[bool, str](diag_join_named(p.s, "unknown target os name '", t.os_name, "' (expected: linux, darwin, windows)", "unknown target os name"));
     }
     if (isa.arch_id_for(isa_name) == isa.ARCH_UNKNOWN) {
-        ret R.err[bool, str](diag_join_named(p.s, "unknown target isa name '", t.isa_name, "' (expected: x86_64, aarch64)", "unknown target isa name"));
+        ret R.err[bool, str](diag_join_named(p.s, "unknown target isa name '", t.isa_name, "' (expected: x86_64, aarch64, riscv64)", "unknown target isa name"));
     }
 
     val tr: R.Result[target.Target, str] = target.select_of(?p.s.registry, isa_name, os_name, abi_name, of_name);

--- a/src/lang/fe/comptime.mach
+++ b/src/lang/fe/comptime.mach
@@ -2070,6 +2070,7 @@ fun os_tag_for(name: StrView) R.Result[u32, str] {
 fun arch_tag_for(name: StrView) R.Result[u32, str] {
     if (view_eq_str(name, "x86_64"))  { ret R.ok[u32, str](isa.ARCH_X86_64); }
     if (view_eq_str(name, "aarch64")) { ret R.ok[u32, str](isa.ARCH_AARCH64); }
+    if (view_eq_str(name, "riscv64")) { ret R.ok[u32, str](isa.ARCH_RISCV64); }
     ret R.err[u32, str]("unknown `$mach.arch.*` tag");
 }
 
@@ -2081,6 +2082,7 @@ fun abi_tag_for(name: StrView) R.Result[u32, str] {
     if (view_eq_str(name, "sysv"))    { ret R.ok[u32, str](abi.ABI_SYSV); }
     if (view_eq_str(name, "win64"))   { ret R.ok[u32, str](abi.ABI_WIN64); }
     if (view_eq_str(name, "aapcs64")) { ret R.ok[u32, str](abi.ABI_AAPCS64); }
+    if (view_eq_str(name, "lp64"))    { ret R.ok[u32, str](abi.ABI_LP64); }
     ret R.err[u32, str]("unknown `$mach.abi.*` tag");
 }
 

--- a/src/lang/target.mach
+++ b/src/lang/target.mach
@@ -18,6 +18,7 @@
 use std.allocator.page;
 use std.filesystem;
 use std.types.bool.bool;
+use std.types.bool.false;
 use std.types.bool.true;
 use std.types.string.str;
 use std.types.string.str_empty;
@@ -30,10 +31,12 @@ use R: std.types.result;
 use mach.lang.intern;
 use mach.lang.target.abi;
 use mach.lang.target.abi.aapcs64;
+use mach.lang.target.abi.lp64;
 use mach.lang.target.abi.sysv;
 use mach.lang.target.abi.win64;
 use mach.lang.target.isa;
 use arm64: mach.lang.target.isa.arm64.register;
+use riscv64: mach.lang.target.isa.riscv64.register;
 use x64: mach.lang.target.isa.x64.register;
 use mach.lang.target.of;
 use mach.lang.target.of.coff;
@@ -142,13 +145,14 @@ pub fun registry_init() TargetRegistry {
 # install every target-component implementation into `reg`.
 #
 # composes the four orthogonal dimensions by invoking each implementation's
-# registering entry point: the x86-64 and AArch64 ISAs, the SysV / Win64 /
-# AAPCS64 ABIs, the ELF / COFF / Mach-O / raw object formats, and the Linux /
-# Darwin / Windows / freestanding operating systems. The AArch64 backend and the
-# non-Linux stubs are registered so `select` reports an unsupported pair rather
-# than a missing registration; they fail loudly only when their selection or
-# encoding paths are reached. Must be called once at startup, before any `select`
-# against `reg`.
+# registering entry point: the x86-64, AArch64, and RISC-V (RV64) ISAs, the SysV /
+# Win64 / AAPCS64 / lp64d ABIs, the ELF / COFF / Mach-O / raw object formats, and
+# the Linux / Darwin / Windows / freestanding operating systems. The AArch64 and
+# RISC-V backends and the non-Linux stubs are registered so `select` reports an
+# unsupported pair rather than a missing registration; they fail loudly only when
+# their selection or encoding paths are reached. The RISC-V ISA is the slice-1
+# machine description: it composes and resolves but wires no codegen hooks yet.
+# Must be called once at startup, before any `select` against `reg`.
 # Every registrar is idempotent, so a redundant call is harmless. No interner is
 # needed: vtable string fields are immutable `str` constants, interned at the
 # point of use in the linker and object-format consumers.
@@ -160,12 +164,16 @@ pub fun register_all(reg: *TargetRegistry) R.Result[bool, str] {
     if (R.is_err[bool, str](res)) { ret res; }
     res = arm64.register_arm64(?reg.isa);
     if (R.is_err[bool, str](res)) { ret res; }
+    res = riscv64.register_riscv64(?reg.isa);
+    if (R.is_err[bool, str](res)) { ret res; }
 
     res = sysv.register(?reg.abi);
     if (R.is_err[bool, str](res)) { ret res; }
     res = win64.register_win64(?reg.abi);
     if (R.is_err[bool, str](res)) { ret res; }
     res = aapcs64.register(?reg.abi);
+    if (R.is_err[bool, str](res)) { ret res; }
+    res = lp64.register(?reg.abi);
     if (R.is_err[bool, str](res)) { ret res; }
 
     res = elf.register(?reg.of);
@@ -309,8 +317,9 @@ test "mach.lang.target.select:linux_aarch64" {
     val res_reg: R.Result[bool, str] = register_all(?reg);
     if (R.is_err[bool, str](res_reg)) { ret 1; }
 
-    # the AAPCS64 registration brings the ABI registry to three conventions.
-    if (abi.registered_count(?reg.abi) != 3) { ret 1; }
+    # the SysV / Win64 / AAPCS64 / lp64d registrations bring the ABI registry to
+    # four conventions.
+    if (abi.registered_count(?reg.abi) != 4) { ret 1; }
 
     val res_target: R.Result[resolved.Target, str] = select(?reg, "aarch64", "linux", "aapcs64");
     if (R.is_err[resolved.Target, str](res_target)) { ret 1; }
@@ -327,6 +336,86 @@ test "mach.lang.target.select:linux_aarch64" {
     if (t.abi.id != abi.ABI_AAPCS64) { ret 1; }
     if (t.abi.arg_passing == nil)    { ret 1; }
     if (t.abi.ret_passing == nil)    { ret 1; }
+
+    ret 0;
+}
+
+# selecting a Linux/RISC-V (RV64) target composes the slice-1 machine description:
+# the riscv64 ISA vtable (EM_RISCV, 64-bit, gpr + fpr banks, no flags bank) and the
+# lp64d ABI vtable resolve and bind. the codegen hooks are nil - composition stays
+# clean and only an attempt to generate code would fail loudly. this asserts the
+# description, not codegen.
+test "mach.lang.target.select:linux_riscv64" {
+    var reg: TargetRegistry = registry_init();
+    val res_reg: R.Result[bool, str] = register_all(?reg);
+    if (R.is_err[bool, str](res_reg)) { ret 1; }
+
+    val res_target: R.Result[resolved.Target, str] = select_of(?reg, "riscv64", "linux", "lp64", "");
+    if (R.is_err[resolved.Target, str](res_target)) { ret 1; }
+    val t: resolved.Target = R.unwrap_ok[resolved.Target, str](res_target);
+
+    # the ISA vtable resolved to the RV64 machine description.
+    if (t.arch == nil)                 { ret 1; }
+    if (t.arch.id != isa.ARCH_RISCV64) { ret 1; }
+    if (t.arch.elf_machine != 243)     { ret 1; }  # EM_RISCV
+    # the pointer-width fields are in bytes: 8 bytes = 64-bit.
+    if (t.arch.pointer_width != 8)     { ret 1; }
+
+    # slice 1 wires no codegen hooks: select / encode are nil, so the shared
+    # dispatchers error loudly if reached while composition stays clean.
+    if (t.arch.select != nil) { ret 1; }
+    if (t.arch.encode != nil) { ret 1; }
+
+    # the machine model carries the RV64 widths and exactly the gpr + fpr banks: no
+    # flags bank, since RISC-V has no condition-flags register.
+    if (t.model.pointer_width != 8)              { ret 1; }
+    if (t.model.gpr_width != 8)                  { ret 1; }
+    if (t.model.endianness != isa.ENDIAN_LITTLE) { ret 1; }
+    if (t.model.reg_class_len != 2)              { ret 1; }
+
+    # locate the two banks by role, never by a magic index. the gpr bank exposes 32
+    # integer registers (x0-x31); the fpr bank exposes 30 (f0-f29, f30/f31 held back
+    # as FP scratch).
+    var gp_len: u32 = 0;
+    var fp_len: u32 = 0;
+    var ci: u32 = 0;
+    for (ci < t.model.reg_class_len) {
+        if (t.model.reg_classes[ci].kind == isa.RC_GENERAL) { gp_len = t.model.reg_classes[ci].len; }
+        if (t.model.reg_classes[ci].kind == isa.RC_FLOAT)   { fp_len = t.model.reg_classes[ci].len; }
+        ci = ci + 1;
+    }
+    if (gp_len != 32) { ret 1; }
+    if (fp_len != 30) { ret 1; }
+
+    # x0 (the hardwired zero register) is reserved and never allocatable.
+    var x0_reserved: bool = false;
+    var ri: i32 = 0;
+    for (ri < t.model.reserved_len) {
+        if (t.model.reserved_regs[ri].id == 0) { x0_reserved = true; }
+        ri = ri + 1;
+    }
+    if (!x0_reserved) { ret 1; }
+
+    # the frame / stack pointer role ids are s0/fp (x8) and sp (x2).
+    if (t.model.frame_ptr_reg != 8) { ret 1; }
+    if (t.model.stack_ptr_reg != 2) { ret 1; }
+
+    # the lp64d ABI resolved (not silently the SysV vtable) and classifies the first
+    # integer / float argument into a0 (x10) / fa0 (composite f10) and the integer
+    # return into a0.
+    if (t.abi == nil)            { ret 1; }
+    if (t.abi.id != abi.ABI_LP64) { ret 1; }
+    val arg: abi.ArgPassingFn = t.abi.arg_passing::abi.ArgPassingFn;
+    val ai: abi.ParamSlot = arg(0, 8, 8, false, 0, false, 0, 0, 0, 0);
+    if (ai.class != abi.CLASS_GP) { ret 1; }
+    if (ai.reg != 10)             { ret 1; }  # a0 = x10
+    val af: abi.ParamSlot = arg(0, 8, 8, true, 0, false, 0, 0, 0, 0);
+    if (af.class != abi.CLASS_FP)                                  { ret 1; }
+    if (af.reg != isa.regid_make(isa.REG_CLASS_ID_XMM, 10))        { ret 1; }  # fa0 = f10
+    val rp: abi.RetPassingFn = t.abi.ret_passing::abi.RetPassingFn;
+    val rr: abi.ParamSlot = rp(8, 8, false, 0, false, 0, 0);
+    if (rr.class != abi.CLASS_GP) { ret 1; }
+    if (rr.reg != 10)             { ret 1; }  # a0 = x10
 
     ret 0;
 }

--- a/src/lang/target/abi.mach
+++ b/src/lang/target/abi.mach
@@ -32,6 +32,10 @@ pub val ABI_WIN64:   u32 = 2;
 # it and fails loudly at `lookup` until the AAPCS64 implementation
 # registers, never silently composing the x86-64 SysV vtable for an arm64 target.
 pub val ABI_AAPCS64: u32 = 3;
+# RISC-V lp64d (the standard 64-bit hard-float convention). resolves an
+# (os, riscv64) pair to the lp64 vtable; arg/return placement uses the integer
+# a0-a7 and float fa0-fa7 register banks.
+pub val ABI_LP64: u32 = 4;
 
 # how a single parameter or return value is classified for passing.
 pub def ParamClass: u8;

--- a/src/lang/target/abi/lp64.mach
+++ b/src/lang/target/abi/lp64.mach
@@ -1,0 +1,481 @@
+# mach.lang.target.abi.lp64: RISC-V lp64d calling convention.
+#
+# Implements `abi.AbiVTable` and self-registers under `abi.ABI_LP64`. Owns the
+# lp64d classification of parameters and return values -- the scalar one-register
+# rule, the <=8-byte / 9-16-byte integer-aggregate rule, the >16-byte
+# by-reference rule, and the hard-float scalar rule that passes a float in an fa
+# register (falling back to an integer argument register, then the stack) -- plus
+# the integer a0-a7 / float fa0-fa7 argument banks, the s1-s11 + fs0-fs11
+# callee-saved banks, the 16-byte stack alignment, and no red zone. The integer
+# and float argument banks advance independently.
+#
+# The register-role numbers (a0-a7, fa0-fa7, s1-s11, fs0-fs11) are XLEN-independent
+# and identical to an RV32 ilp32 convention. What makes this lp64d (vs ilp32d) and
+# RV64-specific is the scalar width of a register slot (8 bytes) and the 2*XLEN=16
+# byte register-return / by-reference threshold; an ilp32 sibling would mirror this
+# file with 4-byte slots and an 8-byte threshold.
+#
+# A large aggregate (>16 bytes) is passed by hidden reference: the caller copies it
+# to memory and passes the pointer in the next integer argument register, or, once
+# the integer bank is exhausted, on the stack. The hidden sret pointer for a
+# >16-byte return rides a0 (the first integer argument register), consuming a GP
+# argument slot, so `indirect_result_in_argfile` is true -- the lp64 layout the
+# RISC-V psABI mandates.
+#
+# DEFERRED (later ABI-completion slice): the RISC-V hard-float struct-flattening
+# rules that place a struct of one or two floating-point members (or one float plus
+# one integer) in fa / fa+a registers, and the boundary rule that splits a 9-16
+# byte aggregate across the last integer register and the stack. Slice 1 classifies
+# such aggregates conservatively through the integer-register path, which is the
+# soft-float-correct placement but not the full lp64d hard-float layout. The vtable
+# shape, register banks, and scalar / large-aggregate placement are complete.
+#
+# The vtable's classify/arg/ret function pointers are type-erased (`*u8`); a
+# consumer casts each back to the neutral signature declared in `abi`.
+
+use std.types.bool.bool;
+use std.types.bool.false;
+use std.types.bool.true;
+use std.types.string.str;
+
+use R: std.types.result;
+
+use mach.lang.target.abi;
+use mach.lang.target.isa;
+
+# canonical RISC-V integer register numbers used by the lp64d convention. these are
+# the same physical-register ids the riscv64 ISA exposes; they are fixed by the
+# architecture, so the ABI carries them directly rather than depending on the ISA
+# implementation being registered first. a0 / a1 (x10 / x11) are the integer
+# argument and return registers; s1 (x9) and s2 (x18) anchor the callee-saved set.
+pub val REG_A0: i32 = 10;
+pub val REG_A1: i32 = 11;
+pub val REG_S1: i32 = 9;
+pub val REG_S2: i32 = 18;
+
+# number of integer registers available for argument passing (a0-a7 = x10-x17)
+pub val GP_PARAM_COUNT:        i32 = 8;
+# number of float registers available for argument passing (fa0-fa7 = f10-f17)
+pub val FP_PARAM_COUNT:        i32 = 8;
+# number of callee-saved integer registers (s1-s11 = x9, x18-x27). s0/fp is
+# reserved and preserved by the frame discipline, so it is not in this set.
+pub val GP_CALLEE_SAVED_COUNT: i32 = 11;
+# number of callee-saved float registers (fs0-fs11 = f8, f9, f18-f27)
+pub val FP_CALLEE_SAVED_COUNT: i32 = 12;
+# total callee-saved registers across both banks
+pub val CALLEE_SAVED_COUNT:    i32 = 23;
+
+# required stack alignment in bytes at a call boundary
+pub val STACK_ALIGN: u32 = 16;
+# RISC-V defines no leaf-function red zone
+pub val RED_ZONE:    u32 = 0;
+# largest aggregate size in bytes passed/returned in registers; anything larger is
+# passed/returned by hidden reference (2 * XLEN)
+pub val MAX_REG_RET: u64 = 16;
+
+# the integer argument register for a zero-based argument-register index, or -1
+# past the eight integer argument registers (a0-a7)
+# ---
+# index: zero-based integer argument-register index
+# ret:   the physical register id, or -1 if out of range
+pub fun gp_param_reg(index: i32) i32 {
+    if (index < 0)               { ret -1; }
+    if (index >= GP_PARAM_COUNT) { ret -1; }
+    ret REG_A0 + index;
+}
+
+# the float argument register for a zero-based argument-register index, or -1 past
+# fa7
+#
+# fa registers are numbered f10-f17; the returned id is composite (the float class
+# tag in the high byte, via `isa.regid_make`) so a float pre-coloring carries its
+# bank and is never aliased onto the integer register of the same index.
+# ---
+# index: zero-based float argument-register index
+# ret:   the composite fa register id, or -1 if out of range
+pub fun fp_param_reg(index: i32) i32 {
+    if (index < 0)               { ret -1; }
+    if (index >= FP_PARAM_COUNT) { ret -1; }
+    ret isa.regid_make(isa.REG_CLASS_ID_XMM, REG_A0 + index);
+}
+
+# classify one value into an lp64d placement decision
+#
+# This is the body behind the erased `AbiVTable.classify` pointer; it treats the
+# value as the first argument and routes through `classify_arg`. Returns are routed
+# separately through `classify_return`.
+# ---
+# size:          value size in bytes
+# align:         value alignment in bytes
+# is_float:      true if the value is FP-eligible
+# fp_eightbytes: per-eightbyte SSE mask (unused -- lp64d routes scalars by is_float)
+# is_aggregate:  true if the value is an aggregate
+# gp_used:       integer registers already consumed
+# fp_used:       float registers already consumed
+# hfa_members:   HFA member count (AAPCS64-only; unused under lp64d)
+# hfa_elem:      HFA fundamental member width (AAPCS64-only; unused under lp64d)
+# ret:           the placement decision
+pub fun classify(size: u64, align: u64, is_float: bool, fp_eightbytes: u8,
+                 is_aggregate: bool, gp_used: i32, fp_used: i32,
+                 hfa_members: u8, hfa_elem: u8) abi.ParamSlot {
+    ret classify_arg(0, size, align, is_float, fp_eightbytes, is_aggregate, gp_used, fp_used, hfa_members, hfa_elem);
+}
+
+# assign registers or a stack slot for one argument (lp64d)
+#
+# A non-HFA aggregate larger than 16 bytes is passed by hidden reference -- the
+# caller copies it to memory and passes the pointer in the next integer register
+# (CLASS_BYREF), or, once the integer bank is exhausted, on the stack
+# (CLASS_STACK_BYREF). An aggregate of <=8 bytes takes one integer register; a 9-16
+# byte one takes a consecutive integer register pair; either spills the whole
+# aggregate by value when the integer bank lacks the register(s) it needs. A scalar
+# float takes the next fa register, falling back to an integer argument register
+# (the raw bits ride the GP reg) and then the stack once the fa bank is exhausted.
+# A scalar integer / pointer takes one integer register, then the stack. This
+# classifier is RISC-V-specific by selection: `target.select` only composes the
+# lp64 vtable for a riscv64 (os, arch) pair.
+# ---
+# index:         zero-based logical argument position
+# size:          argument size in bytes
+# align:         argument alignment in bytes
+# is_float:      true if the argument is a scalar float
+# fp_eightbytes: per-eightbyte SSE mask (unused -- lp64d routes scalars by is_float)
+# is_aggregate:  true if the argument is an aggregate
+# gp_used:       integer registers already consumed
+# fp_used:       float registers already consumed
+# hfa_members:   HFA member count (AAPCS64-only; unused under lp64d)
+# hfa_elem:      HFA fundamental member width (AAPCS64-only; unused under lp64d)
+# ret:           the placement decision
+pub fun classify_arg(index: i32, size: u64, align: u64,
+                     is_float: bool, fp_eightbytes: u8, is_aggregate: bool,
+                     gp_used: i32, fp_used: i32, hfa_members: u8, hfa_elem: u8) abi.ParamSlot {
+    if (is_aggregate && size > MAX_REG_RET) {
+        if (gp_used < GP_PARAM_COUNT) {
+            ret abi.make_slot(abi.CLASS_BYREF, gp_param_reg(gp_used), -1, 0, 8);
+        }
+        ret abi.make_slot(abi.CLASS_STACK_BYREF, -1, -1, 0, 8);
+    }
+
+    if (is_aggregate) {
+        if (size <= 8) {
+            if (gp_used < GP_PARAM_COUNT) {
+                ret abi.make_slot(abi.CLASS_GP, gp_param_reg(gp_used), -1, 0, size);
+            }
+            ret abi.make_slot(abi.CLASS_STACK, -1, -1, 0, size);
+        }
+        # 9-16 bytes: a consecutive integer pair, or spill by value if two integer
+        # registers do not remain.
+        if (gp_used + 2 <= GP_PARAM_COUNT) {
+            ret abi.make_slot(abi.CLASS_GP, gp_param_reg(gp_used), gp_param_reg(gp_used + 1), 0, size);
+        }
+        ret abi.make_slot(abi.CLASS_STACK, -1, -1, 0, size);
+    }
+
+    if (is_float) {
+        if (fp_used < FP_PARAM_COUNT) {
+            ret abi.make_slot(abi.CLASS_FP, fp_param_reg(fp_used), -1, 0, size);
+        }
+        # the fa bank is exhausted: lp64d passes the float in an integer argument
+        # register (its raw bits), then on the stack.
+        if (gp_used < GP_PARAM_COUNT) {
+            ret abi.make_slot(abi.CLASS_GP, gp_param_reg(gp_used), -1, 0, size);
+        }
+        ret abi.make_slot(abi.CLASS_STACK, -1, -1, 0, size);
+    }
+
+    if (gp_used < GP_PARAM_COUNT) {
+        ret abi.make_slot(abi.CLASS_GP, gp_param_reg(gp_used), -1, 0, size);
+    }
+    ret abi.make_slot(abi.CLASS_STACK, -1, -1, 0, size);
+}
+
+# assign registers or an sret pointer for a return value (lp64d)
+#
+# A zero-size (void) return yields CLASS_GP with reg=-1. A scalar returns in a0, or
+# fa0 for a float. A non-HFA aggregate of <=8 bytes returns in a0; a 9-16 byte one
+# returns in the a0:a1 pair. A non-HFA aggregate larger than 16 bytes is returned
+# through a hidden sret pointer: the caller passes the result-storage address in a0
+# and the callee returns it in a0 (CLASS_SRET, reg=a0). This classifier is
+# RISC-V-specific by selection -- the lp64 vtable is only composed for a riscv64
+# target.
+# ---
+# size:          return-value size in bytes
+# align:         return-value alignment in bytes
+# is_float:      true if the value is a scalar float
+# fp_eightbytes: per-eightbyte SSE mask (unused -- lp64d routes scalars by is_float)
+# is_aggregate:  true if the value is an aggregate
+# hfa_members:   HFA member count (AAPCS64-only; unused under lp64d)
+# hfa_elem:      HFA fundamental member width (AAPCS64-only; unused under lp64d)
+# ret:           the placement decision
+pub fun classify_return(size: u64, align: u64,
+                        is_float: bool, fp_eightbytes: u8, is_aggregate: bool,
+                        hfa_members: u8, hfa_elem: u8) abi.ParamSlot {
+    if (size == 0) {
+        ret abi.make_slot(abi.CLASS_GP, -1, -1, 0, 0);
+    }
+
+    if (is_aggregate && size > MAX_REG_RET) {
+        ret abi.make_slot(abi.CLASS_SRET, REG_A0, -1, 0, 8);
+    }
+
+    if (is_aggregate) {
+        if (size <= 8) {
+            ret abi.make_slot(abi.CLASS_GP, REG_A0, -1, 0, size);
+        }
+        ret abi.make_slot(abi.CLASS_GP, REG_A0, REG_A1, 0, size);
+    }
+
+    if (is_float) {
+        ret abi.make_slot(abi.CLASS_FP, fp_param_reg(0), -1, 0, size);
+    }
+
+    ret abi.make_slot(abi.CLASS_GP, REG_A0, -1, 0, size);
+}
+
+# fill `out` with the integer argument registers, in passing order
+#
+# Writes `out[0..GP_PARAM_COUNT)` with a0-a7 (each 8 bytes wide). The caller owns
+# `out`, which must hold at least `GP_PARAM_COUNT` registers; the count is returned
+# so the call composes with `RegisterFile`.
+# ---
+# out: caller-owned buffer of at least GP_PARAM_COUNT registers
+# ret: the number of registers written (GP_PARAM_COUNT)
+pub fun gp_param_regs(out: *isa.Register) i32 {
+    var i: i32 = 0;
+    for (i < GP_PARAM_COUNT) {
+        out[i].id   = gp_param_reg(i);
+        out[i].size = 8;
+        i = i + 1;
+    }
+    ret GP_PARAM_COUNT;
+}
+
+# fill `out` with the float argument registers, in passing order
+#
+# Writes `out[0..FP_PARAM_COUNT)` with fa0-fa7 (composite float ids, each 8 bytes
+# wide under the D extension). The caller owns `out`, which must hold at least
+# `FP_PARAM_COUNT` registers.
+# ---
+# out: caller-owned buffer of at least FP_PARAM_COUNT registers
+# ret: the number of registers written (FP_PARAM_COUNT)
+pub fun fp_param_regs(out: *isa.Register) i32 {
+    var i: i32 = 0;
+    for (i < FP_PARAM_COUNT) {
+        out[i].id   = fp_param_reg(i);
+        out[i].size = 8;
+        i = i + 1;
+    }
+    ret FP_PARAM_COUNT;
+}
+
+# fill `out` with the callee-saved registers across both banks
+#
+# Writes `out[0..CALLEE_SAVED_COUNT)` with the integer set s1, s2-s11 (x9, x18-x27,
+# 8 bytes each) then the float set fs0-fs11 (f8, f9, f18-f27, composite float ids,
+# 8 bytes each). A callee that touches any of these must preserve it across the
+# call; regalloc routes each to its bank by the composite-id class tag. s0/fp is
+# excluded -- it is reserved and preserved by the frame discipline. The caller owns
+# `out`, which must hold at least `CALLEE_SAVED_COUNT` registers.
+# ---
+# out: caller-owned buffer of at least CALLEE_SAVED_COUNT registers
+# ret: the number of registers written (CALLEE_SAVED_COUNT)
+pub fun callee_saved(out: *isa.Register) i32 {
+    out[0].id   = REG_S1;  # s1 = x9
+    out[0].size = 8;
+    var i: i32 = 0;
+    for (i < 10) {
+        out[1 + i].id   = REG_S2 + i;  # s2-s11 = x18-x27
+        out[1 + i].size = 8;
+        i = i + 1;
+    }
+    out[11].id   = isa.regid_make(isa.REG_CLASS_ID_XMM, 8);  # fs0 = f8
+    out[11].size = 8;
+    out[12].id   = isa.regid_make(isa.REG_CLASS_ID_XMM, 9);  # fs1 = f9
+    out[12].size = 8;
+    i = 0;
+    for (i < 10) {
+        out[13 + i].id   = isa.regid_make(isa.REG_CLASS_ID_XMM, 18 + i);  # fs2-fs11 = f18-f27
+        out[13 + i].size = 8;
+        i = i + 1;
+    }
+    ret CALLEE_SAVED_COUNT;
+}
+
+# the required stack alignment in bytes at a call boundary (16)
+# ---
+# ret: the alignment in bytes
+pub fun stack_align() u32 {
+    ret STACK_ALIGN;
+}
+
+# the size in bytes of the leaf-function red zone (0 -- RISC-V defines none)
+# ---
+# ret: the red-zone size in bytes
+pub fun red_zone() u32 {
+    ret RED_ZONE;
+}
+
+# the largest aggregate size in bytes returnable in registers (16)
+#
+# Aggregates larger than this are returned via an sret pointer.
+# ---
+# ret: the maximum register-return size in bytes
+pub fun max_reg_ret() u64 {
+    ret MAX_REG_RET;
+}
+
+# the lp64d call-side variadic-ABI model
+#
+# RISC-V encodes no caller vector-count register, so `vector_count_reg` is -1 (the
+# pre-call vector-count move is never emitted) and `float_dup_gp` is false. The
+# full RISC-V `va_list` callee surface is a separate, deferred concern; nothing here
+# carries it.
+# ---
+# ret: the lp64d call-side variadic model
+pub fun va_model() abi.VaModel {
+    var m: abi.VaModel;
+    m.kind             = abi.VA_MODEL_REG_SAVE;
+    m.float_dup_gp     = false;
+    m.vector_count_reg = -1;
+    ret m;
+}
+
+# the lp64d ABI vtable. populated by `register` on first call and handed out as a
+# borrowed pointer to the registry. its classify/arg/ret function pointers are
+# stored type-erased (`*u8`); consumers cast them back to
+# `ClassifyFn`/`ArgPassingFn`/`RetPassingFn`.
+var lp64_vtable: abi.AbiVTable;
+
+# build the lp64d AbiVTable and install it into `reg`
+#
+# Sets the convention name ("lp64") as an immutable `str` constant, wires the
+# type-erased classify/arg/ret operation pointers and the integer/float
+# argument-register and callee-saved register-file accessors, sets the 16-byte
+# stack alignment, no red zone, and no shadow space, and registers it under
+# `abi.ABI_LP64` so `target.select` can find it through `abi.lookup`. The hidden
+# sret pointer rides a0 (the first integer argument register), consuming a GP
+# argument slot, so `indirect_result_in_argfile` is true. Idempotent: the registry
+# entry is write-once.
+# ---
+# reg: the ABI registry to install the vtable into
+# ret: ok(true) on success
+pub fun register(reg: *abi.AbiRegistry) R.Result[bool, str] {
+    lp64_vtable.id           = abi.ABI_LP64;
+    lp64_vtable.name         = "lp64";
+    lp64_vtable.classify     = classify::*u8;
+    lp64_vtable.arg_passing  = classify_arg::*u8;
+    lp64_vtable.ret_passing  = classify_return::*u8;
+    lp64_vtable.gp_arg_regs  = gp_param_regs::*u8;
+    lp64_vtable.fp_arg_regs  = fp_param_regs::*u8;
+    lp64_vtable.callee_saved = callee_saved::*u8;
+    lp64_vtable.stack_align  = STACK_ALIGN;
+    lp64_vtable.red_zone     = RED_ZONE;
+    # lp64d reserves no caller shadow space -- stack arguments start at [sp+0].
+    lp64_vtable.shadow_space = 0;
+    # the hidden sret pointer rides a0, the first integer argument register, so
+    # `classify_signature` seeds gp_used = 1 for an sret return.
+    lp64_vtable.indirect_result_reg        = gp_param_reg(0);
+    lp64_vtable.indirect_result_in_argfile = true;
+    lp64_vtable.va_model                   = va_model::*u8;
+
+    abi.register(reg, ?lp64_vtable);
+    ret R.ok[bool, str](true);
+}
+
+# a scalar integer takes an integer argument register; a scalar float takes an fa
+# register
+test "mach.lang.target.abi.lp64.classify_arg:scalar_register_banks" {
+    val i: abi.ParamSlot = classify_arg(0, 8, 8, false, 0, false, 0, 0, 0, 0);
+    if (i.class != abi.CLASS_GP) { ret 1; }
+    if (i.reg != REG_A0)         { ret 1; }
+    val f: abi.ParamSlot = classify_arg(0, 8, 8, true, 0, false, 0, 0, 0, 0);
+    if (f.class != abi.CLASS_FP)  { ret 1; }
+    if (f.reg != fp_param_reg(0)) { ret 1; }
+    ret 0;
+}
+
+# the integer and float argument banks advance independently, and a float falls
+# back to an integer register then the stack once the fa bank is exhausted
+test "mach.lang.target.abi.lp64.classify_arg:banks_independent_and_float_fallback" {
+    # seven integer registers used: a scalar integer still has a7, a float still
+    # has fa0.
+    val i: abi.ParamSlot = classify_arg(0, 8, 8, false, 0, false, 7, 0, 0, 0);
+    if (i.class != abi.CLASS_GP) { ret 1; }
+    if (i.reg != REG_A0 + 7)     { ret 1; }
+    val f: abi.ParamSlot = classify_arg(0, 8, 8, true, 0, false, 7, 0, 0, 0);
+    if (f.class != abi.CLASS_FP)  { ret 1; }
+    if (f.reg != fp_param_reg(0)) { ret 1; }
+    # fa bank exhausted, an integer register remains: the float rides it.
+    val g: abi.ParamSlot = classify_arg(0, 8, 8, true, 0, false, 0, 8, 0, 0);
+    if (g.class != abi.CLASS_GP) { ret 1; }
+    if (g.reg != REG_A0)         { ret 1; }
+    # both banks exhausted: the float spills to the stack.
+    val s: abi.ParamSlot = classify_arg(0, 8, 8, true, 0, false, 8, 8, 0, 0);
+    if (s.class != abi.CLASS_STACK) { ret 1; }
+    ret 0;
+}
+
+# a 16-byte integer aggregate rides a consecutive integer pair; an 8-byte one a
+# single integer register; a >16-byte aggregate is passed by reference, on the
+# stack once the integer bank is exhausted
+test "mach.lang.target.abi.lp64.classify_arg:aggregate_placement" {
+    val s: abi.ParamSlot = classify_arg(0, 16, 8, false, 0, true, 0, 0, 0, 0);
+    if (s.class != abi.CLASS_GP) { ret 1; }
+    if (s.reg  != REG_A0)        { ret 1; }
+    if (s.reg2 != REG_A1)        { ret 1; }
+    val o: abi.ParamSlot = classify_arg(0, 8, 8, false, 0, true, 0, 0, 0, 0);
+    if (o.class != abi.CLASS_GP) { ret 1; }
+    if (o.reg  != REG_A0)        { ret 1; }
+    if (o.reg2 != -1)            { ret 1; }
+    # >16 bytes with an integer register free: the pointer rides it.
+    val b: abi.ParamSlot = classify_arg(0, 32, 8, false, 0, true, 0, 0, 0, 0);
+    if (b.class != abi.CLASS_BYREF) { ret 1; }
+    if (b.reg   != REG_A0)          { ret 1; }
+    # >16 bytes with the integer bank exhausted: the pointer is passed on the stack.
+    val e: abi.ParamSlot = classify_arg(0, 32, 8, false, 0, true, 8, 0, 0, 0);
+    if (e.class != abi.CLASS_STACK_BYREF) { ret 1; }
+    ret 0;
+}
+
+# scalar and small-aggregate returns place a0 / fa0 / a0:a1, and a >16-byte
+# aggregate returns through the a0 sret pointer
+test "mach.lang.target.abi.lp64.classify_return:placement" {
+    val v: abi.ParamSlot = classify_return(0, 0, false, 0, false, 0, 0);
+    if (v.class != abi.CLASS_GP || v.reg != -1) { ret 1; }
+    val i: abi.ParamSlot = classify_return(8, 8, false, 0, false, 0, 0);
+    if (i.reg != REG_A0) { ret 1; }
+    val f: abi.ParamSlot = classify_return(8, 8, true, 0, false, 0, 0);
+    if (f.class != abi.CLASS_FP || f.reg != fp_param_reg(0)) { ret 1; }
+    val a: abi.ParamSlot = classify_return(16, 8, false, 0, true, 0, 0);
+    if (a.reg != REG_A0 || a.reg2 != REG_A1) { ret 1; }
+    val r: abi.ParamSlot = classify_return(32, 8, false, 0, true, 0, 0);
+    if (r.class != abi.CLASS_SRET || r.reg != REG_A0) { ret 1; }
+    ret 0;
+}
+
+# the indirect-result pointer rides a0 inside the integer argument file
+test "mach.lang.target.abi.lp64.register:indirect_result_in_argfile" {
+    var reg: abi.AbiRegistry = abi.registry_init();
+    val r: R.Result[bool, str] = register(?reg);
+    if (R.is_err[bool, str](r))                            { ret 1; }
+    if (lp64_vtable.indirect_result_reg != gp_param_reg(0)) { ret 1; }
+    if (lp64_vtable.indirect_result_reg != REG_A0)          { ret 1; }
+    if (!lp64_vtable.indirect_result_in_argfile)            { ret 1; }
+    ret 0;
+}
+
+# the register-file accessors fill the canonical banks
+test "mach.lang.target.abi.lp64:register_file_banks" {
+    var gp: [8]isa.Register;
+    if (gp_param_regs(?gp[0]) != GP_PARAM_COUNT)        { ret 1; }
+    if (gp[0].id != REG_A0 || gp[7].id != REG_A0 + 7)  { ret 1; }
+    var fp: [8]isa.Register;
+    if (fp_param_regs(?fp[0]) != FP_PARAM_COUNT)                    { ret 1; }
+    if (fp[0].id != fp_param_reg(0) || fp[7].id != fp_param_reg(7)) { ret 1; }
+    var cs: [23]isa.Register;
+    if (callee_saved(?cs[0]) != CALLEE_SAVED_COUNT)            { ret 1; }
+    if (cs[0].id != REG_S1 || cs[10].id != REG_S2 + 9)        { ret 1; }
+    if (cs[11].id != isa.regid_make(isa.REG_CLASS_ID_XMM, 8)) { ret 1; }
+    if (cs[22].id != isa.regid_make(isa.REG_CLASS_ID_XMM, 27)) { ret 1; }
+    ret 0;
+}

--- a/src/lang/target/isa.mach
+++ b/src/lang/target/isa.mach
@@ -35,6 +35,7 @@ pub val ENDIAN_BIG:    Endian = 1;  # most-significant byte first
 pub val ARCH_UNKNOWN: u32 = 0;  # unrecognized or unset architecture
 pub val ARCH_X86_64:  u32 = 1;  # x86-64 (amd64)
 pub val ARCH_AARCH64: u32 = 2;  # 64-bit arm (aarch64)
+pub val ARCH_RISCV64: u32 = 3;  # 64-bit risc-v (rv64)
 
 # pseudo-opcodes shared by every ISA. they occupy the high end of the opcode
 # space so no real machine opcode collides with them. the backend emits these
@@ -442,11 +443,12 @@ pub rec IsaRegistry {
 
 # map a target isa name to its canonical architecture id
 # ---
-# name: target isa name ("x86_64", "aarch64")
+# name: target isa name ("x86_64", "aarch64", "riscv64")
 # ret:  the matching ARCH_* id, or ARCH_UNKNOWN if unrecognized
 pub fun arch_id_for(name: str) u32 {
     if (str_equals(name, "x86_64"))  { ret ARCH_X86_64; }
     if (str_equals(name, "aarch64")) { ret ARCH_AARCH64; }
+    if (str_equals(name, "riscv64")) { ret ARCH_RISCV64; }
     ret ARCH_UNKNOWN;
 }
 
@@ -457,6 +459,7 @@ pub fun arch_id_for(name: str) u32 {
 pub fun arch_name_for(id: u32) str {
     if (id == ARCH_X86_64)  { ret "x86_64"; }
     if (id == ARCH_AARCH64) { ret "aarch64"; }
+    if (id == ARCH_RISCV64) { ret "riscv64"; }
     ret "unknown";
 }
 
@@ -705,10 +708,13 @@ fun operand_blank(kind: OperandKind, size: u8) Operand {
 test "mach.lang.target.isa.arch_id_for:name_roundtrip" {
     if (arch_id_for("x86_64") != ARCH_X86_64)   { ret 1; }
     if (arch_id_for("aarch64") != ARCH_AARCH64) { ret 1; }
+    if (arch_id_for("riscv64") != ARCH_RISCV64) { ret 1; }
+    # the bare "riscv" family name is not a concrete isa; only "riscv64" resolves
     if (arch_id_for("riscv") != ARCH_UNKNOWN)   { ret 1; }
 
     if (!str_equals(arch_name_for(ARCH_X86_64), "x86_64"))   { ret 1; }
     if (!str_equals(arch_name_for(ARCH_AARCH64), "aarch64")) { ret 1; }
+    if (!str_equals(arch_name_for(ARCH_RISCV64), "riscv64")) { ret 1; }
     if (!str_equals(arch_name_for(ARCH_UNKNOWN), "unknown")) { ret 1; }
     ret 0;
 }

--- a/src/lang/target/isa/riscv64.mach
+++ b/src/lang/target/isa/riscv64.mach
@@ -1,0 +1,145 @@
+# RISC-V (RV64) register numbering and ABI register roles
+#
+# Owns the concrete register ids and the psABI register roles for RV64 - the leaf
+# definitions the sibling `riscv64` sub-modules build on. The register files and
+# the `isa.IsaVTable` are constructed and registered by `riscv64.register`; the
+# instruction selector and byte encoder land in later slices (`riscv64.isel` /
+# `riscv64.encode`). This module is data only and carries no logic; it mirrors the
+# register tables of `mach.lang.target.isa.x64` and `mach.lang.target.isa.arm64`.
+#
+# The integer file is x0-x31 and the floating-point file (the F/D extension the
+# lp64d convention passes scalars in) is f0-f31. The ids double as the 5-bit
+# register fields of the RISC-V instruction encoding, so they are used directly as
+# `Operand.reg` values throughout isel, regalloc, and encode.
+#
+# Everything in this module is XLEN-independent: the register numbering, the psABI
+# role assignments (sp=x2, ra=x1, fp=x8, t0-t6, ...), and the bank counts are
+# identical for RV32 and RV64. The register WIDTH lives in the `MachineModel`
+# (`riscv64.register`) and the calling convention in the lp64 ABI; an RV32 (ilp32)
+# sibling would reuse this file unchanged and differ only there. The "riscv64"
+# naming reflects the only target wired today, not a width assumption baked here.
+
+# integer register ids (x0-x31), the canonical RV64 GP numbers used directly as
+# `Operand.reg` values. x0 reads as hardwired zero and discards writes, so it is
+# reserved and never handed to the allocator.
+pub val X0:  i32 = 0;
+pub val X1:  i32 = 1;
+pub val X2:  i32 = 2;
+pub val X3:  i32 = 3;
+pub val X4:  i32 = 4;
+pub val X5:  i32 = 5;
+pub val X6:  i32 = 6;
+pub val X7:  i32 = 7;
+pub val X8:  i32 = 8;
+pub val X9:  i32 = 9;
+pub val X10: i32 = 10;
+pub val X11: i32 = 11;
+pub val X12: i32 = 12;
+pub val X13: i32 = 13;
+pub val X14: i32 = 14;
+pub val X15: i32 = 15;
+pub val X16: i32 = 16;
+pub val X17: i32 = 17;
+pub val X18: i32 = 18;
+pub val X19: i32 = 19;
+pub val X20: i32 = 20;
+pub val X21: i32 = 21;
+pub val X22: i32 = 22;
+pub val X23: i32 = 23;
+pub val X24: i32 = 24;
+pub val X25: i32 = 25;
+pub val X26: i32 = 26;
+pub val X27: i32 = 27;
+pub val X28: i32 = 28;
+pub val X29: i32 = 29;
+pub val X30: i32 = 30;
+pub val X31: i32 = 31;
+
+# psABI integer register roles. the calling convention and the frame discipline
+# name registers by role; these aliases keep the role intent legible at the use
+# site instead of a bare x-number. zero, ra, gp, and tp are architecturally fixed
+# and never allocatable; sp and fp are owned by the frame pass.
+pub val ZERO: i32 = X0;   # hardwired zero
+pub val RA:   i32 = X1;   # return address (the jal / jalr link register)
+pub val SP:   i32 = X2;   # stack pointer
+pub val GP:   i32 = X3;   # global pointer (set up at startup; never allocated)
+pub val TP:   i32 = X4;   # thread pointer (never allocated)
+pub val FP:   i32 = X8;   # frame pointer (s0)
+
+# the stack and frame pointers, named to match the x64 / arm64 spelling the frame
+# pass reads. both are reserved and never handed to the allocator.
+pub val STACK_REG: i32 = SP;
+pub val FRAME_REG: i32 = FP;
+
+# the integer temporaries t0-t6 (x5-x7, x28-x31). they carry no ABI argument role,
+# so the back end draws its address-materialization, two-register lowering, and
+# spill-reload scratch from them; t5 / t6 stay allocatable for values.
+pub val T0: i32 = X5;
+pub val T1: i32 = X6;
+pub val T2: i32 = X7;
+pub val T3: i32 = X28;
+pub val T4: i32 = X29;
+pub val T5: i32 = X30;
+pub val T6: i32 = X31;
+
+# the scratch registers the back end reserves from value allocation. `SCRATCH_REG`
+# (t0) and `SCRATCH_REG2` (t1) are the encoder's address-materialization and
+# two-register lowering scratch - the RV64 analogue of AArch64 IP0/IP1. the
+# reload-scratch pool (t2, t3, t4) covers the worst-case simultaneous spill
+# reloads of one instruction's base, index, and value operands. five temporaries
+# are consumed; t5 and t6 remain in the allocatable value pool.
+pub val SCRATCH_REG:  i32 = T0;
+pub val SCRATCH_REG2: i32 = T1;
+
+# floating-point register ids (f0-f31), a distinct id space from the integer
+# registers. the lp64d convention passes float scalars in this file. a physical
+# float id is carried composite (the float class tag in the high byte, via
+# `isa.regid_make`) so a float value is never aliased onto the integer register of
+# the same index.
+pub val F0:  i32 = 0;
+pub val F1:  i32 = 1;
+pub val F2:  i32 = 2;
+pub val F3:  i32 = 3;
+pub val F4:  i32 = 4;
+pub val F5:  i32 = 5;
+pub val F6:  i32 = 6;
+pub val F7:  i32 = 7;
+pub val F8:  i32 = 8;
+pub val F9:  i32 = 9;
+pub val F10: i32 = 10;
+pub val F11: i32 = 11;
+pub val F12: i32 = 12;
+pub val F13: i32 = 13;
+pub val F14: i32 = 14;
+pub val F15: i32 = 15;
+pub val F16: i32 = 16;
+pub val F17: i32 = 17;
+pub val F18: i32 = 18;
+pub val F19: i32 = 19;
+pub val F20: i32 = 20;
+pub val F21: i32 = 21;
+pub val F22: i32 = 22;
+pub val F23: i32 = 23;
+pub val F24: i32 = 24;
+pub val F25: i32 = 25;
+pub val F26: i32 = 26;
+pub val F27: i32 = 27;
+pub val F28: i32 = 28;
+pub val F29: i32 = 29;
+pub val F30: i32 = 30;
+pub val F31: i32 = 31;
+
+# number of integer registers exposed as the gpr register class (x0-x31). the
+# architecturally-fixed and frame-owned role registers (zero, ra, sp, gp, tp, fp)
+# sit inside this range and are held off the allocator through the ISA vtable's
+# reserved-register list.
+pub val GPR_COUNT: i32 = 32;
+
+# number of floating-point registers exposed as the fpr register class (f0-f29).
+# f30 and f31 (ft10 / ft11) are held back as the two fixed FP scratch registers
+# the float-op encoder routes spilled operands through - the RV64 analogue of
+# x86-64 holding XMM14/XMM15 and AArch64 holding V30/V31 back from the value pool.
+# two are required: a binary float op whose destination and both sources are all
+# spilled needs two FP registers live at once to materialize the three-address
+# form, which one scratch cannot supply.
+pub val FPR_COUNT: i32 = 30;

--- a/src/lang/target/isa/riscv64/register.mach
+++ b/src/lang/target/isa/riscv64/register.mach
@@ -1,0 +1,204 @@
+# RISC-V (RV64) ISA vtable registration
+#
+# The composition seam for the RV64 backend: it imports the ISA definitions
+# (`riscv64`) and wires a machine description into an `IsaVTable` installed in the
+# registry. It mirrors `isa.x64.register` and `isa.arm64.register`, living in its
+# own module so wiring future children (the selector and encoder) into the parent
+# does not close an import cycle.
+#
+# This is slice 1 of the RV64 backend: the machine description only. The codegen
+# hooks (`select` / `encode` / `emit_asm` / `asm_clobbers` / `apply_reloc`) are left
+# nil - the shared isel / encode dispatchers and the linker error loudly on a nil
+# slot, exactly as they do for an unregistered ISA, so a riscv64 target composes and
+# resolves cleanly while any attempt to actually generate code fails with a precise
+# message. Later slices supply `riscv64.isel`, `riscv64.encode`, and the
+# `apply_reloc` registrar and point these slots at them.
+
+use std.types.bool.bool;
+use std.types.bool.true;
+use std.types.string.str;
+
+use R: std.types.result;
+
+use mach.lang.target.isa;
+use mach.lang.target.isa.riscv64;
+
+# process-global storage for the RV64 vtable and its register classes. written
+# once by `register_riscv64` and borrowed by the vtable installed into the ISA
+# registry; lives for the process lifetime. RISC-V has no condition-flags register
+# (branches compare two GP registers directly), so the model declares only the two
+# real banks - gpr and fpr - and no RC_FLAGS class.
+var riscv64_vtable:  isa.IsaVTable;
+var riscv64_classes: [2]isa.RegClass;
+
+# process-global storage for the RV64 machine-model template. written once by
+# `register_riscv64` and pointed to by the vtable's `model` field; `target.select`
+# copies it by value and overlays the selected abi's stack scalars. lives for the
+# process lifetime. its register-file pointers borrow the same per-arch arrays the
+# vtable does (`riscv64_classes`, `riscv64_reload_scratch_regs`,
+# `riscv64_reserved_regs`).
+var riscv64_model: isa.MachineModel;
+
+# the registers the allocator must never assign: the hardwired-zero register (x0),
+# the return-address / link register (ra), the stack pointer (sp), the global and
+# thread pointers (gp / tp, fixed by the startup environment), and the frame
+# pointer (s0/fp). borrowed by the vtable's `reserved_regs` field; lives for the
+# process lifetime. filled by `register_riscv64`.
+var riscv64_reserved_regs: [6]isa.Register;
+
+# the integer temporaries (t2/t3/t4) the allocator reserves from value allocation
+# and draws spill-reload temporaries from. a single high-pressure instruction can
+# reload its memory base, scaled index, and value operands at once, so three
+# temporaries cover the worst case. these are caller-saved temporaries distinct
+# from t0/t1 (`scratch_reg` / `scratch_reg2`), which the encoder claims for address
+# materialization and two-register lowering. borrowed by the vtable's
+# `reload_scratch_regs` field; lives for the process lifetime. filled by
+# `register_riscv64`.
+var riscv64_reload_scratch_regs: [3]isa.Register;
+
+# build and install the RV64 ISA vtable
+#
+# Sets the architecture and register-class names, fills the two register classes
+# (gpr 64x32 for x0-x31, fpr 64x30 for f0-f29 with f30/f31 held back as FP
+# scratch), and populates the vtable with the pointer width (8 bytes / 64 bits),
+# the EM_RISCV ELF machine type (243), the reserved registers (zero/ra/sp/gp/tp/fp),
+# the reload-scratch pool (t2/t3/t4), the scratch identities (t0/t1 and the
+# composite f31 FP scratch), the frame/stack pointers (fp/sp), and -1 for the
+# division / shift register identities (RV64 wires none: div / rem write a normal
+# destination and a variable shift rides any register). Installs the result into
+# `reg`. Idempotent: the registry entry is write-once. Must run at compiler startup
+# before `target.select` requests a riscv64 target.
+#
+# This is the slice-1 machine description: the `select` / `encode` / `emit_asm` /
+# `asm_clobbers` / `apply_reloc` codegen hooks are left nil and the shared
+# dispatchers error loudly when reached, so the target composes but generates no
+# code yet. Later slices wire the hooks.
+# ---
+# reg: the ISA registry to install the vtable into
+# ret: true on success
+pub fun register_riscv64(reg: *isa.IsaRegistry) R.Result[bool, str] {
+    riscv64_classes[0].name      = "gpr";
+    riscv64_classes[0].kind      = isa.RC_GENERAL;
+    riscv64_classes[0].bit_width = 64;
+    riscv64_classes[0].len       = riscv64.GPR_COUNT::u32;
+
+    # the fpr bank exposes f0-f29 (count 30) to the allocator. f30 and f31
+    # (ft10 / ft11) are held back as the two fixed FP scratch registers the float-op
+    # encoder routes spilled operands through, so a live float vreg can never occupy
+    # one and be clobbered. the F/D extension registers are 64 bits wide under
+    # lp64d, the same width as the integer registers - unlike x86-64 / AArch64 whose
+    # 128-bit vector bank the shared float-bank lookup keys on by width.
+    riscv64_classes[1].name      = "fpr";
+    riscv64_classes[1].kind      = isa.RC_FLOAT;
+    riscv64_classes[1].bit_width = 64;
+    riscv64_classes[1].len       = riscv64.FPR_COUNT::u32;
+
+    riscv64_reserved_regs[0].id   = riscv64.ZERO;
+    riscv64_reserved_regs[0].size = 8;
+    riscv64_reserved_regs[1].id   = riscv64.RA;
+    riscv64_reserved_regs[1].size = 8;
+    riscv64_reserved_regs[2].id   = riscv64.SP;
+    riscv64_reserved_regs[2].size = 8;
+    riscv64_reserved_regs[3].id   = riscv64.GP;
+    riscv64_reserved_regs[3].size = 8;
+    riscv64_reserved_regs[4].id   = riscv64.TP;
+    riscv64_reserved_regs[4].size = 8;
+    riscv64_reserved_regs[5].id   = riscv64.FP;
+    riscv64_reserved_regs[5].size = 8;
+
+    riscv64_reload_scratch_regs[0].id   = riscv64.T2;
+    riscv64_reload_scratch_regs[0].size = 8;
+    riscv64_reload_scratch_regs[1].id   = riscv64.T3;
+    riscv64_reload_scratch_regs[1].size = 8;
+    riscv64_reload_scratch_regs[2].id   = riscv64.T4;
+    riscv64_reload_scratch_regs[2].size = 8;
+
+    riscv64_vtable.id                   = isa.ARCH_RISCV64;
+    riscv64_vtable.name                 = "riscv64";
+    riscv64_vtable.elf_machine          = 243;  # EM_RISCV
+    riscv64_vtable.pointer_width        = 8;
+    riscv64_vtable.reg_classes          = ?riscv64_classes[0];
+    riscv64_vtable.reg_class_count      = 2;
+    # slice 1 wires no codegen hooks: nil is the dispatchers' clean "unimplemented"
+    # signal. later slices point these at the riscv64 selector / encoder / printer /
+    # inline-asm analyzer, and the linker's apply_reloc registrar at its patcher.
+    riscv64_vtable.select               = nil;
+    riscv64_vtable.encode               = nil;
+    riscv64_vtable.emit_asm             = nil;
+    riscv64_vtable.asm_clobbers         = nil;
+    riscv64_vtable.apply_reloc          = nil;
+    riscv64_vtable.reserved_regs        = ?riscv64_reserved_regs[0];
+    riscv64_vtable.reserved_reg_count   = 6;
+    riscv64_vtable.reload_scratch_regs  = ?riscv64_reload_scratch_regs[0];
+    riscv64_vtable.reload_scratch_count = 3;
+    riscv64_vtable.scratch_reg          = riscv64.SCRATCH_REG;
+    riscv64_vtable.scratch_reg2         = riscv64.SCRATCH_REG2;
+    # the FP scratch is a composite register id (the float class tag in the high
+    # byte), mirroring x86-64's FP_SCRATCH_REG and AArch64's V31 - a raw bank index
+    # would read as an integer register. the encoder pairs it with f30 (the second
+    # held-back scratch) for the both-sources-spilled binary float case.
+    riscv64_vtable.fp_scratch_reg       = isa.regid_make(isa.REG_CLASS_ID_XMM, riscv64.F31);
+    riscv64_vtable.frame_ptr_reg        = riscv64.FP;
+    riscv64_vtable.stack_ptr_reg        = riscv64.SP;
+    # the RV64 frame discipline sets s0/fp to the canonical frame address (the stack
+    # pointer at entry) and saves ra / old-fp below it, so incoming stack arguments
+    # sit at [fp+0] - unlike x86-64 / AArch64, whose saved frame record pushes the
+    # first incoming stack argument to [fp+16].
+    riscv64_vtable.incoming_arg_base    = 0;
+    # RV64 div / divu / rem / remu write a normal destination register and a shift
+    # count rides the low bits of any register, so the ISA wires no fixed division /
+    # shift register: -1 for all three.
+    riscv64_vtable.div_reg              = -1;
+    riscv64_vtable.div_hi_reg           = -1;
+    riscv64_vtable.shift_count_reg      = -1;
+
+    # the machine-model template the shared stages read. widths are in bytes; the
+    # register-file pointers borrow the same per-arch arrays the vtable does; the
+    # stack scalars stay 0 here and are overlaid by `target.select` from the abi.
+    #
+    # these four width fields and the two register-class bit_widths above are the
+    # ONLY RV64-specific (XLEN=64) values in the machine description - everything
+    # else (the register file, roles, scratch ids, addressing capability, frame
+    # facts) is XLEN-independent. an RV32 (ilp32) sibling would set 4-byte widths
+    # and 32-bit class widths here and reuse the rest unchanged.
+    riscv64_model.pointer_width   = 8;
+    riscv64_model.gpr_width       = 8;
+    riscv64_model.index_width     = 8;
+    riscv64_model.spill_width     = 8;
+    riscv64_model.endianness      = isa.ENDIAN_LITTLE;
+
+    riscv64_model.reg_classes     = ?riscv64_classes[0];
+    riscv64_model.reg_class_len   = 2;
+    riscv64_model.frame_ptr_reg   = riscv64.FP;
+    riscv64_model.stack_ptr_reg   = riscv64.SP;
+    riscv64_model.scratch_regs    = ?riscv64_reload_scratch_regs[0];
+    riscv64_model.scratch_len     = 3;
+    riscv64_model.reserved_regs   = ?riscv64_reserved_regs[0];
+    riscv64_model.reserved_len    = 6;
+    riscv64_model.div_reg         = -1;
+    riscv64_model.div_hi_reg      = -1;
+    riscv64_model.shift_count_reg = -1;
+
+    # RV64 addressing is base + 12-bit signed displacement only: there is no
+    # scaled-index form (so ADDR_BASE_INDEX is absent and `addr_scales` is empty) and
+    # no absolute [disp] form (constant addresses are materialized into a register).
+    # symbol references are pc-relative (the auipc-based `la` sequence), so
+    # ADDR_PCREL is present. the displacement field of a load / store immediate is a
+    # signed 12-bit.
+    riscv64_model.addr_forms      = isa.ADDR_BASE | isa.ADDR_BASE_DISP | isa.ADDR_PCREL;
+    riscv64_model.addr_scales     = 0;
+    riscv64_model.addr_disp_bits  = 12;
+
+    riscv64_model.stack_grows_down  = true;
+    riscv64_model.fp_relative_frame = true;
+    riscv64_model.incoming_arg_base = 0;
+    riscv64_model.stack_align       = 0;
+    riscv64_model.red_zone          = 0;
+    riscv64_model.shadow_space      = 0;
+
+    riscv64_vtable.model = ?riscv64_model;
+
+    isa.register(reg, ?riscv64_vtable);
+
+    ret R.ok[bool, str](true);
+}


### PR DESCRIPTION
Slice 1 of the riscv64 backend (#1172), the first brand-new target on the v2.6.0 retargeting foundation (epic #1180). **Machine description only - no instruction selection or encoding.** A riscv64-linux target now composes and `select`s cleanly; any attempt to actually generate code fails loudly through the foundation's nil-guards.

## What landed

- `src/lang/target/isa/riscv64.mach` - RV64 register file (x0-x31 integer, f0-f31 float) with psABI role assignments. XLEN-independent (no width literals).
- `src/lang/target/isa/riscv64/register.mach` - `register_riscv64`: the `IsaVTable` + `MachineModel`. EM_RISCV (243), 64-bit widths, two banks (gpr 32, fpr 30 - no flags bank, RISC-V has no condition-flags register), base + 12-bit-disp + pc-relative addressing (no scaled index), downward little-endian frame. Reserved: zero/ra/sp/gp/tp/fp. Scratch: t0/t1 encoder + t2/t3/t4 reload + f31 FP scratch (f30 its pair). All codegen hooks nil.
- `src/lang/target/abi/lp64.mach` - lp64d `AbiVTable`: int args a0-a7 / ret a0:a1, float args fa0-fa7 / ret fa0:fa1, callee-saved s1-s11 + fs0-fs11, sret in a0 (in argfile), 16-byte stack align, no red zone.
- Shared plumbing: `ARCH_RISCV64` / `ABI_LP64` ids, `arch_id_for`/`arch_name_for`, the `$mach.arch.riscv64` / `$mach.abi.lp64` comptime tags, the driver unknown-isa diagnostic, and `register_all` wiring + a selection test.

## Stubbed / deferred (later slices)

- `select` / `encode` / `emit_asm` / `asm_clobbers` / `apply_reloc` are nil. The shared isel/encode dispatchers and the linker error loudly on a nil slot, exactly as for an unregistered ISA.
- lp64d hard-float struct-flattening (one/two FP-member structs in fa registers) and the 9-16 byte register/stack split: deferred to ABI completion. Scalar + large-aggregate classification is complete.
- Foundation gap surfaced (not worked around): the shared float-bank lookup `fp_class_index` keys on `bit_width >= 128`, but RV64D FPRs are 64-bit. The model declares the truthful 64-bit fpr width; the float-codegen slice needs that lookup changed to find the bank by `RC_FLOAT` kind (parallel to `gp_class_index`). Not exercised in slice 1 (no codegen).

## Verification

- `mach build .` succeeds.
- `mach test .` 619 passed, 0 failed (612 baseline + 6 lp64 ABI tests + 1 riscv64 selection test).
- Default x86_64 codegen path untouched (additive registration + one diagnostic string only). Self-host fixpoint confirmed: the freshly built compiler rebuilds itself byte-identically (stage b == stage c).

## Notes

- File layout mirrors the actual x64/arm64 split (`isa/<arch>.mach` = register defs, `isa/<arch>/register.mach` = vtable+model), which is the inverse of the task's literal description but keeps riscv64 consistent with the two existing backends and the `use <arch>: ...isa.<arch>.register` import convention.
- No shared-backend (be/codegen/*, regalloc, frame, linker core) edits.
