### PR TITLE
fix: migrate int/ and dbg/ fixture manifests to the V2 schema

### DIFF
--- a/dbg/fixtures/aggregate/mach.toml
+++ b/dbg/fixtures/aggregate/mach.toml
@@ -1,11 +1,10 @@
 [project]
-id      = "dbgagg"
-name    = "dbgagg"
+id = "dbgagg"
+name = "dbgagg"
+description = "debug-info fixture"
 version = "0.0.0"
-src     = "src"
-dep     = "dep"
-target  = "linux"
-out     = "out/{target}/{profile}/bin/{name}{ext}"
+src = "src"
+out = "out/{target.name}/{profile.name}"
 
 [target.linux]
 isa = "x86_64"
@@ -26,7 +25,6 @@ abi = "lp64"
 isa = "x86_64"
 os  = "windows"
 abi = "win64"
-ext = ".exe"
 
 [target.darwin-x86_64]
 isa = "x86_64"
@@ -44,9 +42,12 @@ opt = 0
 [profile.release]
 opt = 2
 
-[bin.dbgagg]
+[artifact.dbgagg]
+kind = "bin"
 entry = "main.mach"
+out = "bin/dbgagg"
+targets = ["*"]
 
-[deps.mach-std]
+[dep.mach-std]
 git = "https://github.com/briar-systems/mach-std"
 ref = "branch/main"

--- a/dbg/fixtures/inline/mach.toml
+++ b/dbg/fixtures/inline/mach.toml
@@ -1,11 +1,10 @@
 [project]
-id      = "inlinefix"
-name    = "inlinefix"
+id = "inlinefix"
+name = "inlinefix"
+description = "debug-info fixture"
 version = "0.0.0"
-src     = "src"
-dep     = "dep"
-target  = "linux"
-out     = "out/{target}/{profile}/bin/{name}{ext}"
+src = "src"
+out = "out/{target.name}/{profile.name}"
 
 [target.linux]
 isa = "x86_64"
@@ -28,9 +27,12 @@ opt = 0
 [profile.release]
 opt = 2
 
-[bin.inlinefix]
+[artifact.inlinefix]
+kind = "bin"
 entry = "main.mach"
+out = "bin/inlinefix"
+targets = ["*"]
 
-[deps.mach-std]
+[dep.mach-std]
 git = "https://github.com/briar-systems/mach-std"
 ref = "branch/main"

--- a/dbg/fixtures/inline4/mach.toml
+++ b/dbg/fixtures/inline4/mach.toml
@@ -1,11 +1,10 @@
 [project]
-id      = "inline4fix"
-name    = "inline4fix"
+id = "inline4fix"
+name = "inline4fix"
+description = "debug-info fixture"
 version = "0.0.0"
-src     = "src"
-dep     = "dep"
-target  = "linux"
-out     = "out/{target}/{profile}/bin/{name}{ext}"
+src = "src"
+out = "out/{target.name}/{profile.name}"
 
 [target.linux]
 isa = "x86_64"
@@ -28,9 +27,12 @@ opt = 0
 [profile.release]
 opt = 2
 
-[bin.inline4fix]
+[artifact.inline4fix]
+kind = "bin"
 entry = "main.mach"
+out = "bin/inline4fix"
+targets = ["*"]
 
-[deps.mach-std]
+[dep.mach-std]
 git = "https://github.com/briar-systems/mach-std"
 ref = "branch/main"

--- a/dbg/fixtures/multi/mach.toml
+++ b/dbg/fixtures/multi/mach.toml
@@ -1,11 +1,10 @@
 [project]
-id      = "dbgfix"
-name    = "dbgfix"
+id = "dbgfix"
+name = "dbgfix"
+description = "debug-info fixture"
 version = "0.0.0"
-src     = "src"
-dep     = "dep"
-target  = "linux"
-out     = "out/{target}/{profile}/bin/{name}{ext}"
+src = "src"
+out = "out/{target.name}/{profile.name}"
 
 [target.linux]
 isa = "x86_64"
@@ -26,7 +25,6 @@ abi = "lp64"
 isa = "x86_64"
 os  = "windows"
 abi = "win64"
-ext = ".exe"
 
 [target.darwin-x86_64]
 isa = "x86_64"
@@ -44,9 +42,12 @@ opt = 0
 [profile.release]
 opt = 2
 
-[bin.dbgfix]
+[artifact.dbgfix]
+kind = "bin"
 entry = "main.mach"
