### PR TITLE
ci(int): run darwin on merge to main, not a schedule

### DIFF
--- a/.github/workflows/int-main.yml
+++ b/.github/workflows/int-main.yml
@@ -1,14 +1,16 @@
-name: int nightly
+name: int main
 
-# the darwin legs of the integration matrix run on a nightly cadence (and on
-# manual dispatch) rather than per-PR: the macOS runners are scarce, and darwin
-# releases are arm64-only, so a from-source compiler for each darwin target has to
-# be cross-built on linux first. the leg set is still data-driven from
-# int/targets.conf (the nightly-cadence rows), so adding a darwin target is one row.
+# the darwin legs of the integration matrix run on merge to main (and on manual
+# dispatch) rather than per-PR: the macOS runners are scarce, and darwin releases
+# are arm64-only, so a from-source compiler for each darwin target has to be
+# cross-built on linux first. running at the release-integration gate catches a
+# darwin codegen regression there while paying the macOS cost only then. the leg set
+# is still data-driven from int/targets.conf (the main-cadence rows), so adding a
+# darwin target is one row.
 
 on:
-  schedule:
-    - cron: '17 7 * * *'
+  push:
+    branches: [main]
   workflow_dispatch:
 
 permissions:
@@ -23,7 +25,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - id: gen
-        run: echo "include=$(bash int/lib/ci-matrix.sh nightly)" >> "$GITHUB_OUTPUT"
+        run: echo "include=$(bash int/lib/ci-matrix.sh main)" >> "$GITHUB_OUTPUT"
 
   # darwin releases are arm64-only (there is no x86_64-darwin seed to self-host
   # from), so the from-source compiler for each darwin target is cross-built on

--- a/int/targets.conf
+++ b/int/targets.conf
@@ -8,12 +8,12 @@
 #   name      the `mach --target` name, also the harness/CI leg identifier
 #   runner    the GitHub Actions runner label the leg executes on
 #   run-mode  native (run the binary directly) | qemu (run under qemu-user)
-#   cadence   pr (every pull request) | nightly (scheduled + manual dispatch)
+#   cadence   pr (every pull request) | main (on merge to main)
 #
 # name           runner            run-mode  cadence
 linux            ubuntu-latest     native    pr
 linux-arm64      ubuntu-24.04-arm  native    pr
 linux-riscv64    ubuntu-latest     qemu      pr
 windows          windows-latest    native    pr
-darwin-x86_64    macos-13          native    nightly
-darwin-aarch64   macos-14          native    nightly
+darwin-x86_64    macos-13          native    main
+darwin-aarch64   macos-14          native    main


### PR DESCRIPTION
Corrects the darwin integration cadence: no scheduled actions. The darwin legs now run on **merge to main** (the release-integration gate) plus manual dispatch — catching a darwin codegen regression there while paying the scarce macOS cost only then, never on a timer or per-PR.

## Changes
- Rename `.github/workflows/int-nightly.yml` → `.github/workflows/int-main.yml`.
- Trigger: `schedule: (cron)` → `push: branches: [main]`; `workflow_dispatch` kept (manual is not a schedule). Cron removed entirely.
- `name:` → `int main`; header comment updated (merge-to-main, not nightly).
- Matrix job reads `ci-matrix.sh main` (was `nightly`).
- `int/targets.conf`: darwin rows' cadence `nightly` → `main`; cadence doc comment → `pr (every pull request) | main (on merge to main)`.
- Darwin bootstrap (cross-build the compiler on linux, hand to the macOS runner) unchanged. The per-PR `integration` job in `ci.yml` is untouched.

## Verification
- `bash int/lib/ci-matrix.sh main` → exactly the two darwin legs (`darwin-x86_64`/macos-13, `darwin-aarch64`/macos-14).
- `bash int/lib/ci-matrix.sh pr` → unchanged (linux, linux-arm64, linux-riscv64, windows), so PR CI is unaffected.
- `int-main.yml` parses; triggers are `push` + `workflow_dispatch` (no schedule). No remaining "nightly" wording under `int/` or the workflows.

Refs #1758
