### PR TITLE
feat(check): machine-readable diagnostics (--format json)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 A follow-up hardening, cleanup, and tooling sweep over the 2.12.0 overhaul.
 `--pie` images regain read-only hardening for their relocated constants
 (`PT_GNU_RELRO`), the register allocator sheds redundant copies for a smaller
-binary, `mach test --format json` and `mach info targets` add machine-readable
-surfaces, diagnostics gain `= help:` lines and secondary spans, and out-of-range
-integer literals now report their bounds.
+binary, `mach test --format json`, `mach check --format json`, and `mach info
+targets` add machine-readable surfaces, diagnostics gain `= help:` lines and
+secondary spans, and out-of-range integer literals now report their bounds.
 
 ### Added
 
@@ -30,6 +30,14 @@ integer literals now report their bounds.
   escaped so the stream is byte-identical across platforms; labels are emitted
   verbatim; `test` events arrive in **completion order** (sort by `index` for
   declaration order) (#1792).
+- check: **`mach check --format json`** - a versioned, machine-readable NDJSON
+  diagnostic stream (a `diagnostic` object per diagnostic carrying severity,
+  message, primary location, note, help, and the LSP-shaped related list, then a
+  closing `summary`; `schema: 1`) for editors and CI, documented in
+  `doc/tooling/check-json.md`. JSON goes to stdout with no human frames
+  interleaved; positions are 1-based and spans half-open; it reuses the
+  `mach.cli.json` emitter, which grew nested-object and array support to carry
+  the model (#1815).
 - diag: diagnostics gained a distinct **`= help:` line** and an optional
   **secondary span** - a duplicate definition now points at the prior binding in
   its own `--> file:line:col` frame labelled `previous definition here`, and

--- a/doc/cli.md
+++ b/doc/cli.md
@@ -22,6 +22,7 @@ matched exactly: `--flag value` (a value follows in the next argument) or a bare
 | `build` | compile the project to objects and (for a `[bin.*]`) a linked binary |
 | `run`   | execute the already-built binary (a post-`build` convenience, not a rebuild) |
 | `test`  | build the test binary and run the collected tests |
+| `check` | report diagnostics for a single source file, without a project |
 | `dep`   | manage git-backed dependencies (clone, lock, vendor) under `<dep>` |
 | `init`  | scaffold a new project |
 | `doc`   | generate Markdown reference docs from source doc-comments |
@@ -265,6 +266,30 @@ integer. Build diagnostics stay on stderr, so the stdout stream is clean.
 
 Exit codes: `0` all passed, `1` any failed, `2` build/internal error.
 
+## `mach check`
+
+```
+mach check <file> [--format human|json]
+```
+
+Reports diagnostics for a single source file, feeding its text straight through
+the editor query surface — no `mach.toml`, module graph, or link step. It is the
+editor-facing diagnostics slice exposed as a CLI verb.
+
+| Flag              | Value            | Effect |
+|-------------------|------------------|--------|
+| `--format <mode>` | `human`\|`json`  | diagnostic format: framed source snippets on stderr (default `human`), or the machine-readable NDJSON stream on stdout |
+
+`--format json` emits one JSON object per line on stdout — a `diagnostic` object
+per reported diagnostic (severity, message, primary location, note, help, and
+the related list) and a closing `summary` — with no human frames interleaved.
+The schema is versioned and documented in
+[tooling/check-json.md](tooling/check-json.md); pin tooling to its `schema`
+integer. Usage and io errors stay on stderr, so the stdout stream is clean.
+
+Exit codes: `0` when the buffer has no error-severity diagnostics, `1` when it
+has any (or on a usage / io error).
+
 ## `mach dep`
 
 ```
@@ -476,4 +501,5 @@ non-zero.
 - [manifest.md](manifest.md) — the `mach.toml` reference
 - [language/test.md](language/test.md) — the `test` declaration and `mach test`
 - [tooling/test-json.md](tooling/test-json.md) — the `mach test --format json` event schema
+- [tooling/check-json.md](tooling/check-json.md) — the `mach check --format json` diagnostic schema
 - [language/files.md](language/files.md) — project file layout

--- a/doc/cli.md
+++ b/doc/cli.md
@@ -274,21 +274,26 @@ mach check <file> [--format human|json]
 
 Reports diagnostics for a single source file, feeding its text straight through
 the editor query surface — no `mach.toml`, module graph, or link step. It is the
-editor-facing diagnostics slice exposed as a CLI verb.
+editor-facing diagnostics slice exposed as a CLI verb. It reports **parse-stage
+diagnostics only**: it does not run name resolution or sema, so a real run never
+carries the `= help:` suggestions or secondary (`related`) spans those stages
+produce — whether check should deepen to resolve is tracked in
+[#1839](https://github.com/briar-systems/mach/issues/1839).
 
 | Flag              | Value            | Effect |
 |-------------------|------------------|--------|
 | `--format <mode>` | `human`\|`json`  | diagnostic format: framed source snippets on stderr (default `human`), or the machine-readable NDJSON stream on stdout |
 
 `--format json` emits one JSON object per line on stdout — a `diagnostic` object
-per reported diagnostic (severity, message, primary location, note, help, and
-the related list) and a closing `summary` — with no human frames interleaved.
-The schema is versioned and documented in
+per reported diagnostic (severity, message, primary location, and the `note`,
+`help`, and `related` fields, structurally `null` / empty today per the
+parse-only note above) and a closing `summary` — with no human frames
+interleaved. The schema is versioned and documented in
 [tooling/check-json.md](tooling/check-json.md); pin tooling to its `schema`
 integer. Usage and io errors stay on stderr, so the stdout stream is clean.
 
 Exit codes: `0` when the buffer has no error-severity diagnostics, `1` when it
-has any (or on a usage / io error).
+has any (or on a usage / io error), and `2` on an allocator bootstrap failure.
 
 ## `mach dep`
 

--- a/doc/tooling/check-json.md
+++ b/doc/tooling/check-json.md
@@ -10,7 +10,8 @@ The stream is written to **stdout**. Usage errors and internal failures (an
 unreadable file, an analysis that could not run) stay on **stderr**, so a
 consumer reads a clean event stream on stdout regardless of that noise. Exit
 codes are unchanged from the human mode: `0` when the buffer has no
-error-severity diagnostics, `1` when it has any (or on a usage / io error).
+error-severity diagnostics, `1` when it has any (or on a usage / io error), and
+`2` on an allocator bootstrap failure.
 
 Every line is a complete JSON object carrying a `schema` version integer and an
 `event` discriminator. Strings are escaped to printable ASCII: control
@@ -23,12 +24,21 @@ json` uses (see [test-json.md](test-json.md) for the escaping rationale).
 ### Paths and positions
 
 `file` is emitted exactly as the compiler references it — the path passed to
-`mach check`, relative to the working directory or absolute as given. Line and
-column numbers are **1-based**, matching the human renderer and the compiler's
-own convention; a consumer feeding an LSP (whose `Position` is 0-based) subtracts
-one from each. A span is half-open: `start` is the position of its first byte
-and `end` is the position just past its last, so a zero-width span has
-`start == end`.
+`mach check`, relative to the working directory or absolute as given. Positions
+are **1-based**, matching the human renderer and the compiler's own convention:
+`line` is the 1-based line number, and `col` is the 1-based **byte** offset of
+the position within its line (not a character or code-unit count). A span is
+half-open: `start` is the position of its first byte and `end` is the position
+just past its last, so a zero-width span has `start == end`.
+
+Converting to an LSP `Position` is therefore **not** a uniform subtract-one. LSP
+is 0-based and its `Position.character` counts UTF-16 code units by default.
+Subtract one from `line`. For `col`, subtract one to get a 0-based byte offset,
+then convert that byte offset to a UTF-16 code-unit offset against the line's
+text: an ASCII line converts one-to-one, but a line with multibyte content does
+not — on a `héllo` line, mach's byte `col` 4 lands at LSP `character` 2, not 3. A
+consumer that retains the source buffer does this with the line text it already
+holds.
 
 ## Versioning
 
@@ -71,10 +81,28 @@ Each **related** element is:
 | `location` | object / null | the secondary location, or `null` when its file does not resolve |
 | `label`    | string / null | the caption rendered under the secondary span, or `null` for a bare context span |
 
+A diagnostic as `mach check` emits it today — a syntactic error with no note,
+help, or related span:
+
 ```json
 {"schema":1,"event":"diagnostic","severity":"error","message":"expected an expression","location":{"file":"buf.mach","start":{"line":2,"col":12},"end":{"line":2,"col":13}},"note":null,"help":null,"related":[]}
+```
+
+The `note`, `help`, and `related` fields carry the full diagnostic model for a
+diagnostic that populates them — a resolve-stage diagnostic such as a duplicate
+definition, with a `= help:` suggestion and a `previous definition here` related
+span:
+
+```json
 {"schema":1,"event":"diagnostic","severity":"error","message":"duplicate definition of 'dup'","location":{"file":"buf.mach","start":{"line":2,"col":5},"end":{"line":2,"col":8}},"note":null,"help":"rename one of the definitions","related":[{"location":{"file":"buf.mach","start":{"line":1,"col":5},"end":{"line":1,"col":8}},"label":"previous definition here"}]}
 ```
+
+Today `mach check` reports **parse-stage diagnostics only**, so `note`, `help`,
+and `related` are structurally `null` / empty on a real run — the second example
+illustrates the schema's capacity, not current output. `help` and `related` are
+populated at the resolve stage, which `mach check` does not yet run (see
+[editor-api.md](editor-api.md)); whether check should deepen to resolve is
+tracked in [#1839](https://github.com/briar-systems/mach/issues/1839).
 
 ### `summary`
 

--- a/doc/tooling/check-json.md
+++ b/doc/tooling/check-json.md
@@ -1,0 +1,109 @@
+# `mach check` JSON diagnostic schema (v1)
+
+`mach check --format json` emits its diagnostics as a machine-readable stream
+instead of the framed source snippets: one JSON object per line
+(newline-delimited JSON / NDJSON), no interleaved human text. Editors, LSP
+shims, and CI annotators parse this stream rather than scraping the human
+frames, which stay free to evolve.
+
+The stream is written to **stdout**. Usage errors and internal failures (an
+unreadable file, an analysis that could not run) stay on **stderr**, so a
+consumer reads a clean event stream on stdout regardless of that noise. Exit
+codes are unchanged from the human mode: `0` when the buffer has no
+error-severity diagnostics, `1` when it has any (or on a usage / io error).
+
+Every line is a complete JSON object carrying a `schema` version integer and an
+`event` discriminator. Strings are escaped to printable ASCII: control
+characters use their JSON escapes and every byte `>= 0x80` is emitted as a
+`\uXXXX` escape (UTF-8 decoded, astral code points as a surrogate pair), so the
+output is byte-for-byte identical on every platform. Numbers are integers. The
+escaper is the shared `mach.cli.json` emitter, the same one `mach test --format
+json` uses (see [test-json.md](test-json.md) for the escaping rationale).
+
+### Paths and positions
+
+`file` is emitted exactly as the compiler references it — the path passed to
+`mach check`, relative to the working directory or absolute as given. Line and
+column numbers are **1-based**, matching the human renderer and the compiler's
+own convention; a consumer feeding an LSP (whose `Position` is 0-based) subtracts
+one from each. A span is half-open: `start` is the position of its first byte
+and `end` is the position just past its last, so a zero-width span has
+`start == end`.
+
+## Versioning
+
+`schema` is `1`. It is bumped only on an **incompatible** change to the object
+shapes — a removed or renamed field, or a changed field type or meaning. Adding
+a new optional field (for example a diagnostic `code`) or a new `event` kind is
+backward compatible and does **not** bump the version; a consumer must ignore
+unknown fields and unknown `event` values. Pin behavior to the `schema` integer,
+never to field ordering.
+
+## Events
+
+### `diagnostic`
+
+Emitted once per reported diagnostic, in report order.
+
+| Field      | Type          | Description |
+|------------|---------------|-------------|
+| `schema`   | int           | schema version (`1`) |
+| `event`    | string        | `"diagnostic"` |
+| `severity` | string        | `"error"`, `"warning"`, `"info"`, or `"help"` |
+| `message`  | string        | the diagnostic message, verbatim |
+| `location` | object / null | the primary source location (see below), or `null` when its file does not resolve |
+| `note`     | string / null | the attached `= note:` line, or `null` |
+| `help`     | string / null | the attached `= help:` suggestion, or `null` |
+| `related`  | array         | secondary locations (possibly empty); see below |
+
+A **location** object is:
+
+| Field   | Type   | Description |
+|---------|--------|-------------|
+| `file`  | string | source file path as the compiler references it |
+| `start` | object | inclusive start position `{ "line": int, "col": int }` |
+| `end`   | object | exclusive end position `{ "line": int, "col": int }` |
+
+Each **related** element is:
+
+| Field      | Type          | Description |
+|------------|---------------|-------------|
+| `location` | object / null | the secondary location, or `null` when its file does not resolve |
+| `label`    | string / null | the caption rendered under the secondary span, or `null` for a bare context span |
+
+```json
+{"schema":1,"event":"diagnostic","severity":"error","message":"expected an expression","location":{"file":"buf.mach","start":{"line":2,"col":12},"end":{"line":2,"col":13}},"note":null,"help":null,"related":[]}
+{"schema":1,"event":"diagnostic","severity":"error","message":"duplicate definition of 'dup'","location":{"file":"buf.mach","start":{"line":2,"col":5},"end":{"line":2,"col":8}},"note":null,"help":"rename one of the definitions","related":[{"location":{"file":"buf.mach","start":{"line":1,"col":5},"end":{"line":1,"col":8}},"label":"previous definition here"}]}
+```
+
+### `summary`
+
+Emitted once, after every `diagnostic`, closing the stream — even when the
+buffer produced no diagnostics.
+
+| Field      | Type   | Description |
+|------------|--------|-------------|
+| `schema`   | int    | schema version (`1`) |
+| `event`    | string | `"summary"` |
+| `errors`   | int    | number of error-severity diagnostics |
+| `warnings` | int    | number of warning-severity diagnostics |
+
+```json
+{"schema":1,"event":"summary","errors":1,"warnings":0}
+```
+
+## Stream shape
+
+A run is zero or more `diagnostic` objects followed by exactly one `summary`. A
+clean buffer emits only the `summary` (with zero counts), so a consumer always
+sees a terminating object. A fatal error before analysis (an unreadable file, a
+failed parse setup) prints to stderr and exits non-zero with no stdout stream.
+
+`mach build`'s diagnostics are **out of scope** for this schema: a build
+interleaves diagnostics with progress and readout output and warrants its own
+event model, so `--format json` shapes only `mach check`.
+
+## See also
+
+- [cli.md](../cli.md) — the `mach check` command and its flags.
+- [test-json.md](test-json.md) — the sibling `mach test` event schema.

--- a/src/cli/cmd/check.mach
+++ b/src/cli/cmd/check.mach
@@ -1,9 +1,12 @@
-# `mach check <file>` - single-file diagnostics without a project.
+# `mach check <file> [--format human|json]` - single-file diagnostics without a
+# project.
 #
 # The editor-facing diagnostics slice exposed as a CLI verb: read one source
 # file, feed its text directly into the editor query surface (mach.lang.editor),
-# and render every reported diagnostic as a framed source snippet (headline,
-# `--> file:line:col`, gutter, and caret). It needs no mach.toml, no module
+# and render every reported diagnostic. `--format human` (the default) draws each
+# as a framed source snippet (headline, `--> file:line:col`, gutter, and caret)
+# on stderr; `--format json` emits the machine-readable NDJSON diagnostic stream
+# on stdout instead (doc/tooling/check-json.md). It needs no mach.toml, no module
 # graph, and no link step; it is best-effort over a single buffer, exactly what
 # an editor wants, and the in-tree consumer that exercises the editor surface
 # end to end.
@@ -14,8 +17,12 @@
 use std.allocator.arena;
 use std.filesystem;
 use std.print;
+use std.types.bool.bool;
+use std.types.bool.false;
+use std.types.bool.true;
 use std.types.size.usize;
 use std.types.string.str;
+use std.types.string.str_equals;
 
 use A:      std.allocator;
 use O:      std.types.option;
@@ -31,19 +38,36 @@ use mach.lang.source;
 
 # `mach check` subcommand entry point
 #
-# Reads argv[2] as the file path, loads it as an unsaved buffer, and prints its
-# diagnostics. Every allocation is suballocated through one arena over a page
-# allocator and reclaimed in a single dnit before returning.
+# Resolves the file path as the first positional argument, reads `--format`, loads
+# the file as an unsaved buffer, and renders its diagnostics in the chosen format.
+# Every allocation is suballocated through one arena over a page allocator and
+# reclaimed in a single dnit before returning.
 # ---
 # argc: argument count including argv[0]
 # argv: the argument vector (argc null-terminated byte pointers)
 # ret:  0 when the buffer has no errors, 1 on errors or a usage / io failure
 pub fun run(argc: usize, argv: **u8) i64 {
-    if (argc < 3) {
-        print.eprintln("usage: mach check <file>");
+    val pos: usize = util.positional_index(argc, argv, 2);
+    if (pos >= argc) {
+        print.eprintln("usage: mach check <file> [--format human|json]");
         ret 1;
     }
-    val path: str = argv[2]::str;
+    val path: str = argv[pos]::str;
+
+    # `--format json` emits the machine-readable NDJSON diagnostic stream on
+    # stdout (doc/tooling/check-json.md); `human` (the default) keeps the framed
+    # renderer on stderr. an unrecognized value is a usage error.
+    var json_out: bool = false;
+    val opt_format: O.Option[*u8] = util.get_value(argc, argv, "--format");
+    if (O.is_some[*u8](opt_format)) {
+        val fv: str = O.unwrap[*u8](opt_format)::str;
+        if (str_equals(fv, "json"))  { json_out = true;  }
+        or (str_equals(fv, "human")) { json_out = false; }
+        or {
+            print.eprintln("error: --format expects 'human' or 'json'");
+            ret 1;
+        }
+    }
 
     var backing: A.Allocator;
     var ar:      arena.Arena;
@@ -73,7 +97,7 @@ pub fun run(argc: usize, argv: **u8) i64 {
     var s: session.Session = R.unwrap_ok[session.Session, str](res_session);
 
     var es:   editor.EditorSession = editor.init(?s);
-    val code: i64                  = check_buffer(?es, path, text);
+    val code: i64                  = check_buffer(?es, path, text, json_out);
 
     editor.dnit(?es);
     session.dnit(?s);
@@ -83,15 +107,18 @@ pub fun run(argc: usize, argv: **u8) i64 {
 
 # open the buffer, collect its diagnostics, render them, and return the exit code
 #
-# The renderer is ASCII-only, so an LSP consuming this stream reads plain text,
-# never color or terminal escapes. The session backing the source-map spans is
-# the one the editor session borrows.
+# The framed renderer is ASCII-only, so an LSP consuming it reads plain text,
+# never color or terminal escapes; `json_out` selects the machine-readable NDJSON
+# stream on stdout instead. Either way the session backing the source-map spans
+# is the one the editor session borrows. A failure to open or analyze the buffer
+# is an internal error reported on stderr regardless of format.
 # ---
-# es:   the editor session the buffer is opened in
-# path: display path of the buffer, shown in diagnostic locations
-# text: the buffer's full source text
-# ret:  0 when the buffer has no error-severity diagnostics, 1 otherwise
-fun check_buffer(es: *editor.EditorSession, path: str, text: str) i64 {
+# es:       the editor session the buffer is opened in
+# path:     display path of the buffer, shown in diagnostic locations
+# text:     the buffer's full source text
+# json_out: render the NDJSON diagnostic stream on stdout rather than the frames
+# ret:      0 when the buffer has no error-severity diagnostics, 1 otherwise
+fun check_buffer(es: *editor.EditorSession, path: str, text: str, json_out: bool) i64 {
     val res_file: R.Result[source.FileId, str] = editor.open(es, path, text);
     if (R.is_err[source.FileId, str](res_file)) {
         print.eprint("error: ");
@@ -109,8 +136,15 @@ fun check_buffer(es: *editor.EditorSession, path: str, text: str) i64 {
     val list: *diagnostic.DiagList = R.unwrap_ok[*diagnostic.DiagList, str](res_diags);
 
     var w: writer.Writer;
-    filesystem.get_writer(?filesystem.stderr, ?w);
-    cli_diag.flush(?w, es.s, list);
+    if (json_out) {
+        filesystem.get_writer(?filesystem.stdout, ?w);
+        cli_diag.flush_json(?w, es.s, list);
+    }
+    or {
+        filesystem.get_writer(?filesystem.stderr, ?w);
+        cli_diag.flush(?w, es.s, list);
+    }
+
     if (diagnostic.has_errors(list)) {
         ret 1;
     }

--- a/src/cli/diagnostic.mach
+++ b/src/cli/diagnostic.mach
@@ -34,6 +34,7 @@ use R:      std.types.result;
 use writer: std.io.writer;
 use fmt:    std.format;
 
+use json: mach.cli.json;
 use mach.lang.diagnostic;
 use mach.lang.fe.token;
 use mach.lang.session;
@@ -41,6 +42,10 @@ use mach.lang.source;
 
 # source lines rendered for one multi-line span before the middle is elided
 val MAX_SPAN_LINES: usize = 10;
+
+# version of the `mach check --format json` diagnostic schema, documented in
+# doc/tooling/check-json.md. every emitted object carries it.
+val SCHEMA_VERSION: i64 = 1;
 
 # render every diagnostic in `list` through `out` against the session source map.
 #
@@ -493,6 +498,139 @@ fun severity_label(severity: diagnostic.Severity) str {
     ret "help: ";
 }
 
+# render every diagnostic in `list` as an NDJSON stream through `out`.
+#
+# The machine-readable sibling of `flush`: one `diagnostic` object per diagnostic
+# carrying its severity, message, primary location, note, help, and related list,
+# then a single closing `summary` object with the error and warning counts. Every
+# object is one NDJSON line and carries the schema version. Locations resolve
+# against the same source map and clamping as the framed renderer; an unresolvable
+# location emits JSON `null`. The schema is documented in doc/tooling/check-json.md;
+# the CLI points `out` at stdout so the human frames never interleave.
+# ---
+# out:  the writer the NDJSON stream is emitted through
+# s:    session carrying the source map spans resolve against
+# list: diagnostics to render, in order
+pub fun flush_json(out: *writer.Writer, s: *session.Session, list: *diagnostic.DiagList) {
+    var errors:   usize = 0;
+    var warnings: usize = 0;
+
+    var i: usize = 0;
+    for (i < list.len) {
+        val d: *diagnostic.Diagnostic = ?list.items[i];
+        emit_json_diagnostic(out, s, d);
+
+        if (d.severity == diagnostic.SEVERITY_ERROR)   { errors   = errors + 1;   }
+        or (d.severity == diagnostic.SEVERITY_WARNING) { warnings = warnings + 1; }
+
+        i = i + 1;
+    }
+
+    emit_json_summary(out, errors, warnings);
+}
+
+# emit one `diagnostic` NDJSON object: severity, message, primary location, note,
+# help, and the related list (each entry its own location and label).
+# ---
+# out: the writer the object is emitted through
+# s:   session carrying the source map
+# d:   the diagnostic to emit
+fun emit_json_diagnostic(out: *writer.Writer, s: *session.Session, d: *diagnostic.Diagnostic) {
+    var o: json.Object;
+    json.object_begin(out, ?o);
+    json.field_i64(?o, "schema", SCHEMA_VERSION);
+    json.field_str(?o, "event", "diagnostic");
+    json.field_str(?o, "severity", json_severity(d.severity));
+    json.field_str(?o, "message", d.message);
+    emit_json_location(s, ?o, "location", d.loc);
+    json.field_str_or_null(?o, "note", d.note);
+    json.field_str_or_null(?o, "help", d.help);
+
+    var rel: json.Array;
+    json.field_array_begin(?o, "related", ?rel);
+    var i: usize = 0;
+    for (i < d.related_len) {
+        val r: *diagnostic.Related = ?d.related[i];
+        var e: json.Object;
+        json.array_object_begin(?rel, ?e);
+        emit_json_location(s, ?e, "location", r.loc);
+        json.field_str_or_null(?e, "label", r.label);
+        json.object_end_value(?e);
+        i = i + 1;
+    }
+    json.array_end(?rel);
+
+    json.object_end(?o);
+}
+
+# emit a `key` member holding the resolved location object, or JSON `null` when
+# the location's file does not resolve.
+#
+# Reuses the framed renderer's `locate` so the span clamping is identical; the
+# span is emitted half-open as `start` (inclusive) and `end` (exclusive) 1-based
+# line/col positions.
+# ---
+# s:   session carrying the source map
+# o:   the open object the member is added to
+# key: the member key
+# loc: the location to resolve
+fun emit_json_location(s: *session.Session, o: *json.Object, key: *u8, loc: diagnostic.Location) {
+    val opt: O.Option[Frame] = locate(s, loc);
+    if (O.is_none[Frame](opt)) {
+        json.field_null(o, key);
+        ret;
+    }
+    val f:  Frame            = O.unwrap[Frame](opt);
+    val ep: source.Position  = source.position(f.sf, f.end);
+
+    var loc_o: json.Object;
+    json.field_object_begin(o, key, ?loc_o);
+    json.field_str(?loc_o, "file", f.sf.path);
+    emit_json_position(?loc_o, "start", f.line_s, f.col_s);
+    emit_json_position(?loc_o, "end", ep.line, ep.col);
+    json.object_end_value(?loc_o);
+}
+
+# emit a `key` member holding a `{line, col}` position object.
+# ---
+# o:    the open object the member is added to
+# key:  the member key
+# line: 1-based line
+# col:  1-based column
+fun emit_json_position(o: *json.Object, key: *u8, line: usize, col: usize) {
+    var p: json.Object;
+    json.field_object_begin(o, key, ?p);
+    json.field_i64(?p, "line", line::i64);
+    json.field_i64(?p, "col", col::i64);
+    json.object_end_value(?p);
+}
+
+# emit the closing `summary` NDJSON object with the run's severity counts.
+# ---
+# out:      the writer the object is emitted through
+# errors:   number of error-severity diagnostics rendered
+# warnings: number of warning-severity diagnostics rendered
+fun emit_json_summary(out: *writer.Writer, errors: usize, warnings: usize) {
+    var o: json.Object;
+    json.object_begin(out, ?o);
+    json.field_i64(?o, "schema", SCHEMA_VERSION);
+    json.field_str(?o, "event", "summary");
+    json.field_i64(?o, "errors", errors::i64);
+    json.field_i64(?o, "warnings", warnings::i64);
+    json.object_end(?o);
+}
+
+# the JSON severity token for a diagnostic severity.
+# ---
+# severity: severity to label
+# ret:      the bare token ("error" / "warning" / "info" / "help")
+fun json_severity(severity: diagnostic.Severity) str {
+    if (severity == diagnostic.SEVERITY_ERROR)   { ret "error";   }
+    if (severity == diagnostic.SEVERITY_WARNING) { ret "warning"; }
+    if (severity == diagnostic.SEVERITY_INFO)    { ret "info";    }
+    ret "help";
+}
+
 # a fixed-capacity byte sink capturing rendered output in tests.
 # ---
 # buf: destination buffer
@@ -686,6 +824,110 @@ test "mach.cli.diagnostic.render:unresolvable_primary_still_renders_secondary" {
     if (!sink_contains(?sink, "--> t.mach:3:"))      { code = 1; }
     if (!sink_contains(?sink, "gamma"))              { code = 1; }
     if (!sink_contains(?sink, "look here"))          { code = 1; }
+
+    diagnostic.dnit(?list);
+    session.dnit(?s);
+    ret code;
+}
+
+# flush_json emits the full model: a diagnostic object with a nested location,
+# note, help, and a related list, then a summary object with the counts.
+test "mach.cli.diagnostic.flush_json:full_model" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+    val res_s: R.Result[session.Session, str] = session.init(?alloc);
+    if (R.is_err[session.Session, str](res_s)) { ret 1; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](res_s);
+
+    val res_fid: R.Result[source.FileId, str] = session.load_source(?s, "t.mach", "alpha\nbeta\ngamma\n");
+    if (R.is_err[source.FileId, str](res_fid)) { session.dnit(?s); ret 1; }
+    val fid: source.FileId = R.unwrap_ok[source.FileId, str](res_fid);
+
+    val opt_sf: O.Option[*source.SourceFile] = source.get(?s.sources, fid);
+    if (O.is_none[*source.SourceFile](opt_sf)) { session.dnit(?s); ret 1; }
+    val sf: *source.SourceFile = O.unwrap[*source.SourceFile](opt_sf);
+
+    var list: diagnostic.DiagList = diagnostic.init(?alloc);
+    diagnostic.error(?list, fid, line_span(sf, 2), "boom");
+    diagnostic.attach_note(?list, "a note");
+    diagnostic.attach_help(?list, "a help");
+    diagnostic.attach_related(?list, fid, line_span(sf, 3), "prior");
+
+    var buf:  [1024]u8;
+    var sink: RenderSink;
+    var w:    writer.Writer;
+    render_writer(?w, ?sink, ?buf[0], 1024);
+    flush_json(?w, ?s, ?list);
+
+    var code: i32 = 0;
+    if (!sink_contains(?sink, "{\"schema\":1,\"event\":\"diagnostic\",\"severity\":\"error\",\"message\":\"boom\"")) { code = 1; }
+    if (!sink_contains(?sink, "\"location\":{\"file\":\"t.mach\",\"start\":{\"line\":2,\"col\":1},\"end\":{\"line\":2,\"col\":5}}")) { code = 1; }
+    if (!sink_contains(?sink, "\"note\":\"a note\",\"help\":\"a help\"")) { code = 1; }
+    if (!sink_contains(?sink, "\"related\":[{\"location\":{\"file\":\"t.mach\",\"start\":{\"line\":3,\"col\":1}")) { code = 1; }
+    if (!sink_contains(?sink, "\"label\":\"prior\"}]}\n")) { code = 1; }
+    if (!sink_contains(?sink, "{\"schema\":1,\"event\":\"summary\",\"errors\":1,\"warnings\":0}\n")) { code = 1; }
+
+    diagnostic.dnit(?list);
+    session.dnit(?s);
+    ret code;
+}
+
+# an unresolvable primary and an unresolvable related both emit `"location":null`
+# while still carrying the message and label.
+test "mach.cli.diagnostic.flush_json:unresolvable_location_null" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+    val res_s: R.Result[session.Session, str] = session.init(?alloc);
+    if (R.is_err[session.Session, str](res_s)) { ret 1; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](res_s);
+
+    val res_fid: R.Result[source.FileId, str] = session.load_source(?s, "t.mach", "alpha\nbeta\ngamma\n");
+    if (R.is_err[source.FileId, str](res_fid)) { session.dnit(?s); ret 1; }
+    val fid: source.FileId = R.unwrap_ok[source.FileId, str](res_fid);
+
+    val opt_sf: O.Option[*source.SourceFile] = source.get(?s.sources, fid);
+    if (O.is_none[*source.SourceFile](opt_sf)) { session.dnit(?s); ret 1; }
+    val sf: *source.SourceFile = O.unwrap[*source.SourceFile](opt_sf);
+
+    val bad: source.FileId = 4242;
+    var list: diagnostic.DiagList = diagnostic.init(?alloc);
+    diagnostic.error(?list, bad, line_span(sf, 2), "orphan");
+    diagnostic.attach_related(?list, bad, line_span(sf, 2), "also orphan");
+
+    var buf:  [512]u8;
+    var sink: RenderSink;
+    var w:    writer.Writer;
+    render_writer(?w, ?sink, ?buf[0], 512);
+    flush_json(?w, ?s, ?list);
+
+    var code: i32 = 0;
+    if (!sink_contains(?sink, "\"message\":\"orphan\",\"location\":null,")) { code = 1; }
+    if (!sink_contains(?sink, "\"related\":[{\"location\":null,\"label\":\"also orphan\"}]}\n")) { code = 1; }
+
+    diagnostic.dnit(?list);
+    session.dnit(?s);
+    ret code;
+}
+
+# an empty diagnostic list still terminates the stream with a zero summary.
+test "mach.cli.diagnostic.flush_json:empty_emits_summary" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+    val res_s: R.Result[session.Session, str] = session.init(?alloc);
+    if (R.is_err[session.Session, str](res_s)) { ret 1; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](res_s);
+
+    var list: diagnostic.DiagList = diagnostic.init(?alloc);
+
+    var buf:  [128]u8;
+    var sink: RenderSink;
+    var w:    writer.Writer;
+    render_writer(?w, ?sink, ?buf[0], 128);
+    flush_json(?w, ?s, ?list);
+
+    var code: i32 = 0;
+    if (!sink_contains(?sink, "{\"schema\":1,\"event\":\"summary\",\"errors\":0,\"warnings\":0}\n")) { code = 1; }
+    if (sink_count(?sink, "\"event\":") != 1) { code = 1; }
 
     diagnostic.dnit(?list);
     session.dnit(?s);

--- a/src/cli/json.mach
+++ b/src/cli/json.mach
@@ -1,8 +1,12 @@
 # streaming JSON object emitter for one-object-per-line (NDJSON) output.
 #
-# emits flat JSON objects through a caller-owned writer with ASCII-only string
+# emits JSON objects through a caller-owned writer with ASCII-only string
 # escaping, so a machine consumer reads a stable, valid stream regardless of the
-# bytes a test label or path carries. string values are escaped per RFC 8259;
+# bytes a test label or path carries. objects nest: a member value or an array
+# element may itself be an object (field_object_begin / array_object_begin,
+# closed with object_end_value), and only the top-level object_end writes the
+# NDJSON line terminator, so a whole nested object still lands on one line.
+# string values are escaped per RFC 8259;
 # every byte >= 0x80 is UTF-8 decoded and emitted as a `\uXXXX` escape (astral
 # code points as a surrogate pair), so every emitted byte is printable ASCII on
 # every platform with no platform branches. invalid UTF-8 is emitted as the
@@ -27,6 +31,15 @@ pub rec Object {
     first: bool;
 }
 
+# an open JSON array, tracking the comma boundary between its elements
+# ---
+# w:     the writer the array is emitted through (borrowed)
+# first: no element has been emitted into the array yet
+pub rec Array {
+    w:     *writer.Writer;
+    first: bool;
+}
+
 # begin a JSON object, writing `{` and arming the first-member state
 # ---
 # w: the writer to emit through (must outlive the object)
@@ -41,8 +54,65 @@ pub fun object_begin(w: *writer.Writer, o: *Object) {
 # ---
 # o: the object to close
 pub fun object_end(o: *Object) {
-    fmt.write_byte(o.w, '}');
+    object_end_value(o);
     fmt.write_newline(o.w);
+}
+
+# close a nested object, writing `}` without the NDJSON line terminator
+#
+# Used for an object that is a member value or an array element, where the
+# enclosing container - not this object - owns the line boundary.
+# ---
+# o: the object to close
+pub fun object_end_value(o: *Object) {
+    fmt.write_byte(o.w, '}');
+}
+
+# open an object-valued member: the key lead-in, then `{`, arming `child` over
+# the parent's writer
+#
+# Fill `child` with the field_* helpers and close it with object_end_value; the
+# parent stays open and takes further members afterwards.
+# ---
+# o:     the open parent object
+# key:   the member key
+# child: the nested object state to initialise
+pub fun field_object_begin(o: *Object, key: *u8, child: *Object) {
+    member(o, key);
+    object_begin(o.w, child);
+}
+
+# open an array-valued member: the key lead-in, then `[`, arming `arr` over the
+# parent's writer. Close it with array_end.
+# ---
+# o:   the open parent object
+# key: the member key
+# arr: the array state to initialise
+pub fun field_array_begin(o: *Object, key: *u8, arr: *Array) {
+    member(o, key);
+    arr.w     = o.w;
+    arr.first = true;
+    fmt.write_byte(o.w, '[');
+}
+
+# close an array, writing `]`
+# ---
+# arr: the array to close
+pub fun array_end(arr: *Array) {
+    fmt.write_byte(arr.w, ']');
+}
+
+# open an object element of `arr`: the element separator, then `{`, arming
+# `child` over the array's writer
+#
+# Fill `child` with the field_* helpers and close it with object_end_value.
+# ---
+# arr:   the open array
+# child: the element object state to initialise
+pub fun array_object_begin(arr: *Array, child: *Object) {
+    if (!arr.first) { fmt.write_byte(arr.w, ','); }
+    arr.first = false;
+    object_begin(arr.w, child);
 }
 
 # emit a string-valued member (the value quoted and ASCII-escaped)
@@ -481,3 +551,62 @@ test "mach.cli.json.write_json_string:utf8_truncated_rejected" {
     ret 0;
 }
 
+
+# nested object and array members compose into one valid NDJSON line.
+test "mach.cli.json.compose:nested_object_and_array" {
+    var out:  [128]u8;
+    var sink: TestSink;
+    var w:    writer.Writer;
+    test_writer(?w, ?sink, ?out[0], 128);
+
+    var root: Object;
+    object_begin(?w, ?root);
+    field_i64(?root, "a", 1);
+
+    var loc: Object;
+    field_object_begin(?root, "loc", ?loc);
+    field_i64(?loc, "line", 2);
+    field_i64(?loc, "col", 3);
+    object_end_value(?loc);
+
+    var rel: Array;
+    field_array_begin(?root, "rel", ?rel);
+    var e0: Object;
+    array_object_begin(?rel, ?e0);
+    field_str(?e0, "label", "x");
+    object_end_value(?e0);
+    var e1: Object;
+    array_object_begin(?rel, ?e1);
+    field_str(?e1, "label", "y");
+    object_end_value(?e1);
+    array_end(?rel);
+
+    object_end(?root);
+
+    val want: *u8 = "{\"a\":1,\"loc\":{\"line\":2,\"col\":3},\"rel\":[{\"label\":\"x\"},{\"label\":\"y\"}]}\n";
+    var wl: usize = 0;
+    for (want[wl] != 0) { wl = wl + 1; }
+    if (!sink_is(?sink, want, wl)) { ret 1; }
+    ret 0;
+}
+
+# an empty array member emits `[]`.
+test "mach.cli.json.compose:empty_array" {
+    var out:  [32]u8;
+    var sink: TestSink;
+    var w:    writer.Writer;
+    test_writer(?w, ?sink, ?out[0], 32);
+
+    var root: Object;
+    object_begin(?w, ?root);
+    var rel: Array;
+    field_array_begin(?root, "rel", ?rel);
+    array_end(?rel);
+    object_end(?root);
+
+    val want: *u8 = "{\"rel\":[]}\n";
+    var wl: usize = 0;
+    for (want[wl] != 0) { wl = wl + 1; }
+    if (!sink_is(?sink, want, wl)) { ret 1; }
+    ret 0;
+}

--- a/src/cli/json.mach
+++ b/src/cli/json.mach
@@ -139,6 +139,15 @@ pub fun field_str_or_null(o: *Object, key: *u8, v: *u8) {
     write_json_string(o.w, v);
 }
 
+# emit a JSON `null`-valued member
+# ---
+# o:   the open object
+# key: the member key
+pub fun field_null(o: *Object, key: *u8) {
+    member(o, key);
+    fmt.write_str(o.w, "null");
+}
+
 # emit an integer-valued member
 # ---
 # o:   the open object


### PR DESCRIPTION
Closes #1815.

## What

`mach check --format json` emits its diagnostics as a versioned NDJSON stream on **stdout** (no framed human output interleaved) so editors/LSP shims and CI annotators can consume it without scraping the human frames. The framed renderer stays the default (`--format human`).

## Design

- **Full #1818 model per diagnostic**, LSP-shaped (per the #1792 decision): severity, message, primary `location` (file + half-open, 1-based line/col span), `note`, `help`, and the `related` **list** (each with its own location + label). Unresolvable locations emit JSON `null`. A closing `summary` object always terminates the stream (even for a clean buffer).
- **Emitter extension.** `mach.cli.json` was flat-object only (its `object_end` also wrote the NDJSON newline). Split that into `object_end_value` (bare `}`) and add `field_object_begin`, `field_array_begin`/`array_end`, `array_object_begin`, and `field_null`, so a member value or array element can itself be an object and a whole nested object still lands on one line. Purely additive — the flat API and test-json's bytes are unchanged. Kept behind the existing `mach.cli.json` surface so the later mach-std#338 migration stays mechanical.
- **Renderer** (`flush_json` in `mach.cli.diagnostic`) resolves locations through the framed renderer's own `locate`, so span clamping is identical between the two outputs.
- **CLI**: `--format` parsed via `util.get_value` (already in `is_value_flag`); path resolved via `util.positional_index` so flags may precede or follow it. JSON on stdout, usage/io errors on stderr, exit codes unchanged.
- **Schema doc** `doc/tooling/check-json.md` (schema 1), sibling to `test-json.md`; `cli.md` gains a `mach check` section (the command was undocumented); CHANGELOG `[Unreleased]` entry.
- **`mach build` diagnostics are out of scope** (documented) — a build interleaves diagnostics with progress/readout and warrants its own event model.

## Verification

- `mach test .` green — 481 passing, incl. 6 `mach.cli.diagnostic` (3 new `flush_json`) and 12 `mach.cli.json` (2 new nesting/array).
- Self-host fixpoint byte-identical (stage2 == stage3); `int/run.sh --target linux` all pass.
- e2e: real `mach check --format json` output parsed line-by-line with python `json` — valid; stdout pure NDJSON, **0 bytes on stderr** in json mode; human mode unchanged (frames on stderr, stdout empty); clean buffer emits only the `summary`; invalid `--format` value errors; flags before/after the path both resolve.
- The emitter's exact nested/array output (asserted byte-for-byte by the unit tests) also validated as JSON by python: nested `location`, `related` array-of-objects, `null` locations, empty array.

## Notes

- **`mach check` is parse-only today** (`editor.diagnostics` runs `parse_inner` only; `related`/`help` attach in `resolve.mach`, which check doesn't run), so a real file currently only yields parse diagnostics — never `related`/`help`. The renderer and schema carry the full model regardless, and `related`/`help`/`note`/null-location are exercised by `flush_json` unit tests over constructed `DiagList`s. Deepening check's analysis is out of scope here.
- The model has no diagnostic `code` field yet, so none is emitted; adding one later is backward-compatible under the schema's versioning rule.
- Rebased onto current dev. #1810 (generic unknown-flag rejection) was **not yet in dev** at rebase time — its merge must keep `--format` accepted for `mach check` (it is in `is_value_flag`); will re-rebase if it lands first.
