### PR TITLE
feat(riscv64): RV64A atomic inline-asm mnemonics (lr/sc, amo*, ordering suffixes)

### DIFF
--- a/src/lang/target/isa/riscv64/encode.mach
+++ b/src/lang/target/isa/riscv64/encode.mach
@@ -94,7 +94,8 @@ val JALR:      u32 = 0x67;  # jump and link register (I-type)
 val LUI:       u32 = 0x37;  # load upper immediate (U-type)
 val AUIPC:     u32 = 0x17;  # add upper immediate to pc (U-type)
 val SYSTEM:    u32 = 0x73;  # ecall / ebreak
-val MISC_MEM:  u32 = 0x0F;  # fence (the only inline-asm consumer of this group)
+val MISC_MEM:  u32 = 0x0F;  # fence / pause (the inline-asm consumers of this group)
+val AMO:       u32 = 0x2F;  # RV64A atomics (lr / sc / amo*), R-type with aq/rl bits
 
 # the three-bit funct3 selectors. for the ALU groups these name the operation; for
 # loads / stores / branches they name the access width / relation (see the width
@@ -189,6 +190,27 @@ val FMT_D: u32 = 0x1;
 # assigned value.
 val FP_SCRATCH:  u32 = 31;
 val FP_SCRATCH2: u32 = 30;
+
+# the RV64A atomic width selector (funct3 of an AMO word): W is the 32-bit form, D the
+# 64-bit form. an rv32 reuses the W forms, so this split is the only XLEN-specific bit.
+val F3_AMO_W: u32 = 0x2;
+val F3_AMO_D: u32 = 0x3;
+
+# the RV64A atomic operation selectors (the 5-bit funct5 in an AMO word's bits [31:27]).
+# the aq / rl ordering bits sit just below in [26:25], so the assembled funct7 is
+# `(funct5 << 2) | (aq << 1) | rl`. lr / sc are the load-reserved / store-conditional
+# pair; the amo* forms are the read-modify-write atomics.
+val A5_LR:      u32 = 0x02;
+val A5_SC:      u32 = 0x03;
+val A5_AMOSWAP: u32 = 0x01;
+val A5_AMOADD:  u32 = 0x00;
+val A5_AMOXOR:  u32 = 0x04;
+val A5_AMOAND:  u32 = 0x0C;
+val A5_AMOOR:   u32 = 0x08;
+val A5_AMOMIN:  u32 = 0x10;
+val A5_AMOMAX:  u32 = 0x14;
+val A5_AMOMINU: u32 = 0x18;
+val A5_AMOMAXU: u32 = 0x1C;
 
 # the register roles the encoder uses directly, the leaf module's psABI ids cast to
 # the 5-bit register fields. ZERO discards writes and reads as 0; RA is the link
@@ -2677,6 +2699,84 @@ fun rv_jalr(st: *encode.EncodeState, args: str, default_rd: u32) R.Result[bool, 
     ret R.err[bool, str]("encode: inline-asm jalr expects rs or rd, rs, imm");
 }
 
