### PR TITLE
fix(link): require #[library] attribution for dynamic imports on two-level-namespace formats

### DIFF
--- a/int/lib/produce.sh
+++ b/int/lib/produce.sh
@@ -20,6 +20,10 @@
 #                 for a cross-built target with no host runner (a freestanding
 #                 aarch64/riscv64 image on the x86_64 leg). the observable is a
 #                 constant, so the golden is the fact "it emitted".
+#
+# build-fails is a run-mode but not a producer: it asserts the compile is REJECTED
+# and takes the compiler's 'error:' diagnostic as the observable. it is handled in
+# run.sh (there is no artifact to run), noted here for discoverability.
 
 # the directory this file lives in (int/lib), used to find flat_loader.c. resolved
 # from the sourced path so it does not depend on run.sh's variables.

--- a/int/run.sh
+++ b/int/run.sh
@@ -196,25 +196,52 @@ for dir in "$here"/surface/$filter "$here"/regression/$filter; do
             fi
         fi
 
-        if ! (cd "$dir" && "$compiler" dep pull && $buildcc build . --target "$build_target" --profile "$profile" $case_build_flags -o "$relbin") >"$tmp/build.log" 2>&1; then
-            echo "FAIL $label (build)"
-            sed 's/^/    /' "$tmp/build.log" >&2
-            fails=$((fails + 1))
-            rm -rf "$tmp" "$dir/out/int"
-            continue
+        if (cd "$dir" && "$compiler" dep pull && $buildcc build . --target "$build_target" --profile "$profile" $case_build_flags -o "$relbin") >"$tmp/build.log" 2>&1; then
+            build_ok=1
+        else
+            build_ok=0
         fi
 
-        if produce "$case_run" "$runmode" "$target" "$bin" >"$tmp/out.txt" 2>"$tmp/err.txt"; then
-            prc=0
+        # a build-fails case asserts the compile is rejected and takes the compiler's
+        # 'error:' diagnostic as its observable (deterministic: no paths, just the
+        # message text). every other mode requires a clean build and runs a producer
+        # on the artifact.
+        if [ "$case_run" = build-fails ]; then
+            if [ "$build_ok" -eq 1 ]; then
+                echo "FAIL $label (build succeeded; expected a link error)"
+                fails=$((fails + 1))
+                rm -rf "$tmp" "$dir/out/int"
+                continue
+            fi
+            grep '^error:' "$tmp/build.log" >"$tmp/out.txt" || true
+            if [ ! -s "$tmp/out.txt" ]; then
+                echo "FAIL $label (build failed without an 'error:' diagnostic)"
+                sed 's/^/    /' "$tmp/build.log" >&2
+                fails=$((fails + 1))
+                rm -rf "$tmp" "$dir/out/int"
+                continue
+            fi
         else
-            prc=$?
-        fi
-        if [ "$prc" -ne 0 ]; then
-            echo "FAIL $label (producer exit $prc)"
-            sed 's/^/    /' "$tmp/err.txt" >&2
-            fails=$((fails + 1))
-            rm -rf "$tmp" "$dir/out/int"
-            continue
+            if [ "$build_ok" -eq 0 ]; then
+                echo "FAIL $label (build)"
+                sed 's/^/    /' "$tmp/build.log" >&2
+                fails=$((fails + 1))
+                rm -rf "$tmp" "$dir/out/int"
+                continue
+            fi
+
+            if produce "$case_run" "$runmode" "$target" "$bin" >"$tmp/out.txt" 2>"$tmp/err.txt"; then
+                prc=0
+            else
+                prc=$?
+            fi
+            if [ "$prc" -ne 0 ]; then
+                echo "FAIL $label (producer exit $prc)"
+                sed 's/^/    /' "$tmp/err.txt" >&2
+                fails=$((fails + 1))
+                rm -rf "$tmp" "$dir/out/int"
+                continue
+            fi
         fi
 
         if [ "$bless" -eq 1 ]; then

--- a/int/surface/pe-import-attribution/case.conf
+++ b/int/surface/pe-import-attribution/case.conf
@@ -1,0 +1,6 @@
+# an unattributed dynamic import must be rejected on a two-level-namespace (PE)
+# target (#1800). cross-build the win64 PE on the linux leg and capture the link
+# diagnostic as the observable; no windows runner is needed.
+run: build-fails
+targets: linux
+build-target: windows

