### PR TITLE
fix(driver): dump --emit-ir from the final post-pipeline IR

### DIFF
--- a/doc/cli.md
+++ b/doc/cli.md
@@ -51,6 +51,11 @@ A verbosity flag (`-v`/`-vv`) and `--quiet` together is a parse error.
 | `--no-emit-ir`   | —                | force per-module IR emission off, overriding the profile's `emit_ir` |
 | `--verify-ir`    | —                | run the IR verifier after each optimisation pass |
 
+> Under `mach test`, the entry module's `--emit-ir` dump shows the neutralized
+> project `main` the test dispatcher substitutes for the real entry (the final IR
+> that build is made from), so it differs from the same module's `mach build`
+> dump. That divergence is expected.
+
 > `mach dep` and `mach init` do not use the shared config parser; they read only
 > their own flags listed below.
 

--- a/doc/cli.md
+++ b/doc/cli.md
@@ -46,7 +46,7 @@ A verbosity flag (`-v`/`-vv`) and `--quiet` together is a parse error.
 | `-o <path>`      | path             | override the artifact path, rooted at the project root (build/run/test) |
 | `--all-targets`  | —                | build every declared `[target.*]`, not just the default |
 | `--emit-asm`     | —                | emit per-module assembly text (`.s`); forces the selected profile's `emit_asm` on |
-| `--emit-ir`      | —                | emit per-module SSA IR text (`.ir`); forces the selected profile's `emit_ir` on |
+| `--emit-ir`      | —                | emit per-module SSA IR text (`.ir`) — the final post-pipeline IR the object is built from, so it varies with `-O`; forces the selected profile's `emit_ir` on |
 | `--no-emit-asm`  | —                | force per-module assembly emission off, overriding the profile's `emit_asm` |
 | `--no-emit-ir`   | —                | force per-module IR emission off, overriding the profile's `emit_ir` |
 | `--verify-ir`    | —                | run the IR verifier after each optimisation pass |

--- a/doc/manifest.md
+++ b/doc/manifest.md
@@ -57,7 +57,7 @@ opt = 0                    # 0 (no optimization) | 1 (standard) | 2 (aggressive)
 
 [profile.release]
 opt      = 2
-emit_ir  = true            # emit per-module IR for this profile (default false)
+emit_ir  = true            # emit per-module post-pipeline IR for this profile (default false)
 emit_asm = false           # emit per-module assembly for this profile (default false)
 
 [deps.mach-std]            # a dependency: exactly one of git|path, plus ref for git
@@ -143,7 +143,7 @@ toggles live here because they are variant concerns.
 | Key        | Type    | Default | Meaning |
 |------------|---------|---------|---------|
 | `opt`      | integer | — (debug) | Optimization level: `0` (no optimization beyond the always-on pipeline), `1` (standard), or `2` (aggressive). `1` and `2` currently select the same pass set; `2` is where future loop/vectorization work lands. Any other integer — or a non-integer — is a manifest error (`profile '<name>': opt must be 0, 1, or 2`). |
-| `emit_ir`  | bool    | `false` | Write per-module IR dumps under the `ir` template for this profile. |
+| `emit_ir`  | bool    | `false` | Write per-module SSA IR dumps under the `ir` template for this profile — the final post-pipeline IR the object is built from, so it varies with `opt`. |
 | `emit_asm` | bool    | `false` | Write per-module assembly dumps under the `asm` template for this profile. |
 
 A CLI `-O0` / `-O1` / `-O2` / `--release` flag overrides the selected profile's

