### PR TITLE
fix(ci): route the darwin-x86_64 int leg to macos-14 (Rosetta 2)

### DIFF
--- a/.github/workflows/int-main.yml
+++ b/.github/workflows/int-main.yml
@@ -35,6 +35,7 @@ jobs:
     name: seed ${{ matrix.target }}
     needs: int-matrix
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:
@@ -61,10 +62,14 @@ jobs:
           if-no-files-found: error
           retention-days: 1
 
+  # timeout-minutes bounds execution, not queue time: a leg pinned to an
+  # unavailable runner class still sits in queue to GitHub's 24h cap (#1787).
+  # keeping every row on an available runner class is the real guard.
   integration:
     name: int ${{ matrix.target }}
     needs: [int-matrix, seed]
     runs-on: ${{ matrix.runner }}
+    timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:

--- a/int/targets.conf
+++ b/int/targets.conf
@@ -15,5 +15,7 @@ linux            ubuntu-latest     native    pr
 linux-arm64      ubuntu-24.04-arm  native    pr
 linux-riscv64    ubuntu-latest     qemu      pr
 windows          windows-latest    native    pr
-darwin-x86_64    macos-13          native    main
+# x86_64-darwin runs on apple-silicon macos-14 under Rosetta 2, mirroring cd.yml:
+# intel macos-13 runners are queue-starved and never dispatch (#1787)
+darwin-x86_64    macos-14          native    main
 darwin-aarch64   macos-14          native    main


### PR DESCRIPTION
Closes #1787.

The `int darwin-x86_64` job has never executed: `int/targets.conf` pins it to `macos-13`, a runner class GitHub no longer meaningfully serves — every run queued for exactly 24h with no runner assigned (`runner_id: 0`) and died at the queue cap. cd.yml already moved both darwin archives to `macos-14` for the same reason; this mirrors that into the int matrix single-source-of-truth.

- `int/targets.conf`: `darwin-x86_64` runner `macos-13` → `macos-14` (Rosetta 2 translates the x86_64 Mach-O transparently; run-mode stays `native`, no harness change).
- `int-main.yml`: `timeout-minutes: 20` on `seed` and `integration` — bounds *execution* hangs on 10×-billed macOS runners. Noted in-file that this cannot catch queue starvation; runner availability is the real guard.

Verified locally: `int/lib/ci-matrix.sh main` emits both darwin legs on `macos-14`; `pr` cadence unchanged.

Post-merge verification: manual `gh workflow run 'int main' --ref dev` to watch both darwin legs go green.
