### PR TITLE
feat(test): single dispatcher binary per test build (one link, argv-index dispatch)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   platforms - timing via `chrono.monotonic`, durations via
   `chrono.format_duration`, columns via the `{:<N}`/`{:N}` format spec (#1775).
 
+### Changed
+
+- test: `mach test` builds **one dispatcher executable** covering every
+  collected test instead of one standalone executable per test - one link
+  instead of N (on mach itself: 44.9s → 7.2s wall, 9.4 GB → 7.3 MB on disk).
+  Each test still runs as its own process, spawned as `<exe> <idx>`. `--runner`
+  now receives the executable path and the test index as its two arguments;
+  `--filter` selects at run time, so the built executable is identical
+  regardless of filter; the `tests` template's `{name}` resolves to the product
+  name (falling back to the project id) rather than a per-test name (#1789).
+
 ### Removed
 
 - build: the `--verbose` flag, replaced by `-v`/`-vv` (#1775).

--- a/doc/cli.md
+++ b/doc/cli.md
@@ -225,15 +225,20 @@ passed.
 | `--filter <pattern>`| pattern | run only tests whose name contains `<pattern>` |
 | `--include-deps`    | —       | also collect tests declared in dependency modules |
 | `--list`            | —       | list the collected tests and exit |
-| `--runner <cmd>`    | command | launch every test as `<cmd> <exe>` instead of exec'ing it directly |
+| `--runner <cmd>`    | command | launch every test as `<cmd> <exe> <idx>` instead of exec'ing the dispatcher directly |
 
-Plus the `build` and global flags (`-v` lists every test). `--runner` has the
-same semantics as on `mach run`: a single command name or path (no shell-style
-word splitting), resolved on `PATH`, for foreign-target tests the host cannot
-exec directly — e.g. `mach test . --target windows --runner wine`. Without it, a
-test executable the host cannot launch reports a per-test failure — `(exit 127)`
-when `execve` rejects the binary in the spawned child, `(spawn failed)` when the
-spawn itself fails — with no auto-detection.
+Plus the `build` and global flags (`-v` lists every test). The build produces a
+single dispatcher executable covering every collected test; the runner spawns it
+once per test as `<exe> <idx>`, so each test still runs in its own process.
+`--filter` selects at run time — the built executable is identical regardless of
+filter. `--runner` has the same semantics as on `mach run`: a single command
+name or path (no shell-style word splitting), resolved on `PATH`, for
+foreign-target tests the host cannot exec directly — e.g. `mach test . --target
+windows --runner wine` (the runner receives the executable path and the test
+index as its two arguments). Without it, a test executable the host cannot
+launch reports a per-test failure — `(exit 127)` when `execve` rejects the
+binary in the spawned child, `(spawn failed)` when the spawn itself fails — with
+no auto-detection.
 
 Exit codes: `0` all passed, `1` any failed, `2` build/internal error.
 

--- a/doc/manifest.md
+++ b/doc/manifest.md
@@ -25,7 +25,7 @@ out     = "out/{target}/{profile}/bin/{name}{ext}"  # artifact path template
 obj     = "out/{target}/{profile}/obj"              # intermediate-object dir template
 ir      = "out/{target}/{profile}/ir"               # IR-dump dir template
 asm     = "out/{target}/{profile}/asm"              # ASM-dump dir template
-tests   = "out/{target}/{profile}/test/{name}"      # per-test executable path template (mach test)
+tests   = "out/{target}/{profile}/test/{name}"      # test dispatcher executable path template (mach test)
 # optional metadata: name, description, license, authors
 
 [target.linux]             # a platform: a fully-spelled tuple, nothing inferred
@@ -79,7 +79,7 @@ ref = "v0.4.0"
 | `obj`     | string | no       | `"out/{target}/{profile}/obj"` | Per-module object tree template. |
 | `ir`      | string | no       | `"out/{target}/{profile}/ir"`  | Per-module IR-dump template (used when emission is on). |
 | `asm`     | string | no       | `"out/{target}/{profile}/asm"` | Per-module assembly-dump template (used when emission is on). |
-| `tests`   | string | no       | `"out/{target}/{profile}/test/{name}"` | Per-test executable path template. `mach test` builds one standalone executable per `test` block here, with `{name}` the sanitized test name (see below). |
+| `tests`   | string | no       | `"out/{target}/{profile}/test/{name}"` | Test dispatcher executable path template. `mach test` builds one executable covering every collected `test` block here, with `{name}` the product name (see below). |
 
 Optional metadata read by the `$project.*` comptime roots but not the build:
 `name`, `description`, `license`, `authors`.
@@ -256,14 +256,12 @@ is a hard error. Two artifacts that resolve to the same `out` path collide and
 fail at build start. A per-artifact or per-cell `out` overrides the project
 template for that artifact.
 
-The `tests` template is expanded the same way, except `{name}` is the **per-test
-name** rather than the artifact name (`{target}`/`{profile}`/`{ext}` resolve as
-usual). `mach test` substitutes `{name}` per test as `<index>-<sanitized label>`:
-the zero-based collection index keeps the name unique — test labels are not
-globally unique across modules — and stable, and every label byte outside
-`[A-Za-z0-9._-]` becomes `_` (the label portion is truncated to keep the name
-short). A test labeled `"parses empty input"` collected third lands at, e.g.,
-`out/linux/debug/test/2-parses_empty_input`.
+The `tests` template is expanded the same way and locates the single test
+dispatcher executable `mach test` builds (`{target}`/`{profile}`/`{ext}` resolve
+as usual). `{name}` is the selected artifact's product name, falling back to the
+project id for artifact-less (library) builds. The dispatcher embeds every
+collected test and runs the one selected by a decimal index argument, so a
+project's test build lands at, e.g., `out/linux/debug/test/mach`.
 
 ## Selection and the build matrix
 
@@ -318,7 +316,7 @@ out     = "out/{target}/bin/{name}{ext}"  # e.g. out/linux/bin/mach
 obj     = "out/{target}/obj"
 ir      = "out/{target}/ir"
 asm     = "out/{target}/asm"
-tests   = "out/{target}/test/{name}"      # e.g. out/linux/test/2-parses_empty_input
+tests   = "out/{target}/test/{name}"      # e.g. out/linux/test/myproj
 
 [target.linux]
 isa = "x86_64"

--- a/src/cli/cmd/build.mach
+++ b/src/cli/cmd/build.mach
@@ -25,7 +25,6 @@ use std.types.bool.false;
 use std.types.bool.true;
 use std.types.size.usize;
 use std.types.string.str;
-use std.types.string.str_contains;
 use std.types.string.str_empty;
 use std.types.string.str_equals;
 use std.types.string.str_len;
@@ -66,7 +65,7 @@ pub rec BuildResult {
     output_path: *u8;
 }
 
-# one built test - its reporting metadata and the executable path
+# one built test - its reporting metadata and its dispatch coordinates
 #
 # All owned strings come from the build allocator, so they outlive the session
 # teardown inside `build_tests` and stay valid until the caller frees that
@@ -77,13 +76,16 @@ pub rec BuildResult {
 # label:  owned printable test name (the `test "..."` literal's inner text)
 # file:   owned source file path of the declaring module
 # line:   1-based source line of the `test` keyword
-# exe:    owned absolute path to the test executable; nil in `--list` mode
+# exe:    owned absolute path to the shared dispatcher executable (the same
+#         path on every artifact of a build); nil in `--list` mode
+# idx:    the test's dispatch index - the dispatcher runs it for `<exe> <idx>`
 pub rec TestArtifact {
     module: *u8;
     label:  *u8;
     file:   *u8;
     line:   u32;
     exe:    *u8;
+    idx:    u32;
 }
 
 # the growing TestArtifact array a test build fills, in collection order
@@ -358,14 +360,15 @@ pub fun build(a: *A.Allocator, argc: usize, argv: **u8, emit_obj: bool) BuildRes
     ret build_unit(a, argc, argv, emit_obj, false, nil, nil, false);
 }
 
-# build one standalone executable per `test` declaration
+# build the single dispatcher executable covering every collected `test`
 #
-# Returns the per-test artifacts (label, source `file:line`, and executable
-# path) for the `mach test` runner to spawn. Every test executable is the
-# project's transitive code plus a synthesized `main` that calls just that test
-# and exits with its `i32` result - independently runnable, never the project's
-# own binary path. Only tests declared in the current project's own modules are
-# built by default; `--include-deps` widens the build to dependency tests (#1556).
+# Returns the per-test artifacts (label, source `file:line`, and dispatch
+# coordinates) for the `mach test` runner to spawn. The one executable is the
+# project's transitive code plus a synthesized dispatcher `main` that runs the
+# test selected by a decimal index argument and exits with its `i32` result -
+# never the project's own binary path. Only tests declared in the current
+# project's own modules are collected by default; `--include-deps` widens the
+# collection to dependency tests (#1556), changing what the dispatcher embeds.
 # With `list_only` the build stops after collecting the tests, leaving each
 # artifact's `exe` nil. The returned strings are owned by `a` and outlive this
 # call's internal session teardown, so the caller frees `a` once it has run every
@@ -443,8 +446,8 @@ pub fun selection_from_config(config: *cfg.Config, out_sel: *manifest.Selection)
 # `cmd.run`/`cmd.test` path); with `ovr` set they come from one enumerated
 # matrix cell (the `mach build` loop), the only field the override replaces -
 # profile and every other flag still apply to each unit. When `tests_out` is
-# non-nil the build is a test build: it produces one executable per `test`
-# declaration and fills `tests_out` instead of linking a single artifact
+# non-nil the build is a test build: it produces the single test dispatcher
+# executable and fills `tests_out` instead of linking the project artifact
 # (`list_only` stops after collection). `test_mode` mirrors `tests_out != nil`.
 # ---
 # a:         allocator owning the session and the returned artifact path
@@ -665,8 +668,8 @@ fun resolve_opt_level(p: *driver.Project, cli_level: u8, cli_set: bool) u8 {
 # Returns the exit code and sets `*out_path` to the produced artifact path on
 # success. `out_override` (-o), when non-nil, replaces the resolved artifact
 # path. When `tests_out` is non-nil the build is a test build: per-module
-# objects are written once and one executable is linked per `test` (filling
-# `tests_out`) rather than a single artifact; `list_only` stops after collecting
+# objects are written once and the single test dispatcher executable is linked
+# (filling `tests_out`) rather than the project artifact; `list_only` stops after collecting
 # the tests.
 # ---
 # p:            the project carrying the module graph and session
@@ -793,23 +796,25 @@ fun compile_and_link(p: *driver.Project, level: u8, emit_obj: bool, test_mode: b
     ret code;
 }
 
-# build one standalone executable per collected `test`
+# build the single dispatcher executable covering every in-scope `test`
 #
-# The per-module objects are written once under the resolved `obj` template; the
-# external link inputs (libc, manifest/CLI libs) are resolved once. Then, for
-# each selected `test`, a tiny entry module (`main(){ret <test>();}`) is
-# synthesized, optimized, codegen'd to its own object, and linked with the shared
-# object set into a standalone executable at the resolved `tests` template path.
-# Only tests declared in the current project's own modules are selected by
-# default; `--include-deps` widens the selection to dependency tests (#1556), and
-# `--filter` narrows it by name. Each test's reporting metadata (label, source
-# `file:line`) and executable path are appended to `tests_out`. With `list_only`
-# the collection alone is reported and no objects or executables are produced. A
+# The per-module objects are written once under the resolved `obj` template and
+# the external link inputs (libc, manifest/CLI libs) are resolved once. One
+# dispatcher entry module (`main(argc, argv)` selecting a test by decimal
+# index) is then synthesized over the in-scope tests, optimized, codegen'd, and
+# linked with the shared object set into one executable at the resolved `tests`
+# template path. Only tests declared in the current project's own modules are
+# in scope by default; `--include-deps` widens the scope to dependency tests
+# (#1556), changing what the dispatcher embeds. `--filter` is a run-time
+# selection in the runner, so the built executable is identical regardless of
+# filter. Each test's reporting metadata (label, source `file:line`) and its
+# dispatch coordinates are appended to `tests_out`. With `list_only` the
+# collection alone is reported and no objects or executables are produced. A
 # build with no tests is a user error.
 # ---
 # p:         the project carrying the module graph and session
 # level:     optimization pipeline level
-# verify_ir: run the IR verifier on each synthesized entry module
+# verify_ir: run the IR verifier on the synthesized dispatcher module
 # root:      the resolved project root directory
 # argc:      argument count including argv[0]
 # argv:      the argument vector (argc null-terminated byte pointers)
@@ -836,26 +841,44 @@ fun build_test_executables(p: *driver.Project, level: u8, verify_ir: bool,
         ret 1;
     }
 
-    # `--filter <substr>`: only the tests whose label contains the substring are
-    # built and reported. applied at build time so a filtered run builds only the
-    # matching executables. nil filter = every test.
-    val filter: *u8 = filter_value(argc, argv);
-
     # `--include-deps`: by default a test run is scoped to the current project's
-    # own modules; this flag also builds and runs tests declared in dependency
+    # own modules; this flag also embeds and runs tests declared in dependency
     # modules (#1556).
     val include_deps: bool = util.has_flag(argc, argv, "--include-deps");
 
-    # `--list`: report each selected test's metadata without producing any object.
-    if (list_only) {
-        var i: u32 = 0;
-        for (i < col.count) {
-            if (test_selected(p, ?col.tests[i], filter, include_deps)) {
-                val rc: i64 = record_test(p, ?col.tests[i], nil, tests_out, p.s.alloc);
-                if (rc != 0) { testrunner.free(p.s, ?col); ret rc; }
-            }
-            i = i + 1;
+    # the in-scope selection the dispatcher embeds; a test's dispatch index is
+    # its position here, stable for the built executable's lifetime.
+    val res_sel: R.Result[*testrunner.Test, str] = A.allocate[testrunner.Test](p.s.alloc, col.count::usize);
+    if (R.is_err[*testrunner.Test, str](res_sel)) {
+        testrunner.free(p.s, ?col);
+        print.eprint("error: out of memory\n");
+        ret 2;
+    }
+    val sel: *testrunner.Test = R.unwrap_ok[*testrunner.Test, str](res_sel);
+    var sel_len: u32 = 0;
+    var i: u32 = 0;
+    for (i < col.count) {
+        if (test_selected(p, ?col.tests[i], include_deps)) {
+            sel[sel_len] = col.tests[i];
+            sel_len = sel_len + 1;
         }
+        i = i + 1;
+    }
+
+    # `--list`: report each in-scope test's metadata without producing any object.
+    if (list_only) {
+        var k: u32 = 0;
+        for (k < sel_len) {
+            val rc: i64 = record_test(p, ?sel[k], nil, k, tests_out, p.s.alloc);
+            if (rc != 0) { testrunner.free(p.s, ?col); ret rc; }
+            k = k + 1;
+        }
+        testrunner.free(p.s, ?col);
+        ret 0;
+    }
+
+    # a scope that selected nothing builds nothing and runs nothing.
+    if (sel_len == 0) {
         testrunner.free(p.s, ?col);
         ret 0;
     }
@@ -891,14 +914,13 @@ fun build_test_executables(p: *driver.Project, level: u8, verify_ir: bool,
         ret ec;
     }
 
-    # each test's compile/link allocations (the synthesized entry IR, its codegen
-    # object image, the parsed link inputs, the merged output image, and the
-    # format unwind tables) route through a per-test scratch arena that is reset
-    # after every test, so peak memory stays bounded by a single test link rather
-    # than growing with the suite. a fresh page allocator backs the scratch arena
-    # so its reset actually returns the chunks to the OS; the shared per-module
-    # objects, the collected list, and each recorded artifact stay on the
-    # persistent allocator, which the reset never touches.
+    # the dispatcher's compile/link allocations (the synthesized entry IR, its
+    # codegen object image, the parsed link inputs, the merged output image, and
+    # the format unwind tables) route through a scratch arena torn down as soon
+    # as the executable is linked, so the transients never outlive the build. a
+    # fresh page allocator backs the arena so teardown actually returns the
+    # chunks to the OS; the shared per-module objects, the collected list, and
+    # each recorded artifact stay on the persistent allocator.
     var scratch_backing: A.Allocator;
     if (O.is_some[str](page.make(?scratch_backing))) {
         free_paths(p.s.alloc, shared, shared_len, shared_len);
@@ -925,63 +947,47 @@ fun build_test_executables(p: *driver.Project, level: u8, verify_ir: bool,
         ret 2;
     }
 
-    # the persistent build allocator, swapped back after every per-test build so
-    # the shared inputs, the collected list, and the recorded artifacts outlive
-    # the scratch reset.
+    # the persistent build allocator, swapped back once the dispatcher is built
+    # so the shared inputs, the collected list, and the recorded artifacts never
+    # touch the scratch arena.
     val persistent: *A.Allocator = p.s.alloc;
 
-    var code: i64 = 0;
-    var i: u32 = 0;
-    for (i < col.count) {
-        if (test_selected(p, ?col.tests[i], filter, include_deps)) {
-            # `i` is the stable collection index, so a test's executable name is
-            # unchanged whether or not a filter is in effect.
-            p.s.alloc = ?scratch_alloc;
-            code = build_one_test(p, level, verify_ir, ?obj_base[0], root, i, ?col.tests[i],
-                                  shared, shared_len, sonames, soname_len, tests_out, persistent);
-            p.s.alloc = persistent;
-            arena.reset(?scratch_ar);
+    var exe_path: [4096]u8;
+    p.s.alloc = ?scratch_alloc;
+    var code: i64 = build_dispatch_executable(p, level, verify_ir, ?obj_base[0], root,
+                                              sel, sel_len, shared, shared_len,
+                                              sonames, soname_len, ?exe_path[0], 4096);
+    p.s.alloc = persistent;
+    arena.dnit(?scratch_ar);
+
+    if (code == 0) {
+        var k: u32 = 0;
+        for (k < sel_len) {
+            code = record_test(p, ?sel[k], ?exe_path[0], k, tests_out, persistent);
             if (code != 0) { brk; }
+            k = k + 1;
         }
-        i = i + 1;
     }
 
-    arena.dnit(?scratch_ar);
     free_paths(p.s.alloc, shared, shared_len, shared_len);
     free_sonames(p.s.alloc, sonames, soname_len);
     testrunner.free(p.s, ?col);
     ret code;
 }
 
-# the `--filter <substr>` value from argv, or nil when absent
-# ---
-# argc: argument count including argv[0]
-# argv: the argument vector (argc null-terminated byte pointers)
-# ret:  the filter substring, or nil when `--filter` is absent
-fun filter_value(argc: usize, argv: **u8) *u8 {
-    val opt_filter: O.Option[*u8] = util.get_value(argc, argv, "--filter");
-    if (O.is_some[*u8](opt_filter)) { ret O.unwrap[*u8](opt_filter); }
-    ret nil;
-}
-
-# whether a test is selected for this run
+# whether a collected test is in scope for this run
 #
-# A test is selected when it is in scope - its declaring module is part of the
-# current project, unless `include_deps` opts dependency tests in (#1556) - and
-# passes the name filter (every test when `filter` is nil, else those whose label
-# contains the filter substring).
+# A test is in scope when its declaring module is part of the current project;
+# `include_deps` opts dependency tests in (#1556). Label filtering (`--filter`)
+# happens at run time in the runner, never here.
 # ---
-# p:            the project (for its interner and module table)
-# t:            the test to test
-# filter:       the filter substring, or nil to select every test
+# p:            the project (for its module table)
+# t:            the test to check
 # include_deps: also select tests declared in dependency modules
-# ret:          true when the test is selected
-fun test_selected(p: *driver.Project, t: *testrunner.Test, filter: *u8, include_deps: bool) bool {
-    if (!include_deps && !test_in_project(p, t)) { ret false; }
-    if (filter == nil) { ret true; }
-    val opt_label: O.Option[str] = intern.lookup(?p.s.interner, t.label);
-    if (O.is_none[str](opt_label)) { ret false; }
-    ret str_contains(O.unwrap[str](opt_label), util.cstr_str(filter));
+# ret:          true when the test is in scope
+fun test_selected(p: *driver.Project, t: *testrunner.Test, include_deps: bool) bool {
+    if (include_deps) { ret true; }
+    ret test_in_project(p, t);
 }
 
 # whether a collected test was declared in a current-project module rather than a
@@ -996,37 +1002,36 @@ fun test_in_project(p: *driver.Project, t: *testrunner.Test) bool {
     ret driver.module_in_current_project(p, m.fqn);
 }
 
-# synthesize, codegen, and link a single test's executable, then record its
-# artifact
+# synthesize, codegen, and link the dispatcher executable
 #
-# The entry module is `main(){ret <test>();}`; its object is written to
-# `<obj_base>/__mach_test_entry_<idx>.o` and linked with the shared object set
-# into the resolved `tests` path. The transient compile/link allocations come
-# from the session allocator, which the caller points at a per-test scratch arena
-# it resets afterward; the recorded artifact is duplicated into `persistent` so it
-# outlives that reset.
+# The entry module is the index dispatcher over `sel`; its object is written to
+# `<obj_base>/__mach_test_dispatch.o` and linked with the shared object set into
+# the resolved `tests` path, whose `{name}` is the product name (falling back to
+# the project id for artifact-less builds). The transient compile/link
+# allocations come from the session allocator, which the caller points at a
+# scratch arena it tears down afterward; the executable path lands in the
+# caller-owned `exe_buf`, which survives that teardown.
 # ---
 # p:          the project carrying the module graph and session
 # level:      optimization pipeline level
-# verify_ir:  run the IR verifier on the synthesized entry module
+# verify_ir:  run the IR verifier on the synthesized dispatcher module
 # obj_base:   the resolved per-module object tree root
 # root:       the resolved project root directory
-# idx:        the test's stable collection index
-# t:          the test to build
+# sel:        the in-scope tests, dispatch index = array position
+# sel_len:    number of tests in `sel`
 # shared:     the shared per-module object path set
 # shared_len: number of shared object paths
 # sonames:    the shared dynamic-dependency soname list
 # soname_len: number of sonames
-# tests_out:  the list to append the test's artifact to
-# persistent: allocator the recorded artifact is duplicated into, outliving the
-#             per-test scratch reset
+# exe_buf:    receives the executable path on success
+# exe_cap:    capacity of `exe_buf`
 # ret:        0 on success, or a non-zero exit code
-fun build_one_test(p: *driver.Project, level: u8, verify_ir: bool, obj_base: *u8, root: *u8,
-                   idx: u32, t: *testrunner.Test,
-                   shared: **u8, shared_len: u32,
-                   sonames: *intern.StrId, soname_len: u32,
-                   tests_out: *TestList, persistent: *A.Allocator) i64 {
-    val res_synth: R.Result[ir.Module, str] = testrunner.synthesize_entry(p.s, t.linkage);
+fun build_dispatch_executable(p: *driver.Project, level: u8, verify_ir: bool, obj_base: *u8, root: *u8,
+                              sel: *testrunner.Test, sel_len: u32,
+                              shared: **u8, shared_len: u32,
+                              sonames: *intern.StrId, soname_len: u32,
+                              exe_buf: *u8, exe_cap: usize) i64 {
+    val res_synth: R.Result[ir.Module, str] = testrunner.synthesize_dispatcher(p.s, sel, sel_len);
     if (R.is_err[ir.Module, str](res_synth)) {
         print.eprint("error: ");
         print.eprint(R.unwrap_err[ir.Module, str](res_synth));
@@ -1054,9 +1059,10 @@ fun build_one_test(p: *driver.Project, level: u8, verify_ir: bool, obj_base: *u8
     }
     var entry_img: of.ObjectImage = R.unwrap_ok[of.ObjectImage, str](res_codegen);
 
-    # write the entry object alongside the per-module objects.
+    # write the dispatcher object alongside the per-module objects.
     var entry_path: [4096]u8;
-    if (!entry_object_path(obj_base, idx, ?entry_path[0], 4096) || !util.ensure_parents(?entry_path[0])) {
+    if (util.join_into(?entry_path[0], 4096, obj_base, "__mach_test_dispatch.o") == 0
+        || !util.ensure_parents(?entry_path[0])) {
         obj.dnit(?entry_img);
         ir.dnit(?entry_ir);
         print.eprint("error: failed to create test object directory\n");
@@ -1072,19 +1078,27 @@ fun build_one_test(p: *driver.Project, level: u8, verify_ir: bool, obj_base: *u8
         ret 1;
     }
 
-    # the executable path: `<root>/<tests template with {name} = sanitized name>`.
-    var name_buf: [256]u8;
-    sanitize_test_name(?name_buf[0], 256, idx, t.label, ?p.s.interner);
-    var exe_path: [4096]u8;
-    if (!resolve_test_exe(p, root, util.cstr_str(?name_buf[0]), ?exe_path[0], 4096) || !util.ensure_parents(?exe_path[0])) {
+    # the executable path: `<root>/<tests template with {name} = product name>`.
+    if (!resolve_test_exe(p, root, util.cstr_str(dispatch_exe_name(p)), exe_buf, exe_cap)
+        || !util.ensure_parents(exe_buf)) {
         print.eprint("error: failed to resolve the test executable path; check the `tests` template in mach.toml\n");
         ret 2;
     }
 
-    val lc: i64 = link_one_test(p, shared, shared_len, sonames, soname_len, ?entry_path[0], ?exe_path[0]);
-    if (lc != 0) { ret lc; }
+    ret link_one_test(p, shared, shared_len, sonames, soname_len, ?entry_path[0], exe_buf);
+}
 
-    ret record_test(p, t, ?exe_path[0], tests_out, persistent);
+# the dispatcher executable's `{name}`: the selected artifact's product name,
+# falling back to the project id when no artifact is selected (a library build)
+# ---
+# p:   the project carrying the session and selected artifact config
+# ret: the borrowed null-terminated name, never empty
+fun dispatch_exe_name(p: *driver.Project) *u8 {
+    val product: *u8 = artifact_product_name(p);
+    if (str_len(util.cstr_str(product)) > 0) { ret product; }
+    val opt_id: O.Option[str] = intern.lookup(?p.s.interner, p.config.id);
+    if (O.is_some[str](opt_id)) { ret O.unwrap[str](opt_id)::*u8; }
+    ret "tests";
 }
 
 # the selected artifact's product name (the `[bin.<name>]`), resolved to a
@@ -1102,7 +1116,7 @@ fun artifact_product_name(p: *driver.Project) *u8 {
     ret ""::*u8;
 }
 
-# link the shared object set plus one test's entry object into the test
+# link the shared object set plus the dispatcher entry object into the test
 # executable at `exe_path`
 #
 # The shared paths are reused across tests, so the combined array borrows their
@@ -1143,17 +1157,19 @@ fun link_one_test(p: *driver.Project, shared: **u8, shared_len: u32,
 # append a test's reporting artifact to `tests_out`
 #
 # Duplicates every string into `a` so it outlives the session teardown and the
-# per-test scratch reset. `exe` is nil in `--list` mode.
+# dispatcher build's scratch teardown. `exe` is nil in `--list` mode.
 # ---
 # p:         the project (for its interner and source map)
 # t:         the test to record
-# exe:       the executable path, or nil in `--list` mode
+# exe:       the dispatcher executable path, or nil in `--list` mode
+# idx:       the test's dispatch index
 # tests_out: the list to append the artifact to
 # a:         allocator backing the duplicated strings and the list
 # ret:       0 on success, or a non-zero exit code
-fun record_test(p: *driver.Project, t: *testrunner.Test, exe: *u8, tests_out: *TestList, a: *A.Allocator) i64 {
+fun record_test(p: *driver.Project, t: *testrunner.Test, exe: *u8, idx: u32, tests_out: *TestList, a: *A.Allocator) i64 {
     var artifact: TestArtifact;
     artifact.line = t.line;
+    artifact.idx  = idx;
 
     artifact.module = dup_cstr(a, test_module_fqn(p, t.mod_idx));
     if (artifact.module == nil) { print.eprint("error: out of memory\n"); ret 2; }
@@ -1234,27 +1250,6 @@ fun test_source_path(p: *driver.Project, mod_idx: u32) *u8 {
     val opt_file: O.Option[*source.SourceFile] = source.get(?p.s.sources, m.file_id);
     if (O.is_none[*source.SourceFile](opt_file)) { ret "<unknown>"; }
     ret O.unwrap[*source.SourceFile](opt_file).path::*u8;
-}
-
-# compose `<obj_base>/__mach_test_entry_<idx>.o` into `buf`
-# ---
-# obj_base: the per-module object tree root
-# idx:      the test's collection index
-# buf:      the destination buffer
-# cap:      the buffer capacity
-# ret:      false if it would not fit
-fun entry_object_path(obj_base: *u8, idx: u32, buf: *u8, cap: usize) bool {
-    var leaf: [64]u8;
-    var k:    usize = 0;
-    val prefix: str   = "__mach_test_entry_";
-    val pl:     usize = str_len(prefix);
-    var i: usize = 0;
-    for (i < pl) { leaf[k] = prefix[i]; k = k + 1; i = i + 1; }
-    k = k + write_u32(?leaf[k], 64 - k, idx);
-    leaf[k] = '.'; k = k + 1;
-    leaf[k] = 'o'; k = k + 1;
-    leaf[k] = 0;
-    ret util.join_into(buf, cap, obj_base, ?leaf[0]) > 0;
 }
 
 # write the `{name}` for a test's executable into `buf` as `<idx>-<label>`

--- a/src/cli/cmd/help.mach
+++ b/src/cli/cmd/help.mach
@@ -131,18 +131,19 @@ fun help_run() {
 fun help_test() {
     print.print("usage: mach test <path> [options]\n");
     print.print("\n");
-    print.print("build one standalone executable per 'test' declaration (under the\n");
-    print.print("'tests' template) and run each as a separate process, reporting\n");
-    print.print("'name file:line PASS|FAIL'. a crash reports its signal and the run\n");
-    print.print("continues. only the current project's own tests run by default;\n");
-    print.print("all 'mach build' and global flags apply.\n");
+    print.print("build one dispatcher executable covering every 'test' declaration\n");
+    print.print("(under the 'tests' template) and run each test as its own process\n");
+    print.print("('<exe> <idx>'), reporting a per-module roll-up that expands failures.\n");
+    print.print("a crash reports its signal and the run continues. only the current\n");
+    print.print("project's own tests run by default; all 'mach build' and global\n");
+    print.print("flags apply.\n");
     print.print("\n");
     print.print("options:\n");
     print.print("  --filter <substr>   run only tests whose name contains <substr>\n");
     print.print("  --include-deps      also run tests declared in dependency modules\n");
     print.print("  --list              list the collected tests and exit\n");
-    print.print("  --runner <cmd>      launch every test as '<cmd> <exe>'. <cmd> is a\n");
-    print.print("                      single command name or path (no shell splitting),\n");
+    print.print("  --runner <cmd>      launch every test as '<cmd> <exe> <idx>'. <cmd> is\n");
+    print.print("                      a single command name or path (no shell splitting),\n");
     print.print("                      resolved on PATH. for foreign-target tests, e.g.\n");
     print.print("                      --target windows --runner wine\n");
     print.print("\n");

--- a/src/cli/cmd/testing.mach
+++ b/src/cli/cmd/testing.mach
@@ -1,10 +1,12 @@
-# `mach test` - build one executable per test, run each as a separate process,
-# and report a per-module roll-up.
+# `mach test` - build one dispatcher executable, run each test as a separate
+# process, and report a per-module roll-up.
 #
-# `mach test` compiles every `test "..."` block into its own standalone
-# executable (the test plus the project's transitive code, with a synthesized
-# `main` that calls just that test). this command spawns each executable as a
-# separate process, captures its output, times it, and reads its exit status.
+# `mach test` compiles the project's `test "..."` blocks into a single
+# executable (the project's transitive code plus a synthesized dispatcher
+# `main` that runs the test selected by a decimal index argument). this command
+# spawns that executable once per test as `<exe> <idx>`, captures each child's
+# output, times it, and reads its exit status - per-test process isolation is
+# unchanged, only the build is shared.
 #
 # the default readout collapses every all-passing module to a single roll-up
 # line (`mach.lang.driver  36 ok  41ms`) and expands any module with failures,
@@ -23,11 +25,12 @@
 # by default only `test` blocks declared in the current project's own modules are
 # collected; `--include-deps` widens collection to dependency modules too (#1556).
 # `--list` prints the collected tests without building or running them.
-# `--filter <substr>` selects the tests whose name contains the substring.
-# `--runner <cmd>` launches every test as `<cmd> <exe>` instead of spawning the
-# executable directly - the host-side launcher for foreign-target artifacts
-# (e.g. wine for a windows target, #1345). absent the flag, executables are
-# spawned directly and a spawn failure reports exactly that.
+# `--filter <substr>` selects the tests whose name contains the substring; it is
+# applied here at run time, so the built executable is identical regardless of
+# filter. `--runner <cmd>` launches every test as `<cmd> <exe> <idx>` instead of
+# spawning the executable directly - the host-side launcher for foreign-target
+# artifacts (e.g. wine for a windows target, #1345). absent the flag, the
+# executable is spawned directly and a spawn failure reports exactly that.
 #
 # spawning and output capture go through `std.process`, which is multiplatform
 # (linux, darwin, windows), so the readout behaves identically on every host.
@@ -41,6 +44,7 @@ use std.types.bool.false;
 use std.types.bool.true;
 use std.types.size.usize;
 use std.types.string.str;
+use std.types.string.str_contains;
 use std.types.string.str_equals;
 use std.types.string.str_len;
 use std.types.string.str_starts_with;
@@ -129,17 +133,45 @@ pub fun run(argc: usize, argv: **u8) i64 {
         ret tbr.code;
     }
 
-    # the build has already applied `--filter`, so every returned artifact runs.
-    # `--list`: report each test's `label file:line`, no execution.
+    # `--filter <substr>` selects at run time: the dispatcher embeds every
+    # in-scope test, this command runs (or lists) only the matching ones.
+    var filter: *u8 = nil;
+    val opt_filter: O.Option[*u8] = util.get_value(argc, argv, "--filter");
+    if (O.is_some[*u8](opt_filter)) { filter = O.unwrap[*u8](opt_filter); }
+
+    # `--list`: report each selected test's `label file:line`, no execution.
     if (list) {
         var i: u32 = 0;
         for (i < tbr.len) {
-            artifact_report(?tbr.tests[i]);
-            print.print("\n");
+            if (filter_matches(?tbr.tests[i], filter)) {
+                artifact_report(?tbr.tests[i]);
+                print.print("\n");
+            }
             i = i + 1;
         }
         arena.dnit(?ar);
         ret 0;
+    }
+
+    # the selected artifacts, in collection order (module runs stay adjacent).
+    var selected: *build.TestArtifact = nil;
+    var sel_len:  u32 = 0;
+    if (tbr.len > 0) {
+        val res_sel: R.Result[*build.TestArtifact, str] = A.allocate[build.TestArtifact](?a, tbr.len::usize);
+        if (R.is_err[*build.TestArtifact, str](res_sel)) {
+            arena.dnit(?ar);
+            print.eprint("error: out of memory\n");
+            ret 2;
+        }
+        selected = R.unwrap_ok[*build.TestArtifact, str](res_sel);
+        var i: u32 = 0;
+        for (i < tbr.len) {
+            if (filter_matches(?tbr.tests[i], filter)) {
+                selected[sel_len] = tbr.tests[i];
+                sel_len = sel_len + 1;
+            }
+            i = i + 1;
+        }
     }
 
     # `--runner <cmd>`: launch each test as `<cmd> <exe>`. resolved to a concrete
@@ -163,14 +195,14 @@ pub fun run(argc: usize, argv: **u8) i64 {
     }
 
     # a filtered run that matched nothing has no work and no failures.
-    if (tbr.len == 0) {
+    if (sel_len == 0) {
         print.print("0 passed, 0 failed, 0 total  (0ms)\n");
         arena.dnit(?ar);
         ret 0;
     }
 
-    # one Outcome per test, plus a single reused stdout capture buffer.
-    val res_out: R.Result[*Outcome, str] = A.allocate[Outcome](?a, tbr.len::usize);
+    # one Outcome per selected test, plus a single reused stdout capture buffer.
+    val res_out: R.Result[*Outcome, str] = A.allocate[Outcome](?a, sel_len::usize);
     if (R.is_err[*Outcome, str](res_out)) {
         arena.dnit(?ar);
         print.eprint("error: out of memory\n");
@@ -186,21 +218,21 @@ pub fun run(argc: usize, argv: **u8) i64 {
     }
     val buf: *u8 = R.unwrap_ok[*u8, str](res_buf);
 
-    execute_all(?a, ?tbr, runner, outcomes, buf);
+    execute_all(?a, selected, sel_len, runner, outcomes, buf);
 
-    if (verbose) { render_verbose(outcomes, tbr.len); }
-    or          { render_default(outcomes, tbr.len); }
+    if (verbose) { render_verbose(outcomes, sel_len); }
+    or          { render_default(outcomes, sel_len); }
 
-    val failed: u32 = count_failed(outcomes, tbr.len);
-    val passed: u32 = tbr.len - failed;
-    render_summary(outcomes, tbr.len, passed, failed);
+    val failed: u32 = count_failed(outcomes, sel_len);
+    val passed: u32 = sel_len - failed;
+    render_summary(outcomes, sel_len, passed, failed);
 
     arena.dnit(?ar);
     if (failed > 0) { ret 1; }
     ret 0;
 }
 
-# spawn every test, capturing its stdout and timing it, into `outcomes`
+# spawn every selected test, capturing its stdout and timing it, into `outcomes`
 #
 # Each child is run with its stdout piped and drained to EOF (capture), so a
 # chatty test cannot deadlock the runner; stderr is inherited. A failing test's
@@ -208,26 +240,34 @@ pub fun run(argc: usize, argv: **u8) i64 {
 # they survive the next test overwriting the buffer.
 # ---
 # a:        allocator retaining each failing test's captured output
-# tbr:      the built test artifacts to run
-# runner:   resolved `--runner` launcher, or nil to exec each test directly
-# outcomes: caller-owned array (length tbr.len) filled in test order
+# arts:     the selected test artifacts to run, in collection order
+# n:        number of artifacts in `arts`
+# runner:   resolved `--runner` launcher, or nil to exec the dispatcher directly
+# outcomes: caller-owned array (length n) filled in test order
 # buf:      the reused capture buffer (CAP_OUTPUT bytes)
-fun execute_all(a: *A.Allocator, tbr: *build.TestBuildResult, runner: *u8, outcomes: *Outcome, buf: *u8) {
+fun execute_all(a: *A.Allocator, arts: *build.TestArtifact, n: u32, runner: *u8, outcomes: *Outcome, buf: *u8) {
     var i: u32 = 0;
-    for (i < tbr.len) {
-        val art: *build.TestArtifact = ?tbr.tests[i];
+    for (i < n) {
+        val art: *build.TestArtifact = ?arts[i];
 
-        # child argv: [exe] directly, or [runner, exe] under --runner. argv[0]
-        # doubles as the pathname the spawn receives, so a runner needs no PATH search.
-        var child_argv: [3]*u8;
+        # the test's dispatch index, rendered for the child's argv
+        var ibuf: [16]u8;
+        write_index(?ibuf[0], 16, art.idx);
+
+        # child argv: [exe, idx] directly, or [runner, exe, idx] under --runner.
+        # argv[0] doubles as the pathname the spawn receives, so a runner needs
+        # no PATH search.
+        var child_argv: [4]*u8;
         if (runner != nil) {
             child_argv[0] = runner;
             child_argv[1] = art.exe;
-            child_argv[2] = nil;
+            child_argv[2] = ?ibuf[0];
+            child_argv[3] = nil;
         }
         or {
             child_argv[0] = art.exe;
-            child_argv[1] = nil;
+            child_argv[1] = ?ibuf[0];
+            child_argv[2] = nil;
         }
 
         var o: Outcome;
@@ -549,4 +589,32 @@ fun artifact_report(art: *build.TestArtifact) {
     print.print(art.file::str);
     print.print(":");
     print.u64(art.line::u64);
+}
+
+# whether an artifact passes the `--filter` selection (every artifact when
+# `filter` is nil, else those whose label contains the substring)
+# ---
+# art:    the artifact to check
+# filter: the filter substring, or nil to select everything
+# ret:    true when selected
+fun filter_matches(art: *build.TestArtifact, filter: *u8) bool {
+    if (filter == nil) { ret true; }
+    ret str_contains(util.cstr_str(art.label), util.cstr_str(filter));
+}
+
+# write the decimal text of `n` into `buf`, null-terminated (the dispatch
+# index argument handed to the test executable)
+# ---
+# buf: the destination buffer
+# cap: the buffer capacity (must hold the digits plus the terminator)
+# n:   the value to render
+fun write_index(buf: *u8, cap: usize, n: u32) {
+    var tmp: [16]u8;
+    var t:   usize = 0;
+    var v:   u32   = n;
+    if (v == 0) { tmp[0] = '0'; t = 1; }
+    for (v > 0) { tmp[t] = (v % 10)::u8 + '0'; v = v / 10; t = t + 1; }
+    var k: usize = 0;
+    for (k < t && k + 1 < cap) { buf[k] = tmp[t - 1 - k]; k = k + 1; }
+    buf[k] = 0;
 }

--- a/src/lang/me/lower/testrunner.mach
+++ b/src/lang/me/lower/testrunner.mach
@@ -1,23 +1,24 @@
-# synthesizes one standalone entry per `test`.
+# synthesizes the single test dispatcher entry for a test build.
 #
-# `mach test` builds every `test "..."` block into its own small executable: the
-# test function plus the project's transitive code, with a synthesized `main`
-# that calls just that one test and returns its `i32` result as the process exit
-# status (0 = pass, non-zero = fail). the per-test executables are run as
-# separate processes by `mach test`, so a crashing test reports a signal and the
-# run continues.
+# `mach test` builds one executable per test build: the project's transitive
+# code plus a synthesized dispatcher `main(argc, argv)` that selects one test by
+# its decimal collection index in `argv[1]`, calls it, and returns its `i32`
+# result as the process exit status (0 = pass, non-zero = fail). the runner
+# still spawns one process per test (`<exe> <idx>`), so a crashing test reports
+# a signal and the run continues; a missing, malformed, or out-of-range index
+# exits 2, the harness's internal-error code.
 #
 # this module does two jobs for that build:
 #   - `collect` gathers every `FN_FLAG_TEST` function across the lowered module
 #     set into a `Collected` list (linkage name, printable label, source line,
 #     and the index of the declaring module, for `file:line` reporting).
-#   - `synthesize_entry` builds, for one collected test, a tiny IR module whose
-#     `main` is `ret <test>();` - a signature-only extern for the test symbol
-#     plus a two-instruction body. it carries no OS interaction of its own, so it
-#     works for any target with or without a standard library.
+#   - `synthesize_dispatcher` builds one IR module: a signature-only extern per
+#     selected test plus the dispatching `main`. argv arrives as `main`
+#     parameters from the target runtime, so the synthesized IR itself stays
+#     stdlib-independent.
 #
 # `neutralize_project_main` turns the project's own `main` into a body-less
-# extern so each test executable's sole program entry is the synthesized one.
+# extern so the test executable's sole program entry is the synthesized one.
 
 use std.types.bool.bool;
 use std.types.bool.true;
@@ -123,8 +124,8 @@ pub fun free(s: *session.Session, c: *Collected) {
 }
 
 # turn every function whose linkage name is literally `main` into a body-less
-# extern, so a test executable's sole program entry is the synthesized per-test
-# `main`
+# extern, so the test executable's sole program entry is the synthesized
+# dispatcher `main`
 #
 # The dropped blocks are reclaimed by the module's own dnit; a test build never
 # references the project's `main`, so the extern emits nothing. Called between
@@ -159,20 +160,25 @@ pub fun neutralize_project_main(s: *session.Session, modules: *ir.Module, count:
     ret R.ok[bool, str](true);
 }
 
-# build a fresh IR module whose `main` calls the single test named by `linkage`
-# and returns its i32 result as the process exit status
+# build a fresh IR module whose `main(argc, argv)` dispatches `argv[1]` (a
+# decimal collection index) to the matching test and returns its i32 result as
+# the process exit status
 #
-# The module declares the test symbol as a signature-only `i32()` extern (the
-# linker binds it to the test's defining object) and emits `main` as
-# `ret <test>();`. The caller optimises, codegens, and links it with the
-# project's per-module objects into one standalone test executable. The returned
-# module is owned by the caller (ir.dnit).
+# The module declares each test symbol as a signature-only `i32()` extern (the
+# linker binds them to their defining objects). `main` returns 2 - the
+# harness's internal-error exit code - for a missing, empty, malformed, or
+# out-of-range index. The caller optimises, codegens, and links the module with
+# the project's per-module objects into the single test executable. The
+# returned module is owned by the caller (ir.dnit).
 # ---
-# s:       session holding the string interner and allocator
-# linkage: linkage name of the test symbol `main` should call
-# ret:     the synthesized module, or an allocation error
-pub fun synthesize_entry(s: *session.Session, linkage: intern.StrId) R.Result[ir.Module, str] {
-    val res_name: R.Result[intern.StrId, str] = intern.intern(?s.interner, "__mach_test_entry");
+# s:     session holding the string interner and allocator
+# tests: the selected tests, dispatch index = array position
+# count: number of tests in `tests`
+# ret:   the synthesized module, or an error
+pub fun synthesize_dispatcher(s: *session.Session, tests: *Test, count: u32) R.Result[ir.Module, str] {
+    if (count == 0) { ret R.err[ir.Module, str]("test dispatcher: no tests to dispatch"); }
+
+    val res_name: R.Result[intern.StrId, str] = intern.intern(?s.interner, "__mach_test_dispatch");
     if (R.is_err[intern.StrId, str](res_name)) {
         ret R.err[ir.Module, str](R.unwrap_err[intern.StrId, str](res_name));
     }
@@ -183,7 +189,7 @@ pub fun synthesize_entry(s: *session.Session, linkage: intern.StrId) R.Result[ir
     }
     var m: ir.Module = R.unwrap_ok[ir.Module, str](res_module);
 
-    val res_build: R.Result[bool, str] = build_entry(s, ?m, linkage);
+    val res_build: R.Result[bool, str] = build_dispatcher(s, ?m, tests, count);
     if (R.is_err[bool, str](res_build)) {
         ir.dnit(?m);
         ret R.err[ir.Module, str](R.unwrap_err[bool, str](res_build));
@@ -227,61 +233,240 @@ fun push_test(s: *session.Session, c: *Collected, t: Test) R.Result[bool, str] {
     ret R.ok[bool, str](true);
 }
 
-# emit the test symbol's extern and the `main(){ ret <test>(); }` body into `m`
+# emit the per-test externs and the dispatching `main(argc, argv)` body into `m`
+#
+# The CFG is: entry checks `argc >= 2`; getarg loads `argv[1]` and rejects an
+# empty string; a phi loop parses the decimal index (any non-digit byte exits
+# 2); a compare/branch chain then dispatches the index to its test call, whose
+# i32 result is sign-extended and returned. All failure paths return 2, the
+# harness's internal-error exit code, distinguishable from a test's own failure.
 # ---
-# s:       session holding the string interner
-# m:       the module to populate
-# linkage: linkage name of the test symbol to call
-# ret:     true on success, or an allocation error
-fun build_entry(s: *session.Session, m: *ir.Module, linkage: intern.StrId) R.Result[bool, str] {
+# s:     session holding the string interner
+# m:     the module to populate
+# tests: the selected tests, dispatch index = array position
+# count: number of tests in `tests`
+# ret:   true on success, or an error
+fun build_dispatcher(s: *session.Session, m: *ir.Module, tests: *Test, count: u32) R.Result[bool, str] {
+    val res_i8: R.Result[type.IrTypeId, str] = type.intern_int(?m.types, 8);
+    if (R.is_err[type.IrTypeId, str](res_i8)) { ret R.err[bool, str](R.unwrap_err[type.IrTypeId, str](res_i8)); }
+    val i8t: type.IrTypeId = R.unwrap_ok[type.IrTypeId, str](res_i8);
+
     val res_i32: R.Result[type.IrTypeId, str] = type.intern_int(?m.types, 32);
-    if (R.is_err[type.IrTypeId, str](res_i32)) {
-        ret R.err[bool, str](R.unwrap_err[type.IrTypeId, str](res_i32));
-    }
-    val i32: type.IrTypeId = R.unwrap_ok[type.IrTypeId, str](res_i32);
+    if (R.is_err[type.IrTypeId, str](res_i32)) { ret R.err[bool, str](R.unwrap_err[type.IrTypeId, str](res_i32)); }
+    val i32t: type.IrTypeId = R.unwrap_ok[type.IrTypeId, str](res_i32);
 
-    val res_sig: R.Result[type.IrTypeId, str] = type.intern_fn(?m.types, i32, nil, 0);
-    if (R.is_err[type.IrTypeId, str](res_sig)) {
-        ret R.err[bool, str](R.unwrap_err[type.IrTypeId, str](res_sig));
-    }
-    val sig: type.IrTypeId = R.unwrap_ok[type.IrTypeId, str](res_sig);
+    val res_i64: R.Result[type.IrTypeId, str] = type.intern_int(?m.types, 64);
+    if (R.is_err[type.IrTypeId, str](res_i64)) { ret R.err[bool, str](R.unwrap_err[type.IrTypeId, str](res_i64)); }
+    val i64t: type.IrTypeId = R.unwrap_ok[type.IrTypeId, str](res_i64);
 
-    # the test symbol, declared signature-only so the call resolves across objects
-    val res_ext: R.Result[u32, str] = append_function(m, linkage, sig, ir.FN_FLAG_EXTERN);
-    if (R.is_err[u32, str](res_ext)) {
-        ret R.err[bool, str](R.unwrap_err[u32, str](res_ext));
+    val res_ptr: R.Result[type.IrTypeId, str] = type.intern_ptr(?m.types);
+    if (R.is_err[type.IrTypeId, str](res_ptr)) { ret R.err[bool, str](R.unwrap_err[type.IrTypeId, str](res_ptr)); }
+    val ptrt: type.IrTypeId = R.unwrap_ok[type.IrTypeId, str](res_ptr);
+
+    # every test shares the `i32()` signature; main is `i64(i64, **u8)`, the
+    # contract the runtime start calls (`fun main(argc: i64, argv: **u8) i64`).
+    val res_tsig: R.Result[type.IrTypeId, str] = type.intern_fn(?m.types, i32t, nil, 0);
+    if (R.is_err[type.IrTypeId, str](res_tsig)) { ret R.err[bool, str](R.unwrap_err[type.IrTypeId, str](res_tsig)); }
+    val tsig: type.IrTypeId = R.unwrap_ok[type.IrTypeId, str](res_tsig);
+
+    var main_params: [2]type.IrTypeId;
+    main_params[0] = i64t;
+    main_params[1] = ptrt;
+    val res_msig: R.Result[type.IrTypeId, str] = type.intern_fn(?m.types, i64t, ?main_params[0], 2);
+    if (R.is_err[type.IrTypeId, str](res_msig)) { ret R.err[bool, str](R.unwrap_err[type.IrTypeId, str](res_msig)); }
+    val msig: type.IrTypeId = R.unwrap_ok[type.IrTypeId, str](res_msig);
+
+    # the test symbols, declared signature-only so each call resolves across objects
+    val res_callees: R.Result[*value.Value, str] = A.allocate[value.Value](m.alloc, count::usize);
+    if (R.is_err[*value.Value, str](res_callees)) { ret R.err[bool, str](R.unwrap_err[*value.Value, str](res_callees)); }
+    val callees: *value.Value = R.unwrap_ok[*value.Value, str](res_callees);
+
+    var k: u32 = 0;
+    for (k < count) {
+        val res_ext: R.Result[u32, str] = append_function(m, tests[k].linkage, tsig, ir.FN_FLAG_EXTERN);
+        if (R.is_err[u32, str](res_ext)) { ret R.err[bool, str](R.unwrap_err[u32, str](res_ext)); }
+        callees[k] = value.fn(R.unwrap_ok[u32, str](res_ext), tsig);
+        k = k + 1;
     }
-    val callee: value.Value = value.fn(R.unwrap_ok[u32, str](res_ext), sig);
 
     # `main` is emitted verbatim: a synthesized module is not run through the
-    # export registry, so the OS entry calls the literal `main`. its body is one
-    # call to the test and a return of the i32 result, which the process exit
-    # status carries (0 = pass).
+    # export registry, so the OS entry calls the literal `main`.
     val res_main: R.Result[intern.StrId, str] = intern.intern(?s.interner, "main");
-    if (R.is_err[intern.StrId, str](res_main)) {
-        ret R.err[bool, str](R.unwrap_err[intern.StrId, str](res_main));
-    }
-    val res_main_idx: R.Result[u32, str] = append_function(m, R.unwrap_ok[intern.StrId, str](res_main), sig, ir.FN_FLAG_PUB);
-    if (R.is_err[u32, str](res_main_idx)) {
-        ret R.err[bool, str](R.unwrap_err[u32, str](res_main_idx));
-    }
+    if (R.is_err[intern.StrId, str](res_main)) { ret R.err[bool, str](R.unwrap_err[intern.StrId, str](res_main)); }
+    val res_main_idx: R.Result[u32, str] = append_function(m, R.unwrap_ok[intern.StrId, str](res_main), msig, ir.FN_FLAG_PUB);
+    if (R.is_err[u32, str](res_main_idx)) { ret R.err[bool, str](R.unwrap_err[u32, str](res_main_idx)); }
     val main_idx: u32 = R.unwrap_ok[u32, str](res_main_idx);
+
+    # the function's VAL_PARAM array; codegen maps parameter vregs from it, so
+    # a function that reads its params must carry it (function_add leaves none)
+    val res_params: R.Result[*value.Value, str] = A.allocate[value.Value](m.alloc, 2);
+    if (R.is_err[*value.Value, str](res_params)) { ret R.err[bool, str](R.unwrap_err[*value.Value, str](res_params)); }
+    val params: *value.Value = R.unwrap_ok[*value.Value, str](res_params);
+    params[0] = value.param(0, i64t);
+    params[1] = value.param(1, ptrt);
+    m.functions[main_idx].params      = params;
+    m.functions[main_idx].param_count = 2;
 
     var b: builder.Builder = builder.init(m);
     builder.set_function(?b, ?m.functions[main_idx]);
 
-    val res_block: R.Result[id.BlockId, str] = builder.new_block(?b);
-    if (R.is_err[id.BlockId, str](res_block)) {
-        ret R.err[bool, str](R.unwrap_err[id.BlockId, str](res_block));
-    }
-    builder.set_block(?b, R.unwrap_ok[id.BlockId, str](res_block));
+    val res_entry: R.Result[id.BlockId, str] = builder.new_block(?b);
+    if (R.is_err[id.BlockId, str](res_entry)) { ret R.err[bool, str](R.unwrap_err[id.BlockId, str](res_entry)); }
+    val b_entry: id.BlockId = R.unwrap_ok[id.BlockId, str](res_entry);
 
-    val res_call: R.Result[value.Value, str] = builder.emit_call(?b, callee, nil, 0, i32);
-    if (R.is_err[value.Value, str](res_call)) {
-        ret R.err[bool, str](R.unwrap_err[value.Value, str](res_call));
+    val res_bad: R.Result[id.BlockId, str] = builder.new_block(?b);
+    if (R.is_err[id.BlockId, str](res_bad)) { ret R.err[bool, str](R.unwrap_err[id.BlockId, str](res_bad)); }
+    val b_bad: id.BlockId = R.unwrap_ok[id.BlockId, str](res_bad);
+
+    val res_getarg: R.Result[id.BlockId, str] = builder.new_block(?b);
+    if (R.is_err[id.BlockId, str](res_getarg)) { ret R.err[bool, str](R.unwrap_err[id.BlockId, str](res_getarg)); }
+    val b_getarg: id.BlockId = R.unwrap_ok[id.BlockId, str](res_getarg);
+
+    val res_head: R.Result[id.BlockId, str] = builder.new_block(?b);
+    if (R.is_err[id.BlockId, str](res_head)) { ret R.err[bool, str](R.unwrap_err[id.BlockId, str](res_head)); }
+    val b_head: id.BlockId = R.unwrap_ok[id.BlockId, str](res_head);
+
+    val res_low: R.Result[id.BlockId, str] = builder.new_block(?b);
+    if (R.is_err[id.BlockId, str](res_low)) { ret R.err[bool, str](R.unwrap_err[id.BlockId, str](res_low)); }
+    val b_low_ok: id.BlockId = R.unwrap_ok[id.BlockId, str](res_low);
+
+    val res_body: R.Result[id.BlockId, str] = builder.new_block(?b);
+    if (R.is_err[id.BlockId, str](res_body)) { ret R.err[bool, str](R.unwrap_err[id.BlockId, str](res_body)); }
+    val b_body: id.BlockId = R.unwrap_ok[id.BlockId, str](res_body);
+
+    # the dispatch chain and call blocks, one pair per test
+    val res_dblocks: R.Result[*id.BlockId, str] = A.allocate[id.BlockId](m.alloc, count::usize);
+    if (R.is_err[*id.BlockId, str](res_dblocks)) { ret R.err[bool, str](R.unwrap_err[*id.BlockId, str](res_dblocks)); }
+    val dblocks: *id.BlockId = R.unwrap_ok[*id.BlockId, str](res_dblocks);
+
+    val res_cblocks: R.Result[*id.BlockId, str] = A.allocate[id.BlockId](m.alloc, count::usize);
+    if (R.is_err[*id.BlockId, str](res_cblocks)) { ret R.err[bool, str](R.unwrap_err[*id.BlockId, str](res_cblocks)); }
+    val cblocks: *id.BlockId = R.unwrap_ok[*id.BlockId, str](res_cblocks);
+
+    k = 0;
+    for (k < count) {
+        val res_d: R.Result[id.BlockId, str] = builder.new_block(?b);
+        if (R.is_err[id.BlockId, str](res_d)) { ret R.err[bool, str](R.unwrap_err[id.BlockId, str](res_d)); }
+        dblocks[k] = R.unwrap_ok[id.BlockId, str](res_d);
+
+        val res_c: R.Result[id.BlockId, str] = builder.new_block(?b);
+        if (R.is_err[id.BlockId, str](res_c)) { ret R.err[bool, str](R.unwrap_err[id.BlockId, str](res_c)); }
+        cblocks[k] = R.unwrap_ok[id.BlockId, str](res_c);
+        k = k + 1;
     }
 
-    ret builder.emit_ret(?b, R.unwrap_ok[value.Value, str](res_call));
+    val argc: value.Value = value.param(0, i64t);
+    val argv: value.Value = value.param(1, ptrt);
+
+    # entry: argc < 2 -> bad
+    builder.set_block(?b, b_entry);
+    val res_lt2: R.Result[value.Value, str] = builder.emit_cmp_lt_s(?b, argc, value.const_int(2, i64t));
+    if (R.is_err[value.Value, str](res_lt2)) { ret R.err[bool, str](R.unwrap_err[value.Value, str](res_lt2)); }
+    val res_cbr0: R.Result[bool, str] = builder.emit_cbr(?b, R.unwrap_ok[value.Value, str](res_lt2), b_bad, b_getarg);
+    if (R.is_err[bool, str](res_cbr0)) { ret res_cbr0; }
+
+    # bad: every rejection exits 2
+    builder.set_block(?b, b_bad);
+    val res_ret2: R.Result[bool, str] = builder.emit_ret(?b, value.const_int(2, i64t));
+    if (R.is_err[bool, str](res_ret2)) { ret res_ret2; }
+
+    # getarg: arg = argv[1]; an empty string is malformed
+    builder.set_block(?b, b_getarg);
+    var one_idx: [1]value.Value;
+    one_idx[0] = value.const_int(1, i64t);
+    val res_gep1: R.Result[value.Value, str] = builder.emit_gep(?b, argv, ptrt, ?one_idx[0], 1);
+    if (R.is_err[value.Value, str](res_gep1)) { ret R.err[bool, str](R.unwrap_err[value.Value, str](res_gep1)); }
+    val res_arg: R.Result[value.Value, str] = builder.emit_load(?b, R.unwrap_ok[value.Value, str](res_gep1), ptrt);
+    if (R.is_err[value.Value, str](res_arg)) { ret R.err[bool, str](R.unwrap_err[value.Value, str](res_arg)); }
+    val arg: value.Value = R.unwrap_ok[value.Value, str](res_arg);
+    val res_c0: R.Result[value.Value, str] = builder.emit_load(?b, arg, i8t);
+    if (R.is_err[value.Value, str](res_c0)) { ret R.err[bool, str](R.unwrap_err[value.Value, str](res_c0)); }
+    val res_c0z: R.Result[value.Value, str] = builder.emit_cmp_eq(?b, R.unwrap_ok[value.Value, str](res_c0), value.const_int(0, i8t));
+    if (R.is_err[value.Value, str](res_c0z)) { ret R.err[bool, str](R.unwrap_err[value.Value, str](res_c0z)); }
+    val res_cbr1: R.Result[bool, str] = builder.emit_cbr(?b, R.unwrap_ok[value.Value, str](res_c0z), b_bad, b_head);
+    if (R.is_err[bool, str](res_cbr1)) { ret res_cbr1; }
+
+    # head: p/acc flow around the digit loop; a NUL ends the number
+    builder.set_block(?b, b_head);
+    val res_pphi: R.Result[value.Value, str] = builder.emit_phi(?b, ptrt);
+    if (R.is_err[value.Value, str](res_pphi)) { ret R.err[bool, str](R.unwrap_err[value.Value, str](res_pphi)); }
+    val p_phi: value.Value = R.unwrap_ok[value.Value, str](res_pphi);
+    val res_aphi: R.Result[value.Value, str] = builder.emit_phi(?b, i64t);
+    if (R.is_err[value.Value, str](res_aphi)) { ret R.err[bool, str](R.unwrap_err[value.Value, str](res_aphi)); }
+    val acc_phi: value.Value = R.unwrap_ok[value.Value, str](res_aphi);
+
+    val res_c: R.Result[value.Value, str] = builder.emit_load(?b, p_phi, i8t);
+    if (R.is_err[value.Value, str](res_c)) { ret R.err[bool, str](R.unwrap_err[value.Value, str](res_c)); }
+    val c: value.Value = R.unwrap_ok[value.Value, str](res_c);
+    val res_end: R.Result[value.Value, str] = builder.emit_cmp_eq(?b, c, value.const_int(0, i8t));
+    if (R.is_err[value.Value, str](res_end)) { ret R.err[bool, str](R.unwrap_err[value.Value, str](res_end)); }
+    val res_cbr2: R.Result[bool, str] = builder.emit_cbr(?b, R.unwrap_ok[value.Value, str](res_end), dblocks[0], b_low_ok);
+    if (R.is_err[bool, str](res_cbr2)) { ret res_cbr2; }
+
+    # low_ok / body: reject bytes outside '0'..'9', else acc = acc*10 + digit
+    builder.set_block(?b, b_low_ok);
+    val res_lt0: R.Result[value.Value, str] = builder.emit_cmp_lt_u(?b, c, value.const_int(48, i8t));
+    if (R.is_err[value.Value, str](res_lt0)) { ret R.err[bool, str](R.unwrap_err[value.Value, str](res_lt0)); }
+    val res_cbr3: R.Result[bool, str] = builder.emit_cbr(?b, R.unwrap_ok[value.Value, str](res_lt0), b_bad, b_body);
+    if (R.is_err[bool, str](res_cbr3)) { ret res_cbr3; }
+
+    builder.set_block(?b, b_body);
+    val res_gt9: R.Result[value.Value, str] = builder.emit_cmp_lt_u(?b, value.const_int(57, i8t), c);
+    if (R.is_err[value.Value, str](res_gt9)) { ret R.err[bool, str](R.unwrap_err[value.Value, str](res_gt9)); }
+
+    val res_step: R.Result[id.BlockId, str] = builder.new_block(?b);
+    if (R.is_err[id.BlockId, str](res_step)) { ret R.err[bool, str](R.unwrap_err[id.BlockId, str](res_step)); }
+    val b_step: id.BlockId = R.unwrap_ok[id.BlockId, str](res_step);
+    val res_cbr4: R.Result[bool, str] = builder.emit_cbr(?b, R.unwrap_ok[value.Value, str](res_gt9), b_bad, b_step);
+    if (R.is_err[bool, str](res_cbr4)) { ret res_cbr4; }
+
+    builder.set_block(?b, b_step);
+    val res_cz: R.Result[value.Value, str] = builder.emit_zext(?b, c, i64t);
+    if (R.is_err[value.Value, str](res_cz)) { ret R.err[bool, str](R.unwrap_err[value.Value, str](res_cz)); }
+    val res_dig: R.Result[value.Value, str] = builder.emit_sub(?b, R.unwrap_ok[value.Value, str](res_cz), value.const_int(48, i64t));
+    if (R.is_err[value.Value, str](res_dig)) { ret R.err[bool, str](R.unwrap_err[value.Value, str](res_dig)); }
+    val res_m10: R.Result[value.Value, str] = builder.emit_mul(?b, acc_phi, value.const_int(10, i64t));
+    if (R.is_err[value.Value, str](res_m10)) { ret R.err[bool, str](R.unwrap_err[value.Value, str](res_m10)); }
+    val res_acc: R.Result[value.Value, str] = builder.emit_add(?b, R.unwrap_ok[value.Value, str](res_m10), R.unwrap_ok[value.Value, str](res_dig));
+    if (R.is_err[value.Value, str](res_acc)) { ret R.err[bool, str](R.unwrap_err[value.Value, str](res_acc)); }
+    val acc_next: value.Value = R.unwrap_ok[value.Value, str](res_acc);
+    val res_pn: R.Result[value.Value, str] = builder.emit_gep(?b, p_phi, i8t, ?one_idx[0], 1);
+    if (R.is_err[value.Value, str](res_pn)) { ret R.err[bool, str](R.unwrap_err[value.Value, str](res_pn)); }
+    val p_next: value.Value = R.unwrap_ok[value.Value, str](res_pn);
+    val res_br: R.Result[bool, str] = builder.emit_br(?b, b_head);
+    if (R.is_err[bool, str](res_br)) { ret res_br; }
+
+    val res_in1: R.Result[bool, str] = builder.phi_add_incoming(?b, p_phi, b_getarg, arg);
+    if (R.is_err[bool, str](res_in1)) { ret res_in1; }
+    val res_in2: R.Result[bool, str] = builder.phi_add_incoming(?b, p_phi, b_step, p_next);
+    if (R.is_err[bool, str](res_in2)) { ret res_in2; }
+    val res_in3: R.Result[bool, str] = builder.phi_add_incoming(?b, acc_phi, b_getarg, value.const_int(0, i64t));
+    if (R.is_err[bool, str](res_in3)) { ret res_in3; }
+    val res_in4: R.Result[bool, str] = builder.phi_add_incoming(?b, acc_phi, b_step, acc_next);
+    if (R.is_err[bool, str](res_in4)) { ret res_in4; }
+
+    # dispatch chain: acc == k -> call test k; falling off the end is out-of-range
+    k = 0;
+    for (k < count) {
+        builder.set_block(?b, dblocks[k]);
+        val res_eq: R.Result[value.Value, str] = builder.emit_cmp_eq(?b, acc_phi, value.const_int(k::u64, i64t));
+        if (R.is_err[value.Value, str](res_eq)) { ret R.err[bool, str](R.unwrap_err[value.Value, str](res_eq)); }
+        var miss: id.BlockId = b_bad;
+        if (k + 1 < count) { miss = dblocks[k + 1]; }
+        val res_cbrk: R.Result[bool, str] = builder.emit_cbr(?b, R.unwrap_ok[value.Value, str](res_eq), cblocks[k], miss);
+        if (R.is_err[bool, str](res_cbrk)) { ret res_cbrk; }
+
+        builder.set_block(?b, cblocks[k]);
+        val res_call: R.Result[value.Value, str] = builder.emit_call(?b, callees[k], nil, 0, i32t);
+        if (R.is_err[value.Value, str](res_call)) { ret R.err[bool, str](R.unwrap_err[value.Value, str](res_call)); }
+        val res_r64: R.Result[value.Value, str] = builder.emit_sext(?b, R.unwrap_ok[value.Value, str](res_call), i64t);
+        if (R.is_err[value.Value, str](res_r64)) { ret R.err[bool, str](R.unwrap_err[value.Value, str](res_r64)); }
+        val res_retk: R.Result[bool, str] = builder.emit_ret(?b, R.unwrap_ok[value.Value, str](res_r64));
+        if (R.is_err[bool, str](res_retk)) { ret res_retk; }
+        k = k + 1;
+    }
+
+    ret R.ok[bool, str](true);
 }
 
 # append a Function with the given linkage to the module and register it in the


### PR DESCRIPTION
Closes #1789. Part of epic #1788.

Replaces the one-executable-per-test build with a single synthesized dispatcher binary. The dispatcher's `main(argc, argv)` parses `argv[1]` as a decimal collection index (built as direct IR in `testrunner.mach`, stdlib-independent — argv arrives as `main` parameters from the mach-std runtime on every prime) and branches to the matching test call; missing/malformed/out-of-range indices exit 2. The runner spawns `<exe> <idx>` per test, so per-test process isolation is unchanged.

**Measured on the mach repo itself (438 tests):**
- `mach test .`: **44.9s → 7.2s wall** (438 full links → 1)
- `out/linux/debug/test/`: **9.4 GB (438 files) → one 7.3 MB binary**
- identical result set: 438 passed / 0 failed; self-host fixpoint byte-identical

**Semantics:**
- `--filter` moves from build time to run time (cargo/go shape): the built executable is byte-identical regardless of filter; `--include-deps` stays collection-time.
- `--runner` now receives `<exe> <idx>` (verified with `--runner /usr/bin/env` and forced failures via `--runner /bin/false`).
- `tests` template `{name}` = product name (falls back to project id); default template unchanged.
- `TestArtifact` gains `idx`; docs (`doc/cli.md`, `doc/manifest.md`), `mach test --help`, and the changelog updated.

Verified: full suite parity, `--list` (438), run-time filter, dispatcher error paths (no-arg/empty/malformed/out-of-range → 2), failure rendering, cross-builds to all declared targets, self-host fixpoint.
