### PR TITLE
fix(debuginfo): inline-site identity channel (inert, dbg-clone deferred to #1707)

### DIFF
--- a/src/lang/be/codegen/mir.mach
+++ b/src/lang/be/codegen/mir.mach
@@ -355,6 +355,11 @@ pub rec MirAsm {
 #                cannot perturb allocation - the instruction stream is identical with
 #                and without -g.
 # dbg_binding_count: number of dbg bindings (0 for the common no-binding case).
+# inline_site:   the 1-based inline instance this instruction belongs to (0 = the
+#                function's own body), forwarded from the IR instruction's inline-site
+#                map. lets the encoder group an inlined expansion's PC ranges for the
+#                DWARF inlined_subroutine producer (#1707). pure metadata that rides
+#                like `loc`; never affects the emitted bytes.
 pub rec MirInstr {
     opcode:            MirOpcode;
     operands:          *MirOperand;
@@ -365,6 +370,7 @@ pub rec MirInstr {
     loc:               source.SrcLoc;
     dbg_bindings:      *MirDbgBinding;
     dbg_binding_count: u32;
+    inline_site:       u32;
 }
 
 # one `-g` source-variable binding attached to a MirInstr: the OP_DBG_VALUE identity

--- a/src/lang/be/codegen/mir/context.mach
+++ b/src/lang/be/codegen/mir/context.mach
@@ -89,6 +89,12 @@ pub rec LowerCtx {
     # lowering loop; source.loc_nil() outside one (params / prologue setup).
     cur_loc: source.SrcLoc;
 
+    # inline instance (1-based, 0 = function body) of the IR instruction currently
+    # being lowered, stamped onto every MirInstr `push_instr` appends so the encoder
+    # can group an inlined expansion's PC ranges. set per IR instruction by the
+    # lowering loop alongside cur_loc; 0 outside one.
+    cur_inline_site: u32;
+
     # `-g`-only source-variable bindings awaiting attachment: an OP_DBG_VALUE records
     # its (iid, vreg) here, and the next `push_instr` attaches the whole list (in order)
     # to the instruction at whose PC the variables become live, then clears it. any
@@ -499,6 +505,9 @@ pub fun push_instr(ctx: *LowerCtx, mb: *mir.MirBlock, mi: mir.MirInstr) R.Result
     # append chokepoint - the same reason asm_block is nil'd here (struct locals are
     # not zero-initialized, so an unstamped loc would carry residue).
     ni.loc = ctx.cur_loc;
+    # the inline instance rides beside loc, stamped at the same chokepoint for the same
+    # non-zero-init reason, so every lowered instruction carries its inlined-from origin.
+    ni.inline_site = ctx.cur_inline_site;
     # the dbg-binding list defaults empty here for the same reason (callers build
     # instructions field-by-field and never set it); any pending -g binding then
     # attaches to this instruction, the next one after its OP_DBG_VALUE.

--- a/src/lang/be/codegen/mir/lower.mach
+++ b/src/lang/be/codegen/mir/lower.mach
@@ -151,6 +151,7 @@ fun lower_function(tgt: *target.Target, m: *ir.Module, fn: *ir.Function, interne
     ctx.interner       = interner;
     ctx.sret_vreg      = mir.MIR_VREG_NIL;
     ctx.cur_loc        = source.loc_nil();
+    ctx.cur_inline_site = 0;
     ctx.pending        = nil;
     ctx.pending_count  = 0;
     ctx.pending_cap    = 0;
@@ -609,6 +610,7 @@ fun insert_mov_before_terminator(ctx: *lctx.LowerCtx, mb: *mir.MirBlock, dst: mi
     # it), so stamp the location and empty the binding list.
     mi.asm_block         = nil;
     mi.loc               = ctx.cur_loc;
+    mi.inline_site       = ctx.cur_inline_site;
     mi.dbg_bindings      = nil;
     mi.dbg_binding_count = 0;
 
@@ -732,6 +734,10 @@ fun split_critical_edge(ctx: *lctx.LowerCtx, pred: *mir.MirBlock, succ_id: u32) 
     # it to the surrounding code) and it carries no dbg bindings.
     br.asm_block         = nil;
     br.loc               = source.loc_nil();
+    # a synthesized critical-edge branch has no inlined-from origin; attribute it to the
+    # function body (0). the encoder groups by instance, so this at worst splits an
+    # inline instance's PC range at the edge, which the range list represents faithfully.
+    br.inline_site       = 0;
     br.dbg_bindings      = nil;
     br.dbg_binding_count = 0;
 
@@ -820,6 +826,9 @@ fun lower_instr(ctx: *lctx.LowerCtx, fn: *ir.Function, mb: *mir.MirBlock, iid: i
     # stamp the current source location so every MirInstr this instruction lowers to
     # (through `push_instr`) carries its origin for the debug line table.
     ctx.cur_loc = inst.loc;
+    # and its inline instance, so lowered instructions carry which inlined expansion
+    # they came from (0 for the function's own body).
+    ctx.cur_inline_site = ir.instr_inline_site_of(fn, iid);
 
     if (inst.kind == instr.OP_CALL) {
         ret mabi.lower_call(ctx, mb, inst, iid);

--- a/src/lang/be/codegen/regalloc.mach
+++ b/src/lang/be/codegen/regalloc.mach
@@ -2908,7 +2908,7 @@ fun rewrite_instr(tgt: *target.Target, ctx: *AllocCtx, mi: *mir.MirInstr,
                         ret R.err[bool, str](regalloc_msg(ctx, "regalloc: no free register for spilled source in '", "'", "regalloc: no free register for spilled source"));
                     }
                     claimed[claimed_count] = tmp; claimed_count = claimed_count + 1;
-                    val er: R.Result[bool, str] = emit_reload(ctx, dst, wp, tmp::u32, v, mi.loc);
+                    val er: R.Result[bool, str] = emit_reload(ctx, dst, wp, tmp::u32, v, mi.loc, mi.inline_site);
                     if (R.is_err[bool, str](er)) { free_ops(ctx, ops, n); ret er; }
                     ops[k] = mir.op_preg(tmp::u32);
                 } or {
@@ -2937,7 +2937,7 @@ fun rewrite_instr(tgt: *target.Target, ctx: *AllocCtx, mi: *mir.MirInstr,
                         ret R.err[bool, str](regalloc_msg(ctx, "regalloc: no free register for spilled MEM base in '", "'", "regalloc: no free register for spilled MEM base"));
                     }
                     claimed[claimed_count] = tmp; claimed_count = claimed_count + 1;
-                    val er: R.Result[bool, str] = emit_reload(ctx, dst, wp, tmp::u32, v, mi.loc);
+                    val er: R.Result[bool, str] = emit_reload(ctx, dst, wp, tmp::u32, v, mi.loc, mi.inline_site);
                     if (R.is_err[bool, str](er)) { free_ops(ctx, ops, n); ret er; }
                     ops[k].vreg = mir.MIR_VREG_NIL;
                     ops[k].preg = tmp::u32;
@@ -2959,7 +2959,7 @@ fun rewrite_instr(tgt: *target.Target, ctx: *AllocCtx, mi: *mir.MirInstr,
                         ret R.err[bool, str](regalloc_msg(ctx, "regalloc: no free register for spilled MEM index in '", "'", "regalloc: no free register for spilled MEM index"));
                     }
                     claimed[claimed_count] = tmp; claimed_count = claimed_count + 1;
-                    val er: R.Result[bool, str] = emit_reload(ctx, dst, wp, tmp::u32, iv, mi.loc);
+                    val er: R.Result[bool, str] = emit_reload(ctx, dst, wp, tmp::u32, iv, mi.loc, mi.inline_site);
                     if (R.is_err[bool, str](er)) { free_ops(ctx, ops, n); ret er; }
                     ops[k].index         = tmp::u32;
                     ops[k].index_is_preg = true;
@@ -2993,6 +2993,7 @@ fun rewrite_instr(tgt: *target.Target, ctx: *AllocCtx, mi: *mir.MirInstr,
             dst[@wp].width             = mi.width;
             dst[@wp].src_width         = mi.src_width;
             dst[@wp].loc               = mi.loc;
+            dst[@wp].inline_site       = mi.inline_site;
             dst[@wp].dbg_bindings      = mi.dbg_bindings;
             dst[@wp].dbg_binding_count = mi.dbg_binding_count;
             @wp = @wp + 1;
@@ -3016,6 +3017,9 @@ fun rewrite_instr(tgt: *target.Target, ctx: *AllocCtx, mi: *mir.MirInstr,
     # table still maps this instruction's final bytes to its origin (the zeroed
     # buffer would otherwise leave file 0, a real FileId, not FILE_NIL).
     dst[@wp].loc           = mi.loc;
+    # carry the inline instance through likewise; the zeroed buffer would otherwise
+    # drop every instruction back to the function body and erase the channel.
+    dst[@wp].inline_site   = mi.inline_site;
     # transfer the -g dbg-binding list (ownership moves to the rewritten instruction);
     # the encoder reads it to record VarLocs, and the original instr's array is not
     # freed with its operands below.
@@ -3030,7 +3034,7 @@ fun rewrite_instr(tgt: *target.Target, ctx: *AllocCtx, mi: *mir.MirInstr,
 
     # store a spilled destination back to its slot.
     if (store_dst_vreg != mir.MIR_VREG_NIL) {
-        val sr: R.Result[bool, str] = emit_store(ctx, dst, wp, store_dst_vreg, store_dst_tmp::u32, mi.loc);
+        val sr: R.Result[bool, str] = emit_store(ctx, dst, wp, store_dst_vreg, store_dst_tmp::u32, mi.loc, mi.inline_site);
         if (R.is_err[bool, str](sr)) { ret sr; }
     }
     ret R.ok[bool, str](true);
@@ -3144,7 +3148,7 @@ fun id_claimed(claimed: *i32, count: u32, id: i32) bool {
 # slot), matching the by-value-spill addressing convention. propagates an
 # operand-array allocation failure as a Result, mirroring its twin emit_store (the
 # rewrite already threads every other allocation failure through Result)
-fun emit_reload(ctx: *AllocCtx, dst: *mir.MirInstr, wp: *u32, tmp: u32, v: u32, loc: source.SrcLoc) R.Result[bool, str] {
+fun emit_reload(ctx: *AllocCtx, dst: *mir.MirInstr, wp: *u32, tmp: u32, v: u32, loc: source.SrcLoc, inline_site: u32) R.Result[bool, str] {
     val ro: R.Result[*mir.MirOperand, str] = A.allocate[mir.MirOperand](ctx.alloc, 2::usize);
     if (R.is_err[*mir.MirOperand, str](ro)) { ret R.err[bool, str](R.unwrap_err[*mir.MirOperand, str](ro)); }
     val ops: *mir.MirOperand = R.unwrap_ok[*mir.MirOperand, str](ro);
@@ -3159,6 +3163,9 @@ fun emit_reload(ctx: *AllocCtx, dst: *mir.MirInstr, wp: *u32, tmp: u32, v: u32, 
     # inherit the served instruction's location so a reload-before-use is attributed
     # to the line it serves (the zeroed buffer would otherwise leave file 0).
     dst[@wp].loc           = loc;
+    # and its inline instance, so a reload inside an inlined expansion stays within
+    # that instance's PC range instead of splitting it at the body.
+    dst[@wp].inline_site   = inline_site;
     @wp = @wp + 1;
     ret R.ok[bool, str](true);
 }
@@ -3166,7 +3173,7 @@ fun emit_reload(ctx: *AllocCtx, dst: *mir.MirInstr, wp: *u32, tmp: u32, v: u32, 
 # append `MIR_MOV [rbp + slot] <- (preg tmp)` storing a temporary
 # back to a spilled destination vreg's slot. the destination MEM base is the
 # spilled vreg id so the encoder resolves it to `[rbp + offset]`
-fun emit_store(ctx: *AllocCtx, dst: *mir.MirInstr, wp: *u32, v: u32, tmp: u32, loc: source.SrcLoc) R.Result[bool, str] {
+fun emit_store(ctx: *AllocCtx, dst: *mir.MirInstr, wp: *u32, v: u32, tmp: u32, loc: source.SrcLoc, inline_site: u32) R.Result[bool, str] {
     val ro: R.Result[*mir.MirOperand, str] = A.allocate[mir.MirOperand](ctx.alloc, 2::usize);
     if (R.is_err[*mir.MirOperand, str](ro)) { ret R.err[bool, str](R.unwrap_err[*mir.MirOperand, str](ro)); }
     val ops: *mir.MirOperand = R.unwrap_ok[*mir.MirOperand, str](ro);
@@ -3180,6 +3187,9 @@ fun emit_store(ctx: *AllocCtx, dst: *mir.MirInstr, wp: *u32, v: u32, tmp: u32, l
     dst[@wp].src_width     = ctx.spill_width;
     # inherit the served instruction's location (store-after-def), as emit_reload does.
     dst[@wp].loc           = loc;
+    # and its inline instance, so a spill inside an inlined expansion stays within that
+    # instance's PC range.
+    dst[@wp].inline_site   = inline_site;
     @wp = @wp + 1;
     ret R.ok[bool, str](true);
 }

--- a/src/lang/me/ir.mach
+++ b/src/lang/me/ir.mach
@@ -941,58 +941,6 @@ pub fun instr_inline_site_of(fn: *Function, iid: id.InstructionId) u32 {
     ret @R.unwrap_ok[*u32, str](res);
 }
 
-# copy the -g source-variable metadata (DbgVar identity and any DbgExpr salvage steps)
-# the OP_DBG_VALUE `src_iid` carries in `src_fn` onto the cloned OP_DBG_VALUE `dst_iid`
-# in `dst_fn`. Used by the inline pass so an inlined local keeps its name / type /
-# expression identity in the caller instead of being anonymous. A no-op when `src_iid`
-# carries no dbg-var. The operands were remapped separately, so the copied identity
-# rides the caller's value.
-# ---
-# m:       module owning the allocator
-# src_fn:  the callee the metadata is read from
-# dst_fn:  the caller the metadata is copied into
-# src_iid: the callee OP_DBG_VALUE id
-# dst_iid: the cloned OP_DBG_VALUE id in the caller
-# ret:     ok(true), or an allocation error
-pub fun clone_dbg_metadata(m: *Module, src_fn: *Function, dst_fn: *Function, src_iid: id.InstructionId, dst_iid: id.InstructionId) R.Result[bool, str] {
-    val odv: O.Option[*DbgVar] = dbg_var_get(src_fn, src_iid);
-    if (O.is_none[*DbgVar](odv)) { ret R.ok[bool, str](true); }
-    var dv: DbgVar = @O.unwrap[*DbgVar](odv);
-    val ri: R.Result[bool, str] = map.insert[id.InstructionId, DbgVar](?dst_fn.dbg_vars, dst_iid, dv);
-    if (R.is_err[bool, str](ri)) { ret ri; }
-
-    val seid: DbgExprId = dbg_expr_id(src_fn, src_iid);
-    val ose: O.Option[*DbgExpr] = dbg_expr_get(src_fn, seid);
-    if (O.is_none[*DbgExpr](ose)) { ret R.ok[bool, str](true); }
-    val n: u32 = O.unwrap[*DbgExpr](ose).op_count;
-    if (n == 0) { ret R.ok[bool, str](true); }
-
-    # snapshot the source steps before any pool mutation (dbg_expr_new below may grow
-    # the source pool too when src_fn == dst_fn is impossible here, but be safe): copy
-    # them out, then rebuild the destination expression through the pool's own API.
-    val rsnap: R.Result[*DbgOp, str] = A.allocate[DbgOp](m.alloc, n::usize);
-    if (R.is_err[*DbgOp, str](rsnap)) { ret R.err[bool, str](R.unwrap_err[*DbgOp, str](rsnap)); }
-    val snap: *DbgOp = R.unwrap_ok[*DbgOp, str](rsnap);
-    var i: u32 = 0;
-    val se0: *DbgExpr = O.unwrap[*DbgExpr](ose);
-    for (i < n) { snap[i] = se0.ops[i]; i = i + 1; }
-
-    # build the destination expression through the tested pool API: a fresh empty
-    # expression, then prepend each step in reverse so the final order matches. this
-    # keeps op-array ownership entirely inside dbg_expr_prepend_op's allocation.
-    val rne: R.Result[DbgExprId, str] = dbg_expr_new(m, dst_fn, dst_iid);
-    if (R.is_err[DbgExprId, str](rne)) { A.deallocate[DbgOp](m.alloc, snap, n::usize); ret R.err[bool, str](R.unwrap_err[DbgExprId, str](rne)); }
-    val deid: DbgExprId = R.unwrap_ok[DbgExprId, str](rne);
-    var j: u32 = n;
-    for (j > 0) {
-        val rp: R.Result[bool, str] = dbg_expr_prepend_op(m, dst_fn, deid, snap[j - 1]);
-        if (R.is_err[bool, str](rp)) { A.deallocate[DbgOp](m.alloc, snap, n::usize); ret rp; }
-        j = j - 1;
-    }
-    A.deallocate[DbgOp](m.alloc, snap, n::usize);
-    ret R.ok[bool, str](true);
-}
-
 # allocate a fresh, empty block at the end of a function's block array and return
 # its BlockId. the block's id field is set to its index; all owned lists start
 # empty and its terminator is INSTR_NIL
@@ -1413,11 +1361,10 @@ test "mach.lang.me.ir.dnit:frees_by_capacity_not_count" {
     ret 0;
 }
 
-# the inline-site channel round-trips instances and their instruction grouping, and
-# clone_dbg_metadata copies both a source variable's identity and its salvage
-# expression onto a destination instruction id -- the exact surface the inline pass
-# uses to make inlined locals non-anonymous.
-test "mach.lang.me.ir.inline_site_channel:add_get_clone" {
+# the inline-site channel round-trips instances (callee, parent chain) and their
+# per-instruction grouping -- the identity surface the inline pass fills and the DWARF
+# inlined_subroutine producer consumes.
+test "mach.lang.me.ir.inline_site_channel:add_get_group" {
     var alloc: A.Allocator;
     page.make(?alloc);
     val rm: R.Result[Module, str] = init(?alloc, intern.STR_NIL);
@@ -1432,7 +1379,6 @@ test "mach.lang.me.ir.inline_site_channel:add_get_clone" {
     val sigty: type.IrTypeId = R.unwrap_ok[type.IrTypeId, str](rsig);
     if (R.is_err[u32, str](function_add(?m, 100::intern.StrId, sigty, 0))) { dnit(?m); ret 1; }
     if (R.is_err[u32, str](function_add(?m, 200::intern.StrId, sigty, 0))) { dnit(?m); ret 1; }
-    val callee: *Function = ?m.functions[0];
     val caller: *Function = ?m.functions[1];
 
     # two instances: the second nested under the first.
@@ -1455,35 +1401,6 @@ test "mach.lang.me.ir.inline_site_channel:add_get_clone" {
     if (R.is_err[bool, str](instr_inline_site_set(caller, 7::id.InstructionId, 2))) { dnit(?m); ret 1; }
     if (instr_inline_site_of(caller, 7::id.InstructionId) != 2) { dnit(?m); ret 1; }
     if (instr_inline_site_of(caller, 8::id.InstructionId) != 0) { dnit(?m); ret 1; }
-
-    # a source variable with a one-step salvage expression on callee id 5.
-    var dv: DbgVar;
-    dv.name     = 900::intern.StrId;
-    dv.ty       = voidty;
-    dv.ty_sem   = semtype.TYPE_NIL;
-    dv.is_param = false;
-    dv.scope    = 0;
-    if (R.is_err[bool, str](map.insert[id.InstructionId, DbgVar](?callee.dbg_vars, 5::id.InstructionId, dv))) { dnit(?m); ret 1; }
-    val rne: R.Result[DbgExprId, str] = dbg_expr_new(?m, callee, 5::id.InstructionId);
-    if (R.is_err[DbgExprId, str](rne)) { dnit(?m); ret 1; }
-    var op: DbgOp;
-    op.op  = DBG_OP_PLUS_CONST;
-    op.arg = 8;
-    if (R.is_err[bool, str](dbg_expr_prepend_op(?m, callee, R.unwrap_ok[DbgExprId, str](rne), op))) { dnit(?m); ret 1; }
-
-    # clone onto caller id 9 and confirm both the identity and the expression copied.
-    if (R.is_err[bool, str](clone_dbg_metadata(?m, callee, caller, 5::id.InstructionId, 9::id.InstructionId))) { dnit(?m); ret 1; }
-    val odv: O.Option[*DbgVar] = dbg_var_get(caller, 9::id.InstructionId);
-    if (O.is_none[*DbgVar](odv))                              { dnit(?m); ret 1; }
-    if (O.unwrap[*DbgVar](odv).name != 900::intern.StrId)     { dnit(?m); ret 1; }
-    val ceid: DbgExprId = dbg_expr_id(caller, 9::id.InstructionId);
-    if (ceid == DBG_EXPR_IDENTITY)                            { dnit(?m); ret 1; }
-    val oce: O.Option[*DbgExpr] = dbg_expr_get(caller, ceid);
-    if (O.is_none[*DbgExpr](oce))                             { dnit(?m); ret 1; }
-    val ce: *DbgExpr = O.unwrap[*DbgExpr](oce);
-    if (ce.op_count != 1)                                     { dnit(?m); ret 1; }
-    if (ce.ops[0].op != DBG_OP_PLUS_CONST)                   { dnit(?m); ret 1; }
-    if (ce.ops[0].arg != 8)                                  { dnit(?m); ret 1; }
 
     dnit(?m);
     ret 0;

--- a/src/lang/me/pass/inline.mach
+++ b/src/lang/me/pass/inline.mach
@@ -489,10 +489,9 @@ fun do_inline(
     val res_run: R.Result[bool, str] = run_inline(?cx, call_bi, call_ii, call_id);
 
     # stamp -g inline-site metadata onto the clones while cx.instr_map is still live: an
-    # InlineSite for this expansion (plus remapped nested instances), each cloned
-    # instruction's owning instance, and the callee's dbg-vars/dbg-exprs copied onto the
-    # cloned OP_DBG_VALUEs. pure debug metadata; a build without -g still runs it but the
-    # side tables it fills are simply never consumed.
+    # InlineSite for this expansion (plus remapped nested instances) and each cloned
+    # instruction's owning instance. pure identity metadata; consumed only by the DWARF
+    # inlined_subroutine producer (#1707), so a build never changes because of it.
     var res_meta: R.Result[bool, str] = R.ok[bool, str](true);
     if (!R.is_err[bool, str](res_run)) {
         res_meta = stamp_inline_metadata(m, ?cx, call_loc, parent_site);
@@ -521,9 +520,10 @@ fun do_inline(
 
 # stamp the -g inline-site side tables for one completed expansion (cx.instr_map maps
 # each callee instruction index to its clone in the caller). Records an InlineSite for
-# this expansion, remaps the callee's own nested instances beneath it, tags every cloned
-# instruction with its owning instance, and copies the callee's dbg-var / dbg-expr
-# identity onto the cloned OP_DBG_VALUEs. -g metadata only; never affects emitted code.
+# this expansion, remaps the callee's own nested instances beneath it, and tags every
+# cloned instruction with its owning instance. -g identity metadata only; never affects
+# emitted code. The DWARF inlined_subroutine producer (#1707) also clones the callee's
+# dbg-vars/dbg-exprs, but that ships there with the nesting that attributes them.
 # ---
 # m:           the module
 # cx:          the inline context (caller / callee / instr_map populated)
@@ -567,8 +567,6 @@ fun stamp_inline_metadata(m: *ir.Module, cx: *InlineCtx, call_loc: source.SrcLoc
         }
         val rs: R.Result[bool, str] = ir.instr_inline_site_set(caller, cloned_iid, caller_site);
         if (R.is_err[bool, str](rs)) { if (site_map != nil) { A.deallocate[u32](m.alloc, site_map, (nsite + 1)::usize); } ret rs; }
-        val rc: R.Result[bool, str] = ir.clone_dbg_metadata(m, callee, caller, i::id.InstructionId, cloned_iid);
-        if (R.is_err[bool, str](rc)) { if (site_map != nil) { A.deallocate[u32](m.alloc, site_map, (nsite + 1)::usize); } ret rc; }
         i = i + 1;
     }
     if (site_map != nil) { A.deallocate[u32](m.alloc, site_map, (nsite + 1)::usize); }


### PR DESCRIPTION
Re-scopes the inline-site prerequisite to the inert identity channel and completes it through to the encoder. Corrects the merged #1928, whose dbg-metadata clone (landed before the split was finalized) makes the current producer emit inlined locals as flat caller locals — a wrong-scope attribution no sequencing may create.

## What
- **Complete the channel to the encoder**: a `MirInstr.inline_site` field riding beside `loc`. The lowering cursor stamps it from the IR inline-site map; `push_instr`, the splice, and the synthesized critical-edge branch set it; regalloc forwards it through instruction rewrites, and reloads/spills inherit their served instruction's instance (threaded through `emit_reload`/`emit_store`) so a spill inside an inlined expansion stays in that instance's PC range.
- **Remove the dbg-metadata clone** (`clone_dbg_metadata` + its inline-pass call + the dbg-clone half of the unit test). The inline pass now stamps inline-site identity only (InlineSite pool + per-instruction instance). The IR channel pieces from #1928 (pool, `instr_inline_site` map, stamping, three-site Function init) stay.

## Inert by construction
Nothing consumes the channel; it is pure identity metadata for the #1707 producer.
- non-`-g` release output **byte-identical to a clean-dev compiler**,
- self-host fixpoint identical (S2 == S3),
- release `-g` builds are stable (the dbg-expr-copy segfault is gone with the clone) and `llvm-dwarfdump --verify` reports no errors,
- 536/536 unit tests (the channel test now covers instances + per-instruction grouping).

## Seam note
The encoder **range-grouping** is intentionally NOT here: the encoder's `LineRow` drops no-loc instructions (wrong for ranges) and a range table with no consumer is dead code whose shape depends on the producer. The identity reaches the encoder-visible `MirInstr.inline_site`; #1707 records per-instance ranges at the ISA encode sites (where `mi.inline_site` + the text offset are both live) together with its rnglists consumer.

## Follow-on
#1707 consumes this: dbg-clone + abstract-instance subprograms + `DW_TAG_inlined_subroutine` + `.debug_rnglists` + the PC-range grouping — every consumer shipping with its data.

Closes #1924.
