### PR TITLE
feat(test): per-module test runner readout (collapse pass, expand failures, capture output)

### DIFF
--- a/doc/cli.md
+++ b/doc/cli.md
@@ -189,9 +189,31 @@ mach test <path> [options]
 
 Builds one standalone executable per `test` declaration (the test plus the
 project's transitive code, with a synthesized `main` calling just that test),
-then spawns each as a separate process and reports a per-test
-`name file:line PASS|FAIL` line. A crashing test reports its signal and the run
-continues. A test build always links executables, even for a library target.
+then spawns each as a separate process, captures its output, and times it.
+A test build always links executables, even for a library target.
+
+The default readout collapses every all-passing module to a single roll-up
+line and expands only modules that have a failure:
+
+```
+mach.lang.intern                     3 ok  568us
+mach.lang.driver                    27 ok     1 FAIL  146ms
+  FAIL  builds:cyclic_import  ./src/lang/driver.mach:142  (exit 1)
+    expected a diagnostic, got none
+
+failures:
+  mach.lang.driver.builds:cyclic_import  ./src/lang/driver.mach:142  (exit 1)
+
+437 passed, 1 failed, 438 total  (268ms)
+```
+
+A roll-up is `<module>  <ok> ok[  <fail> FAIL]  <duration>`. Each expanded
+failure carries the test's `file:line`, its exit code (`(exit N)`) or signal
+(`(signal N)`), and the child's captured stdout indented beneath it; a passing
+test stays quiet. A crashing test reports its signal and the run continues. The
+closing summary re-lists every failure as `<test>  file:line  (reason)`. `-v`
+lists every test, grouped by module, with each test's duration. The layout is
+fixed-width ASCII (no color, no terminal-width queries).
 
 Only `test` blocks declared in the current project's own modules are collected by
 default; tests in dependency modules are excluded unless `--include-deps` is
@@ -204,13 +226,13 @@ passed.
 | `--list`            | —       | list the collected tests and exit |
 | `--runner <cmd>`    | command | launch every test as `<cmd> <exe>` instead of exec'ing it directly |
 
-Plus the `build` and global flags. `--runner` has the same semantics as on
-`mach run`: a single command name or path (no shell-style word splitting),
-resolved on `PATH`, for foreign-target tests the host cannot exec directly —
-e.g. `mach test . --target windows --runner wine`. Without it, a test executable
-the host cannot launch reports a per-test failure — `FAIL(exit 127)` when
-`execve` rejects the binary in the spawned child, `FAIL(spawn)` when the spawn
-itself fails — with no auto-detection.
+Plus the `build` and global flags (`-v` lists every test). `--runner` has the
+same semantics as on `mach run`: a single command name or path (no shell-style
+word splitting), resolved on `PATH`, for foreign-target tests the host cannot
+exec directly — e.g. `mach test . --target windows --runner wine`. Without it, a
+test executable the host cannot launch reports a per-test failure — `(exit 127)`
+when `execve` rejects the binary in the spawned child, `(spawn failed)` when the
+spawn itself fails — with no auto-detection.
 
 Exit codes: `0` all passed, `1` any failed, `2` build/internal error.
 

--- a/doc/language/test.md
+++ b/doc/language/test.md
@@ -83,8 +83,10 @@ in-tree. `--filter` narrows the run by test name in either mode.
 
 ## The `mach test` workflow
 
-`mach test` builds the project with the test-runner entry point and then
-runs the resulting binary, surfacing its exit code:
+`mach test` builds one standalone executable per `test` declaration, spawns
+each as its own process, captures its output, and renders a per-module readout —
+collapsing all-passing modules to a single roll-up line and expanding any
+module with a failure to show the failing test's captured output and location:
 
 ```
 usage: mach test [options]
@@ -95,9 +97,15 @@ options:
   --filter <pattern>  run only tests whose name contains <pattern>
   --include-deps      also run tests declared in dependency modules
   --list              list the collected tests and exit
+  -v                  list every test, grouped by module, with durations
 
 exit: 0 all passed, 1 any failed, 2 build/internal error
 ```
+
+A roll-up is `<module>  <ok> ok[  <fail> FAIL]  <duration>`. Each expanded
+failure shows `file:line`, the exit code (`(exit N)`) or signal (`(signal N)`),
+and the child's captured stdout indented beneath; a passing test stays quiet.
+The run closes with a summary that re-lists every failure.
 
 The command itself does two things:
 
@@ -121,19 +129,20 @@ whose label contains the given pattern.
 
 ## The runner
 
-The runner is synthesized in IR by the compiler (`mach.lang.me.lower.testrunner`)
-during a test build and codegen'd into one extra object that joins the link.
-For each collected test it emits a body-less extern referencing the test's
-linkage name plus a private `.rodata` global holding the label; the synthesized
-`main` then walks the table. In a test build the project's own `main` is
-neutralised (turned into a body-less extern) so the runner's `main` is the sole
-program entry, and an executable is always linked — even for a library target.
+For each collected test the compiler (`mach.lang.me.lower.testrunner`)
+synthesizes a tiny IR module whose `main` is `ret <test>();` — a signature-only
+extern for the test symbol plus a two-instruction body — codegen'd into one extra
+object that links with the project's objects into a standalone executable for
+that test. In a test build the project's own `main` is neutralised (turned into a
+body-less extern) so the synthesized `main` is the sole program entry, and an
+executable is always linked — even for a library target.
 
