### PR TITLE
fix(link): cross-TU .debug_* dedup — .debug_abbrev (#1708)

### DIFF
--- a/src/lang/be/linker.mach
+++ b/src/lang/be/linker.mach
@@ -1399,6 +1399,14 @@ fun total_sections(modules: *of.ObjectImage, module_count: u32) u32 {
 fun accumulate_sections(s: *session.Session, modules: *of.ObjectImage, module_count: u32,
                         merged: *MergedSection, debug_names: *intern.StrId, debug_count: u32,
                         placements: *Placement, sec_base: *u32) R.Result[bool, str] {
+    # .debug_abbrev is byte-identical across every module (a deterministic, complete
+    # build_abbrev) and every CU references it at offset 0, so only the first copy is
+    # ever read. dedup it: a later object's table shares the first at offset 0 and adds
+    # no bytes to the merged section (#1708).
+    val an_r: R.Result[intern.StrId, str] = intern.intern(?s.interner, ".debug_abbrev");
+    if (R.is_err[intern.StrId, str](an_r)) { ret R.err[bool, str](R.unwrap_err[intern.StrId, str](an_r)); }
+    val abbrev_name: intern.StrId = R.unwrap_ok[intern.StrId, str](an_r);
+
     var flat: u32 = 0;
     var m: u32 = 0;
     for (m < module_count) {
@@ -1416,6 +1424,7 @@ fun accumulate_sections(s: *session.Session, modules: *of.ObjectImage, module_co
             # section routes to the name-keyed slot for its section name so distinct
             # debug sections never merge together.
             var ki: u32 = sec.kind::u32;
+            var dedup: bool = false;
             if (sec.kind == of.SK_DEBUG) {
                 var found: bool = false;
                 var di: u32 = 0;
@@ -1426,28 +1435,40 @@ fun accumulate_sections(s: *session.Session, modules: *of.ObjectImage, module_co
                 # discover_debug_names registered every debug name from these same
                 # inputs, so a miss is an internal invariant break, not an input error.
                 if (!found) { ret R.err[bool, str]("linker: debug section name not registered in the merge"); }
+                # a later .debug_abbrev copy shares the first at offset 0 (#1708).
+                if (sec.name == abbrev_name && merged[ki].used) { dedup = true; }
             }
 
-            var a: u32 = sec.align;
-            if (a == 0)               { a = 1; }
-            if (a > merged[ki].align) { merged[ki].align = a; }
-
-            # align the running offset to this section's alignment and add this
-            # section's bytes, computed in u64 so a >4GiB merged section group is
-            # rejected rather than wrapping the u32 length into a tiny value that
-            # later truncates the output.
-            val off64: u64 = bin.align_up_u64(merged[ki].len::u64, a::u64);
-            val newlen: u64 = off64 + sec.len::u64;
-            if (newlen > 0xFFFFFFFF) {
-                ret R.err[bool, str](named_message(s, "linker: merged section '", merged_section_name(s, sec.kind), "' exceeds the 4 GiB u32 limit", "linker: merged section size exceeds the 4 GiB u32 limit"));
+            if (dedup) {
+                # share the surviving first copy: offset 0, no bytes added. the copy pass
+                # rewrites offset 0 with this identical table (harmless); every CU already
+                # references offset 0, so nothing points into a dropped copy.
+                placements[flat].merged_index = ki;
+                placements[flat].offset       = 0;
+                placements[flat].vaddr        = 0;
             }
+            or {
+                var a: u32 = sec.align;
+                if (a == 0)               { a = 1; }
+                if (a > merged[ki].align) { merged[ki].align = a; }
 
-            placements[flat].merged_index = ki;
-            placements[flat].offset       = off64::u32;
-            placements[flat].vaddr        = 0;
+                # align the running offset to this section's alignment and add this
+                # section's bytes, computed in u64 so a >4GiB merged section group is
+                # rejected rather than wrapping the u32 length into a tiny value that
+                # later truncates the output.
+                val off64: u64 = bin.align_up_u64(merged[ki].len::u64, a::u64);
+                val newlen: u64 = off64 + sec.len::u64;
+                if (newlen > 0xFFFFFFFF) {
+                    ret R.err[bool, str](named_message(s, "linker: merged section '", merged_section_name(s, sec.kind), "' exceeds the 4 GiB u32 limit", "linker: merged section size exceeds the 4 GiB u32 limit"));
+                }
 
-            merged[ki].len  = newlen::u32;
-            merged[ki].used = true;
+                placements[flat].merged_index = ki;
+                placements[flat].offset       = off64::u32;
+                placements[flat].vaddr        = 0;
+
+                merged[ki].len  = newlen::u32;
+                merged[ki].used = true;
+            }
 
             flat = flat + 1;
             sc = sc + 1;


### PR DESCRIPTION
Part of #1708 (cross-TU `.debug_*` merge/dedup). See the coordination note below — scope of the `.debug_str` string-merge is pending a decision.

## Context (measured on the -g self-host compiler, 146 CUs / 162 objects)
The linker already does **offset-correct concatenation** of `.debug_*` (per-module placements + rebased relocations); `llvm-dwarfdump --verify` is already clean on the multi-TU compiler. So #1708 is about **dedup / size**, not correctness. Current `.debug_*` breakdown:

| section | bytes | dedup potential |
|---|---|---|
| .debug_line | 1,565,337 | per-module (inherent) |
| .debug_info | 895,570 | per-CU (inherent, sans type-DIE dedup) |
| .debug_str | 405,420 | 38,585 strings, **10,297 unique** → ~250 KB |
| .debug_abbrev | 44,968 | 146 identical tables → **~44.6 KB (this PR)** |
| .debug_loclists | 117,820 | per-module (inherent) |

## This PR: `.debug_abbrev` dedup
Every module emits a byte-identical `.debug_abbrev` and every CU references it at offset 0, so 145 of 146 copies were dead bytes carried through the merge. Keep exactly one; later objects share it at offset 0.

**Result:** `.debug_abbrev` 44,968 → **345 bytes** on the -g compiler; `--verify` clean.

## Verification
- unit suite: 573/0; dbg/verify.sh (both profiles, all ELF ISAs); self-additive (5 PT_LOAD identical — non-loadable debug, so -g stays byte-additive); int linux; self-host fixpoint converged.

## `.debug_str` string-merge — design ready, scope pending
The bigger win (~250 KB). Producer emits per-module `<module>#.debug_str` anchors; strp = anchor_offset + addend. Plan: a pre-pass parses each module's `.debug_str`, builds a global dedup buffer + per-module (offset→deduped-offset) remap; the merged `.debug_str` becomes the deduped buffer; strp relocations resolve through the remap (with a content-equality check per site as the correctness guard). This is a relocation-core change; raised for a scope decision (proceed here vs. focused follow-up) rather than rushed.
