### PR TITLE
fix(build): reject -o combined with --all-targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,6 +100,11 @@ secondary spans, and out-of-range integer literals now report their bounds.
   (`phdr_count <= 72`). Past that the image was silently unloadable; the writers now
   return a link error instead. Latent (real builds emit ~9 headers), owning the
   invariant before segment counts grow (#1814).
+- build: **`mach build --all-targets -o <path>` is now rejected** - `-o` names a
+  single artifact path, so combined with `--all-targets` every target linked to
+  that one path and overwrote the previous, leaving only the last target's binary
+  with no warning. The combination now errors (`-o cannot be combined with
+  --all-targets`) at parse; single-target `-o` is unchanged (#1831).
 
 ## [2.12.0] - 2026-07-01
 

--- a/doc/cli.md
+++ b/doc/cli.md
@@ -66,7 +66,7 @@ A verbosity flag (`-v`/`-vv`) and `--quiet` together is a parse error.
 | `--bin <name>`   | artifact name    | narrow the build to one `[bin.<name>]` artifact |
 | `--lib <name>`   | artifact name    | narrow the build to one `[lib.<name>]` artifact (mutually exclusive with `--bin`) |
 | `-o <path>`      | path             | override the artifact path, rooted at the project root (build/run/test) |
-| `--all-targets`  | —                | build every declared `[target.*]`, not just the default |
+| `--all-targets`  | —                | build every declared `[target.*]`, not just the default (mutually exclusive with `-o`, which names one path) |
 | `--emit-asm`     | —                | emit per-module assembly text (`.s`); forces the selected profile's `emit_asm` on |
 | `--emit-ir`      | —                | emit per-module SSA IR text (`.ir`) — the final post-pipeline IR the object is built from, so it varies with `-O`; forces the selected profile's `emit_ir` on |
 | `--no-emit-asm`  | —                | force per-module assembly emission off, overriding the profile's `emit_asm` |

--- a/src/cli/cmd/build.mach
+++ b/src/cli/cmd/build.mach
@@ -446,6 +446,40 @@ pub fun selection_from_config(config: *cfg.Config, out_sel: *manifest.Selection)
     ret R.ok[bool, str](true);
 }
 
+# reject a `mach build` flag combination that cannot produce correct output
+#
+# `-o` names a single artifact path; `--all-targets` builds every declared
+# target. Combined, each target would link to that one path and overwrite the
+# previous, leaving only the last target's binary with no warning. A per-target
+# `-o` template could be considered later; an explicit error is the floor.
+# ---
+# config: the parsed CLI config
+# ret:    ok(true) when the combination is valid, err naming the conflict
+fun reject_output_all_targets(config: *cfg.Config) R.Result[bool, str] {
+    if (config.output != nil && config.all_targets) {
+        ret R.err[bool, str]("-o cannot be combined with --all-targets (it names a single output)");
+    }
+    ret R.ok[bool, str](true);
+}
+
+# `-o` and `--all-targets` are rejected together; either alone is accepted.
+test "mach.cli.cmd.build.reject_output_all_targets:rejects_the_pair" {
+    var config: cfg.Config;
+
+    config.output      = "bin/app";
+    config.all_targets = true;
+    if (R.is_ok[bool, str](reject_output_all_targets(?config)))  { ret 1; }
+
+    config.all_targets = false;
+    if (R.is_err[bool, str](reject_output_all_targets(?config))) { ret 1; }
+
+    config.output      = nil;
+    config.all_targets = true;
+    if (R.is_err[bool, str](reject_output_all_targets(?config))) { ret 1; }
+
+    ret 0;
+}
+
 # the single-unit build body
 #
 # With `ovr` nil the target/artifact are derived from the CLI flags (the
@@ -2653,6 +2687,13 @@ pub fun run(argc: usize, argv: **u8, marks: *bool) i64 {
     val config: cfg.Config = R.unwrap_ok[cfg.Config, str](res_config);
     if (config.bin != nil && config.lib != nil) {
         print.eprint("error: --bin and --lib cannot be combined\n");
+        ret 1;
+    }
+    val oc: R.Result[bool, str] = reject_output_all_targets(?config);
+    if (R.is_err[bool, str](oc)) {
+        print.eprint("error: ");
+        print.eprint(R.unwrap_err[bool, str](oc));
+        print.eprint("\n");
         ret 1;
     }
 


### PR DESCRIPTION
Closes #1831.

## Problem

`mach build --all-targets -o <path>` pointed **every** matrix cell at the same override path, so each target's link overwrote the previous one and only the last target's binary survived — silently, exit 0, no warning. `run` passes the same `argv` (hence the same `-o`) to every `build_unit`, and `link_artifact` applies `out_override` unconditionally per unit.

## Fix: reject the combination at parse

`-o` is a single-artifact override; `--all-targets` is inherently multi-artifact, so the combination is meaningless. I reject it with a clear error, consistent with the repo's fail-at-composition direction (the same shape as `--bin`+`--lib`):

```
$ mach build . --all-targets -o out.bin
error: -o cannot be combined with --all-targets (it names a single output)
```

I chose the explicit error over per-target `-o` templating: the issue calls the error "the correct floor", and a `-o` template for the matrix can be added later without breaking this. The check is a small pure `reject_output_all_targets(config)` returning a typed error, called right after the existing `--bin`+`--lib` check in `build.run`. It fires before project resolution, so the conflict is reported regardless of the manifest — the same ordering as `--bin`+`--lib`.

The matrix loop that causes the clobber is unique to `mach build`; `mach run` builds a single unit via `selection_from_config` and `mach test` has its own path, so neither enumerates a target matrix and neither shares the defect.

## Changes

- `src/cli/cmd/build.mach`: `reject_output_all_targets` helper + its call in `build.run`, plus an in-source unit test pinning the rejection (and that either flag alone is accepted).
- `CHANGELOG.md`: `[Unreleased] > Fixed` entry (follow-up commit).
- `doc/cli.md`: note the mutual exclusion on the `--all-targets` row (follow-up commit).

## Verification

- new unit test `mach.cli.cmd.build.reject_output_all_targets:rejects_the_pair` passes
- manual: `--all-targets -o` errors; `-o` alone and `--all-targets` alone fall through unchanged
- full green sweep (fixpoint / suite / int linux) run before marking ready
