### PR TITLE
feat(diag): distinct `= help:` label and secondary span at an arbitrary location

### DIFF
--- a/doc/tooling/editor-api.md
+++ b/doc/tooling/editor-api.md
@@ -54,26 +54,35 @@ cached `Ast` / `ResolveResult`, so the next `parse` / `resolve` recomputes.
 ## Diagnostics — the first consumer slice
 
 `diagnostics` runs `tokenize → emit-lex-errors → parse` and returns the
-session `DiagList`. Each `diag.Diagnostic` carries `(severity, file_id, span,
-message, note, help, related)`: `note` and `help` are optional secondary lines
-(a suggestion rides `help`, rendered `= help:`), and `related` is an optional
-secondary span (`file_id`, `span`, `label`) at an unrelated location, absent
-when `related.label` is nil. Map each `span` to a position with
-`source.position`:
+session `DiagList` of **syntactic** diagnostics only. Each `diag.Diagnostic`
+carries `(severity, loc, message, note, help, related[])`: `loc` is a
+`Location` (`file_id`, `span`) for the primary report, `note` and `help` are
+optional trailing lines, and `related` is a growable array (`related_len`
+entries) of secondary `Location`s each with an optional `label`. Map each
+`loc.span` to a position with `source.position`:
 
 ```mach
 val list: *diag.DiagList = unwrap_ok[...](editor.diagnostics(?es, fid));
 var i: usize = 0;
 for (i < list.len) {
     val d: *diag.Diagnostic = ?list.items[i];
-    val sf: *src.SourceFile = unwrap[...](src.get(?s.sources, d.file_id));
-    val pos: src.Position = src.position(sf, d.span.offset); // 1-based line/col
+    val sf: *src.SourceFile = unwrap[...](src.get(?s.sources, d.loc.file_id));
+    val pos: src.Position = src.position(sf, d.loc.span.offset); // 1-based line/col
     // d.severity, pos.line, pos.col, d.message -> LSP Diagnostic
     i = i + 1;
 }
 ```
 
-The `mach check <file>` CLI command is the in-tree consumer of this slice.
+`help` and `related` are populated by the **resolve** stage (a suggestion rides
+`help`, rendered `= help:`; a prior binding rides `related`, e.g. `previous
+definition here`), so an integrator wanting them drives `resolve` (or full
+`analyze`) and reads `es.s.diags` — the parse-only `diagnostics` slice never
+sets them. Map a `related` entry's `loc` to a position the same way, and surface
+its `label` as an LSP `relatedInformation` item.
+
+The `mach check <file>` CLI command is the in-tree consumer of the parse-only
+slice; `mach build` renders the resolve-stage diagnostics that carry `help` and
+`related`.
 
 ## Position lookup — offset → id
 

--- a/doc/tooling/editor-api.md
+++ b/doc/tooling/editor-api.md
@@ -55,7 +55,11 @@ cached `Ast` / `ResolveResult`, so the next `parse` / `resolve` recomputes.
 
 `diagnostics` runs `tokenize → emit-lex-errors → parse` and returns the
 session `DiagList`. Each `diag.Diagnostic` carries `(severity, file_id, span,
-message, note)`. Map each `span` to a position with `source.position`:
+message, note, help, related)`: `note` and `help` are optional secondary lines
+(a suggestion rides `help`, rendered `= help:`), and `related` is an optional
+secondary span (`file_id`, `span`, `label`) at an unrelated location, absent
+when `related.label` is nil. Map each `span` to a position with
+`source.position`:
 
 ```mach
 val list: *diag.DiagList = unwrap_ok[...](editor.diagnostics(?es, fid));

--- a/src/cli/diagnostic.mach
+++ b/src/cli/diagnostic.mach
@@ -4,17 +4,23 @@
 # diagnostic prints as a severity headline (`error:` / `warning:`), a
 # `--> file:line:col` location line, an ASCII line-number gutter, and the
 # offending span underlined with `^`; a span that runs across several source
-# lines marks its continuation lines with `-`. an attached note renders as a
-# `= note:` line. a non-empty run ends with an `N errors / M warnings` summary.
+# lines marks its continuation lines with `-`. a diagnostic may carry a secondary
+# span at an unrelated location, drawn in its own `--> file:line:col` frame with a
+# `-` underline and a trailing label. attached notes render as `= note:` and
+# suggestions as `= help:`. a non-empty run ends with an `N errors / M warnings`
+# summary.
 #
 # spans resolve against the session source map via the diagnostic's file_id and
-# span; the data model is unchanged. output is ASCII only - no Unicode, no color,
-# no terminal escapes - and fixed-width, so it is byte-identical across linux,
-# darwin, and windows. both `mach build` (whole project) and `mach check` (single
-# buffer) render through `flush`.
+# span. output is ASCII only - no Unicode, no color, no terminal escapes - and
+# fixed-width, so it is byte-identical across linux, darwin, and windows. both
+# `mach build` (whole project) and `mach check` (single buffer) render through
+# `flush`.
 
 use std.print;
 use std.system.os;
+use std.types.bool.bool;
+use std.types.bool.false;
+use std.types.bool.true;
 use std.types.size.usize;
 use std.types.string.str;
 use std.types.string.str_len;
@@ -22,6 +28,7 @@ use std.types.string.str_len;
 use O: std.types.option;
 
 use mach.lang.diagnostic;
+use mach.lang.fe.token;
 use mach.lang.session;
 use mach.lang.source;
 
@@ -59,29 +66,43 @@ pub fun flush(s: *session.Session, list: *diagnostic.DiagList) {
     }
 }
 
-# render one diagnostic: headline, then a source frame when the file resolves.
+# the resolved geometry of one span against its source file, shared by the
+# primary and secondary frames of a diagnostic.
+# ---
+# sf:     the resolved source file
+# off:    clamped span start byte offset
+# end:    clamped span end byte offset (exclusive)
+# line_s: 1-based first line the span touches
+# line_e: 1-based last line the span touches
+# col_s:  1-based column of the span start
+rec Frame {
+    sf:     *source.SourceFile;
+    off:    usize;
+    end:    usize;
+    line_s: usize;
+    line_e: usize;
+    col_s:  usize;
+}
+
+# resolve a (file_id, span) pair to a Frame, or none when the file is unknown.
 #
 # The span is clamped to the file bounds so a synthesized or out-of-range span
-# degrades to a valid frame rather than crashing. The note, when present, renders
-# under the frame (or directly under the headline when there is no frame).
+# degrades to a valid frame rather than crashing.
 # ---
