### PR TITLE
feat(debuginfo): source location on IR instructions + builder loc cursor

### DIFF
--- a/src/lang/me/ir/builder.mach
+++ b/src/lang/me/ir/builder.mach
@@ -21,6 +21,7 @@
 # second terminator emission is rejected with an error rather than silently
 # overwriting the first.
 
+use std.allocator.page;
 use std.types.bool.bool;
 use std.types.bool.true;
 use std.types.size.usize;
@@ -29,21 +30,27 @@ use std.types.string.str;
 use A: std.allocator;
 use R: std.types.result;
 
+use mach.lang.intern;
 use mach.lang.me.ir;
 use mach.lang.me.ir.id;
 use mach.lang.me.ir.instruction;
 use mach.lang.me.ir.type;
 use mach.lang.me.ir.value;
+use mach.lang.source;
 
 # an insertion cursor over an IR module
 # ---
 # m:     the module being built (owns instruction-pool growth via its functions)
 # fn:    the function currently being emitted into (nil until set_function)
 # block: the block new instructions land in (BLOCK_NIL until set_block)
+# loc:   current debug-location cursor stamped onto every emitted instruction;
+#        FILE_NIL until set_loc, and reset to FILE_NIL on each set_function so a
+#        new function's prologue never inherits a stale location
 pub rec Builder {
     m:     *ir.Module;
     fn:    *ir.Function;
     block: id.BlockId;
+    loc:   source.SrcLoc;
 }
 
 # construct a builder positioned on a module with no current function
