### PR TITLE
feat(driver): profile `debug` key + -g flag + producer/comp_dir plumbing

### DIFF
--- a/doc/cli.md
+++ b/doc/cli.md
@@ -98,6 +98,7 @@ and nothing is linked.
 | `-O0`          | —              | force the debug pipeline (overrides `--release`) |
 | `-O1`          | —              | select the release pipeline |
 | `-O2`          | —              | select the release pipeline |
+| `-g`           | —              | emit debug info for this build, forcing the selected profile's `debug` on (precedence `-g` > profile > off) |
 | `--emit <kind>`| `obj`\|`exe`   | `obj` stops at the relocatable objects; `exe` (default) links a binary |
 | `--pie`        | —              | emit a position-independent (ET_DYN) executable for ASLR instead of the default fixed-address one; opt-in (see below) |
 | `-L <dir>`     | dir            | add a search directory for `-l`-resolved inputs; repeatable |

--- a/doc/manifest.md
+++ b/doc/manifest.md
@@ -53,12 +53,14 @@ entry = "hello_win.mach"   # overrides the artifact's entry for this target only
 libs  = ["user32.dll"]     # appended to the merged link overlay
 
 [profile.debug]            # a build variant
-opt = 0                    # 0 (no optimization) | 1 (standard) | 2 (aggressive)
+opt   = 0                  # 0 (no optimization) | 1 (standard) | 2 (aggressive)
+debug = true               # emit debug info for this profile (default false)
 
 [profile.release]
 opt      = 2
 emit_ir  = true            # emit per-module post-pipeline IR for this profile (default false)
 emit_asm = false           # emit per-module assembly for this profile (default false)
+debug    = false           # release-with-symbols: set true to keep debug info in a release profile
 
 [deps.mach-std]            # a dependency: exactly one of git|path, plus ref for git
 git = "https://github.com/briar-systems/mach-std"
@@ -145,11 +147,15 @@ toggles live here because they are variant concerns.
 | `opt`      | integer | — (debug) | Optimization level: `0` (no optimization beyond the always-on pipeline), `1` (standard), or `2` (aggressive). `1` and `2` currently select the same pass set; `2` is where future loop/vectorization work lands. Any other integer — or a non-integer — is a manifest error (`profile '<name>': opt must be 0, 1, or 2`). |
 | `emit_ir`  | bool    | `false` | Write per-module SSA IR dumps under the `ir` template for this profile — the final post-pipeline IR the object is built from, so it varies with `opt`. |
 | `emit_asm` | bool    | `false` | Write per-module assembly dumps under the `asm` template for this profile. |
+| `debug`    | bool    | `false` | Emit debug info (DWARF on ELF/Mach-O, CodeView on COFF) for this profile. Declare it once so a project ships symbols without passing a flag every build, or set it on a release profile for release-with-symbols. A non-boolean value is a manifest error (`profile '<name>': debug must be a boolean`). Gates emission only, never the optimizer. |
 
 A CLI `-O0` / `-O1` / `-O2` / `--release` flag overrides the selected profile's
 `opt` per invocation, and `--emit-ir` / `--emit-asm` / `--no-emit-ir` /
-`--no-emit-asm` override the emission toggles. Absent `--profile`/`--release`, the
-first declared profile is used; with no profile declared, a `debug` default (no
+`--no-emit-asm` override the emission toggles. A CLI `-g` forces `debug` on for one
+invocation regardless of the selected profile's key (precedence `-g` > profile >
+off); there is no flag to force it off over a `debug = true` profile — edit the
+manifest or select another profile. Absent `--profile`/`--release`, the first
+declared profile is used; with no profile declared, a `debug` default (no
 optimization, no emission) applies.
 
 ## `[deps.<alias>]`

--- a/src/cli/cmd/build.mach
+++ b/src/cli/cmd/build.mach
@@ -619,6 +619,19 @@ fun build_unit(a: *A.Allocator, argc: usize, argv: **u8, marks: *bool, emit_obj:
     }
     var p: driver.Project = R.unwrap_ok[driver.Project, str](res_project);
 
