### PR TITLE
fix(mem2reg): make alloca escape analysis blind to debug values (release -g additivity)

### DIFF
--- a/dbg/fixtures/promote/mach.toml
+++ b/dbg/fixtures/promote/mach.toml
@@ -1,0 +1,36 @@
+[project]
+id      = "promotefix"
+name    = "promotefix"
+version = "0.0.0"
+src     = "src"
+dep     = "dep"
+target  = "linux"
+out     = "out/{target}/{profile}/bin/{name}{ext}"
+
+[target.linux]
+isa = "x86_64"
+os  = "linux"
+abi = "sysv64"
+
+[target.linux-arm64]
+isa = "aarch64"
+os  = "linux"
+abi = "aapcs64"
+
+[target.linux-riscv64]
+isa = "riscv64"
+os  = "linux"
+abi = "lp64"
+
+[profile.debug]
+opt = 0
+
+[profile.release]
+opt = 2
+
+[bin.promotefix]
+entry = "main.mach"
+
+[deps.mach-std]
+git = "https://github.com/briar-systems/mach-std"
+ref = "branch/main"

--- a/dbg/fixtures/promote/src/main.mach
+++ b/dbg/fixtures/promote/src/main.mach
@@ -1,0 +1,27 @@
+# release -g additivity fixture (#1944). `compute`'s named local `acc` has its address
+# passed to `bump`; before inlining the address escapes, so mem2reg cannot promote it.
+# `bump` is tiny and inlines at release, after which `acc` no longer escapes and becomes
+# promotable to SSA. under -g `acc` also carries an OP_DBG_VALUE naming its slot; a
+# release-only pass that treats that debug use as a real address escape keeps `acc` in
+# memory under -g while dropping it without, emitting different machine code. the runner
+# asserts the -g and no-g release builds share every loadable segment.
+use std.runtime;
+use std.types.size.usize;
+use p: std.print;
+
+fun bump(q: *i64) i64 {
+    ret @q + 1;
+}
+
+fun compute(a: i64, b: i64) i64 {
+    var acc: i64 = a;
+    val r: i64 = bump(?acc);
+    acc = r + b;
+    ret acc + r;
+}
+
+#[symbol("main")]
+fun main(argc: usize, argv: **u8) i64 {
+    p.printlnf("c={}", compute(3, 4));
+    ret 0;
+}

