### PR TITLE
docs(skills): rewrite mach-* authoring skills against the v2.12 language

### DIFF
--- a/.github/skills/README.md
+++ b/.github/skills/README.md
@@ -9,15 +9,15 @@ for **writing Mach programs**, not for working on the compiler.
 
 | Skill | Purpose | Triggers when |
 |---|---|---|
-| [writing-mach](writing-mach/SKILL.md) | Core language: project/module structure, `use`/`fwd`, the shadow-module pattern, every declaration form, the type grammar, literals, operators, statements, expressions, docstrings, and the entrypoint / `std.print` idioms. | Writing, editing, or reviewing any `.mach` source. The default entry point. |
-| [mach-comptime](mach-comptime/SKILL.md) | The comptime channel (`$`): `$mach.*` reads, backtick codegen decorators, the closed intrinsic set, `$if`/`$or` control flow, and `$name: T` comptime parameters. | Code touches `$` — conditional compilation, target/build queries, decorators, intrinsics, or comptime params. |
-| [mach-lowlevel](mach-lowlevel/SKILL.md) | Inline assembly (`asm <isa> { ... }` with `{name}` substitution, multi-arch dispatch, inferred operands/clobbers) and when to write `asm` versus call the standard library. | Writing/reviewing inline `asm`, syscalls, or other target-specific code. |
+| [writing-mach](writing-mach/SKILL.md) | Core language: project/module structure, `use`/`fwd`, the shadow-module pattern, every declaration form (including `test`), variadic packs, the type grammar and the `^` secret qualifier, literals, operators and casts, statements, docstrings, and the entrypoint / `std.print` idioms. | Writing, editing, or reviewing any `.mach` source. The default entry point. |
+| [mach-comptime](mach-comptime/SKILL.md) | The comptime channel (`$`): `$mach.*`/`$project.*`/`$bin.*` reads, `#[...]` decorators, the closed intrinsic set (`$size_of`, `$type_of`, `$fields`, `$error`, …), `$if`/`$or` conditional compilation, `$each` unrolls, and `$name: T` comptime parameters. | Code touches `$` or `#[...]` — conditional compilation, target/build queries, decorators, intrinsics, packs, or comptime params. |
+| [mach-lowlevel](mach-lowlevel/SKILL.md) | Inline assembly (`asm <isa> { ... }` for x86_64/aarch64/riscv64 with `{name}` substitution and inferred operands/clobbers), multi-arch dispatch, module target guards, and when to write `asm` versus call the standard library. | Writing/reviewing inline `asm`, syscalls, or other target-specific code. |
 
-Scope is partitioned: core language lives in **writing-mach**, the `$` channel in
-**mach-comptime**, and `asm` in **mach-lowlevel**. writing-mach carries a
-one-paragraph summary of the `$` channel and defers the rest to mach-comptime;
-the low-level skill restates a few core gotchas as reminders and points back to
-writing-mach for the full rules.
+Scope is partitioned: core language lives in **writing-mach**, the `$` channel
+and decorators in **mach-comptime**, and `asm` in **mach-lowlevel**.
+writing-mach carries a one-paragraph summary of the `$` channel and defers the
+rest to mach-comptime; the low-level skill restates a few core gotchas as
+reminders and points back to the others for the full rules.
 
 ## Adopting these skills
 
@@ -36,5 +36,5 @@ language reference disagree, the reference wins and the skill is the bug.
 The skills are the fast path, not the contract. The complete, per-feature
 language reference — grammar, semantics, and implementation status — lives in
 the Mach repository under
