### PR TITLE
feat: [profile.X] simd lever semantics (scalarize | require)

### DIFF
--- a/src/cli/cmd/build.mach
+++ b/src/cli/cmd/build.mach
@@ -681,6 +681,11 @@ fun build_unit(a: *A.Allocator, argc: usize, argv: **u8, marks: *bool, emit_obj:
         debug_ok = false;
     }
 
+    # thread the selected profile's resolved SIMD posture onto the session so the
+    # middle-end scalarize/require gate reads the consumer's setting (#2017). the
+    # posture is the consumer's alone; a dependency's own value never reaches here.
+    p.s.simd = p.config.simd;
+
     # fold the manifest default into the level: a CLI `-O*` flag wins,
     # otherwise the selected profile's opt applies, else debug.
     val level: u8 = resolve_opt_level(?p, cli_level, cli_set);

--- a/src/cli/cmd/build.mach
+++ b/src/cli/cmd/build.mach
@@ -1228,7 +1228,7 @@ fun build_dispatch_executable(p: *driver.Project, level: u8, verify_ir: bool, ob
     }
     var entry_ir: ir.Module = R.unwrap_ok[ir.Module, str](res_synth);
 
-    val res_opt: R.Result[bool, str] = pipeline.run(?entry_ir, ?p.target, level, verify_ir);
+    val res_opt: R.Result[bool, str] = pipeline.run(?entry_ir, ?p.target, level, verify_ir, p.s.simd == manifest.SIMD_REQUIRE, ?p.s.interner);
     if (R.is_err[bool, str](res_opt)) {
         ir.dnit(?entry_ir);
         print.eprint("error: ");

--- a/src/lang/be/codegen.mach
+++ b/src/lang/be/codegen.mach
@@ -12,13 +12,16 @@
 # here is shared across architectures. This module is the compute body of
 # `Q_CODEGEN`: one `ir.Module` produces exactly one `of.ObjectImage`.
 
+use std.allocator.page;
 use std.io.writer;
 use std.types.bool.bool;
 use std.types.bool.false;
 use std.types.bool.true;
 use std.types.size.usize;
 use std.types.string.str;
+use std.types.string.str_contains;
 use std.types.string.str_equals;
+use std.types.string.str_len;
 
 use A: std.allocator;
 use O: std.types.option;
@@ -34,12 +37,17 @@ use mach.lang.be.codegen.regalloc;
 use mach.lang.be.obj;
 use mach.lang.float;
 use mach.lang.intern;
+use mach.lang.manifest;
 use mach.lang.me.ir;
+use builder: mach.lang.me.ir.builder;
+use mach.lang.me.ir.id;
+use instruction: mach.lang.me.ir.instruction;
 use mach.lang.me.ir.type;
 use mach.lang.me.ir.value;
 use mach.lang.session;
 use source: mach.lang.source;
 use mach.lang.target;
+use resolved: mach.lang.target.resolved;
 use mach.lang.target.of;
 
 # a function moved out of `.text` by a `#[section("...")]` decorator
@@ -65,6 +73,121 @@ rec SectionPlacement {
 rec PlacedSite {
     sec: u32;
     off: u32;
+}
+
+# concatenate two strings into a fresh session-allocated buffer, degrading to `b`
+# on allocation failure (the message is best-effort, never load-bearing storage)
+fun cat(alloc: *A.Allocator, a: str, b: str) str {
+    val la: usize = str_len(a);
+    val lb: usize = str_len(b);
+    val res_buf: R.Result[*u8, str] = A.allocate[u8](alloc, la + lb + 1);
+    if (R.is_err[*u8, str](res_buf)) { ret b; }
+    val buf: *u8 = R.unwrap_ok[*u8, str](res_buf);
+    var w: usize = 0;
+    var i: usize = 0;
+    for (i < la) { buf[w] = a[i]; w = w + 1; i = i + 1; }
+    i = 0;
+    for (i < lb) { buf[w] = b[i]; w = w + 1; i = i + 1; }
+    buf[w] = 0;
+    ret buf::str;
+}
+
+# true when type id `ty` resolves to an IRT_VECTOR in the module's type table
+fun ty_is_vector(m: *ir.Module, ty: type.IrTypeId) bool {
+    val ot: O.Option[*type.IrType] = type.get(?m.types, ty);
+    if (!O.is_some[*type.IrType](ot)) { ret false; }
+    ret O.unwrap[*type.IrType](ot).kind == type.IRT_VECTOR;
+}
+
+# true when a 128-bit vector value flows through the instruction (result or operand),
+# i.e. it would scalarize on a target with no SIMD unit
+fun instr_touches_vector(m: *ir.Module, ins: *instruction.Instruction) bool {
+    if (ty_is_vector(m, ins.ty)) { ret true; }
+    var i: u32 = 0;
+    for (i < ins.operand_count) {
+        if (ty_is_vector(m, ins.operands[i].ty)) { ret true; }
+        i = i + 1;
+    }
+    ret false;
+}
+
+# a friendly category name for a lane-wise vector operation, for the require error
+fun vector_op_name(k: instruction.InstrKind) str {
+    if (k == instruction.OP_ADD)       { ret "add"; }
+    if (k == instruction.OP_SUB)       { ret "subtract"; }
+    if (k == instruction.OP_NEG)       { ret "negate"; }
+    if (k == instruction.OP_MUL)       { ret "multiply"; }
+    if (k == instruction.OP_DIV_S)     { ret "divide"; }
+    if (k == instruction.OP_DIV_U)     { ret "divide"; }
+    if (k == instruction.OP_AND)       { ret "and"; }
+    if (k == instruction.OP_OR)        { ret "or"; }
+    if (k == instruction.OP_XOR)       { ret "xor"; }
+    if (k == instruction.OP_NOT)       { ret "complement"; }
+    if (k == instruction.OP_CMP_EQ)    { ret "compare"; }
+    if (k == instruction.OP_CMP_NE)    { ret "compare"; }
+    if (k == instruction.OP_CMP_LT_S)  { ret "compare"; }
+    if (k == instruction.OP_CMP_LT_U)  { ret "compare"; }
+    if (k == instruction.OP_CMP_LE_S)  { ret "compare"; }
+    if (k == instruction.OP_CMP_LE_U)  { ret "compare"; }
+    ret "value";
+}
+
+# assemble the precise `require`-mode error naming the offending operation, the
+# containing function, and the incapable target arch, plus the actionable fix
+fun require_error_msg(s: *session.Session, tgt: *target.Target, fn: *ir.Function, ins: *instruction.Instruction) str {
+    val op: str = vector_op_name(ins.kind);
+    var fname: str = "<anonymous>";
+    val on: O.Option[str] = intern.lookup(?s.interner, fn.name);
+    if (O.is_some[str](on)) { fname = O.unwrap[str](on); }
+
+    var msg: str = cat(s.alloc, "codegen: simd = \"require\": vector ", op);
+    msg = cat(s.alloc, msg, " in '");
+    msg = cat(s.alloc, msg, fname);
+    msg = cat(s.alloc, msg, "' would scalarize on ");
+    msg = cat(s.alloc, msg, tgt.arch.name);
+    msg = cat(s.alloc, msg, " (target has no 128-bit SIMD); set simd = \"scalarize\" to build with the scalar expansion");
+    ret msg;
+}
+
+# #2017: enforce the resolved `require` SIMD posture over the target capability fact.
+#
+# On an incapable target (`MachineModel.has_v128 == false`) every lane-wise vector
+# operator scalarizes; `simd = "require"` is the consumer's request to reject that,
+# so any surviving `IRT_VECTOR`-typed instruction is a precise build error naming the
+# operation and its containing function rather than a silent scalarization. Inert on
+# capable targets and under `simd = "scalarize"` (the default posture, where #2016's
+# scalarization pass lowers vector ops before codegen so none reach here). Rides the
+# same vector-op detection the isel guard uses; #2016's cross-module scalarization
+# tally refines the enumeration when it lands. Reports the first offending op, so the
+# build aborts once with an actionable message.
+# ---
+# s:     the session carrying the resolved `simd` posture
+# tgt:   the resolved target carrying the `has_v128` capability fact
+# irmod: the module about to be lowered
+# ret:   ok(true) when the build may proceed, or the require error string
+fun require_simd_check(s: *session.Session, tgt: *target.Target, irmod: *ir.Module) R.Result[bool, str] {
+    if (s.simd != manifest.SIMD_REQUIRE) { ret R.ok[bool, str](true); }
+    if (tgt.model.has_v128)              { ret R.ok[bool, str](true); }
+
+    var fi: u32 = 0;
+    for (fi < irmod.function_len) {
+        val fn: *ir.Function = ?irmod.functions[fi];
+        var bi: u32 = 0;
+        for (bi < fn.block_count) {
+            val blk: *ir.Block = ?fn.blocks[bi];
+            var ix: u32 = 0;
+            for (ix < blk.instr_count) {
+                val ins: *instruction.Instruction = ?fn.instrs[blk.instructions[ix]];
+                if (instr_touches_vector(irmod, ins)) {
+                    ret R.err[bool, str](require_error_msg(s, tgt, fn, ins));
+                }
+                ix = ix + 1;
+            }
+            bi = bi + 1;
+        }
+        fi = fi + 1;
+    }
+    ret R.ok[bool, str](true);
 }
 
 # generate an object image for one optimised IR module
@@ -106,6 +229,11 @@ pub fun codegen_module(s: *session.Session, tgt: *target.Target,
     if (s == nil)     { ret R.err[of.ObjectImage, str]("codegen: nil session"); }
     if (tgt == nil)   { ret R.err[of.ObjectImage, str]("codegen: nil target"); }
     if (irmod == nil) { ret R.err[of.ObjectImage, str]("codegen: nil ir module"); }
+
+    # #2017: enforce the resolved `require` posture before lowering. On an incapable
+    # target a vector op would scalarize; `require` rejects that with a precise error.
+    val res_req: R.Result[bool, str] = require_simd_check(s, tgt, irmod);
+    if (R.is_err[bool, str](res_req)) { ret R.err[of.ObjectImage, str](R.unwrap_err[bool, str](res_req)); }
 
     val res_lower: R.Result[mir.MirModule, str] = lower.lower_ir(tgt, irmod, ?s.interner);
     if (R.is_err[mir.MirModule, str](res_lower)) {
@@ -1078,4 +1206,94 @@ test "mach.lang.be.codegen.pack_rows:rehomes_sectioned_and_text" {
     # blob 20: `.text` after the 8-byte excised range -> section 1 at offset 20 - 8 = 12.
     if (enc.rows[2].sec != 1 || enc.rows[2].text_offset != 12) { ret 1; }
     ret 0;
+}
+
+# #2017: the require posture resolved over the target capability fact. On an
+# incapable target (riscv64, has_v128 false) a vector op is a precise, actionable
+# build error naming the operation, the containing function, and the arch; on a
+# capable target (x86_64) require is inert; under scalarize nothing errors; and a
+# vectorless module is always clean regardless of posture or target.
+test "mach.lang.be.codegen.require_simd_check:posture_over_capability" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+    var code: i32 = 0;
+
+    var reg: target.TargetRegistry = target.registry_init();
+    if (R.is_err[bool, str](target.register_all(?reg))) { ret 1; }
+    val trr: R.Result[resolved.Target, str] = target.select(?reg, "riscv64", "linux", "lp64");
+    if (R.is_err[resolved.Target, str](trr)) { ret 1; }
+    var rv: resolved.Target = R.unwrap_ok[resolved.Target, str](trr);
+    val txr: R.Result[resolved.Target, str] = target.select(?reg, "x86_64", "linux", "sysv64");
+    if (R.is_err[resolved.Target, str](txr)) { ret 1; }
+    var x64: resolved.Target = R.unwrap_ok[resolved.Target, str](txr);
+
+    val res_s: R.Result[session.Session, str] = session.init(?alloc);
+    if (R.is_err[session.Session, str](res_s)) { ret 1; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](res_s);
+
+    # a module with one function 'kernel' whose body holds a vector add
+    val fname_r: R.Result[intern.StrId, str] = intern.intern(?s.interner, "kernel");
+    if (R.is_err[intern.StrId, str](fname_r)) { session.dnit(?s); ret 1; }
+    val fname: intern.StrId = R.unwrap_ok[intern.StrId, str](fname_r);
+
+    val res_m: R.Result[ir.Module, str] = ir.init(?alloc, intern.STR_NIL);
+    if (R.is_err[ir.Module, str](res_m)) { session.dnit(?s); ret 1; }
+    var m: ir.Module = R.unwrap_ok[ir.Module, str](res_m);
+    val ef: R.Result[type.IrTypeId, str] = type.intern_float(?m.types, 32);
+    if (R.is_err[type.IrTypeId, str](ef)) { code = 1; }
+    val vf: R.Result[type.IrTypeId, str] = type.intern_vector(?m.types, R.unwrap_ok[type.IrTypeId, str](ef), 4);
+    if (R.is_err[type.IrTypeId, str](vf)) { code = 1; }
+    val vecty: type.IrTypeId = R.unwrap_ok[type.IrTypeId, str](vf);
+    val res_fn: R.Result[u32, str] = ir.function_add(?m, fname, type.IRT_NIL, 0);
+    if (R.is_err[u32, str](res_fn)) { code = 1; }
+    val fn: *ir.Function = ?m.functions[R.unwrap_ok[u32, str](res_fn)];
+    var b: builder.Builder = builder.init(?m);
+    builder.set_function(?b, fn);
+    val rb: R.Result[id.BlockId, str] = builder.new_block(?b);
+    if (R.is_err[id.BlockId, str](rb)) { code = 1; }
+    builder.set_block(?b, R.unwrap_ok[id.BlockId, str](rb));
+    if (R.is_err[value.Value, str](builder.emit_add(?b, value.const_int(0, vecty), value.const_int(0, vecty)))) { code = 1; }
+
+    # require + incapable + vector -> a precise error naming op, function, and arch
+    s.simd = manifest.SIMD_REQUIRE;
+    val e1: R.Result[bool, str] = require_simd_check(?s, ?rv, ?m);
+    if (R.is_ok[bool, str](e1)) { code = 1; }
+    or {
+        val msg: str = R.unwrap_err[bool, str](e1);
+        if (!str_contains(msg, "simd = \"require\"")) { code = 1; }
+        if (!str_contains(msg, "kernel"))            { code = 1; }
+        if (!str_contains(msg, "riscv64"))           { code = 1; }
+        if (!str_contains(msg, "would scalarize"))   { code = 1; }
+    }
+
+    # require + capable -> inert
+    if (R.is_err[bool, str](require_simd_check(?s, ?x64, ?m))) { code = 1; }
+
+    # scalarize + incapable -> the pass will scalarize; no require error here
+    s.simd = manifest.SIMD_SCALARIZE;
+    if (R.is_err[bool, str](require_simd_check(?s, ?rv, ?m))) { code = 1; }
+
+    # require + incapable + no vector -> clean (the walk finds nothing to reject)
+    val res_m2: R.Result[ir.Module, str] = ir.init(?alloc, intern.STR_NIL);
+    if (R.is_err[ir.Module, str](res_m2)) { code = 1; }
+    var m2: ir.Module = R.unwrap_ok[ir.Module, str](res_m2);
+    val i32r: R.Result[type.IrTypeId, str] = type.intern_int(?m2.types, 32);
+    if (R.is_err[type.IrTypeId, str](i32r)) { code = 1; }
+    val i32t: type.IrTypeId = R.unwrap_ok[type.IrTypeId, str](i32r);
+    val rf2: R.Result[u32, str] = ir.function_add(?m2, fname, type.IRT_NIL, 0);
+    if (R.is_err[u32, str](rf2)) { code = 1; }
+    val fn2: *ir.Function = ?m2.functions[R.unwrap_ok[u32, str](rf2)];
+    var b2: builder.Builder = builder.init(?m2);
+    builder.set_function(?b2, fn2);
+    val rb2: R.Result[id.BlockId, str] = builder.new_block(?b2);
+    if (R.is_err[id.BlockId, str](rb2)) { code = 1; }
+    builder.set_block(?b2, R.unwrap_ok[id.BlockId, str](rb2));
+    if (R.is_err[value.Value, str](builder.emit_add(?b2, value.const_int(0, i32t), value.const_int(1, i32t)))) { code = 1; }
+    s.simd = manifest.SIMD_REQUIRE;
+    if (R.is_err[bool, str](require_simd_check(?s, ?rv, ?m2))) { code = 1; }
+
+    ir.dnit(?m2);
+    ir.dnit(?m);
+    session.dnit(?s);
+    ret code;
 }

--- a/src/lang/be/codegen.mach
+++ b/src/lang/be/codegen.mach
@@ -169,6 +169,10 @@ fun require_simd_check(s: *session.Session, tgt: *target.Target, irmod: *ir.Modu
     if (s.simd != manifest.SIMD_REQUIRE) { ret R.ok[bool, str](true); }
     if (tgt.model.has_v128)              { ret R.ok[bool, str](true); }
 
+    # a recognized lane-wise operator makes the most actionable message, so prefer
+    # one over an incidental vector value (a literal or lane load) if any is present.
+    var any_fn:  *ir.Function        = nil;
+    var any_ins: *instruction.Instruction = nil;
     var fi: u32 = 0;
     for (fi < irmod.function_len) {
         val fn: *ir.Function = ?irmod.functions[fi];
@@ -179,7 +183,10 @@ fun require_simd_check(s: *session.Session, tgt: *target.Target, irmod: *ir.Modu
             for (ix < blk.instr_count) {
                 val ins: *instruction.Instruction = ?fn.instrs[blk.instructions[ix]];
                 if (instr_touches_vector(irmod, ins)) {
-                    ret R.err[bool, str](require_error_msg(s, tgt, fn, ins));
+                    if (!str_equals(vector_op_name(ins.kind), "value")) {
+                        ret R.err[bool, str](require_error_msg(s, tgt, fn, ins));
+                    }
+                    if (any_ins == nil) { any_fn = fn; any_ins = ins; }
                 }
                 ix = ix + 1;
             }
@@ -187,6 +194,7 @@ fun require_simd_check(s: *session.Session, tgt: *target.Target, irmod: *ir.Modu
         }
         fi = fi + 1;
     }
+    if (any_ins != nil) { ret R.err[bool, str](require_error_msg(s, tgt, any_fn, any_ins)); }
     ret R.ok[bool, str](true);
 }
 

--- a/src/lang/be/codegen.mach
+++ b/src/lang/be/codegen.mach
@@ -12,16 +12,13 @@
 # here is shared across architectures. This module is the compute body of
 # `Q_CODEGEN`: one `ir.Module` produces exactly one `of.ObjectImage`.
 
-use std.allocator.page;
 use std.io.writer;
 use std.types.bool.bool;
 use std.types.bool.false;
 use std.types.bool.true;
 use std.types.size.usize;
 use std.types.string.str;
-use std.types.string.str_contains;
 use std.types.string.str_equals;
-use std.types.string.str_len;
 
 use A: std.allocator;
 use O: std.types.option;
@@ -37,17 +34,12 @@ use mach.lang.be.codegen.regalloc;
 use mach.lang.be.obj;
 use mach.lang.float;
 use mach.lang.intern;
-use mach.lang.manifest;
 use mach.lang.me.ir;
-use builder: mach.lang.me.ir.builder;
-use mach.lang.me.ir.id;
-use instruction: mach.lang.me.ir.instruction;
 use mach.lang.me.ir.type;
 use mach.lang.me.ir.value;
 use mach.lang.session;
 use source: mach.lang.source;
 use mach.lang.target;
-use resolved: mach.lang.target.resolved;
 use mach.lang.target.of;
 
 # a function moved out of `.text` by a `#[section("...")]` decorator
@@ -73,129 +65,6 @@ rec SectionPlacement {
 rec PlacedSite {
     sec: u32;
     off: u32;
-}
-
-# concatenate two strings into a fresh session-allocated buffer, degrading to `b`
-# on allocation failure (the message is best-effort, never load-bearing storage)
-fun cat(alloc: *A.Allocator, a: str, b: str) str {
-    val la: usize = str_len(a);
-    val lb: usize = str_len(b);
-    val res_buf: R.Result[*u8, str] = A.allocate[u8](alloc, la + lb + 1);
-    if (R.is_err[*u8, str](res_buf)) { ret b; }
-    val buf: *u8 = R.unwrap_ok[*u8, str](res_buf);
-    var w: usize = 0;
-    var i: usize = 0;
-    for (i < la) { buf[w] = a[i]; w = w + 1; i = i + 1; }
-    i = 0;
-    for (i < lb) { buf[w] = b[i]; w = w + 1; i = i + 1; }
-    buf[w] = 0;
-    ret buf::str;
-}
-
-# true when type id `ty` resolves to an IRT_VECTOR in the module's type table
-fun ty_is_vector(m: *ir.Module, ty: type.IrTypeId) bool {
-    val ot: O.Option[*type.IrType] = type.get(?m.types, ty);
-    if (!O.is_some[*type.IrType](ot)) { ret false; }
-    ret O.unwrap[*type.IrType](ot).kind == type.IRT_VECTOR;
-}
-
-# true when a 128-bit vector value flows through the instruction (result or operand),
-# i.e. it would scalarize on a target with no SIMD unit
-fun instr_touches_vector(m: *ir.Module, ins: *instruction.Instruction) bool {
-    if (ty_is_vector(m, ins.ty)) { ret true; }
-    var i: u32 = 0;
-    for (i < ins.operand_count) {
-        if (ty_is_vector(m, ins.operands[i].ty)) { ret true; }
-        i = i + 1;
-    }
-    ret false;
-}
-
-# a friendly category name for a lane-wise vector operation, for the require error
-fun vector_op_name(k: instruction.InstrKind) str {
-    if (k == instruction.OP_ADD)       { ret "add"; }
-    if (k == instruction.OP_SUB)       { ret "subtract"; }
-    if (k == instruction.OP_NEG)       { ret "negate"; }
-    if (k == instruction.OP_MUL)       { ret "multiply"; }
-    if (k == instruction.OP_DIV_S)     { ret "divide"; }
-    if (k == instruction.OP_DIV_U)     { ret "divide"; }
-    if (k == instruction.OP_AND)       { ret "and"; }
-    if (k == instruction.OP_OR)        { ret "or"; }
-    if (k == instruction.OP_XOR)       { ret "xor"; }
-    if (k == instruction.OP_NOT)       { ret "complement"; }
-    if (k == instruction.OP_CMP_EQ)    { ret "compare"; }
-    if (k == instruction.OP_CMP_NE)    { ret "compare"; }
-    if (k == instruction.OP_CMP_LT_S)  { ret "compare"; }
-    if (k == instruction.OP_CMP_LT_U)  { ret "compare"; }
-    if (k == instruction.OP_CMP_LE_S)  { ret "compare"; }
-    if (k == instruction.OP_CMP_LE_U)  { ret "compare"; }
-    ret "value";
-}
-
-# assemble the precise `require`-mode error naming the offending operation, the
-# containing function, and the incapable target arch, plus the actionable fix
-fun require_error_msg(s: *session.Session, tgt: *target.Target, fn: *ir.Function, ins: *instruction.Instruction) str {
-    val op: str = vector_op_name(ins.kind);
-    var fname: str = "<anonymous>";
-    val on: O.Option[str] = intern.lookup(?s.interner, fn.name);
-    if (O.is_some[str](on)) { fname = O.unwrap[str](on); }
-
-    var msg: str = cat(s.alloc, "codegen: simd = \"require\": vector ", op);
-    msg = cat(s.alloc, msg, " in '");
-    msg = cat(s.alloc, msg, fname);
-    msg = cat(s.alloc, msg, "' would scalarize on ");
-    msg = cat(s.alloc, msg, tgt.arch.name);
-    msg = cat(s.alloc, msg, " (target has no 128-bit SIMD); set simd = \"scalarize\" to build with the scalar expansion");
-    ret msg;
-}
-
-# #2017: enforce the resolved `require` SIMD posture over the target capability fact.
-#
-# On an incapable target (`MachineModel.has_v128 == false`) every lane-wise vector
-# operator scalarizes; `simd = "require"` is the consumer's request to reject that,
-# so any surviving `IRT_VECTOR`-typed instruction is a precise build error naming the
-# operation and its containing function rather than a silent scalarization. Inert on
-# capable targets and under `simd = "scalarize"` (the default posture, where #2016's
-# scalarization pass lowers vector ops before codegen so none reach here). Rides the
-# same vector-op detection the isel guard uses; #2016's cross-module scalarization
-# tally refines the enumeration when it lands. Reports the first offending op, so the
-# build aborts once with an actionable message.
-# ---
-# s:     the session carrying the resolved `simd` posture
-# tgt:   the resolved target carrying the `has_v128` capability fact
-# irmod: the module about to be lowered
-# ret:   ok(true) when the build may proceed, or the require error string
-fun require_simd_check(s: *session.Session, tgt: *target.Target, irmod: *ir.Module) R.Result[bool, str] {
-    if (s.simd != manifest.SIMD_REQUIRE) { ret R.ok[bool, str](true); }
-    if (tgt.model.has_v128)              { ret R.ok[bool, str](true); }
-
-    # a recognized lane-wise operator makes the most actionable message, so prefer
-    # one over an incidental vector value (a literal or lane load) if any is present.
-    var any_fn:  *ir.Function        = nil;
-    var any_ins: *instruction.Instruction = nil;
-    var fi: u32 = 0;
-    for (fi < irmod.function_len) {
-        val fn: *ir.Function = ?irmod.functions[fi];
-        var bi: u32 = 0;
-        for (bi < fn.block_count) {
-            val blk: *ir.Block = ?fn.blocks[bi];
-            var ix: u32 = 0;
-            for (ix < blk.instr_count) {
-                val ins: *instruction.Instruction = ?fn.instrs[blk.instructions[ix]];
-                if (instr_touches_vector(irmod, ins)) {
-                    if (!str_equals(vector_op_name(ins.kind), "value")) {
-                        ret R.err[bool, str](require_error_msg(s, tgt, fn, ins));
-                    }
-                    if (any_ins == nil) { any_fn = fn; any_ins = ins; }
-                }
-                ix = ix + 1;
-            }
-            bi = bi + 1;
-        }
-        fi = fi + 1;
-    }
-    if (any_ins != nil) { ret R.err[bool, str](require_error_msg(s, tgt, any_fn, any_ins)); }
-    ret R.ok[bool, str](true);
 }
 
 # generate an object image for one optimised IR module
@@ -237,11 +106,6 @@ pub fun codegen_module(s: *session.Session, tgt: *target.Target,
     if (s == nil)     { ret R.err[of.ObjectImage, str]("codegen: nil session"); }
     if (tgt == nil)   { ret R.err[of.ObjectImage, str]("codegen: nil target"); }
     if (irmod == nil) { ret R.err[of.ObjectImage, str]("codegen: nil ir module"); }
-
-    # #2017: enforce the resolved `require` posture before lowering. On an incapable
-    # target a vector op would scalarize; `require` rejects that with a precise error.
-    val res_req: R.Result[bool, str] = require_simd_check(s, tgt, irmod);
-    if (R.is_err[bool, str](res_req)) { ret R.err[of.ObjectImage, str](R.unwrap_err[bool, str](res_req)); }
 
     val res_lower: R.Result[mir.MirModule, str] = lower.lower_ir(tgt, irmod, ?s.interner);
     if (R.is_err[mir.MirModule, str](res_lower)) {
@@ -1214,94 +1078,4 @@ test "mach.lang.be.codegen.pack_rows:rehomes_sectioned_and_text" {
     # blob 20: `.text` after the 8-byte excised range -> section 1 at offset 20 - 8 = 12.
     if (enc.rows[2].sec != 1 || enc.rows[2].text_offset != 12) { ret 1; }
     ret 0;
-}
-
-# #2017: the require posture resolved over the target capability fact. On an
-# incapable target (riscv64, has_v128 false) a vector op is a precise, actionable
-# build error naming the operation, the containing function, and the arch; on a
-# capable target (x86_64) require is inert; under scalarize nothing errors; and a
-# vectorless module is always clean regardless of posture or target.
-test "mach.lang.be.codegen.require_simd_check:posture_over_capability" {
-    var alloc: A.Allocator;
-    page.make(?alloc);
-    var code: i32 = 0;
-
-    var reg: target.TargetRegistry = target.registry_init();
-    if (R.is_err[bool, str](target.register_all(?reg))) { ret 1; }
-    val trr: R.Result[resolved.Target, str] = target.select(?reg, "riscv64", "linux", "lp64");
-    if (R.is_err[resolved.Target, str](trr)) { ret 1; }
-    var rv: resolved.Target = R.unwrap_ok[resolved.Target, str](trr);
-    val txr: R.Result[resolved.Target, str] = target.select(?reg, "x86_64", "linux", "sysv64");
-    if (R.is_err[resolved.Target, str](txr)) { ret 1; }
-    var x64: resolved.Target = R.unwrap_ok[resolved.Target, str](txr);
-
-    val res_s: R.Result[session.Session, str] = session.init(?alloc);
-    if (R.is_err[session.Session, str](res_s)) { ret 1; }
-    var s: session.Session = R.unwrap_ok[session.Session, str](res_s);
-
-    # a module with one function 'kernel' whose body holds a vector add
-    val fname_r: R.Result[intern.StrId, str] = intern.intern(?s.interner, "kernel");
-    if (R.is_err[intern.StrId, str](fname_r)) { session.dnit(?s); ret 1; }
-    val fname: intern.StrId = R.unwrap_ok[intern.StrId, str](fname_r);
-
-    val res_m: R.Result[ir.Module, str] = ir.init(?alloc, intern.STR_NIL);
-    if (R.is_err[ir.Module, str](res_m)) { session.dnit(?s); ret 1; }
-    var m: ir.Module = R.unwrap_ok[ir.Module, str](res_m);
-    val ef: R.Result[type.IrTypeId, str] = type.intern_float(?m.types, 32);
-    if (R.is_err[type.IrTypeId, str](ef)) { code = 1; }
-    val vf: R.Result[type.IrTypeId, str] = type.intern_vector(?m.types, R.unwrap_ok[type.IrTypeId, str](ef), 4);
-    if (R.is_err[type.IrTypeId, str](vf)) { code = 1; }
-    val vecty: type.IrTypeId = R.unwrap_ok[type.IrTypeId, str](vf);
-    val res_fn: R.Result[u32, str] = ir.function_add(?m, fname, type.IRT_NIL, 0);
-    if (R.is_err[u32, str](res_fn)) { code = 1; }
-    val fn: *ir.Function = ?m.functions[R.unwrap_ok[u32, str](res_fn)];
-    var b: builder.Builder = builder.init(?m);
-    builder.set_function(?b, fn);
-    val rb: R.Result[id.BlockId, str] = builder.new_block(?b);
-    if (R.is_err[id.BlockId, str](rb)) { code = 1; }
-    builder.set_block(?b, R.unwrap_ok[id.BlockId, str](rb));
-    if (R.is_err[value.Value, str](builder.emit_add(?b, value.const_int(0, vecty), value.const_int(0, vecty)))) { code = 1; }
-
-    # require + incapable + vector -> a precise error naming op, function, and arch
-    s.simd = manifest.SIMD_REQUIRE;
-    val e1: R.Result[bool, str] = require_simd_check(?s, ?rv, ?m);
-    if (R.is_ok[bool, str](e1)) { code = 1; }
-    or {
-        val msg: str = R.unwrap_err[bool, str](e1);
-        if (!str_contains(msg, "simd = \"require\"")) { code = 1; }
-        if (!str_contains(msg, "kernel"))            { code = 1; }
-        if (!str_contains(msg, "riscv64"))           { code = 1; }
-        if (!str_contains(msg, "would scalarize"))   { code = 1; }
-    }
-
-    # require + capable -> inert
-    if (R.is_err[bool, str](require_simd_check(?s, ?x64, ?m))) { code = 1; }
-
-    # scalarize + incapable -> the pass will scalarize; no require error here
-    s.simd = manifest.SIMD_SCALARIZE;
-    if (R.is_err[bool, str](require_simd_check(?s, ?rv, ?m))) { code = 1; }
-
-    # require + incapable + no vector -> clean (the walk finds nothing to reject)
-    val res_m2: R.Result[ir.Module, str] = ir.init(?alloc, intern.STR_NIL);
-    if (R.is_err[ir.Module, str](res_m2)) { code = 1; }
-    var m2: ir.Module = R.unwrap_ok[ir.Module, str](res_m2);
-    val i32r: R.Result[type.IrTypeId, str] = type.intern_int(?m2.types, 32);
-    if (R.is_err[type.IrTypeId, str](i32r)) { code = 1; }
-    val i32t: type.IrTypeId = R.unwrap_ok[type.IrTypeId, str](i32r);
-    val rf2: R.Result[u32, str] = ir.function_add(?m2, fname, type.IRT_NIL, 0);
-    if (R.is_err[u32, str](rf2)) { code = 1; }
-    val fn2: *ir.Function = ?m2.functions[R.unwrap_ok[u32, str](rf2)];
-    var b2: builder.Builder = builder.init(?m2);
-    builder.set_function(?b2, fn2);
-    val rb2: R.Result[id.BlockId, str] = builder.new_block(?b2);
-    if (R.is_err[id.BlockId, str](rb2)) { code = 1; }
-    builder.set_block(?b2, R.unwrap_ok[id.BlockId, str](rb2));
-    if (R.is_err[value.Value, str](builder.emit_add(?b2, value.const_int(0, i32t), value.const_int(1, i32t)))) { code = 1; }
-    s.simd = manifest.SIMD_REQUIRE;
-    if (R.is_err[bool, str](require_simd_check(?s, ?rv, ?m2))) { code = 1; }
-
-    ir.dnit(?m2);
-    ir.dnit(?m);
-    session.dnit(?s);
-    ret code;
 }

--- a/src/lang/driver.mach
+++ b/src/lang/driver.mach
@@ -5042,7 +5042,7 @@ fun q_lower_compute(db: *query.QueryDb, key: u64, alloc: *A.Allocator) R.Result[
 
     # optimize in place: the cached artifact is the post-pipeline IR the object is
     # built from, so an unchanged optimized module reuses its codegen output.
-    val res_opt: R.Result[bool, str] = pipeline.run(?irmod, ?p.target, p.opt_level, p.verify_ir);
+    val res_opt: R.Result[bool, str] = pipeline.run(?irmod, ?p.target, p.opt_level, p.verify_ir, p.s.simd == manifest.SIMD_REQUIRE, ?p.s.interner);
     if (R.is_err[bool, str](res_opt)) {
         ir.dnit(?irmod);
         ret R.err[query.QueryOutput, str](R.unwrap_err[bool, str](res_opt));

--- a/src/lang/driver.mach
+++ b/src/lang/driver.mach
@@ -181,6 +181,9 @@ pub rec DepEntry {
 # emit_asm:     selected profile's ASM-emission default
 # debug:        selected profile's debug-info default (`[profile.*] debug`); the
 #               driver ORs it with the CLI `-g` flag into the session's resolved bit
+# simd:         selected profile's SIMD strictness lever (`[profile.*] simd`); the
+#               consumer's posture over the target capability fact, resolved onto the
+#               session and read at the build's scalarize/require gate (#2017)
 # defines:      merged comptime defines for the selected unit (artifact < target
 #               < cell), each `NAME` or `NAME=VALUE`; bound into every module's
 #               comptime ctx during load (#1191); nil when none
@@ -212,6 +215,7 @@ pub rec ProjectConfig {
     emit_ir:      bool;
     emit_asm:     bool;
     debug:        bool;
+    simd:         manifest.SimdMode;
     defines:      *intern.StrId;
     define_count: u32;
     cascade_libs:      *intern.StrId;
@@ -1396,6 +1400,7 @@ fun init_project(p: *Project, s: *session.Session) {
     p.config.emit_ir      = false;
     p.config.emit_asm     = false;
     p.config.debug        = false;
+    p.config.simd         = manifest.SIMD_SCALARIZE;
     p.config.defines       = nil;
     p.config.define_count  = 0;
     p.config.cascade_libs      = nil;
@@ -1601,6 +1606,7 @@ fun load_config(p: *Project, project_root: str, t: *toml.Table, sel: *manifest.S
     p.config.emit_ir      = bu.emit_ir;
     p.config.emit_asm     = bu.emit_asm;
     p.config.debug        = bu.debug;
+    p.config.simd         = bu.simd;
     p.config.defines       = bu.defines;
     p.config.define_count  = bu.define_count;
     p.target_entry        = ?p.config.targets[0];

--- a/src/lang/manifest.mach
+++ b/src/lang/manifest.mach
@@ -168,6 +168,7 @@ pub rec BuildUnit {
     emit_ir:      bool;
     emit_asm:     bool;
     debug:        bool;
+    simd:         SimdMode;
     is_lib:       bool;
     kind:         LibKind;
     libs:         *intern.StrId;
@@ -188,6 +189,7 @@ pub rec ResolvedProfile {
     emit_ir:  bool;
     emit_asm: bool;
     debug:    bool;
+    simd:     SimdMode;
 }
 
 rec StrArr {
@@ -1273,6 +1275,7 @@ fun profile_resolved(pf: *ProfileDef) ResolvedProfile {
     rp.emit_ir  = pf.emit_ir;
     rp.emit_asm = pf.emit_asm;
     rp.debug    = pf.debug;
+    rp.simd     = pf.simd;
     ret rp;
 }
 
@@ -1301,6 +1304,7 @@ pub fun resolve_profile(alloc: *A.Allocator, itn: *intern.Interner, m: *Manifest
     rp.emit_ir  = false;
     rp.emit_asm = false;
     rp.debug    = false;
+    rp.simd     = SIMD_SCALARIZE;
     ret R.ok[ResolvedProfile, str](rp);
 }
 
@@ -1648,6 +1652,7 @@ pub fun resolve_build_unit(alloc: *A.Allocator, itn: *intern.Interner, m: *Manif
     u.emit_ir      = rp.emit_ir;
     u.emit_asm     = rp.emit_asm;
     u.debug        = rp.debug;
+    u.simd         = rp.simd;
     u.is_lib       = a.is_lib;
     u.kind         = LIBKIND_STATIC;
     val kind_str: str = idstr(itn, a.kind);

--- a/src/lang/manifest.mach
+++ b/src/lang/manifest.mach
@@ -2188,6 +2188,56 @@ test "mach.lang.manifest.resolve_build_unit:default_profile" {
     ret code;
 }
 
+# #2017: the selected profile's `simd` posture threads onto the resolved BuildUnit
+# (require / scalarize), and the no-`[profile]` default branch resolves to scalarize.
+test "mach.lang.manifest.resolve_build_unit:simd_posture" {
+    var backing: A.Allocator; var ar: arena.Arena; var alloc: A.Allocator; var itn: intern.Interner;
+    if (!tinit(?backing, ?ar, ?alloc, ?itn)) { ret 1; }
+    var code: i32 = 0;
+    val art: str = "[artifact.app]\nkind=\"bin\"\nentry=\"main.mach\"\nout=\"bin/app\"\ntargets=[\"*\"]\nlink = []\nneed = []\n";
+
+    # explicit require threads through as SIMD_REQUIRE
+    var req: str = cc(?alloc, "[project]\nid=\"x\"\nversion=\"1\"\nsrc=\"src\"\nout=\"out/{profile.name}\"\n", art);
+    req = cc(?alloc, req, "[profile.debug]\nopt=0\ndebug=false\nsimd=\"require\"\n");
+    req = cc(?alloc, req, host_target_stanza(?alloc, "h"));
+    val rr: R.Result[Manifest, str] = tparse(?alloc, ?itn, req);
+    if (R.is_err[Manifest, str](rr)) { code = 1; }
+    or {
+        var m: Manifest = R.unwrap_ok[Manifest, str](rr);
+        val u: R.Result[BuildUnit, str] = resolve_build_unit(?alloc, ?itn, ?m, mk_sel("native", "", "app", false, true));
+        if (R.is_err[BuildUnit, str](u)) { code = 1; }
+        or { if (R.unwrap_ok[BuildUnit, str](u).simd != SIMD_REQUIRE) { code = 1; } }
+    }
+
+    # explicit scalarize threads through as SIMD_SCALARIZE
+    var scl: str = cc(?alloc, "[project]\nid=\"x\"\nversion=\"1\"\nsrc=\"src\"\nout=\"out/{profile.name}\"\n", art);
+    scl = cc(?alloc, scl, "[profile.debug]\nopt=0\ndebug=false\nsimd=\"scalarize\"\n");
+    scl = cc(?alloc, scl, host_target_stanza(?alloc, "h"));
+    val rs: R.Result[Manifest, str] = tparse(?alloc, ?itn, scl);
+    if (R.is_err[Manifest, str](rs)) { code = 1; }
+    or {
+        var m: Manifest = R.unwrap_ok[Manifest, str](rs);
+        val u: R.Result[BuildUnit, str] = resolve_build_unit(?alloc, ?itn, ?m, mk_sel("native", "", "app", false, true));
+        if (R.is_err[BuildUnit, str](u)) { code = 1; }
+        or { if (R.unwrap_ok[BuildUnit, str](u).simd != SIMD_SCALARIZE) { code = 1; } }
+    }
+
+    # no [profile] declared -> the default branch of resolve_profile is scalarize
+    var non: str = cc(?alloc, "[project]\nid=\"y\"\nversion=\"1\"\nsrc=\"src\"\nout=\"out/{profile.name}\"\n", art);
+    non = cc(?alloc, non, host_target_stanza(?alloc, "h"));
+    val rn: R.Result[Manifest, str] = tparse(?alloc, ?itn, non);
+    if (R.is_err[Manifest, str](rn)) { code = 1; }
+    or {
+        var m: Manifest = R.unwrap_ok[Manifest, str](rn);
+        val u: R.Result[BuildUnit, str] = resolve_build_unit(?alloc, ?itn, ?m, mk_sel("native", "", "app", false, true));
+        if (R.is_err[BuildUnit, str](u)) { code = 1; }
+        or { if (R.unwrap_ok[BuildUnit, str](u).simd != SIMD_SCALARIZE) { code = 1; } }
+    }
+
+    arena.dnit(?ar);
+    ret code;
+}
+
 test "mach.lang.manifest.resolve_build_unit:native_resolution_multi_match" {
     var backing: A.Allocator; var ar: arena.Arena; var alloc: A.Allocator; var itn: intern.Interner;
     if (!tinit(?backing, ?ar, ?alloc, ?itn)) { ret 1; }
@@ -2649,6 +2699,36 @@ test "mach.lang.manifest.parse:root_reject_dep_consume" {
             if ( link_matches_target(?itn, k, tl)) { code = 1; }
         }
     }
+    arena.dnit(?ar);
+    ret code;
+}
+
+# #2017 no-ecosystem-fork guarantee: the simd posture is the consumer's alone. A
+# dependency manifest parsed off-root (as_root = false) is tolerated whether it
+# declares simd or omits it entirely, so a library can neither force `require` on a
+# consumer nor be broken by the required-key switch as a dependency; the key is
+# required only for the library's own standalone (as-root) builds. A dependency
+# carries no profile into the consumer's single root-resolved BuildUnit, so its simd
+# value is structurally inert -- DepDef/DepEntry hold no profile data.
+test "mach.lang.manifest.parse:simd_consumer_overrides_library" {
+    var backing: A.Allocator; var ar: arena.Arena; var alloc: A.Allocator; var itn: intern.Interner;
+    if (!tinit(?backing, ?ar, ?alloc, ?itn)) { ret 1; }
+    var code: i32 = 0;
+    val head: str = "[project]\nid=\"lib\"\nversion=\"1\"\nsrc=\"src\"\nout=\"out/{profile.name}\"\n[target.l]\nisa=\"x86_64\"\nos=\"linux\"\nabi=\"sysv64\"\n[artifact.lib]\nkind=\"static\"\nentry=\"lib.mach\"\nout=\"lib/lib\"\ntargets=[\"*\"]\nlink=[]\nneed=[]\n";
+
+    # a dependency declaring simd = "require" on its profiles: tolerated off-root, its
+    # posture never reaches the consumer build
+    val dep_req: str = cc(?alloc, head, "[profile.debug]\nopt=0\ndebug=false\nsimd=\"require\"\n[profile.release]\nopt=2\ndebug=false\nsimd=\"require\"\n");
+    if (R.is_err[Manifest, str](tparse_lenient(?alloc, ?itn, dep_req))) { code = 1; }
+
+    # a dependency omitting simd entirely: also tolerated off-root (not required)
+    val dep_bare: str = cc(?alloc, head, "[profile.debug]\nopt=0\ndebug=false\n[profile.release]\nopt=2\ndebug=false\n");
+    if (R.is_err[Manifest, str](tparse_lenient(?alloc, ?itn, dep_bare))) { code = 1; }
+
+    # but the same manifest built as a root is rejected: simd is required standalone
+    val bare_root: R.Result[Manifest, str] = tparse(?alloc, ?itn, dep_bare);
+    if (R.is_ok[Manifest, str](bare_root) || !str_contains(R.unwrap_err[Manifest, str](bare_root), "is missing required key 'simd'")) { code = 1; }
+
     arena.dnit(?ar);
     ret code;
 }

--- a/src/lang/me/pipeline.mach
+++ b/src/lang/me/pipeline.mach
@@ -14,7 +14,10 @@ use std.allocator.page;
 use std.types.bool.bool;
 use std.types.bool.false;
 use std.types.bool.true;
+use std.types.size.usize;
 use std.types.string.str;
+use std.types.string.str_contains;
+use std.types.string.str_len;
 
 use A: std.allocator;
 use O: std.types.option;
@@ -38,6 +41,7 @@ use mach.lang.me.pass.mem2reg;
 use mach.lang.me.pass.scalarize;
 use mach.lang.source;
 use mach.lang.target;
+use resolved: mach.lang.target.resolved;
 
 # optimisation level selecting the pipeline's stage sequence
 pub def OptLevel: u8;
@@ -56,12 +60,17 @@ pub val OPT_RELEASE: OptLevel = 1;
 # internal compiler error. When `verify_ir` is set, the verifier also runs after
 # every pass with the opt-in aggregate-representation checks enabled.
 # ---
-# m:         module to optimise in place
-# tgt:       target, consulted by the cost-model passes (inline)
-# level:     selects the stage sequence (debug vs release)
-# verify_ir: run the verifier after every pass, with representation checks on
-# ret:       ok(true) on a clean pipeline, or an internal-compiler-error message
-pub fun run(m: *ir.Module, tgt: *target.Target, level: OptLevel, verify_ir: bool) R.Result[bool, str] {
+# m:            module to optimise in place
+# tgt:          target, consulted by the cost-model passes (inline)
+# level:        selects the stage sequence (debug vs release)
+# verify_ir:    run the verifier after every pass, with representation checks on
+# simd_require: the resolved `[profile.X] simd == "require"` posture (#2017); on an
+#               incapable target it turns a would-scalarize vector op into a build
+#               error at the same gate where the scalarize pass would otherwise run
+# itn:          interner, consulted only on the require-error path to name the site
+# ret:          ok(true) on a clean pipeline, or an internal-compiler-error / a
+#               require-mode build-error message
+pub fun run(m: *ir.Module, tgt: *target.Target, level: OptLevel, verify_ir: bool, simd_require: bool, itn: *intern.Interner) R.Result[bool, str] {
     # entry verification sanity-checks the lowered input. reachability and
     # dominance are not enforced here: freshly-lowered IR still carries the
     # unreachable blocks the lowerer parks after terminators, which dce removes
@@ -157,18 +166,104 @@ pub fun run(m: *ir.Module, tgt: *target.Target, level: OptLevel, verify_ir: bool
         if (R.is_err[bool, str](res_verify_dce2)) { ret res_verify_dce2; }
     }
 
-    # target-conditional vector scalarization: on a SIMD-incapable target every
-    # IRT_VECTOR value and lane-wise operator is lowered to a defined per-lane scalar
-    # form over 16-byte stack slots, so no vector survives to MIR selection (#2016).
-    # a no-op on a capable target. runs last, after all optimization, so it legalizes
-    # the final IR the back end consumes; the verifier then re-checks the result.
-    val res_scalarize: R.Result[bool, str] = scalarize.run(m, tgt);
-    if (R.is_err[bool, str](res_scalarize)) { ret res_scalarize; }
-    val res_verify_scalarize: R.Result[bool, str] = verify_stage(m, true, verify_ir);
-    if (R.is_err[bool, str](res_verify_scalarize)) { ret res_verify_scalarize; }
+    # the single SIMD gate (#2017), keyed on the resolved posture over the target
+    # capability fact. on an incapable target (`has_v128 == false`) the profile lever
+    # decides what a would-scalarize vector op means:
+    #   require   -> a precise build error naming the op, function, and arch, from the
+    #                shared detection (#2016's `scalarize.detect`); the pass is skipped
+    #                so nothing is silently expanded.
+    #   scalarize -> the default posture: run #2016's scalarization pass, which lowers
+    #                every IRT_VECTOR value and lane-wise operator to a defined per-lane
+    #                scalar form over 16-byte stack slots (so no vector survives to MIR
+    #                selection) and tallies the one-shot note. runs last, after all
+    #                optimization, so it legalizes the final IR; the verifier re-checks.
+    # a no-op on a capable target under either posture (nothing scalarizes).
+    if (!tgt.model.has_v128) {
+        if (simd_require) {
+            val res_req: R.Result[bool, str] = require_check(m, tgt, itn);
+            if (R.is_err[bool, str](res_req)) { ret res_req; }
+        } or {
+            val res_scalarize: R.Result[bool, str] = scalarize.run(m, tgt);
+            if (R.is_err[bool, str](res_scalarize)) { ret res_scalarize; }
+            val res_verify_scalarize: R.Result[bool, str] = verify_stage(m, true, verify_ir);
+            if (R.is_err[bool, str](res_verify_scalarize)) { ret res_verify_scalarize; }
+        }
+    }
 
     # exit verification: full invariant check before the backend takes over.
     ret run_verify(m, true, false);
+}
+
+# the `require`-posture enforcement (#2017): reject the first would-scalarize vector
+# operator on an incapable target, using #2016's shared detection so the error names
+# exactly the sites the scalarize-posture note would tally. clean (ok) for a module
+# with no would-scalarize operators, so a vectorless build is never rejected.
+# ---
+# m:   the module about to be handed to the back end
+# tgt: the incapable target (`has_v128 == false`) whose arch the message names
+# itn: interner, to resolve the offending function's name
+# ret: ok(true) when nothing would scalarize, or the require build-error string
+fun require_check(m: *ir.Module, tgt: *target.Target, itn: *intern.Interner) R.Result[bool, str] {
+    var site: scalarize.ScalarizeSite;
+    val count: u32 = scalarize.detect(m, ?site);
+    if (count == 0) { ret R.ok[bool, str](true); }
+    ret R.err[bool, str](require_msg(m, tgt, itn, ?site, count));
+}
+
+# assemble the precise require-mode error naming the offending operator, its
+# containing function, and the incapable arch, plus the actionable fix
+fun require_msg(m: *ir.Module, tgt: *target.Target, itn: *intern.Interner, site: *scalarize.ScalarizeSite, count: u32) str {
+    val op: str = vector_op_name(site.op);
+    var fname: str = "<anonymous>";
+    val on: O.Option[str] = intern.lookup(itn, site.fn_name);
+    if (O.is_some[str](on)) { fname = O.unwrap[str](on); }
+
+    var msg: str = cat(m.alloc, "simd = \"require\": vector ", op);
+    msg = cat(m.alloc, msg, " in '");
+    msg = cat(m.alloc, msg, fname);
+    msg = cat(m.alloc, msg, "' would scalarize on ");
+    msg = cat(m.alloc, msg, tgt.arch.name);
+    msg = cat(m.alloc, msg, " (target has no 128-bit SIMD); set simd = \"scalarize\" to build with the scalar expansion");
+    ret msg;
+}
+
+# a friendly name for a lane-wise vector operator (the set `scalarize.detect`
+# reports; anything else is defensive)
+fun vector_op_name(k: instruction.InstrKind) str {
+    if (k == instruction.OP_ADD)      { ret "add"; }
+    if (k == instruction.OP_SUB)      { ret "subtract"; }
+    if (k == instruction.OP_NEG)      { ret "negate"; }
+    if (k == instruction.OP_MUL)      { ret "multiply"; }
+    if (k == instruction.OP_DIV_S)    { ret "divide"; }
+    if (k == instruction.OP_DIV_U)    { ret "divide"; }
+    if (k == instruction.OP_AND)      { ret "and"; }
+    if (k == instruction.OP_OR)       { ret "or"; }
+    if (k == instruction.OP_XOR)      { ret "xor"; }
+    if (k == instruction.OP_NOT)      { ret "complement"; }
+    if (k == instruction.OP_CMP_EQ)   { ret "compare"; }
+    if (k == instruction.OP_CMP_NE)   { ret "compare"; }
+    if (k == instruction.OP_CMP_LT_S) { ret "compare"; }
+    if (k == instruction.OP_CMP_LT_U) { ret "compare"; }
+    if (k == instruction.OP_CMP_LE_S) { ret "compare"; }
+    if (k == instruction.OP_CMP_LE_U) { ret "compare"; }
+    ret "operation";
+}
+
+# concatenate two strings into a fresh module-allocated buffer, degrading to `b`
+# on allocation failure (the message is best-effort, never load-bearing storage)
+fun cat(alloc: *A.Allocator, a: str, b: str) str {
+    val la: usize = str_len(a);
+    val lb: usize = str_len(b);
+    val res_buf: R.Result[*u8, str] = A.allocate[u8](alloc, la + lb + 1);
+    if (R.is_err[*u8, str](res_buf)) { ret b; }
+    val buf: *u8 = R.unwrap_ok[*u8, str](res_buf);
+    var w: usize = 0;
+    var i: usize = 0;
+    for (i < la) { buf[w] = a[i]; w = w + 1; i = i + 1; }
+    i = 0;
+    for (i < lb) { buf[w] = b[i]; w = w + 1; i = i + 1; }
+    buf[w] = 0;
+    ret buf::str;
 }
 
 # run the per-stage verifier when `verify_ir` is set, otherwise pass clean
@@ -477,4 +572,79 @@ test "mach.lang.me.pipeline.dbg:salvage_grows_expression_pool" {
 
     ir.dnit(?m);
     ret 0;
+}
+
+# #2017: the single SIMD gate in the pipeline over #2016's shared detection. On an
+# incapable target under `require`, a live would-scalarize vector operator is a
+# precise build error naming the op, function, and arch (the gate short-circuits
+# before exit verification); a vectorless module proceeds cleanly under `require`.
+# Inert on a capable target (the `has_v128` dispatch guard) is exercised end-to-end
+# by the driver build path.
+test "mach.lang.me.pipeline.run:simd_require_gate" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+    var itn: intern.Interner = intern.init(?alloc);
+    var code: i32 = 0;
+
+    var reg: target.TargetRegistry = target.registry_init();
+    if (R.is_err[bool, str](target.register_all(?reg))) { intern.dnit(?itn); ret 1; }
+    val trr: R.Result[resolved.Target, str] = target.select(?reg, "riscv64", "linux", "lp64");
+    if (R.is_err[resolved.Target, str](trr)) { intern.dnit(?itn); ret 1; }
+    var rv: resolved.Target = R.unwrap_ok[resolved.Target, str](trr);
+
+    val rfn: R.Result[intern.StrId, str] = intern.intern(?itn, "kernel");
+    if (R.is_err[intern.StrId, str](rfn)) { intern.dnit(?itn); ret 1; }
+    val kname: intern.StrId = R.unwrap_ok[intern.StrId, str](rfn);
+
+    # module 1: a live vector add in 'kernel' (returned, so dce keeps it)
+    val rm: R.Result[ir.Module, str] = ir.init(?alloc, intern.STR_NIL);
+    if (R.is_err[ir.Module, str](rm)) { intern.dnit(?itn); ret 1; }
+    var m: ir.Module = R.unwrap_ok[ir.Module, str](rm);
+    val rf: R.Result[ir_type.IrTypeId, str] = ir_type.intern_float(?m.types, 32);
+    if (R.is_err[ir_type.IrTypeId, str](rf)) { ir.dnit(?m); intern.dnit(?itn); ret 1; }
+    val rvt: R.Result[ir_type.IrTypeId, str] = ir_type.intern_vector(?m.types, R.unwrap_ok[ir_type.IrTypeId, str](rf), 4);
+    if (R.is_err[ir_type.IrTypeId, str](rvt)) { ir.dnit(?m); intern.dnit(?itn); ret 1; }
+    val vec: ir_type.IrTypeId = R.unwrap_ok[ir_type.IrTypeId, str](rvt);
+    val rfa: R.Result[u32, str] = ir.function_add(?m, kname, vec, 0);
+    if (R.is_err[u32, str](rfa)) { ir.dnit(?m); intern.dnit(?itn); ret 1; }
+    val fn: *ir.Function = ?m.functions[R.unwrap_ok[u32, str](rfa)];
+    var b: builder.Builder = builder.init(?m);
+    builder.set_function(?b, fn);
+    val rb: R.Result[id.BlockId, str] = builder.new_block(?b);
+    if (R.is_err[id.BlockId, str](rb)) { ir.dnit(?m); intern.dnit(?itn); ret 1; }
+    builder.set_block(?b, R.unwrap_ok[id.BlockId, str](rb));
+    val radd: R.Result[value.Value, str] = builder.emit_add(?b, value.param(0, vec), value.param(1, vec));
+    if (R.is_err[value.Value, str](radd)) { code = 1; }
+    or { if (R.is_err[bool, str](builder.emit_ret(?b, R.unwrap_ok[value.Value, str](radd)))) { code = 1; } }
+
+    # require + incapable + vector -> a precise error naming op, function, and arch
+    val e1: R.Result[bool, str] = run(?m, ?rv, OPT_DEBUG, false, true, ?itn);
+    if (R.is_ok[bool, str](e1)) { code = 1; }
+    or {
+        val msg: str = R.unwrap_err[bool, str](e1);
+        if (!str_contains(msg, "simd = \"require\"")) { code = 1; }
+        if (!str_contains(msg, "add"))               { code = 1; }
+        if (!str_contains(msg, "kernel"))            { code = 1; }
+        if (!str_contains(msg, "riscv64"))           { code = 1; }
+    }
+    ir.dnit(?m);
+
+    # module 2: no vectors -> `require` proceeds cleanly through the exit verifier
+    val rm2: R.Result[ir.Module, str] = ir.init(?alloc, intern.STR_NIL);
+    if (R.is_err[ir.Module, str](rm2)) { intern.dnit(?itn); ret 1; }
+    var m2: ir.Module = R.unwrap_ok[ir.Module, str](rm2);
+    val rfa2: R.Result[u32, str] = ir.function_add(?m2, kname, ir_type.IRT_NIL, 0);
+    if (R.is_err[u32, str](rfa2)) { ir.dnit(?m2); intern.dnit(?itn); ret 1; }
+    val fn2: *ir.Function = ?m2.functions[R.unwrap_ok[u32, str](rfa2)];
+    var b2: builder.Builder = builder.init(?m2);
+    builder.set_function(?b2, fn2);
+    val rb2: R.Result[id.BlockId, str] = builder.new_block(?b2);
+    if (R.is_err[id.BlockId, str](rb2)) { ir.dnit(?m2); intern.dnit(?itn); ret 1; }
+    builder.set_block(?b2, R.unwrap_ok[id.BlockId, str](rb2));
+    if (R.is_err[bool, str](builder.emit_ret_void(?b2))) { code = 1; }
+    if (R.is_err[bool, str](run(?m2, ?rv, OPT_DEBUG, false, true, ?itn))) { code = 1; }
+    ir.dnit(?m2);
+
+    intern.dnit(?itn);
+    ret code;
 }

--- a/src/lang/session.mach
+++ b/src/lang/session.mach
@@ -24,6 +24,7 @@ use R: std.types.result;
 use mach.lang.diagnostic;
 use mach.lang.fe.ast;
 use mach.lang.intern;
+use mach.lang.manifest;
 use mach.lang.module;
 use mach.lang.query;
 use mach.lang.readout;
@@ -157,6 +158,12 @@ pub rec Session {
     debug_producer: intern.StrId;
     debug_comp_dir: intern.StrId;
 
+    # resolved SIMD strictness posture for this build (`[profile.*] simd`, the
+    # consumer's setting): SIMD_SCALARIZE tolerates scalarization on an incapable
+    # target, SIMD_REQUIRE rejects it. read at the build's scalarize/require gate over
+    # the target capability fact (`MachineModel.has_v128`). SIMD_SCALARIZE by default.
+    simd:           manifest.SimdMode;
+
     # in-memory source overlays keyed by path (#1588): live unsaved buffer text a
     # long-lived session's parse read uses instead of the file on disk. a small
     # owned array scanned by path - the open-buffer set is tiny - grown on demand
@@ -213,6 +220,7 @@ pub fun init(alloc: *A.Allocator) R.Result[Session, str] {
     s.debug            = false;
     s.debug_producer   = intern.STR_NIL;
     s.debug_comp_dir   = intern.STR_NIL;
+    s.simd             = manifest.SIMD_SCALARIZE;
     s.overlays         = nil;
     s.overlay_len      = 0;
     s.overlay_cap      = 0;


### PR DESCRIPTION
Closes #2017. Part of #1965 (tier 1). Integrated on merged #2016 (#2036).

Implements the `simd` profile lever's *semantics* over the target capability
fact: resolution + threading of the posture, the single scalarize/require gate,
and the consumer-overrides-library guarantee.

## What's here
- **Resolution + threading** — the resolved posture flows `ProfileDef.simd` →
  `ResolvedProfile.simd` → `BuildUnit.simd` → `ProjectConfig.simd` →
  `Session.simd`, mirroring the `debug` bit; the no-`[profile]` default branch
  resolves to `scalarize`, resolved onto the session next to `resolve_debug`.
- **The single SIMD gate** (`pipeline.run`, at the `dce → exit-verify` seam) —
  keyed on the resolved posture over `MachineModel.has_v128`:
  - `require` on an incapable target → a precise build error naming the
    offending operator, its function, and the arch, from #2016's shared
    `scalarize.detect()` sites (so the scalarization note and the require error
    name the same sites by construction); the pass is skipped.
  - `scalarize` (default) → #2016's scalarization pass runs.
  - inert on a capable target under either posture.
  `pipeline.run` gains a `simd_require: bool` (threaded from `p.s.simd` at both
  call sites) and the interner for naming the site.
- **Consumer overrides library** — pinned by test over the existing
  single-`ProjectConfig` architecture; a dependency manifest is tolerated
  off-root whether it declares or omits `simd`, required only for a standalone
  build. No new per-dep plumbing (structural — `DepDef`/`DepEntry` carry no
  profile).

## Seam with #2016 (recorded on both issues)
`scalarize.detect(m, *first) → count` is the one shared detection: `run()` sets
the note count from it and this gate names its sites. The per-target MIR isel
guard remains the loud backstop for anything upstream of the gate (e.g. a
vector *value* with no operator under `require`).

## Tests (colocated, +3 over the dev baseline of 590)
- `manifest.resolve_build_unit:simd_posture` — require/scalarize thread onto the
  BuildUnit; no-`[profile]` default is scalarize.
- `manifest.parse:simd_consumer_overrides_library` — the no-ecosystem-fork
  guarantee.
- `pipeline.run:simd_require_gate` — end-to-end: the gate drives #2016's real
  `detect()` on riscv64, producing the precise error naming the real op; a
  vectorless module proceeds cleanly.

## Verification bars (freshly built HEAD)
- Full unit suite: **593 passed** (dev baseline 590 + 3 new).
- `-g` additivity: compiler PT_LOAD segments byte-identical with/without `-g` at
  **both** debug and release profiles.
- `llvm-dwarfdump --verify`: clean (21 target builds).
- Self-host fixpoint: gen2 == gen3 byte-identical (release).
- `int` suite: **42/42** green on linux.

End-to-end confirmed with a scratch program: rv64+require → the precise error
via `detect()`; rv64+scalarize → builds (the scalarization note fires);
x86_64+require → inert (require adds no error; the interim isel scaffolding
until #2014 lands is unrelated).
