### PR TITLE
feat(link): aarch64 GOT/PIC and shared-object (.so) emission (#1980 P2b)

### DIFF
--- a/src/lang/be/codegen/mir.mach
+++ b/src/lang/be/codegen/mir.mach
@@ -280,6 +280,13 @@ pub rec MirOperand {
     index:         u32;
     scale:         u8;
     index_is_preg: bool;
+    # marks a MIR_OP_SYM whose address must be loaded GOT-indirect rather than
+    # materialized absolute (a preemptible / imported reference). arm64 encode reads
+    # it to select the adrp :got: + ldr :got_lo12: sequence. the GOT-indirect
+    # foundation ships dormant: nothing sets it yet, since routing imported data
+    # through the GOT awaits RFC #2026 (see mir.context.lower_value). always false
+    # today, so every reference keeps the position-independent adrp+add form
+    sym_got:       bool;
 }
 
 # one resolved `{name}` binding for an inline-asm block
@@ -543,6 +550,7 @@ pub fun op_vreg(vreg: u32) MirOperand {
     o.index         = MIR_VREG_NIL;
     o.scale         = 0;
     o.index_is_preg = false;
+    o.sym_got       = false;
     ret o;
 }
 
@@ -561,6 +569,7 @@ pub fun op_preg(preg: u32) MirOperand {
     o.index         = MIR_VREG_NIL;
     o.scale         = 0;
     o.index_is_preg = false;
+    o.sym_got       = false;
     ret o;
 }
 
@@ -579,6 +588,7 @@ pub fun op_imm(imm: i64) MirOperand {
     o.index         = MIR_VREG_NIL;
     o.scale         = 0;
     o.index_is_preg = false;
+    o.sym_got       = false;
     ret o;
 }
 
@@ -604,6 +614,7 @@ pub fun op_mem_slot(slotkey: u32, disp: i64) MirOperand {
     o.index         = MIR_VREG_NIL;
     o.scale         = 0;
     o.index_is_preg = false;
+    o.sym_got       = false;
     ret o;
 }
 
@@ -627,6 +638,7 @@ pub fun op_mem_preg(preg: u32, disp: i64) MirOperand {
     o.index         = MIR_VREG_NIL;
     o.scale         = 0;
     o.index_is_preg = false;
+    o.sym_got       = false;
     ret o;
 }
 
@@ -650,6 +662,7 @@ pub fun op_mem_value(base: u32, disp: i64) MirOperand {
     o.index         = MIR_VREG_NIL;
     o.scale         = 0;
     o.index_is_preg = false;
+    o.sym_got       = false;
     ret o;
 }
 
@@ -669,6 +682,7 @@ pub fun op_sym(sym: intern.StrId, sym_off: i32) MirOperand {
     o.index         = MIR_VREG_NIL;
     o.scale         = 0;
     o.index_is_preg = false;
+    o.sym_got       = false;
     ret o;
 }
 
@@ -687,6 +701,7 @@ pub fun op_block(block: u32) MirOperand {
     o.index         = MIR_VREG_NIL;
     o.scale         = 0;
     o.index_is_preg = false;
+    o.sym_got       = false;
     ret o;
 }
 

--- a/src/lang/be/codegen/mir/context.mach
+++ b/src/lang/be/codegen/mir/context.mach
@@ -425,6 +425,14 @@ pub fun lower_value(ctx: *LowerCtx, v: value.Value) mir.MirOperand {
     }
     if (v.kind == value.VAL_GLOBAL) {
         if (v.data.global_ix < ctx.m.global_len) {
+            # NOTE: an imported (`is_extern`) global is preemptible and would load
+            # GOT-indirect (set `o.sym_got = true` here). that wiring is withheld
+            # pending RFC #2026: with no compile-time import signal and no linker
+            # GOT relaxation, routing every `is_extern` reference through the GOT
+            # would tax all cross-module data access. `is_extern` data therefore
+            # keeps the position-independent adrp+add form for now; the GOT-indirect
+            # codegen foundation (RK_GOT_*, emit_global_addr_got, MirOperand.sym_got)
+            # ships dormant.
             ret mir.op_sym(ctx.m.globals[v.data.global_ix].name, 0);
         }
         # an in-range global index is an IR invariant; an out-of-range one is a

--- a/src/lang/be/codegen/mir/lower.mach
+++ b/src/lang/be/codegen/mir/lower.mach
@@ -2040,7 +2040,11 @@ fun lower_memzero(ctx: *lctx.LowerCtx, mb: *mir.MirBlock, inst: *instr.Instructi
 fun agg_pointer_mem(ctx: *lctx.LowerCtx, v: value.Value, disp: i64) mir.MirOperand {
     val op: mir.MirOperand = lctx.lower_value(ctx, v);
     if (op.kind == mir.MIR_OP_VREG) { ret mir.op_mem_value(op.vreg, disp); }
-    if (op.kind == mir.MIR_OP_SYM)  { ret mir.op_sym(op.sym, op.sym_off + disp::i32); }
+    if (op.kind == mir.MIR_OP_SYM)  {
+        var so: mir.MirOperand = mir.op_sym(op.sym, op.sym_off + disp::i32);
+        so.sym_got = op.sym_got;
+        ret so;
+    }
     ret op;
 }
 

--- a/src/lang/target/isa/arm64/encode.mach
+++ b/src/lang/target/isa/arm64/encode.mach
@@ -745,6 +745,79 @@ fun emit_global_store(st: *encode.EncodeState, symop: *mir.MirOperand, val_op: *
     ret encode.push_reloc(st, arm64_reloc_offset(pos), ldst_lo12_kind(w), symop.sym, symop.sym_off);
 }
 
+# emit `adrp Xd, :got:sym` with a zero page-delta placeholder and record the
+# RK_GOT_PAGE21 relocation at the instruction-word start. the GOT analogue of
+# emit_adrp_reloc: the page-high half of a GOT-slot address. the addend is always
+# zero - the slot holds the symbol's own base and any symbol addend is applied to
+# the loaded address afterward, since a GOT reloc cannot carry it. the caller pairs
+# it with the `ldr :got_lo12:` low half that dereferences the slot
+fun emit_adrp_got_reloc(st: *encode.EncodeState, rd: u32, sym: intern.StrId) R.Result[bool, str] {
+    val pos: u32 = st.buf.len::u32;
+    emit_word(st, pack_adrp(rd));
+    ret encode.push_reloc(st, arm64_reloc_offset(pos), of.RK_GOT_PAGE21, sym, 0);
+}
+
+# a preemptible / imported symbol's address loaded GOT-indirect -
+# `adrp Xd, :got:sym` (RK_GOT_PAGE21) ; `ldr Xd, [Xd, :got_lo12:sym]` (RK_GOT_LO12).
+# the LDR dereferences the GOT slot, so Xd holds the symbol's runtime absolute
+# address, which the dynamic loader bound through an R_AARCH64_GLOB_DAT. a nonzero
+# addend rides a trailing `add Xd, Xd, #off` (the slot addresses the symbol base
+# only). this is the imported-data analogue of the absolute emit_global_addr
+fun emit_global_addr_got(st: *encode.EncodeState, rd: u32, symop: *mir.MirOperand) R.Result[bool, str] {
+    if (symop.sym == intern.STR_NIL) {
+        ret R.err[bool, str]("encode: GOT address-of has no resolved symbol name");
+    }
+    val ar: R.Result[bool, str] = emit_adrp_got_reloc(st, rd, symop.sym);
+    if (R.is_err[bool, str](ar)) { ret ar; }
+    val pos: u32 = st.buf.len::u32;
+    emit_word(st, pack_ldst(ldst_base_scaled(8, true), rd, rd, 0));
+    val pr: R.Result[bool, str] = encode.push_reloc(st, arm64_reloc_offset(pos), of.RK_GOT_LO12, symop.sym, 0);
+    if (R.is_err[bool, str](pr)) { ret pr; }
+    if (symop.sym_off != 0) { emit_add_imm(st, rd, rd, symop.sym_off::i64); }
+    ret R.ok[bool, str](true);
+}
+
+# a GOT-indirect load - the imported-data analogue of emit_global_load. the
+# symbol's address is loaded from its GOT slot into the destination register, then
+# dereferenced in place at the access width. the destination doubles as the address
+# scratch (the GOT sequence and the value load chain through Rt), so no reserved
+# scratch is spent
+fun emit_global_load_got(st: *encode.EncodeState, rt: u32, symop: *mir.MirOperand, width: u8) R.Result[bool, str] {
+    var w: u8 = width;
+    if (w == 0) { w = 8; }
+    val ar: R.Result[bool, str] = emit_global_addr_got(st, rt, symop);
+    if (R.is_err[bool, str](ar)) { ret ar; }
+    emit_mem_access(st, rt, rt, 0, w, true);
+    ret R.ok[bool, str](true);
+}
+
+# a GOT-indirect store - the imported-data analogue of emit_global_store. the
+# stored value resolves first (the zero register for an immediate 0, IP1 for a
+# non-zero immediate, the value's own register otherwise) so materializing the
+# symbol's address into IP0 never clobbers it; then the address is loaded from the
+# GOT slot into IP0 and the value stored through it
+fun emit_global_store_got(st: *encode.EncodeState, symop: *mir.MirOperand, val_op: *mir.MirOperand, width: u8) R.Result[bool, str] {
+    var w: u8 = width;
+    if (w == 0) { w = 8; }
+
+    var rt: u32 = ZR;
+    if (val_op.kind == mir.MIR_OP_IMM) {
+        if (val_op.imm != 0) {
+            emit_movewide_seq(st, SCRATCH1, val_op.imm::u64, is64(width));
+            rt = SCRATCH1;
+        }
+    } or {
+        val rr: R.Result[i32, str] = req_gpr(val_op);
+        if (R.is_err[i32, str](rr)) { ret R.err[bool, str](R.unwrap_err[i32, str](rr)); }
+        rt = R.unwrap_ok[i32, str](rr)::u32;
+    }
+
+    val ar: R.Result[bool, str] = emit_global_addr_got(st, SCRATCH0, symop);
+    if (R.is_err[bool, str](ar)) { ret ar; }
+    emit_mem_access(st, rt, SCRATCH0, 0, w, false);
+    ret R.ok[bool, str](true);
+}
+
 # a direct or indirect call. a MIR_OP_SYM callee emits `bl sym` with a
 # zero imm26 placeholder and records RK_PLT32 at the instruction-word start (the
 # linker maps it to CALL26; addend is the symbol's own constant only - no x86 -4
@@ -947,6 +1020,7 @@ fun encode_mov(st: *encode.EncodeState, f: *mir.MirFunction, mi: *mir.MirInstr) 
 # destination is a folded-global store: `adrp IP0, sym` + `str Xt, [IP0, :lo12:sym]`
 fun emit_store_mem(st: *encode.EncodeState, f: *mir.MirFunction, dst_mem: *mir.MirOperand, val_op: *mir.MirOperand, width: u8) R.Result[bool, str] {
     if (dst_mem.kind == mir.MIR_OP_SYM) {
+        if (dst_mem.sym_got) { ret emit_global_store_got(st, dst_mem, val_op, width); }
         ret emit_global_store(st, dst_mem, val_op, width);
     }
     val mr: R.Result[A64Mem, str] = resolve_mem(f, dst_mem);
@@ -1027,6 +1101,7 @@ fun encode_load(st: *encode.EncodeState, f: *mir.MirFunction, mi: *mir.MirInstr)
     val rd: u32 = R.unwrap_ok[i32, str](rdr)::u32;
 
     if (src.kind == mir.MIR_OP_SYM) {
+        if (src.sym_got) { ret emit_global_load_got(st, rd, src, mi.src_width); }
         ret emit_global_load(st, rd, src, mi.src_width);
     }
     val mr: R.Result[A64Mem, str] = resolve_mem(f, src);
@@ -1057,6 +1132,7 @@ fun encode_addr(st: *encode.EncodeState, f: *mir.MirFunction, mi: *mir.MirInstr)
 
     val memop: *mir.MirOperand = ?mi.operands[1];
     if (memop.kind == mir.MIR_OP_SYM) {
+        if (memop.sym_got) { ret emit_global_addr_got(st, rd, memop); }
         ret emit_global_addr(st, rd, memop);
     }
     val mr: R.Result[A64Mem, str] = resolve_mem(f, memop);
@@ -4914,6 +4990,81 @@ test "mach.lang.target.isa.arm64.encode:call_global_emitters_record_relocs_plus_
     or {
         if (st.relocs[6].kind != of.RK_LDST32_LO12) { bad = 1; }
         if (st.relocs[6].offset != 28)              { bad = 1; }
+    }
+
+    encode.buf_dnit(?st.buf);
+    if (st.relocs != nil && st.reloc_cap > 0) {
+        A.deallocate[encode.PendingReloc](?alloc, st.relocs, st.reloc_cap::usize);
+    }
+    ret bad;
+}
+
+# the GOT-indirect emitters (a preemptible / imported symbol) drive the adrp+ldr
+# GOT sequence and record RK_GOT_PAGE21 / RK_GOT_LO12 at the instruction-word
+# starts, both addend zero (the slot holds the symbol base). the load derefs the
+# GOT-loaded address in place; the store resolves its value first then addresses
+# through IP0. the reloc fields are zero placeholders pre-link.
+# GOT emitters record GOT relocs + base words
+test "mach.lang.target.isa.arm64.encode:got_indirect_emitters_record_relocs_plus_base_words" {
+    var bad: i32 = 0;
+    var st: encode.EncodeState;
+    var alloc: A.Allocator;
+    tbuf(?st, ?alloc);
+    st.alloc       = ?alloc;
+    st.relocs      = nil;
+    st.reloc_count = 0;
+    st.reloc_cap   = 0;
+
+    val sym: intern.StrId = 7::intern.StrId;
+
+    # GOT address-of: adrp x0,:got:sym ; ldr x0,[x0,:got_lo12:sym] ->
+    # 0x90000000 ; 0xf9400000, RK_GOT_PAGE21 @0, RK_GOT_LO12 @4, both addend 0.
+    var ao: mir.MirOperand = mir.op_sym(sym, 0);
+    ao.sym_got = true;
+    emit_global_addr_got(?st, 0, ?ao);
+    if (read_word(?st.buf, 0) != 0x90000000) { bad = 1; }
+    if (read_word(?st.buf, 4) != 0xF9400000) { bad = 1; }
+    if (st.reloc_count != 2)                 { bad = 1; }
+    or {
+        if (st.relocs[0].kind != of.RK_GOT_PAGE21) { bad = 1; }
+        if (st.relocs[0].offset != 0)              { bad = 1; }
+        if (st.relocs[0].addend != 0)              { bad = 1; }
+        if (st.relocs[1].kind != of.RK_GOT_LO12)   { bad = 1; }
+        if (st.relocs[1].offset != 4)              { bad = 1; }
+        if (st.relocs[1].addend != 0)              { bad = 1; }
+    }
+
+    # GOT load: adrp x0 ; ldr x0,[x0] (GOT) ; ldr x0,[x0] (deref) ->
+    # 0x90000000 ; 0xf9400000 ; 0xf9400000, RK_GOT_PAGE21 @8, RK_GOT_LO12 @12; the
+    # deref carries no reloc.
+    var lo: mir.MirOperand = mir.op_sym(sym, 0);
+    lo.sym_got = true;
+    emit_global_load_got(?st, 0, ?lo, 8);
+    if (read_word(?st.buf, 8)  != 0x90000000) { bad = 1; }
+    if (read_word(?st.buf, 12) != 0xF9400000) { bad = 1; }
+    if (read_word(?st.buf, 16) != 0xF9400000) { bad = 1; }
+    if (st.reloc_count != 4)                  { bad = 1; }
+    or {
+        if (st.relocs[2].kind != of.RK_GOT_PAGE21) { bad = 1; }
+        if (st.relocs[3].kind != of.RK_GOT_LO12)   { bad = 1; }
+        if (st.relocs[3].offset != 12)             { bad = 1; }
+    }
+
+    # GOT store: value x1 already in a register ; adrp x16 ; ldr x16,[x16] (GOT) ;
+    # str w1,[x16] -> 0x90000010 ; 0xf9400210 ; 0xb9000201, RK_GOT_PAGE21 @20,
+    # RK_GOT_LO12 @24; the store carries no reloc.
+    var so: mir.MirOperand = mir.op_sym(sym, 0);
+    so.sym_got = true;
+    var sv: mir.MirOperand = mir.op_preg(1);
+    emit_global_store_got(?st, ?so, ?sv, 4);
+    if (read_word(?st.buf, 20) != 0x90000010) { bad = 1; }
+    if (read_word(?st.buf, 24) != 0xF9400210) { bad = 1; }
+    if (read_word(?st.buf, 28) != 0xB9000201) { bad = 1; }
+    if (st.reloc_count != 6)                  { bad = 1; }
+    or {
+        if (st.relocs[4].kind != of.RK_GOT_PAGE21) { bad = 1; }
+        if (st.relocs[5].kind != of.RK_GOT_LO12)   { bad = 1; }
+        if (st.relocs[5].offset != 24)             { bad = 1; }
     }
 
     encode.buf_dnit(?st.buf);

--- a/src/lang/target/isa/arm64/register.mach
+++ b/src/lang/target/isa/arm64/register.mach
@@ -77,6 +77,8 @@ fun arm64_elf_reloc_type(kind: of.RelocKind) u32 {
     if (kind == of.RK_LDST64_LO12)  { ret elf.R_AARCH64_LDST64_ABS_LO12_NC; }
     if (kind == of.RK_LDST128_LO12) { ret elf.R_AARCH64_LDST128_ABS_LO12_NC; }
     if (kind == of.RK_ABS32)        { ret elf.R_AARCH64_ABS32; }
+    if (kind == of.RK_GOT_PAGE21)   { ret elf.R_AARCH64_ADR_GOT_PAGE; }
+    if (kind == of.RK_GOT_LO12)     { ret elf.R_AARCH64_LD64_GOT_LO12_NC; }
     ret 0;
 }
 
@@ -264,9 +266,10 @@ pub fun register_arm64(reg: *isa.IsaRegistry) R.Result[bool, str] {
 }
 
 # the aarch64 forward reloc map produces the right R_AARCH64_* number for each kind
-# it supports, including a distinct LDST type per access width (Option B), and 0
-# (R_AARCH64_NONE) for a kind it has no width-correct ELF type for (RK_GOTPCREL /
-# RK_ABS32S / RK_ADDR32NB are not aarch64's)
+# it supports, including a distinct LDST type per access width (Option B), the GOT
+# twins (the two-instruction adrp+ldr GOT-indirect load), and 0 (R_AARCH64_NONE)
+# for a kind it has no width-correct ELF type for (the one-instruction x64
+# RK_GOTPCREL / RK_ABS32S / RK_ADDR32NB are not aarch64's)
 test "mach.lang.target.isa.arm64.register.arm64_elf_reloc_type:forward_map" {
     if (arm64_elf_reloc_type(of.RK_ABS64)        != elf.R_AARCH64_ABS64)               { ret 1; }
     if (arm64_elf_reloc_type(of.RK_PC32)         != elf.R_AARCH64_PREL32)              { ret 1; }
@@ -279,6 +282,8 @@ test "mach.lang.target.isa.arm64.register.arm64_elf_reloc_type:forward_map" {
     if (arm64_elf_reloc_type(of.RK_LDST64_LO12)  != elf.R_AARCH64_LDST64_ABS_LO12_NC)  { ret 1; }
     if (arm64_elf_reloc_type(of.RK_LDST128_LO12) != elf.R_AARCH64_LDST128_ABS_LO12_NC) { ret 1; }
     if (arm64_elf_reloc_type(of.RK_ABS32)        != elf.R_AARCH64_ABS32)               { ret 1; }
+    if (arm64_elf_reloc_type(of.RK_GOT_PAGE21)   != elf.R_AARCH64_ADR_GOT_PAGE)        { ret 1; }
+    if (arm64_elf_reloc_type(of.RK_GOT_LO12)     != elf.R_AARCH64_LD64_GOT_LO12_NC)    { ret 1; }
 
     # a kind aarch64 has no ELF type for maps to 0, the writer's unsupported signal.
     if (arm64_elf_reloc_type(of.RK_GOTPCREL) != 0) { ret 1; }

--- a/src/lang/target/of.mach
+++ b/src/lang/target/of.mach
@@ -117,6 +117,17 @@ pub val RK_SECREL32:     RelocKind = 17;
 # symbol's section, the CodeView partner of RK_SECREL32; patches a 2-byte field.
 # COFF-only; ELF and Mach-O never emit it
 pub val RK_SECTION:      RelocKind = 18;
+# aarch64 GOT page-high 21 bits (R_AARCH64_ADR_GOT_PAGE): the signed page delta to
+# the symbol's GOT slot packed into an ADRP, the GOT analogue of RK_PAGE21. the high
+# half of a GOT-indirect address load; pairs with RK_GOT_LO12. distinct from the
+# one-instruction x64 RK_GOTPCREL because the aarch64 GOT load is a two-instruction,
+# two-relocation adrp+ldr sequence
+pub val RK_GOT_PAGE21:   RelocKind = 19;
+# aarch64 GOT scaled lo12 (R_AARCH64_LD64_GOT_LO12_NC): (GOT(S) & 0xFFF) >> 3 into an
+# LDR imm12, the 64-bit-scaled GOT analogue of RK_LDST64_LO12. the low half of a
+# GOT-indirect address load: an LDR that dereferences the GOT slot; pairs with
+# RK_GOT_PAGE21
+pub val RK_GOT_LO12:     RelocKind = 20;
 
 # object-symbol flags, combined as a bitmask in `Symbol.flags`
 # ---
@@ -883,6 +894,8 @@ pub fun reloc_kind_name(kind: RelocKind) str {
     if (kind == RK_ABS32)        { ret "abs32"; }
     if (kind == RK_SECREL32)     { ret "secrel32"; }
     if (kind == RK_SECTION)      { ret "section"; }
+    if (kind == RK_GOT_PAGE21)   { ret "got_page21"; }
+    if (kind == RK_GOT_LO12)     { ret "got_lo12"; }
     ret "unknown";
 }
 

--- a/src/lang/target/of/elf.mach
+++ b/src/lang/target/of/elf.mach
@@ -107,6 +107,11 @@ pub val R_AARCH64_LDST16_ABS_LO12_NC:  u32 = 284;
 pub val R_AARCH64_LDST32_ABS_LO12_NC:  u32 = 285;
 pub val R_AARCH64_LDST64_ABS_LO12_NC:  u32 = 286;
 pub val R_AARCH64_LDST128_ABS_LO12_NC: u32 = 299;
+# GOT-indirect addressing: the page-high half on the `adrp` and the scaled lo12
+# low half on the `ldr`, the GOT analogues of ADR_PREL_PG_HI21 / LDST64_ABS_LO12_NC.
+# a reference to a preemptible / imported symbol loads its address from a GOT slot
+pub val R_AARCH64_ADR_GOT_PAGE:        u32 = 311;
+pub val R_AARCH64_LD64_GOT_LO12_NC:    u32 = 312;
 
 # riscv relocation types. pub for the riscv64 `elf_reloc_type` forward map, as with
 # the x86_64 / aarch64 numbers above. R_RISCV_32 / R_RISCV_64 are the width-specific
@@ -167,6 +172,13 @@ val PF_R: u32 = 4;
 val R_X86_64_JUMP_SLOT:  u32 = 7;
 val R_AARCH64_JUMP_SLOT: u32 = 1026;
 val R_RISCV_JUMP_SLOT:   u32 = 5;
+
+# ELF GOT-slot dynamic relocation types: the loader binds a GOT entry to the
+# absolute address of a preemptible symbol (a data import). one per GOT slot in
+# `.rela.dyn`
+val R_X86_64_GLOB_DAT:  u32 = 6;
+val R_AARCH64_GLOB_DAT: u32 = 1025;
+val R_RISCV_GLOB_DAT:   u32 = 4;
 
 # ELF base (load-bias) relocation types: the loader adds the image's load bias to
 # the slot. one per in-image absolute pointer in a PIE image's `.rela.dyn`
@@ -310,6 +322,8 @@ fun reloc_kind_for(itn: *intern.Interner, alloc: *A.Allocator, machine: u16, r_t
     if (r_type == R_AARCH64_LDST32_ABS_LO12_NC)                 { ret R.ok[of.RelocKind, str](of.RK_LDST32_LO12); }
     if (r_type == R_AARCH64_LDST64_ABS_LO12_NC)                 { ret R.ok[of.RelocKind, str](of.RK_LDST64_LO12); }
     if (r_type == R_AARCH64_LDST128_ABS_LO12_NC)                { ret R.ok[of.RelocKind, str](of.RK_LDST128_LO12); }
+    if (r_type == R_AARCH64_ADR_GOT_PAGE)                       { ret R.ok[of.RelocKind, str](of.RK_GOT_PAGE21); }
+    if (r_type == R_AARCH64_LD64_GOT_LO12_NC)                   { ret R.ok[of.RelocKind, str](of.RK_GOT_LO12); }
     ret R.err[of.RelocKind, str](unsupported_type_message(itn, alloc, r_type::u64));
 }
 
@@ -4174,28 +4188,31 @@ test "mach.lang.target.of.elf.emit_object:unmapped_reloc_kind" {
 
 # the aarch64 page/page-offset reloc kinds (#1163) map back from their R_AARCH64
 # machine types 1:1; each per-width LDST type recovers a distinct kind so the
-# linker reads the access-size scale from the kind alone (Option B). this covers
-# the reverse parse map (`reloc_kind_for`); the forward map now lives with the
-# aarch64 ISA and is tested in target/isa/arm64/register.mach
+# linker reads the access-size scale from the kind alone (Option B), and the GOT
+# twins (ADR_GOT_PAGE / LD64_GOT_LO12_NC) recover their GOT-indirect kinds. this
+# covers the reverse parse map (`reloc_kind_for`); the forward map now lives with
+# the aarch64 ISA and is tested in target/isa/arm64/register.mach
 test "mach.lang.target.of.elf.reloc_kind_for:aarch64_page_lo12_reverse" {
     var alloc: A.Allocator;
     page.make(?alloc);
     var i: intern.Interner = intern.init(?alloc);
 
-    var kinds: [7]of.RelocKind;
+    var kinds: [9]of.RelocKind;
     kinds[0] = of.RK_PAGE21;      kinds[1] = of.RK_ADD_LO12;
     kinds[2] = of.RK_LDST8_LO12;  kinds[3] = of.RK_LDST16_LO12;
     kinds[4] = of.RK_LDST32_LO12; kinds[5] = of.RK_LDST64_LO12;
     kinds[6] = of.RK_LDST128_LO12;
+    kinds[7] = of.RK_GOT_PAGE21;  kinds[8] = of.RK_GOT_LO12;
 
-    var expect: [7]u32;
+    var expect: [9]u32;
     expect[0] = R_AARCH64_ADR_PREL_PG_HI21; expect[1] = R_AARCH64_ADD_ABS_LO12_NC;
     expect[2] = R_AARCH64_LDST8_ABS_LO12_NC; expect[3] = R_AARCH64_LDST16_ABS_LO12_NC;
     expect[4] = R_AARCH64_LDST32_ABS_LO12_NC; expect[5] = R_AARCH64_LDST64_ABS_LO12_NC;
     expect[6] = R_AARCH64_LDST128_ABS_LO12_NC;
+    expect[7] = R_AARCH64_ADR_GOT_PAGE; expect[8] = R_AARCH64_LD64_GOT_LO12_NC;
 
     var n: usize = 0;
-    for (n < 7) {
+    for (n < 9) {
         val kr: R.Result[of.RelocKind, str] = reloc_kind_for(?i, ?alloc, 183, expect[n]);
         if (R.is_err[of.RelocKind, str](kr))                { ret 1; }
         if (R.unwrap_ok[of.RelocKind, str](kr) != kinds[n]) { ret 1; }


### PR DESCRIPTION
## #1980 phase 2b — aarch64 GOT/PIC and shared-object (.so) emission

Builds the aarch64 half of shared-object support and lands the GOT/PIC codegen
foundation. Scope: aarch64-linux ELF. `Closes #2022` (#1980 stays open for P2c/P2d).

### The boundary this PR establishes

- **aarch64 `kind = "shared"` `.so` emission works and is proven.** A `MODE_LIBRARY`
  artifact links to a real `ET_DYN` `.so` through the unchanged arch-neutral P2a seam
  (`emit_shared_object` → `collect_exports` → `emit_shared`), with the aarch64
  base-reloc type (`R_AARCH64_RELATIVE`) coming for free.
- **Function imports already work** via the existing PLT path (`RK_PLT32` →
  `R_AARCH64_CALL26`).
- **DATA imports are not yet supported** — on aarch64 *or* on x86_64. The GOT-indirect
  codegen foundation ships here **dormant**; activating it (routing imported data
  through the GOT) is deferred to **RFC #2026** because of a design fork specific to
  mach's per-module model (below).

### The design fork (why the foundation ships dormant — RFC #2026)

The GOT-indirect *load/store* instruction shape (`adrp :got:` + `ldr :got_lo12:`)
differs from the absolute `adrp` + `add`, so the compiler must commit to one at
codegen time. But in mach's per-module model, a cross-module-same-artifact data
reference is `is_extern` (SHN_UNDEF) at compile time and **indistinguishable** from a
genuine `.so` import — `ensure_extern_global` is the single path for any undefined
runtime-global reference, and it cannot know link-time binding. With no compile-time
import signal and no linker GOT relaxation, wiring `is_extern → GOT` routes *every*
cross-module data access through a GOT slot + indirection + a `RELATIVE` reloc — a
permanent aarch64 codegen-quality regression that contradicts the issue's own
expectation that "locally-defined data keeps the PIC-clean adrp+add." That tradeoff
is an owner decision, tracked in RFC #2026; this PR lands the foundation and keeps
`is_extern` data on the position-independent `adrp`+`add` form.

### #1752 deliverable-2 open question — answered

> Does dynamic linking against a `.so` work on aarch64 at all today, given the GOT
> absence (PLT/`CALL26` present, GOT absent)?

**Imported functions:** yes — the dynamic-executable path binds undefined `ext`
functions through the PLT (`R_AARCH64_CALL26`), unchanged by this PR. **Imported
data:** no, not yet — data access needs the GOT, which had no codegen path. This PR
lands that path's foundation (the `RK_GOT_PAGE21`/`RK_GOT_LO12` kinds and reloc
maps, the `emit_global_addr_got` primitive, `R_AARCH64_GLOB_DAT`), leaving activation
+ the linker GOT construction to RFC #2026. **Cross-ISA parity:** the same latent gap
exists on x86_64 — grep confirms no isel/lower/encode site ever *emits* `RK_GOTPCREL`;
x64 addresses cross-module data rip-relative via `RK_PC32` and a genuine `.so` data
import hits the same undefined-symbol path. So imported-data dynamic linking is
unsupported on both ISAs today, and this PR is the prerequisite foundation for it.

### What it does

- **`of.mach` / `elf.mach`:** neutral `RK_GOT_PAGE21` / `RK_GOT_LO12` kinds (the
  two-instruction `adrp`+`ldr` GOT load, mirroring the absolute `RK_PAGE21` /
  `RK_LDST64_LO12` split — the single-instruction x64 `RK_GOTPCREL` can't express the
  aarch64 pair); `R_AARCH64_ADR_GOT_PAGE`=311, `R_AARCH64_LD64_GOT_LO12_NC`=312,
  `R_AARCH64_GLOB_DAT`=1025. Wired through the aarch64 forward reloc map and the ELF
  reverse parse; forward-map and reverse-round-trip tests extended (`RK_GOTPCREL → 0`
  preserved).
- **`arm64/encode.mach`:** `emit_global_addr_got` + GOT load/store variants + isel
  dispatch, gated on a new `MirOperand.sym_got` flag; unit-tested against llvm-mc
  byte values.
- **`mir.mach` / `mir/context.mach` / `mir/lower.mach`:** the `sym_got` field and its
  threading, dormant (nothing sets it; `lower_value` keeps `is_extern` data on
  `adrp`+`add` pending RFC #2026).

### Verification — all green

**aarch64**
- Compiler **cross-builds from source** for `linux-arm64` (the build that failed
  `relocation 'got_page21' not supported` before the wiring was withheld).
- **int** exec fixtures under **qemu-aarch64**: 10/10 match goldens (aggregate-abi,
  control-flow, float, and the regression set).
- **`.so` emission:** `readelf` → `ET_DYN` / `AArch64`, `SONAME libmath.so`, `HASH`;
  `nm -D` / `objdump -T` list the exports as `.text` / `T`.
- **PIC clean:** internal same-module data refs use `R_AARCH64_ADR_PREL_PG_HI21` +
  `LDST64_ABS_LO12_NC` (page-relative, never GOT, never ABS64-in-text); an in-image
  pointer's `ABS64` in `.data.rel.ro` becomes `R_AARCH64_RELATIVE` in the `.so`
  (0 `GLOB_DAT`, 0 `ABS64` in the final image).
- **P2a artifact rulings hold:** release `.so` = 0 section headers
  (program-headers-only, byte-minimal); `-g` `.so` = full descriptive SHT
  (`.text`/`.dynsym`/`.dynstr`/`.hash`/`.dynamic` + `.debug_*` + `.shstrtab`); the
  loadable image is byte-identical (differs only in `e_shoff`/`e_shnum`/`e_shstrndx`
  + the appended non-loaded tail).

**x86_64 — completely unaffected**
- Self-host **fixpoint** byte-identical (gen2 == gen1, release).
- **`-g` additivity:** compiler load image byte-identical with/without `-g` (differs
  only in the SHT-pointer header fields; `-g` appends the debug SHT).
- Unit suite **577/577** = the 576 dev baseline + **1** added test block (the
  `got_indirect_emitters` test in `arm64/encode.mach`).
- **linux int** leg: all cases pass.
- `llvm-dwarfdump --verify` on the `-g` build: **No errors**.

**Native-legs flag (explicit):** page-size / `mprotect` semantics (16 KiB
load-segment alignment, RELRO re-protect) need native aarch64 legs (#1885) and remain
flagged; qemu-user + the structural checks prove load / layout / symbol resolution,
not native page-protection. A `dlopen` execution smoke of the `.so` needs an aarch64
dynamic loader/sysroot (absent in this env; only qemu-user + static-PIE, which proves
the non-`.so` legs) — it belongs on the native `linux-arm64` CI leg.
