### PR TITLE
fix(link): activate mach-std PIE self-relocation + exec guard (#1727)

### DIFF
--- a/int/surface/pie-reloc/case.conf
+++ b/int/surface/pie-reloc/case.conf
@@ -1,0 +1,10 @@
+# build the program with --pie and RUN it: the sibling elf-pie field guard only
+# inspects e_type host-side, so this is where the relocated-pointer runtime is
+# actually exercised. the binary dereferences relocated global pointers and calls
+# through a relocated function-pointer table, so its golden output appears only when
+# mach-std's _rt_relocate applied the .rela.dyn RELATIVE entries at startup. scoped
+# to the no-libc linux arches that carry the self-relocating runtime (riscv64 cross-
+# builds and runs under qemu); other formats are covered by their own field guards.
+run: exec
+targets: linux linux-arm64 linux-riscv64
+build-flags: --pie

--- a/int/surface/pie-reloc/expect.txt
+++ b/int/surface/pie-reloc/expect.txt
@@ -1,0 +1,2 @@
+data_sum=6006
+fn_sum=503

--- a/int/surface/pie-reloc/mach.toml
+++ b/int/surface/pie-reloc/mach.toml
@@ -1,0 +1,36 @@
+[project]
+id      = "case"
+name    = "case"
+version = "0.0.0"
+src     = "src"
+dep     = "dep"
+target  = "linux"
+out     = "out/{target}/{profile}/bin/{name}{ext}"
+
+[target.linux]
+isa = "x86_64"
+os  = "linux"
+abi = "sysv64"
+
+[target.linux-arm64]
+isa = "aarch64"
+os  = "linux"
+abi = "aapcs64"
+
+[target.linux-riscv64]
+isa = "riscv64"
+os  = "linux"
+abi = "lp64"
+
+[profile.debug]
+opt = 0
+
+[profile.release]
+opt = 2
+
+[bin.case]
+entry = "main.mach"
+
+[deps.mach-std]
+git = "https://github.com/briar-systems/mach-std"
+ref = "branch/main"

--- a/int/surface/pie-reloc/src/main.mach
+++ b/int/surface/pie-reloc/src/main.mach
@@ -1,0 +1,50 @@
+# pie-reloc surface case: the static-PIE self-relocation exec guard.
+#
+# a `mach build --pie` image is an ET_DYN executable the kernel loads at a random,
+# non-zero base with no ld.so to apply its .rela.dyn. every global that stores an
+# absolute address - a data pointer into another global, a function-pointer table -
+# becomes an R_*_RELATIVE entry whose stored value is the link-time (un-based)
+# address. only mach-std's _rt_relocate, run from _rt_init before main, slides each
+# entry by the load bias. without it the dereferences read un-based addresses
+# (un-mapped under ASLR -> crash, or stale) and the call targets are wrong; with it
+# the printed sums are exact. so this program produces the golden output ONLY when
+# self-relocation is active, making it a permanent regression guard for the --pie
+# startup path on the no-libc linux runtime.
+
+use std.runtime;
+use std.types.size.usize;
+use p: std.print;
+
+# distinct globals reached only through relocated pointers.
+var v0: i64 = 1001;
+var v1: i64 = 2002;
+var v2: i64 = 3003;
+
+# a global table of data pointers into the globals above: three RELATIVE entries.
+var data_table: [3]*i64 = [3]*i64{?v0, ?v1, ?v2};
+
+# functions whose addresses populate a function-pointer table: RELATIVE entries to
+# code, exercised by an indirect call through the relocated slot.
+fun f0(x: i64) i64 { ret x + 10; }
+fun f1(x: i64) i64 { ret x * 3; }
+fun f2(x: i64) i64 { ret x - 7; }
+
+def UnaryFn: fun(i64) i64;
+var fn_table: [3]UnaryFn = [3]UnaryFn{f0, f1, f2};
+
+#[symbol("main")]
+fun main(argc: usize, argv: **u8) i64 {
+    # sum the values reached through the relocated data-pointer table.
+    var data_sum: i64 = 0;
+    var i: usize = 0;
+    for (i < 3) { data_sum = data_sum + data_table[i][0]; i = i + 1; }
+    p.printlnf("data_sum={}", data_sum);   # 1001 + 2002 + 3003 = 6006
+
+    # call each function through the relocated function-pointer table.
+    var fn_sum: i64 = 0;
+    i = 0;
+    for (i < 3) { fn_sum = fn_sum + fn_table[i](100); i = i + 1; }
+    p.printlnf("fn_sum={}", fn_sum);        # 110 + 300 + 93 = 503
+
+    ret 0;
+}

--- a/mach.lock
+++ b/mach.lock
@@ -3,4 +3,4 @@
 [deps.mach-std]
 url = "https://github.com/briar-systems/mach-std"
 ref = "branch/main"
-commit = "0262511fd60e21efb6aa95a66200b534940ea2f7"
+commit = "3c7f0d65ca12491bf44ec87d98d75ea0e43e0f74"


### PR DESCRIPTION
Closes #1727

Phase 2 of static-PIE: activate the mach-std runtime self-relocation and add an execution-level regression guard. Phase 1 (#1770) shipped the compiler side (`--pie`, `ET_DYN` + `.rela.dyn` RELATIVE + `PT_DYNAMIC`, `$mach.build.pie`, and a structural ELF field guard).

## Part A — activate self-relocation
- Re-resolve `mach.lock` to mach-std main HEAD `3c7f0d65ca12491bf44ec87d98d75ea0e43e0f74`, which ships `_rt_relocate`: the static-PIE startup that recovers the load bias from auxv and applies the image's own `R_*_RELATIVE` relocations before `main`, gated on `$mach.build.pie` and called from `_rt_init`.
- `mach.toml` `[deps.mach-std] ref = "branch/main"` is unchanged; only the pinned commit moves.

## Part B — exec guard
- New `int/surface/pie-reloc/` exec case: a `--pie` binary that dereferences relocated global data pointers and calls through a relocated function-pointer table, printing sums that are correct only if the RELATIVE relocations were applied at startup. On a kernel-loaded static-PIE (non-zero base, no `ld.so`) the stored pointers hold link-time addresses until `_rt_relocate` slides them, so the program is a genuine discriminator and a permanent self-reloc regression guard.
- Built via the harness's existing per-case `build-flags:` key (added in phase 1 for the field guard); no `--pie` special-casing. Scoped to the no-libc linux arches; riscv64 cross-builds and runs under qemu.

## Verification (linux, from-source current-`dev` compiler seeded by v2.11.0)
- self-host fixpoint a→b→c: `cmp -s b c` byte-identical.
- `mach test .`: 438 passed, 0 failed.
- full int suite green on `linux` and `linux-riscv64` (qemu) including the new guard; the `--pie` binary builds `ET_DYN` on `linux`/`linux-arm64`/`linux-riscv64` and runs to `data_sum=6006` / `fn_sum=503` on all three.
- the `--pie` image is a true static-PIE: no `PT_INTERP`, 14 `R_X86_64_RELATIVE` entries (`RELACOUNT=14`), the last six covering the data-pointer and function-pointer tables.
- RED proof: the identical program built against the pre-self-reloc mach-std (`0262511`) crashes with SIGSEGV (exit 139); against the new lock it exits 0 with the golden output.
