### PR TITLE
fix(arm64): dispatch cset in inline-asm assembler + advance mach.lock to mach-std v0.16.0

### DIFF
--- a/mach.lock
+++ b/mach.lock
@@ -3,4 +3,4 @@
 [deps.mach-std]
 url = "https://github.com/briar-systems/mach-std"
 ref = "branch/main"
-commit = "e910495c7dadcf28b4684ef611761f0295024f8c"
+commit = "05f937bb7f268f7eb20789cec8024fb315f77a43"

--- a/src/lang/target/isa/arm64/encode.mach
+++ b/src/lang/target/isa/arm64/encode.mach
@@ -2968,6 +2968,23 @@ fun emit_asm_cmp(st: *encode.EncodeState, args: str) R.Result[bool, str] {
     ret R.err[bool, str]("encode: inline-asm 'cmp' second operand must be a register or imm12");
 }
 
+# `cset Rd, <cond>` - the CSINC Rd, XZR, XZR, invert(cond) alias. the
+# condition resolves through asm_parse_cond (the table b.<cond> shares); both X and W
+# destination widths are supported. darwin's aarch64 syscall wrappers use this to
+# materialize the carry-on-error flag (`cset x9, cs`).
+fun emit_asm_cset(st: *encode.EncodeState, args: str) R.Result[bool, str] {
+    var b0: [128]u8; var b1: [128]u8; var b2: [128]u8; var b3: [128]u8;
+    var n: u32 = 0;
+    if (!asm_split(args, ?b0[0], ?b1[0], ?b2[0], ?b3[0], 128, ?n)) { ret R.err[bool, str]("encode: malformed inline-asm 'cset' operands"); }
+    if (n != 2)                                                    { ret R.err[bool, str]("encode: inline-asm 'cset' expects Rd, <cond>"); }
+    var rd: AsmOp;
+    if (!asm_parse_operand((?b0[0])::str, ?rd) || rd.kind != ASMOP_REG) { ret R.err[bool, str]("encode: inline-asm 'cset' destination must be a register"); }
+    var cc: u32 = 0;
+    if (!asm_parse_cond((?b1[0])::str, ?cc)) { ret R.err[bool, str]("encode: inline-asm 'cset' condition is unrecognized"); }
+    emit_word(st, pack_cset(sel(rd.is64, CSINC_X, CSINC_W), rd.reg, cc));
+    ret R.ok[bool, str](true);
+}
+
 # `adrp Xd, sym` - the page-relative high half, RK_PAGE21.
 fun emit_asm_adrp(st: *encode.EncodeState, args: str) R.Result[bool, str] {
     var b0: [128]u8; var b1: [128]u8; var b2: [128]u8; var b3: [128]u8;
@@ -3406,10 +3423,11 @@ fun asm_stmt_clobbers(stmt: str, gp: *u32, fp: *u32) {
     if (str_equals(mnem, "ldp")) { asm_mark_op(args, 0, gp); asm_mark_op(args, 1, gp); asm_mark_ldstp_wb(args, gp); ret; }
     if (str_equals(mnem, "stp")) { asm_mark_ldstp_wb(args, gp); ret; }
 
-    # dest = operand 0: data-processing / load / shift forms and stlxr's status reg.
+    # dest = operand 0: data-processing / load / shift forms, cset, and stlxr's status reg.
     if (str_equals(mnem, "mov") || str_equals(mnem, "movz") || str_equals(mnem, "movk") ||
         str_equals(mnem, "add") || str_equals(mnem, "sub") || str_equals(mnem, "and") ||
         str_equals(mnem, "orr") || str_equals(mnem, "eor") || str_equals(mnem, "adrp") ||
+        str_equals(mnem, "cset") ||
         str_equals(mnem, "ldr") || str_equals(mnem, "ldrb") || str_equals(mnem, "ldrh") ||
         str_equals(mnem, "ldar") || str_equals(mnem, "ldaxr") || str_equals(mnem, "stlxr") ||
         str_equals(mnem, "lsl") || str_equals(mnem, "lsr") || str_equals(mnem, "asr") ||
@@ -3456,6 +3474,7 @@ fun encode_asm_stmt_arm64(st: *encode.EncodeState, f: *mir.MirFunction, fn_base:
     if (str_equals(mnem, "orr"))  { ret emit_asm_logical(st, args, ORR_X, ORR_W); }
     if (str_equals(mnem, "eor"))  { ret emit_asm_logical(st, args, EOR_X, EOR_W); }
     if (str_equals(mnem, "cmp"))  { ret emit_asm_cmp(st, args); }
+    if (str_equals(mnem, "cset")) { ret emit_asm_cset(st, args); }
     if (str_equals(mnem, "adrp")) { ret emit_asm_adrp(st, args); }
     if (str_equals(mnem, "bl"))   { ret emit_asm_bl(st, args); }
     if (str_equals(mnem, "blr"))  { ret emit_asm_one_reg(st, args, true); }
@@ -4984,6 +5003,46 @@ test "mach.lang.target.isa.arm64.encode:inline_asm_data_processing_forms" {
     if (read_word(?st.buf, 92)  != 0x6B01001F) { bad = 1; }
     if (read_word(?st.buf, 96)  != 0xD63F0000) { bad = 1; }
     if (read_word(?st.buf, 100) != 0xD61F0000) { bad = 1; }
+
+    asm_labels_dnit(?labels);
+    encode.buf_dnit(?st.buf);
+    ret bad;
+}
+
+# `cset Xd/Wd, <cond>` round-trips through the inline-asm assembler, byte-exact
+# against llvm-mc. darwin's aarch64 syscall wrappers use `cset x9, cs` to capture the
+# carry-on-error flag (#1714).
+test "mach.lang.target.isa.arm64.encode:inline_asm_cset_forms" {
+    var bad: i32 = 0;
+    var st: encode.EncodeState;
+    var alloc: A.Allocator;
+    var interner: intern.Interner;
+    tasm(?st, ?alloc, ?interner);
+    var labels: AsmLabels;
+    asm_labels_init(?labels, ?alloc);
+    var f: mir.MirFunction;
+
+    encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "cset x9, cs");   # 0
+    encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "cset w9, cs");   # 4
+    encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "cset x0, eq");   # 8
+    encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "cset w0, eq");   # 12
+    encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "cset x5, ne");   # 16
+    encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "cset w5, ne");   # 20
+    encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "cset x9, lt");   # 24
+    encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "cset w19, le");  # 28
+    encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "cset x3, hi");   # 32
+    encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "cset w7, ge");   # 36
+
+    if (read_word(?st.buf, 0)  != 0x9A9F37E9) { bad = 1; }  # cset x9, cs (hs)
+    if (read_word(?st.buf, 4)  != 0x1A9F37E9) { bad = 1; }  # cset w9, cs (hs)
+    if (read_word(?st.buf, 8)  != 0x9A9F17E0) { bad = 1; }  # cset x0, eq
+    if (read_word(?st.buf, 12) != 0x1A9F17E0) { bad = 1; }  # cset w0, eq
+    if (read_word(?st.buf, 16) != 0x9A9F07E5) { bad = 1; }  # cset x5, ne
+    if (read_word(?st.buf, 20) != 0x1A9F07E5) { bad = 1; }  # cset w5, ne
+    if (read_word(?st.buf, 24) != 0x9A9FA7E9) { bad = 1; }  # cset x9, lt
+    if (read_word(?st.buf, 28) != 0x1A9FC7F3) { bad = 1; }  # cset w19, le
+    if (read_word(?st.buf, 32) != 0x9A9F97E3) { bad = 1; }  # cset x3, hi
+    if (read_word(?st.buf, 36) != 0x1A9FB7E7) { bad = 1; }  # cset w7, ge
 
     asm_labels_dnit(?labels);
     encode.buf_dnit(?st.buf);