-# s: session carrying the source map
-# d: the diagnostic to render
-fun render(s: *session.Session, d: *diagnostic.Diagnostic) {
-    emit_headline(d.severity, d.message);
-
-    val opt_file: O.Option[*source.SourceFile] = source.get(?s.sources, d.file_id);
-    if (O.is_none[*source.SourceFile](opt_file)) {
-        if (d.note != nil) { emit_note(d.note, 2); }
-        ret;
-    }
+# s:       session carrying the source map
+# file_id: file the span points into
+# span:    byte range to resolve
+# ret:     some(Frame) when the file resolves, none otherwise
+fun locate(s: *session.Session, file_id: source.FileId, span: token.Span) O.Option[Frame] {
+    val opt_file: O.Option[*source.SourceFile] = source.get(?s.sources, file_id);
+    if (O.is_none[*source.SourceFile](opt_file)) { ret O.none[Frame](); }
     val sf: *source.SourceFile = O.unwrap[*source.SourceFile](opt_file);
 
     val text_len: usize = str_len(sf.text);
 
-    var off: usize = d.span.offset;
+    var off: usize = span.offset;
     if (off > text_len) { off = text_len; }
-    var end: usize = d.span.offset + d.span.len;
+    var end: usize = span.offset + span.len;
     if (end > text_len) { end = text_len; }
     if (end < off)      { end = off;      }
 
@@ -90,23 +111,90 @@ fun render(s: *session.Session, d: *diagnostic.Diagnostic) {
     if (end > off) { last = end - 1; }
     val end_pos: source.Position = source.position(sf, last);
 
-    val w: usize = decimal_width(end_pos.line);
+    var f: Frame;
+    f.sf     = sf;
+    f.off    = off;
+    f.end    = end;
+    f.line_s = start_pos.line;
+    f.line_e = end_pos.line;
+    f.col_s  = start_pos.col;
+    ret O.some[Frame](f);
+}
 
-    emit_loc(w, sf.path, start_pos.line, start_pos.col);
-    emit_bar(w);
-    emit_snippet(sf, w, start_pos.line, end_pos.line, off, end);
+# render one diagnostic: headline, a primary source frame, an optional secondary
+# frame, then note and help lines.
+#
+# The gutter width is unified across the primary and secondary frames so their
+# bars align. When the primary file does not resolve the diagnostic degrades to
+# its headline plus any note and help lines with no source frame.
+# ---
+# s: session carrying the source map
+# d: the diagnostic to render
+fun render(s: *session.Session, d: *diagnostic.Diagnostic) {
+    emit_headline(d.severity, d.message);
 
-    if (d.note != nil) {
-        emit_bar(w);
-        emit_note(d.note, w + 1);
+    val opt_pf: O.Option[Frame] = locate(s, d.file_id, d.span);
+    if (O.is_none[Frame](opt_pf)) {
+        emit_trailer(d, 2, false);
+        ret;
     }
+    val pf: Frame = O.unwrap[Frame](opt_pf);
+
+    var w: usize = decimal_width(pf.line_e);
+
+    var has_rel: bool = false;
+    var rf: Frame;
+    if (d.related.label != nil) {
+        val opt_rf: O.Option[Frame] = locate(s, d.related.file_id, d.related.span);
+        if (O.is_some[Frame](opt_rf)) {
+            rf = O.unwrap[Frame](opt_rf);
+            has_rel = true;
+            val rw: usize = decimal_width(rf.line_e);
+            if (rw > w) { w = rw; }
+        }
+    }
+
+    emit_frame(?pf, w, "^", nil);
+    if (has_rel) { emit_frame(?rf, w, "-", d.related.label); }
+
+    emit_trailer(d, w + 1, true);
+}
+
+# draw one frame: its `--> file:line:col` line, a blank gutter bar, and the
+# underlined source line(s).
+# ---
+# f:     resolved frame geometry
+# w:     unified gutter width in columns
+# head:  underline glyph for the first line ("^" primary, "-" secondary)
+# label: label appended to the final underline line, or nil for none
+fun emit_frame(f: *Frame, w: usize, head: str, label: str) {
+    emit_loc(w, f.sf.path, f.line_s, f.col_s);
+    emit_bar(w);
+    emit_snippet(f.sf, w, f.line_s, f.line_e, f.off, f.end, head, label);
+}
+
+# render the note and help lines that trail a diagnostic's frames.
+#
+# When the diagnostic was framed a blank gutter bar separates the frame from the
+# trailer; the unframed (degraded) path emits the lines directly under the
+# headline.
+# ---
+# d:      the diagnostic whose note/help lines are rendered
+# indent: spaces preceding the `=` on each line
+# framed: whether a source frame preceded these lines
+fun emit_trailer(d: *diagnostic.Diagnostic, indent: usize, framed: bool) {
+    if (d.note == nil && d.help == nil) { ret; }
+    if (framed) { emit_bar(indent - 1); }
+    if (d.note != nil) { emit_note(d.note, indent); }
+    if (d.help != nil) { emit_help(d.help, indent); }
 }
 
 # render the source line(s) the span covers, each followed by its underline.
 #
-# A single-line span underlines its range with `^`. A multi-line span marks the
-# first line with `^` and every continuation line with `-`; a span taller than
-# MAX_SPAN_LINES renders only its first and last lines with the middle elided.
+# A single-line span underlines its range with `head`. A multi-line span marks
+# the first line with `head` and every continuation line with `-`; a span taller
+# than MAX_SPAN_LINES renders only its first and last lines with the middle
+# elided. The label, when present, trails the final underline line.
 # ---
 # sf:     source file the lines are drawn from
 # w:      gutter width in columns
@@ -114,10 +202,12 @@ fun render(s: *session.Session, d: *diagnostic.Diagnostic) {
 # line_e: 1-based last line of the span
 # off:    clamped span start byte offset
 # end:    clamped span end byte offset (exclusive)
-fun emit_snippet(sf: *source.SourceFile, w: usize, line_s: usize, line_e: usize, off: usize, end: usize) {
+# head:   underline glyph for the first line ("^" primary, "-" secondary)
+# label:  label appended to the final underline line, or nil for none
+fun emit_snippet(sf: *source.SourceFile, w: usize, line_s: usize, line_e: usize, off: usize, end: usize, head: str, label: str) {
     if (line_e <= line_s) {
         emit_source_line(sf, w, line_s);
-        emit_underline(sf, w, line_s, off, end, "^");
+        emit_underline(sf, w, line_s, off, end, head, label);
         ret;
     }
 
@@ -125,18 +215,19 @@ fun emit_snippet(sf: *source.SourceFile, w: usize, line_s: usize, line_e: usize,
         var l: usize = line_s;
         for (l <= line_e) {
             emit_source_line(sf, w, l);
-            if (l == line_s) { emit_underline(sf, w, l, off, end, "^"); }
-            or               { emit_underline(sf, w, l, off, end, "-"); }
+            if (l == line_s)      { emit_underline(sf, w, l, off, end, head, nil);  }
+            or (l == line_e)      { emit_underline(sf, w, l, off, end, "-", label); }
+            or                    { emit_underline(sf, w, l, off, end, "-", nil);   }
             l = l + 1;
         }
         ret;
     }
 
     emit_source_line(sf, w, line_s);
-    emit_underline(sf, w, line_s, off, end, "^");
+    emit_underline(sf, w, line_s, off, end, head, nil);
     emit_elision(w);
     emit_source_line(sf, w, line_e);
-    emit_underline(sf, w, line_e, off, end, "-");
+    emit_underline(sf, w, line_e, off, end, "-", label);
 }
 
 # write one numbered source line through the gutter, verbatim.
@@ -161,7 +252,8 @@ fun emit_source_line(sf: *source.SourceFile, w: usize, line: usize) {
 # The leading run up to the marked range is reproduced as tabs and spaces so the
 # markers land under the span regardless of tab width. The marker glyph (`^` for
 # the primary line, `-` for a continuation) fills the covered range, with a
-# zero-length range marking a single column.
+# zero-length range marking a single column. A non-nil `label` trails the glyph
+# run after a single space.
 # ---
 # sf:    source file the line is drawn from
 # w:     gutter width in columns
@@ -169,7 +261,8 @@ fun emit_source_line(sf: *source.SourceFile, w: usize, line: usize) {
 # off:   clamped span start byte offset
 # end:   clamped span end byte offset (exclusive)
 # glyph: the marker glyph, "^" or "-"
-fun emit_underline(sf: *source.SourceFile, w: usize, line: usize, off: usize, end: usize, glyph: str) {
+# label: label appended after the glyph run, or nil for none
+fun emit_underline(sf: *source.SourceFile, w: usize, line: usize, off: usize, end: usize, glyph: str, label: str) {
     val opt_bounds: O.Option[source.LineSpan] = source.line_bounds(sf, line);
     if (O.is_none[source.LineSpan](opt_bounds)) { ret; }
     val b: source.LineSpan = O.unwrap[source.LineSpan](opt_bounds);
@@ -193,6 +286,10 @@ fun emit_underline(sf: *source.SourceFile, w: usize, line: usize, off: usize, en
     if (n == 0) { n = 1; }
     var j: usize = 0;
     for (j < n) { print.eprint(glyph); j = j + 1; }
+    if (label != nil) {
+        print.eprint(" ");
+        print.eprint(label);
+    }
     print.eprint("\n");
 }
 
@@ -255,6 +352,16 @@ fun emit_note(note: str, indent: usize) {
     emit_spaces(indent);
     print.eprint("= note: ");
     print.eprintln(note);
+}
+
+# write a `= help:` line indented so its `=` aligns with the gutter bar.
+# ---
+# help:   the suggestion text
+# indent: spaces preceding the `=`
+fun emit_help(help: str, indent: usize) {
+    emit_spaces(indent);
+    print.eprint("= help: ");
+    print.eprintln(help);
 }
 
 # write the closing `N errors / M warnings` counts line.

--- a/src/cli/diagnostic.mach
+++ b/src/cli/diagnostic.mach
@@ -4,17 +4,19 @@
 # diagnostic prints as a severity headline (`error:` / `warning:`), a
 # `--> file:line:col` location line, an ASCII line-number gutter, and the
 # offending span underlined with `^`; a span that runs across several source
-# lines marks its continuation lines with `-`. a diagnostic may carry a secondary
-# span at an unrelated location, drawn in its own `--> file:line:col` frame with a
-# `-` underline and a trailing label. attached notes render as `= note:` and
-# suggestions as `= help:`. a non-empty run ends with an `N errors / M warnings`
-# summary.
+# lines marks its continuation lines with `-`. a diagnostic may carry any number
+# of secondary locations at unrelated positions, each drawn in its own
+# `--> file:line:col` frame with a `-` underline and an optional trailing label,
+# separated from the frame before it by a blank gutter bar. attached notes render
+# as `= note:` and suggestions as `= help:`. a non-empty run ends with an
+# `N errors / M warnings` summary.
 #
-# spans resolve against the session source map via the diagnostic's file_id and
-# span. output is ASCII only - no Unicode, no color, no terminal escapes - and
-# fixed-width, so it is byte-identical across linux, darwin, and windows. both
-# `mach build` (whole project) and `mach check` (single buffer) render through
-# `flush`.
+# locations resolve against the session source map via each Location's file_id
+# and span; an unresolvable captioned location degrades to a `= note:` line rather
+# than vanishing. output is ASCII only - no Unicode, no color, no terminal escapes
+# - and fixed-width, so it is byte-identical across linux, darwin, and windows.
+# both `mach build` (whole project) and `mach check` (single buffer) render
+# through `flush`.
 
 use std.print;
 use std.system.os;
@@ -28,7 +30,6 @@ use std.types.string.str_len;
 use O: std.types.option;
 
 use mach.lang.diagnostic;
-use mach.lang.fe.token;
 use mach.lang.session;
 use mach.lang.source;
 
@@ -84,25 +85,24 @@ rec Frame {
     col_s:  usize;
 }
 
-# resolve a (file_id, span) pair to a Frame, or none when the file is unknown.
+# resolve a Location to a Frame, or none when its file is unknown.
 #
 # The span is clamped to the file bounds so a synthesized or out-of-range span
 # degrades to a valid frame rather than crashing.
 # ---
-# s:       session carrying the source map
-# file_id: file the span points into
-# span:    byte range to resolve
-# ret:     some(Frame) when the file resolves, none otherwise
-fun locate(s: *session.Session, file_id: source.FileId, span: token.Span) O.Option[Frame] {
-    val opt_file: O.Option[*source.SourceFile] = source.get(?s.sources, file_id);
+# s:   session carrying the source map
+# loc: the location to resolve
+# ret: some(Frame) when the file resolves, none otherwise
+fun locate(s: *session.Session, loc: diagnostic.Location) O.Option[Frame] {
+    val opt_file: O.Option[*source.SourceFile] = source.get(?s.sources, loc.file_id);
     if (O.is_none[*source.SourceFile](opt_file)) { ret O.none[Frame](); }
     val sf: *source.SourceFile = O.unwrap[*source.SourceFile](opt_file);
 
     val text_len: usize = str_len(sf.text);
 
-    var off: usize = span.offset;
+    var off: usize = loc.span.offset;
     if (off > text_len) { off = text_len; }
-    var end: usize = span.offset + span.len;
+    var end: usize = loc.span.offset + loc.span.len;
     if (end > text_len) { end = text_len; }
     if (end < off)      { end = off;      }
 
@@ -121,43 +121,68 @@ fun locate(s: *session.Session, file_id: source.FileId, span: token.Span) O.Opti
     ret O.some[Frame](f);
 }
 
-# render one diagnostic: headline, a primary source frame, an optional secondary
+# render one diagnostic: headline, a primary source frame, every secondary
 # frame, then note and help lines.
 #
-# The gutter width is unified across the primary and secondary frames so their
-# bars align. When the primary file does not resolve the diagnostic degrades to
-# its headline plus any note and help lines with no source frame.
+# The gutter width is unified across the primary and all resolvable secondary
+# frames so their bars align. A secondary frame is separated from the one before
+# it by a blank gutter bar. A location whose file does not resolve never vanishes:
+# a captioned one degrades to a `= note:` line in the trailer, and the primary
+# failing to resolve still lets resolvable secondaries render.
 # ---
 # s: session carrying the source map
 # d: the diagnostic to render
 fun render(s: *session.Session, d: *diagnostic.Diagnostic) {
     emit_headline(d.severity, d.message);
 
-    val opt_pf: O.Option[Frame] = locate(s, d.file_id, d.span);
-    if (O.is_none[Frame](opt_pf)) {
-        emit_trailer(d, 2, false);
-        ret;
+    val opt_pf: O.Option[Frame] = locate(s, d.loc);
+    val w: usize = gutter_width(s, d, opt_pf);
+
+    var framed: bool = false;
+    if (O.is_some[Frame](opt_pf)) {
+        var pf: Frame = O.unwrap[Frame](opt_pf);
+        emit_frame(?pf, w, "^", nil);
+        framed = true;
     }
-    val pf: Frame = O.unwrap[Frame](opt_pf);
 
-    var w: usize = decimal_width(pf.line_e);
-
-    var has_rel: bool = false;
-    var rf: Frame;
-    if (d.related.label != nil) {
-        val opt_rf: O.Option[Frame] = locate(s, d.related.file_id, d.related.span);
+    var i: usize = 0;
+    for (i < d.related_len) {
+        val rel: *diagnostic.Related = ?d.related[i];
+        val opt_rf: O.Option[Frame] = locate(s, rel.loc);
         if (O.is_some[Frame](opt_rf)) {
-            rf = O.unwrap[Frame](opt_rf);
-            has_rel = true;
-            val rw: usize = decimal_width(rf.line_e);
+            if (framed) { emit_bar(w); }
+            var rf: Frame = O.unwrap[Frame](opt_rf);
+            emit_frame(?rf, w, "-", rel.label);
+            framed = true;
+        }
+        i = i + 1;
+    }
+
+    emit_trailer(s, d, framed, w);
+}
+
+# the gutter width unified across the primary frame and every resolvable
+# secondary frame, so their `|` bars align. At least 1 so an all-unresolved
+# diagnostic still yields a sane width.
+# ---
+# s:      session carrying the source map
+# d:      the diagnostic being rendered
+# opt_pf: the already-resolved primary frame, or none
+# ret:    the gutter width in columns
+fun gutter_width(s: *session.Session, d: *diagnostic.Diagnostic, opt_pf: O.Option[Frame]) usize {
+    var w: usize = 1;
+    if (O.is_some[Frame](opt_pf)) { w = decimal_width(O.unwrap[Frame](opt_pf).line_e); }
+
+    var i: usize = 0;
+    for (i < d.related_len) {
+        val opt_rf: O.Option[Frame] = locate(s, d.related[i].loc);
+        if (O.is_some[Frame](opt_rf)) {
+            val rw: usize = decimal_width(O.unwrap[Frame](opt_rf).line_e);
             if (rw > w) { w = rw; }
         }
+        i = i + 1;
     }
-
-    emit_frame(?pf, w, "^", nil);
-    if (has_rel) { emit_frame(?rf, w, "-", d.related.label); }
-
-    emit_trailer(d, w + 1, true);
+    ret w;
 }
 
 # draw one frame: its `--> file:line:col` line, a blank gutter bar, and the
@@ -173,20 +198,53 @@ fun emit_frame(f: *Frame, w: usize, head: str, label: str) {
     emit_snippet(f.sf, w, f.line_s, f.line_e, f.off, f.end, head, label);
 }
 
-# render the note and help lines that trail a diagnostic's frames.
+# render the trailing lines under a diagnostic's frames: the caption of every
+# unresolvable-but-captioned secondary location, then the note, then the help.
 #
-# When the diagnostic was framed a blank gutter bar separates the frame from the
-# trailer; the unframed (degraded) path emits the lines directly under the
-# headline.
+# When at least one frame was drawn a single blank gutter bar separates the
+# frames from the trailer and the lines indent to align with the gutter; the
+# unframed (degraded) path emits the lines directly under the headline.
 # ---
-# d:      the diagnostic whose note/help lines are rendered
-# indent: spaces preceding the `=` on each line
-# framed: whether a source frame preceded these lines
-fun emit_trailer(d: *diagnostic.Diagnostic, indent: usize, framed: bool) {
-    if (d.note == nil && d.help == nil) { ret; }
-    if (framed) { emit_bar(indent - 1); }
-    if (d.note != nil) { emit_note(d.note, indent); }
-    if (d.help != nil) { emit_help(d.help, indent); }
+# s:      session carrying the source map
+# d:      the diagnostic whose trailing lines are rendered
+# framed: whether any source frame preceded these lines
+# w:      unified gutter width in columns
+fun emit_trailer(s: *session.Session, d: *diagnostic.Diagnostic, framed: bool, w: usize) {
+    if (!has_trailer(s, d)) { ret; }
+
+    var indent: usize = 2;
+    if (framed) {
+        emit_bar(w);
+        indent = w + 1;
+    }
+
+    var i: usize = 0;
+    for (i < d.related_len) {
+        val rel: *diagnostic.Related = ?d.related[i];
+        if (rel.label != nil && O.is_none[Frame](locate(s, rel.loc))) {
+            emit_tagged("note", rel.label, indent);
+        }
+        i = i + 1;
+    }
+    if (d.note != nil) { emit_tagged("note", d.note, indent); }
+    if (d.help != nil) { emit_tagged("help", d.help, indent); }
+}
+
+# whether a diagnostic has any trailing line to render: a note, a help, or an
+# unresolvable-but-captioned secondary location.
+# ---
+# s:   session carrying the source map
+# d:   the diagnostic being rendered
+# ret: true when at least one trailing line is present
+fun has_trailer(s: *session.Session, d: *diagnostic.Diagnostic) bool {
+    if (d.note != nil || d.help != nil) { ret true; }
+
+    var i: usize = 0;
+    for (i < d.related_len) {
+        if (d.related[i].label != nil && O.is_none[Frame](locate(s, d.related[i].loc))) { ret true; }
+        i = i + 1;
+    }
+    ret false;
 }
 
 # render the source line(s) the span covers, each followed by its underline.
@@ -344,24 +402,17 @@ fun emit_gutter_bar(w: usize) {
     print.eprint(" | ");
 }
 
-# write a `= note:` line indented so its `=` aligns with the gutter bar.
+# write a `= <tag>:` line indented so its `=` aligns with the gutter bar.
 # ---
-# note:   the note text
+# tag:    the line tag ("note" or "help")
+# text:   the line text
 # indent: spaces preceding the `=`
-fun emit_note(note: str, indent: usize) {
+fun emit_tagged(tag: str, text: str, indent: usize) {
     emit_spaces(indent);
-    print.eprint("= note: ");
-    print.eprintln(note);
-}
-
-# write a `= help:` line indented so its `=` aligns with the gutter bar.
-# ---
-# help:   the suggestion text
-# indent: spaces preceding the `=`
-fun emit_help(help: str, indent: usize) {
-    emit_spaces(indent);
-    print.eprint("= help: ");
-    print.eprintln(help);
+    print.eprint("= ");
+    print.eprint(tag);
+    print.eprint(": ");
+    print.eprintln(text);
 }
 
 # write the closing `N errors / M warnings` counts line.

--- a/src/lang/diagnostic.mach
+++ b/src/lang/diagnostic.mach
@@ -35,6 +35,22 @@ pub val SEVERITY_INFO:    Severity = 2;
 # a help hint attached to another diagnostic
 pub val SEVERITY_HELP:    Severity = 3;
 
+# an optional secondary source location attached to a diagnostic
+#
+# Carries its own file_id and span so it can point at an unrelated location (for
+# example the earlier binding behind a "duplicate definition"). `label == nil`
+# marks the whole secondary span as absent; when present the label renders under
+# the secondary underline.
+# ---
+# file_id: identifier of the file the secondary span points into
+# span:    byte range of the secondary location
+# label:   owned label rendered under the secondary underline, or nil when absent
+pub rec Related {
+    file_id: source.FileId;
+    span:    token.Span;
+    label:   str;
+}
+
 # a single reported diagnostic tied to a span in a source file
 # ---
 # severity: severity level of the diagnostic
@@ -42,12 +58,16 @@ pub val SEVERITY_HELP:    Severity = 3;
 # span:     byte range being reported on
 # message:  owned human-readable message
 # note:     owned secondary "note:" line, or nil when absent
+# help:     owned "help:" suggestion line, or nil when absent
+# related:  optional secondary span; related.label is nil when absent
 pub rec Diagnostic {
     severity: Severity;
     file_id:  source.FileId;
     span:     token.Span;
     message:  str;
     note:     str;
+    help:     str;
+    related:  Related;
 }
 
 # owning list of diagnostics collected across one or more phases
@@ -92,6 +112,12 @@ pub fun dnit(list: *DiagList) {
         str_free(list.a, d.message);
         if (d.note != nil) {
             str_free(list.a, d.note);
+        }
+        if (d.help != nil) {
+            str_free(list.a, d.help);
+        }
+        if (d.related.label != nil) {
+            str_free(list.a, d.related.label);
         }
         i = i + 1;
     }
@@ -173,6 +199,53 @@ pub fun attach_note(list: *DiagList, note: str) {
     d.note = R.unwrap_ok[str, str](res_dup);
 }
 
+# attach an owned "help:" suggestion line to the most recently recorded
+# diagnostic
+#
+# The help line is distinct from a plain note: the renderer labels it `= help:`.
+# A no-op when the list is empty or the last diagnostic already carries a help
+# line. Allocation failure is swallowed so a missing suggestion never aborts a
+# pass; the suggestion is advisory, and a failed copy simply leaves it absent.
+# ---
+# list: diagnostic list whose last entry receives the help line
+# help: human-readable suggestion (copied)
+pub fun attach_help(list: *DiagList, help: str) {
+    if (list == nil || list.len == 0) { ret; }
+
+    val d: *Diagnostic = ?list.items[list.len - 1];
+    if (d.help != nil) { ret; }
+
+    val res_dup: R.Result[str, str] = str_dup(list.a, help);
+    if (R.is_err[str, str](res_dup)) { ret; }
+    d.help = R.unwrap_ok[str, str](res_dup);
+}
+
+# attach a secondary source span with its own file_id and label to the most
+# recently recorded diagnostic
+#
+# The renderer draws the secondary span at its own location with a `-` underline
+# and the label beneath it. A no-op when the list is empty or the last
+# diagnostic already carries a secondary span. Allocation failure is swallowed so
+# a missing secondary span never aborts a pass; a failed label copy simply leaves
+# the secondary span absent.
+# ---
+# list:    diagnostic list whose last entry receives the secondary span
+# file_id: identifier of the file the secondary span points into
+# span:    byte range of the secondary location
+# label:   label rendered under the secondary underline (copied)
+pub fun attach_related(list: *DiagList, file_id: source.FileId, span: token.Span, label: str) {
+    if (list == nil || list.len == 0) { ret; }
+
+    val d: *Diagnostic = ?list.items[list.len - 1];
+    if (d.related.label != nil) { ret; }
+
+    val res_dup: R.Result[str, str] = str_dup(list.a, label);
+    if (R.is_err[str, str](res_dup)) { ret; }
+    d.related.file_id = file_id;
+    d.related.span    = span;
+    d.related.label   = R.unwrap_ok[str, str](res_dup);
+}
+
 # whether the list holds at least one error-severity diagnostic
 # ---
 # list: the list to scan
@@ -192,7 +265,7 @@ pub fun has_errors(list: *DiagList) bool {
 # identifier
 #
 # The returned string is owned by `a`; the caller frees it with str_free after
-# handing it to attach_note (which copies it into the list's allocator). Returns
+# handing it to attach_help (which copies it into the list's allocator). Returns
 # nil on allocation failure, which a caller treats as "no suggestion".
 # ---
 # a:    allocator backing the returned string
@@ -255,11 +328,13 @@ fun emit(list: *DiagList, severity: Severity, file_id: source.FileId, span: toke
     }
 
     var d: Diagnostic;
-    d.severity = severity;
-    d.file_id  = file_id;
-    d.span     = span;
-    d.message  = owned;
-    d.note     = nil;
+    d.severity      = severity;
+    d.file_id       = file_id;
+    d.span          = span;
+    d.message       = owned;
+    d.note          = nil;
+    d.help          = nil;
+    d.related.label = nil;
     list.items[list.len] = d;
     list.len = list.len + 1;
 
@@ -311,6 +386,67 @@ test "mach.lang.diagnostic.attach_note:idempotent" {
 
     attach_note(?list, "second note");
     if (list.items[0].note != first) { dnit(?list); ret 1; }
+
+    dnit(?list);
+    ret 0;
+}
+
+# a help line is recorded independently of a note and stays idempotent
+test "mach.lang.diagnostic.attach_help:distinct_from_note" {
+    var a: A.Allocator;
+    page.make(?a);
+    var list: DiagList = init(?a);
+
+    var sp: token.Span;
+    sp.offset = 0;
+    sp.len    = 1;
+
+    val res_err: R.Result[bool, str] = error(?list, 0::source.FileId, sp, "an error");
+    if (R.is_err[bool, str](res_err)) { dnit(?list); ret 1; }
+
+    attach_note(?list, "a note");
+    attach_help(?list, "did you mean `foo`?");
+    if (list.items[0].note == nil) { dnit(?list); ret 1; }
+    if (list.items[0].help == nil) { dnit(?list); ret 1; }
+
+    val first: str = list.items[0].help;
+    attach_help(?list, "did you mean `bar`?");
+    if (list.items[0].help != first) { dnit(?list); ret 1; }
+
+    dnit(?list);
+    ret 0;
+}
+
+# a related secondary span records its own file_id, span, and label, and a second
+# attach is a no-op while one is present
+test "mach.lang.diagnostic.attach_related:records_secondary_span" {
+    var a: A.Allocator;
+    page.make(?a);
+    var list: DiagList = init(?a);
+
+    var sp: token.Span;
+    sp.offset = 10;
+    sp.len    = 3;
+
+    val res_err: R.Result[bool, str] = error(?list, 0::source.FileId, sp, "an error");
+    if (R.is_err[bool, str](res_err)) { dnit(?list); ret 1; }
+
+    if (list.items[0].related.label != nil) { dnit(?list); ret 1; }
+
+    var rel: token.Span;
+    rel.offset = 42;
+    rel.len    = 5;
+    attach_related(?list, 7::source.FileId, rel, "previous definition here");
+
+    if (list.items[0].related.label == nil)          { dnit(?list); ret 1; }
+    if (list.items[0].related.file_id != 7::source.FileId) { dnit(?list); ret 1; }
+    if (list.items[0].related.span.offset != 42)     { dnit(?list); ret 1; }
+    if (list.items[0].related.span.len != 5)         { dnit(?list); ret 1; }
+
+    val first: str = list.items[0].related.label;
+    attach_related(?list, 9::source.FileId, sp, "other label");
+    if (list.items[0].related.label != first)        { dnit(?list); ret 1; }
+    if (list.items[0].related.file_id != 7::source.FileId) { dnit(?list); ret 1; }
 
     dnit(?list);
     ret 0;

--- a/src/lang/diagnostic.mach
+++ b/src/lang/diagnostic.mach
@@ -1,9 +1,10 @@
 # severity-tagged diagnostic sink shared by every compiler phase
 #
 # A single list of records that every phase appends to. Rendering is decoupled
-# from recording: a diagnostic carries a (FileId, Span) for its source location
-# and an owned message, and turning that into text happens later through the
-# source registry.
+# from recording: a diagnostic carries a primary Location (a file and a span) and
+# an owned message, and turning that into text happens later through the source
+# registry. Each diagnostic may also carry optional note/help lines and a
+# growable list of secondary Locations at unrelated positions.
 
 use std.allocator.page;
 use std.memory;
@@ -35,39 +36,51 @@ pub val SEVERITY_INFO:    Severity = 2;
 # a help hint attached to another diagnostic
 pub val SEVERITY_HELP:    Severity = 3;
 
-# an optional secondary source location attached to a diagnostic
+# a source location: a file and a byte range within it
 #
-# Carries its own file_id and span so it can point at an unrelated location (for
-# example the earlier binding behind a "duplicate definition"). `label == nil`
-# marks the whole secondary span as absent; when present the label renders under
-# the secondary underline.
+# The shared shape of a diagnostic's primary location and every secondary
+# (Related) location, so both resolve through the source registry identically.
 # ---
-# file_id: identifier of the file the secondary span points into
-# span:    byte range of the secondary location
-# label:   owned label rendered under the secondary underline, or nil when absent
-pub rec Related {
+# file_id: identifier of the file the span points into
+# span:    byte range within the file
+pub rec Location {
     file_id: source.FileId;
     span:    token.Span;
-    label:   str;
 }
 
-# a single reported diagnostic tied to a span in a source file
+# a secondary source location attached to a diagnostic
+#
+# Points at a location related to the primary diagnostic, for example the earlier
+# binding behind a "duplicate definition". Presence is tracked by the owning
+# diagnostic's related-array length, so the label is genuinely optional: a nil
+# label is a bare context span with no caption.
 # ---
-# severity: severity level of the diagnostic
-# file_id:  identifier of the file the span points into
-# span:     byte range being reported on
-# message:  owned human-readable message
-# note:     owned secondary "note:" line, or nil when absent
-# help:     owned "help:" suggestion line, or nil when absent
-# related:  optional secondary span; related.label is nil when absent
+# loc:   the secondary location
+# label: owned caption rendered under the secondary underline, or nil for none
+pub rec Related {
+    loc:   Location;
+    label: str;
+}
+
+# a single reported diagnostic tied to a primary location in a source file
+# ---
+# severity:    severity level of the diagnostic
+# loc:         primary location the diagnostic is reported at
+# message:     owned human-readable message
+# note:        owned "= note:" line, or nil when absent
+# help:        owned "= help:" suggestion line, or nil when absent
+# related:     growable array of secondary locations, or nil when none
+# related_len: number of secondary locations stored (presence count)
+# related_cap: allocated slots in related
 pub rec Diagnostic {
-    severity: Severity;
-    file_id:  source.FileId;
-    span:     token.Span;
-    message:  str;
-    note:     str;
-    help:     str;
-    related:  Related;
+    severity:    Severity;
+    loc:         Location;
+    message:     str;
+    note:        str;
+    help:        str;
+    related:     *Related;
+    related_len: usize;
+    related_cap: usize;
 }
 
 # owning list of diagnostics collected across one or more phases
@@ -85,6 +98,9 @@ pub rec DiagList {
 
 # initial slot count for the items array on first append
 val INITIAL_CAP: usize = 16;
+
+# initial slot count for a diagnostic's related array on its first secondary span
+val INITIAL_RELATED_CAP: usize = 2;
 
 # construct an empty diagnostic list backed by the given allocator
 # ---
@@ -116,8 +132,15 @@ pub fun dnit(list: *DiagList) {
         if (d.help != nil) {
             str_free(list.a, d.help);
         }
-        if (d.related.label != nil) {
-            str_free(list.a, d.related.label);
+        var r: usize = 0;
+        for (r < d.related_len) {
+            if (d.related[r].label != nil) {
+                str_free(list.a, d.related[r].label);
+            }
+            r = r + 1;
+        }
+        if (d.related != nil && d.related_cap > 0) {
+            A.deallocate[Related](list.a, d.related, d.related_cap);
         }
         i = i + 1;
     }
@@ -179,8 +202,22 @@ pub fun help(list: *DiagList, file_id: source.FileId, span: token.Span, message:
     ret emit(list, SEVERITY_HELP, file_id, span, message);
 }
 
-# attach an owned secondary "note:" line to the most recently recorded
-# diagnostic
+# copy `text` into `a`, or nil on allocation failure or a nil/empty input
+#
+# The shared body of the attach helpers: an owned line/label is advisory, so a
+# failed or empty copy degrades to nil rather than aborting the pass.
+# ---
+# a:    allocator to copy into
+# text: text to copy, or nil
+# ret:  the owned copy, or nil
+fun dup_or_nil(a: *A.Allocator, text: str) str {
+    if (text == nil || str_len(text) == 0) { ret nil; }
+    val res_dup: R.Result[str, str] = str_dup(a, text);
+    if (R.is_err[str, str](res_dup)) { ret nil; }
+    ret R.unwrap_ok[str, str](res_dup);
+}
+
+# attach an owned "= note:" line to the most recently recorded diagnostic
 #
 # A no-op when the list is empty or the last diagnostic already carries a note.
 # Allocation failure is swallowed so a missing note never aborts a pass; the
@@ -190,16 +227,12 @@ pub fun help(list: *DiagList, file_id: source.FileId, span: token.Span, message:
 # note: human-readable secondary message (copied)
 pub fun attach_note(list: *DiagList, note: str) {
     if (list == nil || list.len == 0) { ret; }
-
     val d: *Diagnostic = ?list.items[list.len - 1];
     if (d.note != nil) { ret; }
-
-    val res_dup: R.Result[str, str] = str_dup(list.a, note);
-    if (R.is_err[str, str](res_dup)) { ret; }
-    d.note = R.unwrap_ok[str, str](res_dup);
+    d.note = dup_or_nil(list.a, note);
 }
 
-# attach an owned "help:" suggestion line to the most recently recorded
+# attach an owned "= help:" suggestion line to the most recently recorded
 # diagnostic
 #
 # The help line is distinct from a plain note: the renderer labels it `= help:`.
@@ -211,39 +244,47 @@ pub fun attach_note(list: *DiagList, note: str) {
 # help: human-readable suggestion (copied)
 pub fun attach_help(list: *DiagList, help: str) {
     if (list == nil || list.len == 0) { ret; }
-
     val d: *Diagnostic = ?list.items[list.len - 1];
     if (d.help != nil) { ret; }
-
-    val res_dup: R.Result[str, str] = str_dup(list.a, help);
-    if (R.is_err[str, str](res_dup)) { ret; }
-    d.help = R.unwrap_ok[str, str](res_dup);
+    d.help = dup_or_nil(list.a, help);
 }
 
-# attach a secondary source span with its own file_id and label to the most
-# recently recorded diagnostic
+# append a secondary location to the most recently recorded diagnostic
 #
-# The renderer draws the secondary span at its own location with a `-` underline
-# and the label beneath it. A no-op when the list is empty or the last
-# diagnostic already carries a secondary span. Allocation failure is swallowed so
-# a missing secondary span never aborts a pass; a failed label copy simply leaves
-# the secondary span absent.
+# The renderer draws each secondary location at its own `-->` frame with a `-`
+# underline and the label beneath it. A no-op when the list is empty. The label
+# is optional: a nil or empty label records a bare context span with no caption.
+# Allocation failure is swallowed so a missing secondary span never aborts a
+# pass.
 # ---
-# list:    diagnostic list whose last entry receives the secondary span
+# list:    diagnostic list whose last entry receives the secondary location
 # file_id: identifier of the file the secondary span points into
 # span:    byte range of the secondary location
-# label:   label rendered under the secondary underline (copied)
+# label:   caption rendered under the secondary underline (copied), or nil
 pub fun attach_related(list: *DiagList, file_id: source.FileId, span: token.Span, label: str) {
     if (list == nil || list.len == 0) { ret; }
-
     val d: *Diagnostic = ?list.items[list.len - 1];
-    if (d.related.label != nil) { ret; }
 
-    val res_dup: R.Result[str, str] = str_dup(list.a, label);
-    if (R.is_err[str, str](res_dup)) { ret; }
-    d.related.file_id = file_id;
-    d.related.span    = span;
-    d.related.label   = R.unwrap_ok[str, str](res_dup);
+    if (d.related == nil) {
+        val res_alloc: R.Result[*Related, str] = A.allocate[Related](list.a, INITIAL_RELATED_CAP);
+        if (R.is_err[*Related, str](res_alloc)) { ret; }
+        d.related     = R.unwrap_ok[*Related, str](res_alloc);
+        d.related_cap = INITIAL_RELATED_CAP;
+    }
+    or (d.related_len == d.related_cap) {
+        val new_cap: usize = d.related_cap * 2;
+        val res_realloc: R.Result[*Related, str] = A.reallocate[Related](list.a, d.related, d.related_cap, new_cap);
+        if (R.is_err[*Related, str](res_realloc)) { ret; }
+        d.related     = R.unwrap_ok[*Related, str](res_realloc);
+        d.related_cap = new_cap;
+    }
+
+    var r: Related;
+    r.loc.file_id = file_id;
+    r.loc.span    = span;
+    r.label       = dup_or_nil(list.a, label);
+    d.related[d.related_len] = r;
+    d.related_len = d.related_len + 1;
 }
 
 # whether the list holds at least one error-severity diagnostic
@@ -328,13 +369,15 @@ fun emit(list: *DiagList, severity: Severity, file_id: source.FileId, span: toke
     }
 
     var d: Diagnostic;
-    d.severity      = severity;
-    d.file_id       = file_id;
-    d.span          = span;
-    d.message       = owned;
-    d.note          = nil;
-    d.help          = nil;
-    d.related.label = nil;
+    d.severity     = severity;
+    d.loc.file_id  = file_id;
+    d.loc.span     = span;
+    d.message      = owned;
+    d.note         = nil;
+    d.help         = nil;
+    d.related      = nil;
+    d.related_len  = 0;
+    d.related_cap  = 0;
     list.items[list.len] = d;
     list.len = list.len + 1;
 
@@ -417,9 +460,9 @@ test "mach.lang.diagnostic.attach_help:distinct_from_note" {
     ret 0;
 }
 
-# a related secondary span records its own file_id, span, and label, and a second
-# attach is a no-op while one is present
-test "mach.lang.diagnostic.attach_related:records_secondary_span" {
+# attach_related appends secondary locations, records each loc + label, and
+# treats a nil/empty label as a bare context span
+test "mach.lang.diagnostic.attach_related:appends_secondary_locations" {
     var a: A.Allocator;
     page.make(?a);
     var list: DiagList = init(?a);
@@ -431,22 +474,24 @@ test "mach.lang.diagnostic.attach_related:records_secondary_span" {
     val res_err: R.Result[bool, str] = error(?list, 0::source.FileId, sp, "an error");
     if (R.is_err[bool, str](res_err)) { dnit(?list); ret 1; }
 
-    if (list.items[0].related.label != nil) { dnit(?list); ret 1; }
+    if (list.items[0].related_len != 0) { dnit(?list); ret 1; }
 
     var rel: token.Span;
     rel.offset = 42;
     rel.len    = 5;
     attach_related(?list, 7::source.FileId, rel, "previous definition here");
 
-    if (list.items[0].related.label == nil)          { dnit(?list); ret 1; }
-    if (list.items[0].related.file_id != 7::source.FileId) { dnit(?list); ret 1; }
-    if (list.items[0].related.span.offset != 42)     { dnit(?list); ret 1; }
-    if (list.items[0].related.span.len != 5)         { dnit(?list); ret 1; }
+    if (list.items[0].related_len != 1)                        { dnit(?list); ret 1; }
+    if (list.items[0].related[0].label == nil)                 { dnit(?list); ret 1; }
+    if (list.items[0].related[0].loc.file_id != 7::source.FileId) { dnit(?list); ret 1; }
+    if (list.items[0].related[0].loc.span.offset != 42)        { dnit(?list); ret 1; }
+    if (list.items[0].related[0].loc.span.len != 5)            { dnit(?list); ret 1; }
 
-    val first: str = list.items[0].related.label;
-    attach_related(?list, 9::source.FileId, sp, "other label");
-    if (list.items[0].related.label != first)        { dnit(?list); ret 1; }
-    if (list.items[0].related.file_id != 7::source.FileId) { dnit(?list); ret 1; }
+    # a second attach appends rather than being a no-op; an empty label is bare
+    attach_related(?list, 9::source.FileId, sp, "");
+    if (list.items[0].related_len != 2)                        { dnit(?list); ret 1; }
+    if (list.items[0].related[1].loc.file_id != 9::source.FileId) { dnit(?list); ret 1; }
+    if (list.items[0].related[1].label != nil)                 { dnit(?list); ret 1; }
 
     dnit(?list);
     ret 0;

--- a/src/lang/editor.mach
+++ b/src/lang/editor.mach
@@ -689,6 +689,35 @@ fun diag_note_has(list: *diagnostic.DiagList, sub: str) bool {
     ret false;
 }
 
+# true when any diagnostic on `list` carries a help line containing `sub`
+# ---
+# list: the diagnostic list to scan
+# sub:  substring to search each help line for
+# ret:  true on the first match, false when none match
+fun diag_help_has(list: *diagnostic.DiagList, sub: str) bool {
+    var i: usize = 0;
+    for (i < list.len) {
+        if (list.items[i].help != nil && str_contains(list.items[i].help, sub)) { ret true; }
+        i = i + 1;
+    }
+    ret false;
+}
+
+# true when any diagnostic on `list` carries a secondary span whose label
+# contains `sub`
+# ---
+# list: the diagnostic list to scan
+# sub:  substring to search each secondary-span label for
+# ret:  true on the first match, false when none match
+fun diag_related_has(list: *diagnostic.DiagList, sub: str) bool {
+    var i: usize = 0;
+    for (i < list.len) {
+        if (list.items[i].related.label != nil && str_contains(list.items[i].related.label, sub)) { ret true; }
+        i = i + 1;
+    }
+    ret false;
+}
+
 # the number of diagnostics on `list` whose message contains `sub`
 # ---
 # list: the diagnostic list to scan
@@ -1352,7 +1381,7 @@ test "mach.lang.editor.resolve:unresolved_ident_suggestion" {
     var es: EditorSession = init(?s);
 
     # `helpr` is one edit from the in-scope `helper`, so the message embeds the
-    # unresolved name and a `did you mean` note points at the near match.
+    # unresolved name and a `did you mean` help line points at the near match.
     val res_fid: R.Result[source.FileId, str] = open(?es, "ident.mach",
         "fun helper() i64 { ret 0; }\nfun main() i64 { ret helpr(); }\n");
     if (R.is_err[source.FileId, str](res_fid)) { dnit(?es); session.dnit(?s); ret 1; }
@@ -1363,7 +1392,7 @@ test "mach.lang.editor.resolve:unresolved_ident_suggestion" {
 
     val list: *diagnostic.DiagList = ?es.s.diags;
     if (!diag_has(list, "unresolved identifier `helpr`")) { dnit(?es); session.dnit(?s); ret 1; }
-    if (!diag_note_has(list, "did you mean `helper`?"))   { dnit(?es); session.dnit(?s); ret 1; }
+    if (!diag_help_has(list, "did you mean `helper`?"))   { dnit(?es); session.dnit(?s); ret 1; }
 
     dnit(?es);
     session.dnit(?s);
@@ -1390,7 +1419,43 @@ test "mach.lang.editor.resolve:unresolved_type_suggestion" {
 
     val list: *diagnostic.DiagList = ?es.s.diags;
     if (!diag_has(list, "unresolved type name `Widgt`")) { dnit(?es); session.dnit(?s); ret 1; }
-    if (!diag_note_has(list, "did you mean `Widget`?"))  { dnit(?es); session.dnit(?s); ret 1; }
+    if (!diag_help_has(list, "did you mean `Widget`?"))  { dnit(?es); session.dnit(?s); ret 1; }
+
+    dnit(?es);
+    session.dnit(?s);
+    ret 0;
+}
+
+# a duplicate definition points a secondary span at the previous binding
+test "mach.lang.editor.resolve:duplicate_definition_secondary_span" {
+    var alloc: A.Allocator;
+    val res_session: R.Result[session.Session, str] = t_session(?alloc);
+    if (R.is_err[session.Session, str](res_session)) { ret 1; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](res_session);
+    var es: EditorSession = init(?s);
+
+    # the second `foo` collides with the first; the error carries a secondary span
+    # labelled `previous definition here` pinned to the first `foo` at offset 4.
+    val res_fid: R.Result[source.FileId, str] = open(?es, "dup.mach",
+        "fun foo() i64 { ret 0; }\nfun foo() i64 { ret 1; }\n");
+    if (R.is_err[source.FileId, str](res_fid)) { dnit(?es); session.dnit(?s); ret 1; }
+    val fid: source.FileId = R.unwrap_ok[source.FileId, str](res_fid);
+
+    val res_resolve: R.Result[*res.ResolveResult, str] = resolve(?es, fid);
+    if (R.is_err[*res.ResolveResult, str](res_resolve)) { dnit(?es); session.dnit(?s); ret 1; }
+
+    val list: *diagnostic.DiagList = ?es.s.diags;
+    if (!diag_has(list, "duplicate definition: `foo`"))     { dnit(?es); session.dnit(?s); ret 1; }
+    if (!diag_related_has(list, "previous definition here")) { dnit(?es); session.dnit(?s); ret 1; }
+
+    # the secondary span must land on the first `foo`, not the colliding one
+    var found: bool = false;
+    var i: usize = 0;
+    for (i < list.len) {
+        if (list.items[i].related.label != nil && list.items[i].related.span.offset == 4) { found = true; }
+        i = i + 1;
+    }
+    if (!found) { dnit(?es); session.dnit(?s); ret 1; }
 
     dnit(?es);
     session.dnit(?s);

--- a/src/lang/editor.mach
+++ b/src/lang/editor.mach
@@ -703,16 +703,21 @@ fun diag_help_has(list: *diagnostic.DiagList, sub: str) bool {
     ret false;
 }
 
-# true when any diagnostic on `list` carries a secondary span whose label
+# true when any diagnostic on `list` carries a secondary location whose label
 # contains `sub`
 # ---
 # list: the diagnostic list to scan
-# sub:  substring to search each secondary-span label for
+# sub:  substring to search each secondary-location label for
 # ret:  true on the first match, false when none match
 fun diag_related_has(list: *diagnostic.DiagList, sub: str) bool {
     var i: usize = 0;
     for (i < list.len) {
-        if (list.items[i].related.label != nil && str_contains(list.items[i].related.label, sub)) { ret true; }
+        var r: usize = 0;
+        for (r < list.items[i].related_len) {
+            val rel: *diagnostic.Related = ?list.items[i].related[r];
+            if (rel.label != nil && str_contains(rel.label, sub)) { ret true; }
+            r = r + 1;
+        }
         i = i + 1;
     }
     ret false;
@@ -1452,7 +1457,12 @@ test "mach.lang.editor.resolve:duplicate_definition_secondary_span" {
     var found: bool = false;
     var i: usize = 0;
     for (i < list.len) {
-        if (list.items[i].related.label != nil && list.items[i].related.span.offset == 4) { found = true; }
+        var r: usize = 0;
+        for (r < list.items[i].related_len) {
+            val rel: *diagnostic.Related = ?list.items[i].related[r];
+            if (rel.label != nil && rel.loc.span.offset == 4) { found = true; }
+            r = r + 1;
+        }
         i = i + 1;
     }
     if (!found) { dnit(?es); session.dnit(?s); ret 1; }

--- a/src/lang/fe/ast.mach
+++ b/src/lang/fe/ast.mach
@@ -439,8 +439,14 @@ pub fun get_decl(a: *Ast, id_: id.DeclId) O.Option[*decl.Decl] {
 
 # the span of a declaration's bound identifier, or an empty span (len 0) when the
 # id is out of range or the decl kind carries no name (test, comptime, error).
-# `use`/`fwd` report their alias span. lets diagnostics point a secondary span at
-# the source location of a named declaration.
+# lets diagnostics point a secondary span at the source location of a named
+# declaration.
+#
+# `use`/`fwd` report their alias span, which is empty for an unaliased form
+# (`use std.mem;`): isolating the introduced name would mean splitting the dotted
+# path at its final `.`, which needs the module source this AST-only query does
+# not hold. Callers wanting the path leaf resolve it against the source themselves
+# (see resolve.prior_name_span).
 # ---
 # a:   the Ast
 # id_: DeclId to read the name span of

--- a/src/lang/fe/ast.mach
+++ b/src/lang/fe/ast.mach
@@ -437,6 +437,34 @@ pub fun get_decl(a: *Ast, id_: id.DeclId) O.Option[*decl.Decl] {
     ret O.some[*decl.Decl](?a.decls[id_]);
 }
 
+# the span of a declaration's bound identifier, or an empty span (len 0) when the
+# id is out of range or the decl kind carries no name (test, comptime, error).
+# `use`/`fwd` report their alias span. lets diagnostics point a secondary span at
+# the source location of a named declaration.
+# ---
+# a:   the Ast
+# id_: DeclId to read the name span of
+# ret: the identifier span, or an empty span when there is no name
+pub fun decl_name_span(a: *Ast, id_: id.DeclId) token.Span {
+    var empty: token.Span;
+    empty.offset = 0;
+    empty.len    = 0;
+
+    val opt_d: O.Option[*decl.Decl] = get_decl(a, id_);
+    if (O.is_none[*decl.Decl](opt_d)) { ret empty; }
+    val d: *decl.Decl = O.unwrap[*decl.Decl](opt_d);
+
+    if (d.kind == decl.DECL_KIND_USE) { ret d.data.use_.alias; }
+    if (d.kind == decl.DECL_KIND_FWD) { ret d.data.fwd_.alias; }
+    if (d.kind == decl.DECL_KIND_FUN) { ret d.data.fun_.name;  }
+    if (d.kind == decl.DECL_KIND_REC) { ret d.data.rec_.name;  }
+    if (d.kind == decl.DECL_KIND_UNI) { ret d.data.uni_.name;  }
+    if (d.kind == decl.DECL_KIND_DEF) { ret d.data.def_.name;  }
+    if (d.kind == decl.DECL_KIND_VAL) { ret d.data.bind.name;  }
+    if (d.kind == decl.DECL_KIND_VAR) { ret d.data.bind.name;  }
+    ret empty;
+}
+
 # append a Type to the Ast
 # ---
 # a:   target Ast

--- a/src/lang/fe/lexer.mach
+++ b/src/lang/fe/lexer.mach
@@ -696,7 +696,7 @@ test "mach.lang.fe.lexer.emit_diagnostics:drains_to_sink" {
 
     if (diags.len != stream.error_len)                        { dnit(?stream, ?alloc); diagnostic.dnit(?diags); ret 1; }
     if (diags.items[0].severity != diagnostic.SEVERITY_ERROR) { dnit(?stream, ?alloc); diagnostic.dnit(?diags); ret 1; }
-    if (diags.items[0].span.offset != 2)                      { dnit(?stream, ?alloc); diagnostic.dnit(?diags); ret 1; }
+    if (diags.items[0].loc.span.offset != 2)                  { dnit(?stream, ?alloc); diagnostic.dnit(?diags); ret 1; }
 
     diagnostic.dnit(?diags);
     dnit(?stream, ?alloc);

--- a/src/lang/fe/parser/decl.mach
+++ b/src/lang/fe/parser/decl.mach
@@ -1491,10 +1491,10 @@ test "mach.lang.fe.parser.decl.parse_decl:error_span_pinned" {
     var p_a: state.Parser = state.make(?stream_a, ?a_a, ?diags_a);
     parse_module(?p_a);
     var rc: i32 = 0;
-    if (diags_a.len != 1)                  { rc = 1; }
-    or (diags_a.items[0].span.offset != 0) { rc = 1; }
-    or (diags_a.items[0].span.len    != 2) { rc = 1; }
-    or (a_a.decl_len < 1)                  { rc = 1; }
+    if (diags_a.len != 1)                      { rc = 1; }
+    or (diags_a.items[0].loc.span.offset != 0) { rc = 1; }
+    or (diags_a.items[0].loc.span.len    != 2) { rc = 1; }
+    or (a_a.decl_len < 1)                      { rc = 1; }
     diagnostic.dnit(?diags_a);
     ast.dnit(?a_a);
     lexer.dnit(?stream_a, ?alloc_a);

--- a/src/lang/fe/resolve.mach
+++ b/src/lang/fe/resolve.mach
@@ -742,25 +742,50 @@ fun declare(
     ret R.ok[SymbolId, str](sid);
 }
 
-# attach the prior binding of a duplicate-definition error to the last diagnostic
+# attach the prior binding of a name-collision error to the last diagnostic
 #
 # When `prior` was declared in this module and its declaration carries a name
 # span, the location is attached as a secondary span labelled `previous
-# definition here`. A prior binding with no in-module span (an imported or
-# synthetic symbol) has no source location to point at, so it degrades to a plain
-# clarifying note instead.
+# definition here`. A prior binding declared in another module (an imported or
+# re-exported symbol whose source this module does not hold) has no local
+# location to point at, so it degrades to a plain clarifying note instead. Shared
+# by the duplicate-definition site and the import / re-export collision sites.
 # ---
 # rc:    resolver state for the module being resolved
 # prior: SymbolId of the existing binding the new declaration collides with
 fun report_prior_binding(rc: *ResolveContext, prior: SymbolId) {
     if (rc.symbols[prior].origin == rc.own_module && rc.symbols[prior].decl != id.DECL_NIL) {
-        val prev: token.Span = ast.decl_name_span(rc.a, rc.symbols[prior].decl);
+        val prev: token.Span = prior_name_span(rc, rc.symbols[prior].decl);
         if (prev.len != 0) {
             diagnostic.attach_related(?rc.s.diags, rc.a.file_id, prev, "previous definition here");
             ret;
         }
     }
     diagnostic.attach_note(?rc.s.diags, "a name with this spelling is already bound here");
+}
+
+# the name span of a prior binding's declaration for a "previous definition here"
+# secondary span
+#
+# Delegates to `ast.decl_name_span`, which returns an empty span for an unaliased
+# `use`/`fwd` (its alias span is empty). In that case the dotted path's leaf
+# segment - the name the binding actually introduces - is used instead, resolved
+# against the module source `decl_name_span` cannot reach.
+# ---
+# rc:      resolver state for the module being resolved
+# decl_id: the prior binding's declaration
+# ret:     the name span, or an empty span when the decl carries no name
+fun prior_name_span(rc: *ResolveContext, decl_id: id.DeclId) token.Span {
+    val span: token.Span = ast.decl_name_span(rc.a, decl_id);
+    if (span.len != 0) { ret span; }
+
+    val opt_d: O.Option[*decl.Decl] = ast.get_decl(rc.a, decl_id);
+    if (O.is_none[*decl.Decl](opt_d)) { ret span; }
+    val d: *decl.Decl = O.unwrap[*decl.Decl](opt_d);
+
+    if (d.kind == decl.DECL_KIND_USE) { ret leaf_span(rc, d.data.use_.path); }
+    if (d.kind == decl.DECL_KIND_FWD) { ret leaf_span(rc, d.data.fwd_.path); }
+    ret span;
 }
 
 # seeds the primitive type names (u8..f64, ptr) into the resolver's primitive
@@ -1106,7 +1131,10 @@ fun bind_imported_symbol(rc: *ResolveContext, decl_id: id.DeclId, bind_span: tok
 
     val existing: SymbolId = scope_lookup_local(rc, scope, name_id);
     if (existing != SYMBOL_NIL) {
-        report_named(rc, bind_span, "imported name `", name_id, "` is already defined in this scope");
+        val de: R.Result[bool, str] = report_named(rc, bind_span, "imported name `", name_id, "` is already defined in this scope");
+        if (R.is_ok[bool, str](de)) {
+            report_prior_binding(rc, existing);
+        }
         ret R.ok[bool, str](true);
     }
 
@@ -1525,7 +1553,10 @@ fun bind_fwd(rc: *ResolveContext, decl_id: id.DeclId, df: *decl.DeclFwd, flags: 
 
     val existing: SymbolId = scope_lookup_local(rc, rc.module_scope, name_id);
     if (existing != SYMBOL_NIL) {
-        report_named(rc, bind_span, "re-exported name `", name_id, "` is already defined in this scope");
+        val de: R.Result[bool, str] = report_named(rc, bind_span, "re-exported name `", name_id, "` is already defined in this scope");
+        if (R.is_ok[bool, str](de)) {
+            report_prior_binding(rc, existing);
+        }
         ret R.ok[bool, str](true);
     }
 
@@ -1571,7 +1602,10 @@ fun bind_fwd_module(rc: *ResolveContext, decl_id: id.DeclId, df: *decl.DeclFwd, 
 
     val existing: SymbolId = scope_lookup_local(rc, rc.module_scope, name_id);
     if (existing != SYMBOL_NIL) {
-        report_named(rc, alias_span, "re-exported name `", name_id, "` is already defined in this scope");
+        val de: R.Result[bool, str] = report_named(rc, alias_span, "re-exported name `", name_id, "` is already defined in this scope");
+        if (R.is_ok[bool, str](de)) {
+            report_prior_binding(rc, existing);
+        }
         ret R.ok[bool, str](true);
     }
 

--- a/src/lang/fe/resolve.mach
+++ b/src/lang/fe/resolve.mach
@@ -725,7 +725,7 @@ fun declare(
     if (existing != SYMBOL_NIL) {
         val de: R.Result[bool, str] = report_named(rc, name, "duplicate definition: `", name_id, "` is already bound in this scope");
         if (R.is_ok[bool, str](de)) {
-            diagnostic.attach_note(?rc.s.diags, "a name with this spelling is already bound here");
+            report_prior_binding(rc, existing);
         }
         ret R.ok[SymbolId, str](SYMBOL_NIL);
     }
@@ -740,6 +740,27 @@ fun declare(
     }
 
     ret R.ok[SymbolId, str](sid);
+}
+
+# attach the prior binding of a duplicate-definition error to the last diagnostic
+#
+# When `prior` was declared in this module and its declaration carries a name
+# span, the location is attached as a secondary span labelled `previous
+# definition here`. A prior binding with no in-module span (an imported or
+# synthetic symbol) has no source location to point at, so it degrades to a plain
+# clarifying note instead.
+# ---
+# rc:    resolver state for the module being resolved
+# prior: SymbolId of the existing binding the new declaration collides with
+fun report_prior_binding(rc: *ResolveContext, prior: SymbolId) {
+    if (rc.symbols[prior].origin == rc.own_module && rc.symbols[prior].decl != id.DECL_NIL) {
+        val prev: token.Span = ast.decl_name_span(rc.a, rc.symbols[prior].decl);
+        if (prev.len != 0) {
+            diagnostic.attach_related(?rc.s.diags, rc.a.file_id, prev, "previous definition here");
+            ret;
+        }
+    }
+    diagnostic.attach_note(?rc.s.diags, "a name with this spelling is already bound here");
 }
 
 # seeds the primitive type names (u8..f64, ptr) into the resolver's primitive
@@ -2377,7 +2398,7 @@ fun attach_suggestion(rc: *ResolveContext, target: intern.StrId) {
 
     val note: str = diagnostic.suggestion_build(rc.s.alloc, bname);
     if (note == nil) { ret; }
-    diagnostic.attach_note(?rc.s.diags, note);
+    diagnostic.attach_help(?rc.s.diags, note);
     str_free(rc.s.alloc, note);
 }
 


### PR DESCRIPTION
Closes #1783. Follow-up to #1777 (part of the #1773 output overhaul).

## What

Two minimal, documented additions to the diagnostic data model, with the renderer and emission sites updated to use them:

1. **Distinct `= help:` label.** `Diagnostic` gains an owned `help` line, separate from `note`. The did-you-mean suggestion now attaches via `attach_help` and renders as `= help:`; plain clarifying notes keep `= note:`.
2. **Secondary span at an arbitrary location.** `Diagnostic` gains an optional `Related` record (its own `file_id`, `span`, `label`). On a duplicate definition the prior binding is attached as a secondary span labelled `previous definition here`, drawn in its own `--> file:line:col` frame with a `-` underline.

The model/renderer split stays clean: help lines and secondary spans are structured fields, so the future `mach check --format json` consumer (#1815) reads them without scraping the note text.

## Model changes

- `diagnostic.mach`: new `pub rec Related { file_id; span; label }`; `Diagnostic` gains `help: str` and `related: Related` (both absent-sentinelled by nil). New `attach_help` / `attach_related` mirror `attach_note`'s last-diagnostic, idempotent, allocation-tolerant contract; `dnit` frees the new owned strings.
- `ast.mach`: new `decl_name_span(a, decl_id)` returns a declaration's identifier span (empty when the kind carries no name).
- `resolve.mach`: suggestion → `attach_help`; duplicate definition → `report_prior_binding`, which locates the prior decl in this module and attaches the secondary span, degrading to the existing `= note:` when the prior binding has no in-module span (imported/synthetic).
- `cli/diagnostic.mach`: `Frame`/`locate` geometry helper; primary and secondary spans draw through one `emit_frame` with a unified gutter width.

## Sample rendered output

```
error: duplicate definition: `demo_dup` is already bound in this scope
 --> demo/src/main.mach:3:5
  |
3 | fun demo_dup() i64 { ret 1; }
  |     ^^^^^^^^
 --> demo/src/main.mach:2:5
  |
2 | fun demo_dup() i64 { ret 0; }
  |     -------- previous definition here

error: unresolved identifier `demo_helpr`
 --> demo/src/main.mach:4:22
  |
4 | fun main() i64 { ret demo_helpr(); }
  |                      ^^^^^^^^^^
  |
  = help: did you mean `demo_helper`?
```

## Verification

- `mach test .` — 447 passed, 0 failed (adds 2 model tests in `diagnostic.mach`, 1 secondary-span test in `editor.mach`; existing suggestion tests moved from note to help assertions).
- Self-host fixpoint: host-built stage1 and stage1-built stage2 byte-identical (rendering-only change).
- `int/run.sh --target linux`: all cases pass.
