### PR TITLE
chore(init): normalize scaffold target names to <os>-<isa>

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,10 @@ integer literals now report their bounds.
   COFF being x86_64-only) or whose ABI does not match the ISA is rejected with a
   message naming the missing capability, instead of composing and failing deep in
   codegen or link (#1806).
+- driver: **`mach init` scaffold target names** follow the `<os>-<isa>`
+  convention (`linux-x86_64`, `windows-x86_64`, `darwin-x86_64` on the host isa),
+  matching the root manifest's normalized naming. A fresh project now writes
+  `out/linux-x86_64/…` rather than `out/linux/…` (#1832).
 
 ### Removed
 

--- a/src/cli/cmd/init.mach
+++ b/src/cli/cmd/init.mach
@@ -155,9 +155,9 @@ pub fun run(argc: usize, argv: **u8) i64 {
 # write the `mach.toml` manifest for a freshly scaffolded project
 #
 # Emits a `[project]` block (id, version, src/dep dirs, output-path templates,
-# and `module` for a library), `[target.linux|windows|darwin]` blocks on the host
-# isa, one `[bin.<id>]` or `[lib.<id>]` artifact, debug/release profiles, and the
-# `[deps.mach-std]` dependency.
+# and `module` for a library), `[target.<os>-<isa>]` blocks for linux/windows/darwin
+# on the host isa, one `[bin.<id>]` or `[lib.<id>]` artifact, debug/release profiles,
+# and the `[deps.mach-std]` dependency.
 # ---
 # path:   destination path for the manifest
 # id:     project id (already validated)
@@ -189,7 +189,11 @@ fun write_manifest(path: *u8, id: *u8, is_lib: bool) bool {
     buf_put(?buf, "tests = \"out/{target}/{profile}/test/{name}\"\n");
     buf_put(?buf, "\n");
 
-    buf_put(?buf, "[target.linux]\n");
+    # target names follow the `<os>-<isa>` convention the root manifest uses; the
+    # isa suffix is the host isa verbatim, so the name always matches the isa field
+    buf_put(?buf, "[target.linux-");
+    buf_put(?buf, host_isa());
+    buf_put(?buf, "]\n");
     buf_put(?buf, "isa = \"");
     buf_put(?buf, host_isa());
     buf_put(?buf, "\"\n");
@@ -197,7 +201,9 @@ fun write_manifest(path: *u8, id: *u8, is_lib: bool) bool {
     buf_put(?buf, "abi = \"sysv64\"\n");
     buf_put(?buf, "\n");
 
-    buf_put(?buf, "[target.windows]\n");
+    buf_put(?buf, "[target.windows-");
+    buf_put(?buf, host_isa());
+    buf_put(?buf, "]\n");
     buf_put(?buf, "isa = \"");
     buf_put(?buf, host_isa());
     buf_put(?buf, "\"\n");
@@ -206,7 +212,9 @@ fun write_manifest(path: *u8, id: *u8, is_lib: bool) bool {
     buf_put(?buf, "ext = \".exe\"\n");
     buf_put(?buf, "\n");
 
-    buf_put(?buf, "[target.darwin]\n");
+    buf_put(?buf, "[target.darwin-");
+    buf_put(?buf, host_isa());
+    buf_put(?buf, "]\n");
     buf_put(?buf, "isa = \"");
     buf_put(?buf, host_isa());
     buf_put(?buf, "\"\n");


### PR DESCRIPTION
Closes #1832.

## Problem

`mach init` scaffolded a `mach.toml` with os-only target names — `[target.linux]`, `[target.windows]`, `[target.darwin]` — while the compiler's root manifest was normalized to `<os>-<isa>` names in `46231078`. A freshly-initialized project therefore used the old convention and wrote `out/linux/…` rather than `out/linux-x86_64/…`.

## Change

`write_manifest` in `src/cli/cmd/init.mach` now composes the target header as `[target.<os>-<isa>]`, where the isa suffix is the host isa (`host_isa()`) verbatim — the same value already written to the `isa` field. No alias table is introduced (the name suffix always equals the isa string), keeping the scaffold from encoding a naming convention beyond `<os>-<isa>`.

On an x86_64 host a fresh scaffold now emits:

```toml
[target.linux-x86_64]
isa = "x86_64"
os  = "linux"
abi = "sysv64"

[target.windows-x86_64]
isa = "x86_64"
os  = "windows"
abi = "win64"
ext = ".exe"

[target.darwin-x86_64]
isa = "x86_64"
os  = "darwin"
abi = "sysv64"
```

## Scope

Template-string change only. The `doc/manifest.md` examples deliberately use bare labels to teach that target names are arbitrary, and the `driver.mach` `uniontest` fixtures rely on `linux` being the first-declared default for host-tie test invariants — both are independent namespaces (as noted in the `46231078` message about the int harness) and are left untouched. The int/ fixtures already use `<os>-<isa>` names.

## Verification

- from-source compiler (`out/linux-x86_64/debug/bin/mach`) scaffolds `demo` (bin) and `demolib` (lib); both build cleanly and the bin prints `Hello, World!`, writing `out/linux-x86_64/…`
- `mach test .`: 473 passed, 0 failed
- `int/run.sh --target linux`: all cases passed