--- a/src/cli/cmd/build.mach
+++ b/src/cli/cmd/build.mach
@@ -182,12 +182,12 @@ fun compile_modules(p: *driver.Project, level: u8, test_mode: bool, verify_ir: b
     # do not lower or codegen a semantically broken module graph.
     if (diagnostic.has_errors(?p.s.diags)) { ret R.ok[bool, str](true); }
 
-    # lower every module to IR (rendering the textual `.ir` straight after each
-    # lowering, before optimization), then optimize, then - in test mode -
-    # neutralize the project `main` (the runner supplies the program entry) before
-    # any module is codegen'd. the three passes are timed as distinct readout
-    # phases; splitting lower from optimize is purely structural and leaves the
-    # produced objects byte-identical.
+    # lower every module to IR, then optimize, then - in test mode - neutralize
+    # the project `main` (the runner supplies the program entry) before any module
+    # is codegen'd. the `.ir` and `.s` debug artifacts are both rendered in the
+    # codegen pass, from the final post-pipeline IR the object is built from. the
+    # three passes are timed as distinct readout phases; splitting lower from
+    # optimize is purely structural and leaves the produced objects byte-identical.
     readout.phase_begin(p.s.readout, readout.PH_LOWER);
     var i: u32 = 0;
     for (i < p.topo_len) {
@@ -202,13 +202,6 @@ fun compile_modules(p: *driver.Project, level: u8, test_mode: bool, verify_ir: b
         irs[mid::u32]      = R.unwrap_ok[ir.Module, str](res_lower);
         ir_ready[mid::u32] = true;
 
-        # textual SSA IR, rendered straight after lowering.
-        if (ea.want_ir) {
-            val res_emit: R.Result[bool, str] = emit_ir(p, ea, m.fqn, ?irs[mid::u32]);
-            if (R.is_err[bool, str](res_emit)) {
-                ret R.err[bool, str](R.unwrap_err[bool, str](res_emit));
-            }
-        }
         readout.item(p.s.readout, readout.PH_LOWER, fqn_name(p, m.fqn), t_item);
         i = i + 1;
     }
@@ -245,6 +238,15 @@ fun compile_modules(p: *driver.Project, level: u8, test_mode: bool, verify_ir: b
 
         val t_item: ctime.Time = readout.item_begin(p.s.readout);
 
+        # textual SSA IR, rendered from the final post-pipeline module the object
+        # is built from (matching the `.s` artifact rendered during codegen below).
+        if (ea.want_ir) {
+            val res_emit: R.Result[bool, str] = emit_ir(p, ea, m.fqn, ?irs[mid::u32]);
+            if (R.is_err[bool, str](res_emit)) {
+                ret R.err[bool, str](R.unwrap_err[bool, str](res_emit));
+            }
+        }
+
         # codegen, optionally rendering the resolved MIR to a `.s` artifact.
         var asm_file: filesystem.File;
         var asm_w:    writer.Writer;
@@ -277,13 +279,15 @@ fun compile_modules(p: *driver.Project, level: u8, test_mode: bool, verify_ir: b
     ret R.ok[bool, str](true);
 }
 
-# render one module's textual SSA IR to its `.ir` artifact, straight after
-# lowering
+# render one module's textual SSA IR to its `.ir` artifact
+#
+# Called in the codegen pass, so `m` is the final post-pipeline IR the object is
+# built from - the same module codegen consumes for the `.s` artifact.
 # ---
 # p:   the project (for its interner)
 # ea:  the emission settings (for `ir_base`)
 # fqn: the module's interned fully-qualified name
-# m:   the lowered IR module to render
+# m:   the IR module to render
 # ret: ok(true) on success, or err with the failure message
 fun emit_ir(p: *driver.Project, ea: *EmitArtifacts, fqn: intern.StrId, m: *ir.Module) R.Result[bool, str] {
     val opt_fqn: O.Option[str] = intern.lookup(?p.s.interner, fqn);

--- a/src/cli/config.mach
+++ b/src/cli/config.mach
@@ -39,7 +39,9 @@ pub val COLOR_NEVER:  ColorMode = 2;  # force-disable color
 # emit_asm:    --emit-asm was passed; emit per-module human-readable assembly
 #              text (`.s`) alongside each object, for debugging / transparency
 # emit_ir:     --emit-ir was passed; emit per-module human-readable SSA IR text
-#              (`.ir`) alongside each object, for debugging / transparency
+#              (`.ir`) alongside each object, for debugging / transparency - the
+#              final post-pipeline IR the object is built from, so it varies with
+#              the optimization level
 # no_emit_asm: --no-emit-asm was passed; force ASM emission off, overriding a v2
 #              profile's `emit_asm` default
 # no_emit_ir:  --no-emit-ir was passed; force IR emission off, overriding a v2


### PR DESCRIPTION
## What

`--emit-ir` dumped the SSA IR *before* the optimization pipeline ran: `emit_ir`
was called in the lower loop of `compile_modules`, ahead of `pipeline.run`, so the
`.ir` text was the naive lowering rather than the IR the objects are built from. It
never varied with the optimization level and diverged from `--emit-asm`, which is
rendered during codegen and reflects the final program.

## Fix

Move the `emit_ir` call out of the lower loop and into the codegen loop, beside the
`.s` render, so both debug artifacts are produced from the same final post-pipeline
module that codegen consumes (this also picks up test-mode `main` neutralization,
exactly matching what the binary is made from). No new flags.

Doc/comment updates: `doc/cli.md`, `src/cli/config.mach`, and the in-file comments
now state that `.ir` is the final post-pipeline IR and varies with `-O`.

## Verification (manual)

Built the compiler from source in the worktree; self-host **byte-identical fixpoint holds**.

A specimen with a promotable local (`var acc` stored/reloaded), a repeated
subexpression, and a dead local, built with the freshly-built compiler:

**`-O0` (debug) `main.ir`** — mem2reg + dce reflected; no `alloca`/`store`/`load`, no dead `+7`:
```
fn @_M4spec4mainN7compute(%p0: i64, %p1: i64): i64 {
  block bb0:
    %7  = add i64 %p0, %p1
    %12 = mul i64 %p0, %p1
    %13 = add i64 %7, %12
    %18 = mul i64 %p0, %p1
    %19 = add i64 %13, %18
    ret %19
}
```

**`--release` `main.ir`** — differs: the repeated `mul` is CSE'd (`%19 = add %13, %12`)
and `compute` is inlined into `main`. `diff` of debug vs release is non-empty.

For contrast, the **released host compiler (2.12.0, pre-fix)** emits the raw lowering
(full `alloca`/`store`/`load`, the dead `+7`) and its debug and release `.ir` are
**byte-identical** — the bug this PR fixes.

Also confirmed: a default build (no `--emit-ir`) and `--emit-ir --no-emit-ir` both
emit zero `.ir` files (criterion 3 unchanged), and the release binary runs correctly.

### Why no int/ regression case

The `int/` harness produces observables from the built binary (`exec` stdout,
structural header `field`, `flat-loader` exit) and has no producer for compiler
debug-artifact text; an `.ir` golden would be brittle against unrelated
codegen/mangling changes. The change is verified manually above instead.

Closes #1802