+out = "bin/dbgfix"
+targets = ["*"]
 
-[deps.mach-std]
+[dep.mach-std]
 git = "https://github.com/briar-systems/mach-std"
 ref = "branch/main"

--- a/dbg/fixtures/promote/mach.toml
+++ b/dbg/fixtures/promote/mach.toml
@@ -1,11 +1,10 @@
 [project]
-id      = "promotefix"
-name    = "promotefix"
+id = "promotefix"
+name = "promotefix"
+description = "debug-info fixture"
 version = "0.0.0"
-src     = "src"
-dep     = "dep"
-target  = "linux"
-out     = "out/{target}/{profile}/bin/{name}{ext}"
+src = "src"
+out = "out/{target.name}/{profile.name}"
 
 [target.linux]
 isa = "x86_64"
@@ -28,9 +27,12 @@ opt = 0
 [profile.release]
 opt = 2
 
-[bin.promotefix]
+[artifact.promotefix]
+kind = "bin"
 entry = "main.mach"
+out = "bin/promotefix"
+targets = ["*"]
 
-[deps.mach-std]
+[dep.mach-std]
 git = "https://github.com/briar-systems/mach-std"
 ref = "branch/main"

--- a/int/regression/1750-i32-signext/mach.toml
+++ b/int/regression/1750-i32-signext/mach.toml
@@ -1,11 +1,10 @@
 [project]
-id      = "case"
-name    = "case"
+id = "case"
+name = "case"
+description = "integration test fixture"
 version = "0.0.0"
-src     = "src"
-dep     = "dep"
-target  = "linux"
-out     = "out/{target}/{profile}/bin/{name}{ext}"
+src = "src"
+out = "out/{target.name}/{profile.name}"
 
 [target.linux]
 isa = "x86_64"
@@ -26,7 +25,6 @@ abi = "lp64"
 isa = "x86_64"
 os  = "windows"
 abi = "win64"
-ext = ".exe"
 
 [target.darwin-x86_64]
 isa = "x86_64"
@@ -44,9 +42,12 @@ opt = 0
 [profile.release]
 opt = 2
 
-[bin.case]
+[artifact.case]
+kind = "bin"
 entry = "main.mach"
+out = "bin/case"
+targets = ["*"]
 
-[deps.mach-std]
+[dep.mach-std]
 git = "https://github.com/briar-systems/mach-std"
 ref = "branch/main"

--- a/int/regression/1762-rv64-float-vararg/mach.toml
+++ b/int/regression/1762-rv64-float-vararg/mach.toml
@@ -1,11 +1,10 @@
 [project]
-id      = "case"
-name    = "case"
+id = "case"
+name = "case"
+description = "integration test fixture"
 version = "0.0.0"
-src     = "src"
-dep     = "dep"
-target  = "linux"
-out     = "out/{target}/{profile}/bin/{name}{ext}"
+src = "src"
+out = "out/{target.name}/{profile.name}"
 
 [target.linux]
 isa = "x86_64"
@@ -26,7 +25,6 @@ abi = "lp64"
 isa = "x86_64"
 os  = "windows"
 abi = "win64"
-ext = ".exe"
 
 [target.darwin-x86_64]
 isa = "x86_64"
@@ -44,9 +42,12 @@ opt = 0
 [profile.release]
 opt = 2
 
-[bin.case]
+[artifact.case]
+kind = "bin"
 entry = "main.mach"
+out = "bin/case"
+targets = ["*"]
 
-[deps.mach-std]
+[dep.mach-std]
 git = "https://github.com/briar-systems/mach-std"
 ref = "branch/main"

--- a/int/regression/1851-rv64-phi-signext/mach.toml
+++ b/int/regression/1851-rv64-phi-signext/mach.toml
@@ -1,11 +1,10 @@
 [project]
-id      = "case"
-name    = "case"
+id = "case"
+name = "case"
+description = "integration test fixture"
 version = "0.0.0"
-src     = "src"
-dep     = "dep"
-target  = "linux"
-out     = "out/{target}/{profile}/bin/{name}{ext}"
+src = "src"
+out = "out/{target.name}/{profile.name}"
 
 [target.linux]
 isa = "x86_64"
@@ -26,7 +25,6 @@ abi = "lp64"
 isa = "x86_64"
 os  = "windows"
 abi = "win64"
