### PR TITLE
test(int): riscv64 self-host smoke under qemu

### DIFF
--- a/int/regression/1852-rv64-self-host/case.conf
+++ b/int/regression/1852-rv64-self-host/case.conf
@@ -1,0 +1,9 @@
+# the riscv64 self-host smoke (#1852). `self-host` builds this case with the current
+# compiler cross-built to the leg target and driven under the leg's run-mode — i.e.
+# the riscv64 compiler executing under qemu-riscv64 — then the exec producer runs the
+# artifact it emits and diffs its stdout. this is the only place the compiler itself
+# runs on riscv64 in CI; the other qemu cases only run produced binaries. release
+# profile exercises the -O2 self-host path where #1851's phi codegen defect lived.
+targets: linux-riscv64
+profiles: release
+self-host: true

--- a/int/regression/1852-rv64-self-host/expect.txt
+++ b/int/regression/1852-rv64-self-host/expect.txt
@@ -1,0 +1,2 @@
+acc=-2
+v_lt_0=true

--- a/int/regression/1852-rv64-self-host/mach.toml
+++ b/int/regression/1852-rv64-self-host/mach.toml
@@ -1,0 +1,28 @@
+[project]
+id      = "case"
+name    = "case"
+version = "0.0.0"
+src     = "src"
+dep     = "dep"
+target  = "linux-riscv64"
+out     = "out/{target}/{profile}/bin/{name}{ext}"
+
+# riscv64-only: this case is compiled by the riscv64-hosted compiler under qemu
+# (see case.conf `self-host`), so it never targets another format.
+[target.linux-riscv64]
+isa = "riscv64"
+os  = "linux"
+abi = "lp64"
+
+[profile.debug]
+opt = 0
+
+[profile.release]
+opt = 2
+
+[bin.case]
+entry = "main.mach"
+
+[deps.mach-std]
+git = "https://github.com/briar-systems/mach-std"
+ref = "branch/main"

--- a/int/regression/1852-rv64-self-host/src/main.mach
+++ b/int/regression/1852-rv64-self-host/src/main.mach
@@ -1,0 +1,27 @@
+# the multi-block input the riscv64-hosted compiler (running under qemu-riscv64)
+# must compile into a working artifact. a loop-carried i32 accumulator crossing a
+# back edge and an if/else, then a negative i32 reaching a signed compare through a
+# branch merge — the cross-block liveness the compiler could not handle on riscv64
+# before #1851. the observable is the artifact's own stdout: if the self-hosted
+# compiler is broken it either fails to emit or emits wrong code, diverging here.
+
+use std.runtime;
+use std.types.size.usize;
+use p: std.print;
+
+#[symbol("main")]
+fun main(argc: usize, argv: **u8) i64 {
+    var acc: i32 = 0;
+    var i:   i32 = 0;
+    for (i < 8) {
+        if (i < 3) { acc = acc + i; } or { acc = acc - 1; }
+        i = i + 1;
+    }
+    p.printlnf("acc={}", acc);
+
+    var v: i32 = -1;
+    if (acc > 100) { v = acc; }
+    if (v < 0) { p.println("v_lt_0=true"); } or { p.println("v_lt_0=false"); }
+
+    ret 0;
+}

--- a/int/run.sh
+++ b/int/run.sh
@@ -118,6 +118,7 @@ for dir in "$here"/surface/$filter "$here"/regression/$filter; do
     case_run=exec
     case_build_target=
     case_build_flags=
+    case_self_host=false
     if [ -f "$dir/case.conf" ]; then
         while IFS= read -r line || [ -n "$line" ]; do
             case "$line" in ''|\#*) continue ;; esac
@@ -132,6 +133,7 @@ for dir in "$here"/surface/$filter "$here"/regression/$filter; do
                 run)            case_run=$value ;;
                 build-target)   case_build_target=$value ;;
                 build-flags)    case_build_flags=$value ;;
+                self-host)      case_self_host=$value ;;
                 *) echo "run.sh: $case_id/case.conf: unknown key '$key'" >&2; exit 2 ;;
             esac
         done < "$dir/case.conf"
