### PR TITLE
test(dbg): debug-info CI verification lane + fixtures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -356,3 +356,38 @@ jobs:
       - name: run integration suite
         shell: bash
         run: bash int/run.sh --target ${{ matrix.target }} ./m
+
+  # debug-info verification: build a from-source compiler (seeded by the matching
+  # release), then run dbg/verify.sh, which builds the dbg/ fixtures with and without
+  # -g and machine-checks the emitted DWARF — llvm-dwarfdump --verify, an addr2line
+  # PC->file:line round-trip, and the additive-only byte-identity guard (-g must not
+  # perturb the loaded program). the validators read the target object regardless of
+  # the host ISA, so this one x86_64 linux runner covers every shipped ELF ISA. the
+  # macho/coff lanes are staged pending their producers (see dbg/README.md).
+  debuginfo:
+    name: debuginfo
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: install debug-info validators
+        run: |
+          set -euo pipefail
+          sudo apt-get update
+          sudo apt-get install -y llvm binutils
+
+      - name: build the from-source compiler
+        env:
+          GH_TOKEN: ${{ github.token }}
+          SEED: mach-*-x86_64-linux.tar.gz
+        run: |
+          set -euo pipefail
+          tmp="$(mktemp -d)"
+          gh release download -R "$GITHUB_REPOSITORY" -p "$SEED" -D "$tmp"
+          tar -xzf "$tmp"/$SEED -C /usr/local/bin mach
+          chmod +x /usr/local/bin/mach
+          mach dep pull
+          mach build . -o m
+
+      - name: verify debug info
+        run: bash dbg/verify.sh ./m

--- a/dbg/.gitattributes
+++ b/dbg/.gitattributes
@@ -1,0 +1,3 @@
+# fixture sources and the harness are LF on every host; keep a windows checkout
+# from turning them into CRLF and perturbing a build or a byte-identity compare.
+* text eol=lf

--- a/dbg/.gitignore
+++ b/dbg/.gitignore
@@ -1,0 +1,4 @@
+# per-fixture build state, realized by the harness (`<compiler> dep pull` + build)
+dep/
+out/
+mach.lock

