### PR TITLE
incremental: bind the back half (Q_LOWER / Q_CODEGEN / Q_LINK) into the query engine

### DIFF
--- a/src/cli/cmd/build.mach
+++ b/src/cli/cmd/build.mach
@@ -1503,6 +1503,42 @@ fun link_artifact(p: *driver.Project, emit_obj: bool, root: *u8,
         ret 2;
     }
 
+    # record the link inputs into Q_LINK_CONFIG and consult Q_LINK: when no link
+    # input changed and the prior artifact is present, reuse it instead of
+    # re-linking. the external link inputs are paths[topo_len..len) (paths[0..topo_len)
+    # are the per-module objects Q_CODEGEN already tracks). a cold-cache CLI build
+    # always re-links (Q_LINK is a fresh entry), so this is behaviour-preserving for
+    # a one-shot build and only skips on a warm session.
+    val ext_from:  u32  = p.topo_len;
+    val ext_count: u32  = len - p.topo_len;
+    val cfg_r: R.Result[bool, str] = driver.set_link_config_input(p, ?artifact[0], artifact_product_name(p), linker.LINK_EXE::u32,
+                                                                  ?paths[ext_from], ext_count, sonames, soname_len);
+    if (R.is_err[bool, str](cfg_r)) {
+        free_paths(p.s.alloc, paths, len, len);
+        free_sonames(p.s.alloc, sonames, soname_len);
+        print.eprint("error: ");
+        print.eprint(R.unwrap_err[bool, str](cfg_r));
+        print.eprint("\n");
+        ret 2;
+    }
+    val relink_r: R.Result[bool, str] = driver.run_link_pass(p);
+    if (R.is_err[bool, str](relink_r)) {
+        free_paths(p.s.alloc, paths, len, len);
+        free_sonames(p.s.alloc, sonames, soname_len);
+        print.eprint("error: ");
+        print.eprint(R.unwrap_err[bool, str](relink_r));
+        print.eprint("\n");
+        ret 2;
+    }
+    if (!R.unwrap_ok[bool, str](relink_r) && filesystem.is_file((?artifact[0])::str)) {
+        free_paths(p.s.alloc, paths, len, len);
+        free_sonames(p.s.alloc, sonames, soname_len);
+        @out_path = dup_cstr(p.s.alloc, ?artifact[0]);
+        readout.item(p.s.readout, readout.PH_LINK, (?artifact[0])::str, t_link);
+        readout.phase_end(p.s.readout, readout.PH_LINK, 1, "binary", "binaries");
+        ret 0;
+    }
+
     val res_link: R.Result[bool, str] =
         linker.link(p.s, ?p.target, paths, len, sonames, soname_len, ?artifact[0], artifact_product_name(p), linker.LINK_EXE);
     free_paths(p.s.alloc, paths, len, len);
