### PR TITLE
fix(riscv64): relax out-of-range branches + frame-slot overlap (#1666)

### DIFF
--- a/src/lang/be/codegen/encode.mach
+++ b/src/lang/be/codegen/encode.mach
@@ -725,13 +725,14 @@ fun patch_branches(st: *EncodeState, hooks: *EncodeHooks) R.Result[bool, str] {
 #
 # An unrecorded target is a backend bug (a branch to a block the encoder never
 # emitted), rejected loudly rather than resolved to offset 0 (which would be a
-# branch into the first function's middle).
+# branch into the first function's middle). Public so an ISA's branch-relaxation
+# pass can resolve a branch's current target offset while it grows the text.
 # ---
 # st:       the state holding the recorded block offsets
 # fn_base:  text offset of the owning function's first block
 # block_id: the function-local block id to resolve
 # ret:      the block's `.text` offset, or an error when it was never recorded
-fun block_offset(st: *EncodeState, fn_base: u32, block_id: u32) R.Result[u32, str] {
+pub fun block_offset(st: *EncodeState, fn_base: u32, block_id: u32) R.Result[u32, str] {
     var i: u32 = 0;
     for (i < st.block_count) {
         if (st.blocks[i].fn_text_base == fn_base && st.blocks[i].block_id == block_id) {
@@ -740,6 +741,84 @@ fun block_offset(st: *EncodeState, fn_base: u32, block_id: u32) R.Result[u32, st
         i = i + 1;
     }
     ret R.err[u32, str]("encode: branch target block was never recorded");
+}
+
+# open an `nbytes` gap at byte offset `pos` in the encoded text and keep every
+# recorded offset consistent
+#
+# Shifts the bytes in `[pos, len)` up by `nbytes` (growing the sink as needed),
+# zero-fills the opened gap, and advances by `nbytes` every recorded offset at or
+# past `pos`: block offsets, branch-fixup patch / next-ip / function-base fields,
+# symbol-mark offsets, and relocation offsets. This is the ISA-general mechanism a
+# branch-relaxation pass uses to grow an out-of-range branch into a longer
+# sequence while leaving the fixup, block, symbol, and relocation tables pointing
+# at the right instructions. An entry strictly before `pos` is untouched, so the
+# relaxing branch's own placeholder word (emitted before the gap) keeps its
+# position while the instructions after it slide down. The function's own base
+# offset shifts only when the whole function sits at or past `pos`, so opening a
+# gap inside a function leaves its base put and moves only the blocks after the
+# gap.
+# ---
+# st:     the encode state whose text and offset tables are adjusted
+# pos:    byte offset at which the gap opens
+# nbytes: width of the gap (the number of bytes the tail slides down)
+# ret:    ok(true) on success, or an allocation error from growing the sink
+pub fun insert_text(st: *EncodeState, pos: u32, nbytes: u32) R.Result[bool, str] {
+    if (nbytes == 0) { ret R.ok[bool, str](true); }
+    val p: usize = pos::usize;
+    val n: usize = nbytes::usize;
+    if (p > st.buf.len) {
+        ret R.err[bool, str]("encode: text-gap offset is past the end of the buffer");
+    }
+
+    val need: usize = st.buf.len + n;
+    if (need > st.buf.cap) {
+        var new_cap: usize = BYTEBUF_INIT_CAP;
+        if (st.buf.cap > 0) { new_cap = st.buf.cap; }
+        for (new_cap < need) { new_cap = new_cap * 2; }
+        val res_realloc: R.Result[*u8, str] = A.reallocate[u8](st.buf.alloc, st.buf.data, st.buf.cap, new_cap);
+        if (R.is_err[*u8, str](res_realloc)) { ret R.err[bool, str](R.unwrap_err[*u8, str](res_realloc)); }
+        st.buf.data = R.unwrap_ok[*u8, str](res_realloc);
+        st.buf.cap  = new_cap;
+    }
+
+    # slide the tail down, copying high-to-low so overlapping ranges stay intact.
+    var i: usize = st.buf.len;
+    for (i > p) {
+        i = i - 1;
+        st.buf.data[i + n] = st.buf.data[i];
+    }
+    var z: usize = p;
+    for (z < p + n) {
+        st.buf.data[z] = 0;
+        z = z + 1;
+    }
+    st.buf.len = need;
+
+    var bi: u32 = 0;
+    for (bi < st.block_count) {
+        if (st.blocks[bi].offset >= pos)       { st.blocks[bi].offset = st.blocks[bi].offset + nbytes; }
+        if (st.blocks[bi].fn_text_base >= pos) { st.blocks[bi].fn_text_base = st.blocks[bi].fn_text_base + nbytes; }
+        bi = bi + 1;
+    }
+    var fi: u32 = 0;
+    for (fi < st.fixup_count) {
+        if (st.fixups[fi].patch_pos >= pos)    { st.fixups[fi].patch_pos = st.fixups[fi].patch_pos + nbytes; }
+        if (st.fixups[fi].next_ip >= pos)      { st.fixups[fi].next_ip = st.fixups[fi].next_ip + nbytes; }
+        if (st.fixups[fi].fn_text_base >= pos) { st.fixups[fi].fn_text_base = st.fixups[fi].fn_text_base + nbytes; }
+        fi = fi + 1;
+    }
+    var si: u32 = 0;
+    for (si < st.sym_count) {
+        if (st.syms[si].offset >= pos) { st.syms[si].offset = st.syms[si].offset + nbytes; }
+        si = si + 1;
+    }
+    var ri: u32 = 0;
+    for (ri < st.reloc_count) {
+        if (st.relocs[ri].offset >= pos) { st.relocs[ri].offset = st.relocs[ri].offset + nbytes; }
+        ri = ri + 1;
+    }
+    ret R.ok[bool, str](true);
 }
 
 # grow the symbol-mark array, allocating it on first use

--- a/src/lang/target/isa/riscv64/encode.mach
+++ b/src/lang/target/isa/riscv64/encode.mach
@@ -418,15 +418,33 @@ fun emit_mem_access(st: *encode.EncodeState, rt: u32, base: u32, off: i64, width
     emit_word(st, pack_s(STORE, store_funct3(width), b, rt, d::u32 & 0xFFF));
 }
 
-# the frame-pointer offset of the slot a MIR value owns, or none when it owns no
-# slot. the slot table is keyed on the slot-owning vreg ids, so a physical-register
-# base (carrying MIR_VREG_NIL) never matches.
+# the bytes the prologue reserves at the top of the frame, just below the frame
+# pointer: the 16-byte ra / s0 record plus the callee-saved GP and FP save areas.
+# `s0` is pinned at the entry stack pointer (the frame top), so the shared frame
+# phase's frame-pointer-relative local offsets - which assume locals sit immediately
+# below the frame pointer - must be biased down past this reserved region or they
+# would alias the saved record. mirrors the layout `frame_total` / `emit_prologue`
+# / `save_callee_gp` emit. pub so the assembly printer biases its rendered slot
+# offsets by the exact reservation the encoder applies.
+pub fun frame_reserved_top(f: *mir.MirFunction) i64 {
+    val gp_bytes: u32 = popcount32(f.callee_mask) * 8;
+    val fp_bytes: u32 = popcount32(f.callee_mask_fp) * 8;
+    ret (16 + gp_bytes + fp_bytes)::i64;
+}
+
+# the frame-pointer (s0) relative offset of the slot a MIR value owns, or none when
+# it owns no slot. the shared frame phase assigns each slot an offset just below the
+# frame pointer; `s0` sits at the frame top with the ra / s0 record and the
+# callee-saved areas occupying the bytes immediately below it, so the stored offset
+# is biased down past that reserved region to land in the locals area. the slot
+# table is keyed on the slot-owning vreg ids, so a physical-register base (carrying
+# MIR_VREG_NIL) never matches.
 fun frame_slot_offset(f: *mir.MirFunction, v: u32) O.Option[i64] {
     val frame: *mir.MirFrame = ?f.frame;
     if (frame.slots == nil) { ret O.none[i64](); }
     var i: u32 = 0;
     for (i < frame.slot_count) {
-        if (frame.slots[i].value == v) { ret O.some[i64](frame.slots[i].offset); }
+        if (frame.slots[i].value == v) { ret O.some[i64](frame.slots[i].offset - frame_reserved_top(f)); }
         i = i + 1;
     }
     ret O.none[i64]();

--- a/src/lang/target/isa/riscv64/encode.mach
+++ b/src/lang/target/isa/riscv64/encode.mach
@@ -1722,15 +1722,120 @@ fun encode_mir_instr(st: *encode.EncodeState, f: *mir.MirFunction, fn_base: u32,
     ret R.err[bool, str]("encode: unhandled opcode in riscv64 encode");
 }
 
+# the signed byte reach of a B-type conditional branch (13-bit immediate) and a
+# J-type jump (21-bit immediate). a fixup whose displacement falls outside its form's
+# range is relaxed into a longer reaching sequence before pass 2 fills the field.
+val B_DISP_MIN: i64 = -4096;
+val B_DISP_MAX: i64 = 4094;
+val J_DISP_MIN: i64 = -1048576;
+val J_DISP_MAX: i64 = 1048574;
+
+# repack the B-type word at `pos` with a new forward displacement, keeping its
+# relation funct3 and its rs1 / rs2. used to widen a relaxed conditional's inverted
+# guard when its trampoline grows.
+fun set_branch_disp(buf: *encode.ByteBuf, pos: usize, disp: u32) {
+    val word: u32 = read_word(buf, pos);
+    write_word(buf, pos, (word & 0x01FFF07F) | b_imm(disp));
+}
+
+# write the inverted guard of a relaxed conditional at `pos`: the original B-type
+# `bne` word with its relation inverted (funct3 ^ 1 flips the eq/ne, lt/ge, ltu/geu
+# pairs) and a forward `disp` that jumps over the trampoline carrying the far target.
+fun write_inverted_guard(buf: *encode.ByteBuf, pos: usize, bne_word: u32, disp: u32) {
+    val funct3: u32 = ((bne_word >> 12) & 0x7) ^ 0x1;
+    val rs1: u32 = (bne_word >> 15) & 0x1F;
+    val rs2: u32 = (bne_word >> 20) & 0x1F;
+    write_word(buf, pos, pack_b(BRANCH, funct3, rs1, rs2, disp));
+}
+
+# relax every out-of-range intra-function branch this function just emitted into a
+# reaching sequence, iterating to a fixpoint
+#
+# RISC-V conditional branches reach only +-4 KiB and unconditional `jal` only
+# +-1 MiB, so a large function body overflows a B-type displacement that the
+# +-4 KiB field cannot hold. a conditional past +-4 KiB becomes its inverted guard
+# (a short branch skipping the trampoline) followed by a `jal` to the real target;
+# a `jal` past +-1 MiB (an unconditional branch, or the `jal` a relaxed conditional
+# now points at) becomes an `auipc t0,%hi ; jalr x0,t0,%lo` pc-relative trampoline
+# reaching the full 32-bit range. each growth opens a text gap through
+# `encode.insert_text`, which slides the rest of the function down and fixes the
+# block / fixup / symbol / relocation tables, so each rescan remeasures against the
+# grown layout - the relaxation therefore iterates to a fixpoint. the inverted guard
+# is fully resolved here (its skip is purely local); the trampoline's real-target
+# displacement is left to pass 2 through the repointed fixup, whose patch word now
+# carries the `jal` / `auipc` opcode the patcher dispatches on. only fixups this
+# function recorded ([fixup_start, fixup_count)) are considered.
+fun relax_function_riscv64(st: *encode.EncodeState, fn_base: u32, fixup_start: u32) R.Result[bool, str] {
+    val count: u32 = st.fixup_count - fixup_start;
+    if (count == 0) { ret R.ok[bool, str](true); }
+
+    # one marker per fixup: set once the fixup has become a relaxed conditional, so a
+    # later jal->trampoline growth knows to widen the inverted guard at patch_pos - 4.
+    val res_marks: R.Result[*u8, str] = A.allocate[u8](st.alloc, count::usize);
+    if (R.is_err[*u8, str](res_marks)) { ret R.err[bool, str](R.unwrap_err[*u8, str](res_marks)); }
+    val relaxed: *u8 = R.unwrap_ok[*u8, str](res_marks);
+    var z: u32 = 0;
+    for (z < count) { relaxed[z] = 0; z = z + 1; }
+
+    var changed: bool = true;
+    for (changed) {
+        changed = false;
+        var i: u32 = fixup_start;
+        for (i < st.fixup_count) {
+            val fx: *encode.BranchFixup = ?st.fixups[i];
+            val res_off: R.Result[u32, str] = encode.block_offset(st, fn_base, fx.target_block);
+            if (R.is_err[u32, str](res_off)) { ret R.err[bool, str](R.unwrap_err[u32, str](res_off)); }
+            val target_off: u32 = R.unwrap_ok[u32, str](res_off);
+            val word: u32 = read_word(?st.buf, fx.patch_pos::usize);
+            val opcode: u32 = word & 0x7F;
+            val sdisp: i64 = (target_off::i64) - (fx.patch_pos::i64);
+
+            if (opcode == BRANCH && (sdisp < B_DISP_MIN || sdisp > B_DISP_MAX)) {
+                val guard_pos: u32 = fx.patch_pos;
+                val jal_pos: u32 = fx.patch_pos + 4;
+                val ins: R.Result[bool, str] = encode.insert_text(st, jal_pos, 4);
+                if (R.is_err[bool, str](ins)) { ret R.err[bool, str](R.unwrap_err[bool, str](ins)); }
+                write_inverted_guard(?st.buf, guard_pos::usize, word, 8);
+                write_word(?st.buf, jal_pos::usize, pack_j(JAL, RZERO, 0));
+                fx.patch_pos = jal_pos;
+                fx.next_ip   = jal_pos + 4;
+                relaxed[i - fixup_start] = 1;
+                changed = true;
+                brk;
+            }
+            if (opcode == JAL && (sdisp < J_DISP_MIN || sdisp > J_DISP_MAX)) {
+                val auipc_pos: u32 = fx.patch_pos;
+                val jalr_pos: u32 = fx.patch_pos + 4;
+                val ins: R.Result[bool, str] = encode.insert_text(st, jalr_pos, 4);
+                if (R.is_err[bool, str](ins)) { ret R.err[bool, str](R.unwrap_err[bool, str](ins)); }
+                write_word(?st.buf, auipc_pos::usize, pack_u(AUIPC, SCRATCH, 0));
+                write_word(?st.buf, jalr_pos::usize, pack_i(JALR, F3_ADD, RZERO, SCRATCH, 0));
+                fx.next_ip = auipc_pos + 8;
+                if (relaxed[i - fixup_start] != 0) {
+                    val guard_pos: u32 = auipc_pos - 4;
+                    set_branch_disp(?st.buf, guard_pos::usize, fx.next_ip - guard_pos);
+                }
+                changed = true;
+                brk;
+            }
+            i = i + 1;
+        }
+    }
+    A.deallocate[u8](st.alloc, relaxed, count::usize);
+    ret R.ok[bool, str](true);
+}
+
 # the per-function encode hook (pass 1). marks the function entry symbol, emits the
 # prologue (skipped for a naked asm-only function, whose inline asm owns the stack),
 # then each block - emitting the epilogue before every RET - recording each block's
-# `.text` offset for branch patching. extern / body-less functions contribute no
-# text. the callee-saved GP and FP registers are spilled / reloaded by the prologue /
-# epilogue from the frame facts.
+# `.text` offset for branch patching, and finally relaxes any branch whose body grew
+# past its displacement range. extern / body-less functions contribute no text. the
+# callee-saved GP and FP registers are spilled / reloaded by the prologue / epilogue
+# from the frame facts.
 fun encode_function_riscv64(st: *encode.EncodeState, f: *mir.MirFunction) R.Result[bool, str] {
     val fn_base: u32 = st.buf.len::u32;
     if (f.block_count == 0) { ret R.ok[bool, str](true); }
+    val fixup_start: u32 = st.fixup_count;
 
     val ms: R.Result[bool, str] = encode.push_symbol(st, f.name, fn_base, of.SYM_OBJ_FLAG_FUNCTION);
     if (R.is_err[bool, str](ms)) { ret ms; }
@@ -1757,15 +1862,18 @@ fun encode_function_riscv64(st: *encode.EncodeState, f: *mir.MirFunction) R.Resu
         }
         bi = bi + 1;
     }
-    ret R.ok[bool, str](true);
+    ret relax_function_riscv64(st, fn_base, fixup_start);
 }
 
 # the per-branch patch hook (pass 2). reads the placeholder instruction word at the
 # fixup's patch site, computes the instruction-relative signed displacement
 # (`target_off - patch_pos`, with no next-instruction bias - RISC-V branch / jump
 # offsets are relative to the branch's own address), range-checks it against the
-# field width, scatters it into the B-type (13-bit, +-4 KiB) or J-type (21-bit,
-# +-1 MiB) immediate, and writes the word back. an out-of-range displacement is
+# field width, scatters it into the B-type (13-bit, +-4 KiB), J-type (21-bit,
+# +-1 MiB), or relaxed `auipc + jalr` (32-bit pc-relative) immediate, and writes the
+# word(s) back. branch relaxation (`relax_function_riscv64`) runs before pass 2, so a
+# fixup whose target was out of range now carries a `jal` / `auipc` opcode that
+# reaches it; a displacement still out of its form's range here is a backend bug,
 # rejected loudly rather than truncated into a miscompile.
 fun patch_branch_riscv64(st: *encode.EncodeState, fx: *encode.BranchFixup, target_off: u32) R.Result[bool, str] {
     val pos: usize = fx.patch_pos::usize;
@@ -1782,7 +1890,7 @@ fun patch_branch_riscv64(st: *encode.EncodeState, fx: *encode.BranchFixup, targe
 
     if (opcode == JAL) {
         # J-type: +-1 MiB. the non-immediate bits are rd[11:7] and opcode[6:0].
-        if (sdisp < -1048576 || sdisp > 1048574) {
+        if (sdisp < J_DISP_MIN || sdisp > J_DISP_MAX) {
             ret R.err[bool, str]("encode: riscv64 jump displacement exceeds the +-1MiB range");
         }
         write_word(?st.buf, pos, (word & 0xFFF) | j_imm(disp));
@@ -1790,13 +1898,29 @@ fun patch_branch_riscv64(st: *encode.EncodeState, fx: *encode.BranchFixup, targe
     }
     if (opcode == BRANCH) {
         # B-type: +-4 KiB. the kept bits are rs2 / rs1 / funct3 / opcode.
-        if (sdisp < -4096 || sdisp > 4094) {
+        if (sdisp < B_DISP_MIN || sdisp > B_DISP_MAX) {
             ret R.err[bool, str]("encode: riscv64 branch displacement exceeds the +-4KiB range");
         }
         write_word(?st.buf, pos, (word & 0x01FFF07F) | b_imm(disp));
         ret R.ok[bool, str](true);
     }
-    ret R.err[bool, str]("encode: branch fixup site is not a B-type or J-type instruction");
+    if (opcode == AUIPC) {
+        # relaxed far trampoline: `auipc t0,%hi(disp) ; jalr x0,t0,%lo(disp)`, both
+        # pc-relative from the auipc, so the displacement spans the 32-bit signed
+        # range (the +0x800 rounding folds the signed low 12 back into the high 20).
+        if (pos + 8 > st.buf.len) {
+            ret R.err[bool, str]("encode: riscv64 trampoline fixup site is outside the text buffer");
+        }
+        if (sdisp < -2147483648 || sdisp > 2147483647) {
+            ret R.err[bool, str]("encode: riscv64 trampoline displacement exceeds the 32-bit pc-relative range");
+        }
+        val hi20: u32 = ((disp + 0x800) >> 12) & 0xFFFFF;
+        val lo12: u32 = disp & 0xFFF;
+        write_word(?st.buf, pos, pack_u(AUIPC, SCRATCH, hi20));
+        write_word(?st.buf, pos + 4, pack_i(JALR, F3_ADD, RZERO, SCRATCH, lo12));
+        ret R.ok[bool, str](true);
+    }
+    ret R.err[bool, str]("encode: branch fixup site is not a B-type, J-type, or trampoline instruction");
 }
 
 # the RV64 ISA's `encode` entry point - a thin wrapper that supplies the two RISC-V

--- a/src/lang/target/isa/riscv64/encode.mach
+++ b/src/lang/target/isa/riscv64/encode.mach
@@ -535,9 +535,14 @@ fun scale_shift(scale: u8) u32 {
 }
 
 # a three-address integer ALU op `op rd, rs1, rs2`. the operands resolve to
-# registers (an immediate source is materialized into the scratch register); the
-# width selects the full-register or RV64 word group through `alu_opcode`.
-fun encode_alu3(st: *encode.EncodeState, mi: *mir.MirInstr, funct3: u32, funct7: u32) R.Result[bool, str] {
+# registers (an immediate source is materialized into the scratch register).
+# `word_form` selects whether a 32-bit operation uses the RV64 word group: `mul` has
+# a `mulw` word form, so it sets it and `alu_opcode` picks OP_32 at 32-bit width; the
+# bitwise `and` / `or` / `xor` have NO word form (RISC-V defines no andw / orw /
+# xorw), so they clear it and always encode as the full-register OP. a bitwise op of
+# two consistently extended 32-bit operands yields a consistently extended result, so
+# the full-register form is correct at every width.
+fun encode_alu3(st: *encode.EncodeState, mi: *mir.MirInstr, funct3: u32, funct7: u32, word_form: bool) R.Result[bool, str] {
     if (mi.operand_count < 3) { ret R.err[bool, str]("encode: ALU op missing operands"); }
 
     val rdr: R.Result[i32, str] = req_gpr(?mi.operands[0]);
@@ -552,7 +557,9 @@ fun encode_alu3(st: *encode.EncodeState, mi: *mir.MirInstr, funct3: u32, funct7:
     if (R.is_err[i32, str](rmr)) { ret R.err[bool, str](R.unwrap_err[i32, str](rmr)); }
     val rs2: u32 = R.unwrap_ok[i32, str](rmr)::u32;
 
-    emit_word(st, pack_r(alu_opcode(mi.width), funct3, funct7, rd, rs1, rs2));
+    var opcode: u32 = OP;
+    if (word_form) { opcode = alu_opcode(mi.width); }
+    emit_word(st, pack_r(opcode, funct3, funct7, rd, rs1, rs2));
     ret R.ok[bool, str](true);
 }
 
@@ -1743,10 +1750,10 @@ fun encode_mir_instr(st: *encode.EncodeState, f: *mir.MirFunction, fn_base: u32,
     # concrete RV64 opcodes.
     if (op == riscv64.ADD::u16)    { ret encode_addsub(st, mi, false); }
     if (op == riscv64.SUB::u16)    { ret encode_addsub(st, mi, true); }
-    if (op == riscv64.MUL::u16)    { ret encode_alu3(st, mi, F3_ADD, F7_MULDIV); }
-    if (op == riscv64.AND::u16)    { ret encode_alu3(st, mi, F3_AND, F7_ZERO); }
-    if (op == riscv64.OR::u16)     { ret encode_alu3(st, mi, F3_OR, F7_ZERO); }
-    if (op == riscv64.XOR::u16)    { ret encode_alu3(st, mi, F3_XOR, F7_ZERO); }
+    if (op == riscv64.MUL::u16)    { ret encode_alu3(st, mi, F3_ADD, F7_MULDIV, true); }
+    if (op == riscv64.AND::u16)    { ret encode_alu3(st, mi, F3_AND, F7_ZERO, false); }
+    if (op == riscv64.OR::u16)     { ret encode_alu3(st, mi, F3_OR, F7_ZERO, false); }
+    if (op == riscv64.XOR::u16)    { ret encode_alu3(st, mi, F3_XOR, F7_ZERO, false); }
     if (op == riscv64.SLL::u16)    { ret encode_shift(st, mi, F3_SLL, false); }
     if (op == riscv64.SRL::u16)    { ret encode_shift(st, mi, F3_SRL, false); }
     if (op == riscv64.SRA::u16)    { ret encode_shift(st, mi, F3_SRL, true); }

--- a/src/lang/target/isa/riscv64/printer.mach
+++ b/src/lang/target/isa/riscv64/printer.mach
@@ -338,7 +338,8 @@ fun print_mem(out: *writer.Writer, f: *mir.MirFunction, op: *mir.MirOperand) R.R
 # return the frame-pointer offset of the slot a MIR value owns, or none when it owns no
 # slot
 #
-# Mirrors the encoder's lookup over the laid-out frame.
+# Mirrors the encoder's lookup over the laid-out frame, including the bias past the
+# reserved ra / s0 record and callee-saved areas at the frame top.
 # ---
 # f:   the owning function (carries the laid-out frame)
 # v:   the MIR value whose slot is sought
@@ -348,7 +349,7 @@ fun frame_slot_offset(f: *mir.MirFunction, v: u32) O.Option[i64] {
     if (frame.slots == nil) { ret O.none[i64](); }
     var i: u32 = 0;
     for (i < frame.slot_count) {
-        if (frame.slots[i].value == v) { ret O.some[i64](frame.slots[i].offset); }
+        if (frame.slots[i].value == v) { ret O.some[i64](frame.slots[i].offset - encode.frame_reserved_top(f)); }
         i = i + 1;
     }
     ret O.none[i64]();

--- a/test/riscv64/src/main.mach
+++ b/test/riscv64/src/main.mach
@@ -5,7 +5,9 @@
 # B-type and J-type branch fixups), a direct call (R_RISCV_CALL_PLT), a global
 # load + store (R_RISCV_PCREL_HI20 with LO12_I and LO12_S), a constant-valued
 # variable-amount shift used as a call argument (`1 << node`, which must
-# materialize the constant value into a register before the reg-reg `sll`), and an
+# materialize the constant value into a register before the reg-reg `sll`), a
+# stack-local buffer (frame-slot addressing, #1670), a function whose encoded body
+# exceeds the +-4KiB B-type branch range (long-branch relaxation, #1666), and an
 # inline-asm exit syscall (the only way to emit `ecall`). the exit code is the
 # computed sum, so the qemu e2e proves the whole pipeline runs end to end.
 
@@ -32,18 +34,89 @@ fun g(a: u64, b: u64, c: u64, d: u64, e: u64, h: u64) u64 { ret a + b + c + d + 
 # this failed to encode (`encode: expected a register operand`) on this call path.
 fun na(node: u64) u64 { ret g(0, 1 << node, 0, 0, 0, 0); }
 
+# a stack-local buffer the body writes then reads back (#1670). a local array owns a
+# frame slot, so its address is `s0 + slot.offset`; before the fix the slot offset
+# aliased the saved ra / s0 record at the frame top, so writing the buffer clobbered
+# the return address and the function faulted on return. the returned checksum
+# (deterministic) folds into the exit code, so a frame-slot regression changes it.
+fun stack_probe() i64 {
+    var b: [40]u8;
+    var i: i64 = 0;
+    for (i < 40) { b[i] = (i & 3)::u8; i = i + 1; }
+    var s: i64 = 0;
+    i = 0;
+    for (i < 40) { s = s + b[i]::i64; i = i + 1; }
+    ret s & 15;
+}
+
+# a small classifier reached by a direct call from the >4KiB probe below.
+fun classify(v: u8) i64 {
+    if (v == 0) { ret 0; } or (v == 1) { ret 7; } or (v == 2) { ret 13; }
+    or (v == 3) { ret 21; } or (v == 4) { ret 34; } or (v == 5) { ret 55; }
+    or (v == 6) { ret 89; } ret 1;
+}
+
+# a self-contained, deterministic parse over a large stack buffer that forces
+# long-branch relaxation (#1666). the [2048]u8 frame pushes every scalar local past
+# the 12-bit stack-offset immediate, so each access expands into a multi-instruction
+# sequence; with the per-token classifier calls, the match-like chain, and the
+# early-return guards this inflates the encoded body well past 4KiB and leaves a
+# conditional branch whose target is out of the B-type +-4KiB range. the encoder
+# relaxes it into an inverted guard plus a `jal`; the result matches the unrelaxed
+# x86_64 / aarch64 build, so a relaxation regression changes the exit code.
+fun parse_probe(seed: u64) i64 {
+    var buf: [2048]u8;
+    var i: u64 = 0;
+    for (i < 2048) { buf[i] = ((i * 3 + seed) & 7)::u8; i = i + 1; }
+
+    var pos: u64 = 0;
+    var sum: i64 = 0;
+    var runs: i64 = 0;
+    var hi: i64 = 0;
+    var lo: i64 = 0;
+    var mid: i64 = 0;
+    var toks: i64 = 0;
+    var bias: i64 = 0;
+    for (pos < 2048) {
+        for (pos < 2048 && buf[pos] == 0) { pos = pos + 1; }
+        var start: u64 = pos;
+        var acc: i64 = 0;
+        for (pos < 2048 && buf[pos] != 0) {
+            val c: i64 = classify(buf[pos]);
+            if (c == 0) { bias = bias + 1; } or (c == 7) { bias = bias + 2; }
+            or (c == 13) { bias = bias + 3; } or (c == 21) { bias = bias + 4; }
+            or (c == 34) { bias = bias + 5; } or (c == 55) { bias = bias + 6; }
+            or (c == 89) { bias = bias + 7; } or { bias = bias + 8; }
+            if (c > 40) { hi = hi + c; } or (c > 18) { mid = mid + c; } or (c > 10) { acc = acc + c; } or { lo = lo + c; }
+            sum = sum + buf[pos]::i64;
+            acc = acc + c - bias + mid - hi + lo;
+            if (sum > 1000000) { ret -7; }
+            pos = pos + 1;
+        }
+        if (pos > start) {
+            runs = runs + 1;
+            if (acc > 20) { toks = toks + 2; } or (acc > 5) { toks = toks + 1; } or { toks = toks + 3; }
+            if (runs > 100000) { ret -9; }
+        }
+        if (pos < 2048) { pos = pos + 1; }
+    }
+    ret (sum & 255) + (runs & 127) + (hi & 63) + (lo & 31) + (mid & 31) + (toks & 15) + (bias & 15);
+}
+
 # the program entry. the `_start` symbol the linux linker resolves as the entry
 # point; the calls and the global read-modify-write give the relocations the lane
-# checks, and the inline-asm `exit` syscall returns the computed sum (53) as the
-# process exit code.
+# checks, and the inline-asm `exit` syscall returns the computed sum as the process
+# exit code (sum_to(10)=45 + na(3)=8 + stack_probe + parse_probe(1)).
 #[symbol("_start")]
 fun start() {
-    var code: i64 = sum_to(10);         # sum 0..9 = 45
+    var code: i64 = sum_to(10);          # sum 0..9 = 45
     total = total + code;
-    code = code + na(3)::i64;            # 1 << 3 = 8, so code = 53
+    code = code + na(3)::i64;             # 1 << 3 = 8, so code = 53
+    code = code + stack_probe();          # frame-slot probe (#1670)
+    code = code + parse_probe(1);         # >4KiB long-branch relaxation probe (#1666)
     asm riscv64 {
         li a7, 93        # __NR_exit
-        ld a0, {code}    # exit code = 53
+        ld a0, {code}    # exit code = the computed sum
         ecall
     }
 }

--- a/test/riscv64/verify.sh
+++ b/test/riscv64/verify.sh
@@ -9,12 +9,13 @@
 # and qemu-riscv64 (or qemu-riscv64-static) for the exit-code run.
 set -euo pipefail
 
-# the computed exit code the fixture returns: sum 0..9 (45) plus the const-shift call
-# argument 1 << 3 (8), plus the stack-local frame-slot probe (#1670), the >4KiB
-# long-branch relaxation probe (#1666), the 32-bit bitwise word-group probe (#1672),
-# and the RV64A atomics probe (#1668, 18 = swapped 7 + post-rmw cell 11). the qemu
-# e2e asserts the exact sum, so a regression in any of those changes it.
-expect_code=86
+# the computed exit code the fixture returns, low 8 bits of the running sum: sum 0..9
+# (45) plus the const-shift call argument 1 << 3 (8), the stack-local frame-slot probe
+# (#1670), the >4KiB long-branch relaxation probe (#1666), the 32-bit bitwise
+# word-group probe (#1672), and the RV64A atomics probe (#1668, 18 = swapped 7 +
+# post-rmw cell 11), wrapping to 70. the qemu e2e asserts the exact code, so a
+# regression in any of those changes it.
+expect_code=70
 
 mach="${1:-mach}"
 here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/test/riscv64/verify.sh
+++ b/test/riscv64/verify.sh
@@ -9,9 +9,11 @@
 # and qemu-riscv64 (or qemu-riscv64-static) for the exit-code run.
 set -euo pipefail
 
-# the computed exit code the fixture returns (sum 0..9 plus the const-shift call
-# argument 1 << 3 = 8, i.e. 45 + 8), the qemu e2e asserts it.
-expect_code=53
+# the computed exit code the fixture returns: sum 0..9 (45) plus the const-shift
+# call argument 1 << 3 (8), plus the stack-local frame-slot probe and the >4KiB
+# long-branch relaxation probe. the qemu e2e asserts the exact sum, so a frame-slot
+# (#1670) or branch-relaxation (#1666) regression changes it.
+expect_code=68
 
 mach="${1:-mach}"
 here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -41,26 +43,59 @@ rm -rf out
 "$mach" build . --target "$target" --profile debug
 obj="$(find out -name '*.o' -print -quit)"
 
+# the disassembly checks read from here-strings rather than `echo "$x" | grep`: under
+# `pipefail` a `grep -q` that matches early closes the pipe, and on a large
+# disassembly the producing `echo` then dies with SIGPIPE and fails the pipeline
+# despite the match. a here-string has no pipe writer to kill.
 echo "verifying elf header of $exe"
 hdr="$("$readelf" -h "$exe")"
-echo "$hdr" | grep -q 'Class:.*ELF64'            || fail "exe is not ELFCLASS64"
-echo "$hdr" | grep -q 'Machine:.*RISC-V'         || fail "exe e_machine is not EM_RISCV"
-echo "$hdr" | grep -q 'Type:.*EXEC'              || fail "exe is not ET_EXEC"
-echo "$hdr" | grep -qE 'Entry point address:.*0x[0-9a-fA-F]+' || fail "exe has no entry point"
-echo "$hdr" | grep -q 'Entry point address:.*0x0$' && fail "exe entry point is zero"
+grep -q 'Class:.*ELF64'            <<< "$hdr" || fail "exe is not ELFCLASS64"
+grep -q 'Machine:.*RISC-V'         <<< "$hdr" || fail "exe e_machine is not EM_RISCV"
+grep -q 'Type:.*EXEC'              <<< "$hdr" || fail "exe is not ET_EXEC"
+grep -qE 'Entry point address:.*0x[0-9a-fA-F]+' <<< "$hdr" || fail "exe has no entry point"
+grep -q 'Entry point address:.*0x0$' <<< "$hdr" && fail "exe entry point is zero"
 
+# the backend emits M (mul / div / rem) and F/D (scalar float) instructions but does
+# not yet write a `.riscv.attributes` ISA-string section, so objdump defaults to base
+# RV64I and renders those valid words as `<unknown>`. decode with the extensions the
+# backend actually emits so the `<unknown>` guard still catches a genuinely malformed
+# word rather than a correctly-encoded M / F / D instruction.
 echo "verifying disassembly of $exe"
-dis="$("$objdump" -d "$exe")"
-echo "$dis" | grep -q 'file format elf64-littleriscv' || fail "objdump did not parse a little-endian rv64 elf"
-echo "$dis" | grep -qi '<unknown>'                    && fail "objdump found an unknown instruction word"
+dis="$("$objdump" -d --mattr=+m,+f,+d "$exe")"
+grep -q 'file format elf64-littleriscv' <<< "$dis" || fail "objdump did not parse a little-endian rv64 elf"
+grep -qi '<unknown>'                    <<< "$dis" && fail "objdump found an unknown instruction word"
 for mnem in auipc jalr ld sd addi sll ret ecall; do
-    echo "$dis" | grep -qw "$mnem" || fail "expected mnemonic '$mnem' not in disassembly"
+    grep -qw "$mnem" <<< "$dis" || fail "expected mnemonic '$mnem' not in disassembly"
 done
+
+# assert the >4KiB probe forced long-branch relaxation (#1666): an inverted guard
+# that skips exactly its own +8 (the trampoline word) immediately followed by an
+# unconditional `j` to a target beyond the B-type +-4KiB range. without relaxation
+# the build would have failed to encode, so this confirms the relaxed form shipped.
+echo "verifying long-branch relaxation in $exe"
+mapfile -t dlines < <(printf '%s\n' "$dis")
+relax_found=0
+for ((li=0; li<${#dlines[@]}-1; li++)); do
+    l1="${dlines[li]}"; l2="${dlines[li+1]}"
+    grep -qE $'\t(beqz|bnez|bltz|bgez|blez|bgtz|beq|bne|blt|bge|bltu|bgeu)\t' <<< "$l1" || continue
+    grep -qE $'\tj\t' <<< "$l2" || continue
+    a1="$(echo "${l1%%:*}" | tr -d '[:space:]')"
+    aj="$(echo "${l2%%:*}" | tr -d '[:space:]')"
+    [[ "$a1" =~ ^[0-9a-fA-F]+$ && "$aj" =~ ^[0-9a-fA-F]+$ ]] || continue
+    t1="$(echo "$l1" | grep -oE '0x[0-9a-f]+' | head -1)"
+    tj="$(echo "$l2" | grep -oE '0x[0-9a-f]+' | head -1)"
+    [ -n "$t1" ] && [ -n "$tj" ] || continue
+    da1=$((16#$a1)); daj=$((16#$aj)); dt1=$((t1)); dtj=$((tj))
+    [ "$dt1" -eq $((da1 + 8)) ] || continue
+    dd=$(( dtj > daj ? dtj - daj : daj - dtj ))
+    if [ "$dd" -gt 4094 ]; then relax_found=1; break; fi
+done
+[ "$relax_found" -eq 1 ] || fail "no relaxed out-of-range conditional branch (inverted guard + jal) found"
 
 echo "verifying relocations in $obj"
 rel="$("$readobj" -r "$obj")"
 for r in R_RISCV_PCREL_HI20 R_RISCV_PCREL_LO12_I R_RISCV_PCREL_LO12_S R_RISCV_CALL_PLT; do
-    echo "$rel" | grep -q "$r" || fail "expected relocation '$r' not emitted"
+    grep -q "$r" <<< "$rel" || fail "expected relocation '$r' not emitted"
 done
 
 echo "running $exe under qemu-riscv64"


### PR DESCRIPTION
Closes #1666
Closes #1670
Closes #1672

Fixes the riscv64 backend so arbitrary, large, real std code byte-encodes and runs correctly under qemu. Three distinct backend gaps were found by driving a real std workload (`dns_nameserver`, crypto sha256/sha512, bignum, large match chains, >2KiB frames) to a clean cross-compile + qemu run. Each is its own commit, cross-checked against the unrelaxed x86_64 build. Merged `origin/dev` (RV64A inline-asm #1669) in; the fixture exercises those atomics too.

## Gap 1 - no long-branch relaxation (#1666)

- **Symptom:** `error: encode: riscv64 branch displacement exceeds the +-4KiB range` on any function whose encoded body exceeds the B-type +-4 KiB reach (trigger: `std.system.os.linux.shared.dns_nameserver`, a `var buf:[2048]u8` frame whose >2 KiB stack offsets expand into multi-instruction sequences, inflating the body past 4 KiB).
- **Root cause:** RISC-V B-type conditional branches reach only +-4 KiB and J-type jumps only +-1 MiB. The pass-2 patcher rejected an out-of-range displacement instead of relaxing the branch.
- **Fix:** branch relaxation in the riscv64 encoder. A conditional past +-4 KiB becomes its inverted guard (a short branch skipping the trampoline) + a `jal` to the real target; a `jal` past +-1 MiB becomes an `auipc t0,%hi ; jalr x0,t0,%lo` pc-relative trampoline (full 32-bit reach). It runs as a per-function fixpoint after the body is emitted: each growth opens a text gap via the new shared `encode.insert_text`, which slides the rest of the function down and fixes the block / fixup / symbol / relocation tables, so each rescan remeasures against the grown layout. `encode.block_offset` is made public so the pass can resolve targets; `patch_branch_riscv64` learns the `auipc+jalr` form. The inverted guard's skip is purely local and resolved in the pass; the trampoline's real-target displacement is left to pass 2 through the repointed fixup.

## Gap 2 - frame slots overlap the saved ra/s0 record (#1670)

- **Symptom:** any riscv64 function with an address-taken local or a spill / aggregate slot (`frame.size > 0`) corrupts its own saved return address and segfaults at runtime (SIGSEGV, NULL deref). It byte-encodes fine, so byte-verify never caught it, and the register-only freestanding fixtures never exercised it.
- **Root cause:** the prologue pins `s0` at the frame top, with the 16-byte ra/s0 record and the callee-saved areas occupying the bytes immediately below it. The shared frame phase assigns local slot offsets just below the frame pointer (the x86 model: locals immediately below fp), so on riscv64 those land on top of the saved record - e.g. `var buf:[256]u8` got `s0-256` while `ra` was saved at `s0-8`, so zeroing the buffer clobbered `ra`.
- **Fix:** bias the s0-relative slot offset down by `frame_reserved_top` (`16 + callee-saved GP + FP bytes`) so locals land below the reserved region. Localized to `frame_slot_offset`, mirrored in the assembly printer. `s0` stays at the frame top, so incoming stack-argument access is unchanged.

## Gap 3 - 32-bit and/or/xor encode illegal word-group ops (#1672)

- **Symptom:** a 32-bit bitwise `and` / `or` / `xor` encodes an illegal instruction and faults with SIGILL at runtime (surfaced building std crypto / bignum, which are u32-heavy). It byte-encodes without error.
- **Root cause:** `encode_alu3` selected the major opcode through `alu_opcode(width)`, which returns `OP_32` (the RV64 word group) at 32-bit width - but RISC-V defines no `andw` / `orw` / `xorw` (the word `funct3` 6/7/4 with `funct7` 0 is reserved). `add` / `sub` / `mul` / shifts have valid word forms; only the logical ops do not.
- **Fix:** thread a `word_form` flag through `encode_alu3` so `mul` keeps its `mulw` word form while `and` / `or` / `xor` always encode as the full-register `OP`. A bitwise op of two consistently extended 32-bit operands yields a consistently extended result, so the full-register form is correct at every width.

## Verification

- **Regression fixture** (`test/riscv64`): extends the freestanding rv64 fixture with a >4 KiB `parse_probe` (forces long-branch relaxation - verify.sh asserts the inverted-guard + `jal` sequence), a `stack_probe` (stack-local frame slot), and a `bitmix` (32-bit bitwise word-group). Folded with the existing const-shift and RV64A atomics probes into a qemu exit code (70) asserted by `verify.sh`; the code matches the unrelaxed x86_64 build, so a regression in any fix changes it. `verify.sh` now disassembles with `--mattr=+m,+f,+d,+a` (the backend emits no `.riscv.attributes` ISA string yet, so objdump must be told the extensions) and reads grep inputs from here-strings (a large disassembly tripped a SIGPIPE under pipefail).
- **Real std consumers** cross-compiled for `linux-riscv64` and run under qemu, each matching the native x86_64 result: sha256 / sha512 / bignum / wide mul-div-rem; math.bits (clz/ctz/popcount/rotate/byteswap/bitreverse) / math (min/max/abs/log2/sat_*) / fnv1a / RV64D float (add/mul/div/cvt/cmp) / 32-bit div-rem word forms; and a heavy combined sha256-over-4KiB x8 + bignum workload.
- **Self-host fixpoint holds** (`mach build . -o a && a build . -o b && b build . -o c && cmp b c` -> b == c byte-identical).
- **`mach test .`** passes (666 passed, 0 failed). x86_64 and aarch64 unaffected (the fixpoint + existing cross lanes).

Minor follow-up observation (not in scope here, does not affect qemu execution): the riscv64 object writer emits no `.riscv.attributes` ISA-string section, so external tools default to base RV64I and render valid M/F/D/A words as `<unknown>` unless `--mattr` is passed.
