### PR TITLE
fix(dwarf): emit prologue_end so break <fn> clears parameter homing (#2007)

### DIFF
--- a/src/lang/be/codegen/dwarf.mach
+++ b/src/lang/be/codegen/dwarf.mach
@@ -211,10 +211,14 @@ val NAME_OMIT: u32 = 0xFFFFFFFF;
 
 # DWARF 5 line-number program: standard opcodes, extended opcodes, and the tuned
 # special-opcode parameters this producer emits
-val DW_LNS_copy:         u8 = 0x01;
-val DW_LNS_advance_pc:   u8 = 0x02;
-val DW_LNS_advance_line: u8 = 0x03;
-val DW_LNS_set_file:     u8 = 0x04;
+val DW_LNS_copy:          u8 = 0x01;
+val DW_LNS_advance_pc:    u8 = 0x02;
+val DW_LNS_advance_line:  u8 = 0x03;
+val DW_LNS_set_file:      u8 = 0x04;
+# marks a row as the first past the prologue (parameter homing / entry spills), so a
+# debugger's `break <fn>` stops where every parameter is live (#2007). declared in the
+# header's standard_opcode_lengths (opcode 10, zero args) already
+val DW_LNS_set_prologue_end: u8 = 0x0a;
 
 val DW_LNE_end_sequence: u8 = 0x01;
 val DW_LNE_set_address:  u8 = 0x02;
@@ -1994,6 +1998,7 @@ fun build_line(s: *session.Session, funcs: *DwFunc, nfuncs: u32, rows: *enc.Line
         var cur_off:  u32 = fn.offset;
         var cur_line: i32 = 1;
         var cur_file: i64 = -1;
+        var first_row: bool = true;
 
         var r: u32 = 0;
         for (r < row_count) {
@@ -2004,6 +2009,19 @@ fun build_line(s: *session.Session, funcs: *DwFunc, nfuncs: u32, rows: *enc.Line
                     enc.emit_byte(b, DW_LNS_set_file);
                     uleb(b, pl.file::u64);
                     cur_file = pl.file::i64;
+                }
+                if (first_row) {
+                    # the encoder emits no row over the prologue / parameter homing. anchor a
+                    # row at the function entry (low_pc) so a debugger's line-based prologue
+                    # skip engages, then flag the first post-homing instruction prologue_end so
+                    # `break <fn>` stops where every parameter is live (#2007). when the first
+                    # row already sits at low_pc there is no homing gap to span.
+                    if (row.text_offset > fn.offset) {
+                        emit_row(b, 0, pl.line - cur_line);
+                        cur_line = pl.line;
+                    }
+                    enc.emit_byte(b, DW_LNS_set_prologue_end);
+                    first_row = false;
                 }
                 val addr_delta: u32 = row.text_offset - cur_off;
                 emit_row(b, addr_delta, pl.line - cur_line);
@@ -3558,6 +3576,45 @@ test "mach.lang.be.codegen.dwarf.emit_row:special_and_fallback" {
     var e2: [3]u8; e2[0] = DW_LNS_advance_pc; e2[1] = 100; e2[2] = DW_LNS_copy;
     if (!buf_eq(?c, ?e2[0], 3)) { code = 1; }
     enc.buf_dnit(?c);
+    ret code;
+}
+
+# build_line anchors a row at the function's low_pc and flags the first post-prologue row
+# DW_LNS_set_prologue_end, so a debugger's `break <fn>` stops past parameter homing where
+# every parameter is live (#2007)
+test "mach.lang.be.codegen.dwarf.build_line:prologue_end_and_entry_row" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+    val sr: R.Result[session.Session, str] = session.init(?alloc);
+    if (R.is_err[session.Session, str](sr)) { ret 1; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](sr);
+    var code: i32 = 0;
+
+    # one function [0,16) whose only row is a body instruction at offset 8; no source file is
+    # registered, so pos_of degrades to (file 0, line 1).
+    var fn: DwFunc;
+    fn.name = intern.STR_NIL; fn.offset = 0; fn.size = 16; fn.weak = false;
+    fn.disp = intern.STR_NIL; fn.disp_off = 0; fn.external = false;
+    fn.decl_file = 0; fn.decl_line = 1; fn.ret_ty = -1; fn.var_start = 0; fn.var_count = 0;
+
+    var row: enc.LineRow;
+    row.text_offset = 8; row.sec = 0; row.loc.file = source.FILE_NIL; row.loc.offset = 0;
+
+    var ft: FileTable; ft.count = 0;
+    var b: enc.ByteBuf = enc.buf_init(?alloc);
+    var addr_off: [1]u32; addr_off[0] = 0;
+    build_line(?s, ?fn, 1, ?row, 1, 0, 8, "/", ?ft, ?b, ?addr_off[0]);
+
+    # exactly one DW_LNS_set_prologue_end for the one function. scan the program past the
+    # DW_LNE_set_address address field (addr_off records its start) so no header u32 length
+    # byte aliases 0x0a; the entry copy + body copy use special opcodes, never 0x0a.
+    var pe: u32 = 0;
+    var i: usize = (addr_off[0] + 8)::usize;
+    for (i < b.len) { if (b.data[i] == DW_LNS_set_prologue_end) { pe = pe + 1; } i = i + 1; }
+    if (pe != 1) { code = 1; }
+
+    enc.buf_dnit(?b);
+    session.dnit(?s);
     ret code;
 }
 


### PR DESCRIPTION
Closes #2007. Follow-up scoped out of #1954/#2006.

## Problem
mach's line program emitted no `DW_LNS_set_prologue_end`, so a debugger's `break <fn>` fell back to a prologue heuristic. gdb's heuristic lands one instruction before the entry spill that reconstructs a register-passed aggregate parameter, so `break take; print pt` read zeros (the #2006 money-proof needed a manual `next`).

## Fix (dwarf.mach, line program only)
`build_line`, per function:
1. Anchors a line row at the function entry (`low_pc`) — mach emitted no row over the prologue/homing, so a debugger's line-based prologue skip had nothing to anchor on and fell back to arch heuristics. The entry row uses the first row's file/line.
2. Flags the first post-homing row `DW_LNS_set_prologue_end` (opcode 10, already declared in the header's `standard_opcode_lengths`, so no header change).

`break <fn>` then stops at the prologue_end row, where every parameter (scalar and aggregate) is live. Line-table only; loadable segments untouched, so `-g` stays byte-additive.

## Falsifiable evidence
- `llvm-dwarfdump --debug-line`: `prologue_end` appears once per function, on the first row after the entry (take: entry row at `low_pc`, `prologue_end` on the next row past the RDI:RSI spill).
- gdb (the #2006 repro, default `break take`, no `next`): `print pt` -> `$1 = {x = 11, y = 31}`. `--verify` clean.

## Verification
- unit suite: 573 (572 baseline + 1 build_line test); dbg/verify.sh (both profiles, all ELF ISAs); self-additive (both profiles); int linux; self-host fixpoint - in thread.
