### PR TITLE
feat(codegen): regalloc copy hygiene — dead-def sweep + allocation hints

### DIFF
--- a/src/lang/be/codegen/regalloc.mach
+++ b/src/lang/be/codegen/regalloc.mach
@@ -7,25 +7,43 @@
 # job is purely physical. There is no `isa.InstBuf` instruction model here; the
 # allocator consumes and mutates MIR directly.
 #
-# The algorithm is a standard linear scan:
-#   1. blocks are reordered into reverse-postorder so the flat instruction stream
+# The algorithm is an evolved linear scan (hint-biased coloring; live-range
+# splitting is future work):
+#   1. DEAD-DEF SWEEP: before any position-dependent structure is built, every
+#      register move whose destination vreg is never read is deleted (retallied to
+#      a fixpoint, since dropping one copy can make an earlier copy into its source
+#      dead). This runs on the raw blocks, so the flat stream and ranges below are
+#      built once on already-clean instruction lists;
+#   2. blocks are reordered into reverse-postorder so the flat instruction stream
 #      reads in a topological order;
-#   2. one merged live range per vreg is built over that stream from def/use of
-#      `MIR_OP_VREG` operands (including a `MIR_OP_MEM` base vreg), then extended
-#      by per-block live-in/live-out from a backward dataflow fixpoint so values
-#      live across a loop back edge are covered;
-#   3. `MIR_OP_PREG` operands (the ABI param / argument / return pre-coloring
+#   3. one merged live range per vreg is built over that stream from def/use of
+#      `MIR_OP_VREG` operands (including a `MIR_OP_MEM` base vreg), then extended by
+#      per-block live-in/live-out from a backward dataflow fixpoint. THE RANGE MODEL
+#      is a single contiguous [start, end] interval bounding register occupancy:
+#      start = min(operand touches, live-IN block first positions), end =
+#      max(operand touches, live-OUT block last positions). The two bounds extend
+#      independently (see `extend_range_for_block`) - a value live-in but dying
+#      mid-block adds no phantom tail, a value born mid-block and flowing out adds
+#      no phantom head - while a loop-carried value (live-in AND live-out) still
+#      spans its blocks;
+#   4. `MIR_OP_PREG` operands (the ABI param / argument / return pre-coloring
 #      `lower_ir` emitted) are FIXED - their physical register is reserved for
 #      the instruction that names it, and incoming param-register lifetimes are
 #      held busy from entry until the `MOV vreg <- preg` that captures them;
-#   4. ranges are assigned in start order, call-crossing ranges preferring
-#      callee-saved registers (so the value survives a call without a save) and
-#      others preferring caller-saved; on pressure the lowest-density victim is
-#      spilled to a fresh `SLOT_SPILL` frame slot;
-#   5. around each `MIR_CALL` - the caller-saved clobber barrier (see its MIR
+#   5. COPY HINTS: each vreg first defined by a plain register copy records its
+#      source register (step done before the scan);
+#   6. ranges are assigned in start order (ties broken by ascending end, so a copy
+#      source dying at the copy colors before its destination). Each range prefers
+#      its copy-source register when the hint can be honored (`pick_hint`), so the
+#      copy collapses to a self-move dropped at rewrite; otherwise a call-crossing
+#      range prefers callee-saved and others caller-saved. On pressure the
+#      lowest-density victim is spilled to a fresh `SLOT_SPILL` frame slot;
+#   7. around each `MIR_CALL` - the caller-saved clobber barrier (see its MIR
 #      definition) - any live vreg whose assigned register is caller-saved (or
 #      any FP register) is spilled and reloaded;
-#   6. a final pass rewrites every `MIR_OP_VREG` to its assigned `MIR_OP_PREG`;
+#   8. a final pass rewrites every `MIR_OP_VREG` to its assigned `MIR_OP_PREG` and
+#      drops any full-width register move whose operands rewrote to the same
+#      physical register (a coalesced copy);
 #      a `MIR_OP_MEM` base that is a value-pointer vreg becomes a physical-register
 #      base (`preg` set, `vreg` cleared to MIR_VREG_NIL) while a frame-slot-owning
 #      MEM base keeps its slot-key vreg id (the encoder resolves it to `[rbp +
