### PR TITLE
fix(link/elf): refuse a PIE header block that overflows its reserved page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,13 @@ integer literals now report their bounds.
   overflowed a signed slot (e.g. `val mask: i64 = 0xFFFFFFFFFFFFFFFF;`) used to
   compile and silently wrap at runtime; it is now rejected, while `u64` slots
   keep their legitimate maximum (#1804).
+- link/elf: **the ELF exec writers refuse a program-header table that overflows
+  its reserved header page** - the PIE and dynamic writers extend the first
+  `PT_LOAD` down exactly one page to cover the ELF header + program headers, which
+  only maps segment 0 at its vaddr while the header block fits that page
+  (`phdr_count <= 72`). Past that the image was silently unloadable; the writers now
+  return a link error instead. Latent (real builds emit ~9 headers), owning the
+  invariant before segment counts grow (#1814).
 
 ## [2.12.0] - 2026-07-01
 

--- a/src/lang/target/of/elf.mach
+++ b/src/lang/target/of/elf.mach
@@ -1429,15 +1429,16 @@ fun emit_exec(alloc: *A.Allocator, itn: *intern.Interner, tgt_isa: *isa.IsaVTabl
 }
 
 # whether the ELF header + `phdr_count` program headers fit the single page the linker
-# reserves below the first load segment for a PIE image (`assign_section_vaddrs`)
+# reserves below the first load segment for a PIE or dynamic image (`assign_section_vaddrs`)
 #
-# The PIE writer extends the first PT_LOAD down exactly one page to file offset 0 so it
-# covers the ELF header and the program-header table, mapping them at `segs[0].vaddr -
-# page`. That holds the loader's `p_offset == p_vaddr (mod page)` congruence only while
-# the header block fits that one page: `ELF_HEADER_SIZE + phdr_count * PHDR_SIZE <= page`,
-# i.e. `phdr_count <= 72`. A larger table spills onto a second page, pushing the first
-# segment's file offset a page past `hdr_vaddr + page` so segment 0 no longer maps at its
-# vaddr - an image the kernel refuses to exec. The writer refuses at link time instead.
+# The PIE and dynamic writers extend the first PT_LOAD down exactly one page to file offset
+# 0 so it covers the ELF header and the program-header table, mapping them at
+# `segs[0].vaddr - page`. That holds the loader's `p_offset == p_vaddr (mod page)`
+# congruence only while the header block fits that one page: `ELF_HEADER_SIZE + phdr_count
+# * PHDR_SIZE <= page`, i.e. `phdr_count <= 72`. A larger table spills onto a second page,
+# pushing the first segment's file offset a page past `hdr_vaddr + page` so segment 0 no
+# longer maps at its vaddr - an image the kernel refuses to exec. The writer refuses at
+# link time instead.
 # ---
 # phdr_count: the number of program headers the writer will emit
 # ret:        true when the header block still fits its one reserved page
@@ -1984,6 +1985,14 @@ fun emit_dyn_exec(alloc: *A.Allocator, itn: *intern.Interner, tgt_isa: *isa.IsaV
     # synthesized + PT_DYNAMIC). the first linker segment also maps the ELF
     # header + phdrs, so no separate header-covering PT_LOAD is needed.
     val phdr_count: u32 = seg_count + 6;
+
+    # like the PIE writer, the first PT_LOAD covers the ELF header + phdr table by
+    # extending one page below segment 0; a header block larger than that page would break
+    # segment 0's mapping, so refuse rather than emit an unloadable image (see #1814).
+    if (!header_fits_reserved_page(phdr_count)) {
+        ret R.err[bool, str]("elf: dynamic-exec program headers exceed the one-page header reservation (too many load segments)");
+    }
+
     val phdr_offset: usize = ELF_HEADER_SIZE;
     val phdr_table_size: usize = phdr_count::usize * PHDR_SIZE;
 
@@ -4328,6 +4337,52 @@ test "mach.lang.target.of.elf.emit_pie_exec:header_overflow_refused" {
     val tpath: str = filesystem.temp_path(?tf);
 
     val em: R.Result[bool, str] = emit_pie_exec(?alloc, ?i, ?isa_vt, ?segs[0], 70, 0x401000, ?dyn, tpath::*u8);
+    filesystem.temp_close_and_remove(?tf);
+    if (R.is_ok[bool, str](em)) { ret 1; }
+    ret 0;
+}
+
+# emit_dyn_exec shares the PIE writer's one-page header trick with `phdr_count = seg_count
+# + 6`, so it refuses the same overflow: 67 segments emit 73 program headers whose table
+# spills onto a second page. the writer must return an error rather than emit an unloadable
+# dynamic image (issue #1814).
+test "mach.lang.target.of.elf.emit_dyn_exec:header_overflow_refused" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+    var i: intern.Interner = intern.init(?alloc);
+
+    var isa_vt: isa.IsaVTable;
+    isa_vt.id            = isa.ARCH_X86_64;
+    isa_vt.elf_machine   = 62;       # EM_X86_64
+    isa_vt.pointer_width = 8;
+
+    # vaddrs are immaterial: the guard fires before segment layout, so the segments carry
+    # no bytes and only their count drives the refusal.
+    var segs: [67]of.LoadSegment;
+    var s: u32 = 0;
+    for (s < 67) {
+        segs[s].vaddr = 0x401000 + s::u64 * EXEC_PAGE_SIZE;
+        segs[s].filesz = 0; segs[s].memsz = 0;
+        segs[s].flags = of.SEG_FLAG_READ; segs[s].bytes = nil;
+        s = s + 1;
+    }
+
+    # a non-PIE dynamic plan with no imports so emit_dyn_exec stays on the ET_EXEC path.
+    var dyn: of.DynamicInfo;
+    dyn.libs = nil;            dyn.lib_count = 0;
+    dyn.imports = nil;         dyn.import_count = 0;
+    dyn.interp = intern.STR_NIL;
+    dyn.base_relocs = nil;     dyn.base_reloc_count = 0;
+    dyn.pie = false;
+
+    val tf_r: R.Result[filesystem.TempFile, str] = filesystem.temp_create(?alloc, "elf_dyn_overflow");
+    if (R.is_err[filesystem.TempFile, str](tf_r)) { ret 1; }
+    var tf: filesystem.TempFile = R.unwrap_ok[filesystem.TempFile, str](tf_r);
+    val tpath: str = filesystem.temp_path(?tf);
+
+    val em: R.Result[bool, str] = emit_dyn_exec(?alloc, ?i, ?isa_vt, ?segs[0], 67, 0x401000,
+                                                nil::*of.ExecFunction, 0, ?dyn, nil::*of.PltFixup, 0,
+                                                tpath::*u8, "dynoverflow"::*u8);
     filesystem.temp_close_and_remove(?tf);
     if (R.is_ok[bool, str](em)) { ret 1; }
     ret 0;

--- a/src/lang/target/of/elf.mach
+++ b/src/lang/target/of/elf.mach
@@ -1428,6 +1428,23 @@ fun emit_exec(alloc: *A.Allocator, itn: *intern.Interner, tgt_isa: *isa.IsaVTabl
     ret R.ok[bool, str](true);
 }
 
+# whether the ELF header + `phdr_count` program headers fit the single page the linker
+# reserves below the first load segment for a PIE image (`assign_section_vaddrs`)
+#
+# The PIE writer extends the first PT_LOAD down exactly one page to file offset 0 so it
+# covers the ELF header and the program-header table, mapping them at `segs[0].vaddr -
+# page`. That holds the loader's `p_offset == p_vaddr (mod page)` congruence only while
+# the header block fits that one page: `ELF_HEADER_SIZE + phdr_count * PHDR_SIZE <= page`,
+# i.e. `phdr_count <= 72`. A larger table spills onto a second page, pushing the first
+# segment's file offset a page past `hdr_vaddr + page` so segment 0 no longer maps at its
+# vaddr - an image the kernel refuses to exec. The writer refuses at link time instead.
+# ---
+# phdr_count: the number of program headers the writer will emit
+# ret:        true when the header block still fits its one reserved page
+fun header_fits_reserved_page(phdr_count: u32) bool {
+    ret ELF_HEADER_SIZE + phdr_count::usize * PHDR_SIZE <= EXEC_PAGE_SIZE::usize;
+}
+
 # write a position-independent (PIE / ET_DYN) static executable for linux ASLR
 #
 # A static-PIE: an ET_DYN image the kernel loads at a randomized base, self-relocated
@@ -1487,6 +1504,14 @@ fun emit_pie_exec(alloc: *A.Allocator, itn: *intern.Interner, tgt_isa: *isa.IsaV
     var relro_extra: u32 = 0;
     if (pie_relro_seg(segs, seg_count, dyn) >= 0) { relro_extra = 1; }
     val phdr_count: u32 = seg_count + 3 + relro_extra;
+
+    # the first PT_LOAD covers the ELF header + phdr table by extending one page below
+    # segment 0; a header block larger than that page would break segment 0's mapping, so
+    # refuse rather than emit an image the kernel cannot exec (see #1814).
+    if (!header_fits_reserved_page(phdr_count)) {
+        ret R.err[bool, str]("elf: PIE program headers exceed the one-page header reservation (too many load segments)");
+    }
+
     val phdr_offset: usize = ELF_HEADER_SIZE;
     val phdr_table_size: usize = phdr_count::usize * PHDR_SIZE;
 
@@ -4249,5 +4274,61 @@ test "mach.lang.target.of.elf.emit_pie_exec:relro_covers_ro_reloc_segment" {
     if (data_load_flags != (PF_R | PF_W))   { bad = true; }
 
     if (bad) { ret 1; }
+    ret 0;
+}
+
+# header_fits_reserved_page pins the one-page header threshold the PIE writer refuses
+# past: the ELF header + phdr table must fit the single page the linker reserves below
+# segment 0, so `64 + 72*56 == 4096` fits exactly and 73 headers (4152 bytes) do not.
+test "mach.lang.target.of.elf.header_fits_reserved_page:one_page_threshold" {
+    var bad: bool = false;
+    if (!header_fits_reserved_page(1))  { bad = true; }
+    if (!header_fits_reserved_page(72)) { bad = true; }
+    if (header_fits_reserved_page(73))  { bad = true; }
+    if (bad) { ret 1; }
+    ret 0;
+}
+
+# emit_pie_exec refuses a header block that overflows the one page the linker reserves
+# below the first load segment: 70 segments emit 73 program headers (seg_count + 3), whose
+# table (4152 bytes) spills onto a second page, so the first PT_LOAD extended down one page
+# could no longer map segment 0 at its vaddr. the writer must return an error at link time
+# rather than emit a silently unloadable image (issue #1814).
+test "mach.lang.target.of.elf.emit_pie_exec:header_overflow_refused" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+    var i: intern.Interner = intern.init(?alloc);
+
+    var isa_vt: isa.IsaVTable;
+    isa_vt.id            = isa.ARCH_X86_64;
+    isa_vt.elf_machine   = 62;       # EM_X86_64
+    isa_vt.pointer_width = 8;
+
+    # vaddrs are immaterial: the guard fires before segment layout, so the segments carry
+    # no bytes and only their count drives the refusal.
+    var segs: [70]of.LoadSegment;
+    var s: u32 = 0;
+    for (s < 70) {
+        segs[s].vaddr = 0x401000 + s::u64 * EXEC_PAGE_SIZE;
+        segs[s].filesz = 0; segs[s].memsz = 0;
+        segs[s].flags = of.SEG_FLAG_READ; segs[s].bytes = nil;
+        s = s + 1;
+    }
+
+    var dyn: of.DynamicInfo;
+    dyn.libs = nil;            dyn.lib_count = 0;
+    dyn.imports = nil;         dyn.import_count = 0;
+    dyn.interp = intern.STR_NIL;
+    dyn.base_relocs = nil;     dyn.base_reloc_count = 0;
+    dyn.pie = true;
+
+    val tf_r: R.Result[filesystem.TempFile, str] = filesystem.temp_create(?alloc, "elf_pie_overflow");
+    if (R.is_err[filesystem.TempFile, str](tf_r)) { ret 1; }
+    var tf: filesystem.TempFile = R.unwrap_ok[filesystem.TempFile, str](tf_r);
+    val tpath: str = filesystem.temp_path(?tf);
+
+    val em: R.Result[bool, str] = emit_pie_exec(?alloc, ?i, ?isa_vt, ?segs[0], 70, 0x401000, ?dyn, tpath::*u8);
+    filesystem.temp_close_and_remove(?tf);
+    if (R.is_ok[bool, str](em)) { ret 1; }
     ret 0;
 }


### PR DESCRIPTION
Closes #1814.

## Problem

The ELF static-PIE writer (`emit_pie_exec`) extends the first `PT_LOAD` down exactly one page to file offset 0 so a single load segment covers the ELF header + program-header table, mapping them at `segs[0].vaddr - page`. The linker's `assign_section_vaddrs` reserves exactly that one page above the base. The scheme holds the loader's `p_offset ≡ p_vaddr (mod page)` congruence only while the header block fits that one page: `ELF_HEADER_SIZE + phdr_count * PHDR_SIZE ≤ 4096`, i.e. `phdr_count ≤ 72`. Past that, `seg_offsets[0]` jumps to the second page boundary while `hdr_vaddr` stays one page below `segs[0].vaddr`; segment 0 no longer maps at its vaddr and the kernel refuses to exec the image — with nothing at link time flagging the cause.

Not constructible today (a PIE emits `seg_count + 3 (+1 RELRO)` headers and the merged-kind model caps `seg_count` at 5, so `phdr_count` is ~9); filed to own the invariant before segment counts grow. The dynamic ET_EXEC writer (`emit_dyn_exec` / `write_dyn_phdrs`) uses the identical one-page header trick with `phdr_count = seg_count + 6`, so it shares the same latent break at `seg_count > 66` — both writers are covered here.

## Fix chosen: loud link-time refusal (not multi-page mapping)

The issue offers two fixes. I implemented the **refusal**, and here is why the multi-page mapping alternative is disproportionate:

- Keeping congruence while mapping the header at `segs[0].vaddr - roundup(hdr_size, page)` forces the header below `segs[0].vaddr - page`, i.e. below `base`. For linux (`0x400000`) / darwin (`0x100000000`) that is merely a lower vaddr, but for **freestanding (`base = 0`) it underflows u64**.
- Making it correct-by-construction instead requires the *format-agnostic* linker (`assign_section_vaddrs`, shared by ELF/Mach-O/COFF) to reserve `roundup(hdr_size, page)` above base — which means teaching the generic layout the ELF-specific phdr-count formula (`seg_count + 3 (+relro)` / `seg_count + 6`), or adding an `OfVTable` header-size hook and threading it through layout. That cross-subsystem coupling to fix a non-constructible path is out of proportion.

The refusal instead makes real the contract the linker **already documents** at `assign_section_vaddrs` — *"The writer asserts the header fits the one-page reservation"* — an assertion that did not previously exist. It is localized to the writers (where `phdr_count` is known), preserves the RELRO *"each segment owns its trailing page"* / page-rounded `p_memsz` invariants untouched, and converts a silent unloadable-image bug into a clear diagnostic.

## Change

- `header_fits_reserved_page(phdr_count)` — pure predicate for the `ELF_HEADER_SIZE + phdr_count * PHDR_SIZE ≤ EXEC_PAGE_SIZE` threshold, shared by both ELF exec writers.
- `emit_pie_exec` and `emit_dyn_exec` each gate on it right after computing `phdr_count`, returning a clear link error before any allocation or file creation.
- `CHANGELOG.md`: a `Fixed` entry under `[Unreleased]`.

## Tests

- `header_fits_reserved_page:one_page_threshold` — pins the exact boundary (1 and 72 fit; 73 does not).
- `emit_pie_exec:header_overflow_refused` — 70 segments → 73 phdrs → the writer returns an error and writes no file.
- `emit_dyn_exec:header_overflow_refused` — 67 segments → 73 phdrs → same, on the dynamic path.

Verification: full unit suite `473 passed, 0 failed`; PIE + RELRO integration cases pass on the linux leg (`elf-pie`, `pie-reloc`, `pie-relro-fault`, `elf-relro`, `macho-pie-*`); self-host build with the from-source compiler succeeds.
