### PR TITLE
fix(driver): reused cached phase replays its diagnostics (#1586)

### DIFF
--- a/src/lang/diagnostic.mach
+++ b/src/lang/diagnostic.mach
@@ -332,6 +332,82 @@ pub fun suggestion_build(a: *A.Allocator, name: str) str {
     ret buf;
 }
 
+# deep-copy diagnostic `d` into `dst`, duplicating its owned message, optional
+# note/help lines, and every secondary location
+#
+# The shared body of clone_tail and append_all: a diagnostic owns heap strings, so
+# a copy must re-intern them into `dst`'s allocator. Only the primary emit can
+# fail meaningfully; the advisory attach helpers swallow their own allocation
+# failures, matching how a live pass records them.
+# ---
+# dst: diagnostic list receiving the copy
+# d:   diagnostic to copy
+# ret: true on success, or an allocation error from copying the primary record
+fun copy_into(dst: *DiagList, d: *Diagnostic) R.Result[bool, str] {
+    val res_emit: R.Result[bool, str] = emit(dst, d.severity, d.loc.file_id, d.loc.span, d.message);
+    if (R.is_err[bool, str](res_emit)) { ret res_emit; }
+
+    if (d.note != nil) { attach_note(dst, d.note); }
+    if (d.help != nil) { attach_help(dst, d.help); }
+
+    var r: usize = 0;
+    for (r < d.related_len) {
+        attach_related(dst, d.related[r].loc.file_id, d.related[r].loc.span, d.related[r].label);
+        r = r + 1;
+    }
+    ret R.ok[bool, str](true);
+}
+
+# snapshot the diagnostics recorded from index `from` onward into a fresh owned
+# list allocated with `a`
+#
+# The capture half of diagnostics-as-query-output (#1586): a derived query records
+# the sink length before it runs, then clones the tail it appended into a list the
+# query cache owns, so a later reused `get` can replay it. The returned list is
+# heap-owned; the caller frees it with dnit plus a single-element deallocate.
+# ---
+# src:  list to snapshot from
+# from: first index to copy (a length mark taken before the producing pass)
+# a:    allocator backing the returned list
+# ret:  the owned snapshot list, or an allocation error
+pub fun clone_tail(src: *DiagList, from: usize, a: *A.Allocator) R.Result[*DiagList, str] {
+    val res_alloc: R.Result[*DiagList, str] = A.allocate[DiagList](a, 1);
+    if (R.is_err[*DiagList, str](res_alloc)) { ret res_alloc; }
+    val list: *DiagList = R.unwrap_ok[*DiagList, str](res_alloc);
+    @list = init(a);
+
+    var i: usize = from;
+    for (i < src.len) {
+        val res_copy: R.Result[bool, str] = copy_into(list, ?src.items[i]);
+        if (R.is_err[bool, str](res_copy)) {
+            dnit(list);
+            A.deallocate[DiagList](a, list, 1);
+            ret R.err[*DiagList, str](R.unwrap_err[bool, str](res_copy));
+        }
+        i = i + 1;
+    }
+    ret R.ok[*DiagList, str](list);
+}
+
+# deep-copy every diagnostic in `src` onto the end of `dst`
+#
+# The replay half of diagnostics-as-query-output (#1586): a reused query replays
+# its cached snapshot into the live sink so a warm-session build surfaces the same
+# diagnostics a cold compute would. `src` is left intact for the next replay.
+# ---
+# dst: list receiving the copies
+# src: snapshot list to replay
+# ret: true on success, or an allocation error mid-copy
+pub fun append_all(dst: *DiagList, src: *DiagList) R.Result[bool, str] {
+    var i: usize = 0;
+    for (i < src.len) {
+        val res_copy: R.Result[bool, str] = copy_into(dst, ?src.items[i]);
+        if (R.is_err[bool, str](res_copy)) { ret res_copy; }
+        i = i + 1;
+    }
+    ret R.ok[bool, str](true);
+}
+
 # append a diagnostic of the given severity, growing the items array and copying
 # the message into the list's allocator
 # ---
@@ -510,4 +586,58 @@ test "mach.lang.diagnostic.suggestion_build:length" {
 
     str_free(?a, note);
     ret 0;
+}
+
+# clone_tail deep-copies the tail from a mark and append_all re-emits it, so a
+# captured snapshot round-trips a diagnostic's message, help line, and secondary
+# location intact (#1586)
+test "mach.lang.diagnostic.clone_tail:round_trips_via_append_all" {
+    var a: A.Allocator;
+    page.make(?a);
+    var src: DiagList = init(?a);
+
+    var sp: token.Span;
+    sp.offset = 4;
+    sp.len    = 2;
+
+    # a leading diagnostic that a mark past index 0 must exclude from the snapshot.
+    if (R.is_err[bool, str](warning(?src, 0::source.FileId, sp, "leading warning"))) { dnit(?src); ret 1; }
+    val mark: usize = src.len;
+
+    var esp: token.Span;
+    esp.offset = 10;
+    esp.len    = 3;
+    if (R.is_err[bool, str](error(?src, 5::source.FileId, esp, "the error"))) { dnit(?src); ret 1; }
+    attach_help(?src, "try this");
+    var rsp: token.Span;
+    rsp.offset = 20;
+    rsp.len    = 1;
+    attach_related(?src, 6::source.FileId, rsp, "previous here");
+
+    # snapshot from the mark: only the error and its attachments, not the warning.
+    val cr: R.Result[*DiagList, str] = clone_tail(?src, mark, ?a);
+    if (R.is_err[*DiagList, str](cr)) { dnit(?src); ret 1; }
+    val snap: *DiagList = R.unwrap_ok[*DiagList, str](cr);
+
+    var bad: i32 = 0;
+    if (snap.len != 1)                                             { bad = 1; }
+    or (snap.items[0].severity != SEVERITY_ERROR)                 { bad = 1; }
+    or (snap.items[0].loc.file_id != 5::source.FileId)            { bad = 1; }
+    or (snap.items[0].loc.span.offset != 10)                      { bad = 1; }
+    or (snap.items[0].help == nil)                                { bad = 1; }
+    or (snap.items[0].related_len != 1)                           { bad = 1; }
+    or (snap.items[0].related[0].loc.file_id != 6::source.FileId) { bad = 1; }
+
+    # replay the snapshot into a fresh sink; the round-trip must reproduce it.
+    var dst: DiagList = init(?a);
+    if (R.is_err[bool, str](append_all(?dst, snap))) { dnit(?src); dnit(snap); A.deallocate[DiagList](?a, snap, 1); dnit(?dst); ret 1; }
+    if (dst.len != 1)                                  { bad = 1; }
+    or (dst.items[0].related_len != 1)                 { bad = 1; }
+    or (dst.items[0].related[0].label == nil)          { bad = 1; }
+
+    dnit(?dst);
+    dnit(snap);
+    A.deallocate[DiagList](?a, snap, 1);
+    dnit(?src);
+    ret bad;
 }

--- a/src/lang/diagnostic.mach
+++ b/src/lang/diagnostic.mach
@@ -16,6 +16,7 @@ use std.types.bool.true;
 use std.types.char.char;
 use std.types.size.usize;
 use std.types.string.str;
+use std.types.string.str_equals;
 use std.types.string.str_len;
 
 use A: std.allocator;
@@ -619,25 +620,40 @@ test "mach.lang.diagnostic.clone_tail:round_trips_via_append_all" {
     if (R.is_err[*DiagList, str](cr)) { dnit(?src); ret 1; }
     val snap: *DiagList = R.unwrap_ok[*DiagList, str](cr);
 
-    var bad: i32 = 0;
-    if (snap.len != 1)                                             { bad = 1; }
-    or (snap.items[0].severity != SEVERITY_ERROR)                 { bad = 1; }
-    or (snap.items[0].loc.file_id != 5::source.FileId)            { bad = 1; }
-    or (snap.items[0].loc.span.offset != 10)                      { bad = 1; }
-    or (snap.items[0].help == nil)                                { bad = 1; }
-    or (snap.items[0].related_len != 1)                           { bad = 1; }
-    or (snap.items[0].related[0].loc.file_id != 6::source.FileId) { bad = 1; }
-
     # replay the snapshot into a fresh sink; the round-trip must reproduce it.
     var dst: DiagList = init(?a);
     if (R.is_err[bool, str](append_all(?dst, snap))) { dnit(?src); dnit(snap); A.deallocate[DiagList](?a, snap, 1); dnit(?dst); ret 1; }
-    if (dst.len != 1)                                  { bad = 1; }
-    or (dst.items[0].related_len != 1)                 { bad = 1; }
-    or (dst.items[0].related[0].label == nil)          { bad = 1; }
+
+    # independence: free the source sink now, before reading the copies. deep copies
+    # must outlive it; a shallow alias would fault reading the strings below.
+    dnit(?src);
+
+    var bad: i32 = 0;
+    # snap holds exactly the error, with its owned message / help / label copied
+    # byte-for-byte from the (now freed) source.
+    if (snap.len != 1)                                                       { bad = 1; }
+    or (snap.items[0].severity != SEVERITY_ERROR)                           { bad = 1; }
+    or (snap.items[0].loc.file_id != 5::source.FileId)                      { bad = 1; }
+    or (snap.items[0].loc.span.offset != 10)                                { bad = 1; }
+    or (!str_equals(snap.items[0].message, "the error"))                    { bad = 1; }
+    or (snap.items[0].help == nil)                                          { bad = 1; }
+    or (!str_equals(snap.items[0].help, "try this"))                        { bad = 1; }
+    or (snap.items[0].related_len != 1)                                     { bad = 1; }
+    or (snap.items[0].related[0].loc.file_id != 6::source.FileId)           { bad = 1; }
+    or (snap.items[0].related[0].label == nil)                              { bad = 1; }
+    or (!str_equals(snap.items[0].related[0].label, "previous here"))       { bad = 1; }
+
+    # the replayed copy is likewise independent and content-correct.
+    if (dst.len != 1)                                                  { bad = 1; }
+    or (!str_equals(dst.items[0].message, "the error"))               { bad = 1; }
+    or (dst.items[0].help == nil)                                     { bad = 1; }
+    or (!str_equals(dst.items[0].help, "try this"))                   { bad = 1; }
+    or (dst.items[0].related_len != 1)                                { bad = 1; }
+    or (dst.items[0].related[0].label == nil)                         { bad = 1; }
+    or (!str_equals(dst.items[0].related[0].label, "previous here"))  { bad = 1; }
 
     dnit(?dst);
     dnit(snap);
     A.deallocate[DiagList](?a, snap, 1);
-    dnit(?src);
     ret bad;
 }

--- a/src/lang/driver.mach
+++ b/src/lang/driver.mach
@@ -2562,6 +2562,10 @@ fun parse_module(p: *Project, mid: session.ModuleId, fqn: intern.StrId) R.Result
 # cross-build-stable key a reused result remaps through (#1582).
 fun ensure_query_pipeline(s: *session.Session) R.Result[bool, str] {
     query.set_ctx(?s.queries, s::ptr);
+    # bridge the session diagnostic sink to the engine so a reused phase replays
+    # the diagnostics it emitted when computed (#1586). refreshed every build like
+    # set_ctx; the session address is stable.
+    query.set_diag_hooks(?s.queries, diag_mark_hook, diag_capture_hook, diag_replay_hook, diag_free_hook);
     if (!query.is_registered(?s.queries, query.Q_PARSE)) {
         val rp: R.Result[bool, str] = query.register_derived_owned(?s.queries, query.Q_PARSE, q_parse_compute, q_parse_finalize);
         if (R.is_err[bool, str](rp)) { ret rp; }
@@ -2595,6 +2599,45 @@ fun ensure_query_pipeline(s: *session.Session) R.Result[bool, str] {
         if (R.is_err[bool, str](rln)) { ret rln; }
     }
     ret R.ok[bool, str](true);
+}
+
+# the diagnostics-as-query-output hooks the query engine calls to capture the
+# diagnostics a derived compute emits onto the session sink and replay them on a
+# reused get (#1586). the engine is diagnostic-agnostic; these cast db.ctx back to
+# the session and bridge its `diags` sink. a captured snapshot is a heap
+# diagnostic.DiagList the query entry owns and the engine frees through
+# diag_free_hook.
+
+# read the session sink's current length, the mark a compute's diagnostics start at
+fun diag_mark_hook(ctx: ptr) u64 {
+    val s: *session.Session = ctx::*session.Session;
+    ret s.diags.len::u64;
+}
+
+# snapshot the diagnostics appended since `mark` into an owned DiagList handle, or
+# nil when the compute emitted none. an allocation failure yields nil - diagnostics
+# are advisory, so a failed capture degrades to no replay rather than aborting.
+fun diag_capture_hook(ctx: ptr, mark: u64, a: *A.Allocator) ptr {
+    val s: *session.Session = ctx::*session.Session;
+    if (s.diags.len <= mark::usize) { ret nil; }
+    val cr: R.Result[*diagnostic.DiagList, str] = diagnostic.clone_tail(?s.diags, mark::usize, a);
+    if (R.is_err[*diagnostic.DiagList, str](cr)) { ret nil; }
+    ret R.unwrap_ok[*diagnostic.DiagList, str](cr)::ptr;
+}
+
+# replay a captured snapshot into the live session sink on a reused get. the
+# advisory append failure is swallowed, as elsewhere in the diagnostic sink.
+fun diag_replay_hook(ctx: ptr, handle: ptr) {
+    val s: *session.Session = ctx::*session.Session;
+    val list: *diagnostic.DiagList = handle::*diagnostic.DiagList;
+    diagnostic.append_all(?s.diags, list);
+}
+
+# release a captured snapshot handle when its query entry is freed
+fun diag_free_hook(handle: ptr, a: *A.Allocator) {
+    val list: *diagnostic.DiagList = handle::*diagnostic.DiagList;
+    diagnostic.dnit(list);
+    A.deallocate[diagnostic.DiagList](a, list, 1::usize);
 }
 
 # the Q_PARSE derived compute - lex + parse one file into a heap
@@ -5729,6 +5772,114 @@ test "mach.lang.driver:incremental_qparse_ast_reuse_and_reparse" {
     if (ut_ast(?p3, ?s, "uniontest.a")    == a1)    { bad = 1; }   # edited: re-parsed
     dnit_project(?p3);
 
+    filesystem.remove_all(?alloc, root);
+    session.dnit(?s);
+    ret bad;
+}
+
+# whether two optional owned strings are equal: both nil, or both present and
+# byte-equal. used by the diagnostic-replay comparison below.
+fun ut_opt_str_eq(a: str, b: str) bool {
+    if (a == nil && b == nil) { ret true; }
+    if (a == nil || b == nil) { ret false; }
+    ret str_equals(a, b);
+}
+
+# whether two diagnostic lists are structurally identical: same length and, per
+# entry, the same severity, primary location, message, note/help lines, and
+# secondary locations. the replay test asserts a warm-session rebuild reproduces
+# the cold build's diagnostics exactly (#1586).
+fun ut_diag_list_eq(x: *diagnostic.DiagList, y: *diagnostic.DiagList) bool {
+    if (x.len != y.len) { ret false; }
+    var i: usize = 0;
+    for (i < x.len) {
+        val dx: *diagnostic.Diagnostic = ?x.items[i];
+        val dy: *diagnostic.Diagnostic = ?y.items[i];
+        if (dx.severity != dy.severity)               { ret false; }
+        if (dx.loc.file_id != dy.loc.file_id)         { ret false; }
+        if (dx.loc.span.offset != dy.loc.span.offset) { ret false; }
+        if (dx.loc.span.len != dy.loc.span.len)       { ret false; }
+        if (!ut_opt_str_eq(dx.message, dy.message))   { ret false; }
+        if (!ut_opt_str_eq(dx.note, dy.note))         { ret false; }
+        if (!ut_opt_str_eq(dx.help, dy.help))         { ret false; }
+        if (dx.related_len != dy.related_len)         { ret false; }
+        var r: usize = 0;
+        for (r < dx.related_len) {
+            val rx: *diagnostic.Related = ?dx.related[r];
+            val ry: *diagnostic.Related = ?dy.related[r];
+            if (rx.loc.file_id != ry.loc.file_id)         { ret false; }
+            if (rx.loc.span.offset != ry.loc.span.offset) { ret false; }
+            if (rx.loc.span.len != ry.loc.span.len)       { ret false; }
+            if (!ut_opt_str_eq(rx.label, ry.label))       { ret false; }
+            r = r + 1;
+        }
+        i = i + 1;
+    }
+    ret true;
+}
+
+# driver incremental: a reused phase replays the diagnostics it emitted when
+# computed, so a warm-session rebuild surfaces the same diagnostics a cold compute
+# did (#1586). main.mach carries a duplicate module-scope definition, so name
+# resolution emits one error diagnostic (with a related "previous definition"
+# span). without the replay the reused Q_RESOLVE stays silent and the warm sink is
+# empty.
+test "mach.lang.driver:incremental_reused_phase_replays_diagnostics" {
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    val sr: R.Result[session.Session, str] = session.init(?alloc);
+    if (R.is_err[session.Session, str](sr)) { ret 1; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](sr);
+
+    val rr: R.Result[bool, str] = setup_registry(?s.registry);
+    if (R.is_err[bool, str](rr)) { session.dnit(?s); ret 1; }
+
+    var names: [1]str;
+    names[0] = "main.mach";
+    var texts: [1]str;
+    texts[0] = "fun dup() i32 { ret 1; }\nfun dup() i32 { ret 2; }\n\nfun main() i32 { ret 0; }\n";
+
+    val root_r: R.Result[str, str] = ut_scaffold(?alloc, ?names[0], ?texts[0], 1);
+    if (R.is_err[str, str](root_r)) { session.dnit(?s); ret 1; }
+    val root: str = R.unwrap_ok[str, str](root_r);
+
+    var bad: i32 = 0;
+
+    # build 1: cold. the resolve pass emits the diagnostic and the engine captures
+    # it onto the Q_RESOLVE entry.
+    val p1r: R.Result[Project, str] = build_project_union(?s, root);
+    if (R.is_err[Project, str](p1r)) { filesystem.remove_all(?alloc, root); session.dnit(?s); ret 1; }
+    var p1: Project = R.unwrap_ok[Project, str](p1r);
+
+    # snapshot the cold diagnostics before the sink is reset; a non-empty snapshot
+    # proves the diagnostic was produced at all.
+    val cold_r: R.Result[*diagnostic.DiagList, str] = diagnostic.clone_tail(?s.diags, 0, ?alloc);
+    if (R.is_err[*diagnostic.DiagList, str](cold_r)) { dnit_project(?p1); filesystem.remove_all(?alloc, root); session.dnit(?s); ret 1; }
+    val cold: *diagnostic.DiagList = R.unwrap_ok[*diagnostic.DiagList, str](cold_r);
+    if (cold.len == 0) { bad = 1; }
+    dnit_project(?p1);
+
+    # a warm-session consumer resets the sink between builds; do the same so the
+    # second build's sink reflects only its own (replayed) diagnostics.
+    diagnostic.dnit(?s.diags);
+    s.diags = diagnostic.init(?alloc);
+
+    # build 2: warm. nothing changed, so every phase is reused. the reused
+    # Q_RESOLVE must replay its captured diagnostic - identically to the cold build.
+    val p2r: R.Result[Project, str] = build_project_union(?s, root);
+    if (R.is_err[Project, str](p2r)) {
+        diagnostic.dnit(cold);
+        A.deallocate[diagnostic.DiagList](?alloc, cold, 1::usize);
+        filesystem.remove_all(?alloc, root);
+        session.dnit(?s);
+        ret 1;
+    }
+    var p2: Project = R.unwrap_ok[Project, str](p2r);
+    if (!ut_diag_list_eq(?s.diags, cold)) { bad = 1; }
+    dnit_project(?p2);
+
+    diagnostic.dnit(cold);
+    A.deallocate[diagnostic.DiagList](?alloc, cold, 1::usize);
     filesystem.remove_all(?alloc, root);
     session.dnit(?s);
     ret bad;

--- a/src/lang/query.mach
+++ b/src/lang/query.mach
@@ -193,6 +193,24 @@ pub def FinalizeFn: fun(*u8, u32, *A.Allocator);
 # metadata kind.
 pub def RevisionFn: fun(u64) Revision;
 
+# the diagnostics-as-query-output hooks (#1586). a derived compute emits
+# diagnostics as a side effect onto the owner's sink; a reused `get` must replay
+# them so a warm session surfaces the same diagnostics a cold compute would. the
+# engine stays diagnostic-agnostic - the owner installs these through
+# set_diag_hooks, and the engine calls them only around a top-level compute or
+# reuse. all four nil leaves the engine capturing nothing.
+#
+# mark reads the sink's current length before a compute; capture snapshots
+# everything appended since that mark into an owned opaque handle stored on the
+# entry (nil when nothing was appended or on allocation failure - diagnostics are
+# advisory, so a failed capture degrades to no replay rather than aborting the
+# build); replay re-emits a handle's diagnostics into the sink on a reused get;
+# free releases a handle. the ctx passed to mark/capture/replay is db.ctx.
+pub def DiagMarkFn:    fun(ptr) u64;
+pub def DiagCaptureFn: fun(ptr, u64, *A.Allocator) ptr;
+pub def DiagReplayFn:  fun(ptr, ptr);
+pub def DiagFreeFn:    fun(ptr, *A.Allocator);
+
 # bytes produced by a derived ComputeFn; ownership transfers into the cache entry
 # on a successful compute
 # ---
@@ -226,6 +244,9 @@ pub rec Dep {
 # deps:         queries read while computing value
 # dep_len:      number of entries in deps
 # dep_cap:      allocated slots in deps
+# diags:        owned opaque handle to the diagnostics this entry's compute emitted,
+#               replayed on a reused get and freed through the owner's DiagFreeFn;
+#               nil when the compute emitted none or no diag hooks are installed
 pub rec QueryEntry {
     key:          u64;
     value:        *u8;
@@ -234,6 +255,7 @@ pub rec QueryEntry {
     deps:         *Dep;
     dep_len:      u32;
     dep_cap:      u32;
+    diags:        ptr;
 }
 
 # per-kind storage; the kind equals the shard's index in QueryDb.storage
@@ -276,12 +298,26 @@ pub rec QueryShard {
 # ctx:      opaque context handle a derived ComputeFn casts back to reach the
 #           compiler's services (e.g. the Session); installed by set_ctx, nil
 #           until then
+# diag_mark:    diagnostics-as-query-output hook: reads the sink length before a
+#               compute (#1586); nil until set_diag_hooks, which disables capture
+# diag_capture: hook that snapshots a compute's emitted diagnostics; nil until set
+# diag_replay:  hook that replays a snapshot on a reused get; nil until set
+# diag_free:    hook that releases a captured snapshot handle; nil until set
+# compute_depth: number of derived computes currently on the stack. reuse replays
+#           an entry's cached diagnostics only at depth 0 (a top-level get), so a
+#           nested reuse reached from inside another compute does not double-emit
+#           diagnostics the driver already surfaced by driving that phase directly
 pub rec QueryDb {
-    a:        *A.Allocator;
-    revision: Revision;
-    storage:  *QueryShard;
-    kinds:    u32;
-    ctx:      ptr;
+    a:            *A.Allocator;
+    revision:     Revision;
+    storage:      *QueryShard;
+    kinds:        u32;
+    ctx:          ptr;
+    diag_mark:    DiagMarkFn;
+    diag_capture: DiagCaptureFn;
+    diag_replay:  DiagReplayFn;
+    diag_free:    DiagFreeFn;
+    compute_depth: u32;
 }
 
 # initial capacities for a shard's entries array and an entry's deps array
@@ -296,11 +332,16 @@ val INITIAL_DEP_CAP:   u32 = 4;
 # ret: a new empty QueryDb, or an allocation error
 pub fun init(a: *A.Allocator) R.Result[QueryDb, str] {
     var db: QueryDb;
-    db.a        = a;
-    db.revision = 0;
-    db.storage  = nil;
-    db.kinds    = 0;
-    db.ctx      = nil;
+    db.a             = a;
+    db.revision      = 0;
+    db.storage       = nil;
+    db.kinds         = 0;
+    db.ctx           = nil;
+    db.diag_mark     = nil::DiagMarkFn;
+    db.diag_capture  = nil::DiagCaptureFn;
+    db.diag_replay   = nil::DiagReplayFn;
+    db.diag_free     = nil::DiagFreeFn;
+    db.compute_depth = 0;
     ret R.ok[QueryDb, str](db);
 }
 
@@ -396,6 +437,25 @@ pub fun register_metadata(db: *QueryDb, kind: QueryKind, lookup: RevisionFn) R.R
 # ctx: opaque handle stored verbatim and never dereferenced by the engine
 pub fun set_ctx(db: *QueryDb, ctx: ptr) {
     db.ctx = ctx;
+}
+
+# install the diagnostics-as-query-output hooks the engine uses to capture the
+# diagnostics a derived compute emits and replay them on a reused get (#1586)
+#
+# The owner (which knows about its diagnostic sink) installs all four together;
+# passing nil for any disables capture/replay entirely. Idempotent across
+# rebuilds - the owner re-installs each build, as it does set_ctx.
+# ---
+# db:      the database
+# mark:    reads the sink's current length before a compute
+# capture: snapshots the diagnostics appended since a mark into an owned handle
+# replay:  re-emits a captured handle's diagnostics into the sink
+# free:    releases a captured handle
+pub fun set_diag_hooks(db: *QueryDb, mark: DiagMarkFn, capture: DiagCaptureFn, replay: DiagReplayFn, free: DiagFreeFn) {
+    db.diag_mark    = mark;
+    db.diag_capture = capture;
+    db.diag_replay  = replay;
+    db.diag_free    = free;
 }
 
 # whether shard `kind` has been claimed by a register_* call
@@ -524,7 +584,16 @@ pub fun get(db: *QueryDb, kind: QueryKind, key: u64) R.Result[*QueryEntry, str] 
 
     val existing: *QueryEntry = entry_find(sh, key);
     if (existing != nil) {
-        if (is_entry_valid(db, existing)) { ret R.ok[*QueryEntry, str](existing); }
+        if (is_entry_valid(db, existing)) {
+            # reuse: the compute did not run, so replay its cached diagnostics into
+            # the sink. only at depth 0 (a top-level get) - a nested reuse reached
+            # from inside another compute is one the driver drives directly at depth
+            # 0 too, so replaying here as well would double-emit (#1586).
+            if (db.compute_depth == 0 && existing.diags != nil && db.diag_replay != nil::DiagReplayFn) {
+                db.diag_replay(db.ctx, existing.diags);
+            }
+            ret R.ok[*QueryEntry, str](existing);
+        }
         ret recompute(db, sh, existing, key);
     }
 
@@ -709,6 +778,7 @@ fun entry_append(db: *QueryDb, sh: *QueryShard, key: u64) R.Result[*QueryEntry, 
     entry.deps         = nil;
     entry.dep_len      = 0;
     entry.dep_cap      = 0;
+    entry.diags        = nil;
     sh.len = sh.len + 1;
     ret R.ok[*QueryEntry, str](entry);
 }
@@ -742,11 +812,15 @@ fun entry_free(db: *QueryDb, sh: *QueryShard, entry: *QueryEntry) {
     if (entry.deps != nil && entry.dep_cap > 0) {
         A.deallocate[Dep](db.a, entry.deps, entry.dep_cap::usize);
     }
+    if (entry.diags != nil && db.diag_free != nil::DiagFreeFn) {
+        db.diag_free(entry.diags, db.a);
+    }
     entry.value     = nil;
     entry.value_len = 0;
     entry.deps      = nil;
     entry.dep_len   = 0;
     entry.dep_cap   = 0;
+    entry.diags     = nil;
 }
 
 # free every entry in a shard plus the entries array itself.
@@ -807,7 +881,15 @@ fun recompute(db: *QueryDb, sh: *QueryShard, entry: *QueryEntry, key: u64) R.Res
 
     entry.dep_len = 0;
 
+    # mark the sink before the compute so its emitted diagnostics can be captured;
+    # bump the depth so a nested reuse the compute reaches does not replay (#1586).
+    var diag_mark: u64 = 0;
+    if (db.diag_mark != nil::DiagMarkFn) { diag_mark = db.diag_mark(db.ctx); }
+
+    db.compute_depth = db.compute_depth + 1;
     val res_output: R.Result[QueryOutput, str] = sh.compute(db, key, db.a);
+    db.compute_depth = db.compute_depth - 1;
+
     if (R.is_err[QueryOutput, str](res_output)) {
         # a failed compute must not leave a poisoned entry behind: it now has zero
         # deps, which is_entry_valid reads as vacuously valid, so the next get would
@@ -817,6 +899,16 @@ fun recompute(db: *QueryDb, sh: *QueryShard, entry: *QueryEntry, key: u64) R.Res
         ret R.err[*QueryEntry, str](R.unwrap_err[QueryOutput, str](res_output));
     }
     val out: QueryOutput = R.unwrap_ok[QueryOutput, str](res_output);
+
+    # capture the diagnostics this compute emitted so a later reused get can replay
+    # them (#1586). done before the early-cutoff return so an entry whose bytes are
+    # unchanged still refreshes its cached diagnostics. a nil snapshot (nothing
+    # emitted, or an advisory allocation failure) leaves the entry with none.
+    if (db.diag_capture != nil::DiagCaptureFn) {
+        val snap: ptr = db.diag_capture(db.ctx, diag_mark, db.a);
+        if (entry.diags != nil && db.diag_free != nil::DiagFreeFn) { db.diag_free(entry.diags, db.a); }
+        entry.diags = snap;
+    }
 
     # owned-handle shards never early-cut: the handle differs every compute and
     # the artifact behind it propagates by input change, so skip the byte
@@ -1099,5 +1191,123 @@ test "mach.lang.query.register_derived_owned:finalizer_frees_artifacts" {
     # dnit finalizes every live handle; a balanced count proves no leak / double-free.
     dnit(?db);
     if (t_live != 0) { ret 1; }
+    ret 0;
+}
+
+# mock diagnostic sink for the capture/replay hook tests: a length counter a
+# compute "emits" into, that the hooks snapshot and replay. a scalar stands in for
+# the real DiagList so the engine test stays free of the diagnostic module.
+var t_diag_count: usize = 0;
+
+# reset the mock sink between phases of the test.
+fun t_diag_reset() { t_diag_count = 0; }
+
+# a captured run of emitted diagnostics: just how many, since order/content is the
+# driver test's concern; this engine test asserts replay and depth suppression.
+rec TDiagSnap { n: usize; }
+
+# mark hook: the mock sink's current length.
+fun t_diag_mark(ctx: ptr) u64 { ret t_diag_count::u64; }
+
+# capture hook: snapshot the count of diagnostics appended since `mark`, or nil
+# when none were.
+fun t_diag_capture(ctx: ptr, mark: u64, a: *A.Allocator) ptr {
+    if (t_diag_count <= mark::usize) { ret nil; }
+    val sr: R.Result[*TDiagSnap, str] = A.allocate[TDiagSnap](a, 1::usize);
+    if (R.is_err[*TDiagSnap, str](sr)) { ret nil; }
+    val snap: *TDiagSnap = R.unwrap_ok[*TDiagSnap, str](sr);
+    snap.n = t_diag_count - mark::usize;
+    ret snap::ptr;
+}
+
+# replay hook: re-append a snapshot's diagnostics onto the mock sink.
+fun t_diag_replay(ctx: ptr, handle: ptr) {
+    val snap: *TDiagSnap = handle::*TDiagSnap;
+    t_diag_count = t_diag_count + snap.n;
+}
+
+# free hook: release a snapshot handle.
+fun t_diag_free(handle: ptr, a: *A.Allocator) {
+    A.deallocate[TDiagSnap](a, handle::*TDiagSnap, 1::usize);
+}
+
+# an inner derived compute that "emits" one diagnostic and returns a fixed byte, so
+# its entry is reused on an unchanged input.
+fun t_inner_diag_compute(db: *QueryDb, key: u64, a: *A.Allocator) R.Result[QueryOutput, str] {
+    val rd: R.Result[bool, str] = record_dep(db, Q_TOKENIZE, key, Q_FILE_TEXT, key);
+    if (R.is_err[bool, str](rd)) { ret R.err[QueryOutput, str](R.unwrap_err[bool, str](rd)); }
+    t_diag_count = t_diag_count + 1;
+    val rb: R.Result[*u8, str] = A.allocate[u8](a, 1);
+    if (R.is_err[*u8, str](rb)) { ret R.err[QueryOutput, str](R.unwrap_err[*u8, str](rb)); }
+    val buf: *u8 = R.unwrap_ok[*u8, str](rb);
+    buf[0] = 1;
+    var out: QueryOutput;
+    out.bytes = buf;
+    out.len   = 1;
+    ret R.ok[QueryOutput, str](out);
+}
+
+# an outer derived compute that "emits" one diagnostic then reads the inner query,
+# so the test can observe that the nested reuse it triggers does not replay.
+fun t_outer_diag_compute(db: *QueryDb, key: u64, a: *A.Allocator) R.Result[QueryOutput, str] {
+    val rd: R.Result[bool, str] = record_dep(db, Q_PARSE, key, Q_FILE_TEXT, key);
+    if (R.is_err[bool, str](rd)) { ret R.err[QueryOutput, str](R.unwrap_err[bool, str](rd)); }
+    t_diag_count = t_diag_count + 1;
+    val g: R.Result[*QueryEntry, str] = get(db, Q_TOKENIZE, key);
+    if (R.is_err[*QueryEntry, str](g)) { ret R.err[QueryOutput, str](R.unwrap_err[*QueryEntry, str](g)); }
+    val rb: R.Result[*u8, str] = A.allocate[u8](a, 1);
+    if (R.is_err[*u8, str](rb)) { ret R.err[QueryOutput, str](R.unwrap_err[*u8, str](rb)); }
+    val buf: *u8 = R.unwrap_ok[*u8, str](rb);
+    buf[0] = 2;
+    var out: QueryOutput;
+    out.bytes = buf;
+    out.len   = 1;
+    ret R.ok[QueryOutput, str](out);
+}
+
+# a reused entry replays its captured diagnostics on a top-level get, and a nested
+# reuse reached from inside another compute is suppressed so it does not
+# double-emit what the driver drives directly (#1586).
+test "mach.lang.query.get:reused_entry_replays_diagnostics" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+    val res_db: R.Result[QueryDb, str] = init(?alloc);
+    if (R.is_err[QueryDb, str](res_db)) { ret 1; }
+    var db: QueryDb = R.unwrap_ok[QueryDb, str](res_db);
+
+    if (R.is_err[bool, str](register_input(?db, Q_FILE_TEXT)))                        { dnit(?db); ret 1; }
+    if (R.is_err[bool, str](register_derived(?db, Q_TOKENIZE, t_inner_diag_compute))) { dnit(?db); ret 1; }
+    if (R.is_err[bool, str](register_derived(?db, Q_PARSE, t_outer_diag_compute)))    { dnit(?db); ret 1; }
+    set_diag_hooks(?db, t_diag_mark, t_diag_capture, t_diag_replay, t_diag_free);
+    if (R.is_err[bool, str](set_input(?db, Q_FILE_TEXT, 1, "x"::*u8, 1)))             { dnit(?db); ret 1; }
+
+    # cold inner compute emits its diagnostic directly.
+    t_diag_reset();
+    if (R.is_err[*QueryEntry, str](get(?db, Q_TOKENIZE, 1))) { dnit(?db); ret 1; }
+    if (t_diag_count != 1)                                   { dnit(?db); ret 1; }
+
+    # reused inner replays its one diagnostic.
+    t_diag_reset();
+    if (R.is_err[*QueryEntry, str](get(?db, Q_TOKENIZE, 1))) { dnit(?db); ret 1; }
+    if (t_diag_count != 1)                                   { dnit(?db); ret 1; }
+
+    # cold outer compute emits its own diagnostic; the nested reused inner is
+    # suppressed at depth > 0, so exactly one lands - not two.
+    t_diag_reset();
+    if (R.is_err[*QueryEntry, str](get(?db, Q_PARSE, 1))) { dnit(?db); ret 1; }
+    if (t_diag_count != 1)                                { dnit(?db); ret 1; }
+
+    # reused outer replays exactly its own captured diagnostic.
+    t_diag_reset();
+    if (R.is_err[*QueryEntry, str](get(?db, Q_PARSE, 1))) { dnit(?db); ret 1; }
+    if (t_diag_count != 1)                                { dnit(?db); ret 1; }
+
+    # invalidate drops the snapshot; a re-get recomputes and re-emits directly.
+    if (R.is_err[bool, str](invalidate(?db, Q_PARSE, 1))) { dnit(?db); ret 1; }
+    t_diag_reset();
+    if (R.is_err[*QueryEntry, str](get(?db, Q_PARSE, 1))) { dnit(?db); ret 1; }
+    if (t_diag_count != 1)                                { dnit(?db); ret 1; }
+
+    dnit(?db);
     ret 0;
 }

--- a/src/lang/query.mach
+++ b/src/lang/query.mach
@@ -1199,6 +1199,10 @@ test "mach.lang.query.register_derived_owned:finalizer_frees_artifacts" {
 # the real DiagList so the engine test stays free of the diagnostic module.
 var t_diag_count: usize = 0;
 
+# count of snapshot handles the free hook released, so the test can observe that
+# entry teardown (on invalidate and on dnit) actually frees captured diagnostics.
+var t_diag_free_count: usize = 0;
+
 # reset the mock sink between phases of the test.
 fun t_diag_reset() { t_diag_count = 0; }
 
@@ -1226,9 +1230,10 @@ fun t_diag_replay(ctx: ptr, handle: ptr) {
     t_diag_count = t_diag_count + snap.n;
 }
 
-# free hook: release a snapshot handle.
+# free hook: release a snapshot handle and count the release.
 fun t_diag_free(handle: ptr, a: *A.Allocator) {
     A.deallocate[TDiagSnap](a, handle::*TDiagSnap, 1::usize);
+    t_diag_free_count = t_diag_free_count + 1;
 }
 
 # an inner derived compute that "emits" one diagnostic and returns a fixed byte, so
@@ -1280,6 +1285,7 @@ test "mach.lang.query.get:reused_entry_replays_diagnostics" {
     if (R.is_err[bool, str](register_derived(?db, Q_PARSE, t_outer_diag_compute)))    { dnit(?db); ret 1; }
     set_diag_hooks(?db, t_diag_mark, t_diag_capture, t_diag_replay, t_diag_free);
     if (R.is_err[bool, str](set_input(?db, Q_FILE_TEXT, 1, "x"::*u8, 1)))             { dnit(?db); ret 1; }
+    t_diag_free_count = 0;
 
     # cold inner compute emits its diagnostic directly.
     t_diag_reset();
@@ -1302,12 +1308,21 @@ test "mach.lang.query.get:reused_entry_replays_diagnostics" {
     if (R.is_err[*QueryEntry, str](get(?db, Q_PARSE, 1))) { dnit(?db); ret 1; }
     if (t_diag_count != 1)                                { dnit(?db); ret 1; }
 
-    # invalidate drops the snapshot; a re-get recomputes and re-emits directly.
+    # invalidate drops the outer entry; its captured snapshot must be freed through
+    # the free hook (exactly once - the inner snapshot is untouched).
     if (R.is_err[bool, str](invalidate(?db, Q_PARSE, 1))) { dnit(?db); ret 1; }
+    if (t_diag_free_count != 1)                           { dnit(?db); ret 1; }
+
+    # a re-get recomputes and re-emits directly, capturing a fresh snapshot onto the
+    # new entry and freeing nothing (the entry started empty).
     t_diag_reset();
     if (R.is_err[*QueryEntry, str](get(?db, Q_PARSE, 1))) { dnit(?db); ret 1; }
     if (t_diag_count != 1)                                { dnit(?db); ret 1; }
+    if (t_diag_free_count != 1)                           { dnit(?db); ret 1; }
 
+    # dnit frees every remaining entry's captured snapshot - the inner and the
+    # recomputed outer - so the free hook runs twice more (no leak).
     dnit(?db);
+    if (t_diag_free_count != 3) { ret 1; }
     ret 0;
 }


### PR DESCRIPTION
Closes #1586.

## Problem
Phases routed through the query engine emit diagnostics as a side effect (lex/parse errors in Q_PARSE, name-resolution errors in Q_RESOLVE). When a cached entry is **reused** (firewall held), the compute does not run, so those diagnostics are **not re-emitted** — a warm session driving `build_project` repeatedly loses them. This directly serves the LSP, a warm-session consumer.

## Fix — diagnostics-as-query-output
Treat the diagnostics a derived compute emits as part of its cached output, captured on compute and replayed on a reused `get`, done once generically in the query engine rather than per phase.

- **`diagnostic.mach`** — `clone_tail` snapshots a sink's tail from a length mark into an owned list; `append_all` replays a snapshot back. Both deep-copy message, note/help, and secondary locations.
- **`query.mach`** — owner-installed diag hooks (`set_diag_hooks`). The engine marks the sink before a compute, captures what the compute appended onto the entry, and replays that snapshot on a reused get. Replay is gated to a top-level get (`compute_depth == 0`) so a nested reuse reached from inside another compute never double-emits diagnostics the driver already surfaces by driving that phase directly. The engine stays diagnostic-agnostic: the snapshot is an opaque handle freed through the owner's `DiagFreeFn`.
- **`driver.mach`** — `ensure_query_pipeline` installs the four hooks bridging the session sink each build. The mechanism is generic, so it covers Q_PARSE, Q_RESOLVE, Q_SEMA and every derived phase.

Compute still emits directly, so cold builds are byte-for-byte unchanged; only the reuse path is newly wired to replay.

## Verification
- from-source build: clean (0 errors / 0 warnings)
- self-host fixpoint: stage2 == stage3 byte-identical
- unit suite: 492 passed, 0 failed
- int harness (`--target linux`, from-source compiler): all cases passed
- new tests:
  - `mach.lang.diagnostic.clone_tail:round_trips_via_append_all`
  - `mach.lang.query.get:reused_entry_replays_diagnostics` (replay on reuse + nested-reuse suppression + free on invalidate)
  - `mach.lang.driver:incremental_reused_phase_replays_diagnostics` (warm rebuild replays the resolve diagnostic identically to the cold compute)