@@ -51,22 +58,42 @@ pub rec Builder {
 # The caller must `set_function` and `set_block` before emitting.
 # ---
 # m:   the module to build into
-# ret: a Builder with fn = nil and a BLOCK_NIL block cursor
+# ret: a Builder with fn = nil, a BLOCK_NIL block cursor, and an empty loc cursor
 pub fun init(m: *ir.Module) Builder {
     var b: Builder;
     b.m     = m;
     b.fn    = nil;
     b.block = id.BLOCK_NIL;
+    b.loc   = source.loc_nil();
     ret b;
 }
 
-# move the cursor to a function, clearing the block cursor
+# move the cursor to a function, clearing the block and location cursors
 # ---
 # b:  the builder
 # fn: the function to emit into
 pub fun set_function(b: *Builder, fn: *ir.Function) {
     b.fn    = fn;
     b.block = id.BLOCK_NIL;
+    b.loc   = source.loc_nil();
+}
+
+# set the current debug-location cursor stamped onto subsequently emitted
+# instructions; the frontend updates it per statement / expression
+# ---
+# b:   the builder
+# loc: the source location to stamp
+pub fun set_loc(b: *Builder, loc: source.SrcLoc) {
+    b.loc = loc;
+}
+
+# read the current debug-location cursor, so a caller can save and later restore
+# it around a nested lowering
+# ---
+# b:   the builder
+# ret: the current location cursor
+pub fun current_loc(b: *Builder) source.SrcLoc {
+    ret b.loc;
 }
 
 # move the cursor to a block within the current function
@@ -1038,6 +1065,7 @@ fun pool_append(b: *Builder, k: instruction.InstrKind, ty: type.IrTypeId, operan
     ins.operand_cap   = operand_count;          # `operands` is allocated to exactly this many here
     ins.flags         = 0;
     ins.aux_ty        = type.IRT_NIL;
+    ins.loc           = b.loc;                   # stamp the current debug-location cursor
     ret ir.instruction_add(b.m, b.fn, ins);
 }
 
@@ -1084,4 +1112,48 @@ fun void_type(b: *Builder) R.Result[type.IrTypeId, str] {
 # ret: the pointer IrTypeId, or an error
 fun ptr_type(b: *Builder) R.Result[type.IrTypeId, str] {
     ret type.intern_ptr(?b.m.types);
+}
+
+# pool_append stamps the builder's current debug-location cursor onto every
+# emitted instruction, and set_function resets the cursor so a fresh function
+# begins unlocated (FILE_NIL) rather than inheriting the previous one's location
+test "mach.lang.me.ir.builder.pool_append:stamps_loc_cursor" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+
+    val res_m: R.Result[ir.Module, str] = ir.init(?alloc, intern.STR_NIL);
+    if (R.is_err[ir.Module, str](res_m)) { ret 1; }
+    var m: ir.Module = R.unwrap_ok[ir.Module, str](res_m);
+
+    val res_i64: R.Result[type.IrTypeId, str] = type.intern_int(?m.types, 64);
+    if (R.is_err[type.IrTypeId, str](res_i64)) { ret 1; }
+    val i64t: type.IrTypeId = R.unwrap_ok[type.IrTypeId, str](res_i64);
+
+    val res_fn: R.Result[u32, str] = ir.function_add(?m, intern.STR_NIL, type.IRT_NIL, 0);
+    if (R.is_err[u32, str](res_fn)) { ret 1; }
+    val fn: *ir.Function = ?m.functions[R.unwrap_ok[u32, str](res_fn)];
+
+    var b: Builder = init(?m);
+    set_function(?b, fn);
+    val res_blk: R.Result[id.BlockId, str] = new_block(?b);
+    if (R.is_err[id.BlockId, str](res_blk)) { ret 1; }
+    set_block(?b, R.unwrap_ok[id.BlockId, str](res_blk));
+
+    # an instruction emitted under a set cursor carries that exact location
+    set_loc(?b, source.loc(7, 42));
+    val res_add: R.Result[value.Value, str] = emit_add(?b, value.const_int(1, i64t), value.const_int(2, i64t));
+    if (R.is_err[value.Value, str](res_add)) { ret 1; }
+    val add_id: id.InstructionId = R.unwrap_ok[value.Value, str](res_add).data.instr;
+    if (fn.instrs[add_id::u32].loc.file != 7)    { ret 1; }
+    if (fn.instrs[add_id::u32].loc.offset != 42) { ret 1; }
+
+    # set_function resets the cursor: a new function starts unlocated
+    val res_fn2: R.Result[u32, str] = ir.function_add(?m, intern.STR_NIL, type.IRT_NIL, 0);
+    if (R.is_err[u32, str](res_fn2)) { ret 1; }
+    val fn2: *ir.Function = ?m.functions[R.unwrap_ok[u32, str](res_fn2)];
+    set_function(?b, fn2);
+    if (source.loc_is_valid(current_loc(?b))) { ret 1; }
+
+    ir.dnit(?m);
+    ret 0;
 }

--- a/src/lang/me/ir/instruction.mach
+++ b/src/lang/me/ir/instruction.mach
@@ -23,6 +23,8 @@ use std.types.bool.bool;
 use std.types.bool.false;
 use std.types.bool.true;
 
+use mach.lang.source;
+
 use ir_type: mach.lang.me.ir.type;
 use mach.lang.me.ir.value;
 
@@ -172,6 +174,10 @@ pub val INSTR_FLAG_VOLATILE: u16 = 0x08;
 #                OP_ALLOCA it is the allocated element type sizing the stack slot
 #                (its result type and Value are the IRT_PTR). IRT_NIL for every
 #                other opcode.
+# loc:           source location (file + byte offset) this instruction lowered
+#                from, stamped by the builder from its debug-location cursor. pure
+#                debug metadata: it never influences emitted code, and is FILE_NIL
+#                for compiler-synthesized instructions with no source origin.
 pub rec Instruction {
     kind:          InstrKind;
     ty:            ir_type.IrTypeId;
@@ -180,6 +186,7 @@ pub rec Instruction {
     operand_cap:   u32;
     flags:         u16;
     aux_ty:        ir_type.IrTypeId;
+    loc:           source.SrcLoc;
 }
 
 # true when the opcode ends a block (BR/CBR/RET/UNREACHABLE)

--- a/src/lang/me/lower/decl.mach
+++ b/src/lang/me/lower/decl.mach
@@ -232,6 +232,10 @@ pub fun lower_pack_instance(ctx: *context.LowerContext, did: id.DeclId, d: *decl
     if (R.is_err[ir.BlockId, str](res_entry)) { ret R.err[bool, str](R.unwrap_err[ir.BlockId, str](res_entry)); }
     builder.set_block(?ctx.builder, R.unwrap_ok[ir.BlockId, str](res_entry));
 
+    # stamp the pack instance's prologue with its declaration location; the body
+    # overrides this per statement.
+    builder.set_loc(?ctx.builder, source.loc(ctx.a.file_id, d.span.offset));
+
     val res_params: R.Result[bool, str] = lower_pack_params(ctx, did, d, fn_index, fixed_count, types, type_len);
     if (R.is_err[bool, str](res_params)) { clear_pack_state(ctx); ret res_params; }
 
@@ -405,6 +409,10 @@ fun emit_function_body(ctx: *context.LowerContext, did: id.DeclId, d: *decl.Decl
     val res_entry: R.Result[ir.BlockId, str] = builder.new_block(?ctx.builder);
     if (R.is_err[ir.BlockId, str](res_entry)) { ret R.err[bool, str](R.unwrap_err[ir.BlockId, str](res_entry)); }
     builder.set_block(?ctx.builder, R.unwrap_ok[ir.BlockId, str](res_entry));
+
+    # stamp prologue instructions (parameter homing, the default terminator) with
+    # the function's own location; the body then overrides this per statement.
+    builder.set_loc(?ctx.builder, source.loc(ctx.a.file_id, d.span.offset));
 
     val res_params: R.Result[bool, str] = lower_params(ctx, did, d, fn_index);
     if (R.is_err[bool, str](res_params)) { ret res_params; }
@@ -761,6 +769,10 @@ fun emit_test_body(ctx: *context.LowerContext, d: *decl.Decl, fn_index: u32, ret
     val res_entry: R.Result[ir.BlockId, str] = builder.new_block(?ctx.builder);
     if (R.is_err[ir.BlockId, str](res_entry)) { ret R.err[bool, str](R.unwrap_err[ir.BlockId, str](res_entry)); }
     builder.set_block(?ctx.builder, R.unwrap_ok[ir.BlockId, str](res_entry));
+
+    # stamp the test body's prologue and default terminator with its declaration
+    # location; the body overrides this per statement.
+    builder.set_loc(?ctx.builder, source.loc(ctx.a.file_id, d.span.offset));
 
     if (d.data.test_.body != id.STMT_NIL) {
         val res_body: R.Result[bool, str] = stmt.lower_stmt(ctx, d.data.test_.body);

--- a/src/lang/me/lower/expr.mach
+++ b/src/lang/me/lower/expr.mach
@@ -57,6 +57,13 @@ pub fun lower_rvalue(ctx: *context.LowerContext, eid: id.ExprId) R.Result[value.
         ret R.err[value.Value, str]("lower: expression id out of range");
     }
     val e: *expr.Expr    = O.unwrap[*expr.Expr](opt_e);
+
+    # point the debug-location cursor at this expression, restoring the caller's on
+    # exit so a subexpression never leaks its location to the enclosing operation.
+    val saved_loc: source.SrcLoc = builder.current_loc(?ctx.builder);
+    builder.set_loc(?ctx.builder, source.loc(ctx.a.file_id, e.span.offset));
+    fin { builder.set_loc(?ctx.builder, saved_loc); }
+
     val k: expr.ExprKind = e.kind;
 
     if (k == expr.EXPR_KIND_LIT_INT)        { ret lower_lit_int(ctx, eid, e); }
@@ -94,6 +101,13 @@ pub fun lower_lvalue(ctx: *context.LowerContext, eid: id.ExprId) R.Result[value.
         ret R.err[value.Value, str]("lower: lvalue id out of range");
     }
     val e: *expr.Expr    = O.unwrap[*expr.Expr](opt_e);
+
+    # point the debug-location cursor at this expression, restoring the caller's on
+    # exit so a subexpression never leaks its location to the enclosing operation.
+    val saved_loc: source.SrcLoc = builder.current_loc(?ctx.builder);
+    builder.set_loc(?ctx.builder, source.loc(ctx.a.file_id, e.span.offset));
+    fin { builder.set_loc(?ctx.builder, saved_loc); }
+
     val k: expr.ExprKind = e.kind;
 
     if (k == expr.EXPR_KIND_IDENT)   { ret lower_ident_lvalue(ctx, eid); }

--- a/src/lang/me/lower/stmt.mach
+++ b/src/lang/me/lower/stmt.mach
@@ -40,6 +40,7 @@ use ir_type: mach.lang.me.ir.type;
 use mach.lang.me.ir.value;
 use mach.lang.me.lower.context;
 use mach.lang.me.lower.expr;
+use mach.lang.source;
 use mach.lang.type;
 
 # initial / doubling capacity for an inline-asm body's `{name}` binding array
@@ -56,6 +57,13 @@ pub fun lower_stmt(ctx: *context.LowerContext, sid: id.StmtId) R.Result[bool, st
         ret R.err[bool, str]("lower: statement id out of range");
     }
     val s: *stmt.Stmt     = O.unwrap[*stmt.Stmt](opt_stmt);
+
+    # point the debug-location cursor at this statement, restoring the caller's on
+    # exit so a nested statement never leaks its location to the enclosing scope.
+    val saved_loc: source.SrcLoc = builder.current_loc(?ctx.builder);
+    builder.set_loc(?ctx.builder, source.loc(ctx.a.file_id, s.span.offset));
+    fin { builder.set_loc(?ctx.builder, saved_loc); }
+
     val k: stmt.StmtKind  = s.kind;
 
     if (k == stmt.STMT_KIND_EXPR)          { ret lower_expr_stmt(ctx, s); }

--- a/src/lang/me/pass/inline.mach
+++ b/src/lang/me/pass/inline.mach
@@ -34,6 +34,7 @@ use mach.lang.me.ir.id;
 use mach.lang.me.ir.instruction;
 use mach.lang.me.ir.type;
 use mach.lang.me.ir.value;
+use mach.lang.source;
 use mach.lang.target;
 
 # instruction-count ceiling below which a callee is small enough to inline
@@ -597,6 +598,7 @@ fun clone_instructions(cx: *InlineCtx) R.Result[bool, str] {
         clone.operand_count = src.operand_count;
         clone.flags         = src.flags;
         clone.aux_ty        = src.aux_ty;        # preserve GEP source pointee type
+        clone.loc           = src.loc;           # a faithful clone carries the source location
         clone.operands      = nil;
         if (src.operand_count > 0) {
             val res_ops: R.Result[*value.Value, str] = A.allocate[value.Value](m.alloc, src.operand_count::usize);
@@ -852,6 +854,7 @@ fun emit_br(cx: *InlineCtx, target_blk: id.BlockId) R.Result[id.InstructionId, s
     br.operand_count = 1;
     br.flags         = 0;
     br.aux_ty        = type.IRT_NIL;
+    br.loc           = source.loc_nil();     # synthesized control-flow edge, no source origin
     val res_id: R.Result[id.InstructionId, str] = ir.instruction_add(m, cx.caller, br);
     if (R.is_err[id.InstructionId, str](res_id)) {
         A.deallocate[value.Value](m.alloc, ops, 1::usize);
@@ -894,6 +897,7 @@ fun finish_returns(cx: *InlineCtx, call_id: id.InstructionId) R.Result[bool, str
         phi.operand_count = 0;
         phi.flags         = 0;
         phi.aux_ty        = type.IRT_NIL;
+        phi.loc           = source.loc_nil();    # synthesized result join, no source origin
         val res_phi: R.Result[id.InstructionId, str] = ir.instruction_add(m, caller, phi);
         if (R.is_err[id.InstructionId, str](res_phi)) {
             ret R.err[bool, str](R.unwrap_err[id.InstructionId, str](res_phi));

--- a/src/lang/me/pass/mem2reg.mach
+++ b/src/lang/me/pass/mem2reg.mach
@@ -31,6 +31,7 @@ use mach.lang.me.ir.id;
 use mach.lang.me.ir.instruction;
 use mach.lang.me.ir.type;
 use mach.lang.me.ir.value;
+use mach.lang.source;
 
 # sentinel marking an unprocessed entry in a u32 work array (idom / rpo index /
 # alloca lookup)
@@ -974,6 +975,7 @@ fun place_phi(st: *State, bid: id.BlockId, alloca_id: id.InstructionId) R.Result
     phi.operand_count = 0;
     phi.flags         = 0;
     phi.aux_ty        = type.IRT_NIL;
+    phi.loc           = source.loc_nil();    # synthesized SSA join, no single source location
 
     val res_id: R.Result[id.InstructionId, str] = ir.instruction_add(st.m, st.fn, phi);
     if (R.is_err[id.InstructionId, str](res_id)) {

--- a/src/lang/source.mach
+++ b/src/lang/source.mach
@@ -29,6 +29,49 @@ use mach.lang.query;
 # stable handle into a SourceMap's file array
 pub def FileId: u32;
 
+# sentinel FileId naming no source file, carried by a synthesized or as-yet-unset
+# location. distinct from every real FileId, which the SourceMap assigns from 0
+pub val FILE_NIL: FileId = 0xFFFFFFFF;
+
+# a source location: a file handle plus a byte offset into that file's text
+#
+# The offset resolves to a 1-based line/column via `position` on the named file.
+# A loc whose file is FILE_NIL has no source origin (compiler-synthesized IR).
+# ---
+# file:   owning source file, or FILE_NIL when unknown
+# offset: byte offset into the file's text
+pub rec SrcLoc {
+    file:   FileId;
+    offset: usize;
+}
+
+# construct a source location from a file handle and a byte offset
+# ---
+# file:   the owning source file
+# offset: byte offset into the file's text
+# ret:    the SrcLoc
+pub fun loc(file: FileId, offset: usize) SrcLoc {
+    var l: SrcLoc;
+    l.file   = file;
+    l.offset = offset;
+    ret l;
+}
+
+# the empty source location, naming no file
+# ---
+# ret: a SrcLoc whose file is FILE_NIL
+pub fun loc_nil() SrcLoc {
+    ret loc(FILE_NIL, 0);
+}
+
+# whether a location names a real source file (not FILE_NIL)
+# ---
+# l:   the location to test
+# ret: true when l.file is not FILE_NIL
+pub fun loc_is_valid(l: SrcLoc) bool {
+    ret l.file != FILE_NIL;
+}
+
 # a 1-based line and column within a source file
 # ---
 # line: line number, 1-based
@@ -497,6 +540,39 @@ test "mach.lang.source.update:revision_cutoff_on_identical_text" {
 
     dnit(?m);
     intern.dnit(?ix);
+    query.dnit(?db);
+    ret 0;
+}
+
+# a SrcLoc's byte offset round-trips to a 1-based line/column via position, the
+# nil location is distinguishable from a real one, and loc preserves its fields
+test "mach.lang.source.srcloc:offset_roundtrips_to_line_col" {
+    var a: A.Allocator;
+    page.make(?a);
+
+    val res_db: R.Result[query.QueryDb, str] = query.init(?a);
+    if (R.is_err[query.QueryDb, str](res_db)) { ret 1; }
+    var db: query.QueryDb = R.unwrap_ok[query.QueryDb, str](res_db);
+    var m:  SourceMap     = init(?a);
+
+    val res_fid: R.Result[FileId, str] = add(?m, ?db, "p.mach", "ab\ncde\nf");
+    if (R.is_err[FileId, str](res_fid)) { ret 1; }
+    val fid: FileId = R.unwrap_ok[FileId, str](res_fid);
+
+    # a real location names its file and preserves its offset; the nil one does not
+    val l: SrcLoc = loc(fid, 4);
+    if (!loc_is_valid(l))        { ret 1; }
+    if (l.file != fid)           { ret 1; }
+    if (l.offset != 4)           { ret 1; }
+    if (loc_is_valid(loc_nil())) { ret 1; }
+
+    # offset 4 ('d' on the second line of "ab\ncde\nf") is line 2, column 2
+    val file: *SourceFile = ?m.files[fid::usize];
+    val p: Position = position(file, l.offset);
+    if (p.line != 2) { ret 1; }
+    if (p.col != 2)  { ret 1; }
+
+    dnit(?m);
     query.dnit(?db);
     ret 0;
 }


### PR DESCRIPTION
Closes #1689. First landable slice of the debug-info foundation epic #1688.

## What

- **`source.SrcLoc`** — a shared `(FileId, offset)` location primitive with a `FILE_NIL` sentinel and `loc` / `loc_nil` / `loc_is_valid` helpers. Format- and ISA-agnostic; the later MIR loc + PC↔line tables (#1691) reuse it.
- **`Instruction.loc`** — an additive `SrcLoc` field on the IR instruction record. Pure debug metadata: never read by codegen, `FILE_NIL` for compiler-synthesized instructions.
- **Builder debug-location cursor** — a `loc` cursor on `Builder`, an LLVM-IRBuilder-style `set_loc` / `current_loc`, reset to `FILE_NIL` on `set_function`, and stamped onto every instruction in `pool_append`. No span argument is added to any `emit_*`.
- **Lowering sets the cursor** — `me/lower/{stmt,expr,decl}` point the cursor at each statement / expression / function from the AST node's `.span` and `ctx.a.file_id`. `stmt`/`expr` save and `fin`-restore the cursor so a subexpression never leaks its location to the enclosing operation (correct per-operation attribution).
- **Pass hygiene** — inline's cloned instructions faithfully carry their source loc; genuinely synthesized nodes (inline continuation br / result phi, mem2reg SSA-join phis) are `FILE_NIL`. (Loc *survival* through the optimizer is #1690/#1696; this only avoids leaving the new field at a misleading default.)

## Invariant: byte-identical without `-g`

There is no `-g` surface yet, so the entire change must be output-preserving. The IR printer/verifier need no change — `loc` is inert metadata with no textual surface, so IR dumps stay byte-identical.

Verification (dev-baseline compiler vs this branch, both from source via the release seed, compiling the identical pristine dev tree):

- **Byte-identical emitted output on all six shipped targets** — linux-x86_64, linux-arm64, linux-riscv64, windows-x86_64, darwin-x86_64, darwin-aarch64 all `cmp`-identical.
- **Self-host fixpoint converges** (b == c) on the branch.
- **Unit suite: 503 passed, 0 failed** (dev baseline 501; +2 are the two tests added here: `me.ir.builder` cursor-stamping and `source.srcloc` round-trip).
- **int harness green** on the linux leg (all surface + regression cases, debug and release).
