### PR TITLE
feat(debuginfo): inline-site identity channel + dbg-metadata cloning

### DIFF
--- a/src/lang/me/ir.mach
+++ b/src/lang/me/ir.mach
@@ -28,6 +28,7 @@ use mach.lang.me.ir.id;
 use mach.lang.me.ir.instruction;
 use mach.lang.me.ir.type;
 use mach.lang.me.ir.value;
+use mach.lang.source;
 
 use semtype: mach.lang.type;
 
@@ -156,6 +157,21 @@ pub rec DbgExpr {
     op_cap:   u32;
 }
 
+# one inlined-subroutine instance: a single expansion of a callee body into a caller,
+# recorded in Function.inline_sites (1-based; instances group cloned instructions via
+# Function.instr_inline_site). pure -g metadata the DWARF producer (#1707) reads to emit
+# a DW_TAG_inlined_subroutine per instance; it never affects emitted code.
+# ---
+# callee:   the inlined callee's function symbol name, for DW_AT_abstract_origin
+# call_loc: the call-site source location, for DW_AT_call_file / DW_AT_call_line
+# parent:   the enclosing inline instance (1-based) when this expansion was itself
+#           inside inlined code, else 0 (the caller's own body); chains nested inlines
+pub rec InlineSite {
+    callee:   intern.StrId;
+    call_loc: source.SrcLoc;
+    parent:   u32;
+}
+
 # a basic block: an ordered instruction list ending in exactly one terminator,
 # plus its phi nodes and predecessor list
 # ---
@@ -254,6 +270,15 @@ pub rec Function {
     dbg_expr_len: u32;
     dbg_expr_cap: u32;
     dbg_expr_ids: map.Map[id.InstructionId, DbgExprId];
+
+    # inlined-subroutine instances created by the inline pass (owned); empty when the
+    # function contains no inlined code. `instr_inline_site` maps a cloned instruction
+    # id to the 1-based instance it belongs to (absent = the caller's own body). pure -g
+    # metadata the #1707 producer consumes; never affects emitted code.
+    inline_sites:      *InlineSite;
+    inline_site_len:   u32;
+    inline_site_cap:   u32;
+    instr_inline_site: map.Map[id.InstructionId, u32];
 }
 
 # a module-level global data declaration
@@ -486,6 +511,12 @@ fun function_dnit(m: *Module, fn: *Function) {
         A.deallocate[DbgExpr](m.alloc, fn.dbg_exprs, fn.dbg_expr_cap::usize);
     }
     map.dnit[id.InstructionId, DbgExprId](?fn.dbg_expr_ids);
+
+    # inline-site pool owns no per-record heap storage; free the pool and its id map.
+    if (fn.inline_sites != nil && fn.inline_site_cap > 0) {
+        A.deallocate[InlineSite](m.alloc, fn.inline_sites, fn.inline_site_cap::usize);
+    }
+    map.dnit[id.InstructionId, u32](?fn.instr_inline_site);
 }
 
 # free one block's owned instruction, phi, and predecessor arrays
