### PR TITLE
test(codegen/riscv64): assert a same-bank float bitcast selects FMV (#1762)

### DIFF
--- a/src/lang/target/isa/riscv64/isel.mach
+++ b/src/lang/target/isa/riscv64/isel.mach
@@ -351,10 +351,10 @@ test "mach.lang.target.isa.riscv64.isel:opcode_rewrites" {
     var alloc: A.Allocator;
     var tgt:   target.Target;
 
-    var instrs: [13]mir.MirInstr;
-    var ops:    [13][3]mir.MirOperand;
+    var instrs: [14]mir.MirInstr;
+    var ops:    [14][3]mir.MirOperand;
     var i:      u32 = 0;
-    for (i < 13) {
+    for (i < 14) {
         ops[i][0] = mir.op_preg(10);
         ops[i][1] = mir.op_preg(11);
         ops[i][2] = mir.op_preg(12);
@@ -377,10 +377,14 @@ test "mach.lang.target.isa.riscv64.isel:opcode_rewrites" {
     instrs[7].opcode  = mir.MIR_MOV;
     instrs[8].opcode  = mir.MIR_MOV;
     ops[8][0] = fp_preg(10); ops[8][1] = fp_preg(11);
-    # a cross-bank `:~` bitcast selects FMV; a same-bank one stays MIR_BITCAST.
+    # a bitcast touching the float bank selects FMV - cross-bank (instrs[9]) and
+    # same-bank float-to-float (instrs[13], the #1762 case); a same-bank GP<->GP
+    # bitcast (instrs[10]) stays MIR_BITCAST.
     instrs[9].opcode  = mir.MIR_BITCAST;
     ops[9][0] = fp_preg(10); ops[9][1] = mir.op_preg(11);
     instrs[10].opcode = mir.MIR_BITCAST;
+    instrs[13].opcode = mir.MIR_BITCAST;
+    ops[13][0] = fp_preg(10); ops[13][1] = fp_preg(11);
     # control flow.
     instrs[11].opcode = mir.MIR_BR;
     instrs[12].opcode = mir.MIR_RET;
@@ -388,7 +392,7 @@ test "mach.lang.target.isa.riscv64.isel:opcode_rewrites" {
     var blk: mir.MirBlock;
     blk.id          = 0;
     blk.instrs      = ?instrs[0];
-    blk.instr_count = 13;
+    blk.instr_count = 14;
 
     var fn: mir.MirFunction;
     fn.blocks      = ?blk;
@@ -407,9 +411,10 @@ test "mach.lang.target.isa.riscv64.isel:opcode_rewrites" {
     if (instrs[7].opcode  != riscv64.MOV::u32)    { bad = 1; }  # GP move
     if (instrs[8].opcode  != riscv64.FMV::u32)    { bad = 1; }  # float move
     if (instrs[9].opcode  != riscv64.FMV::u32)    { bad = 1; }  # cross-bank bitcast
-    if (instrs[10].opcode != mir.MIR_BITCAST)     { bad = 1; }  # same-bank bitcast survives
+    if (instrs[10].opcode != mir.MIR_BITCAST)     { bad = 1; }  # same-bank GP bitcast survives
     if (instrs[11].opcode != riscv64.JMP::u32)    { bad = 1; }
     if (instrs[12].opcode != riscv64.RET::u32)    { bad = 1; }
+    if (instrs[13].opcode != riscv64.FMV::u32)    { bad = 1; }  # same-bank float bitcast (#1762)
 
     ret bad;
 }


### PR DESCRIPTION
Follow-up to #1763 (the #1762 fix, already merged). That PR merged just before this isel unit-test guard landed on the branch, so it's broken out here.

Adds a same-bank float→float `MIR_BITCAST` case (both operands float-bank) to the riscv64 isel `opcode_rewrites` test, asserting it selects `FMV` — a native, per-PR guard right at the selection seam where #1762 lived (any same-bank float bitcast was silently a no-op). Complements the e2e `int/regression/1762-rv64-float-vararg` pin (which guards it under qemu).

`mach test .` → 430/0.

Refs #1762
