### PR TITLE
feat(debuginfo): DWARF inlined_subroutine + .debug_rnglists (#1707)

### DIFF
--- a/dbg/fixtures/inline/mach.toml
+++ b/dbg/fixtures/inline/mach.toml
@@ -1,0 +1,36 @@
+[project]
+id      = "inlinefix"
+name    = "inlinefix"
+version = "0.0.0"
+src     = "src"
+dep     = "dep"
+target  = "linux"
+out     = "out/{target}/{profile}/bin/{name}{ext}"
+
+[target.linux]
+isa = "x86_64"
+os  = "linux"
+abi = "sysv64"
+
+[target.linux-arm64]
+isa = "aarch64"
+os  = "linux"
+abi = "aapcs64"
+
+[target.linux-riscv64]
+isa = "riscv64"
+os  = "linux"
+abi = "lp64"
+
+[profile.debug]
+opt = 0
+
+[profile.release]
+opt = 2
+
+[bin.inlinefix]
+entry = "main.mach"
+
+[deps.mach-std]
+git = "https://github.com/briar-systems/mach-std"
+ref = "branch/main"

--- a/dbg/fixtures/inline/src/main.mach
+++ b/dbg/fixtures/inline/src/main.mach
@@ -1,0 +1,29 @@
+# inlining fixture for the release-profile DWARF inlined_subroutine leg (#1707). Built at
+# release (where the inline pass fires) with -g; the runner asserts DW_TAG_inlined_
+# subroutine DIEs (including a nested one) verify clean. opaque is recursive so it is not
+# inlined and not constant-folded, keeping the inlined bodies live and multi-extent.
+use std.runtime;
+
+# a recursive, non-inlinable, non-foldable value source.
+fun opaque(n: i32) i32 {
+    if (n <= 0) { ret 1; }
+    ret opaque(n - 1) + n;
+}
+
+#[inline]
+fun leaf(y: i32) i32 {
+    var lv: i32 = y * 3;
+    ret lv - 1;
+}
+
+#[inline]
+fun mid(x: i32) i32 {
+    var mv: i32 = leaf(x) + opaque(x);
+    ret mv + 5;
+}
+
+#[symbol("main")]
+fun main() i32 {
+    var top: i32 = mid(opaque(4));
+    ret top;
+}

--- a/dbg/fixtures/inline4/mach.toml
+++ b/dbg/fixtures/inline4/mach.toml
@@ -1,0 +1,36 @@
+[project]
+id      = "inline4fix"
+name    = "inline4fix"
+version = "0.0.0"
+src     = "src"
+dep     = "dep"
+target  = "linux"
+out     = "out/{target}/{profile}/bin/{name}{ext}"
+
+[target.linux]
+isa = "x86_64"
+os  = "linux"
+abi = "sysv64"
+
+[target.linux-arm64]
+isa = "aarch64"
+os  = "linux"
+abi = "aapcs64"
+
+[target.linux-riscv64]
+isa = "riscv64"
+os  = "linux"
+abi = "lp64"
+
+[profile.debug]
+opt = 0
+
+[profile.release]
+opt = 2
+
+[bin.inline4fix]
+entry = "main.mach"
+
+[deps.mach-std]
+git = "https://github.com/briar-systems/mach-std"
+ref = "branch/main"

--- a/dbg/fixtures/inline4/src/main.mach
+++ b/dbg/fixtures/inline4/src/main.mach
@@ -1,0 +1,43 @@
+# four-level inlining fixture for the release-profile DWARF inlined_subroutine leg
+# (#1707). a -> b -> c -> d is a chain of #[inline] callees, so a single call in main
+# expands to four nested inlined_subroutine instances; the runner asserts all four
+# verify clean and are present (the regression pin for nested-instance rollup recovery).
+# opaque is recursive at every level so nothing is inlined away or constant-folded,
+# keeping every inlined body live and multi-extent.
+use std.runtime;
+
+# a recursive, non-inlinable, non-foldable value source.
+fun opaque(n: i32) i32 {
+    if (n <= 0) { ret 1; }
+    ret opaque(n - 1) + n;
+}
+
+#[inline]
+fun d(y: i32) i32 {
+    var dv: i32 = y * 3;
+    ret dv - 1;
+}
+
+#[inline]
+fun c(x: i32) i32 {
+    var cv: i32 = d(x) + opaque(x);
+    ret cv * 2;
+}
+
+#[inline]
+fun b(w: i32) i32 {
+    var bv: i32 = c(w) + opaque(w);
+    ret bv + 5;
+}
+
+#[inline]
+fun a(v: i32) i32 {
+    var av: i32 = b(v) + opaque(v);
+    ret av - 3;
+}
+
+#[symbol("main")]
+fun main() i32 {
+    var top: i32 = a(opaque(4));
+    ret top;
+}

--- a/dbg/verify.sh
+++ b/dbg/verify.sh
@@ -219,7 +219,10 @@ verify_dwarf() {
 
     # 5. additive-only: -g must not perturb the loaded program. every PT_LOAD segment
     #    is byte-identical between the -g and no-g builds (modulo the ELF header's
-    #    section-table bookkeeping). a codegen change under -g fails here.
+    #    section-table bookkeeping). a codegen change under -g fails here. NOTE: this
+    #    runs at the debug profile only; the release counterpart is deferred to #1944
+    #    (release -g still perturbs .text on clean dev), so verify_inline_release does
+    #    not yet assert it.
     if ! elf_seg_identical "$g" "$nog"; then
         echo "FAIL $label (-g perturbed a loadable segment vs the no-g build)"; rm -rf "$tmp"; return 1
     fi
@@ -252,15 +255,17 @@ verify_dwarf() {
     return 0
 }
 
-# verify_inline_release <fixture_dir> <build_target> — the inline pass fires only at
-# release, so this leg builds one -g release binary and asserts the DWARF inlined_
-# subroutine tier: llvm-dwarfdump --verify is clean and the expected inlined callees
-# appear as DW_TAG_inlined_subroutine DIEs. Byte-for-byte -g additivity is NOT asserted
-# here yet: release -g still perturbs .text on clean dev (a pre-existing -g-sensitive
-# inlining decision, tracked in #1944). turn the elf_seg_identical assertion on at release
-# once #1944 lands.
+# verify_inline_release <fixture_dir> <build_target> <min_dies> <callees> — the inline
+# pass fires only at release, so this leg builds one -g release binary and asserts the
+# DWARF inlined_subroutine tier: llvm-dwarfdump --verify is clean, at least <min_dies>
+# DW_TAG_inlined_subroutine DIEs are present, and each name in <callees> (space-
+# separated) appears as an inlined instance (its DW_AT_abstract_origin resolves to it) —
+# the pin that every level of a nested inline chain survived. Byte-for-byte -g additivity
+# is NOT asserted here yet: release -g still perturbs .text on clean dev (a pre-existing
+# -g-sensitive inlining decision, tracked in #1944 — see step 5's note). turn the
+# elf_seg_identical assertion on at release once #1944 lands.
 verify_inline_release() {
-    dir=$1; bt=$2
+    dir=$1; bt=$2; min=$3; callees=$4
     label="${dir#"$here"/} [$bt release]"
     tmp=$(mktemp -d)
     g="$tmp/g"
@@ -271,10 +276,10 @@ verify_inline_release() {
         echo "FAIL $label (llvm-dwarfdump --verify)"; tail -30 "$tmp/v.log" | sed 's/^/    /' >&2; rm -rf "$tmp"; return 1
     fi
     n=$("$dwarfdump" --debug-info "$g" 2>/dev/null | grep -c DW_TAG_inlined_subroutine)
-    if [ "$n" -lt 2 ]; then
-        echo "FAIL $label (expected >=2 inlined_subroutine DIEs, found $n)"; rm -rf "$tmp"; return 1
+    if [ "$n" -lt "$min" ]; then
+        echo "FAIL $label (expected >=$min inlined_subroutine DIEs, found $n)"; rm -rf "$tmp"; return 1
     fi
-    for callee in leaf mid; do
+    for callee in $callees; do
         if ! "$dwarfdump" --debug-info "$g" 2>/dev/null | grep -q "DW_AT_abstract_origin.*\"$callee\""; then
             echo "FAIL $label (no inlined_subroutine referencing $callee)"; rm -rf "$tmp"; return 1
         fi
@@ -286,21 +291,29 @@ verify_inline_release() {
 
 for dir in "$fixtures"/$filter; do
     [ -f "$dir/mach.toml" ] || continue
-    # the inline fixture is release-only (its callees inline away at -O0); it has its own
-    # release leg below and does not fit the debug fixture's structural checks.
-    [ "$(basename "$dir")" = "inline" ] && continue
+    # the inline fixtures are release-only (their callees inline away at -O0); they have
+    # their own release legs below and do not fit the debug fixture's structural checks.
+    case "$(basename "$dir")" in inline|inline4) continue;; esac
     for bt in $elf_targets; do
         ran=$((ran + 1))
         verify_dwarf "$dir" "$bt" || fails=$((fails + 1))
     done
 done
 
-# release leg: exercise the release-only inline pass so the inlined_subroutine tier
-# (#1707) is actually verified in CI (debug builds never inline).
+# release legs: exercise the release-only inline pass so the inlined_subroutine tier
+# (#1707) is actually verified in CI (debug builds never inline). inline is a 2-level
+# chain (leaf under mid); inline4 is a 4-level chain (a>b>c>d) that pins nested-instance
+# rollup recovery — every level must survive as its own inlined instance.
 if [ -f "$fixtures/inline/mach.toml" ]; then
     for bt in $elf_targets; do
         ran=$((ran + 1))
-        verify_inline_release "$fixtures/inline" "$bt" || fails=$((fails + 1))
+        verify_inline_release "$fixtures/inline" "$bt" 2 "leaf mid" || fails=$((fails + 1))
+    done
+fi
+if [ -f "$fixtures/inline4/mach.toml" ]; then
+    for bt in $elf_targets; do
+        ran=$((ran + 1))
+        verify_inline_release "$fixtures/inline4" "$bt" 4 "a b c d" || fails=$((fails + 1))
     done
 fi
 

--- a/dbg/verify.sh
+++ b/dbg/verify.sh
@@ -257,8 +257,8 @@ verify_dwarf() {
 # subroutine tier: llvm-dwarfdump --verify is clean and the expected inlined callees
 # appear as DW_TAG_inlined_subroutine DIEs. Byte-for-byte -g additivity is NOT asserted
 # here yet: release -g still perturbs .text on clean dev (a pre-existing -g-sensitive
-# inlining decision, tracked in #1946). turn the elf_seg_identical assertion on at release
-# once #1946 lands.
+# inlining decision, tracked in #1944). turn the elf_seg_identical assertion on at release
+# once #1944 lands.
 verify_inline_release() {
     dir=$1; bt=$2
     label="${dir#"$here"/} [$bt release]"

--- a/dbg/verify.sh
+++ b/dbg/verify.sh
@@ -252,13 +252,55 @@ verify_dwarf() {
     return 0
 }
 
+# verify_inline_release <fixture_dir> <build_target> — the inline pass fires only at
+# release, so this leg builds one -g release binary and asserts the DWARF inlined_
+# subroutine tier: llvm-dwarfdump --verify is clean and the expected inlined callees
+# appear as DW_TAG_inlined_subroutine DIEs. Byte-for-byte -g additivity is NOT checked at
+# release (a separate, pre-existing codegen-determinism issue tracked outside this lane).
+verify_inline_release() {
+    dir=$1; bt=$2
+    label="${dir#"$here"/} [$bt release]"
+    tmp=$(mktemp -d)
+    g="$tmp/g"
+    if ! (cd "$dir" && "$compiler" dep pull && "$compiler" build . --target "$bt" --profile release -g -o "$g") >"$tmp/b.log" 2>&1; then
+        echo "FAIL $label (build release -g)"; sed 's/^/    /' "$tmp/b.log" >&2; rm -rf "$tmp"; return 1
+    fi
+    if ! "$dwarfdump" --verify "$g" >"$tmp/v.log" 2>&1; then
+        echo "FAIL $label (llvm-dwarfdump --verify)"; tail -30 "$tmp/v.log" | sed 's/^/    /' >&2; rm -rf "$tmp"; return 1
+    fi
+    n=$("$dwarfdump" --debug-info "$g" 2>/dev/null | grep -c DW_TAG_inlined_subroutine)
+    if [ "$n" -lt 2 ]; then
+        echo "FAIL $label (expected >=2 inlined_subroutine DIEs, found $n)"; rm -rf "$tmp"; return 1
+    fi
+    for callee in leaf mid; do
+        if ! "$dwarfdump" --debug-info "$g" 2>/dev/null | grep -q "DW_AT_abstract_origin.*\"$callee\""; then
+            echo "FAIL $label (no inlined_subroutine referencing $callee)"; rm -rf "$tmp"; return 1
+        fi
+    done
+    echo "PASS $label ($n inlined_subroutine DIEs)"
+    rm -rf "$tmp"
+    return 0
+}
+
 for dir in "$fixtures"/$filter; do
     [ -f "$dir/mach.toml" ] || continue
+    # the inline fixture is release-only (its callees inline away at -O0); it has its own
+    # release leg below and does not fit the debug fixture's structural checks.
+    [ "$(basename "$dir")" = "inline" ] && continue
     for bt in $elf_targets; do
         ran=$((ran + 1))
         verify_dwarf "$dir" "$bt" || fails=$((fails + 1))
     done
 done
+
+# release leg: exercise the release-only inline pass so the inlined_subroutine tier
+# (#1707) is actually verified in CI (debug builds never inline).
+if [ -f "$fixtures/inline/mach.toml" ]; then
+    for bt in $elf_targets; do
+        ran=$((ran + 1))
+        verify_inline_release "$fixtures/inline" "$bt" || fails=$((fails + 1))
+    done
+fi
 
 # STAGED — expansion points wired but not yet live, each pending its producer. these
 # consume the same fixtures; a tier issue turns one on by adding its checks here and

--- a/dbg/verify.sh
+++ b/dbg/verify.sh
@@ -255,8 +255,10 @@ verify_dwarf() {
 # verify_inline_release <fixture_dir> <build_target> — the inline pass fires only at
 # release, so this leg builds one -g release binary and asserts the DWARF inlined_
 # subroutine tier: llvm-dwarfdump --verify is clean and the expected inlined callees
-# appear as DW_TAG_inlined_subroutine DIEs. Byte-for-byte -g additivity is NOT checked at
-# release (a separate, pre-existing codegen-determinism issue tracked outside this lane).
+# appear as DW_TAG_inlined_subroutine DIEs. Byte-for-byte -g additivity is NOT asserted
+# here yet: release -g still perturbs .text on clean dev (a pre-existing -g-sensitive
+# inlining decision, tracked in #1946). turn the elf_seg_identical assertion on at release
+# once #1946 lands.
 verify_inline_release() {
     dir=$1; bt=$2
     label="${dir#"$here"/} [$bt release]"

--- a/src/lang/be/codegen.mach
+++ b/src/lang/be/codegen.mach
@@ -236,7 +236,7 @@ fun pack_image(s: *session.Session, tgt: *target.Target, irmod: *ir.Module,
     # encoder's re-homed PC<->source rows, per-PC variable-location records, and the
     # packed function symbols. off without `-g`, so non-debug output is unchanged.
     if (s.debug && format_uses_dwarf(tgt)) {
-        val res_dwarf: R.Result[bool, str] = dwarf.produce(s, tgt, irmod, ?image, enc.rows, enc.row_count, enc.varlocs, enc.varloc_count, text_sec);
+        val res_dwarf: R.Result[bool, str] = dwarf.produce(s, tgt, irmod, ?image, enc.rows, enc.row_count, enc.varlocs, enc.varloc_count, enc.inline_pcs, enc.inline_pc_count, text_sec);
         if (R.is_err[bool, str](res_dwarf)) {
             obj.dnit(?image);
             ret R.err[of.ObjectImage, str](R.unwrap_err[bool, str](res_dwarf));
@@ -450,6 +450,15 @@ fun pack_rows(enc: *encode.EncoderOutput, placements: *SectionPlacement, placeme
         enc.varlocs[v].sec         = vsite.sec;
         enc.varlocs[v].text_offset = vsite.off;
         v = v + 1;
+    }
+    # inline-instance transitions re-home identically (the #1707 inlined_subroutine
+    # producer reads the final (sec, text_offset) to bound each instance range).
+    var ip: u32 = 0;
+    for (ip < enc.inline_pc_count) {
+        val ipsite: PlacedSite = site_placed(placements, placement_count, text_sec, enc.inline_pcs[ip].text_offset);
+        enc.inline_pcs[ip].sec         = ipsite.sec;
+        enc.inline_pcs[ip].text_offset = ipsite.off;
+        ip = ip + 1;
     }
 }
 

--- a/src/lang/be/codegen/dwarf.mach
+++ b/src/lang/be/codegen/dwarf.mach
@@ -457,6 +457,9 @@ fun bytes_eq_str(b: *enc.ByteBuf, start: usize, end: usize, s: str) bool {
 val IRLT_SYM:     u8 = 0;
 val IRLT_STR:     u8 = 1;
 val IRLT_LOCLIST: u8 = 2;
+# IRLT_RNGLIST: the reloc targets the module's `.debug_rnglists` anchor, `addend`
+#           bytes in (an inlined_subroutine's DW_AT_ranges DW_FORM_sec_offset pointer)
+val IRLT_RNGLIST: u8 = 3;
 
 # one deferred `.debug_info` relocation. `build_info` records the patch sites as it
 # writes strp / addr fields whose targets are section anchors or function symbols;
@@ -508,6 +511,24 @@ rec LocReloc {
 # off:   patch-site offset within `.debug_loclists`
 # sym:   target function symbol name
 fun push_loc_reloc(list: *LocReloc, count: *u32, off: u32, sym: intern.StrId) {
+    list[@count].off = off;
+    list[@count].sym = sym;
+    @count = @count + 1;
+}
+
+# one `.debug_rnglists` base-address relocation: a DW_RLE_base_address address field
+# resolves to the enclosing function symbol, so an instance's offset-pair ranges are
+# relative to that function's low_pc (identical shape to LocReloc).
+# ---
+# off: patch-site byte offset within `.debug_rnglists`
+# sym: enclosing function symbol name
+rec RngReloc {
+    off: u32;
+    sym: intern.StrId;
+}
+
+# append a `.debug_rnglists` base-address relocation to the growing list
+fun push_rng_reloc(list: *RngReloc, count: *u32, off: u32, sym: intern.StrId) {
     list[@count].off = off;
     list[@count].sym = sym;
     @count = @count + 1;
@@ -863,9 +884,9 @@ fun build_info(b: *enc.ByteBuf, address_size: u8, producer: str, name: str, comp
     # instance (no dedup yet); DW_AT_name is the callee's source spelling.
     var ai: u32 = 0;
     for (ai < ninl) {
-        # only the instances the subprogram loop emits (single-extent, top-level) get an
-        # abstract instance this tier; the rest are held for the rnglists / nesting commits.
-        if (inlines[ai].range_count != 1 || inlines[ai].parent != 0) { ai = ai + 1; cnt; }
+        # only the top-level instances the subprogram loop emits get an abstract instance
+        # this tier; nested instances (parent != 0) are held for the nesting commit.
+        if (inlines[ai].parent != 0) { ai = ai + 1; cnt; }
         var cnm: str = resolve(?s.interner, inlines[ai].callee);
         val oi: O.Option[u32] = ir.function_lookup(irmod, inlines[ai].callee);
         if (O.is_some[u32](oi)) {
@@ -904,21 +925,28 @@ fun build_info(b: *enc.ByteBuf, address_size: u8, producer: str, name: str, comp
             vi = vi + 1;
         }
 
-        # its inlined_subroutine children. This tier emits the single-extent, top-level
-        # instances only -- exact low_pc/high_pc, non-overlapping. Multi-extent instances
-        # (exact DW_AT_ranges into `.debug_rnglists`) and nested instances (parent != 0,
-        # emitted under their parent's DIE) ship in the following commits; emitting them
-        # flat with a span approximation would overlap sibling ranges, so they are held.
+        # its inlined_subroutine children (top-level; nested instances gain parent
+        # nesting in the following commit). A single-extent instance uses exact
+        # low_pc/high_pc; a multi-extent instance uses an exact DW_AT_ranges list in
+        # `.debug_rnglists` (never a span, which would overlap sibling ranges).
         var xi: u32 = 0;
         for (xi < ninl) {
-            if (inlines[xi].func_idx != f || inlines[xi].range_count != 1 || inlines[xi].parent != 0) { xi = xi + 1; cnt; }
+            if (inlines[xi].func_idx != f || inlines[xi].parent != 0) { xi = xi + 1; cnt; }
             val di: *DwInline = ?inlines[xi];
-            val rg: *DwInlineRange = ?iranges[di.range_start];
-            enc.emit_byte(b, ABBREV_INLINED);
-            enc.emit_u32(b, di.origin_off);   # DW_AT_abstract_origin (ref4, backward)
-            push_info_reloc(relocs, reloc_count, b.len::u32, of.RK_ABS64, IRLT_SYM, fn.name, (rg.start - fn.offset)::i64);
-            emit_addr(b, address_size);        # DW_AT_low_pc (enclosing fn + range start)
-            enc.emit_u64(b, (rg.end - rg.start)::u64);   # DW_AT_high_pc
+            if (di.range_count == 1) {
+                val rg: *DwInlineRange = ?iranges[di.range_start];
+                enc.emit_byte(b, ABBREV_INLINED);
+                enc.emit_u32(b, di.origin_off);   # DW_AT_abstract_origin (ref4, backward)
+                push_info_reloc(relocs, reloc_count, b.len::u32, of.RK_ABS64, IRLT_SYM, fn.name, (rg.start - fn.offset)::i64);
+                emit_addr(b, address_size);        # DW_AT_low_pc (enclosing fn + range start)
+                enc.emit_u64(b, (rg.end - rg.start)::u64);   # DW_AT_high_pc
+            }
+            or {
+                enc.emit_byte(b, ABBREV_INLINED_RANGES);
+                enc.emit_u32(b, di.origin_off);   # DW_AT_abstract_origin (ref4, backward)
+                push_info_reloc(relocs, reloc_count, b.len::u32, of.RK_ABS32, IRLT_RNGLIST, intern.STR_NIL, di.rnglist_off::i64);
+                enc.emit_u32(b, 0);                # DW_AT_ranges (sec_offset into .debug_rnglists)
+            }
             uleb(b, di.call_file::u64);
             uleb(b, di.call_line::u64);
             xi = xi + 1;
@@ -1153,6 +1181,54 @@ fun build_loclists(b: *enc.ByteBuf, funcs: *DwFunc, nfuncs: u32, vars: *DwVar, r
         f = f + 1;
     }
 
+    bin.write_u32_le(b.data, len_pos, (b.len - body)::u32);
+}
+
+# build the DWARF 5 `.debug_rnglists` section: the unit header (offset_entry_count 0,
+# direct sec_offset) then one range list per multi-extent inlined instance. Each list is
+# a DW_RLE_base_address (the enclosing function's low_pc, relocated) then a
+# DW_RLE_offset_pair per contiguous extent, closed by DW_RLE_end_of_list; `rnglist_off`
+# is stamped so build_info patches the instance's DW_AT_ranges sec_offset. Single-extent
+# and nested instances are handled elsewhere. Range accuracy inherits the #1904 caveat.
+# ---
+# b:            the buffer the rnglists bytes are appended to
+# funcs/nfuncs: the subprograms (for the enclosing function symbol + low_pc)
+# inlines/ninl: the gathered instances (rnglist_off filled in place)
+# iranges:      the shared extent array
+# address_size: target pointer width
+# rng_relocs:   out - the base-address relocation list
+# rng_reloc_count: out - number of RngRelocs appended
+fun build_rnglists(b: *enc.ByteBuf, funcs: *DwFunc, nfuncs: u32, inlines: *DwInline, ninl: u32,
+                   iranges: *DwInlineRange, address_size: u8, rng_relocs: *RngReloc, rng_reloc_count: *u32) {
+    val len_pos: usize = b.len;
+    enc.emit_u32(b, 0);             # unit_length (backpatched)
+    val body: usize = b.len;
+    enc.emit_u16(b, 5);            # version
+    enc.emit_byte(b, address_size);
+    enc.emit_byte(b, 0);           # segment_selector_size
+    enc.emit_u32(b, 0);            # offset_entry_count (0 = direct sec_offset)
+
+    var i: u32 = 0;
+    for (i < ninl) {
+        val di: *DwInline = ?inlines[i];
+        if (di.parent != 0 || di.range_count <= 1) { i = i + 1; cnt; }
+        val fn: *DwFunc = ?funcs[di.func_idx];
+        di.rnglist_off = b.len::u32;
+        enc.emit_byte(b, DW_RLE_base_address);
+        push_rng_reloc(rng_relocs, rng_reloc_count, b.len::u32, fn.name);
+        emit_addr(b, address_size);   # base address = fn low_pc (relocated)
+        var r: u32 = di.range_start;
+        val rend: u32 = di.range_start + di.range_count;
+        for (r < rend) {
+            val rg: *DwInlineRange = ?iranges[r];
+            enc.emit_byte(b, DW_RLE_offset_pair);
+            uleb(b, (rg.start - fn.offset)::u64);
+            uleb(b, (rg.end - fn.offset)::u64);
+            r = r + 1;
+        }
+        enc.emit_byte(b, DW_RLE_end_of_list);
+        i = i + 1;
+    }
     bin.write_u32_le(b.data, len_pos, (b.len - body)::u32);
 }
 
@@ -1675,12 +1751,34 @@ pub fun produce(s: *session.Session, tgt: *target.Target, irmod: *ir.Module,
     var nir:  u32 = 0;
     gather_inlines(s, irmod, subs, nsub, inline_pcs, inline_pc_count, text_sec, ?ft, inlines, ?ninl, inl_cap, iranges, ?nir, inl_cap);
 
+    # a `.debug_rnglists` section only when some top-level instance is multi-extent.
+    var has_rnglists: bool = false;
+    var hr: u32 = 0;
+    for (hr < ninl) { if (inlines[hr].parent == 0 && inlines[hr].range_count > 1) { has_rnglists = true; } hr = hr + 1; }
+    # one DW_RLE_base_address reloc per multi-extent instance (bounded by the count).
+    val rng_reloc_cap: u32 = inl_cap + 1;
+    val rrr: R.Result[*RngReloc, str] = A.allocate[RngReloc](s.alloc, rng_reloc_cap::usize);
+    if (R.is_err[*RngReloc, str](rrr)) {
+        A.deallocate[DwInlineRange](s.alloc, iranges, inl_cap::usize); A.deallocate[DwInline](s.alloc, inlines, inl_cap::usize);
+        enc.buf_dnit(?b_rnglists); enc.buf_dnit(?b_loclists); enc.buf_dnit(?b_info); enc.buf_dnit(?b_line); enc.buf_dnit(?b_abbrev); enc.buf_dnit(?strtab.buf);
+        A.deallocate[LocReloc](s.alloc, loc_relocs, loc_reloc_cap::usize); A.deallocate[InfoReloc](s.alloc, info_relocs, reloc_cap::usize);
+        A.deallocate[u32](s.alloc, addr_off, nfuncs::usize); A.deallocate[BaseType](s.alloc, bts, MAX_BASE_TYPES::usize);
+        A.deallocate[LocRange](s.alloc, ranges, range_cap::usize); A.deallocate[DwVar](s.alloc, vars, var_cap::usize);
+        A.deallocate[DwFunc](s.alloc, subs, nfuncs::usize); A.deallocate[DwFunc](s.alloc, funcs, nfuncs::usize);
+        ret R.err[bool, str](R.unwrap_err[*RngReloc, str](rrr));
+    }
+    val rng_relocs: *RngReloc = R.unwrap_ok[*RngReloc, str](rrr);
+    var rng_reloc_count: u32 = 0;
+
     build_abbrev(?b_abbrev);
     build_line(s, funcs, nfuncs, rows, row_count, text_sec, address_size, comp_dir, ?ft, ?b_line, addr_off);
-    # loclists before info: build_loclists stamps each loclist variable's `loclist_off`,
-    # which build_info patches into the variable's DW_FORM_sec_offset field.
+    # loclists / rnglists before info: they stamp each variable's `loclist_off` and each
+    # instance's `rnglist_off`, which build_info patches into the sec_offset fields.
     if (has_loclists) {
         build_loclists(?b_loclists, subs, nsub, vars, ranges, address_size, loc_relocs, ?loc_reloc_count);
+    }
+    if (has_rnglists) {
+        build_rnglists(?b_rnglists, subs, nsub, inlines, ninl, iranges, address_size, rng_relocs, ?rng_reloc_count);
     }
     var low_off:  u32 = 0;
     var stmt_off: u32 = 0;
@@ -1690,8 +1788,8 @@ pub fun produce(s: *session.Session, tgt: *target.Target, irmod: *ir.Module,
 
     val pr: R.Result[bool, str] = install(s, image, itn, funcs, nfuncs, cu_low_name,
                                           ?b_abbrev, ?b_line, ?b_info, ?strtab.buf, ?b_loclists, has_loclists,
-                                          addr_off, low_off, stmt_off, info_relocs, info_reloc_count,
-                                          loc_relocs, loc_reloc_count);
+                                          ?b_rnglists, has_rnglists, addr_off, low_off, stmt_off, info_relocs, info_reloc_count,
+                                          loc_relocs, loc_reloc_count, rng_relocs, rng_reloc_count);
 
     enc.buf_dnit(?b_abbrev);
     enc.buf_dnit(?b_line);
@@ -1701,6 +1799,7 @@ pub fun produce(s: *session.Session, tgt: *target.Target, irmod: *ir.Module,
     enc.buf_dnit(?strtab.buf);
     A.deallocate[DwInlineRange](s.alloc, iranges, inl_cap::usize);
     A.deallocate[DwInline](s.alloc, inlines, inl_cap::usize);
+    A.deallocate[RngReloc](s.alloc, rng_relocs, rng_reloc_cap::usize);
     A.deallocate[LocReloc](s.alloc, loc_relocs, loc_reloc_cap::usize);
     A.deallocate[InfoReloc](s.alloc, info_relocs, reloc_cap::usize);
     A.deallocate[u32](s.alloc, addr_off, nfuncs::usize);
@@ -2107,9 +2206,11 @@ fun first_row_loc(rows: *enc.LineRow, row_count: u32, text_sec: u32, start: u32,
 fun install(s: *session.Session, image: *of.ObjectImage, itn: *intern.Interner,
             funcs: *DwFunc, nfuncs: u32, cu_low_name: intern.StrId, b_abbrev: *enc.ByteBuf, b_line: *enc.ByteBuf,
             b_info: *enc.ByteBuf, b_str: *enc.ByteBuf, b_loclists: *enc.ByteBuf, has_loclists: bool,
+            b_rnglists: *enc.ByteBuf, has_rnglists: bool,
             addr_off: *u32, low_off: u32, stmt_off: u32,
             info_relocs: *InfoReloc, info_reloc_count: u32,
-            loc_relocs: *LocReloc, loc_reloc_count: u32) R.Result[bool, str] {
+            loc_relocs: *LocReloc, loc_reloc_count: u32,
+            rng_relocs: *RngReloc, rng_reloc_count: u32) R.Result[bool, str] {
     val n_abbrev: R.Result[intern.StrId, str] = intern.intern(itn, ".debug_abbrev");
     if (R.is_err[intern.StrId, str](n_abbrev)) { ret R.err[bool, str](R.unwrap_err[intern.StrId, str](n_abbrev)); }
     val n_line: R.Result[intern.StrId, str] = intern.intern(itn, ".debug_line");
@@ -2163,6 +2264,24 @@ fun install(s: *session.Session, image: *of.ObjectImage, itn: *intern.Interner,
         if (R.is_err[u32, str](llar)) { ret R.err[bool, str](R.unwrap_err[u32, str](llar)); }
     }
 
+    # `.debug_rnglists` + its anchor, only when some inlined instance is multi-extent;
+    # the anchor at offset 0 lets each inlined_subroutine's DW_AT_ranges sec_offset (abs32
+    # + addend) resolve into this module's contribution after the linker concatenates it.
+    var rnglists_sec: u32 = 0;
+    var rnglists_anchor: intern.StrId = intern.STR_NIL;
+    if (has_rnglists) {
+        val n_rl: R.Result[intern.StrId, str] = intern.intern(itn, ".debug_rnglists");
+        if (R.is_err[intern.StrId, str](n_rl)) { ret R.err[bool, str](R.unwrap_err[intern.StrId, str](n_rl)); }
+        val rrl: R.Result[u32, str] = add_debug_section(image, R.unwrap_ok[intern.StrId, str](n_rl), b_rnglists);
+        if (R.is_err[u32, str](rrl)) { ret R.err[bool, str](R.unwrap_err[u32, str](rrl)); }
+        rnglists_sec = R.unwrap_ok[u32, str](rrl);
+        val rlanchor_r: R.Result[intern.StrId, str] = intern_anchor(itn, resolve(itn, image.name), ".debug_rnglists");
+        if (R.is_err[intern.StrId, str](rlanchor_r)) { ret R.err[bool, str](R.unwrap_err[intern.StrId, str](rlanchor_r)); }
+        rnglists_anchor = R.unwrap_ok[intern.StrId, str](rlanchor_r);
+        val rlar: R.Result[u32, str] = add_anchor(image, rnglists_anchor, rnglists_sec);
+        if (R.is_err[u32, str](rlar)) { ret R.err[bool, str](R.unwrap_err[u32, str](rlar)); }
+    }
+
     # .debug_info: low_pc -> the CU's lowest subprogram function (abs64), stmt_list ->
     # .debug_line (abs32).
     val r1: R.Result[bool, str] = add_reloc(image, info_sec, low_off, of.RK_ABS64, cu_low_name);
@@ -2179,6 +2298,7 @@ fun install(s: *session.Session, image: *of.ObjectImage, itn: *intern.Interner,
         var sym: intern.StrId = ir2.sym;
         if (ir2.target == IRLT_STR)     { sym = str_anchor; }
         or (ir2.target == IRLT_LOCLIST) { sym = loclists_anchor; }
+        or (ir2.target == IRLT_RNGLIST) { sym = rnglists_anchor; }
         val rk: R.Result[bool, str] = add_reloc_addend(image, info_sec, ir2.off, ir2.kind, sym, ir2.addend);
         if (R.is_err[bool, str](rk)) { ret rk; }
         k = k + 1;
@@ -2191,6 +2311,15 @@ fun install(s: *session.Session, image: *of.ObjectImage, itn: *intern.Interner,
         val rlrx: R.Result[bool, str] = add_reloc(image, loclists_sec, lr.off, of.RK_ABS64, lr.sym);
         if (R.is_err[bool, str](rlrx)) { ret rlrx; }
         li = li + 1;
+    }
+
+    # .debug_rnglists: each DW_RLE_base_address -> its instance's enclosing function (abs64).
+    var ri3: u32 = 0;
+    for (ri3 < rng_reloc_count) {
+        val rr3: *RngReloc = ?rng_relocs[ri3];
+        val rrx: R.Result[bool, str] = add_reloc(image, rnglists_sec, rr3.off, of.RK_ABS64, rr3.sym);
+        if (R.is_err[bool, str](rrx)) { ret rrx; }
+        ri3 = ri3 + 1;
     }
 
     # .debug_line: one DW_LNE_set_address (abs64) per function.

--- a/src/lang/be/codegen/dwarf.mach
+++ b/src/lang/be/codegen/dwarf.mach
@@ -52,6 +52,7 @@ val DW_TAG_base_type:        u8 = 0x24;
 val DW_TAG_subprogram:       u8 = 0x2e;
 val DW_TAG_formal_parameter: u8 = 0x05;
 val DW_TAG_variable:         u8 = 0x34;
+val DW_TAG_inlined_subroutine: u8 = 0x1d;
 val DW_CHILDREN_no:          u8 = 0x00;
 val DW_CHILDREN_yes:         u8 = 0x01;
 
@@ -70,6 +71,16 @@ val DW_AT_type:       u8 = 0x49;
 val DW_AT_location:   u8 = 0x02;
 val DW_AT_decl_file:  u8 = 0x3a;
 val DW_AT_decl_line:  u8 = 0x3b;
+val DW_AT_ranges:          u8 = 0x55;
+val DW_AT_abstract_origin: u8 = 0x31;
+val DW_AT_inline:          u8 = 0x20;
+val DW_AT_call_file:       u8 = 0x58;
+val DW_AT_call_line:       u8 = 0x59;
+
+# DW_AT_inline value: this subprogram is an abstract instance that was inlined (never
+# out-of-line here); its concrete expansions are DW_TAG_inlined_subroutine DIEs that
+# reference it by DW_AT_abstract_origin.
+val DW_INL_inlined:   u8 = 0x01;
 
 val DW_FORM_addr:       u8 = 0x01;
 val DW_FORM_data2:      u8 = 0x05;
@@ -99,6 +110,13 @@ val DW_ATE_unsigned: u8 = 0x07;
 val DW_LLE_end_of_list:  u8 = 0x00;
 val DW_LLE_base_address: u8 = 0x06;
 val DW_LLE_offset_pair:  u8 = 0x04;
+
+# DWARF 5 range-list entry codes for `.debug_rnglists`; an inlined instance's
+# DW_AT_ranges names a list of DW_RLE_base_address (its enclosing function's low_pc)
+# then DW_RLE_offset_pair per contiguous `.text` extent, closed by DW_RLE_end_of_list
+val DW_RLE_end_of_list:  u8 = 0x00;
+val DW_RLE_base_address: u8 = 0x05;
+val DW_RLE_offset_pair:  u8 = 0x04;
 
 val DW_OP_reg0:        u8 = 0x50;
 val DW_OP_breg0:       u8 = 0x70;

--- a/src/lang/be/codegen/dwarf.mach
+++ b/src/lang/be/codegen/dwarf.mach
@@ -1408,7 +1408,8 @@ fun add_reloc_addend(image: *of.ObjectImage, sec: u32, offset: u32, kind: of.Rel
 # ret:      ok(true) on success, or an allocation error
 pub fun produce(s: *session.Session, tgt: *target.Target, irmod: *ir.Module,
                 image: *of.ObjectImage, rows: *enc.LineRow, row_count: u32,
-                varlocs: *enc.VarLoc, varloc_count: u32, text_sec: u32) R.Result[bool, str] {
+                varlocs: *enc.VarLoc, varloc_count: u32,
+                inline_pcs: *enc.InlinePc, inline_pc_count: u32, text_sec: u32) R.Result[bool, str] {
     val nfuncs: u32 = count_funcs(image, text_sec);
     if (nfuncs == 0) { ret R.ok[bool, str](true); }
 
@@ -1550,6 +1551,37 @@ pub fun produce(s: *session.Session, tgt: *target.Target, irmod: *ir.Module,
     var b_line:     enc.ByteBuf = enc.buf_init(s.alloc);
     var b_info:     enc.ByteBuf = enc.buf_init(s.alloc);
     var b_loclists: enc.ByteBuf = enc.buf_init(s.alloc);
+    var b_rnglists: enc.ByteBuf = enc.buf_init(s.alloc);
+
+    # inlined-subroutine instances: gathered before build_line so their call-site files
+    # are registered in the file table the line header emits. capacity is bounded by the
+    # transition count (each starts at most one instance-range).
+    var inl_cap: u32 = inline_pc_count;
+    if (inl_cap == 0) { inl_cap = 1; }
+    val rinl: R.Result[*DwInline, str] = A.allocate[DwInline](s.alloc, inl_cap::usize);
+    if (R.is_err[*DwInline, str](rinl)) {
+        enc.buf_dnit(?b_rnglists); enc.buf_dnit(?b_loclists); enc.buf_dnit(?b_info); enc.buf_dnit(?b_line); enc.buf_dnit(?b_abbrev); enc.buf_dnit(?strtab.buf);
+        A.deallocate[LocReloc](s.alloc, loc_relocs, loc_reloc_cap::usize); A.deallocate[InfoReloc](s.alloc, info_relocs, reloc_cap::usize);
+        A.deallocate[u32](s.alloc, addr_off, nfuncs::usize); A.deallocate[BaseType](s.alloc, bts, MAX_BASE_TYPES::usize);
+        A.deallocate[LocRange](s.alloc, ranges, range_cap::usize); A.deallocate[DwVar](s.alloc, vars, var_cap::usize);
+        A.deallocate[DwFunc](s.alloc, subs, nfuncs::usize); A.deallocate[DwFunc](s.alloc, funcs, nfuncs::usize);
+        ret R.err[bool, str](R.unwrap_err[*DwInline, str](rinl));
+    }
+    val inlines: *DwInline = R.unwrap_ok[*DwInline, str](rinl);
+    val rirng: R.Result[*DwInlineRange, str] = A.allocate[DwInlineRange](s.alloc, inl_cap::usize);
+    if (R.is_err[*DwInlineRange, str](rirng)) {
+        A.deallocate[DwInline](s.alloc, inlines, inl_cap::usize);
+        enc.buf_dnit(?b_rnglists); enc.buf_dnit(?b_loclists); enc.buf_dnit(?b_info); enc.buf_dnit(?b_line); enc.buf_dnit(?b_abbrev); enc.buf_dnit(?strtab.buf);
+        A.deallocate[LocReloc](s.alloc, loc_relocs, loc_reloc_cap::usize); A.deallocate[InfoReloc](s.alloc, info_relocs, reloc_cap::usize);
+        A.deallocate[u32](s.alloc, addr_off, nfuncs::usize); A.deallocate[BaseType](s.alloc, bts, MAX_BASE_TYPES::usize);
+        A.deallocate[LocRange](s.alloc, ranges, range_cap::usize); A.deallocate[DwVar](s.alloc, vars, var_cap::usize);
+        A.deallocate[DwFunc](s.alloc, subs, nfuncs::usize); A.deallocate[DwFunc](s.alloc, funcs, nfuncs::usize);
+        ret R.err[bool, str](R.unwrap_err[*DwInlineRange, str](rirng));
+    }
+    val iranges: *DwInlineRange = R.unwrap_ok[*DwInlineRange, str](rirng);
+    var ninl: u32 = 0;
+    var nir:  u32 = 0;
+    gather_inlines(s, irmod, subs, nsub, inline_pcs, inline_pc_count, text_sec, ?ft, inlines, ?ninl, inl_cap, iranges, ?nir, inl_cap);
 
     build_abbrev(?b_abbrev);
     build_line(s, funcs, nfuncs, rows, row_count, text_sec, address_size, comp_dir, ?ft, ?b_line, addr_off);
@@ -1572,7 +1604,10 @@ pub fun produce(s: *session.Session, tgt: *target.Target, irmod: *ir.Module,
     enc.buf_dnit(?b_line);
     enc.buf_dnit(?b_info);
     enc.buf_dnit(?b_loclists);
+    enc.buf_dnit(?b_rnglists);
     enc.buf_dnit(?strtab.buf);
+    A.deallocate[DwInlineRange](s.alloc, iranges, inl_cap::usize);
+    A.deallocate[DwInline](s.alloc, inlines, inl_cap::usize);
     A.deallocate[LocReloc](s.alloc, loc_relocs, loc_reloc_cap::usize);
     A.deallocate[InfoReloc](s.alloc, info_relocs, reloc_cap::usize);
     A.deallocate[u32](s.alloc, addr_off, nfuncs::usize);
@@ -1674,7 +1709,7 @@ fun gather_subprograms(s: *session.Session, tgt: *target.Target, irmod: *ir.Modu
 # out:      the DwInline array to fill; ninl is its running count (in/out), inl_cap its cap
 # iranges:  the shared DwInlineRange array; nir its running count (in/out), ir_cap its cap
 fun gather_inlines(s: *session.Session, irmod: *ir.Module, funcs: *DwFunc, nfuncs: u32,
-                   inline_pcs: *enc.InlinePc, inline_pc_count: u32, ft: *FileTable,
+                   inline_pcs: *enc.InlinePc, inline_pc_count: u32, text_sec: u32, ft: *FileTable,
                    out: *DwInline, ninl: *u32, inl_cap: u32,
                    iranges: *DwInlineRange, nir: *u32, ir_cap: u32) {
     var i: u32 = 0;
@@ -1711,9 +1746,9 @@ fun gather_inlines(s: *session.Session, irmod: *ir.Module, funcs: *DwFunc, nfunc
             var j: u32 = 0;
             for (j < inline_pc_count) {
                 val o: u32 = inline_pcs[j].text_offset;
-                if (o >= lo && o < hi && inline_pcs[j].inline_site == k) {
+                if (inline_pcs[j].sec == text_sec && o >= lo && o < hi && inline_pcs[j].inline_site == k) {
                     var seg_end: u32 = hi;
-                    if (j + 1 < inline_pc_count && inline_pcs[j + 1].text_offset < hi) { seg_end = inline_pcs[j + 1].text_offset; }
+                    if (j + 1 < inline_pc_count && inline_pcs[j + 1].sec == text_sec && inline_pcs[j + 1].text_offset < hi && inline_pcs[j + 1].text_offset > o) { seg_end = inline_pcs[j + 1].text_offset; }
                     if (@nir < ir_cap) {
                         iranges[@nir].start = o;
                         iranges[@nir].end   = seg_end;

--- a/src/lang/be/codegen/dwarf.mach
+++ b/src/lang/be/codegen/dwarf.mach
@@ -327,6 +327,41 @@ rec LocRange {
     net:   i64;
 }
 
+# one inlined-subroutine instance, emitted as a DW_TAG_inlined_subroutine nested under
+# its enclosing subprogram (or parent instance). Its `.text` extents come from the
+# encoder's InlinePc transitions; a single contiguous extent uses DW_AT_low_pc /
+# DW_AT_high_pc, multiple extents use DW_AT_ranges into `.debug_rnglists`.
+# ---
+# func_idx:    index of the enclosing DwFunc (subprogram) in the subs array
+# callee:      inlined callee's symbol name (DW_AT_abstract_origin target)
+# origin_off:  `.debug_info` offset of the callee's abstract-instance subprogram DIE
+# call_file:   1-based DWARF file index of the call site (DW_AT_call_file)
+# call_line:   1-based source line of the call site (DW_AT_call_line)
+# parent:      enclosing instance's 1-based site id within the same function (0 = directly
+#              under the subprogram), for nested inlines
+# site_id:     this instance's 1-based ir inline-site id (matches InlinePc.inline_site)
+# range_start/range_count: this instance's extents in the shared DwInlineRange array
+# rnglist_off: byte offset of this instance's `.debug_rnglists` list (multi-extent only)
+rec DwInline {
+    func_idx:    u32;
+    callee:      intern.StrId;
+    origin_off:  u32;
+    call_file:   u32;
+    call_line:   u32;
+    parent:      u32;
+    site_id:     u32;
+    range_start: u32;
+    range_count: u32;
+    rnglist_off: u32;
+}
+
+# one contiguous `.text` extent `[start, end)` of an inlined instance (absolute byte
+# offsets, like LocRange)
+rec DwInlineRange {
+    start: u32;
+    end:   u32;
+}
+
 # whether two non-optimized-out homes name the same location. the single-location
 # tier keeps an inline exprloc only when every one of a variable's real bindings agrees
 # under this predicate; a disagreement makes the variable a VLOC_LOCLIST
@@ -1618,6 +1653,79 @@ fun gather_subprograms(s: *session.Session, tgt: *target.Target, irmod: *ir.Modu
             gather_vars(s, tgt, irfn, fn.offset, fn.offset + fn.size, varlocs, varloc_count, text_sec,
                         address_size, bts, nbt, strtab, vars, var_count, var_cap, ranges, range_count, range_cap);
             fn.var_count = @var_count - fn.var_start;
+        }
+        i = i + 1;
+    }
+}
+
+# gather each function's inlined-subroutine instances from the encoder's InlinePc
+# transitions joined with the IR inline-site pool. Every ir inline-site that has emitted
+# `.text` becomes a DwInline whose extents are the transition segments tagged with that
+# site (record j at o_j governs `[o_j, next_within_fn)`); the site's call location gives
+# DW_AT_call_file / DW_AT_call_line. Instances with no surviving `.text` (fully folded
+# away) are dropped. The linear-order range reasoning inherits the #1904 fidelity caveat.
+# ---
+# s:        session (interner + file positions)
+# irmod:    the IR module (inline-site pools)
+# funcs:    the subprogram DwFuncs (offset / size / name)
+# nfuncs:   number of subprograms
+# inline_pcs/inline_pc_count: the encoder's inline-instance transitions
+# ft:       the file table (call-site files are indexed in)
+# out:      the DwInline array to fill; ninl is its running count (in/out), inl_cap its cap
+# iranges:  the shared DwInlineRange array; nir its running count (in/out), ir_cap its cap
+fun gather_inlines(s: *session.Session, irmod: *ir.Module, funcs: *DwFunc, nfuncs: u32,
+                   inline_pcs: *enc.InlinePc, inline_pc_count: u32, ft: *FileTable,
+                   out: *DwInline, ninl: *u32, inl_cap: u32,
+                   iranges: *DwInlineRange, nir: *u32, ir_cap: u32) {
+    var i: u32 = 0;
+    for (i < nfuncs) {
+        val opt_idx: O.Option[u32] = ir.function_lookup(irmod, funcs[i].name);
+        if (O.is_none[u32](opt_idx)) { i = i + 1; cnt; }
+        val irfn: *ir.Function = ?irmod.functions[O.unwrap[u32](opt_idx)];
+        if (irfn.inline_site_len == 0) { i = i + 1; cnt; }
+        val lo: u32 = funcs[i].offset;
+        val hi: u32 = funcs[i].offset + funcs[i].size;
+
+        var k: u32 = 1;
+        for (k <= irfn.inline_site_len) {
+            if (@ninl >= inl_cap) { brk; }
+            val site: *ir.InlineSite = ?irfn.inline_sites[k - 1];
+            val di: *DwInline = ?out[@ninl];
+            di.func_idx    = i;
+            di.callee      = site.callee;
+            di.origin_off  = 0;
+            di.parent      = site.parent;
+            di.site_id     = k;
+            di.range_start = @nir;
+            di.range_count = 0;
+            di.rnglist_off = 0;
+            di.call_file   = 0;
+            di.call_line   = 0;
+            if (source.loc_is_valid(site.call_loc)) {
+                file_index(ft, site.call_loc.file);
+                val pl: PosLine = pos_of(s, site.call_loc, ft);
+                di.call_file = pl.file;
+                di.call_line = pl.line::u32;
+            }
+
+            var j: u32 = 0;
+            for (j < inline_pc_count) {
+                val o: u32 = inline_pcs[j].text_offset;
+                if (o >= lo && o < hi && inline_pcs[j].inline_site == k) {
+                    var seg_end: u32 = hi;
+                    if (j + 1 < inline_pc_count && inline_pcs[j + 1].text_offset < hi) { seg_end = inline_pcs[j + 1].text_offset; }
+                    if (@nir < ir_cap) {
+                        iranges[@nir].start = o;
+                        iranges[@nir].end   = seg_end;
+                        @nir = @nir + 1;
+                        di.range_count = di.range_count + 1;
+                    }
+                }
+                j = j + 1;
+            }
+
+            if (di.range_count > 0) { @ninl = @ninl + 1; }
+            k = k + 1;
         }
         i = i + 1;
     }

--- a/src/lang/be/codegen/dwarf.mach
+++ b/src/lang/be/codegen/dwarf.mach
@@ -154,6 +154,13 @@ val ABBREV_PARAM_NOLOC:     u8 = 0x08;
 val ABBREV_VARIABLE_LOCLIST: u8 = 0x09;
 val ABBREV_PARAM_LOCLIST:    u8 = 0x0a;
 
+# inlining tier: an abstract-instance subprogram (name + DW_AT_inline, no code range) the
+# inlined_subroutine DIEs reference, and the two inlined_subroutine shapes -- a single
+# contiguous extent (low_pc/high_pc) or a range list (DW_AT_ranges into `.debug_rnglists`)
+val ABBREV_SUBPROGRAM_ABSTRACT: u8 = 0x0b;
+val ABBREV_INLINED:             u8 = 0x0c;
+val ABBREV_INLINED_RANGES:      u8 = 0x0d;
+
 # DWARF 5 line-number program: standard opcodes, extended opcodes, and the tuned
 # special-opcode parameters this producer emits
 val DW_LNS_copy:         u8 = 0x01;
@@ -698,7 +705,45 @@ fun build_abbrev(b: *enc.ByteBuf) {
     build_var_loclist_abbrev(b, ABBREV_VARIABLE_LOCLIST, DW_TAG_variable);
     build_var_loclist_abbrev(b, ABBREV_PARAM_LOCLIST,    DW_TAG_formal_parameter);
 
+    # abstract-instance subprogram: name (strp) + DW_AT_inline (data1), no code range and
+    # (this tier) no children; the dbg-clone increment gives it abstract locals + children.
+    uleb(b, ABBREV_SUBPROGRAM_ABSTRACT::u64);
+    uleb(b, DW_TAG_subprogram::u64);
+    enc.emit_byte(b, DW_CHILDREN_no);
+    emit_attr(b, DW_AT_name,   DW_FORM_strp);
+    emit_attr(b, DW_AT_inline, DW_FORM_data1);
+    uleb(b, 0); uleb(b, 0);
+
+    # inlined_subroutine, contiguous-extent and range-list shapes.
+    build_inlined_abbrev(b, ABBREV_INLINED,        false);
+    build_inlined_abbrev(b, ABBREV_INLINED_RANGES, true);
+
     uleb(b, 0);   # null abbrev code terminates the table
+}
+
+# emit one DW_TAG_inlined_subroutine abbreviation. `ranges` selects DW_AT_ranges
+# (sec_offset into `.debug_rnglists`) for a non-contiguous instance, else an inline
+# DW_AT_low_pc / DW_AT_high_pc pair. No children this tier (flat, no inlined locals); the
+# dbg-clone / nesting increment adds a children-bearing shape.
+# ---
+# b:      the abbrev buffer
+# code:   the abbreviation code
+# ranges: true for the DW_AT_ranges shape, false for the low_pc/high_pc shape
+fun build_inlined_abbrev(b: *enc.ByteBuf, code: u8, ranges: bool) {
+    uleb(b, code::u64);
+    uleb(b, DW_TAG_inlined_subroutine::u64);
+    enc.emit_byte(b, DW_CHILDREN_no);
+    emit_attr(b, DW_AT_abstract_origin, DW_FORM_ref4);
+    if (ranges) {
+        emit_attr(b, DW_AT_ranges,  DW_FORM_sec_offset);
+    }
+    or {
+        emit_attr(b, DW_AT_low_pc,  DW_FORM_addr);
+        emit_attr(b, DW_AT_high_pc, DW_FORM_data8);
+    }
+    emit_attr(b, DW_AT_call_file, DW_FORM_udata);
+    emit_attr(b, DW_AT_call_line, DW_FORM_udata);
+    uleb(b, 0); uleb(b, 0);
 }
 
 # emit one subprogram abbreviation (now with children: its parameters and locals).
@@ -779,7 +824,9 @@ fun build_var_loclist_abbrev(b: *enc.ByteBuf, code: u8, tag: u8) {
 # stmt_off:     out - byte offset of the CU 4-byte stmt_list field
 fun build_info(b: *enc.ByteBuf, address_size: u8, producer: str, name: str, comp_dir: str,
                high_pc: u64, fb_reg: i32, funcs: *DwFunc, nfuncs: u32, bts: *BaseType, nbt: u32,
-               vars: *DwVar, relocs: *InfoReloc, reloc_count: *u32, low_off: *u32, stmt_off: *u32) {
+               vars: *DwVar, relocs: *InfoReloc, reloc_count: *u32, low_off: *u32, stmt_off: *u32,
+               s: *session.Session, irmod: *ir.Module, strtab: *StrTab,
+               inlines: *DwInline, ninl: u32, iranges: *DwInlineRange) {
     val len_pos: usize = b.len;
     enc.emit_u32(b, 0);                 # unit_length (backpatched)
     val body_start: usize = b.len;
@@ -811,6 +858,28 @@ fun build_info(b: *enc.ByteBuf, address_size: u8, producer: str, name: str, comp
         t = t + 1;
     }
 
+    # abstract-instance subprograms for the inlined callees, before the concrete
+    # subprograms so each inlined_subroutine references its origin backward. One per
+    # instance (no dedup yet); DW_AT_name is the callee's source spelling.
+    var ai: u32 = 0;
+    for (ai < ninl) {
+        # only the instances the subprogram loop emits (single-extent, top-level) get an
+        # abstract instance this tier; the rest are held for the rnglists / nesting commits.
+        if (inlines[ai].range_count != 1 || inlines[ai].parent != 0) { ai = ai + 1; cnt; }
+        var cnm: str = resolve(?s.interner, inlines[ai].callee);
+        val oi: O.Option[u32] = ir.function_lookup(irmod, inlines[ai].callee);
+        if (O.is_some[u32](oi)) {
+            val cf: *ir.Function = ?irmod.functions[O.unwrap[u32](oi)];
+            if (cf.disp != intern.STR_NIL) { cnm = resolve(?s.interner, cf.disp); }
+        }
+        inlines[ai].origin_off = (b.len - len_pos)::u32;
+        enc.emit_byte(b, ABBREV_SUBPROGRAM_ABSTRACT);
+        push_info_reloc(relocs, reloc_count, b.len::u32, of.RK_ABS32, IRLT_STR, intern.STR_NIL, str_off(strtab, cnm)::i64);
+        enc.emit_u32(b, 0);                # DW_AT_name (strp)
+        enc.emit_byte(b, DW_INL_inlined);  # DW_AT_inline (no children this tier)
+        ai = ai + 1;
+    }
+
     # one subprogram DIE per function.
     var f: u32 = 0;
     for (f < nfuncs) {
@@ -828,12 +897,33 @@ fun build_info(b: *enc.ByteBuf, address_size: u8, producer: str, name: str, comp
         emit_frame_base(b, fb_reg);
         if (fn.ret_bt >= 0) { enc.emit_u32(b, bts[fn.ret_bt::u32].off); }   # DW_AT_type (ref4)
 
-        # the subprogram's variable / parameter children, then a null DIE.
+        # the subprogram's variable / parameter children.
         var vi: u32 = 0;
         for (vi < fn.var_count) {
             emit_variable(b, ?vars[fn.var_start + vi], bts, relocs, reloc_count);
             vi = vi + 1;
         }
+
+        # its inlined_subroutine children. This tier emits the single-extent, top-level
+        # instances only -- exact low_pc/high_pc, non-overlapping. Multi-extent instances
+        # (exact DW_AT_ranges into `.debug_rnglists`) and nested instances (parent != 0,
+        # emitted under their parent's DIE) ship in the following commits; emitting them
+        # flat with a span approximation would overlap sibling ranges, so they are held.
+        var xi: u32 = 0;
+        for (xi < ninl) {
+            if (inlines[xi].func_idx != f || inlines[xi].range_count != 1 || inlines[xi].parent != 0) { xi = xi + 1; cnt; }
+            val di: *DwInline = ?inlines[xi];
+            val rg: *DwInlineRange = ?iranges[di.range_start];
+            enc.emit_byte(b, ABBREV_INLINED);
+            enc.emit_u32(b, di.origin_off);   # DW_AT_abstract_origin (ref4, backward)
+            push_info_reloc(relocs, reloc_count, b.len::u32, of.RK_ABS64, IRLT_SYM, fn.name, (rg.start - fn.offset)::i64);
+            emit_addr(b, address_size);        # DW_AT_low_pc (enclosing fn + range start)
+            enc.emit_u64(b, (rg.end - rg.start)::u64);   # DW_AT_high_pc
+            uleb(b, di.call_file::u64);
+            uleb(b, di.call_line::u64);
+            xi = xi + 1;
+        }
+
         enc.emit_byte(b, 0);   # null DIE terminates this subprogram's children
         f = f + 1;
     }
@@ -1521,7 +1611,9 @@ pub fun produce(s: *session.Session, tgt: *target.Target, irmod: *ir.Module,
 
     # the `.debug_info` reloc list: 2 CU + 2 per subprogram (name strp, low_pc addr) +
     # 1 per base type (name strp) + up to 2 per variable (name strp, loclist sec_offset).
-    val reloc_cap: u32 = 2 + 2 * nsub + nbt + 2 * var_count;
+    # + 2 per inlined instance (abstract-instance name strp, inlined_subroutine low_pc
+    # sym); bounded by the transition count, an upper bound on the instance count.
+    val reloc_cap: u32 = 2 + 2 * nsub + nbt + 2 * var_count + 2 * inline_pc_count;
     val rr2: R.Result[*InfoReloc, str] = A.allocate[InfoReloc](s.alloc, reloc_cap::usize);
     if (R.is_err[*InfoReloc, str](rr2)) {
         A.deallocate[u32](s.alloc, addr_off, nfuncs::usize); enc.buf_dnit(?strtab.buf);
@@ -1593,7 +1685,8 @@ pub fun produce(s: *session.Session, tgt: *target.Target, irmod: *ir.Module,
     var low_off:  u32 = 0;
     var stmt_off: u32 = 0;
     build_info(?b_info, address_size, producer, name, comp_dir, high_pc, frame_base_reg(tgt),
-               subs, nsub, bts, nbt, vars, info_relocs, ?info_reloc_count, ?low_off, ?stmt_off);
+               subs, nsub, bts, nbt, vars, info_relocs, ?info_reloc_count, ?low_off, ?stmt_off,
+               s, irmod, ?strtab, inlines, ninl, iranges);
 
     val pr: R.Result[bool, str] = install(s, image, itn, funcs, nfuncs, cu_low_name,
                                           ?b_abbrev, ?b_line, ?b_info, ?strtab.buf, ?b_loclists, has_loclists,
@@ -2161,15 +2254,16 @@ test "mach.lang.be.codegen.dwarf.uleb_sleb:canonical" {
     ret code;
 }
 
-# build_abbrev emits the exact ten-abbrev table (compile-unit, base type, the two
-# subprogram shapes, the located / no-location variable + parameter shapes, and the two
-# loclist variable + parameter shapes), byte for byte
+# build_abbrev emits the exact thirteen-abbrev table (compile-unit, base type, the two
+# subprogram shapes, the located / no-location variable + parameter shapes, the two
+# loclist variable + parameter shapes, the abstract-instance subprogram, and the two
+# inlined_subroutine shapes), byte for byte
 test "mach.lang.be.codegen.dwarf.build_abbrev:golden" {
     var alloc: A.Allocator;
     page.make(?alloc);
     var b: enc.ByteBuf = enc.buf_init(?alloc);
     build_abbrev(?b);
-    var e: [133]u8;
+    var e: [170]u8;
     e[0]=0x01; e[1]=0x11; e[2]=0x01; e[3]=0x25; e[4]=0x08; e[5]=0x03; e[6]=0x08; e[7]=0x1B;
     e[8]=0x08; e[9]=0x13; e[10]=0x05; e[11]=0x11; e[12]=0x01; e[13]=0x12; e[14]=0x07; e[15]=0x10;
     e[16]=0x17; e[17]=0x00; e[18]=0x00; e[19]=0x02; e[20]=0x24; e[21]=0x00; e[22]=0x03; e[23]=0x0E;
@@ -2190,8 +2284,19 @@ test "mach.lang.be.codegen.dwarf.build_abbrev:golden" {
     # ABBREV_PARAM_LOCLIST (0x0A): DW_TAG_formal_parameter, name strp, type ref4, location sec_offset.
     e[121]=0x0A; e[122]=0x05; e[123]=0x00; e[124]=0x03; e[125]=0x0E; e[126]=0x49; e[127]=0x13;
     e[128]=0x02; e[129]=0x17; e[130]=0x00; e[131]=0x00;
-    e[132]=0x00;   # null abbrev code terminates the table
-    val ok: bool = buf_eq(?b, ?e[0], 133);
+    # ABBREV_SUBPROGRAM_ABSTRACT (0x0B): DW_TAG_subprogram, no children, name strp, DW_AT_inline data1.
+    e[132]=0x0B; e[133]=0x2E; e[134]=0x00; e[135]=0x03; e[136]=0x0E; e[137]=0x20; e[138]=0x0B;
+    e[139]=0x00; e[140]=0x00;
+    # ABBREV_INLINED (0x0C): DW_TAG_inlined_subroutine, no children, abstract_origin ref4,
+    # low_pc addr, high_pc data8, call_file udata, call_line udata.
+    e[141]=0x0C; e[142]=0x1D; e[143]=0x00; e[144]=0x31; e[145]=0x13; e[146]=0x11; e[147]=0x01;
+    e[148]=0x12; e[149]=0x07; e[150]=0x58; e[151]=0x0F; e[152]=0x59; e[153]=0x0F; e[154]=0x00; e[155]=0x00;
+    # ABBREV_INLINED_RANGES (0x0D): DW_TAG_inlined_subroutine, no children, abstract_origin ref4,
+    # ranges sec_offset, call_file udata, call_line udata.
+    e[156]=0x0D; e[157]=0x1D; e[158]=0x00; e[159]=0x31; e[160]=0x13; e[161]=0x55; e[162]=0x17;
+    e[163]=0x58; e[164]=0x0F; e[165]=0x59; e[166]=0x0F; e[167]=0x00; e[168]=0x00;
+    e[169]=0x00;   # null abbrev code terminates the table
+    val ok: bool = buf_eq(?b, ?e[0], 170);
     enc.buf_dnit(?b);
     if (!ok) { ret 1; }
     ret 0;

--- a/src/lang/be/codegen/dwarf.mach
+++ b/src/lang/be/codegen/dwarf.mach
@@ -314,6 +314,9 @@ rec DwVar {
     range_start: u32;
     range_count: u32;
     loclist_off: u32;
+    # the inline instance this variable belongs to (0 = the function's own body, else a
+    # 1-based inline-site id); the #1707 producer nests a non-zero one under its instance
+    inline_site: u32;
 }
 
 # one PC-range of a VLOC_LOCLIST variable: over `[start, end)` (absolute `.text` byte
@@ -847,14 +850,18 @@ fun build_var_loclist_abbrev(b: *enc.ByteBuf, code: u8, tag: u8) {
 # fn:           the enclosing DwFunc (symbol name + `.text` offset)
 # address_size: target pointer width
 fun emit_inlines(b: *enc.ByteBuf, f: u32, parent_site: u32, inlines: *DwInline, ninl: u32,
-                 iranges: *DwInlineRange, relocs: *InfoReloc, reloc_count: *u32, fn: *DwFunc, address_size: u8) {
+                 iranges: *DwInlineRange, relocs: *InfoReloc, reloc_count: *u32, fn: *DwFunc, address_size: u8,
+                 vars: *DwVar, bts: *BaseType) {
     var xi: u32 = 0;
     for (xi < ninl) {
         if (inlines[xi].func_idx != f || inlines[xi].parent != parent_site) { xi = xi + 1; cnt; }
         val di: *DwInline = ?inlines[xi];
+        # children = nested inlines and/or inlined locals living in this instance.
         var kids: bool = false;
         var ck: u32 = 0;
         for (ck < ninl) { if (inlines[ck].func_idx == f && inlines[ck].parent == di.site_id) { kids = true; } ck = ck + 1; }
+        var cv: u32 = 0;
+        for (cv < fn.var_count) { if (vars[fn.var_start + cv].inline_site == di.site_id) { kids = true; } cv = cv + 1; }
 
         if (di.range_count == 1) {
             if (kids) { enc.emit_byte(b, ABBREV_INLINED_KIDS); } or { enc.emit_byte(b, ABBREV_INLINED); }
@@ -874,7 +881,13 @@ fun emit_inlines(b: *enc.ByteBuf, f: u32, parent_site: u32, inlines: *DwInline, 
         uleb(b, di.call_line::u64);
 
         if (kids) {
-            emit_inlines(b, f, di.site_id, inlines, ninl, iranges, relocs, reloc_count, fn, address_size);
+            # this instance's inlined locals, then its nested inlines, then the terminator.
+            var vv: u32 = 0;
+            for (vv < fn.var_count) {
+                if (vars[fn.var_start + vv].inline_site == di.site_id) { emit_variable(b, ?vars[fn.var_start + vv], bts, relocs, reloc_count); }
+                vv = vv + 1;
+            }
+            emit_inlines(b, f, di.site_id, inlines, ninl, iranges, relocs, reloc_count, fn, address_size, vars, bts);
             enc.emit_byte(b, 0);   # null DIE terminates this instance's children
         }
         xi = xi + 1;
@@ -972,16 +985,17 @@ fun build_info(b: *enc.ByteBuf, address_size: u8, producer: str, name: str, comp
         emit_frame_base(b, fb_reg);
         if (fn.ret_bt >= 0) { enc.emit_u32(b, bts[fn.ret_bt::u32].off); }   # DW_AT_type (ref4)
 
-        # the subprogram's variable / parameter children.
+        # the subprogram's own variable / parameter children (inline instance 0); an
+        # inlined local (instance != 0) is emitted under its inlined_subroutine instead.
         var vi: u32 = 0;
         for (vi < fn.var_count) {
-            emit_variable(b, ?vars[fn.var_start + vi], bts, relocs, reloc_count);
+            if (vars[fn.var_start + vi].inline_site == 0) { emit_variable(b, ?vars[fn.var_start + vi], bts, relocs, reloc_count); }
             vi = vi + 1;
         }
 
         # its inlined_subroutine children, as a tree by inline-instance parent (top-level
         # instances directly under the subprogram, nested instances under their parent).
-        emit_inlines(b, f, 0, inlines, ninl, iranges, relocs, reloc_count, fn, address_size);
+        emit_inlines(b, f, 0, inlines, ninl, iranges, relocs, reloc_count, fn, address_size, vars, bts);
 
         enc.emit_byte(b, 0);   # null DIE terminates this subprogram's children
         f = f + 1;
@@ -2051,6 +2065,9 @@ fun gather_vars(s: *session.Session, tgt: *target.Target, irfn: *ir.Function, lo
             vars[@var_count].range_start = 0;
             vars[@var_count].range_count = 0;
             vars[@var_count].loclist_off = 0;
+            # the inline instance this variable lives in (0 = the caller's own body); the
+            # #1707 producer nests a non-zero one under its inlined_subroutine.
+            vars[@var_count].inline_site = ir.instr_inline_site_of(irfn, vl.iid::id.InstructionId);
             @var_count = @var_count + 1;
         }
         i = i + 1;

--- a/src/lang/be/codegen/dwarf.mach
+++ b/src/lang/be/codegen/dwarf.mach
@@ -160,6 +160,9 @@ val ABBREV_PARAM_LOCLIST:    u8 = 0x0a;
 val ABBREV_SUBPROGRAM_ABSTRACT: u8 = 0x0b;
 val ABBREV_INLINED:             u8 = 0x0c;
 val ABBREV_INLINED_RANGES:      u8 = 0x0d;
+# children-bearing shapes, used when an instance has nested inlines / (later) inlined locals
+val ABBREV_INLINED_KIDS:        u8 = 0x0e;
+val ABBREV_INLINED_RANGES_KIDS: u8 = 0x0f;
 
 # DWARF 5 line-number program: standard opcodes, extended opcodes, and the tuned
 # special-opcode parameters this producer emits
@@ -735,25 +738,30 @@ fun build_abbrev(b: *enc.ByteBuf) {
     emit_attr(b, DW_AT_inline, DW_FORM_data1);
     uleb(b, 0); uleb(b, 0);
 
-    # inlined_subroutine, contiguous-extent and range-list shapes.
-    build_inlined_abbrev(b, ABBREV_INLINED,        false);
-    build_inlined_abbrev(b, ABBREV_INLINED_RANGES, true);
+    # inlined_subroutine, contiguous / range-list shapes, each in a leaf and a
+    # children-bearing form (children = nested inlines and, later, inlined locals).
+    build_inlined_abbrev(b, ABBREV_INLINED,             false, false);
+    build_inlined_abbrev(b, ABBREV_INLINED_RANGES,      true,  false);
+    build_inlined_abbrev(b, ABBREV_INLINED_KIDS,        false, true);
+    build_inlined_abbrev(b, ABBREV_INLINED_RANGES_KIDS, true,  true);
 
     uleb(b, 0);   # null abbrev code terminates the table
 }
 
 # emit one DW_TAG_inlined_subroutine abbreviation. `ranges` selects DW_AT_ranges
 # (sec_offset into `.debug_rnglists`) for a non-contiguous instance, else an inline
-# DW_AT_low_pc / DW_AT_high_pc pair. No children this tier (flat, no inlined locals); the
-# dbg-clone / nesting increment adds a children-bearing shape.
+# DW_AT_low_pc / DW_AT_high_pc pair. `kids` selects DW_CHILDREN_yes (nested inlines /
+# inlined locals) over a leaf shape.
 # ---
 # b:      the abbrev buffer
 # code:   the abbreviation code
 # ranges: true for the DW_AT_ranges shape, false for the low_pc/high_pc shape
-fun build_inlined_abbrev(b: *enc.ByteBuf, code: u8, ranges: bool) {
+# kids:   true for DW_CHILDREN_yes
+fun build_inlined_abbrev(b: *enc.ByteBuf, code: u8, ranges: bool, kids: bool) {
     uleb(b, code::u64);
     uleb(b, DW_TAG_inlined_subroutine::u64);
-    enc.emit_byte(b, DW_CHILDREN_no);
+    if (kids) { enc.emit_byte(b, DW_CHILDREN_yes); }
+    or        { enc.emit_byte(b, DW_CHILDREN_no); }
     emit_attr(b, DW_AT_abstract_origin, DW_FORM_ref4);
     if (ranges) {
         emit_attr(b, DW_AT_ranges,  DW_FORM_sec_offset);
@@ -824,6 +832,55 @@ fun build_var_loclist_abbrev(b: *enc.ByteBuf, code: u8, tag: u8) {
     uleb(b, 0); uleb(b, 0);
 }
 
+# emit the DW_TAG_inlined_subroutine DIEs of function `f` whose inline-instance parent is
+# `parent_site` (0 = directly under the subprogram), recursing so a nested instance nests
+# under its parent's DIE. A single-extent instance carries low_pc/high_pc; a multi-extent
+# one carries DW_AT_ranges. An instance with nested children uses a children-bearing
+# abbrev and a closing null DIE.
+# ---
+# b:            the info buffer
+# f:            the enclosing subprogram index (into the DwInline.func_idx space)
+# parent_site:  the parent inline-instance id whose children to emit (0 = subprogram)
+# inlines/ninl: the gathered instances
+# iranges:      the shared extent array
+# relocs/reloc_count: the InfoReloc list (abstract_origin/low_pc/ranges patch sites)
+# fn:           the enclosing DwFunc (symbol name + `.text` offset)
+# address_size: target pointer width
+fun emit_inlines(b: *enc.ByteBuf, f: u32, parent_site: u32, inlines: *DwInline, ninl: u32,
+                 iranges: *DwInlineRange, relocs: *InfoReloc, reloc_count: *u32, fn: *DwFunc, address_size: u8) {
+    var xi: u32 = 0;
+    for (xi < ninl) {
+        if (inlines[xi].func_idx != f || inlines[xi].parent != parent_site) { xi = xi + 1; cnt; }
+        val di: *DwInline = ?inlines[xi];
+        var kids: bool = false;
+        var ck: u32 = 0;
+        for (ck < ninl) { if (inlines[ck].func_idx == f && inlines[ck].parent == di.site_id) { kids = true; } ck = ck + 1; }
+
+        if (di.range_count == 1) {
+            if (kids) { enc.emit_byte(b, ABBREV_INLINED_KIDS); } or { enc.emit_byte(b, ABBREV_INLINED); }
+            enc.emit_u32(b, di.origin_off);   # DW_AT_abstract_origin (ref4, backward)
+            val rg: *DwInlineRange = ?iranges[di.range_start];
+            push_info_reloc(relocs, reloc_count, b.len::u32, of.RK_ABS64, IRLT_SYM, fn.name, (rg.start - fn.offset)::i64);
+            emit_addr(b, address_size);        # DW_AT_low_pc (enclosing fn + range start)
+            enc.emit_u64(b, (rg.end - rg.start)::u64);   # DW_AT_high_pc
+        }
+        or {
+            if (kids) { enc.emit_byte(b, ABBREV_INLINED_RANGES_KIDS); } or { enc.emit_byte(b, ABBREV_INLINED_RANGES); }
+            enc.emit_u32(b, di.origin_off);   # DW_AT_abstract_origin (ref4, backward)
+            push_info_reloc(relocs, reloc_count, b.len::u32, of.RK_ABS32, IRLT_RNGLIST, intern.STR_NIL, di.rnglist_off::i64);
+            enc.emit_u32(b, 0);                # DW_AT_ranges (sec_offset into .debug_rnglists)
+        }
+        uleb(b, di.call_file::u64);
+        uleb(b, di.call_line::u64);
+
+        if (kids) {
+            emit_inlines(b, f, di.site_id, inlines, ninl, iranges, relocs, reloc_count, fn, address_size);
+            enc.emit_byte(b, 0);   # null DIE terminates this instance's children
+        }
+        xi = xi + 1;
+    }
+}
+
 # build the `.debug_info` compile unit: the DWARF 5 unit header, the CU DIE
 # (producer / name / comp_dir strings, language, code range, stmt_list), then a
 # `DW_TAG_base_type` DIE per gathered primitive and a `DW_TAG_subprogram` DIE per
@@ -884,9 +941,6 @@ fun build_info(b: *enc.ByteBuf, address_size: u8, producer: str, name: str, comp
     # instance (no dedup yet); DW_AT_name is the callee's source spelling.
     var ai: u32 = 0;
     for (ai < ninl) {
-        # only the top-level instances the subprogram loop emits get an abstract instance
-        # this tier; nested instances (parent != 0) are held for the nesting commit.
-        if (inlines[ai].parent != 0) { ai = ai + 1; cnt; }
         var cnm: str = resolve(?s.interner, inlines[ai].callee);
         val oi: O.Option[u32] = ir.function_lookup(irmod, inlines[ai].callee);
         if (O.is_some[u32](oi)) {
@@ -925,32 +979,9 @@ fun build_info(b: *enc.ByteBuf, address_size: u8, producer: str, name: str, comp
             vi = vi + 1;
         }
 
-        # its inlined_subroutine children (top-level; nested instances gain parent
-        # nesting in the following commit). A single-extent instance uses exact
-        # low_pc/high_pc; a multi-extent instance uses an exact DW_AT_ranges list in
-        # `.debug_rnglists` (never a span, which would overlap sibling ranges).
-        var xi: u32 = 0;
-        for (xi < ninl) {
-            if (inlines[xi].func_idx != f || inlines[xi].parent != 0) { xi = xi + 1; cnt; }
-            val di: *DwInline = ?inlines[xi];
-            if (di.range_count == 1) {
-                val rg: *DwInlineRange = ?iranges[di.range_start];
-                enc.emit_byte(b, ABBREV_INLINED);
-                enc.emit_u32(b, di.origin_off);   # DW_AT_abstract_origin (ref4, backward)
-                push_info_reloc(relocs, reloc_count, b.len::u32, of.RK_ABS64, IRLT_SYM, fn.name, (rg.start - fn.offset)::i64);
-                emit_addr(b, address_size);        # DW_AT_low_pc (enclosing fn + range start)
-                enc.emit_u64(b, (rg.end - rg.start)::u64);   # DW_AT_high_pc
-            }
-            or {
-                enc.emit_byte(b, ABBREV_INLINED_RANGES);
-                enc.emit_u32(b, di.origin_off);   # DW_AT_abstract_origin (ref4, backward)
-                push_info_reloc(relocs, reloc_count, b.len::u32, of.RK_ABS32, IRLT_RNGLIST, intern.STR_NIL, di.rnglist_off::i64);
-                enc.emit_u32(b, 0);                # DW_AT_ranges (sec_offset into .debug_rnglists)
-            }
-            uleb(b, di.call_file::u64);
-            uleb(b, di.call_line::u64);
-            xi = xi + 1;
-        }
+        # its inlined_subroutine children, as a tree by inline-instance parent (top-level
+        # instances directly under the subprogram, nested instances under their parent).
+        emit_inlines(b, f, 0, inlines, ninl, iranges, relocs, reloc_count, fn, address_size);
 
         enc.emit_byte(b, 0);   # null DIE terminates this subprogram's children
         f = f + 1;
@@ -1900,6 +1931,19 @@ fun gather_subprograms(s: *session.Session, tgt: *target.Target, irmod: *ir.Modu
 # ft:       the file table (call-site files are indexed in)
 # out:      the DwInline array to fill; ninl is its running count (in/out), inl_cap its cap
 # iranges:  the shared DwInlineRange array; nir its running count (in/out), ir_cap its cap
+# whether inline instance `k` is `s` itself or an ancestor of `s`, walking `s`'s parent
+# chain in `irfn`'s inline-site pool. Used so a parent instance's PC ranges cover its
+# whole subtree (a nested child's ranges must be contained in its parent's).
+fun inline_ancestor_or_self(irfn: *ir.Function, k: u32, s: u32) bool {
+    var cur: u32 = s;
+    for (cur != 0) {
+        if (cur == k) { ret true; }
+        val ps: *ir.InlineSite = ?irfn.inline_sites[cur - 1];
+        cur = ps.parent;
+    }
+    ret false;
+}
+
 fun gather_inlines(s: *session.Session, irmod: *ir.Module, funcs: *DwFunc, nfuncs: u32,
                    inline_pcs: *enc.InlinePc, inline_pc_count: u32, text_sec: u32, ft: *FileTable,
                    out: *DwInline, ninl: *u32, inl_cap: u32,
@@ -1938,7 +1982,7 @@ fun gather_inlines(s: *session.Session, irmod: *ir.Module, funcs: *DwFunc, nfunc
             var j: u32 = 0;
             for (j < inline_pc_count) {
                 val o: u32 = inline_pcs[j].text_offset;
-                if (inline_pcs[j].sec == text_sec && o >= lo && o < hi && inline_pcs[j].inline_site == k) {
+                if (inline_pcs[j].sec == text_sec && o >= lo && o < hi && inline_ancestor_or_self(irfn, k, inline_pcs[j].inline_site)) {
                     var seg_end: u32 = hi;
                     if (j + 1 < inline_pc_count && inline_pcs[j + 1].sec == text_sec && inline_pcs[j + 1].text_offset < hi && inline_pcs[j + 1].text_offset > o) { seg_end = inline_pcs[j + 1].text_offset; }
                     if (@nir < ir_cap) {
@@ -2424,8 +2468,14 @@ test "mach.lang.be.codegen.dwarf.build_abbrev:golden" {
     # ranges sec_offset, call_file udata, call_line udata.
     e[156]=0x0D; e[157]=0x1D; e[158]=0x00; e[159]=0x31; e[160]=0x13; e[161]=0x55; e[162]=0x17;
     e[163]=0x58; e[164]=0x0F; e[165]=0x59; e[166]=0x0F; e[167]=0x00; e[168]=0x00;
-    e[169]=0x00;   # null abbrev code terminates the table
-    val ok: bool = buf_eq(?b, ?e[0], 170);
+    # ABBREV_INLINED_KIDS (0x0E): as 0x0C but DW_CHILDREN_yes.
+    e[169]=0x0E; e[170]=0x1D; e[171]=0x01; e[172]=0x31; e[173]=0x13; e[174]=0x11; e[175]=0x01;
+    e[176]=0x12; e[177]=0x07; e[178]=0x58; e[179]=0x0F; e[180]=0x59; e[181]=0x0F; e[182]=0x00; e[183]=0x00;
+    # ABBREV_INLINED_RANGES_KIDS (0x0F): as 0x0D but DW_CHILDREN_yes.
+    e[184]=0x0F; e[185]=0x1D; e[186]=0x01; e[187]=0x31; e[188]=0x13; e[189]=0x55; e[190]=0x17;
+    e[191]=0x58; e[192]=0x0F; e[193]=0x59; e[194]=0x0F; e[195]=0x00; e[196]=0x00;
+    e[197]=0x00;   # null abbrev code terminates the table
+    val ok: bool = buf_eq(?b, ?e[0], 198);
     enc.buf_dnit(?b);
     if (!ok) { ret 1; }
     ret 0;

--- a/src/lang/be/codegen/dwarf.mach
+++ b/src/lang/be/codegen/dwarf.mach
@@ -849,6 +849,19 @@ fun build_var_loclist_abbrev(b: *enc.ByteBuf, code: u8, tag: u8) {
 # relocs/reloc_count: the InfoReloc list (abstract_origin/low_pc/ranges patch sites)
 # fn:           the enclosing DwFunc (symbol name + `.text` offset)
 # address_size: target pointer width
+# whether function `f` has a materialized inline instance with the given 1-based site id
+# (an instance with no surviving `.text` is dropped by gather_inlines, so a variable
+# tagged with it has no inlined_subroutine to nest under and must fall back to the
+# subprogram scope rather than vanish).
+fun inline_present(inlines: *DwInline, ninl: u32, f: u32, site: u32) bool {
+    var i: u32 = 0;
+    for (i < ninl) {
+        if (inlines[i].func_idx == f && inlines[i].site_id == site) { ret true; }
+        i = i + 1;
+    }
+    ret false;
+}
+
 fun emit_inlines(b: *enc.ByteBuf, f: u32, parent_site: u32, inlines: *DwInline, ninl: u32,
                  iranges: *DwInlineRange, relocs: *InfoReloc, reloc_count: *u32, fn: *DwFunc, address_size: u8,
                  vars: *DwVar, bts: *BaseType) {
@@ -954,6 +967,17 @@ fun build_info(b: *enc.ByteBuf, address_size: u8, producer: str, name: str, comp
     # instance (no dedup yet); DW_AT_name is the callee's source spelling.
     var ai: u32 = 0;
     for (ai < ninl) {
+        # dedup by callee: one abstract instance per distinct callee, shared by every
+        # inlined_subroutine of it (a reused abstract_origin, per DWARF's single abstract
+        # instance model).
+        var dup: bool = false;
+        var pj: u32 = 0;
+        for (pj < ai) {
+            if (inlines[pj].callee == inlines[ai].callee) { inlines[ai].origin_off = inlines[pj].origin_off; dup = true; brk; }
+            pj = pj + 1;
+        }
+        if (dup) { ai = ai + 1; cnt; }
+
         var cnm: str = resolve(?s.interner, inlines[ai].callee);
         val oi: O.Option[u32] = ir.function_lookup(irmod, inlines[ai].callee);
         if (O.is_some[u32](oi)) {
@@ -985,11 +1009,13 @@ fun build_info(b: *enc.ByteBuf, address_size: u8, producer: str, name: str, comp
         emit_frame_base(b, fb_reg);
         if (fn.ret_bt >= 0) { enc.emit_u32(b, bts[fn.ret_bt::u32].off); }   # DW_AT_type (ref4)
 
-        # the subprogram's own variable / parameter children (inline instance 0); an
-        # inlined local (instance != 0) is emitted under its inlined_subroutine instead.
+        # the subprogram's own variable / parameter children: instance-0 vars, plus any
+        # var whose inline instance was dropped (no materialized inlined_subroutine to
+        # nest under) so it keeps a scope rather than vanishing.
         var vi: u32 = 0;
         for (vi < fn.var_count) {
-            if (vars[fn.var_start + vi].inline_site == 0) { emit_variable(b, ?vars[fn.var_start + vi], bts, relocs, reloc_count); }
+            val dvr: *DwVar = ?vars[fn.var_start + vi];
+            if (dvr.inline_site == 0 || !inline_present(inlines, ninl, f, dvr.inline_site)) { emit_variable(b, dvr, bts, relocs, reloc_count); }
             vi = vi + 1;
         }
 
@@ -1256,7 +1282,9 @@ fun build_rnglists(b: *enc.ByteBuf, funcs: *DwFunc, nfuncs: u32, inlines: *DwInl
     var i: u32 = 0;
     for (i < ninl) {
         val di: *DwInline = ?inlines[i];
-        if (di.parent != 0 || di.range_count <= 1) { i = i + 1; cnt; }
+        # every multi-extent instance needs a list, nested or not; emit_inlines picks the
+        # DW_AT_ranges shape purely on range_count, so a skipped nested one would dangle.
+        if (di.range_count <= 1) { i = i + 1; cnt; }
         val fn: *DwFunc = ?funcs[di.func_idx];
         di.rnglist_off = b.len::u32;
         enc.emit_byte(b, DW_RLE_base_address);
@@ -1767,10 +1795,16 @@ pub fun produce(s: *session.Session, tgt: *target.Target, irmod: *ir.Module,
     var b_rnglists: enc.ByteBuf = enc.buf_init(s.alloc);
 
     # inlined-subroutine instances: gathered before build_line so their call-site files
-    # are registered in the file table the line header emits. capacity is bounded by the
-    # transition count (each starts at most one instance-range).
-    var inl_cap: u32 = inline_pc_count;
+    # are registered in the file table the line header emits. Instances are bounded by the
+    # total inline-site count; ranges by inline_pc_count * max nesting depth (a descendant
+    # extent rolls into every ancestor). gather_inlines errors loudly if either is exceeded.
+    var tot_sites: u32 = 0;
+    var max_depth: u32 = 1;
+    inline_caps(irmod, subs, nsub, ?tot_sites, ?max_depth);
+    var inl_cap: u32 = tot_sites;
     if (inl_cap == 0) { inl_cap = 1; }
+    var ir_cap: u32 = inline_pc_count * max_depth;
+    if (ir_cap == 0) { ir_cap = 1; }
     val rinl: R.Result[*DwInline, str] = A.allocate[DwInline](s.alloc, inl_cap::usize);
     if (R.is_err[*DwInline, str](rinl)) {
         enc.buf_dnit(?b_rnglists); enc.buf_dnit(?b_loclists); enc.buf_dnit(?b_info); enc.buf_dnit(?b_line); enc.buf_dnit(?b_abbrev); enc.buf_dnit(?strtab.buf);
@@ -1781,7 +1815,7 @@ pub fun produce(s: *session.Session, tgt: *target.Target, irmod: *ir.Module,
         ret R.err[bool, str](R.unwrap_err[*DwInline, str](rinl));
     }
     val inlines: *DwInline = R.unwrap_ok[*DwInline, str](rinl);
-    val rirng: R.Result[*DwInlineRange, str] = A.allocate[DwInlineRange](s.alloc, inl_cap::usize);
+    val rirng: R.Result[*DwInlineRange, str] = A.allocate[DwInlineRange](s.alloc, ir_cap::usize);
     if (R.is_err[*DwInlineRange, str](rirng)) {
         A.deallocate[DwInline](s.alloc, inlines, inl_cap::usize);
         enc.buf_dnit(?b_rnglists); enc.buf_dnit(?b_loclists); enc.buf_dnit(?b_info); enc.buf_dnit(?b_line); enc.buf_dnit(?b_abbrev); enc.buf_dnit(?strtab.buf);
@@ -1794,17 +1828,26 @@ pub fun produce(s: *session.Session, tgt: *target.Target, irmod: *ir.Module,
     val iranges: *DwInlineRange = R.unwrap_ok[*DwInlineRange, str](rirng);
     var ninl: u32 = 0;
     var nir:  u32 = 0;
-    gather_inlines(s, irmod, subs, nsub, inline_pcs, inline_pc_count, text_sec, ?ft, inlines, ?ninl, inl_cap, iranges, ?nir, inl_cap);
+    val rgi: R.Result[bool, str] = gather_inlines(s, irmod, subs, nsub, inline_pcs, inline_pc_count, text_sec, ?ft, inlines, ?ninl, inl_cap, iranges, ?nir, ir_cap);
+    if (R.is_err[bool, str](rgi)) {
+        A.deallocate[DwInlineRange](s.alloc, iranges, ir_cap::usize); A.deallocate[DwInline](s.alloc, inlines, inl_cap::usize);
+        enc.buf_dnit(?b_rnglists); enc.buf_dnit(?b_loclists); enc.buf_dnit(?b_info); enc.buf_dnit(?b_line); enc.buf_dnit(?b_abbrev); enc.buf_dnit(?strtab.buf);
+        A.deallocate[LocReloc](s.alloc, loc_relocs, loc_reloc_cap::usize); A.deallocate[InfoReloc](s.alloc, info_relocs, reloc_cap::usize);
+        A.deallocate[u32](s.alloc, addr_off, nfuncs::usize); A.deallocate[BaseType](s.alloc, bts, MAX_BASE_TYPES::usize);
+        A.deallocate[LocRange](s.alloc, ranges, range_cap::usize); A.deallocate[DwVar](s.alloc, vars, var_cap::usize);
+        A.deallocate[DwFunc](s.alloc, subs, nfuncs::usize); A.deallocate[DwFunc](s.alloc, funcs, nfuncs::usize);
+        ret rgi;
+    }
 
-    # a `.debug_rnglists` section only when some top-level instance is multi-extent.
+    # a `.debug_rnglists` section only when some instance (nested or not) is multi-extent.
     var has_rnglists: bool = false;
     var hr: u32 = 0;
-    for (hr < ninl) { if (inlines[hr].parent == 0 && inlines[hr].range_count > 1) { has_rnglists = true; } hr = hr + 1; }
+    for (hr < ninl) { if (inlines[hr].range_count > 1) { has_rnglists = true; } hr = hr + 1; }
     # one DW_RLE_base_address reloc per multi-extent instance (bounded by the count).
     val rng_reloc_cap: u32 = inl_cap + 1;
     val rrr: R.Result[*RngReloc, str] = A.allocate[RngReloc](s.alloc, rng_reloc_cap::usize);
     if (R.is_err[*RngReloc, str](rrr)) {
-        A.deallocate[DwInlineRange](s.alloc, iranges, inl_cap::usize); A.deallocate[DwInline](s.alloc, inlines, inl_cap::usize);
+        A.deallocate[DwInlineRange](s.alloc, iranges, ir_cap::usize); A.deallocate[DwInline](s.alloc, inlines, inl_cap::usize);
         enc.buf_dnit(?b_rnglists); enc.buf_dnit(?b_loclists); enc.buf_dnit(?b_info); enc.buf_dnit(?b_line); enc.buf_dnit(?b_abbrev); enc.buf_dnit(?strtab.buf);
         A.deallocate[LocReloc](s.alloc, loc_relocs, loc_reloc_cap::usize); A.deallocate[InfoReloc](s.alloc, info_relocs, reloc_cap::usize);
         A.deallocate[u32](s.alloc, addr_off, nfuncs::usize); A.deallocate[BaseType](s.alloc, bts, MAX_BASE_TYPES::usize);
@@ -1842,7 +1885,7 @@ pub fun produce(s: *session.Session, tgt: *target.Target, irmod: *ir.Module,
     enc.buf_dnit(?b_loclists);
     enc.buf_dnit(?b_rnglists);
     enc.buf_dnit(?strtab.buf);
-    A.deallocate[DwInlineRange](s.alloc, iranges, inl_cap::usize);
+    A.deallocate[DwInlineRange](s.alloc, iranges, ir_cap::usize);
     A.deallocate[DwInline](s.alloc, inlines, inl_cap::usize);
     A.deallocate[RngReloc](s.alloc, rng_relocs, rng_reloc_cap::usize);
     A.deallocate[LocReloc](s.alloc, loc_relocs, loc_reloc_cap::usize);
@@ -1958,10 +2001,34 @@ fun inline_ancestor_or_self(irfn: *ir.Function, k: u32, s: u32) bool {
     ret false;
 }
 
+# upper bounds for the inline arrays: the total inline-site count across the subprograms
+# (an exact bound on instances) and the deepest parent chain (ranges roll a descendant's
+# extent into every ancestor, so they are bounded by inline_pc_count * max_depth).
+fun inline_caps(irmod: *ir.Module, funcs: *DwFunc, nfuncs: u32, total: *u32, max_depth: *u32) {
+    @total = 0;
+    @max_depth = 1;
+    var i: u32 = 0;
+    for (i < nfuncs) {
+        val oi: O.Option[u32] = ir.function_lookup(irmod, funcs[i].name);
+        if (O.is_none[u32](oi)) { i = i + 1; cnt; }
+        val irfn: *ir.Function = ?irmod.functions[O.unwrap[u32](oi)];
+        @total = @total + irfn.inline_site_len;
+        var k: u32 = 1;
+        for (k <= irfn.inline_site_len) {
+            var d: u32 = 0;
+            var cur: u32 = k;
+            for (cur != 0) { d = d + 1; val ps: *ir.InlineSite = ?irfn.inline_sites[cur - 1]; cur = ps.parent; }
+            if (d > @max_depth) { @max_depth = d; }
+            k = k + 1;
+        }
+        i = i + 1;
+    }
+}
+
 fun gather_inlines(s: *session.Session, irmod: *ir.Module, funcs: *DwFunc, nfuncs: u32,
                    inline_pcs: *enc.InlinePc, inline_pc_count: u32, text_sec: u32, ft: *FileTable,
                    out: *DwInline, ninl: *u32, inl_cap: u32,
-                   iranges: *DwInlineRange, nir: *u32, ir_cap: u32) {
+                   iranges: *DwInlineRange, nir: *u32, ir_cap: u32) R.Result[bool, str] {
     var i: u32 = 0;
     for (i < nfuncs) {
         val opt_idx: O.Option[u32] = ir.function_lookup(irmod, funcs[i].name);
@@ -1973,7 +2040,7 @@ fun gather_inlines(s: *session.Session, irmod: *ir.Module, funcs: *DwFunc, nfunc
 
         var k: u32 = 1;
         for (k <= irfn.inline_site_len) {
-            if (@ninl >= inl_cap) { brk; }
+            if (@ninl >= inl_cap) { ret R.err[bool, str]("dwarf.gather_inlines: inline-instance capacity exceeded"); }
             val site: *ir.InlineSite = ?irfn.inline_sites[k - 1];
             val di: *DwInline = ?out[@ninl];
             di.func_idx    = i;
@@ -1984,22 +2051,33 @@ fun gather_inlines(s: *session.Session, irmod: *ir.Module, funcs: *DwFunc, nfunc
             di.range_start = @nir;
             di.range_count = 0;
             di.rnglist_off = 0;
-            di.call_file   = 0;
-            di.call_line   = 0;
             if (source.loc_is_valid(site.call_loc)) {
                 file_index(ft, site.call_loc.file);
                 val pl: PosLine = pos_of(s, site.call_loc, ft);
                 di.call_file = pl.file;
                 di.call_line = pl.line::u32;
             }
+            or {
+                # no call-site location: attribute to the enclosing function's file rather
+                # than file index 0, which is out of range when the file table is empty.
+                di.call_file = funcs[i].decl_file;
+                di.call_line = funcs[i].decl_line;
+            }
 
             var j: u32 = 0;
             for (j < inline_pc_count) {
                 val o: u32 = inline_pcs[j].text_offset;
                 if (inline_pcs[j].sec == text_sec && o >= lo && o < hi && inline_ancestor_or_self(irfn, k, inline_pcs[j].inline_site)) {
+                    # the segment ends at the next same-section transition (skipping any
+                    # other-section records), clamped to the function end. Two records at
+                    # the same offset (a zero-byte site change) make seg_end == o, a
+                    # zero-length segment that is dropped rather than over-extended to hi.
                     var seg_end: u32 = hi;
-                    if (j + 1 < inline_pc_count && inline_pcs[j + 1].sec == text_sec && inline_pcs[j + 1].text_offset < hi && inline_pcs[j + 1].text_offset > o) { seg_end = inline_pcs[j + 1].text_offset; }
-                    if (@nir < ir_cap) {
+                    var jn: u32 = j + 1;
+                    for (jn < inline_pc_count && inline_pcs[jn].sec != text_sec) { jn = jn + 1; }
+                    if (jn < inline_pc_count && inline_pcs[jn].text_offset < hi) { seg_end = inline_pcs[jn].text_offset; }
+                    if (o < seg_end) {
+                        if (@nir >= ir_cap) { ret R.err[bool, str]("dwarf.gather_inlines: inline-range capacity exceeded"); }
                         iranges[@nir].start = o;
                         iranges[@nir].end   = seg_end;
                         @nir = @nir + 1;
@@ -2014,6 +2092,7 @@ fun gather_inlines(s: *session.Session, irmod: *ir.Module, funcs: *DwFunc, nfunc
         }
         i = i + 1;
     }
+    ret R.ok[bool, str](true);
 }
 
 # gather one function's DWARF variables from the encoder's variable-location records.
@@ -2048,10 +2127,14 @@ fun gather_vars(s: *session.Session, tgt: *target.Target, irfn: *ir.Function, lo
         val obt: O.Option[u32] = varloc_ident(s, irfn, vl, address_size, bts, nbt, strtab);
         if (O.is_none[u32](obt)) { i = i + 1; cnt; }
         val name_off: u32 = O.unwrap[u32](obt);
+        # the inline instance this variable lives in (0 = the caller's own body); a caller
+        # local and an identically-named inlined local are DISTINCT scopes, so the dedup
+        # key is (name_off, inline_site), not name alone.
+        val vsite: u32 = ir.instr_inline_site_of(irfn, vl.iid::id.InstructionId);
 
         var found: bool = false;
         var j: u32 = fn_var_start;
-        for (j < @var_count) { if (vars[j].name_off == name_off) { found = true; } j = j + 1; }
+        for (j < @var_count) { if (vars[j].name_off == name_off && vars[j].inline_site == vsite) { found = true; } j = j + 1; }
         if (!found && @var_count < var_cap) {
             val dv: *ir.DbgVar = O.unwrap[*ir.DbgVar](ir.dbg_var_get(irfn, vl.iid::id.InstructionId));
             val bt: i32 = bt_intern(bts, nbt, strtab, O.unwrap[BaseType](sem_base_type(s, dv.ty_sem, address_size)));
@@ -2065,9 +2148,7 @@ fun gather_vars(s: *session.Session, tgt: *target.Target, irfn: *ir.Function, lo
             vars[@var_count].range_start = 0;
             vars[@var_count].range_count = 0;
             vars[@var_count].loclist_off = 0;
-            # the inline instance this variable lives in (0 = the caller's own body); the
-            # #1707 producer nests a non-zero one under its inlined_subroutine.
-            vars[@var_count].inline_site = ir.instr_inline_site_of(irfn, vl.iid::id.InstructionId);
+            vars[@var_count].inline_site = vsite;
             @var_count = @var_count + 1;
         }
         i = i + 1;

--- a/src/lang/be/codegen/dwarf.mach
+++ b/src/lang/be/codegen/dwarf.mach
@@ -2788,3 +2788,44 @@ test "mach.lang.be.codegen.dwarf.build_loclists:ranges" {
     if (vars[0].loclist_off != 12) { code = 1; }  # the entry begins at DW_LLE_base_address
     ret code;
 }
+
+# build_rnglists emits the DWARF 5 header and, for one multi-extent inlined instance
+# with two extents, a DW_RLE_base_address (with a recorded relocation), a
+# DW_RLE_offset_pair per extent (function-relative), and a DW_RLE_end_of_list - byte for
+# byte, with the instance's rnglist_off stamped for its DW_AT_ranges sec_offset
+test "mach.lang.be.codegen.dwarf.build_rnglists:ranges" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+    var code: i32 = 0;
+
+    var funcs: [1]DwFunc;
+    funcs[0].name = intern.STR_NIL; funcs[0].offset = 0;
+    var inls: [1]DwInline;
+    inls[0].func_idx = 0; inls[0].parent = 0; inls[0].range_start = 0; inls[0].range_count = 2; inls[0].rnglist_off = 0;
+    var irng: [2]DwInlineRange;
+    irng[0].start = 0; irng[0].end = 4;
+    irng[1].start = 8; irng[1].end = 12;
+
+    var relocs: [4]RngReloc;
+    var nrel: u32 = 0;
+    var b: enc.ByteBuf = enc.buf_init(?alloc);
+    build_rnglists(?b, ?funcs[0], 1, ?inls[0], 1, ?irng[0], 8, ?relocs[0], ?nrel);
+
+    var e: [28]u8;
+    e[0]=0x18; e[1]=0x00; e[2]=0x00; e[3]=0x00;                      # unit_length = 24
+    e[4]=0x05; e[5]=0x00;                                            # version 5
+    e[6]=0x08; e[7]=0x00;                                            # address_size, segment_selector_size
+    e[8]=0x00; e[9]=0x00; e[10]=0x00; e[11]=0x00;                    # offset_entry_count 0
+    e[12]=0x05;                                                      # DW_RLE_base_address
+    e[13]=0x00; e[14]=0x00; e[15]=0x00; e[16]=0x00; e[17]=0x00; e[18]=0x00; e[19]=0x00; e[20]=0x00;
+    e[21]=0x04; e[22]=0x00; e[23]=0x04;                             # offset_pair [0,4)
+    e[24]=0x04; e[25]=0x08; e[26]=0x0C;                             # offset_pair [8,12)
+    e[27]=0x00;                                                      # DW_RLE_end_of_list
+    val ok: bool = buf_eq(?b, ?e[0], 28);
+    enc.buf_dnit(?b);
+    if (!ok) { code = 1; }
+    if (nrel != 1) { code = 1; }
+    if (relocs[0].off != 13) { code = 1; }       # the base-address address field
+    if (inls[0].rnglist_off != 12) { code = 1; } # the list begins at DW_RLE_base_address
+    ret code;
+}

--- a/src/lang/be/codegen/encode.mach
+++ b/src/lang/be/codegen/encode.mach
@@ -72,6 +72,8 @@ pub rec EncoderOutput {
     row_count:    u32;
     varlocs:      *VarLoc;
     varloc_count: u32;
+    inline_pcs:   *InlinePc;
+    inline_pc_count: u32;
 }
 
 # one retained PC<->source mapping: a `.text` byte offset and the source location of
@@ -95,6 +97,24 @@ pub rec LineRow {
     text_offset: u32;
     sec:         u32;
     loc:         source.SrcLoc;
+}
+
+# one inline-instance transition: at `text_offset` the active inline instance becomes
+# `inline_site` (0 = the function's own body, else a 1-based ir.Function inline-site id).
+# The encoder appends one only when the instance CHANGES between consecutive
+# instructions, in ascending `text_offset` order, so a record governs `[text_offset,
+# next_offset)`. insert_text keeps `text_offset` correct through branch relaxation, and
+# pack re-homes it exactly like a LineRow. The DWARF inlined_subroutine producer (#1707)
+# groups these into per-instance `.text` ranges; nothing else reads them and they never
+# affect the emitted bytes.
+# ---
+# text_offset: `.text` byte offset where this instance becomes active
+# sec:         owning section index after re-homing (0 until then)
+# inline_site: the 1-based inline instance now active, or 0 for the function body
+pub rec InlinePc {
+    text_offset: u32;
+    sec:         u32;
+    inline_site: u32;
 }
 
 # a source-variable location record: at `.text` offset `text_offset`, the variable
@@ -426,6 +446,10 @@ pub rec EncodeState {
     varlocs:     *VarLoc;
     varloc_count: u32;
     varloc_cap:  u32;
+    inline_pcs:  *InlinePc;
+    inline_pc_count: u32;
+    inline_pc_cap:   u32;
+    last_inline_site: u32;
     interner:    *intern.Interner;
     abi:         *abi.AbiVTable;
     os:          *tos.OsVTable;
@@ -542,6 +566,8 @@ pub fun encode_driver(alloc: *A.Allocator, tgt: *target.Target, m: *mir.MirModul
     out.symbol_count = st.sym_count;
     out.rows         = st.rows;
     out.row_count    = st.row_count;
+    out.inline_pcs   = st.inline_pcs;
+    out.inline_pc_count = st.inline_pc_count;
     out.varlocs      = st.varlocs;
     out.varloc_count = st.varloc_count;
 
@@ -814,6 +840,10 @@ fun state_init(st: *EncodeState, alloc: *A.Allocator, m: *mir.MirModule, tgt: *t
     st.varlocs     = nil;
     st.varloc_count = 0;
     st.varloc_cap  = 0;
+    st.inline_pcs  = nil;
+    st.inline_pc_count = 0;
+    st.inline_pc_cap   = 0;
+    st.last_inline_site = 0;
     st.interner    = m.interner;
     st.abi         = tgt.abi;
     st.os          = tgt.os;
@@ -849,6 +879,12 @@ fun state_dnit(st: *EncodeState) {
     st.varlocs      = nil;
     st.varloc_count = 0;
     st.varloc_cap   = 0;
+    if (st.inline_pcs != nil && st.inline_pc_cap > 0) {
+        A.deallocate[InlinePc](st.alloc, st.inline_pcs, st.inline_pc_cap::usize);
+    }
+    st.inline_pcs      = nil;
+    st.inline_pc_count = 0;
+    st.inline_pc_cap   = 0;
     scratch_release(st);
 }
 
@@ -1028,6 +1064,11 @@ pub fun insert_text(st: *EncodeState, pos: u32, nbytes: u32) R.Result[bool, str]
         if (st.varlocs[vli].text_offset >= pos) { st.varlocs[vli].text_offset = st.varlocs[vli].text_offset + nbytes; }
         vli = vli + 1;
     }
+    var ipi: u32 = 0;
+    for (ipi < st.inline_pc_count) {
+        if (st.inline_pcs[ipi].text_offset >= pos) { st.inline_pcs[ipi].text_offset = st.inline_pcs[ipi].text_offset + nbytes; }
+        ipi = ipi + 1;
+    }
     ret R.ok[bool, str](true);
 }
 
@@ -1131,6 +1172,49 @@ fun grow_rows(st: *EncodeState) R.Result[bool, str] {
     ret R.ok[bool, str](true);
 }
 
+# grow the inline-pc transition array, allocating it on first use
+# ---
+# st:  the state whose inline-pc array is grown
+# ret: ok(true) once the array has room, or an allocation error
+fun grow_inline_pcs(st: *EncodeState) R.Result[bool, str] {
+    if (st.inline_pcs == nil) {
+        val res_alloc: R.Result[*InlinePc, str] = A.allocate[InlinePc](st.alloc, DRIVER_INIT_CAP::usize);
+        if (R.is_err[*InlinePc, str](res_alloc)) { ret R.err[bool, str](R.unwrap_err[*InlinePc, str](res_alloc)); }
+        st.inline_pcs    = R.unwrap_ok[*InlinePc, str](res_alloc);
+        st.inline_pc_cap = DRIVER_INIT_CAP;
+        ret R.ok[bool, str](true);
+    }
+    val new_cap: u32 = st.inline_pc_cap * 2;
+    val res_realloc: R.Result[*InlinePc, str] = A.reallocate[InlinePc](st.alloc, st.inline_pcs, st.inline_pc_cap::usize, new_cap::usize);
+    if (R.is_err[*InlinePc, str](res_realloc)) { ret R.err[bool, str](R.unwrap_err[*InlinePc, str](res_realloc)); }
+    st.inline_pcs    = R.unwrap_ok[*InlinePc, str](res_realloc);
+    st.inline_pc_cap = new_cap;
+    ret R.ok[bool, str](true);
+}
+
+# record that at `text_offset` the active inline instance becomes `inline_site`. Only a
+# CHANGE from the previously active instance appends a record, so a run of instructions
+# in one instance forms a single range `[text_offset, next_offset)`. Called for every
+# instruction at its first byte; a no-op for the common body-to-body (0) run.
+# ---
+# st:          the encode state
+# text_offset: `.text` offset of the instruction being encoded
+# inline_site: the instruction's inline instance (0 = function body)
+# ret:         ok(true), or an allocation error
+pub fun push_inline_pc(st: *EncodeState, text_offset: u32, inline_site: u32) R.Result[bool, str] {
+    if (inline_site == st.last_inline_site) { ret R.ok[bool, str](true); }
+    if (st.inline_pc_count >= st.inline_pc_cap) {
+        val res_grow: R.Result[bool, str] = grow_inline_pcs(st);
+        if (R.is_err[bool, str](res_grow)) { ret res_grow; }
+    }
+    st.inline_pcs[st.inline_pc_count].text_offset = text_offset;
+    st.inline_pcs[st.inline_pc_count].sec         = 0;
+    st.inline_pcs[st.inline_pc_count].inline_site = inline_site;
+    st.inline_pc_count  = st.inline_pc_count + 1;
+    st.last_inline_site = inline_site;
+    ret R.ok[bool, str](true);
+}
+
 # a minimal encode state for the row / varloc / insert_text unit tests: a text sink and
 # an empty set of mark / reloc / fixup / block / row / varloc arrays, no interner or
 # vtables
@@ -1143,6 +1227,7 @@ fun t_row_state(alloc: *A.Allocator, st: *EncodeState) {
     st.blocks = nil; st.block_count = 0; st.block_cap = 0;
     st.rows = nil;   st.row_count = 0;   st.row_cap = 0;
     st.varlocs = nil; st.varloc_count = 0; st.varloc_cap = 0;
+    st.inline_pcs = nil; st.inline_pc_count = 0; st.inline_pc_cap = 0;
     st.interner = nil; st.abi = nil; st.os = nil;
 }
 

--- a/src/lang/be/codegen/encode.mach
+++ b/src/lang/be/codegen/encode.mach
@@ -537,6 +537,10 @@ pub fun encode_driver(alloc: *A.Allocator, tgt: *target.Target, m: *mir.MirModul
 
     var fi: u32 = 0;
     for (fi < m.function_len) {
+        # each function starts in its own body (inline instance 0); reset the transition
+        # tracker so a function whose last instruction was inlined does not suppress the
+        # next function's opening transition (inline-site ids are per-function).
+        st.last_inline_site = 0;
         val res_encode: R.Result[bool, str] = hooks.encode_function(?st, ?m.functions[fi]);
         if (R.is_err[bool, str](res_encode)) {
             state_dnit(?st);

--- a/src/lang/me/ir.mach
+++ b/src/lang/me/ir.mach
@@ -941,6 +941,53 @@ pub fun instr_inline_site_of(fn: *Function, iid: id.InstructionId) u32 {
     ret @R.unwrap_ok[*u32, str](res);
 }
 
+# copy the -g source-variable metadata (DbgVar identity and any DbgExpr salvage steps)
+# the OP_DBG_VALUE `src_iid` carries in `src_fn` onto the cloned OP_DBG_VALUE `dst_iid`
+# in `dst_fn`. Used by the inline pass so an inlined local keeps its name / type /
+# expression identity in the caller, where the DWARF inlined_subroutine producer (#1707)
+# nests it under its inline instance. A no-op when `src_iid` carries no dbg-var.
+# ---
+# m:       module owning the allocator
+# src_fn:  the callee the metadata is read from
+# dst_fn:  the caller the metadata is copied into
+# src_iid: the callee OP_DBG_VALUE id
+# dst_iid: the cloned OP_DBG_VALUE id in the caller
+# ret:     ok(true), or an allocation error
+pub fun clone_dbg_metadata(m: *Module, src_fn: *Function, dst_fn: *Function, src_iid: id.InstructionId, dst_iid: id.InstructionId) R.Result[bool, str] {
+    val odv: O.Option[*DbgVar] = dbg_var_get(src_fn, src_iid);
+    if (O.is_none[*DbgVar](odv)) { ret R.ok[bool, str](true); }
+    var dv: DbgVar = @O.unwrap[*DbgVar](odv);
+    val ri: R.Result[bool, str] = map.insert[id.InstructionId, DbgVar](?dst_fn.dbg_vars, dst_iid, dv);
+    if (R.is_err[bool, str](ri)) { ret ri; }
+
+    val seid: DbgExprId = dbg_expr_id(src_fn, src_iid);
+    val ose: O.Option[*DbgExpr] = dbg_expr_get(src_fn, seid);
+    if (O.is_none[*DbgExpr](ose)) { ret R.ok[bool, str](true); }
+    val n: u32 = O.unwrap[*DbgExpr](ose).op_count;
+    if (n == 0) { ret R.ok[bool, str](true); }
+
+    # snapshot the source steps, then rebuild the destination expression through the
+    # pool's own API (a hand-built op array corrupts the pool once salvage reallocates it).
+    val rsnap: R.Result[*DbgOp, str] = A.allocate[DbgOp](m.alloc, n::usize);
+    if (R.is_err[*DbgOp, str](rsnap)) { ret R.err[bool, str](R.unwrap_err[*DbgOp, str](rsnap)); }
+    val snap: *DbgOp = R.unwrap_ok[*DbgOp, str](rsnap);
+    var i: u32 = 0;
+    val se0: *DbgExpr = O.unwrap[*DbgExpr](ose);
+    for (i < n) { snap[i] = se0.ops[i]; i = i + 1; }
+
+    val rne: R.Result[DbgExprId, str] = dbg_expr_new(m, dst_fn, dst_iid);
+    if (R.is_err[DbgExprId, str](rne)) { A.deallocate[DbgOp](m.alloc, snap, n::usize); ret R.err[bool, str](R.unwrap_err[DbgExprId, str](rne)); }
+    val deid: DbgExprId = R.unwrap_ok[DbgExprId, str](rne);
+    var j: u32 = n;
+    for (j > 0) {
+        val rp: R.Result[bool, str] = dbg_expr_prepend_op(m, dst_fn, deid, snap[j - 1]);
+        if (R.is_err[bool, str](rp)) { A.deallocate[DbgOp](m.alloc, snap, n::usize); ret rp; }
+        j = j - 1;
+    }
+    A.deallocate[DbgOp](m.alloc, snap, n::usize);
+    ret R.ok[bool, str](true);
+}
+
 # allocate a fresh, empty block at the end of a function's block array and return
 # its BlockId. the block's id field is set to its index; all owned lists start
 # empty and its terminator is INSTR_NIL

--- a/src/lang/me/pass/inline.mach
+++ b/src/lang/me/pass/inline.mach
@@ -214,18 +214,27 @@ fun callee_has_asm(callee: *ir.Function) bool {
     ret false;
 }
 
-# count the instructions that live in the callee's blocks
+# count the instructions that live in the callee's blocks, EXCLUDING OP_DBG_VALUE
 #
-# Pool entries orphaned by earlier passes are not counted.
+# OP_DBG_VALUE births are emitted only under -g, so counting them would let the size
+# threshold in should_inline decide differently with and without -g and emit different
+# machine code -- a -g additivity violation. The count must be -g-invariant, so debug
+# values are skipped. Pool entries orphaned by earlier passes are not counted.
 # ---
 # callee: the callee function
-# ret:    total live phi, body, and terminator instructions
+# ret:    total live phi, non-debug body, and terminator instructions
 fun callee_instr_count(callee: *ir.Function) u32 {
     var total: u32 = 0;
     var i: u32 = 0;
     for (i < callee.block_count) {
         val blk: *ir.Block = ?callee.blocks[i];
-        total = total + blk.phi_count + blk.instr_count;
+        total = total + blk.phi_count;
+        var k: u32 = 0;
+        for (k < blk.instr_count) {
+            val oi: O.Option[*instruction.Instruction] = ir.instruction_get(callee, blk.instructions[k]);
+            if (O.is_some[*instruction.Instruction](oi) && O.unwrap[*instruction.Instruction](oi).kind != instruction.OP_DBG_VALUE) { total = total + 1; }
+            k = k + 1;
+        }
         if (blk.terminator != id.INSTR_NIL) { total = total + 1; }
         i = i + 1;
     }

--- a/src/lang/me/pass/inline.mach
+++ b/src/lang/me/pass/inline.mach
@@ -567,6 +567,10 @@ fun stamp_inline_metadata(m: *ir.Module, cx: *InlineCtx, call_loc: source.SrcLoc
         }
         val rs: R.Result[bool, str] = ir.instr_inline_site_set(caller, cloned_iid, caller_site);
         if (R.is_err[bool, str](rs)) { if (site_map != nil) { A.deallocate[u32](m.alloc, site_map, (nsite + 1)::usize); } ret rs; }
+        # copy the callee's dbg-var / dbg-expr identity onto the cloned OP_DBG_VALUE so the
+        # inlined local keeps its name/type; the #1707 producer nests it under its instance.
+        val rc: R.Result[bool, str] = ir.clone_dbg_metadata(m, callee, caller, i::id.InstructionId, cloned_iid);
+        if (R.is_err[bool, str](rc)) { if (site_map != nil) { A.deallocate[u32](m.alloc, site_map, (nsite + 1)::usize); } ret rc; }
         i = i + 1;
     }
     if (site_map != nil) { A.deallocate[u32](m.alloc, site_map, (nsite + 1)::usize); }

--- a/src/lang/me/pass/inline.mach
+++ b/src/lang/me/pass/inline.mach
@@ -37,6 +37,7 @@ use mach.lang.me.ir.type;
 use mach.lang.me.ir.value;
 use mach.lang.source;
 use mach.lang.target;
+use semtype: mach.lang.type;
 
 # instruction-count ceiling below which a callee is small enough to inline
 # unconditionally. fixed for the rewrite; future cost models read it off the
@@ -1151,5 +1152,85 @@ test "mach.lang.me.pass.inline.mark_recursive:direct_self_call" {
     A.deallocate[bool](m.alloc, recursive, 1::usize);
     ir.dnit(?m);
     if (is_recursive == false) { ret 1; }
+    ret 0;
+}
+
+# callee_instr_count must be -g-invariant: OP_DBG_VALUE births exist only under -g,
+# so counting them would let the size gate in should_inline decide differently with
+# and without -g and emit different machine code. This builds two callees with the
+# identical real body -- one clean, one carrying enough OP_DBG_VALUE births to cross
+# INLINE_INSTR_THRESHOLD if they were counted -- and proves the count (hence the
+# inline decision) is the same for both, at the size boundary where it matters.
+test "mach.lang.me.pass.inline.callee_instr_count:dbg_value_blind" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+    val res_m: R.Result[ir.Module, str] = ir.init(?alloc, intern.STR_NIL);
+    if (R.is_err[ir.Module, str](res_m)) { ret 1; }
+    var m: ir.Module = R.unwrap_ok[ir.Module, str](res_m);
+
+    val res_i64: R.Result[type.IrTypeId, str] = type.intern_int(?m.types, 64);
+    if (R.is_err[type.IrTypeId, str](res_i64)) { ir.dnit(?m); ret 1; }
+    val i64t: type.IrTypeId = R.unwrap_ok[type.IrTypeId, str](res_i64);
+
+    # nadd real adds keep the clean count just below the threshold; kdbg debug
+    # values are enough to push a dbg-value-counting implementation over it.
+    val nadd: u32 = 19;
+    val kdbg: u32 = 6;
+
+    var bld: builder.Builder = builder.init(?m);
+
+    # clean callee: nadd adds + a terminator, no debug values.
+    val res_c: R.Result[u32, str] = ir.function_add(?m, intern.STR_NIL, type.IRT_NIL, 0);
+    if (R.is_err[u32, str](res_c)) { ir.dnit(?m); ret 1; }
+    val fn_clean: *ir.Function = ?m.functions[R.unwrap_ok[u32, str](res_c)];
+    builder.set_function(?bld, fn_clean);
+    val res_cb: R.Result[id.BlockId, str] = builder.new_block(?bld);
+    if (R.is_err[id.BlockId, str](res_cb)) { ir.dnit(?m); ret 1; }
+    builder.set_block(?bld, R.unwrap_ok[id.BlockId, str](res_cb));
+    var ca: value.Value = value.const_int(1, i64t);
+    var i: u32 = 0;
+    for (i < nadd) {
+        val r: R.Result[value.Value, str] = builder.emit_add(?bld, ca, value.const_int(1, i64t));
+        if (R.is_err[value.Value, str](r)) { ir.dnit(?m); ret 1; }
+        ca = R.unwrap_ok[value.Value, str](r);
+        i = i + 1;
+    }
+    if (R.is_err[bool, str](builder.emit_ret_void(?bld))) { ir.dnit(?m); ret 1; }
+
+    # laden callee: the same nadd adds, then kdbg debug values, then a terminator.
+    val res_l: R.Result[u32, str] = ir.function_add(?m, intern.STR_NIL, type.IRT_NIL, 0);
+    if (R.is_err[u32, str](res_l)) { ir.dnit(?m); ret 1; }
+    val fn_laden: *ir.Function = ?m.functions[R.unwrap_ok[u32, str](res_l)];
+    builder.set_function(?bld, fn_laden);
+    val res_lb: R.Result[id.BlockId, str] = builder.new_block(?bld);
+    if (R.is_err[id.BlockId, str](res_lb)) { ir.dnit(?m); ret 1; }
+    builder.set_block(?bld, R.unwrap_ok[id.BlockId, str](res_lb));
+    var la: value.Value = value.const_int(1, i64t);
+    var track: value.Value = la;
+    var j: u32 = 0;
+    for (j < nadd) {
+        val r: R.Result[value.Value, str] = builder.emit_add(?bld, la, value.const_int(1, i64t));
+        if (R.is_err[value.Value, str](r)) { ir.dnit(?m); ret 1; }
+        la = R.unwrap_ok[value.Value, str](r);
+        track = la;
+        j = j + 1;
+    }
+    var d: u32 = 0;
+    for (d < kdbg) {
+        if (R.is_err[bool, str](builder.emit_dbg_value(?bld, track, intern.STR_NIL, i64t, semtype.TYPE_NIL, false, 0))) { ir.dnit(?m); ret 1; }
+        d = d + 1;
+    }
+    if (R.is_err[bool, str](builder.emit_ret_void(?bld))) { ir.dnit(?m); ret 1; }
+
+    val clean: u32 = callee_instr_count(fn_clean);
+    val laden: u32 = callee_instr_count(fn_laden);
+    ir.dnit(?m);
+
+    # the fix: debug values do not change the count, so the decision is unchanged
+    if (clean != laden)                        { ret 1; }
+    # the clean body is under the threshold -- it inlines
+    if (!(clean < INLINE_INSTR_THRESHOLD))     { ret 1; }
+    # counting the debug values would have crossed the threshold and refused to inline
+    if (clean + kdbg < INLINE_INSTR_THRESHOLD) { ret 1; }
     ret 0;
 }

--- a/src/lang/target/isa/arm64/encode.mach
+++ b/src/lang/target/isa/arm64/encode.mach
@@ -2130,6 +2130,10 @@ fun encode_function_arm64(st: *encode.EncodeState, f: *mir.MirFunction) R.Result
             # epilogue, so an epilogue+RET maps to the RET's line).
             val rr: R.Result[bool, str] = encode.push_row(st, st.buf.len::u32, mi.loc);
             if (R.is_err[bool, str](rr)) { ret rr; }
+            # record the active inline instance at this instruction for the DWARF
+            # inlined_subroutine producer; only instance transitions append a record.
+            val rip: R.Result[bool, str] = encode.push_inline_pc(st, st.buf.len::u32, mi.inline_site);
+            if (R.is_err[bool, str](rip)) { ret rip; }
             if (mi.opcode::u16 == arm64.RET::u16 && !naked) {
                 emit_epilogue(st, f, subsize);
             }

--- a/src/lang/target/isa/riscv64/encode.mach
+++ b/src/lang/target/isa/riscv64/encode.mach
@@ -2001,6 +2001,10 @@ fun encode_function_riscv64(st: *encode.EncodeState, f: *mir.MirFunction) R.Resu
             # kept correct by the relax pass's insert_text below.
             val rr: R.Result[bool, str] = encode.push_row(st, st.buf.len::u32, mi.loc);
             if (R.is_err[bool, str](rr)) { ret rr; }
+            # record the active inline instance at this instruction for the DWARF
+            # inlined_subroutine producer; only instance transitions append a record.
+            val rip: R.Result[bool, str] = encode.push_inline_pc(st, st.buf.len::u32, mi.inline_site);
+            if (R.is_err[bool, str](rip)) { ret rip; }
             if (mi.opcode::u16 == riscv64.RET::u16 && !naked) {
                 emit_epilogue(st, f, total);
             }

--- a/src/lang/target/isa/x64/encode.mach
+++ b/src/lang/target/isa/x64/encode.mach
@@ -2502,6 +2502,10 @@ fun encode_function(st: *enc.EncodeState, f: *mir.MirFunction) R.Result[bool, st
             # epilogue, so an epilogue+RET maps to the RET's line).
             val rr: R.Result[bool, str] = enc.push_row(st, st.buf.len::u32, mi.loc);
             if (R.is_err[bool, str](rr)) { ret rr; }
+            # record the active inline instance at this instruction for the DWARF
+            # inlined_subroutine producer; only instance transitions append a record.
+            val rip: R.Result[bool, str] = enc.push_inline_pc(st, st.buf.len::u32, mi.inline_site);
+            if (R.is_err[bool, str](rip)) { ret rip; }
             # the function epilogue precedes every RET: restore callee-saved
             # registers and tear down the frame, then encode the RET itself.
             if (mi.opcode::u16 == x64.RET::u16 && !naked) {


### PR DESCRIPTION
The producer tier on top of the inline-site channel (#1924): makes inlined code transparent to debuggers. gdb shows inlined frames with correct call file:line, nested inlines, and inlined-frame parameters + locals, on optimized `-g` binaries.

## Money proof
On an optimized `-g` build with a forced-inline `helper`, gdb at an inlined PC:
```
#0  helper (x=16) at ./src/main.mach:3     (inlined frame + parameter)
#1  main () at ./src/main.mach:5           (caller, at the call site)
(gdb) info locals  ->  zzscratch = 16      (the inlined local, with its value)
```
A two-level fixture nests `leaf` under `mid` under `main`, `--verify` clean.

## Complete
- [x] Encoder per-instance PC-range tracking (`InlinePc` transitions).
- [x] DWARF inlining vocabulary (tags/attrs/`DW_RLE_*`).
- [x] `gather_inlines` (IR inline-sites × transitions → per-instance extents + call file/line; a descendant's extents roll into its ancestors so nested ranges are contained).
- [x] `produce` wiring.
- [x] Abstract-instance subprograms (`DW_AT_inline`) + `DW_TAG_inlined_subroutine` (abstract_origin, call_file/call_line).
- [x] `.debug_rnglists` + `DW_AT_ranges` for multi-extent instances (exact, no span-overlap).
- [x] Nested instances under their parent's DIE (recursive tree emission).
- [x] dbg-clone re-added: inlined locals nested under their instance (the #1930 removal, now with its consumer).

## Bar
`llvm-dwarfdump --verify` clean; release `-g` stable (no crash); 536/536 unit; self-host fixpoint byte-identical; non-`-g` byte-identical to dev; step-5 additivity (`-g` adds only debug sections). #1904-class range-fidelity caveat extends to inlined-variable ranges.

Closes #1707. Builds on the merged #1924 channel.