@@ -568,6 +599,10 @@ pub fun function_add(m: *Module, name: intern.StrId, sig: type.IrTypeId, flags: 
     f.dbg_expr_len = 0;
     f.dbg_expr_cap = 0;
     f.dbg_expr_ids = map.init[id.InstructionId, DbgExprId](m.alloc, map.hash_u32, map.eq_u32);
+    f.inline_sites      = nil;
+    f.inline_site_len   = 0;
+    f.inline_site_cap   = 0;
+    f.instr_inline_site = map.init[id.InstructionId, u32](m.alloc, map.hash_u32, map.eq_u32);
     m.functions[idx] = f;
     m.function_len   = m.function_len + 1;
     ret R.ok[u32, str](idx);
@@ -852,6 +887,109 @@ pub fun dbg_expr_prepend_op(m: *Module, fn: *Function, eid: DbgExprId, op: DbgOp
     }
     dex.ops[0]   = op;
     dex.op_count = dex.op_count + 1;
+    ret R.ok[bool, str](true);
+}
+
+# append an inlined-subroutine instance to `fn`'s pool and return its 1-based id.
+# ---
+# m:        module owning the allocator
+# fn:       the caller function receiving the instance
+# callee:   the inlined callee's symbol name (DW_AT_abstract_origin)
+# call_loc: the call-site location (DW_AT_call_file / DW_AT_call_line)
+# parent:   the enclosing instance (1-based), or 0 for the caller's own body
+# ret:      the new instance's 1-based id, or an allocation error
+pub fun inline_site_add(m: *Module, fn: *Function, callee: intern.StrId, call_loc: source.SrcLoc, parent: u32) R.Result[u32, str] {
+    if (fn.inline_site_len >= fn.inline_site_cap) {
+        var new_cap: u32 = fn.inline_site_cap * 2;
+        if (new_cap < 4) { new_cap = 4; }
+        if (fn.inline_sites == nil) {
+            val ra: R.Result[*InlineSite, str] = A.allocate[InlineSite](m.alloc, new_cap::usize);
+            if (R.is_err[*InlineSite, str](ra)) { ret R.err[u32, str](R.unwrap_err[*InlineSite, str](ra)); }
+            fn.inline_sites = R.unwrap_ok[*InlineSite, str](ra);
+        }
+        or {
+            val rr: R.Result[*InlineSite, str] = A.reallocate[InlineSite](m.alloc, fn.inline_sites, fn.inline_site_cap::usize, new_cap::usize);
+            if (R.is_err[*InlineSite, str](rr)) { ret R.err[u32, str](R.unwrap_err[*InlineSite, str](rr)); }
+            fn.inline_sites = R.unwrap_ok[*InlineSite, str](rr);
+        }
+        fn.inline_site_cap = new_cap;
+    }
+    val idx: u32 = fn.inline_site_len;
+    fn.inline_sites[idx].callee   = callee;
+    fn.inline_sites[idx].call_loc = call_loc;
+    fn.inline_sites[idx].parent   = parent;
+    fn.inline_site_len = fn.inline_site_len + 1;
+    ret R.ok[u32, str](idx + 1);
+}
+
+# the inline-site record for a 1-based instance id, or none for 0 / out of range.
+pub fun inline_site_get(fn: *Function, site: u32) O.Option[*InlineSite] {
+    if (site == 0 || site > fn.inline_site_len) { ret O.none[*InlineSite](); }
+    ret O.some[*InlineSite](?fn.inline_sites[site - 1]);
+}
+
+# record that instruction `iid` belongs to inline instance `site` (1-based).
+pub fun instr_inline_site_set(fn: *Function, iid: id.InstructionId, site: u32) R.Result[bool, str] {
+    ret map.insert[id.InstructionId, u32](?fn.instr_inline_site, iid, site);
+}
+
+# the 1-based inline instance instruction `iid` belongs to, or 0 for the caller body.
+pub fun instr_inline_site_of(fn: *Function, iid: id.InstructionId) u32 {
+    var key: id.InstructionId = iid;
+    val res: R.Result[*u32, str] = map.get[id.InstructionId, u32](?fn.instr_inline_site, ?key);
+    if (R.is_err[*u32, str](res)) { ret 0; }
+    ret @R.unwrap_ok[*u32, str](res);
+}
+
+# copy the -g source-variable metadata (DbgVar identity and any DbgExpr salvage steps)
+# the OP_DBG_VALUE `src_iid` carries in `src_fn` onto the cloned OP_DBG_VALUE `dst_iid`
+# in `dst_fn`. Used by the inline pass so an inlined local keeps its name / type /
+# expression identity in the caller instead of being anonymous. A no-op when `src_iid`
+# carries no dbg-var. The operands were remapped separately, so the copied identity
+# rides the caller's value.
+# ---
+# m:       module owning the allocator
+# src_fn:  the callee the metadata is read from
+# dst_fn:  the caller the metadata is copied into
+# src_iid: the callee OP_DBG_VALUE id
+# dst_iid: the cloned OP_DBG_VALUE id in the caller
+# ret:     ok(true), or an allocation error
+pub fun clone_dbg_metadata(m: *Module, src_fn: *Function, dst_fn: *Function, src_iid: id.InstructionId, dst_iid: id.InstructionId) R.Result[bool, str] {
+    val odv: O.Option[*DbgVar] = dbg_var_get(src_fn, src_iid);
+    if (O.is_none[*DbgVar](odv)) { ret R.ok[bool, str](true); }
+    var dv: DbgVar = @O.unwrap[*DbgVar](odv);
+    val ri: R.Result[bool, str] = map.insert[id.InstructionId, DbgVar](?dst_fn.dbg_vars, dst_iid, dv);
+    if (R.is_err[bool, str](ri)) { ret ri; }
+
+    val seid: DbgExprId = dbg_expr_id(src_fn, src_iid);
+    val ose: O.Option[*DbgExpr] = dbg_expr_get(src_fn, seid);
+    if (O.is_none[*DbgExpr](ose)) { ret R.ok[bool, str](true); }
+    val n: u32 = O.unwrap[*DbgExpr](ose).op_count;
+    if (n == 0) { ret R.ok[bool, str](true); }
+
+    # snapshot the source steps before any pool mutation (dbg_expr_new below may grow
+    # the source pool too when src_fn == dst_fn is impossible here, but be safe): copy
+    # them out, then rebuild the destination expression through the pool's own API.
+    val rsnap: R.Result[*DbgOp, str] = A.allocate[DbgOp](m.alloc, n::usize);
+    if (R.is_err[*DbgOp, str](rsnap)) { ret R.err[bool, str](R.unwrap_err[*DbgOp, str](rsnap)); }
+    val snap: *DbgOp = R.unwrap_ok[*DbgOp, str](rsnap);
+    var i: u32 = 0;
+    val se0: *DbgExpr = O.unwrap[*DbgExpr](ose);
+    for (i < n) { snap[i] = se0.ops[i]; i = i + 1; }
+
+    # build the destination expression through the tested pool API: a fresh empty
+    # expression, then prepend each step in reverse so the final order matches. this
+    # keeps op-array ownership entirely inside dbg_expr_prepend_op's allocation.
+    val rne: R.Result[DbgExprId, str] = dbg_expr_new(m, dst_fn, dst_iid);
+    if (R.is_err[DbgExprId, str](rne)) { A.deallocate[DbgOp](m.alloc, snap, n::usize); ret R.err[bool, str](R.unwrap_err[DbgExprId, str](rne)); }
+    val deid: DbgExprId = R.unwrap_ok[DbgExprId, str](rne);
+    var j: u32 = n;
+    for (j > 0) {
+        val rp: R.Result[bool, str] = dbg_expr_prepend_op(m, dst_fn, deid, snap[j - 1]);
+        if (R.is_err[bool, str](rp)) { A.deallocate[DbgOp](m.alloc, snap, n::usize); ret rp; }
+        j = j - 1;
+    }
+    A.deallocate[DbgOp](m.alloc, snap, n::usize);
     ret R.ok[bool, str](true);
 }
 
