### PR TITLE
fix(driver): terminate git checkout committish with -- (#1890)

### DIFF
--- a/src/cli/cmd/dep.mach
+++ b/src/cli/cmd/dep.mach
@@ -1122,17 +1122,8 @@ fun git_fetch(gt: *GitTool, dir: str) {
 # ref: the dep's ref string
 # ret: ok(true), or an error when git exits non-zero
 fun git_checkout(a: *A.Allocator, gt: *GitTool, dir: str, ref: str) R.Result[bool, str] {
-    if (str_empty(ref)) { ret git_checkout_one(gt, dir, "origin/HEAD"); }
-    if (str_starts_with(ref, "branch/")) {
-        ret git_checkout_one(gt, dir, with_prefix(a, "origin/", drop_prefix(ref, 7)));
-    }
-    if (str_starts_with(ref, "tag/")) {
-        ret git_checkout_one(gt, dir, drop_prefix(ref, 4));
-    }
-    if (str_starts_with(ref, "commit/")) {
-        ret git_checkout_one(gt, dir, drop_prefix(ref, 7));
-    }
-    if (is_hex_sha(ref)) { ret git_checkout_one(gt, dir, ref); }
+    val committish: O.Option[str] = resolve_committish(a, ref);
+    if (O.is_some[str](committish)) { ret git_checkout_one(gt, dir, O.unwrap[str](committish)); }
 
     val remote_ref: str = with_prefix(a, "refs/remotes/origin/", ref);
     if (git_ref_exists(gt, dir, remote_ref)) {
@@ -1141,21 +1132,48 @@ fun git_checkout(a: *A.Allocator, gt: *GitTool, dir: str, ref: str) R.Result[boo
     ret git_checkout_one(gt, dir, ref);
 }
 
-# run `git -C <dir> checkout --detach <committish>`
+# resolve a dep ref to its committish for the deterministic ref kinds
+#
+# The empty (default-branch) ref maps to `origin/HEAD`; `branch/<n>` to the
+# remote-tracking `origin/<n>`; `tag/<n>` to the bare tag; `commit/<n>` or a bare
+# sha to the literal commit. The `branch/`, `tag/`, and `commit/` values are
+# everything after their prefix, so a slashed branch name (`feat/x`, `fix/x`)
+# survives intact - the split is on the prefix, never the last slash. A bare name
+# resolves to none; git_checkout probes the live remote-tracking ref for it.
+# ---
+# a:   allocator for the resolved committish
+# ref: the dep's ref string
+# ret: the committish, or none for a bare name
+fun resolve_committish(a: *A.Allocator, ref: str) O.Option[str] {
+    if (str_empty(ref))                  { ret O.some[str]("origin/HEAD"); }
+    if (str_starts_with(ref, "branch/")) { ret O.some[str](with_prefix(a, "origin/", drop_prefix(ref, 7))); }
+    if (str_starts_with(ref, "tag/"))    { ret O.some[str](drop_prefix(ref, 4)); }
+    if (str_starts_with(ref, "commit/")) { ret O.some[str](drop_prefix(ref, 7)); }
+    if (is_hex_sha(ref))                 { ret O.some[str](ref); }
+    ret O.none[str]();
+}
+
+# run `git -C <dir> checkout --detach <committish> --`
+#
+# The trailing `--` ends the pathspec list, so a committish that fails to resolve
+# is reported as an invalid reference instead of being reinterpreted as a path -
+# git's misleading `--detach does not take a path argument` otherwise fires for
+# any unresolved ref, including a slashed branch name (#1890).
 # ---
 # gt:         the resolved git transport
 # dir:        the checkout directory
 # committish: the resolved commit-ish to detach onto
 # ret:        ok(true), or an error when git exits non-zero
 fun git_checkout_one(gt: *GitTool, dir: str, committish: str) R.Result[bool, str] {
-    var argv: [7]usize;
+    var argv: [8]usize;
     argv[0] = gt.git::usize;
     argv[1] = "-C"::usize;
     argv[2] = dir::usize;
     argv[3] = "checkout"::usize;
     argv[4] = "--detach"::usize;
     argv[5] = committish::usize;
-    argv[6] = 0;
+    argv[6] = "--"::usize;
+    argv[7] = 0;
     ret run_git(gt.git, gt.env, (?argv[0])::**u8);
 }
 
@@ -2051,6 +2069,37 @@ test "mach.cli.cmd.dep.ref_advanceable" {
     if (ref_advanceable("tag/v1.0.0"))                               { ret 1; }
     if (ref_advanceable("commit/abcdef0"))                           { ret 1; }
     if (ref_advanceable("0123456789abcdef0123456789abcdef01234567")) { ret 1; }
+    ret 0;
+}
+
+# resolve_committish maps each ref kind to its committish and keeps the full
+# slashed branch name (everything after `branch/`, not just the last segment) so
+# `feat/x` / `fix/x` refs resolve to `origin/feat/x` / `origin/fix/x` (#1890).
+test "mach.cli.cmd.dep.resolve_committish" {
+    var a: A.Allocator;
+    if (O.is_some[str](page.make(?a))) { ret 1; }
+
+    val def: O.Option[str] = resolve_committish(?a, "");
+    if (!O.is_some[str](def) || !str_equals(O.unwrap[str](def), "origin/HEAD"))                { ret 1; }
+
+    val plain: O.Option[str] = resolve_committish(?a, "branch/main");
+    if (!O.is_some[str](plain) || !str_equals(O.unwrap[str](plain), "origin/main"))            { ret 1; }
+
+    val slashed: O.Option[str] = resolve_committish(?a, "branch/fix/1890");
+    if (!O.is_some[str](slashed) || !str_equals(O.unwrap[str](slashed), "origin/fix/1890"))    { ret 1; }
+
+    val tag: O.Option[str] = resolve_committish(?a, "tag/v1.2.3");
+    if (!O.is_some[str](tag) || !str_equals(O.unwrap[str](tag), "v1.2.3"))                     { ret 1; }
+
+    val commit: O.Option[str] = resolve_committish(?a, "commit/deadbee");
+    if (!O.is_some[str](commit) || !str_equals(O.unwrap[str](commit), "deadbee"))              { ret 1; }
+
+    val sha: str = "0123456789abcdef0123456789abcdef01234567";
+    val res_sha: O.Option[str] = resolve_committish(?a, sha);
+    if (!O.is_some[str](res_sha) || !str_equals(O.unwrap[str](res_sha), sha))                  { ret 1; }
+
+    # a bare name defers to the live remote-tracking probe.
+    if (O.is_some[str](resolve_committish(?a, "some-tip")))                                    { ret 1; }
     ret 0;
 }
 


### PR DESCRIPTION
Closes #1890

## Root cause

`git_checkout_one` ran `git -C <dir> checkout --detach <committish>` with no `--` pathspec terminator. When `<committish>` fails to resolve to a revision, git reinterprets it as a pathspec and dies with the misleading `fatal: git checkout: --detach does not take a path argument '<committish>'`. A dep pointed at a branch absent from its repo hits exactly this — the slash in `branch/fix/1885` is incidental (any unresolved ref, slashed or not, triggers it).

The resolution itself was already correct: `branch/fix/1885` → `origin/fix/1885`, and an existing slashed branch checks out fine. The defect was the missing pathspec terminator turning "ref not found" into a confusing "path argument" error.

## Fix

- Append `--` to the `git checkout --detach` argv. An unresolved ref is now reported as `fatal: invalid reference: <committish>`; existing branches (slashed or not), tags, commits, and shas continue to check out unchanged.
- Extract the deterministic ref→committish mapping into a pure `resolve_committish` helper and unit-test it, locking in that a slashed branch name (`feat/x`, `fix/x`) survives intact — the `branch/` value is everything after the prefix, not the last slash.

## Verification

- From-source build; self-host fixpoint byte-identical (stage2 == stage3).
- Unit suite: 537 passed, 0 failed (dev baseline 536 + the new `resolve_committish` test).
- int linux leg: all cases pass.
- End-to-end with the from-source binary: `branch/fix/<n>` checks out its tip; an absent ref now errors with `fatal: invalid reference: ...` instead of the pathspec message.
