### PR TITLE
fix(cli): drop --help acceptance, narrow -- to mach run (follow-up to #1810)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,6 +112,15 @@ secondary spans, and out-of-range integer literals now report their bounds.
   that one path and overwrote the previous, leaving only the last target's binary
   with no warning. The combination now errors (`-o cannot be combined with
   --all-targets`) at parse; single-target `-o` is unchanged (#1831).
+- driver: **unknown flags are rejected instead of silently misparsing** - an
+  unrecognized flag was never reported and hijacked positional resolution
+  (`mach build --color always .` resolved `always` as the project path). Each
+  command now marks the flags it consumes and rejects the first unmarked
+  `-`-prefixed token before resolving positionals - `error: unknown flag '<flag>'
+  for '<command>'`, exit `1`. `-h` / `--help` are not flags; use `mach help
+  <command>`. The `--` end-of-flags separator is honored only by `mach run`, which
+  forwards every post-`--` token to the executed program as its `argv`; on every
+  other command `--` is itself rejected as an unknown flag (#1810).
 
 ## [2.12.0] - 2026-07-01
 

--- a/doc/cli.md
+++ b/doc/cli.md
@@ -16,26 +16,22 @@ matched exactly: `--flag value` (a value follows in the next argument) or a bare
 **not** recognized.
 
 An unrecognized flag is a hard error. Before it resolves positionals, each
-command rejects the first `-`/`--` token it does not accept — `error: unknown
+command rejects the first `-`-prefixed token it does not accept — `error: unknown
 flag '<flag>' for '<command>'`, exit `1` — so a typo'd or removed flag never
-silently misparses as a project path or link input. `-h` / `--help` is accepted
-on every command and prints that command's help page.
+silently misparses as a project path or link input. There is no `-h` / `--help`
+flag; both are rejected as unknown. Use `mach help <command>` for a command's
+usage.
 
-A `--` separator ends the flag region on every command: `--` itself and every
-token after it are never flag-rejected. What happens to the tokens after it
-depends on the command:
+The `--` end-of-flags separator is honored only by `mach run`, which forwards
+every token after `--` to the executed binary as its `argv` — `mach run <path> --
+--flag` passes `--flag` through to the program. On every other command `--` has
+no special meaning: it is an unmarked `-`-prefixed token and is rejected as an
+unknown flag like any other.
 
-- `run` forwards them to the executed binary as its `argv`
-  (`mach run <path> -- --flag`); `build` and `test` stop scanning at `--` (post-`--`
-  tokens are neither flags nor link inputs).
-- `doc`, `check`, and `init` take the token right after `--` as their positional,
-  so a `-`-leading path is reachable: `mach doc -- -weird-dir`,
-  `mach check -- -weird.mach`.
-
-Consequently a lone `-` or a negative-number token (e.g. `-1`) at a flag position
-is rejected as an unknown flag; where a command reads a positional after `--`
-(above), pass it there. No CLI positional legitimately begins with `-` today, so
-this only matters for oddly-named paths.
+Consequently a lone `-`, a `--`, or a negative-number token (e.g. `-1`) at a flag
+position is rejected as an unknown flag. No CLI positional legitimately begins
+with `-`, so a dash-leading positional is unsupported outside `mach run`'s
+argument forwarding.
 
 ## Commands
 

--- a/src/cli/cmd.mach
+++ b/src/cli/cmd.mach
@@ -17,8 +17,6 @@ use A: std.allocator;
 use O: std.types.option;
 use R: std.types.result;
 
-use mach.cli.util;
-
 use mach.cli.cmd.build;
 use mach.cli.cmd.check;
 use mach.cli.cmd.dep;
@@ -41,15 +39,6 @@ pub fun dispatch(argc: usize, argv: **u8) i64 {
     }
 
     val command: str = argv[1]::str;
-
-    # `-h` / `--help` before a `--` separator is the near-universal help gesture:
-    # print the command's page (top-level usage for an unknown command) and exit
-    # cleanly, rather than letting the rejector treat it as an unknown flag (#1810).
-    val eff: usize = util.separator_index(argc, argv);
-    if (util.has_flag(eff, argv, "-h") || util.has_flag(eff, argv, "--help")) {
-        if (!help.page(command)) { help.usage(); }
-        ret 0;
-    }
 
     # one consumption record parallel to argv: each subcommand marks the flags it
     # recognizes (config.parse for the cross-cutting set, the command for its own),

--- a/src/cli/cmd/build.mach
+++ b/src/cli/cmd/build.mach
@@ -506,16 +506,11 @@ fun build_unit(a: *A.Allocator, argc: usize, argv: **u8, marks: *bool, emit_obj:
     br.code        = 2;
     br.output_path = nil;
 
-    # everything at or after a `--` separator is a program argument (forwarded by
-    # `mach run`), never a build flag or link input. clip the count the build
-    # scanners see so post-`--` args cannot leak into config parsing, the link
-    # scan, or the project-path positional. with no `--` present this is argc.
-    val eff: usize = util.separator_index(argc, argv);
-
-    # the unknown-flag rejection ran in the command entry (`build.run` / `run.run` /
-    # `testing.run`) before this shared body, populating `marks`; a nil marks
-    # vector re-parses config without recording (rejection is already done).
-    val res_config: R.Result[cfg.Config, str] = cfg.parse(eff, argv, nil);
+    # the unknown-flag rejection ran in the command entry (`build.run` /
+    # `testing.run`) before this shared body, populating `marks` and rejecting any
+    # stray `--`, so this scans the full argc; a nil marks vector re-parses config
+    # without recording (rejection is already done).
+    val res_config: R.Result[cfg.Config, str] = cfg.parse(argc, argv, nil);
     if (R.is_err[cfg.Config, str](res_config)) {
         print.eprint("error: ");
         print.eprint(R.unwrap_err[cfg.Config, str](res_config));
@@ -527,8 +522,8 @@ fun build_unit(a: *A.Allocator, argc: usize, argv: **u8, marks: *bool, emit_obj:
 
     # the project root is the required non-flag positional after the subcommand
     # (`mach build <path>`); a bare invocation with no path is a user error.
-    val pix: usize = util.positional_index(eff, argv, marks, 2);
-    if (pix >= eff) {
+    val pix: usize = util.positional_index(argc, argv, marks, 2);
+    if (pix >= argc) {
         print.eprint("error: missing project path; pass the project root (e.g. '.')\n");
         br.code = 1;
         ret br;
@@ -551,10 +546,10 @@ fun build_unit(a: *A.Allocator, argc: usize, argv: **u8, marks: *bool, emit_obj:
     # build_project.
     var cli_level: u8   = pipeline.OPT_DEBUG;
     var cli_set:   bool = false;
-    if (util.has_flag(eff, argv, "-O0"))       { cli_level = pipeline.OPT_DEBUG;   cli_set = true; }
-    or (util.has_flag(eff, argv, "-O1"))       { cli_level = pipeline.OPT_RELEASE; cli_set = true; }
-    or (util.has_flag(eff, argv, "-O2"))       { cli_level = pipeline.OPT_RELEASE; cli_set = true; }
-    or (util.has_flag(eff, argv, "--release")) { cli_level = pipeline.OPT_RELEASE; cli_set = true; }
+    if (util.has_flag(argc, argv, "-O0"))       { cli_level = pipeline.OPT_DEBUG;   cli_set = true; }
+    or (util.has_flag(argc, argv, "-O1"))       { cli_level = pipeline.OPT_RELEASE; cli_set = true; }
+    or (util.has_flag(argc, argv, "-O2"))       { cli_level = pipeline.OPT_RELEASE; cli_set = true; }
+    or (util.has_flag(argc, argv, "--release")) { cli_level = pipeline.OPT_RELEASE; cli_set = true; }
 
     # the build selection threaded to the driver; it narrows target/profile/
     # artifact. an enumerated matrix cell pins target and artifact, but the profile
@@ -645,7 +640,7 @@ fun build_unit(a: *A.Allocator, argc: usize, argv: **u8, marks: *bool, emit_obj:
     if (config.emit_ir)     { eff_emit_ir = true; }
     if (config.no_emit_ir)  { eff_emit_ir = false; }
 
-    br.code = compile_and_link(?p, level, emit_obj, test_mode, config.verify_ir, eff_emit_asm, eff_emit_ir, ?root[0], config.output, eff, argv, marks, ?br.output_path, tests_out, list_only);
+    br.code = compile_and_link(?p, level, emit_obj, test_mode, config.verify_ir, eff_emit_asm, eff_emit_ir, ?root[0], config.output, argc, argv, marks, ?br.output_path, tests_out, list_only);
 
     # close the readout with the recap line on a successful, non-test build.
     if (br.code == 0 && s.readout != nil) {
@@ -2675,9 +2670,7 @@ pub fun run(argc: usize, argv: **u8, marks: *bool) i64 {
         ret 2;
     }
 
-    # post-`--` args are program arguments, never build flags; clip the scanners.
-    val eff: usize = util.separator_index(argc, argv);
-    val res_config: R.Result[cfg.Config, str] = cfg.parse(eff, argv, marks);
+    val res_config: R.Result[cfg.Config, str] = cfg.parse(argc, argv, marks);
     if (R.is_err[cfg.Config, str](res_config)) {
         print.eprint("error: ");
         print.eprint(R.unwrap_err[cfg.Config, str](res_config));
@@ -2699,14 +2692,15 @@ pub fun run(argc: usize, argv: **u8, marks: *bool) i64 {
 
     # config.parse marked the cross-cutting flags; mark the build-specific ones,
     # then reject any unrecognized flag before the project-path positional is
-    # resolved (so an unknown flag can never displace the path).
-    mark_build_flags(marks, eff, argv);
-    if (util.reject_unknown(eff, argv, marks, 2, "mach build")) { ret 1; }
+    # resolved (so an unknown flag can never displace the path). `mach build` gives
+    # `--` no special meaning, so a stray `--` is rejected here like any other flag.
+    mark_build_flags(marks, argc, argv);
+    if (util.reject_unknown(argc, argv, marks, 2, "mach build")) { ret 1; }
 
     # the project root is the required non-flag positional (`mach build <path>`);
     # a bare invocation with no path is a user error.
-    val pix: usize = util.positional_index(eff, argv, marks, 2);
-    if (pix >= eff) {
+    val pix: usize = util.positional_index(argc, argv, marks, 2);
+    if (pix >= argc) {
         print.eprint("error: missing project path; pass the project root (e.g. '.')\n");
         ret 1;
     }

--- a/src/cli/cmd/check.mach
+++ b/src/cli/cmd/check.mach
@@ -49,8 +49,9 @@ use mach.lang.source;
 # ret:   0 when the buffer has no errors, 1 on errors or a usage / io failure
 pub fun run(argc: usize, argv: **u8, marks: *bool) i64 {
     # `mach check <file> [--format ...]`: marking `--format` both registers it for
-    # the rejector and reads its value. reject any other flag, then resolve the file
-    # (a `--` separator escapes a dash-leading filename).
+    # the rejector and reads its value. reject any other flag, then resolve the
+    # file positional (a `-`-leading filename is unsupported - `--` is not honored
+    # here, only by `mach run`).
     val opt_format: O.Option[*u8] = util.mark_value(marks, argc, argv, "--format");
     if (util.reject_unknown(argc, argv, marks, 2, "mach check")) { ret 1; }
     val pix: usize = util.positional_index(argc, argv, marks, 2);

--- a/src/cli/cmd/help.mach
+++ b/src/cli/cmd/help.mach
@@ -23,9 +23,8 @@ val MACH_VERSION: str = $project.version;
 # print the top-level usage or a subcommand detail page
 #
 # called by `mach.cli.cmd.dispatch`, including its unknown-command error path.
-# `mach help <cmd>` accepts only a subcommand name; a flag token is rejected like
-# any other command's (the `-h`/`--help` gesture is intercepted by the dispatcher
-# before it reaches here).
+# `mach help <cmd>` accepts only a subcommand name; a flag token (including
+# `-h`/`--help`, which is not a recognized flag anywhere) is rejected as unknown.
 # ---
 # argc:  argument count including argv[0]
 # argv:  the argument vector (argc null-terminated byte pointers)
@@ -52,12 +51,12 @@ pub fun run(argc: usize, argv: **u8, marks: *bool) i64 {
 
 # print `cmd`'s detail page, reporting whether it named a command with a page
 #
-# The shared subcommand-to-page map behind both `mach help <cmd>` and the
-# dispatcher's `-h`/`--help` interception, so the accepted set lives in one place.
+# The subcommand-to-page map behind `mach help <cmd>`, factored so the accepted
+# set lives in one place.
 # ---
 # cmd: the subcommand name to describe
 # ret: true when `cmd` had a detail page (which was printed), false otherwise
-pub fun page(cmd: str) bool {
+fun page(cmd: str) bool {
     if (str_equals(cmd, "build")) { help_build(); ret true; }
     if (str_equals(cmd, "run"))   { help_run();   ret true; }
     if (str_equals(cmd, "test"))  { help_test();  ret true; }

--- a/src/cli/util.mach
+++ b/src/cli/util.mach
@@ -186,9 +186,11 @@ pub fun is_flag(s: *u8) bool {
 
 # index of the `--` separator in argv, or argc when absent
 #
-# The value doubles as the effective argument count for the build: everything
-# at or after `--` is a program argument the build must not scan, so callers
-# pass this index as the argc handed to the build's flag and link scanners.
+# Meaningful only to `mach run`, whose contract forwards every post-`--` token to
+# the executed program as its argv. `run` passes this index as the effective argc
+# to its flag and positional scanners so those tokens are never read as flags; on
+# every other command `--` has no special meaning and is rejected as an unknown
+# flag (see reject_unknown).
 # ---
 # argc: number of arguments
 # argv: argument vector (argc null-terminated byte pointers)
@@ -208,14 +210,14 @@ pub fun separator_index(argc: usize, argv: **u8) usize {
 # its value were marked when read (config.parse plus each command's own flag
 # reads), so this steps over any marked index and returns the first bare token
 # nobody claimed - no separate value-flag table to drift from the reads (#1810).
-# A `--` separator ends the flag region: the token right after it is the first
-# positional, which lets a path-taking command accept a `-`-leading argument
-# (`mach doc -- -weird`). Commands that forward program arguments after `--`
-# (run/test) instead pass the separator index as `argc`, so `--` is never
-# reached here. An unmarked flag before the first positional cannot occur -
-# reject_unknown rejects it first - so it is stepped over defensively only.
+# A `--` gets no special treatment: it is not a positional, and reject_unknown
+# has already rejected any unmarked flag (including a stray `--`) before this
+# runs, so a leading `-` token can only be a marked flag, stepped over here. No
+# CLI positional legitimately begins with `-`; `mach run` forwards its post-`--`
+# program arguments by passing the separator index as `argc`, so they are never
+# scanned as positionals.
 # ---
-# argc:  number of arguments to scan (the `--` boundary for forwarding commands)
+# argc:  number of arguments to scan (the `--` boundary for `mach run`)
 # argv:  argument vector (argc null-terminated byte pointers)
 # marks: consumption record parallel to argv
 # start: index to begin scanning from (typically 2, past the subcommand)
@@ -224,10 +226,6 @@ pub fun positional_index(argc: usize, argv: **u8, marks: *bool, start: usize) us
     var i: usize = start;
     for (i < argc) {
         val a: *u8 = argv[i];
-        if (str_equals(a::str, "--")) {
-            if (i + 1 < argc) { ret i + 1; }
-            ret argc;
-        }
         if (marks[i])                { i = i + 1; cnt; }
         if (a != nil && !is_flag(a)) { ret i; }
         i = i + 1;
@@ -241,12 +239,14 @@ pub fun positional_index(argc: usize, argv: **u8, marks: *bool, start: usize) us
 # recognized flag and its value; this walks the same range and errors on the
 # first `-`-prefixed token nobody claimed, so a typo'd or removed flag is a hard
 # error rather than a silently misparsed positional (#1810). Bare (non-flag)
-# tokens are positionals or link inputs and are left alone. Scanning stops at a
-# `--` separator: it and every token after it are program arguments, not flags,
-# on every command - so the caller may pass the full `argc`. The diagnostic names
-# the flag and the command; the caller returns its usage-error exit code.
+# tokens are positionals or link inputs and are left alone. A `--` separator gets
+# no special treatment - it is an unmarked `-`-prefixed token and so is reported
+# as an unknown flag; only `mach run` gives it meaning, and it does so by passing
+# the separator index as `argc`, clipping the scan before `--` so its post-`--`
+# program arguments are never reached. The diagnostic names the flag and the
+# command; the caller returns its usage-error exit code.
 # ---
-# argc:  number of arguments to scan
+# argc:  number of arguments to scan (the `--` boundary for `mach run`)
 # argv:  argument vector (argc null-terminated byte pointers)
 # marks: consumption record parallel to argv
 # start: index to begin scanning from (past the subcommand / action)
@@ -255,7 +255,6 @@ pub fun positional_index(argc: usize, argv: **u8, marks: *bool, start: usize) us
 pub fun reject_unknown(argc: usize, argv: **u8, marks: *bool, start: usize, cmd: *u8) bool {
     var i: usize = start;
     for (i < argc) {
-        if (str_equals(argv[i]::str, "--")) { ret false; }
         if (!marks[i] && is_flag(argv[i])) {
             print.eprint("error: unknown flag '");
             print.eprint(argv[i]::str);
@@ -578,26 +577,32 @@ test "mach.cli.util.positional_index:jobs_value_not_positional" {
     ret 0;
 }
 
-# `--` ends the flag region for both scanners: reject_unknown stops there (a
-# following `-`-token is a program argument, not rejected), and positional_index
-# returns the token after it (so a `-`-leading positional is reachable).
-test "mach.cli.util.separator:ends_flag_region" {
-    # [mach, run, ., --, --after]: --after is a program arg, never rejected.
+# `--` is meaningful only to `mach run`, which forwards post-`--` tokens to the
+# child by passing the separator index as `argc` - clipping the scan so `--` and
+# everything after it are never read as flags or positionals. Every other command
+# passes the full argc, so a `--` is an unmarked `-`-prefixed token that
+# reject_unknown reports as an unknown flag.
+test "mach.cli.util.separator:run_only" {
+    # [mach, run, ., --, --after]: run clips at the separator (index 3), so the
+    # scanners over the clipped range accept `.` and never see `--`/`--after`.
     var a: [5]*u8;
     a[0] = "mach"; a[1] = "run"; a[2] = "."; a[3] = "--"; a[4] = "--after";
     var m: [5]bool;
     var i: usize = 0;
     for (i < 5) { m[i] = false; i = i + 1; }
-    if (reject_unknown(5, ?a[0], ?m[0], 2, "mach run")) { ret 1; }
+    val sep: usize = separator_index(5, ?a[0]);
+    if (sep != 3)                                         { ret 1; }
+    if (reject_unknown(sep, ?a[0], ?m[0], 2, "mach run")) { ret 1; }
+    if (positional_index(sep, ?a[0], ?m[0], 2) != 2)      { ret 1; }
 
-    # [mach, doc, --, -weird]: `--` escapes a dash-leading positional.
+    # [mach, doc, --, -weird] over the full argc: `--` gets no exemption and is
+    # reported as an unknown flag (no dash-leading-positional escape outside run).
     var b: [4]*u8;
     b[0] = "mach"; b[1] = "doc"; b[2] = "--"; b[3] = "-weird";
     var mb: [4]bool;
     i = 0;
     for (i < 4) { mb[i] = false; i = i + 1; }
-    if (reject_unknown(4, ?b[0], ?mb[0], 2, "mach doc")) { ret 1; }
-    if (positional_index(4, ?b[0], ?mb[0], 2) != 3)      { ret 1; }
+    if (!reject_unknown(4, ?b[0], ?mb[0], 2, "mach doc")) { ret 1; }
     ret 0;
 }
 


### PR DESCRIPTION
Follow-up scope correction to #1810 (shipped in #1835), implementing the maintainer's review decision. No dedicated issue.

Two behaviors rode along with the unknown-flag rejector and are reverted here; the rejector itself (the point of #1810) stays intact.

## Decision

> `--help` is an antipattern since we have `mach help <cmd>`; `--` is fine for the run context, does not make sense anywhere else.

## Change 1 — drop `-h` / `--help` acceptance

#1835 added a dispatcher hook that intercepted `-h`/`--help` on every command and printed that command's help page (exit 0). Removed: `-h`/`--help` are now ordinary unknown flags, rejected by `reject_unknown` like any other (`error: unknown flag '--help' for 'mach build'`, exit 1). Use `mach help <cmd>`.

## Change 2 — narrow `--` end-of-flags to `mach run` only

#1835 made `--` uniform across all commands (rejection stopped at the separator; post-`--` tokens became eligible positionals on doc/check/init). Reverted everywhere except `run`:

- `run` keeps its contract: flags stop at `--`, post-`--` tokens forward to the executed program (`mach run . -- -h` passes `-h` to the child).
- Every other command (build/test/check/doc/init/info/dep/help) gives `--` no special treatment: it is an unmarked `-`-prefixed token, so `reject_unknown` reports it as an unknown flag.
- The dash-leading-filename escape is removed from check/doc; dash-leading positionals are unsupported outside run's forwarding.

The marks mechanism (`mark_flag`/`mark_value`/`reject_unknown`, `--jobs 4 .` positional resolution) is untouched.