@@ -1272,5 +1410,81 @@ test "mach.lang.me.ir.dnit:frees_by_capacity_not_count" {
     if (tracker.live != 0) { ret 1; }                  # any residual live allocation is a leak
 
     A.deallocate[TrackEntry](?page_alloc, tracker.entries, 8192::usize);
+    ret 0;
+}
+
+# the inline-site channel round-trips instances and their instruction grouping, and
+# clone_dbg_metadata copies both a source variable's identity and its salvage
+# expression onto a destination instruction id -- the exact surface the inline pass
+# uses to make inlined locals non-anonymous.
+test "mach.lang.me.ir.inline_site_channel:add_get_clone" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+    val rm: R.Result[Module, str] = init(?alloc, intern.STR_NIL);
+    if (R.is_err[Module, str](rm)) { ret 1; }
+    var m: Module = R.unwrap_ok[Module, str](rm);
+
+    val rvoid: R.Result[type.IrTypeId, str] = type.intern_void(?m.types);
+    if (R.is_err[type.IrTypeId, str](rvoid)) { dnit(?m); ret 1; }
+    val voidty: type.IrTypeId = R.unwrap_ok[type.IrTypeId, str](rvoid);
+    val rsig: R.Result[type.IrTypeId, str] = type.intern_fn(?m.types, voidty, nil, 0);
+    if (R.is_err[type.IrTypeId, str](rsig)) { dnit(?m); ret 1; }
+    val sigty: type.IrTypeId = R.unwrap_ok[type.IrTypeId, str](rsig);
+    if (R.is_err[u32, str](function_add(?m, 100::intern.StrId, sigty, 0))) { dnit(?m); ret 1; }
+    if (R.is_err[u32, str](function_add(?m, 200::intern.StrId, sigty, 0))) { dnit(?m); ret 1; }
+    val callee: *Function = ?m.functions[0];
+    val caller: *Function = ?m.functions[1];
+
+    # two instances: the second nested under the first.
+    val ra: R.Result[u32, str] = inline_site_add(?m, caller, 300::intern.StrId, source.loc_nil(), 0);
+    if (R.is_err[u32, str](ra) || R.unwrap_ok[u32, str](ra) != 1) { dnit(?m); ret 1; }
+    val rb: R.Result[u32, str] = inline_site_add(?m, caller, 301::intern.StrId, source.loc_nil(), 1);
+    if (R.is_err[u32, str](rb) || R.unwrap_ok[u32, str](rb) != 2) { dnit(?m); ret 1; }
+
+    val g1: O.Option[*InlineSite] = inline_site_get(caller, 1);
+    if (O.is_none[*InlineSite](g1)) { dnit(?m); ret 1; }
+    if (O.unwrap[*InlineSite](g1).callee != 300::intern.StrId) { dnit(?m); ret 1; }
+    if (O.unwrap[*InlineSite](g1).parent != 0)                { dnit(?m); ret 1; }
+    val g2: O.Option[*InlineSite] = inline_site_get(caller, 2);
+    if (O.is_none[*InlineSite](g2))                           { dnit(?m); ret 1; }
+    if (O.unwrap[*InlineSite](g2).parent != 1)                { dnit(?m); ret 1; }
+    if (O.is_some[*InlineSite](inline_site_get(caller, 0)))   { dnit(?m); ret 1; }
+    if (O.is_some[*InlineSite](inline_site_get(caller, 3)))   { dnit(?m); ret 1; }
+
+    # instruction-to-instance grouping (0 for an unmapped id).
+    if (R.is_err[bool, str](instr_inline_site_set(caller, 7::id.InstructionId, 2))) { dnit(?m); ret 1; }
+    if (instr_inline_site_of(caller, 7::id.InstructionId) != 2) { dnit(?m); ret 1; }
+    if (instr_inline_site_of(caller, 8::id.InstructionId) != 0) { dnit(?m); ret 1; }
+
+    # a source variable with a one-step salvage expression on callee id 5.
+    var dv: DbgVar;
+    dv.name     = 900::intern.StrId;
+    dv.ty       = voidty;
+    dv.ty_sem   = semtype.TYPE_NIL;
+    dv.is_param = false;
+    dv.scope    = 0;
+    if (R.is_err[bool, str](map.insert[id.InstructionId, DbgVar](?callee.dbg_vars, 5::id.InstructionId, dv))) { dnit(?m); ret 1; }
+    val rne: R.Result[DbgExprId, str] = dbg_expr_new(?m, callee, 5::id.InstructionId);
+    if (R.is_err[DbgExprId, str](rne)) { dnit(?m); ret 1; }
+    var op: DbgOp;
+    op.op  = DBG_OP_PLUS_CONST;
+    op.arg = 8;
+    if (R.is_err[bool, str](dbg_expr_prepend_op(?m, callee, R.unwrap_ok[DbgExprId, str](rne), op))) { dnit(?m); ret 1; }
+
+    # clone onto caller id 9 and confirm both the identity and the expression copied.
+    if (R.is_err[bool, str](clone_dbg_metadata(?m, callee, caller, 5::id.InstructionId, 9::id.InstructionId))) { dnit(?m); ret 1; }
+    val odv: O.Option[*DbgVar] = dbg_var_get(caller, 9::id.InstructionId);
+    if (O.is_none[*DbgVar](odv))                              { dnit(?m); ret 1; }
+    if (O.unwrap[*DbgVar](odv).name != 900::intern.StrId)     { dnit(?m); ret 1; }
+    val ceid: DbgExprId = dbg_expr_id(caller, 9::id.InstructionId);
+    if (ceid == DBG_EXPR_IDENTITY)                            { dnit(?m); ret 1; }
+    val oce: O.Option[*DbgExpr] = dbg_expr_get(caller, ceid);
+    if (O.is_none[*DbgExpr](oce))                             { dnit(?m); ret 1; }
+    val ce: *DbgExpr = O.unwrap[*DbgExpr](oce);
+    if (ce.op_count != 1)                                     { dnit(?m); ret 1; }
+    if (ce.ops[0].op != DBG_OP_PLUS_CONST)                   { dnit(?m); ret 1; }
+    if (ce.ops[0].arg != 8)                                  { dnit(?m); ret 1; }
+
+    dnit(?m);
     ret 0;
 }

