### PR TITLE
feat(codegen): MirInstr loc + encoder PC<->source line-row table

### DIFF
--- a/src/lang/be/codegen.mach
+++ b/src/lang/be/codegen.mach
@@ -36,6 +36,7 @@ use mach.lang.me.ir;
 use mach.lang.me.ir.type;
 use mach.lang.me.ir.value;
 use mach.lang.session;
+use source: mach.lang.source;
 use mach.lang.target;
 use mach.lang.target.of;
 
@@ -196,6 +197,10 @@ fun pack_image(s: *session.Session, tgt: *target.Target, irmod: *ir.Module,
     }
 
     val res_relocs: R.Result[bool, str] = pack_relocs(?image, enc, text_sec, placements, placement_count);
+    # re-home the retained PC<->source rows the same way symbols are, while the
+    # placements are still live, so the #1699 line producer reads final section
+    # offsets. infallible (in-place offset math), so no error to thread.
+    pack_rows(enc, placements, placement_count, text_sec);
     if (placements != nil) { A.deallocate[SectionPlacement](s.alloc, placements, enc.symbol_count::usize); }
     if (R.is_err[bool, str](res_relocs)) {
         obj.dnit(?image);
@@ -388,6 +393,31 @@ fun pack_relocs(image: *of.ObjectImage, enc: *encode.EncoderOutput,
         i = i + 1;
     }
     ret R.ok[bool, str](true);
+}
+
+# re-home every retained PC<->source line row into its final section and offset,
+# the line-table analogue of pack_symbols / pack_relocs
+#
+# Each row's encoder-blob `text_offset` resolves through `site_placed` exactly as a
+# symbol mark does: a row inside a `#[section("...")]` function moves to that
+# function's named section at its section-relative offset, and a `.text`-resident
+# row keeps `.text` and shifts down by the excised ranges below it. With no
+# sectioned function the rows keep `.text` (section index `text_sec`) and their
+# offsets are unchanged, matching the byte-for-byte default path. Rebases the rows
+# in place; the #1699 line-table producer reads the final `(sec, text_offset, loc)`.
+# ---
+# enc:             encoder output whose rows are re-homed in place
+# placements:      the sectioned-function ranges, in increasing text offset
+# placement_count: number of placements
+# text_sec:        index of the `.text` section a non-sectioned row stays in
+fun pack_rows(enc: *encode.EncoderOutput, placements: *SectionPlacement, placement_count: u32, text_sec: u32) {
+    var i: u32 = 0;
+    for (i < enc.row_count) {
+        val site: PlacedSite = site_placed(placements, placement_count, text_sec, enc.rows[i].text_offset);
+        enc.rows[i].sec         = site.sec;
+        enc.rows[i].text_offset = site.off;
+        i = i + 1;
+    }
 }
 
 # materialise every module global into the image
@@ -976,4 +1006,34 @@ fun is_f32_type(types: *type.IrTypeTable, id: type.IrTypeId) bool {
     if (O.is_none[*type.IrType](opt_type)) { ret false; }
     val t: *type.IrType = O.unwrap[*type.IrType](opt_type);
     ret t.kind == type.IRT_FLOAT && t.data.bits == 32;
+}
+
+# pack_rows re-homes each retained PC<->source row into its final section and offset
+# under `#[section(...)]` excision: a row inside the sectioned range moves to that
+# section at its section-relative offset, and a `.text` row after the excised range
+# shifts down by its length - the same site_placed mapping symbols use, so a row's
+# final offset matches the final `.text`.
+test "mach.lang.be.codegen.pack_rows:rehomes_sectioned_and_text" {
+    var rows: [3]encode.LineRow;
+    rows[0].text_offset = 0;  rows[0].sec = 0; rows[0].loc = source.loc(0, 100);
+    rows[1].text_offset = 10; rows[1].sec = 0; rows[1].loc = source.loc(0, 200);
+    rows[2].text_offset = 20; rows[2].sec = 0; rows[2].loc = source.loc(0, 300);
+
+    var enc: encode.EncoderOutput;
+    enc.rows      = ?rows[0];
+    enc.row_count = 3;
+
+    # one sectioned function occupying the encoder blob range [8, 16), homed to section 5.
+    var pls: [1]SectionPlacement;
+    pls[0].text_start = 8; pls[0].text_end = 16; pls[0].sec = 5;
+
+    pack_rows(?enc, ?pls[0], 1, 1);
+
+    # blob 0: `.text`, nothing excised below -> section 1, offset unchanged.
+    if (enc.rows[0].sec != 1 || enc.rows[0].text_offset != 0)  { ret 1; }
+    # blob 10: inside [8, 16) -> section 5 at offset 10 - 8 = 2.
+    if (enc.rows[1].sec != 5 || enc.rows[1].text_offset != 2)  { ret 1; }
+    # blob 20: `.text` after the 8-byte excised range -> section 1 at offset 20 - 8 = 12.
+    if (enc.rows[2].sec != 1 || enc.rows[2].text_offset != 12) { ret 1; }
+    ret 0;
 }

