### PR TITLE
chore(infra): add GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,0 +1,37 @@
+---
+name: Bug
+about: Observed behavior contradicts the spec, docs, or obvious intent
+title: ""
+labels: ["bug"]
+---
+
+<!--
+Before submitting, set these in the sidebar, since a template cannot:
+  area:*    one or more of frontend, sema, codegen, link, driver, diag, infra
+  target:*  darwin, windows, or aarch64, only when the work is target-specific
+  milestone the track this belongs to
+  flags     critical (a miscompilation, data loss, or release blocker) or blocked, when they apply
+Put relationships in the body, like "Part of #N" or "Depends on #M".
+Use this template for a defect, where the behavior is wrong. Use the Problem template
+when the behavior works as built but is wrong by design. The two are mutually exclusive.
+-->
+
+## What
+
+<!-- A one or two line summary of the defect. -->
+
+## Repro
+
+<!-- The minimal steps or program that triggers it. -->
+
+## Expected
+
+<!-- What should happen, and why. Cite the spec, docs, or intent if it helps. -->
+
+## Actual
+
+<!-- What happens instead, with the exact diagnostic, exit, or wrong output. -->
+
+## Environment
+
+<!-- The triple or target, the toolchain version or commit, and the OS if it matters. -->

--- a/.github/ISSUE_TEMPLATE/chore.md
+++ b/.github/ISSUE_TEMPLATE/chore.md
@@ -1,0 +1,22 @@
+---
+name: Chore
+about: Mechanical upkeep and release engineering (dep bumps, version rolls, cuts, tags, infra)
+title: ""
+labels: ["chore"]
+---
+
+<!--
+Before submitting, set these in the sidebar, since a template cannot:
+  area:*    usually infra or driver, but pick what fits
+  milestone the track this belongs to, if any
+Put relationships in the body, like "Part of #N" or "Depends on #M".
+Use the refactor or docs label instead when one of those fits better.
+-->
+
+## What
+
+<!-- The upkeep task and why it is needed now. -->
+
+## Acceptance
+
+- [ ] <!-- the concrete done state -->

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/epic.md
+++ b/.github/ISSUE_TEMPLATE/epic.md
@@ -1,0 +1,36 @@
+---
+name: Epic
+about: Umbrella issue tracking a family of sub-issues
+title: "epic: "
+labels: ["epic"]
+---
+
+<!--
+Before submitting, set these in the sidebar, since a template cannot:
+  area:*    the dominant area or areas of the family
+  target:*  darwin, windows, or aarch64, only when the whole family is target-specific
+  milestone the track this epic represents
+Wire every child as a native sub-issue from the sidebar, and mirror the list in the
+## Children checklist below so the body reads on its own. Write cross-repo children
+as owner/repo#N.
+-->
+
+> ## Status (YYYY-MM-DD)
+>
+> <!-- One paragraph on where the track stands today, what is active, and what comes next.
+>      Keep this block current, since it is the first thing a reader sees. -->
+
+## What
+
+<!-- The goal of the family, why it matters, and the model that ties the children together. -->
+
+## Children
+
+<!-- Mirror the native sub-issues. Markers are [x] done, [ ] todo, and [~] partial. -->
+
+- [ ] #NNNN <!-- short description -->
+
+## Sequencing
+
+<!-- The order things land in and why, including dependencies, what de-risks what, and
+     what can run in parallel. -->

--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -1,0 +1,26 @@
+---
+name: Feature
+about: New capability, or an extension of an existing one
+title: ""
+labels: ["feature"]
+---
+
+<!--
+Before submitting, set these in the sidebar, since a template cannot:
+  area:*    one or more of frontend, sema, codegen, link, driver, diag, infra
+  target:*  darwin, windows, or aarch64, only when the work is target-specific
+  milestone the track this belongs to
+  flags     critical (a release blocker) or blocked, when they apply
+Put relationships in the body, like "Part of #N", "Depends on #M", or "Blocks #N".
+If this is a child of an epic, also add it as a sub-issue on that epic.
+-->
+
+Part of #. Depends on #.
+
+## What
+
+<!-- The capability, why it exists, and the design, with enough detail to implement from. -->
+
+## Acceptance
+
+- [ ] <!-- what must be observably true, and the tests that must pass -->

--- a/.github/ISSUE_TEMPLATE/problem.md
+++ b/.github/ISSUE_TEMPLATE/problem.md
@@ -1,0 +1,32 @@
+---
+name: Problem
+about: A problem with an existing feature's design or behavior (working as built, wrong by design)
+title: ""
+labels: ["problem"]
+---
+
+<!--
+Before submitting, set these in the sidebar, since a template cannot:
+  area:*    one or more of frontend, sema, codegen, link, driver, diag, infra
+  target:*  darwin, windows, or aarch64, only when the work is target-specific
+  milestone the track this belongs to
+  flags     critical or blocked, when they apply
+Put relationships in the body, like "Part of #N", "Depends on #M", or "Blocks #N".
+Problem is exclusive with bug. Use this template when the behavior works as built but the
+design is wrong, and use the Bug template for an outright defect.
+-->
+
+Part of #. Depends on #.
+
+## What
+
+<!-- The current design or behavior, why it is wrong, and how that was confirmed. -->
+
+## Fix
+
+<!-- The proper fix as a design change. List the candidate designs and the preferred one
+     with its rationale. Do not propose a workaround. -->
+
+## Acceptance
+
+- [ ] <!-- what must be observably true, and the tests that must pass -->

--- a/.github/ISSUE_TEMPLATE/rfc.md
+++ b/.github/ISSUE_TEMPLATE/rfc.md
@@ -1,0 +1,32 @@
+---
+name: RFC
+about: Design discussion or request for comment, direction not yet decided
+title: "RFC: "
+labels: ["rfc"]
+---
+
+<!--
+Before submitting, set these in the sidebar, since a template cannot:
+  area:*    the area or areas the proposal touches
+  target:*  darwin, windows, or aarch64, only when the work is target-specific
+  milestone the track this belongs to, if any
+Put relationships in the body, like "Part of #N" or "Depends on #M".
+An RFC records an open question. Relabel or close it once the direction is decided and
+the implementation work is cut into feature or problem issues.
+-->
+
+## Problem
+
+<!-- What forces a decision, such as the constraint, gap, or tension. -->
+
+## Proposal
+
+<!-- The proposed direction in enough detail to evaluate, with its limits stated honestly. -->
+
+## Alternatives
+
+<!-- The other directions considered, and why this one is preferred or still open. -->
+
+## Open questions
+
+- <!-- what must be resolved before this can be cut into implementation issues -->


### PR DESCRIPTION
Closes #1658.

Adds the repo-side half of the issue convention as GitHub issue templates.

## Templates (`.github/ISSUE_TEMPLATE/`)

Per-type markdown templates for feature, bug, problem, epic, rfc, and chore. Each one pre-attaches its type label and scaffolds the body shape (relationship links, then `## What`, then the type's own sections, then `## Acceptance`). `config.yml` turns off blank issues. An HTML comment at the top of each template reminds the author to set the fields a template cannot, which are the milestone and the area and target labels.

The CLI and agent side, authoring fully specified issues with the right labels, milestone, and native sub-issue links, lives in a local `mach-issue` skill rather than in the repo.
