### PR TITLE
hotfix(link): honest PT_GNU_RELRO extent — arm64 PIE RELRO mprotect (#1885)

### DIFF
--- a/src/lang/target/of/elf.mach
+++ b/src/lang/target/of/elf.mach
@@ -1685,14 +1685,15 @@ fun write_pie_phdrs(buf: *u8, phdr_offset: usize, phdr_count: u32,
     # with relocated constants), when present. the region is mapped writable above for the
     # self-reloc; this header is the runtime's cue to re-protect it read-only (see the
     # `pie_seg_flags` contract). pure `.rodata` carries no base relocation, so it is never
-    # covered here and stays read-only from load. p_memsz is page-rounded so the runtime
-    # re-protects whole pages with no arithmetic of its own - safe because every merged
-    # kind starts on a fresh page (assign_section_vaddrs), so the next segment begins where
-    # this one ends.
+    # covered here and stays read-only from load. p_memsz is the segment's actual extent,
+    # NOT rounded to the image max-page: a max-page larger than the runtime page (a 64 KiB
+    # aarch64 image on a 4 KiB kernel) would overshoot the mapping, and the runtime's
+    # re-protect would fault ENOMEM (briar-systems/mach#1885). the runtime rounds this
+    # extent up to the runtime page (AT_PAGESZ) - the pages the kernel actually mapped.
     val relro_seg: i64 = pie_relro_seg(segs, seg_count, dyn);
     if (relro_seg >= 0) {
         val ri: u32 = relro_seg::u32;
-        val relro_size: usize = bin.align_up(segs[ri].memsz, page_size::usize);
+        val relro_size: usize = segs[ri].memsz;
         pos = write_phdr(buf, pos, PT_GNU_RELRO, PF_R, seg_offsets[ri], segs[ri].vaddr,
                          relro_size, relro_size, 1);
     }
@@ -4270,7 +4271,7 @@ test "mach.lang.target.of.elf.emit_pie_exec:relro_splits_rodata_from_rel_ro" {
     var bad: bool = false;
 
     # walk the program headers: exactly one PT_GNU_RELRO, spanning the rel.ro segment
-    # (vaddr 0x404000, page-rounded memsz), read-only. pure `.rodata` at 0x402000 must be
+    # (vaddr 0x404000, its actual 16-byte memsz), read-only. pure `.rodata` at 0x402000 must be
     # R at load and uncovered; the writable segment at 0x403000 stays R+W and uncovered;
     # the rel.ro load segment at 0x404000 is force-mapped R+W (the self-reloc precondition).
     val e_phoff: usize = bin.read_u64_le(buf.data, 32)::usize;
@@ -4293,8 +4294,10 @@ test "mach.lang.target.of.elf.emit_pie_exec:relro_splits_rodata_from_rel_ro" {
             relro_vaddr = pvaddr;
             if (pflags != PF_R)            { bad = true; }
             if (pvaddr != 0x404000)        { bad = true; }
-            if (pfilesz != 4096) { bad = true; }
-            if (pmemsz != 4096)  { bad = true; }
+            # p_memsz is the rel.ro segment's actual extent (16 bytes here), NOT rounded to
+            # the page; the runtime rounds it up to AT_PAGESZ (mach#1885).
+            if (pfilesz != 16) { bad = true; }
+            if (pmemsz != 16)  { bad = true; }
         }
         if (pt == PT_LOAD && pvaddr == 0x402000) { rodata_load_flags = pflags; }
         if (pt == PT_LOAD && pvaddr == 0x403000) { data_load_flags = pflags; }


### PR DESCRIPTION
Hotfix off **main (v2.14.0)** for the critical arm64 startup crash #1885. The runtime half (mach-std#360) is merged to mach-std dev+main and is the actual crash fix; this is the writer half — emit an honest PT_GNU_RELRO extent so the header matches what the runtime protects. Branched off main (not dev) so a v2.14.1 does not carry dev's debug-info work; targets main for the dual-merge.

## What

The PIE writer rounded `PT_GNU_RELRO` p_memsz up to the IMAGE max-page (64 KiB on aarch64, #1845). The kernel maps the tiny `.data.rel.ro` segment rounded to the RUNTIME page, so on a 4K/16K-page aarch64 kernel the declared region overshot the mapping and the (now-fatal, mach-std#347) re-protect faulted `ENOMEM` at startup. This emits p_memsz as the segment's **actual extent**; the runtime rounds it up to `AT_PAGESZ`.

The runtime fix (mach-std#360) alone repairs already-released v2.14.0 binaries on rebuild (it uses the `.data.rel.ro` PT_LOAD's mapped extent, robust to the over-rounded header); this writer change makes the header honest so the two agree.

## Verification

- Native arm64 (scratch CI, 4K-page runner), full fixed toolchain: `readelf GNU_RELRO MemSiz 0x10` (was 0x10000), `mprotect(…, 4096, PROT_READ) = 0` (was 65536 ENOMEM), exit 42 (was 133).
- `int linux-arm64` (native) green on the fixed stack (this branch's CI, pulling fixed mach-std main).
- self-host fixpoint byte-identical; unit suite 501/501 — `emit_pie_exec:relro_splits` updated to pin the actual extent, not page-rounded.

## Note on x86_64/riscv64

Behaviorally unaffected (int + fixpoint green; the runtime uses the PT_LOAD mapped extent regardless). The only change is the RELRO p_memsz **header field** (page-rounded → actual extent), per the actual-extent model. If strict byte-identity is preferred, the extent can round to the 4 KiB minimum page instead.
