### PR TITLE
fix(dce): salvage dbg-values by OP_DBG_VALUE presence, not DbgVar metadata

### DIFF
--- a/src/lang/me/ir/mutate.mach
+++ b/src/lang/me/ir/mutate.mach
@@ -15,7 +15,6 @@
 #     own predicate (dce's dead set, mem2reg's promoted memops).
 #   - cloning: `clone_instruction`, a faithful per-instruction copy.
 
-use std.collections.map;
 use std.types.bool.bool;
 use std.types.bool.false;
 use std.types.bool.true;
@@ -226,6 +225,14 @@ pub def EraseTest: fun(ptr, id.InstructionId) bool;
 # ret:  ok(true) once every marked instruction is dropped and its dbg-values
 #       salvaged, or an allocation error raised while growing the pool
 pub fun erase_marked(m: *ir.Module, fn: *ir.Function, ctx: ptr, test: EraseTest) R.Result[bool, str] {
+    # salvage runs only when the function actually holds debug values, decided once
+    # here by scanning for an OP_DBG_VALUE. gating on debug-value presence (not on
+    # DbgVar metadata) is load-bearing: the inliner clones a callee's OP_DBG_VALUE
+    # instructions before its dbg-clone attaches their metadata, so a caller can bind
+    # a debug operand with an empty dbg_vars map; that operand still needs salvaging
+    # when its value is dropped, or it dangles at a value the verifier rejects.
+    val dbg: bool = has_dbg_values(fn);
+
     var b: u32 = 0;
     for (b < fn.block_count) {
         val blk: *ir.Block = ?fn.blocks[b];
@@ -237,7 +244,7 @@ pub fun erase_marked(m: *ir.Module, fn: *ir.Function, ctx: ptr, test: EraseTest)
                 blk.phis[w] = blk.phis[r];
                 w = w + 1;
             }
-            or {
+            or (dbg) {
                 val res: R.Result[bool, str] = salvage_dbg_values(m, fn, ctx, test, blk.phis[r]);
                 if (R.is_err[bool, str](res)) { ret res; }
             }
@@ -252,7 +259,7 @@ pub fun erase_marked(m: *ir.Module, fn: *ir.Function, ctx: ptr, test: EraseTest)
                 blk.instructions[w] = blk.instructions[r];
                 w = w + 1;
             }
-            or {
+            or (dbg) {
                 val res: R.Result[bool, str] = salvage_dbg_values(m, fn, ctx, test, blk.instructions[r]);
                 if (R.is_err[bool, str](res)) { ret res; }
             }
@@ -265,6 +272,25 @@ pub fun erase_marked(m: *ir.Module, fn: *ir.Function, ctx: ptr, test: EraseTest)
     ret R.ok[bool, str](true);
 }
 
+# true when `fn` holds any OP_DBG_VALUE instruction in its pool
+#
+# OP_DBG_VALUE instructions exist only under `-g`. erase_marked scans for one once per
+# call so salvage runs whenever debug values are present -- including inlined debug-value
+# clones that bind an operand but carry no DbgVar metadata yet, which a dbg_vars-length
+# test would miss.
+# ---
+# fn:  the function to scan
+# ret: true when at least one OP_DBG_VALUE lives in the instruction pool
+fun has_dbg_values(fn: *ir.Function) bool {
+    var i: u32 = 0;
+    for (i < fn.instr_len) {
+        val inst: *instruction.Instruction = ?fn.instrs[i];
+        if (inst.kind == instruction.OP_DBG_VALUE) { ret true; }
+        i = i + 1;
+    }
+    ret false;
+}
+
 # salvage every debug value bound to instruction `dropped`, which erase_marked is
 # about to remove, so its variable's location survives the erase
 #
@@ -274,8 +300,8 @@ pub fun erase_marked(m: *ir.Module, fn: *ir.Function, ctx: ptr, test: EraseTest)
 # value stays computable. Otherwise (an unrecoverable op, or a base that is also
 # being erased) the debug value is marked optimized out: its operand becomes the
 # null idiom, so the debugger shows *optimized out* rather than a stale value.
-# Without `-g` a function holds no debug values and the length guard makes this a
-# no-op.
+# The caller (erase_marked) gates this on has_dbg_values, so it is reached only when
+# the function actually holds OP_DBG_VALUE instructions.
 # ---
 # m:       module owning the allocator
 # fn:      the function being compacted
@@ -284,8 +310,6 @@ pub fun erase_marked(m: *ir.Module, fn: *ir.Function, ctx: ptr, test: EraseTest)
 # dropped: the instruction id being removed
 # ret:     ok(true), or an allocation error from growing the expression pool
 fun salvage_dbg_values(m: *ir.Module, fn: *ir.Function, ctx: ptr, test: EraseTest, dropped: id.InstructionId) R.Result[bool, str] {
-    if (map.length[id.InstructionId, ir.DbgVar](fn.dbg_vars) == 0) { ret R.ok[bool, str](true); }
-
     var base:        value.Value;
     var op:          ir.DbgOp;
     var recoverable: bool = false;

--- a/src/lang/me/pass/dce.mach
+++ b/src/lang/me/pass/dce.mach
@@ -27,6 +27,8 @@ use A: std.allocator;
 use O: std.types.option;
 use R: std.types.result;
 
+use map: std.collections.map;
+
 use mach.lang.intern;
 use mach.lang.me.ir;
 use mach.lang.me.ir.builder;
@@ -35,6 +37,7 @@ use mach.lang.me.ir.instruction;
 use mach.lang.me.ir.mutate;
 use mach.lang.me.ir.type;
 use mach.lang.me.ir.value;
+use semtype: mach.lang.type;
 
 # sentinel for a removed block in the reachability compaction remap
 val BLOCK_GONE: u32 = 0xFFFFFFFF;
@@ -682,5 +685,66 @@ test "mach.lang.me.pass.dce.run:dead_block_and_phi_pruned" {
     val phi_id: id.InstructionId = fn.blocks[1].phis[0];
     val phi_inst: *instruction.Instruction = ?fn.instrs[phi_id];
     if (phi_inst.operand_count != 2) { ret 1; }
+    ret 0;
+}
+
+# a -g additivity regression (#1944): a dropped value's debug value must be salvaged
+# even when the function carries no DbgVar metadata for it -- the state the inliner
+# leaves after cloning a callee's OP_DBG_VALUE instructions but before its dbg-clone
+# attaches their metadata. erase_marked gates salvage on OP_DBG_VALUE presence, not on
+# dbg_vars length; keying it on the map length (the reverted behaviour) skips salvage
+# here and leaves the debug value dangling at the removed instruction.
+test "mach.lang.me.pass.dce.run:salvages_metadata_free_dbg_value" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+
+    val res_module: R.Result[ir.Module, str] = ir.init(?alloc, intern.STR_NIL);
+    if (R.is_err[ir.Module, str](res_module)) { ret 1; }
+    var m: ir.Module = R.unwrap_ok[ir.Module, str](res_module);
+
+    val res_i64: R.Result[type.IrTypeId, str] = type.intern_int(?m.types, 64);
+    if (R.is_err[type.IrTypeId, str](res_i64)) { ret 1; }
+    val i64t: type.IrTypeId = R.unwrap_ok[type.IrTypeId, str](res_i64);
+
+    val res_fn: R.Result[u32, str] = ir.function_add(?m, intern.STR_NIL, type.IRT_NIL, 0);
+    if (R.is_err[u32, str](res_fn)) { ret 1; }
+    val fn: *ir.Function = ?m.functions[R.unwrap_ok[u32, str](res_fn)];
+
+    var bld: builder.Builder = builder.init(?m);
+    builder.set_function(?bld, fn);
+    val res_entry: R.Result[id.BlockId, str] = builder.new_block(?bld);
+    if (R.is_err[id.BlockId, str](res_entry)) { ret 1; }
+    builder.set_block(?bld, R.unwrap_ok[id.BlockId, str](res_entry));
+
+    val p0: value.Value = value.param(0, i64t);
+    val p1: value.Value = value.param(1, i64t);
+
+    # x = add(p0, p1) -- referenced only by the debug value, so DCE drops it.
+    val res_x: R.Result[value.Value, str] = builder.emit_add(?bld, p0, p1);
+    if (R.is_err[value.Value, str](res_x)) { ret 1; }
+    val x: value.Value = R.unwrap_ok[value.Value, str](res_x);
+
+    if (R.is_err[bool, str](builder.emit_dbg_value(?bld, x, intern.STR_NIL, i64t, semtype.TYPE_NIL, false, 0))) { ret 1; }
+    if (R.is_err[bool, str](builder.emit_ret(?bld, p0))) { ret 1; }
+
+    # simulate an inlined debug-value clone: the OP_DBG_VALUE binds x but carries no
+    # DbgVar metadata (empty dbg_vars).
+    map.clear[id.InstructionId, ir.DbgVar](?fn.dbg_vars);
+
+    if (R.is_err[bool, str](run(?m))) { ret 1; }
+
+    # x is dropped; its debug value survives (not removable) and must be salvaged to the
+    # optimized-out null idiom, never left dangling at the removed instruction.
+    var found: bool = false;
+    var i: u32 = 0;
+    for (i < fn.instr_len) {
+        val ins: *instruction.Instruction = ?fn.instrs[i];
+        if (ins.kind == instruction.OP_DBG_VALUE) {
+            found = true;
+            if (ins.operands[0].kind != value.VAL_CONST_NULL) { ret 1; }
+        }
+        i = i + 1;
+    }
+    if (found == false) { ret 1; }
     ret 0;
 }


### PR DESCRIPTION
Closes #1958. Follow-up to #1944 / PR #1957 — the salvage-guard half that merged without.

## Root cause

`mutate.salvage_dbg_values` gated the dbg-value salvage on `map.length(fn.dbg_vars) == 0`, keying applicability on DbgVar metadata presence rather than on OP_DBG_VALUE presence. The inliner clones a callee's `OP_DBG_VALUE` instructions before its dbg-clone attaches their metadata, so a caller can hold a metadata-free `OP_DBG_VALUE` with an empty `dbg_vars` map; when DCE drops the value it names, the guard skips salvage and the dbg-value dangles at a removed instruction — which the verifier rejects (`VC_DOMINANCE`) under release `-g`.

## Fix

`erase_marked` decides once (scanning for an `OP_DBG_VALUE` via `has_dbg_values`) whether to salvage, and gates its per-drop salvage calls on that; the `dbg_vars`-length guard is removed from `salvage_dbg_values`. Salvage now covers every dbg-value bound to a dropped value.

## Why this is separate / why it still matters

Currently **masked on dev** by #1932's `clone_dbg_metadata` (which keeps `dbg_vars` populated for inlined dbg-values), so it does not manifest today. But the guard's contract is wrong regardless — a defect hidden by another feature's side effect is still a defect. PR #1957 fixed the mem2reg escape half of #1944 and merged before this could join it.

## Guard (falsifiable)

`mach.lang.me.pass.dce.run:salvages_metadata_free_dbg_value` — a metadata-free `OP_DBG_VALUE` (empty `dbg_vars`) whose value DCE drops must be salvaged to the optimized-out null idiom. Reverting the gate leaves it dangling and fails the test.

## Verification

From-source build; unit suite 542/0 (+1 regression); non-`-g` output byte-identical; the fix is a no-op on current dev's machine code (inert until a metadata-free dbg-value arises), so all additivity/fixpoint/dbg-lane results are unchanged.
