### PR TITLE
fix(dwarf): omit DW_AT_name for nameless aggregate DIEs (#1955)

### DIFF
--- a/src/lang/be/codegen/dwarf.mach
+++ b/src/lang/be/codegen/dwarf.mach
@@ -195,6 +195,19 @@ val ABBREV_SUBRANGE:    u8 = 0x16;
 val ABBREV_POINTER:     u8 = 0x17;
 val ABBREV_STRUCT_LEAF: u8 = 0x18;
 val ABBREV_UNION_LEAF:  u8 = 0x19;
+# name-less variants of the composite abbrevs (#1955): a generic instance or an
+# anonymous shape carries no source spelling, so its DIE omits DW_AT_name entirely
+# rather than pointing it at an empty string (DWARF 5 §2.13), the same leaf/kids
+# abbrev-split discipline as #1949
+val ABBREV_STRUCT_ANON:      u8 = 0x1a;
+val ABBREV_STRUCT_LEAF_ANON: u8 = 0x1b;
+val ABBREV_UNION_ANON:       u8 = 0x1c;
+val ABBREV_UNION_LEAF_ANON:  u8 = 0x1d;
+val ABBREV_MEMBER_ANON:      u8 = 0x1e;
+
+# name_off sentinel marking a composite / member with no source spelling, so the emitter
+# selects the *_ANON abbrev and omits DW_AT_name rather than emitting an empty strp (#1955)
+val NAME_OMIT: u32 = 0xFFFFFFFF;
 
 # DWARF 5 line-number program: standard opcodes, extended opcodes, and the tuned
 # special-opcode parameters this producer emits
@@ -1085,6 +1098,39 @@ fun build_abbrev(b: *enc.ByteBuf) {
     emit_attr(b, DW_AT_byte_size, DW_FORM_udata);
     uleb(b, 0); uleb(b, 0);
 
+    # the name-less struct / union / member variants (#1955): identical to the abbrevs
+    # above minus DW_AT_name, for a composite or member with no source spelling.
+    uleb(b, ABBREV_STRUCT_ANON::u64);
+    uleb(b, DW_TAG_structure_type::u64);
+    enc.emit_byte(b, DW_CHILDREN_yes);
+    emit_attr(b, DW_AT_byte_size, DW_FORM_udata);
+    uleb(b, 0); uleb(b, 0);
+
+    uleb(b, ABBREV_STRUCT_LEAF_ANON::u64);
+    uleb(b, DW_TAG_structure_type::u64);
+    enc.emit_byte(b, DW_CHILDREN_no);
+    emit_attr(b, DW_AT_byte_size, DW_FORM_udata);
+    uleb(b, 0); uleb(b, 0);
+
+    uleb(b, ABBREV_UNION_ANON::u64);
+    uleb(b, DW_TAG_union_type::u64);
+    enc.emit_byte(b, DW_CHILDREN_yes);
+    emit_attr(b, DW_AT_byte_size, DW_FORM_udata);
+    uleb(b, 0); uleb(b, 0);
+
+    uleb(b, ABBREV_UNION_LEAF_ANON::u64);
+    uleb(b, DW_TAG_union_type::u64);
+    enc.emit_byte(b, DW_CHILDREN_no);
+    emit_attr(b, DW_AT_byte_size, DW_FORM_udata);
+    uleb(b, 0); uleb(b, 0);
+
+    uleb(b, ABBREV_MEMBER_ANON::u64);
+    uleb(b, DW_TAG_member::u64);
+    enc.emit_byte(b, DW_CHILDREN_no);
+    emit_attr(b, DW_AT_type,                 DW_FORM_ref4);
+    emit_attr(b, DW_AT_data_member_location, DW_FORM_udata);
+    uleb(b, 0); uleb(b, 0);
+
     uleb(b, 0);   # null abbrev code terminates the table
 }
 
@@ -1311,23 +1357,35 @@ fun emit_type_dies(b: *enc.ByteBuf, tc: *TypeCtx, len_pos: usize, relocs: *InfoR
         }
         or {
             # a memberless aggregate uses the DW_CHILDREN_no leaf abbrev (and no
-            # terminator), so it never advertises children it lacks (#1949).
+            # terminator), so it never advertises children it lacks (#1949); a shape with
+            # no source spelling uses the *_ANON abbrev and omits DW_AT_name (#1955).
             val kids: bool = td.memb_count > 0;
+            val anon: bool = td.name_off == NAME_OMIT;
+            var ab: u8 = ABBREV_STRUCT;
             if (td.kind == TK_UNION) {
-                if (kids) { enc.emit_byte(b, ABBREV_UNION); } or { enc.emit_byte(b, ABBREV_UNION_LEAF); }
+                if (kids) { ab = ABBREV_UNION;      if (anon) { ab = ABBREV_UNION_ANON; } }
+                or        { ab = ABBREV_UNION_LEAF; if (anon) { ab = ABBREV_UNION_LEAF_ANON; } }
             } or {
-                if (kids) { enc.emit_byte(b, ABBREV_STRUCT); } or { enc.emit_byte(b, ABBREV_STRUCT_LEAF); }
+                if (kids) { ab = ABBREV_STRUCT;      if (anon) { ab = ABBREV_STRUCT_ANON; } }
+                or        { ab = ABBREV_STRUCT_LEAF; if (anon) { ab = ABBREV_STRUCT_LEAF_ANON; } }
             }
-            push_info_reloc(relocs, reloc_count, b.len::u32, of.RK_ABS32, IRLT_STR, intern.STR_NIL, td.name_off::i64);
-            enc.emit_u32(b, 0);                 # DW_AT_name (strp)
+            enc.emit_byte(b, ab);
+            if (!anon) {
+                push_info_reloc(relocs, reloc_count, b.len::u32, of.RK_ABS32, IRLT_STR, intern.STR_NIL, td.name_off::i64);
+                enc.emit_u32(b, 0);             # DW_AT_name (strp)
+            }
             uleb(b, td.byte_size::u64);         # DW_AT_byte_size
             var m: u32 = td.memb_start;
             val mend: u32 = td.memb_start + td.memb_count;
             for (m < mend) {
                 val mb: *TypeMember = ?tc.membs[m];
-                enc.emit_byte(b, ABBREV_MEMBER);
-                push_info_reloc(relocs, reloc_count, b.len::u32, of.RK_ABS32, IRLT_STR, intern.STR_NIL, mb.name_off::i64);
-                enc.emit_u32(b, 0);             # DW_AT_name (strp)
+                if (mb.name_off == NAME_OMIT) {
+                    enc.emit_byte(b, ABBREV_MEMBER_ANON);
+                } or {
+                    enc.emit_byte(b, ABBREV_MEMBER);
+                    push_info_reloc(relocs, reloc_count, b.len::u32, of.RK_ABS32, IRLT_STR, intern.STR_NIL, mb.name_off::i64);
+                    enc.emit_u32(b, 0);         # DW_AT_name (strp)
+                }
                 push_type_fixup(fixups, nfix, b.len::u32, mb.type_ix);
                 enc.emit_u32(b, 0);             # DW_AT_type (ref4, patched)
                 uleb(b, mb.offset::u64);        # DW_AT_data_member_location
@@ -2981,8 +3039,11 @@ fun struct_intern(s: *session.Session, tgt: *target.Target, irmod: *ir.Module, t
 
     var tk: u8 = TK_STRUCT;
     if (t.kind == semtype.TYPE_UNI) { tk = TK_UNION; }
-    # resolve the name string before any further interning (comp_name reads `t`).
-    val name_off: u32 = str_off(strtab, comp_name(s, t));
+    # resolve the name string before any further interning (comp_name reads `t`); an
+    # anonymous shape (empty spelling) is marked NAME_OMIT so its DIE drops DW_AT_name (#1955).
+    val cnm: str = comp_name(s, t);
+    var name_off: u32 = NAME_OMIT;
+    if (str_len(cnm) > 0) { name_off = str_off(strtab, cnm); }
     val bsize: u32 = ir_type.byte_size(?irmod.types, ir_ty, tgt);
 
     val ix: i32 = comp_reserve(tc, tk, sem);
@@ -3019,7 +3080,13 @@ fun struct_intern(s: *session.Session, tgt: *target.Target, irmod: *ir.Module, t
         val fty: i32 = type_intern(s, tgt, irmod, tc, strtab, f_ty, address_size);
         if (fty < 0) { j = j + 1; cnt; }
         if (!memb_reserve(tc)) { j = j + 1; cnt; }
-        tc.membs[tc.nmemb].name_off = str_off(strtab, resolve(?s.interner, f_name));
+        # an anonymous field (name == STR_NIL, or an empty spelling) drops DW_AT_name (#1955).
+        var mno: u32 = NAME_OMIT;
+        if (f_name != intern.STR_NIL) {
+            val mnm: str = resolve(?s.interner, f_name);
+            if (str_len(mnm) > 0) { mno = str_off(strtab, mnm); }
+        }
+        tc.membs[tc.nmemb].name_off = mno;
         tc.membs[tc.nmemb].type_ix  = fty::u32;
         tc.membs[tc.nmemb].offset   = ir_type.byte_offset(?irmod.types, ir_ty, j, tgt);
         tc.nmemb = tc.nmemb + 1;
@@ -3285,7 +3352,7 @@ test "mach.lang.be.codegen.dwarf.build_abbrev:golden" {
     page.make(?alloc);
     var b: enc.ByteBuf = enc.buf_init(?alloc);
     build_abbrev(?b);
-    var e: [308]u8;
+    var e: [345]u8;
     e[0]=0x01; e[1]=0x11; e[2]=0x01; e[3]=0x25; e[4]=0x08; e[5]=0x03; e[6]=0x08; e[7]=0x1B;
     e[8]=0x08; e[9]=0x13; e[10]=0x05; e[11]=0x11; e[12]=0x01; e[13]=0x12; e[14]=0x07; e[15]=0x10;
     e[16]=0x17; e[17]=0x00; e[18]=0x00; e[19]=0x02; e[20]=0x24; e[21]=0x00; e[22]=0x03; e[23]=0x0E;
@@ -3347,8 +3414,18 @@ test "mach.lang.be.codegen.dwarf.build_abbrev:golden" {
     e[289]=0x18; e[290]=0x13; e[291]=0x00; e[292]=0x03; e[293]=0x0E; e[294]=0x0B; e[295]=0x0F; e[296]=0x00; e[297]=0x00;
     # ABBREV_UNION_LEAF (0x19): DW_TAG_union_type, no children, name strp, byte_size udata.
     e[298]=0x19; e[299]=0x17; e[300]=0x00; e[301]=0x03; e[302]=0x0E; e[303]=0x0B; e[304]=0x0F; e[305]=0x00; e[306]=0x00;
-    e[307]=0x00;   # null abbrev code terminates the table
-    val ok: bool = buf_eq(?b, ?e[0], 308);
+    # ABBREV_STRUCT_ANON (0x1a): DW_TAG_structure_type, children, byte_size udata (no name).
+    e[307]=0x1a; e[308]=0x13; e[309]=0x01; e[310]=0x0B; e[311]=0x0F; e[312]=0x00; e[313]=0x00;
+    # ABBREV_STRUCT_LEAF_ANON (0x1b): DW_TAG_structure_type, no children, byte_size udata.
+    e[314]=0x1b; e[315]=0x13; e[316]=0x00; e[317]=0x0B; e[318]=0x0F; e[319]=0x00; e[320]=0x00;
+    # ABBREV_UNION_ANON (0x1c): DW_TAG_union_type, children, byte_size udata.
+    e[321]=0x1c; e[322]=0x17; e[323]=0x01; e[324]=0x0B; e[325]=0x0F; e[326]=0x00; e[327]=0x00;
+    # ABBREV_UNION_LEAF_ANON (0x1d): DW_TAG_union_type, no children, byte_size udata.
+    e[328]=0x1d; e[329]=0x17; e[330]=0x00; e[331]=0x0B; e[332]=0x0F; e[333]=0x00; e[334]=0x00;
+    # ABBREV_MEMBER_ANON (0x1e): DW_TAG_member, no children, type ref4, data_member_location udata.
+    e[335]=0x1e; e[336]=0x0D; e[337]=0x00; e[338]=0x49; e[339]=0x13; e[340]=0x38; e[341]=0x0F; e[342]=0x00; e[343]=0x00;
+    e[344]=0x00;   # null abbrev code terminates the table
+    val ok: bool = buf_eq(?b, ?e[0], 345);
     enc.buf_dnit(?b);
     if (!ok) { ret 1; }
     ret 0;
@@ -3400,6 +3477,48 @@ test "mach.lang.be.codegen.dwarf.emit_type_dies:composite_refs" {
     if (b.data[td[4].off::usize] != ABBREV_STRUCT_LEAF) { code = 1; }
     # the pointer references the struct, the array references the base.
     if (td[2].elem != 1 || td[3].elem != 0) { code = 1; }
+
+    enc.buf_dnit(?b);
+    ret code;
+}
+
+# an aggregate with no source spelling (name_off == NAME_OMIT) emits the name-less
+# composite abbrev and no DW_AT_name strp, per member as well as the type itself (#1955);
+# a named member in the same aggregate keeps its name.
+test "mach.lang.be.codegen.dwarf.emit_type_dies:anonymous_omits_name" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+    var code: i32 = 0;
+
+    # types: [0] base i32, [1] an anonymous struct with an anonymous and a named member.
+    var td: [2]TypeDie;
+    td[0].kind=TK_BASE;   td[0].off=0; td[0].sem=semtype.TYPE_NIL; td[0].name="i32"; td[0].name_off=1; td[0].encoding=DW_ATE_signed; td[0].byte_size=4; td[0].elem=-1; td[0].count=0; td[0].memb_start=0; td[0].memb_count=0;
+    td[1].kind=TK_STRUCT; td[1].off=0; td[1].sem=100; td[1].name=""; td[1].name_off=NAME_OMIT; td[1].encoding=0; td[1].byte_size=8; td[1].elem=-1; td[1].count=0; td[1].memb_start=0; td[1].memb_count=2;
+
+    var mb: [2]TypeMember;
+    mb[0].name_off=NAME_OMIT; mb[0].type_ix=0; mb[0].offset=0;
+    mb[1].name_off=20;        mb[1].type_ix=0; mb[1].offset=4;
+
+    var tc: TypeCtx;
+    tc.alloc=?alloc; tc.types=?td[0]; tc.ntypes=2; tc.type_cap=2; tc.membs=?mb[0]; tc.nmemb=2; tc.memb_cap=2;
+
+    var relocs: [16]InfoReloc;
+    var rc: u32 = 0;
+    var fixups: [8]TypeFixup;
+    var nfix: u32 = 0;
+    var b: enc.ByteBuf = enc.buf_init(?alloc);
+    emit_type_dies(?b, ?tc, 0, ?relocs[0], ?rc, ?fixups[0], ?nfix);
+
+    # the anonymous struct opens with the name-less abbrev, not ABBREV_STRUCT.
+    if (b.data[td[1].off::usize] != ABBREV_STRUCT_ANON) { code = 1; }
+    # byte_size (0x08) is one uleb byte, so the first member DIE follows at off+2; the
+    # anonymous member uses the name-less member abbrev.
+    if (b.data[(td[1].off + 2)::usize] != ABBREV_MEMBER_ANON) { code = 1; }
+    # exactly two DW_AT_name strps are relocated: the base type and the one named member.
+    # the anonymous struct and the anonymous member contribute none (pre-fix: four).
+    if (rc != 2) { code = 1; }
+    # two DW_AT_type ref4 fixups: one per member.
+    if (nfix != 2) { code = 1; }
 
     enc.buf_dnit(?b);
     ret code;


### PR DESCRIPTION
Closes #1955. Split out of the #1919 adversarial review (finding 6/7).

## Problem
A composite whose `comp_name` yields no source spelling — a generic instance (`TYPE_INSTANCE`, e.g. `List[i32]`) or an anonymous field (`FieldEntry.name == STR_NIL`) — emitted its `DW_TAG_structure_type` / `_union_type` / `_member` with `DW_AT_name = ""` (a strp to an empty string) rather than omitting the attribute. DWARF 5 §2.13 says an anonymous type omits `DW_AT_name`.

## Fix (dwarf.mach only)
Following the #1949 leaf/kids abbrev-split precedent, add five name-less variants of the name-bearing composite abbrevs — `ABBREV_STRUCT_ANON`, `STRUCT_LEAF_ANON`, `UNION_ANON`, `UNION_LEAF_ANON`, `MEMBER_ANON` (codes 0x1a–0x1e). A composite/member whose spelling is empty is marked `NAME_OMIT` at intern time; the emitter selects the `*_ANON` abbrev and skips the `DW_AT_name` strp. Named types are byte-identical (same abbrev, same name reloc).

## Falsifiable evidence (llvm-dwarfdump on a generic-instance fixture)
A fixture with a generic `Pair[i32]` local (anonymous) alongside a nominal `Point`:

| | empty `DW_AT_name ("")` attrs | `Point` name | `--verify` |
|---|---|---|---|
| pre-fix (3.2.0 seed) | **75** | `("Point")` | OK |
| post-fix | **0** | `("Point")` | OK |

Pre-fix each anonymous `DW_TAG_structure_type` shows `DW_AT_name ("")`; post-fix the attribute is absent, and named types keep their names.

## Tests
- `emit_type_dies:anonymous_omits_name` (new): a `NAME_OMIT` struct with an anonymous and a named member opens with `ABBREV_STRUCT_ANON`, its anonymous member with `ABBREV_MEMBER_ANON`, and exactly two name strps are relocated (base + named member; pre-fix: four).
- `build_abbrev:golden` updated for the five new abbrevs.

## Verification
- unit suite through the fresh compiler: 570 (569 baseline + 1)
- `--verify` clean; dbg lane (debug + release) + additivity; self-host fixpoint; `int/run.sh --target linux` 42/42 — in the PR thread.