+# strip a trailing RV64A ordering suffix (`.aqrl` / `.aq` / `.rl`) from atomic mnemonic
+# `mnem` of length `len`, returning the length without the suffix and setting the aq / rl
+# bits. an atomic with no ordering suffix leaves both clear.
+fun rv_amo_ordering(mnem: str, len: usize, aq_out: *bool, rl_out: *bool) usize {
+    @aq_out = false; @rl_out = false;
+    if (len >= 5 && str_region_equals(mnem, len - 5, 5, ".aqrl")) { @aq_out = true; @rl_out = true; ret len - 5; }
+    if (len >= 3 && str_region_equals(mnem, len - 3, 3, ".aq"))   { @aq_out = true; ret len - 3; }
+    if (len >= 3 && str_region_equals(mnem, len - 3, 3, ".rl"))   { @rl_out = true; ret len - 3; }
+    ret len;
+}
+
+# map an atomic base name `mnem[0..len)` (the mnemonic with its width and ordering
+# suffixes already stripped) to its 5-bit funct5, setting `is_lr_out` for the two-operand
+# `lr` form. returns false when the base is not an RV64A atomic.
+fun rv_amo_base(mnem: str, len: usize, funct5_out: *u32, is_lr_out: *bool) bool {
+    @is_lr_out = false;
+    if (str_region_equals(mnem, 0, len, "lr"))      { @funct5_out = A5_LR; @is_lr_out = true; ret true; }
+    if (str_region_equals(mnem, 0, len, "sc"))      { @funct5_out = A5_SC;      ret true; }
+    if (str_region_equals(mnem, 0, len, "amoswap")) { @funct5_out = A5_AMOSWAP; ret true; }
+    if (str_region_equals(mnem, 0, len, "amoadd"))  { @funct5_out = A5_AMOADD;  ret true; }
+    if (str_region_equals(mnem, 0, len, "amoand"))  { @funct5_out = A5_AMOAND;  ret true; }
+    if (str_region_equals(mnem, 0, len, "amoor"))   { @funct5_out = A5_AMOOR;   ret true; }
+    if (str_region_equals(mnem, 0, len, "amoxor"))  { @funct5_out = A5_AMOXOR;  ret true; }
+    if (str_region_equals(mnem, 0, len, "amomax"))  { @funct5_out = A5_AMOMAX;  ret true; }
+    if (str_region_equals(mnem, 0, len, "amomin"))  { @funct5_out = A5_AMOMIN;  ret true; }
+    if (str_region_equals(mnem, 0, len, "amomaxu")) { @funct5_out = A5_AMOMAXU; ret true; }
+    if (str_region_equals(mnem, 0, len, "amominu")) { @funct5_out = A5_AMOMINU; ret true; }
+    ret false;
+}
+
+# encode one RV64A atomic statement (the AMO major opcode, R-type with the aq / rl
+# ordering bits folded into funct7). `lr` is `rd, (rs1)` with rs2 forced to x0; `sc` and
+# the `amo*` read-modify-writes are `rd, rs2, (rs1)`. the address is the base-only
+# `(rs1)` form atomics require - a displacement is rejected, unlike a regular load /
+# store. `matched` is set only when `mnem` decodes to a real atomic, so an unrelated
+# mnemonic falls through to the dispatch's unsupported-mnemonic error.
+fun rv_amo(st: *encode.EncodeState, mnem: str, args: str, matched: *bool) R.Result[bool, str] {
+    @matched = false;
+    val len: usize = str_len(mnem);
+    var aq: bool = false; var rl: bool = false;
+    val wlen: usize = rv_amo_ordering(mnem, len, ?aq, ?rl);
+    if (wlen < 4) { ret R.ok[bool, str](true); }
+    var funct3: u32 = 0;
+    if (str_region_equals(mnem, wlen - 2, 2, ".w")) { funct3 = F3_AMO_W; }
+    or (str_region_equals(mnem, wlen - 2, 2, ".d")) { funct3 = F3_AMO_D; }
+    or { ret R.ok[bool, str](true); }
+    var funct5: u32 = 0; var is_lr: bool = false;
+    if (!rv_amo_base(mnem, wlen - 2, ?funct5, ?is_lr)) { ret R.ok[bool, str](true); }
+    @matched = true;
+
+    var funct7: u32 = funct5 << 2;
+    if (aq) { funct7 = funct7 | 0x2; }
+    if (rl) { funct7 = funct7 | 0x1; }
+
+    var b0: [64]u8; var b1: [64]u8; var b2: [64]u8; var b3: [64]u8;
+    var n: u32 = 0;
+    if (!rv_split(args, ?b0[0], ?b1[0], ?b2[0], ?b3[0], 64, ?n)) { ret R.err[bool, str]("encode: malformed inline-asm atomic operands"); }
+
+    if (is_lr) {
+        if (n != 2)                                                         { ret R.err[bool, str]("encode: inline-asm 'lr' expects rd, (rs1)"); }
+        var rd: RvAsmOp; var mem: RvAsmOp;
+        if (!rv_parse_operand((?b0[0])::str, ?rd) || rd.kind != RVOP_REG)   { ret R.err[bool, str]("encode: inline-asm 'lr' destination must be a register"); }
+        if (!rv_parse_operand((?b1[0])::str, ?mem) || mem.kind != RVOP_MEM) { ret R.err[bool, str]("encode: inline-asm 'lr' address must be (rs1)"); }
+        if (mem.imm != 0)                                                   { ret R.err[bool, str]("encode: inline-asm atomic address takes no displacement"); }
+        emit_word(st, pack_r(AMO, funct3, funct7, rd.reg::u32, mem.reg::u32, RZERO));
+        ret R.ok[bool, str](true);
+    }
+
+    if (n != 3)                                                        { ret R.err[bool, str]("encode: inline-asm atomic expects rd, rs2, (rs1)"); }
+    var rd: RvAsmOp; var rs2: RvAsmOp; var mem: RvAsmOp;
+    if (!rv_parse_operand((?b0[0])::str, ?rd) || rd.kind != RVOP_REG)   { ret R.err[bool, str]("encode: inline-asm atomic destination must be a register"); }
+    if (!rv_parse_operand((?b1[0])::str, ?rs2) || rs2.kind != RVOP_REG) { ret R.err[bool, str]("encode: inline-asm atomic source must be a register"); }
+    if (!rv_parse_operand((?b2[0])::str, ?mem) || mem.kind != RVOP_MEM) { ret R.err[bool, str]("encode: inline-asm atomic address must be (rs1)"); }
+    if (mem.imm != 0)                                                   { ret R.err[bool, str]("encode: inline-asm atomic address takes no displacement"); }
+    emit_word(st, pack_r(AMO, funct3, funct7, rd.reg::u32, mem.reg::u32, rs2.reg::u32));
+    ret R.ok[bool, str](true);
+}
+
 # parse and encode one trimmed inline-asm statement. a numeric local-label definition
 # `<digits>:` records the current offset (resolving forward references) and re-dispatches
 # any instruction following it. an unrecognized mnemonic is a hard error so the
