### PR TITLE
feat(diag): framed source-snippet diagnostic renderer

### DIFF
--- a/src/cli/cmd/build.mach
+++ b/src/cli/cmd/build.mach
@@ -599,7 +599,7 @@ fun build_unit(a: *A.Allocator, argc: usize, argv: **u8, emit_obj: bool, test_mo
 
     br.code = compile_and_link(?p, level, emit_obj, test_mode, config.verify_ir, config.verbose, eff_emit_asm, eff_emit_ir, ?root[0], config.output, eff, argv, ?br.output_path, tests_out, list_only);
 
-    cli_diag.flush(?s, ?s.diags, cfg.color_enabled(config.color));
+    cli_diag.flush(?s, ?s.diags);
     driver.dnit_project(?p);
     session.dnit(?s);
     ret br;

--- a/src/cli/cmd/check.mach
+++ b/src/cli/cmd/check.mach
@@ -2,10 +2,11 @@
 #
 # The editor-facing diagnostics slice exposed as a CLI verb: read one source
 # file, feed its text directly into the editor query surface (mach.lang.editor),
-# and render every reported diagnostic as `severity: path:line:col: message`
-# with a caret underline. It needs no mach.toml, no module graph, and no link
-# step; it is best-effort over a single buffer, exactly what an editor wants, and
-# the in-tree consumer that exercises the editor surface end to end.
+# and render every reported diagnostic as a framed source snippet (headline,
+# `--> file:line:col`, gutter, and caret). It needs no mach.toml, no module
+# graph, and no link step; it is best-effort over a single buffer, exactly what
+# an editor wants, and the in-tree consumer that exercises the editor surface
+# end to end.
 #
 # Exit codes: 0 when the buffer has no error-severity diagnostics, 1 when it has
 # any (or on a usage / io error).
@@ -13,7 +14,6 @@
 use std.allocator.arena;
 use std.filesystem;
 use std.print;
-use std.types.bool.false;
 use std.types.size.usize;
 use std.types.string.str;
 
@@ -82,8 +82,8 @@ pub fun run(argc: usize, argv: **u8) i64 {
 
 # open the buffer, collect its diagnostics, render them, and return the exit code
 #
-# The diagnostics are rendered uncolored so an LSP consuming this stream reads
-# plain text, never ANSI escapes. The session backing the source-map spans is
+# The renderer is ASCII-only, so an LSP consuming this stream reads plain text,
+# never color or terminal escapes. The session backing the source-map spans is
 # the one the editor session borrows.
 # ---
 # es:   the editor session the buffer is opened in
@@ -107,7 +107,7 @@ fun check_buffer(es: *editor.EditorSession, path: str, text: str) i64 {
     }
     val list: *diagnostic.DiagList = R.unwrap_ok[*diagnostic.DiagList, str](res_diags);
 
-    cli_diag.flush(es.s, list, false);
+    cli_diag.flush(es.s, list);
     if (diagnostic.has_errors(list)) {
         ret 1;
     }

--- a/src/cli/diagnostic.mach
+++ b/src/cli/diagnostic.mach
@@ -1,109 +1,303 @@
 # the shared CLI diagnostic renderer.
 #
-# one renderer for every command that surfaces compiler diagnostics. each entry
-# prints as `severity: path:line:col: message`, followed by the offending source
-# line and a caret underline marking the span, all resolved against the session
-# source map. `color` gates ANSI styling of the severity label only; the message
-# body and the snippet are never colorized. both `mach build` (whole project)
-# and `mach check` (single buffer) render through `flush`.
+# one framed renderer for every command that surfaces compiler diagnostics. each
+# diagnostic prints as a severity headline (`error:` / `warning:`), a
+# `--> file:line:col` location line, an ASCII line-number gutter, and the
+# offending span underlined with `^`; a span that runs across several source
+# lines marks its continuation lines with `-`. an attached note renders as a
+# `= note:` line. a non-empty run ends with an `N errors / M warnings` summary.
+#
+# spans resolve against the session source map via the diagnostic's file_id and
+# span; the data model is unchanged. output is ASCII only - no Unicode, no color,
+# no terminal escapes - and fixed-width, so it is byte-identical across linux,
+# darwin, and windows. both `mach build` (whole project) and `mach check` (single
+# buffer) render through `flush`.
 
 use std.print;
 use std.system.os;
-use std.types.bool.bool;
 use std.types.size.usize;
 use std.types.string.str;
+use std.types.string.str_len;
 
 use O: std.types.option;
 
 use mach.lang.diagnostic;
-use mach.lang.fe.token;
 use mach.lang.session;
 use mach.lang.source;
 
+# source lines rendered for one multi-line span before the middle is elided
+val MAX_SPAN_LINES: usize = 10;
+
 # render every diagnostic in `list` to stderr against the session source map.
 #
-# When a diagnostic's file resolves, the location prefix and a caret snippet are
-# emitted; otherwise only the message is shown. A trailing `note:` line is
-# printed when present.
+# Each diagnostic is framed individually, separated by a blank line, and a
+# non-empty run closes with a counts summary. A diagnostic whose file does not
+# resolve degrades to its headline (and note) with no source frame.
 # ---
-# s:     session carrying the source map spans resolve against
-# list:  diagnostics to render, in order
-# color: true to wrap each severity label in its ANSI color
-pub fun flush(s: *session.Session, list: *diagnostic.DiagList, color: bool) {
+# s:    session carrying the source map spans resolve against
+# list: diagnostics to render, in order
+pub fun flush(s: *session.Session, list: *diagnostic.DiagList) {
+    var errors:   usize = 0;
+    var warnings: usize = 0;
+
     var i: usize = 0;
     for (i < list.len) {
         val d: *diagnostic.Diagnostic = ?list.items[i];
 
-        if (color) { print.eprint(severity_color(d.severity)); }
-        print.eprint(severity_label(d.severity));
-        if (color) { print.eprint("\x1b[0m"); }
+        if (i > 0) { print.eprint("\n"); }
+        render(s, d);
 
-        val opt_file: O.Option[*source.SourceFile] = source.get(?s.sources, d.file_id);
-        if (O.is_some[*source.SourceFile](opt_file)) {
-            val sf:  *source.SourceFile = O.unwrap[*source.SourceFile](opt_file);
-            val pos: source.Position    = source.position(sf, d.span.offset);
-            print.eprint(sf.path);
-            print.eprint(":");
-            print.eu64(pos.line::u64);
-            print.eprint(":");
-            print.eu64(pos.col::u64);
-            print.eprint(": ");
-            print.eprintln(d.message);
-            emit_snippet(sf, ?d.span, pos.line);
-        }
-        or {
-            print.eprintln(d.message);
-        }
-
-        if (d.note != nil) {
-            print.eprint("  note: ");
-            print.eprintln(d.note);
-        }
+        if (d.severity == diagnostic.SEVERITY_ERROR)        { errors   = errors + 1;   }
+        or (d.severity == diagnostic.SEVERITY_WARNING)      { warnings = warnings + 1; }
 
         i = i + 1;
     }
+
+    if (list.len > 0) {
+        print.eprint("\n");
+        emit_summary(errors, warnings);
+    }
 }
 
-# render the source line containing `span` followed by a caret underline.
+# render one diagnostic: headline, then a source frame when the file resolves.
 #
-# The underline mirrors the line's leading bytes so the caret lands under the
-# span: tabs are kept verbatim and every other byte becomes a single space. The
-# span start is marked with `^` and each remaining byte with `~`; a zero-length
-# span underlines a single column. The caret is clamped to the rendered line so
-# a span reaching past either end still marks a valid column.
+# The span is clamped to the file bounds so a synthesized or out-of-range span
+# degrades to a valid frame rather than crashing. The note, when present, renders
+# under the frame (or directly under the headline when there is no frame).
+# ---
+# s: session carrying the source map
+# d: the diagnostic to render
+fun render(s: *session.Session, d: *diagnostic.Diagnostic) {
+    emit_headline(d.severity, d.message);
+
+    val opt_file: O.Option[*source.SourceFile] = source.get(?s.sources, d.file_id);
+    if (O.is_none[*source.SourceFile](opt_file)) {
+        if (d.note != nil) { emit_note(d.note, 2); }
+        ret;
+    }
+    val sf: *source.SourceFile = O.unwrap[*source.SourceFile](opt_file);
+
+    val text_len: usize = str_len(sf.text);
+
+    var off: usize = d.span.offset;
+    if (off > text_len) { off = text_len; }
+    var end: usize = d.span.offset + d.span.len;
+    if (end > text_len) { end = text_len; }
+    if (end < off)      { end = off;      }
+
+    val start_pos: source.Position = source.position(sf, off);
+    var last: usize = off;
+    if (end > off) { last = end - 1; }
+    val end_pos: source.Position = source.position(sf, last);
+
+    val w: usize = decimal_width(end_pos.line);
+
+    emit_loc(w, sf.path, start_pos.line, start_pos.col);
+    emit_bar(w);
+    emit_snippet(sf, w, start_pos.line, end_pos.line, off, end);
+
+    if (d.note != nil) {
+        emit_bar(w);
+        emit_note(d.note, w + 1);
+    }
+}
+
+# render the source line(s) the span covers, each followed by its underline.
+#
+# A single-line span underlines its range with `^`. A multi-line span marks the
+# first line with `^` and every continuation line with `-`; a span taller than
+# MAX_SPAN_LINES renders only its first and last lines with the middle elided.
+# ---
+# sf:     source file the lines are drawn from
+# w:      gutter width in columns
+# line_s: 1-based first line of the span
+# line_e: 1-based last line of the span
+# off:    clamped span start byte offset
+# end:    clamped span end byte offset (exclusive)
+fun emit_snippet(sf: *source.SourceFile, w: usize, line_s: usize, line_e: usize, off: usize, end: usize) {
+    if (line_e <= line_s) {
+        emit_source_line(sf, w, line_s);
+        emit_underline(sf, w, line_s, off, end, "^");
+        ret;
+    }
+
+    if (line_e - line_s + 1 <= MAX_SPAN_LINES) {
+        var l: usize = line_s;
+        for (l <= line_e) {
+            emit_source_line(sf, w, l);
+            if (l == line_s) { emit_underline(sf, w, l, off, end, "^"); }
+            or               { emit_underline(sf, w, l, off, end, "-"); }
+            l = l + 1;
+        }
+        ret;
+    }
+
+    emit_source_line(sf, w, line_s);
+    emit_underline(sf, w, line_s, off, end, "^");
+    emit_elision(w);
+    emit_source_line(sf, w, line_e);
+    emit_underline(sf, w, line_e, off, end, "-");
+}
+
+# write one numbered source line through the gutter, verbatim.
 # ---
 # sf:   source file the line is drawn from
-# span: byte range to underline
-# line: 1-based line number containing the span
-fun emit_snippet(sf: *source.SourceFile, span: *token.Span, line: usize) {
+# w:    gutter width in columns
+# line: 1-based line number to print
+fun emit_source_line(sf: *source.SourceFile, w: usize, line: usize) {
     val opt_bounds: O.Option[source.LineSpan] = source.line_bounds(sf, line);
     if (O.is_none[source.LineSpan](opt_bounds)) { ret; }
-    val bounds: source.LineSpan = O.unwrap[source.LineSpan](opt_bounds);
+    val b: source.LineSpan = O.unwrap[source.LineSpan](opt_bounds);
 
-    os.write(os.STDERR_FD, ?sf.text[bounds.start], bounds.end - bounds.start);
+    emit_gutter_num(w, line);
+    if (b.end > b.start) {
+        os.write(os.STDERR_FD, ?sf.text[b.start], b.end - b.start);
+    }
     print.eprint("\n");
+}
 
-    var caret_at: usize = span.offset;
-    if (caret_at < bounds.start) { caret_at = bounds.start; }
-    if (caret_at > bounds.end)   { caret_at = bounds.end;   }
+# write the underline for the portion of `line` the span covers.
+#
+# The leading run up to the marked range is reproduced as tabs and spaces so the
+# markers land under the span regardless of tab width. The marker glyph (`^` for
+# the primary line, `-` for a continuation) fills the covered range, with a
+# zero-length range marking a single column.
+# ---
+# sf:    source file the line is drawn from
+# w:     gutter width in columns
+# line:  1-based line number being underlined
+# off:   clamped span start byte offset
+# end:   clamped span end byte offset (exclusive)
+# glyph: the marker glyph, "^" or "-"
+fun emit_underline(sf: *source.SourceFile, w: usize, line: usize, off: usize, end: usize, glyph: str) {
+    val opt_bounds: O.Option[source.LineSpan] = source.line_bounds(sf, line);
+    if (O.is_none[source.LineSpan](opt_bounds)) { ret; }
+    val b: source.LineSpan = O.unwrap[source.LineSpan](opt_bounds);
 
-    var i: usize = bounds.start;
-    for (i < caret_at) {
+    var mark_from: usize = b.start;
+    if (off > b.start && off <= b.end) { mark_from = off; }
+    var mark_to: usize = b.end;
+    if (end >= b.start && end <= b.end) { mark_to = end; }
+    if (mark_to < mark_from) { mark_to = mark_from; }
+
+    emit_gutter_bar(w);
+
+    var i: usize = b.start;
+    for (i < mark_from) {
         if (sf.text[i] == '\t') { print.eprint("\t"); }
         or                      { print.eprint(" ");  }
         i = i + 1;
     }
 
-    print.eprint("^");
-
-    var span_end: usize = span.offset + span.len;
-    if (span_end > bounds.end) { span_end = bounds.end; }
-    i = caret_at + 1;
-    for (i < span_end) {
-        print.eprint("~");
-        i = i + 1;
-    }
+    var n: usize = mark_to - mark_from;
+    if (n == 0) { n = 1; }
+    var j: usize = 0;
+    for (j < n) { print.eprint(glyph); j = j + 1; }
     print.eprint("\n");
+}
+
+# write the `--> file:line:col` location line under the gutter.
+# ---
+# w:    gutter width in columns
+# path: source file path
+# line: 1-based line of the span start
+# col:  1-based column of the span start
+fun emit_loc(w: usize, path: str, line: usize, col: usize) {
+    emit_spaces(w);
+    print.eprint("--> ");
+    print.eprint(path);
+    print.eprint(":");
+    print.eu64(line::u64);
+    print.eprint(":");
+    print.eu64(col::u64);
+    print.eprint("\n");
+}
+
+# write a blank gutter line (`|`) terminated by a newline.
+# ---
+# w: gutter width in columns
+fun emit_bar(w: usize) {
+    emit_spaces(w);
+    print.eprint(" |\n");
+}
+
+# write the `...` elision marker standing in for omitted span lines.
+# ---
+# w: gutter width in columns
+fun emit_elision(w: usize) {
+    emit_spaces(w);
+    print.eprint(" | ...\n");
+}
+
+# write a right-aligned line number followed by the ` | ` gutter separator.
+# ---
+# w:    gutter width in columns
+# line: 1-based line number to print
+fun emit_gutter_num(w: usize, line: usize) {
+    emit_spaces(w - decimal_width(line));
+    print.eu64(line::u64);
+    print.eprint(" | ");
+}
+
+# write a blank (numberless) gutter prefix ending in the ` | ` separator.
+# ---
+# w: gutter width in columns
+fun emit_gutter_bar(w: usize) {
+    emit_spaces(w);
+    print.eprint(" | ");
+}
+
+# write a `= note:` line indented so its `=` aligns with the gutter bar.
+# ---
+# note:   the note text
+# indent: spaces preceding the `=`
+fun emit_note(note: str, indent: usize) {
+    emit_spaces(indent);
+    print.eprint("= note: ");
+    print.eprintln(note);
+}
+
+# write the closing `N errors / M warnings` counts line.
+# ---
+# errors:   number of error-severity diagnostics rendered
+# warnings: number of warning-severity diagnostics rendered
+fun emit_summary(errors: usize, warnings: usize) {
+    print.eu64(errors::u64);
+    if (errors == 1) { print.eprint(" error");  }
+    or               { print.eprint(" errors"); }
+    print.eprint(" / ");
+    print.eu64(warnings::u64);
+    if (warnings == 1) { print.eprint(" warning");  }
+    or                 { print.eprint(" warnings"); }
+    print.eprint("\n");
+}
+
+# write the `severity: message` headline line.
+# ---
+# severity: severity of the diagnostic
+# message:  the diagnostic message
+fun emit_headline(severity: diagnostic.Severity, message: str) {
+    print.eprint(severity_label(severity));
+    print.eprintln(message);
+}
+
+# write `n` spaces to stderr.
+# ---
+# n: number of spaces to emit
+fun emit_spaces(n: usize) {
+    var i: usize = 0;
+    for (i < n) { print.eprint(" "); i = i + 1; }
+}
+
+# the count of decimal digits in `n` (at least 1).
+# ---
+# n:   the value to measure
+# ret: number of decimal digits
+fun decimal_width(n: usize) usize {
+    var w: usize = 1;
+    var v: usize = n;
+    for (v >= 10) { w = w + 1; v = v / 10; }
+    ret w;
 }
 
 # the leading `severity: ` text for a diagnostic severity.
@@ -115,17 +309,4 @@ fun severity_label(severity: diagnostic.Severity) str {
     if (severity == diagnostic.SEVERITY_WARNING) { ret "warning: "; }
     if (severity == diagnostic.SEVERITY_INFO)    { ret "info: ";    }
     ret "help: ";
-}
-
-# the ANSI SGR sequence for a severity label, applied only when color is enabled.
-#
-# Error is bold red, warning bold magenta, info bold cyan, help bold green.
-# ---
-# severity: severity whose color to select
-# ret:      the SGR escape sequence opening the color
-fun severity_color(severity: diagnostic.Severity) str {
-    if (severity == diagnostic.SEVERITY_ERROR)   { ret "\x1b[1;31m"; }
-    if (severity == diagnostic.SEVERITY_WARNING) { ret "\x1b[1;35m"; }
-    if (severity == diagnostic.SEVERITY_INFO)    { ret "\x1b[1;36m"; }
-    ret "\x1b[1;32m";
 }


### PR DESCRIPTION
Closes #1777. Part of the output-overhaul epic #1773.

## What
Replaces the one-line `file:line:col: error: msg` flush (`src/cli/diagnostic.mach`) with a framed source-snippet renderer:

- `error:` / `warning:` headline
- a `--> file:line:col` location line
- an ASCII line-number gutter (`|`)
- the offending span underlined with `^`; a span crossing several source lines marks its continuation lines with `-`
- a `= note:` line drawn from the diagnostic's existing note/suggestion field
- a closing `N errors / M warnings` summary across a run

ASCII only — no Unicode, no color, no terminal escapes, no width ioctl. Fixed-width, so output is byte-identical across linux/darwin/windows. Spans resolve against the session source map via the diagnostic's existing `file_id` + span; the **data model is unchanged**.

## Before / after

Before:
```
error: unresolved identifier `countt`
./src/main.mach:3:9: ret countt;
        ^~~~~~
  note: did you mean `count`?
```

After (error + note):
```
error: unresolved identifier `countt`
 --> ./src/main.mach:3:9
  |
3 |     ret countt;
  |         ^^^^^^
  |
  = note: did you mean `count`?

1 error / 0 warnings
```

Multi-line span (primary `^` + secondary `-`):
```
error: type mismatch: expected i64, found *i64
 --> ./src/main.mach:3:5
  |
3 |     ret id(
  |     ^^^^^^^
4 |         nil
  | -----------
5 |     );
  | ------
  |
  = note: mach has no implicit widening; cast the value with `value::Type`

1 error / 0 warnings
```

Warning in the same frame:
```
warning: documented component matches no parameter, field, generic, or `ret` of this declaration
 --> warn.mach:4:3
  |
4 | # z: misspelled
  |   ^

0 errors / 1 warning
```

Span at EOF (no trailing newline) and a synthesized diagnostic (out-of-range file id) both degrade gracefully — caret at the final column, and a message-only frame respectively.

## Edge cases
EOF, multi-line, very long line (rendered verbatim, no truncation), and no source span (synthesized) all degrade to a sane frame without crashing.

## Verification
- self-host fixpoint a→b→c **byte-identical** (`cmp -s b c`), seeded from the v2.11.0 release
- `mach test .` — **438 passed, 0 failed**
- manually triggered error, warning, multi-line span, EOF span, multi-diagnostic summary, and synthesized no-source cases (samples above)

## Notes for review
- The `color` parameter was removed from `flush` (renderer is ASCII-only); the two call sites (`build.mach`, `check.mach`) are updated. The `--color` CLI flag / `ColorMode` / `config.color_enabled` are now unread — left for a scoped follow-up rather than widening this change.
- `src/cli/cmd/build.mach` is touched only at the one `flush` call site (flagged for #1775 coordination).
- The `= help:` label and a *separate* secondary-context span are not derivable from the current single-`span`/single-`note` model without a data-model field; the secondary `-` is delivered via multi-line continuation and notes render as `= note:`. See the worker report for the open question.
