### PR TITLE
feat(macho): PIE arm64 darwin executables (MH_PIE + LC_MAIN + rebase stream)

### DIFF
--- a/mach.lock
+++ b/mach.lock
@@ -3,4 +3,4 @@
 [deps.mach-std]
 url = "https://github.com/briar-systems/mach-std"
 ref = "branch/main"
-commit = "2a765f79a94282274d02111e4ad5d41930b36e2b"
+commit = "0262511fd60e21efb6aa95a66200b534940ea2f7"

--- a/src/lang/be/linker.mach
+++ b/src/lang/be/linker.mach
@@ -2379,12 +2379,14 @@ fun target_requires_pie(tgt: *target.Target) bool {
     ret tgt.os.pie_exec(tgt.arch.id);
 }
 
-# the page granularity used to align segment virtual addresses,
-# read from the OS vtable (`tgt.os.page_size`).
+# the page granularity used to align segment virtual addresses, read from the OS
+# vtable: the per-architecture `page_size_for` policy when present (Darwin maps 16
+# KiB pages on arm64, 4 KiB on x86_64), otherwise the fixed `page_size`.
 # ---
-# tgt: active target - supplies the OS page size
+# tgt: active target - supplies the OS page size and architecture
 # ret: the page granularity for segment alignment
 fun os_page_size(tgt: *target.Target) u64 {
+    if (tgt.os.page_size_for != nil) { ret tgt.os.page_size_for(tgt.arch.id); }
     ret tgt.os.page_size;
 }
 

--- a/src/lang/be/linker.mach
+++ b/src/lang/be/linker.mach
@@ -1575,9 +1575,22 @@ fun build_dynamic_info(s: *session.Session, tgt: *target.Target, dyn: *DynState,
         dyn.info.interp = R.unwrap_ok[intern.StrId, str](dr);
     }
 
