### PR TITLE
refactor(ir): single Function initializer (function_new)

### DIFF
--- a/src/lang/me/ir.mach
+++ b/src/lang/me/ir.mach
@@ -554,6 +554,49 @@ fun agg_value_dnit(m: *Module, v: *value.Value) {
     }
 }
 
+# construct a fresh Function with the given identity, every storage field zeroed to
+# safe empty state: no params, blocks, or instructions, and each side table (asm,
+# dbg-vars, dbg-exprs, inline sites) an empty map/pool backed by `alloc`. the single
+# authority for Function field initialisation - every creation site builds through
+# this, so a new Function field is added in exactly one place and can never be left
+# nil at a forgetful site (the -g-only nil-allocator faults of #1898/#1905/#1924).
+# ---
+# alloc: allocator backing the function's owned side-table maps
+# name:  interned function symbol name
+# sig:   IRT_FN signature type id
+# flags: bitwise-or of FN_FLAG_* bits
+# ret:   the initialised Function, ready to append to a module
+pub fun function_new(alloc: *A.Allocator, name: intern.StrId, sig: type.IrTypeId, flags: u32) Function {
+    var f: Function;
+    f.name        = name;
+    f.sig         = sig;
+    f.params      = nil;
+    f.param_count = 0;
+    f.blocks      = nil;
+    f.block_count = 0;
+    f.block_cap   = 0;
+    f.instrs      = nil;
+    f.instr_len   = 0;
+    f.instr_cap   = 0;
+    f.flags       = flags;
+    f.label       = intern.STR_NIL;
+    f.line        = 0;
+    f.section     = intern.STR_NIL;
+    f.disp        = intern.STR_NIL;
+    f.ret_sem     = semtype.TYPE_NIL;
+    f.asm_blocks  = map.init[id.InstructionId, IrAsm](alloc, map.hash_u32, map.eq_u32);
+    f.dbg_vars    = map.init[id.InstructionId, DbgVar](alloc, map.hash_u32, map.eq_u32);
+    f.dbg_exprs    = nil;
+    f.dbg_expr_len = 0;
+    f.dbg_expr_cap = 0;
+    f.dbg_expr_ids = map.init[id.InstructionId, DbgExprId](alloc, map.hash_u32, map.eq_u32);
+    f.inline_sites      = nil;
+    f.inline_site_len   = 0;
+    f.inline_site_cap   = 0;
+    f.instr_inline_site = map.init[id.InstructionId, u32](alloc, map.hash_u32, map.eq_u32);
+    ret f;
+}
+
 # append a new empty function to the module and return its index. the function
 # carries the given name, signature, and flags, with no params, blocks, or
 # instructions, and an empty inline-asm side table; the function array grows as
@@ -576,34 +619,7 @@ pub fun function_add(m: *Module, name: intern.StrId, sig: type.IrTypeId, flags: 
         m.function_cap = new_cap;
     }
     val idx: u32 = m.function_len;
-    var f: Function;
-    f.name        = name;
-    f.sig         = sig;
-    f.params      = nil;
-    f.param_count = 0;
-    f.blocks      = nil;
-    f.block_count = 0;
-    f.block_cap   = 0;
-    f.instrs      = nil;
-    f.instr_len   = 0;
-    f.instr_cap   = 0;
-    f.flags       = flags;
-    f.label       = intern.STR_NIL;
-    f.line        = 0;
-    f.section     = intern.STR_NIL;
-    f.disp        = intern.STR_NIL;
-    f.ret_sem     = semtype.TYPE_NIL;
-    f.asm_blocks  = map.init[id.InstructionId, IrAsm](m.alloc, map.hash_u32, map.eq_u32);
-    f.dbg_vars    = map.init[id.InstructionId, DbgVar](m.alloc, map.hash_u32, map.eq_u32);
-    f.dbg_exprs    = nil;
-    f.dbg_expr_len = 0;
-    f.dbg_expr_cap = 0;
-    f.dbg_expr_ids = map.init[id.InstructionId, DbgExprId](m.alloc, map.hash_u32, map.eq_u32);
-    f.inline_sites      = nil;
-    f.inline_site_len   = 0;
-    f.inline_site_cap   = 0;
-    f.instr_inline_site = map.init[id.InstructionId, u32](m.alloc, map.hash_u32, map.eq_u32);
-    m.functions[idx] = f;
+    m.functions[idx] = function_new(m.alloc, name, sig, flags);
     m.function_len   = m.function_len + 1;
     ret R.ok[u32, str](idx);
 }

--- a/src/lang/me/lower/context.mach
+++ b/src/lang/me/lower/context.mach
@@ -1214,35 +1214,7 @@ pub fun ensure_extern_function(lc: *LowerContext, name: intern.StrId, sig: ir_ty
     }
 
     val idx: u32 = m.function_len;
