### PR TITLE
feat(test): --format json machine-readable output

### DIFF
--- a/doc/cli.md
+++ b/doc/cli.md
@@ -230,6 +230,7 @@ passed.
 | `--filter <pattern>`| pattern | run only tests whose name contains `<pattern>` |
 | `--include-deps`    | —       | also collect tests declared in dependency modules |
 | `--list`            | —       | list the collected tests and exit |
+| `--format <mode>`   | `human`\|`json` | output format: the live readout (default `human`), or the machine-readable JSON event stream |
 | `--runner <cmd>`    | command | launch every test as `<cmd> <exe> <idx>` instead of exec'ing the dispatcher directly |
 
 Plus the `build` and global flags (`-v` lists every test). The build produces a
@@ -249,6 +250,13 @@ host cannot exec directly — e.g. `mach test . --target windows --runner wine`
 arguments). Without it, a test executable the host cannot launch reports a
 per-test failure — `(exit 127)` when `execve` rejects the binary in the spawned
 child, `(spawn failed)` when the spawn itself fails — with no auto-detection.
+
+`--format json` replaces the live readout with a machine-readable stream: one
+JSON object per line on stdout (`run_start`, one `test` per result, `summary`),
+with no human text interleaved. `--list --format json` emits one `case` object
+per collected test instead. The schema is versioned and documented in
+[tooling/test-json.md](tooling/test-json.md); pin tooling to its `schema`
+integer. Build diagnostics stay on stderr, so the stdout stream is clean.
 
 Exit codes: `0` all passed, `1` any failed, `2` build/internal error.
 
@@ -442,4 +450,5 @@ non-zero.
 
 - [manifest.md](manifest.md) — the `mach.toml` reference
 - [language/test.md](language/test.md) — the `test` declaration and `mach test`
+- [tooling/test-json.md](tooling/test-json.md) — the `mach test --format json` event schema
 - [language/files.md](language/files.md) — project file layout

--- a/doc/tooling/test-json.md
+++ b/doc/tooling/test-json.md
@@ -16,6 +16,31 @@ characters use their JSON escapes and every byte `>= 0x80` is emitted as a
 `\uXXXX` escape (UTF-8 decoded, astral code points as a surrogate pair), so the
 output is byte-for-byte identical on every platform. Numbers are integers.
 
+### ASCII escaping (considered alternative)
+
+The escaper is `ensure_ascii`: it never emits a raw byte `>= 0x80`. Verbatim
+UTF-8 passthrough would be equally deterministic and equally valid under RFC
+8259 (which mandates UTF-8), and would be smaller and more readable. The
+`ensure_ascii` form was chosen for two properties a machine stream benefits
+from: it makes no assumption about the consumer's byte-encoding handling, and it
+is robust to invalid UTF-8 in the underlying bytes — malformed sequences (a path
+on Linux is an arbitrary byte string) decode to the U+FFFD replacement escape
+rather than propagating raw or producing invalid JSON. The tradeoff is size and
+human readability, which do not matter for a machine stream.
+
+### Paths and ordering
+
+`file`, `exe`, and `output` are emitted exactly as the compiler references them
+— relative to the working directory the run was invoked from (the same form the
+human readout prints, e.g. `./src/...`), unless a path was configured as
+absolute. Resolve them against that cwd.
+
+`test` events arrive in **completion order** — each is emitted the moment its
+test process finalizes, so a slow test never delays results that finished before
+it. Consumers that want collection (declaration) order sort by `index`, which is
+the stable per-test dispatch index. `run_start` always precedes every `test`,
+and `summary` always follows every `test`.
+
 ## Versioning
 
 `schema` is `1`. It is bumped only on an **incompatible** change to the event
@@ -56,7 +81,7 @@ order as the human readout), regardless of completion order.
 | `kind`        | string        | outcome (see below) |
 | `code`        | int           | exit code (`kind` = `exit`) or signal number (`kind` = `signal`); `0` otherwise |
 | `duration_ns` | int           | wall time of the test process, in nanoseconds |
-| `index`       | int           | the test's dispatch index (`<exe> <index>` reruns exactly this test) |
+| `index`       | int           | the test's collection-order dispatch index (`<exe> <index>` reruns exactly this test; sort by it for declaration order) |
 | `exe`         | string        | the dispatcher executable path |
 | `output`      | string / null | path to the retained capture file, or `null` |
 
