### PR TITLE
fix(target): raw flat-image build path via produces_image predicate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -215,6 +215,38 @@ jobs:
       - name: cross-compile and byte-verify the macho fixture
         run: bash test/macho/verify.sh "$PWD/m"
 
+  # the freestanding/raw flat-image build path (#1616): builds a compiler from the
+  # PR source, builds the minimal os=freestanding, of=raw x86_64 fixture (which
+  # links straight from the in-memory codegen images, no per-module .o), confirms
+  # the output is a container-free flat binary, then mmaps the position-independent
+  # image and runs it to assert its computed exit code. needs only a C compiler for
+  # the loader harness - no llvm, no qemu.
+  cross-freestanding:
+    name: cross freestanding (raw)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: fetch released mach
+        env:
+          GH_TOKEN: ${{ github.token }}
+          SEED: mach-*-x86_64-linux.tar.gz
+        run: |
+          set -euo pipefail
+          tmp="$(mktemp -d)"
+          gh release download -R "$GITHUB_REPOSITORY" -p "$SEED" -D "$tmp"
+          tar -xzf "$tmp"/$SEED -C /usr/local/bin mach
+          chmod +x /usr/local/bin/mach
+
+      - name: build a compiler from source
+        run: |
+          set -euo pipefail
+          mach dep pull
+          mach build . -o m
+
+      - name: build and run the freestanding raw flat image
+        run: bash test/freestanding/verify.sh "$PWD/m"
+
   build-windows:
     name: build ${{ matrix.target }}
     runs-on: ${{ matrix.runs-on }}

