### PR TITLE
feat(debuginfo): DWARF aggregate/composite type DIEs (#1919)

### DIFF
--- a/dbg/fixtures/aggregate/mach.toml
+++ b/dbg/fixtures/aggregate/mach.toml
@@ -1,0 +1,52 @@
+[project]
+id      = "dbgagg"
+name    = "dbgagg"
+version = "0.0.0"
+src     = "src"
+dep     = "dep"
+target  = "linux"
+out     = "out/{target}/{profile}/bin/{name}{ext}"
+
+[target.linux]
+isa = "x86_64"
+os  = "linux"
+abi = "sysv64"
+
+[target.linux-arm64]
+isa = "aarch64"
+os  = "linux"
+abi = "aapcs64"
+
+[target.linux-riscv64]
+isa = "riscv64"
+os  = "linux"
+abi = "lp64"
+
+[target.windows]
+isa = "x86_64"
+os  = "windows"
+abi = "win64"
+ext = ".exe"
+
+[target.darwin-x86_64]
+isa = "x86_64"
+os  = "darwin"
+abi = "sysv64"
+
+[target.darwin-aarch64]
+isa = "aarch64"
+os  = "darwin"
+abi = "aapcs64"
+
+[profile.debug]
+opt = 0
+
+[profile.release]
+opt = 2
+
+[bin.dbgagg]
+entry = "main.mach"
+
+[deps.mach-std]
+git = "https://github.com/briar-systems/mach-std"
+ref = "branch/main"

--- a/dbg/fixtures/aggregate/src/main.mach
+++ b/dbg/fixtures/aggregate/src/main.mach
@@ -1,0 +1,61 @@
+# debug-info verification fixture: aggregate and composite-typed locals
+#
+# exercises the #1919 composite type-DIE tier. `main` holds a struct local (a record
+# with mixed-width fields), an array local, and a typed pointer to the struct, so the
+# emitted DWARF must carry a DW_TAG_structure_type with DW_TAG_member children at their
+# byte offsets, a DW_TAG_array_type + DW_TAG_subrange_type, and a DW_TAG_pointer_type
+# resolving to the record. the dbg lane's aggregate leg asserts those DIEs; add/mul/
+# square keep the generic structural + additivity checks (shared with `multi`) live.
+
+use std.runtime;
+use std.types.size.usize;
+use p: std.print;
+
+# a record with mixed-width fields, so member byte offsets are non-trivial (padding
+# between `tag` and `count`) and exercise the IR-layout-driven DW_AT_data_member_location.
+rec Point {
+    x:     i32;
+    y:     i32;
+    tag:   u8;
+    count: i64;
+}
+
+fun add(a: i64, b: i64) i64 {
+    ret a + b;
+}
+
+fun mul(a: i64, b: i64) i64 {
+    ret a * b;
+}
+
+fun square(v: i64) i64 {
+    val s: i64 = mul(v, v);
+    ret s;
+}
+
+fun sink(v: i64) i64 {
+    ret v;
+}
+
+#[symbol("main")]
+fun main(argc: usize, argv: **u8) i64 {
+    var pt: Point;
+    pt.x     = 7;
+    pt.y     = 9;
+    pt.tag   = 3;
+    pt.count = 100;
+
+    var arr: [4]i32;
+    arr[0] = 10;
+    arr[1] = 20;
+    arr[2] = 30;
+    arr[3] = 40;
+
+    var pp: *Point = ?pt;
+
+    val acc: i64 = add(pt.x::i64, pt.y::i64);
+    val q:   i64 = square(pp.count);
+    val s:   i64 = sink(acc + q + arr[2]::i64 + mul(pp.x::i64, 2));
+    p.printlnf("s={}", s);
+    ret 0;
+}

--- a/dbg/verify.sh
+++ b/dbg/verify.sh
@@ -250,6 +250,30 @@ verify_dwarf() {
         fi
     fi
 
+    # 8. composite type DIEs (#1919): a fixture with a record local emits a
+    #    DW_TAG_structure_type with DW_TAG_member children at their byte offsets, a
+    #    DW_TAG_array_type + DW_TAG_subrange_type for its array local, and a
+    #    DW_TAG_pointer_type resolving the record for its typed pointer. under the
+    #    primitive-only tier all of these are absent, so this is the falsifiable
+    #    composite check. the by-reference aggregate location (DW_OP_breg / fbreg+deref,
+    #    not DW_OP_reg) is what makes an aggregate's members readable, so it is asserted too.
+    if grep -q '^rec ' "$src"; then
+        di=$("$dwarfdump" --debug-info "$g" 2>/dev/null)
+        for tag in DW_TAG_structure_type DW_TAG_member DW_TAG_array_type DW_TAG_subrange_type DW_TAG_pointer_type; do
+            if ! printf '%s\n' "$di" | grep -q "$tag"; then
+                echo "FAIL $label (no $tag DIE for aggregate/composite locals)"; rm -rf "$tmp"; return 1
+            fi
+        done
+        if ! printf '%s\n' "$di" | grep -q 'DW_AT_data_member_location'; then
+            echo "FAIL $label (struct member has no DW_AT_data_member_location)"; rm -rf "$tmp"; return 1
+        fi
+        # a record local's location must address its storage (DW_OP_breg or fbreg+deref),
+        # never DW_OP_reg (which would misread the address as the aggregate's bytes).
+        if ! printf '%s\n' "$di" | grep -Eq 'DW_OP_breg|DW_OP_fbreg'; then
+            echo "FAIL $label (no by-reference aggregate location)"; rm -rf "$tmp"; return 1
+        fi
+    fi
+
     echo "PASS $label"
     rm -rf "$tmp"
     return 0

--- a/dbg/verify.sh
+++ b/dbg/verify.sh
@@ -134,25 +134,6 @@ var_computed() {
         END { print "0" }' | head -1
 }
 
-# var_home_class <binary> <name> — the DWARF opcode class of the named local's inline
-# single-location DW_AT_location: "fbreg" / "breg" / "reg", or "" for a loclist or no
-# location. A by-reference aggregate (#1919) MUST be "breg" (address in a register) or
-# "fbreg" (address via the frame, dereferenced) because its home holds the storage
-# pointer; a regression to "reg" (value-in-register) would misread that pointer as the
-# aggregate's bytes and — critically — llvm-dwarfdump --verify still accepts it, so this
-# is the falsifiable pin that value-encoding an aggregate can't slip past CI.
-var_home_class() {
-    "$dwarfdump" --debug-info "$1" 2>/dev/null | awk -v want="$2" '
-        /DW_TAG_/    { invar = ($0 ~ /DW_TAG_variable/); name="" }
-        /DW_AT_name/ && invar { if ($0 ~ "\\(\"" want "\"\\)") name=want }
-        name==want && /DW_AT_location/ {
-            if ($0 ~ /DW_OP_fbreg/) { print "fbreg"; exit }
-            if ($0 ~ /DW_OP_breg/)  { print "breg";  exit }
-            if ($0 ~ /DW_OP_reg/)   { print "reg";   exit }
-            print ""; exit
-        }' | head -1
-}
-
 # elf_seg_identical <a> <b> — true if every PT_LOAD segment of <a> has byte-identical
 # file content in <b>, after the ELF header's section-table bookkeeping (e_shoff,
 # e_shnum, e_shstrndx — expected to differ once -g adds named sections) is normalized.
@@ -273,9 +254,8 @@ verify_dwarf() {
     #    DW_TAG_structure_type with DW_TAG_member children at their byte offsets, a
     #    DW_TAG_array_type + DW_TAG_subrange_type for its array local, and a
     #    DW_TAG_pointer_type resolving the record for its typed pointer. under the
-    #    primitive-only tier all of these are absent, so this is the falsifiable
-    #    composite check. the by-reference aggregate location (DW_OP_breg / fbreg+deref,
-    #    not DW_OP_reg) is what makes an aggregate's members readable, so it is asserted too.
+    #    primitive-only tier all of these are absent, so this is the falsifiable composite
+    #    check.
     if grep -q '^rec ' "$src"; then
         di=$("$dwarfdump" --debug-info "$g" 2>/dev/null)
         for tag in DW_TAG_structure_type DW_TAG_member DW_TAG_array_type DW_TAG_subrange_type DW_TAG_pointer_type; do
@@ -286,18 +266,37 @@ verify_dwarf() {
         if ! printf '%s\n' "$di" | grep -q 'DW_AT_data_member_location'; then
             echo "FAIL $label (struct member has no DW_AT_data_member_location)"; rm -rf "$tmp"; return 1
         fi
-        # the record local's OWN location must address its storage (DW_OP_breg, or
-        # DW_OP_fbreg+deref when spilled), never DW_OP_reg — its dbg-value binds the
-        # storage pointer, so value-in-register would misread that pointer as the
-        # aggregate's bytes. scoped to the `pt` record local (not a whole-dump grep, which
-        # every scalar frame slot's DW_OP_fbreg would satisfy) so a regression to value
-        # encoding is actually caught; llvm-dwarfdump --verify accepts either form.
-        if grep -q 'var pt:' "$src"; then
-            cls=$(var_home_class "$g" pt)
-            if [ "$cls" != "breg" ] && [ "$cls" != "fbreg" ]; then
-                echo "FAIL $label (record local 'pt' location class is '${cls:-none}', expected by-reference DW_OP_breg/fbreg, not DW_OP_reg)"; rm -rf "$tmp"; return 1
-            fi
+
+        # 8a. the array's element count and the pointer's pointee are VALUE-checked, not
+        #     just tag-checked: llvm-dwarfdump synthesizes a type's name from its DIE, so
+        #     a wrong DW_AT_count renders "i32[3]" not "i32[4]", and a pointer whose ref4
+        #     resolves to the wrong pointee renders e.g. "i32 *" not "Point *". both would
+        #     pass --verify (any in-CU ref4 / any count is structurally valid), so these
+        #     catch value drift the tag greps miss.
+        if ! printf '%s\n' "$di" | grep -q 'DW_AT_type.*"i32\[4\]"'; then
+            echo "FAIL $label (array local's DW_AT_count is not 4: no i32[4] type)"; rm -rf "$tmp"; return 1
         fi
+        if ! printf '%s\n' "$di" | grep -q 'DW_AT_type.*"Point \*"'; then
+            echo "FAIL $label (typed pointer does not resolve to the Point record)"; rm -rf "$tmp"; return 1
+        fi
+
+        # 8b. by-reference aggregate locations never use a bare register address. An
+        #     aggregate's dbg-value is its storage POINTER; describing it whole-scope as
+        #     DW_OP_breg<reg>+0 (address in a reused register) is a wild pointer read that
+        #     --verify accepts. The producer instead emits DW_OP_fbreg+DW_OP_deref for a
+        #     frame home and OMITS a register home, so a DW_OP_breg location that is NOT a
+        #     computed value (no DW_OP_stack_value) is the regression, on any variable.
+        if printf '%s\n' "$di" | grep 'DW_OP_breg' | grep -qv 'DW_OP_stack_value'; then
+            echo "FAIL $label (a DW_OP_breg location is a bare register address, not a computed value — the aggregate wild-read regression)"; rm -rf "$tmp"; return 1
+        fi
+
+        # NOTE (member VALUES): these checks are structural — DIE shape, DW_AT_count and
+        # pointee names, and location-form. They do NOT read a member's runtime VALUE
+        # (`pt.count == 100`); that needs a debugger executing the target, and the ELF lane
+        # is a host-side DWARF inspector (llvm-dwarfdump / addr2line), tool-free of a
+        # runtime. The member-value read is the STAGED lldb source-breakpoint check (see the
+        # staged block below); until a runtime runner lands, a frame-homed aggregate's
+        # member values are proven only by the PR's manual gdb transcript, not by CI.
     fi
 
     echo "PASS $label"
@@ -366,6 +365,36 @@ verify_no_foreign_file() {
     return 0
 }
 
+# verify_aggregate_release <fixture_dir> <build_target> — the release counterpart of the
+# composite checks. At -O2 an aggregate's storage pointer re-homes across its scope, so
+# its location becomes a `.debug_loclists` list (the debug build keeps a single stable
+# home and never exercises that path). This leg asserts --verify is clean and, crucially,
+# that no aggregate location is a bare DW_OP_breg register address (the wild-read
+# regression) even when homes move — the byref plumb-through in the per-range loclist
+# emit is otherwise unexercised by CI.
+verify_aggregate_release() {
+    dir=$1; bt=$2
+    label="${dir#"$here"/} [$bt release]"
+    tmp=$(mktemp -d)
+    g="$tmp/g"
+    if ! (cd "$dir" && "$compiler" dep pull && "$compiler" build . --target "$bt" --profile release -g -o "$g") >"$tmp/b.log" 2>&1; then
+        echo "FAIL $label (build release -g)"; sed 's/^/    /' "$tmp/b.log" >&2; rm -rf "$tmp"; return 1
+    fi
+    if ! "$dwarfdump" --verify "$g" >"$tmp/v.log" 2>&1; then
+        echo "FAIL $label (llvm-dwarfdump --verify)"; tail -30 "$tmp/v.log" | sed 's/^/    /' >&2; rm -rf "$tmp"; return 1
+    fi
+    di=$("$dwarfdump" --debug-info "$g" 2>/dev/null)
+    if ! printf '%s\n' "$di" | grep -q 'DW_TAG_structure_type'; then
+        echo "FAIL $label (no composite type DIE at release)"; rm -rf "$tmp"; return 1
+    fi
+    if printf '%s\n' "$di" | grep 'DW_OP_breg' | grep -qv 'DW_OP_stack_value'; then
+        echo "FAIL $label (a moving aggregate rendered a bare DW_OP_breg register address — the wild-read regression in the loclist path)"; rm -rf "$tmp"; return 1
+    fi
+    echo "PASS $label"
+    rm -rf "$tmp"
+    return 0
+}
+
 for dir in "$fixtures"/$filter; do
     [ -f "$dir/mach.toml" ] || continue
     # the inline fixtures are release-only (their callees inline away at -O0); they have
@@ -391,6 +420,16 @@ if [ -f "$fixtures/inline4/mach.toml" ]; then
     for bt in $elf_targets; do
         ran=$((ran + 1))
         verify_inline_release "$fixtures/inline4" "$bt" 4 "a b c d" || fails=$((fails + 1))
+    done
+fi
+
+# #1919 release leg: an aggregate re-homes at -O2, so its location becomes a loclist; this
+# exercises the byref plumb-through in the per-range loclist emit that the debug build
+# (single stable home) never reaches, and pins the no-bare-breg wild-read guard there.
+if [ -f "$fixtures/aggregate/mach.toml" ]; then
+    for bt in $elf_targets; do
+        ran=$((ran + 1))
+        verify_aggregate_release "$fixtures/aggregate" "$bt" || fails=$((fails + 1))
     done
 fi
 

--- a/dbg/verify.sh
+++ b/dbg/verify.sh
@@ -134,6 +134,25 @@ var_computed() {
         END { print "0" }' | head -1
 }
 
+# var_home_class <binary> <name> — the DWARF opcode class of the named local's inline
+# single-location DW_AT_location: "fbreg" / "breg" / "reg", or "" for a loclist or no
+# location. A by-reference aggregate (#1919) MUST be "breg" (address in a register) or
+# "fbreg" (address via the frame, dereferenced) because its home holds the storage
+# pointer; a regression to "reg" (value-in-register) would misread that pointer as the
+# aggregate's bytes and — critically — llvm-dwarfdump --verify still accepts it, so this
+# is the falsifiable pin that value-encoding an aggregate can't slip past CI.
+var_home_class() {
+    "$dwarfdump" --debug-info "$1" 2>/dev/null | awk -v want="$2" '
+        /DW_TAG_/    { invar = ($0 ~ /DW_TAG_variable/); name="" }
+        /DW_AT_name/ && invar { if ($0 ~ "\\(\"" want "\"\\)") name=want }
+        name==want && /DW_AT_location/ {
+            if ($0 ~ /DW_OP_fbreg/) { print "fbreg"; exit }
+            if ($0 ~ /DW_OP_breg/)  { print "breg";  exit }
+            if ($0 ~ /DW_OP_reg/)   { print "reg";   exit }
+            print ""; exit
+        }' | head -1
+}
+
 # elf_seg_identical <a> <b> — true if every PT_LOAD segment of <a> has byte-identical
 # file content in <b>, after the ELF header's section-table bookkeeping (e_shoff,
 # e_shnum, e_shstrndx — expected to differ once -g adds named sections) is normalized.
@@ -267,10 +286,17 @@ verify_dwarf() {
         if ! printf '%s\n' "$di" | grep -q 'DW_AT_data_member_location'; then
             echo "FAIL $label (struct member has no DW_AT_data_member_location)"; rm -rf "$tmp"; return 1
         fi
-        # a record local's location must address its storage (DW_OP_breg or fbreg+deref),
-        # never DW_OP_reg (which would misread the address as the aggregate's bytes).
-        if ! printf '%s\n' "$di" | grep -Eq 'DW_OP_breg|DW_OP_fbreg'; then
-            echo "FAIL $label (no by-reference aggregate location)"; rm -rf "$tmp"; return 1
+        # the record local's OWN location must address its storage (DW_OP_breg, or
+        # DW_OP_fbreg+deref when spilled), never DW_OP_reg — its dbg-value binds the
+        # storage pointer, so value-in-register would misread that pointer as the
+        # aggregate's bytes. scoped to the `pt` record local (not a whole-dump grep, which
+        # every scalar frame slot's DW_OP_fbreg would satisfy) so a regression to value
+        # encoding is actually caught; llvm-dwarfdump --verify accepts either form.
+        if grep -q 'var pt:' "$src"; then
+            cls=$(var_home_class "$g" pt)
+            if [ "$cls" != "breg" ] && [ "$cls" != "fbreg" ]; then
+                echo "FAIL $label (record local 'pt' location class is '${cls:-none}', expected by-reference DW_OP_breg/fbreg, not DW_OP_reg)"; rm -rf "$tmp"; return 1
+            fi
         fi
     fi
 

--- a/src/lang/be/codegen/dwarf.mach
+++ b/src/lang/be/codegen/dwarf.mach
@@ -53,6 +53,14 @@ val DW_TAG_subprogram:       u8 = 0x2e;
 val DW_TAG_formal_parameter: u8 = 0x05;
 val DW_TAG_variable:         u8 = 0x34;
 val DW_TAG_inlined_subroutine: u8 = 0x1d;
+# composite / aggregate type DIEs (#1919): struct / union / array with member and
+# subrange children, and a typed pointer to a pointee DIE
+val DW_TAG_array_type:       u8 = 0x01;
+val DW_TAG_pointer_type:     u8 = 0x0f;
+val DW_TAG_member:           u8 = 0x0d;
+val DW_TAG_structure_type:   u8 = 0x13;
+val DW_TAG_union_type:       u8 = 0x17;
+val DW_TAG_subrange_type:    u8 = 0x21;
 val DW_CHILDREN_no:          u8 = 0x00;
 val DW_CHILDREN_yes:         u8 = 0x01;
 
@@ -76,6 +84,10 @@ val DW_AT_abstract_origin: u8 = 0x31;
 val DW_AT_inline:          u8 = 0x20;
 val DW_AT_call_file:       u8 = 0x58;
 val DW_AT_call_line:       u8 = 0x59;
+# composite-type attributes (#1919): a member's byte offset within its enclosing
+# struct/union, and an array subrange's element count
+val DW_AT_data_member_location: u8 = 0x38;
+val DW_AT_count:                u8 = 0x37;
 
 # DW_AT_inline value: this subprogram is an abstract instance that was inlined (never
 # out-of-line here); its concrete expansions are DW_TAG_inlined_subroutine DIEs that

--- a/src/lang/be/codegen/dwarf.mach
+++ b/src/lang/be/codegen/dwarf.mach
@@ -181,6 +181,14 @@ val ABBREV_INLINED_RANGES_KIDS: u8 = 0x0f;
 # --verify (#1949)
 val ABBREV_SUBPROGRAM_LEAF:      u8 = 0x10;
 val ABBREV_SUBPROGRAM_VOID_LEAF: u8 = 0x11;
+# composite/aggregate type DIEs (#1919): a struct/union with member children, an array
+# with a subrange child, and a childless typed pointer
+val ABBREV_STRUCT:   u8 = 0x12;
+val ABBREV_UNION:    u8 = 0x13;
+val ABBREV_MEMBER:   u8 = 0x14;
+val ABBREV_ARRAY:    u8 = 0x15;
+val ABBREV_SUBRANGE: u8 = 0x16;
+val ABBREV_POINTER:  u8 = 0x17;
 
 # DWARF 5 line-number program: standard opcodes, extended opcodes, and the tuned
 # special-opcode parameters this producer emits
@@ -771,6 +779,51 @@ fun build_abbrev(b: *enc.ByteBuf) {
     # subprogram that emits no parameters, locals, or inlined instances (#1949).
     build_subprogram_abbrev(b, ABBREV_SUBPROGRAM_LEAF,      true,  false);
     build_subprogram_abbrev(b, ABBREV_SUBPROGRAM_VOID_LEAF, false, false);
+
+    # composite type DIEs (#1919). struct / union carry a name + byte size and hold
+    # DW_TAG_member children; a member names its type (ref4) and byte offset. an array
+    # names its element type and holds a DW_TAG_subrange child carrying the element count.
+    # a typed pointer names its pointee (ref4) and pointer width.
+    uleb(b, ABBREV_STRUCT::u64);
+    uleb(b, DW_TAG_structure_type::u64);
+    enc.emit_byte(b, DW_CHILDREN_yes);
+    emit_attr(b, DW_AT_name,      DW_FORM_strp);
+    emit_attr(b, DW_AT_byte_size, DW_FORM_udata);
+    uleb(b, 0); uleb(b, 0);
+
+    uleb(b, ABBREV_UNION::u64);
+    uleb(b, DW_TAG_union_type::u64);
+    enc.emit_byte(b, DW_CHILDREN_yes);
+    emit_attr(b, DW_AT_name,      DW_FORM_strp);
+    emit_attr(b, DW_AT_byte_size, DW_FORM_udata);
+    uleb(b, 0); uleb(b, 0);
+
+    uleb(b, ABBREV_MEMBER::u64);
+    uleb(b, DW_TAG_member::u64);
+    enc.emit_byte(b, DW_CHILDREN_no);
+    emit_attr(b, DW_AT_name,                 DW_FORM_strp);
+    emit_attr(b, DW_AT_type,                 DW_FORM_ref4);
+    emit_attr(b, DW_AT_data_member_location, DW_FORM_udata);
+    uleb(b, 0); uleb(b, 0);
+
+    uleb(b, ABBREV_ARRAY::u64);
+    uleb(b, DW_TAG_array_type::u64);
+    enc.emit_byte(b, DW_CHILDREN_yes);
+    emit_attr(b, DW_AT_type, DW_FORM_ref4);
+    uleb(b, 0); uleb(b, 0);
+
+    uleb(b, ABBREV_SUBRANGE::u64);
+    uleb(b, DW_TAG_subrange_type::u64);
+    enc.emit_byte(b, DW_CHILDREN_no);
+    emit_attr(b, DW_AT_count, DW_FORM_udata);
+    uleb(b, 0); uleb(b, 0);
+
+    uleb(b, ABBREV_POINTER::u64);
+    uleb(b, DW_TAG_pointer_type::u64);
+    enc.emit_byte(b, DW_CHILDREN_no);
+    emit_attr(b, DW_AT_type,      DW_FORM_ref4);
+    emit_attr(b, DW_AT_byte_size, DW_FORM_udata);
+    uleb(b, 0); uleb(b, 0);
 
     uleb(b, 0);   # null abbrev code terminates the table
 }
@@ -2580,16 +2633,16 @@ test "mach.lang.be.codegen.dwarf.uleb_sleb:canonical" {
     ret code;
 }
 
-# build_abbrev emits the exact thirteen-abbrev table (compile-unit, base type, the two
-# subprogram shapes, the located / no-location variable + parameter shapes, the two
-# loclist variable + parameter shapes, the abstract-instance subprogram, and the two
-# inlined_subroutine shapes), byte for byte
+# build_abbrev emits the exact abbrev table byte for byte: compile-unit, base type, the
+# subprogram shapes (with/without return, children/leaf), the variable + parameter shapes
+# (located / no-location / loclist), the abstract-instance and inlined_subroutine shapes,
+# and the composite type shapes (struct / union / member / array / subrange / pointer)
 test "mach.lang.be.codegen.dwarf.build_abbrev:golden" {
     var alloc: A.Allocator;
     page.make(?alloc);
     var b: enc.ByteBuf = enc.buf_init(?alloc);
     build_abbrev(?b);
-    var e: [238]u8;
+    var e: [290]u8;
     e[0]=0x01; e[1]=0x11; e[2]=0x01; e[3]=0x25; e[4]=0x08; e[5]=0x03; e[6]=0x08; e[7]=0x1B;
     e[8]=0x08; e[9]=0x13; e[10]=0x05; e[11]=0x11; e[12]=0x01; e[13]=0x12; e[14]=0x07; e[15]=0x10;
     e[16]=0x17; e[17]=0x00; e[18]=0x00; e[19]=0x02; e[20]=0x24; e[21]=0x00; e[22]=0x03; e[23]=0x0E;
@@ -2635,8 +2688,20 @@ test "mach.lang.be.codegen.dwarf.build_abbrev:golden" {
     e[218]=0x11; e[219]=0x2E; e[220]=0x00; e[221]=0x03; e[222]=0x0E; e[223]=0x11; e[224]=0x01;
     e[225]=0x12; e[226]=0x07; e[227]=0x3F; e[228]=0x0C; e[229]=0x3A; e[230]=0x0F; e[231]=0x3B;
     e[232]=0x0F; e[233]=0x40; e[234]=0x18; e[235]=0x00; e[236]=0x00;
-    e[237]=0x00;   # null abbrev code terminates the table
-    val ok: bool = buf_eq(?b, ?e[0], 238);
+    # ABBREV_STRUCT (0x12): DW_TAG_structure_type, children, name strp, byte_size udata.
+    e[237]=0x12; e[238]=0x13; e[239]=0x01; e[240]=0x03; e[241]=0x0E; e[242]=0x0B; e[243]=0x0F; e[244]=0x00; e[245]=0x00;
+    # ABBREV_UNION (0x13): DW_TAG_union_type, children, name strp, byte_size udata.
+    e[246]=0x13; e[247]=0x17; e[248]=0x01; e[249]=0x03; e[250]=0x0E; e[251]=0x0B; e[252]=0x0F; e[253]=0x00; e[254]=0x00;
+    # ABBREV_MEMBER (0x14): DW_TAG_member, no children, name strp, type ref4, data_member_location udata.
+    e[255]=0x14; e[256]=0x0D; e[257]=0x00; e[258]=0x03; e[259]=0x0E; e[260]=0x49; e[261]=0x13; e[262]=0x38; e[263]=0x0F; e[264]=0x00; e[265]=0x00;
+    # ABBREV_ARRAY (0x15): DW_TAG_array_type, children, element type ref4.
+    e[266]=0x15; e[267]=0x01; e[268]=0x01; e[269]=0x49; e[270]=0x13; e[271]=0x00; e[272]=0x00;
+    # ABBREV_SUBRANGE (0x16): DW_TAG_subrange_type, no children, count udata.
+    e[273]=0x16; e[274]=0x21; e[275]=0x00; e[276]=0x37; e[277]=0x0F; e[278]=0x00; e[279]=0x00;
+    # ABBREV_POINTER (0x17): DW_TAG_pointer_type, no children, pointee type ref4, byte_size udata.
+    e[280]=0x17; e[281]=0x0F; e[282]=0x00; e[283]=0x49; e[284]=0x13; e[285]=0x0B; e[286]=0x0F; e[287]=0x00; e[288]=0x00;
+    e[289]=0x00;   # null abbrev code terminates the table
+    val ok: bool = buf_eq(?b, ?e[0], 290);
     enc.buf_dnit(?b);
     if (!ok) { ret 1; }
     ret 0;

--- a/src/lang/be/codegen/dwarf.mach
+++ b/src/lang/be/codegen/dwarf.mach
@@ -791,9 +791,14 @@ fun sem_to_ir(s: *session.Session, irmod: *ir.Module, sem: semtype.TypeId) R.Res
     if (k == semtype.TYPE_POINTER)           { ret ir_type.intern_ptr(?irmod.types); }
 
     if (k == semtype.TYPE_ARRAY) {
-        val rb: R.Result[ir_type.IrTypeId, str] = sem_to_ir(s, irmod, t.data.array.base);
+        # capture element + count before recursing: bridging the element can materialize a
+        # generic instance's field table (ensure_fields), reallocating s.types and dangling
+        # `t` - so a post-recursion `t.data.array.count` would read freed memory.
+        val ebase: semtype.TypeId = t.data.array.base;
+        val ecount: u32 = t.data.array.count;
+        val rb: R.Result[ir_type.IrTypeId, str] = sem_to_ir(s, irmod, ebase);
         if (R.is_err[ir_type.IrTypeId, str](rb)) { ret rb; }
-        ret ir_type.intern_array(?irmod.types, R.unwrap_ok[ir_type.IrTypeId, str](rb), t.data.array.count);
+        ret ir_type.intern_array(?irmod.types, R.unwrap_ok[ir_type.IrTypeId, str](rb), ecount);
     }
 
     if (k == semtype.TYPE_REC || k == semtype.TYPE_UNI || k == semtype.TYPE_INSTANCE) {

--- a/src/lang/be/codegen/dwarf.mach
+++ b/src/lang/be/codegen/dwarf.mach
@@ -34,11 +34,13 @@ use R: std.types.result;
 use enc:     mach.lang.be.codegen.encode;
 use obj:     mach.lang.be.obj;
 use ir:      mach.lang.me.ir;
+use ir_type: mach.lang.me.ir.type;
 use id:      mach.lang.me.ir.id;
 use intern:  mach.lang.intern;
 use session: mach.lang.session;
 use source:  mach.lang.source;
 use semtype: mach.lang.type;
+use generics: mach.lang.fe.sema.generics;
 use target:  mach.lang.target.resolved;
 use isa:     mach.lang.target.isa;
 use of:      mach.lang.target.of;
@@ -182,13 +184,17 @@ val ABBREV_INLINED_RANGES_KIDS: u8 = 0x0f;
 val ABBREV_SUBPROGRAM_LEAF:      u8 = 0x10;
 val ABBREV_SUBPROGRAM_VOID_LEAF: u8 = 0x11;
 # composite/aggregate type DIEs (#1919): a struct/union with member children, an array
-# with a subrange child, and a childless typed pointer
-val ABBREV_STRUCT:   u8 = 0x12;
-val ABBREV_UNION:    u8 = 0x13;
-val ABBREV_MEMBER:   u8 = 0x14;
-val ABBREV_ARRAY:    u8 = 0x15;
-val ABBREV_SUBRANGE: u8 = 0x16;
-val ABBREV_POINTER:  u8 = 0x17;
+# with a subrange child, and a childless typed pointer. The *_LEAF struct/union variants
+# are DW_CHILDREN_no, for a memberless aggregate (an empty record) so it never advertises
+# children it lacks (the #1949 discipline)
+val ABBREV_STRUCT:      u8 = 0x12;
+val ABBREV_UNION:       u8 = 0x13;
+val ABBREV_MEMBER:      u8 = 0x14;
+val ABBREV_ARRAY:       u8 = 0x15;
+val ABBREV_SUBRANGE:    u8 = 0x16;
+val ABBREV_POINTER:     u8 = 0x17;
+val ABBREV_STRUCT_LEAF: u8 = 0x18;
+val ABBREV_UNION_LEAF:  u8 = 0x19;
 
 # DWARF 5 line-number program: standard opcodes, extended opcodes, and the tuned
 # special-opcode parameters this producer emits
@@ -329,6 +335,10 @@ val VLOC_CONST: u8 = 4;
 #           in the shared LocRange array; each range carries its own home + expression
 # loclist_off: byte offset of this variable's `.debug_loclists` entry, set by
 #           build_loclists, patched into the DW_FORM_sec_offset field
+# byref:    true when the variable is a by-reference aggregate (struct / union / array):
+#           its OP_DBG_VALUE binds the storage POINTER (an aggregate value is its
+#           storage), so its home holds the aggregate's address, not its value, and the
+#           location reads through that address rather than naming it
 rec DwVar {
     name_off:    u32;
     ty:          i32;
@@ -340,6 +350,7 @@ rec DwVar {
     range_start: u32;
     range_count: u32;
     loclist_off: u32;
+    byref:       bool;
     # the inline instance this variable belongs to (0 = the function's own body, else a
     # 1-based inline-site id); the #1707 producer nests a non-zero one under its instance
     inline_site: u32;
@@ -463,6 +474,19 @@ rec TypeMember {
     name_off: u32;
     type_ix:  u32;
     offset:   u32;
+}
+
+# a deferred DW_FORM_ref4 patch within the type-DIE block: at `.debug_info` byte offset
+# `pos` write the CU-relative offset of type `target`. Type DIEs cross-reference each
+# other (a member / element / pointee), and a self-referential aggregate makes some of
+# those references forward, so their targets' offsets are only known after the whole
+# block is emitted
+# ---
+# pos:    absolute `.debug_info` byte offset of the 4-byte ref4 field
+# target: the referenced type's index in the TypeCtx table
+rec TypeFixup {
+    pos:    u32;
+    target: u32;
 }
 
 # the compile unit's growable type table: the distinct type DIEs it emits plus the
@@ -739,6 +763,99 @@ fun sem_base_type(s: *session.Session, tid: semtype.TypeId, address_size: u8) O.
     ret O.some[TypeDie](bt);
 }
 
+# bridge a semantic type to its IR type, the single layout authority for aggregate DIEs
+# (member byte offsets / struct sizes). Mirrors the front end's `lower_type` structural
+# mapping; because the IR type interners deduplicate, this lands on the exact type
+# lowering already produced (a lookup in practice - every reachable type was lowered)
+# rather than a new one, so DWARF member offsets come from the same layout that emitted
+# the code. IR pointers are opaque, so this never recurses through one (it terminates)
+# ---
+# s:     session (semantic type universe, align overrides, allocator)
+# irmod: the IR module whose type universe is consulted
+# sem:   the semantic TypeId to bridge
+# ret:   the corresponding IrTypeId, or an allocation error
+fun sem_to_ir(s: *session.Session, irmod: *ir.Module, sem: semtype.TypeId) R.Result[ir_type.IrTypeId, str] {
+    if (sem == semtype.TYPE_NIL) { ret ir_type.intern_void(?irmod.types); }
+    val to: O.Option[*semtype.Type] = semtype.get(?s.types, sem);
+    if (O.is_none[*semtype.Type](to)) { ret ir_type.intern_void(?irmod.types); }
+    val t: *semtype.Type = O.unwrap[*semtype.Type](to);
+    val k: semtype.TypeKind = t.kind;
+
+    # secrecy has no runtime representation: `^T` bridges to exactly `T`'s shape.
+    if (k == semtype.TYPE_SECRET) { ret sem_to_ir(s, irmod, t.data.secret.base); }
+
+    val d: semtype.PrimDesc = semtype.prim_desc(k);
+    if (d.class == semtype.PRIM_CLASS_INT)   { ret ir_type.intern_int(?irmod.types, d.bits); }
+    if (d.class == semtype.PRIM_CLASS_FLOAT) { ret ir_type.intern_float(?irmod.types, d.bits); }
+    if (d.class == semtype.PRIM_CLASS_PTR)   { ret ir_type.intern_ptr(?irmod.types); }
+    if (k == semtype.TYPE_POINTER)           { ret ir_type.intern_ptr(?irmod.types); }
+
+    if (k == semtype.TYPE_ARRAY) {
+        val rb: R.Result[ir_type.IrTypeId, str] = sem_to_ir(s, irmod, t.data.array.base);
+        if (R.is_err[ir_type.IrTypeId, str](rb)) { ret rb; }
+        ret ir_type.intern_array(?irmod.types, R.unwrap_ok[ir_type.IrTypeId, str](rb), t.data.array.count);
+    }
+
+    if (k == semtype.TYPE_REC || k == semtype.TYPE_UNI || k == semtype.TYPE_INSTANCE) {
+        ret sem_to_ir_nominal(s, irmod, sem, k == semtype.TYPE_UNI);
+    }
+
+    # function / generic-param / error types bridge to an opaque pointer-width slot, as
+    # `lower_type` does, so a variable of such a type still sizes correctly.
+    ret ir_type.intern_ptr(?irmod.types);
+}
+
+# bridge a nominal (rec / uni) or generic instance to an IR struct / union of its lowered
+# field types, read from the session-global field store - the same source `lower_nominal`
+# uses, so the interned layout matches
+# ---
+# s:        session
+# irmod:    the IR module
+# tid:      the nominal / instance semantic TypeId
+# is_union: bridge to an IR union rather than a struct
+# ret:      the IrTypeId, or an allocation error
+fun sem_to_ir_nominal(s: *session.Session, irmod: *ir.Module, tid: semtype.TypeId, is_union: bool) R.Result[ir_type.IrTypeId, str] {
+    # materialize a generic instance's substituted field table before reading it, exactly
+    # as lower_type does; a no-op for a non-instance or an already-built table.
+    generics.ensure_fields(s, tid);
+
+    var nom_align: u32 = 0;
+    val ta: O.Option[u32] = session.type_align(s, tid::u32);
+    if (O.is_some[u32](ta)) { nom_align = O.unwrap[u32](ta); }
+
+    val fields_len: u32 = semtype.field_count(?s.types, tid);
+    if (fields_len == 0) {
+        if (is_union) { ret ir_type.intern_union(?irmod.types, nil, 0, nom_align); }
+        ret ir_type.intern_struct(?irmod.types, nil, 0, nom_align);
+    }
+
+    val rbuf: R.Result[*ir_type.IrTypeId, str] = A.allocate[ir_type.IrTypeId](s.alloc, fields_len::usize);
+    if (R.is_err[*ir_type.IrTypeId, str](rbuf)) { ret R.err[ir_type.IrTypeId, str](R.unwrap_err[*ir_type.IrTypeId, str](rbuf)); }
+    val buf: *ir_type.IrTypeId = R.unwrap_ok[*ir_type.IrTypeId, str](rbuf);
+
+    var i: u32 = 0;
+    for (i < fields_len) {
+        val fe: O.Option[*semtype.FieldEntry] = semtype.field_at(?s.types, tid, i);
+        if (O.is_none[*semtype.FieldEntry](fe)) {
+            A.deallocate[ir_type.IrTypeId](s.alloc, buf, fields_len::usize);
+            ret R.err[ir_type.IrTypeId, str]("dwarf.sem_to_ir: corrupt field table");
+        }
+        val rf: R.Result[ir_type.IrTypeId, str] = sem_to_ir(s, irmod, O.unwrap[*semtype.FieldEntry](fe).ty);
+        if (R.is_err[ir_type.IrTypeId, str](rf)) {
+            A.deallocate[ir_type.IrTypeId](s.alloc, buf, fields_len::usize);
+            ret rf;
+        }
+        buf[i] = R.unwrap_ok[ir_type.IrTypeId, str](rf);
+        i = i + 1;
+    }
+
+    var res: R.Result[ir_type.IrTypeId, str];
+    if (is_union) { res = ir_type.intern_union(?irmod.types, buf, fields_len, nom_align); }
+    or            { res = ir_type.intern_struct(?irmod.types, buf, fields_len, nom_align); }
+    A.deallocate[ir_type.IrTypeId](s.alloc, buf, fields_len::usize);
+    ret res;
+}
+
 # the frame-base DWARF register number for the target, read through the ISA's
 # `dwarf_reg` hook (#1693) mapping the physical frame pointer to its DWARF number.
 # DWARF-based targets always wire the hook, so this is defined for every arch that
@@ -947,6 +1064,22 @@ fun build_abbrev(b: *enc.ByteBuf) {
     emit_attr(b, DW_AT_byte_size, DW_FORM_udata);
     uleb(b, 0); uleb(b, 0);
 
+    # the DW_CHILDREN_no struct / union variants for a memberless aggregate (an empty
+    # record), so it never advertises children it lacks (#1949).
+    uleb(b, ABBREV_STRUCT_LEAF::u64);
+    uleb(b, DW_TAG_structure_type::u64);
+    enc.emit_byte(b, DW_CHILDREN_no);
+    emit_attr(b, DW_AT_name,      DW_FORM_strp);
+    emit_attr(b, DW_AT_byte_size, DW_FORM_udata);
+    uleb(b, 0); uleb(b, 0);
+
+    uleb(b, ABBREV_UNION_LEAF::u64);
+    uleb(b, DW_TAG_union_type::u64);
+    enc.emit_byte(b, DW_CHILDREN_no);
+    emit_attr(b, DW_AT_name,      DW_FORM_strp);
+    emit_attr(b, DW_AT_byte_size, DW_FORM_udata);
+    uleb(b, 0); uleb(b, 0);
+
     uleb(b, 0);   # null abbrev code terminates the table
 }
 
@@ -1132,32 +1265,107 @@ fun emit_inlines(b: *enc.ByteBuf, f: u32, parent_site: u32, inlines: *DwInline, 
 }
 
 # emit the compile unit's type DIEs in table order, recording each type's `.debug_info`
-# offset (`off`, CU-relative) for the ref4 references that follow. This increment emits
-# only DW_TAG_base_type scalars; composite kinds are added by the aggregate tier
+# offset (`off`, CU-relative) for the ref4 references that follow. Scalars emit a
+# DW_TAG_base_type; a pointer / array / record / union emits its composite tag with its
+# children (members / subrange). Cross-type ref4s are written as placeholders and their
+# `pos`/`target` recorded in `fixups`; `resolve_type_fixups` patches them once every
+# type's offset is known (handling the forward references self-referential aggregates
+# introduce)
 # ---
 # b:       the info buffer
 # tc:      the type table (each entry's `off` filled in place)
 # len_pos: buffer offset of the CU unit_length field (ref4 offsets are relative to it)
 # relocs/reloc_count: the deferred `.debug_info` relocation list (for name strps)
-fun emit_type_dies(b: *enc.ByteBuf, tc: *TypeCtx, len_pos: usize, relocs: *InfoReloc, reloc_count: *u32) {
+# fixups/nfix: out - the deferred ref4 patch list and its running count
+fun emit_type_dies(b: *enc.ByteBuf, tc: *TypeCtx, len_pos: usize, relocs: *InfoReloc, reloc_count: *u32,
+                   fixups: *TypeFixup, nfix: *u32) {
     var t: u32 = 0;
     for (t < tc.ntypes) {
         val td: *TypeDie = ?tc.types[t];
         td.off = (b.len - len_pos)::u32;
-        enc.emit_byte(b, ABBREV_BASE_TYPE);
-        push_info_reloc(relocs, reloc_count, b.len::u32, of.RK_ABS32, IRLT_STR, intern.STR_NIL, td.name_off::i64);
-        enc.emit_u32(b, 0);                     # DW_AT_name (strp, relocated to .debug_str)
-        enc.emit_byte(b, td.encoding);
-        enc.emit_byte(b, td.byte_size::u8);
+        if (td.kind == TK_BASE) {
+            enc.emit_byte(b, ABBREV_BASE_TYPE);
+            push_info_reloc(relocs, reloc_count, b.len::u32, of.RK_ABS32, IRLT_STR, intern.STR_NIL, td.name_off::i64);
+            enc.emit_u32(b, 0);                 # DW_AT_name (strp)
+            enc.emit_byte(b, td.encoding);
+            enc.emit_byte(b, td.byte_size::u8);
+        }
+        or (td.kind == TK_POINTER) {
+            enc.emit_byte(b, ABBREV_POINTER);
+            push_type_fixup(fixups, nfix, b.len::u32, td.elem::u32);
+            enc.emit_u32(b, 0);                 # DW_AT_type (ref4, patched)
+            uleb(b, td.byte_size::u64);         # DW_AT_byte_size
+        }
+        or (td.kind == TK_ARRAY) {
+            enc.emit_byte(b, ABBREV_ARRAY);
+            push_type_fixup(fixups, nfix, b.len::u32, td.elem::u32);
+            enc.emit_u32(b, 0);                 # DW_AT_type (ref4, patched)
+            enc.emit_byte(b, ABBREV_SUBRANGE);  # the single subrange child gives the count
+            uleb(b, td.count::u64);             # DW_AT_count
+            enc.emit_byte(b, 0);                # null DIE terminates the array's children
+        }
+        or {
+            # a memberless aggregate uses the DW_CHILDREN_no leaf abbrev (and no
+            # terminator), so it never advertises children it lacks (#1949).
+            val kids: bool = td.memb_count > 0;
+            if (td.kind == TK_UNION) {
+                if (kids) { enc.emit_byte(b, ABBREV_UNION); } or { enc.emit_byte(b, ABBREV_UNION_LEAF); }
+            } or {
+                if (kids) { enc.emit_byte(b, ABBREV_STRUCT); } or { enc.emit_byte(b, ABBREV_STRUCT_LEAF); }
+            }
+            push_info_reloc(relocs, reloc_count, b.len::u32, of.RK_ABS32, IRLT_STR, intern.STR_NIL, td.name_off::i64);
+            enc.emit_u32(b, 0);                 # DW_AT_name (strp)
+            uleb(b, td.byte_size::u64);         # DW_AT_byte_size
+            var m: u32 = td.memb_start;
+            val mend: u32 = td.memb_start + td.memb_count;
+            for (m < mend) {
+                val mb: *TypeMember = ?tc.membs[m];
+                enc.emit_byte(b, ABBREV_MEMBER);
+                push_info_reloc(relocs, reloc_count, b.len::u32, of.RK_ABS32, IRLT_STR, intern.STR_NIL, mb.name_off::i64);
+                enc.emit_u32(b, 0);             # DW_AT_name (strp)
+                push_type_fixup(fixups, nfix, b.len::u32, mb.type_ix);
+                enc.emit_u32(b, 0);             # DW_AT_type (ref4, patched)
+                uleb(b, mb.offset::u64);        # DW_AT_data_member_location
+                m = m + 1;
+            }
+            if (kids) { enc.emit_byte(b, 0); }  # null DIE terminates the members (only when present)
+        }
         t = t + 1;
+    }
+    resolve_type_fixups(b, tc, fixups, nfix);
+}
+
+# record a deferred ref4 patch: at buffer offset `pos`, the CU-relative offset of type
+# `target` is written once the whole type block is emitted
+# ---
+# fixups/nfix: the patch list and its running count (grown by the caller's cap)
+# pos:         absolute `.debug_info` offset of the ref4 field
+# target:      the referenced type's index
+fun push_type_fixup(fixups: *TypeFixup, nfix: *u32, pos: u32, target: u32) {
+    fixups[@nfix].pos    = pos;
+    fixups[@nfix].target = target;
+    @nfix = @nfix + 1;
+}
+
+# patch every recorded type ref4 with its target's now-known CU-relative offset
+# ---
+# b:           the info buffer (patched in place)
+# tc:          the type table (target offsets)
+# fixups/nfix: the recorded patches
+fun resolve_type_fixups(b: *enc.ByteBuf, tc: *TypeCtx, fixups: *TypeFixup, nfix: *u32) {
+    var i: u32 = 0;
+    for (i < @nfix) {
+        bin.write_u32_le(b.data, fixups[i].pos::usize, tc.types[fixups[i].target].off);
+        i = i + 1;
     }
 }
 
 # build the `.debug_info` compile unit: the DWARF 5 unit header, the CU DIE
-# (producer / name / comp_dir strings, language, code range, stmt_list), then a
-# `DW_TAG_base_type` DIE per gathered primitive and a `DW_TAG_subprogram` DIE per
-# function, closed by a null DIE. Records the CU low_pc / stmt_list field offsets and
-# appends an `InfoReloc` for every strp (name) and addr (low_pc) field
+# (producer / name / comp_dir strings, language, code range, stmt_list), then a type DIE
+# per gathered type (base scalars + composite records / unions / arrays / pointers) and a
+# `DW_TAG_subprogram` DIE per function, closed by a null DIE. Records the CU low_pc /
+# stmt_list field offsets and appends an `InfoReloc` for every strp (name) and addr
+# (low_pc) field
 # ---
 # b:            the buffer the info bytes are appended to
 # address_size: target pointer width in bytes
@@ -1172,11 +1380,12 @@ fun emit_type_dies(b: *enc.ByteBuf, tc: *TypeCtx, len_pos: usize, relocs: *InfoR
 # reloc_count:  out - number of InfoRelocs appended
 # low_off:      out - byte offset of the CU 8-byte low_pc field
 # stmt_off:     out - byte offset of the CU 4-byte stmt_list field
+# fixups:       scratch - the type-DIE ref4 patch list (cap >= type count + member count)
 fun build_info(b: *enc.ByteBuf, address_size: u8, producer: str, name: str, comp_dir: str,
                high_pc: u64, fb_reg: i32, funcs: *DwFunc, nfuncs: u32, tc: *TypeCtx,
                vars: *DwVar, relocs: *InfoReloc, reloc_count: *u32, low_off: *u32, stmt_off: *u32,
                s: *session.Session, irmod: *ir.Module, strtab: *StrTab,
-               inlines: *DwInline, ninl: u32, iranges: *DwInlineRange) {
+               inlines: *DwInline, ninl: u32, iranges: *DwInlineRange, fixups: *TypeFixup) {
     val len_pos: usize = b.len;
     enc.emit_u32(b, 0);                 # unit_length (backpatched)
     val body_start: usize = b.len;
@@ -1197,7 +1406,8 @@ fun build_info(b: *enc.ByteBuf, address_size: u8, producer: str, name: str, comp
     enc.emit_u32(b, 0);                 # stmt_list (relocated to .debug_line)
 
     # type DIEs first, so the subprograms below reference them by ref4.
-    emit_type_dies(b, tc, len_pos, relocs, reloc_count);
+    var nfix: u32 = 0;
+    emit_type_dies(b, tc, len_pos, relocs, reloc_count, fixups, ?nfix);
 
     # abstract-instance subprograms for the inlined callees, before the concrete
     # subprograms so each inlined_subroutine references its origin backward. One per
@@ -1370,17 +1580,35 @@ fun dbg_expr_net(irfn: *ir.Function, iid: id.InstructionId) i64 {
     ret net;
 }
 
+# whether type index `ty` names a by-reference aggregate DIE (struct / union / array).
+# such a value is manipulated through its storage address, so a variable of this type
+# homes an address rather than a value (see DwVar.byref)
+# ---
+# tc: the type table
+# ty: a type index, or -1
+# ret: true for a composite aggregate kind
+fun type_is_aggregate(tc: *TypeCtx, ty: i32) bool {
+    if (ty < 0) { ret false; }
+    val k: u8 = tc.types[ty::u32].kind;
+    ret k == TK_STRUCT || k == TK_UNION || k == TK_ARRAY;
+}
+
 # append the DWARF expression ops for a home to `e`. A register or frame slot with the
 # identity expression (net == 0) is a plain location; a salvaged value (net != 0)
 # computes the value and marks it DW_OP_stack_value; a constant home is the computed
-# value `off + net` pushed directly and marked DW_OP_stack_value
+# value `off + net` pushed directly and marked DW_OP_stack_value. When `byref`, the home
+# holds a pointer to the aggregate's storage (not its value): the location yields that
+# address - a register home is the address itself (DW_OP_breg reg 0), a spilled home
+# loads the pointer from its slot (DW_OP_fbreg off, DW_OP_deref) - so the consumer reads
+# the aggregate's bytes from it rather than misreading the pointer as the value
 # ---
-# e:    the expression buffer
-# kind: VLOC_REG / VLOC_FRAME / VLOC_CONST
-# reg:  DWARF register number when kind == VLOC_REG
-# off:  frame-base offset when kind == VLOC_FRAME; the constant value when VLOC_CONST
-# net:  the salvage net constant (0 = identity)
-fun build_loc_ops(e: *enc.ByteBuf, kind: u8, reg: i32, off: i64, net: i64) {
+# e:     the expression buffer
+# kind:  VLOC_REG / VLOC_FRAME / VLOC_CONST
+# reg:   DWARF register number when kind == VLOC_REG
+# off:   frame-base offset when kind == VLOC_FRAME; the constant value when VLOC_CONST
+# net:   the salvage net constant (0 = identity)
+# byref: true for a by-reference aggregate whose home addresses its storage
+fun build_loc_ops(e: *enc.ByteBuf, kind: u8, reg: i32, off: i64, net: i64, byref: bool) {
     if (kind == VLOC_CONST) {
         # the variable IS the compile-time constant `off + net`; push it and mark the
         # result a value, not a location. the DIE's DW_AT_type sizes / signs it, so the
@@ -1388,6 +1616,19 @@ fun build_loc_ops(e: *enc.ByteBuf, kind: u8, reg: i32, off: i64, net: i64) {
         enc.emit_byte(e, DW_OP_consts);
         sleb(e, off + net);
         enc.emit_byte(e, DW_OP_stack_value);
+        ret;
+    }
+    if (byref) {
+        # the home addresses the aggregate's storage; leave the address on the stack (no
+        # DW_OP_stack_value) so the consumer dereferences it for the aggregate's bytes.
+        if (kind == VLOC_REG) {
+            emit_reg_op(e, DW_OP_breg0, 0, reg);
+            sleb(e, 0);
+        } or {   # VLOC_FRAME: the slot holds the storage pointer, so load it.
+            enc.emit_byte(e, DW_OP_fbreg);
+            sleb(e, off);
+            enc.emit_byte(e, DW_OP_deref);
+        }
         ret;
     }
     if (kind == VLOC_REG) {
@@ -1415,9 +1656,10 @@ fun build_loc_ops(e: *enc.ByteBuf, kind: u8, reg: i32, off: i64, net: i64) {
 # ---
 # b:    the destination buffer
 # kind/reg/off/net: the home the expression describes
-fun emit_counted_loc(b: *enc.ByteBuf, kind: u8, reg: i32, off: i64, net: i64) {
+# byref: true for a by-reference aggregate whose home addresses its storage
+fun emit_counted_loc(b: *enc.ByteBuf, kind: u8, reg: i32, off: i64, net: i64, byref: bool) {
     var e: enc.ByteBuf = enc.buf_init(b.alloc);
-    build_loc_ops(?e, kind, reg, off, net);
+    build_loc_ops(?e, kind, reg, off, net, byref);
     uleb(b, e.len::u64);
     var i: usize = 0;
     for (i < e.len) { enc.emit_byte(b, e.data[i]); i = i + 1; }
@@ -1429,7 +1671,7 @@ fun emit_counted_loc(b: *enc.ByteBuf, kind: u8, reg: i32, off: i64, net: i64) {
 # b: the info buffer
 # v: the variable whose location is emitted (loc_kind is VLOC_REG or VLOC_FRAME)
 fun emit_var_location(b: *enc.ByteBuf, v: *DwVar) {
-    emit_counted_loc(b, v.loc_kind, v.reg, v.offset, v.net);
+    emit_counted_loc(b, v.loc_kind, v.reg, v.offset, v.net, v.byref);
 }
 
 # build the DWARF 5 `.debug_loclists` section: the unit header (offset_entry_count 0,
@@ -1485,7 +1727,7 @@ fun build_loclists(b: *enc.ByteBuf, funcs: *DwFunc, nfuncs: u32, vars: *DwVar, r
                     enc.emit_byte(b, DW_LLE_offset_pair);
                     uleb(b, (rg.start - fn.offset)::u64);
                     uleb(b, (rg.end - fn.offset)::u64);
-                    emit_counted_loc(b, rg.kind, rg.reg, rg.off, rg.net);
+                    emit_counted_loc(b, rg.kind, rg.reg, rg.off, rg.net, v.byref);
                 }
                 r = r + 1;
             }
@@ -2099,6 +2341,22 @@ pub fun produce(s: *session.Session, tgt: *target.Target, irmod: *ir.Module,
     val rng_relocs: *RngReloc = R.unwrap_ok[*RngReloc, str](rrr);
     var rng_reloc_count: u32 = 0;
 
+    # the type-DIE ref4 patch list: one per pointer / array element and one per member
+    # (bounded by the type count + member count), plus a guard slot for an empty table.
+    val fixup_cap: u32 = tc.ntypes + tc.nmemb + 1;
+    val rfx: R.Result[*TypeFixup, str] = A.allocate[TypeFixup](s.alloc, fixup_cap::usize);
+    if (R.is_err[*TypeFixup, str](rfx)) {
+        A.deallocate[RngReloc](s.alloc, rng_relocs, rng_reloc_cap::usize);
+        A.deallocate[DwInlineRange](s.alloc, iranges, ir_cap::usize); A.deallocate[DwInline](s.alloc, inlines, inl_cap::usize);
+        enc.buf_dnit(?b_rnglists); enc.buf_dnit(?b_loclists); enc.buf_dnit(?b_info); enc.buf_dnit(?b_line); enc.buf_dnit(?b_abbrev); enc.buf_dnit(?strtab.buf);
+        A.deallocate[LocReloc](s.alloc, loc_relocs, loc_reloc_cap::usize); A.deallocate[InfoReloc](s.alloc, info_relocs, reloc_cap::usize);
+        A.deallocate[u32](s.alloc, addr_off, nfuncs::usize); type_ctx_dnit(?tc);
+        A.deallocate[LocRange](s.alloc, ranges, range_cap::usize); A.deallocate[DwVar](s.alloc, vars, var_cap::usize);
+        A.deallocate[DwFunc](s.alloc, subs, nfuncs::usize); A.deallocate[DwFunc](s.alloc, funcs, nfuncs::usize);
+        ret R.err[bool, str](R.unwrap_err[*TypeFixup, str](rfx));
+    }
+    val type_fixups: *TypeFixup = R.unwrap_ok[*TypeFixup, str](rfx);
+
     build_abbrev(?b_abbrev);
     build_line(s, funcs, nfuncs, rows, row_count, text_sec, address_size, comp_dir, ?ft, ?b_line, addr_off);
     # loclists / rnglists before info: they stamp each variable's `loclist_off` and each
@@ -2113,7 +2371,7 @@ pub fun produce(s: *session.Session, tgt: *target.Target, irmod: *ir.Module,
     var stmt_off: u32 = 0;
     build_info(?b_info, address_size, producer, name, comp_dir, high_pc, frame_base_reg(tgt),
                subs, nsub, ?tc, vars, info_relocs, ?info_reloc_count, ?low_off, ?stmt_off,
-               s, irmod, ?strtab, inlines, ninl, iranges);
+               s, irmod, ?strtab, inlines, ninl, iranges, type_fixups);
 
     val pr: R.Result[bool, str] = install(s, image, itn, funcs, nfuncs, cu_low_name,
                                           ?b_abbrev, ?b_line, ?b_info, ?strtab.buf, ?b_loclists, has_loclists,
@@ -2126,6 +2384,7 @@ pub fun produce(s: *session.Session, tgt: *target.Target, irmod: *ir.Module,
     enc.buf_dnit(?b_loclists);
     enc.buf_dnit(?b_rnglists);
     enc.buf_dnit(?strtab.buf);
+    A.deallocate[TypeFixup](s.alloc, type_fixups, fixup_cap::usize);
     A.deallocate[DwInlineRange](s.alloc, iranges, ir_cap::usize);
     A.deallocate[DwInline](s.alloc, inlines, inl_cap::usize);
     A.deallocate[RngReloc](s.alloc, rng_relocs, rng_reloc_cap::usize);
@@ -2387,6 +2646,7 @@ fun gather_vars(s: *session.Session, tgt: *target.Target, irmod: *ir.Module, irf
             vars[@var_count].range_count = 0;
             vars[@var_count].loclist_off = 0;
             vars[@var_count].inline_site = vsite;
+            vars[@var_count].byref       = type_is_aggregate(tc, ty);
             @var_count = @var_count + 1;
         }
         i = i + 1;
@@ -2538,23 +2798,209 @@ fun base_intern(tc: *TypeCtx, strtab: *StrTab, bt: TypeDie) i32 {
     ret (tc.ntypes - 1)::i32;
 }
 
-# intern a semantic type into the compile unit's type table, returning its type index,
-# or -1 when the type carries no DIE (void / unresolved). This increment resolves
-# primitive scalars only; the aggregate tier extends it to composites
+# find an already-interned composite type by semantic TypeId, or -1. Composites (unlike
+# base types, which dedup by spelling) are keyed by their semantic identity, so a nominal
+# and a distinct type with the same layout stay separate DIEs
 # ---
-# s:            session (semantic type universe, interner)
+# tc:  the type table
+# sem: the semantic TypeId to look for
+# ret: the type's index, or -1 when absent
+fun comp_find(tc: *TypeCtx, sem: semtype.TypeId) i32 {
+    var i: u32 = 0;
+    for (i < tc.ntypes) {
+        if (tc.types[i].kind != TK_BASE && tc.types[i].sem == sem) { ret i::i32; }
+        i = i + 1;
+    }
+    ret -1;
+}
+
+# append a composite TypeDie of `kind` keyed by `sem`, with zeroed structural links, and
+# return its index (or -1 on allocation failure). Registering the entry before recursing
+# into its children makes self-referential aggregates (a struct reached again through one
+# of its `*T` members) terminate on the second visit
+# ---
+# tc:   the type table
+# kind: the composite TK_* kind
+# sem:  the semantic identity (dedup key)
+# ret:  the new type's index, or -1
+fun comp_reserve(tc: *TypeCtx, kind: u8, sem: semtype.TypeId) i32 {
+    if (!type_reserve(tc)) { ret -1; }
+    val ix: u32 = tc.ntypes;
+    tc.types[ix].kind       = kind;
+    tc.types[ix].sem        = sem;
+    tc.types[ix].off        = 0;
+    tc.types[ix].name       = "";
+    tc.types[ix].name_off   = 0;
+    tc.types[ix].encoding   = 0;
+    tc.types[ix].byte_size  = 0;
+    tc.types[ix].elem       = -1;
+    tc.types[ix].count      = 0;
+    tc.types[ix].memb_start = 0;
+    tc.types[ix].memb_count = 0;
+    tc.ntypes = tc.ntypes + 1;
+    ret ix::i32;
+}
+
+# the source spelling of a nominal record / union for DW_AT_name, or "" for an anonymous
+# composite (a generic instance or an unnamed shape) that carries no nominal name
+# ---
+# s:   session (interner)
+# t:   the semantic Type
+# ret: the name, or ""
+fun comp_name(s: *session.Session, t: *semtype.Type) str {
+    if (t.kind == semtype.TYPE_REC || t.kind == semtype.TYPE_UNI) { ret resolve(?s.interner, t.data.nominal.name); }
+    ret "";
+}
+
+# intern a semantic type into the compile unit's type table, returning its type index, or
+# -1 when the type carries no DIE (void / unresolved). Primitive scalars become base type
+# DIEs; typed pointers, arrays, records, and unions become composite DIEs whose member
+# layout is read from the IR type (the single layout authority, via `sem_to_ir`) and whose
+# names come from the semantic type. Idempotent - a repeat resolves to the same index
+# ---
+# s:            session (semantic type universe, interner, allocator)
 # tgt:          resolved target (member layout via the IR type table)
 # irmod:        the IR module (IR type universe for composite layout)
 # tc:           the type table
 # strtab:       the `.debug_str` string table
 # sem:          the semantic TypeId to intern
-# address_size: target pointer width, for a raw `ptr` byte size
+# address_size: target pointer width, for a raw / typed pointer byte size
 # ret:          the type's index in `tc`, or -1
 fun type_intern(s: *session.Session, tgt: *target.Target, irmod: *ir.Module, tc: *TypeCtx,
                 strtab: *StrTab, sem: semtype.TypeId, address_size: u8) i32 {
+    if (sem == semtype.TYPE_NIL || sem == semtype.TYPE_ERROR) { ret -1; }
+    val to: O.Option[*semtype.Type] = semtype.get(?s.types, sem);
+    if (O.is_none[*semtype.Type](to)) { ret -1; }
+    val t: *semtype.Type = O.unwrap[*semtype.Type](to);
+    val kind: semtype.TypeKind = t.kind;
+
+    # secrecy is representation-transparent: `^T` interns as exactly `T`.
+    if (kind == semtype.TYPE_SECRET) { ret type_intern(s, tgt, irmod, tc, strtab, t.data.secret.base, address_size); }
+
+    # primitive scalars (incl. the raw opaque `ptr`) become base type DIEs.
     val obt: O.Option[TypeDie] = sem_base_type(s, sem, address_size);
-    if (O.is_none[TypeDie](obt)) { ret -1; }
-    ret base_intern(tc, strtab, O.unwrap[TypeDie](obt));
+    if (O.is_some[TypeDie](obt)) { ret base_intern(tc, strtab, O.unwrap[TypeDie](obt)); }
+
+    # composites dedup by semantic identity.
+    val found: i32 = comp_find(tc, sem);
+    if (found >= 0) { ret found; }
+
+    if (kind == semtype.TYPE_POINTER) {
+        # a typed pointer resolves its pointee; an unresolvable pointee (void-like) degrades
+        # to the raw opaque `ptr` base type rather than a pointer to nothing.
+        val pe: i32 = type_intern(s, tgt, irmod, tc, strtab, t.data.pointer.base, address_size);
+        if (pe < 0) { ret base_intern(tc, strtab, ptr_base_type(address_size)); }
+        val ix: i32 = comp_reserve(tc, TK_POINTER, sem);
+        if (ix < 0) { ret -1; }
+        tc.types[ix::u32].elem      = pe;
+        tc.types[ix::u32].byte_size = address_size::u32;
+        ret ix;
+    }
+
+    if (kind == semtype.TYPE_ARRAY) {
+        val el: i32 = type_intern(s, tgt, irmod, tc, strtab, t.data.array.base, address_size);
+        if (el < 0) { ret -1; }
+        val ix: i32 = comp_reserve(tc, TK_ARRAY, sem);
+        if (ix < 0) { ret -1; }
+        tc.types[ix::u32].elem  = el;
+        tc.types[ix::u32].count = t.data.array.count;
+        ret ix;
+    }
+
+    if (kind == semtype.TYPE_REC || kind == semtype.TYPE_UNI || kind == semtype.TYPE_INSTANCE) {
+        ret struct_intern(s, tgt, irmod, tc, strtab, sem, t, address_size);
+    }
+
+    # a first-class function value (and any residual generic-param / pack) lowers to a
+    # pointer-width slot, exactly as lower_type does; represent it as the raw address
+    # type so a member of that type still carries a DIE rather than being dropped.
+    ret base_intern(tc, strtab, ptr_base_type(address_size));
+}
+
+# intern a record / union / generic-instance as a TK_STRUCT / TK_UNION DIE with a
+# DW_TAG_member child per field. Member offsets and the aggregate size come from the IR
+# type (`sem_to_ir`, the layout authority); member names and types come from the semantic
+# field table. The entry is registered before its fields recurse, so a self-referential
+# aggregate terminates
+# ---
+# s/tgt/irmod:  session / target / IR module
+# tc:           the type table
+# strtab:       the `.debug_str` string table
+# sem:          the aggregate's semantic TypeId
+# t:            its resolved semantic Type
+# address_size: target pointer width
+# ret:          the type's index, or -1
+fun struct_intern(s: *session.Session, tgt: *target.Target, irmod: *ir.Module, tc: *TypeCtx,
+                  strtab: *StrTab, sem: semtype.TypeId, t: *semtype.Type, address_size: u8) i32 {
+    # the IR type is the single layout authority; without it we cannot place members.
+    val rir: R.Result[ir_type.IrTypeId, str] = sem_to_ir(s, irmod, sem);
+    if (R.is_err[ir_type.IrTypeId, str](rir)) { ret -1; }
+    val ir_ty: ir_type.IrTypeId = R.unwrap_ok[ir_type.IrTypeId, str](rir);
+
+    var is_union: bool = false;
+    if (t.kind == semtype.TYPE_UNI) { is_union = true; }
+    var tk: u8 = TK_STRUCT;
+    if (is_union) { tk = TK_UNION; }
+
+    val ix: i32 = comp_reserve(tc, tk, sem);
+    if (ix < 0) { ret -1; }
+    tc.types[ix::u32].name_off  = str_off(strtab, comp_name(s, t));
+    tc.types[ix::u32].byte_size = ir_type.byte_size(?irmod.types, ir_ty, tgt);
+
+    val nfields: u32 = semtype.field_count(?s.types, sem);
+
+    # pass 1: intern every field type first, so all descendant types and their members
+    # are appended before this aggregate's own contiguous member run.
+    var i: u32 = 0;
+    for (i < nfields) {
+        val fe: O.Option[*semtype.FieldEntry] = semtype.field_at(?s.types, sem, i);
+        if (O.is_some[*semtype.FieldEntry](fe)) { type_intern(s, tgt, irmod, tc, strtab, O.unwrap[*semtype.FieldEntry](fe).ty, address_size); }
+        i = i + 1;
+    }
+
+    # pass 2: append this aggregate's members contiguously (the field re-intern is a cheap
+    # dedup hit). A member whose type is unresolvable is skipped rather than mistyped.
+    val memb_start: u32 = tc.nmemb;
+    var count: u32 = 0;
+    var j: u32 = 0;
+    for (j < nfields) {
+        val fe: O.Option[*semtype.FieldEntry] = semtype.field_at(?s.types, sem, j);
+        if (O.is_none[*semtype.FieldEntry](fe)) { j = j + 1; cnt; }
+        val f: *semtype.FieldEntry = O.unwrap[*semtype.FieldEntry](fe);
+        val fty: i32 = type_intern(s, tgt, irmod, tc, strtab, f.ty, address_size);
+        if (fty < 0) { j = j + 1; cnt; }
+        if (!memb_reserve(tc)) { j = j + 1; cnt; }
+        tc.membs[tc.nmemb].name_off = str_off(strtab, resolve(?s.interner, f.name));
+        tc.membs[tc.nmemb].type_ix  = fty::u32;
+        tc.membs[tc.nmemb].offset   = ir_type.byte_offset(?irmod.types, ir_ty, j, tgt);
+        tc.nmemb = tc.nmemb + 1;
+        count = count + 1;
+        j = j + 1;
+    }
+    tc.types[ix::u32].memb_start = memb_start;
+    tc.types[ix::u32].memb_count = count;
+    ret ix;
+}
+
+# a DWARF base type for the target's raw address (`ptr`): the fallback DIE for a pointer
+# whose pointee carries no type
+# ---
+# address_size: target pointer width in bytes
+# ret:          a TK_BASE `ptr` type DIE
+fun ptr_base_type(address_size: u8) TypeDie {
+    var bt: TypeDie;
+    bt.kind       = TK_BASE;
+    bt.name       = "ptr";
+    bt.sem        = semtype.TYPE_NIL;
+    bt.off        = 0;
+    bt.name_off   = 0;
+    bt.encoding   = DW_ATE_address;
+    bt.byte_size  = address_size::u32;
+    bt.elem       = -1;
+    bt.count      = 0;
+    bt.memb_start = 0;
+    bt.memb_count = 0;
+    ret bt;
 }
 
 # the source location of a function's first row in `.text` order (the lowest-offset
@@ -2790,7 +3236,7 @@ test "mach.lang.be.codegen.dwarf.build_abbrev:golden" {
     page.make(?alloc);
     var b: enc.ByteBuf = enc.buf_init(?alloc);
     build_abbrev(?b);
-    var e: [290]u8;
+    var e: [308]u8;
     e[0]=0x01; e[1]=0x11; e[2]=0x01; e[3]=0x25; e[4]=0x08; e[5]=0x03; e[6]=0x08; e[7]=0x1B;
     e[8]=0x08; e[9]=0x13; e[10]=0x05; e[11]=0x11; e[12]=0x01; e[13]=0x12; e[14]=0x07; e[15]=0x10;
     e[16]=0x17; e[17]=0x00; e[18]=0x00; e[19]=0x02; e[20]=0x24; e[21]=0x00; e[22]=0x03; e[23]=0x0E;
@@ -2848,11 +3294,66 @@ test "mach.lang.be.codegen.dwarf.build_abbrev:golden" {
     e[273]=0x16; e[274]=0x21; e[275]=0x00; e[276]=0x37; e[277]=0x0F; e[278]=0x00; e[279]=0x00;
     # ABBREV_POINTER (0x17): DW_TAG_pointer_type, no children, pointee type ref4, byte_size udata.
     e[280]=0x17; e[281]=0x0F; e[282]=0x00; e[283]=0x49; e[284]=0x13; e[285]=0x0B; e[286]=0x0F; e[287]=0x00; e[288]=0x00;
-    e[289]=0x00;   # null abbrev code terminates the table
-    val ok: bool = buf_eq(?b, ?e[0], 290);
+    # ABBREV_STRUCT_LEAF (0x18): DW_TAG_structure_type, no children, name strp, byte_size udata.
+    e[289]=0x18; e[290]=0x13; e[291]=0x00; e[292]=0x03; e[293]=0x0E; e[294]=0x0B; e[295]=0x0F; e[296]=0x00; e[297]=0x00;
+    # ABBREV_UNION_LEAF (0x19): DW_TAG_union_type, no children, name strp, byte_size udata.
+    e[298]=0x19; e[299]=0x17; e[300]=0x00; e[301]=0x03; e[302]=0x0E; e[303]=0x0B; e[304]=0x0F; e[305]=0x00; e[306]=0x00;
+    e[307]=0x00;   # null abbrev code terminates the table
+    val ok: bool = buf_eq(?b, ?e[0], 308);
     enc.buf_dnit(?b);
     if (!ok) { ret 1; }
     ret 0;
+}
+
+# emit_type_dies lays out a base type, a two-member struct, a pointer to that struct, an
+# array of the base, and a memberless struct; every cross-type DW_FORM_ref4 (each member,
+# the pointer's pointee, the array's element) is a fixup patched to its target's recorded
+# CU offset, and a memberless struct uses the DW_CHILDREN_no leaf abbrev
+test "mach.lang.be.codegen.dwarf.emit_type_dies:composite_refs" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+    var code: i32 = 0;
+
+    # types: [0] base i32, [1] struct S{i32,i32}, [2] *S, [3] [4]i32, [4] empty struct.
+    var td: [5]TypeDie;
+    td[0].kind=TK_BASE;    td[0].off=0; td[0].sem=semtype.TYPE_NIL; td[0].name="i32"; td[0].name_off=1; td[0].encoding=DW_ATE_signed; td[0].byte_size=4; td[0].elem=-1; td[0].count=0; td[0].memb_start=0; td[0].memb_count=0;
+    td[1].kind=TK_STRUCT;  td[1].off=0; td[1].sem=100; td[1].name=""; td[1].name_off=5; td[1].encoding=0; td[1].byte_size=8; td[1].elem=-1; td[1].count=0; td[1].memb_start=0; td[1].memb_count=2;
+    td[2].kind=TK_POINTER; td[2].off=0; td[2].sem=101; td[2].name=""; td[2].name_off=0; td[2].encoding=0; td[2].byte_size=8; td[2].elem=1; td[2].count=0; td[2].memb_start=0; td[2].memb_count=0;
+    td[3].kind=TK_ARRAY;   td[3].off=0; td[3].sem=102; td[3].name=""; td[3].name_off=0; td[3].encoding=0; td[3].byte_size=16; td[3].elem=0; td[3].count=4; td[3].memb_start=0; td[3].memb_count=0;
+    td[4].kind=TK_STRUCT;  td[4].off=0; td[4].sem=103; td[4].name=""; td[4].name_off=9; td[4].encoding=0; td[4].byte_size=0; td[4].elem=-1; td[4].count=0; td[4].memb_start=2; td[4].memb_count=0;
+
+    var mb: [2]TypeMember;
+    mb[0].name_off=20; mb[0].type_ix=0; mb[0].offset=0;
+    mb[1].name_off=24; mb[1].type_ix=0; mb[1].offset=4;
+
+    var tc: TypeCtx;
+    tc.alloc=?alloc; tc.types=?td[0]; tc.ntypes=5; tc.type_cap=5; tc.membs=?mb[0]; tc.nmemb=2; tc.memb_cap=2;
+
+    var relocs: [16]InfoReloc;
+    var rc: u32 = 0;
+    var fixups: [8]TypeFixup;
+    var nfix: u32 = 0;
+    var b: enc.ByteBuf = enc.buf_init(?alloc);
+    emit_type_dies(?b, ?tc, 0, ?relocs[0], ?rc, ?fixups[0], ?nfix);
+
+    # four ref4 fixups: two members -> base, the pointer -> struct, the array -> base.
+    if (nfix != 4) { code = 1; }
+    var i: u32 = 0;
+    for (i < nfix) {
+        val v: u32 = bin.read_u32_le(b.data, fixups[i].pos::usize);
+        if (v != td[fixups[i].target].off) { code = 1; }
+        i = i + 1;
+    }
+    # offsets were recorded in emit order: the base opens the block at 0, later types after it.
+    if (td[1].off == 0 || td[2].off <= td[1].off || td[4].off <= td[3].off) { code = 1; }
+    # the populated struct opens with ABBREV_STRUCT; the memberless one with the leaf abbrev.
+    if (b.data[td[1].off::usize] != ABBREV_STRUCT)      { code = 1; }
+    if (b.data[td[4].off::usize] != ABBREV_STRUCT_LEAF) { code = 1; }
+    # the pointer references the struct, the array references the base.
+    if (td[2].elem != 1 || td[3].elem != 0) { code = 1; }
+
+    enc.buf_dnit(?b);
+    ret code;
 }
 
 # emit_row packs a small line advance into a single special opcode and falls back to
@@ -2930,7 +3431,7 @@ test "mach.lang.be.codegen.dwarf.emit_var_location:reg_frame_salvage" {
     var code: i32 = 0;
 
     # register 5 (RDI), identity: len 1, DW_OP_reg5 = 0x50 + 5 = 0x55.
-    var vr: DwVar; vr.loc_kind = VLOC_REG; vr.reg = 5; vr.offset = 0; vr.net = 0;
+    var vr: DwVar; vr.loc_kind = VLOC_REG; vr.reg = 5; vr.offset = 0; vr.net = 0; vr.byref = false;
     var b: enc.ByteBuf = enc.buf_init(?alloc);
     emit_var_location(?b, ?vr);
     var e1: [2]u8; e1[0] = 0x01; e1[1] = 0x55;
@@ -2938,7 +3439,7 @@ test "mach.lang.be.codegen.dwarf.emit_var_location:reg_frame_salvage" {
     enc.buf_dnit(?b);
 
     # frame slot -8, identity: len 2, DW_OP_fbreg (0x91), sleb(-8) = 0x78.
-    var vf: DwVar; vf.loc_kind = VLOC_FRAME; vf.reg = 0; vf.offset = -8; vf.net = 0;
+    var vf: DwVar; vf.loc_kind = VLOC_FRAME; vf.reg = 0; vf.offset = -8; vf.net = 0; vf.byref = false;
     var c: enc.ByteBuf = enc.buf_init(?alloc);
     emit_var_location(?c, ?vf);
     var e2: [3]u8; e2[0] = 0x02; e2[1] = 0x91; e2[2] = 0x78;
@@ -2946,7 +3447,7 @@ test "mach.lang.be.codegen.dwarf.emit_var_location:reg_frame_salvage" {
     enc.buf_dnit(?c);
 
     # register 5 + 4 (salvaged): len 3, DW_OP_breg5 (0x75), sleb(4) = 0x04, stack_value (0x9F).
-    var vs: DwVar; vs.loc_kind = VLOC_REG; vs.reg = 5; vs.offset = 0; vs.net = 4;
+    var vs: DwVar; vs.loc_kind = VLOC_REG; vs.reg = 5; vs.offset = 0; vs.net = 4; vs.byref = false;
     var d: enc.ByteBuf = enc.buf_init(?alloc);
     emit_var_location(?d, ?vs);
     var e3: [4]u8; e3[0] = 0x03; e3[1] = 0x75; e3[2] = 0x04; e3[3] = 0x9F;
@@ -2954,12 +3455,30 @@ test "mach.lang.be.codegen.dwarf.emit_var_location:reg_frame_salvage" {
     enc.buf_dnit(?d);
 
     # constant 40 + net 2 = 42: len 3, DW_OP_consts (0x11), sleb(42) = 0x2A, stack_value (0x9F).
-    var vk: DwVar; vk.loc_kind = VLOC_CONST; vk.reg = 0; vk.offset = 40; vk.net = 2;
+    var vk: DwVar; vk.loc_kind = VLOC_CONST; vk.reg = 0; vk.offset = 40; vk.net = 2; vk.byref = false;
     var g: enc.ByteBuf = enc.buf_init(?alloc);
     emit_var_location(?g, ?vk);
     var e4: [4]u8; e4[0] = 0x03; e4[1] = 0x11; e4[2] = 0x2A; e4[3] = 0x9F;
     if (!buf_eq(?g, ?e4[0], 4)) { code = 1; }
     enc.buf_dnit(?g);
+
+    # a by-reference aggregate homed in register 5: len 3, DW_OP_breg5 (0x75), sleb(0) =
+    # 0x00, DW_OP_deref-less (the address is the location, no stack_value).
+    var va: DwVar; va.loc_kind = VLOC_REG; va.reg = 5; va.offset = 0; va.net = 0; va.byref = true;
+    var h: enc.ByteBuf = enc.buf_init(?alloc);
+    emit_var_location(?h, ?va);
+    var e5: [3]u8; e5[0] = 0x02; e5[1] = 0x75; e5[2] = 0x00;
+    if (!buf_eq(?h, ?e5[0], 3)) { code = 1; }
+    enc.buf_dnit(?h);
+
+    # a by-reference aggregate spilled to frame slot -8: len 3, DW_OP_fbreg (0x91),
+    # sleb(-8) = 0x78, DW_OP_deref (0x06) to load the storage pointer.
+    var vm: DwVar; vm.loc_kind = VLOC_FRAME; vm.reg = 0; vm.offset = -8; vm.net = 0; vm.byref = true;
+    var k: enc.ByteBuf = enc.buf_init(?alloc);
+    emit_var_location(?k, ?vm);
+    var e6: [4]u8; e6[0] = 0x03; e6[1] = 0x91; e6[2] = 0x78; e6[3] = 0x06;
+    if (!buf_eq(?k, ?e6[0], 4)) { code = 1; }
+    enc.buf_dnit(?k);
     ret code;
 }
 
@@ -3036,7 +3555,7 @@ test "mach.lang.be.codegen.dwarf.build_loclists:ranges" {
     var funcs: [1]DwFunc;
     funcs[0].name = intern.STR_NIL; funcs[0].offset = 0; funcs[0].var_start = 0; funcs[0].var_count = 1;
     var vars: [1]DwVar;
-    vars[0].loc_kind = VLOC_LOCLIST; vars[0].range_start = 0; vars[0].range_count = 2; vars[0].loclist_off = 0;
+    vars[0].loc_kind = VLOC_LOCLIST; vars[0].range_start = 0; vars[0].range_count = 2; vars[0].loclist_off = 0; vars[0].byref = false;
     var ranges: [2]LocRange;
     ranges[0].start=0; ranges[0].end=4; ranges[0].kind=VLOC_REG; ranges[0].reg=5; ranges[0].off=0; ranges[0].net=0;
     ranges[1].start=4; ranges[1].end=8; ranges[1].kind=VLOC_REG; ranges[1].reg=6; ranges[1].off=0; ranges[1].net=0;

--- a/src/lang/be/codegen/dwarf.mach
+++ b/src/lang/be/codegen/dwarf.mach
@@ -1597,17 +1597,18 @@ fun type_is_aggregate(tc: *TypeCtx, ty: i32) bool {
 # identity expression (net == 0) is a plain location; a salvaged value (net != 0)
 # computes the value and marks it DW_OP_stack_value; a constant home is the computed
 # value `off + net` pushed directly and marked DW_OP_stack_value. When `byref`, the home
-# holds a pointer to the aggregate's storage (not its value): the location yields that
-# address - a register home is the address itself (DW_OP_breg reg 0), a spilled home
-# loads the pointer from its slot (DW_OP_fbreg off, DW_OP_deref) - so the consumer reads
-# the aggregate's bytes from it rather than misreading the pointer as the value
+# is a frame slot holding a pointer to the aggregate's storage (register homes never
+# reach here - classify_var / build_loclists filter them out, since a reused register
+# cannot describe the address whole-scope): the location loads that pointer, adds any
+# salvage offset, and leaves the address on the stack (no DW_OP_stack_value) so the
+# consumer reads the aggregate's bytes from it
 # ---
 # e:     the expression buffer
 # kind:  VLOC_REG / VLOC_FRAME / VLOC_CONST
 # reg:   DWARF register number when kind == VLOC_REG
 # off:   frame-base offset when kind == VLOC_FRAME; the constant value when VLOC_CONST
 # net:   the salvage net constant (0 = identity)
-# byref: true for a by-reference aggregate whose home addresses its storage
+# byref: true for a by-reference aggregate located from a frame slot holding its address
 fun build_loc_ops(e: *enc.ByteBuf, kind: u8, reg: i32, off: i64, net: i64, byref: bool) {
     if (kind == VLOC_CONST) {
         # the variable IS the compile-time constant `off + net`; push it and mark the
@@ -1619,16 +1620,12 @@ fun build_loc_ops(e: *enc.ByteBuf, kind: u8, reg: i32, off: i64, net: i64, byref
         ret;
     }
     if (byref) {
-        # the home addresses the aggregate's storage; leave the address on the stack (no
-        # DW_OP_stack_value) so the consumer dereferences it for the aggregate's bytes.
-        if (kind == VLOC_REG) {
-            emit_reg_op(e, DW_OP_breg0, 0, reg);
-            sleb(e, 0);
-        } or {   # VLOC_FRAME: the slot holds the storage pointer, so load it.
-            enc.emit_byte(e, DW_OP_fbreg);
-            sleb(e, off);
-            enc.emit_byte(e, DW_OP_deref);
-        }
+        # a frame slot holds the storage pointer: load it, add any salvage offset (an
+        # aggregate address recovered as base + k), and leave the address on the stack.
+        enc.emit_byte(e, DW_OP_fbreg);
+        sleb(e, off);
+        enc.emit_byte(e, DW_OP_deref);
+        if (net != 0) { emit_net_const(e, net); }
         ret;
     }
     if (kind == VLOC_REG) {
@@ -1723,7 +1720,9 @@ fun build_loclists(b: *enc.ByteBuf, funcs: *DwFunc, nfuncs: u32, vars: *DwVar, r
             val rend: u32 = v.range_start + v.range_count;
             for (r < rend) {
                 val rg: *LocRange = ?ranges[r];
-                if (rg.kind != VLOC_NONE) {
+                # a non-real home (optimized out, or a byref aggregate's transient register)
+                # is left as a gap the consumer reports as unavailable, never a stale address.
+                if (range_real_home(v, rg)) {
                     enc.emit_byte(b, DW_LLE_offset_pair);
                     uleb(b, (rg.start - fn.offset)::u64);
                     uleb(b, (rg.end - fn.offset)::u64);
@@ -2743,11 +2742,27 @@ fun sort_ranges(ranges: *LocRange, start: u32, end: u32) {
     }
 }
 
+# whether a range is a real, describable home for variable `v`. An optimized-out binding
+# (VLOC_NONE) never is. For a by-reference aggregate a REGISTER home never is either: the
+# register holds the storage address only transiently and is reused, so describing the
+# aggregate from it whole-scope would dereference a stale value (a wild read) - such a
+# variable is located only from a frame slot (scope-stable) or omitted
+# ---
+# v:  the variable the range belongs to
+# rg: the range to test
+# ret: true when the range names a home the producer can faithfully describe
+fun range_real_home(v: *DwVar, rg: *LocRange) bool {
+    if (rg.kind == VLOC_NONE) { ret false; }
+    if (v.byref && rg.kind == VLOC_REG) { ret false; }
+    ret true;
+}
+
 # classify a variable's location tier from its gathered ranges: VLOC_NONE when no
-# binding has a real home (every binding optimized out); a single inline exprloc
-# (VLOC_REG / VLOC_FRAME, `range_count` cleared) when every real binding agrees on one
-# home; VLOC_LOCLIST (ranges kept) when two real homes disagree. An optimized-out
-# binding never constrains a stationary home - it only introduces a loclist gap
+# binding has a real home (every binding optimized out, or - for a byref aggregate -
+# only register homes, which it cannot describe); a single inline exprloc (VLOC_REG /
+# VLOC_FRAME, `range_count` cleared) when every real binding agrees on one home;
+# VLOC_LOCLIST (ranges kept) when two real homes disagree. A non-real binding never
+# constrains a stationary home - it only introduces a loclist gap
 # ---
 # v:      the variable to classify (loc_kind / home / range_count set in place)
 # ranges: the shared range array (this variable's slice is `[range_start, +range_count)`)
@@ -2757,7 +2772,7 @@ fun classify_var(v: *DwVar, ranges: *LocRange) {
     var r: u32 = v.range_start;
     val end: u32 = v.range_start + v.range_count;
     for (r < end) {
-        if (ranges[r].kind != VLOC_NONE) {
+        if (range_real_home(v, ?ranges[r])) {
             if (first < 0) {
                 first = r::i32;
             } or (!home_eq(ranges[first::u32].kind, ranges[first::u32].reg, ranges[first::u32].off, ranges[first::u32].net,
@@ -2886,9 +2901,17 @@ fun type_intern(s: *session.Session, tgt: *target.Target, irmod: *ir.Module, tc:
     if (found >= 0) { ret found; }
 
     if (kind == semtype.TYPE_POINTER) {
+        # capture the pointee TypeId before recursing: interning it can grow s.types and
+        # dangle `t`.
+        val ptee: semtype.TypeId = t.data.pointer.base;
+        val pe: i32 = type_intern(s, tgt, irmod, tc, strtab, ptee, address_size);
+        # the pointee recursion may have interned THIS exact pointer already (a cycle, e.g.
+        # rec Node { next: *Node } reached via a `*Node` local), so re-dedup rather than
+        # emit a second identical DIE.
+        val f2: i32 = comp_find(tc, sem);
+        if (f2 >= 0) { ret f2; }
         # a typed pointer resolves its pointee; an unresolvable pointee (void-like) degrades
         # to the raw opaque `ptr` base type rather than a pointer to nothing.
-        val pe: i32 = type_intern(s, tgt, irmod, tc, strtab, t.data.pointer.base, address_size);
         if (pe < 0) { ret base_intern(tc, strtab, ptr_base_type(address_size)); }
         val ix: i32 = comp_reserve(tc, TK_POINTER, sem);
         if (ix < 0) { ret -1; }
@@ -2898,23 +2921,30 @@ fun type_intern(s: *session.Session, tgt: *target.Target, irmod: *ir.Module, tc:
     }
 
     if (kind == semtype.TYPE_ARRAY) {
-        val el: i32 = type_intern(s, tgt, irmod, tc, strtab, t.data.array.base, address_size);
+        # capture element type + count before recursing: interning the element can grow
+        # s.types and dangle `t` (a stale `t.data.array.count` would be a garbage length).
+        val ebase: semtype.TypeId = t.data.array.base;
+        val ecount: u32 = t.data.array.count;
+        val el: i32 = type_intern(s, tgt, irmod, tc, strtab, ebase, address_size);
         if (el < 0) { ret -1; }
+        val f2: i32 = comp_find(tc, sem);   # element recursion may have interned this array (cycle)
+        if (f2 >= 0) { ret f2; }
         val ix: i32 = comp_reserve(tc, TK_ARRAY, sem);
         if (ix < 0) { ret -1; }
         tc.types[ix::u32].elem  = el;
-        tc.types[ix::u32].count = t.data.array.count;
+        tc.types[ix::u32].count = ecount;
         ret ix;
     }
 
     if (kind == semtype.TYPE_REC || kind == semtype.TYPE_UNI || kind == semtype.TYPE_INSTANCE) {
-        ret struct_intern(s, tgt, irmod, tc, strtab, sem, t, address_size);
+        ret struct_intern(s, tgt, irmod, tc, strtab, sem, address_size);
     }
 
-    # a first-class function value (and any residual generic-param / pack) lowers to a
-    # pointer-width slot, exactly as lower_type does; represent it as the raw address
-    # type so a member of that type still carries a DIE rather than being dropped.
-    ret base_intern(tc, strtab, ptr_base_type(address_size));
+    # an unresolved type here (an unsubstituted generic parameter / pack, or a first-class
+    # function value) has no faithful composite DIE: omit it rather than misattribute it to
+    # a raw `ptr` - conservative omission beats a wrong DW_AT_type that aliases every
+    # instantiation to one address-typed DIE.
+    ret -1;
 }
 
 # intern a record / union / generic-instance as a TK_STRUCT / TK_UNION DIE with a
@@ -2927,25 +2957,33 @@ fun type_intern(s: *session.Session, tgt: *target.Target, irmod: *ir.Module, tc:
 # tc:           the type table
 # strtab:       the `.debug_str` string table
 # sem:          the aggregate's semantic TypeId
-# t:            its resolved semantic Type
 # address_size: target pointer width
 # ret:          the type's index, or -1
 fun struct_intern(s: *session.Session, tgt: *target.Target, irmod: *ir.Module, tc: *TypeCtx,
-                  strtab: *StrTab, sem: semtype.TypeId, t: *semtype.Type, address_size: u8) i32 {
+                  strtab: *StrTab, sem: semtype.TypeId, address_size: u8) i32 {
     # the IR type is the single layout authority; without it we cannot place members.
+    # sem_to_ir can materialize a generic instance's field table (ensure_fields), growing
+    # s.types and reallocating it - so every borrow into s.types must be taken AFTER it.
     val rir: R.Result[ir_type.IrTypeId, str] = sem_to_ir(s, irmod, sem);
     if (R.is_err[ir_type.IrTypeId, str](rir)) { ret -1; }
     val ir_ty: ir_type.IrTypeId = R.unwrap_ok[ir_type.IrTypeId, str](rir);
 
-    var is_union: bool = false;
-    if (t.kind == semtype.TYPE_UNI) { is_union = true; }
+    # re-fetch the semantic type now that interning has settled; a pointer taken before
+    # sem_to_ir would dangle.
+    val to: O.Option[*semtype.Type] = semtype.get(?s.types, sem);
+    if (O.is_none[*semtype.Type](to)) { ret -1; }
+    val t: *semtype.Type = O.unwrap[*semtype.Type](to);
+
     var tk: u8 = TK_STRUCT;
-    if (is_union) { tk = TK_UNION; }
+    if (t.kind == semtype.TYPE_UNI) { tk = TK_UNION; }
+    # resolve the name string before any further interning (comp_name reads `t`).
+    val name_off: u32 = str_off(strtab, comp_name(s, t));
+    val bsize: u32 = ir_type.byte_size(?irmod.types, ir_ty, tgt);
 
     val ix: i32 = comp_reserve(tc, tk, sem);
     if (ix < 0) { ret -1; }
-    tc.types[ix::u32].name_off  = str_off(strtab, comp_name(s, t));
-    tc.types[ix::u32].byte_size = ir_type.byte_size(?irmod.types, ir_ty, tgt);
+    tc.types[ix::u32].name_off  = name_off;
+    tc.types[ix::u32].byte_size = bsize;
 
     val nfields: u32 = semtype.field_count(?s.types, sem);
 
@@ -2954,7 +2992,10 @@ fun struct_intern(s: *session.Session, tgt: *target.Target, irmod: *ir.Module, t
     var i: u32 = 0;
     for (i < nfields) {
         val fe: O.Option[*semtype.FieldEntry] = semtype.field_at(?s.types, sem, i);
-        if (O.is_some[*semtype.FieldEntry](fe)) { type_intern(s, tgt, irmod, tc, strtab, O.unwrap[*semtype.FieldEntry](fe).ty, address_size); }
+        if (O.is_some[*semtype.FieldEntry](fe)) {
+            val fty_sem: semtype.TypeId = O.unwrap[*semtype.FieldEntry](fe).ty;   # capture before recursion (fe may dangle)
+            type_intern(s, tgt, irmod, tc, strtab, fty_sem, address_size);
+        }
         i = i + 1;
     }
 
@@ -2966,11 +3007,14 @@ fun struct_intern(s: *session.Session, tgt: *target.Target, irmod: *ir.Module, t
     for (j < nfields) {
         val fe: O.Option[*semtype.FieldEntry] = semtype.field_at(?s.types, sem, j);
         if (O.is_none[*semtype.FieldEntry](fe)) { j = j + 1; cnt; }
-        val f: *semtype.FieldEntry = O.unwrap[*semtype.FieldEntry](fe);
-        val fty: i32 = type_intern(s, tgt, irmod, tc, strtab, f.ty, address_size);
+        # capture the field's type + name before type_intern: interning can grow s.types
+        # and dangle `fe`.
+        val f_ty:   semtype.TypeId = O.unwrap[*semtype.FieldEntry](fe).ty;
+        val f_name: intern.StrId   = O.unwrap[*semtype.FieldEntry](fe).name;
+        val fty: i32 = type_intern(s, tgt, irmod, tc, strtab, f_ty, address_size);
         if (fty < 0) { j = j + 1; cnt; }
         if (!memb_reserve(tc)) { j = j + 1; cnt; }
-        tc.membs[tc.nmemb].name_off = str_off(strtab, resolve(?s.interner, f.name));
+        tc.membs[tc.nmemb].name_off = str_off(strtab, resolve(?s.interner, f_name));
         tc.membs[tc.nmemb].type_ix  = fty::u32;
         tc.membs[tc.nmemb].offset   = ir_type.byte_offset(?irmod.types, ir_ty, j, tgt);
         tc.nmemb = tc.nmemb + 1;
@@ -3462,23 +3506,25 @@ test "mach.lang.be.codegen.dwarf.emit_var_location:reg_frame_salvage" {
     if (!buf_eq(?g, ?e4[0], 4)) { code = 1; }
     enc.buf_dnit(?g);
 
-    # a by-reference aggregate homed in register 5: len 3, DW_OP_breg5 (0x75), sleb(0) =
-    # 0x00, DW_OP_deref-less (the address is the location, no stack_value).
-    var va: DwVar; va.loc_kind = VLOC_REG; va.reg = 5; va.offset = 0; va.net = 0; va.byref = true;
-    var h: enc.ByteBuf = enc.buf_init(?alloc);
-    emit_var_location(?h, ?va);
-    var e5: [3]u8; e5[0] = 0x02; e5[1] = 0x75; e5[2] = 0x00;
-    if (!buf_eq(?h, ?e5[0], 3)) { code = 1; }
-    enc.buf_dnit(?h);
-
-    # a by-reference aggregate spilled to frame slot -8: len 3, DW_OP_fbreg (0x91),
-    # sleb(-8) = 0x78, DW_OP_deref (0x06) to load the storage pointer.
+    # a by-reference aggregate at frame slot -8: len 3, DW_OP_fbreg (0x91), sleb(-8) =
+    # 0x78, DW_OP_deref (0x06) to load the storage pointer (address, no stack_value).
+    # register-homed byref never reaches build_loc_ops (classify_var / build_loclists omit
+    # it), so only the frame form is exercised.
     var vm: DwVar; vm.loc_kind = VLOC_FRAME; vm.reg = 0; vm.offset = -8; vm.net = 0; vm.byref = true;
     var k: enc.ByteBuf = enc.buf_init(?alloc);
     emit_var_location(?k, ?vm);
     var e6: [4]u8; e6[0] = 0x03; e6[1] = 0x91; e6[2] = 0x78; e6[3] = 0x06;
     if (!buf_eq(?k, ?e6[0], 4)) { code = 1; }
     enc.buf_dnit(?k);
+
+    # a by-reference aggregate at frame slot -8 salvaged onto base + 16: len 5, DW_OP_fbreg
+    # (0x91), sleb(-8) = 0x78, DW_OP_deref (0x06), DW_OP_plus_uconst (0x23), uleb(16) = 0x10.
+    var vn: DwVar; vn.loc_kind = VLOC_FRAME; vn.reg = 0; vn.offset = -8; vn.net = 16; vn.byref = true;
+    var m: enc.ByteBuf = enc.buf_init(?alloc);
+    emit_var_location(?m, ?vn);
+    var e7: [6]u8; e7[0] = 0x05; e7[1] = 0x91; e7[2] = 0x78; e7[3] = 0x06; e7[4] = 0x23; e7[5] = 0x10;
+    if (!buf_eq(?m, ?e7[0], 6)) { code = 1; }
+    enc.buf_dnit(?m);
     ret code;
 }
 

--- a/src/lang/be/codegen/dwarf.mach
+++ b/src/lang/be/codegen/dwarf.mach
@@ -278,8 +278,8 @@ fun resolve(itn: *intern.Interner, id: intern.StrId) str {
 # external:  true when the symbol has global linkage (DW_AT_external)
 # decl_file: 0-based DWARF file index of the function's first row, or 0
 # decl_line: 1-based source line of the function's first row, or 0
-# ret_bt:    index into the base-type table for the return type, or -1 when the
-#            return is void or a non-primitive type (no DW_AT_type)
+# ret_ty:    index into the type table for the return type, or -1 when the return is
+#            void or an unresolved type (no DW_AT_type)
 # var_start: index of this function's first variable in the shared var array
 # var_count: number of variables this function contributes
 rec DwFunc {
@@ -292,7 +292,7 @@ rec DwFunc {
     external:  bool;
     decl_file: u32;
     decl_line: u32;
-    ret_bt:    i32;
+    ret_ty:    i32;
     var_start: u32;
     var_count: u32;
 }
@@ -313,12 +313,12 @@ val VLOC_CONST: u8 = 4;
 
 # a source variable's DWARF DIE data, joined from the IR dbg-var identity and the
 # per-PC variable-location records. A DW_TAG_variable (or DW_TAG_formal_parameter)
-# references its base type by ref4 and carries a DW_AT_location that is either an
-# inline single-location exprloc (VLOC_REG / VLOC_FRAME) or a DW_FORM_sec_offset into
+# references its type by ref4 and carries a DW_AT_location that is either an inline
+# single-location exprloc (VLOC_REG / VLOC_FRAME) or a DW_FORM_sec_offset into
 # `.debug_loclists` (VLOC_LOCLIST)
 # ---
 # name_off: DW_AT_name byte offset within `.debug_str`
-# bt:       base-type index for DW_AT_type
+# ty:       type index (into the TypeCtx table) for DW_AT_type
 # is_param: true for a formal parameter, false for a local
 # loc_kind: VLOC_NONE / VLOC_REG / VLOC_FRAME / VLOC_LOCLIST
 # reg:      DWARF register number when loc_kind == VLOC_REG
@@ -331,7 +331,7 @@ val VLOC_CONST: u8 = 4;
 #           build_loclists, patched into the DW_FORM_sec_offset field
 rec DwVar {
     name_off:    u32;
-    bt:          i32;
+    ty:          i32;
     is_param:    bool;
     loc_kind:    u8;
     reg:         i32;
@@ -416,24 +416,139 @@ fun home_eq(k1: u8, r1: i32, o1: i64, n1: i64, k2: u8, r2: i32, o2: i64, n2: i64
     ret true;
 }
 
-# a DWARF base type gathered from a primitive semantic return type
+# a type DIE's shape kind. TK_BASE is a scalar (DW_TAG_base_type); the rest are
+# composites: TK_STRUCT / TK_UNION carry members, TK_ARRAY an element + count,
+# TK_POINTER a pointee. Every kind records its emitted DIE offset for ref4
+val TK_BASE:    u8 = 0;
+val TK_STRUCT:  u8 = 1;
+val TK_UNION:   u8 = 2;
+val TK_ARRAY:   u8 = 3;
+val TK_POINTER: u8 = 4;
+
+# one type DIE in the compile unit's type table. A scalar base type (TK_BASE) carries
+# `encoding` / `byte_size` and is deduplicated by source spelling; a composite carries
+# its structural links (element / pointee `elem`, array `count`, or the `[memb_start,
+# memb_start + memb_count)` member slice) and is deduplicated by semantic TypeId
 # ---
-# name:      the type's source spelling (e.g. "i32", "u64", "f64", "ptr")
-# encoding:  DW_ATE_* scalar encoding
-# byte_size: width in bytes
-# off:       byte offset of the emitted DIE within `.debug_info`, for DW_FORM_ref4
-# str_off:   byte offset of `name` within `.debug_str`, for DW_FORM_strp
-rec BaseType {
-    name:      str;
-    encoding:  u8;
-    byte_size: u8;
-    off:       u32;
-    str_off:   u32;
+# kind:       TK_* shape discriminator
+# off:        byte offset of the emitted DIE within `.debug_info`, for DW_FORM_ref4
+# sem:        semantic TypeId (composite dedup key; TYPE_NIL for a base type)
+# name:       source spelling (base dedup key; "" for an anonymous composite shape)
+# name_off:   byte offset of `name` within `.debug_str` (base + struct / union), else 0
+# encoding:   DW_ATE_* scalar encoding (TK_BASE)
+# byte_size:  width in bytes (base scalar width, or a composite's total size)
+# elem:       element (TK_ARRAY) or pointee (TK_POINTER) type index, else -1
+# count:      element count (TK_ARRAY)
+# memb_start/memb_count: the type's member slice in the shared TypeMember array
+rec TypeDie {
+    kind:       u8;
+    off:        u32;
+    sem:        semtype.TypeId;
+    name:       str;
+    name_off:   u32;
+    encoding:   u8;
+    byte_size:  u32;
+    elem:       i32;
+    count:      u32;
+    memb_start: u32;
+    memb_count: u32;
 }
 
-# the largest number of distinct primitive return types a compile unit emits base
-# types for; the primitive universe (u8..f64, ptr) is small
-val MAX_BASE_TYPES: u32 = 16;
+# one member of a TK_STRUCT / TK_UNION type DIE, emitted as a DW_TAG_member child
+# ---
+# name_off: byte offset of the member name within `.debug_str`
+# type_ix:  the member's type index in the TypeDie table (DW_AT_type ref4)
+# offset:   byte offset of the member within its aggregate (DW_AT_data_member_location)
+rec TypeMember {
+    name_off: u32;
+    type_ix:  u32;
+    offset:   u32;
+}
+
+# the compile unit's growable type table: the distinct type DIEs it emits plus the
+# members of its aggregates. Base types dedup by spelling, composites by semantic
+# TypeId; both grow on demand so a large module never silently drops a type
+# ---
+# alloc:                 the allocator the arrays are owned through
+# types/ntypes/type_cap: the TypeDie array, its live count, and its capacity
+# membs/nmemb/memb_cap:  the TypeMember array, its live count, and its capacity
+rec TypeCtx {
+    alloc:    *A.Allocator;
+    types:    *TypeDie;
+    ntypes:   u32;
+    type_cap: u32;
+    membs:    *TypeMember;
+    nmemb:    u32;
+    memb_cap: u32;
+}
+
+# an initial, empty type context; the arrays allocate lazily on first insert
+# ---
+# alloc: the allocator its arrays are owned through
+# ret:   a zeroed context
+fun type_ctx_init(alloc: *A.Allocator) TypeCtx {
+    var tc: TypeCtx;
+    tc.alloc    = alloc;
+    tc.types    = nil;
+    tc.ntypes   = 0;
+    tc.type_cap = 0;
+    tc.membs    = nil;
+    tc.nmemb    = 0;
+    tc.memb_cap = 0;
+    ret tc;
+}
+
+# free a type context's arrays
+# ---
+# tc: the context to release
+fun type_ctx_dnit(tc: *TypeCtx) {
+    if (tc.types != nil) { A.deallocate[TypeDie](tc.alloc, tc.types, tc.type_cap::usize); tc.types = nil; }
+    if (tc.membs != nil) { A.deallocate[TypeMember](tc.alloc, tc.membs, tc.memb_cap::usize); tc.membs = nil; }
+}
+
+# ensure room for one more TypeDie, doubling capacity as needed. Returns false only on
+# an allocation failure (the caller degrades that type to no DIE rather than aborting)
+# ---
+# tc:  the context to grow
+# ret: true when a slot is available
+fun type_reserve(tc: *TypeCtx) bool {
+    if (tc.ntypes < tc.type_cap) { ret true; }
+    if (tc.type_cap == 0) {
+        val ra: R.Result[*TypeDie, str] = A.allocate[TypeDie](tc.alloc, 8::usize);
+        if (R.is_err[*TypeDie, str](ra)) { ret false; }
+        tc.types    = R.unwrap_ok[*TypeDie, str](ra);
+        tc.type_cap = 8;
+        ret true;
+    }
+    val new_cap: u32 = tc.type_cap * 2;
+    val rr: R.Result[*TypeDie, str] = A.reallocate[TypeDie](tc.alloc, tc.types, tc.type_cap::usize, new_cap::usize);
+    if (R.is_err[*TypeDie, str](rr)) { ret false; }
+    tc.types    = R.unwrap_ok[*TypeDie, str](rr);
+    tc.type_cap = new_cap;
+    ret true;
+}
+
+# ensure room for one more TypeMember, doubling capacity as needed. Returns false only
+# on an allocation failure
+# ---
+# tc:  the context to grow
+# ret: true when a slot is available
+fun memb_reserve(tc: *TypeCtx) bool {
+    if (tc.nmemb < tc.memb_cap) { ret true; }
+    if (tc.memb_cap == 0) {
+        val ra: R.Result[*TypeMember, str] = A.allocate[TypeMember](tc.alloc, 16::usize);
+        if (R.is_err[*TypeMember, str](ra)) { ret false; }
+        tc.membs    = R.unwrap_ok[*TypeMember, str](ra);
+        tc.memb_cap = 16;
+        ret true;
+    }
+    val new_cap: u32 = tc.memb_cap * 2;
+    val rr: R.Result[*TypeMember, str] = A.reallocate[TypeMember](tc.alloc, tc.membs, tc.memb_cap::usize, new_cap::usize);
+    if (R.is_err[*TypeMember, str](rr)) { ret false; }
+    tc.membs    = R.unwrap_ok[*TypeMember, str](rr);
+    tc.memb_cap = new_cap;
+    ret true;
+}
 
 # a compile-unit `.debug_str` string table: accumulates NUL-terminated strings,
 # deduplicated by content, and hands out each string's byte offset for DW_FORM_strp
@@ -584,37 +699,44 @@ fun prim_name(kind: semtype.TypeKind) str {
     ret "";
 }
 
-# resolve a semantic return type to its DWARF base type (name / encoding / byte_size),
-# or none when the type is void, unresolved, or not a primitive scalar. Non-primitive
-# returns (typed pointers, records) carry no DW_AT_type in this increment
+# resolve a semantic type to its DWARF base type DIE (a TK_BASE TypeDie: name /
+# encoding / byte_size), or none when the type is void, unresolved, or not a primitive
+# scalar. A raw `ptr` is a base type; a typed pointer / record / array is a composite
+# handled by `type_intern`
 # ---
 # s:            session, for the semantic type universe
-# tid:          the semantic return TypeId
+# tid:          the semantic TypeId
 # address_size: target pointer width, used for the raw `ptr` byte size
-# ret:          the base type (off/str_off unset), or none
-fun sem_base_type(s: *session.Session, tid: semtype.TypeId, address_size: u8) O.Option[BaseType] {
-    if (tid == semtype.TYPE_NIL || tid == semtype.TYPE_ERROR) { ret O.none[BaseType](); }
+# ret:          the base type DIE (off / name_off unset), or none
+fun sem_base_type(s: *session.Session, tid: semtype.TypeId, address_size: u8) O.Option[TypeDie] {
+    if (tid == semtype.TYPE_NIL || tid == semtype.TYPE_ERROR) { ret O.none[TypeDie](); }
     val to: O.Option[*semtype.Type] = semtype.get(?s.types, tid);
-    if (O.is_none[*semtype.Type](to)) { ret O.none[BaseType](); }
+    if (O.is_none[*semtype.Type](to)) { ret O.none[TypeDie](); }
     val kind: semtype.TypeKind = O.unwrap[*semtype.Type](to).kind;
     val d: semtype.PrimDesc = semtype.prim_desc(kind);
-    if (d.class == semtype.PRIM_CLASS_NONE) { ret O.none[BaseType](); }
+    if (d.class == semtype.PRIM_CLASS_NONE) { ret O.none[TypeDie](); }
 
-    var bt: BaseType;
-    bt.name    = prim_name(kind);
-    bt.off     = 0;
-    bt.str_off = 0;
+    var bt: TypeDie;
+    bt.kind       = TK_BASE;
+    bt.name       = prim_name(kind);
+    bt.sem        = semtype.TYPE_NIL;
+    bt.off        = 0;
+    bt.name_off   = 0;
+    bt.elem       = -1;
+    bt.count      = 0;
+    bt.memb_start = 0;
+    bt.memb_count = 0;
     if (d.class == semtype.PRIM_CLASS_FLOAT) {
         bt.encoding  = DW_ATE_float;
-        bt.byte_size = (d.bits / 8)::u8;
+        bt.byte_size = (d.bits / 8)::u32;
     } or (d.class == semtype.PRIM_CLASS_PTR) {
         bt.encoding  = DW_ATE_address;
-        bt.byte_size = address_size;
+        bt.byte_size = address_size::u32;
     } or {
         if (d.signed) { bt.encoding = DW_ATE_signed; } or { bt.encoding = DW_ATE_unsigned; }
-        bt.byte_size = (d.bits / 8)::u8;
+        bt.byte_size = (d.bits / 8)::u32;
     }
-    ret O.some[BaseType](bt);
+    ret O.some[TypeDie](bt);
 }
 
 # the frame-base DWARF register number for the target, read through the ISA's
@@ -966,7 +1088,7 @@ fun subprogram_has_children(f: u32, fn: *DwFunc, vars: *DwVar, inlines: *DwInlin
 
 fun emit_inlines(b: *enc.ByteBuf, f: u32, parent_site: u32, inlines: *DwInline, ninl: u32,
                  iranges: *DwInlineRange, relocs: *InfoReloc, reloc_count: *u32, fn: *DwFunc, address_size: u8,
-                 vars: *DwVar, bts: *BaseType) {
+                 vars: *DwVar, tc: *TypeCtx) {
     var xi: u32 = 0;
     for (xi < ninl) {
         if (inlines[xi].func_idx != f || inlines[xi].parent != parent_site) { xi = xi + 1; cnt; }
@@ -999,13 +1121,35 @@ fun emit_inlines(b: *enc.ByteBuf, f: u32, parent_site: u32, inlines: *DwInline, 
             # this instance's inlined locals, then its nested inlines, then the terminator.
             var vv: u32 = 0;
             for (vv < fn.var_count) {
-                if (vars[fn.var_start + vv].inline_site == di.site_id) { emit_variable(b, ?vars[fn.var_start + vv], bts, relocs, reloc_count); }
+                if (vars[fn.var_start + vv].inline_site == di.site_id) { emit_variable(b, ?vars[fn.var_start + vv], tc, relocs, reloc_count); }
                 vv = vv + 1;
             }
-            emit_inlines(b, f, di.site_id, inlines, ninl, iranges, relocs, reloc_count, fn, address_size, vars, bts);
+            emit_inlines(b, f, di.site_id, inlines, ninl, iranges, relocs, reloc_count, fn, address_size, vars, tc);
             enc.emit_byte(b, 0);   # null DIE terminates this instance's children
         }
         xi = xi + 1;
+    }
+}
+
+# emit the compile unit's type DIEs in table order, recording each type's `.debug_info`
+# offset (`off`, CU-relative) for the ref4 references that follow. This increment emits
+# only DW_TAG_base_type scalars; composite kinds are added by the aggregate tier
+# ---
+# b:       the info buffer
+# tc:      the type table (each entry's `off` filled in place)
+# len_pos: buffer offset of the CU unit_length field (ref4 offsets are relative to it)
+# relocs/reloc_count: the deferred `.debug_info` relocation list (for name strps)
+fun emit_type_dies(b: *enc.ByteBuf, tc: *TypeCtx, len_pos: usize, relocs: *InfoReloc, reloc_count: *u32) {
+    var t: u32 = 0;
+    for (t < tc.ntypes) {
+        val td: *TypeDie = ?tc.types[t];
+        td.off = (b.len - len_pos)::u32;
+        enc.emit_byte(b, ABBREV_BASE_TYPE);
+        push_info_reloc(relocs, reloc_count, b.len::u32, of.RK_ABS32, IRLT_STR, intern.STR_NIL, td.name_off::i64);
+        enc.emit_u32(b, 0);                     # DW_AT_name (strp, relocated to .debug_str)
+        enc.emit_byte(b, td.encoding);
+        enc.emit_byte(b, td.byte_size::u8);
+        t = t + 1;
     }
 }
 
@@ -1023,13 +1167,13 @@ fun emit_inlines(b: *enc.ByteBuf, f: u32, parent_site: u32, inlines: *DwInline, 
 # high_pc:      code span in bytes (high_pc - low_pc)
 # fb_reg:       frame-base DWARF register number
 # funcs/nfuncs: the module's functions (with resolved decl / return metadata)
-# bts/nbt:      the gathered base types (with resolved DIE / string offsets)
+# tc:           the gathered type table (with resolved DIE / string offsets)
 # relocs:       out - the InfoReloc list
 # reloc_count:  out - number of InfoRelocs appended
 # low_off:      out - byte offset of the CU 8-byte low_pc field
 # stmt_off:     out - byte offset of the CU 4-byte stmt_list field
 fun build_info(b: *enc.ByteBuf, address_size: u8, producer: str, name: str, comp_dir: str,
-               high_pc: u64, fb_reg: i32, funcs: *DwFunc, nfuncs: u32, bts: *BaseType, nbt: u32,
+               high_pc: u64, fb_reg: i32, funcs: *DwFunc, nfuncs: u32, tc: *TypeCtx,
                vars: *DwVar, relocs: *InfoReloc, reloc_count: *u32, low_off: *u32, stmt_off: *u32,
                s: *session.Session, irmod: *ir.Module, strtab: *StrTab,
                inlines: *DwInline, ninl: u32, iranges: *DwInlineRange) {
@@ -1052,17 +1196,8 @@ fun build_info(b: *enc.ByteBuf, address_size: u8, producer: str, name: str, comp
     @stmt_off = b.len::u32;
     enc.emit_u32(b, 0);                 # stmt_list (relocated to .debug_line)
 
-    # base-type DIEs first, so the subprograms below reference them by ref4.
-    var t: u32 = 0;
-    for (t < nbt) {
-        bts[t].off = (b.len - len_pos)::u32;
-        enc.emit_byte(b, ABBREV_BASE_TYPE);
-        push_info_reloc(relocs, reloc_count, b.len::u32, of.RK_ABS32, IRLT_STR, intern.STR_NIL, bts[t].str_off::i64);
-        enc.emit_u32(b, 0);             # DW_AT_name (strp, relocated to .debug_str)
-        enc.emit_byte(b, bts[t].encoding);
-        enc.emit_byte(b, bts[t].byte_size);
-        t = t + 1;
-    }
+    # type DIEs first, so the subprograms below reference them by ref4.
+    emit_type_dies(b, tc, len_pos, relocs, reloc_count);
 
     # abstract-instance subprograms for the inlined callees, before the concrete
     # subprograms so each inlined_subroutine references its origin backward. One per
@@ -1101,7 +1236,7 @@ fun build_info(b: *enc.ByteBuf, address_size: u8, producer: str, name: str, comp
         # a subprogram with no children uses the DW_CHILDREN_no leaf abbrev (and emits no
         # terminator), so it never advertises children it lacks (#1949).
         val has_kids: bool = subprogram_has_children(f, fn, vars, inlines, ninl);
-        if (fn.ret_bt >= 0) {
+        if (fn.ret_ty >= 0) {
             if (has_kids) { enc.emit_byte(b, ABBREV_SUBPROGRAM); } or { enc.emit_byte(b, ABBREV_SUBPROGRAM_LEAF); }
         } or {
             if (has_kids) { enc.emit_byte(b, ABBREV_SUBPROGRAM_VOID); } or { enc.emit_byte(b, ABBREV_SUBPROGRAM_VOID_LEAF); }
@@ -1115,7 +1250,7 @@ fun build_info(b: *enc.ByteBuf, address_size: u8, producer: str, name: str, comp
         uleb(b, fn.decl_file::u64);
         uleb(b, fn.decl_line::u64);
         emit_frame_base(b, fb_reg);
-        if (fn.ret_bt >= 0) { enc.emit_u32(b, bts[fn.ret_bt::u32].off); }   # DW_AT_type (ref4)
+        if (fn.ret_ty >= 0) { enc.emit_u32(b, tc.types[fn.ret_ty::u32].off); }   # DW_AT_type (ref4)
 
         # the subprogram's own variable / parameter children: instance-0 vars, plus any
         # var whose inline instance was dropped (no materialized inlined_subroutine to
@@ -1123,13 +1258,13 @@ fun build_info(b: *enc.ByteBuf, address_size: u8, producer: str, name: str, comp
         var vi: u32 = 0;
         for (vi < fn.var_count) {
             val dvr: *DwVar = ?vars[fn.var_start + vi];
-            if (dvr.inline_site == 0 || !inline_present(inlines, ninl, f, dvr.inline_site)) { emit_variable(b, dvr, bts, relocs, reloc_count); }
+            if (dvr.inline_site == 0 || !inline_present(inlines, ninl, f, dvr.inline_site)) { emit_variable(b, dvr, tc, relocs, reloc_count); }
             vi = vi + 1;
         }
 
         # its inlined_subroutine children, as a tree by inline-instance parent (top-level
         # instances directly under the subprogram, nested instances under their parent).
-        emit_inlines(b, f, 0, inlines, ninl, iranges, relocs, reloc_count, fn, address_size, vars, bts);
+        emit_inlines(b, f, 0, inlines, ninl, iranges, relocs, reloc_count, fn, address_size, vars, tc);
 
         if (has_kids) { enc.emit_byte(b, 0); }   # null DIE terminates the children (only when present)
         f = f + 1;
@@ -1146,14 +1281,14 @@ fun build_info(b: *enc.ByteBuf, address_size: u8, producer: str, name: str, comp
 # ---
 # b:      the info buffer
 # v:      the variable to emit
-# bts:    the base-type table (DW_AT_type ref4 target)
+# tc:     the type table (DW_AT_type ref4 target)
 # relocs/reloc_count: the deferred `.debug_info` relocation list (for the name strp)
-fun emit_variable(b: *enc.ByteBuf, v: *DwVar, bts: *BaseType, relocs: *InfoReloc, reloc_count: *u32) {
+fun emit_variable(b: *enc.ByteBuf, v: *DwVar, tc: *TypeCtx, relocs: *InfoReloc, reloc_count: *u32) {
     if (v.loc_kind == VLOC_LOCLIST) {
         if (v.is_param) { enc.emit_byte(b, ABBREV_PARAM_LOCLIST); } or { enc.emit_byte(b, ABBREV_VARIABLE_LOCLIST); }
         push_info_reloc(relocs, reloc_count, b.len::u32, of.RK_ABS32, IRLT_STR, intern.STR_NIL, v.name_off::i64);
-        enc.emit_u32(b, 0);                    # DW_AT_name (strp, relocated to .debug_str)
-        enc.emit_u32(b, bts[v.bt::u32].off);   # DW_AT_type (ref4)
+        enc.emit_u32(b, 0);                          # DW_AT_name (strp, relocated to .debug_str)
+        enc.emit_u32(b, tc.types[v.ty::u32].off);    # DW_AT_type (ref4)
         # DW_AT_location (sec_offset), relocated to the `.debug_loclists` entry.
         push_info_reloc(relocs, reloc_count, b.len::u32, of.RK_ABS32, IRLT_LOCLIST, intern.STR_NIL, v.loclist_off::i64);
         enc.emit_u32(b, 0);
@@ -1166,8 +1301,8 @@ fun emit_variable(b: *enc.ByteBuf, v: *DwVar, bts: *BaseType, relocs: *InfoReloc
         if (located) { enc.emit_byte(b, ABBREV_VARIABLE); } or { enc.emit_byte(b, ABBREV_VARIABLE_NOLOC); }
     }
     push_info_reloc(relocs, reloc_count, b.len::u32, of.RK_ABS32, IRLT_STR, intern.STR_NIL, v.name_off::i64);
-    enc.emit_u32(b, 0);                    # DW_AT_name (strp, relocated to .debug_str)
-    enc.emit_u32(b, bts[v.bt::u32].off);   # DW_AT_type (ref4)
+    enc.emit_u32(b, 0);                          # DW_AT_name (strp, relocated to .debug_str)
+    enc.emit_u32(b, tc.types[v.ty::u32].off);    # DW_AT_type (ref4)
     if (located) { emit_var_location(b, v); }
 }
 
@@ -1838,18 +1973,15 @@ pub fun produce(s: *session.Session, tgt: *target.Target, irmod: *ir.Module,
     }
     val ranges: *LocRange = R.unwrap_ok[*LocRange, str](rgr);
 
-    # gather base types + per-subprogram metadata + variables (+ their loclist ranges),
+    # gather types + per-subprogram metadata + variables (+ their loclist ranges),
     # building the `.debug_str` table as names / type spellings resolve.
-    val rb: R.Result[*BaseType, str] = A.allocate[BaseType](s.alloc, MAX_BASE_TYPES::usize);
-    if (R.is_err[*BaseType, str](rb)) { A.deallocate[LocRange](s.alloc, ranges, range_cap::usize); A.deallocate[DwVar](s.alloc, vars, var_cap::usize); A.deallocate[DwFunc](s.alloc, subs, nfuncs::usize); A.deallocate[DwFunc](s.alloc, funcs, nfuncs::usize); ret R.err[bool, str](R.unwrap_err[*BaseType, str](rb)); }
-    val bts: *BaseType = R.unwrap_ok[*BaseType, str](rb);
+    var tc: TypeCtx = type_ctx_init(s.alloc);
     var strtab: StrTab;
     strtab.buf = enc.buf_init(s.alloc);
-    var nbt: u32 = 0;
     var var_count: u32 = 0;
     var range_count: u32 = 0;
     gather_subprograms(s, tgt, irmod, subs, nsub, rows, row_count, varlocs, varloc_count, text_sec, ?ft, address_size,
-                       bts, ?nbt, ?strtab, vars, ?var_count, var_cap, ranges, ?range_count, range_cap);
+                       ?tc, ?strtab, vars, ?var_count, var_cap, ranges, ?range_count, range_cap);
 
     # a module emits a `.debug_loclists` section only when some variable's home moves.
     var has_loclists: bool = false;
@@ -1859,7 +1991,7 @@ pub fun produce(s: *session.Session, tgt: *target.Target, irmod: *ir.Module,
     # per-function set_address field offsets, filled by build_line.
     val ra: R.Result[*u32, str] = A.allocate[u32](s.alloc, nfuncs::usize);
     if (R.is_err[*u32, str](ra)) {
-        enc.buf_dnit(?strtab.buf); A.deallocate[BaseType](s.alloc, bts, MAX_BASE_TYPES::usize);
+        enc.buf_dnit(?strtab.buf); type_ctx_dnit(?tc);
         A.deallocate[LocRange](s.alloc, ranges, range_cap::usize); A.deallocate[DwVar](s.alloc, vars, var_cap::usize);
         A.deallocate[DwFunc](s.alloc, subs, nfuncs::usize); A.deallocate[DwFunc](s.alloc, funcs, nfuncs::usize);
         ret R.err[bool, str](R.unwrap_err[*u32, str](ra));
@@ -1867,14 +1999,15 @@ pub fun produce(s: *session.Session, tgt: *target.Target, irmod: *ir.Module,
     val addr_off: *u32 = R.unwrap_ok[*u32, str](ra);
 
     # the `.debug_info` reloc list: 2 CU + 2 per subprogram (name strp, low_pc addr) +
-    # 1 per base type (name strp) + up to 2 per variable (name strp, loclist sec_offset).
-    # + 2 per inlined instance (abstract-instance name strp, inlined_subroutine low_pc
-    # sym); bounded by the transition count, an upper bound on the instance count.
-    val reloc_cap: u32 = 2 + 2 * nsub + nbt + 2 * var_count + 2 * inline_pc_count;
+    # 1 per named type DIE (base + struct / union name strp) + 1 per aggregate member
+    # (name strp) + up to 2 per variable (name strp, loclist sec_offset) + 2 per inlined
+    # instance (abstract-instance name strp, inlined_subroutine low_pc sym); bounded by
+    # the transition count, an upper bound on the instance count.
+    val reloc_cap: u32 = 2 + 2 * nsub + tc.ntypes + tc.nmemb + 2 * var_count + 2 * inline_pc_count;
     val rr2: R.Result[*InfoReloc, str] = A.allocate[InfoReloc](s.alloc, reloc_cap::usize);
     if (R.is_err[*InfoReloc, str](rr2)) {
         A.deallocate[u32](s.alloc, addr_off, nfuncs::usize); enc.buf_dnit(?strtab.buf);
-        A.deallocate[BaseType](s.alloc, bts, MAX_BASE_TYPES::usize);
+        type_ctx_dnit(?tc);
         A.deallocate[LocRange](s.alloc, ranges, range_cap::usize); A.deallocate[DwVar](s.alloc, vars, var_cap::usize);
         A.deallocate[DwFunc](s.alloc, subs, nfuncs::usize); A.deallocate[DwFunc](s.alloc, funcs, nfuncs::usize);
         ret R.err[bool, str](R.unwrap_err[*InfoReloc, str](rr2));
@@ -1888,7 +2021,7 @@ pub fun produce(s: *session.Session, tgt: *target.Target, irmod: *ir.Module,
     if (R.is_err[*LocReloc, str](rlr)) {
         A.deallocate[InfoReloc](s.alloc, info_relocs, reloc_cap::usize);
         A.deallocate[u32](s.alloc, addr_off, nfuncs::usize); enc.buf_dnit(?strtab.buf);
-        A.deallocate[BaseType](s.alloc, bts, MAX_BASE_TYPES::usize);
+        type_ctx_dnit(?tc);
         A.deallocate[LocRange](s.alloc, ranges, range_cap::usize); A.deallocate[DwVar](s.alloc, vars, var_cap::usize);
         A.deallocate[DwFunc](s.alloc, subs, nfuncs::usize); A.deallocate[DwFunc](s.alloc, funcs, nfuncs::usize);
         ret R.err[bool, str](R.unwrap_err[*LocReloc, str](rlr));
@@ -1917,7 +2050,7 @@ pub fun produce(s: *session.Session, tgt: *target.Target, irmod: *ir.Module,
     if (R.is_err[*DwInline, str](rinl)) {
         enc.buf_dnit(?b_rnglists); enc.buf_dnit(?b_loclists); enc.buf_dnit(?b_info); enc.buf_dnit(?b_line); enc.buf_dnit(?b_abbrev); enc.buf_dnit(?strtab.buf);
         A.deallocate[LocReloc](s.alloc, loc_relocs, loc_reloc_cap::usize); A.deallocate[InfoReloc](s.alloc, info_relocs, reloc_cap::usize);
-        A.deallocate[u32](s.alloc, addr_off, nfuncs::usize); A.deallocate[BaseType](s.alloc, bts, MAX_BASE_TYPES::usize);
+        A.deallocate[u32](s.alloc, addr_off, nfuncs::usize); type_ctx_dnit(?tc);
         A.deallocate[LocRange](s.alloc, ranges, range_cap::usize); A.deallocate[DwVar](s.alloc, vars, var_cap::usize);
         A.deallocate[DwFunc](s.alloc, subs, nfuncs::usize); A.deallocate[DwFunc](s.alloc, funcs, nfuncs::usize);
         ret R.err[bool, str](R.unwrap_err[*DwInline, str](rinl));
@@ -1928,7 +2061,7 @@ pub fun produce(s: *session.Session, tgt: *target.Target, irmod: *ir.Module,
         A.deallocate[DwInline](s.alloc, inlines, inl_cap::usize);
         enc.buf_dnit(?b_rnglists); enc.buf_dnit(?b_loclists); enc.buf_dnit(?b_info); enc.buf_dnit(?b_line); enc.buf_dnit(?b_abbrev); enc.buf_dnit(?strtab.buf);
         A.deallocate[LocReloc](s.alloc, loc_relocs, loc_reloc_cap::usize); A.deallocate[InfoReloc](s.alloc, info_relocs, reloc_cap::usize);
-        A.deallocate[u32](s.alloc, addr_off, nfuncs::usize); A.deallocate[BaseType](s.alloc, bts, MAX_BASE_TYPES::usize);
+        A.deallocate[u32](s.alloc, addr_off, nfuncs::usize); type_ctx_dnit(?tc);
         A.deallocate[LocRange](s.alloc, ranges, range_cap::usize); A.deallocate[DwVar](s.alloc, vars, var_cap::usize);
         A.deallocate[DwFunc](s.alloc, subs, nfuncs::usize); A.deallocate[DwFunc](s.alloc, funcs, nfuncs::usize);
         ret R.err[bool, str](R.unwrap_err[*DwInlineRange, str](rirng));
@@ -1941,7 +2074,7 @@ pub fun produce(s: *session.Session, tgt: *target.Target, irmod: *ir.Module,
         A.deallocate[DwInlineRange](s.alloc, iranges, ir_cap::usize); A.deallocate[DwInline](s.alloc, inlines, inl_cap::usize);
         enc.buf_dnit(?b_rnglists); enc.buf_dnit(?b_loclists); enc.buf_dnit(?b_info); enc.buf_dnit(?b_line); enc.buf_dnit(?b_abbrev); enc.buf_dnit(?strtab.buf);
         A.deallocate[LocReloc](s.alloc, loc_relocs, loc_reloc_cap::usize); A.deallocate[InfoReloc](s.alloc, info_relocs, reloc_cap::usize);
-        A.deallocate[u32](s.alloc, addr_off, nfuncs::usize); A.deallocate[BaseType](s.alloc, bts, MAX_BASE_TYPES::usize);
+        A.deallocate[u32](s.alloc, addr_off, nfuncs::usize); type_ctx_dnit(?tc);
         A.deallocate[LocRange](s.alloc, ranges, range_cap::usize); A.deallocate[DwVar](s.alloc, vars, var_cap::usize);
         A.deallocate[DwFunc](s.alloc, subs, nfuncs::usize); A.deallocate[DwFunc](s.alloc, funcs, nfuncs::usize);
         ret rgi;
@@ -1958,7 +2091,7 @@ pub fun produce(s: *session.Session, tgt: *target.Target, irmod: *ir.Module,
         A.deallocate[DwInlineRange](s.alloc, iranges, ir_cap::usize); A.deallocate[DwInline](s.alloc, inlines, inl_cap::usize);
         enc.buf_dnit(?b_rnglists); enc.buf_dnit(?b_loclists); enc.buf_dnit(?b_info); enc.buf_dnit(?b_line); enc.buf_dnit(?b_abbrev); enc.buf_dnit(?strtab.buf);
         A.deallocate[LocReloc](s.alloc, loc_relocs, loc_reloc_cap::usize); A.deallocate[InfoReloc](s.alloc, info_relocs, reloc_cap::usize);
-        A.deallocate[u32](s.alloc, addr_off, nfuncs::usize); A.deallocate[BaseType](s.alloc, bts, MAX_BASE_TYPES::usize);
+        A.deallocate[u32](s.alloc, addr_off, nfuncs::usize); type_ctx_dnit(?tc);
         A.deallocate[LocRange](s.alloc, ranges, range_cap::usize); A.deallocate[DwVar](s.alloc, vars, var_cap::usize);
         A.deallocate[DwFunc](s.alloc, subs, nfuncs::usize); A.deallocate[DwFunc](s.alloc, funcs, nfuncs::usize);
         ret R.err[bool, str](R.unwrap_err[*RngReloc, str](rrr));
@@ -1979,7 +2112,7 @@ pub fun produce(s: *session.Session, tgt: *target.Target, irmod: *ir.Module,
     var low_off:  u32 = 0;
     var stmt_off: u32 = 0;
     build_info(?b_info, address_size, producer, name, comp_dir, high_pc, frame_base_reg(tgt),
-               subs, nsub, bts, nbt, vars, info_relocs, ?info_reloc_count, ?low_off, ?stmt_off,
+               subs, nsub, ?tc, vars, info_relocs, ?info_reloc_count, ?low_off, ?stmt_off,
                s, irmod, ?strtab, inlines, ninl, iranges);
 
     val pr: R.Result[bool, str] = install(s, image, itn, funcs, nfuncs, cu_low_name,
@@ -1999,7 +2132,7 @@ pub fun produce(s: *session.Session, tgt: *target.Target, irmod: *ir.Module,
     A.deallocate[LocReloc](s.alloc, loc_relocs, loc_reloc_cap::usize);
     A.deallocate[InfoReloc](s.alloc, info_relocs, reloc_cap::usize);
     A.deallocate[u32](s.alloc, addr_off, nfuncs::usize);
-    A.deallocate[BaseType](s.alloc, bts, MAX_BASE_TYPES::usize);
+    type_ctx_dnit(?tc);
     A.deallocate[LocRange](s.alloc, ranges, range_cap::usize);
     A.deallocate[DwVar](s.alloc, vars, var_cap::usize);
     A.deallocate[DwFunc](s.alloc, subs, nfuncs::usize);
@@ -2007,10 +2140,9 @@ pub fun produce(s: *session.Session, tgt: *target.Target, irmod: *ir.Module,
     ret pr;
 }
 
-# resolve each function's subprogram metadata and gather the distinct base types its
-# return types reference. Fills `funcs[*].disp`, `disp_off`, `decl_file`, `decl_line`,
-# `ret_bt`, and each `bts[*]` (name / encoding / byte_size / str_off). Returns the
-# number of base types
+# resolve each function's subprogram metadata and gather the distinct types its return
+# types reference. Fills `funcs[*].disp`, `disp_off`, `decl_file`, `decl_line`, `ret_ty`,
+# and the type table (`tc`) with the referenced DIEs / string offsets
 # ---
 # s:            session (IR lookup, type universe, source map)
 # irmod:        the IR module supplying disp / ret_sem
@@ -2020,14 +2152,14 @@ pub fun produce(s: *session.Session, tgt: *target.Target, irmod: *ir.Module,
 # text_sec:     the `.text` section index
 # ft:           the file table (for decl_file resolution)
 # address_size: target pointer width, for a raw-pointer return's byte size
-# bts:          out - the base-type array (cap MAX_BASE_TYPES)
+# tc:           out - the type table
 # strtab:       out - the `.debug_str` string table
 # vars/var_count/var_cap: out - the shared variable array
 # ranges/range_count/range_cap: out - the shared loclist-range array
 fun gather_subprograms(s: *session.Session, tgt: *target.Target, irmod: *ir.Module,
                        funcs: *DwFunc, nfuncs: u32, rows: *enc.LineRow, row_count: u32,
                        varlocs: *enc.VarLoc, varloc_count: u32, text_sec: u32,
-                       ft: *FileTable, address_size: u8, bts: *BaseType, nbt: *u32, strtab: *StrTab,
+                       ft: *FileTable, address_size: u8, tc: *TypeCtx, strtab: *StrTab,
                        vars: *DwVar, var_count: *u32, var_cap: u32,
                        ranges: *LocRange, range_count: *u32, range_cap: u32) {
     var i: u32 = 0;
@@ -2036,7 +2168,7 @@ fun gather_subprograms(s: *session.Session, tgt: *target.Target, irmod: *ir.Modu
         fn.decl_file = 0;
         fn.decl_line = 0;
         fn.disp      = intern.STR_NIL;
-        fn.ret_bt    = -1;
+        fn.ret_ty    = -1;
         fn.var_start = @var_count;
         fn.var_count = 0;
 
@@ -2064,17 +2196,14 @@ fun gather_subprograms(s: *session.Session, tgt: *target.Target, irmod: *ir.Modu
             fn.decl_line = pl.line::u32;
         }
 
-        # return base type, deduplicated by spelling.
-        val obt: O.Option[BaseType] = sem_base_type(s, ret_sem, address_size);
-        if (O.is_some[BaseType](obt)) {
-            fn.ret_bt = bt_intern(bts, nbt, strtab, O.unwrap[BaseType](obt));
-        }
+        # return type: any resolvable type (a composite un-defers #1907's aggregates).
+        fn.ret_ty = type_intern(s, tgt, irmod, tc, strtab, ret_sem, address_size);
 
         # variables + parameters: join the encoder's variable-location records for this
         # function's `.text` range with the IR dbg-var identity.
         if (irfn != nil) {
-            gather_vars(s, tgt, irfn, fn.offset, fn.offset + fn.size, varlocs, varloc_count, text_sec,
-                        address_size, bts, nbt, strtab, vars, var_count, var_cap, ranges, range_count, range_cap);
+            gather_vars(s, tgt, irmod, irfn, fn.offset, fn.offset + fn.size, varlocs, varloc_count, text_sec,
+                        address_size, tc, strtab, vars, var_count, var_cap, ranges, range_count, range_cap);
             fn.var_count = @var_count - fn.var_start;
         }
         i = i + 1;
@@ -2208,22 +2337,23 @@ fun gather_inlines(s: *session.Session, irmod: *ir.Module, funcs: *DwFunc, nfunc
 # dbg-var identity (name / semantic type / param flag); named, primitive-typed
 # variables get a DwVar. Each variable's bindings become PC-ordered LocRanges; a
 # variable whose real homes all agree keeps a single inline exprloc, one whose homes
-# disagree becomes a VLOC_LOCLIST with per-PC ranges. Only primitives get a DIE this
-# increment
+# disagree becomes a VLOC_LOCLIST with per-PC ranges. A variable's type is interned
+# through `type_intern`, so aggregates and typed pointers carry their composite DIE
 # ---
-# s/tgt:        session + target (the ISA dwarf_reg hook)
+# s/tgt:        session + target (the ISA dwarf_reg hook, member layout)
+# irmod:        the IR module (IR type universe for composite layout)
 # irfn:         the IR function (dbg-var / dbg-expr side tables)
 # lo/hi:        the function's `.text` byte range
 # varlocs/varloc_count: the encoder's variable-location records
 # text_sec:     the `.text` section index (records in other sections are skipped)
 # address_size: pointer width, for a raw-pointer base type
-# bts/nbt:      the base-type table
+# tc:           the type table
 # strtab:       the `.debug_str` string table
 # vars/var_count/var_cap:       the shared variable array
 # ranges/range_count/range_cap: the shared loclist-range array
-fun gather_vars(s: *session.Session, tgt: *target.Target, irfn: *ir.Function, lo: u32, hi: u32,
+fun gather_vars(s: *session.Session, tgt: *target.Target, irmod: *ir.Module, irfn: *ir.Function, lo: u32, hi: u32,
                 varlocs: *enc.VarLoc, varloc_count: u32, text_sec: u32, address_size: u8,
-                bts: *BaseType, nbt: *u32, strtab: *StrTab, vars: *DwVar, var_count: *u32, var_cap: u32,
+                tc: *TypeCtx, strtab: *StrTab, vars: *DwVar, var_count: *u32, var_cap: u32,
                 ranges: *LocRange, range_count: *u32, range_cap: u32) {
     val fn_var_start: u32 = @var_count;
 
@@ -2232,7 +2362,7 @@ fun gather_vars(s: *session.Session, tgt: *target.Target, irfn: *ir.Function, lo
     for (i < varloc_count) {
         val vl: *enc.VarLoc = ?varlocs[i];
         if (vl.sec != text_sec || vl.text_offset < lo || vl.text_offset >= hi) { i = i + 1; cnt; }
-        val obt: O.Option[u32] = varloc_ident(s, irfn, vl, address_size, bts, nbt, strtab);
+        val obt: O.Option[u32] = varloc_ident(s, tgt, irmod, irfn, vl, address_size, tc, strtab);
         if (O.is_none[u32](obt)) { i = i + 1; cnt; }
         val name_off: u32 = O.unwrap[u32](obt);
         # the inline instance this variable lives in (0 = the caller's own body); a caller
@@ -2245,9 +2375,9 @@ fun gather_vars(s: *session.Session, tgt: *target.Target, irfn: *ir.Function, lo
         for (j < @var_count) { if (vars[j].name_off == name_off && vars[j].inline_site == vsite) { found = true; } j = j + 1; }
         if (!found && @var_count < var_cap) {
             val dv: *ir.DbgVar = O.unwrap[*ir.DbgVar](ir.dbg_var_get(irfn, vl.iid::id.InstructionId));
-            val bt: i32 = bt_intern(bts, nbt, strtab, O.unwrap[BaseType](sem_base_type(s, dv.ty_sem, address_size)));
+            val ty: i32 = type_intern(s, tgt, irmod, tc, strtab, dv.ty_sem, address_size);
             vars[@var_count].name_off    = name_off;
-            vars[@var_count].bt          = bt;
+            vars[@var_count].ty          = ty;
             vars[@var_count].is_param    = dv.is_param;
             vars[@var_count].loc_kind    = VLOC_NONE;
             vars[@var_count].reg         = 0;
@@ -2273,7 +2403,7 @@ fun gather_vars(s: *session.Session, tgt: *target.Target, irfn: *ir.Function, lo
             val vl: *enc.VarLoc = ?varlocs[k];
             if (vl.sec != text_sec || vl.text_offset < lo || vl.text_offset >= hi) { k = k + 1; cnt; }
             if (@range_count >= range_cap) { k = k + 1; cnt; }
-            val oid: O.Option[u32] = varloc_ident(s, irfn, vl, address_size, bts, nbt, strtab);
+            val oid: O.Option[u32] = varloc_ident(s, tgt, irmod, irfn, vl, address_size, tc, strtab);
             if (O.is_none[u32](oid)) { k = k + 1; cnt; }
             if (O.unwrap[u32](oid) != v.name_off) { k = k + 1; cnt; }
 
@@ -2310,26 +2440,26 @@ fun gather_vars(s: *session.Session, tgt: *target.Target, irfn: *ir.Function, lo
 }
 
 # join a variable-location record to its IR dbg-var identity and return the variable's
-# `.debug_str` name offset, or none when the binding has no named, primitive-typed
-# source variable (so it contributes no DIE). Interns the name and base type as a side
-# effect (idempotent - a repeat resolves to the same offsets)
+# `.debug_str` name offset, or none when the binding has no named, DIE-carrying source
+# variable (so it contributes no DIE). Interns the name and type as a side effect
+# (idempotent - a repeat resolves to the same offsets)
 # ---
 # s:            session (interner, type universe)
+# tgt:          resolved target (member layout via the IR type table)
+# irmod:        the IR module (IR type universe for composite layout)
 # irfn:         the IR function holding the dbg-var side table
 # vl:           the variable-location record (its `iid` joins the identity)
 # address_size: pointer width, for a raw-pointer base type
-# bts/nbt:      the base-type table
+# tc:           the type table
 # strtab:       the `.debug_str` string table
 # ret:          the variable's name offset, or none
-fun varloc_ident(s: *session.Session, irfn: *ir.Function, vl: *enc.VarLoc, address_size: u8,
-                 bts: *BaseType, nbt: *u32, strtab: *StrTab) O.Option[u32] {
+fun varloc_ident(s: *session.Session, tgt: *target.Target, irmod: *ir.Module, irfn: *ir.Function,
+                 vl: *enc.VarLoc, address_size: u8, tc: *TypeCtx, strtab: *StrTab) O.Option[u32] {
     val odv: O.Option[*ir.DbgVar] = ir.dbg_var_get(irfn, vl.iid::id.InstructionId);
     if (O.is_none[*ir.DbgVar](odv)) { ret O.none[u32](); }
     val dv: *ir.DbgVar = O.unwrap[*ir.DbgVar](odv);
     if (dv.name == intern.STR_NIL) { ret O.none[u32](); }
-    val obt: O.Option[BaseType] = sem_base_type(s, dv.ty_sem, address_size);
-    if (O.is_none[BaseType](obt)) { ret O.none[u32](); }
-    if (bt_intern(bts, nbt, strtab, O.unwrap[BaseType](obt)) < 0) { ret O.none[u32](); }
+    if (type_intern(s, tgt, irmod, tc, strtab, dv.ty_sem, address_size) < 0) { ret O.none[u32](); }
     ret O.some[u32](str_off(strtab, resolve(?s.interner, dv.name)));
 }
 
@@ -2386,27 +2516,45 @@ fun classify_var(v: *DwVar, ranges: *LocRange) {
     v.range_count = 0;
 }
 
-# find or append a base type by spelling, returning its index. Resolves the type's
+# find or append a base type by spelling, returning its type index. Resolves the type's
 # name string offset on first insertion
 # ---
-# bts:    the base-type array (cap MAX_BASE_TYPES)
-# nbt:    in/out - current count
+# tc:     the type context (base types dedup against its TK_BASE entries)
 # strtab: the string table, for the name's `.debug_str` offset
-# bt:     the base type to intern (name / encoding / byte_size set)
-# ret:    the base type's index, or -1 when the table is full
-fun bt_intern(bts: *BaseType, nbt: *u32, strtab: *StrTab, bt: BaseType) i32 {
+# bt:     the base type DIE to intern (kind TK_BASE, name / encoding / byte_size set)
+# ret:    the base type's index, or -1 on allocation failure
+fun base_intern(tc: *TypeCtx, strtab: *StrTab, bt: TypeDie) i32 {
     var i: u32 = 0;
-    for (i < @nbt) {
-        if (str_equals(bts[i].name, bt.name)) { ret i::i32; }
+    for (i < tc.ntypes) {
+        if (tc.types[i].kind == TK_BASE && str_equals(tc.types[i].name, bt.name)) { ret i::i32; }
         i = i + 1;
     }
-    if (@nbt >= MAX_BASE_TYPES) { ret -1; }
-    var e: BaseType = bt;
-    e.str_off = str_off(strtab, bt.name);
-    e.off     = 0;
-    bts[@nbt] = e;
-    @nbt = @nbt + 1;
-    ret (@nbt - 1)::i32;
+    if (!type_reserve(tc)) { ret -1; }
+    var e: TypeDie = bt;
+    e.name_off = str_off(strtab, bt.name);
+    e.off      = 0;
+    tc.types[tc.ntypes] = e;
+    tc.ntypes = tc.ntypes + 1;
+    ret (tc.ntypes - 1)::i32;
+}
+
+# intern a semantic type into the compile unit's type table, returning its type index,
+# or -1 when the type carries no DIE (void / unresolved). This increment resolves
+# primitive scalars only; the aggregate tier extends it to composites
+# ---
+# s:            session (semantic type universe, interner)
+# tgt:          resolved target (member layout via the IR type table)
+# irmod:        the IR module (IR type universe for composite layout)
+# tc:           the type table
+# strtab:       the `.debug_str` string table
+# sem:          the semantic TypeId to intern
+# address_size: target pointer width, for a raw `ptr` byte size
+# ret:          the type's index in `tc`, or -1
+fun type_intern(s: *session.Session, tgt: *target.Target, irmod: *ir.Module, tc: *TypeCtx,
+                strtab: *StrTab, sem: semtype.TypeId, address_size: u8) i32 {
+    val obt: O.Option[TypeDie] = sem_base_type(s, sem, address_size);
+    if (O.is_none[TypeDie](obt)) { ret -1; }
+    ret base_intern(tc, strtab, O.unwrap[TypeDie](obt));
 }
 
 # the source location of a function's first row in `.text` order (the lowest-offset

--- a/src/lang/me/lower/context.mach
+++ b/src/lang/me/lower/context.mach
@@ -1176,7 +1176,16 @@ pub fun emit_dbg_birth(lc: *LowerContext, name_span: token.Span, ty: ir_type.IrT
         ret R.err[bool, str](R.unwrap_err[intern.StrId, str](res_name));
     }
     val name: intern.StrId = R.unwrap_ok[intern.StrId, str](res_name);
-    ret builder.emit_dbg_value(?lc.builder, val_v, name, ty, ty_sem, is_param, 0);
+    # inside a monomorphized instance body, a local/param written as a bare generic param
+    # (`T`, `*T`, `[N]T`) resolves to TYPE_GENERIC_PARAM here; substitute the active
+    # type-arguments so the debug type is the concrete instance type (the paired IR type
+    # already is), the same way decl_ret_sem substitutes the return type. a no-op outside
+    # an instance body and for an already-concrete type.
+    var sem: type.TypeId = ty_sem;
+    if (lc.subst != nil && lc.subst_len > 0) {
+        sem = generics.substitute(lc.s, sem, lc.subst, lc.subst_len);
+    }
+    ret builder.emit_dbg_value(?lc.builder, val_v, name, ty, sem, is_param, 0);
 }
 
 # return a pointer to a resolved Symbol by id, or none when out of range


### PR DESCRIPTION
Closes #1919.

Emits DWARF composite type DIEs for records, unions, arrays, and typed pointers, and un-defers #1907's aggregate / typed-pointer locals so they carry a DIE with members. gdb shows a frame-homed aggregate's members with correct names, types, and values; a location that can't be described safely is omitted, never rendered as garbage.

## Location correctness this tier exposed (a real bug fix, not just types)

Un-deferring aggregate variables surfaced a **wrong-home DIE** in the existing location tier — the invariant's worst class (`no DIE ever shows a wrong home; conservative omission beats misattribution`), latent only because aggregates never carried a location before. An aggregate local's `OP_DBG_VALUE` binds its **storage pointer** (lowering: "an aggregate value IS its storage"), so the encoder homes an *address*, not the value.

The correct rendering depends on where that address lives, and the adversarial review pinned the subtle part:

- **Frame slot** (the pointer is spilled): `DW_OP_fbreg off, DW_OP_deref` (`+ base offset` for a salvaged address). The slot is scope-stable, so this is a single-location exprloc and the debugger reads the members.
- **Register**: the register holds the address only transiently and is reused, so describing it whole-scope as `DW_OP_reg`/`DW_OP_breg` makes the debugger read (or *dereference*, for an aggregate) a clobbered register — a wrong value, or a wild pointer read. This home is therefore **omitted** (filtered at `classify_var`, gapped in `.debug_loclists`), i.e. the variable reads as optimized-out rather than garbage.

`DwVar.byref` (set when the type is `TK_STRUCT`/`UNION`/`ARRAY`) drives this; scalars and pointers are untouched (a pointer's *value* is the pointer). Only `.debug_*` bytes change, so `-g` stays byte-additive.

**Why it's pinned in the lane:** `llvm-dwarfdump --verify` accepts a bare `DW_OP_breg` register address on an aggregate, so a regression to the wild-read form would pass `--verify`. The dbg lane asserts that **no** `DW_OP_breg` location is a bare register address (none without a following `DW_OP_stack_value`) — the exact shape of the regression — at both debug and release, on all three ELF ISAs.

## What landed

- **Composite type DIEs**: `DW_TAG_structure_type` / `union_type` with a `DW_TAG_member` per field (byte offset via `DW_AT_data_member_location`), `DW_TAG_array_type` + `DW_TAG_subrange_type`, and `DW_TAG_pointer_type` resolving its pointee. Composites dedup by semantic TypeId and register before recursing, so a self-referential aggregate (`rec Node { next: *Node }`) terminates; a cyclic pointer/array reached as an outer entry re-dedups after its pointee recursion, so no duplicate DIE. Cross-type `DW_FORM_ref4`s are patched after the block is laid out.
- **Layout authority**: member offsets / sizes come from the IR type via `sem_to_ir`, a producer-local mirror of `lower_type` that dedup-lands on the exact IR type lowering already produced — DWARF offsets come from the same layout that emitted the code, never a re-derivation. Every borrow into the semantic type universe is taken *after* any call that can materialize an instance's field table (which reallocates it). Names come from the semantic field table.
- **Un-defer #1907**: aggregate / typed-pointer locals and params carry a `DW_TAG_variable` with a composite `DW_AT_type` and the by-reference location above. A generic local's `ty_sem` is substituted at the dbg-birth site, so a debug local of an instantiated generic gets its concrete type; an unresolved type is omitted, never misattributed to a raw `ptr`.
- **Cleanliness**: a memberless aggregate uses a `DW_CHILDREN_no` leaf abbrev (the #1949 discipline); the fixed-cap base-type array is now a growable, bundled `TypeCtx` so a large module never silently drops a type.

## Money proof

gdb on an `-O0 -g` binary:
- a **frame-homed** record local prints its members with correct names/types/values — `{x = 21, y = 22, tag = 23, count = 24}` via `DW_OP_fbreg -256, DW_OP_deref`;
- a **register-homed** aggregate reads `<optimized out>` — absent, never a wild read;
- the typed pointer resolves its pointee record and `->` member access works.

`llvm-dwarfdump --verify`: No errors, all three ELF ISAs.

## Bar

540 unit / 0 fail; dbg lane green on all three ELF ISAs at **debug and release** (18 target builds) incl. the `aggregate` fixture with array-count / pointee value checks and the no-bare-`breg` wild-read guard; `-g` byte-additive vs no-g; self-host fixpoint S1==S2; int linux leg green (surface + regression, debug + release).

## Adversarial review remediation

13 findings (10 confirmed) triaged and fixed on this branch:

- **Aggregate location wild read** (P0): register-homed aggregate addresses are omitted; only frame slots get `fbreg+deref`; salvage offset applied.
- **Memory safety** (P0): the borrowed `*semtype.Type` is re-fetched / its fields captured before any interning call that can reallocate the type universe (`struct_intern`, the array-count read).
- **Wrong type** (P0): the `ptr` fallthrough is removed (unknown → absent); generic-param `ty_sem` is substituted at the dbg-birth site.
- **Duplicate DIE**: cyclic pointer/array re-dedups after pointee recursion.
- **Lane hardening**: value checks for `DW_AT_count` / pointee, the no-bare-`breg` guard, and a release leg that exercises the moving-home (loclist) byref path.
- **Deferred (filed)**: register-passed by-value aggregate parameters get no location (encoder/ABI, #1954); anonymous / generic-instance aggregates emit an empty `DW_AT_name` (needs anon abbrevs or instance-name synthesis, #1955). Both are invariant-2-compliant omissions / cosmetic, not correctness.

## Deferred — not in this tier

`DW_OP_piece` fragmentation is **not** built: the backend does not split aggregates into per-field registers yet, so there is no fragmentation input to render and no falsifiable proof — it would be dead scaffolding. It slots in at the `VarLoc` channel + a per-fragment expr step once aggregate splitting (SROA / regalloc-split, ~#1933 territory) lands. The member-VALUE runtime read (`pt.count == 100`) is the staged lldb check — the ELF lane is a host-side DWARF inspector and can't execute the target; frame-homed member values are proven by the manual gdb transcript above.
