### PR TITLE
feat(debuginfo): OP_DBG_VALUE IR entity + source-variable identity + births

### DIFF
--- a/src/lang/be/codegen/mir/lower.mach
+++ b/src/lang/be/codegen/mir/lower.mach
@@ -814,6 +814,11 @@ fun lower_instr(ctx: *lctx.LowerCtx, fn: *ir.Function, mb: *mir.MirBlock, iid: i
     if (inst.kind == instr.OP_PHI) {
         ret R.ok[bool, str](true);
     }
+    # OP_DBG_VALUE is pure debug metadata (present only under -g); it lowers to no
+    # machine code, so builds with and without debug info emit identical text.
+    if (inst.kind == instr.OP_DBG_VALUE) {
+        ret R.ok[bool, str](true);
+    }
     if (inst.kind == instr.OP_ALLOCA) {
         ret lower_alloca(ctx, mb, inst, iid);
     }

--- a/src/lang/me/ir.mach
+++ b/src/lang/me/ir.mach
@@ -87,6 +87,22 @@ pub rec IrAsm {
     bind_cap:   u32;
 }
 
+# the source-variable identity attached to an OP_DBG_VALUE instruction, kept in
+# Function.dbg_vars (out of the instruction proper) on the same side-table model
+# as OP_ASM. binds a source variable's identity to the instruction's operand --
+# the variable's current SSA value. pure debug metadata: recorded only under `-g`
+# and never lowered to code, so it owns nothing and never affects emitted output.
+# ---
+# name:  interned source variable name
+# ty:    the variable's IR type
+# scope: lexical scope id the variable is declared in (0 = the function body); the
+#        location-emitter tiers build the scope tree from these ids
+pub rec DbgVar {
+    name:  intern.StrId;
+    ty:    type.IrTypeId;
+    scope: u32;
+}
+
 # a basic block: an ordered instruction list ending in exactly one terminator,
 # plus its phi nodes and predecessor list.
 # ---
@@ -140,6 +156,7 @@ pub rec Block {
 # section:     object section name from a `#[section("...")]` decorator, or STR_NIL
 #              for the default `.text`; the back end places the encoded bytes there
 # asm_blocks:  OP_ASM instruction id -> IrAsm payload map
+# dbg_vars:    OP_DBG_VALUE instruction id -> DbgVar source-variable identity map
 pub rec Function {
     name:        intern.StrId;
     sig:         type.IrTypeId;
@@ -161,6 +178,7 @@ pub rec Function {
     section:     intern.StrId;
 
     asm_blocks:  map.Map[id.InstructionId, IrAsm];
+    dbg_vars:    map.Map[id.InstructionId, DbgVar];
 }
 
 # a module-level global data declaration.
@@ -374,6 +392,8 @@ fun function_dnit(m: *Module, fn: *Function) {
         A.deallocate[instruction.Instruction](m.alloc, fn.instrs, fn.instr_cap::usize);
     }
     map.dnit[id.InstructionId, IrAsm](?fn.asm_blocks);
+    # DbgVar owns no heap storage, so the map's own teardown suffices.
+    map.dnit[id.InstructionId, DbgVar](?fn.dbg_vars);
 }
 
 # free one block's owned instruction, phi, and predecessor arrays.
@@ -449,6 +469,7 @@ pub fun function_add(m: *Module, name: intern.StrId, sig: type.IrTypeId, flags: 
     f.line        = 0;
     f.section     = intern.STR_NIL;
     f.asm_blocks  = map.init[id.InstructionId, IrAsm](m.alloc, map.hash_u32, map.eq_u32);
+    f.dbg_vars    = map.init[id.InstructionId, DbgVar](m.alloc, map.hash_u32, map.eq_u32);
     m.functions[idx] = f;
     m.function_len   = m.function_len + 1;
     ret R.ok[u32, str](idx);

--- a/src/lang/me/ir/builder.mach
+++ b/src/lang/me/ir/builder.mach
@@ -22,6 +22,7 @@
 # overwriting the first.
 
 use std.allocator.page;
+use std.collections.map;
 use std.types.bool.bool;
 use std.types.bool.true;
 use std.types.size.usize;
@@ -845,6 +846,43 @@ pub fun emit_asm(b: *Builder, operands: *value.Value, operand_count: u32) R.Resu
         i = i + 1;
     }
     ret emit_raw_owned(b, instruction.OP_ASM, void_ty, ops, operand_count);
+}
+
+# emit an OP_DBG_VALUE binding the source variable (name, ty, scope) to `val`, its
+# current SSA value; produces no value
+#
+# Records the variable identity in the current function's dbg_vars side table,
+# keyed by the new instruction's id. The frontend emits this only under `-g`; it
+# is pure debug metadata the back end skips, so it never affects emitted code. Its
+# `val` operand is rewritten by RAUW like any other, so the debug value follows the
+# SSA value it tracks across the optimizer.
+# ---
+# b:     the builder
+# val:   the SSA value the variable currently holds
+# name:  interned source variable name
+# ty:    the variable's IR type
+# scope: lexical scope id the variable is declared in
+# ret:   ok(true) on success, or an error
+pub fun emit_dbg_value(b: *Builder, val: value.Value, name: intern.StrId, ty: type.IrTypeId, scope: u32) R.Result[bool, str] {
+    val res_void: R.Result[type.IrTypeId, str] = void_type(b);
+    if (R.is_err[type.IrTypeId, str](res_void)) {
+        ret R.err[bool, str](R.unwrap_err[type.IrTypeId, str](res_void));
+    }
+    val void_ty: type.IrTypeId = R.unwrap_ok[type.IrTypeId, str](res_void);
+
+    var ops: [1]value.Value;
+    ops[0] = val;
+    val res_iid: R.Result[id.InstructionId, str] = emit_raw(b, instruction.OP_DBG_VALUE, void_ty, ?ops[0], 1);
+    if (R.is_err[id.InstructionId, str](res_iid)) {
+        ret R.err[bool, str](R.unwrap_err[id.InstructionId, str](res_iid));
+    }
+    val iid: id.InstructionId = R.unwrap_ok[id.InstructionId, str](res_iid);
+
+    var dv: ir.DbgVar;
+    dv.name  = name;
+    dv.ty    = ty;
+    dv.scope = scope;
+    ret map.insert[id.InstructionId, ir.DbgVar](?b.fn.dbg_vars, iid, dv);
 }
 
 # shared body for two-operand binary ops; result type follows lhs

--- a/src/lang/me/ir/builder.mach
+++ b/src/lang/me/ir/builder.mach
@@ -35,6 +35,7 @@ use mach.lang.intern;
 use mach.lang.me.ir;
 use mach.lang.me.ir.id;
 use mach.lang.me.ir.instruction;
+use mach.lang.me.ir.mutate;
 use mach.lang.me.ir.type;
 use mach.lang.me.ir.value;
 use mach.lang.source;
@@ -1191,6 +1192,61 @@ test "mach.lang.me.ir.builder.pool_append:stamps_loc_cursor" {
     val fn2: *ir.Function = ?m.functions[R.unwrap_ok[u32, str](res_fn2)];
     set_function(?b, fn2);
     if (source.loc_is_valid(current_loc(?b))) { ret 1; }
+
+    ir.dnit(?m);
+    ret 0;
+}
+
+# emit_dbg_value records the source variable in dbg_vars and binds it to a value
+# operand, and RAUW (mutate.replace_uses) rewrites that operand like any other, so
+# a debug value follows the SSA value it tracks
+test "mach.lang.me.ir.builder.emit_dbg_value:records_and_rauw_moves" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+
+    val res_m: R.Result[ir.Module, str] = ir.init(?alloc, intern.STR_NIL);
+    if (R.is_err[ir.Module, str](res_m)) { ret 1; }
+    var m: ir.Module = R.unwrap_ok[ir.Module, str](res_m);
+
+    val res_i64: R.Result[type.IrTypeId, str] = type.intern_int(?m.types, 64);
+    if (R.is_err[type.IrTypeId, str](res_i64)) { ret 1; }
+    val i64t: type.IrTypeId = R.unwrap_ok[type.IrTypeId, str](res_i64);
+
+    val res_fn: R.Result[u32, str] = ir.function_add(?m, intern.STR_NIL, type.IRT_NIL, 0);
+    if (R.is_err[u32, str](res_fn)) { ret 1; }
+    val fn: *ir.Function = ?m.functions[R.unwrap_ok[u32, str](res_fn)];
+
+    var b: Builder = init(?m);
+    set_function(?b, fn);
+    val res_blk: R.Result[id.BlockId, str] = new_block(?b);
+    if (R.is_err[id.BlockId, str](res_blk)) { ret 1; }
+    set_block(?b, R.unwrap_ok[id.BlockId, str](res_blk));
+
+    # a value to track, then a debug value binding a variable to it
+    val res_add: R.Result[value.Value, str] = emit_add(?b, value.const_int(1, i64t), value.const_int(2, i64t));
+    if (R.is_err[value.Value, str](res_add)) { ret 1; }
+    val v: value.Value = R.unwrap_ok[value.Value, str](res_add);
+    val v_id: id.InstructionId = v.data.instr;
+
+    if (R.is_err[bool, str](emit_dbg_value(?b, v, intern.STR_NIL, i64t, 0))) { ret 1; }
+
+    # the OP_DBG_VALUE is the last-appended instruction; its operand is v
+    val dbg_id: u32 = fn.instr_len - 1;
+    val dbg: *instruction.Instruction = ?fn.instrs[dbg_id];
+    if (dbg.kind != instruction.OP_DBG_VALUE)    { ret 1; }
+    if (dbg.operand_count != 1)                  { ret 1; }
+    if (dbg.operands[0].kind != value.VAL_INSTR) { ret 1; }
+    if (dbg.operands[0].data.instr != v_id)      { ret 1; }
+
+    # the variable identity is recorded in dbg_vars
+    var key: id.InstructionId = dbg_id::id.InstructionId;
+    if (R.is_err[*ir.DbgVar, str](map.get[id.InstructionId, ir.DbgVar](?fn.dbg_vars, ?key))) { ret 1; }
+
+    # RAUW replaces v with param 0; the debug value's operand moves with it
+    mutate.replace_uses(fn, v_id, value.param(0, i64t));
+    val dbg2: *instruction.Instruction = ?fn.instrs[dbg_id];
+    if (dbg2.operands[0].kind != value.VAL_PARAM) { ret 1; }
+    if (dbg2.operands[0].data.param_ix != 0)      { ret 1; }
 
     ir.dnit(?m);
     ret 0;

--- a/src/lang/me/ir/instruction.mach
+++ b/src/lang/me/ir/instruction.mach
@@ -134,6 +134,15 @@ pub val OP_ASM:         InstrKind = 43;
 # opcode is reserved for record / union / array slots.
 pub val OP_MEMZERO:     InstrKind = 44;
 
+# debug variable location; operand [value]; produces no value. pure debug
+# metadata binding a source variable to its current SSA value: the source
+# variable's identity (name, type, scope) lives in Function.dbg_vars keyed by this
+# instruction's id, the same side-table model OP_ASM uses. emitted only under `-g`
+# and never lowered to code -- the back end skips it -- so builds without debug
+# info are byte-identical. its operand is rewritten by RAUW like any other, which
+# is how a debug value follows the SSA value it tracks across the optimizer.
+pub val OP_DBG_VALUE:   InstrKind = 45;
+
 # no-signed-wrap: the result is poison if signed overflow occurs
 pub val INSTR_FLAG_NSW:      u16 = 0x01;
 # no-unsigned-wrap: the result is poison if unsigned overflow occurs
@@ -223,6 +232,7 @@ pub fun is_pure(k: InstrKind) bool {
     if (k == OP_ALLOCA)   { ret false; }
     if (k == OP_ASM)      { ret false; }
     if (k == OP_PHI)      { ret false; }
+    if (k == OP_DBG_VALUE) { ret false; }
     ret true;
 }
 

--- a/src/lang/me/ir/printer.mach
+++ b/src/lang/me/ir/printer.mach
@@ -542,9 +542,10 @@ fun print_flag_suffixes(out: *writer.Writer, flags: u16) R.Result[bool, str] {
 # ret: true when the opcode yields a named SSA result
 fun produces_value(k: instruction.InstrKind) bool {
     if (instruction.is_terminator(k)) { ret false; }
-    if (k == instruction.OP_STORE)    { ret false; }
-    if (k == instruction.OP_MEMZERO)  { ret false; }
-    if (k == instruction.OP_ASM)      { ret false; }
+    if (k == instruction.OP_STORE)     { ret false; }
+    if (k == instruction.OP_MEMZERO)   { ret false; }
+    if (k == instruction.OP_ASM)       { ret false; }
+    if (k == instruction.OP_DBG_VALUE) { ret false; }
     ret true;
 }
 
@@ -591,6 +592,7 @@ fun opcode_name(k: instruction.InstrKind) str {
     if (k == instruction.OP_LOAD)        { ret "load"; }
     if (k == instruction.OP_STORE)       { ret "store"; }
     if (k == instruction.OP_MEMZERO)     { ret "memzero"; }
+    if (k == instruction.OP_DBG_VALUE)   { ret "dbg_value"; }
     if (k == instruction.OP_GEP)         { ret "gep"; }
     if (k == instruction.OP_EXTRACT)     { ret "extract"; }
     if (k == instruction.OP_INSERT)      { ret "insert"; }

--- a/src/lang/me/ir/verify.mach
+++ b/src/lang/me/ir/verify.mach
@@ -1285,6 +1285,8 @@ fun arity_ok(k: instruction.InstrKind, operand_count: u32) bool {
     if (k == instruction.OP_UNREACHABLE) { ret operand_count == 0; }
     # asm: any number of input operands.
     if (k == instruction.OP_ASM) { ret true; }
+    # dbg_value: [value] -- the SSA value the source variable currently holds.
+    if (k == instruction.OP_DBG_VALUE) { ret operand_count == 1; }
     # an opcode with no arity entry is a missing dispatch case, not valid IR:
     # fail loudly (VC_OPERAND_TYPE) instead of silently accepting any count.
     ret false;

--- a/src/lang/me/lower/context.mach
+++ b/src/lang/me/lower/context.mach
@@ -23,6 +23,7 @@ use mach.lang.fe.comptime;
 use mach.lang.fe.resolve;
 use mach.lang.fe.sema;
 use mach.lang.fe.sema.generics;
+use mach.lang.fe.token;
 use mach.lang.intern;
 use mach.lang.me.ir;
 use mach.lang.me.ir.builder;
@@ -1151,6 +1152,28 @@ pub fun module_source(lc: *LowerContext) str {
     val sf: O.Option[*source.SourceFile] = source.get(?lc.s.sources, lc.a.file_id);
     if (O.is_none[*source.SourceFile](sf)) { ret ""; }
     ret O.unwrap[*source.SourceFile](sf).text;
+}
+
+# emit an OP_DBG_VALUE binding the source variable named by `name_span` (type
+# `ty`) to `val_v`, its current value
+#
+# Interns the variable's source name and records the debug value in the current
+# function. Scope is the function body (0) for now; the location-emitter tiers
+# build the scope tree. Callers gate this on `lc.s.debug`; shared by the decl,
+# parameter, and reassignment birth sites.
+# ---
+# lc:        the lowering context
+# name_span: source span of the variable's identifier
+# ty:        the variable's IR type
+# val_v:     the value the variable currently holds
+# ret:       true on success, or an error
+pub fun emit_dbg_birth(lc: *LowerContext, name_span: token.Span, ty: ir_type.IrTypeId, val_v: value.Value) R.Result[bool, str] {
+    val res_name: R.Result[intern.StrId, str] = intern.intern_span(?lc.s.interner, module_source(lc), name_span);
+    if (R.is_err[intern.StrId, str](res_name)) {
+        ret R.err[bool, str](R.unwrap_err[intern.StrId, str](res_name));
+    }
+    val name: intern.StrId = R.unwrap_ok[intern.StrId, str](res_name);
+    ret builder.emit_dbg_value(?lc.builder, val_v, name, ty, 0);
 }
 
 # return a pointer to a resolved Symbol by id, or none when out of range.

--- a/src/lang/me/lower/context.mach
+++ b/src/lang/me/lower/context.mach
@@ -1203,6 +1203,7 @@ pub fun ensure_extern_function(lc: *LowerContext, name: intern.StrId, sig: ir_ty
     f.label       = intern.STR_NIL;
     f.section     = intern.STR_NIL;
     f.asm_blocks  = map.init[ir.InstructionId, ir.IrAsm](m.alloc, map.hash_u32, map.eq_u32);
+    f.dbg_vars    = map.init[ir.InstructionId, ir.DbgVar](m.alloc, map.hash_u32, map.eq_u32);
 
     m.functions[idx] = f;
     m.function_len   = m.function_len + 1;

--- a/src/lang/me/lower/decl.mach
+++ b/src/lang/me/lower/decl.mach
@@ -870,7 +870,7 @@ fun lower_params(ctx: *context.LowerContext, did: id.DeclId, d: *decl.Decl, fn_i
 
         # debug birth: bind the parameter to its incoming value, under -g only.
         if (ctx.s.debug && pool_ix::usize < ctx.a.typed_name_len) {
-            val res_dbg: R.Result[bool, str] = stmt.emit_dbg_birth(ctx, ctx.a.typed_names[pool_ix].name, p_ir, pval);
+            val res_dbg: R.Result[bool, str] = context.emit_dbg_birth(ctx, ctx.a.typed_names[pool_ix].name, p_ir, pval);
             if (R.is_err[bool, str](res_dbg)) {
                 if (params != nil) { A.deallocate[value.Value](ctx.s.alloc, params, rt_count::usize); }
                 ret res_dbg;

--- a/src/lang/me/lower/decl.mach
+++ b/src/lang/me/lower/decl.mach
@@ -1232,6 +1232,7 @@ fun append_function(ctx: *context.LowerContext, name: intern.StrId, sig: ir_type
     f.line        = 0;
     f.section     = intern.STR_NIL;
     f.asm_blocks  = map.init[ir.InstructionId, ir.IrAsm](m.alloc, map.hash_u32, map.eq_u32);
+    f.dbg_vars    = map.init[ir.InstructionId, ir.DbgVar](m.alloc, map.hash_u32, map.eq_u32);
 
     m.functions[idx] = f;
     m.function_len   = m.function_len + 1;

--- a/src/lang/me/lower/decl.mach
+++ b/src/lang/me/lower/decl.mach
@@ -867,6 +867,16 @@ fun lower_params(ctx: *context.LowerContext, did: id.DeclId, d: *decl.Decl, fn_i
                 ret res_bind;
             }
         }
+
+        # debug birth: bind the parameter to its incoming value, under -g only.
+        if (ctx.s.debug && pool_ix::usize < ctx.a.typed_name_len) {
+            val res_dbg: R.Result[bool, str] = stmt.emit_dbg_birth(ctx, ctx.a.typed_names[pool_ix].name, p_ir, pval);
+            if (R.is_err[bool, str](res_dbg)) {
+                if (params != nil) { A.deallocate[value.Value](ctx.s.alloc, params, rt_count::usize); }
+                ret res_dbg;
+            }
+        }
+
         w = w + 1;
         i = i + 1;
     }

--- a/src/lang/me/lower/expr.mach
+++ b/src/lang/me/lower/expr.mach
@@ -2230,6 +2230,22 @@ fun lower_assign(ctx: *context.LowerContext, e: *expr.Expr) R.Result[value.Value
 
     val res_store: R.Result[bool, str] = builder.emit_store(?ctx.builder, rhs, ptr);
     if (R.is_err[bool, str](res_store)) { ret R.err[value.Value, str](R.unwrap_err[bool, str](res_store)); }
+
+    # debug birth on reassignment: rebind a simple named variable to its new value,
+    # under -g only. field / index / deref lvalues are memory writes, not variable
+    # rebinds, so they carry no debug value.
+    if (ctx.s.debug) {
+        val opt_lhs: O.Option[*expr.Expr] = ast.get_expr(ctx.a, e.data.binary.lhs);
+        if (O.is_some[*expr.Expr](opt_lhs)) {
+            val lhs_e: *expr.Expr = O.unwrap[*expr.Expr](opt_lhs);
+            if (lhs_e.kind == expr.EXPR_KIND_IDENT) {
+                val res_dbg: R.Result[bool, str] = context.emit_dbg_birth(ctx, lhs_e.span, rhs.ty, rhs);
+                if (R.is_err[bool, str](res_dbg)) {
+                    ret R.err[value.Value, str](R.unwrap_err[bool, str](res_dbg));
+                }
+            }
+        }
+    }
     ret R.ok[value.Value, str](rhs);
 }
 

--- a/src/lang/me/lower/stmt.mach
+++ b/src/lang/me/lower/stmt.mach
@@ -435,30 +435,9 @@ fun lower_decl_stmt(ctx: *context.LowerContext, s: *stmt.Stmt) R.Result[bool, st
     # debug birth: bind the source variable to the value it currently holds. only
     # under -g, so a non-debug build emits identical code.
     if (ctx.s.debug) {
-        ret emit_dbg_birth(ctx, d.data.bind.name, slot_ty, birth_val);
+        ret context.emit_dbg_birth(ctx, d.data.bind.name, slot_ty, birth_val);
     }
     ret R.ok[bool, str](true);
-}
-
-# emit an OP_DBG_VALUE binding the source variable named by `name_span` (type
-# `ty`) to `val_v`, its current value
-#
-# Interns the variable's source name and records the debug value in the current
-# function. Scope is the function body (0) for now; the location-emitter tiers
-# build the scope tree. Callers gate this on `ctx.s.debug`.
-# ---
-# ctx:       the context
-# name_span: source span of the variable's identifier
-# ty:        the variable's IR type
-# val_v:     the value the variable currently holds
-# ret:       true on success, or an error
-pub fun emit_dbg_birth(ctx: *context.LowerContext, name_span: token.Span, ty: ir_type.IrTypeId, val_v: value.Value) R.Result[bool, str] {
-    val res_name: R.Result[intern.StrId, str] = intern.intern_span(?ctx.s.interner, context.module_source(ctx), name_span);
-    if (R.is_err[intern.StrId, str](res_name)) {
-        ret R.err[bool, str](R.unwrap_err[intern.StrId, str](res_name));
-    }
-    val name: intern.StrId = R.unwrap_ok[intern.StrId, str](res_name);
-    ret builder.emit_dbg_value(?ctx.builder, val_v, name, ty, 0);
 }
 
 # lower an inline-asm statement

--- a/src/lang/me/lower/stmt.mach
+++ b/src/lang/me/lower/stmt.mach
@@ -404,19 +404,61 @@ fun lower_decl_stmt(ctx: *context.LowerContext, s: *stmt.Stmt) R.Result[bool, st
     val res_bind: R.Result[bool, str] = context.bind_local(ctx, sym, slot);
     if (R.is_err[bool, str](res_bind)) { ret res_bind; }
 
+    # the value the variable initially holds, used to birth its debug value under
+    # -g: the initializer for an explicit binding, the storage pointer for a
+    # zero-filled aggregate (an aggregate value IS its storage), the zero constant
+    # for a scalar.
+    var birth_val: value.Value;
+
     if (d.data.bind.init != id.EXPR_NIL) {
         val res_init: R.Result[value.Value, str] = expr.lower_rvalue(ctx, d.data.bind.init);
         if (R.is_err[value.Value, str](res_init)) {
             ret R.err[bool, str](R.unwrap_err[value.Value, str](res_init));
         }
         val init: value.Value = R.unwrap_ok[value.Value, str](res_init);
-        ret builder.emit_store(?ctx.builder, init, slot);
+        val res_store: R.Result[bool, str] = builder.emit_store(?ctx.builder, init, slot);
+        if (R.is_err[bool, str](res_store)) { ret res_store; }
+        birth_val = init;
+    }
+    or (ir_type.is_aggregate(?ctx.m.types, slot_ty)) {
+        val res_mz: R.Result[bool, str] = builder.emit_memzero(?ctx.builder, slot, slot_ty);
+        if (R.is_err[bool, str](res_mz)) { ret res_mz; }
+        birth_val = slot;
+    }
+    or {
+        val zc: value.Value = zero_const(ctx, slot_ty);
+        val res_store: R.Result[bool, str] = builder.emit_store(?ctx.builder, zc, slot);
+        if (R.is_err[bool, str](res_store)) { ret res_store; }
+        birth_val = zc;
     }
 
-    if (ir_type.is_aggregate(?ctx.m.types, slot_ty)) {
-        ret builder.emit_memzero(?ctx.builder, slot, slot_ty);
+    # debug birth: bind the source variable to the value it currently holds. only
+    # under -g, so a non-debug build emits identical code.
+    if (ctx.s.debug) {
+        ret emit_dbg_birth(ctx, d.data.bind.name, slot_ty, birth_val);
     }
-    ret builder.emit_store(?ctx.builder, zero_const(ctx, slot_ty), slot);
+    ret R.ok[bool, str](true);
+}
+
+# emit an OP_DBG_VALUE binding the source variable named by `name_span` (type
+# `ty`) to `val_v`, its current value
+#
+# Interns the variable's source name and records the debug value in the current
+# function. Scope is the function body (0) for now; the location-emitter tiers
+# build the scope tree. Callers gate this on `ctx.s.debug`.
+# ---
+# ctx:       the context
+# name_span: source span of the variable's identifier
+# ty:        the variable's IR type
+# val_v:     the value the variable currently holds
+# ret:       true on success, or an error
+fun emit_dbg_birth(ctx: *context.LowerContext, name_span: token.Span, ty: ir_type.IrTypeId, val_v: value.Value) R.Result[bool, str] {
+    val res_name: R.Result[intern.StrId, str] = intern.intern_span(?ctx.s.interner, context.module_source(ctx), name_span);
+    if (R.is_err[intern.StrId, str](res_name)) {
+        ret R.err[bool, str](R.unwrap_err[intern.StrId, str](res_name));
+    }
+    val name: intern.StrId = R.unwrap_ok[intern.StrId, str](res_name);
+    ret builder.emit_dbg_value(?ctx.builder, val_v, name, ty, 0);
 }
 
 # lower an inline-asm statement

--- a/src/lang/me/lower/stmt.mach
+++ b/src/lang/me/lower/stmt.mach
@@ -452,7 +452,7 @@ fun lower_decl_stmt(ctx: *context.LowerContext, s: *stmt.Stmt) R.Result[bool, st
 # ty:        the variable's IR type
 # val_v:     the value the variable currently holds
 # ret:       true on success, or an error
-fun emit_dbg_birth(ctx: *context.LowerContext, name_span: token.Span, ty: ir_type.IrTypeId, val_v: value.Value) R.Result[bool, str] {
+pub fun emit_dbg_birth(ctx: *context.LowerContext, name_span: token.Span, ty: ir_type.IrTypeId, val_v: value.Value) R.Result[bool, str] {
     val res_name: R.Result[intern.StrId, str] = intern.intern_span(?ctx.s.interner, context.module_source(ctx), name_span);
     if (R.is_err[intern.StrId, str](res_name)) {
         ret R.err[bool, str](R.unwrap_err[intern.StrId, str](res_name));


### PR DESCRIPTION
Closes #1695. Debug-info foundation (#1688): the shared IR substrate that binds a source variable to its current SSA value, consumed unchanged by both the DWARF and CodeView location emitters.

## What
- **OP_DBG_VALUE** opcode (45): operand `[value]`, produces no value, non-pure (never CSE'd or dropped). Its variable identity (name, type, scope) lives in `Function.dbg_vars` keyed by instruction id — the same side-table model OP_ASM uses. Printer renders `dbg_value`; verifier accepts a 1-operand arity; the **back end skips it** (lowers to no MIR, like a phi).
- **`builder.emit_dbg_value`** emits it + records the `DbgVar`.
- **Births at lowering, gated on `session.debug` (`-g`):** each local `val`/`var`, each parameter, and each reassignment of a simple named variable emits `dbg_value(var, current-value)`. Field/index/deref writes are memory stores, not variable rebinds, and carry none. `emit_dbg_birth` (in `me/lower/context.mach`) is the shared birth helper.
- **Maintained by the mutation API for free:** the `[value]` operand is rewritten by RAUW like any other, so a debug value follows the SSA value it tracks. Under `-g`, mem2reg promotion rewrites the operands to the reaching SSA defs (confirmed in the emitted IR).

## Model / notes
- dbg.value-style (bind to the value), not dbg.declare (bind to the slot) — directly tracks the value, valid until the next dbg-value for the variable, and exactly what #1696 extends.
- `scope` is a placeholder id (0 = function body); the location-emitter tiers build the scope tree.
- No emitter here (that is the DWARF/CodeView tiers); no optimizer birth/salvage (that is #1696).
- Fixed a latent crash: two direct `Function` constructors didn't init the new `dbg_vars` map, so a dbg-value insert under `-g` segfaulted (invisible without `-g`).

## Verification (dev-baseline vs branch, rebased on current dev)
- **Byte-identical emitted output without `-g` on all six shipped targets** (the invariant holds — nothing changes emitted code).
- `-g` builds cleanly on all paths; the IR shows dbg-values whose operands are the mem2reg-promoted SSA values.
- Self-host fixpoint converges; unit suite 521/0 (dev baseline 520 + the one new `emit_dbg_value` test); int green on linux.

Depends-on: #1689, #1690 (both merged).
