### PR TITLE
feat(of): DebugInfo vtable seam + RK_ABS32/RK_SECREL32/RK_SECTION reloc kinds

### DIFF
--- a/src/lang/be/obj.mach
+++ b/src/lang/be/obj.mach
@@ -18,7 +18,10 @@ use std.types.bool.true;
 use std.types.size.usize;
 use std.types.string.str;
 
+use std.allocator.page;
+
 use A: std.allocator;
+use O: std.types.option;
 use R: std.types.result;
 
 use mach.lang.intern;
@@ -179,4 +182,96 @@ fun array_grow_one[T](a: *A.Allocator, arr: *T, len: u32) R.Result[*T, str] {
         ret A.allocate[T](a, 1::usize);
     }
     ret A.reallocate[T](a, arr, len::usize, (len + 1)::usize);
+}
+
+# intern a string for a test, yielding STR_NIL on the (test-only) interning failure
+# ---
+# itn: interner to intern into
+# s:   the string to intern
+# ret: the interned id, or STR_NIL on failure
+fun t_obj_intern(itn: *intern.Interner, s: str) intern.StrId {
+    val r: R.Result[intern.StrId, str] = intern.intern(itn, s);
+    if (R.is_err[intern.StrId, str](r)) { ret intern.STR_NIL; }
+    ret R.unwrap_ok[intern.StrId, str](r);
+}
+
+# a test debug-info producer that writes a minimal debug section into a module
+# image through this builder - the exact shape (an SK_DEBUG section, an anchor
+# symbol into it, and a cross-section RK_ABS32 relocation) a real DWARF/CodeView
+# producer uses behind the `of.DebugVTable` seam. proves the seam's "writes into
+# the per-module ObjectImage via be.obj" contract end to end.
+# ---
+# ctx: the debug context carrying the image to append to
+# ret: true on success, or the builder's allocation error
+fun t_debug_produce(ctx: *of.DebugContext) R.Result[bool, str] {
+    val br: R.Result[*u8, str] = A.allocate[u8](ctx.image.alloc, 4::usize);
+    if (R.is_err[*u8, str](br)) { ret R.err[bool, str](R.unwrap_err[*u8, str](br)); }
+
+    var sec: of.Section;
+    sec.name  = t_obj_intern(ctx.image.interner, ".debug_info");
+    sec.kind  = of.SK_DEBUG;
+    sec.bytes = R.unwrap_ok[*u8, str](br);
+    sec.len   = 4;
+    sec.align = 1;
+    val sr: R.Result[u32, str] = add_section(ctx.image, sec);
+    if (R.is_err[u32, str](sr)) { ret R.err[bool, str](R.unwrap_err[u32, str](sr)); }
+    val sec_idx: u32 = R.unwrap_ok[u32, str](sr);
+
+    var sym: of.Symbol;
+    sym.name    = t_obj_intern(ctx.image.interner, ".Ldebug_info0");
+    sym.section = sec_idx;
+    sym.offset  = 0;
+    sym.size    = 0;
+    sym.flags   = 0;
+    val yr: R.Result[u32, str] = add_symbol(ctx.image, sym);
+    if (R.is_err[u32, str](yr)) { ret R.err[bool, str](R.unwrap_err[u32, str](yr)); }
+
+    var rel: of.Relocation;
+    rel.section = sec_idx;
+    rel.offset  = 0;
+    rel.kind    = of.RK_ABS32;
+    rel.symbol  = sym.name;
+    rel.addend  = 0;
+    ret add_relocation(ctx.image, rel);
+}
+
+# a producer registered behind the of.DebugVTable seam writes SK_DEBUG sections,
+# anchor symbols, and RK_ABS32 relocations into a module's ObjectImage through this
+# builder. exercises the whole seam: build an image, register a producer, resolve
+# it by name, dispatch, and confirm the image gained exactly the debug section,
+# symbol, and relocation the producer appended.
+test "mach.lang.be.obj.debug_seam:producer_writes_into_image" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+    var itn: intern.Interner = intern.init(?alloc);
+
+    val ir: R.Result[of.ObjectImage, str] = init(?alloc, ?itn, t_obj_intern(?itn, "m"));
+    if (R.is_err[of.ObjectImage, str](ir)) { ret 1; }
+    var img: of.ObjectImage = R.unwrap_ok[of.ObjectImage, str](ir);
+
+    var reg: of.DebugRegistry = of.debug_registry_init();
+    var vt: of.DebugVTable;
+    vt.id = of.DBG_DWARF; vt.name = "dwarf"; vt.produce = t_debug_produce;
+    of.debug_register(?reg, ?vt);
+
+    val got: O.Option[*of.DebugVTable] = of.debug_lookup(?reg, "dwarf");
+    if (!O.is_some[*of.DebugVTable](got)) { dnit(?img); ret 1; }
+
+    var ctx: of.DebugContext;
+    ctx.image    = ?img;
+    ctx.arch     = nil;
+    ctx.producer = intern.STR_NIL;
+    ctx.comp_dir = intern.STR_NIL;
+    val pr: R.Result[bool, str] = O.unwrap[*of.DebugVTable](got).produce(?ctx);
+    if (R.is_err[bool, str](pr)) { dnit(?img); ret 1; }
+
+    if (img.section_count != 1)                 { dnit(?img); ret 1; }
+    if (img.sections[0].kind != of.SK_DEBUG)    { dnit(?img); ret 1; }
+    if (img.symbol_count != 1)                  { dnit(?img); ret 1; }
+    if (img.symbols[0].section != 0)            { dnit(?img); ret 1; }
+    if (img.reloc_count != 1)                   { dnit(?img); ret 1; }
+    if (img.relocations[0].kind != of.RK_ABS32) { dnit(?img); ret 1; }
+
+    dnit(?img);
+    ret 0;
 }

--- a/src/lang/target/isa/arm64/register.mach
+++ b/src/lang/target/isa/arm64/register.mach
@@ -76,6 +76,7 @@ fun arm64_elf_reloc_type(kind: of.RelocKind) u32 {
     if (kind == of.RK_LDST32_LO12)  { ret elf.R_AARCH64_LDST32_ABS_LO12_NC; }
     if (kind == of.RK_LDST64_LO12)  { ret elf.R_AARCH64_LDST64_ABS_LO12_NC; }
     if (kind == of.RK_LDST128_LO12) { ret elf.R_AARCH64_LDST128_ABS_LO12_NC; }
+    if (kind == of.RK_ABS32)        { ret elf.R_AARCH64_ABS32; }
     ret 0;
 }
 