-    var f: ir.Function;
-    f.name        = name;
-    f.sig         = sig;
-    f.params      = nil;
-    f.param_count = 0;
-    f.blocks      = nil;
-    f.block_count = 0;
-    f.block_cap   = 0;
-    f.instrs      = nil;
-    f.instr_len   = 0;
-    f.instr_cap   = 0;
-    f.flags       = ir.FN_FLAG_EXTERN;
-    f.label       = intern.STR_NIL;
-    f.line        = 0;
-    f.section     = intern.STR_NIL;
-    f.disp        = intern.STR_NIL;
-    f.ret_sem     = type.TYPE_NIL;
-    f.asm_blocks  = map.init[ir.InstructionId, ir.IrAsm](m.alloc, map.hash_u32, map.eq_u32);
-    f.dbg_vars    = map.init[ir.InstructionId, ir.DbgVar](m.alloc, map.hash_u32, map.eq_u32);
-    f.dbg_exprs    = nil;
-    f.dbg_expr_len = 0;
-    f.dbg_expr_cap = 0;
-    f.dbg_expr_ids = map.init[ir.InstructionId, ir.DbgExprId](m.alloc, map.hash_u32, map.eq_u32);
-    f.inline_sites      = nil;
-    f.inline_site_len   = 0;
-    f.inline_site_cap   = 0;
-    f.instr_inline_site = map.init[ir.InstructionId, u32](m.alloc, map.hash_u32, map.eq_u32);
-
-    m.functions[idx] = f;
+    m.functions[idx] = ir.function_new(m.alloc, name, sig, ir.FN_FLAG_EXTERN);
     m.function_len   = m.function_len + 1;
     val res_reg: R.Result[bool, str] = ir.function_register(m, name, idx);
     if (R.is_err[bool, str](res_reg)) { ret R.err[u32, str](R.unwrap_err[bool, str](res_reg)); }

--- a/src/lang/me/lower/decl.mach
+++ b/src/lang/me/lower/decl.mach
@@ -1233,35 +1233,7 @@ fun append_function(ctx: *context.LowerContext, name: intern.StrId, sig: ir_type
     }
 
     val idx: u32 = m.function_len;
-    var f: ir.Function;
-    f.name        = name;
-    f.sig         = sig;
-    f.params      = nil;
-    f.param_count = 0;
-    f.blocks      = nil;
-    f.block_count = 0;
-    f.block_cap   = 0;
-    f.instrs      = nil;
-    f.instr_len   = 0;
-    f.instr_cap   = 0;
-    f.flags       = flags;
-    f.label       = intern.STR_NIL;
-    f.line        = 0;
-    f.section     = intern.STR_NIL;
-    f.disp        = intern.STR_NIL;
-    f.ret_sem     = type.TYPE_NIL;
-    f.asm_blocks  = map.init[ir.InstructionId, ir.IrAsm](m.alloc, map.hash_u32, map.eq_u32);
-    f.dbg_vars    = map.init[ir.InstructionId, ir.DbgVar](m.alloc, map.hash_u32, map.eq_u32);
-    f.dbg_exprs    = nil;
-    f.dbg_expr_len = 0;
-    f.dbg_expr_cap = 0;
-    f.dbg_expr_ids = map.init[ir.InstructionId, ir.DbgExprId](m.alloc, map.hash_u32, map.eq_u32);
-    f.inline_sites      = nil;
-    f.inline_site_len   = 0;
-    f.inline_site_cap   = 0;
-    f.instr_inline_site = map.init[ir.InstructionId, u32](m.alloc, map.hash_u32, map.eq_u32);
-
-    m.functions[idx] = f;
+    m.functions[idx] = ir.function_new(m.alloc, name, sig, flags);
     m.function_len   = m.function_len + 1;
     val res_reg: R.Result[bool, str] = ir.function_register(m, name, idx);
     if (R.is_err[bool, str](res_reg)) { ret R.err[u32, str](R.unwrap_err[bool, str](res_reg)); }


### PR DESCRIPTION
## What

`ir.Function` was hand-initialised field-by-field at three sites — `function_add` in `ir.mach` plus the two lowering constructors `append_function` (`me/lower/decl.mach`) and `ensure_extern_function` (`me/lower/context.mach`). Every new field had to be added at all three, and a missed site left a map with a nil allocator that is inert until first use and faults only under `-g`. This trap caused three `-g`-only segfaults in consecutive PRs: #1898 (`dbg_vars`), #1905 (`dbg_expr_ids`), #1924 (inline-site fields).

## Change

A single `function_new(alloc, name, sig, flags)` constructor in `ir.mach` now owns all Function field initialisation. The three creation sites call it with their own identity inputs (`ensure_extern_function` passing `FN_FLAG_EXTERN`). Net −40 lines; the two lowering sites drop ~30 lines of duplicated init each.

Adding a hypothetical Function field is now a one-line edit inside `function_new` — the diff shape at the two lowering sites would be zero, where before it was three identical edits.

## Behaviour

Pure refactor, pinned by byte-identity:

- **Unit suite:** 536 passed / 0 failed, exact match to fresh-`dev` baseline (also 536/536).
- **Self-host fixpoint:** byte-identical on this branch (stage2 == stage3) and on clean `dev`.
- **Refactor equivalence (airtight):** the refactored compiler and the `dev` compiler emit **byte-identical** output for identical input, in both directions — `myFix(devSrc) == devFix(devSrc)` and `devFix(mySrc) == myFix(mySrc)`. Codegen is provably unchanged.
- **int harness (linux leg):** all surface + regression cases pass (debug + release).
- **`-g` sanity:** the `dbg/` DWARF lane passes on all three ELF ISAs, and a full `-g` build of the compiler itself runs the suite clean (536/536) — exercising every Function creation path at scale, which is exactly the bug class this prevents.

Acceptance criterion met: `grep` shows no field-by-field Function init outside `function_new`.

Closes #1906