--- a/int/surface/pe-import-attribution/expect.windows.txt
+++ b/int/surface/pe-import-attribution/expect.windows.txt
@@ -1,0 +1,1 @@
+error: dynamic import 'some_unattributed_import' has no #[library] attribution; a two-level-namespace target requires every import to name its providing library — annotate the declaration with #[library("...")]; candidate libraries: kernel32.dll

--- a/int/surface/pe-import-attribution/mach.toml
+++ b/int/surface/pe-import-attribution/mach.toml
@@ -1,0 +1,25 @@
+[project]
+id      = "case"
+name    = "case"
+version = "0.0.0"
+src     = "src"
+target  = "windows"
+out     = "out/{target}/{profile}/bin/{name}{ext}"
+
+[target.windows]
+isa = "x86_64"
+os  = "windows"
+abi = "win64"
+ext = ".exe"
+
+[profile.debug]
+opt = 0
+
+[profile.release]
+opt = 2
+
+[os.windows]
+libs = ["kernel32.dll"]
+
+[bin.case]
+entry = "main.mach"

--- a/int/surface/pe-import-attribution/src/main.mach
+++ b/int/surface/pe-import-attribution/src/main.mach
@@ -1,0 +1,15 @@
+# a PE program whose only unattributed dynamic import must be rejected by the
+# linker: on a two-level namespace every import must name its providing library
+# (#1800). ExitProcess is pinned, so the single unattributed symbol is the only
+# link error. the build-fails harness mode captures the diagnostic host-side.
+#[library("kernel32.dll")]
+ext fun ExitProcess(code: u32);
+
+# deliberately missing a #[library] attribution.
+ext fun some_unattributed_import();
+
+#[symbol("mainCRTStartup")]
+pub fun _start() {
+    some_unattributed_import();
+    ExitProcess(0);
+}

