### PR TITLE
feat(macho): emit ad-hoc Mach-O code signature for Darwin executables

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -181,9 +181,9 @@ jobs:
   # Mach-O-capable compiler from the PR source, cross-compiles the freestanding
   # fixtures for x86_64-darwin and aarch64-darwin, and byte-verifies both the static
   # (LC_UNIXTHREAD) and the dynamic (LC_LOAD_DYLINKER + LC_LOAD_DYLIB + dyld bind +
-  # LC_DYSYMTAB) executables with the llvm tools. there is no execution step: Darwin
-  # binaries cannot run on the Linux host, and an arm64 Darwin binary additionally
-  # needs a code signature this writer does not emit.
+  # LC_DYSYMTAB) executables with the llvm tools, including the ad-hoc
+  # LC_CODE_SIGNATURE + CodeDirectory each carries. there is no execution step:
+  # Darwin binaries cannot run on the Linux host (on-Mac exec is the macOS lane).
   cross-darwin:
     name: cross darwin (macho)
     runs-on: ubuntu-latest

--- a/src/cli/cmd/build.mach
+++ b/src/cli/cmd/build.mach
@@ -1000,6 +1000,21 @@ fun build_one_test(p: *driver.Project, level: u8, verify_ir: bool, obj_base: *u8
     ret record_test(p, t, ?exe_path[0], tests_out, persistent);
 }
 
+# the selected artifact's product name (the `[bin.<name>]`), resolved to a
+# borrowed null-terminated string, or "" when unset
+#
+# This is the writer's stable signing identity (the Mach-O code-signing
+# identifier), deliberately independent of the `-o` output path so a rename-based
+# self-host fixpoint (a -> b -> c) produces byte-identical signed images.
+# ---
+# p:   the project carrying the session and selected artifact config
+# ret: the borrowed product name, or "" when no artifact name is set
+fun artifact_product_name(p: *driver.Project) *u8 {
+    val nm: O.Option[str] = intern.lookup(?p.s.interner, p.config.bin_name);
+    if (O.is_some[str](nm)) { ret O.unwrap[str](nm)::*u8; }
+    ret ""::*u8;
+}
+
 # link the shared object set plus one test's entry object into the test
 # executable at `exe_path`
 #