--- a/dbg/verify.sh
+++ b/dbg/verify.sh
@@ -219,10 +219,10 @@ verify_dwarf() {
 
     # 5. additive-only: -g must not perturb the loaded program. every PT_LOAD segment
     #    is byte-identical between the -g and no-g builds (modulo the ELF header's
-    #    section-table bookkeeping). a codegen change under -g fails here. NOTE: this
-    #    runs at the debug profile only; the release counterpart is deferred to #1944
-    #    (release -g still perturbs .text on clean dev), so verify_inline_release does
-    #    not yet assert it.
+    #    section-table bookkeeping). a codegen change under -g fails here. this fixture
+    #    builds at the debug profile; the release counterpart (where the inline / late
+    #    sweep passes fire) is asserted the same way in verify_inline_release below,
+    #    restored by #1944.
     if ! elf_seg_identical "$g" "$nog"; then
         echo "FAIL $label (-g perturbed a loadable segment vs the no-g build)"; rm -rf "$tmp"; return 1
     fi
@@ -256,21 +256,26 @@ verify_dwarf() {
 }
 
 # verify_inline_release <fixture_dir> <build_target> <min_dies> <callees> — the inline
-# pass fires only at release, so this leg builds one -g release binary and asserts the
-# DWARF inlined_subroutine tier: llvm-dwarfdump --verify is clean, at least <min_dies>
-# DW_TAG_inlined_subroutine DIEs are present, and each name in <callees> (space-
-# separated) appears as an inlined instance (its DW_AT_abstract_origin resolves to it) —
-# the pin that every level of a nested inline chain survived. Byte-for-byte -g additivity
-# is NOT asserted here yet: release -g still perturbs .text on clean dev (a pre-existing
-# -g-sensitive inlining decision, tracked in #1944 — see step 5's note). turn the
-# elf_seg_identical assertion on at release once #1944 lands.
+# pass fires only at release, so this leg builds a -g and a no-g release binary and
+# asserts two things: the DWARF inlined_subroutine tier (llvm-dwarfdump --verify clean,
+# at least <min_dies> DW_TAG_inlined_subroutine DIEs, and each name in <callees> (space-
+# separated) present as an inlined instance whose DW_AT_abstract_origin resolves to it —
+# the pin that every level of a nested inline chain survived), and byte-for-byte -g
+# additivity at release: every PT_LOAD segment is identical between the two builds, the
+# release counterpart of step 5. This is the guard #1944 restored (the release-only
+# passes must be blind to debug metadata); the compiler's own object-format/ABI writers
+# still carry a separate backend -g-sensitivity tracked in #1956, which these fixtures
+# do not exercise.
 verify_inline_release() {
     dir=$1; bt=$2; min=$3; callees=$4
     label="${dir#"$here"/} [$bt release]"
     tmp=$(mktemp -d)
-    g="$tmp/g"
+    g="$tmp/g"; nog="$tmp/nog"
     if ! (cd "$dir" && "$compiler" dep pull && "$compiler" build . --target "$bt" --profile release -g -o "$g") >"$tmp/b.log" 2>&1; then
         echo "FAIL $label (build release -g)"; sed 's/^/    /' "$tmp/b.log" >&2; rm -rf "$tmp"; return 1
+    fi
+    if ! (cd "$dir" && "$compiler" build . --target "$bt" --profile release -o "$nog") >"$tmp/b2.log" 2>&1; then
+        echo "FAIL $label (build release no-g)"; sed 's/^/    /' "$tmp/b2.log" >&2; rm -rf "$tmp"; return 1
     fi
     if ! "$dwarfdump" --verify "$g" >"$tmp/v.log" 2>&1; then
         echo "FAIL $label (llvm-dwarfdump --verify)"; tail -30 "$tmp/v.log" | sed 's/^/    /' >&2; rm -rf "$tmp"; return 1
@@ -284,7 +289,36 @@ verify_inline_release() {
             echo "FAIL $label (no inlined_subroutine referencing $callee)"; rm -rf "$tmp"; return 1
         fi
     done
-    echo "PASS $label ($n inlined_subroutine DIEs)"
+    # additive-only at release: the release-only inline / mem2reg / late-sweep passes must
+    # not perturb one byte of the loaded program under -g.
+    if ! elf_seg_identical "$g" "$nog"; then
+        echo "FAIL $label (-g perturbed a loadable segment vs the no-g release build)"; rm -rf "$tmp"; return 1
+    fi
+    echo "PASS $label ($n inlined_subroutine DIEs, -g additive)"
+    rm -rf "$tmp"
+    return 0
+}
+
+# verify_release_additive <fixture_dir> <build_target> — assert byte-for-byte -g
+# additivity at the release profile: the -g and no-g release builds share every PT_LOAD
+# segment. this is the falsifiable guard for the release-only passes (a fixture whose
+# local promotes to SSA only after inlining, so a -g-blind escape/salvage bug keeps it in
+# memory under -g and drops it without — #1944).
+verify_release_additive() {
+    dir=$1; bt=$2
+    label="${dir#"$here"/} [$bt release additive]"
+    tmp=$(mktemp -d)
+    g="$tmp/g"; nog="$tmp/nog"
+    if ! (cd "$dir" && "$compiler" dep pull && "$compiler" build . --target "$bt" --profile release -g -o "$g") >"$tmp/b.log" 2>&1; then
+        echo "FAIL $label (build release -g)"; sed 's/^/    /' "$tmp/b.log" >&2; rm -rf "$tmp"; return 1
+    fi
+    if ! (cd "$dir" && "$compiler" build . --target "$bt" --profile release -o "$nog") >"$tmp/b2.log" 2>&1; then
+        echo "FAIL $label (build release no-g)"; sed 's/^/    /' "$tmp/b2.log" >&2; rm -rf "$tmp"; return 1
+    fi
+    if ! elf_seg_identical "$g" "$nog"; then
+        echo "FAIL $label (-g perturbed a loadable segment vs the no-g release build)"; rm -rf "$tmp"; return 1
+    fi
+    echo "PASS $label"
     rm -rf "$tmp"
     return 0
 }
@@ -293,7 +327,7 @@ for dir in "$fixtures"/$filter; do
     [ -f "$dir/mach.toml" ] || continue
     # the inline fixtures are release-only (their callees inline away at -O0); they have
     # their own release legs below and do not fit the debug fixture's structural checks.
-    case "$(basename "$dir")" in inline|inline4) continue;; esac
+    case "$(basename "$dir")" in inline|inline4|promote) continue;; esac
     for bt in $elf_targets; do
         ran=$((ran + 1))
         verify_dwarf "$dir" "$bt" || fails=$((fails + 1))
@@ -314,6 +348,15 @@ if [ -f "$fixtures/inline4/mach.toml" ]; then
     for bt in $elf_targets; do
         ran=$((ran + 1))
         verify_inline_release "$fixtures/inline4" "$bt" 4 "a b c d" || fails=$((fails + 1))
