### PR TITLE
chore(manifest): accept the simd profile key — #2013 seed staging

### DIFF
--- a/src/lang/manifest.mach
+++ b/src/lang/manifest.mach
@@ -33,6 +33,19 @@ pub val MOPT_DEFAULT: MOpt = 0;
 pub val MOPT_DEBUG:   MOpt = 1;
 pub val MOPT_RELEASE: MOpt = 2;
 
+# the SIMD strictness lever a declared profile sets (#1965): on a target without
+# the hardware vector unit, "scalarize" emits a defined unrolled expansion while
+# "require" fails the build.
+#
+# BOOTSTRAP STAGING (#2013 seed gate): this stage makes the strict parser ACCEPT
+# and validate the key without requiring it, so a swept manifest parses cleanly
+# under this compiler once it becomes the seed. The required-everywhere flip (per
+# owner ruling 1) lands with #2013 itself; resolution and enforcement are #2017.
+pub def SimdMode: u8;
+
+pub val SIMD_SCALARIZE: SimdMode = 0;
+pub val SIMD_REQUIRE:   SimdMode = 1;
+
 pub def LibKind: u8;
 
 pub val LIBKIND_STATIC: LibKind = 0;
@@ -76,6 +89,7 @@ pub rec ProfileDef {
     emit_ir:  bool;
     emit_asm: bool;
     debug:    bool;
+    simd:     SimdMode;
 }
 
 pub rec DepDef {
@@ -411,6 +425,25 @@ fun debug_err(alloc: *A.Allocator, name: str, v: *toml.Value) str {
         opt_value_text(alloc, v), ")");
 }
 
