### PR TITLE
feat(codegen): skip homing moves for unused scalar params

### DIFF
--- a/src/lang/be/codegen/mir/abi.mach
+++ b/src/lang/be/codegen/mir/abi.mach
@@ -25,6 +25,7 @@ use R: std.types.result;
 
 use mach.lang.be.codegen.mir;
 use mach.lang.be.codegen.mir.context;
+use ir: mach.lang.me.ir;
 use mach.lang.me.ir.id;
 use mach.lang.me.ir.instruction;
 use mach.lang.me.ir.type;
@@ -1239,10 +1240,18 @@ pub fun lower_params(ctx: *context.LowerCtx, mb: *mir.MirBlock) R.Result[bool, s
         val pag:  bool = context.value_is_aggregate(ctx, pty);
         val slot: abi.ParamSlot = layout.params[i];
 
-        val er: R.Result[bool, str] = emit_param_slot(ctx, mb, slot, pv, slot.size, slot.offset, pag);
-        if (R.is_err[bool, str](er)) {
-            sig_layout_free(ctx, ?layout);
-            ret er;
+        # a scalar parameter the optimized body never reads needs no homing move:
+        # after the always-on mem2reg/dce its entry spill is gone, so the copy out
+        # of the incoming register would be dead on arrival. skip minting it (the
+        # regalloc dead-def sweep remains the general backstop; #1820). an aggregate
+        # parameter is out of scope -- its spill-slot store / reconstruction may
+        # still be needed even when the pointer vreg is unread -- so it always lowers.
+        if (pag || param_has_use(ctx.fn, i)) {
+            val er: R.Result[bool, str] = emit_param_slot(ctx, mb, slot, pv, slot.size, slot.offset, pag);
+            if (R.is_err[bool, str](er)) {
+                sig_layout_free(ctx, ?layout);
+                ret er;
+            }
         }
         i = i + 1;
     }
@@ -1317,6 +1326,66 @@ fun emit_param_slot(ctx: *context.LowerCtx, mb: *mir.MirBlock, slot: abi.ParamSl
         ret materialize_pieces(ctx, mb, slot, plan);
     }
     ret context.emit_mov(ctx, mb, mir.op_vreg(pv), mir.op_preg(slot.reg::u32));
+}
+
+# report whether IR parameter `param_ix` is read anywhere in the function body
+#
+# Walks the block-reachable instructions -- each block's phis, ordered body, and
+# terminator, the same set the translation lowers -- for an operand naming the
+# parameter. The block lists are the liveness source of truth, so an instruction
+# the middle end unlinked but left in the pool is correctly not counted as a use.
+# `lower_params` consults this to drop the homing move for a scalar parameter with
+# no uses: after the always-on mem2reg/dce an ignored parameter's entry spill is
+# gone, leaving zero uses, so its incoming-register copy is dead on arrival.
+# ---
+# fn:       the IR function being lowered
+# param_ix: the zero-based parameter index
+# ret:      true when some live operand names the parameter
+fun param_has_use(fn: *ir.Function, param_ix: u32) bool {
+    var bi: u32 = 0;
+    for (bi < fn.block_count) {
+        val blk: *ir.Block = ?fn.blocks[bi];
+
+        var pj: u32 = 0;
+        for (pj < blk.phi_count) {
+            if (instr_names_param(fn, blk.phis[pj], param_ix)) { ret true; }
+            pj = pj + 1;
+        }
+
+        var ii: u32 = 0;
+        for (ii < blk.instr_count) {
+            if (instr_names_param(fn, blk.instructions[ii], param_ix)) { ret true; }
+            ii = ii + 1;
+        }
+
+        if (instr_names_param(fn, blk.terminator, param_ix)) { ret true; }
+
+        bi = bi + 1;
+    }
+    ret false;
+}
+
+# report whether the instruction `iid` names IR parameter `param_ix` in an operand
+#
+# A nil / out-of-range id yields false (a block's absent terminator or a stale id).
+# Block-target operands are integer constants, not VAL_PARAM, so a branch's
+# successor slots never register as a parameter use.
+# ---
+# fn:       the IR function owning the instruction pool
+# iid:      the instruction id to inspect
+# param_ix: the zero-based parameter index
+# ret:      true when an operand is the VAL_PARAM for `param_ix`
+fun instr_names_param(fn: *ir.Function, iid: id.InstructionId, param_ix: u32) bool {
+    if (iid == id.INSTR_NIL)      { ret false; }
+    if (iid::u32 >= fn.instr_len) { ret false; }
+    val inst: *instruction.Instruction = ?fn.instrs[iid::u32];
+    var k: u32 = 0;
+    for (k < inst.operand_count) {
+        val v: value.Value = inst.operands[k];
+        if (v.kind == value.VAL_PARAM && v.data.param_ix == param_ix) { ret true; }
+        k = k + 1;
+    }
+    ret false;
 }
 
 # emit the return-value ABI pre-coloring before an OP_RET terminator


### PR DESCRIPTION
## What

`lower_params` (`src/lang/be/codegen/mir/abi.mach`) minted a `MIR_MOV` homing copy for **every** classified scalar parameter, whether or not the optimized body ever read it. The `-O0` `main(argc, argv)` that ignores both parameters is the canonical case: two dead `mov`s were built, then deleted by #1801's regalloc dead-def sweep.

This teaches ABI lowering not to create the copy in the first place when the parameter has no uses. `param_has_use` walks the function's block-reachable instructions (each block's phis, ordered body, and terminator — the liveness source of truth, so instructions the middle end unlinked but left in the pool don't count) for an operand naming the parameter; `lower_params` emits the homing move only when the parameter is used.

The always-on `mem2reg`/`dce` (they run at every opt level) promote away an ignored parameter's entry alloca+store spill, so an unused parameter genuinely has zero uses in the post-pipeline IR that codegen sees — its incoming-register copy is dead on arrival.

## Scope

- Only the **scalar-register homing move** is gated (`if (pag || param_has_use(ctx.fn, i))`: emit when the parameter is an aggregate or has a use; skip only scalar + zero-use).
- A **by-value aggregate** parameter is explicitly out of scope: its spill-slot store / register reconstruction may still be needed even when the pointer vreg is unread, so it always lowers.
- #1801's regalloc dead-def sweep **stays** as the general backstop (it also catches unread phi/return captures the front end can't know about). This is the complementary emit-what's-needed win: fewer instructions built before the backend runs.

## Verification

- **Full unit suite**: 470 passed, 0 failed.
- **Self-host byte-identical fixpoint** at both `-O0` and `--profile release` (`mach build . -o a; ./a build . -o b; ./b build . -o c; cmp b c`). Final machine code is unchanged, as expected — the sweep already removed these moves.
- **Integration suite** (`int/run.sh`): all cases pass on `linux` (native, sysv64) and `linux-riscv64` (qemu, lp64). Representative param-heavy cases (`float`, `sign-extension`, `aggregate-abi`, `control-flow`) cross-built and run under `qemu-aarch64` (aapcs64) match their goldens.

## Numbers (honest)

The final binary is byte-identical, so the win is compile-time work avoided — homing moves not built that the sweep would otherwise build then delete. Measured two independent ways over the whole compiler corpus (`src/` + `dep/mach-std`, 8503 functions with bodies):

| profile | homing moves skipped |
|---|---|
| `-O0` (debug) | 111 |
| `-O2` (release) | 113 |

Method: (1) parsing the post-pipeline `--emit-ir` dump for scalar params (type not `{`/`[`) with zero body references; (2) a throwaway instrumented build emitting one marker per gate firing, counted on stderr. Both agree exactly.

Closes #1820.
