### PR TITLE
fix(be): loud-error backend silent fallbacks + AAPCS64 edge-rule docs

### DIFF
--- a/src/lang/be/codegen.mach
+++ b/src/lang/be/codegen.mach
@@ -446,6 +446,17 @@ fun pack_globals(s: *session.Session, tgt: *target.Target, image: *of.ObjectImag
             # value is silently lost - every initialized scalar global would read
             # as 0. `int_lit` aliases the value's raw bits (the IR Value's data is
             # a union), so it is the bit source for both int and float.
+            #
+            # this kind also legitimately carries the compact zero placeholder the
+            # middle end emits for a global with no explicit initializer (or one
+            # that folds to zero): `me.lower.decl.lower_global` lowers it as
+            # `const_int(0, <full storage type>)`, so for `var buf: [256]u8;` it is
+            # a VAL_CONST_INT 0 whose type is the whole 256-byte aggregate. the
+            # eight-byte size bound below is therefore a real dispatch, not a guard
+            # to harden: a 1..8 byte value is serialized into .data/.rodata; an
+            # aggregate-sized (or void) zero placeholder must reach the bytes==nil
+            # .bss fall-through. only a NON-zero bit pattern at an unrepresentable
+            # size would silently drop a real value, and that alone is a loud error.
             val gsz: u32 = type.byte_size(?irmod.types, g.ty, tgt);
             if (gsz > 0 && gsz <= 8) {
                 val res_bytes: R.Result[*u8, str] = A.allocate[u8](s.alloc, gsz::usize);
@@ -466,14 +477,10 @@ fun pack_globals(s: *session.Session, tgt: *target.Target, image: *of.ObjectImag
                 len = gsz;
             }
             or (g.init.data.int_lit != 0) {
-                # a register-width scalar is 1..8 bytes; a zero/over-eight size that
-                # carries a non-zero bit pattern is the one case where falling
-                # through to a zero-filled .bss entry would silently drop a real
-                # value. that is an IR-classification bug, reported loudly. a zero
-                # bit pattern at this size is the compact zero-initializer the
-                # middle end emits for an aggregate (or void) global -- correctly
-                # routed to a zero-filled .bss reservation by the bytes==nil
-                # fall-through below, so it is left to do exactly that.
+                # a non-zero bit pattern at a zero/over-eight size is the only case
+                # the .bss fall-through would silently drop (a zero placeholder is
+                # routed there correctly); that is an IR-classification bug, reported
+                # loudly rather than dropped.
                 ret R.err[bool, str]("be.codegen.pack_globals: non-zero scalar constant global initializer has unsupported size (expected 1..8 bytes)");
             }
         }

--- a/src/lang/be/codegen.mach
+++ b/src/lang/be/codegen.mach
@@ -465,6 +465,17 @@ fun pack_globals(s: *session.Session, tgt: *target.Target, image: *of.ObjectImag
                 }
                 len = gsz;
             }
+            or (g.init.data.int_lit != 0) {
+                # a register-width scalar is 1..8 bytes; a zero/over-eight size that
+                # carries a non-zero bit pattern is the one case where falling
+                # through to a zero-filled .bss entry would silently drop a real
+                # value. that is an IR-classification bug, reported loudly. a zero
+                # bit pattern at this size is the compact zero-initializer the
+                # middle end emits for an aggregate (or void) global -- correctly
+                # routed to a zero-filled .bss reservation by the bytes==nil
+                # fall-through below, so it is left to do exactly that.
+                ret R.err[bool, str]("be.codegen.pack_globals: non-zero scalar constant global initializer has unsupported size (expected 1..8 bytes)");
+            }
         }
 
         # a global with an initializer (a non-nil byte image) is initialized data

