### PR TITLE
fix(abi): shared register/stack-split + mixed-class aggregate slot primitive

### DIFF
--- a/src/lang/be/codegen/mir/abi.mach
+++ b/src/lang/be/codegen/mir/abi.mach
@@ -701,8 +701,11 @@ pub fun lower_call(ctx: *context.LowerCtx, mb: *mir.MirBlock, inst: *instruction
             slot = classify_arg(pidx::i32, asz, aal, afl, 0, aag, gp_used, fp_used, 0, 0);
             # round a stack-passed tail argument up to its slot alignment before
             # placing it (identity on x86; honors a 16-aligned AAPCS64 by-value arg).
+            # a register-plus-stack split's tail stack chunk is eight-byte-granular.
             if (slot.class == abi.CLASS_STACK || slot.class == abi.CLASS_STACK_BYREF) {
                 stack_off = round_up_i64(stack_off, stack_arg_align(slot.class, aal));
+            } or (slot_has_stack_piece(?slot)) {
+                stack_off = round_up_i64(stack_off, 8);
             }
             soff = stack_off;
         }
@@ -751,6 +754,10 @@ pub fun lower_call(ctx: *context.LowerCtx, mb: *mir.MirBlock, inst: *instruction
                 stack_off = stack_off + context.stack_slot_bytes(slot.size);
             } or {
                 advance_arg_cursors(?slot, ?gp_used, ?fp_used);
+                # a split tail also consumes its stack chunk's outgoing slot.
+                if (slot_has_stack_piece(?slot)) {
+                    stack_off = stack_off + split_stack_bytes(?slot);
+                }
             }
         }
 

