### PR TITLE
fix(test): exclude target-gated orphan modules from whole-src collection

### DIFF
--- a/src/cli/cmd/build.mach
+++ b/src/cli/cmd/build.mach
@@ -91,26 +91,30 @@ pub rec TestArtifact {
 #
 # Allocated from the build allocator.
 # ---
-# tests: owned array of artifacts
-# len:   number of populated entries
-# cap:   allocated length of `tests`
+# tests:   owned array of artifacts
+# len:     number of populated entries
+# cap:     allocated length of `tests`
+# skipped: number of target-gated own-src modules excluded from collection (#1873)
 rec TestList {
-    tests: *TestArtifact;
-    len:   u32;
-    cap:   u32;
+    tests:   *TestArtifact;
+    len:     u32;
+    cap:     u32;
+    skipped: u32;
 }
 
 # the outcome of a `build_tests` invocation
 #
 # The collected test artifacts are owned by the caller's allocator.
 # ---
-# code:  process exit code (0 ok, 1 user error, 2 internal error)
-# tests: built test artifacts; nil when the build failed before collection
-# len:   number of artifacts
+# code:    process exit code (0 ok, 1 user error, 2 internal error)
+# tests:   built test artifacts; nil when the build failed before collection
+# len:     number of artifacts
+# skipped: number of target-gated own-src modules excluded from collection (#1873)
 pub rec TestBuildResult {
-    code:  i64;
-    tests: *TestArtifact;
-    len:   u32;
+    code:    i64;
+    tests:   *TestArtifact;
+    len:     u32;
+    skipped: u32;
 }
 
 # the debug-artifact emission settings threaded into the per-module compile loop
@@ -370,16 +374,18 @@ pub fun build(a: *A.Allocator, argc: usize, argv: **u8, marks: *bool, emit_obj: 
 # ret:       a TestBuildResult carrying the exit code and the test artifacts
 pub fun build_tests(a: *A.Allocator, argc: usize, argv: **u8, marks: *bool, list_only: bool) TestBuildResult {
     var list: TestList;
-    list.tests = nil;
-    list.len   = 0;
-    list.cap   = 0;
+    list.tests   = nil;
+    list.len     = 0;
+    list.cap     = 0;
+    list.skipped = 0;
 
     val br: BuildResult = build_unit(a, argc, argv, marks, false, true, nil, ?list, list_only);
 
     var tbr: TestBuildResult;
-    tbr.code  = br.code;
-    tbr.tests = list.tests;
-    tbr.len   = list.len;
+    tbr.code    = br.code;
+    tbr.tests   = list.tests;
+    tbr.len     = list.len;
+    tbr.skipped = list.skipped;
     ret tbr;
 }
 
@@ -792,6 +798,10 @@ fun compile_and_link(p: *driver.Project, level: u8, emit_obj: bool, test_mode: b
     for (i < p.module_len) {
         ir_ready[i]    = false;
         image_ready[i] = false;
+        # a target-gated orphan is not lowered (it is kept out of topo), so its IR
+        # view slot is never filled; an empty function list keeps test collection,
+        # which scans every module id, from reading an uninitialized slot (#1873).
+        irs[i].function_len = 0;
         i = i + 1;
     }
 
@@ -860,6 +870,8 @@ fun build_test_executables(p: *driver.Project, level: u8, verify_ir: bool,
                            root: *u8, argc: usize, argv: **u8, marks: *bool,
                            images: *of.ObjectImage, irs: *ir.Module,
                            list_only: bool, tests_out: *TestList) i64 {
+    tests_out.skipped = driver.count_target_gated(p);
+
     val res_collect: R.Result[testrunner.Collected, str] = testrunner.collect(p.s, irs, p.module_len);
     if (R.is_err[testrunner.Collected, str](res_collect)) {
         print.eprint("error: ");

--- a/src/cli/cmd/testing.mach
+++ b/src/cli/cmd/testing.mach
@@ -209,6 +209,10 @@ pub fun run(argc: usize, argv: **u8, marks: *bool) i64 {
         ret tbr.code;
     }
 
+    # surface any target-gated own-src modules excluded from collection, so the
+    # whole-source test set never drops a module silently (#1873).
+    if (tbr.skipped > 0) { report_skipped(tbr.skipped); }
+
     # `--filter <substr>` (read above) selects at run time: the dispatcher embeds
     # every in-scope test, this command runs (or lists) only the matching ones.
     var filter: *u8 = nil;
@@ -1223,6 +1227,20 @@ fun artifact_report(art: *build.TestArtifact) {
 fun filter_matches(art: *build.TestArtifact, filter: *u8) bool {
     if (filter == nil) { ret true; }
     ret str_contains(util.cstr_str(art.label), util.cstr_str(filter));
+}
+
+# print the per-run note that `n` own-source modules were excluded as target-gated
+# (#1873), so the whole-source test set never drops a module silently. Written to
+# stderr, so it never pollutes the `--list` / `--format json` stdout streams.
+# ---
+# n: number of excluded modules (only called when non-zero)
+fun report_skipped(n: u32) {
+    var buf: [16]u8;
+    write_index(?buf[0], 16, n);
+    print.eprint("note: skipped ");
+    print.eprint(util.cstr_str(?buf[0]));
+    if (n == 1) { print.eprint(" target-gated module\n"); }
+    or          { print.eprint(" target-gated modules\n"); }
 }
 
 # write the decimal text of `n` into `buf`, null-terminated (the dispatch

--- a/src/lang/driver.mach
+++ b/src/lang/driver.mach
@@ -266,6 +266,7 @@ pub rec ModuleEntry {
     ir_module:         *ir.Module;
     object_image:      *of.ObjectImage;
     stable_id:         session.StableModuleId;
+    target_gated:      bool;
 }
 
 # load state for one module during DFS.
@@ -367,6 +368,11 @@ pub rec Project {
     opt_level:    pipeline.OptLevel;
     verify_ir:    bool;
     test_mode:    bool;
+
+    # set only while load_all_own_src loads orphan roots, so the load walk knows a
+    # top-level `$error` guard it reaches marks a target-gated orphan to exclude
+    # rather than the fatal build error a reachable module's guard stays (#1873).
+    loading_orphans: bool;
 }
 
 # seed capacities for the per-build growable arrays (module table, a module's pub
@@ -744,6 +750,19 @@ fun cmp_src_mod(a: *SrcMod, b: *SrcMod) i64 {
 # is enumerated, mapped to its FQN, sorted for determinism, and dfs_loaded; dfs_load
 # dedups by FQN, so the already-loaded entry closure re-loads as a no-op and only
 # the orphaned modules are added.
+# the number of modules excluded from this build as target-gated orphans (#1873).
+# `mach test` reports it as the per-run "skipped N target-gated modules" note so an
+# exclusion is never silent.
+pub fun count_target_gated(p: *Project) u32 {
+    var n: u32 = 0;
+    var i: u32 = 0;
+    for (i < p.module_len) {
+        if ((?p.modules[i]).target_gated) { n = n + 1; }
+        i = i + 1;
+    }
+    ret n;
+}
+
 fun load_all_own_src(p: *Project) R.Result[bool, str] {
     val root_opt: O.Option[str] = intern.lookup(?p.s.interner, p.config.project_root);
     if (O.is_none[str](root_opt)) { ret R.err[bool, str]("project_root StrId not interned"); }
@@ -763,15 +782,21 @@ fun load_all_own_src(p: *Project) R.Result[bool, str] {
 
     sort.sort[SrcMod](mods.data, mods.len, cmp_src_mod);
 
+    # while these orphan roots load, a top-level `$error` guard reached on a live
+    # path flags its module target-gated (excluded from the test build) instead of
+    # firing as a fatal diagnostic (#1873).
+    p.loading_orphans = true;
     var i: usize = 0;
     for (i < mods.len) {
         val lr: R.Result[session.ModuleId, str] = dfs_load(p, mods.data[i].fqn);
         if (R.is_err[session.ModuleId, str](lr)) {
+            p.loading_orphans = false;
             vector.dnit[SrcMod](?mods);
             ret R.err[bool, str](R.unwrap_err[session.ModuleId, str](lr));
         }
         i = i + 1;
     }
+    p.loading_orphans = false;
     vector.dnit[SrcMod](?mods);
     ret R.ok[bool, str](true);
 }
@@ -1359,6 +1384,7 @@ fun init_project(p: *Project, s: *session.Session) {
     p.opt_level     = pipeline.OPT_DEBUG;
     p.verify_ir     = false;
     p.test_mode     = false;
+    p.loading_orphans = false;
 }
 
 # release every owned array a ProjectConfig holds (targets and their libs, deps,
@@ -2288,6 +2314,15 @@ fun dfs_load(p: *Project, fqn: intern.StrId) R.Result[session.ModuleId, str] {
 
     p.load_status[mid::u32] = LOAD_DONE;
 
+    # a target-gated orphan (its load-time `$error` guard fired under this target)
+    # is kept out of the topo set: resolve / sema / lower / codegen all walk topo,
+    # so the module is never touched and its guard never fires. it is excluded from
+    # test collection with a per-run note (#1873). nothing depends on an orphan, so
+    # leaving it out of topo is safe.
+    if ((?p.modules[mid::u32]).target_gated) {
+        ret R.ok[session.ModuleId, str](mid);
+    }
+
     val topo_r: R.Result[bool, str] = topo_push(p, mid);
     if (R.is_err[bool, str](topo_r)) { ret R.err[session.ModuleId, str](R.unwrap_err[bool, str](topo_r)); }
 
@@ -2358,6 +2393,7 @@ fun register_module_slot(p: *Project, fqn: intern.StrId) R.Result[session.Module
     m.sema_result       = nil;
     m.ir_module         = nil;
     m.object_image      = nil;
+    m.target_gated      = false;
     p.modules[p.module_len] = m;
     p.module_len = p.module_len + 1;
 
@@ -2934,7 +2970,47 @@ fun walk_one_decl_for_load(p: *Project, mid: session.ModuleId, did: id.DeclId) R
     if (d.kind == decl.DECL_KIND_VAL) {
         ret register_val_for_load(p, mid, d, did);
     }
+    if (d.kind == decl.DECL_KIND_COMPTIME_ATTR) {
+        ret walk_comptime_attr_for_load(p, mid, ?d.data.comptime_attr);
+    }
     ret R.ok[bool, str](true);
+}
+
+# a top-level comptime directive reached on a live path during an orphan's load walk.
+#
+# Only meaningful while load_all_own_src loads orphan roots: a reached `$error`
+# guard is the module's self-declaration that it is not compilable for the selected
+# target, so the module is flagged target-gated and later excluded from the test
+# build (#1873). The guard is not evaluated into a diagnostic here. A reachable
+# module (loading_orphans false) is left untouched, so sema keeps its live `$error`
+# a fatal build error.
+fun walk_comptime_attr_for_load(p: *Project, mid: session.ModuleId, ca: *decl.DeclComptimeAttr) R.Result[bool, str] {
+    if (!p.loading_orphans)       { ret R.ok[bool, str](true); }
+    if (ca.target == id.EXPR_NIL) { ret R.ok[bool, str](true); }
+
+    val m: *ModuleEntry = ?p.modules[mid::u32];
+    val src_opt: O.Option[*src.SourceFile] = src.get(?p.s.sources, m.file_id);
+    if (O.is_none[*src.SourceFile](src_opt)) { ret R.err[bool, str]("module file_id not found in SourceMap"); }
+    val source: str = O.unwrap[*src.SourceFile](src_opt).text;
+
+    if (comptime.is_error_call(m.a, source, ca.target)) {
+        m.target_gated = true;
+    }
+    ret R.ok[bool, str](true);
+}
+
+# propagate transitive target-gating across a load-time dependency edge.
+#
+# While loading orphan roots, a module that depends (`use` / `fwd`) on a
+# target-gated module is itself not compilable for the selected target — a
+# platform backend that imports its gated OS/ISA layer, say — so it is gated too
+# and excluded from the test build (#1873). Returns whether `mid` is now gated, so
+# the caller can skip work a to-be-excluded module does not need.
+fun propagate_target_gate(p: *Project, mid: session.ModuleId, dep_mid: session.ModuleId) bool {
+    if (!p.loading_orphans)                       { ret false; }
+    if (!(?p.modules[dep_mid::u32]).target_gated) { ret false; }
+    (?p.modules[mid::u32]).target_gated = true;
+    ret true;
 }
 
 # load-walk a `$if` chain: every some-target branch in union mode, else the first
@@ -3138,6 +3214,10 @@ fun walk_use_for_load(p: *Project, mid: session.ModuleId, du: *decl.DeclUse) R.R
     val record_r: R.Result[bool, str] = record_dep(p, mid, dep_mid);
     if (R.is_err[bool, str](record_r)) { ret record_r; }
 
+    # a gated dependency gates the importer too; it is excluded, so skip the pub
+    # const merge it no longer needs.
+    if (propagate_target_gate(p, mid, dep_mid)) { ret R.ok[bool, str](true); }
+
     if (du.alias.len > 0) {
         ret R.ok[bool, str](true);
     }
@@ -3172,7 +3252,12 @@ fun walk_fwd_for_load(p: *Project, mid: session.ModuleId, df: *decl.DeclFwd) R.R
     if (R.is_err[session.ModuleId, str](dep_r)) { ret R.err[bool, str](R.unwrap_err[session.ModuleId, str](dep_r)); }
     val dep_mid: session.ModuleId = R.unwrap_ok[session.ModuleId, str](dep_r);
 
-    ret record_dep(p, mid, dep_mid);
+    val record_r: R.Result[bool, str] = record_dep(p, mid, dep_mid);
+    if (R.is_err[bool, str](record_r)) { ret record_r; }
+
+    # forwarding a gated module's surface gates this module too (#1873).
+    propagate_target_gate(p, mid, dep_mid);
+    ret R.ok[bool, str](true);
 }
 
 # the resolution of a `use` path into the module to load plus
@@ -5217,6 +5302,145 @@ fun ut_build_multi(s: *session.Session, alloc: *A.Allocator, names: *str, texts:
     val pr: R.Result[Project, str] = build_project_union(s, root);
     filesystem.remove_all(alloc, root);
     ret pr;
+}
+
+# ut_build over build_project_test (the whole-source test loader), so the
+# target-gated-orphan exclusion (#1873) can be exercised. Scaffolds the src files,
+# builds the test Project, removes the temp tree, and returns it.
+fun ut_build_test(s: *session.Session, alloc: *A.Allocator, names: *str, texts: *str, n: u32) R.Result[Project, str] {
+    val root_r: R.Result[str, str] = ut_scaffold(alloc, names, texts, n);
+    if (R.is_err[str, str](root_r)) { ret R.err[Project, str](R.unwrap_err[str, str](root_r)); }
+    val root: str = R.unwrap_ok[str, str](root_r);
+    val rr: R.Result[bool, str] = setup_registry(?s.registry);
+    if (R.is_err[bool, str](rr)) { filesystem.remove_all(alloc, root); ret R.err[Project, str](R.unwrap_err[bool, str](rr)); }
+    var sel: manifest.Selection;
+    sel.target       = "";
+    sel.profile      = "";
+    sel.artifact     = "";
+    sel.want_lib     = false;
+    sel.has_artifact = false;
+    val pr: R.Result[Project, str] = build_project_test(s, root, ?sel);
+    filesystem.remove_all(alloc, root);
+    ret pr;
+}
+
+# the target_gated flag of module `fqn` in project `p` (false when absent).
+fun ut_gated(p: *Project, s: *session.Session, fqn: str) bool {
+    val mid: session.ModuleId = ut_mid(p, s, fqn);
+    if (mid == session.MODULE_NIL) { ret false; }
+    ret (?p.modules[mid::u32]).target_gated;
+}
+
+# whether module `fqn` is in project `p`'s topo set (its compiled / collected set).
+fun ut_in_topo(p: *Project, s: *session.Session, fqn: str) bool {
+    val mid: session.ModuleId = ut_mid(p, s, fqn);
+    if (mid == session.MODULE_NIL) { ret false; }
+    var i: u32 = 0;
+    for (i < p.topo_len) {
+        if (p.topo[i] == mid) { ret true; }
+        i = i + 1;
+    }
+    ret false;
+}
+
+# #1873: an orphan module (no in-tree consumer) whose load-time comptime evaluation
+# reaches a `$error` is target-gated - loaded but kept out of the topo set and
+# counted for the skip note - so a `mach test` over a tree with other-target modules
+# does not fail on their guards. Sema over the remaining topo raises no error.
+test "mach.lang.driver:test_gated_orphan_excluded" {
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    val sr: R.Result[session.Session, str] = session.init(?alloc);
+    if (R.is_err[session.Session, str](sr)) { ret 1; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](sr);
+
+    var names: [2]str;
+    names[0] = "main.mach"; names[1] = "gated.mach";
+    var texts: [2]str;
+    texts[0] = "fun main() i32 { ret 0; }\n";
+    texts[1] = "$error(\"gated: not for this target\");\n\ntest \"gt\" { ret 0; }\n";
+
+    val pr: R.Result[Project, str] = ut_build_test(?s, ?alloc, ?names[0], ?texts[0], 2);
+    if (R.is_err[Project, str](pr)) { session.dnit(?s); ret 1; }
+    var p: Project = R.unwrap_ok[Project, str](pr);
+
+    var bad: i32 = 0;
+    if (!ut_has(?p, ?s, "uniontest.gated"))    { bad = 1; }  # loaded,
+    if (!ut_gated(?p, ?s, "uniontest.gated"))  { bad = 1; }  # flagged gated,
+    if (ut_in_topo(?p, ?s, "uniontest.gated")) { bad = 1; }  # but excluded from topo.
+    if (count_target_gated(?p) != 1)           { bad = 1; }
+    if (!ut_in_topo(?p, ?s, "uniontest.main")) { bad = 1; }  # the entry stays compiled.
+    val se: R.Result[bool, str] = run_sema_pass(?p);
+    if (R.is_err[bool, str](se))               { bad = 1; }
+    if (ut_count_errors(?p.s.diags) != 0)      { bad = 1; }  # the guard never fires.
+
+    dnit_project(?p);
+    session.dnit(?s);
+    ret bad;
+}
+
+# #1873 / #1863: an orphan module WITHOUT a target guard keeps its tests collected -
+# it loads into topo like any own-src module, preserving the whole-source collection
+# guarantee (the editor-subtree case).
+test "mach.lang.driver:test_ungated_orphan_collected" {
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    val sr: R.Result[session.Session, str] = session.init(?alloc);
+    if (R.is_err[session.Session, str](sr)) { ret 1; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](sr);
+
+    var names: [2]str;
+    names[0] = "main.mach"; names[1] = "orphan.mach";
+    var texts: [2]str;
+    texts[0] = "fun main() i32 { ret 0; }\n";
+    texts[1] = "test \"ot\" { ret 0; }\n";
+
+    val pr: R.Result[Project, str] = ut_build_test(?s, ?alloc, ?names[0], ?texts[0], 2);
+    if (R.is_err[Project, str](pr)) { session.dnit(?s); ret 1; }
+    var p: Project = R.unwrap_ok[Project, str](pr);
+
+    var bad: i32 = 0;
+    if (!ut_has(?p, ?s, "uniontest.orphan"))     { bad = 1; }
+    if (ut_gated(?p, ?s, "uniontest.orphan"))    { bad = 1; }  # not gated,
+    if (!ut_in_topo(?p, ?s, "uniontest.orphan")) { bad = 1; }  # collected.
+    if (count_target_gated(?p) != 0)             { bad = 1; }
+
+    dnit_project(?p);
+    session.dnit(?s);
+    ret bad;
+}
+
+# #1873: a `$error` in an ENTRY-REACHABLE module is never gated - it stays in topo
+# and its guard remains a fatal sema error, so the orphan-only exclusion never masks
+# a genuine error in reachable code.
+test "mach.lang.driver:test_reachable_error_still_fatal" {
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    val sr: R.Result[session.Session, str] = session.init(?alloc);
+    if (R.is_err[session.Session, str](sr)) { ret 1; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](sr);
+
+    var names: [2]str;
+    names[0] = "main.mach"; names[1] = "bad.mach";
+    var texts: [2]str;
+    texts[0] = "use uniontest.bad;\n\nfun main() i32 { ret 0; }\n";
+    texts[1] = "$error(\"reachable boom\");\n\npub fun f() i32 { ret 0; }\n";
+
+    val pr: R.Result[Project, str] = ut_build_test(?s, ?alloc, ?names[0], ?texts[0], 2);
+    if (R.is_err[Project, str](pr)) { session.dnit(?s); ret 1; }
+    var p: Project = R.unwrap_ok[Project, str](pr);
+
+    var bad: i32 = 0;
+    if (ut_gated(?p, ?s, "uniontest.bad"))    { bad = 1; }  # reachable: not gated,
+    if (!ut_in_topo(?p, ?s, "uniontest.bad")) { bad = 1; }  # stays in topo,
+    if (count_target_gated(?p) != 0)          { bad = 1; }
+    val se: R.Result[bool, str] = run_sema_pass(?p);
+    if (R.is_err[bool, str](se))              { bad = 1; }
+    if (ut_count_errors(?p.s.diags) == 0)     { bad = 1; }  # its `$error` still fires.
+
+    dnit_project(?p);
+    session.dnit(?s);
+    ret bad;
 }
 
 # whether the union Project loaded a module with the given FQN.


### PR DESCRIPTION
Closes #1873.

Regression from #1863 (PR #1866): whole-source `mach test` collection force-loads target-gated modules the entry walk deliberately never reached. A module carrying a top-level comptime guard like `$error("... requires windows target")` gets loaded into a native test build and the guard fires as a hard build error — `mach test .` on mach-std fails on a dev compiler.

## Fix (orphan-only exclusion, per the issue's preferred design)

A module loaded **only** as an orphan root (during `load_all_own_src`, not reachable from the entry/union walk) is **target-gated** when its load walk reaches a live top-level `$error` — the module's own declaration that it is not compilable for the selected target. A gated module is flagged and kept out of `p.topo`, so resolve / sema / lower / codegen (all of which walk topo) never touch it and its guard never fires. Gating propagates across `use`/`fwd` edges, so a platform backend that imports its gated OS/ISA layer (e.g. `runtime.linux.aarch64` → `os.linux.aarch64`) is excluded too.

- **Reachable `$error` stays fatal:** the flag is only set while `loading_orphans`, so an entry-reachable module is never gated and sema still fails the build on its guard. No masking of genuine errors.
- **Ungated orphans still collected:** #1863's guarantee (the editor-subtree case) is preserved — an orphan without a guard loads into topo and its tests are collected.
- **Never silent:** `mach test` prints `skipped N target-gated modules` on stderr (both run and `--list`) whenever any module is excluded.
- No new annotations, no manifest lists — the existing guard is the declaration.

## Changes

- `src/lang/driver.mach`: `ModuleEntry.target_gated` + `Project.loading_orphans`; detect a live `$error` in the orphan load walk (`walk_comptime_attr_for_load`), propagate across `use`/`fwd` (`propagate_target_gate`), skip `topo_push` for gated modules, `count_target_gated`. Three driver tests (gated-orphan excluded, ungated-orphan collected, reachable-`$error` fatal).
- `src/cli/cmd/build.mach`: `skipped` on `TestList`/`TestBuildResult`; empty every IR view slot so collection never reads an uninitialized slot for a non-topo module.
- `src/cli/cmd/testing.mach`: the `skipped N target-gated modules` note.

## Verification

- **Real-world repro:** `mach test .` on `briar-systems/mach-std` with a from-source dev compiler now runs the full suite (**588 passed, 0 failed**) with `note: skipped 16 target-gated modules` — **byte-identical to the v2.13.0 release compiler** on the same checkout (588/588; the 620 in the issue predates mach-std churn). The 16 windows/darwin/other-arch guards no longer fire.
- **mach self:** self-host fixpoint converged (a→b→c, b==c); unit suite **501 passed, 0 failed** (498 + 3 new driver tests, no gated modules so no note); int harness linux (debug+release) all pass.
- The 3 driver-test arms pass individually.

CHANGELOG (`[Unreleased]`) untouched, per instruction.