--- a/src/lang/be/linker.mach
+++ b/src/lang/be/linker.mach
@@ -1659,14 +1659,20 @@ fun build_dynamic_info(s: *session.Session, tgt: *target.Target, dyn: *DynState,
             val idx: u32 = dyn.info.import_count;
             dyn.info.imports[idx].symbol    = sym.name;
             # pin the import to the library a `$<sym>.library` directive named, when
-            # present; an unattributed import stays DYNLIB_ANY. a directive naming a
-            # library not among this link's dependencies is a hard error.
+            # present. a directive naming a library not among this link's
+            # dependencies is a hard error. an unattributed import stays DYNLIB_ANY
+            # on a flat-namespace format (ELF), but is a hard error on a two-level
+            # namespace (PE, Mach-O) where the image must name a providing library
+            # per import.
             val lib_opt: O.Option[intern.StrId] = session.import_library(s, sym.name);
             if (O.is_some[intern.StrId](lib_opt)) {
                 val want: intern.StrId = O.unwrap[intern.StrId](lib_opt);
                 val li_opt: O.Option[u32] = soname_index_of(sonames, soname_count, want);
                 if (!O.is_some[u32](li_opt)) { ret R.err[bool, str](pinned_lib_message(s, sym.name, want)); }
                 dyn.info.imports[idx].lib_index = O.unwrap[u32](li_opt);
+            }
+            or (tgt.of.two_level_namespace) {
+                ret R.err[bool, str](unattributed_import_message(s, sym.name, sonames, soname_count));
             }
             or {
                 dyn.info.imports[idx].lib_index = of.DYNLIB_ANY;
@@ -2479,6 +2485,56 @@ fun pinned_lib_message(s: *session.Session, sym_name: intern.StrId, lib: intern.
         ret join3(s, pre, O.unwrap[str](lno), "' not among the link's dependencies", "import pinned to unknown library");
     }
     ret "import pinned to a library not among the link's dependencies";
+}
+
+# build the diagnostic for a dynamic import with no `#[library]` attribution on a
+# two-level-namespace format (PE, Mach-O), where the image must name a providing
+# library per import. names the symbol, points at `#[library]`, and lists the
+# link's dependency sonames as the candidate libraries to attribute to. degrades
+# to a symbol-less form when the name cannot be resolved.
+# ---
+# s:            shared session holding the interner
+# sym_name:     interned name of the unattributed import
+# sonames:      the link's dependency soname list (candidate libraries)
+# soname_count: number of dependencies
+# ret:          the diagnostic string
+fun unattributed_import_message(s: *session.Session, sym_name: intern.StrId,
+                                sonames: *intern.StrId, soname_count: u32) str {
+    val sno: O.Option[str] = intern.lookup(?s.interner, sym_name);
+    if (!O.is_some[str](sno)) {
+        ret "dynamic import has no #[library] attribution; a two-level-namespace target requires every import to name its providing library with #[library(\"...\")]";
+    }
+    val head: str = join3(s, "dynamic import '", O.unwrap[str](sno),
+        "' has no #[library] attribution; a two-level-namespace target requires every import to name its providing library — annotate the declaration with #[library(\"...\")]",
+        "dynamic import has no #[library] attribution");
+    val cands: str = join_sonames(s, sonames, soname_count);
+    if (str_len(cands) == 0) { ret head; }
+    val pre: str = join2(s, head, "; candidate libraries: ", head);
+    ret join2(s, pre, cands, pre);
+}
+
+# join a link's dependency sonames into a "a, b, c" list for a diagnostic. an
+# unresolvable name is skipped; the empty list yields the empty string.
+# ---
+# s:            shared session (allocator, interner)
+# sonames:      the dependency soname list
+# soname_count: number of dependencies
+# ret:          the comma-separated soname list, or "" when none resolve
+fun join_sonames(s: *session.Session, sonames: *intern.StrId, soname_count: u32) str {
+    var acc: str = "";
+    var i: u32 = 0;
+    for (i < soname_count) {
+        val nm: O.Option[str] = intern.lookup(?s.interner, sonames[i]);
+        if (!O.is_some[str](nm)) { i = i + 1; cnt; }
+        val piece: str = O.unwrap[str](nm);
+        if (str_len(acc) == 0) { acc = piece; }
+        or {
+            val sep: str = join2(s, acc, ", ", acc);
+            acc = join2(s, sep, piece, sep);
+        }
+        i = i + 1;
+    }
+    ret acc;
 }
 
 # build the "relocation '<kind>' to '<sym>' overflows" diagnostic

--- a/src/lang/target/of.mach
+++ b/src/lang/target/of.mach
@@ -501,17 +501,25 @@ val OF_ISA_MAX: u32 = 8;
 # covers_isa_any: true for an isa-agnostic flat image (no machine relocation
 #                 types, e.g. raw), which covers every instruction set regardless
 #                 of `covers_isas`
+# two_level_namespace: true when the format resolves dynamic imports through a
+#                 two-level namespace — each import physically names its providing
+#                 library in the image (PE's import directory, Mach-O's dyld bind).
+#                 the linker requires every dynamic import to carry a `#[library]`
+#                 attribution on such a format, since `DYNLIB_ANY` has no meaning
+#                 there. false for a flat global namespace (ELF), where an
+#                 unattributed import is resolved by the loader's global search
 pub rec OfVTable {
-    id:               u32;
-    name:             str;
-    produces_image:   bool;
-    emit_object:      WriterFn;
-    parse_object:     ParserFn;
-    emit_exec:        ExecFn;
-    emit_dyn_exec:    DynExecFn;
-    covers_isas:      [OF_ISA_MAX]u32;
-    covers_isa_count: u32;
-    covers_isa_any:   bool;
+    id:                  u32;
+    name:                str;
+    produces_image:      bool;
+    emit_object:         WriterFn;
+    parse_object:        ParserFn;
+    emit_exec:           ExecFn;
+    emit_dyn_exec:       DynExecFn;
+    covers_isas:         [OF_ISA_MAX]u32;
+    covers_isa_count:    u32;
+    covers_isa_any:      bool;
+    two_level_namespace: bool;
 }
 
 # maximum number of object-format implementations an OfRegistry holds

--- a/src/lang/target/of/coff.mach
+++ b/src/lang/target/of/coff.mach
@@ -2895,6 +2895,10 @@ pub fun register_coff(reg: *of.OfRegistry) R.Result[bool, str] {
     coff_vtable.emit_exec        = coff_emit_exec;
     coff_vtable.emit_dyn_exec    = coff_emit_dyn_exec;
 
+    # PE resolves imports through a two-level namespace: the import directory
+    # names a providing DLL per import, so every dynamic import must be attributed.
+    coff_vtable.two_level_namespace = true;
+
     # the COFF relocation mapping and writer cover x86-64 only today.
     coff_vtable.covers_isa_any   = false;
     coff_vtable.covers_isa_count = 0;

--- a/src/lang/target/of/elf.mach
+++ b/src/lang/target/of/elf.mach
@@ -1118,6 +1118,10 @@ pub fun register(reg: *of.OfRegistry) R.Result[bool, str] {
     elf_vtable.emit_exec      = emit_exec;
     elf_vtable.emit_dyn_exec  = emit_dyn_exec;
 
+    # ELF has a flat global namespace: an unattributed import is resolved by the
+    # loader's global search, so no per-import library attribution is required.
+    elf_vtable.two_level_namespace = false;
+
     # elf relocates and writes for every isa with an `elf_reloc_type` map.
     elf_vtable.covers_isa_any   = false;
     elf_vtable.covers_isa_count = 0;

--- a/src/lang/target/of/macho.mach
+++ b/src/lang/target/of/macho.mach
@@ -1191,6 +1191,10 @@ pub fun register_macho(reg: *of.OfRegistry) R.Result[bool, str] {
     macho_vtable.emit_exec      = emit_exec;
     macho_vtable.emit_dyn_exec  = emit_dyn_exec;
 
+    # dyld resolves imports through a two-level namespace: each bind names its
+    # source dylib, so every dynamic import must be attributed (as on PE).
+    macho_vtable.two_level_namespace = true;
+
     # Mach-O relocates and writes for the two Apple-silicon-era isas.
     macho_vtable.covers_isa_any   = false;
     macho_vtable.covers_isa_count = 0;

--- a/src/lang/target/of/raw.mach
+++ b/src/lang/target/of/raw.mach
@@ -23,6 +23,7 @@ use std.filesystem;
 use std.memory;
 use std.types.bool.bool;
 use std.types.bool.true;
+use std.types.bool.false;
 use std.types.size.usize;
 use std.types.string.str;
 use std.types.string.str_contains;
@@ -227,6 +228,9 @@ pub fun register(reg: *of.OfRegistry) R.Result[bool, str] {
     raw_vtable.parse_object   = parse_object;
     raw_vtable.emit_exec      = emit_exec;
     raw_vtable.emit_dyn_exec  = emit_dyn_exec;
+
+    # a flat image has no dynamic-import namespace at all.
+    raw_vtable.two_level_namespace = false;
 
     # a flat image carries no machine relocation types, so it is isa-agnostic and
     # covers every instruction set with an encoder.


### PR DESCRIPTION
Closes #1800. Depends on mach-std#334 (merged; std pin bumped on dev in #1879).

## What

An `ext` import with no `#[library]` attribution reached the import plan as `DYNLIB_ANY`. On ELF that is a real concept — the loader's flat global namespace resolves it. On PE it is not: the two-level import directory names a providing DLL per import, so the COFF writer had to invent an answer for the sentinel and bound it to **dependency index 0** (`import_lib_of`). That is correct only while the providing DLL happens to sort first; the first mixed-DLL link (mach-std + a windowing dep's `glfw3.dll`) silently mis-binds one set and the loader rejects the exe with `STATUS_ENTRYPOINT_NOT_FOUND` — off the build host.

## Fix

Attribution becomes mandatory at the import-plan seam (`build_dynamic_info`) when the object format's namespace is two-level. An unattributed dynamic import is a hard link error naming the symbol, listing the link's dependency libraries, and pointing at `#[library]`:

```
error: dynamic import 'some_unattributed_import' has no #[library] attribution; a two-level-namespace target requires every import to name its providing library — annotate the declaration with #[library("...")]; candidate libraries: kernel32.dll
```

The gate is a self-reported `OfVTable.two_level_namespace` capability (COFF + Mach-O true; ELF + raw false) rather than a branch on format id, so Mach-O inherits the rule for free when its dynamic imports land (#1176). ELF keeps `DYNLIB_ANY` unchanged.

## Verification

- **Self-host fixpoint**: gen2 == gen3 byte-identical.
- **Unit suite**: 501 passed, 0 failed — count-neutral vs pristine dev (501).
- **ELF byte-identical**: a fixed linux program built by the pristine-dev compiler and by this branch produces `cmp`-identical output (the ELF path is untouched).
- **int matrix (linux leg)**: all cases pass, including every ELF case (elf-pie, elf-relro, pie-reloc, pie-relro-fault), the macho-pie cross-builds (flag inert today, no regression), pe-aslr, and the new negative case. The windows/arm64/riscv64/darwin legs run in CI.
- **Negative test (falsifiable)**: `int/surface/pe-import-attribution` cross-builds a win64 PE with one unattributed import on the linux leg and diffs the link diagnostic. The pre-change linker binds it silently, so the case fails on baseline and passes here.
- **Positive**: pinning the same import links, and it lands under the named DLL even with that DLL placed last in `libs`.

## Harness

Adds a `build-fails` run-mode to the int harness: it asserts the compile is rejected and takes the compiler's `error:` line as the golden observable (deterministic — symbol + candidate libraries, no paths). Documented in `run.sh` and `produce.sh`.
