### PR TITLE
feat(ir): maintain dbg-values through optimization (salvage + expression pool)

### DIFF
--- a/src/lang/me/ir.mach
+++ b/src/lang/me/ir.mach
@@ -105,6 +105,50 @@ pub rec DbgVar {
     scope: u32;
 }
 
+# add the op's `arg` to the operand value
+pub val DBG_OP_PLUS_CONST:  u8 = 0;
+# subtract the op's `arg` from the operand value
+pub val DBG_OP_MINUS_CONST: u8 = 1;
+
+# one step of a debug-location expression, applied to an OP_DBG_VALUE operand to
+# recover the source variable's value after the instruction that defined the operand
+# was folded away (`%c = add %a, 4` deleted -> operand rebased to %a, expression
+# gains a +4 step). the op set is deliberately small and extensible: each -g location
+# emitter maps a step to its own encoding (a DWARF DW_OP_plus_uconst / minus, a
+# CodeView defrange adjust).
+# ---
+# op:  DBG_OP_* selector
+# arg: the step's u64 immediate (the folded constant's bit pattern)
+pub rec DbgOp {
+    op:  u8;
+    arg: u64;
+}
+
+# a DbgExprId of DBG_EXPR_IDENTITY names the empty expression: the OP_DBG_VALUE
+# operand is the variable's value verbatim, with no steps to apply. it owns no pool
+# slot, so a function that never salvages allocates no expression storage.
+pub val DBG_EXPR_IDENTITY: DbgExprId = 0;
+
+# an index identifying the debug-location expression an OP_DBG_VALUE applies to its
+# operand. DBG_EXPR_IDENTITY (0) is the empty expression and owns no slot; every
+# other id is 1-based into the owning function's `dbg_exprs` pool.
+pub def DbgExprId: u32;
+
+# a debug-location expression: the steps applied base-first to an OP_DBG_VALUE
+# operand to recover the source variable's value. this is the emitter-facing seam --
+# the -g location emitters (DWARF loclists, CodeView defranges) read one shared,
+# format-agnostic pool per function (Function.dbg_exprs) rather than each re-deriving
+# recovery math. an empty `ops` is the identity expression.
+# ---
+# ops:      the expression steps, applied in order (owned)
+# op_count: number of live steps
+# op_cap:   allocated capacity of `ops` (the true allocation size freed at teardown)
+pub rec DbgExpr {
+    ops:      *DbgOp;
+    op_count: u32;
+    op_cap:   u32;
+}
+
 # a basic block: an ordered instruction list ending in exactly one terminator,
 # plus its phi nodes and predecessor list.
 # ---