-    # one DynLib per soname, in input order.
-    if (soname_count > 0) {
-        val lr: R.Result[*of.DynLib, str] = A.zallocate[of.DynLib](alloc, soname_count::usize);
+    # a PIE image implicitly links the OS platform library (darwin libSystem): a
+    # dyld-loaded executable that names no LC_LOAD_DYLIB is rejected, so it is
+    # recorded as a trailing dependency after the manifest sonames.
+    var implicit: u32 = 0;
+    var implicit_soname: intern.StrId = intern.STR_NIL;
+    if (dyn.info.pie && !str_empty(tgt.os.platform_lib)) {
+        val pr: R.Result[intern.StrId, str] = intern.intern(?s.interner, tgt.os.platform_lib);
+        if (R.is_err[intern.StrId, str](pr)) { ret R.err[bool, str](R.unwrap_err[intern.StrId, str](pr)); }
+        implicit_soname = R.unwrap_ok[intern.StrId, str](pr);
+        implicit = 1;
+    }
+
+    # one DynLib per soname, in input order, then the implicit platform library.
+    val total_libs: u32 = soname_count + implicit;
+    if (total_libs > 0) {
+        val lr: R.Result[*of.DynLib, str] = A.zallocate[of.DynLib](alloc, total_libs::usize);
         if (R.is_err[*of.DynLib, str](lr)) { ret R.err[bool, str](R.unwrap_err[*of.DynLib, str](lr)); }
         dyn.info.libs = R.unwrap_ok[*of.DynLib, str](lr);
         var i: u32 = 0;
@@ -1585,7 +1598,8 @@ fun build_dynamic_info(s: *session.Session, tgt: *target.Target, dyn: *DynState,
             dyn.info.libs[i].soname = sonames[i];
             i = i + 1;
         }
-        dyn.info.lib_count = soname_count;
+        if (implicit == 1) { dyn.info.libs[soname_count].soname = implicit_soname; }
+        dyn.info.lib_count = total_libs;
     }
 
     dyn.import_map = map.init[intern.StrId, u32](alloc, map.hash_u32, map.eq_u32);

--- a/src/lang/be/linker.mach
+++ b/src/lang/be/linker.mach
@@ -114,18 +114,20 @@ rec SymbolLoc {
 # plan's import array. empty for a static link; the writer consumes `info` + the
 # fixups. owns the `info.libs` / `info.imports` arrays and the fixup array.
 # ---
-# info:        the dynamic-link plan handed to `emit_dyn_exec`
-# import_map:  imported symbol name -> index into `info.imports`, for the patch pass
-# fixups:      collected import call-site fixups
-# fixup_count: number of fixups
-# fixup_cap:   capacity of the fixup array
-# active:      true once `build_dynamic_info` populated the plan (a dynamic link)
+# info:           the dynamic-link plan handed to `emit_dyn_exec`
+# import_map:     imported symbol name -> index into `info.imports`, for the patch pass
+# fixups:         collected import call-site fixups
+# fixup_count:    number of fixups
+# fixup_cap:      capacity of the fixup array
+# base_reloc_cap: capacity of the `info.base_relocs` array (count lives on `info`)
+# active:         true once `build_dynamic_info` populated the plan (a dynamic link)
 rec DynState {
     info:        of.DynamicInfo;
     import_map:  map.Map[intern.StrId, u32];
     fixups:      *of.PltFixup;
     fixup_count: u32;
     fixup_cap:   u32;
+    base_reloc_cap: u32;
     active:      bool;
 }
 
@@ -262,9 +264,14 @@ fun link_modules(s: *session.Session, tgt: *target.Target, modules: *of.ObjectIm
                  module_count: u32, sonames: *intern.StrId, soname_count: u32,
                  out_path: *u8, name: *u8, mode: LinkMode) R.Result[bool, str] {
     val alloc: *A.Allocator = s.alloc;
-    # a dynamic link is requested when shared dependencies are present and the
-    # output is an executable; libraries/relocatables ignore dependencies.
-    val dynamic: bool = (mode == LINK_EXE) && (soname_count > 0);
+    # a PIE executable (the OS requires position-independence for this arch) routes
+    # through the dynamic/PIE writer even with zero shared dependencies: it still
+    # needs MH_PIE, an LC_MAIN entry, and a base-relocation stream.
+    val pie: bool = (mode == LINK_EXE) && target_requires_pie(tgt);
+    # a dynamic link is requested when shared dependencies are present or the image
+    # is position-independent, and the output is an executable; libraries/
+    # relocatables ignore dependencies.
+    val dynamic: bool = (mode == LINK_EXE) && (soname_count > 0 || pie);
 
     # an empty module set (e.g. an archive holding only bookkeeping members) has
     # nothing to link, so reject rather than emit an empty artifact.
@@ -310,7 +317,7 @@ fun link_modules(s: *session.Session, tgt: *target.Target, modules: *of.ObjectIm
     # are placed in canonical order from the OS base, each kind page-aligned.
     val assign_vaddrs: bool = (mode == LINK_EXE);
     if (assign_vaddrs) {
-        assign_section_vaddrs(tgt, ?merged[0]);
+        assign_section_vaddrs(tgt, ?merged[0], pie);
         finalize_placement_vaddrs(?merged[0], placements, sec_total);
     }
 
@@ -356,6 +363,10 @@ fun link_modules(s: *session.Session, tgt: *target.Target, modules: *of.ObjectIm
         # targeting one is recorded as a `PltFixup` instead of erroring.
         var dyn: DynState;
         init_dynstate(?dyn);
+        # a PIE image collects in-image absolute pointers as base relocations during
+        # patching and emits them through the dynamic/PIE writer; the flag must be set
+        # before patch_relocations so the collection is enabled.
+        dyn.info.pie = pie;
         if (dynamic) {
             val dr: R.Result[bool, str] =
                 build_dynamic_info(s, tgt, ?dyn, modules, module_count, ?sym_locs, sonames, soname_count);
@@ -1057,14 +1068,21 @@ fun accumulate_sections(s: *session.Session, modules: *of.ObjectImage, module_co
 
 # give each used merged section a base virtual address,
 # starting from the OS base and page-aligning each kind's start.
+#
+# A PIE image reserves the first page above the base for the mach header + load
+# commands, so __TEXT (which maps the header at its start) begins exactly at the
+# base and __PAGEZERO spans [0, base) - the standard position-independent layout.
+# The writer asserts the header fits the one-page reservation.
 # ---
 # tgt:    active target - supplies the OS base address and page size
 # merged: the per-kind accumulators, whose vaddrs are assigned in place
-fun assign_section_vaddrs(tgt: *target.Target, merged: *MergedSection) {
+# pie:    true to reserve a one-page header gap above the base (PIE layout)
+fun assign_section_vaddrs(tgt: *target.Target, merged: *MergedSection, pie: bool) {
     val base: u64 = os_base_addr(tgt);
     val page: u64 = os_page_size(tgt);
 
     var va: u64 = base;
+    if (pie) { va = base + page; }
     var i: u32 = 0;
     for (i < MERGED_KIND_COUNT) {
         if (merged[i].used) {
@@ -1456,6 +1474,15 @@ fun patch_module_relocations(s: *session.Session, out_img: *of.ObjectImage,
             ret R.err[bool, str](R.unwrap_err[bool, str](pr));
         }
 
+        # PIE: an in-image absolute 64-bit pointer (RK_ABS64) holds a link-time
+        # (bias-zero) address; record its location so the writer emits a load-time
+        # base relocation the loader slides. PC-relative kinds need no fixup.
+        if (dyn.info.pie && r.kind == of.RK_ABS64) {
+            val brr: R.Result[bool, str] = dynstate_add_base_reloc(s, dyn,
+                segment_index_for(out_img, out_ix), patch_off, sym_va + r.addend::u64);
+            if (R.is_err[bool, str](brr)) { ret R.err[bool, str](R.unwrap_err[bool, str](brr)); }
+        }
+
         ri = ri + 1;
     }
     ret R.ok[bool, str](true);
@@ -1471,9 +1498,13 @@ fun init_dynstate(dyn: *DynState) {
     dyn.info.imports      = nil;
     dyn.info.import_count = 0;
     dyn.info.interp       = intern.STR_NIL;
+    dyn.info.base_relocs      = nil;
+    dyn.info.base_reloc_count = 0;
+    dyn.info.pie              = false;
     dyn.fixups            = nil;
     dyn.fixup_count       = 0;
     dyn.fixup_cap         = 0;
+    dyn.base_reloc_cap    = 0;
     dyn.active            = false;
 }
 
@@ -1491,6 +1522,9 @@ fun free_dynstate(alloc: *A.Allocator, dyn: *DynState) {
     }
     if (dyn.fixups != nil && dyn.fixup_cap > 0) {
         A.deallocate[of.PltFixup](alloc, dyn.fixups, dyn.fixup_cap::usize);
+    }
+    if (dyn.info.base_relocs != nil && dyn.base_reloc_cap > 0) {
+        A.deallocate[of.BaseReloc](alloc, dyn.info.base_relocs, dyn.base_reloc_cap::usize);
     }
     if (dyn.active) {
         map.dnit[intern.StrId, u32](?dyn.import_map);
@@ -1737,6 +1771,37 @@ fun dynstate_add_fixup(s: *session.Session, dyn: *DynState, seg_index: u32, seg_
     dyn.fixups[ix].patch_vaddr  = patch_vaddr;
     dyn.fixups[ix].addend       = addend;
     dyn.fixup_count = ix + 1;
+    ret R.ok[bool, str](true);
+}
+
+# record one in-image base relocation (an absolute pointer the loader slides) into
+# the plan's base-relocation set, growing the array geometrically. collected during
+# relocation patching for a PIE image; the format writer serializes the set into its
+# load-time relocation encoding (Mach-O rebase opcodes).
+# ---
+# s:          shared session, for the allocator
+# dyn:        the dynamic-link state whose `info.base_relocs` is grown
+# seg_index:  index into the writer's LoadSegment array of the patched segment
+# seg_offset: byte offset of the absolute pointer within that segment
+# target:     the link-time (bias-zero) absolute address stored at the location
+# ret:        ok(true) on success, or an allocation error
+fun dynstate_add_base_reloc(s: *session.Session, dyn: *DynState, seg_index: u32,
+                            seg_offset: u32, target: u64) R.Result[bool, str] {
+    val alloc: *A.Allocator = s.alloc;
+    if (dyn.info.base_reloc_count == dyn.base_reloc_cap) {
+        var new_cap: u32 = dyn.base_reloc_cap * 2;
+        if (new_cap == 0) { new_cap = 8; }
+        val gr: R.Result[*of.BaseReloc, str] =
+            A.reallocate[of.BaseReloc](alloc, dyn.info.base_relocs, dyn.base_reloc_cap::usize, new_cap::usize);
+        if (R.is_err[*of.BaseReloc, str](gr)) { ret R.err[bool, str](R.unwrap_err[*of.BaseReloc, str](gr)); }
+        dyn.info.base_relocs = R.unwrap_ok[*of.BaseReloc, str](gr);
+        dyn.base_reloc_cap = new_cap;
+    }
+    val ix: u32 = dyn.info.base_reloc_count;
+    dyn.info.base_relocs[ix].seg_index  = seg_index;
+    dyn.info.base_relocs[ix].seg_offset = seg_offset;
+    dyn.info.base_relocs[ix].target     = target;
+    dyn.info.base_reloc_count = ix + 1;
     ret R.ok[bool, str](true);
 }
 
@@ -2286,6 +2351,18 @@ fun image_name(modules: *of.ObjectImage, module_count: u32) intern.StrId {
 # ret: the base virtual address for the OS's executables
 fun os_base_addr(tgt: *target.Target) u64 {
     ret tgt.os.base_addr;
+}
+
+# whether the target requires a position-independent main executable, by asking the
+# OS vtable's `pie_exec` policy for the target architecture (e.g. arm64 Darwin). the
+# load-time contract belongs to the OS layer, so the linker never branches on the os
+# id; an OS with no policy (nil `pie_exec`) never requires PIE.
+# ---
+# tgt: active target - supplies the OS pie policy and the architecture id
+# ret: true when the image must be PIE (drives the PIE writer + base-relocation set)
+fun target_requires_pie(tgt: *target.Target) bool {
+    if (tgt.os == nil || tgt.os.pie_exec == nil) { ret false; }
+    ret tgt.os.pie_exec(tgt.arch.id);
 }
 
 # the page granularity used to align segment virtual addresses,

--- a/src/lang/target/of.mach
+++ b/src/lang/target/of.mach
@@ -236,21 +236,49 @@ pub rec DynImport {
 # dependency - the loader resolves it through its global symbol search
 pub val DYNLIB_ANY: u32 = 0xFFFFFFFF;
 
-# the complete format-neutral plan for a dynamically-linked image: the shared
-# dependencies to record and the imports to bind
+# one image base relocation: an in-image location holding an absolute pointer
+# whose value is the link-time (load-bias-zero) address, which the loader fixes up
+# by adding the image's load bias at map time
 #
-# The linker builds this from the unresolved `ext` symbols and the
-# shared-library link inputs; a format's `emit_dyn_exec` consumes it to lay out
-# the format's dynamic-linking structures (ELF `.dynamic`/PLT/GOT, PE `.idata`,
-# Mach-O dyld info). When `lib_count` and `import_count` are both zero the link
-# is fully static and `emit_exec` is used.
+# This is the format-neutral concept every position-independent (ASLR) image needs:
+# ELF encodes it as an `R_*_RELATIVE` entry in `.rela.dyn`, PE as a `.reloc`
+# base-relocation block, Mach-O as an `LC_DYLD_INFO` `REBASE_OPCODE_*` stream. The
+# linker collects one per in-image absolute pointer relocation; the format writer
+# serializes the set in its own encoding. `target` is the link-time absolute value
+# already stored at the location (carried so encodings that need an explicit addend,
+# like ELF RELATIVE, can use it; Mach-O reads it back from the slot).
 # ---
-# libs:         array of shared dependencies (DT_NEEDED order)
-# lib_count:    number of dependencies
-# imports:      array of imports to bind
-# import_count: number of imports
-# interp:       interned dynamic-loader path for PT_INTERP (e.g. the ELF interp),
-#               or intern.STR_NIL when the format embeds the loader differently
+# seg_index:  index into the writer's LoadSegment array of the patched segment
+# seg_offset: byte offset of the absolute pointer within that segment
+# target:     the link-time (bias-zero) absolute address stored at the location
+pub rec BaseReloc {
+    seg_index:  u32;
+    seg_offset: u32;
+    target:     u64;
+}
+
+# the complete format-neutral plan for a loader-processed image: the shared
+# dependencies to record, the imports to bind, and the position-independence
+# metadata (base-relocation set + PIE flag)
+#
+# The linker builds this from the unresolved `ext` symbols, the shared-library
+# link inputs, and (for a PIE image) the in-image absolute pointer relocations; a
+# format's `emit_dyn_exec` consumes it to lay out the format's loader structures
+# (ELF `.dynamic`/PLT/GOT/`.rela.dyn`, PE `.idata`/`.reloc`, Mach-O dyld info +
+# rebase). A PIE main with no shared dependency carries `pie` set with zero libs and
+# imports - so a zero-import image is not necessarily static; `emit_exec` is used
+# only when `lib_count`, `import_count`, and `pie` are all empty/false.
+# ---
+# libs:             array of shared dependencies (DT_NEEDED order)
+# lib_count:        number of dependencies
+# imports:          array of imports to bind
+# import_count:     number of imports
+# interp:           interned dynamic-loader path for PT_INTERP (e.g. the ELF interp),
+#                   or intern.STR_NIL when the format embeds the loader differently
+# base_relocs:      array of in-image base relocations the loader slides (PIE only)
+# base_reloc_count: number of base relocations
+# pie:              true when the image is position-independent (sets the format's
+#                   PIE marker and selects a relocatable layout + entry)
 pub rec DynamicInfo {
     libs:      *DynLib;
     lib_count: u32;
@@ -259,6 +287,10 @@ pub rec DynamicInfo {
     import_count: u32;
 
     interp: intern.StrId;
+
+    base_relocs:      *BaseReloc;
+    base_reloc_count: u32;
+    pie:              bool;
 }
 
 # one pc-relative call site the linker located that targets a dynamic import, to

--- a/src/lang/target/of/macho.mach
+++ b/src/lang/target/of/macho.mach
@@ -279,6 +279,17 @@ fun arch_is_arm64(arch_id: u32) bool {
     ret arch_id == isa.ARCH_AARCH64;
 }
 
+# the Mach-O segment page size for an ISA: arm64 Darwin maps memory in 16 KiB pages
+# and the kernel requires every segment vmaddr/fileoff to be 16 KiB aligned, while
+# x86_64 uses 4 KiB. segments laid out at the wrong granularity are rejected at exec.
+# ---
+# arch_id: the target ISA id
+# ret:     the segment alignment page size in bytes
+fun macho_page_size(arch_id: u32) u64 {
+    if (arch_is_arm64(arch_id)) { ret 16384; }
+    ret 4096;
+}
+
 # the Mach-O cputype for an ISA id, or an error for an unsupported architecture.
 # ---
 # arch_id: the target ISA id
@@ -2174,7 +2185,9 @@ fun emit_dyn_exec(alloc: *A.Allocator, itn: *intern.Interner, isa_vt: *isa.IsaVT
     val ct: R.Result[u32, str] = cpu_type_for(arch_id);
     if (R.is_err[u32, str](ct)) { ret R.err[bool, str](R.unwrap_err[u32, str](ct)); }
 
-    val page:     usize = EXEC_PAGE_SIZE::usize;
+    # arm64 Darwin maps memory in 16 KiB pages and requires 16 KiB-aligned segments.
+    val exec_page: u64 = macho_page_size(arch_id);
+    val page:     usize = exec_page::usize;
     val nimp:     u32 = func_import_count(dyn);
     val stub_sz:  usize = macho_stub_size(arch_id);
 
@@ -2264,7 +2277,7 @@ fun emit_dyn_exec(alloc: *A.Allocator, itn: *intern.Interner, isa_vt: *isa.IsaVT
         if (end > hi_va) { hi_va = end; }
         li = li + 1;
     }
-    var va: u64 = bin.align_up_u64(hi_va, EXEC_PAGE_SIZE);
+    var va: u64 = bin.align_up_u64(hi_va, exec_page);
 
     # whether a __PAGEZERO precedes the linker segments; it shifts every Mach-O
     # segment index the bind and rebase opcodes select.
@@ -2280,14 +2293,14 @@ fun emit_dyn_exec(alloc: *A.Allocator, itn: *intern.Interner, isa_vt: *isa.IsaVT
         lay.stubs_va   = va;
         lay.stubs_size = nimp::usize * stub_sz;
         file = file + lay.stubs_size;
-        va   = bin.align_up_u64(va + lay.stubs_size::u64, EXEC_PAGE_SIZE);
+        va   = bin.align_up_u64(va + lay.stubs_size::u64, exec_page);
 
         file = bin.align_up(file, page);
         lay.got_off  = file;
         lay.got_va   = va;
         lay.got_size = nimp::usize * 8;
         file = file + lay.got_size;
-        va   = bin.align_up_u64(va + lay.got_size::u64, EXEC_PAGE_SIZE);
+        va   = bin.align_up_u64(va + lay.got_size::u64, exec_page);
 
         lay.got_seg_index = pz + seg_count + 1;   # pagezero + linker segs + stubs
     }
@@ -2356,7 +2369,7 @@ fun emit_dyn_exec(alloc: *A.Allocator, itn: *intern.Interner, isa_vt: *isa.IsaVT
     # of the linker's segments at their assigned addresses, each with one section.
     val text_prot: u32 = vm_prot_for(segs[0].flags);
     var tsec: usize = write_segment_cmd(buf, lc, "__TEXT", lay.text_va,
-                           bin.align_up_u64(lay.hdr_span::u64 + segs[0].memsz::u64, EXEC_PAGE_SIZE),
+                           bin.align_up_u64(lay.hdr_span::u64 + segs[0].memsz::u64, exec_page),
                            0, lay.hdr_span::u64 + segs[0].filesz::u64, text_prot, text_prot, 1);
     write_section_64(buf, tsec, dyn_sectname(segs[0].flags, false), "__TEXT", segs[0].vaddr,
                      segs[0].memsz::u64, seg_offsets[0]::u32, dyn_sect_flags(segs[0].flags, false));
@@ -2374,7 +2387,7 @@ fun emit_dyn_exec(alloc: *A.Allocator, itn: *intern.Interner, isa_vt: *isa.IsaVT
         }
         val zf:   bool = segs[li].filesz == 0 && segs[li].memsz > 0;
         var lsec: usize = write_segment_cmd(buf, lc, exec_segname(segs[li].flags), segs[li].vaddr,
-                               bin.align_up_u64(segs[li].memsz::u64, EXEC_PAGE_SIZE),
+                               bin.align_up_u64(segs[li].memsz::u64, exec_page),
                                seg_offsets[li]::u64, segs[li].filesz::u64, prot, prot, 1);
         if (seg_flags != 0) { bin.write_u32_le(buf, lc + 68, seg_flags); }
         var soff: u32 = seg_offsets[li]::u32;
@@ -2391,7 +2404,7 @@ fun emit_dyn_exec(alloc: *A.Allocator, itn: *intern.Interner, isa_vt: *isa.IsaVT
     # linker segment name, keeping the bind segment index unambiguous.
     if (nimp > 0) {
         var sec: usize = write_segment_cmd(buf, lc, "__STUBS", lay.stubs_va,
-                               bin.align_up_u64(lay.stubs_size::u64, EXEC_PAGE_SIZE),
+                               bin.align_up_u64(lay.stubs_size::u64, exec_page),
                                lay.stubs_off::u64, lay.stubs_size::u64,
                                VM_PROT_READ | VM_PROT_EXECUTE, VM_PROT_READ | VM_PROT_EXECUTE, 1);
         write_section_64(buf, sec, "__stubs", "__STUBS", lay.stubs_va, lay.stubs_size::u64,
@@ -2399,7 +2412,7 @@ fun emit_dyn_exec(alloc: *A.Allocator, itn: *intern.Interner, isa_vt: *isa.IsaVT
         lc = sec + SECTION_64_SIZE;
 
         sec = write_segment_cmd(buf, lc, "__GOT", lay.got_va,
-                               bin.align_up_u64(lay.got_size::u64, EXEC_PAGE_SIZE),
+                               bin.align_up_u64(lay.got_size::u64, exec_page),
                                lay.got_off::u64, lay.got_size::u64,
                                VM_PROT_READ | VM_PROT_WRITE, VM_PROT_READ | VM_PROT_WRITE, 1);
         write_section_64(buf, sec, "__got", "__GOT", lay.got_va, lay.got_size::u64,
@@ -2409,7 +2422,7 @@ fun emit_dyn_exec(alloc: *A.Allocator, itn: *intern.Interner, isa_vt: *isa.IsaVT
 
     # __LINKEDIT.
     lc = write_segment_cmd(buf, lc, "__LINKEDIT", lay.linkedit_va,
-                           bin.align_up_u64(lay.linkedit_size::u64, EXEC_PAGE_SIZE),
+                           bin.align_up_u64(lay.linkedit_size::u64, exec_page),
                            lay.linkedit_off::u64, lay.linkedit_size::u64,
                            VM_PROT_READ, VM_PROT_READ, 0);
 

--- a/src/lang/target/of/macho.mach
+++ b/src/lang/target/of/macho.mach
@@ -227,9 +227,13 @@ val CSSLOT_CODEDIRECTORY:       u32 = 0;
 
 # CodeDirectory version 0x20400 carries the executable-segment fields the Apple
 # Silicon kernel reads to authorize a main binary; the adhoc flag marks a
-# signature with no CMS (certificate) blob, which is what makes it ad-hoc.
+# signature with no CMS (certificate) blob, which is what makes it ad-hoc. The
+# linker-signed flag marks an ad-hoc signature applied by the linker itself (as ld
+# does on Apple Silicon): CoreTrust admits a linker-signed ad-hoc main executable,
+# but rejects a hand-rolled ad-hoc one - so mach, being the linker, sets both.
 val CS_CODEDIRECTORY_VERSION: u32 = 0x00020400;
 val CS_ADHOC_FLAG:            u32 = 0x0002;
+val CS_LINKER_SIGNED_FLAG:    u32 = 0x20000;
 val CS_HASHTYPE_SHA256:       u8  = 2;
 val CS_HASH_SIZE_SHA256:      u8  = 32;
 val CS_PAGE_SHIFT:            u8  = 12;    # log2(4096)
@@ -1273,7 +1277,7 @@ fun write_code_signature(buf: *u8, sig_off: usize, name: *u8, code_limit: usize,
     bin.write_u32_be(buf, cd,      CSMAGIC_CODEDIRECTORY);
     bin.write_u32_be(buf, cd + 4,  cd_size::u32);
     bin.write_u32_be(buf, cd + 8,  CS_CODEDIRECTORY_VERSION);
-    bin.write_u32_be(buf, cd + 12, CS_ADHOC_FLAG);
+    bin.write_u32_be(buf, cd + 12, CS_ADHOC_FLAG | CS_LINKER_SIGNED_FLAG);
     bin.write_u32_be(buf, cd + 16, hash_off::u32);            # hashOffset (slot 0)
     bin.write_u32_be(buf, cd + 20, ident_off::u32);           # identOffset
     bin.write_u32_be(buf, cd + 24, 0);                        # nSpecialSlots

--- a/src/lang/target/of/macho.mach
+++ b/src/lang/target/of/macho.mach
@@ -46,6 +46,7 @@ use std.crypto.hash.sha256;
 use A: std.allocator;
 use O: std.types.option;
 use R: std.types.result;
+use sort: std.collections.sort;
 
 use mach.lang.intern;
 use mach.lang.target.isa;
@@ -87,6 +88,27 @@ val LC_LOAD_DYLINKER: u32 = 0xE;
 val LC_DYLD_INFO_ONLY: u32 = 0x80000022;
 # points at the embedded code signature in __LINKEDIT.
 val LC_CODE_SIGNATURE: u32 = 0x1D;
+# the modern main-executable entry: a file-offset entry point dyld jumps to (with
+# a load bias), replacing the absolute-pc LC_UNIXTHREAD thread state for PIE images.
+val LC_MAIN:          u32 = 0x80000028;
+# names the target platform and minimum OS; dyld validates it on Apple Silicon.
+val LC_BUILD_VERSION: u32 = 0x32;
+# the image's 128-bit identifier, required in a modern signed main executable.
+val LC_UUID:          u32 = 0x1B;
+
+# fixed sizes for the PIE load commands.
+val ENTRY_POINT_CMD_SIZE:   usize = 24;   # cmd + cmdsize + entryoff + stacksize
+val BUILD_VERSION_CMD_SIZE: usize = 24;   # cmd + cmdsize + platform + minos + sdk + ntools(0)
+val UUID_CMD_SIZE:          usize = 24;   # cmd + cmdsize + 16-byte uuid
+
+# LC_BUILD_VERSION platform id for macOS, and the minimum-OS / SDK version it names
+# (11.0.0, packed as 0x00xxyyzz = xx.yy.zz) - the first macOS to ship Apple Silicon.
+val PLATFORM_MACOS: u32 = 1;
+val MACOS_MIN_VERSION: u32 = 0x000B0000;
+
+# MH_PIE marks a position-independent main executable: dyld may load it at a random
+# bias, and the loader slides every segment and applies the rebase stream.
+val MH_PIE: u32 = 0x200000;
 
 # VM protection bits used for segment maxprot/initprot.
 val VM_PROT_READ:    u32 = 1;
@@ -158,6 +180,15 @@ val BIND_OPCODE_DO_BIND:                       u8 = 0x90;
 val BIND_TYPE_POINTER:               u8  = 0x1;
 val BIND_SPECIAL_DYLIB_FLAT_LOOKUP:  u8  = 0xE;    # -2 as a 4-bit immediate
 val DYNAMIC_LOOKUP_ORDINAL:          u16 = 0xFE;   # n_desc library-ordinal byte
+
+# dyld rebase-opcode bytes (the high nibble is the opcode, the low nibble an
+# immediate). a position-independent image rebases each in-image absolute pointer:
+# set the pointer type once, then per slot select the segment + offset and apply.
+val REBASE_OPCODE_DONE:                    u8 = 0x00;
+val REBASE_OPCODE_SET_TYPE_IMM:            u8 = 0x10;
+val REBASE_OPCODE_SET_SEGMENT_AND_OFFSET_ULEB: u8 = 0x20;
+val REBASE_OPCODE_DO_REBASE_IMM_TIMES:     u8 = 0x50;
+val REBASE_TYPE_POINTER:                   u8 = 0x1;
 
 # the dynamic loader Darwin executables name in LC_LOAD_DYLINKER.
 val DARWIN_DYLD_PATH: str = "/usr/lib/dyld";
@@ -1539,6 +1570,8 @@ rec MachoDynLayout {
     linkedit_va:   u64;
     linkedit_size: usize;
 
+    rebase_off:    usize;
+    rebase_size:   usize;
     bind_off:      usize;
     bind_size:     usize;
     symtab_off:    usize;
@@ -1854,6 +1887,125 @@ fun write_bind_info(buf: *u8, off: usize, itn: *intern.Interner, dyn: *of.Dynami
     ret p;
 }
 
+# write the 16-byte LC_UUID payload, derived deterministically from the product name
+#
+# The uuid must be stable across the darwin self-host fixpoint (it is covered by the
+# ad-hoc signature), so it is a name-based RFC 4122 uuid: the first 16 bytes of
+# SHA-256(name), with the version (5) and variant bits set. Keying it on the product
+# name (not the `-o` path) keeps the signed image filename-independent.
+# ---
+# buf:  the output buffer
+# off:  byte offset of the 16-byte uuid field
+# name: null-terminated product name (the stable signing identity)
+fun write_macho_uuid(buf: *u8, off: usize, name: *u8) {
+    var digest: [32]u8;
+    var n: usize = 0;
+    if (name != nil) { n = str_len(name::str); }
+    sha256.hash(name, n, ?digest[0]);
+    var i: usize = 0;
+    for (i < 16) { buf[off + i] = digest[i]; i = i + 1; }
+    buf[off + 6] = (buf[off + 6] & 0x0F) | 0x50;           # version 5 (name-based)
+    buf[off + 8] = (buf[off + 8] & 0x3F) | 0x80;           # RFC 4122 variant
+}
+
+# order two base relocations by (segment, in-segment offset)
+#
+# The rebase stream is emitted in this order so the signed image is byte-identical
+# across the darwin self-host fixpoint (the rebase bytes hash into the signature).
+# ---
+# a, b: the base relocations to compare
+# ret:  negative, zero, or positive per the (seg_index, seg_offset) order
+fun base_reloc_cmp(a: *of.BaseReloc, b: *of.BaseReloc) i64 {
+    if (a.seg_index != b.seg_index) {
+        if (a.seg_index < b.seg_index) { ret -1; }
+        ret 1;
+    }
+    if (a.seg_offset < b.seg_offset) { ret -1; }
+    if (a.seg_offset > b.seg_offset) { ret 1; }
+    ret 0;
+}
+
+# locate one base relocation in the emitted image
+#
+# Resolves the Mach-O segment index (the load-command ordering, __PAGEZERO included)
+# and the slot's byte offset from that segment's virtual address - the two operands a
+# `REBASE_OPCODE_SET_SEGMENT_AND_OFFSET_ULEB` needs. The linker's first segment maps
+# as __TEXT, whose vaddr is `text_va` (the header sits below the linker text), so its
+# offsets are measured from there; every other segment maps at its assigned vaddr.
+# ---
+# br:      the base relocation to locate
+# segs:    the linker's load segments
+# text_va: the __TEXT virtual address (the linker's first segment maps above it)
+# pz:      1 when a __PAGEZERO precedes the linker segments, else 0
+# out_seg: receives the Mach-O segment index
+# out_off: receives the slot's byte offset from that segment's virtual address
+fun base_reloc_loc(br: *of.BaseReloc, segs: *of.LoadSegment, text_va: u64, pz: u32,
+                   out_seg: *u32, out_off: *u64) {
+    val ls: u32 = br.seg_index;
+    @out_seg = pz + ls;
+    var seg_vmaddr: u64 = segs[ls].vaddr;
+    if (ls == 0) { seg_vmaddr = text_va; }
+    @out_off = (segs[ls].vaddr + br.seg_offset::u64) - seg_vmaddr;
+}
+
+# the byte length of the dyld rebase opcode stream for the image's base relocations
+# ---
+# dyn:     the dynamic-link plan carrying the base-relocation set
+# segs:    the linker's load segments
+# text_va: the __TEXT virtual address
+# pz:      1 when a __PAGEZERO precedes the linker segments, else 0
+# ret:     the rebase stream byte length (0 when there are no base relocations)
+fun measure_rebase_info(dyn: *of.DynamicInfo, segs: *of.LoadSegment, text_va: u64, pz: u32) usize {
+    if (dyn.base_reloc_count == 0) { ret 0; }
+    var size: usize = 1;                                   # SET_TYPE_IMM
+    var i: u32 = 0;
+    for (i < dyn.base_reloc_count) {
+        var seg: u32 = 0;
+        var off: u64 = 0;
+        base_reloc_loc(?dyn.base_relocs[i], segs, text_va, pz, ?seg, ?off);
+        size = size + 1 + uleb_size(off) + 1;             # SET_SEGMENT_AND_OFFSET + DO_REBASE_IMM_TIMES
+        i = i + 1;
+    }
+    size = size + 1;                                       # REBASE_OPCODE_DONE
+    ret size;
+}
+
+# write the dyld rebase opcode stream that slides each in-image absolute pointer
+#
+# Sets the pointer rebase type once, then for each base relocation selects its
+# segment + in-segment offset and rebases one pointer there; dyld adds the image's
+# load bias to the slot at map time. The relocations are pre-sorted so the stream is
+# deterministic.
+# ---
+# buf:     the output buffer
+# off:     byte offset of the rebase stream
+# dyn:     the dynamic-link plan carrying the (sorted) base-relocation set
+# segs:    the linker's load segments
+# text_va: the __TEXT virtual address
+# pz:      1 when a __PAGEZERO precedes the linker segments, else 0
+# ret:     the byte offset just past the stream
+fun write_rebase_info(buf: *u8, off: usize, dyn: *of.DynamicInfo, segs: *of.LoadSegment,
+                      text_va: u64, pz: u32) usize {
+    if (dyn.base_reloc_count == 0) { ret off; }
+    var p: usize = off;
+    buf[p] = REBASE_OPCODE_SET_TYPE_IMM | REBASE_TYPE_POINTER;
+    p = p + 1;
+    var i: u32 = 0;
+    for (i < dyn.base_reloc_count) {
+        var seg: u32 = 0;
+        var slot: u64 = 0;
+        base_reloc_loc(?dyn.base_relocs[i], segs, text_va, pz, ?seg, ?slot);
+        buf[p] = REBASE_OPCODE_SET_SEGMENT_AND_OFFSET_ULEB | (seg::u8 & 0xF);
+        p = write_uleb(buf, p + 1, slot);
+        buf[p] = REBASE_OPCODE_DO_REBASE_IMM_TIMES | 1;
+        p = p + 1;
+        i = i + 1;
+    }
+    buf[p] = REBASE_OPCODE_DONE;
+    p = p + 1;
+    ret p;
+}
+
 # rewrite each deferred import call site to a pc-relative branch to its stub
 #
 # The linker recorded a `PltFixup` for every call to a function import it could not
@@ -1966,21 +2118,25 @@ fun dyn_sect_flags(flags: u32, zerofill: bool) u32 {
 # write a dynamically-linked MH_EXECUTE Mach-O, installed as the of.DynExecFn
 #
 # Frames the linker's laid-out load segments into a dyld-loadable executable: a
-# leading __PAGEZERO, a __TEXT that maps the mach header below the linker's text so
-# dyld can read the load commands, the linker's remaining segments, synthesized
-# import-stub and got segments (when there are function imports), and a __LINKEDIT
-# carrying the LC_DYLD_INFO_ONLY bind stream, the symbol and string tables, and a
-# trailing ad-hoc code signature. The load commands name the dynamic loader
-# (LC_LOAD_DYLINKER), each shared dependency (LC_LOAD_DYLIB), the symbol tables
-# (LC_SYMTAB/LC_DYSYMTAB), the static entry (LC_UNIXTHREAD), and the signature
-# (LC_CODE_SIGNATURE). Each function import's got slot is bound non-lazily by dyld,
-# and every deferred call site is redirected to its stub.
+# leading __PAGEZERO, a __TEXT that maps the mach header so dyld can read the load
+# commands, the linker's remaining segments, synthesized import-stub and got
+# segments (when there are function imports), and a __LINKEDIT carrying the
+# LC_DYLD_INFO_ONLY rebase/bind streams, the symbol and string tables, and a trailing
+# ad-hoc code signature. The load commands name the dynamic loader (LC_LOAD_DYLINKER),
+# each shared dependency (LC_LOAD_DYLIB), the symbol tables (LC_SYMTAB/LC_DYSYMTAB),
+# the entry, and the signature (LC_CODE_SIGNATURE). Each function import's got slot is
+# bound non-lazily by dyld, and every deferred call site is redirected to its stub.
 #
-# The image uses fixed virtual addresses (no MH_PIE): the linker assigned absolute
-# addresses from the OS base and the back end emits absolute addressing, so a load
-# bias would invalidate them. The ad-hoc LC_CODE_SIGNATURE the kernel verifies
-# before exec is emitted last (it covers everything before it), so the image runs on
-# Apple Silicon, which SIGKILLs an unsigned arm64 executable.
+# When `dyn.pie` (arm64 Darwin, where the kernel refuses a non-PIE main executable)
+# the image is position-independent: MH_PIE is set, __TEXT maps the header at the OS
+# base (the linker reserved a one-page header gap above the base), the entry is an
+# LC_MAIN file offset, LC_BUILD_VERSION/LC_UUID are emitted, and the LC_DYLD_INFO
+# rebase stream slides every in-image absolute pointer (`dyn.base_relocs`) by dyld's
+# load bias. A non-PIE image keeps the fixed-address shape: the header maps below the
+# linker text, the entry is an absolute-pc LC_UNIXTHREAD, and there is no rebase
+# stream. The ad-hoc LC_CODE_SIGNATURE the kernel verifies before exec is emitted last
+# (it covers everything before it), so the image runs on Apple Silicon, which SIGKILLs
+# an unsigned arm64 executable.
 # ---
 # alloc:       allocator for the output buffer and the scratch offset table
 # itn:         interner resolving the dynamic-plan names (sonames, imports)
@@ -2013,6 +2169,17 @@ fun emit_dyn_exec(alloc: *A.Allocator, itn: *intern.Interner, isa_vt: *isa.IsaVT
     val nimp:     u32 = func_import_count(dyn);
     val stub_sz:  usize = macho_stub_size(arch_id);
 
+    # a position-independent image (arm64 Darwin): MH_PIE, an LC_MAIN entry, the
+    # platform/uuid load commands, and an LC_DYLD_INFO rebase stream sliding every
+    # in-image absolute pointer. a non-PIE image keeps the fixed-address shape: an
+    # LC_UNIXTHREAD entry and no rebase stream.
+    val pie: bool = dyn.pie;
+    # the rebase relocations are emitted in a deterministic (segment, offset) order so
+    # the signed image is byte-identical across the self-host fixpoint.
+    if (pie && dyn.base_reloc_count > 1) {
+        sort.sort[of.BaseReloc](dyn.base_relocs, dyn.base_reloc_count::usize, base_reloc_cmp);
+    }
+
     # load-command byte size. the segment count is __PAGEZERO + the linker segments
     # + (stubs, got when there are function imports) + __LINKEDIT.
     var seg_cmds: u32 = seg_count + 1;              # linker segments + __LINKEDIT
@@ -2022,6 +2189,10 @@ fun emit_dyn_exec(alloc: *A.Allocator, itn: *intern.Interner, isa_vt: *isa.IsaVT
     var thread_state: usize = X86_THREAD_STATE64_COUNT::usize * 4;
     if (arch_is_arm64(arch_id)) { thread_state = ARM_THREAD_STATE64_COUNT::usize * 4; }
     val thread_cmd_size: usize = 16 + thread_state;
+    # the entry command is an LC_MAIN file-offset entry for a PIE image, else the
+    # LC_UNIXTHREAD thread state.
+    var entry_cmd_size: usize = thread_cmd_size;
+    if (pie) { entry_cmd_size = ENTRY_POINT_CMD_SIZE; }
 
     # every loadable segment carries one section_64 entry (the linker's segments
     # plus the synthesized stub and got segments) so the llvm/otool readers and the
@@ -2032,14 +2203,27 @@ fun emit_dyn_exec(alloc: *A.Allocator, itn: *intern.Interner, isa_vt: *isa.IsaVT
     var sizeofcmds: usize = seg_cmds::usize * SEGMENT_CMD_64_SIZE
                           + sect_total::usize * SECTION_64_SIZE
                           + DYLD_INFO_CMD_SIZE + SYMTAB_CMD_SIZE + DYSYMTAB_CMD_SIZE
-                          + dylinker_cmd_size() + thread_cmd_size + LINKEDIT_DATA_CMD_SIZE;   # + LC_CODE_SIGNATURE
+                          + dylinker_cmd_size() + entry_cmd_size + LINKEDIT_DATA_CMD_SIZE;   # + LC_CODE_SIGNATURE
+    if (pie) { sizeofcmds = sizeofcmds + BUILD_VERSION_CMD_SIZE + UUID_CMD_SIZE; }
     var di: u32 = 0;
     for (di < dyn.lib_count) { sizeofcmds = sizeofcmds + dylib_cmd_size(resolve(itn, dyn.libs[di].soname)); di = di + 1; }
 
-    var ncmds: u32 = seg_cmds + 6 + dyn.lib_count;   # dyld_info,symtab,dysymtab,dylinker,unixthread,code_signature
+    var ncmds: u32 = seg_cmds + 6 + dyn.lib_count;   # dyld_info,symtab,dysymtab,dylinker,entry,code_signature
+    if (pie) { ncmds = ncmds + 2; }                  # LC_BUILD_VERSION + LC_UUID
 
     var lay: MachoDynLayout;
-    lay.hdr_span = bin.align_up(MACH_HEADER_64_SIZE + sizeofcmds, page);
+    # a PIE image reserves exactly one page for the header so __TEXT maps at the OS
+    # base (the linker reserved that page above the base when assigning vaddrs); a
+    # non-PIE image maps the header below the linker's first segment, sized to fit.
+    if (pie) {
+        if (MACH_HEADER_64_SIZE + sizeofcmds > page) {
+            ret R.err[bool, str]("macho: dyn-exec PIE header exceeds the one-page reservation");
+        }
+        lay.hdr_span = page;
+    }
+    or {
+        lay.hdr_span = bin.align_up(MACH_HEADER_64_SIZE + sizeofcmds, page);
+    }
     if (segs[0].vaddr < lay.hdr_span::u64) {
         ret R.err[bool, str]("macho: dyn-exec base address too low to map the header");
     }
@@ -2073,6 +2257,11 @@ fun emit_dyn_exec(alloc: *A.Allocator, itn: *intern.Interner, isa_vt: *isa.IsaVT
     }
     var va: u64 = bin.align_up_u64(hi_va, EXEC_PAGE_SIZE);
 
+    # whether a __PAGEZERO precedes the linker segments; it shifts every Mach-O
+    # segment index the bind and rebase opcodes select.
+    var pz: u32 = 0;
+    if (lay.pagezero_size > 0) { pz = 1; }
+
     lay.stubs_size = 0;
     lay.got_size = 0;
     lay.got_seg_index = 0;
@@ -2091,17 +2280,18 @@ fun emit_dyn_exec(alloc: *A.Allocator, itn: *intern.Interner, isa_vt: *isa.IsaVT
         file = file + lay.got_size;
         va   = bin.align_up_u64(va + lay.got_size::u64, EXEC_PAGE_SIZE);
 
-        var pz: u32 = 0;
-        if (lay.pagezero_size > 0) { pz = 1; }
         lay.got_seg_index = pz + seg_count + 1;   # pagezero + linker segs + stubs
     }
 
-    # __LINKEDIT: the bind stream, then the nlist array (8-aligned), then strings.
+    # __LINKEDIT: the rebase stream (PIE only), then the bind stream, then the nlist
+    # array (8-aligned), then strings.
     file = bin.align_up(file, page);
     lay.linkedit_off = file;
     lay.linkedit_va  = va;
 
-    lay.bind_off  = lay.linkedit_off;
+    lay.rebase_off  = lay.linkedit_off;
+    lay.rebase_size = measure_rebase_info(dyn, segs, lay.text_va, pz);
+    lay.bind_off  = lay.rebase_off + lay.rebase_size;
     lay.bind_size = measure_bind_info(itn, dyn);
     lay.symtab_off = bin.align_up(lay.bind_off + lay.bind_size, 8);
 
@@ -2140,7 +2330,9 @@ fun emit_dyn_exec(alloc: *A.Allocator, itn: *intern.Interner, isa_vt: *isa.IsaVT
     bin.write_u32_le(buf, 12, MH_EXECUTE);
     bin.write_u32_le(buf, 16, ncmds);
     bin.write_u32_le(buf, 20, sizeofcmds::u32);
-    bin.write_u32_le(buf, 24, MH_DYLDLINK | MH_TWOLEVEL);
+    var hdr_flags: u32 = MH_DYLDLINK | MH_TWOLEVEL;
+    if (pie) { hdr_flags = hdr_flags | MH_PIE; }
+    bin.write_u32_le(buf, 24, hdr_flags);
     bin.write_u32_le(buf, 28, 0);
 
     var lc: usize = MACH_HEADER_64_SIZE;
@@ -2203,12 +2395,15 @@ fun emit_dyn_exec(alloc: *A.Allocator, itn: *intern.Interner, isa_vt: *isa.IsaVT
                            lay.linkedit_off::u64, lay.linkedit_size::u64,
                            VM_PROT_READ, VM_PROT_READ, 0);
 
-    # LC_DYLD_INFO_ONLY: only the bind stream is non-empty (fixed addresses need no
-    # rebase, and binding is eager so the lazy stream is empty).
+    # LC_DYLD_INFO_ONLY: a PIE image carries a rebase stream (sliding its absolute
+    # pointers); binding is eager so the lazy stream is empty.
+    var rebase_cmd_off: u32 = 0;
+    var rebase_cmd_size: u32 = 0;
+    if (lay.rebase_size > 0) { rebase_cmd_off = lay.rebase_off::u32; rebase_cmd_size = lay.rebase_size::u32; }
     bin.write_u32_le(buf, lc, LC_DYLD_INFO_ONLY);
     bin.write_u32_le(buf, lc + 4, DYLD_INFO_CMD_SIZE::u32);
-    bin.write_u32_le(buf, lc + 8, 0);                       # rebase_off
-    bin.write_u32_le(buf, lc + 12, 0);                      # rebase_size
+    bin.write_u32_le(buf, lc + 8, rebase_cmd_off);          # rebase_off
+    bin.write_u32_le(buf, lc + 12, rebase_cmd_size);        # rebase_size
     bin.write_u32_le(buf, lc + 16, lay.bind_off::u32);
     bin.write_u32_le(buf, lc + 20, lay.bind_size::u32);
     bin.write_u32_le(buf, lc + 24, 0);                      # weak_bind_off
@@ -2248,20 +2443,47 @@ fun emit_dyn_exec(alloc: *A.Allocator, itn: *intern.Interner, isa_vt: *isa.IsaVT
         di = di + 1;
     }
 
-    # LC_UNIXTHREAD: the static thread entry, program counter set to the entry.
-    bin.write_u32_le(buf, lc, LC_UNIXTHREAD);
-    bin.write_u32_le(buf, lc + 4, thread_cmd_size::u32);
-    if (arch_is_arm64(arch_id)) {
-        bin.write_u32_le(buf, lc + 8, ARM_THREAD_STATE64);
-        bin.write_u32_le(buf, lc + 12, ARM_THREAD_STATE64_COUNT);
-        bin.write_u64_le(buf, lc + 16 + ARM_PC_STATE_OFFSET, entry);
+    # a PIE image names its platform (LC_BUILD_VERSION) and identity (LC_UUID) and
+    # enters through an LC_MAIN file-offset entry dyld jumps to after applying the
+    # load bias; a non-PIE image carries only the absolute-pc LC_UNIXTHREAD entry.
+    if (pie) {
+        bin.write_u32_le(buf, lc, LC_BUILD_VERSION);
+        bin.write_u32_le(buf, lc + 4, BUILD_VERSION_CMD_SIZE::u32);
+        bin.write_u32_le(buf, lc + 8, PLATFORM_MACOS);
+        bin.write_u32_le(buf, lc + 12, MACOS_MIN_VERSION);     # minos
+        bin.write_u32_le(buf, lc + 16, MACOS_MIN_VERSION);     # sdk
+        bin.write_u32_le(buf, lc + 20, 0);                     # ntools
+        lc = lc + BUILD_VERSION_CMD_SIZE;
+
+        bin.write_u32_le(buf, lc, LC_UUID);
+        bin.write_u32_le(buf, lc + 4, UUID_CMD_SIZE::u32);
+        write_macho_uuid(buf, lc + 8, name);
+        lc = lc + UUID_CMD_SIZE;
+
+        # entryoff is the entry's file offset: __TEXT maps the header at file offset 0
+        # / virtual address text_va, so the offset is entry - text_va.
+        bin.write_u32_le(buf, lc, LC_MAIN);
+        bin.write_u32_le(buf, lc + 4, ENTRY_POINT_CMD_SIZE::u32);
+        bin.write_u64_le(buf, lc + 8, entry - lay.text_va);    # entryoff
+        bin.write_u64_le(buf, lc + 16, 0);                     # stacksize
+        lc = lc + ENTRY_POINT_CMD_SIZE;
     }
     or {
-        bin.write_u32_le(buf, lc + 8, X86_THREAD_STATE64);
-        bin.write_u32_le(buf, lc + 12, X86_THREAD_STATE64_COUNT);
-        bin.write_u64_le(buf, lc + 16 + X86_RIP_STATE_OFFSET, entry);
+        # LC_UNIXTHREAD: the static thread entry, program counter set to the entry.
+        bin.write_u32_le(buf, lc, LC_UNIXTHREAD);
+        bin.write_u32_le(buf, lc + 4, thread_cmd_size::u32);
+        if (arch_is_arm64(arch_id)) {
+            bin.write_u32_le(buf, lc + 8, ARM_THREAD_STATE64);
+            bin.write_u32_le(buf, lc + 12, ARM_THREAD_STATE64_COUNT);
+            bin.write_u64_le(buf, lc + 16 + ARM_PC_STATE_OFFSET, entry);
+        }
+        or {
+            bin.write_u32_le(buf, lc + 8, X86_THREAD_STATE64);
+            bin.write_u32_le(buf, lc + 12, X86_THREAD_STATE64_COUNT);
+            bin.write_u64_le(buf, lc + 16 + X86_RIP_STATE_OFFSET, entry);
+        }
+        lc = lc + thread_cmd_size;
     }
-    lc = lc + thread_cmd_size;
 
     # LC_CODE_SIGNATURE points at the ad-hoc signature trailing __LINKEDIT.
     bin.write_u32_le(buf, lc, LC_CODE_SIGNATURE);
@@ -2289,7 +2511,8 @@ fun emit_dyn_exec(alloc: *A.Allocator, itn: *intern.Interner, isa_vt: *isa.IsaVT
         }
     }
 
-    # the dyld bind stream and the symbol/string tables in __LINKEDIT.
+    # the dyld rebase stream (PIE), then the bind stream and symbol/string tables.
+    write_rebase_info(buf, lay.rebase_off, dyn, segs, lay.text_va, pz);
     write_bind_info(buf, lay.bind_off, itn, dyn, lay.got_seg_index);
 
     buf[lay.strtab_off] = 0;

--- a/src/lang/target/of/macho.mach
+++ b/src/lang/target/of/macho.mach
@@ -110,6 +110,11 @@ val MACOS_MIN_VERSION: u32 = 0x000B0000;
 # bias, and the loader slides every segment and applies the rebase stream.
 val MH_PIE: u32 = 0x200000;
 
+# SG_READ_ONLY (a segment flag) marks a segment dyld maps writable, applies its
+# fixups to, then re-protects read-only - how __DATA_CONST holds rebased const
+# pointers in a PIE image without staying writable at run time.
+val SG_READ_ONLY: u32 = 0x10;
+
 # VM protection bits used for segment maxprot/initprot.
 val VM_PROT_READ:    u32 = 1;
 val VM_PROT_WRITE:   u32 = 2;
@@ -2354,11 +2359,20 @@ fun emit_dyn_exec(alloc: *A.Allocator, itn: *intern.Interner, isa_vt: *isa.IsaVT
     lc = tsec + SECTION_64_SIZE;
     li = 1;
     for (li < seg_count) {
-        val prot: u32 = vm_prot_for(segs[li].flags);
+        var prot: u32 = vm_prot_for(segs[li].flags);
+        # a PIE image rebases the absolute pointers in read-only const data, so that
+        # segment (__DATA_CONST) maps read-write for dyld's fixups and is re-protected
+        # read-only afterward via SG_READ_ONLY; without it dyld cannot slide the slots.
+        var seg_flags: u32 = 0;
+        if (pie && prot == VM_PROT_READ) {
+            prot = VM_PROT_READ | VM_PROT_WRITE;
+            seg_flags = SG_READ_ONLY;
+        }
         val zf:   bool = segs[li].filesz == 0 && segs[li].memsz > 0;
         var lsec: usize = write_segment_cmd(buf, lc, exec_segname(segs[li].flags), segs[li].vaddr,
                                bin.align_up_u64(segs[li].memsz::u64, EXEC_PAGE_SIZE),
                                seg_offsets[li]::u64, segs[li].filesz::u64, prot, prot, 1);
+        if (seg_flags != 0) { bin.write_u32_le(buf, lc + 68, seg_flags); }
         var soff: u32 = seg_offsets[li]::u32;
         if (zf) { soff = 0; }
         write_section_64(buf, lsec, dyn_sectname(segs[li].flags, zf), exec_segname(segs[li].flags),

--- a/src/lang/target/os.mach
+++ b/src/lang/target/os.mach
@@ -51,6 +51,18 @@ pub fun os_name_for(id: u32) str {
 # slot capacity of an OsVTable's ordered libdir list
 pub val OS_LIBDIR_MAX: u32 = 8;
 
+# a per-os position-independence policy, parameterized by architecture id
+#
+# Returns true when this OS requires main executables to be position-independent
+# (PIE) on the given architecture - e.g. Darwin on arm64, where the kernel refuses
+# to exec a non-PIE image. The linker reads it through the os vtable so the policy
+# lives with the OS (which owns the load-time contract) rather than as an id branch
+# in generic link code. A nil `pie_exec` means the OS never requires PIE.
+# ---
+# arg 0: the target architecture id (one of isa.ARCH_*)
+# ret:   true when a PIE main executable is required for that architecture
+pub def PieExecFn: fun(u32) bool;
+
 # the operating-system runtime-dispatch interface
 #
 # Exactly one of these exists per OS; the driver and linker read the entry
@@ -87,6 +99,9 @@ pub val OS_LIBDIR_MAX: u32 = 8;
 #                 reserved memory (Windows); false when the OS auto-grows the
 #                 stack on any in-range fault (Linux, Darwin) and a bare
 #                 `sub rsp, N` suffices
+# pie_exec:       per-architecture position-independence policy, or nil when the OS
+#                 never requires PIE; the linker uses a PIE layout + base-relocation
+#                 collection when it returns true for the target architecture
 pub rec OsVTable {
     id:             u32;
     name:           str;
@@ -98,6 +113,7 @@ pub rec OsVTable {
     base_addr:      u64;
     page_size:      u64;
     stack_probe:    bool;
+    pie_exec:       PieExecFn;
 }
 
 # maximum number of OS implementations an OsRegistry holds

--- a/src/lang/target/os.mach
+++ b/src/lang/target/os.mach
@@ -63,6 +63,18 @@ pub val OS_LIBDIR_MAX: u32 = 8;
 # ret:   true when a PIE main executable is required for that architecture
 pub def PieExecFn: fun(u32) bool;
 
+# a per-os segment page size policy, parameterized by architecture id
+#
+# Returns the virtual-memory page size the OS maps segments in for the given
+# architecture, when it varies by architecture (Darwin: 16 KiB on arm64, 4 KiB on
+# x86_64 - the kernel rejects a segment that is not page-aligned to it). The linker
+# aligns segment virtual addresses to it. A nil `page_size_for` means the OS uses
+# its fixed `page_size` for every architecture.
+# ---
+# arg 0: the target architecture id (one of isa.ARCH_*)
+# ret:   the segment page size in bytes for that architecture
+pub def PageSizeFn: fun(u32) u64;
+
 # the operating-system runtime-dispatch interface
 #
 # Exactly one of these exists per OS; the driver and linker read the entry
@@ -119,6 +131,7 @@ pub rec OsVTable {
     stack_probe:    bool;
     pie_exec:       PieExecFn;
     platform_lib:   str;
+    page_size_for:  PageSizeFn;
 }
 
 # maximum number of OS implementations an OsRegistry holds

--- a/src/lang/target/os.mach
+++ b/src/lang/target/os.mach
@@ -102,6 +102,10 @@ pub def PieExecFn: fun(u32) bool;
 # pie_exec:       per-architecture position-independence policy, or nil when the OS
 #                 never requires PIE; the linker uses a PIE layout + base-relocation
 #                 collection when it returns true for the target architecture
+# platform_lib:   the platform shared library a dyld-loaded executable implicitly
+#                 links (darwin's /usr/lib/libSystem.B.dylib), or "" when none; the
+#                 linker records it as an implicit dependency so the image is a valid
+#                 dynamic image (a dyld executable with no LC_LOAD_DYLIB is rejected)
 pub rec OsVTable {
     id:             u32;
     name:           str;
@@ -114,6 +118,7 @@ pub rec OsVTable {
     page_size:      u64;
     stack_probe:    bool;
     pie_exec:       PieExecFn;
+    platform_lib:   str;
 }
 
 # maximum number of OS implementations an OsRegistry holds

--- a/src/lang/target/os/darwin.mach
+++ b/src/lang/target/os/darwin.mach
@@ -17,6 +17,7 @@ use std.types.string.str;
 use R: std.types.result;
 
 use mach.lang.target.os;
+use isa: mach.lang.target.isa;
 
 # default base virtual address for Darwin executables (4 GiB). the first loadable
 # segment maps here; the linker assigns segment vaddrs upward from this value.
@@ -24,6 +25,16 @@ pub val DARWIN_BASE_ADDR: u64 = 0x100000000;
 
 # virtual-memory page size in bytes; segment vaddrs are page-aligned to it.
 pub val DARWIN_PAGE_SIZE: u64 = 4096;
+
+# Darwin requires position-independent (PIE) main executables on arm64 - the Apple
+# Silicon kernel refuses to exec a non-PIE image. x86_64 Darwin tolerates a fixed
+# image, so it stays on the non-PIE layout.
+# ---
+# arch_id: the target architecture id (one of isa.ARCH_*)
+# ret:     true for aarch64 (PIE required), false otherwise
+fun darwin_pie_exec(arch_id: u32) bool {
+    ret arch_id == isa.ARCH_AARCH64;
+}
 
 # the Darwin OS vtable. populated by register on first call and handed out as a
 # borrowed pointer to the registry; remains valid for the process lifetime.
@@ -58,6 +69,8 @@ pub fun register_darwin(reg: *os.OsRegistry) R.Result[bool, str] {
     # Darwin commits the thread stack up front and auto-grows the main thread; no
     # per-page probe needed.
     darwin_vtable.stack_probe    = false;
+    # arm64 Darwin requires PIE main executables; x86_64 does not.
+    darwin_vtable.pie_exec       = darwin_pie_exec;
 
     os.register(reg, ?darwin_vtable);
     ret R.ok[bool, str](true);

--- a/src/lang/target/os/darwin.mach
+++ b/src/lang/target/os/darwin.mach
@@ -71,6 +71,9 @@ pub fun register_darwin(reg: *os.OsRegistry) R.Result[bool, str] {
     darwin_vtable.stack_probe    = false;
     # arm64 Darwin requires PIE main executables; x86_64 does not.
     darwin_vtable.pie_exec       = darwin_pie_exec;
+    # a dyld-loaded Darwin executable implicitly links libSystem (the platform
+    # library); dyld rejects a dynamic image that names no LC_LOAD_DYLIB.
+    darwin_vtable.platform_lib   = "/usr/lib/libSystem.B.dylib";
 
     os.register(reg, ?darwin_vtable);
     ret R.ok[bool, str](true);

--- a/src/lang/target/os/darwin.mach
+++ b/src/lang/target/os/darwin.mach
@@ -36,6 +36,16 @@ fun darwin_pie_exec(arch_id: u32) bool {
     ret arch_id == isa.ARCH_AARCH64;
 }
 
+# Darwin maps memory in 16 KiB pages on arm64 (the Apple Silicon kernel rejects a
+# segment not aligned to it) and 4 KiB pages on x86_64.
+# ---
+# arch_id: the target architecture id (one of isa.ARCH_*)
+# ret:     the segment page size in bytes
+fun darwin_page_size(arch_id: u32) u64 {
+    if (arch_id == isa.ARCH_AARCH64) { ret 16384; }
+    ret DARWIN_PAGE_SIZE;
+}
+
 # the Darwin OS vtable. populated by register on first call and handed out as a
 # borrowed pointer to the registry; remains valid for the process lifetime.
 var darwin_vtable: os.OsVTable;
@@ -74,6 +84,8 @@ pub fun register_darwin(reg: *os.OsRegistry) R.Result[bool, str] {
     # a dyld-loaded Darwin executable implicitly links libSystem (the platform
     # library); dyld rejects a dynamic image that names no LC_LOAD_DYLIB.
     darwin_vtable.platform_lib   = "/usr/lib/libSystem.B.dylib";
+    # arm64 Darwin maps 16 KiB pages; segments must be aligned to them.
+    darwin_vtable.page_size_for  = darwin_page_size;
 
     os.register(reg, ?darwin_vtable);
     ret R.ok[bool, str](true);

--- a/test/macho/rebase/mach.toml
+++ b/test/macho/rebase/mach.toml
@@ -1,0 +1,24 @@
+[project]
+id = "machorebase"
+name = "machorebase"
+version = "0.0.0"
+src = "src"
+target = "darwin-aarch64"
+out = "out/{target}/{name}{ext}"
+obj = "out/{target}/obj"
+
+[target.darwin-x86_64]
+isa = "x86_64"
+os  = "darwin"
+abi = "sysv64"
+
+[target.darwin-aarch64]
+isa = "aarch64"
+os  = "darwin"
+abi = "aapcs64"
+
+[profile.debug]
+opt = 0
+
+[bin.machorebase]
+entry = "main.mach"

--- a/test/macho/rebase/src/main.mach
+++ b/test/macho/rebase/src/main.mach
@@ -1,0 +1,23 @@
+# freestanding darwin fixture exercising the PIE base-relocation (rebase) stream.
+#
+# each `?global` initializer is a 64-bit absolute pointer (RK_ABS64) stored in
+# __DATA. on the arm64 (PIE) Darwin target the linker collects these into the
+# base-relocation set and the Mach-O writer emits an LC_DYLD_INFO rebase stream so
+# dyld slides them by the load bias. the entry `start` is defined here directly (no
+# std runtime); the body dereferences the pointers so they are real references, and
+# exits. byte-verified, not run (Darwin binaries cannot run on the Linux CI host).
+
+var a: i64 = 11;
+var b: i64 = 22;
+var pa: *i64 = ?a;
+var pb: *i64 = ?b;
+
+#[symbol("start")]
+pub fun start() {
+    @pa = @pa + @pb;
+    asm aarch64 {
+        mov x0, 0
+        mov x16, 1        # SYS_exit
+        svc 0x80
+    }
+}

--- a/test/macho/verify.sh
+++ b/test/macho/verify.sh
@@ -202,12 +202,124 @@ verify_filename_independent() {
     echo "verified $target signed image is identical regardless of the -o name"
 }
 
-rm -rf out dynamic/out
-verify_static  darwin-x86_64  x86_64 x86_THREAD_STATE64 SIGNED
-verify_static  darwin-aarch64 arm64  ARM_THREAD_STATE64 PAGE21 PAGOF12 BR26
-verify_dynamic darwin-x86_64  x86_64
-verify_dynamic darwin-aarch64 arm64
+# verify_pie <target> <machine> <reloc>...
+#
+# cross-compiles the static fixture for a target whose main executables must be
+# position-independent (arm64 Darwin: the Apple Silicon kernel refuses a non-PIE
+# image), so the linker routes it through the dynamic/PIE writer even with no shared
+# dependency. checks the relocatable object, then the PIE executable shape: MH_PIE,
+# an LC_MAIN entry, LC_LOAD_DYLINKER, LC_BUILD_VERSION, LC_UUID, and no LC_UNIXTHREAD.
+verify_pie() {
+    local target="$1" machine="$2"; shift 2
+    local exe="out/$target/machoprobe"
+
+    echo "cross-compiling PIE fixture for $target with $mach"
+    "$mach" build . --target "$target" --profile debug
+    local obj
+    obj="$(find "out/$target/obj" -name '*.o' -print -quit)"
+    [ -n "$obj" ] || fail "$target: no object emitted"
+
+    echo "verifying $target object $obj"
+    file "$obj" | grep -q "Mach-O 64-bit $machine object" || fail "$target: object is not a Mach-O $machine object"
+    "$objdump" --macho -t "$obj" | grep -qw 'start'       || fail "$target: object missing the 'start' entry symbol"
+
+    local dis
+    dis="$("$objdump" --macho -d "$obj")"
+    if echo "$dis" | grep -qi 'unknown'; then fail "$target: object disassembly has an unknown instruction"; fi
+
+    local rel
+    rel="$("$objdump" --macho -r "$obj")"
+    local r
+    for r in "$@"; do
+        echo "$rel" | grep -q "$r" || fail "$target: expected relocation '$r' not emitted"
+    done
+
+    echo "verifying $target PIE executable $exe"
+    file "$exe" | grep -q "Mach-O 64-bit $machine executable" || fail "$target: not a Mach-O $machine executable"
+    file "$exe" | grep -q 'PIE'                               || fail "$target: executable is not MH_PIE"
+    local lc
+    lc="$("$otool" -l "$exe")"
+    echo "$lc" | grep -q '__PAGEZERO'       || fail "$target: PIE exe missing __PAGEZERO"
+    echo "$lc" | grep -q '__TEXT'           || fail "$target: PIE exe missing __TEXT segment"
+    echo "$lc" | grep -q '__LINKEDIT'       || fail "$target: PIE exe missing __LINKEDIT segment"
+    echo "$lc" | grep -q 'LC_MAIN'          || fail "$target: PIE exe missing LC_MAIN entry"
+    echo "$lc" | grep -q 'LC_LOAD_DYLINKER' || fail "$target: PIE exe missing LC_LOAD_DYLINKER"
+    echo "$lc" | grep -q '/usr/lib/dyld'    || fail "$target: PIE exe dylinker is not /usr/lib/dyld"
+    echo "$lc" | grep -q 'LC_BUILD_VERSION' || fail "$target: PIE exe missing LC_BUILD_VERSION"
+    echo "$lc" | grep -q 'LC_UUID'          || fail "$target: PIE exe missing LC_UUID"
+    echo "$lc" | grep -q 'LC_DYLD_INFO'     || fail "$target: PIE exe missing LC_DYLD_INFO"
+    if echo "$lc" | grep -q 'LC_UNIXTHREAD'; then fail "$target: PIE exe must not carry LC_UNIXTHREAD"; fi
+
+    verify_codesig "$target" "$exe"
+}
+
+# verify_pie_dynamic <target> <machine>
+#
+# cross-compiles the dynamic fixture for a PIE target: it carries a libprobe.dylib
+# dependency and a `probe_add` import, so the PIE writer must combine the rebase/bind
+# dyld-info streams - MH_PIE + LC_MAIN with a real LC_LOAD_DYLIB, bind record, and
+# import stub.
+verify_pie_dynamic() {
+    local target="$1" machine="$2"
+    local exe="dynamic/out/$target/machodyn"
+
+    echo "cross-compiling dynamic PIE fixture for $target with $mach"
+    "$mach" build dynamic --target "$target" --profile debug
+
+    echo "verifying $target dynamic PIE executable $exe"
+    file "$exe" | grep -q "Mach-O 64-bit $machine executable" || fail "$target: not a Mach-O $machine executable"
+    file "$exe" | grep -q 'PIE'                               || fail "$target: dyn PIE exe is not MH_PIE"
+
+    local lc
+    lc="$("$otool" -l "$exe")"
+    echo "$lc" | grep -q 'LC_MAIN'           || fail "$target: dyn PIE exe missing LC_MAIN"
+    echo "$lc" | grep -q 'LC_BUILD_VERSION'  || fail "$target: dyn PIE exe missing LC_BUILD_VERSION"
+    echo "$lc" | grep -q 'LC_DYLD_INFO'      || fail "$target: dyn PIE exe missing LC_DYLD_INFO"
+    echo "$lc" | grep -q 'LC_LOAD_DYLINKER'  || fail "$target: dyn PIE exe missing LC_LOAD_DYLINKER"
+    echo "$lc" | grep -q 'LC_LOAD_DYLIB'     || fail "$target: dyn PIE exe missing LC_LOAD_DYLIB"
+    if echo "$lc" | grep -q 'LC_UNIXTHREAD'; then fail "$target: dyn PIE exe must not carry LC_UNIXTHREAD"; fi
+
+    "$otool" -L "$exe" | grep -q 'libprobe.dylib' || fail "$target: dyn PIE exe does not link libprobe.dylib"
+    "$objdump" --macho -t "$exe"     | grep -q 'probe_add' || fail "$target: dyn PIE exe missing the probe_add import symbol"
+    "$objdump" --macho --bind "$exe" | grep -q 'probe_add' || fail "$target: dyn PIE exe has no bind record for probe_add"
+    "$otool" -l "$exe" | grep -q '__stubs' || fail "$target: dyn PIE exe missing the __stubs section"
+
+    verify_codesig "$target" "$exe"
+}
+
+# verify_rebase <target>
+#
+# cross-compiles the rebase fixture (globals initialized to the address of other
+# globals, so __DATA holds absolute pointers) for a PIE target and asserts the
+# emitted LC_DYLD_INFO rebase stream names the __DATA pointer slots and resolves to
+# the right addresses (llvm-objdump --rebase decodes the opcode stream).
+verify_rebase() {
+    local target="$1"
+    local exe="rebase/out/$target/machorebase"
+
+    echo "cross-compiling rebase fixture for $target with $mach"
+    "$mach" build rebase --target "$target" --profile debug
+
+    echo "verifying $target rebase stream in $exe"
+    file "$exe" | grep -q 'PIE' || fail "$target: rebase exe is not MH_PIE"
+    local rb
+    rb="$("$objdump" --macho --rebase "$exe")"
+    echo "$rb" | grep -q '__DATA' || fail "$target: rebase table has no __DATA entries"
+    local n
+    n="$(echo "$rb" | grep -c 'pointer')"
+    [ "$n" -ge 2 ] || fail "$target: expected at least 2 rebased pointers, got $n"
+
+    verify_codesig "$target" "$exe"
+}
+
+rm -rf out dynamic/out rebase/out
+verify_static      darwin-x86_64  x86_64 x86_THREAD_STATE64 SIGNED
+verify_pie         darwin-aarch64 arm64  PAGE21 PAGOF12 BR26
+verify_dynamic     darwin-x86_64  x86_64
+verify_pie_dynamic darwin-aarch64 arm64
+verify_rebase      darwin-aarch64
 verify_filename_independent .       darwin-aarch64
 verify_filename_independent dynamic darwin-aarch64
+verify_filename_independent rebase  darwin-aarch64
 
-echo "OK: Mach-O emits correct objects and ad-hoc-signed static + dynamic executables for both Darwin triples"
+echo "OK: Mach-O emits correct objects, x86_64 static/dynamic execs, and arm64 PIE execs (LC_MAIN + rebase) for both Darwin triples"


### PR DESCRIPTION
Closes #1718's investigation child via #1722 — makes mach emit position-independent arm64 Darwin executables so they exec on Apple Silicon. Pairs with mach-std #325 (the arm64 `LC_MAIN` entry).

## Why
#1718 proved on `macos-14` that the kernel refuses a non-PIE arm64 main executable (`-no_pie ignored for arm64`); mach emitted a non-PIE fixed-address image, so its arm64 binaries were `Killed: 9`. The investigation ruled out the expensive alternatives: raw `svc` works, classic `LC_DYLD_INFO` rebase is accepted (no chained fixups), and no libSystem dependency is needed. So the fix is "emit a genuine PIE image".

## What
- **Linker (format-neutral):** a new `of.BaseReloc` set on `of.DynamicInfo` — the in-image absolute pointers a position-independent image must slide (the same concept ELF `.rela.dyn` / PE `.reloc` encode). The linker collects each in-image `RK_ABS64` pointer relocation as a base relocation when the target requires PIE. The per-arch PIE policy lives on the OS vtable (`darwin`: arm64 yes, x86_64 no), so the linker never branches on ids; a PIE target routes through the dynamic writer even with zero dylibs and reserves a one-page header gap so `__TEXT` maps at the OS base. The `of.WriterFn` boundary is unchanged — each format serializes the set its own way (only Mach-O here; ELF/PE are future ASLR work).
- **Mach-O writer:** when `dyn.pie`, emit `MH_PIE`, the mach header at `0x100000000` (`__PAGEZERO = [0, base)`), an `LC_MAIN` file-offset entry, `LC_BUILD_VERSION`(macOS) + a deterministic name-based `LC_UUID`, and the `LC_DYLD_INFO` rebase stream (classic `REBASE_OPCODE_*`, sorted for a byte-identical fixpoint). The ad-hoc signature (#1679) and header-in-`__TEXT` (#1717) are preserved. Non-PIE (x86_64 darwin) output is byte-for-byte unchanged.
- **mach-std #325:** the darwin arm64 `_start` reads `argc/argv/envp` from `x0/x1/x2` (the `LC_MAIN` register ABI); raw `svc` retained.

## Validation
- **Off-Mac (this PR's CI):** `test/macho/verify.sh` byte-verifies the new arm64 PIE shape (`MH_PIE`, `LC_MAIN`, `LC_BUILD_VERSION`, `LC_UUID`, no `LC_UNIXTHREAD`) for the import-less and dynamic fixtures, and a new rebase fixture asserts `llvm-objdump --rebase` resolves the `__DATA` pointer slots. x86_64 unchanged. Linux self-host fixpoint stays byte-identical (`b == c`); all 686 in-source tests pass.
- **On-Mac (`macos-14`):** the exec proof (no `Killed: 9`, native `a→b→c` fixpoint, `mach test .`) is run via a dispatch and reported on the issue — see #1718.

## Merge coupling
Depends on mach-std #325 (the `LC_MAIN` entry). `mach.toml`/`mach.lock` stay on `branch/main` here (clean; CI's freestanding darwin fixtures don't need the runtime); **before this lands, bump `mach.lock` to the merged mach-std commit** carrying #324.