-[`doc/language/`](https://github.com/briar-systems/mach/tree/dev/doc/language). Each
-skill points there for exhaustive detail.
+[`doc/language/`](https://github.com/briar-systems/mach/tree/dev/doc/language).
+Each skill points there for exhaustive detail.

--- a/.github/skills/mach-comptime/SKILL.md
+++ b/.github/skills/mach-comptime/SKILL.md
@@ -28,6 +28,7 @@ All reads, all comptime constants, closed tree:
 ```mach
 $mach.build.os / .arch / .abi / .mode   # live; compare against the tag tables
 $mach.build.pointer_width               # live; integer byte count (8 on 64-bit)
+$mach.build.pie                         # live; 1 when building position-independent
 $mach.build.<NAME>                      # live; manifest `defines` lookup (see below)
 $mach.version / .major / .minor / .patch    # live; compiler version
 $mach.compiler.name / .version              # live

--- a/.github/skills/mach-comptime/SKILL.md
+++ b/.github/skills/mach-comptime/SKILL.md
@@ -1,238 +1,246 @@
 ---
 name: mach-comptime
-description: Use when writing or reviewing Mach code that touches the comptime channel: the $ namespace, conditional compilation, target/compiler/build/project/source queries ($mach.*), backtick codegen decorators (symbol/library/inline/align/section), compiler intrinsics ($size_of/$align_of/$offset_of/$error/$assert), $if/$or comptime control flow, and comptime function parameters ($name: T).
+description: Use when writing or reviewing Mach code that touches the comptime channel or decorators: the $ namespace ($mach.*, $project.*, $bin.*), conditional compilation with $if/$or, #[...] codegen decorators (symbol/library/inline/align/section), intrinsics ($size_of/$align_of/$offset_of/$type_of/$fields/$error/$assert), $each unrolls with field projection v.[f], comptime function parameters ($name: T), and variadic packs.
 ---
 
 # Mach comptime channel
 
 `$` opens the compiler-owned comptime channel — read-only: it *selects and
-expands*, never executes or mutates. Three structurally distinct shapes — the
-parser disambiguates by shape, not by a mode flag:
+expands*, never executes or mutates. The parser disambiguates by shape:
 
 | Shape | Meaning |
 |---|---|
-| `$mach.path.to.value` | read compiler-owned value |
-| `$sym(args)` | comptime call — closed intrinsic set, or a user call passing comptime args (no user comptime defs) |
+| `$mach.*` / `$project.*` / `$bin.*` | read a compiler-owned tree (roots are reserved) |
+| `$sym(args)` | comptime call — the closed intrinsic set |
 | `$if` / `$or` | comptime control flow |
+| `$each x in SEQ { }` | comptime unroll over `$fields(T)` or a variadic pack |
 
-`mach` is reserved at the top of `$`; user symbols cannot collide there.
-Per-declaration codegen directives are backtick decorators (a separate
-mechanism — see Decorators below), not `$` writes.
+A bare `$ident` (`$mode`, `$foo`) is none of these and is rejected: comptime
+*parameters* are referenced without `$`; comptime *paths* are rooted.
+Per-declaration codegen directives are `#[...]` decorators (below), not `$`
+shapes — the `$sym.attr = value;` setters were removed in v2.0.0 and the
+backtick decorators in v2.4.0.
 
-## `$mach.*` — read-only compiler state
+## `$mach.*` — compiler and build state
 
-All reads, all comptime constants. Closed tree. Subtrees:
+All reads, all comptime constants, closed tree:
 
 ```mach
-$mach.build.os                  # live; compare against $mach.os.* tags
-$mach.build.arch                # live; compare against $mach.arch.* tags
-$mach.build.abi                 # live; compare against $mach.abi.* tags
-$mach.build.pointer_width       # live; integer byte count
-$mach.build.mode                # live; compare against $mach.mode.* tags
-$mach.build.timestamp           # stub
-$mach.build.git.commit          # stub
-$mach.build.git.dirty           # stub
-$mach.build.host                # stub
+$mach.build.os / .arch / .abi / .mode   # live; compare against the tag tables
+$mach.build.pointer_width               # live; integer byte count (8 on 64-bit)
+$mach.build.<NAME>                      # live; manifest `defines` lookup (see below)
+$mach.version / .major / .minor / .patch    # live; compiler version
+$mach.compiler.name / .version              # live
 
-$mach.version                   # live; version string, e.g. "2.0.0"
-$mach.version.major             # live; integer component
-$mach.version.minor             # live
-$mach.version.patch             # live
-$mach.compiler.name             # live
-$mach.compiler.version          # live
-
-$mach.project.name              # stub
-$mach.project.version           # stub
-$mach.project.root              # stub
-
-$mach.source.file               # stub
-$mach.source.line               # stub
-$mach.source.module             # stub
-$mach.source.function           # stub
-
-$mach.os.linux $mach.os.darwin $mach.os.windows $mach.os.freestanding
-$mach.arch.x86_64 $mach.arch.aarch64
-$mach.abi.sysv $mach.abi.win64 $mach.abi.aapcs64
-$mach.mode.debug $mach.mode.release
+$mach.os.linux    .darwin   .windows  .freestanding
+$mach.arch.x86_64 .aarch64  .riscv64
+$mach.abi.sysv    .win64    .aapcs64  .lp64
+$mach.mode.debug  .release
 ```
 
-> **Implementation status.** The resolved-build facts
-> `$mach.build.{os,arch,abi,pointer_width,mode}`, the tag tables
-> `$mach.{os,arch,abi,mode}.*`, `$mach.version[.{major,minor,patch}]`, and
-> `$mach.compiler.{name,version}` are live. `$mach.build.{timestamp,host,git.*}`,
-> `$mach.project.*`, and `$mach.source.*` are reserved stubs — reading one is a
-> compile error. `$mach.arch.aarch64` resolves as a value; the aarch64 dispatch
-> branches below illustrate the multi-arch pattern.
+`$mach.build.{timestamp,host,git.*}`, `$mach.project.*`, and `$mach.source.*`
+are reserved stubs — reading one is a compile error. The tag tables are closed;
+an unrecognized tag is a compile error, never a silent fold.
 
-Tag comparison is path-value — no `.id` suffix, no unwrapping:
+Tag comparison is path-value — plain `==`, no `.id` suffix, no unwrap:
 
 ```mach
 $if ($mach.build.os == $mach.os.linux) { ... }
-$if ($mach.build.arch == $mach.arch.x86_64) { ... }
+$if ($mach.build.arch == $mach.arch.riscv64) { ... }
 ```
 
-`$mach.os.*` / `$mach.arch.*` are closed lists; a tag exists only because the
-compiler can target it. A `$mach.*` read can fold into a runtime binding (no
-type inference — the binding still declares its type):
+A `$mach.build.<NAME>` that names none of the reserved facts resolves to the
+manifest's per-target comptime `defines` (`defines = ["TRACING", "DEPTH=4"]`
+in a `[target.*]` stanza); an undeclared name is a loud error.
+
+A `$mach.*` read can fold into a runtime binding — the binding still declares
+its type:
 
 ```mach
 pub val IS_LINUX: u8  = $mach.build.os == $mach.os.linux;
 pub val COMPILER: *u8 = $mach.compiler.name;
 ```
 
-## Decorators — backtick codegen directives
+## `$project.*` / `$bin.*` — manifest state
 
-Per-declaration codegen directives are **backtick decorators** (#1476), on the
-line(s) above the decl — not `$` writes. The `$sym.attr = value;` setter form was
-removed in v2.0.0. Closed set:
+```mach
+$project.id / .version / .name / .description   # [project] metadata
+$project.version.major / .minor / .patch        # folded integer components
+$project.target.os / .arch / .abi               # the selected target's declared *strings*
+$bin.name                                       # the artifact being built
+```
+
+`$project.target.*` carries the manifest's string spellings (`"linux"`,
+`"x86_64"`) — distinct from `$mach.build.*`'s numeric tags. A field the
+manifest does not declare is reported unavailable, not folded to `""`.
+
+## Decorators — `#[...]`
+
+Codegen directives on the line(s) above a declaration (after the docstring).
+One clause each, stackable on one line or several; they attach only to the
+immediately following declaration. Closed set:
 
 | Decorator | Applies to | Argument | Purpose |
 |---|---|---|---|
-| `` `symbol(str)` `` | functions, vars | `*u8` literal | linker name override |
-| `` `library(str)` `` | `ext` functions | `*u8` literal | PE import DLL routing |
-| `` `inline` `` | functions | none | strong inline hint |
-| `` `align(expr)` `` | vars, records, unions | comptime int | alignment in bytes |
-| `` `section(str)` `` | functions, vars | `*u8` literal | linker section name |
+| `#[symbol("name")]` | fun, ext fun, val/var | string | linker name override |
+| `#[library("x.dll")]` | ext fun | string | PE import DLL pin |
+| `#[inline]` | fun | none | force inlining |
+| `#[align(expr)]` | val/var, rec/uni | comptime int | alignment override |
+| `#[section(".name")]` | fun, ext fun, val/var | string | object section placement |
 
 ```mach
-`symbol("read")`
-ext fun read(fd: i32, buf: *u8, n: u64) i64;
+#[symbol("read")]
+pub ext fun sys_read(fd: i32, buf: *u8, n: u64) i64;
 
-`align(64)`
+#[align(64)] #[section(".hot")]
 pub var cache_line: u8 = 0;
 ```
 
-Each directive is its own backtick pair; stack several on one decl (e.g.
-`` `library("ws2_32.dll")` `` `` `symbol("socket")` ``). There is **no** `$`-write
-setter and **no** decl-attached prefix sugar (`$inline pub fun ...` does not
-exist). See `doc/language/decorators.md` for argument rules and applicability.
+`align` takes any comptime expression (`#[align($align_of(T))]`). A `library`
+pin must name a DLL in the target's `libs` set — pinning to an absent library
+is a link error; on ELF the pin is validated but has no binary effect. Beware:
+a line comment starting `#[` with no space parses as a decorator — write
+`# [...]` in prose comments.
 
 ## Intrinsics — `$name(args)`
 
-Closed compiler-shipped set; same call shape as user comptime calls.
+Closed compiler-shipped set. New ones require a compiler change; runtime
+instruction emitters (`trap`, `fence`, `pause`) are **not** intrinsics — they
+are stdlib functions with per-arch `asm` bodies.
 
-Value intrinsics resolve to comptime constant **unsigned integers**. Storage
-type is whatever the binding declares (no compiler-known `usize`):
-
-```mach
-$size_of(T)             # byte size of T
-$align_of(T)            # byte alignment of T
-$offset_of(T, field)    # byte offset of T's field
-
-pub val POINT_SIZE: i64 = $size_of(Point);
-pub val POINT_X:    i64 = $offset_of(Point, x);
-```
-
-Diagnostic intrinsics operate at compile time:
+### Layout values
 
 ```mach
-$error("msg")           # fails compilation
-$assert(cond, "msg")    # sugar: $if (!cond) { $error("msg"); }
-
-$assert($size_of(i64) == 8, "expected 64-bit i64");
+$size_of(T)   $align_of(T)   $offset_of(T, field)
 ```
 
-> **Implementation status.** `$error` / `$assert` parse but are not yet
-> evaluated — a failing directive is currently accepted rather than aborting the
-> build. The shapes above describe the intended behavior.
+Comptime unsigned integers; the binding declares the storage type
+(`pub val POINT_SIZE: i64 = $size_of(Point);`).
 
-Runtime-instruction emitters (`trap`, `fence`, `pause`, …) are **not**
-intrinsics — they live in stdlib as functions with per-arch `asm` bodies. The
-intrinsic set is closed; new ones need a compiler patch.
+### `$type_of(expr)` — type dispatch
 
-## `$if` / `$or` — comptime control flow
+Produces a comptime type value, comparable with `==`/`!=` against a type name
+inside `$if`. Dead arms are **pruned before type-checking**, so each arm can
+use the value at its own concrete type with no cast:
+
+```mach
+$if ($type_of(arg) == str)  { write_str(w, arg); }
+$or ($type_of(arg) == i64)  { write_i64(w, arg); }
+$or { $error("no writer for this argument type"); }
+```
+
+This is the idiom inside `$each` bodies for per-element dispatch (stdlib
+`vformat` is built exactly this way).
+
+### `$fields(T)` and projection
+
+`$fields(T)` yields a comptime sequence of field descriptors for a `rec`/`uni`,
+consumed by `$each`. Each descriptor `f` carries `f.name` (`*u8`), `f.type`
+(type value), `f.offset` (integer); `v.[f]` projects the concrete field off an
+instance — an lvalue, re-typed per iteration:
+
+```mach
+fun sum_fields(p: Pair) i64 {
+    var t: i64 = 0;
+    $each f in $fields(Pair) { t = t + p.[f]; }
+    ret t;
+}
+```
+
+### `$each` — comptime unroll
+
+Statement-scope only. The body is spliced once per element — not a runtime
+loop. Two sequence forms: `$each f in $fields(T)` and `$each a in va` (packs —
+see below). Enclosing runtime variables thread across the unrolled copies;
+nesting is allowed.
+
+### Diagnostics
+
+`$error("msg")` fails the build when **reached** — unconditional position or a
+selected `$if`/`$or` arm. A `$error` in a discarded arm never fires, making it
+the natural exhaustiveness fallback for target and type dispatch. Valid at
+declaration and statement scope. **`$assert` parses but is not yet evaluated**
+— write `$if (!cond) { $error("msg"); }` instead.
+
+## `$if` / `$or` — conditional compilation
 
 ```mach
 $if (cond) { ... }
 $or (cond) { ... }
-$or { ... }             # comptime else — no condition
+$or { ... }             # comptime else — no condition; there is no `$or $if`
 ```
 
-Only the taken branch compiles. Discarded branches are **not** resolved,
+Only the taken branch compiles: discarded branches are not resolved,
 type-checked, or emitted — names inside them are never looked up. This is what
-makes per-arch `asm` blocks safe: the untaken block may reference registers a
-backend doesn't know.
+makes per-arch `asm` and per-OS `use` safe. Valid at declaration scope
+(selecting `use`/`fwd`/declarations) and statement scope.
 
-`cond` must be comptime: `$mach.*` reads, or comparisons of comptime constants.
-
-```mach
-$if ($mach.build.os == $mach.os.linux) {
-    use std.runtime.linux;
-}
-$or ($mach.build.os == $mach.os.windows) {
-    use std.runtime.windows;
-}
-$or {
-    $error("unsupported OS");
-}
-```
-
-Multi-arch `asm` dispatch happens at the outer `$if` level; there is no nested
-arch-block construct.
+Conditions must be comptime: `$mach.*`/`$project.*` reads, comptime constants
+(`pub val`), comptime parameters, `$type_of` comparisons. Comptime comparison
+follows the runtime rules — mathematical values, mixed signedness fine;
+overflow in comptime arithmetic is a compile error, not a wrap.
 
 ## Comptime function parameters — `$name: T`
 
-A comptime value parameter sits in the regular paren list as `$name: T`. The
-caller must pass a comptime-evaluable value; the compiler enforces it at the
-call site. Inside the body, reference it by bare `name` (no `$`). This is the
-idiom for passing memory orderings and similar variants into stdlib wrappers.
+A `$`-marked parameter in the regular list must receive a comptime-evaluable
+argument (literal, `pub val` constant — including imported ones — or another
+comptime parameter). The compiler **monomorphizes the body per distinct
+value**; each instance compiles only the arms its value selects. Referenced
+bare inside the body:
 
 ```mach
-pub fun load($order: Order, ptr: *i64) i64 {
-    var result: i64 = 0;
+val MODE_DOUBLE: u8 = 0;
+val MODE_SQUARE: u8 = 1;
 
-    $if ($mach.build.arch == $mach.arch.aarch64) {
-        $if (order == RELAXED) {
-            asm aarch64 { ldr {result}, [{ptr}] }
-        }
-        $or (order == ACQUIRE) {
-            asm aarch64 { ldar {result}, [{ptr}] }
-        }
-    }
-
-    ret result;
+pub fun apply($mode: u8, n: i64) i64 {
+    $if (mode == MODE_DOUBLE) { ret n + n; }
+    $or (mode == MODE_SQUARE) { ret n * n; }
+    ret 0;
 }
 ```
 
-> **Implementation status.** The `$name: T` parameter is accepted in a
-> signature, but it is not yet usable as a comptime constant inside the body —
-> `$if (order == RELAXED)` reports that the identifier is not a comptime
-> constant in scope. Per-call-site dispatch requires monomorphizing the body per
-> distinct value, which is not yet done. Until it lands, branch on such a
-> parameter with a runtime `if`.
+Rules that bite:
 
-The `$name: T` form applies to **function parameters only** — not record
-fields, not generic-bracket contexts. Generic *type* parameters use `[T]`
-brackets and are a separate mechanism.
+- Unlike target-gated `$if`, **all** arms of a parameter-gated `$if` are
+  resolved and type-checked structurally; only the selected arm is emitted per
+  instance. Each arm must be independently valid.
+- No storage: `?mode` is rejected; the parameter is stripped from the lowered
+  signature and ABI.
+- A comptime-parameter function is a template, not a value — it cannot be
+  assigned, passed, or compared, only called.
+- Not yet combinable with generic type params (`fun f[T]($m: u8, ...)` is a
+  clear diagnostic).
+- Function parameters only — never record fields.
+
+## Variadic packs (comptime-adjacent)
+
+`va: ...` (trailing parameter) collects call-site arguments into a comptime
+sequence; monomorphized per distinct type-list. `$each a in va` consumes it
+(heterogeneous packs work — dispatch with `$type_of` per element), `va.len`
+folds to the count, `g(va...)` forwards the whole pack (sole trailing argument
+only; no partial forward). No runtime `va_list` exists. Pack functions have no
+stable ABI symbol: not `ext`, not addressable. See `doc/language/variadics.md`.
 
 ## Pitfalls
 
-- **Tag comparison is path-value.** Write `$mach.build.os == $mach.os.linux`,
-  never an `.id` suffix or any unwrap.
-- **No `$or $if`.** The else arm is bare `$or { ... }` with no condition. A
-  conditional alternative is `$or (cond) { ... }`.
-- **Codegen directives are backtick decorators, not `$` writes.** Use
-  `` `symbol("...")` `` / `` `inline` `` / `` `align(N)` `` on the line above the
-  decl; the `$sym.attr = value;` setter form was removed in v2.0.0.
-- **No prefix sugar.** `$inline pub fun ...` does not exist — a decorator sits on
-  its own line above the decl.
-- **Closed sets.** Intrinsic names, decorator names, and `$mach.os.*`/`.arch.*`
-  tags are all closed. Don't invent members; new ones require a compiler change.
-- **Value intrinsics are unsigned constants with no implicit type.** The binding
-  declares the storage type (Mach has no type inference and no `usize`).
-- **Comptime param is referenced bare in the body.** Declared `$order: Order`,
-  used as `order`.
-- **Not in the channel:** no `$<Type>.*` reflection subtree (types aren't
-  first-class comptime values), no comptime function definitions, no comptime
-  loops.
-- **`$if` vs runtime `if`.** `$if` discards untaken branches entirely at compile
-  time; runtime `if`/`or` emits a runtime branch. Use `$if` for conditional
-  compilation, never to fake reflection over untaken code.
+- **Backticks and `$sym.attr =` setters are removed syntax.** Decorators are
+  `#[...]` only.
+- **No `$or $if`** — the else arm is bare `$or { }`.
+- **Closed sets everywhere.** Intrinsics, decorators, `$mach.*` tags. Don't
+  invent members.
+- **`$assert` doesn't fire yet**; `$error` does.
+- **Comptime params are referenced bare** (`order`, not `$order`) and their
+  `$if` arms all must type-check.
+- **`$if` vs `if`.** `$if` selects at compile time and discards the rest;
+  `if` emits a runtime branch. Never use `$if` to fake reflection over code
+  that must exist at runtime.
+- **Not in the channel:** no `$<Type>.*` reflection, no comptime function
+  definitions, no comptime loops beyond `$each` over fields/packs.
 
 ## Reference
 
-The authoritative comptime reference lives in the Mach repository under
-[`doc/language/`](https://github.com/briar-systems/mach/tree/dev/doc/language) —
-`comptime.md`, `comptime-mach.md`, `comptime-attrs.md`,
-`comptime-intrinsics.md`, and `comptime-control.md`. When a skill and the
-reference disagree, the reference wins.
+Authoritative docs in the Mach repository under
+[`doc/language/`](https://github.com/briar-systems/mach/tree/dev/doc/language):
+`comptime.md`, `comptime-mach.md`, `comptime-intrinsics.md`,
+`comptime-control.md`, `decorators.md`, `variadics.md`. The reference wins on
+any disagreement.

--- a/.github/skills/mach-lowlevel/SKILL.md
+++ b/.github/skills/mach-lowlevel/SKILL.md
@@ -1,19 +1,19 @@
 ---
 name: mach-lowlevel
-description: Use when writing or reviewing Mach inline assembly, syscalls, or other target-specific code. Covers the asm <isa> { ... } form with {name} operand substitution, multi-arch dispatch via $if on $mach.build.arch, the compiler-infers-operands-and-clobbers model, and when to write asm versus call a standard-library wrapper.
+description: Use when writing or reviewing Mach inline assembly, syscalls, or other target-specific code. Covers the asm <isa> { ... } form (x86_64/aarch64/riscv64) with {name} operand substitution, the compiler-infers-operands-and-clobbers model, multi-arch dispatch via $if on $mach.build.arch, module target guards, comptime-parameter variant dispatch, and when to write asm versus call the standard library.
 ---
 
 # Mach low-level layer
 
-Inline assembly and target-specific code. Two concerns: how to write an `asm`
-block correctly, and when to reach for `asm` versus a stdlib wrapper.
+Inline assembly and target-specific code: how to write an `asm` block
+correctly, and when to reach for `asm` versus a stdlib wrapper.
 
 ## The `asm` form
 
 One inline-assembly form: an ISA-tagged block of raw instruction lines.
 
 ```mach
-asm <isa> {
+asm x86_64 {
     # raw instructions, one per line, # for comments
     mov rax, [{ptr}]
     mov {result}, rax
@@ -22,14 +22,21 @@ asm <isa> {
 
 Locked rules:
 
-- The ISA tag is **mandatory**. Bare `asm { ... }` does not exist.
-- ISA tags are a closed set: `x86_64`, `aarch64`. **Only `x86_64` has a working backend today**; `aarch64` is a recognized tag for portable target-conditional source but has no code generator yet ([#1045](https://github.com/briar-systems/mach/issues/1045)). An `asm aarch64` block is therefore valid only inside a branch that gets comptime-discarded on an `x86_64` build.
-- Body is **unquoted raw lines**, one instruction per line, in the ISA's native syntax. No surrounding quotes, no string concatenation. (Mach has no multi-line string; the `asm` body is not a string.)
-- `#` introduces a line comment.
+- The ISA tag is **mandatory**; bare `asm { }` is rejected. The tag set is
+  closed: `x86_64`, `aarch64`, `riscv64` — each with a working native
+  assembler. All three are exercised in CI (riscv64 binaries run under
+  qemu; the compiler itself does not yet self-host on riscv64).
+- The body is **raw text**, not tokens: unquoted lines in the ISA's native
+  syntax, captured to the brace-matched `}` (nested braces balance). Mach has
+  no multi-line string; the `asm` body is not a string.
+- `#` starts a line comment; everything after it on the line is inert.
 
 ## Operand substitution — `{name}`
 
-`{name}` substitutes a local in scope. The compiler resolves it to a memory or register operand from liveness and the instruction's expected operand class. Use the bare local name inside the braces; address it with the ISA's own syntax (e.g. `[{ptr}]` to dereference on x86_64).
+`{name}` substitutes a local in scope; the compiler resolves it to a register
+or memory operand from liveness and the instruction's operand class. Address
+it with the ISA's own syntax (`[{ptr}]` on x86_64, `[{ptr}]`/`ldr` on aarch64,
+`ld t0, ({ptr})` on riscv64).
 
 ```mach
 pub fun add_via_asm(a: i64, b: i64) i64 {
@@ -43,89 +50,100 @@ pub fun add_via_asm(a: i64, b: i64) i64 {
 }
 ```
 
-`{name}` is the only substitution. There is no `in`/`out` syntax, no `%0` positional operands, no `=` constraint markers.
+`{name}` is the only substitution: no `in`/`out` lists, no `%0` positionals,
+no `=` constraints. The compiler infers **operand direction** (from position),
+the **clobber set** (from each instruction's semantics), and assumes a
+conservative **memory clobber** for every block. Writing a clobber list is a
+syntax error, not optional metadata.
 
-## What the compiler infers (do NOT declare these)
+## Multi-arch and multi-OS dispatch
 
-- **Operand direction** — read vs write, from operand position in the instruction.
-- **Clobber set** — every register and flag each instruction touches, added to the enclosing function's clobber set automatically.
-- **Memory clobber** — implicit and conservative: every `asm` block is assumed to modify arbitrary memory.
-
-There is no clobber list and no operand-direction declaration. Writing one is invalid syntax, not optional metadata.
-
-## Multi-arch dispatch
-
-No nested arch-block construct exists inside `asm`. Dispatch at the outer level by wrapping each block in `$if` on `$mach.build.arch`:
+No nested arch construct exists inside `asm`. Dispatch at the outer level with
+`$if` on `$mach.build.arch` (or `.os` for syscall ABIs); discarded branches
+never compile, so each block only needs to be valid for its own ISA:
 
 ```mach
 $if ($mach.build.arch == $mach.arch.x86_64) {
-    asm x86_64 {
-        # x86_64 instructions
-    }
+    asm x86_64 { ud2 }
 }
 $or ($mach.build.arch == $mach.arch.aarch64) {
-    asm aarch64 {
-        # aarch64 instructions
-    }
+    asm aarch64 { brk 0 }
+}
+$or ($mach.build.arch == $mach.arch.riscv64) {
+    asm riscv64 { unimp }
 }
 $or {
     $error("unsupported arch");
 }
 ```
 
-- Only the taken branch compiles; discarded branches are not resolved or codegen'd. Each `asm` block only needs to be valid for its own tagged ISA.
-- Compare with path values: `$mach.build.arch == $mach.arch.x86_64`. No `.id` suffix, no string compare.
-- `$or` has **no condition** for the final else arm — `$or { ... }`. A conditional middle arm is `$or (COND) { ... }`. There is no `$or $if`.
-- Same pattern keys off `$mach.build.os` against `$mach.os.linux` / `.darwin` / `.windows` / `.freestanding` for OS-specific bodies (e.g. syscall ABIs).
-
-## When to write `asm` vs call stdlib
-
-Write `asm` only for truly target-specific operations with no 1:1 stdlib wrapper: raw syscalls, special-register reads, stack-frame surgery.
-
-For anything that maps to a named stdlib function — atomics, fences, traps, bit ops, the SIMD long-tail — **call the stdlib API**. Those wrappers already contain the arch-dispatched `asm`; reimplementing them inline duplicates the dispatch and loses the encapsulation. The standard library covers, among others:
-
-- **Atomics** — load/store/cas/RMW, per arch × per ordering.
-- **Memory fences and CPU hints** — pause, prefetch.
-- **Traps / unreachable** — `trap()` with per-arch ISA-tagged blocks
-  (`asm x86_64 { ud2 }` / `asm aarch64 { brk 0 }`).
-- **Syscalls** — per-platform ABI wrappers.
-- **Bit manipulation** — popcount, clz, ctz, bswap.
-- **SIMD long tail** — shuffles, reductions, gather/scatter, saturating arithmetic, specialized math (once SIMD types land).
-
-Rule of thumb: if the operation maps to a fixed instruction sequence per arch, there is (or should be) a stdlib wrapper — prefer it. Reach for raw `asm` only when no such wrapper exists.
-
-## Variant parameters in stdlib wrappers
-
-Memory orderings and similar runtime-relevant variants are passed as **comptime function parameters**, not as separate functions per variant. The `$name: T` form is for function parameters only — caller must pass a comptime-evaluable value, enforced at the call site.
+Compare path-values (`$mach.arch.x86_64`), final else is bare `$or { }`. A
+platform-specific module guards itself at the top so misuse fails loudly at
+compile time — the stdlib pattern:
 
 ```mach
-fun atomic_load[T](ptr: *T, $order: Order) T { ... }
+$if ($mach.build.arch != $mach.arch.x86_64) {
+    $error("myproj.os.linux.x86_64: requires x86_64 target");
+}
 ```
 
-> **Implementation status.** A `$name: T` parameter is accepted in a signature
-> but is not yet usable as a comptime constant inside the body (`$if (order ==
-> RELAXED)` is not yet supported). Until it lands, branch on such a parameter
-> with a runtime `if`.
+## Variant dispatch — comptime parameters
 
-## SIMD type spelling
+Memory orderings and similar variants are one function with a `$name: T`
+comptime parameter, not a function per variant. The compiler monomorphizes per
+distinct value and each instance compiles only its selected `asm` arm:
 
-Vector types follow `<u|i|f><width>x<count>`: `f32x4`, `i32x8`, `u8x16`. Higher dimensions are grammatically legal (`f32x4x4`). **Planned, not yet implemented** — these names do not resolve as types today. Once seeded, the basic operators on them are compiler intrinsics and everything beyond is stdlib.
+```mach
+pub fun load($order: u8, ptr: *i64) i64 {
+    var result: i64 = 0;
+    $if ($mach.build.arch == $mach.arch.aarch64) {
+        $if (order == RELAXED) { asm aarch64 { ldr {result}, [{ptr}] } }
+        $or (order == ACQUIRE) { asm aarch64 { ldar {result}, [{ptr}] } }
+    }
+    ret result;
+}
+```
 
-## Mach gotchas that bite in low-level code
+The call site must pass a comptime-evaluable value. Full rules in the
+**mach-comptime** skill.
 
-- **No type inference.** Every binding declares its type: `var result: i64 = 0;`. The `asm` block does not infer the result type from usage.
-- **No compiler-known type aliases.** `usize`, `str` are stdlib `def`s, not built-ins. `$size_of`/`$align_of`/`$offset_of` resolve to comptime constant unsigned integers stored in whatever type the binding declares.
-- **Strings are `"..."` → `*u8`, null-terminated** in the data segment. Backtick delimits a per-declaration decorator (`` `symbol(...)` `` etc.) on the line before a decl; it has no role inside an `asm` body or expression.
-- **`ext fun` is the only body-less function form.** No forward declarations; body-less signatures are reserved for C-ABI externals. Symbol rename via the `` `symbol("real_name")` `` decorator.
-- **`fwd` is bare** (no `pub fwd`) and **always publishes** — it re-exports a symbol through a surface file, used by both topical splits (all impls forwarded unconditionally) and multiplatform splits (one impl forwarded per target).
-- **No tagged unions, no `match`.** Discriminated values are a `rec` carrying a discriminator plus a `uni` payload (`rec{ kind: ValueKind; data: uni{...} }`); consumers branch with `if`/`or`. The compiler does not enforce kind/payload consistency.
-- **Atomic / volatile are not in the primitive type name.** There are no bare-letter modifiers (`u32a` etc.); those concerns live outside the primitive name, via stdlib atomics.
+## `asm` vs stdlib
+
+Write `asm` only for truly target-specific operations with no stdlib wrapper:
+raw syscalls, special-register reads, stack-frame surgery. For anything that
+maps to a named function — atomics, fences, `trap()`, bit ops (popcount, clz,
+bswap), syscall wrappers — **call the stdlib**: those functions already
+contain the arch-dispatched `asm`, and reimplementing them inline duplicates
+the dispatch. Rule of thumb: if the operation is a fixed instruction sequence
+per arch, there is (or should be) a stdlib wrapper.
+
+## Secrecy — `asm` is a trusted-base crossing
+
+The `^` secret qualifier's flow rules stop at an `asm` boundary: the type
+system cannot check instruction streams, so an `asm` block can observe or
+launder secrets silently. Inside `asm` that touches `^` data, constant-time
+discipline (no secret-dependent branches, addresses, or variable-latency
+instructions) is entirely on you. See `doc/language/secrecy.md`.
+
+## Gotchas that bite in low-level code
+
+- **Every binding declares its type** — `var result: i64 = 0;` before the
+  block; nothing is inferred from `asm` usage.
+- **Decorators are `#[...]`**: pin a symbol for an asm branch target with
+  `#[symbol("_my_trampoline")]`; import a syscall with
+  `#[symbol("write")] ext fun ...`. Backticks are removed syntax.
+- **`usize`/`str` are stdlib defs**; `$size_of`/`$offset_of` produce untyped
+  comptime integers stored in whatever type the binding declares.
+- **`ext fun` is the only body-less form** — reserved for C-ABI externals.
+- **No tagged unions/`match`** — discriminated values are `rec` + `uni` with
+  `if`/`or` chains.
+- **SIMD vector types are not seeded yet** (`f32x4` does not resolve); the
+  SIMD long tail will live in stdlib once they land.
 
 ## Reference
 
-The authoritative low-level reference lives in the Mach repository under
-[`doc/language/`](https://github.com/briar-systems/mach/tree/dev/doc/language) —
-`asm.md` (the `asm` form, operand substitution, inferred clobbers, multi-arch
-dispatch), `comptime-control.md` (`$if`/`$or` over `$mach.build.arch`), and
-`policy.md` (the full compiler-vs-stdlib boundary). When a skill and the
-reference disagree, the reference wins.
+Authoritative docs in the Mach repository under
+[`doc/language/`](https://github.com/briar-systems/mach/tree/dev/doc/language):
+`asm.md` (form, substitution, inference), `comptime-control.md` (`$if`
+dispatch), `secrecy.md` (the trusted base), and `policy.md` (the compiler-vs-
+stdlib boundary). The reference wins on any disagreement.

--- a/.github/skills/mach-lowlevel/SKILL.md
+++ b/.github/skills/mach-lowlevel/SKILL.md
@@ -15,7 +15,8 @@ One inline-assembly form: an ISA-tagged block of raw instruction lines.
 ```mach
 asm x86_64 {
     # raw instructions, one per line, # for comments
-    mov rax, [{ptr}]
+    mov rcx, {ptr}
+    mov rax, [rcx]
     mov {result}, rax
 }
 ```
@@ -34,9 +35,20 @@ Locked rules:
 ## Operand substitution — `{name}`
 
 `{name}` substitutes a local in scope; the compiler resolves it to a register
-or memory operand from liveness and the instruction's operand class. Address
-it with the ISA's own syntax (`[{ptr}]` on x86_64, `[{ptr}]`/`ldr` on aarch64,
-`ld t0, ({ptr})` on riscv64).
+or memory operand from liveness and the instruction's operand class. In
+practice a `{name}` binds the local's **storage — typically a stack slot** —
+so to reach a pointee, stage the pointer through a scratch register first;
+never write a double indirection like `[{ptr}]`:
+
+```mach
+mov rcx, {ptr}          # x86_64: load the pointer value
+mov rax, [rcx]          # then address through the register
+                        # aarch64: ldr x12, {ptr}  /  ldr x9, [x12]
+```
+
+Branch targets inside a block are numeric local labels with direction
+suffixes (`1:` … `bnez a4, 1b`, `b.ne 2f`), the stdlib's convention across
+all three ISAs.
 
 ```mach
 pub fun add_via_asm(a: i64, b: i64) i64 {
@@ -64,16 +76,16 @@ never compile, so each block only needs to be valid for its own ISA:
 
 ```mach
 $if ($mach.build.arch == $mach.arch.x86_64) {
-    asm x86_64 { ud2 }
+    asm x86_64 { hlt }
 }
 $or ($mach.build.arch == $mach.arch.aarch64) {
     asm aarch64 { brk 0 }
 }
 $or ($mach.build.arch == $mach.arch.riscv64) {
-    asm riscv64 { unimp }
+    asm riscv64 { ebreak }
 }
 $or {
-    $error("unsupported arch");
+    $error("mymod.trap: unsupported architecture");
 }
 ```
 
@@ -97,8 +109,20 @@ distinct value and each instance compiles only its selected `asm` arm:
 pub fun load($order: u8, ptr: *i64) i64 {
     var result: i64 = 0;
     $if ($mach.build.arch == $mach.arch.aarch64) {
-        $if (order == RELAXED) { asm aarch64 { ldr {result}, [{ptr}] } }
-        $or (order == ACQUIRE) { asm aarch64 { ldar {result}, [{ptr}] } }
+        $if (order == RELAXED) {
+            asm aarch64 {
+                ldr x12, {ptr}
+                ldr x9, [x12]
+                str x9, {result}
+            }
+        }
+        $or (order == ACQUIRE) {
+            asm aarch64 {
+                ldr x12, {ptr}
+                ldar x9, [x12]
+                str x9, {result}
+            }
+        }
     }
     ret result;
 }

--- a/.github/skills/writing-mach/SKILL.md
+++ b/.github/skills/writing-mach/SKILL.md
@@ -1,365 +1,355 @@
 ---
 name: writing-mach
-description: Use when writing, editing, or reviewing Mach (.mach) source files. Covers project/module structure, use/fwd imports and re-exports, the shadow-module pattern, all declaration forms (pub/ext, def, rec, uni, fun, ext fun, val/var), the type grammar (primitives, SIMD vectors, pointers, arrays, function types), literals, operators, statements (if/or, for, ret, brk/cnt, fin, blocks), expressions, docstring conventions, and the executable entrypoint and std.print output idioms.
+description: Use when writing, editing, or reviewing Mach (.mach) source files. Covers project/module structure, use/fwd imports and re-exports, the shadow-module pattern, all declaration forms (pub/ext, def, rec, uni, fun, ext fun, val/var, test), #[...] decorators, variadic packs, the type grammar (primitives, pointers, arrays, function types, the ^ secret qualifier), literals, operators and casts, statements (if/or, for, ret, brk/cnt, fin, blocks), docstring conventions, and the entrypoint / std.print idioms.
 ---
 
 # Writing Mach
 
-Mach is a low-level, explicitly-typed language. No type inference, no garbage
-collection, no hidden control flow. Files use the `.mach` extension. This skill
-is the fast path for authoring correct Mach; the language reference (see the
-Reference section) is the exhaustive source of truth.
+Mach is a low-level, explicitly-typed language: no type inference, no garbage
+collection, no hidden control flow. Files use `.mach`. This skill is the fast
+path for authoring correct Mach; `doc/language/` in the Mach repository is the
+authoritative reference and wins on any disagreement.
 
 ## Hard rules — get these right
 
 - **No type inference.** Every binding declares its type. `val x = 42;` is an
   error; write `val x: i64 = 42;`.
-- **No compiler-known type aliases.** `bool`, `usize`, `str`, etc. are *stdlib*
-  `def`s, not built-ins. The compiler ships only `ptr`, `va_list`, and the
-  numeric/SIMD family. Import the alias from stdlib before using it. `bool` is
-  `def bool: u8;`; `true`/`false` are stdlib `val`s (`1`/`0`). Comparison and
-  logical operators produce `u8`.
-- **Strings are `*u8`.** `"hello"` produces a `*u8` pointing at null-terminated
-  bytes. There is no fat-pointer string type — `std.types.string.str` is itself
-  `def str: *char;` (a null-terminated pointer, not length-aware). The
-  length-aware view is the stdlib record `std.types.string.StrView`
-  (`{ data: *char; len: usize; }`). Backtick `` ` `` has no role: the lexer
-  treats it as an unexpected character (a lex error) — never emit it.
-- **`fwd` is bare and always public.** No `pub fwd`. `ext fun` is the *only*
-  body-less function form — there are no forward declarations of regular
-  functions.
-- **No tagged unions, no `match`.** Discriminated values are a `rec` carrying a
-  discriminator plus a payload `uni`; consumers branch with `if`/`or`.
-- **`$or` has no condition for the else arm.** There is no `$or $if`. Comptime
-  control is `$if (C) {}` / `$or (C) {}` / `$or {}`.
+- **No compiler-known type aliases.** `bool`, `usize`, `str`, `char` are stdlib
+  `def`s, not built-ins. Import them before use (`use std.types.bool.bool;`).
+  `true`/`false` are stdlib `val`s (`1`/`0`); comparisons and logical operators
+  produce `u8`.
+- **Decorators are `#[...]` attributes** on the line(s) above a declaration:
+  `#[symbol("main")]`, `#[inline]`, `#[align(64)]`. The backtick form was
+  removed in v2.4.0 and is a migration error — never emit backticks.
+- **Variadics are comptime packs.** A trailing `va: ...` parameter, consumed by
+  `$each a in va`. There is no `va_list`/`va_start`/`va_arg` and the C-style
+  bare `...` parameter is a removed-syntax error.
+- **Strings are `*u8`, single-line.** `"hello"` is a pointer to null-terminated
+  bytes. No fat-pointer string type (`str` is `def str: *char;`); no multi-line
+  string literal — use `\n` escapes.
+- **No tagged unions, no `match`.** A discriminated value is a `rec` carrying a
+  discriminator plus a payload `uni`; consumers branch with `if`/`or`. This is
+  exactly how stdlib `Result[T, E]` is built.
+- **No compound assignment.** `+=` etc. do not exist; write `x = x + 1;`.
+- **`fwd` is bare and always public** (no `pub fwd`). `ext fun` is the only
+  body-less function form.
 
-## File and module structure
+## Project and module structure
 
-A project has a `mach.toml` at its root whose `[project] id` is the root of
-every module path. A file at `src/foo/bar.mach` in a project with `id = "myproj"`
-is the module `myproj.foo.bar`. Path separator is `.`. There is **no `this.`
-self-prefix** — always reference modules by full project-rooted path.
+A project has a `mach.toml` at its root; `[project] id` roots every module
+path. A file at `src/foo/bar.mach` in project `id = "myproj"` is the module
+`myproj.foo.bar`. There is no `this.` self-prefix — always use the full
+project-rooted path, including for sibling modules. A one-segment `use <id>;`
+resolves only when that project declares a `[project] module` surface file
+(e.g. a library `glfw` imported as `use glfw;`); `std` does not — always
+import full `std.*` paths.
 
-Entrypoints by convention: `lib.mach` (library, no executable), `main.mach`
-(executable). The dominant role is set by the target's `mode` / `entrypoint` in
-`mach.toml`.
+A file reads top-down: module docstring, `use`/`fwd` lines, declarations.
 
-A file begins with a module docstring (see Docstrings), then `use`/`fwd` lines,
-then declarations.
+### `use` — private import
 
-## Executable entrypoint
+```mach
+use std.types.size;             # binds module `size`; use as size.usize
+use sz: std.types.size;         # module under alias; use as sz.usize
+use std.types.size.usize;       # binds the symbol; use bare as usize
+```
 
-The standard library provides the platform `_start` symbol that calls your
-`main`. Pull it in with `use std.runtime;`, tag `main` with the `` `symbol` ``
-decorator so the linker finds it, and return an exit code:
+The resolver binds whatever the path ends at: a **module** (members reached
+qualified) or a **symbol** (used bare). Importing a module does not pull its
+members in unqualified. No splat, no `use foo.{a,b}` — one name per line. A
+module `use`s every dependency it directly names, even ones reachable through
+a re-export: the dependency graph is visible at the top of every file.
+
+### `fwd` — public re-export
+
+```mach
+fwd impl.Point;                 # re-export as Point
+fwd Pt: impl.Point;             # re-export as Pt
+fwd impl.helpers;               # a module path re-exports the whole module
+```
+
+Mirrors `use` grammar; always publishes.
+
+### Shadow-module pattern
+
+A surface file `foo.mach` co-exists with directory `foo/` holding split
+implementations. The surface `use`s each split and `fwd`s its public symbols;
+consumers `use myproj.foo;` and never name the splits. Topical splits forward
+everything unconditionally; multiplatform splits pick one impl per target:
+
+```mach
+$if ($mach.build.os == $mach.os.linux) {
+    use impl: myproj.os.linux;
+}
+$or ($mach.build.os == $mach.os.windows) {
+    use impl: myproj.os.windows;
+}
+$or {
+    $error("myproj.os: unsupported target");
+}
+
+fwd impl.page_size;
+```
+
+## Entrypoint and output
+
+The stdlib provides the platform `_start`, which calls whatever function
+exports the linker symbol `main`. `use std.runtime;` is required to link it in
+even though nothing references it by name:
 
 ```mach
 use std.runtime;
+use std.print;
 
-`symbol("main")`
+#[symbol("main")]
 fun main(argc: i64, argv: **u8) i64 {
+    print.println("hello, mach");
     ret 0;
 }
 ```
 
-`use std.runtime;` is what links the entrypoint into the binary.
-
-## Output — `std.print`
-
-There is no built-in `print`. Use the standard library, which returns a
-`Result` (output can fail):
-
-```mach
-use std.print;
-
-fun greet() {
-    print.println("hello, mach");
-}
-```
-
-`use std.print;` binds the leaf name `print` (the module), so members are
-reached qualified as `print.<member>` — `std` is not itself in scope, so
-`std.print.println(...)` would not resolve. The `print` module exposes
-`print` / `println` (stdout), `eprint` / `eprintln` (stderr), and formatting
-variants. Each returns `Result[usize, str]` — bytes written, or an error.
-
-## `use` — private import
+`use std.print;` binds the leaf module `print` (`std` itself is not in scope).
+It exposes `print`/`println` (stdout), `eprint`/`eprintln` (stderr), and the
+format family `printf`/`printlnf`/`eprintf`/`eprintlnf` — pack-variadic, with
+`{}` holes filled in argument order plus `{:x}`-style specs (`{:X}`, `{:c}`,
+`{:5}`, `{:<5}`, `{:08x}`; `{{`/`}}` for literal braces). All return
+`Result[usize, str]`.
 
 ```mach
-use std.types.size;        # binds module `size`; use as `size.usize`
-use sz: std.types.size;    # module under alias `sz`; use as `sz.usize`
-use std.types.size.usize;  # binds the symbol; use bare as `usize`
+print.printlnf("built {} in {}ms", name, elapsed);
 ```
-
-The resolver binds whatever the path ends at: a **module** (access members
-qualified, `module.member`) or a **symbol** (used bare). Importing a module
-does **not** pull its members in unqualified — to use `usize` bare, import the
-symbol, not the module. **No splat, no combined forms** (`use foo.*` and
-`use foo.{a,b}` do not exist). One name per line. A module must `use` every
-dependency it directly names — even ones reached through a re-export. The
-dependency graph is visible at the top of every file.
-
-## `fwd` — public re-export
-
-```mach
-fwd impl.Point;        # re-export as `Point`
-fwd Pt: impl.Point;    # re-export as `Pt`
-```
-
-Mirrors `use` grammar; always publishes; no `pub` modifier. One per line, no
-splat.
-
-## Shadow-module pattern
-
-A surface file `foo.mach` co-exists with a directory `foo/`. The surface owns
-the public face; the directory holds split implementations. The surface `use`s
-each split and `fwd`s its public symbols, flattening them into the `foo`
-namespace. Consumers `use myproj.foo;` and reach `foo.X` without naming splits.
-
-```mach
-use myproj.foo.data;
-use myproj.foo.ops;
-
-fwd data.Point;
-fwd ops.add;
-```
-
-- **Topical split** — forward all impls unconditionally.
-- **Multiplatform split** — pick one impl per target with `$if` on
-  `$mach.build.os` / `$mach.build.arch`, then `use` + `fwd` the chosen one.
 
 ## Declarations
 
-Modifiers: `pub` (public surface) and `ext` (C-ABI, functions only, no body).
-Without `pub`, a declaration is file-private. `pub` applies to `fun`, `rec`,
-`uni`, `def`, `val`, `var`, `ext fun`.
+Modifiers: `pub` (public surface; without it a declaration is file-private)
+and `ext` (C-ABI external, functions only). Both apply to `fun`, `rec`, `uni`,
+`def`, `val`, `var`.
 
 ### `def` — type alias
 
 ```mach
-pub def Age:    i64;
-pub def BinOp:  fun(i64, i64) i64;
-pub def Anon:   rec { x: i64; y: i64; };
-pub def Choice: uni { a: i64; b: f64; };
+pub def Age:   i64;
+pub def BinOp: fun(i64, i64) i64;
 ```
 
-Aliases name any type; alias and underlying type are interchangeable (no
-nominal distinction).
+Aliases name any type; alias and underlying type are interchangeable.
 
-### `rec` — record / `uni` — raw union
+### `rec` / `uni`
 
 ```mach
 pub rec Point { x: i64; y: i64; }
-pub rec Pair[T, U] { left: T; right: U; }   # generic
+pub rec Pair[T, U] { left: T; right: U; }      # generic
 
-pub uni Number { i: i64; f: f64; }
-pub uni Maybe[T] { some: T; none: u8; }     # generic
+pub uni Number { i: i64; f: f64; }              # fields overlap; size of largest
 ```
 
-A `rec` lays fields out with padding; a `uni` overlaps all fields in one slot
-(size of largest field). The compiler does not track which `uni` field is live.
-
-Discriminated value (the only sum-type idiom) — this is exactly how the stdlib
-`Result[T, E]` is built:
+The compiler does not track which `uni` field is live. The sum-type idiom
+(stdlib `Result[T, E]` verbatim):
 
 ```mach
-rec Result[T, E] {
+pub rec Result[T, E] {
     tag:   bool;
-    value: uni { ok: T; err: E; }
+    value: uni { ok: T; err: E; };
 }
 ```
 
-Read the discriminator, then access the matching payload field with `if`/`or`.
+Packed layout is not available; `#[align(N)]` raises a type's or global's
+alignment.
 
-### `fun` — function
-
-```mach
-fun NAME(args) RET { ... }        # with return type
-fun NAME(args) { ... }            # no return
-fun NAME[T](args) RET { ... }     # generic type params (no constraints)
-fun NAME($p: T, args) RET { ... } # comptime value param
-fun NAME(a, b, ...) RET { ... }   # variadic (trailing ...)
-```
+### `fun`
 
 ```mach
 pub fun add(a: i64, b: i64) i64 { ret a + b; }
-pub fun identity[T](value: T) T { ret value; }
+pub fun identity[T](value: T) T { ret value; }  # generic; call: identity[i64](42)
+pub fun load($order: u8, p: *i64) i64 { ... }   # comptime value param
+pub fun sum(va: ...) i64 {                      # variadic pack
+    var t: i64 = 0;
+    $each a in va { t = t + a; }
+    ret t;
+}
 ```
 
-- Generic type params in `[T]` brackets — **types only, no constraints**;
-  compiler monomorphizes per instantiation. Call sites supply types:
-  `identity[i64](42)`.
-- Comptime value params use `$name: T` *in the regular paren list*; the caller
-  passes a comptime-evaluable value (enforced at the call site, passed
-  positionally like a runtime arg). This form is **function parameters only** —
-  never record fields.
-- Variadic via trailing `...`; access through `va_list` / `va_start` /
-  `va_arg[T]` / `va_end` (C convention). The `va_list` builtin type and the
-  `va_*` intrinsics are compiler-seeded — typed in sema and lowered to
-  dedicated IR opcodes against the SysV register-save area. The limitation is
-  ABI completeness at the edges (e.g. passing/fetching large by-value
-  aggregates as variadic arguments); scalar and pointer varargs work.
+- Generic params `[T]` take types only, no constraints; monomorphized per
+  instantiation; call sites always supply the types explicitly.
+- `$name: T` params must receive a comptime-evaluable argument; the body
+  branches on them with `$if`, monomorphized per distinct value. Referenced
+  bare (`order`, not `$order`) inside the body. See the **mach-comptime**
+  skill for the full rules.
+- A pack (`va: ...`) must be the last parameter. `va.len` folds to the element
+  count; `g(va...)` forwards the whole pack to another pack-tailed function.
+  Pack functions are source-level only — no stable ABI symbol, so no `ext` and
+  no function pointer to one.
 
-### `ext fun` — external function
+### `ext fun`
 
 ```mach
-`symbol("write")`                          # optional linker-name override
+#[symbol("write")]
 pub ext fun libc_write(fd: i64, buf: *u8, n: i64) i64;
 ```
 
-Body-less, ends in `;`. C ABI is the contract; arg/return types must be C-
-representable. The only body-less function form.
+Body-less, ends in `;`, C ABI is the contract. Provide the definition at link
+time (`mach build . -l c`, manifest `libs`, or an explicit `.o`/`.a`/`.so`).
+On PE targets pin imports to their DLL with `#[library("ws2_32.dll")]`.
 
-### `val` / `var` — bindings
-
-```mach
-val pi: f64 = 3.14159;     # immutable, initializer required
-var counter: i64 = 0;      # mutable, explicit init
-var buf: [256]u8;          # mutable, default-initialized (zero)
-```
-
-Work at module top level (`pub val` / `pub var` export) and in function bodies.
-
-## Type grammar
-
-Primitives follow `<u|i|f><width>(x<count>)*`.
-
-- Scalars: `u8 u16 u32 u64`, `i8 i16 i32 i64`, `f32 f64`.
-- Untyped pointer: `ptr`. (`bool` is a stdlib `def` for `u8`, not a built-in.)
-- Variadic cursor: `va_list` — the compiler-seeded register-save struct used
-  with `va_start` / `va_arg[T]` / `va_end` (see Variadics under `fun`).
-- SIMD vectors: append `x<count>` — `f32x4`, `i32x8`, `u8x16`. **Planned, not
-  yet implemented**: vector type names do not resolve as types today. Higher
-  dims (`f32x4x4`) are grammatically legal. Atomic/volatile live outside the
-  type name (no bare-letter modifiers).
-
-Compound:
+### `val` / `var`
 
 ```mach
-*T              # pointer
-[N]T  [N][M]T   # array, nested
-fun(T1, T2) R   # function-pointer type
+val pi: f64 = 3.14159;          # immutable; initializer required
+var counter: i64 = 0;
+var buf: [256]u8;               # default-initialized to zero
 ```
 
+Work at module top level (`pub` exports) and in function bodies.
+
+### `test`
+
+Tests are declarations, inline next to the code they cover, in any module:
+
 ```mach
-var x: i64 = 9;
-var p: *i64 = ?x;     # address-of yields *i64
-val v: i64  = @p;     # dereference
-val a: [4]i64 = [4]i64{1, 2, 3, 4};
-def BinOp: fun(i64, i64) i64;
+test "point: add is commutative" {
+    if (add(1, 2) != add(2, 1)) { ret 1; }
+    ret 0;
+}
 ```
+
+The label is a required string literal; convention is `"topic: behavior"`.
+The body checks like an `i32` function: `ret 0` (or falling off the end)
+passes, any non-zero return fails. There are no assertion builtins — return
+early on a failed check. `mach test` collects every test in the project
+(dependencies excluded unless `--include-deps`), builds one executable per
+test, and reports per-module; `--filter <pattern>` narrows, `--list`
+enumerates.
+
+## Types
+
+Compiler-seeded primitives (the complete set): `u8 u16 u32 u64`,
+`i8 i16 i32 i64`, `f32 f64`, and the untyped pointer `ptr`. SIMD vector names
+(`f32x4` …) are a planned design and **do not resolve as types yet**.
+
+```mach
+*T                  # pointer          ?x address-of, @p dereference
+[N]T  [N][M]T       # array            val a: [4]i64 = [4]i64{1, 2, 3, 4};
+fun(T1, T2) R       # function pointer val op: BinOp = add;  op(2, 3)
+^T                  # secret-qualified (see below)
+```
+
+Pointers index like arrays: `p[i]` reads the i-th element (this is how `str`
+is walked). A `fun(...)` type may carry a trailing `...` for FFI only.
+
+### `^` — the secret qualifier
+
+`^T` marks data as secret for the constant-time discipline. Secrets may move
+and be stored but may never reach an observable position: a branch or loop
+condition, the left operand of `&&`/`||`, a memory index, or a `/`/`%`
+operand — each is a compile error. Public flows up to secret implicitly; the
+**only** downgrade is the explicit strip cast `x:^` (or `x:^T`). Any operation
+with a secret operand yields a secret result; `uni` variants must agree on
+secrecy; a secret-welded pointer (`*^T`) cannot be erased to `ptr`. See
+`doc/language/secrecy.md` before touching crypto code.
 
 ## Literals
 
 | Form | Example | Notes |
 |---|---|---|
-| Decimal / hex / bin / octal | `42` `0xDEAD` `0b1010` `0o755` | untyped |
-| Underscores / scientific | `1_000_000` `1.5e10` | untyped |
-| Typed suffix | `7i64` `255u8` `2.5f64` | typed by suffix |
-| Char | `'M'` | `u8` |
-| String | `"hi\n"` | `*u8`, null-terminated |
-| `nil` | `nil` | null-address literal; coerces to any pointer type |
+| Int (dec/hex/bin/oct) | `42` `0xDEAD` `0b1010` `0o755` `1_000_000` | untyped until context |
+| Typed suffix | `7i64` `255u8` `2.5f64` | use when context doesn't constrain |
+| Float | `1.5` `1.5e10` | `.` must be followed by a digit |
+| Char | `'M'` | `u8`; escapes `\n \t \r \\ \' \0 \xHH` |
+| String | `"hi\n"` | `*u8`, null-terminated, single-line; adds `\"` |
+| `nil` | `nil` | null address; coerces to any pointer **or function** type |
 
-Untyped numeric literals are *checked* against the surrounding declared type;
-they do not infer it. If context does not constrain the type, use a suffix
-(`42i64`). `nil` types as `*u8` with no context and coerces to any pointer;
-relate function pointers to `nil` via `==` / `!=`, not assignment. Char escapes:
-`\n \t \r \\ \' \0 \xHH`. String escapes: same plus `\"`. A string literal may
-span multiple lines — the lexer scans to the next unescaped `"`, so a raw
-newline inside the quotes is part of the literal.
+Untyped literals are *checked* against the declared type, never used to infer
+it. `nil` with no context types as `*u8`; `var cb: fun(u32) = nil;` is legal.
 
-## Operators
+## Operators and casts
 
-- Arithmetic: `+ - * / %` — int/float scalars (and lane-wise on planned SIMD
-  vectors).
-- Bitwise: `& | ^ ~ << >>` — integer scalars (and planned integer vectors).
-- Comparison: `== != < > <= >=` → `u8` (`1`/`0`). A pointer may be compared
-  against `nil`.
-- Logical: `&& || !` — short-circuiting; `u8` operands (`0` false, nonzero
-  true) → `u8`.
-- Unary: `-` negate, `~` bitwise NOT, `!` logical NOT.
-- Pointer: `?expr` address-of, `@ptr` dereference (also `@p = x;` to write).
-- Cast: `expr::Type` value conversion (width/sign/pointer, int↔float by value) and `expr:~Type` bit reinterpret (read the exact bits as an equal-size type).
+- Arithmetic `+ - * / %` (ints and floats; `%` truncated remainder, sign of
+  the dividend, floats included). Bitwise `& | ^ ~ << >>` (ints).
+- Comparison `== != < > <= >=` → `u8`. Mixed int signedness/width compares
+  **mathematical values** (a negative `i64` < any `u64`). Int vs float
+  comparison is a compile error — cast explicitly.
+- Logical `&& || !` — short-circuit, `u8` operands and result.
+- Pointer: `?expr` address-of, `@p` dereference (`@p = x;` writes through).
+- Casts (postfix): `expr::T` value conversion (resize, int↔float);
+  `expr:~T` bit reinterpret (same byte size required); `expr:^` strips the
+  secret qualifier (the only one that can).
+- Assignment `=` is an expression form used in statement position;
+  right-associative, lowest precedence.
 
-Precedence follows C-family conventions. There is no compound assignment
-(`+=`, `-=`, … do not exist).
+Precedence is C-family: `* / %` > `+ -` > `<< >>` > relational > equality >
+`&` > `^` > `|` > `&&` > `||` > `=`. Note bitwise binds looser than
+comparison, as in C — parenthesize `(a & b) != 0`.
 
 ## Statements
 
-End with `;` except when ending in a block `{...}`. There is no
-brace-less single-statement body.
+Statements end with `;` unless they end with a block. Bodies are always
+blocks — there is no brace-less form.
 
 ```mach
 if (cond) { ... } or (cond) { ... } or { ... }   # `or {}` is the catch-all
-for (cond) { ... }                                # single condition-loop; no for-each
-ret expr;  ret;                                   # value / void return
-brk;  cnt;                                         # break / continue enclosing for
-fin stmt;   fin { ... }                            # defer to scope exit, reverse order
-{ ... }                                            # bare block = new lexical scope
+for (cond) { ... }                               # condition loop
+for { ... }                                      # no condition: infinite loop
+ret expr;   ret;                                 # value / void return
+brk;   cnt;                                      # break / continue enclosing for
+fin { ... }                                      # run at scope exit, reverse order
+{ ... }                                          # bare block = new scope
 ```
 
-`fin` schedules cleanup that runs when the enclosing scope exits, in reverse
-declaration order. It takes a single statement or a block — no bare-expression
-form.
+`fin` requires a block — `fin stmt;` is rejected. There is no for-each; loop a
+counter or a pointer cursor. `$if`/`$or` (comptime) and `$each` (comptime
+unroll) also appear in statement position — see the **mach-comptime** skill.
 
-## Expressions
+## Stdlib idioms
+
+- `Result[T, E]` with `ok`/`err` constructors and `is_ok`/`is_err`/
+  `unwrap_ok`/`unwrap_err`; `Option[T]` with `some`/`none`/`is_some`/`unwrap`.
+  Generic arguments are always explicit at call sites:
 
 ```mach
-counter                              # name in scope
-core.add                             # module-qualified
-Point{ x: 1, y: 2 }                  # record literal
-[3]i64{10, 20, 30}                   # array literal
-Number{ i: 99 }                      # union literal
-Pair[i64, u8]{ left: 5, right: 6u8 } # generic literal: type args before body
-p.x   a[0]                           # field / index access
-add(2, 3)   identity[i64](42)        # call / generic call
+val r: Result[usize, str] = parse(s);
+if (is_err[usize, str](r)) { ret r; }
+val n: usize = unwrap_ok[usize, str](r);
 ```
 
-Vector literals (`f32x4{ ... }`) follow the same shape but depend on the SIMD
-vector types, which are not yet implemented.
+- `str` is `*char` (null-terminated); `std.types.string` provides `str_len`,
+  comparison, and `StrView { data, len }` for length-aware slices.
+- Naming: `snake_case` functions/bindings, `PascalCase` types,
+  `SCREAMING_SNAKE` constants. Indent 4 spaces; align `:` columns in field
+  blocks, import groups, and consecutive `val`/`var` runs when it aids
+  scanning.
 
 ## Docstrings
 
-`#` comments immediately above a declaration. Summary line, optional `# ---`
-separator, then one component line per exposed element. Prose is lowercase
-except proper nouns and type names.
+`#` comments immediately above a declaration: a lowercase summary line, then —
+only when there are elements to document — a `# ---` separator and one aligned
+component line per parameter/field/return:
 
 ```mach
-# realtime: read the wall-clock time.
+# read the wall-clock time.
 # ---
 # out: pointer to Timespec to populate
 # ret: 0 on success, negative errno on failure
 pub fun realtime(out: *Timespec) i64 { ... }
 ```
 
-Component identifiers: parameter name, `$name` (comptime param), `[T]` (generic
-param), `ret` (return), field name, variant name. Summary-only docstrings omit
-the separator and component block:
+Component identifiers: parameter name, `$name`, `[T]`, `ret`, field name,
+variant name. Summary-only docstrings omit the separator. Every file opens
+with a module docstring (summary, optional paragraphs separated by blank `#`
+lines) before any `use`/`fwd`/decorator. Decorators sit between the docstring
+and the declaration. Document every `pub` entity.
 
-```mach
-# spin_hint: yield the CPU to other threads.
-pub fun spin_hint() { ... }
-```
+## Comptime channel — brief
 
-A module file opens with a module docstring (full dotted path as `<name>`)
-before any `use`/`fwd`/attribute. Modules may add paragraphs separated by blank
-`#` lines; other declaration kinds do not extend past the component block.
-Backtick decorators follow the docstring, immediately above the decl.
-
-## Comptime channel (`$`) — brief
-
-`$mach.*` reads compiler-provided state; per-declaration backtick decorators
-`` `name(args)` `` attach codegen attributes to the following decl. Closed
-decorator set: `` `symbol` `` `` `library` `` `` `inline` `` `` `align` `` `` `section` ``. Comptime control:
-`$if (C) {} $or (C) {} $or {}` — only the taken branch compiles. Value
-intrinsics `$size_of(T) $align_of(T) $offset_of(T, f)` yield comptime unsigned
-integers; `$error("msg")` / `$assert(C, "msg")` are diagnostics. The full
-comptime/asm grammar is out of scope here — see the **mach-comptime** skill.
+`$` is the compiler-owned comptime channel: `$mach.*`/`$project.*`/`$bin.*`
+reads, the closed intrinsic set (`$size_of`, `$type_of`, `$fields`, `$error`,
+…), `$if`/`$or` conditional compilation, and `$each` unrolls. `#[...]`
+decorators (`symbol`, `library`, `inline`, `align`, `section`) are a separate
+closed set. Full rules: the **mach-comptime** skill. Inline `asm`: the
+**mach-lowlevel** skill.
 
 ## Reference
 
-The authoritative per-feature language reference lives in the Mach repository
-under
+The authoritative per-feature reference lives in the Mach repository under
 [`doc/language/`](https://github.com/briar-systems/mach/tree/dev/doc/language),
-including the EBNF in `grammar.md`. When a skill and the reference disagree, the
-reference wins.
+including the full EBNF in `grammar.md`. When this skill and the reference
+disagree, the reference wins.

--- a/.github/skills/writing-mach/SKILL.md
+++ b/.github/skills/writing-mach/SKILL.md
@@ -313,6 +313,9 @@ val n: usize = unwrap_ok[usize, str](r);
 
 - `str` is `*char` (null-terminated); `std.types.string` provides `str_len`,
   comparison, and `StrView { data, len }` for length-aware slices.
+- No methods, no UFCS: everything is a free function taking an explicit
+  receiver (usually a pointer), reached through the module alias —
+  `vec.push[T](?v, x)`, not `v.push(x)`.
 - Naming: `snake_case` functions/bindings, `PascalCase` types,
   `SCREAMING_SNAKE` constants. Indent 4 spaces; align `:` columns in field
   blocks, import groups, and consecutive `val`/`var` runs when it aids
@@ -320,12 +323,13 @@ val n: usize = unwrap_ok[usize, str](r);
 
 ## Docstrings
 
-`#` comments immediately above a declaration: a lowercase summary line, then —
-only when there are elements to document — a `# ---` separator and one aligned
-component line per parameter/field/return:
+`#` comments immediately above a declaration: a bare lowercase summary line
+(no `name:` prefix, no trailing period), then — only when there are elements
+to document — a `# ---` separator and one aligned component line per
+parameter/field/return:
 
 ```mach
-# read the wall-clock time.
+# read the wall-clock time
 # ---
 # out: pointer to Timespec to populate
 # ret: 0 on success, negative errno on failure
@@ -337,6 +341,11 @@ variant name. Summary-only docstrings omit the separator. Every file opens
 with a module docstring (summary, optional paragraphs separated by blank `#`
 lines) before any `use`/`fwd`/decorator. Decorators sit between the docstring
 and the declaration. Document every `pub` entity.
+
+Much existing code still carries the older `# name: summary.` form (leading
+identifier, trailing period) from before the convention tightened — when
+editing such a file, match its surrounding style; use the bare form in new
+files.
 
 ## Comptime channel — brief
 

--- a/.github/skills/writing-mach/SKILL.md
+++ b/.github/skills/writing-mach/SKILL.md
@@ -122,8 +122,8 @@ print.printlnf("built {} in {}ms", name, elapsed);
 ## Declarations
 
 Modifiers: `pub` (public surface; without it a declaration is file-private)
-and `ext` (C-ABI external, functions only). Both apply to `fun`, `rec`, `uni`,
-`def`, `val`, `var`.
+applies to `fun`, `rec`, `uni`, `def`, `val`, `var`; `ext` (C-ABI external)
+applies to functions only.
 
 ### `def` — type alias
 


### PR DESCRIPTION
Closes #1909.

Complete rewrite of the three `.github/skills/` Mach-authoring skills (plus the section README) against `doc/language/` at v2.12 and the conventions practiced in `src/` and `mach-std`. The old skills were last accuracy-passed at the v2.0.0 collapse and actively taught removed syntax (backtick decorators, C-style `va_list` variadics) and stale implementation status (comptime params 'not usable', $error 'not evaluated', aarch64 'no backend').

New coverage: `#[...]` decorators, variadic packs (`va: ...` / `$each` / `va...`), `test` declarations + `mach test`, the `^` secrecy qualifier and `:^` strip cast, `$type_of`/`$fields`/`$each` + `v.[f]`, `$project.*`/`$bin.*` roots and manifest defines, riscv64 asm + `$mach.arch.riscv64`/`$mach.abi.lp64`, the printf format family, Result/Option idioms, docstring conventions, single-line strings, block-body `fin`, infinite `for`, and the exact precedence ladder.

Facts were verified against the parser-derived grammar (`doc/language/grammar.md`), the compiler source (`src/lang/fe/comptime.mach` tag tables), the live stdlib (`dep/mach-std`), and the integration matrix (`int/targets.conf`).