-ext = ".exe"
 
 [target.darwin-x86_64]
 isa = "x86_64"
@@ -44,9 +42,12 @@ opt = 0
 [profile.release]
 opt = 2
 
-[bin.case]
+[artifact.case]
+kind = "bin"
 entry = "main.mach"
+out = "bin/case"
+targets = ["*"]
 
-[deps.mach-std]
+[dep.mach-std]
 git = "https://github.com/briar-systems/mach-std"
 ref = "branch/main"

--- a/int/regression/1852-rv64-self-host/mach.toml
+++ b/int/regression/1852-rv64-self-host/mach.toml
@@ -1,11 +1,10 @@
 [project]
-id      = "case"
-name    = "case"
+id = "case"
+name = "case"
+description = "integration test fixture"
 version = "0.0.0"
-src     = "src"
-dep     = "dep"
-target  = "linux-riscv64"
-out     = "out/{target}/{profile}/bin/{name}{ext}"
+src = "src"
+out = "out/{target.name}/{profile.name}"
 
 # riscv64-only: this case is compiled by the riscv64-hosted compiler under qemu
 # (see case.conf `self-host`), so it never targets another format.
@@ -20,9 +19,12 @@ opt = 0
 [profile.release]
 opt = 2
 
-[bin.case]
+[artifact.case]
+kind = "bin"
 entry = "main.mach"
+out = "bin/case"
+targets = ["*"]
 
-[deps.mach-std]
+[dep.mach-std]
 git = "https://github.com/briar-systems/mach-std"
 ref = "branch/main"

--- a/int/regression/1923-comptime-field-gate/mach.toml
+++ b/int/regression/1923-comptime-field-gate/mach.toml
@@ -1,11 +1,10 @@
 [project]
-id      = "case"
-name    = "case"
+id = "case"
+name = "case"
+description = "integration test fixture"
 version = "0.0.0"
-src     = "src"
-dep     = "dep"
-target  = "linux"
-out     = "out/{target}/{profile}/bin/{name}{ext}"
+src = "src"
+out = "out/{target.name}/{profile.name}"
 
 [target.linux]
 isa = "x86_64"
@@ -26,7 +25,6 @@ abi = "lp64"
 isa = "x86_64"
 os  = "windows"
 abi = "win64"
-ext = ".exe"
 
 [target.darwin-x86_64]
 isa = "x86_64"
@@ -44,9 +42,12 @@ opt = 0
 [profile.release]
 opt = 2
 
-[bin.case]
+[artifact.case]
+kind = "bin"
 entry = "main.mach"
+out = "bin/case"
+targets = ["*"]
 
-[deps.mach-std]
+[dep.mach-std]
 git = "https://github.com/briar-systems/mach-std"
 ref = "branch/main"

--- a/int/regression/1925-global-aggregate-byval/mach.toml
+++ b/int/regression/1925-global-aggregate-byval/mach.toml
@@ -1,11 +1,10 @@
 [project]
-id      = "case"
-name    = "case"
+id = "case"
+name = "case"
+description = "integration test fixture"
 version = "0.0.0"
-src     = "src"
-dep     = "dep"
-target  = "linux"
-out     = "out/{target}/{profile}/bin/{name}{ext}"
+src = "src"
+out = "out/{target.name}/{profile.name}"
 
 [target.linux]
 isa = "x86_64"
@@ -26,7 +25,6 @@ abi = "lp64"
 isa = "x86_64"
 os  = "windows"
 abi = "win64"
-ext = ".exe"
 
 [target.darwin-x86_64]
 isa = "x86_64"
@@ -44,9 +42,12 @@ opt = 0
 [profile.release]
 opt = 2
 
-[bin.case]
+[artifact.case]
+kind = "bin"
 entry = "main.mach"
+out = "bin/case"
+targets = ["*"]
 
-[deps.mach-std]
+[dep.mach-std]
 git = "https://github.com/briar-systems/mach-std"
 ref = "branch/main"

--- a/int/surface/aggregate-abi/mach.toml
+++ b/int/surface/aggregate-abi/mach.toml
@@ -1,11 +1,10 @@
 [project]
-id      = "case"
-name    = "case"
+id = "case"
+name = "case"
+description = "integration test fixture"
 version = "0.0.0"
-src     = "src"
-dep     = "dep"
-target  = "linux"
-out     = "out/{target}/{profile}/bin/{name}{ext}"
+src = "src"
+out = "out/{target.name}/{profile.name}"
 
 [target.linux]
 isa = "x86_64"
