### PR TITLE
release: v2.12.0

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,1 +1,1 @@
-github: [octalide]
+github: [briar-systems]

--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,1 +1,0 @@
-github: [briar-systems]

--- a/.github/workflows/int-main.yml
+++ b/.github/workflows/int-main.yml
@@ -35,6 +35,7 @@ jobs:
     name: seed ${{ matrix.target }}
     needs: int-matrix
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:
@@ -61,10 +62,14 @@ jobs:
           if-no-files-found: error
           retention-days: 1
 
+  # timeout-minutes bounds execution, not queue time: a leg pinned to an
+  # unavailable runner class still sits in queue to GitHub's 24h cap (#1787).
+  # keeping every row on an available runner class is the real guard.
   integration:
     name: int ${{ matrix.target }}
     needs: [int-matrix, seed]
     runs-on: ${{ matrix.runner }}
+    timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   platforms - timing via `chrono.monotonic`, durations via
   `chrono.format_duration`, columns via the `{:<N}`/`{:N}` format spec (#1775).
 
+### Changed
+
+- test: `mach test` builds **one dispatcher executable** covering every
+  collected test instead of one standalone executable per test - one link
+  instead of N (on mach itself: 44.9s → 7.2s wall, 9.4 GB → 7.3 MB on disk).
+  Each test still runs as its own process, spawned as `<exe> <idx>`. `--runner`
+  now receives the executable path and the test index as its two arguments;
+  `--filter` selects at run time, so the built executable is identical
+  regardless of filter; the `tests` template's `{name}` resolves to the product
+  name (falling back to the project id) rather than a per-test name (#1789).
+
 ### Removed
 
 - build: the `--verbose` flag, replaced by `-v`/`-vv` (#1775).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [2.12.0] - 2026-07-01
+
+The terminal output & test-harness overhaul: framed source-snippet diagnostics,
+a per-phase build readout, and `mach test` rebuilt around a single dispatcher
+binary with live, parallel, deterministic reporting (epic #1788 - on mach's own
+438-test suite, `mach test .` drops 44.9s -> 7.2s wall and 9.4 GB -> one 7.3 MB
+artifact). Static-PIE self-relocation is now active under `--pie`. Contains
+breaking CLI changes - see Breaking. Built with mach 2.11.0.
+
+### Breaking
+
+- build/test: the `--verbose` flag is gone; use `-v` / `-vv` (#1775).
+- test: `--runner <cmd>` now launches `<cmd> <exe> <idx>` - the runner receives
+  the dispatcher path and a test index instead of a per-test executable (#1789).
+- test: the `tests` manifest template's `{name}` resolves to the product name
+  (one dispatcher binary) rather than a per-test name (#1789).
 
 ### Added
 
@@ -19,6 +34,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   re-lists the failures; a crashing test reports its signal and the run
   continues (#1776). Extended to a live, parallel readout later in this
   cycle (see the `Changed` entries).
+- link: static-PIE self-relocation is active - under `--pie` the mach-std
+  runtime relocates the image's absolute pointers at startup, covered by an
+  int exec guard (#1727).
 - build: `-v` prints a per-phase readout (load / resolve / sema / lower /
   optimize / codegen / link) with item counts and timing, closed by a
   `built <path>  N modules  <size>  in <time>` summary; `-vv` adds a
@@ -58,6 +76,41 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 - build: the `--verbose` flag, replaced by `-v`/`-vv` (#1775).
+
+### Fixed
+
+- ci(int): the darwin-x86_64 integration leg never ran - it queued forever on
+  starved `macos-13` runners and died at GitHub's 24h cap; routed to `macos-14`
+  under Rosetta 2, mirroring CD (#1787).
+
+## [2.11.0] - 2026-06-30
+
+Position independence and multi-arch ELF dynamic linking: opt-in static-PIE
+executable emission for linux, PLT/GOT writers for aarch64 and riscv64, plus
+editor groundwork and a loud-error sweep over the backend's silent fallbacks.
+Built with mach 2.10.0.
+
+### Added
+
+- link/elf: opt-in **static-PIE** (`ET_DYN`) linux executables via `--pie` /
+  `$mach.build.pie` - `PT_PHDR` load-bias recovery, a synthesized `.rela.dyn`
+  of `R_*_RELATIVE` base relocations, and `PT_DYNAMIC`; runtime self-relocation
+  activates in the next release (#1727).
+- of/elf: aarch64 and riscv64 **PLT/GOT dynamic-link writers** with byte-level
+  encoding guards, completing dynamic linking across the shipped linux ISAs
+  (#1741).
+- editor: sema retains per-expression types on `SemaResult` for editor/LSP
+  consumption (#1501).
+- ci: an x86_64-darwin release lane via Rosetta 2 on `macos-14` - Intel
+  runners are queue-starved (#1728); darwin integration legs run on merge to
+  main rather than a schedule (#1765).
+- int: structural (field) and freestanding (flat-loader) producers widen what
+  the integration harness can assert (#1760).
+
+### Fixed
+
+- be: silent backend fallbacks now fail loudly, with the AAPCS64 edge rules
+  documented where they were being papered over (#1745).
 
 ## [2.10.0] - 2026-06-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- test: `mach test` runs tests **in parallel** - a sliding window of `--jobs`
+  child processes (default: the CPUs available to the process; `--jobs 1`
+  serializes), reaped with a blocking wait-any. Each child's stdout *and
+  stderr* are captured to a per-test file under `log/` beside the dispatcher;
+  a passing test's file is removed on reap, a failing test's stays (the
+  expanded failure shows the first 64KB, a `full output:` pointer when
+  truncated, and the exact `rerun: <exe> <idx>` command). Results render in
+  collection order regardless of completion order, so the readout is
+  deterministic (#1791).
 - test: the `mach test` readout is **live** - each module's roll-up prints the
   moment its last test completes, and failures expand as they happen. Column
   widths are computed from the collected tests (clamped) instead of hard-coded,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- test: the `mach test` readout is **live** - each module's roll-up prints the
+  moment its last test completes, and failures expand as they happen. Column
+  widths are computed from the collected tests (clamped) instead of hard-coded,
+  test labels print verbatim as declared (the old `<module>.`-prefix stripping
+  is gone), durations right-align, and the closing summary reports the run's
+  wall time. `-v` prints each test's line as it completes; `-vv` now also
+  prints passing tests' captured output (it was a silent alias of `-v`);
+  `mach test --help` documents both (#1790).
 - test: `mach test` builds **one dispatcher executable** covering every
   collected test instead of one standalone executable per test - one link
   instead of N (on mach itself: 44.9s → 7.2s wall, 9.4 GB → 7.3 MB on disk).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- build: `-v` prints a per-phase readout (load / resolve / sema / lower /
+  optimize / codegen / link) with item counts and timing, closed by a
+  `built <path>  N modules  <size>  in <time>` summary; `-vv` adds a
+  per-module/file line under each phase with its own duration and a `(slow)`
+  marker on the slowest item. Fixed-width ASCII on stderr, identical across
+  platforms - timing via `chrono.monotonic`, durations via
+  `chrono.format_duration`, columns via the `{:<N}`/`{:N}` format spec (#1775).
+
+### Removed
+
+- build: the `--verbose` flag, replaced by `-v`/`-vv` (#1775).
+
 ## [2.10.0] - 2026-06-29
 
 Native arm64 macOS. mach now compiles, ad-hoc code-signs, and self-hosts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- diag: a framed source-snippet renderer for driver diagnostics - each
+  reported error/warning shows its source line in a frame with a caret span,
+  file:line:col header, and severity-tagged message, replacing the one-line
+  flush (#1777).
+- test: a per-module roll-up readout for `mach test` - all-passing modules
+  collapse to one line, failures expand with the child's captured stdout,
+  `file:line`, and exit code or signal, and the run ends with a summary that
+  re-lists the failures; a crashing test reports its signal and the run
+  continues (#1776). Extended to a live, parallel readout later in this
+  cycle (see the `Changed` entries).
 - build: `-v` prints a per-phase readout (load / resolve / sema / lower /
   optimize / codegen / link) with item counts and timing, closed by a
   `built <path>  N modules  <size>  in <time>` summary; `-vv` adds a

--- a/doc/cli.md
+++ b/doc/cli.md
@@ -31,11 +31,12 @@ matched exactly: `--flag value` (a value follows in the next argument) or a bare
 ## Global flags
 
 Read by `build`, `run`, `test`, and `doc` (they share one config parser).
-`--verbose` and `--quiet` together is a parse error.
+A verbosity flag (`-v`/`-vv`) and `--quiet` together is a parse error.
 
 | Flag             | Value            | Effect |
 |------------------|------------------|--------|
-| `--verbose`, `-v`| —                | write extra detail (per-stage compile progress) to stderr |
+| `-v`             | —                | `mach build`: per-phase roll-up (load/resolve/sema/lower/optimize/codegen/link) with item counts + timing, then a `built … N modules … in …` summary, on stderr |
+| `-vv`            | —                | `-v` plus a per-module/file line under each phase with its duration and a `(slow)` marker on the slowest |
 | `--quiet`, `-q`  | —                | suppress non-error output |
 | `--color <mode>` | `auto`\|`always`\|`never` | color preference for terminal output (default `auto`); an unknown mode is a parse error |
 | `--target <name>`| target name      | select a declared target; absent, defers to `[project].target` |

--- a/doc/cli.md
+++ b/doc/cli.md
@@ -189,9 +189,31 @@ mach test <path> [options]
 
 Builds one standalone executable per `test` declaration (the test plus the
 project's transitive code, with a synthesized `main` calling just that test),
-then spawns each as a separate process and reports a per-test
-`name file:line PASS|FAIL` line. A crashing test reports its signal and the run
-continues. A test build always links executables, even for a library target.
+then spawns each as a separate process, captures its output, and times it.
+A test build always links executables, even for a library target.
+
+The default readout collapses every all-passing module to a single roll-up
+line and expands only modules that have a failure:
+
+```
+mach.lang.intern                     3 ok  568us
+mach.lang.driver                    27 ok     1 FAIL  146ms
+  FAIL  builds:cyclic_import  ./src/lang/driver.mach:142  (exit 1)
+    expected a diagnostic, got none
+
+failures:
+  mach.lang.driver.builds:cyclic_import  ./src/lang/driver.mach:142  (exit 1)
+
+437 passed, 1 failed, 438 total  (268ms)
+```
+
+A roll-up is `<module>  <ok> ok[  <fail> FAIL]  <duration>`. Each expanded
+failure carries the test's `file:line`, its exit code (`(exit N)`) or signal
+(`(signal N)`), and the child's captured stdout indented beneath it; a passing
+test stays quiet. A crashing test reports its signal and the run continues. The
+closing summary re-lists every failure as `<test>  file:line  (reason)`. `-v`
+lists every test, grouped by module, with each test's duration. The layout is
+fixed-width ASCII (no color, no terminal-width queries).
 
 Only `test` blocks declared in the current project's own modules are collected by
 default; tests in dependency modules are excluded unless `--include-deps` is
@@ -204,13 +226,13 @@ passed.
 | `--list`            | —       | list the collected tests and exit |
 | `--runner <cmd>`    | command | launch every test as `<cmd> <exe>` instead of exec'ing it directly |
 
-Plus the `build` and global flags. `--runner` has the same semantics as on
-`mach run`: a single command name or path (no shell-style word splitting),
-resolved on `PATH`, for foreign-target tests the host cannot exec directly —
-e.g. `mach test . --target windows --runner wine`. Without it, a test executable
-the host cannot launch reports a per-test failure — `FAIL(exit 127)` when
-`execve` rejects the binary in the spawned child, `FAIL(spawn)` when the spawn
-itself fails — with no auto-detection.
+Plus the `build` and global flags (`-v` lists every test). `--runner` has the
+same semantics as on `mach run`: a single command name or path (no shell-style
+word splitting), resolved on `PATH`, for foreign-target tests the host cannot
+exec directly — e.g. `mach test . --target windows --runner wine`. Without it, a
+test executable the host cannot launch reports a per-test failure — `(exit 127)`
+when `execve` rejects the binary in the spawned child, `(spawn failed)` when the
+spawn itself fails — with no auto-detection.
 
 Exit codes: `0` all passed, `1` any failed, `2` build/internal error.
 

--- a/doc/cli.md
+++ b/doc/cli.md
@@ -225,15 +225,20 @@ passed.
 | `--filter <pattern>`| pattern | run only tests whose name contains `<pattern>` |
 | `--include-deps`    | —       | also collect tests declared in dependency modules |
 | `--list`            | —       | list the collected tests and exit |
-| `--runner <cmd>`    | command | launch every test as `<cmd> <exe>` instead of exec'ing it directly |
+| `--runner <cmd>`    | command | launch every test as `<cmd> <exe> <idx>` instead of exec'ing the dispatcher directly |
 
-Plus the `build` and global flags (`-v` lists every test). `--runner` has the
-same semantics as on `mach run`: a single command name or path (no shell-style
-word splitting), resolved on `PATH`, for foreign-target tests the host cannot
-exec directly — e.g. `mach test . --target windows --runner wine`. Without it, a
-test executable the host cannot launch reports a per-test failure — `(exit 127)`
-when `execve` rejects the binary in the spawned child, `(spawn failed)` when the
-spawn itself fails — with no auto-detection.
+Plus the `build` and global flags (`-v` lists every test). The build produces a
+single dispatcher executable covering every collected test; the runner spawns it
+once per test as `<exe> <idx>`, so each test still runs in its own process.
+`--filter` selects at run time — the built executable is identical regardless of
+filter. `--runner` has the same semantics as on `mach run`: a single command
+name or path (no shell-style word splitting), resolved on `PATH`, for
+foreign-target tests the host cannot exec directly — e.g. `mach test . --target
+windows --runner wine` (the runner receives the executable path and the test
+index as its two arguments). Without it, a test executable the host cannot
+launch reports a per-test failure — `(exit 127)` when `execve` rejects the
+binary in the spawned child, `(spawn failed)` when the spawn itself fails — with
+no auto-detection.
 
 Exit codes: `0` all passed, `1` any failed, `2` build/internal error.
 

--- a/doc/cli.md
+++ b/doc/cli.md
@@ -227,23 +227,29 @@ passed.
 
 | Flag                | Value   | Effect |
 |---------------------|---------|--------|
+| `--jobs <n>`        | count   | run up to `<n>` test processes at once (default: the CPUs available; 1 serializes) |
 | `--filter <pattern>`| pattern | run only tests whose name contains `<pattern>` |
 | `--include-deps`    | —       | also collect tests declared in dependency modules |
 | `--list`            | —       | list the collected tests and exit |
 | `--runner <cmd>`    | command | launch every test as `<cmd> <exe> <idx>` instead of exec'ing the dispatcher directly |
 
 Plus the `build` and global flags (`-v` lists every test). The build produces a
-single dispatcher executable covering every collected test; the runner spawns it
-once per test as `<exe> <idx>`, so each test still runs in its own process.
-`--filter` selects at run time — the built executable is identical regardless of
-filter. `--runner` has the same semantics as on `mach run`: a single command
-name or path (no shell-style word splitting), resolved on `PATH`, for
-foreign-target tests the host cannot exec directly — e.g. `mach test . --target
-windows --runner wine` (the runner receives the executable path and the test
-index as its two arguments). Without it, a test executable the host cannot
-launch reports a per-test failure — `(exit 127)` when `execve` rejects the
-binary in the spawned child, `(spawn failed)` when the spawn itself fails — with
-no auto-detection.
+single dispatcher executable covering every collected test; the runner keeps up
+to `--jobs` children in flight, each spawned as `<exe> <idx>`, so every test
+still runs in its own process. Each child's stdout and stderr are captured to a
+per-test file under `log/` beside the dispatcher: a passing test's file is
+removed on the spot, a failing test's file stays for inspection (the expanded
+failure shows the first 64KB, a `full output:` pointer when that truncates, and
+the exact `rerun:` command). Results render in collection order regardless of
+completion order, so the readout is deterministic. `--filter` selects at run
+time — the built executable is identical regardless of filter. `--runner` has
+the same semantics as on `mach run`: a single command name or path (no
+shell-style word splitting), resolved on `PATH`, for foreign-target tests the
+host cannot exec directly — e.g. `mach test . --target windows --runner wine`
+(the runner receives the executable path and the test index as its two
+arguments). Without it, a test executable the host cannot launch reports a
+per-test failure — `(exit 127)` when `execve` rejects the binary in the spawned
+child, `(spawn failed)` when the spawn itself fails — with no auto-detection.
 
 Exit codes: `0` all passed, `1` any failed, `2` build/internal error.
 

--- a/doc/cli.md
+++ b/doc/cli.md
@@ -193,13 +193,14 @@ project's transitive code, with a synthesized `main` calling just that test),
 then spawns each as a separate process, captures its output, and times it.
 A test build always links executables, even for a library target.
 
-The default readout collapses every all-passing module to a single roll-up
-line and expands only modules that have a failure:
+The readout is live: every all-passing module collapses to a single roll-up
+line that prints the moment the module's last test completes, and a module
+with failures expands each failing test as it happens:
 
 ```
-mach.lang.intern                     3 ok  568us
-mach.lang.driver                    27 ok     1 FAIL  146ms
-  FAIL  builds:cyclic_import  ./src/lang/driver.mach:142  (exit 1)
+mach.lang.intern      3 ok     568us
+mach.lang.driver     27 ok     1 FAIL    146ms
+  FAIL  mach.lang.driver.builds:cyclic_import  ./src/lang/driver.mach:142  (exit 1)
     expected a diagnostic, got none
 
 failures:
@@ -208,12 +209,16 @@ failures:
 437 passed, 1 failed, 438 total  (268ms)
 ```
 
-A roll-up is `<module>  <ok> ok[  <fail> FAIL]  <duration>`. Each expanded
-failure carries the test's `file:line`, its exit code (`(exit N)`) or signal
-(`(signal N)`), and the child's captured stdout indented beneath it; a passing
-test stays quiet. A crashing test reports its signal and the run continues. The
-closing summary re-lists every failure as `<test>  file:line  (reason)`. `-v`
-lists every test, grouped by module, with each test's duration. The layout is
+A roll-up is `<module>  <ok> ok[  <fail> FAIL]  <duration>`. Column widths are
+computed from the collected tests before the run (clamped, so one long name
+cannot blow out the table); test labels print verbatim, exactly as declared.
+Each expanded failure carries the test's `file:line`, its exit code
+(`(exit N)`) or signal (`(signal N)`), and the child's captured stdout
+indented beneath it; a passing test stays quiet. A crashing test reports its
+signal and the run continues. The closing summary re-lists every failure as
+`<test>  file:line  (reason)` and reports the run's wall time. `-v` prints a
+module header when its first test starts and a line per test as it completes;
+`-vv` additionally prints passing tests' captured output. The layout is
 fixed-width ASCII (no color, no terminal-width queries).
 
 Only `test` blocks declared in the current project's own modules are collected by

--- a/doc/language/test.md
+++ b/doc/language/test.md
@@ -83,8 +83,10 @@ in-tree. `--filter` narrows the run by test name in either mode.
 
 ## The `mach test` workflow
 
-`mach test` builds the project with the test-runner entry point and then
-runs the resulting binary, surfacing its exit code:
+`mach test` builds one standalone executable per `test` declaration, spawns
+each as its own process, captures its output, and renders a per-module readout —
+collapsing all-passing modules to a single roll-up line and expanding any
+module with a failure to show the failing test's captured output and location:
 
 ```
 usage: mach test [options]
@@ -95,9 +97,15 @@ options:
   --filter <pattern>  run only tests whose name contains <pattern>
   --include-deps      also run tests declared in dependency modules
   --list              list the collected tests and exit
+  -v                  list every test, grouped by module, with durations
 
 exit: 0 all passed, 1 any failed, 2 build/internal error
 ```
+
+A roll-up is `<module>  <ok> ok[  <fail> FAIL]  <duration>`. Each expanded
+failure shows `file:line`, the exit code (`(exit N)`) or signal (`(signal N)`),
+and the child's captured stdout indented beneath; a passing test stays quiet.
+The run closes with a summary that re-lists every failure.
 
 The command itself does two things:
 
@@ -121,19 +129,20 @@ whose label contains the given pattern.
 
 ## The runner
 
-The runner is synthesized in IR by the compiler (`mach.lang.me.lower.testrunner`)
-during a test build and codegen'd into one extra object that joins the link.
-For each collected test it emits a body-less extern referencing the test's
-linkage name plus a private `.rodata` global holding the label; the synthesized
-`main` then walks the table. In a test build the project's own `main` is
-neutralised (turned into a body-less extern) so the runner's `main` is the sole
-program entry, and an executable is always linked — even for a library target.
+For each collected test the compiler (`mach.lang.me.lower.testrunner`)
+synthesizes a tiny IR module whose `main` is `ret <test>();` — a signature-only
+extern for the test symbol plus a two-instruction body — codegen'd into one extra
+object that links with the project's objects into a standalone executable for
+that test. In a test build the project's own `main` is neutralised (turned into a
+body-less extern) so the synthesized `main` is the sole program entry, and an
+executable is always linked — even for a library target.
 
-The runner prints one line per executed test, `PASS <label>` or `FAIL <label>`,
-to stdout, and returns `0` when every selected test passed and `1` otherwise.
-It reads `--list` / `--filter` from its own argv (forwarded by `mach test`). The
-only OS interaction is a `write` syscall emitted as a small inline-asm helper,
-so the runner has no standard-library dependency.
+`mach test` itself spawns each per-test executable, captures the child's stdout,
+times it, and reads its exit status, then renders the per-module readout
+described above (a roll-up per module, expanded failures with captured output
+and `file:line`, a closing failure summary) and returns `0` when every selected
+test passed and `1` otherwise. `--list` / `--filter` select or enumerate which
+tests are built and run; `-v` lists every test with its duration.
 
 Tests live inline alongside the code they cover: write `test "..." { }`
 declarations directly in the relevant `src/` module, or group them under

--- a/doc/manifest.md
+++ b/doc/manifest.md
@@ -25,7 +25,7 @@ out     = "out/{target}/{profile}/bin/{name}{ext}"  # artifact path template
 obj     = "out/{target}/{profile}/obj"              # intermediate-object dir template
 ir      = "out/{target}/{profile}/ir"               # IR-dump dir template
 asm     = "out/{target}/{profile}/asm"              # ASM-dump dir template
-tests   = "out/{target}/{profile}/test/{name}"      # per-test executable path template (mach test)
+tests   = "out/{target}/{profile}/test/{name}"      # test dispatcher executable path template (mach test)
 # optional metadata: name, description, license, authors
 
 [target.linux]             # a platform: a fully-spelled tuple, nothing inferred
@@ -79,7 +79,7 @@ ref = "v0.4.0"
 | `obj`     | string | no       | `"out/{target}/{profile}/obj"` | Per-module object tree template. |
 | `ir`      | string | no       | `"out/{target}/{profile}/ir"`  | Per-module IR-dump template (used when emission is on). |
 | `asm`     | string | no       | `"out/{target}/{profile}/asm"` | Per-module assembly-dump template (used when emission is on). |
-| `tests`   | string | no       | `"out/{target}/{profile}/test/{name}"` | Per-test executable path template. `mach test` builds one standalone executable per `test` block here, with `{name}` the sanitized test name (see below). |
+| `tests`   | string | no       | `"out/{target}/{profile}/test/{name}"` | Test dispatcher executable path template. `mach test` builds one executable covering every collected `test` block here, with `{name}` the product name (see below). |
 
 Optional metadata read by the `$project.*` comptime roots but not the build:
 `name`, `description`, `license`, `authors`.
@@ -256,14 +256,12 @@ is a hard error. Two artifacts that resolve to the same `out` path collide and
 fail at build start. A per-artifact or per-cell `out` overrides the project
 template for that artifact.
 
-The `tests` template is expanded the same way, except `{name}` is the **per-test
-name** rather than the artifact name (`{target}`/`{profile}`/`{ext}` resolve as
-usual). `mach test` substitutes `{name}` per test as `<index>-<sanitized label>`:
-the zero-based collection index keeps the name unique — test labels are not
-globally unique across modules — and stable, and every label byte outside
-`[A-Za-z0-9._-]` becomes `_` (the label portion is truncated to keep the name
-short). A test labeled `"parses empty input"` collected third lands at, e.g.,
-`out/linux/debug/test/2-parses_empty_input`.
+The `tests` template is expanded the same way and locates the single test
+dispatcher executable `mach test` builds (`{target}`/`{profile}`/`{ext}` resolve
+as usual). `{name}` is the selected artifact's product name, falling back to the
+project id for artifact-less (library) builds. The dispatcher embeds every
+collected test and runs the one selected by a decimal index argument, so a
+project's test build lands at, e.g., `out/linux/debug/test/mach`.
 
 ## Selection and the build matrix
 
@@ -318,7 +316,7 @@ out     = "out/{target}/bin/{name}{ext}"  # e.g. out/linux/bin/mach
 obj     = "out/{target}/obj"
 ir      = "out/{target}/ir"
 asm     = "out/{target}/asm"
-tests   = "out/{target}/test/{name}"      # e.g. out/linux/test/2-parses_empty_input
+tests   = "out/{target}/test/{name}"      # e.g. out/linux/test/myproj
 
 [target.linux]
 isa = "x86_64"

--- a/int/surface/pie-reloc/case.conf
+++ b/int/surface/pie-reloc/case.conf
@@ -1,0 +1,10 @@
+# build the program with --pie and RUN it: the sibling elf-pie field guard only
+# inspects e_type host-side, so this is where the relocated-pointer runtime is
+# actually exercised. the binary dereferences relocated global pointers and calls
+# through a relocated function-pointer table, so its golden output appears only when
+# mach-std's _rt_relocate applied the .rela.dyn RELATIVE entries at startup. scoped
+# to the no-libc linux arches that carry the self-relocating runtime (riscv64 cross-
+# builds and runs under qemu); other formats are covered by their own field guards.
+run: exec
+targets: linux linux-arm64 linux-riscv64
+build-flags: --pie

--- a/int/surface/pie-reloc/expect.txt
+++ b/int/surface/pie-reloc/expect.txt
@@ -1,0 +1,2 @@
+data_sum=6006
+fn_sum=503

--- a/int/surface/pie-reloc/mach.toml
+++ b/int/surface/pie-reloc/mach.toml
@@ -1,0 +1,36 @@
+[project]
+id      = "case"
+name    = "case"
+version = "0.0.0"
+src     = "src"
+dep     = "dep"
+target  = "linux"
+out     = "out/{target}/{profile}/bin/{name}{ext}"
+
+[target.linux]
+isa = "x86_64"
+os  = "linux"
+abi = "sysv64"
+
+[target.linux-arm64]
+isa = "aarch64"
+os  = "linux"
+abi = "aapcs64"
+
+[target.linux-riscv64]
+isa = "riscv64"
+os  = "linux"
+abi = "lp64"
+
+[profile.debug]
+opt = 0
+
+[profile.release]
+opt = 2
+
+[bin.case]
+entry = "main.mach"
+
+[deps.mach-std]
+git = "https://github.com/briar-systems/mach-std"
+ref = "branch/main"

--- a/int/surface/pie-reloc/src/main.mach
+++ b/int/surface/pie-reloc/src/main.mach
@@ -1,0 +1,50 @@
+# pie-reloc surface case: the static-PIE self-relocation exec guard.
+#
+# a `mach build --pie` image is an ET_DYN executable the kernel loads at a random,
+# non-zero base with no ld.so to apply its .rela.dyn. every global that stores an
+# absolute address - a data pointer into another global, a function-pointer table -
+# becomes an R_*_RELATIVE entry whose stored value is the link-time (un-based)
+# address. only mach-std's _rt_relocate, run from _rt_init before main, slides each
+# entry by the load bias. without it the dereferences read un-based addresses
+# (un-mapped under ASLR -> crash, or stale) and the call targets are wrong; with it
+# the printed sums are exact. so this program produces the golden output ONLY when
+# self-relocation is active, making it a permanent regression guard for the --pie
+# startup path on the no-libc linux runtime.
+
+use std.runtime;
+use std.types.size.usize;
+use p: std.print;
+
+# distinct globals reached only through relocated pointers.
+var v0: i64 = 1001;
+var v1: i64 = 2002;
+var v2: i64 = 3003;
+
+# a global table of data pointers into the globals above: three RELATIVE entries.
+var data_table: [3]*i64 = [3]*i64{?v0, ?v1, ?v2};
+
+# functions whose addresses populate a function-pointer table: RELATIVE entries to
+# code, exercised by an indirect call through the relocated slot.
+fun f0(x: i64) i64 { ret x + 10; }
+fun f1(x: i64) i64 { ret x * 3; }
+fun f2(x: i64) i64 { ret x - 7; }
+
+def UnaryFn: fun(i64) i64;
+var fn_table: [3]UnaryFn = [3]UnaryFn{f0, f1, f2};
+
+#[symbol("main")]
+fun main(argc: usize, argv: **u8) i64 {
+    # sum the values reached through the relocated data-pointer table.
+    var data_sum: i64 = 0;
+    var i: usize = 0;
+    for (i < 3) { data_sum = data_sum + data_table[i][0]; i = i + 1; }
+    p.printlnf("data_sum={}", data_sum);   # 1001 + 2002 + 3003 = 6006
+
+    # call each function through the relocated function-pointer table.
+    var fn_sum: i64 = 0;
+    i = 0;
+    for (i < 3) { fn_sum = fn_sum + fn_table[i](100); i = i + 1; }
+    p.printlnf("fn_sum={}", fn_sum);        # 110 + 300 + 93 = 503
+
+    ret 0;
+}

--- a/int/targets.conf
+++ b/int/targets.conf
@@ -15,5 +15,7 @@ linux            ubuntu-latest     native    pr
 linux-arm64      ubuntu-24.04-arm  native    pr
 linux-riscv64    ubuntu-latest     qemu      pr
 windows          windows-latest    native    pr
-darwin-x86_64    macos-13          native    main
+# x86_64-darwin runs on apple-silicon macos-14 under Rosetta 2, mirroring cd.yml:
+# intel macos-13 runners are queue-starved and never dispatch (#1787)
+darwin-x86_64    macos-14          native    main
 darwin-aarch64   macos-14          native    main

--- a/mach.lock
+++ b/mach.lock
@@ -3,4 +3,4 @@
 [deps.mach-std]
 url = "https://github.com/briar-systems/mach-std"
 ref = "branch/main"
-commit = "3c7f0d65ca12491bf44ec87d98d75ea0e43e0f74"
+commit = "51e0d2bb53e69d441c1a1ec6e3a8853b154c4c28"

--- a/mach.lock
+++ b/mach.lock
@@ -3,4 +3,4 @@
 [deps.mach-std]
 url = "https://github.com/briar-systems/mach-std"
 ref = "branch/main"
-commit = "0262511fd60e21efb6aa95a66200b534940ea2f7"
+commit = "3c7f0d65ca12491bf44ec87d98d75ea0e43e0f74"

--- a/mach.toml
+++ b/mach.toml
@@ -10,7 +10,7 @@ obj = "out/{target}/{profile}/obj"
 ir  = "out/{target}/{profile}/ir"
 asm = "out/{target}/{profile}/asm"
 
-[target.linux]
+[target.linux-x86_64]
 isa = "x86_64"
 os  = "linux"
 abi = "sysv64"
@@ -20,15 +20,12 @@ isa = "aarch64"
 os  = "linux"
 abi = "aapcs64"
 
-# cross-compile-only: mach-std has no riscv64 linux runtime yet, so the compiler
-# itself cannot be built for this target. it still composes and selects so the
-# backend emits a correct RV64 ELF under cross-compilation.
 [target.linux-riscv64]
 isa = "riscv64"
 os  = "linux"
 abi = "lp64"
 
-[target.windows]
+[target.windows-x86_64]
 isa  = "x86_64"
 os   = "windows"
 abi  = "win64"

--- a/mach.toml
+++ b/mach.toml
@@ -1,7 +1,7 @@
 [project]
 id = "mach"
 name = "Mach Compiler"
-version = "2.11.0"
+version = "2.12.0"
 src = "src"
 dep = "dep"
 target = "native"

--- a/src/cli/cmd/build.mach
+++ b/src/cli/cmd/build.mach
@@ -599,7 +599,7 @@ fun build_unit(a: *A.Allocator, argc: usize, argv: **u8, emit_obj: bool, test_mo
 
     br.code = compile_and_link(?p, level, emit_obj, test_mode, config.verify_ir, config.verbose, eff_emit_asm, eff_emit_ir, ?root[0], config.output, eff, argv, ?br.output_path, tests_out, list_only);
 
-    cli_diag.flush(?s, ?s.diags, cfg.color_enabled(config.color));
+    cli_diag.flush(?s, ?s.diags);
     driver.dnit_project(?p);
     session.dnit(?s);
     ret br;

--- a/src/cli/cmd/build.mach
+++ b/src/cli/cmd/build.mach
@@ -33,6 +33,7 @@ use std.types.string.str_len;
 use A: std.allocator;
 use O: std.types.option;
 use R: std.types.result;
+use ctime: std.chrono.time;
 
 use cfg: mach.cli.config;
 use cli_diag: mach.cli.diagnostic;
@@ -50,6 +51,7 @@ use mach.lang.me.lower;
 use mach.lang.me.lower.context;
 use mach.lang.me.lower.testrunner;
 use mach.lang.me.pipeline;
+use mach.lang.readout;
 use mach.lang.session;
 use mach.lang.source;
 use mach.lang.target;
@@ -126,45 +128,17 @@ rec EmitArtifacts {
     want_ir:  bool;
 }
 
-# resolve an interned StrId against the project interner and write it to stderr;
-# a miss writes "<?>"
-# ---
-# p:  the project (for its session interner)
-# id: the interned string to render
-fun emit_id(p: *driver.Project, id: intern.StrId) {
-    val opt_name: O.Option[str] = intern.lookup(?p.s.interner, id);
-    if (O.is_some[str](opt_name)) {
-        print.eprint(O.unwrap[str](opt_name));
-    }
-    or {
-        print.eprint("<?>");
-    }
-}
-
-# write the resolved target name and module count to stderr
+# resolve an interned module FQN to its readout display string
 #
-# The leading line of verbose output, emitted once after graph discovery.
+# Falls back to "<?>" for an un-interned id so a readout item always has a name.
 # ---
-# p: the project carrying the selected target and module graph
-fun emit_target(p: *driver.Project) {
-    print.eprint("target ");
-    if (p.target_entry != nil) { emit_id(p, p.target_entry.name); }
-    or                         { print.eprint("<none>"); }
-    print.eprint(" (");
-    print.eu64(p.topo_len::u64);
-    print.eprint(" module(s))\n");
-}
-
-# write a `<stage> <fqn>` progress line to stderr for one module
-# ---
-# p:     the project (for its interner)
-# stage: a short stage label (e.g. "sema", "codegen")
-# fqn:   the module's interned fully-qualified name
-fun emit_stage(p: *driver.Project, stage: *u8, fqn: intern.StrId) {
-    print.eprint(stage::str);
-    print.eprint(" ");
-    emit_id(p, fqn);
-    print.eprint("\n");
+# p:   the project (for its session interner)
+# fqn: the module's interned fully-qualified name
+# ret: the FQN string, or "<?>"
+fun fqn_name(p: *driver.Project, fqn: intern.StrId) str {
+    val opt_name: O.Option[str] = intern.lookup(?p.s.interner, fqn);
+    if (O.is_some[str](opt_name)) { ret O.unwrap[str](opt_name); }
+    ret "<?>";
 }
 
 # drive every reachable module through the back half of the pipeline
@@ -180,21 +154,21 @@ fun emit_stage(p: *driver.Project, stage: *u8, fqn: intern.StrId) {
 # level:       optimization pipeline level
 # test_mode:   neutralize the project `main` before codegen (the runner supplies entry)
 # verify_ir:   run the IR verifier after each module's pipeline
-# verbose:     write per-module stage lines to stderr
 # ea:          requested `.ir` / `.s` debug artifacts
 # irs:         caller-owned IR-module array, filled in topo order
 # ir_ready:    per-module flag set true once `irs[mid]` holds a built module
 # images:      caller-owned ObjectImage array, filled in topo order
 # image_ready: per-module flag set true once `images[mid]` holds a built image
 # ret:         ok(true) on success, or err with the first failure message
-fun compile_modules(p: *driver.Project, level: u8, test_mode: bool, verify_ir: bool, verbose: bool, ea: *EmitArtifacts,
+fun compile_modules(p: *driver.Project, level: u8, test_mode: bool, verify_ir: bool, ea: *EmitArtifacts,
                     irs: *ir.Module, ir_ready: *bool,
                     images: *of.ObjectImage, image_ready: *bool) R.Result[bool, str] {
     # type-check the whole module graph through Q_SEMA in topo order - memoized
     # and incremental across rebuilds on a long-lived session, computed fresh
     # each CLI build (fresh session, cold cache). run_sema_pass borrows each
     # module's SemaResult onto its ModuleEntry and publishes its typing /
-    # resolution / comptime ctx to the session for the back-end monomorphizer.
+    # resolution / comptime ctx to the session for the back-end monomorphizer. it
+    # records the readout's `sema` phase internally.
     val res_sema: R.Result[bool, str] = driver.run_sema_pass(p);
     if (R.is_err[bool, str](res_sema)) {
         ret R.err[bool, str](R.unwrap_err[bool, str](res_sema));
@@ -203,16 +177,19 @@ fun compile_modules(p: *driver.Project, level: u8, test_mode: bool, verify_ir: b
     # do not lower or codegen a semantically broken module graph.
     if (diagnostic.has_errors(?p.s.diags)) { ret R.ok[bool, str](true); }
 
-    # lower + optimize every module first. in test mode the project's `main` is
-    # then neutralized (the runner supplies the program entry) before any module
-    # is codegen'd, so the dropped `main` body never reaches an object.
+    # lower every module to IR (rendering the textual `.ir` straight after each
+    # lowering, before optimization), then optimize, then - in test mode -
+    # neutralize the project `main` (the runner supplies the program entry) before
+    # any module is codegen'd. the three passes are timed as distinct readout
+    # phases; splitting lower from optimize is purely structural and leaves the
+    # produced objects byte-identical.
+    readout.phase_begin(p.s.readout, readout.PH_LOWER);
     var i: u32 = 0;
     for (i < p.topo_len) {
         val mid: session.ModuleId   = p.topo[i];
         val m:   *driver.ModuleEntry = ?p.modules[mid::u32];
 
-        if (verbose) { emit_stage(p, "lower", m.fqn); }
-
+        val t_item: ctime.Time = readout.item_begin(p.s.readout);
         val res_lower: R.Result[ir.Module, str] = lower.lower_module(p.s, ?p.target, m.a, m.fqn, mid, m.sema_result, m.resolve_result, ?m.ctx);
         if (R.is_err[ir.Module, str](res_lower)) {
             ret R.err[bool, str](R.unwrap_err[ir.Module, str](res_lower));
@@ -227,14 +204,26 @@ fun compile_modules(p: *driver.Project, level: u8, test_mode: bool, verify_ir: b
                 ret R.err[bool, str](R.unwrap_err[bool, str](res_emit));
             }
         }
+        readout.item(p.s.readout, readout.PH_LOWER, fqn_name(p, m.fqn), t_item);
+        i = i + 1;
+    }
+    readout.phase_end(p.s.readout, readout.PH_LOWER, p.topo_len, "module", "modules");
 
+    readout.phase_begin(p.s.readout, readout.PH_OPTIMIZE);
+    i = 0;
+    for (i < p.topo_len) {
+        val mid: session.ModuleId   = p.topo[i];
+        val m:   *driver.ModuleEntry = ?p.modules[mid::u32];
+
+        val t_item: ctime.Time = readout.item_begin(p.s.readout);
         val res_opt: R.Result[bool, str] = pipeline.run(?irs[mid::u32], ?p.target, level, verify_ir);
         if (R.is_err[bool, str](res_opt)) {
             ret R.err[bool, str](R.unwrap_err[bool, str](res_opt));
         }
-
+        readout.item(p.s.readout, readout.PH_OPTIMIZE, fqn_name(p, m.fqn), t_item);
         i = i + 1;
     }
+    readout.phase_end(p.s.readout, readout.PH_OPTIMIZE, p.topo_len, "module", "modules");
 
     if (test_mode) {
         val res_neutralize: R.Result[bool, str] = testrunner.neutralize_project_main(p.s, irs, p.module_len);
@@ -243,12 +232,13 @@ fun compile_modules(p: *driver.Project, level: u8, test_mode: bool, verify_ir: b
         }
     }
 
+    readout.phase_begin(p.s.readout, readout.PH_CODEGEN);
     i = 0;
     for (i < p.topo_len) {
         val mid: session.ModuleId   = p.topo[i];
         val m:   *driver.ModuleEntry = ?p.modules[mid::u32];
 
-        if (verbose) { emit_stage(p, "codegen", m.fqn); }
+        val t_item: ctime.Time = readout.item_begin(p.s.readout);
 
         # codegen, optionally rendering the resolved MIR to a `.s` artifact.
         var asm_file: filesystem.File;
@@ -275,8 +265,10 @@ fun compile_modules(p: *driver.Project, level: u8, test_mode: bool, verify_ir: b
         images[mid::u32]      = R.unwrap_ok[of.ObjectImage, str](res_codegen);
         image_ready[mid::u32] = true;
 
+        readout.item(p.s.readout, readout.PH_CODEGEN, fqn_name(p, m.fqn), t_item);
         i = i + 1;
     }
+    readout.phase_end(p.s.readout, readout.PH_CODEGEN, p.topo_len, "module", "modules");
     ret R.ok[bool, str](true);
 }
 
@@ -564,10 +556,15 @@ fun build_unit(a: *A.Allocator, argc: usize, argv: **u8, emit_obj: bool, test_mo
     s.opt_explicit = cli_set;
     s.opt_release  = cli_level == pipeline.OPT_RELEASE;
 
-    # thread the CLI `--verbose` intent into the session so the front-end load
-    # walk emits per-module `lex`/`parse`/`resolve` progress lines, matching the
-    # back-end stage lines this command prints from `config.verbose`.
-    s.verbose = config.verbose;
+    # attach the build-progress readout (`-v`/`-vv`) so every phase from the
+    # front-end load walk through the back-end link records into one accumulator.
+    # a plain build (verbosity 0) leaves s.readout nil and stays silent; a test
+    # build's output belongs to the test runner, so the readout is build-only.
+    var ro: readout.Readout;
+    if (!test_mode && config.verbosity > 0) {
+        readout.init(?ro, a, config.verbosity);
+        s.readout = ?ro;
+    }
 
     # thread the CLI `--pie` intent into the session so the linker emits a
     # position-independent (ET_DYN) executable; off leaves the default ET_EXEC output.
@@ -597,12 +594,48 @@ fun build_unit(a: *A.Allocator, argc: usize, argv: **u8, emit_obj: bool, test_mo
     if (config.emit_ir)     { eff_emit_ir = true; }
     if (config.no_emit_ir)  { eff_emit_ir = false; }
 
-    br.code = compile_and_link(?p, level, emit_obj, test_mode, config.verify_ir, config.verbose, eff_emit_asm, eff_emit_ir, ?root[0], config.output, eff, argv, ?br.output_path, tests_out, list_only);
+    br.code = compile_and_link(?p, level, emit_obj, test_mode, config.verify_ir, eff_emit_asm, eff_emit_ir, ?root[0], config.output, eff, argv, ?br.output_path, tests_out, list_only);
+
+    # close the readout with the recap line on a successful, non-test build.
+    if (br.code == 0 && s.readout != nil) {
+        emit_summary(?p, ?ro, emit_obj, br.output_path);
+    }
 
     cli_diag.flush(?s, ?s.diags, cfg.color_enabled(config.color));
     driver.dnit_project(?p);
+    readout.dnit(?ro);
     session.dnit(?s);
     ret br;
+}
+
+# render the readout's closing recap for a finished build
+#
+# Reports the module count and total time, plus the linked binary's size when
+# the build produced one (an executable). A library / object-only build has no
+# single binary, so the size segment is omitted.
+# ---
+# p:        the built project (for its module count and target mode)
+# ro:       the active readout
+# emit_obj: whether the build emitted objects only (no linked binary)
+# out:      the produced artifact path, or nil
+fun emit_summary(p: *driver.Project, ro: *readout.Readout, emit_obj: bool, out: *u8) {
+    var out_str: str = "<output>";
+    if (out != nil) { out_str = out::str; }
+
+    val te: *driver.TargetEntry = p.target_entry;
+    val is_lib: bool = emit_obj || (te != nil && te.mode == driver.MODE_LIBRARY);
+
+    if (!is_lib && out != nil) {
+        val fi_r: R.Result[filesystem.FileInfo, str] = filesystem.info_path(out::str);
+        if (R.is_ok[filesystem.FileInfo, str](fi_r)) {
+            val fi: filesystem.FileInfo = R.unwrap_ok[filesystem.FileInfo, str](fi_r);
+            var unit: str = "B";
+            val mag: i64 = readout.size_split(fi.size, ?unit);
+            readout.summary(ro, out_str, p.module_len, mag, unit, true);
+            ret;
+        }
+    }
+    readout.summary(ro, out_str, p.module_len, 0, "B", false);
 }
 
 # pick the optimization pipeline level for this build
@@ -638,7 +671,6 @@ fun resolve_opt_level(p: *driver.Project, cli_level: u8, cli_set: bool) u8 {
 # emit_obj:     emit a relocatable object instead of an executable
 # test_mode:    neutralize the project `main` before codegen
 # verify_ir:    run the IR verifier after each module's pipeline
-# verbose:      write per-stage progress to stderr
 # emit_asm:     request the per-module `.s` debug artifacts
 # emit_ir:      request the per-module `.ir` debug artifacts
 # root:         the resolved project root directory
@@ -649,7 +681,7 @@ fun resolve_opt_level(p: *driver.Project, cli_level: u8, cli_set: bool) u8 {
 # tests_out:    the list a test build fills, or nil for a normal build
 # list_only:    collect the tests without building executables (`--list`)
 # ret:          the process exit code
-fun compile_and_link(p: *driver.Project, level: u8, emit_obj: bool, test_mode: bool, verify_ir: bool, verbose: bool,
+fun compile_and_link(p: *driver.Project, level: u8, emit_obj: bool, test_mode: bool, verify_ir: bool,
                      emit_asm: bool, emit_ir: bool,
                      root: *u8, out_override: *u8,
                      argc: usize, argv: **u8, out_path: **u8,
@@ -659,8 +691,6 @@ fun compile_and_link(p: *driver.Project, level: u8, emit_obj: bool, test_mode: b
         print.eprint("error: project graph is empty; the entrypoint loaded no modules\n");
         ret 1;
     }
-
-    if (verbose) { emit_target(p); }
 
     # resolve the per-module `.ir` / `.s` output directories once, up front, each
     # from the manifest's resolved `ir`/`asm` template.
@@ -730,7 +760,7 @@ fun compile_and_link(p: *driver.Project, level: u8, emit_obj: bool, test_mode: b
     }
 
     var code: i64 = 0;
-    val res_compile: R.Result[bool, str] = compile_modules(p, level, test_mode, verify_ir, verbose, ?ea, irs, ir_ready, images, image_ready);
+    val res_compile: R.Result[bool, str] = compile_modules(p, level, test_mode, verify_ir, ?ea, irs, ir_ready, images, image_ready);
     if (R.is_err[bool, str](res_compile)) {
         # a `lower:reported` sentinel means lowering already filed a located
         # diagnostic on the sink; the flush prints it, so skip the raw reprint.
@@ -746,10 +776,10 @@ fun compile_and_link(p: *driver.Project, level: u8, emit_obj: bool, test_mode: b
         code = 1;
     }
     or (tests_out != nil) {
-        code = build_test_executables(p, level, verify_ir, verbose, root, argc, argv, images, irs, list_only, tests_out);
+        code = build_test_executables(p, level, verify_ir, root, argc, argv, images, irs, list_only, tests_out);
     }
     or {
-        code = link_artifact(p, emit_obj, verbose, root, out_override, argc, argv, images, out_path);
+        code = link_artifact(p, emit_obj, root, out_override, argc, argv, images, out_path);
     }
 
     free_modules(p, irs, ir_ready, images, image_ready);
@@ -777,7 +807,6 @@ fun compile_and_link(p: *driver.Project, level: u8, emit_obj: bool, test_mode: b
 # p:         the project carrying the module graph and session
 # level:     optimization pipeline level
 # verify_ir: run the IR verifier on each synthesized entry module
-# verbose:   write the test-executable count to stderr
 # root:      the resolved project root directory
 # argc:      argument count including argv[0]
 # argv:      the argument vector (argc null-terminated byte pointers)
@@ -786,7 +815,7 @@ fun compile_and_link(p: *driver.Project, level: u8, emit_obj: bool, test_mode: b
 # list_only: report the collected tests without building (`--list`)
 # tests_out: the list to append each test's artifact to
 # ret:       0 on success, 1 on a user error, 2 on an internal error
-fun build_test_executables(p: *driver.Project, level: u8, verify_ir: bool, verbose: bool,
+fun build_test_executables(p: *driver.Project, level: u8, verify_ir: bool,
                            root: *u8, argc: usize, argv: **u8,
                            images: *of.ObjectImage, irs: *ir.Module,
                            list_only: bool, tests_out: *TestList) i64 {
@@ -857,12 +886,6 @@ fun build_test_executables(p: *driver.Project, level: u8, verify_ir: bool, verbo
         free_sonames(p.s.alloc, sonames, soname_len);
         testrunner.free(p.s, ?col);
         ret ec;
-    }
-
-    if (verbose) {
-        print.eprint("test ");
-        print.eu64(col.count::u64);
-        print.eprint(" executable(s)\n");
     }
 
     # each test's compile/link allocations (the synthesized entry IR, its codegen
@@ -1342,7 +1365,6 @@ fun subst_name(tmpl: str, name: str, out: *u8, cap: usize) usize {
 # ---
 # p:            the project carrying the module graph and session
 # emit_obj:     emit the per-module objects only, linking no executable
-# verbose:      write the object count and output path to stderr
 # root:         the resolved project root directory
 # out_override: the `-o` artifact path, or nil to use the resolved path
 # argc:         argument count including argv[0]
@@ -1350,7 +1372,7 @@ fun subst_name(tmpl: str, name: str, out: *u8, cap: usize) usize {
 # images:       the per-module object images to write
 # out_path:     receives the owned produced-artifact path on success
 # ret:          0 on success, 1 on a user error, 2 on an internal error
-fun link_artifact(p: *driver.Project, emit_obj: bool, verbose: bool, root: *u8,
+fun link_artifact(p: *driver.Project, emit_obj: bool, root: *u8,
                   out_override: *u8,
                   argc: usize, argv: **u8,
                   images: *of.ObjectImage, out_path: **u8) i64 {
@@ -1360,10 +1382,13 @@ fun link_artifact(p: *driver.Project, emit_obj: bool, verbose: bool, root: *u8,
     # a flat-image object format (`produces_image`) has no relocatable `.o`
     # container: it cannot emit per-module objects or re-parse them at link time.
     # link the in-memory codegen images straight into the flat executable instead
-    # of round-tripping through `.o` files.
+    # of round-tripping through `.o` files. it records its own link phase.
     if (p.target.of != nil && p.target.of.produces_image) {
-        ret link_image_artifact(p, emit_obj, verbose, root, out_override, images, out_path);
+        ret link_image_artifact(p, emit_obj, root, out_override, images, out_path);
     }
+
+    readout.phase_begin(p.s.readout, readout.PH_LINK);
+    val t_link: ctime.Time = readout.item_begin(p.s.readout);
 
     # the per-module object tree root: `<root>/<resolved obj template>`.
     var obj_base: [4096]u8;
@@ -1380,13 +1405,9 @@ fun link_artifact(p: *driver.Project, emit_obj: bool, verbose: bool, root: *u8,
     # library mode (or `--emit obj`): the per-module objects are the deliverable;
     # do not link an executable.
     if (te.mode == driver.MODE_LIBRARY || emit_obj) {
-        if (verbose) {
-            print.eprint("output ");
-            print.eprint((?obj_base[0])::str);
-            print.eprint("\n");
-        }
         free_paths(p.s.alloc, paths, len, len);
         @out_path = dup_cstr(p.s.alloc, ?obj_base[0]);
+        readout.phase_end(p.s.readout, readout.PH_LINK, len, "object", "objects");
         ret 0;
     }
 
@@ -1403,18 +1424,6 @@ fun link_artifact(p: *driver.Project, emit_obj: bool, verbose: bool, root: *u8,
         free_paths(p.s.alloc, paths, len, len);
         free_sonames(p.s.alloc, sonames, soname_len);
         ret ext_code;
-    }
-
-    if (verbose) {
-        print.eprint("link ");
-        print.eu64(len::u64);
-        print.eprint(" object(s)");
-        if (soname_len > 0) {
-            print.eprint(", ");
-            print.eu64(soname_len::u64);
-            print.eprint(" shared lib(s)");
-        }
-        print.eprint("\n");
     }
 
     # the executable path: an absolute `-o` is used verbatim; a relative one is
@@ -1451,13 +1460,9 @@ fun link_artifact(p: *driver.Project, emit_obj: bool, verbose: bool, root: *u8,
         ret 1;
     }
 
-    if (verbose) {
-        print.eprint("output ");
-        print.eprint((?artifact[0])::str);
-        print.eprint("\n");
-    }
-
     @out_path = dup_cstr(p.s.alloc, ?artifact[0]);
+    readout.item(p.s.readout, readout.PH_LINK, (?artifact[0])::str, t_link);
+    readout.phase_end(p.s.readout, readout.PH_LINK, 1, "binary", "binaries");
     ret 0;
 }
 
@@ -1476,13 +1481,12 @@ fun link_artifact(p: *driver.Project, emit_obj: bool, verbose: bool, root: *u8,
 # ---
 # p:            the project carrying the module graph and session
 # emit_obj:     reject when set - a flat-image format has no relocatable object output
-# verbose:      write the image count and output path to stderr
 # root:         the resolved project root directory
 # out_override: the `-o` artifact path, or nil to use the resolved path
 # images:       the per-module codegen images, indexed by module id
 # out_path:     receives the owned produced-artifact path on success
 # ret:          0 on success, 1 on a user error, 2 on an internal error
-fun link_image_artifact(p: *driver.Project, emit_obj: bool, verbose: bool, root: *u8,
+fun link_image_artifact(p: *driver.Project, emit_obj: bool, root: *u8,
                         out_override: *u8, images: *of.ObjectImage, out_path: **u8) i64 {
     val te: *driver.TargetEntry = p.target_entry;
     if (te == nil) { print.eprint("error: no target selected\n"); ret 2; }
@@ -1492,6 +1496,9 @@ fun link_image_artifact(p: *driver.Project, emit_obj: bool, verbose: bool, root:
         print.eprint("error: a flat-image object format produces only executables; library and '--emit obj' outputs are unsupported\n");
         ret 1;
     }
+
+    readout.phase_begin(p.s.readout, readout.PH_LINK);
+    val t_link: ctime.Time = readout.item_begin(p.s.readout);
 
     # the executable path: an absolute `-o` is used verbatim; a relative one is
     # rooted at <root>; otherwise the unit's resolved artifact path is used.
@@ -1525,12 +1532,6 @@ fun link_image_artifact(p: *driver.Project, emit_obj: bool, verbose: bool, root:
         i = i + 1;
     }
 
-    if (verbose) {
-        print.eprint("link ");
-        print.eu64(len::u64);
-        print.eprint(" image(s)\n");
-    }
-
     val res_link: R.Result[bool, str] =
         linker.link_images(p.s, ?p.target, ordered, len, nil::*intern.StrId, 0, ?artifact[0], artifact_product_name(p), linker.LINK_EXE);
     A.deallocate[of.ObjectImage](p.s.alloc, ordered, len::usize);
@@ -1541,13 +1542,9 @@ fun link_image_artifact(p: *driver.Project, emit_obj: bool, verbose: bool, root:
         ret 1;
     }
 
-    if (verbose) {
-        print.eprint("output ");
-        print.eprint((?artifact[0])::str);
-        print.eprint("\n");
-    }
-
     @out_path = dup_cstr(p.s.alloc, ?artifact[0]);
+    readout.item(p.s.readout, readout.PH_LINK, (?artifact[0])::str, t_link);
+    readout.phase_end(p.s.readout, readout.PH_LINK, 1, "binary", "binaries");
     ret 0;
 }
 

--- a/src/cli/cmd/build.mach
+++ b/src/cli/cmd/build.mach
@@ -70,15 +70,18 @@ pub rec BuildResult {
 # teardown inside `build_tests` and stay valid until the caller frees that
 # allocator (after it has run every test).
 # ---
-# label: owned printable test name (the `test "..."` literal's inner text)
-# file:  owned source file path of the declaring module
-# line:  1-based source line of the `test` keyword
-# exe:   owned absolute path to the test executable; nil in `--list` mode
+# module: owned fully-qualified name of the declaring module, the runner's
+#         per-module roll-up key (collection order keeps a module's tests adjacent)
+# label:  owned printable test name (the `test "..."` literal's inner text)
+# file:   owned source file path of the declaring module
+# line:   1-based source line of the `test` keyword
+# exe:    owned absolute path to the test executable; nil in `--list` mode
 pub rec TestArtifact {
-    label: *u8;
-    file:  *u8;
-    line:  u32;
-    exe:   *u8;
+    module: *u8;
+    label:  *u8;
+    file:   *u8;
+    line:   u32;
+    exe:    *u8;
 }
 
 # the growing TestArtifact array a test build fills, in collection order
@@ -1129,6 +1132,9 @@ fun record_test(p: *driver.Project, t: *testrunner.Test, exe: *u8, tests_out: *T
     var artifact: TestArtifact;
     artifact.line = t.line;
 
+    artifact.module = dup_cstr(a, test_module_fqn(p, t.mod_idx));
+    if (artifact.module == nil) { print.eprint("error: out of memory\n"); ret 2; }
+
     val opt_label: O.Option[str] = intern.lookup(?p.s.interner, t.label);
     var label_src: *u8 = "<test>";
     if (O.is_some[str](opt_label)) { label_src = O.unwrap[str](opt_label)::*u8; }
@@ -1173,6 +1179,22 @@ fun test_list_push(a: *A.Allocator, list: *TestList, t: TestArtifact) bool {
     list.tests[list.len] = t;
     list.len = list.len + 1;
     ret true;
+}
+
+# the fully-qualified name of the module a test was declared in
+#
+# Borrowed from the session interner (the caller duplicates). "<unknown>" when
+# the index is out of range or the FQN is not interned.
+# ---
+# p:       the project (for its interner and module table)
+# mod_idx: the declaring module's index
+# ret:     the borrowed module FQN, or "<unknown>"
+fun test_module_fqn(p: *driver.Project, mod_idx: u32) *u8 {
+    if (mod_idx >= p.module_len) { ret "<unknown>"; }
+    val m: *driver.ModuleEntry = ?p.modules[mod_idx];
+    val opt_fqn: O.Option[str] = intern.lookup(?p.s.interner, m.fqn);
+    if (O.is_none[str](opt_fqn)) { ret "<unknown>"; }
+    ret O.unwrap[str](opt_fqn)::*u8;
 }
 
 # the source file path of the module a test was declared in

--- a/src/cli/cmd/build.mach
+++ b/src/cli/cmd/build.mach
@@ -25,7 +25,6 @@ use std.types.bool.false;
 use std.types.bool.true;
 use std.types.size.usize;
 use std.types.string.str;
-use std.types.string.str_contains;
 use std.types.string.str_empty;
 use std.types.string.str_equals;
 use std.types.string.str_len;
@@ -66,7 +65,7 @@ pub rec BuildResult {
     output_path: *u8;
 }
 
-# one built test - its reporting metadata and the executable path
+# one built test - its reporting metadata and its dispatch coordinates
 #
 # All owned strings come from the build allocator, so they outlive the session
 # teardown inside `build_tests` and stay valid until the caller frees that
@@ -77,13 +76,16 @@ pub rec BuildResult {
 # label:  owned printable test name (the `test "..."` literal's inner text)
 # file:   owned source file path of the declaring module
 # line:   1-based source line of the `test` keyword
-# exe:    owned absolute path to the test executable; nil in `--list` mode
+# exe:    owned absolute path to the shared dispatcher executable (the same
+#         path on every artifact of a build); nil in `--list` mode
+# idx:    the test's dispatch index - the dispatcher runs it for `<exe> <idx>`
 pub rec TestArtifact {
     module: *u8;
     label:  *u8;
     file:   *u8;
     line:   u32;
     exe:    *u8;
+    idx:    u32;
 }
 
 # the growing TestArtifact array a test build fills, in collection order
@@ -358,14 +360,15 @@ pub fun build(a: *A.Allocator, argc: usize, argv: **u8, emit_obj: bool) BuildRes
     ret build_unit(a, argc, argv, emit_obj, false, nil, nil, false);
 }
 
-# build one standalone executable per `test` declaration
+# build the single dispatcher executable covering every collected `test`
 #
-# Returns the per-test artifacts (label, source `file:line`, and executable
-# path) for the `mach test` runner to spawn. Every test executable is the
-# project's transitive code plus a synthesized `main` that calls just that test
-# and exits with its `i32` result - independently runnable, never the project's
-# own binary path. Only tests declared in the current project's own modules are
-# built by default; `--include-deps` widens the build to dependency tests (#1556).
+# Returns the per-test artifacts (label, source `file:line`, and dispatch
+# coordinates) for the `mach test` runner to spawn. The one executable is the
+# project's transitive code plus a synthesized dispatcher `main` that runs the
+# test selected by a decimal index argument and exits with its `i32` result -
+# never the project's own binary path. Only tests declared in the current
+# project's own modules are collected by default; `--include-deps` widens the
+# collection to dependency tests (#1556), changing what the dispatcher embeds.
 # With `list_only` the build stops after collecting the tests, leaving each
 # artifact's `exe` nil. The returned strings are owned by `a` and outlive this
 # call's internal session teardown, so the caller frees `a` once it has run every
@@ -443,8 +446,8 @@ pub fun selection_from_config(config: *cfg.Config, out_sel: *manifest.Selection)
 # `cmd.run`/`cmd.test` path); with `ovr` set they come from one enumerated
 # matrix cell (the `mach build` loop), the only field the override replaces -
 # profile and every other flag still apply to each unit. When `tests_out` is
-# non-nil the build is a test build: it produces one executable per `test`
-# declaration and fills `tests_out` instead of linking a single artifact
+# non-nil the build is a test build: it produces the single test dispatcher
+# executable and fills `tests_out` instead of linking the project artifact
 # (`list_only` stops after collection). `test_mode` mirrors `tests_out != nil`.
 # ---
 # a:         allocator owning the session and the returned artifact path
@@ -665,8 +668,8 @@ fun resolve_opt_level(p: *driver.Project, cli_level: u8, cli_set: bool) u8 {
 # Returns the exit code and sets `*out_path` to the produced artifact path on
 # success. `out_override` (-o), when non-nil, replaces the resolved artifact
 # path. When `tests_out` is non-nil the build is a test build: per-module
-# objects are written once and one executable is linked per `test` (filling
-# `tests_out`) rather than a single artifact; `list_only` stops after collecting
+# objects are written once and the single test dispatcher executable is linked
+# (filling `tests_out`) rather than the project artifact; `list_only` stops after collecting
 # the tests.
 # ---
 # p:            the project carrying the module graph and session
@@ -793,23 +796,25 @@ fun compile_and_link(p: *driver.Project, level: u8, emit_obj: bool, test_mode: b
     ret code;
 }
 
-# build one standalone executable per collected `test`
+# build the single dispatcher executable covering every in-scope `test`
 #
-# The per-module objects are written once under the resolved `obj` template; the
-# external link inputs (libc, manifest/CLI libs) are resolved once. Then, for
-# each selected `test`, a tiny entry module (`main(){ret <test>();}`) is
-# synthesized, optimized, codegen'd to its own object, and linked with the shared
-# object set into a standalone executable at the resolved `tests` template path.
-# Only tests declared in the current project's own modules are selected by
-# default; `--include-deps` widens the selection to dependency tests (#1556), and
-# `--filter` narrows it by name. Each test's reporting metadata (label, source
-# `file:line`) and executable path are appended to `tests_out`. With `list_only`
-# the collection alone is reported and no objects or executables are produced. A
+# The per-module objects are written once under the resolved `obj` template and
+# the external link inputs (libc, manifest/CLI libs) are resolved once. One
+# dispatcher entry module (`main(argc, argv)` selecting a test by decimal
+# index) is then synthesized over the in-scope tests, optimized, codegen'd, and
+# linked with the shared object set into one executable at the resolved `tests`
+# template path. Only tests declared in the current project's own modules are
+# in scope by default; `--include-deps` widens the scope to dependency tests
+# (#1556), changing what the dispatcher embeds. `--filter` is a run-time
+# selection in the runner, so the built executable is identical regardless of
+# filter. Each test's reporting metadata (label, source `file:line`) and its
+# dispatch coordinates are appended to `tests_out`. With `list_only` the
+# collection alone is reported and no objects or executables are produced. A
 # build with no tests is a user error.
 # ---
 # p:         the project carrying the module graph and session
 # level:     optimization pipeline level
-# verify_ir: run the IR verifier on each synthesized entry module
+# verify_ir: run the IR verifier on the synthesized dispatcher module
 # root:      the resolved project root directory
 # argc:      argument count including argv[0]
 # argv:      the argument vector (argc null-terminated byte pointers)
@@ -836,26 +841,44 @@ fun build_test_executables(p: *driver.Project, level: u8, verify_ir: bool,
         ret 1;
     }
 
-    # `--filter <substr>`: only the tests whose label contains the substring are
-    # built and reported. applied at build time so a filtered run builds only the
-    # matching executables. nil filter = every test.
-    val filter: *u8 = filter_value(argc, argv);
-
     # `--include-deps`: by default a test run is scoped to the current project's
-    # own modules; this flag also builds and runs tests declared in dependency
+    # own modules; this flag also embeds and runs tests declared in dependency
     # modules (#1556).
     val include_deps: bool = util.has_flag(argc, argv, "--include-deps");
 
-    # `--list`: report each selected test's metadata without producing any object.
-    if (list_only) {
-        var i: u32 = 0;
-        for (i < col.count) {
-            if (test_selected(p, ?col.tests[i], filter, include_deps)) {
-                val rc: i64 = record_test(p, ?col.tests[i], nil, tests_out, p.s.alloc);
-                if (rc != 0) { testrunner.free(p.s, ?col); ret rc; }
-            }
-            i = i + 1;
+    # the in-scope selection the dispatcher embeds; a test's dispatch index is
+    # its position here, stable for the built executable's lifetime.
+    val res_sel: R.Result[*testrunner.Test, str] = A.allocate[testrunner.Test](p.s.alloc, col.count::usize);
+    if (R.is_err[*testrunner.Test, str](res_sel)) {
+        testrunner.free(p.s, ?col);
+        print.eprint("error: out of memory\n");
+        ret 2;
+    }
+    val sel: *testrunner.Test = R.unwrap_ok[*testrunner.Test, str](res_sel);
+    var sel_len: u32 = 0;
+    var i: u32 = 0;
+    for (i < col.count) {
+        if (test_selected(p, ?col.tests[i], include_deps)) {
+            sel[sel_len] = col.tests[i];
+            sel_len = sel_len + 1;
         }
+        i = i + 1;
+    }
+
+    # `--list`: report each in-scope test's metadata without producing any object.
+    if (list_only) {
+        var k: u32 = 0;
+        for (k < sel_len) {
+            val rc: i64 = record_test(p, ?sel[k], nil, k, tests_out, p.s.alloc);
+            if (rc != 0) { testrunner.free(p.s, ?col); ret rc; }
+            k = k + 1;
+        }
+        testrunner.free(p.s, ?col);
+        ret 0;
+    }
+
+    # a scope that selected nothing builds nothing and runs nothing.
+    if (sel_len == 0) {
         testrunner.free(p.s, ?col);
         ret 0;
     }
@@ -891,14 +914,13 @@ fun build_test_executables(p: *driver.Project, level: u8, verify_ir: bool,
         ret ec;
     }
 
-    # each test's compile/link allocations (the synthesized entry IR, its codegen
-    # object image, the parsed link inputs, the merged output image, and the
-    # format unwind tables) route through a per-test scratch arena that is reset
-    # after every test, so peak memory stays bounded by a single test link rather
-    # than growing with the suite. a fresh page allocator backs the scratch arena
-    # so its reset actually returns the chunks to the OS; the shared per-module
-    # objects, the collected list, and each recorded artifact stay on the
-    # persistent allocator, which the reset never touches.
+    # the dispatcher's compile/link allocations (the synthesized entry IR, its
+    # codegen object image, the parsed link inputs, the merged output image, and
+    # the format unwind tables) route through a scratch arena torn down as soon
+    # as the executable is linked, so the transients never outlive the build. a
+    # fresh page allocator backs the arena so teardown actually returns the
+    # chunks to the OS; the shared per-module objects, the collected list, and
+    # each recorded artifact stay on the persistent allocator.
     var scratch_backing: A.Allocator;
     if (O.is_some[str](page.make(?scratch_backing))) {
         free_paths(p.s.alloc, shared, shared_len, shared_len);
@@ -925,63 +947,47 @@ fun build_test_executables(p: *driver.Project, level: u8, verify_ir: bool,
         ret 2;
     }
 
-    # the persistent build allocator, swapped back after every per-test build so
-    # the shared inputs, the collected list, and the recorded artifacts outlive
-    # the scratch reset.
+    # the persistent build allocator, swapped back once the dispatcher is built
+    # so the shared inputs, the collected list, and the recorded artifacts never
+    # touch the scratch arena.
     val persistent: *A.Allocator = p.s.alloc;
 
-    var code: i64 = 0;
-    var i: u32 = 0;
-    for (i < col.count) {
-        if (test_selected(p, ?col.tests[i], filter, include_deps)) {
-            # `i` is the stable collection index, so a test's executable name is
-            # unchanged whether or not a filter is in effect.
-            p.s.alloc = ?scratch_alloc;
-            code = build_one_test(p, level, verify_ir, ?obj_base[0], root, i, ?col.tests[i],
-                                  shared, shared_len, sonames, soname_len, tests_out, persistent);
-            p.s.alloc = persistent;
-            arena.reset(?scratch_ar);
+    var exe_path: [4096]u8;
+    p.s.alloc = ?scratch_alloc;
+    var code: i64 = build_dispatch_executable(p, level, verify_ir, ?obj_base[0], root,
+                                              sel, sel_len, shared, shared_len,
+                                              sonames, soname_len, ?exe_path[0], 4096);
+    p.s.alloc = persistent;
+    arena.dnit(?scratch_ar);
+
+    if (code == 0) {
+        var k: u32 = 0;
+        for (k < sel_len) {
+            code = record_test(p, ?sel[k], ?exe_path[0], k, tests_out, persistent);
             if (code != 0) { brk; }
+            k = k + 1;
         }
-        i = i + 1;
     }
 
-    arena.dnit(?scratch_ar);
     free_paths(p.s.alloc, shared, shared_len, shared_len);
     free_sonames(p.s.alloc, sonames, soname_len);
     testrunner.free(p.s, ?col);
     ret code;
 }
 
-# the `--filter <substr>` value from argv, or nil when absent
-# ---
-# argc: argument count including argv[0]
-# argv: the argument vector (argc null-terminated byte pointers)
-# ret:  the filter substring, or nil when `--filter` is absent
-fun filter_value(argc: usize, argv: **u8) *u8 {
-    val opt_filter: O.Option[*u8] = util.get_value(argc, argv, "--filter");
-    if (O.is_some[*u8](opt_filter)) { ret O.unwrap[*u8](opt_filter); }
-    ret nil;
-}
-
-# whether a test is selected for this run
+# whether a collected test is in scope for this run
 #
-# A test is selected when it is in scope - its declaring module is part of the
-# current project, unless `include_deps` opts dependency tests in (#1556) - and
-# passes the name filter (every test when `filter` is nil, else those whose label
-# contains the filter substring).
+# A test is in scope when its declaring module is part of the current project;
+# `include_deps` opts dependency tests in (#1556). Label filtering (`--filter`)
+# happens at run time in the runner, never here.
 # ---
-# p:            the project (for its interner and module table)
-# t:            the test to test
-# filter:       the filter substring, or nil to select every test
+# p:            the project (for its module table)
+# t:            the test to check
 # include_deps: also select tests declared in dependency modules
-# ret:          true when the test is selected
-fun test_selected(p: *driver.Project, t: *testrunner.Test, filter: *u8, include_deps: bool) bool {
-    if (!include_deps && !test_in_project(p, t)) { ret false; }
-    if (filter == nil) { ret true; }
-    val opt_label: O.Option[str] = intern.lookup(?p.s.interner, t.label);
-    if (O.is_none[str](opt_label)) { ret false; }
-    ret str_contains(O.unwrap[str](opt_label), util.cstr_str(filter));
+# ret:          true when the test is in scope
+fun test_selected(p: *driver.Project, t: *testrunner.Test, include_deps: bool) bool {
+    if (include_deps) { ret true; }
+    ret test_in_project(p, t);
 }
 
 # whether a collected test was declared in a current-project module rather than a
@@ -996,37 +1002,36 @@ fun test_in_project(p: *driver.Project, t: *testrunner.Test) bool {
     ret driver.module_in_current_project(p, m.fqn);
 }
 
-# synthesize, codegen, and link a single test's executable, then record its
-# artifact
+# synthesize, codegen, and link the dispatcher executable
 #
-# The entry module is `main(){ret <test>();}`; its object is written to
-# `<obj_base>/__mach_test_entry_<idx>.o` and linked with the shared object set
-# into the resolved `tests` path. The transient compile/link allocations come
-# from the session allocator, which the caller points at a per-test scratch arena
-# it resets afterward; the recorded artifact is duplicated into `persistent` so it
-# outlives that reset.
+# The entry module is the index dispatcher over `sel`; its object is written to
+# `<obj_base>/__mach_test_dispatch.o` and linked with the shared object set into
+# the resolved `tests` path, whose `{name}` is the product name (falling back to
+# the project id for artifact-less builds). The transient compile/link
+# allocations come from the session allocator, which the caller points at a
+# scratch arena it tears down afterward; the executable path lands in the
+# caller-owned `exe_buf`, which survives that teardown.
 # ---
 # p:          the project carrying the module graph and session
 # level:      optimization pipeline level
-# verify_ir:  run the IR verifier on the synthesized entry module
+# verify_ir:  run the IR verifier on the synthesized dispatcher module
 # obj_base:   the resolved per-module object tree root
 # root:       the resolved project root directory
-# idx:        the test's stable collection index
-# t:          the test to build
+# sel:        the in-scope tests, dispatch index = array position
+# sel_len:    number of tests in `sel`
 # shared:     the shared per-module object path set
 # shared_len: number of shared object paths
 # sonames:    the shared dynamic-dependency soname list
 # soname_len: number of sonames
-# tests_out:  the list to append the test's artifact to
-# persistent: allocator the recorded artifact is duplicated into, outliving the
-#             per-test scratch reset
+# exe_buf:    receives the executable path on success
+# exe_cap:    capacity of `exe_buf`
 # ret:        0 on success, or a non-zero exit code
-fun build_one_test(p: *driver.Project, level: u8, verify_ir: bool, obj_base: *u8, root: *u8,
-                   idx: u32, t: *testrunner.Test,
-                   shared: **u8, shared_len: u32,
-                   sonames: *intern.StrId, soname_len: u32,
-                   tests_out: *TestList, persistent: *A.Allocator) i64 {
-    val res_synth: R.Result[ir.Module, str] = testrunner.synthesize_entry(p.s, t.linkage);
+fun build_dispatch_executable(p: *driver.Project, level: u8, verify_ir: bool, obj_base: *u8, root: *u8,
+                              sel: *testrunner.Test, sel_len: u32,
+                              shared: **u8, shared_len: u32,
+                              sonames: *intern.StrId, soname_len: u32,
+                              exe_buf: *u8, exe_cap: usize) i64 {
+    val res_synth: R.Result[ir.Module, str] = testrunner.synthesize_dispatcher(p.s, sel, sel_len);
     if (R.is_err[ir.Module, str](res_synth)) {
         print.eprint("error: ");
         print.eprint(R.unwrap_err[ir.Module, str](res_synth));
@@ -1054,9 +1059,10 @@ fun build_one_test(p: *driver.Project, level: u8, verify_ir: bool, obj_base: *u8
     }
     var entry_img: of.ObjectImage = R.unwrap_ok[of.ObjectImage, str](res_codegen);
 
-    # write the entry object alongside the per-module objects.
+    # write the dispatcher object alongside the per-module objects.
     var entry_path: [4096]u8;
-    if (!entry_object_path(obj_base, idx, ?entry_path[0], 4096) || !util.ensure_parents(?entry_path[0])) {
+    if (util.join_into(?entry_path[0], 4096, obj_base, "__mach_test_dispatch.o") == 0
+        || !util.ensure_parents(?entry_path[0])) {
         obj.dnit(?entry_img);
         ir.dnit(?entry_ir);
         print.eprint("error: failed to create test object directory\n");
@@ -1072,19 +1078,27 @@ fun build_one_test(p: *driver.Project, level: u8, verify_ir: bool, obj_base: *u8
         ret 1;
     }
 
-    # the executable path: `<root>/<tests template with {name} = sanitized name>`.
-    var name_buf: [256]u8;
-    sanitize_test_name(?name_buf[0], 256, idx, t.label, ?p.s.interner);
-    var exe_path: [4096]u8;
-    if (!resolve_test_exe(p, root, util.cstr_str(?name_buf[0]), ?exe_path[0], 4096) || !util.ensure_parents(?exe_path[0])) {
+    # the executable path: `<root>/<tests template with {name} = product name>`.
+    if (!resolve_test_exe(p, root, util.cstr_str(dispatch_exe_name(p)), exe_buf, exe_cap)
+        || !util.ensure_parents(exe_buf)) {
         print.eprint("error: failed to resolve the test executable path; check the `tests` template in mach.toml\n");
         ret 2;
     }
 
-    val lc: i64 = link_one_test(p, shared, shared_len, sonames, soname_len, ?entry_path[0], ?exe_path[0]);
-    if (lc != 0) { ret lc; }
+    ret link_one_test(p, shared, shared_len, sonames, soname_len, ?entry_path[0], exe_buf);
+}
 
-    ret record_test(p, t, ?exe_path[0], tests_out, persistent);
+# the dispatcher executable's `{name}`: the selected artifact's product name,
+# falling back to the project id when no artifact is selected (a library build)
+# ---
+# p:   the project carrying the session and selected artifact config
+# ret: the borrowed null-terminated name, never empty
+fun dispatch_exe_name(p: *driver.Project) *u8 {
+    val product: *u8 = artifact_product_name(p);
+    if (str_len(util.cstr_str(product)) > 0) { ret product; }
+    val opt_id: O.Option[str] = intern.lookup(?p.s.interner, p.config.id);
+    if (O.is_some[str](opt_id)) { ret O.unwrap[str](opt_id)::*u8; }
+    ret "tests";
 }
 
 # the selected artifact's product name (the `[bin.<name>]`), resolved to a
@@ -1102,7 +1116,7 @@ fun artifact_product_name(p: *driver.Project) *u8 {
     ret ""::*u8;
 }
 
-# link the shared object set plus one test's entry object into the test
+# link the shared object set plus the dispatcher entry object into the test
 # executable at `exe_path`
 #
 # The shared paths are reused across tests, so the combined array borrows their
@@ -1143,17 +1157,19 @@ fun link_one_test(p: *driver.Project, shared: **u8, shared_len: u32,
 # append a test's reporting artifact to `tests_out`
 #
 # Duplicates every string into `a` so it outlives the session teardown and the
-# per-test scratch reset. `exe` is nil in `--list` mode.
+# dispatcher build's scratch teardown. `exe` is nil in `--list` mode.
 # ---
 # p:         the project (for its interner and source map)
 # t:         the test to record
-# exe:       the executable path, or nil in `--list` mode
+# exe:       the dispatcher executable path, or nil in `--list` mode
+# idx:       the test's dispatch index
 # tests_out: the list to append the artifact to
 # a:         allocator backing the duplicated strings and the list
 # ret:       0 on success, or a non-zero exit code
-fun record_test(p: *driver.Project, t: *testrunner.Test, exe: *u8, tests_out: *TestList, a: *A.Allocator) i64 {
+fun record_test(p: *driver.Project, t: *testrunner.Test, exe: *u8, idx: u32, tests_out: *TestList, a: *A.Allocator) i64 {
     var artifact: TestArtifact;
     artifact.line = t.line;
+    artifact.idx  = idx;
 
     artifact.module = dup_cstr(a, test_module_fqn(p, t.mod_idx));
     if (artifact.module == nil) { print.eprint("error: out of memory\n"); ret 2; }
@@ -1234,27 +1250,6 @@ fun test_source_path(p: *driver.Project, mod_idx: u32) *u8 {
     val opt_file: O.Option[*source.SourceFile] = source.get(?p.s.sources, m.file_id);
     if (O.is_none[*source.SourceFile](opt_file)) { ret "<unknown>"; }
     ret O.unwrap[*source.SourceFile](opt_file).path::*u8;
-}
-
-# compose `<obj_base>/__mach_test_entry_<idx>.o` into `buf`
-# ---
-# obj_base: the per-module object tree root
-# idx:      the test's collection index
-# buf:      the destination buffer
-# cap:      the buffer capacity
-# ret:      false if it would not fit
-fun entry_object_path(obj_base: *u8, idx: u32, buf: *u8, cap: usize) bool {
-    var leaf: [64]u8;
-    var k:    usize = 0;
-    val prefix: str   = "__mach_test_entry_";
-    val pl:     usize = str_len(prefix);
-    var i: usize = 0;
-    for (i < pl) { leaf[k] = prefix[i]; k = k + 1; i = i + 1; }
-    k = k + write_u32(?leaf[k], 64 - k, idx);
-    leaf[k] = '.'; k = k + 1;
-    leaf[k] = 'o'; k = k + 1;
-    leaf[k] = 0;
-    ret util.join_into(buf, cap, obj_base, ?leaf[0]) > 0;
 }
 
 # write the `{name}` for a test's executable into `buf` as `<idx>-<label>`

--- a/src/cli/cmd/check.mach
+++ b/src/cli/cmd/check.mach
@@ -2,10 +2,11 @@
 #
 # The editor-facing diagnostics slice exposed as a CLI verb: read one source
 # file, feed its text directly into the editor query surface (mach.lang.editor),
-# and render every reported diagnostic as `severity: path:line:col: message`
-# with a caret underline. It needs no mach.toml, no module graph, and no link
-# step; it is best-effort over a single buffer, exactly what an editor wants, and
-# the in-tree consumer that exercises the editor surface end to end.
+# and render every reported diagnostic as a framed source snippet (headline,
+# `--> file:line:col`, gutter, and caret). It needs no mach.toml, no module
+# graph, and no link step; it is best-effort over a single buffer, exactly what
+# an editor wants, and the in-tree consumer that exercises the editor surface
+# end to end.
 #
 # Exit codes: 0 when the buffer has no error-severity diagnostics, 1 when it has
 # any (or on a usage / io error).
@@ -13,7 +14,6 @@
 use std.allocator.arena;
 use std.filesystem;
 use std.print;
-use std.types.bool.false;
 use std.types.size.usize;
 use std.types.string.str;
 
@@ -82,8 +82,8 @@ pub fun run(argc: usize, argv: **u8) i64 {
 
 # open the buffer, collect its diagnostics, render them, and return the exit code
 #
-# The diagnostics are rendered uncolored so an LSP consuming this stream reads
-# plain text, never ANSI escapes. The session backing the source-map spans is
+# The renderer is ASCII-only, so an LSP consuming this stream reads plain text,
+# never color or terminal escapes. The session backing the source-map spans is
 # the one the editor session borrows.
 # ---
 # es:   the editor session the buffer is opened in
@@ -107,7 +107,7 @@ fun check_buffer(es: *editor.EditorSession, path: str, text: str) i64 {
     }
     val list: *diagnostic.DiagList = R.unwrap_ok[*diagnostic.DiagList, str](res_diags);
 
-    cli_diag.flush(es.s, list, false);
+    cli_diag.flush(es.s, list);
     if (diagnostic.has_errors(list)) {
         ret 1;
     }

--- a/src/cli/cmd/help.mach
+++ b/src/cli/cmd/help.mach
@@ -141,6 +141,8 @@ fun help_test() {
     print.print("options:\n");
     print.print("  -v                  list every test under its module as it completes\n");
     print.print("  -vv                 as -v, also printing passing tests' output\n");
+    print.print("  --jobs <n>          run up to <n> test processes at once; defaults to\n");
+    print.print("                      the CPUs available to this process, 1 serializes\n");
     print.print("  --filter <substr>   run only tests whose name contains <substr>\n");
     print.print("  --include-deps      also run tests declared in dependency modules\n");
     print.print("  --list              list the collected tests and exit\n");

--- a/src/cli/cmd/help.mach
+++ b/src/cli/cmd/help.mach
@@ -139,6 +139,8 @@ fun help_test() {
     print.print("flags apply.\n");
     print.print("\n");
     print.print("options:\n");
+    print.print("  -v                  list every test under its module as it completes\n");
+    print.print("  -vv                 as -v, also printing passing tests' output\n");
     print.print("  --filter <substr>   run only tests whose name contains <substr>\n");
     print.print("  --include-deps      also run tests declared in dependency modules\n");
     print.print("  --list              list the collected tests and exit\n");

--- a/src/cli/cmd/help.mach
+++ b/src/cli/cmd/help.mach
@@ -52,8 +52,9 @@ pub fun run(argc: usize, argv: **u8) i64 {
 # that honours them.
 fun global_flags() {
     print.print("global flags:\n");
-    print.print("  --verbose, -v     surface extra detail (per-stage progress) on stderr\n");
-    print.print("  --quiet, -q       suppress non-error output (mutually exclusive with -v)\n");
+    print.print("  -v                phase roll-up with timing + a build summary on stderr\n");
+    print.print("  -vv               -v plus per-module/file detail under each phase\n");
+    print.print("  --quiet, -q       suppress non-error output (mutually exclusive with -v/-vv)\n");
     print.print("  --color <mode>    auto | always | never (default auto)\n");
     print.print("  --target <name>   select a [targets.<name>] entry\n");
     print.print("  -o <path>         override the linked-binary path (build/run/test)\n");

--- a/src/cli/cmd/help.mach
+++ b/src/cli/cmd/help.mach
@@ -131,18 +131,19 @@ fun help_run() {
 fun help_test() {
     print.print("usage: mach test <path> [options]\n");
     print.print("\n");
-    print.print("build one standalone executable per 'test' declaration (under the\n");
-    print.print("'tests' template) and run each as a separate process, reporting\n");
-    print.print("'name file:line PASS|FAIL'. a crash reports its signal and the run\n");
-    print.print("continues. only the current project's own tests run by default;\n");
-    print.print("all 'mach build' and global flags apply.\n");
+    print.print("build one dispatcher executable covering every 'test' declaration\n");
+    print.print("(under the 'tests' template) and run each test as its own process\n");
+    print.print("('<exe> <idx>'), reporting a per-module roll-up that expands failures.\n");
+    print.print("a crash reports its signal and the run continues. only the current\n");
+    print.print("project's own tests run by default; all 'mach build' and global\n");
+    print.print("flags apply.\n");
     print.print("\n");
     print.print("options:\n");
     print.print("  --filter <substr>   run only tests whose name contains <substr>\n");
     print.print("  --include-deps      also run tests declared in dependency modules\n");
     print.print("  --list              list the collected tests and exit\n");
-    print.print("  --runner <cmd>      launch every test as '<cmd> <exe>'. <cmd> is a\n");
-    print.print("                      single command name or path (no shell splitting),\n");
+    print.print("  --runner <cmd>      launch every test as '<cmd> <exe> <idx>'. <cmd> is\n");
+    print.print("                      a single command name or path (no shell splitting),\n");
     print.print("                      resolved on PATH. for foreign-target tests, e.g.\n");
     print.print("                      --target windows --runner wine\n");
     print.print("\n");

--- a/src/cli/cmd/testing.mach
+++ b/src/cli/cmd/testing.mach
@@ -8,19 +8,21 @@
 # output, times it, and reads its exit status - per-test process isolation is
 # unchanged, only the build is shared.
 #
-# the default readout collapses every all-passing module to a single roll-up
-# line (`mach.lang.driver  36 ok  41ms`) and expands any module with failures,
-# printing each failing test's captured child output, `file:line`, and exit
-# code or signal. the run ends with a summary that re-lists the failures. a
-# crashing test (a signal) is reported and the run continues, so one SIGSEGV no
-# longer kills the suite. `-v` lists every test, grouped by module, with its
-# duration. timing is `chrono.monotonic`; durations and the column widths use
-# the stdlib formatting primitives; the layout is fixed-width ASCII.
+# the readout is live: each module's roll-up line (`mach.lang.driver  36 ok
+# 41ms`) prints the moment its last test completes, and a module with failures
+# expands each failing test's captured child output, `file:line`, and exit
+# code or signal as it happens. the run ends with a summary that re-lists the
+# failures and reports the run's wall time. a crashing test (a signal) is
+# reported and the run continues, so one SIGSEGV no longer kills the suite.
+# `-v` lists every test under its module header as it completes; `-vv` also
+# prints passing tests' captured output. timing is `chrono.monotonic`; column
+# widths are computed from the collected tests before the run (clamped, so one
+# long name cannot blow out the table); the layout is fixed-width ASCII.
 #
 # child output is captured through `std.process.exec.capture`, which pipes the
 # child's stdout and drains it to EOF before waiting, so a chatty test never
 # deadlocks the runner. only failing tests retain their output (passing tests
-# stay quiet); the captured bytes surface under the expanded failure.
+# stay quiet below `-vv`); the captured bytes surface under the expanded test.
 #
 # by default only `test` blocks declared in the current project's own modules are
 # collected; `--include-deps` widens collection to dependency modules too (#1556).
@@ -47,7 +49,6 @@ use std.types.string.str;
 use std.types.string.str_contains;
 use std.types.string.str_equals;
 use std.types.string.str_len;
-use std.types.string.str_starts_with;
 
 use A:      std.allocator;
 use O:      std.types.option;
@@ -78,9 +79,9 @@ val CAP_OUTPUT: usize = 65536;
 
 # the result of running one test
 #
-# `out` retains the captured child stdout only for a failing test (passing tests
-# discard it); it is owned by the run allocator and aliases nothing in the reused
-# capture buffer.
+# `out` retains the captured child stdout for a failing test (and for a passing
+# one under `-vv`); it is owned by the run allocator and aliases nothing in the
+# reused capture buffer.
 # ---
 # art:       the built test artifact (borrowed; owned by the run allocator)
 # kind:      a KIND_* outcome
@@ -110,9 +111,11 @@ rec Outcome {
 pub fun run(argc: usize, argv: **u8) i64 {
     val list: bool = util.has_flag(argc, argv, "--list");
 
-    # `-v` or `-vv` lists every test; the runner has a single verbose level and
-    # mirrors the shared verbosity flags (`--verbose` was dropped in #1775).
-    val verbose: bool = util.has_flag(argc, argv, "-v") || util.has_flag(argc, argv, "-vv");
+    # verbosity mirrors the shared flags (`--verbose` was dropped in #1775):
+    # `-v` lists every test as it completes, `-vv` also prints passing output.
+    var level: u8 = 0;
+    if (util.has_flag(argc, argv, "-v"))  { level = 1; }
+    if (util.has_flag(argc, argv, "-vv")) { level = 2; }
 
     # back the build with an arena over a page allocator, matching `mach build`.
     # the build's internal teardown frees through this allocator; the page
@@ -218,37 +221,56 @@ pub fun run(argc: usize, argv: **u8) i64 {
     }
     val buf: *u8 = R.unwrap_ok[*u8, str](res_buf);
 
-    execute_all(?a, selected, sel_len, runner, outcomes, buf);
+    # column widths come from the selection, so live lines align on the first
+    # write with no second pass; clamping keeps one long name from blowing out
+    # the whole table.
+    val mod_w:   usize = module_col_width(selected, sel_len);
+    val label_w: usize = label_col_width(selected, sel_len);
 
-    if (verbose) { render_verbose(outcomes, sel_len); }
-    or          { render_default(outcomes, sel_len); }
+    val run_start: tm.Time = tm.monotonic();
+    execute_and_render(?a, selected, sel_len, runner, outcomes, buf, level, mod_w, label_w);
+    val wall: du.Duration = tm.time_sub(tm.monotonic(), run_start);
 
     val failed: u32 = count_failed(outcomes, sel_len);
     val passed: u32 = sel_len - failed;
-    render_summary(outcomes, sel_len, passed, failed);
+    render_summary(outcomes, sel_len, passed, failed, wall);
 
     arena.dnit(?ar);
     if (failed > 0) { ret 1; }
     ret 0;
 }
 
-# spawn every selected test, capturing its stdout and timing it, into `outcomes`
+# spawn every selected test in collection order, rendering the readout live as
+# results land
 #
 # Each child is run with its stdout piped and drained to EOF (capture), so a
-# chatty test cannot deadlock the runner; stderr is inherited. A failing test's
-# captured bytes are copied out of the reused buffer into the run allocator so
-# they survive the next test overwriting the buffer.
+# chatty test cannot deadlock the runner; stderr is inherited. A retained
+# test's captured bytes are copied out of the reused buffer into the run
+# allocator so they survive the next test overwriting the buffer (failures
+# always retain; passes retain under `-vv`). At the default level a module's
+# roll-up prints the moment its last test completes; under `-v` a module
+# header prints when its first test starts and each test line prints on
+# completion.
 # ---
-# a:        allocator retaining each failing test's captured output
+# a:        allocator retaining captured output
 # arts:     the selected test artifacts to run, in collection order
 # n:        number of artifacts in `arts`
 # runner:   resolved `--runner` launcher, or nil to exec the dispatcher directly
 # outcomes: caller-owned array (length n) filled in test order
 # buf:      the reused capture buffer (CAP_OUTPUT bytes)
-fun execute_all(a: *A.Allocator, arts: *build.TestArtifact, n: u32, runner: *u8, outcomes: *Outcome, buf: *u8) {
+# level:    verbosity (0 roll-ups, 1 per-test lines, 2 also passing output)
+# mod_w:    module roll-up column width
+# label_w:  `-v` label column width
+fun execute_and_render(a: *A.Allocator, arts: *build.TestArtifact, n: u32, runner: *u8,
+                       outcomes: *Outcome, buf: *u8, level: u8, mod_w: usize, label_w: usize) {
+    # first index of the module run currently executing
+    var first: u32 = 0;
     var i: u32 = 0;
     for (i < n) {
         val art: *build.TestArtifact = ?arts[i];
+        val mod_name: str = util.cstr_str(art.module);
+
+        if (level > 0 && i == first) { print.printf("{}\n", mod_name); }
 
         # the test's dispatch index, rendered for the child's argv
         var ibuf: [16]u8;
@@ -291,6 +313,8 @@ fun execute_all(a: *A.Allocator, arts: *build.TestArtifact, n: u32, runner: *u8,
             val st:  exec.ExitStatus = cap.status;
             if (exec.exited(st) && exec.code(st) == 0) {
                 o.kind = KIND_PASS;
+                # `-vv` surfaces passing output too, so it is worth retaining
+                if (level >= 2) { retain_output(a, ?o, buf, cap.len); }
             }
             or (exec.signaled(st)) {
                 # a crash reports the signal and the run continues to the next test.
@@ -310,7 +334,48 @@ fun execute_all(a: *A.Allocator, arts: *build.TestArtifact, n: u32, runner: *u8,
         }
 
         outcomes[i] = o;
+
+        if (level > 0) { print_verbose_test(?outcomes[i], label_w); }
+
+        # the module's run is complete when the next artifact starts a new
+        # module (or the selection ends); the roll-up prints right then.
+        val last_of_module: bool = i + 1 == n
+            || !str_equals(util.cstr_str(arts[i + 1].module), mod_name);
+        if (last_of_module) {
+            if (level == 0) { render_module_run(outcomes, first, i, mod_name, mod_w); }
+            first = i + 1;
+        }
         i = i + 1;
+    }
+}
+
+# render one completed module run under the default readout: the roll-up line,
+# then the expanded detail of each failure in the run
+# ---
+# outcomes: the run outcomes in test order
+# first:    index of the module's first outcome
+# last:     index of the module's last outcome (inclusive)
+# mod_name: the module's fully-qualified name
+# mod_w:    module column width
+fun render_module_run(outcomes: *Outcome, first: u32, last: u32, mod_name: str, mod_w: usize) {
+    var ok:      u32 = 0;
+    var fail:    u32 = 0;
+    var elapsed: du.Duration = 0;
+    var j: u32 = first;
+    for (j <= last) {
+        if (outcomes[j].kind == KIND_PASS) { ok = ok + 1; }
+        or                                 { fail = fail + 1; }
+        elapsed = elapsed + outcomes[j].elapsed;
+        j = j + 1;
+    }
+
+    print_rollup(mod_name, ok, fail, elapsed, mod_w);
+    if (fail > 0) {
+        j = first;
+        for (j <= last) {
+            if (outcomes[j].kind != KIND_PASS) { print_fail_detail(?outcomes[j]); }
+            j = j + 1;
+        }
     }
 }
 
@@ -345,64 +410,71 @@ fun retain_output(a: *A.Allocator, o: *Outcome, buf: *u8, full: usize) {
     o.out_len = stored;
 }
 
-# the default readout: one roll-up line per module, expanding only failures
-#
-# Tests arrive grouped by declaring module (collection order), so a module's run
-# is the maximal adjacent run of equal module names. An all-passing module shows
-# only its roll-up; a module with failures additionally expands each failing test.
+# the width of the module roll-up column: the longest selected module FQN,
+# clamped so one deep module tree cannot blow out the table, plus the gutter
 # ---
-# outcomes: the run outcomes in test order
-# len:      number of outcomes
-fun render_default(outcomes: *Outcome, len: u32) {
+# arts: the selected test artifacts
+# n:    number of artifacts
+# ret:  the column width in bytes
+fun module_col_width(arts: *build.TestArtifact, n: u32) usize {
+    var w: usize = 0;
     var i: u32 = 0;
-    for (i < len) {
-        val mod_name: str = util.cstr_str(outcomes[i].art.module);
-
-        var j:       u32 = i;
-        var ok:      u32 = 0;
-        var fail:    u32 = 0;
-        var elapsed: du.Duration = 0;
-        for (j < len) {
-            if (!str_equals(util.cstr_str(outcomes[j].art.module), mod_name)) { brk; }
-            if (outcomes[j].kind == KIND_PASS) { ok = ok + 1; }
-            or                                 { fail = fail + 1; }
-            elapsed = elapsed + outcomes[j].elapsed;
-            j = j + 1;
-        }
-
-        print_rollup(mod_name, ok, fail, elapsed);
-        if (fail > 0) {
-            var k: u32 = i;
-            for (k < j) {
-                if (outcomes[k].kind != KIND_PASS) { print_fail_detail(?outcomes[k], mod_name); }
-                k = k + 1;
-            }
-        }
-        i = j;
+    for (i < n) {
+        val l: usize = str_len(util.cstr_str(arts[i].module));
+        if (l > w) { w = l; }
+        i = i + 1;
     }
+    if (w < 16) { w = 16; }
+    if (w > 48) { w = 48; }
+    ret w + 2;
 }
 
-# the `-v` readout: every test listed under its module with its duration
-#
-# Failing tests additionally carry their location, exit status, and captured
-# output, so `-v` is a superset of the default expansion.
+# the width of the `-v` label column: the longest label (verbatim, as the
+# test declared it), clamped, plus the gutter
 # ---
-# outcomes: the run outcomes in test order
-# len:      number of outcomes
-fun render_verbose(outcomes: *Outcome, len: u32) {
+# arts: the selected test artifacts
+# n:    number of artifacts
+# ret:  the column width in bytes
+fun label_col_width(arts: *build.TestArtifact, n: u32) usize {
+    var w: usize = 0;
     var i: u32 = 0;
-    for (i < len) {
-        val mod_name: str = util.cstr_str(outcomes[i].art.module);
-        print.printf("{}\n", mod_name);
-
-        var j: u32 = i;
-        for (j < len) {
-            if (!str_equals(util.cstr_str(outcomes[j].art.module), mod_name)) { brk; }
-            print_verbose_test(?outcomes[j], mod_name);
-            j = j + 1;
-        }
-        i = j;
+    for (i < n) {
+        val l: usize = str_len(util.cstr_str(arts[i].label));
+        if (l > w) { w = l; }
+        i = i + 1;
     }
+    if (w < 24) { w = 24; }
+    if (w > 72) { w = 72; }
+    ret w + 2;
+}
+
+# write `s` padded with trailing spaces to `width`; a value longer than the
+# column still gets the two-space gutter so the next column never touches it
+# ---
+# s:     the column value
+# width: the column width
+fun print_col(s: str, width: usize) {
+    print.print(s);
+    var pad: usize = 2;
+    val l: usize = str_len(s);
+    if (l + 2 < width) { pad = width - l; }
+    var i: usize = 0;
+    for (i < pad) { print.print(" "); i = i + 1; }
+}
+
+# write the two-space gutter, then a duration right-aligned to a seven-byte
+# column (durations end their line, so the shared right edge keeps the table
+# tidy)
+# ---
+# elapsed: the duration to render
+fun print_dur(elapsed: du.Duration) {
+    var dbuf: [24]u8;
+    val ds: str = du.format_duration(elapsed, ?dbuf[0], 24::usize);
+    val l: usize = str_len(ds);
+    print.print("  ");
+    var i: usize = l;
+    for (i < 7) { print.print(" "); i = i + 1; }
+    print.print(ds);
 }
 
 # write one module's roll-up line: `<module>  <ok> ok[  <fail> FAIL]  <dur>`
@@ -410,43 +482,46 @@ fun render_verbose(outcomes: *Outcome, len: u32) {
 # mod_name: the module's fully-qualified name
 # ok:       number of passing tests
 # fail:     number of failing tests
-# elapsed:  total wall time of the module's tests
-fun print_rollup(mod_name: str, ok: u32, fail: u32, elapsed: du.Duration) {
-    var dbuf: [24]u8;
-    val ds: str = du.format_duration(elapsed, ?dbuf[0], 24::usize);
-    if (fail > 0) {
-        print.printf("{:<34}{:4} ok  {:4} FAIL  {}\n", mod_name, ok::i64, fail::i64, ds);
-    }
-    or {
-        print.printf("{:<34}{:4} ok  {}\n", mod_name, ok::i64, ds);
-    }
+# elapsed:  summed wall time of the module's tests
+# mod_w:    module column width
+fun print_rollup(mod_name: str, ok: u32, fail: u32, elapsed: du.Duration, mod_w: usize) {
+    print_col(mod_name, mod_w);
+    if (fail > 0) { print.printf("{:4} ok  {:4} FAIL", ok::i64, fail::i64); }
+    or           { print.printf("{:4} ok", ok::i64); }
+    print_dur(elapsed);
+    print.print("\n");
 }
 
 # write the expanded detail for one failing test under the default readout
 # ---
-# o:        the failing outcome
-# mod_name: its module's name, stripped from the label for a compact display
-fun print_fail_detail(o: *Outcome, mod_name: str) {
-    val label: str = display_label(mod_name, util.cstr_str(o.art.label));
+# o: the failing outcome
+fun print_fail_detail(o: *Outcome) {
+    val label: str = util.cstr_str(o.art.label);
     print.printf("  FAIL  {}  {}:{}  ", label, util.cstr_str(o.art.file), o.art.line::i64);
     print_reason(o);
     print.print("\n");
     print_captured(o);
 }
 
-# write one test's line under the `-v` readout, expanding a failure inline
+# write one test's line under the `-v` readout as it completes, expanding a
+# failure inline; a passing test's retained output (`-vv`) prints beneath it
 # ---
-# o:        the outcome to list
-# mod_name: its module's name, stripped from the label for a compact display
-fun print_verbose_test(o: *Outcome, mod_name: str) {
-    var dbuf: [24]u8;
-    val ds:    str = du.format_duration(o.elapsed, ?dbuf[0], 24::usize);
-    val label: str = display_label(mod_name, util.cstr_str(o.art.label));
+# o:       the outcome to list
+# label_w: label column width
+fun print_verbose_test(o: *Outcome, label_w: usize) {
+    val label: str = util.cstr_str(o.art.label);
     if (o.kind == KIND_PASS) {
-        print.printf("  {:<4}  {:<40}{}\n", "ok", label, ds);
+        print.print("  ok    ");
+        print_col(label, label_w);
+        print_dur(o.elapsed);
+        print.print("\n");
+        print_captured(o);
     }
     or {
-        print.printf("  {:<4}  {:<40}{}  ", "FAIL", label, ds);
+        print.print("  FAIL  ");
+        print_col(label, label_w);
+        print_dur(o.elapsed);
+        print.print("  ");
         print_reason(o);
         print.printf("  {}:{}\n", util.cstr_str(o.art.file), o.art.line::i64);
         print_captured(o);
@@ -463,8 +538,8 @@ fun print_reason(o: *Outcome) {
     or                         { print.print("(failed)"); }
 }
 
-# write a failing test's retained stdout, each line indented, then a truncation
-# note when the output overflowed the capture buffer
+# write a test's retained stdout, each line indented, then a truncation note
+# when the output overflowed the capture buffer
 #
 # Nothing is written when the test produced no output. The bytes are streamed
 # verbatim through a stdout writer so arbitrary content (not null-terminated)
@@ -499,13 +574,14 @@ fun print_captured(o: *Outcome) {
 }
 
 # write the closing summary: a `failures:` block re-listing each failure, then a
-# `passed/failed/total` count with the run's total wall time
+# `passed/failed/total` count with the run's wall time
 # ---
 # outcomes: the run outcomes in test order
 # len:      number of outcomes
 # passed:   number of passing tests
 # failed:   number of failing tests
-fun render_summary(outcomes: *Outcome, len: u32, passed: u32, failed: u32) {
+# wall:     the run's wall time (start of first spawn to last completion)
+fun render_summary(outcomes: *Outcome, len: u32, passed: u32, failed: u32, wall: du.Duration) {
     print.print("\n");
 
     if (failed > 0) {
@@ -526,7 +602,7 @@ fun render_summary(outcomes: *Outcome, len: u32, passed: u32, failed: u32) {
     }
 
     var dbuf: [24]u8;
-    val ds: str = du.format_duration(total_elapsed(outcomes, len), ?dbuf[0], 24::usize);
+    val ds: str = du.format_duration(wall, ?dbuf[0], 24::usize);
     print.printf("{} passed, {} failed, {} total  ({})\n", passed::i64, failed::i64, len::i64, ds);
 }
 
@@ -543,40 +619,6 @@ fun count_failed(outcomes: *Outcome, len: u32) u32 {
         i = i + 1;
     }
     ret f;
-}
-
-# the summed wall time of every outcome
-# ---
-# outcomes: the run outcomes
-# len:      number of outcomes
-# ret:      total elapsed duration
-fun total_elapsed(outcomes: *Outcome, len: u32) du.Duration {
-    var t: du.Duration = 0;
-    var i: u32 = 0;
-    for (i < len) {
-        t = t + outcomes[i].elapsed;
-        i = i + 1;
-    }
-    ret t;
-}
-
-# strip a leading `<module>.` from a test label for a compact per-module display
-#
-# Mach tests are named with their fully-qualified path by convention (e.g.
-# `mach.lang.driver.builds:trivial`), so under a module roll-up the prefix is
-# redundant. A label that does not carry the prefix is returned unchanged.
-# ---
-# mod_name: the module's fully-qualified name
-# label:    the test's printable label
-# ret:      the label with a matching `<module>.` prefix removed
-fun display_label(mod_name: str, label: str) str {
-    if (str_starts_with(label, mod_name)) {
-        val ml: usize = str_len(mod_name);
-        if (label[ml] == '.') {
-            ret (label::usize + ml + 1::usize)::str;
-        }
-    }
-    ret label;
 }
 
 # write a test's identifying `label file:line` prefix to stdout, no trailing

--- a/src/cli/cmd/testing.mach
+++ b/src/cli/cmd/testing.mach
@@ -19,17 +19,23 @@
 # widths are computed from the collected tests before the run (clamped, so one
 # long name cannot blow out the table); the layout is fixed-width ASCII.
 #
-# child output is captured through `std.process.exec.capture`, which pipes the
-# child's stdout and drains it to EOF before waiting, so a chatty test never
-# deadlocks the runner. only failing tests retain their output (passing tests
-# stay quiet below `-vv`); the captured bytes surface under the expanded test.
+# tests run in parallel: a sliding window of `--jobs` children (defaulting to
+# the CPUs available to this process; 1 serializes) is kept in flight and
+# reaped with a blocking wait-any. each child's stdout and stderr are bound to
+# a per-test capture file under `log/` beside the dispatcher, so the kernel
+# does the buffering and a chatty test never blocks. a passing test's file is
+# unlinked on reap (retained first under `-vv`); a failing test's file stays
+# for inspection, and its first 64KB surface under the expanded failure along
+# with the exact rerun command. results always render in collection order, so
+# the readout is deterministic regardless of completion order.
 #
 # by default only `test` blocks declared in the current project's own modules are
 # collected; `--include-deps` widens collection to dependency modules too (#1556).
 # `--list` prints the collected tests without building or running them.
 # `--filter <substr>` selects the tests whose name contains the substring; it is
 # applied here at run time, so the built executable is identical regardless of
-# filter. `--runner <cmd>` launches every test as `<cmd> <exe> <idx>` instead of
+# filter. `--jobs <n>` overrides the parallel window width. `--runner <cmd>`
+# launches every test as `<cmd> <exe> <idx>` instead of
 # spawning the executable directly - the host-side launcher for foreign-target
 # artifacts (e.g. wine for a windows target, #1345). absent the flag, the
 # executable is spawned directly and a spawn failure reports exactly that.
@@ -55,6 +61,7 @@ use O:      std.types.option;
 use R:      std.types.result;
 use fmt:    std.format;
 use fs:     std.filesystem;
+use sys:    std.system.os;
 use writer: std.io.writer;
 use tm:     std.chrono.time;
 use du:     std.chrono.duration;
@@ -72,16 +79,18 @@ val KIND_SIGNAL: u8 = 2;
 val KIND_SPAWN:  u8 = 3;
 # a test that neither exited nor signaled (should not occur)
 val KIND_OTHER:  u8 = 4;
+# a test not yet finalized; the render cursor never crosses one
+val KIND_PENDING: u8 = 5;
 
-# capacity of the per-test stdout capture buffer; a child writing more is drained
-# past it (so it never blocks) and its retained output is marked truncated
+# most retained bytes per test from its capture file; a file holding more is
+# retained truncated (the file itself keeps the full output)
 val CAP_OUTPUT: usize = 65536;
 
 # the result of running one test
 #
-# `out` retains the captured child stdout for a failing test (and for a passing
-# one under `-vv`); it is owned by the run allocator and aliases nothing in the
-# reused capture buffer.
+# `out` retains the captured child output for a failing test (and for a
+# passing one under `-vv`), read back from the test's capture file; it is
+# owned by the run allocator.
 # ---
 # art:       the built test artifact (borrowed; owned by the run allocator)
 # kind:      a KIND_* outcome
@@ -116,6 +125,23 @@ pub fun run(argc: usize, argv: **u8) i64 {
     var level: u8 = 0;
     if (util.has_flag(argc, argv, "-v"))  { level = 1; }
     if (util.has_flag(argc, argv, "-vv")) { level = 2; }
+
+    # `--jobs <n>` bounds how many test children run at once; the default is
+    # the CPUs available to this process, and 1 serializes.
+    var jobs: u32 = 1;
+    val opt_jobs: O.Option[*u8] = util.get_value(argc, argv, "--jobs");
+    if (O.is_some[*u8](opt_jobs)) {
+        val jv: i64 = parse_count(O.unwrap[*u8](opt_jobs));
+        if (jv < 1) {
+            print.eprint("error: --jobs expects a positive integer\n");
+            ret 1;
+        }
+        jobs = jv::u32;
+    }
+    or {
+        val nc: i64 = sys.cpu_count();
+        if (nc > 1) { jobs = nc::u32; }
+    }
 
     # back the build with an arena over a page allocator, matching `mach build`.
     # the build's internal teardown frees through this allocator; the page
@@ -204,7 +230,7 @@ pub fun run(argc: usize, argv: **u8) i64 {
         ret 0;
     }
 
-    # one Outcome per selected test, plus a single reused stdout capture buffer.
+    # one Outcome per selected test.
     val res_out: R.Result[*Outcome, str] = A.allocate[Outcome](?a, sel_len::usize);
     if (R.is_err[*Outcome, str](res_out)) {
         arena.dnit(?ar);
@@ -213,13 +239,16 @@ pub fun run(argc: usize, argv: **u8) i64 {
     }
     val outcomes: *Outcome = R.unwrap_ok[*Outcome, str](res_out);
 
-    val res_buf: R.Result[*u8, str] = A.allocate[u8](?a, CAP_OUTPUT);
-    if (R.is_err[*u8, str](res_buf)) {
+    # per-test capture files live under `log/` beside the dispatcher. wiping
+    # this build's index range at run start leaves the directory holding only
+    # the failures of the run about to happen.
+    var log_dir: [4096]u8;
+    if (!capture_log_dir(selected[0].exe, ?log_dir[0], 4096)) {
         arena.dnit(?ar);
-        print.eprint("error: out of memory\n");
+        print.eprint("error: test log path too long\n");
         ret 2;
     }
-    val buf: *u8 = R.unwrap_ok[*u8, str](res_buf);
+    wipe_logs(?log_dir[0], tbr.len);
 
     # column widths come from the selection, so live lines align on the first
     # write with no second pass; clamping keeps one long name from blowing out
@@ -228,7 +257,7 @@ pub fun run(argc: usize, argv: **u8) i64 {
     val label_w: usize = label_col_width(selected, sel_len);
 
     val run_start: tm.Time = tm.monotonic();
-    execute_and_render(?a, selected, sel_len, runner, outcomes, buf, level, mod_w, label_w);
+    execute_and_render(?a, selected, sel_len, runner, outcomes, level, mod_w, label_w, jobs, ?log_dir[0]);
     val wall: du.Duration = tm.time_sub(tm.monotonic(), run_start);
 
     val failed: u32 = count_failed(outcomes, sel_len);
@@ -240,113 +269,313 @@ pub fun run(argc: usize, argv: **u8) i64 {
     ret 0;
 }
 
-# spawn every selected test in collection order, rendering the readout live as
-# results land
+# one in-flight test child
+# ---
+# pid:   the child's process id; 0 marks the slot free
+# art:   the artifact the child is running
+# idx:   index into the selection/outcomes arrays
+# start: monotonic spawn time
+# f:     the capture file, held open until the child is reaped
+rec Slot {
+    pid:   i64;
+    art:   *build.TestArtifact;
+    idx:   u32;
+    start: tm.Time;
+    f:     fs.File;
+}
+
+# run every selected test through a sliding window of child processes,
+# rendering the readout live in collection order as results finalize
 #
-# Each child is run with its stdout piped and drained to EOF (capture), so a
-# chatty test cannot deadlock the runner; stderr is inherited. A retained
-# test's captured bytes are copied out of the reused buffer into the run
-# allocator so they survive the next test overwriting the buffer (failures
-# always retain; passes retain under `-vv`). At the default level a module's
-# roll-up prints the moment its last test completes; under `-v` a module
-# header prints when its first test starts and each test line prints on
-# completion.
+# Up to `jobs` children are in flight at once, each with stdout and stderr
+# bound to its capture file; a blocking wait-any reaps whichever exits first.
+# The render cursor trails completion in collection order, so the readout is
+# deterministic regardless of completion order: at the default level a
+# module's roll-up prints the moment its last test finalizes, and under `-v`
+# the module header and each test line print as the cursor crosses them.
 # ---
 # a:        allocator retaining captured output
 # arts:     the selected test artifacts to run, in collection order
 # n:        number of artifacts in `arts`
 # runner:   resolved `--runner` launcher, or nil to exec the dispatcher directly
 # outcomes: caller-owned array (length n) filled in test order
-# buf:      the reused capture buffer (CAP_OUTPUT bytes)
 # level:    verbosity (0 roll-ups, 1 per-test lines, 2 also passing output)
 # mod_w:    module roll-up column width
 # label_w:  `-v` label column width
+# jobs:     window width (1 serializes)
+# log_dir:  the capture-file directory
 fun execute_and_render(a: *A.Allocator, arts: *build.TestArtifact, n: u32, runner: *u8,
-                       outcomes: *Outcome, buf: *u8, level: u8, mod_w: usize, label_w: usize) {
-    # first index of the module run currently executing
-    var first: u32 = 0;
+                       outcomes: *Outcome, level: u8, mod_w: usize, label_w: usize,
+                       jobs: u32, log_dir: *u8) {
     var i: u32 = 0;
-    for (i < n) {
-        val art: *build.TestArtifact = ?arts[i];
-        val mod_name: str = util.cstr_str(art.module);
+    for (i < n) { outcomes[i].kind = KIND_PENDING; i = i + 1; }
 
-        if (level > 0 && i == first) { print.printf("{}\n", mod_name); }
+    var window: u32 = jobs;
+    if (window < 1) { window = 1; }
+    if (window > n) { window = n; }
 
-        # the test's dispatch index, rendered for the child's argv
-        var ibuf: [16]u8;
-        write_index(?ibuf[0], 16, art.idx);
-
-        # child argv: [exe, idx] directly, or [runner, exe, idx] under --runner.
-        # argv[0] doubles as the pathname the spawn receives, so a runner needs
-        # no PATH search.
-        var child_argv: [4]*u8;
-        if (runner != nil) {
-            child_argv[0] = runner;
-            child_argv[1] = art.exe;
-            child_argv[2] = ?ibuf[0];
-            child_argv[3] = nil;
+    val res_slots: R.Result[*Slot, str] = A.allocate[Slot](a, window::usize);
+    if (R.is_err[*Slot, str](res_slots)) {
+        print.eprint("error: out of memory\n");
+        i = 0;
+        for (i < n) {
+            outcomes[i].art       = ?arts[i];
+            outcomes[i].kind      = KIND_OTHER;
+            outcomes[i].code      = 0;
+            outcomes[i].elapsed   = 0;
+            outcomes[i].out       = nil;
+            outcomes[i].out_len   = 0;
+            outcomes[i].truncated = false;
+            i = i + 1;
         }
-        or {
-            child_argv[0] = art.exe;
-            child_argv[1] = ?ibuf[0];
-            child_argv[2] = nil;
-        }
+        ret;
+    }
+    val slots: *Slot = R.unwrap_ok[*Slot, str](res_slots);
+    i = 0;
+    for (i < window) { slots[i].pid = 0; i = i + 1; }
 
-        var o: Outcome;
-        o.art       = art;
-        o.code      = 0;
-        o.out       = nil;
-        o.out_len   = 0;
-        o.truncated = false;
+    var spawned:  u32 = 0;
+    var done:     u32 = 0;
+    var inflight: u32 = 0;
+    var cursor:   u32 = 0;
+    var first:    u32 = 0;
 
-        # each test child inherits the parent's environment unmodified.
-        val start: tm.Time = tm.monotonic();
-        val res: R.Result[exec.Capture, str] = exec.capture(child_argv[0], ?child_argv[0], env.environ(), buf, CAP_OUTPUT);
-        val finish: tm.Time = tm.monotonic();
-        o.elapsed = tm.time_sub(finish, start);
-
-        if (R.is_err[exec.Capture, str](res)) {
-            o.kind = KIND_SPAWN;
-        }
-        or {
-            val cap: exec.Capture    = R.unwrap_ok[exec.Capture, str](res);
-            val st:  exec.ExitStatus = cap.status;
-            if (exec.exited(st) && exec.code(st) == 0) {
-                o.kind = KIND_PASS;
-                # `-vv` surfaces passing output too, so it is worth retaining
-                if (level >= 2) { retain_output(a, ?o, buf, cap.len); }
-            }
-            or (exec.signaled(st)) {
-                # a crash reports the signal and the run continues to the next test.
-                o.kind = KIND_SIGNAL;
-                o.code = exec.signal(st);
-                retain_output(a, ?o, buf, cap.len);
-            }
-            or (exec.exited(st)) {
-                o.kind = KIND_EXIT;
-                o.code = exec.code(st);
-                retain_output(a, ?o, buf, cap.len);
+    for (done < n) {
+        # top the window back up
+        for (inflight < window && spawned < n) {
+            val idx: u32 = spawned;
+            spawned = spawned + 1;
+            if (spawn_one(slots, window, ?arts[idx], idx, runner, log_dir)) {
+                inflight = inflight + 1;
             }
             or {
-                o.kind = KIND_OTHER;
-                retain_output(a, ?o, buf, cap.len);
+                # the spawn itself failed, so the outcome is final immediately
+                outcomes[idx].art       = ?arts[idx];
+                outcomes[idx].kind      = KIND_SPAWN;
+                outcomes[idx].code      = 0;
+                outcomes[idx].elapsed   = 0;
+                outcomes[idx].out       = nil;
+                outcomes[idx].out_len   = 0;
+                outcomes[idx].truncated = false;
+                done = done + 1;
             }
         }
 
-        outcomes[i] = o;
-
-        if (level > 0) { print_verbose_test(?outcomes[i], label_w); }
-
-        # the module's run is complete when the next artifact starts a new
-        # module (or the selection ends); the roll-up prints right then.
-        val last_of_module: bool = i + 1 == n
-            || !str_equals(util.cstr_str(arts[i + 1].module), mod_name);
-        if (last_of_module) {
-            if (level == 0) { render_module_run(outcomes, first, i, mod_name, mod_w); }
-            first = i + 1;
+        if (inflight > 0) {
+            var st: exec.ExitStatus;
+            st.raw = 0;
+            val wr: R.Result[exec.Child, str] = exec.wait_any(?st);
+            if (R.is_err[exec.Child, str](wr)) {
+                # nothing reapable despite live children: report each rather
+                # than spinning forever
+                print.eprint("error: waiting for test children failed\n");
+                var sx: u32 = 0;
+                for (sx < window) {
+                    if (slots[sx].pid != 0) {
+                        fs.close(?slots[sx].f);
+                        outcomes[slots[sx].idx].art       = slots[sx].art;
+                        outcomes[slots[sx].idx].kind      = KIND_OTHER;
+                        outcomes[slots[sx].idx].code      = 0;
+                        outcomes[slots[sx].idx].elapsed   = 0;
+                        outcomes[slots[sx].idx].out       = nil;
+                        outcomes[slots[sx].idx].out_len   = 0;
+                        outcomes[slots[sx].idx].truncated = false;
+                        slots[sx].pid = 0;
+                        inflight = inflight - 1;
+                        done = done + 1;
+                    }
+                    sx = sx + 1;
+                }
+            }
+            or {
+                # a pid not in the window is a reparented grandchild; it is not
+                # a test result, so it does not account against the run.
+                val pid: i64 = R.unwrap_ok[exec.Child, str](wr).pid;
+                var sx: u32 = 0;
+                for (sx < window) {
+                    if (slots[sx].pid == pid) {
+                        finalize_slot(a, ?slots[sx], st, outcomes, level, log_dir);
+                        slots[sx].pid = 0;
+                        inflight = inflight - 1;
+                        done = done + 1;
+                        brk;
+                    }
+                    sx = sx + 1;
+                }
+            }
         }
-        i = i + 1;
+
+        # advance the render cursor across everything finalized so far
+        for (cursor < n && outcomes[cursor].kind != KIND_PENDING) {
+            val mod_name: str = util.cstr_str(arts[cursor].module);
+            if (level > 0 && cursor == first) { print.printf("{}\n", mod_name); }
+            if (level > 0) { print_verbose_test(?outcomes[cursor], label_w, runner, log_dir); }
+            val last_of_module: bool = cursor + 1 == n
+                || !str_equals(util.cstr_str(arts[cursor + 1].module), mod_name);
+            if (last_of_module) {
+                if (level == 0) { render_module_run(outcomes, first, cursor, mod_name, mod_w, runner, log_dir); }
+                first = cursor + 1;
+            }
+            cursor = cursor + 1;
+        }
     }
+}
+
+# spawn one test child into a free slot, its stdout and stderr bound to its
+# capture file
+#
+# A false return means the child never started (capture-file creation or the
+# spawn failed); the caller records the KIND_SPAWN outcome.
+# ---
+# slots:   the window's slot array
+# window:  number of slots
+# art:     the test to spawn
+# idx:     the test's index in the selection/outcomes arrays
+# runner:  resolved `--runner` launcher, or nil to exec the dispatcher directly
+# log_dir: the capture-file directory
+# ret:     true when the child is running and its slot is filled
+fun spawn_one(slots: *Slot, window: u32, art: *build.TestArtifact, idx: u32,
+              runner: *u8, log_dir: *u8) bool {
+    var s: u32 = 0;
+    for (s < window && slots[s].pid != 0) { s = s + 1; }
+    if (s == window) { ret false; }
+
+    var lp: [4096]u8;
+    if (!log_path(?lp[0], 4096, log_dir, art.idx)) { ret false; }
+    val res_f: R.Result[fs.File, str] = fs.create(util.cstr_str(?lp[0]), 420);
+    if (R.is_err[fs.File, str](res_f)) { ret false; }
+    var f: fs.File = R.unwrap_ok[fs.File, str](res_f);
+
+    # the test's dispatch index, rendered for the child's argv
+    var ibuf: [16]u8;
+    write_index(?ibuf[0], 16, art.idx);
+
+    # child argv: [exe, idx] directly, or [runner, exe, idx] under --runner.
+    # argv[0] doubles as the pathname the spawn receives, so a runner needs
+    # no PATH search. the child inherits the parent's environment unmodified.
+    var child_argv: [4]*u8;
+    if (runner != nil) {
+        child_argv[0] = runner;
+        child_argv[1] = art.exe;
+        child_argv[2] = ?ibuf[0];
+        child_argv[3] = nil;
+    }
+    or {
+        child_argv[0] = art.exe;
+        child_argv[1] = ?ibuf[0];
+        child_argv[2] = nil;
+    }
+
+    val start: tm.Time = tm.monotonic();
+    val res_c: R.Result[exec.Child, str] =
+        exec.spawn_redirected(util.cstr_str(child_argv[0]), ?child_argv[0], env.environ(), f.fd, f.fd);
+    if (R.is_err[exec.Child, str](res_c)) {
+        fs.close(?f);
+        fs.unlink(util.cstr_str(?lp[0]));
+        ret false;
+    }
+
+    slots[s].pid   = R.unwrap_ok[exec.Child, str](res_c).pid;
+    slots[s].art   = art;
+    slots[s].idx   = idx;
+    slots[s].start = start;
+    slots[s].f     = f;
+    ret true;
+}
+
+# turn a reaped child's status into its final Outcome
+#
+# Closes the capture file, classifies the wait status, retains the captured
+# bytes where the readout needs them (always on failure, on pass under `-vv`),
+# and unlinks a passing test's file so only failures persist in `log/`.
+# ---
+# a:        allocator retaining captured output
+# slot:     the reaped child's slot
+# st:       the wait status
+# outcomes: the outcomes array to finalize into
+# level:    verbosity (2 retains passing output)
+# log_dir:  the capture-file directory
+fun finalize_slot(a: *A.Allocator, slot: *Slot, st: exec.ExitStatus,
+                  outcomes: *Outcome, level: u8, log_dir: *u8) {
+    var o: Outcome;
+    o.art       = slot.art;
+    o.code      = 0;
+    o.out       = nil;
+    o.out_len   = 0;
+    o.truncated = false;
+    o.elapsed   = tm.time_sub(tm.monotonic(), slot.start);
+
+    fs.close(?slot.f);
+
+    if (exec.exited(st) && exec.code(st) == 0) { o.kind = KIND_PASS; }
+    or (exec.signaled(st)) {
+        # a crash reports the signal and the run continues.
+        o.kind = KIND_SIGNAL;
+        o.code = exec.signal(st);
+    }
+    or (exec.exited(st)) {
+        o.kind = KIND_EXIT;
+        o.code = exec.code(st);
+    }
+    or { o.kind = KIND_OTHER; }
+
+    var lp: [4096]u8;
+    if (log_path(?lp[0], 4096, log_dir, slot.art.idx)) {
+        if (o.kind == KIND_PASS) {
+            if (level >= 2) { retain_from_file(a, ?o, util.cstr_str(?lp[0])); }
+            fs.unlink(util.cstr_str(?lp[0]));
+        }
+        or {
+            retain_from_file(a, ?o, util.cstr_str(?lp[0]));
+        }
+    }
+
+    outcomes[slot.idx] = o;
+}
+
+# copy up to CAP_OUTPUT bytes of a test's capture file into `a`, marking the
+# outcome truncated when the file holds more
+#
+# Any filesystem or allocation error leaves the outcome without retained
+# output; the result still reports its location and exit status, and a failing
+# test's file stays on disk for direct inspection.
+# ---
+# a:    allocator owning the retained copy
+# o:    the outcome to attach the copy to
+# path: the capture-file path
+fun retain_from_file(a: *A.Allocator, o: *Outcome, path: str) {
+    val res_f: R.Result[fs.File, str] = fs.open(path);
+    if (R.is_err[fs.File, str](res_f)) { ret; }
+    var f: fs.File = R.unwrap_ok[fs.File, str](res_f);
+
+    val res_fi: R.Result[fs.FileInfo, str] = fs.info(?f);
+    if (R.is_err[fs.FileInfo, str](res_fi)) { fs.close(?f); ret; }
+    val size: usize = R.unwrap_ok[fs.FileInfo, str](res_fi).size;
+
+    var stored: usize = size;
+    if (stored > CAP_OUTPUT) {
+        stored      = CAP_OUTPUT;
+        o.truncated = true;
+    }
+    if (stored == 0) { fs.close(?f); ret; }
+
+    val res_buf: R.Result[*u8, str] = A.allocate[u8](a, stored);
+    if (R.is_err[*u8, str](res_buf)) { fs.close(?f); ret; }
+    val dst: *u8 = R.unwrap_ok[*u8, str](res_buf);
+
+    var got: usize = 0;
+    for (got < stored) {
+        val res_n: R.Result[usize, str] = fs.read(?f, (dst::usize + got)::*u8, stored - got);
+        if (R.is_err[usize, str](res_n)) { brk; }
+        val n: usize = R.unwrap_ok[usize, str](res_n);
+        if (n == 0) { brk; }
+        got = got + n;
+    }
+    fs.close(?f);
+
+    if (got == 0) { ret; }
+    o.out     = dst;
+    o.out_len = got;
 }
 
 # render one completed module run under the default readout: the roll-up line,
@@ -357,7 +586,10 @@ fun execute_and_render(a: *A.Allocator, arts: *build.TestArtifact, n: u32, runne
 # last:     index of the module's last outcome (inclusive)
 # mod_name: the module's fully-qualified name
 # mod_w:    module column width
-fun render_module_run(outcomes: *Outcome, first: u32, last: u32, mod_name: str, mod_w: usize) {
+# runner:   resolved `--runner` launcher, or nil (for the rerun command)
+# log_dir:  the capture-file directory (for the full-output pointer)
+fun render_module_run(outcomes: *Outcome, first: u32, last: u32, mod_name: str, mod_w: usize,
+                      runner: *u8, log_dir: *u8) {
     var ok:      u32 = 0;
     var fail:    u32 = 0;
     var elapsed: du.Duration = 0;
@@ -373,41 +605,10 @@ fun render_module_run(outcomes: *Outcome, first: u32, last: u32, mod_name: str, 
     if (fail > 0) {
         j = first;
         for (j <= last) {
-            if (outcomes[j].kind != KIND_PASS) { print_fail_detail(?outcomes[j]); }
+            if (outcomes[j].kind != KIND_PASS) { print_fail_detail(?outcomes[j], runner, log_dir); }
             j = j + 1;
         }
     }
-}
-
-# copy a failing test's captured stdout out of the reused buffer into `a`
-#
-# Stores at most CAP_OUTPUT bytes, marking the outcome truncated when the child
-# wrote more. An allocation failure leaves the outcome without retained output;
-# the failure still reports its location and exit status.
-# ---
-# a:    allocator owning the retained copy
-# o:    the outcome to attach the copy to
-# buf:  the capture buffer holding the child's stdout
-# full: the full output length the capture reported (may exceed CAP_OUTPUT)
-fun retain_output(a: *A.Allocator, o: *Outcome, buf: *u8, full: usize) {
-    var stored: usize = full;
-    if (stored > CAP_OUTPUT) {
-        stored      = CAP_OUTPUT;
-        o.truncated = true;
-    }
-    if (stored == 0) { ret; }
-
-    val res: R.Result[*u8, str] = A.allocate[u8](a, stored);
-    if (R.is_err[*u8, str](res)) { ret; }
-    val dst: *u8 = R.unwrap_ok[*u8, str](res);
-
-    var i: usize = 0;
-    for (i < stored) {
-        dst[i] = buf[i];
-        i = i + 1;
-    }
-    o.out     = dst;
-    o.out_len = stored;
 }
 
 # the width of the module roll-up column: the longest selected module FQN,
@@ -492,15 +693,45 @@ fun print_rollup(mod_name: str, ok: u32, fail: u32, elapsed: du.Duration, mod_w:
     print.print("\n");
 }
 
-# write the expanded detail for one failing test under the default readout
+# write the expanded detail for one failing test under the default readout:
+# the FAIL line, the captured output, a full-output pointer when the retained
+# copy is truncated, and the exact rerun command
 # ---
-# o: the failing outcome
-fun print_fail_detail(o: *Outcome) {
+# o:       the failing outcome
+# runner:  resolved `--runner` launcher, or nil
+# log_dir: the capture-file directory
+fun print_fail_detail(o: *Outcome, runner: *u8, log_dir: *u8) {
     val label: str = util.cstr_str(o.art.label);
     print.printf("  FAIL  {}  {}:{}  ", label, util.cstr_str(o.art.file), o.art.line::i64);
     print_reason(o);
     print.print("\n");
     print_captured(o);
+    print_fail_pointers(o, runner, log_dir);
+}
+
+# write a failing test's trailing pointers: `full output:` when the retained
+# copy is truncated (the capture file holds everything), and the `rerun:`
+# command that reproduces exactly this test
+# ---
+# o:       the failing outcome
+# runner:  resolved `--runner` launcher, or nil
+# log_dir: the capture-file directory
+fun print_fail_pointers(o: *Outcome, runner: *u8, log_dir: *u8) {
+    if (o.truncated) {
+        var lp: [4096]u8;
+        if (log_path(?lp[0], 4096, log_dir, o.art.idx)) {
+            print.printf("    full output: {}\n", util.cstr_str(?lp[0]));
+        }
+    }
+    print.print("    rerun: ");
+    if (runner != nil) {
+        print.print(runner::str);
+        print.print(" ");
+    }
+    print.print(o.art.exe::str);
+    print.print(" ");
+    print.u64(o.art.idx::u64);
+    print.print("\n");
 }
 
 # write one test's line under the `-v` readout as it completes, expanding a
@@ -508,7 +739,9 @@ fun print_fail_detail(o: *Outcome) {
 # ---
 # o:       the outcome to list
 # label_w: label column width
-fun print_verbose_test(o: *Outcome, label_w: usize) {
+# runner:  resolved `--runner` launcher, or nil (for the rerun command)
+# log_dir: the capture-file directory (for the full-output pointer)
+fun print_verbose_test(o: *Outcome, label_w: usize, runner: *u8, log_dir: *u8) {
     val label: str = util.cstr_str(o.art.label);
     if (o.kind == KIND_PASS) {
         print.print("  ok    ");
@@ -525,6 +758,7 @@ fun print_verbose_test(o: *Outcome, label_w: usize) {
         print_reason(o);
         print.printf("  {}:{}\n", util.cstr_str(o.art.file), o.art.line::i64);
         print_captured(o);
+        print_fail_pointers(o, runner, log_dir);
     }
 }
 
@@ -659,4 +893,83 @@ fun write_index(buf: *u8, cap: usize, n: u32) {
     var k: usize = 0;
     for (k < t && k + 1 < cap) { buf[k] = tmp[t - 1 - k]; k = k + 1; }
     buf[k] = 0;
+}
+
+# parse a positive decimal flag value (the `--jobs` argument)
+# ---
+# s:   the null-terminated value text
+# ret: the parsed value, or -1 when empty, non-decimal, or absurdly large
+fun parse_count(s: *u8) i64 {
+    if (s == nil || s[0] == 0) { ret -1; }
+    var v: i64 = 0;
+    var i: usize = 0;
+    for (s[i] != 0) {
+        if (s[i] < '0' || s[i] > '9') { ret -1; }
+        v = v * 10 + (s[i] - '0')::i64;
+        if (v > 65536) { ret -1; }
+        i = i + 1;
+    }
+    ret v;
+}
+
+# derive the capture-file directory - `log/` beside the dispatcher - from the
+# dispatcher's executable path
+# ---
+# exe: the dispatcher executable path
+# buf: the destination buffer, receiving `<exe dir>/log` null-terminated
+# cap: the buffer capacity
+# ret: false when the result would not fit
+fun capture_log_dir(exe: *u8, buf: *u8, cap: usize) bool {
+    val el: usize = str_len(exe::str);
+    # the directory prefix ends at the last path separator, either flavor
+    var cut: usize = 0;
+    var i: usize = 0;
+    for (i < el) {
+        if (exe[i] == '/' || exe[i] == 92) { cut = i + 1; }
+        i = i + 1;
+    }
+    if (cut + 4 >= cap) { ret false; }
+    i = 0;
+    for (i < cut) { buf[i] = exe[i]; i = i + 1; }
+    buf[cut]     = 'l';
+    buf[cut + 1] = 'o';
+    buf[cut + 2] = 'g';
+    buf[cut + 3] = 0;
+    ret true;
+}
+
+# compose `<log_dir>/<idx>.log` into `buf`
+# ---
+# buf:     the destination buffer
+# cap:     the buffer capacity
+# log_dir: the capture-file directory
+# idx:     the test's dispatch index
+# ret:     false when the result would not fit
+fun log_path(buf: *u8, cap: usize, log_dir: *u8, idx: u32) bool {
+    var leaf: [24]u8;
+    write_index(?leaf[0], 16, idx);
+    var k: usize = str_len(util.cstr_str(?leaf[0]));
+    leaf[k]     = '.';
+    leaf[k + 1] = 'l';
+    leaf[k + 2] = 'o';
+    leaf[k + 3] = 'g';
+    leaf[k + 4] = 0;
+    ret util.join_into(buf, cap, log_dir, ?leaf[0]) > 0;
+}
+
+# remove every capture file this build could have written, so `log/` carries
+# only the run about to happen; the directory is created on the way
+# ---
+# log_dir: the capture-file directory
+# total:   the build's dispatch-index count (indices are 0..total-1)
+fun wipe_logs(log_dir: *u8, total: u32) {
+    var lp: [4096]u8;
+    var idx: u32 = 0;
+    for (idx < total) {
+        if (log_path(?lp[0], 4096, log_dir, idx)) {
+            if (idx == 0) { util.ensure_parents(?lp[0]); }
+            fs.unlink(util.cstr_str(?lp[0]));
+        }
+        idx = idx + 1;
+    }
 }

--- a/src/cli/cmd/testing.mach
+++ b/src/cli/cmd/testing.mach
@@ -1,10 +1,12 @@
-# `mach test` - build one executable per test, run each as a separate process,
-# and report a per-module roll-up.
+# `mach test` - build one dispatcher executable, run each test as a separate
+# process, and report a per-module roll-up.
 #
-# `mach test` compiles every `test "..."` block into its own standalone
-# executable (the test plus the project's transitive code, with a synthesized
-# `main` that calls just that test). this command spawns each executable as a
-# separate process, captures its output, times it, and reads its exit status.
+# `mach test` compiles the project's `test "..."` blocks into a single
+# executable (the project's transitive code plus a synthesized dispatcher
+# `main` that runs the test selected by a decimal index argument). this command
+# spawns that executable once per test as `<exe> <idx>`, captures each child's
+# output, times it, and reads its exit status - per-test process isolation is
+# unchanged, only the build is shared.
 #
 # the default readout collapses every all-passing module to a single roll-up
 # line (`mach.lang.driver  36 ok  41ms`) and expands any module with failures,
@@ -23,11 +25,12 @@
 # by default only `test` blocks declared in the current project's own modules are
 # collected; `--include-deps` widens collection to dependency modules too (#1556).
 # `--list` prints the collected tests without building or running them.
-# `--filter <substr>` selects the tests whose name contains the substring.
-# `--runner <cmd>` launches every test as `<cmd> <exe>` instead of spawning the
-# executable directly - the host-side launcher for foreign-target artifacts
-# (e.g. wine for a windows target, #1345). absent the flag, executables are
-# spawned directly and a spawn failure reports exactly that.
+# `--filter <substr>` selects the tests whose name contains the substring; it is
+# applied here at run time, so the built executable is identical regardless of
+# filter. `--runner <cmd>` launches every test as `<cmd> <exe> <idx>` instead of
+# spawning the executable directly - the host-side launcher for foreign-target
+# artifacts (e.g. wine for a windows target, #1345). absent the flag, the
+# executable is spawned directly and a spawn failure reports exactly that.
 #
 # spawning and output capture go through `std.process`, which is multiplatform
 # (linux, darwin, windows), so the readout behaves identically on every host.
@@ -41,6 +44,7 @@ use std.types.bool.false;
 use std.types.bool.true;
 use std.types.size.usize;
 use std.types.string.str;
+use std.types.string.str_contains;
 use std.types.string.str_equals;
 use std.types.string.str_len;
 use std.types.string.str_starts_with;
@@ -129,17 +133,45 @@ pub fun run(argc: usize, argv: **u8) i64 {
         ret tbr.code;
     }
 
-    # the build has already applied `--filter`, so every returned artifact runs.
-    # `--list`: report each test's `label file:line`, no execution.
+    # `--filter <substr>` selects at run time: the dispatcher embeds every
+    # in-scope test, this command runs (or lists) only the matching ones.
+    var filter: *u8 = nil;
+    val opt_filter: O.Option[*u8] = util.get_value(argc, argv, "--filter");
+    if (O.is_some[*u8](opt_filter)) { filter = O.unwrap[*u8](opt_filter); }
+
+    # `--list`: report each selected test's `label file:line`, no execution.
     if (list) {
         var i: u32 = 0;
         for (i < tbr.len) {
-            artifact_report(?tbr.tests[i]);
-            print.print("\n");
+            if (filter_matches(?tbr.tests[i], filter)) {
+                artifact_report(?tbr.tests[i]);
+                print.print("\n");
+            }
             i = i + 1;
         }
         arena.dnit(?ar);
         ret 0;
+    }
+
+    # the selected artifacts, in collection order (module runs stay adjacent).
+    var selected: *build.TestArtifact = nil;
+    var sel_len:  u32 = 0;
+    if (tbr.len > 0) {
+        val res_sel: R.Result[*build.TestArtifact, str] = A.allocate[build.TestArtifact](?a, tbr.len::usize);
+        if (R.is_err[*build.TestArtifact, str](res_sel)) {
+            arena.dnit(?ar);
+            print.eprint("error: out of memory\n");
+            ret 2;
+        }
+        selected = R.unwrap_ok[*build.TestArtifact, str](res_sel);
+        var i: u32 = 0;
+        for (i < tbr.len) {
+            if (filter_matches(?tbr.tests[i], filter)) {
+                selected[sel_len] = tbr.tests[i];
+                sel_len = sel_len + 1;
+            }
+            i = i + 1;
+        }
     }
 
     # `--runner <cmd>`: launch each test as `<cmd> <exe>`. resolved to a concrete
@@ -163,14 +195,14 @@ pub fun run(argc: usize, argv: **u8) i64 {
     }
 
     # a filtered run that matched nothing has no work and no failures.
-    if (tbr.len == 0) {
+    if (sel_len == 0) {
         print.print("0 passed, 0 failed, 0 total  (0ms)\n");
         arena.dnit(?ar);
         ret 0;
     }
 
-    # one Outcome per test, plus a single reused stdout capture buffer.
-    val res_out: R.Result[*Outcome, str] = A.allocate[Outcome](?a, tbr.len::usize);
+    # one Outcome per selected test, plus a single reused stdout capture buffer.
+    val res_out: R.Result[*Outcome, str] = A.allocate[Outcome](?a, sel_len::usize);
     if (R.is_err[*Outcome, str](res_out)) {
         arena.dnit(?ar);
         print.eprint("error: out of memory\n");
@@ -186,21 +218,21 @@ pub fun run(argc: usize, argv: **u8) i64 {
     }
     val buf: *u8 = R.unwrap_ok[*u8, str](res_buf);
 
-    execute_all(?a, ?tbr, runner, outcomes, buf);
+    execute_all(?a, selected, sel_len, runner, outcomes, buf);
 
-    if (verbose) { render_verbose(outcomes, tbr.len); }
-    or          { render_default(outcomes, tbr.len); }
+    if (verbose) { render_verbose(outcomes, sel_len); }
+    or          { render_default(outcomes, sel_len); }
 
-    val failed: u32 = count_failed(outcomes, tbr.len);
-    val passed: u32 = tbr.len - failed;
-    render_summary(outcomes, tbr.len, passed, failed);
+    val failed: u32 = count_failed(outcomes, sel_len);
+    val passed: u32 = sel_len - failed;
+    render_summary(outcomes, sel_len, passed, failed);
 
     arena.dnit(?ar);
     if (failed > 0) { ret 1; }
     ret 0;
 }
 
-# spawn every test, capturing its stdout and timing it, into `outcomes`
+# spawn every selected test, capturing its stdout and timing it, into `outcomes`
 #
 # Each child is run with its stdout piped and drained to EOF (capture), so a
 # chatty test cannot deadlock the runner; stderr is inherited. A failing test's
@@ -208,26 +240,34 @@ pub fun run(argc: usize, argv: **u8) i64 {
 # they survive the next test overwriting the buffer.
 # ---
 # a:        allocator retaining each failing test's captured output
-# tbr:      the built test artifacts to run
-# runner:   resolved `--runner` launcher, or nil to exec each test directly
-# outcomes: caller-owned array (length tbr.len) filled in test order
+# arts:     the selected test artifacts to run, in collection order
+# n:        number of artifacts in `arts`
+# runner:   resolved `--runner` launcher, or nil to exec the dispatcher directly
+# outcomes: caller-owned array (length n) filled in test order
 # buf:      the reused capture buffer (CAP_OUTPUT bytes)
-fun execute_all(a: *A.Allocator, tbr: *build.TestBuildResult, runner: *u8, outcomes: *Outcome, buf: *u8) {
+fun execute_all(a: *A.Allocator, arts: *build.TestArtifact, n: u32, runner: *u8, outcomes: *Outcome, buf: *u8) {
     var i: u32 = 0;
-    for (i < tbr.len) {
-        val art: *build.TestArtifact = ?tbr.tests[i];
+    for (i < n) {
+        val art: *build.TestArtifact = ?arts[i];
 
-        # child argv: [exe] directly, or [runner, exe] under --runner. argv[0]
-        # doubles as the pathname the spawn receives, so a runner needs no PATH search.
-        var child_argv: [3]*u8;
+        # the test's dispatch index, rendered for the child's argv
+        var ibuf: [16]u8;
+        write_index(?ibuf[0], 16, art.idx);
+
+        # child argv: [exe, idx] directly, or [runner, exe, idx] under --runner.
+        # argv[0] doubles as the pathname the spawn receives, so a runner needs
+        # no PATH search.
+        var child_argv: [4]*u8;
         if (runner != nil) {
             child_argv[0] = runner;
             child_argv[1] = art.exe;
-            child_argv[2] = nil;
+            child_argv[2] = ?ibuf[0];
+            child_argv[3] = nil;
         }
         or {
             child_argv[0] = art.exe;
-            child_argv[1] = nil;
+            child_argv[1] = ?ibuf[0];
+            child_argv[2] = nil;
         }
 
         var o: Outcome;
@@ -549,4 +589,32 @@ fun artifact_report(art: *build.TestArtifact) {
     print.print(art.file::str);
     print.print(":");
     print.u64(art.line::u64);
+}
+
+# whether an artifact passes the `--filter` selection (every artifact when
+# `filter` is nil, else those whose label contains the substring)
+# ---
+# art:    the artifact to check
+# filter: the filter substring, or nil to select everything
+# ret:    true when selected
+fun filter_matches(art: *build.TestArtifact, filter: *u8) bool {
+    if (filter == nil) { ret true; }
+    ret str_contains(util.cstr_str(art.label), util.cstr_str(filter));
+}
+
+# write the decimal text of `n` into `buf`, null-terminated (the dispatch
+# index argument handed to the test executable)
+# ---
+# buf: the destination buffer
+# cap: the buffer capacity (must hold the digits plus the terminator)
+# n:   the value to render
+fun write_index(buf: *u8, cap: usize, n: u32) {
+    var tmp: [16]u8;
+    var t:   usize = 0;
+    var v:   u32   = n;
+    if (v == 0) { tmp[0] = '0'; t = 1; }
+    for (v > 0) { tmp[t] = (v % 10)::u8 + '0'; v = v / 10; t = t + 1; }
+    var k: usize = 0;
+    for (k < t && k + 1 < cap) { buf[k] = tmp[t - 1 - k]; k = k + 1; }
+    buf[k] = 0;
 }

--- a/src/cli/cmd/testing.mach
+++ b/src/cli/cmd/testing.mach
@@ -1,12 +1,24 @@
-# `mach test` - build one executable per test and run each as a separate process.
+# `mach test` - build one executable per test, run each as a separate process,
+# and report a per-module roll-up.
 #
 # `mach test` compiles every `test "..."` block into its own standalone
 # executable (the test plus the project's transitive code, with a synthesized
 # `main` that calls just that test). this command spawns each executable as a
-# separate process, reads its exit status, and reports a per-test line:
-# `name file:line PASS` / `FAIL(exit n)` / `FAIL(signal s)`. a crashing test (a
-# signal) is reported and the run continues, so one SIGSEGV no longer kills the
-# suite. the run ends with a `passed/failed/total` summary.
+# separate process, captures its output, times it, and reads its exit status.
+#
+# the default readout collapses every all-passing module to a single roll-up
+# line (`mach.lang.driver  36 ok  41ms`) and expands any module with failures,
+# printing each failing test's captured child output, `file:line`, and exit
+# code or signal. the run ends with a summary that re-lists the failures. a
+# crashing test (a signal) is reported and the run continues, so one SIGSEGV no
+# longer kills the suite. `-v` lists every test, grouped by module, with its
+# duration. timing is `chrono.monotonic`; durations and the column widths use
+# the stdlib formatting primitives; the layout is fixed-width ASCII.
+#
+# child output is captured through `std.process.exec.capture`, which pipes the
+# child's stdout and drains it to EOF before waiting, so a chatty test never
+# deadlocks the runner. only failing tests retain their output (passing tests
+# stay quiet); the captured bytes surface under the expanded failure.
 #
 # by default only `test` blocks declared in the current project's own modules are
 # collected; `--include-deps` widens collection to dependency modules too (#1556).
@@ -25,15 +37,63 @@ use std.print;
 use std.process.env;
 use std.process.exec;
 use std.types.bool.bool;
+use std.types.bool.false;
+use std.types.bool.true;
 use std.types.size.usize;
 use std.types.string.str;
+use std.types.string.str_equals;
+use std.types.string.str_len;
+use std.types.string.str_starts_with;
 
-use A: std.allocator;
-use O: std.types.option;
-use R: std.types.result;
+use A:      std.allocator;
+use O:      std.types.option;
+use R:      std.types.result;
+use fmt:    std.format;
+use fs:     std.filesystem;
+use writer: std.io.writer;
+use tm:     std.chrono.time;
+use du:     std.chrono.duration;
 
 use mach.cli.cmd.build;
 use mach.cli.util;
+
+# a test that passed
+val KIND_PASS:   u8 = 0;
+# a test that exited with a non-zero code (`code` carries it)
+val KIND_EXIT:   u8 = 1;
+# a test killed by a signal (`code` carries the signal number)
+val KIND_SIGNAL: u8 = 2;
+# a test whose executable could not be spawned
+val KIND_SPAWN:  u8 = 3;
+# a test that neither exited nor signaled (should not occur)
+val KIND_OTHER:  u8 = 4;
+
+# capacity of the per-test stdout capture buffer; a child writing more is drained
+# past it (so it never blocks) and its retained output is marked truncated
+val CAP_OUTPUT: usize = 65536;
+
+# the result of running one test
+#
+# `out` retains the captured child stdout only for a failing test (passing tests
+# discard it); it is owned by the run allocator and aliases nothing in the reused
+# capture buffer.
+# ---
+# art:       the built test artifact (borrowed; owned by the run allocator)
+# kind:      a KIND_* outcome
+# code:      exit code (KIND_EXIT) or signal number (KIND_SIGNAL); 0 otherwise
+# elapsed:   wall time of the child process
+# out:       retained captured stdout, or nil when the test passed or wrote none
+# out_len:   bytes stored in `out`
+# truncated: the child wrote more than the capture buffer held
+rec Outcome {
+    art:       *build.TestArtifact;
+    kind:      u8;
+    code:      i32;
+    elapsed:   du.Duration;
+    out:       *u8;
+    out_len:   usize;
+    truncated: bool;
+}
 
 # `mach test` subcommand entry: build one executable per test, run each as its
 # own process, and report the results
@@ -44,7 +104,8 @@ use mach.cli.util;
 # argv: argument vector of argc null-terminated byte pointers
 # ret:  0 if all selected tests passed, 1 if any failed, 2 on a build or internal error
 pub fun run(argc: usize, argv: **u8) i64 {
-    val list: bool = util.has_flag(argc, argv, "--list");
+    val list:    bool = util.has_flag(argc, argv, "--list");
+    val verbose: bool = util.has_flag(argc, argv, "-v") || util.has_flag(argc, argv, "--verbose");
 
     # back the build with an arena over a page allocator, matching `mach build`.
     # the build's internal teardown frees through this allocator; the page
@@ -98,15 +159,63 @@ pub fun run(argc: usize, argv: **u8) i64 {
         runner = R.unwrap_ok[*u8, str](res_resolve);
     }
 
-    # spawn each test as its own process and report its result.
-    var passed: u32 = 0;
-    var failed: u32 = 0;
-    var i:      u32 = 0;
+    # a filtered run that matched nothing has no work and no failures.
+    if (tbr.len == 0) {
+        print.print("0 passed, 0 failed, 0 total  (0ms)\n");
+        arena.dnit(?ar);
+        ret 0;
+    }
+
+    # one Outcome per test, plus a single reused stdout capture buffer.
+    val res_out: R.Result[*Outcome, str] = A.allocate[Outcome](?a, tbr.len::usize);
+    if (R.is_err[*Outcome, str](res_out)) {
+        arena.dnit(?ar);
+        print.eprint("error: out of memory\n");
+        ret 2;
+    }
+    val outcomes: *Outcome = R.unwrap_ok[*Outcome, str](res_out);
+
+    val res_buf: R.Result[*u8, str] = A.allocate[u8](?a, CAP_OUTPUT);
+    if (R.is_err[*u8, str](res_buf)) {
+        arena.dnit(?ar);
+        print.eprint("error: out of memory\n");
+        ret 2;
+    }
+    val buf: *u8 = R.unwrap_ok[*u8, str](res_buf);
+
+    execute_all(?a, ?tbr, runner, outcomes, buf);
+
+    if (verbose) { render_verbose(outcomes, tbr.len); }
+    or          { render_default(outcomes, tbr.len); }
+
+    val failed: u32 = count_failed(outcomes, tbr.len);
+    val passed: u32 = tbr.len - failed;
+    render_summary(outcomes, tbr.len, passed, failed);
+
+    arena.dnit(?ar);
+    if (failed > 0) { ret 1; }
+    ret 0;
+}
+
+# spawn every test, capturing its stdout and timing it, into `outcomes`
+#
+# Each child is run with its stdout piped and drained to EOF (capture), so a
+# chatty test cannot deadlock the runner; stderr is inherited. A failing test's
+# captured bytes are copied out of the reused buffer into the run allocator so
+# they survive the next test overwriting the buffer.
+# ---
+# a:        allocator retaining each failing test's captured output
+# tbr:      the built test artifacts to run
+# runner:   resolved `--runner` launcher, or nil to exec each test directly
+# outcomes: caller-owned array (length tbr.len) filled in test order
+# buf:      the reused capture buffer (CAP_OUTPUT bytes)
+fun execute_all(a: *A.Allocator, tbr: *build.TestBuildResult, runner: *u8, outcomes: *Outcome, buf: *u8) {
+    var i: u32 = 0;
     for (i < tbr.len) {
         val art: *build.TestArtifact = ?tbr.tests[i];
 
         # child argv: [exe] directly, or [runner, exe] under --runner. argv[0]
-        # doubles as the pathname execve receives, so a runner needs no PATH search.
+        # doubles as the pathname the spawn receives, so a runner needs no PATH search.
         var child_argv: [3]*u8;
         if (runner != nil) {
             child_argv[0] = runner;
@@ -118,57 +227,317 @@ pub fun run(argc: usize, argv: **u8) i64 {
             child_argv[1] = nil;
         }
 
-        artifact_report(art);
-        print.print(" ");
+        var o: Outcome;
+        o.art       = art;
+        o.code      = 0;
+        o.out       = nil;
+        o.out_len   = 0;
+        o.truncated = false;
 
         # each test child inherits the parent's environment unmodified.
-        val res_exec: R.Result[exec.ExitStatus, str] = exec.run(child_argv[0], ?child_argv[0], env.environ());
-        if (R.is_err[exec.ExitStatus, str](res_exec)) {
-            print.print("FAIL(spawn)\n");
-            failed = failed + 1;
-            i = i + 1;
-            cnt;
-        }
-        val status: exec.ExitStatus = R.unwrap_ok[exec.ExitStatus, str](res_exec);
+        val start: tm.Time = tm.monotonic();
+        val res: R.Result[exec.Capture, str] = exec.capture(child_argv[0], ?child_argv[0], env.environ(), buf, CAP_OUTPUT);
+        val finish: tm.Time = tm.monotonic();
+        o.elapsed = tm.time_sub(finish, start);
 
-        if (exec.exited(status) && exec.code(status) == 0) {
-            print.print("PASS\n");
-            passed = passed + 1;
-        }
-        or (exec.signaled(status)) {
-            # a crash reports the signal and the run continues to the next test.
-            print.print("FAIL(signal ");
-            print.u64(exec.signal(status)::u64);
-            print.print(")\n");
-            failed = failed + 1;
-        }
-        or (exec.exited(status)) {
-            print.print("FAIL(exit ");
-            print.u64(exec.code(status)::u64);
-            print.print(")\n");
-            failed = failed + 1;
+        if (R.is_err[exec.Capture, str](res)) {
+            o.kind = KIND_SPAWN;
         }
         or {
-            print.print("FAIL\n");
-            failed = failed + 1;
+            val cap: exec.Capture    = R.unwrap_ok[exec.Capture, str](res);
+            val st:  exec.ExitStatus = cap.status;
+            if (exec.exited(st) && exec.code(st) == 0) {
+                o.kind = KIND_PASS;
+            }
+            or (exec.signaled(st)) {
+                # a crash reports the signal and the run continues to the next test.
+                o.kind = KIND_SIGNAL;
+                o.code = exec.signal(st);
+                retain_output(a, ?o, buf, cap.len);
+            }
+            or (exec.exited(st)) {
+                o.kind = KIND_EXIT;
+                o.code = exec.code(st);
+                retain_output(a, ?o, buf, cap.len);
+            }
+            or {
+                o.kind = KIND_OTHER;
+                retain_output(a, ?o, buf, cap.len);
+            }
+        }
+
+        outcomes[i] = o;
+        i = i + 1;
+    }
+}
+
+# copy a failing test's captured stdout out of the reused buffer into `a`
+#
+# Stores at most CAP_OUTPUT bytes, marking the outcome truncated when the child
+# wrote more. An allocation failure leaves the outcome without retained output;
+# the failure still reports its location and exit status.
+# ---
+# a:    allocator owning the retained copy
+# o:    the outcome to attach the copy to
+# buf:  the capture buffer holding the child's stdout
+# full: the full output length the capture reported (may exceed CAP_OUTPUT)
+fun retain_output(a: *A.Allocator, o: *Outcome, buf: *u8, full: usize) {
+    var stored: usize = full;
+    if (stored > CAP_OUTPUT) {
+        stored      = CAP_OUTPUT;
+        o.truncated = true;
+    }
+    if (stored == 0) { ret; }
+
+    val res: R.Result[*u8, str] = A.allocate[u8](a, stored);
+    if (R.is_err[*u8, str](res)) { ret; }
+    val dst: *u8 = R.unwrap_ok[*u8, str](res);
+
+    var i: usize = 0;
+    for (i < stored) {
+        dst[i] = buf[i];
+        i = i + 1;
+    }
+    o.out     = dst;
+    o.out_len = stored;
+}
+
+# the default readout: one roll-up line per module, expanding only failures
+#
+# Tests arrive grouped by declaring module (collection order), so a module's run
+# is the maximal adjacent run of equal module names. An all-passing module shows
+# only its roll-up; a module with failures additionally expands each failing test.
+# ---
+# outcomes: the run outcomes in test order
+# len:      number of outcomes
+fun render_default(outcomes: *Outcome, len: u32) {
+    var i: u32 = 0;
+    for (i < len) {
+        val mod_name: str = util.cstr_str(outcomes[i].art.module);
+
+        var j:       u32 = i;
+        var ok:      u32 = 0;
+        var fail:    u32 = 0;
+        var elapsed: du.Duration = 0;
+        for (j < len) {
+            if (!str_equals(util.cstr_str(outcomes[j].art.module), mod_name)) { brk; }
+            if (outcomes[j].kind == KIND_PASS) { ok = ok + 1; }
+            or                                 { fail = fail + 1; }
+            elapsed = elapsed + outcomes[j].elapsed;
+            j = j + 1;
+        }
+
+        print_rollup(mod_name, ok, fail, elapsed);
+        if (fail > 0) {
+            var k: u32 = i;
+            for (k < j) {
+                if (outcomes[k].kind != KIND_PASS) { print_fail_detail(?outcomes[k], mod_name); }
+                k = k + 1;
+            }
+        }
+        i = j;
+    }
+}
+
+# the `-v` readout: every test listed under its module with its duration
+#
+# Failing tests additionally carry their location, exit status, and captured
+# output, so `-v` is a superset of the default expansion.
+# ---
+# outcomes: the run outcomes in test order
+# len:      number of outcomes
+fun render_verbose(outcomes: *Outcome, len: u32) {
+    var i: u32 = 0;
+    for (i < len) {
+        val mod_name: str = util.cstr_str(outcomes[i].art.module);
+        print.printf("{}\n", mod_name);
+
+        var j: u32 = i;
+        for (j < len) {
+            if (!str_equals(util.cstr_str(outcomes[j].art.module), mod_name)) { brk; }
+            print_verbose_test(?outcomes[j], mod_name);
+            j = j + 1;
+        }
+        i = j;
+    }
+}
+
+# write one module's roll-up line: `<module>  <ok> ok[  <fail> FAIL]  <dur>`
+# ---
+# mod_name: the module's fully-qualified name
+# ok:       number of passing tests
+# fail:     number of failing tests
+# elapsed:  total wall time of the module's tests
+fun print_rollup(mod_name: str, ok: u32, fail: u32, elapsed: du.Duration) {
+    var dbuf: [24]u8;
+    val ds: str = du.format_duration(elapsed, ?dbuf[0], 24::usize);
+    if (fail > 0) {
+        print.printf("{:<34}{:4} ok  {:4} FAIL  {}\n", mod_name, ok::i64, fail::i64, ds);
+    }
+    or {
+        print.printf("{:<34}{:4} ok  {}\n", mod_name, ok::i64, ds);
+    }
+}
+
+# write the expanded detail for one failing test under the default readout
+# ---
+# o:        the failing outcome
+# mod_name: its module's name, stripped from the label for a compact display
+fun print_fail_detail(o: *Outcome, mod_name: str) {
+    val label: str = display_label(mod_name, util.cstr_str(o.art.label));
+    print.printf("  FAIL  {}  {}:{}  ", label, util.cstr_str(o.art.file), o.art.line::i64);
+    print_reason(o);
+    print.print("\n");
+    print_captured(o);
+}
+
+# write one test's line under the `-v` readout, expanding a failure inline
+# ---
+# o:        the outcome to list
+# mod_name: its module's name, stripped from the label for a compact display
+fun print_verbose_test(o: *Outcome, mod_name: str) {
+    var dbuf: [24]u8;
+    val ds:    str = du.format_duration(o.elapsed, ?dbuf[0], 24::usize);
+    val label: str = display_label(mod_name, util.cstr_str(o.art.label));
+    if (o.kind == KIND_PASS) {
+        print.printf("  {:<4}  {:<40}{}\n", "ok", label, ds);
+    }
+    or {
+        print.printf("  {:<4}  {:<40}{}  ", "FAIL", label, ds);
+        print_reason(o);
+        print.printf("  {}:{}\n", util.cstr_str(o.art.file), o.art.line::i64);
+        print_captured(o);
+    }
+}
+
+# write a failing outcome's reason token: `(exit N)`, `(signal N)`, or a word
+# ---
+# o: the failing outcome
+fun print_reason(o: *Outcome) {
+    if (o.kind == KIND_EXIT)   { print.printf("(exit {})", o.code::i64); }
+    or (o.kind == KIND_SIGNAL) { print.printf("(signal {})", o.code::i64); }
+    or (o.kind == KIND_SPAWN)  { print.print("(spawn failed)"); }
+    or                         { print.print("(failed)"); }
+}
+
+# write a failing test's retained stdout, each line indented, then a truncation
+# note when the output overflowed the capture buffer
+#
+# Nothing is written when the test produced no output. The bytes are streamed
+# verbatim through a stdout writer so arbitrary content (not null-terminated)
+# renders faithfully.
+# ---
+# o: the failing outcome
+fun print_captured(o: *Outcome) {
+    if (o.out == nil || o.out_len == 0) {
+        if (o.truncated) { print.print("    ... (output truncated)\n"); }
+        ret;
+    }
+
+    var w: writer.Writer;
+    fs.get_writer(?fs.stdout, ?w);
+
+    var i:   usize = 0;
+    var seg: usize = 0;
+    for (i < o.out_len) {
+        if (o.out[i] == '\n') {
+            fmt.write_str(?w, "    ");
+            fmt.write_bytes(?w, (o.out::usize + seg)::*u8, i - seg + 1::usize);
+            seg = i + 1::usize;
         }
         i = i + 1;
     }
-
-    print.print("\n");
-    print.u64(passed::u64);
-    print.print(" passed, ");
-    print.u64(failed::u64);
-    print.print(" failed, ");
-    print.u64(tbr.len::u64);
-    print.print(" total\n");
-
-    arena.dnit(?ar);
-    if (failed > 0) { ret 1; }
-    ret 0;
+    if (seg < o.out_len) {
+        fmt.write_str(?w, "    ");
+        fmt.write_bytes(?w, (o.out::usize + seg)::*u8, o.out_len - seg);
+        fmt.write_newline(?w);
+    }
+    if (o.truncated) { fmt.write_str(?w, "    ... (output truncated)\n"); }
 }
 
-# write a test's identifying `label file:line` prefix to stdout, no trailing newline
+# write the closing summary: a `failures:` block re-listing each failure, then a
+# `passed/failed/total` count with the run's total wall time
+# ---
+# outcomes: the run outcomes in test order
+# len:      number of outcomes
+# passed:   number of passing tests
+# failed:   number of failing tests
+fun render_summary(outcomes: *Outcome, len: u32, passed: u32, failed: u32) {
+    print.print("\n");
+
+    if (failed > 0) {
+        print.print("failures:\n");
+        var i: u32 = 0;
+        for (i < len) {
+            if (outcomes[i].kind != KIND_PASS) {
+                print.printf("  {}  {}:{}  ",
+                    util.cstr_str(outcomes[i].art.label),
+                    util.cstr_str(outcomes[i].art.file),
+                    outcomes[i].art.line::i64);
+                print_reason(?outcomes[i]);
+                print.print("\n");
+            }
+            i = i + 1;
+        }
+        print.print("\n");
+    }
+
+    var dbuf: [24]u8;
+    val ds: str = du.format_duration(total_elapsed(outcomes, len), ?dbuf[0], 24::usize);
+    print.printf("{} passed, {} failed, {} total  ({})\n", passed::i64, failed::i64, len::i64, ds);
+}
+
+# the number of non-passing outcomes
+# ---
+# outcomes: the run outcomes
+# len:      number of outcomes
+# ret:      count of failing tests
+fun count_failed(outcomes: *Outcome, len: u32) u32 {
+    var f: u32 = 0;
+    var i: u32 = 0;
+    for (i < len) {
+        if (outcomes[i].kind != KIND_PASS) { f = f + 1; }
+        i = i + 1;
+    }
+    ret f;
+}
+
+# the summed wall time of every outcome
+# ---
+# outcomes: the run outcomes
+# len:      number of outcomes
+# ret:      total elapsed duration
+fun total_elapsed(outcomes: *Outcome, len: u32) du.Duration {
+    var t: du.Duration = 0;
+    var i: u32 = 0;
+    for (i < len) {
+        t = t + outcomes[i].elapsed;
+        i = i + 1;
+    }
+    ret t;
+}
+
+# strip a leading `<module>.` from a test label for a compact per-module display
+#
+# Mach tests are named with their fully-qualified path by convention (e.g.
+# `mach.lang.driver.builds:trivial`), so under a module roll-up the prefix is
+# redundant. A label that does not carry the prefix is returned unchanged.
+# ---
+# mod_name: the module's fully-qualified name
+# label:    the test's printable label
+# ret:      the label with a matching `<module>.` prefix removed
+fun display_label(mod_name: str, label: str) str {
+    if (str_starts_with(label, mod_name)) {
+        val ml: usize = str_len(mod_name);
+        if (label[ml] == '.') {
+            ret (label::usize + ml + 1::usize)::str;
+        }
+    }
+    ret label;
+}
+
+# write a test's identifying `label file:line` prefix to stdout, no trailing
+# newline (the `--list` line shape)
 # ---
 # art: the test artifact to describe
 fun artifact_report(art: *build.TestArtifact) {

--- a/src/cli/cmd/testing.mach
+++ b/src/cli/cmd/testing.mach
@@ -104,8 +104,11 @@ rec Outcome {
 # argv: argument vector of argc null-terminated byte pointers
 # ret:  0 if all selected tests passed, 1 if any failed, 2 on a build or internal error
 pub fun run(argc: usize, argv: **u8) i64 {
-    val list:    bool = util.has_flag(argc, argv, "--list");
-    val verbose: bool = util.has_flag(argc, argv, "-v") || util.has_flag(argc, argv, "--verbose");
+    val list: bool = util.has_flag(argc, argv, "--list");
+
+    # `-v` or `-vv` lists every test; the runner has a single verbose level and
+    # mirrors the shared verbosity flags (`--verbose` was dropped in #1775).
+    val verbose: bool = util.has_flag(argc, argv, "-v") || util.has_flag(argc, argv, "-vv");
 
     # back the build with an arena over a page allocator, matching `mach build`.
     # the build's internal teardown frees through this allocator; the page

--- a/src/cli/cmd/testing.mach
+++ b/src/cli/cmd/testing.mach
@@ -24,13 +24,13 @@
 # collected; `--include-deps` widens collection to dependency modules too (#1556).
 # `--list` prints the collected tests without building or running them.
 # `--filter <substr>` selects the tests whose name contains the substring.
-# `--runner <cmd>` launches every test as `<cmd> <exe>` instead of exec'ing the
+# `--runner <cmd>` launches every test as `<cmd> <exe>` instead of spawning the
 # executable directly - the host-side launcher for foreign-target artifacts
 # (e.g. wine for a windows target, #1345). absent the flag, executables are
-# exec'd directly and a spawn failure reports exactly that.
+# spawned directly and a spawn failure reports exactly that.
 #
-# execution is currently linux-only (the spawn path is POSIX `fork`/`exec`); a
-# win64 runner needs `CreateProcess` (tracked on #1235).
+# spawning and output capture go through `std.process`, which is multiplatform
+# (linux, darwin, windows), so the readout behaves identically on every host.
 
 use std.allocator.arena;
 use std.print;

--- a/src/cli/config.mach
+++ b/src/cli/config.mach
@@ -5,8 +5,8 @@
 # selection - so each command's `run` does not reimplement the same flag
 # handling. `parse` reads these flags out of the raw argv via the `util`
 # helpers and leaves every per-subcommand flag in place for the subcommand to
-# consume itself. `verbose` and `quiet` are mutually exclusive: passing both is
-# a parse error that yields an error message.
+# consume itself. verbosity (`-v`/`-vv`) and `quiet` are mutually exclusive:
+# passing both is a parse error that yields an error message.
 
 use std.types.bool.bool;
 use std.types.size.usize;
@@ -28,7 +28,7 @@ pub val COLOR_NEVER:  ColorMode = 2;  # force-disable color
 # cross-cutting CLI settings shared by every subcommand
 # ---
 # color:       resolved color preference
-# verbose:     --verbose / -v was passed; surface extra detail
+# verbosity:   readout detail level: 0 plain, 1 (`-v`), 2 (`-vv`)
 # quiet:       --quiet / -q was passed; suppress non-error output
 # verify_ir:   --verify-ir was passed; run the IR verifier after each optimization pass
 # target:      selected target name (nil when --target was not given)
@@ -58,7 +58,7 @@ pub val COLOR_NEVER:  ColorMode = 2;  # force-disable color
 #              ASLR instead of the default fixed-address one. opt-in, off by default
 pub rec Config {
     color:       ColorMode;
-    verbose:     bool;
+    verbosity:   u8;
     quiet:       bool;
     verify_ir:   bool;
     target:      *u8;
@@ -93,8 +93,8 @@ pub fun color_enabled(mode: ColorMode) bool {
 #
 # Per-subcommand flags are left in argv for the subcommand to consume itself.
 # Returns a specific error message on a parse error so the caller can tell the
-# user which flag was wrong: an unknown `--color` mode, or both `--verbose` and
-# `--quiet` together.
+# user which flag was wrong: an unknown `--color` mode, or a verbosity flag
+# (`-v`/`-vv`) combined with `--quiet`.
 # ---
 # argc: argument count including argv[0]
 # argv: the argument vector (argc null-terminated byte pointers)
@@ -102,13 +102,16 @@ pub fun color_enabled(mode: ColorMode) bool {
 pub fun parse(argc: usize, argv: **u8) R.Result[Config, str] {
     var c: Config;
 
-    val verbose: bool = util.has_flag(argc, argv, "--verbose") || util.has_flag(argc, argv, "-v");
-    val quiet:   bool = util.has_flag(argc, argv, "--quiet")   || util.has_flag(argc, argv, "-q");
-    if (verbose && quiet) {
-        ret R.err[Config, str]("`--verbose`/`-v` and `--quiet`/`-q` cannot be combined");
+    # `-vv` is two levels of detail, `-v` one; the highest present wins.
+    var verbosity: u8 = 0;
+    if (util.has_flag(argc, argv, "-v"))  { verbosity = 1; }
+    if (util.has_flag(argc, argv, "-vv")) { verbosity = 2; }
+    val quiet: bool = util.has_flag(argc, argv, "--quiet") || util.has_flag(argc, argv, "-q");
+    if (verbosity > 0 && quiet) {
+        ret R.err[Config, str]("`-v`/`-vv` and `--quiet`/`-q` cannot be combined");
     }
 
-    c.verbose     = verbose;
+    c.verbosity   = verbosity;
     c.quiet       = quiet;
     c.verify_ir   = util.has_flag(argc, argv, "--verify-ir");
     c.emit_asm    = util.has_flag(argc, argv, "--emit-asm");

--- a/src/cli/diagnostic.mach
+++ b/src/cli/diagnostic.mach
@@ -1,109 +1,303 @@
 # the shared CLI diagnostic renderer.
 #
-# one renderer for every command that surfaces compiler diagnostics. each entry
-# prints as `severity: path:line:col: message`, followed by the offending source
-# line and a caret underline marking the span, all resolved against the session
-# source map. `color` gates ANSI styling of the severity label only; the message
-# body and the snippet are never colorized. both `mach build` (whole project)
-# and `mach check` (single buffer) render through `flush`.
+# one framed renderer for every command that surfaces compiler diagnostics. each
+# diagnostic prints as a severity headline (`error:` / `warning:`), a
+# `--> file:line:col` location line, an ASCII line-number gutter, and the
+# offending span underlined with `^`; a span that runs across several source
+# lines marks its continuation lines with `-`. an attached note renders as a
+# `= note:` line. a non-empty run ends with an `N errors / M warnings` summary.
+#
+# spans resolve against the session source map via the diagnostic's file_id and
+# span; the data model is unchanged. output is ASCII only - no Unicode, no color,
+# no terminal escapes - and fixed-width, so it is byte-identical across linux,
+# darwin, and windows. both `mach build` (whole project) and `mach check` (single
+# buffer) render through `flush`.
 
 use std.print;
 use std.system.os;
-use std.types.bool.bool;
 use std.types.size.usize;
 use std.types.string.str;
+use std.types.string.str_len;
 
 use O: std.types.option;
 
 use mach.lang.diagnostic;
-use mach.lang.fe.token;
 use mach.lang.session;
 use mach.lang.source;
 
+# source lines rendered for one multi-line span before the middle is elided
+val MAX_SPAN_LINES: usize = 10;
+
 # render every diagnostic in `list` to stderr against the session source map.
 #
-# When a diagnostic's file resolves, the location prefix and a caret snippet are
-# emitted; otherwise only the message is shown. A trailing `note:` line is
-# printed when present.
+# Each diagnostic is framed individually, separated by a blank line, and a
+# non-empty run closes with a counts summary. A diagnostic whose file does not
+# resolve degrades to its headline (and note) with no source frame.
 # ---
-# s:     session carrying the source map spans resolve against
-# list:  diagnostics to render, in order
-# color: true to wrap each severity label in its ANSI color
-pub fun flush(s: *session.Session, list: *diagnostic.DiagList, color: bool) {
+# s:    session carrying the source map spans resolve against
+# list: diagnostics to render, in order
+pub fun flush(s: *session.Session, list: *diagnostic.DiagList) {
+    var errors:   usize = 0;
+    var warnings: usize = 0;
+
     var i: usize = 0;
     for (i < list.len) {
         val d: *diagnostic.Diagnostic = ?list.items[i];
 
-        if (color) { print.eprint(severity_color(d.severity)); }
-        print.eprint(severity_label(d.severity));
-        if (color) { print.eprint("\x1b[0m"); }
+        if (i > 0) { print.eprint("\n"); }
+        render(s, d);
 
-        val opt_file: O.Option[*source.SourceFile] = source.get(?s.sources, d.file_id);
-        if (O.is_some[*source.SourceFile](opt_file)) {
-            val sf:  *source.SourceFile = O.unwrap[*source.SourceFile](opt_file);
-            val pos: source.Position    = source.position(sf, d.span.offset);
-            print.eprint(sf.path);
-            print.eprint(":");
-            print.eu64(pos.line::u64);
-            print.eprint(":");
-            print.eu64(pos.col::u64);
-            print.eprint(": ");
-            print.eprintln(d.message);
-            emit_snippet(sf, ?d.span, pos.line);
-        }
-        or {
-            print.eprintln(d.message);
-        }
-
-        if (d.note != nil) {
-            print.eprint("  note: ");
-            print.eprintln(d.note);
-        }
+        if (d.severity == diagnostic.SEVERITY_ERROR)        { errors   = errors + 1;   }
+        or (d.severity == diagnostic.SEVERITY_WARNING)      { warnings = warnings + 1; }
 
         i = i + 1;
     }
+
+    if (list.len > 0) {
+        print.eprint("\n");
+        emit_summary(errors, warnings);
+    }
 }
 
-# render the source line containing `span` followed by a caret underline.
+# render one diagnostic: headline, then a source frame when the file resolves.
 #
-# The underline mirrors the line's leading bytes so the caret lands under the
-# span: tabs are kept verbatim and every other byte becomes a single space. The
-# span start is marked with `^` and each remaining byte with `~`; a zero-length
-# span underlines a single column. The caret is clamped to the rendered line so
-# a span reaching past either end still marks a valid column.
+# The span is clamped to the file bounds so a synthesized or out-of-range span
+# degrades to a valid frame rather than crashing. The note, when present, renders
+# under the frame (or directly under the headline when there is no frame).
+# ---
+# s: session carrying the source map
+# d: the diagnostic to render
+fun render(s: *session.Session, d: *diagnostic.Diagnostic) {
+    emit_headline(d.severity, d.message);
+
+    val opt_file: O.Option[*source.SourceFile] = source.get(?s.sources, d.file_id);
+    if (O.is_none[*source.SourceFile](opt_file)) {
+        if (d.note != nil) { emit_note(d.note, 2); }
+        ret;
+    }
+    val sf: *source.SourceFile = O.unwrap[*source.SourceFile](opt_file);
+
+    val text_len: usize = str_len(sf.text);
+
+    var off: usize = d.span.offset;
+    if (off > text_len) { off = text_len; }
+    var end: usize = d.span.offset + d.span.len;
+    if (end > text_len) { end = text_len; }
+    if (end < off)      { end = off;      }
+
+    val start_pos: source.Position = source.position(sf, off);
+    var last: usize = off;
+    if (end > off) { last = end - 1; }
+    val end_pos: source.Position = source.position(sf, last);
+
+    val w: usize = decimal_width(end_pos.line);
+
+    emit_loc(w, sf.path, start_pos.line, start_pos.col);
+    emit_bar(w);
+    emit_snippet(sf, w, start_pos.line, end_pos.line, off, end);
+
+    if (d.note != nil) {
+        emit_bar(w);
+        emit_note(d.note, w + 1);
+    }
+}
+
+# render the source line(s) the span covers, each followed by its underline.
+#
+# A single-line span underlines its range with `^`. A multi-line span marks the
+# first line with `^` and every continuation line with `-`; a span taller than
+# MAX_SPAN_LINES renders only its first and last lines with the middle elided.
+# ---
+# sf:     source file the lines are drawn from
+# w:      gutter width in columns
+# line_s: 1-based first line of the span
+# line_e: 1-based last line of the span
+# off:    clamped span start byte offset
+# end:    clamped span end byte offset (exclusive)
+fun emit_snippet(sf: *source.SourceFile, w: usize, line_s: usize, line_e: usize, off: usize, end: usize) {
+    if (line_e <= line_s) {
+        emit_source_line(sf, w, line_s);
+        emit_underline(sf, w, line_s, off, end, "^");
+        ret;
+    }
+
+    if (line_e - line_s + 1 <= MAX_SPAN_LINES) {
+        var l: usize = line_s;
+        for (l <= line_e) {
+            emit_source_line(sf, w, l);
+            if (l == line_s) { emit_underline(sf, w, l, off, end, "^"); }
+            or               { emit_underline(sf, w, l, off, end, "-"); }
+            l = l + 1;
+        }
+        ret;
+    }
+
+    emit_source_line(sf, w, line_s);
+    emit_underline(sf, w, line_s, off, end, "^");
+    emit_elision(w);
+    emit_source_line(sf, w, line_e);
+    emit_underline(sf, w, line_e, off, end, "-");
+}
+
+# write one numbered source line through the gutter, verbatim.
 # ---
 # sf:   source file the line is drawn from
-# span: byte range to underline
-# line: 1-based line number containing the span
-fun emit_snippet(sf: *source.SourceFile, span: *token.Span, line: usize) {
+# w:    gutter width in columns
+# line: 1-based line number to print
+fun emit_source_line(sf: *source.SourceFile, w: usize, line: usize) {
     val opt_bounds: O.Option[source.LineSpan] = source.line_bounds(sf, line);
     if (O.is_none[source.LineSpan](opt_bounds)) { ret; }
-    val bounds: source.LineSpan = O.unwrap[source.LineSpan](opt_bounds);
+    val b: source.LineSpan = O.unwrap[source.LineSpan](opt_bounds);
 
-    os.write(os.STDERR_FD, ?sf.text[bounds.start], bounds.end - bounds.start);
+    emit_gutter_num(w, line);
+    if (b.end > b.start) {
+        os.write(os.STDERR_FD, ?sf.text[b.start], b.end - b.start);
+    }
     print.eprint("\n");
+}
 
-    var caret_at: usize = span.offset;
-    if (caret_at < bounds.start) { caret_at = bounds.start; }
-    if (caret_at > bounds.end)   { caret_at = bounds.end;   }
+# write the underline for the portion of `line` the span covers.
+#
+# The leading run up to the marked range is reproduced as tabs and spaces so the
+# markers land under the span regardless of tab width. The marker glyph (`^` for
+# the primary line, `-` for a continuation) fills the covered range, with a
+# zero-length range marking a single column.
+# ---
+# sf:    source file the line is drawn from
+# w:     gutter width in columns
+# line:  1-based line number being underlined
+# off:   clamped span start byte offset
+# end:   clamped span end byte offset (exclusive)
+# glyph: the marker glyph, "^" or "-"
+fun emit_underline(sf: *source.SourceFile, w: usize, line: usize, off: usize, end: usize, glyph: str) {
+    val opt_bounds: O.Option[source.LineSpan] = source.line_bounds(sf, line);
+    if (O.is_none[source.LineSpan](opt_bounds)) { ret; }
+    val b: source.LineSpan = O.unwrap[source.LineSpan](opt_bounds);
 
-    var i: usize = bounds.start;
-    for (i < caret_at) {
+    var mark_from: usize = b.start;
+    if (off > b.start && off <= b.end) { mark_from = off; }
+    var mark_to: usize = b.end;
+    if (end >= b.start && end <= b.end) { mark_to = end; }
+    if (mark_to < mark_from) { mark_to = mark_from; }
+
+    emit_gutter_bar(w);
+
+    var i: usize = b.start;
+    for (i < mark_from) {
         if (sf.text[i] == '\t') { print.eprint("\t"); }
         or                      { print.eprint(" ");  }
         i = i + 1;
     }
 
-    print.eprint("^");
-
-    var span_end: usize = span.offset + span.len;
-    if (span_end > bounds.end) { span_end = bounds.end; }
-    i = caret_at + 1;
-    for (i < span_end) {
-        print.eprint("~");
-        i = i + 1;
-    }
+    var n: usize = mark_to - mark_from;
+    if (n == 0) { n = 1; }
+    var j: usize = 0;
+    for (j < n) { print.eprint(glyph); j = j + 1; }
     print.eprint("\n");
+}
+
+# write the `--> file:line:col` location line under the gutter.
+# ---
+# w:    gutter width in columns
+# path: source file path
+# line: 1-based line of the span start
+# col:  1-based column of the span start
+fun emit_loc(w: usize, path: str, line: usize, col: usize) {
+    emit_spaces(w);
+    print.eprint("--> ");
+    print.eprint(path);
+    print.eprint(":");
+    print.eu64(line::u64);
+    print.eprint(":");
+    print.eu64(col::u64);
+    print.eprint("\n");
+}
+
+# write a blank gutter line (`|`) terminated by a newline.
+# ---
+# w: gutter width in columns
+fun emit_bar(w: usize) {
+    emit_spaces(w);
+    print.eprint(" |\n");
+}
+
+# write the `...` elision marker standing in for omitted span lines.
+# ---
+# w: gutter width in columns
+fun emit_elision(w: usize) {
+    emit_spaces(w);
+    print.eprint(" | ...\n");
+}
+
+# write a right-aligned line number followed by the ` | ` gutter separator.
+# ---
+# w:    gutter width in columns
+# line: 1-based line number to print
+fun emit_gutter_num(w: usize, line: usize) {
+    emit_spaces(w - decimal_width(line));
+    print.eu64(line::u64);
+    print.eprint(" | ");
+}
+
+# write a blank (numberless) gutter prefix ending in the ` | ` separator.
+# ---
+# w: gutter width in columns
+fun emit_gutter_bar(w: usize) {
+    emit_spaces(w);
+    print.eprint(" | ");
+}
+
+# write a `= note:` line indented so its `=` aligns with the gutter bar.
+# ---
+# note:   the note text
+# indent: spaces preceding the `=`
+fun emit_note(note: str, indent: usize) {
+    emit_spaces(indent);
+    print.eprint("= note: ");
+    print.eprintln(note);
+}
+
+# write the closing `N errors / M warnings` counts line.
+# ---
+# errors:   number of error-severity diagnostics rendered
+# warnings: number of warning-severity diagnostics rendered
+fun emit_summary(errors: usize, warnings: usize) {
+    print.eu64(errors::u64);
+    if (errors == 1) { print.eprint(" error");  }
+    or               { print.eprint(" errors"); }
+    print.eprint(" / ");
+    print.eu64(warnings::u64);
+    if (warnings == 1) { print.eprint(" warning");  }
+    or                 { print.eprint(" warnings"); }
+    print.eprint("\n");
+}
+
+# write the `severity: message` headline line.
+# ---
+# severity: severity of the diagnostic
+# message:  the diagnostic message
+fun emit_headline(severity: diagnostic.Severity, message: str) {
+    print.eprint(severity_label(severity));
+    print.eprintln(message);
+}
+
+# write `n` spaces to stderr.
+# ---
+# n: number of spaces to emit
+fun emit_spaces(n: usize) {
+    var i: usize = 0;
+    for (i < n) { print.eprint(" "); i = i + 1; }
+}
+
+# the count of decimal digits in `n` (at least 1).
+# ---
+# n:   the value to measure
+# ret: number of decimal digits
+fun decimal_width(n: usize) usize {
+    var w: usize = 1;
+    var v: usize = n;
+    for (v >= 10) { w = w + 1; v = v / 10; }
+    ret w;
 }
 
 # the leading `severity: ` text for a diagnostic severity.
@@ -115,17 +309,4 @@ fun severity_label(severity: diagnostic.Severity) str {
     if (severity == diagnostic.SEVERITY_WARNING) { ret "warning: "; }
     if (severity == diagnostic.SEVERITY_INFO)    { ret "info: ";    }
     ret "help: ";
-}
-
-# the ANSI SGR sequence for a severity label, applied only when color is enabled.
-#
-# Error is bold red, warning bold magenta, info bold cyan, help bold green.
-# ---
-# severity: severity whose color to select
-# ret:      the SGR escape sequence opening the color
-fun severity_color(severity: diagnostic.Severity) str {
-    if (severity == diagnostic.SEVERITY_ERROR)   { ret "\x1b[1;31m"; }
-    if (severity == diagnostic.SEVERITY_WARNING) { ret "\x1b[1;35m"; }
-    if (severity == diagnostic.SEVERITY_INFO)    { ret "\x1b[1;36m"; }
-    ret "\x1b[1;32m";
 }

--- a/src/lang/driver.mach
+++ b/src/lang/driver.mach
@@ -15,7 +15,6 @@ use std.collections.map;
 use std.data.toml;
 use std.filesystem;
 use std.memory;
-use std.print;
 use std.text.string.str_dup;
 use std.text.string.str_free;
 use std.types.bool.bool;
@@ -35,6 +34,7 @@ use std.types.string.view_eq_str;
 use A: std.allocator;
 use O: std.types.option;
 use R: std.types.result;
+use ctime: std.chrono.time;
 
 use be_linker: mach.lang.be.linker;
 use mach.lang.diagnostic;
@@ -52,6 +52,7 @@ use mach.lang.fe.token;
 use mach.lang.intern;
 use mach.lang.manifest;
 use mach.lang.query;
+use mach.lang.readout;
 use mach.lang.session;
 use src: mach.lang.source;
 use mach.lang.target;
@@ -566,6 +567,7 @@ fun build_project_impl(s: *session.Session, project_root: str, sel: *manifest.Se
     }
     val entry_fqn: intern.StrId = R.unwrap_ok[intern.StrId, str](entry_path_r);
 
+    readout.phase_begin(p.s.readout, readout.PH_LOAD);
     val load_r: R.Result[session.ModuleId, str] = dfs_load(?p, entry_fqn);
     if (R.is_err[session.ModuleId, str](load_r)) {
         dnit_project(?p);
@@ -585,6 +587,7 @@ fun build_project_impl(s: *session.Session, project_root: str, sel: *manifest.Se
         }
         ei = ei + 1;
     }
+    readout.phase_end(p.s.readout, readout.PH_LOAD, p.topo_len, "module", "modules");
 
     # the module table is stable past the load pass; publish every module's
     # AST to the session registry so later phases can reach cross-module
@@ -2026,10 +2029,14 @@ fun dfs_load(p: *Project, fqn: intern.StrId) R.Result[session.ModuleId, str] {
     if (R.is_err[bool, str](cap_r)) { ret R.err[session.ModuleId, str](R.unwrap_err[bool, str](cap_r)); }
     p.load_status[mid::u32] = LOAD_LOADING;
 
+    # the load phase times each module's read + lex + parse as one item; the
+    # walk that follows recurses into dependencies, so it is timed separately.
+    val t_load: ctime.Time = readout.item_begin(p.s.readout);
     val parse_r: R.Result[bool, str] = parse_module(p, mid, fqn);
     if (R.is_err[bool, str](parse_r)) {
         ret R.err[session.ModuleId, str](R.unwrap_err[bool, str](parse_r));
     }
+    readout.item(p.s.readout, readout.PH_LOAD, fqn_name(p, fqn), t_load);
 
     val walk_r: R.Result[bool, str] = walk_module_for_load(p, mid);
     if (R.is_err[bool, str](walk_r)) {
@@ -2250,22 +2257,17 @@ fun parse_define_int(s: str, start: usize, len: usize, out: *i64) bool {
     ret true;
 }
 
-# write a `<stage> <fqn>` front-end progress line to stderr for one
-# module, matching the back-end's `--verbose` stage lines (cmd.build.emit_stage).
-# a no-op unless the session's `verbose` flag is set; an un-interned fqn renders
-# as "<?>".
+# resolve an interned module FQN to its display string for the readout
+#
+# Falls back to "<?>" for an un-interned id so a readout item always has a name.
 # ---
-# p:     the project (for its session interner and verbose flag)
-# stage: a short stage label (e.g. "lex", "parse", "resolve")
-# fqn:   the module's interned fully-qualified name
-fun emit_stage(p: *Project, stage: str, fqn: intern.StrId) {
-    if (!p.s.verbose) { ret; }
-    print.eprint(stage);
-    print.eprint(" ");
+# p:   the project (for its session interner)
+# fqn: the module's interned fully-qualified name
+# ret: the FQN string, or "<?>"
+fun fqn_name(p: *Project, fqn: intern.StrId) str {
     val o: O.Option[str] = intern.lookup(?p.s.interner, fqn);
-    if (O.is_some[str](o)) { print.eprint(O.unwrap[str](o)); }
-    or                   { print.eprint("<?>"); }
-    print.eprint("\n");
+    if (O.is_some[str](o)) { ret O.unwrap[str](o); }
+    ret "<?>";
 }
 
 # resolve `fqn` to a file, load its source into the session, and route the parse
@@ -2356,7 +2358,6 @@ fun q_parse_compute(db: *query.QueryDb, key: u64, alloc: *A.Allocator) R.Result[
     if (O.is_none[*src.SourceFile](file_opt)) { ret R.err[query.QueryOutput, str]("Q_PARSE: FileId not registered with the session"); }
     val file: *src.SourceFile = O.unwrap[*src.SourceFile](file_opt);
 
-    if (s.verbose) { q_parse_emit_stage(s, "lex", file.path); }
     val tok_r: R.Result[lexer.TokenStream, str] = lexer.tokenize(file.text, alloc, file_id);
     if (R.is_err[lexer.TokenStream, str](tok_r)) { ret R.err[query.QueryOutput, str](R.unwrap_err[lexer.TokenStream, str](tok_r)); }
     var stream: lexer.TokenStream = R.unwrap_ok[lexer.TokenStream, str](tok_r);
@@ -2376,7 +2377,6 @@ fun q_parse_compute(db: *query.QueryDb, key: u64, alloc: *A.Allocator) R.Result[
         lexer.dnit(?stream, alloc);
         ret R.err[query.QueryOutput, str](R.unwrap_err[bool, str](le_r));
     }
-    if (s.verbose) { q_parse_emit_stage(s, "parse", file.path); }
     val fatal: bool = parser.parse(?stream, a, ?s.diags);
     lexer.dnit(?stream, alloc);
     # a fatal allocation failure leaves the AST incomplete; refuse to publish it
@@ -2427,15 +2427,6 @@ fun ast_handle_decode(e: *query.QueryEntry) *ast.Ast {
     if (e.value == nil || e.value_len::usize < $size_of(ptr)) { ret nil; }
     val slot: *ptr = e.value::ptr::*ptr;
     ret slot[0]::*ast.Ast;
-}
-
-# the verbose front-end progress line for a Q_PARSE compute,
-# labeled by source path (the compute's identifier; the FQN is the driver's).
-fun q_parse_emit_stage(s: *session.Session, stage: str, path: str) {
-    print.eprint(stage);
-    print.eprint(" ");
-    print.eprint(path);
-    print.eprint("\n");
 }
 
 # the Q_EXPORTS derived compute - a deterministic byte
@@ -3183,6 +3174,7 @@ fun register_module_asts(p: *Project) R.Result[bool, str] {
 fun run_resolve_pass(p: *Project) R.Result[bool, str] {
     session.set_active_project(p.s, p::ptr);
 
+    readout.phase_begin(p.s.readout, readout.PH_RESOLVE);
     var i: u32 = 0;
     for (i < p.topo_len) {
         val mid: session.ModuleId = p.topo[i];
@@ -3193,6 +3185,7 @@ fun run_resolve_pass(p: *Project) R.Result[bool, str] {
         }
         i = i + 1;
     }
+    readout.phase_end(p.s.readout, readout.PH_RESOLVE, p.topo_len, "module", "modules");
     session.set_active_project(p.s, nil);
     ret R.ok[bool, str](true);
 }
@@ -3204,7 +3197,7 @@ fun run_resolve_pass(p: *Project) R.Result[bool, str] {
 fun run_resolve_one(p: *Project, mid: session.ModuleId) R.Result[bool, str] {
     val m: *ModuleEntry = ?p.modules[mid::u32];
 
-    emit_stage(p, "resolve", m.fqn);
+    val t_item: ctime.Time = readout.item_begin(p.s.readout);
 
     val e_r: R.Result[*query.QueryEntry, str] = query.get(?p.s.queries, query.Q_RESOLVE, m.stable_id::u64);
     if (R.is_err[*query.QueryEntry, str](e_r)) { ret R.err[bool, str](R.unwrap_err[*query.QueryEntry, str](e_r)); }
@@ -3229,6 +3222,7 @@ fun run_resolve_one(p: *Project, mid: session.ModuleId) R.Result[bool, str] {
 
     m.resolve_result = rr;
     m.resolved       = true;
+    readout.item(p.s.readout, readout.PH_RESOLVE, fqn_name(p, m.fqn), t_item);
     ret R.ok[bool, str](true);
 }
 
@@ -3390,6 +3384,7 @@ pub fun run_sema_pass(p: *Project) R.Result[bool, str] {
     # from the pre-epoch build-once behaviour.
     type.field_epoch_bump(?p.s.types);
 
+    readout.phase_begin(p.s.readout, readout.PH_SEMA);
     var i: u32 = 0;
     for (i < p.topo_len) {
         val mid: session.ModuleId = p.topo[i];
@@ -3400,6 +3395,7 @@ pub fun run_sema_pass(p: *Project) R.Result[bool, str] {
         }
         i = i + 1;
     }
+    readout.phase_end(p.s.readout, readout.PH_SEMA, p.topo_len, "module", "modules");
     session.set_active_project(p.s, nil);
     ret R.ok[bool, str](true);
 }
@@ -3413,7 +3409,7 @@ pub fun run_sema_pass(p: *Project) R.Result[bool, str] {
 fun run_sema_one(p: *Project, mid: session.ModuleId) R.Result[bool, str] {
     val m: *ModuleEntry = ?p.modules[mid::u32];
 
-    emit_stage(p, "sema", m.fqn);
+    val t_item: ctime.Time = readout.item_begin(p.s.readout);
 
     val e_r: R.Result[*query.QueryEntry, str] = query.get(?p.s.queries, query.Q_SEMA, m.stable_id::u64);
     if (R.is_err[*query.QueryEntry, str](e_r)) { ret R.err[bool, str](R.unwrap_err[*query.QueryEntry, str](e_r)); }
@@ -3440,6 +3436,7 @@ fun run_sema_one(p: *Project, mid: session.ModuleId) R.Result[bool, str] {
     if (R.is_err[bool, str](rr2)) { ret R.err[bool, str](R.unwrap_err[bool, str](rr2)); }
     val rc: R.Result[bool, str] = session.register_module_comptime(p.s, mid, (?m.ctx)::ptr);
     if (R.is_err[bool, str](rc)) { ret R.err[bool, str](R.unwrap_err[bool, str](rc)); }
+    readout.item(p.s.readout, readout.PH_SEMA, fqn_name(p, m.fqn), t_item);
     ret R.ok[bool, str](true);
 }
 

--- a/src/lang/me/lower/testrunner.mach
+++ b/src/lang/me/lower/testrunner.mach
@@ -1,23 +1,24 @@
-# synthesizes one standalone entry per `test`.
+# synthesizes the single test dispatcher entry for a test build.
 #
-# `mach test` builds every `test "..."` block into its own small executable: the
-# test function plus the project's transitive code, with a synthesized `main`
-# that calls just that one test and returns its `i32` result as the process exit
-# status (0 = pass, non-zero = fail). the per-test executables are run as
-# separate processes by `mach test`, so a crashing test reports a signal and the
-# run continues.
+# `mach test` builds one executable per test build: the project's transitive
+# code plus a synthesized dispatcher `main(argc, argv)` that selects one test by
+# its decimal collection index in `argv[1]`, calls it, and returns its `i32`
+# result as the process exit status (0 = pass, non-zero = fail). the runner
+# still spawns one process per test (`<exe> <idx>`), so a crashing test reports
+# a signal and the run continues; a missing, malformed, or out-of-range index
+# exits 2, the harness's internal-error code.
 #
 # this module does two jobs for that build:
 #   - `collect` gathers every `FN_FLAG_TEST` function across the lowered module
 #     set into a `Collected` list (linkage name, printable label, source line,
 #     and the index of the declaring module, for `file:line` reporting).
-#   - `synthesize_entry` builds, for one collected test, a tiny IR module whose
-#     `main` is `ret <test>();` - a signature-only extern for the test symbol
-#     plus a two-instruction body. it carries no OS interaction of its own, so it
-#     works for any target with or without a standard library.
+#   - `synthesize_dispatcher` builds one IR module: a signature-only extern per
+#     selected test plus the dispatching `main`. argv arrives as `main`
+#     parameters from the target runtime, so the synthesized IR itself stays
+#     stdlib-independent.
 #
 # `neutralize_project_main` turns the project's own `main` into a body-less
-# extern so each test executable's sole program entry is the synthesized one.
+# extern so the test executable's sole program entry is the synthesized one.
 
 use std.types.bool.bool;
 use std.types.bool.true;
@@ -123,8 +124,8 @@ pub fun free(s: *session.Session, c: *Collected) {
 }
 
 # turn every function whose linkage name is literally `main` into a body-less
-# extern, so a test executable's sole program entry is the synthesized per-test
-# `main`
+# extern, so the test executable's sole program entry is the synthesized
+# dispatcher `main`
 #
 # The dropped blocks are reclaimed by the module's own dnit; a test build never
 # references the project's `main`, so the extern emits nothing. Called between
@@ -159,20 +160,25 @@ pub fun neutralize_project_main(s: *session.Session, modules: *ir.Module, count:
     ret R.ok[bool, str](true);
 }
 
-# build a fresh IR module whose `main` calls the single test named by `linkage`
-# and returns its i32 result as the process exit status
+# build a fresh IR module whose `main(argc, argv)` dispatches `argv[1]` (a
+# decimal collection index) to the matching test and returns its i32 result as
+# the process exit status
 #
-# The module declares the test symbol as a signature-only `i32()` extern (the
-# linker binds it to the test's defining object) and emits `main` as
-# `ret <test>();`. The caller optimises, codegens, and links it with the
-# project's per-module objects into one standalone test executable. The returned
-# module is owned by the caller (ir.dnit).
+# The module declares each test symbol as a signature-only `i32()` extern (the
+# linker binds them to their defining objects). `main` returns 2 - the
+# harness's internal-error exit code - for a missing, empty, malformed, or
+# out-of-range index. The caller optimises, codegens, and links the module with
+# the project's per-module objects into the single test executable. The
+# returned module is owned by the caller (ir.dnit).
 # ---
-# s:       session holding the string interner and allocator
-# linkage: linkage name of the test symbol `main` should call
-# ret:     the synthesized module, or an allocation error
-pub fun synthesize_entry(s: *session.Session, linkage: intern.StrId) R.Result[ir.Module, str] {
-    val res_name: R.Result[intern.StrId, str] = intern.intern(?s.interner, "__mach_test_entry");
+# s:     session holding the string interner and allocator
+# tests: the selected tests, dispatch index = array position
+# count: number of tests in `tests`
+# ret:   the synthesized module, or an error
+pub fun synthesize_dispatcher(s: *session.Session, tests: *Test, count: u32) R.Result[ir.Module, str] {
+    if (count == 0) { ret R.err[ir.Module, str]("test dispatcher: no tests to dispatch"); }
+
+    val res_name: R.Result[intern.StrId, str] = intern.intern(?s.interner, "__mach_test_dispatch");
     if (R.is_err[intern.StrId, str](res_name)) {
         ret R.err[ir.Module, str](R.unwrap_err[intern.StrId, str](res_name));
     }
@@ -183,7 +189,7 @@ pub fun synthesize_entry(s: *session.Session, linkage: intern.StrId) R.Result[ir
     }
     var m: ir.Module = R.unwrap_ok[ir.Module, str](res_module);
 
-    val res_build: R.Result[bool, str] = build_entry(s, ?m, linkage);
+    val res_build: R.Result[bool, str] = build_dispatcher(s, ?m, tests, count);
     if (R.is_err[bool, str](res_build)) {
         ir.dnit(?m);
         ret R.err[ir.Module, str](R.unwrap_err[bool, str](res_build));
@@ -227,61 +233,240 @@ fun push_test(s: *session.Session, c: *Collected, t: Test) R.Result[bool, str] {
     ret R.ok[bool, str](true);
 }
 
-# emit the test symbol's extern and the `main(){ ret <test>(); }` body into `m`
+# emit the per-test externs and the dispatching `main(argc, argv)` body into `m`
+#
+# The CFG is: entry checks `argc >= 2`; getarg loads `argv[1]` and rejects an
+# empty string; a phi loop parses the decimal index (any non-digit byte exits
+# 2); a compare/branch chain then dispatches the index to its test call, whose
+# i32 result is sign-extended and returned. All failure paths return 2, the
+# harness's internal-error exit code, distinguishable from a test's own failure.
 # ---
-# s:       session holding the string interner
-# m:       the module to populate
-# linkage: linkage name of the test symbol to call
-# ret:     true on success, or an allocation error
-fun build_entry(s: *session.Session, m: *ir.Module, linkage: intern.StrId) R.Result[bool, str] {
+# s:     session holding the string interner
+# m:     the module to populate
+# tests: the selected tests, dispatch index = array position
+# count: number of tests in `tests`
+# ret:   true on success, or an error
+fun build_dispatcher(s: *session.Session, m: *ir.Module, tests: *Test, count: u32) R.Result[bool, str] {
+    val res_i8: R.Result[type.IrTypeId, str] = type.intern_int(?m.types, 8);
+    if (R.is_err[type.IrTypeId, str](res_i8)) { ret R.err[bool, str](R.unwrap_err[type.IrTypeId, str](res_i8)); }
+    val i8t: type.IrTypeId = R.unwrap_ok[type.IrTypeId, str](res_i8);
+
     val res_i32: R.Result[type.IrTypeId, str] = type.intern_int(?m.types, 32);
-    if (R.is_err[type.IrTypeId, str](res_i32)) {
-        ret R.err[bool, str](R.unwrap_err[type.IrTypeId, str](res_i32));
-    }
-    val i32: type.IrTypeId = R.unwrap_ok[type.IrTypeId, str](res_i32);
+    if (R.is_err[type.IrTypeId, str](res_i32)) { ret R.err[bool, str](R.unwrap_err[type.IrTypeId, str](res_i32)); }
+    val i32t: type.IrTypeId = R.unwrap_ok[type.IrTypeId, str](res_i32);
 
-    val res_sig: R.Result[type.IrTypeId, str] = type.intern_fn(?m.types, i32, nil, 0);
-    if (R.is_err[type.IrTypeId, str](res_sig)) {
-        ret R.err[bool, str](R.unwrap_err[type.IrTypeId, str](res_sig));
-    }
-    val sig: type.IrTypeId = R.unwrap_ok[type.IrTypeId, str](res_sig);
+    val res_i64: R.Result[type.IrTypeId, str] = type.intern_int(?m.types, 64);
+    if (R.is_err[type.IrTypeId, str](res_i64)) { ret R.err[bool, str](R.unwrap_err[type.IrTypeId, str](res_i64)); }
+    val i64t: type.IrTypeId = R.unwrap_ok[type.IrTypeId, str](res_i64);
 
-    # the test symbol, declared signature-only so the call resolves across objects
-    val res_ext: R.Result[u32, str] = append_function(m, linkage, sig, ir.FN_FLAG_EXTERN);
-    if (R.is_err[u32, str](res_ext)) {
-        ret R.err[bool, str](R.unwrap_err[u32, str](res_ext));
+    val res_ptr: R.Result[type.IrTypeId, str] = type.intern_ptr(?m.types);
+    if (R.is_err[type.IrTypeId, str](res_ptr)) { ret R.err[bool, str](R.unwrap_err[type.IrTypeId, str](res_ptr)); }
+    val ptrt: type.IrTypeId = R.unwrap_ok[type.IrTypeId, str](res_ptr);
+
+    # every test shares the `i32()` signature; main is `i64(i64, **u8)`, the
+    # contract the runtime start calls (`fun main(argc: i64, argv: **u8) i64`).
+    val res_tsig: R.Result[type.IrTypeId, str] = type.intern_fn(?m.types, i32t, nil, 0);
+    if (R.is_err[type.IrTypeId, str](res_tsig)) { ret R.err[bool, str](R.unwrap_err[type.IrTypeId, str](res_tsig)); }
+    val tsig: type.IrTypeId = R.unwrap_ok[type.IrTypeId, str](res_tsig);
+
+    var main_params: [2]type.IrTypeId;
+    main_params[0] = i64t;
+    main_params[1] = ptrt;
+    val res_msig: R.Result[type.IrTypeId, str] = type.intern_fn(?m.types, i64t, ?main_params[0], 2);
+    if (R.is_err[type.IrTypeId, str](res_msig)) { ret R.err[bool, str](R.unwrap_err[type.IrTypeId, str](res_msig)); }
+    val msig: type.IrTypeId = R.unwrap_ok[type.IrTypeId, str](res_msig);
+
+    # the test symbols, declared signature-only so each call resolves across objects
+    val res_callees: R.Result[*value.Value, str] = A.allocate[value.Value](m.alloc, count::usize);
+    if (R.is_err[*value.Value, str](res_callees)) { ret R.err[bool, str](R.unwrap_err[*value.Value, str](res_callees)); }
+    val callees: *value.Value = R.unwrap_ok[*value.Value, str](res_callees);
+
+    var k: u32 = 0;
+    for (k < count) {
+        val res_ext: R.Result[u32, str] = append_function(m, tests[k].linkage, tsig, ir.FN_FLAG_EXTERN);
+        if (R.is_err[u32, str](res_ext)) { ret R.err[bool, str](R.unwrap_err[u32, str](res_ext)); }
+        callees[k] = value.fn(R.unwrap_ok[u32, str](res_ext), tsig);
+        k = k + 1;
     }
-    val callee: value.Value = value.fn(R.unwrap_ok[u32, str](res_ext), sig);
 
     # `main` is emitted verbatim: a synthesized module is not run through the
-    # export registry, so the OS entry calls the literal `main`. its body is one
-    # call to the test and a return of the i32 result, which the process exit
-    # status carries (0 = pass).
+    # export registry, so the OS entry calls the literal `main`.
     val res_main: R.Result[intern.StrId, str] = intern.intern(?s.interner, "main");
-    if (R.is_err[intern.StrId, str](res_main)) {
-        ret R.err[bool, str](R.unwrap_err[intern.StrId, str](res_main));
-    }
-    val res_main_idx: R.Result[u32, str] = append_function(m, R.unwrap_ok[intern.StrId, str](res_main), sig, ir.FN_FLAG_PUB);
-    if (R.is_err[u32, str](res_main_idx)) {
-        ret R.err[bool, str](R.unwrap_err[u32, str](res_main_idx));
-    }
+    if (R.is_err[intern.StrId, str](res_main)) { ret R.err[bool, str](R.unwrap_err[intern.StrId, str](res_main)); }
+    val res_main_idx: R.Result[u32, str] = append_function(m, R.unwrap_ok[intern.StrId, str](res_main), msig, ir.FN_FLAG_PUB);
+    if (R.is_err[u32, str](res_main_idx)) { ret R.err[bool, str](R.unwrap_err[u32, str](res_main_idx)); }
     val main_idx: u32 = R.unwrap_ok[u32, str](res_main_idx);
+
+    # the function's VAL_PARAM array; codegen maps parameter vregs from it, so
+    # a function that reads its params must carry it (function_add leaves none)
+    val res_params: R.Result[*value.Value, str] = A.allocate[value.Value](m.alloc, 2);
+    if (R.is_err[*value.Value, str](res_params)) { ret R.err[bool, str](R.unwrap_err[*value.Value, str](res_params)); }
+    val params: *value.Value = R.unwrap_ok[*value.Value, str](res_params);
+    params[0] = value.param(0, i64t);
+    params[1] = value.param(1, ptrt);
+    m.functions[main_idx].params      = params;
+    m.functions[main_idx].param_count = 2;
 
     var b: builder.Builder = builder.init(m);
     builder.set_function(?b, ?m.functions[main_idx]);
 
-    val res_block: R.Result[id.BlockId, str] = builder.new_block(?b);
-    if (R.is_err[id.BlockId, str](res_block)) {
-        ret R.err[bool, str](R.unwrap_err[id.BlockId, str](res_block));
-    }
-    builder.set_block(?b, R.unwrap_ok[id.BlockId, str](res_block));
+    val res_entry: R.Result[id.BlockId, str] = builder.new_block(?b);
+    if (R.is_err[id.BlockId, str](res_entry)) { ret R.err[bool, str](R.unwrap_err[id.BlockId, str](res_entry)); }
+    val b_entry: id.BlockId = R.unwrap_ok[id.BlockId, str](res_entry);
 
-    val res_call: R.Result[value.Value, str] = builder.emit_call(?b, callee, nil, 0, i32);
-    if (R.is_err[value.Value, str](res_call)) {
-        ret R.err[bool, str](R.unwrap_err[value.Value, str](res_call));
+    val res_bad: R.Result[id.BlockId, str] = builder.new_block(?b);
+    if (R.is_err[id.BlockId, str](res_bad)) { ret R.err[bool, str](R.unwrap_err[id.BlockId, str](res_bad)); }
+    val b_bad: id.BlockId = R.unwrap_ok[id.BlockId, str](res_bad);
+
+    val res_getarg: R.Result[id.BlockId, str] = builder.new_block(?b);
+    if (R.is_err[id.BlockId, str](res_getarg)) { ret R.err[bool, str](R.unwrap_err[id.BlockId, str](res_getarg)); }
+    val b_getarg: id.BlockId = R.unwrap_ok[id.BlockId, str](res_getarg);
+
+    val res_head: R.Result[id.BlockId, str] = builder.new_block(?b);
+    if (R.is_err[id.BlockId, str](res_head)) { ret R.err[bool, str](R.unwrap_err[id.BlockId, str](res_head)); }
+    val b_head: id.BlockId = R.unwrap_ok[id.BlockId, str](res_head);
+
+    val res_low: R.Result[id.BlockId, str] = builder.new_block(?b);
+    if (R.is_err[id.BlockId, str](res_low)) { ret R.err[bool, str](R.unwrap_err[id.BlockId, str](res_low)); }
+    val b_low_ok: id.BlockId = R.unwrap_ok[id.BlockId, str](res_low);
+
+    val res_body: R.Result[id.BlockId, str] = builder.new_block(?b);
+    if (R.is_err[id.BlockId, str](res_body)) { ret R.err[bool, str](R.unwrap_err[id.BlockId, str](res_body)); }
+    val b_body: id.BlockId = R.unwrap_ok[id.BlockId, str](res_body);
+
+    # the dispatch chain and call blocks, one pair per test
+    val res_dblocks: R.Result[*id.BlockId, str] = A.allocate[id.BlockId](m.alloc, count::usize);
+    if (R.is_err[*id.BlockId, str](res_dblocks)) { ret R.err[bool, str](R.unwrap_err[*id.BlockId, str](res_dblocks)); }
+    val dblocks: *id.BlockId = R.unwrap_ok[*id.BlockId, str](res_dblocks);
+
+    val res_cblocks: R.Result[*id.BlockId, str] = A.allocate[id.BlockId](m.alloc, count::usize);
+    if (R.is_err[*id.BlockId, str](res_cblocks)) { ret R.err[bool, str](R.unwrap_err[*id.BlockId, str](res_cblocks)); }
+    val cblocks: *id.BlockId = R.unwrap_ok[*id.BlockId, str](res_cblocks);
+
+    k = 0;
+    for (k < count) {
+        val res_d: R.Result[id.BlockId, str] = builder.new_block(?b);
+        if (R.is_err[id.BlockId, str](res_d)) { ret R.err[bool, str](R.unwrap_err[id.BlockId, str](res_d)); }
+        dblocks[k] = R.unwrap_ok[id.BlockId, str](res_d);
+
+        val res_c: R.Result[id.BlockId, str] = builder.new_block(?b);
+        if (R.is_err[id.BlockId, str](res_c)) { ret R.err[bool, str](R.unwrap_err[id.BlockId, str](res_c)); }
+        cblocks[k] = R.unwrap_ok[id.BlockId, str](res_c);
+        k = k + 1;
     }
 
-    ret builder.emit_ret(?b, R.unwrap_ok[value.Value, str](res_call));
+    val argc: value.Value = value.param(0, i64t);
+    val argv: value.Value = value.param(1, ptrt);
+
+    # entry: argc < 2 -> bad
+    builder.set_block(?b, b_entry);
+    val res_lt2: R.Result[value.Value, str] = builder.emit_cmp_lt_s(?b, argc, value.const_int(2, i64t));
+    if (R.is_err[value.Value, str](res_lt2)) { ret R.err[bool, str](R.unwrap_err[value.Value, str](res_lt2)); }
+    val res_cbr0: R.Result[bool, str] = builder.emit_cbr(?b, R.unwrap_ok[value.Value, str](res_lt2), b_bad, b_getarg);
+    if (R.is_err[bool, str](res_cbr0)) { ret res_cbr0; }
+
+    # bad: every rejection exits 2
+    builder.set_block(?b, b_bad);
+    val res_ret2: R.Result[bool, str] = builder.emit_ret(?b, value.const_int(2, i64t));
+    if (R.is_err[bool, str](res_ret2)) { ret res_ret2; }
+
+    # getarg: arg = argv[1]; an empty string is malformed
+    builder.set_block(?b, b_getarg);
+    var one_idx: [1]value.Value;
+    one_idx[0] = value.const_int(1, i64t);
+    val res_gep1: R.Result[value.Value, str] = builder.emit_gep(?b, argv, ptrt, ?one_idx[0], 1);
+    if (R.is_err[value.Value, str](res_gep1)) { ret R.err[bool, str](R.unwrap_err[value.Value, str](res_gep1)); }
+    val res_arg: R.Result[value.Value, str] = builder.emit_load(?b, R.unwrap_ok[value.Value, str](res_gep1), ptrt);
+    if (R.is_err[value.Value, str](res_arg)) { ret R.err[bool, str](R.unwrap_err[value.Value, str](res_arg)); }
+    val arg: value.Value = R.unwrap_ok[value.Value, str](res_arg);
+    val res_c0: R.Result[value.Value, str] = builder.emit_load(?b, arg, i8t);
+    if (R.is_err[value.Value, str](res_c0)) { ret R.err[bool, str](R.unwrap_err[value.Value, str](res_c0)); }
+    val res_c0z: R.Result[value.Value, str] = builder.emit_cmp_eq(?b, R.unwrap_ok[value.Value, str](res_c0), value.const_int(0, i8t));
+    if (R.is_err[value.Value, str](res_c0z)) { ret R.err[bool, str](R.unwrap_err[value.Value, str](res_c0z)); }
+    val res_cbr1: R.Result[bool, str] = builder.emit_cbr(?b, R.unwrap_ok[value.Value, str](res_c0z), b_bad, b_head);
+    if (R.is_err[bool, str](res_cbr1)) { ret res_cbr1; }
+
+    # head: p/acc flow around the digit loop; a NUL ends the number
+    builder.set_block(?b, b_head);
+    val res_pphi: R.Result[value.Value, str] = builder.emit_phi(?b, ptrt);
+    if (R.is_err[value.Value, str](res_pphi)) { ret R.err[bool, str](R.unwrap_err[value.Value, str](res_pphi)); }
+    val p_phi: value.Value = R.unwrap_ok[value.Value, str](res_pphi);
+    val res_aphi: R.Result[value.Value, str] = builder.emit_phi(?b, i64t);
+    if (R.is_err[value.Value, str](res_aphi)) { ret R.err[bool, str](R.unwrap_err[value.Value, str](res_aphi)); }
+    val acc_phi: value.Value = R.unwrap_ok[value.Value, str](res_aphi);
+
+    val res_c: R.Result[value.Value, str] = builder.emit_load(?b, p_phi, i8t);
+    if (R.is_err[value.Value, str](res_c)) { ret R.err[bool, str](R.unwrap_err[value.Value, str](res_c)); }
+    val c: value.Value = R.unwrap_ok[value.Value, str](res_c);
+    val res_end: R.Result[value.Value, str] = builder.emit_cmp_eq(?b, c, value.const_int(0, i8t));
+    if (R.is_err[value.Value, str](res_end)) { ret R.err[bool, str](R.unwrap_err[value.Value, str](res_end)); }
+    val res_cbr2: R.Result[bool, str] = builder.emit_cbr(?b, R.unwrap_ok[value.Value, str](res_end), dblocks[0], b_low_ok);
+    if (R.is_err[bool, str](res_cbr2)) { ret res_cbr2; }
+
+    # low_ok / body: reject bytes outside '0'..'9', else acc = acc*10 + digit
+    builder.set_block(?b, b_low_ok);
+    val res_lt0: R.Result[value.Value, str] = builder.emit_cmp_lt_u(?b, c, value.const_int(48, i8t));
+    if (R.is_err[value.Value, str](res_lt0)) { ret R.err[bool, str](R.unwrap_err[value.Value, str](res_lt0)); }
+    val res_cbr3: R.Result[bool, str] = builder.emit_cbr(?b, R.unwrap_ok[value.Value, str](res_lt0), b_bad, b_body);
+    if (R.is_err[bool, str](res_cbr3)) { ret res_cbr3; }
+
+    builder.set_block(?b, b_body);
+    val res_gt9: R.Result[value.Value, str] = builder.emit_cmp_lt_u(?b, value.const_int(57, i8t), c);
+    if (R.is_err[value.Value, str](res_gt9)) { ret R.err[bool, str](R.unwrap_err[value.Value, str](res_gt9)); }
+
+    val res_step: R.Result[id.BlockId, str] = builder.new_block(?b);
+    if (R.is_err[id.BlockId, str](res_step)) { ret R.err[bool, str](R.unwrap_err[id.BlockId, str](res_step)); }
+    val b_step: id.BlockId = R.unwrap_ok[id.BlockId, str](res_step);
+    val res_cbr4: R.Result[bool, str] = builder.emit_cbr(?b, R.unwrap_ok[value.Value, str](res_gt9), b_bad, b_step);
+    if (R.is_err[bool, str](res_cbr4)) { ret res_cbr4; }
+
+    builder.set_block(?b, b_step);
+    val res_cz: R.Result[value.Value, str] = builder.emit_zext(?b, c, i64t);
+    if (R.is_err[value.Value, str](res_cz)) { ret R.err[bool, str](R.unwrap_err[value.Value, str](res_cz)); }
+    val res_dig: R.Result[value.Value, str] = builder.emit_sub(?b, R.unwrap_ok[value.Value, str](res_cz), value.const_int(48, i64t));
+    if (R.is_err[value.Value, str](res_dig)) { ret R.err[bool, str](R.unwrap_err[value.Value, str](res_dig)); }
+    val res_m10: R.Result[value.Value, str] = builder.emit_mul(?b, acc_phi, value.const_int(10, i64t));
+    if (R.is_err[value.Value, str](res_m10)) { ret R.err[bool, str](R.unwrap_err[value.Value, str](res_m10)); }
+    val res_acc: R.Result[value.Value, str] = builder.emit_add(?b, R.unwrap_ok[value.Value, str](res_m10), R.unwrap_ok[value.Value, str](res_dig));
+    if (R.is_err[value.Value, str](res_acc)) { ret R.err[bool, str](R.unwrap_err[value.Value, str](res_acc)); }
+    val acc_next: value.Value = R.unwrap_ok[value.Value, str](res_acc);
+    val res_pn: R.Result[value.Value, str] = builder.emit_gep(?b, p_phi, i8t, ?one_idx[0], 1);
+    if (R.is_err[value.Value, str](res_pn)) { ret R.err[bool, str](R.unwrap_err[value.Value, str](res_pn)); }
+    val p_next: value.Value = R.unwrap_ok[value.Value, str](res_pn);
+    val res_br: R.Result[bool, str] = builder.emit_br(?b, b_head);
+    if (R.is_err[bool, str](res_br)) { ret res_br; }
+
+    val res_in1: R.Result[bool, str] = builder.phi_add_incoming(?b, p_phi, b_getarg, arg);
+    if (R.is_err[bool, str](res_in1)) { ret res_in1; }
+    val res_in2: R.Result[bool, str] = builder.phi_add_incoming(?b, p_phi, b_step, p_next);
+    if (R.is_err[bool, str](res_in2)) { ret res_in2; }
+    val res_in3: R.Result[bool, str] = builder.phi_add_incoming(?b, acc_phi, b_getarg, value.const_int(0, i64t));
+    if (R.is_err[bool, str](res_in3)) { ret res_in3; }
+    val res_in4: R.Result[bool, str] = builder.phi_add_incoming(?b, acc_phi, b_step, acc_next);
+    if (R.is_err[bool, str](res_in4)) { ret res_in4; }
+
+    # dispatch chain: acc == k -> call test k; falling off the end is out-of-range
+    k = 0;
+    for (k < count) {
+        builder.set_block(?b, dblocks[k]);
+        val res_eq: R.Result[value.Value, str] = builder.emit_cmp_eq(?b, acc_phi, value.const_int(k::u64, i64t));
+        if (R.is_err[value.Value, str](res_eq)) { ret R.err[bool, str](R.unwrap_err[value.Value, str](res_eq)); }
+        var miss: id.BlockId = b_bad;
+        if (k + 1 < count) { miss = dblocks[k + 1]; }
+        val res_cbrk: R.Result[bool, str] = builder.emit_cbr(?b, R.unwrap_ok[value.Value, str](res_eq), cblocks[k], miss);
+        if (R.is_err[bool, str](res_cbrk)) { ret res_cbrk; }
+
+        builder.set_block(?b, cblocks[k]);
+        val res_call: R.Result[value.Value, str] = builder.emit_call(?b, callees[k], nil, 0, i32t);
+        if (R.is_err[value.Value, str](res_call)) { ret R.err[bool, str](R.unwrap_err[value.Value, str](res_call)); }
+        val res_r64: R.Result[value.Value, str] = builder.emit_sext(?b, R.unwrap_ok[value.Value, str](res_call), i64t);
+        if (R.is_err[value.Value, str](res_r64)) { ret R.err[bool, str](R.unwrap_err[value.Value, str](res_r64)); }
+        val res_retk: R.Result[bool, str] = builder.emit_ret(?b, R.unwrap_ok[value.Value, str](res_r64));
+        if (R.is_err[bool, str](res_retk)) { ret res_retk; }
+        k = k + 1;
+    }
+
+    ret R.ok[bool, str](true);
 }
 
 # append a Function with the given linkage to the module and register it in the

--- a/src/lang/readout.mach
+++ b/src/lang/readout.mach
@@ -1,0 +1,326 @@
+# build-progress readout - the timed phase roll-up behind `mach build -v`/`-vv`.
+#
+# A single Readout, attached to the Session for the span of one build, collects
+# the seven compile phases (load, resolve, sema, lower, optimize, codegen, link)
+# as the front-end (driver) and back-end (cmd.build) walk the module graph. Each
+# phase is bracketed by `phase_begin`/`phase_end`; each module or file inside a
+# phase is timed with `item_begin`/`item`. At `-v` only the per-phase roll-up
+# line prints; at `-vv` every item prints under its phase with a `(slow)` marker
+# on the slowest. `summary` closes a successful build with one recap line. All
+# output is fixed-width ASCII on stderr, multiplatform: timing comes from
+# `chrono.monotonic` and durations render through `chrono.format_duration`, with
+# columns aligned by the `{:<N}`/`{:N}` format spec. A nil Readout (level 0, the
+# default) makes every call a no-op, so a plain build stays silent.
+
+use std.print;
+use std.types.bool.bool;
+use std.types.bool.false;
+use std.types.bool.true;
+use std.types.size.usize;
+use std.types.string.str;
+
+use A: std.allocator;
+use R: std.types.result;
+use ctime: std.chrono.time;
+use cdur:  std.chrono.duration;
+
+# phase identifiers, indexing the Readout's fixed phase table in emit order
+pub val PH_LOAD:     u8 = 0;  # read + lex + parse each module's source
+pub val PH_RESOLVE:  u8 = 1;  # name resolution per module
+pub val PH_SEMA:     u8 = 2;  # type checking per module
+pub val PH_LOWER:    u8 = 3;  # AST -> SSA IR per module
+pub val PH_OPTIMIZE: u8 = 4;  # the optimization pipeline per module
+pub val PH_CODEGEN:  u8 = 5;  # IR -> machine code per module
+pub val PH_LINK:     u8 = 6;  # link / emit the final artifact
+
+# number of phases (the fixed phase-table length)
+val PHASE_COUNT: u32 = 7;
+
+# verbosity levels
+pub val LEVEL_PHASES: u8 = 1;  # -v:  per-phase roll-up + summary
+pub val LEVEL_ITEMS:  u8 = 2;  # -vv: per-item detail under each phase
+
+# capacity (incl. terminator) of a rendered duration; 24 holds any i64 duration
+val DUR_CAP: usize = 24;
+
+# one timed item within a phase - a module or file and how long it took
+# ---
+# name: the item's display name (an interned FQN or file path, borrowed)
+# d:    the item's elapsed time
+rec Item {
+    name: str;
+    d:    cdur.Duration;
+}
+
+# a single phase's accumulator
+# ---
+# items:   the per-item array, grown on demand (only populated at -vv)
+# len:     number of populated items
+# cap:     allocated length of `items`
+# started: the phase's start instant, set by `phase_begin`
+rec Phase {
+    items:   *Item;
+    len:     u32;
+    cap:     u32;
+    started: ctime.Time;
+}
+
+# the build-wide readout state
+# ---
+# level:  verbosity (LEVEL_PHASES or LEVEL_ITEMS); never 0 for a live Readout
+# alloc:  allocator backing the per-phase item arrays
+# start:  the build's start instant, for the summary's total duration
+# phases: the per-phase accumulators, indexed by the PH_* ids
+pub rec Readout {
+    level:  u8;
+    alloc:  *A.Allocator;
+    start:  ctime.Time;
+    phases: [PHASE_COUNT]Phase;
+}
+
+# initialize a Readout for a build at verbosity `level`
+#
+# `level` is 1 (-v) or 2 (-vv); a plain build never constructs a Readout (the
+# Session simply holds a nil pointer). The build start instant is captured here.
+# ---
+# ro:    the Readout to initialize
+# alloc: allocator backing the per-phase item arrays
+# level: verbosity (LEVEL_PHASES or LEVEL_ITEMS)
+pub fun init(ro: *Readout, alloc: *A.Allocator, level: u8) {
+    ro.level = level;
+    ro.alloc = alloc;
+    ro.start = ctime.monotonic();
+    var i: u32 = 0;
+    for (i < PHASE_COUNT) {
+        val p: *Phase = ?ro.phases[i];
+        p.items = nil;
+        p.len   = 0;
+        p.cap   = 0;
+        i = i + 1;
+    }
+}
+
+# release any per-phase item arrays still held
+#
+# `phase_end` frees each phase's array as it renders, so this only reclaims
+# phases that were begun but never ended (an aborted build).
+# ---
+# ro: the Readout to tear down
+pub fun dnit(ro: *Readout) {
+    if (ro == nil) { ret; }
+    var i: u32 = 0;
+    for (i < PHASE_COUNT) {
+        free_items(ro, ?ro.phases[i]);
+        i = i + 1;
+    }
+}
+
+# mark the start of phase `ph`
+# ---
+# ro: the Readout, or nil to no-op
+# ph: the phase id (a PH_* constant)
+pub fun phase_begin(ro: *Readout, ph: u8) {
+    if (ro == nil) { ret; }
+    val p: *Phase = ?ro.phases[ph];
+    p.len     = 0;
+    p.started = ctime.monotonic();
+}
+
+# capture an item's start instant
+#
+# Returns the monotonic clock only at -vv, where per-item durations are shown;
+# at -v (or with a nil Readout) it returns the zero instant and `item` ignores
+# it, so item-level timing adds no overhead to a -v build.
+# ---
+# ro:  the Readout, or nil
+# ret: the item's start instant, or the zero instant when item timing is off
+pub fun item_begin(ro: *Readout) ctime.Time {
+    if (ro == nil || ro.level < LEVEL_ITEMS) { ret ctime.Time{sec: 0, nsec: 0}; }
+    ret ctime.monotonic();
+}
+
+# record one completed item in phase `ph`
+#
+# Only retained at -vv (the per-item display); a no-op otherwise. `name` is
+# borrowed and must stay valid until `phase_end` renders the phase (interned
+# FQNs and source paths both outlive the build).
+# ---
+# ro:    the Readout, or nil
+# ph:    the phase id (a PH_* constant)
+# name:  the item's display name (borrowed)
+# start: the instant returned by the matching `item_begin`
+pub fun item(ro: *Readout, ph: u8, name: str, start: ctime.Time) {
+    if (ro == nil || ro.level < LEVEL_ITEMS) { ret; }
+    val d: cdur.Duration = ctime.time_sub(ctime.monotonic(), start);
+    val p: *Phase = ?ro.phases[ph];
+    if (!ensure_item_cap(ro, p)) { ret; }
+    p.items[p.len].name = name;
+    p.items[p.len].d    = d;
+    p.len = p.len + 1;
+}
+
+# close phase `ph` and render it
+#
+# Prints the roll-up line `<phase>  <count> <noun>  <dur>` (`noun_one` when
+# `count` is 1, else `noun_many`), and at -vv every recorded item beneath it
+# with the slowest flagged `(slow)`. The phase's wall-clock duration is the
+# span since `phase_begin`. Frees the phase's item array.
+# ---
+# ro:       the Readout, or nil to no-op
+# ph:       the phase id (a PH_* constant)
+# count:    the item count for the roll-up (e.g. the module count)
+# noun_one: the singular unit noun (e.g. "module")
+# noun_many:the plural unit noun (e.g. "modules")
+pub fun phase_end(ro: *Readout, ph: u8, count: u32, noun_one: str, noun_many: str) {
+    if (ro == nil) { ret; }
+    val p: *Phase = ?ro.phases[ph];
+    val elapsed: cdur.Duration = ctime.time_sub(ctime.monotonic(), p.started);
+
+    var dbuf: [DUR_CAP]u8;
+    val dstr: str = cdur.format_duration(elapsed, ?dbuf[0], DUR_CAP);
+    var noun: str = noun_many;
+    if (count == 1) { noun = noun_one; }
+    print.eprintf("{:<9} {:3} {:<8} {:7}\n", phase_label(ph), count::i64, noun, dstr);
+
+    if (ro.level >= LEVEL_ITEMS) { render_items(p); }
+    free_items(ro, p);
+}
+
+# render a successful build's closing recap line
+#
+# `built <out>  <N> modules  [<size> <unit>  ]in <total>` - the size segment is
+# omitted when `has_size` is false (a library / object-only build has no single
+# binary). The total duration spans from `init`.
+# ---
+# ro:        the Readout, or nil to no-op
+# out:       the produced artifact's path (borrowed)
+# modules:   the module count
+# size:      the artifact size magnitude in `unit`
+# unit:      the size unit ("B"/"KB"/"MB")
+# has_size:  whether to print the size segment
+pub fun summary(ro: *Readout, out: str, modules: u32, size: i64, unit: str, has_size: bool) {
+    if (ro == nil) { ret; }
+    val total: cdur.Duration = ctime.time_sub(ctime.monotonic(), ro.start);
+    var dbuf: [DUR_CAP]u8;
+    val dstr: str = cdur.format_duration(total, ?dbuf[0], DUR_CAP);
+    if (has_size) {
+        print.eprintf("built {}  {} modules  {} {}  in {}\n", out, modules::i64, size, unit, dstr);
+    }
+    or {
+        print.eprintf("built {}  {} modules  in {}\n", out, modules::i64, dstr);
+    }
+}
+
+# split a byte count into a magnitude + unit for the summary
+#
+# Integer-only ASCII: bytes under 1 KiB stay bytes, under 1 MiB round to KB,
+# else round to MB. Used only by the build summary (no cross-area formatter is
+# warranted).
+# ---
+# bytes: the raw byte count
+# unit:  receives the chosen unit string ("B"/"KB"/"MB")
+# ret:   the magnitude in `unit`
+pub fun size_split(bytes: usize, unit: *str) i64 {
+    val b: i64 = bytes::i64;
+    if (b < 1024) {
+        @unit = "B";
+        ret b;
+    }
+    if (b < 1024 * 1024) {
+        @unit = "KB";
+        ret (b + 512) / 1024;
+    }
+    @unit = "MB";
+    ret (b + 512 * 1024) / (1024 * 1024);
+}
+
+# the fixed display label for phase `ph`
+# ---
+# ph:  the phase id (a PH_* constant)
+# ret: the phase's label
+fun phase_label(ph: u8) str {
+    if (ph == PH_LOAD)     { ret "load"; }
+    if (ph == PH_RESOLVE)  { ret "resolve"; }
+    if (ph == PH_SEMA)     { ret "sema"; }
+    if (ph == PH_LOWER)    { ret "lower"; }
+    if (ph == PH_OPTIMIZE) { ret "optimize"; }
+    if (ph == PH_CODEGEN)  { ret "codegen"; }
+    ret "link";
+}
+
+# print every recorded item of phase `p`, flagging the slowest with `(slow)`
+#
+# The slowest is marked only when the phase holds at least two items with a
+# positive duration, so a single-item phase carries no marker.
+# ---
+# p: the phase whose items to render
+fun render_items(p: *Phase) {
+    val slow: i64 = slowest_index(p);
+    var i: u32 = 0;
+    for (i < p.len) {
+        var dbuf: [DUR_CAP]u8;
+        val dstr: str = cdur.format_duration(p.items[i].d, ?dbuf[0], DUR_CAP);
+        if (i::i64 == slow) {
+            print.eprintf("  {:<32} {:7}  (slow)\n", p.items[i].name, dstr);
+        }
+        or {
+            print.eprintf("  {:<32} {:7}\n", p.items[i].name, dstr);
+        }
+        i = i + 1;
+    }
+}
+
+# the index of the slowest item in `p`, or -1 when no item should be flagged
+#
+# Returns -1 for a phase with fewer than two items, so a lone item is never
+# flagged as the slowest.
+# ---
+# p:   the phase to scan
+# ret: the slowest item's index, or -1
+fun slowest_index(p: *Phase) i64 {
+    if (p.len < 2) { ret -1; }
+    var best: u32 = 0;
+    var i: u32 = 1;
+    for (i < p.len) {
+        if (p.items[i].d > p.items[best].d) { best = i; }
+        i = i + 1;
+    }
+    if (p.items[best].d <= 0) { ret -1; }
+    ret best::i64;
+}
+
+# ensure phase `p` has room for one more item, doubling its array when full
+# ---
+# ro: the Readout (for its allocator)
+# p:  the phase whose item array to grow
+# ret: false on allocation failure
+fun ensure_item_cap(ro: *Readout, p: *Phase) bool {
+    if (p.len < p.cap) { ret true; }
+    var new_cap: u32 = p.cap * 2;
+    if (new_cap < 16) { new_cap = 16; }
+    if (p.items == nil) {
+        val r: R.Result[*Item, str] = A.allocate[Item](ro.alloc, new_cap::usize);
+        if (R.is_err[*Item, str](r)) { ret false; }
+        p.items = R.unwrap_ok[*Item, str](r);
+    }
+    or {
+        val r: R.Result[*Item, str] = A.reallocate[Item](ro.alloc, p.items, p.cap::usize, new_cap::usize);
+        if (R.is_err[*Item, str](r)) { ret false; }
+        p.items = R.unwrap_ok[*Item, str](r);
+    }
+    p.cap = new_cap;
+    ret true;
+}
+
+# release phase `p`'s item array
+# ---
+# ro: the Readout (for its allocator)
+# p:  the phase whose item array to free
+fun free_items(ro: *Readout, p: *Phase) {
+    if (p.items != nil && p.cap > 0) {
+        A.deallocate[Item](ro.alloc, p.items, p.cap::usize);
+    }
+    p.items = nil;
+    p.len   = 0;
+    p.cap   = 0;
+}

--- a/src/lang/session.mach
+++ b/src/lang/session.mach
@@ -22,6 +22,7 @@ use mach.lang.fe.ast;
 use mach.lang.intern;
 use mach.lang.module;
 use mach.lang.query;
+use mach.lang.readout;
 use mach.lang.source;
 use mach.lang.target;
 use mach.lang.type;
@@ -118,9 +119,10 @@ pub rec Session {
     opt_explicit: bool;
     opt_release:  bool;
 
-    # CLI `--verbose` intent, set before the build so the front-end load walk
-    # emits a per-module progress line to stderr. off leaves the load silent.
-    verbose: bool;
+    # the build-progress readout (`mach build -v`/`-vv`), attached before the
+    # build so the front-end load/resolve/sema phases record into the same
+    # accumulator the back-end closes. nil leaves the build silent.
+    readout: *readout.Readout;
 
     # CLI `--pie` intent: emit a position-independent (ET_DYN) executable for ASLR
     # instead of the default fixed-address one. opt-in; the linker ORs it with the
@@ -166,7 +168,7 @@ pub fun init(alloc: *A.Allocator) R.Result[Session, str] {
     s.registry         = target.registry_init();
     s.opt_explicit     = false;
     s.opt_release      = false;
-    s.verbose          = false;
+    s.readout          = nil;
     s.pie              = false;
 
     val opt_types: O.Option[str] = type.init(?s.types, alloc);


### PR DESCRIPTION
Sweep dev → main for v2.12.0 — the terminal output & test-harness overhaul (epic #1788: dispatcher test build, live parallel readout), framed diagnostics (#1777), per-phase build readout (#1775), static-PIE self-relocation activation (#1727), the int darwin runner fix (#1787), and the `<os>-<isa>` target-name normalization. **Contains breaking CLI changes** — `--verbose` removal, `--runner` contract, `tests` template `{name}` — detailed in the changelog's Breaking section.
