### PR TITLE
feat(codegen): DWARF computed constant locations (stack_value)

### DIFF
--- a/dbg/fixtures/multi/src/main.mach
+++ b/dbg/fixtures/multi/src/main.mach
@@ -34,11 +34,17 @@ fun pick(a: i64, b: i64, c: i64) i64 {
     ret x;
 }
 
+fun konst(a: i64) i64 {
+    var kc: i64 = 1000;
+    ret a;
+}
+
 #[symbol("main")]
 fun main(argc: usize, argv: **u8) i64 {
     p.printlnf("add={}", add(2, 3));
     p.printlnf("mul={}", mul(4, 5));
     p.printlnf("square={}", square(6));
     p.printlnf("pick={}", pick(1, 2, 3));
+    p.printlnf("konst={}", konst(7));
     ret 0;
 }

--- a/dbg/verify.sh
+++ b/dbg/verify.sh
@@ -123,6 +123,17 @@ var_loclist_ranges() {
         END { print cnt+0 }'
 }
 
+# var_computed <binary> <name> — "1" if the named local's DW_AT_location is a computed
+# value (DW_OP_const* ... DW_OP_stack_value), else "0". A constant-folded local (the
+# #1706 tier) renders this way instead of dropping its location.
+var_computed() {
+    "$dwarfdump" --debug-info "$1" 2>/dev/null | awk -v want="$2" '
+        /DW_TAG_/    { invar = ($0 ~ /DW_TAG_variable/); name="" }
+        /DW_AT_name/ && invar { if ($0 ~ "\\(\"" want "\"\\)") name=want }
+        name==want && /DW_AT_location/ && /DW_OP_const/ && /DW_OP_stack_value/ { print "1"; exit }
+        END { print "0" }' | head -1
+}
+
 # elf_seg_identical <a> <b> — true if every PT_LOAD segment of <a> has byte-identical
 # file content in <b>, after the ELF header's section-table bookkeeping (e_shoff,
 # e_shnum, e_shstrndx — expected to differ once -g adds named sections) is normalized.
