### PR TITLE
feat(sema): secret-qualifier flow typing - join, gate, welded-storage pointers

### DIFF
--- a/doc/language/README.md
+++ b/doc/language/README.md
@@ -31,6 +31,7 @@ neighboring links; start from the index below.
 
 - [literals.md](literals.md) — numeric, char, string
 - [types.md](types.md) — primitive grammar, compound types
+- [secrecy.md](secrecy.md) — the `^` secret qualifier, flow typing, gates, `:^`
 - [operators.md](operators.md) — arithmetic, bitwise, comparison, logical, pointer, cast
 - [expressions.md](expressions.md) — construction, access, calls, generic instantiation
 

--- a/doc/language/grammar.md
+++ b/doc/language/grammar.md
@@ -408,8 +408,10 @@ Notes:
 - `^T` marks `T` as carrying secret data for the constant-time guarantee
   (#1643). It is a prefix qualifier binding to the type immediately to its
   right, so it nests with `*` and `[N]` in any order (`*^u8`, `^*u8`,
-  `[N]^u8`). The grammar accepts it in every type position; its flow-typing
-  semantics are not yet enforced (tracked by #1645).
+  `[N]^u8`). The grammar accepts it in every type position. Its flow-typing
+  semantics - the secrecy lattice and join, the leakage-model gates, and the
+  welded-storage pointer rules - are enforced by sema (#1645) and documented in
+  [secrecy.md](secrecy.md).
 - `*T` is a pointer; the untyped pointer type is the primitive name `ptr`
   (an ordinary `named-type`, not its own syntax).
 - `[N]T` is a fixed-length array; `N` is a full expression (a comptime
@@ -487,12 +489,13 @@ cast         ::= ( "::" | ":~" ) type
 ```
 
 `::` is a value conversion and `:~` a same-size bit reinterpret; see
-[operators.md](operators.md#cast). `:^` strips the `^` secret qualifier from
-the operand's type (#1643): a bare `:^` needs no target, while `:^Type` takes
-an optional named target for parallelism with `:~Type`. A non-`named-type`
-lead (`*`, `[`, ...) after `:^` leaves a bare strip so it still binds as a
-multiply/index on the stripped value. Its semantics are not yet enforced
-(tracked by #1645). All three bind as postfix.
+[operators.md](operators.md#cast). Neither `::` nor `:~` may add or drop the
+`^` secret qualifier. `:^` is the only downgrade: it strips `^` from the
+operand's type, producing a new public value (#1643, [secrecy.md](secrecy.md)).
+A bare `:^` needs no target, while `:^Type` names the operand's stripped public
+type (`:^` never reinterprets storage). A non-`named-type` lead (`*`, `[`, ...)
+after `:^` leaves a bare strip so it still binds as a multiply/index on the
+stripped value. All three bind as postfix.
 
 Disambiguating a postfix `[`: a bracket whose matching `]` is **not** followed
 by `(` is always an index `obj[idx]`. When it **is** followed by `(`, the

--- a/doc/language/operators.md
+++ b/doc/language/operators.md
@@ -104,7 +104,12 @@ val b: u64 = 1.5:~u64;          # 0x3FF8000000000000 (raw IEEE-754 bits)
 val f: f64 = b:~f64;            # 1.5                (bits read back as a float)
 ```
 
+Neither `::` nor `:~` may add or drop the `^` secret qualifier, and neither can
+erase a secret-welded pointer to `ptr`. The only downgrade is the `:^` strip
+cast. See [secrecy.md](secrecy.md).
+
 ## See also
 
 - [expressions.md](expressions.md) — how operators compose into expressions
 - [types.md](types.md) — which types support which operators
+- [secrecy.md](secrecy.md) — the `^` secret qualifier and the `:^` strip cast

--- a/doc/language/secrecy.md
+++ b/doc/language/secrecy.md
@@ -1,0 +1,103 @@
+# `^` — the secret qualifier
+
+`^T` marks a type as carrying secret data for Mach's constant-time guarantee.
+Sema tracks secrecy as an information-flow discipline: secret data may move and
+be stored, but it may never reach a position a classical leakage model observes
+(a branch, a memory address, a variable-latency instruction). This page covers
+the flow-typing rules. The grammar lives in [grammar.md](grammar.md); the
+`#[oblivious]` codegen contract that turns these types into a per-build proof is
+separate.
+
+## Secrecy lattice
+
+There are two secrecy levels in a two-point lattice: public is the bottom,
+secret the top. `^` lifts a type to secret and binds to the type immediately to
+its right, so it nests with `*` and `[N]` in any order: `^u32`, `*^u8`, `^*u8`,
+`[N]^u8`, `^MyRec`. Doubling collapses: `^^T` is `^T`.
+
+A public value coerces *up* to secret wherever a secret is expected, with no
+syntax:
+
+```mach
+fun up(p: u32) ^u32 { ret p; }      # public u32 flows into a secret slot
+```
+
+The reverse never happens implicitly. The only downgrade is the explicit `:^`
+strip below.
+
+## Join
+
+Any operation with a secret operand yields a secret result. Taint joins across
+arithmetic, bitwise, shift, and comparison operators, and through a value read
+out of a secret container:
+
+```mach
+fun mix(a: ^u32, b: u32) ^u32 { ret a + b; }    # ^u32 + u32 -> ^u32
+rec Key { d: ^[32]u8; }
+fun first(k: Key) ^u8 { ret k.d[0]; }            # element of a secret array is ^u8
+```
+
+`&T` of a `^T` value is the public pointer `*^T` (the address is public, the
+pointee secret), and dereferencing `*^T` recovers the secret `^T`.
+
+## Gates
+
+A secret may not reach a position the leakage model observes. Each is a compile
+error decided by operand type:
+
+- a secret branch or loop condition (`if`, `for`)
+- a secret short-circuiting `&&` / `||` operand (it controls a branch)
+- a secret memory index (`table[i]` with `i` secret)
+- a secret operand of the always-variable-latency `/` or `%`
+
+```mach
+fun leak(a: ^u32, t: *u8) u8 {
+    if (a) { ret 1; }       # error: secret value used as a branch condition
+    ret t[a];               # error: secret value used as a memory index
+}
+```
+
+Floating-point operations (gated by default) and integer multiply (gated per the
+target's constant-time capability) join these once the codegen taint contract
+lands.
+
+## Downgrade with `:^`
+
+`:^` is the only way to remove `^`. It produces a new public value and never
+reinterprets storage in place:
+
+```mach
+fun publish(a: ^u32) u32 { ret a:^; }       # bare strip
+fun publish2(a: ^u32) u32 { ret a:^u32; }   # explicit target names the public type
+```
+
+`:^` peels exactly the outer qualifier, so it can never launder a welded pointee
+(`*^T` stays `*^T`). `::` and `:~` may neither add nor drop `^`.
+
+## Welded-storage pointers
+
+Secrecy is fixed at declaration and is non-launderable, which makes the
+public/secret aliasing leak unconstructable with no alias analysis:
+
+- a `^T` is stored only through a `*^T`, never a `*T` (the lattice forbids the
+  downgrade)
+- a secret-welded pointer cannot be erased to the untyped `ptr`
+- a `uni`'s overlapping variants must agree on secrecy
+
+```mach
+fun erase(p: *^u8) ptr { ret p; }     # error: cannot erase a secret pointer to ptr
+uni Bad { a: ^u32; b: u32; }          # error: variants disagree on secrecy
+```
+
+## Trusted base
+
+The only secret-to-public crossings are the explicit `:^` cast and inline `asm`
+blocks (which a type system cannot check). Everything else is enforced. A proof
+is always relative to a leakage model. Its fidelity to real silicon is
+empirical.
+
+## See also
+
+- [types.md](types.md) — the compound type grammar `^` qualifies
+- [operators.md](operators.md) — the `::` / `:~` casts that preserve secrecy
+- [grammar.md](grammar.md) — the formal grammar of `^` and `:^`

--- a/doc/language/secrecy.md
+++ b/doc/language/secrecy.md
@@ -46,7 +46,8 @@ A secret may not reach a position the leakage model observes. Each is a compile
 error decided by operand type:
 
 - a secret branch or loop condition (`if`, `for`)
-- a secret short-circuiting `&&` / `||` operand (it controls a branch)
+- a secret left operand of a short-circuiting `&&` / `||` (it is the branch the
+  operator keys on; a secret right operand only taints the result)
 - a secret memory index (`table[i]` with `i` secret)
 - a secret operand of the always-variable-latency `/` or `%`
 

--- a/doc/language/types.md
+++ b/doc/language/types.md
@@ -78,5 +78,6 @@ val r:  i64   = op(2, 3);
 
 ## See also
 
+- [secrecy.md](secrecy.md) — the `^` secret qualifier over any of these types
 - [operators.md](operators.md) — what operations work on each type
 - [comptime-intrinsics.md](comptime-intrinsics.md) — `$size_of`, `$align_of`

--- a/doc/language/uni.md
+++ b/doc/language/uni.md
@@ -33,6 +33,11 @@ pub uni Maybe[T] {
 A `uni`'s size is the size of its largest field, plus any alignment
 padding.
 
+A `uni`'s overlapping variants must agree on secrecy: every field is either
+secret (`^`) or every field is public. A mixed union would let the same storage
+be read at two secrecy classifications, the aliasing leak the welded-storage
+rules forbid. See [secrecy.md](secrecy.md).
+
 ## Discriminated values — by convention
 
 Mach has no tagged-union construct and no pattern-matching dispatch.
@@ -57,3 +62,4 @@ the composed form already expresses honestly.
 
 - [rec.md](rec.md) — the discriminator-and-payload outer shape
 - [statements.md](statements.md) — `if`/`or` chains for discrimination
+- [secrecy.md](secrecy.md) — why overlapping variants must agree on secrecy

--- a/src/lang/driver.mach
+++ b/src/lang/driver.mach
@@ -5636,3 +5636,100 @@ test "mach.lang.driver:incremental_sema_reshape_renumber_recheck" {
     session.dnit(?sA);
     ret bad;
 }
+
+# scaffold a single-module project from `text`, run parse + resolve + the sema
+# pass, and return its error-diagnostic count (-1 on a harness failure). the
+# secret flow-typing matrix below asserts this count against an expectation
+# (#1645).
+fun ut_sema_errs(text: str) i32 {
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret -1; }
+    val sr: R.Result[session.Session, str] = session.init(?alloc);
+    if (R.is_err[session.Session, str](sr)) { ret -1; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](sr);
+
+    var names: [1]str;
+    names[0] = "main.mach";
+    var texts: [1]str;
+    texts[0] = text;
+
+    val pr: R.Result[Project, str] = ut_build(?s, ?alloc, ?names[0], ?texts[0], 1);
+    if (R.is_err[Project, str](pr)) { session.dnit(?s); ret -1; }
+    var p: Project = R.unwrap_ok[Project, str](pr);
+
+    var errs: i32 = -1;
+    val sem: R.Result[bool, str] = run_sema_pass(?p);
+    if (R.is_ok[bool, str](sem)) { errs = ut_count_errors(?s.diags)::i32; }
+
+    dnit_project(?p);
+    session.dnit(?s);
+    ret errs;
+}
+
+# whether `text` type-checks with zero sema errors.
+fun ut_sema_clean(text: str) bool { ret ut_sema_errs(text) == 0; }
+
+# whether `text` is rejected with at least one sema error.
+fun ut_sema_rejects(text: str) bool { ret ut_sema_errs(text) > 0; }
+
+# secret flow typing: a clean program exercising the join, the implicit
+# public->secret up-coerce, the `:^` strip, secret record fields, storing public
+# through `*^T`, and an all-secret union, all without a sema error (#1645).
+test "mach.lang.driver:secret_join_coerce_strip_clean" {
+    val src: str = "rec Key { d: ^[32]u8; }\nuni Both { a: ^u32; b: ^u32; }\nfun join(a: ^u32, b: ^u32) ^u32 { ret a + b; }\nfun join_pub(a: ^u32) ^u32 { ret a * 2; }\nfun up(p: u32) ^u32 { ret p; }\nfun down(a: ^u32) u32 { ret a:^; }\nfun down_typed(a: ^u32) u32 { ret a:^u32; }\nfun store_ok(p: *^u8, v: u8) { @p = v; }\nfun field_read(k: Key) ^u8 { ret k.d[0]; }\nfun main() i32 { ret 0; }\n";
+    if (!ut_sema_clean(src)) { ret 1; }
+    ret 0;
+}
+
+# secret flow typing: every classical-leakage gate rejects a secret operand - a
+# branch / loop condition, a memory index, the always-variable-latency `/` and
+# `%`, and a short-circuiting `&&`. the same code on public operands is clean, so
+# the gates key on secrecy, not shape (#1645).
+test "mach.lang.driver:secret_gates_rejected" {
+    var bad: i32 = 0;
+    if (!ut_sema_rejects("fun f(a: ^u32) i32 { if (a) { ret 1; } ret 0; }\nfun main() i32 { ret 0; }\n"))  { bad = 1; }
+    if (!ut_sema_rejects("fun f(a: ^u32) i32 { for (a) { ret 1; } ret 0; }\nfun main() i32 { ret 0; }\n")) { bad = 1; }
+    if (!ut_sema_rejects("fun f(t: *u8, i: ^u64) u8 { ret t[i]; }\nfun main() i32 { ret 0; }\n"))          { bad = 1; }
+    if (!ut_sema_rejects("fun f(a: ^u32, b: ^u32) ^u32 { ret a / b; }\nfun main() i32 { ret 0; }\n"))      { bad = 1; }
+    if (!ut_sema_rejects("fun f(a: ^u32, b: ^u32) ^u32 { ret a % b; }\nfun main() i32 { ret 0; }\n"))      { bad = 1; }
+    if (!ut_sema_rejects("fun f(a: ^u32, b: u32) ^u8 { ret a && b; }\nfun main() i32 { ret 0; }\n"))       { bad = 1; }
+    if (!ut_sema_clean("fun f(a: u32) i32 { if (a) { ret 1; } ret 0; }\nfun main() i32 { ret 0; }\n"))     { bad = 1; }
+    if (!ut_sema_clean("fun f(t: *u8, i: u64) u8 { ret t[i]; }\nfun main() i32 { ret 0; }\n"))             { bad = 1; }
+    if (!ut_sema_clean("fun f(a: u32, b: u32) u32 { ret a / b; }\nfun main() i32 { ret 0; }\n"))           { bad = 1; }
+    ret bad;
+}
+
+# secret flow typing: `::` and `:~` can neither drop nor add the `^` qualifier
+# (the only downgrade is `:^`), but a cast that preserves secrecy is fine (#1645).
+test "mach.lang.driver:secret_cast_secrecy_rejected" {
+    var bad: i32 = 0;
+    if (!ut_sema_rejects("fun f(a: ^u32) u32 { ret a::u32; }\nfun main() i32 { ret 0; }\n"))                  { bad = 1; }
+    if (!ut_sema_rejects("fun f(a: u32) i32 { var s: ^u32 = a::^u32; ret 0; }\nfun main() i32 { ret 0; }\n")) { bad = 1; }
+    if (!ut_sema_rejects("fun f(a: ^u32) u32 { ret a:~u32; }\nfun main() i32 { ret 0; }\n"))                  { bad = 1; }
+    if (!ut_sema_clean("fun f(a: ^u32) ^u64 { ret a::^u64; }\nfun main() i32 { ret 0; }\n"))                  { bad = 1; }
+    ret bad;
+}
+
+# secret flow typing: welded-storage pointers are non-launderable - a `*^T`
+# cannot be erased to the untyped `ptr` (by return-coercion or by `:~`), and a
+# secret cannot be stored through a public `*T`; a public `*T` still erases to
+# `ptr` freely (#1645).
+test "mach.lang.driver:secret_pointer_not_launderable" {
+    var bad: i32 = 0;
+    if (!ut_sema_rejects("fun f(p: *^u8) ptr { ret p; }\nfun main() i32 { ret 0; }\n"))      { bad = 1; }
+    if (!ut_sema_rejects("fun f(p: *^u8) ptr { ret p:~ptr; }\nfun main() i32 { ret 0; }\n")) { bad = 1; }
+    if (!ut_sema_rejects("fun f(p: *u8, s: ^u8) { @p = s; }\nfun main() i32 { ret 0; }\n"))   { bad = 1; }
+    if (!ut_sema_clean("fun f(p: *u8) ptr { ret p; }\nfun main() i32 { ret 0; }\n"))          { bad = 1; }
+    ret bad;
+}
+
+# secret flow typing: a `uni`'s overlapping variants must agree on secrecy -
+# a part-secret part-public union is rejected, a uniformly secret or uniformly
+# public one is accepted (#1645).
+test "mach.lang.driver:secret_uni_field_secrecy" {
+    var bad: i32 = 0;
+    if (!ut_sema_rejects("uni U { a: ^u32; b: u32; }\nfun main() i32 { ret 0; }\n")) { bad = 1; }
+    if (!ut_sema_clean("uni U { a: ^u32; b: ^u32; }\nfun main() i32 { ret 0; }\n"))  { bad = 1; }
+    if (!ut_sema_clean("uni U { a: u32; b: u32; }\nfun main() i32 { ret 0; }\n"))    { bad = 1; }
+    ret bad;
+}

--- a/src/lang/driver.mach
+++ b/src/lang/driver.mach
@@ -5696,6 +5696,9 @@ test "mach.lang.driver:secret_gates_rejected" {
     if (!ut_sema_clean("fun f(a: u32) i32 { if (a) { ret 1; } ret 0; }\nfun main() i32 { ret 0; }\n"))     { bad = 1; }
     if (!ut_sema_clean("fun f(t: *u8, i: u64) u8 { ret t[i]; }\nfun main() i32 { ret 0; }\n"))             { bad = 1; }
     if (!ut_sema_clean("fun f(a: u32, b: u32) u32 { ret a / b; }\nfun main() i32 { ret 0; }\n"))           { bad = 1; }
+    # `&&` branches on the LEFT operand only: a public left with a secret right
+    # is no secret branch (the result is still tainted secret)
+    if (!ut_sema_clean("fun f(a: u32, b: ^u32) ^u8 { ret a && b; }\nfun main() i32 { ret 0; }\n"))         { bad = 1; }
     ret bad;
 }
 

--- a/src/lang/fe/resolve.mach
+++ b/src/lang/fe/resolve.mach
@@ -2717,6 +2717,9 @@ fun bind_type(rc: *ResolveContext, tid: id.TypeId) R.Result[bool, str] {
     if (t.kind == atype.TYPE_KIND_PTR) {
         ret bind_type(rc, t.data.ptr.pointee);
     }
+    if (t.kind == atype.TYPE_KIND_SECRET) {
+        ret bind_type(rc, t.data.secret.inner);
+    }
     if (t.kind == atype.TYPE_KIND_ARRAY) {
         val re: R.Result[bool, str] = bind_expr(rc, t.data.array.length);
         if (R.is_err[bool, str](re)) { ret re; }

--- a/src/lang/fe/sema/check.mach
+++ b/src/lang/fe/sema/check.mach
@@ -261,7 +261,21 @@ pub fun imported_module_const_sym(sc: *context.SemaContext, sym: *resolve.Symbol
 pub fun check_index(sc: *context.SemaContext, object: type.TypeId, index: type.TypeId, span: token.Span) O.Option[type.TypeId] {
     if (object == type.TYPE_ERROR) { ret O.some[type.TypeId](type.TYPE_ERROR); }
 
-    val opt_object: O.Option[*type.Type] = type.get(?sc.s.types, object);
+    # GATE: a secret index becomes a secret-dependent memory address the leakage
+    # model observes through the access trace (#1645). reported before the integer
+    # check, which sees through the `^` and would otherwise accept it.
+    if (index != type.TYPE_ERROR && type.is_secret(?sc.s.types, index)) {
+        report_note(sc, span, "secret value used as a memory index",
+            "a secret may not address memory; the access pattern leaks through the cache trace. index by a public value, or load the whole table obliviously");
+    }
+
+    # a secret container `^[N]T` / `^*T` is indexed through its inner type, and
+    # the secrecy joins onto the element (every element of a secret aggregate is
+    # secret). `[N]^T` carries the `^` on the element directly.
+    val obj_secret: bool = type.is_secret(?sc.s.types, object);
+    val base_obj:   type.TypeId = type.strip_secret(?sc.s.types, object);
+
+    val opt_object: O.Option[*type.Type] = type.get(?sc.s.types, base_obj);
     if (O.is_none[*type.Type](opt_object)) {
         report(sc, span, "not indexable: object is neither a pointer nor an array");
         ret O.none[type.TypeId]();
@@ -283,6 +297,7 @@ pub fun check_index(sc: *context.SemaContext, object: type.TypeId, index: type.T
     if (index != type.TYPE_ERROR && !is_integer(sc, index)) {
         report(sc, span, "type mismatch: index must be an integer");
     }
+    if (obj_secret) { elem = secret_of(sc, elem); }
     ret O.some[type.TypeId](elem);
 }
 
@@ -302,9 +317,19 @@ pub fun check_index(sc: *context.SemaContext, object: type.TypeId, index: type.T
 pub fun check_member(sc: *context.SemaContext, object: type.TypeId, name: intern.StrId, span: token.Span) O.Option[type.TypeId] {
     if (object == type.TYPE_ERROR) { ret O.some[type.TypeId](type.TYPE_ERROR); }
 
-    val record: type.TypeId = deref_one(sc, object);
+    # a secret container taints every field read out of it: accessing a field of a
+    # `^Rec` (or through a `*^Rec`) yields a secret value. the field's own
+    # declared `^` (e.g. `d: ^[32]u8`) joins with the container's.
+    val deref:          type.TypeId = deref_one(sc, type.strip_secret(?sc.s.types, object));
+    val container_secret: bool      = type.is_secret(?sc.s.types, object) || type.is_secret(?sc.s.types, deref);
+    val record:         type.TypeId = type.strip_secret(?sc.s.types, deref);
+
     val opt_field: O.Option[type.TypeId] = context.field_lookup(sc, record, name);
-    if (O.is_some[type.TypeId](opt_field)) { ret opt_field; }
+    if (O.is_some[type.TypeId](opt_field)) {
+        var fty: type.TypeId = O.unwrap[type.TypeId](opt_field);
+        if (container_secret) { fty = secret_of(sc, fty); }
+        ret O.some[type.TypeId](fty);
+    }
 
     report_no_field(sc, span, name, record);
     ret O.none[type.TypeId]();
@@ -325,7 +350,14 @@ pub fun check_cast(sc: *context.SemaContext, from: type.TypeId, to: type.TypeId,
     if (from == type.TYPE_ERROR || to == type.TYPE_ERROR) { ret O.some[type.TypeId](to); }
     if (from == to)                                       { ret O.some[type.TypeId](to); }
 
-    # primitive numeric <-> primitive numeric conversion
+    # the welded-storage discipline (#1645): `::` may neither launder a secret
+    # pointer to the untyped `ptr` nor add / drop a `^`. checked before the
+    # value-conversion rules, which strip secrecy to size and classify operands.
+    if (!check_secrecy_cast(sc, from, to, span)) { ret O.none[type.TypeId](); }
+
+    # primitive numeric <-> primitive numeric conversion (secrecy preserved: the
+    # secrecy check above already proved from and to agree, so the result keeps
+    # whatever `^` the target was written with)
     if (is_numeric(sc, from) && is_numeric(sc, to)) {
         ret O.some[type.TypeId](to);
     }
@@ -343,6 +375,36 @@ pub fun check_cast(sc: *context.SemaContext, from: type.TypeId, to: type.TypeId,
     ret O.none[type.TypeId]();
 }
 
+# enforce the welded-storage secrecy rules common to `::` and `:~` (#1645)
+#
+# Two prohibitions keep the public/secret aliasing leak unconstructable with no
+# alias analysis: a secret-welded pointer (`*^T` and friends) may never be erased
+# to the untyped `ptr`, and a cast may never add or drop a `^` (that is the sole
+# job of the implicit up-coerce and the `:^` strip). Differing inner leaf shapes
+# the cast genuinely converts are unaffected - only `^` placement is compared.
+# ---
+# sc:   the active sema context
+# from: the operand's type
+# to:   the target type
+# span: source range of the cast
+# ret:  true when the cast respects secrecy, false (with a diagnostic) otherwise
+fun check_secrecy_cast(sc: *context.SemaContext, from: type.TypeId, to: type.TypeId, span: token.Span) bool {
+    val from_raw_ptr: bool = from == type.TYPE_PTR;
+    val to_raw_ptr:   bool = to == type.TYPE_PTR;
+    if ((from_raw_ptr && type.carries_secret(?sc.s.types, to))
+        || (to_raw_ptr && type.carries_secret(?sc.s.types, from))) {
+        report_note(sc, span, "cast: a secret-welded pointer cannot be erased to the untyped `ptr`",
+            "secret memory is reached only through secrecy-typed pointers; erasing `^` to `ptr` would let a public alias read it");
+        ret false;
+    }
+    if (!type.secrecy_structure_equal(?sc.s.types, from, to)) {
+        report_note(sc, span, "cast: `::` and `:~` cannot add or drop the secret qualifier `^`",
+            "a public value coerces up to secret with no syntax; `:^` is the only downgrade");
+        ret false;
+    }
+    ret true;
+}
+
 # checks a bit-reinterpret cast `value:~Type`
 #
 # legal only when `from` and `to` have a known, identical byte size; the
@@ -357,6 +419,10 @@ pub fun check_cast(sc: *context.SemaContext, from: type.TypeId, to: type.TypeId,
 # ret:  some(to) when the reinterpret is legal, none (with a diagnostic) otherwise
 pub fun check_reinterpret(sc: *context.SemaContext, from: type.TypeId, to: type.TypeId, span: token.Span) O.Option[type.TypeId] {
     if (from == type.TYPE_ERROR || to == type.TYPE_ERROR) { ret O.some[type.TypeId](to); }
+
+    # `:~` is bound by the same welded-storage secrecy rules as `::` - it can
+    # neither erase a secret pointer to `ptr` nor change a `^` (#1645).
+    if (!check_secrecy_cast(sc, from, to, span)) { ret O.none[type.TypeId](); }
 
     val size_from: u32 = byte_size(sc, from);
     val size_to:   u32 = byte_size(sc, to);
@@ -403,6 +469,14 @@ pub fun check_return(sc: *context.SemaContext, fn_ret: type.TypeId, value: type.
 # ret:  true when the condition is an integer primitive, false otherwise
 pub fun check_condition(sc: *context.SemaContext, cond: type.TypeId, span: token.Span) bool {
     if (cond == type.TYPE_ERROR) { ret true; }
+    # GATE: a secret condition is a secret-dependent branch the leakage model
+    # observes through the control-flow trace (#1645). reported before the integer
+    # check, which sees through the `^` and would otherwise accept it.
+    if (type.is_secret(?sc.s.types, cond)) {
+        report_note(sc, span, "secret value used as a branch condition",
+            "a secret may not steer control flow; branching on it leaks through timing. compute branch-free, or `:^` to a public value when disclosure is intended");
+        ret false;
+    }
     if (is_integer(sc, cond))    { ret true; }
     report_note(sc, span, "type mismatch: condition must be an integer",
         "mach has no `bool` type; comparisons yield an integer truth value");
@@ -431,18 +505,34 @@ pub fun is_integer(sc: *context.SemaContext, t: type.TypeId) bool {
     ret type.is_integer(?sc.s.types, t);
 }
 
+# wrap `t` in the secret qualifier `^t`, used by the secrecy JOIN when a secret
+# container taints a value read out of it (#1645)
+#
+# A doubled qualifier collapses in intern_secret; an allocation failure degrades
+# to `t` unchanged (the diagnostic for the real error lands elsewhere).
+# ---
+# sc:  the active sema context
+# t:   the type to qualify
+# ret: `^t`, or `t` unchanged on an allocation failure
+fun secret_of(sc: *context.SemaContext, t: type.TypeId) type.TypeId {
+    val r: R.Result[type.TypeId, str] = type.intern_secret(?sc.s.types, t);
+    if (R.is_err[type.TypeId, str](r)) { ret t; }
+    ret R.unwrap_ok[type.TypeId, str](r);
+}
+
 # the byte size of a type, resolving pointers/arrays/records via the interner
 #
 # pointer and function values are pointer-sized, read from the target's pointer
 # width; records and unions report 0 because their layout is not computed in
 # sema (the backend owns layout). a 0 result signals "size unknown" and disables
-# same-size cast reinterpretation.
+# same-size cast reinterpretation. secrecy has no runtime width, so a `^T` sizes
+# exactly as `T`.
 # ---
 # sc:  the active sema context
 # t:   a TypeId
 # ret: the size in bytes, or 0 when the size is not known at this layer
 pub fun byte_size(sc: *context.SemaContext, t: type.TypeId) u32 {
-    val opt_type: O.Option[*type.Type] = type.get(?sc.s.types, t);
+    val opt_type: O.Option[*type.Type] = type.get(?sc.s.types, type.strip_secret(?sc.s.types, t));
     if (O.is_none[*type.Type](opt_type)) { ret 0; }
     val tp: *type.Type    = O.unwrap[*type.Type](opt_type);
     val k:  type.TypeKind = tp.kind;
@@ -1087,6 +1177,9 @@ fun type_str_len(sc: *context.SemaContext, t: type.TypeId) usize {
     if (k == type.TYPE_POINTER) {
         ret 1 + type_str_len(sc, tp.data.pointer.base);
     }
+    if (k == type.TYPE_SECRET) {
+        ret 1 + type_str_len(sc, tp.data.secret.base);
+    }
     if (k == type.TYPE_ARRAY) {
         ret 1 + decimal_len(tp.data.array.count::usize) + 1 + type_str_len(sc, tp.data.array.base);
     }
@@ -1134,6 +1227,10 @@ fun write_type_str(sc: *context.SemaContext, buf: str, k: usize, t: type.TypeId)
     if (kind == type.TYPE_POINTER) {
         val w: usize = write_char(buf, k, '*');
         ret write_type_str(sc, buf, w, tp.data.pointer.base);
+    }
+    if (kind == type.TYPE_SECRET) {
+        val w: usize = write_char(buf, k, '^');
+        ret write_type_str(sc, buf, w, tp.data.secret.base);
     }
     if (kind == type.TYPE_ARRAY) {
         var w: usize = write_char(buf, k, '[');

--- a/src/lang/fe/sema/coerce.mach
+++ b/src/lang/fe/sema/coerce.mach
@@ -55,7 +55,15 @@ use mach.lang.type;
 #      updated), none when no literal coercion applies
 pub fun try_coerce_literal(sc: *context.SemaContext, eid: id.ExprId, to: type.TypeId) O.Option[type.TypeId] {
     if (to == type.TYPE_NIL || to == type.TYPE_ERROR) { ret O.none[type.TypeId](); }
-    ret coerce_to(sc, eid, to, false);
+
+    # a literal flowing into a secret slot fixes against the public base (a
+    # literal is public), then takes the secret type via the implicit up-coerce
+    # (public is the bottom of the lattice). so `var s: ^u32 = 5;` types `5` as
+    # `^u32` (#1645).
+    val pub_to: type.TypeId = type.strip_secret(?sc.s.types, to);
+    val r: O.Option[type.TypeId] = coerce_to(sc, eid, pub_to, false);
+    if (O.is_some[type.TypeId](r) && pub_to != to) { ret commit(sc, eid, to); }
+    ret r;
 }
 
 # recursive core of try_coerce_literal, dispatching on the expression's kind
@@ -286,6 +294,19 @@ fun commit(sc: *context.SemaContext, eid: id.ExprId, to: type.TypeId) O.Option[t
 pub fun is_assignable(sc: *context.SemaContext, from: type.TypeId, to: type.TypeId) bool {
     if (from == to)                                       { ret true; }
     if (from == type.TYPE_ERROR || to == type.TYPE_ERROR) { ret true; }
+
+    # the secrecy lattice (#1645): public is the bottom, secret the top. a value
+    # coerces UP to a secret slot with no syntax, so a secret destination accepts
+    # a public or secret source of the same base. the reverse - a secret source
+    # into a public slot - is the forbidden downgrade and falls through to fail
+    # (only the explicit `:^` strip downgrades).
+    val to_secret:   bool = type.is_secret(?sc.s.types, to);
+    val from_secret: bool = type.is_secret(?sc.s.types, from);
+    if (to_secret) {
+        ret is_assignable(sc, type.strip_secret(?sc.s.types, from), type.strip_secret(?sc.s.types, to));
+    }
+    if (from_secret) { ret false; }
+
     if (ptr_compatible(sc, from, to))                     { ret true; }
     ret type.type_equals_signatures(?sc.s.types, from, to);
 }
@@ -301,8 +322,15 @@ pub fun is_assignable(sc: *context.SemaContext, from: type.TypeId, to: type.Type
 # to:   the second type
 # ret:  true when one side is the raw `ptr` and the other a typed `*T`
 fun ptr_compatible(sc: *context.SemaContext, from: type.TypeId, to: type.TypeId) bool {
-    if (from == type.TYPE_PTR && is_typed_pointer(sc, to)) { ret true; }
-    if (to == type.TYPE_PTR && is_typed_pointer(sc, from)) { ret true; }
+    # the welded-storage rule (#1645): the untyped `ptr` interconverts with any
+    # typed pointer EXCEPT one carrying secret data. erasing a `*^T` to `ptr`
+    # would let a public alias read secret memory, so it is unconstructable.
+    if (from == type.TYPE_PTR && is_typed_pointer(sc, to)) {
+        ret !type.carries_secret(?sc.s.types, to);
+    }
+    if (to == type.TYPE_PTR && is_typed_pointer(sc, from)) {
+        ret !type.carries_secret(?sc.s.types, from);
+    }
     ret false;
 }
 

--- a/src/lang/fe/sema/generics.mach
+++ b/src/lang/fe/sema/generics.mach
@@ -184,6 +184,15 @@ pub fun substitute(s: *session.Session, body_type: type.TypeId, args: *type.Type
         ret unwrap_or_error(type.intern_array(?s.types, base, count));
     }
 
+    # a `^T` body type specializes its inner type and re-wraps the qualifier, so
+    # `^T` instantiated at `u32` becomes `^u32` (#1645).
+    if (t.kind == type.TYPE_SECRET) {
+        val original_base: type.TypeId = t.data.secret.base;
+        val base:          type.TypeId = substitute(s, original_base, args, arg_count);
+        if (base == original_base) { ret body_type; }
+        ret unwrap_or_error(type.intern_secret(?s.types, base));
+    }
+
     if (t.kind == type.TYPE_FUN)      { ret substitute_fun(s, t, args, arg_count, body_type); }
     if (t.kind == type.TYPE_INSTANCE) { ret substitute_instance(s, t, args, arg_count, body_type); }
 
@@ -594,6 +603,7 @@ fun mentions_gparam(s: *session.Session, tid: type.TypeId, scan: *GParamScan) bo
 
     if (t.kind == type.TYPE_GENERIC_PARAM) { ret true; }
     if (t.kind == type.TYPE_POINTER)       { ret mentions_gparam(s, t.data.pointer.base, scan); }
+    if (t.kind == type.TYPE_SECRET)        { ret mentions_gparam(s, t.data.secret.base, scan); }
     if (t.kind == type.TYPE_ARRAY)         { ret mentions_gparam(s, t.data.array.base, scan); }
     if (t.kind == type.TYPE_REC || t.kind == type.TYPE_UNI) {
         ret nominal_fields_mention(s, tid, scan);

--- a/src/lang/fe/sema/infer.mach
+++ b/src/lang/fe/sema/infer.mach
@@ -606,7 +606,8 @@ fun infer_binary(sc: *context.SemaContext, eid: id.ExprId, b: *expr.ExprBinary, 
     # secrecy JOIN: an operation with any secret operand yields a secret result
     # (public is the bottom of the lattice). taint is read from the original
     # operands here and reapplied to whatever result type each operator computes.
-    val either_secret: bool = type.is_secret(?sc.s.types, lt) || type.is_secret(?sc.s.types, rt);
+    val lhs_secret:    bool = type.is_secret(?sc.s.types, lt);
+    val either_secret: bool = lhs_secret || type.is_secret(?sc.s.types, rt);
 
     # GATE: `/` and `%` are variable-latency on every target (the leakage model
     # always observes them), so a secret operand is a compile error here. the
@@ -663,10 +664,12 @@ fun infer_binary(sc: *context.SemaContext, eid: id.ExprId, b: *expr.ExprBinary, 
             context.report(sc, span, "type mismatch: logical operands must be integer types");
             ret type.TYPE_ERROR;
         }
-        # GATE: `&&` / `||` short-circuit, so a secret operand becomes a
-        # secret-dependent branch the leakage model observes.
-        if (either_secret) {
-            context.report(sc, span, "secret value used as an operand of a short-circuiting `&&` / `||`; the branch it controls leaks through control flow");
+        # GATE: `&&` / `||` short-circuit by branching on the LEFT operand (the
+        # right is evaluated conditionally), so a secret left operand is the
+        # secret-dependent branch the leakage model observes. a secret right
+        # operand only taints the result (no branch keys on it).
+        if (lhs_secret) {
+            context.report(sc, span, "secret value used as the left operand of a short-circuiting `&&` / `||`; the branch it controls leaks through control flow");
         }
         ret join_secret(sc, u8t, either_secret);
     }

--- a/src/lang/fe/sema/infer.mach
+++ b/src/lang/fe/sema/infer.mach
@@ -168,8 +168,35 @@ fun infer_nominal_uni(sc: *context.SemaContext, did: id.DeclId, name_span: token
     val ty: type.TypeId = R.unwrap_ok[type.TypeId, str](tr);
 
     build_field_table(sc, ty, u.fields_start, u.fields_len);
+    check_uni_secrecy(sc, u.fields_start, u.fields_len);
     record_type_align(sc, did, ty);
     ret ty;
+}
+
+# enforce that a union's overlapping variants agree on secrecy (#1645)
+#
+# A `uni`'s fields share storage, so a mixed-secrecy union would let the same
+# bytes be read as both secret and public - the welded-storage aliasing leak. All
+# variants must be uniformly secret or uniformly public. The first variant whose
+# secrecy disagrees with the first variant's is reported on its own field span.
+# ---
+# sc:           sema context
+# fields_start: start index into ast.typed_names
+# fields_len:   number of variants
+fun check_uni_secrecy(sc: *context.SemaContext, fields_start: u32, fields_len: u32) {
+    if (fields_len < 2) { ret; }
+
+    val first_tn:     *decl.TypedName = ?sc.a.typed_names[fields_start];
+    val first_secret: bool            = type.is_secret(?sc.s.types, context.resolved_type_of(sc, first_tn.ty));
+
+    var i: u32 = 1;
+    for (i < fields_len) {
+        val tn: *decl.TypedName = ?sc.a.typed_names[fields_start + i];
+        if (type.is_secret(?sc.s.types, context.resolved_type_of(sc, tn.ty)) != first_secret) {
+            context.report(sc, tn.name, "union variants must agree on secrecy: overlapping fields are part secret `^` and part public, which would alias the same storage at two classifications");
+        }
+        i = i + 1;
+    }
 }
 
 # fold an `#[align(...)]` decorator on `did` and record the resulting alignment
@@ -357,6 +384,9 @@ pub fun infer_expr(sc: *context.SemaContext, eid: id.ExprId) type.TypeId {
     }
     or (e.kind == expr.EXPR_KIND_CAST) {
         t = infer_cast(sc, ?e.data.cast, e.span);
+    }
+    or (e.kind == expr.EXPR_KIND_STRIP) {
+        t = infer_strip(sc, ?e.data.strip, e.span);
     }
     or (e.kind == expr.EXPR_KIND_ARRAY_LIT) {
         t = infer_array_lit(sc, ?e.data.array_lit, e.span);
@@ -573,6 +603,19 @@ fun infer_binary(sc: *context.SemaContext, eid: id.ExprId, b: *expr.ExprBinary, 
     var rt: type.TypeId = infer_expr(sc, b.rhs);
     if (lt == type.TYPE_ERROR || rt == type.TYPE_ERROR) { ret type.TYPE_ERROR; }
 
+    # secrecy JOIN: an operation with any secret operand yields a secret result
+    # (public is the bottom of the lattice). taint is read from the original
+    # operands here and reapplied to whatever result type each operator computes.
+    val either_secret: bool = type.is_secret(?sc.s.types, lt) || type.is_secret(?sc.s.types, rt);
+
+    # GATE: `/` and `%` are variable-latency on every target (the leakage model
+    # always observes them), so a secret operand is a compile error here. the
+    # float-default and integer-multiply gates are target-CT-capability dependent
+    # and land with the taint-to-MIR contract (#1646).
+    if ((b.op == expr.BIN_DIV || b.op == expr.BIN_MOD) && either_secret) {
+        context.report(sc, span, "secret value used as an operand of a variable-latency `/` or `%`; a secret divisor or dividend leaks through timing");
+    }
+
     # let a literal operand take the shape of the other side
     val co: O.Option[type.TypeId] = unify_literals(sc, b.lhs, lt, b.rhs, rt);
     if (O.is_some[type.TypeId](co)) {
@@ -608,28 +651,51 @@ fun infer_binary(sc: *context.SemaContext, eid: id.ExprId, b: *expr.ExprBinary, 
         if (int_float_mix) { report_int_float_cmp(sc, span); ret type.TYPE_ERROR; }
         val addr_ok: bool = is_pointer_like(sc, lt) && is_pointer_like(sc, rt);
         if (!operands_ok && !both_float && !addr_ok) { type_mismatch(sc, span, lt, rt); ret type.TYPE_ERROR; }
-        ret u8t;
+        ret join_secret(sc, u8t, either_secret);
     }
     if (b.op == expr.BIN_LT || b.op == expr.BIN_LEQ || b.op == expr.BIN_GT || b.op == expr.BIN_GEQ) {
         if (int_float_mix)            { report_int_float_cmp(sc, span); ret type.TYPE_ERROR; }
         if (!both_int && !both_float) { type_mismatch(sc, span, lt, rt); ret type.TYPE_ERROR; }
-        ret u8t;
+        ret join_secret(sc, u8t, either_secret);
     }
     if (b.op == expr.BIN_AND || b.op == expr.BIN_OR) {
         if (!both_int) {
             context.report(sc, span, "type mismatch: logical operands must be integer types");
             ret type.TYPE_ERROR;
         }
-        ret u8t;
+        # GATE: `&&` / `||` short-circuit, so a secret operand becomes a
+        # secret-dependent branch the leakage model observes.
+        if (either_secret) {
+            context.report(sc, span, "secret value used as an operand of a short-circuiting `&&` / `||`; the branch it controls leaks through control flow");
+        }
+        ret join_secret(sc, u8t, either_secret);
     }
     if (b.op == expr.BIN_BIT_AND || b.op == expr.BIN_BIT_OR || b.op == expr.BIN_BIT_XOR
         || b.op == expr.BIN_SHL || b.op == expr.BIN_SHR) {
         if (!both_int) { type_mismatch(sc, span, lt, rt); ret type.TYPE_ERROR; }
-        ret lt;
+        ret join_secret(sc, lt, either_secret);
     }
     # arithmetic: ADD, SUB, MUL, DIV, MOD
     if (!operands_ok || !is_numeric(sc, lt)) { type_mismatch(sc, span, lt, rt); ret type.TYPE_ERROR; }
-    ret lt;
+    ret join_secret(sc, lt, either_secret);
+}
+
+# apply the secrecy JOIN to a binary/unary result base type (#1645)
+#
+# Strips any secrecy already on `base` and re-wraps in `^` exactly when an
+# operand was secret, so a doubled qualifier never forms and the result's
+# secrecy is precisely the join of its operands'.
+# ---
+# sc:     sema context
+# base:   the operator's computed result type
+# secret: true when any operand was secret
+# ret:    `^strip(base)` when `secret`, else `strip(base)`
+fun join_secret(sc: *context.SemaContext, base: type.TypeId, secret: bool) type.TypeId {
+    val pub: type.TypeId = type.strip_secret(?sc.s.types, base);
+    if (!secret) { ret pub; }
+    val r: R.Result[type.TypeId, str] = type.intern_secret(?sc.s.types, pub);
+    if (R.is_err[type.TypeId, str](r)) { ret type.TYPE_ERROR; }
+    ret R.unwrap_ok[type.TypeId, str](r);
 }
 
 # type a type comparison (`$type_of(...) == TypeName`)
@@ -749,7 +815,9 @@ fun infer_assign(sc: *context.SemaContext, b: *expr.ExprBinary, span: token.Span
 #
 # NEG returns the operand type, NOT returns u8, BIT_NOT returns the operand
 # type, ADDR returns a pointer to the operand type, DEREF returns the pointee of
-# a pointer operand.
+# a pointer operand. The value operators (`-`, `!`, `~`) join the operand's
+# secrecy onto their result; `&` instead nests it (`&^T` is the public pointer
+# `*^T`), and DEREF recovers it from the pointee (`@(*^T)` is `^T`).
 # ---
 # sc:   sema context
 # u:    the unary operation payload
@@ -759,17 +827,19 @@ fun infer_unary(sc: *context.SemaContext, u: *expr.ExprUnary, span: token.Span) 
     val ot: type.TypeId = infer_expr(sc, u.operand);
     if (ot == type.TYPE_ERROR) { ret type.TYPE_ERROR; }
 
+    val ot_secret: bool = type.is_secret(?sc.s.types, ot);
+
     if (u.op == expr.UN_NEG) {
         if (!is_numeric(sc, ot)) { context.report(sc, span, "type mismatch: unary - requires a numeric operand"); ret type.TYPE_ERROR; }
-        ret ot;
+        ret join_secret(sc, ot, ot_secret);
     }
     if (u.op == expr.UN_NOT) {
         if (!is_integer(sc, ot)) { context.report(sc, span, "type mismatch: unary ! requires an integer operand"); ret type.TYPE_ERROR; }
-        ret prim_or_error(sc, type.TYPE_U8);
+        ret join_secret(sc, prim_or_error(sc, type.TYPE_U8), ot_secret);
     }
     if (u.op == expr.UN_BIT_NOT) {
         if (!is_integer(sc, ot)) { context.report(sc, span, "type mismatch: unary ~ requires an integer operand"); ret type.TYPE_ERROR; }
-        ret ot;
+        ret join_secret(sc, ot, ot_secret);
     }
     if (u.op == expr.UN_ADDR) {
         # a comptime value parameter has no runtime storage -- it folds to a
@@ -1490,6 +1560,43 @@ fun infer_cast(sc: *context.SemaContext, c: *expr.ExprCast, span: token.Span) ty
     ret O.unwrap[type.TypeId](r);
 }
 
+# STRIP: the `:^` secret-qualifier strip cast - the sole downgrade (#1645)
+#
+# Removes the outer `^` from the operand's type, producing a NEW public value
+# (the only secret->public crossing the type system permits). It peels exactly
+# the top-level qualifier: a welded `*^T` pointer's pointee secrecy is never
+# laundered by `:^` since the outer type there is a (public) pointer. A bare
+# `value:^` strips in place; `value:^Type` strips to an explicit target, which
+# must itself be public (a `^Type` target would re-add the qualifier the cast
+# removes).
+# ---
+# sc:   sema context
+# st:   the strip payload
+# span: the cast span for diagnostics
+# ret:  the stripped (public) TypeId, or TYPE_ERROR
+fun infer_strip(sc: *context.SemaContext, st: *expr.ExprStrip, span: token.Span) type.TypeId {
+    val vt: type.TypeId = infer_expr(sc, st.value);
+    if (vt == type.TYPE_ERROR) { ret type.TYPE_ERROR; }
+
+    val stripped: type.TypeId = type.strip_secret(?sc.s.types, vt);
+
+    if (st.ty == id.TYPE_NIL) { ret stripped; }
+
+    val tt: type.TypeId = context.resolved_type_of(sc, st.ty);
+    if (tt == type.TYPE_ERROR) { ret type.TYPE_ERROR; }
+    if (type.is_secret(?sc.s.types, tt)) {
+        context.report(sc, span, "secret strip: a `:^` target type must be public; `:^` only removes the `^` qualifier");
+        ret type.TYPE_ERROR;
+    }
+    # `:^` removes secrecy only; it never reinterprets storage, so an explicit
+    # target must name the operand's own stripped type.
+    if (tt != stripped) {
+        context.report(sc, span, "secret strip: a `:^Type` target must name the operand's stripped (public) type; `:^` does not convert the value");
+        ret type.TYPE_ERROR;
+    }
+    ret tt;
+}
+
 # ARRAY_LIT: result is [count]elem of the declared array type
 #
 # Every element is checked against the element type via check.check_assignable,
@@ -1588,9 +1695,10 @@ pub fun resolve_type_ref(sc: *context.SemaContext, tid: id.TypeId) type.TypeId {
     if (O.is_none[*atype.Type](t_opt)) { ret type.TYPE_ERROR; }
     val t: *atype.Type = O.unwrap[*atype.Type](t_opt);
 
-    if (t.kind == atype.TYPE_KIND_NAMED) { ret resolve_type_named(sc, tid, ?t.data.named, t.span); }
-    if (t.kind == atype.TYPE_KIND_PTR)   { ret resolve_type_ptr(sc, ?t.data.ptr); }
-    if (t.kind == atype.TYPE_KIND_ARRAY) { ret resolve_type_array(sc, ?t.data.array, t.span); }
+    if (t.kind == atype.TYPE_KIND_NAMED)  { ret resolve_type_named(sc, tid, ?t.data.named, t.span); }
+    if (t.kind == atype.TYPE_KIND_PTR)    { ret resolve_type_ptr(sc, ?t.data.ptr); }
+    if (t.kind == atype.TYPE_KIND_SECRET) { ret resolve_type_secret(sc, ?t.data.secret); }
+    if (t.kind == atype.TYPE_KIND_ARRAY)  { ret resolve_type_array(sc, ?t.data.array, t.span); }
     if (t.kind == atype.TYPE_KIND_FUN)   { ret resolve_type_fun(sc, ?t.data.fun_); }
     if (t.kind == atype.TYPE_KIND_REC)   { ret resolve_type_anon(sc, tid, t.data.rec_.fields_start, t.data.rec_.fields_len, type.TYPE_REC); }
     if (t.kind == atype.TYPE_KIND_UNI)   { ret resolve_type_anon(sc, tid, t.data.uni_.fields_start, t.data.uni_.fields_len, type.TYPE_UNI); }
@@ -1729,6 +1837,22 @@ fun instantiate_named(sc: *context.SemaContext, sym: *resolve.Symbol, named: *at
 fun resolve_type_ptr(sc: *context.SemaContext, p: *atype.TypePtr) type.TypeId {
     val base: type.TypeId = resolve_type_ref(sc, p.pointee);
     ret ptr_to(sc, base);
+}
+
+# SECRET: recurse on the inner type and intern a `^inner` qualifier (#1645)
+#
+# A poisoned inner poisons the qualifier. `^^T` collapses in intern_secret, so
+# the secrecy lattice stays two-point.
+# ---
+# sc:  sema context
+# s:   the secret-type payload
+# ret: the `^inner` TypeId, or TYPE_ERROR
+fun resolve_type_secret(sc: *context.SemaContext, s: *atype.TypeSecret) type.TypeId {
+    val inner: type.TypeId = resolve_type_ref(sc, s.inner);
+    if (inner == type.TYPE_ERROR) { ret type.TYPE_ERROR; }
+    val r: R.Result[type.TypeId, str] = type.intern_secret(?sc.s.types, inner);
+    if (R.is_err[type.TypeId, str](r)) { ret type.TYPE_ERROR; }
+    ret R.unwrap_ok[type.TypeId, str](r);
 }
 
 # ARRAY: resolve the element type, evaluate the length via the comptime
@@ -1929,14 +2053,18 @@ fun ptr_to(sc: *context.SemaContext, base: type.TypeId) type.TypeId {
 
 # the pointee type of a pointer
 #
-# Non-pointer operands report a diagnostic and yield TYPE_ERROR.
+# Non-pointer operands report a diagnostic and yield TYPE_ERROR. A secret pointer
+# `^*T` is peeled to its pointer first, so dereferencing recovers the pointee
+# `T`; the canonical welded form `*^T` is already a (public) pointer whose
+# pointee is the secret `^T`.
 # ---
 # sc:   sema context
 # ty:   the operand TypeId
 # span: the operand span for diagnostics
 # ret:  the pointee TypeId, or TYPE_ERROR
 fun pointee_of(sc: *context.SemaContext, ty: type.TypeId, span: token.Span) type.TypeId {
-    val t_opt: O.Option[*type.Type] = type.get(?sc.s.types, ty);
+    val base: type.TypeId = type.strip_secret(?sc.s.types, ty);
+    val t_opt: O.Option[*type.Type] = type.get(?sc.s.types, base);
     if (O.is_none[*type.Type](t_opt)) { ret type.TYPE_ERROR; }
     val t: *type.Type = O.unwrap[*type.Type](t_opt);
     if (t.kind != type.TYPE_POINTER) {

--- a/src/lang/me/lower/context.mach
+++ b/src/lang/me/lower/context.mach
@@ -924,6 +924,11 @@ pub fun lower_type(lc: *LowerContext, tid: type.TypeId) R.Result[ir_type.IrTypeI
     val t: *type.Type = O.unwrap[*type.Type](t_opt);
     val k: type.TypeKind = t.kind;
 
+    # secrecy has no runtime representation (#1645): `^T` lowers to exactly `T`'s
+    # machine shape. the secret-taint-to-MIR contract that propagates it through
+    # codegen for the constant-time guarantee lands separately (#1646).
+    if (k == type.TYPE_SECRET) { ret lower_type(lc, t.data.secret.base); }
+
     val d: type.PrimDesc = type.prim_desc(k);
     if (d.class == type.PRIM_CLASS_INT)   { ret ir_type.intern_int(?lc.m.types, d.bits); }
     if (d.class == type.PRIM_CLASS_FLOAT) { ret ir_type.intern_float(?lc.m.types, d.bits); }

--- a/src/lang/me/lower/expr.mach
+++ b/src/lang/me/lower/expr.mach
@@ -72,6 +72,7 @@ pub fun lower_rvalue(ctx: *context.LowerContext, eid: id.ExprId) R.Result[value.
     if (k == expr.EXPR_KIND_BINARY)         { ret lower_binary(ctx, eid, e); }
     if (k == expr.EXPR_KIND_UNARY)          { ret lower_unary(ctx, eid, e); }
     if (k == expr.EXPR_KIND_CAST)           { ret lower_cast(ctx, eid, e); }
+    if (k == expr.EXPR_KIND_STRIP)          { ret lower_strip(ctx, e); }
     if (k == expr.EXPR_KIND_COMPTIME_IDENT) { ret lower_comptime_path(ctx, eid); }
     if (k == expr.EXPR_KIND_ARRAY_LIT)      { ret lower_array_lit(ctx, eid, e); }
     if (k == expr.EXPR_KIND_STRUCT_LIT)     { ret lower_struct_lit(ctx, eid, e); }
@@ -2372,6 +2373,20 @@ fun lower_cast(ctx: *context.LowerContext, eid: id.ExprId, e: *expr.Expr) R.Resu
         ret builder.emit_zext(?ctx.builder, v, dst);
     }
     ret builder.emit_bitcast(?ctx.builder, v, dst);
+}
+
+# lower a `:^` secret-qualifier strip cast to the value it wraps (#1645)
+#
+# `:^` removes secrecy without reinterpreting storage: secrecy has no runtime
+# representation (a `^T` shares `T`'s machine shape), so stripping is a pure
+# value passthrough. sema already proved the operand's stripped type matches the
+# result, so no conversion is emitted.
+# ---
+# ctx: per-module lowering context
+# e:   the resolved strip node
+# ret: the operand's lowered Value, or an error
+fun lower_strip(ctx: *context.LowerContext, e: *expr.Expr) R.Result[value.Value, str] {
+    ret lower_rvalue(ctx, e.data.strip.value);
 }
 
 # fold a value-context comptime path to its constant value

--- a/src/lang/me/lower/mangle.mach
+++ b/src/lang/me/lower/mangle.mach
@@ -484,6 +484,12 @@ fun encoded_type_len(s: *session.Session, tid: type.TypeId) usize {
     if (kind == type.TYPE_POINTER) {
         ret 1 + encoded_type_len(s, t.data.pointer.base);
     }
+    # secrecy is erased at lowering (#1645), so `^T` mangles exactly as `T`: two
+    # instances differing only in secrecy lower to one machine shape and one
+    # symbol. (#1646's per-instance oblivious distinction revisits this.)
+    if (kind == type.TYPE_SECRET) {
+        ret encoded_type_len(s, t.data.secret.base);
+    }
     if (kind == type.TYPE_ARRAY) {
         ret 1 + decimal_len(t.data.array.count::usize) + 1 + encoded_type_len(s, t.data.array.base);
     }
@@ -524,6 +530,10 @@ fun write_encoded_type(s: *session.Session, buf: *u8, k: usize, tid: type.TypeId
     if (kind == type.TYPE_POINTER) {
         buf[k] = 'P';
         ret write_encoded_type(s, buf, k + 1, t.data.pointer.base);
+    }
+    # secrecy is erased at lowering (#1645): `^T` encodes exactly as `T`.
+    if (kind == type.TYPE_SECRET) {
+        ret write_encoded_type(s, buf, k, t.data.secret.base);
     }
     if (kind == type.TYPE_ARRAY) {
         buf[k] = 'A';

--- a/src/lang/type.mach
+++ b/src/lang/type.mach
@@ -68,6 +68,12 @@ pub val TYPE_INSTANCE:      TypeKind = 17;  # concrete instantiation of a generi
 # supplied by monomorphization, never carried on the type itself.
 pub val TYPE_PACK: TypeKind = 18;
 
+# the `^T` secret qualifier (#1645): the top of the two-point secrecy lattice
+# (public is the bottom). wraps an inner type to mark its data secret for the
+# constant-time guarantee. secrecy has no runtime representation - a `^T` lowers
+# to the same machine shape as `T`; it constrains only sema's flow typing.
+pub val TYPE_SECRET: TypeKind = 19;
+
 # scalar class of a primitive TypeKind, the discriminator of PrimDesc
 pub def PrimClass: u8;
 
@@ -129,6 +135,16 @@ pub fun prim_desc(kind: TypeKind) PrimDesc {
 # ---
 # base: pointee TypeId
 pub rec TypePointer {
+    base: TypeId;
+}
+
+# secret-qualifier `^T` payload (#1645)
+#
+# Carries the inner type the qualifier wraps. `^^T` never forms: intern_secret
+# collapses a doubled qualifier, keeping the lattice two-point.
+# ---
+# base: the inner (public-spelled) TypeId the qualifier wraps
+pub rec TypeSecret {
     base: TypeId;
 }
 
@@ -200,6 +216,7 @@ pub rec Type {
     kind: TypeKind;
     data: uni {
         pointer:       TypePointer;
+        secret:        TypeSecret;
         array:         TypeArray;
         fn:            TypeFun;
         nominal:       TypeNominal;
@@ -482,35 +499,41 @@ pub fun prim(ti: *TypeInterner, kind: TypeKind) O.Option[TypeId] {
 # Reads the kind through the interner, so, unlike a bare `tid == TYPE_U8`
 # ordinal test, it never depends on a primitive's TypeId equaling its kind
 # ordinal. The single shared predicate for sema's infer / check / coerce passes.
+# A secret `^T` is classified by its inner type, so secret integers participate
+# in arithmetic exactly as public ones (the join and gates are layered on top).
 # ---
 # ti:  the interner
 # tid: the TypeId to classify
 # ret: true for u8..u64 and i8..i64
 pub fun is_integer(ti: *TypeInterner, tid: TypeId) bool {
-    val opt_type: O.Option[*Type] = get(ti, tid);
+    val opt_type: O.Option[*Type] = get(ti, strip_secret(ti, tid));
     if (O.is_none[*Type](opt_type)) { ret false; }
     ret prim_desc(O.unwrap[*Type](opt_type).kind).class == PRIM_CLASS_INT;
 }
 
 # whether `tid` is an integer or float primitive (u8..f64)
+#
+# A secret `^T` is classified by its inner type.
 # ---
 # ti:  the interner
 # tid: the TypeId to classify
 # ret: true for any integer or float primitive
 pub fun is_numeric(ti: *TypeInterner, tid: TypeId) bool {
-    val opt_type: O.Option[*Type] = get(ti, tid);
+    val opt_type: O.Option[*Type] = get(ti, strip_secret(ti, tid));
     if (O.is_none[*Type](opt_type)) { ret false; }
     val c: PrimClass = prim_desc(O.unwrap[*Type](opt_type).kind).class;
     ret c == PRIM_CLASS_INT || c == PRIM_CLASS_FLOAT;
 }
 
 # whether `tid` is a float primitive (f32 or f64)
+#
+# A secret `^T` is classified by its inner type.
 # ---
 # ti:  the interner
 # tid: the TypeId to classify
 # ret: true for f32 or f64
 pub fun is_float(ti: *TypeInterner, tid: TypeId) bool {
-    val opt_type: O.Option[*Type] = get(ti, tid);
+    val opt_type: O.Option[*Type] = get(ti, strip_secret(ti, tid));
     if (O.is_none[*Type](opt_type)) { ret false; }
     ret prim_desc(O.unwrap[*Type](opt_type).kind).class == PRIM_CLASS_FLOAT;
 }
@@ -519,16 +542,98 @@ pub fun is_float(ti: *TypeInterner, tid: TypeId) bool {
 # (a code address)
 #
 # Used to relate `nil` and reinterpret casts against pointer and function
-# operands.
+# operands. A secret `^T` is classified by its inner type.
 # ---
 # ti:  the interner
 # tid: the TypeId to classify
 # ret: true for TYPE_PTR / TYPE_POINTER / TYPE_FUN
 pub fun is_pointer_like(ti: *TypeInterner, tid: TypeId) bool {
-    val opt_type: O.Option[*Type] = get(ti, tid);
+    val opt_type: O.Option[*Type] = get(ti, strip_secret(ti, tid));
     if (O.is_none[*Type](opt_type)) { ret false; }
     val k: TypeKind = O.unwrap[*Type](opt_type).kind;
     ret k == TYPE_PTR || k == TYPE_POINTER || k == TYPE_FUN;
+}
+
+# whether `tid` is a secret-qualified type `^T`
+# ---
+# ti:  the interner
+# tid: the TypeId to classify
+# ret: true when `tid`'s kind is TYPE_SECRET
+pub fun is_secret(ti: *TypeInterner, tid: TypeId) bool {
+    val opt_type: O.Option[*Type] = get(ti, tid);
+    if (O.is_none[*Type](opt_type)) { ret false; }
+    ret O.unwrap[*Type](opt_type).kind == TYPE_SECRET;
+}
+
+# peel one secret qualifier from `tid`, returning the inner type
+#
+# A non-secret type is returned unchanged. `^^T` never forms (intern_secret
+# collapses it), so a single peel is exhaustive.
+# ---
+# ti:  the interner
+# tid: the TypeId to strip
+# ret: the inner type when `tid` is `^T`, else `tid` unchanged
+pub fun strip_secret(ti: *TypeInterner, tid: TypeId) TypeId {
+    val opt_type: O.Option[*Type] = get(ti, tid);
+    if (O.is_none[*Type](opt_type)) { ret tid; }
+    val t: *Type = O.unwrap[*Type](opt_type);
+    if (t.kind != TYPE_SECRET) { ret tid; }
+    ret t.data.secret.base;
+}
+
+# whether `tid` carries secret data anywhere along its pointer / array / secret
+# spine - the predicate the welded-storage rules use to keep secret memory off
+# the untyped `ptr`
+#
+# Follows `^` (true immediately), a typed pointer's pointee, and an array's
+# element. A nominal rec/uni is a leaf here (its secret fields are welded at the
+# field level), so the walk is over a finite spine and always terminates.
+# ---
+# ti:  the interner
+# tid: the TypeId to inspect
+# ret: true when a secret qualifier appears along the spine
+pub fun carries_secret(ti: *TypeInterner, tid: TypeId) bool {
+    val opt_type: O.Option[*Type] = get(ti, tid);
+    if (O.is_none[*Type](opt_type)) { ret false; }
+    val t: *Type = O.unwrap[*Type](opt_type);
+    if (t.kind == TYPE_SECRET)  { ret true; }
+    if (t.kind == TYPE_POINTER) { ret carries_secret(ti, t.data.pointer.base); }
+    if (t.kind == TYPE_ARRAY)   { ret carries_secret(ti, t.data.array.base); }
+    ret false;
+}
+
+# whether two types place the secret qualifier identically along their spines
+#
+# `::` and `:~` may neither add nor drop `^`, so a cast's operand and target must
+# match secret-for-secret at the top level and through every pointer / array
+# step. Differing inner leaf types (e.g. `^u32` vs `^u64`) still match - only the
+# `^` placement is compared, not the underlying shapes the cast itself converts.
+# ---
+# ti:  the interner
+# a:   the first TypeId
+# b:   the second TypeId
+# ret: true when both carry the same secret-qualifier placement along the spine
+pub fun secrecy_structure_equal(ti: *TypeInterner, a: TypeId, b: TypeId) bool {
+    val a_secret: bool = is_secret(ti, a);
+    val b_secret: bool = is_secret(ti, b);
+    if (a_secret != b_secret) { ret false; }
+
+    val sa: TypeId = strip_secret(ti, a);
+    val sb: TypeId = strip_secret(ti, b);
+
+    val oa: O.Option[*Type] = get(ti, sa);
+    val ob: O.Option[*Type] = get(ti, sb);
+    if (O.is_none[*Type](oa) || O.is_none[*Type](ob)) { ret true; }
+    val ta: *Type = O.unwrap[*Type](oa);
+    val tb: *Type = O.unwrap[*Type](ob);
+
+    if (ta.kind == TYPE_POINTER && tb.kind == TYPE_POINTER) {
+        ret secrecy_structure_equal(ti, ta.data.pointer.base, tb.data.pointer.base);
+    }
+    if (ta.kind == TYPE_ARRAY && tb.kind == TYPE_ARRAY) {
+        ret secrecy_structure_equal(ti, ta.data.array.base, tb.data.array.base);
+    }
+    ret true;
 }
 
 # intern a pointer-to type
@@ -542,6 +647,24 @@ pub fun intern_pointer(ti: *TypeInterner, base: TypeId) R.Result[TypeId, str] {
     var t: Type;
     t.kind              = TYPE_POINTER;
     t.data.pointer.base = base;
+    ret intern_dedup(ti, t);
+}
+
+# intern a secret-qualified type `^base` (#1645)
+#
+# A doubled qualifier collapses (`^^T` interns to `^T`) so the secrecy lattice
+# stays two-point, and a poisoned base poisons the qualifier. Returns an existing
+# TypeId when the same base has been wrapped before.
+# ---
+# ti:   the interner
+# base: the inner TypeId to wrap
+# ret:  TypeId for `^base`, or an allocation error
+pub fun intern_secret(ti: *TypeInterner, base: TypeId) R.Result[TypeId, str] {
+    if (base == TYPE_ERROR) { ret R.ok[TypeId, str](TYPE_ERROR); }
+    if (is_secret(ti, base)) { ret R.ok[TypeId, str](base); }
+    var t: Type;
+    t.kind             = TYPE_SECRET;
+    t.data.secret.base = base;
     ret intern_dedup(ti, t);
 }
 
@@ -1179,6 +1302,9 @@ fun hash_type(p: ptr) u64 {
     if (t.kind == TYPE_POINTER) {
         h = fnv1a.step_u32(h, t.data.pointer.base::u32);
     }
+    or (t.kind == TYPE_SECRET) {
+        h = fnv1a.step_u32(h, t.data.secret.base::u32);
+    }
     or (t.kind == TYPE_ARRAY) {
         h = fnv1a.step_u32(h, t.data.array.base::u32);
         h = fnv1a.step_u32(h, t.data.array.count);
@@ -1207,6 +1333,9 @@ fun eq_type(pa: ptr, pb: ptr) bool {
 
     if (a.kind == TYPE_POINTER) {
         ret a.data.pointer.base == b.data.pointer.base;
+    }
+    if (a.kind == TYPE_SECRET) {
+        ret a.data.secret.base == b.data.secret.base;
     }
     if (a.kind == TYPE_ARRAY) {
         ret a.data.array.base == b.data.array.base
@@ -1372,6 +1501,63 @@ test "mach.lang.type:numeric_predicate_boundaries" {
     if (!is_float(?ti, f32_id))   { dnit(?ti); ret 1; }
     # array is not an integer
     if (is_integer(?ti, arr_id))  { dnit(?ti); ret 1; }
+
+    dnit(?ti);
+    ret 0;
+}
+
+# intern_secret dedups, collapses a doubled qualifier, and threads the secret
+# qualifier through the classifier / spine predicates (#1645)
+test "mach.lang.type.intern_secret:dedup_collapse_and_predicates" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+    var ti: TypeInterner;
+    if (O.is_some[str](init(?ti, ?alloc))) { ret 1; }
+
+    val u32_id: TypeId = O.unwrap[TypeId](prim(?ti, TYPE_U32));
+
+    # `^u32` interned twice -> one TypeId, distinct from `u32`
+    val s1: R.Result[TypeId, str] = intern_secret(?ti, u32_id);
+    val s2: R.Result[TypeId, str] = intern_secret(?ti, u32_id);
+    if (R.is_err[TypeId, str](s1) || R.is_err[TypeId, str](s2)) { dnit(?ti); ret 1; }
+    val sec_u32: TypeId = R.unwrap_ok[TypeId, str](s1);
+    if (sec_u32 != R.unwrap_ok[TypeId, str](s2)) { dnit(?ti); ret 1; }
+    if (sec_u32 == u32_id)                       { dnit(?ti); ret 1; }
+
+    # `^^u32` collapses to `^u32` - the lattice is two-point
+    val s3: R.Result[TypeId, str] = intern_secret(?ti, sec_u32);
+    if (R.is_err[TypeId, str](s3))                  { dnit(?ti); ret 1; }
+    if (R.unwrap_ok[TypeId, str](s3) != sec_u32)    { dnit(?ti); ret 1; }
+
+    # is_secret / strip_secret round-trip
+    if (!is_secret(?ti, sec_u32))                 { dnit(?ti); ret 1; }
+    if (is_secret(?ti, u32_id))                   { dnit(?ti); ret 1; }
+    if (strip_secret(?ti, sec_u32) != u32_id)     { dnit(?ti); ret 1; }
+    if (strip_secret(?ti, u32_id) != u32_id)      { dnit(?ti); ret 1; }
+
+    # a secret integer is still an integer for arithmetic classification
+    if (!is_integer(?ti, sec_u32))                { dnit(?ti); ret 1; }
+    if (!is_numeric(?ti, sec_u32))                { dnit(?ti); ret 1; }
+
+    # `*^u32` carries secret along its spine; `*u32` does not
+    val pp_sec: R.Result[TypeId, str] = intern_pointer(?ti, sec_u32);
+    val pp_pub: R.Result[TypeId, str] = intern_pointer(?ti, u32_id);
+    if (R.is_err[TypeId, str](pp_sec) || R.is_err[TypeId, str](pp_pub)) { dnit(?ti); ret 1; }
+    val ptr_sec: TypeId = R.unwrap_ok[TypeId, str](pp_sec);
+    val ptr_pub: TypeId = R.unwrap_ok[TypeId, str](pp_pub);
+    if (!carries_secret(?ti, ptr_sec))            { dnit(?ti); ret 1; }
+    if (carries_secret(?ti, ptr_pub))             { dnit(?ti); ret 1; }
+    if (!carries_secret(?ti, sec_u32))            { dnit(?ti); ret 1; }
+
+    # secrecy_structure_equal: `*^u32` differs from `*u32`, matches itself, and
+    # `^u32` vs `^u64` (same placement, differing leaves) is equal
+    val u64_id:  TypeId = O.unwrap[TypeId](prim(?ti, TYPE_U64));
+    val sec_u64: R.Result[TypeId, str] = intern_secret(?ti, u64_id);
+    if (R.is_err[TypeId, str](sec_u64)) { dnit(?ti); ret 1; }
+    if (secrecy_structure_equal(?ti, ptr_sec, ptr_pub))                       { dnit(?ti); ret 1; }
+    if (!secrecy_structure_equal(?ti, ptr_sec, ptr_sec))                      { dnit(?ti); ret 1; }
+    if (!secrecy_structure_equal(?ti, sec_u32, R.unwrap_ok[TypeId, str](sec_u64))) { dnit(?ti); ret 1; }
+    if (secrecy_structure_equal(?ti, sec_u32, u32_id))                       { dnit(?ti); ret 1; }
 
     dnit(?ti);
     ret 0;


### PR DESCRIPTION
Implements the information-flow type rules for the `^` secret qualifier. Closes #1645. Part of the constant-time / PQC epic #1643; builds on the frontend tokens/AST from #1644.

## What

Threads a two-point secrecy lattice (public is the bottom, secret the top) through resolve / infer / check / coerce and enforces the leakage-model gates and the welded-storage pointer discipline. Sema/flow-typing only - the `#[oblivious]` codegen contract and the secret-taint-to-MIR are #1646.

### Lattice and join
- `TYPE_SECRET` wraps an inner type in the type universe; `intern_secret` dedups and collapses `^^T` so the lattice stays two-point.
- Public coerces UP to secret implicitly (no syntax). Any operation with a secret operand yields a secret result (the join), threaded through `infer_binary` / `infer_unary`, plus field/element reads out of a secret container.

### Gates (each a compile error with a teaching note)
- secret branch / loop condition (`check_condition`)
- secret memory index (`check_index`)
- secret operand of the always-variable-latency `/` and `%`
- secret operand of a short-circuiting `&&` / `||`

The float-by-default and integer-multiply gates depend on the target CT-capability flag defined in #1646.

### Downgrade
- `:^` strip is the only downgrade (a new public value; never reinterprets storage).
- `::` and `:~` can neither add nor drop `^`.

### Welded-storage pointers (no alias analysis)
- deref of `*^T` yields `^T`; a `^T` cannot be stored through a `*T` (lattice).
- a secret-welded pointer cannot be erased to the untyped `ptr`.
- a `uni`'s overlapping variants must agree on secrecy.

### Lowering
Secrecy has no runtime representation: `^T` lowers to `T`'s machine shape, `:^` is a value passthrough, and mangling / generic substitution thread the qualifier transparently.

## Tests
- `type.mach` unit test for `intern_secret` dedup/collapse + the spine predicates.
- end-to-end sema tests (join, implicit coerce, `:^` strip, the gate rejections, `::`/`:~` secrecy preservation, pointer non-launderability, uni secrecy agreement).

Self-host fixpoint and `mach test .` both green.