@@ -26,7 +25,6 @@ abi = "lp64"
 isa = "x86_64"
 os  = "windows"
 abi = "win64"
-ext = ".exe"
 
 [target.darwin-x86_64]
 isa = "x86_64"
@@ -44,9 +42,12 @@ opt = 0
 [profile.release]
 opt = 2
 
-[bin.case]
+[artifact.case]
+kind = "bin"
 entry = "main.mach"
+out = "bin/case"
+targets = ["*"]
 
-[deps.mach-std]
+[dep.mach-std]
 git = "https://github.com/briar-systems/mach-std"
 ref = "branch/main"

--- a/int/surface/control-flow/mach.toml
+++ b/int/surface/control-flow/mach.toml
@@ -1,11 +1,10 @@
 [project]
-id      = "case"
-name    = "case"
+id = "case"
+name = "case"
+description = "integration test fixture"
 version = "0.0.0"
-src     = "src"
-dep     = "dep"
-target  = "linux"
-out     = "out/{target}/{profile}/bin/{name}{ext}"
+src = "src"
+out = "out/{target.name}/{profile.name}"
 
 [target.linux]
 isa = "x86_64"
@@ -26,7 +25,6 @@ abi = "lp64"
 isa = "x86_64"
 os  = "windows"
 abi = "win64"
-ext = ".exe"
 
 [target.darwin-x86_64]
 isa = "x86_64"
@@ -44,9 +42,12 @@ opt = 0
 [profile.release]
 opt = 2
 
-[bin.case]
+[artifact.case]
+kind = "bin"
 entry = "main.mach"
+out = "bin/case"
+targets = ["*"]
 
-[deps.mach-std]
+[dep.mach-std]
 git = "https://github.com/briar-systems/mach-std"
 ref = "branch/main"

--- a/int/surface/elf-pie/mach.toml
+++ b/int/surface/elf-pie/mach.toml
@@ -1,11 +1,10 @@
 [project]
-id      = "case"
-name    = "case"
+id = "case"
+name = "case"
+description = "integration test fixture"
 version = "0.0.0"
-src     = "src"
-dep     = "dep"
-target  = "linux"
-out     = "out/{target}/{profile}/bin/{name}{ext}"
+src = "src"
+out = "out/{target.name}/{profile.name}"
 
 [target.linux]
 isa = "x86_64"
@@ -18,9 +17,12 @@ opt = 0
 [profile.release]
 opt = 2
 
-[bin.case]
+[artifact.case]
+kind = "bin"
 entry = "main.mach"
+out = "bin/case"
+targets = ["*"]
 
-[deps.mach-std]
+[dep.mach-std]
 git = "https://github.com/briar-systems/mach-std"
 ref = "branch/main"

--- a/int/surface/elf-relro/mach.toml
+++ b/int/surface/elf-relro/mach.toml
@@ -1,11 +1,10 @@
 [project]
-id      = "case"
-name    = "case"
+id = "case"
+name = "case"
+description = "integration test fixture"
 version = "0.0.0"
-src     = "src"
-dep     = "dep"
-target  = "linux"
-out     = "out/{target}/{profile}/bin/{name}{ext}"
+src = "src"
+out = "out/{target.name}/{profile.name}"
 
 [target.linux]
 isa = "x86_64"
@@ -28,9 +27,12 @@ opt = 0
 [profile.release]
 opt = 2
 
-[bin.case]
+[artifact.case]
+kind = "bin"
 entry = "main.mach"
+out = "bin/case"
+targets = ["*"]
 
-[deps.mach-std]
+[dep.mach-std]
 git = "https://github.com/briar-systems/mach-std"
 ref = "branch/main"

--- a/int/surface/float/mach.toml
+++ b/int/surface/float/mach.toml
@@ -1,11 +1,10 @@
 [project]
-id      = "case"
-name    = "case"
+id = "case"
+name = "case"
+description = "integration test fixture"
 version = "0.0.0"
-src     = "src"
-dep     = "dep"
-target  = "linux"
-out     = "out/{target}/{profile}/bin/{name}{ext}"
+src = "src"
+out = "out/{target.name}/{profile.name}"
 
 [target.linux]
 isa = "x86_64"
@@ -26,7 +25,6 @@ abi = "lp64"
 isa = "x86_64"
 os  = "windows"
 abi = "win64"