+# parse a profile's `simd` strictness lever (#1965). BOOTSTRAP STAGING (#2013):
+# the key is ACCEPTED and value-validated ("scalarize"|"require", rejected
+# otherwise) but NOT yet required — an absent key defaults to scalarize on every
+# path. The required-everywhere flip (owner ruling 1) lands with #2013 once this
+# compiler is the seed
+fun parse_simd_mode(alloc: *A.Allocator, name: str, sub: *toml.Table, as_root: bool) R.Result[SimdMode, str] {
+    val v: *toml.Value = toml.get(sub, "simd");
+    if (v == nil)                  { ret R.ok[SimdMode, str](SIMD_SCALARIZE); }
+    if (v.tag != toml.TYPE_STRING) { ret R.err[SimdMode, str](simd_err(alloc, name, v)); }
+    if (str_equals(v.data.string, "scalarize")) { ret R.ok[SimdMode, str](SIMD_SCALARIZE); }
+    if (str_equals(v.data.string, "require"))   { ret R.ok[SimdMode, str](SIMD_REQUIRE); }
+    ret R.err[SimdMode, str](simd_err(alloc, name, v));
+}
+
+fun simd_err(alloc: *A.Allocator, name: str, v: *toml.Value) str {
+    ret cc5(alloc, "mach.toml: profile '", name, "': simd must be \"scalarize\" or \"require\" (got ",
+        opt_value_text(alloc, v), ")");
+}
+
 fun int_to_str(alloc: *A.Allocator, n: i64) str {
     if (n == 0) { ret "0"; }
     var neg: bool = false;
@@ -456,7 +489,7 @@ fun key_known(kind: TableKind, k: str, as_root: bool) bool {
             || str_equals(k, "targets") || str_equals(k, "link") || str_equals(k, "need");
     }
     if (kind == TK_PROFILE) {
-        if (str_equals(k, "opt") || str_equals(k, "debug")) { ret true; }
+        if (str_equals(k, "opt") || str_equals(k, "debug") || str_equals(k, "simd")) { ret true; }
         # emit_ir/emit_asm are CLI-only (--emit-ir/--emit-asm); like name/description
         # they are pre-flag-day keys tolerated off-root, an unknown key as root (#1971).
         if (!as_root && (str_equals(k, "emit_ir") || str_equals(k, "emit_asm"))) { ret true; }
@@ -758,6 +791,9 @@ fun parse_profiles(alloc: *A.Allocator, itn: *intern.Interner, t: *toml.Table, m
         val res_debug: R.Result[bool, str] = parse_debug_flag(alloc, name, sub, as_root);
         if (R.is_err[bool, str](res_debug)) { ret R.err[bool, str](R.unwrap_err[bool, str](res_debug)); }
         pf.debug    = R.unwrap_ok[bool, str](res_debug);
+        val res_simd: R.Result[SimdMode, str] = parse_simd_mode(alloc, name, sub, as_root);
+        if (R.is_err[SimdMode, str](res_simd)) { ret R.err[bool, str](R.unwrap_err[SimdMode, str](res_simd)); }
+        pf.simd     = R.unwrap_ok[SimdMode, str](res_simd);
 
         m.profiles[i] = pf;
         i = i + 1;
@@ -2017,6 +2053,39 @@ test "mach.lang.manifest.parse:unknown_keys" {
 
     val b: R.Result[Manifest, str] = tparse(?alloc, ?itn, "[project]\nid=\"x\"\nversion=\"1\"\nsrc=\"src\"\nout=\"out\"\n[target.l]\nisa=\"x86_64\"\nos=\"linux\"\nabi=\"sysv64\"\nwat=\"z\"\n");
     if (R.is_ok[Manifest, str](b) || !str_equals(R.unwrap_err[Manifest, str](b), "mach.toml: unknown key 'wat' in [target.l]")) { code = 1; }
+    arena.dnit(?ar);
+    ret code;
+}
+
+# #2013 bootstrap staging: the strict parser ACCEPTS and value-validates `simd`
+# on a declared profile but does NOT yet require it -- "scalarize"/"require" parse
+# and store, an absent key is tolerated, and only an invalid value is rejected.
+# the required-everywhere flip lands with #2013 once this compiler is the seed
+test "mach.lang.manifest.parse:simd_accepted_not_required" {
+    var backing: A.Allocator; var ar: arena.Arena; var alloc: A.Allocator; var itn: intern.Interner;
+    if (!tinit(?backing, ?ar, ?alloc, ?itn)) { ret 1; }
+    var code: i32 = 0;
+    val head: str = "[project]\nid=\"x\"\nversion=\"1\"\nsrc=\"src\"\nout=\"out\"\n";
+
+    # "scalarize" parses and stores.
+    val a: R.Result[Manifest, str] = tparse(?alloc, ?itn, cc(?alloc, head, "[profile.p]\nopt=0\ndebug=false\nsimd=\"scalarize\"\n"));
+    if (R.is_err[Manifest, str](a)) { code = 1; }
+    or { if (R.unwrap_ok[Manifest, str](a).profiles[0].simd != SIMD_SCALARIZE) { code = 1; } }
+
+    # "require" parses and stores.
+    val b: R.Result[Manifest, str] = tparse(?alloc, ?itn, cc(?alloc, head, "[profile.p]\nopt=0\ndebug=false\nsimd=\"require\"\n"));
+    if (R.is_err[Manifest, str](b)) { code = 1; }
+    or { if (R.unwrap_ok[Manifest, str](b).profiles[0].simd != SIMD_REQUIRE) { code = 1; } }
+
+    # an absent key is tolerated in this stage (not yet required) and defaults to scalarize.
+    val c: R.Result[Manifest, str] = tparse(?alloc, ?itn, cc(?alloc, head, "[profile.p]\nopt=0\ndebug=false\n"));
+    if (R.is_err[Manifest, str](c)) { code = 1; }
+    or { if (R.unwrap_ok[Manifest, str](c).profiles[0].simd != SIMD_SCALARIZE) { code = 1; } }
+
+    # an invalid value is rejected with the specific error.
+    val d: R.Result[Manifest, str] = tparse(?alloc, ?itn, cc(?alloc, head, "[profile.p]\nopt=0\ndebug=false\nsimd=\"bogus\"\n"));
+    if (R.is_ok[Manifest, str](d) || !str_contains(R.unwrap_err[Manifest, str](d), "simd must be \"scalarize\" or \"require\"")) { code = 1; }
+
     arena.dnit(?ar);
     ret code;
 }


### PR DESCRIPTION
Bootstrap staging (stage α) for the required `simd` manifest key of the SIMD program (epic #1965, gate #2013).

Part of #2013.

## Why

The 3.3.0 seed rejects unknown manifest keys, so #2013 can't add a required-everywhere `simd` key and sweep the repo-root `mach.toml` in one step — the seed would fail to parse the swept root. Following the #1979 precedent (the 3.1.0 seed gate for the V2 totality flip), this small PR makes the strict parser **accept and value-validate** `simd` on `[profile.X]` **without requiring it yet**, so a compiler built from this source can parse a swept manifest and serve as the simd-aware seed for #2013's require-flip.

## What

- `SimdMode` (`scalarize` | `require`) on `ProfileDef`, `simd` added to the profile's known keys, and `parse_simd_mode` validating the value (invalid → specific error) but **tolerating an absent key** on every path (defaults to `scalarize`).
- No manifest changes anywhere in the tree — the required flip and the 28-manifest sweep land with #2013 (`Closes #2013`, stage γ), per owner ruling 1 (end state: required-everywhere).
- One colocated test pinning the tolerant-but-validating behavior.

## Verification

- Full suite green: 578 passed (dev baseline 577 + 1 new test).
- Self-host fixpoint byte-identical.
- Builds directly under the current 3.3.0 seed (no manifest changes, so trivially green in CI).