@@ -1027,7 +1042,7 @@ fun link_one_test(p: *driver.Project, shared: **u8, shared_len: u32,
     paths[shared_len] = entry_path;
 
     val res_link: R.Result[bool, str] =
-        linker.link(p.s, ?p.target, paths, total, sonames, soname_len, exe_path, linker.LINK_EXE);
+        linker.link(p.s, ?p.target, paths, total, sonames, soname_len, exe_path, artifact_product_name(p), linker.LINK_EXE);
     A.deallocate[*u8](p.s.alloc, paths, total::usize);
     if (R.is_err[bool, str](res_link)) {
         print.eprint("error: ");
@@ -1365,7 +1380,7 @@ fun link_artifact(p: *driver.Project, emit_obj: bool, verbose: bool, root: *u8,
     }
 
     val res_link: R.Result[bool, str] =
-        linker.link(p.s, ?p.target, paths, len, sonames, soname_len, ?artifact[0], linker.LINK_EXE);
+        linker.link(p.s, ?p.target, paths, len, sonames, soname_len, ?artifact[0], artifact_product_name(p), linker.LINK_EXE);
     free_paths(p.s.alloc, paths, len, len);
     free_sonames(p.s.alloc, sonames, soname_len);
     if (R.is_err[bool, str](res_link)) {
@@ -1456,7 +1471,7 @@ fun link_image_artifact(p: *driver.Project, emit_obj: bool, verbose: bool, root:
     }
 
     val res_link: R.Result[bool, str] =
-        linker.link_images(p.s, ?p.target, ordered, len, nil::*intern.StrId, 0, ?artifact[0], linker.LINK_EXE);
+        linker.link_images(p.s, ?p.target, ordered, len, nil::*intern.StrId, 0, ?artifact[0], artifact_product_name(p), linker.LINK_EXE);
     A.deallocate[of.ObjectImage](p.s.alloc, ordered, len::usize);
     if (R.is_err[bool, str](res_link)) {
         print.eprint("error: ");

--- a/src/lang/be/linker.mach
+++ b/src/lang/be/linker.mach
@@ -156,11 +156,12 @@ rec DynState {
 # sonames:      interned shared-library sonames to depend on dynamically (or nil)
 # soname_count: number of shared-library dependencies
 # out_path:     null-terminated output file path
+# name:         null-terminated product name; the writer's stable signing identity
 # mode:         executable, relocatable (library), or shared
 # ret:          true once the artifact is written, or an error string
 pub fun link(s: *session.Session, tgt: *target.Target, obj_paths: **u8,
              obj_count: u32, sonames: *intern.StrId, soname_count: u32,
-             out_path: *u8, mode: LinkMode) R.Result[bool, str] {
+             out_path: *u8, name: *u8, mode: LinkMode) R.Result[bool, str] {
     if (s == nil)      { ret R.err[bool, str]("link: nil session"); }
     if (tgt == nil)    { ret R.err[bool, str]("link: nil target"); }
     if (tgt.of == nil) { ret R.err[bool, str]("link: target has no object-format vtable"); }
@@ -188,7 +189,7 @@ pub fun link(s: *session.Session, tgt: *target.Target, obj_paths: **u8,
     # the parsed images are owned here (read from disk), so they are torn down
     # after linking regardless of outcome.
     val r: R.Result[bool, str] =
-        link_modules(s, tgt, modules, module_count, sonames, soname_count, out_path, mode);
+        link_modules(s, tgt, modules, module_count, sonames, soname_count, out_path, name, mode);
     free_modules(alloc, modules, module_count);
     ret r;
 }
@@ -211,11 +212,12 @@ pub fun link(s: *session.Session, tgt: *target.Target, obj_paths: **u8,
 # sonames:      interned shared-library sonames to depend on dynamically (or nil)
 # soname_count: number of shared-library dependencies
 # out_path:     null-terminated output file path
+# name:         null-terminated product name; the writer's stable signing identity
 # mode:         executable, relocatable (library), or shared
 # ret:          true once the artifact is written, or an error string
 pub fun link_images(s: *session.Session, tgt: *target.Target, images: *of.ObjectImage,
                     image_count: u32, sonames: *intern.StrId, soname_count: u32,
-                    out_path: *u8, mode: LinkMode) R.Result[bool, str] {
+                    out_path: *u8, name: *u8, mode: LinkMode) R.Result[bool, str] {
     if (s == nil)      { ret R.err[bool, str]("link: nil session"); }
     if (tgt == nil)    { ret R.err[bool, str]("link: nil target"); }
     if (tgt.of == nil) { ret R.err[bool, str]("link: target has no object-format vtable"); }
@@ -226,7 +228,7 @@ pub fun link_images(s: *session.Session, tgt: *target.Target, images: *of.Object
     if (images == nil || image_count == 0) {
         ret R.err[bool, str]("link: no input objects");
     }
-    ret link_modules(s, tgt, images, image_count, sonames, soname_count, out_path, mode);
+    ret link_modules(s, tgt, images, image_count, sonames, soname_count, out_path, name, mode);
 }
 
 # combine an already-built module-image array into the requested artifact.
@@ -253,11 +255,12 @@ pub fun link_images(s: *session.Session, tgt: *target.Target, images: *of.Object
 # sonames:      interned shared-library sonames to depend on dynamically (or nil)
 # soname_count: number of shared-library dependencies
 # out_path:     null-terminated output file path
+# name:         null-terminated product name; the writer's stable signing identity
 # mode:         executable, relocatable (library), or shared
 # ret:          true once the artifact is written, or an error string
 fun link_modules(s: *session.Session, tgt: *target.Target, modules: *of.ObjectImage,
                  module_count: u32, sonames: *intern.StrId, soname_count: u32,
-                 out_path: *u8, mode: LinkMode) R.Result[bool, str] {
+                 out_path: *u8, name: *u8, mode: LinkMode) R.Result[bool, str] {
     val alloc: *A.Allocator = s.alloc;
     # a dynamic link is requested when shared dependencies are present and the
     # output is an executable; libraries/relocatables ignore dependencies.
@@ -377,10 +380,10 @@ fun link_modules(s: *session.Session, tgt: *target.Target, modules: *of.ObjectIm
 
         var emit_r: R.Result[bool, str] = R.ok[bool, str](true);
         if (dynamic) {
-            emit_r = emit_dynamic_executable(s, tgt, ?out_img, ?merged[0], ?sym_locs, ?dyn, out_path);
+            emit_r = emit_dynamic_executable(s, tgt, ?out_img, ?merged[0], ?sym_locs, ?dyn, out_path, name);
         }
         or {
-            emit_r = emit_executable(s, tgt, ?out_img, ?merged[0], ?sym_locs, out_path);
+            emit_r = emit_executable(s, tgt, ?out_img, ?merged[0], ?sym_locs, out_path, name);
         }
 
         free_dynstate(alloc, ?dyn);
@@ -639,10 +642,11 @@ fun parse_archive(s: *session.Session, tgt: *target.Target, path: str, buf: *u8,
 # merged:   the per-kind merged-section accumulators (carry vaddrs and lengths)
 # sym_locs: resolved symbol table, for the entry address
 # out_path: null-terminated output file path
+# name:     null-terminated product name; the writer's stable signing identity
 # ret:      true once the executable is written, or an error string
 fun emit_executable(s: *session.Session, tgt: *target.Target, out_img: *of.ObjectImage,
                     merged: *MergedSection, sym_locs: *map.Map[intern.StrId, SymbolLoc],
-                    out_path: *u8) R.Result[bool, str] {
+                    out_path: *u8, name: *u8) R.Result[bool, str] {
     if (tgt.of.emit_exec == nil) {
         ret R.err[bool, str]("link: object format cannot write executables");
     }
@@ -670,7 +674,7 @@ fun emit_executable(s: *session.Session, tgt: *target.Target, out_img: *of.Objec
     val funcs: *of.ExecFunction = R.unwrap_ok[*of.ExecFunction, str](fr);
 
     val emit_r: R.Result[bool, str] =
-        tgt.of.emit_exec(alloc, ?s.interner, tgt.arch, segs, seg_count, entry, funcs, func_count, out_path);
+        tgt.of.emit_exec(alloc, ?s.interner, tgt.arch, segs, seg_count, entry, funcs, func_count, out_path, name);
 
     if (funcs != nil && func_count > 0) {
         A.deallocate[of.ExecFunction](alloc, funcs, func_count::usize);
@@ -698,10 +702,11 @@ fun emit_executable(s: *session.Session, tgt: *target.Target, out_img: *of.Objec
 # sym_locs: resolved symbol table, for the entry address
 # dyn:      the dynamic-link plan + collected import call-site fixups
 # out_path: null-terminated output file path
+# name:     null-terminated product name; the writer's stable signing identity
 # ret:      true once the executable is written, or an error string
 fun emit_dynamic_executable(s: *session.Session, tgt: *target.Target, out_img: *of.ObjectImage,
                             merged: *MergedSection, sym_locs: *map.Map[intern.StrId, SymbolLoc],
-                            dyn: *DynState, out_path: *u8) R.Result[bool, str] {
+                            dyn: *DynState, out_path: *u8, name: *u8) R.Result[bool, str] {
     if (tgt.of.emit_dyn_exec == nil) {
         ret R.err[bool, str]("link: object format cannot write dynamically-linked executables");
     }
@@ -730,7 +735,7 @@ fun emit_dynamic_executable(s: *session.Session, tgt: *target.Target, out_img: *
 
     val emit_r: R.Result[bool, str] =
         tgt.of.emit_dyn_exec(alloc, ?s.interner, tgt.arch, segs, seg_count, entry,
-                             funcs, func_count, ?dyn.info, dyn.fixups, dyn.fixup_count, out_path);
+                             funcs, func_count, ?dyn.info, dyn.fixups, dyn.fixup_count, out_path, name);
 
     if (funcs != nil && func_count > 0) {
         A.deallocate[of.ExecFunction](alloc, funcs, func_count::usize);

--- a/src/lang/target.mach
+++ b/src/lang/target.mach
@@ -523,7 +523,7 @@ test "mach.lang.target.select_of:freestanding_raw_emits_flat_image" {
 
     # enter at the image base; the raw writer rejects any other entry.
     val em: R.Result[bool, str] =
-        t.of.emit_exec(?alloc, ?itn, t.arch, ?segs[0], 1, t.os.base_addr, nil::*of.ExecFunction, 0, tpath::*u8);
+        t.of.emit_exec(?alloc, ?itn, t.arch, ?segs[0], 1, t.os.base_addr, nil::*of.ExecFunction, 0, tpath::*u8, "selraw"::*u8);
     if (R.is_err[bool, str](em)) { filesystem.temp_close_and_remove(?tf); ret 1; }
 
     val rr: R.Result[filesystem.Buffer, str] = filesystem.read_all_sized(?alloc, tpath);

--- a/src/lang/target/of.mach
+++ b/src/lang/target/of.mach
@@ -370,9 +370,12 @@ pub def ParserFn: fun(*A.Allocator, *intern.Interner, *u8, usize, *ObjectImage) 
 # arg 6: per-function descriptors (may be nil when count is 0)
 # arg 7: number of per-function descriptors
 # arg 8: null-terminated output file path
+# arg 9: null-terminated product name (the artifact's stable identity, independent
+#        of the `-o` output path); used as the Mach-O code-signing identifier and
+#        ignored by formats that do not sign
 # ret:   true on success, or an error string
 pub def ExecFn: fun(*A.Allocator, *intern.Interner, *isa.IsaVTable, *LoadSegment, u32, u64,
-                    *ExecFunction, u32, *u8) R.Result[bool, str];
+                    *ExecFunction, u32, *u8, *u8) R.Result[bool, str];
 
 # a dynamically-linked-executable writer: serializes the linker's laid-out load
 # segments into a dynamically-linked executable, framing the format's
@@ -401,9 +404,12 @@ pub def ExecFn: fun(*A.Allocator, *intern.Interner, *isa.IsaVTable, *LoadSegment
 # arg 9:  the import call-site fixups to redirect to call-thunks
 # arg 10: number of fixups
 # arg 11: null-terminated output file path
+# arg 12: null-terminated product name (the artifact's stable identity, independent
+#         of the `-o` output path); used as the Mach-O code-signing identifier and
+#         ignored by formats that do not sign
 # ret:    true on success, or an error string
 pub def DynExecFn: fun(*A.Allocator, *intern.Interner, *isa.IsaVTable, *LoadSegment, u32, u64,
-                       *ExecFunction, u32, *DynamicInfo, *PltFixup, u32, *u8) R.Result[bool, str];
+                       *ExecFunction, u32, *DynamicInfo, *PltFixup, u32, *u8, *u8) R.Result[bool, str];
 
 # the object-format runtime-dispatch interface
 #

--- a/src/lang/target/of/bin.mach
+++ b/src/lang/target/of/bin.mach
@@ -103,6 +103,17 @@ pub fun read_u32_le(buf: *u8, offset: usize) u32 {
       | (buf[offset + 2]::u32 << 16) | (buf[offset + 3]::u32 << 24);
 }
 
+# read a big-endian u32 from `buf` at `offset`, the form the Mach-O code-signing
+# structures use
+# ---
+# buf:    source buffer
+# offset: byte offset of the field
+# ret:    the decoded value
+pub fun read_u32_be(buf: *u8, offset: usize) u32 {
+    ret (buf[offset]::u32 << 24) | (buf[offset + 1]::u32 << 16)
+      | (buf[offset + 2]::u32 << 8) | buf[offset + 3]::u32;
+}
+
 # read a little-endian u64 from `buf` at `offset`
 # ---
 # buf:    source buffer

--- a/src/lang/target/of/bin.mach
+++ b/src/lang/target/of/bin.mach
@@ -59,6 +59,31 @@ pub fun write_u64_le(buf: *u8, offset: usize, value: u64) {
     write_u32_le(buf, offset + 4, ((value >> 32) & 0xFFFFFFFF)::u32);
 }
 
+# write `value` as a big-endian u32 into `buf` at `offset`
+#
+# Mach-O is little-endian, but its embedded code-signing structures
+# (SuperBlob / CodeDirectory) are big-endian, so the Mach-O writer needs this form.
+# ---
+# buf:    destination buffer
+# offset: byte offset of the field
+# value:  the value to encode
+pub fun write_u32_be(buf: *u8, offset: usize, value: u32) {
+    buf[offset]     = ((value >> 24) & 0xFF)::u8;
+    buf[offset + 1] = ((value >> 16) & 0xFF)::u8;
+    buf[offset + 2] = ((value >> 8) & 0xFF)::u8;
+    buf[offset + 3] = (value & 0xFF)::u8;
+}
+
+# write `value` as a big-endian u64 into `buf` at `offset`
+# ---
+# buf:    destination buffer
+# offset: byte offset of the field
+# value:  the value to encode
+pub fun write_u64_be(buf: *u8, offset: usize, value: u64) {
+    write_u32_be(buf, offset,     ((value >> 32) & 0xFFFFFFFF)::u32);
+    write_u32_be(buf, offset + 4, (value & 0xFFFFFFFF)::u32);
+}
+
 # read a little-endian u16 from `buf` at `offset`
 # ---
 # buf:    source buffer

--- a/src/lang/target/of/coff.mach
+++ b/src/lang/target/of/coff.mach
@@ -2143,10 +2143,11 @@ fun compute_pe_layout(itn: *intern.Interner, lay: *PeLayout, segs: *of.LoadSegme
 # funcs:      per-function metadata for unwind-table emission
 # func_count: number of entries in funcs
 # path:       null-terminated output file path
+# name:       product name; accepted for of.ExecFn conformance (PE does not sign here)
 # ret:        ok(true) on success, or an error string
 fun coff_emit_exec(alloc: *A.Allocator, itn: *intern.Interner, isa_vt: *isa.IsaVTable, segs: *of.LoadSegment,
                    seg_count: u32, entry: u64, funcs: *of.ExecFunction,
-                   func_count: u32, path: *u8) R.Result[bool, str] {
+                   func_count: u32, path: *u8, name: *u8) R.Result[bool, str] {
     # a static PE carries no dynamic plan, so it resolves no interned names; the
     # interner is forwarded only so a write failure can be located on its path.
     ret write_pe(alloc, itn, isa_vt, segs, seg_count, entry, funcs, func_count, nil, nil, 0, path);
@@ -2172,11 +2173,12 @@ fun coff_emit_exec(alloc: *A.Allocator, itn: *intern.Interner, isa_vt: *isa.IsaV
 # fixups:      the import call-site fixups to redirect to import stubs
 # fixup_count: number of fixups
 # path:        null-terminated output file path
+# name:        product name; accepted for of.DynExecFn conformance (PE does not sign)
 # ret:         ok(true) on success, or an error string
 fun coff_emit_dyn_exec(alloc: *A.Allocator, itn: *intern.Interner, isa_vt: *isa.IsaVTable, segs: *of.LoadSegment,
                        seg_count: u32, entry: u64, funcs: *of.ExecFunction,
                        func_count: u32, dyn: *of.DynamicInfo,
-                       fixups: *of.PltFixup, fixup_count: u32, path: *u8) R.Result[bool, str] {
+                       fixups: *of.PltFixup, fixup_count: u32, path: *u8, name: *u8) R.Result[bool, str] {
     ret write_pe(alloc, itn, isa_vt, segs, seg_count, entry, funcs, func_count, dyn, fixups, fixup_count, path);
 }
 
@@ -3320,7 +3322,7 @@ test "mach.lang.target.of.coff.coff_emit_exec:pe32plus_header" {
     if (R.is_err[filesystem.TempFile, str](tf_r)) { ret 1; }
     var tf: filesystem.TempFile = R.unwrap_ok[filesystem.TempFile, str](tf_r);
 
-    val em: R.Result[bool, str] = coff_emit_exec(?alloc, ?i, ?isa_vt, ?segs[0], 2, entry, nil, 0, filesystem.temp_path(?tf)::*u8);
+    val em: R.Result[bool, str] = coff_emit_exec(?alloc, ?i, ?isa_vt, ?segs[0], 2, entry, nil, 0, filesystem.temp_path(?tf)::*u8, "coffexe"::*u8);
     if (R.is_err[bool, str](em)) { filesystem.temp_close_and_remove(?tf); ret 1; }
 
     val rb: R.Result[filesystem.Buffer, str] = filesystem.read_all_sized(?alloc, filesystem.temp_path(?tf));
@@ -3564,7 +3566,7 @@ test "mach.lang.target.of.coff.coff_emit_exec:unwind_xdata_pdata" {
     if (R.is_err[filesystem.TempFile, str](tf_r)) { ret 1; }
     var tf: filesystem.TempFile = R.unwrap_ok[filesystem.TempFile, str](tf_r);
 
-    val em: R.Result[bool, str] = coff_emit_exec(?alloc, ?i, ?isa_vt, ?segs[0], 1, entry, ?funcs[0], 1, filesystem.temp_path(?tf)::*u8);
+    val em: R.Result[bool, str] = coff_emit_exec(?alloc, ?i, ?isa_vt, ?segs[0], 1, entry, ?funcs[0], 1, filesystem.temp_path(?tf)::*u8, "coffunwind"::*u8);
     if (R.is_err[bool, str](em)) { filesystem.temp_close_and_remove(?tf); ret 1; }
 
     val rb: R.Result[filesystem.Buffer, str] = filesystem.read_all_sized(?alloc, filesystem.temp_path(?tf));

--- a/src/lang/target/of/elf.mach
+++ b/src/lang/target/of/elf.mach
@@ -943,10 +943,11 @@ fun pf_flags_for(flags: u32) u32 {
 # funcs:      per-function metadata (unused; see above)
 # func_count: number of entries in funcs (unused; see above)
 # path:       null-terminated output file path
+# name:       product name; accepted for of.ExecFn conformance (ELF does not sign)
 # ret:        ok(true) on success, or an error string
 fun emit_exec(alloc: *A.Allocator, itn: *intern.Interner, tgt_isa: *isa.IsaVTable, segs: *of.LoadSegment,
               seg_count: u32, entry: u64, funcs: *of.ExecFunction,
-              func_count: u32, path: *u8) R.Result[bool, str] {
+              func_count: u32, path: *u8, name: *u8) R.Result[bool, str] {
     if (tgt_isa == nil) { ret R.err[bool, str]("elf: nil exec isa"); }
     if (path == nil)    { ret R.err[bool, str]("elf: nil exec path"); }
 
@@ -1150,11 +1151,12 @@ fun dynstr_name_len(itn: *intern.Interner, id: intern.StrId) usize {
 # fixups:      import call-site fixups to redirect to PLT stubs
 # fixup_count: number of fixups
 # path:        null-terminated output file path
+# name:        product name; accepted for of.DynExecFn conformance (ELF does not sign)
 # ret:         ok(true) on success, or an error string
 fun emit_dyn_exec(alloc: *A.Allocator, itn: *intern.Interner, tgt_isa: *isa.IsaVTable, segs: *of.LoadSegment,
                   seg_count: u32, entry: u64, funcs: *of.ExecFunction,
                   func_count: u32, dyn: *of.DynamicInfo, fixups: *of.PltFixup,
-                  fixup_count: u32, path: *u8) R.Result[bool, str] {
+                  fixup_count: u32, path: *u8, name: *u8) R.Result[bool, str] {
     if (tgt_isa == nil) { ret R.err[bool, str]("elf: nil dyn-exec isa"); }
     if (path == nil)    { ret R.err[bool, str]("elf: nil dyn-exec path"); }
     if (dyn == nil)     { ret R.err[bool, str]("elf: nil dynamic plan"); }

--- a/src/lang/target/of/macho.mach
+++ b/src/lang/target/of/macho.mach
@@ -41,6 +41,8 @@ use std.types.string.str;
 use std.types.string.str_contains;
 use std.types.string.str_len;
 
+use std.crypto.hash.sha256;
+
 use A: std.allocator;
 use O: std.types.option;
 use R: std.types.result;
@@ -83,6 +85,8 @@ val LC_LOAD_DYLINKER: u32 = 0xE;
 # the LC_REQ_DYLD bit is set on LC_DYLD_INFO_ONLY so a loader that cannot read
 # the compressed dyld-info stream refuses the image rather than mis-loading it.
 val LC_DYLD_INFO_ONLY: u32 = 0x80000022;
+# points at the embedded code signature in __LINKEDIT.
+val LC_CODE_SIGNATURE: u32 = 0x1D;
 
 # VM protection bits used for segment maxprot/initprot.
 val VM_PROT_READ:    u32 = 1;
@@ -177,6 +181,30 @@ val ARM_PC_STATE_OFFSET:  usize = 256;
 # default page size for the static executable layout; segment file offsets are
 # page-aligned to keep each segment's `fileoff` congruent with its `vmaddr`.
 val EXEC_PAGE_SIZE: u64 = 4096;
+
+# embedded code-signing magics and the single code-directory sub-blob slot. all
+# code-signing structures are big-endian, unlike the little-endian Mach-O around
+# them.
+val CSMAGIC_EMBEDDED_SIGNATURE: u32 = 0xFADE0CC0;
+val CSMAGIC_CODEDIRECTORY:      u32 = 0xFADE0C02;
+val CSSLOT_CODEDIRECTORY:       u32 = 0;
+
+# CodeDirectory version 0x20400 carries the executable-segment fields the Apple
+# Silicon kernel reads to authorize a main binary; the adhoc flag marks a
+# signature with no CMS (certificate) blob, which is what makes it ad-hoc.
+val CS_CODEDIRECTORY_VERSION: u32 = 0x00020400;
+val CS_ADHOC_FLAG:            u32 = 0x0002;
+val CS_HASHTYPE_SHA256:       u8  = 2;
+val CS_HASH_SIZE_SHA256:      u8  = 32;
+val CS_PAGE_SHIFT:            u8  = 12;    # log2(4096)
+val CS_EXECSEG_MAIN_BINARY:   u64 = 0x1;
+
+# on-disk sizes of the code-signing structures and the LC_CODE_SIGNATURE command.
+val LINKEDIT_DATA_CMD_SIZE: usize = 16;   # cmd, cmdsize, dataoff, datasize
+val SUPERBLOB_HEADER_SIZE:  usize = 20;   # magic, length, count, one blob index
+val CODEDIR_HEADER_SIZE:    usize = 88;   # the fixed version-0x20400 header
+val CODE_SIG_PAGE_SIZE:     usize = 4096; # the 4 KiB hashing page (pageSize 12)
+val CODE_SIG_ALIGN:         usize = 16;   # the signature blob is 16-byte aligned
 
 # the machine relocation a Mach-O writer emits for one abstract kind.
 # ---
@@ -1041,6 +1069,139 @@ fun exec_segname(flags: u32) str {
     ret "__DATA_CONST";
 }
 
+# the offset of the output basename within a null-terminated path: the first byte
+# after the last '/', or 0 when the path has no separator.
+# ---
+# path: the null-terminated output path
+# ret:  the byte offset of the basename within `path`
+fun codesign_ident_start(path: *u8) usize {
+    var len:   usize = 0;
+    for (path[len] != 0) { len = len + 1; }
+    var start: usize = 0;
+    var i:     usize = 0;
+    for (i < len) {
+        if (path[i] == 47) { start = i + 1; }   # '/'
+        i = i + 1;
+    }
+    ret start;
+}
+
+# the basename length of a null-terminated path, used as the CodeDirectory
+# identifier length (excludes the terminator).
+# ---
+# path: the null-terminated output path
+# ret:  the basename byte length
+fun codesign_ident_len(path: *u8) usize {
+    var len: usize = 0;
+    for (path[len] != 0) { len = len + 1; }
+    ret len - codesign_ident_start(path);
+}
+
+# the number of 4 KiB code slots covering the file bytes [0, code_limit), rounded
+# up so the final (possibly short) page gets its own slot.
+# ---
+# code_limit: the file offset where the signature begins
+# ret:        the code-slot count
+fun codesign_code_slots(code_limit: usize) usize {
+    ret (code_limit + CODE_SIG_PAGE_SIZE - 1) / CODE_SIG_PAGE_SIZE;
+}
+
+# the byte length of the CodeDirectory blob: the fixed header, the nul-terminated
+# identifier, then one SHA-256 hash per code slot.
+# ---
+# ident_len:  the identifier byte length (excludes the terminator)
+# code_limit: the file offset where the signature begins
+# ret:        the CodeDirectory blob byte length
+fun codedir_blob_size(ident_len: usize, code_limit: usize) usize {
+    ret CODEDIR_HEADER_SIZE + ident_len + 1 + codesign_code_slots(code_limit) * CS_HASH_SIZE_SHA256::usize;
+}
+
+# the byte length of the embedded-signature SuperBlob wrapping one CodeDirectory.
+# ---
+# ident_len:  the identifier byte length (excludes the terminator)
+# code_limit: the file offset where the signature begins
+# ret:        the total signature byte length
+fun code_signature_size(ident_len: usize, code_limit: usize) usize {
+    ret SUPERBLOB_HEADER_SIZE + codedir_blob_size(ident_len, code_limit);
+}
+
+# write an ad-hoc embedded code signature into `buf` at `sig_off`
+#
+# Lays out a CSMAGIC_EMBEDDED_SIGNATURE SuperBlob wrapping a single
+# CSMAGIC_CODEDIRECTORY (version 0x20400, adhoc flag, SHA-256). The CodeDirectory
+# hashes the file bytes [0, code_limit) in 4 KiB pages - so every byte before the
+# signature is covered - and records the executable segment so the Apple Silicon
+# kernel authorizes the main binary. All code-signing fields are big-endian. The
+# result is deterministic: a pure function of the input bytes, the identifier, and
+# the layout, with no timestamp or nonce, so identical input yields identical bytes.
+# ---
+# buf:        the output buffer (the file bytes [0, code_limit) already written)
+# sig_off:    file offset the signature is written at (equal to code_limit)
+# path:       null-terminated output path; its basename is the identifier
+# code_limit: file offset where the signature begins (hashes cover [0, code_limit))
+# exec_base:  file offset of the executable (__TEXT) segment
+# exec_limit: file byte size of the executable (__TEXT) segment
+fun write_code_signature(buf: *u8, sig_off: usize, path: *u8, code_limit: usize,
+                         exec_base: u64, exec_limit: u64) {
+    val ident_start: usize = codesign_ident_start(path);
+    val ident_len:   usize = codesign_ident_len(path);
+    val n_slots:     usize = codesign_code_slots(code_limit);
+    val cd_size:     usize = codedir_blob_size(ident_len, code_limit);
+    val sig_size:    usize = SUPERBLOB_HEADER_SIZE + cd_size;
+
+    # SuperBlob header, then one blob index pointing at the CodeDirectory.
+    bin.write_u32_be(buf, sig_off,      CSMAGIC_EMBEDDED_SIGNATURE);
+    bin.write_u32_be(buf, sig_off + 4,  sig_size::u32);
+    bin.write_u32_be(buf, sig_off + 8,  1);
+    bin.write_u32_be(buf, sig_off + 12, CSSLOT_CODEDIRECTORY);
+    bin.write_u32_be(buf, sig_off + 16, SUPERBLOB_HEADER_SIZE::u32);
+
+    # CodeDirectory: the identifier follows the fixed header, then the code hashes.
+    val cd:        usize = sig_off + SUPERBLOB_HEADER_SIZE;
+    val ident_off: usize = CODEDIR_HEADER_SIZE;
+    val hash_off:  usize = CODEDIR_HEADER_SIZE + ident_len + 1;
+
+    bin.write_u32_be(buf, cd,      CSMAGIC_CODEDIRECTORY);
+    bin.write_u32_be(buf, cd + 4,  cd_size::u32);
+    bin.write_u32_be(buf, cd + 8,  CS_CODEDIRECTORY_VERSION);
+    bin.write_u32_be(buf, cd + 12, CS_ADHOC_FLAG);
+    bin.write_u32_be(buf, cd + 16, hash_off::u32);            # hashOffset (slot 0)
+    bin.write_u32_be(buf, cd + 20, ident_off::u32);           # identOffset
+    bin.write_u32_be(buf, cd + 24, 0);                        # nSpecialSlots
+    bin.write_u32_be(buf, cd + 28, n_slots::u32);             # nCodeSlots
+    bin.write_u32_be(buf, cd + 32, code_limit::u32);          # codeLimit
+    buf[cd + 36] = CS_HASH_SIZE_SHA256;                       # hashSize
+    buf[cd + 37] = CS_HASHTYPE_SHA256;                        # hashType
+    buf[cd + 38] = 0;                                         # platform
+    buf[cd + 39] = CS_PAGE_SHIFT;                             # pageSize (log2)
+    bin.write_u32_be(buf, cd + 40, 0);                        # spare2
+    bin.write_u32_be(buf, cd + 44, 0);                        # scatterOffset
+    bin.write_u32_be(buf, cd + 48, 0);                        # teamOffset
+    bin.write_u32_be(buf, cd + 52, 0);                        # spare3
+    bin.write_u64_be(buf, cd + 56, 0);                        # codeLimit64 (unused)
+    bin.write_u64_be(buf, cd + 64, exec_base);                # execSegBase
+    bin.write_u64_be(buf, cd + 72, exec_limit);               # execSegLimit
+    bin.write_u64_be(buf, cd + 80, CS_EXECSEG_MAIN_BINARY);   # execSegFlags
+
+    # the identifier C-string (the basename of the output path).
+    var k: usize = 0;
+    for (k < ident_len) {
+        buf[cd + ident_off + k] = path[ident_start + k];
+        k = k + 1;
+    }
+    buf[cd + ident_off + ident_len] = 0;
+
+    # one SHA-256 per 4 KiB page of [0, code_limit); the final page may be short.
+    var slot: usize = 0;
+    for (slot < n_slots) {
+        val page_off: usize = slot * CODE_SIG_PAGE_SIZE;
+        var page_len: usize = CODE_SIG_PAGE_SIZE;
+        if (page_off + page_len > code_limit) { page_len = code_limit - page_off; }
+        sha256.hash(?buf[page_off], page_len, ?buf[cd + hash_off + slot * CS_HASH_SIZE_SHA256::usize]);
+        slot = slot + 1;
+    }
+}
+
 # write a static MH_EXECUTE Mach-O, installed as the of.ExecFn
 #
 # Frames the linker's laid-out load segments with a leading __PAGEZERO (the
@@ -1048,9 +1209,9 @@ fun exec_segname(flags: u32) str {
 # LC_UNIXTHREAD whose thread state carries the entry point - the static thread
 # entry, with no dyld dependency. The mach header and load commands occupy the
 # file head; each segment's file bytes follow at a page-aligned offset congruent
-# with its virtual address. A runnable Darwin image (header inside __TEXT, dyld /
-# LC_MAIN, code signature) is the Darwin-runtime follow-up (#1178); this writer
-# emits the structurally complete static skeleton the byte-verify lane checks.
+# with its virtual address. A trailing __LINKEDIT segment carries an ad-hoc
+# LC_CODE_SIGNATURE so the Apple Silicon kernel admits the image (it SIGKILLs an
+# unsigned arm64 executable).
 #
 # `funcs`/`func_count` are accepted for of.ExecFn conformance; no unwind table is
 # emitted.
@@ -1078,14 +1239,17 @@ fun emit_exec(alloc: *A.Allocator, itn: *intern.Interner, isa_vt: *isa.IsaVTable
     # (freestanding) there is none.
     var pagezero_size: u64 = 0;
     if (seg_count > 0) { pagezero_size = segs[0].vaddr & ~(EXEC_PAGE_SIZE - 1); }
-    var ncmds: u32 = seg_count + 1;                 # one LC_UNIXTHREAD
-    if (pagezero_size > 0) { ncmds = ncmds + 1; }   # plus __PAGEZERO
+    # the linker segments, a trailing __LINKEDIT (carrying the code signature),
+    # LC_UNIXTHREAD, LC_CODE_SIGNATURE, and __PAGEZERO when the base is non-zero.
+    var ncmds: u32 = seg_count + 3;
+    if (pagezero_size > 0) { ncmds = ncmds + 1; }
 
     var thread_state: usize = X86_THREAD_STATE64_COUNT::usize * 4;
     if (arch_is_arm64(arch_id)) { thread_state = ARM_THREAD_STATE64_COUNT::usize * 4; }
     val thread_cmd_size: usize = 16 + thread_state;
 
-    var sizeofcmds: usize = seg_count::usize * SEGMENT_CMD_64_SIZE + thread_cmd_size;
+    var sizeofcmds: usize = seg_count::usize * SEGMENT_CMD_64_SIZE + thread_cmd_size
+                          + SEGMENT_CMD_64_SIZE + LINKEDIT_DATA_CMD_SIZE;   # __LINKEDIT + LC_CODE_SIGNATURE
     if (pagezero_size > 0) { sizeofcmds = sizeofcmds + SEGMENT_CMD_64_SIZE; }
     val header_end: usize = MACH_HEADER_64_SIZE + sizeofcmds;
 
@@ -1104,6 +1268,35 @@ fun emit_exec(alloc: *A.Allocator, itn: *intern.Interner, isa_vt: *isa.IsaVTable
         total_size = total_size + segs[li].filesz;
         li = li + 1;
     }
+
+    # the highest mapped virtual address and the executable segment, for the trailing
+    # __LINKEDIT placement and the code signature's executable-segment fields.
+    var hi_va:      u64 = 0;
+    var exec_base:  u64 = 0;
+    var exec_limit: u64 = 0;
+    var found_exec: bool = false;
+    li = 0;
+    for (li < seg_count) {
+        val end: u64 = segs[li].vaddr + bin.align_up_u64(segs[li].memsz::u64, EXEC_PAGE_SIZE);
+        if (end > hi_va) { hi_va = end; }
+        if (!found_exec && (segs[li].flags & of.SEG_FLAG_EXECUTE) != 0) {
+            exec_base  = seg_offsets[li]::u64;
+            exec_limit = segs[li].filesz::u64;
+            found_exec = true;
+        }
+        li = li + 1;
+    }
+
+    # the ad-hoc code signature lives in a trailing __LINKEDIT segment and covers
+    # every byte before it, so it is laid out last and page-aligned. codeLimit is the
+    # signature's file offset; the bytes between the last segment and it hash as zero.
+    val ident_len:     usize = codesign_ident_len(path);
+    val linkedit_off:  usize = bin.align_up(total_size, EXEC_PAGE_SIZE::usize);
+    val code_limit:    usize = linkedit_off;
+    val sig_size:      usize = code_signature_size(ident_len, code_limit);
+    val linkedit_size: usize = sig_size;
+    val linkedit_va:   u64 = bin.align_up_u64(hi_va, EXEC_PAGE_SIZE);
+    total_size = linkedit_off + sig_size;
 
     val res_buf: R.Result[*u8, str] = A.zallocate[u8](alloc, total_size);
     if (R.is_err[*u8, str](res_buf)) {
@@ -1159,6 +1352,12 @@ fun emit_exec(alloc: *A.Allocator, itn: *intern.Interner, isa_vt: *isa.IsaVTable
         li = li + 1;
     }
 
+    # __LINKEDIT carries only the ad-hoc code signature.
+    lc = write_segment_cmd(buf, lc, "__LINKEDIT", linkedit_va,
+                           bin.align_up_u64(linkedit_size::u64, EXEC_PAGE_SIZE),
+                           linkedit_off::u64, linkedit_size::u64,
+                           VM_PROT_READ, VM_PROT_READ, 0);
+
     # LC_UNIXTHREAD: the static entry, with the program counter in the thread
     # state. the surrounding state is zero (the buffer is zero-initialized).
     bin.write_u32_le(buf, lc, LC_UNIXTHREAD);
@@ -1172,6 +1371,16 @@ fun emit_exec(alloc: *A.Allocator, itn: *intern.Interner, isa_vt: *isa.IsaVTable
         bin.write_u32_le(buf, lc + 12, X86_THREAD_STATE64_COUNT);
         bin.write_u64_le(buf, lc + 16 + X86_RIP_STATE_OFFSET, entry);
     }
+    lc = lc + thread_cmd_size;
+
+    # LC_CODE_SIGNATURE points at the ad-hoc signature in __LINKEDIT.
+    bin.write_u32_le(buf, lc, LC_CODE_SIGNATURE);
+    bin.write_u32_le(buf, lc + 4, LINKEDIT_DATA_CMD_SIZE::u32);
+    bin.write_u32_le(buf, lc + 8, code_limit::u32);
+    bin.write_u32_le(buf, lc + 12, sig_size::u32);
+
+    # all file bytes [0, code_limit) are now in place; hash them into the signature.
+    write_code_signature(buf, code_limit, path, code_limit, exec_base, exec_limit);
 
     if (seg_offsets != nil) { A.deallocate[usize](alloc, seg_offsets, seg_count::usize); }
 

--- a/src/lang/target/of/macho.mach
+++ b/src/lang/target/of/macho.mach
@@ -1864,18 +1864,18 @@ fun dyn_sect_flags(flags: u32, zerofill: bool) u32 {
 # leading __PAGEZERO, a __TEXT that maps the mach header below the linker's text so
 # dyld can read the load commands, the linker's remaining segments, synthesized
 # import-stub and got segments (when there are function imports), and a __LINKEDIT
-# carrying the LC_DYLD_INFO_ONLY bind stream plus the symbol and string tables. The
-# load commands name the dynamic loader (LC_LOAD_DYLINKER), each shared dependency
-# (LC_LOAD_DYLIB), the symbol tables (LC_SYMTAB/LC_DYSYMTAB), and the static entry
-# (LC_UNIXTHREAD). Each function import's got slot is bound non-lazily by dyld, and
-# every deferred call site is redirected to its stub.
+# carrying the LC_DYLD_INFO_ONLY bind stream, the symbol and string tables, and a
+# trailing ad-hoc code signature. The load commands name the dynamic loader
+# (LC_LOAD_DYLINKER), each shared dependency (LC_LOAD_DYLIB), the symbol tables
+# (LC_SYMTAB/LC_DYSYMTAB), the static entry (LC_UNIXTHREAD), and the signature
+# (LC_CODE_SIGNATURE). Each function import's got slot is bound non-lazily by dyld,
+# and every deferred call site is redirected to its stub.
 #
 # The image uses fixed virtual addresses (no MH_PIE): the linker assigned absolute
 # addresses from the OS base and the back end emits absolute addressing, so a load
-# bias would invalidate them. Apple Silicon additionally requires a code signature
-# the kernel verifies before exec; this writer emits no LC_CODE_SIGNATURE, so its
-# output is byte-verifiable but not runnable on arm64 without an external ad-hoc
-# sign step.
+# bias would invalidate them. The ad-hoc LC_CODE_SIGNATURE the kernel verifies
+# before exec is emitted last (it covers everything before it), so the image runs on
+# Apple Silicon, which SIGKILLs an unsigned arm64 executable.
 # ---
 # alloc:       allocator for the output buffer and the scratch offset table
 # itn:         interner resolving the dynamic-plan names (sonames, imports)
@@ -1926,11 +1926,11 @@ fun emit_dyn_exec(alloc: *A.Allocator, itn: *intern.Interner, isa_vt: *isa.IsaVT
     var sizeofcmds: usize = seg_cmds::usize * SEGMENT_CMD_64_SIZE
                           + sect_total::usize * SECTION_64_SIZE
                           + DYLD_INFO_CMD_SIZE + SYMTAB_CMD_SIZE + DYSYMTAB_CMD_SIZE
-                          + dylinker_cmd_size() + thread_cmd_size;
+                          + dylinker_cmd_size() + thread_cmd_size + LINKEDIT_DATA_CMD_SIZE;   # + LC_CODE_SIGNATURE
     var di: u32 = 0;
     for (di < dyn.lib_count) { sizeofcmds = sizeofcmds + dylib_cmd_size(resolve(itn, dyn.libs[di].soname)); di = di + 1; }
 
-    var ncmds: u32 = seg_cmds + 5 + dyn.lib_count;   # dyld_info,symtab,dysymtab,dylinker,unixthread
+    var ncmds: u32 = seg_cmds + 6 + dyn.lib_count;   # dyld_info,symtab,dysymtab,dylinker,unixthread,code_signature
 
     var lay: MachoDynLayout;
     lay.hdr_span = bin.align_up(MACH_HEADER_64_SIZE + sizeofcmds, page);
@@ -2009,7 +2009,14 @@ fun emit_dyn_exec(alloc: *A.Allocator, itn: *intern.Interner, isa_vt: *isa.IsaVT
         si = si + 1;
     }
     lay.strtab_off  = lay.symtab_off + nimp::usize * NLIST_64_SIZE;
-    val total_size: usize = lay.strtab_off + lay.strtab_size;
+
+    # the ad-hoc code signature trails the symbol/string tables inside __LINKEDIT,
+    # 16-byte aligned; it covers everything before it, so codeLimit is its offset.
+    val ident_len:  usize = codesign_ident_len(path);
+    val sig_off:    usize = bin.align_up(lay.strtab_off + lay.strtab_size, CODE_SIG_ALIGN);
+    val sig_size:   usize = code_signature_size(ident_len, sig_off);
+    val exec_limit: u64 = lay.hdr_span::u64 + segs[0].filesz::u64;   # __TEXT file size
+    val total_size: usize = sig_off + sig_size;
     lay.linkedit_size = total_size - lay.linkedit_off;
 
     val res_buf: R.Result[*u8, str] = A.zallocate[u8](alloc, total_size);
@@ -2148,6 +2155,13 @@ fun emit_dyn_exec(alloc: *A.Allocator, itn: *intern.Interner, isa_vt: *isa.IsaVT
         bin.write_u32_le(buf, lc + 12, X86_THREAD_STATE64_COUNT);
         bin.write_u64_le(buf, lc + 16 + X86_RIP_STATE_OFFSET, entry);
     }
+    lc = lc + thread_cmd_size;
+
+    # LC_CODE_SIGNATURE points at the ad-hoc signature trailing __LINKEDIT.
+    bin.write_u32_le(buf, lc, LC_CODE_SIGNATURE);
+    bin.write_u32_le(buf, lc + 4, LINKEDIT_DATA_CMD_SIZE::u32);
+    bin.write_u32_le(buf, lc + 8, sig_off::u32);
+    bin.write_u32_le(buf, lc + 12, sig_size::u32);
 
     # copy the linker's segment bytes to their file offsets.
     li = 0;
@@ -2206,6 +2220,10 @@ fun emit_dyn_exec(alloc: *A.Allocator, itn: *intern.Interner, isa_vt: *isa.IsaVT
         A.deallocate[u8](alloc, buf, total_size);
         ret R.err[bool, str](R.unwrap_err[bool, str](fx_r));
     }
+
+    # the signature hashes the finished file, so it is written last - after the
+    # segment bytes, the bind/symbol tables, and the call-site fixups are all placed.
+    write_code_signature(buf, sig_off, path, sig_off, 0, exec_limit);
 
     val wr: R.Result[bool, str] = write_file(itn, alloc, path, buf, total_size, "macho: dyn-exec");
     A.deallocate[u8](alloc, buf, total_size);

--- a/src/lang/target/of/macho.mach
+++ b/src/lang/target/of/macho.mach
@@ -1069,32 +1069,20 @@ fun exec_segname(flags: u32) str {
     ret "__DATA_CONST";
 }
 
-# the offset of the output basename within a null-terminated path: the first byte
-# after the last '/', or 0 when the path has no separator.
+# the CodeDirectory identifier length: the byte length of the null-terminated
+# product name (excludes the terminator; 0 for a nil name)
+#
+# The identifier is the artifact's stable product name (e.g. "mach"), not the `-o`
+# output basename, so the signed image is byte-identical regardless of the output
+# filename - which the rename-based self-host fixpoint (a -> b -> c) requires.
 # ---
-# path: the null-terminated output path
-# ret:  the byte offset of the basename within `path`
-fun codesign_ident_start(path: *u8) usize {
-    var len:   usize = 0;
-    for (path[len] != 0) { len = len + 1; }
-    var start: usize = 0;
-    var i:     usize = 0;
-    for (i < len) {
-        if (path[i] == 47) { start = i + 1; }   # '/'
-        i = i + 1;
-    }
-    ret start;
-}
-
-# the basename length of a null-terminated path, used as the CodeDirectory
-# identifier length (excludes the terminator).
-# ---
-# path: the null-terminated output path
-# ret:  the basename byte length
-fun codesign_ident_len(path: *u8) usize {
+# name: the null-terminated product name
+# ret:  the identifier byte length
+fun codesign_ident_len(name: *u8) usize {
+    if (name == nil) { ret 0; }
     var len: usize = 0;
-    for (path[len] != 0) { len = len + 1; }
-    ret len - codesign_ident_start(path);
+    for (name[len] != 0) { len = len + 1; }
+    ret len;
 }
 
 # the number of 4 KiB code slots covering the file bytes [0, code_limit), rounded
@@ -1137,14 +1125,13 @@ fun code_signature_size(ident_len: usize, code_limit: usize) usize {
 # ---
 # buf:        the output buffer (the file bytes [0, code_limit) already written)
 # sig_off:    file offset the signature is written at (equal to code_limit)
-# path:       null-terminated output path; its basename is the identifier
+# name:       null-terminated product name used as the identifier (filename-stable)
 # code_limit: file offset where the signature begins (hashes cover [0, code_limit))
 # exec_base:  file offset of the executable (__TEXT) segment
 # exec_limit: file byte size of the executable (__TEXT) segment
-fun write_code_signature(buf: *u8, sig_off: usize, path: *u8, code_limit: usize,
+fun write_code_signature(buf: *u8, sig_off: usize, name: *u8, code_limit: usize,
                          exec_base: u64, exec_limit: u64) {
-    val ident_start: usize = codesign_ident_start(path);
-    val ident_len:   usize = codesign_ident_len(path);
+    val ident_len:   usize = codesign_ident_len(name);
     val n_slots:     usize = codesign_code_slots(code_limit);
     val cd_size:     usize = codedir_blob_size(ident_len, code_limit);
     val sig_size:    usize = SUPERBLOB_HEADER_SIZE + cd_size;
@@ -1183,10 +1170,10 @@ fun write_code_signature(buf: *u8, sig_off: usize, path: *u8, code_limit: usize,
     bin.write_u64_be(buf, cd + 72, exec_limit);               # execSegLimit
     bin.write_u64_be(buf, cd + 80, CS_EXECSEG_MAIN_BINARY);   # execSegFlags
 
-    # the identifier C-string (the basename of the output path).
+    # the identifier C-string (the product name).
     var k: usize = 0;
     for (k < ident_len) {
-        buf[cd + ident_off + k] = path[ident_start + k];
+        buf[cd + ident_off + k] = name[k];
         k = k + 1;
     }
     buf[cd + ident_off + ident_len] = 0;
@@ -1225,10 +1212,11 @@ fun write_code_signature(buf: *u8, sig_off: usize, path: *u8, code_limit: usize,
 # funcs:      per-function metadata (unused)
 # func_count: number of entries in funcs (unused)
 # path:       null-terminated output file path
+# name:       null-terminated product name; the filename-stable code-sign identifier
 # ret:        ok(true) on success, or an error string
 fun emit_exec(alloc: *A.Allocator, itn: *intern.Interner, isa_vt: *isa.IsaVTable, segs: *of.LoadSegment,
               seg_count: u32, entry: u64, funcs: *of.ExecFunction, func_count: u32,
-              path: *u8) R.Result[bool, str] {
+              path: *u8, name: *u8) R.Result[bool, str] {
     if (isa_vt == nil) { ret R.err[bool, str]("macho: nil exec isa"); }
     if (path == nil)   { ret R.err[bool, str]("macho: nil exec path"); }
     val arch_id: u32 = isa_vt.id;
@@ -1290,7 +1278,7 @@ fun emit_exec(alloc: *A.Allocator, itn: *intern.Interner, isa_vt: *isa.IsaVTable
     # the ad-hoc code signature lives in a trailing __LINKEDIT segment and covers
     # every byte before it, so it is laid out last and page-aligned. codeLimit is the
     # signature's file offset; the bytes between the last segment and it hash as zero.
-    val ident_len:     usize = codesign_ident_len(path);
+    val ident_len:     usize = codesign_ident_len(name);
     val linkedit_off:  usize = bin.align_up(total_size, EXEC_PAGE_SIZE::usize);
     val code_limit:    usize = linkedit_off;
     val sig_size:      usize = code_signature_size(ident_len, code_limit);
@@ -1380,7 +1368,7 @@ fun emit_exec(alloc: *A.Allocator, itn: *intern.Interner, isa_vt: *isa.IsaVTable
     bin.write_u32_le(buf, lc + 12, sig_size::u32);
 
     # all file bytes [0, code_limit) are now in place; hash them into the signature.
-    write_code_signature(buf, code_limit, path, code_limit, exec_base, exec_limit);
+    write_code_signature(buf, code_limit, name, code_limit, exec_base, exec_limit);
 
     if (seg_offsets != nil) { A.deallocate[usize](alloc, seg_offsets, seg_count::usize); }
 
@@ -1889,11 +1877,12 @@ fun dyn_sect_flags(flags: u32, zerofill: bool) u32 {
 # fixups:      the deferred import call-site fixups
 # fixup_count: number of fixups
 # path:        null-terminated output file path
+# name:        null-terminated product name; the filename-stable code-sign identifier
 # ret:         ok(true) on success, or an error string
 fun emit_dyn_exec(alloc: *A.Allocator, itn: *intern.Interner, isa_vt: *isa.IsaVTable, segs: *of.LoadSegment,
                   seg_count: u32, entry: u64, funcs: *of.ExecFunction, func_count: u32,
                   dyn: *of.DynamicInfo, fixups: *of.PltFixup, fixup_count: u32,
-                  path: *u8) R.Result[bool, str] {
+                  path: *u8, name: *u8) R.Result[bool, str] {
     if (isa_vt == nil) { ret R.err[bool, str]("macho: nil dyn-exec isa"); }
     if (path == nil)   { ret R.err[bool, str]("macho: nil dyn-exec path"); }
     if (dyn == nil)    { ret R.err[bool, str]("macho: nil dynamic plan"); }
@@ -2012,7 +2001,7 @@ fun emit_dyn_exec(alloc: *A.Allocator, itn: *intern.Interner, isa_vt: *isa.IsaVT
 
     # the ad-hoc code signature trails the symbol/string tables inside __LINKEDIT,
     # 16-byte aligned; it covers everything before it, so codeLimit is its offset.
-    val ident_len:  usize = codesign_ident_len(path);
+    val ident_len:  usize = codesign_ident_len(name);
     val sig_off:    usize = bin.align_up(lay.strtab_off + lay.strtab_size, CODE_SIG_ALIGN);
     val sig_size:   usize = code_signature_size(ident_len, sig_off);
     val exec_limit: u64 = lay.hdr_span::u64 + segs[0].filesz::u64;   # __TEXT file size
@@ -2223,7 +2212,7 @@ fun emit_dyn_exec(alloc: *A.Allocator, itn: *intern.Interner, isa_vt: *isa.IsaVT
 
     # the signature hashes the finished file, so it is written last - after the
     # segment bytes, the bind/symbol tables, and the call-site fixups are all placed.
-    write_code_signature(buf, sig_off, path, sig_off, 0, exec_limit);
+    write_code_signature(buf, sig_off, name, sig_off, 0, exec_limit);
 
     val wr: R.Result[bool, str] = write_file(itn, alloc, path, buf, total_size, "macho: dyn-exec");
     A.deallocate[u8](alloc, buf, total_size);
@@ -2949,7 +2938,9 @@ fun ts_exec_x64() u8 {
     var tf: filesystem.TempFile = R.unwrap_ok[filesystem.TempFile, str](tf_r);
     val tpath: str = filesystem.temp_path(?tf);
 
-    val em: R.Result[bool, str] = emit_exec(?alloc, ?itn, ?isa_vt, ?segs[0], 1, entry, nil::*of.ExecFunction, 0, tpath::*u8);
+    # the product name is deliberately not the temp-file basename, to prove the
+    # code-sign identifier tracks the name, not the output path.
+    val em: R.Result[bool, str] = emit_exec(?alloc, ?itn, ?isa_vt, ?segs[0], 1, entry, nil::*of.ExecFunction, 0, tpath::*u8, "machoexe"::*u8);
     if (R.is_err[bool, str](em)) { filesystem.temp_close_and_remove(?tf); ret 1; }
 
     val rb: R.Result[filesystem.Buffer, str] = filesystem.read_all_sized(?alloc, tpath);
@@ -2983,6 +2974,10 @@ fun ts_exec_x64() u8 {
     val cd: usize = sig_off + SUPERBLOB_HEADER_SIZE;
     if (bin.read_u32_be(buf.data, cd) != CSMAGIC_CODEDIRECTORY)           { ret 1; }
     if (bin.read_u32_be(buf.data, cd + 32) != sig_off::u32)               { ret 1; }
+    # the identifier is the product name "machoexe", not the temp-path basename.
+    val id_off: usize = cd + bin.read_u32_be(buf.data, cd + 20)::usize;
+    if (!t_bytes_contain(buf.data, id_off, str_len("machoexe"), "machoexe")) { ret 1; }
+    if (buf.data[id_off + str_len("machoexe")] != 0)                         { ret 1; }
     ret 0;
 }
 
@@ -3010,7 +3005,7 @@ fun ts_exec_arm64() u8 {
     var tf: filesystem.TempFile = R.unwrap_ok[filesystem.TempFile, str](tf_r);
     val tpath: str = filesystem.temp_path(?tf);
 
-    val em: R.Result[bool, str] = emit_exec(?alloc, ?itn, ?isa_vt, ?segs[0], 1, entry, nil::*of.ExecFunction, 0, tpath::*u8);
+    val em: R.Result[bool, str] = emit_exec(?alloc, ?itn, ?isa_vt, ?segs[0], 1, entry, nil::*of.ExecFunction, 0, tpath::*u8, "machoa64"::*u8);
     if (R.is_err[bool, str](em)) { filesystem.temp_close_and_remove(?tf); ret 1; }
 
     val rb: R.Result[filesystem.Buffer, str] = filesystem.read_all_sized(?alloc, tpath);
@@ -3128,7 +3123,7 @@ fun ts_dyn_exec(arch_id: u32) u8 {
     val tpath: str = filesystem.temp_path(?tf);
 
     val em: R.Result[bool, str] = emit_dyn_exec(?alloc, ?itn, ?isa_vt, ?segs[0], 1, entry,
-                                                nil::*of.ExecFunction, 0, ?dyn, ?fx[0], 1, tpath::*u8);
+                                                nil::*of.ExecFunction, 0, ?dyn, ?fx[0], 1, tpath::*u8, "machodyn"::*u8);
     if (R.is_err[bool, str](em)) { filesystem.temp_close_and_remove(?tf); ret 1; }
 
     val rb: R.Result[filesystem.Buffer, str] = filesystem.read_all_sized(?alloc, tpath);

--- a/src/lang/target/of/macho.mach
+++ b/src/lang/target/of/macho.mach
@@ -2959,8 +2959,8 @@ fun ts_exec_x64() u8 {
 
     if (bin.read_u32_le(buf.data, 0) != MH_MAGIC_64) { ret 1; }
     if (bin.read_u32_le(buf.data, 12) != MH_EXECUTE) { ret 1; }
-    # ncmds: __PAGEZERO + one segment + LC_UNIXTHREAD.
-    if (bin.read_u32_le(buf.data, 16) != 3) { ret 1; }
+    # ncmds: __PAGEZERO + one segment + __LINKEDIT + LC_UNIXTHREAD + LC_CODE_SIGNATURE.
+    if (bin.read_u32_le(buf.data, 16) != 5) { ret 1; }
 
     # the first load command is __PAGEZERO spanning the image base.
     val pz: usize = MACH_HEADER_64_SIZE;
@@ -2973,6 +2973,16 @@ fun ts_exec_x64() u8 {
     if (th == 0)                                                        { ret 1; }
     if (bin.read_u32_le(buf.data, th + 8) != X86_THREAD_STATE64)        { ret 1; }
     if (bin.read_u64_le(buf.data, th + 16 + X86_RIP_STATE_OFFSET) != entry) { ret 1; }
+
+    # the ad-hoc code signature: LC_CODE_SIGNATURE points at an embedded-signature
+    # SuperBlob whose codeLimit (big-endian) equals its own file offset.
+    val cs: usize = t_find_lc(buf.data, LC_CODE_SIGNATURE);
+    if (cs == 0)                                          { ret 1; }
+    val sig_off: usize = bin.read_u32_le(buf.data, cs + 8)::usize;
+    if (bin.read_u32_be(buf.data, sig_off) != CSMAGIC_EMBEDDED_SIGNATURE) { ret 1; }
+    val cd: usize = sig_off + SUPERBLOB_HEADER_SIZE;
+    if (bin.read_u32_be(buf.data, cd) != CSMAGIC_CODEDIRECTORY)           { ret 1; }
+    if (bin.read_u32_be(buf.data, cd + 32) != sig_off::u32)               { ret 1; }
     ret 0;
 }
 
@@ -3162,6 +3172,13 @@ fun ts_dyn_exec(arch_id: u32) u8 {
     or {
         if (bin.read_u64_le(buf.data, th + 16 + X86_RIP_STATE_OFFSET) != entry) { ret 1; }
     }
+
+    # the ad-hoc code signature trailing __LINKEDIT.
+    val cs: usize = t_find_lc(buf.data, LC_CODE_SIGNATURE);
+    if (cs == 0)                                                          { ret 1; }
+    val sig_off: usize = bin.read_u32_le(buf.data, cs + 8)::usize;
+    if (bin.read_u32_be(buf.data, sig_off) != CSMAGIC_EMBEDDED_SIGNATURE) { ret 1; }
+    if (bin.read_u32_be(buf.data, sig_off + SUPERBLOB_HEADER_SIZE) != CSMAGIC_CODEDIRECTORY) { ret 1; }
     ret 0;
 }
 

--- a/src/lang/target/of/raw.mach
+++ b/src/lang/target/of/raw.mach
@@ -139,10 +139,11 @@ fun parse_object(a: *A.Allocator, itn: *intern.Interner, buf: *u8, buf_len: usiz
 # funcs:      per-function metadata (unused; see above)
 # func_count: number of entries in funcs (unused; see above)
 # path:       null-terminated output file path
+# name:       product name; accepted for of.ExecFn conformance (a flat image is unsigned)
 # ret:        ok(true) on success, or an error string
 fun emit_exec(alloc: *A.Allocator, itn: *intern.Interner, tgt_isa: *isa.IsaVTable, segs: *of.LoadSegment,
               seg_count: u32, entry: u64, funcs: *of.ExecFunction,
-              func_count: u32, path: *u8) R.Result[bool, str] {
+              func_count: u32, path: *u8, name: *u8) R.Result[bool, str] {
     if (tgt_isa == nil) { ret R.err[bool, str]("raw: nil exec isa"); }
     if (path == nil)    { ret R.err[bool, str]("raw: nil exec path"); }
 
@@ -192,11 +193,12 @@ fun emit_exec(alloc: *A.Allocator, itn: *intern.Interner, tgt_isa: *isa.IsaVTabl
 # fixups:     the import call-site fixups
 # fixup_count: number of fixups
 # path:       null-terminated output file path
+# name:       product name; accepted for of.DynExecFn conformance (always unsupported)
 # ret:        the unsupported-format error
 fun emit_dyn_exec(alloc: *A.Allocator, itn: *intern.Interner, tgt_isa: *isa.IsaVTable, segs: *of.LoadSegment,
                   seg_count: u32, entry: u64, funcs: *of.ExecFunction, func_count: u32,
                   dyn: *of.DynamicInfo, fixups: *of.PltFixup, fixup_count: u32,
-                  path: *u8) R.Result[bool, str] {
+                  path: *u8, name: *u8) R.Result[bool, str] {
     ret R.err[bool, str](RAW_UNSUPPORTED);
 }
 
@@ -278,7 +280,7 @@ test "mach.lang.target.of.raw.emit_exec:flat_layout" {
     val tpath: str = filesystem.temp_path(?tf);
 
     val em: R.Result[bool, str] =
-        emit_exec(?alloc, ?i, ?isa_vt, ?segs[0], 2, 0x1000, nil::*of.ExecFunction, 0, tpath::*u8);
+        emit_exec(?alloc, ?i, ?isa_vt, ?segs[0], 2, 0x1000, nil::*of.ExecFunction, 0, tpath::*u8, "rawflat"::*u8);
     if (R.is_err[bool, str](em)) { filesystem.temp_close_and_remove(?tf); ret 1; }
 
     val rr: R.Result[filesystem.Buffer, str] = filesystem.read_all_sized(?alloc, tpath);
@@ -328,7 +330,7 @@ test "mach.lang.target.of.raw.emit_exec:entry_must_be_base" {
 
     # entry 0x1008 != image base 0x1000 must be rejected.
     val em: R.Result[bool, str] =
-        emit_exec(?alloc, ?i, ?isa_vt, ?segs[0], 1, 0x1008, nil::*of.ExecFunction, 0, "raw_should_not_exist"::*u8);
+        emit_exec(?alloc, ?i, ?isa_vt, ?segs[0], 1, 0x1008, nil::*of.ExecFunction, 0, "raw_should_not_exist"::*u8, "rawbad"::*u8);
     if (!R.is_err[bool, str](em))                                { ret 1; }
     if (!str_contains(R.unwrap_err[bool, str](em), "base"))      { ret 1; }
     ret 0;

--- a/test/macho/verify.sh
+++ b/test/macho/verify.sh
@@ -6,14 +6,14 @@
 # segments, LC_UNIXTHREAD entry), and a dyld-loadable DYNAMIC executable
 # (LC_LOAD_DYLINKER, LC_LOAD_DYLIB, an LC_DYLD_INFO_ONLY bind stream, the
 # LC_SYMTAB/LC_DYSYMTAB pair, and an import stub the call site is redirected to).
-# nothing is run: Darwin binaries cannot run on this Linux host, and an arm64
-# Darwin binary additionally needs a code signature the kernel verifies, which
-# this writer does not emit. this mirrors the riscv64 cross lane - byte
-# verification, no execution step.
+# both executables also carry an ad-hoc LC_CODE_SIGNATURE, whose embedded
+# SuperBlob + CodeDirectory this script parses and validates by hand (codesign is
+# macOS-only). nothing is run: Darwin binaries cannot run on this Linux host. this
+# mirrors the riscv64 cross lane - byte verification, no execution step.
 #
 # usage: verify.sh [path-to-mach]   (defaults to `mach` on PATH)
 #
-# requires: file, llvm-objdump, llvm-otool (unversioned or `-NN` suffixed).
+# requires: file, od, llvm-objdump, llvm-otool (unversioned or `-NN` suffixed).
 set -euo pipefail
 
 mach="${1:-mach}"
@@ -34,6 +34,68 @@ resolve_tool() {
 
 objdump="$(resolve_tool llvm-objdump)" || fail "llvm-objdump not found"
 otool="$(resolve_tool llvm-otool)"     || fail "llvm-otool not found"
+
+# read a big-endian u32 at byte offset $2 of file $1, as a decimal value. the code
+# signing structures are big-endian, unlike the little-endian Mach-O around them.
+be32() {
+    local hex; hex="$(od -An -tx1 -j "$2" -N 4 "$1" | tr -d ' \n')"
+    printf '%d' "0x$hex"
+}
+
+# read a u8 at byte offset $2 of file $1, as a decimal value.
+u8() {
+    local hex; hex="$(od -An -tx1 -j "$2" -N 1 "$1" | tr -d ' \n')"
+    printf '%d' "0x$hex"
+}
+
+# verify_codesig <target> <exe>
+#
+# asserts the executable carries an LC_CODE_SIGNATURE and that the bytes it points
+# at are a well-formed embedded ad-hoc signature: a CSMAGIC_EMBEDDED_SIGNATURE
+# SuperBlob whose sole sub-blob is a CSMAGIC_CODEDIRECTORY with the adhoc flag,
+# SHA-256 hashes, a 4 KiB page size, codeLimit equal to the signature offset, and
+# one code slot per page of [0, codeLimit). all fields are big-endian.
+verify_codesig() {
+    local target="$1" exe="$2"
+    local lc; lc="$("$otool" -l "$exe")"
+    echo "$lc" | grep -q 'LC_CODE_SIGNATURE' || fail "$target: executable missing LC_CODE_SIGNATURE"
+
+    local dataoff datasize
+    dataoff="$(echo "$lc"  | awk '/cmd LC_CODE_SIGNATURE/{f=1} f&&$1=="dataoff" {print $2; exit}')"
+    datasize="$(echo "$lc" | awk '/cmd LC_CODE_SIGNATURE/{f=1} f&&$1=="datasize"{print $2; exit}')"
+    [ -n "$dataoff" ] && [ -n "$datasize" ] || fail "$target: LC_CODE_SIGNATURE has no dataoff/datasize"
+
+    # the signature must lie inside the __LINKEDIT segment's file range.
+    local le_off le_size
+    le_off="$(echo "$lc"  | awk '/segname __LINKEDIT/{f=1} f&&$1=="fileoff" {print $2; exit}')"
+    le_size="$(echo "$lc" | awk '/segname __LINKEDIT/{f=1} f&&$1=="filesize"{print $2; exit}')"
+    [ -n "$le_off" ] && [ -n "$le_size" ] || fail "$target: no __LINKEDIT segment for the signature"
+    [ "$dataoff" -ge "$le_off" ] && [ $((dataoff + datasize)) -le $((le_off + le_size)) ] \
+        || fail "$target: signature escapes __LINKEDIT"
+
+    # SuperBlob: magic, total length == datasize, and a CSSLOT_CODEDIRECTORY index.
+    [ "$(be32 "$exe" "$dataoff")" = "$((0xFADE0CC0))" ] || fail "$target: bad CSMAGIC_EMBEDDED_SIGNATURE"
+    [ "$(be32 "$exe" $((dataoff + 4)))" = "$datasize" ] || fail "$target: SuperBlob length != datasize"
+    [ "$(be32 "$exe" $((dataoff + 8)))" -ge 1 ]         || fail "$target: SuperBlob has no sub-blobs"
+    [ "$(be32 "$exe" $((dataoff + 12)))" = 0 ]          || fail "$target: first slot is not CSSLOT_CODEDIRECTORY"
+    local cd=$((dataoff + $(be32 "$exe" $((dataoff + 16)))))
+
+    # CodeDirectory: magic, adhoc flag, SHA-256, 4 KiB pages, codeLimit, slot count.
+    [ "$(be32 "$exe" "$cd")" = "$((0xFADE0C02))" ]      || fail "$target: bad CSMAGIC_CODEDIRECTORY"
+    [ $(( $(be32 "$exe" $((cd + 12))) & 0x2 )) -ne 0 ]  || fail "$target: CodeDirectory adhoc flag not set"
+    [ "$(be32 "$exe" $((cd + 24)))" = 0 ]               || fail "$target: CodeDirectory has special slots"
+    [ "$(u8   "$exe" $((cd + 36)))" = 32 ]              || fail "$target: hashSize is not 32 (SHA-256)"
+    [ "$(u8   "$exe" $((cd + 37)))" = 2 ]               || fail "$target: hashType is not SHA-256"
+    [ "$(u8   "$exe" $((cd + 39)))" = 12 ]              || fail "$target: pageSize is not 12 (4 KiB)"
+    local code_limit n_code expect
+    code_limit="$(be32 "$exe" $((cd + 32)))"
+    [ "$code_limit" = "$dataoff" ]                      || fail "$target: codeLimit != signature offset"
+    n_code="$(be32 "$exe" $((cd + 28)))"
+    expect=$(( (code_limit + 4095) / 4096 ))
+    [ "$n_code" = "$expect" ]                           || fail "$target: nCodeSlots != ceil(codeLimit/4096)"
+
+    echo "verified $target ad-hoc code signature (codeLimit=$code_limit, nCodeSlots=$n_code)"
+}
 
 # verify_static <target> <machine> <thread-flavor> <reloc>...
 #
@@ -70,8 +132,11 @@ verify_static() {
     lc="$("$otool" -l "$exe")"
     echo "$lc" | grep -q '__PAGEZERO'    || fail "$target: executable missing __PAGEZERO"
     echo "$lc" | grep -q '__TEXT'        || fail "$target: executable missing __TEXT segment"
+    echo "$lc" | grep -q '__LINKEDIT'    || fail "$target: executable missing __LINKEDIT segment"
     echo "$lc" | grep -q 'LC_UNIXTHREAD' || fail "$target: executable missing LC_UNIXTHREAD"
     echo "$lc" | grep -q "$flavor"       || fail "$target: executable thread state is not $flavor"
+
+    verify_codesig "$target" "$exe"
 }
 
 # verify_dynamic <target> <machine>
@@ -113,6 +178,8 @@ verify_dynamic() {
     local dis
     dis="$("$objdump" --macho -d --section=__stubs "$exe")"
     if echo "$dis" | grep -qi 'unknown'; then fail "$target: __stubs disassembly has an unknown instruction"; fi
+
+    verify_codesig "$target" "$exe"
 }
 
 rm -rf out dynamic/out
@@ -121,4 +188,4 @@ verify_static  darwin-aarch64 arm64  ARM_THREAD_STATE64 PAGE21 PAGOF12 BR26
 verify_dynamic darwin-x86_64  x86_64
 verify_dynamic darwin-aarch64 arm64
 
-echo "OK: Mach-O emits correct objects and static + dynamic executables for both Darwin triples"
+echo "OK: Mach-O emits correct objects and ad-hoc-signed static + dynamic executables for both Darwin triples"

--- a/test/macho/verify.sh
+++ b/test/macho/verify.sh
@@ -182,10 +182,32 @@ verify_dynamic() {
     verify_codesig "$target" "$exe"
 }
 
+# verify_filename_independent <dir> <target>
+#
+# builds the fixture in <dir> twice under two different `-o` output names and
+# asserts the two signed images are byte-identical. the code-signing identifier is
+# the artifact's product name, not the `-o` basename, so the output filename must
+# not perturb a single byte - this is exactly what the darwin self-host fixpoint
+# (a -> b -> c, b == c) depends on, and it is the only filename-sensitive part of
+# the writer, so it is the part worth locking down.
+verify_filename_independent() {
+    local dir="$1" target="$2"
+    echo "checking $target signed-image filename-independence in $dir"
+    mkdir -p "$PWD/$dir/out"
+    local a="$PWD/$dir/out/fnind_a" b="$PWD/$dir/out/fnind_b"
+    "$mach" build "$dir" --target "$target" --profile debug -o "$a"
+    "$mach" build "$dir" --target "$target" --profile debug -o "$b"
+    cmp -s "$a" "$b" \
+        || fail "$target: signed image differs under a different -o name (identifier leaks the filename)"
+    echo "verified $target signed image is identical regardless of the -o name"
+}
+
 rm -rf out dynamic/out
 verify_static  darwin-x86_64  x86_64 x86_THREAD_STATE64 SIGNED
 verify_static  darwin-aarch64 arm64  ARM_THREAD_STATE64 PAGE21 PAGOF12 BR26
 verify_dynamic darwin-x86_64  x86_64
 verify_dynamic darwin-aarch64 arm64
+verify_filename_independent .       darwin-aarch64
+verify_filename_independent dynamic darwin-aarch64
 
 echo "OK: Mach-O emits correct objects and ad-hoc-signed static + dynamic executables for both Darwin triples"


### PR DESCRIPTION
Closes #1679.

Emits an ad-hoc Mach-O code signature from the executable writers so a
mach-built Darwin binary is admitted by the Apple Silicon kernel (which
SIGKILLs unsigned arm64 executables).

## Changes

- `bin.mach`: big-endian `write_u32_be` / `write_u64_be` (code-signing
  structures are big-endian, unlike the rest of Mach-O).
- `macho.mach`: a shared `write_code_signature` that lays out a
  `CSMAGIC_EMBEDDED_SIGNATURE` SuperBlob wrapping a single
  `CSMAGIC_CODEDIRECTORY` (version 0x20400, adhoc flag, SHA-256,
  pageSize 12), hashing the file bytes `[0, codeLimit)` per 4 KiB page.
  Wired into both the static (LC_UNIXTHREAD) and dynamic
  (LC_LOAD_DYLINKER / LC_DYLD_INFO_ONLY) writers; the signature is laid
  out last in `__LINKEDIT` with `LC_CODE_SIGNATURE` pointing at it, and
  the header `ncmds`/`sizeofcmds` and segment sizing updated to match.
- Deterministic: no timestamps or nonces, so the `a -> b -> c`
  byte-identity fixpoint holds.
- `test/macho/verify.sh`: asserts `LC_CODE_SIGNATURE` and a structurally
  valid SuperBlob/CodeDirectory in both fixtures.
- Drops the stale "not runnable on arm64" caveat from the `macho.mach`
  comment and the `cross-darwin` lane in `ci.yml`.

Full on-Mac exec verification (`codesign --verify`, no `Killed: 9`)
happens in the #1680 macOS CI lane; structural byte-verification is the
bar on Linux.
