### PR TITLE
fix(codegen): make lazy param homing blind to debug values (release -g additivity)

### DIFF
--- a/src/lang/be/codegen/mir/abi.mach
+++ b/src/lang/be/codegen/mir/abi.mach
@@ -13,6 +13,7 @@
 # translation core (`mir.lower`) import this module for signature classification
 # and call / param / ret lowering.
 
+use std.allocator.page;
 use std.types.bool.bool;
 use std.types.bool.false;
 use std.types.bool.true;
@@ -23,9 +24,11 @@ use A: std.allocator;
 use O: std.types.option;
 use R: std.types.result;
 
+use mach.lang.intern;
 use mach.lang.be.codegen.mir;
 use mach.lang.be.codegen.mir.context;
 use ir: mach.lang.me.ir;
+use mach.lang.me.ir.builder;
 use mach.lang.me.ir.id;
 use mach.lang.me.ir.instruction;
 use mach.lang.me.ir.type;
@@ -33,6 +36,7 @@ use mach.lang.me.ir.value;
 use mach.lang.target.abi;
 use mach.lang.target.isa;
 use target: mach.lang.target.resolved;
+use semtype: mach.lang.type;
 
 # upper bound on the GP argument-register file size, sizing the stack buffer
 # `abi_gp_arg_reg` fills from `tgt.abi.gp_arg_regs`. every modeled convention's GP
@@ -1369,7 +1373,10 @@ fun param_has_use(fn: *ir.Function, param_ix: u32) bool {
 #
 # A nil / out-of-range id yields false (a block's absent terminator or a stale id).
 # Block-target operands are integer constants, not VAL_PARAM, so a branch's
-# successor slots never register as a parameter use.
+# successor slots never register as a parameter use. An OP_DBG_VALUE naming the
+# parameter is a debug-only use, never a real read: counting it would home the
+# parameter (a dead load out of its incoming register) under -g but not without,
+# a -g additivity violation, so it is skipped.
 # ---
 # fn:       the IR function owning the instruction pool
 # iid:      the instruction id to inspect
@@ -1379,6 +1386,7 @@ fun instr_names_param(fn: *ir.Function, iid: id.InstructionId, param_ix: u32) bo
     if (iid == id.INSTR_NIL)      { ret false; }
     if (iid::u32 >= fn.instr_len) { ret false; }
     val inst: *instruction.Instruction = ?fn.instrs[iid::u32];
+    if (inst.kind == instruction.OP_DBG_VALUE) { ret false; }
     var k: u32 = 0;
     for (k < inst.operand_count) {
         val v: value.Value = inst.operands[k];
@@ -1524,5 +1532,43 @@ test "mach.lang.be.codegen.mir.abi:stack_arg_alignment" {
     # a by-value slot honors the value's alignment, clamped to the 8-byte minimum.
     if (stack_arg_align(abi.CLASS_STACK, 16) != 16) { ret 1; }
     if (stack_arg_align(abi.CLASS_STACK, 4) != 8)   { ret 1; }
+    ret 0;
+}
+
+# a -g additivity regression (#1956): an OP_DBG_VALUE naming a parameter is a debug-only
+# use, so it must not make the lazy param-homing (#1820) home that parameter. A parameter
+# read only by a debug value reports no use; a really-read one still does. Reverting the
+# OP_DBG_VALUE skip in instr_names_param homes the debug-only parameter under -g (a dead
+# load out of its incoming register) that the no-g build never emits.
+test "mach.lang.be.codegen.mir.abi.param_has_use:dbg_value_is_not_a_use" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+    val res_module: R.Result[ir.Module, str] = ir.init(?alloc, intern.STR_NIL);
+    if (R.is_err[ir.Module, str](res_module)) { ret 1; }
+    var m: ir.Module = R.unwrap_ok[ir.Module, str](res_module);
+
+    val res_i64: R.Result[type.IrTypeId, str] = type.intern_int(?m.types, 64);
+    if (R.is_err[type.IrTypeId, str](res_i64)) { ir.dnit(?m); ret 1; }
+    val i64t: type.IrTypeId = R.unwrap_ok[type.IrTypeId, str](res_i64);
+
+    val res_fn: R.Result[u32, str] = ir.function_add(?m, intern.STR_NIL, type.IRT_NIL, 0);
+    if (R.is_err[u32, str](res_fn)) { ir.dnit(?m); ret 1; }
+    val fn: *ir.Function = ?m.functions[R.unwrap_ok[u32, str](res_fn)];
+
+    var bld: builder.Builder = builder.init(?m);
+    builder.set_function(?bld, fn);
+    val res_entry: R.Result[id.BlockId, str] = builder.new_block(?bld);
+    if (R.is_err[id.BlockId, str](res_entry)) { ir.dnit(?m); ret 1; }
+    builder.set_block(?bld, R.unwrap_ok[id.BlockId, str](res_entry));
+
+    # p0 is named only by a debug value; p1 is really returned.
+    if (R.is_err[bool, str](builder.emit_dbg_value(?bld, value.param(0, i64t), intern.STR_NIL, i64t, semtype.TYPE_NIL, true, 0))) { ir.dnit(?m); ret 1; }
+    if (R.is_err[bool, str](builder.emit_ret(?bld, value.param(1, i64t)))) { ir.dnit(?m); ret 1; }
+
+    # the debug use of p0 must not count; p1's real use must.
+    if (param_has_use(fn, 0) != false) { ir.dnit(?m); ret 1; }
+    if (param_has_use(fn, 1) != true)  { ir.dnit(?m); ret 1; }
+
+    ir.dnit(?m);
     ret 0;
 }


### PR DESCRIPTION
Closes #1956. The final release-mode `-g` additivity residual, after #1932 (inliner count) and #1944/PR #1957 (mem2reg escape).

## Root cause

`param_has_use` — the lazy param-homing use test (#1820) — counted an `OP_DBG_VALUE` naming a parameter as a real use (via `instr_names_param`). Under `-g`, a parameter read only by its debug value was therefore homed: a dead load out of its incoming register (`mov rdx, [rbp+N]`) that the no-`-g` build never emits. The two builds' machine code differed. It manifested wherever a function has many parameters some of which the optimized body never reads — the compiler's own object-format/ABI writers (`of/{raw,elf,macho,coff}`, `abi/{sysv,win64}`), and it broke additivity at **both** debug and release (the debug fixtures were just too small to exercise it).

## Fix

`instr_names_param` skips `OP_DBG_VALUE`, so a debug use never homes a parameter. The pass is now blind to debug metadata, the same principle as the inliner-count and mem2reg-escape fixes.

## Guard (falsifiable)

`mach.lang.be.codegen.mir.abi.param_has_use:dbg_value_is_not_a_use` — a parameter named only by a debug value reports no use; a really-read one still does. Reverting the skip fails it.

## Verification (money proof)

With this fix the **whole compiler self-build is byte-identical with and without `-g`** — every module, at **both** debug and release (previously 720 B release / 160 B debug of divergence remained). Bar: from-source build; self-host fixpoint identical; unit suite 542/0 (+1 regression); dbg lane green across x86_64/arm64/riscv64 (`llvm-dwarfdump --verify` clean — no invalid DWARF from the un-homed params); non-`-g` output byte-identical with and without the change.

## Sequencing

#1904 (phi-merge births) stays serialized behind this — it adds `-g`-only IR to exactly this lowering surface.
