### PR TITLE
fix(codegen/riscv64): encode FP loads/stores as fld/fsd, not integer ld/sd

### DIFF
--- a/src/lang/target/isa/riscv64/encode.mach
+++ b/src/lang/target/isa/riscv64/encode.mach
@@ -704,6 +704,18 @@ fun encode_mov(st: *encode.EncodeState, f: *mir.MirFunction, mi: *mir.MirInstr) 
 # folded-global symbol destination emits the auipc-based `la` store sequence; otherwise
 # a non-register value (an immediate) is materialized into the scratch register first.
 fun emit_store_mem(st: *encode.EncodeState, f: *mir.MirFunction, dst_mem: *mir.MirOperand, val_op: *mir.MirOperand, width: u8) R.Result[bool, str] {
+    # a float-bank value stores through the F/D store form (fsw / fsd), recovering its
+    # f-register index from the composite id; the folded-global symbol destination has
+    # no float la-store form yet, so it errors loudly rather than mis-encoding as an
+    # integer store of the aliasing GP index.
+    if (reg_is_fp(val_op)) {
+        if (dst_mem.kind == mir.MIR_OP_SYM) {
+            ret R.err[bool, str]("encode: float store to a folded-global symbol is unsupported");
+        }
+        val rr: R.Result[i32, str] = req_fpr(val_op);
+        if (R.is_err[i32, str](rr)) { ret R.err[bool, str](R.unwrap_err[i32, str](rr)); }
+        ret emit_fp_slot_store(st, f, dst_mem, R.unwrap_ok[i32, str](rr)::u32, width);
+    }
     if (dst_mem.kind == mir.MIR_OP_SYM) {
         ret emit_global_store(st, dst_mem, val_op, width);
     }
@@ -803,10 +815,27 @@ fun emit_global_store(st: *encode.EncodeState, symop: *mir.MirOperand, val_op: *
 # extending sub-word form (`load_funct3`) still defines the whole destination register.
 fun encode_load(st: *encode.EncodeState, f: *mir.MirFunction, mi: *mir.MirInstr) R.Result[bool, str] {
     if (mi.operand_count < 2) { ret R.err[bool, str]("encode: load missing operands"); }
-    val rdr: R.Result[i32, str] = req_gpr(?mi.operands[0]);
+    val dst: *mir.MirOperand = ?mi.operands[0];
+    val src: *mir.MirOperand = ?mi.operands[1];
+    # a float-bank destination reads the F/D load form (flw / fld), recovering its
+    # f-register index from the composite id; the folded-global symbol source has no
+    # float la-load form yet, so it errors loudly rather than mis-encoding as an integer
+    # load into the aliasing GP index.
+    if (reg_is_fp(dst)) {
+        if (src.kind == mir.MIR_OP_SYM) {
+            ret R.err[bool, str]("encode: float load from a folded-global symbol is unsupported");
+        }
+        val frd: R.Result[i32, str] = req_fpr(dst);
+        if (R.is_err[i32, str](frd)) { ret R.err[bool, str](R.unwrap_err[i32, str](frd)); }
+        val fmr: R.Result[RvMem, str] = resolve_mem(f, src);
+        if (R.is_err[RvMem, str](fmr)) { ret R.err[bool, str](R.unwrap_err[RvMem, str](fmr)); }
+        val fm: RvMem = R.unwrap_ok[RvMem, str](fmr);
+        emit_fp_mem(st, R.unwrap_ok[i32, str](frd)::u32, fm.base, fm.off, mi.src_width, true);
+        ret R.ok[bool, str](true);
+    }
+    val rdr: R.Result[i32, str] = req_gpr(dst);
     if (R.is_err[i32, str](rdr)) { ret R.err[bool, str](R.unwrap_err[i32, str](rdr)); }
     val rd: u32 = R.unwrap_ok[i32, str](rdr)::u32;
-    val src: *mir.MirOperand = ?mi.operands[1];
     if (src.kind == mir.MIR_OP_SYM) { ret emit_global_load(st, rd, src, mi.src_width); }
     val mr: R.Result[RvMem, str] = resolve_mem(f, src);
     if (R.is_err[RvMem, str](mr)) { ret R.err[bool, str](R.unwrap_err[RvMem, str](mr)); }

--- a/test/riscv64/src/main.mach
+++ b/test/riscv64/src/main.mach
@@ -9,8 +9,10 @@
 # stack-local buffer (frame-slot addressing, #1670), a function whose encoded body
 # exceeds the +-4KiB B-type branch range (long-branch relaxation, #1666), the RV64A
 # atomics (an lr/sc compare-and-swap loop and an amoadd.d read-modify-write, #1668),
-# and an inline-asm exit syscall (the only way to emit `ecall`). the exit code is the
-# computed sum, so the qemu e2e proves the whole pipeline runs end to end.
+# the lp64d hard-float aggregate placements (a mixed float+integer struct and a
+# different-width float pair passed by value, #1637), and an inline-asm exit syscall
+# (the only way to emit `ecall`). the exit code is the computed sum, so the qemu e2e
+# proves the whole pipeline runs end to end.
 
 var total: i64 = 0;
 
@@ -131,12 +133,50 @@ fun split_probe(p0: i64, p1: i64, p2: i64, p3: i64, p4: i64, p5: i64, p6: i64, s
     ret p0 + p1 + p2 + p3 + p4 + p5 + p6 + s.a + s.b;
 }
 
+# a mixed float+integer struct that flattens to two leaves of different banks.
+rec FI { f: f64; i: i64; }
+
+# the lp64d mixed float+integer probe (#1637 case A): the struct is passed by value, so
+# the caller places its float member `f` in fa0 and its integer member `i` in a0, each
+# loaded from its own field offset; the callee reads both members back and folds them
+# into one integer. the folded result proves the cross-bank placement and the callee's
+# reconstruction from a float register plus an integer register agree.
+fun fi_probe(s: FI) i64 { ret s.f::i64 + s.i; }
+
+# a different-fundamental-width float pair: an f32 and an f64 member flatten to two
+# float leaves of unequal width.
+rec FF { a: f32; b: f64; }
+
+# the lp64d different-width float-pair probe (#1637 case B): the struct is passed by
+# value, so the caller places `a` in fa0 (a 4-byte move) and `b` in fa1 (an 8-byte
+# move), each at its own field offset; the callee reads both members back, widening the
+# f32 to f64 before the fold. the folded result proves the per-member-width placement
+# and the callee's reconstruction agree.
+fun ff_probe(s: FF) i64 {
+    val w: f64 = s.a::f64;
+    ret w::i64 + s.b::i64;
+}
+
+# a mixed float+integer struct with SUB-WORD members: an f32 and an i32 flatten to two
+# 4-byte leaves at offsets 0 and 4 of an 8-byte aggregate.
+rec FJ { f: f32; j: i32; }
+
+# the lp64d sub-word mixed probe (#1637 case A, sub-word): the integer member `j` sits
+# at offset 4 and is only 4 bytes wide, so its GP chunk must be a 4-byte access -- a
+# full-word load/store would run past the 8-byte aggregate (the over-wide-GP miscompile
+# the #1637 review caught). the folded result proves the sub-word cross-bank placement
+# and reconstruction agree with no out-of-bounds access.
+fun fj_probe(s: FJ) i64 {
+    val w: f64 = s.f::f64;
+    ret w::i64 + s.j::i64;
+}
+
 # the program entry. the `_start` symbol the linux linker resolves as the entry
 # point; the calls and the global read-modify-write give the relocations the lane
 # checks, the inline-asm block exercises the RV64A atomics (#1668), and the
 # inline-asm `exit` syscall returns the computed sum as the process exit code
 # (sum_to(10)=45 + na(3)=8 + stack_probe + parse_probe(1) + bitmix + split_probe=35
-# + atomics).
+# + fi_probe=7 + ff_probe=12 + fj_probe=9 + atomics).
 #
 # the atomics run on a stack cell (`{cell}`, address taken through `p`): an lr/sc
 # compare-and-swap loop swaps it from 0 to 7 - the reservation-retry (1b) and
@@ -157,6 +197,26 @@ fun start() {
     pr.a = 2;
     pr.b = 5;
     code = code + split_probe(1, 2, 3, 4, 5, 6, 7, pr);
+
+    # the mixed float+integer probe (#1637 case A): f(2.0) -> fa0, i(5) -> a0, fold = 7.
+    var fi: FI;
+    fi.f = 2.0;
+    fi.i = 5;
+    code = code + fi_probe(fi);
+
+    # the different-width float-pair probe (#1637 case B): a(4.0) -> fa0 (4-byte), b(8.0)
+    # -> fa1 (8-byte), fold = 12.
+    var ff: FF;
+    ff.a = 4.0::f32;
+    ff.b = 8.0;
+    code = code + ff_probe(ff);
+
+    # the sub-word mixed probe (#1637 case A, sub-word): f(3.0) -> fa0 (4-byte), j(6) ->
+    # a0 (4-byte, at offset 4), fold = 9. catches the over-wide-GP regression e2e.
+    var fj: FJ;
+    fj.f = 3.0::f32;
+    fj.j = 6;
+    code = code + fj_probe(fj);
 
     var cell:  i64  = 0;
     var p:     *i64 = ?cell;

--- a/test/riscv64/verify.sh
+++ b/test/riscv64/verify.sh
@@ -13,10 +13,13 @@ set -euo pipefail
 # (45) plus the const-shift call argument 1 << 3 (8), the stack-local frame-slot probe
 # (#1670), the >4KiB long-branch relaxation probe (#1666), the 32-bit bitwise
 # word-group probe (#1672), the lp64d register-plus-stack split probe (#1637, 35 =
-# 1+..+7 + struct halves 2 + 5), and the RV64A atomics probe (#1668, 18 = swapped 7 +
-# post-rmw cell 11), wrapping to 105. the qemu e2e asserts the exact code, so a
-# regression in any of those changes it.
-expect_code=105
+# 1+..+7 + struct halves 2 + 5), the lp64d mixed float+integer probe (#1637 case A, 7 =
+# f 2.0 in fa0 + i 5 in a0), the lp64d different-width float-pair probe (#1637 case B,
+# 12 = a 4.0 in fa0 + b 8.0 in fa1), the lp64d sub-word mixed probe (#1637 case A
+# sub-word, 9 = f 3.0 in fa0 + j 6 in a0 at offset 4, the 4-byte GP chunk), and the
+# RV64A atomics probe (#1668, 18 = swapped 7 + post-rmw cell 11), wrapping to 133. the
+# qemu e2e asserts the exact code, so a regression in any of those changes it.
+expect_code=133
 
 mach="${1:-mach}"
 here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"


### PR DESCRIPTION
Closes #1733.

The riscv64 `encode_load` / `emit_store_mem` resolved every operand via `req_gpr` and emitted the integer load/store form, so an f32/f64 round-tripping through memory was read/written from the GP register aliasing the FP index — a silent miscompile of **all** riscv64 hard-float that touches memory (scalar floats, the lp64d HFA flattening, and the #1637 mixed / different-width float aggregates). Latent because the backend is cross-only and the corpus had no riscv float code until the #1637 hard-float fixture exposed it.

## Fix
Both encoders dispatch a float-bank operand (`reg_is_fp`) to `req_fpr` + `emit_fp_mem` / `emit_fp_slot_store` (flw/fld, fsw/fsd), reusing the helpers already wired into the regalloc spill path. The folded-global FP symbol load/store sub-case has no float `la`-form yet and errors loudly rather than mis-encoding (it appears unreachable — riscv lowering materializes a global's address and loads via the pointer path).

## Verification
`test/riscv64` gains float-bearing probes — scalar round-trip plus #1637 case A (mixed f64+i64), **case A sub-word (f32+i32, the 4-byte GP chunk the #1637 review flagged)**, and case B (f32+f64 pair) — so the qemu e2e proves lp64d hard-float end to end. `mach build` clean, `mach test` 690/690, riscv64 fixture **exit 133**, macho + freestanding green. The fixture's many existing integer load/store probes still fold correctly, so the GP path is unregressed.

This unblocks the end-to-end validation of #1637 cases A/B (the ABI classifier side merged in #1732).