@@ -75,6 +100,12 @@ stderr. It is a path for a `test` whose capture file persists — every failure
 (`exit`, `signal`, `other`) — and `null` otherwise: a `pass` file is unlinked on
 completion, and a `spawn` failure never produced one. The file is the complete
 output (unlike the human readout's 64KB inline excerpt).
+
+The capture file is **single-run scoped**: the next `mach test` invocation wipes
+the `log/` directory beside the dispatcher — regardless of `--filter` — before
+it runs, so read a referenced file before starting another run. The path is
+composed to fit exactly, so `output` is never `null` for a failure on account of
+path length.
 
 ```json
 {"schema":1,"event":"test","label":"mach.cli.util.path_into:absolute_and_relative","module":"mach.cli.util","file":"./src/cli/util.mach","line":427,"kind":"pass","code":0,"duration_ns":489607,"index":12,"exe":"./out/linux-x86_64/debug/test/mach","output":null}

--- a/doc/tooling/test-json.md
+++ b/doc/tooling/test-json.md
@@ -1,0 +1,130 @@
+# `mach test` JSON event schema (v1)
+
+`mach test --format json` emits a machine-readable stream instead of the human
+readout: one JSON object per line (newline-delimited JSON / NDJSON), no
+interleaved human text. Editors, CI annotators, and other tooling parse this
+stream rather than scraping the live readout, which stays free to evolve.
+
+The stream is written to **stdout**. Build diagnostics and internal errors stay
+on **stderr**, so a consumer reads a clean event stream on stdout regardless of
+build noise. Exit codes are unchanged from the human mode: `0` all passed, `1`
+any failed, `2` build/internal error.
+
+Every line is a complete JSON object carrying a `schema` version integer and an
+`event` discriminator. Strings are escaped to printable ASCII: control
+characters use their JSON escapes and every byte `>= 0x80` is emitted as a
+`\uXXXX` escape (UTF-8 decoded, astral code points as a surrogate pair), so the
+output is byte-for-byte identical on every platform. Numbers are integers.
+
+## Versioning
+
+`schema` is `1`. It is bumped only on an **incompatible** change to the event
+shapes — a removed or renamed field, or a changed field type or meaning. Adding
+a new optional field or a new `event` kind is backward compatible and does
+**not** bump the version; a consumer must ignore unknown fields and unknown
+`event` values. Pin behavior to the `schema` integer, never to field ordering.
+
+## Events
+
+### `run_start`
+
+Emitted once, before any `test` event.
+
+| Field    | Type   | Description |
+|----------|--------|-------------|
+| `schema` | int    | schema version (`1`) |
+| `event`  | string | `"run_start"` |
+| `tests`  | int    | number of tests selected for the run |
+
+```json
+{"schema":1,"event":"run_start","tests":438}
+```
+
+### `test`
+
+Emitted once per finalized test, in collection order (the same deterministic
+order as the human readout), regardless of completion order.
+
+| Field         | Type          | Description |
+|---------------|---------------|-------------|
+| `schema`      | int           | schema version (`1`) |
+| `event`       | string        | `"test"` |
+| `label`       | string        | the test's label, verbatim as authored in `test "..."` |
+| `module`      | string        | the declaring module's fully-qualified name |
+| `file`        | string        | source file path of the declaring module |
+| `line`        | int           | 1-based source line of the `test` keyword |
+| `kind`        | string        | outcome (see below) |
+| `code`        | int           | exit code (`kind` = `exit`) or signal number (`kind` = `signal`); `0` otherwise |
+| `duration_ns` | int           | wall time of the test process, in nanoseconds |
+| `index`       | int           | the test's dispatch index (`<exe> <index>` reruns exactly this test) |
+| `exe`         | string        | the dispatcher executable path |
+| `output`      | string / null | path to the retained capture file, or `null` |
+
+`kind` is one of:
+
+| `kind`   | Meaning |
+|----------|---------|
+| `pass`   | exited `0` |
+| `exit`   | exited non-zero; `code` carries the exit code |
+| `signal` | killed by a signal; `code` carries the signal number |
+| `spawn`  | the test executable could not be spawned |
+| `other`  | neither exited nor signaled (should not occur) |
+
+`output` references the on-disk capture file holding the test's full stdout and
+stderr. It is a path for a `test` whose capture file persists — every failure
+(`exit`, `signal`, `other`) — and `null` otherwise: a `pass` file is unlinked on
+completion, and a `spawn` failure never produced one. The file is the complete
+output (unlike the human readout's 64KB inline excerpt).
+
+```json
+{"schema":1,"event":"test","label":"mach.cli.util.path_into:absolute_and_relative","module":"mach.cli.util","file":"./src/cli/util.mach","line":427,"kind":"pass","code":0,"duration_ns":489607,"index":12,"exe":"./out/linux-x86_64/debug/test/mach","output":null}
+{"schema":1,"event":"test","label":"builds:cyclic_import","module":"mach.lang.driver","file":"./src/lang/driver.mach","line":142,"kind":"exit","code":1,"duration_ns":146002310,"index":37,"exe":"./out/linux-x86_64/debug/test/mach","output":"./out/linux-x86_64/debug/test/log/37.log"}
+```
+
+### `summary`
+
+Emitted once, after every `test` event.
+
+| Field         | Type   | Description |
+|---------------|--------|-------------|
+| `schema`      | int    | schema version (`1`) |
+| `event`       | string | `"summary"` |
+| `passed`      | int    | number of passing tests |
+| `failed`      | int    | number of non-passing tests |
+| `total`       | int    | number of tests run |
+| `duration_ns` | int    | the run's wall time, in nanoseconds |
+
+```json
+{"schema":1,"event":"summary","passed":437,"failed":1,"total":438,"duration_ns":268000000}
+```
+
+### `case`
+
+Emitted by `mach test --list --format json` — one per collected test, with no
+run. Carries the static identity fields only (no outcome). `exe` is absent
+because `--list` does not build the dispatcher.
+
+| Field    | Type   | Description |
+|----------|--------|-------------|
+| `schema` | int    | schema version (`1`) |
+| `event`  | string | `"case"` |
+| `label`  | string | the test's label, verbatim |
+| `module` | string | the declaring module's fully-qualified name |
+| `file`   | string | source file path of the declaring module |
+| `line`   | int    | 1-based source line of the `test` keyword |
+| `index`  | int    | the test's dispatch index |
+
+```json
+{"schema":1,"event":"case","label":"mach.cli.util.path_into:absolute_and_relative","module":"mach.cli.util","file":"./src/cli/util.mach","line":427,"index":12}
+```
+
+## Stream shape
+
+A run is `run_start`, then zero or more `test` (or, under `--list`, zero or more
+`case`), then `summary`. A filtered run that matched nothing still brackets an
+empty run with `run_start` (`tests: 0`) and `summary`. `--list` emits `case`
+lines only — no `run_start` or `summary`.
+
+## See also
+
+- [cli.md](../cli.md) — the `mach test` command and its flags.

--- a/src/cli/cmd/testing.mach
+++ b/src/cli/cmd/testing.mach
@@ -42,6 +42,12 @@
 #
 # spawning and output capture go through `std.process`, which is multiplatform
 # (linux, darwin, windows), so the readout behaves identically on every host.
+#
+# `--format json` swaps the human readout for a machine-readable NDJSON event
+# stream (one object per line: `run_start`, one `test` per result, `summary`;
+# `case` per test under `--list`) driven off the same per-test event stream as
+# the human renderer through the `Renderer` vtable. the schema is versioned in
+# `doc/tooling/test-json.md`; `mach.cli.json` owns the ASCII-safe encoding.
 
 use std.allocator.arena;
 use std.print;
@@ -68,6 +74,7 @@ use du:     std.chrono.duration;
 
 use mach.cli.cmd.build;
 use mach.cli.util;
+use json: mach.cli.json;
 
 # a test that passed
 val KIND_PASS:   u8 = 0;
@@ -81,6 +88,10 @@ val KIND_SPAWN:  u8 = 3;
 val KIND_OTHER:  u8 = 4;
 # a test not yet finalized; the render cursor never crosses one
 val KIND_PENDING: u8 = 5;
+
+# the machine-readable output schema version stamped on every JSON event; bump
+# it on any incompatible change to the event shapes (see doc/tooling/test-json.md)
+val SCHEMA_VERSION: i64 = 1;
 
 # most retained bytes per test from its capture file; a file holding more is
 # retained truncated (the file itself keeps the full output)
@@ -126,6 +137,21 @@ pub fun run(argc: usize, argv: **u8) i64 {
     if (util.has_flag(argc, argv, "-v"))  { level = 1; }
     if (util.has_flag(argc, argv, "-vv")) { level = 2; }
 
+    # `--format json` selects the machine-readable NDJSON event stream (one JSON
+    # object per line, no human readout); `human` (the default) keeps the live
+    # readout. an unrecognized value is a usage error.
+    var json_out: bool = false;
+    val opt_format: O.Option[*u8] = util.get_value(argc, argv, "--format");
+    if (O.is_some[*u8](opt_format)) {
+        val fv: str = O.unwrap[*u8](opt_format)::str;
+        if (str_equals(fv, "json"))  { json_out = true; }
+        or (str_equals(fv, "human")) { json_out = false; }
+        or {
+            print.eprint("error: --format expects 'human' or 'json'\n");
+            ret 1;
+        }
+    }
+
     # `--jobs <n>` bounds how many test children run at once; the default is
     # the CPUs available to this process, and 1 serializes.
     var jobs: u32 = 1;
@@ -168,13 +194,19 @@ pub fun run(argc: usize, argv: **u8) i64 {
     val opt_filter: O.Option[*u8] = util.get_value(argc, argv, "--filter");
     if (O.is_some[*u8](opt_filter)) { filter = O.unwrap[*u8](opt_filter); }
 
-    # `--list`: report each selected test's `label file:line`, no execution.
+    # `--list`: report each selected test with no execution - one `case` JSON
+    # object per test under `--format json`, else `label file:line`.
     if (list) {
+        var lw: writer.Writer;
+        if (json_out) { fs.get_writer(?fs.stdout, ?lw); }
         var i: u32 = 0;
         for (i < tbr.len) {
             if (filter_matches(?tbr.tests[i], filter)) {
-                artifact_report(?tbr.tests[i]);
-                print.print("\n");
+                if (json_out) { emit_list_case(?lw, ?tbr.tests[i]); }
+                or {
+                    artifact_report(?tbr.tests[i]);
+                    print.print("\n");
+                }
             }
             i = i + 1;
         }
@@ -225,7 +257,13 @@ pub fun run(argc: usize, argv: **u8) i64 {
 
     # a filtered run that matched nothing has no work and no failures.
     if (sel_len == 0) {
-        print.print("0 passed, 0 failed, 0 total  (0ms)\n");
+        if (json_out) {
+            var jc: JsonCtx;
+            var r:  Renderer = json_renderer(?jc, nil);
+            r.fn_start(r.ctx, nil, 0);
+            r.fn_summary(r.ctx, nil, 0, 0, 0, 0);
+        }
+        or { print.print("0 passed, 0 failed, 0 total  (0ms)\n"); }
         arena.dnit(?ar);
         ret 0;
     }
@@ -256,13 +294,22 @@ pub fun run(argc: usize, argv: **u8) i64 {
     val mod_w:   usize = module_col_width(selected, sel_len);
     val label_w: usize = label_col_width(selected, sel_len);
 
+    # the human readout and the JSON stream are sibling renderers over the same
+    # per-test event stream; only one is live per run.
+    var hc: HumanCtx;
+    var jc: JsonCtx;
+    var r:  Renderer;
+    if (json_out) { r = json_renderer(?jc, ?log_dir[0]); }
+    or           { r = human_renderer(?hc, level, mod_w, label_w, runner, ?log_dir[0]); }
+
     val run_start: tm.Time = tm.monotonic();
-    execute_and_render(?a, selected, sel_len, runner, outcomes, level, mod_w, label_w, jobs, ?log_dir[0]);
+    r.fn_start(r.ctx, selected, sel_len);
+    execute_and_render(?a, selected, sel_len, runner, outcomes, level, jobs, ?log_dir[0], ?r);
     val wall: du.Duration = tm.time_sub(tm.monotonic(), run_start);
 
     val failed: u32 = count_failed(outcomes, sel_len);
     val passed: u32 = sel_len - failed;
-    render_summary(outcomes, sel_len, passed, failed, wall);
+    r.fn_summary(r.ctx, outcomes, sel_len, passed, failed, wall);
 
     arena.dnit(?ar);
     if (failed > 0) { ret 1; }
@@ -285,14 +332,13 @@ rec Slot {
 }
 
 # run every selected test through a sliding window of child processes,
-# rendering the readout live in collection order as results finalize
+# driving the renderer over the finalized outcomes in collection order
 #
 # Up to `jobs` children are in flight at once, each with stdout and stderr
 # bound to its capture file; a blocking wait-any reaps whichever exits first.
-# The render cursor trails completion in collection order, so the readout is
-# deterministic regardless of completion order: at the default level a
-# module's roll-up prints the moment its last test finalizes, and under `-v`
-# the module header and each test line print as the cursor crosses them.
+# The render cursor trails completion in collection order, so the renderer sees
+# each outcome exactly once in test order regardless of completion order, and
+# the readout is deterministic.
 # ---
 # a:        allocator retaining captured output
 # arts:     the selected test artifacts to run, in collection order
@@ -300,13 +346,12 @@ rec Slot {
 # runner:   resolved `--runner` launcher, or nil to exec the dispatcher directly
 # outcomes: caller-owned array (length n) filled in test order
 # level:    verbosity (0 roll-ups, 1 per-test lines, 2 also passing output)
-# mod_w:    module roll-up column width
-# label_w:  `-v` label column width
 # jobs:     window width (1 serializes)
 # log_dir:  the capture-file directory
+# r:        the renderer notified as each outcome finalizes
 fun execute_and_render(a: *A.Allocator, arts: *build.TestArtifact, n: u32, runner: *u8,
-                       outcomes: *Outcome, level: u8, mod_w: usize, label_w: usize,
-                       jobs: u32, log_dir: *u8) {
+                       outcomes: *Outcome, level: u8, jobs: u32, log_dir: *u8,
+                       r: *Renderer) {
     var i: u32 = 0;
     for (i < n) { outcomes[i].kind = KIND_PENDING; i = i + 1; }
 
@@ -338,7 +383,6 @@ fun execute_and_render(a: *A.Allocator, arts: *build.TestArtifact, n: u32, runne
     var done:     u32 = 0;
     var inflight: u32 = 0;
     var cursor:   u32 = 0;
-    var first:    u32 = 0;
 
     for (done < n) {
         # top the window back up
@@ -405,20 +449,223 @@ fun execute_and_render(a: *A.Allocator, arts: *build.TestArtifact, n: u32, runne
             }
         }
 
-        # advance the render cursor across everything finalized so far
+        # advance the render cursor across everything finalized so far,
+        # handing each outcome to the renderer once in collection order
         for (cursor < n && outcomes[cursor].kind != KIND_PENDING) {
-            val mod_name: str = util.cstr_str(arts[cursor].module);
-            if (level > 0 && cursor == first) { print.printf("{}\n", mod_name); }
-            if (level > 0) { print_verbose_test(?outcomes[cursor], label_w, runner, log_dir); }
-            val last_of_module: bool = cursor + 1 == n
-                || !str_equals(util.cstr_str(arts[cursor + 1].module), mod_name);
-            if (last_of_module) {
-                if (level == 0) { render_module_run(outcomes, first, cursor, mod_name, mod_w, runner, log_dir); }
-                first = cursor + 1;
-            }
+            r.fn_test(r.ctx, outcomes, arts, cursor);
             cursor = cursor + 1;
         }
     }
+}
+
+# the run-event renderer: an opaque ctx plus per-event callbacks, so the human
+# readout and the machine-readable JSON stream are sibling consumers of one
+# event stream rather than one scraping the other's text
+# ---
+# ctx:        opaque renderer state handed to each callback
+# fn_start:   run start (selected artifacts, count)
+# fn_test:    one finalized outcome in collection order (outcomes, artifacts, index)
+# fn_summary: run end (outcomes, count, passed, failed, wall time)
+rec Renderer {
+    ctx:        ptr;
+    fn_start:   fun(ptr, *build.TestArtifact, u32);
+    fn_test:    fun(ptr, *Outcome, *build.TestArtifact, u32);
+    fn_summary: fun(ptr, *Outcome, u32, u32, u32, du.Duration);
+}
+
+# state the human readout carries across its per-test callbacks
+# ---
+# level:   verbosity (0 roll-ups, 1 per-test lines, 2 also passing output)
+# mod_w:   module roll-up column width
+# label_w: `-v` label column width
+# runner:  resolved `--runner` launcher, or nil
+# log_dir: the capture-file directory
+# n:       number of selected tests
+# first:   index of the current module's first outcome
+rec HumanCtx {
+    level:   u8;
+    mod_w:   usize;
+    label_w: usize;
+    runner:  *u8;
+    log_dir: *u8;
+    n:       u32;
+    first:   u32;
+}
+
+# state the JSON stream carries across its per-test callbacks
+# ---
+# log_dir: the capture-file directory, source of each test's output reference
+# n:       number of selected tests
+# w:       the stdout writer the NDJSON lines are emitted through
+rec JsonCtx {
+    log_dir: *u8;
+    n:       u32;
+    w:       writer.Writer;
+}
+
+# build a human-readout renderer over caller-owned ctx storage
+# ---
+# hc:      the ctx cell the renderer borrows (must outlive the run)
+# level:   verbosity
+# mod_w:   module roll-up column width
+# label_w: `-v` label column width
+# runner:  resolved `--runner` launcher, or nil
+# log_dir: the capture-file directory
+# ret:     a Renderer bound to `hc`
+fun human_renderer(hc: *HumanCtx, level: u8, mod_w: usize, label_w: usize,
+                   runner: *u8, log_dir: *u8) Renderer {
+    hc.level   = level;
+    hc.mod_w   = mod_w;
+    hc.label_w = label_w;
+    hc.runner  = runner;
+    hc.log_dir = log_dir;
+    hc.n       = 0;
+    hc.first   = 0;
+    var r: Renderer;
+    r.ctx        = hc::ptr;
+    r.fn_start   = human_start;
+    r.fn_test    = human_test;
+    r.fn_summary = human_summary;
+    ret r;
+}
+
+# record the run size; the human readout writes nothing at start
+fun human_start(ctx: ptr, arts: *build.TestArtifact, n: u32) {
+    val hc: *HumanCtx = ctx::*HumanCtx;
+    hc.n     = n;
+    hc.first = 0;
+}
+
+# render one finalized outcome under the live human readout, reproducing the
+# module header, per-test line, and end-of-module roll-up as the cursor crosses
+fun human_test(ctx: ptr, outcomes: *Outcome, arts: *build.TestArtifact, idx: u32) {
+    val hc: *HumanCtx = ctx::*HumanCtx;
+    val mod_name: str = util.cstr_str(arts[idx].module);
+    if (hc.level > 0 && idx == hc.first) { print.printf("{}\n", mod_name); }
+    if (hc.level > 0) { print_verbose_test(?outcomes[idx], hc.label_w, hc.runner, hc.log_dir); }
+    val last_of_module: bool = idx + 1 == hc.n
+        || !str_equals(util.cstr_str(arts[idx + 1].module), mod_name);
+    if (last_of_module) {
+        if (hc.level == 0) { render_module_run(outcomes, hc.first, idx, mod_name, hc.mod_w, hc.runner, hc.log_dir); }
+        hc.first = idx + 1;
+    }
+}
+
+# render the closing human summary
+fun human_summary(ctx: ptr, outcomes: *Outcome, n: u32, passed: u32, failed: u32, wall: du.Duration) {
+    render_summary(outcomes, n, passed, failed, wall);
+}
+
+# build a JSON-stream renderer over caller-owned ctx storage
+# ---
+# jc:      the ctx cell the renderer borrows (must outlive the run)
+# log_dir: the capture-file directory, or nil when no tests will run
+# ret:     a Renderer bound to `jc`
+fun json_renderer(jc: *JsonCtx, log_dir: *u8) Renderer {
+    jc.log_dir = log_dir;
+    jc.n       = 0;
+    fs.get_writer(?fs.stdout, ?jc.w);
+    var r: Renderer;
+    r.ctx        = jc::ptr;
+    r.fn_start   = json_start;
+    r.fn_test    = json_test;
+    r.fn_summary = json_summary;
+    ret r;
+}
+
+# emit the `run_start` event
+fun json_start(ctx: ptr, arts: *build.TestArtifact, n: u32) {
+    val jc: *JsonCtx = ctx::*JsonCtx;
+    jc.n = n;
+    var o: json.Object;
+    json.object_begin(?jc.w, ?o);
+    json.field_i64(?o, "schema", SCHEMA_VERSION);
+    json.field_str(?o, "event", "run_start");
+    json.field_i64(?o, "tests", n::i64);
+    json.object_end(?o);
+}
+
+# emit one `test` event for a finalized outcome
+fun json_test(ctx: ptr, outcomes: *Outcome, arts: *build.TestArtifact, idx: u32) {
+    val jc:  *JsonCtx            = ctx::*JsonCtx;
+    val o0:  *Outcome            = ?outcomes[idx];
+    val art: *build.TestArtifact = ?arts[idx];
+    var o: json.Object;
+    json.object_begin(?jc.w, ?o);
+    json.field_i64(?o, "schema", SCHEMA_VERSION);
+    json.field_str(?o, "event", "test");
+    json.field_str(?o, "label", art.label);
+    json.field_str(?o, "module", art.module);
+    json.field_str(?o, "file", art.file);
+    json.field_i64(?o, "line", art.line::i64);
+    json.field_str(?o, "kind", kind_name(o0.kind));
+    json.field_i64(?o, "code", o0.code::i64);
+    json.field_i64(?o, "duration_ns", du.duration_nsec(o0.elapsed));
+    json.field_i64(?o, "index", art.idx::i64);
+    json.field_str(?o, "exe", art.exe);
+    # `output` references the on-disk capture file when the outcome kept one;
+    # a pass (unlinked) and a spawn failure (never created) have none.
+    var lp: [4096]u8;
+    if (has_capture(o0.kind) && log_path(?lp[0], 4096, jc.log_dir, art.idx)) {
+        json.field_str(?o, "output", ?lp[0]);
+    }
+    or {
+        json.field_str_or_null(?o, "output", nil);
+    }
+    json.object_end(?o);
+}
+
+# emit the `summary` event
+fun json_summary(ctx: ptr, outcomes: *Outcome, n: u32, passed: u32, failed: u32, wall: du.Duration) {
+    val jc: *JsonCtx = ctx::*JsonCtx;
+    var o: json.Object;
+    json.object_begin(?jc.w, ?o);
+    json.field_i64(?o, "schema", SCHEMA_VERSION);
+    json.field_str(?o, "event", "summary");
+    json.field_i64(?o, "passed", passed::i64);
+    json.field_i64(?o, "failed", failed::i64);
+    json.field_i64(?o, "total", n::i64);
+    json.field_i64(?o, "duration_ns", du.duration_nsec(wall));
+    json.object_end(?o);
+}
+
+# emit one `case` event describing a collected test in `--list` mode
+# ---
+# w:   the stdout writer to emit through
+# art: the collected test artifact
+fun emit_list_case(w: *writer.Writer, art: *build.TestArtifact) {
+    var o: json.Object;
+    json.object_begin(w, ?o);
+    json.field_i64(?o, "schema", SCHEMA_VERSION);
+    json.field_str(?o, "event", "case");
+    json.field_str(?o, "label", art.label);
+    json.field_str(?o, "module", art.module);
+    json.field_str(?o, "file", art.file);
+    json.field_i64(?o, "line", art.line::i64);
+    json.field_i64(?o, "index", art.idx::i64);
+    json.object_end(?o);
+}
+
+# the JSON `kind` token for an outcome kind
+# ---
+# kind: a KIND_* outcome
+# ret:  the stable token ("pass", "exit", "signal", "spawn", "other")
+fun kind_name(kind: u8) *u8 {
+    if (kind == KIND_PASS)   { ret "pass"; }
+    if (kind == KIND_EXIT)   { ret "exit"; }
+    if (kind == KIND_SIGNAL) { ret "signal"; }
+    if (kind == KIND_SPAWN)  { ret "spawn"; }
+    ret "other";
+}
+
+# whether a finalized outcome left its capture file on disk (so its output can
+# be referenced): a reaped non-passing outcome keeps its file, while a pass is
+# unlinked and a spawn failure never created one
+# ---
+# kind: a KIND_* outcome
+# ret:  true when the capture file persists
+fun has_capture(kind: u8) bool {
+    ret kind == KIND_EXIT || kind == KIND_SIGNAL || kind == KIND_OTHER;
 }
 
 # spawn one test child into a free slot, its stdout and stderr bound to its

--- a/src/cli/cmd/testing.mach
+++ b/src/cli/cmd/testing.mach
@@ -259,7 +259,7 @@ pub fun run(argc: usize, argv: **u8) i64 {
     if (sel_len == 0) {
         if (json_out) {
             var jc: JsonCtx;
-            var r:  Renderer = json_renderer(?jc, nil);
+            var r:  Renderer = json_renderer(?jc, ?a, nil);
             r.fn_start(r.ctx, nil, 0);
             r.fn_summary(r.ctx, nil, 0, 0, 0, 0);
         }
@@ -288,23 +288,24 @@ pub fun run(argc: usize, argv: **u8) i64 {
     }
     wipe_logs(?log_dir[0], tbr.len);
 
-    # column widths come from the selection, so live lines align on the first
-    # write with no second pass; clamping keeps one long name from blowing out
-    # the whole table.
-    val mod_w:   usize = module_col_width(selected, sel_len);
-    val label_w: usize = label_col_width(selected, sel_len);
-
     # the human readout and the JSON stream are sibling renderers over the same
-    # per-test event stream; only one is live per run.
+    # per-test event stream; only one is live per run. the human renderer needs
+    # the column widths (computed from the selection, so lines align on the first
+    # write) and the retained per-test output bytes; the JSON stream needs
+    # neither - it emits paths, not inline output - so both are skipped for it.
     var hc: HumanCtx;
     var jc: JsonCtx;
     var r:  Renderer;
-    if (json_out) { r = json_renderer(?jc, ?log_dir[0]); }
-    or           { r = human_renderer(?hc, level, mod_w, label_w, runner, ?log_dir[0]); }
+    if (json_out) { r = json_renderer(?jc, ?a, ?log_dir[0]); }
+    or {
+        val mod_w:   usize = module_col_width(selected, sel_len);
+        val label_w: usize = label_col_width(selected, sel_len);
+        r = human_renderer(?hc, level, mod_w, label_w, runner, ?log_dir[0]);
+    }
 
     val run_start: tm.Time = tm.monotonic();
     r.fn_start(r.ctx, selected, sel_len);
-    execute_and_render(?a, selected, sel_len, runner, outcomes, level, jobs, ?log_dir[0], ?r);
+    execute_and_render(?a, selected, sel_len, runner, outcomes, level, jobs, ?log_dir[0], !json_out, ?r);
     val wall: du.Duration = tm.time_sub(tm.monotonic(), run_start);
 
     val failed: u32 = count_failed(outcomes, sel_len);
@@ -332,26 +333,29 @@ rec Slot {
 }
 
 # run every selected test through a sliding window of child processes,
-# driving the renderer over the finalized outcomes in collection order
+# notifying the renderer as each outcome finalizes, in completion order
 #
 # Up to `jobs` children are in flight at once, each with stdout and stderr
 # bound to its capture file; a blocking wait-any reaps whichever exits first.
-# The render cursor trails completion in collection order, so the renderer sees
-# each outcome exactly once in test order regardless of completion order, and
-# the readout is deterministic.
+# The renderer's `fn_test` fires the moment an outcome finalizes - in
+# completion order, not collection order - so a live JSON consumer sees each
+# result as it lands and a slow test never head-of-line-blocks the stream. A
+# renderer that wants collection order (the human readout) buffers internally.
 # ---
-# a:        allocator retaining captured output
-# arts:     the selected test artifacts to run, in collection order
-# n:        number of artifacts in `arts`
-# runner:   resolved `--runner` launcher, or nil to exec the dispatcher directly
-# outcomes: caller-owned array (length n) filled in test order
-# level:    verbosity (0 roll-ups, 1 per-test lines, 2 also passing output)
-# jobs:     window width (1 serializes)
-# log_dir:  the capture-file directory
-# r:        the renderer notified as each outcome finalizes
+# a:          allocator retaining captured output
+# arts:       the selected test artifacts to run, in collection order
+# n:          number of artifacts in `arts`
+# runner:     resolved `--runner` launcher, or nil to exec the dispatcher directly
+# outcomes:   caller-owned array (length n) filled in test order
+# level:      verbosity (0 roll-ups, 1 per-test lines, 2 also passing output)
+# jobs:       window width (1 serializes)
+# log_dir:    the capture-file directory
+# want_bytes: retain each failing test's captured output in memory (the human
+#             readout inlines it; the JSON stream references the file instead)
+# r:          the renderer notified as each outcome finalizes
 fun execute_and_render(a: *A.Allocator, arts: *build.TestArtifact, n: u32, runner: *u8,
                        outcomes: *Outcome, level: u8, jobs: u32, log_dir: *u8,
-                       r: *Renderer) {
+                       want_bytes: bool, r: *Renderer) {
     var i: u32 = 0;
     for (i < n) { outcomes[i].kind = KIND_PENDING; i = i + 1; }
 
@@ -373,6 +377,8 @@ fun execute_and_render(a: *A.Allocator, arts: *build.TestArtifact, n: u32, runne
             outcomes[i].truncated = false;
             i = i + 1;
         }
+        i = 0;
+        for (i < n) { r.fn_test(r.ctx, outcomes, arts, i); i = i + 1; }
         ret;
     }
     val slots: *Slot = R.unwrap_ok[*Slot, str](res_slots);
@@ -382,7 +388,6 @@ fun execute_and_render(a: *A.Allocator, arts: *build.TestArtifact, n: u32, runne
     var spawned:  u32 = 0;
     var done:     u32 = 0;
     var inflight: u32 = 0;
-    var cursor:   u32 = 0;
 
     for (done < n) {
         # top the window back up
@@ -402,6 +407,7 @@ fun execute_and_render(a: *A.Allocator, arts: *build.TestArtifact, n: u32, runne
                 outcomes[idx].out_len   = 0;
                 outcomes[idx].truncated = false;
                 done = done + 1;
+                r.fn_test(r.ctx, outcomes, arts, idx);
             }
         }
 
@@ -416,17 +422,19 @@ fun execute_and_render(a: *A.Allocator, arts: *build.TestArtifact, n: u32, runne
                 var sx: u32 = 0;
                 for (sx < window) {
                     if (slots[sx].pid != 0) {
+                        val eidx: u32 = slots[sx].idx;
                         fs.close(?slots[sx].f);
-                        outcomes[slots[sx].idx].art       = slots[sx].art;
-                        outcomes[slots[sx].idx].kind      = KIND_OTHER;
-                        outcomes[slots[sx].idx].code      = 0;
-                        outcomes[slots[sx].idx].elapsed   = 0;
-                        outcomes[slots[sx].idx].out       = nil;
-                        outcomes[slots[sx].idx].out_len   = 0;
-                        outcomes[slots[sx].idx].truncated = false;
+                        outcomes[eidx].art       = slots[sx].art;
+                        outcomes[eidx].kind      = KIND_OTHER;
+                        outcomes[eidx].code      = 0;
+                        outcomes[eidx].elapsed   = 0;
+                        outcomes[eidx].out       = nil;
+                        outcomes[eidx].out_len   = 0;
+                        outcomes[eidx].truncated = false;
                         slots[sx].pid = 0;
                         inflight = inflight - 1;
                         done = done + 1;
+                        r.fn_test(r.ctx, outcomes, arts, eidx);
                     }
                     sx = sx + 1;
                 }
@@ -438,22 +446,17 @@ fun execute_and_render(a: *A.Allocator, arts: *build.TestArtifact, n: u32, runne
                 var sx: u32 = 0;
                 for (sx < window) {
                     if (slots[sx].pid == pid) {
-                        finalize_slot(a, ?slots[sx], st, outcomes, level, log_dir);
+                        val fidx: u32 = slots[sx].idx;
+                        finalize_slot(a, ?slots[sx], st, outcomes, level, want_bytes, log_dir);
                         slots[sx].pid = 0;
                         inflight = inflight - 1;
                         done = done + 1;
+                        r.fn_test(r.ctx, outcomes, arts, fidx);
                         brk;
                     }
                     sx = sx + 1;
                 }
             }
-        }
-
-        # advance the render cursor across everything finalized so far,
-        # handing each outcome to the renderer once in collection order
-        for (cursor < n && outcomes[cursor].kind != KIND_PENDING) {
-            r.fn_test(r.ctx, outcomes, arts, cursor);
-            cursor = cursor + 1;
         }
     }
 }
@@ -464,7 +467,7 @@ fun execute_and_render(a: *A.Allocator, arts: *build.TestArtifact, n: u32, runne
 # ---
 # ctx:        opaque renderer state handed to each callback
 # fn_start:   run start (selected artifacts, count)
-# fn_test:    one finalized outcome in collection order (outcomes, artifacts, index)
+# fn_test:    one finalized outcome, fired in completion order (outcomes, artifacts, index)
 # fn_summary: run end (outcomes, count, passed, failed, wall time)
 rec Renderer {
     ctx:        ptr;
@@ -474,6 +477,10 @@ rec Renderer {
 }
 
 # state the human readout carries across its per-test callbacks
+#
+# `fn_test` fires in completion order, so the readout keeps its own `cursor`
+# and renders collection order by advancing across contiguous finalized
+# outcomes from the front on each call.
 # ---
 # level:   verbosity (0 roll-ups, 1 per-test lines, 2 also passing output)
 # mod_w:   module roll-up column width
@@ -481,6 +488,7 @@ rec Renderer {
 # runner:  resolved `--runner` launcher, or nil
 # log_dir: the capture-file directory
 # n:       number of selected tests
+# cursor:  index of the next outcome to render in collection order
 # first:   index of the current module's first outcome
 rec HumanCtx {
     level:   u8;
@@ -489,15 +497,18 @@ rec HumanCtx {
     runner:  *u8;
     log_dir: *u8;
     n:       u32;
+    cursor:  u32;
     first:   u32;
 }
 
 # state the JSON stream carries across its per-test callbacks
 # ---
+# a:       allocator for each test's output-reference path
 # log_dir: the capture-file directory, source of each test's output reference
 # n:       number of selected tests
 # w:       the stdout writer the NDJSON lines are emitted through
 rec JsonCtx {
+    a:       *A.Allocator;
     log_dir: *u8;
     n:       u32;
     w:       writer.Writer;
@@ -520,6 +531,7 @@ fun human_renderer(hc: *HumanCtx, level: u8, mod_w: usize, label_w: usize,
     hc.runner  = runner;
     hc.log_dir = log_dir;
     hc.n       = 0;
+    hc.cursor  = 0;
     hc.first   = 0;
     var r: Renderer;
     r.ctx        = hc::ptr;
@@ -530,28 +542,54 @@ fun human_renderer(hc: *HumanCtx, level: u8, mod_w: usize, label_w: usize,
 }
 
 # record the run size; the human readout writes nothing at start
+# ---
+# ctx:  the HumanCtx cell
+# arts: the selected artifacts (unused; the cursor reads them per-test)
+# n:    number of selected tests
 fun human_start(ctx: ptr, arts: *build.TestArtifact, n: u32) {
     val hc: *HumanCtx = ctx::*HumanCtx;
-    hc.n     = n;
-    hc.first = 0;
+    hc.n      = n;
+    hc.cursor = 0;
+    hc.first  = 0;
 }
 
-# render one finalized outcome under the live human readout, reproducing the
-# module header, per-test line, and end-of-module roll-up as the cursor crosses
+# advance the human readout across every outcome that has finalized since the
+# last call, rendering the module header, per-test line, and end-of-module
+# roll-up in collection order
+#
+# `idx` (the just-finalized outcome, in completion order) is not read directly:
+# the cursor renders strictly in collection order, crossing an outcome only once
+# every earlier one has also finalized, so the readout stays deterministic.
+# ---
+# ctx:      the HumanCtx cell
+# outcomes: the run outcomes, finalized in place
+# arts:     the selected artifacts, in collection order
+# idx:      the outcome that just finalized (drives the cursor forward)
 fun human_test(ctx: ptr, outcomes: *Outcome, arts: *build.TestArtifact, idx: u32) {
     val hc: *HumanCtx = ctx::*HumanCtx;
-    val mod_name: str = util.cstr_str(arts[idx].module);
-    if (hc.level > 0 && idx == hc.first) { print.printf("{}\n", mod_name); }
-    if (hc.level > 0) { print_verbose_test(?outcomes[idx], hc.label_w, hc.runner, hc.log_dir); }
-    val last_of_module: bool = idx + 1 == hc.n
-        || !str_equals(util.cstr_str(arts[idx + 1].module), mod_name);
-    if (last_of_module) {
-        if (hc.level == 0) { render_module_run(outcomes, hc.first, idx, mod_name, hc.mod_w, hc.runner, hc.log_dir); }
-        hc.first = idx + 1;
+    for (hc.cursor < hc.n && outcomes[hc.cursor].kind != KIND_PENDING) {
+        val c: u32 = hc.cursor;
+        val mod_name: str = util.cstr_str(arts[c].module);
+        if (hc.level > 0 && c == hc.first) { print.printf("{}\n", mod_name); }
+        if (hc.level > 0) { print_verbose_test(?outcomes[c], hc.label_w, hc.runner, hc.log_dir); }
+        val last_of_module: bool = c + 1 == hc.n
+            || !str_equals(util.cstr_str(arts[c + 1].module), mod_name);
+        if (last_of_module) {
+            if (hc.level == 0) { render_module_run(outcomes, hc.first, c, mod_name, hc.mod_w, hc.runner, hc.log_dir); }
+            hc.first = c + 1;
+        }
+        hc.cursor = c + 1;
     }
 }
 
 # render the closing human summary
+# ---
+# ctx:      the HumanCtx cell (unused)
+# outcomes: the run outcomes in test order
+# n:        number of outcomes
+# passed:   number of passing tests
+# failed:   number of failing tests
+# wall:     the run's wall time
 fun human_summary(ctx: ptr, outcomes: *Outcome, n: u32, passed: u32, failed: u32, wall: du.Duration) {
     render_summary(outcomes, n, passed, failed, wall);
 }
@@ -559,9 +597,11 @@ fun human_summary(ctx: ptr, outcomes: *Outcome, n: u32, passed: u32, failed: u32
 # build a JSON-stream renderer over caller-owned ctx storage
 # ---
 # jc:      the ctx cell the renderer borrows (must outlive the run)
+# a:       allocator for output-reference paths
 # log_dir: the capture-file directory, or nil when no tests will run
 # ret:     a Renderer bound to `jc`
-fun json_renderer(jc: *JsonCtx, log_dir: *u8) Renderer {
+fun json_renderer(jc: *JsonCtx, a: *A.Allocator, log_dir: *u8) Renderer {
+    jc.a       = a;
     jc.log_dir = log_dir;
     jc.n       = 0;
     fs.get_writer(?fs.stdout, ?jc.w);
@@ -573,27 +613,43 @@ fun json_renderer(jc: *JsonCtx, log_dir: *u8) Renderer {
     ret r;
 }
 
+# open a JSON event object and write its shared `schema` and `event` members
+# ---
+# w:     the writer to emit through
+# o:     the object state to open
+# event: the event discriminator token
+fun json_event_begin(w: *writer.Writer, o: *json.Object, event: *u8) {
+    json.object_begin(w, o);
+    json.field_i64(o, "schema", SCHEMA_VERSION);
+    json.field_str(o, "event", event);
+}
+
 # emit the `run_start` event
+# ---
+# ctx:  the JsonCtx cell
+# arts: the selected artifacts (unused)
+# n:    number of selected tests
 fun json_start(ctx: ptr, arts: *build.TestArtifact, n: u32) {
     val jc: *JsonCtx = ctx::*JsonCtx;
     jc.n = n;
     var o: json.Object;
-    json.object_begin(?jc.w, ?o);
-    json.field_i64(?o, "schema", SCHEMA_VERSION);
-    json.field_str(?o, "event", "run_start");
+    json_event_begin(?jc.w, ?o, "run_start");
     json.field_i64(?o, "tests", n::i64);
     json.object_end(?o);
 }
 
 # emit one `test` event for a finalized outcome
+# ---
+# ctx:      the JsonCtx cell
+# outcomes: the run outcomes, finalized in place
+# arts:     the selected artifacts, in collection order
+# idx:      the outcome to emit
 fun json_test(ctx: ptr, outcomes: *Outcome, arts: *build.TestArtifact, idx: u32) {
     val jc:  *JsonCtx            = ctx::*JsonCtx;
     val o0:  *Outcome            = ?outcomes[idx];
     val art: *build.TestArtifact = ?arts[idx];
     var o: json.Object;
-    json.object_begin(?jc.w, ?o);
-    json.field_i64(?o, "schema", SCHEMA_VERSION);
-    json.field_str(?o, "event", "test");
+    json_event_begin(?jc.w, ?o, "test");
     json.field_str(?o, "label", art.label);
     json.field_str(?o, "module", art.module);
     json.field_str(?o, "file", art.file);
@@ -603,11 +659,10 @@ fun json_test(ctx: ptr, outcomes: *Outcome, arts: *build.TestArtifact, idx: u32)
     json.field_i64(?o, "duration_ns", du.duration_nsec(o0.elapsed));
     json.field_i64(?o, "index", art.idx::i64);
     json.field_str(?o, "exe", art.exe);
-    # `output` references the on-disk capture file when the outcome kept one;
-    # a pass (unlinked) and a spawn failure (never created) have none.
-    var lp: [4096]u8;
-    if (has_capture(o0.kind) && log_path(?lp[0], 4096, jc.log_dir, art.idx)) {
-        json.field_str(?o, "output", ?lp[0]);
+    # `output` references the on-disk capture file when the outcome kept one; a
+    # pass (unlinked) and a spawn failure (never created) have none.
+    if (has_capture(o0.kind)) {
+        json.field_str_or_null(?o, "output", json_output_ref(jc, art.idx));
     }
     or {
         json.field_str_or_null(?o, "output", nil);
@@ -616,17 +671,42 @@ fun json_test(ctx: ptr, outcomes: *Outcome, arts: *build.TestArtifact, idx: u32)
 }
 
 # emit the `summary` event
+# ---
+# ctx:      the JsonCtx cell
+# outcomes: the run outcomes (unused)
+# n:        number of outcomes
+# passed:   number of passing tests
+# failed:   number of failing tests
+# wall:     the run's wall time
 fun json_summary(ctx: ptr, outcomes: *Outcome, n: u32, passed: u32, failed: u32, wall: du.Duration) {
     val jc: *JsonCtx = ctx::*JsonCtx;
     var o: json.Object;
-    json.object_begin(?jc.w, ?o);
-    json.field_i64(?o, "schema", SCHEMA_VERSION);
-    json.field_str(?o, "event", "summary");
+    json_event_begin(?jc.w, ?o, "summary");
     json.field_i64(?o, "passed", passed::i64);
     json.field_i64(?o, "failed", failed::i64);
     json.field_i64(?o, "total", n::i64);
     json.field_i64(?o, "duration_ns", du.duration_nsec(wall));
     json.object_end(?o);
+}
+
+# compose the `<log_dir>/<idx>.log` capture path into a freshly allocated buffer
+#
+# Allocating exactly to fit means the reference can never overflow a fixed
+# buffer; the result is owned by the run allocator. nil only on allocation
+# failure (the event then carries `output: null`).
+# ---
+# jc:  the JSON stream state (allocator + capture directory)
+# idx: the test's dispatch index
+# ret: the null-terminated path, or nil on allocation failure
+fun json_output_ref(jc: *JsonCtx, idx: u32) *u8 {
+    # the separator, up to ten index digits, `.log`, and the terminator fit in
+    # 32 bytes past the directory length.
+    val cap: usize = util.cstr_len(jc.log_dir) + 32;
+    val res: R.Result[*u8, str] = A.allocate[u8](jc.a, cap);
+    if (R.is_err[*u8, str](res)) { ret nil; }
+    val buf: *u8 = R.unwrap_ok[*u8, str](res);
+    log_path(buf, cap, jc.log_dir, idx);
+    ret buf;
 }
 
 # emit one `case` event describing a collected test in `--list` mode
@@ -635,9 +715,7 @@ fun json_summary(ctx: ptr, outcomes: *Outcome, n: u32, passed: u32, failed: u32,
 # art: the collected test artifact
 fun emit_list_case(w: *writer.Writer, art: *build.TestArtifact) {
     var o: json.Object;
-    json.object_begin(w, ?o);
-    json.field_i64(?o, "schema", SCHEMA_VERSION);
-    json.field_str(?o, "event", "case");
+    json_event_begin(w, ?o, "case");
     json.field_str(?o, "label", art.label);
     json.field_str(?o, "module", art.module);
     json.field_str(?o, "file", art.file);
@@ -732,18 +810,21 @@ fun spawn_one(slots: *Slot, window: u32, art: *build.TestArtifact, idx: u32,
 
 # turn a reaped child's status into its final Outcome
 #
-# Closes the capture file, classifies the wait status, retains the captured
-# bytes where the readout needs them (always on failure, on pass under `-vv`),
-# and unlinks a passing test's file so only failures persist in `log/`.
+# Closes the capture file, classifies the wait status, and unlinks a passing
+# test's file so only failures persist in `log/`. When `want_bytes` is set the
+# readout wants the captured output inline, so it is retained (always on
+# failure, on pass under `-vv`); the JSON stream clears it and references the
+# on-disk file instead, so nothing is read into memory.
 # ---
-# a:        allocator retaining captured output
-# slot:     the reaped child's slot
-# st:       the wait status
-# outcomes: the outcomes array to finalize into
-# level:    verbosity (2 retains passing output)
-# log_dir:  the capture-file directory
+# a:          allocator retaining captured output
+# slot:       the reaped child's slot
+# st:         the wait status
+# outcomes:   the outcomes array to finalize into
+# level:      verbosity (2 retains passing output)
+# want_bytes: retain the captured output in memory for the readout
+# log_dir:    the capture-file directory
 fun finalize_slot(a: *A.Allocator, slot: *Slot, st: exec.ExitStatus,
-                  outcomes: *Outcome, level: u8, log_dir: *u8) {
+                  outcomes: *Outcome, level: u8, want_bytes: bool, log_dir: *u8) {
     var o: Outcome;
     o.art       = slot.art;
     o.code      = 0;
@@ -769,11 +850,11 @@ fun finalize_slot(a: *A.Allocator, slot: *Slot, st: exec.ExitStatus,
     var lp: [4096]u8;
     if (log_path(?lp[0], 4096, log_dir, slot.art.idx)) {
         if (o.kind == KIND_PASS) {
-            if (level >= 2) { retain_from_file(a, ?o, util.cstr_str(?lp[0])); }
+            if (want_bytes && level >= 2) { retain_from_file(a, ?o, util.cstr_str(?lp[0])); }
             fs.unlink(util.cstr_str(?lp[0]));
         }
         or {
-            retain_from_file(a, ?o, util.cstr_str(?lp[0]));
+            if (want_bytes) { retain_from_file(a, ?o, util.cstr_str(?lp[0])); }
         }
     }
 

--- a/src/cli/json.mach
+++ b/src/cli/json.mach
@@ -1,0 +1,362 @@
+# streaming JSON object emitter for one-object-per-line (NDJSON) output.
+#
+# emits flat JSON objects through a caller-owned writer with ASCII-only string
+# escaping, so a machine consumer reads a stable, valid stream regardless of the
+# bytes a test label or path carries. string values are escaped per RFC 8259;
+# every byte >= 0x80 is UTF-8 decoded and emitted as a `\uXXXX` escape (astral
+# code points as a surrogate pair), so every emitted byte is printable ASCII on
+# every platform with no platform branches. invalid UTF-8 is emitted as the
+# U+FFFD replacement character. numbers are integers only.
+
+use std.types.bool.bool;
+use std.types.bool.true;
+use std.types.bool.false;
+use std.types.size.usize;
+use std.types.string.str;
+
+use R:      std.types.result;
+use writer: std.io.writer;
+use fmt:    std.format;
+
+# an open JSON object, tracking the comma boundary between its members
+# ---
+# w:     the writer the object is emitted through (borrowed)
+# first: no member has been emitted into the object yet
+pub rec Object {
+    w:     *writer.Writer;
+    first: bool;
+}
+
+# begin a JSON object, writing `{` and arming the first-member state
+# ---
+# w: the writer to emit through (must outlive the object)
+# o: the object state to initialise
+pub fun object_begin(w: *writer.Writer, o: *Object) {
+    o.w     = w;
+    o.first = true;
+    fmt.write_byte(w, '{');
+}
+
+# end a JSON object, writing `}` and the newline that terminates the NDJSON line
+# ---
+# o: the object to close
+pub fun object_end(o: *Object) {
+    fmt.write_byte(o.w, '}');
+    fmt.write_newline(o.w);
+}
+
+# emit a string-valued member (the value quoted and ASCII-escaped)
+# ---
+# o:   the open object
+# key: the member key (ASCII, emitted verbatim between quotes)
+# v:   the null-terminated value, escaped; nil emits an empty string
+pub fun field_str(o: *Object, key: *u8, v: *u8) {
+    member(o, key);
+    write_json_string(o.w, v);
+}
+
+# emit a string-or-null member: the escaped value, or JSON `null` when `v` is nil
+# ---
+# o:   the open object
+# key: the member key
+# v:   the null-terminated value, or nil for a JSON null
+pub fun field_str_or_null(o: *Object, key: *u8, v: *u8) {
+    member(o, key);
+    if (v == nil) {
+        fmt.write_str(o.w, "null");
+        ret;
+    }
+    write_json_string(o.w, v);
+}
+
+# emit an integer-valued member
+# ---
+# o:   the open object
+# key: the member key
+# v:   the integer value
+pub fun field_i64(o: *Object, key: *u8, v: i64) {
+    member(o, key);
+    fmt.write_i64(o.w, v);
+}
+
+# emit a boolean-valued member
+# ---
+# o:   the open object
+# key: the member key
+# v:   the boolean value
+pub fun field_bool(o: *Object, key: *u8, v: bool) {
+    member(o, key);
+    if (v) { fmt.write_str(o.w, "true"); }
+    or     { fmt.write_str(o.w, "false"); }
+}
+
+# write a JSON string literal: the value quoted, every byte escaped to printable
+# ASCII
+# ---
+# w: the writer to emit through
+# s: the null-terminated value, or nil for an empty string
+pub fun write_json_string(w: *writer.Writer, s: *u8) {
+    fmt.write_byte(w, '"');
+    if (s != nil) {
+        var i: usize = 0;
+        for (s[i] != 0) { i = write_escaped(w, s, i); }
+    }
+    fmt.write_byte(w, '"');
+}
+
+# write the key/colon lead-in of a member, prefixing a comma after the first
+# ---
+# o:   the open object
+# key: the member key (ASCII, emitted verbatim)
+fun member(o: *Object, key: *u8) {
+    if (!o.first) { fmt.write_byte(o.w, ','); }
+    o.first = false;
+    fmt.write_byte(o.w, '"');
+    fmt.write_str(o.w, key::str);
+    fmt.write_byte(o.w, '"');
+    fmt.write_byte(o.w, ':');
+}
+
+# escape one code unit of `s` starting at `i`, returning the next byte index
+#
+# The mandatory JSON escapes (`"`, `\`, and the C0 controls) are emitted as short
+# or `\u00XX` escapes; printable ASCII passes through verbatim; a byte >= 0x80
+# begins a UTF-8 sequence decoded to a `\uXXXX` escape.
+# ---
+# w: the writer to emit through
+# s: the null-terminated source
+# i: the byte index to escape
+# ret: the index of the next byte to process
+fun write_escaped(w: *writer.Writer, s: *u8, i: usize) usize {
+    val c: u8 = s[i];
+    if (c == '"')  { fmt.write_str(w, "\\\""); ret i + 1; }
+    if (c == '\\') { fmt.write_str(w, "\\\\"); ret i + 1; }
+    if (c == 8)    { fmt.write_str(w, "\\b");  ret i + 1; }
+    if (c == '\t') { fmt.write_str(w, "\\t");  ret i + 1; }
+    if (c == '\n') { fmt.write_str(w, "\\n");  ret i + 1; }
+    if (c == 12)   { fmt.write_str(w, "\\f");  ret i + 1; }
+    if (c == '\r') { fmt.write_str(w, "\\r");  ret i + 1; }
+    if (c < 0x20)  { write_u_hex(w, c::u32);   ret i + 1; }
+    if (c < 0x80)  { fmt.write_byte(w, c);     ret i + 1; }
+    ret write_utf8_escape(w, s, i);
+}
+
+# decode the UTF-8 sequence at `i` and emit it as a `\uXXXX` escape, returning
+# the index past the sequence; a malformed sequence emits the U+FFFD replacement
+# escape and consumes one byte
+# ---
+# w: the writer to emit through
+# s: the null-terminated source
+# i: the index of the sequence's lead byte (>= 0x80)
+# ret: the index of the next byte to process
+fun write_utf8_escape(w: *writer.Writer, s: *u8, i: usize) usize {
+    val b0: u8 = s[i];
+    var cp:   u32   = 0;
+    var need: usize = 0;
+    if (b0 >= 0xF0) { cp = (b0 & 0x07)::u32; need = 3; }
+    or (b0 >= 0xE0) { cp = (b0 & 0x0F)::u32; need = 2; }
+    or (b0 >= 0xC0) { cp = (b0 & 0x1F)::u32; need = 1; }
+    or {
+        write_u_hex(w, 0xFFFD);
+        ret i + 1;
+    }
+
+    var k: usize = 0;
+    var j: usize = i + 1;
+    for (k < need) {
+        val cb: u8 = s[j];
+        if (cb == 0 || (cb & 0xC0) != 0x80) {
+            write_u_hex(w, 0xFFFD);
+            ret i + 1;
+        }
+        cp = (cp << 6) | (cb & 0x3F)::u32;
+        j  = j + 1;
+        k  = k + 1;
+    }
+
+    write_codepoint(w, cp);
+    ret i + 1 + need;
+}
+
+# emit a code point as a `\uXXXX` escape, or a surrogate pair when astral
+# ---
+# w:  the writer to emit through
+# cp: the Unicode code point
+fun write_codepoint(w: *writer.Writer, cp: u32) {
+    if (cp <= 0xFFFF) {
+        write_u_hex(w, cp);
+        ret;
+    }
+    val v:  u32 = cp - 0x10000;
+    val hi: u32 = 0xD800 + (v >> 10);
+    val lo: u32 = 0xDC00 + (v & 0x3FF);
+    write_u_hex(w, hi);
+    write_u_hex(w, lo);
+}
+
+# emit a `\u` escape for a 16-bit value
+# ---
+# w:    the writer to emit through
+# code: the 16-bit value (only the low 16 bits are used)
+fun write_u_hex(w: *writer.Writer, code: u32) {
+    fmt.write_str(w, "\\u");
+    fmt.write_byte(w, hex_digit((code >> 12) & 0xF));
+    fmt.write_byte(w, hex_digit((code >> 8) & 0xF));
+    fmt.write_byte(w, hex_digit((code >> 4) & 0xF));
+    fmt.write_byte(w, hex_digit(code & 0xF));
+}
+
+# map a nibble (0-15) to its lowercase hexadecimal ASCII digit
+# ---
+# n:   the nibble value
+# ret: the ASCII digit byte
+fun hex_digit(n: u32) u8 {
+    if (n < 10) { ret n::u8 + '0'; }
+    ret n::u8 - 10 + 'a';
+}
+
+# a fixed-capacity byte sink used to capture emitter output in tests.
+# ---
+# buf: destination buffer
+# cap: buffer capacity
+# len: bytes written so far
+rec TestSink {
+    buf: *u8;
+    cap: usize;
+    len: usize;
+}
+
+# writer callback appending to a TestSink, dropping bytes past its capacity.
+fun test_sink_write(ctx: ptr, buf: *u8, len: usize) R.Result[usize, str] {
+    val s: *TestSink = ctx::*TestSink;
+    var i: usize = 0;
+    for (i < len && s.len < s.cap) {
+        s.buf[s.len] = buf[i];
+        s.len = s.len + 1;
+        i = i + 1;
+    }
+    ret R.ok[usize, str](len);
+}
+
+# whether the sink's captured bytes equal the first `wlen` bytes of `want`.
+fun sink_is(s: *TestSink, want: *u8, wlen: usize) bool {
+    if (s.len != wlen) { ret false; }
+    var i: usize = 0;
+    for (i < wlen) {
+        if (s.buf[i] != want[i]) { ret false; }
+        i = i + 1;
+    }
+    ret true;
+}
+
+# wire a Writer over a TestSink backed by `buf`.
+fun test_writer(w: *writer.Writer, s: *TestSink, buf: *u8, cap: usize) {
+    s.buf = buf;
+    s.cap = cap;
+    s.len = 0;
+    w.ctx      = s::ptr;
+    w.fn_write = test_sink_write;
+}
+
+# printable ASCII passes through verbatim, wrapped in quotes.
+test "mach.cli.json.write_json_string:plain_ascii" {
+    var out:  [64]u8;
+    var sink: TestSink;
+    var w:    writer.Writer;
+    test_writer(?w, ?sink, ?out[0], 64);
+
+    write_json_string(?w, "mach.cli.json");
+
+    var want: [15]u8;
+    want[0] = '"';
+    val src: *u8 = "mach.cli.json";
+    var i: usize = 0;
+    for (src[i] != 0) { want[i + 1] = src[i]; i = i + 1; }
+    want[i + 1] = '"';
+    if (!sink_is(?sink, ?want[0], i + 2)) { ret 1; }
+    ret 0;
+}
+
+# quotes and backslashes get their short escapes.
+test "mach.cli.json.write_json_string:quote_and_backslash" {
+    var out:  [32]u8;
+    var sink: TestSink;
+    var w:    writer.Writer;
+    test_writer(?w, ?sink, ?out[0], 32);
+
+    var input: [5]u8;
+    input[0] = 'x'; input[1] = '"'; input[2] = '\\'; input[3] = 'y'; input[4] = 0;
+    write_json_string(?w, ?input[0]);
+
+    var want: [8]u8;
+    want[0] = '"'; want[1] = 'x'; want[2] = '\\'; want[3] = '"';
+    want[4] = '\\'; want[5] = '\\'; want[6] = 'y'; want[7] = '"';
+    if (!sink_is(?sink, ?want[0], 8)) { ret 1; }
+    ret 0;
+}
+
+# a newline is the short `\n` escape; a bare control byte is a `\u00XX` escape.
+test "mach.cli.json.write_json_string:control_escapes" {
+    var out:  [32]u8;
+    var sink: TestSink;
+    var w:    writer.Writer;
+    test_writer(?w, ?sink, ?out[0], 32);
+
+    var nl: [2]u8;
+    nl[0] = 10; nl[1] = 0;
+    write_json_string(?w, ?nl[0]);
+    var want_nl: [4]u8;
+    want_nl[0] = '"'; want_nl[1] = '\\'; want_nl[2] = 'n'; want_nl[3] = '"';
+    if (!sink_is(?sink, ?want_nl[0], 4)) { ret 1; }
+
+    test_writer(?w, ?sink, ?out[0], 32);
+    var c1: [2]u8;
+    c1[0] = 1; c1[1] = 0;
+    write_json_string(?w, ?c1[0]);
+    var want_c1: [8]u8;
+    want_c1[0] = '"'; want_c1[1] = '\\'; want_c1[2] = 'u'; want_c1[3] = '0';
+    want_c1[4] = '0'; want_c1[5] = '0'; want_c1[6] = '1'; want_c1[7] = '"';
+    if (!sink_is(?sink, ?want_c1[0], 8)) { ret 1; }
+    ret 0;
+}
+
+# a two-byte UTF-8 sequence is decoded to a single `\uXXXX` escape.
+test "mach.cli.json.write_json_string:utf8_bmp" {
+    var out:  [32]u8;
+    var sink: TestSink;
+    var w:    writer.Writer;
+    test_writer(?w, ?sink, ?out[0], 32);
+
+    # U+00E9 (e-acute) encodes as 0xC3 0xA9.
+    var input: [3]u8;
+    input[0] = 0xC3; input[1] = 0xA9; input[2] = 0;
+    write_json_string(?w, ?input[0]);
+
+    var want: [8]u8;
+    want[0] = '"'; want[1] = '\\'; want[2] = 'u'; want[3] = '0';
+    want[4] = '0'; want[5] = 'e'; want[6] = '9'; want[7] = '"';
+    if (!sink_is(?sink, ?want[0], 8)) { ret 1; }
+    ret 0;
+}
+
+# an astral code point is decoded to a UTF-16 surrogate pair.
+test "mach.cli.json.write_json_string:utf8_astral" {
+    var out:  [32]u8;
+    var sink: TestSink;
+    var w:    writer.Writer;
+    test_writer(?w, ?sink, ?out[0], 32);
+
+    # U+1F600 (grinning face) encodes as 0xF0 0x9F 0x98 0x80.
+    var input: [5]u8;
+    input[0] = 0xF0; input[1] = 0x9F; input[2] = 0x98; input[3] = 0x80; input[4] = 0;
+    write_json_string(?w, ?input[0]);
+
+    var want: [14]u8;
+    want[0]  = '"'; want[1]  = '\\'; want[2]  = 'u'; want[3]  = 'd';
+    want[4]  = '8'; want[5]  = '3'; want[6]  = 'd'; want[7]  = '\\';
+    want[8]  = 'u'; want[9]  = 'd'; want[10] = 'e'; want[11] = '0';
+    want[12] = '0'; want[13] = '"';
+    if (!sink_is(?sink, ?want[0], 14)) { ret 1; }
+    ret 0;
+}
+

--- a/src/cli/json.mach
+++ b/src/cli/json.mach
@@ -142,8 +142,15 @@ fun write_escaped(w: *writer.Writer, s: *u8, i: usize) usize {
 }
 
 # decode the UTF-8 sequence at `i` and emit it as a `\uXXXX` escape, returning
-# the index past the sequence; a malformed sequence emits the U+FFFD replacement
-# escape and consumes one byte
+# the index past the sequence
+#
+# Full RFC 3629 validation: the lead byte fixes the length and the first
+# continuation byte's allowed range, which together reject overlong encodings
+# (`0xC0`/`0xC1`, `0xE0 80-9F`, `0xF0 80-8F`), the UTF-16 surrogate range
+# (`0xED A0-BF`), and code points above U+10FFFF (`0xF4 90-BF`); invalid lead
+# bytes (`0x80-0xBF`, `0xF5-0xFF`) and any bad or truncated continuation are
+# rejected too. A rejected sequence emits the U+FFFD replacement escape and
+# consumes exactly one byte, so the scan resynchronizes on the next byte.
 # ---
 # w: the writer to emit through
 # s: the null-terminated source
@@ -151,21 +158,36 @@ fun write_escaped(w: *writer.Writer, s: *u8, i: usize) usize {
 # ret: the index of the next byte to process
 fun write_utf8_escape(w: *writer.Writer, s: *u8, i: usize) usize {
     val b0: u8 = s[i];
-    var cp:   u32   = 0;
-    var need: usize = 0;
-    if (b0 >= 0xF0) { cp = (b0 & 0x07)::u32; need = 3; }
-    or (b0 >= 0xE0) { cp = (b0 & 0x0F)::u32; need = 2; }
-    or (b0 >= 0xC0) { cp = (b0 & 0x1F)::u32; need = 1; }
+
+    # length, plus the tightened [lo, hi] range for the first continuation byte
+    # that pins overlong / surrogate / out-of-range sequences to their lead.
+    var len: usize = 0;
+    var lo:  u8    = 0x80;
+    var hi:  u8    = 0xBF;
+    var cp:  u32   = 0;
+    if (b0 >= 0xC2 && b0 <= 0xDF) { len = 2; cp = (b0 & 0x1F)::u32; }
+    or (b0 == 0xE0)               { len = 3; lo = 0xA0; cp = (b0 & 0x0F)::u32; }
+    or (b0 >= 0xE1 && b0 <= 0xEC) { len = 3; cp = (b0 & 0x0F)::u32; }
+    or (b0 == 0xED)               { len = 3; hi = 0x9F; cp = (b0 & 0x0F)::u32; }
+    or (b0 >= 0xEE && b0 <= 0xEF) { len = 3; cp = (b0 & 0x0F)::u32; }
+    or (b0 == 0xF0)               { len = 4; lo = 0x90; cp = (b0 & 0x07)::u32; }
+    or (b0 >= 0xF1 && b0 <= 0xF3) { len = 4; cp = (b0 & 0x07)::u32; }
+    or (b0 == 0xF4)               { len = 4; hi = 0x8F; cp = (b0 & 0x07)::u32; }
     or {
         write_u_hex(w, 0xFFFD);
         ret i + 1;
     }
 
-    var k: usize = 0;
+    var k: usize = 1;
     var j: usize = i + 1;
-    for (k < need) {
+    for (k < len) {
         val cb: u8 = s[j];
-        if (cb == 0 || (cb & 0xC0) != 0x80) {
+        # the first continuation byte carries the tightened range; the rest span
+        # the full 0x80-0xBF. a NUL (truncated sequence) fails the lower bound.
+        var clo: u8 = 0x80;
+        var chi: u8 = 0xBF;
+        if (k == 1) { clo = lo; chi = hi; }
+        if (cb < clo || cb > chi) {
             write_u_hex(w, 0xFFFD);
             ret i + 1;
         }
@@ -175,13 +197,17 @@ fun write_utf8_escape(w: *writer.Writer, s: *u8, i: usize) usize {
     }
 
     write_codepoint(w, cp);
-    ret i + 1 + need;
+    ret i + len;
 }
 
-# emit a code point as a `\uXXXX` escape, or a surrogate pair when astral
+# emit a valid Unicode scalar as a `\uXXXX` escape, or a surrogate pair when
+# astral
+#
+# `cp` is a validated scalar (U+0000-U+10FFFF, never a surrogate), so the astral
+# branch always yields a well-formed high/low surrogate pair.
 # ---
 # w:  the writer to emit through
-# cp: the Unicode code point
+# cp: the Unicode scalar value
 fun write_codepoint(w: *writer.Writer, cp: u32) {
     if (cp <= 0xFFFF) {
         write_u_hex(w, cp);
@@ -357,6 +383,101 @@ test "mach.cli.json.write_json_string:utf8_astral" {
     want[8]  = 'u'; want[9]  = 'd'; want[10] = 'e'; want[11] = '0';
     want[12] = '0'; want[13] = '"';
     if (!sink_is(?sink, ?want[0], 14)) { ret 1; }
+    ret 0;
+}
+
+# whether the sink holds exactly `count` U+FFFD replacement escapes, quoted.
+#
+# A pure run of `�` proves the decoder rejected the input entirely: any
+# accepted (overlong, surrogate, or out-of-range) decode would emit different
+# bytes, and a lone surrogate would emit `\ud...` rather than `�`.
+fun sink_is_replacements(s: *TestSink, count: usize) bool {
+    if (s.len != count * 6 + 2) { ret false; }
+    if (s.buf[0] != '"' || s.buf[s.len - 1] != '"') { ret false; }
+    var k: usize = 0;
+    for (k < count) {
+        val b: usize = 1 + k * 6;
+        if (s.buf[b] != '\\' || s.buf[b + 1] != 'u') { ret false; }
+        if (s.buf[b + 2] != 'f' || s.buf[b + 3] != 'f') { ret false; }
+        if (s.buf[b + 4] != 'f' || s.buf[b + 5] != 'd') { ret false; }
+        k = k + 1;
+    }
+    ret true;
+}
+
+# a UTF-16 surrogate encoded as UTF-8 (CESU-8) is rejected, never emitted as a
+# lone `\ud...` escape.
+test "mach.cli.json.write_json_string:utf8_surrogate_rejected" {
+    var out:  [64]u8;
+    var sink: TestSink;
+    var w:    writer.Writer;
+    test_writer(?w, ?sink, ?out[0], 64);
+
+    # U+D800 CESU-8 encodes as 0xED 0xA0 0x80; each byte resyncs to a replacement.
+    var input: [4]u8;
+    input[0] = 0xED; input[1] = 0xA0; input[2] = 0x80; input[3] = 0;
+    write_json_string(?w, ?input[0]);
+    if (!sink_is_replacements(?sink, 3)) { ret 1; }
+    ret 0;
+}
+
+# an overlong 2-byte encoding is rejected.
+test "mach.cli.json.write_json_string:utf8_overlong_rejected" {
+    var out:  [64]u8;
+    var sink: TestSink;
+    var w:    writer.Writer;
+    test_writer(?w, ?sink, ?out[0], 64);
+
+    # 0xC0 0x80 is an overlong NUL; the lead and the stray byte each resync.
+    var input: [3]u8;
+    input[0] = 0xC0; input[1] = 0x80; input[2] = 0;
+    write_json_string(?w, ?input[0]);
+    if (!sink_is_replacements(?sink, 2)) { ret 1; }
+    ret 0;
+}
+
+# a lead byte above the UTF-8 range is rejected.
+test "mach.cli.json.write_json_string:utf8_bad_lead_rejected" {
+    var out:  [32]u8;
+    var sink: TestSink;
+    var w:    writer.Writer;
+    test_writer(?w, ?sink, ?out[0], 32);
+
+    # 0xF5 begins no valid sequence (max lead is 0xF4).
+    var input: [2]u8;
+    input[0] = 0xF5; input[1] = 0;
+    write_json_string(?w, ?input[0]);
+    if (!sink_is_replacements(?sink, 1)) { ret 1; }
+    ret 0;
+}
+
+# a 4-byte sequence decoding above U+10FFFF is rejected.
+test "mach.cli.json.write_json_string:utf8_above_max_rejected" {
+    var out:  [64]u8;
+    var sink: TestSink;
+    var w:    writer.Writer;
+    test_writer(?w, ?sink, ?out[0], 64);
+
+    # 0xF4 0x90 ... would be U+110000; 0x90 is out of 0xF4's [0x80,0x8F] range.
+    var input: [5]u8;
+    input[0] = 0xF4; input[1] = 0x90; input[2] = 0x80; input[3] = 0x80; input[4] = 0;
+    write_json_string(?w, ?input[0]);
+    if (!sink_is_replacements(?sink, 4)) { ret 1; }
+    ret 0;
+}
+
+# a truncated multi-byte sequence (valid prefix, missing tail) is rejected.
+test "mach.cli.json.write_json_string:utf8_truncated_rejected" {
+    var out:  [32]u8;
+    var sink: TestSink;
+    var w:    writer.Writer;
+    test_writer(?w, ?sink, ?out[0], 32);
+
+    # 0xE2 0x82 starts a 3-byte sequence that the NUL terminates early.
+    var input: [3]u8;
+    input[0] = 0xE2; input[1] = 0x82; input[2] = 0;
+    write_json_string(?w, ?input[0]);
+    if (!sink_is_replacements(?sink, 2)) { ret 1; }
     ret 0;
 }
 

--- a/src/cli/util.mach
+++ b/src/cli/util.mach
@@ -143,6 +143,7 @@ pub fun is_value_flag(a: *u8) bool {
         || str_equals(s, "--artifacts")
         || str_equals(s, "--emit")
         || str_equals(s, "--filter")
+        || str_equals(s, "--format")
         || str_equals(s, "--out")
         || str_equals(s, "--name")
         || str_equals(s, "--ref")


### PR DESCRIPTION
Closes #1792.

Adds `mach test --format json`: a versioned, machine-readable NDJSON event stream for editors, CI annotators, and tooling that today would scrape the human readout. The human readout stays authoritative and free to evolve.

## Design

The JSON stream is a **sibling renderer over the same event stream** as the live readout, not a scrape or a fork of the human formatter. `execute_and_render` now drives a `Renderer` vtable (opaque ctx + per-event callbacks: `fn_start` / `fn_test` / `fn_summary`); the human readout is moved behind it unchanged, and the JSON stream is a second implementation. A new reusable `mach.cli.json` module owns the streaming object emitter.

- **Escaping / ASCII-only, no platform branches.** Strings are escaped per RFC 8259 with `ensure_ascii` semantics: control chars use their JSON escapes, and every byte `>= 0x80` is UTF-8 decoded and emitted as `\uXXXX` (astral code points as surrogate pairs). Windows paths (`\`) and quoted labels stay valid, and the stream is byte-identical on linux/darwin/windows. Invalid UTF-8 emits U+FFFD.
- **Labels verbatim.** Test labels are emitted exactly as authored, never normalized.
- **stdout vs stderr.** JSON on stdout, build diagnostics/errors on stderr, so the event stream is clean. Exit codes unchanged (`0`/`1`/`2`).
- `mach.cli.json` is deliberately reusable so the `mach check` follow-up (see below) can share the encoder.

## Schema (`schema: 1`, documented in `doc/tooling/test-json.md`)

One JSON object per line, each carrying `schema` (int version) and `event` (discriminator):

| event | fields |
|-------|--------|
| `run_start` | `schema`, `event`, `tests` |
| `test` | `schema`, `event`, `label`, `module`, `file`, `line`, `kind`, `code`, `duration_ns`, `index`, `exe`, `output` |
| `summary` | `schema`, `event`, `passed`, `failed`, `total`, `duration_ns` |
| `case` (`--list`) | `schema`, `event`, `label`, `module`, `file`, `line`, `index` |

`kind` ∈ `pass` \| `exit` \| `signal` \| `spawn` \| `other`. `code` carries the exit code (`exit`) or signal number (`signal`). `output` is the path to the retained capture file (present for failures; `null` for a pass, unlinked, or a spawn failure, never created) and points at the **full** output. `schema` bumps only on incompatible changes; new fields/events are additive and consumers must ignore unknowns.

## `mach check` decision

**Split into its own follow-up: #1815.** The test-run event stream and the diagnostic stream are different data models (the latter is span/severity/LSP-shaped), so bundling them would bloat one PR and one schema doc. Crucially, #1783 (diag help label + secondary span) is actively reshaping the diagnostic model, so designing check-json now would race it. The reusable `mach.cli.json` emitter added here is exactly what #1815 will build its diagnostic renderer on.

## Verification

- Self-hosting fixpoint holds: gen2 (built by gen1) is **byte-identical** to gen1.
- Full suite: **443 passed, 0 failed** (438 baseline + 5 new `mach.cli.json` escaper tests covering quote/backslash, control, BMP, and astral UTF-8).
- Every emitted line parsed cleanly by a JSON parser (`python3 -m json`); run_start/test/summary/case shapes validated.
- Failure path end-to-end: a `test "... \"quotes\" \\ café"` that `ret 7` yields `kind:"exit"`, `code:7`, `label` round-trips verbatim (`café` → `é`), and `output` references a real capture file containing the child's stdout.
- `--list --format json` (case events), empty-filtered run (`run_start` tests:0 + summary), and human default output all verified.

## Changelog

Left to the wave's changelog backfill pass; no `[Unreleased]` section exists to append to and the repo backfills per-wave.