@@ -2703,6 +2803,7 @@ fun encode_asm_stmt_riscv64(st: *encode.EncodeState, f: *mir.MirFunction, fn_bas
     if (str_equals(mnem, "nop"))    { emit_word(st, pack_i(OP_IMM, F3_ADD, RZERO, RZERO, 0)); ret R.ok[bool, str](true); }
     if (str_equals(mnem, "ret"))    { emit_word(st, pack_i(JALR, F3_ADD, RZERO, RRA, 0)); ret R.ok[bool, str](true); }
     if (str_equals(mnem, "fence"))  { emit_word(st, pack_i(MISC_MEM, F3_ADD, RZERO, RZERO, 0xFF)); ret R.ok[bool, str](true); }
+    if (str_equals(mnem, "pause"))  { emit_word(st, pack_i(MISC_MEM, F3_ADD, RZERO, RZERO, 0x010)); ret R.ok[bool, str](true); }
 
     # register-register ALU (R-type).
     if (str_equals(mnem, "add"))    { ret rv_three_reg(st, args, OP, F3_ADD, F7_ZERO); }
@@ -2843,6 +2944,12 @@ fun encode_asm_stmt_riscv64(st: *encode.EncodeState, f: *mir.MirFunction, fn_bas
         emit_word(st, pack_i(OP_IMM_32, F3_ADD, rd, rs, 0));
         ret R.ok[bool, str](true);
     }
+
+    # atomics (RV64A) - lr / sc / amo* with their width (.w/.d) and ordering
+    # (.aq/.rl/.aqrl) suffixes parsed inline; only a real atomic claims the dispatch.
+    var amo_matched: bool = false;
+    val amo_r: R.Result[bool, str] = rv_amo(st, mnem, args, ?amo_matched);
+    if (amo_matched) { ret amo_r; }
 
     ret R.err[bool, str](rv_named_err(st, "encode: unsupported riscv64 inline-asm mnemonic '", mnem, "'", "encode: unsupported riscv64 inline-asm mnemonic"));
 }