@@ -277,6 +278,7 @@ test "mach.lang.target.isa.arm64.register.arm64_elf_reloc_type:forward_map" {
     if (arm64_elf_reloc_type(of.RK_LDST32_LO12)  != elf.R_AARCH64_LDST32_ABS_LO12_NC)  { ret 1; }
     if (arm64_elf_reloc_type(of.RK_LDST64_LO12)  != elf.R_AARCH64_LDST64_ABS_LO12_NC)  { ret 1; }
     if (arm64_elf_reloc_type(of.RK_LDST128_LO12) != elf.R_AARCH64_LDST128_ABS_LO12_NC) { ret 1; }
+    if (arm64_elf_reloc_type(of.RK_ABS32)        != elf.R_AARCH64_ABS32)               { ret 1; }
 
     # a kind aarch64 has no ELF type for maps to 0, the writer's unsupported signal.
     if (arm64_elf_reloc_type(of.RK_GOTPCREL) != 0) { ret 1; }

--- a/src/lang/target/isa/riscv64/register.mach
+++ b/src/lang/target/isa/riscv64/register.mach
@@ -81,12 +81,12 @@ var riscv64_reload_scratch_regs: [3]isa.Register;
 # The forward half of the riscv64 ELF relocation seam: the ELF object writer reads it
 # through `IsaVTable.elf_reloc_type` instead of branching on the arch id, so riscv64
 # owns its own R_RISCV_* numbers (drawn from the ELF format module, the single source
-# the reverse parse map shares). RK_ABS64 maps to the width-specific R_RISCV_64 (an
-# rv32 sibling's RK_ABS32 would map to R_RISCV_32); RK_PLT32 to R_RISCV_CALL_PLT (the
-# auipc + jalr call pair); the pc-relative load-address idiom's RK_PCREL_HI20 /
-# RK_PCREL_LO12_I / RK_PCREL_LO12_S to their R_RISCV_PCREL_* types. A kind riscv64 has
-# no width-correct ELF type for returns 0 (R_RISCV_NONE), which the writer turns into
-# the unsupported-kind error.
+# the reverse parse map shares). RK_ABS64 maps to the width-specific R_RISCV_64 and
+# RK_ABS32 to R_RISCV_32 (the 32-bit absolute DWARF cross-section refs use); RK_PLT32
+# to R_RISCV_CALL_PLT (the auipc + jalr call pair); the pc-relative load-address
+# idiom's RK_PCREL_HI20 / RK_PCREL_LO12_I / RK_PCREL_LO12_S to their R_RISCV_PCREL_*
+# types. A kind riscv64 has no width-correct ELF type for returns 0 (R_RISCV_NONE),
+# which the writer turns into the unsupported-kind error.
 # ---
 # kind: the abstract relocation kind to map
 # ret:  the riscv64 ELF reloc type, or 0 when riscv64 has none for this kind
@@ -97,6 +97,7 @@ fun riscv64_elf_reloc_type(kind: of.RelocKind) u32 {
     if (kind == of.RK_PCREL_HI20)   { ret elf.R_RISCV_PCREL_HI20; }
     if (kind == of.RK_PCREL_LO12_I) { ret elf.R_RISCV_PCREL_LO12_I; }
     if (kind == of.RK_PCREL_LO12_S) { ret elf.R_RISCV_PCREL_LO12_S; }
+    if (kind == of.RK_ABS32)        { ret elf.R_RISCV_32; }
     ret 0;
 }
 
@@ -329,6 +330,7 @@ test "mach.lang.target.isa.riscv64.register.riscv64_elf_reloc_type:forward_map" 
     if (riscv64_elf_reloc_type(of.RK_PCREL_HI20)   != elf.R_RISCV_PCREL_HI20)   { ret 1; }
     if (riscv64_elf_reloc_type(of.RK_PCREL_LO12_I) != elf.R_RISCV_PCREL_LO12_I) { ret 1; }
     if (riscv64_elf_reloc_type(of.RK_PCREL_LO12_S) != elf.R_RISCV_PCREL_LO12_S) { ret 1; }
+    if (riscv64_elf_reloc_type(of.RK_ABS32)        != elf.R_RISCV_32)           { ret 1; }
 
     # a kind riscv64 has no ELF type for maps to 0, the writer's unsupported signal.
     if (riscv64_elf_reloc_type(of.RK_GOTPCREL) != 0) { ret 1; }

--- a/src/lang/target/isa/x64/register.mach
+++ b/src/lang/target/isa/x64/register.mach
@@ -73,6 +73,7 @@ fun x64_elf_reloc_type(kind: of.RelocKind) u32 {
     if (kind == of.RK_PLT32)    { ret elf.R_X86_64_PLT32; }
     if (kind == of.RK_GOTPCREL) { ret elf.R_X86_64_GOTPCREL; }
     if (kind == of.RK_ABS32S)   { ret elf.R_X86_64_32S; }
+    if (kind == of.RK_ABS32)    { ret elf.R_X86_64_32; }
     ret 0;
 }
 
@@ -317,6 +318,7 @@ test "mach.lang.target.isa.x64.register.x64_elf_reloc_type:forward_map" {
     if (x64_elf_reloc_type(of.RK_PLT32)    != elf.R_X86_64_PLT32)    { ret 1; }
     if (x64_elf_reloc_type(of.RK_GOTPCREL) != elf.R_X86_64_GOTPCREL) { ret 1; }
     if (x64_elf_reloc_type(of.RK_ABS32S)   != elf.R_X86_64_32S)      { ret 1; }
+    if (x64_elf_reloc_type(of.RK_ABS32)    != elf.R_X86_64_32)       { ret 1; }
 
     # a kind x86_64 has no ELF type for maps to 0, the writer's unsupported signal.
     if (x64_elf_reloc_type(of.RK_ADDR32NB) != 0) { ret 1; }

--- a/src/lang/target/of.mach
+++ b/src/lang/target/of.mach
@@ -104,6 +104,19 @@ pub val RK_PCREL_LO12_I: RelocKind = 14;
 # (bits[11:7]) of the store that follows the paired auipc. the store-instruction
 # counterpart of RK_PCREL_LO12_I.
 pub val RK_PCREL_LO12_S: RelocKind = 15;
+# 32-bit unsigned absolute (R_X86_64_32 / R_AARCH64_ABS32 / R_RISCV_32;
+# X86_64_RELOC_UNSIGNED / ARM64_RELOC_UNSIGNED with length=2; IMAGE_REL_AMD64_ADDR32):
+# a DWARF cross-section reference (DW_FORM_strp / sec_offset / ref_addr). the
+# unsigned counterpart of the signed RK_ABS32S, sized for a 4-byte debug field.
+pub val RK_ABS32:        RelocKind = 16;
+# section-relative 32-bit offset (IMAGE_REL_AMD64_SECREL): the displacement of a
+# target from the start of its own section, a CodeView code reference
+# (DEBUG_S_LINES / S_GPROC32_ID). COFF-only; ELF and Mach-O never emit it.
+pub val RK_SECREL32:     RelocKind = 17;
+# 16-bit section index (IMAGE_REL_AMD64_SECTION): the 1-based index of a target
+# symbol's section, the CodeView partner of RK_SECREL32; patches a 2-byte field.
+# COFF-only; ELF and Mach-O never emit it.
+pub val RK_SECTION:      RelocKind = 18;
 
 # object-symbol flags, combined as a bitmask in `Symbol.flags`
 # ---
@@ -667,6 +680,9 @@ pub fun reloc_kind_name(kind: RelocKind) str {
     if (kind == RK_PCREL_HI20)   { ret "pcrel_hi20"; }
     if (kind == RK_PCREL_LO12_I) { ret "pcrel_lo12_i"; }
     if (kind == RK_PCREL_LO12_S) { ret "pcrel_lo12_s"; }
+    if (kind == RK_ABS32)        { ret "abs32"; }
+    if (kind == RK_SECREL32)     { ret "secrel32"; }
+    if (kind == RK_SECTION)      { ret "section"; }
     ret "unknown";
 }
 

--- a/src/lang/target/of.mach
+++ b/src/lang/target/of.mach
@@ -617,6 +617,145 @@ pub fun registered(reg: *OfRegistry, idx: u32) O.Option[*OfVTable] {
     ret O.some[*OfVTable](reg.entries[idx]);
 }
 
+# canonical numeric ids for known debug-info models, stable across compiler
+# versions. a producer declares which model it implements; the driver selects one
+# by name for the target.
+pub val DBG_UNKNOWN:  u32 = 0;  # no/unknown debug model
+pub val DBG_DWARF:    u32 = 1;  # dwarf (elf, mach-o)
+pub val DBG_CODEVIEW: u32 = 2;  # codeview (coff/pe)
+
+# the format-independent context a debug-info producer writes into
+#
+# Carries everything a DWARF/CodeView producer needs that is not container-specific:
+# the per-module `ObjectImage` it appends SK_DEBUG sections, anchor symbols, and
+# relocations to (through the `be.obj` builder), the target ISA (for the per-ISA
+# debug register-number tables and the abstract `RK_*` kinds it emits), and the
+# compilation-unit metadata only the driver knows. A producer speaks the abstract
+# object model only - it never touches container byte layout; the active `OfVTable`
+# maps its `RK_*` kinds and SK_DEBUG sections to the format on emit. Later
+# increments extend this record with the retained PC<->line rows and value model;
+# extension is additive, so the seam contract itself stays stable.
+# ---
+# image:    the per-module object image to append debug sections/symbols/relocs to
+# arch:     the target ISA vtable (register-number tables, pointer width)
+# producer: interned producer string (DW_AT_producer / CodeView compiler id)
+# comp_dir: interned compilation directory (DW_AT_comp_dir / CodeView working dir)
+pub rec DebugContext {
+    image:    *ObjectImage;
+    arch:     *isa.IsaVTable;
+    producer: intern.StrId;
+    comp_dir: intern.StrId;
+}
+
+# a debug-info producer: writes one module's debug sections into `ctx.image`
+#
+# The single entry point behind the `DebugVTable` seam. It appends the
+# format-neutral SK_DEBUG sections, their anchor symbols, and the cross-section
+# `RK_*` relocations that tie them together; the active `OfVTable` serializes them
+# on emit. Returns an error string on an allocation or encoding failure. The driver
+# gates it on `-g` (#1697): without `-g` no producer runs and the image carries no
+# debug sections, so output stays byte-identical.
+# ---
+# arg 0: the debug context (image to write, ISA, CU metadata)
+# ret:   true on success, or an error string
+pub def DebugProduceFn: fun(*DebugContext) R.Result[bool, str];
+
+# a debug-info producer's runtime-dispatch interface
+#
+# Exactly one exists per debug model; the driver invokes `produce` behind the seam
+# without ever branching on `id`. The debug-model analogue of `OfVTable`: a
+# registry installs producers at startup and the driver selects one by name for the
+# target's model.
+# ---
+# id:      debug-model id (one of DBG_*)
+# name:    model name ("dwarf", "codeview"); an immutable str constant
+# produce: writes a module's debug sections into a DebugContext
+pub rec DebugVTable {
+    id:      u32;
+    name:    str;
+    produce: DebugProduceFn;
+}
+
+# maximum number of debug-info producers a DebugRegistry holds
+val DEBUG_REGISTRY_CAP: u32 = 4;
+
+# a session/driver-owned table of debug-info producer vtables, keyed by model name
+#
+# The debug-model analogue of `OfRegistry`, bundled beside it: producers are
+# installed through `debug_register` at startup and the driver resolves one by the
+# target model's name. Empty until a producer (DWARF #1699, CodeView #1595)
+# registers, so the seam is inert on its own and emits nothing.
+# ---
+# entries: densely-packed registered vtable pointers, in registration order
+# count:   number of registered vtables
+pub rec DebugRegistry {
+    entries: [4]*DebugVTable;
+    count:   u32;
+}
+
+# construct a fresh debug-info registry with every slot empty
+# ---
+# ret: a zeroed DebugRegistry
+pub fun debug_registry_init() DebugRegistry {
+    var reg: DebugRegistry;
+    var i:   u32 = 0;
+    for (i < DEBUG_REGISTRY_CAP) {
+        reg.entries[i] = nil;
+        i = i + 1;
+    }
+    reg.count = 0;
+    ret reg;
+}
+
+# install a debug-info producer vtable into `reg`
+#
+# Write-once per model name: a second registration under a name already present is
+# ignored so the first producer to initialize wins deterministically. a nil vtable,
+# or one past the registry's capacity, is ignored.
+# ---
+# reg: the registry to install into
+# vt:  the debug-info vtable to register; its `name` is the key
+pub fun debug_register(reg: *DebugRegistry, vt: *DebugVTable) {
+    if (vt == nil)                                        { ret; }
+    if (O.is_some[*DebugVTable](debug_lookup(reg, vt.name))) { ret; }
+    if (reg.count >= DEBUG_REGISTRY_CAP)                  { ret; }
+    reg.entries[reg.count] = vt;
+    reg.count = reg.count + 1;
+}
+
+# find the debug-info vtable registered under a model name in `reg`
+# ---
+# reg:  the registry to read
+# name: debug-model name ("dwarf", "codeview")
+# ret:  the registered vtable, or none if no producer is registered under the name
+pub fun debug_lookup(reg: *DebugRegistry, name: str) O.Option[*DebugVTable] {
+    var i: u32 = 0;
+    for (i < reg.count) {
+        if (str_equals(reg.entries[i].name, name)) { ret O.some[*DebugVTable](reg.entries[i]); }
+        i = i + 1;
+    }
+    ret O.none[*DebugVTable]();
+}
+
+# count the debug-info producers registered in `reg`
+# ---
+# reg: the registry to read
+# ret: number of registered vtables
+pub fun debug_registered_count(reg: *DebugRegistry) u32 {
+    ret reg.count;
+}
+
+# the debug-info vtable at enumeration index `idx` (0-based, in registration order)
+# in `reg`; pairs with `debug_registered_count` to walk the registry
+# ---
+# reg: the registry to read
+# idx: enumeration index in [0, debug_registered_count)
+# ret: the vtable at that index, or none when idx is out of range
+pub fun debug_registered(reg: *DebugRegistry, idx: u32) O.Option[*DebugVTable] {
+    if (idx >= reg.count) { ret O.none[*DebugVTable](); }
+    ret O.some[*DebugVTable](reg.entries[idx]);
+}
+
 # declare that object format `vt` covers instruction set `arch_id`, appending it
 # to the vtable's coverage list
 #
@@ -704,5 +843,46 @@ test "mach.lang.target.of.covers_isa:declared_and_agnostic" {
     flat.covers_isa_count = 0;
     if (!covers_isa(?flat, isa.ARCH_X86_64))  { ret 1; }
     if (!covers_isa(?flat, isa.ARCH_RISCV64)) { ret 1; }
+    ret 0;
+}
+
+# a no-op producer used only to exercise the DebugRegistry seam. the end-to-end
+# "writes SK_DEBUG sections into an ObjectImage via be.obj" path is proven in
+# be.obj, where the builder is importable without an import cycle.
+fun t_debug_produce(ctx: *DebugContext) R.Result[bool, str] {
+    ret R.ok[bool, str](true);
+}
+
+# the debug-info registry installs a producer, resolves it by name, dispatches
+# through the seam, and is write-once: a second registration under a live name is
+# ignored and an unregistered name resolves to none.
+test "mach.lang.target.of.debug_register:install_lookup_dispatch" {
+    var reg: DebugRegistry = debug_registry_init();
+    if (debug_registered_count(?reg) != 0) { ret 1; }
+
+    var dw: DebugVTable;
+    dw.id = DBG_DWARF; dw.name = "dwarf"; dw.produce = t_debug_produce;
+    debug_register(?reg, ?dw);
+    if (debug_registered_count(?reg) != 1) { ret 1; }
+
+    val got: O.Option[*DebugVTable] = debug_lookup(?reg, "dwarf");
+    if (!O.is_some[*DebugVTable](got))               { ret 1; }
+    if (O.unwrap[*DebugVTable](got).id != DBG_DWARF) { ret 1; }
+
+    # dispatching through the seam reaches the registered producer.
+    var ctx: DebugContext;
+    ctx.image = nil; ctx.arch = nil;
+    ctx.producer = intern.STR_NIL; ctx.comp_dir = intern.STR_NIL;
+    val pr: R.Result[bool, str] = O.unwrap[*DebugVTable](got).produce(?ctx);
+    if (R.is_err[bool, str](pr)) { ret 1; }
+
+    # a second registration under the same name is ignored (write-once).
+    var dw2: DebugVTable;
+    dw2.id = DBG_DWARF; dw2.name = "dwarf"; dw2.produce = t_debug_produce;
+    debug_register(?reg, ?dw2);
+    if (debug_registered_count(?reg) != 1) { ret 1; }
+
+    # an unregistered model name resolves to none.
+    if (O.is_some[*DebugVTable](debug_lookup(?reg, "codeview"))) { ret 1; }
     ret 0;
 }

--- a/src/lang/target/of/coff.mach
+++ b/src/lang/target/of/coff.mach
@@ -78,6 +78,11 @@ val IMAGE_REL_AMD64_ADDR64:   u16 = 0x0001;
 val IMAGE_REL_AMD64_ADDR32:   u16 = 0x0002;
 val IMAGE_REL_AMD64_ADDR32NB: u16 = 0x0003;
 val IMAGE_REL_AMD64_REL32:    u16 = 0x0004;
+# CodeView debug references: SECTION is the target symbol's 16-bit section index
+# (a 2-byte field), SECREL is its 32-bit offset within that section (a 4-byte
+# field). used by DEBUG_S_LINES / S_GPROC32_ID to point debug records at code.
+val IMAGE_REL_AMD64_SECTION:  u16 = 0x000A;
+val IMAGE_REL_AMD64_SECREL:   u16 = 0x000B;
 
 # symbol storage classes (IMAGE_SYM_CLASS_*).
 val IMAGE_SYM_CLASS_EXTERNAL:      u8 = 2;
@@ -176,12 +181,16 @@ fun resolve(itn: *intern.Interner, id: intern.StrId) str {
 # unmapped kind is an error naming the kind, never silently serialized as ADDR64
 # (an 8-byte write over what codegen sized as a 4-byte field). pc32/plt32 both
 # encode a 32-bit pc-relative reference (REL32); addr32nb is the image-relative
-# ADDR32NB. `itn`/`alloc` back the error string.
+# ADDR32NB; abs32 is the 32-bit absolute ADDR32; secrel32/section are the CodeView
+# debug references. `itn`/`alloc` back the error string.
 fun reloc_type_for(itn: *intern.Interner, alloc: *A.Allocator, kind: of.RelocKind) R.Result[u16, str] {
     if (kind == of.RK_ABS64)    { ret R.ok[u16, str](IMAGE_REL_AMD64_ADDR64); }
     if (kind == of.RK_PC32)     { ret R.ok[u16, str](IMAGE_REL_AMD64_REL32); }
     if (kind == of.RK_PLT32)    { ret R.ok[u16, str](IMAGE_REL_AMD64_REL32); }
     if (kind == of.RK_ADDR32NB) { ret R.ok[u16, str](IMAGE_REL_AMD64_ADDR32NB); }
+    if (kind == of.RK_ABS32)    { ret R.ok[u16, str](IMAGE_REL_AMD64_ADDR32); }
+    if (kind == of.RK_SECREL32) { ret R.ok[u16, str](IMAGE_REL_AMD64_SECREL); }
+    if (kind == of.RK_SECTION)  { ret R.ok[u16, str](IMAGE_REL_AMD64_SECTION); }
     ret R.err[u16, str](unsupported_kind_message(itn, alloc, kind));
 }
 
@@ -222,9 +231,12 @@ fun validate_reloc_kinds(img: *of.ObjectImage) R.Result[bool, str] {
 # REL32 is next-byte-relative: link.exe/lld resolve `S + A_coff - (P+4)`, four
 # bytes more than the abstract `S + A_elf - P`. so the recovered abstract addend
 # is `A_elf = A_coff - 4` - subtract 4 from the field for REL32 only. ADDR64
-# (absolute) and ADDR32NB (image-relative) carry no P+4 term and are unchanged.
+# (absolute), ADDR32NB (image-relative), ADDR32 (absolute), and SECREL carry no
+# P+4 term and are unchanged. SECTION resolves to a 16-bit section index with no
+# addend, so its 2-byte field is never read as one.
 fun read_inplace_addend(sec: *of.Section, r_type: u16, offset: u32) i64 {
-    if (sec.bytes == nil) { ret 0; }
+    if (sec.bytes == nil)                  { ret 0; }
+    if (r_type == IMAGE_REL_AMD64_SECTION) { ret 0; }
     if (r_type == IMAGE_REL_AMD64_ADDR64) {
         if (offset::usize + 8 > sec.len::usize) { ret 0; }
         ret bin.read_u64_le(sec.bytes, offset::usize)::i64;
@@ -237,13 +249,16 @@ fun read_inplace_addend(sec: *of.Section, r_type: u16, offset: u32) i64 {
 
 # map a COFF x86-64 machine relocation type back to its abstract RK_* kind. an
 # unrecognized type is an error naming the type rather than a silent fall-through
-# to abs64. ADDR32 (a 32-bit absolute) is rejected too: there is no width-correct
-# abstract kind for it, and aliasing it to abs64 would link a foreign object's
-# 4-byte field with an 8-byte write.
+# to abs64. ADDR32 reads back as RK_ABS32 (its 4-byte unsigned absolute); SECREL /
+# SECTION as the CodeView debug kinds. a type with no width-correct abstract kind
+# is still rejected, so a foreign 4-byte field is never linked with an 8-byte write.
 fun reloc_kind_for(itn: *intern.Interner, alloc: *A.Allocator, r_type: u16) R.Result[of.RelocKind, str] {
     if (r_type == IMAGE_REL_AMD64_ADDR64)   { ret R.ok[of.RelocKind, str](of.RK_ABS64); }
     if (r_type == IMAGE_REL_AMD64_REL32)    { ret R.ok[of.RelocKind, str](of.RK_PC32); }
     if (r_type == IMAGE_REL_AMD64_ADDR32NB) { ret R.ok[of.RelocKind, str](of.RK_ADDR32NB); }
+    if (r_type == IMAGE_REL_AMD64_ADDR32)   { ret R.ok[of.RelocKind, str](of.RK_ABS32); }
+    if (r_type == IMAGE_REL_AMD64_SECREL)   { ret R.ok[of.RelocKind, str](of.RK_SECREL32); }
+    if (r_type == IMAGE_REL_AMD64_SECTION)  { ret R.ok[of.RelocKind, str](of.RK_SECTION); }
     ret R.err[of.RelocKind, str](unsupported_type_message(itn, alloc, r_type::u64));
 }
 
@@ -451,12 +466,14 @@ fun validate_reloc_symbols(img: *of.ObjectImage) R.Result[bool, str] {
     ret R.ok[bool, str](true);
 }
 
-# the byte width of a relocation's patched field - 8 for the
-# 64-bit absolute kind, 4 for every other supported kind (pc32 / plt32 / addr32nb,
-# all 4-byte). derived from the abstract kind directly; `validate_reloc_kinds`
-# rejects any kind the writer cannot map before this is consulted.
+# the byte width of a relocation's patched field - 8 for the 64-bit absolute kind,
+# 2 for the SECTION index (a 16-bit field), 4 for every other supported kind
+# (pc32 / plt32 / addr32nb / abs32 / secrel32, all 4-byte). derived from the
+# abstract kind directly; `validate_reloc_kinds` rejects any kind the writer
+# cannot map before this is consulted.
 fun reloc_field_width(kind: of.RelocKind) usize {
-    if (kind == of.RK_ABS64) { ret 8; }
+    if (kind == of.RK_ABS64)   { ret 8; }
+    if (kind == of.RK_SECTION) { ret 2; }
     ret 4;
 }
 
@@ -1029,9 +1046,10 @@ fun coff_serialize_image(img: *of.ObjectImage, comdat: *bool, path: *u8) R.Resul
     # field is next-byte-relative (link.exe/lld resolve `S + A_coff - (P+4)`), so
     # the on-wire field must hold `A_coff = A_elf + 4`. fold that effective value:
     # a `call sym` (RK_PC32/RK_PLT32, abstract addend -4) then writes 0, the
-    # correct COFF convention. ADDR64/ADDR32NB carry no P+4 term and fold the
-    # addend unchanged. `validate_reloc_ranges` already proved every field is in
-    # range; `read_inplace_addend` recovers `A_elf` on parse, so the round-trip
+    # correct COFF convention. ADDR64/ADDR32NB/ADDR32/SECREL carry no P+4 term and
+    # fold the addend unchanged; SECTION resolves to a section index and carries no
+    # addend, so it never folds. `validate_reloc_ranges` already proved every field
+    # is in range; `read_inplace_addend` recovers `A_elf` on parse, so the round-trip
     # is identity.
     var ridx: u32 = 0;
     for (ridx < img.reloc_count) {
@@ -4030,8 +4048,38 @@ test "mach.lang.target.of.coff.coff_emit_object:unsupported_reloc_kind" {
     ret 0;
 }
 
-# parse rejects a foreign ADDR32 relocation type instead of aliasing it to abs64 (#1256)
-test "mach.lang.target.of.coff.coff_parse_object:rejects_addr32" {
+# the three debug reloc kinds round-trip through the COFF hooks: the forward map
+# emits ADDR32 / SECREL / SECTION and the reverse map reads each back. SECTION is a
+# 2-byte section-index field, the others are 4-byte.
+test "mach.lang.target.of.coff.reloc_type_for:debug_kinds_roundtrip" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+    var i: intern.Interner = intern.init(?alloc);
+
+    var kinds: [3]of.RelocKind;
+    kinds[0] = of.RK_ABS32; kinds[1] = of.RK_SECREL32; kinds[2] = of.RK_SECTION;
+    var types: [3]u16;
+    types[0] = IMAGE_REL_AMD64_ADDR32; types[1] = IMAGE_REL_AMD64_SECREL; types[2] = IMAGE_REL_AMD64_SECTION;
+
+    var n: usize = 0;
+    for (n < 3) {
+        val tr: R.Result[u16, str] = reloc_type_for(?i, ?alloc, kinds[n]);
+        if (R.is_err[u16, str](tr) || R.unwrap_ok[u16, str](tr) != types[n])                       { ret 1; }
+        val kr: R.Result[of.RelocKind, str] = reloc_kind_for(?i, ?alloc, types[n]);
+        if (R.is_err[of.RelocKind, str](kr) || R.unwrap_ok[of.RelocKind, str](kr) != kinds[n])      { ret 1; }
+        n = n + 1;
+    }
+
+    if (reloc_field_width(of.RK_SECTION)  != 2) { ret 1; }
+    if (reloc_field_width(of.RK_ABS32)    != 4) { ret 1; }
+    if (reloc_field_width(of.RK_SECREL32) != 4) { ret 1; }
+    ret 0;
+}
+
+# parse rejects an unmapped relocation type (SREL32, signed section-relative)
+# instead of aliasing it to abs64 (#1256). ADDR32 / SECREL / SECTION now map, so a
+# still-unmapped type stands in for the "foreign type over a mismatched field" guard.
+test "mach.lang.target.of.coff.coff_parse_object:rejects_unmapped_type" {
     var alloc: A.Allocator;
     page.make(?alloc);
     var i: intern.Interner = intern.init(?alloc);
@@ -4083,12 +4131,13 @@ test "mach.lang.target.of.coff.coff_parse_object:rejects_addr32" {
     if (R.is_err[filesystem.Buffer, str](rb)) { ret 1; }
     val buf: filesystem.Buffer = R.unwrap_ok[filesystem.Buffer, str](rb);
 
-    # overwrite the lone relocation record's Type with ADDR32 (a 32-bit absolute
-    # the writer never emits). before #1256 the parser aliased ADDR32 to abs64 -
-    # an 8-byte relocation over the 4-byte field.
+    # overwrite the lone relocation record's Type with SREL32 (0x000C, a signed
+    # section-relative type the writer never emits and the parser does not map).
+    # before #1256 an unmapped type was aliased to abs64 - an 8-byte relocation
+    # over a smaller field.
     val rptr: usize = bin.read_u32_le(buf.data, COFF_HEADER_SIZE + 24)::usize;
     if (rptr == 0) { ret 1; }
-    bin.write_u16_le(buf.data, rptr + 8, IMAGE_REL_AMD64_ADDR32);
+    bin.write_u16_le(buf.data, rptr + 8, 0x000C);
 
     var out: of.ObjectImage;
     val pr: R.Result[bool, str] = coff_parse_object(?alloc, ?i, buf.data, buf.len, ?out);

--- a/src/lang/target/of/elf.mach
+++ b/src/lang/target/of/elf.mach
@@ -88,11 +88,13 @@ pub val R_X86_64_64:       u32 = 1;
 pub val R_X86_64_PC32:     u32 = 2;
 pub val R_X86_64_PLT32:    u32 = 4;
 pub val R_X86_64_GOTPCREL: u32 = 9;
+pub val R_X86_64_32:       u32 = 10;
 pub val R_X86_64_32S:      u32 = 11;
 
 # aarch64 relocation types. pub for the aarch64 `elf_reloc_type` forward map, as
 # with the x86_64 numbers above.
 pub val R_AARCH64_ABS64:               u32 = 257;
+pub val R_AARCH64_ABS32:               u32 = 258;
 pub val R_AARCH64_PREL32:              u32 = 261;
 pub val R_AARCH64_CALL26:              u32 = 283;
 pub val R_AARCH64_ADR_PREL_PG_HI21:    u32 = 275;
@@ -282,6 +284,7 @@ fun reloc_kind_for(itn: *intern.Interner, alloc: *A.Allocator, machine: u16, r_t
         if (r_type == R_RISCV_PCREL_HI20)   { ret R.ok[of.RelocKind, str](of.RK_PCREL_HI20); }
         if (r_type == R_RISCV_PCREL_LO12_I) { ret R.ok[of.RelocKind, str](of.RK_PCREL_LO12_I); }
         if (r_type == R_RISCV_PCREL_LO12_S) { ret R.ok[of.RelocKind, str](of.RK_PCREL_LO12_S); }
+        if (r_type == R_RISCV_32)           { ret R.ok[of.RelocKind, str](of.RK_ABS32); }
         ret R.err[of.RelocKind, str](unsupported_type_message(itn, alloc, r_type::u64));
     }
     if (r_type == R_X86_64_64 || r_type == R_AARCH64_ABS64)     { ret R.ok[of.RelocKind, str](of.RK_ABS64); }
@@ -289,6 +292,7 @@ fun reloc_kind_for(itn: *intern.Interner, alloc: *A.Allocator, machine: u16, r_t
     if (r_type == R_X86_64_PLT32 || r_type == R_AARCH64_CALL26) { ret R.ok[of.RelocKind, str](of.RK_PLT32); }
     if (r_type == R_X86_64_GOTPCREL)                            { ret R.ok[of.RelocKind, str](of.RK_GOTPCREL); }
     if (r_type == R_X86_64_32S)                                 { ret R.ok[of.RelocKind, str](of.RK_ABS32S); }
+    if (r_type == R_X86_64_32 || r_type == R_AARCH64_ABS32)     { ret R.ok[of.RelocKind, str](of.RK_ABS32); }
     if (r_type == R_AARCH64_ADR_PREL_PG_HI21)                   { ret R.ok[of.RelocKind, str](of.RK_PAGE21); }
     if (r_type == R_AARCH64_ADD_ABS_LO12_NC)                    { ret R.ok[of.RelocKind, str](of.RK_ADD_LO12); }
     if (r_type == R_AARCH64_LDST8_ABS_LO12_NC)                  { ret R.ok[of.RelocKind, str](of.RK_LDST8_LO12); }
@@ -3225,6 +3229,7 @@ fun t_x64_elf_reloc_type(kind: of.RelocKind) u32 {
     if (kind == of.RK_PLT32)    { ret R_X86_64_PLT32; }
     if (kind == of.RK_GOTPCREL) { ret R_X86_64_GOTPCREL; }
     if (kind == of.RK_ABS32S)   { ret R_X86_64_32S; }
+    if (kind == of.RK_ABS32)    { ret R_X86_64_32; }
     ret 0;
 }
 
@@ -3241,6 +3246,7 @@ fun t_riscv_elf_reloc_type(kind: of.RelocKind) u32 {
     if (kind == of.RK_PCREL_HI20)   { ret R_RISCV_PCREL_HI20; }
     if (kind == of.RK_PCREL_LO12_I) { ret R_RISCV_PCREL_LO12_I; }
     if (kind == of.RK_PCREL_LO12_S) { ret R_RISCV_PCREL_LO12_S; }
+    if (kind == of.RK_ABS32)        { ret R_RISCV_32; }
     ret 0;
 }
 
@@ -3442,6 +3448,27 @@ test "mach.lang.target.of.elf.reloc_kind_for:riscv_machine_keyed_reverse" {
     ret 0;
 }
 
+# RK_ABS32 (the 32-bit unsigned absolute DWARF cross-section refs need) round-trips
+# through the ELF hooks on every shipped ISA: the per-arch forward map emits the
+# width-specific absolute type (R_X86_64_32 / R_RISCV_32; arm64's forward map is
+# tested with the ISA) and the machine-keyed reverse map reads each back as RK_ABS32.
+test "mach.lang.target.of.elf.reloc_kind_for:abs32_roundtrip" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+    var i: intern.Interner = intern.init(?alloc);
+
+    if (t_x64_elf_reloc_type(of.RK_ABS32)   != R_X86_64_32) { ret 1; }
+    if (t_riscv_elf_reloc_type(of.RK_ABS32) != R_RISCV_32)  { ret 1; }
+
+    val xr: R.Result[of.RelocKind, str] = reloc_kind_for(?i, ?alloc, 62, R_X86_64_32);
+    if (R.is_err[of.RelocKind, str](xr) || R.unwrap_ok[of.RelocKind, str](xr) != of.RK_ABS32) { ret 1; }
+    val ar: R.Result[of.RelocKind, str] = reloc_kind_for(?i, ?alloc, 183, R_AARCH64_ABS32);
+    if (R.is_err[of.RelocKind, str](ar) || R.unwrap_ok[of.RelocKind, str](ar) != of.RK_ABS32) { ret 1; }
+    val rr: R.Result[of.RelocKind, str] = reloc_kind_for(?i, ?alloc, EM_RISCV, R_RISCV_32);
+    if (R.is_err[of.RelocKind, str](rr) || R.unwrap_ok[of.RelocKind, str](rr) != of.RK_ABS32) { ret 1; }
+    ret 0;
+}
+
 # parse_object must reject an ELF machine relocation type it cannot map to an
 # abstract kind (#1256) instead of silently reading it back as abs64 (an 8-byte
 # relocation over a 4-byte field).
@@ -3496,8 +3523,9 @@ test "mach.lang.target.of.elf.parse_object:unknown_reloc_type" {
     val buf: filesystem.Buffer = R.unwrap_ok[filesystem.Buffer, str](rb);
 
     # overwrite the lone rela entry's r_type (the low 32 bits of r_info) with a
-    # type the parser does not map (R_X86_64_32 = 10). before #1256 this was
-    # silently read back as abs64 - an 8-byte relocation over a 4-byte field.
+    # type the parser does not map (R_X86_64_16 = 12, a 16-bit absolute). before
+    # #1256 an unmapped type was silently read back as abs64 - an 8-byte
+    # relocation over a smaller field.
     val e_shoff:     usize = bin.read_u64_le(buf.data, 40)::usize;
     val e_shentsize: usize = bin.read_u16_le(buf.data, 58)::usize;
     val e_shnum:     usize = bin.read_u16_le(buf.data, 60)::usize;
@@ -3509,7 +3537,7 @@ test "mach.lang.target.of.elf.parse_object:unknown_reloc_type" {
         sh = sh + 1;
     }
     if (rela_off == 0) { ret 1; }
-    bin.write_u32_le(buf.data, rela_off + 8, 10);
+    bin.write_u32_le(buf.data, rela_off + 8, 12);
 
     var out: of.ObjectImage;
     val pr: R.Result[bool, str] = parse_object(?alloc, ?i, buf.data, buf.len, ?out);

--- a/src/lang/target/of/macho.mach
+++ b/src/lang/target/of/macho.mach
@@ -332,12 +332,19 @@ fun macho_reloc_for(itn: *intern.Interner, alloc: *A.Allocator, arch_id: u32, ki
         if (kind == of.RK_LDST32_LO12)  { r.r_type = ARM64_RELOC_PAGEOFF12; r.pcrel = 0; r.length = 2; ret R.ok[MachoReloc, str](r); }
         if (kind == of.RK_LDST64_LO12)  { r.r_type = ARM64_RELOC_PAGEOFF12; r.pcrel = 0; r.length = 2; ret R.ok[MachoReloc, str](r); }
         if (kind == of.RK_LDST128_LO12) { r.r_type = ARM64_RELOC_PAGEOFF12; r.pcrel = 0; r.length = 2; ret R.ok[MachoReloc, str](r); }
+        # the 32-bit unsigned absolute is the same UNSIGNED type as RK_ABS64, only
+        # length=2 (4-byte) instead of length=3 (8-byte); the parse side reads the
+        # length back to tell them apart.
+        if (kind == of.RK_ABS32)        { r.r_type = ARM64_RELOC_UNSIGNED;  r.pcrel = 0; r.length = 2; ret R.ok[MachoReloc, str](r); }
         ret R.err[MachoReloc, str](unsupported_kind_message(itn, alloc, kind));
     }
     if (kind == of.RK_ABS64)    { r.r_type = X86_64_RELOC_UNSIGNED; r.pcrel = 0; r.length = 3; ret R.ok[MachoReloc, str](r); }
     if (kind == of.RK_PC32)     { r.r_type = X86_64_RELOC_SIGNED;   r.pcrel = 1; r.length = 2; ret R.ok[MachoReloc, str](r); }
     if (kind == of.RK_PLT32)    { r.r_type = X86_64_RELOC_BRANCH;   r.pcrel = 1; r.length = 2; ret R.ok[MachoReloc, str](r); }
     if (kind == of.RK_GOTPCREL) { r.r_type = X86_64_RELOC_GOT_LOAD; r.pcrel = 1; r.length = 2; ret R.ok[MachoReloc, str](r); }
+    # the 32-bit unsigned absolute: UNSIGNED with length=2, the 4-byte sibling of
+    # RK_ABS64's length=3.
+    if (kind == of.RK_ABS32)    { r.r_type = X86_64_RELOC_UNSIGNED; r.pcrel = 0; r.length = 2; ret R.ok[MachoReloc, str](r); }
     ret R.err[MachoReloc, str](unsupported_kind_message(itn, alloc, kind));
 }
 
@@ -345,30 +352,44 @@ fun macho_reloc_for(itn: *intern.Interner, alloc: *A.Allocator, arch_id: u32, ki
 #
 # Keyed on the parsed header's cputype, since x86_64 and arm64 reuse low type
 # numbers with different meanings (type 3 is GOT_LOAD on x86_64 but PAGE21 on
-# arm64). arm64's `PAGEOFF12` is scale-agnostic on the wire, so the patched
+# arm64). the UNSIGNED type carries both the 8-byte RK_ABS64 and the 4-byte
+# RK_ABS32; `r_length` (log2 of the field width) disambiguates them - 3 is abs64,
+# 2 is abs32. arm64's `PAGEOFF12` is scale-agnostic on the wire, so the patched
 # instruction `insn` is decoded to recover the exact ADD / LDST*-width kind the
 # linker needs. An unrecognized type is an error naming it.
 # ---
-# itn:     interner backing the error string
-# alloc:   allocator backing the error string
-# cputype: the parsed header cputype (selects the per-arch table)
-# r_type:  the machine relocation type to map
-# insn:    the 32-bit instruction word at the patch site (arm64 PAGEOFF12 only)
-# ret:     ok(abstract kind), or an error naming the unrecognized type
-fun reloc_kind_for(itn: *intern.Interner, alloc: *A.Allocator, cputype: u32, r_type: u32, insn: u32) R.Result[of.RelocKind, str] {
+# itn:      interner backing the error string
+# alloc:    allocator backing the error string
+# cputype:  the parsed header cputype (selects the per-arch table)
+# r_type:   the machine relocation type to map
+# r_length: the on-wire r_length (log2 field width) disambiguating UNSIGNED
+# insn:     the 32-bit instruction word at the patch site (arm64 PAGEOFF12 only)
+# ret:      ok(abstract kind), or an error naming the unrecognized type
+fun reloc_kind_for(itn: *intern.Interner, alloc: *A.Allocator, cputype: u32, r_type: u32, r_length: u32, insn: u32) R.Result[of.RelocKind, str] {
     if (cputype == CPU_TYPE_ARM64) {
-        if (r_type == ARM64_RELOC_UNSIGNED)  { ret R.ok[of.RelocKind, str](of.RK_ABS64); }
+        if (r_type == ARM64_RELOC_UNSIGNED)  { ret unsigned_kind(r_length); }
         if (r_type == ARM64_RELOC_BRANCH26)  { ret R.ok[of.RelocKind, str](of.RK_PLT32); }
         if (r_type == ARM64_RELOC_PAGE21)    { ret R.ok[of.RelocKind, str](of.RK_PAGE21); }
         if (r_type == ARM64_RELOC_PAGEOFF12) { ret pageoff12_kind(itn, alloc, insn); }
         ret R.err[of.RelocKind, str](unsupported_type_message(itn, alloc, r_type::u64));
     }
-    if (r_type == X86_64_RELOC_UNSIGNED) { ret R.ok[of.RelocKind, str](of.RK_ABS64); }
+    if (r_type == X86_64_RELOC_UNSIGNED) { ret unsigned_kind(r_length); }
     if (r_type == X86_64_RELOC_SIGNED)   { ret R.ok[of.RelocKind, str](of.RK_PC32); }
     if (r_type == X86_64_RELOC_BRANCH)   { ret R.ok[of.RelocKind, str](of.RK_PLT32); }
     if (r_type == X86_64_RELOC_GOT_LOAD) { ret R.ok[of.RelocKind, str](of.RK_GOTPCREL); }
     if (r_type == X86_64_RELOC_GOT)      { ret R.ok[of.RelocKind, str](of.RK_GOTPCREL); }
     ret R.err[of.RelocKind, str](unsupported_type_message(itn, alloc, r_type::u64));
+}
+
+# resolve an UNSIGNED relocation's abstract kind from its on-wire length: length=3
+# is the 8-byte RK_ABS64, length=2 the 4-byte RK_ABS32. shared by both arches, which
+# both overload the one UNSIGNED type across the two widths.
+# ---
+# r_length: the on-wire r_length (log2 of the patched field width)
+# ret:      ok(RK_ABS64) for length 3, otherwise ok(RK_ABS32)
+fun unsigned_kind(r_length: u32) R.Result[of.RelocKind, str] {
+    if (r_length == 3) { ret R.ok[of.RelocKind, str](of.RK_ABS64); }
+    ret R.ok[of.RelocKind, str](of.RK_ABS32);
 }
 
 # recover the abstract low-12 kind of an arm64 PAGEOFF12 relocation from the
@@ -491,18 +512,18 @@ fun coalesce_kind(kind: of.SectionKind) of.SectionKind {
 }
 
 # whether an arm64 relocation carries its addend in a preceding ARM64_RELOC_ADDEND
-# entry. The 8-byte UNSIGNED (RK_ABS64) form keeps its addend in-place like
-# x86_64; the page/page-offset/branch kinds cannot, so a non-zero addend needs
-# the separate entry.
+# entry. The UNSIGNED forms (RK_ABS64 8-byte, RK_ABS32 4-byte) keep their addend
+# in-place like x86_64; the page/page-offset/branch kinds cannot, so a non-zero
+# addend needs the separate entry.
 # ---
 # arch_id: the target ISA id
 # kind:    the abstract relocation kind
 # addend:  the relocation addend
 # ret:     true when a separate ARM64_RELOC_ADDEND entry is required
 fun needs_addend_entry(arch_id: u32, kind: of.RelocKind, addend: i64) bool {
-    if (!arch_is_arm64(arch_id)) { ret false; }
-    if (addend == 0)             { ret false; }
-    if (kind == of.RK_ABS64)     { ret false; }
+    if (!arch_is_arm64(arch_id))                     { ret false; }
+    if (addend == 0)                                 { ret false; }
+    if (kind == of.RK_ABS64 || kind == of.RK_ABS32) { ret false; }
     ret true;
 }
 
@@ -2924,6 +2945,7 @@ fun populate_relocs(alloc: *A.Allocator, itn: *intern.Interner, buf: *u8, buf_si
                     val word:    u32 = bin.read_u32_le(buf, e + 4);
                     val symnum:  u32 = word & 0xFFFFFF;
                     val pcrel:   u32 = (word >> 24) & 0x1;
+                    val r_length: u32 = (word >> 25) & 0x3;
                     val extn:    u32 = (word >> 27) & 0x1;
                     val r_type:  u32 = (word >> 28) & 0xF;
 
@@ -2940,7 +2962,7 @@ fun populate_relocs(alloc: *A.Allocator, itn: *intern.Interner, buf: *u8, buf_si
                     if (out.sections[sec_i].bytes != nil && (address::usize + 4) <= out.sections[sec_i].len::usize) {
                         insn = bin.read_u32_le(out.sections[sec_i].bytes, address::usize);
                     }
-                    val rk: R.Result[of.RelocKind, str] = reloc_kind_for(itn, alloc, cputype, r_type, insn);
+                    val rk: R.Result[of.RelocKind, str] = reloc_kind_for(itn, alloc, cputype, r_type, r_length, insn);
                     if (R.is_err[of.RelocKind, str](rk)) { ret R.err[bool, str](R.unwrap_err[of.RelocKind, str](rk)); }
                     val kind: of.RelocKind = R.unwrap_ok[of.RelocKind, str](rk);
 
@@ -2978,8 +3000,9 @@ fun sign_extend24(v: u32) i64 {
 # recover a relocation's abstract addend from its in-place field or a paired
 # ARM64_RELOC_ADDEND value
 #
-# An 8-byte UNSIGNED (RK_ABS64) field holds the full addend; an x86_64
-# pc-relative field is next-instruction-relative, so the abstract addend is
+# An 8-byte UNSIGNED (RK_ABS64) field holds the full addend and a 4-byte UNSIGNED
+# (RK_ABS32) field the sign-extended 32-bit one, both in-place on either arch; an
+# x86_64 pc-relative field is next-instruction-relative, so the abstract addend is
 # `field - 4`. arm64 page/page-offset/branch kinds take the paired addend (0 when
 # none was present).
 # ---
@@ -2998,6 +3021,10 @@ fun recover_addend(out: *of.ObjectImage, sec_i: u32, address: u32, cputype: u32,
     val len:   usize = out.sections[sec_i].len::usize;
     if (kind == of.RK_ABS64) {
         if (bytes != nil && (address::usize + 8) <= len) { ret bin.read_u64_le(bytes, address::usize)::i64; }
+        ret 0;
+    }
+    if (kind == of.RK_ABS32) {
+        if (bytes != nil && (address::usize + 4) <= len) { ret (bin.read_u32_le(bytes, address::usize)::i32)::i64; }
         ret 0;
     }
     if (cputype == CPU_TYPE_ARM64) {
@@ -3399,18 +3426,48 @@ fun ts_pageoff12() u8 {
     page.make(?alloc);
     var i: intern.Interner = intern.init(?alloc);
 
-    val add: R.Result[of.RelocKind, str] = reloc_kind_for(?i, ?alloc, CPU_TYPE_ARM64, ARM64_RELOC_PAGEOFF12, 0x91000000);
+    val add: R.Result[of.RelocKind, str] = reloc_kind_for(?i, ?alloc, CPU_TYPE_ARM64, ARM64_RELOC_PAGEOFF12, 2, 0x91000000);
     if (R.is_err[of.RelocKind, str](add) || R.unwrap_ok[of.RelocKind, str](add) != of.RK_ADD_LO12)        { ret 1; }
-    val b8: R.Result[of.RelocKind, str] = reloc_kind_for(?i, ?alloc, CPU_TYPE_ARM64, ARM64_RELOC_PAGEOFF12, 0x39400000);
+    val b8: R.Result[of.RelocKind, str] = reloc_kind_for(?i, ?alloc, CPU_TYPE_ARM64, ARM64_RELOC_PAGEOFF12, 2, 0x39400000);
     if (R.unwrap_ok[of.RelocKind, str](b8) != of.RK_LDST8_LO12)                                           { ret 1; }
-    val h16: R.Result[of.RelocKind, str] = reloc_kind_for(?i, ?alloc, CPU_TYPE_ARM64, ARM64_RELOC_PAGEOFF12, 0x79400000);
+    val h16: R.Result[of.RelocKind, str] = reloc_kind_for(?i, ?alloc, CPU_TYPE_ARM64, ARM64_RELOC_PAGEOFF12, 2, 0x79400000);
     if (R.unwrap_ok[of.RelocKind, str](h16) != of.RK_LDST16_LO12)                                         { ret 1; }
-    val w32: R.Result[of.RelocKind, str] = reloc_kind_for(?i, ?alloc, CPU_TYPE_ARM64, ARM64_RELOC_PAGEOFF12, 0xB9400000);
+    val w32: R.Result[of.RelocKind, str] = reloc_kind_for(?i, ?alloc, CPU_TYPE_ARM64, ARM64_RELOC_PAGEOFF12, 2, 0xB9400000);
     if (R.unwrap_ok[of.RelocKind, str](w32) != of.RK_LDST32_LO12)                                         { ret 1; }
-    val x64: R.Result[of.RelocKind, str] = reloc_kind_for(?i, ?alloc, CPU_TYPE_ARM64, ARM64_RELOC_PAGEOFF12, 0xF9400000);
+    val x64: R.Result[of.RelocKind, str] = reloc_kind_for(?i, ?alloc, CPU_TYPE_ARM64, ARM64_RELOC_PAGEOFF12, 2, 0xF9400000);
     if (R.unwrap_ok[of.RelocKind, str](x64) != of.RK_LDST64_LO12)                                         { ret 1; }
-    val q128: R.Result[of.RelocKind, str] = reloc_kind_for(?i, ?alloc, CPU_TYPE_ARM64, ARM64_RELOC_PAGEOFF12, 0x3DC00000);
+    val q128: R.Result[of.RelocKind, str] = reloc_kind_for(?i, ?alloc, CPU_TYPE_ARM64, ARM64_RELOC_PAGEOFF12, 2, 0x3DC00000);
     if (R.unwrap_ok[of.RelocKind, str](q128) != of.RK_LDST128_LO12)                                       { ret 1; }
+    ret 0;
+}
+
+# RK_ABS32 (the DWARF 32-bit cross-section reference) round-trips through the Mach-O
+# hooks on both arches: the forward map emits UNSIGNED with length=2 (the 4-byte
+# sibling of RK_ABS64's length=3), and the reverse map reads the length back to tell
+# the two UNSIGNED widths apart.
+fun ts_abs32() u8 {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+    var i: intern.Interner = intern.init(?alloc);
+
+    val x32: R.Result[MachoReloc, str] = macho_reloc_for(?i, ?alloc, isa.ARCH_X86_64, of.RK_ABS32);
+    if (R.is_err[MachoReloc, str](x32))                                       { ret 1; }
+    if (R.unwrap_ok[MachoReloc, str](x32).r_type != X86_64_RELOC_UNSIGNED)    { ret 1; }
+    if (R.unwrap_ok[MachoReloc, str](x32).length != 2)                        { ret 1; }
+    val a32: R.Result[MachoReloc, str] = macho_reloc_for(?i, ?alloc, isa.ARCH_AARCH64, of.RK_ABS32);
+    if (R.is_err[MachoReloc, str](a32))                                       { ret 1; }
+    if (R.unwrap_ok[MachoReloc, str](a32).r_type != ARM64_RELOC_UNSIGNED)     { ret 1; }
+    if (R.unwrap_ok[MachoReloc, str](a32).length != 2)                        { ret 1; }
+
+    # length disambiguates the shared UNSIGNED type: 2 is abs32, 3 is abs64, on both arches.
+    val xr2: R.Result[of.RelocKind, str] = reloc_kind_for(?i, ?alloc, CPU_TYPE_X86_64, X86_64_RELOC_UNSIGNED, 2, 0);
+    if (R.is_err[of.RelocKind, str](xr2) || R.unwrap_ok[of.RelocKind, str](xr2) != of.RK_ABS32) { ret 1; }
+    val xr3: R.Result[of.RelocKind, str] = reloc_kind_for(?i, ?alloc, CPU_TYPE_X86_64, X86_64_RELOC_UNSIGNED, 3, 0);
+    if (R.is_err[of.RelocKind, str](xr3) || R.unwrap_ok[of.RelocKind, str](xr3) != of.RK_ABS64) { ret 1; }
+    val ar2: R.Result[of.RelocKind, str] = reloc_kind_for(?i, ?alloc, CPU_TYPE_ARM64, ARM64_RELOC_UNSIGNED, 2, 0);
+    if (R.is_err[of.RelocKind, str](ar2) || R.unwrap_ok[of.RelocKind, str](ar2) != of.RK_ABS32) { ret 1; }
+    val ar3: R.Result[of.RelocKind, str] = reloc_kind_for(?i, ?alloc, CPU_TYPE_ARM64, ARM64_RELOC_UNSIGNED, 3, 0);
+    if (R.is_err[of.RelocKind, str](ar3) || R.unwrap_ok[of.RelocKind, str](ar3) != of.RK_ABS64) { ret 1; }
     ret 0;
 }
 
@@ -3772,6 +3829,7 @@ test "mach.lang.target.of.macho:object_round_trip_and_reloc_maps" {
     if (ts_many_sections_coalesce() != 0) { ret 1; }
     if (ts_reloc_map() != 0)             { ret 1; }
     if (ts_pageoff12() != 0)             { ret 1; }
+    if (ts_abs32() != 0)                 { ret 1; }
     ret 0;
 }
 


### PR DESCRIPTION
Closes #1692. Part of the #1688 debug-info foundation.

## What
- **Three abstract reloc kinds** (`target/of.mach`): `RK_ABS32` (32-bit unsigned absolute, DWARF cross-section refs — DW_FORM_strp/sec_offset/ref_addr), `RK_SECREL32` and `RK_SECTION` (CodeView code refs), mapped per-format **and** per-ISA:
  - **ELF** forward maps (per-ISA `elf_reloc_type`): `RK_ABS32` → R_X86_64_32 / R_AARCH64_ABS32 / R_RISCV_32 (riscv64 gains its first R_RISCV_32 mapping); reverse parse map keyed on e_machine.
  - **Mach-O**: `RK_ABS32` → UNSIGNED length=2 on x64 and arm64; the reverse map now takes the on-wire `r_length` to split the two UNSIGNED widths (abs32 len 2 vs abs64 len 3).
  - **COFF**: `RK_ABS32`→ADDR32, `RK_SECREL32`→SECREL, `RK_SECTION`→SECTION. SECTION patches a 2-byte section-index field (distinct `reloc_field_width`, never read as an addend).
- **DebugInfo producer seam** (`target/of.mach`): `DebugContext` (image + ISA + producer/comp_dir CU metadata), `DebugProduceFn`, `DebugVTable`, and a write-once `DebugRegistry` keyed by model name — parallel to `OfVTable`/`OfRegistry`. A be.obj test producer registers behind it and writes an SK_DEBUG section + anchor symbol + RK_ABS32 relocation into a module `ObjectImage`, proving the 'via be.obj' contract end to end.

## Invariant — byte-identical without `-g`
Purely additive and inert: no producer is registered and no emitter produces the new kinds, so non-debug output is unchanged. Verified by building a fixed input (origin/dev source) with a from-source dev-baseline compiler vs this branch's compiler — **all 160+ artifacts byte-identical across all six targets** (ELF x64/arm64/riscv64, COFF windows, Mach-O x64/arm64), final binaries included.

## Verification
- From-source build clean; unit suite **511 pass / 0 fail** (baseline + 4 new: ELF/COFF/Mach-O reloc round-trips + the two seam tests).
- Self-host fixpoint reached (stage2 == stage3 byte-identical).
- Byte-identity pin: 6/6 targets identical vs fresh origin/dev baseline.
- int harness green on the linux leg (incl. the COFF/Mach-O/ELF structural cases across every ISA).
- Rebased onto current origin/dev (integrates SK_RELRO + #1693 register tables) cleanly.
