### PR TITLE
docs(lower): document widen_index as the target-derived index-normalization point

### DIFF
--- a/src/lang/me/lower/expr.mach
+++ b/src/lang/me/lower/expr.mach
@@ -2713,6 +2713,13 @@ fun index_type(ctx: *context.LowerContext) R.Result[ir_type.IrTypeId, str] {
 # A narrower index (e.g. a u8 enum/kind) is extended per its signedness; a pointer-width
 # (or wider) index is left as-is. Without this the back end scales the index's full
 # register while its high bits are undefined, producing a wild address.
+#
+# This is the intentional, target-derived index-normalization point: the width is
+# the active target's pointer width (index_type), and the sign/zero extension is
+# chosen here from the semantic signedness. it deliberately stays in the middle-end,
+# not the back end - the IR is signless and OP_GEP carries no per-index signedness,
+# so the back end could not pick sext vs zext; relocating it would regress signed
+# sub-word indices (#1598).
 # ---
 # ctx:    per-module lowering context
 # v:      the index value


### PR DESCRIPTION
Closes #1598.

## Finding
#1598 asked to move GEP index normalization to the target word width into the codegen layer. Investigation shows the substantive goal is already met on dev, and the literal relocation is the wrong design:

- **Width already target-derived.** Commit `2faa31a1` ("derive index/address width from the target pointer width") already changed `index_type` and `widen_index` to use `ctx.tgt.arch.pointer_width * 8` instead of a hardcoded `intern_int(64)`. The middle-end no longer bakes a 64-bit assumption — a 16-bit target would normalize sub-word indices to 16 automatically.
- **Relocation to the backend would regress correctness.** This IR's integer types are signless by design — "signedness is on the consuming instruction, never on the type" (`me/ir/type.mach:52`), and `OP_GEP` carries only `aux_ty`, no per-index signedness (`me/ir/instruction.mach:175`). `widen_index` picks sext vs zext from the *semantic* type's signedness, which exists only in the middle-end. A backend-side zext-only normalization would miscompile signed sub-word indices (e.g. `p[i]` with `i: i8 = -1`). Doing it "properly" in the backend would require expanding the `OP_GEP` schema to carry per-index signedness — larger surface, moves codegen bytes, zero benefit on any current (all 64-bit) target.

## Change
Comment-only. Documents `widen_index` as the intentional, target-derived index-normalization point and records why it deliberately stays in the middle-end rather than the backend, so the "move it to the codegen layer" instinct isn't re-litigated.
