### PR TITLE
fix(dwarf): locate register-passed by-value aggregate parameters (#1954)

### DIFF
--- a/src/lang/be/codegen/dwarf.mach
+++ b/src/lang/be/codegen/dwarf.mach
@@ -364,6 +364,10 @@ rec DwVar {
     range_count: u32;
     loclist_off: u32;
     byref:       bool;
+    # true when a byref aggregate's frame home addresses its storage directly (a
+    # register-passed param reconstructed into a slot it owns, #1954), so the location
+    # omits the pointer deref; false when the frame slot holds the storage pointer
+    storage:     bool;
     # the inline instance this variable belongs to (0 = the function's own body, else a
     # 1-based inline-site id); the #1707 producer nests a non-zero one under its instance
     inline_site: u32;
@@ -382,12 +386,13 @@ rec DwVar {
 # off:       frame-base offset when kind == VLOC_FRAME
 # net:       salvage net constant (0 = identity)
 rec LocRange {
-    start: u32;
-    end:   u32;
-    kind:  u8;
-    reg:   i32;
-    off:   i64;
-    net:   i64;
+    start:   u32;
+    end:     u32;
+    kind:    u8;
+    reg:     i32;
+    off:     i64;
+    net:     i64;
+    storage: bool;
 }
 
 # one inlined-subroutine instance, emitted as a DW_TAG_inlined_subroutine nested under
@@ -1608,17 +1613,19 @@ fun emit_frame_base(b: *enc.ByteBuf, fb_reg: i32) {
 # tgt:      resolved target, for the ISA dwarf_reg hook
 # vl:       the variable-location record
 # out_kind/out_reg/out_off: the resolved DWARF location
-fun varloc_home(tgt: *target.Target, vl: *enc.VarLoc, out_kind: *u8, out_reg: *i32, out_off: *i64) {
-    @out_kind = VLOC_NONE;
-    @out_reg  = 0;
-    @out_off  = 0;
+fun varloc_home(tgt: *target.Target, vl: *enc.VarLoc, out_kind: *u8, out_reg: *i32, out_off: *i64, out_storage: *bool) {
+    @out_kind    = VLOC_NONE;
+    @out_reg     = 0;
+    @out_off     = 0;
+    @out_storage = false;
     if (vl.kind == enc.VARLOC_REG) {
         val f: isa.DwarfRegFn = tgt.arch.dwarf_reg::isa.DwarfRegFn;
         val d: i32 = f(vl.reg);
         if (d >= 0) { @out_kind = VLOC_REG; @out_reg = d; }
     } or (vl.kind == enc.VARLOC_FRAME) {
-        @out_kind = VLOC_FRAME;
-        @out_off  = vl.off;
+        @out_kind    = VLOC_FRAME;
+        @out_off     = vl.off;
+        @out_storage = vl.off_storage;
     }
 }
 
@@ -1671,8 +1678,9 @@ fun type_is_aggregate(tc: *TypeCtx, ty: i32) bool {
 # reg:   DWARF register number when kind == VLOC_REG
 # off:   frame-base offset when kind == VLOC_FRAME; the constant value when VLOC_CONST
 # net:   the salvage net constant (0 = identity)
-# byref: true for a by-reference aggregate located from a frame slot holding its address
-fun build_loc_ops(e: *enc.ByteBuf, kind: u8, reg: i32, off: i64, net: i64, byref: bool) {
+# byref: true for a by-reference aggregate located from a frame slot; storage true when
+#        that slot IS the aggregate's bytes (deref omitted), false when it holds the pointer
+fun build_loc_ops(e: *enc.ByteBuf, kind: u8, reg: i32, off: i64, net: i64, byref: bool, storage: bool) {
     if (kind == VLOC_CONST) {
         # the variable IS the compile-time constant `off + net`; push it and mark the
         # result a value, not a location. the DIE's DW_AT_type sizes / signs it, so the
@@ -1683,11 +1691,12 @@ fun build_loc_ops(e: *enc.ByteBuf, kind: u8, reg: i32, off: i64, net: i64, byref
         ret;
     }
     if (byref) {
-        # a frame slot holds the storage pointer: load it, add any salvage offset (an
-        # aggregate address recovered as base + k), and leave the address on the stack.
+        # the location leaves the aggregate's storage address on the stack. a direct storage
+        # slot (a register-passed param reconstructed into it, #1954) IS the bytes, so its
+        # address is DW_OP_fbreg alone; a slot holding the storage POINTER loads it (deref).
         enc.emit_byte(e, DW_OP_fbreg);
         sleb(e, off);
-        enc.emit_byte(e, DW_OP_deref);
+        if (!storage) { enc.emit_byte(e, DW_OP_deref); }
         if (net != 0) { emit_net_const(e, net); }
         ret;
     }
@@ -1717,9 +1726,10 @@ fun build_loc_ops(e: *enc.ByteBuf, kind: u8, reg: i32, off: i64, net: i64, byref
 # b:    the destination buffer
 # kind/reg/off/net: the home the expression describes
 # byref: true for a by-reference aggregate whose home addresses its storage
-fun emit_counted_loc(b: *enc.ByteBuf, kind: u8, reg: i32, off: i64, net: i64, byref: bool) {
+# storage: true when a byref frame slot IS the aggregate's bytes (deref omitted)
+fun emit_counted_loc(b: *enc.ByteBuf, kind: u8, reg: i32, off: i64, net: i64, byref: bool, storage: bool) {
     var e: enc.ByteBuf = enc.buf_init(b.alloc);
-    build_loc_ops(?e, kind, reg, off, net, byref);
+    build_loc_ops(?e, kind, reg, off, net, byref, storage);
     uleb(b, e.len::u64);
     var i: usize = 0;
     for (i < e.len) { enc.emit_byte(b, e.data[i]); i = i + 1; }
@@ -1731,7 +1741,7 @@ fun emit_counted_loc(b: *enc.ByteBuf, kind: u8, reg: i32, off: i64, net: i64, by
 # b: the info buffer
 # v: the variable whose location is emitted (loc_kind is VLOC_REG or VLOC_FRAME)
 fun emit_var_location(b: *enc.ByteBuf, v: *DwVar) {
-    emit_counted_loc(b, v.loc_kind, v.reg, v.offset, v.net, v.byref);
+    emit_counted_loc(b, v.loc_kind, v.reg, v.offset, v.net, v.byref, v.storage);
 }
 
 # build the DWARF 5 `.debug_loclists` section: the unit header (offset_entry_count 0,
@@ -1789,7 +1799,7 @@ fun build_loclists(b: *enc.ByteBuf, funcs: *DwFunc, nfuncs: u32, vars: *DwVar, r
                     enc.emit_byte(b, DW_LLE_offset_pair);
                     uleb(b, (rg.start - fn.offset)::u64);
                     uleb(b, (rg.end - fn.offset)::u64);
-                    emit_counted_loc(b, rg.kind, rg.reg, rg.off, rg.net, v.byref);
+                    emit_counted_loc(b, rg.kind, rg.reg, rg.off, rg.net, v.byref, rg.storage);
                 }
                 r = r + 1;
             }
@@ -2709,6 +2719,7 @@ fun gather_vars(s: *session.Session, tgt: *target.Target, irmod: *ir.Module, irf
             vars[@var_count].loclist_off = 0;
             vars[@var_count].inline_site = vsite;
             vars[@var_count].byref       = type_is_aggregate(tc, ty);
+            vars[@var_count].storage     = false;
             @var_count = @var_count + 1;
         }
         i = i + 1;
@@ -2732,7 +2743,8 @@ fun gather_vars(s: *session.Session, tgt: *target.Target, irmod: *ir.Module, irf
             var kind: u8 = VLOC_NONE;
             var reg:  i32 = 0;
             var off:  i64 = 0;
-            varloc_home(tgt, vl, ?kind, ?reg, ?off);
+            var storage: bool = false;
+            varloc_home(tgt, vl, ?kind, ?reg, ?off, ?storage);
             # a binding with no register/frame home may still be a compile-time constant
             # (a folded local): render it as a computed DW_OP_const value rather than
             # dropping the location. the constant lives in `off` for VLOC_CONST.
@@ -2740,12 +2752,13 @@ fun gather_vars(s: *session.Session, tgt: *target.Target, irmod: *ir.Module, irf
                 val oc: O.Option[i64] = ir.dbg_value_const(irfn, vl.iid::id.InstructionId);
                 if (O.is_some[i64](oc)) { kind = VLOC_CONST; off = O.unwrap[i64](oc); }
             }
-            ranges[@range_count].start = vl.text_offset;
-            ranges[@range_count].end   = hi;
-            ranges[@range_count].kind  = kind;
-            ranges[@range_count].reg   = reg;
-            ranges[@range_count].off   = off;
-            ranges[@range_count].net   = dbg_expr_net(irfn, vl.iid::id.InstructionId);
+            ranges[@range_count].start   = vl.text_offset;
+            ranges[@range_count].end     = hi;
+            ranges[@range_count].kind    = kind;
+            ranges[@range_count].reg     = reg;
+            ranges[@range_count].off     = off;
+            ranges[@range_count].net     = dbg_expr_net(irfn, vl.iid::id.InstructionId);
+            ranges[@range_count].storage = storage;
             @range_count = @range_count + 1;
             k = k + 1;
         }
@@ -2851,6 +2864,7 @@ fun classify_var(v: *DwVar, ranges: *LocRange) {
     v.reg         = ranges[first::u32].reg;
     v.offset      = ranges[first::u32].off;
     v.net         = ranges[first::u32].net;
+    v.storage     = ranges[first::u32].storage;
     v.range_count = 0;
 }
 
@@ -3634,7 +3648,7 @@ test "mach.lang.be.codegen.dwarf.emit_var_location:reg_frame_salvage" {
     # 0x78, DW_OP_deref (0x06) to load the storage pointer (address, no stack_value).
     # register-homed byref never reaches build_loc_ops (classify_var / build_loclists omit
     # it), so only the frame form is exercised.
-    var vm: DwVar; vm.loc_kind = VLOC_FRAME; vm.reg = 0; vm.offset = -8; vm.net = 0; vm.byref = true;
+    var vm: DwVar; vm.loc_kind = VLOC_FRAME; vm.reg = 0; vm.offset = -8; vm.net = 0; vm.byref = true; vm.storage = false;
     var k: enc.ByteBuf = enc.buf_init(?alloc);
     emit_var_location(?k, ?vm);
     var e6: [4]u8; e6[0] = 0x03; e6[1] = 0x91; e6[2] = 0x78; e6[3] = 0x06;
@@ -3643,12 +3657,22 @@ test "mach.lang.be.codegen.dwarf.emit_var_location:reg_frame_salvage" {
 
     # a by-reference aggregate at frame slot -8 salvaged onto base + 16: len 5, DW_OP_fbreg
     # (0x91), sleb(-8) = 0x78, DW_OP_deref (0x06), DW_OP_plus_uconst (0x23), uleb(16) = 0x10.
-    var vn: DwVar; vn.loc_kind = VLOC_FRAME; vn.reg = 0; vn.offset = -8; vn.net = 16; vn.byref = true;
+    var vn: DwVar; vn.loc_kind = VLOC_FRAME; vn.reg = 0; vn.offset = -8; vn.net = 16; vn.byref = true; vn.storage = false;
     var m: enc.ByteBuf = enc.buf_init(?alloc);
     emit_var_location(?m, ?vn);
     var e7: [6]u8; e7[0] = 0x05; e7[1] = 0x91; e7[2] = 0x78; e7[3] = 0x06; e7[4] = 0x23; e7[5] = 0x10;
     if (!buf_eq(?m, ?e7[0], 6)) { code = 1; }
     enc.buf_dnit(?m);
+
+    # a register-passed aggregate reconstructed into a frame slot it owns (#1954): storage
+    # true drops the DW_OP_deref, so the slot address IS the aggregate's bytes. len 2,
+    # DW_OP_fbreg (0x91), sleb(-8) = 0x78 - no deref (contrast vm above).
+    var vp: DwVar; vp.loc_kind = VLOC_FRAME; vp.reg = 0; vp.offset = -8; vp.net = 0; vp.byref = true; vp.storage = true;
+    var q: enc.ByteBuf = enc.buf_init(?alloc);
+    emit_var_location(?q, ?vp);
+    var e8: [3]u8; e8[0] = 0x02; e8[1] = 0x91; e8[2] = 0x78;
+    if (!buf_eq(?q, ?e8[0], 3)) { code = 1; }
+    enc.buf_dnit(?q);
     ret code;
 }
 

--- a/src/lang/be/codegen/encode.mach
+++ b/src/lang/be/codegen/encode.mach
@@ -130,6 +130,10 @@ pub rec InlinePc {
 # kind:        VARLOC_NONE / VARLOC_REG / VARLOC_FRAME
 # reg:         physical register id when kind == VARLOC_REG
 # off:         frame-base offset when kind == VARLOC_FRAME
+# off_storage: true when a VARLOC_FRAME slot holds the value's storage directly (a
+#              register-passed aggregate reconstructed into a slot it owns, #1954), so an
+#              aggregate location addresses the slot without the byref pointer deref; false
+#              for a regalloc spill, whose slot holds the value (a pointer, for an aggregate)
 pub rec VarLoc {
     text_offset: u32;
     sec:         u32;
@@ -137,6 +141,7 @@ pub rec VarLoc {
     kind:        u8;
     reg:         i32;
     off:         i64;
+    off_storage: bool;
 }
 
 # a variable-location record's home kind
@@ -746,6 +751,7 @@ pub fun push_varloc(st: *EncodeState, text_offset: u32, fn: *mir.MirFunction, vr
     var kind: u8  = VARLOC_NONE;
     var reg:  i32 = 0;
     var off:  i64 = 0;
+    var storage: bool = false;
     if (vreg != mir.MIR_VREG_NIL && vreg < fn.vreg_count) {
         val vr: *mir.MirVReg = ?fn.vregs[vreg];
         if (vr.assigned != mir.MIR_VREG_NIL) {
@@ -756,6 +762,19 @@ pub fun push_varloc(st: *EncodeState, text_offset: u32, fn: *mir.MirFunction, vr
             var si: u32 = 0;
             for (si < fn.frame.slot_count) {
                 if (fn.frame.slots[si].value == vreg) { kind = VARLOC_FRAME; off = fn.frame.slots[si].offset; }
+                si = si + 1;
+            }
+        }
+        or {
+            # a register-passed aggregate parameter is reconstructed into a mir.SLOT_SPILL
+            # slot it owns; regalloc excludes the slot-owner vreg, so it has no assigned
+            # register and no regalloc spill. the slot holds the aggregate's bytes, so the
+            # binding is a direct frame location addressing that storage (#1954).
+            var si: u32 = 0;
+            for (si < fn.frame.slot_count) {
+                if (fn.frame.slots[si].value == vreg && fn.frame.slots[si].kind == mir.SLOT_SPILL) {
+                    kind = VARLOC_FRAME; off = fn.frame.slots[si].offset; storage = true;
+                }
                 si = si + 1;
             }
         }
@@ -771,6 +790,7 @@ pub fun push_varloc(st: *EncodeState, text_offset: u32, fn: *mir.MirFunction, vr
     st.varlocs[st.varloc_count].kind        = kind;
     st.varlocs[st.varloc_count].reg         = reg;
     st.varlocs[st.varloc_count].off         = off;
+    st.varlocs[st.varloc_count].off_storage = storage;
     st.varloc_count = st.varloc_count + 1;
     ret R.ok[bool, str](true);
 }
@@ -1308,6 +1328,43 @@ test "mach.lang.be.codegen.encode.push_varloc:reg_frame_dead" {
     if (st.varlocs[0].kind != VARLOC_REG || st.varlocs[0].reg != 7 || st.varlocs[0].iid != 100) { code = 1; }
     if (st.varlocs[1].kind != VARLOC_FRAME || st.varlocs[1].off != -16 || st.varlocs[1].iid != 101) { code = 1; }
     if (st.varlocs[2].kind != VARLOC_NONE || st.varlocs[2].iid != 102) { code = 1; }
+
+    if (st.varlocs != nil && st.varloc_cap > 0) { A.deallocate[VarLoc](?alloc, st.varlocs, st.varloc_cap::usize); }
+    buf_dnit(?st.buf);
+    ret code;
+}
+
+# push_varloc resolves a register-passed aggregate parameter - a vreg with no assigned
+# register and no regalloc spill, but owning the mir.SLOT_SPILL slot its bytes are
+# reconstructed into - to a direct frame location (VARLOC_FRAME with off_storage set), so
+# the parameter is locatable rather than silently omitted (#1954)
+test "mach.lang.be.codegen.encode.push_varloc:slot_spill_owner_is_direct_frame" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+    var code: i32 = 0;
+
+    var st: EncodeState;
+    t_row_state(?alloc, ?st);
+
+    # vreg 0 owns a mir.SLOT_SPILL slot at -32 (its reconstructed aggregate bytes): no
+    # assigned register and no regalloc spill.
+    var vregs: [1]mir.MirVReg;
+    vregs[0].id = 0; vregs[0].class = 0; vregs[0].spill_slot = -1; vregs[0].assigned = mir.MIR_VREG_NIL;
+
+    var slots: [1]mir.MirSlot;
+    slots[0].value = 0; slots[0].kind = mir.SLOT_SPILL; slots[0].offset = -32; slots[0].size = 16; slots[0].align = 8;
+
+    var fn: mir.MirFunction;
+    fn.vregs = ?vregs[0]; fn.vreg_count = 1;
+    fn.frame.slots = ?slots[0]; fn.frame.slot_count = 1; fn.frame.slot_cap = 1;
+    fn.frame.size = 0; fn.frame.align = 0; fn.frame.outgoing_size = 0;
+
+    val r: R.Result[bool, str] = push_varloc(?st, 0, ?fn, 0, 200); if (R.is_err[bool, str](r)) { code = 1; }
+
+    if (st.varloc_count != 1) { code = 1; }
+    # a direct frame location at the slot offset, flagged storage so the producer omits the
+    # byref pointer deref.
+    if (st.varlocs[0].kind != VARLOC_FRAME || st.varlocs[0].off != -32 || !st.varlocs[0].off_storage) { code = 1; }
 
     if (st.varlocs != nil && st.varloc_cap > 0) { A.deallocate[VarLoc](?alloc, st.varlocs, st.varloc_cap::usize); }
     buf_dnit(?st.buf);


### PR DESCRIPTION
Closes #1954. Split out of the #1919 adversarial review (finding 5).

## Problem
A register-passed by-value aggregate parameter (e.g. a <=16-byte struct in RDI:RSI on sysv64) got a `DW_TAG_formal_parameter` with its composite `DW_AT_type` but **no `DW_AT_location`** — a debugger could not show the argument. The ABI reconstructs the parameter into a `mir.SLOT_SPILL` frame slot it owns, but regalloc excludes the slot-owner vreg (no assigned register, `spill_slot == -1`), so `encode.push_varloc` reported `VARLOC_NONE`.

## Fix (encode.mach + dwarf.mach)
- `push_varloc` now recognizes a vreg owning a `SLOT_SPILL` slot and reports a **direct frame location** (`VARLOC_FRAME`, new `off_storage` flag).
- Because that slot holds the aggregate's **bytes** (not a pointer to them, as a regalloc spill of a byref pointer would), the location is `DW_OP_fbreg <off>` **without** the byref `DW_OP_deref`. The `off_storage` flag threads through `varloc_home` → `LocRange` → `DwVar` → `build_loc_ops`. Regalloc-spilled byref pointers keep their `fbreg+deref`; named/scalar homes are byte-identical.

The honest-DWARF question (per the #1919 program rules): the reconstruction slot IS the storage, so a direct frame location is correct and cheap — no `DW_OP_piece` composition is needed (and none is emitted, since that path stays deferred).

## gdb money-proof
Fixture `fun take(pt: Point)` with `Point` a 16-byte struct:
- **pre-fix**: `pt` has no `DW_AT_location` (optimized-out).
- **post-fix**: `DW_AT_location (DW_OP_fbreg -24)`; `llvm-dwarfdump --verify` clean; at a post-prologue breakpoint gdb prints `pt = {x = 11, y = 31}` (transcript in thread).

## Tests
- `encode.push_varloc:slot_spill_owner_is_direct_frame` — the new branch reports `VARLOC_FRAME` + `off_storage`.
- `dwarf` location test extended: a `storage` byref frame home renders `DW_OP_fbreg` with no deref (contrast the pointer-spill case that keeps the deref).

## Verification
- unit suite: 571 (570 baseline + 1); dbg/verify.sh both profiles; self-additive both profiles; int linux 42/42; self-host fixpoint — in thread.

## Scoped out
gdb's default `break <fn>` prologue heuristic lands one instruction before the aggregate spill (mach emits no `prologue_end` for any function), so `print pt` there reads zeros; reading is correct at any post-prologue PC. That's a separate line-table gap — recommend a follow-up to emit `DW_LNS_set_prologue_end`.