--- a/src/lang/be/codegen/encode.mach
+++ b/src/lang/be/codegen/encode.mach
@@ -36,11 +36,14 @@ use std.types.bool.true;
 use std.types.size.usize;
 use std.types.string.str;
 
+use std.allocator.page;
+
 use A: std.allocator;
 use R: std.types.result;
 
 use mach.lang.be.codegen.mir;
 use mach.lang.intern;
+use source: mach.lang.source;
 use mach.lang.target.abi;
 use mach.lang.target.of;
 use tos:    mach.lang.target.os;
@@ -56,6 +59,8 @@ use target: mach.lang.target.resolved;
 # reloc_count:  number of relocations
 # symbols:      symbol marks, one per function entry (owned)
 # symbol_count: number of symbol marks
+# rows:         PC<->source line rows, ordered by ascending `text_offset` (owned)
+# row_count:    number of line rows
 pub rec EncoderOutput {
     text:         *u8;
     text_len:     u32;
@@ -63,6 +68,31 @@ pub rec EncoderOutput {
     reloc_count:  u32;
     symbols:      *SymbolMark;
     symbol_count: u32;
+    rows:         *LineRow;
+    row_count:    u32;
+}
+
+# one retained PC<->source mapping: a `.text` byte offset and the source location of
+# the instruction that begins there
+#
+# The encoder appends one per instruction with a valid source location, in
+# ascending `text_offset` order. `insert_text` (branch relaxation) keeps
+# `text_offset` correct while the text grows; codegen's `#[section(...)]` re-homing
+# (`pack_rows`) then assigns each row's final `sec` and rebases `text_offset` into
+# that section. Until re-homing every row is relative to the single encoder `.text`
+# blob and `sec` is 0. The source `loc` (file + byte offset) resolves to a 1-based
+# line/column via `source.position`; the #1699 `.debug_line` / CodeView producer
+# consumes it. The row never affects the emitted bytes.
+# ---
+# text_offset: byte offset of the instruction within its owning section (`.text`
+#              blob-relative until re-homing rebases it)
+# sec:         owning object-section index, assigned by codegen re-homing (0 while
+#              the row is still relative to the single encoder blob)
+# loc:         source location (file + byte offset) the instruction lowered from
+pub rec LineRow {
+    text_offset: u32;
+    sec:         u32;
+    loc:         source.SrcLoc;
 }
 
 # one relocation the encoder leaves for the object writer to resolve
@@ -361,6 +391,9 @@ pub rec EncodeState {
     blocks:      *BlockOffset;
     block_count: u32;
     block_cap:   u32;
+    rows:        *LineRow;
+    row_count:   u32;
+    row_cap:     u32;
     interner:    *intern.Interner;
     abi:         *abi.AbiVTable;
     os:          *tos.OsVTable;
@@ -475,9 +508,11 @@ pub fun encode_driver(alloc: *A.Allocator, tgt: *target.Target, m: *mir.MirModul
     out.reloc_count  = st.reloc_count;
     out.symbols      = st.syms;
     out.symbol_count = st.sym_count;
+    out.rows         = st.rows;
+    out.row_count    = st.row_count;
 
-    # the text, symbol, and relocation arrays are transferred to the output; only
-    # the driver-internal fixup and block-offset arrays are released.
+    # the text, symbol, relocation, and line-row arrays are transferred to the output;
+    # only the driver-internal fixup and block-offset arrays are released.
     scratch_release(?st);
     ret R.ok[EncoderOutput, str](out);
 }
@@ -605,6 +640,32 @@ pub fun push_block(st: *EncodeState, fn_text_base: u32, block_id: u32, offset: u
     ret R.ok[bool, str](true);
 }
 
+# append a PC<->source line row, growing the row array on demand
+#
+# Called by an ISA encoder for each instruction that carries a source location, at
+# the `.text` offset where its bytes begin. A location naming no file
+# (`source.loc_nil()`, a compiler-synthesized instruction) is dropped so its byte
+# range is attributed to the preceding row's line. The row survives into
+# `EncoderOutput` and is kept correct under `insert_text` relaxation and codegen
+# re-homing.
+# ---
+# st:          the encode state whose row array receives the entry
+# text_offset: byte offset of the instruction's first byte within `.text`
+# loc:         the instruction's source location
+# ret:         ok(true) on success (or a dropped nil location), or an allocation error
+pub fun push_row(st: *EncodeState, text_offset: u32, loc: source.SrcLoc) R.Result[bool, str] {
+    if (!source.loc_is_valid(loc)) { ret R.ok[bool, str](true); }
+    if (st.row_count >= st.row_cap) {
+        val res_grow: R.Result[bool, str] = grow_rows(st);
+        if (R.is_err[bool, str](res_grow)) { ret res_grow; }
+    }
+    st.rows[st.row_count].text_offset = text_offset;
+    st.rows[st.row_count].sec         = 0;
+    st.rows[st.row_count].loc         = loc;
+    st.row_count = st.row_count + 1;
+    ret R.ok[bool, str](true);
+}
+
 # initialise an encode state with empty output arrays for one driver run
 # ---
 # st:    the state to populate in place
@@ -626,6 +687,9 @@ fun state_init(st: *EncodeState, alloc: *A.Allocator, m: *mir.MirModule, tgt: *t
     st.blocks      = nil;
     st.block_count = 0;
     st.block_cap   = 0;
+    st.rows        = nil;
+    st.row_count   = 0;
+    st.row_cap     = 0;
     st.interner    = m.interner;
     st.abi         = tgt.abi;
     st.os          = tgt.os;
@@ -649,6 +713,12 @@ fun state_dnit(st: *EncodeState) {
     st.relocs      = nil;
     st.reloc_count = 0;
     st.reloc_cap   = 0;
+    if (st.rows != nil && st.row_cap > 0) {
+        A.deallocate[LineRow](st.alloc, st.rows, st.row_cap::usize);
+    }
+    st.rows      = nil;
+    st.row_count = 0;
+    st.row_cap   = 0;
     scratch_release(st);
 }
 
@@ -749,7 +819,7 @@ pub fun block_offset(st: *EncodeState, fn_base: u32, block_id: u32) R.Result[u32
 # Shifts the bytes in `[pos, len)` up by `nbytes` (growing the sink as needed),
 # zero-fills the opened gap, and advances by `nbytes` every recorded offset at or
 # past `pos`: block offsets, branch-fixup patch / next-ip / function-base fields,
-# symbol-mark offsets, and relocation offsets. This is the ISA-general mechanism a
+# symbol-mark offsets, relocation offsets, and line-row text offsets. This is the ISA-general mechanism a
 # branch-relaxation pass uses to grow an out-of-range branch into a longer
 # sequence while leaving the fixup, block, symbol, and relocation tables pointing
 # at the right instructions. An entry strictly before `pos` is untouched, so the
@@ -817,6 +887,11 @@ pub fun insert_text(st: *EncodeState, pos: u32, nbytes: u32) R.Result[bool, str]
     for (ri < st.reloc_count) {
         if (st.relocs[ri].offset >= pos) { st.relocs[ri].offset = st.relocs[ri].offset + nbytes; }
         ri = ri + 1;
+    }
+    var wi: u32 = 0;
+    for (wi < st.row_count) {
+        if (st.rows[wi].text_offset >= pos) { st.rows[wi].text_offset = st.rows[wi].text_offset + nbytes; }
+        wi = wi + 1;
     }
     ret R.ok[bool, str](true);
 }
@@ -899,4 +974,75 @@ fun grow_blocks(st: *EncodeState) R.Result[bool, str] {
     st.blocks    = R.unwrap_ok[*BlockOffset, str](res_realloc);
     st.block_cap = new_cap;
     ret R.ok[bool, str](true);
+}
+
+# grow the line-row array, allocating it on first use
+# ---
+# st:  the state whose row array is grown
+# ret: ok(true) once the array has room, or an allocation error
+fun grow_rows(st: *EncodeState) R.Result[bool, str] {
+    if (st.rows == nil) {
+        val res_alloc: R.Result[*LineRow, str] = A.allocate[LineRow](st.alloc, DRIVER_INIT_CAP::usize);
+        if (R.is_err[*LineRow, str](res_alloc)) { ret R.err[bool, str](R.unwrap_err[*LineRow, str](res_alloc)); }
+        st.rows    = R.unwrap_ok[*LineRow, str](res_alloc);
+        st.row_cap = DRIVER_INIT_CAP;
+        ret R.ok[bool, str](true);
+    }
+    val new_cap: u32 = st.row_cap * 2;
+    val res_realloc: R.Result[*LineRow, str] = A.reallocate[LineRow](st.alloc, st.rows, st.row_cap::usize, new_cap::usize);
+    if (R.is_err[*LineRow, str](res_realloc)) { ret R.err[bool, str](R.unwrap_err[*LineRow, str](res_realloc)); }
+    st.rows    = R.unwrap_ok[*LineRow, str](res_realloc);
+    st.row_cap = new_cap;
+    ret R.ok[bool, str](true);
+}
+
+# a minimal encode state for the row / insert_text unit tests: a text sink and an
+# empty set of mark / reloc / fixup / block / row arrays, no interner or vtables.
+fun t_row_state(alloc: *A.Allocator, st: *EncodeState) {
+    st.alloc = alloc;
+    st.buf = buf_init(alloc);
+    st.syms = nil;   st.sym_count = 0;   st.sym_cap = 0;
+    st.relocs = nil; st.reloc_count = 0; st.reloc_cap = 0;
+    st.fixups = nil; st.fixup_count = 0; st.fixup_cap = 0;
+    st.blocks = nil; st.block_count = 0; st.block_cap = 0;
+    st.rows = nil;   st.row_count = 0;   st.row_cap = 0;
+    st.interner = nil; st.abi = nil; st.os = nil;
+}
+
+# push_row drops a location naming no file, and insert_text (branch relaxation)
+# advances every line row at or past the gap while leaving earlier rows put - so a
+# row's text_offset keeps pointing at its instruction after the text grows.
+test "mach.lang.be.codegen.encode.insert_text:shifts_line_rows" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+
+    var st: EncodeState;
+    t_row_state(?alloc, ?st);
+
+    # a 12-byte placeholder .text so insert_text has bytes to slide.
+    var i: u32 = 0;
+    for (i < 12) { emit_byte(?st.buf, 0x90); i = i + 1; }
+
+    # three real rows at 0 / 4 / 8, plus a nil-location row that must be dropped.
+    val r0: R.Result[bool, str] = push_row(?st, 0, source.loc(0, 100)); if (R.is_err[bool, str](r0)) { ret 1; }
+    val r1: R.Result[bool, str] = push_row(?st, 4, source.loc(0, 200)); if (R.is_err[bool, str](r1)) { ret 1; }
+    val rn: R.Result[bool, str] = push_row(?st, 4, source.loc_nil());   if (R.is_err[bool, str](rn)) { ret 1; }
+    val r2: R.Result[bool, str] = push_row(?st, 8, source.loc(0, 300)); if (R.is_err[bool, str](r2)) { ret 1; }
+    if (st.row_count != 3) { buf_dnit(?st.buf); ret 1; }
+
+    # open a 4-byte gap at offset 4 (as a relaxed branch would).
+    val it: R.Result[bool, str] = insert_text(?st, 4, 4);
+    if (R.is_err[bool, str](it)) { buf_dnit(?st.buf); ret 1; }
+
+    var code: i32 = 0;
+    # the row before the gap is untouched; the rows at/after it advance by 4.
+    if (st.rows[0].text_offset != 0)  { code = 1; }
+    if (st.rows[1].text_offset != 8)  { code = 1; }
+    if (st.rows[2].text_offset != 12) { code = 1; }
+    # the source locations ride along unchanged.
+    if (st.rows[1].loc.offset != 200) { code = 1; }
+
+    buf_dnit(?st.buf);
+    if (st.rows != nil && st.row_cap > 0) { A.deallocate[LineRow](?alloc, st.rows, st.row_cap::usize); }
+    ret code;
 }

--- a/src/lang/be/codegen/mir.mach
+++ b/src/lang/be/codegen/mir.mach
@@ -30,6 +30,7 @@ use A: std.allocator;
 use R: std.types.result;
 
 use mach.lang.intern;
+use source: mach.lang.source;
 
 # discriminant selecting which fields of a MirOperand are live
 pub def MirOperandKind: u8;
@@ -340,6 +341,11 @@ pub rec MirAsm {
 # asm_block:     inline-asm payload for a MIR_ASM instruction (owned), else nil.
 #                carries the raw body text plus `{name}` -> slot-vreg bindings the
 #                encoder expands into machine instructions.
+# loc:           source location (file + byte offset) this instruction lowered from,
+#                forwarded from the IR instruction; source.loc_nil() for a
+#                compiler-synthesized instruction with no source origin. the encoder
+#                retains it as a PC<->source row for debug line tables; it never
+#                affects the emitted bytes.
 pub rec MirInstr {
     opcode:        MirOpcode;
     operands:      *MirOperand;
@@ -347,6 +353,7 @@ pub rec MirInstr {
     width:         u8;
     src_width:     u8;
     asm_block:     *MirAsm;
+    loc:           source.SrcLoc;
 }
 
 # a MIR basic block - an ordered instruction list plus predecessor ids, sharing the source IR `Block.id`

--- a/src/lang/be/codegen/mir/context.mach
+++ b/src/lang/be/codegen/mir/context.mach
@@ -31,6 +31,7 @@ use mach.lang.me.ir.id;
 use mach.lang.me.ir.instruction;
 use ir_type: mach.lang.me.ir.type;
 use mach.lang.me.ir.value;
+use mach.lang.source;
 use mach.lang.target.isa;
 use target:  mach.lang.target.resolved;
 
@@ -81,6 +82,12 @@ pub rec LowerCtx {
     # argument register in `lower_params`; mir.MIR_VREG_NIL otherwise. `lower_ret`
     # copies the returned aggregate into this storage and returns it in RAX.
     sret_vreg: u32;
+
+    # source location of the IR instruction currently being lowered, stamped onto
+    # every MirInstr `push_instr` appends so lowered machine instructions carry a
+    # PC<->source mapping for debug line tables. set per IR instruction by the
+    # lowering loop; source.loc_nil() outside one (params / prologue setup).
+    cur_loc: source.SrcLoc;
 }
 
 # allocate the per-definition vreg maps and assign a vreg to every parameter and
@@ -427,6 +434,10 @@ pub fun mem_operand_of(ctx: *LowerCtx, v: value.Value) mir.MirOperand {
 pub fun push_instr(ctx: *LowerCtx, mb: *mir.MirBlock, mi: mir.MirInstr) R.Result[bool, str] {
     var ni: mir.MirInstr = mi;
     if (ni.opcode != mir.MIR_ASM) { ni.asm_block = nil; }
+    # stamp the source location of the IR instruction being lowered, at the single
+    # append chokepoint - the same reason asm_block is nil'd here (struct locals are
+    # not zero-initialized, so an unstamped loc would carry residue).
+    ni.loc = ctx.cur_loc;
     val res_grow: R.Result[bool, str] = grow_instr(ctx, mb);
     if (R.is_err[bool, str](res_grow)) { ret res_grow; }
     mb.instrs[mb.instr_count] = ni;

--- a/src/lang/be/codegen/mir/lower.mach
+++ b/src/lang/be/codegen/mir/lower.mach
@@ -47,6 +47,7 @@ use id:      mach.lang.me.ir.id;
 use instr:   mach.lang.me.ir.instruction;
 use ir_type: mach.lang.me.ir.type;
 use value:   mach.lang.me.ir.value;
+use source:  mach.lang.source;
 use target:  mach.lang.target.resolved;
 
 # lower an IR module to a parallel MIR module, one MIR function per IR function
@@ -149,6 +150,7 @@ fun lower_function(tgt: *target.Target, m: *ir.Module, fn: *ir.Function, interne
     ctx.instr_count    = fn.instr_len;
     ctx.interner       = interner;
     ctx.sret_vreg      = mir.MIR_VREG_NIL;
+    ctx.cur_loc        = source.loc_nil();
 
     val setup: R.Result[bool, str] = lctx.ctx_setup(?ctx, tgt, fn);
     if (R.is_err[bool, str](setup)) {
@@ -589,8 +591,10 @@ fun insert_mov_before_terminator(ctx: *lctx.LowerCtx, mb: *mir.MirBlock, dst: mi
     }
     # this splice bypasses lctx.push_instr, so enforce the asm_block invariant here:
     # struct locals are not zero-initialized, and regalloc.flatten reads a non-nil
-    # asm_block as an inline-asm clobber barrier.
+    # asm_block as an inline-asm clobber barrier. the same non-zero-init reasoning
+    # applies to `loc` (FILE_NIL is not 0), so stamp the current lowering location.
     mi.asm_block     = nil;
+    mi.loc           = ctx.cur_loc;
 
     # grow by one, shift the terminator right, and drop the move into its place.
     val gr: R.Result[bool, str] = lctx.grow_instr(ctx, mb);
@@ -707,8 +711,11 @@ fun split_critical_edge(ctx: *lctx.LowerCtx, pred: *mir.MirBlock, succ_id: u32) 
     br.src_width     = ctx.tgt.model.gpr_width::u8;
     # this splice bypasses lctx.push_instr, so enforce the asm_block invariant here:
     # struct locals are not zero-initialized, and regalloc.flatten reads a non-nil
-    # asm_block as an inline-asm clobber barrier.
+    # asm_block as an inline-asm clobber barrier. this is a synthesized critical-edge
+    # branch with no source instruction, so its loc is nil (the line table attributes
+    # it to the surrounding code).
     br.asm_block     = nil;
+    br.loc           = source.loc_nil();
 
     val ri: R.Result[*mir.MirInstr, str] = A.allocate[mir.MirInstr](ctx.alloc, 1::usize);
     if (R.is_err[*mir.MirInstr, str](ri)) { A.deallocate[mir.MirOperand](ctx.alloc, bops, 1::usize); ret R.err[*mir.MirBlock, str](R.unwrap_err[*mir.MirInstr, str](ri)); }
@@ -791,6 +798,10 @@ fun lower_instr(ctx: *lctx.LowerCtx, fn: *ir.Function, mb: *mir.MirBlock, iid: i
         ret R.err[bool, str]("mir.lower_ir: dangling instruction id");
     }
     val inst: *instr.Instruction = O.unwrap[*instr.Instruction](gi);
+
+    # stamp the current source location so every MirInstr this instruction lowers to
+    # (through `push_instr`) carries its origin for the debug line table.
+    ctx.cur_loc = inst.loc;
 
     if (inst.kind == instr.OP_CALL) {
         ret mabi.lower_call(ctx, mb, inst, iid);

--- a/src/lang/be/codegen/regalloc.mach
+++ b/src/lang/be/codegen/regalloc.mach
@@ -79,6 +79,7 @@ use R: std.types.result;
 
 use mach.lang.be.codegen.mir;
 use mach.lang.intern;
+use source: mach.lang.source;
 use mach.lang.target;
 use mach.lang.target.abi;
 use mach.lang.target.isa;
@@ -2900,7 +2901,7 @@ fun rewrite_instr(tgt: *target.Target, ctx: *AllocCtx, mi: *mir.MirInstr,
                         ret R.err[bool, str](regalloc_msg(ctx, "regalloc: no free register for spilled source in '", "'", "regalloc: no free register for spilled source"));
                     }
                     claimed[claimed_count] = tmp; claimed_count = claimed_count + 1;
-                    val er: R.Result[bool, str] = emit_reload(ctx, dst, wp, tmp::u32, v);
+                    val er: R.Result[bool, str] = emit_reload(ctx, dst, wp, tmp::u32, v, mi.loc);
                     if (R.is_err[bool, str](er)) { free_ops(ctx, ops, n); ret er; }
                     ops[k] = mir.op_preg(tmp::u32);
                 } or {
@@ -2929,7 +2930,7 @@ fun rewrite_instr(tgt: *target.Target, ctx: *AllocCtx, mi: *mir.MirInstr,
                         ret R.err[bool, str](regalloc_msg(ctx, "regalloc: no free register for spilled MEM base in '", "'", "regalloc: no free register for spilled MEM base"));
                     }
                     claimed[claimed_count] = tmp; claimed_count = claimed_count + 1;
-                    val er: R.Result[bool, str] = emit_reload(ctx, dst, wp, tmp::u32, v);
+                    val er: R.Result[bool, str] = emit_reload(ctx, dst, wp, tmp::u32, v, mi.loc);
                     if (R.is_err[bool, str](er)) { free_ops(ctx, ops, n); ret er; }
                     ops[k].vreg = mir.MIR_VREG_NIL;
                     ops[k].preg = tmp::u32;
@@ -2951,7 +2952,7 @@ fun rewrite_instr(tgt: *target.Target, ctx: *AllocCtx, mi: *mir.MirInstr,
                         ret R.err[bool, str](regalloc_msg(ctx, "regalloc: no free register for spilled MEM index in '", "'", "regalloc: no free register for spilled MEM index"));
                     }
                     claimed[claimed_count] = tmp; claimed_count = claimed_count + 1;
-                    val er: R.Result[bool, str] = emit_reload(ctx, dst, wp, tmp::u32, iv);
+                    val er: R.Result[bool, str] = emit_reload(ctx, dst, wp, tmp::u32, iv, mi.loc);
                     if (R.is_err[bool, str](er)) { free_ops(ctx, ops, n); ret er; }
                     ops[k].index         = tmp::u32;
                     ops[k].index_is_preg = true;
@@ -2990,6 +2991,10 @@ fun rewrite_instr(tgt: *target.Target, ctx: *AllocCtx, mi: *mir.MirInstr,
     dst[@wp].width         = mi.width;
     dst[@wp].src_width     = mi.src_width;
     dst[@wp].asm_block     = mi.asm_block;
+    # carry the source location through register assignment so the encoder's line
+    # table still maps this instruction's final bytes to its origin (the zeroed
+    # buffer would otherwise leave file 0, a real FileId, not FILE_NIL).
+    dst[@wp].loc           = mi.loc;
     @wp = @wp + 1;
 
     # release the original operand array; its contents were copied into `ops`.
@@ -2999,7 +3004,7 @@ fun rewrite_instr(tgt: *target.Target, ctx: *AllocCtx, mi: *mir.MirInstr,
 
     # store a spilled destination back to its slot.
     if (store_dst_vreg != mir.MIR_VREG_NIL) {
-        val sr: R.Result[bool, str] = emit_store(ctx, dst, wp, store_dst_vreg, store_dst_tmp::u32);
+        val sr: R.Result[bool, str] = emit_store(ctx, dst, wp, store_dst_vreg, store_dst_tmp::u32, mi.loc);
         if (R.is_err[bool, str](sr)) { ret sr; }
     }
     ret R.ok[bool, str](true);
@@ -3113,7 +3118,7 @@ fun id_claimed(claimed: *i32, count: u32, id: i32) bool {
 # slot), matching the by-value-spill addressing convention. propagates an
 # operand-array allocation failure as a Result, mirroring its twin emit_store (the
 # rewrite already threads every other allocation failure through Result).
-fun emit_reload(ctx: *AllocCtx, dst: *mir.MirInstr, wp: *u32, tmp: u32, v: u32) R.Result[bool, str] {
+fun emit_reload(ctx: *AllocCtx, dst: *mir.MirInstr, wp: *u32, tmp: u32, v: u32, loc: source.SrcLoc) R.Result[bool, str] {
     val ro: R.Result[*mir.MirOperand, str] = A.allocate[mir.MirOperand](ctx.alloc, 2::usize);
     if (R.is_err[*mir.MirOperand, str](ro)) { ret R.err[bool, str](R.unwrap_err[*mir.MirOperand, str](ro)); }
     val ops: *mir.MirOperand = R.unwrap_ok[*mir.MirOperand, str](ro);
@@ -3125,6 +3130,9 @@ fun emit_reload(ctx: *AllocCtx, dst: *mir.MirInstr, wp: *u32, tmp: u32, v: u32) 
     # a spill slot holds a full register; reload it at the machine-word width.
     dst[@wp].width         = ctx.spill_width;
     dst[@wp].src_width     = ctx.spill_width;
+    # inherit the served instruction's location so a reload-before-use is attributed
+    # to the line it serves (the zeroed buffer would otherwise leave file 0).
+    dst[@wp].loc           = loc;
     @wp = @wp + 1;
     ret R.ok[bool, str](true);
 }
@@ -3132,7 +3140,7 @@ fun emit_reload(ctx: *AllocCtx, dst: *mir.MirInstr, wp: *u32, tmp: u32, v: u32) 
 # append `MIR_MOV [rbp + slot] <- (preg tmp)` storing a temporary
 # back to a spilled destination vreg's slot. the destination MEM base is the
 # spilled vreg id so the encoder resolves it to `[rbp + offset]`.
-fun emit_store(ctx: *AllocCtx, dst: *mir.MirInstr, wp: *u32, v: u32, tmp: u32) R.Result[bool, str] {
+fun emit_store(ctx: *AllocCtx, dst: *mir.MirInstr, wp: *u32, v: u32, tmp: u32, loc: source.SrcLoc) R.Result[bool, str] {
     val ro: R.Result[*mir.MirOperand, str] = A.allocate[mir.MirOperand](ctx.alloc, 2::usize);
     if (R.is_err[*mir.MirOperand, str](ro)) { ret R.err[bool, str](R.unwrap_err[*mir.MirOperand, str](ro)); }
     val ops: *mir.MirOperand = R.unwrap_ok[*mir.MirOperand, str](ro);
@@ -3144,6 +3152,8 @@ fun emit_store(ctx: *AllocCtx, dst: *mir.MirInstr, wp: *u32, v: u32, tmp: u32) R
     # a spill slot holds a full register; store it at the machine-word width.
     dst[@wp].width         = ctx.spill_width;
     dst[@wp].src_width     = ctx.spill_width;
+    # inherit the served instruction's location (store-after-def), as emit_reload does.
+    dst[@wp].loc           = loc;
     @wp = @wp + 1;
     ret R.ok[bool, str](true);
 }

--- a/src/lang/target/isa/arm64/encode.mach
+++ b/src/lang/target/isa/arm64/encode.mach
@@ -2121,6 +2121,10 @@ fun encode_function_arm64(st: *encode.EncodeState, f: *mir.MirFunction) R.Result
         var ii: u32 = 0;
         for (ii < blk.instr_count) {
             val mi: *mir.MirInstr = ?blk.instrs[ii];
+            # record the PC<->source row at this instruction's first byte (before its
+            # epilogue, so an epilogue+RET maps to the RET's line).
+            val rr: R.Result[bool, str] = encode.push_row(st, st.buf.len::u32, mi.loc);
+            if (R.is_err[bool, str](rr)) { ret rr; }
             if (mi.opcode::u16 == arm64.RET::u16 && !naked) {
                 emit_epilogue(st, f, subsize);
             }

--- a/src/lang/target/isa/riscv64/encode.mach
+++ b/src/lang/target/isa/riscv64/encode.mach
@@ -1991,6 +1991,11 @@ fun encode_function_riscv64(st: *encode.EncodeState, f: *mir.MirFunction) R.Resu
         var ii: u32 = 0;
         for (ii < blk.instr_count) {
             val mi: *mir.MirInstr = ?blk.instrs[ii];
+            # record the PC<->source row at this instruction's first byte (before its
+            # epilogue, so an epilogue+RET maps to the RET's line). the row's offset is
+            # kept correct by the relax pass's insert_text below.
+            val rr: R.Result[bool, str] = encode.push_row(st, st.buf.len::u32, mi.loc);
+            if (R.is_err[bool, str](rr)) { ret rr; }
             if (mi.opcode::u16 == riscv64.RET::u16 && !naked) {
                 emit_epilogue(st, f, total);
             }

--- a/src/lang/target/isa/x64/encode.mach
+++ b/src/lang/target/isa/x64/encode.mach
@@ -2498,6 +2498,10 @@ fun encode_function(st: *enc.EncodeState, f: *mir.MirFunction) R.Result[bool, st
         var ii: u32 = 0;
         for (ii < blk.instr_count) {
             val mi: *mir.MirInstr = ?blk.instrs[ii];
+            # record the PC<->source row at this instruction's first byte (before its
+            # epilogue, so an epilogue+RET maps to the RET's line).
+            val rr: R.Result[bool, str] = enc.push_row(st, st.buf.len::u32, mi.loc);
+            if (R.is_err[bool, str](rr)) { ret rr; }
             # the function epilogue precedes every RET: restore callee-saved
             # registers and tear down the frame, then encode the RET itself.
             if (mi.opcode::u16 == x64.RET::u16 && !naked) {


### PR DESCRIPTION
Closes #1691. Part of the #1688 debug-info foundation.

## What
- **MirInstr.loc**: a source location forwarded from the IR instruction, stamped at the single `push_instr` append chokepoint (like `asm_block`, since struct locals aren't zero-initialized and FILE_NIL≠0). The two direct-append bypasses (phi edge-copy splice, critical-edge branch) and the regalloc flatten rewrite (rewritten instr keeps its loc; a spill reload/store inherits the served instruction's) all set it, so every MirInstr reaching the encoder has a defined location.
- **Encoder row table**: `EncoderOutput` gains an ordered `LineRow (text_offset, sec, loc)` array, mirroring `SymbolMark`/`PendingReloc` (allocated in `EncodeState`, transferred out, freed on error). `push_row` records one per instruction with a valid loc; each ISA's `encode_function` (x64/arm64/riscv64) calls it at the instruction's first byte.
- **Relaxation tracking**: `insert_text` advances row offsets at/past the gap alongside the block/fixup/symbol/reloc tables, so a relaxed riscv64 branch leaves rows pointing at final bytes.
- **`#[section(...)]` re-homing**: `pack_rows` re-homes each row through `site_placed` exactly as symbols are — a sectioned row moves to its named section at the section-relative offset; a `.text` row shifts down by the excised ranges below it.

The row's `loc` (file + byte offset) resolves to line/col via `source.position`; the #1699 `.debug_line`/CodeView producer consumes it. Rows never affect the emitted bytes.

## Invariant
Rows ride the module allocator like the symbol/reloc arrays and nothing emits them yet. Verified byte-identical across all six targets (ELF x64/arm64/riscv64, COFF, Mach-O x64/arm64): my compiler vs origin/dev baseline = **0 differing artifacts** on each. Self-host fixpoint reached; int linux green; unit suite 520 pass / 0 fail (+2: the insert_text relaxation and pack_rows re-home tests).

## Design note
`LineRow` carries a `sec` field beyond the issue's `(text_offset, file, line)`: `site_placed` returns a (section, offset) pair, so a row needs its owning section to be correctly re-homed across `#[section]` excision, exactly as `of.Symbol` does. Line/col is resolved by the consumer from `loc` (the encoder has no SourceMap), which the issue anticipates ('Offset->line/col reuses the existing source.position machinery').