--- a/src/cli/cmd/build.mach
+++ b/src/cli/cmd/build.mach
@@ -1281,6 +1281,14 @@ fun link_artifact(p: *driver.Project, emit_obj: bool, verbose: bool, root: *u8,
     val te: *driver.TargetEntry = p.target_entry;
     if (te == nil) { print.eprint("error: no target selected\n"); ret 2; }
 
+    # a flat-image object format (`produces_image`) has no relocatable `.o`
+    # container: it cannot emit per-module objects or re-parse them at link time.
+    # link the in-memory codegen images straight into the flat executable instead
+    # of round-tripping through `.o` files.
+    if (p.target.of != nil && p.target.of.produces_image) {
+        ret link_image_artifact(p, emit_obj, verbose, root, out_override, images, out_path);
+    }
+
     # the per-module object tree root: `<root>/<resolved obj template>`.
     var obj_base: [4096]u8;
     if (!resolve_obj_base(p, root, ?obj_base[0], 4096)) {
@@ -1360,6 +1368,96 @@ fun link_artifact(p: *driver.Project, emit_obj: bool, verbose: bool, root: *u8,
         linker.link(p.s, ?p.target, paths, len, sonames, soname_len, ?artifact[0], linker.LINK_EXE);
     free_paths(p.s.alloc, paths, len, len);
     free_sonames(p.s.alloc, sonames, soname_len);
+    if (R.is_err[bool, str](res_link)) {
+        print.eprint("error: ");
+        print.eprint(R.unwrap_err[bool, str](res_link));
+        print.eprint("\n");
+        ret 1;
+    }
+
+    if (verbose) {
+        print.eprint("output ");
+        print.eprint((?artifact[0])::str);
+        print.eprint("\n");
+    }
+
+    @out_path = dup_cstr(p.s.alloc, ?artifact[0]);
+    ret 0;
+}
+
+# link the in-memory codegen images straight into a flat executable image,
+# bypassing the per-module `.o` emit/parse round-trip
+#
+# The build path for a flat-image object format (`produces_image`): the codegen
+# images are handed to the linker directly (`linker.link_images`), so no
+# relocatable `.o` is written or re-parsed. A flat image is self-contained and
+# has only an executable form, so library mode and `--emit obj` are rejected, and
+# there are no external relocatable link inputs (the format has no parser to
+# consume them). The images are gathered into a contiguous topo-ordered array so
+# the link order matches the on-disk path; the wrapper array is freed afterward,
+# never the images (the caller owns them). Sets `*out_path` to the produced
+# executable path on success.
+# ---
+# p:            the project carrying the module graph and session
+# emit_obj:     reject when set - a flat-image format has no relocatable object output
+# verbose:      write the image count and output path to stderr
+# root:         the resolved project root directory
+# out_override: the `-o` artifact path, or nil to use the resolved path
+# images:       the per-module codegen images, indexed by module id
+# out_path:     receives the owned produced-artifact path on success
+# ret:          0 on success, 1 on a user error, 2 on an internal error
+fun link_image_artifact(p: *driver.Project, emit_obj: bool, verbose: bool, root: *u8,
+                        out_override: *u8, images: *of.ObjectImage, out_path: **u8) i64 {
+    val te: *driver.TargetEntry = p.target_entry;
+    if (te == nil) { print.eprint("error: no target selected\n"); ret 2; }
+
+    # a flat image is not a relocatable object, so it has no library form.
+    if (te.mode == driver.MODE_LIBRARY || emit_obj) {
+        print.eprint("error: a flat-image object format produces only executables; library and '--emit obj' outputs are unsupported\n");
+        ret 1;
+    }
+
+    # the executable path: an absolute `-o` is used verbatim; a relative one is
+    # rooted at <root>; otherwise the unit's resolved artifact path is used.
+    var artifact: [4096]u8;
+    if (out_override != nil) {
+        util.path_into(?artifact[0], 4096, root, out_override);
+    }
+    or {
+        val opt_bin: O.Option[str] = intern.lookup(?p.s.interner, p.config.bin_out);
+        if (O.is_none[str](opt_bin) || str_empty(O.unwrap[str](opt_bin))) {
+            print.eprint("error: selected artifact has no output path; set the `out` template in mach.toml\n");
+            ret 1;
+        }
+        join_into_str(?artifact[0], 4096, root, O.unwrap[str](opt_bin));
+    }
+    if (!util.ensure_parents(?artifact[0])) {
+        print.eprint("error: failed to create binary directory\n");
+        ret 2;
+    }
+
+    # gather the topo-ordered images into a contiguous array. each `of.ObjectImage`
+    # is a shallow value carrying borrowed array pointers, so copying it shares the
+    # underlying storage; only this wrapper array is freed, never the images.
+    val len: u32 = p.topo_len;
+    val res_ord: R.Result[*of.ObjectImage, str] = A.allocate[of.ObjectImage](p.s.alloc, len::usize);
+    if (R.is_err[*of.ObjectImage, str](res_ord)) { print.eprint("error: out of memory\n"); ret 2; }
+    val ordered: *of.ObjectImage = R.unwrap_ok[*of.ObjectImage, str](res_ord);
+    var i: u32 = 0;
+    for (i < len) {
+        ordered[i] = images[(p.topo[i])::u32];
+        i = i + 1;
+    }
+
+    if (verbose) {
+        print.eprint("link ");
+        print.eu64(len::u64);
+        print.eprint(" image(s)\n");
+    }
+
+    val res_link: R.Result[bool, str] =
+        linker.link_images(p.s, ?p.target, ordered, len, nil::*intern.StrId, 0, ?artifact[0], linker.LINK_EXE);
+    A.deallocate[of.ObjectImage](p.s.alloc, ordered, len::usize);
     if (R.is_err[bool, str](res_link)) {
         print.eprint("error: ");
         print.eprint(R.unwrap_err[bool, str](res_link));

--- a/src/lang/be/linker.mach
+++ b/src/lang/be/linker.mach
@@ -171,30 +171,101 @@ pub fun link(s: *session.Session, tgt: *target.Target, obj_paths: **u8,
     if (obj_paths == nil || obj_count == 0) {
         ret R.err[bool, str]("link: no input objects");
     }
-    # a dynamic link is requested when shared dependencies are present and the
-    # output is an executable; libraries/relocatables ignore dependencies.
-    val dynamic: bool = (mode == LINK_EXE) && (soname_count > 0);
 
     val alloc: *A.Allocator = s.alloc;
 
-    # read and parse every input object file into an in-memory image array. the
-    # array and each populated image are torn down on every exit path below. an
+    # read and parse every input object file into an in-memory image array. an
     # `.a` archive input expands into one image per member object, so the parsed
     # image count can exceed the input-path count - `read_objects` reports the
     # true module count through `module_count`.
-    var modules: *of.ObjectImage = nil;
     var module_count: u32 = 0;
     val read_r: R.Result[*of.ObjectImage, str] = read_objects(s, tgt, obj_paths, obj_count, ?module_count);
     if (R.is_err[*of.ObjectImage, str](read_r)) {
         ret R.err[bool, str](R.unwrap_err[*of.ObjectImage, str](read_r));
     }
-    modules = R.unwrap_ok[*of.ObjectImage, str](read_r);
+    val modules: *of.ObjectImage = R.unwrap_ok[*of.ObjectImage, str](read_r);
 
-    # every input resolved to zero modules (e.g. an empty archive or one holding
-    # only bookkeeping members) - there is nothing to link, so reject rather than
-    # emit an empty artifact.
+    # the parsed images are owned here (read from disk), so they are torn down
+    # after linking regardless of outcome.
+    val r: R.Result[bool, str] =
+        link_modules(s, tgt, modules, module_count, sonames, soname_count, out_path, mode);
+    free_modules(alloc, modules, module_count);
+    ret r;
+}
+
+# combine an array of in-memory codegen images into the requested artifact,
+# bypassing the per-module `.o` emit/parse round-trip.
+#
+# the image-producing build path for a flat-image object format
+# (`tgt.of.produces_image` true): the back end's codegen images are linked
+# straight from memory rather than written to relocatable `.o` files and read
+# back through `parse_object`, which a flat-image format has no parser for. the
+# merge, symbol resolution, relocation patching, and segment layout are identical
+# to `link`; only the input source differs. the caller owns `images` and frees
+# them - this never tears them down.
+# ---
+# s:            shared session (allocator, interner, diagnostics)
+# tgt:          active target - selects OS base address, entry symbol, and writers
+# images:       the in-memory codegen images, one per module
+# image_count:  number of images
+# sonames:      interned shared-library sonames to depend on dynamically (or nil)
+# soname_count: number of shared-library dependencies
+# out_path:     null-terminated output file path
+# mode:         executable, relocatable (library), or shared
+# ret:          true once the artifact is written, or an error string
+pub fun link_images(s: *session.Session, tgt: *target.Target, images: *of.ObjectImage,
+                    image_count: u32, sonames: *intern.StrId, soname_count: u32,
+                    out_path: *u8, mode: LinkMode) R.Result[bool, str] {
+    if (s == nil)      { ret R.err[bool, str]("link: nil session"); }
+    if (tgt == nil)    { ret R.err[bool, str]("link: nil target"); }
+    if (tgt.of == nil) { ret R.err[bool, str]("link: target has no object-format vtable"); }
+    if (tgt.os == nil) { ret R.err[bool, str]("link: target has no OS vtable"); }
+    if (mode == LINK_SHARED) {
+        ret R.err[bool, str]("link: shared-object output is not yet supported");
+    }
+    if (images == nil || image_count == 0) {
+        ret R.err[bool, str]("link: no input objects");
+    }
+    ret link_modules(s, tgt, images, image_count, sonames, soname_count, out_path, mode);
+}
+
+# combine an already-built module-image array into the requested artifact.
+#
+# the shared core of `link` (disk inputs read + parsed) and `link_images`
+# (in-memory codegen images): merges symbols (rejecting duplicate strong
+# definitions), lays out the concatenated sections, and either (executable)
+# assigns virtual addresses, patches relocations, and writes page-aligned load
+# segments through `tgt.of.emit_exec`, or (library / relocatable) carries the
+# input relocations forward and writes a single merged object through
+# `obj.emit`. it never owns `modules` - the caller frees them - and frees only
+# its own scratch.
+#
+# DYNAMIC vs STATIC resolution of an undefined `ext` mirrors `link`: with no
+# shared dependencies every undefined `ext` must resolve against an input module
+# or the link fails; with shared dependencies any `ext` left undefined becomes a
+# dynamic import bound at run time, and the executable is emitted through
+# `emit_dyn_exec`.
+# ---
+# s:            shared session (allocator, interner, diagnostics)
+# tgt:          active target - selects OS base address, entry symbol, and writers
+# modules:      the input module images (caller-owned)
+# module_count: number of modules
+# sonames:      interned shared-library sonames to depend on dynamically (or nil)
+# soname_count: number of shared-library dependencies
+# out_path:     null-terminated output file path
+# mode:         executable, relocatable (library), or shared
+# ret:          true once the artifact is written, or an error string
+fun link_modules(s: *session.Session, tgt: *target.Target, modules: *of.ObjectImage,
+                 module_count: u32, sonames: *intern.StrId, soname_count: u32,
+                 out_path: *u8, mode: LinkMode) R.Result[bool, str] {
+    val alloc: *A.Allocator = s.alloc;
+    # a dynamic link is requested when shared dependencies are present and the
+    # output is an executable; libraries/relocatables ignore dependencies.
+    val dynamic: bool = (mode == LINK_EXE) && (soname_count > 0);
+
+    # an empty module set (e.g. an archive holding only bookkeeping members) has
+    # nothing to link, so reject rather than emit an empty artifact.
     if (module_count == 0) {
-        free_modules(alloc, modules, module_count);
         ret R.err[bool, str]("link: no input objects");
     }
 
@@ -211,7 +282,6 @@ pub fun link(s: *session.Session, tgt: *target.Target, obj_paths: **u8,
     if (sec_total > 0) {
         val pr: R.Result[*Placement, str] = A.zallocate[Placement](alloc, sec_total::usize);
         if (R.is_err[*Placement, str](pr)) {
-            free_modules(alloc, modules, module_count);
             ret R.err[bool, str](R.unwrap_err[*Placement, str](pr));
         }
         placements = R.unwrap_ok[*Placement, str](pr);
@@ -222,7 +292,6 @@ pub fun link(s: *session.Session, tgt: *target.Target, obj_paths: **u8,
     val br: R.Result[*u32, str] = A.zallocate[u32](alloc, module_count::usize);
     if (R.is_err[*u32, str](br)) {
         free_placements(alloc, placements, sec_total);
-        free_modules(alloc, modules, module_count);
         ret R.err[bool, str](R.unwrap_err[*u32, str](br));
     }
     sec_base = R.unwrap_ok[*u32, str](br);
@@ -231,7 +300,6 @@ pub fun link(s: *session.Session, tgt: *target.Target, obj_paths: **u8,
         accumulate_sections(s, modules, module_count, ?merged[0], placements, sec_base);
     if (R.is_err[bool, str](acc_r)) {
         free_scratch(alloc, placements, sec_total, sec_base, module_count);
-        free_modules(alloc, modules, module_count);
         ret R.err[bool, str](R.unwrap_err[bool, str](acc_r));
     }
 
@@ -253,7 +321,6 @@ pub fun link(s: *session.Session, tgt: *target.Target, obj_paths: **u8,
     if (R.is_err[bool, str](collect_r)) {
         map.dnit[intern.StrId, SymbolLoc](?sym_locs);
         free_scratch(alloc, placements, sec_total, sec_base, module_count);
-        free_modules(alloc, modules, module_count);
         ret R.err[bool, str](R.unwrap_err[bool, str](collect_r));
     }
 
@@ -264,7 +331,6 @@ pub fun link(s: *session.Session, tgt: *target.Target, obj_paths: **u8,
     if (R.is_err[of.ObjectImage, str](img_r)) {
         map.dnit[intern.StrId, SymbolLoc](?sym_locs);
         free_scratch(alloc, placements, sec_total, sec_base, module_count);
-        free_modules(alloc, modules, module_count);
         ret R.err[bool, str](R.unwrap_err[of.ObjectImage, str](img_r));
     }
     out_img = R.unwrap_ok[of.ObjectImage, str](img_r);
@@ -275,7 +341,6 @@ pub fun link(s: *session.Session, tgt: *target.Target, obj_paths: **u8,
         obj.dnit(?out_img);
         map.dnit[intern.StrId, SymbolLoc](?sym_locs);
         free_scratch(alloc, placements, sec_total, sec_base, module_count);
-        free_modules(alloc, modules, module_count);
         ret R.err[bool, str](R.unwrap_err[bool, str](build_r));
     }
 
@@ -296,7 +361,6 @@ pub fun link(s: *session.Session, tgt: *target.Target, obj_paths: **u8,
                 obj.dnit(?out_img);
                 map.dnit[intern.StrId, SymbolLoc](?sym_locs);
                 free_scratch(alloc, placements, sec_total, sec_base, module_count);
-                free_modules(alloc, modules, module_count);
                 ret R.err[bool, str](R.unwrap_err[bool, str](dr));
             }
         }
@@ -308,7 +372,6 @@ pub fun link(s: *session.Session, tgt: *target.Target, obj_paths: **u8,
             obj.dnit(?out_img);
             map.dnit[intern.StrId, SymbolLoc](?sym_locs);
             free_scratch(alloc, placements, sec_total, sec_base, module_count);
-            free_modules(alloc, modules, module_count);
             ret R.err[bool, str](R.unwrap_err[bool, str](patch_r));
         }
 
@@ -324,7 +387,6 @@ pub fun link(s: *session.Session, tgt: *target.Target, obj_paths: **u8,
         obj.dnit(?out_img);
         map.dnit[intern.StrId, SymbolLoc](?sym_locs);
         free_scratch(alloc, placements, sec_total, sec_base, module_count);
-        free_modules(alloc, modules, module_count);
 
         if (R.is_err[bool, str](emit_r)) {
             ret R.err[bool, str](R.unwrap_err[bool, str](emit_r));
@@ -340,7 +402,6 @@ pub fun link(s: *session.Session, tgt: *target.Target, obj_paths: **u8,
         obj.dnit(?out_img);
         map.dnit[intern.StrId, SymbolLoc](?sym_locs);
         free_scratch(alloc, placements, sec_total, sec_base, module_count);
-        free_modules(alloc, modules, module_count);
         ret R.err[bool, str](R.unwrap_err[bool, str](carry_r));
     }
 
@@ -349,7 +410,6 @@ pub fun link(s: *session.Session, tgt: *target.Target, obj_paths: **u8,
     obj.dnit(?out_img);
     map.dnit[intern.StrId, SymbolLoc](?sym_locs);
     free_scratch(alloc, placements, sec_total, sec_base, module_count);
-    free_modules(alloc, modules, module_count);
 
     if (R.is_err[bool, str](obj_r)) {
         ret R.err[bool, str](R.unwrap_err[bool, str](obj_r));

--- a/src/lang/driver.mach
+++ b/src/lang/driver.mach
@@ -1705,7 +1705,7 @@ fun select_target(p: *Project, t: *TargetEntry) R.Result[bool, str] {
     if (O.is_some[str](of_opt)) { of_name = O.unwrap[str](of_opt); }
 
     if (os.os_id_for(os_name) == os.OS_UNKNOWN) {
-        ret R.err[bool, str](diag_join_named(p.s, "unknown target os name '", t.os_name, "' (expected: linux, darwin, windows)", "unknown target os name"));
+        ret R.err[bool, str](diag_join_named(p.s, "unknown target os name '", t.os_name, "' (expected: linux, darwin, windows, freestanding)", "unknown target os name"));
     }
     if (isa.arch_id_for(isa_name) == isa.ARCH_UNKNOWN) {
         ret R.err[bool, str](diag_join_named(p.s, "unknown target isa name '", t.isa_name, "' (expected: x86_64, aarch64, riscv64)", "unknown target isa name"));

--- a/src/lang/target/of.mach
+++ b/src/lang/target/of.mach
@@ -412,21 +412,32 @@ pub def DynExecFn: fun(*A.Allocator, *intern.Interner, *isa.IsaVTable, *LoadSegm
 # through `emit_exec` (or `emit_dyn_exec` for a dynamic link). Each format maps
 # the abstract `RK_*` kinds to its own machine relocation types internally. It
 # never branches on `id`.
+#
+# `produces_image` declares whether the format is a container-free flat image
+# (true) or a relocatable-object format that round-trips through `.o` files
+# (false). The build driver dispatches on it: a relocatable format codegens each
+# module to a `.o` (`emit_object`), then the linker reads every input back
+# (`parse_object`) before laying out the executable; a flat-image format has no
+# relocatable container, so the driver links straight from the in-memory codegen
+# images and never calls `emit_object`/`parse_object`.
 # ---
-# id:            object-format id (one of OF_*)
-# name:          format name ("elf", "coff", "macho"); an immutable str constant
-# emit_object:   serializes an ObjectImage to a relocatable object file
-# parse_object:  reads a relocatable object file into an ObjectImage
-# emit_exec:     serializes laid-out load segments into a static executable
-# emit_dyn_exec: serializes them into a dynamically-linked executable, or nil
-#                when the format has no dynamic-link writer yet
+# id:             object-format id (one of OF_*)
+# name:           format name ("elf", "coff", "macho", "raw"); an immutable str constant
+# produces_image: true for a container-free flat image, false for a relocatable
+#                 object format that round-trips through `.o` files
+# emit_object:    serializes an ObjectImage to a relocatable object file
+# parse_object:   reads a relocatable object file into an ObjectImage
+# emit_exec:      serializes laid-out load segments into a static executable
+# emit_dyn_exec:  serializes them into a dynamically-linked executable, or nil
+#                 when the format has no dynamic-link writer yet
 pub rec OfVTable {
-    id:            u32;
-    name:          str;
-    emit_object:   WriterFn;
-    parse_object:  ParserFn;
-    emit_exec:     ExecFn;
-    emit_dyn_exec: DynExecFn;
+    id:             u32;
+    name:           str;
+    produces_image: bool;
+    emit_object:    WriterFn;
+    parse_object:   ParserFn;
+    emit_exec:      ExecFn;
+    emit_dyn_exec:  DynExecFn;
 }
 
 # maximum number of object-format implementations an OfRegistry holds

--- a/src/lang/target/of/coff.mach
+++ b/src/lang/target/of/coff.mach
@@ -2734,6 +2734,7 @@ var coff_vtable: of.OfVTable;
 pub fun register_coff(reg: *of.OfRegistry) R.Result[bool, str] {
     coff_vtable.id               = of.OF_COFF;
     coff_vtable.name             = "coff";
+    coff_vtable.produces_image   = false;
     coff_vtable.emit_object      = coff_emit_object;
     coff_vtable.parse_object     = coff_parse_object;
     coff_vtable.emit_exec        = coff_emit_exec;

--- a/src/lang/target/of/elf.mach
+++ b/src/lang/target/of/elf.mach
@@ -892,12 +892,13 @@ var elf_vtable: of.OfVTable;
 # reg: the object-format registry to install the vtable into
 # ret: ok(true) on success
 pub fun register(reg: *of.OfRegistry) R.Result[bool, str] {
-    elf_vtable.id            = of.OF_ELF;
-    elf_vtable.name          = "elf";
-    elf_vtable.emit_object   = emit_object;
-    elf_vtable.parse_object  = parse_object;
-    elf_vtable.emit_exec     = emit_exec;
-    elf_vtable.emit_dyn_exec = emit_dyn_exec;
+    elf_vtable.id             = of.OF_ELF;
+    elf_vtable.name           = "elf";
+    elf_vtable.produces_image = false;
+    elf_vtable.emit_object    = emit_object;
+    elf_vtable.parse_object   = parse_object;
+    elf_vtable.emit_exec      = emit_exec;
+    elf_vtable.emit_dyn_exec  = emit_dyn_exec;
 
     of.register(reg, ?elf_vtable);
     ret R.ok[bool, str](true);

--- a/src/lang/target/of/macho.mach
+++ b/src/lang/target/of/macho.mach
@@ -950,12 +950,13 @@ var macho_vtable: of.OfVTable;
 # reg: the object-format registry to install the vtable into
 # ret: ok(true) on success
 pub fun register_macho(reg: *of.OfRegistry) R.Result[bool, str] {
-    macho_vtable.id            = of.OF_MACHO;
-    macho_vtable.name          = "macho";
-    macho_vtable.emit_object   = emit_object;
-    macho_vtable.parse_object  = parse_object;
-    macho_vtable.emit_exec     = emit_exec;
-    macho_vtable.emit_dyn_exec = nil::of.DynExecFn;
+    macho_vtable.id             = of.OF_MACHO;
+    macho_vtable.name           = "macho";
+    macho_vtable.produces_image = false;
+    macho_vtable.emit_object    = emit_object;
+    macho_vtable.parse_object   = parse_object;
+    macho_vtable.emit_exec      = emit_exec;
+    macho_vtable.emit_dyn_exec  = nil::of.DynExecFn;
 
     of.register(reg, ?macho_vtable);
     ret R.ok[bool, str](true);

--- a/src/lang/target/of/raw.mach
+++ b/src/lang/target/of/raw.mach
@@ -215,12 +215,13 @@ var raw_vtable: of.OfVTable;
 # reg: object-format registry to install the vtable into
 # ret: ok(true) on success
 pub fun register(reg: *of.OfRegistry) R.Result[bool, str] {
-    raw_vtable.id            = of.OF_RAW;
-    raw_vtable.name          = "raw";
-    raw_vtable.emit_object   = emit_object;
-    raw_vtable.parse_object  = parse_object;
-    raw_vtable.emit_exec     = emit_exec;
-    raw_vtable.emit_dyn_exec = emit_dyn_exec;
+    raw_vtable.id             = of.OF_RAW;
+    raw_vtable.name           = "raw";
+    raw_vtable.produces_image = true;
+    raw_vtable.emit_object    = emit_object;
+    raw_vtable.parse_object   = parse_object;
+    raw_vtable.emit_exec      = emit_exec;
+    raw_vtable.emit_dyn_exec  = emit_dyn_exec;
 
     of.register(reg, ?raw_vtable);
     ret R.ok[bool, str](true);

--- a/test/freestanding/mach.toml
+++ b/test/freestanding/mach.toml
@@ -1,0 +1,19 @@
+[project]
+id = "rawprobe"
+name = "rawprobe"
+version = "0.0.0"
+src = "src"
+target = "freestanding-x86_64"
+out = "out/{target}/{name}{ext}"
+obj = "out/{target}/obj"
+
+[target.freestanding-x86_64]
+isa = "x86_64"
+os  = "freestanding"
+abi = "sysv64"
+
+[profile.debug]
+opt = 0
+
+[bin.rawprobe]
+entry = "main.mach"

--- a/test/freestanding/src/main.mach
+++ b/test/freestanding/src/main.mach
@@ -1,0 +1,29 @@
+# freestanding x86_64 flat-image (raw) build fixture.
+#
+# no OS and no std runtime: the entry symbol is defined here and the program
+# exits through a raw `exit` syscall. it proves the object-centric build path now
+# reaches a flat image for an `os=freestanding, of=raw` target - codegen builds
+# an in-memory image per module, the driver links straight from those images (no
+# per-module `.o` round-trip, which a flat image has no parser for), and the raw
+# writer lays the single load segment out as a container-free binary entered at
+# its base. the body sums 0..9 with an intra-function counted loop and exits with
+# the result (45), so running the image asserts the emitted machine code is
+# correct end to end.
+#
+# `start` is the only function, so its code begins at file offset 0 (the image
+# base), satisfying raw's entry-at-base contract.
+
+#[symbol("_start")]
+fun start() {
+    var code: i64 = 0;
+    var i: i64 = 0;
+    for (i < 10) {
+        code = code + i;
+        i = i + 1;
+    }
+    asm x86_64 {
+        mov rax, 60      # __NR_exit
+        mov rdi, {code}  # exit code = sum 0..9 = 45
+        syscall
+    }
+}

--- a/test/freestanding/verify.sh
+++ b/test/freestanding/verify.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# build the freestanding x86_64 fixture as a raw flat image, verify the build
+# bypassed the per-module .o round-trip, confirm the output is a container-free
+# flat binary (not an ELF), then load and run it to assert its exit code. proves
+# an `os=freestanding, of=raw` program builds end to end to a working flat image
+# (mach#1616): codegen -> in-memory image link -> raw emit_exec.
+#
+# usage: verify.sh [path-to-mach]   (defaults to `mach` on PATH)
+#
+# requires: a C compiler (cc) for the loader harness. the harness mmaps the flat
+# image into an executable page and calls it; the image is position-independent
+# and exits via a raw `exit` syscall, so it runs at any load address and the
+# harness process exits with the image's computed code.
+set -euo pipefail
+
+# the exit code the fixture computes (sum 0..9) and exits with.
+expect_code=45
+
+mach="${1:-mach}"
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$here"
+
+fail() { echo "FAIL: $1" >&2; exit 1; }
+
+target="freestanding-x86_64"
+img="out/$target/rawprobe"
+
+echo "building flat image for $target with $mach"
+rm -rf out
+"$mach" build . --target "$target" --profile debug
+
+[ -f "$img" ] || fail "flat image was not produced at $img"
+
+# a flat-image build links straight from the in-memory codegen images, so no
+# per-module relocatable object is ever written.
+if find out -name '*.o' | grep -q .; then
+    fail "a .o was written - the per-module round-trip was not bypassed"
+fi
+
+# the image is a container-free flat binary: it must not carry an ELF header.
+magic="$(head -c4 "$img" | od -An -tx1 | tr -d ' \n')"
+[ "$magic" != "7f454c46" ] || fail "output is an ELF, not a flat image"
+
+# the first byte is the entry function's code (the image is entered at its base).
+[ -s "$img" ] || fail "flat image is empty"
+
+echo "loading and running the flat image"
+work="$(mktemp -d)"
+trap 'rm -rf "$work"' EXIT
+cat > "$work/harness.c" <<'EOF'
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/mman.h>
+int main(int argc, char** argv) {
+    FILE* f = fopen(argv[1], "rb");
+    if (!f) { perror("open"); return 2; }
+    fseek(f, 0, SEEK_END); long n = ftell(f); fseek(f, 0, SEEK_SET);
+    void* p = mmap(NULL, n, PROT_READ | PROT_WRITE | PROT_EXEC,
+                   MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+    if (p == MAP_FAILED) { perror("mmap"); return 2; }
+    if (fread(p, 1, n, f) != (size_t)n) { return 2; }
+    fclose(f);
+    ((void (*)(void))p)();
+    return 0; /* unreachable: the flat image exits via syscall */
+}
+EOF
+cc -O2 -o "$work/harness" "$work/harness.c" || fail "could not build the loader harness"
+
+set +e
+"$work/harness" "$img"
+code=$?
+set -e
+[ "$code" -eq "$expect_code" ] || fail "exit code $code, expected $expect_code"
+
+echo "OK: os=freestanding, of=raw builds a working flat image that runs to exit code $expect_code"


### PR DESCRIPTION
Closes #1616
Closes #1617

The `raw` flat-image object format (`of/raw`, #1613) implements only `emit_exec`
and stubs `emit_object`/`parse_object` (a flat image has no relocatable
container). But `mach build` was object-file-centric: it codegens each module,
writes a `.o` per module (`emit_object`), then the linker re-parses every input
(`parse_object`) before laying out the executable. So a raw target failed before
the linker with `raw output supports only executables` and never reached
`emit_exec`. This was the last gap to a real `os=freestanding, of=raw`
flat-image build (#1179).

## Fix: a build/link pipeline change, dispatched on a vtable predicate

A format now declares whether it round-trips through relocatable `.o` files. The
driver dispatches on that instead of assuming every target emits and re-parses
objects.

- **`of.OfVTable.produces_image`** (new): `true` for a container-free flat image
  (raw), `false` for a relocatable-object format that round-trips through `.o`
  files (elf, coff, macho). This is the predicate the retargeting design (#1600)
  called for but did not land.
- **`linker.link_images`** (new): links an already-built `of.ObjectImage` array
  straight from memory. `link` (disk inputs) and `link_images` (in-memory codegen
  images) now share a `link_modules` core that never owns the modules - the
  caller frees them. The merge, symbol resolution, relocation patching, and
  segment layout are identical, so the existing elf/coff/macho output is
  byte-unchanged.
- **`cli/build` branch**: when `produces_image`, the build links the in-memory
  codegen images directly (`link_image_artifact` -> `linker.link_images`),
  bypassing the per-module `.o` round-trip entirely. The relocatable formats keep
  writing and re-parsing per-module objects unchanged. A flat image has only an
  executable form, so library mode and `--emit obj` are rejected for it.

No defensive fallback for the raw-can't-round-trip case: the driver dispatches on
the predicate so the flat-image path never reaches `emit_object`/`parse_object`.

## #1617 (same area, trivial)

`os_id_for` has accepted `freestanding` since #1613, but the unknown-os
diagnostic still read `(expected: linux, darwin, windows)`. Now lists
`freestanding`.

## Verification

A new `test/freestanding` fixture (a minimal `os=freestanding, of=raw` x86_64
program: a counted loop summing 0..9, then a raw `exit` syscall) builds end to
end to a flat image. `verify.sh` (modeled on `test/macho` / `test/riscv64`):
asserts no `.o` was written (round-trip bypassed), confirms the output is a
container-free flat binary (no ELF header), then mmaps the position-independent
image into an executable page and runs it, asserting exit code 45. A CI lane
builds a compiler from PR source and runs it.

Built with the modified compiler:
- `mach build .` on the fixture prints `link 1 image(s)` and produces the flat
  image with zero `.o` files.
- The 176-byte flat image disassembles to the expected prologue/loop/`exit`
  syscall, entered at offset 0 (the image base), and runs to exit code 45.
- The unknown-os diagnostic now reads
  `(expected: linux, darwin, windows, freestanding)`.

Self-host fixpoint (`a->b->c`, `cmp b c`) and `mach test .` results are added as
a comment once the rebuild completes.
