### PR TITLE
docs(ir): mark disp/ret_sem as inert debug metadata

### DIFF
--- a/src/lang/me/ir.mach
+++ b/src/lang/me/ir.mach
@@ -157,12 +157,14 @@ pub rec Block {
 #              reported as `file:line` by `mach test`; 0 for every non-test function
 # section:     object section name from a `#[section("...")]` decorator, or STR_NIL
 #              for the default `.text`; the back end places the encoded bytes there
-# disp:        bare source name of the function, retained so the DWARF producer emits
-#              a readable DW_AT_name instead of the mangled linkage name; STR_NIL for
-#              a synthesized function that has no source spelling
-# ret_sem:     semantic return type (`mach.lang.type`, which keeps integer signedness
-#              the IR type erases), retained so the DWARF producer emits an accurate
-#              return base type; TYPE_NIL for a void return or an unrecovered type
+# disp:        bare source name of the function. inert debug metadata like `loc`
+#              (#1689): the machine-code path never reads it; only the `-g` DWARF
+#              producer does, for a readable DW_AT_name instead of the mangled linkage
+#              name. STR_NIL for a synthesized function with no source spelling
+# ret_sem:     semantic return type (`mach.lang.type`, which keeps the integer
+#              signedness the IR type erases). inert debug metadata read only by the
+#              `-g` DWARF producer, for an accurate return base type; TYPE_NIL for a
+#              void return or an unrecovered type
 # asm_blocks:  OP_ASM instruction id -> IrAsm payload map
 # dbg_vars:    OP_DBG_VALUE instruction id -> DbgVar source-variable identity map
 pub rec Function {


### PR DESCRIPTION
Small follow-up to #1703 (merged as #1901). The `ir.Function.disp` / `ret_sem` field docs now state explicitly that they are inert debug metadata — the machine-code path never reads them; only the `-g` DWARF producer does — mirroring the framing of #1689's `loc` field. Requested in review of #1703; the clause missed the #1901 merge by timing.

Doc-only; no behavior change.
