### PR TITLE
fix(codegen): encode spilled-float load/store via the FP scratch on riscv64 + arm64 (#1737)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -176,6 +176,44 @@ jobs:
       - name: cross-compile, byte-verify, and run the rv64 fixture
         run: bash test/riscv64/verify.sh "$PWD/m"
 
+  # aarch64-linux is cross-compile-only on this x86_64 host: the integer-heavy self-host
+  # never spills floats, so the spilled-float load/store encoding (#1737) has no other
+  # e2e guard. this lane builds an aarch64-capable compiler from the PR source,
+  # cross-compiles the freestanding fixture (forty simultaneously-live f64s forcing an FP
+  # spill), asserts the spilled float encodes as scalar-FP ldr/str Dd, and runs it under
+  # qemu-aarch64 to assert its inline-asm `exit` exit code.
+  cross-arm64:
+    name: cross aarch64-linux
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: install llvm tools and qemu
+        run: |
+          set -euo pipefail
+          sudo apt-get update
+          sudo apt-get install -y llvm qemu-user
+
+      - name: fetch released mach
+        env:
+          GH_TOKEN: ${{ github.token }}
+          SEED: mach-*-x86_64-linux.tar.gz
+        run: |
+          set -euo pipefail
+          tmp="$(mktemp -d)"
+          gh release download -R "$GITHUB_REPOSITORY" -p "$SEED" -D "$tmp"
+          tar -xzf "$tmp"/$SEED -C /usr/local/bin mach
+          chmod +x /usr/local/bin/mach
+
+      - name: build aarch64-capable compiler from source
+        run: |
+          set -euo pipefail
+          mach dep pull
+          mach build . -o m
+
+      - name: cross-compile, byte-verify, and run the arm64 fixture
+        run: bash test/arm64/verify.sh "$PWD/m"
+
   # the Darwin triples are cross-compile-only here: the compiler cannot run on the
   # Linux host, so it is not built or self-tested for darwin. this lane builds a
   # Mach-O-capable compiler from the PR source, cross-compiles the freestanding

--- a/src/lang/target/isa/arm64/encode.mach
+++ b/src/lang/target/isa/arm64/encode.mach
@@ -964,6 +964,15 @@ fun emit_store_mem(st: *encode.EncodeState, f: *mir.MirFunction, dst_mem: *mir.M
         ret R.ok[bool, str](true);
     }
 
+    # a spilled float VALUE: regalloc left it as its frame slot. load it into the reserved
+    # FP scratch, then store the scratch to the destination at the float store width.
+    if (is_fp_slot(f, val_op)) {
+        val ldr: R.Result[bool, str] = emit_fp_slot_load(st, f, val_op, FP_SCRATCH0, width);
+        if (R.is_err[bool, str](ldr)) { ret ldr; }
+        emit_fp_mem(st, FP_SCRATCH0, m.base, m.off, width, false);
+        ret R.ok[bool, str](true);
+    }
+
     var rt: u32 = ZR;
     if (val_op.kind == mir.MIR_OP_IMM) {
         if (val_op.imm != 0) {
@@ -991,6 +1000,16 @@ fun encode_load(st: *encode.EncodeState, f: *mir.MirFunction, mi: *mir.MirInstr)
     if (mi.operand_count < 2) { ret R.err[bool, str]("encode: load missing operands"); }
     val dstop: *mir.MirOperand = ?mi.operands[0];
     val src: *mir.MirOperand = ?mi.operands[1];
+
+    # a spilled float DESTINATION: regalloc left it as its frame slot, for the encoder to
+    # fulfill. load the source into the reserved FP scratch then store the scratch to the
+    # destination slot (the scratch is never live across this single instruction's
+    # expansion). the source is a frame slot / pointer, never a folded symbol.
+    if (is_fp_slot(f, dstop)) {
+        val ldr: R.Result[bool, str] = emit_fp_slot_load(st, f, src, FP_SCRATCH0, mi.src_width);
+        if (R.is_err[bool, str](ldr)) { ret ldr; }
+        ret emit_fp_slot_store(st, f, dstop, FP_SCRATCH0, mi.src_width);
+    }
 
     if (reg_is_vec(dstop)) {
         val rvr: R.Result[i32, str] = req_vec(dstop);
@@ -1188,6 +1207,26 @@ fun emit_fp_slot_store(st: *encode.EncodeState, f: *mir.MirFunction, memop: *mir
     if (m.has_index) { ret R.err[bool, str]("encode: indexed float spill destination not expected"); }
     emit_fp_mem(st, rt, m.base, m.off, width, false);
     ret R.ok[bool, str](true);
+}
+
+# load a frame-slot / pointer MEM source into vector register `rt` at float `width`. the
+# spilled-float-source counterpart of `emit_fp_slot_store`.
+fun emit_fp_slot_load(st: *encode.EncodeState, f: *mir.MirFunction, memop: *mir.MirOperand, rt: u32, width: u8) R.Result[bool, str] {
+    val mr: R.Result[A64Mem, str] = resolve_mem(f, memop);
+    if (R.is_err[A64Mem, str](mr)) { ret R.err[bool, str](R.unwrap_err[A64Mem, str](mr)); }
+    val m: A64Mem = R.unwrap_ok[A64Mem, str](mr);
+    if (m.has_index) { ret R.err[bool, str]("encode: indexed float spill source not expected"); }
+    emit_fp_mem(st, rt, m.base, m.off, width, true);
+    ret R.ok[bool, str](true);
+}
+
+# true when `op` is a spilled FLOAT value: a frame-slot MEM operand whose slot-key vreg
+# is float-classed. regalloc leaves a spilled float load destination / store value in
+# place as `op_mem_slot(v, 0)` with `v` the original float vreg -- its class survives --
+# for the load / store encoder to fulfill through the FP scratch. a pointer-base MEM
+# (op_mem_preg, vreg NIL) or a GP slot (an alloca pointer / integer spill) is not float.
+fun is_fp_slot(f: *mir.MirFunction, op: *mir.MirOperand) bool {
+    ret op.kind == mir.MIR_OP_MEM && op.vreg != mir.MIR_VREG_NIL && mir.vreg_is_fp(f, op.vreg);
 }
 
 # materialize a float-constant bit pattern into vector register index

--- a/src/lang/target/isa/riscv64/encode.mach
+++ b/src/lang/target/isa/riscv64/encode.mach
@@ -716,6 +716,16 @@ fun emit_store_mem(st: *encode.EncodeState, f: *mir.MirFunction, dst_mem: *mir.M
         if (R.is_err[i32, str](rr)) { ret R.err[bool, str](R.unwrap_err[i32, str](rr)); }
         ret emit_fp_slot_store(st, f, dst_mem, R.unwrap_ok[i32, str](rr)::u32, width);
     }
+    # a spilled float VALUE: regalloc left it as its frame slot. load it into the reserved
+    # FP scratch, then store the scratch to the destination at the float store width.
+    if (is_fp_slot(f, val_op)) {
+        if (dst_mem.kind == mir.MIR_OP_SYM) {
+            ret R.err[bool, str]("encode: float store to a folded-global symbol is unsupported");
+        }
+        val ldr: R.Result[bool, str] = emit_fp_slot_load(st, f, val_op, FP_SCRATCH, width);
+        if (R.is_err[bool, str](ldr)) { ret ldr; }
+        ret emit_fp_slot_store(st, f, dst_mem, FP_SCRATCH, width);
+    }
     if (dst_mem.kind == mir.MIR_OP_SYM) {
         ret emit_global_store(st, dst_mem, val_op, width);
     }
@@ -817,6 +827,16 @@ fun encode_load(st: *encode.EncodeState, f: *mir.MirFunction, mi: *mir.MirInstr)
     if (mi.operand_count < 2) { ret R.err[bool, str]("encode: load missing operands"); }
     val dst: *mir.MirOperand = ?mi.operands[0];
     val src: *mir.MirOperand = ?mi.operands[1];
+    # a spilled float DESTINATION: regalloc left it as its frame slot, for the encoder to
+    # fulfill. load the source into the reserved FP scratch then store the scratch to the
+    # destination slot (the scratch is never live across this single instruction's
+    # expansion). the source is a frame slot / pointer, never a folded symbol -- lowering
+    # materializes a float load's symbol pointer into a base vreg first.
+    if (is_fp_slot(f, dst)) {
+        val ldr: R.Result[bool, str] = emit_fp_slot_load(st, f, src, FP_SCRATCH, mi.src_width);
+        if (R.is_err[bool, str](ldr)) { ret ldr; }
+        ret emit_fp_slot_store(st, f, dst, FP_SCRATCH, mi.src_width);
+    }
     # a float-bank destination reads the F/D load form (flw / fld), recovering its
     # f-register index from the composite id; the folded-global symbol source has no
     # float la-load form yet, so it errors loudly rather than mis-encoding as an integer
@@ -1165,6 +1185,27 @@ fun emit_fp_slot_store(st: *encode.EncodeState, f: *mir.MirFunction, memop: *mir
     if (m.has_index) { ret R.err[bool, str]("encode: indexed float spill destination not expected"); }
     emit_fp_mem(st, rt, m.base, m.off, width, false);
     ret R.ok[bool, str](true);
+}
+
+# load a frame-slot / pointer MEM source into float register `rt` at float `width`. the
+# spilled-float-source counterpart of `emit_fp_slot_store`.
+fun emit_fp_slot_load(st: *encode.EncodeState, f: *mir.MirFunction, memop: *mir.MirOperand, rt: u32, width: u8) R.Result[bool, str] {
+    val mr: R.Result[RvMem, str] = resolve_mem(f, memop);
+    if (R.is_err[RvMem, str](mr)) { ret R.err[bool, str](R.unwrap_err[RvMem, str](mr)); }
+    val m: RvMem = R.unwrap_ok[RvMem, str](mr);
+    if (m.has_index) { ret R.err[bool, str]("encode: indexed float spill source not expected"); }
+    emit_fp_mem(st, rt, m.base, m.off, width, true);
+    ret R.ok[bool, str](true);
+}
+
+# true when `op` is a spilled FLOAT value: a frame-slot MEM operand whose slot-key vreg
+# is float-classed. regalloc leaves a spilled float load destination / store value in
+# place as `op_mem_slot(v, 0)` with `v` the original float vreg -- its class survives --
+# for the load / store encoder to fulfill through the FP scratch, the same contract
+# `encode_fmov` already honors. a pointer-base MEM (op_mem_preg, vreg NIL) or a GP slot
+# (an alloca pointer / integer spill) is not float.
+fun is_fp_slot(f: *mir.MirFunction, op: *mir.MirOperand) bool {
+    ret op.kind == mir.MIR_OP_MEM && op.vreg != mir.MIR_VREG_NIL && mir.vreg_is_fp(f, op.vreg);
 }
 
 # the GP->FP reinterpret funct7 for a float width: fmv.w.x at 4 bytes, fmv.d.x at 8.

--- a/test/arm64/mach.toml
+++ b/test/arm64/mach.toml
@@ -1,0 +1,19 @@
+[project]
+id = "a64probe"
+name = "a64probe"
+version = "0.0.0"
+src = "src"
+target = "linux-arm64"
+out = "out/{target}/{name}{ext}"
+obj = "out/{target}/obj"
+
+[target.linux-arm64]
+isa = "aarch64"
+os  = "linux"
+abi = "aapcs64"
+
+[profile.debug]
+opt = 0
+
+[bin.a64probe]
+entry = "main.mach"

--- a/test/arm64/src/main.mach
+++ b/test/arm64/src/main.mach
@@ -1,0 +1,109 @@
+# freestanding aarch64-linux fixture for the #1737 spilled-float load/store fix.
+#
+# no std runtime is linked: the entry symbol is defined here directly. forty
+# simultaneously-live f64s exceed the AArch64 vector register file, so the allocator
+# spills float LOAD results (and the STORE values written back) to frame slots. before
+# #1737 the encoder aborted ("expected a register operand") on the first such spilled
+# float load/store; now it fulfills the slot regalloc set up, through the FP scratch
+# (ldr/str Sd|Dd). fps_in holds (i & 1), so the sum is the twenty odd indices in 0..39
+# = 20, returned as the process exit code; the qemu-aarch64 e2e asserts it.
+
+var fps_in:  [40]f64;
+var fps_out: [40]f64;
+
+fun fp_spill_probe() i64 {
+    var i: i64 = 0;
+    for (i < 40) { fps_in[i] = (i & 1)::f64; i = i + 1; }
+    var v0: f64 = fps_in[0];
+    var v1: f64 = fps_in[1];
+    var v2: f64 = fps_in[2];
+    var v3: f64 = fps_in[3];
+    var v4: f64 = fps_in[4];
+    var v5: f64 = fps_in[5];
+    var v6: f64 = fps_in[6];
+    var v7: f64 = fps_in[7];
+    var v8: f64 = fps_in[8];
+    var v9: f64 = fps_in[9];
+    var v10: f64 = fps_in[10];
+    var v11: f64 = fps_in[11];
+    var v12: f64 = fps_in[12];
+    var v13: f64 = fps_in[13];
+    var v14: f64 = fps_in[14];
+    var v15: f64 = fps_in[15];
+    var v16: f64 = fps_in[16];
+    var v17: f64 = fps_in[17];
+    var v18: f64 = fps_in[18];
+    var v19: f64 = fps_in[19];
+    var v20: f64 = fps_in[20];
+    var v21: f64 = fps_in[21];
+    var v22: f64 = fps_in[22];
+    var v23: f64 = fps_in[23];
+    var v24: f64 = fps_in[24];
+    var v25: f64 = fps_in[25];
+    var v26: f64 = fps_in[26];
+    var v27: f64 = fps_in[27];
+    var v28: f64 = fps_in[28];
+    var v29: f64 = fps_in[29];
+    var v30: f64 = fps_in[30];
+    var v31: f64 = fps_in[31];
+    var v32: f64 = fps_in[32];
+    var v33: f64 = fps_in[33];
+    var v34: f64 = fps_in[34];
+    var v35: f64 = fps_in[35];
+    var v36: f64 = fps_in[36];
+    var v37: f64 = fps_in[37];
+    var v38: f64 = fps_in[38];
+    var v39: f64 = fps_in[39];
+    fps_out[0] = v0;
+    fps_out[1] = v1;
+    fps_out[2] = v2;
+    fps_out[3] = v3;
+    fps_out[4] = v4;
+    fps_out[5] = v5;
+    fps_out[6] = v6;
+    fps_out[7] = v7;
+    fps_out[8] = v8;
+    fps_out[9] = v9;
+    fps_out[10] = v10;
+    fps_out[11] = v11;
+    fps_out[12] = v12;
+    fps_out[13] = v13;
+    fps_out[14] = v14;
+    fps_out[15] = v15;
+    fps_out[16] = v16;
+    fps_out[17] = v17;
+    fps_out[18] = v18;
+    fps_out[19] = v19;
+    fps_out[20] = v20;
+    fps_out[21] = v21;
+    fps_out[22] = v22;
+    fps_out[23] = v23;
+    fps_out[24] = v24;
+    fps_out[25] = v25;
+    fps_out[26] = v26;
+    fps_out[27] = v27;
+    fps_out[28] = v28;
+    fps_out[29] = v29;
+    fps_out[30] = v30;
+    fps_out[31] = v31;
+    fps_out[32] = v32;
+    fps_out[33] = v33;
+    fps_out[34] = v34;
+    fps_out[35] = v35;
+    fps_out[36] = v36;
+    fps_out[37] = v37;
+    fps_out[38] = v38;
+    fps_out[39] = v39;
+    var s: f64 = v0 + v1 + v2 + v3 + v4 + v5 + v6 + v7 + v8 + v9 + v10 + v11 + v12 + v13 + v14 + v15 + v16 + v17 + v18 + v19 + v20 + v21 + v22 + v23 + v24 + v25 + v26 + v27 + v28 + v29 + v30 + v31 + v32 + v33 + v34 + v35 + v36 + v37 + v38 + v39;
+    ret s::i64;
+}
+
+#[symbol("_start")]
+fun start() {
+    var code: i64 = fp_spill_probe();
+    asm aarch64 {
+        mov x8, 93
+        ldr x0, {code}
+        svc 0
+    }
+}

--- a/test/arm64/verify.sh
+++ b/test/arm64/verify.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# cross-compile the freestanding aarch64 fixture, byte-verify the result with the llvm
+# tools, then run it under qemu-aarch64 and assert its exit code. proves the arm64
+# backend encodes a spilled-float load/store as the scalar-FP slot form (ldr/str Sd|Dd)
+# rather than aborting -- the #1737 fix on the arm64 encoder.
+#
+# usage: verify.sh [path-to-mach]   (defaults to `mach` on PATH)
+#
+# requires: llvm-readelf, llvm-objdump (unversioned or `-NN` suffixed) and qemu-aarch64
+# (or qemu-aarch64-static) for the exit-code run.
+set -euo pipefail
+
+# the exit code the fixture returns: fps_in holds (i & 1) over a 40-wide f64 buffer the
+# allocator must spill, so the sum is the twenty odd indices in 0..39 = 20. the qemu e2e
+# asserts the exact code, so a regression in the spilled-float load/store encoding (an
+# abort, or an integer ld/st of the float bits) changes or breaks it.
+expect_code=20
+
+mach="${1:-mach}"
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$here"
+
+fail() { echo "FAIL: $1" >&2; exit 1; }
+
+# resolve an llvm tool by its unversioned name, falling back to the highest `-NN`
+# suffixed variant on PATH (ubuntu ships e.g. llvm-objdump-18).
+resolve_tool() {
+    local base="$1" cand
+    if command -v "$base" >/dev/null 2>&1; then echo "$base"; return 0; fi
+    cand="$(compgen -c "$base-" | sort -V | tail -n 1)"
+    if [ -n "$cand" ] && command -v "$cand" >/dev/null 2>&1; then echo "$cand"; return 0; fi
+    return 1
+}
+
+readelf="$(resolve_tool llvm-readelf)" || fail "llvm-readelf not found"
+objdump="$(resolve_tool llvm-objdump)" || fail "llvm-objdump not found"
+
+target="linux-arm64"
+exe="out/$target/a64probe"
+
+echo "cross-compiling fixture for $target with $mach"
+rm -rf out
+"$mach" build . --target "$target" --profile debug
+
+echo "verifying elf header of $exe"
+hdr="$("$readelf" -h "$exe")"
+grep -q 'Class:.*ELF64'    <<< "$hdr" || fail "exe is not ELFCLASS64"
+grep -q 'Machine:.*AArch64' <<< "$hdr" || fail "exe e_machine is not EM_AARCH64"
+
+# the spilled float must encode as the scalar-FP slot load/store (ldr/str Sd|Dd off a
+# frame base), not an integer ld/st of the float bits and not an encode abort (the build
+# above would have failed). assert both an FP slot load and store appear.
+echo "verifying spilled-float FP slot load/store in $exe"
+dis="$("$objdump" -d "$exe")"
+grep -qiE '\bldr\s+d[0-9]+,' <<< "$dis" || fail "no FP-register load (ldr Dd) found -- spilled float not encoded as scalar FP"
+grep -qiE '\bstr\s+d[0-9]+,' <<< "$dis" || fail "no FP-register store (str Dd) found -- spilled float not encoded as scalar FP"
+
+echo "running $exe under qemu-aarch64"
+qemu="$(command -v qemu-aarch64 || command -v qemu-aarch64-static || true)"
+[ -n "$qemu" ] || fail "qemu-aarch64 not found"
+set +e
+"$qemu" "$exe"
+code=$?
+set -e
+[ "$code" -eq "$expect_code" ] || fail "exit code $code, expected $expect_code"
+
+echo "OK: arm64 backend encodes spilled-float load/store as scalar FP and runs to exit code $expect_code"

--- a/test/riscv64/src/main.mach
+++ b/test/riscv64/src/main.mach
@@ -171,12 +171,109 @@ fun fj_probe(s: FJ) i64 {
     ret w::i64 + s.j::i64;
 }
 
+# global f64 buffers the spilled-float probe loads from and stores back to.
+var fps_in:  [40]f64;
+var fps_out: [40]f64;
+
+# the spilled-float load/store probe (#1737): forty simultaneously-live f64s exceed the
+# RISC-V float register file, so the allocator spills float LOAD results (and the STORE
+# values written back) to frame slots. before #1737 the encoder aborted ("expected a
+# register operand") on the first such spilled float load/store; now it fulfills the
+# slot contract regalloc set up, through the FP scratch (fld/fsd). fps_in holds (i & 1),
+# so the sum is the twenty odd indices in 0..39 = 20, a deterministic fold.
+fun fp_spill_probe() i64 {
+    var i: i64 = 0;
+    for (i < 40) { fps_in[i] = (i & 1)::f64; i = i + 1; }
+    var v0: f64 = fps_in[0];
+    var v1: f64 = fps_in[1];
+    var v2: f64 = fps_in[2];
+    var v3: f64 = fps_in[3];
+    var v4: f64 = fps_in[4];
+    var v5: f64 = fps_in[5];
+    var v6: f64 = fps_in[6];
+    var v7: f64 = fps_in[7];
+    var v8: f64 = fps_in[8];
+    var v9: f64 = fps_in[9];
+    var v10: f64 = fps_in[10];
+    var v11: f64 = fps_in[11];
+    var v12: f64 = fps_in[12];
+    var v13: f64 = fps_in[13];
+    var v14: f64 = fps_in[14];
+    var v15: f64 = fps_in[15];
+    var v16: f64 = fps_in[16];
+    var v17: f64 = fps_in[17];
+    var v18: f64 = fps_in[18];
+    var v19: f64 = fps_in[19];
+    var v20: f64 = fps_in[20];
+    var v21: f64 = fps_in[21];
+    var v22: f64 = fps_in[22];
+    var v23: f64 = fps_in[23];
+    var v24: f64 = fps_in[24];
+    var v25: f64 = fps_in[25];
+    var v26: f64 = fps_in[26];
+    var v27: f64 = fps_in[27];
+    var v28: f64 = fps_in[28];
+    var v29: f64 = fps_in[29];
+    var v30: f64 = fps_in[30];
+    var v31: f64 = fps_in[31];
+    var v32: f64 = fps_in[32];
+    var v33: f64 = fps_in[33];
+    var v34: f64 = fps_in[34];
+    var v35: f64 = fps_in[35];
+    var v36: f64 = fps_in[36];
+    var v37: f64 = fps_in[37];
+    var v38: f64 = fps_in[38];
+    var v39: f64 = fps_in[39];
+    fps_out[0] = v0;
+    fps_out[1] = v1;
+    fps_out[2] = v2;
+    fps_out[3] = v3;
+    fps_out[4] = v4;
+    fps_out[5] = v5;
+    fps_out[6] = v6;
+    fps_out[7] = v7;
+    fps_out[8] = v8;
+    fps_out[9] = v9;
+    fps_out[10] = v10;
+    fps_out[11] = v11;
+    fps_out[12] = v12;
+    fps_out[13] = v13;
+    fps_out[14] = v14;
+    fps_out[15] = v15;
+    fps_out[16] = v16;
+    fps_out[17] = v17;
+    fps_out[18] = v18;
+    fps_out[19] = v19;
+    fps_out[20] = v20;
+    fps_out[21] = v21;
+    fps_out[22] = v22;
+    fps_out[23] = v23;
+    fps_out[24] = v24;
+    fps_out[25] = v25;
+    fps_out[26] = v26;
+    fps_out[27] = v27;
+    fps_out[28] = v28;
+    fps_out[29] = v29;
+    fps_out[30] = v30;
+    fps_out[31] = v31;
+    fps_out[32] = v32;
+    fps_out[33] = v33;
+    fps_out[34] = v34;
+    fps_out[35] = v35;
+    fps_out[36] = v36;
+    fps_out[37] = v37;
+    fps_out[38] = v38;
+    fps_out[39] = v39;
+    var s: f64 = v0 + v1 + v2 + v3 + v4 + v5 + v6 + v7 + v8 + v9 + v10 + v11 + v12 + v13 + v14 + v15 + v16 + v17 + v18 + v19 + v20 + v21 + v22 + v23 + v24 + v25 + v26 + v27 + v28 + v29 + v30 + v31 + v32 + v33 + v34 + v35 + v36 + v37 + v38 + v39;
+    ret s::i64;
+}
+
 # the program entry. the `_start` symbol the linux linker resolves as the entry
 # point; the calls and the global read-modify-write give the relocations the lane
 # checks, the inline-asm block exercises the RV64A atomics (#1668), and the
 # inline-asm `exit` syscall returns the computed sum as the process exit code
 # (sum_to(10)=45 + na(3)=8 + stack_probe + parse_probe(1) + bitmix + split_probe=35
-# + fi_probe=7 + ff_probe=12 + fj_probe=9 + atomics).
+# + fi_probe=7 + ff_probe=12 + fj_probe=9 + fp_spill_probe=20 + atomics).
 #
 # the atomics run on a stack cell (`{cell}`, address taken through `p`): an lr/sc
 # compare-and-swap loop swaps it from 0 to 7 - the reservation-retry (1b) and
@@ -217,6 +314,9 @@ fun start() {
     fj.f = 3.0::f32;
     fj.j = 6;
     code = code + fj_probe(fj);
+
+    # the spilled-float load/store probe (#1737): 20 (twenty odd indices in 0..39).
+    code = code + fp_spill_probe();
 
     var cell:  i64  = 0;
     var p:     *i64 = ?cell;

--- a/test/riscv64/verify.sh
+++ b/test/riscv64/verify.sh
@@ -16,10 +16,12 @@ set -euo pipefail
 # 1+..+7 + struct halves 2 + 5), the lp64d mixed float+integer probe (#1637 case A, 7 =
 # f 2.0 in fa0 + i 5 in a0), the lp64d different-width float-pair probe (#1637 case B,
 # 12 = a 4.0 in fa0 + b 8.0 in fa1), the lp64d sub-word mixed probe (#1637 case A
-# sub-word, 9 = f 3.0 in fa0 + j 6 in a0 at offset 4, the 4-byte GP chunk), and the
-# RV64A atomics probe (#1668, 18 = swapped 7 + post-rmw cell 11), wrapping to 133. the
-# qemu e2e asserts the exact code, so a regression in any of those changes it.
-expect_code=133
+# sub-word, 9 = f 3.0 in fa0 + j 6 in a0 at offset 4, the 4-byte GP chunk), the
+# spilled-float load/store probe (#1737, 20 = twenty odd values in a 40-wide f64 buffer
+# the allocator must spill through the FP scratch), and the RV64A atomics probe (#1668,
+# 18 = swapped 7 + post-rmw cell 11), wrapping to 153. the qemu e2e asserts the exact
+# code, so a regression in any of those changes it.
+expect_code=153
 
 mach="${1:-mach}"
 here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"


### PR DESCRIPTION
Closes #1737.

## The bug
When register allocation spills a float, it leaves the spilled load destination / store value in place as a frame-slot MEM operand (`op_mem_slot(v)` carrying the float vreg id) for the encoder to fulfill — the contract `encode_fmov` already honored for spilled float MOVs. But the riscv64 and arm64 **load/store** encoders dispatched the scalar-FP form only on a float PREG (`reg_is_fp` / `req_vec`), so a spilled float (now a MEM with no PREG) fell through to `req_gpr` → `encode: expected a register operand` abort. Latent on arm64 because the integer-heavy self-host never spills floats; a float-heavy program under FP pressure aborts on **both** backends.

## The fix (approach (a), encoder-local — signed off)
Detect a spilled-float slot operand by its slot-key vreg's class (`is_fp_slot` via `vreg_is_fp`) — no isel/regalloc change, matching the existing operand-class FP seam and regalloc's own "identify the float side by vreg class" rule — and route it through the reserved FP scratch (never live across the single instruction's expansion, mirroring `encode_fmov`):
- spilled-dest **LOAD**: src → fp scratch → dest slot
- spilled-value **STORE**: value slot → fp scratch → dest mem

via the new `emit_fp_slot_load` mirroring `emit_fp_slot_store`, in both `riscv64/encode.mach` and `arm64/encode.mach`.

## Validation (before → after)
- Both ISAs **abort on pre-fix dev** (`encode: expected a register operand`) and **run correctly after** the fix.
- **riscv64 fixture**: a `fp_spill_probe` (forty simultaneously-live f64s, loaded from + stored back to a global buffer) folds into the exit code; fixture 133 → **153** under qemu-riscv64.
- **arm64 fixture (new `test/arm64/`)**: same probe, run under qemu-aarch64 to **exit 20**, asserting the spilled float encodes as scalar-FP `ldr/str Dd` (not an integer ld/st or an abort).
- `mach test` 690/0; macho + freestanding fixtures unchanged.

Draft for review — not marked ready.