-ext = ".exe"
 
 [target.darwin-x86_64]
 isa = "x86_64"
@@ -44,9 +42,12 @@ opt = 0
 [profile.release]
 opt = 2
 
-[bin.case]
+[artifact.case]
+kind = "bin"
 entry = "main.mach"
+out = "bin/case"
+targets = ["*"]
 
-[deps.mach-std]
+[dep.mach-std]
 git = "https://github.com/briar-systems/mach-std"
 ref = "branch/main"

--- a/int/surface/freestanding-aarch64/mach.toml
+++ b/int/surface/freestanding-aarch64/mach.toml
@@ -1,10 +1,10 @@
 [project]
-id      = "case"
-name    = "case"
+id = "case"
+name = "case"
+description = "integration test fixture"
 version = "0.0.0"
-src     = "src"
-target  = "freestanding-aarch64"
-out     = "out/{target}/{profile}/bin/{name}{ext}"
+src = "src"
+out = "out/{target.name}/{profile.name}"
 
 [target.freestanding-aarch64]
 isa = "aarch64"
@@ -17,5 +17,8 @@ opt = 0
 [profile.release]
 opt = 2
 
-[bin.case]
+[artifact.case]
+kind = "bin"
 entry = "main.mach"
+out = "bin/case"
+targets = ["*"]

--- a/int/surface/freestanding-riscv64/mach.toml
+++ b/int/surface/freestanding-riscv64/mach.toml
@@ -1,10 +1,10 @@
 [project]
-id      = "case"
-name    = "case"
+id = "case"
+name = "case"
+description = "integration test fixture"
 version = "0.0.0"
-src     = "src"
-target  = "freestanding-riscv64"
-out     = "out/{target}/{profile}/bin/{name}{ext}"
+src = "src"
+out = "out/{target.name}/{profile.name}"
 
 [target.freestanding-riscv64]
 isa = "riscv64"
@@ -17,5 +17,8 @@ opt = 0
 [profile.release]
 opt = 2
 
-[bin.case]
+[artifact.case]
+kind = "bin"
 entry = "main.mach"
+out = "bin/case"
+targets = ["*"]

--- a/int/surface/freestanding/mach.toml
+++ b/int/surface/freestanding/mach.toml
@@ -1,10 +1,10 @@
 [project]
-id      = "case"
-name    = "case"
+id = "case"
+name = "case"
+description = "integration test fixture"
 version = "0.0.0"
-src     = "src"
-target  = "freestanding-x86_64"
-out     = "out/{target}/{profile}/bin/{name}{ext}"
+src = "src"
+out = "out/{target.name}/{profile.name}"
 
 [target.freestanding-x86_64]
 isa = "x86_64"
@@ -17,5 +17,8 @@ opt = 0
 [profile.release]
 opt = 2
 
-[bin.case]
+[artifact.case]
+kind = "bin"
 entry = "main.mach"
+out = "bin/case"
+targets = ["*"]

--- a/int/surface/macho-pie-aarch64/mach.toml
+++ b/int/surface/macho-pie-aarch64/mach.toml
@@ -1,11 +1,10 @@
 [project]
-id      = "case"
-name    = "case"
+id = "case"
+name = "case"
+description = "integration test fixture"
 version = "0.0.0"
-src     = "src"
-dep     = "dep"
-target  = "darwin-aarch64"
-out     = "out/{target}/{profile}/bin/{name}{ext}"
+src = "src"
+out = "out/{target.name}/{profile.name}"
 
 [target.darwin-aarch64]
 isa = "aarch64"
@@ -18,9 +17,12 @@ opt = 0
 [profile.release]
 opt = 2
 
-[bin.case]
+[artifact.case]
+kind = "bin"
 entry = "main.mach"
+out = "bin/case"
+targets = ["*"]
 
-[deps.mach-std]
+[dep.mach-std]
 git = "https://github.com/briar-systems/mach-std"
 ref = "branch/main"

--- a/int/surface/macho-pie-x86_64/mach.toml
+++ b/int/surface/macho-pie-x86_64/mach.toml
@@ -1,11 +1,10 @@
 [project]
-id      = "case"
-name    = "case"
+id = "case"
+name = "case"
+description = "integration test fixture"
 version = "0.0.0"