@@ -1338,9 +1356,7 @@ fun extend_liveness(ctx: *AllocCtx) R.Result[bool, str] {
         var v: u32 = 0;
         for (v < nv) {
             val idx: usize = base + v::usize;
-            val lr: *LiveRange = ?ctx.ranges[v];
-            if (live_in[idx] && span.start >= 0 && span.start < lr.start) { lr.start = span.start; }
-            if (live_out[idx] && span.end > lr.end_pos)                   { lr.end_pos = span.end; }
+            extend_range_for_block(?ctx.ranges[v], span, live_in[idx], live_out[idx]);
             v = v + 1;
         }
         bi = bi + 1;
@@ -1351,6 +1367,24 @@ fun extend_liveness(ctx: *AllocCtx) R.Result[bool, str] {
     A.deallocate[bool](ctx.alloc, live_in, total);
     A.deallocate[bool](ctx.alloc, live_out, total);
     ret R.ok[bool, str](true);
+}
+
+# extend one range's occupancy bounds over one block, per the unified
+# range model. A merged range is a single contiguous [start, end] interval bounding
+# where the value occupies its register:
+#   start = min(operand touches, live-in block first positions)
+#   end   = max(operand touches, live-out block last positions)
+# So a live-IN vreg occupies its register from block entry - pull start back to the
+# block's first position - and a live-OUT vreg holds it through the terminator -
+# push end forward to the block's last position. The two are INDEPENDENT: a value
+# live-in but not live-out keeps the in-block last-use end `build_ranges` recorded
+# (no phantom tail to the block end), and a value live-out but not live-in keeps its
+# in-block def start (no phantom head). An empty block (span.start < 0) extends
+# nothing. A loop-carried value is live-in AND live-out, so both bounds extend and
+# the loop stays covered.
+fun extend_range_for_block(lr: *LiveRange, span: BlockSpan, live_in: bool, live_out: bool) {
+    if (live_in && span.start >= 0 && span.start < lr.start) { lr.start = span.start; }
+    if (live_out && span.end > lr.end_pos)                   { lr.end_pos = span.end; }
 }
 
 # precompute each block's [first, last] flat-stream position in
@@ -1986,14 +2020,9 @@ fun pick_hint(ctx: *AllocCtx, v: u32, lr: *LiveRange) i32 {
             ctx.gp_busy[idx] = true;
             ret rid;
         }
-        # busy: honor only by transferring the register from the copy source when
-        # that source vreg dies exactly at the copy (its last use is the read this
-        # move performs), so source and destination provably never coexist even
-        # though the destination's extended range overlaps the source. remove_active
-        # drops the source from the active set while its busy flag stays set, so the
-        # register passes intact to the destination.
-        if (source_dies_at_copy(ctx, h)) {
-            remove_active(ctx, h.src_vreg);
+        # busy: honor only by transferring the register from the copy source.
+        if (can_transfer(ctx, lr, h)) {
+            transfer_source_reg(ctx, h.src_vreg, rid::u32);
             ret rid;
         }
         ret -1;
@@ -2008,22 +2037,62 @@ fun pick_hint(ctx: *AllocCtx, v: u32, lr: *LiveRange) i32 {
             ctx.fp_busy[idx] = true;
             ret rid;
         }
-        if (source_dies_at_copy(ctx, h)) {
-            remove_active(ctx, h.src_vreg);
+        if (can_transfer(ctx, lr, h)) {
+            transfer_source_reg(ctx, h.src_vreg, rid::u32);
             ret rid;
         }
         ret -1;
     }
 }
 
-# true when a copy hint's source is a vreg whose last use is the copy
-# itself - the register it currently holds may then be handed to the copy's
-# destination, since the source is read at the same instruction it dies at and can
-# never coexist with the destination the copy defines.
-fun source_dies_at_copy(ctx: *AllocCtx, h: *CopyHint) bool {
+# true when the copy source's register may be transferred to the copy
+# destination `lr`, freeing the source's busy register for the destination.
+#
+# TWO conditions, both required:
+#   - the source vreg dies exactly at the copy (`end_pos == copy_pos`): its last
+#     use is the read this move performs, so it holds no value past the copy.
+#   - the destination is BORN at the copy (`lr.start == copy_pos`): its range has
+#     no position before the copy. This is the load-bearing guard. A destination
+#     that is live BEFORE the copy - a loop-carried phi target the liveness pass
+#     extended back to its block start, read between the source's def and the copy
+#     (e.g. `next = i + 1 ; arr[i] = x ; i = next`) - genuinely coexists with the
+#     source over that prefix: handing it the source's register lets `next`'s
+#     write clobber `i` before `arr[i]` reads it. Requiring the destination to be
+#     born at the copy admits exactly the param-homing / return / diamond-merge
+#     shapes, where the destination first appears at the copy and the two never
+#     overlap.
+fun can_transfer(ctx: *AllocCtx, lr: *LiveRange, h: *CopyHint) bool {
     if (h.src_vreg == mir.MIR_VREG_NIL) { ret false; }
     if (h.copy_pos < 0)                 { ret false; }
-    ret ctx.ranges[h.src_vreg].end_pos == h.copy_pos;
+    if (ctx.ranges[h.src_vreg].end_pos != h.copy_pos) { ret false; }
+    if (lr.start != h.copy_pos)                       { ret false; }
+    ret true;
+}
+
+# hand the copy source's physical register to the copy destination by
+# dropping the source from the active set while its busy flag stays set, so the
+# register passes intact. Asserts the transfer's cross-pass precondition: the
+# source must still be active and own `rid`. The scan's end tie-break colors the
+# source before the destination and the liveness extension is only-backward, so a
+# source dying at the copy is always still active and holds its register when the
+# destination is colored; a future sort / extension change that breaks that
+# coupling would hand a live value's register to the destination, so it fails
+# loudly here rather than miscompiling silently.
+fun transfer_source_reg(ctx: *AllocCtx, src: u32, rid: u32) {
+    if (!vreg_in_active(ctx, src) || ctx.f.vregs[src].assigned != rid) {
+        panic("regalloc: copy-hint transfer source is not the live owner of its register\n");
+    }
+    remove_active(ctx, src);
+}
+
+# true when vreg `v` is in the active set.
+fun vreg_in_active(ctx: *AllocCtx, v: u32) bool {
+    var i: u32 = 0;
+    for (i < ctx.active_count) {
+        if (ctx.active[i] == v) { ret true; }
+        i = i + 1;
+    }
+    ret false;
 }
 
 # choose a free general-purpose register, preferring caller-saved for a
@@ -3121,6 +3190,149 @@ test "mach.lang.be.codegen.regalloc.seed_reserved:aarch64_reserved_and_fp_bank" 
     # registers the float-op encoder routes spilled operands through (count 30, ids
     # 0..29).
     if (bank_count(?t, fp_class_index(?t)) != 30) { ret 1; }
+
+    ret 0;
+}
+
+# the unified range-model extension is per-bound: live-IN pulls start back to the
+# block's first position, live-OUT pushes end forward to the last, and the two are
+# independent so no phantom head / tail is added. this matrix pins all four cases;
+# the live-in-but-not-live-out row is the tightening that unblocks the return-reg
+# coalescing (it removes the phantom tail that falsely interfered with the precolored
+# return def).
+test "mach.lang.be.codegen.regalloc.extend_range_for_block:in_out_matrix" {
+    var span: BlockSpan;
+    span.start = 100;
+    span.end   = 110;
+
+    # both live-in and live-out: both bounds extend to the block span.
+    var lr1: LiveRange;
+    lr1.start = 105; lr1.end_pos = 106;
+    extend_range_for_block(?lr1, span, true, true);
+    if (lr1.start != 100 || lr1.end_pos != 110) { ret 1; }
+
+    # live-in only: start extends, end keeps the in-block last use (no phantom tail).
+    var lr2: LiveRange;
+    lr2.start = 105; lr2.end_pos = 106;
+    extend_range_for_block(?lr2, span, true, false);
+    if (lr2.start != 100 || lr2.end_pos != 106) { ret 1; }
+
+    # live-out only: end extends, start keeps the in-block def (no phantom head).
+    var lr3: LiveRange;
+    lr3.start = 105; lr3.end_pos = 106;
+    extend_range_for_block(?lr3, span, false, true);
+    if (lr3.start != 105 || lr3.end_pos != 110) { ret 1; }
+
+    # neither: unchanged.
+    var lr4: LiveRange;
+    lr4.start = 105; lr4.end_pos = 106;
+    extend_range_for_block(?lr4, span, false, false);
+    if (lr4.start != 105 || lr4.end_pos != 106) { ret 1; }
+
+    # an empty block (span.start < 0) extends nothing even when live.
+    var empty: BlockSpan;
+    empty.start = -1; empty.end = -1;
+    var lr5: LiveRange;
+    lr5.start = 105; lr5.end_pos = 106;
+    extend_range_for_block(?lr5, empty, true, true);
+    if (lr5.start != 105 || lr5.end_pos != 106) { ret 1; }
+
+    ret 0;
+}
+
+# the copy-hint register transfer is honored only when the source dies exactly at
+# the copy AND the destination is born there. the destination-born clause is the
+# guard against handing a source's register to a loop-carried destination live
+# before the copy (the `next = i + 1 ; arr[i] = x ; i = next` miscompile).
+test "mach.lang.be.codegen.regalloc.can_transfer:destination_born_guard" {
+    var ctx: AllocCtx;
+    var ranges: [4]LiveRange;
+    ctx.ranges = ?ranges[0];
+    # source vreg 1 dies exactly at copy position 10.
+    ranges[1].end_pos = 10;
+
+    var h: CopyHint;
+    h.src_vreg = 1;
+    h.src_preg = -1;
+    h.copy_pos = 10;
+
+    # destination born at the copy (start == copy_pos): the safe homing / return /
+    # diamond shape - transfer allowed.
+    var lr_born: LiveRange;
+    lr_born.start = 10;
+    if (!can_transfer(?ctx, ?lr_born, ?h)) { ret 1; }
+
+    # destination live before the copy (a loop-carried phi target extended back over
+    # its block): transfer must be refused.
+    var lr_live_in: LiveRange;
+    lr_live_in.start = 3;
+    if (can_transfer(?ctx, ?lr_live_in, ?h)) { ret 1; }
+
+    # source does not die at the copy (still live past it): refused.
+    ranges[1].end_pos = 14;
+    if (can_transfer(?ctx, ?lr_born, ?h)) { ret 1; }
+    ranges[1].end_pos = 10;
+
+    # a physical-register-source hint (no vreg to displace): not a transfer.
+    h.src_vreg = mir.MIR_VREG_NIL;
+    h.src_preg = 5;
+    if (can_transfer(?ctx, ?lr_born, ?h)) { ret 1; }
+
+    ret 0;
+}
+
+# the dead-def sweep drops only a plain move whose destination is an unread value
+# vreg: a copy into a physical register (an ABI effect), a still-read vreg, a
+# slot-owning storage vreg, and a width-changing move are all preserved.
+test "mach.lang.be.codegen.regalloc.is_dead_mov:physical_dest_and_read_guards" {
+    var reg: target.TargetRegistry = target.registry_init();
+    if (R.is_err[bool, str](target.register_all(?reg))) { ret 1; }
+    val ts: R.Result[target.Target, str] = target.select(?reg, "x86_64", "linux", "sysv64");
+    if (R.is_err[target.Target, str](ts)) { ret 1; }
+    var t: target.Target = R.unwrap_ok[target.Target, str](ts);
+
+    var f: mir.MirFunction;
+    f.vreg_count = 3;
+    var slot: [3]bool;
+    slot[0] = false; slot[1] = false; slot[2] = true;   # vreg 2 owns a storage slot
+
+    var ctx: AllocCtx;
+    ctx.f = ?f;
+    ctx.vreg_slot_flag = ?slot[0];
+
+    var reads: [3]u32;
+    reads[0] = 0; reads[1] = 1; reads[2] = 0;
+
+    var ops: [2]mir.MirOperand;
+    ops[0] = mir.op_vreg(0);
+    ops[1] = mir.op_vreg(1);
+    var mv: mir.MirInstr;
+    mv.opcode        = mir.MIR_MOV;
+    mv.operands      = ?ops[0];
+    mv.operand_count = 2;
+    mv.width         = 8;
+    mv.src_width     = 8;
+    mv.asm_block     = nil;
+
+    # dst = unread value vreg 0: dead.
+    if (!is_dead_mov(?t, ?ctx, ?mv, ?reads[0], 3)) { ret 1; }
+
+    # dst = vreg 1, read once: not dead.
+    ops[0] = mir.op_vreg(1);
+    if (is_dead_mov(?t, ?ctx, ?mv, ?reads[0], 3)) { ret 1; }
+
+    # dst = vreg 2, unread but slot-owning storage: not dead.
+    ops[0] = mir.op_vreg(2);
+    if (is_dead_mov(?t, ?ctx, ?mv, ?reads[0], 3)) { ret 1; }
+
+    # dst = physical register (precolored, an ABI effect): never dead.
+    ops[0] = mir.op_preg(0);
+    if (is_dead_mov(?t, ?ctx, ?mv, ?reads[0], 3)) { ret 1; }
+
+    # a width-changing move (width != src_width) is not a plain copy: not swept.
+    ops[0] = mir.op_vreg(0);
+    mv.src_width = 4;
+    if (is_dead_mov(?t, ?ctx, ?mv, ?reads[0], 3)) { ret 1; }
 
     ret 0;
 }

--- a/src/lang/be/codegen/regalloc.mach
+++ b/src/lang/be/codegen/regalloc.mach
@@ -112,6 +112,28 @@ rec BlockSpan {
     end:   i64;
 }
 
+# an allocation hint recording the source register a vreg's defining copy reads
+#
+# When a vreg is first defined by a plain register copy (`MOV v <- src`), the scan
+# prefers to color `v` onto `src`'s register so the copy collapses to `mov x, x`
+# and is dropped at rewrite. The two source shapes are mutually exclusive per
+# hint; a copy with an immediate or otherwise unhintable source leaves both fields
+# at their empty sentinels.
+# ---
+# src_vreg: source vreg id for a `MOV v <- v2` copy, else MIR_VREG_NIL
+# src_preg: source composite physical-register id for a `MOV v <- preg` copy, else -1
+# copy_pos: flat-stream position of the defining copy, or -1 when no hint. the
+#           merged-range model extends a phi destination's live range back over its
+#           whole defining block, so its range start no longer marks the copy; this
+#           exact position is what proves the source vreg dies precisely at the copy
+#           (its register may then transfer to the destination), independent of the
+#           extension
+rec CopyHint {
+    src_vreg: u32;
+    src_preg: i32;
+    copy_pos: i64;
+}
+
 # the per-function allocation scratch state
 #
 # Owns every working array for the duration of one function's allocation and
@@ -185,6 +207,11 @@ rec BlockSpan {
 #                       so vreg_has_slot is an O(1) read. spill slots added later name
 #                       only spilled vregs, which is_spilled rejects before consulting
 #                       this, so the flag stays correct after the scan
+# hints:                per-vreg allocation hint (the source register of the vreg's
+#                       first defining copy), sized f.vreg_count; the scan biases
+#                       coloring toward it so a coalesced copy collapses to a dropped
+#                       self-move. an empty hint (src_vreg == MIR_VREG_NIL and
+#                       src_preg < 0) is advisory-only and never affects correctness
 rec AllocCtx {
     alloc:                *A.Allocator;
     interner:             *intern.Interner;
@@ -221,6 +248,7 @@ rec AllocCtx {
     block_id_index_cap:   u32;
     block_spans:          *BlockSpan;
     vreg_slot_flag:       *bool;
+    hints:                *CopyHint;
 }
 
 # the allocating function's source name, or "<unknown>" when unresolved
@@ -363,6 +391,19 @@ fun alloc_function(tgt: *target.Target, m: *mir.MirModule, f: *mir.MirFunction) 
         reserve_reg(?ctx, tgt.arch.shift_count_reg);
     }
 
+    # per-vreg storage-slot flags are needed by the dead-def sweep (a slot-owning
+    # vreg is never swept) and later by the scan / rewrite; build them first, since
+    # they read only the frame and vreg count, not the instruction stream.
+    val vs: R.Result[bool, str] = build_vreg_slot_flags(?ctx);
+    if (R.is_err[bool, str](vs)) { ctx_dnit(?ctx); ret vs; }
+
+    # copy hygiene, step 1: delete register moves whose destination is never read,
+    # before any position-dependent structure (block order, flat stream, live
+    # ranges) is built, so every later pass sees the already-cleaned instruction
+    # lists with no staleness to reconcile.
+    val ds: R.Result[bool, str] = sweep_dead_movs(tgt, ?ctx);
+    if (R.is_err[bool, str](ds)) { ctx_dnit(?ctx); ret ds; }
+
     val bo: R.Result[bool, str] = build_order(?ctx);
     if (R.is_err[bool, str](bo)) { ctx_dnit(?ctx); ret bo; }
 
@@ -372,12 +413,9 @@ fun alloc_function(tgt: *target.Target, m: *mir.MirModule, f: *mir.MirFunction) 
     val fl: R.Result[bool, str] = flatten(?ctx);
     if (R.is_err[bool, str](fl)) { ctx_dnit(?ctx); ret fl; }
 
-    # precompute the per-block flat spans and per-vreg storage-slot flags the
-    # liveness and scan passes would otherwise rebuild by rescanning.
+    # precompute the per-block flat spans the liveness range-extension reads.
     val bs: R.Result[bool, str] = build_block_spans(?ctx);
     if (R.is_err[bool, str](bs)) { ctx_dnit(?ctx); ret bs; }
-    val vs: R.Result[bool, str] = build_vreg_slot_flags(?ctx);
-    if (R.is_err[bool, str](vs)) { ctx_dnit(?ctx); ret vs; }
 
     build_ranges(?ctx);
 
@@ -386,6 +424,10 @@ fun alloc_function(tgt: *target.Target, m: *mir.MirModule, f: *mir.MirFunction) 
 
     val mc: R.Result[bool, str] = mark_call_crossing(?ctx);
     if (R.is_err[bool, str](mc)) { ctx_dnit(?ctx); ret mc; }
+
+    # copy hygiene, step 2: record each vreg's copy-source hint so the scan can bias
+    # coloring toward it and collapse the copy to a self-move dropped at rewrite.
+    build_hints(tgt, ?ctx);
 
     val sc: R.Result[bool, str] = linear_scan(tgt, ?ctx);
     if (R.is_err[bool, str](sc)) { ctx_dnit(?ctx); ret sc; }
@@ -440,6 +482,7 @@ fun ctx_init(ctx: *AllocCtx, tgt: *target.Target, m: *mir.MirModule, f: *mir.Mir
     ctx.block_id_index_cap   = 0;
     ctx.block_spans          = nil;
     ctx.vreg_slot_flag       = nil;
+    ctx.hints                = nil;
 
     val ro: R.Result[*u32, str] = A.allocate[u32](m.alloc, f.block_count::usize);
     if (R.is_err[*u32, str](ro)) { ret R.err[bool, str](R.unwrap_err[*u32, str](ro)); }
@@ -521,6 +564,17 @@ fun ctx_init(ctx: *AllocCtx, tgt: *target.Target, m: *mir.MirModule, f: *mir.Mir
     val ra: R.Result[*u32, str] = A.allocate[u32](m.alloc, f.vreg_count::usize);
     if (R.is_err[*u32, str](ra)) { ctx_dnit(ctx); ret R.err[bool, str](R.unwrap_err[*u32, str](ra)); }
     ctx.active = R.unwrap_ok[*u32, str](ra);
+
+    val rh: R.Result[*CopyHint, str] = A.allocate[CopyHint](m.alloc, f.vreg_count::usize);
+    if (R.is_err[*CopyHint, str](rh)) { ctx_dnit(ctx); ret R.err[bool, str](R.unwrap_err[*CopyHint, str](rh)); }
+    ctx.hints = R.unwrap_ok[*CopyHint, str](rh);
+    var hi: u32 = 0;
+    for (hi < f.vreg_count) {
+        ctx.hints[hi].src_vreg = mir.MIR_VREG_NIL;
+        ctx.hints[hi].src_preg = -1;
+        ctx.hints[hi].copy_pos = -1;
+        hi = hi + 1;
+    }
 
     ret R.ok[bool, str](true);
 }
@@ -607,6 +661,10 @@ fun ctx_dnit(ctx: *AllocCtx) {
     if (ctx.vreg_slot_flag != nil && ctx.f.vreg_count > 0) {
         A.deallocate[bool](ctx.alloc, ctx.vreg_slot_flag, ctx.f.vreg_count::usize);
         ctx.vreg_slot_flag = nil;
+    }
+    if (ctx.hints != nil && ctx.f.vreg_count > 0) {
+        A.deallocate[CopyHint](ctx.alloc, ctx.hints, ctx.f.vreg_count::usize);
+        ctx.hints = nil;
     }
 }
 
@@ -1019,6 +1077,172 @@ fun build_ranges(ctx: *AllocCtx) {
     }
 }
 
+# true when a post-selection opcode is one of the active ISA's plain
+# register-move forms, via the ISA vtable's `is_reg_move` classifier. an ISA that
+# wires no classifier reports false, disabling both copy-hygiene passes for that
+# target rather than risking a wrong identification of a non-move opcode.
+fun isa_is_reg_move(tgt: *target.Target, opcode: u32) bool {
+    if (tgt.arch.is_reg_move == nil) { ret false; }
+    val f: isa.IsRegMoveFn = tgt.arch.is_reg_move::isa.IsRegMoveFn;
+    ret f(opcode);
+}
+
+# true when an instruction is a plain register-or-immediate copy - a
+# coalescable move whose destination register receives its source unchanged with no
+# side effect. the opcode is one of the ISA's move forms; the operands are
+# [dst-register, source-register/immediate] with no memory operand (so a store /
+# load routed through the same encoder opcode is rejected); and the source and
+# destination widths are equal, so no narrowing / sign- or zero-extension rides on
+# the move (a truncating or extending move carries width != src_width). an
+# inline-asm instruction is never a copy.
+fun instr_is_reg_copy(tgt: *target.Target, mi: *mir.MirInstr) bool {
+    if (mi.operand_count != 2)            { ret false; }
+    if (mi.asm_block != nil)              { ret false; }
+    if (mi.width != mi.src_width)         { ret false; }
+    if (!isa_is_reg_move(tgt, mi.opcode)) { ret false; }
+    val d: *mir.MirOperand = ?mi.operands[0];
+    val s: *mir.MirOperand = ?mi.operands[1];
+    if (d.kind != mir.MIR_OP_VREG && d.kind != mir.MIR_OP_PREG) { ret false; }
+    if (s.kind != mir.MIR_OP_VREG && s.kind != mir.MIR_OP_PREG && s.kind != mir.MIR_OP_IMM) { ret false; }
+    ret true;
+}
+
+# tally, per vreg, how many times it is READ across the whole function -
+# every operand occurrence that is a use rather than a definition. mirrors the
+# use classification `build_ranges` / `compute_use_def` apply: operand 0 of a
+# defining instruction is the written destination (not a read), a MEM base or
+# scaled-index vreg is always a read. a vreg with zero reads is never used and its
+# defining copies are dead.
+fun tally_reads(ctx: *AllocCtx, reads: *u32, nv: u32) {
+    val f: *mir.MirFunction = ctx.f;
+    var bi: u32 = 0;
+    for (bi < f.block_count) {
+        val blk: *mir.MirBlock = ?f.blocks[bi];
+        var ii: u32 = 0;
+        for (ii < blk.instr_count) {
+            val mi: *mir.MirInstr = ?blk.instrs[ii];
+            val has_def: bool = instr_defines(mi);
+            var k: u32 = 0;
+            for (k < mi.operand_count) {
+                val op: *mir.MirOperand = ?mi.operands[k];
+                if (op.kind == mir.MIR_OP_VREG) {
+                    val is_dst: bool = has_def && k == 0;
+                    if (!is_dst && op.vreg < nv) { reads[op.vreg] = reads[op.vreg] + 1; }
+                } or (op.kind == mir.MIR_OP_MEM && op.vreg != mir.MIR_VREG_NIL && op.vreg < nv) {
+                    reads[op.vreg] = reads[op.vreg] + 1;
+                }
+                if (op.kind == mir.MIR_OP_MEM && !op.index_is_preg && op.index != mir.MIR_VREG_NIL && op.index < nv) {
+                    reads[op.index] = reads[op.index] + 1;
+                }
+                k = k + 1;
+            }
+            ii = ii + 1;
+        }
+        bi = bi + 1;
+    }
+}
+
+# true when a register copy's destination vreg is never read, so the
+# copy is dead. a copy INTO a physical register (dst not a vreg) has an ABI effect
+# and is never dead; a slot-owning vreg is storage addressed through memory and is
+# not a plain value the sweep may drop.
+fun is_dead_mov(tgt: *target.Target, ctx: *AllocCtx, mi: *mir.MirInstr, reads: *u32, nv: u32) bool {
+    if (!instr_is_reg_copy(tgt, mi)) { ret false; }
+    val d: *mir.MirOperand = ?mi.operands[0];
+    if (d.kind != mir.MIR_OP_VREG) { ret false; }
+    if (d.vreg >= nv)              { ret false; }
+    if (vreg_has_slot(ctx, d.vreg)) { ret false; }
+    ret reads[d.vreg] == 0;
+}
+
+# delete every register move whose destination vreg is never read.
+#
+# The dead-def sweep of issue #1801. Runs before block ordering / flattening so no
+# later structure needs reconciling. Deleting `MOV v <- s` removes a use of `s`,
+# which can make an earlier copy into `s` dead in turn, so the pass iterates to a
+# fixpoint: each round retallies reads from scratch and compacts every block's
+# instruction list, dropping the dead moves. A block always ends in a terminator
+# (never a move), so it never empties. An ISA with no move classifier no-ops.
+fun sweep_dead_movs(tgt: *target.Target, ctx: *AllocCtx) R.Result[bool, str] {
+    val f: *mir.MirFunction = ctx.f;
+    val nv: u32 = f.vreg_count;
+    if (nv == 0)                     { ret R.ok[bool, str](true); }
+    if (tgt.arch.is_reg_move == nil) { ret R.ok[bool, str](true); }
+
+    val rr: R.Result[*u32, str] = A.allocate[u32](ctx.alloc, nv::usize);
+    if (R.is_err[*u32, str](rr)) { ret R.err[bool, str](R.unwrap_err[*u32, str](rr)); }
+    val reads: *u32 = R.unwrap_ok[*u32, str](rr);
+
+    var changed: bool = true;
+    for (changed) {
+        changed = false;
+        var i: u32 = 0;
+        for (i < nv) { reads[i] = 0; i = i + 1; }
+        tally_reads(ctx, reads, nv);
+
+        var bi: u32 = 0;
+        for (bi < f.block_count) {
+            val blk: *mir.MirBlock = ?f.blocks[bi];
+            var write: u32 = 0;
+            var read:  u32 = 0;
+            for (read < blk.instr_count) {
+                val mi: *mir.MirInstr = ?blk.instrs[read];
+                if (is_dead_mov(tgt, ctx, mi, reads, nv)) {
+                    # the move never reaches encode; release its operand array.
+                    if (mi.operands != nil && mi.operand_count > 0) {
+                        A.deallocate[mir.MirOperand](ctx.alloc, mi.operands, mi.operand_count::usize);
+                    }
+                    changed = true;
+                } or {
+                    if (write != read) { blk.instrs[write] = blk.instrs[read]; }
+                    write = write + 1;
+                }
+                read = read + 1;
+            }
+            blk.instr_count = write;
+            bi = bi + 1;
+        }
+    }
+
+    A.deallocate[u32](ctx.alloc, reads, nv::usize);
+    ret R.ok[bool, str](true);
+}
+
+# record each vreg's copy-source allocation hint.
+#
+# For every vreg first defined by a plain register copy, remember the copy's source
+# (a physical register for `MOV v <- preg`, or a vreg for `MOV v <- v2`) and the
+# copy's flat position, so the scan can bias `v`'s color toward the source. Walks
+# the flat stream so the position is in hand and first-def-wins is first in scan
+# order: a vreg defined by copies on several paths (phi merges) can coalesce onto
+# only one source under the one-merged-range-per-vreg model, so the earliest
+# defining copy sets the hint. A self-copy or immediate source yields no register
+# hint. Runs after flatten / liveness so `flat_instr` and the ranges are available.
+fun build_hints(tgt: *target.Target, ctx: *AllocCtx) {
+    if (tgt.arch.is_reg_move == nil) { ret; }
+    val nv: u32 = ctx.f.vreg_count;
+    var pos: u32 = 0;
+    for (pos < ctx.flat_count) {
+        val mi: *mir.MirInstr = flat_instr(ctx, pos);
+        if (instr_is_reg_copy(tgt, mi)) {
+            val d: *mir.MirOperand = ?mi.operands[0];
+            if (d.kind == mir.MIR_OP_VREG && d.vreg < nv
+                && ctx.hints[d.vreg].src_vreg == mir.MIR_VREG_NIL
+                && ctx.hints[d.vreg].src_preg < 0) {
+                val s: *mir.MirOperand = ?mi.operands[1];
+                if (s.kind == mir.MIR_OP_VREG && s.vreg != d.vreg) {
+                    ctx.hints[d.vreg].src_vreg = s.vreg;
+                    ctx.hints[d.vreg].copy_pos = pos::i64;
+                } or (s.kind == mir.MIR_OP_PREG) {
+                    ctx.hints[d.vreg].src_preg = s.preg::i32;
+                    ctx.hints[d.vreg].copy_pos = pos::i64;
+                }
+            }
+        }
+        pos = pos + 1;
+    }
+}
+
 # solve per-block live-in/live-out by a backward dataflow
 # fixpoint over the RPO block order, then extend each vreg's range to span every
 # block in which it is live so values crossing a loop back edge are covered.
@@ -1095,7 +1319,18 @@ fun extend_liveness(ctx: *AllocCtx) R.Result[bool, str] {
         }
     }
 
-    # extend ranges to cover blocks where the vreg is live-in or live-out.
+    # extend ranges over the blocks a vreg spans, tightly. a live-IN value occupies
+    # its register from block entry, so its start extends back to the block's first
+    # position; a live-OUT value must hold its register through the terminator, so
+    # its end extends forward to the block's last position. the two are separate: a
+    # value live-in but not live-out dies at its last in-block use (already in
+    # end_pos from build_ranges) and its end is NOT pushed to the block end, and a
+    # value live-out but not live-in is born at its in-block def and its start is NOT
+    # pulled to the block start. dropping those phantom tails / heads removes the
+    # false interference they create with a precolored def elsewhere in the block
+    # (e.g. a return-register move the merged value is itself the source of), which a
+    # coalescing hint must not be blocked by. a loop-carried value is live-in AND
+    # live-out of its blocks, so both bounds still extend and the loop stays covered.
     var bi: u32 = 0;
     for (bi < nb) {
         val span: BlockSpan = ctx.block_spans[bi];
@@ -1103,11 +1338,9 @@ fun extend_liveness(ctx: *AllocCtx) R.Result[bool, str] {
         var v: u32 = 0;
         for (v < nv) {
             val idx: usize = base + v::usize;
-            if (live_in[idx] || live_out[idx]) {
-                val lr: *LiveRange = ?ctx.ranges[v];
-                if (span.start >= 0 && span.start < lr.start) { lr.start = span.start; }
-                if (span.end > lr.end_pos)                    { lr.end_pos = span.end; }
-            }
+            val lr: *LiveRange = ?ctx.ranges[v];
+            if (live_in[idx] && span.start >= 0 && span.start < lr.start) { lr.start = span.start; }
+            if (live_out[idx] && span.end > lr.end_pos)                   { lr.end_pos = span.end; }
             v = v + 1;
         }
         bi = bi + 1;
@@ -1362,10 +1595,18 @@ fun linear_scan(tgt: *target.Target, ctx: *AllocCtx) R.Result[bool, str] {
         ctx.cur_end   = lr.end_pos;
 
         var preg: i32 = -1;
-        if (lr.reg_class == REG_CLASS_GP) {
-            preg = pick_gp(ctx, lr.crosses_call);
-        } or {
-            preg = pick_fp(ctx, lr.crosses_call);
+        # prefer the copy-source register when a hint can be honored, so the
+        # defining copy collapses to a self-move dropped at rewrite; otherwise fall
+        # back to the normal class pick.
+        if (ctx.hints[v].src_vreg != mir.MIR_VREG_NIL || ctx.hints[v].src_preg >= 0) {
+            preg = pick_hint(ctx, v, lr);
+        }
+        if (preg < 0) {
+            if (lr.reg_class == REG_CLASS_GP) {
+                preg = pick_gp(ctx, lr.crosses_call);
+            } or {
+                preg = pick_fp(ctx, lr.crosses_call);
+            }
         }
 
         if (preg >= 0) {
@@ -1634,15 +1875,27 @@ fun vreg_has_slot(ctx: *AllocCtx, v: u32) bool {
     ret ctx.vreg_slot_flag[v];
 }
 
-# insertion-sort vreg ids in `order` by ascending range start,
-# the order linear scan walks them in.
+# true when range `a` sorts before range `b` in scan order -
+# ascending start, then ascending end to break ties. the end tie-break colors a
+# shorter range before a longer one that begins at the same position, so a copy
+# source (which dies at the copy) is colored before the copy destination whose
+# merged range the liveness pass extended back to the same start; the destination's
+# allocation hint then sees the source's assignment and can coalesce onto it.
+fun range_sorts_before(ctx: *AllocCtx, a: u32, b: u32) bool {
+    val sa: i64 = ctx.ranges[a].start;
+    val sb: i64 = ctx.ranges[b].start;
+    if (sa != sb) { ret sa < sb; }
+    ret ctx.ranges[a].end_pos < ctx.ranges[b].end_pos;
+}
+
+# insertion-sort vreg ids in `order` by ascending range start, then
+# ascending end, the order linear scan walks them in.
 fun sort_by_start(ctx: *AllocCtx, order: *u32, count: u32) {
     var i: u32 = 1;
     for (i < count) {
         val key: u32 = order[i];
-        val ks: i64 = ctx.ranges[key].start;
         var j: i64 = i::i64 - 1;
-        for (j >= 0 && ctx.ranges[order[j::u32]].start > ks) {
+        for (j >= 0 && range_sorts_before(ctx, key, order[j::u32])) {
             order[(j + 1)::u32] = order[j::u32];
             j = j - 1;
         }
@@ -1683,6 +1936,94 @@ fun free_assigned(ctx: *AllocCtx, v: u32) {
     } or {
         if (index < ctx.fp_count) { ctx.fp_busy[index] = false; }
     }
+}
+
+# try to color vreg `v` onto its copy-source register so the defining
+# copy collapses to a dropped self-move.
+#
+# The allocation-hint half of issue #1801. Returns the composite register id to
+# assign (with the bank's busy flag already claimed), or -1 when the hint cannot be
+# honored - the classic advisory linear-scan extension, so an unhonorable hint
+# never affects correctness. A hint is honored only when the register passes every
+# check the normal pick applies to `v`'s range (not reserved, not held by an
+# outgoing-argument or precolored-def window, not pinned for a different capture),
+# and either is free or is held solely by the copy's source vreg dying exactly at
+# this copy - in which case the register is transferred from source to destination,
+# since a source read at the same position it is overwritten provably never
+# coexists with the destination. A call-crossing range is never hinted onto a
+# caller-saved register: coalescing the copy there would only force a spill/reload
+# around the call, so the normal callee-saved-preferring pick is left to run.
+fun pick_hint(ctx: *AllocCtx, v: u32, lr: *LiveRange) i32 {
+    val h: *CopyHint = ?ctx.hints[v];
+
+    # resolve the hinted composite register id from the recorded copy source.
+    var rid: i32 = -1;
+    if (h.src_preg >= 0) {
+        rid = h.src_preg;
+    } or (h.src_vreg != mir.MIR_VREG_NIL) {
+        val s: u32 = h.src_vreg;
+        if (s < ctx.f.vreg_count && !is_spilled(ctx, s) && !vreg_has_slot(ctx, s)) {
+            val a: u32 = ctx.f.vregs[s].assigned;
+            if (a != mir.MIR_VREG_NIL) { rid = a::i32; }
+        }
+    }
+    if (rid < 0) { ret -1; }
+
+    val rclass: i32 = isa.regid_class(rid);
+    val idx: u32 = isa.regid_index(rid)::u32;
+
+    if (lr.reg_class == REG_CLASS_GP) {
+        if (rclass != isa.REG_CLASS_ID_GP) { ret -1; }
+        if (idx >= ctx.gp_count)           { ret -1; }
+        if (ctx.reserved[idx])             { ret -1; }
+        if (lr.crosses_call && !ctx.callee_saved[idx]) { ret -1; }
+        if (arg_reg_reserved(ctx, rid::u32)) { ret -1; }
+        if (def_reg_reserved(ctx, rid::u32)) { ret -1; }
+        # a pin blocks the register unless it ends exactly at this def - i.e. it is
+        # the pin protecting the incoming param register until this very capture.
+        if (ctx.pinned_end[idx] >= 0 && ctx.pinned_end[idx] != lr.start) { ret -1; }
+        if (!ctx.gp_busy[idx]) {
+            ctx.gp_busy[idx] = true;
+            ret rid;
+        }
+        # busy: honor only by transferring the register from the copy source when
+        # that source vreg dies exactly at the copy (its last use is the read this
+        # move performs), so source and destination provably never coexist even
+        # though the destination's extended range overlaps the source. remove_active
+        # drops the source from the active set while its busy flag stays set, so the
+        # register passes intact to the destination.
+        if (source_dies_at_copy(ctx, h)) {
+            remove_active(ctx, h.src_vreg);
+            ret rid;
+        }
+        ret -1;
+    } or {
+        if (rclass != isa.REG_CLASS_ID_XMM) { ret -1; }
+        if (idx >= ctx.fp_count)            { ret -1; }
+        if (lr.crosses_call && (ctx.fp_callee_saved == nil || !ctx.fp_callee_saved[idx])) { ret -1; }
+        if (arg_reg_reserved(ctx, rid::u32)) { ret -1; }
+        if (def_reg_reserved(ctx, rid::u32)) { ret -1; }
+        if (ctx.fp_pinned_end != nil && ctx.fp_pinned_end[idx] >= 0 && ctx.fp_pinned_end[idx] != lr.start) { ret -1; }
+        if (!ctx.fp_busy[idx]) {
+            ctx.fp_busy[idx] = true;
+            ret rid;
+        }
+        if (source_dies_at_copy(ctx, h)) {
+            remove_active(ctx, h.src_vreg);
+            ret rid;
+        }
+        ret -1;
+    }
+}
+
+# true when a copy hint's source is a vreg whose last use is the copy
+# itself - the register it currently holds may then be handed to the copy's
+# destination, since the source is read at the same instruction it dies at and can
+# never coexist with the destination the copy defines.
+fun source_dies_at_copy(ctx: *AllocCtx, h: *CopyHint) bool {
+    if (h.src_vreg == mir.MIR_VREG_NIL) { ret false; }
+    if (h.copy_pos < 0)                 { ret false; }
+    ret ctx.ranges[h.src_vreg].end_pos == h.copy_pos;
 }
 
 # choose a free general-purpose register, preferring caller-saved for a
@@ -2552,6 +2893,23 @@ fun rewrite_instr(tgt: *target.Target, ctx: *AllocCtx, mi: *mir.MirInstr,
             }
         }
         k = k + 1;
+    }
+
+    # drop a coalesced copy: a full-width register move whose operands rewrote to
+    # the same physical register is a no-op, so the hint that colored destination
+    # onto source has erased the copy. only when the destination was not spilled (a
+    # spilled destination still owes its store) and only at the full machine word,
+    # since a sub-word `mov` zero-extends and dropping it would skip that clear.
+    if (store_dst_vreg == mir.MIR_VREG_NIL
+        && mi.width >= ctx.spill_width
+        && instr_is_reg_copy(tgt, mi)
+        && ops[0].kind == mir.MIR_OP_PREG && ops[1].kind == mir.MIR_OP_PREG
+        && ops[0].preg == ops[1].preg) {
+        free_ops(ctx, ops, n);
+        if (mi.operands != nil && mi.operand_count > 0) {
+            A.deallocate[mir.MirOperand](ctx.alloc, mi.operands, mi.operand_count::usize);
+        }
+        ret R.ok[bool, str](true);
     }
 
     # the rewritten instruction itself. the operation width / source width are

--- a/src/lang/target/isa.mach
+++ b/src/lang/target/isa.mach
@@ -292,6 +292,20 @@ pub rec MachineModel {
 # fp_out: receives the vector-register clobber bitmask (index n -> bit n)
 pub def AsmClobbersFn: fun(str, *u32, *u32);
 
+# the concrete signature the erased `IsaVTable.is_reg_move` pointer is cast back to
+#
+# Given a post-selection concrete opcode, returns true when it is one of this
+# arch's plain full-width register-or-immediate move forms (the concrete opcode a
+# `mir.MIR_MOV` selects to, plus `mir.MIR_MOV` itself for the reload/store moves
+# regalloc splices post-selection). It returns false for width-changing moves
+# (sign/zero extend, truncate) and for the memory / arithmetic opcodes an ISA may
+# route through the same encoder opcode - the copy-hygiene passes further gate on
+# operand shape and equal source/destination width, so a false positive on shape
+# is impossible and a move mis-reported as a non-move only forgoes an optimization.
+# ---
+# opcode: the concrete post-selection opcode to classify
+pub def IsRegMoveFn: fun(u32) bool;
+
 # the ISA runtime-dispatch interface
 #
 # Exactly one of these exists per architecture; the backend reads pointer width,
@@ -353,6 +367,12 @@ pub def AsmClobbersFn: fun(str, *u32, *u32);
 #                       register a body writes. nil when the ISA supplies no
 #                       analyzer, which regalloc treats conservatively (every
 #                       register potentially clobbered)
+# is_reg_move:          erased fn ptr - classify a post-selection opcode as one of
+#                       this arch's plain register-move forms (cast back to
+#                       `IsRegMoveFn`), letting the shared regalloc copy-hygiene
+#                       passes recognize a coalescable copy without naming an
+#                       arch opcode. nil when the ISA wires no classifier, which
+#                       disables the copy-hygiene passes for that arch (they no-op)
 # apply_reloc:          erased fn ptr - apply one relocation for this arch (cast
 #                       back to the linker's `ApplyRelocFn`); nil until the
 #                       be-layer linker registrar wires it, and the linker errors
@@ -422,6 +442,7 @@ pub rec IsaVTable {
     encode:               *u8;
     emit_asm:             *u8;
     asm_clobbers:         *u8;
+    is_reg_move:          *u8;
     apply_reloc:          *u8;
     elf_reloc_type:       *u8;
     elf_attributes:       *u8;

--- a/src/lang/target/isa/arm64/isel.mach
+++ b/src/lang/target/isa/arm64/isel.mach
@@ -336,3 +336,13 @@ fun write_opcode_ice(opcode: u32) {
     os.write(os.STDERR_FD, ?digits[0], len);
     os.write(os.STDERR_FD, "\n", 1);
 }
+
+# the copy-hygiene move classifier admits both concrete move forms (GP and float)
+# and the generic MIR_MOV regalloc splices, and rejects a non-move opcode.
+test "mach.lang.target.isa.arm64.isel:is_reg_move" {
+    if (!is_reg_move(arm64.MOV::u32))  { ret 1; }
+    if (!is_reg_move(arm64.FMOV::u32)) { ret 1; }
+    if (!is_reg_move(mir.MIR_MOV))     { ret 1; }
+    if (is_reg_move(arm64.ADD::u32))   { ret 1; }
+    ret 0;
+}

--- a/src/lang/target/isa/arm64/isel.mach
+++ b/src/lang/target/isa/arm64/isel.mach
@@ -114,6 +114,21 @@ pub fun select(a: *A.Allocator, tgt: *target.Target, fn: *mir.MirFunction) R.Res
     ret R.ok[bool, str](true);
 }
 
+# classify a post-selection opcode as an aarch64 plain register move
+#
+# A `mir.MIR_MOV` selects to `arm64.MOV` (GP, `orr xd, xzr, xn`) or `arm64.FMOV`
+# (float), and the reload / store moves regalloc splices after selection stay
+# generic `mir.MIR_MOV`; all three are plain full-width copies. The shared
+# copy-hygiene passes further gate on operand shape and equal source/destination
+# width. This is the aarch64 implementation behind the ISA vtable's `is_reg_move`
+# slot.
+# ---
+# opcode: the concrete post-selection opcode to classify
+# ret:    true when the opcode is a plain register-move form
+pub fun is_reg_move(opcode: u32) bool {
+    ret opcode == arm64.MOV::u32 || opcode == arm64.FMOV::u32 || opcode == mir.MIR_MOV;
+}
+
 # rewrite a single generic MIR opcode in place into its concrete AArch64 encoder
 # opcode, or leave it as a surviving sentinel / pass-through
 #

--- a/src/lang/target/isa/arm64/register.mach
+++ b/src/lang/target/isa/arm64/register.mach
@@ -153,6 +153,7 @@ pub fun register_arm64(reg: *isa.IsaRegistry) R.Result[bool, str] {
     # points this at `printer.print_asm_arm64::*u8`.
     arm64_vtable.emit_asm             = nil;
     arm64_vtable.asm_clobbers         = encode.asm_clobbers::*u8;
+    arm64_vtable.is_reg_move          = isel.is_reg_move::*u8;
     arm64_vtable.reserved_regs        = ?arm64_reserved_regs[0];
     arm64_vtable.reserved_reg_count   = 3;
     arm64_vtable.reload_scratch_regs  = ?arm64_reload_scratch_regs[0];

--- a/src/lang/target/isa/riscv64/isel.mach
+++ b/src/lang/target/isa/riscv64/isel.mach
@@ -122,6 +122,20 @@ pub fun select(a: *A.Allocator, tgt: *target.Target, fn: *mir.MirFunction) R.Res
     ret R.ok[bool, str](true);
 }
 
+# classify a post-selection opcode as an RV64 plain register move
+#
+# A `mir.MIR_MOV` selects to `riscv64.MOV` (GP, `mv`) or `riscv64.FMV` (float), and
+# the reload / store moves regalloc splices after selection stay generic
+# `mir.MIR_MOV`; all three are plain full-width copies. The shared copy-hygiene
+# passes further gate on operand shape and equal source/destination width. This is
+# the RV64 implementation behind the ISA vtable's `is_reg_move` slot.
+# ---
+# opcode: the concrete post-selection opcode to classify
+# ret:    true when the opcode is a plain register-move form
+pub fun is_reg_move(opcode: u32) bool {
+    ret opcode == riscv64.MOV::u32 || opcode == riscv64.FMV::u32 || opcode == mir.MIR_MOV;
+}
+
 # rewrite a single generic MIR opcode in place into its concrete RV64 encoder
 # opcode, or leave it as a surviving sentinel / pass-through
 #

--- a/src/lang/target/isa/riscv64/isel.mach
+++ b/src/lang/target/isa/riscv64/isel.mach
@@ -430,12 +430,15 @@ test "mach.lang.target.isa.riscv64.isel:opcode_rewrites" {
     if (instrs[12].opcode != riscv64.RET::u32)    { bad = 1; }
     if (instrs[13].opcode != riscv64.FMV::u32)    { bad = 1; }  # same-bank float bitcast (#1762)
 
-    # the copy-hygiene move classifier admits both concrete move forms and the
-    # generic MIR_MOV regalloc splices, and rejects a non-move opcode.
-    if (!is_reg_move(riscv64.MOV::u32)) { bad = 1; }
-    if (!is_reg_move(riscv64.FMV::u32)) { bad = 1; }
-    if (!is_reg_move(mir.MIR_MOV))      { bad = 1; }
-    if (is_reg_move(riscv64.ADD::u32))  { bad = 1; }
-
     ret bad;
+}
+
+# the copy-hygiene move classifier admits both concrete move forms (GP and float)
+# and the generic MIR_MOV regalloc splices, and rejects a non-move opcode.
+test "mach.lang.target.isa.riscv64.isel:is_reg_move" {
+    if (!is_reg_move(riscv64.MOV::u32)) { ret 1; }
+    if (!is_reg_move(riscv64.FMV::u32)) { ret 1; }
+    if (!is_reg_move(mir.MIR_MOV))      { ret 1; }
+    if (is_reg_move(riscv64.ADD::u32))  { ret 1; }
+    ret 0;
 }

--- a/src/lang/target/isa/riscv64/isel.mach
+++ b/src/lang/target/isa/riscv64/isel.mach
@@ -430,5 +430,12 @@ test "mach.lang.target.isa.riscv64.isel:opcode_rewrites" {
     if (instrs[12].opcode != riscv64.RET::u32)    { bad = 1; }
     if (instrs[13].opcode != riscv64.FMV::u32)    { bad = 1; }  # same-bank float bitcast (#1762)
 
+    # the copy-hygiene move classifier admits both concrete move forms and the
+    # generic MIR_MOV regalloc splices, and rejects a non-move opcode.
+    if (!is_reg_move(riscv64.MOV::u32)) { bad = 1; }
+    if (!is_reg_move(riscv64.FMV::u32)) { bad = 1; }
+    if (!is_reg_move(mir.MIR_MOV))      { bad = 1; }
+    if (is_reg_move(riscv64.ADD::u32))  { bad = 1; }
+
     ret bad;
 }

--- a/src/lang/target/isa/riscv64/register.mach
+++ b/src/lang/target/isa/riscv64/register.mach
@@ -199,6 +199,7 @@ pub fun register_riscv64(reg: *isa.IsaRegistry) R.Result[bool, str] {
     riscv64_vtable.encode               = encode.encode_riscv64::*u8;
     riscv64_vtable.emit_asm             = printer.print_asm_riscv64::*u8;
     riscv64_vtable.asm_clobbers         = encode.asm_clobbers::*u8;
+    riscv64_vtable.is_reg_move          = isel.is_reg_move::*u8;
     riscv64_vtable.reserved_regs        = ?riscv64_reserved_regs[0];
     riscv64_vtable.reserved_reg_count   = 6;
     riscv64_vtable.reload_scratch_regs  = ?riscv64_reload_scratch_regs[0];

--- a/src/lang/target/isa/x64/isel.mach
+++ b/src/lang/target/isa/x64/isel.mach
@@ -122,6 +122,21 @@ pub fun select(a: *A.Allocator, tgt: *target.Target, fn: *mir.MirFunction) R.Res
     ret R.ok[bool, str](true);
 }
 
+# classify a post-selection opcode as an x86-64 plain register move
+#
+# A `mir.MIR_MOV` selects to `x64.MOV`, and the reload / store moves regalloc
+# splices after selection stay generic `mir.MIR_MOV`; both are plain full-width
+# copies. `x64.MOV` also carries stores, loads, and truncations, but the shared
+# copy-hygiene passes further gate on operand shape and equal source/destination
+# width, so this predicate only needs to admit the move opcode. This is the x86-64
+# implementation behind the ISA vtable's `is_reg_move` slot.
+# ---
+# opcode: the concrete post-selection opcode to classify
+# ret:    true when the opcode is a plain register-move form
+pub fun is_reg_move(opcode: u32) bool {
+    ret opcode == x64.MOV::u32 || opcode == mir.MIR_MOV;
+}
+
 # select concrete instructions for one block
 #
 # Instructions that map 1:1 to a concrete opcode are rewritten in place; the few

--- a/src/lang/target/isa/x64/isel.mach
+++ b/src/lang/target/isa/x64/isel.mach
@@ -563,3 +563,14 @@ fun write_opcode_ice(opcode: u32) {
     os.write(os.STDERR_FD, ?buf[0], len);
     os.write(os.STDERR_FD, "\n", 1);
 }
+
+# the copy-hygiene move classifier admits the concrete move form and the generic
+# MIR_MOV regalloc splices, and rejects a non-move opcode (an add) and a
+# width-changing move (a zero-extend), which the shared passes must never coalesce.
+test "mach.lang.target.isa.x64.isel:is_reg_move" {
+    if (!is_reg_move(x64.MOV::u32))  { ret 1; }
+    if (!is_reg_move(mir.MIR_MOV))   { ret 1; }
+    if (is_reg_move(x64.ADD::u32))   { ret 1; }
+    if (is_reg_move(x64.MOVZX::u32)) { ret 1; }
+    ret 0;
+}

--- a/src/lang/target/isa/x64/register.mach
+++ b/src/lang/target/isa/x64/register.mach
@@ -145,6 +145,7 @@ pub fun register_x64(reg: *isa.IsaRegistry) R.Result[bool, str] {
     x64_vtable.encode               = encode.encode_x64::*u8;
     x64_vtable.emit_asm             = printer.print_asm_x64::*u8;
     x64_vtable.asm_clobbers         = encode.asm_clobbers::*u8;
+    x64_vtable.is_reg_move          = isel.is_reg_move::*u8;
     x64_vtable.reserved_regs        = ?x64_reserved_regs[0];
     x64_vtable.reserved_reg_count   = 2;
     x64_vtable.reload_scratch_regs  = ?x64_reload_scratch_regs[0];


### PR DESCRIPTION
Closes #1801.

## What

> **Review round (addressed):** guarded the copy-hint register transfer against a live loop-carried destination (a latent miscompile the fixpoint didn't surface — now refused unless the destination is born at the copy, with a cross-pass invariant assertion); added unit tests for the transfer guard, the live-in/out extension matrix, and the sweep guards; refreshed the algorithm overview; and **corrected the code-size headline from a mistaken −16.5% (a debug-vs-release comparison error) to the true −4.0%.**


Adds the two cooperating copy-cleanup pieces the backend was missing, both in the linear-scan allocator, sharing its liveness data.

### 1. Dead-def sweep
Before block ordering, delete every register move whose destination vreg is never read. Reads are retallied to a fixpoint (dropping `MOV v <- s` removes a use of `s`, which can make an earlier copy into `s` dead in turn). This runs before any position-dependent structure is built, so no later pass has staleness to reconcile.

### 2. Allocation hints
Record each vreg's copy-source register; in the scan, bias the destination onto it. A hint is honored only when the source register passes every reservation check the normal pick applies. When the source is a vreg whose last use is the copy itself, its register is *transferred* to the destination (the copy's read and the destination's def provably never coexist). A honored hint collapses the copy to a self-move, dropped at rewrite. Hints are advisory — an unhonorable one falls back to the normal pick, so correctness is never affected.

### Move identification
Regalloc runs after instruction selection, where `MIR_MOV` has collapsed into arch move opcodes (`x64.MOV`, `arm64.MOV`/`FMOV`, `riscv64.MOV`/`FMV`) shared with stores/loads/extends. A new `is_reg_move` ISA-vtable classifier (mirroring `asm_clobbers`) recognizes a copy arch-agnostically; the shared pass further gates on operand shape and **equal source/destination width**, so a store, a load, or a width-changing move is never mistaken for a coalescable copy.

### Two supporting changes the hints require
- **Tighter liveness extension.** Extend a range's start back over a block only when the vreg is live-IN there, and its end forward only when live-OUT — instead of both whenever either holds. A value live-in but dying mid-block no longer carries a phantom tail to the block end, which had falsely interfered with a later precolored def (notably the return-register move the value feeds) and blocked coalescing. Loop-carried values are live-in AND live-out, so both bounds still extend and loop coverage is unchanged. This also removes many false interferences corpus-wide, cutting spills.
- **Tie-break by end.** Among equal range starts, color the shorter range first, so a copy source (which dies at the copy) colors before the destination whose extended range starts at the same position; the destination's hint then sees the source's assignment.

## Design decisions (where the issue left latitude)
- **Sweep placement.** The issue frames the sweep as running "after live ranges are built." Physically deleting instructions post-flatten would invalidate the flat stream, ranges, and spans. It's cleaner and equally correct to run it as a pre-pass with its own read tally, so every later structure is built once on already-clean lists.
- **Scope = moves only, gated by width.** Deleting only side-effect-free moves (never a dead load/div/call) is the issue's stated scope and the safe one. The self-move drop is restricted to full-machine-word moves, because a sub-word `mov eax, eax` zero-extends — dropping it would skip that clear.
- **Both diamond edges.** The merged one-range-per-vreg model makes a phi destination interfere with the branch temp whose def lies inside its extended range, so a single-register hint coalesces one edge. Both edges need live-range splitting — the future work #1801 explicitly defers.

## Acceptance
- **Specimen** (`-O0` `main` ignoring `argc`/`argv`): zero dead movs in the prologue on x64, arm64 (verified by disassembly; arm64 has no asm printer), and riscv64. ✅
- **Diamond** (`if/else` merge): the merge value materializes in one register; param-homing, one phi edge, and (on x64) the return move all coalesce. x64 goes from 4 movs to 1. ✅
- **IR verifier + full test suite pass unchanged**; spill paths under register pressure exercised and correct when hints cannot be honored. ✅

## Before / after (compiler's own release corpus, identical source)
Baseline = the merge-base (34b48f3f) compiler; new = this branch's compiler; both built this branch's source at `--profile release`.

| metric | baseline codegen | this branch | delta |
|---|---|---|---|
| executable segment (`LOAD R E`) | 8,156,119 B | 7,826,933 B | **−4.0%** |
| file size | 8,392,704 B | 8,060,928 B | −4.0% |
| plain `mov` lines | 984,187 | 920,936 | −6.4% |
| redundant reg-reg self-moves | 22,813 | 2,709 | −88.1% |

The shrink is entirely code (fewer copies plus fewer spills from the tighter live ranges).

## Verification
- **Self-host fixpoint**: the compiler built by this compiler rebuilds itself byte-identically (`mach2 == mach3`).
- **Unit tests**: 440 passed / 0 failed, both seed-compiled and compiled by this compiler (+2 `is_reg_move` classifier tests).
- **Integration harness** (`int/`): native linux and riscv64-under-qemu legs pass; arm64 legs fail only on the host's missing arm64 binfmt (native run-mode), confirmed correct by running the same binaries through `qemu-aarch64`.
- **Cross-target builds**: all six targets (linux x86_64/arm64/riscv64, windows x86_64, darwin x86_64/aarch64) build from a from-source current-dev compiler.
- **Runnable stress** on all three arches (debug + release, native / qemu): the diamond, a register-pressure function with 9 live values crossing a call, and a float phi diamond all compute the expected results.
- **`--verify-ir`** full self-build clean.

## Risk
The tighter-liveness change touches core range construction; it is the highest-risk change and is validated by the byte-identical self-host fixpoint (millions of instructions across every register class, spill path, call, float, and vararg in the compiler's own code) plus the full test and integration suites. The changelog is left for the wave's separate docs backfill.
