### PR TITLE
link(elf): target-parameterized max page size (aarch64-linux 64K)

### DIFF
--- a/src/lang/be/linker.mach
+++ b/src/lang/be/linker.mach
@@ -689,7 +689,7 @@ fun emit_executable(s: *session.Session, tgt: *target.Target, out_img: *of.Objec
     val funcs: *of.ExecFunction = R.unwrap_ok[*of.ExecFunction, str](fr);
 
     val emit_r: R.Result[bool, str] =
-        tgt.of.emit_exec(alloc, ?s.interner, tgt.arch, segs, seg_count, entry, funcs, func_count, out_path, name);
+        tgt.of.emit_exec(alloc, ?s.interner, tgt.arch, segs, seg_count, os_page_size(tgt), entry, funcs, func_count, out_path, name);
 
     if (funcs != nil && func_count > 0) {
         A.deallocate[of.ExecFunction](alloc, funcs, func_count::usize);
@@ -749,7 +749,7 @@ fun emit_dynamic_executable(s: *session.Session, tgt: *target.Target, out_img: *
     val funcs: *of.ExecFunction = R.unwrap_ok[*of.ExecFunction, str](fr);
 
     val emit_r: R.Result[bool, str] =
-        tgt.of.emit_dyn_exec(alloc, ?s.interner, tgt.arch, segs, seg_count, entry,
+        tgt.of.emit_dyn_exec(alloc, ?s.interner, tgt.arch, segs, seg_count, os_page_size(tgt), entry,
                              funcs, func_count, ?dyn.info, dyn.fixups, dyn.fixup_count, out_path, name);
 
     if (funcs != nil && func_count > 0) {

--- a/src/lang/target.mach
+++ b/src/lang/target.mach
@@ -649,7 +649,7 @@ test "mach.lang.target.select_of:freestanding_raw_emits_flat_image" {
 
     # enter at the image base; the raw writer rejects any other entry.
     val em: R.Result[bool, str] =
-        t.of.emit_exec(?alloc, ?itn, t.arch, ?segs[0], 1, t.os.base_addr, nil::*of.ExecFunction, 0, tpath::*u8, "selraw"::*u8);
+        t.of.emit_exec(?alloc, ?itn, t.arch, ?segs[0], 1, t.os.page_size, t.os.base_addr, nil::*of.ExecFunction, 0, tpath::*u8, "selraw"::*u8);
     if (R.is_err[bool, str](em)) { filesystem.temp_close_and_remove(?tf); ret 1; }
 
     val rr: R.Result[filesystem.Buffer, str] = filesystem.read_all_sized(?alloc, tpath);

--- a/src/lang/target/of.mach
+++ b/src/lang/target/of.mach
@@ -411,15 +411,19 @@ pub def ParserFn: fun(*A.Allocator, *intern.Interner, *u8, usize, *ObjectImage) 
 # arg 2: the instruction-set vtable describing the machine
 # arg 3: the loadable segments, in ascending virtual-address order
 # arg 4: number of load segments
-# arg 5: program entry-point virtual address
-# arg 6: per-function descriptors (may be nil when count is 0)
-# arg 7: number of per-function descriptors
-# arg 8: null-terminated output file path
-# arg 9: null-terminated product name (the artifact's stable identity, independent
+# arg 5: the segment-alignment page size the linker aligned the vaddrs to (the OS's
+#        `page_size_for` policy); the writer's p_align, header-page reservation, and
+#        file-offset congruence use this one value. formats with a fixed container
+#        page (Mach-O, PE) may ignore it.
+# arg 6: program entry-point virtual address
+# arg 7: per-function descriptors (may be nil when count is 0)
+# arg 8: number of per-function descriptors
+# arg 9: null-terminated output file path
+# arg 10: null-terminated product name (the artifact's stable identity, independent
 #        of the `-o` output path); used as the Mach-O code-signing identifier and
 #        ignored by formats that do not sign
 # ret:   true on success, or an error string
-pub def ExecFn: fun(*A.Allocator, *intern.Interner, *isa.IsaVTable, *LoadSegment, u32, u64,
+pub def ExecFn: fun(*A.Allocator, *intern.Interner, *isa.IsaVTable, *LoadSegment, u32, u64, u64,
                     *ExecFunction, u32, *u8, *u8) R.Result[bool, str];
 
 # a dynamically-linked-executable writer: serializes the linker's laid-out load
@@ -442,18 +446,21 @@ pub def ExecFn: fun(*A.Allocator, *intern.Interner, *isa.IsaVTable, *LoadSegment
 # arg 2:  the instruction-set vtable describing the machine
 # arg 3:  the loadable segments, in ascending virtual-address order
 # arg 4:  number of load segments
-# arg 5:  program entry-point virtual address
-# arg 6:  per-function descriptors (may be nil when count is 0)
-# arg 7:  number of per-function descriptors
-# arg 8:  the dynamic-link plan (dependencies, imports, interpreter)
-# arg 9:  the import call-site fixups to redirect to call-thunks
-# arg 10: number of fixups
-# arg 11: null-terminated output file path
-# arg 12: null-terminated product name (the artifact's stable identity, independent
+# arg 5:  the segment-alignment page size the linker aligned the vaddrs to (the OS's
+#         `page_size_for` policy); the writer's p_align, header-page reservation, and
+#         file-offset congruence use this one value
+# arg 6:  program entry-point virtual address
+# arg 7:  per-function descriptors (may be nil when count is 0)
+# arg 8:  number of per-function descriptors
+# arg 9:  the dynamic-link plan (dependencies, imports, interpreter)
+# arg 10: the import call-site fixups to redirect to call-thunks
+# arg 11: number of fixups
+# arg 12: null-terminated output file path
+# arg 13: null-terminated product name (the artifact's stable identity, independent
 #         of the `-o` output path); used as the Mach-O code-signing identifier and
 #         ignored by formats that do not sign
 # ret:    true on success, or an error string
-pub def DynExecFn: fun(*A.Allocator, *intern.Interner, *isa.IsaVTable, *LoadSegment, u32, u64,
+pub def DynExecFn: fun(*A.Allocator, *intern.Interner, *isa.IsaVTable, *LoadSegment, u32, u64, u64,
                        *ExecFunction, u32, *DynamicInfo, *PltFixup, u32, *u8, *u8) R.Result[bool, str];
 
 # maximum number of instruction sets an OfVTable's ISA-coverage list holds

--- a/src/lang/target/of/coff.mach
+++ b/src/lang/target/of/coff.mach
@@ -2262,13 +2262,15 @@ fun compute_pe_layout(itn: *intern.Interner, lay: *PeLayout, segs: *of.LoadSegme
 # segs:       the loadable segments, in ascending virtual-address order
 # seg_count:  number of load segments
 # entry:      program entry-point virtual address
+# page_size:  segment-alignment page (unused; PE uses its own fixed section/file
+#             alignment - PE_SECTION_ALIGN / PE_FILE_ALIGN)
 # funcs:      per-function metadata for unwind-table emission
 # func_count: number of entries in funcs
 # path:       null-terminated output file path
 # name:       product name; accepted for of.ExecFn conformance (PE does not sign here)
 # ret:        ok(true) on success, or an error string
 fun coff_emit_exec(alloc: *A.Allocator, itn: *intern.Interner, isa_vt: *isa.IsaVTable, segs: *of.LoadSegment,
-                   seg_count: u32, entry: u64, funcs: *of.ExecFunction,
+                   seg_count: u32, page_size: u64, entry: u64, funcs: *of.ExecFunction,
                    func_count: u32, path: *u8, name: *u8) R.Result[bool, str] {
     # a static PE carries no dynamic plan, so it resolves no interned names; the
     # interner is forwarded only so a write failure can be located on its path.
@@ -2288,6 +2290,8 @@ fun coff_emit_exec(alloc: *A.Allocator, itn: *intern.Interner, isa_vt: *isa.IsaV
 # isa_vt:      the instruction-set vtable describing the machine (must be x86-64)
 # segs:        the loadable segments, in ascending virtual-address order
 # seg_count:   number of load segments
+# page_size:   segment-alignment page (unused; PE uses its own fixed section/file
+#              alignment - PE_SECTION_ALIGN / PE_FILE_ALIGN)
 # entry:       program entry-point virtual address
 # funcs:       per-function metadata for unwind-table emission
 # func_count:  number of entries in funcs
@@ -2298,7 +2302,7 @@ fun coff_emit_exec(alloc: *A.Allocator, itn: *intern.Interner, isa_vt: *isa.IsaV
 # name:        product name; accepted for of.DynExecFn conformance (PE does not sign)
 # ret:         ok(true) on success, or an error string
 fun coff_emit_dyn_exec(alloc: *A.Allocator, itn: *intern.Interner, isa_vt: *isa.IsaVTable, segs: *of.LoadSegment,
-                       seg_count: u32, entry: u64, funcs: *of.ExecFunction,
+                       seg_count: u32, page_size: u64, entry: u64, funcs: *of.ExecFunction,
                        func_count: u32, dyn: *of.DynamicInfo,
                        fixups: *of.PltFixup, fixup_count: u32, path: *u8, name: *u8) R.Result[bool, str] {
     ret write_pe(alloc, itn, isa_vt, segs, seg_count, entry, funcs, func_count, dyn, fixups, fixup_count, path);
@@ -3476,7 +3480,7 @@ test "mach.lang.target.of.coff.coff_emit_exec:pe32plus_header" {
     if (R.is_err[filesystem.TempFile, str](tf_r)) { ret 1; }
     var tf: filesystem.TempFile = R.unwrap_ok[filesystem.TempFile, str](tf_r);
 
-    val em: R.Result[bool, str] = coff_emit_exec(?alloc, ?i, ?isa_vt, ?segs[0], 2, entry, nil, 0, filesystem.temp_path(?tf)::*u8, "coffexe"::*u8);
+    val em: R.Result[bool, str] = coff_emit_exec(?alloc, ?i, ?isa_vt, ?segs[0], 2, 4096, entry, nil, 0, filesystem.temp_path(?tf)::*u8, "coffexe"::*u8);
     if (R.is_err[bool, str](em)) { filesystem.temp_close_and_remove(?tf); ret 1; }
 
     val rb: R.Result[filesystem.Buffer, str] = filesystem.read_all_sized(?alloc, filesystem.temp_path(?tf));
@@ -3720,7 +3724,7 @@ test "mach.lang.target.of.coff.coff_emit_exec:unwind_xdata_pdata" {
     if (R.is_err[filesystem.TempFile, str](tf_r)) { ret 1; }
     var tf: filesystem.TempFile = R.unwrap_ok[filesystem.TempFile, str](tf_r);
 
-    val em: R.Result[bool, str] = coff_emit_exec(?alloc, ?i, ?isa_vt, ?segs[0], 1, entry, ?funcs[0], 1, filesystem.temp_path(?tf)::*u8, "coffunwind"::*u8);
+    val em: R.Result[bool, str] = coff_emit_exec(?alloc, ?i, ?isa_vt, ?segs[0], 1, 4096, entry, ?funcs[0], 1, filesystem.temp_path(?tf)::*u8, "coffunwind"::*u8);
     if (R.is_err[bool, str](em)) { filesystem.temp_close_and_remove(?tf); ret 1; }
 
     val rb: R.Result[filesystem.Buffer, str] = filesystem.read_all_sized(?alloc, filesystem.temp_path(?tf));

--- a/src/lang/target/of/elf.mach
+++ b/src/lang/target/of/elf.mach
@@ -4313,6 +4313,82 @@ test "mach.lang.target.of.elf.emit_pie_exec:relro_splits_rodata_from_rel_ro" {
     ret 0;
 }
 
+# emit_pie_exec stamps the target's page size onto every PT_LOAD's p_align and keeps each
+# segment's file offset congruent to its vaddr modulo that page - the kernel's exec check.
+# A 64 KiB page (aarch64's max-page) must reach every load header, so a 4 KiB-page kernel
+# and a 16 KiB or 64 KiB one all admit the one image (#1845).
+test "mach.lang.target.of.elf.emit_pie_exec:page_align_congruence_64k" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+    var i: intern.Interner = intern.init(?alloc);
+
+    var isa_vt: isa.IsaVTable;
+    isa_vt.id            = isa.ARCH_AARCH64;
+    isa_vt.elf_machine   = 183;      # EM_AARCH64
+    isa_vt.pointer_width = 8;
+
+    # three 64 KiB-aligned segments (the linker aligns vaddrs to the target page before
+    # the writer runs); text, pure `.rodata`, and a reloc-bearing `.data.rel.ro`.
+    var text:   [16]u8;
+    var rodata: [16]u8;
+    var relro:  [16]u8;
+    var k: usize = 0;
+    for (k < 16) { text[k] = 0x90; rodata[k] = 0; relro[k] = 0; k = k + 1; }
+    var segs: [3]of.LoadSegment;
+    segs[0].vaddr = 0x410000; segs[0].filesz = 16; segs[0].memsz = 16;
+    segs[0].flags = of.SEG_FLAG_READ | of.SEG_FLAG_EXECUTE; segs[0].bytes = ?text[0];
+    segs[1].vaddr = 0x420000; segs[1].filesz = 16; segs[1].memsz = 16;
+    segs[1].flags = of.SEG_FLAG_READ; segs[1].bytes = ?rodata[0];
+    segs[2].vaddr = 0x430000; segs[2].filesz = 16; segs[2].memsz = 16;
+    segs[2].flags = of.SEG_FLAG_READ; segs[2].bytes = ?relro[0];
+
+    var brs: [1]of.BaseReloc;
+    brs[0].seg_index = 2; brs[0].seg_offset = 8; brs[0].target = 0x410000;
+
+    var dyn: of.DynamicInfo;
+    dyn.libs = nil;            dyn.lib_count = 0;
+    dyn.imports = nil;         dyn.import_count = 0;
+    dyn.interp = intern.STR_NIL;
+    dyn.base_relocs = ?brs[0]; dyn.base_reloc_count = 1;
+    dyn.pie = true;
+
+    val tf_r: R.Result[filesystem.TempFile, str] = filesystem.temp_create(?alloc, "elf_align");
+    if (R.is_err[filesystem.TempFile, str](tf_r)) { ret 1; }
+    var tf: filesystem.TempFile = R.unwrap_ok[filesystem.TempFile, str](tf_r);
+    val tpath: str = filesystem.temp_path(?tf);
+
+    val em: R.Result[bool, str] = emit_pie_exec(?alloc, ?i, ?isa_vt, ?segs[0], 3, 65536, 0x410000, ?dyn, tpath::*u8);
+    if (R.is_err[bool, str](em)) { filesystem.temp_close_and_remove(?tf); ret 1; }
+
+    val rb: R.Result[filesystem.Buffer, str] = filesystem.read_all_sized(?alloc, tpath);
+    filesystem.temp_close_and_remove(?tf);
+    if (R.is_err[filesystem.Buffer, str](rb)) { ret 1; }
+    val buf: filesystem.Buffer = R.unwrap_ok[filesystem.Buffer, str](rb);
+
+    var bad: bool = false;
+    # every PT_LOAD carries the 64 KiB p_align and keeps p_offset congruent to p_vaddr
+    # modulo the page (65536 = 0x10000, so the low 16 bits must match).
+    val e_phoff: usize = bin.read_u64_le(buf.data, 32)::usize;
+    val e_phnum: usize = bin.read_u16_le(buf.data, 56)::usize;
+    var loads: u32 = 0;
+    var ph: usize = 0;
+    for (ph < e_phnum) {
+        val po: usize = e_phoff + ph * PHDR_SIZE;
+        if (bin.read_u32_le(buf.data, po) == PT_LOAD) {
+            val poff:  u64 = bin.read_u64_le(buf.data, po + 8);
+            val pvad:  u64 = bin.read_u64_le(buf.data, po + 16);
+            val palgn: u64 = bin.read_u64_le(buf.data, po + 48);
+            loads = loads + 1;
+            if (palgn != 65536)                     { bad = true; }
+            if ((poff & 0xFFFF) != (pvad & 0xFFFF)) { bad = true; }
+        }
+        ph = ph + 1;
+    }
+    if (loads == 0) { bad = true; }
+    if (bad) { ret 1; }
+    ret 0;
+}
+
 # header_fits_reserved_page pins the one-page header threshold the PIE writer refuses
 # past: the ELF header + phdr table must fit the single page the linker reserves below
 # segment 0, so on a 4 KiB page `64 + 72*56 == 4096` fits exactly and 73 headers (4152

--- a/src/lang/target/of/elf.mach
+++ b/src/lang/target/of/elf.mach
@@ -204,12 +204,6 @@ val PHDR_SIZE:       usize = 56;
 val SYM_SIZE:        usize = 24;
 val RELA_SIZE:       usize = 24;
 
-# default page size for static executables; segment vaddrs are page-aligned. must match
-# the OS page size the linker laid the segments out with (linux: `LINUX_PAGE_SIZE`, via
-# `assign_section_vaddrs`) - the PIE header gap and the PT_GNU_RELRO page-rounding both
-# assume this writer's page equals the segment-alignment page.
-val EXEC_PAGE_SIZE: u64 = 4096;
-
 # resolve an interned StrId to its backing text, or nil for an absent interner
 # or an out-of-range id
 #
@@ -1206,7 +1200,7 @@ fun seg_section_flags(flags: u32) u64 {
 # name:       product name; accepted for of.ExecFn conformance (ELF does not sign)
 # ret:        ok(true) on success, or an error string
 fun emit_exec(alloc: *A.Allocator, itn: *intern.Interner, tgt_isa: *isa.IsaVTable, segs: *of.LoadSegment,
-              seg_count: u32, entry: u64, funcs: *of.ExecFunction,
+              seg_count: u32, page_size: u64, entry: u64, funcs: *of.ExecFunction,
               func_count: u32, path: *u8, name: *u8) R.Result[bool, str] {
     if (tgt_isa == nil) { ret R.err[bool, str]("elf: nil exec isa"); }
     if (path == nil)    { ret R.err[bool, str]("elf: nil exec path"); }
@@ -1230,10 +1224,10 @@ fun emit_exec(alloc: *A.Allocator, itn: *intern.Interner, tgt_isa: *isa.IsaVTabl
         seg_offsets = R.unwrap_ok[*usize, str](ro);
     }
 
-    var total_size: usize = bin.align_up(phdr_offset + phdr_table_size, EXEC_PAGE_SIZE::usize);
+    var total_size: usize = bin.align_up(phdr_offset + phdr_table_size, page_size::usize);
     var li: u32 = 0;
     for (li < seg_count) {
-        total_size = bin.align_up(total_size, EXEC_PAGE_SIZE::usize);
+        total_size = bin.align_up(total_size, page_size::usize);
         seg_offsets[li] = total_size;
         total_size = total_size + segs[li].filesz;
         li = li + 1;
@@ -1315,8 +1309,8 @@ fun emit_exec(alloc: *A.Allocator, itn: *intern.Interner, tgt_isa: *isa.IsaVTabl
     var phdr_pos: usize = phdr_offset;
 
     # leading PT_LOAD covering the ELF header and the program headers.
-    var hdr_vaddr: u64 = entry & ~(EXEC_PAGE_SIZE - 1);
-    if (seg_count > 0) { hdr_vaddr = segs[0].vaddr & ~(EXEC_PAGE_SIZE - 1); }
+    var hdr_vaddr: u64 = entry & ~(page_size - 1);
+    if (seg_count > 0) { hdr_vaddr = segs[0].vaddr & ~(page_size - 1); }
     val hdr_filesz: usize = phdr_offset + phdr_table_size;
     bin.write_u32_le(buf, phdr_pos, PT_LOAD);
     bin.write_u32_le(buf, phdr_pos + 4, PF_R);
@@ -1325,7 +1319,7 @@ fun emit_exec(alloc: *A.Allocator, itn: *intern.Interner, tgt_isa: *isa.IsaVTabl
     bin.write_u64_le(buf, phdr_pos + 24, hdr_vaddr);
     bin.write_u64_le(buf, phdr_pos + 32, hdr_filesz::u64);
     bin.write_u64_le(buf, phdr_pos + 40, hdr_filesz::u64);
-    bin.write_u64_le(buf, phdr_pos + 48, EXEC_PAGE_SIZE);
+    bin.write_u64_le(buf, phdr_pos + 48, page_size);
     phdr_pos = phdr_pos + PHDR_SIZE;
 
     li = 0;
@@ -1337,7 +1331,7 @@ fun emit_exec(alloc: *A.Allocator, itn: *intern.Interner, tgt_isa: *isa.IsaVTabl
         bin.write_u64_le(buf, phdr_pos + 24, segs[li].vaddr);
         bin.write_u64_le(buf, phdr_pos + 32, segs[li].filesz::u64);
         bin.write_u64_le(buf, phdr_pos + 40, segs[li].memsz::u64);
-        bin.write_u64_le(buf, phdr_pos + 48, EXEC_PAGE_SIZE);
+        bin.write_u64_le(buf, phdr_pos + 48, page_size);
         phdr_pos = phdr_pos + PHDR_SIZE;
 
         if (segs[li].bytes != nil && segs[li].filesz > 0) {
@@ -1380,7 +1374,7 @@ fun emit_exec(alloc: *A.Allocator, itn: *intern.Interner, tgt_isa: *isa.IsaVTabl
             bin.write_u64_le(buf, hp + 32, segs[li].filesz::u64);
             bin.write_u32_le(buf, hp + 40, 0);
             bin.write_u32_le(buf, hp + 44, 0);
-            bin.write_u64_le(buf, hp + 48, EXEC_PAGE_SIZE);
+            bin.write_u64_le(buf, hp + 48, page_size);
             bin.write_u64_le(buf, hp + 56, 0);
             hp = hp + SHDR_SIZE;
             name_cursor = name_cursor + str_len(seg_section_name(segs[li].flags)) + 1;
@@ -1435,15 +1429,16 @@ fun emit_exec(alloc: *A.Allocator, itn: *intern.Interner, tgt_isa: *isa.IsaVTabl
 # 0 so it covers the ELF header and the program-header table, mapping them at
 # `segs[0].vaddr - page`. That holds the loader's `p_offset == p_vaddr (mod page)`
 # congruence only while the header block fits that one page: `ELF_HEADER_SIZE + phdr_count
-# * PHDR_SIZE <= page`, i.e. `phdr_count <= 72`. A larger table spills onto a second page,
-# pushing the first segment's file offset a page past `hdr_vaddr + page` so segment 0 no
-# longer maps at its vaddr - an image the kernel refuses to exec. The writer refuses at
-# link time instead.
+# * PHDR_SIZE <= page` (with a 4 KiB page, `phdr_count <= 72`; a larger max-page raises the
+# bound). A larger table spills onto a second page, pushing the first segment's file offset
+# a page past `hdr_vaddr + page` so segment 0 no longer maps at its vaddr - an image the
+# kernel refuses to exec. The writer refuses at link time instead.
 # ---
 # phdr_count: the number of program headers the writer will emit
+# page_size:  the segment-alignment page the header block must fit within
 # ret:        true when the header block still fits its one reserved page
-fun header_fits_reserved_page(phdr_count: u32) bool {
-    ret ELF_HEADER_SIZE + phdr_count::usize * PHDR_SIZE <= EXEC_PAGE_SIZE::usize;
+fun header_fits_reserved_page(phdr_count: u32, page_size: u64) bool {
+    ret ELF_HEADER_SIZE + phdr_count::usize * PHDR_SIZE <= page_size::usize;
 }
 
 # write a position-independent (PIE / ET_DYN) static executable for linux ASLR
@@ -1480,12 +1475,13 @@ fun header_fits_reserved_page(phdr_count: u32) bool {
 # tgt_isa:   the instruction-set vtable selecting the ELF machine + RELATIVE type
 # segs:      the linker's loadable segments, ascending virtual-address order
 # seg_count: number of segments
+# page_size: the segment-alignment page (p_align, header reservation, offset congruence)
 # entry:     program entry-point virtual address (link-time)
 # dyn:       the dynamic-link plan carrying the base-relocation set
 # path:      null-terminated output file path
 # ret:       ok(true) on success, or an error string
 fun emit_pie_exec(alloc: *A.Allocator, itn: *intern.Interner, tgt_isa: *isa.IsaVTable,
-                  segs: *of.LoadSegment, seg_count: u32, entry: u64,
+                  segs: *of.LoadSegment, seg_count: u32, page_size: u64, entry: u64,
                   dyn: *of.DynamicInfo, path: *u8) R.Result[bool, str] {
     val nrel: u32 = dyn.base_reloc_count;
 
@@ -1510,7 +1506,7 @@ fun emit_pie_exec(alloc: *A.Allocator, itn: *intern.Interner, tgt_isa: *isa.IsaV
     # the first PT_LOAD covers the ELF header + phdr table by extending one page below
     # segment 0; a header block larger than that page would break segment 0's mapping, so
     # refuse rather than emit an image the kernel cannot exec (see #1814).
-    if (!header_fits_reserved_page(phdr_count)) {
+    if (!header_fits_reserved_page(phdr_count, page_size)) {
         ret R.err[bool, str]("elf: PIE program headers exceed the one-page header reservation (too many load segments)");
     }
 
@@ -1518,7 +1514,7 @@ fun emit_pie_exec(alloc: *A.Allocator, itn: *intern.Interner, tgt_isa: *isa.IsaV
     val phdr_table_size: usize = phdr_count::usize * PHDR_SIZE;
 
     # per-segment file offsets, page-aligned so `offset % page == vaddr % page` holds.
-    var struct_file: usize = bin.align_up(phdr_offset + phdr_table_size, EXEC_PAGE_SIZE::usize);
+    var struct_file: usize = bin.align_up(phdr_offset + phdr_table_size, page_size::usize);
     var seg_offsets: *usize = nil;
     if (seg_count > 0) {
         val ro: R.Result[*usize, str] = A.zallocate[usize](alloc, seg_count::usize);
@@ -1526,7 +1522,7 @@ fun emit_pie_exec(alloc: *A.Allocator, itn: *intern.Interner, tgt_isa: *isa.IsaV
         seg_offsets = R.unwrap_ok[*usize, str](ro);
         li = 0;
         for (li < seg_count) {
-            struct_file = bin.align_up(struct_file, EXEC_PAGE_SIZE::usize);
+            struct_file = bin.align_up(struct_file, page_size::usize);
             seg_offsets[li] = struct_file;
             struct_file = struct_file + segs[li].filesz;
             li = li + 1;
@@ -1535,8 +1531,8 @@ fun emit_pie_exec(alloc: *A.Allocator, itn: *intern.Interner, tgt_isa: *isa.IsaV
 
     # the synthesized read-only segment: .rela.dyn (Elf64_Rela[nrel]) then .dynamic,
     # page-aligned above the linker segments. file offset and vaddr advance in lockstep.
-    val ro_off: usize = bin.align_up(struct_file, EXEC_PAGE_SIZE::usize);
-    val ro_va:  u64   = bin.align_up_u64(hi_va, EXEC_PAGE_SIZE);
+    val ro_off: usize = bin.align_up(struct_file, page_size::usize);
+    val ro_va:  u64   = bin.align_up_u64(hi_va, page_size);
     val reladyn_off:  usize = ro_off;
     val reladyn_va:   u64   = ro_va;
     val reladyn_size: usize = nrel::usize * RELA_SIZE;
@@ -1611,7 +1607,7 @@ fun emit_pie_exec(alloc: *A.Allocator, itn: *intern.Interner, tgt_isa: *isa.IsaV
     dpos = write_dyn_entry(buf, dpos, DT_NULL, 0);
 
     write_pie_phdrs(buf, phdr_offset, phdr_count, segs, seg_offsets, seg_count,
-                    ro_off, ro_va, ro_size, dyn_off, dyn_va, dyn_size, dyn);
+                    ro_off, ro_va, ro_size, dyn_off, dyn_va, dyn_size, dyn, page_size);
 
     if (seg_offsets != nil) { A.deallocate[usize](alloc, seg_offsets, seg_count::usize); }
 
@@ -1648,17 +1644,18 @@ fun emit_pie_exec(alloc: *A.Allocator, itn: *intern.Interner, tgt_isa: *isa.IsaV
 # ro_off/ro_va/ro_size:    the synthesized read-only segment (.rela.dyn + .dynamic)
 # dyn_off/dyn_va/dyn_size:  the .dynamic table
 # dyn:          the dynamic-link plan, for the per-segment writable check
+# page_size:    the segment-alignment page (p_align and the one-page header gap)
 fun write_pie_phdrs(buf: *u8, phdr_offset: usize, phdr_count: u32,
                     segs: *of.LoadSegment, seg_offsets: *usize, seg_count: u32,
                     ro_off: usize, ro_va: u64, ro_size: usize,
-                    dyn_off: usize, dyn_va: u64, dyn_size: usize, dyn: *of.DynamicInfo) {
+                    dyn_off: usize, dyn_va: u64, dyn_size: usize, dyn: *of.DynamicInfo, page_size: u64) {
     var pos: usize = phdr_offset;
     val phdr_bytes: usize = phdr_count::usize * PHDR_SIZE;
 
     # the page the ELF header + phdrs map at: one page below the first segment's base,
     # so extending the first segment down to file offset 0 covers them.
     var hdr_vaddr: u64 = 0;
-    if (seg_count > 0) { hdr_vaddr = (segs[0].vaddr & ~(EXEC_PAGE_SIZE - 1)) - EXEC_PAGE_SIZE; }
+    if (seg_count > 0) { hdr_vaddr = (segs[0].vaddr & ~(page_size - 1)) - page_size; }
 
     # PT_PHDR -> the program-header table (within the first, header-covering PT_LOAD).
     pos = write_phdr(buf, pos, PT_PHDR, PF_R, phdr_offset, hdr_vaddr + phdr_offset::u64,
@@ -1670,17 +1667,17 @@ fun write_pie_phdrs(buf: *u8, phdr_offset: usize, phdr_count: u32,
             val first_filesz: usize = seg_offsets[0] + segs[0].filesz;
             val first_memsz:  usize = seg_offsets[0] + segs[0].memsz;
             pos = write_phdr(buf, pos, PT_LOAD, pie_seg_flags(segs, li, seg_count, dyn), 0,
-                             hdr_vaddr, first_filesz, first_memsz, EXEC_PAGE_SIZE);
+                             hdr_vaddr, first_filesz, first_memsz, page_size);
         }
         or {
             pos = write_phdr(buf, pos, PT_LOAD, pie_seg_flags(segs, li, seg_count, dyn), seg_offsets[li],
-                             segs[li].vaddr, segs[li].filesz, segs[li].memsz, EXEC_PAGE_SIZE);
+                             segs[li].vaddr, segs[li].filesz, segs[li].memsz, page_size);
         }
         li = li + 1;
     }
 
     # the synthesized .rela.dyn/.dynamic read-only segment.
-    pos = write_phdr(buf, pos, PT_LOAD, PF_R, ro_off, ro_va, ro_size, ro_size, EXEC_PAGE_SIZE);
+    pos = write_phdr(buf, pos, PT_LOAD, PF_R, ro_off, ro_va, ro_size, ro_size, page_size);
     # PT_DYNAMIC -> the .dynamic table.
     pos = write_phdr(buf, pos, PT_DYNAMIC, PF_R, dyn_off, dyn_va, dyn_size, dyn_size, 8);
 
@@ -1695,7 +1692,7 @@ fun write_pie_phdrs(buf: *u8, phdr_offset: usize, phdr_count: u32,
     val relro_seg: i64 = pie_relro_seg(segs, seg_count, dyn);
     if (relro_seg >= 0) {
         val ri: u32 = relro_seg::u32;
-        val relro_size: usize = bin.align_up(segs[ri].memsz, EXEC_PAGE_SIZE::usize);
+        val relro_size: usize = bin.align_up(segs[ri].memsz, page_size::usize);
         pos = write_phdr(buf, pos, PT_GNU_RELRO, PF_R, seg_offsets[ri], segs[ri].vaddr,
                          relro_size, relro_size, 1);
     }
@@ -1932,6 +1929,7 @@ fun dynstr_name_len(itn: *intern.Interner, id: intern.StrId) usize {
 # tgt_isa:     instruction-set vtable selecting the ELF machine and JUMP_SLOT type
 # segs:        the linker's loadable segments, ascending virtual-address order
 # seg_count:   number of segments
+# page_size:   the segment-alignment page (p_align, header reservation, offset congruence)
 # entry:       program entry-point virtual address
 # funcs:       per-function metadata (unused; see above)
 # func_count:  number of entries in funcs (unused; see above)
@@ -1942,7 +1940,7 @@ fun dynstr_name_len(itn: *intern.Interner, id: intern.StrId) usize {
 # name:        product name; accepted for of.DynExecFn conformance (ELF does not sign)
 # ret:         ok(true) on success, or an error string
 fun emit_dyn_exec(alloc: *A.Allocator, itn: *intern.Interner, tgt_isa: *isa.IsaVTable, segs: *of.LoadSegment,
-                  seg_count: u32, entry: u64, funcs: *of.ExecFunction,
+                  seg_count: u32, page_size: u64, entry: u64, funcs: *of.ExecFunction,
                   func_count: u32, dyn: *of.DynamicInfo, fixups: *of.PltFixup,
                   fixup_count: u32, path: *u8, name: *u8) R.Result[bool, str] {
     if (tgt_isa == nil) { ret R.err[bool, str]("elf: nil dyn-exec isa"); }
@@ -1968,7 +1966,7 @@ fun emit_dyn_exec(alloc: *A.Allocator, itn: *intern.Interner, tgt_isa: *isa.IsaV
         if (dyn.import_count > 0 || dyn.lib_count > 0) {
             ret R.err[bool, str]("elf: PIE with dynamic imports is not supported (static-PIE only)");
         }
-        ret emit_pie_exec(alloc, itn, tgt_isa, segs, seg_count, entry, dyn, path);
+        ret emit_pie_exec(alloc, itn, tgt_isa, segs, seg_count, page_size, entry, dyn, path);
     }
 
     val nimp: u32 = func_import_count(dyn);
@@ -1993,7 +1991,7 @@ fun emit_dyn_exec(alloc: *A.Allocator, itn: *intern.Interner, tgt_isa: *isa.IsaV
     # like the PIE writer, the first PT_LOAD covers the ELF header + phdr table by
     # extending one page below segment 0; a header block larger than that page would break
     # segment 0's mapping, so refuse rather than emit an unloadable image (see #1814).
-    if (!header_fits_reserved_page(phdr_count)) {
+    if (!header_fits_reserved_page(phdr_count, page_size)) {
         ret R.err[bool, str]("elf: dynamic-exec program headers exceed the one-page header reservation (too many load segments)");
     }
 
@@ -2003,7 +2001,7 @@ fun emit_dyn_exec(alloc: *A.Allocator, itn: *intern.Interner, tgt_isa: *isa.IsaV
     # the file offset where the synthesized structures begin: after the linker's
     # segment file bytes, page-aligned. the linker segments are written at file
     # offsets matching their vaddr page (`offset % page == vaddr % page`).
-    var struct_file: usize = bin.align_up(phdr_offset + phdr_table_size, EXEC_PAGE_SIZE::usize);
+    var struct_file: usize = bin.align_up(phdr_offset + phdr_table_size, page_size::usize);
     var seg_offsets: *usize = nil;
     if (seg_count > 0) {
         val ro: R.Result[*usize, str] = A.zallocate[usize](alloc, seg_count::usize);
@@ -2011,7 +2009,7 @@ fun emit_dyn_exec(alloc: *A.Allocator, itn: *intern.Interner, tgt_isa: *isa.IsaV
         seg_offsets = R.unwrap_ok[*usize, str](ro);
         li = 0;
         for (li < seg_count) {
-            struct_file = bin.align_up(struct_file, EXEC_PAGE_SIZE::usize);
+            struct_file = bin.align_up(struct_file, page_size::usize);
             seg_offsets[li] = struct_file;
             struct_file = struct_file + segs[li].filesz;
             li = li + 1;
@@ -2019,8 +2017,8 @@ fun emit_dyn_exec(alloc: *A.Allocator, itn: *intern.Interner, tgt_isa: *isa.IsaV
     }
 
     var lay: DynLayout;
-    compute_dyn_layout(itn, ?lay, dyn, nimp, tgt_isa.id, bin.align_up(struct_file, EXEC_PAGE_SIZE::usize),
-                       bin.align_up_u64(hi_va, EXEC_PAGE_SIZE));
+    compute_dyn_layout(itn, ?lay, dyn, nimp, tgt_isa.id, bin.align_up(struct_file, page_size::usize),
+                       bin.align_up_u64(hi_va, page_size), page_size);
 
     val total_size: usize = lay.rw_off + lay.rw_size;
 
@@ -2103,7 +2101,7 @@ fun emit_dyn_exec(alloc: *A.Allocator, itn: *intern.Interner, tgt_isa: *isa.IsaV
 
     # program headers: leading header-cover PT_LOAD, PT_INTERP, the linker
     # segments, the RO/PLT/RW synthesized segments, then PT_DYNAMIC.
-    write_dyn_phdrs(buf, phdr_offset, ?lay, segs, seg_offsets, seg_count);
+    write_dyn_phdrs(buf, phdr_offset, ?lay, segs, seg_offsets, seg_count, page_size);
 
     if (seg_offsets != nil) { A.deallocate[usize](alloc, seg_offsets, seg_count::usize); }
 
@@ -2136,9 +2134,10 @@ fun emit_dyn_exec(alloc: *A.Allocator, itn: *intern.Interner, tgt_isa: *isa.IsaV
 # arch_id:     the target ISA id selecting the PLT[0] size and BIND_NOW entries
 # struct_file: file offset the synthesized structures start at
 # struct_va:   virtual address the synthesized structures start at
+# page_size:   the segment-alignment page the .text/.rodata/.data splits round to
 fun compute_dyn_layout(itn: *intern.Interner, lay: *DynLayout, dyn: *of.DynamicInfo, nimp: u32,
-                       arch_id: u32, struct_file: usize, struct_va: u64) {
-    val page_sz: usize = EXEC_PAGE_SIZE::usize;
+                       arch_id: u32, struct_file: usize, struct_va: u64, page_size: u64) {
+    val page_sz: usize = page_size::usize;
 
     # read-only metadata segment.
     lay.ro_off = struct_file;
@@ -2752,14 +2751,15 @@ fun func_ordinal(dyn: *of.DynamicInfo, import_index: u32) u32 {
 # segs:        the linker's loadable segments
 # seg_offsets: per-segment file offsets of the linker's segments
 # seg_count:   number of segments
+# page_size:   the segment-alignment page (p_align and the one-page header gap)
 fun write_dyn_phdrs(buf: *u8, phdr_offset: usize, lay: *DynLayout,
-                    segs: *of.LoadSegment, seg_offsets: *usize, seg_count: u32) {
+                    segs: *of.LoadSegment, seg_offsets: *usize, seg_count: u32, page_size: u64) {
     var pos: usize = phdr_offset;
 
     # the page the ELF header + phdrs map at: one page below the first segment's
     # base, so extending the first segment down to file offset 0 covers them.
     var hdr_vaddr: u64 = 0;
-    if (seg_count > 0) { hdr_vaddr = (segs[0].vaddr & ~(EXEC_PAGE_SIZE - 1)) - EXEC_PAGE_SIZE; }
+    if (seg_count > 0) { hdr_vaddr = (segs[0].vaddr & ~(page_size - 1)) - page_size; }
 
     # PT_PHDR -> the program-header table, so the dynamic loader can locate the
     # program's own headers. it lies within the first (header+text) PT_LOAD.
@@ -2778,19 +2778,19 @@ fun write_dyn_phdrs(buf: *u8, phdr_offset: usize, lay: *DynLayout,
             val first_filesz: usize = seg_offsets[0] + segs[0].filesz;
             val first_memsz:  usize = seg_offsets[0] + segs[0].memsz;
             pos = write_phdr(buf, pos, PT_LOAD, pf_flags_for(segs[0].flags), 0,
-                             hdr_vaddr, first_filesz, first_memsz, EXEC_PAGE_SIZE);
+                             hdr_vaddr, first_filesz, first_memsz, page_size);
         }
         or {
             pos = write_phdr(buf, pos, PT_LOAD, pf_flags_for(segs[li].flags), seg_offsets[li],
-                             segs[li].vaddr, segs[li].filesz, segs[li].memsz, EXEC_PAGE_SIZE);
+                             segs[li].vaddr, segs[li].filesz, segs[li].memsz, page_size);
         }
         li = li + 1;
     }
 
     # RO metadata, PLT (R+X), RW (R+W) synthesized segments.
-    pos = write_phdr(buf, pos, PT_LOAD, PF_R, lay.ro_off, lay.ro_va, lay.ro_size, lay.ro_size, EXEC_PAGE_SIZE);
-    pos = write_phdr(buf, pos, PT_LOAD, PF_R | PF_X, lay.plt_off, lay.plt_va, lay.plt_size, lay.plt_size, EXEC_PAGE_SIZE);
-    pos = write_phdr(buf, pos, PT_LOAD, PF_R | PF_W, lay.rw_off, lay.rw_va, lay.rw_size, lay.rw_size, EXEC_PAGE_SIZE);
+    pos = write_phdr(buf, pos, PT_LOAD, PF_R, lay.ro_off, lay.ro_va, lay.ro_size, lay.ro_size, page_size);
+    pos = write_phdr(buf, pos, PT_LOAD, PF_R | PF_X, lay.plt_off, lay.plt_va, lay.plt_size, lay.plt_size, page_size);
+    pos = write_phdr(buf, pos, PT_LOAD, PF_R | PF_W, lay.rw_off, lay.rw_va, lay.rw_size, lay.rw_size, page_size);
 
     # PT_DYNAMIC -> the .dynamic table.
     pos = write_phdr(buf, pos, PT_DYNAMIC, PF_R | PF_W, lay.dynamic_off, lay.dynamic_va,
@@ -3808,7 +3808,7 @@ fun t_emit_dyn_one(alloc: *A.Allocator, itn: *intern.Interner, arch_id: u32, lay
     dyn.base_relocs = nil;     dyn.base_reloc_count = 0;
     dyn.pie = false;
 
-    compute_dyn_layout(itn, lay, ?dyn, 1, arch_id, 0, 0x400000);
+    compute_dyn_layout(itn, lay, ?dyn, 1, arch_id, 0, 0x400000, 4096);
     val total: usize = lay.rw_off + lay.rw_size;
     val rb: R.Result[*u8, str] = A.zallocate[u8](alloc, total);
     if (R.is_err[*u8, str](rb)) { ret nil; }
@@ -4125,7 +4125,7 @@ test "mach.lang.target.of.elf.emit_pie_exec:static_pie_layout" {
     var tf: filesystem.TempFile = R.unwrap_ok[filesystem.TempFile, str](tf_r);
     val tpath: str = filesystem.temp_path(?tf);
 
-    val em: R.Result[bool, str] = emit_pie_exec(?alloc, ?i, ?isa_vt, ?segs[0], 1, 0x401000, ?dyn, tpath::*u8);
+    val em: R.Result[bool, str] = emit_pie_exec(?alloc, ?i, ?isa_vt, ?segs[0], 1, 4096, 0x401000, ?dyn, tpath::*u8);
     if (R.is_err[bool, str](em)) { filesystem.temp_close_and_remove(?tf); ret 1; }
 
     val rb: R.Result[filesystem.Buffer, str] = filesystem.read_all_sized(?alloc, tpath);
@@ -4259,7 +4259,7 @@ test "mach.lang.target.of.elf.emit_pie_exec:relro_splits_rodata_from_rel_ro" {
     var tf: filesystem.TempFile = R.unwrap_ok[filesystem.TempFile, str](tf_r);
     val tpath: str = filesystem.temp_path(?tf);
 
-    val em: R.Result[bool, str] = emit_pie_exec(?alloc, ?i, ?isa_vt, ?segs[0], 4, 0x401000, ?dyn, tpath::*u8);
+    val em: R.Result[bool, str] = emit_pie_exec(?alloc, ?i, ?isa_vt, ?segs[0], 4, 4096, 0x401000, ?dyn, tpath::*u8);
     if (R.is_err[bool, str](em)) { filesystem.temp_close_and_remove(?tf); ret 1; }
 
     val rb: R.Result[filesystem.Buffer, str] = filesystem.read_all_sized(?alloc, tpath);
@@ -4293,8 +4293,8 @@ test "mach.lang.target.of.elf.emit_pie_exec:relro_splits_rodata_from_rel_ro" {
             relro_vaddr = pvaddr;
             if (pflags != PF_R)            { bad = true; }
             if (pvaddr != 0x404000)        { bad = true; }
-            if (pfilesz != EXEC_PAGE_SIZE) { bad = true; }
-            if (pmemsz != EXEC_PAGE_SIZE)  { bad = true; }
+            if (pfilesz != 4096) { bad = true; }
+            if (pmemsz != 4096)  { bad = true; }
         }
         if (pt == PT_LOAD && pvaddr == 0x402000) { rodata_load_flags = pflags; }
         if (pt == PT_LOAD && pvaddr == 0x403000) { data_load_flags = pflags; }
@@ -4315,12 +4315,15 @@ test "mach.lang.target.of.elf.emit_pie_exec:relro_splits_rodata_from_rel_ro" {
 
 # header_fits_reserved_page pins the one-page header threshold the PIE writer refuses
 # past: the ELF header + phdr table must fit the single page the linker reserves below
-# segment 0, so `64 + 72*56 == 4096` fits exactly and 73 headers (4152 bytes) do not.
+# segment 0, so on a 4 KiB page `64 + 72*56 == 4096` fits exactly and 73 headers (4152
+# bytes) do not, while a 64 KiB max-page admits far more (the aarch64 case).
 test "mach.lang.target.of.elf.header_fits_reserved_page:one_page_threshold" {
     var bad: bool = false;
-    if (!header_fits_reserved_page(1))  { bad = true; }
-    if (!header_fits_reserved_page(72)) { bad = true; }
-    if (header_fits_reserved_page(73))  { bad = true; }
+    if (!header_fits_reserved_page(1, 4096))  { bad = true; }
+    if (!header_fits_reserved_page(72, 4096)) { bad = true; }
+    if (header_fits_reserved_page(73, 4096))  { bad = true; }
+    # a 64 KiB max-page (aarch64) fits the 73-header table that overflows a 4 KiB page.
+    if (!header_fits_reserved_page(73, 65536)) { bad = true; }
     if (bad) { ret 1; }
     ret 0;
 }
@@ -4345,7 +4348,7 @@ test "mach.lang.target.of.elf.emit_pie_exec:header_overflow_refused" {
     var segs: [70]of.LoadSegment;
     var s: u32 = 0;
     for (s < 70) {
-        segs[s].vaddr = 0x401000 + s::u64 * EXEC_PAGE_SIZE;
+        segs[s].vaddr = 0x401000 + s::u64 * 4096;
         segs[s].filesz = 0; segs[s].memsz = 0;
         segs[s].flags = of.SEG_FLAG_READ; segs[s].bytes = nil;
         s = s + 1;
@@ -4363,7 +4366,7 @@ test "mach.lang.target.of.elf.emit_pie_exec:header_overflow_refused" {
     var tf: filesystem.TempFile = R.unwrap_ok[filesystem.TempFile, str](tf_r);
     val tpath: str = filesystem.temp_path(?tf);
 
-    val em: R.Result[bool, str] = emit_pie_exec(?alloc, ?i, ?isa_vt, ?segs[0], 70, 0x401000, ?dyn, tpath::*u8);
+    val em: R.Result[bool, str] = emit_pie_exec(?alloc, ?i, ?isa_vt, ?segs[0], 70, 4096, 0x401000, ?dyn, tpath::*u8);
     filesystem.temp_close_and_remove(?tf);
     if (R.is_ok[bool, str](em)) { ret 1; }
     ret 0;
@@ -4388,7 +4391,7 @@ test "mach.lang.target.of.elf.emit_dyn_exec:header_overflow_refused" {
     var segs: [67]of.LoadSegment;
     var s: u32 = 0;
     for (s < 67) {
-        segs[s].vaddr = 0x401000 + s::u64 * EXEC_PAGE_SIZE;
+        segs[s].vaddr = 0x401000 + s::u64 * 4096;
         segs[s].filesz = 0; segs[s].memsz = 0;
         segs[s].flags = of.SEG_FLAG_READ; segs[s].bytes = nil;
         s = s + 1;
@@ -4407,7 +4410,7 @@ test "mach.lang.target.of.elf.emit_dyn_exec:header_overflow_refused" {
     var tf: filesystem.TempFile = R.unwrap_ok[filesystem.TempFile, str](tf_r);
     val tpath: str = filesystem.temp_path(?tf);
 
-    val em: R.Result[bool, str] = emit_dyn_exec(?alloc, ?i, ?isa_vt, ?segs[0], 67, 0x401000,
+    val em: R.Result[bool, str] = emit_dyn_exec(?alloc, ?i, ?isa_vt, ?segs[0], 67, 4096, 0x401000,
                                                 nil::*of.ExecFunction, 0, ?dyn, nil::*of.PltFixup, 0,
                                                 tpath::*u8, "dynoverflow"::*u8);
     filesystem.temp_close_and_remove(?tf);

--- a/src/lang/target/of/macho.mach
+++ b/src/lang/target/of/macho.mach
@@ -1367,6 +1367,8 @@ fun write_code_signature(buf: *u8, sig_off: usize, name: *u8, code_limit: usize,
 # isa_vt:     the instruction-set vtable selecting the cputype and thread state
 # segs:       loadable segments, in ascending virtual-address order
 # seg_count:  number of segments
+# page_size:  segment-alignment page (unused; Mach-O maps its own fixed per-arch vm
+#             page via `macho_page_size` - 16 KiB arm64, 4 KiB x86_64)
 # entry:      program entry-point virtual address
 # funcs:      per-function metadata (unused)
 # func_count: number of entries in funcs (unused)
@@ -1374,7 +1376,7 @@ fun write_code_signature(buf: *u8, sig_off: usize, name: *u8, code_limit: usize,
 # name:       null-terminated product name; the filename-stable code-sign identifier
 # ret:        ok(true) on success, or an error string
 fun emit_exec(alloc: *A.Allocator, itn: *intern.Interner, isa_vt: *isa.IsaVTable, segs: *of.LoadSegment,
-              seg_count: u32, entry: u64, funcs: *of.ExecFunction, func_count: u32,
+              seg_count: u32, page_size: u64, entry: u64, funcs: *of.ExecFunction, func_count: u32,
               path: *u8, name: *u8) R.Result[bool, str] {
     if (isa_vt == nil) { ret R.err[bool, str]("macho: nil exec isa"); }
     if (path == nil)   { ret R.err[bool, str]("macho: nil exec path"); }
@@ -2183,6 +2185,8 @@ fun dyn_sect_flags(flags: u32, zerofill: bool) u32 {
 # isa_vt:      the instruction-set vtable selecting the cputype and stub encoding
 # segs:        loadable segments, in ascending virtual-address order
 # seg_count:   number of segments
+# page_size:   segment-alignment page (unused; Mach-O maps its own fixed per-arch vm
+#              page via `macho_page_size`)
 # entry:       program entry-point virtual address
 # funcs:       per-function metadata (unused)
 # func_count:  number of entries in funcs (unused)
@@ -2193,7 +2197,7 @@ fun dyn_sect_flags(flags: u32, zerofill: bool) u32 {
 # name:        null-terminated product name; the filename-stable code-sign identifier
 # ret:         ok(true) on success, or an error string
 fun emit_dyn_exec(alloc: *A.Allocator, itn: *intern.Interner, isa_vt: *isa.IsaVTable, segs: *of.LoadSegment,
-                  seg_count: u32, entry: u64, funcs: *of.ExecFunction, func_count: u32,
+                  seg_count: u32, page_size: u64, entry: u64, funcs: *of.ExecFunction, func_count: u32,
                   dyn: *of.DynamicInfo, fixups: *of.PltFixup, fixup_count: u32,
                   path: *u8, name: *u8) R.Result[bool, str] {
     if (isa_vt == nil) { ret R.err[bool, str]("macho: nil dyn-exec isa"); }
@@ -3434,7 +3438,7 @@ fun ts_exec_x64() u8 {
 
     # the product name is deliberately not the temp-file basename, to prove the
     # code-sign identifier tracks the name, not the output path.
-    val em: R.Result[bool, str] = emit_exec(?alloc, ?itn, ?isa_vt, ?segs[0], 1, entry, nil::*of.ExecFunction, 0, tpath::*u8, "machoexe"::*u8);
+    val em: R.Result[bool, str] = emit_exec(?alloc, ?itn, ?isa_vt, ?segs[0], 1, 4096, entry, nil::*of.ExecFunction, 0, tpath::*u8, "machoexe"::*u8);
     if (R.is_err[bool, str](em)) { filesystem.temp_close_and_remove(?tf); ret 1; }
 
     val rb: R.Result[filesystem.Buffer, str] = filesystem.read_all_sized(?alloc, tpath);
@@ -3511,7 +3515,7 @@ fun ts_exec_arm64() u8 {
     var tf: filesystem.TempFile = R.unwrap_ok[filesystem.TempFile, str](tf_r);
     val tpath: str = filesystem.temp_path(?tf);
 
-    val em: R.Result[bool, str] = emit_exec(?alloc, ?itn, ?isa_vt, ?segs[0], 1, entry, nil::*of.ExecFunction, 0, tpath::*u8, "machoa64"::*u8);
+    val em: R.Result[bool, str] = emit_exec(?alloc, ?itn, ?isa_vt, ?segs[0], 1, 16384, entry, nil::*of.ExecFunction, 0, tpath::*u8, "machoa64"::*u8);
     if (R.is_err[bool, str](em)) { filesystem.temp_close_and_remove(?tf); ret 1; }
 
     val rb: R.Result[filesystem.Buffer, str] = filesystem.read_all_sized(?alloc, tpath);
@@ -3628,7 +3632,7 @@ fun ts_dyn_exec(arch_id: u32) u8 {
     var tf: filesystem.TempFile = R.unwrap_ok[filesystem.TempFile, str](tf_r);
     val tpath: str = filesystem.temp_path(?tf);
 
-    val em: R.Result[bool, str] = emit_dyn_exec(?alloc, ?itn, ?isa_vt, ?segs[0], 1, entry,
+    val em: R.Result[bool, str] = emit_dyn_exec(?alloc, ?itn, ?isa_vt, ?segs[0], 1, 4096, entry,
                                                 nil::*of.ExecFunction, 0, ?dyn, ?fx[0], 1, tpath::*u8, "machodyn"::*u8);
     if (R.is_err[bool, str](em)) { filesystem.temp_close_and_remove(?tf); ret 1; }
 

--- a/src/lang/target/of/raw.mach
+++ b/src/lang/target/of/raw.mach
@@ -135,6 +135,8 @@ fun parse_object(a: *A.Allocator, itn: *intern.Interner, buf: *u8, buf_len: usiz
 #             nil check; a flat image embeds no machine field)
 # segs:       loadable segments, in ascending virtual-address order
 # seg_count:  number of segments
+# page_size:  segment-alignment page (unused; a flat image lays segments out by
+#             their already-assigned vaddrs with no page granularity of its own)
 # entry:      program entry-point virtual address (must equal the image base)
 # funcs:      per-function metadata (unused; see above)
 # func_count: number of entries in funcs (unused; see above)
@@ -142,7 +144,7 @@ fun parse_object(a: *A.Allocator, itn: *intern.Interner, buf: *u8, buf_len: usiz
 # name:       product name; accepted for of.ExecFn conformance (a flat image is unsigned)
 # ret:        ok(true) on success, or an error string
 fun emit_exec(alloc: *A.Allocator, itn: *intern.Interner, tgt_isa: *isa.IsaVTable, segs: *of.LoadSegment,
-              seg_count: u32, entry: u64, funcs: *of.ExecFunction,
+              seg_count: u32, page_size: u64, entry: u64, funcs: *of.ExecFunction,
               func_count: u32, path: *u8, name: *u8) R.Result[bool, str] {
     if (tgt_isa == nil) { ret R.err[bool, str]("raw: nil exec isa"); }
     if (path == nil)    { ret R.err[bool, str]("raw: nil exec path"); }
@@ -186,6 +188,7 @@ fun emit_exec(alloc: *A.Allocator, itn: *intern.Interner, tgt_isa: *isa.IsaVTabl
 # tgt_isa:    instruction-set vtable describing the machine
 # segs:       loadable segments
 # seg_count:  number of segments
+# page_size:  segment-alignment page (unused; a flat image is never dynamically linked)
 # entry:      program entry-point virtual address
 # funcs:      per-function metadata
 # func_count: number of entries in funcs
@@ -196,7 +199,7 @@ fun emit_exec(alloc: *A.Allocator, itn: *intern.Interner, tgt_isa: *isa.IsaVTabl
 # name:       product name; accepted for of.DynExecFn conformance (always unsupported)
 # ret:        the unsupported-format error
 fun emit_dyn_exec(alloc: *A.Allocator, itn: *intern.Interner, tgt_isa: *isa.IsaVTable, segs: *of.LoadSegment,
-                  seg_count: u32, entry: u64, funcs: *of.ExecFunction, func_count: u32,
+                  seg_count: u32, page_size: u64, entry: u64, funcs: *of.ExecFunction, func_count: u32,
                   dyn: *of.DynamicInfo, fixups: *of.PltFixup, fixup_count: u32,
                   path: *u8, name: *u8) R.Result[bool, str] {
     ret R.err[bool, str](RAW_UNSUPPORTED);
@@ -285,7 +288,7 @@ test "mach.lang.target.of.raw.emit_exec:flat_layout" {
     val tpath: str = filesystem.temp_path(?tf);
 
     val em: R.Result[bool, str] =
-        emit_exec(?alloc, ?i, ?isa_vt, ?segs[0], 2, 0x1000, nil::*of.ExecFunction, 0, tpath::*u8, "rawflat"::*u8);
+        emit_exec(?alloc, ?i, ?isa_vt, ?segs[0], 2, 4096, 0x1000, nil::*of.ExecFunction, 0, tpath::*u8, "rawflat"::*u8);
     if (R.is_err[bool, str](em)) { filesystem.temp_close_and_remove(?tf); ret 1; }
 
     val rr: R.Result[filesystem.Buffer, str] = filesystem.read_all_sized(?alloc, tpath);
@@ -335,7 +338,7 @@ test "mach.lang.target.of.raw.emit_exec:entry_must_be_base" {
 
     # entry 0x1008 != image base 0x1000 must be rejected.
     val em: R.Result[bool, str] =
-        emit_exec(?alloc, ?i, ?isa_vt, ?segs[0], 1, 0x1008, nil::*of.ExecFunction, 0, "raw_should_not_exist"::*u8, "rawbad"::*u8);
+        emit_exec(?alloc, ?i, ?isa_vt, ?segs[0], 1, 4096, 0x1008, nil::*of.ExecFunction, 0, "raw_should_not_exist"::*u8, "rawbad"::*u8);
     if (!R.is_err[bool, str](em))                                { ret 1; }
     if (!str_contains(R.unwrap_err[bool, str](em), "base"))      { ret 1; }
     ret 0;

--- a/src/lang/target/os.mach
+++ b/src/lang/target/os.mach
@@ -69,16 +69,20 @@ pub val OS_OF_MAX: u32 = 8;
 # ret:   true when a PIE main executable is required for that architecture
 pub def PieExecFn: fun(u32) bool;
 
-# a per-os segment page size policy, parameterized by architecture id
+# a per-os segment-alignment page size policy, parameterized by architecture id
 #
-# Returns the virtual-memory page size the OS maps segments in for the given
-# architecture, when it varies by architecture (Darwin: 16 KiB on arm64, 4 KiB on
-# x86_64 - the kernel rejects a segment that is not page-aligned to it). The linker
-# aligns segment virtual addresses to it. A nil `page_size_for` means the OS uses
-# its fixed `page_size` for every architecture.
+# Returns the page size the linker aligns segment virtual addresses to for the
+# given architecture, chosen so the image loads on every kernel page size that
+# architecture supports. It is the OS's own fixed per-arch page where that is
+# constant (Darwin: 16 KiB on arm64, 4 KiB on x86_64 - the kernel rejects a
+# segment not aligned to it), or the conventional max page where the kernel page
+# is configurable (Linux aarch64: 64 KiB, covering 4K/16K/64K-page kernels). The
+# linker aligns vaddrs to it and threads the same value into the ELF writer's
+# p_align and header-reservation math. A nil `page_size_for` means the OS uses its
+# fixed `page_size` for every architecture.
 # ---
 # arg 0: the target architecture id (one of isa.ARCH_*)
-# ret:   the segment page size in bytes for that architecture
+# ret:   the segment-alignment page size in bytes for that architecture
 pub def PageSizeFn: fun(u32) u64;
 
 # a per-os native calling-convention policy, parameterized by architecture id

--- a/src/lang/target/os/linux.mach
+++ b/src/lang/target/os/linux.mach
@@ -112,3 +112,15 @@ pub fun register_linux(reg: *os.OsRegistry) R.Result[bool, str] {
     os.register(reg, ?linux_vtable);
     ret R.ok[bool, str](true);
 }
+
+# linux_page_size pins the per-arch segment-alignment page: aarch64 uses the 64 KiB
+# max-page (so an image loads on 4K/16K/64K-page kernels), x86_64 and riscv64 the fixed
+# 4 KiB. This is the single page-size home the linker and ELF writer both consume.
+test "mach.lang.target.os.linux.linux_page_size:per_arch_max_page" {
+    var bad: bool = false;
+    if (linux_page_size(isa.ARCH_AARCH64) != 65536) { bad = true; }
+    if (linux_page_size(isa.ARCH_X86_64)  != 4096)  { bad = true; }
+    if (linux_page_size(isa.ARCH_RISCV64) != 4096)  { bad = true; }
+    if (bad) { ret 1; }
+    ret 0;
+}

--- a/src/lang/target/os/linux.mach
+++ b/src/lang/target/os/linux.mach
@@ -21,8 +21,28 @@ use mach.lang.target.isa;
 # segment is mapped here; the linker assigns vaddrs starting from this value.
 pub val LINUX_BASE_ADDR: u64 = 0x400000;
 
-# virtual-memory page size in bytes; segment vaddrs are page-aligned to it.
+# the default (x86_64/riscv64) virtual-memory page size in bytes, and the fixed
+# `page_size` fallback. segment vaddrs are page-aligned to the per-arch
+# `linux_page_size` policy, which returns this for x86_64/riscv64 and a larger
+# max-page for aarch64.
 pub val LINUX_PAGE_SIZE: u64 = 4096;
+
+# the segment-alignment page size for a Linux architecture
+#
+# aarch64 Linux kernels can be built with 4 KiB, 16 KiB, or 64 KiB base pages, and
+# the kernel's exec check requires `p_offset ≡ p_vaddr (mod pagesize)` at the
+# actual page. Aligning segments to the conventional max page (65536, lld's
+# aarch64 default) makes a single image load on every such kernel and keeps the
+# RELRO runtime's page-congruence gate satisfied; x86_64 and riscv64 use the fixed
+# 4 KiB page. The linker aligns vaddrs to this and threads the same value into the
+# ELF writer's p_align and header-reservation math (one page-size home).
+# ---
+# arch_id: the target architecture id (one of isa.ARCH_*)
+# ret:     the segment-alignment page size in bytes
+fun linux_page_size(arch_id: u32) u64 {
+    if (arch_id == isa.ARCH_AARCH64) { ret 65536; }
+    ret LINUX_PAGE_SIZE;
+}
 
 # the default x86-64 glibc dynamic loader. a dynamically-linked Linux ELF names
 # it in PT_INTERP so the kernel hands control to it to resolve shared
@@ -82,6 +102,8 @@ pub fun register_linux(reg: *os.OsRegistry) R.Result[bool, str] {
     linux_vtable.dynamic_linker = LINUX_DYNAMIC_LINKER;
     linux_vtable.base_addr      = LINUX_BASE_ADDR;
     linux_vtable.page_size      = LINUX_PAGE_SIZE;
+    # aarch64 aligns to a 64 KiB max-page so images load on 4K/16K/64K-page kernels.
+    linux_vtable.page_size_for  = linux_page_size;
     # Linux auto-grows the stack on any in-range fault; no per-page probe needed.
     linux_vtable.stack_probe    = false;
     # the System V psABI per arch; `mach init` scaffolds it as the target block's abi.


### PR DESCRIPTION
Closes #1845. Second of the RELRO end-state trio (after #1844); unblocks the mach-std fatal-reprotect follow-up.

## What

The ELF writer hardcoded a 4 KiB page (`EXEC_PAGE_SIZE`) for `p_align`, the one-page header reservation, and file-offset congruence — decoupled from the linker's own segment-alignment page. This makes the page a single target-supplied parameter:

- **linux OS vtable** (`os/linux.mach`): a `page_size_for` policy returning **65536 for aarch64** (lld's default max-page-size) and 4096 for x86_64/riscv64. Aligning to the max page makes one image load on 4K/16K/64K-page aarch64 kernels and keeps the RELRO runtime's `p_offset ≡ p_vaddr (mod pagesize)` gate satisfied.
- **writer contract** (`of.mach` `ExecFn`/`DynExecFn`): a `page_size` argument. The linker passes `os_page_size(tgt)` — the value it already aligns vaddrs to — so writer and layout agree by construction. The ELF writer consumes it throughout; `EXEC_PAGE_SIZE` is deleted. macho/coff/raw accept it but keep their fixed container page.

Split into two bisectable commits: (1) behavior-preserving threading (all output byte-identical), (2) activating the aarch64 64 KiB page.

## Acceptance status

- [x] x86_64/riscv64 output **byte-identical** to dev (verified: same sample built with a dev-baseline compiler vs this branch — identical, `--pie` and non-pie)
- [x] one target-supplied page-size home; no independent 4096 constants remain in the writer
- [x] self-host fixpoint byte-identical; full unit suite green
- [ ] aarch64 `--pie` carries 64 KiB `p_align` with congruent offsets (readelf evidence)
- [ ] per-ISA alignment/congruence unit tests
- [ ] documented size cost on the compiler corpus
