### PR TITLE
refactor(abi): consolidate the ParamPiece slot model (#1734)

### DIFF
--- a/src/lang/be/codegen/mir/abi.mach
+++ b/src/lang/be/codegen/mir/abi.mach
@@ -560,7 +560,12 @@ pub fun classify_signature(ctx: *context.LowerCtx, sig: type.IrTypeId, ret_type:
     var ret_hm:    u8   = 0;
     var ret_he:    u8   = 0;
     hfa_info(ctx, ret_type, ?ret_hm, ?ret_he);
-    out.ret_slot = classify_ret(ret_size, 0, ret_float, ret_eb, ret_aggr, ret_hm, ret_he, agg_layout(ctx, ret_type, ret_aggr));
+    # only the lp64d classifier reads the flattened-aggregate descriptor; for every
+    # other convention skip the per-value flatten walk and pass the no-information one.
+    val wants_agg: bool = ctx.tgt.abi.consumes_agg_layout;
+    var ret_agg: abi.AggLayout = abi.agg_none();
+    if (wants_agg) { ret_agg = agg_layout(ctx, ret_type, ret_aggr); }
+    out.ret_slot = classify_ret(ret_size, 0, ret_float, ret_eb, ret_aggr, ret_hm, ret_he, ret_agg);
 
     var gp_used:   i32 = 0;
     var fp_used:   i32 = 0;
@@ -614,7 +619,9 @@ pub fun classify_signature(ctx: *context.LowerCtx, sig: type.IrTypeId, ret_type:
         var phm:  u8   = 0;
         var phe:  u8   = 0;
         hfa_info(ctx, pty, ?phm, ?phe);
-        var slot: abi.ParamSlot = classify_arg(i::i32, psz, pal, pfl, peb, pag, gp_used, fp_used, phm, phe, agg_layout(ctx, pty, pag));
+        var pagg: abi.AggLayout = abi.agg_none();
+        if (wants_agg) { pagg = agg_layout(ctx, pty, pag); }
+        var slot: abi.ParamSlot = classify_arg(i::i32, psz, pal, pfl, peb, pag, gp_used, fp_used, phm, phe, pagg);
 
         # record the real outgoing stack offset on the slot (the ABI classifier
         # returns a sizing-only slot with offset 0); the param / call lowering

--- a/src/lang/be/codegen/mir/abi.mach
+++ b/src/lang/be/codegen/mir/abi.mach
@@ -949,6 +949,85 @@ fun lower_value_addr(ctx: *context.LowerCtx, mb: *mir.MirBlock, v: value.Value) 
     ret R.ok[mir.MirOperand, str](mir.op_vreg(addr));
 }
 
+# how `materialize_pieces` transfers a placement's register / stack chunks: the
+# direction (register load vs store), the per-chunk register-side memory operand, and
+# the stack-side base for a register-plus-stack split's PIECE_STACK chunk.
+# ---
+# store:      true to store each register chunk to its memory operand (a callee spill /
+#             a call result's storage); false to load each chunk into its register (a
+#             caller's outgoing argument, a callee's return value)
+# mem_base:   the base the register chunk's memory operand is formed from -- a spill
+#             slot key when `mem_slot` is true, else a pointer vreg
+# mem_slot:   true to form `op_mem_slot(mem_base, src_off)`, false `op_mem_value`
+# stack_base: physical register a PIECE_STACK chunk's stack side is addressed off (the
+#             stack pointer for an outgoing slot, the frame pointer for an incoming one)
+# stack_off:  byte offset of the slot's stack region from `stack_base`
+# stack_ok:   false when the placement must carry no PIECE_STACK chunk (a return value);
+#             such a chunk is then a classifier bug reported loudly
+rec PiecePlan {
+    store:      bool;
+    mem_base:   u32;
+    mem_slot:   bool;
+    stack_base: u32;
+    stack_off:  i64;
+    stack_ok:   bool;
+}
+
+# materialize a register / register-plus-stack placement's pieces, the one path behind
+# the caller-argument, callee-parameter, callee-return, and call-result reconstructions.
+#
+# Each register chunk loads from / stores to `[mem_base + src_off]` at the chunk width,
+# the move's machine form following the register's bank (a GP word, an FP `width`-byte
+# move) -- so a single, a pair, a CLASS_HFA run, a mixed GP / FP aggregate, and a split
+# all flow through one loop. A PIECE_STACK chunk (a register-plus-stack split's tail)
+# transfers a full word between that memory operand and `[stack_base + stack_off +
+# stk_off]`, in the direction `plan.store` selects.
+# ---
+# ctx:  the active lowering context
+# mb:   the MIR block the move(s) are appended to
+# slot: the classified slot whose pieces are materialized
+# plan: the transfer direction, register-side memory operand, and stack-side base
+# ret:  ok(true) on success, or a loud error
+fun materialize_pieces(ctx: *context.LowerCtx, mb: *mir.MirBlock, slot: abi.ParamSlot, plan: PiecePlan) R.Result[bool, str] {
+    var i: u32 = 0;
+    for (i < slot.piece_count) {
+        val p: abi.ParamPiece = slot.pieces[i];
+        var mem: mir.MirOperand = mir.op_mem_value(plan.mem_base, p.src_off);
+        if (plan.mem_slot) { mem = mir.op_mem_slot(plan.mem_base, p.src_off); }
+        if (p.kind == abi.PIECE_STACK) {
+            if (!plan.stack_ok) {
+                ret R.err[bool, str]("mir.lower_ir: return slot carries an outgoing stack chunk");
+            }
+            # a full-word transfer between the register-side memory operand and the
+            # stack slot, through a scratch GP register; the direction follows `store`.
+            val stk: mir.MirOperand = mir.op_mem_preg(plan.stack_base, plan.stack_off + p.stk_off);
+            val tr: R.Result[u32, str] = context.new_vreg(ctx, mir.REG_CLASS_GP);
+            if (R.is_err[u32, str](tr)) { ret R.err[bool, str](R.unwrap_err[u32, str](tr)); }
+            val tmp: u32 = R.unwrap_ok[u32, str](tr);
+            var src: mir.MirOperand = mem;
+            var dst: mir.MirOperand = stk;
+            if (plan.store) { src = stk; dst = mem; }
+            val ld: R.Result[bool, str] = context.emit_mov(ctx, mb, mir.op_vreg(tmp), src);
+            if (R.is_err[bool, str](ld)) { ret ld; }
+            val st: R.Result[bool, str] = context.emit_store_to(ctx, mb, dst, mir.op_vreg(tmp));
+            if (R.is_err[bool, str](st)) { ret st; }
+        } or {
+            # a register chunk: the GP and FP banks share the move (a MOV at `width`); the
+            # register id's class tag drives the machine form, GP word or FP move.
+            val reg: mir.MirOperand = mir.op_preg(p.reg::u32);
+            if (plan.store) {
+                val st: R.Result[bool, str] = context.emit_store_to_w(ctx, mb, mem, reg, p.width);
+                if (R.is_err[bool, str](st)) { ret st; }
+            } or {
+                val mr: R.Result[bool, str] = context.emit_mov_w(ctx, mb, reg, mem, p.width);
+                if (R.is_err[bool, str](mr)) { ret mr; }
+            }
+        }
+        i = i + 1;
+    }
+    ret R.ok[bool, str](true);
+}
+
 # emit the pre-coloring move(s) placing one classified argument
 #
 # A BYREF argument moves the aggregate's address into the register; a STACK argument
@@ -1014,35 +1093,14 @@ fun emit_arg_slot(ctx: *context.LowerCtx, mb: *mir.MirBlock, slot: abi.ParamSlot
         var base: u32 = mir.MIR_VREG_NIL;
         val ar: R.Result[bool, str] = context.addr_to_vreg(ctx, mb, argop, ?base);
         if (R.is_err[bool, str](ar)) { ret ar; }
-        val sp: u32 = ctx.tgt.arch.stack_ptr_reg::u32;
-        var i: u32 = 0;
-        for (i < slot.piece_count) {
-            val p: abi.ParamPiece = slot.pieces[i];
-            if (p.kind == abi.PIECE_GP) {
-                val mr: R.Result[bool, str] = context.emit_mov_w(ctx, mb,
-                    mir.op_preg(p.reg::u32), mir.op_mem_value(base, p.src_off), p.width);
-                if (R.is_err[bool, str](mr)) { ret mr; }
-            } or (p.kind == abi.PIECE_FP) {
-                val mr: R.Result[bool, str] = context.emit_fmov(ctx, mb,
-                    mir.op_preg(p.reg::u32), mir.op_mem_value(base, p.src_off), p.width);
-                if (R.is_err[bool, str](mr)) { ret mr; }
-            } or {
-                # PIECE_STACK: the split's tail rides an outgoing stack slot. load the
-                # chunk word from storage into a scratch register, then store it at
-                # `[sp + stack_off + stk_off]`.
-                val tr: R.Result[u32, str] = context.new_vreg(ctx, mir.REG_CLASS_GP);
-                if (R.is_err[u32, str](tr)) { ret R.err[bool, str](R.unwrap_err[u32, str](tr)); }
-                val tmp: u32 = R.unwrap_ok[u32, str](tr);
-                val ld: R.Result[bool, str] = context.emit_mov(ctx, mb,
-                    mir.op_vreg(tmp), mir.op_mem_value(base, p.src_off));
-                if (R.is_err[bool, str](ld)) { ret ld; }
-                val st: R.Result[bool, str] = context.emit_store_to(ctx, mb,
-                    mir.op_mem_preg(sp, stack_off + p.stk_off), mir.op_vreg(tmp));
-                if (R.is_err[bool, str](st)) { ret st; }
-            }
-            i = i + 1;
-        }
-        ret R.ok[bool, str](true);
+        var plan: PiecePlan;
+        plan.store      = false;
+        plan.mem_base   = base;
+        plan.mem_slot   = false;
+        plan.stack_base = ctx.tgt.arch.stack_ptr_reg::u32;
+        plan.stack_off  = stack_off;
+        plan.stack_ok   = true;
+        ret materialize_pieces(ctx, mb, slot, plan);
     }
     # single FP register scalar argument: a float copy into the XMM argument
     # register. the XMM argument preg carries the SSE class, so the encoder
@@ -1102,23 +1160,14 @@ fun record_outgoing_size(ctx: *context.LowerCtx, bytes: i64) {
 # ret:     ok(true) on success, or a loud error
 fun emit_ret_slot_to_vreg(ctx: *context.LowerCtx, mb: *mir.MirBlock, slot: abi.ParamSlot, dst: u32, is_aggr: bool) R.Result[bool, str] {
     if (is_aggr) {
-        var i: u32 = 0;
-        for (i < slot.piece_count) {
-            val p: abi.ParamPiece = slot.pieces[i];
-            if (p.kind == abi.PIECE_GP) {
-                val st: R.Result[bool, str] = context.emit_store_to_w(ctx, mb,
-                    mir.op_mem_value(dst, p.src_off), mir.op_preg(p.reg::u32), p.width);
-                if (R.is_err[bool, str](st)) { ret st; }
-            } or (p.kind == abi.PIECE_FP) {
-                val st: R.Result[bool, str] = context.emit_store_to_w(ctx, mb,
-                    mir.op_mem_value(dst, p.src_off), mir.op_preg(p.reg::u32), p.width);
-                if (R.is_err[bool, str](st)) { ret st; }
-            } or {
-                ret R.err[bool, str]("mir.lower_ir: return slot carries an outgoing stack chunk");
-            }
-            i = i + 1;
-        }
-        ret R.ok[bool, str](true);
+        var plan: PiecePlan;
+        plan.store      = true;
+        plan.mem_base   = dst;
+        plan.mem_slot   = false;
+        plan.stack_base = 0;
+        plan.stack_off  = 0;
+        plan.stack_ok   = false;
+        ret materialize_pieces(ctx, mb, slot, plan);
     }
     ret context.emit_mov(ctx, mb, mir.op_vreg(dst), mir.op_preg(slot.reg::u32));
 }
@@ -1247,34 +1296,14 @@ fun emit_param_slot(ctx: *context.LowerCtx, mb: *mir.MirBlock, slot: abi.ParamSl
         # names the storage for downstream uses.
         val sr: R.Result[bool, str] = context.add_spill_slot(ctx, pv, size);
         if (R.is_err[bool, str](sr)) { ret sr; }
-        val fp: u32 = ctx.tgt.arch.frame_ptr_reg::u32;
-        var i: u32 = 0;
-        for (i < slot.piece_count) {
-            val p: abi.ParamPiece = slot.pieces[i];
-            if (p.kind == abi.PIECE_GP) {
-                val st: R.Result[bool, str] = context.emit_store_to_w(ctx, mb,
-                    mir.op_mem_slot(pv, p.src_off), mir.op_preg(p.reg::u32), p.width);
-                if (R.is_err[bool, str](st)) { ret st; }
-            } or (p.kind == abi.PIECE_FP) {
-                val st: R.Result[bool, str] = context.emit_store_to_w(ctx, mb,
-                    mir.op_mem_slot(pv, p.src_off), mir.op_preg(p.reg::u32), p.width);
-                if (R.is_err[bool, str](st)) { ret st; }
-            } or {
-                # PIECE_STACK: the caller placed this chunk in an incoming stack slot;
-                # load it off the frame pointer and store it into the spill slot.
-                val tr: R.Result[u32, str] = context.new_vreg(ctx, mir.REG_CLASS_GP);
-                if (R.is_err[u32, str](tr)) { ret R.err[bool, str](R.unwrap_err[u32, str](tr)); }
-                val tmp: u32 = R.unwrap_ok[u32, str](tr);
-                val ld: R.Result[bool, str] = context.emit_mov(ctx, mb,
-                    mir.op_vreg(tmp), mir.op_mem_preg(fp, arg_base + stack_off + p.stk_off));
-                if (R.is_err[bool, str](ld)) { ret ld; }
-                val st: R.Result[bool, str] = context.emit_store_to(ctx, mb,
-                    mir.op_mem_slot(pv, p.src_off), mir.op_vreg(tmp));
-                if (R.is_err[bool, str](st)) { ret st; }
-            }
-            i = i + 1;
-        }
-        ret R.ok[bool, str](true);
+        var plan: PiecePlan;
+        plan.store      = true;
+        plan.mem_base   = pv;
+        plan.mem_slot   = true;
+        plan.stack_base = ctx.tgt.arch.frame_ptr_reg::u32;
+        plan.stack_off  = arg_base + stack_off;
+        plan.stack_ok   = true;
+        ret materialize_pieces(ctx, mb, slot, plan);
     }
     ret context.emit_mov(ctx, mb, mir.op_vreg(pv), mir.op_preg(slot.reg::u32));
 }
@@ -1340,22 +1369,15 @@ pub fun lower_ret(ctx: *context.LowerCtx, mb: *mir.MirBlock, inst: *instruction.
         var base: u32 = mir.MIR_VREG_NIL;
         val ar: R.Result[bool, str] = context.addr_to_vreg(ctx, mb, rvop, ?base);
         if (R.is_err[bool, str](ar)) { ret ar; }
-        var i: u32 = 0;
-        for (i < slot.piece_count) {
-            val p: abi.ParamPiece = slot.pieces[i];
-            if (p.kind == abi.PIECE_GP) {
-                val mr: R.Result[bool, str] = context.emit_mov_w(ctx, mb,
-                    mir.op_preg(p.reg::u32), mir.op_mem_value(base, p.src_off), p.width);
-                if (R.is_err[bool, str](mr)) { ret mr; }
-            } or (p.kind == abi.PIECE_FP) {
-                val mr: R.Result[bool, str] = context.emit_fmov(ctx, mb,
-                    mir.op_preg(p.reg::u32), mir.op_mem_value(base, p.src_off), p.width);
-                if (R.is_err[bool, str](mr)) { ret mr; }
-            } or {
-                ret R.err[bool, str]("mir.lower_ir: return slot carries an outgoing stack chunk");
-            }
-            i = i + 1;
-        }
+        var plan: PiecePlan;
+        plan.store      = false;
+        plan.mem_base   = base;
+        plan.mem_slot   = false;
+        plan.stack_base = 0;
+        plan.stack_off  = 0;
+        plan.stack_ok   = false;
+        val mr: R.Result[bool, str] = materialize_pieces(ctx, mb, slot, plan);
+        if (R.is_err[bool, str](mr)) { ret mr; }
     } or (slot.class == abi.CLASS_FP) {
         # scalar float return: a float copy into XMM0. the XMM0 return preg carries
         # the SSE class, so the encoder dispatches the move on operand class and emits

--- a/src/lang/be/codegen/mir/abi.mach
+++ b/src/lang/be/codegen/mir/abi.mach
@@ -127,59 +127,91 @@ fun mark_eightbyte_range(classes: *u8, off: u64, size: u64, cls: u8) {
     }
 }
 
-# classify each leaf scalar of an aggregate into the eightbyte(s) it occupies
+# the most scalar leaves a flattened aggregate is enumerated into: a <=16 byte
+# aggregate (the only size the SSE mask and the lp64d flatten inspect) holds at most
+# sixteen one-byte leaves.
+val AGG_LEAF_CAP: u32 = 16;
+
+# enumerate the scalar leaves of `ty` into `out` (capacity `cap`) in offset order
 #
-# Recurses from absolute byte offset `base_off`. A float leaf marks its eightbytes
-# SSE; an integer / pointer / function leaf marks them INTEGER; structs recurse at
-# each field offset, unions at offset 0 (members overlap), arrays at each element
-# offset. `classes[0..1]` accumulate the merged per-eightbyte class for the SysV
-# SSE-aggregate classification.
+# The one shared leaf traversal behind the SysV SSE-eightbyte mask and the lp64d
+# AggLayout descriptor. Recurses structs at each field offset and arrays at each
+# element offset from `base_off`, recording each IRT_FLOAT leaf as a float field and
+# each integer / pointer / function leaf as a non-float field. Returns the running leaf
+# count, or a value past `cap` when the aggregate is non-flattenable at that cap.
+#
+# `strict` selects the two consumers' divergent treatment of what an offset-ordered
+# enumeration cannot represent. A union's members overlap at one offset: in `strict`
+# mode (the AggLayout flatten) the aggregate is rejected -- it stops with a past-cap
+# sentinel; in lenient mode (the SSE mask, where each overlapping member contributes to
+# its eightbyte's class) every member is enumerated at the shared offset. An
+# unresolvable type likewise poisons in `strict` mode and is skipped in lenient mode.
+# `hfa_walk` does NOT ride this iterator -- it is a homogeneity reduction, not an
+# enumeration (see its note).
 # ---
 # ctx:      the active lowering context (supplies the IR type oracle and target)
-# ty:       the type whose leaves are classified
+# ty:       the type whose leaves are enumerated
 # base_off: the type's absolute byte offset within the enclosing aggregate
-# classes:  the two-entry per-eightbyte class array to accumulate into
-fun mark_eightbyte_classes(ctx: *context.LowerCtx, ty: type.IrTypeId, base_off: u64, classes: *u8) {
+# strict:   reject unions / unresolvable types (the flatten) vs enumerate through (the mask)
+# out:      the leaf array, written for indices in [0, cap)
+# cap:      the capacity of `out` (the flatten's two-leaf cap, the mask's sixteen)
+# count:    the running leaf count before this type's leaves
+# ret:      the running leaf count after this type's leaves (> cap when non-flattenable)
+fun collect_leaves(ctx: *context.LowerCtx, ty: type.IrTypeId, base_off: u64, strict: bool,
+                   out: *abi.AggField, cap: u32, count: u32) u32 {
+    if (count > cap) { ret count; }
     val it: O.Option[*type.IrType] = type.get(ctx.types, ty);
-    if (!O.is_some[*type.IrType](it)) { ret; }
+    if (!O.is_some[*type.IrType](it)) {
+        if (strict) { ret cap + 1; }
+        ret count;
+    }
     val t: *type.IrType = O.unwrap[*type.IrType](it);
 
-    if (t.kind == type.IRT_FLOAT) {
-        mark_eightbyte_range(classes, base_off, type.byte_size(ctx.types, ty, ctx.tgt)::u64, EB_SSE);
-        ret;
-    }
     if (t.kind == type.IRT_STRUCT) {
+        var c: u32 = count;
         var i: u32 = 0;
         for (i < t.data.struct_.field_count) {
-            val fid: type.IrTypeId = t.data.struct_.fields[i];
-            val fo:  u64 = type.byte_offset(ctx.types, ty, i, ctx.tgt)::u64;
-            mark_eightbyte_classes(ctx, fid, base_off + fo, classes);
+            val fo: u64 = type.byte_offset(ctx.types, ty, i, ctx.tgt)::u64;
+            c = collect_leaves(ctx, t.data.struct_.fields[i], base_off + fo, strict, out, cap, c);
+            if (strict && c > cap) { ret c; }
             i = i + 1;
         }
-        ret;
-    }
-    if (t.kind == type.IRT_UNION) {
-        # union members all overlap at offset 0; merge each member's classes.
-        var i: u32 = 0;
-        for (i < t.data.struct_.field_count) {
-            mark_eightbyte_classes(ctx, t.data.struct_.fields[i], base_off, classes);
-            i = i + 1;
-        }
-        ret;
+        ret c;
     }
     if (t.kind == type.IRT_ARRAY) {
         val elem: type.IrTypeId = t.data.array_.element;
         val es:   u64 = type.byte_size(ctx.types, elem, ctx.tgt)::u64;
         val n:    u32 = type.array_count(ctx.types, ty);
+        var c: u32 = count;
         var i: u32 = 0;
         for (i < n) {
-            mark_eightbyte_classes(ctx, elem, base_off + i::u64 * es, classes);
+            c = collect_leaves(ctx, elem, base_off + i::u64 * es, strict, out, cap, c);
+            if (strict && c > cap) { ret c; }
             i = i + 1;
         }
-        ret;
+        ret c;
     }
-    # integer / pointer / function leaf: an INTEGER-class eightbyte.
-    mark_eightbyte_range(classes, base_off, type.byte_size(ctx.types, ty, ctx.tgt)::u64, EB_INTEGER);
+    if (t.kind == type.IRT_UNION) {
+        # a union's members overlap at one offset. the strict flatten rejects it; the
+        # lenient mask enumerates each member at the shared offset (its eightbyte class).
+        if (strict) { ret cap + 1; }
+        var c: u32 = count;
+        var i: u32 = 0;
+        for (i < t.data.struct_.field_count) {
+            c = collect_leaves(ctx, t.data.struct_.fields[i], base_off, strict, out, cap, c);
+            i = i + 1;
+        }
+        ret c;
+    }
+
+    # a scalar leaf (IRT_FLOAT or an integer / pointer / function): record it when
+    # within the cap, then count it.
+    if (count < cap) {
+        out[count].is_float = t.kind == type.IRT_FLOAT;
+        out[count].offset   = base_off::u32;
+        out[count].width    = type.byte_size(ctx.types, ty, ctx.tgt)::u8;
+    }
+    ret count + 1;
 }
 
 # the per-eightbyte SSE mask for a <=16 byte aggregate type
@@ -196,10 +228,20 @@ fun aggregate_sse_mask(ctx: *context.LowerCtx, ty: type.IrTypeId) u8 {
     if (!context.value_is_aggregate(ctx, ty)) { ret 0; }
     val size: u64 = type.byte_size(ctx.types, ty, ctx.tgt)::u64;
     if (size == 0 || size > 16) { ret 0; }
+    # enumerate the leaves (lenient: a union's overlapping members each contribute to
+    # their eightbyte's class), then merge each leaf's range into its eightbyte(s).
+    var leaves: [16]abi.AggField;
+    val n: u32 = collect_leaves(ctx, ty, 0, false, ?leaves[0], AGG_LEAF_CAP, 0);
     var classes: [2]u8;
     classes[0] = EB_NO_CLASS;
     classes[1] = EB_NO_CLASS;
-    mark_eightbyte_classes(ctx, ty, 0, ?classes[0]);
+    var i: u32 = 0;
+    for (i < n) {
+        var cls: u8 = EB_INTEGER;
+        if (leaves[i].is_float) { cls = EB_SSE; }
+        mark_eightbyte_range(?classes[0], leaves[i].offset::u64, leaves[i].width::u64, cls);
+        i = i + 1;
+    }
     var mask: u8 = 0;
     if (classes[0] == EB_SSE) { mask = mask | 1; }
     if (classes[1] == EB_SSE) { mask = mask | 2; }
@@ -214,6 +256,13 @@ fun aggregate_sse_mask(ctx: *context.LowerCtx, ty: type.IrTypeId) u8 {
 # overlap). Any non-FP leaf, an empty aggregate, or a mix of fundamental widths
 # makes the whole aggregate non-homogeneous. Member counting is by recursion, never
 # `size / width`, so an explicit `#[align(...)]` padding the size never inflates it.
+#
+# This deliberately does NOT ride the shared `collect_leaves` iterator: it is a
+# homogeneity REDUCTION, not a leaf enumeration. Its union arm takes the widest
+# member's count (max), where the offset-ordered enumeration would sum every member's
+# leaves -- routing it through `collect_leaves` would silently change union-of-floats
+# HFA placement (a count of sum vs max), a divergence no test or fixture covers. Keep
+# the reduction here; do not "unify" it with the enumeration walk.
 # ---
 # ctx:       the active lowering context (supplies the IR type oracle and target)
 # ty:        the type to test
@@ -307,71 +356,6 @@ fun hfa_info(ctx: *context.LowerCtx, ty: type.IrTypeId, out_members: *u8, out_el
 # non-flattenable (the lp64d mixed / float-pair rules act on at most two leaves).
 val AGG_MAX_LEAVES: u32 = 2;
 
-# flatten the scalar leaves of `ty` into `out`, returning the running leaf count
-#
-# Recurses from absolute byte offset `base_off`, recording each IRT_FLOAT leaf as a
-# float field and each integer / pointer / function leaf as a non-float field, in
-# offset order: a struct recurses at each field offset, an array at each element
-# offset. A union cannot flatten to offset-ordered leaves (its members overlap), so
-# it poisons the walk by returning a count past the cap. Once more than two leaves
-# are seen the walk only counts (it records no further fields), so the caller can
-# reject the aggregate.
-# ---
-# ctx:      the active lowering context (supplies the IR type oracle and target)
-# ty:       the type whose leaves are flattened
-# base_off: the type's absolute byte offset within the enclosing aggregate
-# out:      the descriptor whose `fields` receive the first two leaves
-# count:    the running leaf count before this type's leaves
-# ret:      the running leaf count after this type's leaves (> 2 when non-flattenable)
-fun agg_flatten(ctx: *context.LowerCtx, ty: type.IrTypeId, base_off: u64,
-                out: *abi.AggLayout, count: u32) u32 {
-    if (count > AGG_MAX_LEAVES) { ret count; }
-    val it: O.Option[*type.IrType] = type.get(ctx.types, ty);
-    # an unresolvable type has no known leaf to record; poison the walk past the cap so
-    # the caller rejects the whole aggregate (it falls to the integer convention).
-    if (!O.is_some[*type.IrType](it)) { ret AGG_MAX_LEAVES + 1; }
-    val t: *type.IrType = O.unwrap[*type.IrType](it);
-
-    if (t.kind == type.IRT_STRUCT) {
-        var c: u32 = count;
-        var i: u32 = 0;
-        for (i < t.data.struct_.field_count) {
-            val fid: type.IrTypeId = t.data.struct_.fields[i];
-            val fo:  u64 = type.byte_offset(ctx.types, ty, i, ctx.tgt)::u64;
-            c = agg_flatten(ctx, fid, base_off + fo, out, c);
-            if (c > AGG_MAX_LEAVES) { ret c; }
-            i = i + 1;
-        }
-        ret c;
-    }
-    if (t.kind == type.IRT_ARRAY) {
-        val elem: type.IrTypeId = t.data.array_.element;
-        val es:   u64 = type.byte_size(ctx.types, elem, ctx.tgt)::u64;
-        val n:    u32 = type.array_count(ctx.types, ty);
-        var c: u32 = count;
-        var i: u32 = 0;
-        for (i < n) {
-            c = agg_flatten(ctx, elem, base_off + i::u64 * es, out, c);
-            if (c > AGG_MAX_LEAVES) { ret c; }
-            i = i + 1;
-        }
-        ret c;
-    }
-    if (t.kind == type.IRT_UNION) {
-        # a union's members overlap, so it has no offset-ordered leaf flattening;
-        # poison the walk past the cap so the caller rejects the whole aggregate.
-        ret AGG_MAX_LEAVES + 1;
-    }
-
-    # a scalar leaf: record it when still within the cap, then count it.
-    if (count < AGG_MAX_LEAVES) {
-        out.fields[count].is_float = t.kind == type.IRT_FLOAT;
-        out.fields[count].offset   = base_off::u32;
-        out.fields[count].width    = type.byte_size(ctx.types, ty, ctx.tgt)::u8;
-    }
-    ret count + 1;
-}
-
 # the <=2-leaf flattened-aggregate descriptor for a type
 #
 # Flattens an aggregate's scalar leaves in offset order, capped at two, for the
@@ -390,8 +374,10 @@ fun agg_layout(ctx: *context.LowerCtx, ty: type.IrTypeId, is_aggr: bool) abi.Agg
     var out: abi.AggLayout;
     out.field_count = 0;
     if (!is_aggr) { ret out; }
-    val c: u32 = agg_flatten(ctx, ty, 0, ?out, 0);
-    if (c == 1 || c == 2) { out.field_count = c::u8; }
+    # strict enumeration straight into the two-leaf `fields`: more than two leaves, a
+    # union, or an empty aggregate leaves field_count 0 (the integer convention).
+    val n: u32 = collect_leaves(ctx, ty, 0, true, ?out.fields[0], AGG_MAX_LEAVES, 0);
+    if (n == 1 || n == 2) { out.field_count = n::u8; }
     ret out;
 }
 

--- a/src/lang/target/abi.mach
+++ b/src/lang/target/abi.mach
@@ -279,6 +279,11 @@ pub def VaModelFn: fun() VaModel;
 #                             seeds gp_used = 1 for an sret return); false when the
 #                             pointer rides a register outside the argument file
 #                             (AAPCS64's X8), leaving the GP cursor at 0
+# consumes_agg_layout:        true when the convention's classifier reads the <=2-leaf
+#                             flattened-aggregate descriptor (lp64d's mixed
+#                             float-plus-integer and different-width float-pair rules);
+#                             false for the conventions that ignore it, letting
+#                             `classify_signature` skip the per-value flatten walk
 # va_model:                   erased fn ptr -- return the convention's `VaModel` (VaModelFn)
 pub rec AbiVTable {
     id:                         u32;
@@ -294,6 +299,7 @@ pub rec AbiVTable {
     shadow_space:               u32;
     indirect_result_reg:        i32;
     indirect_result_in_argfile: bool;
+    consumes_agg_layout:        bool;
     va_model:                   *u8;
 }
 

--- a/src/lang/target/abi.mach
+++ b/src/lang/target/abi.mach
@@ -54,21 +54,15 @@ pub val CLASS_BYREF:       ParamClass = 4;
 # stack slot holds the 8-byte pointer rather than the aggregate's bytes. distinct
 # from CLASS_STACK, whose slot holds the value itself.
 pub val CLASS_STACK_BYREF: ParamClass = 5;
-# passed in a run of consecutive FP / vector registers: an AAPCS64 Homogeneous
-# Floating-point / Short-Vector Aggregate (HFA/HVA) of 1-4 same-typed members,
-# one member per register at `reg_width` bytes each, riding
-# V[reg]..V[reg+reg_count-1]. distinct from CLASS_FP, a single scalar float.
-pub val CLASS_HFA:         ParamClass = 6;
 
 # how one location of a multi-location aggregate placement is filled.
 #
-# A value that rides more than one register, or a register plus a stack slot, or
-# whose members differ in register bank or width, is described as a list of
-# `ParamPiece`s rather than the single-`reg` / `reg2` shorthand: each piece names
-# where one chunk of the aggregate's storage goes. The shorthand placements
-# (one register, a two-register pair, a CLASS_HFA run) populate an equivalent piece
-# list too, so the backend materializes every register / stack aggregate through one
-# uniform per-piece path.
+# A register / stack aggregate placement is described as a list of `ParamPiece`s:
+# each piece names where one chunk of the aggregate's storage goes. A single-register
+# placement is one piece, a two-register pair two, a homogeneous-FP run one per member,
+# and a mixed-bank / different-width / register-plus-stack split a piece per chunk -- so
+# the backend materializes every register / stack aggregate through one uniform
+# per-piece path. A scalar's single register rides the slot's `reg` directly.
 pub def PieceKind: u8;
 # the chunk rides a general-purpose register.
 pub val PIECE_GP:    PieceKind = 0;
@@ -125,21 +119,16 @@ pub fun agg_none() AggLayout { var a: AggLayout; a.field_count = 0; ret a; }
 
 # placement decision for one parameter or return value.
 #
-# `reg2` carries the second register of a 9-16 byte aggregate split across two
-# registers; it is -1 when the value occupies a single register or the stack.
-# `reg_count` / `reg_width` describe a CLASS_HFA register run and are 1 / 0 for
-# every other placement. `pieces` / `piece_count` are the canonical multi-location
-# form the backend materializes a register / stack aggregate from: every constructor
-# fills them (a single register is one piece, a pair two, a CLASS_HFA run one per
-# member), and `make_slot_pieces` builds the mixed-bank, different-width, and
-# register-plus-stack-split shapes the `reg` / `reg2` shorthand cannot express.
+# A register / stack aggregate is materialized from `pieces` / `piece_count`, the
+# canonical multi-location form every constructor fills (a single register is one
+# piece, a two-register pair two, a homogeneous-FP run one per member); `make_slot_pieces`
+# builds the mixed-bank, different-width, and register-plus-stack-split shapes. A scalar
+# or by-reference placement carries its one register in `reg` and the consumer routes it
+# by `class`.
 # ---
 # class:       classification (CLASS_GP, CLASS_FP, CLASS_STACK, ...)
-# reg:         first register id if register-passed (-1 if stack/byref); the base
-#              register of a CLASS_HFA run
-# reg2:        second register id for a two-register aggregate (-1 otherwise)
-# reg_count:   consecutive registers from `reg` for a CLASS_HFA (1 otherwise)
-# reg_width:   per-register member width in bytes for a CLASS_HFA (0 otherwise)
+# reg:         the register id of a scalar / by-reference / sret placement (-1 if
+#              stack-passed); a multi-piece placement carries its registers in `pieces`
 # offset:      stack offset in bytes if stack-passed (the stack base of any
 #              PIECE_STACK pieces for a register-plus-stack split)
 # size:        size in bytes of this slot
@@ -149,9 +138,6 @@ pub fun agg_none() AggLayout { var a: AggLayout; a.field_count = 0; ret a; }
 pub rec ParamSlot {
     class:       ParamClass;
     reg:         i32;
-    reg2:        i32;
-    reg_count:   u8;
-    reg_width:   u8;
     offset:      i64;
     size:        u64;
     pieces:      [4]ParamPiece;
@@ -454,12 +440,12 @@ fun piece_for_reg(reg: i32, src_off: i64) ParamPiece {
     ret make_piece(kind, reg, src_off, 0, 8);
 }
 
-# build a single-register or stack `ParamSlot`. `reg_count` is 1 and `reg_width`
-# 0 -- the CLASS_HFA register-run fields are set only by `make_slot_hfa`. A
-# register-bearing placement (one register, or a 9-16 byte two-register pair) also
-# fills the canonical `pieces` list -- one chunk per register at the fixed 0 / 8
-# eightbyte offsets, each piece's bank taken from its register id -- so the backend
-# materializes it through the same per-piece path as a mixed or split placement.
+# build a single-register or stack `ParamSlot`. A register-bearing placement (one
+# register, or a 9-16 byte two-register pair) fills the canonical `pieces` list -- one
+# chunk per register at the fixed 0 / 8 eightbyte offsets, each piece's bank taken from
+# its register id -- so the backend materializes it through the same per-piece path as a
+# mixed or split placement; `reg` carries the scalar / by-reference register for the
+# consumer paths that route by `class`.
 # ---
 # class:  classification
 # reg:    first register id (-1 if none)
@@ -471,9 +457,6 @@ pub fun make_slot(class: ParamClass, reg: i32, reg2: i32, offset: i64, size: u64
     var s: ParamSlot;
     s.class       = class;
     s.reg         = reg;
-    s.reg2        = reg2;
-    s.reg_count   = 1;
-    s.reg_width   = 0;
     s.offset      = offset;
     s.size        = size;
     s.piece_count = 0;
@@ -488,22 +471,21 @@ pub fun make_slot(class: ParamClass, reg: i32, reg2: i32, offset: i64, size: u64
     ret s;
 }
 
-# build a CLASS_HFA `ParamSlot` for a homogeneous FP aggregate placed in a run of
-# `count` consecutive registers from `base_reg`, each holding one `elem`-byte
-# member. used by the AAPCS64 classifier for HFA/HVA arguments and returns.
+# build a `ParamSlot` for a homogeneous FP aggregate placed in a run of `count`
+# consecutive registers from `base_reg`, each holding one `elem`-byte member. used by
+# the AAPCS64 classifier for HFA/HVA arguments and returns and the lp64d hard-float
+# flattening. the run is materialized as `count` FP pieces; `class` is CLASS_FP, the
+# is_aggregate consumer paths routing it by `pieces` like any other register aggregate.
 # ---
 # base_reg: the first (lowest-numbered) register of the run
 # count:    number of consecutive registers (the HFA member count, 1-4)
 # elem:     per-register member width in bytes
 # size:     total aggregate size in bytes
-# ret:      the assembled CLASS_HFA ParamSlot
+# ret:      the assembled ParamSlot
 pub fun make_slot_hfa(base_reg: i32, count: u8, elem: u8, size: u64) ParamSlot {
     var s: ParamSlot;
-    s.class     = CLASS_HFA;
+    s.class     = CLASS_FP;
     s.reg       = base_reg;
-    s.reg2      = -1;
-    s.reg_count = count;
-    s.reg_width = elem;
     s.offset    = 0;
     s.size      = size;
     # one FP chunk per member, at consecutive registers from `base_reg` and field
@@ -539,12 +521,11 @@ pub fun make_piece(kind: PieceKind, reg: i32, src_off: i64, stk_off: i64, width:
 
 # build a placement from an explicit list of register / stack pieces, for an
 # aggregate whose members span more than one register bank, differ in width, or split
-# across a register and the stack -- shapes the single-`reg` / `reg2` shorthand
-# cannot express (the RISC-V lp64d mixed float-plus-integer struct, the
-# different-width float pair, and the 9-16 byte register-plus-stack split). The
-# `reg` / `reg2` / `reg_count` / `reg_width` shorthand is left at its no-register
-# defaults; the consumer drives this placement off `pieces`. `offset` is left 0 and
-# is filled by the signature walk for a placement carrying a PIECE_STACK chunk.
+# across a register and the stack -- shapes the single-`reg` shorthand cannot express
+# (the RISC-V lp64d mixed float-plus-integer struct, the different-width float pair, and
+# the 9-16 byte register-plus-stack split). `reg` is left at -1; the consumer drives
+# this placement off `pieces`. `offset` is left 0 and is filled by the signature walk
+# for a placement carrying a PIECE_STACK chunk.
 # ---
 # class:  classification label (CLASS_GP for an integer-bank-anchored split, etc.)
 # pieces: borrowed array of `count` pieces, copied into the slot
@@ -555,9 +536,6 @@ pub fun make_slot_pieces(class: ParamClass, pieces: *ParamPiece, count: u32, siz
     var s: ParamSlot;
     s.class     = class;
     s.reg       = -1;
-    s.reg2      = -1;
-    s.reg_count = 1;
-    s.reg_width = 0;
     s.offset    = 0;
     s.size      = size;
     var i: u32 = 0;

--- a/src/lang/target/abi/aapcs64.mach
+++ b/src/lang/target/abi/aapcs64.mach
@@ -404,13 +404,14 @@ test "mach.lang.target.abi.aapcs64.classify_arg:scalar_register_banks" {
 # GP register
 test "mach.lang.target.abi.aapcs64.classify_arg:integer_aggregate_gp" {
     val s: abi.ParamSlot = classify_arg(0, 16, 8, false, 0, true, 0, 0, 0, 0, abi.agg_none());
-    if (s.class != abi.CLASS_GP) { ret 1; }
-    if (s.reg  != REG_X0)        { ret 1; }
-    if (s.reg2 != REG_X1)        { ret 1; }
+    if (s.class != abi.CLASS_GP)    { ret 1; }
+    if (s.piece_count   != 2)       { ret 1; }
+    if (s.pieces[0].reg != REG_X0)  { ret 1; }
+    if (s.pieces[1].reg != REG_X1)  { ret 1; }
     val o: abi.ParamSlot = classify_arg(0, 8, 8, false, 0, true, 0, 0, 0, 0, abi.agg_none());
-    if (o.class != abi.CLASS_GP) { ret 1; }
-    if (o.reg  != REG_X0)        { ret 1; }
-    if (o.reg2 != -1)            { ret 1; }
+    if (o.class != abi.CLASS_GP)    { ret 1; }
+    if (o.piece_count   != 1)       { ret 1; }
+    if (o.pieces[0].reg != REG_X0)  { ret 1; }
     ret 0;
 }
 
@@ -432,21 +433,20 @@ test "mach.lang.target.abi.aapcs64.classify_arg:large_aggregate_byref" {
 test "mach.lang.target.abi.aapcs64.classify_arg:hfa_v_run" {
     # struct { f32, f32 } -> 2 members of 4 bytes in V0:V1.
     val s: abi.ParamSlot = classify_arg(0, 8, 4, false, 0, true, 0, 0, 2, 4, abi.agg_none());
-    if (s.class != abi.CLASS_HFA) { ret 1; }
-    if (s.reg != fp_param_reg(0)) { ret 1; }
-    if (s.reg_count != 2)         { ret 1; }
-    if (s.reg_width != 4)         { ret 1; }
-    if (s.size != 8)              { ret 1; }
+    if (s.piece_count     != 2)               { ret 1; }
+    if (s.pieces[0].reg   != fp_param_reg(0)) { ret 1; }
+    if (s.pieces[0].width != 4)               { ret 1; }
+    if (s.pieces[1].reg   != fp_param_reg(1)) { ret 1; }
+    if (s.size != 8)                          { ret 1; }
     # a 4xf64 HFA is 32 bytes yet still rides V0..V3 (HFA precedes the byref rule).
     val q: abi.ParamSlot = classify_arg(0, 32, 8, false, 0, true, 0, 0, 4, 8, abi.agg_none());
-    if (q.class != abi.CLASS_HFA) { ret 1; }
-    if (q.reg != fp_param_reg(0)) { ret 1; }
-    if (q.reg_count != 4)         { ret 1; }
-    if (q.reg_width != 8)         { ret 1; }
+    if (q.piece_count     != 4)               { ret 1; }
+    if (q.pieces[0].reg   != fp_param_reg(0)) { ret 1; }
+    if (q.pieces[0].width != 8)               { ret 1; }
+    if (q.pieces[3].reg   != fp_param_reg(3)) { ret 1; }
     # the run starts at the next free V register (NSRN cursor honored).
     val a: abi.ParamSlot = classify_arg(0, 8, 4, false, 0, true, 0, 5, 2, 4, abi.agg_none());
-    if (a.class != abi.CLASS_HFA) { ret 1; }
-    if (a.reg != fp_param_reg(5)) { ret 1; }
+    if (a.pieces[0].reg != fp_param_reg(5)) { ret 1; }
     # all-or-memory: a 3-member HFA cannot fit when only two V registers remain, so
     # the WHOLE aggregate spills by value (no partial V placement).
     val m: abi.ParamSlot = classify_arg(0, 12, 4, false, 0, true, 0, 6, 3, 4, abi.agg_none());
@@ -478,7 +478,7 @@ test "mach.lang.target.abi.aapcs64.classify_return:scalar_and_small_aggregate" {
     val f: abi.ParamSlot = classify_return(8, 8, true, 0, false, 0, 0, abi.agg_none());
     if (f.class != abi.CLASS_FP || f.reg != fp_param_reg(0)) { ret 1; }
     val a: abi.ParamSlot = classify_return(16, 8, false, 0, true, 0, 0, abi.agg_none());
-    if (a.reg != REG_X0 || a.reg2 != REG_X1) { ret 1; }
+    if (a.pieces[0].reg != REG_X0 || a.pieces[1].reg != REG_X1) { ret 1; }
     ret 0;
 }
 
@@ -486,14 +486,13 @@ test "mach.lang.target.abi.aapcs64.classify_return:scalar_and_small_aggregate" {
 test "mach.lang.target.abi.aapcs64.classify_return:hfa_before_sret" {
     # struct { f32, f32, f32 } returns in V0:V1:V2.
     val s: abi.ParamSlot = classify_return(12, 4, false, 0, true, 3, 4, abi.agg_none());
-    if (s.class != abi.CLASS_HFA) { ret 1; }
-    if (s.reg != fp_param_reg(0)) { ret 1; }
-    if (s.reg_count != 3)         { ret 1; }
-    if (s.reg_width != 4)         { ret 1; }
+    if (s.piece_count     != 3)               { ret 1; }
+    if (s.pieces[0].reg   != fp_param_reg(0)) { ret 1; }
+    if (s.pieces[0].width != 4)               { ret 1; }
+    if (s.pieces[2].reg   != fp_param_reg(2)) { ret 1; }
     # a 4xf64 HFA is 32 bytes yet returns in V0..V3, not via X8 sret.
     val q: abi.ParamSlot = classify_return(32, 8, false, 0, true, 4, 8, abi.agg_none());
-    if (q.class != abi.CLASS_HFA) { ret 1; }
-    if (q.reg_count != 4)         { ret 1; }
+    if (q.piece_count != 4)       { ret 1; }
     # a >16-byte non-HFA aggregate still returns via the X8 indirect-result register.
     val r: abi.ParamSlot = classify_return(32, 8, false, 0, true, 0, 0, abi.agg_none());
     if (r.class != abi.CLASS_SRET || r.reg != REG_X8) { ret 1; }

--- a/src/lang/target/abi/aapcs64.mach
+++ b/src/lang/target/abi/aapcs64.mach
@@ -381,6 +381,8 @@ pub fun register(reg: *abi.AbiRegistry) R.Result[bool, str] {
     # and the real arguments still start at X0.
     aapcs64_vtable.indirect_result_reg        = REG_X8;
     aapcs64_vtable.indirect_result_in_argfile = false;
+    # AAPCS64 ignores the flattened-aggregate descriptor (the lp64d hard-float rules).
+    aapcs64_vtable.consumes_agg_layout        = false;
     aapcs64_vtable.va_model                   = va_model::*u8;
 
     abi.register(reg, ?aapcs64_vtable);

--- a/src/lang/target/abi/lp64.mach
+++ b/src/lang/target/abi/lp64.mach
@@ -560,13 +560,14 @@ test "mach.lang.target.abi.lp64.classify_arg:banks_independent_and_float_fallbac
 # stack once the integer bank is exhausted
 test "mach.lang.target.abi.lp64.classify_arg:aggregate_placement" {
     val s: abi.ParamSlot = classify_arg(0, 16, 8, false, 0, true, 0, 0, 0, 0, abi.agg_none());
-    if (s.class != abi.CLASS_GP) { ret 1; }
-    if (s.reg  != REG_A0)        { ret 1; }
-    if (s.reg2 != REG_A1)        { ret 1; }
+    if (s.class != abi.CLASS_GP)    { ret 1; }
+    if (s.piece_count   != 2)       { ret 1; }
+    if (s.pieces[0].reg != REG_A0)  { ret 1; }
+    if (s.pieces[1].reg != REG_A1)  { ret 1; }
     val o: abi.ParamSlot = classify_arg(0, 8, 8, false, 0, true, 0, 0, 0, 0, abi.agg_none());
-    if (o.class != abi.CLASS_GP) { ret 1; }
-    if (o.reg  != REG_A0)        { ret 1; }
-    if (o.reg2 != -1)            { ret 1; }
+    if (o.class != abi.CLASS_GP)    { ret 1; }
+    if (o.piece_count   != 1)       { ret 1; }
+    if (o.pieces[0].reg != REG_A0)  { ret 1; }
     # >16 bytes with an integer register free: the pointer rides it.
     val b: abi.ParamSlot = classify_arg(0, 32, 8, false, 0, true, 0, 0, 0, 0, abi.agg_none());
     if (b.class != abi.CLASS_BYREF) { ret 1; }
@@ -597,33 +598,32 @@ test "mach.lang.target.abi.lp64.classify_arg:aggregate_register_stack_split" {
     ret 0;
 }
 
-# a struct that flattens to one or two floating-point members rides the fa registers
-# (CLASS_HFA), one member per register at its fundamental width; an fa bank without
-# the registers falls back to the integer convention
+# a struct that flattens to one or two floating-point members rides the fa registers,
+# one member per register at its fundamental width; an fa bank without the registers
+# falls back to the integer convention
 test "mach.lang.target.abi.lp64.classify_arg:hard_float_struct_flattening" {
     # a single-float struct (8 bytes, one f64 member) rides fa0.
     val one: abi.ParamSlot = classify_arg(0, 8, 8, false, 0, true, 0, 0, 1, 8, abi.agg_none());
-    if (one.class     != abi.CLASS_HFA)    { ret 1; }
-    if (one.reg       != fp_param_reg(0))  { ret 1; }
-    if (one.reg_count != 1)                { ret 1; }
-    if (one.reg_width != 8)                { ret 1; }
+    if (one.piece_count     != 1)               { ret 1; }
+    if (one.pieces[0].reg   != fp_param_reg(0)) { ret 1; }
+    if (one.pieces[0].width != 8)               { ret 1; }
     # a two-float struct (two f32 members) rides fa0:fa1, each 4 bytes.
     val two: abi.ParamSlot = classify_arg(0, 8, 4, false, 0, true, 0, 0, 2, 4, abi.agg_none());
-    if (two.class     != abi.CLASS_HFA)    { ret 1; }
-    if (two.reg       != fp_param_reg(0))  { ret 1; }
-    if (two.reg_count != 2)                { ret 1; }
-    if (two.reg_width != 4)                { ret 1; }
+    if (two.piece_count     != 2)               { ret 1; }
+    if (two.pieces[0].reg   != fp_param_reg(0)) { ret 1; }
+    if (two.pieces[0].width != 4)               { ret 1; }
+    if (two.pieces[1].reg   != fp_param_reg(1)) { ret 1; }
     # the float bank advances independently of the integer bank: with six fa
     # registers used, a two-float struct rides the last fa pair (fa6:fa7).
     val mid: abi.ParamSlot = classify_arg(0, 16, 8, false, 0, true, 3, 6, 2, 8, abi.agg_none());
-    if (mid.class != abi.CLASS_HFA)        { ret 1; }
-    if (mid.reg   != fp_param_reg(6))      { ret 1; }
+    if (mid.piece_count   != 2)               { ret 1; }
+    if (mid.pieces[0].reg != fp_param_reg(6)) { ret 1; }
     # the fa bank lacks two registers (seven used): the struct falls back to the
     # integer convention (a 9-16 byte pair here), not a cross-bank split.
     val fall: abi.ParamSlot = classify_arg(0, 16, 8, false, 0, true, 0, 7, 2, 8, abi.agg_none());
-    if (fall.class != abi.CLASS_GP) { ret 1; }
-    if (fall.reg   != REG_A0)       { ret 1; }
-    if (fall.reg2  != REG_A1)       { ret 1; }
+    if (fall.class != abi.CLASS_GP)    { ret 1; }
+    if (fall.pieces[0].reg != REG_A0)  { ret 1; }
+    if (fall.pieces[1].reg != REG_A1)  { ret 1; }
     # a three-float struct is not flattened (hfa_members > 2): the integer convention.
     val three: abi.ParamSlot = classify_arg(0, 16, 4, false, 0, true, 0, 0, 3, 4, abi.agg_none());
     if (three.class != abi.CLASS_GP) { ret 1; }
@@ -678,10 +678,10 @@ test "mach.lang.target.abi.lp64.classify_arg:mixed_and_diff_width_float_pairs" {
     # the fa bank is exhausted for the mixed case (fp_used = 8): fall back to the
     # integer convention (a 9-16 byte a0:a1 pair), not a cross-bank piece slot.
     val fb: abi.ParamSlot = classify_arg(0, 16, 8, false, 0, true, 0, 8, 0, 0, fi);
-    if (fb.class          != abi.CLASS_GP) { ret 1; }
-    if (fb.reg            != REG_A0)       { ret 1; }
-    if (fb.reg2           != REG_A1)       { ret 1; }
-    if (fb.pieces[0].kind != abi.PIECE_GP) { ret 1; }
+    if (fb.class           != abi.CLASS_GP) { ret 1; }
+    if (fb.pieces[0].reg   != REG_A0)       { ret 1; }
+    if (fb.pieces[1].reg   != REG_A1)       { ret 1; }
+    if (fb.pieces[0].kind  != abi.PIECE_GP) { ret 1; }
     ret 0;
 }
 
@@ -731,15 +731,15 @@ test "mach.lang.target.abi.lp64.classify_return:placement" {
     val f: abi.ParamSlot = classify_return(8, 8, true, 0, false, 0, 0, abi.agg_none());
     if (f.class != abi.CLASS_FP || f.reg != fp_param_reg(0)) { ret 1; }
     val a: abi.ParamSlot = classify_return(16, 8, false, 0, true, 0, 0, abi.agg_none());
-    if (a.reg != REG_A0 || a.reg2 != REG_A1) { ret 1; }
+    if (a.pieces[0].reg != REG_A0 || a.pieces[1].reg != REG_A1) { ret 1; }
     val r: abi.ParamSlot = classify_return(32, 8, false, 0, true, 0, 0, abi.agg_none());
     if (r.class != abi.CLASS_SRET || r.reg != REG_A0) { ret 1; }
     # a struct that flattens to two floats returns in the fa0:fa1 run.
     val h: abi.ParamSlot = classify_return(16, 8, false, 0, true, 2, 8, abi.agg_none());
-    if (h.class     != abi.CLASS_HFA)   { ret 1; }
-    if (h.reg       != fp_param_reg(0)) { ret 1; }
-    if (h.reg_count != 2)               { ret 1; }
-    if (h.reg_width != 8)               { ret 1; }
+    if (h.piece_count     != 2)               { ret 1; }
+    if (h.pieces[0].reg   != fp_param_reg(0)) { ret 1; }
+    if (h.pieces[0].width != 8)               { ret 1; }
+    if (h.pieces[1].reg   != fp_param_reg(1)) { ret 1; }
     ret 0;
 }
 

--- a/src/lang/target/abi/lp64.mach
+++ b/src/lang/target/abi/lp64.mach
@@ -494,6 +494,9 @@ pub fun register(reg: *abi.AbiRegistry) R.Result[bool, str] {
     # `classify_signature` seeds gp_used = 1 for an sret return.
     lp64_vtable.indirect_result_reg        = gp_param_reg(0);
     lp64_vtable.indirect_result_in_argfile = true;
+    # lp64d is the one convention whose classifier reads the flattened-aggregate
+    # descriptor (the mixed float+int and different-width float-pair rules).
+    lp64_vtable.consumes_agg_layout        = true;
     lp64_vtable.va_model                   = va_model::*u8;
 
     abi.register(reg, ?lp64_vtable);

--- a/src/lang/target/abi/lp64.mach
+++ b/src/lang/target/abi/lp64.mach
@@ -111,6 +111,55 @@ pub fun fp_param_reg(index: i32) i32 {
     ret isa.regid_make(isa.REG_CLASS_ID_XMM, REG_A0 + index);
 }
 
+# count the floating-point leaves of a flattened <=2-leaf aggregate descriptor
+# ---
+# agg: the two-leaf flattened descriptor
+# ret: the number of float leaves (0, 1, or 2)
+fun two_leaf_float_count(agg: abi.AggLayout) u32 {
+    var nf: u32 = 0;
+    var k: u32 = 0;
+    for (k < 2) { if (agg.fields[k].is_float) { nf = nf + 1; } k = k + 1; }
+    ret nf;
+}
+
+# build the lp64d placement for a <=2-leaf aggregate the uniform-HFA rule did not place
+#
+# Covers the different-width float pair (two float leaves, one fa register each) and the
+# mixed float-plus-integer struct (the float leaf in an fa register, the integer leaf in
+# an a register), each leaf loaded from its own field offset at its own width. The float
+# leaves take `fp0` then `fp1` in offset order and the integer leaf takes `gp0`; the
+# class is CLASS_FP for an all-float pair, CLASS_GP for the mixed case. Shared by
+# classify_arg (passing the next free argument registers) and classify_return (passing
+# fa0 / fa1 and a0, every bank being free at a return) so arg and return placement of
+# the same struct can never drift apart.
+# ---
+# agg:  the two-leaf flattened descriptor
+# nf:   the float-leaf count (1 selects the mixed case, 2 the float pair)
+# fp0:  the fa register for the first float leaf
+# fp1:  the fa register for the second float leaf (unused when nf == 1)
+# gp0:  the a register for the integer leaf (unused when nf == 2)
+# size: the aggregate's byte size
+# ret:  the assembled multi-piece ParamSlot
+fun make_two_leaf_slot(agg: abi.AggLayout, nf: u32, fp0: i32, fp1: i32, gp0: i32, size: u64) abi.ParamSlot {
+    var ps: [2]abi.ParamPiece;
+    var fa_used: u32 = 0;
+    var j: u32 = 0;
+    for (j < 2) {
+        if (agg.fields[j].is_float) {
+            var reg: i32 = fp0;
+            if (fa_used != 0) { reg = fp1; }
+            ps[j] = abi.make_piece(abi.PIECE_FP, reg, agg.fields[j].offset::i64, 0, agg.fields[j].width);
+            fa_used = fa_used + 1;
+        } or {
+            ps[j] = abi.make_piece(abi.PIECE_GP, gp0, agg.fields[j].offset::i64, 0, agg.fields[j].width);
+        }
+        j = j + 1;
+    }
+    var class: abi.ParamClass = abi.CLASS_GP;
+    if (nf == 2) { class = abi.CLASS_FP; }
+    ret abi.make_slot_pieces(class, ?ps[0], 2, size);
+}
+
 # classify one value into an lp64d placement decision
 #
 # This is the body behind the erased `AbiVTable.classify` pointer; it treats the
@@ -191,33 +240,18 @@ pub fun classify_arg(index: i32, size: u64, align: u64,
     }
 
     # different-width float pair / mixed float+integer struct (lp64d): a <=2-leaf
-    # aggregate the uniform-HFA rule above did not place. count the float leaves.
+    # aggregate the uniform-HFA rule above did not place. the float pair rides one fa
+    # register each, the mixed case the float in fa and the integer in a; either falls
+    # through to the integer convention when a needed bank lacks a register.
     if (is_aggregate && agg.field_count == 2) {
-        var nf: u32 = 0;
-        var k: u32 = 0;
-        for (k < 2) { if (agg.fields[k].is_float) { nf = nf + 1; } k = k + 1; }
+        val nf: u32 = two_leaf_float_count(agg);
         if (nf == 2) {
-            # two floats of (possibly) different widths -> one fa register each.
             if (fp_used + 2 <= FP_PARAM_COUNT) {
-                var ps: [2]abi.ParamPiece;
-                ps[0] = abi.make_piece(abi.PIECE_FP, fp_param_reg(fp_used),     agg.fields[0].offset::i64, 0, agg.fields[0].width);
-                ps[1] = abi.make_piece(abi.PIECE_FP, fp_param_reg(fp_used + 1), agg.fields[1].offset::i64, 0, agg.fields[1].width);
-                ret abi.make_slot_pieces(abi.CLASS_FP, ?ps[0], 2, size);
+                ret make_two_leaf_slot(agg, 2, fp_param_reg(fp_used), fp_param_reg(fp_used + 1), -1, size);
             }
         } or (nf == 1) {
-            # one float + one integer -> the float in fa, the integer in a.
             if (fp_used < FP_PARAM_COUNT && gp_used < GP_PARAM_COUNT) {
-                var ps: [2]abi.ParamPiece;
-                var j: u32 = 0;
-                for (j < 2) {
-                    if (agg.fields[j].is_float) {
-                        ps[j] = abi.make_piece(abi.PIECE_FP, fp_param_reg(fp_used), agg.fields[j].offset::i64, 0, agg.fields[j].width);
-                    } or {
-                        ps[j] = abi.make_piece(abi.PIECE_GP, gp_param_reg(gp_used), agg.fields[j].offset::i64, 0, agg.fields[j].width);
-                    }
-                    j = j + 1;
-                }
-                ret abi.make_slot_pieces(abi.CLASS_GP, ?ps[0], 2, size);
+                ret make_two_leaf_slot(agg, 1, fp_param_reg(fp_used), -1, gp_param_reg(gp_used), size);
             }
         }
         # two ints, or a needed bank is exhausted: fall through to the integer convention.
@@ -312,26 +346,11 @@ pub fun classify_return(size: u64, align: u64,
     # aggregate the uniform-HFA rule above did not place. all fa / a registers are free
     # at a return, so the float pair returns in fa0:fa1 and the mixed case in fa0 + a0.
     if (is_aggregate && agg.field_count == 2) {
-        var nf: u32 = 0;
-        var k: u32 = 0;
-        for (k < 2) { if (agg.fields[k].is_float) { nf = nf + 1; } k = k + 1; }
+        val nf: u32 = two_leaf_float_count(agg);
         if (nf == 2) {
-            var ps: [2]abi.ParamPiece;
-            ps[0] = abi.make_piece(abi.PIECE_FP, fp_param_reg(0), agg.fields[0].offset::i64, 0, agg.fields[0].width);
-            ps[1] = abi.make_piece(abi.PIECE_FP, fp_param_reg(1), agg.fields[1].offset::i64, 0, agg.fields[1].width);
-            ret abi.make_slot_pieces(abi.CLASS_FP, ?ps[0], 2, size);
+            ret make_two_leaf_slot(agg, 2, fp_param_reg(0), fp_param_reg(1), -1, size);
         } or (nf == 1) {
-            var ps: [2]abi.ParamPiece;
-            var j: u32 = 0;
-            for (j < 2) {
-                if (agg.fields[j].is_float) {
-                    ps[j] = abi.make_piece(abi.PIECE_FP, fp_param_reg(0), agg.fields[j].offset::i64, 0, agg.fields[j].width);
-                } or {
-                    ps[j] = abi.make_piece(abi.PIECE_GP, REG_A0, agg.fields[j].offset::i64, 0, agg.fields[j].width);
-                }
-                j = j + 1;
-            }
-            ret abi.make_slot_pieces(abi.CLASS_GP, ?ps[0], 2, size);
+            ret make_two_leaf_slot(agg, 1, fp_param_reg(0), -1, REG_A0, size);
         }
         # two ints: fall through to the integer-aggregate return convention.
     }

--- a/src/lang/target/abi/sysv.mach
+++ b/src/lang/target/abi/sysv.mach
@@ -427,18 +427,19 @@ pub fun register(reg: *abi.AbiRegistry) R.Result[bool, str] {
 # {f64; f64} -> both eightbytes SSE -> the two vector argument registers.
 test "mach.lang.target.abi.sysv.classify_arg:all_float_16byte_rides_xmm_pair" {
     val s: abi.ParamSlot = classify_arg(0, 16, 8, false, 3, true, 0, 0, 0, 0, abi.agg_none());
-    if (s.class != abi.CLASS_GP)    { ret 1; }
-    if (s.reg   != fp_param_reg(0)) { ret 1; }
-    if (s.reg2  != fp_param_reg(1)) { ret 1; }
+    if (s.class != abi.CLASS_GP)            { ret 1; }
+    if (s.piece_count   != 2)               { ret 1; }
+    if (s.pieces[0].reg != fp_param_reg(0)) { ret 1; }
+    if (s.pieces[1].reg != fp_param_reg(1)) { ret 1; }
     ret 0;
 }
 
 # {f32; f32} (8 bytes) -> one SSE eightbyte -> XMM0.
 test "mach.lang.target.abi.sysv.classify_arg:all_float_8byte_rides_one_xmm" {
     val s: abi.ParamSlot = classify_arg(0, 8, 4, false, 1, true, 0, 0, 0, 0, abi.agg_none());
-    if (s.class != abi.CLASS_GP)    { ret 1; }
-    if (s.reg   != fp_param_reg(0)) { ret 1; }
-    if (s.reg2  != -1)              { ret 1; }
+    if (s.class != abi.CLASS_GP)            { ret 1; }
+    if (s.piece_count   != 1)               { ret 1; }
+    if (s.pieces[0].reg != fp_param_reg(0)) { ret 1; }
     ret 0;
 }
 
@@ -446,19 +447,19 @@ test "mach.lang.target.abi.sysv.classify_arg:all_float_8byte_rides_one_xmm" {
 # {f64; i64} fills the banks independently, so the integer eightbyte takes RDI.
 test "mach.lang.target.abi.sysv.classify_arg:mixed_int_sse_rides_rdi_xmm" {
     val s: abi.ParamSlot = classify_arg(0, 16, 8, false, 2, true, 0, 0, 0, 0, abi.agg_none());
-    if (s.reg  != REG_RDI)         { ret 1; }
-    if (s.reg2 != fp_param_reg(0)) { ret 1; }
+    if (s.pieces[0].reg != REG_RDI)         { ret 1; }
+    if (s.pieces[1].reg != fp_param_reg(0)) { ret 1; }
     val r: abi.ParamSlot = classify_arg(0, 16, 8, false, 1, true, 0, 0, 0, 0, abi.agg_none());
-    if (r.reg  != fp_param_reg(0)) { ret 1; }
-    if (r.reg2 != REG_RDI)         { ret 1; }
+    if (r.pieces[0].reg != fp_param_reg(0)) { ret 1; }
+    if (r.pieces[1].reg != REG_RDI)         { ret 1; }
     ret 0;
 }
 
 # {i64; i64} (mask 0) -> RDI:RSI, exactly as before SSE classification.
 test "mach.lang.target.abi.sysv.classify_arg:all_integer_rides_gp_pair" {
     val s: abi.ParamSlot = classify_arg(0, 16, 8, false, 0, true, 0, 0, 0, 0, abi.agg_none());
-    if (s.reg  != REG_RDI) { ret 1; }
-    if (s.reg2 != REG_RSI) { ret 1; }
+    if (s.pieces[0].reg != REG_RDI) { ret 1; }
+    if (s.pieces[1].reg != REG_RSI) { ret 1; }
     ret 0;
 }
 
@@ -474,20 +475,20 @@ test "mach.lang.target.abi.sysv.classify_arg:sse_bank_exhaustion_spills" {
 # {f64; f64} returns in XMM0:XMM1; one all-float eightbyte returns in XMM0.
 test "mach.lang.target.abi.sysv.classify_return:all_float_returns_xmm_pair" {
     val s: abi.ParamSlot = classify_return(16, 8, false, 3, true, 0, 0, abi.agg_none());
-    if (s.reg  != REG_XMM0) { ret 1; }
-    if (s.reg2 != REG_XMM1) { ret 1; }
+    if (s.pieces[0].reg != REG_XMM0) { ret 1; }
+    if (s.pieces[1].reg != REG_XMM1) { ret 1; }
     val o: abi.ParamSlot = classify_return(8, 4, false, 1, true, 0, 0, abi.agg_none());
-    if (o.reg  != REG_XMM0) { ret 1; }
-    if (o.reg2 != -1)       { ret 1; }
+    if (o.piece_count   != 1)        { ret 1; }
+    if (o.pieces[0].reg != REG_XMM0) { ret 1; }
     ret 0;
 }
 
 # {i64; i64} -> RAX:RDX; {i64; f64} -> RAX:XMM0.
 test "mach.lang.target.abi.sysv.classify_return:banks_fill_in_order" {
     val gp: abi.ParamSlot = classify_return(16, 8, false, 0, true, 0, 0, abi.agg_none());
-    if (gp.reg != REG_RAX || gp.reg2 != REG_RDX) { ret 1; }
+    if (gp.pieces[0].reg != REG_RAX || gp.pieces[1].reg != REG_RDX) { ret 1; }
     val mix: abi.ParamSlot = classify_return(16, 8, false, 2, true, 0, 0, abi.agg_none());
-    if (mix.reg != REG_RAX || mix.reg2 != REG_XMM0) { ret 1; }
+    if (mix.pieces[0].reg != REG_RAX || mix.pieces[1].reg != REG_XMM0) { ret 1; }
     ret 0;
 }
 

--- a/src/lang/target/abi/sysv.mach
+++ b/src/lang/target/abi/sysv.mach
@@ -417,6 +417,8 @@ pub fun register(reg: *abi.AbiRegistry) R.Result[bool, str] {
     # a GP argument slot, so `classify_signature` seeds gp_used = 1 for an sret return.
     sysv_vtable.indirect_result_reg        = gp_param_reg(0);
     sysv_vtable.indirect_result_in_argfile = true;
+    # SysV ignores the flattened-aggregate descriptor (the lp64d hard-float rules).
+    sysv_vtable.consumes_agg_layout        = false;
 
     abi.register(reg, ?sysv_vtable);
     ret R.ok[bool, str](true);

--- a/src/lang/target/abi/win64.mach
+++ b/src/lang/target/abi/win64.mach
@@ -447,6 +447,8 @@ pub fun register_win64(reg: *abi.AbiRegistry) R.Result[bool, str] {
     # real arguments shift one slot.
     win64_vtable.indirect_result_reg        = slot_gp_reg(0);
     win64_vtable.indirect_result_in_argfile = true;
+    # win64 ignores the flattened-aggregate descriptor (the lp64d hard-float rules).
+    win64_vtable.consumes_agg_layout        = false;
 
     abi.register(reg, ?win64_vtable);
     ret R.ok[bool, str](true);


### PR DESCRIPTION
Closes #1734.

Behavior-preserving consolidation finishing the #1637 piece-model refactor. One cleanup per commit, each verified: mach test 690/0, the riscv64 / macho / freestanding byte-verify fixtures unchanged (133 / ok / 45), the riscv64 object byte-identical to the pre-refactor compiler, and a self-host fixpoint (the refactored compiler rebuilds itself byte-identically). The leaf-walker change additionally checked byte-identical on x86 via a float-struct SSE-mask probe object.

Cleanups (issue order):
1. ✅ Removed vestigial `reg2` / `reg_count` / `reg_width` and the `CLASS_HFA` discriminant from `ParamSlot`; `make_slot_hfa` labels its run `CLASS_FP`; per-ABI tests rewritten to assert on `pieces`.
2. ✅ Unified the two offset-based leaf-walkers (`mark_eightbyte_classes` + `agg_flatten`) behind one `collect_leaves` enumerator. `hfa_walk` is kept separate **by design** — it is a homogeneity reduction (union = widest member's count, not a leaf sum), so folding it in would change union-HFA placement on an untested path; a load-bearing comment guards it. (Acceptance note added to #1734.)
3. ✅ Factored the four piece-dispatch loops into one `materialize_pieces` (PiecePlan-parameterized); the GP/FP register arms collapse.
4. ✅ Deduped the lp64d two-leaf rule across `classify_arg` / `classify_return` (`two_leaf_float_count` + `make_two_leaf_slot`).
5. ✅ Gated the `agg_layout` flatten on `AbiVTable.consumes_agg_layout`.

Left as **draft** for maintainer review of the full diff before merge.
