### PR TITLE
fix(cli): reject unknown flags instead of misparsing them

### DIFF
--- a/doc/cli.md
+++ b/doc/cli.md
@@ -15,6 +15,13 @@ matched exactly: `--flag value` (a value follows in the next argument) or a bare
 `--flag` toggle. The combined `--flag=value` form and bundled short flags are
 **not** recognized.
 
+An unrecognized flag is a hard error. Before it resolves positionals, each
+command rejects the first `-`/`--` token it does not accept — `error: unknown
+flag '<flag>' for '<command>'` — so a typo'd or removed flag never silently
+misparses as a project path or link input. Arguments after a `--` separator are
+program arguments, not flags (`mach run` forwards them to the executed binary),
+so a value that must begin with `-` is passed there.
+
 ## Commands
 
 | Command | Summary |

--- a/doc/cli.md
+++ b/doc/cli.md
@@ -17,10 +17,25 @@ matched exactly: `--flag value` (a value follows in the next argument) or a bare
 
 An unrecognized flag is a hard error. Before it resolves positionals, each
 command rejects the first `-`/`--` token it does not accept — `error: unknown
-flag '<flag>' for '<command>'` — so a typo'd or removed flag never silently
-misparses as a project path or link input. Arguments after a `--` separator are
-program arguments, not flags (`mach run` forwards them to the executed binary),
-so a value that must begin with `-` is passed there.
+flag '<flag>' for '<command>'`, exit `1` — so a typo'd or removed flag never
+silently misparses as a project path or link input. `-h` / `--help` is accepted
+on every command and prints that command's help page.
+
+A `--` separator ends the flag region on every command: `--` itself and every
+token after it are never flag-rejected. What happens to the tokens after it
+depends on the command:
+
+- `run` forwards them to the executed binary as its `argv`
+  (`mach run <path> -- --flag`); `build` and `test` stop scanning at `--` (post-`--`
+  tokens are neither flags nor link inputs).
+- `doc`, `check`, and `init` take the token right after `--` as their positional,
+  so a `-`-leading path is reachable: `mach doc -- -weird-dir`,
+  `mach check -- -weird.mach`.
+
+Consequently a lone `-` or a negative-number token (e.g. `-1`) at a flag position
+is rejected as an unknown flag; where a command reads a positional after `--`
+(above), pass it there. No CLI positional legitimately begins with `-` today, so
+this only matters for oddly-named paths.
 
 ## Commands
 

--- a/src/cli/cmd.mach
+++ b/src/cli/cmd.mach
@@ -5,10 +5,17 @@
 # one, it prints an error where applicable, invokes help, and returns a nonzero
 # exit code.
 
+use std.allocator.page;
 use std.print;
+use std.types.bool.bool;
+use std.types.bool.false;
 use std.types.size.usize;
 use std.types.string.str;
 use std.types.string.str_equals;
+
+use A: std.allocator;
+use O: std.types.option;
+use R: std.types.result;
 
 use mach.cli.cmd.build;
 use mach.cli.cmd.check;
@@ -31,17 +38,36 @@ pub fun dispatch(argc: usize, argv: **u8) i64 {
         ret 1;
     }
 
+    # one consumption record parallel to argv: each subcommand marks the flags it
+    # recognizes (config.parse for the cross-cutting set, the command for its own),
+    # then rejects any unmarked flag token before resolving positionals, so an
+    # unknown flag is a hard error instead of a silent misparse (#1810). backed by
+    # a page allocator that outlives the dispatched command.
+    var marks_backing: A.Allocator;
+    if (O.is_some[str](page.make(?marks_backing))) {
+        print.eprint("error: failed to initialise allocator\n");
+        ret 2;
+    }
+    val res_marks: R.Result[*bool, str] = A.allocate[bool](?marks_backing, argc);
+    if (R.is_err[*bool, str](res_marks)) {
+        print.eprint("error: out of memory\n");
+        ret 2;
+    }
+    val marks: *bool = R.unwrap_ok[*bool, str](res_marks);
+    var mi: usize = 0;
+    for (mi < argc) { marks[mi] = false; mi = mi + 1; }
+
     val command: str = argv[1]::str;
 
-    if (str_equals(command, "build")) { ret build.run(argc, argv);   }
-    if (str_equals(command, "run"))   { ret run.run(argc, argv);     }
-    if (str_equals(command, "test"))  { ret testing.run(argc, argv); }
-    if (str_equals(command, "check")) { ret check.run(argc, argv);   }
-    if (str_equals(command, "dep"))   { ret dep.run(argc, argv);     }
-    if (str_equals(command, "init"))  { ret init.run(argc, argv);    }
-    if (str_equals(command, "doc"))   { ret doc.run(argc, argv);     }
-    if (str_equals(command, "info"))  { ret info.run(argc, argv);    }
-    if (str_equals(command, "help"))  { ret help.run(argc, argv);    }
+    if (str_equals(command, "build")) { ret build.run(argc, argv, marks);   }
+    if (str_equals(command, "run"))   { ret run.run(argc, argv, marks);     }
+    if (str_equals(command, "test"))  { ret testing.run(argc, argv, marks); }
+    if (str_equals(command, "check")) { ret check.run(argc, argv, marks);   }
+    if (str_equals(command, "dep"))   { ret dep.run(argc, argv, marks);     }
+    if (str_equals(command, "init"))  { ret init.run(argc, argv, marks);    }
+    if (str_equals(command, "doc"))   { ret doc.run(argc, argv, marks);     }
+    if (str_equals(command, "info"))  { ret info.run(argc, argv, marks);    }
+    if (str_equals(command, "help"))  { ret help.run(argc, argv);           }
 
     print.eprint("error: unknown command '");
     print.eprint(command);

--- a/src/cli/cmd.mach
+++ b/src/cli/cmd.mach
@@ -17,6 +17,8 @@ use A: std.allocator;
 use O: std.types.option;
 use R: std.types.result;
 
+use mach.cli.util;
+
 use mach.cli.cmd.build;
 use mach.cli.cmd.check;
 use mach.cli.cmd.dep;
@@ -34,8 +36,19 @@ use mach.cli.cmd.testing;
 # ret:  the subcommand's exit code, or 1 when the subcommand is missing or unknown
 pub fun dispatch(argc: usize, argv: **u8) i64 {
     if (argc < 2) {
-        help.run(argc, argv);
+        help.usage();
         ret 1;
+    }
+
+    val command: str = argv[1]::str;
+
+    # `-h` / `--help` before a `--` separator is the near-universal help gesture:
+    # print the command's page (top-level usage for an unknown command) and exit
+    # cleanly, rather than letting the rejector treat it as an unknown flag (#1810).
+    val eff: usize = util.separator_index(argc, argv);
+    if (util.has_flag(eff, argv, "-h") || util.has_flag(eff, argv, "--help")) {
+        if (!help.page(command)) { help.usage(); }
+        ret 0;
     }
 
     # one consumption record parallel to argv: each subcommand marks the flags it
@@ -57,8 +70,6 @@ pub fun dispatch(argc: usize, argv: **u8) i64 {
     var mi: usize = 0;
     for (mi < argc) { marks[mi] = false; mi = mi + 1; }
 
-    val command: str = argv[1]::str;
-
     if (str_equals(command, "build")) { ret build.run(argc, argv, marks);   }
     if (str_equals(command, "run"))   { ret run.run(argc, argv, marks);     }
     if (str_equals(command, "test"))  { ret testing.run(argc, argv, marks); }
@@ -67,11 +78,11 @@ pub fun dispatch(argc: usize, argv: **u8) i64 {
     if (str_equals(command, "init"))  { ret init.run(argc, argv, marks);    }
     if (str_equals(command, "doc"))   { ret doc.run(argc, argv, marks);     }
     if (str_equals(command, "info"))  { ret info.run(argc, argv, marks);    }
-    if (str_equals(command, "help"))  { ret help.run(argc, argv);           }
+    if (str_equals(command, "help"))  { ret help.run(argc, argv, marks);    }
 
     print.eprint("error: unknown command '");
     print.eprint(command);
     print.eprint("'\n");
-    help.run(argc, argv);
+    help.usage();
     ret 1;
 }

--- a/src/cli/cmd/build.mach
+++ b/src/cli/cmd/build.mach
@@ -474,7 +474,10 @@ fun build_unit(a: *A.Allocator, argc: usize, argv: **u8, emit_obj: bool, test_mo
     # scan, or the project-path positional. with no `--` present this is argc.
     val eff: usize = util.separator_index(argc, argv);
 
-    val res_config: R.Result[cfg.Config, str] = cfg.parse(eff, argv);
+    # the unknown-flag rejection ran in the command entry (`build.run` / `run.run` /
+    # `testing.run`) before this shared body; a nil marks vector re-parses without
+    # recording consumption.
+    val res_config: R.Result[cfg.Config, str] = cfg.parse(eff, argv, nil);
     if (R.is_err[cfg.Config, str](res_config)) {
         print.eprint("error: ");
         print.eprint(R.unwrap_err[cfg.Config, str](res_config));
@@ -2558,15 +2561,37 @@ fun dup_cstr(a: *A.Allocator, s: *u8) *u8 {
     ret buf;
 }
 
+# mark every `mach build`-specific flag (and its value) into `marks` for the
+# unknown-flag rejector
+#
+# The cross-cutting flags are marked by config.parse; this covers only what
+# `build_unit` reads later - the `-O<n>` optimization level, `--emit`, and the
+# `-L`/`-l` link inputs - which are consumed after positional resolution and so
+# must be registered up front, before the rejector runs. Shared by `mach build`
+# and `mach test`, which accepts the build flags too.
+# ---
+# marks: consumption record parallel to argv
+# argc:  number of arguments to scan (the caller clips at `--`)
+# argv:  argument vector (argc null-terminated byte pointers)
+pub fun mark_build_flags(marks: *bool, argc: usize, argv: **u8) {
+    util.mark_flag(marks, argc, argv, "-O0");
+    util.mark_flag(marks, argc, argv, "-O1");
+    util.mark_flag(marks, argc, argv, "-O2");
+    util.mark_value(marks, argc, argv, "--emit");
+    util.mark_value(marks, argc, argv, "-L");
+    util.mark_value(marks, argc, argv, "-l");
+}
+
 # `mach build` subcommand entry point
 #
 # Builds the current project to an executable (or a relocatable object with
 # `--emit obj`) under `<project_root>/out/`. Called by cmd.dispatch.
 # ---
-# argc: argument count including argv[0]
-# argv: the argument vector (argc null-terminated byte pointers)
-# ret:  0 on success, 1 on a user error, 2 on an internal error
-pub fun run(argc: usize, argv: **u8) i64 {
+# argc:  argument count including argv[0]
+# argv:  the argument vector (argc null-terminated byte pointers)
+# marks: consumption record parallel to argv, for the unknown-flag rejector
+# ret:   0 on success, 1 on a user error, 2 on an internal error
+pub fun run(argc: usize, argv: **u8, marks: *bool) i64 {
     var emit_obj: bool = false;
     val opt_emit: O.Option[*u8] = emit_kind(argc, argv);
     if (O.is_some[*u8](opt_emit)) {
@@ -2592,7 +2617,7 @@ pub fun run(argc: usize, argv: **u8) i64 {
 
     # post-`--` args are program arguments, never build flags; clip the scanners.
     val eff: usize = util.separator_index(argc, argv);
-    val res_config: R.Result[cfg.Config, str] = cfg.parse(eff, argv);
+    val res_config: R.Result[cfg.Config, str] = cfg.parse(eff, argv, marks);
     if (R.is_err[cfg.Config, str](res_config)) {
         print.eprint("error: ");
         print.eprint(R.unwrap_err[cfg.Config, str](res_config));
@@ -2604,6 +2629,12 @@ pub fun run(argc: usize, argv: **u8) i64 {
         print.eprint("error: --bin and --lib cannot be combined\n");
         ret 1;
     }
+
+    # config.parse marked the cross-cutting flags; mark the build-specific ones,
+    # then reject any unrecognized flag before the project-path positional is
+    # resolved (so an unknown flag can never displace the path).
+    mark_build_flags(marks, eff, argv);
+    if (util.reject_unknown(eff, argv, marks, 2, "mach build")) { ret 1; }
 
     # the project root is the required non-flag positional (`mach build <path>`);
     # a bare invocation with no path is a user error.

--- a/src/cli/cmd/build.mach
+++ b/src/cli/cmd/build.mach
@@ -358,10 +358,11 @@ fun free_modules(p: *driver.Project,
 #           must outlive the returned BuildResult
 # argc:     argument count including argv[0]
 # argv:     the argument vector (argc null-terminated byte pointers)
+# marks:    consumption record parallel to argv, for positional/link scanning
 # emit_obj: when true, emit a relocatable object instead of an executable
 # ret:      a BuildResult carrying the exit code and artifact path
-pub fun build(a: *A.Allocator, argc: usize, argv: **u8, emit_obj: bool) BuildResult {
-    ret build_unit(a, argc, argv, emit_obj, false, nil, nil, false);
+pub fun build(a: *A.Allocator, argc: usize, argv: **u8, marks: *bool, emit_obj: bool) BuildResult {
+    ret build_unit(a, argc, argv, marks, emit_obj, false, nil, nil, false);
 }
 
 # build the single dispatcher executable covering every collected `test`
@@ -382,15 +383,16 @@ pub fun build(a: *A.Allocator, argc: usize, argv: **u8, emit_obj: bool) BuildRes
 #            outlive the returned TestBuildResult
 # argc:      argument count including argv[0]
 # argv:      the argument vector (argc null-terminated byte pointers)
+# marks:     consumption record parallel to argv, for positional/link scanning
 # list_only: collect the tests without building executables (`--list`)
 # ret:       a TestBuildResult carrying the exit code and the test artifacts
-pub fun build_tests(a: *A.Allocator, argc: usize, argv: **u8, list_only: bool) TestBuildResult {
+pub fun build_tests(a: *A.Allocator, argc: usize, argv: **u8, marks: *bool, list_only: bool) TestBuildResult {
     var list: TestList;
     list.tests = nil;
     list.len   = 0;
     list.cap   = 0;
 
-    val br: BuildResult = build_unit(a, argc, argv, false, true, nil, ?list, list_only);
+    val br: BuildResult = build_unit(a, argc, argv, marks, false, true, nil, ?list, list_only);
 
     var tbr: TestBuildResult;
     tbr.code  = br.code;
@@ -457,13 +459,15 @@ pub fun selection_from_config(config: *cfg.Config, out_sel: *manifest.Selection)
 # a:         allocator owning the session and the returned artifact path
 # argc:      argument count including argv[0]
 # argv:      the argument vector (argc null-terminated byte pointers)
+# marks:     consumption record parallel to argv (from the command entry); the
+#            positional and link scanners step over the marked flag/value indices
 # emit_obj:  emit a relocatable object instead of an executable
 # test_mode: build per-test executables rather than a single artifact
 # ovr:       the enumerated matrix cell, or nil to derive from CLI flags
 # tests_out: the list a test build fills, or nil for a normal build
 # list_only: collect the tests without building executables (`--list`)
 # ret:       a BuildResult carrying the exit code and artifact path
-fun build_unit(a: *A.Allocator, argc: usize, argv: **u8, emit_obj: bool, test_mode: bool, ovr: *driver.MatrixUnit, tests_out: *TestList, list_only: bool) BuildResult {
+fun build_unit(a: *A.Allocator, argc: usize, argv: **u8, marks: *bool, emit_obj: bool, test_mode: bool, ovr: *driver.MatrixUnit, tests_out: *TestList, list_only: bool) BuildResult {
     var br: BuildResult;
     br.code        = 2;
     br.output_path = nil;
@@ -475,8 +479,8 @@ fun build_unit(a: *A.Allocator, argc: usize, argv: **u8, emit_obj: bool, test_mo
     val eff: usize = util.separator_index(argc, argv);
 
     # the unknown-flag rejection ran in the command entry (`build.run` / `run.run` /
-    # `testing.run`) before this shared body; a nil marks vector re-parses without
-    # recording consumption.
+    # `testing.run`) before this shared body, populating `marks`; a nil marks
+    # vector re-parses config without recording (rejection is already done).
     val res_config: R.Result[cfg.Config, str] = cfg.parse(eff, argv, nil);
     if (R.is_err[cfg.Config, str](res_config)) {
         print.eprint("error: ");
@@ -489,7 +493,7 @@ fun build_unit(a: *A.Allocator, argc: usize, argv: **u8, emit_obj: bool, test_mo
 
     # the project root is the required non-flag positional after the subcommand
     # (`mach build <path>`); a bare invocation with no path is a user error.
-    val pix: usize = util.positional_index(eff, argv, 2);
+    val pix: usize = util.positional_index(eff, argv, marks, 2);
     if (pix >= eff) {
         print.eprint("error: missing project path; pass the project root (e.g. '.')\n");
         br.code = 1;
@@ -607,7 +611,7 @@ fun build_unit(a: *A.Allocator, argc: usize, argv: **u8, emit_obj: bool, test_mo
     if (config.emit_ir)     { eff_emit_ir = true; }
     if (config.no_emit_ir)  { eff_emit_ir = false; }
 
-    br.code = compile_and_link(?p, level, emit_obj, test_mode, config.verify_ir, eff_emit_asm, eff_emit_ir, ?root[0], config.output, eff, argv, ?br.output_path, tests_out, list_only);
+    br.code = compile_and_link(?p, level, emit_obj, test_mode, config.verify_ir, eff_emit_asm, eff_emit_ir, ?root[0], config.output, eff, argv, marks, ?br.output_path, tests_out, list_only);
 
     # close the readout with the recap line on a successful, non-test build.
     if (br.code == 0 && s.readout != nil) {
@@ -692,6 +696,7 @@ fun resolve_opt_level(p: *driver.Project, cli_level: u8, cli_set: bool) u8 {
 # out_override: the `-o` artifact path, or nil to use the resolved path
 # argc:         argument count including argv[0]
 # argv:         the argument vector (argc null-terminated byte pointers)
+# marks:        consumption record parallel to argv, for the link-input scanners
 # out_path:     receives the owned produced-artifact path on success
 # tests_out:    the list a test build fills, or nil for a normal build
 # list_only:    collect the tests without building executables (`--list`)
@@ -699,7 +704,7 @@ fun resolve_opt_level(p: *driver.Project, cli_level: u8, cli_set: bool) u8 {
 fun compile_and_link(p: *driver.Project, level: u8, emit_obj: bool, test_mode: bool, verify_ir: bool,
                      emit_asm: bool, emit_ir: bool,
                      root: *u8, out_override: *u8,
-                     argc: usize, argv: **u8, out_path: **u8,
+                     argc: usize, argv: **u8, marks: *bool, out_path: **u8,
                      tests_out: *TestList, list_only: bool) i64 {
     val n: usize = p.module_len::usize;
     if (n == 0) {
@@ -791,10 +796,10 @@ fun compile_and_link(p: *driver.Project, level: u8, emit_obj: bool, test_mode: b
         code = 1;
     }
     or (tests_out != nil) {
-        code = build_test_executables(p, level, verify_ir, root, argc, argv, images, irs, list_only, tests_out);
+        code = build_test_executables(p, level, verify_ir, root, argc, argv, marks, images, irs, list_only, tests_out);
     }
     or {
-        code = link_artifact(p, emit_obj, root, out_override, argc, argv, images, out_path);
+        code = link_artifact(p, emit_obj, root, out_override, argc, argv, marks, images, out_path);
     }
 
     free_modules(p, irs, ir_ready, images, image_ready);
@@ -827,13 +832,14 @@ fun compile_and_link(p: *driver.Project, level: u8, emit_obj: bool, test_mode: b
 # root:      the resolved project root directory
 # argc:      argument count including argv[0]
 # argv:      the argument vector (argc null-terminated byte pointers)
+# marks:     consumption record parallel to argv, for the link-input scanners
 # images:    the per-module object images to write once and share
 # irs:       the per-module IR (for `test` collection)
 # list_only: report the collected tests without building (`--list`)
 # tests_out: the list to append each test's artifact to
 # ret:       0 on success, 1 on a user error, 2 on an internal error
 fun build_test_executables(p: *driver.Project, level: u8, verify_ir: bool,
-                           root: *u8, argc: usize, argv: **u8,
+                           root: *u8, argc: usize, argv: **u8, marks: *bool,
                            images: *of.ObjectImage, irs: *ir.Module,
                            list_only: bool, tests_out: *TestList) i64 {
     val res_collect: R.Result[testrunner.Collected, str] = testrunner.collect(p.s, irs, p.module_len);
@@ -915,7 +921,7 @@ fun build_test_executables(p: *driver.Project, level: u8, verify_ir: bool,
     # the external link inputs (libc, manifest/CLI libs), resolved once and shared.
     var sonames:    *intern.StrId = nil;
     var soname_len: u32           = 0;
-    val ec: i64 = append_external_inputs(p, root, argc, argv, ?shared, ?shared_len, ?sonames, ?soname_len);
+    val ec: i64 = append_external_inputs(p, root, argc, argv, marks, ?shared, ?shared_len, ?sonames, ?soname_len);
     if (ec != 0) {
         free_paths(p.s.alloc, shared, shared_len, shared_len);
         free_sonames(p.s.alloc, sonames, soname_len);
@@ -1395,12 +1401,13 @@ fun subst_name(tmpl: str, name: str, out: *u8, cap: usize) usize {
 # out_override: the `-o` artifact path, or nil to use the resolved path
 # argc:         argument count including argv[0]
 # argv:         the argument vector (argc null-terminated byte pointers)
+# marks:        consumption record parallel to argv, for the link-input scanners
 # images:       the per-module object images to write
 # out_path:     receives the owned produced-artifact path on success
 # ret:          0 on success, 1 on a user error, 2 on an internal error
 fun link_artifact(p: *driver.Project, emit_obj: bool, root: *u8,
                   out_override: *u8,
-                  argc: usize, argv: **u8,
+                  argc: usize, argv: **u8, marks: *bool,
                   images: *of.ObjectImage, out_path: **u8) i64 {
     val te: *driver.TargetEntry = p.target_entry;
     if (te == nil) { print.eprint("error: no target selected\n"); ret 2; }
@@ -1445,7 +1452,7 @@ fun link_artifact(p: *driver.Project, emit_obj: bool, root: *u8,
     # time). `paths` and `sonames` are grown and re-bound here.
     var sonames:    *intern.StrId = nil;
     var soname_len: u32           = 0;
-    val ext_code: i64 = append_external_inputs(p, root, argc, argv, ?paths, ?len, ?sonames, ?soname_len);
+    val ext_code: i64 = append_external_inputs(p, root, argc, argv, marks, ?paths, ?len, ?sonames, ?soname_len);
     if (ext_code != 0) {
         free_paths(p.s.alloc, paths, len, len);
         free_sonames(p.s.alloc, sonames, soname_len);
@@ -1701,23 +1708,25 @@ fun write_named_candidate(dir: *u8, prefix: *u8, name: *u8, ext: *u8, buf: *u8, 
 # program), the subcommand, every known flag and its value, and the project-path
 # positional are skipped so only real link inputs are counted.
 # ---
-# p:    the project carrying the target entry and config
-# argc: argument count including argv[0]
-# argv: the argument vector (argc null-terminated byte pointers)
-# ret:  the external link-input token count
-fun count_external_tokens(p: *driver.Project, argc: usize, argv: **u8) u32 {
+# p:     the project carrying the target entry and config
+# argc:  argument count including argv[0]
+# argv:  the argument vector (argc null-terminated byte pointers)
+# marks: consumption record parallel to argv; a marked index is a flag or its
+#        value and is stepped over (the `-l` value alone is a counted input)
+# ret:   the external link-input token count
+fun count_external_tokens(p: *driver.Project, argc: usize, argv: **u8, marks: *bool) u32 {
     var n: u32 = 0;
     val te: *driver.TargetEntry = p.target_entry;
     if (te != nil) { n = n + te.lib_count; }
     # cascading transitive dep libs; 0 when no dep contributes any.
     n = n + p.config.cascade_lib_count;
 
-    val proj_ix: usize = util.positional_index(argc, argv, 2);
+    val proj_ix: usize = util.positional_index(argc, argv, marks, 2);
     var i: usize = 0;
     for (i < argc) {
         val a: *u8 = argv[i];
         if (str_equals(a::str, "-l") && i + 1 < argc)                              { n = n + 1; i = i + 2; cnt; }
-        if (util.is_value_flag(a) && i + 1 < argc)                                 { i = i + 2; cnt; }
+        if (marks[i])                                                              { i = i + 1; cnt; }
         if (i > 1 && i != proj_ix && a != nil && a[0] != '-' && is_object_path(a)) { n = n + 1; }
         i = i + 1;
     }
@@ -1740,17 +1749,18 @@ fun count_external_tokens(p: *driver.Project, argc: usize, argv: **u8) u32 {
 # root:       the resolved project root directory
 # argc:       argument count including argv[0]
 # argv:       the argument vector (argc null-terminated byte pointers)
+# marks:      consumption record parallel to argv, stepping over flag/value pairs
 # paths:      the static object-path array to grow and fill
 # len:        the static object-path count, updated to the true count
 # sonames:    the dynamic-dependency soname array to grow and fill
 # soname_len: the soname count
 # ret:        0 on success, or a non-zero exit code
-fun append_external_inputs(p: *driver.Project, root: *u8, argc: usize, argv: **u8,
+fun append_external_inputs(p: *driver.Project, root: *u8, argc: usize, argv: **u8, marks: *bool,
                            paths: ***u8, len: *u32,
                            sonames: **intern.StrId, soname_len: *u32) i64 {
     @sonames    = nil;
     @soname_len = 0;
-    val extra: u32 = count_external_tokens(p, argc, argv);
+    val extra: u32 = count_external_tokens(p, argc, argv, marks);
     if (extra == 0) { ret 0; }
 
     val base:  u32 = @len;
@@ -1794,7 +1804,7 @@ fun append_external_inputs(p: *driver.Project, root: *u8, argc: usize, argv: **u
         i = i + 1;
     }
 
-    val proj_ix: usize = util.positional_index(argc, argv, 2);
+    val proj_ix: usize = util.positional_index(argc, argv, marks, 2);
     var ii: usize = 0;
     for (ii < argc) {
         val a: *u8 = argv[ii];
@@ -1804,7 +1814,7 @@ fun append_external_inputs(p: *driver.Project, root: *u8, argc: usize, argv: **u
             if (code != 0) { shrink_paths(p, paths, len, written, grown); ret code; }
             ii = ii + 2; cnt;
         }
-        if (util.is_value_flag(a) && ii + 1 < argc) { ii = ii + 2; cnt; }
+        if (marks[ii]) { ii = ii + 1; cnt; }
         if (ii > 1 && ii != proj_ix && a != nil && a[0] != '-' && is_object_path(a)) {
             val code: i64 = resolve_and_store_input(p, a, root, argc, argv, ?buf[0], 4096,
                                                     @paths, ?written, sonames, soname_len);
@@ -2563,6 +2573,22 @@ fun dup_cstr(a: *A.Allocator, s: *u8) *u8 {
     ret buf;
 }
 
+# mark the `-O<n>` optimization-level flags into `marks` for the unknown-flag
+# rejector
+#
+# One home for the `-O` set, shared so `mach build`/`mach test` (which consume it)
+# and `mach run` (which accepts it as a no-op, since it does not build) can never
+# drift on which levels are accepted.
+# ---
+# marks: consumption record parallel to argv
+# argc:  number of arguments to scan (the caller clips at `--`)
+# argv:  argument vector (argc null-terminated byte pointers)
+pub fun mark_opt_flags(marks: *bool, argc: usize, argv: **u8) {
+    util.mark_flag(marks, argc, argv, "-O0");
+    util.mark_flag(marks, argc, argv, "-O1");
+    util.mark_flag(marks, argc, argv, "-O2");
+}
+
 # mark every `mach build`-specific flag (and its value) into `marks` for the
 # unknown-flag rejector
 #
@@ -2576,9 +2602,7 @@ fun dup_cstr(a: *A.Allocator, s: *u8) *u8 {
 # argc:  number of arguments to scan (the caller clips at `--`)
 # argv:  argument vector (argc null-terminated byte pointers)
 pub fun mark_build_flags(marks: *bool, argc: usize, argv: **u8) {
-    util.mark_flag(marks, argc, argv, "-O0");
-    util.mark_flag(marks, argc, argv, "-O1");
-    util.mark_flag(marks, argc, argv, "-O2");
+    mark_opt_flags(marks, argc, argv);
     util.mark_value(marks, argc, argv, "--emit");
     util.mark_value(marks, argc, argv, "-L");
     util.mark_value(marks, argc, argv, "-l");
@@ -2640,7 +2664,7 @@ pub fun run(argc: usize, argv: **u8, marks: *bool) i64 {
 
     # the project root is the required non-flag positional (`mach build <path>`);
     # a bare invocation with no path is a user error.
-    val pix: usize = util.positional_index(eff, argv, 2);
+    val pix: usize = util.positional_index(eff, argv, marks, 2);
     if (pix >= eff) {
         print.eprint("error: missing project path; pass the project root (e.g. '.')\n");
         ret 1;
@@ -2706,7 +2730,7 @@ pub fun run(argc: usize, argv: **u8, marks: *bool) i64 {
             ret 2;
         }
 
-        val br: BuildResult = build_unit(?u_alloc, argc, argv, emit_obj, false, unit, nil, false);
+        val br: BuildResult = build_unit(?u_alloc, argc, argv, marks, emit_obj, false, unit, nil, false);
         if (br.code != 0 && code == 0) { code = br.code; }
         arena.dnit(?u_ar);
         i = i + 1;

--- a/src/cli/cmd/check.mach
+++ b/src/cli/cmd/check.mach
@@ -14,6 +14,7 @@
 use std.allocator.arena;
 use std.filesystem;
 use std.print;
+use std.types.bool.bool;
 use std.types.size.usize;
 use std.types.string.str;
 
@@ -34,14 +35,19 @@ use mach.lang.source;
 # diagnostics. Every allocation is suballocated through one arena over a page
 # allocator and reclaimed in a single dnit before returning.
 # ---
-# argc: argument count including argv[0]
-# argv: the argument vector (argc null-terminated byte pointers)
-# ret:  0 when the buffer has no errors, 1 on errors or a usage / io failure
-pub fun run(argc: usize, argv: **u8) i64 {
+# argc:  argument count including argv[0]
+# argv:  the argument vector (argc null-terminated byte pointers)
+# marks: consumption record parallel to argv, for the unknown-flag rejector
+# ret:   0 when the buffer has no errors, 1 on errors or a usage / io failure
+pub fun run(argc: usize, argv: **u8, marks: *bool) i64 {
     if (argc < 3) {
         print.eprintln("usage: mach check <file>");
         ret 1;
     }
+
+    # `mach check` takes only the `<file>` positional; reject any flag token.
+    if (util.reject_unknown(argc, argv, marks, 2, "mach check")) { ret 1; }
+
     val path: str = argv[2]::str;
 
     var backing: A.Allocator;

--- a/src/cli/cmd/check.mach
+++ b/src/cli/cmd/check.mach
@@ -41,15 +41,15 @@ use mach.lang.source;
 # marks: consumption record parallel to argv, for the unknown-flag rejector
 # ret:   0 when the buffer has no errors, 1 on errors or a usage / io failure
 pub fun run(argc: usize, argv: **u8, marks: *bool) i64 {
-    if (argc < 3) {
+    # `mach check` takes only the `<file>` positional; reject any flag token, then
+    # resolve the file. A `--` separator escapes a dash-leading filename.
+    if (util.reject_unknown(argc, argv, marks, 2, "mach check")) { ret 1; }
+    val pix: usize = util.positional_index(argc, argv, marks, 2);
+    if (pix >= argc) {
         print.eprintln("usage: mach check <file>");
         ret 1;
     }
-
-    # `mach check` takes only the `<file>` positional; reject any flag token.
-    if (util.reject_unknown(argc, argv, marks, 2, "mach check")) { ret 1; }
-
-    val path: str = argv[2]::str;
+    val path: str = argv[pix]::str;
 
     var backing: A.Allocator;
     var ar:      arena.Arena;

--- a/src/cli/cmd/dep.mach
+++ b/src/cli/cmd/dep.mach
@@ -121,26 +121,58 @@ rec GitTool {
 }
 
 # `mach dep` subcommand entry point; dispatches on argv[2]
+#
+# `mach dep` reads only its own per-action flags (no shared config parser). Each
+# action marks its accepted flags into `marks` and rejects any unrecognized flag
+# before running - the dep-name positionals are bare tokens, never flags - so a
+# typo'd flag is a hard error rather than silently ignored (#1810).
 # ---
-# argc: argument count including argv[0]
-# argv: the argument vector (argc null-terminated byte pointers)
-# ret:  0 on success, 1 on a user error, 2 on an internal error
-pub fun run(argc: usize, argv: **u8) i64 {
+# argc:  argument count including argv[0]
+# argv:  the argument vector (argc null-terminated byte pointers)
+# marks: consumption record parallel to argv, for the unknown-flag rejector
+# ret:   0 on success, 1 on a user error, 2 on an internal error
+pub fun run(argc: usize, argv: **u8, marks: *bool) i64 {
     if (argc < 3) {
         print.eprint("error: missing dep action\n");
         print.eprint("usage: mach dep <pull|update|add|remove|list>\n");
         ret 1;
     }
 
-    val action: str  = argv[2]::str;
-    val quiet:  bool = arg_quiet(argc, argv);
+    val action: str = argv[2]::str;
 
-    if (str_equals(action, "list"))   { ret dep_list(); }
-    if (str_equals(action, "add"))    { ret dep_add(argc, argv); }
-    if (str_equals(action, "remove")) { ret dep_remove(argc, argv); }
-    if (str_equals(action, "update")) { ret dep_update(argc, argv); }
-    if (str_equals(action, "pull"))   { ret pull_project(".", quiet); }
+    # every action honours --quiet/-q; each action's own flags are marked in its
+    # branch below.
+    util.mark_flag(marks, argc, argv, "--quiet");
+    util.mark_flag(marks, argc, argv, "-q");
+    val quiet: bool = arg_quiet(argc, argv);
+
+    if (str_equals(action, "list")) {
+        if (util.reject_unknown(argc, argv, marks, 3, "mach dep list")) { ret 1; }
+        ret dep_list();
+    }
+    if (str_equals(action, "add")) {
+        util.mark_value(marks, argc, argv, "--git");
+        util.mark_value(marks, argc, argv, "--path");
+        util.mark_value(marks, argc, argv, "--ref");
+        if (util.reject_unknown(argc, argv, marks, 3, "mach dep add")) { ret 1; }
+        ret dep_add(argc, argv);
+    }
+    if (str_equals(action, "remove")) {
+        util.mark_flag(marks, argc, argv, "--purge");
+        if (util.reject_unknown(argc, argv, marks, 3, "mach dep remove")) { ret 1; }
+        ret dep_remove(argc, argv);
+    }
+    if (str_equals(action, "update")) {
+        util.mark_flag(marks, argc, argv, "--all");
+        if (util.reject_unknown(argc, argv, marks, 3, "mach dep update")) { ret 1; }
+        ret dep_update(argc, argv);
+    }
+    if (str_equals(action, "pull")) {
+        if (util.reject_unknown(argc, argv, marks, 3, "mach dep pull")) { ret 1; }
+        ret pull_project(".", quiet);
+    }
     if (str_equals(action, "sync")) {
+        if (util.reject_unknown(argc, argv, marks, 3, "mach dep sync")) { ret 1; }
         # `sync` is the pre-rename name; kept one cycle as a hidden alias.
         print.eprint("note: `mach dep sync` is deprecated; use `mach dep pull`\n");
         ret pull_project(".", quiet);

--- a/src/cli/cmd/doc.mach
+++ b/src/cli/cmd/doc.mach
@@ -494,11 +494,12 @@ fun generate(p: *driver.Project, api_dir: *u8, stats: *DocStats) i64 {
 #
 # Called by cmd.dispatch.
 # ---
-# argc: argument count including argv[0]
-# argv: the argument vector (argc null-terminated byte pointers)
-# ret:  0 on success, 1 on a user error, 2 on an internal error
-pub fun run(argc: usize, argv: **u8) i64 {
-    val res_config: R.Result[cfg.Config, str] = cfg.parse(argc, argv);
+# argc:  argument count including argv[0]
+# argv:  the argument vector (argc null-terminated byte pointers)
+# marks: consumption record parallel to argv, for the unknown-flag rejector
+# ret:   0 on success, 1 on a user error, 2 on an internal error
+pub fun run(argc: usize, argv: **u8, marks: *bool) i64 {
+    val res_config: R.Result[cfg.Config, str] = cfg.parse(argc, argv, marks);
     if (R.is_err[cfg.Config, str](res_config)) {
         print.eprint("error: ");
         print.eprint(R.unwrap_err[cfg.Config, str](res_config));
@@ -506,6 +507,12 @@ pub fun run(argc: usize, argv: **u8) i64 {
         ret 1;
     }
     val config: cfg.Config = R.unwrap_ok[cfg.Config, str](res_config);
+
+    # config.parse marked the cross-cutting flags; `--out` is `doc`'s own. mark it,
+    # then reject any unrecognized flag before the project-path positional is
+    # resolved.
+    util.mark_value(marks, argc, argv, "--out");
+    if (util.reject_unknown(argc, argv, marks, 2, "mach doc")) { ret 1; }
 
     # the project root is the required non-flag positional (`mach doc <path>`); a
     # bare invocation with no path is a user error.

--- a/src/cli/cmd/doc.mach
+++ b/src/cli/cmd/doc.mach
@@ -508,15 +508,15 @@ pub fun run(argc: usize, argv: **u8, marks: *bool) i64 {
     }
     val config: cfg.Config = R.unwrap_ok[cfg.Config, str](res_config);
 
-    # config.parse marked the cross-cutting flags; `--out` is `doc`'s own. mark it,
-    # then reject any unrecognized flag before the project-path positional is
-    # resolved.
-    util.mark_value(marks, argc, argv, "--out");
+    # config.parse marked the cross-cutting flags; `--out` is `doc`'s own. marking
+    # it both registers it for the rejector and reads its value. reject any
+    # unrecognized flag before the project-path positional is resolved.
+    val opt_out: O.Option[*u8] = util.mark_value(marks, argc, argv, "--out");
     if (util.reject_unknown(argc, argv, marks, 2, "mach doc")) { ret 1; }
 
     # the project root is the required non-flag positional (`mach doc <path>`); a
     # bare invocation with no path is a user error.
-    val path_index: usize = util.positional_index(argc, argv, 2);
+    val path_index: usize = util.positional_index(argc, argv, marks, 2);
     if (path_index >= argc) {
         print.eprint("error: missing project path; pass the project root (e.g. '.')\n");
         ret 1;
@@ -570,10 +570,9 @@ pub fun run(argc: usize, argv: **u8, marks: *bool) i64 {
     }
     var p: driver.Project = R.unwrap_ok[driver.Project, str](res_project);
 
-    # resolve the output directory: --out <dir> rooted at the project root, or the
-    # default doc/api.
+    # resolve the output directory: --out <dir> (read above) rooted at the project
+    # root, or the default doc/api.
     var api_dir: [4096]u8;
-    val opt_out: O.Option[*u8] = util.get_value(argc, argv, "--out");
     if (O.is_some[*u8](opt_out)) {
         util.join_into(?api_dir[0], 4096, ?root[0], O.unwrap[*u8](opt_out));
     }

--- a/src/cli/cmd/help.mach
+++ b/src/cli/cmd/help.mach
@@ -8,9 +8,14 @@
 # documented flag surface.
 
 use std.print;
+use std.types.bool.bool;
+use std.types.bool.false;
+use std.types.bool.true;
 use std.types.size.usize;
 use std.types.string.str;
 use std.types.string.str_equals;
+
+use mach.cli.util;
 
 # the compiler version string, folded at compile time from the project manifest
 val MACH_VERSION: str = $project.version;
@@ -18,32 +23,50 @@ val MACH_VERSION: str = $project.version;
 # print the top-level usage or a subcommand detail page
 #
 # called by `mach.cli.cmd.dispatch`, including its unknown-command error path.
+# `mach help <cmd>` accepts only a subcommand name; a flag token is rejected like
+# any other command's (the `-h`/`--help` gesture is intercepted by the dispatcher
+# before it reaches here).
 # ---
-# argc: argument count including argv[0]
-# argv: the argument vector (argc null-terminated byte pointers)
-# ret:  0 for the usage and known detail pages, 1 for an unknown subcommand
-pub fun run(argc: usize, argv: **u8) i64 {
+# argc:  argument count including argv[0]
+# argv:  the argument vector (argc null-terminated byte pointers)
+# marks: consumption record parallel to argv, for the unknown-flag rejector
+# ret:   0 for the usage and known detail pages, 1 for an unknown subcommand or flag
+pub fun run(argc: usize, argv: **u8, marks: *bool) i64 {
     if (argc < 3) {
-        top_level_usage();
+        usage();
         ret 0;
     }
 
+    if (util.reject_unknown(argc, argv, marks, 2, "mach help")) { ret 1; }
+
     val sub: str = argv[2]::str;
-    if (str_equals(sub, "build")) { help_build(); ret 0; }
-    if (str_equals(sub, "run"))   { help_run();   ret 0; }
-    if (str_equals(sub, "test"))  { help_test();  ret 0; }
-    if (str_equals(sub, "check")) { help_check(); ret 0; }
-    if (str_equals(sub, "dep"))   { help_dep();   ret 0; }
-    if (str_equals(sub, "init"))  { help_init();  ret 0; }
-    if (str_equals(sub, "doc"))   { help_doc();   ret 0; }
-    if (str_equals(sub, "info"))  { help_info();  ret 0; }
-    if (str_equals(sub, "help"))  { top_level_usage(); ret 0; }
+    if (str_equals(sub, "help")) { usage(); ret 0; }
+    if (page(sub))               { ret 0;   }
 
     print.eprint("error: unknown command '");
     print.eprint(sub);
     print.eprint("'\n");
-    top_level_usage();
+    usage();
     ret 1;
+}
+
+# print `cmd`'s detail page, reporting whether it named a command with a page
+#
+# The shared subcommand-to-page map behind both `mach help <cmd>` and the
+# dispatcher's `-h`/`--help` interception, so the accepted set lives in one place.
+# ---
+# cmd: the subcommand name to describe
+# ret: true when `cmd` had a detail page (which was printed), false otherwise
+pub fun page(cmd: str) bool {
+    if (str_equals(cmd, "build")) { help_build(); ret true; }
+    if (str_equals(cmd, "run"))   { help_run();   ret true; }
+    if (str_equals(cmd, "test"))  { help_test();  ret true; }
+    if (str_equals(cmd, "check")) { help_check(); ret true; }
+    if (str_equals(cmd, "dep"))   { help_dep();   ret true; }
+    if (str_equals(cmd, "init"))  { help_init();  ret true; }
+    if (str_equals(cmd, "doc"))   { help_doc();   ret true; }
+    if (str_equals(cmd, "info"))  { help_info();  ret true; }
+    ret false;
 }
 
 # print the cross-cutting flags the shared config parser reads
@@ -64,7 +87,7 @@ fun global_flags() {
 }
 
 # print the top-level usage summary and the command list
-fun top_level_usage() {
+pub fun usage() {
     print.print("mach ");
     print.print(MACH_VERSION);
     print.print(" - the Mach compiler\n");
@@ -112,10 +135,12 @@ fun help_build() {
 fun help_run() {
     print.print("usage: mach run <path> [options] [-- args...]\n");
     print.print("\n");
-    print.print("build the project (all 'mach build' flags apply) and execute the\n");
-    print.print("resulting binary. arguments after '--' are forwarded to the program\n");
+    print.print("execute the binary 'mach build' already produced for <path> - a\n");
+    print.print("post-build convenience, not a rebuild. the build selection flags\n");
+    print.print("(--target, --profile/--release, --bin) resolve which artifact to run;\n");
+    print.print("build-only flags (-O0/-O1/-O2) are accepted but have no effect, and\n");
+    print.print("--emit is rejected. arguments after '--' are forwarded to the program\n");
     print.print("as its argv; the program's exit code becomes this command's.\n");
-    print.print("--emit is rejected - running a relocatable object is not meaningful.\n");
     print.print("\n");
     print.print("options:\n");
     print.print("  --runner <cmd>   execute the binary as '<cmd> <binary> <args...>'.\n");
@@ -123,7 +148,7 @@ fun help_run() {
     print.print("                   splitting), resolved on PATH. for foreign-target\n");
     print.print("                   binaries, e.g. --target windows --runner wine\n");
     print.print("\n");
-    print.print("exit: the program's exit code, 1 on build error, 2 internal\n");
+    print.print("exit: the program's exit code, 1 on a resolution error, 2 internal\n");
 }
 
 # print the `mach test` detail page

--- a/src/cli/cmd/info.mach
+++ b/src/cli/cmd/info.mach
@@ -24,6 +24,7 @@ use std.types.string.str_equals;
 use O: std.types.option;
 use R: std.types.result;
 
+use mach.cli.util;
 use mach.lang.target;
 use mach.lang.target.abi;
 use mach.lang.target.isa;
@@ -39,10 +40,16 @@ val MACH_VERSION: str = $project.version;
 # supported target-tuple matrix; otherwise prints the full
 # identity-and-capabilities screen.
 # ---
-# argc: argument count including argv[0]
-# argv: the argument vector (argc null-terminated byte pointers)
-# ret:  0 on success, 2 on an internal failure
-pub fun run(argc: usize, argv: **u8) i64 {
+# argc:  argument count including argv[0]
+# argv:  the argument vector (argc null-terminated byte pointers)
+# marks: consumption record parallel to argv, for the unknown-flag rejector
+# ret:   0 on success, 1 on an unknown flag, 2 on an internal failure
+pub fun run(argc: usize, argv: **u8, marks: *bool) i64 {
+    # `--version` is the only flag; `targets` is a bare verb. mark the flag, then
+    # reject any other flag token before the verb is read.
+    util.mark_flag(marks, argc, argv, "--version");
+    if (util.reject_unknown(argc, argv, marks, 2, "mach info")) { ret 1; }
+
     if (argc >= 3 && str_equals(argv[2]::str, "--version")) {
         print.println(MACH_VERSION);
         ret 0;

--- a/src/cli/cmd/init.mach
+++ b/src/cli/cmd/init.mach
@@ -58,10 +58,21 @@ rec Buf {
 # `mach init` subcommand entry point. scaffolds a new project in the positional
 # directory (or the current directory). called by cmd.dispatch.
 # ---
-# argc: argument count including argv[0]
-# argv: the argument vector (argc null-terminated byte pointers)
-# ret:  0 on success, 1 on a user error, 2 on an internal error
-pub fun run(argc: usize, argv: **u8) i64 {
+# argc:  argument count including argv[0]
+# argv:  the argument vector (argc null-terminated byte pointers)
+# marks: consumption record parallel to argv, for the unknown-flag rejector
+# ret:   0 on success, 1 on a user error, 2 on an internal error
+pub fun run(argc: usize, argv: **u8, marks: *bool) i64 {
+    # `mach init` reads only its own flags (no shared config parser). mark them,
+    # then reject any unrecognized flag before the directory positional is
+    # resolved.
+    util.mark_flag(marks, argc, argv, "--force");
+    util.mark_flag(marks, argc, argv, "--lib");
+    util.mark_flag(marks, argc, argv, "--quiet");
+    util.mark_flag(marks, argc, argv, "-q");
+    util.mark_value(marks, argc, argv, "--name");
+    if (util.reject_unknown(argc, argv, marks, 2, "mach init")) { ret 1; }
+
     val force:  bool = util.has_flag(argc, argv, "--force");
     val is_lib: bool = util.has_flag(argc, argv, "--lib");
     val quiet:  bool = util.has_flag(argc, argv, "--quiet") || util.has_flag(argc, argv, "-q");

--- a/src/cli/cmd/init.mach
+++ b/src/cli/cmd/init.mach
@@ -63,19 +63,17 @@ rec Buf {
 # marks: consumption record parallel to argv, for the unknown-flag rejector
 # ret:   0 on success, 1 on a user error, 2 on an internal error
 pub fun run(argc: usize, argv: **u8, marks: *bool) i64 {
-    # `mach init` reads only its own flags (no shared config parser). mark them,
-    # then reject any unrecognized flag before the directory positional is
-    # resolved.
-    util.mark_flag(marks, argc, argv, "--force");
-    util.mark_flag(marks, argc, argv, "--lib");
-    util.mark_flag(marks, argc, argv, "--quiet");
-    util.mark_flag(marks, argc, argv, "-q");
-    util.mark_value(marks, argc, argv, "--name");
+    # `mach init` reads only its own flags (no shared config parser). marking each
+    # both registers it for the rejector and reads it, so there is no second
+    # unmarked read to drift. reject any unrecognized flag before the directory
+    # positional is resolved.
+    val force:    bool          = util.mark_flag(marks, argc, argv, "--force");
+    val is_lib:   bool          = util.mark_flag(marks, argc, argv, "--lib");
+    val quiet_l:  bool          = util.mark_flag(marks, argc, argv, "--quiet");
+    val quiet_s:  bool          = util.mark_flag(marks, argc, argv, "-q");
+    val quiet:    bool          = quiet_l || quiet_s;
+    val opt_name: O.Option[*u8] = util.mark_value(marks, argc, argv, "--name");
     if (util.reject_unknown(argc, argv, marks, 2, "mach init")) { ret 1; }
-
-    val force:  bool = util.has_flag(argc, argv, "--force");
-    val is_lib: bool = util.has_flag(argc, argv, "--lib");
-    val quiet:  bool = util.has_flag(argc, argv, "--quiet") || util.has_flag(argc, argv, "-q");
 
     var cwd_buf: [4096]u8;
     val cwd_len: i64 = os.getcwd(?cwd_buf[0], 4096);
@@ -89,14 +87,14 @@ pub fun run(argc: usize, argv: **u8, marks: *bool) i64 {
     # verbatim, so a path or `.` is refused by is_valid_id below, never repaired.
     var dir: *u8 = ?cwd_buf[0];
     var id:  *u8 = base_name(?cwd_buf[0]);
-    val pos_idx: usize = util.positional_index(argc, argv, 2);
+    val pos_idx: usize = util.positional_index(argc, argv, marks, 2);
     if (pos_idx < argc) {
         dir = argv[pos_idx];
         id  = argv[pos_idx];
     }
 
-    # --name takes precedence over the positional for the id (never the directory)
-    val opt_name: O.Option[*u8] = util.get_value(argc, argv, "--name");
+    # --name (read above) takes precedence over the positional for the id (never
+    # the directory)
     if (O.is_some[*u8](opt_name)) { id = O.unwrap[*u8](opt_name); }
 
     # validate the id before any filesystem write so a rejected init leaves

--- a/src/cli/cmd/run.mach
+++ b/src/cli/cmd/run.mach
@@ -37,10 +37,11 @@ use mach.lang.manifest;
 # already exist on disk, then execs it forwarding the post-`--` arguments. Called
 # by cmd.dispatch.
 # ---
-# argc: argument count including argv[0]
-# argv: the argument vector (argc null-terminated byte pointers)
-# ret:  the child's exit code, 1 on a resolution or user error, 2 on internal error
-pub fun run(argc: usize, argv: **u8) i64 {
+# argc:  argument count including argv[0]
+# argv:  the argument vector (argc null-terminated byte pointers)
+# marks: consumption record parallel to argv, for the unknown-flag rejector
+# ret:   the child's exit code, 1 on a resolution or user error, 2 on internal error
+pub fun run(argc: usize, argv: **u8, marks: *bool) i64 {
     # the resolution sees only the args before `--`; everything after is the
     # child's argv. clip the count here so a post-`--` `--emit` is the program's
     # argument, not a flag this command rejects.
@@ -67,7 +68,7 @@ pub fun run(argc: usize, argv: **u8) i64 {
     # narrow the artifact here, so `mach run` resolves the exact path `mach build`
     # produced. the args are read clipped at `--` so a forwarded flag never leaks
     # into the selection.
-    val res_cfg: R.Result[cfg.Config, str] = cfg.parse(sep, argv);
+    val res_cfg: R.Result[cfg.Config, str] = cfg.parse(sep, argv, marks);
     if (R.is_err[cfg.Config, str](res_cfg)) {
         print.eprint("error: ");
         print.eprint(R.unwrap_err[cfg.Config, str](res_cfg));
@@ -76,6 +77,19 @@ pub fun run(argc: usize, argv: **u8) i64 {
         ret 1;
     }
     val config: cfg.Config = R.unwrap_ok[cfg.Config, str](res_cfg);
+
+    # `mach run` executes a pre-built artifact and does not build, so the build-only
+    # `-O<n>` flags are accepted (marked) but have no effect; `--runner` is its own.
+    # reject any other unrecognized flag before the project-path positional is
+    # resolved. `--emit` was already rejected above.
+    util.mark_flag(marks, sep, argv, "-O0");
+    util.mark_flag(marks, sep, argv, "-O1");
+    util.mark_flag(marks, sep, argv, "-O2");
+    util.mark_value(marks, sep, argv, "--runner");
+    if (util.reject_unknown(sep, argv, marks, 2, "mach run")) {
+        arena.dnit(?ar);
+        ret 1;
+    }
 
     # the project root is the required non-flag positional after the subcommand
     # (`mach run <path>`); a bare invocation with no path is a user error.

--- a/src/cli/cmd/run.mach
+++ b/src/cli/cmd/run.mach
@@ -80,12 +80,11 @@ pub fun run(argc: usize, argv: **u8, marks: *bool) i64 {
 
     # `mach run` executes a pre-built artifact and does not build, so the build-only
     # `-O<n>` flags are accepted (marked) but have no effect; `--runner` is its own.
+    # marking `--runner` here both registers it for the rejector and reads its value.
     # reject any other unrecognized flag before the project-path positional is
     # resolved. `--emit` was already rejected above.
-    util.mark_flag(marks, sep, argv, "-O0");
-    util.mark_flag(marks, sep, argv, "-O1");
-    util.mark_flag(marks, sep, argv, "-O2");
-    util.mark_value(marks, sep, argv, "--runner");
+    build.mark_opt_flags(marks, sep, argv);
+    val opt_runner: O.Option[*u8] = util.mark_value(marks, sep, argv, "--runner");
     if (util.reject_unknown(sep, argv, marks, 2, "mach run")) {
         arena.dnit(?ar);
         ret 1;
@@ -93,7 +92,7 @@ pub fun run(argc: usize, argv: **u8, marks: *bool) i64 {
 
     # the project root is the required non-flag positional after the subcommand
     # (`mach run <path>`); a bare invocation with no path is a user error.
-    val pix: usize = util.positional_index(sep, argv, 2);
+    val pix: usize = util.positional_index(sep, argv, marks, 2);
     if (pix >= sep) {
         print.eprint("error: missing project path; pass the project root (e.g. '.')\n");
         arena.dnit(?ar);
@@ -136,11 +135,10 @@ pub fun run(argc: usize, argv: **u8, marks: *bool) i64 {
         ret 1;
     }
 
-    # `--runner <cmd>` (scanned before `--`, like every other flag): execute the
+    # `--runner <cmd>` (read above, before `--`, like every other flag): execute the
     # binary as `<cmd> <binary> <args...>`. resolved to a concrete path up front
     # since execve does no PATH search.
     var runner: *u8 = nil;
-    val opt_runner: O.Option[*u8] = util.get_value(sep, argv, "--runner");
     if (O.is_some[*u8](opt_runner)) {
         val name: *u8 = O.unwrap[*u8](opt_runner);
         val res_runner: R.Result[*u8, str] = util.resolve_cmd(?alloc, name);

--- a/src/cli/cmd/testing.mach
+++ b/src/cli/cmd/testing.mach
@@ -142,28 +142,28 @@ pub fun run(argc: usize, argv: **u8, marks: *bool) i64 {
         print.eprint("\n");
         ret 1;
     }
+    val config: cfg.Config = R.unwrap_ok[cfg.Config, str](res_cfg);
+
+    # marking each flag both registers it for the rejector and reads its value, so
+    # there is no second unmarked read to drift. `--include-deps` is marked here for
+    # the rejector and read again in the build layer where it scopes collection.
     build.mark_build_flags(marks, argc, argv);
-    util.mark_flag(marks, argc, argv, "--list");
+    val list:       bool          = util.mark_flag(marks, argc, argv, "--list");
     util.mark_flag(marks, argc, argv, "--include-deps");
-    util.mark_value(marks, argc, argv, "--format");
-    util.mark_value(marks, argc, argv, "--jobs");
-    util.mark_value(marks, argc, argv, "--filter");
-    util.mark_value(marks, argc, argv, "--runner");
+    val opt_format: O.Option[*u8] = util.mark_value(marks, argc, argv, "--format");
+    val opt_jobs:   O.Option[*u8] = util.mark_value(marks, argc, argv, "--jobs");
+    val opt_filter: O.Option[*u8] = util.mark_value(marks, argc, argv, "--filter");
+    val opt_runner: O.Option[*u8] = util.mark_value(marks, argc, argv, "--runner");
     if (util.reject_unknown(argc, argv, marks, 2, "mach test")) { ret 1; }
 
-    val list: bool = util.has_flag(argc, argv, "--list");
-
-    # verbosity mirrors the shared flags (`--verbose` was dropped in #1775):
-    # `-v` lists every test as it completes, `-vv` also prints passing output.
-    var level: u8 = 0;
-    if (util.has_flag(argc, argv, "-v"))  { level = 1; }
-    if (util.has_flag(argc, argv, "-vv")) { level = 2; }
+    # verbosity comes from the shared config (`-v`/`-vv`; `--verbose` was dropped in
+    # #1775): `-v` lists every test as it completes, `-vv` also prints passing output.
+    val level: u8 = config.verbosity;
 
     # `--format json` selects the machine-readable NDJSON event stream (one JSON
     # object per line, no human readout); `human` (the default) keeps the live
     # readout. an unrecognized value is a usage error.
     var json_out: bool = false;
-    val opt_format: O.Option[*u8] = util.get_value(argc, argv, "--format");
     if (O.is_some[*u8](opt_format)) {
         val fv: str = O.unwrap[*u8](opt_format)::str;
         if (str_equals(fv, "json"))  { json_out = true; }
@@ -177,7 +177,6 @@ pub fun run(argc: usize, argv: **u8, marks: *bool) i64 {
     # `--jobs <n>` bounds how many test children run at once; the default is
     # the CPUs available to this process, and 1 serializes.
     var jobs: u32 = 1;
-    val opt_jobs: O.Option[*u8] = util.get_value(argc, argv, "--jobs");
     if (O.is_some[*u8](opt_jobs)) {
         val jv: i64 = parse_count(O.unwrap[*u8](opt_jobs));
         if (jv < 1) {
@@ -204,16 +203,15 @@ pub fun run(argc: usize, argv: **u8, marks: *bool) i64 {
         ret 2;
     }
 
-    val tbr: build.TestBuildResult = build.build_tests(?a, argc, argv, list);
+    val tbr: build.TestBuildResult = build.build_tests(?a, argc, argv, marks, list);
     if (tbr.code != 0) {
         arena.dnit(?ar);
         ret tbr.code;
     }
 
-    # `--filter <substr>` selects at run time: the dispatcher embeds every
-    # in-scope test, this command runs (or lists) only the matching ones.
+    # `--filter <substr>` (read above) selects at run time: the dispatcher embeds
+    # every in-scope test, this command runs (or lists) only the matching ones.
     var filter: *u8 = nil;
-    val opt_filter: O.Option[*u8] = util.get_value(argc, argv, "--filter");
     if (O.is_some[*u8](opt_filter)) { filter = O.unwrap[*u8](opt_filter); }
 
     # `--list`: report each selected test with no execution - one `case` JSON
@@ -257,11 +255,10 @@ pub fun run(argc: usize, argv: **u8, marks: *bool) i64 {
         }
     }
 
-    # `--runner <cmd>`: launch each test as `<cmd> <exe>`. resolved to a concrete
-    # path up front (execve does no PATH search) so a missing runner is one clean
-    # error rather than a FAIL(spawn) per test.
+    # `--runner <cmd>` (read above): launch each test as `<cmd> <exe>`. resolved to
+    # a concrete path up front (execve does no PATH search) so a missing runner is
+    # one clean error rather than a FAIL(spawn) per test.
     var runner: *u8 = nil;
-    val opt_runner: O.Option[*u8] = util.get_value(argc, argv, "--runner");
     if (O.is_some[*u8](opt_runner)) {
         val name: *u8 = O.unwrap[*u8](opt_runner);
         val res_resolve: R.Result[*u8, str] = util.resolve_cmd(?a, name);

--- a/src/cli/cmd/testing.mach
+++ b/src/cli/cmd/testing.mach
@@ -74,6 +74,7 @@ use du:     std.chrono.duration;
 
 use mach.cli.cmd.build;
 use mach.cli.util;
+use cfg:  mach.cli.config;
 use json: mach.cli.json;
 
 # a test that passed
@@ -125,10 +126,31 @@ rec Outcome {
 #
 # Called by cmd.dispatch.
 # ---
-# argc: argument count including argv[0]
-# argv: argument vector of argc null-terminated byte pointers
-# ret:  0 if all selected tests passed, 1 if any failed, 2 on a build or internal error
-pub fun run(argc: usize, argv: **u8) i64 {
+# argc:  argument count including argv[0]
+# argv:  argument vector of argc null-terminated byte pointers
+# marks: consumption record parallel to argv, for the unknown-flag rejector
+# ret:   0 if all selected tests passed, 1 if any failed, 2 on a build or internal error
+pub fun run(argc: usize, argv: **u8, marks: *bool) i64 {
+    # config.parse marks the cross-cutting flags and validates the `-v`/`--quiet`
+    # exclusion; `mach test` also accepts every build flag plus its own. mark them
+    # all, then reject any unrecognized flag before the build runs, so an unknown
+    # flag never slips through the shared build body.
+    val res_cfg: R.Result[cfg.Config, str] = cfg.parse(argc, argv, marks);
+    if (R.is_err[cfg.Config, str](res_cfg)) {
+        print.eprint("error: ");
+        print.eprint(R.unwrap_err[cfg.Config, str](res_cfg));
+        print.eprint("\n");
+        ret 1;
+    }
+    build.mark_build_flags(marks, argc, argv);
+    util.mark_flag(marks, argc, argv, "--list");
+    util.mark_flag(marks, argc, argv, "--include-deps");
+    util.mark_value(marks, argc, argv, "--format");
+    util.mark_value(marks, argc, argv, "--jobs");
+    util.mark_value(marks, argc, argv, "--filter");
+    util.mark_value(marks, argc, argv, "--runner");
+    if (util.reject_unknown(argc, argv, marks, 2, "mach test")) { ret 1; }
+
     val list: bool = util.has_flag(argc, argv, "--list");
 
     # verbosity mirrors the shared flags (`--verbose` was dropped in #1775):

--- a/src/cli/config.mach
+++ b/src/cli/config.mach
@@ -73,40 +73,47 @@ pub rec Config {
 # Per-subcommand flags are left in argv for the subcommand to consume itself.
 # Returns a specific error message on a parse error so the caller can tell the
 # user which flag was wrong: a verbosity flag (`-v`/`-vv`) combined with
-# `--quiet`.
+# `--quiet`. Each recognized flag (and its value) is recorded into `marks` so the
+# subcommand's unknown-flag rejector treats the cross-cutting flags as consumed;
+# `marks` may be nil to parse without recording (a re-parse after rejection).
 # ---
-# argc: argument count including argv[0]
-# argv: the argument vector (argc null-terminated byte pointers)
-# ret:  the populated Config, or a message naming the offending flag
-pub fun parse(argc: usize, argv: **u8) R.Result[Config, str] {
+# argc:  argument count including argv[0]
+# argv:  the argument vector (argc null-terminated byte pointers)
+# marks: consumption record parallel to argv, or nil to parse without recording
+# ret:   the populated Config, or a message naming the offending flag
+pub fun parse(argc: usize, argv: **u8, marks: *bool) R.Result[Config, str] {
     var c: Config;
 
-    # `-vv` is two levels of detail, `-v` one; the highest present wins.
+    # `-vv` is two levels of detail, `-v` one; the highest present wins. both
+    # quiet spellings are marked unconditionally so passing both does not leave
+    # one looking unknown.
     var verbosity: u8 = 0;
-    if (util.has_flag(argc, argv, "-v"))  { verbosity = 1; }
-    if (util.has_flag(argc, argv, "-vv")) { verbosity = 2; }
-    val quiet: bool = util.has_flag(argc, argv, "--quiet") || util.has_flag(argc, argv, "-q");
+    if (util.mark_flag(marks, argc, argv, "-v"))  { verbosity = 1; }
+    if (util.mark_flag(marks, argc, argv, "-vv")) { verbosity = 2; }
+    val quiet_long:  bool = util.mark_flag(marks, argc, argv, "--quiet");
+    val quiet_short: bool = util.mark_flag(marks, argc, argv, "-q");
+    val quiet:       bool = quiet_long || quiet_short;
     if (verbosity > 0 && quiet) {
         ret R.err[Config, str]("`-v`/`-vv` and `--quiet`/`-q` cannot be combined");
     }
 
     c.verbosity   = verbosity;
     c.quiet       = quiet;
-    c.verify_ir   = util.has_flag(argc, argv, "--verify-ir");
-    c.emit_asm    = util.has_flag(argc, argv, "--emit-asm");
-    c.emit_ir     = util.has_flag(argc, argv, "--emit-ir");
-    c.no_emit_asm = util.has_flag(argc, argv, "--no-emit-asm");
-    c.no_emit_ir  = util.has_flag(argc, argv, "--no-emit-ir");
-    c.release     = util.has_flag(argc, argv, "--release");
-    c.all_targets = util.has_flag(argc, argv, "--all-targets");
-    c.pie         = util.has_flag(argc, argv, "--pie");
+    c.verify_ir   = util.mark_flag(marks, argc, argv, "--verify-ir");
+    c.emit_asm    = util.mark_flag(marks, argc, argv, "--emit-asm");
+    c.emit_ir     = util.mark_flag(marks, argc, argv, "--emit-ir");
+    c.no_emit_asm = util.mark_flag(marks, argc, argv, "--no-emit-asm");
+    c.no_emit_ir  = util.mark_flag(marks, argc, argv, "--no-emit-ir");
+    c.release     = util.mark_flag(marks, argc, argv, "--release");
+    c.all_targets = util.mark_flag(marks, argc, argv, "--all-targets");
+    c.pie         = util.mark_flag(marks, argc, argv, "--pie");
 
-    c.target    = flag_value_get(argc, argv, "--target");
-    c.output    = flag_value_get(argc, argv, "-o");
-    c.artifacts = flag_value_get(argc, argv, "--artifacts");
-    c.profile   = flag_value_get(argc, argv, "--profile");
-    c.bin       = flag_value_get(argc, argv, "--bin");
-    c.lib       = flag_value_get(argc, argv, "--lib");
+    c.target    = flag_value_get(marks, argc, argv, "--target");
+    c.output    = flag_value_get(marks, argc, argv, "-o");
+    c.artifacts = flag_value_get(marks, argc, argv, "--artifacts");
+    c.profile   = flag_value_get(marks, argc, argv, "--profile");
+    c.bin       = flag_value_get(marks, argc, argv, "--bin");
+    c.lib       = flag_value_get(marks, argc, argv, "--lib");
 
     ret R.ok[Config, str](c);
 }
@@ -115,14 +122,16 @@ pub fun parse(argc: usize, argv: **u8) R.Result[Config, str] {
 # no following argument
 #
 # Collapses the get/some/unwrap dance every `*u8` flag in `parse` shares; the
-# nil sentinel matches the Config fields' "flag not given" convention.
+# nil sentinel matches the Config fields' "flag not given" convention. Records the
+# flag and its value into `marks` (when non-nil) for the unknown-flag rejector.
 # ---
-# argc: argument count including argv[0]
-# argv: the argument vector (argc null-terminated byte pointers)
-# flag: the flag whose value to read
-# ret:  the value pointer, or nil when the flag is not present
-fun flag_value_get(argc: usize, argv: **u8, flag: *u8) *u8 {
-    val opt_value: O.Option[*u8] = util.get_value(argc, argv, flag);
+# marks: consumption record parallel to argv, or nil to only read
+# argc:  argument count including argv[0]
+# argv:  the argument vector (argc null-terminated byte pointers)
+# flag:  the flag whose value to read
+# ret:   the value pointer, or nil when the flag is not present
+fun flag_value_get(marks: *bool, argc: usize, argv: **u8, flag: *u8) *u8 {
+    val opt_value: O.Option[*u8] = util.mark_value(marks, argc, argv, flag);
     if (O.is_none[*u8](opt_value)) { ret nil; }
     ret O.unwrap[*u8](opt_value);
 }

--- a/src/cli/util.mach
+++ b/src/cli/util.mach
@@ -15,6 +15,7 @@
 use std.allocator.arena;
 use std.allocator.page;
 use std.filesystem;
+use std.print;
 use std.system.os;
 use std.types.bool.bool;
 use std.types.bool.false;
@@ -118,6 +119,63 @@ pub fun get_value(argc: usize, argv: **u8, flag: *u8) O.Option[*u8] {
     ret O.none[*u8]();
 }
 
+# has_flag that also records every matching index into `marks`, so a later
+# reject_unknown pass treats the flag as consumed
+#
+# `marks` is parallel to argv (length argc); nil skips recording, leaving a plain
+# presence test. Every occurrence is marked, so a repeated boolean flag is fully
+# consumed. Consumption itself is the registration - a command marks a flag by
+# reading it, with no separate accepted-flag table to drift.
+# ---
+# marks: consumption record parallel to argv, or nil to only test presence
+# argc:  number of arguments to scan
+# argv:  argument vector (argc null-terminated byte pointers)
+# flag:  the flag to search for
+# ret:   true when the flag appears in argv[0, argc)
+pub fun mark_flag(marks: *bool, argc: usize, argv: **u8, flag: *u8) bool {
+    val want:  str  = flag::str;
+    var found: bool = false;
+    var i:     usize = 0;
+    for (i < argc) {
+        if (str_equals(argv[i]::str, want)) {
+            found = true;
+            if (marks != nil) { marks[i] = true; }
+        }
+        i = i + 1;
+    }
+    ret found;
+}
+
+# get_value that records the flag index and its value index into `marks`, so a
+# later reject_unknown pass treats both as consumed
+#
+# Every occurrence is marked - a repeatable value flag (`-L`, `-l`) consumes each
+# of its pairs - while the first value is returned, matching get_value. `marks`
+# may be nil to only read. A trailing flag with no following value still marks the
+# flag token itself, so it is never misreported as unknown.
+# ---
+# marks: consumption record parallel to argv, or nil to only read
+# argc:  number of arguments to scan
+# argv:  argument vector (argc null-terminated byte pointers)
+# flag:  the flag to search for
+# ret:   some(first value) when the flag is found with a following value, else none
+pub fun mark_value(marks: *bool, argc: usize, argv: **u8, flag: *u8) O.Option[*u8] {
+    val want:  str            = flag::str;
+    var value: O.Option[*u8] = O.none[*u8]();
+    var i:     usize          = 0;
+    for (i < argc) {
+        if (str_equals(argv[i]::str, want)) {
+            if (marks != nil) { marks[i] = true; }
+            if (i + 1 < argc) {
+                if (marks != nil) { marks[i + 1] = true; }
+                if (O.is_none[*u8](value)) { value = O.some[*u8](argv[i + 1]); }
+            }
+        }
+        i = i + 1;
+    }
+    ret value;
+}
+
 # whether `s` looks like a flag (a non-nil token beginning with '-')
 # ---
 # s:   the token to test
@@ -190,6 +248,39 @@ pub fun positional_index(argc: usize, argv: **u8, start: usize) usize {
         i = i + 1;
     }
     ret argc;
+}
+
+# report the first flag token in argv[start, argc) that no reader marked consumed
+#
+# Consumption marking (mark_flag / mark_value, and config.parse) records every
+# recognized flag and its value; this walks the same range and errors on the
+# first `-`-prefixed token nobody claimed, so a typo'd or removed flag is a hard
+# error rather than a silently misparsed positional (#1810). Bare (non-flag)
+# tokens are positionals or link inputs and are left alone. Callers that honour a
+# `--` separator pass the boundary as `argc`, so program arguments after it are
+# never scanned. The diagnostic names the flag and the command; the caller
+# returns its usage-error exit code.
+# ---
+# argc:  number of arguments to scan (the `--` boundary for commands that clip)
+# argv:  argument vector (argc null-terminated byte pointers)
+# marks: consumption record parallel to argv
+# start: index to begin scanning from (past the subcommand / action)
+# cmd:   command label for the diagnostic (e.g. "mach build")
+# ret:   true when an unknown flag was found and reported
+pub fun reject_unknown(argc: usize, argv: **u8, marks: *bool, start: usize, cmd: *u8) bool {
+    var i: usize = start;
+    for (i < argc) {
+        if (!marks[i] && is_flag(argv[i])) {
+            print.eprint("error: unknown flag '");
+            print.eprint(argv[i]::str);
+            print.eprint("' for '");
+            print.eprint(cmd::str);
+            print.eprint("'\n");
+            ret true;
+        }
+        i = i + 1;
+    }
+    ret false;
 }
 
 # join `dir` and `leaf` with a single '/' into `buf` and null-terminate
@@ -479,5 +570,67 @@ test "mach.cli.util.positional_index:skips_value_flag" {
     var c: [3]*u8;
     c[0] = "mach"; c[1] = "build"; c[2] = ".";
     if (positional_index(3, ?c[0], 2) != 2) { ret 1; }
+    ret 0;
+}
+
+# mark_flag records every matching index and reports presence; a nil marks vector
+# leaves it a plain presence test.
+test "mach.cli.util.mark_flag:records_every_occurrence" {
+    var argv: [4]*u8;
+    argv[0] = "mach"; argv[1] = "build"; argv[2] = "-v"; argv[3] = "-v";
+    var marks: [4]bool;
+    var i: usize = 0;
+    for (i < 4) { marks[i] = false; i = i + 1; }
+
+    if (!mark_flag(?marks[0], 4, ?argv[0], "-v")) { ret 1; }
+    if (!marks[2] || !marks[3])                   { ret 1; }
+    if (marks[0] || marks[1])                     { ret 1; }
+    if (mark_flag(?marks[0], 4, ?argv[0], "-q"))  { ret 1; }
+
+    # nil marks is a pure presence test (no crash, correct result).
+    if (!mark_flag(nil, 4, ?argv[0], "-v")) { ret 1; }
+    ret 0;
+}
+
+# mark_value records each flag/value pair (repeatable) and returns the first value.
+test "mach.cli.util.mark_value:marks_pairs_returns_first" {
+    var argv: [6]*u8;
+    argv[0] = "mach"; argv[1] = "build"; argv[2] = "-l"; argv[3] = "a";
+    argv[4] = "-l";   argv[5] = "b";
+    var marks: [6]bool;
+    var i: usize = 0;
+    for (i < 6) { marks[i] = false; i = i + 1; }
+
+    val v: O.Option[*u8] = mark_value(?marks[0], 6, ?argv[0], "-l");
+    if (O.is_none[*u8](v))                     { ret 1; }
+    if (!str_equals(O.unwrap[*u8](v)::str, "a")) { ret 1; }
+    # both -l flags and both values are consumed.
+    if (!marks[2] || !marks[3] || !marks[4] || !marks[5]) { ret 1; }
+    if (marks[0] || marks[1])                             { ret 1; }
+    ret 0;
+}
+
+# reject_unknown flags the first unmarked flag token and leaves marked flags and
+# bare positionals alone.
+test "mach.cli.util.reject_unknown:first_unmarked_flag" {
+    # [mach, build, --bogus, .] with nothing marked: --bogus is rejected.
+    var a: [4]*u8;
+    a[0] = "mach"; a[1] = "build"; a[2] = "--bogus"; a[3] = ".";
+    var ma: [4]bool;
+    var i: usize = 0;
+    for (i < 4) { ma[i] = false; i = i + 1; }
+    if (!reject_unknown(4, ?a[0], ?ma[0], 2, "mach build")) { ret 1; }
+
+    # marking the flag makes it accepted; the bare '.' is never rejected.
+    ma[2] = true;
+    if (reject_unknown(4, ?a[0], ?ma[0], 2, "mach build")) { ret 1; }
+
+    # a bare-only tail (a project path plus a link input) is accepted.
+    var b: [4]*u8;
+    b[0] = "mach"; b[1] = "build"; b[2] = "."; b[3] = "libfoo.o";
+    var mb: [4]bool;
+    i = 0;
+    for (i < 4) { mb[i] = false; i = i + 1; }
+    if (reject_unknown(4, ?b[0], ?mb[0], 2, "mach build")) { ret 1; }
     ret 0;
 }

--- a/src/cli/util.mach
+++ b/src/cli/util.mach
@@ -184,33 +184,6 @@ pub fun is_flag(s: *u8) bool {
     ret s != nil && s[0] == '-';
 }
 
-# whether `a` is a known flag that consumes the following argv entry as its value
-#
-# One table for every value-taking flag the CLI recognizes, so the positional
-# and link-input scanners step over a flag's value rather than mistaking it for
-# a positional or an object path.
-# ---
-# a:   the token to test
-# ret: true when `a` is a value-taking flag
-pub fun is_value_flag(a: *u8) bool {
-    val s: str = a::str;
-    ret str_equals(s, "-L")
-        || str_equals(s, "-l")
-        || str_equals(s, "-o")
-        || str_equals(s, "--target")
-        || str_equals(s, "--artifacts")
-        || str_equals(s, "--emit")
-        || str_equals(s, "--filter")
-        || str_equals(s, "--format")
-        || str_equals(s, "--out")
-        || str_equals(s, "--name")
-        || str_equals(s, "--ref")
-        || str_equals(s, "--profile")
-        || str_equals(s, "--bin")
-        || str_equals(s, "--lib")
-        || str_equals(s, "--runner");
-}
-
 # index of the `--` separator in argv, or argc when absent
 #
 # The value doubles as the effective argument count for the build: everything
@@ -229,21 +202,33 @@ pub fun separator_index(argc: usize, argv: **u8) usize {
     ret argc;
 }
 
-# index of the first bare (non-flag) argument at or after `start`, skipping each
-# known value flag together with its value, or argc when none is present
+# index of the first positional argument at or after `start`, or argc when none
+#
+# The consumption record `marks` is the single source of truth: every flag and
+# its value were marked when read (config.parse plus each command's own flag
+# reads), so this steps over any marked index and returns the first bare token
+# nobody claimed - no separate value-flag table to drift from the reads (#1810).
+# A `--` separator ends the flag region: the token right after it is the first
+# positional, which lets a path-taking command accept a `-`-leading argument
+# (`mach doc -- -weird`). Commands that forward program arguments after `--`
+# (run/test) instead pass the separator index as `argc`, so `--` is never
+# reached here. An unmarked flag before the first positional cannot occur -
+# reject_unknown rejects it first - so it is stepped over defensively only.
 # ---
-# argc:  number of arguments to scan
+# argc:  number of arguments to scan (the `--` boundary for forwarding commands)
 # argv:  argument vector (argc null-terminated byte pointers)
+# marks: consumption record parallel to argv
 # start: index to begin scanning from (typically 2, past the subcommand)
 # ret:   index of the first positional, or argc when there is none
-pub fun positional_index(argc: usize, argv: **u8, start: usize) usize {
+pub fun positional_index(argc: usize, argv: **u8, marks: *bool, start: usize) usize {
     var i: usize = start;
     for (i < argc) {
         val a: *u8 = argv[i];
-        if (is_value_flag(a) && i + 1 < argc) {
-            i = i + 2;
-            cnt;
+        if (str_equals(a::str, "--")) {
+            if (i + 1 < argc) { ret i + 1; }
+            ret argc;
         }
+        if (marks[i])                { i = i + 1; cnt; }
         if (a != nil && !is_flag(a)) { ret i; }
         i = i + 1;
     }
@@ -256,12 +241,12 @@ pub fun positional_index(argc: usize, argv: **u8, start: usize) usize {
 # recognized flag and its value; this walks the same range and errors on the
 # first `-`-prefixed token nobody claimed, so a typo'd or removed flag is a hard
 # error rather than a silently misparsed positional (#1810). Bare (non-flag)
-# tokens are positionals or link inputs and are left alone. Callers that honour a
-# `--` separator pass the boundary as `argc`, so program arguments after it are
-# never scanned. The diagnostic names the flag and the command; the caller
-# returns its usage-error exit code.
+# tokens are positionals or link inputs and are left alone. Scanning stops at a
+# `--` separator: it and every token after it are program arguments, not flags,
+# on every command - so the caller may pass the full `argc`. The diagnostic names
+# the flag and the command; the caller returns its usage-error exit code.
 # ---
-# argc:  number of arguments to scan (the `--` boundary for commands that clip)
+# argc:  number of arguments to scan
 # argv:  argument vector (argc null-terminated byte pointers)
 # marks: consumption record parallel to argv
 # start: index to begin scanning from (past the subcommand / action)
@@ -270,6 +255,7 @@ pub fun positional_index(argc: usize, argv: **u8, start: usize) usize {
 pub fun reject_unknown(argc: usize, argv: **u8, marks: *bool, start: usize, cmd: *u8) bool {
     var i: usize = start;
     for (i < argc) {
+        if (str_equals(argv[i]::str, "--")) { ret false; }
         if (!marks[i] && is_flag(argv[i])) {
             print.eprint("error: unknown flag '");
             print.eprint(argv[i]::str);
@@ -553,23 +539,65 @@ test "mach.cli.util.separator_index:boundary_as_argc" {
     ret 0;
 }
 
-# positional_index skips a value flag together with its value, finds an explicit
+# positional_index steps over marked flag/value indices, finds an explicit
 # positional, and resolves `mach build .`.
-test "mach.cli.util.positional_index:skips_value_flag" {
-    # [mach, init, --name, myproj] has no positional: --name eats myproj.
+test "mach.cli.util.positional_index:skips_marked" {
+    # [mach, init, --name, myproj] has no positional: --name and its value myproj
+    # are both marked (consumed), so nothing remains.
     var a: [4]*u8;
     a[0] = "mach"; a[1] = "init"; a[2] = "--name"; a[3] = "myproj";
-    if (positional_index(4, ?a[0], 2) != 4) { ret 1; }
+    var ma: [4]bool;
+    ma[0] = false; ma[1] = false; ma[2] = true; ma[3] = true;
+    if (positional_index(4, ?a[0], ?ma[0], 2) != 4) { ret 1; }
 
     # an explicit directory is found, and --name's value is still skipped.
     var b: [5]*u8;
     b[0] = "mach"; b[1] = "init"; b[2] = "mydir"; b[3] = "--name"; b[4] = "x";
-    if (positional_index(5, ?b[0], 2) != 2) { ret 1; }
+    var mb: [5]bool;
+    mb[0] = false; mb[1] = false; mb[2] = false; mb[3] = true; mb[4] = true;
+    if (positional_index(5, ?b[0], ?mb[0], 2) != 2) { ret 1; }
 
     # mach build . resolves the '.' positional.
     var c: [3]*u8;
     c[0] = "mach"; c[1] = "build"; c[2] = ".";
-    if (positional_index(3, ?c[0], 2) != 2) { ret 1; }
+    var mc: [3]bool;
+    mc[0] = false; mc[1] = false; mc[2] = false;
+    if (positional_index(3, ?c[0], ?mc[0], 2) != 2) { ret 1; }
+    ret 0;
+}
+
+# positional_index steps over a value flag absent from any hand-kept table - the
+# `mach test --jobs 4 .` shape - because the marks vector is the single source of
+# truth. `4` is --jobs's marked value, so `.` is the resolved positional (#1810).
+test "mach.cli.util.positional_index:jobs_value_not_positional" {
+    var a: [5]*u8;
+    a[0] = "mach"; a[1] = "test"; a[2] = "--jobs"; a[3] = "4"; a[4] = ".";
+    var m: [5]bool;
+    m[0] = false; m[1] = false; m[2] = true; m[3] = true; m[4] = false;
+    if (positional_index(5, ?a[0], ?m[0], 2) != 4) { ret 1; }
+    ret 0;
+}
+
+# `--` ends the flag region for both scanners: reject_unknown stops there (a
+# following `-`-token is a program argument, not rejected), and positional_index
+# returns the token after it (so a `-`-leading positional is reachable).
+test "mach.cli.util.separator:ends_flag_region" {
+    # [mach, run, ., --, --after]: --after is a program arg, never rejected.
+    var a: [5]*u8;
+    a[0] = "mach"; a[1] = "run"; a[2] = "."; a[3] = "--"; a[4] = "--after";
+    var m: [5]bool;
+    var i: usize = 0;
+    for (i < 5) { m[i] = false; i = i + 1; }
+    if (reject_unknown(5, ?a[0], ?m[0], 2, "mach run")) { ret 1; }
+
+    # [mach, doc, --, -weird]: `--` escapes a dash-leading positional.
+    var b: [4]*u8;
+    b[0] = "mach"; b[1] = "doc"; b[2] = "--"; b[3] = "-weird";
+    var mb: [4]bool;
+    i = 0;
+    for (i < 4) { mb[i] = false; i = i + 1; }
+    if (reject_unknown(4, ?b[0], ?mb[0], 2, "mach doc")) { ret 1; }
+    if (positional_index(4, ?b[0], ?mb[0], 2) != 3)      { ret 1; }
     ret 0;
 }
 


### PR DESCRIPTION
Closes #1810.

## Problem

An unrecognized flag was never reported and, worse, corrupted positional
resolution: `positional_index` stepped over only *known* value flags, so an
unknown flag was treated as a bare toggle and its value token was claimed as the
positional. `mach build --color always .` resolved `always` as the project path
and errored with `no mach.toml found …` instead of naming `--color`.

## Fix (design 1 from the issue — central rejector via consumption marking)

Flag consumption now *marks* the argv indices it consumes, and each command
rejects the first unconsumed `-`/`--` token **before** resolving positionals:

- `util.mark_flag` / `util.mark_value` — `has_flag`/`get_value` that also record
  every matched index (and value index) into a `marks` vector. `nil` marks =
  plain read (the re-parse inside `build_unit`).
- `util.reject_unknown(argc, argv, marks, start, cmd)` — walks the same range and
  errors on the first `-`-prefixed token nobody claimed:
  `error: unknown flag '--color' for 'mach build'`. Bare tokens (positionals,
  link inputs) are left alone; callers that honour `--` pass the boundary as
  `argc`.
- `config.parse` gained a `marks` param and marks the cross-cutting flags as it
  reads them — one home for the global set, no drift.
- The `marks` vector is allocated once in `cmd.dispatch` and threaded through
  each `run`. `mach build`/`mach test` share `build.mark_build_flags` for the
  build-specific set (`-O*`, `--emit`, `-L`, `-l`).

Consumption itself is the registration: a new flag is covered the moment a
command reads it, with no per-command allowlist table to drift.

## Acceptance

- `mach build --color always .` → `error: unknown flag '--color' for 'mach build'`; `.` is never displaced.
- `mach build --color aut .` and `mach build --color` likewise name `--color`.
- Every subcommand rejects `--bogus` (build/run/test/check/doc/init/info, and each `mach dep <action>`).
- Full sweep confirms every flag documented in `doc/cli.md` and `mach help` is still accepted where documented (globals, `-O*`/`--emit`/`-L`/`-l`, `--runner`, `--jobs`/`--filter`/`--format`/`--list`/`--include-deps`, `--out`, `--name`/`--force`/`--lib`, `--version`/`targets`, dep `--all`/`--git`/`--path`/`--ref`/`--purge`).
- `--` separator still forwards program args untouched (`mach run . -- --flag`); `mach run --emit` still rejected.
- New unit tests for `mark_flag` / `mark_value` / `reject_unknown` in `util.mach`; `doc/cli.md` documents the new behavior.

Exit code for an unknown flag is `1` (usage error), matching the other parse errors.