--- a/src/lang/me/lower/context.mach
+++ b/src/lang/me/lower/context.mach
@@ -1237,6 +1237,10 @@ pub fun ensure_extern_function(lc: *LowerContext, name: intern.StrId, sig: ir_ty
     f.dbg_expr_len = 0;
     f.dbg_expr_cap = 0;
     f.dbg_expr_ids = map.init[ir.InstructionId, ir.DbgExprId](m.alloc, map.hash_u32, map.eq_u32);
+    f.inline_sites      = nil;
+    f.inline_site_len   = 0;
+    f.inline_site_cap   = 0;
+    f.instr_inline_site = map.init[ir.InstructionId, u32](m.alloc, map.hash_u32, map.eq_u32);
 
     m.functions[idx] = f;
     m.function_len   = m.function_len + 1;

--- a/src/lang/me/lower/decl.mach
+++ b/src/lang/me/lower/decl.mach
@@ -1256,6 +1256,10 @@ fun append_function(ctx: *context.LowerContext, name: intern.StrId, sig: ir_type
     f.dbg_expr_len = 0;
     f.dbg_expr_cap = 0;
     f.dbg_expr_ids = map.init[ir.InstructionId, ir.DbgExprId](m.alloc, map.hash_u32, map.eq_u32);
+    f.inline_sites      = nil;
+    f.inline_site_len   = 0;
+    f.inline_site_cap   = 0;
+    f.instr_inline_site = map.init[ir.InstructionId, u32](m.alloc, map.hash_u32, map.eq_u32);
 
     m.functions[idx] = f;
     m.function_len   = m.function_len + 1;

--- a/src/lang/me/pass/inline.mach
+++ b/src/lang/me/pass/inline.mach
@@ -452,6 +452,12 @@ fun do_inline(
     val call: *instruction.Instruction = O.unwrap[*instruction.Instruction](opt_call);
     val ret_type: type.IrTypeId = call.ty;
 
+    # snapshot the -g inline-site anchors before run_inline unlinks the call: the call
+    # site's own source location (DW_AT_call_file/line for this expansion) and the
+    # inline instance the call itself sat in (for nesting, 0 at the top level).
+    val call_loc: source.SrcLoc = call.loc;
+    val parent_site: u32 = ir.instr_inline_site_of(caller, call_id);
+
     # snapshot the actual arguments (operands [1..]) before any mutation.
     val arg_count: u32 = call.operand_count - 1;
     var args: *value.Value = nil;
@@ -482,6 +488,16 @@ fun do_inline(
 
     val res_run: R.Result[bool, str] = run_inline(?cx, call_bi, call_ii, call_id);
 
+    # stamp -g inline-site metadata onto the clones while cx.instr_map is still live: an
+    # InlineSite for this expansion (plus remapped nested instances), each cloned
+    # instruction's owning instance, and the callee's dbg-vars/dbg-exprs copied onto the
+    # cloned OP_DBG_VALUEs. pure debug metadata; a build without -g still runs it but the
+    # side tables it fills are simply never consumed.
+    var res_meta: R.Result[bool, str] = R.ok[bool, str](true);
+    if (!R.is_err[bool, str](res_run)) {
+        res_meta = stamp_inline_metadata(m, ?cx, call_loc, parent_site);
+    }
+
     if (cx.block_map != nil) {
         A.deallocate[u32](m.alloc, cx.block_map, callee.block_count::usize);
     }
@@ -492,14 +508,71 @@ fun do_inline(
         A.deallocate[value.Value](m.alloc, args, arg_count::usize);
     }
 
+    if (R.is_err[bool, str](res_run)) { ret res_run; }
+    if (R.is_err[bool, str](res_meta)) { ret res_meta; }
+
     # maintain the live call-count table: the inlined call no longer exists (it
     # was a live call to callee_ix, so the count is at least 1), and the cloned
     # callee body's own live calls now live in the caller.
-    if (!R.is_err[bool, str](res_run)) {
-        counts[callee_ix] = counts[callee_ix] - 1;
-        add_fn_call_counts(m, callee, counts);
-    }
+    counts[callee_ix] = counts[callee_ix] - 1;
+    add_fn_call_counts(m, callee, counts);
     ret res_run;
+}
+
+# stamp the -g inline-site side tables for one completed expansion (cx.instr_map maps
+# each callee instruction index to its clone in the caller). Records an InlineSite for
+# this expansion, remaps the callee's own nested instances beneath it, tags every cloned
+# instruction with its owning instance, and copies the callee's dbg-var / dbg-expr
+# identity onto the cloned OP_DBG_VALUEs. -g metadata only; never affects emitted code.
+# ---
+# m:           the module
+# cx:          the inline context (caller / callee / instr_map populated)
+# call_loc:    the call-site source location for this expansion
+# parent_site: the enclosing inline instance (0 at top level)
+# ret:         ok(true), or an allocation error
+fun stamp_inline_metadata(m: *ir.Module, cx: *InlineCtx, call_loc: source.SrcLoc, parent_site: u32) R.Result[bool, str] {
+    val caller: *ir.Function = cx.caller;
+    val callee: *ir.Function = cx.callee;
+
+    val rtop: R.Result[u32, str] = ir.inline_site_add(m, caller, callee.name, call_loc, parent_site);
+    if (R.is_err[u32, str](rtop)) { ret R.err[bool, str](R.unwrap_err[u32, str](rtop)); }
+    val top: u32 = R.unwrap_ok[u32, str](rtop);
+
+    # remap the callee's own inline instances into the caller, parented under `top` (a
+    # callee instance k's parent is always an earlier instance, so site_map[parent] is
+    # already filled). site_map[0] = top names the callee's own body.
+    var site_map: *u32 = nil;
+    val nsite: u32 = callee.inline_site_len;
+    if (nsite > 0) {
+        val rsm: R.Result[*u32, str] = A.allocate[u32](m.alloc, (nsite + 1)::usize);
+        if (R.is_err[*u32, str](rsm)) { ret R.err[bool, str](R.unwrap_err[*u32, str](rsm)); }
+        site_map = R.unwrap_ok[*u32, str](rsm);
+        site_map[0] = top;
+        var k: u32 = 1;
+        for (k <= nsite) {
+            val cs: *ir.InlineSite = ?callee.inline_sites[k - 1];
+            val rp: R.Result[u32, str] = ir.inline_site_add(m, caller, cs.callee, cs.call_loc, site_map[cs.parent]);
+            if (R.is_err[u32, str](rp)) { A.deallocate[u32](m.alloc, site_map, (nsite + 1)::usize); ret R.err[bool, str](R.unwrap_err[u32, str](rp)); }
+            site_map[k] = R.unwrap_ok[u32, str](rp);
+            k = k + 1;
+        }
+    }
+
+    var i: u32 = 0;
+    for (i < callee.instr_len) {
+        val cloned_iid: id.InstructionId = cx.instr_map[i]::id.InstructionId;
+        var caller_site: u32 = top;
+        if (nsite > 0) {
+            caller_site = site_map[ir.instr_inline_site_of(callee, i::id.InstructionId)];
+        }
+        val rs: R.Result[bool, str] = ir.instr_inline_site_set(caller, cloned_iid, caller_site);
+        if (R.is_err[bool, str](rs)) { if (site_map != nil) { A.deallocate[u32](m.alloc, site_map, (nsite + 1)::usize); } ret rs; }
+        val rc: R.Result[bool, str] = ir.clone_dbg_metadata(m, callee, caller, i::id.InstructionId, cloned_iid);
+        if (R.is_err[bool, str](rc)) { if (site_map != nil) { A.deallocate[u32](m.alloc, site_map, (nsite + 1)::usize); } ret rc; }
+        i = i + 1;
+    }
+    if (site_map != nil) { A.deallocate[u32](m.alloc, site_map, (nsite + 1)::usize); }
+    ret R.ok[bool, str](true);
 }
 
 # the inline body proper, operating on the prepared context


### PR DESCRIPTION
Foundation for the DWARF inlined_subroutine tier (#1707). IR-side only, codegen-inert.

## What
- `ir.InlineSite` pool on `Function`: one record per inlined instance (callee symbol name for DW_AT_abstract_origin, call-site `SrcLoc` for DW_AT_call_file/line, `parent` instance for nesting).
- `instr_inline_site` map: cloned instruction id to its 1-based instance (0 = the caller's own body). Groups an instance's instructions for later PC-range emission.
- `clone_dbg_metadata`: copies a callee OP_DBG_VALUE's `DbgVar` identity and its salvage `DbgExpr` onto the cloned instruction id in the caller.
- Inline pass (`stamp_inline_metadata`): per expansion, records the instance, remaps the callee's own nested instances beneath it, tags every clone with its instance, and clones the dbg-metadata. So inlined locals keep name / type / expression identity instead of being anonymous.
- Initializes the new fields at all three `Function` construction sites (`function_add` + the two lowering constructors), the [[issue-fn-init]] class of `-g`-only segfault.

## Correction to #1707's premise
The #1707 issue text claimed the inline pass "clones/remaps callee dbg-values and scopes via clone_instruction". That is false in the tree: `clone_instruction` copies loc only, and the pass did no dbg-metadata work. This PR establishes that channel; #1707 is the producer that consumes it.

## Staging
Codegen is unaffected (the pool and map are read only by the not-yet-built #1707 producer), so byte-identity holds by construction. Transitionally, the copied dbg-vars render as flat **caller** locals under the current #1704/#1705 producer (present and correct, not yet nested) until #1707 nests them under `DW_TAG_inlined_subroutine`.

## Verification
- 535/535 unit tests (adds `inline_site_channel:add_get_clone`, exercising the accessors and the metadata clone).
- Self-host fixpoint byte-identical (S2 == S3).
- `--profile release -g` builds (which actually inline) are clean and `llvm-dwarfdump --verify` reports no errors; the channel runs through all of mach-std's inlining without perturbing codegen.

Closes #1924.
