### PR TITLE
feat(link): carry non-allocated debug sections into executables (#1694)

### DIFF
--- a/src/lang/be/linker.mach
+++ b/src/lang/be/linker.mach
@@ -60,12 +60,14 @@ pub val LINK_RELOCATABLE: LinkMode = 1;
 # shared object / dynamic library
 pub val LINK_SHARED:      LinkMode = 2;
 
-# number of distinct merged output sections, one per `of.SK_*` kind. the merge
-# concatenates every input section of a kind into the kind's single output
-# section, in the canonical order TEXT, DATA, RODATA, RELRO, BSS, DEBUG (the
+# number of fixed, kind-keyed merged output sections - one per `of.SK_*` kind. the
+# merge concatenates every input section of an allocatable kind into that kind's
+# single output section, in the canonical order TEXT, DATA, RODATA, RELRO, BSS (the
 # `of.SK_*` numeric order; RELRO sits before BSS so a read-only-natured RELRO
-# segment is laid out with the constants, and DEBUG is non-allocated and excluded
-# from load segments).
+# segment is laid out with the constants). the `SK_DEBUG` kind slot stays unused:
+# non-allocated debug sections do not collapse by kind but are kept distinct by
+# NAME in name-keyed slots appended past this prefix (see `discover_debug_names`),
+# so `.debug_info`/`.debug_line`/... each survive as their own output section.
 val MERGED_KIND_COUNT: u32 = of.SK_COUNT;
 
 # placement of one input section within the merged image: which merged output
@@ -84,14 +86,22 @@ rec Placement {
 # accumulator describing one merged output section while it is being built: its
 # kind, the maximum alignment demanded by any contributing input section, the
 # running content length, and the assigned base virtual address.
+#
+# The first `MERGED_KIND_COUNT` accumulators are the fixed kind slots (index i
+# merges kind i) and carry `name = STR_NIL` - their output name derives from the
+# kind. Any accumulators past that prefix are name-keyed debug slots: non-allocated
+# `SK_DEBUG` sections kept distinct by name (`.debug_info`, `.debug_line`, ...) so
+# each survives the merge as its own output section rather than collapsing into one.
 # ---
 # kind:  the section kind this accumulator merges
+# name:  interned output name for a name-keyed debug slot, or STR_NIL for a kind slot
 # align: largest alignment any contributing section requires
 # len:   total content length accumulated so far
 # vaddr: base virtual address assigned to this merged section (0 if unassigned)
 # used:  true once at least one input section contributed
 rec MergedSection {
     kind:  of.SectionKind;
+    name:  intern.StrId;
     align: u32;
     len:   u32;
     vaddr: u64;
@@ -283,9 +293,29 @@ fun link_modules(s: *session.Session, tgt: *target.Target, modules: *of.ObjectIm
         ret R.err[bool, str]("link: no input objects");
     }
 
-    # build the merged-section accumulators, one per kind, in canonical order.
-    var merged: [6]MergedSection;
-    init_merged(?merged[0]);
+    # discover the distinct debug-section names (first-encounter order) so the merge
+    # keeps non-allocated debug sections distinct by name instead of collapsing them
+    # into one kind-keyed section. with no debug input this yields 0 and the merge is
+    # the classic per-kind merge.
+    var debug_names: *intern.StrId = nil;
+    var debug_count: u32 = 0;
+    val dn_r: R.Result[bool, str] = discover_debug_names(alloc, modules, module_count, ?debug_names, ?debug_count);
+    if (R.is_err[bool, str](dn_r)) { ret R.err[bool, str](R.unwrap_err[bool, str](dn_r)); }
+
+    # the merged-section accumulators: the fixed kind slots in canonical order,
+    # followed by one name-keyed slot per distinct debug section name. `merged_to_out`
+    # is filled by build_merged_image to map a placement's merged index to its output
+    # section, and stays nil until then.
+    val merged_count: u32 = MERGED_KIND_COUNT + debug_count;
+    var merged: *MergedSection = nil;
+    val mrg_r: R.Result[*MergedSection, str] = A.zallocate[MergedSection](alloc, merged_count::usize);
+    if (R.is_err[*MergedSection, str](mrg_r)) {
+        if (debug_names != nil && debug_count > 0) { A.deallocate[intern.StrId](alloc, debug_names, debug_count::usize); }
+        ret R.err[bool, str](R.unwrap_err[*MergedSection, str](mrg_r));
+    }
+    merged = R.unwrap_ok[*MergedSection, str](mrg_r);
+    init_merged(merged, debug_names, debug_count);
+    var merged_to_out: *u32 = nil;
 
     # first pass over every input section: tally per-kind length and alignment,
     # and remember each input section's placement (merged index + offset). the
@@ -296,6 +326,7 @@ fun link_modules(s: *session.Session, tgt: *target.Target, modules: *of.ObjectIm
     if (sec_total > 0) {
         val pr: R.Result[*Placement, str] = A.zallocate[Placement](alloc, sec_total::usize);
         if (R.is_err[*Placement, str](pr)) {
+            free_scratch(alloc, nil, 0, nil, 0, merged, merged_count, debug_names, debug_count, merged_to_out);
             ret R.err[bool, str](R.unwrap_err[*Placement, str](pr));
         }
         placements = R.unwrap_ok[*Placement, str](pr);
@@ -305,15 +336,15 @@ fun link_modules(s: *session.Session, tgt: *target.Target, modules: *of.ObjectIm
     var sec_base: *u32 = nil;
     val br: R.Result[*u32, str] = A.zallocate[u32](alloc, module_count::usize);
     if (R.is_err[*u32, str](br)) {
-        free_placements(alloc, placements, sec_total);
+        free_scratch(alloc, placements, sec_total, nil, 0, merged, merged_count, debug_names, debug_count, merged_to_out);
         ret R.err[bool, str](R.unwrap_err[*u32, str](br));
     }
     sec_base = R.unwrap_ok[*u32, str](br);
 
     val acc_r: R.Result[bool, str] =
-        accumulate_sections(s, modules, module_count, ?merged[0], placements, sec_base);
+        accumulate_sections(s, modules, module_count, merged, debug_names, debug_count, placements, sec_base);
     if (R.is_err[bool, str](acc_r)) {
-        free_scratch(alloc, placements, sec_total, sec_base, module_count);
+        free_scratch(alloc, placements, sec_total, sec_base, module_count, merged, merged_count, debug_names, debug_count, merged_to_out);
         ret R.err[bool, str](R.unwrap_err[bool, str](acc_r));
     }
 
@@ -321,8 +352,8 @@ fun link_modules(s: *session.Session, tgt: *target.Target, modules: *of.ObjectIm
     # are placed in canonical order from the OS base, each kind page-aligned.
     val assign_vaddrs: bool = (mode == LINK_EXE);
     if (assign_vaddrs) {
-        assign_section_vaddrs(tgt, ?merged[0], pie);
-        finalize_placement_vaddrs(?merged[0], placements, sec_total);
+        assign_section_vaddrs(tgt, merged, pie);
+        finalize_placement_vaddrs(merged, placements, sec_total);
     }
 
     # collect the global symbol table: every defined symbol keyed by name, with
@@ -334,7 +365,7 @@ fun link_modules(s: *session.Session, tgt: *target.Target, modules: *of.ObjectIm
         collect_symbols(s, modules, module_count, placements, sec_base, ?sym_locs, assign_vaddrs);
     if (R.is_err[bool, str](collect_r)) {
         map.dnit[intern.StrId, SymbolLoc](?sym_locs);
-        free_scratch(alloc, placements, sec_total, sec_base, module_count);
+        free_scratch(alloc, placements, sec_total, sec_base, module_count, merged, merged_count, debug_names, debug_count, merged_to_out);
         ret R.err[bool, str](R.unwrap_err[bool, str](collect_r));
     }
 
@@ -344,17 +375,28 @@ fun link_modules(s: *session.Session, tgt: *target.Target, modules: *of.ObjectIm
     val img_r: R.Result[of.ObjectImage, str] = obj.init(alloc, ?s.interner, image_name(modules, module_count));
     if (R.is_err[of.ObjectImage, str](img_r)) {
         map.dnit[intern.StrId, SymbolLoc](?sym_locs);
-        free_scratch(alloc, placements, sec_total, sec_base, module_count);
+        free_scratch(alloc, placements, sec_total, sec_base, module_count, merged, merged_count, debug_names, debug_count, merged_to_out);
         ret R.err[bool, str](R.unwrap_err[of.ObjectImage, str](img_r));
     }
     out_img = R.unwrap_ok[of.ObjectImage, str](img_r);
 
+    # the merged-index -> output-section map, filled by build_merged_image and read
+    # by relocation patching/carry to find the output section a placement landed in.
+    val mto_r: R.Result[*u32, str] = A.zallocate[u32](alloc, merged_count::usize);
+    if (R.is_err[*u32, str](mto_r)) {
+        obj.dnit(?out_img);
+        map.dnit[intern.StrId, SymbolLoc](?sym_locs);
+        free_scratch(alloc, placements, sec_total, sec_base, module_count, merged, merged_count, debug_names, debug_count, merged_to_out);
+        ret R.err[bool, str](R.unwrap_err[*u32, str](mto_r));
+    }
+    merged_to_out = R.unwrap_ok[*u32, str](mto_r);
+
     val build_r: R.Result[bool, str] =
-        build_merged_image(s, ?out_img, modules, module_count, ?merged[0], placements, sec_base);
+        build_merged_image(s, ?out_img, modules, module_count, merged, merged_count, placements, sec_base, merged_to_out);
     if (R.is_err[bool, str](build_r)) {
         obj.dnit(?out_img);
         map.dnit[intern.StrId, SymbolLoc](?sym_locs);
-        free_scratch(alloc, placements, sec_total, sec_base, module_count);
+        free_scratch(alloc, placements, sec_total, sec_base, module_count, merged, merged_count, debug_names, debug_count, merged_to_out);
         ret R.err[bool, str](R.unwrap_err[bool, str](build_r));
     }
 
@@ -378,33 +420,33 @@ fun link_modules(s: *session.Session, tgt: *target.Target, modules: *of.ObjectIm
                 free_dynstate(alloc, ?dyn);
                 obj.dnit(?out_img);
                 map.dnit[intern.StrId, SymbolLoc](?sym_locs);
-                free_scratch(alloc, placements, sec_total, sec_base, module_count);
+                free_scratch(alloc, placements, sec_total, sec_base, module_count, merged, merged_count, debug_names, debug_count, merged_to_out);
                 ret R.err[bool, str](R.unwrap_err[bool, str](dr));
             }
         }
 
         val patch_r: R.Result[bool, str] =
-            patch_relocations(s, ?out_img, modules, module_count, placements, sec_base, ?sym_locs, ?dyn, tgt.arch);
+            patch_relocations(s, ?out_img, modules, module_count, placements, sec_base, merged_to_out, ?sym_locs, ?dyn, tgt.arch);
         if (R.is_err[bool, str](patch_r)) {
             free_dynstate(alloc, ?dyn);
             obj.dnit(?out_img);
             map.dnit[intern.StrId, SymbolLoc](?sym_locs);
-            free_scratch(alloc, placements, sec_total, sec_base, module_count);
+            free_scratch(alloc, placements, sec_total, sec_base, module_count, merged, merged_count, debug_names, debug_count, merged_to_out);
             ret R.err[bool, str](R.unwrap_err[bool, str](patch_r));
         }
 
         var emit_r: R.Result[bool, str] = R.ok[bool, str](true);
         if (dynamic) {
-            emit_r = emit_dynamic_executable(s, tgt, ?out_img, ?merged[0], ?sym_locs, ?dyn, out_path, name);
+            emit_r = emit_dynamic_executable(s, tgt, ?out_img, merged, ?sym_locs, ?dyn, out_path, name);
         }
         or {
-            emit_r = emit_executable(s, tgt, ?out_img, ?merged[0], ?sym_locs, out_path, name);
+            emit_r = emit_executable(s, tgt, ?out_img, merged, ?sym_locs, out_path, name);
         }
 
         free_dynstate(alloc, ?dyn);
         obj.dnit(?out_img);
         map.dnit[intern.StrId, SymbolLoc](?sym_locs);
-        free_scratch(alloc, placements, sec_total, sec_base, module_count);
+        free_scratch(alloc, placements, sec_total, sec_base, module_count, merged, merged_count, debug_names, debug_count, merged_to_out);
 
         if (R.is_err[bool, str](emit_r)) {
             ret R.err[bool, str](R.unwrap_err[bool, str](emit_r));
@@ -415,11 +457,11 @@ fun link_modules(s: *session.Session, tgt: *target.Target, modules: *of.ObjectIm
     # library (relocatable): carry the input relocations forward unpatched and
     # write the single merged object through the format's object writer.
     val carry_r: R.Result[bool, str] =
-        carry_relocations(?out_img, modules, module_count, placements, sec_base);
+        carry_relocations(?out_img, modules, module_count, placements, sec_base, merged_to_out);
     if (R.is_err[bool, str](carry_r)) {
         obj.dnit(?out_img);
         map.dnit[intern.StrId, SymbolLoc](?sym_locs);
-        free_scratch(alloc, placements, sec_total, sec_base, module_count);
+        free_scratch(alloc, placements, sec_total, sec_base, module_count, merged, merged_count, debug_names, debug_count, merged_to_out);
         ret R.err[bool, str](R.unwrap_err[bool, str](carry_r));
     }
 
@@ -427,7 +469,7 @@ fun link_modules(s: *session.Session, tgt: *target.Target, modules: *of.ObjectIm
 
     obj.dnit(?out_img);
     map.dnit[intern.StrId, SymbolLoc](?sym_locs);
-    free_scratch(alloc, placements, sec_total, sec_base, module_count);
+    free_scratch(alloc, placements, sec_total, sec_base, module_count, merged, merged_count, debug_names, debug_count, merged_to_out);
 
     if (R.is_err[bool, str](obj_r)) {
         ret R.err[bool, str](R.unwrap_err[bool, str](obj_r));
@@ -688,9 +730,19 @@ fun emit_executable(s: *session.Session, tgt: *target.Target, out_img: *of.Objec
     }
     val funcs: *of.ExecFunction = R.unwrap_ok[*of.ExecFunction, str](fr);
 
-    val emit_r: R.Result[bool, str] =
-        tgt.of.emit_exec(alloc, ?s.interner, tgt.arch, segs, seg_count, os_page_size(tgt), entry, funcs, func_count, nil::*of.Section, 0, out_path, name);
+    var dbg_count: u32 = 0;
+    val dr: R.Result[*of.Section, str] = collect_debug_sections(alloc, out_img, ?dbg_count);
+    if (R.is_err[*of.Section, str](dr)) {
+        if (funcs != nil && func_count > 0) { A.deallocate[of.ExecFunction](alloc, funcs, func_count::usize); }
+        A.deallocate[of.LoadSegment](alloc, segs, seg_count::usize);
+        ret R.err[bool, str](R.unwrap_err[*of.Section, str](dr));
+    }
+    val dbg: *of.Section = R.unwrap_ok[*of.Section, str](dr);
 
+    val emit_r: R.Result[bool, str] =
+        tgt.of.emit_exec(alloc, ?s.interner, tgt.arch, segs, seg_count, os_page_size(tgt), entry, funcs, func_count, dbg, dbg_count, out_path, name);
+
+    if (dbg != nil && dbg_count > 0) { A.deallocate[of.Section](alloc, dbg, dbg_count::usize); }
     if (funcs != nil && func_count > 0) {
         A.deallocate[of.ExecFunction](alloc, funcs, func_count::usize);
     }
@@ -748,10 +800,20 @@ fun emit_dynamic_executable(s: *session.Session, tgt: *target.Target, out_img: *
     }
     val funcs: *of.ExecFunction = R.unwrap_ok[*of.ExecFunction, str](fr);
 
+    var dbg_count: u32 = 0;
+    val dr: R.Result[*of.Section, str] = collect_debug_sections(alloc, out_img, ?dbg_count);
+    if (R.is_err[*of.Section, str](dr)) {
+        if (funcs != nil && func_count > 0) { A.deallocate[of.ExecFunction](alloc, funcs, func_count::usize); }
+        A.deallocate[of.LoadSegment](alloc, segs, seg_count::usize);
+        ret R.err[bool, str](R.unwrap_err[*of.Section, str](dr));
+    }
+    val dbg: *of.Section = R.unwrap_ok[*of.Section, str](dr);
+
     val emit_r: R.Result[bool, str] =
         tgt.of.emit_dyn_exec(alloc, ?s.interner, tgt.arch, segs, seg_count, os_page_size(tgt), entry,
-                             funcs, func_count, ?dyn.info, dyn.fixups, dyn.fixup_count, nil::*of.Section, 0, out_path, name);
+                             funcs, func_count, ?dyn.info, dyn.fixups, dyn.fixup_count, dbg, dbg_count, out_path, name);
 
+    if (dbg != nil && dbg_count > 0) { A.deallocate[of.Section](alloc, dbg, dbg_count::usize); }
     if (funcs != nil && func_count > 0) {
         A.deallocate[of.ExecFunction](alloc, funcs, func_count::usize);
     }
@@ -761,6 +823,44 @@ fun emit_dynamic_executable(s: *session.Session, tgt: *target.Target, out_img: *
         ret R.err[bool, str](R.unwrap_err[bool, str](emit_r));
     }
     ret R.ok[bool, str](true);
+}
+
+# collect the non-allocated debug sections of the merged image into a freshly
+# allocated compact array (shallow copies sharing the image's section bytes), in
+# image order, for the executable writers' debug channel. returns nil with a zero
+# count when the image has no debug sections. the caller frees the array (never the
+# bytes, which the image owns).
+# ---
+# alloc:   allocator backing the returned array
+# out_img: the merged image whose SK_DEBUG sections are collected
+# count:   out - number of debug sections collected
+# ret:     the debug-section array (freed by the caller), nil when count is 0, or an error string
+fun collect_debug_sections(alloc: *A.Allocator, out_img: *of.ObjectImage, count: *u32) R.Result[*of.Section, str] {
+    @count = 0;
+    var n: u32 = 0;
+    var i: u32 = 0;
+    for (i < out_img.section_count) {
+        if (out_img.sections[i].kind == of.SK_DEBUG) { n = n + 1; }
+        i = i + 1;
+    }
+    if (n == 0) { ret R.ok[*of.Section, str](nil); }
+
+    val ar: R.Result[*of.Section, str] = A.allocate[of.Section](alloc, n::usize);
+    if (R.is_err[*of.Section, str](ar)) { ret R.err[*of.Section, str](R.unwrap_err[*of.Section, str](ar)); }
+    val out: *of.Section = R.unwrap_ok[*of.Section, str](ar);
+
+    var w: u32 = 0;
+    i = 0;
+    for (i < out_img.section_count) {
+        if (out_img.sections[i].kind == of.SK_DEBUG) {
+            out[w] = out_img.sections[i];
+            w = w + 1;
+        }
+        i = i + 1;
+    }
+
+    @count = n;
+    ret R.ok[*of.Section, str](out);
 }
 
 # resolve the program entry point to the OS entry symbol's virtual
@@ -984,21 +1084,98 @@ fun merged_section_bytes(out_img: *of.ObjectImage, kind: of.SectionKind) *u8 {
     ret nil;
 }
 
-# reset the per-kind accumulator array to its canonical kinds and
-# empty state. index i holds kind i (SK_TEXT..SK_DEBUG); the numeric order is the
-# canonical layout order.
+# reset the merged accumulator array to its empty state: the fixed
+# kind slots (index i holds kind i, in canonical layout order) followed by one
+# name-keyed `SK_DEBUG` slot per distinct debug section name, in first-encounter
+# order. every slot starts unused with alignment 1.
 # ---
-# merged: the per-kind accumulator array to reset (MERGED_KIND_COUNT entries)
-fun init_merged(merged: *MergedSection) {
+# merged:      the accumulator array to reset (MERGED_KIND_COUNT + debug_count entries)
+# debug_names: the distinct debug section names for the trailing name-keyed slots
+# debug_count: number of name-keyed debug slots
+fun init_merged(merged: *MergedSection, debug_names: *intern.StrId, debug_count: u32) {
     var i: u32 = 0;
     for (i < MERGED_KIND_COUNT) {
         merged[i].kind  = i::u8;
+        merged[i].name  = intern.STR_NIL;
         merged[i].align = 1;
         merged[i].len   = 0;
         merged[i].vaddr = 0;
         merged[i].used  = false;
         i = i + 1;
     }
+    var d: u32 = 0;
+    for (d < debug_count) {
+        val slot: u32 = MERGED_KIND_COUNT + d;
+        merged[slot].kind  = of.SK_DEBUG;
+        merged[slot].name  = debug_names[d];
+        merged[slot].align = 1;
+        merged[slot].len   = 0;
+        merged[slot].vaddr = 0;
+        merged[slot].used  = false;
+        d = d + 1;
+    }
+}
+
+# collect the distinct `SK_DEBUG` section names across every input image into a
+# freshly allocated array, in first-encounter order (deterministic given the fixed
+# module/section iteration order). the name-keyed merge routes each debug input
+# section to the slot for its name; the count sizes the merged accumulator array.
+# with no debug input the array is nil and the count 0. the caller frees the array.
+# ---
+# alloc:        allocator backing the returned name array
+# modules:      the input image array
+# module_count: number of input images
+# out_names:    out - the distinct debug names (nil when count is 0), freed by caller
+# out_count:    out - number of distinct debug names
+# ret:          ok(true) on success, or an allocation error
+fun discover_debug_names(alloc: *A.Allocator, modules: *of.ObjectImage, module_count: u32,
+                         out_names: **intern.StrId, out_count: *u32) R.Result[bool, str] {
+    @out_names = nil;
+    @out_count = 0;
+    var names: *intern.StrId = nil;
+    var count: u32 = 0;
+    var cap:   u32 = 0;
+
+    var m: u32 = 0;
+    for (m < module_count) {
+        var sc: u32 = 0;
+        for (sc < modules[m].section_count) {
+            val sec: *of.Section = ?modules[m].sections[sc];
+            if (sec.kind != of.SK_DEBUG) { sc = sc + 1; cnt; }
+
+            # a debug section name already seen shares its slot; names are interned
+            # into the one session interner, so StrId equality is name equality.
+            var seen: bool = false;
+            var j: u32 = 0;
+            for (j < count) {
+                if (names[j] == sec.name) { seen = true; }
+                j = j + 1;
+            }
+            if (seen) { sc = sc + 1; cnt; }
+
+            if (count == cap) {
+                var new_cap: u32 = cap * 2;
+                if (new_cap == 0) { new_cap = 4; }
+                val gr: R.Result[*intern.StrId, str] =
+                    A.reallocate[intern.StrId](alloc, names, cap::usize, new_cap::usize);
+                if (R.is_err[*intern.StrId, str](gr)) {
+                    if (names != nil && cap > 0) { A.deallocate[intern.StrId](alloc, names, cap::usize); }
+                    ret R.err[bool, str](R.unwrap_err[*intern.StrId, str](gr));
+                }
+                names = R.unwrap_ok[*intern.StrId, str](gr);
+                cap = new_cap;
+            }
+            names[count] = sec.name;
+            count = count + 1;
+
+            sc = sc + 1;
+        }
+        m = m + 1;
+    }
+
+    @out_names = names;
+    @out_count = count;
+    ret R.ok[bool, str](true);
 }
 
 # sum the section counts of every input image
@@ -1024,12 +1201,15 @@ fun total_sections(modules: *of.ObjectImage, module_count: u32) u32 {
 # s:            shared session, for diagnostics
 # modules:      the input image array
 # module_count: number of input images
-# merged:       the per-kind accumulators, updated in place
+# merged:       the merged accumulators (kind slots + debug name slots), updated in place
+# debug_names:  the distinct debug section names, indexing the name-keyed slots
+# debug_count:  number of name-keyed debug slots
 # placements:   out - per-input-section placement (merged index + offset)
 # sec_base:     out - per-module prefix offset into `placements`
 # ret:          ok(true) on success, or an error string
 fun accumulate_sections(s: *session.Session, modules: *of.ObjectImage, module_count: u32,
-                        merged: *MergedSection, placements: *Placement, sec_base: *u32) R.Result[bool, str] {
+                        merged: *MergedSection, debug_names: *intern.StrId, debug_count: u32,
+                        placements: *Placement, sec_base: *u32) R.Result[bool, str] {
     var flat: u32 = 0;
     var m: u32 = 0;
     for (m < module_count) {
@@ -1043,7 +1223,21 @@ fun accumulate_sections(s: *session.Session, modules: *of.ObjectImage, module_co
             if (sec.kind::u32 >= MERGED_KIND_COUNT) {
                 ret R.err[bool, str](named_message(s, "linker: input section in object '", modules[m].name, "' has an unknown section kind", "linker: input section has an unknown section kind"));
             }
-            val ki: u32 = sec.kind::u32;
+            # allocatable kinds collapse into their kind slot; a non-allocated debug
+            # section routes to the name-keyed slot for its section name so distinct
+            # debug sections never merge together.
+            var ki: u32 = sec.kind::u32;
+            if (sec.kind == of.SK_DEBUG) {
+                var found: bool = false;
+                var di: u32 = 0;
+                for (di < debug_count) {
+                    if (debug_names[di] == sec.name) { ki = MERGED_KIND_COUNT + di; found = true; }
+                    di = di + 1;
+                }
+                # discover_debug_names registered every debug name from these same
+                # inputs, so a miss is an internal invariant break, not an input error.
+                if (!found) { ret R.err[bool, str]("linker: debug section name not registered in the merge"); }
+            }
 
             var a: u32 = sec.align;
             if (a == 0)               { a = 1; }
@@ -1198,33 +1392,37 @@ fun collect_symbols(s: *session.Session, modules: *of.ObjectImage, module_count:
     ret R.ok[bool, str](true);
 }
 
-# allocate one output section per used kind and copy every
+# allocate one output section per used merged slot and copy every
 # contributing input section's bytes into its placed offset. records, on the
-# output image, the merged section's kind, alignment, length, and (for
-# executables) virtual address via the section name. BSS sections carry no
-# bytes.
+# output image, the merged section's name, kind, alignment, and length. the
+# allocatable kind slots produce `.text`/`.data`/... named by kind; each used
+# debug name slot produces its own `.debug_*` section. BSS carries no bytes.
+# `merged_to_out` (sized `merged_count`) is filled with each slot's output-section
+# index (0xFFFFFFFF for an empty slot) so relocation patching/carry can rebase.
 # ---
-# s:            shared session (allocator), for the merged section storage
-# out_img:      out - the merged image to populate with sections and symbols
-# modules:      the input image array
-# module_count: number of input images
-# merged:       the per-kind accumulators (carry each kind's length and alignment)
-# placements:   per-input-section placement (merged index + offset)
-# sec_base:     per-module prefix offset into `placements`
-# ret:          ok(true) on success, or an error string
+# s:             shared session (allocator), for the merged section storage
+# out_img:       out - the merged image to populate with sections and symbols
+# modules:       the input image array
+# module_count:  number of input images
+# merged:        the merged accumulators (carry each slot's name, length, alignment)
+# merged_count:  number of merged slots (kind slots + debug name slots)
+# placements:    per-input-section placement (merged index + offset)
+# sec_base:      per-module prefix offset into `placements`
+# merged_to_out: out - per-slot output-section index (0xFFFFFFFF when empty)
+# ret:           ok(true) on success, or an error string
 fun build_merged_image(s: *session.Session, out_img: *of.ObjectImage,
                        modules: *of.ObjectImage, module_count: u32,
-                       merged: *MergedSection, placements: *Placement, sec_base: *u32) R.Result[bool, str] {
+                       merged: *MergedSection, merged_count: u32, placements: *Placement, sec_base: *u32,
+                       merged_to_out: *u32) R.Result[bool, str] {
     val alloc: *A.Allocator = s.alloc;
 
-    # map each used kind to its output-section index so symbols/relocations can
-    # be rebased; -1 (0xFFFFFFFF) marks a kind with no content.
-    var kind_to_out: [6]u32;
+    # map each used merged slot to its output-section index so symbols/relocations
+    # can be rebased; -1 (0xFFFFFFFF) marks a slot with no content.
     var k: u32 = 0;
-    for (k < MERGED_KIND_COUNT) { kind_to_out[k] = 0xFFFFFFFF; k = k + 1; }
+    for (k < merged_count) { merged_to_out[k] = 0xFFFFFFFF; k = k + 1; }
 
     k = 0;
-    for (k < MERGED_KIND_COUNT) {
+    for (k < merged_count) {
         if (!merged[k].used || merged[k].len == 0) { k = k + 1; cnt; }
 
         var bytes: *u8 = nil;
@@ -1234,8 +1432,11 @@ fun build_merged_image(s: *session.Session, out_img: *of.ObjectImage,
             bytes = R.unwrap_ok[*u8, str](zr);
         }
 
+        # a kind slot names itself by kind; a name-keyed debug slot carries its own
+        # interned section name.
         var sec: of.Section;
-        sec.name  = merged_section_name(s, merged[k].kind);
+        if (merged[k].name == intern.STR_NIL) { sec.name = merged_section_name(s, merged[k].kind); }
+        or                                    { sec.name = merged[k].name; }
         sec.kind  = merged[k].kind;
         sec.bytes = bytes;
         sec.len   = merged[k].len;
@@ -1246,7 +1447,7 @@ fun build_merged_image(s: *session.Session, out_img: *of.ObjectImage,
             if (bytes != nil) { A.deallocate[u8](alloc, bytes, merged[k].len::usize); }
             ret R.err[bool, str](R.unwrap_err[u32, str](add_r));
         }
-        kind_to_out[k] = R.unwrap_ok[u32, str](add_r);
+        merged_to_out[k] = R.unwrap_ok[u32, str](add_r);
         k = k + 1;
     }
 
@@ -1261,7 +1462,7 @@ fun build_merged_image(s: *session.Session, out_img: *of.ObjectImage,
 
             val flat: u32 = sec_base[m] + sc;
             val ki: u32 = placements[flat].merged_index;
-            val out_ix: u32 = kind_to_out[ki];
+            val out_ix: u32 = merged_to_out[ki];
             if (out_ix == 0xFFFFFFFF) { sc = sc + 1; cnt; }
 
             val dst: *u8 = out_img.sections[out_ix].bytes;
@@ -1288,7 +1489,7 @@ fun build_merged_image(s: *session.Session, out_img: *of.ObjectImage,
 
             val flat: u32 = sec_base[m] + isym.section;
             val ki: u32 = placements[flat].merged_index;
-            val out_ix: u32 = kind_to_out[ki];
+            val out_ix: u32 = merged_to_out[ki];
             if (out_ix == 0xFFFFFFFF) { sy = sy + 1; cnt; }
 
             var osym: of.Symbol;
@@ -1327,15 +1528,16 @@ fun build_merged_image(s: *session.Session, out_img: *of.ObjectImage,
 # out_img:      the merged image whose section bytes are patched in place
 # modules:      the input image array (source of the relocations)
 # module_count: number of input images
-# placements:   per-input-section placement (merged index + offset + vaddr)
-# sec_base:     per-module prefix offset into `placements`
-# sym_locs:     the global symbol table, for GLOBAL/extern target resolution
-# dyn:          dynamic-link state; out - collects import call-site fixups
-# arch:         active instruction-set vtable, owning the relocation packer
-# ret:          ok(true) on success, or an error string
+# placements:    per-input-section placement (merged index + offset + vaddr)
+# sec_base:      per-module prefix offset into `placements`
+# merged_to_out: per-merged-slot output-section index (from build_merged_image)
+# sym_locs:      the global symbol table, for GLOBAL/extern target resolution
+# dyn:           dynamic-link state; out - collects import call-site fixups
+# arch:          active instruction-set vtable, owning the relocation packer
+# ret:           ok(true) on success, or an error string
 fun patch_relocations(s: *session.Session, out_img: *of.ObjectImage,
                      modules: *of.ObjectImage, module_count: u32,
-                     placements: *Placement, sec_base: *u32,
+                     placements: *Placement, sec_base: *u32, merged_to_out: *u32,
                      sym_locs: *map.Map[intern.StrId, SymbolLoc],
                      dyn: *DynState, arch: *isa.IsaVTable) R.Result[bool, str] {
     val alloc: *A.Allocator = s.alloc;
@@ -1356,7 +1558,7 @@ fun patch_relocations(s: *session.Session, out_img: *of.ObjectImage,
         }
 
         val pr: R.Result[bool, str] = patch_module_relocations(s, out_img, modules, m,
-            placements, sec_base, sym_locs, dyn, ?local_map, arch);
+            placements, sec_base, merged_to_out, sym_locs, dyn, ?local_map, arch);
         map.dnit[intern.StrId, u64](?local_map);
         if (R.is_err[bool, str](pr)) { ret R.err[bool, str](R.unwrap_err[bool, str](pr)); }
 
@@ -1405,16 +1607,17 @@ fun build_local_index(modules: *of.ObjectImage, m: u32, placements: *Placement, 
 # out_img:      the merged image whose section bytes are patched in place
 # modules:      the input image array
 # m:            index of the module whose relocations are applied
-# placements:   per-input-section placement (merged index + offset + vaddr)
-# sec_base:     per-module prefix offset into `placements`
-# sym_locs:     the global symbol table, for GLOBAL/extern target resolution
-# dyn:          dynamic-link state; out - collects import call-site fixups
-# local_map:    module `m`'s LOCAL-name -> virtual-address index
-# arch:         active instruction-set vtable, owning the relocation packer
-# ret:          ok(true) on success, or an error string
+# placements:    per-input-section placement (merged index + offset + vaddr)
+# sec_base:      per-module prefix offset into `placements`
+# merged_to_out: per-merged-slot output-section index (from build_merged_image)
+# sym_locs:      the global symbol table, for GLOBAL/extern target resolution
+# dyn:           dynamic-link state; out - collects import call-site fixups
+# local_map:     module `m`'s LOCAL-name -> virtual-address index
+# arch:          active instruction-set vtable, owning the relocation packer
+# ret:           ok(true) on success, or an error string
 fun patch_module_relocations(s: *session.Session, out_img: *of.ObjectImage,
                              modules: *of.ObjectImage, m: u32,
-                             placements: *Placement, sec_base: *u32,
+                             placements: *Placement, sec_base: *u32, merged_to_out: *u32,
                              sym_locs: *map.Map[intern.StrId, SymbolLoc], dyn: *DynState,
                              local_map: *map.Map[intern.StrId, u64], arch: *isa.IsaVTable) R.Result[bool, str] {
     var ri: u32 = 0;
@@ -1432,11 +1635,12 @@ fun patch_module_relocations(s: *session.Session, out_img: *of.ObjectImage,
         }
 
         # the patch site's location in the merged image. the placement's
-        # merged_index is a section *kind*; map it to the output-section index.
+        # merged_index selects a merged slot (kind or debug-name); map it to the
+        # output-section index the merge assigned.
         val flat: u32 = sec_base[m] + r.section;
         val pl: *Placement = ?placements[flat];
         val patch_va: u64 = pl.vaddr + r.offset::u64;
-        val out_ix: u32 = out_section_for_merged(out_img, pl.merged_index);
+        val out_ix: u32 = merged_to_out[pl.merged_index];
         # a relocation in a section with no merged output, or one whose patch site
         # lands in a (byteless) BSS section, cannot be applied - that is a contract
         # violation from a buggy parser/codegen, not a relocation to quietly skip.
@@ -1488,10 +1692,13 @@ fun patch_module_relocations(s: *session.Session, out_img: *of.ObjectImage,
             ret R.err[bool, str](R.unwrap_err[bool, str](pr));
         }
 
-        # PIE: an in-image absolute 64-bit pointer (RK_ABS64) holds a link-time
-        # (bias-zero) address; record its location so the writer emits a load-time
-        # base relocation the loader slides. PC-relative kinds need no fixup.
-        if (dyn.info.pie && r.kind == of.RK_ABS64) {
+        # PIE: an in-image absolute 64-bit pointer (RK_ABS64) in a loadable section
+        # holds a link-time (bias-zero) address; record its location so the writer
+        # emits a load-time base relocation the loader slides. a non-allocated debug
+        # section is never mapped, so its absolute pointers are read at their
+        # link-time value and take no base relocation. PC-relative kinds need none.
+        if (dyn.info.pie && r.kind == of.RK_ABS64
+            && is_loadable_kind(out_img.sections[out_ix].kind)) {
             val brr: R.Result[bool, str] = dynstate_add_base_reloc(s, dyn,
                 segment_index_for(out_img, out_ix), patch_off, sym_va + r.addend::u64);
             if (R.is_err[bool, str](brr)) { ret R.err[bool, str](R.unwrap_err[bool, str](brr)); }
@@ -2274,14 +2481,15 @@ pub fun register_reloc_hooks(reg: *isa.IsaRegistry) R.Result[bool, str] {
 # output image rebased to the merged section indices, leaving the bytes
 # unpatched so a later link can resolve them.
 # ---
-# out_img:      out - the merged image the relocations are carried onto
-# modules:      the input image array (source of the relocations)
-# module_count: number of input images
-# placements:   per-input-section placement (merged index + offset)
-# sec_base:     per-module prefix offset into `placements`
-# ret:          ok(true) on success, or an error string
+# out_img:       out - the merged image the relocations are carried onto
+# modules:       the input image array (source of the relocations)
+# module_count:  number of input images
+# placements:    per-input-section placement (merged index + offset)
+# sec_base:      per-module prefix offset into `placements`
+# merged_to_out: per-merged-slot output-section index (from build_merged_image)
+# ret:           ok(true) on success, or an error string
 fun carry_relocations(out_img: *of.ObjectImage, modules: *of.ObjectImage, module_count: u32,
-                     placements: *Placement, sec_base: *u32) R.Result[bool, str] {
+                     placements: *Placement, sec_base: *u32, merged_to_out: *u32) R.Result[bool, str] {
     var m: u32 = 0;
     for (m < module_count) {
         var ri: u32 = 0;
@@ -2299,9 +2507,8 @@ fun carry_relocations(out_img: *of.ObjectImage, modules: *of.ObjectImage, module
             val flat: u32 = sec_base[m] + r.section;
             val pl: *Placement = ?placements[flat];
 
-            # find the output-section index for this kind by matching merged
-            # index against the already-added output sections.
-            val out_ix: u32 = out_section_for_merged(out_img, pl.merged_index);
+            # map the placement's merged slot to its output-section index.
+            val out_ix: u32 = merged_to_out[pl.merged_index];
             if (out_ix == 0xFFFFFFFF) {
                 ret R.err[bool, str]("linker: relocation targets a section with no merged output");
             }
@@ -2321,22 +2528,6 @@ fun carry_relocations(out_img: *of.ObjectImage, modules: *of.ObjectImage, module
         m = m + 1;
     }
     ret R.ok[bool, str](true);
-}
-
-# find the output image's section index whose kind
-# matches the merged kind index; the merge produced at most one section per
-# kind, so a kind-equality match is unambiguous.
-# ---
-# out_img:      the merged image to search
-# merged_index: the merged kind index to match against a section kind
-# ret:          the output-section index, or 0xFFFFFFFF when no kind matches
-fun out_section_for_merged(out_img: *of.ObjectImage, merged_index: u32) u32 {
-    var i: u32 = 0;
-    for (i < out_img.section_count) {
-        if (out_img.sections[i].kind::u32 == merged_index) { ret i; }
-        i = i + 1;
-    }
-    ret 0xFFFFFFFF;
 }
 
 # intern a name, returning STR_NIL on allocation failure so a
@@ -2675,19 +2866,38 @@ fun free_placements(alloc: *A.Allocator, placements: *Placement, sec_total: u32)
     }
 }
 
-# release the per-link scratch allocations (placements + per-module
-# base array).
+# release the per-link scratch allocations: the placements, the
+# per-module base array, the merged accumulators, the discovered debug names, and
+# the merged-slot -> output-section map. every argument is nil-safe so cleanup on
+# an early failure (before some arrays are allocated) is uniform.
 # ---
-# alloc:        allocator the arrays were allocated from
-# placements:   the placement array to release (may be nil)
-# sec_total:    length of the placement array
-# sec_base:     the per-module base array to release (may be nil)
-# module_count: length of the per-module base array
+# alloc:         allocator the arrays were allocated from
+# placements:    the placement array to release (may be nil)
+# sec_total:     length of the placement array
+# sec_base:      the per-module base array to release (may be nil)
+# module_count:  length of the per-module base array
+# merged:        the merged accumulator array to release (may be nil)
+# merged_count:  length of the merged accumulator array and the merged->output map
+# debug_names:   the discovered debug-name array to release (may be nil)
+# debug_count:   length of the debug-name array
+# merged_to_out: the merged-slot -> output-section map to release (may be nil)
 fun free_scratch(alloc: *A.Allocator, placements: *Placement, sec_total: u32,
-                sec_base: *u32, module_count: u32) {
+                sec_base: *u32, module_count: u32,
+                merged: *MergedSection, merged_count: u32,
+                debug_names: *intern.StrId, debug_count: u32,
+                merged_to_out: *u32) {
     free_placements(alloc, placements, sec_total);
     if (sec_base != nil && module_count > 0) {
         A.deallocate[u32](alloc, sec_base, module_count::usize);
+    }
+    if (merged != nil && merged_count > 0) {
+        A.deallocate[MergedSection](alloc, merged, merged_count::usize);
+    }
+    if (debug_names != nil && debug_count > 0) {
+        A.deallocate[intern.StrId](alloc, debug_names, debug_count::usize);
+    }
+    if (merged_to_out != nil && merged_count > 0) {
+        A.deallocate[u32](alloc, merged_to_out, merged_count::usize);
     }
 }
 

--- a/src/lang/be/linker.mach
+++ b/src/lang/be/linker.mach
@@ -689,7 +689,7 @@ fun emit_executable(s: *session.Session, tgt: *target.Target, out_img: *of.Objec
     val funcs: *of.ExecFunction = R.unwrap_ok[*of.ExecFunction, str](fr);
 
     val emit_r: R.Result[bool, str] =
-        tgt.of.emit_exec(alloc, ?s.interner, tgt.arch, segs, seg_count, os_page_size(tgt), entry, funcs, func_count, out_path, name);
+        tgt.of.emit_exec(alloc, ?s.interner, tgt.arch, segs, seg_count, os_page_size(tgt), entry, funcs, func_count, nil::*of.Section, 0, out_path, name);
 
     if (funcs != nil && func_count > 0) {
         A.deallocate[of.ExecFunction](alloc, funcs, func_count::usize);
@@ -750,7 +750,7 @@ fun emit_dynamic_executable(s: *session.Session, tgt: *target.Target, out_img: *
 
     val emit_r: R.Result[bool, str] =
         tgt.of.emit_dyn_exec(alloc, ?s.interner, tgt.arch, segs, seg_count, os_page_size(tgt), entry,
-                             funcs, func_count, ?dyn.info, dyn.fixups, dyn.fixup_count, out_path, name);
+                             funcs, func_count, ?dyn.info, dyn.fixups, dyn.fixup_count, nil::*of.Section, 0, out_path, name);
 
     if (funcs != nil && func_count > 0) {
         A.deallocate[of.ExecFunction](alloc, funcs, func_count::usize);

--- a/src/lang/target.mach
+++ b/src/lang/target.mach
@@ -649,7 +649,7 @@ test "mach.lang.target.select_of:freestanding_raw_emits_flat_image" {
 
     # enter at the image base; the raw writer rejects any other entry.
     val em: R.Result[bool, str] =
-        t.of.emit_exec(?alloc, ?itn, t.arch, ?segs[0], 1, t.os.page_size, t.os.base_addr, nil::*of.ExecFunction, 0, tpath::*u8, "selraw"::*u8);
+        t.of.emit_exec(?alloc, ?itn, t.arch, ?segs[0], 1, t.os.page_size, t.os.base_addr, nil::*of.ExecFunction, 0, nil::*of.Section, 0, tpath::*u8, "selraw"::*u8);
     if (R.is_err[bool, str](em)) { filesystem.temp_close_and_remove(?tf); ret 1; }
 
     val rr: R.Result[filesystem.Buffer, str] = filesystem.read_all_sized(?alloc, tpath);

--- a/src/lang/target/of.mach
+++ b/src/lang/target/of.mach
@@ -431,13 +431,19 @@ pub def ParserFn: fun(*A.Allocator, *intern.Interner, *u8, usize, *ObjectImage) 
 # arg 6: program entry-point virtual address
 # arg 7: per-function descriptors (may be nil when count is 0)
 # arg 8: number of per-function descriptors
-# arg 9: null-terminated output file path
-# arg 10: null-terminated product name (the artifact's stable identity, independent
+# arg 9: non-allocated debug sections (`SK_DEBUG`) the linker merged by name and
+#        relocated to final addresses, or nil when count is 0. the writer frames
+#        each as a non-loaded (no PT_LOAD / zero-vmsize) section trailing the load
+#        segments; their names resolve through arg 1. with a zero count the writer
+#        emits exactly as before.
+# arg 10: number of debug sections
+# arg 11: null-terminated output file path
+# arg 12: null-terminated product name (the artifact's stable identity, independent
 #        of the `-o` output path); used as the Mach-O code-signing identifier and
 #        ignored by formats that do not sign
 # ret:   true on success, or an error string
 pub def ExecFn: fun(*A.Allocator, *intern.Interner, *isa.IsaVTable, *LoadSegment, u32, u64, u64,
-                    *ExecFunction, u32, *u8, *u8) R.Result[bool, str];
+                    *ExecFunction, u32, *Section, u32, *u8, *u8) R.Result[bool, str];
 
 # a dynamically-linked-executable writer: serializes the linker's laid-out load
 # segments into a dynamically-linked executable, framing the format's
@@ -468,13 +474,18 @@ pub def ExecFn: fun(*A.Allocator, *intern.Interner, *isa.IsaVTable, *LoadSegment
 # arg 9:  the dynamic-link plan (dependencies, imports, interpreter)
 # arg 10: the import call-site fixups to redirect to call-thunks
 # arg 11: number of fixups
-# arg 12: null-terminated output file path
-# arg 13: null-terminated product name (the artifact's stable identity, independent
+# arg 12: non-allocated debug sections (`SK_DEBUG`) the linker merged by name and
+#         relocated to final addresses, or nil when count is 0. framed like
+#         `ExecFn`'s: non-loaded sections trailing the load segments, names resolved
+#         through arg 1. with a zero count the writer emits exactly as before.
+# arg 13: number of debug sections
+# arg 14: null-terminated output file path
+# arg 15: null-terminated product name (the artifact's stable identity, independent
 #         of the `-o` output path); used as the Mach-O code-signing identifier and
 #         ignored by formats that do not sign
 # ret:    true on success, or an error string
 pub def DynExecFn: fun(*A.Allocator, *intern.Interner, *isa.IsaVTable, *LoadSegment, u32, u64, u64,
-                       *ExecFunction, u32, *DynamicInfo, *PltFixup, u32, *u8, *u8) R.Result[bool, str];
+                       *ExecFunction, u32, *DynamicInfo, *PltFixup, u32, *Section, u32, *u8, *u8) R.Result[bool, str];
 
 # maximum number of instruction sets an OfVTable's ISA-coverage list holds
 val OF_ISA_MAX: u32 = 8;

--- a/src/lang/target/of/coff.mach
+++ b/src/lang/target/of/coff.mach
@@ -2346,6 +2346,10 @@ fun write_pe(alloc: *A.Allocator, itn: *intern.Interner, isa_vt: *isa.IsaVTable,
         ret R.err[bool, str]("coff: PE emission is only implemented for x86-64");
     }
     if (seg_count == 0) { ret R.err[bool, str]("coff: no loadable segments"); }
+    # the of.ExecFn/DynExecFn debug-section channel (debug/debug_count) is accepted
+    # for seam conformance but not yet framed into the PE image; a `.debug_*` name
+    # exceeds the 8-byte inline section-name field and needs a COFF string table.
+    # tracked by #1887, gated on the Windows verification runner (#1698).
 
     var seg_secs: *PeSection = nil;
     val ssr: R.Result[*PeSection, str] = A.zallocate[PeSection](alloc, seg_count::usize);

--- a/src/lang/target/of/coff.mach
+++ b/src/lang/target/of/coff.mach
@@ -2289,10 +2289,10 @@ fun compute_pe_layout(itn: *intern.Interner, lay: *PeLayout, segs: *of.LoadSegme
 # ret:        ok(true) on success, or an error string
 fun coff_emit_exec(alloc: *A.Allocator, itn: *intern.Interner, isa_vt: *isa.IsaVTable, segs: *of.LoadSegment,
                    seg_count: u32, page_size: u64, entry: u64, funcs: *of.ExecFunction,
-                   func_count: u32, path: *u8, name: *u8) R.Result[bool, str] {
+                   func_count: u32, debug: *of.Section, debug_count: u32, path: *u8, name: *u8) R.Result[bool, str] {
     # a static PE carries no dynamic plan, so it resolves no interned names; the
     # interner is forwarded only so a write failure can be located on its path.
-    ret write_pe(alloc, itn, isa_vt, segs, seg_count, entry, funcs, func_count, nil, nil, 0, path);
+    ret write_pe(alloc, itn, isa_vt, segs, seg_count, entry, funcs, func_count, nil, nil, 0, debug, debug_count, path);
 }
 
 # serialize laid-out load segments into a dynamically-linked
@@ -2316,14 +2316,17 @@ fun coff_emit_exec(alloc: *A.Allocator, itn: *intern.Interner, isa_vt: *isa.IsaV
 # dyn:         the dynamic-link plan (dependencies, imports)
 # fixups:      the import call-site fixups to redirect to import stubs
 # fixup_count: number of fixups
+# debug:       non-allocated debug sections to frame as non-loaded PE sections
+# debug_count: number of debug sections
 # path:        null-terminated output file path
 # name:        product name; accepted for of.DynExecFn conformance (PE does not sign)
 # ret:         ok(true) on success, or an error string
 fun coff_emit_dyn_exec(alloc: *A.Allocator, itn: *intern.Interner, isa_vt: *isa.IsaVTable, segs: *of.LoadSegment,
                        seg_count: u32, page_size: u64, entry: u64, funcs: *of.ExecFunction,
                        func_count: u32, dyn: *of.DynamicInfo,
-                       fixups: *of.PltFixup, fixup_count: u32, path: *u8, name: *u8) R.Result[bool, str] {
-    ret write_pe(alloc, itn, isa_vt, segs, seg_count, entry, funcs, func_count, dyn, fixups, fixup_count, path);
+                       fixups: *of.PltFixup, fixup_count: u32, debug: *of.Section, debug_count: u32,
+                       path: *u8, name: *u8) R.Result[bool, str] {
+    ret write_pe(alloc, itn, isa_vt, segs, seg_count, entry, funcs, func_count, dyn, fixups, fixup_count, debug, debug_count, path);
 }
 
 # the shared PE32+ executable writer behind `coff_emit_exec` (static)
@@ -2336,7 +2339,7 @@ fun coff_emit_dyn_exec(alloc: *A.Allocator, itn: *intern.Interner, isa_vt: *isa.
 fun write_pe(alloc: *A.Allocator, itn: *intern.Interner, isa_vt: *isa.IsaVTable, segs: *of.LoadSegment,
              seg_count: u32, entry: u64, funcs: *of.ExecFunction, func_count: u32,
              dyn: *of.DynamicInfo,
-             fixups: *of.PltFixup, fixup_count: u32, path: *u8) R.Result[bool, str] {
+             fixups: *of.PltFixup, fixup_count: u32, debug: *of.Section, debug_count: u32, path: *u8) R.Result[bool, str] {
     if (isa_vt == nil) { ret R.err[bool, str]("coff: nil exec isa"); }
     if (path == nil)   { ret R.err[bool, str]("coff: nil exec path"); }
     if (isa_vt.id != isa.ARCH_X86_64) {
@@ -3502,7 +3505,7 @@ test "mach.lang.target.of.coff.coff_emit_exec:pe32plus_header" {
     if (R.is_err[filesystem.TempFile, str](tf_r)) { ret 1; }
     var tf: filesystem.TempFile = R.unwrap_ok[filesystem.TempFile, str](tf_r);
 
-    val em: R.Result[bool, str] = coff_emit_exec(?alloc, ?i, ?isa_vt, ?segs[0], 2, 4096, entry, nil, 0, filesystem.temp_path(?tf)::*u8, "coffexe"::*u8);
+    val em: R.Result[bool, str] = coff_emit_exec(?alloc, ?i, ?isa_vt, ?segs[0], 2, 4096, entry, nil, 0, nil::*of.Section, 0, filesystem.temp_path(?tf)::*u8, "coffexe"::*u8);
     if (R.is_err[bool, str](em)) { filesystem.temp_close_and_remove(?tf); ret 1; }
 
     val rb: R.Result[filesystem.Buffer, str] = filesystem.read_all_sized(?alloc, filesystem.temp_path(?tf));
@@ -3746,7 +3749,7 @@ test "mach.lang.target.of.coff.coff_emit_exec:unwind_xdata_pdata" {
     if (R.is_err[filesystem.TempFile, str](tf_r)) { ret 1; }
     var tf: filesystem.TempFile = R.unwrap_ok[filesystem.TempFile, str](tf_r);
 
-    val em: R.Result[bool, str] = coff_emit_exec(?alloc, ?i, ?isa_vt, ?segs[0], 1, 4096, entry, ?funcs[0], 1, filesystem.temp_path(?tf)::*u8, "coffunwind"::*u8);
+    val em: R.Result[bool, str] = coff_emit_exec(?alloc, ?i, ?isa_vt, ?segs[0], 1, 4096, entry, ?funcs[0], 1, nil::*of.Section, 0, filesystem.temp_path(?tf)::*u8, "coffunwind"::*u8);
     if (R.is_err[bool, str](em)) { filesystem.temp_close_and_remove(?tf); ret 1; }
 
     val rb: R.Result[filesystem.Buffer, str] = filesystem.read_all_sized(?alloc, filesystem.temp_path(?tf));

--- a/src/lang/target/of/elf.mach
+++ b/src/lang/target/of/elf.mach
@@ -1537,6 +1537,172 @@ fun header_fits_reserved_page(phdr_count: u32, page_size: u64) bool {
     ret ELF_HEADER_SIZE + phdr_count::usize * PHDR_SIZE <= page_size::usize;
 }
 
+# the file layout of a minimal debug-only section-header table appended to a runtime
+# (ET_DYN / dynamic) image so its non-allocated debug sections are named and located
+# for a debugger. the PIE and dynamic writers otherwise emit no section headers; this
+# table is null + one non-alloc PROGBITS per debug section + `.shstrtab`, all trailing
+# the image outside every PT_LOAD. `present` is false (and the table absent) when there
+# are no debug sections, leaving the image byte-identical.
+# ---
+# present:         true when the image carries a debug section-header table
+# shdr_off:        file offset of the section-header table (the ELF header's e_shoff)
+# sht_count:       number of section headers (e_shnum): debug_count + null + .shstrtab
+# shstrndx:        index of the .shstrtab section (e_shstrndx)
+# debug_offs:      file offset of each debug section's bytes (length debug_count)
+# debug_name_rels: each debug name's offset within .shstrtab (length debug_count)
+# shstr_off:       file offset of the .shstrtab bytes
+# shstr_sz:        byte length of .shstrtab
+# shstr_name_rel:  the ".shstrtab" name's offset within .shstrtab
+# added:           total bytes the table adds after `base`
+rec DebugSht {
+    present:         bool;
+    shdr_off:        usize;
+    sht_count:       u32;
+    shstrndx:        u32;
+    debug_offs:      *usize;
+    debug_name_rels: *usize;
+    shstr_off:       usize;
+    shstr_sz:        usize;
+    shstr_name_rel:  usize;
+    added:           usize;
+}
+
+# plan the debug section-header table starting at file offset `base` (past all of the
+# image's loadable content). allocates the per-section offset arrays on success; the
+# caller frees them through `debug_sht_free`. with no debug sections it returns an
+# empty (`present == false`) plan and allocates nothing.
+# ---
+# alloc:       allocator backing the plan's offset arrays
+# itn:         interner resolving the debug section names (non-nil when count > 0)
+# debug:       the non-allocated debug sections
+# debug_count: number of debug sections
+# base:        file offset where the debug table begins
+# ret:         the layout plan, or an allocation error
+fun debug_sht_plan(alloc: *A.Allocator, itn: *intern.Interner, debug: *of.Section, debug_count: u32,
+                   base: usize) R.Result[DebugSht, str] {
+    var p: DebugSht;
+    p.present = false;
+    p.shdr_off = 0; p.sht_count = 0; p.shstrndx = 0;
+    p.debug_offs = nil; p.debug_name_rels = nil;
+    p.shstr_off = 0; p.shstr_sz = 0; p.shstr_name_rel = 0; p.added = 0;
+    if (debug_count == 0) { ret R.ok[DebugSht, str](p); }
+
+    val oro: R.Result[*usize, str] = A.zallocate[usize](alloc, debug_count::usize);
+    if (R.is_err[*usize, str](oro)) { ret R.err[DebugSht, str](R.unwrap_err[*usize, str](oro)); }
+    p.debug_offs = R.unwrap_ok[*usize, str](oro);
+    val nro: R.Result[*usize, str] = A.zallocate[usize](alloc, debug_count::usize);
+    if (R.is_err[*usize, str](nro)) {
+        A.deallocate[usize](alloc, p.debug_offs, debug_count::usize);
+        ret R.err[DebugSht, str](R.unwrap_err[*usize, str](nro));
+    }
+    p.debug_name_rels = R.unwrap_ok[*usize, str](nro);
+
+    var off: usize = base;
+    var di: u32 = 0;
+    for (di < debug_count) {
+        var da: u32 = debug[di].align;
+        if (da == 0) { da = 1; }
+        off = bin.align_up(off, da::usize);
+        p.debug_offs[di] = off;
+        off = off + debug[di].len::usize;
+        di = di + 1;
+    }
+
+    p.shstr_off = off;
+    var sz: usize = 1;
+    di = 0;
+    for (di < debug_count) {
+        p.debug_name_rels[di] = sz;
+        sz = sz + str_len(resolve(itn, debug[di].name)) + 1;
+        di = di + 1;
+    }
+    p.shstr_name_rel = sz;
+    sz = sz + str_len(".shstrtab") + 1;
+    p.shstr_sz = sz;
+    off = off + sz;
+
+    p.shdr_off = bin.align_up(off, 8);
+    p.sht_count = debug_count + 2;
+    p.shstrndx = debug_count + 1;
+    p.present = true;
+    p.added = (p.shdr_off + SHDR_SIZE * p.sht_count::usize) - base;
+    ret R.ok[DebugSht, str](p);
+}
+
+# write the planned debug section-header table into `buf`: the debug section bytes,
+# the `.shstrtab`, and the section headers (null, one non-alloc PROGBITS per debug
+# section, then `.shstrtab`). a no-op when the plan is absent.
+# ---
+# buf:         the output buffer (sized to include the plan)
+# itn:         interner resolving the debug section names
+# debug:       the non-allocated debug sections
+# debug_count: number of debug sections
+# p:           the layout plan from debug_sht_plan
+fun debug_sht_write(buf: *u8, itn: *intern.Interner, debug: *of.Section, debug_count: u32, p: *DebugSht) {
+    if (!p.present) { ret; }
+
+    var di: u32 = 0;
+    for (di < debug_count) {
+        if (debug[di].bytes != nil && debug[di].len > 0) {
+            memory.raw_copy((buf::usize + p.debug_offs[di])::ptr, debug[di].bytes::ptr, debug[di].len::usize);
+        }
+        di = di + 1;
+    }
+
+    buf[p.shstr_off] = 0;
+    var np: usize = 1;
+    di = 0;
+    for (di < debug_count) {
+        np = np + bin.write_str(buf, p.shstr_off + np, resolve(itn, debug[di].name));
+        di = di + 1;
+    }
+    bin.write_str(buf, p.shstr_off + np, ".shstrtab");
+
+    # [0] reserved null (already zeroed), one non-alloc PROGBITS per debug section
+    # (no SHF_ALLOC, address 0, own file bytes), then .shstrtab.
+    var hp: usize = p.shdr_off + SHDR_SIZE;
+    di = 0;
+    for (di < debug_count) {
+        var da: u32 = debug[di].align;
+        if (da == 0) { da = 1; }
+        bin.write_u32_le(buf, hp, p.debug_name_rels[di]::u32);
+        bin.write_u32_le(buf, hp + 4, SHT_PROGBITS);
+        bin.write_u64_le(buf, hp + 8, 0);
+        bin.write_u64_le(buf, hp + 16, 0);
+        bin.write_u64_le(buf, hp + 24, p.debug_offs[di]::u64);
+        bin.write_u64_le(buf, hp + 32, debug[di].len::u64);
+        bin.write_u32_le(buf, hp + 40, 0);
+        bin.write_u32_le(buf, hp + 44, 0);
+        bin.write_u64_le(buf, hp + 48, da::u64);
+        bin.write_u64_le(buf, hp + 56, 0);
+        hp = hp + SHDR_SIZE;
+        di = di + 1;
+    }
+
+    bin.write_u32_le(buf, hp, p.shstr_name_rel::u32);
+    bin.write_u32_le(buf, hp + 4, SHT_STRTAB);
+    bin.write_u64_le(buf, hp + 8, 0);
+    bin.write_u64_le(buf, hp + 16, 0);
+    bin.write_u64_le(buf, hp + 24, p.shstr_off::u64);
+    bin.write_u64_le(buf, hp + 32, p.shstr_sz::u64);
+    bin.write_u32_le(buf, hp + 40, 0);
+    bin.write_u32_le(buf, hp + 44, 0);
+    bin.write_u64_le(buf, hp + 48, 1);
+    bin.write_u64_le(buf, hp + 56, 0);
+}
+
+# release the offset arrays a `debug_sht_plan` allocated.
+# ---
+# alloc:       allocator the arrays were allocated from
+# p:           the plan whose arrays are released
+# debug_count: number of debug sections (the arrays' length)
+fun debug_sht_free(alloc: *A.Allocator, p: *DebugSht, debug_count: u32) {
+    if (p.debug_offs != nil)      { A.deallocate[usize](alloc, p.debug_offs, debug_count::usize); }
+    if (p.debug_name_rels != nil) { A.deallocate[usize](alloc, p.debug_name_rels, debug_count::usize); }
+    p.debug_offs = nil;
+    p.debug_name_rels = nil;
+}
+
 # write a position-independent (PIE / ET_DYN) static executable for linux ASLR
 #
 # A static-PIE: an ET_DYN image the kernel loads at a randomized base, self-relocated
@@ -1573,12 +1739,14 @@ fun header_fits_reserved_page(phdr_count: u32, page_size: u64) bool {
 # seg_count: number of segments
 # page_size: the segment-alignment page (p_align, header reservation, offset congruence)
 # entry:     program entry-point virtual address (link-time)
-# dyn:       the dynamic-link plan carrying the base-relocation set
-# path:      null-terminated output file path
-# ret:       ok(true) on success, or an error string
+# dyn:         the dynamic-link plan carrying the base-relocation set
+# debug:       non-allocated debug sections to frame in a trailing section table
+# debug_count: number of debug sections
+# path:        null-terminated output file path
+# ret:         ok(true) on success, or an error string
 fun emit_pie_exec(alloc: *A.Allocator, itn: *intern.Interner, tgt_isa: *isa.IsaVTable,
                   segs: *of.LoadSegment, seg_count: u32, page_size: u64, entry: u64,
-                  dyn: *of.DynamicInfo, path: *u8) R.Result[bool, str] {
+                  dyn: *of.DynamicInfo, debug: *of.Section, debug_count: u32, path: *u8) R.Result[bool, str] {
     val nrel: u32 = dyn.base_reloc_count;
 
     # the highest virtual address the linker's segments reach; the synthesized
@@ -1640,17 +1808,31 @@ fun emit_pie_exec(alloc: *A.Allocator, itn: *intern.Interner, tgt_isa: *isa.IsaV
     if (nrel > 0) { dyn_entries = dyn_entries + 4; }
     val dyn_size: usize = dyn_entries::usize * DYN_SIZE;
 
-    val total_size: usize = dyn_off + dyn_size;
-    val ro_size: usize = total_size - ro_off;
+    val struct_total: usize = dyn_off + dyn_size;
+    val ro_size: usize = struct_total - ro_off;
+
+    # a debugger-facing section-header table for the non-allocated debug sections
+    # trails the whole image (past the RO structures), outside every PT_LOAD; the
+    # runtime image is unchanged and the file stays section-header-less when absent.
+    var dsht: DebugSht;
+    val dp: R.Result[DebugSht, str] = debug_sht_plan(alloc, itn, debug, debug_count, struct_total);
+    if (R.is_err[DebugSht, str](dp)) {
+        if (seg_offsets != nil) { A.deallocate[usize](alloc, seg_offsets, seg_count::usize); }
+        ret R.err[bool, str](R.unwrap_err[DebugSht, str](dp));
+    }
+    dsht = R.unwrap_ok[DebugSht, str](dp);
+    val total_size: usize = struct_total + dsht.added;
 
     val res_buf: R.Result[*u8, str] = A.zallocate[u8](alloc, total_size);
     if (R.is_err[*u8, str](res_buf)) {
+        debug_sht_free(alloc, ?dsht, debug_count);
         if (seg_offsets != nil) { A.deallocate[usize](alloc, seg_offsets, seg_count::usize); }
         ret R.err[bool, str]("elf: pie buffer alloc failed");
     }
     var buf: *u8 = R.unwrap_ok[*u8, str](res_buf);
 
-    # ELF header: ET_DYN, e_shoff = 0 (a runtime image, not a tooling object).
+    # ELF header: ET_DYN. e_shoff/e_shnum/e_shstrndx name the trailing debug table
+    # when present, else 0 (a bare runtime image, not a tooling object).
     buf[0] = 0x7F; buf[1] = 0x45; buf[2] = 0x4C; buf[3] = 0x46;
     buf[4] = elf_class_for(tgt_isa); buf[5] = ELFDATA2LSB; buf[6] = EV_CURRENT; buf[7] = ELFOSABI_NONE;
     bin.write_u16_le(buf, 16, ET_DYN);
@@ -1658,14 +1840,19 @@ fun emit_pie_exec(alloc: *A.Allocator, itn: *intern.Interner, tgt_isa: *isa.IsaV
     bin.write_u32_le(buf, 20, 1);
     bin.write_u64_le(buf, 24, entry);
     bin.write_u64_le(buf, 32, phdr_offset::u64);
-    bin.write_u64_le(buf, 40, 0);
+    if (dsht.present) { bin.write_u64_le(buf, 40, dsht.shdr_off::u64); } or { bin.write_u64_le(buf, 40, 0); }
     bin.write_u32_le(buf, 48, 0);
     bin.write_u16_le(buf, 52, ELF_HEADER_SIZE::u16);
     bin.write_u16_le(buf, 54, PHDR_SIZE::u16);
     bin.write_u16_le(buf, 56, phdr_count::u16);
     bin.write_u16_le(buf, 58, SHDR_SIZE::u16);
-    bin.write_u16_le(buf, 60, 0);
-    bin.write_u16_le(buf, 62, 0);
+    if (dsht.present) {
+        bin.write_u16_le(buf, 60, dsht.sht_count::u16);
+        bin.write_u16_le(buf, 62, dsht.shstrndx::u16);
+    } or {
+        bin.write_u16_le(buf, 60, 0);
+        bin.write_u16_le(buf, 62, 0);
+    }
 
     # copy the linker's segment bytes into their file offsets.
     li = 0;
@@ -1704,6 +1891,9 @@ fun emit_pie_exec(alloc: *A.Allocator, itn: *intern.Interner, tgt_isa: *isa.IsaV
 
     write_pie_phdrs(buf, phdr_offset, phdr_count, segs, seg_offsets, seg_count,
                     ro_off, ro_va, ro_size, dyn_off, dyn_va, dyn_size, dyn, page_size);
+
+    debug_sht_write(buf, itn, debug, debug_count, ?dsht);
+    debug_sht_free(alloc, ?dsht, debug_count);
 
     if (seg_offsets != nil) { A.deallocate[usize](alloc, seg_offsets, seg_count::usize); }
 
@@ -2062,7 +2252,7 @@ fun emit_dyn_exec(alloc: *A.Allocator, itn: *intern.Interner, tgt_isa: *isa.IsaV
         if (dyn.import_count > 0 || dyn.lib_count > 0) {
             ret R.err[bool, str]("elf: PIE with dynamic imports is not supported (static-PIE only)");
         }
-        ret emit_pie_exec(alloc, itn, tgt_isa, segs, seg_count, page_size, entry, dyn, path);
+        ret emit_pie_exec(alloc, itn, tgt_isa, segs, seg_count, page_size, entry, dyn, debug, debug_count, path);
     }
 
     val nimp: u32 = func_import_count(dyn);
@@ -2116,10 +2306,23 @@ fun emit_dyn_exec(alloc: *A.Allocator, itn: *intern.Interner, tgt_isa: *isa.IsaV
     compute_dyn_layout(itn, ?lay, dyn, nimp, tgt_isa.id, bin.align_up(struct_file, page_size::usize),
                        bin.align_up_u64(hi_va, page_size), page_size);
 
-    val total_size: usize = lay.rw_off + lay.rw_size;
+    val struct_total: usize = lay.rw_off + lay.rw_size;
+
+    # a debugger-facing section-header table for the non-allocated debug sections
+    # trails the whole image, outside every PT_LOAD; absent (and the file stays
+    # section-header-less) when there are no debug sections.
+    var dsht: DebugSht;
+    val dp: R.Result[DebugSht, str] = debug_sht_plan(alloc, itn, debug, debug_count, struct_total);
+    if (R.is_err[DebugSht, str](dp)) {
+        if (seg_offsets != nil) { A.deallocate[usize](alloc, seg_offsets, seg_count::usize); }
+        ret R.err[bool, str](R.unwrap_err[DebugSht, str](dp));
+    }
+    dsht = R.unwrap_ok[DebugSht, str](dp);
+    val total_size: usize = struct_total + dsht.added;
 
     val res_buf: R.Result[*u8, str] = A.zallocate[u8](alloc, total_size);
     if (R.is_err[*u8, str](res_buf)) {
+        debug_sht_free(alloc, ?dsht, debug_count);
         if (seg_offsets != nil) { A.deallocate[usize](alloc, seg_offsets, seg_count::usize); }
         ret R.err[bool, str]("elf: dyn-exec buffer alloc failed");
     }
@@ -2138,14 +2341,19 @@ fun emit_dyn_exec(alloc: *A.Allocator, itn: *intern.Interner, tgt_isa: *isa.IsaV
     bin.write_u32_le(buf, 20, 1);
     bin.write_u64_le(buf, 24, entry);
     bin.write_u64_le(buf, 32, phdr_offset::u64);
-    bin.write_u64_le(buf, 40, 0);
+    if (dsht.present) { bin.write_u64_le(buf, 40, dsht.shdr_off::u64); } or { bin.write_u64_le(buf, 40, 0); }
     bin.write_u32_le(buf, 48, 0);
     bin.write_u16_le(buf, 52, ELF_HEADER_SIZE::u16);
     bin.write_u16_le(buf, 54, PHDR_SIZE::u16);
     bin.write_u16_le(buf, 56, phdr_count::u16);
     bin.write_u16_le(buf, 58, SHDR_SIZE::u16);
-    bin.write_u16_le(buf, 60, 0);
-    bin.write_u16_le(buf, 62, 0);
+    if (dsht.present) {
+        bin.write_u16_le(buf, 60, dsht.sht_count::u16);
+        bin.write_u16_le(buf, 62, dsht.shstrndx::u16);
+    } or {
+        bin.write_u16_le(buf, 60, 0);
+        bin.write_u16_le(buf, 62, 0);
+    }
 
     # copy the linker's segment bytes into their file offsets.
     li = 0;
@@ -2162,6 +2370,7 @@ fun emit_dyn_exec(alloc: *A.Allocator, itn: *intern.Interner, tgt_isa: *isa.IsaV
     if (dyn.import_count > 0) {
         val ri: R.Result[*usize, str] = A.zallocate[usize](alloc, dyn.import_count::usize);
         if (R.is_err[*usize, str](ri)) {
+            debug_sht_free(alloc, ?dsht, debug_count);
             if (seg_offsets != nil) { A.deallocate[usize](alloc, seg_offsets, seg_count::usize); }
             A.deallocate[u8](alloc, buf, total_size);
             ret R.err[bool, str]("elf: dyn-exec import-name table alloc failed");
@@ -2172,6 +2381,7 @@ fun emit_dyn_exec(alloc: *A.Allocator, itn: *intern.Interner, tgt_isa: *isa.IsaV
     if (dyn.lib_count > 0) {
         val rl: R.Result[*usize, str] = A.zallocate[usize](alloc, dyn.lib_count::usize);
         if (R.is_err[*usize, str](rl)) {
+            debug_sht_free(alloc, ?dsht, debug_count);
             if (imp_str != nil)     { A.deallocate[usize](alloc, imp_str, dyn.import_count::usize); }
             if (seg_offsets != nil) { A.deallocate[usize](alloc, seg_offsets, seg_count::usize); }
             A.deallocate[u8](alloc, buf, total_size);
@@ -2190,6 +2400,7 @@ fun emit_dyn_exec(alloc: *A.Allocator, itn: *intern.Interner, tgt_isa: *isa.IsaV
 
     # an out-of-range call-site fixup fails the link rather than corrupting bytes.
     if (R.is_err[bool, str](fx_r)) {
+        debug_sht_free(alloc, ?dsht, debug_count);
         if (seg_offsets != nil) { A.deallocate[usize](alloc, seg_offsets, seg_count::usize); }
         A.deallocate[u8](alloc, buf, total_size);
         ret R.err[bool, str](R.unwrap_err[bool, str](fx_r));
@@ -2198,6 +2409,9 @@ fun emit_dyn_exec(alloc: *A.Allocator, itn: *intern.Interner, tgt_isa: *isa.IsaV
     # program headers: leading header-cover PT_LOAD, PT_INTERP, the linker
     # segments, the RO/PLT/RW synthesized segments, then PT_DYNAMIC.
     write_dyn_phdrs(buf, phdr_offset, ?lay, segs, seg_offsets, seg_count, page_size);
+
+    debug_sht_write(buf, itn, debug, debug_count, ?dsht);
+    debug_sht_free(alloc, ?dsht, debug_count);
 
     if (seg_offsets != nil) { A.deallocate[usize](alloc, seg_offsets, seg_count::usize); }
 
@@ -4245,7 +4459,7 @@ test "mach.lang.target.of.elf.emit_pie_exec:static_pie_layout" {
     var tf: filesystem.TempFile = R.unwrap_ok[filesystem.TempFile, str](tf_r);
     val tpath: str = filesystem.temp_path(?tf);
 
-    val em: R.Result[bool, str] = emit_pie_exec(?alloc, ?i, ?isa_vt, ?segs[0], 1, 4096, 0x401000, ?dyn, tpath::*u8);
+    val em: R.Result[bool, str] = emit_pie_exec(?alloc, ?i, ?isa_vt, ?segs[0], 1, 4096, 0x401000, ?dyn, nil::*of.Section, 0, tpath::*u8);
     if (R.is_err[bool, str](em)) { filesystem.temp_close_and_remove(?tf); ret 1; }
 
     val rb: R.Result[filesystem.Buffer, str] = filesystem.read_all_sized(?alloc, tpath);
@@ -4379,7 +4593,7 @@ test "mach.lang.target.of.elf.emit_pie_exec:relro_splits_rodata_from_rel_ro" {
     var tf: filesystem.TempFile = R.unwrap_ok[filesystem.TempFile, str](tf_r);
     val tpath: str = filesystem.temp_path(?tf);
 
-    val em: R.Result[bool, str] = emit_pie_exec(?alloc, ?i, ?isa_vt, ?segs[0], 4, 4096, 0x401000, ?dyn, tpath::*u8);
+    val em: R.Result[bool, str] = emit_pie_exec(?alloc, ?i, ?isa_vt, ?segs[0], 4, 4096, 0x401000, ?dyn, nil::*of.Section, 0, tpath::*u8);
     if (R.is_err[bool, str](em)) { filesystem.temp_close_and_remove(?tf); ret 1; }
 
     val rb: R.Result[filesystem.Buffer, str] = filesystem.read_all_sized(?alloc, tpath);
@@ -4477,7 +4691,7 @@ test "mach.lang.target.of.elf.emit_pie_exec:page_align_congruence_64k" {
     var tf: filesystem.TempFile = R.unwrap_ok[filesystem.TempFile, str](tf_r);
     val tpath: str = filesystem.temp_path(?tf);
 
-    val em: R.Result[bool, str] = emit_pie_exec(?alloc, ?i, ?isa_vt, ?segs[0], 3, 65536, 0x410000, ?dyn, tpath::*u8);
+    val em: R.Result[bool, str] = emit_pie_exec(?alloc, ?i, ?isa_vt, ?segs[0], 3, 65536, 0x410000, ?dyn, nil::*of.Section, 0, tpath::*u8);
     if (R.is_err[bool, str](em)) { filesystem.temp_close_and_remove(?tf); ret 1; }
 
     val rb: R.Result[filesystem.Buffer, str] = filesystem.read_all_sized(?alloc, tpath);
@@ -4562,7 +4776,7 @@ test "mach.lang.target.of.elf.emit_pie_exec:header_overflow_refused" {
     var tf: filesystem.TempFile = R.unwrap_ok[filesystem.TempFile, str](tf_r);
     val tpath: str = filesystem.temp_path(?tf);
 
-    val em: R.Result[bool, str] = emit_pie_exec(?alloc, ?i, ?isa_vt, ?segs[0], 70, 4096, 0x401000, ?dyn, tpath::*u8);
+    val em: R.Result[bool, str] = emit_pie_exec(?alloc, ?i, ?isa_vt, ?segs[0], 70, 4096, 0x401000, ?dyn, nil::*of.Section, 0, tpath::*u8);
     filesystem.temp_close_and_remove(?tf);
     if (R.is_ok[bool, str](em)) { ret 1; }
     ret 0;
@@ -4711,6 +4925,104 @@ test "mach.lang.target.of.elf.emit_exec:debug_sections_nonalloc" {
     if (buf.data[n3 + str_len(line_want)] != 0)                     { bad = true; }
     val off3: usize = bin.read_u64_le(buf.data, sh3 + 24)::usize;
     if (buf.data[off3] != 0x11 || buf.data[off3 + 1] != 0x22 || buf.data[off3 + 2] != 0x33) { bad = true; }
+
+    if (bad) { ret 1; }
+    ret 0;
+}
+
+# emit_pie_exec appends a debug-only section-header table to the ET_DYN image so a
+# debugger names and locates the non-allocated debug sections, while the sections
+# themselves trail the image outside every PT_LOAD (never mapped). falsifies a PIE
+# writer that maps debug into a load segment or drops the debug channel.
+test "mach.lang.target.of.elf.emit_pie_exec:debug_sections_trailing_nonloaded" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+    var i: intern.Interner = intern.init(?alloc);
+
+    var isa_vt: isa.IsaVTable;
+    isa_vt.id            = isa.ARCH_X86_64;
+    isa_vt.elf_machine   = 62;
+    isa_vt.pointer_width = 8;
+
+    var text: [16]u8;
+    var k: usize = 0;
+    for (k < 16) { text[k] = 0x90; k = k + 1; }
+    var segs: [1]of.LoadSegment;
+    segs[0].vaddr = 0x401000; segs[0].filesz = 16; segs[0].memsz = 16;
+    segs[0].flags = of.SEG_FLAG_READ | of.SEG_FLAG_EXECUTE; segs[0].bytes = ?text[0];
+
+    var dyn: of.DynamicInfo;
+    dyn.libs = nil;          dyn.lib_count = 0;
+    dyn.imports = nil;       dyn.import_count = 0;
+    dyn.interp = intern.STR_NIL;
+    dyn.base_relocs = nil;   dyn.base_reloc_count = 0;
+    dyn.pie = true;
+
+    var info_bytes: [4]u8;
+    info_bytes[0] = 0xDE; info_bytes[1] = 0xAD; info_bytes[2] = 0xBE; info_bytes[3] = 0xEF;
+    val nm_info: R.Result[intern.StrId, str] = intern.intern(?i, ".debug_info");
+    if (R.is_err[intern.StrId, str](nm_info)) { ret 1; }
+    var dbg: [1]of.Section;
+    dbg[0].name = R.unwrap_ok[intern.StrId, str](nm_info); dbg[0].kind = of.SK_DEBUG;
+    dbg[0].bytes = ?info_bytes[0]; dbg[0].len = 4; dbg[0].align = 1;
+
+    val tf_r: R.Result[filesystem.TempFile, str] = filesystem.temp_create(?alloc, "elf_pie_dbg");
+    if (R.is_err[filesystem.TempFile, str](tf_r)) { ret 1; }
+    var tf: filesystem.TempFile = R.unwrap_ok[filesystem.TempFile, str](tf_r);
+    val tpath: str = filesystem.temp_path(?tf);
+
+    val em: R.Result[bool, str] = emit_pie_exec(?alloc, ?i, ?isa_vt, ?segs[0], 1, 4096, 0x401000, ?dyn, ?dbg[0], 1, tpath::*u8);
+    if (R.is_err[bool, str](em)) { filesystem.temp_close_and_remove(?tf); ret 1; }
+
+    val rb: R.Result[filesystem.Buffer, str] = filesystem.read_all_sized(?alloc, tpath);
+    filesystem.temp_close_and_remove(?tf);
+    if (R.is_err[filesystem.Buffer, str](rb)) { ret 1; }
+    val buf: filesystem.Buffer = R.unwrap_ok[filesystem.Buffer, str](rb);
+
+    var bad: bool = false;
+    if (bin.read_u16_le(buf.data, 16) != ET_DYN) { bad = true; }
+
+    val e_shoff:    usize = bin.read_u64_le(buf.data, 40)::usize;
+    val e_shnum:    u32 = bin.read_u16_le(buf.data, 60)::u32;
+    val e_shstrndx: u32 = bin.read_u16_le(buf.data, 62)::u32;
+    if (e_shoff == 0)    { bad = true; }
+    # null + one debug + .shstrtab.
+    if (e_shnum != 3)    { bad = true; }
+    if (e_shstrndx != 2) { bad = true; }
+    if (bad) { ret 1; }
+
+    # section 1 is the non-allocated .debug_info: PROGBITS, no SHF_ALLOC, address 0,
+    # its own recovered bytes and name.
+    val sh1: usize = e_shoff + 1 * SHDR_SIZE;
+    if (bin.read_u32_le(buf.data, sh1 + 4) != SHT_PROGBITS)    { bad = true; }
+    if ((bin.read_u64_le(buf.data, sh1 + 8) & SHF_ALLOC) != 0) { bad = true; }
+    if (bin.read_u64_le(buf.data, sh1 + 16) != 0)              { bad = true; }
+    if (bin.read_u64_le(buf.data, sh1 + 32)::usize != 4)       { bad = true; }
+    val sh_off: usize = bin.read_u64_le(buf.data, sh1 + 24)::usize;
+    if (buf.data[sh_off] != 0xDE || buf.data[sh_off + 1] != 0xAD
+        || buf.data[sh_off + 2] != 0xBE || buf.data[sh_off + 3] != 0xEF) { bad = true; }
+
+    val shstr_hdr:  usize = e_shoff + e_shstrndx::usize * SHDR_SIZE;
+    val shstr_base: usize = bin.read_u64_le(buf.data, shstr_hdr + 24)::usize;
+    val n1: usize = shstr_base + bin.read_u32_le(buf.data, sh1)::usize;
+    val info_want: str = ".debug_info";
+    var j: usize = 0;
+    for (j < str_len(info_want)) { if (buf.data[n1 + j] != info_want[j]) { bad = true; } j = j + 1; }
+    if (buf.data[n1 + str_len(info_want)] != 0) { bad = true; }
+
+    # the debug bytes trail every PT_LOAD: no program header covers sh_off.
+    val e_phoff: usize = bin.read_u64_le(buf.data, 32)::usize;
+    val e_phnum: usize = bin.read_u16_le(buf.data, 56)::usize;
+    var ph: usize = 0;
+    for (ph < e_phnum) {
+        val po: usize = e_phoff + ph * PHDR_SIZE;
+        if (bin.read_u32_le(buf.data, po) == PT_LOAD) {
+            val pf:  usize = bin.read_u64_le(buf.data, po + 8)::usize;
+            val psz: usize = bin.read_u64_le(buf.data, po + 32)::usize;
+            if (sh_off >= pf && sh_off < pf + psz) { bad = true; }
+        }
+        ph = ph + 1;
+    }
 
     if (bad) { ret 1; }
     ret 0;

--- a/src/lang/target/of/elf.mach
+++ b/src/lang/target/of/elf.mach
@@ -1241,27 +1241,55 @@ fun emit_exec(alloc: *A.Allocator, itn: *intern.Interner, tgt_isa: *isa.IsaVTabl
         li = li + 1;
     }
 
-    # when the ISA emits build attributes, frame the load segments with a section
-    # header table so external tools both read the ISA string and disassemble the
-    # code: one PROGBITS section per load segment (named by its permissions), then the
-    # non-alloc build-attributes section, then the section-name string table. all of
-    # this trails the segments outside every PT_LOAD, so the loader ignores it and the
-    # runtime image is unchanged. an arch with no attributes stays section-header-less.
-    var attr_off:       usize = 0;
-    var attr_sz:        usize = 0;
-    var shstr_off:      usize = 0;
-    var shstr_sz:       usize = 0;
-    var attr_name_rel:  usize = 0;
-    var shstr_name_rel: usize = 0;
-    var shdr_off:       usize = 0;
-    if (attr != nil) {
-        attr_sz    = build_attributes_size(attr);
-        attr_off   = total_size;
-        total_size = total_size + attr_sz;
+    # frame the load segments with a trailing section-header table when the ISA emits
+    # build attributes OR the linker handed us non-allocated debug sections: one
+    # PROGBITS section per load segment (named by its permissions), the optional
+    # build-attributes section, one non-alloc PROGBITS per debug section, then the
+    # section-name string table. all of it trails the segments outside every PT_LOAD,
+    # so the loader ignores it and the runtime image is unchanged. with neither
+    # attributes nor debug the exe stays section-header-less exactly as before.
+    val has_sht: bool = attr != nil || debug_count > 0;
 
-        # .shstrtab: leading nul, one name per load segment, the attributes section
-        # name, then ".shstrtab". the per-segment name offsets are recomputed in the
-        # header-write pass, which walks the segments in the same order.
+    var attr_off:        usize = 0;
+    var attr_sz:         usize = 0;
+    var debug_offs:      *usize = nil;
+    var debug_name_rels: *usize = nil;
+    var shstr_off:       usize = 0;
+    var shstr_sz:        usize = 0;
+    var attr_name_rel:   usize = 0;
+    var shstr_name_rel:  usize = 0;
+    var shdr_off:        usize = 0;
+    var sht_count:       u32 = 0;
+    if (has_sht) {
+        if (attr != nil) {
+            attr_sz    = build_attributes_size(attr);
+            attr_off   = total_size;
+            total_size = total_size + attr_sz;
+        }
+
+        # each debug section's bytes trail the segments (and attributes), aligned to
+        # the section's own alignment; non-loaded, so no vaddr and no PT_LOAD.
+        if (debug_count > 0) {
+            val dro: R.Result[*usize, str] = A.zallocate[usize](alloc, debug_count::usize);
+            if (R.is_err[*usize, str](dro)) {
+                if (seg_offsets != nil) { A.deallocate[usize](alloc, seg_offsets, seg_count::usize); }
+                ret R.err[bool, str]("elf: exec debug offset table alloc failed");
+            }
+            debug_offs = R.unwrap_ok[*usize, str](dro);
+            var di: u32 = 0;
+            for (di < debug_count) {
+                var da: u32 = debug[di].align;
+                if (da == 0) { da = 1; }
+                total_size = bin.align_up(total_size, da::usize);
+                debug_offs[di] = total_size;
+                total_size = total_size + debug[di].len::usize;
+                di = di + 1;
+            }
+        }
+
+        # .shstrtab: leading nul, one name per load segment, the attributes name (if
+        # any), each debug section name, then ".shstrtab". the per-name offsets are
+        # recomputed in the header-write pass, which walks them in the same order.
         shstr_off = total_size;
         shstr_sz  = 1;
         li = 0;
@@ -1269,19 +1297,41 @@ fun emit_exec(alloc: *A.Allocator, itn: *intern.Interner, tgt_isa: *isa.IsaVTabl
             shstr_sz = shstr_sz + str_len(seg_section_name(segs[li].flags)) + 1;
             li = li + 1;
         }
-        attr_name_rel = shstr_sz;
-        shstr_sz = shstr_sz + str_len(attr.section) + 1;
+        if (attr != nil) {
+            attr_name_rel = shstr_sz;
+            shstr_sz = shstr_sz + str_len(attr.section) + 1;
+        }
+        if (debug_count > 0) {
+            val dnro: R.Result[*usize, str] = A.zallocate[usize](alloc, debug_count::usize);
+            if (R.is_err[*usize, str](dnro)) {
+                if (debug_offs != nil)  { A.deallocate[usize](alloc, debug_offs, debug_count::usize); }
+                if (seg_offsets != nil) { A.deallocate[usize](alloc, seg_offsets, seg_count::usize); }
+                ret R.err[bool, str]("elf: exec debug name table alloc failed");
+            }
+            debug_name_rels = R.unwrap_ok[*usize, str](dnro);
+            var di: u32 = 0;
+            for (di < debug_count) {
+                debug_name_rels[di] = shstr_sz;
+                shstr_sz = shstr_sz + str_len(resolve(itn, debug[di].name)) + 1;
+                di = di + 1;
+            }
+        }
         shstr_name_rel = shstr_sz;
         shstr_sz = shstr_sz + str_len(".shstrtab") + 1;
         total_size = total_size + shstr_sz;
 
-        shdr_off   = bin.align_up(total_size, 8);
-        # the section-header table: null + one per segment + attributes + .shstrtab.
-        total_size = shdr_off + SHDR_SIZE * (seg_count + 3)::usize;
+        shdr_off = bin.align_up(total_size, 8);
+        # the section-header table: null + one per segment + attributes(if any) +
+        # one per debug section + .shstrtab.
+        sht_count = seg_count + 1 + debug_count + 1;
+        if (attr != nil) { sht_count = sht_count + 1; }
+        total_size = shdr_off + SHDR_SIZE * sht_count::usize;
     }
 
     val res_buf: R.Result[*u8, str] = A.zallocate[u8](alloc, total_size);
     if (R.is_err[*u8, str](res_buf)) {
+        if (debug_name_rels != nil) { A.deallocate[usize](alloc, debug_name_rels, debug_count::usize); }
+        if (debug_offs != nil)      { A.deallocate[usize](alloc, debug_offs, debug_count::usize); }
         if (seg_offsets != nil) { A.deallocate[usize](alloc, seg_offsets, seg_count::usize); }
         ret R.err[bool, str]("elf: exec buffer alloc failed");
     }
@@ -1298,17 +1348,18 @@ fun emit_exec(alloc: *A.Allocator, itn: *intern.Interner, tgt_isa: *isa.IsaVTabl
     bin.write_u32_le(buf, 20, 1);
     bin.write_u64_le(buf, 24, entry);
     bin.write_u64_le(buf, 32, phdr_offset::u64);
-    if (attr != nil) { bin.write_u64_le(buf, 40, shdr_off::u64); } or { bin.write_u64_le(buf, 40, 0); }
+    if (has_sht) { bin.write_u64_le(buf, 40, shdr_off::u64); } or { bin.write_u64_le(buf, 40, 0); }
     bin.write_u32_le(buf, 48, 0);
     bin.write_u16_le(buf, 52, ELF_HEADER_SIZE::u16);
     bin.write_u16_le(buf, 54, PHDR_SIZE::u16);
     bin.write_u16_le(buf, 56, phdr_count::u16);
     bin.write_u16_le(buf, 58, SHDR_SIZE::u16);
-    if (attr != nil) {
-        # the section-header table is null + one per segment + attributes + .shstrtab;
-        # .shstrtab (the section-name string table) is the last section.
-        bin.write_u16_le(buf, 60, (seg_count + 3)::u16);
-        bin.write_u16_le(buf, 62, (seg_count + 2)::u16);
+    if (has_sht) {
+        # the section-header table is null + one per segment + attributes(if any) +
+        # one per debug section + .shstrtab; .shstrtab (the section-name string table)
+        # is the last section.
+        bin.write_u16_le(buf, 60, sht_count::u16);
+        bin.write_u16_le(buf, 62, (sht_count - 1)::u16);
     } or {
         bin.write_u16_le(buf, 60, 0);
         bin.write_u16_le(buf, 62, 0);
@@ -1348,13 +1399,22 @@ fun emit_exec(alloc: *A.Allocator, itn: *intern.Interner, tgt_isa: *isa.IsaVTabl
         li = li + 1;
     }
 
-    # the build-attributes section data, its name string table, and the section
-    # headers, all after the load segments and outside every PT_LOAD.
-    if (attr != nil) {
-        write_build_attributes(buf, attr_off, attr);
+    # the optional build-attributes section, the debug section bytes, the section-name
+    # string table, and the section headers, all after the load segments and outside
+    # every PT_LOAD.
+    if (has_sht) {
+        if (attr != nil) { write_build_attributes(buf, attr_off, attr); }
 
-        # .shstrtab: leading nul, one name per load segment, the attributes section
-        # name, then ".shstrtab".
+        var di: u32 = 0;
+        for (di < debug_count) {
+            if (debug[di].bytes != nil && debug[di].len > 0) {
+                memory.raw_copy((buf::usize + debug_offs[di])::ptr, debug[di].bytes::ptr, debug[di].len::usize);
+            }
+            di = di + 1;
+        }
+
+        # .shstrtab: leading nul, one name per load segment, the attributes name (if
+        # any), each debug section name, then ".shstrtab".
         buf[shstr_off] = 0;
         var np: usize = 1;
         li = 0;
@@ -1362,14 +1422,19 @@ fun emit_exec(alloc: *A.Allocator, itn: *intern.Interner, tgt_isa: *isa.IsaVTabl
             np = np + bin.write_str(buf, shstr_off + np, seg_section_name(segs[li].flags));
             li = li + 1;
         }
-        np = np + bin.write_str(buf, shstr_off + np, attr.section);
+        if (attr != nil) { np = np + bin.write_str(buf, shstr_off + np, attr.section); }
+        di = 0;
+        for (di < debug_count) {
+            np = np + bin.write_str(buf, shstr_off + np, resolve(itn, debug[di].name));
+            di = di + 1;
+        }
         bin.write_str(buf, shstr_off + np, ".shstrtab");
 
-        # section headers: [0] reserved null (already zeroed by the zalloc), [1..N] a
-        # PROGBITS section per load segment, then the attributes section, then
-        # .shstrtab. each segment section maps the segment's file bytes at its vaddr so
-        # external tools disassemble the code; its name offset walks the same order the
-        # names were written above.
+        # section headers: [0] reserved null (already zeroed by the zalloc), [1..] a
+        # PROGBITS per load segment (mapping the segment's file bytes at its vaddr so
+        # external tools disassemble the code), the attributes section (if any), one
+        # non-alloc PROGBITS per debug section, then .shstrtab. per-segment name
+        # offsets walk the same order the names were written above.
         var hp: usize = shdr_off + SHDR_SIZE;
         var name_cursor: usize = 1;
         li = 0;
@@ -1389,17 +1454,38 @@ fun emit_exec(alloc: *A.Allocator, itn: *intern.Interner, tgt_isa: *isa.IsaVTabl
             li = li + 1;
         }
 
-        bin.write_u32_le(buf, hp, attr_name_rel::u32);
-        bin.write_u32_le(buf, hp + 4, attr.sht);
-        bin.write_u64_le(buf, hp + 8, 0);
-        bin.write_u64_le(buf, hp + 16, 0);
-        bin.write_u64_le(buf, hp + 24, attr_off::u64);
-        bin.write_u64_le(buf, hp + 32, attr_sz::u64);
-        bin.write_u32_le(buf, hp + 40, 0);
-        bin.write_u32_le(buf, hp + 44, 0);
-        bin.write_u64_le(buf, hp + 48, 1);
-        bin.write_u64_le(buf, hp + 56, 0);
-        hp = hp + SHDR_SIZE;
+        if (attr != nil) {
+            bin.write_u32_le(buf, hp, attr_name_rel::u32);
+            bin.write_u32_le(buf, hp + 4, attr.sht);
+            bin.write_u64_le(buf, hp + 8, 0);
+            bin.write_u64_le(buf, hp + 16, 0);
+            bin.write_u64_le(buf, hp + 24, attr_off::u64);
+            bin.write_u64_le(buf, hp + 32, attr_sz::u64);
+            bin.write_u32_le(buf, hp + 40, 0);
+            bin.write_u32_le(buf, hp + 44, 0);
+            bin.write_u64_le(buf, hp + 48, 1);
+            bin.write_u64_le(buf, hp + 56, 0);
+            hp = hp + SHDR_SIZE;
+        }
+
+        # non-allocated debug sections: no SHF_ALLOC, no address, own file bytes.
+        di = 0;
+        for (di < debug_count) {
+            var da: u32 = debug[di].align;
+            if (da == 0) { da = 1; }
+            bin.write_u32_le(buf, hp, debug_name_rels[di]::u32);
+            bin.write_u32_le(buf, hp + 4, SHT_PROGBITS);
+            bin.write_u64_le(buf, hp + 8, 0);
+            bin.write_u64_le(buf, hp + 16, 0);
+            bin.write_u64_le(buf, hp + 24, debug_offs[di]::u64);
+            bin.write_u64_le(buf, hp + 32, debug[di].len::u64);
+            bin.write_u32_le(buf, hp + 40, 0);
+            bin.write_u32_le(buf, hp + 44, 0);
+            bin.write_u64_le(buf, hp + 48, da::u64);
+            bin.write_u64_le(buf, hp + 56, 0);
+            hp = hp + SHDR_SIZE;
+            di = di + 1;
+        }
 
         bin.write_u32_le(buf, hp, shstr_name_rel::u32);
         bin.write_u32_le(buf, hp + 4, SHT_STRTAB);
@@ -1413,6 +1499,8 @@ fun emit_exec(alloc: *A.Allocator, itn: *intern.Interner, tgt_isa: *isa.IsaVTabl
         bin.write_u64_le(buf, hp + 56, 0);
     }
 
+    if (debug_name_rels != nil) { A.deallocate[usize](alloc, debug_name_rels, debug_count::usize); }
+    if (debug_offs != nil)      { A.deallocate[usize](alloc, debug_offs, debug_count::usize); }
     if (seg_offsets != nil) { A.deallocate[usize](alloc, seg_offsets, seg_count::usize); }
 
     val res_file: R.Result[filesystem.File, str] = filesystem.create(path, 0o755);
@@ -4523,5 +4611,107 @@ test "mach.lang.target.of.elf.emit_dyn_exec:header_overflow_refused" {
                                                 nil::*of.Section, 0, tpath::*u8, "dynoverflow"::*u8);
     filesystem.temp_close_and_remove(?tf);
     if (R.is_ok[bool, str](em)) { ret 1; }
+    ret 0;
+}
+
+# emit_exec frames the linker's non-allocated debug sections as their own
+# section-header entries trailing the load segments: SHT_PROGBITS, no SHF_ALLOC,
+# zero address (never mapped), each carrying its own bytes under its distinct
+# .debug_* name. falsifies a writer that drops the debug channel, marks it
+# allocatable, or collapses the sections into one.
+test "mach.lang.target.of.elf.emit_exec:debug_sections_nonalloc" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+    var i: intern.Interner = intern.init(?alloc);
+
+    var isa_vt: isa.IsaVTable;
+    isa_vt.id            = isa.ARCH_X86_64;
+    isa_vt.elf_machine   = 62;       # EM_X86_64
+    isa_vt.pointer_width = 8;
+
+    var text: [16]u8;
+    var k: usize = 0;
+    for (k < 16) { text[k] = 0x90; k = k + 1; }
+    var segs: [1]of.LoadSegment;
+    segs[0].vaddr = 0x401000; segs[0].filesz = 16; segs[0].memsz = 16;
+    segs[0].flags = of.SEG_FLAG_READ | of.SEG_FLAG_EXECUTE; segs[0].bytes = ?text[0];
+
+    # two distinct synthetic debug sections with recognizable bytes.
+    var info_bytes: [4]u8;
+    info_bytes[0] = 0xDE; info_bytes[1] = 0xAD; info_bytes[2] = 0xBE; info_bytes[3] = 0xEF;
+    var line_bytes: [3]u8;
+    line_bytes[0] = 0x11; line_bytes[1] = 0x22; line_bytes[2] = 0x33;
+
+    val nm_info: R.Result[intern.StrId, str] = intern.intern(?i, ".debug_info");
+    val nm_line: R.Result[intern.StrId, str] = intern.intern(?i, ".debug_line");
+    if (R.is_err[intern.StrId, str](nm_info)) { ret 1; }
+    if (R.is_err[intern.StrId, str](nm_line)) { ret 1; }
+
+    var dbg: [2]of.Section;
+    dbg[0].name = R.unwrap_ok[intern.StrId, str](nm_info); dbg[0].kind = of.SK_DEBUG;
+    dbg[0].bytes = ?info_bytes[0]; dbg[0].len = 4; dbg[0].align = 1;
+    dbg[1].name = R.unwrap_ok[intern.StrId, str](nm_line); dbg[1].kind = of.SK_DEBUG;
+    dbg[1].bytes = ?line_bytes[0]; dbg[1].len = 3; dbg[1].align = 1;
+
+    val tf_r: R.Result[filesystem.TempFile, str] = filesystem.temp_create(?alloc, "elf_dbg");
+    if (R.is_err[filesystem.TempFile, str](tf_r)) { ret 1; }
+    var tf: filesystem.TempFile = R.unwrap_ok[filesystem.TempFile, str](tf_r);
+    val tpath: str = filesystem.temp_path(?tf);
+
+    val em: R.Result[bool, str] = emit_exec(?alloc, ?i, ?isa_vt, ?segs[0], 1, 4096, 0x401000,
+                                            nil::*of.ExecFunction, 0, ?dbg[0], 2, tpath::*u8, "elfdbg"::*u8);
+    if (R.is_err[bool, str](em)) { filesystem.temp_close_and_remove(?tf); ret 1; }
+
+    val rb: R.Result[filesystem.Buffer, str] = filesystem.read_all_sized(?alloc, tpath);
+    filesystem.temp_close_and_remove(?tf);
+    if (R.is_err[filesystem.Buffer, str](rb)) { ret 1; }
+    val buf: filesystem.Buffer = R.unwrap_ok[filesystem.Buffer, str](rb);
+
+    var bad: bool = false;
+
+    val e_shoff:    usize = bin.read_u64_le(buf.data, 40)::usize;
+    val e_shnum:    u32 = bin.read_u16_le(buf.data, 60)::u32;
+    val e_shstrndx: u32 = bin.read_u16_le(buf.data, 62)::u32;
+    if (e_shoff == 0)    { bad = true; }
+    # null + one load segment + two debug + .shstrtab.
+    if (e_shnum != 5)    { bad = true; }
+    if (e_shstrndx != 4) { bad = true; }
+
+    if (bad) { ret 1; }
+
+    val shstr_hdr:  usize = e_shoff + e_shstrndx::usize * SHDR_SIZE;
+    val shstr_base: usize = bin.read_u64_le(buf.data, shstr_hdr + 24)::usize;
+
+    # both debug sections are non-allocated PROGBITS at address 0, carrying their
+    # own recovered bytes under their distinct names (sections 2 and 3 by layout).
+    val info_want: str = ".debug_info";
+    val line_want: str = ".debug_line";
+
+    val sh2: usize = e_shoff + 2 * SHDR_SIZE;
+    if (bin.read_u32_le(buf.data, sh2 + 4) != SHT_PROGBITS)         { bad = true; }
+    if ((bin.read_u64_le(buf.data, sh2 + 8) & SHF_ALLOC) != 0)      { bad = true; }
+    if (bin.read_u64_le(buf.data, sh2 + 16) != 0)                   { bad = true; }
+    if (bin.read_u64_le(buf.data, sh2 + 32)::usize != 4)            { bad = true; }
+    val n2: usize = shstr_base + bin.read_u32_le(buf.data, sh2)::usize;
+    var j: usize = 0;
+    for (j < str_len(info_want)) { if (buf.data[n2 + j] != info_want[j]) { bad = true; } j = j + 1; }
+    if (buf.data[n2 + str_len(info_want)] != 0)                     { bad = true; }
+    val off2: usize = bin.read_u64_le(buf.data, sh2 + 24)::usize;
+    if (buf.data[off2] != 0xDE || buf.data[off2 + 1] != 0xAD
+        || buf.data[off2 + 2] != 0xBE || buf.data[off2 + 3] != 0xEF) { bad = true; }
+
+    val sh3: usize = e_shoff + 3 * SHDR_SIZE;
+    if (bin.read_u32_le(buf.data, sh3 + 4) != SHT_PROGBITS)         { bad = true; }
+    if ((bin.read_u64_le(buf.data, sh3 + 8) & SHF_ALLOC) != 0)      { bad = true; }
+    if (bin.read_u64_le(buf.data, sh3 + 16) != 0)                   { bad = true; }
+    if (bin.read_u64_le(buf.data, sh3 + 32)::usize != 3)            { bad = true; }
+    val n3: usize = shstr_base + bin.read_u32_le(buf.data, sh3)::usize;
+    j = 0;
+    for (j < str_len(line_want)) { if (buf.data[n3 + j] != line_want[j]) { bad = true; } j = j + 1; }
+    if (buf.data[n3 + str_len(line_want)] != 0)                     { bad = true; }
+    val off3: usize = bin.read_u64_le(buf.data, sh3 + 24)::usize;
+    if (buf.data[off3] != 0x11 || buf.data[off3 + 1] != 0x22 || buf.data[off3 + 2] != 0x33) { bad = true; }
+
+    if (bad) { ret 1; }
     ret 0;
 }

--- a/src/lang/target/of/elf.mach
+++ b/src/lang/target/of/elf.mach
@@ -1209,7 +1209,7 @@ fun seg_section_flags(flags: u32) u64 {
 # ret:        ok(true) on success, or an error string
 fun emit_exec(alloc: *A.Allocator, itn: *intern.Interner, tgt_isa: *isa.IsaVTable, segs: *of.LoadSegment,
               seg_count: u32, page_size: u64, entry: u64, funcs: *of.ExecFunction,
-              func_count: u32, path: *u8, name: *u8) R.Result[bool, str] {
+              func_count: u32, debug: *of.Section, debug_count: u32, path: *u8, name: *u8) R.Result[bool, str] {
     if (tgt_isa == nil) { ret R.err[bool, str]("elf: nil exec isa"); }
     if (path == nil)    { ret R.err[bool, str]("elf: nil exec path"); }
 
@@ -1950,7 +1950,7 @@ fun dynstr_name_len(itn: *intern.Interner, id: intern.StrId) usize {
 fun emit_dyn_exec(alloc: *A.Allocator, itn: *intern.Interner, tgt_isa: *isa.IsaVTable, segs: *of.LoadSegment,
                   seg_count: u32, page_size: u64, entry: u64, funcs: *of.ExecFunction,
                   func_count: u32, dyn: *of.DynamicInfo, fixups: *of.PltFixup,
-                  fixup_count: u32, path: *u8, name: *u8) R.Result[bool, str] {
+                  fixup_count: u32, debug: *of.Section, debug_count: u32, path: *u8, name: *u8) R.Result[bool, str] {
     if (tgt_isa == nil) { ret R.err[bool, str]("elf: nil dyn-exec isa"); }
     if (path == nil)    { ret R.err[bool, str]("elf: nil dyn-exec path"); }
     if (dyn == nil)     { ret R.err[bool, str]("elf: nil dynamic plan"); }
@@ -4520,7 +4520,7 @@ test "mach.lang.target.of.elf.emit_dyn_exec:header_overflow_refused" {
 
     val em: R.Result[bool, str] = emit_dyn_exec(?alloc, ?i, ?isa_vt, ?segs[0], 67, 4096, 0x401000,
                                                 nil::*of.ExecFunction, 0, ?dyn, nil::*of.PltFixup, 0,
-                                                tpath::*u8, "dynoverflow"::*u8);
+                                                nil::*of.Section, 0, tpath::*u8, "dynoverflow"::*u8);
     filesystem.temp_close_and_remove(?tf);
     if (R.is_ok[bool, str](em)) { ret 1; }
     ret 0;

--- a/src/lang/target/of/macho.mach
+++ b/src/lang/target/of/macho.mach
@@ -1405,6 +1405,10 @@ fun emit_exec(alloc: *A.Allocator, itn: *intern.Interner, isa_vt: *isa.IsaVTable
               debug: *of.Section, debug_count: u32, path: *u8, name: *u8) R.Result[bool, str] {
     if (isa_vt == nil) { ret R.err[bool, str]("macho: nil exec isa"); }
     if (path == nil)   { ret R.err[bool, str]("macho: nil exec path"); }
+    # the of.ExecFn debug-section channel (debug/debug_count) is accepted for seam
+    # conformance but not yet framed into the Mach-O image: it needs a non-mapped
+    # __DWARF segment and the ad-hoc code-signature's code_limit extended to cover
+    # the debug bytes. tracked by #1887, gated on the macOS verification runner (#1698).
     val arch_id: u32 = isa_vt.id;
     val ct: R.Result[u32, str] = cpu_type_for(arch_id);
     if (R.is_err[u32, str](ct)) { ret R.err[bool, str](R.unwrap_err[u32, str](ct)); }
@@ -2227,6 +2231,8 @@ fun emit_dyn_exec(alloc: *A.Allocator, itn: *intern.Interner, isa_vt: *isa.IsaVT
                   debug: *of.Section, debug_count: u32, path: *u8, name: *u8) R.Result[bool, str] {
     if (isa_vt == nil) { ret R.err[bool, str]("macho: nil dyn-exec isa"); }
     if (path == nil)   { ret R.err[bool, str]("macho: nil dyn-exec path"); }
+    # the debug-section channel is accepted for seam conformance but not yet framed
+    # into the dyld image (non-mapped __DWARF segment + code_limit coverage); see #1887.
     if (dyn == nil)    { ret R.err[bool, str]("macho: nil dynamic plan"); }
     if (itn == nil)    { ret R.err[bool, str]("macho: no interner for dyn-exec"); }
     if (seg_count == 0) { ret R.err[bool, str]("macho: dyn-exec has no load segments"); }

--- a/src/lang/target/of/macho.mach
+++ b/src/lang/target/of/macho.mach
@@ -1402,7 +1402,7 @@ fun write_code_signature(buf: *u8, sig_off: usize, name: *u8, code_limit: usize,
 # ret:        ok(true) on success, or an error string
 fun emit_exec(alloc: *A.Allocator, itn: *intern.Interner, isa_vt: *isa.IsaVTable, segs: *of.LoadSegment,
               seg_count: u32, page_size: u64, entry: u64, funcs: *of.ExecFunction, func_count: u32,
-              path: *u8, name: *u8) R.Result[bool, str] {
+              debug: *of.Section, debug_count: u32, path: *u8, name: *u8) R.Result[bool, str] {
     if (isa_vt == nil) { ret R.err[bool, str]("macho: nil exec isa"); }
     if (path == nil)   { ret R.err[bool, str]("macho: nil exec path"); }
     val arch_id: u32 = isa_vt.id;
@@ -2224,7 +2224,7 @@ fun dyn_sect_flags(flags: u32, zerofill: bool) u32 {
 fun emit_dyn_exec(alloc: *A.Allocator, itn: *intern.Interner, isa_vt: *isa.IsaVTable, segs: *of.LoadSegment,
                   seg_count: u32, page_size: u64, entry: u64, funcs: *of.ExecFunction, func_count: u32,
                   dyn: *of.DynamicInfo, fixups: *of.PltFixup, fixup_count: u32,
-                  path: *u8, name: *u8) R.Result[bool, str] {
+                  debug: *of.Section, debug_count: u32, path: *u8, name: *u8) R.Result[bool, str] {
     if (isa_vt == nil) { ret R.err[bool, str]("macho: nil dyn-exec isa"); }
     if (path == nil)   { ret R.err[bool, str]("macho: nil dyn-exec path"); }
     if (dyn == nil)    { ret R.err[bool, str]("macho: nil dynamic plan"); }
@@ -3499,7 +3499,7 @@ fun ts_exec_x64() u8 {
 
     # the product name is deliberately not the temp-file basename, to prove the
     # code-sign identifier tracks the name, not the output path.
-    val em: R.Result[bool, str] = emit_exec(?alloc, ?itn, ?isa_vt, ?segs[0], 1, 4096, entry, nil::*of.ExecFunction, 0, tpath::*u8, "machoexe"::*u8);
+    val em: R.Result[bool, str] = emit_exec(?alloc, ?itn, ?isa_vt, ?segs[0], 1, 4096, entry, nil::*of.ExecFunction, 0, nil::*of.Section, 0, tpath::*u8, "machoexe"::*u8);
     if (R.is_err[bool, str](em)) { filesystem.temp_close_and_remove(?tf); ret 1; }
 
     val rb: R.Result[filesystem.Buffer, str] = filesystem.read_all_sized(?alloc, tpath);
@@ -3576,7 +3576,7 @@ fun ts_exec_arm64() u8 {
     var tf: filesystem.TempFile = R.unwrap_ok[filesystem.TempFile, str](tf_r);
     val tpath: str = filesystem.temp_path(?tf);
 
-    val em: R.Result[bool, str] = emit_exec(?alloc, ?itn, ?isa_vt, ?segs[0], 1, 16384, entry, nil::*of.ExecFunction, 0, tpath::*u8, "machoa64"::*u8);
+    val em: R.Result[bool, str] = emit_exec(?alloc, ?itn, ?isa_vt, ?segs[0], 1, 16384, entry, nil::*of.ExecFunction, 0, nil::*of.Section, 0, tpath::*u8, "machoa64"::*u8);
     if (R.is_err[bool, str](em)) { filesystem.temp_close_and_remove(?tf); ret 1; }
 
     val rb: R.Result[filesystem.Buffer, str] = filesystem.read_all_sized(?alloc, tpath);
@@ -3694,7 +3694,7 @@ fun ts_dyn_exec(arch_id: u32) u8 {
     val tpath: str = filesystem.temp_path(?tf);
 
     val em: R.Result[bool, str] = emit_dyn_exec(?alloc, ?itn, ?isa_vt, ?segs[0], 1, 4096, entry,
-                                                nil::*of.ExecFunction, 0, ?dyn, ?fx[0], 1, tpath::*u8, "machodyn"::*u8);
+                                                nil::*of.ExecFunction, 0, ?dyn, ?fx[0], 1, nil::*of.Section, 0, tpath::*u8, "machodyn"::*u8);
     if (R.is_err[bool, str](em)) { filesystem.temp_close_and_remove(?tf); ret 1; }
 
     val rb: R.Result[filesystem.Buffer, str] = filesystem.read_all_sized(?alloc, tpath);

--- a/src/lang/target/of/raw.mach
+++ b/src/lang/target/of/raw.mach
@@ -149,6 +149,8 @@ fun emit_exec(alloc: *A.Allocator, itn: *intern.Interner, tgt_isa: *isa.IsaVTabl
               func_count: u32, debug: *of.Section, debug_count: u32, path: *u8, name: *u8) R.Result[bool, str] {
     if (tgt_isa == nil) { ret R.err[bool, str]("raw: nil exec isa"); }
     if (path == nil)    { ret R.err[bool, str]("raw: nil exec path"); }
+    # the debug-section channel is accepted for of.ExecFn conformance and ignored: a
+    # flat sectionless image structurally cannot carry debug sections (epic #1688).
 
     var base: u64   = 0;
     var size: usize = 0;

--- a/src/lang/target/of/raw.mach
+++ b/src/lang/target/of/raw.mach
@@ -146,7 +146,7 @@ fun parse_object(a: *A.Allocator, itn: *intern.Interner, buf: *u8, buf_len: usiz
 # ret:        ok(true) on success, or an error string
 fun emit_exec(alloc: *A.Allocator, itn: *intern.Interner, tgt_isa: *isa.IsaVTable, segs: *of.LoadSegment,
               seg_count: u32, page_size: u64, entry: u64, funcs: *of.ExecFunction,
-              func_count: u32, path: *u8, name: *u8) R.Result[bool, str] {
+              func_count: u32, debug: *of.Section, debug_count: u32, path: *u8, name: *u8) R.Result[bool, str] {
     if (tgt_isa == nil) { ret R.err[bool, str]("raw: nil exec isa"); }
     if (path == nil)    { ret R.err[bool, str]("raw: nil exec path"); }
 
@@ -202,7 +202,7 @@ fun emit_exec(alloc: *A.Allocator, itn: *intern.Interner, tgt_isa: *isa.IsaVTabl
 fun emit_dyn_exec(alloc: *A.Allocator, itn: *intern.Interner, tgt_isa: *isa.IsaVTable, segs: *of.LoadSegment,
                   seg_count: u32, page_size: u64, entry: u64, funcs: *of.ExecFunction, func_count: u32,
                   dyn: *of.DynamicInfo, fixups: *of.PltFixup, fixup_count: u32,
-                  path: *u8, name: *u8) R.Result[bool, str] {
+                  debug: *of.Section, debug_count: u32, path: *u8, name: *u8) R.Result[bool, str] {
     ret R.err[bool, str](RAW_UNSUPPORTED);
 }
 
@@ -292,7 +292,7 @@ test "mach.lang.target.of.raw.emit_exec:flat_layout" {
     val tpath: str = filesystem.temp_path(?tf);
 
     val em: R.Result[bool, str] =
-        emit_exec(?alloc, ?i, ?isa_vt, ?segs[0], 2, 4096, 0x1000, nil::*of.ExecFunction, 0, tpath::*u8, "rawflat"::*u8);
+        emit_exec(?alloc, ?i, ?isa_vt, ?segs[0], 2, 4096, 0x1000, nil::*of.ExecFunction, 0, nil::*of.Section, 0, tpath::*u8, "rawflat"::*u8);
     if (R.is_err[bool, str](em)) { filesystem.temp_close_and_remove(?tf); ret 1; }
 
     val rr: R.Result[filesystem.Buffer, str] = filesystem.read_all_sized(?alloc, tpath);
@@ -342,7 +342,7 @@ test "mach.lang.target.of.raw.emit_exec:entry_must_be_base" {
 
     # entry 0x1008 != image base 0x1000 must be rejected.
     val em: R.Result[bool, str] =
-        emit_exec(?alloc, ?i, ?isa_vt, ?segs[0], 1, 4096, 0x1008, nil::*of.ExecFunction, 0, "raw_should_not_exist"::*u8, "rawbad"::*u8);
+        emit_exec(?alloc, ?i, ?isa_vt, ?segs[0], 1, 4096, 0x1008, nil::*of.ExecFunction, 0, nil::*of.Section, 0, "raw_should_not_exist"::*u8, "rawbad"::*u8);
     if (!R.is_err[bool, str](em))                                { ret 1; }
     if (!str_contains(R.unwrap_err[bool, str](em), "base"))      { ret 1; }
     ret 0;


### PR DESCRIPTION
## What

Foundation work for the debug-info epic (#1688): the linker keeps `SK_DEBUG` sections distinct **by name** through the merge, relocates them to final addresses, and carries them to the executable writers through a new seam channel. `SK_DEBUG` stays non-`SHF_ALLOC` / non-loaded.

## Scope of this PR

- **Seam** (`of.mach`): `ExecFn`/`DynExecFn` gain a `(debug: *Section, debug_count)` channel — the merged, relocation-patched debug sections. Every writer (elf/macho/coff/raw) conforms.
- **Linker** (`be/linker.mach`): the merge keys debug input sections by NAME (not the single kind-collapsed `.debug`), so `.debug_info`/`.debug_line`/`.debug_abbrev`/`.debug_str` survive distinctly; a `merged_index → output-section` map replaces the kind-equality lookup used by relocation patching and carry; PIE base-relocation collection skips non-loadable sections; the executable emitters collect the merged debug sections and hand them to the writers.
- **ELF writer** — fully emits debug sections in all three exec paths (static `emit_exec`, static-PIE, and dynamic): non-alloc `SHT_PROGBITS` sections under their distinct names, trailing the load segments outside every `PT_LOAD`. The default linux `mach build` (static `ET_EXEC`) path is the #1700 critical path.

## Deferred (tracked in #1887)

Mach-O and COFF **accept** the debug channel (seam-conformant) but do not yet frame it: Mach-O needs a non-mapped `__DWARF` segment + code-signature `code_limit` coverage, and PE needs a COFF string table for the long `.debug_*` names. Neither is runtime-verifiable in the linux dev/CI environment (no `codesign`/macOS, no PE loader), and the epic flagged Mach-O codesign-under-debug as needing the macOS runner. #1887 owns that work, gated on the #1698 verification runners. The raw flat-image writer ignores the channel by design.

## Verification

- **Byte-identity invariant** (no debug in inputs → output byte-identical): proven — the baseline current-dev compiler and the self-hosted branch compiler produce the **identical** `mach` binary when compiling this worktree; the branch self-host fixpoint converges. Re-proven after rebasing onto current dev (incl. #1692).
- Unit suite 468/468 pass, including two falsifiable ELF tests driving `emit_exec`/`emit_pie_exec` with synthetic debug sections (assert non-alloc `PROGBITS`, distinct names, recovered bytes, and — for PIE — coverage by no `PT_LOAD`).
- Integration harness green on `linux` (all surface + regression cases, including the cross-built `macho-pie-*` and `pe-*` structural cases).

Rebased onto current dev; depends-on #1692 (merged).

Refs #1694 (writer completion for Mach-O/COFF tracked in #1887)
