### PR TITLE
feat(fe): secret type qualifier '^' and ':^' strip-cast (frontend)

### DIFF
--- a/doc/language/grammar.md
+++ b/doc/language/grammar.md
@@ -51,7 +51,7 @@ token ::= IDENT
 punctuation ::= "(" | ")" | "{" | "}" | "[" | "]"
               | ";" | ":" | "," | "." | "?" | "@" | "$" | "`"
               | "#["    (* attribute-open: "#" immediately followed by "[" *)
-              | "::" | ":~" | "..."
+              | "::" | ":~" | ":^" | "..."
 
 operator ::= "+" | "-" | "*" | "/" | "%"
            | "&" | "|" | "^" | "~"
@@ -66,9 +66,11 @@ Notes:
   tokens; the parser recognizes them contextually by their text
   (`at_kw` / `eat_kw` in `parser/state.mach`). The same applies to the
   primitive type names and `nil`.
-- The maximal-munch multi-character operators are `::`, `:~`, `...`, `==`,
-  `!=`, `<=`, `<<`, `>=`, `>>`, `&&`, `||`. A leading `:` lexes as `::` or
-  `:~` before a bare `:`, so `expr:~Type` is one cast, never `:` then `~`.
+- The maximal-munch multi-character operators are `::`, `:~`, `:^`, `...`,
+  `==`, `!=`, `<=`, `<<`, `>=`, `>>`, `&&`, `||`. A leading `:` lexes as `::`,
+  `:~`, or `:^` before a bare `:`, so `expr:~Type` is one cast, never `:` then
+  `~`. A space after the annotation colon (`k: ^[32]u8`) keeps `:` and `^`
+  separate, the same adjacency rule `::`/`:~` rely on.
 - The lexer recognizes the standalone characters `=`, `!`, `<`, `>`, `&`,
   `|` and the two-character forms above. There is no `+=`, `-=`, etc. —
   compound assignment does not exist.
