### PR TITLE
fix(run): execute the already-built artifact instead of rebuilding

### DIFF
--- a/doc/cli.md
+++ b/doc/cli.md
@@ -20,7 +20,7 @@ matched exactly: `--flag value` (a value follows in the next argument) or a bare
 | Command | Summary |
 |---------|---------|
 | `build` | compile the project to objects and (for a `[bin.*]`) a linked binary |
-| `run`   | build, then execute the produced binary |
+| `run`   | execute the already-built binary (a post-`build` convenience, not a rebuild) |
 | `test`  | build the test binary and run the collected tests |
 | `dep`   | manage git-backed dependencies (clone, lock, vendor) under `<dep>` |
 | `init`  | scaffold a new project |
@@ -145,13 +145,18 @@ unknown target, compile errors, an unresolvable link input), `2` internal error.
 mach run <path> [options] [-- args...]
 ```
 
-Builds the project at `<path>` exactly like `mach build`, then executes the
-produced binary.
+Executes the binary `mach build` already produced for `<path>` — a post-build
+convenience, **not** a rebuild. The same selection flags (`--target`,
+`--profile`/`--release`, `--bin`) that narrow a build resolve which artifact to
+run; its path is read from the manifest's `out` template and the existing file
+is exec'd. When the artifact does not exist yet, `mach run` errors and points at
+`mach build` rather than building it.
 Arguments after a `--` separator are forwarded to the child as its `argv`. The
 child's exit code becomes this command's exit code.
 
-`--emit` is rejected — running a relocatable object is not meaningful. All other
-`build` and global flags apply.
+`--emit` is rejected — running a relocatable object is not meaningful. The
+`build` selection and global flags apply; build-only flags (`-O*`, `--emit-*`)
+are accepted but have no effect, since nothing is built.
 
 | Flag             | Value   | Effect |
 |------------------|---------|--------|
@@ -165,8 +170,8 @@ command name or path (no shell-style word splitting); a bare name is resolved on
 as a failure — exit `127` when `execve` rejects the binary in the spawned
 child — with no auto-detection.
 
-Exit codes: the child's exit code, `1` on a build/user error, `2` on internal
-error.
+Exit codes: the child's exit code, `1` on a resolution/user error (including a
+missing artifact), `2` on internal error.
 
 ## `mach test`
 

--- a/src/cli/cmd/build.mach
+++ b/src/cli/cmd/build.mach
@@ -395,6 +395,51 @@ pub fun build_tests(a: *A.Allocator, argc: usize, argv: **u8, list_only: bool) T
     ret tbr;
 }
 
+# resolve the selected profile name from CLI config
+#
+# `--profile <name>` wins; `--release` is sugar for the `release` profile; absent
+# both, the empty string defers to the manifest default. Shared by the `mach
+# build` matrix-override path and selection_from_config.
+# ---
+# config: the parsed CLI config
+# ret:    the selected profile name, empty for the manifest default
+fun profile_selection(config: *cfg.Config) str {
+    var profile_name: *u8 = config.profile;
+    if (profile_name == nil && config.release) { profile_name = "release"; }
+    if (profile_name == nil)                   { profile_name = ""; }
+    ret util.cstr_str(profile_name);
+}
+
+# build the manifest selection from CLI config
+#
+# Maps `--target`/`--profile`/`--release`/`--bin`/`--lib` onto `out_sel`, shared
+# by `mach build` and `mach run` so both narrow the (target, profile, artifact)
+# the same way. An absent `--target` leaves the target empty so the driver defers
+# to `[project].target` (resolving `native`/`host` to the host-matching entry).
+# `--bin` and `--lib` are mutually exclusive.
+# ---
+# config:  the parsed CLI config
+# out_sel: receives the populated selection
+# ret:     ok(true), or err when `--bin` and `--lib` are combined
+pub fun selection_from_config(config: *cfg.Config, out_sel: *manifest.Selection) R.Result[bool, str] {
+    if (config.bin != nil && config.lib != nil) {
+        ret R.err[bool, str]("--bin and --lib cannot be combined");
+    }
+    var target_name: *u8 = config.target;
+    if (target_name == nil) { target_name = ""; }
+    var artifact_name: *u8  = "";
+    var want_lib:      bool = false;
+    var has_artifact:  bool = false;
+    if (config.bin != nil) { artifact_name = config.bin; has_artifact = true; }
+    or (config.lib != nil) { artifact_name = config.lib; want_lib = true; has_artifact = true; }
+    out_sel.profile      = profile_selection(config);
+    out_sel.target       = util.cstr_str(target_name);
+    out_sel.artifact     = util.cstr_str(artifact_name);
+    out_sel.want_lib     = want_lib;
+    out_sel.has_artifact = has_artifact;
+    ret R.ok[bool, str](true);
+}
+
 # the single-unit build body
 #
 # With `ovr` nil the target/artifact are derived from the CLI flags (the
