### PR TITLE
feat: SIMD vector types substrate — seeded types, lane ops, IRT_VECTOR, simd manifest key (#2013)

### DIFF
--- a/dbg/fixtures/aggregate/mach.toml
+++ b/dbg/fixtures/aggregate/mach.toml
@@ -37,10 +37,12 @@ abi = "aapcs64"
 [profile.debug]
 opt = 0
 debug = false
+simd = "scalarize"
 
 [profile.release]
 opt = 2
 debug = false
+simd = "scalarize"
 
 [artifact.dbgagg]
 kind = "bin"

--- a/dbg/fixtures/inline/mach.toml
+++ b/dbg/fixtures/inline/mach.toml
@@ -22,10 +22,12 @@ abi = "lp64"
 [profile.debug]
 opt = 0
 debug = false
+simd = "scalarize"
 
 [profile.release]
 opt = 2
 debug = false
+simd = "scalarize"
 
 [artifact.inlinefix]
 kind = "bin"

--- a/dbg/fixtures/inline4/mach.toml
+++ b/dbg/fixtures/inline4/mach.toml
@@ -22,10 +22,12 @@ abi = "lp64"
 [profile.debug]
 opt = 0
 debug = false
+simd = "scalarize"
 
 [profile.release]
 opt = 2
 debug = false
+simd = "scalarize"
 
 [artifact.inline4fix]
 kind = "bin"

--- a/dbg/fixtures/multi/mach.toml
+++ b/dbg/fixtures/multi/mach.toml
@@ -37,10 +37,12 @@ abi = "aapcs64"
 [profile.debug]
 opt = 0
 debug = false
+simd = "scalarize"
 
 [profile.release]
 opt = 2
 debug = false
+simd = "scalarize"
 
 [artifact.dbgfix]
 kind = "bin"

--- a/dbg/fixtures/promote/mach.toml
+++ b/dbg/fixtures/promote/mach.toml
@@ -22,10 +22,12 @@ abi = "lp64"
 [profile.debug]
 opt = 0
 debug = false
+simd = "scalarize"
 
 [profile.release]
 opt = 2
 debug = false
+simd = "scalarize"
 
 [artifact.promotefix]
 kind = "bin"

--- a/int/regression/1750-i32-signext/mach.toml
+++ b/int/regression/1750-i32-signext/mach.toml
@@ -37,10 +37,12 @@ abi = "aapcs64"
 [profile.debug]
 opt = 0
 debug = false
+simd = "scalarize"
 
 [profile.release]
 opt = 2
 debug = false
+simd = "scalarize"
 
 [artifact.case]
 kind = "bin"

--- a/int/regression/1762-rv64-float-vararg/mach.toml
+++ b/int/regression/1762-rv64-float-vararg/mach.toml
@@ -37,10 +37,12 @@ abi = "aapcs64"
 [profile.debug]
 opt = 0
 debug = false
+simd = "scalarize"
 
 [profile.release]
 opt = 2
 debug = false
+simd = "scalarize"
 
 [artifact.case]
 kind = "bin"

--- a/int/regression/1851-rv64-phi-signext/mach.toml
+++ b/int/regression/1851-rv64-phi-signext/mach.toml
@@ -37,10 +37,12 @@ abi = "aapcs64"
 [profile.debug]
 opt = 0
 debug = false
+simd = "scalarize"
 
 [profile.release]
 opt = 2
 debug = false
+simd = "scalarize"
 
 [artifact.case]
 kind = "bin"

--- a/int/regression/1852-rv64-self-host/mach.toml
+++ b/int/regression/1852-rv64-self-host/mach.toml
@@ -14,10 +14,12 @@ abi = "lp64"
 [profile.debug]
 opt = 0
 debug = false
+simd = "scalarize"
 
 [profile.release]
 opt = 2
 debug = false
+simd = "scalarize"
 
 [artifact.case]
 kind = "bin"

--- a/int/regression/1923-comptime-field-gate/mach.toml
+++ b/int/regression/1923-comptime-field-gate/mach.toml
@@ -37,10 +37,12 @@ abi = "aapcs64"
 [profile.debug]
 opt = 0
 debug = false
+simd = "scalarize"
 
 [profile.release]
 opt = 2
 debug = false
+simd = "scalarize"
 
 [artifact.case]
 kind = "bin"

--- a/int/regression/1925-global-aggregate-byval/mach.toml
+++ b/int/regression/1925-global-aggregate-byval/mach.toml
@@ -37,10 +37,12 @@ abi = "aapcs64"
 [profile.debug]
 opt = 0
 debug = false
+simd = "scalarize"
 
 [profile.release]
 opt = 2
 debug = false
+simd = "scalarize"
 
 [artifact.case]
 kind = "bin"

--- a/int/surface/aggregate-abi/mach.toml
+++ b/int/surface/aggregate-abi/mach.toml
@@ -37,10 +37,12 @@ abi = "aapcs64"
 [profile.debug]
 opt = 0
 debug = false
+simd = "scalarize"
 
 [profile.release]
 opt = 2
 debug = false
+simd = "scalarize"
 
 [artifact.case]
 kind = "bin"

--- a/int/surface/control-flow/mach.toml
+++ b/int/surface/control-flow/mach.toml
@@ -37,10 +37,12 @@ abi = "aapcs64"
 [profile.debug]
 opt = 0
 debug = false
+simd = "scalarize"
 
 [profile.release]
 opt = 2
 debug = false
+simd = "scalarize"
 
 [artifact.case]
 kind = "bin"

--- a/int/surface/elf-pie/mach.toml
+++ b/int/surface/elf-pie/mach.toml
@@ -12,10 +12,12 @@ abi = "sysv64"
 [profile.debug]
 opt = 0
 debug = false
+simd = "scalarize"
 
 [profile.release]
 opt = 2
 debug = false
+simd = "scalarize"
 
 [artifact.case]
 kind = "bin"

--- a/int/surface/elf-relro/mach.toml
+++ b/int/surface/elf-relro/mach.toml
@@ -22,10 +22,12 @@ abi = "lp64"
 [profile.debug]
 opt = 0
 debug = false
+simd = "scalarize"
 
 [profile.release]
 opt = 2
 debug = false
+simd = "scalarize"
 
 [artifact.case]
 kind = "bin"

--- a/int/surface/float/mach.toml
+++ b/int/surface/float/mach.toml
@@ -37,10 +37,12 @@ abi = "aapcs64"
 [profile.debug]
 opt = 0
 debug = false
+simd = "scalarize"
 
 [profile.release]
 opt = 2
 debug = false
+simd = "scalarize"
 
 [artifact.case]
 kind = "bin"

--- a/int/surface/freestanding-aarch64/mach.toml
+++ b/int/surface/freestanding-aarch64/mach.toml
@@ -12,10 +12,12 @@ abi = "aapcs64"
 [profile.debug]
 opt = 0
 debug = false
+simd = "scalarize"
 
 [profile.release]
 opt = 2
 debug = false
+simd = "scalarize"
 
 [artifact.case]
 kind = "bin"

--- a/int/surface/freestanding-riscv64/mach.toml
+++ b/int/surface/freestanding-riscv64/mach.toml
@@ -12,10 +12,12 @@ abi = "lp64"
 [profile.debug]
 opt = 0
 debug = false
+simd = "scalarize"
 
 [profile.release]
 opt = 2
 debug = false
+simd = "scalarize"
 
 [artifact.case]
 kind = "bin"

--- a/int/surface/freestanding/mach.toml
+++ b/int/surface/freestanding/mach.toml
@@ -12,10 +12,12 @@ abi = "sysv64"
 [profile.debug]
 opt = 0
 debug = false
+simd = "scalarize"
 
 [profile.release]
 opt = 2
 debug = false
+simd = "scalarize"
 
 [artifact.case]
 kind = "bin"

--- a/int/surface/macho-pie-aarch64/mach.toml
+++ b/int/surface/macho-pie-aarch64/mach.toml
@@ -12,10 +12,12 @@ abi = "aapcs64"
 [profile.debug]
 opt = 0
 debug = false
+simd = "scalarize"
 
 [profile.release]
 opt = 2
 debug = false
+simd = "scalarize"
 
 [artifact.case]
 kind = "bin"

--- a/int/surface/macho-pie-x86_64/mach.toml
+++ b/int/surface/macho-pie-x86_64/mach.toml
@@ -12,10 +12,12 @@ abi = "sysv64"
 [profile.debug]
 opt = 0
 debug = false
+simd = "scalarize"
 
 [profile.release]
 opt = 2
 debug = false
+simd = "scalarize"
 
 [artifact.case]
 kind = "bin"

--- a/int/surface/pe-aslr/mach.toml
+++ b/int/surface/pe-aslr/mach.toml
@@ -12,10 +12,12 @@ abi = "win64"
 [profile.debug]
 opt = 0
 debug = false
+simd = "scalarize"
 
 [profile.release]
 opt = 2
 debug = false
+simd = "scalarize"
 
 [artifact.case]
 kind = "bin"

--- a/int/surface/pe-import-attribution/mach.toml
+++ b/int/surface/pe-import-attribution/mach.toml
@@ -12,10 +12,12 @@ abi = "win64"
 [profile.debug]
 opt = 0
 debug = false
+simd = "scalarize"
 
 [profile.release]
 opt = 2
 debug = false
+simd = "scalarize"
 
 [artifact.case]
 kind = "bin"

--- a/int/surface/pie-reloc/mach.toml
+++ b/int/surface/pie-reloc/mach.toml
@@ -22,10 +22,12 @@ abi = "lp64"
 [profile.debug]
 opt = 0
 debug = false
+simd = "scalarize"
 
 [profile.release]
 opt = 2
 debug = false
+simd = "scalarize"
 
 [artifact.case]
 kind = "bin"

--- a/int/surface/pie-relro-fault/mach.toml
+++ b/int/surface/pie-relro-fault/mach.toml
@@ -22,10 +22,12 @@ abi = "lp64"
 [profile.debug]
 opt = 0
 debug = false
+simd = "scalarize"
 
 [profile.release]
 opt = 2
 debug = false
+simd = "scalarize"
 
 [artifact.case]
 kind = "bin"

--- a/int/surface/sign-extension/mach.toml
+++ b/int/surface/sign-extension/mach.toml
@@ -37,10 +37,12 @@ abi = "aapcs64"
 [profile.debug]
 opt = 0
 debug = false
+simd = "scalarize"
 
 [profile.release]
 opt = 2
 debug = false
+simd = "scalarize"
 
 [artifact.case]
 kind = "bin"

--- a/int/surface/syscall-inline-asm/mach.toml
+++ b/int/surface/syscall-inline-asm/mach.toml
@@ -37,10 +37,12 @@ abi = "aapcs64"
 [profile.debug]
 opt = 0
 debug = false
+simd = "scalarize"
 
 [profile.release]
 opt = 2
 debug = false
+simd = "scalarize"
 
 [artifact.case]
 kind = "bin"

--- a/mach.toml
+++ b/mach.toml
@@ -37,10 +37,12 @@ abi = "aapcs64"
 [profile.debug]
 opt = 0
 debug = false
+simd = "scalarize"
 
 [profile.release]
 opt = 2
 debug = false
+simd = "scalarize"
 
 [artifact.mach]
 kind = "bin"

--- a/src/cli/cmd/doc.mach
+++ b/src/cli/cmd/doc.mach
@@ -763,7 +763,7 @@ test "mach.cli.cmd.doc.generate:creates_missing_output_dirs" {
     if (R.is_err[bool, str](filesystem.create_dir_all(?alloc, util.cstr_str(?root[0]), 493))) { bad = 1; }
     if (R.is_err[bool, str](filesystem.create_dir_all(?alloc, src_dir, 493)))                 { bad = 1; }
 
-    val manifest_text: str = "[project]\nid = \"doctest\"\nversion = \"0.0.0\"\nsrc = \"src\"\nout = \"out/{target.name}/{profile.name}\"\n\n[target.linux]\nisa = \"x86_64\"\nos = \"linux\"\nabi = \"sysv64\"\n\n[profile.debug]\nopt = 0\ndebug = false\n\n[artifact.doctest]\nkind = \"bin\"\nentry = \"main.mach\"\nout = \"bin/doctest\"\ntargets = [\"*\"]\nlink = []\nneed = []\n";
+    val manifest_text: str = "[project]\nid = \"doctest\"\nversion = \"0.0.0\"\nsrc = \"src\"\nout = \"out/{target.name}/{profile.name}\"\n\n[target.linux]\nisa = \"x86_64\"\nos = \"linux\"\nabi = \"sysv64\"\n\n[profile.debug]\nopt = 0\ndebug = false\nsimd = \"scalarize\"\n\n[artifact.doctest]\nkind = \"bin\"\nentry = \"main.mach\"\nout = \"bin/doctest\"\ntargets = [\"*\"]\nlink = []\nneed = []\n";
     val main_text: str = "fun main() i32 { ret 0; }\n\n# a documented helper\npub fun answer() i32 { ret 42; }\n";
     val mf: str = t_join(?alloc, util.cstr_str(?root[0]), "mach.toml");
     val mn: str = t_join(?alloc, src_dir, "main.mach");

--- a/src/cli/cmd/init.mach
+++ b/src/cli/cmd/init.mach
@@ -231,10 +231,12 @@ fun write_manifest(path: *u8, id: *u8, is_lib: bool) bool {
     buf_put(?buf, "[profile.debug]\n");
     buf_put(?buf, "opt = 0\n");
     buf_put(?buf, "debug = true\n");
+    buf_put(?buf, "simd = \"scalarize\"\n");
     buf_put(?buf, "\n");
     buf_put(?buf, "[profile.release]\n");
     buf_put(?buf, "opt = 2\n");
     buf_put(?buf, "debug = false\n");
+    buf_put(?buf, "simd = \"scalarize\"\n");
     buf_put(?buf, "\n");
 
     buf_put(?buf, "[dep.mach-std]\n");

--- a/src/lang/be/codegen/mir/abi.mach
+++ b/src/lang/be/codegen/mir/abi.mach
@@ -618,7 +618,8 @@ pub fun classify_signature(ctx: *context.LowerCtx, sig: type.IrTypeId, ret_type:
         hfa_info(ctx, pty, ?phm, ?phe);
         var pagg: abi.AggLayout = abi.agg_none();
         if (wants_agg) { pagg = agg_layout(ctx, pty, pag); }
-        var slot: abi.ParamSlot = classify_arg(i::i32, psz, pal, pfl, peb, pag, gp_used, fp_used, phm, phe, pagg);
+        val pvec: bool = context.value_is_vector(ctx, pty);
+        var slot: abi.ParamSlot = classify_arg(i::i32, psz, pal, pfl, peb, pag, pvec, gp_used, fp_used, phm, phe, pagg);
 
         # record the real outgoing stack offset on the slot (the ABI classifier
         # returns a sizing-only slot with offset 0); the param / call lowering
@@ -789,13 +790,14 @@ pub fun lower_call(ctx: *context.LowerCtx, mb: *mir.MirBlock, inst: *instruction
         } or {
             val aal: u64  = type.byte_align(ctx.types, av.ty, ctx.tgt)::u64;
             val afl: bool = context.value_is_float(ctx, av.ty);
+            val avec: bool = context.value_is_vector(ctx, av.ty);
             # a variadic tail aggregate is classified as integer eightbytes (mask 0),
             # never as an HFA (members 0), and with no flattened-aggregate descriptor
             # (agg_none): the va_arg read path walks the GP register-save / overflow
             # areas, so the caller and callee stay consistent. SSE-eightbyte, HFA
             # V-register, and lp64d fa-register passing are for fixed parameters and
             # returns (the C-FFI boundary), not the varargs tail.
-            slot = classify_arg(pidx::i32, asz, aal, afl, 0, aag, gp_used, fp_used, 0, 0, abi.agg_none());
+            slot = classify_arg(pidx::i32, asz, aal, afl, 0, aag, avec, gp_used, fp_used, 0, 0, abi.agg_none());
             # round a stack-passed tail argument up to its slot alignment before
             # placing it (identity on x86; honors a 16-aligned AAPCS64 by-value arg).
             # a register-plus-stack split's tail stack chunk is eight-byte-granular.

--- a/src/lang/be/codegen/mir/abi.mach
+++ b/src/lang/be/codegen/mir/abi.mach
@@ -553,6 +553,7 @@ pub fun classify_signature(ctx: *context.LowerCtx, sig: type.IrTypeId, ret_type:
     val ret_size:  u64  = type.byte_size(ctx.types, ret_type, ctx.tgt)::u64;
     val ret_float: bool = context.value_is_float(ctx, ret_type);
     val ret_aggr:  bool = context.value_is_aggregate(ctx, ret_type);
+    val ret_vec:   bool = context.value_is_vector(ctx, ret_type);
     val ret_eb:    u8   = aggregate_sse_mask(ctx, ret_type);
     var ret_hm:    u8   = 0;
     var ret_he:    u8   = 0;
@@ -562,7 +563,7 @@ pub fun classify_signature(ctx: *context.LowerCtx, sig: type.IrTypeId, ret_type:
     val wants_agg: bool = ctx.tgt.abi.consumes_agg_layout;
     var ret_agg: abi.AggLayout = abi.agg_none();
     if (wants_agg) { ret_agg = agg_layout(ctx, ret_type, ret_aggr); }
-    out.ret_slot = classify_ret(ret_size, 0, ret_float, ret_eb, ret_aggr, ret_hm, ret_he, ret_agg);
+    out.ret_slot = classify_ret(ret_size, 0, ret_float, ret_eb, ret_aggr, ret_vec, ret_hm, ret_he, ret_agg);
 
     var gp_used:   i32 = 0;
     var fp_used:   i32 = 0;

--- a/src/lang/be/codegen/mir/context.mach
+++ b/src/lang/be/codegen/mir/context.mach
@@ -19,6 +19,8 @@ use std.types.bool.true;
 use std.types.size.usize;
 use std.types.string.str;
 
+use std.allocator.page;
+
 use A: std.allocator;
 use O: std.types.option;
 use R: std.types.result;
@@ -1235,5 +1237,52 @@ test "mach.lang.be.codegen.mir.context.fp_class_index" {
     classes[1].bit_width = 128;
     if (fp_class_index(?tgt) != 1) { ret 1; }
 
+    ret 0;
+}
+
+# shared vector scaffolding (#1965): a 128-bit vector routes to the FP/vector bank
+# (like a float) and preserves its 16-byte operand width, while value_is_vector
+# distinguishes it from a scalar; a GP scalar keeps its own bank and width
+test "mach.lang.be.codegen.mir.context.vector_scaffolding" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+    var types: ir_type.IrTypeTable;
+    if (O.is_some[str](ir_type.init(?types, ?alloc))) { ret 1; }
+
+    var classes: [2]isa.RegClass;
+    classes[0].kind = isa.RC_GENERAL;
+    classes[1].kind = isa.RC_FLOAT;
+    classes[1].bit_width = 128;
+    var tgt: target.Target;
+    tgt.model.reg_classes   = ?classes[0];
+    tgt.model.reg_class_len = 2;
+    tgt.model.gpr_width     = 8;
+
+    var ctx: LowerCtx;
+    ctx.types = ?types;
+    ctx.tgt   = ?tgt;
+
+    # f32x4 IR vector and an i32 scalar.
+    val ef: R.Result[ir_type.IrTypeId, str] = ir_type.intern_float(?types, 32);
+    if (R.is_err[ir_type.IrTypeId, str](ef)) { ir_type.dnit(?types); ret 1; }
+    val vr: R.Result[ir_type.IrTypeId, str] = ir_type.intern_vector(?types, R.unwrap_ok[ir_type.IrTypeId, str](ef), 4);
+    if (R.is_err[ir_type.IrTypeId, str](vr)) { ir_type.dnit(?types); ret 1; }
+    val vecty: ir_type.IrTypeId = R.unwrap_ok[ir_type.IrTypeId, str](vr);
+
+    val ir: R.Result[ir_type.IrTypeId, str] = ir_type.intern_int(?types, 32);
+    if (R.is_err[ir_type.IrTypeId, str](ir)) { ir_type.dnit(?types); ret 1; }
+    val i32ty: ir_type.IrTypeId = R.unwrap_ok[ir_type.IrTypeId, str](ir);
+
+    # a vector routes to the FP bank at its full 16-byte width; value_is_vector true.
+    if (reg_class_of(?ctx, ?tgt, vecty) != fp_class_index(?tgt)) { ir_type.dnit(?types); ret 1; }
+    if (op_width_of(?ctx, vecty) != 16)                          { ir_type.dnit(?types); ret 1; }
+    if (!value_is_vector(?ctx, vecty))                           { ir_type.dnit(?types); ret 1; }
+
+    # a GP scalar keeps the general bank, its own 4-byte width, and is not a vector.
+    if (reg_class_of(?ctx, ?tgt, i32ty) != gp_class_index(?tgt)) { ir_type.dnit(?types); ret 1; }
+    if (op_width_of(?ctx, i32ty) != 4)                           { ir_type.dnit(?types); ret 1; }
+    if (value_is_vector(?ctx, i32ty))                           { ir_type.dnit(?types); ret 1; }
+
+    ir_type.dnit(?types);
     ret 0;
 }

--- a/src/lang/be/codegen/mir/context.mach
+++ b/src/lang/be/codegen/mir/context.mach
@@ -306,6 +306,18 @@ pub fun value_is_aggregate(ctx: *LowerCtx, ty: ir_type.IrTypeId) bool {
     ret ir_type.is_aggregate(ctx.types, ty);
 }
 
+# whether an IR value type is a 128-bit vector (#1965)
+#
+# The neutral classifier the psABI classify driver and the target-generic MIR
+# guard both consult; each backend owns only its own vector-class ABI branch.
+# ---
+# ctx: the lowering context
+# ty:  the IR value type to classify
+# ret: true for an IRT_VECTOR
+pub fun value_is_vector(ctx: *LowerCtx, ty: ir_type.IrTypeId) bool {
+    ret ir_type.is_vector(ctx.types, ty);
+}
+
 # the lowered function's IR return type, read from its function type (IRT_FN)
 #
 # Returns IRT_NIL when the signature is unavailable or void so the param
@@ -354,6 +366,9 @@ pub fun op_width_of(ctx: *LowerCtx, ty: ir_type.IrTypeId) u8 {
     if (sz == 1) { ret 1; }
     if (sz == 2) { ret 2; }
     if (sz == 4) { ret 4; }
+    # a 128-bit vector rides its full 16-byte width in a vector register, rather
+    # than clamping to the GP word width (#1965).
+    if (sz == 16 && value_is_vector(ctx, ty)) { ret 16; }
     ret ctx.tgt.model.gpr_width::u8;
 }
 
@@ -1011,7 +1026,8 @@ fun reg_class_of(ctx: *LowerCtx, tgt: *target.Target, ty: ir_type.IrTypeId) u32 
     val opt_type: O.Option[*ir_type.IrType] = ir_type.get(ctx.types, ty);
     if (O.is_some[*ir_type.IrType](opt_type)) {
         val t: *ir_type.IrType = O.unwrap[*ir_type.IrType](opt_type);
-        if (t.kind == ir_type.IRT_FLOAT) {
+        # a 128-bit vector shares the float/vector bank (#1965).
+        if (t.kind == ir_type.IRT_FLOAT || t.kind == ir_type.IRT_VECTOR) {
             ret fp_class_index(tgt);
         }
     }

--- a/src/lang/be/codegen/mir/lower.mach
+++ b/src/lang/be/codegen/mir/lower.mach
@@ -830,6 +830,17 @@ fun lower_instr(ctx: *lctx.LowerCtx, fn: *ir.Function, mb: *mir.MirBlock, iid: i
     # they came from (0 for the function's own body).
     ctx.cur_inline_site = ir.instr_inline_site_of(fn, iid);
 
+    # a 128-bit vector reaching MIR lowering has no backend selection yet (#1965):
+    # the backend children (#2014 SSE2, #2015 NEON, #2016 rv64 scalarize) wire real
+    # selection per target and lift this guard. until then, a defined per-target
+    # compile error, never an ICE or the silent 8-byte GP clamp `op_width_of` would
+    # otherwise apply. phis are eliminated and dbg-values emit no code, so neither
+    # is the erroring site.
+    if (inst.kind != instr.OP_PHI && inst.kind != instr.OP_DBG_VALUE
+        && instr_touches_vector(ctx, inst)) {
+        ret R.err[bool, str](vector_unsupported(ctx));
+    }
+
     if (inst.kind == instr.OP_CALL) {
         ret mabi.lower_call(ctx, mb, inst, iid);
     }
@@ -924,6 +935,53 @@ fun lower_instr(ctx: *lctx.LowerCtx, fn: *ir.Function, mb: *mir.MirBlock, iid: i
     }
 
     ret lower_generic(ctx, mb, inst, iid);
+}
+
+# whether an instruction's result or any operand is a 128-bit vector (#1965)
+# ---
+# ctx:  the lowering context
+# inst: the instruction to inspect
+# ret:  true when a vector-typed value flows through the instruction
+fun instr_touches_vector(ctx: *lctx.LowerCtx, inst: *instr.Instruction) bool {
+    if (lctx.value_is_vector(ctx, inst.ty)) { ret true; }
+    var i: u32 = 0;
+    for (i < inst.operand_count) {
+        if (lctx.value_is_vector(ctx, inst.operands[i].ty)) { ret true; }
+        i = i + 1;
+    }
+    ret false;
+}
+
+# the defined per-target "vectors not yet supported" error, naming the arch
+#
+# Interns the assembled message so it outlives the scratch buffer; degrades to a
+# static target-neutral message on an allocation failure.
+# ---
+# ctx: the lowering context (supplies the target arch name and interner)
+# ret: the owned error message
+fun vector_unsupported(ctx: *lctx.LowerCtx) str {
+    val prefix:   str = "codegen: 128-bit vectors not yet supported on ";
+    val fallback: str = "codegen: 128-bit vectors not yet supported on this target";
+    val arch:     str = ctx.tgt.arch.name;
+    if (arch == nil) { ret fallback; }
+
+    val total: usize = str_len(prefix) + str_len(arch);
+    val r: R.Result[*u8, str] = A.allocate[u8](ctx.alloc, total + 1);
+    if (R.is_err[*u8, str](r)) { ret fallback; }
+    val buf: *u8 = R.unwrap_ok[*u8, str](r);
+    var k: usize = 0;
+    var j: usize = 0;
+    for (j < str_len(prefix)) { buf[k] = prefix[j]; k = k + 1; j = j + 1; }
+    j = 0;
+    for (j < str_len(arch)) { buf[k] = arch[j]; k = k + 1; j = j + 1; }
+    buf[total] = 0;
+
+    val ir_id: R.Result[intern.StrId, str] = intern.intern(ctx.interner, buf::str);
+    A.deallocate[u8](ctx.alloc, buf, total + 1);
+    if (R.is_err[intern.StrId, str](ir_id)) { ret fallback; }
+    val rn: O.Option[str] = intern.lookup(ctx.interner, R.unwrap_ok[intern.StrId, str](ir_id));
+    if (O.is_some[str](rn)) { ret O.unwrap[str](rn); }
+    ret fallback;
 }
 
 # lower an IR OP_CBR into a `mir.MIR_CBR [cond, then, else]`

--- a/src/lang/be/codegen/regalloc.mach
+++ b/src/lang/be/codegen/regalloc.mach
@@ -2392,7 +2392,9 @@ fun add_spill_slot(ctx: *AllocCtx, value_id: u32, size: u32) R.Result[i32, str] 
     frame.slots[si].kind   = mir.SLOT_SPILL;
     frame.slots[si].offset = 0;
     frame.slots[si].size   = size;
-    frame.slots[si].align  = 8;
+    # align each slot to its own width so a 16-byte vector-class spill is 16-byte
+    # aligned; a GP slot's 8-byte width keeps its 8-byte alignment (#1965).
+    frame.slots[si].align  = size;
     frame.slot_count = frame.slot_count + 1;
     ret R.ok[i32, str](si::i32);
 }

--- a/src/lang/be/codegen/regalloc.mach
+++ b/src/lang/be/codegen/regalloc.mach
@@ -2392,9 +2392,7 @@ fun add_spill_slot(ctx: *AllocCtx, value_id: u32, size: u32) R.Result[i32, str] 
     frame.slots[si].kind   = mir.SLOT_SPILL;
     frame.slots[si].offset = 0;
     frame.slots[si].size   = size;
-    # align each slot to its own width so a 16-byte vector-class spill is 16-byte
-    # aligned; a GP slot's 8-byte width keeps its 8-byte alignment (#1965).
-    frame.slots[si].align  = size;
+    frame.slots[si].align  = 8;
     frame.slot_count = frame.slot_count + 1;
     ret R.ok[i32, str](si::i32);
 }

--- a/src/lang/driver.mach
+++ b/src/lang/driver.mach
@@ -5999,7 +5999,7 @@ fun ut_lib_manifest(alloc: *A.Allocator, id: str) str {
 
 # a bin root manifest declaring the single path dep [dep.<alias>] at `path`.
 fun ut_dep_root_one(alloc: *A.Allocator, alias: str, path: str) str {
-    val head: str = "[project]\nid = \"app\"\nversion = \"0.0.0\"\nsrc = \"src\"\nout = \"out/{target.name}/{profile.name}\"\n\n[target.linux]\nisa = \"x86_64\"\nos = \"linux\"\nabi = \"sysv64\"\n\n[profile.debug]\nopt = 0\ndebug = false\n\n[artifact.app]\nkind = \"bin\"\nentry = \"main.mach\"\nout = \"bin/app\"\ntargets = [\"*\"]\nlink = []\nneed = []\n\n[dep.";
+    val head: str = "[project]\nid = \"app\"\nversion = \"0.0.0\"\nsrc = \"src\"\nout = \"out/{target.name}/{profile.name}\"\n\n[target.linux]\nisa = \"x86_64\"\nos = \"linux\"\nabi = \"sysv64\"\n\n[profile.debug]\nopt = 0\ndebug = false\nsimd = \"scalarize\"\n\n[artifact.app]\nkind = \"bin\"\nentry = \"main.mach\"\nout = \"bin/app\"\ntargets = [\"*\"]\nlink = []\nneed = []\n\n[dep.";
     val mid: str = ut_cc3(alloc, head, alias, "]\npath = \"");
     ret ut_cc3(alloc, mid, path, "\"\n");
 }

--- a/src/lang/driver.mach
+++ b/src/lang/driver.mach
@@ -6329,6 +6329,107 @@ fun ut_count_errors(d: *diagnostic.DiagList) u32 {
     ret c;
 }
 
+# whether any error-severity diagnostic's message contains `needle`
+fun ut_diag_has(d: *diagnostic.DiagList, needle: str) bool {
+    var i: usize = 0;
+    for (i < d.len) {
+        if (d.items[i].severity == diagnostic.SEVERITY_ERROR
+            && ut_str_contains(d.items[i].message, needle)) { ret true; }
+        i = i + 1;
+    }
+    ret false;
+}
+
+# build a one-file project from `src` (as main.mach), run resolve + sema, and
+# return the project so a test can inspect p.s.diags. the caller tears down the
+# project and session
+fun ut_vec_sema(s: *session.Session, alloc: *A.Allocator, src: str) R.Result[Project, str] {
+    var names: [1]str;
+    names[0] = "main.mach";
+    var texts: [1]str;
+    texts[0] = src;
+    val pr: R.Result[Project, str] = ut_build(s, alloc, ?names[0], ?texts[0], 1);
+    if (R.is_err[Project, str](pr)) { ret pr; }
+    var p: Project = R.unwrap_ok[Project, str](pr);
+    val se: R.Result[bool, str] = run_sema_pass(?p);
+    if (R.is_err[bool, str](se)) { dnit_project(?p); ret R.err[Project, str](R.unwrap_err[bool, str](se)); }
+    ret R.ok[Project, str](p);
+}
+
+# 0 when compiling `src` through sema leaves an error diagnostic containing
+# `needle`, 1 otherwise. a self-contained session per call, torn down here
+fun ut_vec_diag(src: str, needle: str) i32 {
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    val sr: R.Result[session.Session, str] = session.init(?alloc);
+    if (R.is_err[session.Session, str](sr)) { ret 1; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](sr);
+    val pr: R.Result[Project, str] = ut_vec_sema(?s, ?alloc, src);
+    if (R.is_err[Project, str](pr)) { session.dnit(?s); ret 1; }
+    var p: Project = R.unwrap_ok[Project, str](pr);
+    val hit: bool = ut_diag_has(?p.s.diags, needle);
+    dnit_project(?p);
+    session.dnit(?s);
+    if (hit) { ret 0; }
+    ret 1;
+}
+
+# a well-typed program exercising the full vector surface -- spellings in type
+# position, a full-arity literal, lane-wise arithmetic / bitwise / compare to
+# mask, 16-bit integer multiply, unary ~, and a comptime-constant lane read --
+# passes sema with no errors (#2013)
+test "mach.lang.driver:vector_surface_typechecks" {
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    val sr: R.Result[session.Session, str] = session.init(?alloc);
+    if (R.is_err[session.Session, str](sr)) { ret 1; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](sr);
+
+    val src: str = "fun main() i32 {\n    val a: f32x4 = f32x4{1.0, 2.0, 3.0, 4.0};\n    val b: f32x4 = f32x4{5.0, 6.0, 7.0, 8.0};\n    val c: f32x4 = a + b;\n    val d: f32x4 = a * b;\n    val m: u32x4 = a == b;\n    val x: f32 = a[0];\n    var iv: i16x8 = i16x8{1, 2, 3, 4, 5, 6, 7, 8};\n    val iw: i16x8 = iv & iv;\n    val ip: i16x8 = iv * iv;\n    val iq: i16x8 = ~iv;\n    ret 0;\n}\n";
+    val pr: R.Result[Project, str] = ut_vec_sema(?s, ?alloc, src);
+    if (R.is_err[Project, str](pr)) { session.dnit(?s); ret 1; }
+    var p: Project = R.unwrap_ok[Project, str](pr);
+
+    var bad: i32 = 0;
+    if (ut_count_errors(?p.s.diags) != 0) { bad = 1; }
+
+    dnit_project(?p);
+    session.dnit(?s);
+    ret bad;
+}
+
+# every vector negative diagnostic from the acceptance list lands as a specific
+# error, never an ICE or a silent accept (#2013)
+test "mach.lang.driver:vector_negative_diagnostics" {
+    var bad: i32 = 0;
+
+    # wrong-arity literal
+    if (ut_vec_diag("fun main() i32 { val v: f32x4 = f32x4{1.0, 2.0, 3.0}; ret 0; }\n",
+        "too few elements") != 0) { bad = 1; }
+    if (ut_vec_diag("fun main() i32 { val v: f32x4 = f32x4{1.0, 2.0, 3.0, 4.0, 5.0}; ret 0; }\n",
+        "too many elements") != 0) { bad = 1; }
+    # non-comptime lane index (dynamic)
+    if (ut_vec_diag("fun main(argc: i64, argv: **u8) i32 { val a: f32x4 = f32x4{1.0, 2.0, 3.0, 4.0}; val x: f32 = a[argc]; ret 0; }\n",
+        "dynamic lane index not supported") != 0) { bad = 1; }
+    # out-of-bounds constant lane index
+    if (ut_vec_diag("fun main() i32 { val a: f32x4 = f32x4{1.0, 2.0, 3.0, 4.0}; val x: f32 = a[4]; ret 0; }\n",
+        "vector lane index out of bounds") != 0) { bad = 1; }
+    # vector %
+    if (ut_vec_diag("fun main() i32 { val a: i32x4 = i32x4{1, 2, 3, 4}; val b: i32x4 = i32x4{1, 2, 3, 4}; val c: i32x4 = a % b; ret 0; }\n",
+        "vector `%` is not supported") != 0) { bad = 1; }
+    # integer vector /
+    if (ut_vec_diag("fun main() i32 { val a: i32x4 = i32x4{1, 2, 3, 4}; val b: i32x4 = i32x4{1, 2, 3, 4}; val c: i32x4 = a / b; ret 0; }\n",
+        "integer vector `/` is not supported") != 0) { bad = 1; }
+    # scalar <-> vector mixing
+    if (ut_vec_diag("fun main() i32 { val a: f32x4 = f32x4{1.0, 2.0, 3.0, 4.0}; val s: f32 = 1.0; val c: f32x4 = a + s; ret 0; }\n",
+        "mismatch") != 0) { bad = 1; }
+    # a vector (mask) used where a scalar truth value is required
+    if (ut_vec_diag("fun main() i32 { val a: f32x4 = f32x4{1.0, 2.0, 3.0, 4.0}; val b: f32x4 = f32x4{1.0, 2.0, 3.0, 4.0}; if (a == b) { ret 1; } ret 0; }\n",
+        "vector is not a truth value") != 0) { bad = 1; }
+
+    ret bad;
+}
+
 # a two-char decimal string ("00".."99") for n < 100, owned by `alloc`.
 # names the per-leaf modules of the realloc-mid-walk fixture below
 fun ut_idx2(alloc: *A.Allocator, n: u32) str {

--- a/src/lang/driver.mach
+++ b/src/lang/driver.mach
@@ -6374,6 +6374,53 @@ fun ut_vec_diag(src: str, needle: str) i32 {
     ret 1;
 }
 
+# 0 when compiling `src` through sema + lower + codegen fails at codegen with an
+# error containing `needle` -- the defined per-target isel error a vector op
+# raises until a backend wires selection (#2013 slice 7). 1 otherwise
+fun ut_vec_codegen_err(src: str, needle: str) i32 {
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    val sr: R.Result[session.Session, str] = session.init(?alloc);
+    if (R.is_err[session.Session, str](sr)) { ret 1; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](sr);
+
+    var names: [1]str;
+    names[0] = "main.mach";
+    var texts: [1]str;
+    texts[0] = src;
+    val pr: R.Result[Project, str] = ut_build(?s, ?alloc, ?names[0], ?texts[0], 1);
+    if (R.is_err[Project, str](pr)) { session.dnit(?s); ret 1; }
+    var p: Project = R.unwrap_ok[Project, str](pr);
+
+    var code: i32 = 1;
+    val se: R.Result[bool, str] = run_sema_pass(?p);
+    if (R.is_ok[bool, str](se)) {
+        val le: R.Result[bool, str] = run_lower_pass(?p);
+        if (R.is_ok[bool, str](le)) {
+            val ce: R.Result[bool, str] = run_codegen_pass(?p);
+            if (R.is_err[bool, str](ce) && ut_str_contains(R.unwrap_err[bool, str](ce), needle)) { code = 0; }
+        }
+    }
+    dnit_project(?p);
+    session.dnit(?s);
+    ret code;
+}
+
+# a vector op reaching instruction selection raises the defined per-target
+# compile error (never an ICE, never a silent miscompile): a full-arity literal
+# and a lane-wise add both lower to IRT_VECTOR values that hit the target-generic
+# MIR guard, surfacing the "not yet supported on <arch>" string (#2013 slice 7)
+test "mach.lang.driver:vector_isel_error" {
+    var bad: i32 = 0;
+    # a lane-wise add through pointers (no literal): the add lowers to a vector op.
+    if (ut_vec_codegen_err("fun addv(a: *f32x4, b: *f32x4, out: *f32x4) { @out = @a + @b; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { addv(argv:~*f32x4, argv:~*f32x4, argv:~*f32x4); ret 0; }\n",
+        "128-bit vectors not yet supported") != 0) { bad = 1; }
+    # a full-arity literal: it lowers to an IRT_VECTOR value that also reaches the guard.
+    if (ut_vec_codegen_err("fun mk(out: *f32x4) { @out = f32x4{1.0, 2.0, 3.0, 4.0}; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { mk(argv:~*f32x4); ret 0; }\n",
+        "128-bit vectors not yet supported") != 0) { bad = 1; }
+    ret bad;
+}
+
 # a well-typed program exercising the full vector surface -- spellings in type
 # position, a full-arity literal, lane-wise arithmetic / bitwise / compare to
 # mask, 16-bit integer multiply, unary ~, and a comptime-constant lane read --
@@ -6385,7 +6432,7 @@ test "mach.lang.driver:vector_surface_typechecks" {
     if (R.is_err[session.Session, str](sr)) { ret 1; }
     var s: session.Session = R.unwrap_ok[session.Session, str](sr);
 
-    val src: str = "fun main() i32 {\n    val a: f32x4 = f32x4{1.0, 2.0, 3.0, 4.0};\n    val b: f32x4 = f32x4{5.0, 6.0, 7.0, 8.0};\n    val c: f32x4 = a + b;\n    val d: f32x4 = a * b;\n    val m: u32x4 = a == b;\n    val x: f32 = a[0];\n    var iv: i16x8 = i16x8{1, 2, 3, 4, 5, 6, 7, 8};\n    val iw: i16x8 = iv & iv;\n    val ip: i16x8 = iv * iv;\n    val iq: i16x8 = ~iv;\n    ret 0;\n}\n";
+    val src: str = "fun main() i32 {\n    val a: f32x4 = f32x4{1.0, 2.0, 3.0, 4.0};\n    val b: f32x4 = f32x4{5.0, 6.0, 7.0, 8.0};\n    val c: f32x4 = a + b;\n    val d: f32x4 = a * b;\n    val m: u32x4 = a == b;\n    val x: f32 = a[0];\n    var iv: i16x8 = i16x8{1, 2, 3, 4, 5, 6, 7, 8};\n    val iw: i16x8 = iv & iv;\n    val ip: i16x8 = iv * iv;\n    val iq: i16x8 = ~iv;\n    val im: u16x8 = iv == iv;\n    ret 0;\n}\n";
     val pr: R.Result[Project, str] = ut_vec_sema(?s, ?alloc, src);
     if (R.is_err[Project, str](pr)) { session.dnit(?s); ret 1; }
     var p: Project = R.unwrap_ok[Project, str](pr);
@@ -6426,6 +6473,15 @@ test "mach.lang.driver:vector_negative_diagnostics" {
     # a vector (mask) used where a scalar truth value is required
     if (ut_vec_diag("fun main() i32 { val a: f32x4 = f32x4{1.0, 2.0, 3.0, 4.0}; val b: f32x4 = f32x4{1.0, 2.0, 3.0, 4.0}; if (a == b) { ret 1; } ret 0; }\n",
         "vector is not a truth value") != 0) { bad = 1; }
+    # a positional-brace literal on a non-vector type (record) is a specific error.
+    if (ut_vec_diag("rec Point { x: i64; y: i64; }\nfun main() i32 { val p: Point = Point{1, 2}; ret 0; }\n",
+        "positional-brace literal requires a vector type") != 0) { bad = 1; }
+    # a negative constant lane index.
+    if (ut_vec_diag("fun main() i32 { val a: f32x4 = f32x4{1.0, 2.0, 3.0, 4.0}; val x: f32 = a[-1]; ret 0; }\n",
+        "index must be non-negative") != 0) { bad = 1; }
+    # scalar<->vector mixing in the reversed operand order (scalar on the left).
+    if (ut_vec_diag("fun main() i32 { val a: f32x4 = f32x4{1.0, 2.0, 3.0, 4.0}; val s: f32 = 1.0; val c: f32x4 = s + a; ret 0; }\n",
+        "mismatch") != 0) { bad = 1; }
 
     ret bad;
 }

--- a/src/lang/fe/ast/expr.mach
+++ b/src/lang/fe/ast/expr.mach
@@ -37,6 +37,10 @@ pub val EXPR_KIND_SPREAD:         ExprKind = 17;
 # member of the `::`/`:~` cast family. flow-typing semantics land in #1645; the
 # parser only records the node
 pub val EXPR_KIND_STRIP:          ExprKind = 18;
+# a full-arity vector literal `f32x4{a, b, c, d}` (#1965): a named vector type
+# with a positional brace body, one element per lane. distinguished from a struct
+# literal at parse time by the body lacking `ident :` field syntax
+pub val EXPR_KIND_VECTOR_LIT:     ExprKind = 19;
 pub val EXPR_KIND_ERROR:          ExprKind = 255;
 
 # binary operator encoded in ExprBinary.op
@@ -213,6 +217,17 @@ pub rec ExprStructLit {
     fields_len:   u32;
 }
 
+# a full-arity vector literal `f32x4{a, b, c, d}` (#1965)
+# ---
+# ty:          named vector type being constructed
+# elems_start: start index into ast.expr_ids
+# elems_len:   number of lane element expressions
+pub rec ExprVectorLit {
+    ty:          id.TypeId;
+    elems_start: u32;
+    elems_len:   u32;
+}
+
 # a syntactic expression node
 # ---
 # span: byte range of the expression in source
@@ -234,6 +249,7 @@ pub rec Expr {
         strip:      ExprStrip;
         array_lit:  ExprArrayLit;
         struct_lit: ExprStructLit;
+        vector_lit: ExprVectorLit;
         project:    ExprProject;
         spread:     ExprSpread;
     };

--- a/src/lang/fe/comptime.mach
+++ b/src/lang/fe/comptime.mach
@@ -670,6 +670,7 @@ pub fun eval(
     if (k == expr.EXPR_KIND_CAST)       { ret R.err[CTValue, str]("type casts are not comptime-evaluable"); }
     if (k == expr.EXPR_KIND_ARRAY_LIT)  { ret R.err[CTValue, str]("array literals are not comptime-evaluable"); }
     if (k == expr.EXPR_KIND_STRUCT_LIT) { ret R.err[CTValue, str]("struct literals are not comptime-evaluable"); }
+    if (k == expr.EXPR_KIND_VECTOR_LIT) { ret R.err[CTValue, str]("vector literals are not comptime-evaluable"); }
     if (k == expr.EXPR_KIND_ERROR)      { ret R.err[CTValue, str]("expression has a parse error"); }
 
     ret R.err[CTValue, str]("expression is not comptime-evaluable");

--- a/src/lang/fe/parser/expr.mach
+++ b/src/lang/fe/parser/expr.mach
@@ -834,7 +834,15 @@ fun parse_array_literal(p: *state.Parser) id.ExprId {
 fun parse_typed_literal(p: *state.Parser) id.ExprId {
     val start_tok: token.Token = state.current(p);
     val ty: id.TypeId = parse_type(p);
-    state.expect(p, token.KIND_LBRACE, "expected '{' after type in struct literal");
+    state.expect(p, token.KIND_LBRACE, "expected '{' after type in struct or vector literal");
+
+    # a positional brace body (no leading `ident :` field syntax) is a full-arity
+    # vector literal `f32x4{a, b, c, d}` (#1965), distinct from a named-field
+    # struct literal. an empty body stays a struct literal (a fieldless record).
+    if (!state.at(p, token.KIND_RBRACE)
+        && !(state.at(p, token.KIND_IDENT) && state.peek(p, 1).kind == token.KIND_COLON)) {
+        ret parse_vector_literal_body(p, start_tok, ty);
+    }
 
     # buffer the fields: a field initializer may be a nested struct literal
     # that appends its own FieldInits to the shared pool mid-parse, so flush
@@ -868,6 +876,44 @@ fun parse_typed_literal(p: *state.Parser) id.ExprId {
     node.span            = state.span_of(start_tok.span, close.span);
     node.kind            = expr.EXPR_KIND_STRUCT_LIT;
     node.data.struct_lit = lit;
+    ret state.push_expr(p, node);
+}
+
+# parses the positional body of a vector literal `f32x4{a, b, c, d}` (#1965)
+#
+# The cursor is just past the opening '{' with a non-empty positional body. Each
+# comma-separated element is a lane value; arity is validated in sema.
+# ---
+# p:         parser state, cursor on the first element
+# start_tok: the type-prefix token, for the literal's span
+# ty:        the parsed vector type
+# ret:       ExprId of the EXPR_KIND_VECTOR_LIT node
+fun parse_vector_literal_body(p: *state.Parser, start_tok: token.Token, ty: id.TypeId) id.ExprId {
+    # buffer the elements: a nested literal or call appends its own child ids to
+    # the shared pool mid-parse, so flush this literal's elements afterward (see
+    # parse_array_literal).
+    var buf: state.ListBuf[id.ExprId] = state.list_buf_init[id.ExprId]();
+    state.list_buf_push[id.ExprId](p, ?buf, parse_expr(p));
+    for (state.eat(p, token.KIND_COMMA)) {
+        if (state.at(p, token.KIND_RBRACE)) { brk; }
+        state.list_buf_push[id.ExprId](p, ?buf, parse_expr(p));
+    }
+
+    val close: token.Token = state.current(p);
+    state.expect(p, token.KIND_RBRACE, "expected '}' to close vector literal");
+
+    var elems_len:   u32 = 0;
+    val elems_start: u32 = state.expr_id_buf_flush(p, ?buf, ?elems_len);
+
+    var lit: expr.ExprVectorLit;
+    lit.ty          = ty;
+    lit.elems_start = elems_start;
+    lit.elems_len   = elems_len;
+
+    var node: expr.Expr;
+    node.span            = state.span_of(start_tok.span, close.span);
+    node.kind            = expr.EXPR_KIND_VECTOR_LIT;
+    node.data.vector_lit = lit;
     ret state.push_expr(p, node);
 }
 

--- a/src/lang/fe/resolve.mach
+++ b/src/lang/fe/resolve.mach
@@ -70,6 +70,9 @@ pub val SYM_IMPORTED: SymKind = 8;
 pub val SYM_TEST:     SymKind = 9;
 pub val SYM_UNI:      SymKind = 10;
 pub val SYM_PRIM:     SymKind = 11;
+# a seeded 128-bit vector type name (#1965); `slot` carries the pre-interned
+# semantic vector TypeId directly, not a TypeKind ordinal
+pub val SYM_VECTOR:   SymKind = 12;
 
 # pub-flag bit, set when the symbol's source decl is `pub`, or when it is
 # re-exported by `fwd`
@@ -94,7 +97,8 @@ pub val SYM_FLAG_MODULE: u8 = 4;
 # decl:   originating DeclId in `origin`'s Ast (DECL_NIL when synthetic)
 # slot:   kind-dependent extra payload; param index for SYM_PARAM, generic
 #         index for SYM_GENERIC, target ModuleId for SYM_USE, the primitive
-#         TypeKind ordinal for SYM_PRIM, otherwise 0
+#         TypeKind ordinal for SYM_PRIM, the pre-interned vector TypeId for
+#         SYM_VECTOR, otherwise 0
 # origin: ModuleId of the module that owns `decl` (this module for locally
 #         declared symbols, the dependency for SYM_USE / SYM_IMPORTED)
 # origin_stable: build-stable identity of `origin`, captured at resolve time. a
@@ -208,6 +212,13 @@ rec ResolveContext {
     # colliding with the primitive type spelling.
     prim_names: [11]intern.StrId;
     prim_syms:  [11]SymbolId;
+
+    # vector type registry: the SYM_VECTOR symbols for the ten seeded 128-bit
+    # shapes, keyed by interned spelling. recognised in type position only,
+    # exactly like the primitive registry, so a value named `f32x4` never
+    # collides with the vector type spelling.
+    vec_names: [10]intern.StrId;
+    vec_syms:  [10]SymbolId;
 
     # caches (origin << 32 | decl) -> SymbolId for already-created
     # SYM_IMPORTED entries, so repeated `print.println` use-sites share one
@@ -392,6 +403,12 @@ pub fun resolve(
     if (R.is_err[bool, str](sp_r)) {
         dnit_context(?rc);
         ret R.err[ResolveResult, str](R.unwrap_err[bool, str](sp_r));
+    }
+
+    val sv_r: R.Result[bool, str] = seed_vectors(?rc);
+    if (R.is_err[bool, str](sv_r)) {
+        dnit_context(?rc);
+        ret R.err[ResolveResult, str](R.unwrap_err[bool, str](sv_r));
     }
 
     val m_opt: O.Option[*module.Module] = ast.get_module(a, a.root_module);
@@ -834,18 +851,70 @@ fun seed_one_primitive(rc: *ResolveContext, index: u32, name: str, kind_ordinal:
     ret R.ok[bool, str](true);
 }
 
-# returns the SYM_PRIM symbol for a primitive type spelling, or SYMBOL_NIL
-# when `name` is not a primitive. consulted in type position, taking priority
-# over scope so a same-named value declaration never shadows the type
+# seeds the ten 128-bit vector type spellings (f32x4 .. u64x2) into the
+# resolver's vector registry as SYM_VECTOR symbols whose `slot` carries the
+# pre-interned semantic vector TypeId. recognised in type position only, exactly
+# like the primitive registry, so a value may reuse a vector spelling without
+# colliding. the type universe seeds the shapes at session init, so `type.vec`
+# hands back a stable id here
+# ---
+# rc:  resolver state for the module being resolved
+# ret: ok(true), or an allocation error
+fun seed_vectors(rc: *ResolveContext) R.Result[bool, str] {
+    var i: u32 = 0;
+    for (i < type.VEC_COUNT) {
+        val sh:  type.VecShape      = type.vec_shape(i);
+        val opt: O.Option[type.TypeId] = type.vec(?rc.s.types, i);
+        if (O.is_none[type.TypeId](opt)) { ret R.err[bool, str]("vector shape not seeded in the type universe"); }
+        val vtid: type.TypeId = O.unwrap[type.TypeId](opt);
+
+        val r: R.Result[bool, str] = seed_one_vector(rc, i, sh.name, vtid::u32);
+        if (R.is_err[bool, str](r)) { ret r; }
+        i = i + 1;
+    }
+    ret R.ok[bool, str](true);
+}
+
+# interns one vector spelling and records it in the registry at `index` as a
+# SYM_VECTOR symbol carrying the pre-interned vector TypeId in `slot`
+# ---
+# rc:      resolver state for the module being resolved
+# index:   registry slot to fill
+# name:    the vector spelling
+# type_id: the pre-interned semantic vector TypeId
+# ret:     ok(true), or an allocation error
+fun seed_one_vector(rc: *ResolveContext, index: u32, name: str, type_id: u32) R.Result[bool, str] {
+    val r_id: R.Result[intern.StrId, str] = intern.intern(?rc.s.interner, name);
+    if (R.is_err[intern.StrId, str](r_id)) { ret R.err[bool, str](R.unwrap_err[intern.StrId, str](r_id)); }
+    val name_id: intern.StrId = R.unwrap_ok[intern.StrId, str](r_id);
+
+    val r_sym: R.Result[SymbolId, str] = add_symbol(rc, SYM_VECTOR, 0, name_id, id.DECL_NIL, type_id, rc.own_module);
+    if (R.is_err[SymbolId, str](r_sym)) { ret R.err[bool, str](R.unwrap_err[SymbolId, str](r_sym)); }
+    val sid: SymbolId = R.unwrap_ok[SymbolId, str](r_sym);
+
+    rc.vec_names[index] = name_id;
+    rc.vec_syms[index]  = sid;
+    ret R.ok[bool, str](true);
+}
+
+# returns the SYM_PRIM or SYM_VECTOR symbol for a type spelling, or SYMBOL_NIL
+# when `name` is neither a primitive nor a vector. consulted in type position,
+# taking priority over scope so a same-named value declaration never shadows the
+# type
 # ---
 # rc:   resolver state for the module being resolved
 # name: interned spelling to test
-# ret:  the SYM_PRIM symbol, or SYMBOL_NIL when `name` is not a primitive
+# ret:  the SYM_PRIM / SYM_VECTOR symbol, or SYMBOL_NIL when `name` is neither
 fun prim_symbol_for(rc: *ResolveContext, name: intern.StrId) SymbolId {
     var i: u32 = 0;
     for (i < PRIM_COUNT) {
         if (rc.prim_names[i] == name) { ret rc.prim_syms[i]; }
         i = i + 1;
+    }
+    var v: u32 = 0;
+    for (v < type.VEC_COUNT) {
+        if (rc.vec_names[v] == name) { ret rc.vec_syms[v]; }
+        v = v + 1;
     }
     ret SYMBOL_NIL;
 }

--- a/src/lang/fe/resolve.mach
+++ b/src/lang/fe/resolve.mach
@@ -2345,6 +2345,11 @@ fun bind_expr(rc: *ResolveContext, eid: id.ExprId) R.Result[bool, str] {
         if (R.is_err[bool, str](rt)) { ret rt; }
         ret bind_expr_list(rc, e.data.array_lit.elems_start, e.data.array_lit.elems_len);
     }
+    if (e.kind == expr.EXPR_KIND_VECTOR_LIT) {
+        val rt: R.Result[bool, str] = bind_type(rc, e.data.vector_lit.ty);
+        if (R.is_err[bool, str](rt)) { ret rt; }
+        ret bind_expr_list(rc, e.data.vector_lit.elems_start, e.data.vector_lit.elems_len);
+    }
     if (e.kind == expr.EXPR_KIND_STRUCT_LIT) {
         val rt: R.Result[bool, str] = bind_type(rc, e.data.struct_lit.ty);
         if (R.is_err[bool, str](rt)) { ret rt; }

--- a/src/lang/fe/sema/check.mach
+++ b/src/lang/fe/sema/check.mach
@@ -563,6 +563,8 @@ pub fun byte_size(sc: *context.SemaContext, t: type.TypeId) u32 {
     val k:  type.TypeKind = tp.kind;
     val d:  type.PrimDesc = type.prim_desc(k);
     if (d.class == type.PRIM_CLASS_INT || d.class == type.PRIM_CLASS_FLOAT) { ret d.bits / 8; }
+    # all ten vector shapes are 128-bit (#1965).
+    if (k == type.TYPE_VECTOR) { ret 16; }
     # a raw `ptr`, a typed `*T`, and a function value (a code address) are all
     # pointer-sized, read from the target's pointer width.
     if (k == type.TYPE_PTR || k == type.TYPE_POINTER || k == type.TYPE_FUN) { ret ptr_width(sc); }
@@ -1269,6 +1271,13 @@ fun type_str_len(sc: *context.SemaContext, t: type.TypeId) usize {
     if (k == type.TYPE_ARRAY) {
         ret 1 + decimal_len(tp.data.array.count::usize) + 1 + type_str_len(sc, tp.data.array.base);
     }
+    if (k == type.TYPE_VECTOR) {
+        # `<element>x<lanes>`, e.g. f32x4
+        var el: usize = 0;
+        val ep: O.Option[type.TypeId] = type.prim(?sc.s.types, tp.data.vector.element);
+        if (O.is_some[type.TypeId](ep)) { el = type_str_len(sc, O.unwrap[type.TypeId](ep)); }
+        ret el + 1 + decimal_len(tp.data.vector.lanes::usize);
+    }
     if (k == type.TYPE_REC || k == type.TYPE_UNI) {
         ret name_str_len(sc, tp.data.nominal.name);
     }
@@ -1323,6 +1332,13 @@ fun write_type_str(sc: *context.SemaContext, buf: str, k: usize, t: type.TypeId)
         w = write_decimal(buf, w, tp.data.array.count::usize);
         w = write_char(buf, w, ']');
         ret write_type_str(sc, buf, w, tp.data.array.base);
+    }
+    if (kind == type.TYPE_VECTOR) {
+        var w: usize = k;
+        val ep: O.Option[type.TypeId] = type.prim(?sc.s.types, tp.data.vector.element);
+        if (O.is_some[type.TypeId](ep)) { w = write_type_str(sc, buf, w, O.unwrap[type.TypeId](ep)); }
+        w = write_char(buf, w, 'x');
+        ret write_decimal(buf, w, tp.data.vector.lanes::usize);
     }
     if (kind == type.TYPE_REC || kind == type.TYPE_UNI) {
         ret write_name(sc, buf, k, tp.data.nominal.name);

--- a/src/lang/fe/sema/check.mach
+++ b/src/lang/fe/sema/check.mach
@@ -502,6 +502,12 @@ pub fun check_condition(sc: *context.SemaContext, cond: type.TypeId, span: token
             "a secret may not steer control flow; branching on it leaks through timing. compute branch-free, or `:^` to a public value when disclosure is intended");
         ret false;
     }
+    # a vector (including a comparison mask) is not a scalar truth value (#1965).
+    if (type.is_vector(?sc.s.types, cond)) {
+        report_note(sc, span, "type mismatch: a vector is not a truth value",
+            "a vector, including a comparison mask, is not a scalar condition; reduce it to a scalar before branching");
+        ret false;
+    }
     if (is_integer(sc, cond))    { ret true; }
     report_note(sc, span, "type mismatch: condition must be an integer",
         "mach has no `bool` type; comparisons yield an integer truth value");

--- a/src/lang/fe/sema/infer.mach
+++ b/src/lang/fe/sema/infer.mach
@@ -616,6 +616,13 @@ fun infer_binary(sc: *context.SemaContext, eid: id.ExprId, b: *expr.ExprBinary, 
     val lhs_secret:    bool = type.is_secret(?sc.s.types, lt);
     val either_secret: bool = lhs_secret || type.is_secret(?sc.s.types, rt);
 
+    # vector operands follow the lane-wise op table (#1965), a separate ladder
+    # from the scalar rules below: exact same-shape match, no scalar<->vector
+    # mixing, and no literal unification into a vector.
+    if (type.is_vector(?sc.s.types, lt) || type.is_vector(?sc.s.types, rt)) {
+        ret infer_vector_binary(sc, b.op, lt, rt, either_secret, span);
+    }
+
     # GATE: `/` and `%` are variable-latency on every target (the leakage model
     # always observes them), so a secret operand is a compile error here. the
     # float-default and integer-multiply gates are target-CT-capability dependent
@@ -688,6 +695,90 @@ fun infer_binary(sc: *context.SemaContext, eid: id.ExprId, b: *expr.ExprBinary, 
     # arithmetic: ADD, SUB, MUL, DIV, MOD
     if (!operands_ok || !is_numeric(sc, lt)) { type_mismatch(sc, span, lt, rt); ret type.TYPE_ERROR; }
     ret join_secret(sc, lt, either_secret);
+}
+
+# the lane-wise binary operator table for vector operands (#1965)
+#
+# Operands must be the same vector shape (exact TypeId match, no implicit casts,
+# no scalar<->vector mixing). The honest table of what is 1:1 on the SSE2/NEON
+# baselines: float lanes `+ - * /`; integer lanes `+ -` at all widths and `*` on
+# 16-bit lanes only; bitwise `& | ^ << >>` on integer lanes; comparisons yield
+# the same-shape unsigned mask vector. There is no vector `%` and no integer
+# vector `/`. Result secrecy is the join of the operands'.
+# ---
+# sc:            sema context
+# op:            the binary operator
+# lt:            the left operand type
+# rt:            the right operand type
+# either_secret: whether either operand was secret
+# span:          the operator span for diagnostics
+# ret:           the result TypeId, or TYPE_ERROR
+fun infer_vector_binary(sc: *context.SemaContext, op: expr.BinOp, lt: type.TypeId, rt: type.TypeId, either_secret: bool, span: token.Span) type.TypeId {
+    val lbase: type.TypeId = type.strip_secret(?sc.s.types, lt);
+    val rbase: type.TypeId = type.strip_secret(?sc.s.types, rt);
+
+    # both operands must be vectors of exactly the same shape.
+    if (!type.is_vector(?sc.s.types, lt) || !type.is_vector(?sc.s.types, rt) || lbase != rbase) {
+        type_mismatch(sc, span, lt, rt);
+        ret type.TYPE_ERROR;
+    }
+
+    val d: type.PrimDesc = type.prim_desc(type.vector_element(?sc.s.types, lbase));
+    val float_lane: bool = d.class == type.PRIM_CLASS_FLOAT;
+    val int_lane:   bool = d.class == type.PRIM_CLASS_INT;
+
+    # comparisons -> same-shape unsigned mask vector (all-ones / all-zeros lanes).
+    if (op == expr.BIN_EQ || op == expr.BIN_NEQ || op == expr.BIN_LT
+        || op == expr.BIN_LEQ || op == expr.BIN_GT || op == expr.BIN_GEQ) {
+        val mr: R.Result[type.TypeId, str] = type.vector_mask(?sc.s.types, lbase);
+        if (R.is_err[type.TypeId, str](mr)) { ret type.TYPE_ERROR; }
+        ret join_secret(sc, R.unwrap_ok[type.TypeId, str](mr), either_secret);
+    }
+
+    # bitwise and shifts require integer lanes.
+    if (op == expr.BIN_BIT_AND || op == expr.BIN_BIT_OR || op == expr.BIN_BIT_XOR
+        || op == expr.BIN_SHL || op == expr.BIN_SHR) {
+        if (!int_lane) {
+            context.report(sc, span, "type mismatch: bitwise vector operands must have integer lanes");
+            ret type.TYPE_ERROR;
+        }
+        ret join_secret(sc, lbase, either_secret);
+    }
+
+    # no vector `%` on any lane type.
+    if (op == expr.BIN_MOD) {
+        context.report(sc, span, "vector `%` is not supported");
+        ret type.TYPE_ERROR;
+    }
+
+    # `/` is float-lane only; integer vector division is not supported.
+    if (op == expr.BIN_DIV) {
+        if (!float_lane) {
+            context.report(sc, span, "integer vector `/` is not supported");
+            ret type.TYPE_ERROR;
+        }
+        ret join_secret(sc, lbase, either_secret);
+    }
+
+    # `*` is float lanes, or 16-bit integer lanes only (pmulld is out of baseline).
+    if (op == expr.BIN_MUL) {
+        if (float_lane || (int_lane && d.bits == 16)) {
+            ret join_secret(sc, lbase, either_secret);
+        }
+        context.report(sc, span, "vector `*` on this lane width is not supported (integer multiply is 16-bit lanes only)");
+        ret type.TYPE_ERROR;
+    }
+
+    # `+` / `-` on float or integer lanes at any width.
+    if (op == expr.BIN_ADD || op == expr.BIN_SUB) {
+        if (float_lane || int_lane) { ret join_secret(sc, lbase, either_secret); }
+        type_mismatch(sc, span, lt, rt);
+        ret type.TYPE_ERROR;
+    }
+
+    # `&&` / `||` and anything else are not lane-wise vector operators.
+    context.report(sc, span, "operator not supported on vector operands");
+    ret type.TYPE_ERROR;
 }
 
 # apply the secrecy JOIN to a binary/unary result base type (#1645)
@@ -846,6 +937,15 @@ fun infer_unary(sc: *context.SemaContext, u: *expr.ExprUnary, span: token.Span) 
         ret join_secret(sc, prim_or_error(sc, type.TYPE_U8), ot_secret);
     }
     if (u.op == expr.UN_BIT_NOT) {
+        # `~v` on an integer-lane vector yields the operand vector type (#1965).
+        if (type.is_vector(?sc.s.types, ot)) {
+            val base: type.TypeId = type.strip_secret(?sc.s.types, ot);
+            if (type.prim_desc(type.vector_element(?sc.s.types, base)).class != type.PRIM_CLASS_INT) {
+                context.report(sc, span, "type mismatch: unary ~ requires integer lanes");
+                ret type.TYPE_ERROR;
+            }
+            ret join_secret(sc, base, ot_secret);
+        }
         if (!is_integer(sc, ot)) { context.report(sc, span, "type mismatch: unary ~ requires an integer operand"); ret type.TYPE_ERROR; }
         ret join_secret(sc, ot, ot_secret);
     }
@@ -1404,9 +1504,52 @@ fun infer_index(sc: *context.SemaContext, ix: *expr.ExprIndex, span: token.Span)
     val it: type.TypeId = infer_expr(sc, ix.index);
     if (ot == type.TYPE_ERROR || it == type.TYPE_ERROR) { ret type.TYPE_ERROR; }
 
+    # lane access `v[i]` on a vector: the index must be a comptime constant in
+    # bounds, and the result is the lane scalar (#1965). a dynamic index is a
+    # defined error, deferred by design (a memory round-trip breaks 1:1 on SSE2).
+    if (type.is_vector(?sc.s.types, ot)) {
+        ret infer_vector_lane(sc, ix, ot, span);
+    }
+
     val r: O.Option[type.TypeId] = check.check_index(sc, ot, it, span);
     if (O.is_none[type.TypeId](r)) { ret type.TYPE_ERROR; }
     ret O.unwrap[type.TypeId](r);
+}
+
+# lane access on a vector: demand a comptime-constant, in-bounds index and yield
+# the lane scalar, joining any secrecy on the vector onto the result (#1965)
+# ---
+# sc:   sema context
+# ix:   the index payload
+# ot:   the (possibly secret) vector object type
+# span: the index span for diagnostics
+# ret:  the lane scalar TypeId, or TYPE_ERROR
+fun infer_vector_lane(sc: *context.SemaContext, ix: *expr.ExprIndex, ot: type.TypeId, span: token.Span) type.TypeId {
+    val base:      type.TypeId = type.strip_secret(?sc.s.types, ot);
+    val lanes:     u32         = type.vector_lanes(?sc.s.types, base);
+    val lane_kind: type.TypeKind = type.vector_element(?sc.s.types, base);
+    val lane_ty:   type.TypeId = prim_or_error(sc, lane_kind);
+
+    val cr: R.Result[comptime.CTValue, str] = comptime.eval(sc.ctx, sc.a, sc.source, ix.index, ?sc.s.interner);
+    if (R.is_err[comptime.CTValue, str](cr)) {
+        context.report(sc, span, "dynamic lane index not supported: a vector lane index must be a comptime constant");
+        ret type.TYPE_ERROR;
+    }
+    val cv: comptime.CTValue = R.unwrap_ok[comptime.CTValue, str](cr);
+    if (cv.kind != comptime.CT_KIND_INT) {
+        context.report(sc, span, "dynamic lane index not supported: a vector lane index must be a comptime constant");
+        ret type.TYPE_ERROR;
+    }
+    if (comptime.ct_is_negative(cv)) {
+        context.report(sc, span, "vector lane index out of bounds: index must be non-negative");
+        ret type.TYPE_ERROR;
+    }
+    if (cv.data.i:~u64 >= lanes::u64) {
+        context.report(sc, span, "vector lane index out of bounds for the lane count");
+        ret type.TYPE_ERROR;
+    }
+
+    ret join_secret(sc, lane_ty, type.is_secret(?sc.s.types, ot));
 }
 
 # MEMBER: a member access is either a qualified module reference `alias.symbol`

--- a/src/lang/fe/sema/infer.mach
+++ b/src/lang/fe/sema/infer.mach
@@ -394,6 +394,9 @@ pub fun infer_expr(sc: *context.SemaContext, eid: id.ExprId) type.TypeId {
     or (e.kind == expr.EXPR_KIND_STRUCT_LIT) {
         t = infer_struct_lit(sc, ?e.data.struct_lit, e.span);
     }
+    or (e.kind == expr.EXPR_KIND_VECTOR_LIT) {
+        t = infer_vector_lit(sc, ?e.data.vector_lit, e.span);
+    }
     or {
         t = type.TYPE_ERROR;
     }
@@ -1644,6 +1647,47 @@ fun infer_array_lit(sc: *context.SemaContext, al: *expr.ExprArrayLit, span: toke
         context.report(sc, span, "array literal: too few elements for declared length");
     }
     ret arr_ty;
+}
+
+# VECTOR_LIT: result is the declared vector type; each element is checked against
+# the lane scalar and the element count must equal the lane count exactly (#1965)
+#
+# Mirrors infer_array_lit: full-arity, positional, one value per lane. Splat
+# (`f32x4{1.0}` broadcast) is deferred (#2019).
+# ---
+# sc:   sema context
+# vl:   the vector-literal payload
+# span: the literal span for diagnostics
+# ret:  the vector TypeId
+fun infer_vector_lit(sc: *context.SemaContext, vl: *expr.ExprVectorLit, span: token.Span) type.TypeId {
+    val vec_ty: type.TypeId = context.resolved_type_of(sc, vl.ty);
+
+    var lane_ty:  type.TypeId = type.TYPE_ERROR;
+    var lanes:    u32         = 0;
+    var is_vec:   bool        = false;
+    if (type.is_vector(?sc.s.types, vec_ty)) {
+        is_vec  = true;
+        lanes   = type.vector_lanes(?sc.s.types, vec_ty);
+        lane_ty = prim_or_error(sc, type.vector_element(?sc.s.types, vec_ty));
+    }
+
+    var i: u32 = 0;
+    for (i < vl.elems_len) {
+        val ee: id.ExprId   = sc.a.expr_ids[vl.elems_start + i];
+        val et: type.TypeId = infer_expr(sc, ee);
+        if (is_vec && lane_ty != type.TYPE_ERROR && et != type.TYPE_ERROR) {
+            check.check_coercible(sc, lane_ty, ee, et, span);
+        }
+        i = i + 1;
+    }
+
+    if (is_vec && vl.elems_len > lanes) {
+        context.report(sc, span, "vector literal: too many elements for the lane count");
+    }
+    or (is_vec && vl.elems_len < lanes) {
+        context.report(sc, span, "vector literal: too few elements for the lane count");
+    }
+    ret vec_ty;
 }
 
 # STRUCT_LIT: result is the named record type; each field initializer is checked

--- a/src/lang/fe/sema/infer.mach
+++ b/src/lang/fe/sema/infer.mach
@@ -1804,12 +1804,11 @@ fun infer_array_lit(sc: *context.SemaContext, al: *expr.ExprArrayLit, span: toke
 # ret:  the vector TypeId
 fun infer_vector_lit(sc: *context.SemaContext, vl: *expr.ExprVectorLit, span: token.Span) type.TypeId {
     val vec_ty: type.TypeId = context.resolved_type_of(sc, vl.ty);
+    val is_vec: bool        = type.is_vector(?sc.s.types, vec_ty);
 
-    var lane_ty:  type.TypeId = type.TYPE_ERROR;
-    var lanes:    u32         = 0;
-    var is_vec:   bool        = false;
-    if (type.is_vector(?sc.s.types, vec_ty)) {
-        is_vec  = true;
+    var lane_ty: type.TypeId = type.TYPE_ERROR;
+    var lanes:   u32         = 0;
+    if (is_vec) {
         lanes   = type.vector_lanes(?sc.s.types, vec_ty);
         lane_ty = prim_or_error(sc, type.vector_element(?sc.s.types, vec_ty));
     }
@@ -1824,10 +1823,20 @@ fun infer_vector_lit(sc: *context.SemaContext, vl: *expr.ExprVectorLit, span: to
         i = i + 1;
     }
 
-    if (is_vec && vl.elems_len > lanes) {
+    # a positional-brace body `T{a, b, ...}` is only a vector literal; a non-vector
+    # prefix (`Point{1, 2}`, `i32{5}`) is a specific error, never a silent accept.
+    # a record is constructed with named fields and an array with a `[N]T` prefix.
+    if (!is_vec) {
+        if (vec_ty != type.TYPE_ERROR) {
+            check.report_typed(sc, span, "positional-brace literal requires a vector type; `", vec_ty, "` is not a vector (a record uses named fields, an array a `[N]T` prefix)", "positional-brace literal requires a vector type");
+        }
+        ret type.TYPE_ERROR;
+    }
+
+    if (vl.elems_len > lanes) {
         context.report(sc, span, "vector literal: too many elements for the lane count");
     }
-    or (is_vec && vl.elems_len < lanes) {
+    or (vl.elems_len < lanes) {
         context.report(sc, span, "vector literal: too few elements for the lane count");
     }
     ret vec_ty;

--- a/src/lang/fe/sema/infer.mach
+++ b/src/lang/fe/sema/infer.mach
@@ -520,6 +520,10 @@ fun report_never_value(sc: *context.SemaContext, eid: id.ExprId, sym: *resolve.S
         check.report_named(sc, span, "`", sym.name, "` is a primitive type, not a value; write a literal of that type", "a primitive type is not a value");
         ret true;
     }
+    if (sym.kind == resolve.SYM_VECTOR) {
+        check.report_named(sc, span, "`", sym.name, "` is a vector type, not a value; write a literal of that type", "a vector type is not a value");
+        ret true;
+    }
 
     # a local type declaration carries its kind on the symbol; an imported one is
     # uniformly SYM_IMPORTED and is classified by its origin decl.
@@ -1749,6 +1753,10 @@ fun resolve_type_named(sc: *context.SemaContext, tid: id.TypeId, named: *atype.T
 fun type_for_symbol(sc: *context.SemaContext, sym: *resolve.Symbol, span: token.Span) type.TypeId {
     if (sym.kind == resolve.SYM_PRIM) {
         ret prim_or_error(sc, sym.slot::type.TypeKind);
+    }
+    # a vector symbol carries the pre-interned semantic vector TypeId in `slot`.
+    if (sym.kind == resolve.SYM_VECTOR) {
+        ret sym.slot::type.TypeId;
     }
     if (sym.kind == resolve.SYM_GENERIC) {
         val r: R.Result[type.TypeId, str] = type.intern_generic_param(?sc.s.types, sym.name, sym.decl, sym.slot);

--- a/src/lang/manifest.mach
+++ b/src/lang/manifest.mach
@@ -2053,11 +2053,11 @@ test "mach.lang.manifest.parse:unknown_keys" {
     ret code;
 }
 
-# #2013 bootstrap staging: the strict parser ACCEPTS and value-validates `simd`
-# on a declared profile but does NOT yet require it -- "scalarize"/"require" parse
-# and store, an absent key is tolerated, and only an invalid value is rejected.
-# the required-everywhere flip lands with #2013 once this compiler is the seed
-test "mach.lang.manifest.parse:simd_accepted_not_required" {
+# #2013: `simd` is required and value-validated on a declared root profile --
+# "scalarize"/"require" parse and store, an absent key under as_root is the
+# missing-required-key error, and an invalid value is rejected (the require-flip
+# over the seed-staging accept; owner ruling 1)
+test "mach.lang.manifest.parse:simd_required_and_validated" {
     var backing: A.Allocator; var ar: arena.Arena; var alloc: A.Allocator; var itn: intern.Interner;
     if (!tinit(?backing, ?ar, ?alloc, ?itn)) { ret 1; }
     var code: i32 = 0;
@@ -2073,10 +2073,9 @@ test "mach.lang.manifest.parse:simd_accepted_not_required" {
     if (R.is_err[Manifest, str](b)) { code = 1; }
     or { if (R.unwrap_ok[Manifest, str](b).profiles[0].simd != SIMD_REQUIRE) { code = 1; } }
 
-    # an absent key is tolerated in this stage (not yet required) and defaults to scalarize.
+    # an absent key on a declared root profile is the missing-required-key error.
     val c: R.Result[Manifest, str] = tparse(?alloc, ?itn, cc(?alloc, head, "[profile.p]\nopt=0\ndebug=false\n"));
-    if (R.is_err[Manifest, str](c)) { code = 1; }
-    or { if (R.unwrap_ok[Manifest, str](c).profiles[0].simd != SIMD_SCALARIZE) { code = 1; } }
+    if (R.is_ok[Manifest, str](c) || !str_contains(R.unwrap_err[Manifest, str](c), "[profile.p] is missing required key 'simd'")) { code = 1; }
 
     # an invalid value is rejected with the specific error.
     val d: R.Result[Manifest, str] = tparse(?alloc, ?itn, cc(?alloc, head, "[profile.p]\nopt=0\ndebug=false\nsimd=\"bogus\"\n"));

--- a/src/lang/manifest.mach
+++ b/src/lang/manifest.mach
@@ -35,12 +35,8 @@ pub val MOPT_RELEASE: MOpt = 2;
 
 # the SIMD strictness lever a declared profile sets (#1965): on a target without
 # the hardware vector unit, "scalarize" emits a defined unrolled expansion while
-# "require" fails the build.
-#
-# BOOTSTRAP STAGING (#2013 seed gate): this stage makes the strict parser ACCEPT
-# and validate the key without requiring it, so a swept manifest parses cleanly
-# under this compiler once it becomes the seed. The required-everywhere flip (per
-# owner ruling 1) lands with #2013 itself; resolution and enforcement are #2017.
+# "require" fails the build. this child parses, validates, and stores the key on
+# ProfileDef only; resolution, the default posture, and enforcement are #2017
 pub def SimdMode: u8;
 
 pub val SIMD_SCALARIZE: SimdMode = 0;
@@ -425,13 +421,13 @@ fun debug_err(alloc: *A.Allocator, name: str, v: *toml.Value) str {
         opt_value_text(alloc, v), ")");
 }
 
-# parse a profile's `simd` strictness lever (#1965). BOOTSTRAP STAGING (#2013):
-# the key is ACCEPTED and value-validated ("scalarize"|"require", rejected
-# otherwise) but NOT yet required — an absent key defaults to scalarize on every
-# path. The required-everywhere flip (owner ruling 1) lands with #2013 once this
-# compiler is the seed
+# parse a profile's required `simd` strictness lever (#1965), mirroring
+# parse_debug_flag's totality gate: as-root, an absent key is the same missing-
+# required-key error, and off-root (a dependency's permissively-parsed manifest)
+# it defaults to scalarize. only "scalarize" / "require" are valid values
 fun parse_simd_mode(alloc: *A.Allocator, name: str, sub: *toml.Table, as_root: bool) R.Result[SimdMode, str] {
     val v: *toml.Value = toml.get(sub, "simd");
+    if (v == nil && as_root)       { ret R.err[SimdMode, str](cc3(alloc, "mach.toml: [profile.", name, "] is missing required key 'simd'")); }
     if (v == nil)                  { ret R.ok[SimdMode, str](SIMD_SCALARIZE); }
     if (v.tag != toml.TYPE_STRING) { ret R.err[SimdMode, str](simd_err(alloc, name, v)); }
     if (str_equals(v.data.string, "scalarize")) { ret R.ok[SimdMode, str](SIMD_SCALARIZE); }
@@ -1899,7 +1895,7 @@ pub fun check_collisions(alloc: *A.Allocator, itn: *intern.Interner, m: *Manifes
 # --- test helper / scaffolding ---
 
 fun demo_src() str {
-    ret "[project]\nid = \"demo\"\nversion = \"0.1.0\"\nsrc = \"src\"\nout = \"out/{target.name}/{profile.name}\"\n\n[target.linux]\nisa = \"x86_64\"\nos = \"linux\"\nabi = \"sysv64\"\n\n[target.windows]\nisa = \"x86_64\"\nos = \"windows\"\nabi = \"win64\"\n\n[artifact.ls]\nkind = \"bin\"\nentry = \"bin/ls.mach\"\nout = \"bin/ls\"\ntargets = [\"*\"]\nlink = []\nneed = []\n\n[artifact.cat]\nkind = \"bin\"\nentry = \"bin/cat.mach\"\nout = \"bin/cat\"\ntargets = [\"*\"]\nlink = []\nneed = []\n\n[profile.debug]\nopt = 0\ndebug = false\n\n[profile.release]\nopt = 2\ndebug = false\n\n[dep.mach-std]\ngit = \"https://github.com/briar-systems/mach-std\"\nref = \"v0.4.0\"\n";
+    ret "[project]\nid = \"demo\"\nversion = \"0.1.0\"\nsrc = \"src\"\nout = \"out/{target.name}/{profile.name}\"\n\n[target.linux]\nisa = \"x86_64\"\nos = \"linux\"\nabi = \"sysv64\"\n\n[target.windows]\nisa = \"x86_64\"\nos = \"windows\"\nabi = \"win64\"\n\n[artifact.ls]\nkind = \"bin\"\nentry = \"bin/ls.mach\"\nout = \"bin/ls\"\ntargets = [\"*\"]\nlink = []\nneed = []\n\n[artifact.cat]\nkind = \"bin\"\nentry = \"bin/cat.mach\"\nout = \"bin/cat\"\ntargets = [\"*\"]\nlink = []\nneed = []\n\n[profile.debug]\nopt = 0\ndebug = false\nsimd = \"scalarize\"\n\n[profile.release]\nopt = 2\ndebug = false\nsimd = \"scalarize\"\n\n[dep.mach-std]\ngit = \"https://github.com/briar-systems/mach-std\"\nref = \"v0.4.0\"\n";
 }
 
 fun host_target_stanza(alloc: *A.Allocator, name: str) str {
@@ -2162,7 +2158,7 @@ test "mach.lang.manifest.resolve_build_unit:default_profile" {
     var code: i32 = 0;
 
     # only [profile.debug] declared -> the empty profile selector resolves 'debug'
-    var s1: str = "[project]\nid=\"x\"\nversion=\"1\"\nsrc=\"src\"\nout=\"out/{profile.name}\"\n[artifact.app]\nkind=\"bin\"\nentry=\"main.mach\"\nout=\"bin/app\"\ntargets=[\"*\"]\nlink = []\nneed = []\n[profile.debug]\nopt=0\ndebug = false\n";
+    var s1: str = "[project]\nid=\"x\"\nversion=\"1\"\nsrc=\"src\"\nout=\"out/{profile.name}\"\n[artifact.app]\nkind=\"bin\"\nentry=\"main.mach\"\nout=\"bin/app\"\ntargets=[\"*\"]\nlink = []\nneed = []\n[profile.debug]\nopt=0\ndebug = false\nsimd = \"scalarize\"\n";
     s1 = cc(?alloc, s1, host_target_stanza(?alloc, "h"));
     val r1: R.Result[Manifest, str] = tparse(?alloc, ?itn, s1);
     if (R.is_err[Manifest, str](r1)) { code = 1; }
@@ -2563,11 +2559,15 @@ test "mach.lang.manifest.parse:strict_totality" {
     var code: i32 = 0;
     val head: str = "[project]\nid=\"x\"\nversion=\"1\"\nsrc=\"src\"\nout=\"out\"\n";
 
-    # profile spells opt + debug
-    val p_opt: R.Result[Manifest, str] = tparse(?alloc, ?itn, cc(?alloc, head, "[profile.p]\ndebug=false\n"));
+    # profile spells opt + debug + simd (#1965)
+    val p_opt: R.Result[Manifest, str] = tparse(?alloc, ?itn, cc(?alloc, head, "[profile.p]\ndebug=false\nsimd=\"scalarize\"\n"));
     if (R.is_ok[Manifest, str](p_opt) || !str_contains(R.unwrap_err[Manifest, str](p_opt), "[profile.p] is missing required key 'opt'")) { code = 1; }
-    val p_dbg: R.Result[Manifest, str] = tparse(?alloc, ?itn, cc(?alloc, head, "[profile.p]\nopt=0\n"));
+    val p_dbg: R.Result[Manifest, str] = tparse(?alloc, ?itn, cc(?alloc, head, "[profile.p]\nopt=0\nsimd=\"scalarize\"\n"));
     if (R.is_ok[Manifest, str](p_dbg) || !str_contains(R.unwrap_err[Manifest, str](p_dbg), "[profile.p] is missing required key 'debug'")) { code = 1; }
+    val p_simd: R.Result[Manifest, str] = tparse(?alloc, ?itn, cc(?alloc, head, "[profile.p]\nopt=0\ndebug=false\n"));
+    if (R.is_ok[Manifest, str](p_simd) || !str_contains(R.unwrap_err[Manifest, str](p_simd), "[profile.p] is missing required key 'simd'")) { code = 1; }
+    val p_simd_bad: R.Result[Manifest, str] = tparse(?alloc, ?itn, cc(?alloc, head, "[profile.p]\nopt=0\ndebug=false\nsimd=\"bogus\"\n"));
+    if (R.is_ok[Manifest, str](p_simd_bad) || !str_contains(R.unwrap_err[Manifest, str](p_simd_bad), "simd must be \"scalarize\" or \"require\"")) { code = 1; }
 
     # artifact spells link + need
     val a_link: R.Result[Manifest, str] = tparse(?alloc, ?itn, cc(?alloc, head, "[artifact.a]\nkind=\"bin\"\nentry=\"m.mach\"\nout=\"bin/a\"\ntargets=[\"*\"]\n"));

--- a/src/lang/me/ir/builder.mach
+++ b/src/lang/me/ir/builder.mach
@@ -939,6 +939,23 @@ fun emit_compare(b: *Builder, k: instruction.InstrKind, lhs: value.Value, rhs: v
     ret emit_value_instr(b, k, bool_ty, ?ops[0], 2);
 }
 
+# emit a comparison with an explicit result type, for a lane-wise vector compare
+# whose result is the same-shape unsigned mask vector rather than an 8-bit
+# boolean (#1965). reuses the OP_CMP_* opcodes; only the result type differs
+# ---
+# b:         the builder
+# k:         the comparison opcode to emit
+# lhs:       left operand
+# rhs:       right operand
+# result_ty: the mask vector result type
+# ret:       a value of type `result_ty`, or an error
+pub fun emit_vcompare(b: *Builder, k: instruction.InstrKind, lhs: value.Value, rhs: value.Value, result_ty: type.IrTypeId) R.Result[value.Value, str] {
+    var ops: [2]value.Value;
+    ops[0] = lhs;
+    ops[1] = rhs;
+    ret emit_value_instr(b, k, result_ty, ?ops[0], 2);
+}
+
 # shared body for a void terminator that carries no operands (ret-void,
 # unreachable)
 # ---

--- a/src/lang/me/ir/printer.mach
+++ b/src/lang/me/ir/printer.mach
@@ -392,6 +392,14 @@ pub fun print_type(out: *writer.Writer, m: *ir.Module, tid: type.IrTypeId) R.Res
         if (R.is_err[bool, str](res_close)) { ret res_close; }
         ret print_type(out, m, t.data.array_.element);
     }
+    if (t.kind == type.IRT_VECTOR) {
+        # `<element>x<lanes>`, e.g. f32x4
+        val res_elem: R.Result[bool, str] = print_type(out, m, t.data.vector_.element);
+        if (R.is_err[bool, str](res_elem)) { ret res_elem; }
+        val res_x: R.Result[bool, str] = emit_str(out, "x");
+        if (R.is_err[bool, str](res_x)) { ret res_x; }
+        ret emit_u64(out, t.data.vector_.lanes::u64);
+    }
     if (t.kind == type.IRT_STRUCT || t.kind == type.IRT_UNION) {
         var open: str = "{";
         if (t.kind == type.IRT_UNION) { open = "uni{"; }

--- a/src/lang/me/ir/type.mach
+++ b/src/lang/me/ir/type.mach
@@ -257,6 +257,20 @@ pub fun is_float_scalar(t: *IrTypeTable, id: IrTypeId) bool {
     ret O.unwrap[*IrType](opt_get).kind == IRT_FLOAT;
 }
 
+# whether a type is a 128-bit vector (#1965)
+#
+# The single classifier the backend consults to route a vector value to the
+# vector register bank and to guard against it reaching unimplemented selection.
+# ---
+# t:   the table
+# id:  the IrTypeId to classify
+# ret: true only for IRT_VECTOR
+pub fun is_vector(t: *IrTypeTable, id: IrTypeId) bool {
+    val opt_get: O.Option[*IrType] = get(t, id);
+    if (O.is_none[*IrType](opt_get)) { ret false; }
+    ret O.unwrap[*IrType](opt_get).kind == IRT_VECTOR;
+}
+
 # intern the void type
 # ---
 # t:   the table

--- a/src/lang/me/ir/type.mach
+++ b/src/lang/me/ir/type.mach
@@ -65,6 +65,9 @@ pub val IRT_FN:     IrTypeKind = 6;
 # a union: its members overlap at offset 0; size is the max member size and
 # align the max member align. shares the struct payload (the member type list)
 pub val IRT_UNION:  IrTypeKind = 7;
+# a 128-bit SIMD vector of `lanes` elements of `element` (#1965). register-class,
+# not aggregate: it flows in one vector register, 16-byte size and alignment
+pub val IRT_VECTOR: IrTypeKind = 8;
 
 # array payload: an element type and a fixed element count, stored inline so an
 # array is keyed by structural identity in the dedup map like every other kind
@@ -74,6 +77,16 @@ pub val IRT_UNION:  IrTypeKind = 7;
 pub rec IrTypeArray {
     element: IrTypeId;
     count:   u32;
+}
+
+# vector payload: a scalar element type and a lane count, stored inline so a
+# vector is keyed by structural identity in the dedup map (#1965)
+# ---
+# element: scalar element IrTypeId (an IRT_INT or IRT_FLOAT)
+# lanes:   number of lanes
+pub rec IrTypeVector {
+    element: IrTypeId;
+    lanes:   u32;
 }
 
 # struct payload: an ordered, inline-stored list of field types
@@ -112,6 +125,7 @@ pub rec IrType {
     data: uni {
         bits:    u32;
         array_:  IrTypeArray;
+        vector_: IrTypeVector;
         struct_: IrTypeStruct;
         fn:      IrTypeFn;
     };
@@ -303,6 +317,20 @@ pub fun intern_array(t: *IrTypeTable, element: IrTypeId, count: u32) R.Result[Ir
     ret intern_inline(t, ir);
 }
 
+# intern a 128-bit vector type (#1965)
+# ---
+# t:       the table
+# element: scalar element IrTypeId (an IRT_INT or IRT_FLOAT)
+# lanes:   number of lanes
+# ret:     the IrTypeId for the vector, or an allocation error
+pub fun intern_vector(t: *IrTypeTable, element: IrTypeId, lanes: u32) R.Result[IrTypeId, str] {
+    var ir: IrType;
+    ir.kind                 = IRT_VECTOR;
+    ir.data.vector_.element = element;
+    ir.data.vector_.lanes   = lanes;
+    ret intern_inline(t, ir);
+}
+
 # intern a struct type, copying the field list into table-owned storage and
 # deduplicating structurally against existing struct entries
 # ---
@@ -383,6 +411,8 @@ pub fun byte_size(t: *IrTypeTable, id: IrTypeId, tgt: *target.Target) u32 {
     if (ir.kind == IRT_ARRAY) {
         ret byte_size(t, ir.data.array_.element, tgt) * ir.data.array_.count;
     }
+    # all ten vector shapes are 128-bit (#1965).
+    if (ir.kind == IRT_VECTOR) { ret 16; }
 
     if (ir.kind == IRT_STRUCT) {
         var offset: u32 = 0;
@@ -441,6 +471,8 @@ pub fun byte_align(t: *IrTypeTable, id: IrTypeId, tgt: *target.Target) u32 {
     # a function value is a function pointer; align as one.
     if (ir.kind == IRT_PTR || ir.kind == IRT_FN) { ret tgt.arch.pointer_width; }
     if (ir.kind == IRT_ARRAY)                    { ret byte_align(t, ir.data.array_.element, tgt); }
+    # 128-bit vectors are 16-byte aligned (#1965).
+    if (ir.kind == IRT_VECTOR)                   { ret 16; }
 
     if (ir.kind == IRT_STRUCT || ir.kind == IRT_UNION) {
         var align: u32 = 1;
@@ -657,6 +689,11 @@ fun hash_ir_type(p: ptr) u64 {
         h = fnv1a.step_u32(h, ir.data.array_.count);
         ret h;
     }
+    if (ir.kind == IRT_VECTOR) {
+        h = fnv1a.step_u32(h, ir.data.vector_.element);
+        h = fnv1a.step_u32(h, ir.data.vector_.lanes);
+        ret h;
+    }
     if (ir.kind == IRT_STRUCT || ir.kind == IRT_UNION) {
         h = fnv1a.step_u32(h, ir.data.struct_.field_count);
         var i: u32 = 0;
@@ -701,6 +738,10 @@ fun eq_ir_type(pa: ptr, pb: ptr) bool {
     if (a.kind == IRT_ARRAY) {
         ret a.data.array_.element == b.data.array_.element
             && a.data.array_.count == b.data.array_.count;
+    }
+    if (a.kind == IRT_VECTOR) {
+        ret a.data.vector_.element == b.data.vector_.element
+            && a.data.vector_.lanes == b.data.vector_.lanes;
     }
     if (a.kind == IRT_STRUCT || a.kind == IRT_UNION) {
         if (a.data.struct_.field_count != b.data.struct_.field_count) { ret false; }
@@ -787,6 +828,47 @@ test "mach.lang.me.ir.type.intern_struct:align_override" {
     if (byte_align(?types, algty, ?tgt) != 32) { dnit(?types); ret 1; }
     if (byte_size(?types, algty, ?tgt)  != 32) { dnit(?types); ret 1; }
     if (natty == algty)                        { dnit(?types); ret 1; }
+
+    dnit(?types);
+    ret 0;
+}
+
+# IRT_VECTOR interns and dedups by (element, lanes), sizes and aligns to 16, and
+# is register-class (not aggregate) (#1965)
+test "mach.lang.me.ir.type.intern_vector:dedup_size_align" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+    var types: IrTypeTable;
+    if (O.is_some[str](init(?types, ?alloc))) { ret 1; }
+
+    val res_f32: R.Result[IrTypeId, str] = intern_float(?types, 32);
+    if (R.is_err[IrTypeId, str](res_f32)) { dnit(?types); ret 1; }
+    val f32ty: IrTypeId = R.unwrap_ok[IrTypeId, str](res_f32);
+
+    # f32x4 interned twice -> one id (dedup by shape).
+    val r1: R.Result[IrTypeId, str] = intern_vector(?types, f32ty, 4);
+    val r2: R.Result[IrTypeId, str] = intern_vector(?types, f32ty, 4);
+    if (R.is_err[IrTypeId, str](r1)) { dnit(?types); ret 1; }
+    if (R.is_err[IrTypeId, str](r2)) { dnit(?types); ret 1; }
+    val vecty: IrTypeId = R.unwrap_ok[IrTypeId, str](r1);
+    if (vecty != R.unwrap_ok[IrTypeId, str](r2)) { dnit(?types); ret 1; }
+
+    # a different lane count is a distinct type.
+    val res_i8: R.Result[IrTypeId, str] = intern_int(?types, 8);
+    if (R.is_err[IrTypeId, str](res_i8)) { dnit(?types); ret 1; }
+    val r3: R.Result[IrTypeId, str] = intern_vector(?types, R.unwrap_ok[IrTypeId, str](res_i8), 16);
+    if (R.is_err[IrTypeId, str](r3)) { dnit(?types); ret 1; }
+    if (R.unwrap_ok[IrTypeId, str](r3) == vecty) { dnit(?types); ret 1; }
+
+    var arch: isa.IsaVTable;
+    arch.pointer_width = 8;
+    var tgt: target.Target;
+    tgt.arch = ?arch;
+
+    if (byte_size(?types, vecty, ?tgt)  != 16) { dnit(?types); ret 1; }
+    if (byte_align(?types, vecty, ?tgt) != 16) { dnit(?types); ret 1; }
+    # register-class, not aggregate.
+    if (is_aggregate(?types, vecty))           { dnit(?types); ret 1; }
 
     dnit(?types);
     ret 0;

--- a/src/lang/me/ir/verify.mach
+++ b/src/lang/me/ir/verify.mach
@@ -591,6 +591,20 @@ fun check_type_agree(m: *ir.Module, ins: *instruction.Instruction, fi: u32, bid:
             ret push(r, fi, bid, iid, VC_TYPE_AGREE);
         }
     }
+    # vector op result-shape rules (#1965): a lane-wise binary / unary op preserves
+    # the operand vector shape in its result; a comparison yields the same-lane-count
+    # unsigned mask vector (an integer lane of the operand's lane width).
+    if (ins.operand_count >= 1 && type.is_vector(?m.types, ins.operands[0].ty)) {
+        val vt: type.IrTypeId = ins.operands[0].ty;
+        if (is_vector_compare(k)) {
+            if (ins.operand_count == 2 && ins.operands[1].ty != vt)  { ret push(r, fi, bid, iid, VC_TYPE_AGREE); }
+            if (!vector_mask_shape_ok(m, vt, ins.ty))                { ret push(r, fi, bid, iid, VC_TYPE_AGREE); }
+        }
+        or (is_vector_sameshape(k)) {
+            if (ins.operand_count == 2 && ins.operands[1].ty != vt)  { ret push(r, fi, bid, iid, VC_TYPE_AGREE); }
+            if (ins.ty != vt)                                        { ret push(r, fi, bid, iid, VC_TYPE_AGREE); }
+        }
+    }
     if (k == instruction.OP_LOAD && ins.operand_count >= 1) {
         if (!is_address_typed(m, ins.operands[0].ty)) { ret push(r, fi, bid, iid, VC_TYPE_AGREE); }
     }
@@ -628,6 +642,55 @@ fun is_binary_agree(k: instruction.InstrKind) bool {
     if (k == instruction.OP_CMP_LT_S || k == instruction.OP_CMP_LT_U)                  { ret true; }
     if (k == instruction.OP_CMP_LE_S || k == instruction.OP_CMP_LE_U)                  { ret true; }
     ret false;
+}
+
+# true for a comparison opcode (its vector form yields the same-shape mask) (#1965)
+# ---
+# k:   the opcode to classify
+# ret: true for the OP_CMP_* family
+fun is_vector_compare(k: instruction.InstrKind) bool {
+    ret k == instruction.OP_CMP_EQ || k == instruction.OP_CMP_NE
+        || k == instruction.OP_CMP_LT_S || k == instruction.OP_CMP_LT_U
+        || k == instruction.OP_CMP_LE_S || k == instruction.OP_CMP_LE_U;
+}
+
+# true for a lane-wise opcode whose vector form preserves the operand shape in its
+# result (arithmetic, bitwise, shift, and the value unary ops) (#1965)
+# ---
+# k:   the opcode to classify
+# ret: true for the shape-preserving vector opcodes
+fun is_vector_sameshape(k: instruction.InstrKind) bool {
+    if (k == instruction.OP_ADD || k == instruction.OP_SUB || k == instruction.OP_MUL) { ret true; }
+    if (k == instruction.OP_DIV_S || k == instruction.OP_DIV_U)                        { ret true; }
+    if (k == instruction.OP_AND || k == instruction.OP_OR || k == instruction.OP_XOR)  { ret true; }
+    if (k == instruction.OP_SHL || k == instruction.OP_SHR_S || k == instruction.OP_SHR_U) { ret true; }
+    if (k == instruction.OP_NEG || k == instruction.OP_NOT)                            { ret true; }
+    ret false;
+}
+
+# whether `result_ty` is the correct comparison-mask shape for vector `vt`: a
+# vector of the same lane count whose lane is an integer of the operand's lane
+# width (the same-shape unsigned mask) (#1965)
+# ---
+# m:         the enclosing module (type-table oracle)
+# vt:        the operand vector type
+# result_ty: the instruction's result type
+# ret:       true when result_ty is the same-lane-count integer mask vector
+fun vector_mask_shape_ok(m: *ir.Module, vt: type.IrTypeId, result_ty: type.IrTypeId) bool {
+    val ov: O.Option[*type.IrType] = type.get(?m.types, vt);
+    val orr: O.Option[*type.IrType] = type.get(?m.types, result_ty);
+    if (!O.is_some[*type.IrType](ov) || !O.is_some[*type.IrType](orr)) { ret false; }
+    val v:  *type.IrType = O.unwrap[*type.IrType](ov);
+    val rr: *type.IrType = O.unwrap[*type.IrType](orr);
+    if (v.kind != type.IRT_VECTOR || rr.kind != type.IRT_VECTOR)  { ret false; }
+    if (v.data.vector_.lanes != rr.data.vector_.lanes)            { ret false; }
+
+    val ove: O.Option[*type.IrType] = type.get(?m.types, v.data.vector_.element);
+    val ore: O.Option[*type.IrType] = type.get(?m.types, rr.data.vector_.element);
+    if (!O.is_some[*type.IrType](ove) || !O.is_some[*type.IrType](ore)) { ret false; }
+    val re: *type.IrType = O.unwrap[*type.IrType](ore);
+    if (re.kind != type.IRT_INT) { ret false; }
+    ret O.unwrap[*type.IrType](ove).data.bits == re.data.bits;
 }
 
 # true when type id `ty` resolves to a type of kind `k` in the module's type table

--- a/src/lang/me/ir/verify.mach
+++ b/src/lang/me/ir/verify.mach
@@ -1870,3 +1870,44 @@ test "mach.lang.me.ir.verify.agg_value_is_address_producing:return_phi" {
     if (t_count(?env, false, true, VC_AGG_ADDRESS) != 0) { ret 1; }
     ret 0;
 }
+
+# the verifier accepts a lane-wise vector binary op (operands share the vector
+# type) and a vector comparison whose result is the same-shape unsigned mask
+# rather than an 8-bit boolean (#1965)
+test "mach.lang.me.ir.verify.check_type_agree:vector_ops_and_mask_compare" {
+    var env: TEnv;
+    if (!t_env(?env)) { ret 1; }
+    val b0: id.BlockId = t_block(?env);
+    if (b0 != 0) { ret 1; }
+
+    # f32x4 and its u32x4-shaped mask.
+    val ef: R.Result[type.IrTypeId, str] = type.intern_float(?env.m.types, 32);
+    if (R.is_err[type.IrTypeId, str](ef)) { ret 1; }
+    val vr: R.Result[type.IrTypeId, str] = type.intern_vector(?env.m.types, R.unwrap_ok[type.IrTypeId, str](ef), 4);
+    if (R.is_err[type.IrTypeId, str](vr)) { ret 1; }
+    val vecty: type.IrTypeId = R.unwrap_ok[type.IrTypeId, str](vr);
+
+    val ei: R.Result[type.IrTypeId, str] = type.intern_int(?env.m.types, 32);
+    if (R.is_err[type.IrTypeId, str](ei)) { ret 1; }
+    val mr: R.Result[type.IrTypeId, str] = type.intern_vector(?env.m.types, R.unwrap_ok[type.IrTypeId, str](ei), 4);
+    if (R.is_err[type.IrTypeId, str](mr)) { ret 1; }
+    val maskty: type.IrTypeId = R.unwrap_ok[type.IrTypeId, str](mr);
+
+    builder.set_block(?env.bld, b0);
+
+    # materialize a vector value through storage, then exercise add and compare.
+    val ar: R.Result[value.Value, str] = builder.emit_alloca(?env.bld, vecty, t_ci(?env, 1));
+    if (R.is_err[value.Value, str](ar)) { ret 1; }
+    val slot: value.Value = R.unwrap_ok[value.Value, str](ar);
+
+    val lr: R.Result[value.Value, str] = builder.emit_load(?env.bld, slot, vecty);
+    if (R.is_err[value.Value, str](lr)) { ret 1; }
+    val v: value.Value = R.unwrap_ok[value.Value, str](lr);
+
+    if (R.is_err[value.Value, str](builder.emit_add(?env.bld, v, v))) { ret 1; }
+    if (R.is_err[value.Value, str](builder.emit_vcompare(?env.bld, instruction.OP_CMP_EQ, v, v, maskty))) { ret 1; }
+    if (R.is_err[bool, str](builder.emit_ret_void(?env.bld))) { ret 1; }
+
+    if (t_total(?env, true, false) != 0) { ret 1; }
+    ret 0;
+}

--- a/src/lang/me/lower/context.mach
+++ b/src/lang/me/lower/context.mach
@@ -942,6 +942,15 @@ pub fun lower_type(lc: *LowerContext, tid: type.TypeId) R.Result[ir_type.IrTypeI
         ret ir_type.intern_array(?lc.m.types, R.unwrap_ok[ir_type.IrTypeId, str](res_base), t.data.array.count);
     }
 
+    # a vector lowers to an IRT_VECTOR over its lowered scalar element (#1965).
+    if (k == type.TYPE_VECTOR) {
+        val ed: type.PrimDesc = type.prim_desc(t.data.vector.element);
+        var res_elem: R.Result[ir_type.IrTypeId, str] = ir_type.intern_int(?lc.m.types, ed.bits);
+        if (ed.class == type.PRIM_CLASS_FLOAT) { res_elem = ir_type.intern_float(?lc.m.types, ed.bits); }
+        if (R.is_err[ir_type.IrTypeId, str](res_elem)) { ret res_elem; }
+        ret ir_type.intern_vector(?lc.m.types, R.unwrap_ok[ir_type.IrTypeId, str](res_elem), t.data.vector.lanes);
+    }
+
     # records, unions, and generic instances all lower to an IR struct of their
     # field layout, read from the session-global field store. a generic instance
     # carries a substituted field table (built by `generics.instantiate`), so it

--- a/src/lang/me/lower/expr.mach
+++ b/src/lang/me/lower/expr.mach
@@ -84,6 +84,7 @@ pub fun lower_rvalue(ctx: *context.LowerContext, eid: id.ExprId) R.Result[value.
     if (k == expr.EXPR_KIND_COMPTIME_IDENT) { ret lower_comptime_path(ctx, eid); }
     if (k == expr.EXPR_KIND_ARRAY_LIT)      { ret lower_array_lit(ctx, eid, e); }
     if (k == expr.EXPR_KIND_STRUCT_LIT)     { ret lower_struct_lit(ctx, eid, e); }
+    if (k == expr.EXPR_KIND_VECTOR_LIT)     { ret lower_vector_lit(ctx, eid, e); }
 
     ret R.err[value.Value, str]("lower: unsupported expression kind in rvalue position");
 }
@@ -2593,6 +2594,69 @@ fun lower_array_lit(ctx: *context.LowerContext, eid: id.ExprId, e: *expr.Expr) R
     # the literal's value IS its storage; retype the slot to the array type so the
     # back end treats it as an aggregate, not a scalar pointer.
     ret R.ok[value.Value, str](value.retype(slot, arr_ir));
+}
+
+# lower a full-arity vector literal `f32x4{a, b, c, d}` (#1965)
+#
+# A vector is register-class, so it cannot be addressed lane-wise like an
+# aggregate; the lanes are assembled through array-shaped backing storage (same
+# 16-byte layout) and loaded back as the vector value. The resulting IRT_VECTOR
+# value flows to the target-generic isel guard until a backend wires real
+# construction.
+# ---
+# ctx: per-module lowering context
+# eid: the vector-literal expression (supplies the vector type)
+# e:   the resolved vector-literal node
+# ret: the assembled IRT_VECTOR value, or an error
+fun lower_vector_lit(ctx: *context.LowerContext, eid: id.ExprId, e: *expr.Expr) R.Result[value.Value, str] {
+    val vec_ty: type.TypeId = context.expr_type_of(ctx, eid);
+    val res_vec_ir: R.Result[ir_type.IrTypeId, str] = context.lower_type(ctx, vec_ty);
+    if (R.is_err[ir_type.IrTypeId, str](res_vec_ir)) { ret R.err[value.Value, str](R.unwrap_err[ir_type.IrTypeId, str](res_vec_ir)); }
+    val vec_ir: ir_type.IrTypeId = R.unwrap_ok[ir_type.IrTypeId, str](res_vec_ir);
+
+    # the lane element IR type and lane count, read off the IRT_VECTOR.
+    val opt_vt: O.Option[*ir_type.IrType] = ir_type.get(?ctx.m.types, vec_ir);
+    if (O.is_none[*ir_type.IrType](opt_vt)) { ret R.err[value.Value, str]("lower: vector literal type is not an IR vector"); }
+    val vt: *ir_type.IrType = O.unwrap[*ir_type.IrType](opt_vt);
+    if (vt.kind != ir_type.IRT_VECTOR) { ret R.err[value.Value, str]("lower: vector literal type is not an IR vector"); }
+    val elem_ir: ir_type.IrTypeId = vt.data.vector_.element;
+    val lanes:   u32              = vt.data.vector_.lanes;
+
+    # array-shaped backing storage; a `[lanes]elem` alloca has the vector's layout.
+    val res_arr_ir: R.Result[ir_type.IrTypeId, str] = ir_type.intern_array(?ctx.m.types, elem_ir, lanes);
+    if (R.is_err[ir_type.IrTypeId, str](res_arr_ir)) { ret R.err[value.Value, str](R.unwrap_err[ir_type.IrTypeId, str](res_arr_ir)); }
+    val arr_ir: ir_type.IrTypeId = R.unwrap_ok[ir_type.IrTypeId, str](res_arr_ir);
+
+    val res_xty: R.Result[ir_type.IrTypeId, str] = index_type(ctx);
+    if (R.is_err[ir_type.IrTypeId, str](res_xty)) { ret R.err[value.Value, str](R.unwrap_err[ir_type.IrTypeId, str](res_xty)); }
+    val xty: ir_type.IrTypeId = R.unwrap_ok[ir_type.IrTypeId, str](res_xty);
+
+    val res_slot: R.Result[value.Value, str] = builder.emit_alloca(?ctx.builder, arr_ir, value.const_int(1, xty));
+    if (R.is_err[value.Value, str](res_slot)) { ret res_slot; }
+    val slot: value.Value = R.unwrap_ok[value.Value, str](res_slot);
+
+    var i: u32 = 0;
+    for (i < e.data.vector_lit.elems_len) {
+        val pool_ix: u32 = e.data.vector_lit.elems_start + i;
+        if (pool_ix::usize >= ctx.a.expr_id_len) {
+            ret R.err[value.Value, str]("lower: vector literal element index out of range");
+        }
+        val elem_eid: id.ExprId = ctx.a.expr_ids[pool_ix];
+        val res_elem: R.Result[value.Value, str] = lower_rvalue(ctx, elem_eid);
+        if (R.is_err[value.Value, str](res_elem)) { ret res_elem; }
+
+        var idx: [2]value.Value;
+        idx[0] = value.const_int(0, xty);
+        idx[1] = value.const_int(i::u64, xty);
+        val res_gep: R.Result[value.Value, str] = builder.emit_gep(?ctx.builder, slot, arr_ir, ?idx[0], 2);
+        if (R.is_err[value.Value, str](res_gep)) { ret res_gep; }
+        val res_store: R.Result[bool, str] = builder.emit_store(?ctx.builder, R.unwrap_ok[value.Value, str](res_elem), R.unwrap_ok[value.Value, str](res_gep));
+        if (R.is_err[bool, str](res_store)) { ret R.err[value.Value, str](R.unwrap_err[bool, str](res_store)); }
+        i = i + 1;
+    }
+
+    # load the assembled lanes back as the vector value.
+    ret builder.emit_load(?ctx.builder, slot, vec_ir);
 }
 
 # lower a struct literal into an alloca plus a per-field store through a gep

--- a/src/lang/me/lower/expr.mach
+++ b/src/lang/me/lower/expr.mach
@@ -36,6 +36,7 @@ use mach.lang.fe.token;
 use mach.lang.intern;
 use mach.lang.me.ir;
 use mach.lang.me.ir.builder;
+use mach.lang.me.ir.instruction;
 use ir_type: mach.lang.me.ir.type;
 use mach.lang.me.ir.value;
 use mach.lang.me.lower.context;
@@ -1831,6 +1832,12 @@ fun lower_binary(ctx: *context.LowerContext, eid: id.ExprId, e: *expr.Expr) R.Re
     val rty:    type.TypeId = context.expr_type_of(ctx, e.data.binary.rhs);
     val signed: bool        = is_signed_type(ctx, lty);
 
+    # a lane-wise vector op rides the shared opcodes carrying a vector type; a
+    # vector comparison diverges to the same-shape unsigned mask result (#1965).
+    if (type.is_vector(?ctx.s.types, lty)) {
+        ret lower_vector_binary(ctx, op, lhs, rhs, lty);
+    }
+
     # comparisons compare mathematical values across any integer signedness /
     # width mix and across float widths. lower_cmp owns the value-correct
     # widening and the irreducible i64/u64 sign-test sequence; the back end's
@@ -1866,6 +1873,108 @@ fun lower_binary(ctx: *context.LowerContext, eid: id.ExprId, e: *expr.Expr) R.Re
     }
 
     ret R.err[value.Value, str]("lower: unsupported binary operator");
+}
+
+# lower a lane-wise vector binary op (#1965)
+#
+# Arithmetic and bitwise ops ride the shared opcodes, carrying the operand vector
+# type through as their result (sema restricts the legal lane/op combinations).
+# Comparisons yield the same-shape unsigned mask. The resulting vector-typed IR is
+# caught by the target-generic MIR guard until a backend wires real selection.
+# ---
+# ctx: per-module lowering context
+# op:  the binary operator
+# lhs: the lowered left operand (vector-typed)
+# rhs: the lowered right operand (vector-typed)
+# lty: the left operand's semantic (vector) type
+# ret: the lowered result Value, or an error
+fun lower_vector_binary(ctx: *context.LowerContext, op: expr.BinOp, lhs: value.Value, rhs: value.Value, lty: type.TypeId) R.Result[value.Value, str] {
+    if (is_compare_binop(op)) { ret lower_vector_compare(ctx, op, lhs, rhs, vector_lane_signed(ctx, lty)); }
+
+    if (op == expr.BIN_ADD)     { ret builder.emit_add(?ctx.builder, lhs, rhs); }
+    if (op == expr.BIN_SUB)     { ret builder.emit_sub(?ctx.builder, lhs, rhs); }
+    if (op == expr.BIN_MUL)     { ret builder.emit_mul(?ctx.builder, lhs, rhs); }
+    # sema admits only float-lane vector `/`; float `/` emits as OP_DIV_U.
+    if (op == expr.BIN_DIV)     { ret builder.emit_div_u(?ctx.builder, lhs, rhs); }
+    if (op == expr.BIN_BIT_AND) { ret builder.emit_and(?ctx.builder, lhs, rhs); }
+    if (op == expr.BIN_BIT_OR)  { ret builder.emit_or(?ctx.builder, lhs, rhs); }
+    if (op == expr.BIN_BIT_XOR) { ret builder.emit_xor(?ctx.builder, lhs, rhs); }
+    if (op == expr.BIN_SHL)     { ret builder.emit_shl(?ctx.builder, lhs, rhs); }
+    if (op == expr.BIN_SHR) {
+        if (vector_lane_signed(ctx, lty)) { ret builder.emit_shr_s(?ctx.builder, lhs, rhs); }
+        ret builder.emit_shr_u(?ctx.builder, lhs, rhs);
+    }
+
+    ret R.err[value.Value, str]("lower: unsupported vector binary operator");
+}
+
+# lower a lane-wise vector comparison to the same-shape unsigned mask (#1965)
+#
+# `>` / `>=` reuse `<` / `<=` with the operands swapped, matching emit_cmp_int.
+# The exact opcode is a placeholder the backend re-selects; the load-bearing part
+# is the mask result type, which flows to the MIR guard.
+# ---
+# ctx:    per-module lowering context
+# op:     the comparison operator
+# lhs:    the lowered left operand
+# rhs:    the lowered right operand
+# signed: whether the lanes are signed integers
+# ret:    the mask-typed result Value, or an error
+fun lower_vector_compare(ctx: *context.LowerContext, op: expr.BinOp, lhs: value.Value, rhs: value.Value, signed: bool) R.Result[value.Value, str] {
+    val res_mask: R.Result[ir_type.IrTypeId, str] = vector_mask_ir(ctx, lhs.ty);
+    if (R.is_err[ir_type.IrTypeId, str](res_mask)) { ret R.err[value.Value, str](R.unwrap_err[ir_type.IrTypeId, str](res_mask)); }
+    val mask: ir_type.IrTypeId = R.unwrap_ok[ir_type.IrTypeId, str](res_mask);
+
+    if (op == expr.BIN_EQ)  { ret builder.emit_vcompare(?ctx.builder, instruction.OP_CMP_EQ, lhs, rhs, mask); }
+    if (op == expr.BIN_NEQ) { ret builder.emit_vcompare(?ctx.builder, instruction.OP_CMP_NE, lhs, rhs, mask); }
+    if (op == expr.BIN_LT)  { ret builder.emit_vcompare(?ctx.builder, vec_cmp_lt(signed), lhs, rhs, mask); }
+    if (op == expr.BIN_LEQ) { ret builder.emit_vcompare(?ctx.builder, vec_cmp_le(signed), lhs, rhs, mask); }
+    if (op == expr.BIN_GT)  { ret builder.emit_vcompare(?ctx.builder, vec_cmp_lt(signed), rhs, lhs, mask); }
+    if (op == expr.BIN_GEQ) { ret builder.emit_vcompare(?ctx.builder, vec_cmp_le(signed), rhs, lhs, mask); }
+    ret R.err[value.Value, str]("lower: unsupported vector comparison operator");
+}
+
+# the OP_CMP_LT opcode for the given lane signedness
+fun vec_cmp_lt(signed: bool) instruction.InstrKind {
+    if (signed) { ret instruction.OP_CMP_LT_S; }
+    ret instruction.OP_CMP_LT_U;
+}
+
+# the OP_CMP_LE opcode for the given lane signedness
+fun vec_cmp_le(signed: bool) instruction.InstrKind {
+    if (signed) { ret instruction.OP_CMP_LE_S; }
+    ret instruction.OP_CMP_LE_U;
+}
+
+# whether a vector semantic type's lanes are signed integers
+fun vector_lane_signed(ctx: *context.LowerContext, lty: type.TypeId) bool {
+    val base: type.TypeId = type.strip_secret(?ctx.s.types, lty);
+    ret type.prim_desc(type.vector_element(?ctx.s.types, base)).signed;
+}
+
+# the same-lane-count unsigned mask IR type for a vector compare result
+#
+# The mask element is a signedness-free IRT_INT of the operand's lane width, so a
+# float-lane operand's mask (e.g. f32x4 -> the u32x4-shaped vector) is a distinct
+# IR type from the operand while an integer-lane operand's mask matches it.
+# ---
+# ctx:    per-module lowering context
+# vec_ir: the operand's IR vector type
+# ret:    the mask IR vector type, or an error
+fun vector_mask_ir(ctx: *context.LowerContext, vec_ir: ir_type.IrTypeId) R.Result[ir_type.IrTypeId, str] {
+    val opt_v: O.Option[*ir_type.IrType] = ir_type.get(?ctx.m.types, vec_ir);
+    if (O.is_none[*ir_type.IrType](opt_v)) { ret R.err[ir_type.IrTypeId, str]("lower: vector compare operand is not an IR vector"); }
+    val vt: *ir_type.IrType = O.unwrap[*ir_type.IrType](opt_v);
+    if (vt.kind != ir_type.IRT_VECTOR) { ret R.err[ir_type.IrTypeId, str]("lower: vector compare operand is not an IR vector"); }
+
+    val opt_e: O.Option[*ir_type.IrType] = ir_type.get(?ctx.m.types, vt.data.vector_.element);
+    if (O.is_none[*ir_type.IrType](opt_e)) { ret R.err[ir_type.IrTypeId, str]("lower: vector element type not resolvable"); }
+    val lane_bits: u32 = O.unwrap[*ir_type.IrType](opt_e).data.bits;
+    val lanes:     u32 = vt.data.vector_.lanes;
+
+    val res_elem: R.Result[ir_type.IrTypeId, str] = ir_type.intern_int(?ctx.m.types, lane_bits);
+    if (R.is_err[ir_type.IrTypeId, str](res_elem)) { ret res_elem; }
+    ret ir_type.intern_vector(?ctx.m.types, R.unwrap_ok[ir_type.IrTypeId, str](res_elem), lanes);
 }
 
 # lower a floating-point remainder `lhs % rhs` to the truncated (C `fmod`) form

--- a/src/lang/target.mach
+++ b/src/lang/target.mach
@@ -532,10 +532,10 @@ test "mach.lang.target.select:linux_riscv64" {
     if (t.abi == nil)            { ret 1; }
     if (t.abi.id != abi.ABI_LP64) { ret 1; }
     val arg: abi.ArgPassingFn = t.abi.arg_passing::abi.ArgPassingFn;
-    val ai: abi.ParamSlot = arg(0, 8, 8, false, 0, false, 0, 0, 0, 0, abi.agg_none());
+    val ai: abi.ParamSlot = arg(0, 8, 8, false, 0, false, false, 0, 0, 0, 0, abi.agg_none());
     if (ai.class != abi.CLASS_GP) { ret 1; }
     if (ai.reg != 10)             { ret 1; }  # a0 = x10
-    val af: abi.ParamSlot = arg(0, 8, 8, true, 0, false, 0, 0, 0, 0, abi.agg_none());
+    val af: abi.ParamSlot = arg(0, 8, 8, true, 0, false, false, 0, 0, 0, 0, abi.agg_none());
     if (af.class != abi.CLASS_FP)                                  { ret 1; }
     if (af.reg != isa.regid_make(isa.REG_CLASS_ID_XMM, 10))        { ret 1; }  # fa0 = f10
     val rp: abi.RetPassingFn = t.abi.ret_passing::abi.RetPassingFn;

--- a/src/lang/target.mach
+++ b/src/lang/target.mach
@@ -714,3 +714,26 @@ test "mach.lang.target.select_of:rejects_os_unsupported_of" {
     if (!str_contains(msg, "elf"))     { ret 1; }
     ret 0;
 }
+
+# the has_v128 SIMD capability fact is a declared MachineModel field reading true
+# on x86_64 (SSE2) and aarch64 (NEON) and false on rv64gc (no vector unit until
+# the V extension), the single fact #2016's scalarize gate and #2017's require
+# gate both consume (#1965)
+test "mach.lang.target.select:has_v128_capability" {
+    var reg: TargetRegistry = registry_init();
+    if (R.is_err[bool, str](register_all(?reg))) { ret 1; }
+
+    val tx: R.Result[resolved.Target, str] = select_of(?reg, "x86_64", "linux", "sysv64", "");
+    if (R.is_err[resolved.Target, str](tx)) { ret 1; }
+    if (!R.unwrap_ok[resolved.Target, str](tx).model.has_v128) { ret 1; }
+
+    val ta: R.Result[resolved.Target, str] = select_of(?reg, "aarch64", "linux", "aapcs64", "");
+    if (R.is_err[resolved.Target, str](ta)) { ret 1; }
+    if (!R.unwrap_ok[resolved.Target, str](ta).model.has_v128) { ret 1; }
+
+    val tr: R.Result[resolved.Target, str] = select_of(?reg, "riscv64", "linux", "lp64", "");
+    if (R.is_err[resolved.Target, str](tr)) { ret 1; }
+    if (R.unwrap_ok[resolved.Target, str](tr).model.has_v128) { ret 1; }
+
+    ret 0;
+}

--- a/src/lang/target.mach
+++ b/src/lang/target.mach
@@ -539,7 +539,7 @@ test "mach.lang.target.select:linux_riscv64" {
     if (af.class != abi.CLASS_FP)                                  { ret 1; }
     if (af.reg != isa.regid_make(isa.REG_CLASS_ID_XMM, 10))        { ret 1; }  # fa0 = f10
     val rp: abi.RetPassingFn = t.abi.ret_passing::abi.RetPassingFn;
-    val rr: abi.ParamSlot = rp(8, 8, false, 0, false, 0, 0, abi.agg_none());
+    val rr: abi.ParamSlot = rp(8, 8, false, 0, false, false, 0, 0, abi.agg_none());
     if (rr.class != abi.CLASS_GP) { ret 1; }
     if (rr.reg != 10)             { ret 1; }  # a0 = x10
 

--- a/src/lang/target.mach
+++ b/src/lang/target.mach
@@ -737,3 +737,31 @@ test "mach.lang.target.select:has_v128_capability" {
 
     ret 0;
 }
+
+# the neutral classify-thread vector flag is zero-behavior in the gate: no backend
+# reads is_vector yet, so an argument / return slot is byte-for-byte identical
+# whether is_vector is true or false. this pins the collision-avoidance substrate
+# as inert until the backend children (#2014/#2015/#2016) consume it (#1965)
+test "mach.lang.target.select:classify_vector_flag_zero_behavior" {
+    var reg: TargetRegistry = registry_init();
+    if (R.is_err[bool, str](register_all(?reg))) { ret 1; }
+    val tx: R.Result[resolved.Target, str] = select_of(?reg, "x86_64", "linux", "sysv64", "");
+    if (R.is_err[resolved.Target, str](tx)) { ret 1; }
+    val t: resolved.Target = R.unwrap_ok[resolved.Target, str](tx);
+
+    val arg: abi.ArgPassingFn = t.abi.arg_passing::abi.ArgPassingFn;
+    val a_no:  abi.ParamSlot = arg(0, 8, 8, false, 0, false, false, 0, 0, 0, 0, abi.agg_none());
+    val a_yes: abi.ParamSlot = arg(0, 8, 8, false, 0, false, true,  0, 0, 0, 0, abi.agg_none());
+    if (a_no.class != a_yes.class) { ret 1; }
+    if (a_no.reg != a_yes.reg)     { ret 1; }
+    if (a_no.size != a_yes.size)   { ret 1; }
+
+    val rp: abi.RetPassingFn = t.abi.ret_passing::abi.RetPassingFn;
+    val r_no:  abi.ParamSlot = rp(8, 8, false, 0, false, false, 0, 0, abi.agg_none());
+    val r_yes: abi.ParamSlot = rp(8, 8, false, 0, false, true,  0, 0, abi.agg_none());
+    if (r_no.class != r_yes.class) { ret 1; }
+    if (r_no.reg != r_yes.reg)     { ret 1; }
+    if (r_no.size != r_yes.size)   { ret 1; }
+
+    ret 0;
+}

--- a/src/lang/target/abi.mach
+++ b/src/lang/target/abi.mach
@@ -220,6 +220,11 @@ pub def ArgPassingFn: fun(i32, u64, u64, bool, u8, bool, bool, i32, i32, u8, u8,
 # is_float:      true if the value is returned in FP registers
 # fp_eightbytes: per-eightbyte SSE mask (bit e -> eightbyte e is SSE class)
 # is_aggregate:  true if the value is an aggregate
+# is_vector:     true for a 128-bit SIMD vector return (#1965). the return-side
+#                twin of ArgPassingFn.is_vector: neutral collision-avoidance
+#                substrate so a by-value vector return's psABI class lands in the
+#                backend children (#2014/#2015/#2016) without racing on this shared
+#                signature; no backend reads it yet
 # hfa_members:   HFA member count (1-4), or 0 if the value is not an HFA
 # hfa_elem:      HFA fundamental member width in bytes (0 if not an HFA)
 # agg:           the <=2-leaf flattened-aggregate descriptor (the lp64d mixed
@@ -227,7 +232,7 @@ pub def ArgPassingFn: fun(i32, u64, u64, bool, u8, bool, bool, i32, i32, u8, u8,
 #                is 0 for any value the descriptor does not apply to, which the AMD64
 #                and AAPCS64 conventions ignore
 # ret:           the placement decision
-pub def RetPassingFn: fun(u64, u64, bool, u8, bool, u8, u8, AggLayout) ParamSlot;
+pub def RetPassingFn: fun(u64, u64, bool, u8, bool, bool, u8, u8, AggLayout) ParamSlot;
 
 # fill a caller-owned `out` buffer with a register bank in canonical order and
 # return the count written. the erased `gp_arg_regs` / `fp_arg_regs` /

--- a/src/lang/target/abi.mach
+++ b/src/lang/target/abi.mach
@@ -195,6 +195,11 @@ pub def ClassifyFn: fun(u64, u64, bool, u8, bool, i32, i32, u8, u8) ParamSlot;
 # is_float:      true if the argument goes in FP registers
 # fp_eightbytes: per-eightbyte SSE mask (bit e -> eightbyte e is SSE class)
 # is_aggregate:  true if the argument is an aggregate
+# is_vector:     true if the argument is a 128-bit SIMD vector (#1965). neutral
+#                collision-avoidance substrate: threaded here so the backend
+#                children (#2014/#2015/#2016) each add only their own psABI
+#                vector-class branch without racing on this shared signature; no
+#                backend reads it yet
 # gp_used:       GP registers already consumed
 # fp_used:       FP registers already consumed
 # hfa_members:   HFA member count (1-4), or 0 if the argument is not an HFA
@@ -204,7 +209,7 @@ pub def ClassifyFn: fun(u64, u64, bool, u8, bool, i32, i32, u8, u8) ParamSlot;
 #                is 0 for any value the descriptor does not apply to, which the AMD64
 #                and AAPCS64 conventions ignore
 # ret:           the placement decision
-pub def ArgPassingFn: fun(i32, u64, u64, bool, u8, bool, i32, i32, u8, u8, AggLayout) ParamSlot;
+pub def ArgPassingFn: fun(i32, u64, u64, bool, u8, bool, bool, i32, i32, u8, u8, AggLayout) ParamSlot;
 
 # assign the registers or sret slot for a return value. arch-specific by
 # selection; `fp_eightbytes` and the HFA descriptor carry the same meaning as in

--- a/src/lang/target/abi/aapcs64.mach
+++ b/src/lang/target/abi/aapcs64.mach
@@ -276,12 +276,14 @@ pub fun classify_arg(index: i32, size: u64, align: u64,
 # is_float:      true if the value is returned in an FP register (scalar floats)
 # fp_eightbytes: per-eightbyte SSE mask (unused -- AAPCS64 routes FP through HFA)
 # is_aggregate:  true if the value is an aggregate
+# is_vector:     true for a 128-bit SIMD vector (#1965); neutral, unread here (the
+#                short-vector-return branch is #2015)
 # hfa_members:   HFA member count (1-4), or 0 if the value is not an HFA
 # hfa_elem:      HFA fundamental member width in bytes (0 if not an HFA)
 # agg:           the flattened-aggregate descriptor (lp64d-only; unused under AAPCS64)
 # ret:           the placement decision
 pub fun classify_return(size: u64, align: u64,
-                        is_float: bool, fp_eightbytes: u8, is_aggregate: bool,
+                        is_float: bool, fp_eightbytes: u8, is_aggregate: bool, is_vector: bool,
                         hfa_members: u8, hfa_elem: u8, agg: abi.AggLayout) abi.ParamSlot {
     if (size == 0) {
         ret abi.make_slot(abi.CLASS_GP, -1, -1, 0, 0);
@@ -513,13 +515,13 @@ test "mach.lang.target.abi.aapcs64.classify_arg:banks_independent" {
 
 # scalar and small-aggregate returns place X0 / V0 / X0:X1
 test "mach.lang.target.abi.aapcs64.classify_return:scalar_and_small_aggregate" {
-    val v: abi.ParamSlot = classify_return(0, 0, false, 0, false, 0, 0, abi.agg_none());
+    val v: abi.ParamSlot = classify_return(0, 0, false, 0, false, false, 0, 0, abi.agg_none());
     if (v.class != abi.CLASS_GP || v.reg != -1) { ret 1; }
-    val i: abi.ParamSlot = classify_return(8, 8, false, 0, false, 0, 0, abi.agg_none());
+    val i: abi.ParamSlot = classify_return(8, 8, false, 0, false, false, 0, 0, abi.agg_none());
     if (i.reg != REG_X0) { ret 1; }
-    val f: abi.ParamSlot = classify_return(8, 8, true, 0, false, 0, 0, abi.agg_none());
+    val f: abi.ParamSlot = classify_return(8, 8, true, 0, false, false, 0, 0, abi.agg_none());
     if (f.class != abi.CLASS_FP || f.reg != fp_param_reg(0)) { ret 1; }
-    val a: abi.ParamSlot = classify_return(16, 8, false, 0, true, 0, 0, abi.agg_none());
+    val a: abi.ParamSlot = classify_return(16, 8, false, 0, true, false, 0, 0, abi.agg_none());
     if (a.pieces[0].reg != REG_X0 || a.pieces[1].reg != REG_X1) { ret 1; }
     ret 0;
 }
@@ -527,16 +529,16 @@ test "mach.lang.target.abi.aapcs64.classify_return:scalar_and_small_aggregate" {
 # an HFA return rides the V0 run, before the sret rule
 test "mach.lang.target.abi.aapcs64.classify_return:hfa_before_sret" {
     # struct { f32, f32, f32 } returns in V0:V1:V2.
-    val s: abi.ParamSlot = classify_return(12, 4, false, 0, true, 3, 4, abi.agg_none());
+    val s: abi.ParamSlot = classify_return(12, 4, false, 0, true, false, 3, 4, abi.agg_none());
     if (s.piece_count     != 3)               { ret 1; }
     if (s.pieces[0].reg   != fp_param_reg(0)) { ret 1; }
     if (s.pieces[0].width != 4)               { ret 1; }
     if (s.pieces[2].reg   != fp_param_reg(2)) { ret 1; }
     # a 4xf64 HFA is 32 bytes yet returns in V0..V3, not via X8 sret.
-    val q: abi.ParamSlot = classify_return(32, 8, false, 0, true, 4, 8, abi.agg_none());
+    val q: abi.ParamSlot = classify_return(32, 8, false, 0, true, false, 4, 8, abi.agg_none());
     if (q.piece_count != 4)       { ret 1; }
     # a >16-byte non-HFA aggregate still returns via the X8 indirect-result register.
-    val r: abi.ParamSlot = classify_return(32, 8, false, 0, true, 0, 0, abi.agg_none());
+    val r: abi.ParamSlot = classify_return(32, 8, false, 0, true, false, 0, 0, abi.agg_none());
     if (r.class != abi.CLASS_SRET || r.reg != REG_X8) { ret 1; }
     ret 0;
 }

--- a/src/lang/target/abi/aapcs64.mach
+++ b/src/lang/target/abi/aapcs64.mach
@@ -167,7 +167,7 @@ pub fun fp_param_reg(index: i32) i32 {
 pub fun classify(size: u64, align: u64, is_float: bool, fp_eightbytes: u8,
                  is_aggregate: bool, gp_used: i32, fp_used: i32,
                  hfa_members: u8, hfa_elem: u8) abi.ParamSlot {
-    ret classify_arg(0, size, align, is_float, fp_eightbytes, is_aggregate, gp_used, fp_used, hfa_members, hfa_elem, abi.agg_none());
+    ret classify_arg(0, size, align, is_float, fp_eightbytes, is_aggregate, false, gp_used, fp_used, hfa_members, hfa_elem, abi.agg_none());
 }
 
 # assign registers or a stack slot for one argument (AAPCS64)
@@ -194,6 +194,8 @@ pub fun classify(size: u64, align: u64, is_float: bool, fp_eightbytes: u8,
 # is_float:      true if the argument goes in an FP register (scalar floats)
 # fp_eightbytes: per-eightbyte SSE mask (unused -- AAPCS64 routes FP through HFA)
 # is_aggregate:  true if the argument is an aggregate
+# is_vector:     true for a 128-bit SIMD vector (#1965); neutral, unread here (the
+#                short-vector branch is #2015)
 # gp_used:       GP registers already consumed
 # fp_used:       FP registers already consumed
 # hfa_members:   HFA member count (1-4), or 0 if the argument is not an HFA
@@ -201,7 +203,7 @@ pub fun classify(size: u64, align: u64, is_float: bool, fp_eightbytes: u8,
 # agg:           the flattened-aggregate descriptor (lp64d-only; unused under AAPCS64)
 # ret:           the placement decision
 pub fun classify_arg(index: i32, size: u64, align: u64,
-                     is_float: bool, fp_eightbytes: u8, is_aggregate: bool,
+                     is_float: bool, fp_eightbytes: u8, is_aggregate: bool, is_vector: bool,
                      gp_used: i32, fp_used: i32, hfa_members: u8, hfa_elem: u8,
                      agg: abi.AggLayout) abi.ParamSlot {
     if (is_aggregate && hfa_members > 0) {
@@ -431,10 +433,10 @@ pub fun register(reg: *abi.AbiRegistry) R.Result[bool, str] {
 
 # a scalar integer takes a GP register; a float takes a V register
 test "mach.lang.target.abi.aapcs64.classify_arg:scalar_register_banks" {
-    val i: abi.ParamSlot = classify_arg(0, 8, 8, false, 0, false, 0, 0, 0, 0, abi.agg_none());
+    val i: abi.ParamSlot = classify_arg(0, 8, 8, false, 0, false, false, 0, 0, 0, 0, abi.agg_none());
     if (i.class != abi.CLASS_GP) { ret 1; }
     if (i.reg != REG_X0)         { ret 1; }
-    val f: abi.ParamSlot = classify_arg(0, 8, 8, true, 0, false, 0, 0, 0, 0, abi.agg_none());
+    val f: abi.ParamSlot = classify_arg(0, 8, 8, true, 0, false, false, 0, 0, 0, 0, abi.agg_none());
     if (f.class != abi.CLASS_FP)  { ret 1; }
     if (f.reg != fp_param_reg(0)) { ret 1; }
     ret 0;
@@ -443,12 +445,12 @@ test "mach.lang.target.abi.aapcs64.classify_arg:scalar_register_banks" {
 # a 16-byte integer aggregate rides a consecutive GP pair; an 8-byte one a single
 # GP register
 test "mach.lang.target.abi.aapcs64.classify_arg:integer_aggregate_gp" {
-    val s: abi.ParamSlot = classify_arg(0, 16, 8, false, 0, true, 0, 0, 0, 0, abi.agg_none());
+    val s: abi.ParamSlot = classify_arg(0, 16, 8, false, 0, true, false, 0, 0, 0, 0, abi.agg_none());
     if (s.class != abi.CLASS_GP)    { ret 1; }
     if (s.piece_count   != 2)       { ret 1; }
     if (s.pieces[0].reg != REG_X0)  { ret 1; }
     if (s.pieces[1].reg != REG_X1)  { ret 1; }
-    val o: abi.ParamSlot = classify_arg(0, 8, 8, false, 0, true, 0, 0, 0, 0, abi.agg_none());
+    val o: abi.ParamSlot = classify_arg(0, 8, 8, false, 0, true, false, 0, 0, 0, 0, abi.agg_none());
     if (o.class != abi.CLASS_GP)    { ret 1; }
     if (o.piece_count   != 1)       { ret 1; }
     if (o.pieces[0].reg != REG_X0)  { ret 1; }
@@ -459,11 +461,11 @@ test "mach.lang.target.abi.aapcs64.classify_arg:integer_aggregate_gp" {
 # bank is exhausted
 test "mach.lang.target.abi.aapcs64.classify_arg:large_aggregate_byref" {
     # a GP register remains: the hidden pointer rides it.
-    val s: abi.ParamSlot = classify_arg(0, 32, 8, false, 0, true, 0, 0, 0, 0, abi.agg_none());
+    val s: abi.ParamSlot = classify_arg(0, 32, 8, false, 0, true, false, 0, 0, 0, 0, abi.agg_none());
     if (s.class != abi.CLASS_BYREF) { ret 1; }
     if (s.reg   != REG_X0)          { ret 1; }
     # GP bank exhausted: the pointer is passed on the stack.
-    val e: abi.ParamSlot = classify_arg(0, 32, 8, false, 0, true, 8, 0, 0, 0, abi.agg_none());
+    val e: abi.ParamSlot = classify_arg(0, 32, 8, false, 0, true, false, 8, 0, 0, 0, abi.agg_none());
     if (e.class != abi.CLASS_STACK_BYREF) { ret 1; }
     ret 0;
 }
@@ -472,24 +474,24 @@ test "mach.lang.target.abi.aapcs64.classify_arg:large_aggregate_byref" {
 # the run cannot fit
 test "mach.lang.target.abi.aapcs64.classify_arg:hfa_v_run" {
     # struct { f32, f32 } -> 2 members of 4 bytes in V0:V1.
-    val s: abi.ParamSlot = classify_arg(0, 8, 4, false, 0, true, 0, 0, 2, 4, abi.agg_none());
+    val s: abi.ParamSlot = classify_arg(0, 8, 4, false, 0, true, false, 0, 0, 2, 4, abi.agg_none());
     if (s.piece_count     != 2)               { ret 1; }
     if (s.pieces[0].reg   != fp_param_reg(0)) { ret 1; }
     if (s.pieces[0].width != 4)               { ret 1; }
     if (s.pieces[1].reg   != fp_param_reg(1)) { ret 1; }
     if (s.size != 8)                          { ret 1; }
     # a 4xf64 HFA is 32 bytes yet still rides V0..V3 (HFA precedes the byref rule).
-    val q: abi.ParamSlot = classify_arg(0, 32, 8, false, 0, true, 0, 0, 4, 8, abi.agg_none());
+    val q: abi.ParamSlot = classify_arg(0, 32, 8, false, 0, true, false, 0, 0, 4, 8, abi.agg_none());
     if (q.piece_count     != 4)               { ret 1; }
     if (q.pieces[0].reg   != fp_param_reg(0)) { ret 1; }
     if (q.pieces[0].width != 8)               { ret 1; }
     if (q.pieces[3].reg   != fp_param_reg(3)) { ret 1; }
     # the run starts at the next free V register (NSRN cursor honored).
-    val a: abi.ParamSlot = classify_arg(0, 8, 4, false, 0, true, 0, 5, 2, 4, abi.agg_none());
+    val a: abi.ParamSlot = classify_arg(0, 8, 4, false, 0, true, false, 0, 5, 2, 4, abi.agg_none());
     if (a.pieces[0].reg != fp_param_reg(5)) { ret 1; }
     # all-or-memory: a 3-member HFA cannot fit when only two V registers remain, so
     # the WHOLE aggregate spills by value (no partial V placement).
-    val m: abi.ParamSlot = classify_arg(0, 12, 4, false, 0, true, 0, 6, 3, 4, abi.agg_none());
+    val m: abi.ParamSlot = classify_arg(0, 12, 4, false, 0, true, false, 0, 6, 3, 4, abi.agg_none());
     if (m.class != abi.CLASS_STACK) { ret 1; }
     ret 0;
 }
@@ -497,14 +499,14 @@ test "mach.lang.target.abi.aapcs64.classify_arg:hfa_v_run" {
 # the GP and FP argument banks advance independently
 test "mach.lang.target.abi.aapcs64.classify_arg:banks_independent" {
     # seven GP registers used: a scalar integer still has X7, a float still has V0.
-    val i: abi.ParamSlot = classify_arg(0, 8, 8, false, 0, false, 7, 0, 0, 0, abi.agg_none());
+    val i: abi.ParamSlot = classify_arg(0, 8, 8, false, 0, false, false, 7, 0, 0, 0, abi.agg_none());
     if (i.class != abi.CLASS_GP) { ret 1; }
     if (i.reg != REG_X7)         { ret 1; }
-    val f: abi.ParamSlot = classify_arg(0, 8, 8, true, 0, false, 7, 0, 0, 0, abi.agg_none());
+    val f: abi.ParamSlot = classify_arg(0, 8, 8, true, 0, false, false, 7, 0, 0, 0, abi.agg_none());
     if (f.class != abi.CLASS_FP)  { ret 1; }
     if (f.reg != fp_param_reg(0)) { ret 1; }
     # GP exhausted spills an integer to the stack; the FP bank is untouched.
-    val s: abi.ParamSlot = classify_arg(0, 8, 8, false, 0, false, 8, 0, 0, 0, abi.agg_none());
+    val s: abi.ParamSlot = classify_arg(0, 8, 8, false, 0, false, false, 8, 0, 0, 0, abi.agg_none());
     if (s.class != abi.CLASS_STACK) { ret 1; }
     ret 0;
 }

--- a/src/lang/target/abi/lp64.mach
+++ b/src/lang/target/abi/lp64.mach
@@ -180,7 +180,7 @@ fun make_two_leaf_slot(agg: abi.AggLayout, nf: u32, fp0: i32, fp1: i32, gp0: i32
 pub fun classify(size: u64, align: u64, is_float: bool, fp_eightbytes: u8,
                  is_aggregate: bool, gp_used: i32, fp_used: i32,
                  hfa_members: u8, hfa_elem: u8) abi.ParamSlot {
-    ret classify_arg(0, size, align, is_float, fp_eightbytes, is_aggregate, gp_used, fp_used, hfa_members, hfa_elem, abi.agg_none());
+    ret classify_arg(0, size, align, is_float, fp_eightbytes, is_aggregate, false, gp_used, fp_used, hfa_members, hfa_elem, abi.agg_none());
 }
 
 # assign registers or a stack slot for one argument (lp64d)
@@ -205,6 +205,8 @@ pub fun classify(size: u64, align: u64, is_float: bool, fp_eightbytes: u8,
 # is_float:      true if the argument is a scalar float
 # fp_eightbytes: per-eightbyte SSE mask (unused -- lp64d routes scalars by is_float)
 # is_aggregate:  true if the argument is an aggregate
+# is_vector:     true for a 128-bit SIMD vector (#1965); neutral, unread here (the
+#                lp64 memory-class vector branch is #2016)
 # gp_used:       integer registers already consumed
 # fp_used:       float registers already consumed
 # hfa_members:   homogeneous-float member count; 1 or 2 selects the lp64d hard-float
@@ -215,7 +217,7 @@ pub fun classify(size: u64, align: u64, is_float: bool, fp_eightbytes: u8,
 #                and different-width float-pair rules, field_count 0 otherwise
 # ret:           the placement decision
 pub fun classify_arg(index: i32, size: u64, align: u64,
-                     is_float: bool, fp_eightbytes: u8, is_aggregate: bool,
+                     is_float: bool, fp_eightbytes: u8, is_aggregate: bool, is_vector: bool,
                      gp_used: i32, fp_used: i32, hfa_members: u8, hfa_elem: u8,
                      agg: abi.AggLayout) abi.ParamSlot {
     if (is_aggregate && size > MAX_REG_RET) {
@@ -526,10 +528,10 @@ pub fun register(reg: *abi.AbiRegistry) R.Result[bool, str] {
 # a scalar integer takes an integer argument register; a scalar float takes an fa
 # register
 test "mach.lang.target.abi.lp64.classify_arg:scalar_register_banks" {
-    val i: abi.ParamSlot = classify_arg(0, 8, 8, false, 0, false, 0, 0, 0, 0, abi.agg_none());
+    val i: abi.ParamSlot = classify_arg(0, 8, 8, false, 0, false, false, 0, 0, 0, 0, abi.agg_none());
     if (i.class != abi.CLASS_GP) { ret 1; }
     if (i.reg != REG_A0)         { ret 1; }
-    val f: abi.ParamSlot = classify_arg(0, 8, 8, true, 0, false, 0, 0, 0, 0, abi.agg_none());
+    val f: abi.ParamSlot = classify_arg(0, 8, 8, true, 0, false, false, 0, 0, 0, 0, abi.agg_none());
     if (f.class != abi.CLASS_FP)  { ret 1; }
     if (f.reg != fp_param_reg(0)) { ret 1; }
     ret 0;
@@ -540,18 +542,18 @@ test "mach.lang.target.abi.lp64.classify_arg:scalar_register_banks" {
 test "mach.lang.target.abi.lp64.classify_arg:banks_independent_and_float_fallback" {
     # seven integer registers used: a scalar integer still has a7, a float still
     # has fa0.
-    val i: abi.ParamSlot = classify_arg(0, 8, 8, false, 0, false, 7, 0, 0, 0, abi.agg_none());
+    val i: abi.ParamSlot = classify_arg(0, 8, 8, false, 0, false, false, 7, 0, 0, 0, abi.agg_none());
     if (i.class != abi.CLASS_GP) { ret 1; }
     if (i.reg != REG_A0 + 7)     { ret 1; }
-    val f: abi.ParamSlot = classify_arg(0, 8, 8, true, 0, false, 7, 0, 0, 0, abi.agg_none());
+    val f: abi.ParamSlot = classify_arg(0, 8, 8, true, 0, false, false, 7, 0, 0, 0, abi.agg_none());
     if (f.class != abi.CLASS_FP)  { ret 1; }
     if (f.reg != fp_param_reg(0)) { ret 1; }
     # fa bank exhausted, an integer register remains: the float rides it.
-    val g: abi.ParamSlot = classify_arg(0, 8, 8, true, 0, false, 0, 8, 0, 0, abi.agg_none());
+    val g: abi.ParamSlot = classify_arg(0, 8, 8, true, 0, false, false, 0, 8, 0, 0, abi.agg_none());
     if (g.class != abi.CLASS_GP) { ret 1; }
     if (g.reg != REG_A0)         { ret 1; }
     # both banks exhausted: the float spills to the stack.
-    val s: abi.ParamSlot = classify_arg(0, 8, 8, true, 0, false, 8, 8, 0, 0, abi.agg_none());
+    val s: abi.ParamSlot = classify_arg(0, 8, 8, true, 0, false, false, 8, 8, 0, 0, abi.agg_none());
     if (s.class != abi.CLASS_STACK) { ret 1; }
     ret 0;
 }
@@ -560,21 +562,21 @@ test "mach.lang.target.abi.lp64.classify_arg:banks_independent_and_float_fallbac
 # single integer register; a >16-byte aggregate is passed by reference, on the
 # stack once the integer bank is exhausted
 test "mach.lang.target.abi.lp64.classify_arg:aggregate_placement" {
-    val s: abi.ParamSlot = classify_arg(0, 16, 8, false, 0, true, 0, 0, 0, 0, abi.agg_none());
+    val s: abi.ParamSlot = classify_arg(0, 16, 8, false, 0, true, false, 0, 0, 0, 0, abi.agg_none());
     if (s.class != abi.CLASS_GP)    { ret 1; }
     if (s.piece_count   != 2)       { ret 1; }
     if (s.pieces[0].reg != REG_A0)  { ret 1; }
     if (s.pieces[1].reg != REG_A1)  { ret 1; }
-    val o: abi.ParamSlot = classify_arg(0, 8, 8, false, 0, true, 0, 0, 0, 0, abi.agg_none());
+    val o: abi.ParamSlot = classify_arg(0, 8, 8, false, 0, true, false, 0, 0, 0, 0, abi.agg_none());
     if (o.class != abi.CLASS_GP)    { ret 1; }
     if (o.piece_count   != 1)       { ret 1; }
     if (o.pieces[0].reg != REG_A0)  { ret 1; }
     # >16 bytes with an integer register free: the pointer rides it.
-    val b: abi.ParamSlot = classify_arg(0, 32, 8, false, 0, true, 0, 0, 0, 0, abi.agg_none());
+    val b: abi.ParamSlot = classify_arg(0, 32, 8, false, 0, true, false, 0, 0, 0, 0, abi.agg_none());
     if (b.class != abi.CLASS_BYREF) { ret 1; }
     if (b.reg   != REG_A0)          { ret 1; }
     # >16 bytes with the integer bank exhausted: the pointer is passed on the stack.
-    val e: abi.ParamSlot = classify_arg(0, 32, 8, false, 0, true, 8, 0, 0, 0, abi.agg_none());
+    val e: abi.ParamSlot = classify_arg(0, 32, 8, false, 0, true, false, 8, 0, 0, 0, abi.agg_none());
     if (e.class != abi.CLASS_STACK_BYREF) { ret 1; }
     ret 0;
 }
@@ -585,7 +587,7 @@ test "mach.lang.target.abi.lp64.classify_arg:aggregate_placement" {
 test "mach.lang.target.abi.lp64.classify_arg:aggregate_register_stack_split" {
     # seven integer registers used (a7 free): the low eightbyte rides a7, the high
     # eightbyte rides an outgoing stack slot.
-    val sp: abi.ParamSlot = classify_arg(0, 16, 8, false, 0, true, 7, 0, 0, 0, abi.agg_none());
+    val sp: abi.ParamSlot = classify_arg(0, 16, 8, false, 0, true, false, 7, 0, 0, 0, abi.agg_none());
     if (sp.class            != abi.CLASS_GP)    { ret 1; }
     if (sp.piece_count      != 2)               { ret 1; }
     if (sp.pieces[0].kind   != abi.PIECE_GP)    { ret 1; }
@@ -594,7 +596,7 @@ test "mach.lang.target.abi.lp64.classify_arg:aggregate_register_stack_split" {
     if (sp.pieces[1].kind   != abi.PIECE_STACK) { ret 1; }
     if (sp.pieces[1].src_off != 8)              { ret 1; }
     # no integer register left (all eight used): the whole aggregate spills by value.
-    val st: abi.ParamSlot = classify_arg(0, 16, 8, false, 0, true, 8, 0, 0, 0, abi.agg_none());
+    val st: abi.ParamSlot = classify_arg(0, 16, 8, false, 0, true, false, 8, 0, 0, 0, abi.agg_none());
     if (st.class != abi.CLASS_STACK)            { ret 1; }
     ret 0;
 }
@@ -604,29 +606,29 @@ test "mach.lang.target.abi.lp64.classify_arg:aggregate_register_stack_split" {
 # falls back to the integer convention
 test "mach.lang.target.abi.lp64.classify_arg:hard_float_struct_flattening" {
     # a single-float struct (8 bytes, one f64 member) rides fa0.
-    val one: abi.ParamSlot = classify_arg(0, 8, 8, false, 0, true, 0, 0, 1, 8, abi.agg_none());
+    val one: abi.ParamSlot = classify_arg(0, 8, 8, false, 0, true, false, 0, 0, 1, 8, abi.agg_none());
     if (one.piece_count     != 1)               { ret 1; }
     if (one.pieces[0].reg   != fp_param_reg(0)) { ret 1; }
     if (one.pieces[0].width != 8)               { ret 1; }
     # a two-float struct (two f32 members) rides fa0:fa1, each 4 bytes.
-    val two: abi.ParamSlot = classify_arg(0, 8, 4, false, 0, true, 0, 0, 2, 4, abi.agg_none());
+    val two: abi.ParamSlot = classify_arg(0, 8, 4, false, 0, true, false, 0, 0, 2, 4, abi.agg_none());
     if (two.piece_count     != 2)               { ret 1; }
     if (two.pieces[0].reg   != fp_param_reg(0)) { ret 1; }
     if (two.pieces[0].width != 4)               { ret 1; }
     if (two.pieces[1].reg   != fp_param_reg(1)) { ret 1; }
     # the float bank advances independently of the integer bank: with six fa
     # registers used, a two-float struct rides the last fa pair (fa6:fa7).
-    val mid: abi.ParamSlot = classify_arg(0, 16, 8, false, 0, true, 3, 6, 2, 8, abi.agg_none());
+    val mid: abi.ParamSlot = classify_arg(0, 16, 8, false, 0, true, false, 3, 6, 2, 8, abi.agg_none());
     if (mid.piece_count   != 2)               { ret 1; }
     if (mid.pieces[0].reg != fp_param_reg(6)) { ret 1; }
     # the fa bank lacks two registers (seven used): the struct falls back to the
     # integer convention (a 9-16 byte pair here), not a cross-bank split.
-    val fall: abi.ParamSlot = classify_arg(0, 16, 8, false, 0, true, 0, 7, 2, 8, abi.agg_none());
+    val fall: abi.ParamSlot = classify_arg(0, 16, 8, false, 0, true, false, 0, 7, 2, 8, abi.agg_none());
     if (fall.class != abi.CLASS_GP)    { ret 1; }
     if (fall.pieces[0].reg != REG_A0)  { ret 1; }
     if (fall.pieces[1].reg != REG_A1)  { ret 1; }
     # a three-float struct is not flattened (hfa_members > 2): the integer convention.
-    val three: abi.ParamSlot = classify_arg(0, 16, 4, false, 0, true, 0, 0, 3, 4, abi.agg_none());
+    val three: abi.ParamSlot = classify_arg(0, 16, 4, false, 0, true, false, 0, 0, 3, 4, abi.agg_none());
     if (three.class != abi.CLASS_GP) { ret 1; }
     ret 0;
 }
@@ -645,7 +647,7 @@ test "mach.lang.target.abi.lp64.classify_arg:mixed_and_diff_width_float_pairs" {
     ff.fields[1].is_float = true;
     ff.fields[1].offset   = 8;
     ff.fields[1].width    = 8;
-    val fp: abi.ParamSlot = classify_arg(0, 16, 8, false, 0, true, 0, 0, 0, 0, ff);
+    val fp: abi.ParamSlot = classify_arg(0, 16, 8, false, 0, true, false, 0, 0, 0, 0, ff);
     if (fp.class             != abi.CLASS_FP)    { ret 1; }
     if (fp.piece_count       != 2)               { ret 1; }
     if (fp.pieces[0].kind    != abi.PIECE_FP)    { ret 1; }
@@ -666,7 +668,7 @@ test "mach.lang.target.abi.lp64.classify_arg:mixed_and_diff_width_float_pairs" {
     fi.fields[1].is_float = false;
     fi.fields[1].offset   = 8;
     fi.fields[1].width    = 8;
-    val mx: abi.ParamSlot = classify_arg(0, 16, 8, false, 0, true, 0, 0, 0, 0, fi);
+    val mx: abi.ParamSlot = classify_arg(0, 16, 8, false, 0, true, false, 0, 0, 0, 0, fi);
     if (mx.class             != abi.CLASS_GP)    { ret 1; }
     if (mx.piece_count       != 2)               { ret 1; }
     if (mx.pieces[0].kind    != abi.PIECE_FP)    { ret 1; }
@@ -678,7 +680,7 @@ test "mach.lang.target.abi.lp64.classify_arg:mixed_and_diff_width_float_pairs" {
 
     # the fa bank is exhausted for the mixed case (fp_used = 8): fall back to the
     # integer convention (a 9-16 byte a0:a1 pair), not a cross-bank piece slot.
-    val fb: abi.ParamSlot = classify_arg(0, 16, 8, false, 0, true, 0, 8, 0, 0, fi);
+    val fb: abi.ParamSlot = classify_arg(0, 16, 8, false, 0, true, false, 0, 8, 0, 0, fi);
     if (fb.class           != abi.CLASS_GP) { ret 1; }
     if (fb.pieces[0].reg   != REG_A0)       { ret 1; }
     if (fb.pieces[1].reg   != REG_A1)       { ret 1; }
@@ -699,7 +701,7 @@ test "mach.lang.target.abi.lp64.classify_arg:mixed_subword_gp_width" {
     fi.fields[1].is_float = false;
     fi.fields[1].offset   = 4;
     fi.fields[1].width    = 4;
-    val a: abi.ParamSlot = classify_arg(0, 8, 4, false, 0, true, 0, 0, 0, 0, fi);
+    val a: abi.ParamSlot = classify_arg(0, 8, 4, false, 0, true, false, 0, 0, 0, 0, fi);
     if (a.class             != abi.CLASS_GP)    { ret 1; }
     if (a.piece_count       != 2)               { ret 1; }
     if (a.pieces[0].kind    != abi.PIECE_FP)    { ret 1; }

--- a/src/lang/target/abi/lp64.mach
+++ b/src/lang/target/abi/lp64.mach
@@ -319,6 +319,8 @@ pub fun classify_arg(index: i32, size: u64, align: u64,
 # is_float:      true if the value is a scalar float
 # fp_eightbytes: per-eightbyte SSE mask (unused -- lp64d routes scalars by is_float)
 # is_aggregate:  true if the value is an aggregate
+# is_vector:     true for a 128-bit SIMD vector (#1965); neutral, unread here (the
+#                lp64 memory-class vector-return branch is #2016)
 # hfa_members:   homogeneous-float member count; 1 or 2 selects the lp64d hard-float
 #                flattening (0 or > 2 falls to the integer convention)
 # hfa_elem:      homogeneous-float fundamental member width (the per-fa-register width)
@@ -327,7 +329,7 @@ pub fun classify_arg(index: i32, size: u64, align: u64,
 #                and different-width float-pair rules, field_count 0 otherwise
 # ret:           the placement decision
 pub fun classify_return(size: u64, align: u64,
-                        is_float: bool, fp_eightbytes: u8, is_aggregate: bool,
+                        is_float: bool, fp_eightbytes: u8, is_aggregate: bool, is_vector: bool,
                         hfa_members: u8, hfa_elem: u8, agg: abi.AggLayout) abi.ParamSlot {
     if (size == 0) {
         ret abi.make_slot(abi.CLASS_GP, -1, -1, 0, 0);
@@ -712,7 +714,7 @@ test "mach.lang.target.abi.lp64.classify_arg:mixed_subword_gp_width" {
     if (a.pieces[1].src_off != 4)               { ret 1; }
     if (a.pieces[1].width   != 4)               { ret 1; }  # the leaf width, not the word
     # the return side mirrors it: fa0 + a0, the integer piece 4 bytes wide.
-    val r: abi.ParamSlot = classify_return(8, 4, false, 0, true, 0, 0, fi);
+    val r: abi.ParamSlot = classify_return(8, 4, false, 0, true, false, 0, 0, fi);
     if (r.class             != abi.CLASS_GP)    { ret 1; }
     if (r.piece_count       != 2)               { ret 1; }
     if (r.pieces[0].kind    != abi.PIECE_FP)    { ret 1; }
@@ -727,18 +729,18 @@ test "mach.lang.target.abi.lp64.classify_arg:mixed_subword_gp_width" {
 # scalar and small-aggregate returns place a0 / fa0 / a0:a1, and a >16-byte
 # aggregate returns through the a0 sret pointer
 test "mach.lang.target.abi.lp64.classify_return:placement" {
-    val v: abi.ParamSlot = classify_return(0, 0, false, 0, false, 0, 0, abi.agg_none());
+    val v: abi.ParamSlot = classify_return(0, 0, false, 0, false, false, 0, 0, abi.agg_none());
     if (v.class != abi.CLASS_GP || v.reg != -1) { ret 1; }
-    val i: abi.ParamSlot = classify_return(8, 8, false, 0, false, 0, 0, abi.agg_none());
+    val i: abi.ParamSlot = classify_return(8, 8, false, 0, false, false, 0, 0, abi.agg_none());
     if (i.reg != REG_A0) { ret 1; }
-    val f: abi.ParamSlot = classify_return(8, 8, true, 0, false, 0, 0, abi.agg_none());
+    val f: abi.ParamSlot = classify_return(8, 8, true, 0, false, false, 0, 0, abi.agg_none());
     if (f.class != abi.CLASS_FP || f.reg != fp_param_reg(0)) { ret 1; }
-    val a: abi.ParamSlot = classify_return(16, 8, false, 0, true, 0, 0, abi.agg_none());
+    val a: abi.ParamSlot = classify_return(16, 8, false, 0, true, false, 0, 0, abi.agg_none());
     if (a.pieces[0].reg != REG_A0 || a.pieces[1].reg != REG_A1) { ret 1; }
-    val r: abi.ParamSlot = classify_return(32, 8, false, 0, true, 0, 0, abi.agg_none());
+    val r: abi.ParamSlot = classify_return(32, 8, false, 0, true, false, 0, 0, abi.agg_none());
     if (r.class != abi.CLASS_SRET || r.reg != REG_A0) { ret 1; }
     # a struct that flattens to two floats returns in the fa0:fa1 run.
-    val h: abi.ParamSlot = classify_return(16, 8, false, 0, true, 2, 8, abi.agg_none());
+    val h: abi.ParamSlot = classify_return(16, 8, false, 0, true, false, 2, 8, abi.agg_none());
     if (h.piece_count     != 2)               { ret 1; }
     if (h.pieces[0].reg   != fp_param_reg(0)) { ret 1; }
     if (h.pieces[0].width != 8)               { ret 1; }
@@ -757,7 +759,7 @@ test "mach.lang.target.abi.lp64.classify_return:mixed_and_diff_width_float_pairs
     ff.fields[1].is_float = true;
     ff.fields[1].offset   = 8;
     ff.fields[1].width    = 8;
-    val fr: abi.ParamSlot = classify_return(16, 8, false, 0, true, 0, 0, ff);
+    val fr: abi.ParamSlot = classify_return(16, 8, false, 0, true, false, 0, 0, ff);
     if (fr.class             != abi.CLASS_FP)    { ret 1; }
     if (fr.piece_count       != 2)               { ret 1; }
     if (fr.pieces[0].kind    != abi.PIECE_FP)    { ret 1; }
@@ -774,7 +776,7 @@ test "mach.lang.target.abi.lp64.classify_return:mixed_and_diff_width_float_pairs
     fi.fields[1].is_float = false;
     fi.fields[1].offset   = 8;
     fi.fields[1].width    = 8;
-    val mr: abi.ParamSlot = classify_return(16, 8, false, 0, true, 0, 0, fi);
+    val mr: abi.ParamSlot = classify_return(16, 8, false, 0, true, false, 0, 0, fi);
     if (mr.class          != abi.CLASS_GP)    { ret 1; }
     if (mr.piece_count    != 2)               { ret 1; }
     if (mr.pieces[0].kind  != abi.PIECE_FP)   { ret 1; }

--- a/src/lang/target/abi/sysv.mach
+++ b/src/lang/target/abi/sysv.mach
@@ -116,7 +116,7 @@ pub fun fp_param_reg(index: i32) i32 {
 pub fun classify(size: u64, align: u64, is_float: bool, fp_eightbytes: u8,
                  is_aggregate: bool, gp_used: i32, fp_used: i32,
                  hfa_members: u8, hfa_elem: u8) abi.ParamSlot {
-    ret classify_arg(0, size, align, is_float, fp_eightbytes, is_aggregate,
+    ret classify_arg(0, size, align, is_float, fp_eightbytes, is_aggregate, false,
                      gp_used, fp_used, hfa_members, hfa_elem, abi.agg_none());
 }
 
@@ -146,6 +146,8 @@ pub fun classify(size: u64, align: u64, is_float: bool, fp_eightbytes: u8,
 # is_float:      true if the argument goes in FP registers (scalar floats)
 # fp_eightbytes: per-eightbyte SSE mask for an aggregate (bit e -> eightbyte e SSE)
 # is_aggregate:  true if the argument is an aggregate
+# is_vector:     true for a 128-bit SIMD vector (#1965); neutral, unread here (the
+#                SSE-class vector branch is #2014)
 # gp_used:       GP registers already consumed
 # fp_used:       FP registers already consumed
 # hfa_members:   HFA member count (AAPCS64-only; unused under SysV)
@@ -153,7 +155,7 @@ pub fun classify(size: u64, align: u64, is_float: bool, fp_eightbytes: u8,
 # agg:           the flattened-aggregate descriptor (lp64d-only; unused under SysV)
 # ret:           the placement decision
 pub fun classify_arg(index: i32, size: u64, align: u64,
-                     is_float: bool, fp_eightbytes: u8, is_aggregate: bool,
+                     is_float: bool, fp_eightbytes: u8, is_aggregate: bool, is_vector: bool,
                      gp_used: i32, fp_used: i32, hfa_members: u8, hfa_elem: u8,
                      agg: abi.AggLayout) abi.ParamSlot {
     if (is_aggregate && size > MAX_REG_RET) {
@@ -427,7 +429,7 @@ pub fun register(reg: *abi.AbiRegistry) R.Result[bool, str] {
 
 # {f64; f64} -> both eightbytes SSE -> the two vector argument registers
 test "mach.lang.target.abi.sysv.classify_arg:all_float_16byte_rides_xmm_pair" {
-    val s: abi.ParamSlot = classify_arg(0, 16, 8, false, 3, true, 0, 0, 0, 0, abi.agg_none());
+    val s: abi.ParamSlot = classify_arg(0, 16, 8, false, 3, true, false, 0, 0, 0, 0, abi.agg_none());
     if (s.class != abi.CLASS_GP)            { ret 1; }
     if (s.piece_count   != 2)               { ret 1; }
     if (s.pieces[0].reg != fp_param_reg(0)) { ret 1; }
@@ -437,7 +439,7 @@ test "mach.lang.target.abi.sysv.classify_arg:all_float_16byte_rides_xmm_pair" {
 
 # {f32; f32} (8 bytes) -> one SSE eightbyte -> XMM0
 test "mach.lang.target.abi.sysv.classify_arg:all_float_8byte_rides_one_xmm" {
-    val s: abi.ParamSlot = classify_arg(0, 8, 4, false, 1, true, 0, 0, 0, 0, abi.agg_none());
+    val s: abi.ParamSlot = classify_arg(0, 8, 4, false, 1, true, false, 0, 0, 0, 0, abi.agg_none());
     if (s.class != abi.CLASS_GP)            { ret 1; }
     if (s.piece_count   != 1)               { ret 1; }
     if (s.pieces[0].reg != fp_param_reg(0)) { ret 1; }
@@ -447,10 +449,10 @@ test "mach.lang.target.abi.sysv.classify_arg:all_float_8byte_rides_one_xmm" {
 # {i64; f64} -> eightbyte 0 INTEGER (RDI), eightbyte 1 SSE (XMM0); the reverse
 # {f64; i64} fills the banks independently, so the integer eightbyte takes RDI
 test "mach.lang.target.abi.sysv.classify_arg:mixed_int_sse_rides_rdi_xmm" {
-    val s: abi.ParamSlot = classify_arg(0, 16, 8, false, 2, true, 0, 0, 0, 0, abi.agg_none());
+    val s: abi.ParamSlot = classify_arg(0, 16, 8, false, 2, true, false, 0, 0, 0, 0, abi.agg_none());
     if (s.pieces[0].reg != REG_RDI)         { ret 1; }
     if (s.pieces[1].reg != fp_param_reg(0)) { ret 1; }
-    val r: abi.ParamSlot = classify_arg(0, 16, 8, false, 1, true, 0, 0, 0, 0, abi.agg_none());
+    val r: abi.ParamSlot = classify_arg(0, 16, 8, false, 1, true, false, 0, 0, 0, 0, abi.agg_none());
     if (r.pieces[0].reg != fp_param_reg(0)) { ret 1; }
     if (r.pieces[1].reg != REG_RDI)         { ret 1; }
     ret 0;
@@ -458,7 +460,7 @@ test "mach.lang.target.abi.sysv.classify_arg:mixed_int_sse_rides_rdi_xmm" {
 
 # {i64; i64} (mask 0) -> RDI:RSI, exactly as before SSE classification
 test "mach.lang.target.abi.sysv.classify_arg:all_integer_rides_gp_pair" {
-    val s: abi.ParamSlot = classify_arg(0, 16, 8, false, 0, true, 0, 0, 0, 0, abi.agg_none());
+    val s: abi.ParamSlot = classify_arg(0, 16, 8, false, 0, true, false, 0, 0, 0, 0, abi.agg_none());
     if (s.pieces[0].reg != REG_RDI) { ret 1; }
     if (s.pieces[1].reg != REG_RSI) { ret 1; }
     ret 0;
@@ -467,7 +469,7 @@ test "mach.lang.target.abi.sysv.classify_arg:all_integer_rides_gp_pair" {
 # with seven XMM registers already used, a two-SSE aggregate needs two but only
 # one remains, so the whole aggregate spills to the stack by value
 test "mach.lang.target.abi.sysv.classify_arg:sse_bank_exhaustion_spills" {
-    val s: abi.ParamSlot = classify_arg(0, 16, 8, false, 3, true, 0, 7, 0, 0, abi.agg_none());
+    val s: abi.ParamSlot = classify_arg(0, 16, 8, false, 3, true, false, 0, 7, 0, 0, abi.agg_none());
     if (s.class != abi.CLASS_STACK) { ret 1; }
     if (s.size  != 16)              { ret 1; }
     ret 0;
@@ -495,10 +497,10 @@ test "mach.lang.target.abi.sysv.classify_return:banks_fill_in_order" {
 
 # a scalar float takes an XMM register, a scalar integer a GP register
 test "mach.lang.target.abi.sysv.classify_arg:scalar_float_xmm_integer_gp" {
-    val f: abi.ParamSlot = classify_arg(0, 8, 8, true, 0, false, 0, 0, 0, 0, abi.agg_none());
+    val f: abi.ParamSlot = classify_arg(0, 8, 8, true, 0, false, false, 0, 0, 0, 0, abi.agg_none());
     if (f.class != abi.CLASS_FP)    { ret 1; }
     if (f.reg   != fp_param_reg(0)) { ret 1; }
-    val i: abi.ParamSlot = classify_arg(0, 8, 8, false, 0, false, 0, 0, 0, 0, abi.agg_none());
+    val i: abi.ParamSlot = classify_arg(0, 8, 8, false, 0, false, false, 0, 0, 0, 0, abi.agg_none());
     if (i.class != abi.CLASS_GP) { ret 1; }
     if (i.reg   != REG_RDI)      { ret 1; }
     ret 0;
@@ -522,19 +524,19 @@ test "mach.lang.target.abi.sysv.register:indirect_result_in_argfile" {
 # return, never an argument
 test "mach.lang.target.abi.sysv.classify_arg:large_aggregate_memory_class_by_value" {
     # all six GP argument registers free: still by value on the stack, no register.
-    val s0: abi.ParamSlot = classify_arg(0, 32, 8, false, 0, true, 0, 0, 0, 0, abi.agg_none());
+    val s0: abi.ParamSlot = classify_arg(0, 32, 8, false, 0, true, false, 0, 0, 0, 0, abi.agg_none());
     if (s0.class != abi.CLASS_STACK) { ret 1; }
     if (s0.reg   != -1)              { ret 1; }
     if (s0.size  != 32)              { ret 1; }
 
     # one GP argument register still free: no hidden pointer, by value on the stack.
-    val s1: abi.ParamSlot = classify_arg(0, 32, 8, false, 0, true, 5, 0, 0, 0, abi.agg_none());
+    val s1: abi.ParamSlot = classify_arg(0, 32, 8, false, 0, true, false, 5, 0, 0, 0, abi.agg_none());
     if (s1.class != abi.CLASS_STACK) { ret 1; }
     if (s1.reg   != -1)              { ret 1; }
     if (s1.size  != 32)              { ret 1; }
 
     # GP argument registers exhausted: by value on the stack, the odd size carried through.
-    val s2: abi.ParamSlot = classify_arg(0, 17, 8, false, 0, true, 6, 0, 0, 0, abi.agg_none());
+    val s2: abi.ParamSlot = classify_arg(0, 17, 8, false, 0, true, false, 6, 0, 0, 0, abi.agg_none());
     if (s2.class != abi.CLASS_STACK) { ret 1; }
     if (s2.reg   != -1)              { ret 1; }
     if (s2.size  != 17)              { ret 1; }

--- a/src/lang/target/abi/sysv.mach
+++ b/src/lang/target/abi/sysv.mach
@@ -233,12 +233,14 @@ pub fun classify_arg(index: i32, size: u64, align: u64,
 # is_float:      true if the value is returned in FP registers (scalar floats)
 # fp_eightbytes: per-eightbyte SSE mask for an aggregate (bit e -> eightbyte e SSE)
 # is_aggregate:  true if the value is an aggregate
+# is_vector:     true for a 128-bit SIMD vector (#1965); neutral, unread here (the
+#                SSE-class vector-return branch is #2014)
 # hfa_members:   HFA member count (AAPCS64-only; unused under SysV)
 # hfa_elem:      HFA fundamental member width (AAPCS64-only; unused under SysV)
 # agg:           the flattened-aggregate descriptor (lp64d-only; unused under SysV)
 # ret:           the placement decision
 pub fun classify_return(size: u64, align: u64,
-                        is_float: bool, fp_eightbytes: u8, is_aggregate: bool,
+                        is_float: bool, fp_eightbytes: u8, is_aggregate: bool, is_vector: bool,
                         hfa_members: u8, hfa_elem: u8, agg: abi.AggLayout) abi.ParamSlot {
     if (size == 0) {
         ret abi.make_slot(abi.CLASS_GP, -1, -1, 0, 0);
@@ -477,10 +479,10 @@ test "mach.lang.target.abi.sysv.classify_arg:sse_bank_exhaustion_spills" {
 
 # {f64; f64} returns in XMM0:XMM1; one all-float eightbyte returns in XMM0
 test "mach.lang.target.abi.sysv.classify_return:all_float_returns_xmm_pair" {
-    val s: abi.ParamSlot = classify_return(16, 8, false, 3, true, 0, 0, abi.agg_none());
+    val s: abi.ParamSlot = classify_return(16, 8, false, 3, true, false, 0, 0, abi.agg_none());
     if (s.pieces[0].reg != REG_XMM0) { ret 1; }
     if (s.pieces[1].reg != REG_XMM1) { ret 1; }
-    val o: abi.ParamSlot = classify_return(8, 4, false, 1, true, 0, 0, abi.agg_none());
+    val o: abi.ParamSlot = classify_return(8, 4, false, 1, true, false, 0, 0, abi.agg_none());
     if (o.piece_count   != 1)        { ret 1; }
     if (o.pieces[0].reg != REG_XMM0) { ret 1; }
     ret 0;
@@ -488,9 +490,9 @@ test "mach.lang.target.abi.sysv.classify_return:all_float_returns_xmm_pair" {
 
 # {i64; i64} -> RAX:RDX; {i64; f64} -> RAX:XMM0
 test "mach.lang.target.abi.sysv.classify_return:banks_fill_in_order" {
-    val gp: abi.ParamSlot = classify_return(16, 8, false, 0, true, 0, 0, abi.agg_none());
+    val gp: abi.ParamSlot = classify_return(16, 8, false, 0, true, false, 0, 0, abi.agg_none());
     if (gp.pieces[0].reg != REG_RAX || gp.pieces[1].reg != REG_RDX) { ret 1; }
-    val mix: abi.ParamSlot = classify_return(16, 8, false, 2, true, 0, 0, abi.agg_none());
+    val mix: abi.ParamSlot = classify_return(16, 8, false, 2, true, false, 0, 0, abi.agg_none());
     if (mix.pieces[0].reg != REG_RAX || mix.pieces[1].reg != REG_XMM0) { ret 1; }
     ret 0;
 }

--- a/src/lang/target/abi/win64.mach
+++ b/src/lang/target/abi/win64.mach
@@ -253,12 +253,13 @@ pub fun classify_arg(index: i32, size: u64, align: u64,
 # is_float:      true if the value is returned in FP registers (scalar floats)
 # fp_eightbytes: per-eightbyte SSE mask (unused -- win64 returns aggregates in RAX)
 # is_aggregate:  true if the value is an aggregate
+# is_vector:     true for a 128-bit SIMD vector (#1965); neutral, unread here
 # hfa_members:   HFA member count (AAPCS64-only; unused under win64)
 # hfa_elem:      HFA fundamental member width (AAPCS64-only; unused under win64)
 # agg:           the flattened-aggregate descriptor (lp64d-only; unused under win64)
 # ret:           the placement decision
 pub fun classify_return(size: u64, align: u64,
-                        is_float: bool, fp_eightbytes: u8, is_aggregate: bool,
+                        is_float: bool, fp_eightbytes: u8, is_aggregate: bool, is_vector: bool,
                         hfa_members: u8, hfa_elem: u8, agg: abi.AggLayout) abi.ParamSlot {
     if (size == 0) {
         ret abi.make_slot(abi.CLASS_GP, -1, -1, 0, 0);
@@ -563,15 +564,15 @@ test "mach.lang.target.abi.win64.classify_arg:exhausted_byref_spills_pointer" {
 # scalar returns use RAX (integers) or XMM0 (floats); a void return is CLASS_GP
 # with reg=-1
 test "mach.lang.target.abi.win64.classify_return:scalars" {
-    val voidr: abi.ParamSlot = classify_return(0, 0, false, 0, false, 0, 0, abi.agg_none());
+    val voidr: abi.ParamSlot = classify_return(0, 0, false, 0, false, false, 0, 0, abi.agg_none());
     if (voidr.class != abi.CLASS_GP) { ret 1; }
     if (voidr.reg   != -1)           { ret 1; }
 
-    val ir: abi.ParamSlot = classify_return(8, 8, false, 0, false, 0, 0, abi.agg_none());
+    val ir: abi.ParamSlot = classify_return(8, 8, false, 0, false, false, 0, 0, abi.agg_none());
     if (ir.class != abi.CLASS_GP) { ret 1; }
     if (ir.reg   != REG_RAX)      { ret 1; }
 
-    val fr: abi.ParamSlot = classify_return(8, 8, true, 0, false, 0, 0, abi.agg_none());
+    val fr: abi.ParamSlot = classify_return(8, 8, true, 0, false, false, 0, 0, abi.agg_none());
     if (fr.class != abi.CLASS_FP) { ret 1; }
     if (fr.reg   != REG_XMM0)     { ret 1; }
     ret 0;
@@ -580,15 +581,15 @@ test "mach.lang.target.abi.win64.classify_return:scalars" {
 # a 1/2/4/8-byte aggregate returns in RAX even when all-float (the SSE mask is
 # ignored, unlike SysV); any other aggregate returns through an sret pointer
 test "mach.lang.target.abi.win64.classify_return:aggregate_rax_or_sret" {
-    val small: abi.ParamSlot = classify_return(8, 8, false, 0, true, 0, 0, abi.agg_none());
+    val small: abi.ParamSlot = classify_return(8, 8, false, 0, true, false, 0, 0, abi.agg_none());
     if (small.class != abi.CLASS_GP) { ret 1; }
     if (small.reg   != REG_RAX)      { ret 1; }
 
-    val fsmall: abi.ParamSlot = classify_return(8, 8, true, 1, true, 0, 0, abi.agg_none());
+    val fsmall: abi.ParamSlot = classify_return(8, 8, true, 1, true, false, 0, 0, abi.agg_none());
     if (fsmall.class != abi.CLASS_GP) { ret 1; }
     if (fsmall.reg   != REG_RAX)      { ret 1; }
 
-    val big: abi.ParamSlot = classify_return(12, 4, false, 0, true, 0, 0, abi.agg_none());
+    val big: abi.ParamSlot = classify_return(12, 4, false, 0, true, false, 0, 0, abi.agg_none());
     if (big.class != abi.CLASS_SRET) { ret 1; }
     if (big.reg   != REG_RAX)        { ret 1; }
     ret 0;
@@ -597,7 +598,7 @@ test "mach.lang.target.abi.win64.classify_return:aggregate_rax_or_sret" {
 # an sret return reserves the first positional slot: classify_signature seeds
 # gp_used=1 for the hidden RCX pointer, so the first real integer argument is RDX
 test "mach.lang.target.abi.win64.classify_return:sret_reserves_first_slot" {
-    val ret_slot: abi.ParamSlot = classify_return(24, 8, false, 0, true, 0, 0, abi.agg_none());
+    val ret_slot: abi.ParamSlot = classify_return(24, 8, false, 0, true, false, 0, 0, abi.agg_none());
     if (ret_slot.class != abi.CLASS_SRET) { ret 1; }
     val first_arg: abi.ParamSlot = classify_arg(0, 8, 8, false, 0, false, false, 1, 0, 0, 0, abi.agg_none());
     if (first_arg.class != abi.CLASS_GP) { ret 1; }

--- a/src/lang/target/abi/win64.mach
+++ b/src/lang/target/abi/win64.mach
@@ -165,7 +165,7 @@ pub fun float_dup_gp_reg(index: i32) i32 {
 pub fun classify(size: u64, align: u64, is_float: bool, fp_eightbytes: u8,
                  is_aggregate: bool, gp_used: i32, fp_used: i32,
                  hfa_members: u8, hfa_elem: u8) abi.ParamSlot {
-    ret classify_arg(0, size, align, is_float, fp_eightbytes, is_aggregate, gp_used, fp_used, hfa_members, hfa_elem, abi.agg_none());
+    ret classify_arg(0, size, align, is_float, fp_eightbytes, is_aggregate, false, gp_used, fp_used, hfa_members, hfa_elem, abi.agg_none());
 }
 
 # assign a register or stack slot for one argument (win64)
@@ -192,6 +192,7 @@ pub fun classify(size: u64, align: u64, is_float: bool, fp_eightbytes: u8,
 # is_float:      true if the argument goes in FP registers (scalar floats)
 # fp_eightbytes: per-eightbyte SSE mask (unused -- win64 aggregates ride GP)
 # is_aggregate:  true if the argument is an aggregate
+# is_vector:     true for a 128-bit SIMD vector (#1965); neutral, unread here
 # gp_used:       GP registers already consumed
 # fp_used:       FP registers already consumed
 # hfa_members:   HFA member count (AAPCS64-only; unused under win64)
@@ -199,7 +200,7 @@ pub fun classify(size: u64, align: u64, is_float: bool, fp_eightbytes: u8,
 # agg:           the flattened-aggregate descriptor (lp64d-only; unused under win64)
 # ret:           the placement decision
 pub fun classify_arg(index: i32, size: u64, align: u64,
-                     is_float: bool, fp_eightbytes: u8, is_aggregate: bool,
+                     is_float: bool, fp_eightbytes: u8, is_aggregate: bool, is_vector: bool,
                      gp_used: i32, fp_used: i32, hfa_members: u8, hfa_elem: u8,
                      agg: abi.AggLayout) abi.ParamSlot {
     val slot: i32 = slot_index(gp_used, fp_used);
@@ -458,18 +459,18 @@ pub fun register_win64(reg: *abi.AbiRegistry) R.Result[bool, str] {
 # scalar integers fill RCX, RDX, R8, R9 in order, then the fifth spills to the
 # stack by value
 test "mach.lang.target.abi.win64.classify_arg:scalar_integers_then_spill" {
-    val s0: abi.ParamSlot = classify_arg(0, 8, 8, false, 0, false, 0, 0, 0, 0, abi.agg_none());
+    val s0: abi.ParamSlot = classify_arg(0, 8, 8, false, 0, false, false, 0, 0, 0, 0, abi.agg_none());
     if (s0.class != abi.CLASS_GP) { ret 1; }
     if (s0.reg   != REG_RCX)      { ret 1; }
 
-    val s1: abi.ParamSlot = classify_arg(1, 8, 8, false, 0, false, 1, 0, 0, 0, abi.agg_none());
+    val s1: abi.ParamSlot = classify_arg(1, 8, 8, false, 0, false, false, 1, 0, 0, 0, abi.agg_none());
     if (s1.reg != REG_RDX) { ret 1; }
-    val s2: abi.ParamSlot = classify_arg(2, 8, 8, false, 0, false, 2, 0, 0, 0, abi.agg_none());
+    val s2: abi.ParamSlot = classify_arg(2, 8, 8, false, 0, false, false, 2, 0, 0, 0, abi.agg_none());
     if (s2.reg != REG_R8) { ret 1; }
-    val s3: abi.ParamSlot = classify_arg(3, 8, 8, false, 0, false, 3, 0, 0, 0, abi.agg_none());
+    val s3: abi.ParamSlot = classify_arg(3, 8, 8, false, 0, false, false, 3, 0, 0, 0, abi.agg_none());
     if (s3.reg != REG_R9) { ret 1; }
 
-    val s4: abi.ParamSlot = classify_arg(4, 8, 8, false, 0, false, 4, 0, 0, 0, abi.agg_none());
+    val s4: abi.ParamSlot = classify_arg(4, 8, 8, false, 0, false, false, 4, 0, 0, 0, abi.agg_none());
     if (s4.class != abi.CLASS_STACK) { ret 1; }
     if (s4.reg   != -1)              { ret 1; }
     if (s4.size  != 8)               { ret 1; }
@@ -478,15 +479,15 @@ test "mach.lang.target.abi.win64.classify_arg:scalar_integers_then_spill" {
 
 # floats fill XMM0-XMM3 in order, then the fifth positional argument spills
 test "mach.lang.target.abi.win64.classify_arg:floats_then_spill" {
-    val f0: abi.ParamSlot = classify_arg(0, 8, 8, true, 0, false, 0, 0, 0, 0, abi.agg_none());
+    val f0: abi.ParamSlot = classify_arg(0, 8, 8, true, 0, false, false, 0, 0, 0, 0, abi.agg_none());
     if (f0.class != abi.CLASS_FP)                            { ret 1; }
     if (f0.reg   != isa.regid_make(isa.REG_CLASS_ID_XMM, 0)) { ret 1; }
 
-    val f3: abi.ParamSlot = classify_arg(3, 4, 4, true, 0, false, 0, 3, 0, 0, abi.agg_none());
+    val f3: abi.ParamSlot = classify_arg(3, 4, 4, true, 0, false, false, 0, 3, 0, 0, abi.agg_none());
     if (f3.class != abi.CLASS_FP)                            { ret 1; }
     if (f3.reg   != isa.regid_make(isa.REG_CLASS_ID_XMM, 3)) { ret 1; }
 
-    val f4: abi.ParamSlot = classify_arg(4, 8, 8, true, 0, false, 0, 4, 0, 0, abi.agg_none());
+    val f4: abi.ParamSlot = classify_arg(4, 8, 8, true, 0, false, false, 0, 4, 0, 0, abi.agg_none());
     if (f4.class != abi.CLASS_STACK) { ret 1; }
     ret 0;
 }
@@ -494,15 +495,15 @@ test "mach.lang.target.abi.win64.classify_arg:floats_then_spill" {
 # an integer and a float share one positional slot per argument: an integer in
 # slot 0 (RCX) pushes a following float to slot 1 (XMM1), and vice versa
 test "mach.lang.target.abi.win64.classify_arg:shared_positional_slot" {
-    val i0: abi.ParamSlot = classify_arg(0, 8, 8, false, 0, false, 0, 0, 0, 0, abi.agg_none());
+    val i0: abi.ParamSlot = classify_arg(0, 8, 8, false, 0, false, false, 0, 0, 0, 0, abi.agg_none());
     if (i0.reg != REG_RCX) { ret 1; }
-    val f1: abi.ParamSlot = classify_arg(1, 8, 8, true, 0, false, 1, 0, 0, 0, abi.agg_none());
+    val f1: abi.ParamSlot = classify_arg(1, 8, 8, true, 0, false, false, 1, 0, 0, 0, abi.agg_none());
     if (f1.class != abi.CLASS_FP)                            { ret 1; }
     if (f1.reg   != isa.regid_make(isa.REG_CLASS_ID_XMM, 1)) { ret 1; }
 
-    val g0: abi.ParamSlot = classify_arg(0, 8, 8, true, 0, false, 0, 0, 0, 0, abi.agg_none());
+    val g0: abi.ParamSlot = classify_arg(0, 8, 8, true, 0, false, false, 0, 0, 0, 0, abi.agg_none());
     if (g0.reg != isa.regid_make(isa.REG_CLASS_ID_XMM, 0)) { ret 1; }
-    val g1: abi.ParamSlot = classify_arg(1, 8, 8, false, 0, false, 0, 1, 0, 0, abi.agg_none());
+    val g1: abi.ParamSlot = classify_arg(1, 8, 8, false, 0, false, false, 0, 1, 0, 0, abi.agg_none());
     if (g1.class != abi.CLASS_GP) { ret 1; }
     if (g1.reg   != REG_RDX)      { ret 1; }
     ret 0;
@@ -521,20 +522,20 @@ test "mach.lang.target.abi.win64.float_dup_gp_reg:variadic_duplicate" {
 # 1/2/4/8-byte aggregates ride one integer register by value; every other size is
 # passed by hidden reference, the pointer (8 bytes) in the slot's GP register
 test "mach.lang.target.abi.win64.classify_arg:aggregate_by_value_or_ref" {
-    val by_val: abi.ParamSlot = classify_arg(0, 8, 8, false, 0, true, 0, 0, 0, 0, abi.agg_none());
+    val by_val: abi.ParamSlot = classify_arg(0, 8, 8, false, 0, true, false, 0, 0, 0, 0, abi.agg_none());
     if (by_val.class != abi.CLASS_GP) { ret 1; }
     if (by_val.reg   != REG_RCX)      { ret 1; }
     if (by_val.size  != 8)            { ret 1; }
 
-    val four: abi.ParamSlot = classify_arg(0, 4, 4, false, 0, true, 0, 0, 0, 0, abi.agg_none());
+    val four: abi.ParamSlot = classify_arg(0, 4, 4, false, 0, true, false, 0, 0, 0, 0, abi.agg_none());
     if (four.class != abi.CLASS_GP) { ret 1; }
 
-    val by_ref3: abi.ParamSlot = classify_arg(0, 3, 1, false, 0, true, 0, 0, 0, 0, abi.agg_none());
+    val by_ref3: abi.ParamSlot = classify_arg(0, 3, 1, false, 0, true, false, 0, 0, 0, 0, abi.agg_none());
     if (by_ref3.class != abi.CLASS_BYREF) { ret 1; }
     if (by_ref3.reg   != REG_RCX)         { ret 1; }
     if (by_ref3.size  != 8)               { ret 1; }
 
-    val by_ref16: abi.ParamSlot = classify_arg(0, 16, 8, false, 0, true, 0, 0, 0, 0, abi.agg_none());
+    val by_ref16: abi.ParamSlot = classify_arg(0, 16, 8, false, 0, true, false, 0, 0, 0, 0, abi.agg_none());
     if (by_ref16.class != abi.CLASS_BYREF) { ret 1; }
     if (by_ref16.reg   != REG_RCX)         { ret 1; }
     ret 0;
@@ -544,16 +545,16 @@ test "mach.lang.target.abi.win64.classify_arg:aggregate_by_value_or_ref" {
 # hidden pointer as CLASS_STACK_BYREF (for both a 16-byte and a 3-byte aggregate),
 # while an exhausted by-value-size aggregate spills its own bytes as CLASS_STACK
 test "mach.lang.target.abi.win64.classify_arg:exhausted_byref_spills_pointer" {
-    val s: abi.ParamSlot = classify_arg(4, 16, 8, false, 0, true, 4, 0, 0, 0, abi.agg_none());
+    val s: abi.ParamSlot = classify_arg(4, 16, 8, false, 0, true, false, 4, 0, 0, 0, abi.agg_none());
     if (s.class != abi.CLASS_STACK_BYREF) { ret 1; }
     if (s.reg   != -1)                    { ret 1; }
     if (s.size  != 8)                     { ret 1; }
 
-    val s3: abi.ParamSlot = classify_arg(4, 3, 1, false, 0, true, 4, 0, 0, 0, abi.agg_none());
+    val s3: abi.ParamSlot = classify_arg(4, 3, 1, false, 0, true, false, 4, 0, 0, 0, abi.agg_none());
     if (s3.class != abi.CLASS_STACK_BYREF) { ret 1; }
     if (s3.size  != 8)                     { ret 1; }
 
-    val sv: abi.ParamSlot = classify_arg(4, 8, 8, false, 0, true, 4, 0, 0, 0, abi.agg_none());
+    val sv: abi.ParamSlot = classify_arg(4, 8, 8, false, 0, true, false, 4, 0, 0, 0, abi.agg_none());
     if (sv.class != abi.CLASS_STACK) { ret 1; }
     if (sv.size  != 8)               { ret 1; }
     ret 0;
@@ -598,7 +599,7 @@ test "mach.lang.target.abi.win64.classify_return:aggregate_rax_or_sret" {
 test "mach.lang.target.abi.win64.classify_return:sret_reserves_first_slot" {
     val ret_slot: abi.ParamSlot = classify_return(24, 8, false, 0, true, 0, 0, abi.agg_none());
     if (ret_slot.class != abi.CLASS_SRET) { ret 1; }
-    val first_arg: abi.ParamSlot = classify_arg(0, 8, 8, false, 0, false, 1, 0, 0, 0, abi.agg_none());
+    val first_arg: abi.ParamSlot = classify_arg(0, 8, 8, false, 0, false, false, 1, 0, 0, 0, abi.agg_none());
     if (first_arg.class != abi.CLASS_GP) { ret 1; }
     if (first_arg.reg   != REG_RDX)      { ret 1; }
     ret 0;

--- a/src/lang/target/isa.mach
+++ b/src/lang/target/isa.mach
@@ -246,6 +246,11 @@ pub val ADDR_PCREL:           AddrForm = 0x20;  # [pc + disp]
 # red_zone:          leaf-function red-zone size in bytes, 0 if none (from abi)
 # shadow_space:      home/shadow bytes the caller reserves below the stack args
 #                    (win64's 32, 0 for SysV) (from abi)
+# has_v128:          true when the ISA has a 128-bit SIMD vector unit whose ops
+#                    the backend selects one-per-lane-op (x86-64 SSE2, aarch64
+#                    NEON); false when a target lacks it (rv64gc until V) and
+#                    vector ops scalarize. a declared capability fact, never
+#                    derived from the float bank width (#1965)
 pub rec MachineModel {
     pointer_width: u32;
     gpr_width:     u32;
@@ -275,6 +280,7 @@ pub rec MachineModel {
     stack_align:       u32;
     red_zone:          u32;
     shadow_space:      u32;
+    has_v128:          bool;
 }
 
 # the concrete signature the erased `IsaVTable.asm_clobbers` pointer is cast back to

--- a/src/lang/target/isa/arm64/register.mach
+++ b/src/lang/target/isa/arm64/register.mach
@@ -230,6 +230,8 @@ pub fun register_arm64(reg: *isa.IsaRegistry) R.Result[bool, str] {
     arm64_model.index_width     = 8;
     arm64_model.spill_width     = 8;
     arm64_model.endianness      = isa.ENDIAN_LITTLE;
+    # NEON 128-bit vector unit is baseline on aarch64 (#1965).
+    arm64_model.has_v128        = true;
 
     arm64_model.reg_classes     = ?arm64_classes[0];
     arm64_model.reg_class_len   = 3;

--- a/src/lang/target/isa/riscv64/register.mach
+++ b/src/lang/target/isa/riscv64/register.mach
@@ -15,6 +15,7 @@
 # in be/, which target/ cannot depend on), the same split x86_64 and aarch64 use.
 
 use std.types.bool.bool;
+use std.types.bool.false;
 use std.types.bool.true;
 use std.types.string.str;
 use std.types.string.str_equals;
@@ -281,6 +282,9 @@ pub fun register_riscv64(reg: *isa.IsaRegistry) R.Result[bool, str] {
     riscv64_model.index_width     = 8;
     riscv64_model.spill_width     = 8;
     riscv64_model.endianness      = isa.ENDIAN_LITTLE;
+    # rv64gc has no 128-bit vector unit (the V extension is out of baseline), so
+    # vector ops scalarize (#1965).
+    riscv64_model.has_v128        = false;
 
     riscv64_model.reg_classes     = ?riscv64_classes[0];
     riscv64_model.reg_class_len   = 2;

--- a/src/lang/target/isa/x64/register.mach
+++ b/src/lang/target/isa/x64/register.mach
@@ -274,6 +274,8 @@ pub fun register_x64(reg: *isa.IsaRegistry) R.Result[bool, str] {
     x64_model.index_width     = 8;
     x64_model.spill_width     = 8;
     x64_model.endianness      = isa.ENDIAN_LITTLE;
+    # SSE2 128-bit vector unit is baseline on x86-64 (#1965).
+    x64_model.has_v128        = true;
 
     x64_model.reg_classes     = ?x64_classes[0];
     x64_model.reg_class_len   = 3;

--- a/src/lang/type.mach
+++ b/src/lang/type.mach
@@ -74,6 +74,16 @@ pub val TYPE_PACK: TypeKind = 18;
 # to the same machine shape as `T`; it constrains only sema's flow typing
 pub val TYPE_SECRET: TypeKind = 19;
 
+# a 128-bit SIMD vector type `<u|i|f><width>x<count>` (#1965). the portable
+# vector model: all ten seeded shapes are legal on every target, with a payload
+# carrying the lane scalar kind and lane count. lowers to a 16-byte register-class
+# value; whether a lane-wise op is one instruction or a scalar expansion is a
+# backend concern
+pub val TYPE_VECTOR: TypeKind = 20;
+
+# number of seeded vector types (the ten 128-bit shapes)
+pub val VEC_COUNT: u32 = 10;
+
 # scalar class of a primitive TypeKind, the discriminator of PrimDesc
 pub def PrimClass: u8;
 
@@ -148,6 +158,59 @@ pub rec TypeSecret {
     base: TypeId;
 }
 
+# 128-bit SIMD vector type payload (#1965)
+#
+# Two vectors are identical iff (element, lanes) match. `element` is one of the
+# ten scalar prim kinds; `lanes` is 2, 4, 8, or 16 so that element*lanes is 128.
+# ---
+# element: lane scalar TypeKind (u8..i64, f32, f64)
+# lanes:   lane count
+pub rec TypeVector {
+    element: TypeKind;
+    lanes:   u32;
+}
+
+# the spelling, lane scalar, and lane count of one seeded vector type
+#
+# The single source of truth for the ten shapes, shared by the interner's init
+# seeding and the resolver's name registry, keyed by ordinal.
+# ---
+# name:    source spelling, e.g. "f32x4"
+# element: lane scalar TypeKind
+# lanes:   lane count
+pub rec VecShape {
+    name:    str;
+    element: TypeKind;
+    lanes:   u32;
+}
+
+# the seeded vector shape at ordinal `index`
+#
+# The ten shapes in a fixed order shared between the type interner (which
+# pre-interns them at init) and the resolver (which interns their spellings).
+# ---
+# index: ordinal in [0, VEC_COUNT)
+# ret:   the shape descriptor; a zero-lane VecShape when index is out of range
+pub fun vec_shape(index: u32) VecShape {
+    var s: VecShape;
+    s.name    = nil;
+    s.element = TYPE_U8;
+    s.lanes   = 0;
+
+    if      (index == 0) { s.name = "f32x4"; s.element = TYPE_F32; s.lanes = 4;  }
+    or (index == 1) { s.name = "f64x2"; s.element = TYPE_F64; s.lanes = 2;  }
+    or (index == 2) { s.name = "i8x16"; s.element = TYPE_I8;  s.lanes = 16; }
+    or (index == 3) { s.name = "i16x8"; s.element = TYPE_I16; s.lanes = 8;  }
+    or (index == 4) { s.name = "i32x4"; s.element = TYPE_I32; s.lanes = 4;  }
+    or (index == 5) { s.name = "i64x2"; s.element = TYPE_I64; s.lanes = 2;  }
+    or (index == 6) { s.name = "u8x16"; s.element = TYPE_U8;  s.lanes = 16; }
+    or (index == 7) { s.name = "u16x8"; s.element = TYPE_U16; s.lanes = 8;  }
+    or (index == 8) { s.name = "u32x4"; s.element = TYPE_U32; s.lanes = 4;  }
+    or (index == 9) { s.name = "u64x2"; s.element = TYPE_U64; s.lanes = 2;  }
+
+    ret s;
+}
+
 # fixed-size array type payload
 # ---
 # base:  element TypeId
@@ -218,6 +281,7 @@ pub rec Type {
         pointer:       TypePointer;
         secret:        TypeSecret;
         array:         TypeArray;
+        vector:        TypeVector;
         fn:            TypeFun;
         nominal:       TypeNominal;
         generic_param: TypeGenericParam;
@@ -308,6 +372,10 @@ pub rec TypeInterner {
     instances_cap: u32;
 
     prims: [PRIM_COUNT]TypeId;
+
+    # pre-interned TypeIds for the ten seeded vector shapes, indexed by the
+    # ordinal `vec_shape` uses, so a seeded shape has a stable id from init.
+    vecs: [VEC_COUNT]TypeId;
 
     field_tables:    *FieldTable;
     field_table_len: u32;
@@ -407,6 +475,20 @@ pub fun init(ti: *TypeInterner, a: *A.Allocator) O.Option[str] {
         }
 
         i = i + 1;
+    }
+
+    # seed the ten vector shapes so each has a stable TypeId the resolver reads
+    # back through `vec`. intern_vector dedups, so seeding never doubles a shape.
+    var vi: u32 = 0;
+    for (vi < VEC_COUNT) {
+        val sh: VecShape = vec_shape(vi);
+        val res_vec: R.Result[TypeId, str] = intern_vector(ti, sh.element, sh.lanes);
+        if (R.is_err[TypeId, str](res_vec)) {
+            dnit(ti);
+            ret O.some[str](R.unwrap_err[TypeId, str](res_vec));
+        }
+        ti.vecs[vi] = R.unwrap_ok[TypeId, str](res_vec);
+        vi = vi + 1;
     }
 
     ret O.none[str]();
@@ -565,6 +647,80 @@ pub fun is_secret(ti: *TypeInterner, tid: TypeId) bool {
     ret O.unwrap[*Type](opt_type).kind == TYPE_SECRET;
 }
 
+# whether `tid` is a 128-bit vector type (#1965)
+#
+# A secret `^T` is classified by its inner type, so a secret vector still reports
+# as a vector for layout and lane classification.
+# ---
+# ti:  the interner
+# tid: the TypeId to classify
+# ret: true when `tid` (or its inner type under `^`) is a vector
+pub fun is_vector(ti: *TypeInterner, tid: TypeId) bool {
+    val opt_type: O.Option[*Type] = get(ti, strip_secret(ti, tid));
+    if (O.is_none[*Type](opt_type)) { ret false; }
+    ret O.unwrap[*Type](opt_type).kind == TYPE_VECTOR;
+}
+
+# the lane scalar TypeKind of a vector type, or TYPE_VECTOR itself when `tid` is
+# not a vector (callers gate on is_vector first)
+# ---
+# ti:  the interner
+# tid: a vector TypeId (secret-stripped internally)
+# ret: the lane scalar kind, or TYPE_VECTOR when `tid` is not a vector
+pub fun vector_element(ti: *TypeInterner, tid: TypeId) TypeKind {
+    val opt_type: O.Option[*Type] = get(ti, strip_secret(ti, tid));
+    if (O.is_none[*Type](opt_type)) { ret TYPE_VECTOR; }
+    val t: *Type = O.unwrap[*Type](opt_type);
+    if (t.kind != TYPE_VECTOR) { ret TYPE_VECTOR; }
+    ret t.data.vector.element;
+}
+
+# the lane count of a vector type, or 0 when `tid` is not a vector
+# ---
+# ti:  the interner
+# tid: a vector TypeId (secret-stripped internally)
+# ret: the lane count, or 0 when `tid` is not a vector
+pub fun vector_lanes(ti: *TypeInterner, tid: TypeId) u32 {
+    val opt_type: O.Option[*Type] = get(ti, strip_secret(ti, tid));
+    if (O.is_none[*Type](opt_type)) { ret 0; }
+    val t: *Type = O.unwrap[*Type](opt_type);
+    if (t.kind != TYPE_VECTOR) { ret 0; }
+    ret t.data.vector.lanes;
+}
+
+# the TypeId of the seeded vector shape at ordinal `index`
+# ---
+# ti:    the interner
+# index: ordinal in [0, VEC_COUNT)
+# ret:   some(TypeId) for a seeded shape, none when index is out of range
+pub fun vec(ti: *TypeInterner, index: u32) O.Option[TypeId] {
+    if (index >= VEC_COUNT) { ret O.none[TypeId](); }
+    ret O.some[TypeId](ti.vecs[index]);
+}
+
+# the same-shape unsigned mask vector for a vector comparison result (#1965)
+#
+# A comparison lanes-wise yields all-ones / all-zeros masks in an unsigned vector
+# of the same lane width and count (`f32x4`/`i32x4` -> `u32x4`, `i8x16` ->
+# `u8x16`, and so on).
+# ---
+# ti:  the interner
+# tid: the operand vector TypeId
+# ret: the mask vector TypeId, or an allocation error
+pub fun vector_mask(ti: *TypeInterner, tid: TypeId) R.Result[TypeId, str] {
+    val element: TypeKind = vector_element(ti, tid);
+    val lanes:   u32      = vector_lanes(ti, tid);
+    val bits:    u32      = prim_desc(element).bits;
+
+    var mask_elem: TypeKind = TYPE_U8;
+    if      (bits == 8)  { mask_elem = TYPE_U8;  }
+    or (bits == 16) { mask_elem = TYPE_U16; }
+    or (bits == 32) { mask_elem = TYPE_U32; }
+    or (bits == 64) { mask_elem = TYPE_U64; }
+
+    ret intern_vector(ti, mask_elem, lanes);
+}
+
 # peel one secret qualifier from `tid`, returning the inner type
 #
 # A non-secret type is returned unchanged. `^^T` never forms (intern_secret
@@ -682,6 +838,23 @@ pub fun intern_array(ti: *TypeInterner, base: TypeId, count: u32) R.Result[TypeI
     t.kind             = TYPE_ARRAY;
     t.data.array.base  = base;
     t.data.array.count = count;
+    ret intern_dedup(ti, t);
+}
+
+# intern a 128-bit vector type (#1965)
+#
+# Returns an existing TypeId when the same (element, lanes) shape has been
+# interned before.
+# ---
+# ti:      the interner
+# element: lane scalar TypeKind
+# lanes:   lane count
+# ret:     TypeId for the vector shape, or an allocation error
+pub fun intern_vector(ti: *TypeInterner, element: TypeKind, lanes: u32) R.Result[TypeId, str] {
+    var t: Type;
+    t.kind                = TYPE_VECTOR;
+    t.data.vector.element = element;
+    t.data.vector.lanes   = lanes;
     ret intern_dedup(ti, t);
 }
 
@@ -1309,6 +1482,10 @@ fun hash_type(p: ptr) u64 {
         h = fnv1a.step_u32(h, t.data.array.base::u32);
         h = fnv1a.step_u32(h, t.data.array.count);
     }
+    or (t.kind == TYPE_VECTOR) {
+        h = fnv1a.step_u8(h, t.data.vector.element::u8);
+        h = fnv1a.step_u32(h, t.data.vector.lanes);
+    }
     or (t.kind == TYPE_REC || t.kind == TYPE_UNI) {
         h = fnv1a.step_u32(h, t.data.nominal.origin::u32);
         h = fnv1a.step_u32(h, t.data.nominal.decl::u32);
@@ -1340,6 +1517,10 @@ fun eq_type(pa: ptr, pb: ptr) bool {
     if (a.kind == TYPE_ARRAY) {
         ret a.data.array.base == b.data.array.base
             && a.data.array.count == b.data.array.count;
+    }
+    if (a.kind == TYPE_VECTOR) {
+        ret a.data.vector.element == b.data.vector.element
+            && a.data.vector.lanes == b.data.vector.lanes;
     }
     if (a.kind == TYPE_REC || a.kind == TYPE_UNI) {
         ret a.data.nominal.origin == b.data.nominal.origin
@@ -1423,6 +1604,78 @@ test "mach.lang.type.intern_instance:dedup_by_origin_decl_args" {
     val r4: R.Result[TypeId, str] = intern_instance(?ti, 1::module.ModuleId, 0::id.DeclId, ?a2[0], 2);
     if (R.is_err[TypeId, str](r4))                                    { dnit(?ti); ret 1; }
     if (R.unwrap_ok[TypeId, str](r1) == R.unwrap_ok[TypeId, str](r4)) { dnit(?ti); ret 1; }
+
+    dnit(?ti);
+    ret 0;
+}
+
+# the ten seeded vector shapes are retrievable through `vec`, intern_vector
+# dedups equal shapes to one TypeId, and distinct shapes stay distinct
+test "mach.lang.type.intern_vector:seeded_and_dedup" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+    var ti: TypeInterner;
+    if (O.is_some[str](init(?ti, ?alloc))) { ret 1; }
+
+    # every seeded ordinal resolves to a real vector carrying the shape's payload
+    var vi: u32 = 0;
+    for (vi < VEC_COUNT) {
+        val sh:  VecShape          = vec_shape(vi);
+        val opt: O.Option[TypeId]  = vec(?ti, vi);
+        if (O.is_none[TypeId](opt))                             { dnit(?ti); ret 1; }
+        val tid: TypeId = O.unwrap[TypeId](opt);
+        if (!is_vector(?ti, tid))                               { dnit(?ti); ret 1; }
+        if (vector_element(?ti, tid) != sh.element)             { dnit(?ti); ret 1; }
+        if (vector_lanes(?ti, tid) != sh.lanes)                 { dnit(?ti); ret 1; }
+        vi = vi + 1;
+    }
+
+    # re-interning f32x4 returns the seeded id (dedup by shape)
+    val f0: TypeId = O.unwrap[TypeId](vec(?ti, 0));
+    val r_f: R.Result[TypeId, str] = intern_vector(?ti, TYPE_F32, 4);
+    if (R.is_err[TypeId, str](r_f))                     { dnit(?ti); ret 1; }
+    if (R.unwrap_ok[TypeId, str](r_f) != f0)            { dnit(?ti); ret 1; }
+
+    # a different element at the same lane count is a different type
+    val r_i: R.Result[TypeId, str] = intern_vector(?ti, TYPE_I32, 4);
+    if (R.is_err[TypeId, str](r_i))                     { dnit(?ti); ret 1; }
+    if (R.unwrap_ok[TypeId, str](r_i) == f0)            { dnit(?ti); ret 1; }
+
+    # out-of-range ordinal yields none, and a scalar is not a vector
+    if (O.is_some[TypeId](vec(?ti, VEC_COUNT)))         { dnit(?ti); ret 1; }
+    if (is_vector(?ti, O.unwrap[TypeId](prim(?ti, TYPE_U8)))) { dnit(?ti); ret 1; }
+
+    dnit(?ti);
+    ret 0;
+}
+
+# vector_mask maps each shape to the same-lane-count unsigned mask vector
+test "mach.lang.type.vector_mask:same_shape_unsigned" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+    var ti: TypeInterner;
+    if (O.is_some[str](init(?ti, ?alloc))) { ret 1; }
+
+    # f32x4 -> u32x4
+    val f32x4: TypeId = O.unwrap[TypeId](vec(?ti, 0));
+    val u32x4: TypeId = O.unwrap[TypeId](vec(?ti, 8));
+    val m0: R.Result[TypeId, str] = vector_mask(?ti, f32x4);
+    if (R.is_err[TypeId, str](m0))          { dnit(?ti); ret 1; }
+    if (R.unwrap_ok[TypeId, str](m0) != u32x4) { dnit(?ti); ret 1; }
+
+    # i8x16 -> u8x16
+    val i8x16: TypeId = O.unwrap[TypeId](vec(?ti, 2));
+    val u8x16: TypeId = O.unwrap[TypeId](vec(?ti, 6));
+    val m1: R.Result[TypeId, str] = vector_mask(?ti, i8x16);
+    if (R.is_err[TypeId, str](m1))          { dnit(?ti); ret 1; }
+    if (R.unwrap_ok[TypeId, str](m1) != u8x16) { dnit(?ti); ret 1; }
+
+    # i64x2 -> u64x2
+    val i64x2: TypeId = O.unwrap[TypeId](vec(?ti, 5));
+    val u64x2: TypeId = O.unwrap[TypeId](vec(?ti, 9));
+    val m2: R.Result[TypeId, str] = vector_mask(?ti, i64x2);
+    if (R.is_err[TypeId, str](m2))          { dnit(?ti); ret 1; }
+    if (R.unwrap_ok[TypeId, str](m2) != u64x2) { dnit(?ti); ret 1; }
 
     dnit(?ti);
     ret 0;


### PR DESCRIPTION
Tier-1 gate of the SIMD vector-types program (epic #1965): the frontend + sema + middle-end substrate for the ten 128-bit vector types, the required `simd` manifest key, and the shared backend scaffolding.

Closes #2013.

This is **stage γ** of the #1979 seed dance: stage α (#2027, parser accepts `simd`) shipped in **v3.3.1**, making CI's latest-release seed simd-aware; this PR flips `simd` to required-everywhere and sweeps the tree. Rebased on dev-with-α, so the manifest change here is the require-flip on top of α's accept.

## What landed

- **Semantic types** `TYPE_VECTOR` (element + lanes), dedup interning, ten seeded shapes, `is_vector`/`vector_element`/`vector_lanes`/`vec`/`vector_mask`; sema `byte_size`=16 and a `<element>x<lanes>` diagnostic spelling.
- **Resolver** seeds the ten spellings as `SYM_VECTOR`, recognised in type position with priority over value scope.
- **Full-arity literals** `f32x4{a,b,c,d}` (`EXPR_KIND_VECTOR_LIT`, positional typed-literal parse, `infer_vector_lit` with exact arity + per-lane coercion).
- **Lane access** `v[i]` read/write: comptime-const, in-bounds index → lane scalar; dynamic/OOB → defined error.
- **Lane-wise op table** (float `+ - * /`, int `+ -` all widths + `*` 16-bit-only, bitwise + unary `~` on int lanes, comparisons → same-shape unsigned mask; no vector `%`, no int vector `/`, no scalar↔vector mixing, vector never a truth value).
- **IR** `IRT_VECTOR` (dedup, 16-byte size/align, register-class), `lower_type` mapping, `emit_vcompare` mask compare, verifier acceptance, inert constfold.
- **Shared scaffolding** `reg_class_of` vector→FP, `op_width_of` 16-byte, `value_is_vector`, 16-byte spill align, declared `MachineModel.has_v128` (t/t/f), and the neutral vector-flag thread through **both** `classify_arg` and `classify_return` (zero behavior; consumers are #2014/#2015/#2016).
- **Defined per-target isel error** `codegen: 128-bit vectors not yet supported on <arch>` (x86_64/aarch64/riscv64), never an ICE.
- **Manifest** required `simd` key on `ProfileDef` + the 28-manifest / embedded-string sweep.

Out of scope (siblings): isel/ABI selection (#2014/#2015/#2016), lever enforcement (#2017), DWARF DIEs (#2018), docs (#2020), splat (#2019).

## Verification (from-source HEAD compiler, 3.3.1 seed)

- **Full unit suite:** 585 passed, 0 failed = dev baseline 578 + 7 new tests.
- **Self-host fixpoint:** gen2 == gen3 byte-identical under the 3.3.1 seed.
- **-g additivity:** PT_LOAD byte-identical, release + debug profiles.
- **llvm-dwarfdump --verify:** clean, 21 target builds across three ISAs.
- **int suite:** all cases pass on linux (debug + release).
- **Negative diagnostics:** wrong-arity literal, non-comptime/OOB lane index, vector `%`, integer vector `/`, scalar↔vector mixing, vector-as-truth-value, missing/invalid `simd` key.