@@ -3828,6 +3935,110 @@ test "mach.lang.target.isa.riscv64.encode:inline_asm_symbol_relocs" {
 
     # an unknown mnemonic is a hard error, not silent bytes.
     val ur: R.Result[bool, str] = encode_asm_stmt_riscv64(?st, ?f, 0, ?labels, "frobnicate a0, a1");
+    if (!R.is_err[bool, str](ur)) { bad = 1; }
+    or { if (!str_contains(R.unwrap_err[bool, str](ur), "unsupported riscv64 inline-asm mnemonic")) { bad = 1; } }
+
+    rv_labels_dnit(?labels);
+    encode.buf_dnit(?st.buf);
+    ret bad;
+}
+
+# the RV64A atomic family (lr / sc / amo*) selects the AMO opcode, the .w / .d width
+# funct3, the per-operation funct5, and the .aq / .rl / .aqrl ordering bits, all
+# byte-exact against `llvm-mc -triple=riscv64 -mattr=+a --show-encoding`. `pause` is the
+# fence hint. registers a0/a1/a2 = x10/x11/x12; the address is the base-only `(a1)` form.
+test "mach.lang.target.isa.riscv64.encode:inline_asm_atomics" {
+    var bad: i32 = 0;
+    var st: encode.EncodeState;
+    var alloc: A.Allocator;
+    var interner: intern.Interner;
+    tasm(?st, ?alloc, ?interner);
+    var labels: RvLabels;
+    rv_labels_init(?labels, ?alloc);
+    var f: mir.MirFunction;
+
+    encode_asm_stmt_riscv64(?st, ?f, 0, ?labels, "lr.w a0, (a1)");           # 0
+    encode_asm_stmt_riscv64(?st, ?f, 0, ?labels, "lr.d a0, (a1)");           # 4
+    encode_asm_stmt_riscv64(?st, ?f, 0, ?labels, "sc.w a0, a2, (a1)");       # 8
+    encode_asm_stmt_riscv64(?st, ?f, 0, ?labels, "sc.d a0, a2, (a1)");       # 12
+    encode_asm_stmt_riscv64(?st, ?f, 0, ?labels, "amoswap.w a0, a2, (a1)");  # 16
+    encode_asm_stmt_riscv64(?st, ?f, 0, ?labels, "amoswap.d a0, a2, (a1)");  # 20
+    encode_asm_stmt_riscv64(?st, ?f, 0, ?labels, "amoadd.w a0, a2, (a1)");   # 24
+    encode_asm_stmt_riscv64(?st, ?f, 0, ?labels, "amoadd.d a0, a2, (a1)");   # 28
+    encode_asm_stmt_riscv64(?st, ?f, 0, ?labels, "amoand.w a0, a2, (a1)");   # 32
+    encode_asm_stmt_riscv64(?st, ?f, 0, ?labels, "amoand.d a0, a2, (a1)");   # 36
+    encode_asm_stmt_riscv64(?st, ?f, 0, ?labels, "amoor.w a0, a2, (a1)");    # 40
+    encode_asm_stmt_riscv64(?st, ?f, 0, ?labels, "amoor.d a0, a2, (a1)");    # 44
+    encode_asm_stmt_riscv64(?st, ?f, 0, ?labels, "amoxor.w a0, a2, (a1)");   # 48
+    encode_asm_stmt_riscv64(?st, ?f, 0, ?labels, "amoxor.d a0, a2, (a1)");   # 52
+    encode_asm_stmt_riscv64(?st, ?f, 0, ?labels, "amomax.w a0, a2, (a1)");   # 56
+    encode_asm_stmt_riscv64(?st, ?f, 0, ?labels, "amomax.d a0, a2, (a1)");   # 60
+    encode_asm_stmt_riscv64(?st, ?f, 0, ?labels, "amomin.w a0, a2, (a1)");   # 64
+    encode_asm_stmt_riscv64(?st, ?f, 0, ?labels, "amomin.d a0, a2, (a1)");   # 68
+    encode_asm_stmt_riscv64(?st, ?f, 0, ?labels, "amomaxu.w a0, a2, (a1)");  # 72
+    encode_asm_stmt_riscv64(?st, ?f, 0, ?labels, "amomaxu.d a0, a2, (a1)");  # 76
+    encode_asm_stmt_riscv64(?st, ?f, 0, ?labels, "amominu.w a0, a2, (a1)");  # 80
+    encode_asm_stmt_riscv64(?st, ?f, 0, ?labels, "amominu.d a0, a2, (a1)");  # 84
+    encode_asm_stmt_riscv64(?st, ?f, 0, ?labels, "lr.w.aq a0, (a1)");        # 88
+    encode_asm_stmt_riscv64(?st, ?f, 0, ?labels, "lr.d.aq a0, (a1)");        # 92
+    encode_asm_stmt_riscv64(?st, ?f, 0, ?labels, "lr.w.aqrl a0, (a1)");      # 96
+    encode_asm_stmt_riscv64(?st, ?f, 0, ?labels, "sc.w.rl a0, a2, (a1)");    # 100
+    encode_asm_stmt_riscv64(?st, ?f, 0, ?labels, "sc.d.rl a0, a2, (a1)");    # 104
+    encode_asm_stmt_riscv64(?st, ?f, 0, ?labels, "sc.d.aqrl a0, a2, (a1)");  # 108
+    encode_asm_stmt_riscv64(?st, ?f, 0, ?labels, "amoswap.w.aq a0, a2, (a1)");  # 112
+    encode_asm_stmt_riscv64(?st, ?f, 0, ?labels, "amoswap.d.rl a0, a2, (a1)");  # 116
+    encode_asm_stmt_riscv64(?st, ?f, 0, ?labels, "amoadd.w.aqrl a0, a2, (a1)"); # 120
+    encode_asm_stmt_riscv64(?st, ?f, 0, ?labels, "amoadd.d.aq a0, a2, (a1)");   # 124
+    encode_asm_stmt_riscv64(?st, ?f, 0, ?labels, "amoadd.d.rl a0, a2, (a1)");   # 128
+    encode_asm_stmt_riscv64(?st, ?f, 0, ?labels, "amoadd.d.aqrl a0, a2, (a1)"); # 132
+    encode_asm_stmt_riscv64(?st, ?f, 0, ?labels, "amomaxu.d.aqrl a0, a2, (a1)");# 136
+    encode_asm_stmt_riscv64(?st, ?f, 0, ?labels, "pause");                   # 140
+
+    if (read_word(?st.buf, 0)   != 0x1005A52F) { bad = 1; }
+    if (read_word(?st.buf, 4)   != 0x1005B52F) { bad = 1; }
+    if (read_word(?st.buf, 8)   != 0x18C5A52F) { bad = 1; }
+    if (read_word(?st.buf, 12)  != 0x18C5B52F) { bad = 1; }
+    if (read_word(?st.buf, 16)  != 0x08C5A52F) { bad = 1; }
+    if (read_word(?st.buf, 20)  != 0x08C5B52F) { bad = 1; }
+    if (read_word(?st.buf, 24)  != 0x00C5A52F) { bad = 1; }
+    if (read_word(?st.buf, 28)  != 0x00C5B52F) { bad = 1; }
+    if (read_word(?st.buf, 32)  != 0x60C5A52F) { bad = 1; }
+    if (read_word(?st.buf, 36)  != 0x60C5B52F) { bad = 1; }
+    if (read_word(?st.buf, 40)  != 0x40C5A52F) { bad = 1; }
+    if (read_word(?st.buf, 44)  != 0x40C5B52F) { bad = 1; }
+    if (read_word(?st.buf, 48)  != 0x20C5A52F) { bad = 1; }
+    if (read_word(?st.buf, 52)  != 0x20C5B52F) { bad = 1; }
+    if (read_word(?st.buf, 56)  != 0xA0C5A52F) { bad = 1; }
+    if (read_word(?st.buf, 60)  != 0xA0C5B52F) { bad = 1; }
+    if (read_word(?st.buf, 64)  != 0x80C5A52F) { bad = 1; }
+    if (read_word(?st.buf, 68)  != 0x80C5B52F) { bad = 1; }
+    if (read_word(?st.buf, 72)  != 0xE0C5A52F) { bad = 1; }
+    if (read_word(?st.buf, 76)  != 0xE0C5B52F) { bad = 1; }
+    if (read_word(?st.buf, 80)  != 0xC0C5A52F) { bad = 1; }
+    if (read_word(?st.buf, 84)  != 0xC0C5B52F) { bad = 1; }
+    if (read_word(?st.buf, 88)  != 0x1405A52F) { bad = 1; }
+    if (read_word(?st.buf, 92)  != 0x1405B52F) { bad = 1; }
+    if (read_word(?st.buf, 96)  != 0x1605A52F) { bad = 1; }
+    if (read_word(?st.buf, 100) != 0x1AC5A52F) { bad = 1; }
+    if (read_word(?st.buf, 104) != 0x1AC5B52F) { bad = 1; }
+    if (read_word(?st.buf, 108) != 0x1EC5B52F) { bad = 1; }
+    if (read_word(?st.buf, 112) != 0x0CC5A52F) { bad = 1; }
+    if (read_word(?st.buf, 116) != 0x0AC5B52F) { bad = 1; }
+    if (read_word(?st.buf, 120) != 0x06C5A52F) { bad = 1; }
+    if (read_word(?st.buf, 124) != 0x04C5B52F) { bad = 1; }
+    if (read_word(?st.buf, 128) != 0x02C5B52F) { bad = 1; }
+    if (read_word(?st.buf, 132) != 0x06C5B52F) { bad = 1; }
+    if (read_word(?st.buf, 136) != 0xE6C5B52F) { bad = 1; }
+    if (read_word(?st.buf, 140) != 0x0100000F) { bad = 1; }
+
+    # an atomic address takes no displacement, unlike a regular load / store.
+    val dr: R.Result[bool, str] = encode_asm_stmt_riscv64(?st, ?f, 0, ?labels, "lr.d a0, 8(a1)");
+    if (!R.is_err[bool, str](dr)) { bad = 1; }
+    or { if (!str_contains(R.unwrap_err[bool, str](dr), "no displacement")) { bad = 1; } }
+
+    # a non-atomic mnemonic that shares the `amo` prefix is still unsupported, not
+    # silently swallowed by the atomic dispatch.
+    val ur: R.Result[bool, str] = encode_asm_stmt_riscv64(?st, ?f, 0, ?labels, "amobogus.q a0, a2, (a1)");
     if (!R.is_err[bool, str](ur)) { bad = 1; }
     or { if (!str_contains(R.unwrap_err[bool, str](ur), "unsupported riscv64 inline-asm mnemonic")) { bad = 1; } }
 

--- a/src/lang/target/isa/riscv64/encode.mach
+++ b/src/lang/target/isa/riscv64/encode.mach
@@ -1913,11 +1913,23 @@ fun asm_token(s: str, start: usize, out: *u8, cap: usize, next: *usize) bool {
     ret j > 0;
 }
 
+# true when `mnem` names an RV64A atomic (lr / sc / amo*). the width (.w/.d) and
+# ordering (.aq/.rl/.aqrl) suffixes ride along, so a prefix test classifies the whole
+# family. used by the clobber classifier - lr / sc / amo* all write their rd operand.
+fun rv_mnem_is_amo(mnem: str) bool {
+    val len: usize = str_len(mnem);
+    if (len >= 3 && mnem[0] == 'l'::char && mnem[1] == 'r'::char && mnem[2] == '.'::char) { ret true; }
+    if (len >= 3 && mnem[0] == 's'::char && mnem[1] == 'c'::char && mnem[2] == '.'::char) { ret true; }
+    if (len >= 3 && mnem[0] == 'a'::char && mnem[1] == 'm'::char && mnem[2] == 'o'::char) { ret true; }
+    ret false;
+}
+
 # OR the registers one trimmed RISC-V inline-asm statement writes into `@gp`. a
 # leading `label:` is stripped and the remainder re-dispatched. a call clobbers the
-# caller-saved file; the stores / branches / system / fence / return forms write
-# nothing; the recognized destination-writing forms clobber their first register
-# operand; an unrecognized statement conservatively clobbers everything.
+# caller-saved file; the stores / branches / system / fence / pause / return forms write
+# nothing; the recognized destination-writing forms (including the RV64A atomics) clobber
+# their first register operand; an unrecognized statement conservatively clobbers
+# everything.
 fun asm_stmt_clobbers(s: str, gp: *u32, fp: *u32) {
     var mbuf: [32]u8;
     var after: usize = 0;
@@ -1938,6 +1950,7 @@ fun asm_stmt_clobbers(s: str, gp: *u32, fp: *u32) {
     if (str_equals(mnem, "sb") || str_equals(mnem, "sh") || str_equals(mnem, "sw") ||
         str_equals(mnem, "sd") || str_equals(mnem, "nop") || str_equals(mnem, "ret") ||
         str_equals(mnem, "ecall") || str_equals(mnem, "ebreak") || str_equals(mnem, "fence") ||
+        str_equals(mnem, "pause") ||
         str_equals(mnem, "j") || str_equals(mnem, "jr") ||
         str_equals(mnem, "beq") || str_equals(mnem, "bne") || str_equals(mnem, "blt") ||
         str_equals(mnem, "bge") || str_equals(mnem, "bltu") || str_equals(mnem, "bgeu") ||
@@ -1955,8 +1968,10 @@ fun asm_stmt_clobbers(s: str, gp: *u32, fp: *u32) {
         ret;
     }
 
-    # the destination-writing forms clobber their first register operand (rd).
-    if (str_equals(mnem, "li") || str_equals(mnem, "la") || str_equals(mnem, "lui") ||
+    # the destination-writing forms clobber their first register operand (rd). the
+    # RV64A atomics (lr / sc / amo*) join this set: each writes rd, the leftmost operand.
+    if (rv_mnem_is_amo(mnem) ||
+        str_equals(mnem, "li") || str_equals(mnem, "la") || str_equals(mnem, "lui") ||
         str_equals(mnem, "auipc") || str_equals(mnem, "mv") || str_equals(mnem, "neg") ||
         str_equals(mnem, "not") || str_equals(mnem, "seqz") || str_equals(mnem, "snez") ||
         str_equals(mnem, "add") || str_equals(mnem, "addi") || str_equals(mnem, "sub") ||
@@ -3732,6 +3747,17 @@ test "mach.lang.target.isa.riscv64.encode:asm_clobbers_classification" {
     asm_clobbers("loop: addi t0, t0, 1", ?gp, ?fp);
     if ((gp & (1::u32 << 5)) == 0) { bad = 1; }  # t0 = x5
     if ((gp & ~(1::u32 << 5)) != 0) { bad = 1; } # nothing else
+
+    # the RV64A atomics write their rd operand (the leftmost register); pause writes
+    # nothing. lr / sc / amo* must classify precisely, not fall to the all-clobber path.
+    gp = 0; fp = 0;
+    asm_clobbers("lr.d t0, (a1)\nsc.d t1, a2, (a1)\namoadd.d.aqrl a0, a2, (a1)\npause", ?gp, ?fp);
+    if ((gp & (1::u32 << 5)) == 0)  { bad = 1; }  # t0 = x5 written by lr.d
+    if ((gp & (1::u32 << 6)) == 0)  { bad = 1; }  # t1 = x6 written by sc.d
+    if ((gp & (1::u32 << 10)) == 0) { bad = 1; }  # a0 = x10 written by amoadd.d.aqrl
+    val amo_mask: u32 = (1::u32 << 5) | (1::u32 << 6) | (1::u32 << 10);
+    if ((gp & ~amo_mask) != 0) { bad = 1; }       # nothing else (pause writes none)
+    if (fp != 0) { bad = 1; }
 
     # an unrecognized statement conservatively clobbers everything.
     gp = 0; fp = 0;

--- a/test/riscv64/src/main.mach
+++ b/test/riscv64/src/main.mach
@@ -5,9 +5,10 @@
 # B-type and J-type branch fixups), a direct call (R_RISCV_CALL_PLT), a global
 # load + store (R_RISCV_PCREL_HI20 with LO12_I and LO12_S), a constant-valued
 # variable-amount shift used as a call argument (`1 << node`, which must
-# materialize the constant value into a register before the reg-reg `sll`), and an
-# inline-asm exit syscall (the only way to emit `ecall`). the exit code is the
-# computed sum, so the qemu e2e proves the whole pipeline runs end to end.
+# materialize the constant value into a register before the reg-reg `sll`), the
+# RV64A atomics (an lr/sc compare-and-swap loop and an amoadd.d read-modify-write),
+# and an inline-asm exit syscall (the only way to emit `ecall`). the exit code is
+# the computed sum, so the qemu e2e proves the whole pipeline runs end to end.
 
 var total: i64 = 0;
 
@@ -34,16 +35,43 @@ fun na(node: u64) u64 { ret g(0, 1 << node, 0, 0, 0, 0); }
 
 # the program entry. the `_start` symbol the linux linker resolves as the entry
 # point; the calls and the global read-modify-write give the relocations the lane
-# checks, and the inline-asm `exit` syscall returns the computed sum (53) as the
-# process exit code.
+# checks, the inline-asm block exercises the RV64A atomics (#1668), and the
+# inline-asm `exit` syscall returns the computed sum (71) as the process exit code.
+#
+# the atomics run on a stack cell (`{cell}`, address taken through `p`): an lr/sc
+# compare-and-swap loop swaps it from 0 to 7 - the reservation-retry (1b) and
+# mismatch (2f) arms are encoded though the fast path takes neither - then amoadd.d
+# adds 4 and returns the swapped 7. the folded result (prior 7 + post-rmw 11 = 18)
+# is added to the exit code, so a wrong atomic encoding or a lost store changes it.
 #[symbol("_start")]
 fun start() {
-    var code: i64 = sum_to(10);         # sum 0..9 = 45
+    var code: i64 = sum_to(10);          # sum 0..9 = 45
     total = total + code;
-    code = code + na(3)::i64;            # 1 << 3 = 8, so code = 53
+    code = code + na(3)::i64;             # 1 << 3 = 8, so code = 53
+
+    var cell:  i64  = 0;
+    var p:     *i64 = ?cell;
+    var probe: i64  = 0;
+    asm riscv64 {
+        ld   t2, {p}            # t2 = &cell
+        li   a3, 7              # the compare-and-swap new value
+    1:
+        lr.d t0, (t2)           # load-reserved *cell
+        bnez t0, 2f             # swap only while the cell is still zero
+        sc.d t1, a3, (t2)       # store-conditional 7
+        bnez t1, 1b             # retry if the reservation was lost
+    2:
+        li   a4, 4
+        amoadd.d t3, a4, (t2)   # *cell += 4; t3 = the prior value (7)
+        ld   t4, (t2)           # observe the final *cell (11)
+        add  t5, t3, t4         # 7 + 11 = 18
+        sd   t5, {probe}        # fold the result back into a local
+    }
+    code = code + probe;                  # 53 + 18 = 71
+
     asm riscv64 {
         li a7, 93        # __NR_exit
-        ld a0, {code}    # exit code = 53
+        ld a0, {code}    # exit code = 71
         ecall
     }
 }

--- a/test/riscv64/verify.sh
+++ b/test/riscv64/verify.sh
@@ -9,9 +9,10 @@
 # and qemu-riscv64 (or qemu-riscv64-static) for the exit-code run.
 set -euo pipefail
 
-# the computed exit code the fixture returns (sum 0..9 plus the const-shift call
-# argument 1 << 3 = 8, i.e. 45 + 8), the qemu e2e asserts it.
-expect_code=53
+# the computed exit code the fixture returns (sum 0..9 = 45, plus the const-shift call
+# argument 1 << 3 = 8, plus the RV64A atomics probe 18 = cas-stored 7 + post-rmw cell
+# 11), the qemu e2e asserts it.
+expect_code=71
 
 mach="${1:-mach}"
 here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -50,11 +51,17 @@ echo "$hdr" | grep -qE 'Entry point address:.*0x[0-9a-fA-F]+' || fail "exe has n
 echo "$hdr" | grep -q 'Entry point address:.*0x0$' && fail "exe entry point is zero"
 
 echo "verifying disassembly of $exe"
-dis="$("$objdump" -d "$exe")"
+# +a enables the A-extension decode so the fixture's lr/sc/amo* words disassemble as
+# the real atomics rather than `<unknown>`.
+dis="$("$objdump" -d --mattr=+a "$exe")"
 echo "$dis" | grep -q 'file format elf64-littleriscv' || fail "objdump did not parse a little-endian rv64 elf"
 echo "$dis" | grep -qi '<unknown>'                    && fail "objdump found an unknown instruction word"
 for mnem in auipc jalr ld sd addi sll ret ecall; do
     echo "$dis" | grep -qw "$mnem" || fail "expected mnemonic '$mnem' not in disassembly"
+done
+# the RV64A atomics the probe emits must disassemble as the real instructions.
+for mnem in lr.d sc.d amoadd.d; do
+    echo "$dis" | grep -qw "$mnem" || fail "expected RV64A mnemonic '$mnem' not in disassembly"
 done
 
 echo "verifying relocations in $obj"


### PR DESCRIPTION
Adds the RV64A (atomic extension) subset to the riscv64 inline-asm assembler so std's riscv64 atomic arms (mach-std#308) can be expressed. Before this, `asm riscv64 { amoadd.d ...; lr.d ...; sc.d ... }` failed with `encode: unsupported riscv64 inline-asm mnemonic`.

## What

- `lr.w` / `lr.d`, `sc.w` / `sc.d`
- `amoswap` / `amoadd` / `amoand` / `amoor` / `amoxor` / `amomax` / `amomin` / `amomaxu` / `amominu`, each `.w` and `.d`
- ordering suffixes `.aq` / `.rl` / `.aqrl` on all of the above
- `pause` (a fence hint) for `spin_hint`

## Encoding

The AMO major opcode (`0x2F`) is R-type with the 5-bit funct5 in bits [31:27] and the aq/rl bits in [26:25], so the assembled funct7 is `(funct5 << 2) | (aq << 1) | rl`. Atomics use the base-only `(rs1)` address form (no displacement, unlike a regular load/store). `lr` is the two-operand `rd, (rs1)` form (rs2 forced to x0); `sc` and the `amo*` RMWs are `rd, rs2, (rs1)`. The width (`.w`/`.d`) and ordering suffixes are parsed inline, so a future rv32 reuses the `.w` forms.

## Verification

- New byte-test `inline_asm_atomics` covers every mnemonic and every ordering variant, byte-exact against `llvm-mc -triple=riscv64 -mattr=+a --show-encoding`, plus the no-displacement and unsupported-`amo`-prefix rejections.
- qemu-riscv64 e2e extends `test/riscv64` with an `lr/sc` compare-and-swap loop and an `amoadd.d` RMW, asserting the result under qemu.
- `mach test .` passes; self-host fixpoint holds; x86_64/aarch64 unaffected.

Closes #1668.