@@ -224,6 +235,15 @@ verify_dwarf() {
         nr=$(var_loclist_ranges "$g" x)
         if [ "${nr:-0}" -lt 2 ]; then
             echo "FAIL $label ('x' has $nr loclist ranges; expected a multi-range location list)"; rm -rf "$tmp"; return 1
+        fi
+    fi
+
+    # 7. computed constant values (#1706): `konst`'s folded local `kc` renders as a
+    #    DW_OP_const* ... DW_OP_stack_value computed value. under the reg/frame tiers
+    #    alone it would have no location, so this is the falsifiable computed-value check.
+    if grep -q '^fun konst' "$src"; then
+        if [ "$(var_computed "$g" kc)" != "1" ]; then
+            echo "FAIL $label ('kc' has no DW_OP_const/stack_value computed location)"; rm -rf "$tmp"; return 1
         fi
     fi
 

--- a/src/lang/be/codegen/dwarf.mach
+++ b/src/lang/be/codegen/dwarf.mach
@@ -107,6 +107,7 @@ val DW_OP_fbreg:       u8 = 0x91;
 val DW_OP_deref:       u8 = 0x06;
 val DW_OP_plus_uconst: u8 = 0x23;
 val DW_OP_constu:      u8 = 0x10;
+val DW_OP_consts:      u8 = 0x11;
 val DW_OP_minus:       u8 = 0x1c;
 val DW_OP_stack_value: u8 = 0x9f;
 
@@ -243,16 +244,18 @@ rec DwFunc {
 }
 
 # a variable that lives in one place for its whole scope uses VLOC_REG / VLOC_FRAME /
-# VLOC_NONE (an inline exprloc or no location); one that moves uses VLOC_LOCLIST, and
-# `loclist_off` names its entry in `.debug_loclists`
+# VLOC_CONST / VLOC_NONE (an inline exprloc or no location); one that moves uses
+# VLOC_LOCLIST, and `loclist_off` names its entry in `.debug_loclists`
 val VLOC_LOCLIST: u8 = 3;
 
 # a variable's location kind. NONE = the value was optimized out (no DW_AT_location);
 # REG = live in a register (`reg` is its DWARF number); FRAME = a frame slot at
-# `offset` bytes from the frame base
+# `offset` bytes from the frame base; CONST = a computed value (the variable IS a
+# compile-time constant, held in `offset`), emitted as DW_OP_const + DW_OP_stack_value
 val VLOC_NONE:  u8 = 0;
 val VLOC_REG:   u8 = 1;
 val VLOC_FRAME: u8 = 2;
+val VLOC_CONST: u8 = 4;
 
 # a source variable's DWARF DIE data, joined from the IR dbg-var identity and the
 # per-PC variable-location records. A DW_TAG_variable (or DW_TAG_formal_parameter)
@@ -317,6 +320,7 @@ fun home_eq(k1: u8, r1: i32, o1: i64, n1: i64, k2: u8, r2: i32, o2: i64, n2: i64
     if (k1 != k2) { ret false; }
     if (k1 == VLOC_REG)   { ret r1 == r2 && n1 == n2; }
     if (k1 == VLOC_FRAME) { ret o1 == o2 && n1 == n2; }
+    if (k1 == VLOC_CONST) { ret o1 + n1 == o2 + n2; }
     ret true;
 }
 
@@ -883,14 +887,24 @@ fun dbg_expr_net(irfn: *ir.Function, iid: id.InstructionId) i64 {
 
 # append the DWARF expression ops for a home to `e`. A register or frame slot with the
 # identity expression (net == 0) is a plain location; a salvaged value (net != 0)
-# computes the value and marks it DW_OP_stack_value
+# computes the value and marks it DW_OP_stack_value; a constant home is the computed
+# value `off + net` pushed directly and marked DW_OP_stack_value
 # ---
 # e:    the expression buffer
-# kind: VLOC_REG or VLOC_FRAME
+# kind: VLOC_REG / VLOC_FRAME / VLOC_CONST
 # reg:  DWARF register number when kind == VLOC_REG
-# off:  frame-base offset when kind == VLOC_FRAME
+# off:  frame-base offset when kind == VLOC_FRAME; the constant value when VLOC_CONST
 # net:  the salvage net constant (0 = identity)
 fun build_loc_ops(e: *enc.ByteBuf, kind: u8, reg: i32, off: i64, net: i64) {
+    if (kind == VLOC_CONST) {
+        # the variable IS the compile-time constant `off + net`; push it and mark the
+        # result a value, not a location. the DIE's DW_AT_type sizes / signs it, so the
+        # full i64 is emitted and the consumer truncates to the variable's byte size.
+        enc.emit_byte(e, DW_OP_consts);
+        sleb(e, off + net);
+        enc.emit_byte(e, DW_OP_stack_value);
+        ret;
+    }
     if (kind == VLOC_REG) {
         if (net == 0) {
             emit_reg_op(e, DW_OP_reg0, DW_OP_regx, reg);
@@ -1664,6 +1678,13 @@ fun gather_vars(s: *session.Session, tgt: *target.Target, irfn: *ir.Function, lo
             var reg:  i32 = 0;
             var off:  i64 = 0;
             varloc_home(tgt, vl, ?kind, ?reg, ?off);
+            # a binding with no register/frame home may still be a compile-time constant
+            # (a folded local): render it as a computed DW_OP_const value rather than
+            # dropping the location. the constant lives in `off` for VLOC_CONST.
+            if (kind == VLOC_NONE) {
+                val oc: O.Option[i64] = ir.dbg_value_const(irfn, vl.iid::id.InstructionId);
+                if (O.is_some[i64](oc)) { kind = VLOC_CONST; off = O.unwrap[i64](oc); }
+            }
             ranges[@range_count].start = vl.text_offset;
             ranges[@range_count].end   = hi;
             ranges[@range_count].kind  = kind;
@@ -2112,6 +2133,14 @@ test "mach.lang.be.codegen.dwarf.emit_var_location:reg_frame_salvage" {
     var e3: [4]u8; e3[0] = 0x03; e3[1] = 0x75; e3[2] = 0x04; e3[3] = 0x9F;
     if (!buf_eq(?d, ?e3[0], 4)) { code = 1; }
     enc.buf_dnit(?d);
+
+    # constant 40 + net 2 = 42: len 3, DW_OP_consts (0x11), sleb(42) = 0x2A, stack_value (0x9F).
+    var vk: DwVar; vk.loc_kind = VLOC_CONST; vk.reg = 0; vk.offset = 40; vk.net = 2;
+    var g: enc.ByteBuf = enc.buf_init(?alloc);
+    emit_var_location(?g, ?vk);
+    var e4: [4]u8; e4[0] = 0x03; e4[1] = 0x11; e4[2] = 0x2A; e4[3] = 0x9F;
+    if (!buf_eq(?g, ?e4[0], 4)) { code = 1; }
+    enc.buf_dnit(?g);
     ret code;
 }
 
@@ -2131,6 +2160,10 @@ test "mach.lang.be.codegen.dwarf.home_eq:agreement" {
     # frame home agreement is by offset.
     if (!home_eq(VLOC_FRAME, 0, -16, 0, VLOC_FRAME, 0, -16, 0)) { code = 1; }
     if (home_eq(VLOC_FRAME, 0, -16, 0, VLOC_FRAME, 0, -24, 0))  { code = 1; }
+    # constant home agreement is by the computed value (off + net).
+    if (!home_eq(VLOC_CONST, 0, 42, 0, VLOC_CONST, 0, 40, 2)) { code = 1; }
+    if (home_eq(VLOC_CONST, 0, 42, 0, VLOC_CONST, 0, 7, 0))   { code = 1; }
+    if (home_eq(VLOC_CONST, 0, 42, 0, VLOC_REG, 5, 0, 0))     { code = 1; }
     ret code;
 }
 

--- a/src/lang/be/codegen/regalloc.mach
+++ b/src/lang/be/codegen/regalloc.mach
@@ -2976,6 +2976,20 @@ fun rewrite_instr(tgt: *target.Target, ctx: *AllocCtx, mi: *mir.MirInstr,
         && ops[0].kind == mir.MIR_OP_PREG && ops[1].kind == mir.MIR_OP_PREG
         && ops[0].preg == ops[1].preg) {
         free_ops(ctx, ops, n);
+        # a -g dbg binding attached to this move must not vanish with it: keep a
+        # zero-byte USE pseudo carrying the bindings so the encoder still records their
+        # VarLocs at this PC (the dropped move emitted nothing, so the variable becomes
+        # live here). the pseudo emits no bytes, so -g stays byte-identical to the build
+        # that drops the move outright. (dst is zeroed, so operands / asm_block stay nil.)
+        if (mi.dbg_binding_count > 0) {
+            dst[@wp].opcode            = isa.ISA_USE::mir.MirOpcode;
+            dst[@wp].width             = mi.width;
+            dst[@wp].src_width         = mi.src_width;
+            dst[@wp].loc               = mi.loc;
+            dst[@wp].dbg_bindings      = mi.dbg_bindings;
+            dst[@wp].dbg_binding_count = mi.dbg_binding_count;
+            @wp = @wp + 1;
+        }
         if (mi.operands != nil && mi.operand_count > 0) {
             A.deallocate[mir.MirOperand](ctx.alloc, mi.operands, mi.operand_count::usize);
         }

--- a/src/lang/be/codegen/regalloc.mach
+++ b/src/lang/be/codegen/regalloc.mach
@@ -1207,9 +1207,16 @@ fun sweep_dead_movs(tgt: *target.Target, ctx: *AllocCtx) R.Result[bool, str] {
             for (read < blk.instr_count) {
                 val mi: *mir.MirInstr = ?blk.instrs[read];
                 if (is_dead_mov(tgt, ctx, mi, reads, nv)) {
-                    # the move never reaches encode; release its operand array.
+                    # the move never reaches encode; release its operand array. this runs
+                    # pre-regalloc, so a zero-byte carrier here would perturb the flat
+                    # stream; any -g binding on a deleted dead move is instead released
+                    # (the variable reads as optimized-out at that point, never garbage).
+                    # the block is compacted below, so this is the binding's only owner.
                     if (mi.operands != nil && mi.operand_count > 0) {
                         A.deallocate[mir.MirOperand](ctx.alloc, mi.operands, mi.operand_count::usize);
+                    }
+                    if (mi.dbg_bindings != nil && mi.dbg_binding_count > 0) {
+                        A.deallocate[mir.MirDbgBinding](ctx.alloc, mi.dbg_bindings, mi.dbg_binding_count::usize);
                     }
                     changed = true;
                 } or {

--- a/src/lang/me/ir.mach
+++ b/src/lang/me/ir.mach
@@ -734,6 +734,25 @@ pub fun dbg_var_get(fn: *Function, iid: id.InstructionId) O.Option[*DbgVar] {
     ret O.some[*DbgVar](R.unwrap_ok[*DbgVar, str](res));
 }
 
+# the compile-time integer value the OP_DBG_VALUE `iid` binds its variable to, or none
+# when the operand is not an inline integer constant (a value with a register/frame
+# home, or the VAL_CONST_NULL optimized-out sentinel). The -g computed-location emitter
+# reads this to render a constant-folded local as a DW_OP_const + DW_OP_stack_value
+# instead of dropping its location.
+# ---
+# fn:  the owning function
+# iid: an OP_DBG_VALUE instruction id
+# ret: some(bit pattern as i64) for a VAL_CONST_INT operand, else none
+pub fun dbg_value_const(fn: *Function, iid: id.InstructionId) O.Option[i64] {
+    val gi: O.Option[*instruction.Instruction] = instruction_get(fn, iid);
+    if (O.is_none[*instruction.Instruction](gi)) { ret O.none[i64](); }
+    val inst: *instruction.Instruction = O.unwrap[*instruction.Instruction](gi);
+    if (inst.operand_count == 0) { ret O.none[i64](); }
+    val op: *value.Value = ?inst.operands[0];
+    if (op.kind != value.VAL_CONST_INT) { ret O.none[i64](); }
+    ret O.some[i64](op.data.int_lit::i64);
+}
+
 # the DbgExprId the OP_DBG_VALUE `iid` applies to its operand, or DBG_EXPR_IDENTITY
 # when none is recorded. the single lookup the salvage path and the -g location
 # emitters share


### PR DESCRIPTION
Part of #1706 (DWARF computed/fragmented locations). Depends on #1705 (merged).

Emits computed constant locations for constant-folded locals and preserves the bindings they ride on across register coalescing, so they render correctly on every ISA.

## What

- **Computed constants**: a local whose OP_DBG_VALUE operand is an inline integer constant (a folded value) previously emitted a DW_TAG_variable with no location. It now renders as `DW_OP_consts(value) DW_OP_stack_value` — the DIE's DW_AT_type sizes/signs it. The value is read from the IR in the producer (new `ir.dbg_value_const`), joined to the existing VarLoc channel by PC and combined with any #1696 salvage net; no new data crosses lowering or the encoder. A `VLOC_CONST` home flows through `home_eq` / `classify_var` like reg/frame homes.
- **Binding preservation across coalescing** (regalloc): a binding attached to a register move that coalesces to a self-move was dropped with the move — so a constant local had a DIE on x86-64 but *none at all* on arm64/riscv64, where arg0 and the return register coincide and the return move coalesces away. The move is now kept as a zero-byte USE pseudo when it carries bindings: the encoder records the VarLocs and emits no bytes, so `-g` stays byte-identical to the drop-outright build.

The salvaged-arithmetic-over-a-register case (`DW_OP_breg + net + stack_value`) already shipped in #1705; this completes the computed-value opcode set.

## Scope note — DW_OP_piece deferred

The issue also lists DW_OP_piece/bit_piece for fragmented aggregates. There is no reachable input for it in the current model: aggregate locals get **no** variable DIE today (the producer filters to primitive base types), and scalars are never split across register+slot. So piece would be dead framing with no producer path. It needs a prior step that gives aggregates variable DIEs + a fragment representation — proposed as a follow-up gated on that, split out as #1919 (gated on aggregate variable DIEs).

## Verification

- Unit suite green (+VLOC_CONST arms in emit_var_location / home_eq).
- gdb prints signed / unsigned / negative constants correctly; `llvm-dwarfdump --verify` clean.
- `-g` .text byte-identical to non-`-g` on linux / linux-arm64 / linux-riscv64 (debuginfo lane step 5); non-`-g` byte-identical to dev; self-host fixpoint.
- Debuginfo lane extended with a falsifiable computed-constant check, green on all 3 ELF ISAs.
