### PR TITLE
fix(cli): remove the inert --artifacts flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,12 @@ secondary spans, and out-of-range integer literals now report their bounds.
 - cli: the orphaned **`--color` flag** and its `ColorMode` surface, dead since
   the ASCII-only diagnostic renderer (#1777) dropped the color argument -
   `--color` had parsed but no-opped (#1784).
+- build/run/test: the inert **`--artifacts <dir>` flag** and its `Config`
+  field - it parsed but no code ever read it, so it silently no-opped. The
+  object-tree location is expressed by the manifest `obj` template
+  (`out/{target}/{profile}/obj`), which expands per target/profile/artifact; a
+  flat CLI override cannot and would collide every target's objects into one
+  directory (#1829).
 
 ### Fixed
 

--- a/src/cli/cmd/help.mach
+++ b/src/cli/cmd/help.mach
@@ -80,7 +80,6 @@ fun global_flags() {
     print.print("  --quiet, -q       suppress non-error output (mutually exclusive with -v/-vv)\n");
     print.print("  --target <name>   select a [targets.<name>] entry\n");
     print.print("  -o <path>         override the linked-binary path (build/run/test)\n");
-    print.print("  --artifacts <dir> override the per-target object directory (build/run/test)\n");
     print.print("  --emit-asm        emit per-module .s assembly text beside each object\n");
     print.print("  --emit-ir         emit per-module .ir SSA text beside each object\n");
     print.print("  --verify-ir       run the IR verifier after each optimisation pass\n");

--- a/src/cli/config.mach
+++ b/src/cli/config.mach
@@ -25,8 +25,6 @@ use mach.cli.util;
 # target:      selected target name (nil when --target was not given)
 # output:      -o override for the linked binary path, rooted at the project
 #              root (nil = use the target's `binary` from mach.toml)
-# artifacts:   --artifacts override for the per-module object directory, rooted
-#              at <root>/<out> (nil = use the target's `artifacts` from mach.toml)
 # emit_asm:    --emit-asm was passed; emit per-module human-readable assembly
 #              text (`.s`) alongside each object, for debugging / transparency
 # emit_ir:     --emit-ir was passed; emit per-module human-readable SSA IR text
@@ -55,7 +53,6 @@ pub rec Config {
     verify_ir:   bool;
     target:      *u8;
     output:      *u8;
-    artifacts:   *u8;
     emit_asm:    bool;
     emit_ir:     bool;
     no_emit_asm: bool;
@@ -110,7 +107,6 @@ pub fun parse(argc: usize, argv: **u8, marks: *bool) R.Result[Config, str] {
 
     c.target    = flag_value_get(marks, argc, argv, "--target");
     c.output    = flag_value_get(marks, argc, argv, "-o");
-    c.artifacts = flag_value_get(marks, argc, argv, "--artifacts");
     c.profile   = flag_value_get(marks, argc, argv, "--profile");
     c.bin       = flag_value_get(marks, argc, argv, "--bin");
     c.lib       = flag_value_get(marks, argc, argv, "--lib");


### PR DESCRIPTION
Closes #1829.

## Decision: remove

`--artifacts <dir>` was advertised in `mach help` as "override the per-target object directory" but was a complete no-op: it parsed into `config.artifacts`, and **no code ever read that field**. Every command resolved the object tree from the manifest `obj` template (`resolve_obj_base` -> `p.config.obj_root`) and never consulted the flag.

I chose **remove** over wire, because the object directory is already fully and correctly expressible through the manifest, and a flag override cannot be:

- The object-tree location is the manifest `obj` template (`out/{target}/{profile}/obj` by default), part of the same `out`/`obj`/`ir`/`asm`/`tests` template family. It expands per target/profile/artifact, so any legitimate relocation (moving `out/`, per-profile obj dirs) is already expressible there.
- `--artifacts` is a **flat** value with no template variables. Wiring it as-is would point every target's object tree at one directory, so module FQN `a.b.c` from two targets both write `<dir>/a/b/c.o` and silently clobber each other — the exact multi-target silent-clobber class #1831 is fixing for `-o`. Reintroducing it here would be the same architectural mistake.
- `-o` earns its keep because the binary is the *deliverable* (and #1831 rejects it under `--all-targets`). The object tree is an intermediate build cache with no "deliver here" use case the manifest can't already express.
- The flag's own doc comment referenced a nonexistent manifest `artifacts` key (the real key is `obj`), confirming it was never actually integrated with the mechanism — it was vestigial.

This follows the #1784 `--color` removal pattern.

## Changes

- `src/cli/config.mach`: drop the `artifacts` `Config` field, its parse, and the stale doc comment.
- `src/cli/cmd/help.mach`: drop the `--artifacts` help line.
- `CHANGELOG.md`: `[Unreleased] > Removed` entry.

`doc/cli.md` never listed `--artifacts`, so nothing to remove there.

## Behavior change

`--artifacts` is now reported by the unknown-flag rejector (#1835) instead of being silently swallowed:

```
$ mach build . --artifacts foo
error: unknown flag '--artifacts' for 'mach build'
```

Since the flag was a pure no-op, nothing could have depended on its (nonexistent) effect.

## Verification

- from-source self-host fixpoint converged (`seed build . -o a` -> `a build . -o b` -> `b build . -o c`, `cmp b c` equal)
- full suite: `c test .` — 486 passed, 0 failed
- int linux: `int/run.sh --target linux c` — all cases passed
- manual: `--artifacts` now rejected as unknown; normal build unaffected