@@ -167,6 +211,13 @@ pub rec Block {
 #              void return or an unrecovered type
 # asm_blocks:  OP_ASM instruction id -> IrAsm payload map
 # dbg_vars:    OP_DBG_VALUE instruction id -> DbgVar source-variable identity map
+# dbg_exprs:   debug-location expression pool; a DbgExprId is 1-based into it
+#              (DBG_EXPR_IDENTITY owns no slot). the optimizer's dce salvage grows it,
+#              the -g location emitters consume it (#1696); owned
+# dbg_expr_len: number of live expressions in the pool
+# dbg_expr_cap: allocated capacity of `dbg_exprs`
+# dbg_expr_ids: OP_DBG_VALUE instruction id -> the DbgExprId it applies to its
+#              operand; an absent entry means DBG_EXPR_IDENTITY
 pub rec Function {
     name:        intern.StrId;
     sig:         type.IrTypeId;
@@ -191,6 +242,11 @@ pub rec Function {
 
     asm_blocks:  map.Map[id.InstructionId, IrAsm];
     dbg_vars:    map.Map[id.InstructionId, DbgVar];
+
+    dbg_exprs:    *DbgExpr;
+    dbg_expr_len: u32;
+    dbg_expr_cap: u32;
+    dbg_expr_ids: map.Map[id.InstructionId, DbgExprId];
 }
 
 # a module-level global data declaration.
@@ -271,6 +327,8 @@ val INITIAL_GLOBAL_CAP:      u32 = 8;   # globals array (allocated eagerly by in
 val INITIAL_INSTR_CAP:       u32 = 64;  # a function's instruction pool
 val INITIAL_BLOCK_LIST_CAP:  u32 = 4;   # block instr / phi / pred lists and the block array
 val INITIAL_PHI_OPERAND_CAP: u32 = 4;   # a phi's operand list
+val INITIAL_DBG_EXPR_CAP:    u32 = 4;   # a function's debug-location expression pool
+val INITIAL_DBG_OP_CAP:      u32 = 4;   # one debug-location expression's op list
 
 # construct an empty IR module with an initialized type table and no functions,
 # globals, or init function.
@@ -406,6 +464,21 @@ fun function_dnit(m: *Module, fn: *Function) {
     map.dnit[id.InstructionId, IrAsm](?fn.asm_blocks);
     # DbgVar owns no heap storage, so the map's own teardown suffices.
     map.dnit[id.InstructionId, DbgVar](?fn.dbg_vars);
+
+    # each pooled expression owns its ops array; free those, then the pool and the
+    # per-point id map (a DbgExprId owns no heap storage).
+    var e: u32 = 0;
+    for (e < fn.dbg_expr_len) {
+        val dex: *DbgExpr = ?fn.dbg_exprs[e];
+        if (dex.ops != nil && dex.op_cap > 0) {
+            A.deallocate[DbgOp](m.alloc, dex.ops, dex.op_cap::usize);
+        }
+        e = e + 1;
+    }
+    if (fn.dbg_exprs != nil && fn.dbg_expr_cap > 0) {
+        A.deallocate[DbgExpr](m.alloc, fn.dbg_exprs, fn.dbg_expr_cap::usize);
+    }
+    map.dnit[id.InstructionId, DbgExprId](?fn.dbg_expr_ids);
 }
 
 # free one block's owned instruction, phi, and predecessor arrays.
@@ -484,6 +557,10 @@ pub fun function_add(m: *Module, name: intern.StrId, sig: type.IrTypeId, flags: 
     f.ret_sem     = semtype.TYPE_NIL;
     f.asm_blocks  = map.init[id.InstructionId, IrAsm](m.alloc, map.hash_u32, map.eq_u32);
     f.dbg_vars    = map.init[id.InstructionId, DbgVar](m.alloc, map.hash_u32, map.eq_u32);
+    f.dbg_exprs    = nil;
+    f.dbg_expr_len = 0;
+    f.dbg_expr_cap = 0;
+    f.dbg_expr_ids = map.init[id.InstructionId, DbgExprId](m.alloc, map.hash_u32, map.eq_u32);
     m.functions[idx] = f;
     m.function_len   = m.function_len + 1;
     ret R.ok[u32, str](idx);
@@ -633,6 +710,108 @@ pub fun phi_append_incoming(m: *Module, phi: *instruction.Instruction, pred: id.
     phi.operands[phi.operand_count]     = R.unwrap_ok[value.Value, str](res_target);
     phi.operands[phi.operand_count + 1] = incoming;
     phi.operand_count = needed;
+    ret R.ok[bool, str](true);
+}
+
+# the DbgExprId the OP_DBG_VALUE `iid` applies to its operand, or DBG_EXPR_IDENTITY
+# when none is recorded. the single lookup the salvage path and the -g location
+# emitters share.
+# ---
+# fn:  the owning function
+# iid: an OP_DBG_VALUE instruction id
+# ret: the recorded DbgExprId, or DBG_EXPR_IDENTITY if absent
+pub fun dbg_expr_id(fn: *Function, iid: id.InstructionId) DbgExprId {
+    var key: id.InstructionId = iid;
+    val res: R.Result[*DbgExprId, str] = map.get[id.InstructionId, DbgExprId](?fn.dbg_expr_ids, ?key);
+    if (R.is_err[*DbgExprId, str](res)) { ret DBG_EXPR_IDENTITY; }
+    val p: *DbgExprId = R.unwrap_ok[*DbgExprId, str](res);
+    ret @p;
+}
+
+# a pointer to the pooled expression `eid` names, or none for DBG_EXPR_IDENTITY (the
+# empty expression owns no slot) or an out-of-range id. the accessor through which
+# the -g location emitters read an expression's recovery steps.
+# ---
+# fn:  the owning function
+# eid: the expression id to resolve
+# ret: some(*DbgExpr) for a live pooled expression, none for identity / out of range
+pub fun dbg_expr_get(fn: *Function, eid: DbgExprId) O.Option[*DbgExpr] {
+    if (eid == DBG_EXPR_IDENTITY) { ret O.none[*DbgExpr](); }
+    val idx: u32 = eid::u32 - 1;
+    if (idx >= fn.dbg_expr_len)   { ret O.none[*DbgExpr](); }
+    ret O.some[*DbgExpr](?fn.dbg_exprs[idx]);
+}
+
+# append a fresh, empty expression to `fn`'s pool and record it as the expression
+# OP_DBG_VALUE `iid` applies to its operand, returning its DbgExprId (>= 1). salvage
+# calls this the first time it rewrites a dbg-value's defining instruction; each
+# pooled expression has exactly one referencing OP_DBG_VALUE, so a later prepend into
+# it is unshared.
+# ---
+# m:   module owning the allocator
+# fn:  the function whose pool grows
+# iid: the OP_DBG_VALUE the new expression binds to
+# ret: the new DbgExprId, or an allocation error
+pub fun dbg_expr_new(m: *Module, fn: *Function, iid: id.InstructionId) R.Result[DbgExprId, str] {
+    if (fn.dbg_expr_len >= fn.dbg_expr_cap) {
+        var new_cap: u32 = fn.dbg_expr_cap * 2;
+        if (new_cap < INITIAL_DBG_EXPR_CAP) { new_cap = INITIAL_DBG_EXPR_CAP; }
+        val res_grow: R.Result[*DbgExpr, str] =
+            A.reallocate[DbgExpr](m.alloc, fn.dbg_exprs, fn.dbg_expr_cap::usize, new_cap::usize);
+        if (R.is_err[*DbgExpr, str](res_grow)) {
+            ret R.err[DbgExprId, str](R.unwrap_err[*DbgExpr, str](res_grow));
+        }
+        fn.dbg_exprs    = R.unwrap_ok[*DbgExpr, str](res_grow);
+        fn.dbg_expr_cap = new_cap;
+    }
+    val idx: u32 = fn.dbg_expr_len;
+    fn.dbg_exprs[idx].ops      = nil;
+    fn.dbg_exprs[idx].op_count = 0;
+    fn.dbg_exprs[idx].op_cap   = 0;
+    fn.dbg_expr_len = fn.dbg_expr_len + 1;
+
+    val eid: DbgExprId = (idx + 1)::DbgExprId;
+    val res_ins: R.Result[bool, str] = map.insert[id.InstructionId, DbgExprId](?fn.dbg_expr_ids, iid, eid);
+    if (R.is_err[bool, str](res_ins)) {
+        ret R.err[DbgExprId, str](R.unwrap_err[bool, str](res_ins));
+    }
+    ret R.ok[DbgExprId, str](eid);
+}
+
+# prepend a step to expression `eid` (base-first order), growing its op array as
+# needed. salvage prepends because a newly folded instruction sits closer to the
+# operand than the steps already recorded: the surviving base is mapped back to the
+# old operand before the earlier recovery runs.
+# ---
+# m:   module owning the allocator
+# fn:  the owning function
+# eid: the expression to extend (>= 1)
+# op:  the step to prepend
+# ret: ok(true), or an allocation error
+pub fun dbg_expr_prepend_op(m: *Module, fn: *Function, eid: DbgExprId, op: DbgOp) R.Result[bool, str] {
+    val opt: O.Option[*DbgExpr] = dbg_expr_get(fn, eid);
+    if (O.is_none[*DbgExpr](opt)) { ret R.err[bool, str]("dbg_expr_prepend_op: invalid expression id"); }
+    val dex: *DbgExpr = O.unwrap[*DbgExpr](opt);
+
+    if (dex.op_count >= dex.op_cap) {
+        var new_cap: u32 = dex.op_cap * 2;
+        if (new_cap < INITIAL_DBG_OP_CAP) { new_cap = INITIAL_DBG_OP_CAP; }
+        val res_grow: R.Result[*DbgOp, str] =
+            A.reallocate[DbgOp](m.alloc, dex.ops, dex.op_cap::usize, new_cap::usize);
+        if (R.is_err[*DbgOp, str](res_grow)) {
+            ret R.err[bool, str](R.unwrap_err[*DbgOp, str](res_grow));
+        }
+        dex.ops    = R.unwrap_ok[*DbgOp, str](res_grow);
+        dex.op_cap = new_cap;
+    }
+
+    var i: u32 = dex.op_count;
+    for (i > 0) {
+        dex.ops[i] = dex.ops[i - 1];
+        i = i - 1;
+    }
+    dex.ops[0]   = op;
+    dex.op_count = dex.op_count + 1;
     ret R.ok[bool, str](true);
 }
 

--- a/src/lang/me/ir/instruction.mach
+++ b/src/lang/me/ir/instruction.mach
@@ -141,6 +141,19 @@ pub val OP_MEMZERO:     InstrKind = 44;
 # and never lowered to code -- the back end skips it -- so builds without debug
 # info are byte-identical. its operand is rewritten by RAUW like any other, which
 # is how a debug value follows the SSA value it tracks across the optimizer.
+#
+# The variable's value is the operand with the debug-location expression
+# Function.dbg_exprs[dbg_expr_id] applied (identity when none is recorded): the
+# optimizer's dce salvage rebases the operand onto a surviving value and records a
+# recovery expression when the defining instruction is folded (#1696). A
+# VAL_CONST_NULL operand is the *optimized out* sentinel -- no recoverable location
+# -- so a location emitter shows the variable as optimized out, never a stale value.
+#
+# Fidelity gap (#1904): mem2reg does not yet re-emit a birth at the phi it inserts
+# for a promoted local, so past a control-flow merge a variable's binding may reflect
+# the last-processed predecessor's value rather than the merged phi. Straight-line
+# and single-definition code is exact; only merge points are affected, until the
+# phi-birth + alloca-to-source-variable link lands.
 pub val OP_DBG_VALUE:   InstrKind = 45;
 
 # no-signed-wrap: the result is poison if signed overflow occurs

--- a/src/lang/me/ir/mutate.mach
+++ b/src/lang/me/ir/mutate.mach
@@ -15,6 +15,7 @@
 #     own predicate (dce's dead set, mem2reg's promoted memops).
 #   - cloning: `clone_instruction`, a faithful per-instruction copy.
 
+use std.collections.map;
 use std.types.bool.bool;
 use std.types.bool.false;
 use std.types.bool.true;
@@ -22,6 +23,7 @@ use std.types.size.usize;
 use std.types.string.str;
 
 use A: std.allocator;
+use O: std.types.option;
 use R: std.types.result;
 
 use mach.lang.me.ir;
@@ -217,10 +219,13 @@ pub def EraseTest: fun(ptr, id.InstructionId) bool;
 # Survivor order is preserved; a dropped instruction's pool entry remains as a
 # ghost, reclaimed at function teardown.
 # ---
+# m:    module owning the allocator (salvage grows the function's dbg-expression pool)
 # fn:   the function whose block lists are compacted
 # ctx:  opaque state threaded to `test`
 # test: the removal predicate
-pub fun erase_marked(fn: *ir.Function, ctx: ptr, test: EraseTest) {
+# ret:  ok(true) once every marked instruction is dropped and its dbg-values
+#       salvaged, or an allocation error raised while growing the pool
+pub fun erase_marked(m: *ir.Module, fn: *ir.Function, ctx: ptr, test: EraseTest) R.Result[bool, str] {
     var b: u32 = 0;
     for (b < fn.block_count) {
         val blk: *ir.Block = ?fn.blocks[b];
@@ -231,6 +236,10 @@ pub fun erase_marked(fn: *ir.Function, ctx: ptr, test: EraseTest) {
             if (test(ctx, blk.phis[r]) == false) {
                 blk.phis[w] = blk.phis[r];
                 w = w + 1;
+            }
+            or {
+                val res: R.Result[bool, str] = salvage_dbg_values(m, fn, ctx, test, blk.phis[r]);
+                if (R.is_err[bool, str](res)) { ret res; }
             }
             r = r + 1;
         }
@@ -243,12 +252,148 @@ pub fun erase_marked(fn: *ir.Function, ctx: ptr, test: EraseTest) {
                 blk.instructions[w] = blk.instructions[r];
                 w = w + 1;
             }
+            or {
+                val res: R.Result[bool, str] = salvage_dbg_values(m, fn, ctx, test, blk.instructions[r]);
+                if (R.is_err[bool, str](res)) { ret res; }
+            }
             r = r + 1;
         }
         blk.instr_count = w;
 
         b = b + 1;
     }
+    ret R.ok[bool, str](true);
+}
+
+# salvage every debug value bound to instruction `dropped`, which erase_marked is
+# about to remove, so its variable's location survives the erase
+#
+# When `dropped` is a recoverable pure op (an add/sub of a constant) whose base
+# itself survives this erase, each debug value naming it is rebased onto the base and
+# its pooled expression gains a step recovering the old operand -- the variable's
+# value stays computable. Otherwise (an unrecoverable op, or a base that is also
+# being erased) the debug value is marked optimized out: its operand becomes the
+# null idiom, so the debugger shows *optimized out* rather than a stale value.
+# Without `-g` a function holds no debug values and the length guard makes this a
+# no-op.
+# ---
+# m:       module owning the allocator
+# fn:      the function being compacted
+# ctx:     the erase predicate's context (to test whether the base also dies)
+# test:    the erase predicate
+# dropped: the instruction id being removed
+# ret:     ok(true), or an allocation error from growing the expression pool
+fun salvage_dbg_values(m: *ir.Module, fn: *ir.Function, ctx: ptr, test: EraseTest, dropped: id.InstructionId) R.Result[bool, str] {
+    if (map.length[id.InstructionId, ir.DbgVar](fn.dbg_vars) == 0) { ret R.ok[bool, str](true); }
+
+    var base:        value.Value;
+    var op:          ir.DbgOp;
+    var recoverable: bool = false;
+    salvage_decode(fn, dropped, ?base, ?op, ?recoverable);
+
+    # the recovered expression names the base, so the base must itself survive this
+    # erase; a base that is also dying leaves nothing to compute from.
+    var base_live: bool = false;
+    if (recoverable) {
+        if (base.kind != value.VAL_INSTR) { base_live = true; }
+        or { base_live = test(ctx, base.data.instr) == false; }
+    }
+
+    var i: u32 = 0;
+    for (i < fn.instr_len) {
+        val d: *instruction.Instruction = ?fn.instrs[i];
+        if (d.kind == instruction.OP_DBG_VALUE && d.operand_count == 1
+            && d.operands[0].kind == value.VAL_INSTR && d.operands[0].data.instr == dropped) {
+            if (recoverable && base_live) {
+                val res: R.Result[bool, str] = salvage_rebase(m, fn, i::id.InstructionId, d, base, op);
+                if (R.is_err[bool, str](res)) { ret res; }
+            }
+            or {
+                # unrecoverable: mark optimized out via the null operand idiom.
+                d.operands[0] = value.const_null(d.operands[0].ty);
+            }
+        }
+        i = i + 1;
+    }
+    ret R.ok[bool, str](true);
+}
+
+# rebase debug value `iid` (the instruction `d`) onto `base` and prepend `op` to its
+# pooled expression, so the variable's value is recovered from the surviving base
+# ---
+# m:    module owning the allocator
+# fn:   the owning function
+# iid:  the OP_DBG_VALUE instruction id
+# d:    the OP_DBG_VALUE instruction (its operand is rewritten to `base`)
+# base: the surviving value the expression is rebased onto
+# op:   the recovery step mapping `base` back to the old operand
+# ret:  ok(true), or an allocation error from growing the pool
+fun salvage_rebase(m: *ir.Module, fn: *ir.Function, iid: id.InstructionId, d: *instruction.Instruction, base: value.Value, op: ir.DbgOp) R.Result[bool, str] {
+    var eid: ir.DbgExprId = ir.dbg_expr_id(fn, iid);
+    if (eid == ir.DBG_EXPR_IDENTITY) {
+        val res_new: R.Result[ir.DbgExprId, str] = ir.dbg_expr_new(m, fn, iid);
+        if (R.is_err[ir.DbgExprId, str](res_new)) {
+            ret R.err[bool, str](R.unwrap_err[ir.DbgExprId, str](res_new));
+        }
+        eid = R.unwrap_ok[ir.DbgExprId, str](res_new);
+    }
+    val res_op: R.Result[bool, str] = ir.dbg_expr_prepend_op(m, fn, eid, op);
+    if (R.is_err[bool, str](res_op)) { ret res_op; }
+    d.operands[0] = base;
+    ret R.ok[bool, str](true);
+}
+
+# decode whether instruction `dropped` is a debug-recoverable `add` / `sub` of a
+# constant, yielding the surviving base value and the expression step that recovers
+# the original operand from it
+#
+# `add base, k` and `add k, base` recover as base + k (DBG_OP_PLUS_CONST); `sub
+# base, k` recovers as base - k (DBG_OP_MINUS_CONST). `sub k, base` is not a constant
+# offset of a single value, so it is left unrecoverable.
+# ---
+# fn:          the owning function
+# dropped:     the instruction id to decode
+# base:        receives the non-constant operand (the recovery base)
+# op:          receives the recovery step (kind + immediate)
+# recoverable: receives true when a recovery was decoded
+fun salvage_decode(fn: *ir.Function, dropped: id.InstructionId, base: *value.Value, op: *ir.DbgOp, recoverable: *bool) {
+    @recoverable = false;
+    val opt_x: O.Option[*instruction.Instruction] = ir.instruction_get(fn, dropped);
+    if (O.is_none[*instruction.Instruction](opt_x)) { ret; }
+    val x: *instruction.Instruction = O.unwrap[*instruction.Instruction](opt_x);
+
+    if (x.kind == instruction.OP_ADD && x.operand_count == 2) {
+        if (x.operands[1].kind == value.VAL_CONST_INT) {
+            @base = x.operands[0];
+            @op = dbg_op(ir.DBG_OP_PLUS_CONST, x.operands[1].data.int_lit);
+            @recoverable = true;
+            ret;
+        }
+        if (x.operands[0].kind == value.VAL_CONST_INT) {
+            @base = x.operands[1];
+            @op = dbg_op(ir.DBG_OP_PLUS_CONST, x.operands[0].data.int_lit);
+            @recoverable = true;
+            ret;
+        }
+    }
+    if (x.kind == instruction.OP_SUB && x.operand_count == 2 && x.operands[1].kind == value.VAL_CONST_INT) {
+        @base = x.operands[0];
+        @op = dbg_op(ir.DBG_OP_MINUS_CONST, x.operands[1].data.int_lit);
+        @recoverable = true;
+        ret;
+    }
+}
+
+# build a DbgOp from a selector and immediate
+# ---
+# kind: DBG_OP_* selector
+# arg:  the op's u64 immediate
+# ret:  the DbgOp
+fun dbg_op(kind: u8, arg: u64) ir.DbgOp {
+    var o: ir.DbgOp;
+    o.op  = kind;
+    o.arg = arg;
+    ret o;
 }
 
 # clone instruction `src` into `dst_fn`'s pool and return the new instruction's id

--- a/src/lang/me/ir/printer.mach
+++ b/src/lang/me/ir/printer.mach
@@ -244,7 +244,47 @@ pub fun print_instruction(out: *writer.Writer, m: *ir.Module, fn: *ir.Function, 
         if (R.is_err[bool, str](res_operands)) { ret res_operands; }
     }
 
+    if (ins.kind == instruction.OP_DBG_VALUE) {
+        val res_dbg: R.Result[bool, str] = print_dbg_expr(out, fn, iid);
+        if (R.is_err[bool, str](res_dbg)) { ret res_dbg; }
+    }
+
     ret emit_str(out, "\n");
+}
+
+# append an OP_DBG_VALUE's debug-location expression as ` ; +k, -j` in applied order,
+# or nothing for the identity expression. the operand itself is rendered by the
+# shared operand path, so a VAL_CONST_NULL operand already reads as the optimized-out
+# sentinel.
+# ---
+# out: destination writer
+# fn:  the owning function (for the expression pool)
+# iid: the OP_DBG_VALUE instruction id
+# ret: ok(true) on success, or a write error
+fun print_dbg_expr(out: *writer.Writer, fn: *ir.Function, iid: id.InstructionId) R.Result[bool, str] {
+    val eid: ir.DbgExprId = ir.dbg_expr_id(fn, iid);
+    val opt: O.Option[*ir.DbgExpr] = ir.dbg_expr_get(fn, eid);
+    if (O.is_none[*ir.DbgExpr](opt)) { ret R.ok[bool, str](true); }
+    val dex: *ir.DbgExpr = O.unwrap[*ir.DbgExpr](opt);
+
+    val res_sep: R.Result[bool, str] = emit_str(out, " ; ");
+    if (R.is_err[bool, str](res_sep)) { ret res_sep; }
+
+    var i: u32 = 0;
+    for (i < dex.op_count) {
+        if (i > 0) {
+            val res_comma: R.Result[bool, str] = emit_str(out, ", ");
+            if (R.is_err[bool, str](res_comma)) { ret res_comma; }
+        }
+        var sign: str = "+";
+        if (dex.ops[i].op == ir.DBG_OP_MINUS_CONST) { sign = "-"; }
+        val res_sign: R.Result[bool, str] = emit_str(out, sign);
+        if (R.is_err[bool, str](res_sign)) { ret res_sign; }
+        val res_num: R.Result[bool, str] = emit_u64(out, dex.ops[i].arg);
+        if (R.is_err[bool, str](res_num)) { ret res_num; }
+        i = i + 1;
+    }
+    ret R.ok[bool, str](true);
 }
 
 # render one Value operand reference inline

--- a/src/lang/me/lower/context.mach
+++ b/src/lang/me/lower/context.mach
@@ -1230,6 +1230,10 @@ pub fun ensure_extern_function(lc: *LowerContext, name: intern.StrId, sig: ir_ty
     f.ret_sem     = type.TYPE_NIL;
     f.asm_blocks  = map.init[ir.InstructionId, ir.IrAsm](m.alloc, map.hash_u32, map.eq_u32);
     f.dbg_vars    = map.init[ir.InstructionId, ir.DbgVar](m.alloc, map.hash_u32, map.eq_u32);
+    f.dbg_exprs    = nil;
+    f.dbg_expr_len = 0;
+    f.dbg_expr_cap = 0;
+    f.dbg_expr_ids = map.init[ir.InstructionId, ir.DbgExprId](m.alloc, map.hash_u32, map.eq_u32);
 
     m.functions[idx] = f;
     m.function_len   = m.function_len + 1;

--- a/src/lang/me/lower/decl.mach
+++ b/src/lang/me/lower/decl.mach
@@ -1251,6 +1251,10 @@ fun append_function(ctx: *context.LowerContext, name: intern.StrId, sig: ir_type
     f.ret_sem     = type.TYPE_NIL;
     f.asm_blocks  = map.init[ir.InstructionId, ir.IrAsm](m.alloc, map.hash_u32, map.eq_u32);
     f.dbg_vars    = map.init[ir.InstructionId, ir.DbgVar](m.alloc, map.hash_u32, map.eq_u32);
+    f.dbg_exprs    = nil;
+    f.dbg_expr_len = 0;
+    f.dbg_expr_cap = 0;
+    f.dbg_expr_ids = map.init[ir.InstructionId, ir.DbgExprId](m.alloc, map.hash_u32, map.eq_u32);
 
     m.functions[idx] = f;
     m.function_len   = m.function_len + 1;

--- a/src/lang/me/pass/dce.mach
+++ b/src/lang/me/pass/dce.mach
@@ -187,12 +187,12 @@ fun value_dce(m: *ir.Module, fn: *ir.Function) R.Result[bool, str] {
     marks.dead = dead;
     marks.ilen = ilen;
     val marks_ptr: *DceMarks = ?marks;
-    mutate.erase_marked(fn, marks_ptr::ptr, dce_marked);
+    val res_erase: R.Result[bool, str] = mutate.erase_marked(m, fn, marks_ptr::ptr, dce_marked);
 
     A.deallocate[u32](m.alloc, use_count, ilen::usize);
     A.deallocate[bool](m.alloc, dead, ilen::usize);
     A.deallocate[id.InstructionId](m.alloc, work, ilen::usize);
-    ret R.ok[bool, str](true);
+    ret res_erase;
 }
 
 # whether `inst` may be deleted once its result is unused
@@ -298,15 +298,20 @@ fun seed_if_dead(fn: *ir.Function, iid: id.InstructionId, use_count: *u32, dead:
 #
 # OP_BR's sole operand is a block; OP_CBR operand 0 is the condition value and
 # operands 1 and 2 are blocks; OP_PHI alternates [block, value, ...], so odd
-# slots are values.
+# slots are values. OP_DBG_VALUE's operand is a debug use, not a real one: it must
+# never keep an otherwise-dead value alive, or a `-g` build would drop fewer
+# instructions than a plain build and emit different code. When such a value is in
+# fact dropped, erase_marked salvages the debug value (rebasing it onto a surviving
+# value plus an expression, or marking it optimized out).
 # ---
 # inst: the instruction
 # o:    the operand slot
-# ret:  true when slot `o` is a value use
+# ret:  true when slot `o` is a value use that keeps its definition live
 fun operand_is_value_use(inst: *instruction.Instruction, o: u32) bool {
-    if (inst.kind == instruction.OP_BR)  { ret false; }
-    if (inst.kind == instruction.OP_CBR) { ret o == 0; }
-    if (inst.kind == instruction.OP_PHI) { ret (o % 2) == 1; }
+    if (inst.kind == instruction.OP_BR)        { ret false; }
+    if (inst.kind == instruction.OP_CBR)       { ret o == 0; }
+    if (inst.kind == instruction.OP_PHI)       { ret (o % 2) == 1; }
+    if (inst.kind == instruction.OP_DBG_VALUE) { ret false; }
     ret true;
 }
 

--- a/src/lang/me/pass/mem2reg.mach
+++ b/src/lang/me/pass/mem2reg.mach
@@ -969,6 +969,11 @@ fun place_phi(st: *State, bid: id.BlockId, alloca_id: id.InstructionId) R.Result
         ret R.err[bool, str]("mem2reg: phi placed for a non-promotable alloca");
     }
 
+    # deferred (#1904): under -g, a promoted local's variable value at and after this
+    # merge is the phi result, so a dbg-value birth belongs here binding that variable
+    # to the phi. it is not emitted yet -- mem2reg has no alloca-to-source-variable
+    # link to name the variable -- so past a merge a binding may reflect the
+    # last-processed branch until #1904 lands.
     var phi: instruction.Instruction;
     phi.kind          = instruction.OP_PHI;
     phi.ty            = st.alloca_ty[ai];
@@ -1032,13 +1037,15 @@ fun rename(st: *State) R.Result[bool, str] {
     if (R.is_err[bool, str](res_init)) { ret res_init; }
 
     val res_walk: R.Result[bool, str] = rename_walk(?rc);
+    var res_strip: R.Result[bool, str] = R.ok[bool, str](true);
     if (R.is_ok[bool, str](res_walk)) {
         mutate.rewrite_apply(st.fn, ?rc.rw);
-        strip_promoted(st);
+        res_strip = strip_promoted(st);
     }
 
     rename_ctx_dnit(?rc, na);
-    ret res_walk;
+    if (R.is_err[bool, str](res_walk)) { ret res_walk; }
+    ret res_strip;
 }
 
 # allocate and clear the rename context's rewrite map and per-alloca tables
@@ -1419,9 +1426,11 @@ fun add_phi_incomings(rc: *RenameCtx, pred: id.BlockId, succ: id.BlockId) R.Resu
 # The pool entries remain but are unreferenced; the lists no longer name them, so
 # the backend never sees them.
 # ---
-# st: promotion state with the promotable set finalised
-fun strip_promoted(st: *State) {
-    mutate.erase_marked(st.fn, st::ptr, strip_test);
+# st:  promotion state with the promotable set finalised
+# ret: ok(true) once the strip (and any dbg-value salvage it drives) completes, or an
+#      allocation error
+fun strip_promoted(st: *State) R.Result[bool, str] {
+    ret mutate.erase_marked(st.m, st.fn, st::ptr, strip_test);
 }
 
 # the erase predicate `erase_marked` drives: whether `iid` is a promoted alloca or

--- a/src/lang/me/pipeline.mach
+++ b/src/lang/me/pipeline.mach
@@ -17,6 +17,7 @@ use std.types.bool.true;
 use std.types.string.str;
 
 use A: std.allocator;
+use O: std.types.option;
 use R: std.types.result;
 
 use mach.lang.intern;
@@ -268,6 +269,136 @@ test "mach.lang.me.pipeline.loc:survives_mem2reg_constfold_dce" {
     if (surviving.operands[0].data.param_ix != 0)          { ir.dnit(?m); ret 1; }
     if (surviving.operands[1].kind != value.VAL_CONST_INT) { ir.dnit(?m); ret 1; }
     if (surviving.operands[1].data.int_lit != 5)           { ir.dnit(?m); ret 1; }
+
+    ir.dnit(?m);
+    ret 0;
+}
+
+# a debug value survives the always-on pipeline with a recovered expression: a
+# promoted local feeds `add x, 4` bound by a dbg-value and used nowhere else, so dce
+# drops the add and salvages the dbg-value onto the promoted parameter with a +4
+# recovery step. this is the value-tracking invariant #1696 adds on top of the loc
+# invariant above -- verified by IR inspection, not a textual dump.
+test "mach.lang.me.pipeline.dbg:salvages_folded_add_to_expression" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+    val res_m: R.Result[ir.Module, str] = ir.init(?alloc, intern.STR_NIL);
+    if (R.is_err[ir.Module, str](res_m)) { ret 1; }
+    var m: ir.Module = R.unwrap_ok[ir.Module, str](res_m);
+
+    val res_i64: R.Result[ir_type.IrTypeId, str] = ir_type.intern_int(?m.types, 64);
+    if (R.is_err[ir_type.IrTypeId, str](res_i64)) { ir.dnit(?m); ret 1; }
+    val i64t: ir_type.IrTypeId = R.unwrap_ok[ir_type.IrTypeId, str](res_i64);
+
+    val res_fn: R.Result[u32, str] = ir.function_add(?m, intern.STR_NIL, ir_type.IRT_NIL, 0);
+    if (R.is_err[u32, str](res_fn)) { ir.dnit(?m); ret 1; }
+    val fn: *ir.Function = ?m.functions[R.unwrap_ok[u32, str](res_fn)];
+
+    var bld: builder.Builder = builder.init(?m);
+    builder.set_function(?bld, fn);
+    val res_blk: R.Result[id.BlockId, str] = builder.new_block(?bld);
+    if (R.is_err[id.BlockId, str](res_blk)) { ir.dnit(?m); ret 1; }
+    builder.set_block(?bld, R.unwrap_ok[id.BlockId, str](res_blk));
+
+    val p0: value.Value = value.param(0, i64t);
+
+    # a promotable local: alloca + store(p0) + load. mem2reg rewrites the load to p0.
+    val res_slot: R.Result[value.Value, str] = builder.emit_alloca(?bld, i64t, value.const_int(1, i64t));
+    if (R.is_err[value.Value, str](res_slot)) { ir.dnit(?m); ret 1; }
+    val slot: value.Value = R.unwrap_ok[value.Value, str](res_slot);
+    if (R.is_err[bool, str](builder.emit_store(?bld, p0, slot))) { ir.dnit(?m); ret 1; }
+    val res_load: R.Result[value.Value, str] = builder.emit_load(?bld, slot, i64t);
+    if (R.is_err[value.Value, str](res_load)) { ir.dnit(?m); ret 1; }
+    val x: value.Value = R.unwrap_ok[value.Value, str](res_load);
+
+    # x + 4, tracked by a debug value and used by nothing else, so dce drops it.
+    val res_s: R.Result[value.Value, str] = builder.emit_add(?bld, x, value.const_int(4, i64t));
+    if (R.is_err[value.Value, str](res_s)) { ir.dnit(?m); ret 1; }
+    val s: value.Value = R.unwrap_ok[value.Value, str](res_s);
+    if (R.is_err[bool, str](builder.emit_dbg_value(?bld, s, intern.STR_NIL, i64t, 0))) { ir.dnit(?m); ret 1; }
+    val dbg_id: id.InstructionId = (fn.instr_len - 1)::id.InstructionId;
+
+    if (R.is_err[bool, str](builder.emit_ret(?bld, p0))) { ir.dnit(?m); ret 1; }
+
+    if (R.is_err[bool, str](mem2reg.run(?m)))   { ir.dnit(?m); ret 1; }
+    if (R.is_err[bool, str](constfold.run(?m))) { ir.dnit(?m); ret 1; }
+    if (R.is_err[bool, str](dce.run(?m)))       { ir.dnit(?m); ret 1; }
+
+    # the debug value now binds the promoted parameter directly...
+    val dbg: *instruction.Instruction = ?fn.instrs[dbg_id::u32];
+    if (dbg.kind != instruction.OP_DBG_VALUE)    { ir.dnit(?m); ret 1; }
+    if (dbg.operand_count != 1)                  { ir.dnit(?m); ret 1; }
+    if (dbg.operands[0].kind != value.VAL_PARAM) { ir.dnit(?m); ret 1; }
+    if (dbg.operands[0].data.param_ix != 0)      { ir.dnit(?m); ret 1; }
+
+    # ...with a +4 recovery expression pooled for it.
+    val eid: ir.DbgExprId = ir.dbg_expr_id(fn, dbg_id);
+    if (eid == ir.DBG_EXPR_IDENTITY)             { ir.dnit(?m); ret 1; }
+    val opt: O.Option[*ir.DbgExpr] = ir.dbg_expr_get(fn, eid);
+    if (O.is_none[*ir.DbgExpr](opt))             { ir.dnit(?m); ret 1; }
+    val dex: *ir.DbgExpr = O.unwrap[*ir.DbgExpr](opt);
+    if (dex.op_count != 1)                       { ir.dnit(?m); ret 1; }
+    if (dex.ops[0].op != ir.DBG_OP_PLUS_CONST)   { ir.dnit(?m); ret 1; }
+    if (dex.ops[0].arg != 4)                     { ir.dnit(?m); ret 1; }
+
+    ir.dnit(?m);
+    ret 0;
+}
+
+# an unrecoverable defining instruction degrades to no location: `mul x, 3` bound by
+# a dbg-value and used nowhere else is dropped by dce, and since a multiply is not a
+# constant offset the dbg-value's operand becomes the null idiom (optimized out)
+# rather than a stale value, and no expression is pooled.
+test "mach.lang.me.pipeline.dbg:marks_unrecoverable_optimized_out" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+    val res_m: R.Result[ir.Module, str] = ir.init(?alloc, intern.STR_NIL);
+    if (R.is_err[ir.Module, str](res_m)) { ret 1; }
+    var m: ir.Module = R.unwrap_ok[ir.Module, str](res_m);
+
+    val res_i64: R.Result[ir_type.IrTypeId, str] = ir_type.intern_int(?m.types, 64);
+    if (R.is_err[ir_type.IrTypeId, str](res_i64)) { ir.dnit(?m); ret 1; }
+    val i64t: ir_type.IrTypeId = R.unwrap_ok[ir_type.IrTypeId, str](res_i64);
+
+    val res_fn: R.Result[u32, str] = ir.function_add(?m, intern.STR_NIL, ir_type.IRT_NIL, 0);
+    if (R.is_err[u32, str](res_fn)) { ir.dnit(?m); ret 1; }
+    val fn: *ir.Function = ?m.functions[R.unwrap_ok[u32, str](res_fn)];
+
+    var bld: builder.Builder = builder.init(?m);
+    builder.set_function(?bld, fn);
+    val res_blk: R.Result[id.BlockId, str] = builder.new_block(?bld);
+    if (R.is_err[id.BlockId, str](res_blk)) { ir.dnit(?m); ret 1; }
+    builder.set_block(?bld, R.unwrap_ok[id.BlockId, str](res_blk));
+
+    val p0: value.Value = value.param(0, i64t);
+
+    val res_slot: R.Result[value.Value, str] = builder.emit_alloca(?bld, i64t, value.const_int(1, i64t));
+    if (R.is_err[value.Value, str](res_slot)) { ir.dnit(?m); ret 1; }
+    val slot: value.Value = R.unwrap_ok[value.Value, str](res_slot);
+    if (R.is_err[bool, str](builder.emit_store(?bld, p0, slot))) { ir.dnit(?m); ret 1; }
+    val res_load: R.Result[value.Value, str] = builder.emit_load(?bld, slot, i64t);
+    if (R.is_err[value.Value, str](res_load)) { ir.dnit(?m); ret 1; }
+    val x: value.Value = R.unwrap_ok[value.Value, str](res_load);
+
+    # x * 3 is not a constant offset of a single value, so it is unrecoverable.
+    val res_s: R.Result[value.Value, str] = builder.emit_mul(?bld, x, value.const_int(3, i64t));
+    if (R.is_err[value.Value, str](res_s)) { ir.dnit(?m); ret 1; }
+    val s: value.Value = R.unwrap_ok[value.Value, str](res_s);
+    if (R.is_err[bool, str](builder.emit_dbg_value(?bld, s, intern.STR_NIL, i64t, 0))) { ir.dnit(?m); ret 1; }
+    val dbg_id: id.InstructionId = (fn.instr_len - 1)::id.InstructionId;
+
+    if (R.is_err[bool, str](builder.emit_ret(?bld, p0))) { ir.dnit(?m); ret 1; }
+
+    if (R.is_err[bool, str](mem2reg.run(?m)))   { ir.dnit(?m); ret 1; }
+    if (R.is_err[bool, str](constfold.run(?m))) { ir.dnit(?m); ret 1; }
+    if (R.is_err[bool, str](dce.run(?m)))       { ir.dnit(?m); ret 1; }
+
+    # the debug value is optimized out: a null operand, no pooled expression.
+    val dbg: *instruction.Instruction = ?fn.instrs[dbg_id::u32];
+    if (dbg.kind != instruction.OP_DBG_VALUE)          { ir.dnit(?m); ret 1; }
+    if (dbg.operand_count != 1)                        { ir.dnit(?m); ret 1; }
+    if (dbg.operands[0].kind != value.VAL_CONST_NULL)  { ir.dnit(?m); ret 1; }
+    if (ir.dbg_expr_id(fn, dbg_id) != ir.DBG_EXPR_IDENTITY) { ir.dnit(?m); ret 1; }
 
     ir.dnit(?m);
     ret 0;

--- a/src/lang/me/pipeline.mach
+++ b/src/lang/me/pipeline.mach
@@ -403,3 +403,66 @@ test "mach.lang.me.pipeline.dbg:marks_unrecoverable_optimized_out" {
     ir.dnit(?m);
     ret 0;
 }
+
+# many dbg-values salvaged in one function grow the expression pool past its initial
+# capacity: sixteen `add p0, k` values, each bound by a debug value and used nowhere
+# else, are all dropped by dce and each rebased onto p0 with a +k expression. this
+# exercises the pool's geometric growth (a real function has many tracked locals).
+test "mach.lang.me.pipeline.dbg:salvage_grows_expression_pool" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+    val res_m: R.Result[ir.Module, str] = ir.init(?alloc, intern.STR_NIL);
+    if (R.is_err[ir.Module, str](res_m)) { ret 1; }
+    var m: ir.Module = R.unwrap_ok[ir.Module, str](res_m);
+
+    val res_i64: R.Result[ir_type.IrTypeId, str] = ir_type.intern_int(?m.types, 64);
+    if (R.is_err[ir_type.IrTypeId, str](res_i64)) { ir.dnit(?m); ret 1; }
+    val i64t: ir_type.IrTypeId = R.unwrap_ok[ir_type.IrTypeId, str](res_i64);
+
+    val res_fn: R.Result[u32, str] = ir.function_add(?m, intern.STR_NIL, ir_type.IRT_NIL, 0);
+    if (R.is_err[u32, str](res_fn)) { ir.dnit(?m); ret 1; }
+    val fn: *ir.Function = ?m.functions[R.unwrap_ok[u32, str](res_fn)];
+
+    var bld: builder.Builder = builder.init(?m);
+    builder.set_function(?bld, fn);
+    val res_blk: R.Result[id.BlockId, str] = builder.new_block(?bld);
+    if (R.is_err[id.BlockId, str](res_blk)) { ir.dnit(?m); ret 1; }
+    builder.set_block(?bld, R.unwrap_ok[id.BlockId, str](res_blk));
+
+    val p0: value.Value = value.param(0, i64t);
+
+    # sixteen distinct `p0 + k` values, each tracked by a debug value and dead.
+    var first_dbg: u32 = 0;
+    var k: u64 = 1;
+    for (k <= 16) {
+        val res_s: R.Result[value.Value, str] = builder.emit_add(?bld, p0, value.const_int(k, i64t));
+        if (R.is_err[value.Value, str](res_s)) { ir.dnit(?m); ret 1; }
+        val s: value.Value = R.unwrap_ok[value.Value, str](res_s);
+        if (R.is_err[bool, str](builder.emit_dbg_value(?bld, s, intern.STR_NIL, i64t, 0))) { ir.dnit(?m); ret 1; }
+        if (k == 1) { first_dbg = fn.instr_len - 1; }
+        k = k + 1;
+    }
+
+    if (R.is_err[bool, str](builder.emit_ret(?bld, p0))) { ir.dnit(?m); ret 1; }
+
+    if (R.is_err[bool, str](mem2reg.run(?m)))   { ir.dnit(?m); ret 1; }
+    if (R.is_err[bool, str](constfold.run(?m))) { ir.dnit(?m); ret 1; }
+    if (R.is_err[bool, str](dce.run(?m)))       { ir.dnit(?m); ret 1; }
+
+    # the first debug value binds p0 with a +1 expression (the pool survived growth).
+    val dbg_id: id.InstructionId = first_dbg::id.InstructionId;
+    val dbg: *instruction.Instruction = ?fn.instrs[dbg_id::u32];
+    if (dbg.kind != instruction.OP_DBG_VALUE)    { ir.dnit(?m); ret 1; }
+    if (dbg.operands[0].kind != value.VAL_PARAM) { ir.dnit(?m); ret 1; }
+    val eid: ir.DbgExprId = ir.dbg_expr_id(fn, dbg_id);
+    if (eid == ir.DBG_EXPR_IDENTITY)             { ir.dnit(?m); ret 1; }
+    val opt: O.Option[*ir.DbgExpr] = ir.dbg_expr_get(fn, eid);
+    if (O.is_none[*ir.DbgExpr](opt))             { ir.dnit(?m); ret 1; }
+    val dex: *ir.DbgExpr = O.unwrap[*ir.DbgExpr](opt);
+    if (dex.op_count != 1)                       { ir.dnit(?m); ret 1; }
+    if (dex.ops[0].op != ir.DBG_OP_PLUS_CONST)   { ir.dnit(?m); ret 1; }
+    if (dex.ops[0].arg != 1)                     { ir.dnit(?m); ret 1; }
+
+    ir.dnit(?m);
+    ret 0;
+}


### PR DESCRIPTION
Closes #1696. Last child of the debug-info foundation epic #1688.

## What
Maintains `OP_DBG_VALUE` across the optimizer so a variable's location stays correct after mem2reg -> constfold -> dce (there is no `-O0` escape hatch):

- **RAUW** already moved dbg-value operands via the shared `Rewrite` map (#1695); nothing to add.
- **DCE salvage** (new): when a value-producing instruction bound by a dbg-value is dropped, `erase_marked` salvages the binding — `%c = add %a, 4` deleted rebinds the operand to `%a` and records a `+4` recovery step; an unrecoverable definition (e.g. a multiply) degrades to *optimized out* (a `VAL_CONST_NULL` operand), never a stale value.
- **Debug-only uses**: `dce`'s `operand_is_value_use` now excludes `OP_DBG_VALUE`, so a debug use never pins an otherwise-dead value — a `-g` build drops exactly what a plain build does (codegen identity).

## Expression seam
Salvage recovery lives in a **function-level expression pool** (`Function.dbg_exprs`): each `OP_DBG_VALUE` carries a `DbgExprId` (0 = identity, owns no slot), and steps are `plus_const` / `minus_const` with a `u64` arg (extensible enum). This is the format-agnostic seam the DWARF loclist / CodeView defrange emitters consume — not inline on `DbgVar`, since one variable carries different expressions at different points.

## Deferred (phi-merge births) — three riders
mem2reg does not yet re-emit a birth at the phi it inserts for a promoted local, so past a control-flow merge a binding may reflect the last-processed branch. Deferred with:
- follow-up issue **#1904** (alloca <-> source-variable link + phi births), filed as a child of #1688;
- a breadcrumb at the mem2reg phi-insertion site;
- a fidelity note in the `OP_DBG_VALUE` docs.

## Tests
Two pipeline-survival tests (loc-survival style, verified by IR inspection): a mem2reg-promoted local through constfold/dce keeps its binding with the correct value + `+4` expression; an unrecoverable case shows optimized-out.

## Verification
- from-source build clean; unit suite **528 passed** (526 baseline + 2 new), confirmed with a freshly-built from-source compiler.
- Remaining bar (byte-identical without `-g` on all six targets, `-g` functional, self-host fixpoint, int harness) run before marking ready.
