### PR TITLE
fix(test): scope `mach test` to the current project, excluding dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -248,6 +248,37 @@ jobs:
       - name: build and run the freestanding raw flat image
         run: bash test/freestanding/verify.sh "$PWD/m"
 
+  # `mach test .` scopes test collection to the current project (#1556): builds a
+  # compiler from the PR source, then runs a fixture whose project imports an
+  # in-tree dependency, each carrying a `test`. asserts the default `--list` shows
+  # only the project's test and `--include-deps` adds the dependency's. `--list`
+  # links nothing, so no runtime or qemu is needed.
+  test-scope:
+    name: test scope (#1556)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: fetch released mach
+        env:
+          GH_TOKEN: ${{ github.token }}
+          SEED: mach-*-x86_64-linux.tar.gz
+        run: |
+          set -euo pipefail
+          tmp="$(mktemp -d)"
+          gh release download -R "$GITHUB_REPOSITORY" -p "$SEED" -D "$tmp"
+          tar -xzf "$tmp"/$SEED -C /usr/local/bin mach
+          chmod +x /usr/local/bin/mach
+
+      - name: build a compiler from source
+        run: |
+          set -euo pipefail
+          mach dep pull
+          mach build . -o m
+
+      - name: verify mach test scopes to the current project
+        run: bash test/test-scope/verify.sh "$PWD/m"
+
   build-windows:
     name: build ${{ matrix.target }}
     runs-on: ${{ matrix.runs-on }}

--- a/doc/cli.md
+++ b/doc/cli.md
@@ -180,9 +180,14 @@ then spawns each as a separate process and reports a per-test
 `name file:line PASS|FAIL` line. A crashing test reports its signal and the run
 continues. A test build always links executables, even for a library target.
 
+Only `test` blocks declared in the current project's own modules are collected by
+default; tests in dependency modules are excluded unless `--include-deps` is
+passed.
+
 | Flag                | Value   | Effect |
 |---------------------|---------|--------|
 | `--filter <pattern>`| pattern | run only tests whose name contains `<pattern>` |
+| `--include-deps`    | —       | also collect tests declared in dependency modules |
 | `--list`            | —       | list the collected tests and exit |
 | `--runner <cmd>`    | command | launch every test as `<cmd> <exe>` instead of exec'ing it directly |
 

--- a/doc/language/test.md
+++ b/doc/language/test.md
@@ -72,16 +72,14 @@ in the example above.
 ### Collection across modules
 
 Tests are not tied to a single file. Every `test` declaration in every
-module that is part of the build — the project and its dependencies — is
-collected. `mach test` drives a build whose entry point is a synthesized
-test runner that iterates the collected tests rather than the project's
-normal `main`.
+module of the current project is collected, and `mach test` builds and runs
+one standalone executable per test in place of the project's normal `main`.
 
-> **Note.** Because dependency tests are collected too, a project that
-> depends on a library carrying tests that do not follow the `0` = pass
-> convention will see those tests reported as failures. Use `--filter` to
-> scope a run to your own tests while a dependency's suite is being
-> reconciled.
+By default collection is scoped to the current project's own modules: tests
+declared in dependency modules are excluded, so a library's own suite never
+runs (or fails) as part of your project's `mach test`. Pass `--include-deps`
+to collect dependency tests as well — useful when working on a dependency
+in-tree. `--filter` narrows the run by test name in either mode.
 
 ## The `mach test` workflow
 
@@ -95,6 +93,7 @@ build the project's tests and run them.
 
 options:
   --filter <pattern>  run only tests whose name contains <pattern>
+  --include-deps      also run tests declared in dependency modules
   --list              list the collected tests and exit
 
 exit: 0 all passed, 1 any failed, 2 build/internal error

--- a/src/cli/cmd/build.mach
+++ b/src/cli/cmd/build.mach
@@ -369,10 +369,12 @@ pub fun build(a: *A.Allocator, argc: usize, argv: **u8, emit_obj: bool) BuildRes
 # path) for the `mach test` runner to spawn. Every test executable is the
 # project's transitive code plus a synthesized `main` that calls just that test
 # and exits with its `i32` result - independently runnable, never the project's
-# own binary path. With `list_only` the build stops after collecting the tests,
-# leaving each artifact's `exe` nil. The returned strings are owned by `a` and
-# outlive this call's internal session teardown, so the caller frees `a` once it
-# has run every test.
+# own binary path. Only tests declared in the current project's own modules are
+# built by default; `--include-deps` widens the build to dependency tests (#1556).
+# With `list_only` the build stops after collecting the tests, leaving each
+# artifact's `exe` nil. The returned strings are owned by `a` and outlive this
+# call's internal session teardown, so the caller frees `a` once it has run every
+# test.
 # ---
 # a:         allocator owning the session and the returned artifacts; must
 #            outlive the returned TestBuildResult
@@ -727,12 +729,15 @@ fun compile_and_link(p: *driver.Project, level: u8, emit_obj: bool, test_mode: b
 #
 # The per-module objects are written once under the resolved `obj` template; the
 # external link inputs (libc, manifest/CLI libs) are resolved once. Then, for
-# each `test`, a tiny entry module (`main(){ret <test>();}`) is synthesized,
-# optimized, codegen'd to its own object, and linked with the shared object set
-# into a standalone executable at the resolved `tests` template path. Each
-# test's reporting metadata (label, source `file:line`) and executable path are
-# appended to `tests_out`. With `list_only` the collection alone is reported and
-# no objects or executables are produced. A build with no tests is a user error.
+# each selected `test`, a tiny entry module (`main(){ret <test>();}`) is
+# synthesized, optimized, codegen'd to its own object, and linked with the shared
+# object set into a standalone executable at the resolved `tests` template path.
+# Only tests declared in the current project's own modules are selected by
+# default; `--include-deps` widens the selection to dependency tests (#1556), and
+# `--filter` narrows it by name. Each test's reporting metadata (label, source
+# `file:line`) and executable path are appended to `tests_out`. With `list_only`
+# the collection alone is reported and no objects or executables are produced. A
+# build with no tests is a user error.
 # ---
 # p:         the project carrying the module graph and session
 # level:     optimization pipeline level
@@ -769,11 +774,16 @@ fun build_test_executables(p: *driver.Project, level: u8, verify_ir: bool, verbo
     # matching executables. nil filter = every test.
     val filter: *u8 = filter_value(argc, argv);
 
+    # `--include-deps`: by default a test run is scoped to the current project's
+    # own modules; this flag also builds and runs tests declared in dependency
+    # modules (#1556).
+    val include_deps: bool = util.has_flag(argc, argv, "--include-deps");
+
     # `--list`: report each selected test's metadata without producing any object.
     if (list_only) {
         var i: u32 = 0;
         for (i < col.count) {
-            if (test_selected(p, ?col.tests[i], filter)) {
+            if (test_selected(p, ?col.tests[i], filter, include_deps)) {
                 val rc: i64 = record_test(p, ?col.tests[i], nil, tests_out, p.s.alloc);
                 if (rc != 0) { testrunner.free(p.s, ?col); ret rc; }
             }
@@ -862,7 +872,7 @@ fun build_test_executables(p: *driver.Project, level: u8, verify_ir: bool, verbo
     var code: i64 = 0;
     var i: u32 = 0;
     for (i < col.count) {
-        if (test_selected(p, ?col.tests[i], filter)) {
+        if (test_selected(p, ?col.tests[i], filter, include_deps)) {
             # `i` is the stable collection index, so a test's executable name is
             # unchanged whether or not a filter is in effect.
             p.s.alloc = ?scratch_alloc;
@@ -893,20 +903,36 @@ fun filter_value(argc: usize, argv: **u8) *u8 {
     ret nil;
 }
 
-# whether a test passes the name filter
+# whether a test is selected for this run
 #
-# Every test when `filter` is nil, else those whose label contains the filter
-# substring.
+# A test is selected when it is in scope - its declaring module is part of the
+# current project, unless `include_deps` opts dependency tests in (#1556) - and
+# passes the name filter (every test when `filter` is nil, else those whose label
+# contains the filter substring).
 # ---
-# p:      the project (for its interner)
-# t:      the test to test
-# filter: the filter substring, or nil to select every test
-# ret:    true when the test is selected
-fun test_selected(p: *driver.Project, t: *testrunner.Test, filter: *u8) bool {
+# p:            the project (for its interner and module table)
+# t:            the test to test
+# filter:       the filter substring, or nil to select every test
+# include_deps: also select tests declared in dependency modules
+# ret:          true when the test is selected
+fun test_selected(p: *driver.Project, t: *testrunner.Test, filter: *u8, include_deps: bool) bool {
+    if (!include_deps && !test_in_project(p, t)) { ret false; }
     if (filter == nil) { ret true; }
     val opt_label: O.Option[str] = intern.lookup(?p.s.interner, t.label);
     if (O.is_none[str](opt_label)) { ret false; }
     ret str_contains(O.unwrap[str](opt_label), util.cstr_str(filter));
+}
+
+# whether a collected test was declared in a current-project module rather than a
+# dependency. `t.mod_idx` is the declaring module's id.
+# ---
+# p:   the project (for its module table)
+# t:   the test to locate
+# ret: true when the declaring module is part of the current project
+fun test_in_project(p: *driver.Project, t: *testrunner.Test) bool {
+    if (t.mod_idx >= p.module_len) { ret false; }
+    val m: *driver.ModuleEntry = ?p.modules[t.mod_idx];
+    ret driver.module_in_current_project(p, m.fqn);
 }
 
 # synthesize, codegen, and link a single test's executable, then record its

--- a/src/cli/cmd/help.mach
+++ b/src/cli/cmd/help.mach
@@ -133,10 +133,12 @@ fun help_test() {
     print.print("build one standalone executable per 'test' declaration (under the\n");
     print.print("'tests' template) and run each as a separate process, reporting\n");
     print.print("'name file:line PASS|FAIL'. a crash reports its signal and the run\n");
-    print.print("continues. all 'mach build' and global flags apply.\n");
+    print.print("continues. only the current project's own tests run by default;\n");
+    print.print("all 'mach build' and global flags apply.\n");
     print.print("\n");
     print.print("options:\n");
     print.print("  --filter <substr>   run only tests whose name contains <substr>\n");
+    print.print("  --include-deps      also run tests declared in dependency modules\n");
     print.print("  --list              list the collected tests and exit\n");
     print.print("  --runner <cmd>      launch every test as '<cmd> <exe>'. <cmd> is a\n");
     print.print("                      single command name or path (no shell splitting),\n");

--- a/src/cli/cmd/testing.mach
+++ b/src/cli/cmd/testing.mach
@@ -8,6 +8,8 @@
 # signal) is reported and the run continues, so one SIGSEGV no longer kills the
 # suite. the run ends with a `passed/failed/total` summary.
 #
+# by default only `test` blocks declared in the current project's own modules are
+# collected; `--include-deps` widens collection to dependency modules too (#1556).
 # `--list` prints the collected tests without building or running them.
 # `--filter <substr>` selects the tests whose name contains the substring.
 # `--runner <cmd>` launches every test as `<cmd> <exe>` instead of exec'ing the

--- a/src/lang/driver.mach
+++ b/src/lang/driver.mach
@@ -3849,6 +3849,29 @@ fun build_resolve_deps(p: *Project, m: *ModuleEntry, visited: *bool, list: *sess
     ret R.ok[resolve.ResolveDeps, str](deps);
 }
 
+# whether module `fqn` belongs to the current project's own source tree (its head
+# segment is the project id) rather than a dependency. `mach test` uses this to
+# scope a default test run to the current project, excluding dependency tests
+# (#1556).
+# ---
+# p:   the project carrying the config id and session interner
+# fqn: the module's interned fully-qualified name
+# ret: true when `fqn`'s head segment equals the project id
+pub fun module_in_current_project(p: *Project, fqn: intern.StrId) bool {
+    val fqn_opt: O.Option[str] = intern.lookup(?p.s.interner, fqn);
+    if (O.is_none[str](fqn_opt)) { ret false; }
+    val fqn_text: str = O.unwrap[str](fqn_opt);
+
+    val pid_opt: O.Option[str] = intern.lookup(?p.s.interner, p.config.id);
+    if (O.is_none[str](pid_opt)) { ret false; }
+    val proj_id_text: str = O.unwrap[str](pid_opt);
+
+    val fqn_len: usize = str_len(fqn_text);
+    var head_end: usize = 0;
+    for (head_end < fqn_len && fqn_text[head_end] != '.') { head_end = head_end + 1; }
+    ret view_eq_str(view(fqn_text::*char, head_end), proj_id_text);
+}
+
 # the project id whose declared `[project].module` resolves
 # to module `mod_fqn`, or STR_NIL when `mod_fqn` is not any project's declared
 # module. lets resolve name such a module by the project's bare id (#1326). a

--- a/test/test-scope/dep/depi/mach.toml
+++ b/test/test-scope/dep/depi/mach.toml
@@ -1,0 +1,5 @@
+[project]
+id      = "depi"
+name    = "depi"
+version = "0.0.0"
+src     = "src"

--- a/test/test-scope/dep/depi/src/depi.mach
+++ b/test/test-scope/dep/depi/src/depi.mach
@@ -1,0 +1,17 @@
+# dependency module for the test-scope fixture. it carries its own `test` block so
+# `mach test` can prove dependency tests are excluded from the default run
+# (mach#1556).
+
+# sum two integers.
+# ---
+# a: left addend
+# b: right addend
+# ret: a + b
+pub fun add(a: i32, b: i32) i32 {
+    ret a + b;
+}
+
+test "depi_dependency_test" {
+    if (add(2, 3) != 5) { ret 1; }
+    ret 0;
+}

--- a/test/test-scope/mach.toml
+++ b/test/test-scope/mach.toml
@@ -1,0 +1,26 @@
+[project]
+id      = "scope"
+name    = "test-scope"
+version = "0.0.0"
+src     = "src"
+dep     = "dep"
+target  = "linux"
+out     = "out/{target}/{profile}/bin/{name}{ext}"
+obj     = "out/{target}/{profile}/obj"
+tests   = "out/{target}/{profile}/test/{name}"
+
+[target.linux]
+isa = "x86_64"
+os  = "linux"
+abi = "sysv64"
+
+[profile.debug]
+opt = 0
+
+[bin.scope]
+entry = "main.mach"
+
+# in-tree vendored dependency carrying its own `test` block; `mach test .` must
+# exclude its tests by default (mach#1556).
+[deps.depi]
+path = "dep/depi"

--- a/test/test-scope/src/main.mach
+++ b/test/test-scope/src/main.mach
@@ -1,0 +1,18 @@
+# test-scope fixture entrypoint. it imports the `depi` dependency so that
+# dependency module joins the build graph, then declares its own `test`. `mach
+# test .` must collect only `scope_project_test` by default, adding
+# `depi_dependency_test` only under `--include-deps` (mach#1556).
+
+use depi.depi.add;
+
+# fixture entry; references the dependency so the import is live.
+# ---
+# ret: 0
+fun main() i32 {
+    ret add(40, 2) - 42;
+}
+
+test "scope_project_test" {
+    if (add(1, 1) != 2) { ret 1; }
+    ret 0;
+}

--- a/test/test-scope/verify.sh
+++ b/test/test-scope/verify.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# prove `mach test .` collects only the current project's own `test` blocks by
+# default, excluding dependency modules, and includes dependency tests only under
+# `--include-deps` (mach#1556).
+#
+# the fixture is a project (`scope`) that imports an in-tree vendored dependency
+# (`depi`); each declares one `test`. the check uses `--list`, which runs the
+# collection path (through codegen) but links nothing, so it needs no runtime and
+# is host-independent. it asserts on the collected test set, not on execution.
+#
+# usage: verify.sh [path-to-mach]   (defaults to `mach` on PATH)
+set -euo pipefail
+
+mach="${1:-mach}"
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$here"
+
+fail() { echo "FAIL: $1" >&2; exit 1; }
+
+target="linux"
+
+rm -rf out
+
+echo "listing default-scope tests with $mach"
+default_list="$("$mach" test . --target "$target" --list)"
+echo "$default_list"
+
+if ! grep -q "scope_project_test" <<<"$default_list"; then
+    fail "project test 'scope_project_test' was not collected"
+fi
+if grep -q "depi_dependency_test" <<<"$default_list"; then
+    fail "dependency test 'depi_dependency_test' leaked into the default scope"
+fi
+
+echo "listing tests with --include-deps"
+all_list="$("$mach" test . --target "$target" --include-deps --list)"
+echo "$all_list"
+
+if ! grep -q "scope_project_test" <<<"$all_list"; then
+    fail "project test 'scope_project_test' missing under --include-deps"
+fi
+if ! grep -q "depi_dependency_test" <<<"$all_list"; then
+    fail "dependency test 'depi_dependency_test' missing under --include-deps"
+fi
+
+echo "PASS: mach test scopes to the current project by default (#1556)"


### PR DESCRIPTION
Closes #1556

## Problem

`mach test .` collected, built, and ran every `test` block in the build graph —
including dependency modules. On this repo that means `mach test .` builds and
runs **669** tests (420 project + 249 from `mach-std`), so a project inherits and
is judged by its dependencies' suites (including tests that don't follow the
`0 == pass` convention).

## Change

Scope the default test collection to the **current project's own modules**: a
collected test is kept only when its declaring module's FQN head segment equals
the project id (the same project-vs-dependency identity the loader already uses
to resolve module files). Dependency tests are excluded by default.

- `driver.module_in_current_project(p, fqn)` — the project-scope identity check.
- `mach test` gates `test_selected` on it; a new **`--include-deps`** flag opts
  dependency tests back in. `--filter` still narrows within the chosen scope.

After the change, `mach test .` on this repo collects **420** tests by default and
**669** with `--include-deps`.

## Tests

- New fixture `test/test-scope/`: a project importing an in-tree vendored
  dependency, each with one `test`. `verify.sh` asserts the default `--list`
  shows only the project test and `--include-deps` adds the dependency's. Wired
  as the `test-scope` CI job. The check uses `--list` (runs collection through
  codegen, links nothing) so it needs no runtime.

## Docs

Updated `doc/cli.md`, `doc/language/test.md` (the stale "dependency tests are
collected too" note is now the documented default-exclusion + `--include-deps`),
and the `mach help test` page.