--- a/src/lang/be/codegen/mir/abi.mach
+++ b/src/lang/be/codegen/mir/abi.mach
@@ -388,6 +388,12 @@ fun agg_layout(ctx: *context.LowerCtx, ty: type.IrTypeId, is_aggr: bool) abi.Agg
 # PIECE_STACK (a register-plus-stack split's tail) consumes neither. This covers a
 # scalar, a by-reference pointer, a two-register pair, a CLASS_HFA run, a mixed
 # GP / FP aggregate, and a split uniformly, since every placement carries its pieces.
+#
+# A bank cursor advances only by the registers a slot actually consumes; a fully
+# stack-passed argument advances neither. AAPCS64 saturates the bank cursor to its
+# limit when a register-eligible argument spills for lack of a fitting run (psABI
+# C.4 / C.13) so no later same-bank argument back-fills a left-behind register -- a
+# documented AAPCS64 simplification (see `target.abi.aapcs64`), not modeled here.
 # ---
 # slot:    the classified slot whose register chunks are consumed
 # gp_used: the running GP argument-register cursor, advanced in place

--- a/src/lang/be/codegen/mir/abi.mach
+++ b/src/lang/be/codegen/mir/abi.mach
@@ -1094,7 +1094,9 @@ fun emit_arg_slot(ctx: *context.LowerCtx, mb: *mir.MirBlock, slot: abi.ParamSlot
     # for a float-constant immediate) rather than a general-purpose MOV of the GP
     # register that aliases the XMM index.
     if (slot.class == abi.CLASS_FP) {
-        ret context.emit_fmov(ctx, mb, mir.op_preg(slot.reg::u32), argop, fp_move_width(size));
+        val fw: R.Result[u8, str] = fp_move_width(size);
+        if (R.is_err[u8, str](fw)) { ret R.err[bool, str](R.unwrap_err[u8, str](fw)); }
+        ret context.emit_fmov(ctx, mb, mir.op_preg(slot.reg::u32), argop, R.unwrap_ok[u8, str](fw));
     }
     # single GP register scalar argument. a 32-bit value rides a width-4 move so the
     # backend re-extends it to the register width by its own convention (RV64 lp64
@@ -1105,13 +1107,15 @@ fun emit_arg_slot(ctx: *context.LowerCtx, mb: *mir.MirBlock, slot: abi.ParamSlot
 # the SSE move width (4 for f32, 8 for f64) for a CLASS_FP scalar of `size` bytes
 #
 # A CLASS_FP slot is always a 4- or 8-byte scalar float; any other size is an
-# ABI-classification bug, defaulted to the f64 form.
+# ABI-classification bug, reported loudly rather than defaulted to a move width
+# that would silently mis-size the float copy.
 # ---
 # size: the scalar's byte size
-# ret:  the SSE move width in bytes (4 or 8)
-fun fp_move_width(size: u64) u8 {
-    if (size == 4) { ret 4; }
-    ret 8;
+# ret:  the SSE move width in bytes (4 or 8), or a loud error on an unexpected size
+fun fp_move_width(size: u64) R.Result[u8, str] {
+    if (size == 4) { ret R.ok[u8, str](4); }
+    if (size == 8) { ret R.ok[u8, str](8); }
+    ret R.err[u8, str]("mir.abi.fp_move_width: CLASS_FP scalar of unsupported size (expected 4 or 8 bytes)");
 }
 
 # the move width for materializing a scalar GP value into its argument / return
@@ -1384,7 +1388,9 @@ pub fun lower_ret(ctx: *context.LowerCtx, mb: *mir.MirBlock, inst: *instruction.
         # the SSE class, so the encoder dispatches the move on operand class and emits
         # MOVSS / MOVSD (or MOVABS + MOVQ for a float-constant immediate) rather than a
         # general-purpose MOV of RAX, which aliases XMM0's index.
-        val mr: R.Result[bool, str] = context.emit_fmov(ctx, mb, mir.op_preg(slot.reg::u32), rvop, fp_move_width(rsz));
+        val fw: R.Result[u8, str] = fp_move_width(rsz);
+        if (R.is_err[u8, str](fw)) { ret R.err[bool, str](R.unwrap_err[u8, str](fw)); }
+        val mr: R.Result[bool, str] = context.emit_fmov(ctx, mb, mir.op_preg(slot.reg::u32), rvop, R.unwrap_ok[u8, str](fw));
         if (R.is_err[bool, str](mr)) { ret mr; }
     } or (slot.reg >= 0) {
         # scalar GP return: a 32-bit value rides a width-4 move so the backend

--- a/src/lang/target/abi/aapcs64.mach
+++ b/src/lang/target/abi/aapcs64.mach
@@ -21,6 +21,38 @@
 # consumer casts each back to the neutral signature declared in `abi`. The full
 # AArch64 `va_list` variadic model is deferred: `va_model` returns a register-save
 # placeholder sufficient for non-variadic call lowering.
+#
+# Documented simplifications (each diverges only on the narrow domain noted; none
+# is reached by the signatures mach's own code and tests exercise):
+#
+#   - NGRN/NSRN saturation (psABI C.4 / C.13). When a register-eligible argument is
+#     passed on the stack because its required register run did not fit, the psABI
+#     sets that bank's next-register cursor to 8, forcing every later argument of
+#     the same bank onto the stack too. mach advances each cursor only by the
+#     registers a slot actually consumes (`advance_arg_cursors` in `mir.abi`), so it
+#     does NOT saturate: after such a spill a later, smaller same-bank argument can
+#     still back-fill a register the psABI leaves unused. Diverges only for a
+#     signature that spills a register-eligible argument (an HFA/HVA, or a 9-16 byte
+#     GP aggregate whose run does not fit) AHEAD of a later same-bank argument small
+#     enough to occupy a still-free register; safe for any signature without that
+#     spill-then-backfill tail.
+#
+#   - C.10 even-register-pair alignment. The psABI rounds NGRN up to the next even
+#     number before placing a 16-byte-aligned composite in a GP register pair (so a
+#     pair starts X0:X1 / X2:X3 / ..., never an odd boundary). `classify_arg` places
+#     a 9-16 byte aggregate in the next consecutive GP pair without that rounding
+#     (the `align` argument is ignored on that path). Diverges only for a >8-byte
+#     integer aggregate with 16-byte alignment -- reachable only through an
+#     `#[align(16)]` decorator, since the natural alignment of mach's fundamentals
+#     never exceeds 8 -- classified at an odd NGRN; safe for every naturally-aligned
+#     aggregate.
+#
+#   - Variadic-tail aggregate classification. The AAPCS64 base standard classifies a
+#     variadic aggregate argument exactly like a named one, so the named-argument
+#     classifier below is complete for it. mach also carries no runtime variadic
+#     function type (removed in v2.0.0), leaving the variadic tail vacuous. The
+#     Apple/darwin variadic-args-on-stack divergence is a separate, deferred concern,
+#     unreachable until darwin variadic FFI lands.
 
 use std.types.bool.bool;
 use std.types.bool.false;
@@ -174,7 +206,10 @@ pub fun classify_arg(index: i32, size: u64, align: u64,
                      agg: abi.AggLayout) abi.ParamSlot {
     if (is_aggregate && hfa_members > 0) {
         # the run fits only if every member lands in the remaining V bank; otherwise
-        # the whole aggregate goes to the stack by value (all-or-memory).
+        # the whole aggregate goes to the stack by value (all-or-memory). the psABI
+        # additionally saturates NSRN to 8 on this spill (C.4); mach does not (see the
+        # NGRN/NSRN simplification in the module header), so a later smaller FP
+        # argument may still back-fill a V register the psABI leaves unused.
         if (fp_used + hfa_members::i32 <= FP_PARAM_COUNT) {
             ret abi.make_slot_hfa(fp_param_reg(fp_used), hfa_members, hfa_elem, size);
         }
@@ -198,7 +233,11 @@ pub fun classify_arg(index: i32, size: u64, align: u64,
             ret abi.make_slot(abi.CLASS_STACK, -1, -1, 0, size);
         }
         # 9-16 bytes: a consecutive GP register pair, or spill by value if two GP
-        # registers do not remain.
+        # registers do not remain. the psABI rounds NGRN up to the next even number
+        # first when `align` is 16 (C.10) and saturates NGRN to 8 on the spill (C.13);
+        # mach applies neither (see the C.10 and NGRN/NSRN simplifications in the
+        # module header), so the pair starts at the next register regardless of a
+        # 16-byte alignment, and a later smaller GP argument may back-fill X7.
         if (gp_used + 2 <= GP_PARAM_COUNT) {
             ret abi.make_slot(abi.CLASS_GP, gp_param_reg(gp_used), gp_param_reg(gp_used + 1), 0, size);
         }


### PR DESCRIPTION
Closes #1745.

Cleanup pass from the #1180 foundation audit: convert backend defensive/silent fallbacks to loud errors (or confirm + document them), and confirm the named AAPCS64 minor edge rules against the spec. No live miscompile today; this hardens the design rule that silent fallbacks must become loud errors or be confirmed correct.

## Backend silent fallbacks -> loud errors
- `mir.abi.fp_move_width` now returns `R.Result[u8, str]` and errors on a CLASS_FP scalar whose size is not 4 or 8 (was: silently defaulted to the f64 move width). Both call sites (`emit_arg_slot`, `lower_ret`) propagate.
- `be.codegen.pack_globals` scalar-constant path: the original `gsz <= 8` guard's fall-through is **load-bearing, not a smell** -- a `VAL_CONST_INT 0` of an aggregate (or void) type is the compact zero-initializer the middle end emits for a zero-initialized global, which correctly routes to a zero-filled `.bss` reservation. (A blanket loud error here broke every zero-initialized aggregate global; caught by the test suite.) That path is kept; only a **non-zero** bit pattern at an unrepresentable size -- a genuine value drop, unreachable today since no scalar exceeds 8 bytes -- is now a loud error.

## AAPCS64 edge rules (all three are documented simplifications, not exact implementations)
Documented inline in `src/lang/target/abi/aapcs64.mach` (module header + the two spill branches) and at `mir.abi.advance_arg_cursors`:
- **NGRN/NSRN saturation (psABI C.4/C.13)** -- mach advances a bank cursor only by the registers a slot consumes and never saturates to 8 on a register-eligible spill, so a later smaller same-bank argument can back-fill a register the psABI leaves unused. Diverges only on a spill-then-backfill tail.
- **C.10 even-register-pair alignment** -- the 9-16 byte GP-pair path ignores `align`, so a 16-byte-aligned aggregate is not rounded to an even NGRN. Reachable only via an `#[align(16)]` decorator (natural alignment never exceeds 8).
- **Variadic-tail aggregate classification** -- the base standard classifies variadic aggregates like named ones, and mach has no runtime variadic fn type (removed v2.0.0), so the tail is vacuous. The darwin variadic-on-stack divergence stays deferred.

The NGRN/NSRN and C.10 divergences are real (not just doc gaps); flagged for a possible follow-up issue. Neither is reached by any signature mach's own code or tests exercise.

## Sweep
The codegen/target backend is already heavily hardened (prior audits #1256/#1436/#1673): the `fp_move_width`-style bug-masking default is unique to that function. Its closest sibling `scalar_reg_move_width` is a documented intentional design choice (non-4 sizes legitimately take gpr-width). Other `default`/`fallback` hits are legitimate width-0-pseudo / word-sized defaults or error-*message* degradations (interning-failure), not value fallbacks.

## Verification
- `./m test .` -> 430 passed, 0 failed (includes the `aapcs64.*` classify unit tests).
- self-host fixpoint `a -> b -> c`, `b == c` byte-identical.
