### PR TITLE
fix(codegen/riscv64): f64 through a native variadic pack miscompiles to 0 (#1762)

### DIFF
--- a/int/regression/1762-rv64-float-vararg/expect.txt
+++ b/int/regression/1762-rv64-float-vararg/expect.txt
@@ -1,0 +1,3 @@
+computed=3.75
+literal=0.5
+f32=1.5

--- a/int/regression/1762-rv64-float-vararg/mach.toml
+++ b/int/regression/1762-rv64-float-vararg/mach.toml
@@ -1,0 +1,52 @@
+[project]
+id      = "case"
+name    = "case"
+version = "0.0.0"
+src     = "src"
+dep     = "dep"
+target  = "linux"
+out     = "out/{target}/{profile}/bin/{name}{ext}"
+
+[target.linux]
+isa = "x86_64"
+os  = "linux"
+abi = "sysv64"
+
+[target.linux-arm64]
+isa = "aarch64"
+os  = "linux"
+abi = "aapcs64"
+
+[target.linux-riscv64]
+isa = "riscv64"
+os  = "linux"
+abi = "lp64"
+
+[target.windows]
+isa = "x86_64"
+os  = "windows"
+abi = "win64"
+ext = ".exe"
+
+[target.darwin-x86_64]
+isa = "x86_64"
+os  = "darwin"
+abi = "sysv64"
+
+[target.darwin-aarch64]
+isa = "aarch64"
+os  = "darwin"
+abi = "aapcs64"
+
+[profile.debug]
+opt = 0
+
+[profile.release]
+opt = 2
+
+[bin.case]
+entry = "main.mach"
+
+[deps.mach-std]
+git = "https://github.com/briar-systems/mach-std"
+ref = "branch/main"

--- a/int/regression/1762-rv64-float-vararg/src/main.mach
+++ b/int/regression/1762-rv64-float-vararg/src/main.mach
@@ -1,0 +1,24 @@
+# regression pin for #1762: a freshly-computed f64 through the native variadic pack.
+#
+# std.print.printlnf takes its argument through the language's own variadic pack
+# (`va: ...` / `$each`), and vformat's `arg::f64` reinterpret-casts the pack element.
+# on riscv64 that same-bank float bitcast was dropped (the float destination went
+# unwritten, reading stale bits), so a freshly-computed or constant f64 printed 0.
+# printing a computed and a literal f64 here diverges (or prints 0) on linux-riscv64
+# if it recurs, while x86_64 / aarch64 stay correct. the f32 line covers the widened
+# path too.
+
+use std.runtime;
+use std.types.size.usize;
+use p: std.print;
+
+fun addf(x: f64, y: f64) f64 { ret x + y; }
+fun addf32(x: f32, y: f32) f32 { ret x + y; }
+
+#[symbol("main")]
+fun main(argc: usize, argv: **u8) i64 {
+    p.printlnf("computed={}", addf(2.5, 1.25));        # 3.75 through the variadic pack
+    p.printlnf("literal={}", 0.5);                     # a bare f64 literal
+    p.printlnf("f32={}", addf32(1.0::f32, 0.5::f32));  # an f32 through the pack
+    ret 0;
+}

--- a/src/lang/target/isa/riscv64/isel.mach
+++ b/src/lang/target/isa/riscv64/isel.mach
@@ -246,14 +246,17 @@ fun rewrite(fn: *mir.MirFunction, mi: *mir.MirInstr) R.Result[bool, str] {
         ret R.ok[bool, str](true);
     }
 
-    # a bit reinterpret crossing the GP and float banks (`f64 :~ i64` / `i32 :~ f32`)
-    # selects to FMV, which transfers the raw bits between a GP register and an F/D
-    # register; the encoder picks the direction from operand register class. a
-    # same-bank reinterpret (GP<->GP) stays MIR_BITCAST - a plain register copy the
-    # integer conversion encoder handles. a float-to-float bitcast cannot occur (a
-    # reinterpret is equal-size and the only two float widths differ).
+    # a bit reinterpret touching the float bank selects to FMV, whose encoder picks
+    # the form from operand register class: a cross-bank reinterpret (`f64 :~ i64` /
+    # `i32 :~ f32`) transfers the raw bits between a GP and an F/D register (fmv.d.x /
+    # fmv.x.d); a same-bank float-to-float reinterpret is a float register copy
+    # (fmv.d / fmv.s). the latter arises from the native variadic `arg::f64` over a
+    # float pack element (#1762) - left as MIR_BITCAST it would encode as a GP move of
+    # the aliasing register index, never writing the float destination. a same-bank
+    # GP<->GP reinterpret stays MIR_BITCAST, a plain register copy the integer
+    # conversion encoder handles.
     if (o == mir.MIR_BITCAST) {
-        if (operand_is_fp(fn, ?mi.operands[0]) != operand_is_fp(fn, ?mi.operands[1])) {
+        if (operand_is_fp(fn, ?mi.operands[0]) || operand_is_fp(fn, ?mi.operands[1])) {
             mi.opcode = riscv64.FMV::u32;
         }
         ret R.ok[bool, str](true);


### PR DESCRIPTION
Closes #1762.

## Root cause

The riscv64 instruction selector silently turned **any same-bank float→float `MIR_BITCAST` into a no-op**: its `MIR_BITCAST` arm only rewrote a bitcast to `FMV` when the two operands were in *different* register banks (a cross-bank `f64 :~ i64` reinterpret), on the assumption that "a float-to-float bitcast cannot occur." A same-bank **float** bitcast therefore stayed `MIR_BITCAST`, which the encoder treats as a GP register *copy* of the aliasing GP index — so the float **destination register is never written**.

The native variadic `$each arg in va` (std `vformat`'s `arg::f64` type-directed dispatch) is just the path that *surfaced* this — it emits exactly such a same-bank float bitcast (`fs0 → ft0`). `vformat` then forwarded the stale, never-written register to `fmt_f64_field` / `write_f64`, which read the wrong bits, so an `f64` through `printlnf` printed `0`. The scope of the bug (and the fix) is broader than the variadic symptom: it hardens **every** same-bank-float-bitcast path on riscv64.

This is why the symptom looked variadic- and constant-specific and order-dependent: the stale FP temp held `0` on a fresh path (printed `0`), or a leftover float from a prior `fld` (so a preceding runtime-arg `printlnf` "fixed" later constant ones, and a const-first call printed `1` from a leftover). The value was provably correct all the way into `vformat` (`fa0 = 3.75`, confirmed by a qemu register trace); it was dropped at the no-op bitcast. Not the C-variadic ABI limitation. x86_64 and aarch64 copy the register in their bitcast handling and were unaffected — no self-host fixpoint impact.

## Fix

`src/lang/target/isa/riscv64/isel.mach`: select `FMV` when *either* operand is FP. `encode_fmov` already emits `fmv.d` / `fmv.s` for a float→float copy and `fmv.d.x` / `fmv.x.d` for a cross-bank reinterpret; a GP↔GP bitcast still stays `MIR_BITCAST`. riscv64-local, one condition + comment.

## Tests

- **Unit (per-PR, native):** the isel `opcode_rewrites` test gains a same-bank float `MIR_BITCAST` case asserting it selects `FMV` — a guard right at the selection seam.
- **e2e (per-PR, under qemu):** `int/regression/1762-rv64-float-vararg` prints a computed and a literal `f64` through the native variadic pack. RED on linux-riscv64 with a pre-fix compiler (`computed=0, literal=0`), green after; green on x86_64 throughout.

## Verification (from-source current-dev compiler, not the seed)

- `printlnf("{}", addf(2.5, 1.25))` cross-built for `linux-riscv64` prints `3.75` under qemu in **both debug and release** (was `0`); single/double constant, const-then-int, and `f32` constant all correct; x86_64 reference unchanged.
- `mach test .` → 430/0 (includes the new isel unit test).
- `int/run.sh` green on linux and linux-riscv64 (qemu).