@@ -379,17 +381,19 @@ a statement-list body (see [Statements](#statements)).
 ## Types
 
 ```ebnf
-type ::= ptr-type
+type ::= secret-type
+       | ptr-type
        | array-type
        | fun-type
        | rec-type
        | uni-type
        | named-type
 
-ptr-type   ::= "*" type
-array-type ::= "[" expr "]" type
-named-type ::= dotted-path [ type-args ]
-type-args  ::= "[" [ type { "," type } [ "," ] ] "]"
+secret-type ::= "^" type
+ptr-type    ::= "*" type
+array-type  ::= "[" expr "]" type
+named-type  ::= dotted-path [ type-args ]
+type-args   ::= "[" [ type { "," type } [ "," ] ] "]"
 
 fun-type ::= "fun" "(" [ fun-type-params ] ")" [ type ]
 fun-type-params ::= "..."
@@ -401,6 +405,11 @@ anon-field-block ::= "{" { IDENT ":" type ";" } "}"
 ```
 
 Notes:
+- `^T` marks `T` as carrying secret data for the constant-time guarantee
+  (#1643). It is a prefix qualifier binding to the type immediately to its
+  right, so it nests with `*` and `[N]` in any order (`*^u8`, `^*u8`,
+  `[N]^u8`). The grammar accepts it in every type position; its flow-typing
+  semantics are not yet enforced (tracked by #1645).
 - `*T` is a pointer; the untyped pointer type is the primitive name `ptr`
   (an ordinary `named-type`, not its own syntax).
 - `[N]T` is a fixed-length array; `N` is a full expression (a comptime
@@ -474,10 +483,16 @@ index        ::= "[" expr "]"
 member       ::= "." IDENT
 project      ::= "." "[" expr "]"          (* v.[f]: comptime field projection *)
 cast         ::= ( "::" | ":~" ) type
+              | ":^" [ named-type ]        (* secret-qualifier strip cast *)
 ```
 
 `::` is a value conversion and `:~` a same-size bit reinterpret; see
-[operators.md](operators.md#cast). Both bind as postfix.
+[operators.md](operators.md#cast). `:^` strips the `^` secret qualifier from
+the operand's type (#1643): a bare `:^` needs no target, while `:^Type` takes
+an optional named target for parallelism with `:~Type`. A non-`named-type`
+lead (`*`, `[`, ...) after `:^` leaves a bare strip so it still binds as a
+multiply/index on the stripped value. Its semantics are not yet enforced
+(tracked by #1645). All three bind as postfix.
 
 Disambiguating a postfix `[`: a bracket whose matching `]` is **not** followed
 by `(` is always an index `obj[idx]`. When it **is** followed by `(`, the

--- a/src/lang/fe/ast/expr.mach
+++ b/src/lang/fe/ast/expr.mach
@@ -33,6 +33,10 @@ pub val EXPR_KIND_PROJECT:        ExprKind = 16;
 # whole comptime variadic pack into a trailing pack parameter. recognized only
 # in call-argument position, never globally in the postfix grammar.
 pub val EXPR_KIND_SPREAD:         ExprKind = 17;
+# a `value:^` / `value:^Type` secret-qualifier strip cast (#1643), a postfix
+# member of the `::`/`:~` cast family. flow-typing semantics land in #1645; the
+# parser only records the node.
+pub val EXPR_KIND_STRIP:          ExprKind = 18;
 pub val EXPR_KIND_ERROR:          ExprKind = 255;
 
 # binary operator encoded in ExprBinary.op
@@ -164,6 +168,20 @@ pub rec ExprCast {
     reinterpret: bool;
 }
 
+# a secret-qualifier strip cast `value:^` or `value:^Type`
+#
+# `:^` removes the `^` secret qualifier from the operand's type. the target type
+# is optional: a bare `:^` strips the qualifier in place, while `:^Type` strips
+# to an explicit named type for parallelism with `:~Type`. flow-typing semantics
+# land in #1645; the parser only records the node.
+# ---
+# value: expression whose qualifier is stripped
+# ty:    explicit target type, or TYPE_NIL for a bare `:^`
+pub rec ExprStrip {
+    value: id.ExprId;
+    ty:    id.TypeId;
+}
+
 # an array literal `[N]T{a, b, c}`
 # ---
 # ty:          declared array type including length and element type
@@ -213,6 +231,7 @@ pub rec Expr {
         index:      ExprIndex;
         member:     ExprMember;
         cast:       ExprCast;
+        strip:      ExprStrip;
         array_lit:  ExprArrayLit;
         struct_lit: ExprStructLit;
         project:    ExprProject;

--- a/src/lang/fe/ast/type.mach
+++ b/src/lang/fe/ast/type.mach
@@ -22,6 +22,10 @@ pub val TYPE_KIND_UNI:   TypeKind = 5;
 # `fun f(va: ...)`. carries no payload; the pack's element types are fixed per
 # call site and supplied by monomorphization, not at declaration.
 pub val TYPE_KIND_PACK:  TypeKind = 6;
+# a secret-qualified type `^T` (#1643): marks the inner type as carrying secret
+# data for the constant-time guarantee. flow-typing semantics land in #1645; the
+# parser only records the qualifier.
+pub val TYPE_KIND_SECRET: TypeKind = 7;
 pub val TYPE_KIND_ERROR: TypeKind = 255;
 
 # a named type reference, optionally with generic arguments
@@ -40,6 +44,16 @@ pub rec TypeNamed {
 # pointee: element type being pointed to
 pub rec TypePtr {
     pointee: id.TypeId;
+}
+
+# a secret-qualified type ^T
+#
+# `^` binds to the type constructor immediately to its right and nests freely
+# with `*` and `[N]` (`*^u8`, `[N]^u8`). flow-typing semantics land in #1645.
+# ---
+# inner: the qualified type
+pub rec TypeSecret {
+    inner: id.TypeId;
 }
 
 # a fixed-length array type [N]T
@@ -89,11 +103,12 @@ pub rec Type {
     span: token.Span;
     kind: TypeKind;
     data: uni {
-        named: TypeNamed;
-        ptr:   TypePtr;
-        array: TypeArray;
-        fun_:  TypeFun;
-        rec_:  TypeRec;
-        uni_:  TypeUni;
+        named:  TypeNamed;
+        ptr:    TypePtr;
+        secret: TypeSecret;
+        array:  TypeArray;
+        fun_:   TypeFun;
+        rec_:   TypeRec;
+        uni_:   TypeUni;
     };
 }

--- a/src/lang/fe/lexer.mach
+++ b/src/lang/fe/lexer.mach
@@ -164,6 +164,10 @@ pub fun tokenize(source: str, alloc: *A.Allocator, file_id: src.FileId) R.Result
                 tok = token.make(token.KIND_COLON_TILDE, pos, 2);
                 pos = pos + 2;
             }
+            or (source[pos + 1] == '^') {
+                tok = token.make(token.KIND_COLON_CARET, pos, 2);
+                pos = pos + 2;
+            }
             or {
                 tok = token.make(token.KIND_COLON, pos, 1);
                 pos = pos + 1;
@@ -907,5 +911,45 @@ test "mach.lang.fe.lexer.doc_run_above:skips_attribute_lines" {
     }
 
     dnit(?stream, ?alloc);
+    ret rc;
+}
+
+# an adjacent `:^` lexes as the one strip-cast token KIND_COLON_CARET, while a
+# space after the annotation colon (`k: ^[32]u8`) keeps `:` and `^` separate.
+# the same maximal-munch adjacency rule `::` and `:~` already rely on.
+test "mach.lang.fe.lexer.tokenize:colon_caret_adjacency" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+
+    # (1) adjacent `:^` is one KIND_COLON_CARET token spanning 2 bytes
+    val tr1: R.Result[TokenStream, str] = tokenize("k:^", ?alloc, 0::src.FileId);
+    if (R.is_err[TokenStream, str](tr1)) { ret 1; }
+    var s1: TokenStream = R.unwrap_ok[TokenStream, str](tr1);
+    var rc: i32 = 0;
+    # ident + `:^` + EOF = 3, no lex error
+    if (s1.len != 3)       { rc = 1; }
+    or (s1.error_len != 0) { rc = 1; }
+    or {
+        if (s1.tokens[0].kind != token.KIND_IDENT)       { rc = 1; }
+        or (s1.tokens[1].kind != token.KIND_COLON_CARET) { rc = 1; }
+        or (s1.tokens[1].span.offset != 1)               { rc = 1; }
+        or (s1.tokens[1].span.len    != 2)               { rc = 1; }
+        or (s1.tokens[2].kind != token.KIND_EOF)         { rc = 1; }
+    }
+    dnit(?s1, ?alloc);
+    if (rc != 0) { ret rc; }
+
+    # (2) `k: ^[32]u8`: the space keeps the annotation `:` and the `^` qualifier
+    # apart, so `:` lexes as KIND_COLON and `^` as KIND_CARET, never `:^`
+    val tr2: R.Result[TokenStream, str] = tokenize("k: ^[32]u8", ?alloc, 0::src.FileId);
+    if (R.is_err[TokenStream, str](tr2)) { ret 1; }
+    var s2: TokenStream = R.unwrap_ok[TokenStream, str](tr2);
+    if (s2.error_len != 0) { rc = 1; }
+    or {
+        if (s2.tokens[0].kind != token.KIND_IDENT) { rc = 1; }
+        or (s2.tokens[1].kind != token.KIND_COLON) { rc = 1; }
+        or (s2.tokens[2].kind != token.KIND_CARET) { rc = 1; }
+    }
+    dnit(?s2, ?alloc);
     ret rc;
 }

--- a/src/lang/fe/parser/expr.mach
+++ b/src/lang/fe/parser/expr.mach
@@ -85,6 +85,7 @@ pub fun parse_expr_bp(p: *state.Parser, min_bp: u8) id.ExprId {
 pub fun parse_type(p: *state.Parser) id.TypeId {
     val start: token.Token = state.current(p);
 
+    if (state.at(p, token.KIND_CARET))    { ret parse_secret(p, start.span); }
     if (state.at(p, token.KIND_STAR))     { ret parse_ptr(p, start.span); }
     if (state.at(p, token.KIND_LBRACKET)) { ret parse_array(p, start.span); }
     if (state.at_kw(p, "fun"))            { ret parse_fun(p, start.span); }
@@ -179,6 +180,7 @@ fun parse_postfix(p: *state.Parser, base: id.ExprId) id.ExprId {
         }
         or (k == token.KIND_COLON_COLON) { lhs = parse_cast(p, lhs, false); }
         or (k == token.KIND_COLON_TILDE) { lhs = parse_cast(p, lhs, true); }
+        or (k == token.KIND_COLON_CARET) { lhs = parse_strip(p, lhs); }
         or {
             brk;
         }
@@ -747,6 +749,42 @@ fun parse_cast(p: *state.Parser, value: id.ExprId, reinterpret: bool) id.ExprId 
     ret state.push_expr(p, node);
 }
 
+# parses a secret-qualifier strip cast `value:^` or `value:^Type`
+#
+# `:^` removes the `^` qualifier from the operand's type. the target type is
+# optional and, when present, a named type: a following IDENT (which cannot
+# continue an expression here) is read as the target, while any other lead
+# leaves a bare strip so the postfix/infix machinery still binds `*`/`[` as a
+# multiply/index on the stripped value. flow-typing semantics land in #1645; the
+# parser only records the node.
+# ---
+# p:     parser state, cursor on ':^'
+# value: expression whose qualifier is stripped
+# ret:   ExprId of the EXPR_KIND_STRIP node
+fun parse_strip(p: *state.Parser, value: id.ExprId) id.ExprId {
+    val op: token.Token = state.current(p);
+    state.advance(p);
+
+    var ty: id.TypeId = id.TYPE_NIL;
+    if (state.at(p, token.KIND_IDENT)) {
+        ty = parse_type(p);
+    }
+
+    var strip: expr.ExprStrip;
+    strip.value = value;
+    strip.ty    = ty;
+
+    val start_span: token.Span = expr_span_or(p, value, op.span);
+    var end_span:   token.Span = op.span;
+    if (ty != id.TYPE_NIL) { end_span = type_span_or(p, ty, op.span); }
+
+    var node: expr.Expr;
+    node.span       = state.span_of(start_span, end_span);
+    node.kind       = expr.EXPR_KIND_STRIP;
+    node.data.strip = strip;
+    ret state.push_expr(p, node);
+}
+
 # parses an array literal `[N]T{a, b, c}`
 # ---
 # p:   parser state, cursor on '['
@@ -1016,6 +1054,31 @@ fun parse_ptr(p: *state.Parser, start: token.Span) id.TypeId {
     t.span     = state.span_of(start, end_span);
     t.kind     = type.TYPE_KIND_PTR;
     t.data.ptr = ptr;
+    ret state.push_type(p, t);
+}
+
+# parses a secret-qualified type `^T`
+#
+# `^` binds to the type constructor immediately to its right, so the qualifier
+# nests with `*` and `[N]` through the recursion (`*^u8`, `^*u8`, `[N]^u8`). the
+# infix XOR `^` never reaches here: a type never begins with an infix operator.
+# ---
+# p:     parser state, cursor on '^'
+# start: span of the leading '^' token
+# ret:   TypeId of the resulting TYPE_KIND_SECRET node
+fun parse_secret(p: *state.Parser, start: token.Span) id.TypeId {
+    state.advance(p);
+    val inner: id.TypeId = parse_type(p);
+
+    var secret: type.TypeSecret;
+    secret.inner = inner;
+
+    val end_span: token.Span = type_span_or(p, inner, start);
+
+    var t: type.Type;
+    t.span        = state.span_of(start, end_span);
+    t.kind        = type.TYPE_KIND_SECRET;
+    t.data.secret = secret;
     ret state.push_type(p, t);
 }
 
@@ -1364,6 +1427,191 @@ test "mach.lang.fe.parser.expr.parse_expr:chained_call_provisional_inner" {
         if (inner.kind != expr.EXPR_KIND_CALL)           { rc = 1; }
         or (inner.data.call.index_callee == id.EXPR_NIL) { rc = 1; }
     }
+    if (diagnostic.has_errors(?diags)) { rc = 1; }
+
+    diagnostic.dnit(?diags);
+    ast.dnit(?a);
+    lexer.dnit(?stream, ?alloc);
+    ret rc;
+}
+
+# the secret qualifier `^` parses as a prefix type constructor that nests with
+# `*` and `[N]` in every order, binding to the type immediately to its right
+test "mach.lang.fe.parser.expr.parse_type:secret_qualifier_round_trips" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+
+    var rc: i32 = 0;
+
+    # (1) `^u32`: SECRET wrapping a NAMED type
+    val tr1: R.Result[lexer.TokenStream, str] = lexer.tokenize("^u32", ?alloc, 0::source.FileId);
+    if (R.is_err[lexer.TokenStream, str](tr1)) { ret 1; }
+    var s1: lexer.TokenStream   = R.unwrap_ok[lexer.TokenStream, str](tr1);
+    var a1: ast.Ast             = ast.init(?alloc, 0::source.FileId);
+    var d1: diagnostic.DiagList = diagnostic.init(?alloc);
+    var p1: state.Parser        = state.make(?s1, ?a1, ?d1);
+    val t1: id.TypeId           = parse_type(?p1);
+    val n1: *type.Type          = O.unwrap[*type.Type](ast.get_type(?a1, t1));
+    if (n1.kind != type.TYPE_KIND_SECRET) { rc = 1; }
+    or {
+        val inner: *type.Type = O.unwrap[*type.Type](ast.get_type(?a1, n1.data.secret.inner));
+        if (inner.kind != type.TYPE_KIND_NAMED) { rc = 1; }
+    }
+    if (diagnostic.has_errors(?d1)) { rc = 1; }
+    diagnostic.dnit(?d1); ast.dnit(?a1); lexer.dnit(?s1, ?alloc);
+    if (rc != 0) { ret rc; }
+
+    # (2) `*^u8`: PTR to SECRET to NAMED (public pointer to secret bytes)
+    val tr2: R.Result[lexer.TokenStream, str] = lexer.tokenize("*^u8", ?alloc, 0::source.FileId);
+    if (R.is_err[lexer.TokenStream, str](tr2)) { ret 1; }
+    var s2: lexer.TokenStream   = R.unwrap_ok[lexer.TokenStream, str](tr2);
+    var a2: ast.Ast             = ast.init(?alloc, 0::source.FileId);
+    var d2: diagnostic.DiagList = diagnostic.init(?alloc);
+    var p2: state.Parser        = state.make(?s2, ?a2, ?d2);
+    val t2: id.TypeId           = parse_type(?p2);
+    val n2: *type.Type          = O.unwrap[*type.Type](ast.get_type(?a2, t2));
+    if (n2.kind != type.TYPE_KIND_PTR) { rc = 1; }
+    or {
+        val sec: *type.Type = O.unwrap[*type.Type](ast.get_type(?a2, n2.data.ptr.pointee));
+        if (sec.kind != type.TYPE_KIND_SECRET) { rc = 1; }
+        or {
+            val inner: *type.Type = O.unwrap[*type.Type](ast.get_type(?a2, sec.data.secret.inner));
+            if (inner.kind != type.TYPE_KIND_NAMED) { rc = 1; }
+        }
+    }
+    if (diagnostic.has_errors(?d2)) { rc = 1; }
+    diagnostic.dnit(?d2); ast.dnit(?a2); lexer.dnit(?s2, ?alloc);
+    if (rc != 0) { ret rc; }
+
+    # (3) `^*u8`: SECRET to PTR to NAMED (secret pointer to public bytes)
+    val tr3: R.Result[lexer.TokenStream, str] = lexer.tokenize("^*u8", ?alloc, 0::source.FileId);
+    if (R.is_err[lexer.TokenStream, str](tr3)) { ret 1; }
+    var s3: lexer.TokenStream   = R.unwrap_ok[lexer.TokenStream, str](tr3);
+    var a3: ast.Ast             = ast.init(?alloc, 0::source.FileId);
+    var d3: diagnostic.DiagList = diagnostic.init(?alloc);
+    var p3: state.Parser        = state.make(?s3, ?a3, ?d3);
+    val t3: id.TypeId           = parse_type(?p3);
+    val n3: *type.Type          = O.unwrap[*type.Type](ast.get_type(?a3, t3));
+    if (n3.kind != type.TYPE_KIND_SECRET) { rc = 1; }
+    or {
+        val ptr: *type.Type = O.unwrap[*type.Type](ast.get_type(?a3, n3.data.secret.inner));
+        if (ptr.kind != type.TYPE_KIND_PTR) { rc = 1; }
+        or {
+            val inner: *type.Type = O.unwrap[*type.Type](ast.get_type(?a3, ptr.data.ptr.pointee));
+            if (inner.kind != type.TYPE_KIND_NAMED) { rc = 1; }
+        }
+    }
+    if (diagnostic.has_errors(?d3)) { rc = 1; }
+    diagnostic.dnit(?d3); ast.dnit(?a3); lexer.dnit(?s3, ?alloc);
+    if (rc != 0) { ret rc; }
+
+    # (4) `[N]^u8`: ARRAY whose element is SECRET to NAMED
+    val tr4: R.Result[lexer.TokenStream, str] = lexer.tokenize("[N]^u8", ?alloc, 0::source.FileId);
+    if (R.is_err[lexer.TokenStream, str](tr4)) { ret 1; }
+    var s4: lexer.TokenStream   = R.unwrap_ok[lexer.TokenStream, str](tr4);
+    var a4: ast.Ast             = ast.init(?alloc, 0::source.FileId);
+    var d4: diagnostic.DiagList = diagnostic.init(?alloc);
+    var p4: state.Parser        = state.make(?s4, ?a4, ?d4);
+    val t4: id.TypeId           = parse_type(?p4);
+    val n4: *type.Type          = O.unwrap[*type.Type](ast.get_type(?a4, t4));
+    if (n4.kind != type.TYPE_KIND_ARRAY) { rc = 1; }
+    or {
+        val sec: *type.Type = O.unwrap[*type.Type](ast.get_type(?a4, n4.data.array.element));
+        if (sec.kind != type.TYPE_KIND_SECRET) { rc = 1; }
+        or {
+            val inner: *type.Type = O.unwrap[*type.Type](ast.get_type(?a4, sec.data.secret.inner));
+            if (inner.kind != type.TYPE_KIND_NAMED) { rc = 1; }
+        }
+    }
+    if (diagnostic.has_errors(?d4)) { rc = 1; }
+    diagnostic.dnit(?d4); ast.dnit(?a4); lexer.dnit(?s4, ?alloc);
+    if (rc != 0) { ret rc; }
+
+    # (5) `^MyRec`: SECRET wrapping a user-named type
+    val tr5: R.Result[lexer.TokenStream, str] = lexer.tokenize("^MyRec", ?alloc, 0::source.FileId);
+    if (R.is_err[lexer.TokenStream, str](tr5)) { ret 1; }
+    var s5: lexer.TokenStream   = R.unwrap_ok[lexer.TokenStream, str](tr5);
+    var a5: ast.Ast             = ast.init(?alloc, 0::source.FileId);
+    var d5: diagnostic.DiagList = diagnostic.init(?alloc);
+    var p5: state.Parser        = state.make(?s5, ?a5, ?d5);
+    val t5: id.TypeId           = parse_type(?p5);
+    val n5: *type.Type          = O.unwrap[*type.Type](ast.get_type(?a5, t5));
+    if (n5.kind != type.TYPE_KIND_SECRET) { rc = 1; }
+    or {
+        val inner: *type.Type = O.unwrap[*type.Type](ast.get_type(?a5, n5.data.secret.inner));
+        if (inner.kind != type.TYPE_KIND_NAMED) { rc = 1; }
+    }
+    if (diagnostic.has_errors(?d5)) { rc = 1; }
+    diagnostic.dnit(?d5); ast.dnit(?a5); lexer.dnit(?s5, ?alloc);
+    ret rc;
+}
+
+# `expr:^` is a bare strip cast (no target type) and `expr:^Type` carries an
+# optional named target, parallel to `:~Type`
+test "mach.lang.fe.parser.expr.parse_expr:strip_cast" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+
+    var rc: i32 = 0;
+
+    # (1) `x:^`: a bare strip; the node carries no target type
+    val tr1: R.Result[lexer.TokenStream, str] = lexer.tokenize("x:^", ?alloc, 0::source.FileId);
+    if (R.is_err[lexer.TokenStream, str](tr1)) { ret 1; }
+    var s1: lexer.TokenStream   = R.unwrap_ok[lexer.TokenStream, str](tr1);
+    var a1: ast.Ast             = ast.init(?alloc, 0::source.FileId);
+    var d1: diagnostic.DiagList = diagnostic.init(?alloc);
+    var p1: state.Parser        = state.make(?s1, ?a1, ?d1);
+    val e1: id.ExprId           = parse_expr(?p1);
+    val n1: *expr.Expr          = O.unwrap[*expr.Expr](ast.get_expr(?a1, e1));
+    if (n1.kind != expr.EXPR_KIND_STRIP) { rc = 1; }
+    or (n1.data.strip.ty != id.TYPE_NIL) { rc = 1; }
+    or {
+        val v: *expr.Expr = O.unwrap[*expr.Expr](ast.get_expr(?a1, n1.data.strip.value));
+        if (v.kind != expr.EXPR_KIND_IDENT) { rc = 1; }
+    }
+    if (diagnostic.has_errors(?d1)) { rc = 1; }
+    diagnostic.dnit(?d1); ast.dnit(?a1); lexer.dnit(?s1, ?alloc);
+    if (rc != 0) { ret rc; }
+
+    # (2) `x:^u32`: a typed strip; the node carries a NAMED target type
+    val tr2: R.Result[lexer.TokenStream, str] = lexer.tokenize("x:^u32", ?alloc, 0::source.FileId);
+    if (R.is_err[lexer.TokenStream, str](tr2)) { ret 1; }
+    var s2: lexer.TokenStream   = R.unwrap_ok[lexer.TokenStream, str](tr2);
+    var a2: ast.Ast             = ast.init(?alloc, 0::source.FileId);
+    var d2: diagnostic.DiagList = diagnostic.init(?alloc);
+    var p2: state.Parser        = state.make(?s2, ?a2, ?d2);
+    val e2: id.ExprId           = parse_expr(?p2);
+    val n2: *expr.Expr          = O.unwrap[*expr.Expr](ast.get_expr(?a2, e2));
+    if (n2.kind != expr.EXPR_KIND_STRIP) { rc = 1; }
+    or (n2.data.strip.ty == id.TYPE_NIL) { rc = 1; }
+    or {
+        val ty: *type.Type = O.unwrap[*type.Type](ast.get_type(?a2, n2.data.strip.ty));
+        if (ty.kind != type.TYPE_KIND_NAMED) { rc = 1; }
+    }
+    if (diagnostic.has_errors(?d2)) { rc = 1; }
+    diagnostic.dnit(?d2); ast.dnit(?a2); lexer.dnit(?s2, ?alloc);
+    ret rc;
+}
+
+# the infix XOR `^` in expression position is untouched: `a ^ b` is a binary
+# BIT_XOR, never a type qualifier. the two never collide because a type never
+# begins with an infix operator.
+test "mach.lang.fe.parser.expr.parse_expr:caret_stays_infix_xor" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+
+    val res_tokens: R.Result[lexer.TokenStream, str] = lexer.tokenize("a ^ b", ?alloc, 0::source.FileId);
+    if (R.is_err[lexer.TokenStream, str](res_tokens)) { ret 1; }
+    var stream: lexer.TokenStream   = R.unwrap_ok[lexer.TokenStream, str](res_tokens);
+    var a:      ast.Ast             = ast.init(?alloc, 0::source.FileId);
+    var diags:  diagnostic.DiagList = diagnostic.init(?alloc);
+    var p:      state.Parser        = state.make(?stream, ?a, ?diags);
+
+    val eid: id.ExprId = parse_expr(?p);
+    var rc: i32 = 0;
+    val e: *expr.Expr = O.unwrap[*expr.Expr](ast.get_expr(?a, eid));
+    if (e.kind != expr.EXPR_KIND_BINARY)      { rc = 1; }
+    or (e.data.binary.op != expr.BIN_BIT_XOR) { rc = 1; }
     if (diagnostic.has_errors(?diags)) { rc = 1; }
 
     diagnostic.dnit(?diags);

--- a/src/lang/fe/token.mach
+++ b/src/lang/fe/token.mach
@@ -61,6 +61,7 @@ pub val KIND_COLON_TILDE: Kind = 41;   # :~
 
 pub val KIND_BACKTICK:    Kind = 42;   # ` opening a per-decl codegen decorator
 pub val KIND_ATTR_OPEN:   Kind = 43;   # #[ opening an attribute decorator
+pub val KIND_COLON_CARET: Kind = 44;   # :^ secret-qualifier strip cast
 
 pub val KIND_EOF:         Kind = 254;  # end of input
 pub val KIND_ERROR:       Kind = 255;  # invalid byte or unterminated token
@@ -144,6 +145,7 @@ pub fun kind_str(kind: Kind) str {
     if (kind == KIND_COLON_COLON) { ret "::"; }
     if (kind == KIND_DOT_DOT_DOT) { ret "..."; }
     if (kind == KIND_COLON_TILDE) { ret ":~"; }
+    if (kind == KIND_COLON_CARET) { ret ":^"; }
     if (kind == KIND_BACKTICK)    { ret "`"; }
     if (kind == KIND_ATTR_OPEN)   { ret "#["; }
     if (kind == KIND_EOF)         { ret "eof"; }


### PR DESCRIPTION
Closes #1644. Part of the constant-time + post-quantum epic #1643.

Frontend-only slice: tokens and grammar for the secret type qualifier `^` and
its downgrade cast `:^`. Flow-typing semantics are a separate issue (#1645);
this PR adds **no** type-checking behavior. The new AST nodes are produced by
the parser and exercised by lexer/parser tests only; sema/codegen handling
lands in #1645/#1646.

## Lexer / tokens
- New `KIND_COLON_CARET` token. An adjacent `:^` lexes as one token in the
  `::`/`:~` maximal-munch family; a space after the annotation colon
  (`k: ^[32]u8`) keeps `:` and `^` separate.

## Parser / grammar
- `^` is a prefix type qualifier (`TYPE_KIND_SECRET`), a sibling of `*` and
  `[N]`, binding to the type to its right. Valid in every type position.
- `:^` is a postfix strip cast (`EXPR_KIND_STRIP`). Bare `expr:^` strips the
  qualifier and needs no target; `expr:^T` (named target only) parallels
  `:~T`. The infix XOR `^` in expression position is unchanged.

## Tests
- Lexer: `:^` adjacency and the `k: ^[32]u8` spacing case.
- Parser: round-trips `^u32`, `*^u8`, `^*u8`, `[N]^u8`, `^MyRec`, `expr:^`,
  `expr:^T`, and that infix `a ^ b` still parses as XOR.