@@ -467,41 +512,27 @@ fun build_unit(a: *A.Allocator, argc: usize, argv: **u8, emit_obj: bool, test_mo
     or (util.has_flag(eff, argv, "--release")) { cli_level = pipeline.OPT_RELEASE; cli_set = true; }
 
     # the build selection threaded to the driver; it narrows target/profile/
-    # artifact. `--release` is sugar for `--profile release`, and `--bin`/`--lib`
-    # are mutually exclusive. profile applies to every matrix unit, so it is read
-    # from the flags even under an override.
-    var profile_name: *u8 = config.profile;
-    if (profile_name == nil && config.release) { profile_name = "release"; }
-    if (profile_name == nil)                   { profile_name = ""; }
-
+    # artifact. an enumerated matrix cell pins target and artifact, but the profile
+    # still comes from the flags (it applies to every cell); otherwise the whole
+    # selection is read from the flags via selection_from_config, which `mach run`
+    # shares so it narrows the artifact identically.
     var sel: manifest.Selection;
-    sel.profile = util.cstr_str(profile_name);
     if (ovr != nil) {
-        # one enumerated matrix cell: target and artifact are pre-selected.
+        sel.profile      = profile_selection(?config);
         sel.target       = ovr.target;
         sel.artifact     = ovr.artifact;
         sel.want_lib     = ovr.want_lib;
         sel.has_artifact = ovr.has_artifact;
     }
     or {
-        # when --target is absent, defer to [project].target from mach.toml
-        # (the driver resolves "native"/"host" to the host-matching entry).
-        var target_name: *u8 = config.target;
-        if (target_name == nil) { target_name = ""; }
-        var artifact_name: *u8   = "";
-        var want_lib:      bool  = false;
-        var has_artifact:  bool  = false;
-        if (config.bin != nil && config.lib != nil) {
-            print.eprint("error: --bin and --lib cannot be combined\n");
+        val sr: R.Result[bool, str] = selection_from_config(?config, ?sel);
+        if (R.is_err[bool, str](sr)) {
+            print.eprint("error: ");
+            print.eprint(R.unwrap_err[bool, str](sr));
+            print.eprint("\n");
             br.code = 1;
             ret br;
         }
-        if (config.bin != nil) { artifact_name = config.bin; has_artifact = true; }
-        or (config.lib != nil) { artifact_name = config.lib; want_lib = true; has_artifact = true; }
-        sel.target       = util.cstr_str(target_name);
-        sel.artifact     = util.cstr_str(artifact_name);
-        sel.want_lib     = want_lib;
-        sel.has_artifact = has_artifact;
     }
 
     val res_session: R.Result[session.Session, str] = session.init(a);

--- a/src/cli/cmd/run.mach
+++ b/src/cli/cmd/run.mach
@@ -1,9 +1,11 @@
-# `mach run` - build the project and execute the produced binary
+# `mach run` - execute the already-built artifact for the project
 #
-# Builds through the same pipeline as `build`, then executes the produced
-# binary, forwarding any arguments after a `--` separator to the child as its
-# argv. The child inherits the parent's environment, and its exit code becomes
-# this subcommand's exit code. `--emit obj` is rejected, since running a
+# Locates the binary `mach build` produced for the same selection and executes
+# it, forwarding any arguments after a `--` separator to the child as its argv.
+# This is a post-`mach build` convenience: it does NOT build. When the artifact
+# does not exist yet it errors and points at `mach build` rather than silently
+# building. The child inherits the parent's environment, and its exit code
+# becomes this subcommand's exit code. `--emit obj` is rejected, since running a
 # relocatable object is not meaningful. `--runner <cmd>` executes the binary as
 # `<cmd> <binary> <args...>` instead of exec'ing it directly - the host-side
 # launcher for foreign-target artifacts (e.g. wine for a windows target). Absent
@@ -11,10 +13,11 @@
 # that.
 
 use std.allocator.arena;
+use std.filesystem;
 use std.print;
 use std.process.env;
 use std.process.exec;
-use std.types.bool.false;
+use std.types.bool.bool;
 use std.types.size.usize;
 use std.types.string.str;
 
@@ -22,21 +25,25 @@ use A: std.allocator;
 use O: std.types.option;
 use R: std.types.result;
 
+use cfg: mach.cli.config;
 use mach.cli.cmd.build;
 use mach.cli.util;
+use mach.lang.driver;
+use mach.lang.manifest;
 
 # `mach run` subcommand entry point
 #
-# Builds the project to an executable, then execs it forwarding the post-`--`
-# arguments. Called by cmd.dispatch.
+# Resolves the selected artifact's output path from the manifest, requires it to
+# already exist on disk, then execs it forwarding the post-`--` arguments. Called
+# by cmd.dispatch.
 # ---
 # argc: argument count including argv[0]
 # argv: the argument vector (argc null-terminated byte pointers)
-# ret:  the child's exit code, 1 on a build or user error, 2 on internal error
+# ret:  the child's exit code, 1 on a resolution or user error, 2 on internal error
 pub fun run(argc: usize, argv: **u8) i64 {
-    # the build sees only the args before `--`; everything after is the child's
-    # argv. clip the build's view here too so a post-`--` `--emit` is the
-    # program's argument, not a flag this command rejects.
+    # the resolution sees only the args before `--`; everything after is the
+    # child's argv. clip the count here so a post-`--` `--emit` is the program's
+    # argument, not a flag this command rejects.
     val sep: usize = util.separator_index(argc, argv);
 
     val opt_emit: O.Option[*u8] = build.emit_kind(sep, argv);
@@ -45,12 +52,9 @@ pub fun run(argc: usize, argv: **u8) i64 {
         ret 1;
     }
 
-    # back the build with an arena over a page allocator, matching `mach build`.
-    # the build's internal teardown (`sess.dnit` / `dnit_project`) frees through
-    # this allocator; the page allocator would munmap each block individually,
-    # unmapping the page `output_path` lives in before we exec it. the arena
-    # defers all reclamation to a single `arena.dnit`, so `output_path` stays
-    # mapped until we are done with the child.
+    # the resolved artifact path is suballocated through one arena over a page
+    # allocator. a direct exec never returns, so the arena is reclaimed only on the
+    # error and runner paths, where `arena.dnit` runs after the path is last used.
     var backing: A.Allocator;
     var ar:      arena.Arena;
     var alloc:   A.Allocator;
@@ -59,15 +63,63 @@ pub fun run(argc: usize, argv: **u8) i64 {
         ret 2;
     }
 
-    val build_result: build.BuildResult = build.build(?alloc, argc, argv, false);
-    if (build_result.code != 0) {
+    # the same CLI flags (`--target`/`--profile`/`--bin`/...) that narrow a build
+    # narrow the artifact here, so `mach run` resolves the exact path `mach build`
+    # produced. the args are read clipped at `--` so a forwarded flag never leaks
+    # into the selection.
+    val res_cfg: R.Result[cfg.Config, str] = cfg.parse(sep, argv);
+    if (R.is_err[cfg.Config, str](res_cfg)) {
+        print.eprint("error: ");
+        print.eprint(R.unwrap_err[cfg.Config, str](res_cfg));
+        print.eprint("\n");
         arena.dnit(?ar);
-        ret build_result.code;
+        ret 1;
     }
-    if (build_result.output_path == nil) {
+    val config: cfg.Config = R.unwrap_ok[cfg.Config, str](res_cfg);
+
+    # the project root is the required non-flag positional after the subcommand
+    # (`mach run <path>`); a bare invocation with no path is a user error.
+    val pix: usize = util.positional_index(sep, argv, 2);
+    if (pix >= sep) {
+        print.eprint("error: missing project path; pass the project root (e.g. '.')\n");
         arena.dnit(?ar);
-        print.eprint("error: build produced no executable\n");
-        ret 2;
+        ret 1;
+    }
+    var root: [4096]u8;
+    if (!util.find_project_root(argv[pix], ?root[0], 4096)) {
+        print.eprint("error: no mach.toml found in the working directory or any parent\n");
+        arena.dnit(?ar);
+        ret 1;
+    }
+
+    var sel: manifest.Selection;
+    val res_sel: R.Result[bool, str] = build.selection_from_config(?config, ?sel);
+    if (R.is_err[bool, str](res_sel)) {
+        print.eprint("error: ");
+        print.eprint(R.unwrap_err[bool, str](res_sel));
+        print.eprint("\n");
+        arena.dnit(?ar);
+        ret 1;
+    }
+
+    val res_path: R.Result[str, str] = driver.resolve_artifact_path(?alloc, util.cstr_str(?root[0]), ?sel);
+    if (R.is_err[str, str](res_path)) {
+        print.eprint("error: ");
+        print.eprint(R.unwrap_err[str, str](res_path));
+        print.eprint("\n");
+        arena.dnit(?ar);
+        ret 1;
+    }
+    val output_path: str = R.unwrap_ok[str, str](res_path);
+
+    # a post-build execute, not a rebuild: when the artifact is absent point at
+    # `mach build` instead of silently producing it.
+    if (!filesystem.is_file(output_path)) {
+        print.eprint("error: no built artifact at '");
+        print.eprint(output_path);
+        print.eprint("'; run `mach build` first\n");
+        arena.dnit(?ar);
+        ret 1;
     }
 
     # `--runner <cmd>` (scanned before `--`, like every other flag): execute the
@@ -79,12 +131,12 @@ pub fun run(argc: usize, argv: **u8) i64 {
         val name: *u8 = O.unwrap[*u8](opt_runner);
         val res_runner: R.Result[*u8, str] = util.resolve_cmd(?alloc, name);
         if (R.is_err[*u8, str](res_runner)) {
-            arena.dnit(?ar);
             print.eprint("error: --runner '");
             print.eprint(name::str);
             print.eprint("': ");
             print.eprint(R.unwrap_err[*u8, str](res_runner));
             print.eprint("\n");
+            arena.dnit(?ar);
             ret 1;
         }
         runner = R.unwrap_ok[*u8, str](res_runner);
@@ -101,14 +153,14 @@ pub fun run(argc: usize, argv: **u8) i64 {
     val child_len: usize = lead + 1 + fwd_len + 1;
     val res_child_argv: R.Result[**u8, str] = A.allocate[*u8](?alloc, child_len);
     if (R.is_err[**u8, str](res_child_argv)) {
-        arena.dnit(?ar);
         print.eprint("error: out of memory\n");
+        arena.dnit(?ar);
         ret 2;
     }
     val child_argv: **u8 = R.unwrap_ok[**u8, str](res_child_argv);
 
     if (runner != nil) { child_argv[0] = runner; }
-    child_argv[lead] = build_result.output_path;
+    child_argv[lead] = output_path;
     var i: usize = 0;
     for (i < fwd_len) {
         child_argv[lead + 1 + i] = argv[sep + 1 + i];
@@ -117,15 +169,15 @@ pub fun run(argc: usize, argv: **u8) i64 {
     child_argv[lead + 1 + fwd_len] = nil;
 
     # exec the runner when present, otherwise the built binary directly.
-    var exe: *u8 = build_result.output_path;
+    var exe: *u8 = output_path;
     if (runner != nil) { exe = runner; }
 
     # the child inherits the parent's environment unmodified.
     val res_exec: R.Result[exec.ExitStatus, str] = exec.run(exe::str, child_argv, env.environ());
     if (R.is_err[exec.ExitStatus, str](res_exec)) {
-        arena.dnit(?ar);
         if (runner != nil) { print.eprint("error: failed to execute the runner\n"); }
         or                 { print.eprint("error: failed to execute the built binary\n"); }
+        arena.dnit(?ar);
         ret 1;
     }
     val status: exec.ExitStatus = R.unwrap_ok[exec.ExitStatus, str](res_exec);

--- a/src/lang/driver.mach
+++ b/src/lang/driver.mach
@@ -468,6 +468,53 @@ pub fun enumerate_matrix(alloc: *A.Allocator, project_root: str,
     ret R.ok[Matrix, str](mx);
 }
 
+# resolve a build selection's output-artifact path WITHOUT compiling.
+#
+# Reads `project_root/mach.toml`, resolves the selection (target, profile,
+# artifact) into one build unit, and returns the produced-artifact path rooted at
+# `project_root` - the exact path `mach build` produces for the same selection.
+# `mach run` uses it to locate and execute the already-built binary instead of
+# rebuilding. Only the manifest is read: no module graph is loaded and no
+# dependencies are resolved. The transient toml table, interner, and manifest are
+# all suballocated from `alloc` and reclaimed when it is (pass an arena); the
+# returned path is owned by `alloc`.
+# ---
+# alloc:        allocator for the transient manifest state and the returned path
+# project_root: the resolved project root directory (containing mach.toml)
+# sel:          the build selection narrowing target/profile/artifact
+# ret:          ok(owned absolute artifact path), or err(manifest/selection message)
+pub fun resolve_artifact_path(alloc: *A.Allocator, project_root: str, sel: *manifest.Selection) R.Result[str, str] {
+    val toml_path_r: R.Result[str, str] = join_path(alloc, project_root, "mach.toml");
+    if (R.is_err[str, str](toml_path_r)) { ret toml_path_r; }
+    val toml_path: str = R.unwrap_ok[str, str](toml_path_r);
+
+    val toml_r: R.Result[toml.Table, str] = parse_toml_file(alloc, toml_path);
+    str_free(alloc, toml_path);
+    if (R.is_err[toml.Table, str](toml_r)) { ret R.err[str, str](R.unwrap_err[toml.Table, str](toml_r)); }
+    var t: toml.Table = R.unwrap_ok[toml.Table, str](toml_r);
+
+    var itn: intern.Interner = intern.init(alloc);
+    val mr: R.Result[manifest.Manifest, str] = manifest.parse(alloc, ?itn, ?t);
+    if (R.is_err[manifest.Manifest, str](mr)) { ret R.err[str, str](R.unwrap_err[manifest.Manifest, str](mr)); }
+    var m: manifest.Manifest = R.unwrap_ok[manifest.Manifest, str](mr);
+
+    val ur: R.Result[manifest.BuildUnit, str] = manifest.resolve_build_unit(alloc, ?itn, ?m, @sel);
+    if (R.is_err[manifest.BuildUnit, str](ur)) {
+        manifest.dnit(?m, alloc);
+        ret R.err[str, str](R.unwrap_err[manifest.BuildUnit, str](ur));
+    }
+    val bu: manifest.BuildUnit = R.unwrap_ok[manifest.BuildUnit, str](ur);
+
+    val bin_opt: O.Option[str] = intern.lookup(?itn, bu.bin_path);
+    if (O.is_none[str](bin_opt) || str_empty(O.unwrap[str](bin_opt))) {
+        manifest.dnit(?m, alloc);
+        ret R.err[str, str]("selected artifact has no output path; set the `out` template in mach.toml");
+    }
+    val abs_r: R.Result[str, str] = join_path(alloc, project_root, O.unwrap[str](bin_opt));
+    manifest.dnit(?m, alloc);
+    ret abs_r;
+}
+
 # build_project_sel: load `project_root/mach.toml` and build the module graph
 # for the given build selection (target, profile, and one artifact). the manifest
 # reader resolves the selection into the project's single target entry and
@@ -4553,6 +4600,44 @@ test "mach.lang.driver:union_ambiguous_multi_artifact_default" {
 
     filesystem.remove_all(?alloc, root);
     session.dnit(?s);
+    ret bad;
+}
+
+# resolve_artifact_path returns the build's output path from the manifest alone,
+# without loading the module graph or a session (#1482). an explicit target keeps
+# the expanded path host-independent; an unknown selector surfaces verbatim.
+test "mach.lang.driver:resolve_artifact_path" {
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+
+    var names: [1]str;
+    names[0] = "main.mach";
+    var texts: [1]str;
+    texts[0] = "fun main() i32 { ret 0; }\n";
+
+    val root_r: R.Result[str, str] = ut_scaffold(?alloc, ?names[0], ?texts[0], 1);
+    if (R.is_err[str, str](root_r)) { ret 1; }
+    val root: str = R.unwrap_ok[str, str](root_r);
+
+    var bad: i32 = 0;
+
+    # the manifest's `out` template resolves to the build's output path, rooted.
+    var sel: manifest.Selection;
+    sel.target = "linux"; sel.profile = ""; sel.artifact = ""; sel.want_lib = false; sel.has_artifact = false;
+    val pr: R.Result[str, str] = resolve_artifact_path(?alloc, root, ?sel);
+    if (R.is_err[str, str](pr)) { bad = 1; }
+    or {
+        val want: str = ut_cc3(?alloc, root, "/", "out/linux/bin/uniontest");
+        if (!str_equals(R.unwrap_ok[str, str](pr), want)) { bad = 1; }
+    }
+
+    # an unknown artifact selection surfaces the manifest error, never a path.
+    var sel_bad: manifest.Selection;
+    sel_bad.target = "linux"; sel_bad.profile = ""; sel_bad.artifact = "nope"; sel_bad.want_lib = false; sel_bad.has_artifact = true;
+    val pr_bad: R.Result[str, str] = resolve_artifact_path(?alloc, root, ?sel_bad);
+    if (R.is_ok[str, str](pr_bad)) { bad = 1; }
+
+    filesystem.remove_all(?alloc, root);
     ret bad;
 }
 


### PR DESCRIPTION
Closes #1482.

`mach run` rebuilt the project before executing. It is meant as a post-`mach build` convenience that just **executes** the already-built binary.

## Change
- `mach run [--bin <name>] <path>` now resolves the selected artifact's output path from the manifest and execs the existing file — **no build**.
- When the artifact does not exist yet, it errors and points at `mach build` rather than silently building:
  `error: no built artifact at '<path>'; run \`mach build\` first`
- The same selection flags (`--target`/`--profile`/`--release`/`--bin`) narrow which artifact to run, so the path matches exactly what `mach build` produces.

## Implementation
- `driver.resolve_artifact_path` resolves a selection's output path from `mach.toml` alone — no module graph, no dependency resolution.
- `selection_from_config`/`profile_selection` extracted from `build_unit` so build and run map CLI flags onto a `manifest.Selection` identically (pure refactor of the build path).
- `run.mach` rewritten to resolve + existence-check + exec; the `--runner`, `--` arg-forwarding, exit-code/signal passthrough, and `--emit` rejection are preserved.

## Tests
- New `mach.lang.driver:resolve_artifact_path` in-source test.
- Full suite: **670 passed, 0 failed**.
- Manual end-to-end (minimal linux ELF fixture): run-before-build errors and points at `mach build`; build+run execs and returns the child's exit code; binary mtime is unchanged by run and run still works after deleting the source (proving no rebuild); `--bin`, arg-forwarding, and error paths behave as expected.