+    # resolve debug-info intent onto the session before the fingerprint is taken:
+    # `-g` forces it on over the selected profile's `debug` key. plumbs producer /
+    # comp_dir when on. a resolution failure skips the compile and reports exit 1.
+    var debug_ok: bool = true;
+    val res_debug: R.Result[bool, str] = resolve_debug(?p, config.g);
+    if (R.is_err[bool, str](res_debug)) {
+        print.eprint("error: ");
+        print.eprint(R.unwrap_err[bool, str](res_debug));
+        print.eprint("\n");
+        br.code = 1;
+        debug_ok = false;
+    }
+
     # fold the manifest default into the level: a CLI `-O*`/`--release` flag wins,
     # otherwise the selected profile's opt applies, else debug.
     val level: u8 = resolve_opt_level(?p, cli_level, cli_set);
@@ -632,7 +645,9 @@ fun build_unit(a: *A.Allocator, argc: usize, argv: **u8, marks: *bool, emit_obj:
     if (config.emit_ir)     { eff_emit_ir = true; }
     if (config.no_emit_ir)  { eff_emit_ir = false; }
 
-    br.code = compile_and_link(?p, level, emit_obj, test_mode, config.verify_ir, eff_emit_asm, eff_emit_ir, ?root[0], config.output, argc, argv, marks, ?br.output_path, tests_out, list_only);
+    if (debug_ok) {
+        br.code = compile_and_link(?p, level, emit_obj, test_mode, config.verify_ir, eff_emit_asm, eff_emit_ir, ?root[0], config.output, argc, argv, marks, ?br.output_path, tests_out, list_only);
+    }
 
     # close the readout with the recap line on a successful, non-test build.
     if (br.code == 0 && s.readout != nil) {
@@ -694,6 +709,62 @@ fun resolve_opt_level(p: *driver.Project, cli_level: u8, cli_set: bool) u8 {
     val te: *driver.TargetEntry = p.target_entry;
     if (te != nil && te.opt == driver.TARGET_OPT_RELEASE) { ret pipeline.OPT_RELEASE; }
     ret pipeline.OPT_DEBUG;
+}
+
+# resolve the build's debug-info intent onto the session, plumbing the CU metadata
+# the debug producer needs when it is on
+#
+# The single switch: `-g` forces emission on, otherwise the selected profile's
+# `debug` key, otherwise off (precedence `-g` > profile > off). When on it interns
+# the DW_AT_producer string ("<name> <version>") and records the comp_dir
+# (DW_AT_comp_dir, the project root); when off both stay STR_NIL and nothing is
+# interned, so a non-debug build perturbs neither the interner nor the output.
+# ---
+# p:      the resolved project (its session, compiler identity, and project root)
+# force: whether the CLI `-g` flag was passed
+# ret:    ok(true) once the session carries the resolved intent, or an intern error
+fun resolve_debug(p: *driver.Project, force: bool) R.Result[bool, str] {
+    p.s.debug = force || p.config.debug;
+    if (!p.s.debug) { ret R.ok[bool, str](true); }
+
+    val rp: R.Result[intern.StrId, str] = intern_producer(p.s, p.compiler_name, p.compiler_ver);
+    if (R.is_err[intern.StrId, str](rp)) { ret R.err[bool, str](R.unwrap_err[intern.StrId, str](rp)); }
+    p.s.debug_producer = R.unwrap_ok[intern.StrId, str](rp);
+    p.s.debug_comp_dir = p.config.project_root;
+    ret R.ok[bool, str](true);
+}
+
+# intern the DW_AT_producer string "<name> <version>" from the interned compiler
+# identity. both ids are session-interned by the driver, so a lookup miss is a
+# compiler bug rather than a runtime condition and is reported, not masked.
+# ---
+# s:       the session owning the interner and allocator
+# name_id: interned compiler name (e.g. "mach")
+# ver_id:  interned compiler version (e.g. "2.14.0")
+# ret:     the interned "<name> <version>" id, or an intern/allocation error
+fun intern_producer(s: *session.Session, name_id: intern.StrId, ver_id: intern.StrId) R.Result[intern.StrId, str] {
+    val no: O.Option[str] = intern.lookup(?s.interner, name_id);
+    val vo: O.Option[str] = intern.lookup(?s.interner, ver_id);
+    if (O.is_none[str](no) || O.is_none[str](vo)) {
+        ret R.err[intern.StrId, str]("debug: compiler identity not interned");
+    }
+    val name: str = O.unwrap[str](no);
+    val ver:  str = O.unwrap[str](vo);
+    val ln: usize = str_len(name);
+    val lv: usize = str_len(ver);
+    val rb: R.Result[*u8, str] = A.allocate[u8](s.alloc, ln + 1 + lv + 1);
+    if (R.is_err[*u8, str](rb)) { ret R.err[intern.StrId, str](R.unwrap_err[*u8, str](rb)); }
+    val buf: *u8 = R.unwrap_ok[*u8, str](rb);
+    var w: usize = 0;
+    var i: usize = 0;
+    for (i < ln) { buf[w] = name[i]; w = w + 1; i = i + 1; }
+    buf[w] = ' '; w = w + 1;
+    i = 0;
+    for (i < lv) { buf[w] = ver[i]; w = w + 1; i = i + 1; }
+    buf[w] = 0;
+    val ri: R.Result[intern.StrId, str] = intern.intern(?s.interner, buf::str);
+    A.deallocate[u8](s.alloc, buf, ln + 1 + lv + 1);
+    ret ri;
 }
 
 # orchestrate the per-module compile + link, allocating and freeing the parallel

--- a/src/cli/cmd/build.mach
+++ b/src/cli/cmd/build.mach
@@ -727,7 +727,7 @@ fun resolve_debug(p: *driver.Project, force: bool) R.Result[bool, str] {
     p.s.debug = force || p.config.debug;
     if (!p.s.debug) { ret R.ok[bool, str](true); }
 
-    val rp: R.Result[intern.StrId, str] = intern_producer(p.s, p.compiler_name, p.compiler_ver);
+    val rp: R.Result[intern.StrId, str] = intern_producer(?p.s.interner, p.s.alloc, p.compiler_name, p.compiler_ver);
     if (R.is_err[intern.StrId, str](rp)) { ret R.err[bool, str](R.unwrap_err[intern.StrId, str](rp)); }
     p.s.debug_producer = R.unwrap_ok[intern.StrId, str](rp);
     p.s.debug_comp_dir = p.config.project_root;
@@ -738,13 +738,14 @@ fun resolve_debug(p: *driver.Project, force: bool) R.Result[bool, str] {
 # identity. both ids are session-interned by the driver, so a lookup miss is a
 # compiler bug rather than a runtime condition and is reported, not masked.
 # ---
-# s:       the session owning the interner and allocator
+# itn:     the interner the ids belong to and the result is interned into
+# alloc:   allocator backing the transient concatenation buffer
 # name_id: interned compiler name (e.g. "mach")
 # ver_id:  interned compiler version (e.g. "2.14.0")
 # ret:     the interned "<name> <version>" id, or an intern/allocation error
-fun intern_producer(s: *session.Session, name_id: intern.StrId, ver_id: intern.StrId) R.Result[intern.StrId, str] {
-    val no: O.Option[str] = intern.lookup(?s.interner, name_id);
-    val vo: O.Option[str] = intern.lookup(?s.interner, ver_id);
+fun intern_producer(itn: *intern.Interner, alloc: *A.Allocator, name_id: intern.StrId, ver_id: intern.StrId) R.Result[intern.StrId, str] {
+    val no: O.Option[str] = intern.lookup(itn, name_id);
+    val vo: O.Option[str] = intern.lookup(itn, ver_id);
     if (O.is_none[str](no) || O.is_none[str](vo)) {
         ret R.err[intern.StrId, str]("debug: compiler identity not interned");
     }
@@ -752,7 +753,7 @@ fun intern_producer(s: *session.Session, name_id: intern.StrId, ver_id: intern.S
     val ver:  str = O.unwrap[str](vo);
     val ln: usize = str_len(name);
     val lv: usize = str_len(ver);
-    val rb: R.Result[*u8, str] = A.allocate[u8](s.alloc, ln + 1 + lv + 1);
+    val rb: R.Result[*u8, str] = A.allocate[u8](alloc, ln + 1 + lv + 1);
     if (R.is_err[*u8, str](rb)) { ret R.err[intern.StrId, str](R.unwrap_err[*u8, str](rb)); }
     val buf: *u8 = R.unwrap_ok[*u8, str](rb);
     var w: usize = 0;
@@ -762,9 +763,28 @@ fun intern_producer(s: *session.Session, name_id: intern.StrId, ver_id: intern.S
     i = 0;
     for (i < lv) { buf[w] = ver[i]; w = w + 1; i = i + 1; }
     buf[w] = 0;
-    val ri: R.Result[intern.StrId, str] = intern.intern(?s.interner, buf::str);
-    A.deallocate[u8](s.alloc, buf, ln + 1 + lv + 1);
+    val ri: R.Result[intern.StrId, str] = intern.intern(itn, buf::str);
+    A.deallocate[u8](alloc, buf, ln + 1 + lv + 1);
     ret ri;
+}
+
+# intern_producer builds "<name> <version>" - the DW_AT_producer string the driver
+# plumbs to the debug producer - from the interned compiler identity.
+test "mach.cli.cmd.build.intern_producer:name_version" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+    var itn: intern.Interner = intern.init(?alloc);
+
+    val rn: R.Result[intern.StrId, str] = intern.intern(?itn, "mach");
+    val rv: R.Result[intern.StrId, str] = intern.intern(?itn, "2.14.0");
+    if (R.is_err[intern.StrId, str](rn) || R.is_err[intern.StrId, str](rv)) { ret 1; }
+
+    val rp: R.Result[intern.StrId, str] = intern_producer(?itn, ?alloc,
+        R.unwrap_ok[intern.StrId, str](rn), R.unwrap_ok[intern.StrId, str](rv));
+    if (R.is_err[intern.StrId, str](rp)) { ret 1; }
+    val got: O.Option[str] = intern.lookup(?itn, R.unwrap_ok[intern.StrId, str](rp));
+    if (O.is_none[str](got) || !str_equals(O.unwrap[str](got), "mach 2.14.0")) { ret 1; }
+    ret 0;
 }
 
 # orchestrate the per-module compile + link, allocating and freeing the parallel

--- a/src/cli/cmd/help.mach
+++ b/src/cli/cmd/help.mach
@@ -119,6 +119,7 @@ fun help_build() {
     print.print("  --release        select the release optimisation pipeline\n");
     print.print("  -O0              force the debug pipeline (overrides --release)\n");
     print.print("  -O1, -O2         select the release pipeline\n");
+    print.print("  -g               emit debug info for this build (overrides the profile's debug key)\n");
     print.print("  --emit <kind>    obj | exe (default exe; obj stops at the objects)\n");
     print.print("  -L <dir>         add a search directory for -l inputs; repeatable\n");
     print.print("  -l <name>        link a named object, archive, or shared library; repeatable\n");

--- a/src/cli/config.mach
+++ b/src/cli/config.mach
@@ -47,6 +47,8 @@ use mach.cli.util;
 #              rather than the manifest default
 # pie:         --pie was passed; emit a position-independent (ET_DYN) executable for
 #              ASLR instead of the default fixed-address one. opt-in, off by default
+# g:           -g was passed; force debug-info emission on for this invocation,
+#              overriding the selected profile's `debug` key. opt-in, off by default
 pub rec Config {
     verbosity:   u8;
     quiet:       bool;
@@ -63,6 +65,7 @@ pub rec Config {
     lib:         *u8;
     all_targets: bool;
     pie:         bool;
+    g:           bool;
 }
 
 # read the cross-cutting flags out of `argv` and produce a populated Config
@@ -104,6 +107,7 @@ pub fun parse(argc: usize, argv: **u8, marks: *bool) R.Result[Config, str] {
     c.release     = util.mark_flag(marks, argc, argv, "--release");
     c.all_targets = util.mark_flag(marks, argc, argv, "--all-targets");
     c.pie         = util.mark_flag(marks, argc, argv, "--pie");
+    c.g           = util.mark_flag(marks, argc, argv, "-g");
 
     c.target    = flag_value_get(marks, argc, argv, "--target");
     c.output    = flag_value_get(marks, argc, argv, "-o");

--- a/src/lang/driver.mach
+++ b/src/lang/driver.mach
@@ -171,6 +171,8 @@ pub rec DepEntry {
 #               literal `{name}` placeholder `mach test` fills per test
 # emit_ir:      selected profile's IR-emission default
 # emit_asm:     selected profile's ASM-emission default
+# debug:        selected profile's debug-info default (`[profile.*] debug`); the
+#               driver ORs it with the CLI `-g` flag into the session's resolved bit
 # defines:      merged comptime defines for the selected unit (artifact < target
 #               < cell), each `NAME` or `NAME=VALUE`; bound into every module's
 #               comptime ctx during load (#1191); nil when none
@@ -201,6 +203,7 @@ pub rec ProjectConfig {
     test_root:    intern.StrId;
     emit_ir:      bool;
     emit_asm:     bool;
+    debug:        bool;
     defines:      *intern.StrId;
     define_count: u32;
     cascade_libs:      *intern.StrId;
@@ -1368,6 +1371,7 @@ fun init_project(p: *Project, s: *session.Session) {
     p.config.test_root    = intern.STR_NIL;
     p.config.emit_ir      = false;
     p.config.emit_asm     = false;
+    p.config.debug        = false;
     p.config.defines       = nil;
     p.config.define_count  = 0;
     p.config.cascade_libs      = nil;
@@ -1523,6 +1527,7 @@ fun load_config(p: *Project, project_root: str, t: *toml.Table, sel: *manifest.S
     p.config.test_root    = bu.test_root;
     p.config.emit_ir      = bu.emit_ir;
     p.config.emit_asm     = bu.emit_asm;
+    p.config.debug        = bu.debug;
     p.config.defines       = bu.defines;
     p.config.define_count  = bu.define_count;
     p.target_entry        = ?p.config.targets[0];
@@ -4946,6 +4951,12 @@ fun write_build_config(fb: *FpBuf, p: *Project, build_mode_id: u32) R.Result[boo
     var pie_axis: u32 = 0;
     if (p.s.pie) { pie_axis = 1; }
     val a3p: R.Result[bool, str] = fp_u32(fb, pie_axis);             if (R.is_err[bool, str](a3p)) { ret a3p; }
+    # debug-info intent forks compilation state like pie: Q_TARGET re-codegens every
+    # module (adding/removing debug sections) and re-links, so a `-g`/`debug` toggle
+    # never serves a no-debug object for a debug request or vice versa.
+    var dbg_axis: u32 = 0;
+    if (p.s.debug) { dbg_axis = 1; }
+    val a3d: R.Result[bool, str] = fp_u32(fb, dbg_axis);             if (R.is_err[bool, str](a3d)) { ret a3d; }
     val a4: R.Result[bool, str] = fp_u32(fb, p.target.arch.pointer_width); if (R.is_err[bool, str](a4)) { ret a4; }
     val a5: R.Result[bool, str] = fp_u32(fb, p.target_entry.os_name::u32);  if (R.is_err[bool, str](a5)) { ret a5; }
     val a6: R.Result[bool, str] = fp_u32(fb, p.target_entry.isa_name::u32); if (R.is_err[bool, str](a6)) { ret a6; }

--- a/src/lang/manifest.mach
+++ b/src/lang/manifest.mach
@@ -150,11 +150,13 @@ pub rec ArtifactDef {
 # opt:      declared optimization level
 # emit_ir:  default `--emit-ir` for this profile
 # emit_asm: default `--emit-asm` for this profile
+# debug:    default debug-info emission for this profile (`debug = true|false`)
 pub rec ProfileDef {
     name:     intern.StrId;
     opt:      MOpt;
     emit_ir:  bool;
     emit_asm: bool;
+    debug:    bool;
 }
 
 # one `[os.<name>] libs = [...]` link overlay scoped to a single tuple component
@@ -287,6 +289,7 @@ pub rec Selection {
 # opt:          resolved optimization level
 # emit_ir:      profile default for IR emission
 # emit_asm:     profile default for ASM emission
+# debug:        profile default for debug-info emission
 # is_lib:       whether the artifact is a library
 # kind:         library link kind (meaningful when is_lib)
 # libs:         merged interned link overlay; nil when none
@@ -309,6 +312,7 @@ pub rec BuildUnit {
     opt:          MOpt;
     emit_ir:      bool;
     emit_asm:     bool;
+    debug:        bool;
     is_lib:       bool;
     kind:         LibKind;
     libs:         *intern.StrId;
@@ -333,11 +337,13 @@ pub rec ResolvedTarget {
 # opt:      resolved optimization level
 # emit_ir:  profile default for IR emission
 # emit_asm: profile default for ASM emission
+# debug:    profile default for debug-info emission
 pub rec ResolvedProfile {
     name:     intern.StrId;
     opt:      MOpt;
     emit_ir:  bool;
     emit_asm: bool;
+    debug:    bool;
 }
 
 # an interned string array carved from a TOML array of strings
@@ -591,6 +597,35 @@ fun opt_value_text(alloc: *A.Allocator, v: *toml.Value) str {
     ret "a value";
 }
 
+# parse a profile's boolean `debug` key
+#
+# An absent key is `false` - today's behavior, no debug info. A present value that
+# is not a boolean is a manifest error naming the profile. Unlike `emit_ir`/`emit_asm`
+# (which coerce leniently) `debug` is strict so a typo like `debug = "true"` is caught
+# rather than silently ignored. `-g` can still force emission on over a false/absent key.
+# ---
+# alloc: allocator for the diagnostic
+# name:  profile name, for the diagnostic
+# sub:   the `[profile.<name>]` table
+# ret:   ok(the declared debug bit) on success, err naming the profile otherwise
+fun parse_debug_flag(alloc: *A.Allocator, name: str, sub: *toml.Table) R.Result[bool, str] {
+    val v: *toml.Value = toml.get(sub, "debug");
+    if (v == nil)                { ret R.ok[bool, str](false); }
+    if (v.tag != toml.TYPE_BOOL) { ret R.err[bool, str](debug_err(alloc, name, v)); }
+    ret R.ok[bool, str](v.data.boolean);
+}
+
+# the `profile '<name>': debug must be a boolean (got <value>)` diagnostic
+# ---
+# alloc: allocator owning the message
+# name:  profile name
+# v:     the rejected `debug` value
+# ret:   owned diagnostic string
+fun debug_err(alloc: *A.Allocator, name: str, v: *toml.Value) str {
+    ret cc5(alloc, "mach.toml: profile '", name, "': debug must be a boolean (got ",
+        opt_value_text(alloc, v), ")");
+}
+
 # the decimal text of an i64, freshly allocated and owned by `alloc`
 # ---
 # alloc: allocator owning the result
@@ -659,7 +694,8 @@ fun key_known(kind: TableKind, k: str) bool {
             || str_equals(k, "libs") || str_equals(k, "defines") || str_equals(k, "target");
     }
     if (kind == TK_PROFILE) {
-        ret str_equals(k, "opt") || str_equals(k, "emit_ir") || str_equals(k, "emit_asm");
+        ret str_equals(k, "opt") || str_equals(k, "emit_ir") || str_equals(k, "emit_asm")
+            || str_equals(k, "debug");
     }
     if (kind == TK_DEP) {
         ret str_equals(k, "git") || str_equals(k, "path") || str_equals(k, "ref");
@@ -1144,6 +1180,9 @@ fun parse_profiles(alloc: *A.Allocator, itn: *intern.Interner, t: *toml.Table, m
         pf.opt      = R.unwrap_ok[MOpt, str](res_opt);
         pf.emit_ir  = bool_or(toml.get_bool(sub, "emit_ir"), false);
         pf.emit_asm = bool_or(toml.get_bool(sub, "emit_asm"), false);
+        val res_debug: R.Result[bool, str] = parse_debug_flag(alloc, name, sub);
+        if (R.is_err[bool, str](res_debug)) { ret R.err[bool, str](R.unwrap_err[bool, str](res_debug)); }
+        pf.debug    = R.unwrap_ok[bool, str](res_debug);
 
         m.profiles[i] = pf;
         i = i + 1;
@@ -1587,6 +1626,7 @@ fun profile_resolved(pf: *ProfileDef) ResolvedProfile {
     rp.opt      = pf.opt;
     rp.emit_ir  = pf.emit_ir;
     rp.emit_asm = pf.emit_asm;
+    rp.debug    = pf.debug;
     ret rp;
 }
 
@@ -1625,6 +1665,7 @@ pub fun resolve_profile(alloc: *A.Allocator, itn: *intern.Interner, m: *Manifest
     rp.opt      = MOPT_DEFAULT;
     rp.emit_ir  = false;
     rp.emit_asm = false;
+    rp.debug    = false;
     ret R.ok[ResolvedProfile, str](rp);
 }
 
@@ -1931,6 +1972,7 @@ pub fun resolve_build_unit(alloc: *A.Allocator, itn: *intern.Interner, m: *Manif
     u.opt          = rp.opt;
     u.emit_ir      = rp.emit_ir;
     u.emit_asm     = rp.emit_asm;
+    u.debug        = rp.debug;
     u.is_lib       = a.is_lib;
     u.kind         = a.kind;
     u.warned       = rt.warned;
@@ -2524,6 +2566,31 @@ test "mach.lang.manifest.parse:bad_opt_level" {
     # a string opt is the old form and is no longer accepted; the error names it.
     val b: R.Result[Manifest, str] = tparse(?alloc, ?itn, "[project]\nid=\"x\"\nversion=\"1\"\n[target.l]\nisa=\"x86_64\"\nos=\"linux\"\nabi=\"sysv64\"\n[bin.app]\nentry=\"main.mach\"\n[profile.release]\nopt = \"O2\"\n");
     if (R.is_ok[Manifest, str](b) || !str_equals(R.unwrap_err[Manifest, str](b), "mach.toml: profile 'release': opt must be 0, 1, or 2 (got \"O2\")")) { code = 1; }
+    arena.dnit(?ar);
+    ret code;
+}
+
+# a profile `debug` key resolves to a boolean (defaulting false when absent), and a
+# non-boolean value is rejected naming the profile
+test "mach.lang.manifest.parse:profile_debug" {
+    var backing: A.Allocator; var ar: arena.Arena; var alloc: A.Allocator; var itn: intern.Interner;
+    if (!tinit(?backing, ?ar, ?alloc, ?itn)) { ret 1; }
+    var code: i32 = 0;
+
+    # `debug = true` rides the resolved profile; a profile omitting the key is false.
+    val a: R.Result[Manifest, str] = tparse(?alloc, ?itn, "[project]\nid=\"x\"\nversion=\"1\"\n[target.l]\nisa=\"x86_64\"\nos=\"linux\"\nabi=\"sysv64\"\n[bin.app]\nentry=\"main.mach\"\n[profile.debug]\ndebug = true\n[profile.release]\nopt = 2\n");
+    if (R.is_err[Manifest, str](a)) { code = 1; }
+    or {
+        var m: Manifest = R.unwrap_ok[Manifest, str](a);
+        val rd: R.Result[ResolvedProfile, str] = resolve_profile(?alloc, ?itn, ?m, "debug");
+        if (R.is_err[ResolvedProfile, str](rd) || !R.unwrap_ok[ResolvedProfile, str](rd).debug) { code = 1; }
+        val rr: R.Result[ResolvedProfile, str] = resolve_profile(?alloc, ?itn, ?m, "release");
+        if (R.is_err[ResolvedProfile, str](rr) || R.unwrap_ok[ResolvedProfile, str](rr).debug) { code = 1; }
+    }
+
+    # a non-boolean `debug` value is a manifest error naming the profile and the value.
+    val b: R.Result[Manifest, str] = tparse(?alloc, ?itn, "[project]\nid=\"x\"\nversion=\"1\"\n[target.l]\nisa=\"x86_64\"\nos=\"linux\"\nabi=\"sysv64\"\n[bin.app]\nentry=\"main.mach\"\n[profile.debug]\ndebug = \"yes\"\n");
+    if (R.is_ok[Manifest, str](b) || !str_equals(R.unwrap_err[Manifest, str](b), "mach.toml: profile 'debug': debug must be a boolean (got \"yes\")")) { code = 1; }
     arena.dnit(?ar);
     ret code;
 }

--- a/src/lang/session.mach
+++ b/src/lang/session.mach
@@ -147,6 +147,16 @@ pub rec Session {
     # target's own PIE requirement. off leaves the default ET_EXEC output unchanged.
     pie: bool;
 
+    # resolved debug-info intent for this build (`-g` or a profile's `debug = true`,
+    # precedence `-g` > profile > off). the single switch that gates debug-section
+    # emission; like `pie` it forks compilation state, so the target fingerprint keys
+    # on it. `debug_producer` (DW_AT_producer) and `debug_comp_dir` (DW_AT_comp_dir)
+    # are the compilation-unit metadata the driver plumbs to the debug producer; both
+    # STR_NIL when debug is off.
+    debug:          bool;
+    debug_producer: intern.StrId;
+    debug_comp_dir: intern.StrId;
+
     # in-memory source overlays keyed by path (#1588): live unsaved buffer text a
     # long-lived session's parse read uses instead of the file on disk. a small
     # owned array scanned by path - the open-buffer set is tiny - grown on demand
@@ -200,6 +210,9 @@ pub fun init(alloc: *A.Allocator) R.Result[Session, str] {
     s.opt_release      = false;
     s.readout          = nil;
     s.pie              = false;
+    s.debug            = false;
+    s.debug_producer   = intern.STR_NIL;
+    s.debug_comp_dir   = intern.STR_NIL;
     s.overlays         = nil;
     s.overlay_len      = 0;
     s.overlay_cap      = 0;


### PR DESCRIPTION
Closes #1697. Part of the #1688 debug-info foundation.

## What
Two ways to turn debug-info emission on, one switch underneath:
- **Per-profile `debug = true|false`** in `[profile.*]`, beside `opt` (`manifest.mach`): carried ProfileDef → ResolvedProfile → BuildUnit → ProjectConfig, default `false`. Strict parse — a non-boolean value is a manifest error naming the profile and the value (unlike the lenient `emit_ir`/`emit_asm`).
- **`-g` CLI flag** (`config.mach`, `build.mach`) that forces emission on for the invocation. Precedence `-g` > profile `debug` > off; `-g` only adds (no force-off flag).

The resolved bit lands on the session (`s.debug`) as the single switch. Like `--pie` it forks compilation state, so it keys the **Q_TARGET fingerprint** (`write_build_config`) — a toggle re-codegens every module and re-links, so a warm session never serves a no-debug object for a debug request or vice versa. When on, the driver interns the `DW_AT_producer` string (`"<name> <version>"`) and records `comp_dir` (project root) onto the session for the debug producer (the seam from #1692).

Docs: `mach build` help + `doc/cli.md` gain `-g`; `doc/manifest.md` gains the `debug` key with default, precedence, and diagnostic.

## Invariant — byte-identical without emission
Inert until an emitter consumes the switch/metadata (none registered yet — that's #1699). Verified across the full target matrix (ELF x64/arm64/riscv64, COFF, Mach-O x64/arm64):
- **my compiler vs origin/dev baseline** on a fixed input: 161–162 artifacts each, **0 differing** on all 6 targets.
- **`-g` vs no-`-g`** on the same source: **0 differing** on all 6 targets.

## Verification
- from-source build clean; unit suite **515 pass / 0 fail** (baseline + 2 new: manifest `debug` parse/resolve/diagnostic + the DW_AT_producer builder).
- self-host fixpoint reached (stage2 == stage3 byte-identical).
- int harness green on the linux leg.
- rebased onto current origin/dev cleanly.

Note: a mid-work bug where the `compile_and_link` guard keyed on `br.code == 0` (it initialises to 2) was caught and fixed — the switch now runs the build unless debug resolution itself errors.
