### PR TITLE
fix(driver): key test-mode main-neutralization into Q_LOWER (#1858)

### DIFF
--- a/src/cli/cmd/build.mach
+++ b/src/cli/cmd/build.mach
@@ -190,8 +190,13 @@ fun compile_modules(p: *driver.Project, level: u8, test_mode: bool, verify_ir: b
     # query, so lower + optimize are one cached unit. the per-module IR arrays below
     # are shallow VIEWS onto the query-owned modules for the test / codegen passes,
     # never separately freed (the query DB owns them).
+    # test_mode folds into the Q_LOWER / Q_CODEGEN key: the test variant neutralizes
+    # the project `main` on its own freshly-lowered IR before caching (the runner
+    # supplies the program entry), so query-owned IR is never mutated in place and the
+    # test and normal variants cache independently (#1858).
     p.opt_level = level;
     p.verify_ir = verify_ir;
+    p.test_mode = test_mode;
     val res_lower: R.Result[bool, str] = driver.run_lower_pass(p);
     if (R.is_err[bool, str](res_lower)) {
         ret R.err[bool, str](R.unwrap_err[bool, str](res_lower));
@@ -205,18 +210,6 @@ fun compile_modules(p: *driver.Project, level: u8, test_mode: bool, verify_ir: b
         irs[mid::u32]      = @irm;
         ir_ready[mid::u32] = true;
         i = i + 1;
-    }
-
-    # in test mode neutralize the project `main` (the runner supplies the program
-    # entry) before any module is codegen'd. this mutates the query-owned IR in
-    # place; safe on the CLI's single-shot session (the cache is torn down after
-    # this build), a latent hazard only for a hypothetical long-lived test-driving
-    # session, tracked as a follow-up (#1858).
-    if (test_mode) {
-        val res_neutralize: R.Result[bool, str] = testrunner.neutralize_project_main(p.s, irs, p.module_len);
-        if (R.is_err[bool, str](res_neutralize)) {
-            ret R.err[bool, str](R.unwrap_err[bool, str](res_neutralize));
-        }
     }
 
     # codegen every module to an ObjectImage through Q_CODEGEN - memoized per module

--- a/src/lang/driver.mach
+++ b/src/lang/driver.mach
@@ -56,6 +56,7 @@ use mach.lang.intern;
 use mach.lang.manifest;
 use mach.lang.me.ir;
 use mach.lang.me.lower;
+use mach.lang.me.lower.testrunner;
 use mach.lang.me.pipeline;
 use mach.lang.query;
 use mach.lang.readout;
@@ -327,6 +328,9 @@ rec TargetTuple {
 # opt_level:         the optimization pipeline level the back half lowers at, set
 #                    by the CLI before run_lower_pass (defaults to the debug pipeline)
 # verify_ir:         run the IR verifier after each optimization pass during lowering
+# test_mode:         lower the test variant (the module's `main` neutralized), set by
+#                    the CLI before run_lower_pass; folds into the back-half query key
+#                    so the test and normal variants cache independently (#1858)
 pub rec Project {
     s:            *session.Session;
     config:       ProjectConfig;
@@ -357,6 +361,7 @@ pub rec Project {
 
     opt_level:    pipeline.OptLevel;
     verify_ir:    bool;
+    test_mode:    bool;
 }
 
 # seed capacities for the per-build growable arrays (module table, a module's pub
@@ -1187,6 +1192,7 @@ fun init_project(p: *Project, s: *session.Session) {
     p.topo_cap      = 0;
     p.opt_level     = pipeline.OPT_DEBUG;
     p.verify_ir     = false;
+    p.test_mode     = false;
 }
 
 # release every owned array a ProjectConfig holds (targets and their libs, deps,
@@ -3767,6 +3773,24 @@ rec LowerClosure {
     cap:   u32;
 }
 
+# bit 32 of a packed back-half query key: set for the test-mode variant.
+val BACK_HALF_TEST_BIT: u64 = 0x100000000;
+
+# the packed Q_LOWER / Q_CODEGEN key for module `stable` under build mode
+# `test_mode`: the stable id in the low 32 bits, the test-mode flag in bit 32. A
+# test build (its `main` neutralized) and a normal build cache under distinct keys,
+# so the query-owned IR is never mutated in place to switch variants (#1858).
+fun back_half_key(stable: session.StableModuleId, test_mode: bool) u64 {
+    var k: u64 = stable::u64;
+    if (test_mode) { k = k | BACK_HALF_TEST_BIT; }
+    ret k;
+}
+
+# whether a packed back-half key names the test-mode (neutralized-main) variant.
+fun back_half_key_is_test(key: u64) bool {
+    ret (key & BACK_HALF_TEST_BIT) != 0;
+}
+
 # lower every module to optimized IR in topo order through the Q_LOWER query.
 # the active Project is installed on the session for the pass so the compute can
 # reach the per-build module graph; topo order matches the sema pass. every module's
@@ -3817,7 +3841,7 @@ fun run_lower_one(p: *Project, mid: session.ModuleId) R.Result[bool, str] {
 
     val t_item: ctime.Time = readout.item_begin(p.s.readout);
 
-    val e_r: R.Result[*query.QueryEntry, str] = query.get(?p.s.queries, query.Q_LOWER, m.stable_id::u64);
+    val e_r: R.Result[*query.QueryEntry, str] = query.get(?p.s.queries, query.Q_LOWER, back_half_key(m.stable_id, p.test_mode));
     if (R.is_err[*query.QueryEntry, str](e_r)) { ret R.err[bool, str](R.unwrap_err[*query.QueryEntry, str](e_r)); }
     val irm: *ir.Module = ir_handle_decode(R.unwrap_ok[*query.QueryEntry, str](e_r));
     if (irm == nil) { ret R.err[bool, str]("Q_LOWER produced no result handle"); }
@@ -3840,6 +3864,11 @@ fun run_lower_one(p: *Project, mid: session.ModuleId) R.Result[bool, str] {
 #     not the direct resolve closure - is required because there is no per-hop
 #     lowering firewall: an inlined instance can originate in a transitively-
 #     imported module the direct closure omits (#1618).
+# the key packs the module's stable id with the test-mode flag (back_half_key): the
+# test-mode variant neutralizes the module's `main` on its own freshly-lowered IR
+# before caching, so the two variants cache independently and query-owned IR is never
+# mutated in place (#1858). the deps below key on the stable id alone (test-mode does
+# not fan a module's typing).
 fun q_lower_compute(db: *query.QueryDb, key: u64, alloc: *A.Allocator) R.Result[query.QueryOutput, str] {
     val s: *session.Session = db.ctx::*session.Session;
     if (s == nil) { ret R.err[query.QueryOutput, str]("Q_LOWER: query db has no session context"); }
@@ -3848,6 +3877,7 @@ fun q_lower_compute(db: *query.QueryDb, key: u64, alloc: *A.Allocator) R.Result[
     val p: *Project = pp::*Project;
 
     val stable: session.StableModuleId = key::u32::session.StableModuleId;
+    val test_mode: bool = back_half_key_is_test(key);
     val mid: session.ModuleId = session.module_id_for_stable(s, stable);
     if (mid == session.MODULE_NIL) { ret R.err[query.QueryOutput, str]("Q_LOWER: stable id not loaded this build"); }
     val m: *ModuleEntry = ?p.modules[mid::u32];
@@ -3856,7 +3886,7 @@ fun q_lower_compute(db: *query.QueryDb, key: u64, alloc: *A.Allocator) R.Result[
     val sr: *sema.SemaResult = m.sema_result;
     if (sr == nil) { ret R.err[query.QueryOutput, str]("Q_LOWER: module has no sema result"); }
 
-    val rsd: R.Result[bool, str] = query.record_dep(db, query.Q_LOWER, key, query.Q_SEMA, key);
+    val rsd: R.Result[bool, str] = query.record_dep(db, query.Q_LOWER, key, query.Q_SEMA, stable::u64);
     if (R.is_err[bool, str](rsd)) { ret R.err[query.QueryOutput, str](R.unwrap_err[bool, str](rsd)); }
     val rt: R.Result[bool, str] = query.record_dep(db, query.Q_LOWER, key, query.Q_TARGET, 0);
     if (R.is_err[bool, str](rt)) { ret R.err[query.QueryOutput, str](R.unwrap_err[bool, str](rt)); }
@@ -3896,6 +3926,17 @@ fun q_lower_compute(db: *query.QueryDb, key: u64, alloc: *A.Allocator) R.Result[
     if (R.is_err[bool, str](res_opt)) {
         ir.dnit(?irmod);
         ret R.err[query.QueryOutput, str](R.unwrap_err[bool, str](res_opt));
+    }
+
+    # test variant: neutralize this module's `main` into a body-less extern (the
+    # runner supplies the program entry) on the fresh IR before it is cached, so the
+    # normal variant's Q_LOWER value stays untouched.
+    if (test_mode) {
+        val res_neu: R.Result[bool, str] = testrunner.neutralize_main(s, ?irmod);
+        if (R.is_err[bool, str](res_neu)) {
+            ir.dnit(?irmod);
+            ret R.err[query.QueryOutput, str](R.unwrap_err[bool, str](res_neu));
+        }
     }
 
     val br: R.Result[*ir.Module, str] = A.allocate[ir.Module](alloc, 1::usize);
@@ -4053,7 +4094,7 @@ fun run_codegen_one(p: *Project, mid: session.ModuleId) R.Result[bool, str] {
 
     val t_item: ctime.Time = readout.item_begin(p.s.readout);
 
-    val e_r: R.Result[*query.QueryEntry, str] = query.get(?p.s.queries, query.Q_CODEGEN, m.stable_id::u64);
+    val e_r: R.Result[*query.QueryEntry, str] = query.get(?p.s.queries, query.Q_CODEGEN, back_half_key(m.stable_id, p.test_mode));
     if (R.is_err[*query.QueryEntry, str](e_r)) { ret R.err[bool, str](R.unwrap_err[*query.QueryEntry, str](e_r)); }
     val img: *of.ObjectImage = image_handle_decode(R.unwrap_ok[*query.QueryEntry, str](e_r));
     if (img == nil) { ret R.err[bool, str]("Q_CODEGEN produced no result handle"); }
@@ -4071,8 +4112,10 @@ fun run_codegen_one(p: *Project, mid: session.ModuleId) R.Result[bool, str] {
 #                      unchanged lowered module reuses its object (the per-module
 #                      hash-and-skip);
 #   - Q_TARGET:        a build-config change re-codegens every module.
-# emits no assembly side-channel (the `.s` debug artifact is rendered by the CLI
-# from the borrowed IR when requested).
+# the key is the same packed (stable id, test-mode) key as Q_LOWER, so the Q_LOWER
+# dep names the matching variant and a test build codegens the neutralized IR while a
+# normal build codegens the untouched IR (#1858). emits no assembly side-channel (the
+# `.s` debug artifact is rendered by the CLI from the borrowed IR when requested).
 fun q_codegen_compute(db: *query.QueryDb, key: u64, alloc: *A.Allocator) R.Result[query.QueryOutput, str] {
     val s: *session.Session = db.ctx::*session.Session;
     if (s == nil) { ret R.err[query.QueryOutput, str]("Q_CODEGEN: query db has no session context"); }
@@ -6087,6 +6130,35 @@ fun ut_codegen_lc(s: *session.Session, stable: session.StableModuleId) query.Rev
     ret R.unwrap_ok[*query.QueryEntry, str](e).last_changed;
 }
 
+# the last_changed revision of the Q_LOWER entry under a raw packed back-half key
+# (back_half_key), or a sentinel when absent - the variant-keyed lower reuse probe
+# for the test-mode neutralization firewall (#1858).
+fun ut_lower_lc_key(s: *session.Session, key: u64) query.Revision {
+    val e: R.Result[*query.QueryEntry, str] = query.get(?s.queries, query.Q_LOWER, key);
+    if (R.is_err[*query.QueryEntry, str](e)) { ret 0xFFFFFFFFFFFFFFFF; }
+    ret R.unwrap_ok[*query.QueryEntry, str](e).last_changed;
+}
+
+# inspect the `main` function in a module's borrowed optimized IR: 1 when it is
+# neutralized (a body-less extern), 0 when it retains its body, -1 when no `main`
+# function is present - the neutralization probe for the test-mode variant (#1858).
+fun ut_mod_main_neutralized(s: *session.Session, m: *ir.Module) i32 {
+    val mr: R.Result[intern.StrId, str] = intern.intern(?s.interner, "main");
+    if (R.is_err[intern.StrId, str](mr)) { ret -1; }
+    val main_id: intern.StrId = R.unwrap_ok[intern.StrId, str](mr);
+
+    var i: u32 = 0;
+    for (i < m.function_len) {
+        val fn: *ir.Function = ?m.functions[i];
+        if (fn.name == main_id) {
+            if ((fn.flags & ir.FN_FLAG_EXTERN) != 0 && fn.block_count == 0) { ret 1; }
+            ret 0;
+        }
+        i = i + 1;
+    }
+    ret -1;
+}
+
 # the last_changed revision of the project's Q_LINK entry on session `s`, or a
 # sentinel when absent. Q_LINK's value folds its inputs' revisions, so an unchanged
 # value means no link input changed - the link reuse probe (#1618).
@@ -7015,6 +7087,77 @@ test "mach.lang.driver:incremental_lower_verify_ir_toggle_relowers" {
     if (R.is_err[bool, str](run_lower_pass(?p3))) { dnit_project(?p3); filesystem.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
     if (ut_lower_lc(?sA, st_main) != lc2) { bad = 1; }
     dnit_project(?p3);
+
+    filesystem.remove_all(?alloc, root);
+    session.dnit(?sA);
+    ret bad;
+}
+
+# driver incremental: test-mode `main`-neutralization is a variant of Q_LOWER keyed
+# on (module, test-mode), not an in-place mutation of the cached IR. A warm session
+# that lowers the test variant (its `main` neutralized) then the normal variant of the
+# same module yields correct IR for both, and the test variant's cached value is never
+# rewritten by the normal build - query-owned IR is immutable by construction (#1858).
+test "mach.lang.driver:incremental_test_mode_neutralization_variant" {
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    val sr: R.Result[session.Session, str] = session.init(?alloc);
+    if (R.is_err[session.Session, str](sr)) { ret 1; }
+    var sA: session.Session = R.unwrap_ok[session.Session, str](sr);
+    if (R.is_err[bool, str](setup_registry(?sA.registry))) { session.dnit(?sA); ret 1; }
+
+    # `#[symbol("main")]` gives the entry the literal `main` linkage name (the program
+    # entry a normal build emits and a test build must neutralize); without it the
+    # entry mangles like any other symbol and nothing needs neutralizing.
+    var names: [2]str;
+    names[0] = "main.mach"; names[1] = "leaf.mach";
+    var texts: [2]str;
+    texts[0] = "use uniontest.leaf.fa;\n#[symbol(\"main\")]\nfun main() i32 { ret fa(); }\n";
+    texts[1] = "pub fun fa() i32 { ret 1; }\n";
+    val root_r: R.Result[str, str] = ut_scaffold(?alloc, ?names[0], ?texts[0], 2);
+    if (R.is_err[str, str](root_r)) { session.dnit(?sA); ret 1; }
+    val root: str = R.unwrap_ok[str, str](root_r);
+
+    var bad: i32 = 0;
+
+    # build 1: test mode. Q_LOWER computes the test variant, its `main` neutralized on
+    # the fresh IR before it is cached. the borrowed IR proves the produced variant is
+    # neutralized; lc_test1 pins its cached revision.
+    val p1r: R.Result[Project, str] = build_project_union(?sA, root);
+    if (R.is_err[Project, str](p1r)) { filesystem.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
+    var p1: Project = R.unwrap_ok[Project, str](p1r);
+    p1.test_mode = true;
+    if (R.is_err[bool, str](run_sema_pass(?p1)))  { dnit_project(?p1); filesystem.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
+    if (R.is_err[bool, str](run_lower_pass(?p1))) { dnit_project(?p1); filesystem.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
+    val st_main:  session.StableModuleId = ut_stable(?p1, ?sA, "uniontest.main");
+    val mid1: session.ModuleId = ut_mid(?p1, ?sA, "uniontest.main");
+    if (mid1 == session.MODULE_NIL) { dnit_project(?p1); filesystem.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
+    if (ut_mod_main_neutralized(?sA, p1.modules[mid1::u32].ir_module) != 1) { bad = 2; }
+    val key_test: u64 = back_half_key(st_main, true);
+    val key_norm: u64 = back_half_key(st_main, false);
+    val lc_test1: query.Revision = ut_lower_lc_key(?sA, key_test);
+    dnit_project(?p1);
+
+    # build 2: normal mode, same session, no edit. the normal variant lowers `main`
+    # with its body intact under a distinct key; the test variant, keyed separately,
+    # is not recomputed (its cached revision is unchanged) and so stays neutralized -
+    # both variants coexist and neither wrote through the other's handle.
+    val p2r: R.Result[Project, str] = build_project_union(?sA, root);
+    if (R.is_err[Project, str](p2r)) { filesystem.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
+    var p2: Project = R.unwrap_ok[Project, str](p2r);
+    p2.test_mode = false;
+    if (R.is_err[bool, str](run_sema_pass(?p2)))  { dnit_project(?p2); filesystem.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
+    if (R.is_err[bool, str](run_lower_pass(?p2))) { dnit_project(?p2); filesystem.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
+    val mid2: session.ModuleId = ut_mid(?p2, ?sA, "uniontest.main");
+    if (mid2 == session.MODULE_NIL) { dnit_project(?p2); filesystem.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
+    if (ut_mod_main_neutralized(?sA, p2.modules[mid2::u32].ir_module) != 0) { bad = 3; }
+    # the test variant's cached entry is still present and un-recomputed by the normal
+    # build (owned-handle shards never early-cut, so an unchanged revision means it was
+    # not re-lowered - it holds the same neutralized module build 1 produced).
+    if (ut_lower_lc_key(?sA, key_test) != lc_test1) { bad = 4; }
+    # the normal variant is its own live cached entry under the distinct key.
+    if (ut_lower_lc_key(?sA, key_norm) == 0xFFFFFFFFFFFFFFFF) { bad = 5; }
+    dnit_project(?p2);
 
     filesystem.remove_all(?alloc, root);
     session.dnit(?sA);

--- a/src/lang/me/lower/testrunner.mach
+++ b/src/lang/me/lower/testrunner.mach
@@ -17,8 +17,8 @@
 #     parameters from the target runtime, so the synthesized IR itself stays
 #     stdlib-independent.
 #
-# `neutralize_project_main` turns the project's own `main` into a body-less
-# extern so the test executable's sole program entry is the synthesized one.
+# `neutralize_main` turns a module's `main` into a body-less extern so the test
+# executable's sole program entry is the synthesized one.
 
 use std.types.bool.bool;
 use std.types.bool.true;
@@ -123,38 +123,33 @@ pub fun free(s: *session.Session, c: *Collected) {
     c.cap   = 0;
 }
 
-# turn every function whose linkage name is literally `main` into a body-less
-# extern, so the test executable's sole program entry is the synthesized
-# dispatcher `main`
+# turn a function whose linkage name is literally `main` into a body-less extern,
+# so a test executable's sole program entry is the synthesized dispatcher `main`
 #
-# The dropped blocks are reclaimed by the module's own dnit; a test build never
-# references the project's `main`, so the extern emits nothing. Called between
-# lowering and codegen in a test build.
+# Applied inside the test-mode Q_LOWER compute to the freshly-lowered module before
+# it becomes the cached query value, so the neutralized variant is produced by
+# construction rather than by mutating query-owned IR in place (#1858). The dropped
+# blocks are reclaimed by the module's own dnit; a test build never references the
+# project's `main`, so the extern emits nothing.
 # ---
-# s:       session holding the string interner
-# modules: the lowered module array to rewrite
-# count:   number of modules in `modules`
-# ret:     true on success, or an allocation error
-pub fun neutralize_project_main(s: *session.Session, modules: *ir.Module, count: u32) R.Result[bool, str] {
+# s:   session holding the string interner
+# mod: the lowered module to rewrite
+# ret: true on success, or an allocation error
+pub fun neutralize_main(s: *session.Session, mod: *ir.Module) R.Result[bool, str] {
     val res_main: R.Result[intern.StrId, str] = intern.intern(?s.interner, "main");
     if (R.is_err[intern.StrId, str](res_main)) {
         ret R.err[bool, str](R.unwrap_err[intern.StrId, str](res_main));
     }
     val main_id: intern.StrId = R.unwrap_ok[intern.StrId, str](res_main);
 
-    var i: u32 = 0;
-    for (i < count) {
-        val mod: *ir.Module = ?modules[i];
-        var ii: u32 = 0;
-        for (ii < mod.function_len) {
-            val fn: *ir.Function = ?mod.functions[ii];
-            if (fn.name == main_id && (fn.flags & ir.FN_FLAG_EXTERN) == 0) {
-                fn.flags       = fn.flags | ir.FN_FLAG_EXTERN;
-                fn.block_count = 0;
-            }
-            ii = ii + 1;
+    var ii: u32 = 0;
+    for (ii < mod.function_len) {
+        val fn: *ir.Function = ?mod.functions[ii];
+        if (fn.name == main_id && (fn.flags & ir.FN_FLAG_EXTERN) == 0) {
+            fn.flags       = fn.flags | ir.FN_FLAG_EXTERN;
+            fn.block_count = 0;
         }
-        i = i + 1;
+        ii = ii + 1;
     }
 
     ret R.ok[bool, str](true);

--- a/src/lang/query.mach
+++ b/src/lang/query.mach
@@ -84,9 +84,12 @@ pub val Q_EXPORTS: QueryKind = 8;
 # a module's ModuleId-embedding type identities re-checks it via Q_MODULE_NUMBER.
 pub val Q_SEMA: QueryKind = 9;
 # derived (owned handle): a module's optimized ir.Module, keyed on
-# sess.StableModuleId so an unchanged module's lowered IR is reused across
-# rebuilds even when a graph reshape renumbers per-build ModuleIds. mangled
-# linkage names are FQN-derived, so a cached module stays valid across a reshape.
+# sess.StableModuleId in the low 32 bits with the test-mode flag in bit 32, so an
+# unchanged module's lowered IR is reused across rebuilds even when a graph reshape
+# renumbers per-build ModuleIds. mangled linkage names are FQN-derived, so a cached
+# module stays valid across a reshape. the test-mode variant neutralizes the module's
+# `main` on its own freshly-lowered IR, so a test build and a normal build of the same
+# module cache independently and query-owned IR is never mutated in place (#1858).
 #
 # Reads Q_SEMA(module), Q_TARGET, Q_LOWER_FLAGS, and Q_SEMA of every module in this
 # module's transitive import closure: a generic/comptime instance declared in
@@ -94,7 +97,9 @@ pub val Q_SEMA: QueryKind = 9;
 # feeds this lowered output and a change there must re-lower this module (#1618).
 pub val Q_LOWER: QueryKind = 10;
 # derived (owned handle): a module's of.ObjectImage, keyed on sess.StableModuleId
-# so an unchanged module's codegen output is reused across rebuilds.
+# packed with the test-mode flag (the same key as Q_LOWER), so an unchanged module's
+# codegen output is reused across rebuilds and a test build codegens the neutralized
+# variant independently of the normal build (#1858).
 #
 # Reads Q_LOWER(module) and Q_TARGET. an unchanged lowered IR reuses the cached
 # image (and its on-disk `.o`) instead of re-emitting - the per-module


### PR DESCRIPTION
## What

The test build neutralized the project `main` by mutating the lowered `ir.Module` in place. Since #1618 that IR is owned by the query engine (`Q_LOWER`'s cached value), so the mutation wrote through into the cache. On the CLI's single-shot session this is harmless, but a long-lived session interleaving test and normal builds of the same module would serve neutralized IR to a normal build (or un-neutralized IR to a test build), whichever computed first.

## Fix

Per the issue's preferred design (candidate 2): make the neutralization a derived query keyed on `(module, test-mode)`.

- **`back_half_key(stable, test_mode)`** packs the stable id in the low 32 bits and the test-mode flag in bit 32. `Q_LOWER` and `Q_CODEGEN` key on it; `run_lower_one` / `run_codegen_one` pass the current build's mode (a new `Project.test_mode`, set by the CLI before `run_lower_pass`, default false).
- **`q_lower_compute`** neutralizes the module's `main` on its own freshly-lowered IR (before boxing/caching) when the key's test bit is set. Query-owned IR is immutable by construction — the compute never writes through a cached handle.
- **`Q_CODEGEN`** deps on `Q_LOWER` under the same packed key, so a test build codegens the neutralized IR and a normal build the untouched IR; the two cache independently.
- The CLI's in-place `neutralize_project_main` call is removed; `testrunner.neutralize_project_main` becomes single-module `testrunner.neutralize_main`, applied inside the compute.
- `Q_LINK` runs only on normal builds (test builds link per-test executables directly), so its `Q_CODEGEN` deps stay on the `test=false` key (`= stable`, unchanged).

## Verification (from-source compiler, never the seed)

- Byte-identical self-host fixpoint (stage-2 == stage-3).
- Full unit suite: **490 passed / 0 failed** (adds `incremental_test_mode_neutralization_variant`).
- int/ golden-diff harness: all cases pass on the linux leg.
- New driver test (`last_changed`-probe style): a warm session that lowers the test variant then the normal variant of the same module gets a neutralized `main` in the test variant and an intact `main` in the normal variant, and the test variant is not recomputed by the normal build — both cache independently.
- Falsifiability: disabling neutralization fails `mach test`'s own link (`multiple definition of 'main'`), confirming the path is load-bearing and preserved.

Closes #1858