+    done
+fi
+# promote is the release -g additivity guard: its local escapes into an inlinable
+# helper, so it promotes only after the inline pass runs — a release-only pass that is
+# not blind to the local's debug value keeps it in memory under -g and drops it without.
+if [ -f "$fixtures/promote/mach.toml" ]; then
+    for bt in $elf_targets; do
+        ran=$((ran + 1))
+        verify_release_additive "$fixtures/promote" "$bt" || fails=$((fails + 1))
     done
 fi
 

--- a/src/lang/me/pass/mem2reg.mach
+++ b/src/lang/me/pass/mem2reg.mach
@@ -33,6 +33,7 @@ use mach.lang.me.ir.mutate;
 use mach.lang.me.ir.type;
 use mach.lang.me.ir.value;
 use mach.lang.source;
+use semtype: mach.lang.type;
 
 # sentinel marking an unprocessed entry in a u32 work array (idom / rpo index /
 # alloca lookup)
@@ -354,25 +355,32 @@ fun classify_escapes(st: *State, escaped: *bool) {
             if (inst.kind == instruction.OP_ASM) {
                 mark_asm_binds_escaped(st, c::id.InstructionId, escaped);
             }
-            var o: u32 = 0;
-            for (o < inst.operand_count) {
-                val op: value.Value = inst.operands[o];
-                if (op.kind == value.VAL_INSTR && op.data.instr::u32 < st.pool_len) {
-                    val ai: u32 = st.alloca_of[op.data.instr::u32];
-                    if (ai != NONE_U32) {
-                        val ok_load:  bool = inst.kind == instruction.OP_LOAD  && o == 0;
-                        val ok_store: bool = inst.kind == instruction.OP_STORE && o == 1;
-                        if (ok_load == false && ok_store == false) {
-                            escaped[ai] = true;
-                        } or {
-                            if (st.alloca_ty[ai] == type.IRT_NIL) {
-                                if (ok_load) { st.alloca_ty[ai] = inst.ty; }
-                                or           { st.alloca_ty[ai] = inst.operands[0].ty; }
+            # an OP_DBG_VALUE naming an alloca is a debug-only use, never a real
+            # address escape: letting it mark the slot escaped would keep an otherwise
+            # promotable local in memory under -g and drop it without, so the two
+            # builds emit different code -- a -g additivity violation. the dbg-value is
+            # salvaged (optimized out) when the promoted alloca is erased.
+            if (inst.kind != instruction.OP_DBG_VALUE) {
+                var o: u32 = 0;
+                for (o < inst.operand_count) {
+                    val op: value.Value = inst.operands[o];
+                    if (op.kind == value.VAL_INSTR && op.data.instr::u32 < st.pool_len) {
+                        val ai: u32 = st.alloca_of[op.data.instr::u32];
+                        if (ai != NONE_U32) {
+                            val ok_load:  bool = inst.kind == instruction.OP_LOAD  && o == 0;
+                            val ok_store: bool = inst.kind == instruction.OP_STORE && o == 1;
+                            if (ok_load == false && ok_store == false) {
+                                escaped[ai] = true;
+                            } or {
+                                if (st.alloca_ty[ai] == type.IRT_NIL) {
+                                    if (ok_load) { st.alloca_ty[ai] = inst.ty; }
+                                    or           { st.alloca_ty[ai] = inst.operands[0].ty; }
+                                }
                             }
                         }
                     }
+                    o = o + 1;
                 }
-                o = o + 1;
             }
         }
         c = c + 1;
@@ -1574,6 +1582,54 @@ test "mach.lang.me.pass.mem2reg.run:promote_after_escaping_call_removed" {
 
     # second mem2reg: the escaping call is gone (and the ghost is skipped), so p
     # promotes to SSA and its alloca leaves the block.
+    if (R.is_err[bool, str](run(?m)))          { ret 1; }
+    if (live_alloca_count(fn, entry_blk) != 0) { ret 1; }
+    ret 0;
+}
+
+# a -g additivity regression (#1944): an OP_DBG_VALUE naming an alloca is a debug-only
+# use, not an address escape, so the local still promotes to SSA under -g exactly as it
+# does without. reverting the OP_DBG_VALUE guard in classify_escapes leaves the alloca in
+# memory (live_alloca_count stays 1) and fails this test.
+test "mach.lang.me.pass.mem2reg.run:dbg_value_is_not_an_escape" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+    val res_module: R.Result[ir.Module, str] = ir.init(?alloc, intern.STR_NIL);
+    if (R.is_err[ir.Module, str](res_module)) { ret 1; }
+    var m: ir.Module = R.unwrap_ok[ir.Module, str](res_module);
+
+    val res_i64: R.Result[type.IrTypeId, str] = type.intern_int(?m.types, 64);
+    if (R.is_err[type.IrTypeId, str](res_i64)) { ret 1; }
+    val i64t: type.IrTypeId = R.unwrap_ok[type.IrTypeId, str](res_i64);
+
+    val res_fn: R.Result[u32, str] = ir.function_add(?m, intern.STR_NIL, type.IRT_NIL, 0);
+    if (R.is_err[u32, str](res_fn)) { ret 1; }
+    val fn: *ir.Function = ?m.functions[R.unwrap_ok[u32, str](res_fn)];
+
+    var bld: builder.Builder = builder.init(?m);
+    builder.set_function(?bld, fn);
+    val res_entry: R.Result[id.BlockId, str] = builder.new_block(?bld);
+    if (R.is_err[id.BlockId, str](res_entry)) { ret 1; }
+    val entry: id.BlockId = R.unwrap_ok[id.BlockId, str](res_entry);
+    builder.set_block(?bld, entry);
+
+    # p = alloca i64; store 0 -> p; dbg_value(p); v = load p; ret v. the alloca's only
+    # non-load/store reference is the debug value naming it.
+    val res_alloca: R.Result[value.Value, str] = builder.emit_alloca(?bld, i64t, value.const_int(1, i64t));
+    if (R.is_err[value.Value, str](res_alloca)) { ret 1; }
+    val p: value.Value = R.unwrap_ok[value.Value, str](res_alloca);
+
+    if (R.is_err[bool, str](builder.emit_store(?bld, value.const_int(0, i64t), p)))                 { ret 1; }
+    if (R.is_err[bool, str](builder.emit_dbg_value(?bld, p, intern.STR_NIL, i64t, semtype.TYPE_NIL, false, 0))) { ret 1; }
+
+    val res_load: R.Result[value.Value, str] = builder.emit_load(?bld, p, i64t);
+    if (R.is_err[value.Value, str](res_load))                                                 { ret 1; }
+    if (R.is_err[bool, str](builder.emit_ret(?bld, R.unwrap_ok[value.Value, str](res_load)))) { ret 1; }
+
+    val entry_blk: *ir.Block = ?fn.blocks[entry::u32];
+
+    # the debug use must not pin p in memory: mem2reg promotes it and the alloca leaves
+    # the block.
     if (R.is_err[bool, str](run(?m)))          { ret 1; }
     if (live_alloca_count(fn, entry_blk) != 0) { ret 1; }
     ret 0;


### PR DESCRIPTION
Closes #1944.

## Root cause

`mem2reg.classify_escapes` marked an alloca **escaped** for any non-load/store reference — including an `OP_DBG_VALUE` naming it. An `OP_DBG_VALUE` operand is a debug-only use, never a real address escape. So under `-g`, a local whose address only stops escaping once inlining removes the escaping call — which the no-`-g` build then promotes to SSA — stayed in memory (extra init/store code), emitting different machine code. This is the release-mode `-g` additivity residual that remained after #1932's `callee_instr_count` fix (which is the other half; already merged).

## Fix

Exclude `OP_DBG_VALUE` from escape analysis (`src/lang/me/pass/mem2reg.mach`). The local promotes identically in both builds; the debug value is salvaged (optimized out) when the promoted alloca is erased. The pass is now blind to debug metadata, per the additivity invariant.

## Guards (falsifiable)

- **Unit**: `mem2reg.run:dbg_value_is_not_an_escape` — an alloca whose only non-load/store reference is a debug value must still promote. Fails if the exclusion is reverted.
- **Lane**: `dbg/verify.sh` now asserts release `-g` byte-additivity (step 5 only ran at debug, where the release-only passes never fire). `verify_inline_release` builds a no-`-g` release binary too and asserts `elf_seg_identical`; a new `dbg/fixtures/promote` fixture drives a dedicated `verify_release_additive` leg on all three ELF ISAs. The leg **fails on clean dev and passes with this fix** (confirmed by running the lane with a no-fix compiler).

## Verification

- from-source build; **self-host fixpoint** byte-identical
- unit suite **540 / 0** (was 539; +1 regression)
- debuginfo lane **12/12** across x86_64 / arm64 / riscv64 (qemu), incl. the new release-additivity legs
- **non-`-g` output byte-identical** with and without this change
- release `-g` vs no-`-g`: every mach-std module and all dbg fixtures byte-identical

## Out of scope

A **separate** backend `-g`-sensitivity remains in the compiler's own object-format/ABI writers (`of/{raw,elf,macho,coff}`, `abi/{sysv,win64}`), present at debug and release and pre-existing on clean dev — filed as **#1956** (IR→MIR lowering / regalloc, not this mem2reg cause). The fixtures here do not exercise it; full compiler-self additivity waits on #1956.
