### PR TITLE
feat: session source-overlay API for live buffer text (#1588)

### DIFF
--- a/src/lang/driver.mach
+++ b/src/lang/driver.mach
@@ -2521,19 +2521,32 @@ fun parse_module(p: *Project, mid: session.ModuleId, fqn: intern.StrId) R.Result
     if (R.is_err[str, str](path_r)) { ret R.err[bool, str](R.unwrap_err[str, str](path_r)); }
     val file_path: str = R.unwrap_ok[str, str](path_r);
 
-    val text_r: R.Result[str, str] = filesystem.read_all(p.s.alloc, file_path);
-    if (R.is_err[str, str](text_r)) {
-        str_free(p.s.alloc, file_path);
-        ret R.err[bool, str](R.unwrap_err[str, str](text_r));
+    # an active overlay shadows the on-disk content: use the live unsaved buffer
+    # text as the source input instead of reading the file, so a long-lived session
+    # builds over unsaved edits (#1588). the overlay text is borrowed from the
+    # session (never freed here); a disk read is owned and freed below.
+    var text: str = nil;
+    var text_owned: bool = false;
+    val ov: O.Option[str] = session.overlay_get(p.s, file_path);
+    if (O.is_some[str](ov)) {
+        text = O.unwrap[str](ov);
     }
-    val text: str = R.unwrap_ok[str, str](text_r);
+    or {
+        val text_r: R.Result[str, str] = filesystem.read_all(p.s.alloc, file_path);
+        if (R.is_err[str, str](text_r)) {
+            str_free(p.s.alloc, file_path);
+            ret R.err[bool, str](R.unwrap_err[str, str](text_r));
+        }
+        text = R.unwrap_ok[str, str](text_r);
+        text_owned = true;
+    }
 
     # load_source mirrors the text into the Q_FILE_TEXT input; an unchanged file's
     # input keeps its last_changed (byte-equality cutoff), so the Q_PARSE entry
     # below stays valid and its AST is reused without re-parsing.
     val fid_r: R.Result[src.FileId, str] = session.load_source(p.s, file_path, text);
     str_free(p.s.alloc, file_path);
-    str_free(p.s.alloc, text);
+    if (text_owned) { str_free(p.s.alloc, text); }
     if (R.is_err[src.FileId, str](fid_r)) { ret R.err[bool, str](R.unwrap_err[src.FileId, str](fid_r)); }
     val file_id: src.FileId = R.unwrap_ok[src.FileId, str](fid_r);
 
@@ -5880,6 +5893,85 @@ test "mach.lang.driver:incremental_reused_phase_replays_diagnostics" {
 
     diagnostic.dnit(cold);
     A.deallocate[diagnostic.DiagList](?alloc, cold, 1::usize);
+    filesystem.remove_all(?alloc, root);
+    session.dnit(?s);
+    ret bad;
+}
+
+# driver incremental: a source overlay re-parses exactly the overlaid module and
+# leaves its importer's parse reused; the same overlay bytes reuse it, and clearing
+# it re-reads disk (#1588). probes Q_PARSE AST-handle identity, the reuse signal the
+# qparse test uses.
+test "mach.lang.driver:incremental_overlay_reparses_exactly_overlaid_module" {
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    val sr: R.Result[session.Session, str] = session.init(?alloc);
+    if (R.is_err[session.Session, str](sr)) { ret 1; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](sr);
+
+    val rr: R.Result[bool, str] = setup_registry(?s.registry);
+    if (R.is_err[bool, str](rr)) { session.dnit(?s); ret 1; }
+
+    var names: [2]str;
+    names[0] = "main.mach"; names[1] = "a.mach";
+    var texts: [2]str;
+    texts[0] = "use uniontest.a;\n\nfun main() i32 { ret 0; }\n";
+    texts[1] = "pub fun fa() i32 { ret 1; }\n";
+
+    val root_r: R.Result[str, str] = ut_scaffold(?alloc, ?names[0], ?texts[0], 2);
+    if (R.is_err[str, str](root_r)) { session.dnit(?s); ret 1; }
+    val root: str = R.unwrap_ok[str, str](root_r);
+
+    var bad: i32 = 0;
+
+    # build 1: cold, from disk. capture the two AST handles and a.mach's file id.
+    val p1r: R.Result[Project, str] = build_project_union(?s, root);
+    if (R.is_err[Project, str](p1r)) { filesystem.remove_all(?alloc, root); session.dnit(?s); ret 1; }
+    var p1: Project = R.unwrap_ok[Project, str](p1r);
+    val main1: *ast.Ast = ut_ast(?p1, ?s, "uniontest.main");
+    val a1:    *ast.Ast = ut_ast(?p1, ?s, "uniontest.a");
+    if (main1 == nil || a1 == nil) { bad = 1; }
+    val a_mid: session.ModuleId = ut_mid(?p1, ?s, "uniontest.a");
+    if (a_mid == session.MODULE_NIL) { filesystem.remove_all(?alloc, root); dnit_project(?p1); session.dnit(?s); ret 1; }
+    val a_fid: src.FileId = p1.modules[a_mid::u32].file_id;
+    dnit_project(?p1);
+
+    # the exact path the driver registered a.mach under: the overlay key must match
+    # the file_path parse_module computes, so read it back from the source map.
+    val sf_opt: O.Option[*src.SourceFile] = src.get(?s.sources, a_fid);
+    if (O.is_none[*src.SourceFile](sf_opt)) { filesystem.remove_all(?alloc, root); session.dnit(?s); ret 1; }
+    val a_path: str = O.unwrap[*src.SourceFile](sf_opt).path;
+
+    # build 2: overlay a.mach with DIFFERENT text. only a re-parses; main is reused.
+    val ov_text: str = "pub fun fa() i32 { ret 2; }\n";
+    if (R.is_err[bool, str](session.set_overlay(?s, a_path, ov_text))) { filesystem.remove_all(?alloc, root); session.dnit(?s); ret 1; }
+    val p2r: R.Result[Project, str] = build_project_union(?s, root);
+    if (R.is_err[Project, str](p2r)) { filesystem.remove_all(?alloc, root); session.dnit(?s); ret 1; }
+    var p2: Project = R.unwrap_ok[Project, str](p2r);
+    if (ut_ast(?p2, ?s, "uniontest.main") != main1) { bad = 1; }   # importer reused
+    if (ut_ast(?p2, ?s, "uniontest.a")    == a1)    { bad = 1; }   # overlaid module re-parsed
+    val a2: *ast.Ast = ut_ast(?p2, ?s, "uniontest.a");
+    dnit_project(?p2);
+
+    # build 3: set the SAME overlay bytes again. the byte cutoff reuses a's parse.
+    if (R.is_err[bool, str](session.set_overlay(?s, a_path, ov_text))) { filesystem.remove_all(?alloc, root); session.dnit(?s); ret 1; }
+    val p3r: R.Result[Project, str] = build_project_union(?s, root);
+    if (R.is_err[Project, str](p3r)) { filesystem.remove_all(?alloc, root); session.dnit(?s); ret 1; }
+    var p3: Project = R.unwrap_ok[Project, str](p3r);
+    if (ut_ast(?p3, ?s, "uniontest.main") != main1) { bad = 1; }
+    if (ut_ast(?p3, ?s, "uniontest.a")    != a2)    { bad = 1; }   # overlay unchanged: reused
+    dnit_project(?p3);
+
+    # build 4: clear the overlay. a re-reads disk (differs from the overlay), so it
+    # re-parses; main is still reused.
+    if (!session.clear_overlay(?s, a_path)) { bad = 1; }
+    val p4r: R.Result[Project, str] = build_project_union(?s, root);
+    if (R.is_err[Project, str](p4r)) { filesystem.remove_all(?alloc, root); session.dnit(?s); ret 1; }
+    var p4: Project = R.unwrap_ok[Project, str](p4r);
+    if (ut_ast(?p4, ?s, "uniontest.main") != main1) { bad = 1; }
+    if (ut_ast(?p4, ?s, "uniontest.a")    == a2)    { bad = 1; }   # back to disk: re-parsed
+    dnit_project(?p4);
+
     filesystem.remove_all(?alloc, root);
     session.dnit(?s);
     ret bad;

--- a/src/lang/session.mach
+++ b/src/lang/session.mach
@@ -5,12 +5,16 @@
 # engine remaps against. Every phase takes a `*Session` and routes its service
 # interactions through it.
 
+use std.allocator.page;
 use std.collections.map;
+use std.text.string.str_dup;
+use std.text.string.str_free;
 use std.types.bool.bool;
 use std.types.bool.false;
 use std.types.bool.true;
 use std.types.size.usize;
 use std.types.string.str;
+use std.types.string.str_equals;
 use std.types.string.str_len;
 
 use A: std.allocator;
@@ -33,6 +37,20 @@ fwd module.ModuleId;
 fwd module.MODULE_NIL;
 fwd module.StableModuleId;
 fwd module.STABLE_MODULE_NIL;
+
+# an in-memory source overlay: unsaved buffer `text` shadowing the on-disk content
+# of the file at `path` as the query engine's source input (#1588)
+#
+# The driver's parse read consults the overlay before touching disk, so a
+# long-lived session (an LSP) can drive builds over live, unsaved edits. Both
+# strings are owned by the session.
+# ---
+# path: the on-disk path the overlay shadows (owned)
+# text: the live buffer text to use instead of the file's content (owned)
+pub rec Overlay {
+    path: str;
+    text: str;
+}
 
 # top-level driver state shared across every compilation phase
 #
@@ -128,10 +146,22 @@ pub rec Session {
     # instead of the default fixed-address one. opt-in; the linker ORs it with the
     # target's own PIE requirement. off leaves the default ET_EXEC output unchanged.
     pie: bool;
+
+    # in-memory source overlays keyed by path (#1588): live unsaved buffer text a
+    # long-lived session's parse read uses instead of the file on disk. a small
+    # owned array scanned by path - the open-buffer set is tiny - grown on demand
+    # and freed in dnit. deliberately NOT cleared by reset_module_registry: an
+    # overlay must outlive a build to shadow the file on the next one.
+    overlays:    *Overlay;
+    overlay_len: u32;
+    overlay_cap: u32;
 }
 
 # seed capacity of the module-AST registry, doubled on demand from there
 val MODULE_AST_SEED_CAP: u32 = 16;
+
+# seed capacity of the source-overlay array, doubled on demand from there
+val OVERLAY_SEED_CAP: u32 = 4;
 
 # construct an empty Session backed by the given allocator
 #
@@ -170,6 +200,9 @@ pub fun init(alloc: *A.Allocator) R.Result[Session, str] {
     s.opt_release      = false;
     s.readout          = nil;
     s.pie              = false;
+    s.overlays         = nil;
+    s.overlay_len      = 0;
+    s.overlay_cap      = 0;
 
     val opt_types: O.Option[str] = type.init(?s.types, alloc);
     if (O.is_some[str](opt_types)) {
@@ -249,6 +282,19 @@ fun register_catalog(db: *query.QueryDb) R.Result[bool, str] {
 # s: session to tear down; sub-structures are dnit'd in reverse construction order
 pub fun dnit(s: *Session) {
     if (s == nil) { ret; }
+
+    if (s.overlays != nil && s.overlay_cap > 0) {
+        var oi: u32 = 0;
+        for (oi < s.overlay_len) {
+            str_free(s.alloc, s.overlays[oi].path);
+            str_free(s.alloc, s.overlays[oi].text);
+            oi = oi + 1;
+        }
+        A.deallocate[Overlay](s.alloc, s.overlays, s.overlay_cap::usize);
+        s.overlays    = nil;
+        s.overlay_len = 0;
+        s.overlay_cap = 0;
+    }
 
     if (s.module_asts != nil && s.module_ast_cap > 0) {
         A.deallocate[*ast.Ast](s.alloc, s.module_asts, s.module_ast_cap::usize);
@@ -746,4 +792,159 @@ pub fun load_source(s: *Session, path: str, text: str) R.Result[source.FileId, s
         ret R.err[source.FileId, str](R.unwrap_err[bool, str](res_input));
     }
     ret R.ok[source.FileId, str](fid);
+}
+
+# set (or replace) the in-memory source overlay for `path`
+#
+# `text` shadows the on-disk content of the file at `path` as the query engine's
+# source input the next build reads: the driver's parse read consults the overlay
+# before touching disk. The LSP feeds live unsaved buffer text this way, keyed by
+# path to sidestep its URI-keyed editor FileIds. Both strings are copied into the
+# session; replacing an existing overlay frees its prior text. An unchanged overlay
+# reused across builds keeps the module's Q_PARSE valid (load_source's Q_FILE_TEXT
+# byte cutoff); a changed one re-parses exactly the overlaid module (#1588).
+# ---
+# s:    the session
+# path: the on-disk path to shadow
+# text: the live buffer text to use instead of the file's content
+# ret:  true on success, or an allocation error
+pub fun set_overlay(s: *Session, path: str, text: str) R.Result[bool, str] {
+    val dup_text_r: R.Result[str, str] = str_dup(s.alloc, text);
+    if (R.is_err[str, str](dup_text_r)) { ret R.err[bool, str](R.unwrap_err[str, str](dup_text_r)); }
+    val dup_text: str = R.unwrap_ok[str, str](dup_text_r);
+
+    # replace an existing overlay's text in place, keeping its path key.
+    var i: u32 = 0;
+    for (i < s.overlay_len) {
+        if (str_equals(s.overlays[i].path, path)) {
+            str_free(s.alloc, s.overlays[i].text);
+            s.overlays[i].text = dup_text;
+            ret R.ok[bool, str](true);
+        }
+        i = i + 1;
+    }
+
+    # append a new overlay, growing the array on demand.
+    val dup_path_r: R.Result[str, str] = str_dup(s.alloc, path);
+    if (R.is_err[str, str](dup_path_r)) {
+        str_free(s.alloc, dup_text);
+        ret R.err[bool, str](R.unwrap_err[str, str](dup_path_r));
+    }
+    val dup_path: str = R.unwrap_ok[str, str](dup_path_r);
+
+    val res_grow: R.Result[bool, str] = overlays_reserve(s, s.overlay_len + 1);
+    if (R.is_err[bool, str](res_grow)) {
+        str_free(s.alloc, dup_text);
+        str_free(s.alloc, dup_path);
+        ret res_grow;
+    }
+    s.overlays[s.overlay_len].path = dup_path;
+    s.overlays[s.overlay_len].text = dup_text;
+    s.overlay_len = s.overlay_len + 1;
+    ret R.ok[bool, str](true);
+}
+
+# drop the overlay for `path`, so the next build reads the on-disk content again
+# ---
+# s:    the session
+# path: the overlaid path to clear
+# ret:  true when an overlay was present and removed, false when none matched
+pub fun clear_overlay(s: *Session, path: str) bool {
+    var i: u32 = 0;
+    for (i < s.overlay_len) {
+        if (str_equals(s.overlays[i].path, path)) {
+            str_free(s.alloc, s.overlays[i].path);
+            str_free(s.alloc, s.overlays[i].text);
+            val last: u32 = s.overlay_len - 1;
+            if (i != last) { s.overlays[i] = s.overlays[last]; }
+            s.overlay_len = last;
+            ret true;
+        }
+        i = i + 1;
+    }
+    ret false;
+}
+
+# the overlay text registered for `path`, or none
+#
+# The returned text is borrowed from the session, valid until the overlay is
+# replaced or cleared. The driver's parse read uses it in place of the file.
+# ---
+# s:    the session
+# path: the path to look up
+# ret:  some(text) when an overlay is set for path, none otherwise
+pub fun overlay_get(s: *Session, path: str) O.Option[str] {
+    var i: u32 = 0;
+    for (i < s.overlay_len) {
+        if (str_equals(s.overlays[i].path, path)) {
+            ret O.some[str](s.overlays[i].text);
+        }
+        i = i + 1;
+    }
+    ret O.none[str]();
+}
+
+# grow the overlay array to at least `need` slots, doubling from the seed capacity.
+fun overlays_reserve(s: *Session, need: u32) R.Result[bool, str] {
+    if (need <= s.overlay_cap) { ret R.ok[bool, str](true); }
+
+    var new_cap: u32 = s.overlay_cap;
+    if (new_cap == 0) { new_cap = OVERLAY_SEED_CAP; }
+    for (new_cap < need) { new_cap = new_cap * 2; }
+
+    if (s.overlays == nil) {
+        val res_alloc: R.Result[*Overlay, str] = A.allocate[Overlay](s.alloc, new_cap::usize);
+        if (R.is_err[*Overlay, str](res_alloc)) { ret R.err[bool, str](R.unwrap_err[*Overlay, str](res_alloc)); }
+        s.overlays = R.unwrap_ok[*Overlay, str](res_alloc);
+    }
+    or {
+        val res_realloc: R.Result[*Overlay, str] = A.reallocate[Overlay](s.alloc, s.overlays, s.overlay_cap::usize, new_cap::usize);
+        if (R.is_err[*Overlay, str](res_realloc)) { ret R.err[bool, str](R.unwrap_err[*Overlay, str](res_realloc)); }
+        s.overlays = R.unwrap_ok[*Overlay, str](res_realloc);
+    }
+    s.overlay_cap = new_cap;
+    ret R.ok[bool, str](true);
+}
+
+# overlays set, read back, replace text in place, and clear exactly one entry;
+# an absent path reads as none and clears false (#1588)
+test "mach.lang.session.overlay:set_get_replace_clear" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+    val sr: R.Result[Session, str] = init(?alloc);
+    if (R.is_err[Session, str](sr)) { ret 1; }
+    var s: Session = R.unwrap_ok[Session, str](sr);
+
+    var bad: i32 = 0;
+
+    # absent overlay reads as none; clearing an absent path is false.
+    if (O.is_some[str](overlay_get(?s, "/x/a.mach"))) { bad = 1; }
+    if (clear_overlay(?s, "/x/a.mach"))               { bad = 1; }
+
+    # set two overlays; each reads back its own text.
+    if (R.is_err[bool, str](set_overlay(?s, "/x/a.mach", "AAA"))) { dnit(?s); ret 1; }
+    if (R.is_err[bool, str](set_overlay(?s, "/x/b.mach", "BBB"))) { dnit(?s); ret 1; }
+    if (s.overlay_len != 2) { bad = 1; }
+    val ga: O.Option[str] = overlay_get(?s, "/x/a.mach");
+    val gb: O.Option[str] = overlay_get(?s, "/x/b.mach");
+    if (O.is_none[str](ga) || !str_equals(O.unwrap[str](ga), "AAA")) { bad = 1; }
+    if (O.is_none[str](gb) || !str_equals(O.unwrap[str](gb), "BBB")) { bad = 1; }
+
+    # replacing an existing path swaps text in place, adding no new slot.
+    if (R.is_err[bool, str](set_overlay(?s, "/x/a.mach", "A2"))) { dnit(?s); ret 1; }
+    if (s.overlay_len != 2) { bad = 1; }
+    val ga2: O.Option[str] = overlay_get(?s, "/x/a.mach");
+    if (O.is_none[str](ga2) || !str_equals(O.unwrap[str](ga2), "A2")) { bad = 1; }
+
+    # clearing removes exactly one; the sibling survives.
+    if (!clear_overlay(?s, "/x/a.mach"))              { bad = 1; }
+    if (s.overlay_len != 1)                           { bad = 1; }
+    if (O.is_some[str](overlay_get(?s, "/x/a.mach"))) { bad = 1; }
+    val gb2: O.Option[str] = overlay_get(?s, "/x/b.mach");
+    if (O.is_none[str](gb2) || !str_equals(O.unwrap[str](gb2), "BBB")) { bad = 1; }
+
+    # dnit frees the remaining overlay's owned strings; a clean teardown is the
+    # observable (the page allocator faults a leak/double-free).
+    dnit(?s);
+    ret bad;
 }


### PR DESCRIPTION
Closes #1588. Part of #1164; unblocks the live-buffer slice of octalide/mach-lsp#117.

## Problem
The driver is query-engine-driven, so the LSP already gets incremental Q_PARSE/Q_RESOLVE reuse for **saved** files. But feeding **live unsaved** buffer text into the cross-module graph was blocked: `parse_module` unconditionally `fs.read_all` + `load_source`, clobbering any LSP-set `Q_FILE_TEXT` on the next build.

## API
A session source overlay keyed by **path** (sidesteps the editor's URI-keyed FileIds):

- `session.set_overlay(s, path, text)` — store live buffer text shadowing the on-disk content (copied into the session; replacing an existing overlay frees its prior text).
- `session.clear_overlay(s, path)` — drop the overlay; returns whether one was present.
- `session.overlay_get(s, path)` — the overlay text for a path, or none (borrowed).

Backed by a small owned array scanned by path (the open-buffer set is tiny), grown on demand and freed in `dnit`; deliberately **not** cleared by `reset_module_registry`, so an overlay outlives a build.

`parse_module` consults `overlay_get(file_path)` before `fs.read_all`: an overlay's text becomes the source input (borrowed, not freed), else the file is read as before. `load_source` still mirrors the chosen text into `Q_FILE_TEXT`, so the byte-equality cutoff re-parses **exactly** the overlaid module on a change and reuses it when unchanged.

The LSP maps each open URI → path (`uri_to_path`), sets an overlay per open project-module buffer, and re-demands `build_project_union` — minimal recompute over unsaved edits.

## Verification (from-source compiler, native linux)
- from-source build: clean (0 errors / 0 warnings)
- self-host fixpoint: byte-identical (n2 == n3)
- unit suite: 492 passed / 0 failed (490 dev baseline + 2 new)
- int harness (`--target linux`): all cases passed
- new tests:
  - `mach.lang.session.overlay:set_get_replace_clear` — set/get/replace-in-place/clear-one + teardown
  - `mach.lang.driver:incremental_overlay_reparses_exactly_overlaid_module` — overlay set (differing) re-parses only the overlaid module and reuses its importer; same overlay bytes reuse it (byte cutoff); clear re-reads disk