-src     = "src"
-dep     = "dep"
-target  = "darwin-x86_64"
-out     = "out/{target}/{profile}/bin/{name}{ext}"
+src = "src"
+out = "out/{target.name}/{profile.name}"
 
 [target.darwin-x86_64]
 isa = "x86_64"
@@ -18,9 +17,12 @@ opt = 0
 [profile.release]
 opt = 2
 
-[bin.case]
+[artifact.case]
+kind = "bin"
 entry = "main.mach"
+out = "bin/case"
+targets = ["*"]
 
-[deps.mach-std]
+[dep.mach-std]
 git = "https://github.com/briar-systems/mach-std"
 ref = "branch/main"

--- a/int/surface/pe-aslr/mach.toml
+++ b/int/surface/pe-aslr/mach.toml
@@ -1,17 +1,15 @@
 [project]
-id      = "case"
-name    = "case"
+id = "case"
+name = "case"
+description = "integration test fixture"
 version = "0.0.0"
-src     = "src"
-dep     = "dep"
-target  = "windows"
-out     = "out/{target}/{profile}/bin/{name}{ext}"
+src = "src"
+out = "out/{target.name}/{profile.name}"
 
 [target.windows]
 isa = "x86_64"
 os  = "windows"
 abi = "win64"
-ext = ".exe"
 
 [profile.debug]
 opt = 0
@@ -19,9 +17,12 @@ opt = 0
 [profile.release]
 opt = 2
 
-[bin.case]
+[artifact.case]
+kind = "bin"
 entry = "main.mach"
+out = "bin/case"
+targets = ["*"]
 
-[deps.mach-std]
+[dep.mach-std]
 git = "https://github.com/briar-systems/mach-std"
 ref = "branch/main"

--- a/int/surface/pe-import-attribution/mach.toml
+++ b/int/surface/pe-import-attribution/mach.toml
@@ -1,16 +1,15 @@
 [project]
-id      = "case"
-name    = "case"
+id = "case"
+name = "case"
+description = "integration test fixture"
 version = "0.0.0"
-src     = "src"
-target  = "windows"
-out     = "out/{target}/{profile}/bin/{name}{ext}"
+src = "src"
+out = "out/{target.name}/{profile.name}"
 
 [target.windows]
 isa = "x86_64"
 os  = "windows"
 abi = "win64"
-ext = ".exe"
 
 [profile.debug]
 opt = 0
@@ -18,8 +17,14 @@ opt = 0
 [profile.release]
 opt = 2
 
-[os.windows]
-libs = ["kernel32.dll"]
-
-[bin.case]
+[artifact.case]
+kind = "bin"
 entry = "main.mach"
+out = "bin/case"
+targets = ["*"]
+link = ["kernel32"]
+
+[link.kernel32]
+source = "system"
+name = "kernel32.dll"
+os = ["windows"]

--- a/int/surface/pie-reloc/mach.toml
+++ b/int/surface/pie-reloc/mach.toml
@@ -1,11 +1,10 @@
 [project]
-id      = "case"
-name    = "case"
+id = "case"
+name = "case"
+description = "integration test fixture"
 version = "0.0.0"
-src     = "src"
-dep     = "dep"
-target  = "linux"
-out     = "out/{target}/{profile}/bin/{name}{ext}"
+src = "src"
+out = "out/{target.name}/{profile.name}"
 
 [target.linux]
 isa = "x86_64"
@@ -28,9 +27,12 @@ opt = 0
 [profile.release]
 opt = 2
 
-[bin.case]
+[artifact.case]
+kind = "bin"
 entry = "main.mach"
+out = "bin/case"
+targets = ["*"]
 
-[deps.mach-std]
+[dep.mach-std]
 git = "https://github.com/briar-systems/mach-std"
 ref = "branch/main"

--- a/int/surface/pie-relro-fault/mach.toml
+++ b/int/surface/pie-relro-fault/mach.toml
@@ -1,11 +1,10 @@
 [project]
-id      = "case"
-name    = "case"
+id = "case"
+name = "case"
+description = "integration test fixture"
 version = "0.0.0"
-src     = "src"
-dep     = "dep"
-target  = "linux"
-out     = "out/{target}/{profile}/bin/{name}{ext}"
+src = "src"
+out = "out/{target.name}/{profile.name}"
 
 [target.linux]
 isa = "x86_64"
@@ -28,9 +27,12 @@ opt = 0
 [profile.release]
 opt = 2
 
-[bin.case]
+[artifact.case]
+kind = "bin"
 entry = "main.mach"