@@ -1571,6 +1607,30 @@ fun link_image_artifact(p: *driver.Project, emit_obj: bool, root: *u8,
     if (!util.ensure_parents(?artifact[0])) {
         print.eprint("error: failed to create binary directory\n");
         ret 2;
+    }
+
+    # consult Q_LINK: a flat image has no external link inputs, so the config is the
+    # output path / product / pie. reuse the prior artifact when no link input
+    # changed (a cold build always re-links).
+    val cfg_r: R.Result[bool, str] = driver.set_link_config_input(p, ?artifact[0], artifact_product_name(p), linker.LINK_EXE::u32, nil, 0, nil, 0);
+    if (R.is_err[bool, str](cfg_r)) {
+        print.eprint("error: ");
+        print.eprint(R.unwrap_err[bool, str](cfg_r));
+        print.eprint("\n");
+        ret 2;
+    }
+    val relink_r: R.Result[bool, str] = driver.run_link_pass(p);
+    if (R.is_err[bool, str](relink_r)) {
+        print.eprint("error: ");
+        print.eprint(R.unwrap_err[bool, str](relink_r));
+        print.eprint("\n");
+        ret 2;
+    }
+    if (!R.unwrap_ok[bool, str](relink_r) && filesystem.is_file((?artifact[0])::str)) {
+        @out_path = dup_cstr(p.s.alloc, ?artifact[0]);
+        readout.item(p.s.readout, readout.PH_LINK, (?artifact[0])::str, t_link);
+        readout.phase_end(p.s.readout, readout.PH_LINK, 1, "binary", "binaries");
+        ret 0;
     }
 
     # gather the topo-ordered images into a contiguous array. each `of.ObjectImage`

--- a/src/cli/cmd/build.mach
+++ b/src/cli/cmd/build.mach
@@ -46,7 +46,6 @@ use mach.lang.intern;
 use mach.lang.manifest;
 use mach.lang.me.ir;
 use mach.lang.me.ir.printer;
-use mach.lang.me.lower;
 use mach.lang.me.lower.context;
 use mach.lang.me.lower.testrunner;
 use mach.lang.me.pipeline;
@@ -182,47 +181,36 @@ fun compile_modules(p: *driver.Project, level: u8, test_mode: bool, verify_ir: b
     # do not lower or codegen a semantically broken module graph.
     if (diagnostic.has_errors(?p.s.diags)) { ret R.ok[bool, str](true); }
 
-    # lower every module to IR, then optimize, then - in test mode - neutralize
-    # the project `main` (the runner supplies the program entry) before any module
-    # is codegen'd. the `.ir` and `.s` debug artifacts are both rendered in the
-    # codegen pass, from the final post-pipeline IR the object is built from. the
-    # three passes are timed as distinct readout phases; splitting lower from
-    # optimize is purely structural and leaves the produced objects byte-identical.
-    readout.phase_begin(p.s.readout, readout.PH_LOWER);
+    # lower every module to optimized IR through Q_LOWER in topo order - memoized
+    # and incremental across rebuilds on a long-lived session, computed fresh each
+    # CLI build (fresh session, cold cache). run_lower_pass borrows each module's
+    # optimized IR onto its ModuleEntry (owned by the query DB) and records the
+    # readout's `lower` phase internally; the optimization pipeline runs inside the
+    # query, so lower + optimize are one cached unit. the per-module IR arrays below
+    # are shallow VIEWS onto the query-owned modules for the test / codegen passes,
+    # never separately freed (see free_modules).
+    p.opt_level = level;
+    p.verify_ir = verify_ir;
+    val res_lower: R.Result[bool, str] = driver.run_lower_pass(p);
+    if (R.is_err[bool, str](res_lower)) {
+        ret R.err[bool, str](R.unwrap_err[bool, str](res_lower));
+    }
+
     var i: u32 = 0;
     for (i < p.topo_len) {
-        val mid: session.ModuleId   = p.topo[i];
+        val mid: session.ModuleId    = p.topo[i];
         val m:   *driver.ModuleEntry = ?p.modules[mid::u32];
-
-        val t_item: ctime.Time = readout.item_begin(p.s.readout);
-        val res_lower: R.Result[ir.Module, str] = lower.lower_module(p.s, ?p.target, m.a, m.fqn, mid, m.sema_result, m.resolve_result, ?m.ctx);
-        if (R.is_err[ir.Module, str](res_lower)) {
-            ret R.err[bool, str](R.unwrap_err[ir.Module, str](res_lower));
-        }
-        irs[mid::u32]      = R.unwrap_ok[ir.Module, str](res_lower);
+        val irm: *ir.Module          = m.ir_module;
+        irs[mid::u32]      = @irm;
         ir_ready[mid::u32] = true;
-
-        readout.item(p.s.readout, readout.PH_LOWER, fqn_name(p, m.fqn), t_item);
         i = i + 1;
     }
-    readout.phase_end(p.s.readout, readout.PH_LOWER, p.topo_len, "module", "modules");
 
-    readout.phase_begin(p.s.readout, readout.PH_OPTIMIZE);
-    i = 0;
-    for (i < p.topo_len) {
-        val mid: session.ModuleId   = p.topo[i];
-        val m:   *driver.ModuleEntry = ?p.modules[mid::u32];
-
-        val t_item: ctime.Time = readout.item_begin(p.s.readout);
-        val res_opt: R.Result[bool, str] = pipeline.run(?irs[mid::u32], ?p.target, level, verify_ir);
-        if (R.is_err[bool, str](res_opt)) {
-            ret R.err[bool, str](R.unwrap_err[bool, str](res_opt));
-        }
-        readout.item(p.s.readout, readout.PH_OPTIMIZE, fqn_name(p, m.fqn), t_item);
-        i = i + 1;
-    }
-    readout.phase_end(p.s.readout, readout.PH_OPTIMIZE, p.topo_len, "module", "modules");
-
+    # in test mode neutralize the project `main` (the runner supplies the program
+    # entry) before any module is codegen'd. this mutates the query-owned IR in
+    # place; safe on the CLI's single-shot session (the cache is torn down after
+    # this build), a latent hazard only for a hypothetical long-lived test-driving
+    # session, tracked as a follow-up (#1618).
     if (test_mode) {
         val res_neutralize: R.Result[bool, str] = testrunner.neutralize_project_main(p.s, irs, p.module_len);
         if (R.is_err[bool, str](res_neutralize)) {
@@ -325,24 +313,21 @@ fun open_asm(p: *driver.Project, ea: *EmitArtifacts, fqn: intern.StrId, file: *f
     ret open_artifact(ea.asm_base, O.unwrap[str](opt_fqn), "s", file, w);
 }
 
-# tear down the per-module IR and object images
+# tear down the per-module object images
 #
-# SemaResults are NOT freed here - they are borrowed from the session query DB
-# (the Q_SEMA handles), which owns and frees them (and reuses them across
-# rebuilds), mirroring resolve results and parsed ASTs.
+# Neither the SemaResults nor the per-module IR are freed here - both are borrowed
+# from the session query DB (the Q_SEMA / Q_LOWER handles), which owns and frees
+# them (and reuses them across rebuilds), mirroring resolve results and parsed
+# ASTs. The `irs` array the CLI fills is a shallow VIEW onto the query-owned IR.
 # ---
 # p:           the project carrying the module count
-# irs:         the IR-module array to tear down
-# ir_ready:    per-module flag marking which `irs` entries are live
 # images:      the ObjectImage array to tear down
 # image_ready: per-module flag marking which `images` entries are live
 fun free_modules(p: *driver.Project,
-                 irs: *ir.Module, ir_ready: *bool,
                  images: *of.ObjectImage, image_ready: *bool) {
     var i: u32 = 0;
     for (i < p.module_len) {
         if (image_ready[i]) { obj.dnit(?images[i]); }
-        if (ir_ready[i])    { ir.dnit(?irs[i]); }
         i = i + 1;
     }
 }
@@ -813,7 +798,7 @@ fun compile_and_link(p: *driver.Project, level: u8, emit_obj: bool, test_mode: b
         code = link_artifact(p, emit_obj, root, out_override, argc, argv, marks, images, out_path);
     }
 
-    free_modules(p, irs, ir_ready, images, image_ready);
+    free_modules(p, images, image_ready);
     A.deallocate[bool](p.s.alloc, image_ready, n);
     A.deallocate[of.ObjectImage](p.s.alloc, images, n);
     A.deallocate[bool](p.s.alloc, ir_ready, n);

--- a/src/cli/cmd/build.mach
+++ b/src/cli/cmd/build.mach
@@ -150,9 +150,10 @@ fun fqn_name(p: *driver.Project, fqn: intern.StrId) str {
 # Semantic analysis runs over the whole module graph first; only if no module
 # reported an error does the build proceed to lower + optimize + codegen each
 # module to an ObjectImage. This ordering keeps the lowering and codegen passes
-# off a semantically broken AST. `images` (caller-owned, sized to p.module_len)
-# is filled in topo order. On failure the partial images and IR modules are torn
-# down by the caller via `free_modules`.
+# off a semantically broken AST. The per-module IR and object images are owned by
+# the session query DB (the Q_LOWER / Q_CODEGEN handles); the `irs` / `images`
+# arrays the CLI fills are shallow VIEWS, filled in topo order and never separately
+# freed.
 # ---
 # p:           the project carrying the module graph and session
 # level:       optimization pipeline level
@@ -188,7 +189,7 @@ fun compile_modules(p: *driver.Project, level: u8, test_mode: bool, verify_ir: b
     # readout's `lower` phase internally; the optimization pipeline runs inside the
     # query, so lower + optimize are one cached unit. the per-module IR arrays below
     # are shallow VIEWS onto the query-owned modules for the test / codegen passes,
-    # never separately freed (see free_modules).
+    # never separately freed (the query DB owns them).
     p.opt_level = level;
     p.verify_ir = verify_ir;
     val res_lower: R.Result[bool, str] = driver.run_lower_pass(p);
@@ -218,52 +219,74 @@ fun compile_modules(p: *driver.Project, level: u8, test_mode: bool, verify_ir: b
         }
     }
 
-    readout.phase_begin(p.s.readout, readout.PH_CODEGEN);
+    # codegen every module to an ObjectImage through Q_CODEGEN - memoized per module
+    # (an unchanged lowered module reuses its object), computed fresh each CLI build.
+    # run_codegen_pass borrows each module's image onto its ModuleEntry (owned by the
+    # query DB) and records the readout's `codegen` phase internally.
+    val res_codegen: R.Result[bool, str] = driver.run_codegen_pass(p);
+    if (R.is_err[bool, str](res_codegen)) {
+        ret R.err[bool, str](R.unwrap_err[bool, str](res_codegen));
+    }
+
+    # collect the query-owned images into the CLI's image view array (shallow VIEWS,
+    # never separately freed) and render the optional per-module `.ir` / `.s` debug
+    # artifacts. the `.ir` artifact is rendered from the borrowed post-pipeline IR;
+    # the `.s` artifact is rendered by a separate codegen pass (assembly is a
+    # streaming side-channel not retained in the cached image), so the cached object
+    # path stays single-pass and only a `--emit-asm` build re-runs codegen.
     i = 0;
     for (i < p.topo_len) {
-        val mid: session.ModuleId   = p.topo[i];
+        val mid: session.ModuleId    = p.topo[i];
         val m:   *driver.ModuleEntry = ?p.modules[mid::u32];
+        val img: *of.ObjectImage     = m.object_image;
+        images[mid::u32]      = @img;
+        image_ready[mid::u32] = true;
 
-        val t_item: ctime.Time = readout.item_begin(p.s.readout);
-
-        # textual SSA IR, rendered from the final post-pipeline module the object
-        # is built from (matching the `.s` artifact rendered during codegen below).
         if (ea.want_ir) {
-            val res_emit: R.Result[bool, str] = emit_ir(p, ea, m.fqn, ?irs[mid::u32]);
+            val res_emit: R.Result[bool, str] = emit_ir(p, ea, m.fqn, m.ir_module);
             if (R.is_err[bool, str](res_emit)) {
                 ret R.err[bool, str](R.unwrap_err[bool, str](res_emit));
             }
         }
-
-        # codegen, optionally rendering the resolved MIR to a `.s` artifact.
-        var asm_file: filesystem.File;
-        var asm_w:    writer.Writer;
-        var asm_out:  *writer.Writer = nil;
         if (ea.want_asm) {
-            val res_open: R.Result[bool, str] = open_asm(p, ea, m.fqn, ?asm_file, ?asm_w);
-            if (R.is_err[bool, str](res_open)) {
-                ret R.err[bool, str](R.unwrap_err[bool, str](res_open));
-            }
-            asm_out = ?asm_w;
-        }
-
-        val res_codegen: R.Result[of.ObjectImage, str] = codegen.codegen_module(p.s, ?p.target, ?irs[mid::u32], asm_out);
-        if (ea.want_asm) {
-            val res_close: R.Result[bool, str] = filesystem.close(?asm_file);
-            if (R.is_ok[of.ObjectImage, str](res_codegen) && R.is_err[bool, str](res_close)) {
-                ret R.err[bool, str](R.unwrap_err[bool, str](res_close));
+            val res_asm: R.Result[bool, str] = emit_asm(p, ea, m.fqn, m.ir_module);
+            if (R.is_err[bool, str](res_asm)) {
+                ret R.err[bool, str](R.unwrap_err[bool, str](res_asm));
             }
         }
-        if (R.is_err[of.ObjectImage, str](res_codegen)) {
-            ret R.err[bool, str](R.unwrap_err[of.ObjectImage, str](res_codegen));
-        }
-        images[mid::u32]      = R.unwrap_ok[of.ObjectImage, str](res_codegen);
-        image_ready[mid::u32] = true;
-
-        readout.item(p.s.readout, readout.PH_CODEGEN, fqn_name(p, m.fqn), t_item);
         i = i + 1;
     }
-    readout.phase_end(p.s.readout, readout.PH_CODEGEN, p.topo_len, "module", "modules");
+    ret R.ok[bool, str](true);
+}
+
+# render one module's assembly `.s` artifact from its post-pipeline IR
+#
+# Codegen's assembly text is a streaming side-channel not retained in the cached
+# ObjectImage, so the `.s` debug artifact is produced by a separate, deterministic
+# codegen pass over the same IR the cached object was built from; the throwaway
+# image is discarded. Only reached on a `--emit-asm` build.
+# ---
+# p:   the project (for its session, target, interner)
+# ea:  the emission settings (for `asm_base`)
+# fqn: the module's interned fully-qualified name
+# m:   the post-pipeline IR module to render
+# ret: ok(true) on success, or err with the failure message
+fun emit_asm(p: *driver.Project, ea: *EmitArtifacts, fqn: intern.StrId, m: *ir.Module) R.Result[bool, str] {
+    var asm_file: filesystem.File;
+    var asm_w:    writer.Writer;
+    val res_open: R.Result[bool, str] = open_asm(p, ea, fqn, ?asm_file, ?asm_w);
+    if (R.is_err[bool, str](res_open)) { ret res_open; }
+
+    val res_codegen: R.Result[of.ObjectImage, str] = codegen.codegen_module(p.s, ?p.target, m, ?asm_w);
+    val res_close:   R.Result[bool, str]           = filesystem.close(?asm_file);
+    if (R.is_err[of.ObjectImage, str](res_codegen)) {
+        ret R.err[bool, str](R.unwrap_err[of.ObjectImage, str](res_codegen));
+    }
+    var img: of.ObjectImage = R.unwrap_ok[of.ObjectImage, str](res_codegen);
+    obj.dnit(?img);
+    if (R.is_err[bool, str](res_close)) {
+        ret R.err[bool, str](R.unwrap_err[bool, str](res_close));
+    }
     ret R.ok[bool, str](true);
 }
 
@@ -313,23 +336,22 @@ fun open_asm(p: *driver.Project, ea: *EmitArtifacts, fqn: intern.StrId, file: *f
     ret open_artifact(ea.asm_base, O.unwrap[str](opt_fqn), "s", file, w);
 }
 
-# tear down the per-module object images
+# compile a single build unit selected from the CLI flags
 #
-# Neither the SemaResults nor the per-module IR are freed here - both are borrowed
-# from the session query DB (the Q_SEMA / Q_LOWER handles), which owns and frees
-# them (and reuses them across rebuilds), mirroring resolve results and parsed
-# ASTs. The `irs` array the CLI fills is a shallow VIEW onto the query-owned IR.
+# The shared body behind `run` that `cmd.run` reuses so it can build one
+# artifact and then exec it; `mach build` itself iterates the build matrix
+# (`run` below). The returned `output_path`, when non-nil, is owned by `a` - the
+# caller frees it (and tears `a` down) once done with it.
 # ---
-# p:           the project carrying the module count
-# images:      the ObjectImage array to tear down
-# image_ready: per-module flag marking which `images` entries are live
-fun free_modules(p: *driver.Project,
-                 images: *of.ObjectImage, image_ready: *bool) {
-    var i: u32 = 0;
-    for (i < p.module_len) {
-        if (image_ready[i]) { obj.dnit(?images[i]); }
-        i = i + 1;
-    }
+# a:        allocator owning the session and the returned artifact path;
+#           must outlive the returned BuildResult
+# argc:     argument count including argv[0]
+# argv:     the argument vector (argc null-terminated byte pointers)
+# marks:    consumption record parallel to argv, for positional/link scanning
+# emit_obj: when true, emit a relocatable object instead of an executable
+# ret:      a BuildResult carrying the exit code and artifact path
+pub fun build(a: *A.Allocator, argc: usize, argv: **u8, marks: *bool, emit_obj: bool) BuildResult {
+    ret build_unit(a, argc, argv, marks, emit_obj, false, nil, nil, false);
 }
 
 # build the single dispatcher executable covering every collected `test`
@@ -730,10 +752,11 @@ fun compile_and_link(p: *driver.Project, level: u8, emit_obj: bool, test_mode: b
         }
     }
 
-    # per-module SemaResults are owned by the session query DB (the Q_SEMA
-    # handles) and borrowed onto each ModuleEntry by run_sema_pass, so no
-    # per-build sema array is allocated here; only the IR and object-image arrays
-    # are.
+    # the SemaResults, the optimized IR, and the object images are all owned by the
+    # session query DB (the Q_SEMA / Q_LOWER / Q_CODEGEN handles) and borrowed onto
+    # each ModuleEntry by the driver passes. the IR and object-image arrays below are
+    # per-build shallow VIEWS the CLI fills from those borrows (for the test / link /
+    # emit paths); no artifact is owned here.
     val res_irs: R.Result[*ir.Module, str] = A.allocate[ir.Module](p.s.alloc, n);
     if (R.is_err[*ir.Module, str](res_irs)) {
         print.eprint("error: out of memory\n");
@@ -798,7 +821,9 @@ fun compile_and_link(p: *driver.Project, level: u8, emit_obj: bool, test_mode: b
         code = link_artifact(p, emit_obj, root, out_override, argc, argv, marks, images, out_path);
     }
 
-    free_modules(p, images, image_ready);
+    # the irs / images arrays are shallow VIEWS onto the query-owned IR and object
+    # images (freed by the query DB on session teardown), so only the view arrays
+    # themselves are released here, never their contents.
     A.deallocate[bool](p.s.alloc, image_ready, n);
     A.deallocate[of.ObjectImage](p.s.alloc, images, n);
     A.deallocate[bool](p.s.alloc, ir_ready, n);

--- a/src/cli/cmd/build.mach
+++ b/src/cli/cmd/build.mach
@@ -211,7 +211,7 @@ fun compile_modules(p: *driver.Project, level: u8, test_mode: bool, verify_ir: b
     # entry) before any module is codegen'd. this mutates the query-owned IR in
     # place; safe on the CLI's single-shot session (the cache is torn down after
     # this build), a latent hazard only for a hypothetical long-lived test-driving
-    # session, tracked as a follow-up (#1618).
+    # session, tracked as a follow-up (#1858).
     if (test_mode) {
         val res_neutralize: R.Result[bool, str] = testrunner.neutralize_project_main(p.s, irs, p.module_len);
         if (R.is_err[bool, str](res_neutralize)) {

--- a/src/lang/driver.mach
+++ b/src/lang/driver.mach
@@ -51,6 +51,9 @@ use mach.lang.fe.sema;
 use mach.lang.fe.token;
 use mach.lang.intern;
 use mach.lang.manifest;
+use mach.lang.me.ir;
+use mach.lang.me.lower;
+use mach.lang.me.pipeline;
 use mach.lang.query;
 use mach.lang.readout;
 use mach.lang.session;
@@ -223,6 +226,11 @@ pub rec PubConst {
 #                 reused across rebuilds of an unchanged module; set by
 #                 run_sema_one, nil until then. NOT freed by dnit_project - the
 #                 query DB owns it (its finalizer frees it) (#1583)
+# ir_module:      borrowed pointer to this module's optimized IR, owned by the
+#                 session query DB as the Q_LOWER handle (keyed by stable_id) and
+#                 reused across rebuilds of an unchanged module; set by
+#                 run_lower_one, nil until then. NOT freed by dnit_project - the
+#                 query DB owns it (its finalizer frees it) (#1618)
 # stable_id:      this module's build-stable identity (session-assigned by FQN);
 #                 unlike the discovery-order ModuleId, it survives a graph reshape,
 #                 so cross-build resolve/sema reuse remaps through it (#1579)
@@ -240,6 +248,7 @@ pub rec ModuleEntry {
     resolve_result:    *resolve.ResolveResult;
     resolved:          bool;
     sema_result:       *sema.SemaResult;
+    ir_module:         *ir.Module;
     stable_id:         session.StableModuleId;
 }
 
@@ -305,6 +314,9 @@ rec TargetTuple {
 # topo:              module ids in dep-order (topo[0] has no deps within the graph)
 # topo_len:          number of entries in topo
 # topo_cap:          allocated slots in topo
+# opt_level:         the optimization pipeline level the back half lowers at, set
+#                    by the CLI before run_lower_pass (defaults to the debug pipeline)
+# verify_ir:         run the IR verifier after each optimization pass during lowering
 pub rec Project {
     s:            *session.Session;
     config:       ProjectConfig;
@@ -332,6 +344,9 @@ pub rec Project {
     topo:         *session.ModuleId;
     topo_len:     u32;
     topo_cap:     u32;
+
+    opt_level:    pipeline.OptLevel;
+    verify_ir:    bool;
 }
 
 # seed capacities for the per-build growable arrays (module table, a module's pub
@@ -1160,6 +1175,8 @@ fun init_project(p: *Project, s: *session.Session) {
     p.topo          = nil;
     p.topo_len      = 0;
     p.topo_cap      = 0;
+    p.opt_level     = pipeline.OPT_DEBUG;
+    p.verify_ir     = false;
 }
 
 # release every owned array a ProjectConfig holds (targets and their libs, deps,
@@ -2157,6 +2174,7 @@ fun register_module_slot(p: *Project, fqn: intern.StrId) R.Result[session.Module
     m.resolve_result    = nil;
     m.resolved          = false;
     m.sema_result       = nil;
+    m.ir_module         = nil;
     p.modules[p.module_len] = m;
     p.module_len = p.module_len + 1;
 
@@ -2381,6 +2399,10 @@ fun ensure_query_pipeline(s: *session.Session) R.Result[bool, str] {
     if (!query.is_registered(?s.queries, query.Q_TYPED_EXPORTS)) {
         val rte: R.Result[bool, str] = query.register_derived(?s.queries, query.Q_TYPED_EXPORTS, q_typed_exports_compute);
         if (R.is_err[bool, str](rte)) { ret rte; }
+    }
+    if (!query.is_registered(?s.queries, query.Q_LOWER)) {
+        val rl: R.Result[bool, str] = query.register_derived_owned(?s.queries, query.Q_LOWER, q_lower_compute, q_lower_finalize);
+        if (R.is_err[bool, str](rl)) { ret rl; }
     }
     ret R.ok[bool, str](true);
 }
@@ -3713,6 +3735,250 @@ fun q_typed_exports_compute(db: *query.QueryDb, key: u64, alloc: *A.Allocator) R
     out.bytes = fb.buf;
     out.len   = fb.len;
     ret R.ok[query.QueryOutput, str](out);
+}
+
+# the transitive import closure a Q_LOWER compute records its Q_SEMA deps over.
+# ---
+# list:  owned array of the reachable dep ModuleIds (sized to module_len)
+# count: number of populated entries in list
+# cap:   allocated length of list (the free size)
+rec LowerClosure {
+    list:  *session.ModuleId;
+    count: u32;
+    cap:   u32;
+}
+
+# lower every module to optimized IR in topo order through the Q_LOWER query.
+# the active Project is installed on the session for the pass so the compute can
+# reach the per-build module graph; topo order matches the sema pass. every module's
+# SemaResult (its own and its dep closure's) is already borrowed onto its ModuleEntry
+# and published to the session by a completed run_sema_pass - the monomorphizer
+# reaches a generic template's declaring module through those session registries.
+# resolve and sema must both have run first; the CLI compile path drives this after
+# run_sema_pass (build_project itself stops at resolve, #1583).
+# ---
+# p:   the active project; its topo order and per-build module graph drive the pass
+# ret: true once every module is lowered, or the first error
+pub fun run_lower_pass(p: *Project) R.Result[bool, str] {
+    session.set_active_project(p.s, p::ptr);
+
+    readout.phase_begin(p.s.readout, readout.PH_LOWER);
+    var i: u32 = 0;
+    for (i < p.topo_len) {
+        val mid: session.ModuleId = p.topo[i];
+        val r: R.Result[bool, str] = run_lower_one(p, mid);
+        if (R.is_err[bool, str](r)) {
+            session.set_active_project(p.s, nil);
+            ret r;
+        }
+        i = i + 1;
+    }
+    readout.phase_end(p.s.readout, readout.PH_LOWER, p.topo_len, "module", "modules");
+    session.set_active_project(p.s, nil);
+    ret R.ok[bool, str](true);
+}
+
+# fetch module `mid`'s optimized IR through Q_LOWER - computed fresh when its own
+# typing or any dep-closure module's typing changed, reused otherwise - and borrow
+# it onto the ModuleEntry. the IR is owned by the query DB; m.ir_module only points
+# at it.
+fun run_lower_one(p: *Project, mid: session.ModuleId) R.Result[bool, str] {
+    val m: *ModuleEntry = ?p.modules[mid::u32];
+
+    val t_item: ctime.Time = readout.item_begin(p.s.readout);
+
+    val e_r: R.Result[*query.QueryEntry, str] = query.get(?p.s.queries, query.Q_LOWER, m.stable_id::u64);
+    if (R.is_err[*query.QueryEntry, str](e_r)) { ret R.err[bool, str](R.unwrap_err[*query.QueryEntry, str](e_r)); }
+    val irm: *ir.Module = ir_handle_decode(R.unwrap_ok[*query.QueryEntry, str](e_r));
+    if (irm == nil) { ret R.err[bool, str]("Q_LOWER produced no result handle"); }
+
+    m.ir_module = irm;
+    readout.item(p.s.readout, readout.PH_LOWER, fqn_name(p, m.fqn), t_item);
+    ret R.ok[bool, str](true);
+}
+
+# the Q_LOWER derived compute - lower one module to optimized IR and return it as
+# an opaque owned handle. reaches the per-build module graph through the session's
+# active Project, and records the deps that make the entry incremental:
+#   - Q_SEMA(module):  a change to this module's typing re-lowers it;
+#   - Q_TARGET:        a build-config change re-lowers every module;
+#   - Q_SEMA(dep) for every module in this module's TRANSITIVE import closure: a
+#     generic/comptime instance declared in another module is monomorphized into
+#     THIS module's IR, so a change to that module's typing (including a private
+#     generic body it exposes) must re-lower this module. the transitive closure -
+#     not the direct resolve closure - is required because there is no per-hop
+#     lowering firewall: an inlined instance can originate in a transitively-
+#     imported module the direct closure omits (#1618).
+fun q_lower_compute(db: *query.QueryDb, key: u64, alloc: *A.Allocator) R.Result[query.QueryOutput, str] {
+    val s: *session.Session = db.ctx::*session.Session;
+    if (s == nil) { ret R.err[query.QueryOutput, str]("Q_LOWER: query db has no session context"); }
+    val pp: ptr = session.active_project(s);
+    if (pp == nil) { ret R.err[query.QueryOutput, str]("Q_LOWER: no active project for the lower pass"); }
+    val p: *Project = pp::*Project;
+
+    val stable: session.StableModuleId = key::u32::session.StableModuleId;
+    val mid: session.ModuleId = session.module_id_for_stable(s, stable);
+    if (mid == session.MODULE_NIL) { ret R.err[query.QueryOutput, str]("Q_LOWER: stable id not loaded this build"); }
+    val m: *ModuleEntry = ?p.modules[mid::u32];
+    val a: *ast.Ast = m.a;
+    if (a == nil) { ret R.err[query.QueryOutput, str]("Q_LOWER: module has no parsed AST"); }
+    val sr: *sema.SemaResult = m.sema_result;
+    if (sr == nil) { ret R.err[query.QueryOutput, str]("Q_LOWER: module has no sema result"); }
+
+    val rsd: R.Result[bool, str] = query.record_dep(db, query.Q_LOWER, key, query.Q_SEMA, key);
+    if (R.is_err[bool, str](rsd)) { ret R.err[query.QueryOutput, str](R.unwrap_err[bool, str](rsd)); }
+    val rt: R.Result[bool, str] = query.record_dep(db, query.Q_LOWER, key, query.Q_TARGET, 0);
+    if (R.is_err[bool, str](rt)) { ret R.err[query.QueryOutput, str](R.unwrap_err[bool, str](rt)); }
+
+    # record a dep on Q_SEMA of every module whose typing can feed this module's
+    # lowered IR (its transitive import closure). those Q_SEMA entries are all
+    # computed and valid (run_sema_pass completed before the lower pass), so
+    # record_dep captures their final last_changed directly.
+    val cl_r: R.Result[LowerClosure, str] = collect_lower_closure(p, m);
+    if (R.is_err[LowerClosure, str](cl_r)) { ret R.err[query.QueryOutput, str](R.unwrap_err[LowerClosure, str](cl_r)); }
+    var cl: LowerClosure = R.unwrap_ok[LowerClosure, str](cl_r);
+    var di: u32 = 0;
+    for (di < cl.count) {
+        val dep_mid: session.ModuleId = cl.list[di];
+        val dep_stable: session.StableModuleId = p.modules[dep_mid::u32].stable_id;
+        val rd: R.Result[bool, str] = query.record_dep(db, query.Q_LOWER, key, query.Q_SEMA, dep_stable::u64);
+        if (R.is_err[bool, str](rd)) {
+            free_lower_closure(s.alloc, ?cl);
+            ret R.err[query.QueryOutput, str](R.unwrap_err[bool, str](rd));
+        }
+        di = di + 1;
+    }
+    free_lower_closure(s.alloc, ?cl);
+
+    val res_lower: R.Result[ir.Module, str] = lower.lower_module(s, ?p.target, a, m.fqn, mid, sr, m.resolve_result, ?m.ctx);
+    if (R.is_err[ir.Module, str](res_lower)) { ret R.err[query.QueryOutput, str](R.unwrap_err[ir.Module, str](res_lower)); }
+    var irmod: ir.Module = R.unwrap_ok[ir.Module, str](res_lower);
+
+    # optimize in place: the cached artifact is the post-pipeline IR the object is
+    # built from, so an unchanged optimized module reuses its codegen output.
+    val res_opt: R.Result[bool, str] = pipeline.run(?irmod, ?p.target, p.opt_level, p.verify_ir);
+    if (R.is_err[bool, str](res_opt)) {
+        ir.dnit(?irmod);
+        ret R.err[query.QueryOutput, str](R.unwrap_err[bool, str](res_opt));
+    }
+
+    val br: R.Result[*ir.Module, str] = A.allocate[ir.Module](alloc, 1::usize);
+    if (R.is_err[*ir.Module, str](br)) {
+        ir.dnit(?irmod);
+        ret R.err[query.QueryOutput, str](R.unwrap_err[*ir.Module, str](br));
+    }
+    val box: *ir.Module = R.unwrap_ok[*ir.Module, str](br);
+    box[0] = irmod;
+    ret ir_handle_encode(alloc, box);
+}
+
+# release the optimized IR a Q_LOWER handle owns, called by the engine before it
+# frees the handle buffer (on recompute, invalidate, dnit).
+fun q_lower_finalize(value: *u8, value_len: u32, alloc: *A.Allocator) {
+    if (value == nil || value_len::usize < $size_of(ptr)) { ret; }
+    val slot: *ptr = value::ptr::*ptr;
+    val r: *ir.Module = slot[0]::*ir.Module;
+    if (r == nil) { ret; }
+    ir.dnit(r);
+    A.deallocate[ir.Module](alloc, r, 1::usize);
+}
+
+# wrap a heap ir.Module pointer as a pointer-sized opaque handle buffer - the
+# Q_LOWER query value. like the front-half handles, the heavy IR graph lives in the
+# byte-buffer DB as a handle, never serialized.
+fun ir_handle_encode(alloc: *A.Allocator, r: *ir.Module) R.Result[query.QueryOutput, str] {
+    val n: u32 = $size_of(ptr)::u32;
+    val rb: R.Result[*u8, str] = A.allocate[u8](alloc, n::usize);
+    if (R.is_err[*u8, str](rb)) {
+        ir.dnit(r);
+        A.deallocate[ir.Module](alloc, r, 1::usize);
+        ret R.err[query.QueryOutput, str](R.unwrap_err[*u8, str](rb));
+    }
+    val buf: *u8 = R.unwrap_ok[*u8, str](rb);
+    val slot: *ptr = buf::ptr::*ptr;
+    slot[0] = r::ptr;
+    var out: query.QueryOutput;
+    out.bytes = buf;
+    out.len   = n;
+    ret R.ok[query.QueryOutput, str](out);
+}
+
+# read the ir.Module pointer back out of a Q_LOWER handle entry, or nil when the
+# entry carries no value.
+fun ir_handle_decode(e: *query.QueryEntry) *ir.Module {
+    if (e.value == nil || e.value_len::usize < $size_of(ptr)) { ret nil; }
+    val slot: *ptr = e.value::ptr::*ptr;
+    ret slot[0]::*ir.Module;
+}
+
+# collect the transitive import closure of module `m` (every module reachable from
+# its direct deps, following deps to fixpoint) into a fresh owned list; the module
+# itself is excluded. bounded scratch (a visited mark array sized to module_len,
+# freed here) plus the returned list (also sized to module_len, owned by the session
+# allocator and freed by free_lower_closure).
+fun collect_lower_closure(p: *Project, m: *ModuleEntry) R.Result[LowerClosure, str] {
+    var cl: LowerClosure;
+    cl.list  = nil;
+    cl.count = 0;
+    cl.cap   = 0;
+    if (m.dep_count == 0 || p.module_len == 0) { ret R.ok[LowerClosure, str](cl); }
+
+    val vr: R.Result[*bool, str] = A.allocate[bool](p.s.alloc, p.module_len::usize);
+    if (R.is_err[*bool, str](vr)) { ret R.err[LowerClosure, str](R.unwrap_err[*bool, str](vr)); }
+    val visited: *bool = R.unwrap_ok[*bool, str](vr);
+    var vi: u32 = 0;
+    for (vi < p.module_len) { visited[vi] = false; vi = vi + 1; }
+
+    val lr: R.Result[*session.ModuleId, str] = A.allocate[session.ModuleId](p.s.alloc, p.module_len::usize);
+    if (R.is_err[*session.ModuleId, str](lr)) {
+        A.deallocate[bool](p.s.alloc, visited, p.module_len::usize);
+        ret R.err[LowerClosure, str](R.unwrap_err[*session.ModuleId, str](lr));
+    }
+    val list: *session.ModuleId = R.unwrap_ok[*session.ModuleId, str](lr);
+    var list_len: u32 = 0;
+
+    var i: u32 = 0;
+    for (i < m.dep_count) {
+        val d: session.ModuleId = m.deps[i];
+        if (d::u32 < p.module_len && !visited[d::u32]) {
+            visited[d::u32] = true;
+            list[list_len]  = d;
+            list_len = list_len + 1;
+        }
+        i = i + 1;
+    }
+
+    var head: u32 = 0;
+    for (head < list_len) {
+        val cur: session.ModuleId = list[head];
+        val cm:  *ModuleEntry = ?p.modules[cur::u32];
+        var j: u32 = 0;
+        for (j < cm.dep_count) {
+            val d: session.ModuleId = cm.deps[j];
+            if (d::u32 < p.module_len && !visited[d::u32]) {
+                visited[d::u32] = true;
+                list[list_len]  = d;
+                list_len = list_len + 1;
+            }
+            j = j + 1;
+        }
+        head = head + 1;
+    }
+
+    A.deallocate[bool](p.s.alloc, visited, p.module_len::usize);
+    cl.list  = list;
+    cl.count = list_len;
+    cl.cap   = p.module_len;
+    ret R.ok[LowerClosure, str](cl);
+}
+
+# release the list a LowerClosure owns (freed at its allocated capacity).
+fun free_lower_closure(alloc: *A.Allocator, cl: *LowerClosure) {
+    if (cl.list == nil || cl.cap == 0) { ret; }
+    A.deallocate[session.ModuleId](alloc, cl.list, cl.cap::usize);
+    cl.list  = nil;
+    cl.count = 0;
+    cl.cap   = 0;
 }
 
 # append the typed pub surface of module `mid` to the fingerprint.
@@ -5425,6 +5691,15 @@ fun ut_sema_lc(s: *session.Session, stable: session.StableModuleId) query.Revisi
     ret R.unwrap_ok[*query.QueryEntry, str](e).last_changed;
 }
 
+# the last_changed revision of module `stable`'s Q_LOWER entry on session
+# `s`, or a sentinel when absent. an owned-handle shard never early-cuts, so an
+# unchanged value means the module was NOT re-lowered - the lowering reuse probe (#1618).
+fun ut_lower_lc(s: *session.Session, stable: session.StableModuleId) query.Revision {
+    val e: R.Result[*query.QueryEntry, str] = query.get(?s.queries, query.Q_LOWER, stable::u64);
+    if (R.is_err[*query.QueryEntry, str](e)) { ret 0xFFFFFFFFFFFFFFFF; }
+    ret R.unwrap_ok[*query.QueryEntry, str](e).last_changed;
+}
+
 # whether two ModuleIds name the same module by FQN text
 # across two sessions. an anonymous nominal's origin is MODULE_NIL in both; the test
 # fixtures use only named records, so two MODULE_NIL origins (with a matched decl
@@ -5832,6 +6107,183 @@ test "mach.lang.driver:incremental_sema_reshape_renumber_recheck" {
     dnit_project(?pB);
     session.dnit(?sB);
     dnit_project(?pA2);
+    filesystem.remove_all(?alloc, root);
+    session.dnit(?sA);
+    ret bad;
+}
+
+# driver incremental: a no-change rebuild on a long-lived session re-lowers no
+# module - every Q_LOWER entry is reused, so lowering + optimize + codegen are all
+# skipped (#1618).
+test "mach.lang.driver:incremental_lower_reuse_no_change" {
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    val sr: R.Result[session.Session, str] = session.init(?alloc);
+    if (R.is_err[session.Session, str](sr)) { ret 1; }
+    var sA: session.Session = R.unwrap_ok[session.Session, str](sr);
+    if (R.is_err[bool, str](setup_registry(?sA.registry))) { session.dnit(?sA); ret 1; }
+
+    var names: [2]str;
+    names[0] = "main.mach"; names[1] = "leaf.mach";
+    var texts: [2]str;
+    texts[0] = "use uniontest.leaf.fa;\nfun main() i32 { ret fa(); }\n";
+    texts[1] = "pub fun fa() i32 { ret 1; }\n";
+
+    val root_r: R.Result[str, str] = ut_scaffold(?alloc, ?names[0], ?texts[0], 2);
+    if (R.is_err[str, str](root_r)) { session.dnit(?sA); ret 1; }
+    val root: str = R.unwrap_ok[str, str](root_r);
+
+    var bad: i32 = 0;
+
+    # build 1: sema then lower the whole graph.
+    val p1r: R.Result[Project, str] = build_project_union(?sA, root);
+    if (R.is_err[Project, str](p1r)) { filesystem.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
+    var p1: Project = R.unwrap_ok[Project, str](p1r);
+    if (R.is_err[bool, str](run_sema_pass(?p1)))  { dnit_project(?p1); filesystem.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
+    if (R.is_err[bool, str](run_lower_pass(?p1))) { dnit_project(?p1); filesystem.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
+    val st_main: session.StableModuleId = ut_stable(?p1, ?sA, "uniontest.main");
+    val st_leaf: session.StableModuleId = ut_stable(?p1, ?sA, "uniontest.leaf");
+    val lc_main_1: query.Revision = ut_lower_lc(?sA, st_main);
+    val lc_leaf_1: query.Revision = ut_lower_lc(?sA, st_leaf);
+    dnit_project(?p1);
+
+    # build 2: no source edit, same long-lived session.
+    val p2r: R.Result[Project, str] = build_project_union(?sA, root);
+    if (R.is_err[Project, str](p2r)) { filesystem.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
+    var p2: Project = R.unwrap_ok[Project, str](p2r);
+    if (R.is_err[bool, str](run_sema_pass(?p2)))  { dnit_project(?p2); filesystem.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
+    if (R.is_err[bool, str](run_lower_pass(?p2))) { dnit_project(?p2); filesystem.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
+    val lc_main_2: query.Revision = ut_lower_lc(?sA, st_main);
+    val lc_leaf_2: query.Revision = ut_lower_lc(?sA, st_leaf);
+    dnit_project(?p2);
+
+    # a no-change rebuild re-lowered NOTHING: both modules' Q_LOWER was reused.
+    if (lc_main_2 != lc_main_1) { bad = 1; }
+    if (lc_leaf_2 != lc_leaf_1) { bad = 1; }
+
+    filesystem.remove_all(?alloc, root);
+    session.dnit(?sA);
+    ret bad;
+}
+
+# driver incremental: editing one dependency's body re-lowers it and its importer
+# (the importer inlines nothing here, but has no per-hop lowering firewall so it
+# conservatively re-lowers), while an independent sibling module's Q_LOWER is
+# reused - a single-module edit rebuilds only the affected sub-graph (#1618).
+test "mach.lang.driver:incremental_lower_isolated_edit_reuses_sibling" {
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    val sr: R.Result[session.Session, str] = session.init(?alloc);
+    if (R.is_err[session.Session, str](sr)) { ret 1; }
+    var sA: session.Session = R.unwrap_ok[session.Session, str](sr);
+    if (R.is_err[bool, str](setup_registry(?sA.registry))) { session.dnit(?sA); ret 1; }
+
+    # main imports two independent leaves a and b. editing a re-lowers a and its
+    # importer main, but must not touch b (unrelated to a).
+    var names: [3]str;
+    names[0] = "main.mach"; names[1] = "a.mach"; names[2] = "b.mach";
+    var texts: [3]str;
+    texts[0] = "use uniontest.a.fa;\nuse uniontest.b.fb;\nfun main() i32 { ret fa() + fb(); }\n";
+    texts[1] = "pub fun fa() i32 { ret 1; }\n";
+    texts[2] = "pub fun fb() i32 { ret 2; }\n";
+
+    val root_r: R.Result[str, str] = ut_scaffold(?alloc, ?names[0], ?texts[0], 3);
+    if (R.is_err[str, str](root_r)) { session.dnit(?sA); ret 1; }
+    val root: str = R.unwrap_ok[str, str](root_r);
+
+    var bad: i32 = 0;
+
+    val p1r: R.Result[Project, str] = build_project_union(?sA, root);
+    if (R.is_err[Project, str](p1r)) { filesystem.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
+    var p1: Project = R.unwrap_ok[Project, str](p1r);
+    if (R.is_err[bool, str](run_sema_pass(?p1)))  { dnit_project(?p1); filesystem.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
+    if (R.is_err[bool, str](run_lower_pass(?p1))) { dnit_project(?p1); filesystem.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
+    val st_main: session.StableModuleId = ut_stable(?p1, ?sA, "uniontest.main");
+    val st_a:    session.StableModuleId = ut_stable(?p1, ?sA, "uniontest.a");
+    val st_b:    session.StableModuleId = ut_stable(?p1, ?sA, "uniontest.b");
+    val lc_main_1: query.Revision = ut_lower_lc(?sA, st_main);
+    val lc_a_1:    query.Revision = ut_lower_lc(?sA, st_a);
+    val lc_b_1:    query.Revision = ut_lower_lc(?sA, st_b);
+    dnit_project(?p1);
+
+    # edit a's body only; b and the entry are untouched on disk.
+    val src_dir: str = ut_cc3(?alloc, root, "/", "src");
+    val a_path:  str = ut_cc3(?alloc, src_dir, "/", "a.mach");
+    val a_v2:    str = "pub fun fa() i32 { val t: i32 = 1; ret t; }\n";
+    if (R.is_err[bool, str](filesystem.write_file(a_path, a_v2, str_len(a_v2), 420))) { filesystem.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
+
+    val p2r: R.Result[Project, str] = build_project_union(?sA, root);
+    if (R.is_err[Project, str](p2r)) { filesystem.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
+    var p2: Project = R.unwrap_ok[Project, str](p2r);
+    if (R.is_err[bool, str](run_sema_pass(?p2)))  { dnit_project(?p2); filesystem.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
+    if (R.is_err[bool, str](run_lower_pass(?p2))) { dnit_project(?p2); filesystem.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
+    val lc_main_2: query.Revision = ut_lower_lc(?sA, st_main);
+    val lc_a_2:    query.Revision = ut_lower_lc(?sA, st_a);
+    val lc_b_2:    query.Revision = ut_lower_lc(?sA, st_b);
+    dnit_project(?p2);
+
+    # the edited module and its importer re-lowered; the unrelated sibling did NOT.
+    if (lc_a_2 == lc_a_1)       { bad = 1; }
+    if (lc_main_2 == lc_main_1) { bad = 1; }
+    if (lc_b_2 != lc_b_1)       { bad = 1; }
+
+    filesystem.remove_all(?alloc, root);
+    session.dnit(?sA);
+    ret bad;
+}
+
+# driver incremental: editing the entry module's own body re-lowers only the entry;
+# its unedited dependency's Q_LOWER is reused (editing an importer does not re-lower
+# its dependency) (#1618).
+test "mach.lang.driver:incremental_lower_entry_edit_reuses_dep" {
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    val sr: R.Result[session.Session, str] = session.init(?alloc);
+    if (R.is_err[session.Session, str](sr)) { ret 1; }
+    var sA: session.Session = R.unwrap_ok[session.Session, str](sr);
+    if (R.is_err[bool, str](setup_registry(?sA.registry))) { session.dnit(?sA); ret 1; }
+
+    var names: [2]str;
+    names[0] = "main.mach"; names[1] = "leaf.mach";
+    var texts: [2]str;
+    texts[0] = "use uniontest.leaf.fa;\nfun main() i32 { ret fa(); }\n";
+    texts[1] = "pub fun fa() i32 { ret 1; }\n";
+    val root_r: R.Result[str, str] = ut_scaffold(?alloc, ?names[0], ?texts[0], 2);
+    if (R.is_err[str, str](root_r)) { session.dnit(?sA); ret 1; }
+    val root: str = R.unwrap_ok[str, str](root_r);
+
+    var bad: i32 = 0;
+
+    val p1r: R.Result[Project, str] = build_project_union(?sA, root);
+    if (R.is_err[Project, str](p1r)) { filesystem.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
+    var p1: Project = R.unwrap_ok[Project, str](p1r);
+    if (R.is_err[bool, str](run_sema_pass(?p1)))  { dnit_project(?p1); filesystem.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
+    if (R.is_err[bool, str](run_lower_pass(?p1))) { dnit_project(?p1); filesystem.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
+    val st_main: session.StableModuleId = ut_stable(?p1, ?sA, "uniontest.main");
+    val st_leaf: session.StableModuleId = ut_stable(?p1, ?sA, "uniontest.leaf");
+    val lc_main_1: query.Revision = ut_lower_lc(?sA, st_main);
+    val lc_leaf_1: query.Revision = ut_lower_lc(?sA, st_leaf);
+    dnit_project(?p1);
+
+    # edit the entry's body only (valid syntax); leaf is untouched on disk.
+    val src_dir:   str = ut_cc3(?alloc, root, "/", "src");
+    val main_path: str = ut_cc3(?alloc, src_dir, "/", "main.mach");
+    val main_v2:   str = "use uniontest.leaf.fa;\nfun main() i32 { val x: i32 = fa(); ret x; }\n";
+    if (R.is_err[bool, str](filesystem.write_file(main_path, main_v2, str_len(main_v2), 420))) { filesystem.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
+
+    val p2r: R.Result[Project, str] = build_project_union(?sA, root);
+    if (R.is_err[Project, str](p2r)) { filesystem.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
+    var p2: Project = R.unwrap_ok[Project, str](p2r);
+    if (R.is_err[bool, str](run_sema_pass(?p2)))  { dnit_project(?p2); filesystem.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
+    if (R.is_err[bool, str](run_lower_pass(?p2))) { dnit_project(?p2); filesystem.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
+    val lc_main_2: query.Revision = ut_lower_lc(?sA, st_main);
+    val lc_leaf_2: query.Revision = ut_lower_lc(?sA, st_leaf);
+    dnit_project(?p2);
+
+    # the edited entry re-lowered; its unedited dependency did NOT.
+    if (lc_main_2 == lc_main_1) { bad = 1; }
+    if (lc_leaf_2 != lc_leaf_1) { bad = 1; }
+
     filesystem.remove_all(?alloc, root);
     session.dnit(?sA);
     ret bad;

--- a/src/lang/driver.mach
+++ b/src/lang/driver.mach
@@ -2418,6 +2418,10 @@ fun ensure_query_pipeline(s: *session.Session) R.Result[bool, str] {
         val rcg: R.Result[bool, str] = query.register_derived_owned(?s.queries, query.Q_CODEGEN, q_codegen_compute, q_codegen_finalize);
         if (R.is_err[bool, str](rcg)) { ret rcg; }
     }
+    if (!query.is_registered(?s.queries, query.Q_LINK)) {
+        val rln: R.Result[bool, str] = query.register_derived(?s.queries, query.Q_LINK, q_link_compute);
+        if (R.is_err[bool, str](rln)) { ret rln; }
+    }
     ret R.ok[bool, str](true);
 }
 
@@ -4121,6 +4125,180 @@ fun image_handle_decode(e: *query.QueryEntry) *of.ObjectImage {
     if (e.value == nil || e.value_len::usize < $size_of(ptr)) { ret nil; }
     val slot: *ptr = e.value::ptr::*ptr;
     ret slot[0]::*of.ObjectImage;
+}
+
+# serialize the link-only build configuration into the Q_LINK_CONFIG input, keyed
+# on unit (0) - set by the CLI before the link so Q_LINK invalidates on any change
+# to an input that does NOT flow through a module's Q_CODEGEN.
+#
+# Captures the output path and product name, the output kind, the pie flag, and the
+# external link inputs (object/archive paths plus dynamic-dependency sonames). The
+# ownership boundary: the CLI translates argv/manifest into these resolved inputs;
+# this records them into the query graph. set_input's byte-equality cutoff keeps the
+# link reused when the config is unchanged.
+# ---
+# p:            the active project (for its session query DB and pie flag)
+# out_path:     the resolved output artifact path (nil-safe)
+# product:      the product / signing-identity name (nil-safe)
+# out_kind:     the link output kind discriminator (exe / library / object)
+# ext_paths:    the external static link-input paths
+# ext_count:    number of external paths
+# sonames:      the dynamic-dependency soname ids
+# soname_count: number of sonames
+# ret:          true on success, or the first error
+pub fun set_link_config_input(p: *Project, out_path: *u8, product: *u8, out_kind: u32,
+                              ext_paths: **u8, ext_count: u32,
+                              sonames: *intern.StrId, soname_count: u32) R.Result[bool, str] {
+    var fb: FpBuf;
+    fb.alloc = p.s.alloc;
+    fb.buf   = nil;
+    fb.len   = 0;
+    fb.cap   = 0;
+
+    val w: R.Result[bool, str] = write_link_config(?fb, p, out_path, product, out_kind, ext_paths, ext_count, sonames, soname_count);
+    if (R.is_err[bool, str](w)) {
+        if (fb.buf != nil && fb.cap > 0) { A.deallocate[u8](p.s.alloc, fb.buf, fb.cap::usize); }
+        ret w;
+    }
+
+    val si: R.Result[bool, str] = query.set_input(?p.s.queries, query.Q_LINK_CONFIG, 0, fb.buf, fb.len);
+    if (fb.buf != nil && fb.cap > 0) { A.deallocate[u8](p.s.alloc, fb.buf, fb.cap::usize); }
+    ret si;
+}
+
+# append the link-only configuration bytes into `fb` in a stable order. every input
+# that can change the linked binary without changing a module's object appears here,
+# so a change to any of them advances Q_LINK_CONFIG and re-links.
+fun write_link_config(fb: *FpBuf, p: *Project, out_path: *u8, product: *u8, out_kind: u32,
+                      ext_paths: **u8, ext_count: u32,
+                      sonames: *intern.StrId, soname_count: u32) R.Result[bool, str] {
+    val a0: R.Result[bool, str] = fp_u32(fb, out_kind);            if (R.is_err[bool, str](a0)) { ret a0; }
+    var pie_axis: u32 = 0;
+    if (p.s.pie) { pie_axis = 1; }
+    val a1: R.Result[bool, str] = fp_u32(fb, pie_axis);            if (R.is_err[bool, str](a1)) { ret a1; }
+    val a2: R.Result[bool, str] = fp_cstr(fb, out_path);           if (R.is_err[bool, str](a2)) { ret a2; }
+    val a3: R.Result[bool, str] = fp_cstr(fb, product);            if (R.is_err[bool, str](a3)) { ret a3; }
+
+    val a4: R.Result[bool, str] = fp_u32(fb, ext_count);           if (R.is_err[bool, str](a4)) { ret a4; }
+    var i: u32 = 0;
+    for (i < ext_count) {
+        val ap: R.Result[bool, str] = fp_cstr(fb, ext_paths[i]);  if (R.is_err[bool, str](ap)) { ret ap; }
+        i = i + 1;
+    }
+    val a5: R.Result[bool, str] = fp_u32(fb, soname_count);        if (R.is_err[bool, str](a5)) { ret a5; }
+    var j: u32 = 0;
+    for (j < soname_count) {
+        val as: R.Result[bool, str] = fp_u32(fb, sonames[j]::u32); if (R.is_err[bool, str](as)) { ret as; }
+        j = j + 1;
+    }
+    ret R.ok[bool, str](true);
+}
+
+# compute the project's link fingerprint through Q_LINK and report whether the link
+# must re-run
+#
+# Records Q_LINK's dependency graph (Q_TARGET, Q_LINK_CONFIG, and every module's
+# Q_CODEGEN) and folds each dependency's revision into the entry's value, so
+# Q_LINK's last_changed advances iff a link input changed. The prior entry's
+# revision is peeked before the demand, so a fresh (cold-cache) or invalidated entry
+# reports "re-link needed" and an unchanged one reports "reuse". Q_CODEGEN must have
+# run first (the compute reads each module's object revision). set_link_config_input
+# must have set Q_LINK_CONFIG for this build.
+# ---
+# p:   the active project; its topo order drives the link set
+# ret: true when the link must re-run, false when the prior link is still valid, or
+#      the first error
+pub fun run_link_pass(p: *Project) R.Result[bool, str] {
+    session.set_active_project(p.s, p::ptr);
+
+    val prior: query.Revision = query.peek_revision(?p.s.queries, query.Q_LINK, 0);
+    val e_r: R.Result[*query.QueryEntry, str] = query.get(?p.s.queries, query.Q_LINK, 0);
+    session.set_active_project(p.s, nil);
+    if (R.is_err[*query.QueryEntry, str](e_r)) { ret R.err[bool, str](R.unwrap_err[*query.QueryEntry, str](e_r)); }
+    val now: query.Revision = R.unwrap_ok[*query.QueryEntry, str](e_r).last_changed;
+    ret R.ok[bool, str](now != prior);
+}
+
+# the Q_LINK derived compute - fold the revision of every link input into a
+# fingerprint whose change signals a needed re-link. reaches the per-build module
+# graph through the session's active Project, and records the deps that make the
+# entry incremental:
+#   - Q_TARGET:            a target/profile/pie change re-links (it also re-codegens
+#                          every module, so it is covered twice - deliberately);
+#   - Q_LINK_CONFIG:       a link-only change (output path, product, external inputs)
+#                          re-links even when every object is unchanged;
+#   - Q_CODEGEN(module) for every module in the link set: a changed object re-links.
+# the value is the ordered tuple of those revisions, so an unchanged set of inputs
+# reproduces identical bytes (early cutoff: the link is reused).
+fun q_link_compute(db: *query.QueryDb, key: u64, alloc: *A.Allocator) R.Result[query.QueryOutput, str] {
+    val s: *session.Session = db.ctx::*session.Session;
+    if (s == nil) { ret R.err[query.QueryOutput, str]("Q_LINK: query db has no session context"); }
+    val pp: ptr = session.active_project(s);
+    if (pp == nil) { ret R.err[query.QueryOutput, str]("Q_LINK: no active project for the link pass"); }
+    val p: *Project = pp::*Project;
+
+    var fb: FpBuf;
+    fb.alloc = alloc;
+    fb.buf   = nil;
+    fb.len   = 0;
+    fb.cap   = 0;
+
+    val rt: R.Result[bool, str] = query.record_dep(db, query.Q_LINK, key, query.Q_TARGET, 0);
+    if (R.is_err[bool, str](rt)) { ret link_fp_fail(?fb, alloc, R.unwrap_err[bool, str](rt)); }
+    val wt: R.Result[bool, str] = fp_u64(?fb, query.peek_revision(db, query.Q_TARGET, 0));
+    if (R.is_err[bool, str](wt)) { ret link_fp_fail(?fb, alloc, R.unwrap_err[bool, str](wt)); }
+
+    val rc: R.Result[bool, str] = query.record_dep(db, query.Q_LINK, key, query.Q_LINK_CONFIG, 0);
+    if (R.is_err[bool, str](rc)) { ret link_fp_fail(?fb, alloc, R.unwrap_err[bool, str](rc)); }
+    val wc: R.Result[bool, str] = fp_u64(?fb, query.peek_revision(db, query.Q_LINK_CONFIG, 0));
+    if (R.is_err[bool, str](wc)) { ret link_fp_fail(?fb, alloc, R.unwrap_err[bool, str](wc)); }
+
+    val wn: R.Result[bool, str] = fp_u32(?fb, p.topo_len);
+    if (R.is_err[bool, str](wn)) { ret link_fp_fail(?fb, alloc, R.unwrap_err[bool, str](wn)); }
+    var i: u32 = 0;
+    for (i < p.topo_len) {
+        val m: *ModuleEntry = ?p.modules[(p.topo[i])::u32];
+        val rd: R.Result[bool, str] = query.record_dep(db, query.Q_LINK, key, query.Q_CODEGEN, m.stable_id::u64);
+        if (R.is_err[bool, str](rd)) { ret link_fp_fail(?fb, alloc, R.unwrap_err[bool, str](rd)); }
+        val wm: R.Result[bool, str] = fp_u64(?fb, query.peek_revision(db, query.Q_CODEGEN, m.stable_id::u64));
+        if (R.is_err[bool, str](wm)) { ret link_fp_fail(?fb, alloc, R.unwrap_err[bool, str](wm)); }
+        i = i + 1;
+    }
+
+    var out: query.QueryOutput;
+    out.bytes = fb.buf;
+    out.len   = fb.len;
+    ret R.ok[query.QueryOutput, str](out);
+}
+
+# release a partially-built link fingerprint buffer and wrap the error.
+fun link_fp_fail(fb: *FpBuf, alloc: *A.Allocator, msg: str) R.Result[query.QueryOutput, str] {
+    if (fb.buf != nil && fb.cap > 0) { A.deallocate[u8](alloc, fb.buf, fb.cap::usize); }
+    ret R.err[query.QueryOutput, str](msg);
+}
+
+# append a u64 to the fingerprint as two u32 halves (the FpBuf primitives are u8 /
+# u32 only).
+fun fp_u64(b: *FpBuf, v: u64) R.Result[bool, str] {
+    val lo: R.Result[bool, str] = fp_u32(b, (v & 0xFFFFFFFF)::u32);
+    if (R.is_err[bool, str](lo)) { ret lo; }
+    ret fp_u32(b, (v >> 32)::u32);
+}
+
+# append a nil-terminated string to the fingerprint as a length prefix plus its
+# bytes; a nil pointer contributes a zero length.
+fun fp_cstr(b: *FpBuf, s: *u8) R.Result[bool, str] {
+    if (s == nil) { ret fp_u32(b, 0); }
+    val n: u32 = str_len(s::str)::u32;
+    val rl: R.Result[bool, str] = fp_u32(b, n);
+    if (R.is_err[bool, str](rl)) { ret rl; }
+    var i: u32 = 0;
+    for (i < n) {
+        val rb: R.Result[bool, str] = fp_u8(b, s[i]);
+        if (R.is_err[bool, str](rb)) { ret rb; }
+        i = i + 1;
+    }
+    ret R.ok[bool, str](true);
 }
 
 # append the typed pub surface of module `mid` to the fingerprint.
@@ -5851,6 +6029,15 @@ fun ut_codegen_lc(s: *session.Session, stable: session.StableModuleId) query.Rev
     ret R.unwrap_ok[*query.QueryEntry, str](e).last_changed;
 }
 
+# the last_changed revision of the project's Q_LINK entry on session `s`, or a
+# sentinel when absent. Q_LINK's value folds its inputs' revisions, so an unchanged
+# value means no link input changed - the link reuse probe (#1618).
+fun ut_link_lc(s: *session.Session) query.Revision {
+    val e: R.Result[*query.QueryEntry, str] = query.get(?s.queries, query.Q_LINK, 0);
+    if (R.is_err[*query.QueryEntry, str](e)) { ret 0xFFFFFFFFFFFFFFFF; }
+    ret R.unwrap_ok[*query.QueryEntry, str](e).last_changed;
+}
+
 # whether two ModuleIds name the same module by FQN text
 # across two sessions. an anonymous nominal's origin is MODULE_NIL in both; the test
 # fixtures use only named records, so two MODULE_NIL origins (with a matched decl
@@ -6504,6 +6691,108 @@ test "mach.lang.driver:incremental_codegen_reuse_and_recompute" {
     if (ut_codegen_lc(?sA, st_a) == cg_a_1) { bad = 1; }
     if (ut_codegen_lc(?sA, st_b) != cg_b_1) { bad = 1; }
     dnit_project(?p3);
+
+    filesystem.remove_all(?alloc, root);
+    session.dnit(?sA);
+    ret bad;
+}
+
+# build + sema + lower + codegen a scaffolded project on session `s`, returning the
+# Project (caller dnit_project's it). drives repeated back-half builds on one
+# long-lived session for the link incremental test.
+fun ut_back_half(s: *session.Session, root: str) R.Result[Project, str] {
+    val pr: R.Result[Project, str] = build_project_union(s, root);
+    if (R.is_err[Project, str](pr)) { ret pr; }
+    var p: Project = R.unwrap_ok[Project, str](pr);
+    val rs: R.Result[bool, str] = run_sema_pass(?p);
+    if (R.is_err[bool, str](rs)) { dnit_project(?p); ret R.err[Project, str](R.unwrap_err[bool, str](rs)); }
+    val rl: R.Result[bool, str] = run_lower_pass(?p);
+    if (R.is_err[bool, str](rl)) { dnit_project(?p); ret R.err[Project, str](R.unwrap_err[bool, str](rl)); }
+    val rc: R.Result[bool, str] = run_codegen_pass(?p);
+    if (R.is_err[bool, str](rc)) { dnit_project(?p); ret R.err[Project, str](R.unwrap_err[bool, str](rc)); }
+    ret R.ok[Project, str](p);
+}
+
+# driver incremental: Q_LINK reuses the link on a no-change rebuild, re-links when a
+# module's object changes, and re-links on a link-only config change (a different
+# output path) even when every object is reused - the fingerprint-completeness pin
+# (#1618).
+test "mach.lang.driver:incremental_link_reuse_and_fingerprint" {
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    val sr: R.Result[session.Session, str] = session.init(?alloc);
+    if (R.is_err[session.Session, str](sr)) { ret 1; }
+    var sA: session.Session = R.unwrap_ok[session.Session, str](sr);
+    if (R.is_err[bool, str](setup_registry(?sA.registry))) { session.dnit(?sA); ret 1; }
+
+    var names: [3]str;
+    names[0] = "main.mach"; names[1] = "a.mach"; names[2] = "b.mach";
+    var texts: [3]str;
+    texts[0] = "use uniontest.a.fa;\nuse uniontest.b.fb;\nfun main() i32 { ret fa() + fb(); }\n";
+    texts[1] = "pub fun fa() i32 { ret 1; }\n";
+    texts[2] = "pub fun fb() i32 { ret 2; }\n";
+    val root_r: R.Result[str, str] = ut_scaffold(?alloc, ?names[0], ?texts[0], 3);
+    if (R.is_err[str, str](root_r)) { session.dnit(?sA); ret 1; }
+    val root: str = R.unwrap_ok[str, str](root_r);
+
+    var bad: i32 = 0;
+
+    # build 1: config C1. a cold-cache Q_LINK entry reports "re-link needed".
+    val p1r: R.Result[Project, str] = ut_back_half(?sA, root);
+    if (R.is_err[Project, str](p1r)) { filesystem.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
+    var p1: Project = R.unwrap_ok[Project, str](p1r);
+    val st_a: session.StableModuleId = ut_stable(?p1, ?sA, "uniontest.a");
+    if (R.is_err[bool, str](set_link_config_input(?p1, "out/app"::*u8, "app"::*u8, 0, nil, 0, nil, 0))) { dnit_project(?p1); filesystem.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
+    val r1: R.Result[bool, str] = run_link_pass(?p1);
+    if (R.is_err[bool, str](r1)) { dnit_project(?p1); filesystem.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
+    if (!R.unwrap_ok[bool, str](r1)) { bad = 1; }
+    val lk1: query.Revision = ut_link_lc(?sA);
+    dnit_project(?p1);
+
+    # build 2: no edit, config C1. every link input unchanged -> reuse.
+    val p2r: R.Result[Project, str] = ut_back_half(?sA, root);
+    if (R.is_err[Project, str](p2r)) { filesystem.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
+    var p2: Project = R.unwrap_ok[Project, str](p2r);
+    if (R.is_err[bool, str](set_link_config_input(?p2, "out/app"::*u8, "app"::*u8, 0, nil, 0, nil, 0))) { dnit_project(?p2); filesystem.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
+    val r2: R.Result[bool, str] = run_link_pass(?p2);
+    if (R.is_err[bool, str](r2)) { dnit_project(?p2); filesystem.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
+    if (R.unwrap_ok[bool, str](r2)) { bad = 1; }
+    val lk2: query.Revision = ut_link_lc(?sA);
+    if (lk2 != lk1) { bad = 1; }
+    dnit_project(?p2);
+
+    # build 3: edit a's body, config C1. a's object changed -> re-link.
+    val src_dir: str = ut_cc3(?alloc, root, "/", "src");
+    val a_path:  str = ut_cc3(?alloc, src_dir, "/", "a.mach");
+    val a_v2:    str = "pub fun fa() i32 { val t: i32 = 1; ret t; }\n";
+    if (R.is_err[bool, str](filesystem.write_file(a_path, a_v2, str_len(a_v2), 420))) { filesystem.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
+
+    val p3r: R.Result[Project, str] = ut_back_half(?sA, root);
+    if (R.is_err[Project, str](p3r)) { filesystem.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
+    var p3: Project = R.unwrap_ok[Project, str](p3r);
+    if (R.is_err[bool, str](set_link_config_input(?p3, "out/app"::*u8, "app"::*u8, 0, nil, 0, nil, 0))) { dnit_project(?p3); filesystem.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
+    val r3: R.Result[bool, str] = run_link_pass(?p3);
+    if (R.is_err[bool, str](r3)) { dnit_project(?p3); filesystem.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
+    if (!R.unwrap_ok[bool, str](r3)) { bad = 1; }
+    val lk3: query.Revision = ut_link_lc(?sA);
+    if (lk3 == lk2) { bad = 1; }
+    dnit_project(?p3);
+
+    # build 4: no source edit, but a link-only config change (different output path)
+    # with every object reused -> re-link STILL fires. the fingerprint-completeness
+    # pin: a's Q_CODEGEN is unchanged, yet Q_LINK advances.
+    val p4r: R.Result[Project, str] = ut_back_half(?sA, root);
+    if (R.is_err[Project, str](p4r)) { filesystem.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
+    var p4: Project = R.unwrap_ok[Project, str](p4r);
+    val cg_a_before: query.Revision = ut_codegen_lc(?sA, st_a);
+    if (R.is_err[bool, str](set_link_config_input(?p4, "out/other"::*u8, "app"::*u8, 0, nil, 0, nil, 0))) { dnit_project(?p4); filesystem.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
+    val r4: R.Result[bool, str] = run_link_pass(?p4);
+    if (R.is_err[bool, str](r4)) { dnit_project(?p4); filesystem.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
+    val cg_a_after: query.Revision = ut_codegen_lc(?sA, st_a);
+    if (!R.unwrap_ok[bool, str](r4))     { bad = 1; }
+    if (ut_link_lc(?sA) == lk3)          { bad = 1; }
+    if (cg_a_after != cg_a_before)       { bad = 1; }
+    dnit_project(?p4);
 
     filesystem.remove_all(?alloc, root);
     session.dnit(?sA);

--- a/src/lang/driver.mach
+++ b/src/lang/driver.mach
@@ -36,7 +36,9 @@ use O: std.types.option;
 use R: std.types.result;
 use ctime: std.chrono.time;
 
+use mach.lang.be.codegen;
 use be_linker: mach.lang.be.linker;
+use mach.lang.be.obj;
 use mach.lang.diagnostic;
 use mach.lang.fe.ast;
 use mach.lang.fe.ast.decl;
@@ -60,6 +62,7 @@ use mach.lang.session;
 use src: mach.lang.source;
 use mach.lang.target;
 use mach.lang.target.isa;
+use mach.lang.target.of;
 use mach.lang.target.os;
 use mach.lang.type;
 
@@ -231,6 +234,11 @@ pub rec PubConst {
 #                 reused across rebuilds of an unchanged module; set by
 #                 run_lower_one, nil until then. NOT freed by dnit_project - the
 #                 query DB owns it (its finalizer frees it) (#1618)
+# object_image:   borrowed pointer to this module's codegen ObjectImage, owned by
+#                 the session query DB as the Q_CODEGEN handle (keyed by stable_id)
+#                 and reused across rebuilds of an unchanged module; set by
+#                 run_codegen_one, nil until then. NOT freed by dnit_project - the
+#                 query DB owns it (its finalizer frees it) (#1618)
 # stable_id:      this module's build-stable identity (session-assigned by FQN);
 #                 unlike the discovery-order ModuleId, it survives a graph reshape,
 #                 so cross-build resolve/sema reuse remaps through it (#1579)
@@ -249,6 +257,7 @@ pub rec ModuleEntry {
     resolved:          bool;
     sema_result:       *sema.SemaResult;
     ir_module:         *ir.Module;
+    object_image:      *of.ObjectImage;
     stable_id:         session.StableModuleId;
 }
 
@@ -2175,6 +2184,7 @@ fun register_module_slot(p: *Project, fqn: intern.StrId) R.Result[session.Module
     m.resolved          = false;
     m.sema_result       = nil;
     m.ir_module         = nil;
+    m.object_image      = nil;
     p.modules[p.module_len] = m;
     p.module_len = p.module_len + 1;
 
@@ -2403,6 +2413,10 @@ fun ensure_query_pipeline(s: *session.Session) R.Result[bool, str] {
     if (!query.is_registered(?s.queries, query.Q_LOWER)) {
         val rl: R.Result[bool, str] = query.register_derived_owned(?s.queries, query.Q_LOWER, q_lower_compute, q_lower_finalize);
         if (R.is_err[bool, str](rl)) { ret rl; }
+    }
+    if (!query.is_registered(?s.queries, query.Q_CODEGEN)) {
+        val rcg: R.Result[bool, str] = query.register_derived_owned(?s.queries, query.Q_CODEGEN, q_codegen_compute, q_codegen_finalize);
+        if (R.is_err[bool, str](rcg)) { ret rcg; }
     }
     ret R.ok[bool, str](true);
 }
@@ -3979,6 +3993,134 @@ fun free_lower_closure(alloc: *A.Allocator, cl: *LowerClosure) {
     cl.list  = nil;
     cl.count = 0;
     cl.cap   = 0;
+}
+
+# codegen every module to an ObjectImage in topo order through the Q_CODEGEN query.
+# the active Project is installed on the session for the pass so the compute can
+# reach the per-build module graph. run_lower_pass must have run first (each
+# module's optimized IR is borrowed onto its ModuleEntry). the CLI compile path
+# drives this after run_lower_pass; the per-module objects and the link read the
+# borrowed images.
+# ---
+# p:   the active project; its topo order and per-build module graph drive the pass
+# ret: true once every module is codegen'd, or the first error
+pub fun run_codegen_pass(p: *Project) R.Result[bool, str] {
+    session.set_active_project(p.s, p::ptr);
+
+    readout.phase_begin(p.s.readout, readout.PH_CODEGEN);
+    var i: u32 = 0;
+    for (i < p.topo_len) {
+        val mid: session.ModuleId = p.topo[i];
+        val r: R.Result[bool, str] = run_codegen_one(p, mid);
+        if (R.is_err[bool, str](r)) {
+            session.set_active_project(p.s, nil);
+            ret r;
+        }
+        i = i + 1;
+    }
+    readout.phase_end(p.s.readout, readout.PH_CODEGEN, p.topo_len, "module", "modules");
+    session.set_active_project(p.s, nil);
+    ret R.ok[bool, str](true);
+}
+
+# fetch module `mid`'s ObjectImage through Q_CODEGEN - computed fresh when its
+# optimized IR changed, reused otherwise - and borrow it onto the ModuleEntry. the
+# image is owned by the query DB; m.object_image only points at it.
+fun run_codegen_one(p: *Project, mid: session.ModuleId) R.Result[bool, str] {
+    val m: *ModuleEntry = ?p.modules[mid::u32];
+
+    val t_item: ctime.Time = readout.item_begin(p.s.readout);
+
+    val e_r: R.Result[*query.QueryEntry, str] = query.get(?p.s.queries, query.Q_CODEGEN, m.stable_id::u64);
+    if (R.is_err[*query.QueryEntry, str](e_r)) { ret R.err[bool, str](R.unwrap_err[*query.QueryEntry, str](e_r)); }
+    val img: *of.ObjectImage = image_handle_decode(R.unwrap_ok[*query.QueryEntry, str](e_r));
+    if (img == nil) { ret R.err[bool, str]("Q_CODEGEN produced no result handle"); }
+
+    m.object_image = img;
+    readout.item(p.s.readout, readout.PH_CODEGEN, fqn_name(p, m.fqn), t_item);
+    ret R.ok[bool, str](true);
+}
+
+# the Q_CODEGEN derived compute - generate one module's object image from its
+# optimized IR and return it as an opaque owned handle. reaches the per-build module
+# graph through the session's active Project, and records the deps that make the
+# entry incremental:
+#   - Q_LOWER(module): a change to this module's optimized IR re-codegens it, so an
+#                      unchanged lowered module reuses its object (the per-module
+#                      hash-and-skip);
+#   - Q_TARGET:        a build-config change re-codegens every module.
+# emits no assembly side-channel (the `.s` debug artifact is rendered by the CLI
+# from the borrowed IR when requested).
+fun q_codegen_compute(db: *query.QueryDb, key: u64, alloc: *A.Allocator) R.Result[query.QueryOutput, str] {
+    val s: *session.Session = db.ctx::*session.Session;
+    if (s == nil) { ret R.err[query.QueryOutput, str]("Q_CODEGEN: query db has no session context"); }
+    val pp: ptr = session.active_project(s);
+    if (pp == nil) { ret R.err[query.QueryOutput, str]("Q_CODEGEN: no active project for the codegen pass"); }
+    val p: *Project = pp::*Project;
+
+    val stable: session.StableModuleId = key::u32::session.StableModuleId;
+    val mid: session.ModuleId = session.module_id_for_stable(s, stable);
+    if (mid == session.MODULE_NIL) { ret R.err[query.QueryOutput, str]("Q_CODEGEN: stable id not loaded this build"); }
+    val m: *ModuleEntry = ?p.modules[mid::u32];
+    val irmod: *ir.Module = m.ir_module;
+    if (irmod == nil) { ret R.err[query.QueryOutput, str]("Q_CODEGEN: module has no lowered IR"); }
+
+    val rl: R.Result[bool, str] = query.record_dep(db, query.Q_CODEGEN, key, query.Q_LOWER, key);
+    if (R.is_err[bool, str](rl)) { ret R.err[query.QueryOutput, str](R.unwrap_err[bool, str](rl)); }
+    val rt: R.Result[bool, str] = query.record_dep(db, query.Q_CODEGEN, key, query.Q_TARGET, 0);
+    if (R.is_err[bool, str](rt)) { ret R.err[query.QueryOutput, str](R.unwrap_err[bool, str](rt)); }
+
+    val res_cg: R.Result[of.ObjectImage, str] = codegen.codegen_module(s, ?p.target, irmod, nil);
+    if (R.is_err[of.ObjectImage, str](res_cg)) { ret R.err[query.QueryOutput, str](R.unwrap_err[of.ObjectImage, str](res_cg)); }
+    var img: of.ObjectImage = R.unwrap_ok[of.ObjectImage, str](res_cg);
+
+    val br: R.Result[*of.ObjectImage, str] = A.allocate[of.ObjectImage](alloc, 1::usize);
+    if (R.is_err[*of.ObjectImage, str](br)) {
+        obj.dnit(?img);
+        ret R.err[query.QueryOutput, str](R.unwrap_err[*of.ObjectImage, str](br));
+    }
+    val box: *of.ObjectImage = R.unwrap_ok[*of.ObjectImage, str](br);
+    box[0] = img;
+    ret image_handle_encode(alloc, box);
+}
+
+# release the ObjectImage a Q_CODEGEN handle owns, called by the engine before it
+# frees the handle buffer (on recompute, invalidate, dnit).
+fun q_codegen_finalize(value: *u8, value_len: u32, alloc: *A.Allocator) {
+    if (value == nil || value_len::usize < $size_of(ptr)) { ret; }
+    val slot: *ptr = value::ptr::*ptr;
+    val r: *of.ObjectImage = slot[0]::*of.ObjectImage;
+    if (r == nil) { ret; }
+    obj.dnit(r);
+    A.deallocate[of.ObjectImage](alloc, r, 1::usize);
+}
+
+# wrap a heap ObjectImage pointer as a pointer-sized opaque handle buffer - the
+# Q_CODEGEN query value. like the other back-half handles, the artifact lives in
+# the byte-buffer DB as a handle, never serialized.
+fun image_handle_encode(alloc: *A.Allocator, r: *of.ObjectImage) R.Result[query.QueryOutput, str] {
+    val n: u32 = $size_of(ptr)::u32;
+    val rb: R.Result[*u8, str] = A.allocate[u8](alloc, n::usize);
+    if (R.is_err[*u8, str](rb)) {
+        obj.dnit(r);
+        A.deallocate[of.ObjectImage](alloc, r, 1::usize);
+        ret R.err[query.QueryOutput, str](R.unwrap_err[*u8, str](rb));
+    }
+    val buf: *u8 = R.unwrap_ok[*u8, str](rb);
+    val slot: *ptr = buf::ptr::*ptr;
+    slot[0] = r::ptr;
+    var out: query.QueryOutput;
+    out.bytes = buf;
+    out.len   = n;
+    ret R.ok[query.QueryOutput, str](out);
+}
+
+# read the ObjectImage pointer back out of a Q_CODEGEN handle entry, or nil when
+# the entry carries no value.
+fun image_handle_decode(e: *query.QueryEntry) *of.ObjectImage {
+    if (e.value == nil || e.value_len::usize < $size_of(ptr)) { ret nil; }
+    val slot: *ptr = e.value::ptr::*ptr;
+    ret slot[0]::*of.ObjectImage;
 }
 
 # append the typed pub surface of module `mid` to the fingerprint.
@@ -5700,6 +5842,15 @@ fun ut_lower_lc(s: *session.Session, stable: session.StableModuleId) query.Revis
     ret R.unwrap_ok[*query.QueryEntry, str](e).last_changed;
 }
 
+# the last_changed revision of module `stable`'s Q_CODEGEN entry on session
+# `s`, or a sentinel when absent. an owned-handle shard never early-cuts, so an
+# unchanged value means the module was NOT re-codegen'd - the codegen reuse probe (#1618).
+fun ut_codegen_lc(s: *session.Session, stable: session.StableModuleId) query.Revision {
+    val e: R.Result[*query.QueryEntry, str] = query.get(?s.queries, query.Q_CODEGEN, stable::u64);
+    if (R.is_err[*query.QueryEntry, str](e)) { ret 0xFFFFFFFFFFFFFFFF; }
+    ret R.unwrap_ok[*query.QueryEntry, str](e).last_changed;
+}
+
 # whether two ModuleIds name the same module by FQN text
 # across two sessions. an anonymous nominal's origin is MODULE_NIL in both; the test
 # fixtures use only named records, so two MODULE_NIL origins (with a matched decl
@@ -6283,6 +6434,76 @@ test "mach.lang.driver:incremental_lower_entry_edit_reuses_dep" {
     # the edited entry re-lowered; its unedited dependency did NOT.
     if (lc_main_2 == lc_main_1) { bad = 1; }
     if (lc_leaf_2 != lc_leaf_1) { bad = 1; }
+
+    filesystem.remove_all(?alloc, root);
+    session.dnit(?sA);
+    ret bad;
+}
+
+# driver incremental: a no-change rebuild re-codegens no module (every Q_CODEGEN
+# reused), while editing a module re-codegens it and reuses an unrelated sibling -
+# the per-module codegen hash-and-skip chained off Q_LOWER (#1618).
+test "mach.lang.driver:incremental_codegen_reuse_and_recompute" {
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    val sr: R.Result[session.Session, str] = session.init(?alloc);
+    if (R.is_err[session.Session, str](sr)) { ret 1; }
+    var sA: session.Session = R.unwrap_ok[session.Session, str](sr);
+    if (R.is_err[bool, str](setup_registry(?sA.registry))) { session.dnit(?sA); ret 1; }
+
+    var names: [3]str;
+    names[0] = "main.mach"; names[1] = "a.mach"; names[2] = "b.mach";
+    var texts: [3]str;
+    texts[0] = "use uniontest.a.fa;\nuse uniontest.b.fb;\nfun main() i32 { ret fa() + fb(); }\n";
+    texts[1] = "pub fun fa() i32 { ret 1; }\n";
+    texts[2] = "pub fun fb() i32 { ret 2; }\n";
+    val root_r: R.Result[str, str] = ut_scaffold(?alloc, ?names[0], ?texts[0], 3);
+    if (R.is_err[str, str](root_r)) { session.dnit(?sA); ret 1; }
+    val root: str = R.unwrap_ok[str, str](root_r);
+
+    var bad: i32 = 0;
+
+    val p1r: R.Result[Project, str] = build_project_union(?sA, root);
+    if (R.is_err[Project, str](p1r)) { filesystem.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
+    var p1: Project = R.unwrap_ok[Project, str](p1r);
+    if (R.is_err[bool, str](run_sema_pass(?p1)))    { dnit_project(?p1); filesystem.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
+    if (R.is_err[bool, str](run_lower_pass(?p1)))   { dnit_project(?p1); filesystem.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
+    if (R.is_err[bool, str](run_codegen_pass(?p1))) { dnit_project(?p1); filesystem.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
+    val st_main: session.StableModuleId = ut_stable(?p1, ?sA, "uniontest.main");
+    val st_a:    session.StableModuleId = ut_stable(?p1, ?sA, "uniontest.a");
+    val st_b:    session.StableModuleId = ut_stable(?p1, ?sA, "uniontest.b");
+    val cg_main_1: query.Revision = ut_codegen_lc(?sA, st_main);
+    val cg_a_1:    query.Revision = ut_codegen_lc(?sA, st_a);
+    val cg_b_1:    query.Revision = ut_codegen_lc(?sA, st_b);
+    dnit_project(?p1);
+
+    # build 2: no edit. every module's Q_CODEGEN must be reused.
+    val p2r: R.Result[Project, str] = build_project_union(?sA, root);
+    if (R.is_err[Project, str](p2r)) { filesystem.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
+    var p2: Project = R.unwrap_ok[Project, str](p2r);
+    if (R.is_err[bool, str](run_sema_pass(?p2)))    { dnit_project(?p2); filesystem.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
+    if (R.is_err[bool, str](run_lower_pass(?p2)))   { dnit_project(?p2); filesystem.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
+    if (R.is_err[bool, str](run_codegen_pass(?p2))) { dnit_project(?p2); filesystem.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
+    if (ut_codegen_lc(?sA, st_main) != cg_main_1) { bad = 1; }
+    if (ut_codegen_lc(?sA, st_a)    != cg_a_1)    { bad = 1; }
+    if (ut_codegen_lc(?sA, st_b)    != cg_b_1)    { bad = 1; }
+    dnit_project(?p2);
+
+    # build 3: edit a's body. a re-codegens (its IR changed); b is reused.
+    val src_dir: str = ut_cc3(?alloc, root, "/", "src");
+    val a_path:  str = ut_cc3(?alloc, src_dir, "/", "a.mach");
+    val a_v2:    str = "pub fun fa() i32 { val t: i32 = 1; ret t; }\n";
+    if (R.is_err[bool, str](filesystem.write_file(a_path, a_v2, str_len(a_v2), 420))) { filesystem.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
+
+    val p3r: R.Result[Project, str] = build_project_union(?sA, root);
+    if (R.is_err[Project, str](p3r)) { filesystem.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
+    var p3: Project = R.unwrap_ok[Project, str](p3r);
+    if (R.is_err[bool, str](run_sema_pass(?p3)))    { dnit_project(?p3); filesystem.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
+    if (R.is_err[bool, str](run_lower_pass(?p3)))   { dnit_project(?p3); filesystem.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
+    if (R.is_err[bool, str](run_codegen_pass(?p3))) { dnit_project(?p3); filesystem.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
+    if (ut_codegen_lc(?sA, st_a) == cg_a_1) { bad = 1; }
+    if (ut_codegen_lc(?sA, st_b) != cg_b_1) { bad = 1; }
+    dnit_project(?p3);
 
     filesystem.remove_all(?alloc, root);
     session.dnit(?sA);

--- a/src/lang/driver.mach
+++ b/src/lang/driver.mach
@@ -12,6 +12,7 @@
 
 use std.allocator.page;
 use std.collections.map;
+use std.crypto.hash.sha256;
 use std.data.toml;
 use std.filesystem;
 use std.memory;
@@ -3780,6 +3781,17 @@ rec LowerClosure {
 pub fun run_lower_pass(p: *Project) R.Result[bool, str] {
     session.set_active_project(p.s, p::ptr);
 
+    # publish the lowering diagnostic flags (the IR-verifier toggle) so a change to
+    # them re-lowers; set_input's early-cutoff leaves the input untouched when they
+    # are unchanged, so an unedited module's Q_LOWER stays reused.
+    var vflag: u8 = 0;
+    if (p.verify_ir) { vflag = 1; }
+    val vf: R.Result[bool, str] = query.set_input(?p.s.queries, query.Q_LOWER_FLAGS, 0, ?vflag, 1);
+    if (R.is_err[bool, str](vf)) {
+        session.set_active_project(p.s, nil);
+        ret vf;
+    }
+
     readout.phase_begin(p.s.readout, readout.PH_LOWER);
     var i: u32 = 0;
     for (i < p.topo_len) {
@@ -3820,6 +3832,7 @@ fun run_lower_one(p: *Project, mid: session.ModuleId) R.Result[bool, str] {
 # active Project, and records the deps that make the entry incremental:
 #   - Q_SEMA(module):  a change to this module's typing re-lowers it;
 #   - Q_TARGET:        a build-config change re-lowers every module;
+#   - Q_LOWER_FLAGS:   the IR-verifier toggle re-lowers (re-runs the verifier);
 #   - Q_SEMA(dep) for every module in this module's TRANSITIVE import closure: a
 #     generic/comptime instance declared in another module is monomorphized into
 #     THIS module's IR, so a change to that module's typing (including a private
@@ -3847,6 +3860,11 @@ fun q_lower_compute(db: *query.QueryDb, key: u64, alloc: *A.Allocator) R.Result[
     if (R.is_err[bool, str](rsd)) { ret R.err[query.QueryOutput, str](R.unwrap_err[bool, str](rsd)); }
     val rt: R.Result[bool, str] = query.record_dep(db, query.Q_LOWER, key, query.Q_TARGET, 0);
     if (R.is_err[bool, str](rt)) { ret R.err[query.QueryOutput, str](R.unwrap_err[bool, str](rt)); }
+    # the IR-verifier toggle changes what lowering DOES (whether it runs the verifier
+    # after each optimization pass), so a toggle must re-lower even when the typed
+    # inputs are unchanged.
+    val rvf: R.Result[bool, str] = query.record_dep(db, query.Q_LOWER, key, query.Q_LOWER_FLAGS, 0);
+    if (R.is_err[bool, str](rvf)) { ret R.err[query.QueryOutput, str](R.unwrap_err[bool, str](rvf)); }
 
     # record a dep on Q_SEMA of every module whose typing can feed this module's
     # lowered IR (its transitive import closure). those Q_SEMA entries are all
@@ -4179,10 +4197,19 @@ fun write_link_config(fb: *FpBuf, p: *Project, out_path: *u8, product: *u8, out_
     val a2: R.Result[bool, str] = fp_cstr(fb, out_path);           if (R.is_err[bool, str](a2)) { ret a2; }
     val a3: R.Result[bool, str] = fp_cstr(fb, product);            if (R.is_err[bool, str](a3)) { ret a3; }
 
+    # each static external input (a `.o` / `.a` baked into the output) is folded by
+    # PATH and by CONTENT: a same-path rebuild of a vendored archive changes the
+    # output binary, so its content must invalidate. mirrors the front half, which
+    # fingerprints a source file by its full text (Q_FILE_TEXT); the link folds a
+    # sha256 of the content instead of the raw bytes, since a static archive can be
+    # large. sonames below are DYNAMIC deps (DT_NEEDED, loaded at run time, not baked
+    # in), so they are fingerprinted by identity only - their content never changes
+    # this binary.
     val a4: R.Result[bool, str] = fp_u32(fb, ext_count);           if (R.is_err[bool, str](a4)) { ret a4; }
     var i: u32 = 0;
     for (i < ext_count) {
-        val ap: R.Result[bool, str] = fp_cstr(fb, ext_paths[i]);  if (R.is_err[bool, str](ap)) { ret ap; }
+        val ap: R.Result[bool, str] = fp_cstr(fb, ext_paths[i]);          if (R.is_err[bool, str](ap)) { ret ap; }
+        val ah: R.Result[bool, str] = fp_file_content(fb, p.s.alloc, ext_paths[i]); if (R.is_err[bool, str](ah)) { ret ah; }
         i = i + 1;
     }
     val a5: R.Result[bool, str] = fp_u32(fb, soname_count);        if (R.is_err[bool, str](a5)) { ret a5; }
@@ -4190,6 +4217,34 @@ fun write_link_config(fb: *FpBuf, p: *Project, out_path: *u8, product: *u8, out_
     for (j < soname_count) {
         val as: R.Result[bool, str] = fp_u32(fb, sonames[j]::u32); if (R.is_err[bool, str](as)) { ret as; }
         j = j + 1;
+    }
+    ret R.ok[bool, str](true);
+}
+
+# append the sha256 content hash of the file at `path` to the fingerprint (a length
+# prefix plus the 32 digest bytes); a nil path contributes a zero length. reads the
+# whole file into `alloc` and frees it. a read failure is a hard error - the caller
+# resolved this path to an existing file, so a failure to read it must fail the
+# build rather than silently elide the input from the fingerprint.
+fun fp_file_content(fb: *FpBuf, alloc: *A.Allocator, path: *u8) R.Result[bool, str] {
+    if (path == nil) { ret fp_u32(fb, 0); }
+    val rr: R.Result[filesystem.Buffer, str] = filesystem.read_all_sized(alloc, path::str);
+    if (R.is_err[filesystem.Buffer, str](rr)) {
+        ret R.err[bool, str](R.unwrap_err[filesystem.Buffer, str](rr));
+    }
+    var buf: filesystem.Buffer = R.unwrap_ok[filesystem.Buffer, str](rr);
+    var digest: [32]u8;
+    sha256.hash(buf.data, buf.len, ?digest[0]);
+    # read_all_sized over-allocates by one NUL byte.
+    A.deallocate[u8](alloc, buf.data, (buf.len + 1)::usize);
+
+    val rl: R.Result[bool, str] = fp_u32(fb, sha256.DIGEST_SIZE::u32);
+    if (R.is_err[bool, str](rl)) { ret rl; }
+    var i: u32 = 0;
+    for (i < sha256.DIGEST_SIZE::u32) {
+        val rb: R.Result[bool, str] = fp_u8(fb, digest[i]);
+        if (R.is_err[bool, str](rb)) { ret rb; }
+        i = i + 1;
     }
     ret R.ok[bool, str](true);
 }
@@ -4243,14 +4298,17 @@ fun q_link_compute(db: *query.QueryDb, key: u64, alloc: *A.Allocator) R.Result[q
     fb.len   = 0;
     fb.cap   = 0;
 
-    val rt: R.Result[bool, str] = query.record_dep(db, query.Q_LINK, key, query.Q_TARGET, 0);
-    if (R.is_err[bool, str](rt)) { ret link_fp_fail(?fb, alloc, R.unwrap_err[bool, str](rt)); }
-    val wt: R.Result[bool, str] = fp_u64(?fb, query.peek_revision(db, query.Q_TARGET, 0));
+    # record_dep_rev records the dep AND returns the revision it captured, so each
+    # dependency is scanned once (not once to record, once to peek) - the link fold
+    # is the shipping cold-build path, so this halves its shard scans.
+    val rt: R.Result[query.Revision, str] = query.record_dep_rev(db, query.Q_LINK, key, query.Q_TARGET, 0);
+    if (R.is_err[query.Revision, str](rt)) { ret link_fp_fail(?fb, alloc, R.unwrap_err[query.Revision, str](rt)); }
+    val wt: R.Result[bool, str] = fp_u64(?fb, R.unwrap_ok[query.Revision, str](rt));
     if (R.is_err[bool, str](wt)) { ret link_fp_fail(?fb, alloc, R.unwrap_err[bool, str](wt)); }
 
-    val rc: R.Result[bool, str] = query.record_dep(db, query.Q_LINK, key, query.Q_LINK_CONFIG, 0);
-    if (R.is_err[bool, str](rc)) { ret link_fp_fail(?fb, alloc, R.unwrap_err[bool, str](rc)); }
-    val wc: R.Result[bool, str] = fp_u64(?fb, query.peek_revision(db, query.Q_LINK_CONFIG, 0));
+    val rc: R.Result[query.Revision, str] = query.record_dep_rev(db, query.Q_LINK, key, query.Q_LINK_CONFIG, 0);
+    if (R.is_err[query.Revision, str](rc)) { ret link_fp_fail(?fb, alloc, R.unwrap_err[query.Revision, str](rc)); }
+    val wc: R.Result[bool, str] = fp_u64(?fb, R.unwrap_ok[query.Revision, str](rc));
     if (R.is_err[bool, str](wc)) { ret link_fp_fail(?fb, alloc, R.unwrap_err[bool, str](wc)); }
 
     val wn: R.Result[bool, str] = fp_u32(?fb, p.topo_len);
@@ -4258,9 +4316,9 @@ fun q_link_compute(db: *query.QueryDb, key: u64, alloc: *A.Allocator) R.Result[q
     var i: u32 = 0;
     for (i < p.topo_len) {
         val m: *ModuleEntry = ?p.modules[(p.topo[i])::u32];
-        val rd: R.Result[bool, str] = query.record_dep(db, query.Q_LINK, key, query.Q_CODEGEN, m.stable_id::u64);
-        if (R.is_err[bool, str](rd)) { ret link_fp_fail(?fb, alloc, R.unwrap_err[bool, str](rd)); }
-        val wm: R.Result[bool, str] = fp_u64(?fb, query.peek_revision(db, query.Q_CODEGEN, m.stable_id::u64));
+        val rd: R.Result[query.Revision, str] = query.record_dep_rev(db, query.Q_LINK, key, query.Q_CODEGEN, m.stable_id::u64);
+        if (R.is_err[query.Revision, str](rd)) { ret link_fp_fail(?fb, alloc, R.unwrap_err[query.Revision, str](rd)); }
+        val wm: R.Result[bool, str] = fp_u64(?fb, R.unwrap_ok[query.Revision, str](rd));
         if (R.is_err[bool, str](wm)) { ret link_fp_fail(?fb, alloc, R.unwrap_err[bool, str](wm)); }
         i = i + 1;
     }
@@ -6741,7 +6799,9 @@ test "mach.lang.driver:incremental_link_reuse_and_fingerprint" {
     val p1r: R.Result[Project, str] = ut_back_half(?sA, root);
     if (R.is_err[Project, str](p1r)) { filesystem.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
     var p1: Project = R.unwrap_ok[Project, str](p1r);
-    val st_a: session.StableModuleId = ut_stable(?p1, ?sA, "uniontest.a");
+    val st_a:    session.StableModuleId = ut_stable(?p1, ?sA, "uniontest.a");
+    val st_b:    session.StableModuleId = ut_stable(?p1, ?sA, "uniontest.b");
+    val st_main: session.StableModuleId = ut_stable(?p1, ?sA, "uniontest.main");
     if (R.is_err[bool, str](set_link_config_input(?p1, "out/app"::*u8, "app"::*u8, 0, nil, 0, nil, 0))) { dnit_project(?p1); filesystem.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
     val r1: R.Result[bool, str] = run_link_pass(?p1);
     if (R.is_err[bool, str](r1)) { dnit_project(?p1); filesystem.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
@@ -6784,15 +6844,177 @@ test "mach.lang.driver:incremental_link_reuse_and_fingerprint" {
     val p4r: R.Result[Project, str] = ut_back_half(?sA, root);
     if (R.is_err[Project, str](p4r)) { filesystem.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
     var p4: Project = R.unwrap_ok[Project, str](p4r);
-    val cg_a_before: query.Revision = ut_codegen_lc(?sA, st_a);
+    val cg_a_before:    query.Revision = ut_codegen_lc(?sA, st_a);
+    val cg_b_before:    query.Revision = ut_codegen_lc(?sA, st_b);
+    val cg_main_before: query.Revision = ut_codegen_lc(?sA, st_main);
     if (R.is_err[bool, str](set_link_config_input(?p4, "out/other"::*u8, "app"::*u8, 0, nil, 0, nil, 0))) { dnit_project(?p4); filesystem.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
     val r4: R.Result[bool, str] = run_link_pass(?p4);
     if (R.is_err[bool, str](r4)) { dnit_project(?p4); filesystem.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
-    val cg_a_after: query.Revision = ut_codegen_lc(?sA, st_a);
-    if (!R.unwrap_ok[bool, str](r4))     { bad = 1; }
-    if (ut_link_lc(?sA) == lk3)          { bad = 1; }
-    if (cg_a_after != cg_a_before)       { bad = 1; }
+    # every module's object is reused across a link-only config change; only Q_LINK advances.
+    if (!R.unwrap_ok[bool, str](r4))                    { bad = 1; }
+    if (ut_link_lc(?sA) == lk3)                         { bad = 1; }
+    if (ut_codegen_lc(?sA, st_a)    != cg_a_before)     { bad = 1; }
+    if (ut_codegen_lc(?sA, st_b)    != cg_b_before)     { bad = 1; }
+    if (ut_codegen_lc(?sA, st_main) != cg_main_before)  { bad = 1; }
     dnit_project(?p4);
+
+    filesystem.remove_all(?alloc, root);
+    session.dnit(?sA);
+    ret bad;
+}
+
+# driver incremental: Q_LINK re-links when an external static input's CONTENT changes
+# at the same path (not just its path), when its path changes, and when a dynamic
+# dependency (soname) is added - the external-axis completeness of the link
+# fingerprint (#1618).
+test "mach.lang.driver:incremental_link_external_content_fingerprint" {
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    val sr: R.Result[session.Session, str] = session.init(?alloc);
+    if (R.is_err[session.Session, str](sr)) { ret 1; }
+    var sA: session.Session = R.unwrap_ok[session.Session, str](sr);
+    if (R.is_err[bool, str](setup_registry(?sA.registry))) { session.dnit(?sA); ret 1; }
+
+    var names: [3]str;
+    names[0] = "main.mach"; names[1] = "a.mach"; names[2] = "b.mach";
+    var texts: [3]str;
+    texts[0] = "use uniontest.a.fa;\nuse uniontest.b.fb;\nfun main() i32 { ret fa() + fb(); }\n";
+    texts[1] = "pub fun fa() i32 { ret 1; }\n";
+    texts[2] = "pub fun fb() i32 { ret 2; }\n";
+    val root_r: R.Result[str, str] = ut_scaffold(?alloc, ?names[0], ?texts[0], 3);
+    if (R.is_err[str, str](root_r)) { session.dnit(?sA); ret 1; }
+    val root: str = R.unwrap_ok[str, str](root_r);
+
+    # an external static link input (a vendored archive) on disk.
+    val ext1: str = ut_cc3(?alloc, root, "/", "libx.a");
+    if (R.is_err[bool, str](filesystem.write_file(ext1, "AAAA", 4, 420))) { filesystem.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
+    var ext_a: [1]*u8; ext_a[0] = ext1::*u8;
+
+    var bad: i32 = 0;
+
+    # build A: ext=[ext1] (content AAAA). cold -> re-link.
+    val pAr: R.Result[Project, str] = ut_back_half(?sA, root);
+    if (R.is_err[Project, str](pAr)) { filesystem.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
+    var pA: Project = R.unwrap_ok[Project, str](pAr);
+    if (R.is_err[bool, str](set_link_config_input(?pA, "out/app"::*u8, "app"::*u8, 0, ?ext_a[0], 1, nil, 0))) { dnit_project(?pA); filesystem.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
+    val rlA: R.Result[bool, str] = run_link_pass(?pA);
+    if (R.is_err[bool, str](rlA)) { dnit_project(?pA); filesystem.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
+    if (!R.unwrap_ok[bool, str](rlA)) { bad = 1; }
+    val lkA: query.Revision = ut_link_lc(?sA);
+    dnit_project(?pA);
+
+    # build B: same ext, same content -> reuse.
+    val pBr: R.Result[Project, str] = ut_back_half(?sA, root);
+    if (R.is_err[Project, str](pBr)) { filesystem.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
+    var pB: Project = R.unwrap_ok[Project, str](pBr);
+    if (R.is_err[bool, str](set_link_config_input(?pB, "out/app"::*u8, "app"::*u8, 0, ?ext_a[0], 1, nil, 0))) { dnit_project(?pB); filesystem.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
+    val rlB: R.Result[bool, str] = run_link_pass(?pB);
+    if (R.is_err[bool, str](rlB)) { dnit_project(?pB); filesystem.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
+    if (R.unwrap_ok[bool, str](rlB)) { bad = 1; }
+    if (ut_link_lc(?sA) != lkA)      { bad = 1; }
+    dnit_project(?pB);
+
+    # build C: SAME path, DIFFERENT content -> re-link (the content-hash pin for
+    # finding 1: a same-path archive rebuild must invalidate).
+    if (R.is_err[bool, str](filesystem.write_file(ext1, "BBBB", 4, 420))) { filesystem.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
+    val pCr: R.Result[Project, str] = ut_back_half(?sA, root);
+    if (R.is_err[Project, str](pCr)) { filesystem.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
+    var pC: Project = R.unwrap_ok[Project, str](pCr);
+    if (R.is_err[bool, str](set_link_config_input(?pC, "out/app"::*u8, "app"::*u8, 0, ?ext_a[0], 1, nil, 0))) { dnit_project(?pC); filesystem.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
+    val rlC: R.Result[bool, str] = run_link_pass(?pC);
+    if (R.is_err[bool, str](rlC)) { dnit_project(?pC); filesystem.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
+    if (!R.unwrap_ok[bool, str](rlC)) { bad = 1; }
+    val lkC: query.Revision = ut_link_lc(?sA);
+    if (lkC == lkA)                   { bad = 1; }
+    dnit_project(?pC);
+
+    # build D: a DIFFERENT external path -> re-link.
+    val ext2: str = ut_cc3(?alloc, root, "/", "liby.a");
+    if (R.is_err[bool, str](filesystem.write_file(ext2, "CCCC", 4, 420))) { filesystem.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
+    var ext_b: [1]*u8; ext_b[0] = ext2::*u8;
+    val pDr: R.Result[Project, str] = ut_back_half(?sA, root);
+    if (R.is_err[Project, str](pDr)) { filesystem.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
+    var pD: Project = R.unwrap_ok[Project, str](pDr);
+    if (R.is_err[bool, str](set_link_config_input(?pD, "out/app"::*u8, "app"::*u8, 0, ?ext_b[0], 1, nil, 0))) { dnit_project(?pD); filesystem.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
+    val rlD: R.Result[bool, str] = run_link_pass(?pD);
+    if (R.is_err[bool, str](rlD)) { dnit_project(?pD); filesystem.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
+    if (!R.unwrap_ok[bool, str](rlD)) { bad = 1; }
+    val lkD: query.Revision = ut_link_lc(?sA);
+    if (lkD == lkC)                   { bad = 1; }
+    dnit_project(?pD);
+
+    # build E: add a dynamic dependency (soname) -> re-link.
+    val sn_r: R.Result[intern.StrId, str] = intern.intern(?sA.interner, "libfoo");
+    if (R.is_err[intern.StrId, str](sn_r)) { filesystem.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
+    var sn: [1]intern.StrId; sn[0] = R.unwrap_ok[intern.StrId, str](sn_r);
+    val pEr: R.Result[Project, str] = ut_back_half(?sA, root);
+    if (R.is_err[Project, str](pEr)) { filesystem.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
+    var pE: Project = R.unwrap_ok[Project, str](pEr);
+    if (R.is_err[bool, str](set_link_config_input(?pE, "out/app"::*u8, "app"::*u8, 0, ?ext_b[0], 1, ?sn[0], 1))) { dnit_project(?pE); filesystem.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
+    val rlE: R.Result[bool, str] = run_link_pass(?pE);
+    if (R.is_err[bool, str](rlE)) { dnit_project(?pE); filesystem.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
+    if (!R.unwrap_ok[bool, str](rlE)) { bad = 1; }
+    if (ut_link_lc(?sA) == lkD)       { bad = 1; }
+    dnit_project(?pE);
+
+    filesystem.remove_all(?alloc, root);
+    session.dnit(?sA);
+    ret bad;
+}
+
+# driver incremental: toggling the IR verifier on a warm session re-lowers every
+# module (so the verifier actually runs), while leaving it unchanged reuses lowering
+# - Q_LOWER_FLAGS closes the "requested verification silently skipped" hole (#1618).
+test "mach.lang.driver:incremental_lower_verify_ir_toggle_relowers" {
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    val sr: R.Result[session.Session, str] = session.init(?alloc);
+    if (R.is_err[session.Session, str](sr)) { ret 1; }
+    var sA: session.Session = R.unwrap_ok[session.Session, str](sr);
+    if (R.is_err[bool, str](setup_registry(?sA.registry))) { session.dnit(?sA); ret 1; }
+
+    var names: [2]str;
+    names[0] = "main.mach"; names[1] = "leaf.mach";
+    var texts: [2]str;
+    texts[0] = "use uniontest.leaf.fa;\nfun main() i32 { ret fa(); }\n";
+    texts[1] = "pub fun fa() i32 { ret 1; }\n";
+    val root_r: R.Result[str, str] = ut_scaffold(?alloc, ?names[0], ?texts[0], 2);
+    if (R.is_err[str, str](root_r)) { session.dnit(?sA); ret 1; }
+    val root: str = R.unwrap_ok[str, str](root_r);
+
+    var bad: i32 = 0;
+
+    # build 1: verify off (the default).
+    val p1r: R.Result[Project, str] = build_project_union(?sA, root);
+    if (R.is_err[Project, str](p1r)) { filesystem.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
+    var p1: Project = R.unwrap_ok[Project, str](p1r);
+    p1.verify_ir = false;
+    if (R.is_err[bool, str](run_sema_pass(?p1)))  { dnit_project(?p1); filesystem.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
+    if (R.is_err[bool, str](run_lower_pass(?p1))) { dnit_project(?p1); filesystem.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
+    val st_main: session.StableModuleId = ut_stable(?p1, ?sA, "uniontest.main");
+    val lc1: query.Revision = ut_lower_lc(?sA, st_main);
+    dnit_project(?p1);
+
+    # build 2: verify ON, no source edit -> re-lower (the verifier must run).
+    val p2r: R.Result[Project, str] = build_project_union(?sA, root);
+    if (R.is_err[Project, str](p2r)) { filesystem.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
+    var p2: Project = R.unwrap_ok[Project, str](p2r);
+    p2.verify_ir = true;
+    if (R.is_err[bool, str](run_sema_pass(?p2)))  { dnit_project(?p2); filesystem.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
+    if (R.is_err[bool, str](run_lower_pass(?p2))) { dnit_project(?p2); filesystem.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
+    val lc2: query.Revision = ut_lower_lc(?sA, st_main);
+    dnit_project(?p2);
+    if (lc2 == lc1) { bad = 1; }
+
+    # build 3: verify ON again, no edit -> reuse (flags unchanged).
+    val p3r: R.Result[Project, str] = build_project_union(?sA, root);
+    if (R.is_err[Project, str](p3r)) { filesystem.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
+    var p3: Project = R.unwrap_ok[Project, str](p3r);
+    p3.verify_ir = true;
+    if (R.is_err[bool, str](run_sema_pass(?p3)))  { dnit_project(?p3); filesystem.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
+    if (R.is_err[bool, str](run_lower_pass(?p3))) { dnit_project(?p3); filesystem.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
+    if (ut_lower_lc(?sA, st_main) != lc2) { bad = 1; }
+    dnit_project(?p3);
 
     filesystem.remove_all(?alloc, root);
     session.dnit(?sA);

--- a/src/lang/query.mach
+++ b/src/lang/query.mach
@@ -83,11 +83,27 @@ pub val Q_EXPORTS: QueryKind = 8;
 # because the session type interner is monotonic; a graph reshape that renumbers
 # a module's ModuleId-embedding type identities re-checks it via Q_MODULE_NUMBER.
 pub val Q_SEMA: QueryKind = 9;
-# derived: a module's optimized ir.Module, keyed on sess.ModuleId
+# derived (owned handle): a module's optimized ir.Module, keyed on
+# sess.StableModuleId so an unchanged module's lowered IR is reused across
+# rebuilds even when a graph reshape renumbers per-build ModuleIds. mangled
+# linkage names are FQN-derived, so a cached module stays valid across a reshape.
+#
+# Reads Q_SEMA(module), Q_TARGET, and Q_SEMA of every module in this module's
+# transitive import closure: a generic/comptime instance declared in another
+# module is monomorphized into THIS module's IR, so that module's typing feeds
+# this lowered output and a change there must re-lower this module (#1618).
 pub val Q_LOWER: QueryKind = 10;
-# derived: a module's of.ObjectImage, keyed on sess.ModuleId
+# derived (owned handle): a module's of.ObjectImage, keyed on sess.StableModuleId
+# so an unchanged module's codegen output is reused across rebuilds.
+#
+# Reads Q_LOWER(module) and Q_TARGET. an unchanged lowered IR reuses the cached
+# image (and its on-disk `.o`) instead of re-emitting - the per-module
+# hash-and-skip that also lets codegen run per module in parallel (#1618).
 pub val Q_CODEGEN: QueryKind = 11;
-# derived: the linked output for the project, keyed on unit
+# derived: the project's link status, keyed on unit (0).
+#
+# Reads Q_CODEGEN of every module in the project. an unchanged object set leaves
+# the entry valid so the link is skipped; any changed object re-links (#1618).
 pub val Q_LINK: QueryKind = 12;
 # derived: a byte fingerprint of a module's TYPED public surface (the resolved
 # types of its locally-declared pub symbols plus the field tables of pub

--- a/src/lang/query.mach
+++ b/src/lang/query.mach
@@ -88,10 +88,10 @@ pub val Q_SEMA: QueryKind = 9;
 # rebuilds even when a graph reshape renumbers per-build ModuleIds. mangled
 # linkage names are FQN-derived, so a cached module stays valid across a reshape.
 #
-# Reads Q_SEMA(module), Q_TARGET, and Q_SEMA of every module in this module's
-# transitive import closure: a generic/comptime instance declared in another
-# module is monomorphized into THIS module's IR, so that module's typing feeds
-# this lowered output and a change there must re-lower this module (#1618).
+# Reads Q_SEMA(module), Q_TARGET, Q_LOWER_FLAGS, and Q_SEMA of every module in this
+# module's transitive import closure: a generic/comptime instance declared in
+# another module is monomorphized into THIS module's IR, so that module's typing
+# feeds this lowered output and a change there must re-lower this module (#1618).
 pub val Q_LOWER: QueryKind = 10;
 # derived (owned handle): a module's of.ObjectImage, keyed on sess.StableModuleId
 # so an unchanged module's codegen output is reused across rebuilds.
@@ -132,10 +132,22 @@ pub val Q_MODULE_NUMBER: QueryKind = 14;
 #
 # Carries the link inputs that do NOT flow through a module's Q_CODEGEN - the
 # output path and product name, the output kind, the pie flag, and the external
-# link inputs (libraries / objects / sonames). Q_LINK depends on it so a change to
-# any of them re-links even when every module's object is unchanged; set_input's
-# early-cutoff keeps the link reused when the config is byte-identical (#1618).
+# link inputs. static external inputs (`.o` / `.a` baked into the output) are folded
+# by path AND by content hash, so a same-path rebuild of a vendored archive
+# invalidates; dynamic dependencies (sonames, loaded at run time) are folded by
+# identity. Q_LINK depends on it so a change to any of them re-links even when every
+# module's object is unchanged; set_input's early-cutoff keeps the link reused when
+# the config is byte-identical (#1618).
 pub val Q_LINK_CONFIG: QueryKind = 15;
+# input: the lowering diagnostic flags, keyed on unit (0) and set each build by the
+# driver before the lower pass.
+#
+# Carries the flags that change what lowering DOES without changing the IR it
+# produces - currently the IR-verifier toggle. Q_LOWER depends on it so a warm
+# session that cached a module with verification off re-lowers (and re-runs the
+# verifier) when a later build requests it on; set_input's early-cutoff keeps the
+# lowering reused when the flags are unchanged (#1618).
+pub val Q_LOWER_FLAGS: QueryKind = 16;
 
 # monotonic counter owned by the QueryDb, bumped on every set_input. cached
 # entries record the revision at which they were computed and the revision at
@@ -530,24 +542,38 @@ pub fun get(db: *QueryDb, kind: QueryKind, key: u64) R.Result[*QueryEntry, str] 
 # dep_key:    key that was read
 # ret:        true on success, or an allocation error from growing the dep list
 pub fun record_dep(db: *QueryDb, owner_kind: QueryKind, owner_key: u64, dep_kind: QueryKind, dep_key: u64) R.Result[bool, str] {
+    val r: R.Result[Revision, str] = record_dep_rev(db, owner_kind, owner_key, dep_kind, dep_key);
+    if (R.is_err[Revision, str](r)) { ret R.err[bool, str](R.unwrap_err[Revision, str](r)); }
+    ret R.ok[bool, str](true);
+}
+
+# record_dep, returning the dep's captured last_changed revision
+#
+# Same as record_dep, but hands back the revision it looked up for the dep, so a
+# ComputeFn that also folds that revision into its own value (Q_LINK) avoids a
+# second shard scan via peek_revision.
+# ---
+# ret: the dep's captured last_changed revision, or an allocation error
+pub fun record_dep_rev(db: *QueryDb, owner_kind: QueryKind, owner_key: u64, dep_kind: QueryKind, dep_key: u64) R.Result[Revision, str] {
     if (owner_kind::u32 >= db.kinds) {
-        ret R.err[bool, str]("record_dep: owner kind out of range");
+        ret R.err[Revision, str]("record_dep: owner kind out of range");
     }
     val sh: *QueryShard = ?db.storage[owner_kind::u32];
     val entry: *QueryEntry = entry_find(sh, owner_key);
     if (entry == nil) {
-        ret R.err[bool, str]("record_dep: owner entry not found");
+        ret R.err[Revision, str]("record_dep: owner entry not found");
     }
 
     val res_reserve: R.Result[bool, str] = deps_reserve(db, entry, 1);
-    if (R.is_err[bool, str](res_reserve)) { ret res_reserve; }
+    if (R.is_err[bool, str](res_reserve)) { ret R.err[Revision, str](R.unwrap_err[bool, str](res_reserve)); }
 
+    val rev: Revision = last_changed_get(db, dep_kind, dep_key);
     val dep: *Dep = ?entry.deps[entry.dep_len];
     dep.kind         = dep_kind;
     dep.key          = dep_key;
-    dep.last_changed = last_changed_get(db, dep_kind, dep_key);
+    dep.last_changed = rev;
     entry.dep_len = entry.dep_len + 1;
-    ret R.ok[bool, str](true);
+    ret R.ok[Revision, str](rev);
 }
 
 # the stored last_changed revision for `(kind, key)` WITHOUT validating or

--- a/src/lang/query.mach
+++ b/src/lang/query.mach
@@ -100,10 +100,14 @@ pub val Q_LOWER: QueryKind = 10;
 # image (and its on-disk `.o`) instead of re-emitting - the per-module
 # hash-and-skip that also lets codegen run per module in parallel (#1618).
 pub val Q_CODEGEN: QueryKind = 11;
-# derived: the project's link status, keyed on unit (0).
+# derived: the project's link fingerprint, keyed on unit (0).
 #
-# Reads Q_CODEGEN of every module in the project. an unchanged object set leaves
-# the entry valid so the link is skipped; any changed object re-links (#1618).
+# Reads Q_TARGET, Q_LINK_CONFIG, and Q_CODEGEN of every module in the product's
+# link set. its value folds each dependency's revision, so the entry's
+# last_changed advances iff a link input changed - an object (Q_CODEGEN), the
+# target/profile/pie (Q_TARGET), or a link-only input like the output path or an
+# external library (Q_LINK_CONFIG). run_link_pass compares this last_changed to
+# the prior build's to decide whether the link must re-run (#1618).
 pub val Q_LINK: QueryKind = 12;
 # derived: a byte fingerprint of a module's TYPED public surface (the resolved
 # types of its locally-declared pub symbols plus the field tables of pub
@@ -123,6 +127,15 @@ pub val Q_TYPED_EXPORTS: QueryKind = 13;
 # TypeIds went stale; set_input's early-cutoff leaves it untouched when the number
 # is unchanged, so a content-only edit keeps reuse valid (#1583).
 pub val Q_MODULE_NUMBER: QueryKind = 14;
+# input: the link-only build configuration, keyed on unit (0) and set each build
+# by the CLI before the link.
+#
+# Carries the link inputs that do NOT flow through a module's Q_CODEGEN - the
+# output path and product name, the output kind, the pie flag, and the external
+# link inputs (libraries / objects / sonames). Q_LINK depends on it so a change to
+# any of them re-links even when every module's object is unchanged; set_input's
+# early-cutoff keeps the link reused when the config is byte-identical (#1618).
+pub val Q_LINK_CONFIG: QueryKind = 15;
 
 # monotonic counter owned by the QueryDb, bumped on every set_input. cached
 # entries record the revision at which they were computed and the revision at
@@ -535,6 +548,22 @@ pub fun record_dep(db: *QueryDb, owner_kind: QueryKind, owner_key: u64, dep_kind
     dep.last_changed = last_changed_get(db, dep_kind, dep_key);
     entry.dep_len = entry.dep_len + 1;
     ret R.ok[bool, str](true);
+}
+
+# the stored last_changed revision for `(kind, key)` WITHOUT validating or
+# recomputing - a read-only peek at the cached state
+#
+# Returns 0 when the kind is out of range or has no stored entry. Lets a caller
+# capture an entry's revision before a `get` and compare afterward to learn whether
+# that get advanced it (the "did this input change since I last observed it" signal
+# run_link_pass uses). Metadata kinds resolve through their RevisionFn.
+# ---
+# db:   the database
+# kind: the queried kind
+# key:  the hashed key
+# ret:  the stored last_changed, or 0 when absent
+pub fun peek_revision(db: *QueryDb, kind: QueryKind, key: u64) Revision {
+    ret last_changed_get(db, kind, key);
 }
 
 # claim a shard for a kind, growing the shard array to cover that index when

--- a/src/lang/session.mach
+++ b/src/lang/session.mach
@@ -235,6 +235,12 @@ fun register_catalog(db: *query.QueryDb) R.Result[bool, str] {
     val res_link_cfg: R.Result[bool, str] = query.register_input(db, query.Q_LINK_CONFIG);
     if (R.is_err[bool, str](res_link_cfg)) { ret res_link_cfg; }
 
+    # Q_LOWER_FLAGS carries the lowering diagnostic flags (the IR-verifier toggle) so
+    # Q_LOWER re-lowers when they change; its early cutoff keeps lowering reused when
+    # they are unchanged.
+    val res_lower_flags: R.Result[bool, str] = query.register_input(db, query.Q_LOWER_FLAGS);
+    if (R.is_err[bool, str](res_lower_flags)) { ret res_lower_flags; }
+
     ret R.ok[bool, str](true);
 }
 

--- a/src/lang/session.mach
+++ b/src/lang/session.mach
@@ -229,6 +229,12 @@ fun register_catalog(db: *query.QueryDb) R.Result[bool, str] {
     val res_number: R.Result[bool, str] = query.register_input(db, query.Q_MODULE_NUMBER);
     if (R.is_err[bool, str](res_number)) { ret res_number; }
 
+    # Q_LINK_CONFIG carries the link-only build configuration (output path/product,
+    # output kind, pie, external link inputs) so Q_LINK re-links on a change to any
+    # of them; its early cutoff keeps the link reused when the config is unchanged.
+    val res_link_cfg: R.Result[bool, str] = query.register_input(db, query.Q_LINK_CONFIG);
+    if (R.is_err[bool, str](res_link_cfg)) { ret res_link_cfg; }
+
     ret R.ok[bool, str](true);
 }
 


### PR DESCRIPTION
Binds the back half of the pipeline into the incremental query engine so lowering, codegen, and link cache and parallelize per module instead of re-running every build (#1618). Keyed on `StableModuleId`; the CLI's cold-cache path is behaviour-preserving (always recomputes/links), and the reuse is proven on a long-lived session by driver tests.

## What landed
- **Catalog doc-drift fix** — `Q_LOWER`/`Q_CODEGEN`/`Q_LINK` key on `StableModuleId`.
- **`Q_LOWER`** — owned-handle optimized `ir.Module`. Deps: `Q_SEMA(module)`, `Q_TARGET`, and `Q_SEMA` of the module's **transitive import closure** (a generic/comptime instance from another module is monomorphized into this module's IR; no per-hop lowering firewall, so the full transitive closure is required for soundness). Driver `run_lower_pass`; lower+optimize collapse into one cached unit.
- **`Q_CODEGEN`** — owned-handle `of.ObjectImage`. Deps: `Q_LOWER(module)`, `Q_TARGET`. `--emit-asm` renders via a separate deterministic codegen pass (assembly is a streaming side-channel not in the cached image), so the common path stays single-pass.
- **`Q_LINK`** — derived link fingerprint keyed on unit. Folds the revision of every link input: `Q_TARGET` (target/profile/pie), the new **`Q_LINK_CONFIG`** input (link-only config — output path, product, output kind, external libs/objects/sonames), and `Q_CODEGEN` of every module. `run_link_pass` peeks the prior revision, demands the entry, and returns "re-link needed?"; the CLI (both the normal and flat-image link paths) reuses the prior artifact when unchanged. New `pub query.peek_revision`.
- The CLI routes lower/codegen/link through the driver passes; IR and images are query-owned, borrowed via shallow view arrays; `free_modules` retired.

## Verification (from-source compiler, never the seed)
- Byte-identical self-host fixpoint.
- Full unit suite: **480 passed / 0 failed** (475 baseline + 5 new incremental tests).
- int/ golden-diff harness: all cases pass on the linux leg.
- Cross-target: `linux-arm64` and `windows-x86_64` builds succeed and are byte-deterministic.
- Incremental behavior (driver tests, `last_changed`-probe style): no-change rebuild reuses lower/codegen/link; a single-module edit re-lowers/re-codegens/re-links only what it must; a link-only config change (output path) with every object reused **still** re-links (the `Q_LINK` fingerprint-completeness pin).

## Notes
- `--pie` already lives in `Q_TARGET` (it forks compilation via `$mach.build.pie`), so a `--pie` toggle re-codegens every module and re-links through the `Q_CODEGEN` deps; it is also folded into `Q_LINK_CONFIG` for completeness. The genuine link-only axis the completeness test exercises is the output path.

## Follow-ups (surfaced, being filed by the lead — not in this PR)
- Test-mode `main`-neutralization mutates the query-owned IR in place — safe on the CLI's single-shot session, latent only for a long-lived test-driving session.
- No lowered-surface fingerprint firewall yet: an impl-only edit to a dependency re-lowers importers even when their inlined slice is unchanged — the future twin of `Q_TYPED_EXPORTS`.

Closes #1618