-The runner prints one line per executed test, `PASS <label>` or `FAIL <label>`,
-to stdout, and returns `0` when every selected test passed and `1` otherwise.
-It reads `--list` / `--filter` from its own argv (forwarded by `mach test`). The
-only OS interaction is a `write` syscall emitted as a small inline-asm helper,
-so the runner has no standard-library dependency.
+`mach test` itself spawns each per-test executable, captures the child's stdout,
+times it, and reads its exit status, then renders the per-module readout
+described above (a roll-up per module, expanded failures with captured output
+and `file:line`, a closing failure summary) and returns `0` when every selected
+test passed and `1` otherwise. `--list` / `--filter` select or enumerate which
+tests are built and run; `-v` lists every test with its duration.
 
 Tests live inline alongside the code they cover: write `test "..." { }`
 declarations directly in the relevant `src/` module, or group them under

--- a/src/cli/cmd/build.mach
+++ b/src/cli/cmd/build.mach
@@ -70,15 +70,18 @@ pub rec BuildResult {
 # teardown inside `build_tests` and stay valid until the caller frees that
 # allocator (after it has run every test).
 # ---
-# label: owned printable test name (the `test "..."` literal's inner text)
-# file:  owned source file path of the declaring module
-# line:  1-based source line of the `test` keyword
-# exe:   owned absolute path to the test executable; nil in `--list` mode
+# module: owned fully-qualified name of the declaring module, the runner's
+#         per-module roll-up key (collection order keeps a module's tests adjacent)
+# label:  owned printable test name (the `test "..."` literal's inner text)
+# file:   owned source file path of the declaring module
+# line:   1-based source line of the `test` keyword
+# exe:    owned absolute path to the test executable; nil in `--list` mode
 pub rec TestArtifact {
-    label: *u8;
-    file:  *u8;
-    line:  u32;
-    exe:   *u8;
+    module: *u8;
+    label:  *u8;
+    file:   *u8;
+    line:   u32;
+    exe:    *u8;
 }
 
 # the growing TestArtifact array a test build fills, in collection order
@@ -1129,6 +1132,9 @@ fun record_test(p: *driver.Project, t: *testrunner.Test, exe: *u8, tests_out: *T
     var artifact: TestArtifact;
     artifact.line = t.line;
 
+    artifact.module = dup_cstr(a, test_module_fqn(p, t.mod_idx));
+    if (artifact.module == nil) { print.eprint("error: out of memory\n"); ret 2; }
+
     val opt_label: O.Option[str] = intern.lookup(?p.s.interner, t.label);
     var label_src: *u8 = "<test>";
     if (O.is_some[str](opt_label)) { label_src = O.unwrap[str](opt_label)::*u8; }
@@ -1173,6 +1179,22 @@ fun test_list_push(a: *A.Allocator, list: *TestList, t: TestArtifact) bool {
     list.tests[list.len] = t;
     list.len = list.len + 1;
     ret true;
+}
+
+# the fully-qualified name of the module a test was declared in
+#
+# Borrowed from the session interner (the caller duplicates). "<unknown>" when
+# the index is out of range or the FQN is not interned.
+# ---
+# p:       the project (for its interner and module table)
+# mod_idx: the declaring module's index
+# ret:     the borrowed module FQN, or "<unknown>"
+fun test_module_fqn(p: *driver.Project, mod_idx: u32) *u8 {
+    if (mod_idx >= p.module_len) { ret "<unknown>"; }
+    val m: *driver.ModuleEntry = ?p.modules[mod_idx];
+    val opt_fqn: O.Option[str] = intern.lookup(?p.s.interner, m.fqn);
+    if (O.is_none[str](opt_fqn)) { ret "<unknown>"; }
+    ret O.unwrap[str](opt_fqn)::*u8;
 }
 
 # the source file path of the module a test was declared in

--- a/src/cli/cmd/testing.mach
+++ b/src/cli/cmd/testing.mach
@@ -1,12 +1,24 @@
-# `mach test` - build one executable per test and run each as a separate process.
+# `mach test` - build one executable per test, run each as a separate process,
+# and report a per-module roll-up.
 #
 # `mach test` compiles every `test "..."` block into its own standalone
 # executable (the test plus the project's transitive code, with a synthesized
 # `main` that calls just that test). this command spawns each executable as a
-# separate process, reads its exit status, and reports a per-test line:
-# `name file:line PASS` / `FAIL(exit n)` / `FAIL(signal s)`. a crashing test (a
-# signal) is reported and the run continues, so one SIGSEGV no longer kills the
-# suite. the run ends with a `passed/failed/total` summary.
+# separate process, captures its output, times it, and reads its exit status.
+#
+# the default readout collapses every all-passing module to a single roll-up
+# line (`mach.lang.driver  36 ok  41ms`) and expands any module with failures,
+# printing each failing test's captured child output, `file:line`, and exit
+# code or signal. the run ends with a summary that re-lists the failures. a
+# crashing test (a signal) is reported and the run continues, so one SIGSEGV no
+# longer kills the suite. `-v` lists every test, grouped by module, with its
+# duration. timing is `chrono.monotonic`; durations and the column widths use
+# the stdlib formatting primitives; the layout is fixed-width ASCII.
+#
+# child output is captured through `std.process.exec.capture`, which pipes the
+# child's stdout and drains it to EOF before waiting, so a chatty test never
+# deadlocks the runner. only failing tests retain their output (passing tests
+# stay quiet); the captured bytes surface under the expanded failure.
 #
 # by default only `test` blocks declared in the current project's own modules are
 # collected; `--include-deps` widens collection to dependency modules too (#1556).
@@ -25,15 +37,63 @@ use std.print;
 use std.process.env;
 use std.process.exec;
 use std.types.bool.bool;
+use std.types.bool.false;
+use std.types.bool.true;
 use std.types.size.usize;
 use std.types.string.str;
+use std.types.string.str_equals;
+use std.types.string.str_len;
+use std.types.string.str_starts_with;
 
-use A: std.allocator;
-use O: std.types.option;
-use R: std.types.result;
+use A:      std.allocator;
+use O:      std.types.option;
+use R:      std.types.result;
+use fmt:    std.format;
+use fs:     std.filesystem;
+use writer: std.io.writer;
+use tm:     std.chrono.time;
+use du:     std.chrono.duration;
 
 use mach.cli.cmd.build;
 use mach.cli.util;
+
+# a test that passed
+val KIND_PASS:   u8 = 0;
+# a test that exited with a non-zero code (`code` carries it)
+val KIND_EXIT:   u8 = 1;
+# a test killed by a signal (`code` carries the signal number)
+val KIND_SIGNAL: u8 = 2;
+# a test whose executable could not be spawned
+val KIND_SPAWN:  u8 = 3;
+# a test that neither exited nor signaled (should not occur)
+val KIND_OTHER:  u8 = 4;
+
+# capacity of the per-test stdout capture buffer; a child writing more is drained
+# past it (so it never blocks) and its retained output is marked truncated
+val CAP_OUTPUT: usize = 65536;
+
+# the result of running one test
+#
+# `out` retains the captured child stdout only for a failing test (passing tests
+# discard it); it is owned by the run allocator and aliases nothing in the reused
+# capture buffer.
+# ---
+# art:       the built test artifact (borrowed; owned by the run allocator)
+# kind:      a KIND_* outcome
+# code:      exit code (KIND_EXIT) or signal number (KIND_SIGNAL); 0 otherwise
+# elapsed:   wall time of the child process
+# out:       retained captured stdout, or nil when the test passed or wrote none
+# out_len:   bytes stored in `out`
+# truncated: the child wrote more than the capture buffer held
+rec Outcome {
+    art:       *build.TestArtifact;
+    kind:      u8;
+    code:      i32;
+    elapsed:   du.Duration;
+    out:       *u8;
+    out_len:   usize;
+    truncated: bool;
+}
 
 # `mach test` subcommand entry: build one executable per test, run each as its
 # own process, and report the results
@@ -44,7 +104,8 @@ use mach.cli.util;
 # argv: argument vector of argc null-terminated byte pointers
 # ret:  0 if all selected tests passed, 1 if any failed, 2 on a build or internal error
 pub fun run(argc: usize, argv: **u8) i64 {
-    val list: bool = util.has_flag(argc, argv, "--list");
+    val list:    bool = util.has_flag(argc, argv, "--list");
+    val verbose: bool = util.has_flag(argc, argv, "-v") || util.has_flag(argc, argv, "--verbose");
 
     # back the build with an arena over a page allocator, matching `mach build`.
     # the build's internal teardown frees through this allocator; the page
@@ -98,15 +159,63 @@ pub fun run(argc: usize, argv: **u8) i64 {
         runner = R.unwrap_ok[*u8, str](res_resolve);
     }
 
-    # spawn each test as its own process and report its result.
-    var passed: u32 = 0;
-    var failed: u32 = 0;
-    var i:      u32 = 0;
+    # a filtered run that matched nothing has no work and no failures.
+    if (tbr.len == 0) {
+        print.print("0 passed, 0 failed, 0 total  (0ms)\n");
+        arena.dnit(?ar);
+        ret 0;
+    }
+
+    # one Outcome per test, plus a single reused stdout capture buffer.
+    val res_out: R.Result[*Outcome, str] = A.allocate[Outcome](?a, tbr.len::usize);
+    if (R.is_err[*Outcome, str](res_out)) {
+        arena.dnit(?ar);
+        print.eprint("error: out of memory\n");
+        ret 2;
+    }
+    val outcomes: *Outcome = R.unwrap_ok[*Outcome, str](res_out);
+
+    val res_buf: R.Result[*u8, str] = A.allocate[u8](?a, CAP_OUTPUT);
+    if (R.is_err[*u8, str](res_buf)) {
+        arena.dnit(?ar);
+        print.eprint("error: out of memory\n");
+        ret 2;
+    }
+    val buf: *u8 = R.unwrap_ok[*u8, str](res_buf);
+
+    execute_all(?a, ?tbr, runner, outcomes, buf);
+
+    if (verbose) { render_verbose(outcomes, tbr.len); }
+    or          { render_default(outcomes, tbr.len); }
+
+    val failed: u32 = count_failed(outcomes, tbr.len);
+    val passed: u32 = tbr.len - failed;
+    render_summary(outcomes, tbr.len, passed, failed);
+
+    arena.dnit(?ar);
+    if (failed > 0) { ret 1; }
+    ret 0;
+}
+
+# spawn every test, capturing its stdout and timing it, into `outcomes`
+#
+# Each child is run with its stdout piped and drained to EOF (capture), so a
+# chatty test cannot deadlock the runner; stderr is inherited. A failing test's
+# captured bytes are copied out of the reused buffer into the run allocator so
+# they survive the next test overwriting the buffer.
+# ---
+# a:        allocator retaining each failing test's captured output
+# tbr:      the built test artifacts to run
+# runner:   resolved `--runner` launcher, or nil to exec each test directly
+# outcomes: caller-owned array (length tbr.len) filled in test order
+# buf:      the reused capture buffer (CAP_OUTPUT bytes)
+fun execute_all(a: *A.Allocator, tbr: *build.TestBuildResult, runner: *u8, outcomes: *Outcome, buf: *u8) {
+    var i: u32 = 0;
     for (i < tbr.len) {
         val art: *build.TestArtifact = ?tbr.tests[i];
 
         # child argv: [exe] directly, or [runner, exe] under --runner. argv[0]
-        # doubles as the pathname execve receives, so a runner needs no PATH search.
+        # doubles as the pathname the spawn receives, so a runner needs no PATH search.
         var child_argv: [3]*u8;
         if (runner != nil) {
             child_argv[0] = runner;
@@ -118,57 +227,317 @@ pub fun run(argc: usize, argv: **u8) i64 {
             child_argv[1] = nil;
         }
 
-        artifact_report(art);
-        print.print(" ");
+        var o: Outcome;
+        o.art       = art;
+        o.code      = 0;
+        o.out       = nil;
+        o.out_len   = 0;
+        o.truncated = false;
 
         # each test child inherits the parent's environment unmodified.
-        val res_exec: R.Result[exec.ExitStatus, str] = exec.run(child_argv[0], ?child_argv[0], env.environ());
-        if (R.is_err[exec.ExitStatus, str](res_exec)) {
-            print.print("FAIL(spawn)\n");
-            failed = failed + 1;
-            i = i + 1;
-            cnt;
-        }
-        val status: exec.ExitStatus = R.unwrap_ok[exec.ExitStatus, str](res_exec);
+        val start: tm.Time = tm.monotonic();
+        val res: R.Result[exec.Capture, str] = exec.capture(child_argv[0], ?child_argv[0], env.environ(), buf, CAP_OUTPUT);
+        val finish: tm.Time = tm.monotonic();
+        o.elapsed = tm.time_sub(finish, start);
 
-        if (exec.exited(status) && exec.code(status) == 0) {
-            print.print("PASS\n");
-            passed = passed + 1;
-        }
-        or (exec.signaled(status)) {
-            # a crash reports the signal and the run continues to the next test.
-            print.print("FAIL(signal ");
-            print.u64(exec.signal(status)::u64);
-            print.print(")\n");
-            failed = failed + 1;
-        }
-        or (exec.exited(status)) {
-            print.print("FAIL(exit ");
-            print.u64(exec.code(status)::u64);
-            print.print(")\n");
-            failed = failed + 1;
+        if (R.is_err[exec.Capture, str](res)) {
+            o.kind = KIND_SPAWN;
         }
         or {
-            print.print("FAIL\n");
-            failed = failed + 1;
+            val cap: exec.Capture    = R.unwrap_ok[exec.Capture, str](res);
+            val st:  exec.ExitStatus = cap.status;
+            if (exec.exited(st) && exec.code(st) == 0) {
+                o.kind = KIND_PASS;
+            }
+            or (exec.signaled(st)) {
+                # a crash reports the signal and the run continues to the next test.
+                o.kind = KIND_SIGNAL;
+                o.code = exec.signal(st);
+                retain_output(a, ?o, buf, cap.len);
+            }
+            or (exec.exited(st)) {
+                o.kind = KIND_EXIT;
+                o.code = exec.code(st);
+                retain_output(a, ?o, buf, cap.len);
+            }
+            or {
+                o.kind = KIND_OTHER;
+                retain_output(a, ?o, buf, cap.len);
+            }
+        }
+
+        outcomes[i] = o;
+        i = i + 1;
+    }
+}
+
+# copy a failing test's captured stdout out of the reused buffer into `a`
+#
+# Stores at most CAP_OUTPUT bytes, marking the outcome truncated when the child
+# wrote more. An allocation failure leaves the outcome without retained output;
+# the failure still reports its location and exit status.
+# ---
+# a:    allocator owning the retained copy
+# o:    the outcome to attach the copy to
+# buf:  the capture buffer holding the child's stdout
+# full: the full output length the capture reported (may exceed CAP_OUTPUT)
+fun retain_output(a: *A.Allocator, o: *Outcome, buf: *u8, full: usize) {
+    var stored: usize = full;
+    if (stored > CAP_OUTPUT) {
+        stored      = CAP_OUTPUT;
+        o.truncated = true;
+    }
+    if (stored == 0) { ret; }
+
+    val res: R.Result[*u8, str] = A.allocate[u8](a, stored);
+    if (R.is_err[*u8, str](res)) { ret; }
+    val dst: *u8 = R.unwrap_ok[*u8, str](res);
+
+    var i: usize = 0;
+    for (i < stored) {
+        dst[i] = buf[i];
+        i = i + 1;
+    }
+    o.out     = dst;
+    o.out_len = stored;
+}
+
+# the default readout: one roll-up line per module, expanding only failures
+#
+# Tests arrive grouped by declaring module (collection order), so a module's run
+# is the maximal adjacent run of equal module names. An all-passing module shows
+# only its roll-up; a module with failures additionally expands each failing test.
+# ---
+# outcomes: the run outcomes in test order
+# len:      number of outcomes
+fun render_default(outcomes: *Outcome, len: u32) {
+    var i: u32 = 0;
+    for (i < len) {
+        val mod_name: str = util.cstr_str(outcomes[i].art.module);
+
+        var j:       u32 = i;
+        var ok:      u32 = 0;
+        var fail:    u32 = 0;
+        var elapsed: du.Duration = 0;
+        for (j < len) {
+            if (!str_equals(util.cstr_str(outcomes[j].art.module), mod_name)) { brk; }
+            if (outcomes[j].kind == KIND_PASS) { ok = ok + 1; }
+            or                                 { fail = fail + 1; }
+            elapsed = elapsed + outcomes[j].elapsed;
+            j = j + 1;
+        }
+
+        print_rollup(mod_name, ok, fail, elapsed);
+        if (fail > 0) {
+            var k: u32 = i;
+            for (k < j) {
+                if (outcomes[k].kind != KIND_PASS) { print_fail_detail(?outcomes[k], mod_name); }
+                k = k + 1;
+            }
+        }
+        i = j;
+    }
+}
+
+# the `-v` readout: every test listed under its module with its duration
+#
+# Failing tests additionally carry their location, exit status, and captured
+# output, so `-v` is a superset of the default expansion.
+# ---
+# outcomes: the run outcomes in test order
+# len:      number of outcomes
+fun render_verbose(outcomes: *Outcome, len: u32) {
+    var i: u32 = 0;
+    for (i < len) {
+        val mod_name: str = util.cstr_str(outcomes[i].art.module);
+        print.printf("{}\n", mod_name);
+
+        var j: u32 = i;
+        for (j < len) {
+            if (!str_equals(util.cstr_str(outcomes[j].art.module), mod_name)) { brk; }
+            print_verbose_test(?outcomes[j], mod_name);
+            j = j + 1;
+        }
+        i = j;
+    }
+}
+
+# write one module's roll-up line: `<module>  <ok> ok[  <fail> FAIL]  <dur>`
+# ---
+# mod_name: the module's fully-qualified name
+# ok:       number of passing tests
+# fail:     number of failing tests
+# elapsed:  total wall time of the module's tests
+fun print_rollup(mod_name: str, ok: u32, fail: u32, elapsed: du.Duration) {
+    var dbuf: [24]u8;
+    val ds: str = du.format_duration(elapsed, ?dbuf[0], 24::usize);
+    if (fail > 0) {
+        print.printf("{:<34}{:4} ok  {:4} FAIL  {}\n", mod_name, ok::i64, fail::i64, ds);
+    }
+    or {
+        print.printf("{:<34}{:4} ok  {}\n", mod_name, ok::i64, ds);
+    }
+}
+
+# write the expanded detail for one failing test under the default readout
+# ---
+# o:        the failing outcome
+# mod_name: its module's name, stripped from the label for a compact display
+fun print_fail_detail(o: *Outcome, mod_name: str) {
+    val label: str = display_label(mod_name, util.cstr_str(o.art.label));
+    print.printf("  FAIL  {}  {}:{}  ", label, util.cstr_str(o.art.file), o.art.line::i64);
+    print_reason(o);
+    print.print("\n");
+    print_captured(o);
+}
+
+# write one test's line under the `-v` readout, expanding a failure inline
+# ---
+# o:        the outcome to list
+# mod_name: its module's name, stripped from the label for a compact display
+fun print_verbose_test(o: *Outcome, mod_name: str) {
+    var dbuf: [24]u8;
+    val ds:    str = du.format_duration(o.elapsed, ?dbuf[0], 24::usize);
+    val label: str = display_label(mod_name, util.cstr_str(o.art.label));
+    if (o.kind == KIND_PASS) {
+        print.printf("  {:<4}  {:<40}{}\n", "ok", label, ds);
+    }
+    or {
+        print.printf("  {:<4}  {:<40}{}  ", "FAIL", label, ds);
+        print_reason(o);
+        print.printf("  {}:{}\n", util.cstr_str(o.art.file), o.art.line::i64);
+        print_captured(o);
+    }
+}
+
+# write a failing outcome's reason token: `(exit N)`, `(signal N)`, or a word
+# ---
+# o: the failing outcome
+fun print_reason(o: *Outcome) {
+    if (o.kind == KIND_EXIT)   { print.printf("(exit {})", o.code::i64); }
+    or (o.kind == KIND_SIGNAL) { print.printf("(signal {})", o.code::i64); }
+    or (o.kind == KIND_SPAWN)  { print.print("(spawn failed)"); }
+    or                         { print.print("(failed)"); }
+}
+
+# write a failing test's retained stdout, each line indented, then a truncation
+# note when the output overflowed the capture buffer
+#
+# Nothing is written when the test produced no output. The bytes are streamed
+# verbatim through a stdout writer so arbitrary content (not null-terminated)
+# renders faithfully.
+# ---
+# o: the failing outcome
+fun print_captured(o: *Outcome) {
+    if (o.out == nil || o.out_len == 0) {
+        if (o.truncated) { print.print("    ... (output truncated)\n"); }
+        ret;
+    }
+
+    var w: writer.Writer;
+    fs.get_writer(?fs.stdout, ?w);
+
+    var i:   usize = 0;
+    var seg: usize = 0;
+    for (i < o.out_len) {
+        if (o.out[i] == '\n') {
+            fmt.write_str(?w, "    ");
+            fmt.write_bytes(?w, (o.out::usize + seg)::*u8, i - seg + 1::usize);
+            seg = i + 1::usize;
         }
         i = i + 1;
     }
-
-    print.print("\n");
-    print.u64(passed::u64);
-    print.print(" passed, ");
-    print.u64(failed::u64);
-    print.print(" failed, ");
-    print.u64(tbr.len::u64);
-    print.print(" total\n");
-
-    arena.dnit(?ar);
-    if (failed > 0) { ret 1; }
-    ret 0;
+    if (seg < o.out_len) {
+        fmt.write_str(?w, "    ");
+        fmt.write_bytes(?w, (o.out::usize + seg)::*u8, o.out_len - seg);
+        fmt.write_newline(?w);
+    }
+    if (o.truncated) { fmt.write_str(?w, "    ... (output truncated)\n"); }
 }
 
-# write a test's identifying `label file:line` prefix to stdout, no trailing newline
+# write the closing summary: a `failures:` block re-listing each failure, then a
+# `passed/failed/total` count with the run's total wall time
+# ---
+# outcomes: the run outcomes in test order
+# len:      number of outcomes
+# passed:   number of passing tests
+# failed:   number of failing tests
+fun render_summary(outcomes: *Outcome, len: u32, passed: u32, failed: u32) {
+    print.print("\n");
+
+    if (failed > 0) {
+        print.print("failures:\n");
+        var i: u32 = 0;
+        for (i < len) {
+            if (outcomes[i].kind != KIND_PASS) {
+                print.printf("  {}  {}:{}  ",
+                    util.cstr_str(outcomes[i].art.label),
+                    util.cstr_str(outcomes[i].art.file),
+                    outcomes[i].art.line::i64);
+                print_reason(?outcomes[i]);
+                print.print("\n");
+            }
+            i = i + 1;
+        }
+        print.print("\n");
+    }
+
+    var dbuf: [24]u8;
+    val ds: str = du.format_duration(total_elapsed(outcomes, len), ?dbuf[0], 24::usize);
+    print.printf("{} passed, {} failed, {} total  ({})\n", passed::i64, failed::i64, len::i64, ds);
+}
+
+# the number of non-passing outcomes
+# ---
+# outcomes: the run outcomes
+# len:      number of outcomes
+# ret:      count of failing tests
+fun count_failed(outcomes: *Outcome, len: u32) u32 {
+    var f: u32 = 0;
+    var i: u32 = 0;
+    for (i < len) {
+        if (outcomes[i].kind != KIND_PASS) { f = f + 1; }
+        i = i + 1;
+    }
+    ret f;
+}
+
+# the summed wall time of every outcome
+# ---
+# outcomes: the run outcomes
+# len:      number of outcomes
+# ret:      total elapsed duration
+fun total_elapsed(outcomes: *Outcome, len: u32) du.Duration {
+    var t: du.Duration = 0;
+    var i: u32 = 0;
+    for (i < len) {
+        t = t + outcomes[i].elapsed;
+        i = i + 1;
+    }
+    ret t;
+}
+
+# strip a leading `<module>.` from a test label for a compact per-module display
+#
+# Mach tests are named with their fully-qualified path by convention (e.g.
+# `mach.lang.driver.builds:trivial`), so under a module roll-up the prefix is
+# redundant. A label that does not carry the prefix is returned unchanged.
+# ---
+# mod_name: the module's fully-qualified name
+# label:    the test's printable label
+# ret:      the label with a matching `<module>.` prefix removed
+fun display_label(mod_name: str, label: str) str {
+    if (str_starts_with(label, mod_name)) {
+        val ml: usize = str_len(mod_name);
+        if (label[ml] == '.') {
+            ret (label::usize + ml + 1::usize)::str;
+        }
+    }
+    ret label;
+}
+
+# write a test's identifying `label file:line` prefix to stdout, no trailing
+# newline (the `--list` line shape)
 # ---
 # art: the test artifact to describe
 fun artifact_report(art: *build.TestArtifact) {

--- a/src/cli/cmd/testing.mach
+++ b/src/cli/cmd/testing.mach
@@ -104,8 +104,11 @@ rec Outcome {
 # argv: argument vector of argc null-terminated byte pointers
 # ret:  0 if all selected tests passed, 1 if any failed, 2 on a build or internal error
 pub fun run(argc: usize, argv: **u8) i64 {
-    val list:    bool = util.has_flag(argc, argv, "--list");
-    val verbose: bool = util.has_flag(argc, argv, "-v") || util.has_flag(argc, argv, "--verbose");
+    val list: bool = util.has_flag(argc, argv, "--list");
+
+    # `-v` or `-vv` lists every test; the runner has a single verbose level and
+    # mirrors the shared verbosity flags (`--verbose` was dropped in #1775).
+    val verbose: bool = util.has_flag(argc, argv, "-v") || util.has_flag(argc, argv, "-vv");
 
     # back the build with an arena over a page allocator, matching `mach build`.
     # the build's internal teardown frees through this allocator; the page

--- a/src/cli/cmd/testing.mach
+++ b/src/cli/cmd/testing.mach
@@ -24,13 +24,13 @@
 # collected; `--include-deps` widens collection to dependency modules too (#1556).
 # `--list` prints the collected tests without building or running them.
 # `--filter <substr>` selects the tests whose name contains the substring.
-# `--runner <cmd>` launches every test as `<cmd> <exe>` instead of exec'ing the
+# `--runner <cmd>` launches every test as `<cmd> <exe>` instead of spawning the
 # executable directly - the host-side launcher for foreign-target artifacts
 # (e.g. wine for a windows target, #1345). absent the flag, executables are
-# exec'd directly and a spawn failure reports exactly that.
+# spawned directly and a spawn failure reports exactly that.
 #
-# execution is currently linux-only (the spawn path is POSIX `fork`/`exec`); a
-# win64 runner needs `CreateProcess` (tracked on #1235).
+# spawning and output capture go through `std.process`, which is multiplatform
+# (linux, darwin, windows), so the readout behaves identically on every host.
 
 use std.allocator.arena;
 use std.print;


### PR DESCRIPTION
Closes #1776. Part of the output-overhaul epic #1773.

## What

Overhauls `mach test` output. The old readout was a flat wall of one
`name file:line PASS|FAIL(...)` line per test plus a bare count, and surfaced
only the exit code on failure. The new readout:

- **Default** — one per-module roll-up line, `<module>  <ok> ok[  <fail> FAIL]  <dur>`.
  All-passing modules collapse to just their roll-up; a module with a failure
  expands, printing each failing test's **captured child stdout**, `file:line`,
  and `(exit N)` / `(signal N)`. A closing summary re-lists every failure.
- **`-v`** — lists every test, grouped by module, with its duration (failing
  tests still expand with location + captured output).
- **Capture** — each test child's stdout is captured via
  `std.process.exec.capture` (a single pipe drained to EOF before `wait`, so a
  chatty test cannot deadlock the runner) and surfaced only on failure; passing
  tests stay quiet.

Timing is `chrono.monotonic` + `chrono.format_duration`; column widths use the
`{:<N}` / `{:N}` format spec (pinned mach-std `3c7f0d65`). Layout is fixed-width
ASCII — no color, no Unicode, no terminal-width queries. Exit codes are
unchanged: `0` all-pass, `1` any-fail, `2` build/internal error. The self-host
fixpoint (a→b→c, `cmp -s b c`) holds byte-identical.

## Before

```
mach.cli.cmd.doc.write_doc:summary_only ./src/cli/cmd/doc.mach:689 PASS
mach.cli.cmd.doc.skip_decorators ./src/cli/cmd/doc.mach:713 PASS
... (one line per test, 438 lines)

438 passed, 0 failed, 438 total
```

## After (all-pass, collapsed)

```
mach.lang.intern                     3 ok  568us
mach.lang.driver                    28 ok  146ms
mach.lang.editor                    38 ok  31ms
... (one roll-up line per module)

438 passed, 0 failed, 438 total  (268ms)
```

## After (a deliberately-failed test, expanded)

```
scratch.main                         2 ok     2 FAIL  95ms
  FAIL  computes_a_difference  ./src/main.mach:15  (exit 1)
    expected difference 42, got 7
      left  = 49
      right = 42
  FAIL  dereferences_null  ./src/main.mach:26  (signal 11)

failures:
  scratch.main.computes_a_difference  ./src/main.mach:15  (exit 1)
  scratch.main.dereferences_null  ./src/main.mach:26  (signal 11)

2 passed, 2 failed, 4 total  (95ms)
```

## Files touched

- `src/cli/cmd/testing.mach` — the runner rewrite (capture/timing/roll-up/expand/`-v`/summary).
- `src/cli/cmd/build.mach` — **scoped to the test-build machinery only**: added
  `TestArtifact.module` and the `test_module_fqn()` helper; populated the field
  in `record_test`. No other build path touched. (Flagged for sequencing against
  the concurrent #1775 build-readout work, which also lives in this file.)
- `doc/cli.md`, `doc/language/test.md` — document the new readout.

## Notes / follow-ups

- `std.process.exec.capture` is stdout-only; a test child's **stderr** still
  inherits the terminal. The mach + mach-std corpora write nothing to stderr in
  tests, so the run stays clean today, but capturing/suppressing stderr too would
  need a both-streams (merged) capture added to mach-std — flagged as a stdlib
  follow-up rather than worked around in the CLI.
- `mach test -v` / `-vv` lists every test; `--verbose` was dropped to match
  #1775. The earlier `mach test -v` build-stage stderr noise is **resolved** by
  #1775 — the test build runs silent (`s.readout` stays nil for `test_mode`), so
  the readout is the runner's alone.


## Integration

Merged current `dev` (carries #1775 build-readout + #1782 diagnostics); the
self-host fixpoint a→b→c stays byte-identical and `mach test .` is green on the
integrated tree. My `build.mach` change is exactly: `TestArtifact.module`,
`test_module_fqn()`, one line in `record_test` — no overlap with #1775's verbosity
code.