--- a/src/lang/be/codegen/mir/abi.mach
+++ b/src/lang/be/codegen/mir/abi.mach
@@ -327,7 +327,9 @@ fun agg_flatten(ctx: *context.LowerCtx, ty: type.IrTypeId, base_off: u64,
                 out: *abi.AggLayout, count: u32) u32 {
     if (count > AGG_MAX_LEAVES) { ret count; }
     val it: O.Option[*type.IrType] = type.get(ctx.types, ty);
-    if (!O.is_some[*type.IrType](it)) { ret count + 1; }
+    # an unresolvable type has no known leaf to record; poison the walk past the cap so
+    # the caller rejects the whole aggregate (it falls to the integer convention).
+    if (!O.is_some[*type.IrType](it)) { ret AGG_MAX_LEAVES + 1; }
     val t: *type.IrType = O.unwrap[*type.IrType](it);
 
     if (t.kind == type.IRT_STRUCT) {
@@ -337,6 +339,7 @@ fun agg_flatten(ctx: *context.LowerCtx, ty: type.IrTypeId, base_off: u64,
             val fid: type.IrTypeId = t.data.struct_.fields[i];
             val fo:  u64 = type.byte_offset(ctx.types, ty, i, ctx.tgt)::u64;
             c = agg_flatten(ctx, fid, base_off + fo, out, c);
+            if (c > AGG_MAX_LEAVES) { ret c; }
             i = i + 1;
         }
         ret c;
@@ -349,6 +352,7 @@ fun agg_flatten(ctx: *context.LowerCtx, ty: type.IrTypeId, base_off: u64,
         var i: u32 = 0;
         for (i < n) {
             c = agg_flatten(ctx, elem, base_off + i::u64 * es, out, c);
+            if (c > AGG_MAX_LEAVES) { ret c; }
             i = i + 1;
         }
         ret c;
@@ -378,13 +382,14 @@ fun agg_flatten(ctx: *context.LowerCtx, ty: type.IrTypeId, base_off: u64,
 # convention). Only the lp64d classifier acts on it; the other conventions ignore
 # it, as they do the HFA descriptor.
 # ---
-# ctx: the active lowering context (supplies the IR type oracle and target)
-# ty:  the type to describe
-# ret: the flattened-aggregate descriptor (field_count 0 when not applicable)
-fun agg_layout(ctx: *context.LowerCtx, ty: type.IrTypeId) abi.AggLayout {
+# ctx:     the active lowering context (supplies the IR type oracle and target)
+# ty:      the type to describe
+# is_aggr: whether `ty` is an aggregate (the caller already computed it)
+# ret:     the flattened-aggregate descriptor (field_count 0 when not applicable)
+fun agg_layout(ctx: *context.LowerCtx, ty: type.IrTypeId, is_aggr: bool) abi.AggLayout {
     var out: abi.AggLayout;
     out.field_count = 0;
-    if (!context.value_is_aggregate(ctx, ty)) { ret out; }
+    if (!is_aggr) { ret out; }
     val c: u32 = agg_flatten(ctx, ty, 0, ?out, 0);
     if (c == 1 || c == 2) { out.field_count = c::u8; }
     ret out;
@@ -555,7 +560,7 @@ pub fun classify_signature(ctx: *context.LowerCtx, sig: type.IrTypeId, ret_type:
     var ret_hm:    u8   = 0;
     var ret_he:    u8   = 0;
     hfa_info(ctx, ret_type, ?ret_hm, ?ret_he);
-    out.ret_slot = classify_ret(ret_size, 0, ret_float, ret_eb, ret_aggr, ret_hm, ret_he, agg_layout(ctx, ret_type));
+    out.ret_slot = classify_ret(ret_size, 0, ret_float, ret_eb, ret_aggr, ret_hm, ret_he, agg_layout(ctx, ret_type, ret_aggr));
 
     var gp_used:   i32 = 0;
     var fp_used:   i32 = 0;
@@ -609,7 +614,7 @@ pub fun classify_signature(ctx: *context.LowerCtx, sig: type.IrTypeId, ret_type:
         var phm:  u8   = 0;
         var phe:  u8   = 0;
         hfa_info(ctx, pty, ?phm, ?phe);
-        var slot: abi.ParamSlot = classify_arg(i::i32, psz, pal, pfl, peb, pag, gp_used, fp_used, phm, phe, agg_layout(ctx, pty));
+        var slot: abi.ParamSlot = classify_arg(i::i32, psz, pal, pfl, peb, pag, gp_used, fp_used, phm, phe, agg_layout(ctx, pty, pag));
 
         # record the real outgoing stack offset on the slot (the ABI classifier
         # returns a sizing-only slot with offset 0); the param / call lowering
@@ -1007,8 +1012,8 @@ fun emit_arg_slot(ctx: *context.LowerCtx, mb: *mir.MirBlock, slot: abi.ParamSlot
         for (i < slot.piece_count) {
             val p: abi.ParamPiece = slot.pieces[i];
             if (p.kind == abi.PIECE_GP) {
-                val mr: R.Result[bool, str] = context.emit_mov(ctx, mb,
-                    mir.op_preg(p.reg::u32), mir.op_mem_value(base, p.src_off));
+                val mr: R.Result[bool, str] = context.emit_mov_w(ctx, mb,
+                    mir.op_preg(p.reg::u32), mir.op_mem_value(base, p.src_off), p.width);
                 if (R.is_err[bool, str](mr)) { ret mr; }
             } or (p.kind == abi.PIECE_FP) {
                 val mr: R.Result[bool, str] = context.emit_fmov(ctx, mb,
@@ -1094,8 +1099,8 @@ fun emit_ret_slot_to_vreg(ctx: *context.LowerCtx, mb: *mir.MirBlock, slot: abi.P
         for (i < slot.piece_count) {
             val p: abi.ParamPiece = slot.pieces[i];
             if (p.kind == abi.PIECE_GP) {
-                val st: R.Result[bool, str] = context.emit_store_to(ctx, mb,
-                    mir.op_mem_value(dst, p.src_off), mir.op_preg(p.reg::u32));
+                val st: R.Result[bool, str] = context.emit_store_to_w(ctx, mb,
+                    mir.op_mem_value(dst, p.src_off), mir.op_preg(p.reg::u32), p.width);
                 if (R.is_err[bool, str](st)) { ret st; }
             } or (p.kind == abi.PIECE_FP) {
                 val st: R.Result[bool, str] = context.emit_store_to_w(ctx, mb,
@@ -1240,8 +1245,8 @@ fun emit_param_slot(ctx: *context.LowerCtx, mb: *mir.MirBlock, slot: abi.ParamSl
         for (i < slot.piece_count) {
             val p: abi.ParamPiece = slot.pieces[i];
             if (p.kind == abi.PIECE_GP) {
-                val st: R.Result[bool, str] = context.emit_store_to(ctx, mb,
-                    mir.op_mem_slot(pv, p.src_off), mir.op_preg(p.reg::u32));
+                val st: R.Result[bool, str] = context.emit_store_to_w(ctx, mb,
+                    mir.op_mem_slot(pv, p.src_off), mir.op_preg(p.reg::u32), p.width);
                 if (R.is_err[bool, str](st)) { ret st; }
             } or (p.kind == abi.PIECE_FP) {
                 val st: R.Result[bool, str] = context.emit_store_to_w(ctx, mb,
@@ -1332,8 +1337,8 @@ pub fun lower_ret(ctx: *context.LowerCtx, mb: *mir.MirBlock, inst: *instruction.
         for (i < slot.piece_count) {
             val p: abi.ParamPiece = slot.pieces[i];
             if (p.kind == abi.PIECE_GP) {
-                val mr: R.Result[bool, str] = context.emit_mov(ctx, mb,
-                    mir.op_preg(p.reg::u32), mir.op_mem_value(base, p.src_off));
+                val mr: R.Result[bool, str] = context.emit_mov_w(ctx, mb,
+                    mir.op_preg(p.reg::u32), mir.op_mem_value(base, p.src_off), p.width);
                 if (R.is_err[bool, str](mr)) { ret mr; }
             } or (p.kind == abi.PIECE_FP) {
                 val mr: R.Result[bool, str] = context.emit_fmov(ctx, mb,

--- a/src/lang/be/codegen/mir/abi.mach
+++ b/src/lang/be/codegen/mir/abi.mach
@@ -303,6 +303,93 @@ fun hfa_info(ctx: *context.LowerCtx, ty: type.IrTypeId, out_members: *u8, out_el
     @out_elem    = elem::u8;
 }
 
+# the most scalar leaves `agg_layout` records before rejecting an aggregate as
+# non-flattenable (the lp64d mixed / float-pair rules act on at most two leaves).
+val AGG_MAX_LEAVES: u32 = 2;
+
+# flatten the scalar leaves of `ty` into `out`, returning the running leaf count
+#
+# Recurses from absolute byte offset `base_off`, recording each IRT_FLOAT leaf as a
+# float field and each integer / pointer / function leaf as a non-float field, in
+# offset order: a struct recurses at each field offset, an array at each element
+# offset. A union cannot flatten to offset-ordered leaves (its members overlap), so
+# it poisons the walk by returning a count past the cap. Once more than two leaves
+# are seen the walk only counts (it records no further fields), so the caller can
+# reject the aggregate.
+# ---
+# ctx:      the active lowering context (supplies the IR type oracle and target)
+# ty:       the type whose leaves are flattened
+# base_off: the type's absolute byte offset within the enclosing aggregate
+# out:      the descriptor whose `fields` receive the first two leaves
+# count:    the running leaf count before this type's leaves
+# ret:      the running leaf count after this type's leaves (> 2 when non-flattenable)
+fun agg_flatten(ctx: *context.LowerCtx, ty: type.IrTypeId, base_off: u64,
+                out: *abi.AggLayout, count: u32) u32 {
+    if (count > AGG_MAX_LEAVES) { ret count; }
+    val it: O.Option[*type.IrType] = type.get(ctx.types, ty);
+    if (!O.is_some[*type.IrType](it)) { ret count + 1; }
+    val t: *type.IrType = O.unwrap[*type.IrType](it);
+
+    if (t.kind == type.IRT_STRUCT) {
+        var c: u32 = count;
+        var i: u32 = 0;
+        for (i < t.data.struct_.field_count) {
+            val fid: type.IrTypeId = t.data.struct_.fields[i];
+            val fo:  u64 = type.byte_offset(ctx.types, ty, i, ctx.tgt)::u64;
+            c = agg_flatten(ctx, fid, base_off + fo, out, c);
+            i = i + 1;
+        }
+        ret c;
+    }
+    if (t.kind == type.IRT_ARRAY) {
+        val elem: type.IrTypeId = t.data.array_.element;
+        val es:   u64 = type.byte_size(ctx.types, elem, ctx.tgt)::u64;
+        val n:    u32 = type.array_count(ctx.types, ty);
+        var c: u32 = count;
+        var i: u32 = 0;
+        for (i < n) {
+            c = agg_flatten(ctx, elem, base_off + i::u64 * es, out, c);
+            i = i + 1;
+        }
+        ret c;
+    }
+    if (t.kind == type.IRT_UNION) {
+        # a union's members overlap, so it has no offset-ordered leaf flattening;
+        # poison the walk past the cap so the caller rejects the whole aggregate.
+        ret AGG_MAX_LEAVES + 1;
+    }
+
+    # a scalar leaf: record it when still within the cap, then count it.
+    if (count < AGG_MAX_LEAVES) {
+        out.fields[count].is_float = t.kind == type.IRT_FLOAT;
+        out.fields[count].offset   = base_off::u32;
+        out.fields[count].width    = type.byte_size(ctx.types, ty, ctx.tgt)::u8;
+    }
+    ret count + 1;
+}
+
+# the <=2-leaf flattened-aggregate descriptor for a type
+#
+# Flattens an aggregate's scalar leaves in offset order, capped at two, for the
+# lp64d mixed float-plus-integer and different-width float-pair rules. Reports
+# field_count 1 or 2 with the leaves filled for a one- or two-leaf struct / array
+# aggregate; field_count 0 for a non-aggregate, a union, an empty aggregate, or an
+# aggregate of more than two leaves (each of which falls to the integer
+# convention). Only the lp64d classifier acts on it; the other conventions ignore
+# it, as they do the HFA descriptor.
+# ---
+# ctx: the active lowering context (supplies the IR type oracle and target)
+# ty:  the type to describe
+# ret: the flattened-aggregate descriptor (field_count 0 when not applicable)
+fun agg_layout(ctx: *context.LowerCtx, ty: type.IrTypeId) abi.AggLayout {
+    var out: abi.AggLayout;
+    out.field_count = 0;
+    if (!context.value_is_aggregate(ctx, ty)) { ret out; }
+    val c: u32 = agg_flatten(ctx, ty, 0, ?out, 0);
+    if (c == 1 || c == 2) { out.field_count = c::u8; }
+    ret out;
+}
+
 # advance the GP / FP argument-register cursors past a register-passed slot
 #
 # Walks the slot's placement pieces and advances the bank cursor of each register
@@ -468,7 +555,7 @@ pub fun classify_signature(ctx: *context.LowerCtx, sig: type.IrTypeId, ret_type:
     var ret_hm:    u8   = 0;
     var ret_he:    u8   = 0;
     hfa_info(ctx, ret_type, ?ret_hm, ?ret_he);
-    out.ret_slot = classify_ret(ret_size, 0, ret_float, ret_eb, ret_aggr, ret_hm, ret_he);
+    out.ret_slot = classify_ret(ret_size, 0, ret_float, ret_eb, ret_aggr, ret_hm, ret_he, agg_layout(ctx, ret_type));
 
     var gp_used:   i32 = 0;
     var fp_used:   i32 = 0;
@@ -522,7 +609,7 @@ pub fun classify_signature(ctx: *context.LowerCtx, sig: type.IrTypeId, ret_type:
         var phm:  u8   = 0;
         var phe:  u8   = 0;
         hfa_info(ctx, pty, ?phm, ?phe);
-        var slot: abi.ParamSlot = classify_arg(i::i32, psz, pal, pfl, peb, pag, gp_used, fp_used, phm, phe);
+        var slot: abi.ParamSlot = classify_arg(i::i32, psz, pal, pfl, peb, pag, gp_used, fp_used, phm, phe, agg_layout(ctx, pty));
 
         # record the real outgoing stack offset on the slot (the ABI classifier
         # returns a sizing-only slot with offset 0); the param / call lowering
@@ -693,12 +780,13 @@ pub fun lower_call(ctx: *context.LowerCtx, mb: *mir.MirBlock, inst: *instruction
         } or {
             val aal: u64  = type.byte_align(ctx.types, av.ty, ctx.tgt)::u64;
             val afl: bool = context.value_is_float(ctx, av.ty);
-            # a variadic tail aggregate is classified as integer eightbytes (mask 0)
-            # and never as an HFA (members 0): the va_arg read path walks the GP
-            # register-save / overflow areas, so the caller and callee stay
-            # consistent. SSE-eightbyte and HFA V-register passing are for fixed
-            # parameters and returns (the C-FFI boundary), not the varargs tail.
-            slot = classify_arg(pidx::i32, asz, aal, afl, 0, aag, gp_used, fp_used, 0, 0);
+            # a variadic tail aggregate is classified as integer eightbytes (mask 0),
+            # never as an HFA (members 0), and with no flattened-aggregate descriptor
+            # (agg_none): the va_arg read path walks the GP register-save / overflow
+            # areas, so the caller and callee stay consistent. SSE-eightbyte, HFA
+            # V-register, and lp64d fa-register passing are for fixed parameters and
+            # returns (the C-FFI boundary), not the varargs tail.
+            slot = classify_arg(pidx::i32, asz, aal, afl, 0, aag, gp_used, fp_used, 0, 0, abi.agg_none());
             # round a stack-passed tail argument up to its slot alignment before
             # placing it (identity on x86; honors a 16-aligned AAPCS64 by-value arg).
             # a register-plus-stack split's tail stack chunk is eight-byte-granular.

--- a/src/lang/be/codegen/mir/abi.mach
+++ b/src/lang/be/codegen/mir/abi.mach
@@ -303,53 +303,65 @@ fun hfa_info(ctx: *context.LowerCtx, ty: type.IrTypeId, out_members: *u8, out_el
     @out_elem    = elem::u8;
 }
 
-# the physical V register for member `i` of a CLASS_HFA run
+# advance the GP / FP argument-register cursors past a register-passed slot
 #
-# The i-th register above the run's base (`slot.reg`), used to place each HFA member
-# into its consecutive argument / return register.
+# Walks the slot's placement pieces and advances the bank cursor of each register
+# chunk: a PIECE_GP consumes one GP register, a PIECE_FP one FP register, and a
+# PIECE_STACK (a register-plus-stack split's tail) consumes neither. This covers a
+# scalar, a by-reference pointer, a two-register pair, a CLASS_HFA run, a mixed
+# GP / FP aggregate, and a split uniformly, since every placement carries its pieces.
 # ---
-# base_reg: the run's base V register id
-# i:        zero-based member index within the run
-# ret:      the physical V register id for member `i`
-fun hfa_member_reg(base_reg: i32, i: u32) i32 {
-    ret isa.regid_make(isa.REG_CLASS_ID_XMM, isa.regid_index(base_reg) + i::i32);
-}
-
-# advance the GP or FP argument-register cursor for one assigned register
-#
-# Dispatches on the register's bank (the composite id encodes it). A negative id
-# (no register) advances neither, so a register aggregate's GP and SSE eightbytes
-# each consume from the right file.
-# ---
-# reg:     the assigned physical register id, or negative for none
-# gp_used: the running GP argument-register cursor, advanced in place
-# fp_used: the running FP argument-register cursor, advanced in place
-fun advance_one_cursor(reg: i32, gp_used: *i32, fp_used: *i32) {
-    if (reg < 0) { ret; }
-    if (isa.regid_class(reg) == isa.REG_CLASS_ID_XMM) {
-        @fp_used = @fp_used + 1;
-    } or {
-        @gp_used = @gp_used + 1;
-    }
-}
-
-# advance the GP / FP cursors for a register-passed slot by the bank of each register
-#
-# A scalar, a by-reference pointer, and a mixed GP/SSE aggregate each consume their
-# correct registers (`reg` and, for a two-register aggregate, `reg2`). A CLASS_HFA
-# run consumes `reg_count` consecutive V registers from the FP bank. Stack slots
-# carry no register and advance neither.
-# ---
-# slot:    the classified slot whose registers are consumed
+# slot:    the classified slot whose register chunks are consumed
 # gp_used: the running GP argument-register cursor, advanced in place
 # fp_used: the running FP argument-register cursor, advanced in place
 fun advance_arg_cursors(slot: *abi.ParamSlot, gp_used: *i32, fp_used: *i32) {
-    if (slot.class == abi.CLASS_HFA) {
-        @fp_used = @fp_used + slot.reg_count::i32;
-        ret;
+    var i: u32 = 0;
+    for (i < slot.piece_count) {
+        val k: abi.PieceKind = slot.pieces[i].kind;
+        if (k == abi.PIECE_GP) {
+            @gp_used = @gp_used + 1;
+        } or (k == abi.PIECE_FP) {
+            @fp_used = @fp_used + 1;
+        }
+        i = i + 1;
     }
-    advance_one_cursor(slot.reg, gp_used, fp_used);
-    advance_one_cursor(slot.reg2, gp_used, fp_used);
+}
+
+# whether a slot carries a register-plus-stack split's stack chunk
+#
+# True for a placement with a PIECE_STACK chunk (the RISC-V lp64d 9-16 byte aggregate
+# that rides its last integer register plus an outgoing stack slot); the signature
+# walk assigns and advances the outgoing offset of such a chunk in addition to
+# advancing the register banks for the slot's register chunks.
+# ---
+# slot: the classified slot
+# ret:  true when any piece is PIECE_STACK
+fun slot_has_stack_piece(slot: *abi.ParamSlot) bool {
+    var i: u32 = 0;
+    for (i < slot.piece_count) {
+        if (slot.pieces[i].kind == abi.PIECE_STACK) { ret true; }
+        i = i + 1;
+    }
+    ret false;
+}
+
+# the outgoing stack bytes a split slot's stack chunk(s) consume
+#
+# Each PIECE_STACK chunk occupies an eight-byte-granular outgoing slot sized from its
+# byte width; the sum is the slot's stack footprint above its register chunks.
+# ---
+# slot: the classified slot
+# ret:  the outgoing stack bytes the slot's stack chunks consume
+fun split_stack_bytes(slot: *abi.ParamSlot) i64 {
+    var total: i64 = 0;
+    var i: u32 = 0;
+    for (i < slot.piece_count) {
+        if (slot.pieces[i].kind == abi.PIECE_STACK) {
+            total = total + context.stack_slot_bytes(slot.pieces[i].width::u64);
+        }
+        i = i + 1;
+    }
+    ret total;
 }
 
 # whether a CLASS_SRET return reserves the first GP argument register
@@ -527,6 +539,14 @@ pub fun classify_signature(ctx: *context.LowerCtx, sig: type.IrTypeId, ret_type:
             stack_off   = stack_off + context.stack_slot_bytes(slot.size);
         } or {
             advance_arg_cursors(?slot, ?gp_used, ?fp_used);
+            # a register-plus-stack split also reserves an outgoing stack slot for its
+            # stack chunk: assign the running offset as the chunk's stack base and
+            # advance past it (eight-byte-granular), so the next argument clears it.
+            if (slot_has_stack_piece(?slot)) {
+                stack_off   = round_up_i64(stack_off, 8);
+                slot.offset = stack_off;
+                stack_off   = stack_off + split_stack_bytes(?slot);
+            }
         }
 
         slots[i] = slot;
@@ -824,45 +844,31 @@ fun lower_value_addr(ctx: *context.LowerCtx, mb: *mir.MirBlock, v: value.Value) 
 
 # emit the pre-coloring move(s) placing one classified argument
 #
-# A GP/FP register argument moves the value into the argument register (a 9-16 byte
-# aggregate in two GP registers moves each half from `[base+0]` / `[base+8]`); a
-# BYREF argument moves the aggregate's address into the register; a STACK argument
-# stores the value at `[sp + stack_off]`. A by-value stack aggregate (CLASS_STACK)
-# copies its bytes to the outgoing slot; a by-reference stack spill
-# (CLASS_STACK_BYREF, the win64 exhausted-slot case) stores only the pointer, the
-# stack analog of BYREF. A CLASS_HFA argument loads each member from
-# `[base + i*reg_width]` into its consecutive V argument register.
+# A BYREF argument moves the aggregate's address into the register; a STACK argument
+# stores the value at `[sp + stack_off]` (a by-value aggregate copies its bytes, a
+# scalar stores its word); a by-reference stack spill (CLASS_STACK_BYREF, the win64
+# exhausted-slot case) stores only the pointer, the stack analog of BYREF. Every
+# other aggregate -- a single register, a two-register pair, a CLASS_HFA run, a mixed
+# GP / FP aggregate, or a register-plus-stack split -- is placed piece by piece: each
+# register chunk loads from `[storage + src_off]` into its GP register (a full-word
+# MOV) or FP register (a `width`-byte SSE move), and a split's PIECE_STACK chunk loads
+# its word from storage and stores it at `[sp + stack_off + stk_off]`. A scalar argop
+# is the value itself, placed directly into its register.
 #
 # An aggregate argop is a pointer to the aggregate's storage (aggregates flow by
-# address), normalized through `context.addr_to_vreg` so the two-register /
-# by-reference forms index a register pointer base; a scalar argop is the value
-# itself, placed directly.
+# address), normalized through `context.addr_to_vreg` so the piece loads index a
+# register pointer base.
 # ---
 # ctx:       the active lowering context
 # mb:        the MIR block the move(s) are appended to
 # slot:      the argument's classified slot
 # argop:     the lowered argument operand (a storage pointer for an aggregate)
-# stack_off: the running outgoing-argument offset for a STACK slot
+# stack_off: the slot's outgoing stack base (a STACK slot, or a split's stack chunk)
 # is_aggr:   whether the argument is an aggregate flowing by address
 # size:      the argument's byte size (the copy length for a by-value aggregate)
 # ret:       ok(true) on success, or a loud error
 fun emit_arg_slot(ctx: *context.LowerCtx, mb: *mir.MirBlock, slot: abi.ParamSlot, argop: mir.MirOperand,
                   stack_off: i64, is_aggr: bool, size: u64) R.Result[bool, str] {
-    if (slot.class == abi.CLASS_HFA) {
-        # an HFA argument flows by address; load each member into its V register.
-        var base: u32 = mir.MIR_VREG_NIL;
-        val ar: R.Result[bool, str] = context.addr_to_vreg(ctx, mb, argop, ?base);
-        if (R.is_err[bool, str](ar)) { ret ar; }
-        var i: u32 = 0;
-        for (i < slot.reg_count::u32) {
-            val off: i64 = (i * slot.reg_width::u32)::i64;
-            val mr: R.Result[bool, str] = context.emit_fmov(ctx, mb,
-                mir.op_preg(hfa_member_reg(slot.reg, i)::u32), mir.op_mem_value(base, off), slot.reg_width);
-            if (R.is_err[bool, str](mr)) { ret mr; }
-            i = i + 1;
-        }
-        ret R.ok[bool, str](true);
-    }
     if (slot.class == abi.CLASS_STACK_BYREF) {
         # win64 by-reference overflow: store the hidden aggregate pointer into the
         # outgoing stack slot, not a by-value copy of the aggregate bytes.
@@ -894,24 +900,42 @@ fun emit_arg_slot(ctx: *context.LowerCtx, mb: *mir.MirBlock, slot: abi.ParamSlot
         if (R.is_err[bool, str](ar)) { ret ar; }
         ret context.emit_mov(ctx, mb, mir.op_preg(slot.reg::u32), mir.op_vreg(base));
     }
-    if (slot.reg2 >= 0) {
-        # two-register aggregate: load each 8-byte half from the aggregate's
-        # storage (a value-pointer base) into the two GP registers.
-        var base: u32 = mir.MIR_VREG_NIL;
-        val ar: R.Result[bool, str] = context.addr_to_vreg(ctx, mb, argop, ?base);
-        if (R.is_err[bool, str](ar)) { ret ar; }
-        val lo: R.Result[bool, str] = context.emit_mov(ctx, mb,
-            mir.op_preg(slot.reg::u32), mir.op_mem_value(base, 0));
-        if (R.is_err[bool, str](lo)) { ret lo; }
-        ret context.emit_mov(ctx, mb, mir.op_preg(slot.reg2::u32), mir.op_mem_value(base, 8));
-    }
     if (is_aggr) {
-        # <=8 byte single-register aggregate: load its one word from the aggregate's
-        # storage into the argument register, normalizing a global's address first.
+        # register / register-plus-stack aggregate: place each chunk from the
+        # aggregate's storage into its register or outgoing stack slot. argop is a
+        # pointer to the storage, normalized to a register base.
         var base: u32 = mir.MIR_VREG_NIL;
         val ar: R.Result[bool, str] = context.addr_to_vreg(ctx, mb, argop, ?base);
         if (R.is_err[bool, str](ar)) { ret ar; }
-        ret context.emit_mov(ctx, mb, mir.op_preg(slot.reg::u32), mir.op_mem_value(base, 0));
+        val sp: u32 = ctx.tgt.arch.stack_ptr_reg::u32;
+        var i: u32 = 0;
+        for (i < slot.piece_count) {
+            val p: abi.ParamPiece = slot.pieces[i];
+            if (p.kind == abi.PIECE_GP) {
+                val mr: R.Result[bool, str] = context.emit_mov(ctx, mb,
+                    mir.op_preg(p.reg::u32), mir.op_mem_value(base, p.src_off));
+                if (R.is_err[bool, str](mr)) { ret mr; }
+            } or (p.kind == abi.PIECE_FP) {
+                val mr: R.Result[bool, str] = context.emit_fmov(ctx, mb,
+                    mir.op_preg(p.reg::u32), mir.op_mem_value(base, p.src_off), p.width);
+                if (R.is_err[bool, str](mr)) { ret mr; }
+            } or {
+                # PIECE_STACK: the split's tail rides an outgoing stack slot. load the
+                # chunk word from storage into a scratch register, then store it at
+                # `[sp + stack_off + stk_off]`.
+                val tr: R.Result[u32, str] = context.new_vreg(ctx, mir.REG_CLASS_GP);
+                if (R.is_err[u32, str](tr)) { ret R.err[bool, str](R.unwrap_err[u32, str](tr)); }
+                val tmp: u32 = R.unwrap_ok[u32, str](tr);
+                val ld: R.Result[bool, str] = context.emit_mov(ctx, mb,
+                    mir.op_vreg(tmp), mir.op_mem_value(base, p.src_off));
+                if (R.is_err[bool, str](ld)) { ret ld; }
+                val st: R.Result[bool, str] = context.emit_store_to(ctx, mb,
+                    mir.op_mem_preg(sp, stack_off + p.stk_off), mir.op_vreg(tmp));
+                if (R.is_err[bool, str](st)) { ret st; }
+            }
+            i = i + 1;
+        }
+        ret R.ok[bool, str](true);
     }
     # single FP register scalar argument: a float copy into the XMM argument
     # register. the XMM argument preg carries the SSE class, so the encoder
@@ -956,11 +980,12 @@ fun record_outgoing_size(ctx: *context.LowerCtx, bytes: i64) {
 # move a call's return value out of its canonical return register(s) into `dst`
 #
 # For an aggregate return `dst` is the caller-owned result storage pointer (see
-# `context.alloc_result_storage`): an HFA stores each V member into
-# `[dst + i*reg_width]`, a 9-16 byte register pair stores each half into `[dst+0]` /
-# `[dst+8]`, and a <=8 byte single-register aggregate stores its word into `[dst+0]`,
-# so `dst` stays the storage pointer downstream consumers read by. A scalar return
-# is a plain move into the value vreg `dst`.
+# `context.alloc_result_storage`): each register chunk of the placement is stored
+# into `[dst + src_off]` -- an HFA / mixed run stores each member, a 9-16 byte pair
+# each half, a <=8 byte single-register aggregate its one word -- so `dst` stays the
+# storage pointer downstream consumers read by. A scalar return is a plain move into
+# the value vreg `dst`. A return never carries a stack chunk (a too-large aggregate
+# returns via the sret pointer), so a PIECE_STACK here is a classifier bug.
 # ---
 # ctx:     the active lowering context
 # mb:      the MIR block the move(s) are appended to
@@ -969,26 +994,24 @@ fun record_outgoing_size(ctx: *context.LowerCtx, bytes: i64) {
 # is_aggr: whether the return is an aggregate flowing by address
 # ret:     ok(true) on success, or a loud error
 fun emit_ret_slot_to_vreg(ctx: *context.LowerCtx, mb: *mir.MirBlock, slot: abi.ParamSlot, dst: u32, is_aggr: bool) R.Result[bool, str] {
-    if (slot.class == abi.CLASS_HFA) {
-        # an HFA return arrives in V0..V(reg_count-1); store each member into the
-        # caller-owned result storage so `dst` stays the storage pointer.
+    if (is_aggr) {
         var i: u32 = 0;
-        for (i < slot.reg_count::u32) {
-            val off: i64 = (i * slot.reg_width::u32)::i64;
-            val st: R.Result[bool, str] = context.emit_store_to_w(ctx, mb,
-                mir.op_mem_value(dst, off), mir.op_preg(hfa_member_reg(slot.reg, i)::u32), slot.reg_width);
-            if (R.is_err[bool, str](st)) { ret st; }
+        for (i < slot.piece_count) {
+            val p: abi.ParamPiece = slot.pieces[i];
+            if (p.kind == abi.PIECE_GP) {
+                val st: R.Result[bool, str] = context.emit_store_to(ctx, mb,
+                    mir.op_mem_value(dst, p.src_off), mir.op_preg(p.reg::u32));
+                if (R.is_err[bool, str](st)) { ret st; }
+            } or (p.kind == abi.PIECE_FP) {
+                val st: R.Result[bool, str] = context.emit_store_to_w(ctx, mb,
+                    mir.op_mem_value(dst, p.src_off), mir.op_preg(p.reg::u32), p.width);
+                if (R.is_err[bool, str](st)) { ret st; }
+            } or {
+                ret R.err[bool, str]("mir.lower_ir: return slot carries an outgoing stack chunk");
+            }
             i = i + 1;
         }
         ret R.ok[bool, str](true);
-    }
-    if (slot.reg2 >= 0) {
-        val lo: R.Result[bool, str] = context.emit_store_to(ctx, mb, mir.op_mem_value(dst, 0), mir.op_preg(slot.reg::u32));
-        if (R.is_err[bool, str](lo)) { ret lo; }
-        ret context.emit_store_to(ctx, mb, mir.op_mem_value(dst, 8), mir.op_preg(slot.reg2::u32));
-    }
-    if (is_aggr) {
-        ret context.emit_store_to(ctx, mb, mir.op_mem_value(dst, 0), mir.op_preg(slot.reg::u32));
     }
     ret context.emit_mov(ctx, mb, mir.op_vreg(dst), mir.op_preg(slot.reg::u32));
 }
@@ -1064,21 +1087,22 @@ pub fun lower_params(ctx: *context.LowerCtx, mb: *mir.MirBlock) R.Result[bool, s
 # emit the entry pre-coloring move(s) for one classified incoming parameter
 #
 # An aggregate parameter ends with `pv` holding a pointer to the aggregate's
-# incoming bytes (aggregates flow by address): a register-passed aggregate (one or
-# two GP halves) is spilled into a fresh frame slot keyed on `pv` so `pv` names that
-# storage; a BYREF aggregate takes the hidden pointer directly; a STACK aggregate is
-# the caller's by-value copy, whose address is LEA'd into `pv`; a STACK_BYREF
-# aggregate is the caller's spilled hidden pointer, loaded into `pv` (the stack
-# analog of BYREF). An HFA parameter arrives in V[reg]..V[reg+reg_count-1] and each
-# member is stored into a fresh spill slot keyed on `pv`. A scalar parameter moves
-# its single register / stack word into the parameter value vreg `pv`.
+# incoming bytes (aggregates flow by address): a register / register-plus-stack
+# aggregate is reconstructed into a fresh frame slot keyed on `pv` so `pv` names that
+# storage -- each register chunk is stored into `[pv + src_off]` (a GP chunk full
+# width, an FP chunk at its `width`) and a split's PIECE_STACK chunk is read from the
+# caller's incoming stack slot into the same offset; a BYREF aggregate takes the
+# hidden pointer directly; a STACK aggregate is the caller's by-value copy, whose
+# address is LEA'd into `pv`; a STACK_BYREF aggregate is the caller's spilled hidden
+# pointer, loaded into `pv` (the stack analog of BYREF). A scalar parameter moves its
+# single register / stack word into the parameter value vreg `pv`.
 # ---
 # ctx:       the active lowering context
 # mb:        the entry MIR block the move(s) are appended to
 # slot:      the parameter's classified slot
 # pv:        the parameter vreg, rebound to a storage pointer for an aggregate
 # size:      the parameter's byte size (the spill-slot size for an aggregate)
-# stack_off: the running incoming-argument offset for a STACK slot
+# stack_off: the slot's incoming stack base (a STACK slot, or a split's stack chunk)
 # is_aggr:   whether the parameter is an aggregate flowing by address
 # ret:       ok(true) on success, or a loud error
 fun emit_param_slot(ctx: *context.LowerCtx, mb: *mir.MirBlock, slot: abi.ParamSlot, pv: u32, size: u64,
@@ -1088,22 +1112,6 @@ fun emit_param_slot(ctx: *context.LowerCtx, mb: *mir.MirBlock, slot: abi.ParamSl
     # frame-pointer register is named through the ISA vtable and the base offset
     # through `tgt.model`, never bare literals.
     val arg_base: i64 = ctx.tgt.model.incoming_arg_base;
-    if (slot.class == abi.CLASS_HFA) {
-        # spill each incoming V member into a slot keyed on `pv` so `pv` is the
-        # aggregate's storage pointer for downstream uses (the FP twin of the
-        # register-aggregate spill).
-        val sr: R.Result[bool, str] = context.add_spill_slot(ctx, pv, size);
-        if (R.is_err[bool, str](sr)) { ret sr; }
-        var i: u32 = 0;
-        for (i < slot.reg_count::u32) {
-            val off: i64 = (i * slot.reg_width::u32)::i64;
-            val st: R.Result[bool, str] = context.emit_store_to_w(ctx, mb,
-                mir.op_mem_slot(pv, off), mir.op_preg(hfa_member_reg(slot.reg, i)::u32), slot.reg_width);
-            if (R.is_err[bool, str](st)) { ret st; }
-            i = i + 1;
-        }
-        ret R.ok[bool, str](true);
-    }
     if (slot.class == abi.CLASS_STACK_BYREF) {
         # win64 by-reference overflow: the caller stored the hidden aggregate
         # pointer into this stack slot; load it so `pv` is the aggregate's address,
@@ -1125,23 +1133,41 @@ fun emit_param_slot(ctx: *context.LowerCtx, mb: *mir.MirBlock, slot: abi.ParamSl
     if (slot.class == abi.CLASS_BYREF) {
         ret context.emit_mov(ctx, mb, mir.op_vreg(pv), mir.op_preg(slot.reg::u32));
     }
-    if (slot.reg2 >= 0) {
-        # two-register aggregate: materialize a spill slot keyed on the parameter
-        # vreg and store both halves into it. the slot base is the slot key, so the
-        # encoder resolves it to `[rbp + offset]` and the param vreg names the
-        # slot's storage for downstream uses.
-        val sr: R.Result[bool, str] = context.add_spill_slot(ctx, pv, size);
-        if (R.is_err[bool, str](sr)) { ret sr; }
-        val lo: R.Result[bool, str] = context.emit_store_to(ctx, mb, mir.op_mem_slot(pv, 0), mir.op_preg(slot.reg::u32));
-        if (R.is_err[bool, str](lo)) { ret lo; }
-        ret context.emit_store_to(ctx, mb, mir.op_mem_slot(pv, 8), mir.op_preg(slot.reg2::u32));
-    }
     if (is_aggr) {
-        # <=8 byte single-register aggregate: spill the register into a slot keyed on
-        # the parameter vreg so `pv` is a storage pointer like the two-register form.
+        # register / register-plus-stack aggregate: materialize a spill slot keyed on
+        # the parameter vreg and reconstruct the aggregate into it chunk by chunk, so
+        # the encoder resolves `[pv + off]` to `[rbp + slot_off]` and the param vreg
+        # names the storage for downstream uses.
         val sr: R.Result[bool, str] = context.add_spill_slot(ctx, pv, size);
         if (R.is_err[bool, str](sr)) { ret sr; }
-        ret context.emit_store_to(ctx, mb, mir.op_mem_slot(pv, 0), mir.op_preg(slot.reg::u32));
+        val fp: u32 = ctx.tgt.arch.frame_ptr_reg::u32;
+        var i: u32 = 0;
+        for (i < slot.piece_count) {
+            val p: abi.ParamPiece = slot.pieces[i];
+            if (p.kind == abi.PIECE_GP) {
+                val st: R.Result[bool, str] = context.emit_store_to(ctx, mb,
+                    mir.op_mem_slot(pv, p.src_off), mir.op_preg(p.reg::u32));
+                if (R.is_err[bool, str](st)) { ret st; }
+            } or (p.kind == abi.PIECE_FP) {
+                val st: R.Result[bool, str] = context.emit_store_to_w(ctx, mb,
+                    mir.op_mem_slot(pv, p.src_off), mir.op_preg(p.reg::u32), p.width);
+                if (R.is_err[bool, str](st)) { ret st; }
+            } or {
+                # PIECE_STACK: the caller placed this chunk in an incoming stack slot;
+                # load it off the frame pointer and store it into the spill slot.
+                val tr: R.Result[u32, str] = context.new_vreg(ctx, mir.REG_CLASS_GP);
+                if (R.is_err[u32, str](tr)) { ret R.err[bool, str](R.unwrap_err[u32, str](tr)); }
+                val tmp: u32 = R.unwrap_ok[u32, str](tr);
+                val ld: R.Result[bool, str] = context.emit_mov(ctx, mb,
+                    mir.op_vreg(tmp), mir.op_mem_preg(fp, arg_base + stack_off + p.stk_off));
+                if (R.is_err[bool, str](ld)) { ret ld; }
+                val st: R.Result[bool, str] = context.emit_store_to(ctx, mb,
+                    mir.op_mem_slot(pv, p.src_off), mir.op_vreg(tmp));
+                if (R.is_err[bool, str](st)) { ret st; }
+            }
+            i = i + 1;
+        }
+        ret R.ok[bool, str](true);
     }
     ret context.emit_mov(ctx, mb, mir.op_vreg(pv), mir.op_preg(slot.reg::u32));
 }
@@ -1197,40 +1223,32 @@ pub fun lower_ret(ctx: *context.LowerCtx, mb: *mir.MirBlock, inst: *instruction.
         if (R.is_err[bool, str](cr)) { ret cr; }
         val mr: R.Result[bool, str] = context.emit_mov(ctx, mb, mir.op_preg(slot.reg::u32), mir.op_vreg(ctx.sret_vreg));
         if (R.is_err[bool, str](mr)) { ret mr; }
-    } or (slot.class == abi.CLASS_HFA) {
-        # HFA return: the aggregate flows by address; load each member from its
-        # storage into the consecutive V return register (V0..V(reg_count-1)).
+    } or (rag) {
+        # aggregate return by address: load each register chunk from the aggregate's
+        # storage (a value-pointer base, a global's symbol address materialized first)
+        # into its return register -- an HFA / mixed run's members, a 9-16 byte pair's
+        # halves, or a <=8 byte single word -- rather than returning the pointer,
+        # which would hand back the address of a dead local. A return never carries a
+        # stack chunk (a too-large aggregate returns via the sret pointer above).
         var base: u32 = mir.MIR_VREG_NIL;
         val ar: R.Result[bool, str] = context.addr_to_vreg(ctx, mb, rvop, ?base);
         if (R.is_err[bool, str](ar)) { ret ar; }
         var i: u32 = 0;
-        for (i < slot.reg_count::u32) {
-            val off: i64 = (i * slot.reg_width::u32)::i64;
-            val mr: R.Result[bool, str] = context.emit_fmov(ctx, mb,
-                mir.op_preg(hfa_member_reg(slot.reg, i)::u32), mir.op_mem_value(base, off), slot.reg_width);
-            if (R.is_err[bool, str](mr)) { ret mr; }
+        for (i < slot.piece_count) {
+            val p: abi.ParamPiece = slot.pieces[i];
+            if (p.kind == abi.PIECE_GP) {
+                val mr: R.Result[bool, str] = context.emit_mov(ctx, mb,
+                    mir.op_preg(p.reg::u32), mir.op_mem_value(base, p.src_off));
+                if (R.is_err[bool, str](mr)) { ret mr; }
+            } or (p.kind == abi.PIECE_FP) {
+                val mr: R.Result[bool, str] = context.emit_fmov(ctx, mb,
+                    mir.op_preg(p.reg::u32), mir.op_mem_value(base, p.src_off), p.width);
+                if (R.is_err[bool, str](mr)) { ret mr; }
+            } or {
+                ret R.err[bool, str]("mir.lower_ir: return slot carries an outgoing stack chunk");
+            }
             i = i + 1;
         }
-    } or (slot.reg2 >= 0 && rag) {
-        # 9-16 byte aggregate: load each half from the aggregate's storage (a
-        # value-pointer base), materializing a global's symbol address first.
-        var base: u32 = mir.MIR_VREG_NIL;
-        val ar: R.Result[bool, str] = context.addr_to_vreg(ctx, mb, rvop, ?base);
-        if (R.is_err[bool, str](ar)) { ret ar; }
-        val lo: R.Result[bool, str] = context.emit_mov(ctx, mb, mir.op_preg(slot.reg::u32), mir.op_mem_value(base, 0));
-        if (R.is_err[bool, str](lo)) { ret lo; }
-        val hi: R.Result[bool, str] = context.emit_mov(ctx, mb, mir.op_preg(slot.reg2::u32), mir.op_mem_value(base, 8));
-        if (R.is_err[bool, str](hi)) { ret hi; }
-    } or (slot.reg >= 0 && rag) {
-        # <=8 byte aggregate: the single eightbyte returns in one register, but the
-        # value flows by address (rvop is a value-pointer base), so load the
-        # eightbyte from the aggregate's storage rather than returning the pointer -
-        # otherwise the callee returns the address of a dead local.
-        var base: u32 = mir.MIR_VREG_NIL;
-        val ar: R.Result[bool, str] = context.addr_to_vreg(ctx, mb, rvop, ?base);
-        if (R.is_err[bool, str](ar)) { ret ar; }
-        val mr: R.Result[bool, str] = context.emit_mov(ctx, mb, mir.op_preg(slot.reg::u32), mir.op_mem_value(base, 0));
-        if (R.is_err[bool, str](mr)) { ret mr; }
     } or (slot.class == abi.CLASS_FP) {
         # scalar float return: a float copy into XMM0. the XMM0 return preg carries
         # the SSE class, so the encoder dispatches the move on operand class and emits

--- a/src/lang/target.mach
+++ b/src/lang/target.mach
@@ -406,14 +406,14 @@ test "mach.lang.target.select:linux_riscv64" {
     if (t.abi == nil)            { ret 1; }
     if (t.abi.id != abi.ABI_LP64) { ret 1; }
     val arg: abi.ArgPassingFn = t.abi.arg_passing::abi.ArgPassingFn;
-    val ai: abi.ParamSlot = arg(0, 8, 8, false, 0, false, 0, 0, 0, 0);
+    val ai: abi.ParamSlot = arg(0, 8, 8, false, 0, false, 0, 0, 0, 0, abi.agg_none());
     if (ai.class != abi.CLASS_GP) { ret 1; }
     if (ai.reg != 10)             { ret 1; }  # a0 = x10
-    val af: abi.ParamSlot = arg(0, 8, 8, true, 0, false, 0, 0, 0, 0);
+    val af: abi.ParamSlot = arg(0, 8, 8, true, 0, false, 0, 0, 0, 0, abi.agg_none());
     if (af.class != abi.CLASS_FP)                                  { ret 1; }
     if (af.reg != isa.regid_make(isa.REG_CLASS_ID_XMM, 10))        { ret 1; }  # fa0 = f10
     val rp: abi.RetPassingFn = t.abi.ret_passing::abi.RetPassingFn;
-    val rr: abi.ParamSlot = rp(8, 8, false, 0, false, 0, 0);
+    val rr: abi.ParamSlot = rp(8, 8, false, 0, false, 0, 0, abi.agg_none());
     if (rr.class != abi.CLASS_GP) { ret 1; }
     if (rr.reg != 10)             { ret 1; }  # a0 = x10
 

--- a/src/lang/target/abi.mach
+++ b/src/lang/target/abi.mach
@@ -60,29 +60,83 @@ pub val CLASS_STACK_BYREF: ParamClass = 5;
 # V[reg]..V[reg+reg_count-1]. distinct from CLASS_FP, a single scalar float.
 pub val CLASS_HFA:         ParamClass = 6;
 
+# how one location of a multi-location aggregate placement is filled.
+#
+# A value that rides more than one register, or a register plus a stack slot, or
+# whose members differ in register bank or width, is described as a list of
+# `ParamPiece`s rather than the single-`reg` / `reg2` shorthand: each piece names
+# where one chunk of the aggregate's storage goes. The shorthand placements
+# (one register, a two-register pair, a CLASS_HFA run) populate an equivalent piece
+# list too, so the backend materializes every register / stack aggregate through one
+# uniform per-piece path.
+pub def PieceKind: u8;
+# the chunk rides a general-purpose register.
+pub val PIECE_GP:    PieceKind = 0;
+# the chunk rides a floating-point / vector register.
+pub val PIECE_FP:    PieceKind = 1;
+# the chunk occupies an outgoing stack slot (a register-plus-stack split's tail).
+pub val PIECE_STACK: PieceKind = 2;
+
+# the most register / stack pieces one aggregate placement spans (an AAPCS64 HFA of
+# four members is the widest case).
+pub val PARAM_MAX_PIECES: u32 = 4;
+
+# one location of an aggregate split across registers and / or the stack.
+#
+# `src_off` is the byte offset of this chunk within the aggregate's own storage: the
+# caller loads the chunk from `[storage + src_off]` and the callee stores the
+# incoming register / stack chunk back to `[spill + src_off]`. A PIECE_GP / PIECE_FP
+# chunk rides `reg`; a PIECE_STACK chunk occupies `[stack_base + stk_off]`, where
+# `stack_base` is the slot's assigned outgoing (caller) or incoming (callee) offset.
+# `width` is the move width: the FP move width (4 or 8) for PIECE_FP, the byte count
+# for PIECE_STACK, and the machine word for PIECE_GP (which moves a full register).
+# ---
+# kind:    PIECE_GP / PIECE_FP / PIECE_STACK
+# reg:     register id for PIECE_GP / PIECE_FP (-1 for PIECE_STACK)
+# src_off: byte offset of this chunk within the aggregate's storage
+# stk_off: byte offset within the slot's stack region for PIECE_STACK (0 otherwise)
+# width:   move width in bytes (FP move width / stack byte count / machine word)
+pub rec ParamPiece {
+    kind:    PieceKind;
+    reg:     i32;
+    src_off: i64;
+    stk_off: i64;
+    width:   u8;
+}
+
 # placement decision for one parameter or return value.
 #
 # `reg2` carries the second register of a 9-16 byte aggregate split across two
 # registers; it is -1 when the value occupies a single register or the stack.
 # `reg_count` / `reg_width` describe a CLASS_HFA register run and are 1 / 0 for
-# every other placement.
+# every other placement. `pieces` / `piece_count` are the canonical multi-location
+# form the backend materializes a register / stack aggregate from: every constructor
+# fills them (a single register is one piece, a pair two, a CLASS_HFA run one per
+# member), and `make_slot_pieces` builds the mixed-bank, different-width, and
+# register-plus-stack-split shapes the `reg` / `reg2` shorthand cannot express.
 # ---
-# class:     classification (CLASS_GP, CLASS_FP, CLASS_STACK, ...)
-# reg:       first register id if register-passed (-1 if stack/byref); the base
-#            register of a CLASS_HFA run
-# reg2:      second register id for a two-register aggregate (-1 otherwise)
-# reg_count: consecutive registers from `reg` for a CLASS_HFA (1 otherwise)
-# reg_width: per-register member width in bytes for a CLASS_HFA (0 otherwise)
-# offset:    stack offset in bytes if stack-passed
-# size:      size in bytes of this slot
+# class:       classification (CLASS_GP, CLASS_FP, CLASS_STACK, ...)
+# reg:         first register id if register-passed (-1 if stack/byref); the base
+#              register of a CLASS_HFA run
+# reg2:        second register id for a two-register aggregate (-1 otherwise)
+# reg_count:   consecutive registers from `reg` for a CLASS_HFA (1 otherwise)
+# reg_width:   per-register member width in bytes for a CLASS_HFA (0 otherwise)
+# offset:      stack offset in bytes if stack-passed (the stack base of any
+#              PIECE_STACK pieces for a register-plus-stack split)
+# size:        size in bytes of this slot
+# pieces:      the per-location chunks of a register / stack aggregate placement
+# piece_count: number of valid entries in `pieces` (0 for a scalar / byref / pure
+#              stack placement the consumer routes by `class` instead)
 pub rec ParamSlot {
-    class:     ParamClass;
-    reg:       i32;
-    reg2:      i32;
-    reg_count: u8;
-    reg_width: u8;
-    offset:    i64;
-    size:      u64;
+    class:       ParamClass;
+    reg:         i32;
+    reg2:        i32;
+    reg_count:   u8;
+    reg_width:   u8;
+    offset:      i64;
+    size:        u64;
+    pieces:      [4]ParamPiece;
+    piece_count: u32;
 }
 
 # classify one value into a placement decision. arch-specific by selection
@@ -353,8 +407,30 @@ pub fun registered(reg: *AbiRegistry, idx: u32) O.Option[*AbiVTable] {
     ret O.some[*AbiVTable](reg.entries[idx]);
 }
 
+# build a register ParamPiece, taking the bank from the register id's class tag and
+# reading a full machine-word chunk at `src_off`. an FP eightbyte rides its register
+# as a double-width SSE move; the consumer reads `width` only for the FP / stack
+# banks, so a GP chunk's nominal 8 is harmless.
+# ---
+# reg:     the register id (its class tag selects PIECE_GP vs PIECE_FP)
+# src_off: byte offset of the chunk within the aggregate's storage
+# ret:     the assembled register ParamPiece
+fun piece_for_reg(reg: i32, src_off: i64) ParamPiece {
+    var p: ParamPiece;
+    if (isa.regid_class(reg) == isa.REG_CLASS_ID_XMM) { p.kind = PIECE_FP; } or { p.kind = PIECE_GP; }
+    p.reg     = reg;
+    p.src_off = src_off;
+    p.stk_off = 0;
+    p.width   = 8;
+    ret p;
+}
+
 # build a single-register or stack `ParamSlot`. `reg_count` is 1 and `reg_width`
-# 0 -- the CLASS_HFA register-run fields are set only by `make_slot_hfa`.
+# 0 -- the CLASS_HFA register-run fields are set only by `make_slot_hfa`. A
+# register-bearing placement (one register, or a 9-16 byte two-register pair) also
+# fills the canonical `pieces` list -- one chunk per register at the fixed 0 / 8
+# eightbyte offsets, each piece's bank taken from its register id -- so the backend
+# materializes it through the same per-piece path as a mixed or split placement.
 # ---
 # class:  classification
 # reg:    first register id (-1 if none)
@@ -364,13 +440,22 @@ pub fun registered(reg: *AbiRegistry, idx: u32) O.Option[*AbiVTable] {
 # ret:    the assembled ParamSlot
 pub fun make_slot(class: ParamClass, reg: i32, reg2: i32, offset: i64, size: u64) ParamSlot {
     var s: ParamSlot;
-    s.class     = class;
-    s.reg       = reg;
-    s.reg2      = reg2;
-    s.reg_count = 1;
-    s.reg_width = 0;
-    s.offset    = offset;
-    s.size      = size;
+    s.class       = class;
+    s.reg         = reg;
+    s.reg2        = reg2;
+    s.reg_count   = 1;
+    s.reg_width   = 0;
+    s.offset      = offset;
+    s.size        = size;
+    s.piece_count = 0;
+    if (reg >= 0) {
+        s.pieces[0]   = piece_for_reg(reg, 0);
+        s.piece_count = 1;
+    }
+    if (reg2 >= 0) {
+        s.pieces[1]   = piece_for_reg(reg2, 8);
+        s.piece_count = 2;
+    }
     ret s;
 }
 
@@ -392,5 +477,70 @@ pub fun make_slot_hfa(base_reg: i32, count: u8, elem: u8, size: u64) ParamSlot {
     s.reg_width = elem;
     s.offset    = 0;
     s.size      = size;
+    # one FP chunk per member, at consecutive registers from `base_reg` and field
+    # offsets `i * elem`, so the run materializes through the shared per-piece path.
+    val base_ix: i32 = isa.regid_index(base_reg);
+    var i: u32 = 0;
+    for (i < count::u32) {
+        var p: ParamPiece;
+        p.kind    = PIECE_FP;
+        p.reg     = isa.regid_make(isa.REG_CLASS_ID_XMM, base_ix + i::i32);
+        p.src_off = (i * elem::u32)::i64;
+        p.stk_off = 0;
+        p.width   = elem;
+        s.pieces[i] = p;
+        i = i + 1;
+    }
+    s.piece_count = count::u32;
+    ret s;
+}
+
+# build one register or stack ParamPiece.
+# ---
+# kind:    PIECE_GP / PIECE_FP / PIECE_STACK
+# reg:     register id (-1 for PIECE_STACK)
+# src_off: byte offset of the chunk within the aggregate's storage
+# stk_off: byte offset within the slot's stack region (PIECE_STACK; 0 otherwise)
+# width:   move width in bytes
+# ret:     the assembled ParamPiece
+pub fun make_piece(kind: PieceKind, reg: i32, src_off: i64, stk_off: i64, width: u8) ParamPiece {
+    var p: ParamPiece;
+    p.kind    = kind;
+    p.reg     = reg;
+    p.src_off = src_off;
+    p.stk_off = stk_off;
+    p.width   = width;
+    ret p;
+}
+
+# build a placement from an explicit list of register / stack pieces, for an
+# aggregate whose members span more than one register bank, differ in width, or split
+# across a register and the stack -- shapes the single-`reg` / `reg2` shorthand
+# cannot express (the RISC-V lp64d mixed float-plus-integer struct, the
+# different-width float pair, and the 9-16 byte register-plus-stack split). The
+# `reg` / `reg2` / `reg_count` / `reg_width` shorthand is left at its no-register
+# defaults; the consumer drives this placement off `pieces`. `offset` is left 0 and
+# is filled by the signature walk for a placement carrying a PIECE_STACK chunk.
+# ---
+# class:  classification label (CLASS_GP for an integer-bank-anchored split, etc.)
+# pieces: borrowed array of `count` pieces, copied into the slot
+# count:  number of pieces (1..PARAM_MAX_PIECES)
+# size:   total aggregate size in bytes
+# ret:    the assembled multi-piece ParamSlot
+pub fun make_slot_pieces(class: ParamClass, pieces: *ParamPiece, count: u32, size: u64) ParamSlot {
+    var s: ParamSlot;
+    s.class     = class;
+    s.reg       = -1;
+    s.reg2      = -1;
+    s.reg_count = 1;
+    s.reg_width = 0;
+    s.offset    = 0;
+    s.size      = size;
+    var i: u32 = 0;
+    for (i < count) {
+        s.pieces[i] = pieces[i];
+        i = i + 1;
+    }
+    s.piece_count = count;
     ret s;
 }

--- a/src/lang/target/abi.mach
+++ b/src/lang/target/abi.mach
@@ -443,13 +443,9 @@ pub fun registered(reg: *AbiRegistry, idx: u32) O.Option[*AbiVTable] {
 # src_off: byte offset of the chunk within the aggregate's storage
 # ret:     the assembled register ParamPiece
 fun piece_for_reg(reg: i32, src_off: i64) ParamPiece {
-    var p: ParamPiece;
-    if (isa.regid_class(reg) == isa.REG_CLASS_ID_XMM) { p.kind = PIECE_FP; } or { p.kind = PIECE_GP; }
-    p.reg     = reg;
-    p.src_off = src_off;
-    p.stk_off = 0;
-    p.width   = 8;
-    ret p;
+    var kind: PieceKind = PIECE_GP;
+    if (isa.regid_class(reg) == isa.REG_CLASS_ID_XMM) { kind = PIECE_FP; }
+    ret make_piece(kind, reg, src_off, 0, 8);
 }
 
 # build a single-register or stack `ParamSlot`. `reg_count` is 1 and `reg_width`
@@ -509,13 +505,8 @@ pub fun make_slot_hfa(base_reg: i32, count: u8, elem: u8, size: u64) ParamSlot {
     val base_ix: i32 = isa.regid_index(base_reg);
     var i: u32 = 0;
     for (i < count::u32) {
-        var p: ParamPiece;
-        p.kind    = PIECE_FP;
-        p.reg     = isa.regid_make(isa.REG_CLASS_ID_XMM, base_ix + i::i32);
-        p.src_off = (i * elem::u32)::i64;
-        p.stk_off = 0;
-        p.width   = elem;
-        s.pieces[i] = p;
+        s.pieces[i] = make_piece(PIECE_FP, isa.regid_make(isa.REG_CLASS_ID_XMM, base_ix + i::i32),
+                                 (i * elem::u32)::i64, 0, elem);
         i = i + 1;
     }
     s.piece_count = count::u32;
@@ -564,7 +555,7 @@ pub fun make_slot_pieces(class: ParamClass, pieces: *ParamPiece, count: u32, siz
     s.offset    = 0;
     s.size      = size;
     var i: u32 = 0;
-    for (i < count) {
+    for (i < count && i < PARAM_MAX_PIECES) {
         s.pieces[i] = pieces[i];
         i = i + 1;
     }

--- a/src/lang/target/abi.mach
+++ b/src/lang/target/abi.mach
@@ -104,6 +104,25 @@ pub rec ParamPiece {
     width:   u8;
 }
 
+# one flattened scalar leaf of an aggregate, for the lp64d hard-float / mixed rules.
+# ---
+# is_float: true if the leaf is a floating-point scalar (an `a`/`fa` register choice)
+# offset:   the leaf's absolute byte offset within the aggregate's storage
+# width:    the leaf's byte size
+pub rec AggField { is_float: bool; offset: u32; width: u8; }
+# the flattened leaves of a <=2-leaf aggregate (the lp64d float-flatten / mixed cases).
+# field_count is 0 for a non-aggregate, a union, or a struct with more than two leaves
+# (which falls to the integer convention). fields are in offset order.
+# ---
+# field_count: number of valid `fields` entries (0, 1, or 2)
+# fields:      the flattened scalar leaves, in offset order
+pub rec AggLayout { field_count: u8; fields: [2]AggField; }
+# a no-information AggLayout (field_count 0), passed by classifiers / sites with no
+# flatten data.
+# ---
+# ret: an AggLayout with field_count 0
+pub fun agg_none() AggLayout { var a: AggLayout; a.field_count = 0; ret a; }
+
 # placement decision for one parameter or return value.
 #
 # `reg2` carries the second register of a 9-16 byte aggregate split across two
@@ -182,8 +201,12 @@ pub def ClassifyFn: fun(u64, u64, bool, u8, bool, i32, i32, u8, u8) ParamSlot;
 # fp_used:       FP registers already consumed
 # hfa_members:   HFA member count (1-4), or 0 if the argument is not an HFA
 # hfa_elem:      HFA fundamental member width in bytes (0 if not an HFA)
+# agg:           the <=2-leaf flattened-aggregate descriptor (the lp64d mixed
+#                float-plus-integer and different-width float-pair rules); field_count
+#                is 0 for any value the descriptor does not apply to, which the AMD64
+#                and AAPCS64 conventions ignore
 # ret:           the placement decision
-pub def ArgPassingFn: fun(i32, u64, u64, bool, u8, bool, i32, i32, u8, u8) ParamSlot;
+pub def ArgPassingFn: fun(i32, u64, u64, bool, u8, bool, i32, i32, u8, u8, AggLayout) ParamSlot;
 
 # assign the registers or sret slot for a return value. arch-specific by
 # selection; `fp_eightbytes` and the HFA descriptor carry the same meaning as in
@@ -196,8 +219,12 @@ pub def ArgPassingFn: fun(i32, u64, u64, bool, u8, bool, i32, i32, u8, u8) Param
 # is_aggregate:  true if the value is an aggregate
 # hfa_members:   HFA member count (1-4), or 0 if the value is not an HFA
 # hfa_elem:      HFA fundamental member width in bytes (0 if not an HFA)
+# agg:           the <=2-leaf flattened-aggregate descriptor (the lp64d mixed
+#                float-plus-integer and different-width float-pair rules); field_count
+#                is 0 for any value the descriptor does not apply to, which the AMD64
+#                and AAPCS64 conventions ignore
 # ret:           the placement decision
-pub def RetPassingFn: fun(u64, u64, bool, u8, bool, u8, u8) ParamSlot;
+pub def RetPassingFn: fun(u64, u64, bool, u8, bool, u8, u8, AggLayout) ParamSlot;
 
 # fill a caller-owned `out` buffer with a register bank in canonical order and
 # return the count written. the erased `gp_arg_regs` / `fp_arg_regs` /

--- a/src/lang/target/abi/aapcs64.mach
+++ b/src/lang/target/abi/aapcs64.mach
@@ -135,7 +135,7 @@ pub fun fp_param_reg(index: i32) i32 {
 pub fun classify(size: u64, align: u64, is_float: bool, fp_eightbytes: u8,
                  is_aggregate: bool, gp_used: i32, fp_used: i32,
                  hfa_members: u8, hfa_elem: u8) abi.ParamSlot {
-    ret classify_arg(0, size, align, is_float, fp_eightbytes, is_aggregate, gp_used, fp_used, hfa_members, hfa_elem);
+    ret classify_arg(0, size, align, is_float, fp_eightbytes, is_aggregate, gp_used, fp_used, hfa_members, hfa_elem, abi.agg_none());
 }
 
 # assign registers or a stack slot for one argument (AAPCS64)
@@ -166,10 +166,12 @@ pub fun classify(size: u64, align: u64, is_float: bool, fp_eightbytes: u8,
 # fp_used:       FP registers already consumed
 # hfa_members:   HFA member count (1-4), or 0 if the argument is not an HFA
 # hfa_elem:      HFA fundamental member width in bytes (0 if not an HFA)
+# agg:           the flattened-aggregate descriptor (lp64d-only; unused under AAPCS64)
 # ret:           the placement decision
 pub fun classify_arg(index: i32, size: u64, align: u64,
                      is_float: bool, fp_eightbytes: u8, is_aggregate: bool,
-                     gp_used: i32, fp_used: i32, hfa_members: u8, hfa_elem: u8) abi.ParamSlot {
+                     gp_used: i32, fp_used: i32, hfa_members: u8, hfa_elem: u8,
+                     agg: abi.AggLayout) abi.ParamSlot {
     if (is_aggregate && hfa_members > 0) {
         # the run fits only if every member lands in the remaining V bank; otherwise
         # the whole aggregate goes to the stack by value (all-or-memory).
@@ -235,10 +237,11 @@ pub fun classify_arg(index: i32, size: u64, align: u64,
 # is_aggregate:  true if the value is an aggregate
 # hfa_members:   HFA member count (1-4), or 0 if the value is not an HFA
 # hfa_elem:      HFA fundamental member width in bytes (0 if not an HFA)
+# agg:           the flattened-aggregate descriptor (lp64d-only; unused under AAPCS64)
 # ret:           the placement decision
 pub fun classify_return(size: u64, align: u64,
                         is_float: bool, fp_eightbytes: u8, is_aggregate: bool,
-                        hfa_members: u8, hfa_elem: u8) abi.ParamSlot {
+                        hfa_members: u8, hfa_elem: u8, agg: abi.AggLayout) abi.ParamSlot {
     if (size == 0) {
         ret abi.make_slot(abi.CLASS_GP, -1, -1, 0, 0);
     }
@@ -386,10 +389,10 @@ pub fun register(reg: *abi.AbiRegistry) R.Result[bool, str] {
 
 # a scalar integer takes a GP register; a float takes a V register
 test "mach.lang.target.abi.aapcs64.classify_arg:scalar_register_banks" {
-    val i: abi.ParamSlot = classify_arg(0, 8, 8, false, 0, false, 0, 0, 0, 0);
+    val i: abi.ParamSlot = classify_arg(0, 8, 8, false, 0, false, 0, 0, 0, 0, abi.agg_none());
     if (i.class != abi.CLASS_GP) { ret 1; }
     if (i.reg != REG_X0)         { ret 1; }
-    val f: abi.ParamSlot = classify_arg(0, 8, 8, true, 0, false, 0, 0, 0, 0);
+    val f: abi.ParamSlot = classify_arg(0, 8, 8, true, 0, false, 0, 0, 0, 0, abi.agg_none());
     if (f.class != abi.CLASS_FP)  { ret 1; }
     if (f.reg != fp_param_reg(0)) { ret 1; }
     ret 0;
@@ -398,11 +401,11 @@ test "mach.lang.target.abi.aapcs64.classify_arg:scalar_register_banks" {
 # a 16-byte integer aggregate rides a consecutive GP pair; an 8-byte one a single
 # GP register
 test "mach.lang.target.abi.aapcs64.classify_arg:integer_aggregate_gp" {
-    val s: abi.ParamSlot = classify_arg(0, 16, 8, false, 0, true, 0, 0, 0, 0);
+    val s: abi.ParamSlot = classify_arg(0, 16, 8, false, 0, true, 0, 0, 0, 0, abi.agg_none());
     if (s.class != abi.CLASS_GP) { ret 1; }
     if (s.reg  != REG_X0)        { ret 1; }
     if (s.reg2 != REG_X1)        { ret 1; }
-    val o: abi.ParamSlot = classify_arg(0, 8, 8, false, 0, true, 0, 0, 0, 0);
+    val o: abi.ParamSlot = classify_arg(0, 8, 8, false, 0, true, 0, 0, 0, 0, abi.agg_none());
     if (o.class != abi.CLASS_GP) { ret 1; }
     if (o.reg  != REG_X0)        { ret 1; }
     if (o.reg2 != -1)            { ret 1; }
@@ -413,11 +416,11 @@ test "mach.lang.target.abi.aapcs64.classify_arg:integer_aggregate_gp" {
 # bank is exhausted
 test "mach.lang.target.abi.aapcs64.classify_arg:large_aggregate_byref" {
     # a GP register remains: the hidden pointer rides it.
-    val s: abi.ParamSlot = classify_arg(0, 32, 8, false, 0, true, 0, 0, 0, 0);
+    val s: abi.ParamSlot = classify_arg(0, 32, 8, false, 0, true, 0, 0, 0, 0, abi.agg_none());
     if (s.class != abi.CLASS_BYREF) { ret 1; }
     if (s.reg   != REG_X0)          { ret 1; }
     # GP bank exhausted: the pointer is passed on the stack.
-    val e: abi.ParamSlot = classify_arg(0, 32, 8, false, 0, true, 8, 0, 0, 0);
+    val e: abi.ParamSlot = classify_arg(0, 32, 8, false, 0, true, 8, 0, 0, 0, abi.agg_none());
     if (e.class != abi.CLASS_STACK_BYREF) { ret 1; }
     ret 0;
 }
@@ -426,25 +429,25 @@ test "mach.lang.target.abi.aapcs64.classify_arg:large_aggregate_byref" {
 # the run cannot fit
 test "mach.lang.target.abi.aapcs64.classify_arg:hfa_v_run" {
     # struct { f32, f32 } -> 2 members of 4 bytes in V0:V1.
-    val s: abi.ParamSlot = classify_arg(0, 8, 4, false, 0, true, 0, 0, 2, 4);
+    val s: abi.ParamSlot = classify_arg(0, 8, 4, false, 0, true, 0, 0, 2, 4, abi.agg_none());
     if (s.class != abi.CLASS_HFA) { ret 1; }
     if (s.reg != fp_param_reg(0)) { ret 1; }
     if (s.reg_count != 2)         { ret 1; }
     if (s.reg_width != 4)         { ret 1; }
     if (s.size != 8)              { ret 1; }
     # a 4xf64 HFA is 32 bytes yet still rides V0..V3 (HFA precedes the byref rule).
-    val q: abi.ParamSlot = classify_arg(0, 32, 8, false, 0, true, 0, 0, 4, 8);
+    val q: abi.ParamSlot = classify_arg(0, 32, 8, false, 0, true, 0, 0, 4, 8, abi.agg_none());
     if (q.class != abi.CLASS_HFA) { ret 1; }
     if (q.reg != fp_param_reg(0)) { ret 1; }
     if (q.reg_count != 4)         { ret 1; }
     if (q.reg_width != 8)         { ret 1; }
     # the run starts at the next free V register (NSRN cursor honored).
-    val a: abi.ParamSlot = classify_arg(0, 8, 4, false, 0, true, 0, 5, 2, 4);
+    val a: abi.ParamSlot = classify_arg(0, 8, 4, false, 0, true, 0, 5, 2, 4, abi.agg_none());
     if (a.class != abi.CLASS_HFA) { ret 1; }
     if (a.reg != fp_param_reg(5)) { ret 1; }
     # all-or-memory: a 3-member HFA cannot fit when only two V registers remain, so
     # the WHOLE aggregate spills by value (no partial V placement).
-    val m: abi.ParamSlot = classify_arg(0, 12, 4, false, 0, true, 0, 6, 3, 4);
+    val m: abi.ParamSlot = classify_arg(0, 12, 4, false, 0, true, 0, 6, 3, 4, abi.agg_none());
     if (m.class != abi.CLASS_STACK) { ret 1; }
     ret 0;
 }
@@ -452,27 +455,27 @@ test "mach.lang.target.abi.aapcs64.classify_arg:hfa_v_run" {
 # the GP and FP argument banks advance independently
 test "mach.lang.target.abi.aapcs64.classify_arg:banks_independent" {
     # seven GP registers used: a scalar integer still has X7, a float still has V0.
-    val i: abi.ParamSlot = classify_arg(0, 8, 8, false, 0, false, 7, 0, 0, 0);
+    val i: abi.ParamSlot = classify_arg(0, 8, 8, false, 0, false, 7, 0, 0, 0, abi.agg_none());
     if (i.class != abi.CLASS_GP) { ret 1; }
     if (i.reg != REG_X7)         { ret 1; }
-    val f: abi.ParamSlot = classify_arg(0, 8, 8, true, 0, false, 7, 0, 0, 0);
+    val f: abi.ParamSlot = classify_arg(0, 8, 8, true, 0, false, 7, 0, 0, 0, abi.agg_none());
     if (f.class != abi.CLASS_FP)  { ret 1; }
     if (f.reg != fp_param_reg(0)) { ret 1; }
     # GP exhausted spills an integer to the stack; the FP bank is untouched.
-    val s: abi.ParamSlot = classify_arg(0, 8, 8, false, 0, false, 8, 0, 0, 0);
+    val s: abi.ParamSlot = classify_arg(0, 8, 8, false, 0, false, 8, 0, 0, 0, abi.agg_none());
     if (s.class != abi.CLASS_STACK) { ret 1; }
     ret 0;
 }
 
 # scalar and small-aggregate returns place X0 / V0 / X0:X1
 test "mach.lang.target.abi.aapcs64.classify_return:scalar_and_small_aggregate" {
-    val v: abi.ParamSlot = classify_return(0, 0, false, 0, false, 0, 0);
+    val v: abi.ParamSlot = classify_return(0, 0, false, 0, false, 0, 0, abi.agg_none());
     if (v.class != abi.CLASS_GP || v.reg != -1) { ret 1; }
-    val i: abi.ParamSlot = classify_return(8, 8, false, 0, false, 0, 0);
+    val i: abi.ParamSlot = classify_return(8, 8, false, 0, false, 0, 0, abi.agg_none());
     if (i.reg != REG_X0) { ret 1; }
-    val f: abi.ParamSlot = classify_return(8, 8, true, 0, false, 0, 0);
+    val f: abi.ParamSlot = classify_return(8, 8, true, 0, false, 0, 0, abi.agg_none());
     if (f.class != abi.CLASS_FP || f.reg != fp_param_reg(0)) { ret 1; }
-    val a: abi.ParamSlot = classify_return(16, 8, false, 0, true, 0, 0);
+    val a: abi.ParamSlot = classify_return(16, 8, false, 0, true, 0, 0, abi.agg_none());
     if (a.reg != REG_X0 || a.reg2 != REG_X1) { ret 1; }
     ret 0;
 }
@@ -480,17 +483,17 @@ test "mach.lang.target.abi.aapcs64.classify_return:scalar_and_small_aggregate" {
 # an HFA return rides the V0 run, before the sret rule
 test "mach.lang.target.abi.aapcs64.classify_return:hfa_before_sret" {
     # struct { f32, f32, f32 } returns in V0:V1:V2.
-    val s: abi.ParamSlot = classify_return(12, 4, false, 0, true, 3, 4);
+    val s: abi.ParamSlot = classify_return(12, 4, false, 0, true, 3, 4, abi.agg_none());
     if (s.class != abi.CLASS_HFA) { ret 1; }
     if (s.reg != fp_param_reg(0)) { ret 1; }
     if (s.reg_count != 3)         { ret 1; }
     if (s.reg_width != 4)         { ret 1; }
     # a 4xf64 HFA is 32 bytes yet returns in V0..V3, not via X8 sret.
-    val q: abi.ParamSlot = classify_return(32, 8, false, 0, true, 4, 8);
+    val q: abi.ParamSlot = classify_return(32, 8, false, 0, true, 4, 8, abi.agg_none());
     if (q.class != abi.CLASS_HFA) { ret 1; }
     if (q.reg_count != 4)         { ret 1; }
     # a >16-byte non-HFA aggregate still returns via the X8 indirect-result register.
-    val r: abi.ParamSlot = classify_return(32, 8, false, 0, true, 0, 0);
+    val r: abi.ParamSlot = classify_return(32, 8, false, 0, true, 0, 0, abi.agg_none());
     if (r.class != abi.CLASS_SRET || r.reg != REG_X8) { ret 1; }
     ret 0;
 }

--- a/src/lang/target/abi/lp64.mach
+++ b/src/lang/target/abi/lp64.mach
@@ -213,7 +213,7 @@ pub fun classify_arg(index: i32, size: u64, align: u64,
                     if (agg.fields[j].is_float) {
                         ps[j] = abi.make_piece(abi.PIECE_FP, fp_param_reg(fp_used), agg.fields[j].offset::i64, 0, agg.fields[j].width);
                     } or {
-                        ps[j] = abi.make_piece(abi.PIECE_GP, gp_param_reg(gp_used), agg.fields[j].offset::i64, 0, 8);
+                        ps[j] = abi.make_piece(abi.PIECE_GP, gp_param_reg(gp_used), agg.fields[j].offset::i64, 0, agg.fields[j].width);
                     }
                     j = j + 1;
                 }
@@ -327,7 +327,7 @@ pub fun classify_return(size: u64, align: u64,
                 if (agg.fields[j].is_float) {
                     ps[j] = abi.make_piece(abi.PIECE_FP, fp_param_reg(0), agg.fields[j].offset::i64, 0, agg.fields[j].width);
                 } or {
-                    ps[j] = abi.make_piece(abi.PIECE_GP, REG_A0, agg.fields[j].offset::i64, 0, 8);
+                    ps[j] = abi.make_piece(abi.PIECE_GP, REG_A0, agg.fields[j].offset::i64, 0, agg.fields[j].width);
                 }
                 j = j + 1;
             }
@@ -660,6 +660,42 @@ test "mach.lang.target.abi.lp64.classify_arg:mixed_and_diff_width_float_pairs" {
     if (fb.reg            != REG_A0)       { ret 1; }
     if (fb.reg2           != REG_A1)       { ret 1; }
     if (fb.pieces[0].kind != abi.PIECE_GP) { ret 1; }
+    ret 0;
+}
+
+# a mixed float+integer struct with sub-word members (e.g. {f32; i32}) places each
+# leaf at its OWN width: the integer leaf's GP piece is 4 bytes, not the machine word,
+# so the caller load and the callee / return store never run past the 8-byte aggregate
+test "mach.lang.target.abi.lp64.classify_arg:mixed_subword_gp_width" {
+    # {f32; i32}: f32 at offset 0 (width 4), i32 at offset 4 (width 4); 8 bytes total.
+    var fi: abi.AggLayout;
+    fi.field_count = 2;
+    fi.fields[0].is_float = true;
+    fi.fields[0].offset   = 0;
+    fi.fields[0].width    = 4;
+    fi.fields[1].is_float = false;
+    fi.fields[1].offset   = 4;
+    fi.fields[1].width    = 4;
+    val a: abi.ParamSlot = classify_arg(0, 8, 4, false, 0, true, 0, 0, 0, 0, fi);
+    if (a.class             != abi.CLASS_GP)    { ret 1; }
+    if (a.piece_count       != 2)               { ret 1; }
+    if (a.pieces[0].kind    != abi.PIECE_FP)    { ret 1; }
+    if (a.pieces[0].reg     != fp_param_reg(0)) { ret 1; }
+    if (a.pieces[0].width   != 4)               { ret 1; }
+    if (a.pieces[1].kind    != abi.PIECE_GP)    { ret 1; }
+    if (a.pieces[1].reg     != REG_A0)          { ret 1; }
+    if (a.pieces[1].src_off != 4)               { ret 1; }
+    if (a.pieces[1].width   != 4)               { ret 1; }  # the leaf width, not the word
+    # the return side mirrors it: fa0 + a0, the integer piece 4 bytes wide.
+    val r: abi.ParamSlot = classify_return(8, 4, false, 0, true, 0, 0, fi);
+    if (r.class             != abi.CLASS_GP)    { ret 1; }
+    if (r.piece_count       != 2)               { ret 1; }
+    if (r.pieces[0].kind    != abi.PIECE_FP)    { ret 1; }
+    if (r.pieces[0].width   != 4)               { ret 1; }
+    if (r.pieces[1].kind    != abi.PIECE_GP)    { ret 1; }
+    if (r.pieces[1].reg     != REG_A0)          { ret 1; }
+    if (r.pieces[1].src_off != 4)               { ret 1; }
+    if (r.pieces[1].width   != 4)               { ret 1; }  # the leaf width, not the word
     ret 0;
 }
 

--- a/src/lang/target/abi/lp64.mach
+++ b/src/lang/target/abi/lp64.mach
@@ -25,23 +25,22 @@
 # HARD-FLOAT FLATTENING: a struct that flattens to one or two floating-point members
 # (recursively, through nested structs / arrays of a single fundamental float width)
 # is passed / returned in the fa registers, one member per register at its field
-# offset - the lp64d wrapped-scalar and float-pair rules. The shared
+# offset - the lp64d wrapped-scalar and uniform-width float-pair rules. The shared
 # `classify_signature` computes the homogeneous-float descriptor and hands it here;
 # the placement reuses the shared CLASS_HFA register-run machinery. When the fa bank
 # lacks the register(s), lp64d falls back to the integer convention.
 #
-# DEFERRED (needs a shared `emit_arg_slot` capability the back end does not yet
-# expose, so it is escalated rather than papered over): the mixed float-plus-integer
-# struct rule (one fa + one a register, each from its own field offset), the
-# different-fundamental-width float pair (an fa run with a per-member width), and the
-# boundary rule that splits a 9-16 byte integer aggregate across the last integer
-# register and the stack. None of the three has a slot the shared caller / callee /
-# return lowering can materialize (CLASS_HFA is uniform-width FP-only, the reg2 pair
-# is GP-only from fixed 0 / 8 offsets, and there is no register-plus-stack split
-# class). Each such aggregate stays on the conservative integer / by-value-stack path
-# - self-consistent across a mach caller and callee, divergent from the C psABI only
-# at an FFI boundary. The vtable shape, register banks, scalar / large-aggregate
-# placement, and the homogeneous-float flattening are complete.
+# MIXED AND DIFFERENT-WIDTH PAIRS: a <=2-leaf aggregate the uniform-HFA rule did not
+# place is described by the shared `AggLayout` (per-leaf is_float / offset / width)
+# and placed through the per-piece slot machinery: two floats of different fundamental
+# widths ride one fa register each at their own widths (the different-width float
+# pair), and a one-float-one-integer struct rides the float in an fa register and the
+# integer in an a register, each loaded from its own field offset (the mixed rule).
+# Either falls back to the integer convention when a needed bank is exhausted. The
+# 9-16 byte integer aggregate that splits across the last integer register and an
+# outgoing stack slot is handled by the integer block below via `make_slot_pieces`.
+# The vtable shape, register banks, scalar / large-aggregate placement, the
+# homogeneous-float flattening, and these mixed / split rules are complete.
 #
 # The vtable's classify/arg/ret function pointers are type-erased (`*u8`); a
 # consumer casts each back to the neutral signature declared in `abi`.
@@ -132,7 +131,7 @@ pub fun fp_param_reg(index: i32) i32 {
 pub fun classify(size: u64, align: u64, is_float: bool, fp_eightbytes: u8,
                  is_aggregate: bool, gp_used: i32, fp_used: i32,
                  hfa_members: u8, hfa_elem: u8) abi.ParamSlot {
-    ret classify_arg(0, size, align, is_float, fp_eightbytes, is_aggregate, gp_used, fp_used, hfa_members, hfa_elem);
+    ret classify_arg(0, size, align, is_float, fp_eightbytes, is_aggregate, gp_used, fp_used, hfa_members, hfa_elem, abi.agg_none());
 }
 
 # assign registers or a stack slot for one argument (lp64d)
@@ -162,10 +161,14 @@ pub fun classify(size: u64, align: u64, is_float: bool, fp_eightbytes: u8,
 # hfa_members:   homogeneous-float member count; 1 or 2 selects the lp64d hard-float
 #                flattening (0 or > 2 falls to the integer convention)
 # hfa_elem:      homogeneous-float fundamental member width (the per-fa-register width)
+# agg:           the <=2-leaf flattened-aggregate descriptor; a 2-leaf descriptor the
+#                uniform-HFA rule did not place selects the mixed float-plus-integer
+#                and different-width float-pair rules, field_count 0 otherwise
 # ret:           the placement decision
 pub fun classify_arg(index: i32, size: u64, align: u64,
                      is_float: bool, fp_eightbytes: u8, is_aggregate: bool,
-                     gp_used: i32, fp_used: i32, hfa_members: u8, hfa_elem: u8) abi.ParamSlot {
+                     gp_used: i32, fp_used: i32, hfa_members: u8, hfa_elem: u8,
+                     agg: abi.AggLayout) abi.ParamSlot {
     if (is_aggregate && size > MAX_REG_RET) {
         if (gp_used < GP_PARAM_COUNT) {
             ret abi.make_slot(abi.CLASS_BYREF, gp_param_reg(gp_used), -1, 0, 8);
@@ -185,6 +188,39 @@ pub fun classify_arg(index: i32, size: u64, align: u64,
         if (fp_used + hfa_members::i32 <= FP_PARAM_COUNT) {
             ret abi.make_slot_hfa(fp_param_reg(fp_used), hfa_members, hfa_elem, size);
         }
+    }
+
+    # different-width float pair / mixed float+integer struct (lp64d): a <=2-leaf
+    # aggregate the uniform-HFA rule above did not place. count the float leaves.
+    if (is_aggregate && agg.field_count == 2) {
+        var nf: u32 = 0;
+        var k: u32 = 0;
+        for (k < 2) { if (agg.fields[k].is_float) { nf = nf + 1; } k = k + 1; }
+        if (nf == 2) {
+            # two floats of (possibly) different widths -> one fa register each.
+            if (fp_used + 2 <= FP_PARAM_COUNT) {
+                var ps: [2]abi.ParamPiece;
+                ps[0] = abi.make_piece(abi.PIECE_FP, fp_param_reg(fp_used),     agg.fields[0].offset::i64, 0, agg.fields[0].width);
+                ps[1] = abi.make_piece(abi.PIECE_FP, fp_param_reg(fp_used + 1), agg.fields[1].offset::i64, 0, agg.fields[1].width);
+                ret abi.make_slot_pieces(abi.CLASS_FP, ?ps[0], 2, size);
+            }
+        } or (nf == 1) {
+            # one float + one integer -> the float in fa, the integer in a.
+            if (fp_used < FP_PARAM_COUNT && gp_used < GP_PARAM_COUNT) {
+                var ps: [2]abi.ParamPiece;
+                var j: u32 = 0;
+                for (j < 2) {
+                    if (agg.fields[j].is_float) {
+                        ps[j] = abi.make_piece(abi.PIECE_FP, fp_param_reg(fp_used), agg.fields[j].offset::i64, 0, agg.fields[j].width);
+                    } or {
+                        ps[j] = abi.make_piece(abi.PIECE_GP, gp_param_reg(gp_used), agg.fields[j].offset::i64, 0, 8);
+                    }
+                    j = j + 1;
+                }
+                ret abi.make_slot_pieces(abi.CLASS_GP, ?ps[0], 2, size);
+            }
+        }
+        # two ints, or a needed bank is exhausted: fall through to the integer convention.
     }
 
     if (is_aggregate) {
@@ -250,10 +286,13 @@ pub fun classify_arg(index: i32, size: u64, align: u64,
 # hfa_members:   homogeneous-float member count; 1 or 2 selects the lp64d hard-float
 #                flattening (0 or > 2 falls to the integer convention)
 # hfa_elem:      homogeneous-float fundamental member width (the per-fa-register width)
+# agg:           the <=2-leaf flattened-aggregate descriptor; a 2-leaf descriptor the
+#                uniform-HFA rule did not place selects the mixed float-plus-integer
+#                and different-width float-pair rules, field_count 0 otherwise
 # ret:           the placement decision
 pub fun classify_return(size: u64, align: u64,
                         is_float: bool, fp_eightbytes: u8, is_aggregate: bool,
-                        hfa_members: u8, hfa_elem: u8) abi.ParamSlot {
+                        hfa_members: u8, hfa_elem: u8, agg: abi.AggLayout) abi.ParamSlot {
     if (size == 0) {
         ret abi.make_slot(abi.CLASS_GP, -1, -1, 0, 0);
     }
@@ -267,6 +306,34 @@ pub fun classify_return(size: u64, align: u64,
     # all eight fa registers are free at a return, so the run always fits.
     if (is_aggregate && (hfa_members == 1 || hfa_members == 2)) {
         ret abi.make_slot_hfa(fp_param_reg(0), hfa_members, hfa_elem, size);
+    }
+
+    # different-width float pair / mixed float+integer struct (lp64d): a <=2-leaf
+    # aggregate the uniform-HFA rule above did not place. all fa / a registers are free
+    # at a return, so the float pair returns in fa0:fa1 and the mixed case in fa0 + a0.
+    if (is_aggregate && agg.field_count == 2) {
+        var nf: u32 = 0;
+        var k: u32 = 0;
+        for (k < 2) { if (agg.fields[k].is_float) { nf = nf + 1; } k = k + 1; }
+        if (nf == 2) {
+            var ps: [2]abi.ParamPiece;
+            ps[0] = abi.make_piece(abi.PIECE_FP, fp_param_reg(0), agg.fields[0].offset::i64, 0, agg.fields[0].width);
+            ps[1] = abi.make_piece(abi.PIECE_FP, fp_param_reg(1), agg.fields[1].offset::i64, 0, agg.fields[1].width);
+            ret abi.make_slot_pieces(abi.CLASS_FP, ?ps[0], 2, size);
+        } or (nf == 1) {
+            var ps: [2]abi.ParamPiece;
+            var j: u32 = 0;
+            for (j < 2) {
+                if (agg.fields[j].is_float) {
+                    ps[j] = abi.make_piece(abi.PIECE_FP, fp_param_reg(0), agg.fields[j].offset::i64, 0, agg.fields[j].width);
+                } or {
+                    ps[j] = abi.make_piece(abi.PIECE_GP, REG_A0, agg.fields[j].offset::i64, 0, 8);
+                }
+                j = j + 1;
+            }
+            ret abi.make_slot_pieces(abi.CLASS_GP, ?ps[0], 2, size);
+        }
+        # two ints: fall through to the integer-aggregate return convention.
     }
 
     if (is_aggregate) {
@@ -436,10 +503,10 @@ pub fun register(reg: *abi.AbiRegistry) R.Result[bool, str] {
 # a scalar integer takes an integer argument register; a scalar float takes an fa
 # register
 test "mach.lang.target.abi.lp64.classify_arg:scalar_register_banks" {
-    val i: abi.ParamSlot = classify_arg(0, 8, 8, false, 0, false, 0, 0, 0, 0);
+    val i: abi.ParamSlot = classify_arg(0, 8, 8, false, 0, false, 0, 0, 0, 0, abi.agg_none());
     if (i.class != abi.CLASS_GP) { ret 1; }
     if (i.reg != REG_A0)         { ret 1; }
-    val f: abi.ParamSlot = classify_arg(0, 8, 8, true, 0, false, 0, 0, 0, 0);
+    val f: abi.ParamSlot = classify_arg(0, 8, 8, true, 0, false, 0, 0, 0, 0, abi.agg_none());
     if (f.class != abi.CLASS_FP)  { ret 1; }
     if (f.reg != fp_param_reg(0)) { ret 1; }
     ret 0;
@@ -450,18 +517,18 @@ test "mach.lang.target.abi.lp64.classify_arg:scalar_register_banks" {
 test "mach.lang.target.abi.lp64.classify_arg:banks_independent_and_float_fallback" {
     # seven integer registers used: a scalar integer still has a7, a float still
     # has fa0.
-    val i: abi.ParamSlot = classify_arg(0, 8, 8, false, 0, false, 7, 0, 0, 0);
+    val i: abi.ParamSlot = classify_arg(0, 8, 8, false, 0, false, 7, 0, 0, 0, abi.agg_none());
     if (i.class != abi.CLASS_GP) { ret 1; }
     if (i.reg != REG_A0 + 7)     { ret 1; }
-    val f: abi.ParamSlot = classify_arg(0, 8, 8, true, 0, false, 7, 0, 0, 0);
+    val f: abi.ParamSlot = classify_arg(0, 8, 8, true, 0, false, 7, 0, 0, 0, abi.agg_none());
     if (f.class != abi.CLASS_FP)  { ret 1; }
     if (f.reg != fp_param_reg(0)) { ret 1; }
     # fa bank exhausted, an integer register remains: the float rides it.
-    val g: abi.ParamSlot = classify_arg(0, 8, 8, true, 0, false, 0, 8, 0, 0);
+    val g: abi.ParamSlot = classify_arg(0, 8, 8, true, 0, false, 0, 8, 0, 0, abi.agg_none());
     if (g.class != abi.CLASS_GP) { ret 1; }
     if (g.reg != REG_A0)         { ret 1; }
     # both banks exhausted: the float spills to the stack.
-    val s: abi.ParamSlot = classify_arg(0, 8, 8, true, 0, false, 8, 8, 0, 0);
+    val s: abi.ParamSlot = classify_arg(0, 8, 8, true, 0, false, 8, 8, 0, 0, abi.agg_none());
     if (s.class != abi.CLASS_STACK) { ret 1; }
     ret 0;
 }
@@ -470,20 +537,20 @@ test "mach.lang.target.abi.lp64.classify_arg:banks_independent_and_float_fallbac
 # single integer register; a >16-byte aggregate is passed by reference, on the
 # stack once the integer bank is exhausted
 test "mach.lang.target.abi.lp64.classify_arg:aggregate_placement" {
-    val s: abi.ParamSlot = classify_arg(0, 16, 8, false, 0, true, 0, 0, 0, 0);
+    val s: abi.ParamSlot = classify_arg(0, 16, 8, false, 0, true, 0, 0, 0, 0, abi.agg_none());
     if (s.class != abi.CLASS_GP) { ret 1; }
     if (s.reg  != REG_A0)        { ret 1; }
     if (s.reg2 != REG_A1)        { ret 1; }
-    val o: abi.ParamSlot = classify_arg(0, 8, 8, false, 0, true, 0, 0, 0, 0);
+    val o: abi.ParamSlot = classify_arg(0, 8, 8, false, 0, true, 0, 0, 0, 0, abi.agg_none());
     if (o.class != abi.CLASS_GP) { ret 1; }
     if (o.reg  != REG_A0)        { ret 1; }
     if (o.reg2 != -1)            { ret 1; }
     # >16 bytes with an integer register free: the pointer rides it.
-    val b: abi.ParamSlot = classify_arg(0, 32, 8, false, 0, true, 0, 0, 0, 0);
+    val b: abi.ParamSlot = classify_arg(0, 32, 8, false, 0, true, 0, 0, 0, 0, abi.agg_none());
     if (b.class != abi.CLASS_BYREF) { ret 1; }
     if (b.reg   != REG_A0)          { ret 1; }
     # >16 bytes with the integer bank exhausted: the pointer is passed on the stack.
-    val e: abi.ParamSlot = classify_arg(0, 32, 8, false, 0, true, 8, 0, 0, 0);
+    val e: abi.ParamSlot = classify_arg(0, 32, 8, false, 0, true, 8, 0, 0, 0, abi.agg_none());
     if (e.class != abi.CLASS_STACK_BYREF) { ret 1; }
     ret 0;
 }
@@ -494,7 +561,7 @@ test "mach.lang.target.abi.lp64.classify_arg:aggregate_placement" {
 test "mach.lang.target.abi.lp64.classify_arg:aggregate_register_stack_split" {
     # seven integer registers used (a7 free): the low eightbyte rides a7, the high
     # eightbyte rides an outgoing stack slot.
-    val sp: abi.ParamSlot = classify_arg(0, 16, 8, false, 0, true, 7, 0, 0, 0);
+    val sp: abi.ParamSlot = classify_arg(0, 16, 8, false, 0, true, 7, 0, 0, 0, abi.agg_none());
     if (sp.class            != abi.CLASS_GP)    { ret 1; }
     if (sp.piece_count      != 2)               { ret 1; }
     if (sp.pieces[0].kind   != abi.PIECE_GP)    { ret 1; }
@@ -503,7 +570,7 @@ test "mach.lang.target.abi.lp64.classify_arg:aggregate_register_stack_split" {
     if (sp.pieces[1].kind   != abi.PIECE_STACK) { ret 1; }
     if (sp.pieces[1].src_off != 8)              { ret 1; }
     # no integer register left (all eight used): the whole aggregate spills by value.
-    val st: abi.ParamSlot = classify_arg(0, 16, 8, false, 0, true, 8, 0, 0, 0);
+    val st: abi.ParamSlot = classify_arg(0, 16, 8, false, 0, true, 8, 0, 0, 0, abi.agg_none());
     if (st.class != abi.CLASS_STACK)            { ret 1; }
     ret 0;
 }
@@ -513,53 +580,146 @@ test "mach.lang.target.abi.lp64.classify_arg:aggregate_register_stack_split" {
 # the registers falls back to the integer convention
 test "mach.lang.target.abi.lp64.classify_arg:hard_float_struct_flattening" {
     # a single-float struct (8 bytes, one f64 member) rides fa0.
-    val one: abi.ParamSlot = classify_arg(0, 8, 8, false, 0, true, 0, 0, 1, 8);
+    val one: abi.ParamSlot = classify_arg(0, 8, 8, false, 0, true, 0, 0, 1, 8, abi.agg_none());
     if (one.class     != abi.CLASS_HFA)    { ret 1; }
     if (one.reg       != fp_param_reg(0))  { ret 1; }
     if (one.reg_count != 1)                { ret 1; }
     if (one.reg_width != 8)                { ret 1; }
     # a two-float struct (two f32 members) rides fa0:fa1, each 4 bytes.
-    val two: abi.ParamSlot = classify_arg(0, 8, 4, false, 0, true, 0, 0, 2, 4);
+    val two: abi.ParamSlot = classify_arg(0, 8, 4, false, 0, true, 0, 0, 2, 4, abi.agg_none());
     if (two.class     != abi.CLASS_HFA)    { ret 1; }
     if (two.reg       != fp_param_reg(0))  { ret 1; }
     if (two.reg_count != 2)                { ret 1; }
     if (two.reg_width != 4)                { ret 1; }
     # the float bank advances independently of the integer bank: with six fa
     # registers used, a two-float struct rides the last fa pair (fa6:fa7).
-    val mid: abi.ParamSlot = classify_arg(0, 16, 8, false, 0, true, 3, 6, 2, 8);
+    val mid: abi.ParamSlot = classify_arg(0, 16, 8, false, 0, true, 3, 6, 2, 8, abi.agg_none());
     if (mid.class != abi.CLASS_HFA)        { ret 1; }
     if (mid.reg   != fp_param_reg(6))      { ret 1; }
     # the fa bank lacks two registers (seven used): the struct falls back to the
     # integer convention (a 9-16 byte pair here), not a cross-bank split.
-    val fall: abi.ParamSlot = classify_arg(0, 16, 8, false, 0, true, 0, 7, 2, 8);
+    val fall: abi.ParamSlot = classify_arg(0, 16, 8, false, 0, true, 0, 7, 2, 8, abi.agg_none());
     if (fall.class != abi.CLASS_GP) { ret 1; }
     if (fall.reg   != REG_A0)       { ret 1; }
     if (fall.reg2  != REG_A1)       { ret 1; }
     # a three-float struct is not flattened (hfa_members > 2): the integer convention.
-    val three: abi.ParamSlot = classify_arg(0, 16, 4, false, 0, true, 0, 0, 3, 4);
+    val three: abi.ParamSlot = classify_arg(0, 16, 4, false, 0, true, 0, 0, 3, 4, abi.agg_none());
     if (three.class != abi.CLASS_GP) { ret 1; }
+    ret 0;
+}
+
+# a different-width float pair (e.g. {f32; f64}) the uniform-HFA rule does not place
+# rides one fa register each at its own width / field offset; a mixed float+integer
+# struct (e.g. {f64; i64}) rides the float in fa0 and the integer in a0; either falls
+# back to the integer convention when a needed register bank is exhausted
+test "mach.lang.target.abi.lp64.classify_arg:mixed_and_diff_width_float_pairs" {
+    # {f32; f64}: f32 at offset 0 (width 4), f64 at offset 8 (width 8) -> fa0:fa1.
+    var ff: abi.AggLayout;
+    ff.field_count = 2;
+    ff.fields[0].is_float = true;
+    ff.fields[0].offset   = 0;
+    ff.fields[0].width    = 4;
+    ff.fields[1].is_float = true;
+    ff.fields[1].offset   = 8;
+    ff.fields[1].width    = 8;
+    val fp: abi.ParamSlot = classify_arg(0, 16, 8, false, 0, true, 0, 0, 0, 0, ff);
+    if (fp.class             != abi.CLASS_FP)    { ret 1; }
+    if (fp.piece_count       != 2)               { ret 1; }
+    if (fp.pieces[0].kind    != abi.PIECE_FP)    { ret 1; }
+    if (fp.pieces[0].reg     != fp_param_reg(0)) { ret 1; }
+    if (fp.pieces[0].src_off != 0)               { ret 1; }
+    if (fp.pieces[0].width   != 4)               { ret 1; }
+    if (fp.pieces[1].kind    != abi.PIECE_FP)    { ret 1; }
+    if (fp.pieces[1].reg     != fp_param_reg(1)) { ret 1; }
+    if (fp.pieces[1].src_off != 8)               { ret 1; }
+    if (fp.pieces[1].width   != 8)               { ret 1; }
+
+    # {f64; i64}: float at offset 0 (width 8), integer at offset 8 -> fa0 + a0.
+    var fi: abi.AggLayout;
+    fi.field_count = 2;
+    fi.fields[0].is_float = true;
+    fi.fields[0].offset   = 0;
+    fi.fields[0].width    = 8;
+    fi.fields[1].is_float = false;
+    fi.fields[1].offset   = 8;
+    fi.fields[1].width    = 8;
+    val mx: abi.ParamSlot = classify_arg(0, 16, 8, false, 0, true, 0, 0, 0, 0, fi);
+    if (mx.class             != abi.CLASS_GP)    { ret 1; }
+    if (mx.piece_count       != 2)               { ret 1; }
+    if (mx.pieces[0].kind    != abi.PIECE_FP)    { ret 1; }
+    if (mx.pieces[0].reg     != fp_param_reg(0)) { ret 1; }
+    if (mx.pieces[0].src_off != 0)               { ret 1; }
+    if (mx.pieces[1].kind    != abi.PIECE_GP)    { ret 1; }
+    if (mx.pieces[1].reg     != REG_A0)          { ret 1; }
+    if (mx.pieces[1].src_off != 8)               { ret 1; }
+
+    # the fa bank is exhausted for the mixed case (fp_used = 8): fall back to the
+    # integer convention (a 9-16 byte a0:a1 pair), not a cross-bank piece slot.
+    val fb: abi.ParamSlot = classify_arg(0, 16, 8, false, 0, true, 0, 8, 0, 0, fi);
+    if (fb.class          != abi.CLASS_GP) { ret 1; }
+    if (fb.reg            != REG_A0)       { ret 1; }
+    if (fb.reg2           != REG_A1)       { ret 1; }
+    if (fb.pieces[0].kind != abi.PIECE_GP) { ret 1; }
     ret 0;
 }
 
 # scalar and small-aggregate returns place a0 / fa0 / a0:a1, and a >16-byte
 # aggregate returns through the a0 sret pointer
 test "mach.lang.target.abi.lp64.classify_return:placement" {
-    val v: abi.ParamSlot = classify_return(0, 0, false, 0, false, 0, 0);
+    val v: abi.ParamSlot = classify_return(0, 0, false, 0, false, 0, 0, abi.agg_none());
     if (v.class != abi.CLASS_GP || v.reg != -1) { ret 1; }
-    val i: abi.ParamSlot = classify_return(8, 8, false, 0, false, 0, 0);
+    val i: abi.ParamSlot = classify_return(8, 8, false, 0, false, 0, 0, abi.agg_none());
     if (i.reg != REG_A0) { ret 1; }
-    val f: abi.ParamSlot = classify_return(8, 8, true, 0, false, 0, 0);
+    val f: abi.ParamSlot = classify_return(8, 8, true, 0, false, 0, 0, abi.agg_none());
     if (f.class != abi.CLASS_FP || f.reg != fp_param_reg(0)) { ret 1; }
-    val a: abi.ParamSlot = classify_return(16, 8, false, 0, true, 0, 0);
+    val a: abi.ParamSlot = classify_return(16, 8, false, 0, true, 0, 0, abi.agg_none());
     if (a.reg != REG_A0 || a.reg2 != REG_A1) { ret 1; }
-    val r: abi.ParamSlot = classify_return(32, 8, false, 0, true, 0, 0);
+    val r: abi.ParamSlot = classify_return(32, 8, false, 0, true, 0, 0, abi.agg_none());
     if (r.class != abi.CLASS_SRET || r.reg != REG_A0) { ret 1; }
     # a struct that flattens to two floats returns in the fa0:fa1 run.
-    val h: abi.ParamSlot = classify_return(16, 8, false, 0, true, 2, 8);
+    val h: abi.ParamSlot = classify_return(16, 8, false, 0, true, 2, 8, abi.agg_none());
     if (h.class     != abi.CLASS_HFA)   { ret 1; }
     if (h.reg       != fp_param_reg(0)) { ret 1; }
     if (h.reg_count != 2)               { ret 1; }
     if (h.reg_width != 8)               { ret 1; }
+    ret 0;
+}
+
+# a different-width float pair returns in fa0:fa1 at each member's width; a mixed
+# float+integer struct returns the float in fa0 and the integer in a0
+test "mach.lang.target.abi.lp64.classify_return:mixed_and_diff_width_float_pairs" {
+    var ff: abi.AggLayout;
+    ff.field_count = 2;
+    ff.fields[0].is_float = true;
+    ff.fields[0].offset   = 0;
+    ff.fields[0].width    = 4;
+    ff.fields[1].is_float = true;
+    ff.fields[1].offset   = 8;
+    ff.fields[1].width    = 8;
+    val fr: abi.ParamSlot = classify_return(16, 8, false, 0, true, 0, 0, ff);
+    if (fr.class             != abi.CLASS_FP)    { ret 1; }
+    if (fr.piece_count       != 2)               { ret 1; }
+    if (fr.pieces[0].kind    != abi.PIECE_FP)    { ret 1; }
+    if (fr.pieces[0].reg     != fp_param_reg(0)) { ret 1; }
+    if (fr.pieces[0].width   != 4)               { ret 1; }
+    if (fr.pieces[1].reg     != fp_param_reg(1)) { ret 1; }
+    if (fr.pieces[1].width   != 8)               { ret 1; }
+
+    var fi: abi.AggLayout;
+    fi.field_count = 2;
+    fi.fields[0].is_float = true;
+    fi.fields[0].offset   = 0;
+    fi.fields[0].width    = 8;
+    fi.fields[1].is_float = false;
+    fi.fields[1].offset   = 8;
+    fi.fields[1].width    = 8;
+    val mr: abi.ParamSlot = classify_return(16, 8, false, 0, true, 0, 0, fi);
+    if (mr.class          != abi.CLASS_GP)    { ret 1; }
+    if (mr.piece_count    != 2)               { ret 1; }
+    if (mr.pieces[0].kind  != abi.PIECE_FP)   { ret 1; }
+    if (mr.pieces[0].reg   != fp_param_reg(0)) { ret 1; }
+    if (mr.pieces[1].kind  != abi.PIECE_GP)   { ret 1; }
+    if (mr.pieces[1].reg   != REG_A0)         { ret 1; }
     ret 0;
 }
 

--- a/src/lang/target/abi/lp64.mach
+++ b/src/lang/target/abi/lp64.mach
@@ -194,16 +194,22 @@ pub fun classify_arg(index: i32, size: u64, align: u64,
             }
             ret abi.make_slot(abi.CLASS_STACK, -1, -1, 0, size);
         }
-        # 9-16 bytes: a consecutive integer pair, or spill by value if two integer
-        # registers do not remain. DEFERRED: the psABI rule that splits a 9-16 byte
-        # aggregate across the last integer register and the stack when exactly one
-        # register remains needs a register/stack split slot the shared `emit_arg_slot`
-        # does not model; until that seam exists the whole aggregate is placed by value
-        # on the stack here (self-consistent across caller and callee, divergent from
-        # the C psABI only at an FFI boundary).
+        # 9-16 bytes: a consecutive integer pair when two integer registers remain.
         if (gp_used + 2 <= GP_PARAM_COUNT) {
             ret abi.make_slot(abi.CLASS_GP, gp_param_reg(gp_used), gp_param_reg(gp_used + 1), 0, size);
         }
+        # exactly one integer register remains: the lp64d boundary rule places the low
+        # eightbyte in that register and the high eightbyte in an outgoing stack slot
+        # (a register-plus-stack split), rather than spilling the whole aggregate. the
+        # low eightbyte loads from offset 0; the high eightbyte (offset 8) rides one
+        # XLEN stack slot.
+        if (gp_used + 1 == GP_PARAM_COUNT) {
+            var ps: [2]abi.ParamPiece;
+            ps[0] = abi.make_piece(abi.PIECE_GP,    gp_param_reg(gp_used), 0, 0, 8);
+            ps[1] = abi.make_piece(abi.PIECE_STACK, -1,                    8, 0, 8);
+            ret abi.make_slot_pieces(abi.CLASS_GP, ?ps[0], 2, size);
+        }
+        # no integer register remains: the whole aggregate goes by value on the stack.
         ret abi.make_slot(abi.CLASS_STACK, -1, -1, 0, size);
     }
 
@@ -479,6 +485,26 @@ test "mach.lang.target.abi.lp64.classify_arg:aggregate_placement" {
     # >16 bytes with the integer bank exhausted: the pointer is passed on the stack.
     val e: abi.ParamSlot = classify_arg(0, 32, 8, false, 0, true, 8, 0, 0, 0);
     if (e.class != abi.CLASS_STACK_BYREF) { ret 1; }
+    ret 0;
+}
+
+# a 9-16 byte integer aggregate with exactly one integer register left splits across
+# that register and an outgoing stack slot (the lp64d boundary rule); with none left
+# it spills whole by value
+test "mach.lang.target.abi.lp64.classify_arg:aggregate_register_stack_split" {
+    # seven integer registers used (a7 free): the low eightbyte rides a7, the high
+    # eightbyte rides an outgoing stack slot.
+    val sp: abi.ParamSlot = classify_arg(0, 16, 8, false, 0, true, 7, 0, 0, 0);
+    if (sp.class            != abi.CLASS_GP)    { ret 1; }
+    if (sp.piece_count      != 2)               { ret 1; }
+    if (sp.pieces[0].kind   != abi.PIECE_GP)    { ret 1; }
+    if (sp.pieces[0].reg    != REG_A0 + 7)      { ret 1; }
+    if (sp.pieces[0].src_off != 0)              { ret 1; }
+    if (sp.pieces[1].kind   != abi.PIECE_STACK) { ret 1; }
+    if (sp.pieces[1].src_off != 8)              { ret 1; }
+    # no integer register left (all eight used): the whole aggregate spills by value.
+    val st: abi.ParamSlot = classify_arg(0, 16, 8, false, 0, true, 8, 0, 0, 0);
+    if (st.class != abi.CLASS_STACK)            { ret 1; }
     ret 0;
 }
 

--- a/src/lang/target/abi/sysv.mach
+++ b/src/lang/target/abi/sysv.mach
@@ -116,7 +116,7 @@ pub fun classify(size: u64, align: u64, is_float: bool, fp_eightbytes: u8,
                  is_aggregate: bool, gp_used: i32, fp_used: i32,
                  hfa_members: u8, hfa_elem: u8) abi.ParamSlot {
     ret classify_arg(0, size, align, is_float, fp_eightbytes, is_aggregate,
-                     gp_used, fp_used, hfa_members, hfa_elem);
+                     gp_used, fp_used, hfa_members, hfa_elem, abi.agg_none());
 }
 
 # assign registers or a stack slot for one argument (SysV)
@@ -149,10 +149,12 @@ pub fun classify(size: u64, align: u64, is_float: bool, fp_eightbytes: u8,
 # fp_used:       FP registers already consumed
 # hfa_members:   HFA member count (AAPCS64-only; unused under SysV)
 # hfa_elem:      HFA fundamental member width (AAPCS64-only; unused under SysV)
+# agg:           the flattened-aggregate descriptor (lp64d-only; unused under SysV)
 # ret:           the placement decision
 pub fun classify_arg(index: i32, size: u64, align: u64,
                      is_float: bool, fp_eightbytes: u8, is_aggregate: bool,
-                     gp_used: i32, fp_used: i32, hfa_members: u8, hfa_elem: u8) abi.ParamSlot {
+                     gp_used: i32, fp_used: i32, hfa_members: u8, hfa_elem: u8,
+                     agg: abi.AggLayout) abi.ParamSlot {
     if (is_aggregate && size > MAX_REG_RET) {
         if (gp_used < GP_PARAM_COUNT) {
             ret abi.make_slot(abi.CLASS_BYREF, gp_param_reg(gp_used), -1, 0, 8);
@@ -231,10 +233,11 @@ pub fun classify_arg(index: i32, size: u64, align: u64,
 # is_aggregate:  true if the value is an aggregate
 # hfa_members:   HFA member count (AAPCS64-only; unused under SysV)
 # hfa_elem:      HFA fundamental member width (AAPCS64-only; unused under SysV)
+# agg:           the flattened-aggregate descriptor (lp64d-only; unused under SysV)
 # ret:           the placement decision
 pub fun classify_return(size: u64, align: u64,
                         is_float: bool, fp_eightbytes: u8, is_aggregate: bool,
-                        hfa_members: u8, hfa_elem: u8) abi.ParamSlot {
+                        hfa_members: u8, hfa_elem: u8, agg: abi.AggLayout) abi.ParamSlot {
     if (size == 0) {
         ret abi.make_slot(abi.CLASS_GP, -1, -1, 0, 0);
     }
@@ -421,7 +424,7 @@ pub fun register(reg: *abi.AbiRegistry) R.Result[bool, str] {
 
 # {f64; f64} -> both eightbytes SSE -> the two vector argument registers.
 test "mach.lang.target.abi.sysv.classify_arg:all_float_16byte_rides_xmm_pair" {
-    val s: abi.ParamSlot = classify_arg(0, 16, 8, false, 3, true, 0, 0, 0, 0);
+    val s: abi.ParamSlot = classify_arg(0, 16, 8, false, 3, true, 0, 0, 0, 0, abi.agg_none());
     if (s.class != abi.CLASS_GP)    { ret 1; }
     if (s.reg   != fp_param_reg(0)) { ret 1; }
     if (s.reg2  != fp_param_reg(1)) { ret 1; }
@@ -430,7 +433,7 @@ test "mach.lang.target.abi.sysv.classify_arg:all_float_16byte_rides_xmm_pair" {
 
 # {f32; f32} (8 bytes) -> one SSE eightbyte -> XMM0.
 test "mach.lang.target.abi.sysv.classify_arg:all_float_8byte_rides_one_xmm" {
-    val s: abi.ParamSlot = classify_arg(0, 8, 4, false, 1, true, 0, 0, 0, 0);
+    val s: abi.ParamSlot = classify_arg(0, 8, 4, false, 1, true, 0, 0, 0, 0, abi.agg_none());
     if (s.class != abi.CLASS_GP)    { ret 1; }
     if (s.reg   != fp_param_reg(0)) { ret 1; }
     if (s.reg2  != -1)              { ret 1; }
@@ -440,10 +443,10 @@ test "mach.lang.target.abi.sysv.classify_arg:all_float_8byte_rides_one_xmm" {
 # {i64; f64} -> eightbyte 0 INTEGER (RDI), eightbyte 1 SSE (XMM0); the reverse
 # {f64; i64} fills the banks independently, so the integer eightbyte takes RDI.
 test "mach.lang.target.abi.sysv.classify_arg:mixed_int_sse_rides_rdi_xmm" {
-    val s: abi.ParamSlot = classify_arg(0, 16, 8, false, 2, true, 0, 0, 0, 0);
+    val s: abi.ParamSlot = classify_arg(0, 16, 8, false, 2, true, 0, 0, 0, 0, abi.agg_none());
     if (s.reg  != REG_RDI)         { ret 1; }
     if (s.reg2 != fp_param_reg(0)) { ret 1; }
-    val r: abi.ParamSlot = classify_arg(0, 16, 8, false, 1, true, 0, 0, 0, 0);
+    val r: abi.ParamSlot = classify_arg(0, 16, 8, false, 1, true, 0, 0, 0, 0, abi.agg_none());
     if (r.reg  != fp_param_reg(0)) { ret 1; }
     if (r.reg2 != REG_RDI)         { ret 1; }
     ret 0;
@@ -451,7 +454,7 @@ test "mach.lang.target.abi.sysv.classify_arg:mixed_int_sse_rides_rdi_xmm" {
 
 # {i64; i64} (mask 0) -> RDI:RSI, exactly as before SSE classification.
 test "mach.lang.target.abi.sysv.classify_arg:all_integer_rides_gp_pair" {
-    val s: abi.ParamSlot = classify_arg(0, 16, 8, false, 0, true, 0, 0, 0, 0);
+    val s: abi.ParamSlot = classify_arg(0, 16, 8, false, 0, true, 0, 0, 0, 0, abi.agg_none());
     if (s.reg  != REG_RDI) { ret 1; }
     if (s.reg2 != REG_RSI) { ret 1; }
     ret 0;
@@ -460,7 +463,7 @@ test "mach.lang.target.abi.sysv.classify_arg:all_integer_rides_gp_pair" {
 # with seven XMM registers already used, a two-SSE aggregate needs two but only
 # one remains, so the whole aggregate spills to the stack by value.
 test "mach.lang.target.abi.sysv.classify_arg:sse_bank_exhaustion_spills" {
-    val s: abi.ParamSlot = classify_arg(0, 16, 8, false, 3, true, 0, 7, 0, 0);
+    val s: abi.ParamSlot = classify_arg(0, 16, 8, false, 3, true, 0, 7, 0, 0, abi.agg_none());
     if (s.class != abi.CLASS_STACK) { ret 1; }
     if (s.size  != 16)              { ret 1; }
     ret 0;
@@ -468,10 +471,10 @@ test "mach.lang.target.abi.sysv.classify_arg:sse_bank_exhaustion_spills" {
 
 # {f64; f64} returns in XMM0:XMM1; one all-float eightbyte returns in XMM0.
 test "mach.lang.target.abi.sysv.classify_return:all_float_returns_xmm_pair" {
-    val s: abi.ParamSlot = classify_return(16, 8, false, 3, true, 0, 0);
+    val s: abi.ParamSlot = classify_return(16, 8, false, 3, true, 0, 0, abi.agg_none());
     if (s.reg  != REG_XMM0) { ret 1; }
     if (s.reg2 != REG_XMM1) { ret 1; }
-    val o: abi.ParamSlot = classify_return(8, 4, false, 1, true, 0, 0);
+    val o: abi.ParamSlot = classify_return(8, 4, false, 1, true, 0, 0, abi.agg_none());
     if (o.reg  != REG_XMM0) { ret 1; }
     if (o.reg2 != -1)       { ret 1; }
     ret 0;
@@ -479,19 +482,19 @@ test "mach.lang.target.abi.sysv.classify_return:all_float_returns_xmm_pair" {
 
 # {i64; i64} -> RAX:RDX; {i64; f64} -> RAX:XMM0.
 test "mach.lang.target.abi.sysv.classify_return:banks_fill_in_order" {
-    val gp: abi.ParamSlot = classify_return(16, 8, false, 0, true, 0, 0);
+    val gp: abi.ParamSlot = classify_return(16, 8, false, 0, true, 0, 0, abi.agg_none());
     if (gp.reg != REG_RAX || gp.reg2 != REG_RDX) { ret 1; }
-    val mix: abi.ParamSlot = classify_return(16, 8, false, 2, true, 0, 0);
+    val mix: abi.ParamSlot = classify_return(16, 8, false, 2, true, 0, 0, abi.agg_none());
     if (mix.reg != REG_RAX || mix.reg2 != REG_XMM0) { ret 1; }
     ret 0;
 }
 
 # a scalar float takes an XMM register, a scalar integer a GP register.
 test "mach.lang.target.abi.sysv.classify_arg:scalar_float_xmm_integer_gp" {
-    val f: abi.ParamSlot = classify_arg(0, 8, 8, true, 0, false, 0, 0, 0, 0);
+    val f: abi.ParamSlot = classify_arg(0, 8, 8, true, 0, false, 0, 0, 0, 0, abi.agg_none());
     if (f.class != abi.CLASS_FP)    { ret 1; }
     if (f.reg   != fp_param_reg(0)) { ret 1; }
-    val i: abi.ParamSlot = classify_arg(0, 8, 8, false, 0, false, 0, 0, 0, 0);
+    val i: abi.ParamSlot = classify_arg(0, 8, 8, false, 0, false, 0, 0, 0, 0, abi.agg_none());
     if (i.class != abi.CLASS_GP) { ret 1; }
     if (i.reg   != REG_RDI)      { ret 1; }
     ret 0;
@@ -512,17 +515,17 @@ test "mach.lang.target.abi.sysv.register:indirect_result_in_argfile" {
 # a >16-byte aggregate is MEMORY-class (passed by value on the stack) once the GP
 # argument registers are exhausted; with one register left it is CLASS_BYREF.
 test "mach.lang.target.abi.sysv.classify_arg:large_aggregate_memory_class_when_gp_exhausted" {
-    val s1: abi.ParamSlot = classify_arg(0, 32, 8, false, 0, true, 6, 0, 0, 0);
+    val s1: abi.ParamSlot = classify_arg(0, 32, 8, false, 0, true, 6, 0, 0, 0, abi.agg_none());
     if (s1.class != abi.CLASS_STACK) { ret 1; }
     if (s1.reg   != -1)              { ret 1; }
     if (s1.size  != 32)              { ret 1; }
 
-    val s2: abi.ParamSlot = classify_arg(0, 17, 8, false, 0, true, 6, 0, 0, 0);
+    val s2: abi.ParamSlot = classify_arg(0, 17, 8, false, 0, true, 6, 0, 0, 0, abi.agg_none());
     if (s2.class != abi.CLASS_STACK) { ret 1; }
     if (s2.reg   != -1)              { ret 1; }
     if (s2.size  != 17)              { ret 1; }
 
-    val s3: abi.ParamSlot = classify_arg(0, 32, 8, false, 0, true, 5, 0, 0, 0);
+    val s3: abi.ParamSlot = classify_arg(0, 32, 8, false, 0, true, 5, 0, 0, 0, abi.agg_none());
     if (s3.class != abi.CLASS_BYREF) { ret 1; }
     ret 0;
 }

--- a/src/lang/target/abi/win64.mach
+++ b/src/lang/target/abi/win64.mach
@@ -165,7 +165,7 @@ pub fun float_dup_gp_reg(index: i32) i32 {
 pub fun classify(size: u64, align: u64, is_float: bool, fp_eightbytes: u8,
                  is_aggregate: bool, gp_used: i32, fp_used: i32,
                  hfa_members: u8, hfa_elem: u8) abi.ParamSlot {
-    ret classify_arg(0, size, align, is_float, fp_eightbytes, is_aggregate, gp_used, fp_used, hfa_members, hfa_elem);
+    ret classify_arg(0, size, align, is_float, fp_eightbytes, is_aggregate, gp_used, fp_used, hfa_members, hfa_elem, abi.agg_none());
 }
 
 # assign a register or stack slot for one argument (win64).
@@ -196,10 +196,12 @@ pub fun classify(size: u64, align: u64, is_float: bool, fp_eightbytes: u8,
 # fp_used:       FP registers already consumed
 # hfa_members:   HFA member count (AAPCS64-only; unused under win64)
 # hfa_elem:      HFA fundamental member width (AAPCS64-only; unused under win64)
+# agg:           the flattened-aggregate descriptor (lp64d-only; unused under win64)
 # ret:           the placement decision
 pub fun classify_arg(index: i32, size: u64, align: u64,
                      is_float: bool, fp_eightbytes: u8, is_aggregate: bool,
-                     gp_used: i32, fp_used: i32, hfa_members: u8, hfa_elem: u8) abi.ParamSlot {
+                     gp_used: i32, fp_used: i32, hfa_members: u8, hfa_elem: u8,
+                     agg: abi.AggLayout) abi.ParamSlot {
     val slot: i32 = slot_index(gp_used, fp_used);
 
     if (is_aggregate) {
@@ -252,10 +254,11 @@ pub fun classify_arg(index: i32, size: u64, align: u64,
 # is_aggregate:  true if the value is an aggregate
 # hfa_members:   HFA member count (AAPCS64-only; unused under win64)
 # hfa_elem:      HFA fundamental member width (AAPCS64-only; unused under win64)
+# agg:           the flattened-aggregate descriptor (lp64d-only; unused under win64)
 # ret:           the placement decision
 pub fun classify_return(size: u64, align: u64,
                         is_float: bool, fp_eightbytes: u8, is_aggregate: bool,
-                        hfa_members: u8, hfa_elem: u8) abi.ParamSlot {
+                        hfa_members: u8, hfa_elem: u8, agg: abi.AggLayout) abi.ParamSlot {
     if (size == 0) {
         ret abi.make_slot(abi.CLASS_GP, -1, -1, 0, 0);
     }
@@ -452,18 +455,18 @@ pub fun register_win64(reg: *abi.AbiRegistry) R.Result[bool, str] {
 # scalar integers fill RCX, RDX, R8, R9 in order, then the fifth spills to the
 # stack by value.
 test "mach.lang.target.abi.win64.classify_arg:scalar_integers_then_spill" {
-    val s0: abi.ParamSlot = classify_arg(0, 8, 8, false, 0, false, 0, 0, 0, 0);
+    val s0: abi.ParamSlot = classify_arg(0, 8, 8, false, 0, false, 0, 0, 0, 0, abi.agg_none());
     if (s0.class != abi.CLASS_GP) { ret 1; }
     if (s0.reg   != REG_RCX)      { ret 1; }
 
-    val s1: abi.ParamSlot = classify_arg(1, 8, 8, false, 0, false, 1, 0, 0, 0);
+    val s1: abi.ParamSlot = classify_arg(1, 8, 8, false, 0, false, 1, 0, 0, 0, abi.agg_none());
     if (s1.reg != REG_RDX) { ret 1; }
-    val s2: abi.ParamSlot = classify_arg(2, 8, 8, false, 0, false, 2, 0, 0, 0);
+    val s2: abi.ParamSlot = classify_arg(2, 8, 8, false, 0, false, 2, 0, 0, 0, abi.agg_none());
     if (s2.reg != REG_R8) { ret 1; }
-    val s3: abi.ParamSlot = classify_arg(3, 8, 8, false, 0, false, 3, 0, 0, 0);
+    val s3: abi.ParamSlot = classify_arg(3, 8, 8, false, 0, false, 3, 0, 0, 0, abi.agg_none());
     if (s3.reg != REG_R9) { ret 1; }
 
-    val s4: abi.ParamSlot = classify_arg(4, 8, 8, false, 0, false, 4, 0, 0, 0);
+    val s4: abi.ParamSlot = classify_arg(4, 8, 8, false, 0, false, 4, 0, 0, 0, abi.agg_none());
     if (s4.class != abi.CLASS_STACK) { ret 1; }
     if (s4.reg   != -1)              { ret 1; }
     if (s4.size  != 8)               { ret 1; }
@@ -472,15 +475,15 @@ test "mach.lang.target.abi.win64.classify_arg:scalar_integers_then_spill" {
 
 # floats fill XMM0-XMM3 in order, then the fifth positional argument spills.
 test "mach.lang.target.abi.win64.classify_arg:floats_then_spill" {
-    val f0: abi.ParamSlot = classify_arg(0, 8, 8, true, 0, false, 0, 0, 0, 0);
+    val f0: abi.ParamSlot = classify_arg(0, 8, 8, true, 0, false, 0, 0, 0, 0, abi.agg_none());
     if (f0.class != abi.CLASS_FP)                            { ret 1; }
     if (f0.reg   != isa.regid_make(isa.REG_CLASS_ID_XMM, 0)) { ret 1; }
 
-    val f3: abi.ParamSlot = classify_arg(3, 4, 4, true, 0, false, 0, 3, 0, 0);
+    val f3: abi.ParamSlot = classify_arg(3, 4, 4, true, 0, false, 0, 3, 0, 0, abi.agg_none());
     if (f3.class != abi.CLASS_FP)                            { ret 1; }
     if (f3.reg   != isa.regid_make(isa.REG_CLASS_ID_XMM, 3)) { ret 1; }
 
-    val f4: abi.ParamSlot = classify_arg(4, 8, 8, true, 0, false, 0, 4, 0, 0);
+    val f4: abi.ParamSlot = classify_arg(4, 8, 8, true, 0, false, 0, 4, 0, 0, abi.agg_none());
     if (f4.class != abi.CLASS_STACK) { ret 1; }
     ret 0;
 }
@@ -488,15 +491,15 @@ test "mach.lang.target.abi.win64.classify_arg:floats_then_spill" {
 # an integer and a float share one positional slot per argument: an integer in
 # slot 0 (RCX) pushes a following float to slot 1 (XMM1), and vice versa.
 test "mach.lang.target.abi.win64.classify_arg:shared_positional_slot" {
-    val i0: abi.ParamSlot = classify_arg(0, 8, 8, false, 0, false, 0, 0, 0, 0);
+    val i0: abi.ParamSlot = classify_arg(0, 8, 8, false, 0, false, 0, 0, 0, 0, abi.agg_none());
     if (i0.reg != REG_RCX) { ret 1; }
-    val f1: abi.ParamSlot = classify_arg(1, 8, 8, true, 0, false, 1, 0, 0, 0);
+    val f1: abi.ParamSlot = classify_arg(1, 8, 8, true, 0, false, 1, 0, 0, 0, abi.agg_none());
     if (f1.class != abi.CLASS_FP)                            { ret 1; }
     if (f1.reg   != isa.regid_make(isa.REG_CLASS_ID_XMM, 1)) { ret 1; }
 
-    val g0: abi.ParamSlot = classify_arg(0, 8, 8, true, 0, false, 0, 0, 0, 0);
+    val g0: abi.ParamSlot = classify_arg(0, 8, 8, true, 0, false, 0, 0, 0, 0, abi.agg_none());
     if (g0.reg != isa.regid_make(isa.REG_CLASS_ID_XMM, 0)) { ret 1; }
-    val g1: abi.ParamSlot = classify_arg(1, 8, 8, false, 0, false, 0, 1, 0, 0);
+    val g1: abi.ParamSlot = classify_arg(1, 8, 8, false, 0, false, 0, 1, 0, 0, abi.agg_none());
     if (g1.class != abi.CLASS_GP) { ret 1; }
     if (g1.reg   != REG_RDX)      { ret 1; }
     ret 0;
@@ -515,20 +518,20 @@ test "mach.lang.target.abi.win64.float_dup_gp_reg:variadic_duplicate" {
 # 1/2/4/8-byte aggregates ride one integer register by value; every other size is
 # passed by hidden reference, the pointer (8 bytes) in the slot's GP register.
 test "mach.lang.target.abi.win64.classify_arg:aggregate_by_value_or_ref" {
-    val by_val: abi.ParamSlot = classify_arg(0, 8, 8, false, 0, true, 0, 0, 0, 0);
+    val by_val: abi.ParamSlot = classify_arg(0, 8, 8, false, 0, true, 0, 0, 0, 0, abi.agg_none());
     if (by_val.class != abi.CLASS_GP) { ret 1; }
     if (by_val.reg   != REG_RCX)      { ret 1; }
     if (by_val.size  != 8)            { ret 1; }
 
-    val four: abi.ParamSlot = classify_arg(0, 4, 4, false, 0, true, 0, 0, 0, 0);
+    val four: abi.ParamSlot = classify_arg(0, 4, 4, false, 0, true, 0, 0, 0, 0, abi.agg_none());
     if (four.class != abi.CLASS_GP) { ret 1; }
 
-    val by_ref3: abi.ParamSlot = classify_arg(0, 3, 1, false, 0, true, 0, 0, 0, 0);
+    val by_ref3: abi.ParamSlot = classify_arg(0, 3, 1, false, 0, true, 0, 0, 0, 0, abi.agg_none());
     if (by_ref3.class != abi.CLASS_BYREF) { ret 1; }
     if (by_ref3.reg   != REG_RCX)         { ret 1; }
     if (by_ref3.size  != 8)               { ret 1; }
 
-    val by_ref16: abi.ParamSlot = classify_arg(0, 16, 8, false, 0, true, 0, 0, 0, 0);
+    val by_ref16: abi.ParamSlot = classify_arg(0, 16, 8, false, 0, true, 0, 0, 0, 0, abi.agg_none());
     if (by_ref16.class != abi.CLASS_BYREF) { ret 1; }
     if (by_ref16.reg   != REG_RCX)         { ret 1; }
     ret 0;
@@ -538,16 +541,16 @@ test "mach.lang.target.abi.win64.classify_arg:aggregate_by_value_or_ref" {
 # hidden pointer as CLASS_STACK_BYREF (for both a 16-byte and a 3-byte aggregate),
 # while an exhausted by-value-size aggregate spills its own bytes as CLASS_STACK.
 test "mach.lang.target.abi.win64.classify_arg:exhausted_byref_spills_pointer" {
-    val s: abi.ParamSlot = classify_arg(4, 16, 8, false, 0, true, 4, 0, 0, 0);
+    val s: abi.ParamSlot = classify_arg(4, 16, 8, false, 0, true, 4, 0, 0, 0, abi.agg_none());
     if (s.class != abi.CLASS_STACK_BYREF) { ret 1; }
     if (s.reg   != -1)                    { ret 1; }
     if (s.size  != 8)                     { ret 1; }
 
-    val s3: abi.ParamSlot = classify_arg(4, 3, 1, false, 0, true, 4, 0, 0, 0);
+    val s3: abi.ParamSlot = classify_arg(4, 3, 1, false, 0, true, 4, 0, 0, 0, abi.agg_none());
     if (s3.class != abi.CLASS_STACK_BYREF) { ret 1; }
     if (s3.size  != 8)                     { ret 1; }
 
-    val sv: abi.ParamSlot = classify_arg(4, 8, 8, false, 0, true, 4, 0, 0, 0);
+    val sv: abi.ParamSlot = classify_arg(4, 8, 8, false, 0, true, 4, 0, 0, 0, abi.agg_none());
     if (sv.class != abi.CLASS_STACK) { ret 1; }
     if (sv.size  != 8)               { ret 1; }
     ret 0;
@@ -556,15 +559,15 @@ test "mach.lang.target.abi.win64.classify_arg:exhausted_byref_spills_pointer" {
 # scalar returns use RAX (integers) or XMM0 (floats); a void return is CLASS_GP
 # with reg=-1.
 test "mach.lang.target.abi.win64.classify_return:scalars" {
-    val voidr: abi.ParamSlot = classify_return(0, 0, false, 0, false, 0, 0);
+    val voidr: abi.ParamSlot = classify_return(0, 0, false, 0, false, 0, 0, abi.agg_none());
     if (voidr.class != abi.CLASS_GP) { ret 1; }
     if (voidr.reg   != -1)           { ret 1; }
 
-    val ir: abi.ParamSlot = classify_return(8, 8, false, 0, false, 0, 0);
+    val ir: abi.ParamSlot = classify_return(8, 8, false, 0, false, 0, 0, abi.agg_none());
     if (ir.class != abi.CLASS_GP) { ret 1; }
     if (ir.reg   != REG_RAX)      { ret 1; }
 
-    val fr: abi.ParamSlot = classify_return(8, 8, true, 0, false, 0, 0);
+    val fr: abi.ParamSlot = classify_return(8, 8, true, 0, false, 0, 0, abi.agg_none());
     if (fr.class != abi.CLASS_FP) { ret 1; }
     if (fr.reg   != REG_XMM0)     { ret 1; }
     ret 0;
@@ -573,15 +576,15 @@ test "mach.lang.target.abi.win64.classify_return:scalars" {
 # a 1/2/4/8-byte aggregate returns in RAX even when all-float (the SSE mask is
 # ignored, unlike SysV); any other aggregate returns through an sret pointer.
 test "mach.lang.target.abi.win64.classify_return:aggregate_rax_or_sret" {
-    val small: abi.ParamSlot = classify_return(8, 8, false, 0, true, 0, 0);
+    val small: abi.ParamSlot = classify_return(8, 8, false, 0, true, 0, 0, abi.agg_none());
     if (small.class != abi.CLASS_GP) { ret 1; }
     if (small.reg   != REG_RAX)      { ret 1; }
 
-    val fsmall: abi.ParamSlot = classify_return(8, 8, true, 1, true, 0, 0);
+    val fsmall: abi.ParamSlot = classify_return(8, 8, true, 1, true, 0, 0, abi.agg_none());
     if (fsmall.class != abi.CLASS_GP) { ret 1; }
     if (fsmall.reg   != REG_RAX)      { ret 1; }
 
-    val big: abi.ParamSlot = classify_return(12, 4, false, 0, true, 0, 0);
+    val big: abi.ParamSlot = classify_return(12, 4, false, 0, true, 0, 0, abi.agg_none());
     if (big.class != abi.CLASS_SRET) { ret 1; }
     if (big.reg   != REG_RAX)        { ret 1; }
     ret 0;
@@ -590,9 +593,9 @@ test "mach.lang.target.abi.win64.classify_return:aggregate_rax_or_sret" {
 # an sret return reserves the first positional slot: classify_signature seeds
 # gp_used=1 for the hidden RCX pointer, so the first real integer argument is RDX.
 test "mach.lang.target.abi.win64.classify_return:sret_reserves_first_slot" {
-    val ret_slot: abi.ParamSlot = classify_return(24, 8, false, 0, true, 0, 0);
+    val ret_slot: abi.ParamSlot = classify_return(24, 8, false, 0, true, 0, 0, abi.agg_none());
     if (ret_slot.class != abi.CLASS_SRET) { ret 1; }
-    val first_arg: abi.ParamSlot = classify_arg(0, 8, 8, false, 0, false, 1, 0, 0, 0);
+    val first_arg: abi.ParamSlot = classify_arg(0, 8, 8, false, 0, false, 1, 0, 0, 0, abi.agg_none());
     if (first_arg.class != abi.CLASS_GP) { ret 1; }
     if (first_arg.reg   != REG_RDX)      { ret 1; }
     ret 0;

--- a/test/riscv64/src/main.mach
+++ b/test/riscv64/src/main.mach
@@ -118,11 +118,25 @@ fun bitmix(x: u32, y: u32) i64 {
     ret (b ^ a)::i64 & 255;
 }
 
+# a 16-byte integer struct used to exercise the lp64d register-plus-stack split.
+rec Pair { a: i64; b: i64; }
+
+# the lp64d register-plus-stack split probe (#1637): the seven integer parameters
+# fill a0-a6, so the trailing 16-byte integer struct `s` cannot take a register pair
+# (only a7 remains) and rides the boundary rule - its low eightbyte (`s.a`) in a7 and
+# its high eightbyte (`s.b`) in an outgoing stack slot. the callee reads both halves
+# back, so the folded sum proves the caller's split placement and the callee's
+# reconstruction from a register-plus-stack slot agree.
+fun split_probe(p0: i64, p1: i64, p2: i64, p3: i64, p4: i64, p5: i64, p6: i64, s: Pair) i64 {
+    ret p0 + p1 + p2 + p3 + p4 + p5 + p6 + s.a + s.b;
+}
+
 # the program entry. the `_start` symbol the linux linker resolves as the entry
 # point; the calls and the global read-modify-write give the relocations the lane
 # checks, the inline-asm block exercises the RV64A atomics (#1668), and the
 # inline-asm `exit` syscall returns the computed sum as the process exit code
-# (sum_to(10)=45 + na(3)=8 + stack_probe + parse_probe(1) + bitmix + atomics).
+# (sum_to(10)=45 + na(3)=8 + stack_probe + parse_probe(1) + bitmix + split_probe=35
+# + atomics).
 #
 # the atomics run on a stack cell (`{cell}`, address taken through `p`): an lr/sc
 # compare-and-swap loop swaps it from 0 to 7 - the reservation-retry (1b) and
@@ -137,6 +151,12 @@ fun start() {
     code = code + stack_probe();          # frame-slot probe (#1670)
     code = code + parse_probe(1);         # >4KiB long-branch relaxation probe (#1666)
     code = code + bitmix(0xdeadbeef, 0x12345678);  # 32-bit bitwise word-group probe (#1672)
+
+    # the register-plus-stack split probe (#1637): 28 (1+..+7) + s.a(2) + s.b(5) = 35.
+    var pr: Pair;
+    pr.a = 2;
+    pr.b = 5;
+    code = code + split_probe(1, 2, 3, 4, 5, 6, 7, pr);
 
     var cell:  i64  = 0;
     var p:     *i64 = ?cell;

--- a/test/riscv64/verify.sh
+++ b/test/riscv64/verify.sh
@@ -12,10 +12,11 @@ set -euo pipefail
 # the computed exit code the fixture returns, low 8 bits of the running sum: sum 0..9
 # (45) plus the const-shift call argument 1 << 3 (8), the stack-local frame-slot probe
 # (#1670), the >4KiB long-branch relaxation probe (#1666), the 32-bit bitwise
-# word-group probe (#1672), and the RV64A atomics probe (#1668, 18 = swapped 7 +
-# post-rmw cell 11), wrapping to 70. the qemu e2e asserts the exact code, so a
+# word-group probe (#1672), the lp64d register-plus-stack split probe (#1637, 35 =
+# 1+..+7 + struct halves 2 + 5), and the RV64A atomics probe (#1668, 18 = swapped 7 +
+# post-rmw cell 11), wrapping to 105. the qemu e2e asserts the exact code, so a
 # regression in any of those changes it.
-expect_code=70
+expect_code=105
 
 mach="${1:-mach}"
 here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"


### PR DESCRIPTION
Closes #1637.

The shared backend could not express three RISC-V lp64d aggregate placements (escalated, not worked around, by riscv64 slice 3 #1627): a mixed float+integer struct (members split across the FP and GP files), a struct that flattens to two floats of different fundamental width, and the 9–16 byte integer aggregate that splits across the last integer register and the stack. The `reg`/`reg2`/`reg_count`/`reg_width` slot could only describe a single register, a GP pair at fixed 0/8, or a uniform-width FP-only `CLASS_HFA` run.

**Investigation outcome:** the gap is lp64d-specific. x86-64 SysV already places mixed FP+GP aggregates via the `reg`/`reg2` pair (the FP half rides a class-dispatched MOVSD) and never splits a register placement across the stack; AArch64 AAPCS64 is all-or-memory (HFA, GP pair, byref, or whole-stack) and never mixes or splits; Win64 passes anything >8 bytes by reference. So only lp64d needs the new expressiveness — but the primitive is shared.

## Plan
- [x] **Part 1 — the primitive (this commit).** `ParamPiece` (GP/FP/stack chunk with a source offset, stack offset, and width) + a `pieces[]`/`piece_count` list on `ParamSlot`. Every constructor fills it; the IR→MIR consumer materializes all register/stack aggregates through one uniform per-piece path. Behavior-preserving — all 686 tests and the riscv64/macho/freestanding byte-verify fixtures pass unchanged.
- [ ] **Part 2 — the register-plus-stack split (case C).** lp64d emits a split slot (GP reg + stack chunk) for a 9–16 byte integer aggregate when exactly one integer register remains.
- [ ] **Part 3 — mixed + different-width float (cases A, B).** A flatten descriptor (the per-member is-float/offset/width layout the per-ABI classifier needs but the type oracle owns) feeds lp64d's mixed float+integer and different-width float-pair rules.

## Verification
`mach build .` self-host, `mach test .` (686/686), and `test/{riscv64,macho,freestanding}/verify.sh` all green at each commit.
