### PR TITLE
feat(driver): hard-error on conflicting transitive dep ids (#1968)

### DIFF
--- a/src/lang/driver.mach
+++ b/src/lang/driver.mach
@@ -1969,8 +1969,78 @@ fun intern_opt_unwrap(itn: *intern.Interner, text: str) intern.StrId {
     ret intern_unwrap(itn, text);
 }
 
+# the provenance of one registered dep, tracked parallel to the resolved DepEntry array
+# so a project-id collision in the closure can name the conflicting sources, refs, and
+# requirer chains rather than silently deduping the loser (#1968).
+# ---
+# source: interned source label ("git <url>" / "path <path>") the requirer declared
+# ref:    interned declared ref, STR_NIL when omitted
+# chain:  interned requirer chain ("<root> -> a -> b") ending at this dep's alias
+rec DepProvenance {
+    source: intern.StrId;
+    ref:    intern.StrId;
+    chain:  intern.StrId;
+}
+
+# a re-encountered project id unifies with its prior registration only when both the
+# declared source and ref match exactly; any difference is a hard conflict. the model
+# is exact-ref with no version reconciliation (#1964), so the two legitimate diamonds
+# (same git url+ref, same path) unify and everything else is reported.
+fun dep_id_conflicts(existing_source: intern.StrId, existing_ref: intern.StrId,
+                     new_source: intern.StrId, new_ref: intern.StrId) bool {
+    if (existing_source == new_source && existing_ref == new_ref) { ret false; }
+    ret true;
+}
+
+# the text of an interned id, or `default` when the id is STR_NIL or unrecorded.
+fun id_text_or(s: *session.Session, id: intern.StrId, default: str) str {
+    if (id == intern.STR_NIL) { ret default; }
+    val o: O.Option[str] = intern.lookup(?s.interner, id);
+    if (O.is_some[str](o)) { ret O.unwrap[str](o); }
+    ret default;
+}
+
+# a dep's declared source as an interned identity+display label: "git <url>" for a git
+# source, "path <path>" for a path source, else "<unknown source>". identity is a StrId
+# compare, so the scheme prefix keeps a git url and an identical path string distinct.
+fun dep_source_label(s: *session.Session, d: *manifest.DepDef) intern.StrId {
+    if (d.git != intern.STR_NIL) {
+        val u: O.Option[str] = intern.lookup(?s.interner, d.git);
+        if (O.is_some[str](u)) { ret intern_unwrap(?s.interner, diag_join3(s, "git ", O.unwrap[str](u), "", "git")); }
+    }
+    if (d.path != intern.STR_NIL) {
+        val pth: O.Option[str] = intern.lookup(?s.interner, d.path);
+        if (O.is_some[str](pth)) { ret intern_unwrap(?s.interner, diag_join3(s, "path ", O.unwrap[str](pth), "", "path")); }
+    }
+    ret intern_unwrap(?s.interner, "<unknown source>");
+}
+
+# one "<chain> pins <source>[ @ <ref>]" line of a conflict diagnostic.
+fun dep_conflict_edge(s: *session.Session, chain: str, source: str, ref: str) str {
+    val base: str = diag_join3(s, chain, " pins ", source, chain);
+    if (str_empty(ref)) { ret base; }
+    ret diag_join3(s, base, " @ ", ref, base);
+}
+
+# render the dependency-conflict diagnostic for one project id reached two incompatible
+# ways: names both full requirer chains and the source/ref each pins, so the fix (fork
+# or upstream) is actionable from the message alone (#1968).
+fun dep_conflict_msg(s: *session.Session, project_id: str,
+                     chain_a: str, source_a: str, ref_a: str,
+                     chain_b: str, source_b: str, ref_b: str) str {
+    val head: str = diag_join3(s, "dependency conflict: project id '", project_id,
+        "' is required from two incompatible sources:", "dependency conflict: incompatible sources for one project id");
+    val la: str = dep_conflict_edge(s, chain_a, source_a, ref_a);
+    val lb: str = dep_conflict_edge(s, chain_b, source_b, ref_b);
+    val p1: str = diag_join3(s, head, "\n    ", la, head);
+    val p2: str = diag_join3(s, p1, "\n    ", lb, p1);
+    ret diag_join3(s, p2, "\n    ",
+        "fork or upstream to reconcile; one project id must resolve to a single source and ref (no version remapping)", p2);
+}
+
 fun resolve_deps_recursive(p: *Project, current_root: str, dep_names: *manifest.DepDef, dep_name_count: u32,
-                           deps: *DepEntry, dep_count_ptr: *u32, max_deps: usize, dir_dep: str) R.Result[bool, str] {
+                           deps: *DepEntry, prov: *DepProvenance, dep_count_ptr: *u32, max_deps: usize,
+                           dir_dep: str, requirer_chain: str) R.Result[bool, str] {
     var i: u32 = 0;
     for (i < dep_name_count) {
         val alias_opt: O.Option[str] = intern.lookup(?p.s.interner, dep_names[i].name);
@@ -1981,10 +2051,26 @@ fun resolve_deps_recursive(p: *Project, current_root: str, dep_names: *manifest.
         if (R.is_err[DepEntry, str](rd)) { ret R.err[bool, str](R.unwrap_err[DepEntry, str](rd)); }
         val entry: DepEntry = R.unwrap_ok[DepEntry, str](rd);
 
+        # this dep's declared provenance: its source label, its ref, and the requirer
+        # chain reaching it, so a project-id collision names who required what from where.
+        val src_id: intern.StrId = dep_source_label(p.s, ?dep_names[i]);
+        val ref_id: intern.StrId = dep_names[i].ref;
+        val chain_here: str = diag_join3(p.s, requirer_chain, " -> ", alias, alias);
+
         var exists: bool = false;
         var j: u32 = 0;
         for (j < dep_count_ptr[0]) {
             if (deps[j].project_id == entry.project_id) {
+                if (dep_id_conflicts(prov[j].source, prov[j].ref, src_id, ref_id)) {
+                    val pid: str = id_text_or(p.s, entry.project_id, "?");
+                    ret R.err[bool, str](dep_conflict_msg(p.s, pid,
+                        id_text_or(p.s, prov[j].chain, requirer_chain),
+                        id_text_or(p.s, prov[j].source, "<unknown source>"),
+                        id_text_or(p.s, prov[j].ref, ""),
+                        chain_here,
+                        id_text_or(p.s, src_id, "<unknown source>"),
+                        id_text_or(p.s, ref_id, "")));
+                }
                 exists = true;
             }
             j = j + 1;
@@ -1996,6 +2082,9 @@ fun resolve_deps_recursive(p: *Project, current_root: str, dep_names: *manifest.
             }
             val idx: u32 = dep_count_ptr[0];
             deps[idx] = entry;
+            prov[idx].source = src_id;
+            prov[idx].ref    = ref_id;
+            prov[idx].chain  = intern_unwrap(?p.s.interner, chain_here);
             dep_count_ptr[0] = dep_count_ptr[0] + 1;
 
             val dep_root_opt: O.Option[str] = intern.lookup(?p.s.interner, entry.vendor_root);
@@ -2035,7 +2124,7 @@ fun resolve_deps_recursive(p: *Project, current_root: str, dep_names: *manifest.
                                         k = k + 1;
                                     }
                                     
-                                    val res_rec: R.Result[bool, str] = resolve_deps_recursive(p, current_root, sub_defs, sub_dep_count::u32, deps, dep_count_ptr, max_deps, dir_dep);
+                                    val res_rec: R.Result[bool, str] = resolve_deps_recursive(p, current_root, sub_defs, sub_dep_count::u32, deps, prov, dep_count_ptr, max_deps, dir_dep, chain_here);
                                     A.deallocate[manifest.DepDef](p.s.alloc, sub_defs, sub_dep_count);
                                     if (R.is_err[bool, str](res_rec)) { ret res_rec; }
                                 }
@@ -2063,14 +2152,30 @@ fun resolve_deps(p: *Project, m: *manifest.Manifest, project_root: str) R.Result
     val deps: *DepEntry = R.unwrap_ok[*DepEntry, str](r);
     var dep_count: u32 = 0;
 
+    # provenance runs parallel to `deps`; it is walk-local (only read to diagnose a
+    # collision) and freed as soon as the closure walk returns.
+    val pr: R.Result[*DepProvenance, str] = A.allocate[DepProvenance](p.s.alloc, max_deps);
+    if (R.is_err[*DepProvenance, str](pr)) {
+        A.deallocate[DepEntry](p.s.alloc, deps, max_deps);
+        ret R.err[bool, str](R.unwrap_err[*DepProvenance, str](pr));
+    }
+    val prov: *DepProvenance = R.unwrap_ok[*DepProvenance, str](pr);
+
     val dir_dep_opt: O.Option[str] = intern.lookup(?p.s.interner, p.config.dir_dep);
     if (O.is_none[str](dir_dep_opt)) {
         A.deallocate[DepEntry](p.s.alloc, deps, max_deps);
+        A.deallocate[DepProvenance](p.s.alloc, prov, max_deps);
         ret R.err[bool, str]("dep dir StrId not interned");
     }
     val dir_dep: str = O.unwrap[str](dir_dep_opt);
 
-    val res_rec: R.Result[bool, str] = resolve_deps_recursive(p, project_root, m.deps, m.dep_count, deps, ?dep_count, max_deps, dir_dep);
+    # the requirer chain roots at the project id (or "root" when unrecorded).
+    var root_name: str = "root";
+    val rn_o: O.Option[str] = intern.lookup(?p.s.interner, m.id);
+    if (O.is_some[str](rn_o) && !str_empty(O.unwrap[str](rn_o))) { root_name = O.unwrap[str](rn_o); }
+
+    val res_rec: R.Result[bool, str] = resolve_deps_recursive(p, project_root, m.deps, m.dep_count, deps, prov, ?dep_count, max_deps, dir_dep, root_name);
+    A.deallocate[DepProvenance](p.s.alloc, prov, max_deps);
     if (R.is_err[bool, str](res_rec)) {
         A.deallocate[DepEntry](p.s.alloc, deps, max_deps);
         ret res_rec;
@@ -5787,6 +5892,51 @@ fun ut_scaffold_m(alloc: *A.Allocator, manifest_text: str, names: *str, texts: *
     ret R.ok[str, str](root);
 }
 
+# scan `hay` for the substring `needle`; the dependency-conflict tests use it to
+# assert the diagnostic names each requirer chain.
+fun ut_str_contains(hay: str, needle: str) bool {
+    val hn: usize = str_len(hay);
+    val nn: usize = str_len(needle);
+    if (nn == 0) { ret true; }
+    if (nn > hn) { ret false; }
+    var i: usize = 0;
+    for (i + nn <= hn) {
+        var k: usize = 0;
+        for (k < nn && hay[i + k] == needle[k]) { k = k + 1; }
+        if (k == nn) { ret true; }
+        i = i + 1;
+    }
+    ret false;
+}
+
+# write a project node (mach.toml + src/<src_name>) at `dir`, materializing `dir` and
+# `dir/src`. the dependency-registration tests compose a closure from several of these.
+fun ut_write_node(alloc: *A.Allocator, dir: str, manifest_text: str, src_name: str, src_text: str) R.Result[bool, str] {
+    val d1: R.Result[bool, str] = filesystem.create_dir_all(alloc, dir, 493);
+    if (R.is_err[bool, str](d1)) { ret d1; }
+    val src_dir: str = ut_cc3(alloc, dir, "/", "src");
+    val d2: R.Result[bool, str] = filesystem.create_dir_all(alloc, src_dir, 493);
+    if (R.is_err[bool, str](d2)) { ret d2; }
+    val mf: str = ut_cc3(alloc, dir, "/", "mach.toml");
+    val w0: R.Result[bool, str] = filesystem.write_file(mf, manifest_text, str_len(manifest_text), 420);
+    if (R.is_err[bool, str](w0)) { ret w0; }
+    val sf: str = ut_cc3(alloc, src_dir, "/", src_name);
+    ret filesystem.write_file(sf, src_text, str_len(src_text), 420);
+}
+
+# a minimal static-lib dep manifest carrying project id `id`.
+fun ut_lib_manifest(alloc: *A.Allocator, id: str) str {
+    ret ut_cc3(alloc, "[project]\nid = \"", id,
+        "\"\nname = \"l\"\ndescription = \"d\"\nversion = \"0.0.0\"\nsrc = \"src\"\nout = \"out/{target.name}/{profile.name}\"\n\n[artifact.lib]\nkind = \"static\"\nentry = \"lib.mach\"\nout = \"lib/l\"\ntargets = [\"*\"]\n");
+}
+
+# a bin root manifest declaring the single path dep [dep.<alias>] at `path`.
+fun ut_dep_root_one(alloc: *A.Allocator, alias: str, path: str) str {
+    val head: str = "[project]\nid = \"app\"\nname = \"app\"\ndescription = \"d\"\nversion = \"0.0.0\"\nsrc = \"src\"\nout = \"out/{target.name}/{profile.name}\"\n\n[target.linux]\nisa = \"x86_64\"\nos = \"linux\"\nabi = \"sysv64\"\n\n[profile.debug]\nopt = 0\n\n[artifact.app]\nkind = \"bin\"\nentry = \"main.mach\"\nout = \"bin/app\"\ntargets = [\"*\"]\n\n[dep.";
+    val mid: str = ut_cc3(alloc, head, alias, "]\npath = \"");
+    ret ut_cc3(alloc, mid, path, "\"\n");
+}
+
 # scaffold the module set, build the multi-target union Project, remove
 # the temp tree, and return the Project. the session is the caller's to tear down
 fun ut_build(s: *session.Session, alloc: *A.Allocator, names: *str, texts: *str, n: u32) R.Result[Project, str] {
@@ -6537,6 +6687,132 @@ test "mach.lang.driver:resolve_artifact_path" {
 }
 
 # driver reload: a Session rebuilds after dnit_project, deduping changed sources by path (#1389)
+# a re-encountered project id unifies only when its declared source AND ref match; any
+# difference is a conflict. covers the legitimate diamond plus both conflict shapes: the
+# same source at a different ref, and a different source entirely (#1968).
+test "mach.lang.driver:dep_id_conflicts_unify_and_shapes" {
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    val sr: R.Result[session.Session, str] = session.init(?alloc);
+    if (R.is_err[session.Session, str](sr)) { ret 1; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](sr);
+
+    var bad: i32 = 0;
+    val g1:  intern.StrId = intern_unwrap(?s.interner, "git https://x/foo");
+    val g1b: intern.StrId = intern_unwrap(?s.interner, "git https://x/foo");
+    val g2:  intern.StrId = intern_unwrap(?s.interner, "git https://x/bar");
+    val v1:  intern.StrId = intern_unwrap(?s.interner, "v1");
+    val v2:  intern.StrId = intern_unwrap(?s.interner, "v2");
+
+    # same source, same ref -> unify.
+    if (dep_id_conflicts(g1, v1, g1b, v1))                         { bad = 1; }
+    # same source, both refs omitted -> unify.
+    if (dep_id_conflicts(g1, intern.STR_NIL, g1b, intern.STR_NIL)) { bad = 1; }
+    # same source, different ref -> conflict (two (source, ref) pairs for one id).
+    if (!dep_id_conflicts(g1, v1, g1b, v2))                        { bad = 1; }
+    # different source -> conflict (two projects claim one id).
+    if (!dep_id_conflicts(g1, v1, g2, v1))                         { bad = 1; }
+
+    session.dnit(?s);
+    ret bad;
+}
+
+# two path deps resolve to one project id from different sources: the closure walk must
+# hard-error and name both full requirer chains, not silently dedup the loser (#1968).
+test "mach.lang.driver:dep_closure_conflict_names_chains" {
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    val sr: R.Result[session.Session, str] = session.init(?alloc);
+    if (R.is_err[session.Session, str](sr)) { ret 1; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](sr);
+    val rr: R.Result[bool, str] = setup_registry(?s.registry);
+    if (R.is_err[bool, str](rr)) { session.dnit(?s); ret 1; }
+
+    var names: [1]str; names[0] = "main.mach";
+    var texts: [1]str; texts[0] = "fun main() i32 { ret 0; }\n";
+    val root_manifest: str = ut_cc3(?alloc, ut_dep_root_one(?alloc, "foo", "./vendor/foo"),
+        "\n[dep.bar]\npath = \"./vendor/bar\"\n", "");
+    val root_r: R.Result[str, str] = ut_scaffold_m(?alloc, root_manifest, ?names[0], ?texts[0], 1);
+    if (R.is_err[str, str](root_r)) { session.dnit(?s); ret 1; }
+    val root: str = R.unwrap_ok[str, str](root_r);
+
+    var bad: i32 = 0;
+    val lib: str = ut_lib_manifest(?alloc, "libx");
+    val libsrc: str = "pub fun v() i32 { ret 1; }\n";
+    val wf: R.Result[bool, str] = ut_write_node(?alloc, ut_cc3(?alloc, root, "/", "dep/foo"), lib, "lib.mach", libsrc);
+    val wb: R.Result[bool, str] = ut_write_node(?alloc, ut_cc3(?alloc, root, "/", "dep/bar"), lib, "lib.mach", libsrc);
+    if (R.is_err[bool, str](wf) || R.is_err[bool, str](wb)) { filesystem.remove_all(?alloc, root); session.dnit(?s); ret 1; }
+
+    val pr: R.Result[Project, str] = build_project_union(?s, root);
+    if (R.is_ok[Project, str](pr)) {
+        var p: Project = R.unwrap_ok[Project, str](pr);
+        dnit_project(?p);
+        bad = 1;
+    }
+    or {
+        val msg: str = R.unwrap_err[Project, str](pr);
+        if (!ut_str_contains(msg, "dependency conflict")) { bad = 1; }
+        if (!ut_str_contains(msg, "libx"))                { bad = 1; }
+        if (!ut_str_contains(msg, "app -> foo"))          { bad = 1; }
+        if (!ut_str_contains(msg, "app -> bar"))          { bad = 1; }
+    }
+
+    filesystem.remove_all(?alloc, root);
+    session.dnit(?s);
+    ret bad;
+}
+
+# a transitive path dep (root -> a -> b) registers into the flat id registry: both the
+# direct project and its own dep are present after the closure walk (#1968 subsumes #1927).
+test "mach.lang.driver:dep_closure_registers_transitive" {
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    val sr: R.Result[session.Session, str] = session.init(?alloc);
+    if (R.is_err[session.Session, str](sr)) { ret 1; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](sr);
+    val rr: R.Result[bool, str] = setup_registry(?s.registry);
+    if (R.is_err[bool, str](rr)) { session.dnit(?s); ret 1; }
+
+    var names: [1]str; names[0] = "main.mach";
+    var texts: [1]str; texts[0] = "fun main() i32 { ret 0; }\n";
+    val root_r: R.Result[str, str] = ut_scaffold_m(?alloc, ut_dep_root_one(?alloc, "a", "./vendor/a"), ?names[0], ?texts[0], 1);
+    if (R.is_err[str, str](root_r)) { session.dnit(?s); ret 1; }
+    val root: str = R.unwrap_ok[str, str](root_r);
+
+    var bad: i32 = 0;
+    # dep a is a lib that itself declares a transitive path dep b.
+    val a_manifest: str = ut_cc3(?alloc, ut_lib_manifest(?alloc, "alib"), "\n[dep.b]\npath = \"./vendor/b\"\n", "");
+    val libsrc: str = "pub fun v() i32 { ret 1; }\n";
+    val wa: R.Result[bool, str] = ut_write_node(?alloc, ut_cc3(?alloc, root, "/", "dep/a"), a_manifest, "lib.mach", libsrc);
+    val wb: R.Result[bool, str] = ut_write_node(?alloc, ut_cc3(?alloc, root, "/", "dep/b"), ut_lib_manifest(?alloc, "blib"), "lib.mach", libsrc);
+    if (R.is_err[bool, str](wa) || R.is_err[bool, str](wb)) { filesystem.remove_all(?alloc, root); session.dnit(?s); ret 1; }
+
+    val pr: R.Result[Project, str] = build_project_union(?s, root);
+    if (R.is_err[Project, str](pr)) { filesystem.remove_all(?alloc, root); session.dnit(?s); ret 1; }
+    var p: Project = R.unwrap_ok[Project, str](pr);
+
+    # both the direct dep (alib) and its transitive dep (blib) registered.
+    if (p.config.dep_count != 2) { bad = 1; }
+    or {
+        val a_id: intern.StrId = intern_unwrap(?s.interner, "alib");
+        val b_id: intern.StrId = intern_unwrap(?s.interner, "blib");
+        var saw_a: bool = false;
+        var saw_b: bool = false;
+        var i: u32 = 0;
+        for (i < p.config.dep_count) {
+            if (p.config.deps[i].project_id == a_id) { saw_a = true; }
+            if (p.config.deps[i].project_id == b_id) { saw_b = true; }
+            i = i + 1;
+        }
+        if (!saw_a || !saw_b) { bad = 1; }
+    }
+
+    dnit_project(?p);
+    filesystem.remove_all(?alloc, root);
+    session.dnit(?s);
+    ret bad;
+}
+
 test "mach.lang.driver:reload_rebuild_dedup_sources_by_path" {
     var alloc: A.Allocator;
     if (O.is_some[str](page.make(?alloc))) { ret 1; }


### PR DESCRIPTION
Closes #1968.

The transitive closure walk already registers every fetched dep's project id into the flat id registry (the shipped registration half, #1927 acceptance passing). What was missing is the **conflict half**: a project id re-encountered in the closure was silently deduped at the `project_id` check in `resolve_deps_recursive`, so one id reached from two incompatible sources or refs quietly resolved to whichever won the walk.

## What changed (driver.mach only)
- Track each registered dep's **provenance** — its declared source label (`git <url>` / `path <path>`), its ref, and the requirer chain reaching it — in a `DepProvenance` array threaded parallel to the resolved `DepEntry` array (walk-local; freed as soon as the walk returns).
- When a project id recurs with a **different (source, ref) pair**, fail with a diagnostic that names **both full requirer chains** and what each pins, e.g.:
  ```
  error: dependency conflict: project id 'libx' is required from two incompatible sources:
      app -> foo -> deep pins path ./v/deep
      app -> bar pins path ./v/bar
      fork or upstream to reconcile; one project id must resolve to a single source and ref (no version remapping)
  ```
- **Same (source, ref) still unifies** (the legitimate diamond). Exact-ref model, no version reconciliation or remap levers (#1964). The dedup/registration behavior is otherwise unchanged.

The two conflict shapes from the issue both flow through the same check: *same id from two (source, ref) pairs* (source or ref differs) and *two different projects claiming one id* (sources differ).

## Tests (3, all under `mach.lang.driver`)
- `dep_id_conflicts_unify_and_shapes` — the unify/conflict decision: same source+ref unifies; a different ref conflicts; a different source conflicts.
- `dep_closure_conflict_names_chains` — an on-disk two-path-dep closure resolving one id from two sources errors, and the diagnostic names both requirer chains.
- `dep_closure_registers_transitive` — an on-disk `root -> a -> b` closure registers both the direct and the transitive project (the registration acceptance).

## Verification
- Build from source: clean.
- Unit suite through the fresh compiler: 539 passing, 0 failing (base 536 + these 3).
- `int/run.sh --target linux`: 42/42.
- Self-host fixpoint + end-to-end conflict demo (scratch /tmp path-dep closure): in the PR thread.