@@ -172,7 +174,29 @@ for dir in "$here"/surface/$filter "$here"/regression/$filter; do
         rm -rf "$dir/out/int"
         mkdir -p "$dir/out/int"
 
-        if ! (cd "$dir" && "$compiler" dep pull && "$compiler" build . --target "$build_target" --profile "$profile" $case_build_flags -o "$relbin") >"$tmp/build.log" 2>&1; then
+        # the compiler that builds the case. normally the from-source compiler
+        # itself; a self-host case first cross-builds that compiler to the leg
+        # target and drives it under the leg's run-mode, so the case is compiled by
+        # the target-hosted compiler (the riscv64 compiler under qemu-riscv64), not
+        # the host compiler. this executes the compiler's own emitted code on the
+        # target — the coverage running produced binaries can never reach.
+        buildcc=$compiler
+        if [ "$case_self_host" = true ]; then
+            if ! (cd "$here/.." && "$compiler" build . --target "$target" --profile "$profile" -o "$tmp/selfhostcc") >"$tmp/selfhost.log" 2>&1; then
+                echo "FAIL $label (self-host cross-build)"
+                sed 's/^/    /' "$tmp/selfhost.log" >&2
+                fails=$((fails + 1))
+                rm -rf "$tmp" "$dir/out/int"
+                continue
+            fi
+            if [ "$runmode" = qemu ]; then
+                buildcc="qemu-${target##*-} $tmp/selfhostcc"
+            else
+                buildcc=$tmp/selfhostcc
+            fi
+        fi
+
+        if ! (cd "$dir" && "$compiler" dep pull && $buildcc build . --target "$build_target" --profile "$profile" $case_build_flags -o "$relbin") >"$tmp/build.log" 2>&1; then
             echo "FAIL $label (build)"
             sed 's/^/    /' "$tmp/build.log" >&2
             fails=$((fails + 1))


### PR DESCRIPTION
Closes #1852.

## What

Adds the first int/ case that executes the **compiler itself on riscv64**, closing the coverage gap surfaced by #1742: CI was fully green while the riscv64-hosted compiler could not compile a two-block function (#1851), because nowhere in CI does the compiler run on riscv64 — the qemu riscv64 int leg only runs *produced* binaries.

Two changes:

- **`int/run.sh` — a `self-host` build mode.** A case may set `self-host: true` in `case.conf`. The harness then cross-builds the current compiler to the leg target and drives it under the leg's run-mode to compile the case, instead of using the host compiler. On the qemu riscv64 leg this runs the riscv64-hosted compiler under `qemu-riscv64`. The `exec` producer then runs the emitted artifact and diffs its stdout as usual. Default `false`, so every existing case is unchanged.

- **`int/regression/1852-rv64-self-host`** — a small multi-block input (a loop-carried i32 accumulator across a back edge and an if/else, plus a negative i32 reaching a signed compare through a branch merge — the cross-block liveness riscv64 mishandled before #1851). The riscv64 compiler under qemu must compile it into a working artifact printing `acc=-2` / `v_lt_0=true`.

No `ci.yml` or `targets.conf` edit: the existing riscv64 leg already installs qemu-user, builds the from-source compiler, and pulls repo-root deps, so `run.sh` cross-builds the riscv64 compiler on the fly. Runs release-only for a focused smoke.

## Falsifiability

Verified the check detects the failure class by running it against the pre-#1851 revision `96358fe8` (dev history's broken revision), with the harness change + case applied on top:

- **pre-#1851 (`96358fe8`):** `run.sh` exits 1 — the riscv64-hosted compiler, cross-built by the pre-fix backend, **panics under qemu** compiling the two-block input (`regalloc: GP vreg assigned a non-GP register`, core dumped).
- **current dev (`a376ff36`):** `run.sh` exits 0 — the riscv64 compiler under qemu emits a working artifact; golden matches.

Full int suite is green on both the `linux-riscv64` leg (all four regression cases + surface) and the `linux` leg (self-host case correctly skipped, all others pass), confirming the harness change is backward-compatible.
