### PR TITLE
docs: accuracy pass — asm staging, riscv64 status, comptime tags, manifest ISA table

### DIFF
--- a/doc/language/asm.md
+++ b/doc/language/asm.md
@@ -10,13 +10,14 @@ no `in` / `out` declarations, no clobber list.
 ```mach
 asm <isa> {
     # raw instructions, one per line, # for comments
-    mov rax, [{ptr}]
+    mov rcx, {ptr}
+    mov rax, [rcx]
     mov {result}, rax
 }
 ```
 
 - The ISA tag is mandatory. Bare `asm { ... }` does not exist.
-- The tag comes from a closed set: `x86_64`, `aarch64`, `riscv64`. Each has a working assembler that emits native bytes. `riscv64` is cross-compile-only: its assembler is complete (it emits `ecall` and the rest of the RV64 grammar), but mach-std has no riscv64 runtime yet, so the compiler cannot be built for it.
+- The tag comes from a closed set: `x86_64`, `aarch64`, `riscv64`. Each has a working assembler that emits native bytes; all three run in CI (riscv64 under qemu, including a self-host smoke — riscv64 is a self-hosting target with a byte-identical fixpoint, #1852).
 - Each line is an instruction in the ISA's native syntax.
 - `#` introduces a line comment: everything from `#` to the end of the line is ignored, whatever it contains (`;`, `{}`, `%`, and so on are all inert inside a comment).
 
@@ -24,7 +25,10 @@ asm <isa> {
 
 `{name}` substitutes a local in scope. The compiler resolves the reference
 to a memory or register operand based on liveness and the instruction's
-expected operand class.
+expected operand class. In practice a `{name}` binds the local's storage —
+typically a stack slot — so a pointer local's pointee is reached by staging
+the pointer through a scratch register first (`mov rcx, {ptr}` then
+`mov rax, [rcx]`), never by a direct `[{ptr}]` indirection.
 
 ```mach
 pub fun add_via_asm(a: i64, b: i64) i64 {

--- a/doc/language/comptime-mach.md
+++ b/doc/language/comptime-mach.md
@@ -6,8 +6,8 @@ constants. The tags `$mach.{os,arch,abi,mode}.*` exist for path-value
 comparison against the resolved-build facts.
 
 > **Implementation status.** The resolved-build facts (`$mach.build.{os,arch,
-> abi,pointer_width,mode}`), the tag tables (`$mach.{os,arch,abi,mode}.*`), the
-> compiler version (`$mach.version` and `$mach.version.{major,minor,patch}`),
+> abi,pointer_width,mode,pie}`), the tag tables (`$mach.{os,arch,abi,mode}.*`),
+> the compiler version (`$mach.version` and `$mach.version.{major,minor,patch}`),
 > and `$mach.compiler.{name,version}` are live. The `$mach.build.{timestamp,
 > host}`, `$mach.build.git.*`, `$mach.project.*`, and `$mach.source.*` paths are
 > reserved stubs — reading one is a compile error ("not yet available"). Each
@@ -27,6 +27,7 @@ $mach.build.arch                # live; compared against $mach.arch.* tags
 $mach.build.abi                 # live; compared against $mach.abi.* tags
 $mach.build.pointer_width       # live; integer count of bytes
 $mach.build.mode                # live; compared against $mach.mode.* tags
+$mach.build.pie                 # live; 1 when building position-independent, else 0
 $mach.build.timestamp           # stub — not yet available
 $mach.build.host                # stub — not yet available
 $mach.build.git.commit          # stub — not yet available
@@ -85,9 +86,11 @@ $mach.os.windows
 $mach.os.freestanding           # no OS / bare metal
 $mach.arch.x86_64
 $mach.arch.aarch64
+$mach.arch.riscv64
 $mach.abi.sysv
 $mach.abi.win64
 $mach.abi.aapcs64
+$mach.abi.lp64
 $mach.mode.debug
 $mach.mode.release
 ```

--- a/doc/language/expressions.md
+++ b/doc/language/expressions.md
@@ -45,11 +45,12 @@ val first: i64 = a[0];           # array index
 ```mach
 add(2, 3)
 identity[i64](42)               # generic call: type args in [ ]
-sum(3, 10i64, 20i64, 30i64)     # variadic (call site parses; see fun.md)
+sum(3, 10i64, 20i64, 30i64)     # variadic pack call (see variadics.md)
 ```
 
-Variadic call sites parse, but the callee-side `va_list` machinery is not
-yet implemented — see [fun.md](fun.md).
+A call to a pack-tailed function is monomorphized per distinct trailing
+type-list; `g(va...)` forwards a whole pack — see
+[variadics.md](variadics.md).
 
 For comptime parameters, the value is passed positionally like a runtime
 argument — the function signature determines whether it must be comptime:

--- a/doc/manifest.md
+++ b/doc/manifest.md
@@ -106,8 +106,9 @@ reserved name — declaring `[target.native]` is an error.
 
 | Value     | Status |
 |-----------|--------|
-| `x86_64`  | supported — the only fully working ISA today |
-| `aarch64` | recognized; an ISA vtable exists, but codegen is not yet validated end-to-end |
+| `x86_64`  | supported — the primary ISA |
+| `aarch64` | supported — CI builds and runs linux-arm64 natively on every PR |
+| `riscv64` | supported — CI runs under qemu on every PR; self-hosting target (#1852) |
 
 ### Accepted `os` values
 


### PR DESCRIPTION
Closes #1912.

Four accuracy fixes in `doc/`, each verified against the compiler source, mach-std, and `int/targets.conf`:

- **asm.md** — the headline example now stages the pointer through a scratch register and the operand-substitution section states the stack-slot binding rule (every mach-std block does this; `[{ptr}]` was never the practiced form). riscv64 is described as a self-hosting, CI-exercised target (#1852) instead of cross-compile-only-with-no-runtime.
- **comptime-mach.md** — adds the live `$mach.arch.riscv64` and `$mach.abi.lp64` tags (evaluator `arch_tag_for`/`abi_tag_for`) and the live `$mach.build.pie` fact (read by the stdlib runtime).
- **manifest.md** — the accepted-ISA table now matches the CI matrix: aarch64 native on every PR, riscv64 under qemu + self-hosting.
- **expressions.md** — removes the stale "callee-side `va_list` not yet implemented" note; variadic calls are pack monomorphization per variadics.md.
