### PR TITLE
fix(comptime): fold $each field-descriptor $if gates (#1923)

### DIFF
--- a/int/regression/1923-comptime-field-gate/expect.txt
+++ b/int/regression/1923-comptime-field-gate/expect.txt
@@ -1,0 +1,4 @@
+name: kind field
+name: data.apple = 42
+type: scalar field
+type: union.apple = 42

--- a/int/regression/1923-comptime-field-gate/mach.toml
+++ b/int/regression/1923-comptime-field-gate/mach.toml
@@ -1,0 +1,52 @@
+[project]
+id      = "case"
+name    = "case"
+version = "0.0.0"
+src     = "src"
+dep     = "dep"
+target  = "linux"
+out     = "out/{target}/{profile}/bin/{name}{ext}"
+
+[target.linux]
+isa = "x86_64"
+os  = "linux"
+abi = "sysv64"
+
+[target.linux-arm64]
+isa = "aarch64"
+os  = "linux"
+abi = "aapcs64"
+
+[target.linux-riscv64]
+isa = "riscv64"
+os  = "linux"
+abi = "lp64"
+
+[target.windows]
+isa = "x86_64"
+os  = "windows"
+abi = "win64"
+ext = ".exe"
+
+[target.darwin-x86_64]
+isa = "x86_64"
+os  = "darwin"
+abi = "sysv64"
+
+[target.darwin-aarch64]
+isa = "aarch64"
+os  = "darwin"
+abi = "aapcs64"
+
+[profile.debug]
+opt = 0
+
+[profile.release]
+opt = 2
+
+[bin.case]
+entry = "main.mach"
+
+[deps.mach-std]
+git = "https://github.com/briar-systems/mach-std"
+ref = "branch/main"

--- a/int/regression/1923-comptime-field-gate/src/main.mach
+++ b/int/regression/1923-comptime-field-gate/src/main.mach
@@ -1,0 +1,64 @@
+# regression pin for #1923: comptime `$each $fields(T)` gates on field metadata
+#
+# a `$if` gate that reads a `$each` field descriptor (`f.name` string comparison or
+# `f.type` type comparison) must defer arm selection to the `$each` unroll, where
+# the loop variable is bound per iteration -- so only the live arm is type-checked
+# and `r.[f]` resolves to the concrete field's type. before the fix, `f.name == "x"`
+# was rejected during resolution ("a module-qualified member path is only comptime-
+# evaluable after name resolution"), and a heterogeneous `r.[f]` access under a
+# type gate mis-typed against another field ("no such field `apple` on type u8").
+
+use std.runtime;
+use p: std.print;
+
+pub def FruitKind: u8;
+pub val KindApple: FruitKind = 0;
+
+pub uni FruitData {
+    apple: i64;
+    banana: f64;
+}
+
+pub rec Favorite {
+    kind: FruitKind;
+    data: FruitData;
+}
+
+# defect: string comparison on `f.name`, plus a name-guarded union field access.
+# generic over T, mirroring the reporting scenario.
+pub fun describe_by_name[T](r: T) {
+    $each f in $fields(T) {
+        $if (f.name == "kind") {
+            p.println("name: kind field");
+        }
+        $or (f.name == "data") {
+            p.printf("name: data.apple = {}\n", r.[f].apple);
+        }
+        $or {
+            p.printf("name: other ({})\n", f.name);
+        }
+    }
+}
+
+# defect: a type-guarded union field access on a concrete record. the union arm is
+# type-checked only for the field whose type is FruitData, never against `kind`.
+fun describe_by_type(r: Favorite) {
+    $each f in $fields(Favorite) {
+        $if (f.type == FruitData) {
+            p.printf("type: union.apple = {}\n", r.[f].apple);
+        }
+        $or {
+            p.println("type: scalar field");
+        }
+    }
+}
+
+#[symbol("main")]
+pub fun main(argc: i64, argv: **u8) i64 {
+    var f: Favorite;
+    f.kind = KindApple;
+    f.data.apple = 42;
+    describe_by_name[Favorite](f);
+    describe_by_type(f);
+    ret 0;
+}

--- a/src/lang/fe/comptime.mach
+++ b/src/lang/fe/comptime.mach
@@ -1389,6 +1389,27 @@ pub fun is_field_type_member(a: *ast.Ast, source: str, eid: id.ExprId) bool {
     ret view_eq_str(span_text(source, node.data.member.name), "type");
 }
 
+# whether `eid` is structurally a `.name` / `.type` / `.offset` member access (a
+# candidate field-descriptor projection, #1473). a structural test only - the
+# object is confirmed to be a `$each` loop variable by the typed layers, so a real
+# record field of one of these names is never mistaken for a projection. used to
+# defer a `$if` chain whose gate reads a field descriptor to lowering, where the
+# loop variable is bound per iteration.
+# ---
+# a:      the ast that owns `eid`
+# source: source text (for the member span)
+# eid:    expression id to test
+# ret:    true when `eid` is a `<expr>.name` / `.type` / `.offset` member access
+pub fun is_field_descriptor_member(a: *ast.Ast, source: str, eid: id.ExprId) bool {
+    if (eid == id.EXPR_NIL) { ret false; }
+    val n_opt: O.Option[*expr.Expr] = ast.get_expr(a, eid);
+    if (O.is_none[*expr.Expr](n_opt)) { ret false; }
+    val node: *expr.Expr = O.unwrap[*expr.Expr](n_opt);
+    if (node.kind != expr.EXPR_KIND_MEMBER) { ret false; }
+    val m: StrView = span_text(source, node.data.member.name);
+    ret view_eq_str(m, "name") || view_eq_str(m, "type") || view_eq_str(m, "offset");
+}
+
 # whether `eid` is an `f.type` operand whose object
 # actually evaluates to a field descriptor (a fold-time check used to recognize a
 # `f.type == T` type comparison precisely, without mistaking a real `.type`

--- a/src/lang/fe/resolve.mach
+++ b/src/lang/fe/resolve.mach
@@ -1630,7 +1630,8 @@ fun bind_fwd_module(rc: *ResolveContext, decl_id: id.DeclId, df: *decl.DeclFwd, 
 # ret:            ok(true), or a binding or eval error
 fun bind_comptime_if(rc: *ResolveContext, branches_start: u32, branches_len: u32, at_decl_scope: bool) R.Result[bool, str] {
     if (!at_decl_scope && (comptime_if_gated_on_param(rc, branches_start, branches_len)
-                        || comptime_if_has_type_comparison(rc, branches_start, branches_len))) {
+                        || comptime_if_has_type_comparison(rc, branches_start, branches_len)
+                        || comptime_if_gated_on_field_descriptor(rc, branches_start, branches_len))) {
         var ai: u32 = 0;
         for (ai < branches_len) {
             val arm: *decl.ComptimeBranch = ?rc.a.comptime_branches[branches_start + ai];
@@ -1764,6 +1765,51 @@ fun comptime_if_has_type_comparison(rc: *ResolveContext, branches_start: u32, br
             ret true;
         }
         bi = bi + 1;
+    }
+    ret false;
+}
+
+# reports whether any arm gate of a `$if` chain reads a `$each` field descriptor
+# (`f.name` / `f.type` / `f.offset`). such a gate folds only once the loop variable
+# is bound at the `$each` unroll, so - like a comptime-param or type-comparison
+# gate - its chain binds every arm and defers arm selection to that unroll. the
+# `.type` case overlaps comptime_if_has_type_comparison; the `.name` / `.offset`
+# cases are covered only here.
+# ---
+# rc:             resolver state for the module being resolved
+# branches_start: first branch index
+# branches_len:   number of branches
+# ret:            true when an arm gate reads a `$each` field descriptor
+fun comptime_if_gated_on_field_descriptor(rc: *ResolveContext, branches_start: u32, branches_len: u32) bool {
+    var bi: u32 = 0;
+    for (bi < branches_len) {
+        val br: *decl.ComptimeBranch = ?rc.a.comptime_branches[branches_start + bi];
+        if (br.cond != id.EXPR_NIL && gate_references_field_descriptor(rc, br.cond)) {
+            ret true;
+        }
+        bi = bi + 1;
+    }
+    ret false;
+}
+
+# walks a `$if` gate reporting whether it reads a `$each` field-descriptor
+# projection (`f.name` / `f.type` / `f.offset`) at any depth.
+# ---
+# rc:  resolver state for the module being resolved
+# eid: the gate expression to walk
+# ret: true when a field-descriptor projection appears at any depth
+fun gate_references_field_descriptor(rc: *ResolveContext, eid: id.ExprId) bool {
+    if (eid == id.EXPR_NIL) { ret false; }
+    if (is_field_descriptor_operand(rc, eid)) { ret true; }
+    val e_opt: O.Option[*expr.Expr] = ast.get_expr(rc.a, eid);
+    if (O.is_none[*expr.Expr](e_opt)) { ret false; }
+    val e: *expr.Expr = O.unwrap[*expr.Expr](e_opt);
+    if (e.kind == expr.EXPR_KIND_BINARY) {
+        ret gate_references_field_descriptor(rc, e.data.binary.lhs)
+         || gate_references_field_descriptor(rc, e.data.binary.rhs);
+    }
+    if (e.kind == expr.EXPR_KIND_UNARY) {
+        ret gate_references_field_descriptor(rc, e.data.unary.operand);
     }
     ret false;
 }
@@ -2719,6 +2765,19 @@ fun bind_type_operand(rc: *ResolveContext, operand: id.ExprId) R.Result[bool, st
 # ret: true when `eid` is a `$each` field descriptor's `.type`
 fun is_field_type_operand(rc: *ResolveContext, eid: id.ExprId) bool {
     if (!comptime.is_field_type_member(rc.a, rc.source, eid)) { ret false; }
+    ret member_object_is_field_loopvar(rc, eid);
+}
+
+# whether member expression `eid`'s object resolves, in the current scope, to a
+# `$each` field-descriptor loop variable (a SYM_VAL bearing SYM_FLAG_COMPTIME).
+# shared by the `.type` type-comparison recognition and the broader
+# field-descriptor gate deferral, so a real record field access (`s.type`) is never
+# mistaken for a descriptor projection.
+# ---
+# rc:  resolver state for the module being resolved
+# eid: a member expression (its object is the candidate loop variable)
+# ret: true when the object names a `$each` loop variable
+fun member_object_is_field_loopvar(rc: *ResolveContext, eid: id.ExprId) bool {
     val n_opt: O.Option[*expr.Expr] = ast.get_expr(rc.a, eid);
     if (O.is_none[*expr.Expr](n_opt)) { ret false; }
     val obj: id.ExprId = O.unwrap[*expr.Expr](n_opt).data.member.object;
@@ -2732,6 +2791,19 @@ fun is_field_type_operand(rc: *ResolveContext, eid: id.ExprId) bool {
     if (sid == SYMBOL_NIL) { ret false; }
     val sym: *Symbol = ?rc.symbols[sid];
     ret sym.kind == SYM_VAL && (sym.flags & SYM_FLAG_COMPTIME) != 0;
+}
+
+# whether `eid` is a `<loopvar>.name` / `.type` / `.offset` projection off a `$each`
+# field descriptor. a `$if` gate reading one cannot fold during resolve (the loop
+# variable is bound only per iteration, at the `$each` unroll), so its chain binds
+# every arm and defers arm selection there - mirroring the type-comparison defer.
+# ---
+# rc:  resolver state for the module being resolved
+# eid: the candidate projection expression
+# ret: true when `eid` is a field-descriptor projection over a `$each` loop variable
+fun is_field_descriptor_operand(rc: *ResolveContext, eid: id.ExprId) bool {
+    if (!comptime.is_field_descriptor_member(rc.a, rc.source, eid)) { ret false; }
+    ret member_object_is_field_loopvar(rc, eid);
 }
 
 # interns a static literal in the session interner, returning its StrId or

--- a/src/lang/fe/sema.mach
+++ b/src/lang/fe/sema.mach
@@ -112,7 +112,20 @@ pub fun sema(
         ret R.err[context.SemaResult, str](R.unwrap_err[bool, str](res_decls));
     }
 
+    # install the field / type-comparison resolvers so `comptime.eval` can fold a
+    # `$each $fields(T)` body's gates during inference, selecting the live arm
+    # instead of type-checking every arm against the wrong field type (#1473,
+    # #1923). the field resolver folds `f.name` / `f.type` (`.offset` stays deferred
+    # to lowering); the type resolver folds the type-name / `$type_of` operand of a
+    # type comparison whose type is known at sema. pack / generic bodies stay
+    # deferred and fold against the lowering-installed resolvers instead. both are
+    # cleared after so the borrowed ctx never keeps a dangling `sc` pointer.
+    val scp: *context.SemaContext = ?sc;
+    comptime.set_field_resolver(ctx, context.resolve_field_member::*u8, scp::ptr);
+    comptime.set_type_resolver(ctx, context.resolve_type_comparison_operand::*u8, scp::ptr);
     val res_bodies: R.Result[bool, str] = infer_all_bodies(?sc);
+    comptime.set_field_resolver(ctx, nil, nil);
+    comptime.set_type_resolver(ctx, nil, nil);
     if (R.is_err[bool, str](res_bodies)) {
         dnit_context(?sc);
         ret R.err[context.SemaResult, str](R.unwrap_err[bool, str](res_bodies));

--- a/src/lang/fe/sema/context.mach
+++ b/src/lang/fe/sema/context.mach
@@ -365,6 +365,59 @@ pub fun field_lookup(sc: *SemaContext, ty: type.TypeId, name: intern.StrId) O.Op
     ret O.none[type.TypeId]();
 }
 
+# the field-descriptor member resolver (a comptime.FieldMemberFn) sema installs on
+# the ComptimeCtx while inferring bodies, so `comptime.eval` can fold a `f.name` /
+# `f.type` projection off a `$each` loop variable's CT_KIND_FIELD value (#1473).
+# this is the "name/type half" the field-resolver contract assigns to sema; only
+# `.offset` needs the target layout, so it returns none here (surfacing "not
+# available until lowering") and is resolved by the lowering-installed resolver.
+# without it, a `$each` gate like `$if (f.name == "x")` could not fold at sema and
+# every arm would be type-checked, mis-typing a heterogeneous field access.
+# ---
+# data:  the *SemaContext, erased to a ptr by the installer
+# owner: the owning record's sema TypeId
+# index: the field ordinal
+# sel:   a comptime.FIELD_SEL_* selector
+# ret:   some(value) for `.name` / `.type`, none for `.offset` or an out-of-range ordinal
+pub fun resolve_field_member(data: ptr, owner: u32, index: u32, sel: u8) R.Result[O.Option[comptime.CTValue], str] {
+    val sc: *SemaContext = data::*SemaContext;
+    if (sc == nil) { ret R.ok[O.Option[comptime.CTValue], str](O.none[comptime.CTValue]()); }
+    val fa: O.Option[*type.FieldEntry] = type.field_at(?sc.s.types, owner::type.TypeId, index);
+    if (O.is_none[*type.FieldEntry](fa)) { ret R.ok[O.Option[comptime.CTValue], str](O.none[comptime.CTValue]()); }
+    val fe: *type.FieldEntry = O.unwrap[*type.FieldEntry](fa);
+
+    if (sel == comptime.FIELD_SEL_NAME) {
+        ret R.ok[O.Option[comptime.CTValue], str](O.some[comptime.CTValue](comptime.ct_str(fe.name)));
+    }
+    if (sel == comptime.FIELD_SEL_TYPE) {
+        ret R.ok[O.Option[comptime.CTValue], str](O.some[comptime.CTValue](comptime.ct_type(fe.ty::u32)));
+    }
+    # `.offset` needs the target layout, unavailable until lowering.
+    ret R.ok[O.Option[comptime.CTValue], str](O.none[comptime.CTValue]());
+}
+
+# the type-comparison operand resolver (a comptime.TypeIdentFn) sema installs
+# alongside the field resolver while inferring bodies, so `comptime.eval` can fold a
+# type comparison whose operands' types are already known at sema - an `f.type == T`
+# gate over a `$each` field descriptor, or a `$type_of(x) == T` gate over a value of
+# concrete type (#1472, #1923). the operand arrives already unwrapped past any
+# `$type_of(...)`; its semantic type was written into expr_type by
+# infer_type_comparison, so this reads it back. an unresolved / erroneous operand
+# returns none, deferring arm selection to lowering.
+# ---
+# data: the *SemaContext, erased to a ptr by the installer
+# eid:  the operand value expression id, valid in this module's ast
+# ret:  some(type-id token) when the operand has a resolved type, else none
+pub fun resolve_type_comparison_operand(data: ptr, eid: id.ExprId) R.Result[O.Option[u32], str] {
+    val sc: *SemaContext = data::*SemaContext;
+    if (sc == nil)           { ret R.ok[O.Option[u32], str](O.none[u32]()); }
+    if (sc.expr_type == nil) { ret R.ok[O.Option[u32], str](O.none[u32]()); }
+    if (eid == id.EXPR_NIL || eid >= sc.a.expr_len::u32) { ret R.ok[O.Option[u32], str](O.none[u32]()); }
+    val t: type.TypeId = sc.expr_type[eid];
+    if (t == type.TYPE_NIL || t == type.TYPE_ERROR) { ret R.ok[O.Option[u32], str](O.none[u32]()); }
+    ret R.ok[O.Option[u32], str](O.some[u32](t::u32));
+}
+
 # the declared type of a SYM_PARAM, read from the enclosing function's parameter
 # list at `sym.slot`
 #

--- a/src/lang/fe/sema/infer.mach
+++ b/src/lang/fe/sema/infer.mach
@@ -705,17 +705,18 @@ fun join_secret(sc: *context.SemaContext, base: type.TypeId, secret: bool) type.
 #
 # Each operand is typed for its type identity -- a `$type_of(e)` operand by
 # inferring its inner value `e`, a type-name operand by resolving the named type
-# into its expr_type slot -- so the lowering-time resolver reads a populated type
-# either way. The comparison itself is a bool (u8), foldable only at lowering
-# where the resolver is installed.
+# into its expr_type slot -- so the type resolver reads a populated type either
+# way. The comparison itself is a bool (u8); it folds once both operand types are
+# known -- at sema for a concrete-typed body (the resolver sema installs), else at
+# monomorphization for a pack / generic body deferred to lowering.
 # ---
 # sc:   sema context
 # b:    the equality/inequality payload
 # span: the operator span for diagnostics
 # ret:  u8, or TYPE_ERROR
 fun infer_type_comparison(sc: *context.SemaContext, b: *expr.ExprBinary, span: token.Span) type.TypeId {
-    # a type comparison is comptime-only: it folds to a selected arm at lowering
-    # and has no runtime value. valid only as a `$if` gate condition; in any
+    # a type comparison is comptime-only: it folds to a selected arm at compile
+    # time and has no runtime value. valid only as a `$if` gate condition; in any
     # runtime value position it is a misuse, reported at its own span.
     if (!sc.in_comptime_gate) {
         context.report(sc, span, "a `$type_of` type comparison is comptime-only; it is valid only as a `$if` gate condition");


### PR DESCRIPTION
Closes #1923

## Problem

A `$if` gate that reads a `$each $fields(T)` loop variable's metadata could not fold, because the loop variable is bound only per iteration (at the `$each` unroll), yet the front end handled only *type-comparison* gates that way:

- **Missing string comparison** — `$if (f.name == "kind")` was rejected at resolution with `a module-qualified member path is only comptime-evaluable after name resolution`. Resolve tried to fold the gate eagerly; only `f.type`/`$type_of` gates were deferred to the unroll.
- **Type confusion** — a heterogeneous `r.[f]` access under a `f.type == UnionType` gate mis-typed against another field (`no such field \`apple\` on type u8`), because sema type-checked *every* arm when the gate could not fold, so the union-access arm was checked with `f` bound to the wrong field.

The root cause is one gap: field-descriptor comptime folding was never available during resolve or the sema pass — only at lowering. The `set_field_resolver` contract already documents that *"sema installs the name/type half"*, but sema never installed it.

## Fix

- **resolve** — defer a `$if` chain whose gate reads any field-descriptor projection (`.name` / `.type` / `.offset`) to the `$each` unroll, mirroring the existing type-comparison defer.
- **sema** — install the field and type-comparison resolvers (reading the type table / `expr_type` sema already populates) while inferring bodies, so `f.name` / `f.type == T` gates fold and only the live arm is type-checked. `.offset` stays deferred to lowering (needs the target layout); pack / generic bodies stay deferred and fold at monomorphization against the lowering-installed resolvers.

No expansion-site special-casing: the fix restores the layered field-descriptor fold the model already intended.

## Verification

- from-source build; self-host fixpoint **byte-identical**
- unit suite **536 passed, 0 failed** (unchanged from the origin/dev baseline)
- int **linux** leg green, including the new `regression/1923-comptime-field-gate` case
- the new int case is falsifiable: pre-fix it fails with exactly the issue's three errors (string-comparison rejection at the two `f.name` gates, `no such field \`apple\` on type u8` at the union access); post-fix it builds and runs