+out = "bin/case"
+targets = ["*"]
 
-[deps.mach-std]
+[dep.mach-std]
 git = "https://github.com/briar-systems/mach-std"
 ref = "branch/main"

--- a/int/surface/sign-extension/mach.toml
+++ b/int/surface/sign-extension/mach.toml
@@ -1,11 +1,10 @@
 [project]
-id      = "case"
-name    = "case"
+id = "case"
+name = "case"
+description = "integration test fixture"
 version = "0.0.0"
-src     = "src"
-dep     = "dep"
-target  = "linux"
-out     = "out/{target}/{profile}/bin/{name}{ext}"
+src = "src"
+out = "out/{target.name}/{profile.name}"
 
 [target.linux]
 isa = "x86_64"
@@ -26,7 +25,6 @@ abi = "lp64"
 isa = "x86_64"
 os  = "windows"
 abi = "win64"
-ext = ".exe"
 
 [target.darwin-x86_64]
 isa = "x86_64"
@@ -44,9 +42,12 @@ opt = 0
 [profile.release]
 opt = 2
 
-[bin.case]
+[artifact.case]
+kind = "bin"
 entry = "main.mach"
+out = "bin/case"
+targets = ["*"]
 
-[deps.mach-std]
+[dep.mach-std]
 git = "https://github.com/briar-systems/mach-std"
 ref = "branch/main"

--- a/int/surface/syscall-inline-asm/mach.toml
+++ b/int/surface/syscall-inline-asm/mach.toml
@@ -1,11 +1,10 @@
 [project]
-id      = "case"
-name    = "case"
+id = "case"
+name = "case"
+description = "integration test fixture"
 version = "0.0.0"
-src     = "src"
-dep     = "dep"
-target  = "linux"
-out     = "out/{target}/{profile}/bin/{name}{ext}"
+src = "src"
+out = "out/{target.name}/{profile.name}"
 
 [target.linux]
 isa = "x86_64"
@@ -26,7 +25,6 @@ abi = "lp64"
 isa = "x86_64"
 os  = "windows"
 abi = "win64"
-ext = ".exe"
 
 [target.darwin-x86_64]
 isa = "x86_64"
@@ -44,9 +42,12 @@ opt = 0
 [profile.release]
 opt = 2
 
-[bin.case]
+[artifact.case]
+kind = "bin"
 entry = "main.mach"
+out = "bin/case"
+targets = ["*"]
 
-[deps.mach-std]
+[dep.mach-std]
 git = "https://github.com/briar-systems/mach-std"
 ref = "branch/main"


### PR DESCRIPTION
Closes #1976.

Every tracked fixture manifest under `int/` (22) and `dbg/fixtures/` (5) was still V1 (`[project].dep`/`target`, `[bin.X]`, `[deps.X]`), which the shipped V2 parser rejects at manifest parse — so the integration matrix and the debug-info fixture builds have been red since v3.0.0.

## What changed
Pure schema migration of the manifests only — no harness scripts, case sources, goldens, or `case.conf` files touched. Each manifest now uses the current parser's schema:
- `[project]` `id`/`name`/`description`/`version`/`src`/`out` (dropped `dep`/`target`; `out` is `out/{target.name}/{profile.name}`)
- `[target.X]` `isa`/`os`/`abi` (dropped windows `ext`)
- `[profile.X]`
- `[artifact.X]` `kind`/`entry`/`out`/`targets` (replacing `[bin.X]`)
- `[dep.X]` (replacing `[deps.X]`)

Every target name (`linux`, `linux-arm64`, `linux-riscv64`, `windows`, `darwin-*`, `freestanding-*`) is preserved, and each case keeps its single artifact, so the harness `-o` build and the goldens are unchanged.

The one non-mechanical case, `pe-import-attribution`, carried a V1 `[os.windows] libs = ["kernel32.dll"]`; it becomes a `[link.kernel32]` `source = "system"` entry (os-filtered to windows) referenced from the artifact's `link` list, so the `build-fails` golden's `candidate libraries: kernel32.dll` still resolves.

Note: the issue described `dbg/fixtures/promote` as already-V2; on `dev` it was in fact still V1, so all five dbg manifests were migrated.

## Verification
- `int/run.sh --target linux` — green (was 42 case×profile failures, all manifest-parse)
- `dbg/verify.sh` ELF legs — green
- unit suite via the from-source compiler — 533 passing