--- a/dbg/README.md
+++ b/dbg/README.md
@@ -1,0 +1,68 @@
+# `dbg/` — debug-info verification harness
+
+Machine-checks the debug info `mach build -g` emits, against the format's own
+validators. The compiler is its own linker and ships no external tools, so
+debug-info correctness is asserted in CI against committed fixtures using
+test-only validators (`llvm-dwarfdump`, `addr2line`, and — as their producers
+land — `llvm-pdbutil` / `lldb`). Those deps live here, never in `int/`, which
+stays tool-free by design.
+
+Every debug-info tier issue (the DWARF and CodeView epics under #1688) references
+this lane in its acceptance: it exists early and is extended per producer.
+
+## Layout
+
+```
+dbg/
+  verify.sh          the harness: build each fixture ±-g, run the validators
+  fixtures/
+    multi/           a tiny multi-function program (mach.toml + src/main.mach)
+  README.md
+```
+
+`verify.sh <compiler>` builds every `fixtures/*` case with and without `-g`
+using the given compiler and runs the checks. `--filter <glob>` narrows to
+matching fixture directories. It exits nonzero if any check fails. Per-fixture
+build state (`dep/`, `out/`, `mach.lock`) is gitignored.
+
+## What is live vs staged
+
+**Live — DWARF on ELF.** The DWARF producer emits real
+`.debug_abbrev`/`.debug_info`/`.debug_line` under `-g`, so the ELF lane runs
+today. `llvm-dwarfdump`/`addr2line` read the target object regardless of the
+host's ISA, so one linux runner validates every shipped ELF ISA
+(`linux`, `linux-arm64`, `linux-riscv64`). Per target it asserts:
+
+1. `llvm-dwarfdump --verify` accepts the whole image.
+2. the fixture compile unit exists and its PC range lies inside `.text`.
+3. every helper function is represented in the line table at its own `fun` line,
+   and `addr2line` round-trips one such PC back to `main.mach:<line>`.
+4. the line table references several distinct source lines (multi-function).
+5. **additive-only:** every `PT_LOAD` segment is byte-identical between the `-g`
+   and no-`-g` builds (modulo the ELF header's section-table bookkeeping). `-g`
+   must not perturb one byte of the loaded program — it only appends non-loaded
+   debug sections. This is the invariant that guards the whole program.
+
+**Staged — pending their producers.** Wired as documented expansion points in
+`verify.sh` and provisioned runners; each turns on when its producer lands:
+
+- **Mach-O DWARF runtime** (`darwin-x86_64` / `darwin-aarch64`): the runtime
+  checks from #1698's runtime-check comment — `codesign --verify` covering the
+  `__DWARF` bytes, dyld load, and an `lldb` source-line breakpoint — need a macOS
+  runner, which `int-main.yml` already provides on merge to `main`. The
+  structural `llvm-dwarfdump --verify` already works host-side on a cross-built
+  Mach-O and can be lifted into the ELF loop's shape when a macho fixture leg is
+  added.
+- **COFF / CodeView** (`windows`): needs the CodeView producer (#1595). `mach
+  build -g` emits no debug sections for COFF today, so the lane is dormant and
+  byte-identical off. Once it lands, `llvm-pdbutil` / `llvm-readobj --sections`
+  assert the discardable `.debug$S`/`.debug$T` sections and the COFF long-name
+  string table, on the existing `windows` runner in `ci.yml`.
+
+## Adding a fixture
+
+Drop a mach project under `fixtures/<name>/` (a `mach.toml` plus `src/`). The ELF
+lane picks it up automatically; it must contain the `add`/`mul`/`square`
+functions the line-table checks anchor on, or extend `verify.sh`'s anchor set. A
+tier issue turns a staged lane live by adding its checks to the staged block in
+`verify.sh` and its runner leg to the workflow.

--- a/dbg/fixtures/multi/mach.toml
+++ b/dbg/fixtures/multi/mach.toml
@@ -1,0 +1,52 @@
+[project]
+id      = "dbgfix"
+name    = "dbgfix"
+version = "0.0.0"
+src     = "src"
+dep     = "dep"
+target  = "linux"
+out     = "out/{target}/{profile}/bin/{name}{ext}"
+
+[target.linux]
+isa = "x86_64"
+os  = "linux"
+abi = "sysv64"
+
+[target.linux-arm64]
+isa = "aarch64"
+os  = "linux"
+abi = "aapcs64"
+
+[target.linux-riscv64]
+isa = "riscv64"
+os  = "linux"
+abi = "lp64"
+
+[target.windows]
+isa = "x86_64"
+os  = "windows"
+abi = "win64"
+ext = ".exe"
+
+[target.darwin-x86_64]
+isa = "x86_64"
+os  = "darwin"
+abi = "sysv64"
+
+[target.darwin-aarch64]
+isa = "aarch64"
+os  = "darwin"
+abi = "aapcs64"
+
+[profile.debug]
+opt = 0
+
+[profile.release]
+opt = 2
+
+[bin.dbgfix]
+entry = "main.mach"
+
+[deps.mach-std]
+git = "https://github.com/briar-systems/mach-std"
+ref = "branch/main"

--- a/dbg/fixtures/multi/src/main.mach
+++ b/dbg/fixtures/multi/src/main.mach
@@ -1,0 +1,32 @@
+# debug-info verification fixture: a tiny multi-function program.
+#
+# several functions on distinct source lines. the verifier greps a source line out
+# of this file (the `fun add` line), maps it to a PC through the emitted DWARF line
+# table, and asserts a standard consumer (addr2line) resolves that PC back to this
+# file at that line. the printed output is incidental — the lane inspects DWARF,
+# it does not diff stdout.
+
+use std.runtime;
+use std.types.size.usize;
+use p: std.print;
+
+fun add(a: i64, b: i64) i64 {
+    ret a + b;
+}
+
+fun mul(a: i64, b: i64) i64 {
+    ret a * b;
+}
+
+fun square(v: i64) i64 {
+    val s: i64 = mul(v, v);
+    ret s;
+}
+
+#[symbol("main")]
+fun main(argc: usize, argv: **u8) i64 {
+    p.printlnf("add={}", add(2, 3));
+    p.printlnf("mul={}", mul(4, 5));
+    p.printlnf("square={}", square(6));
+    ret 0;
+}

--- a/dbg/verify.sh
+++ b/dbg/verify.sh
@@ -1,0 +1,237 @@
+#!/usr/bin/env bash
+# verify.sh — the debug-info verification harness.
+#
+# usage: verify.sh [--filter <glob>] <compiler>
+#
+# for each debug-info fixture under dbg/fixtures/, builds it with and without `-g`
+# using the given compiler and machine-checks the emitted debug info with external
+# validators (llvm-dwarfdump, addr2line). the exit status is nonzero if any check
+# on any fixture×target fails.
+#
+# WHY A SEPARATE HARNESS. the int/ golden-diff harness deliberately depends on no
+# external tooling (it reads binary fields with coreutils); debug-info correctness
+# can only be asserted against the format's own validators (llvm-dwarfdump --verify,
+# addr2line, and — once their producers land — llvm-pdbutil / lldb). keeping those
+# test-only deps here leaves int/ tool-free.
+#
+# WHAT IS LIVE TODAY. the DWARF-on-ELF producer emits real .debug_abbrev/.debug_info/
+# .debug_line under `-g`, so the ELF lane below is live: it runs on every shipped ELF
+# ISA (llvm-dwarfdump/addr2line read the target object regardless of host ISA, so one
+# linux runner covers x86_64 + aarch64 + riscv64). the Mach-O runtime checks (lldb /
+# codesign / dyld) and the COFF/CodeView checks (llvm-pdbutil) are STAGED — see the
+# staged block at the end of this file and dbg/README.md. this is the lane every
+# debug-info tier issue references in its acceptance.
+set -u
+
+here=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+fixtures="$here/fixtures"
+
+usage() {
+    echo "usage: verify.sh [--filter <glob>] <compiler>" >&2
+    exit 2
+}
+
+filter='*'
+compiler=
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --filter) shift; [ $# -gt 0 ] || usage; filter=$1 ;;
+        -h|--help) usage ;;
+        -*) echo "verify.sh: unknown flag '$1'" >&2; usage ;;
+        *)  [ -z "$compiler" ] || { echo "verify.sh: unexpected argument '$1'" >&2; usage; }
+            compiler=$1 ;;
+    esac
+    shift
+done
+[ -n "$compiler" ] || { echo "verify.sh: a compiler path is required" >&2; usage; }
+
+# resolve the compiler to an absolute path; fixtures build from their own dirs.
+case "$compiler" in
+    /*) : ;;
+    *)  compiler=$(CDPATH= cd -- "$(dirname -- "$compiler")" && pwd)/$(basename -- "$compiler") ;;
+esac
+
+# the ELF/DWARF targets validated host-side. every shipped ELF ISA emits DWARF and
+# the validators read the target object regardless of the host's ISA, so this one
+# linux runner covers them all. macho/coff are staged (see the end of the file).
+elf_targets="linux linux-arm64 linux-riscv64"
+
+# resolve_dwarfdump — print an llvm-dwarfdump on PATH, preferring the unversioned
+# name and falling back to the highest-versioned one (ubuntu ships llvm-dwarfdump-NN).
+resolve_dwarfdump() {
+    if command -v llvm-dwarfdump >/dev/null 2>&1; then echo llvm-dwarfdump; return 0; fi
+    newest=$(compgen -c 'llvm-dwarfdump-' 2>/dev/null | sort -t- -k3 -n | tail -1)
+    [ -n "$newest" ] && { echo "$newest"; return 0; }
+    return 1
+}
+
+dwarfdump=$(resolve_dwarfdump) || {
+    echo "verify.sh: llvm-dwarfdump not found (install the 'llvm' package)" >&2
+    exit 2
+}
+command -v addr2line >/dev/null 2>&1 || {
+    echo "verify.sh: addr2line not found (install 'binutils')" >&2
+    exit 2
+}
+
+fails=0
+ran=0
+
+# cu_bounds <binary> — print "<low> <high>" (decimal) of the fixture compile unit
+# (the one whose DW_AT_name is the fixture's ./src/main.mach), or nothing if absent.
+cu_bounds() {
+    "$dwarfdump" --debug-info "$1" 2>/dev/null | awk '
+        /DW_TAG_compile_unit/{lo="";hi="";nm=0}
+        $0 ~ /"\.\/src\/main\.mach"/{nm=1}
+        /DW_AT_low_pc/{gsub(/[()]/,"",$2);lo=$2}
+        /DW_AT_high_pc/{gsub(/[()]/,"",$2);hi=$2; if(nm){print strtonum(lo), strtonum(hi); exit}}'
+}
+
+# text_range <binary> — print "<addr> <addr+size>" (decimal) of the .text section.
+text_range() {
+    readelf -SW "$1" 2>/dev/null | awk '
+        /\.text/ && /PROGBITS/ {
+            for (i=1;i<=NF;i++) if ($i=="PROGBITS") { a=strtonum("0x"$(i+1)); s=strtonum("0x"$(i+3)); print a, a+s; exit }
+        }'
+}
+
+# row_addr <binary> <low> <high> <line> — print the first line-table row address
+# (0x-hex) inside [low,high) whose source line equals <line>, or nothing.
+row_addr() {
+    "$dwarfdump" --debug-line "$1" 2>/dev/null | awk -v lo="$2" -v hi="$3" -v ln="$4" '
+        /^0x/{a=strtonum($1); if(a>=lo && a<hi && $2==ln){printf "0x%x\n", a; exit}}'
+}
+
+# distinct_lines <binary> <low> <high> — count distinct source lines the CU's rows
+# reference (a multi-function fixture must reference several).
+distinct_lines() {
+    "$dwarfdump" --debug-line "$1" 2>/dev/null | awk -v lo="$2" -v hi="$3" '
+        /^0x/{a=strtonum($1); if(a>=lo && a<hi) seen[$2]=1} END{print length(seen)}'
+}
+
+# elf_seg_identical <a> <b> — true if every PT_LOAD segment of <a> has byte-identical
+# file content in <b>, after the ELF header's section-table bookkeeping (e_shoff,
+# e_shnum, e_shstrndx — expected to differ once -g adds named sections) is normalized.
+# this is the additive-only guard: -g must not perturb one byte of the loaded program.
+elf_seg_identical() {
+    an=$(mktemp); bn=$(mktemp)
+    _norm_shdr_fields "$1" "$an"; _norm_shdr_fields "$2" "$bn"
+    rc=0
+    while read -r off fsz; do
+        [ "$fsz" -eq 0 ] && continue
+        if ! cmp -s \
+            <(dd if="$an" bs=1M iflag=skip_bytes,count_bytes skip="$off" count="$fsz" status=none) \
+            <(dd if="$bn" bs=1M iflag=skip_bytes,count_bytes skip="$off" count="$fsz" status=none); then
+            rc=1; break
+        fi
+    done < <(readelf -lW "$1" 2>/dev/null | awk '/LOAD/{print strtonum($2), strtonum($6)}')
+    rm -f "$an" "$bn"
+    return $rc
+}
+
+# _norm_shdr_fields <in> <out> — copy <in> to <out> zeroing e_shoff/e_shnum/e_shstrndx.
+_norm_shdr_fields() {
+    cp "$1" "$2"
+    printf '\0\0\0\0\0\0\0\0' | dd of="$2" bs=1 seek=40 count=8 conv=notrunc status=none
+    printf '\0\0'             | dd of="$2" bs=1 seek=60 count=2 conv=notrunc status=none
+    printf '\0\0'             | dd of="$2" bs=1 seek=62 count=2 conv=notrunc status=none
+}
+
+# verify_dwarf <fixture_dir> <build_target> — the live ELF/DWARF checks for one
+# fixture built for one target. returns 0 on pass, 1 on any failed assertion.
+verify_dwarf() {
+    dir=$1; bt=$2
+    label="${dir#"$here"/} [$bt]"
+    tmp=$(mktemp -d)
+    g="$tmp/g"; nog="$tmp/nog"
+    src="$dir/src/main.mach"
+
+    if ! (cd "$dir" && "$compiler" dep pull && "$compiler" build . --target "$bt" --profile debug -g -o "$g") >"$tmp/build.log" 2>&1; then
+        echo "FAIL $label (build -g)"; sed 's/^/    /' "$tmp/build.log" >&2; rm -rf "$tmp"; return 1
+    fi
+    if ! (cd "$dir" && "$compiler" build . --target "$bt" --profile debug -o "$nog") >"$tmp/build2.log" 2>&1; then
+        echo "FAIL $label (build no-g)"; sed 's/^/    /' "$tmp/build2.log" >&2; rm -rf "$tmp"; return 1
+    fi
+
+    # 1. the standard structural verifier accepts the whole image.
+    if ! "$dwarfdump" --verify "$g" >"$tmp/verify.log" 2>&1; then
+        echo "FAIL $label (llvm-dwarfdump --verify)"; tail -20 "$tmp/verify.log" | sed 's/^/    /' >&2; rm -rf "$tmp"; return 1
+    fi
+
+    # 2. the fixture compile unit exists and its PC range lies inside .text.
+    read -r low high < <(cu_bounds "$g")
+    if [ -z "${low:-}" ] || [ -z "${high:-}" ]; then
+        echo "FAIL $label (no compile unit for ./src/main.mach)"; rm -rf "$tmp"; return 1
+    fi
+    read -r tlo thi < <(text_range "$g")
+    if [ -z "${tlo:-}" ] || [ "$low" -lt "$tlo" ] || [ "$high" -gt "$thi" ] || [ "$low" -ge "$high" ]; then
+        echo "FAIL $label (CU [$low,$high) not within .text [$tlo,$thi))"; rm -rf "$tmp"; return 1
+    fi
+
+    # 3. every helper function is represented in the line table at its own `fun` line,
+    #    and a standard consumer (addr2line) round-trips one such PC back to file:line.
+    rc=0
+    for fn in add mul square; do
+        fl=$(grep -n "^fun $fn" "$src" | head -1 | cut -d: -f1)
+        if [ -z "$fl" ]; then echo "FAIL $label (fixture has no 'fun $fn')" >&2; rc=1; continue; fi
+        a=$(row_addr "$g" "$low" "$high" "$fl")
+        if [ -z "$a" ]; then echo "FAIL $label (no line row for 'fun $fn' at line $fl)" >&2; rc=1; continue; fi
+        if [ "$fn" = add ]; then
+            out=$(addr2line -e "$g" "$a" 2>/dev/null)
+            file=${out%:*}; ln=${out##*:}; ln=${ln%% *}
+            if [ "${file##*/}" != "main.mach" ] || [ "$ln" != "$fl" ]; then
+                echo "FAIL $label (addr2line $a -> '$out', want main.mach:$fl)" >&2; rc=1
+            fi
+        fi
+    done
+    if [ "$rc" -ne 0 ]; then rm -rf "$tmp"; return 1; fi
+
+    # 4. multi-function coverage: the CU references several distinct source lines.
+    n=$(distinct_lines "$g" "$low" "$high")
+    if [ "${n:-0}" -lt 3 ]; then
+        echo "FAIL $label (only $n distinct source lines in the CU; expected a multi-function table)"; rm -rf "$tmp"; return 1
+    fi
+
+    # 5. additive-only: -g must not perturb the loaded program. every PT_LOAD segment
+    #    is byte-identical between the -g and no-g builds (modulo the ELF header's
+    #    section-table bookkeeping). a codegen change under -g fails here.
+    if ! elf_seg_identical "$g" "$nog"; then
+        echo "FAIL $label (-g perturbed a loadable segment vs the no-g build)"; rm -rf "$tmp"; return 1
+    fi
+
+    echo "PASS $label"
+    rm -rf "$tmp"
+    return 0
+}
+
+for dir in "$fixtures"/$filter; do
+    [ -f "$dir/mach.toml" ] || continue
+    for bt in $elf_targets; do
+        ran=$((ran + 1))
+        verify_dwarf "$dir" "$bt" || fails=$((fails + 1))
+    done
+done
+
+# STAGED — expansion points wired but not yet live, each pending its producer. these
+# consume the same fixtures; a tier issue turns one on by adding its checks here and
+# its runner leg (see dbg/README.md and issue #1698's runtime-check comment).
+#
+#   Mach-O DWARF runtime (darwin-x86_64 / darwin-aarch64) — needs a macOS runner
+#     (int-main.yml, on merge to main): `codesign --verify` covers the __DWARF bytes,
+#     the image loads under dyld, and lldb hits a source-line breakpoint. the
+#     structural llvm-dwarfdump --verify already works host-side and can be lifted
+#     into the elf loop's shape once a macho fixture leg is added.
+#   COFF / CodeView (windows) — needs the CodeView producer (#1595); `mach build -g`
+#     emits no debug sections for COFF today, so the lane is dormant. once it lands:
+#     llvm-pdbutil / llvm-readobj --sections assert the .debug$S/.debug$T discardable
+#     sections and the COFF long-name string table, on the existing windows runner.
+
+if [ "$ran" -eq 0 ]; then
+    echo "verify.sh: no fixtures matched --filter '$filter'" >&2
+    exit 1
+fi
+if [ "$fails" -ne 0 ]; then
+    echo "dbg: $fails failure(s)"
+    exit 1
+fi
+echo "dbg: all debug-info checks passed ($ran target build(s))"


### PR DESCRIPTION
Closes #1698.

Stands up `dbg/`, the debug-info verification harness the tier issues under the
debuginfo epic (#1688) reference in their acceptance. Now that `mach build -g`
emits real, validated DWARF on ELF (#1899), this verifies real producer output
rather than hand-authored bytes.

## What is live (ELF/DWARF)

`dbg/verify.sh <compiler>` builds each `fixtures/*` case with and without `-g`
and, for every shipped ELF ISA host-side (`llvm-dwarfdump`/`addr2line` read the
target object regardless of the host ISA, so one linux runner covers
`linux` + `linux-arm64` + `linux-riscv64`), asserts:

1. `llvm-dwarfdump --verify` accepts the whole image.
2. the fixture compile unit exists and its PC range lies inside `.text`.
3. every function is represented in the line table at its `fun` line, and
   `addr2line` round-trips a PC back to `main.mach:<line>`.
4. the CU references several distinct source lines (multi-function).
5. **additive-only:** every `PT_LOAD` segment is byte-identical between the `-g`
   and no-`-g` builds (modulo the ELF header's section-table bookkeeping). `-g`
   never perturbs the loaded program — it only appends non-loaded debug sections.
   This is the invariant that guards the whole program.

Wired into `ci.yml` as the `debuginfo` job (per-PR, linux).

## What is staged

Documented expansion points in `verify.sh` + `dbg/README.md`, each pending its
producer, on runners that already exist:

- **Mach-O DWARF runtime** (darwin) — `codesign --verify` / dyld load / `lldb`
  breakpoint from #1698's runtime-check comment, on the `int-main.yml` macOS
  runner. Structural `--verify` already works host-side on a cross-built Mach-O.
- **COFF / CodeView** (windows) — `llvm-pdbutil` checks, pending the CodeView
  producer (#1595). `mach build -g` emits no COFF debug sections today, so the
  lane is dormant and byte-identical off.

## Falsifiability

Each guard was shown to fail on deliberate breakage before passing on real
output: a wrong `addr2line` line expectation (end-to-end lane fails on all three
ISAs), a corrupted `.debug_line` (`--verify` fails), a no-`-g` build (no compile
unit), and a flipped `.text` byte (byte-identity fails). The lane is green on
this PR.