### PR DESCRIPTION
Closes #1714. Lands the mach-side prerequisites for the aarch64-darwin target (#1680).

## What

1. **`chore(deps)`** — advance `mach.lock` from mach-std v0.15.0 (`e910495`) to v0.16.0 (`05f937b`), bringing the darwin runtime fixes #314 (`_rt_argc`/`_rt_argv`/`_rt_envp` exports) and #315 (aarch64 syscall operands loaded with `ldr`). `mach dep pull` follows the lock, so the bump is required for both darwin arches to consume the runtime fix.
2. **`fix(arm64)`** — dispatch the `cset` mnemonic in the arm64 inline-asm assembler (the #1714 gap). Adds `emit_asm_cset` (parses `Rd, <cond>`, resolves via the existing `asm_parse_cond`, emits `pack_cset` for X/W widths), dispatches it in `encode_asm_stmt_arm64`, marks `cset` as writing operand 0 in the clobber inference, and adds a byte-exact (llvm-mc) round-trip encode test. No codegen changes outside the inline-asm assembler.

## Validation (Linux host)

- Self-host fixpoint converges byte-identically (`b==c`) under mach-std v0.16.0; `./c test .` = **426 passed, 0 failed** (incl. the new `inline_asm_cset_forms` test).
- darwin-x86_64 cross-build still produces a valid `MH_NOUNDEFS` Mach-O with `LC_CODE_SIGNATURE` (regression check, green).
- The `cset` gap is closed: the darwin-aarch64 build no longer errors on `cset`.

## Scope note — this PR alone does NOT make aarch64-darwin buildable

With `cset` dispatched, the darwin-aarch64 build advances **past** `cset` and then hits a **separate** defect in the mach-std v0.16.0 darwin aarch64 `_start` (standard-ARM-syntax inline-asm the mach dialect rejects: `#`-prefixed immediates, a 4-operand shifted add, a bitmask-immediate `and`). That is fixed separately in **mach-std #320 / PR briar-systems/mach-std#321**, not here.

End-to-end aarch64-darwin linking is proven with a compiler whose lock points at the mach-std fix branch (valid arm64 Mach-O, MH_NOUNDEFS, LC_CODE_SIGNATURE). The official enablement lands when mach-std cuts v0.16.1 (with that fix) and a follow-up bumps `mach.lock` to it. This PR deliberately keeps the lock at v0.16.0 and stays the clean #1714 (`cset`) deliverable. Full on-Mac execution remains #1680's job (macOS runners).
