### PR TITLE
feat(build): -v/-vv readout with timing + summary (drop --verbose)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- build: `-v` prints a per-phase readout (load / resolve / sema / lower /
+  optimize / codegen / link) with item counts and timing, closed by a
+  `built <path>  N modules  <size>  in <time>` summary; `-vv` adds a
+  per-module/file line under each phase with its own duration and a `(slow)`
+  marker on the slowest item. Fixed-width ASCII on stderr, identical across
+  platforms - timing via `chrono.monotonic`, durations via
+  `chrono.format_duration`, columns via the `{:<N}`/`{:N}` format spec (#1775).
+
+### Removed
+
+- build: the `--verbose` flag, replaced by `-v`/`-vv` (#1775).
+
 ## [2.10.0] - 2026-06-29
 
 Native arm64 macOS. mach now compiles, ad-hoc code-signs, and self-hosts

--- a/doc/cli.md
+++ b/doc/cli.md
@@ -31,11 +31,12 @@ matched exactly: `--flag value` (a value follows in the next argument) or a bare
 ## Global flags
 
 Read by `build`, `run`, `test`, and `doc` (they share one config parser).
-`--verbose` and `--quiet` together is a parse error.
+A verbosity flag (`-v`/`-vv`) and `--quiet` together is a parse error.
 
 | Flag             | Value            | Effect |
 |------------------|------------------|--------|
-| `--verbose`, `-v`| —                | write extra detail (per-stage compile progress) to stderr |
+| `-v`             | —                | `mach build`: per-phase roll-up (load/resolve/sema/lower/optimize/codegen/link) with item counts + timing, then a `built … N modules … in …` summary, on stderr |
+| `-vv`            | —                | `-v` plus a per-module/file line under each phase with its duration and a `(slow)` marker on the slowest |
 | `--quiet`, `-q`  | —                | suppress non-error output |
 | `--color <mode>` | `auto`\|`always`\|`never` | color preference for terminal output (default `auto`); an unknown mode is a parse error |
 | `--target <name>`| target name      | select a declared target; absent, defers to `[project].target` |

--- a/src/cli/cmd/build.mach
+++ b/src/cli/cmd/build.mach
@@ -33,6 +33,7 @@ use std.types.string.str_len;
 use A: std.allocator;
 use O: std.types.option;
 use R: std.types.result;
+use ctime: std.chrono.time;
 
 use cfg: mach.cli.config;
 use cli_diag: mach.cli.diagnostic;
@@ -50,6 +51,7 @@ use mach.lang.me.lower;
 use mach.lang.me.lower.context;
 use mach.lang.me.lower.testrunner;
 use mach.lang.me.pipeline;
+use mach.lang.readout;
 use mach.lang.session;
 use mach.lang.source;
 use mach.lang.target;
@@ -126,45 +128,17 @@ rec EmitArtifacts {
     want_ir:  bool;
 }
 
-# resolve an interned StrId against the project interner and write it to stderr;
-# a miss writes "<?>"
-# ---
-# p:  the project (for its session interner)
-# id: the interned string to render
-fun emit_id(p: *driver.Project, id: intern.StrId) {
-    val opt_name: O.Option[str] = intern.lookup(?p.s.interner, id);
-    if (O.is_some[str](opt_name)) {
-        print.eprint(O.unwrap[str](opt_name));
-    }
-    or {
-        print.eprint("<?>");
-    }
-}
-
-# write the resolved target name and module count to stderr
+# resolve an interned module FQN to its readout display string
 #
-# The leading line of verbose output, emitted once after graph discovery.
+# Falls back to "<?>" for an un-interned id so a readout item always has a name.
 # ---
-# p: the project carrying the selected target and module graph
-fun emit_target(p: *driver.Project) {
-    print.eprint("target ");
-    if (p.target_entry != nil) { emit_id(p, p.target_entry.name); }
-    or                         { print.eprint("<none>"); }
-    print.eprint(" (");
-    print.eu64(p.topo_len::u64);
-    print.eprint(" module(s))\n");
-}
-
-# write a `<stage> <fqn>` progress line to stderr for one module
-# ---
-# p:     the project (for its interner)
-# stage: a short stage label (e.g. "sema", "codegen")
-# fqn:   the module's interned fully-qualified name
-fun emit_stage(p: *driver.Project, stage: *u8, fqn: intern.StrId) {
-    print.eprint(stage::str);
-    print.eprint(" ");
-    emit_id(p, fqn);
-    print.eprint("\n");
+# p:   the project (for its session interner)
+# fqn: the module's interned fully-qualified name
+# ret: the FQN string, or "<?>"
+fun fqn_name(p: *driver.Project, fqn: intern.StrId) str {
+    val opt_name: O.Option[str] = intern.lookup(?p.s.interner, fqn);
+    if (O.is_some[str](opt_name)) { ret O.unwrap[str](opt_name); }
+    ret "<?>";
 }
 
 # drive every reachable module through the back half of the pipeline
@@ -180,21 +154,21 @@ fun emit_stage(p: *driver.Project, stage: *u8, fqn: intern.StrId) {
 # level:       optimization pipeline level
 # test_mode:   neutralize the project `main` before codegen (the runner supplies entry)
 # verify_ir:   run the IR verifier after each module's pipeline
-# verbose:     write per-module stage lines to stderr
 # ea:          requested `.ir` / `.s` debug artifacts
 # irs:         caller-owned IR-module array, filled in topo order
 # ir_ready:    per-module flag set true once `irs[mid]` holds a built module
 # images:      caller-owned ObjectImage array, filled in topo order
 # image_ready: per-module flag set true once `images[mid]` holds a built image
 # ret:         ok(true) on success, or err with the first failure message
-fun compile_modules(p: *driver.Project, level: u8, test_mode: bool, verify_ir: bool, verbose: bool, ea: *EmitArtifacts,
+fun compile_modules(p: *driver.Project, level: u8, test_mode: bool, verify_ir: bool, ea: *EmitArtifacts,
                     irs: *ir.Module, ir_ready: *bool,
                     images: *of.ObjectImage, image_ready: *bool) R.Result[bool, str] {
     # type-check the whole module graph through Q_SEMA in topo order - memoized
     # and incremental across rebuilds on a long-lived session, computed fresh
     # each CLI build (fresh session, cold cache). run_sema_pass borrows each
     # module's SemaResult onto its ModuleEntry and publishes its typing /
-    # resolution / comptime ctx to the session for the back-end monomorphizer.
+    # resolution / comptime ctx to the session for the back-end monomorphizer. it
+    # records the readout's `sema` phase internally.
     val res_sema: R.Result[bool, str] = driver.run_sema_pass(p);
     if (R.is_err[bool, str](res_sema)) {
         ret R.err[bool, str](R.unwrap_err[bool, str](res_sema));
@@ -203,16 +177,19 @@ fun compile_modules(p: *driver.Project, level: u8, test_mode: bool, verify_ir: b
     # do not lower or codegen a semantically broken module graph.
     if (diagnostic.has_errors(?p.s.diags)) { ret R.ok[bool, str](true); }
 
-    # lower + optimize every module first. in test mode the project's `main` is
-    # then neutralized (the runner supplies the program entry) before any module
-    # is codegen'd, so the dropped `main` body never reaches an object.
+    # lower every module to IR (rendering the textual `.ir` straight after each
+    # lowering, before optimization), then optimize, then - in test mode -
+    # neutralize the project `main` (the runner supplies the program entry) before
+    # any module is codegen'd. the three passes are timed as distinct readout
+    # phases; splitting lower from optimize is purely structural and leaves the
+    # produced objects byte-identical.
+    readout.phase_begin(p.s.readout, readout.PH_LOWER);
     var i: u32 = 0;
     for (i < p.topo_len) {
         val mid: session.ModuleId   = p.topo[i];
         val m:   *driver.ModuleEntry = ?p.modules[mid::u32];
 
-        if (verbose) { emit_stage(p, "lower", m.fqn); }
-
+        val t_item: ctime.Time = readout.item_begin(p.s.readout);
         val res_lower: R.Result[ir.Module, str] = lower.lower_module(p.s, ?p.target, m.a, m.fqn, mid, m.sema_result, m.resolve_result, ?m.ctx);
         if (R.is_err[ir.Module, str](res_lower)) {
             ret R.err[bool, str](R.unwrap_err[ir.Module, str](res_lower));
@@ -227,14 +204,26 @@ fun compile_modules(p: *driver.Project, level: u8, test_mode: bool, verify_ir: b
                 ret R.err[bool, str](R.unwrap_err[bool, str](res_emit));
             }
         }
+        readout.item(p.s.readout, readout.PH_LOWER, fqn_name(p, m.fqn), t_item);
+        i = i + 1;
+    }
+    readout.phase_end(p.s.readout, readout.PH_LOWER, p.topo_len, "module", "modules");
 
+    readout.phase_begin(p.s.readout, readout.PH_OPTIMIZE);
+    i = 0;
+    for (i < p.topo_len) {
+        val mid: session.ModuleId   = p.topo[i];
+        val m:   *driver.ModuleEntry = ?p.modules[mid::u32];
+
+        val t_item: ctime.Time = readout.item_begin(p.s.readout);
         val res_opt: R.Result[bool, str] = pipeline.run(?irs[mid::u32], ?p.target, level, verify_ir);
         if (R.is_err[bool, str](res_opt)) {
             ret R.err[bool, str](R.unwrap_err[bool, str](res_opt));
         }
-
+        readout.item(p.s.readout, readout.PH_OPTIMIZE, fqn_name(p, m.fqn), t_item);
         i = i + 1;
     }
+    readout.phase_end(p.s.readout, readout.PH_OPTIMIZE, p.topo_len, "module", "modules");
 
     if (test_mode) {
         val res_neutralize: R.Result[bool, str] = testrunner.neutralize_project_main(p.s, irs, p.module_len);
@@ -243,12 +232,13 @@ fun compile_modules(p: *driver.Project, level: u8, test_mode: bool, verify_ir: b
         }
     }
 
+    readout.phase_begin(p.s.readout, readout.PH_CODEGEN);
     i = 0;
     for (i < p.topo_len) {
         val mid: session.ModuleId   = p.topo[i];
         val m:   *driver.ModuleEntry = ?p.modules[mid::u32];
 
-        if (verbose) { emit_stage(p, "codegen", m.fqn); }
+        val t_item: ctime.Time = readout.item_begin(p.s.readout);
 
         # codegen, optionally rendering the resolved MIR to a `.s` artifact.
         var asm_file: filesystem.File;
@@ -275,8 +265,10 @@ fun compile_modules(p: *driver.Project, level: u8, test_mode: bool, verify_ir: b
         images[mid::u32]      = R.unwrap_ok[of.ObjectImage, str](res_codegen);
         image_ready[mid::u32] = true;
 
+        readout.item(p.s.readout, readout.PH_CODEGEN, fqn_name(p, m.fqn), t_item);
         i = i + 1;
     }
+    readout.phase_end(p.s.readout, readout.PH_CODEGEN, p.topo_len, "module", "modules");
     ret R.ok[bool, str](true);
 }
 
@@ -564,10 +556,15 @@ fun build_unit(a: *A.Allocator, argc: usize, argv: **u8, emit_obj: bool, test_mo
     s.opt_explicit = cli_set;
     s.opt_release  = cli_level == pipeline.OPT_RELEASE;
 
-    # thread the CLI `--verbose` intent into the session so the front-end load
-    # walk emits per-module `lex`/`parse`/`resolve` progress lines, matching the
-    # back-end stage lines this command prints from `config.verbose`.
-    s.verbose = config.verbose;
+    # attach the build-progress readout (`-v`/`-vv`) so every phase from the
+    # front-end load walk through the back-end link records into one accumulator.
+    # a plain build (verbosity 0) leaves s.readout nil and stays silent; a test
+    # build's output belongs to the test runner, so the readout is build-only.
+    var ro: readout.Readout;
+    if (!test_mode && config.verbosity > 0) {
+        readout.init(?ro, a, config.verbosity);
+        s.readout = ?ro;
+    }
 
     # thread the CLI `--pie` intent into the session so the linker emits a
     # position-independent (ET_DYN) executable; off leaves the default ET_EXEC output.
@@ -597,12 +594,48 @@ fun build_unit(a: *A.Allocator, argc: usize, argv: **u8, emit_obj: bool, test_mo
     if (config.emit_ir)     { eff_emit_ir = true; }
     if (config.no_emit_ir)  { eff_emit_ir = false; }
 
-    br.code = compile_and_link(?p, level, emit_obj, test_mode, config.verify_ir, config.verbose, eff_emit_asm, eff_emit_ir, ?root[0], config.output, eff, argv, ?br.output_path, tests_out, list_only);
+    br.code = compile_and_link(?p, level, emit_obj, test_mode, config.verify_ir, eff_emit_asm, eff_emit_ir, ?root[0], config.output, eff, argv, ?br.output_path, tests_out, list_only);
+
+    # close the readout with the recap line on a successful, non-test build.
+    if (br.code == 0 && s.readout != nil) {
+        emit_summary(?p, ?ro, emit_obj, br.output_path);
+    }
 
     cli_diag.flush(?s, ?s.diags, cfg.color_enabled(config.color));
     driver.dnit_project(?p);
+    readout.dnit(?ro);
     session.dnit(?s);
     ret br;
+}
+
+# render the readout's closing recap for a finished build
+#
+# Reports the module count and total time, plus the linked binary's size when
+# the build produced one (an executable). A library / object-only build has no
+# single binary, so the size segment is omitted.
+# ---
+# p:        the built project (for its module count and target mode)
+# ro:       the active readout
+# emit_obj: whether the build emitted objects only (no linked binary)
+# out:      the produced artifact path, or nil
+fun emit_summary(p: *driver.Project, ro: *readout.Readout, emit_obj: bool, out: *u8) {
+    var out_str: str = "<output>";
+    if (out != nil) { out_str = out::str; }
+
+    val te: *driver.TargetEntry = p.target_entry;
+    val is_lib: bool = emit_obj || (te != nil && te.mode == driver.MODE_LIBRARY);
+
+    if (!is_lib && out != nil) {
+        val fi_r: R.Result[filesystem.FileInfo, str] = filesystem.info_path(out::str);
+        if (R.is_ok[filesystem.FileInfo, str](fi_r)) {
+            val fi: filesystem.FileInfo = R.unwrap_ok[filesystem.FileInfo, str](fi_r);
+            var unit: str = "B";
+            val mag: i64 = readout.size_split(fi.size, ?unit);
+            readout.summary(ro, out_str, p.module_len, mag, unit, true);
+            ret;
+        }
+    }
+    readout.summary(ro, out_str, p.module_len, 0, "B", false);
 }
 
 # pick the optimization pipeline level for this build
@@ -638,7 +671,6 @@ fun resolve_opt_level(p: *driver.Project, cli_level: u8, cli_set: bool) u8 {
 # emit_obj:     emit a relocatable object instead of an executable
 # test_mode:    neutralize the project `main` before codegen
 # verify_ir:    run the IR verifier after each module's pipeline
-# verbose:      write per-stage progress to stderr
 # emit_asm:     request the per-module `.s` debug artifacts
 # emit_ir:      request the per-module `.ir` debug artifacts
 # root:         the resolved project root directory
@@ -649,7 +681,7 @@ fun resolve_opt_level(p: *driver.Project, cli_level: u8, cli_set: bool) u8 {
 # tests_out:    the list a test build fills, or nil for a normal build
 # list_only:    collect the tests without building executables (`--list`)
 # ret:          the process exit code
-fun compile_and_link(p: *driver.Project, level: u8, emit_obj: bool, test_mode: bool, verify_ir: bool, verbose: bool,
+fun compile_and_link(p: *driver.Project, level: u8, emit_obj: bool, test_mode: bool, verify_ir: bool,
                      emit_asm: bool, emit_ir: bool,
                      root: *u8, out_override: *u8,
                      argc: usize, argv: **u8, out_path: **u8,
@@ -659,8 +691,6 @@ fun compile_and_link(p: *driver.Project, level: u8, emit_obj: bool, test_mode: b
         print.eprint("error: project graph is empty; the entrypoint loaded no modules\n");
         ret 1;
     }
-
-    if (verbose) { emit_target(p); }
 
     # resolve the per-module `.ir` / `.s` output directories once, up front, each
     # from the manifest's resolved `ir`/`asm` template.
@@ -730,7 +760,7 @@ fun compile_and_link(p: *driver.Project, level: u8, emit_obj: bool, test_mode: b
     }
 
     var code: i64 = 0;
-    val res_compile: R.Result[bool, str] = compile_modules(p, level, test_mode, verify_ir, verbose, ?ea, irs, ir_ready, images, image_ready);
+    val res_compile: R.Result[bool, str] = compile_modules(p, level, test_mode, verify_ir, ?ea, irs, ir_ready, images, image_ready);
     if (R.is_err[bool, str](res_compile)) {
         # a `lower:reported` sentinel means lowering already filed a located
         # diagnostic on the sink; the flush prints it, so skip the raw reprint.
@@ -746,10 +776,10 @@ fun compile_and_link(p: *driver.Project, level: u8, emit_obj: bool, test_mode: b
         code = 1;
     }
     or (tests_out != nil) {
-        code = build_test_executables(p, level, verify_ir, verbose, root, argc, argv, images, irs, list_only, tests_out);
+        code = build_test_executables(p, level, verify_ir, root, argc, argv, images, irs, list_only, tests_out);
     }
     or {
-        code = link_artifact(p, emit_obj, verbose, root, out_override, argc, argv, images, out_path);
+        code = link_artifact(p, emit_obj, root, out_override, argc, argv, images, out_path);
     }
 
     free_modules(p, irs, ir_ready, images, image_ready);
@@ -777,7 +807,6 @@ fun compile_and_link(p: *driver.Project, level: u8, emit_obj: bool, test_mode: b
 # p:         the project carrying the module graph and session
 # level:     optimization pipeline level
 # verify_ir: run the IR verifier on each synthesized entry module
-# verbose:   write the test-executable count to stderr
 # root:      the resolved project root directory
 # argc:      argument count including argv[0]
 # argv:      the argument vector (argc null-terminated byte pointers)
@@ -786,7 +815,7 @@ fun compile_and_link(p: *driver.Project, level: u8, emit_obj: bool, test_mode: b
 # list_only: report the collected tests without building (`--list`)
 # tests_out: the list to append each test's artifact to
 # ret:       0 on success, 1 on a user error, 2 on an internal error
-fun build_test_executables(p: *driver.Project, level: u8, verify_ir: bool, verbose: bool,
+fun build_test_executables(p: *driver.Project, level: u8, verify_ir: bool,
                            root: *u8, argc: usize, argv: **u8,
                            images: *of.ObjectImage, irs: *ir.Module,
                            list_only: bool, tests_out: *TestList) i64 {
@@ -857,12 +886,6 @@ fun build_test_executables(p: *driver.Project, level: u8, verify_ir: bool, verbo
         free_sonames(p.s.alloc, sonames, soname_len);
         testrunner.free(p.s, ?col);
         ret ec;
-    }
-
-    if (verbose) {
-        print.eprint("test ");
-        print.eu64(col.count::u64);
-        print.eprint(" executable(s)\n");
     }
 
     # each test's compile/link allocations (the synthesized entry IR, its codegen
@@ -1342,7 +1365,6 @@ fun subst_name(tmpl: str, name: str, out: *u8, cap: usize) usize {
 # ---
 # p:            the project carrying the module graph and session
 # emit_obj:     emit the per-module objects only, linking no executable
-# verbose:      write the object count and output path to stderr
 # root:         the resolved project root directory
 # out_override: the `-o` artifact path, or nil to use the resolved path
 # argc:         argument count including argv[0]
@@ -1350,7 +1372,7 @@ fun subst_name(tmpl: str, name: str, out: *u8, cap: usize) usize {
 # images:       the per-module object images to write
 # out_path:     receives the owned produced-artifact path on success
 # ret:          0 on success, 1 on a user error, 2 on an internal error
-fun link_artifact(p: *driver.Project, emit_obj: bool, verbose: bool, root: *u8,
+fun link_artifact(p: *driver.Project, emit_obj: bool, root: *u8,
                   out_override: *u8,
                   argc: usize, argv: **u8,
                   images: *of.ObjectImage, out_path: **u8) i64 {
@@ -1360,10 +1382,13 @@ fun link_artifact(p: *driver.Project, emit_obj: bool, verbose: bool, root: *u8,
     # a flat-image object format (`produces_image`) has no relocatable `.o`
     # container: it cannot emit per-module objects or re-parse them at link time.
     # link the in-memory codegen images straight into the flat executable instead
-    # of round-tripping through `.o` files.
+    # of round-tripping through `.o` files. it records its own link phase.
     if (p.target.of != nil && p.target.of.produces_image) {
-        ret link_image_artifact(p, emit_obj, verbose, root, out_override, images, out_path);
+        ret link_image_artifact(p, emit_obj, root, out_override, images, out_path);
     }
+
+    readout.phase_begin(p.s.readout, readout.PH_LINK);
+    val t_link: ctime.Time = readout.item_begin(p.s.readout);
 
     # the per-module object tree root: `<root>/<resolved obj template>`.
     var obj_base: [4096]u8;
@@ -1380,13 +1405,9 @@ fun link_artifact(p: *driver.Project, emit_obj: bool, verbose: bool, root: *u8,
     # library mode (or `--emit obj`): the per-module objects are the deliverable;
     # do not link an executable.
     if (te.mode == driver.MODE_LIBRARY || emit_obj) {
-        if (verbose) {
-            print.eprint("output ");
-            print.eprint((?obj_base[0])::str);
-            print.eprint("\n");
-        }
         free_paths(p.s.alloc, paths, len, len);
         @out_path = dup_cstr(p.s.alloc, ?obj_base[0]);
+        readout.phase_end(p.s.readout, readout.PH_LINK, len, "object", "objects");
         ret 0;
     }
 
@@ -1403,18 +1424,6 @@ fun link_artifact(p: *driver.Project, emit_obj: bool, verbose: bool, root: *u8,
         free_paths(p.s.alloc, paths, len, len);
         free_sonames(p.s.alloc, sonames, soname_len);
         ret ext_code;
-    }
-
-    if (verbose) {
-        print.eprint("link ");
-        print.eu64(len::u64);
-        print.eprint(" object(s)");
-        if (soname_len > 0) {
-            print.eprint(", ");
-            print.eu64(soname_len::u64);
-            print.eprint(" shared lib(s)");
-        }
-        print.eprint("\n");
     }
 
     # the executable path: an absolute `-o` is used verbatim; a relative one is
@@ -1451,13 +1460,9 @@ fun link_artifact(p: *driver.Project, emit_obj: bool, verbose: bool, root: *u8,
         ret 1;
     }
 
-    if (verbose) {
-        print.eprint("output ");
-        print.eprint((?artifact[0])::str);
-        print.eprint("\n");
-    }
-
     @out_path = dup_cstr(p.s.alloc, ?artifact[0]);
+    readout.item(p.s.readout, readout.PH_LINK, (?artifact[0])::str, t_link);
+    readout.phase_end(p.s.readout, readout.PH_LINK, 1, "binary", "binaries");
     ret 0;
 }
 
@@ -1476,13 +1481,12 @@ fun link_artifact(p: *driver.Project, emit_obj: bool, verbose: bool, root: *u8,
 # ---
 # p:            the project carrying the module graph and session
 # emit_obj:     reject when set - a flat-image format has no relocatable object output
-# verbose:      write the image count and output path to stderr
 # root:         the resolved project root directory
 # out_override: the `-o` artifact path, or nil to use the resolved path
 # images:       the per-module codegen images, indexed by module id
 # out_path:     receives the owned produced-artifact path on success
 # ret:          0 on success, 1 on a user error, 2 on an internal error
-fun link_image_artifact(p: *driver.Project, emit_obj: bool, verbose: bool, root: *u8,
+fun link_image_artifact(p: *driver.Project, emit_obj: bool, root: *u8,
                         out_override: *u8, images: *of.ObjectImage, out_path: **u8) i64 {
     val te: *driver.TargetEntry = p.target_entry;
     if (te == nil) { print.eprint("error: no target selected\n"); ret 2; }
@@ -1492,6 +1496,9 @@ fun link_image_artifact(p: *driver.Project, emit_obj: bool, verbose: bool, root:
         print.eprint("error: a flat-image object format produces only executables; library and '--emit obj' outputs are unsupported\n");
         ret 1;
     }
+
+    readout.phase_begin(p.s.readout, readout.PH_LINK);
+    val t_link: ctime.Time = readout.item_begin(p.s.readout);
 
     # the executable path: an absolute `-o` is used verbatim; a relative one is
     # rooted at <root>; otherwise the unit's resolved artifact path is used.
@@ -1525,12 +1532,6 @@ fun link_image_artifact(p: *driver.Project, emit_obj: bool, verbose: bool, root:
         i = i + 1;
     }
 
-    if (verbose) {
-        print.eprint("link ");
-        print.eu64(len::u64);
-        print.eprint(" image(s)\n");
-    }
-
     val res_link: R.Result[bool, str] =
         linker.link_images(p.s, ?p.target, ordered, len, nil::*intern.StrId, 0, ?artifact[0], artifact_product_name(p), linker.LINK_EXE);
     A.deallocate[of.ObjectImage](p.s.alloc, ordered, len::usize);
@@ -1541,13 +1542,9 @@ fun link_image_artifact(p: *driver.Project, emit_obj: bool, verbose: bool, root:
         ret 1;
     }
 
-    if (verbose) {
-        print.eprint("output ");
-        print.eprint((?artifact[0])::str);
-        print.eprint("\n");
-    }
-
     @out_path = dup_cstr(p.s.alloc, ?artifact[0]);
+    readout.item(p.s.readout, readout.PH_LINK, (?artifact[0])::str, t_link);
+    readout.phase_end(p.s.readout, readout.PH_LINK, 1, "binary", "binaries");
     ret 0;
 }
 

--- a/src/cli/cmd/help.mach
+++ b/src/cli/cmd/help.mach
@@ -52,8 +52,9 @@ pub fun run(argc: usize, argv: **u8) i64 {
 # that honours them.
 fun global_flags() {
     print.print("global flags:\n");
-    print.print("  --verbose, -v     surface extra detail (per-stage progress) on stderr\n");
-    print.print("  --quiet, -q       suppress non-error output (mutually exclusive with -v)\n");
+    print.print("  -v                phase roll-up with timing + a build summary on stderr\n");
+    print.print("  -vv               -v plus per-module/file detail under each phase\n");
+    print.print("  --quiet, -q       suppress non-error output (mutually exclusive with -v/-vv)\n");
     print.print("  --color <mode>    auto | always | never (default auto)\n");
     print.print("  --target <name>   select a [targets.<name>] entry\n");
     print.print("  -o <path>         override the linked-binary path (build/run/test)\n");

--- a/src/cli/config.mach
+++ b/src/cli/config.mach
@@ -5,8 +5,8 @@
 # selection - so each command's `run` does not reimplement the same flag
 # handling. `parse` reads these flags out of the raw argv via the `util`
 # helpers and leaves every per-subcommand flag in place for the subcommand to
-# consume itself. `verbose` and `quiet` are mutually exclusive: passing both is
-# a parse error that yields an error message.
+# consume itself. verbosity (`-v`/`-vv`) and `quiet` are mutually exclusive:
+# passing both is a parse error that yields an error message.
 
 use std.types.bool.bool;
 use std.types.size.usize;
@@ -28,7 +28,7 @@ pub val COLOR_NEVER:  ColorMode = 2;  # force-disable color
 # cross-cutting CLI settings shared by every subcommand
 # ---
 # color:       resolved color preference
-# verbose:     --verbose / -v was passed; surface extra detail
+# verbosity:   readout detail level: 0 plain, 1 (`-v`), 2 (`-vv`)
 # quiet:       --quiet / -q was passed; suppress non-error output
 # verify_ir:   --verify-ir was passed; run the IR verifier after each optimization pass
 # target:      selected target name (nil when --target was not given)
@@ -58,7 +58,7 @@ pub val COLOR_NEVER:  ColorMode = 2;  # force-disable color
 #              ASLR instead of the default fixed-address one. opt-in, off by default
 pub rec Config {
     color:       ColorMode;
-    verbose:     bool;
+    verbosity:   u8;
     quiet:       bool;
     verify_ir:   bool;
     target:      *u8;
@@ -93,8 +93,8 @@ pub fun color_enabled(mode: ColorMode) bool {
 #
 # Per-subcommand flags are left in argv for the subcommand to consume itself.
 # Returns a specific error message on a parse error so the caller can tell the
-# user which flag was wrong: an unknown `--color` mode, or both `--verbose` and
-# `--quiet` together.
+# user which flag was wrong: an unknown `--color` mode, or a verbosity flag
+# (`-v`/`-vv`) combined with `--quiet`.
 # ---
 # argc: argument count including argv[0]
 # argv: the argument vector (argc null-terminated byte pointers)
@@ -102,13 +102,16 @@ pub fun color_enabled(mode: ColorMode) bool {
 pub fun parse(argc: usize, argv: **u8) R.Result[Config, str] {
     var c: Config;
 
-    val verbose: bool = util.has_flag(argc, argv, "--verbose") || util.has_flag(argc, argv, "-v");
-    val quiet:   bool = util.has_flag(argc, argv, "--quiet")   || util.has_flag(argc, argv, "-q");
-    if (verbose && quiet) {
-        ret R.err[Config, str]("`--verbose`/`-v` and `--quiet`/`-q` cannot be combined");
+    # `-vv` is two levels of detail, `-v` one; the highest present wins.
+    var verbosity: u8 = 0;
+    if (util.has_flag(argc, argv, "-v"))  { verbosity = 1; }
+    if (util.has_flag(argc, argv, "-vv")) { verbosity = 2; }
+    val quiet: bool = util.has_flag(argc, argv, "--quiet") || util.has_flag(argc, argv, "-q");
+    if (verbosity > 0 && quiet) {
+        ret R.err[Config, str]("`-v`/`-vv` and `--quiet`/`-q` cannot be combined");
     }
 
-    c.verbose     = verbose;
+    c.verbosity   = verbosity;
     c.quiet       = quiet;
     c.verify_ir   = util.has_flag(argc, argv, "--verify-ir");
     c.emit_asm    = util.has_flag(argc, argv, "--emit-asm");

--- a/src/lang/driver.mach
+++ b/src/lang/driver.mach
@@ -15,7 +15,6 @@ use std.collections.map;
 use std.data.toml;
 use std.filesystem;
 use std.memory;
-use std.print;
 use std.text.string.str_dup;
 use std.text.string.str_free;
 use std.types.bool.bool;
@@ -35,6 +34,7 @@ use std.types.string.view_eq_str;
 use A: std.allocator;
 use O: std.types.option;
 use R: std.types.result;
+use ctime: std.chrono.time;
 
 use be_linker: mach.lang.be.linker;
 use mach.lang.diagnostic;
@@ -52,6 +52,7 @@ use mach.lang.fe.token;
 use mach.lang.intern;
 use mach.lang.manifest;
 use mach.lang.query;
+use mach.lang.readout;
 use mach.lang.session;
 use src: mach.lang.source;
 use mach.lang.target;
@@ -566,6 +567,7 @@ fun build_project_impl(s: *session.Session, project_root: str, sel: *manifest.Se
     }
     val entry_fqn: intern.StrId = R.unwrap_ok[intern.StrId, str](entry_path_r);
 
+    readout.phase_begin(p.s.readout, readout.PH_LOAD);
     val load_r: R.Result[session.ModuleId, str] = dfs_load(?p, entry_fqn);
     if (R.is_err[session.ModuleId, str](load_r)) {
         dnit_project(?p);
@@ -585,6 +587,7 @@ fun build_project_impl(s: *session.Session, project_root: str, sel: *manifest.Se
         }
         ei = ei + 1;
     }
+    readout.phase_end(p.s.readout, readout.PH_LOAD, p.topo_len, "module", "modules");
 
     # the module table is stable past the load pass; publish every module's
     # AST to the session registry so later phases can reach cross-module
@@ -2026,10 +2029,14 @@ fun dfs_load(p: *Project, fqn: intern.StrId) R.Result[session.ModuleId, str] {
     if (R.is_err[bool, str](cap_r)) { ret R.err[session.ModuleId, str](R.unwrap_err[bool, str](cap_r)); }
     p.load_status[mid::u32] = LOAD_LOADING;
 
+    # the load phase times each module's read + lex + parse as one item; the
+    # walk that follows recurses into dependencies, so it is timed separately.
+    val t_load: ctime.Time = readout.item_begin(p.s.readout);
     val parse_r: R.Result[bool, str] = parse_module(p, mid, fqn);
     if (R.is_err[bool, str](parse_r)) {
         ret R.err[session.ModuleId, str](R.unwrap_err[bool, str](parse_r));
     }
+    readout.item(p.s.readout, readout.PH_LOAD, fqn_name(p, fqn), t_load);
 
     val walk_r: R.Result[bool, str] = walk_module_for_load(p, mid);
     if (R.is_err[bool, str](walk_r)) {
@@ -2250,22 +2257,17 @@ fun parse_define_int(s: str, start: usize, len: usize, out: *i64) bool {
     ret true;
 }
 
-# write a `<stage> <fqn>` front-end progress line to stderr for one
-# module, matching the back-end's `--verbose` stage lines (cmd.build.emit_stage).
-# a no-op unless the session's `verbose` flag is set; an un-interned fqn renders
-# as "<?>".
+# resolve an interned module FQN to its display string for the readout
+#
+# Falls back to "<?>" for an un-interned id so a readout item always has a name.
 # ---
-# p:     the project (for its session interner and verbose flag)
-# stage: a short stage label (e.g. "lex", "parse", "resolve")
-# fqn:   the module's interned fully-qualified name
-fun emit_stage(p: *Project, stage: str, fqn: intern.StrId) {
-    if (!p.s.verbose) { ret; }
-    print.eprint(stage);
-    print.eprint(" ");
+# p:   the project (for its session interner)
+# fqn: the module's interned fully-qualified name
+# ret: the FQN string, or "<?>"
+fun fqn_name(p: *Project, fqn: intern.StrId) str {
     val o: O.Option[str] = intern.lookup(?p.s.interner, fqn);
-    if (O.is_some[str](o)) { print.eprint(O.unwrap[str](o)); }
-    or                   { print.eprint("<?>"); }
-    print.eprint("\n");
+    if (O.is_some[str](o)) { ret O.unwrap[str](o); }
+    ret "<?>";
 }
 
 # resolve `fqn` to a file, load its source into the session, and route the parse
@@ -2356,7 +2358,6 @@ fun q_parse_compute(db: *query.QueryDb, key: u64, alloc: *A.Allocator) R.Result[
     if (O.is_none[*src.SourceFile](file_opt)) { ret R.err[query.QueryOutput, str]("Q_PARSE: FileId not registered with the session"); }
     val file: *src.SourceFile = O.unwrap[*src.SourceFile](file_opt);
 
-    if (s.verbose) { q_parse_emit_stage(s, "lex", file.path); }
     val tok_r: R.Result[lexer.TokenStream, str] = lexer.tokenize(file.text, alloc, file_id);
     if (R.is_err[lexer.TokenStream, str](tok_r)) { ret R.err[query.QueryOutput, str](R.unwrap_err[lexer.TokenStream, str](tok_r)); }
     var stream: lexer.TokenStream = R.unwrap_ok[lexer.TokenStream, str](tok_r);
@@ -2376,7 +2377,6 @@ fun q_parse_compute(db: *query.QueryDb, key: u64, alloc: *A.Allocator) R.Result[
         lexer.dnit(?stream, alloc);
         ret R.err[query.QueryOutput, str](R.unwrap_err[bool, str](le_r));
     }
-    if (s.verbose) { q_parse_emit_stage(s, "parse", file.path); }
     val fatal: bool = parser.parse(?stream, a, ?s.diags);
     lexer.dnit(?stream, alloc);
     # a fatal allocation failure leaves the AST incomplete; refuse to publish it
@@ -2427,15 +2427,6 @@ fun ast_handle_decode(e: *query.QueryEntry) *ast.Ast {
     if (e.value == nil || e.value_len::usize < $size_of(ptr)) { ret nil; }
     val slot: *ptr = e.value::ptr::*ptr;
     ret slot[0]::*ast.Ast;
-}
-
-# the verbose front-end progress line for a Q_PARSE compute,
-# labeled by source path (the compute's identifier; the FQN is the driver's).
-fun q_parse_emit_stage(s: *session.Session, stage: str, path: str) {
-    print.eprint(stage);
-    print.eprint(" ");
-    print.eprint(path);
-    print.eprint("\n");
 }
 
 # the Q_EXPORTS derived compute - a deterministic byte
@@ -3183,6 +3174,7 @@ fun register_module_asts(p: *Project) R.Result[bool, str] {
 fun run_resolve_pass(p: *Project) R.Result[bool, str] {
     session.set_active_project(p.s, p::ptr);
 
+    readout.phase_begin(p.s.readout, readout.PH_RESOLVE);
     var i: u32 = 0;
     for (i < p.topo_len) {
         val mid: session.ModuleId = p.topo[i];
@@ -3193,6 +3185,7 @@ fun run_resolve_pass(p: *Project) R.Result[bool, str] {
         }
         i = i + 1;
     }
+    readout.phase_end(p.s.readout, readout.PH_RESOLVE, p.topo_len, "module", "modules");
     session.set_active_project(p.s, nil);
     ret R.ok[bool, str](true);
 }
@@ -3204,7 +3197,7 @@ fun run_resolve_pass(p: *Project) R.Result[bool, str] {
 fun run_resolve_one(p: *Project, mid: session.ModuleId) R.Result[bool, str] {
     val m: *ModuleEntry = ?p.modules[mid::u32];
 
-    emit_stage(p, "resolve", m.fqn);
+    val t_item: ctime.Time = readout.item_begin(p.s.readout);
 
     val e_r: R.Result[*query.QueryEntry, str] = query.get(?p.s.queries, query.Q_RESOLVE, m.stable_id::u64);
     if (R.is_err[*query.QueryEntry, str](e_r)) { ret R.err[bool, str](R.unwrap_err[*query.QueryEntry, str](e_r)); }
@@ -3229,6 +3222,7 @@ fun run_resolve_one(p: *Project, mid: session.ModuleId) R.Result[bool, str] {
 
     m.resolve_result = rr;
     m.resolved       = true;
+    readout.item(p.s.readout, readout.PH_RESOLVE, fqn_name(p, m.fqn), t_item);
     ret R.ok[bool, str](true);
 }
 
@@ -3390,6 +3384,7 @@ pub fun run_sema_pass(p: *Project) R.Result[bool, str] {
     # from the pre-epoch build-once behaviour.
     type.field_epoch_bump(?p.s.types);
 
+    readout.phase_begin(p.s.readout, readout.PH_SEMA);
     var i: u32 = 0;
     for (i < p.topo_len) {
         val mid: session.ModuleId = p.topo[i];
@@ -3400,6 +3395,7 @@ pub fun run_sema_pass(p: *Project) R.Result[bool, str] {
         }
         i = i + 1;
     }
+    readout.phase_end(p.s.readout, readout.PH_SEMA, p.topo_len, "module", "modules");
     session.set_active_project(p.s, nil);
     ret R.ok[bool, str](true);
 }
@@ -3413,7 +3409,7 @@ pub fun run_sema_pass(p: *Project) R.Result[bool, str] {
 fun run_sema_one(p: *Project, mid: session.ModuleId) R.Result[bool, str] {
     val m: *ModuleEntry = ?p.modules[mid::u32];
 
-    emit_stage(p, "sema", m.fqn);
+    val t_item: ctime.Time = readout.item_begin(p.s.readout);
 
     val e_r: R.Result[*query.QueryEntry, str] = query.get(?p.s.queries, query.Q_SEMA, m.stable_id::u64);
     if (R.is_err[*query.QueryEntry, str](e_r)) { ret R.err[bool, str](R.unwrap_err[*query.QueryEntry, str](e_r)); }
@@ -3440,6 +3436,7 @@ fun run_sema_one(p: *Project, mid: session.ModuleId) R.Result[bool, str] {
     if (R.is_err[bool, str](rr2)) { ret R.err[bool, str](R.unwrap_err[bool, str](rr2)); }
     val rc: R.Result[bool, str] = session.register_module_comptime(p.s, mid, (?m.ctx)::ptr);
     if (R.is_err[bool, str](rc)) { ret R.err[bool, str](R.unwrap_err[bool, str](rc)); }
+    readout.item(p.s.readout, readout.PH_SEMA, fqn_name(p, m.fqn), t_item);
     ret R.ok[bool, str](true);
 }
 

--- a/src/lang/readout.mach
+++ b/src/lang/readout.mach
@@ -1,0 +1,326 @@
+# build-progress readout - the timed phase roll-up behind `mach build -v`/`-vv`.
+#
+# A single Readout, attached to the Session for the span of one build, collects
+# the seven compile phases (load, resolve, sema, lower, optimize, codegen, link)
+# as the front-end (driver) and back-end (cmd.build) walk the module graph. Each
+# phase is bracketed by `phase_begin`/`phase_end`; each module or file inside a
+# phase is timed with `item_begin`/`item`. At `-v` only the per-phase roll-up
+# line prints; at `-vv` every item prints under its phase with a `(slow)` marker
+# on the slowest. `summary` closes a successful build with one recap line. All
+# output is fixed-width ASCII on stderr, multiplatform: timing comes from
+# `chrono.monotonic` and durations render through `chrono.format_duration`, with
+# columns aligned by the `{:<N}`/`{:N}` format spec. A nil Readout (level 0, the
+# default) makes every call a no-op, so a plain build stays silent.
+
+use std.print;
+use std.types.bool.bool;
+use std.types.bool.false;
+use std.types.bool.true;
+use std.types.size.usize;
+use std.types.string.str;
+
+use A: std.allocator;
+use R: std.types.result;
+use ctime: std.chrono.time;
+use cdur:  std.chrono.duration;
+
+# phase identifiers, indexing the Readout's fixed phase table in emit order
+pub val PH_LOAD:     u8 = 0;  # read + lex + parse each module's source
+pub val PH_RESOLVE:  u8 = 1;  # name resolution per module
+pub val PH_SEMA:     u8 = 2;  # type checking per module
+pub val PH_LOWER:    u8 = 3;  # AST -> SSA IR per module
+pub val PH_OPTIMIZE: u8 = 4;  # the optimization pipeline per module
+pub val PH_CODEGEN:  u8 = 5;  # IR -> machine code per module
+pub val PH_LINK:     u8 = 6;  # link / emit the final artifact
+
+# number of phases (the fixed phase-table length)
+val PHASE_COUNT: u32 = 7;
+
+# verbosity levels
+pub val LEVEL_PHASES: u8 = 1;  # -v:  per-phase roll-up + summary
+pub val LEVEL_ITEMS:  u8 = 2;  # -vv: per-item detail under each phase
+
+# capacity (incl. terminator) of a rendered duration; 24 holds any i64 duration
+val DUR_CAP: usize = 24;
+
+# one timed item within a phase - a module or file and how long it took
+# ---
+# name: the item's display name (an interned FQN or file path, borrowed)
+# d:    the item's elapsed time
+rec Item {
+    name: str;
+    d:    cdur.Duration;
+}
+
+# a single phase's accumulator
+# ---
+# items:   the per-item array, grown on demand (only populated at -vv)
+# len:     number of populated items
+# cap:     allocated length of `items`
+# started: the phase's start instant, set by `phase_begin`
+rec Phase {
+    items:   *Item;
+    len:     u32;
+    cap:     u32;
+    started: ctime.Time;
+}
+
+# the build-wide readout state
+# ---
+# level:  verbosity (LEVEL_PHASES or LEVEL_ITEMS); never 0 for a live Readout
+# alloc:  allocator backing the per-phase item arrays
+# start:  the build's start instant, for the summary's total duration
+# phases: the per-phase accumulators, indexed by the PH_* ids
+pub rec Readout {
+    level:  u8;
+    alloc:  *A.Allocator;
+    start:  ctime.Time;
+    phases: [PHASE_COUNT]Phase;
+}
+
+# initialize a Readout for a build at verbosity `level`
+#
+# `level` is 1 (-v) or 2 (-vv); a plain build never constructs a Readout (the
+# Session simply holds a nil pointer). The build start instant is captured here.
+# ---
+# ro:    the Readout to initialize
+# alloc: allocator backing the per-phase item arrays
+# level: verbosity (LEVEL_PHASES or LEVEL_ITEMS)
+pub fun init(ro: *Readout, alloc: *A.Allocator, level: u8) {
+    ro.level = level;
+    ro.alloc = alloc;
+    ro.start = ctime.monotonic();
+    var i: u32 = 0;
+    for (i < PHASE_COUNT) {
+        val p: *Phase = ?ro.phases[i];
+        p.items = nil;
+        p.len   = 0;
+        p.cap   = 0;
+        i = i + 1;
+    }
+}
+
+# release any per-phase item arrays still held
+#
+# `phase_end` frees each phase's array as it renders, so this only reclaims
+# phases that were begun but never ended (an aborted build).
+# ---
+# ro: the Readout to tear down
+pub fun dnit(ro: *Readout) {
+    if (ro == nil) { ret; }
+    var i: u32 = 0;
+    for (i < PHASE_COUNT) {
+        free_items(ro, ?ro.phases[i]);
+        i = i + 1;
+    }
+}
+
+# mark the start of phase `ph`
+# ---
+# ro: the Readout, or nil to no-op
+# ph: the phase id (a PH_* constant)
+pub fun phase_begin(ro: *Readout, ph: u8) {
+    if (ro == nil) { ret; }
+    val p: *Phase = ?ro.phases[ph];
+    p.len     = 0;
+    p.started = ctime.monotonic();
+}
+
+# capture an item's start instant
+#
+# Returns the monotonic clock only at -vv, where per-item durations are shown;
+# at -v (or with a nil Readout) it returns the zero instant and `item` ignores
+# it, so item-level timing adds no overhead to a -v build.
+# ---
+# ro:  the Readout, or nil
+# ret: the item's start instant, or the zero instant when item timing is off
+pub fun item_begin(ro: *Readout) ctime.Time {
+    if (ro == nil || ro.level < LEVEL_ITEMS) { ret ctime.Time{sec: 0, nsec: 0}; }
+    ret ctime.monotonic();
+}
+
+# record one completed item in phase `ph`
+#
+# Only retained at -vv (the per-item display); a no-op otherwise. `name` is
+# borrowed and must stay valid until `phase_end` renders the phase (interned
+# FQNs and source paths both outlive the build).
+# ---
+# ro:    the Readout, or nil
+# ph:    the phase id (a PH_* constant)
+# name:  the item's display name (borrowed)
+# start: the instant returned by the matching `item_begin`
+pub fun item(ro: *Readout, ph: u8, name: str, start: ctime.Time) {
+    if (ro == nil || ro.level < LEVEL_ITEMS) { ret; }
+    val d: cdur.Duration = ctime.time_sub(ctime.monotonic(), start);
+    val p: *Phase = ?ro.phases[ph];
+    if (!ensure_item_cap(ro, p)) { ret; }
+    p.items[p.len].name = name;
+    p.items[p.len].d    = d;
+    p.len = p.len + 1;
+}
+
+# close phase `ph` and render it
+#
+# Prints the roll-up line `<phase>  <count> <noun>  <dur>` (`noun_one` when
+# `count` is 1, else `noun_many`), and at -vv every recorded item beneath it
+# with the slowest flagged `(slow)`. The phase's wall-clock duration is the
+# span since `phase_begin`. Frees the phase's item array.
+# ---
+# ro:       the Readout, or nil to no-op
+# ph:       the phase id (a PH_* constant)
+# count:    the item count for the roll-up (e.g. the module count)
+# noun_one: the singular unit noun (e.g. "module")
+# noun_many:the plural unit noun (e.g. "modules")
+pub fun phase_end(ro: *Readout, ph: u8, count: u32, noun_one: str, noun_many: str) {
+    if (ro == nil) { ret; }
+    val p: *Phase = ?ro.phases[ph];
+    val elapsed: cdur.Duration = ctime.time_sub(ctime.monotonic(), p.started);
+
+    var dbuf: [DUR_CAP]u8;
+    val dstr: str = cdur.format_duration(elapsed, ?dbuf[0], DUR_CAP);
+    var noun: str = noun_many;
+    if (count == 1) { noun = noun_one; }
+    print.eprintf("{:<9} {:3} {:<8} {:7}\n", phase_label(ph), count::i64, noun, dstr);
+
+    if (ro.level >= LEVEL_ITEMS) { render_items(p); }
+    free_items(ro, p);
+}
+
+# render a successful build's closing recap line
+#
+# `built <out>  <N> modules  [<size> <unit>  ]in <total>` - the size segment is
+# omitted when `has_size` is false (a library / object-only build has no single
+# binary). The total duration spans from `init`.
+# ---
+# ro:        the Readout, or nil to no-op
+# out:       the produced artifact's path (borrowed)
+# modules:   the module count
+# size:      the artifact size magnitude in `unit`
+# unit:      the size unit ("B"/"KB"/"MB")
+# has_size:  whether to print the size segment
+pub fun summary(ro: *Readout, out: str, modules: u32, size: i64, unit: str, has_size: bool) {
+    if (ro == nil) { ret; }
+    val total: cdur.Duration = ctime.time_sub(ctime.monotonic(), ro.start);
+    var dbuf: [DUR_CAP]u8;
+    val dstr: str = cdur.format_duration(total, ?dbuf[0], DUR_CAP);
+    if (has_size) {
+        print.eprintf("built {}  {} modules  {} {}  in {}\n", out, modules::i64, size, unit, dstr);
+    }
+    or {
+        print.eprintf("built {}  {} modules  in {}\n", out, modules::i64, dstr);
+    }
+}
+
+# split a byte count into a magnitude + unit for the summary
+#
+# Integer-only ASCII: bytes under 1 KiB stay bytes, under 1 MiB round to KB,
+# else round to MB. Used only by the build summary (no cross-area formatter is
+# warranted).
+# ---
+# bytes: the raw byte count
+# unit:  receives the chosen unit string ("B"/"KB"/"MB")
+# ret:   the magnitude in `unit`
+pub fun size_split(bytes: usize, unit: *str) i64 {
+    val b: i64 = bytes::i64;
+    if (b < 1024) {
+        @unit = "B";
+        ret b;
+    }
+    if (b < 1024 * 1024) {
+        @unit = "KB";
+        ret (b + 512) / 1024;
+    }
+    @unit = "MB";
+    ret (b + 512 * 1024) / (1024 * 1024);
+}
+
+# the fixed display label for phase `ph`
+# ---
+# ph:  the phase id (a PH_* constant)
+# ret: the phase's label
+fun phase_label(ph: u8) str {
+    if (ph == PH_LOAD)     { ret "load"; }
+    if (ph == PH_RESOLVE)  { ret "resolve"; }
+    if (ph == PH_SEMA)     { ret "sema"; }
+    if (ph == PH_LOWER)    { ret "lower"; }
+    if (ph == PH_OPTIMIZE) { ret "optimize"; }
+    if (ph == PH_CODEGEN)  { ret "codegen"; }
+    ret "link";
+}
+
+# print every recorded item of phase `p`, flagging the slowest with `(slow)`
+#
+# The slowest is marked only when the phase holds at least two items with a
+# positive duration, so a single-item phase carries no marker.
+# ---
+# p: the phase whose items to render
+fun render_items(p: *Phase) {
+    val slow: i64 = slowest_index(p);
+    var i: u32 = 0;
+    for (i < p.len) {
+        var dbuf: [DUR_CAP]u8;
+        val dstr: str = cdur.format_duration(p.items[i].d, ?dbuf[0], DUR_CAP);
+        if (i::i64 == slow) {
+            print.eprintf("  {:<32} {:7}  (slow)\n", p.items[i].name, dstr);
+        }
+        or {
+            print.eprintf("  {:<32} {:7}\n", p.items[i].name, dstr);
+        }
+        i = i + 1;
+    }
+}
+
+# the index of the slowest item in `p`, or -1 when no item should be flagged
+#
+# Returns -1 for a phase with fewer than two items, so a lone item is never
+# flagged as the slowest.
+# ---
+# p:   the phase to scan
+# ret: the slowest item's index, or -1
+fun slowest_index(p: *Phase) i64 {
+    if (p.len < 2) { ret -1; }
+    var best: u32 = 0;
+    var i: u32 = 1;
+    for (i < p.len) {
+        if (p.items[i].d > p.items[best].d) { best = i; }
+        i = i + 1;
+    }
+    if (p.items[best].d <= 0) { ret -1; }
+    ret best::i64;
+}
+
+# ensure phase `p` has room for one more item, doubling its array when full
+# ---
+# ro: the Readout (for its allocator)
+# p:  the phase whose item array to grow
+# ret: false on allocation failure
+fun ensure_item_cap(ro: *Readout, p: *Phase) bool {
+    if (p.len < p.cap) { ret true; }
+    var new_cap: u32 = p.cap * 2;
+    if (new_cap < 16) { new_cap = 16; }
+    if (p.items == nil) {
+        val r: R.Result[*Item, str] = A.allocate[Item](ro.alloc, new_cap::usize);
+        if (R.is_err[*Item, str](r)) { ret false; }
+        p.items = R.unwrap_ok[*Item, str](r);
+    }
+    or {
+        val r: R.Result[*Item, str] = A.reallocate[Item](ro.alloc, p.items, p.cap::usize, new_cap::usize);
+        if (R.is_err[*Item, str](r)) { ret false; }
+        p.items = R.unwrap_ok[*Item, str](r);
+    }
+    p.cap = new_cap;
+    ret true;
+}
+
+# release phase `p`'s item array
+# ---
+# ro: the Readout (for its allocator)
+# p:  the phase whose item array to free
+fun free_items(ro: *Readout, p: *Phase) {
+    if (p.items != nil && p.cap > 0) {
+        A.deallocate[Item](ro.alloc, p.items, p.cap::usize);
+    }
+    p.items = nil;
+    p.len   = 0;
+    p.cap   = 0;
+}

--- a/src/lang/session.mach
+++ b/src/lang/session.mach
@@ -22,6 +22,7 @@ use mach.lang.fe.ast;
 use mach.lang.intern;
 use mach.lang.module;
 use mach.lang.query;
+use mach.lang.readout;
 use mach.lang.source;
 use mach.lang.target;
 use mach.lang.type;
@@ -118,9 +119,10 @@ pub rec Session {
     opt_explicit: bool;
     opt_release:  bool;
 
-    # CLI `--verbose` intent, set before the build so the front-end load walk
-    # emits a per-module progress line to stderr. off leaves the load silent.
-    verbose: bool;
+    # the build-progress readout (`mach build -v`/`-vv`), attached before the
+    # build so the front-end load/resolve/sema phases record into the same
+    # accumulator the back-end closes. nil leaves the build silent.
+    readout: *readout.Readout;
 
     # CLI `--pie` intent: emit a position-independent (ET_DYN) executable for ASLR
     # instead of the default fixed-address one. opt-in; the linker ORs it with the
@@ -166,7 +168,7 @@ pub fun init(alloc: *A.Allocator) R.Result[Session, str] {
     s.registry         = target.registry_init();
     s.opt_explicit     = false;
     s.opt_release      = false;
-    s.verbose          = false;
+    s.readout          = nil;
     s.pie              = false;
 
     val opt_types: O.Option[str] = type.init(?s.types, alloc);


### PR DESCRIPTION
Closes #1775. Part of the output-overhaul epic #1773.

## What

Drops `--verbose` in favor of `-v`/`-vv` on `mach build`, re-shaping the
existing per-stage emit points into a timed, fixed-width phase readout.

- **plain** `mach build` / `-q`: silent on success (unchanged).
- **`-v`**: one line per phase (load / resolve / sema / lower / optimize /
  codegen / link) with item count + duration, then a summary
  `built <path>  N modules  <size>  in <time>`.
- **`-vv`**: a per-module/file line under each phase with its own duration and a
  `(slow)` marker on the slowest item.

Timing is `chrono.monotonic`; durations render via `chrono.format_duration`;
columns align with the `{:<N}`/`{:N}` format spec - all from the pinned
mach-std (`3c7f0d65`). Fixed-width ASCII on stderr, identical across
linux/darwin/windows (no color, no escapes, no terminal-width queries).

## Shape

```
load       29 modules     24ms
resolve    29 modules      8ms
sema       29 modules      6ms
lower      29 modules     35ms
optimize   29 modules     24ms
codegen    29 modules     95ms
link        1 binary       8ms
built ./out/linux/debug/bin/demo  29 modules  247 KB  in 204ms
```

`-vv` adds, under each phase:

```
load       29 modules     24ms
  std.system.os.linux.shared           4ms  (slow)
  std.format                           4ms
  ...
```

## Design

- New `mach.lang.readout` module owns the timed phase accumulator; the
  `Session` carries a borrowed `*Readout` (nil = silent) so the front-end
  (driver) and back-end (cmd.build) record into one accumulator.
- The lower+optimize loop in `compile_modules` is split into two timed passes -
  purely structural; produced objects stay byte-identical (fixpoint verified).
- Test builds keep the readout off; that output belongs to the test-runner
  child (#1776).

## Shared-file note (merge sequencing)

Touches the shared CLI arg parser `src/cli/config.mach`: `Config.verbose: bool`
becomes `Config.verbosity: u8`. The sibling output-epic PRs (#1776 test, #1777
diag) should sequence against this - #1776 will likely read `config.verbosity`
for its own `-v`.

## Verification

- self-host fixpoint a -> b -> c byte-identical (seeded from the v2.11.0
  release), with the changes applied.
- `mach test .` green (438 passed, 0 failed).
- plain build + `-q` silent on success; `-v`/`-vv`/`--emit obj`/library paths
  exercised; `-v`+`-q` is a parse error.
- no `--verbose` reference remains in the source tree, CI, `int/`, docs, or
  skills.
