### PR TITLE
feat(arm64): NEON isel + AAPCS64 short-vector ABI (#2015)

### DIFF
--- a/src/lang/be/codegen/mir/abi.mach
+++ b/src/lang/be/codegen/mir/abi.mach
@@ -1160,9 +1160,13 @@ fun emit_arg_slot(ctx: *context.LowerCtx, mb: *mir.MirBlock, slot: abi.ParamSlot
 # size: the scalar's byte size
 # ret:  the SSE move width in bytes (4 or 8), or a loud error on an unexpected size
 fun fp_move_width(size: u64) R.Result[u8, str] {
-    if (size == 4) { ret R.ok[u8, str](4); }
-    if (size == 8) { ret R.ok[u8, str](8); }
-    ret R.err[u8, str]("mir.abi.fp_move_width: CLASS_FP scalar of unsupported size (expected 4 or 8 bytes)");
+    if (size == 4)  { ret R.ok[u8, str](4); }
+    if (size == 8)  { ret R.ok[u8, str](8); }
+    # a 128-bit vector rides the vector register whole (#1965): a one-member
+    # short-vector aggregate / SSE-class piece moves at the full 16-byte width, which
+    # each backend's FP move encoder realizes (a NEON Q move, an SSE MOVAPS).
+    if (size == 16) { ret R.ok[u8, str](16); }
+    ret R.err[u8, str]("mir.abi.fp_move_width: CLASS_FP scalar of unsupported size (expected 4, 8, or 16 bytes)");
 }
 
 # the move width for materializing a scalar GP value into its argument / return

--- a/src/lang/be/codegen/mir/lower.mach
+++ b/src/lang/be/codegen/mir/lower.mach
@@ -48,6 +48,7 @@ use instr:   mach.lang.me.ir.instruction;
 use ir_type: mach.lang.me.ir.type;
 use value:   mach.lang.me.ir.value;
 use source:  mach.lang.source;
+use isa:     mach.lang.target.isa;
 use target:  mach.lang.target.resolved;
 
 # lower an IR module to a parallel MIR module, one MIR function per IR function
@@ -839,14 +840,15 @@ fun lower_instr(ctx: *lctx.LowerCtx, fn: *ir.Function, mb: *mir.MirBlock, iid: i
     # this is inert until a backend lifts its vector guard below.
     ctx.cur_vec_lane = lctx.compute_vec_lane(ctx, inst);
 
-    # a 128-bit vector reaching MIR lowering has no backend selection yet (#1965):
-    # the backend children (#2014 SSE2, #2015 NEON, #2016 rv64 scalarize) wire real
-    # selection per target and lift this guard. until then, a defined per-target
-    # compile error, never an ICE or the silent 8-byte GP clamp `op_width_of` would
-    # otherwise apply. phis are eliminated and dbg-values emit no code, so neither
-    # is the erroring site.
+    # a 128-bit vector reaching MIR lowering needs backend selection (#1965): a
+    # target whose backend wires it (aarch64 NEON here, x86_64 SSE2, rv64
+    # scalarization) lets it through to real lowering; a target without selection
+    # yet gets a defined per-target compile error, never an ICE or the silent 8-byte
+    # GP clamp `op_width_of` would otherwise apply. phis are eliminated and
+    # dbg-values emit no code, so neither is the erroring site.
     if (inst.kind != instr.OP_PHI && inst.kind != instr.OP_DBG_VALUE
-        && instr_touches_vector(ctx, inst)) {
+        && instr_touches_vector(ctx, inst)
+        && !arch_selects_vectors(ctx.tgt.arch.id)) {
         ret R.err[bool, str](vector_unsupported(ctx));
     }
 
@@ -958,6 +960,16 @@ fun instr_touches_vector(ctx: *lctx.LowerCtx, inst: *instr.Instruction) bool {
         if (lctx.value_is_vector(ctx, inst.operands[i].ty)) { ret true; }
         i = i + 1;
     }
+    ret false;
+}
+
+# whether the target arch's backend selects 128-bit vector ops to real machine
+# code, so a vector-typed instruction lowers rather than hitting the defined
+# "not yet supported" guard. each backend child flips its arch true as it wires
+# selection: aarch64 (NEON) here; x86_64 (#2014 SSE2) and riscv64 (#2016
+# scalarization) add their arm as they land.
+fun arch_selects_vectors(arch_id: u32) bool {
+    if (arch_id == isa.ARCH_AARCH64) { ret true; }
     ret false;
 }
 

--- a/src/lang/be/codegen/regalloc.mach
+++ b/src/lang/be/codegen/regalloc.mach
@@ -3012,6 +3012,10 @@ fun rewrite_instr(tgt: *target.Target, ctx: *AllocCtx, mi: *mir.MirInstr,
     dst[@wp].operand_count = n;
     dst[@wp].width         = mi.width;
     dst[@wp].src_width     = mi.src_width;
+    # carry the 128-bit vector lane descriptor; the encoder reads it to pick the
+    # NEON element arrangement. a zeroed slot reads as element bytes 0 → `.16b`,
+    # collapsing every vector op to a byte arrangement, so it must be copied.
+    dst[@wp].vec_lane      = mi.vec_lane;
     dst[@wp].asm_block     = mi.asm_block;
     # carry the source location through register assignment so the encoder's line
     # table maps this instruction's final bytes to its origin. (a zeroed slot is

--- a/src/lang/target/abi/aapcs64.mach
+++ b/src/lang/target/abi/aapcs64.mach
@@ -194,8 +194,8 @@ pub fun classify(size: u64, align: u64, is_float: bool, fp_eightbytes: u8,
 # is_float:      true if the argument goes in an FP register (scalar floats)
 # fp_eightbytes: per-eightbyte SSE mask (unused -- AAPCS64 routes FP through HFA)
 # is_aggregate:  true if the argument is an aggregate
-# is_vector:     true for a 128-bit SIMD vector (#1965); neutral, unread here (the
-#                short-vector branch is #2015)
+# is_vector:     true for a 128-bit SIMD vector (#1965): placed in a single V
+#                register as a one-member short-vector aggregate
 # gp_used:       GP registers already consumed
 # fp_used:       FP registers already consumed
 # hfa_members:   HFA member count (1-4), or 0 if the argument is not an HFA
@@ -246,6 +246,17 @@ pub fun classify_arg(index: i32, size: u64, align: u64,
         ret abi.make_slot(abi.CLASS_STACK, -1, -1, 0, size);
     }
 
+    # a 128-bit vector is a one-member Homogeneous Short-Vector Aggregate: it rides a
+    # single V register (V0-V7) as a 16-byte member, or spills to the stack by value
+    # once the V bank is exhausted. the neutral driver reports it via `is_vector`
+    # (hfa_members stays 0, since a vector is not a struct of FP fundamentals).
+    if (is_vector) {
+        if (fp_used < FP_PARAM_COUNT) {
+            ret abi.make_slot_hfa(fp_param_reg(fp_used), 1, 16, size);
+        }
+        ret abi.make_slot(abi.CLASS_STACK, -1, -1, 0, size);
+    }
+
     if (is_float) {
         if (fp_used < FP_PARAM_COUNT) {
             ret abi.make_slot(abi.CLASS_FP, fp_param_reg(fp_used), -1, 0, size);
@@ -276,8 +287,8 @@ pub fun classify_arg(index: i32, size: u64, align: u64,
 # is_float:      true if the value is returned in an FP register (scalar floats)
 # fp_eightbytes: per-eightbyte SSE mask (unused -- AAPCS64 routes FP through HFA)
 # is_aggregate:  true if the value is an aggregate
-# is_vector:     true for a 128-bit SIMD vector (#1965); neutral, unread here (the
-#                short-vector-return branch is #2015)
+# is_vector:     true for a 128-bit SIMD vector (#1965): returned in V0 as a
+#                one-member short-vector aggregate
 # hfa_members:   HFA member count (1-4), or 0 if the value is not an HFA
 # hfa_elem:      HFA fundamental member width in bytes (0 if not an HFA)
 # agg:           the flattened-aggregate descriptor (lp64d-only; unused under AAPCS64)
@@ -303,6 +314,11 @@ pub fun classify_return(size: u64, align: u64,
             ret abi.make_slot(abi.CLASS_GP, REG_X0, -1, 0, size);
         }
         ret abi.make_slot(abi.CLASS_GP, REG_X0, REG_X1, 0, size);
+    }
+
+    # a 128-bit vector returns in V0 (a one-member short-vector aggregate).
+    if (is_vector) {
+        ret abi.make_slot_hfa(fp_param_reg(0), 1, 16, size);
     }
 
     if (is_float) {
@@ -495,6 +511,30 @@ test "mach.lang.target.abi.aapcs64.classify_arg:hfa_v_run" {
     # the WHOLE aggregate spills by value (no partial V placement).
     val m: abi.ParamSlot = classify_arg(0, 12, 4, false, 0, true, false, 0, 6, 3, 4, abi.agg_none());
     if (m.class != abi.CLASS_STACK) { ret 1; }
+    ret 0;
+}
+
+# a 128-bit vector is a one-member short-vector aggregate (HVA): a single V
+# register as an argument, back-filling the next free V; V0 as a return; and a
+# by-value stack spill once the V bank is exhausted. the member width is the full 16
+# bytes (a single Q register), distinct from an f32/f64-member HFA.
+test "mach.lang.target.abi.aapcs64.classify_arg:short_vector_hva" {
+    val v: abi.ParamSlot = classify_arg(0, 16, 16, false, 0, false, true, 0, 0, 0, 0, abi.agg_none());
+    if (v.class != abi.CLASS_FP)  { ret 1; }
+    if (v.reg != fp_param_reg(0)) { ret 1; }
+    if (v.piece_count != 1)       { ret 1; }
+    if (v.pieces[0].width != 16)  { ret 1; }
+    # rides the next free V register after prior FP/vector args.
+    val v2: abi.ParamSlot = classify_arg(1, 16, 16, false, 0, false, true, 0, 3, 0, 0, abi.agg_none());
+    if (v2.reg != fp_param_reg(3)) { ret 1; }
+    # the whole V bank consumed -> spill by value.
+    val vs: abi.ParamSlot = classify_arg(2, 16, 16, false, 0, false, true, 0, 8, 0, 0, abi.agg_none());
+    if (vs.class != abi.CLASS_STACK) { ret 1; }
+    # a vector returns in V0 as a 16-byte one-member HVA.
+    val r: abi.ParamSlot = classify_return(16, 16, false, 0, false, true, 0, 0, abi.agg_none());
+    if (r.class != abi.CLASS_FP)  { ret 1; }
+    if (r.reg != fp_param_reg(0)) { ret 1; }
+    if (r.pieces[0].width != 16)  { ret 1; }
     ret 0;
 }
 

--- a/src/lang/target/isa/arm64.mach
+++ b/src/lang/target/isa/arm64.mach
@@ -170,17 +170,23 @@ pub val FMOV: Opcode = 16;
 # logical are one op each; the compares carry their NEON form in the opcode (the
 # generic LT/LE are normalized to GT/GE with an operand swap at isel, and the
 # signed vs unsigned integer form comes from the generic compare's signedness).
-pub val VEC_ADD:  Opcode = 17;  # + : FADD (float) / ADD (int)
-pub val VEC_SUB:  Opcode = 18;  # - : FSUB / SUB
-pub val VEC_MUL:  Opcode = 19;  # * : FMUL / MUL (int only .8h)
-pub val VEC_DIV:  Opcode = 20;  # / : FDIV (float only)
-pub val VEC_AND:  Opcode = 21;  # & : AND.16b
-pub val VEC_ORR:  Opcode = 22;  # | : ORR.16b
-pub val VEC_EOR:  Opcode = 23;  # ^ : EOR.16b
-pub val VEC_NOT:  Opcode = 24;  # ~ : NOT.16b
-pub val VEC_CMEQ: Opcode = 25;  # == : FCMEQ / CMEQ
-pub val VEC_CMNE: Opcode = 26;  # != : (FCMEQ / CMEQ) then NOT
-pub val VEC_CMGT: Opcode = 27;  # > (float / signed int) : FCMGT / CMGT
-pub val VEC_CMGE: Opcode = 28;  # >= (float / signed int) : FCMGE / CMGE
-pub val VEC_CMHI: Opcode = 29;  # > (unsigned int) : CMHI
-pub val VEC_CMHS: Opcode = 30;  # >= (unsigned int) : CMHS
+#
+# These sit at 0x100+, ABOVE the surviving generic MIR opcode values (the
+# conversions / memory ops at 21-34 and `MIR_ASM` at 43 pass isel unchanged and are
+# dispatched by the encoder on their raw value), so a selected vector op never
+# aliases a generic opcode the encoder would misroute to the wrong emitter. The
+# scalar concrete forms above stay in the low 0-16 range, distinct from both.
+pub val VEC_ADD:  Opcode = 0x100;  # + : FADD (float) / ADD (int)
+pub val VEC_SUB:  Opcode = 0x101;  # - : FSUB / SUB
+pub val VEC_MUL:  Opcode = 0x102;  # * : FMUL / MUL (int only .8h)
+pub val VEC_DIV:  Opcode = 0x103;  # / : FDIV (float only)
+pub val VEC_AND:  Opcode = 0x104;  # & : AND.16b
+pub val VEC_ORR:  Opcode = 0x105;  # | : ORR.16b
+pub val VEC_EOR:  Opcode = 0x106;  # ^ : EOR.16b
+pub val VEC_NOT:  Opcode = 0x107;  # ~ : NOT.16b
+pub val VEC_CMEQ: Opcode = 0x108;  # == : FCMEQ / CMEQ
+pub val VEC_CMNE: Opcode = 0x109;  # != : (FCMEQ / CMEQ) then NOT
+pub val VEC_CMGT: Opcode = 0x10a;  # > (float / signed int) : FCMGT / CMGT
+pub val VEC_CMGE: Opcode = 0x10b;  # >= (float / signed int) : FCMGE / CMGE
+pub val VEC_CMHI: Opcode = 0x10c;  # > (unsigned int) : CMHI
+pub val VEC_CMHS: Opcode = 0x10d;  # >= (unsigned int) : CMHS

--- a/src/lang/target/isa/arm64.mach
+++ b/src/lang/target/isa/arm64.mach
@@ -162,3 +162,25 @@ pub val BRK:  Opcode = 15;
 # forms on operand register class, so a float copy or a cross-bank reinterpret can
 # never mis-select to a GP move of the aliasing index.
 pub val FMOV: Opcode = 16;
+
+# NEON 128-bit vector data-processing opcodes (#2015). isel rewrites a vector-typed
+# generic MIR op to one of these, reading the operand shape off `MirInstr.vec_lane`;
+# the encoder emits the arrangement-specific word, picking the float vs integer form
+# from the lane kind and the arrangement from the element width. arithmetic /
+# logical are one op each; the compares carry their NEON form in the opcode (the
+# generic LT/LE are normalized to GT/GE with an operand swap at isel, and the
+# signed vs unsigned integer form comes from the generic compare's signedness).
+pub val VEC_ADD:  Opcode = 17;  # + : FADD (float) / ADD (int)
+pub val VEC_SUB:  Opcode = 18;  # - : FSUB / SUB
+pub val VEC_MUL:  Opcode = 19;  # * : FMUL / MUL (int only .8h)
+pub val VEC_DIV:  Opcode = 20;  # / : FDIV (float only)
+pub val VEC_AND:  Opcode = 21;  # & : AND.16b
+pub val VEC_ORR:  Opcode = 22;  # | : ORR.16b
+pub val VEC_EOR:  Opcode = 23;  # ^ : EOR.16b
+pub val VEC_NOT:  Opcode = 24;  # ~ : NOT.16b
+pub val VEC_CMEQ: Opcode = 25;  # == : FCMEQ / CMEQ
+pub val VEC_CMNE: Opcode = 26;  # != : (FCMEQ / CMEQ) then NOT
+pub val VEC_CMGT: Opcode = 27;  # > (float / signed int) : FCMGT / CMGT
+pub val VEC_CMGE: Opcode = 28;  # >= (float / signed int) : FCMGE / CMGE
+pub val VEC_CMHI: Opcode = 29;  # > (unsigned int) : CMHI
+pub val VEC_CMHS: Opcode = 30;  # >= (unsigned int) : CMHS

--- a/src/lang/target/isa/arm64/encode.mach
+++ b/src/lang/target/isa/arm64/encode.mach
@@ -1775,11 +1775,35 @@ fun encode_fp_conv(st: *encode.EncodeState, f: *mir.MirFunction, mi: *mir.MirIns
 # `mi.width` (4 / 8) selects the S/W vs D/X form throughout
 fun encode_fmov(st: *encode.EncodeState, f: *mir.MirFunction, mi: *mir.MirInstr) R.Result[bool, str] {
     if (mi.operand_count < 2) { ret R.err[bool, str]("encode: fmov missing operands"); }
+    val dst: *mir.MirOperand = ?mi.operands[0];
+    val src: *mir.MirOperand = ?mi.operands[1];
+
+    # a 128-bit vector register move / spill (#2015): `MOV Vd.16b, Vn.16b` (an ORR
+    # alias) register-to-register, or the unaligned-safe Q load/store for a spilled
+    # operand. distinguished from a scalar S/D float move by the 16-byte width; a
+    # vector value never rides an immediate or a cross-bank bitcast.
+    if (mi.width == 16) {
+        if (dst.kind == mir.MIR_OP_MEM) {
+            val rnr: R.Result[i32, str] = resolve_fp_source(st, f, src, FP_SCRATCH0, 16);
+            if (R.is_err[i32, str](rnr)) { ret R.err[bool, str](R.unwrap_err[i32, str](rnr)); }
+            ret emit_fp_slot_store(st, f, dst, R.unwrap_ok[i32, str](rnr)::u32, 16);
+        }
+        val rdr: R.Result[i32, str] = req_vec(dst);
+        if (R.is_err[i32, str](rdr)) { ret R.err[bool, str](R.unwrap_err[i32, str](rdr)); }
+        val rd: u32 = R.unwrap_ok[i32, str](rdr)::u32;
+        if (src.kind == mir.MIR_OP_MEM) {
+            ret emit_fp_slot_load(st, f, src, rd, 16);
+        }
+        val rnr: R.Result[i32, str] = req_vec(src);
+        if (R.is_err[i32, str](rnr)) { ret R.err[bool, str](R.unwrap_err[i32, str](rnr)); }
+        val rn: u32 = R.unwrap_ok[i32, str](rnr)::u32;
+        emit_word(st, pack_neon_3same(VORR, 0, rd, rn, rn));
+        ret R.ok[bool, str](true);
+    }
+
     var w: u8 = mi.width;
     if (w != 4 && w != 8) { w = 8; }
     val dbl: bool = w == 8;
-    val dst: *mir.MirOperand = ?mi.operands[0];
-    val src: *mir.MirOperand = ?mi.operands[1];
 
     # a float-constant immediate source: the FP isel's CONSTANT move and the pre-colored
     # FP return move to V0 both reach here as `FMOV vec <- imm`. materialize the bit

--- a/src/lang/target/isa/arm64/encode.mach
+++ b/src/lang/target/isa/arm64/encode.mach
@@ -268,6 +268,36 @@ val LDUR_S_FP: u32 = 0xBC400000; val STUR_S_FP: u32 = 0xBC000000;
 val LDR_D_REG: u32 = 0xFC606800; val STR_D_REG: u32 = 0xFC206800;
 val LDR_S_REG: u32 = 0xBC606800; val STR_S_REG: u32 = 0xBC206800;
 
+# NEON 128-bit (Q) vector base words (#1965 / #2015). the three-register-same
+# arithmetic / logical / compare forms share the `pack_alu3` register layout
+# (Rm[20:16], Rn[9:5], Rd[4:0]); the lane arrangement rides the size field [23:22]
+# added as `size << 22` by `pack_neon_3same` (float: 0=.4s/single, 1=.2d/double;
+# integer: 0=.16b, 1=.8h, 2=.4s, 3=.2d). signed vs unsigned integer compares are
+# distinct base words (the U bit [29]); the logical ops are byte-agnostic (always
+# .16b) and take size 0. each word is byte-exact against `llvm-mc -triple=aarch64`.
+val VFADD:   u32 = 0x4E20D400; val VFSUB:   u32 = 0x4EA0D400;
+val VFMUL:   u32 = 0x6E20DC00; val VFDIV:   u32 = 0x6E20FC00;
+val VADD:    u32 = 0x4E208400; val VSUB:    u32 = 0x6E208400;
+val VMUL:    u32 = 0x4E209C00;  # integer multiply, legal only on .8h (size 1)
+val VAND:    u32 = 0x4E201C00; val VORR:    u32 = 0x4EA01C00; val VEOR: u32 = 0x6E201C00;
+# integer / float lane-wise compares producing native all-ones / all-zeros masks
+val VCMEQ:   u32 = 0x6E208C00;                                   # integer ==
+val VCMGT_S: u32 = 0x4E203400; val VCMGE_S: u32 = 0x4E203C00;    # signed  > , >=
+val VCMHI_U: u32 = 0x6E203400; val VCMHS_U: u32 = 0x6E203C00;    # unsigned > , >=
+val VFCMEQ:  u32 = 0x4E20E400; val VFCMGT:  u32 = 0x6EA0E400; val VFCMGE: u32 = 0x6E20E400;
+# NOT Vd.16b, Vn.16b: two-register-misc (Rn[9:5], Rd[4:0]); the `!=` mask complement
+val VNOT:    u32 = 0x6E205800;
+# 128-bit load/store (scaled unsigned offset, imm12 scaled by the 16-byte access
+# size) for vector loads / stores / spills, and the Q register move (an ORR alias)
+val LDR_Q_OFF: u32 = 0x3DC00000; val STR_Q_OFF: u32 = 0x3D800000;
+# lane extract / insert: imm5[20:16] selects the element size + lane index via
+# `neon_imm5`. UMOV / SMOV read a lane to a GP register (zero / sign extended); INS
+# writes a GP register (or another lane, `VINS_EL`, imm4[14:11] = source lane) to a
+# vector lane
+val VUMOV_W: u32 = 0x0E003C00; val VUMOV_X: u32 = 0x4E003C00;
+val VSMOV_W: u32 = 0x0E002C00; val VSMOV_X: u32 = 0x4E002C00;
+val VINS_GP: u32 = 0x4E001C00; val VINS_EL: u32 = 0x6E000400;
+
 # acquire/release ordered load-stores + the LL/SC exclusive pair (atomic.mach's
 # LL/SC core): Rt[4:0], Rn[9:5], Rt2 fixed 11111; stlxr's status Rs is [20:16];
 # the X (64-bit) base sets the size bit, the W (32-bit) base clears it
@@ -303,6 +333,44 @@ fun pack_bitfield(base: u32, rd: u32, rn: u32, immr: u32, imms: u32) u32 {
 # 16-bit shift group (0..3 selecting lsl #0/16/32/48)
 fun pack_movewide(base: u32, rd: u32, hw: u32, imm16: u32) u32 {
     ret base | ((hw & 0x3) << 21) | ((imm16 & 0xFFFF) << 5) | (rd & 0x1F);
+}
+
+# a NEON three-register-same 128-bit word (#2015): the lane arrangement rides the
+# size field [23:22], the registers the shared `pack_alu3` layout. logical ops pass
+# size 0 (their base already fixes the op in those bits)
+fun pack_neon_3same(base: u32, size: u32, rd: u32, rn: u32, rm: u32) u32 {
+    ret base | ((size & 0x3) << 22) | ((rm & 0x1F) << 16) | ((rn & 0x1F) << 5) | (rd & 0x1F);
+}
+
+# a NEON two-register-misc 128-bit word (#2015): Rn[9:5], Rd[4:0]. used by NOT (the
+# `!=` mask complement), whose arrangement is fixed .16b
+fun pack_neon_2misc(base: u32, rd: u32, rn: u32) u32 {
+    ret base | ((rn & 0x1F) << 5) | (rd & 0x1F);
+}
+
+# the NEON imm5 lane selector for element `size` (0=b, 1=h, 2=s, 3=d) at lane
+# `index`: the low set bit marks the element size and the index rides above it
+# (#2015). shared by UMOV / SMOV / INS
+fun neon_imm5(size: u32, index: u32) u32 {
+    ret (index << (size + 1)) | (1 << size);
+}
+
+# a NEON lane extract (UMOV / SMOV) word (#2015): imm5[20:16] selects the element
+# size + lane, Rn[9:5] the source vector, Rd[4:0] the GP destination
+fun pack_neon_lane_read(base: u32, size: u32, index: u32, rd: u32, rn: u32) u32 {
+    ret base | ((neon_imm5(size, index) & 0x1F) << 16) | ((rn & 0x1F) << 5) | (rd & 0x1F);
+}
+
+# a NEON INS-from-GP word (#2015): imm5[20:16] selects the destination element +
+# lane, Rn[9:5] the GP source, Rd[4:0] the destination vector
+fun pack_neon_ins_gp(size: u32, index: u32, rd: u32, rn: u32) u32 {
+    ret VINS_GP | ((neon_imm5(size, index) & 0x1F) << 16) | ((rn & 0x1F) << 5) | (rd & 0x1F);
+}
+
+# a NEON 128-bit scaled load/store word (#2015): imm12[21:10] is the byte offset
+# scaled by the 16-byte access size, Rn[9:5] the base, Rt[4:0] the vector register
+fun pack_ldst_q(base: u32, rt: u32, rn: u32, imm12: u32) u32 {
+    ret base | ((imm12 & 0xFFF) << 10) | ((rn & 0x1F) << 5) | (rt & 0x1F);
 }
 
 # a SUBS XZR, Rn, Rm word (the register CMP) - Rm[20:16], Rn[9:5],
@@ -5597,5 +5665,66 @@ test "mach.lang.target.isa.arm64.encode:inline_asm_rejects_unknown_mnemonic_and_
 
     asm_labels_dnit(?labels);
     encode.buf_dnit(?st.buf);
+    ret bad;
+}
+
+# the NEON 128-bit vector base words + packers select byte-exact against
+# `llvm-mc -triple=aarch64`: the three-register-same arrangement (size<<22 over
+# float single/double and integer .16b/.8h/.4s/.2d), the signed/unsigned compare
+# forms, the byte-agnostic logical forms, the NOT `!=` complement, the lane
+# read/write imm5 selectors across element sizes and indices, and the Q load/store
+# scaled offset. reg fields are Rd=v0, Rn=v0/v1, Rm=v1.
+test "mach.lang.target.isa.arm64.encode:neon_vector_base_words" {
+    var bad: i32 = 0;
+
+    # float three-register-same: fadd/fsub/fmul/fdiv, .4s (size 0) and .2d (size 1).
+    if (pack_neon_3same(VFADD, 0, 0, 0, 1) != 0x4E21D400) { bad = 1; }
+    if (pack_neon_3same(VFADD, 1, 0, 0, 1) != 0x4E61D400) { bad = 1; }
+    if (pack_neon_3same(VFSUB, 0, 0, 0, 1) != 0x4EA1D400) { bad = 1; }
+    if (pack_neon_3same(VFSUB, 1, 0, 0, 1) != 0x4EE1D400) { bad = 1; }
+    if (pack_neon_3same(VFMUL, 0, 0, 0, 1) != 0x6E21DC00) { bad = 1; }
+    if (pack_neon_3same(VFDIV, 0, 0, 0, 1) != 0x6E21FC00) { bad = 1; }
+
+    # integer add / sub across widths; multiply legal only on .8h.
+    if (pack_neon_3same(VADD, 0, 0, 0, 1) != 0x4E218400) { bad = 1; }
+    if (pack_neon_3same(VADD, 1, 0, 0, 1) != 0x4E618400) { bad = 1; }
+    if (pack_neon_3same(VADD, 2, 0, 0, 1) != 0x4EA18400) { bad = 1; }
+    if (pack_neon_3same(VADD, 3, 0, 0, 1) != 0x4EE18400) { bad = 1; }
+    if (pack_neon_3same(VSUB, 0, 0, 0, 1) != 0x6E218400) { bad = 1; }
+    if (pack_neon_3same(VMUL, 1, 0, 0, 1) != 0x4E619C00) { bad = 1; }
+
+    # logical (byte-agnostic, size 0) and the register move (ORR Vd,Vn,Vn alias).
+    if (pack_neon_3same(VAND, 0, 0, 0, 1) != 0x4E211C00) { bad = 1; }
+    if (pack_neon_3same(VORR, 0, 0, 0, 1) != 0x4EA11C00) { bad = 1; }
+    if (pack_neon_3same(VEOR, 0, 0, 0, 1) != 0x6E211C00) { bad = 1; }
+    if (pack_neon_3same(VORR, 0, 0, 1, 1) != 0x4EA11C20) { bad = 1; }
+    if (pack_neon_2misc(VNOT, 0, 1)       != 0x6E205820) { bad = 1; }
+
+    # integer == , signed > / >= , unsigned > / >= at .16b; float compares at .4s.
+    if (pack_neon_3same(VCMEQ,  0, 0, 0, 1) != 0x6E218C00) { bad = 1; }
+    if (pack_neon_3same(VCMGT_S, 0, 0, 0, 1) != 0x4E213400) { bad = 1; }
+    if (pack_neon_3same(VCMGE_S, 0, 0, 0, 1) != 0x4E213C00) { bad = 1; }
+    if (pack_neon_3same(VCMHI_U, 0, 0, 0, 1) != 0x6E213400) { bad = 1; }
+    if (pack_neon_3same(VCMHS_U, 0, 0, 0, 1) != 0x6E213C00) { bad = 1; }
+    if (pack_neon_3same(VFCMEQ, 0, 0, 0, 1) != 0x4E21E400) { bad = 1; }
+    if (pack_neon_3same(VFCMGT, 0, 0, 0, 1) != 0x6EA1E400) { bad = 1; }
+    if (pack_neon_3same(VFCMGE, 0, 0, 0, 1) != 0x6E21E400) { bad = 1; }
+
+    # lane extract (UMOV / SMOV) and insert (INS from GP) across element sizes + lanes.
+    if (pack_neon_lane_read(VUMOV_W, 0, 0, 0, 1) != 0x0E013C20) { bad = 1; }
+    if (pack_neon_lane_read(VUMOV_W, 1, 3, 0, 1) != 0x0E0E3C20) { bad = 1; }
+    if (pack_neon_lane_read(VUMOV_W, 2, 2, 0, 1) != 0x0E143C20) { bad = 1; }
+    if (pack_neon_lane_read(VUMOV_X, 3, 1, 0, 1) != 0x4E183C20) { bad = 1; }
+    if (pack_neon_lane_read(VSMOV_X, 0, 0, 0, 1) != 0x4E012C20) { bad = 1; }
+    if (pack_neon_ins_gp(0, 0, 0, 1) != 0x4E011C20) { bad = 1; }
+    if (pack_neon_ins_gp(2, 2, 0, 1) != 0x4E141C20) { bad = 1; }
+    if (pack_neon_ins_gp(3, 1, 0, 1) != 0x4E181C20) { bad = 1; }
+
+    # 128-bit load/store with the byte offset scaled by the 16-byte access size.
+    if (pack_ldst_q(LDR_Q_OFF, 0, 0, 0) != 0x3DC00000) { bad = 1; }
+    if (pack_ldst_q(STR_Q_OFF, 0, 0, 0) != 0x3D800000) { bad = 1; }
+    if (pack_ldst_q(LDR_Q_OFF, 0, 1, 1) != 0x3DC00420) { bad = 1; }
+    if (pack_ldst_q(STR_Q_OFF, 2, 3, 2) != 0x3D800862) { bad = 1; }
+
     ret bad;
 }

--- a/src/lang/target/isa/arm64/encode.mach
+++ b/src/lang/target/isa/arm64/encode.mach
@@ -1496,6 +1496,110 @@ fun encode_fp_arith(st: *encode.EncodeState, f: *mir.MirFunction, mi: *mir.MirIn
     ret R.ok[bool, str](true);
 }
 
+# the NEON arrangement size field [23:22] for a lane descriptor (#2015): float
+# lanes 0=.4s / 1=.2d, integer lanes 0=.16b / 1=.8h / 2=.4s / 3=.2d
+fun neon_size(vl: u8) u32 {
+    val eb: u8 = mir.vec_lane_elem_bytes(vl);
+    if (mir.vec_lane_kind(vl) == mir.VEC_LANE_FLOAT) {
+        if (eb == 8) { ret 1; }
+        ret 0;
+    }
+    if (eb == 2) { ret 1; }
+    if (eb == 4) { ret 2; }
+    if (eb == 8) { ret 3; }
+    ret 0;
+}
+
+# the NEON three-register-same base word for a selected vector opcode, picking the
+# float vs integer form from the lane kind (#2015). the ops that have no float form
+# (the unsigned integer orderings CMHI/CMHS) are integer-only by construction, and
+# VEC_DIV is float-only (sema rejects integer vector division)
+fun neon_base(opcode: u32, is_float: bool) u32 {
+    if (opcode == arm64.VEC_ADD::u32)  { if (is_float) { ret VFADD; } ret VADD; }
+    if (opcode == arm64.VEC_SUB::u32)  { if (is_float) { ret VFSUB; } ret VSUB; }
+    if (opcode == arm64.VEC_MUL::u32)  { if (is_float) { ret VFMUL; } ret VMUL; }
+    if (opcode == arm64.VEC_DIV::u32)  { ret VFDIV; }
+    if (opcode == arm64.VEC_AND::u32)  { ret VAND; }
+    if (opcode == arm64.VEC_ORR::u32)  { ret VORR; }
+    if (opcode == arm64.VEC_EOR::u32)  { ret VEOR; }
+    if (opcode == arm64.VEC_CMEQ::u32) { if (is_float) { ret VFCMEQ; } ret VCMEQ; }
+    if (opcode == arm64.VEC_CMGT::u32) { if (is_float) { ret VFCMGT; } ret VCMGT_S; }
+    if (opcode == arm64.VEC_CMGE::u32) { if (is_float) { ret VFCMGE; } ret VCMGE_S; }
+    if (opcode == arm64.VEC_CMHI::u32) { ret VCMHI_U; }
+    if (opcode == arm64.VEC_CMHS::u32) { ret VCMHS_U; }
+    ret 0;
+}
+
+# materialize a selected NEON vector data op `[dst, lhs(, rhs)]` (#2015)
+#
+# The arrangement (size) and the float-vs-integer form come from `mi.vec_lane`. A
+# spilled operand loads into an FP scratch; a spilled destination computes into the
+# FP scratch and stores back through the 128-bit Q form. NOT is a two-register form;
+# `!=` (VEC_CMNE) emits its equality word followed by a NOT complement of the mask,
+# since NEON has no not-equal compare.
+fun encode_neon(st: *encode.EncodeState, f: *mir.MirFunction, mi: *mir.MirInstr) R.Result[bool, str] {
+    val vl: u8 = mi.vec_lane;
+    val is_float: bool = mir.vec_lane_kind(vl) == mir.VEC_LANE_FLOAT;
+    val size: u32 = neon_size(vl);
+    val op: u32 = mi.opcode;
+
+    # NOT: `NOT Vd.16b, Vn.16b`, a single two-register-misc word.
+    if (op == arm64.VEC_NOT::u32) {
+        if (mi.operand_count < 2) { ret R.err[bool, str]("encode: vector NOT missing operands"); }
+        val rnr: R.Result[i32, str] = resolve_fp_source(st, f, ?mi.operands[1], FP_SCRATCH0, 16);
+        if (R.is_err[i32, str](rnr)) { ret R.err[bool, str](R.unwrap_err[i32, str](rnr)); }
+        val rn: u32 = R.unwrap_ok[i32, str](rnr)::u32;
+        val ndst: *mir.MirOperand = ?mi.operands[0];
+        if (ndst.kind == mir.MIR_OP_MEM) {
+            emit_word(st, pack_neon_2misc(VNOT, FP_SCRATCH0, rn));
+            ret emit_fp_slot_store(st, f, ndst, FP_SCRATCH0, 16);
+        }
+        val rdr: R.Result[i32, str] = req_vec(ndst);
+        if (R.is_err[i32, str](rdr)) { ret R.err[bool, str](R.unwrap_err[i32, str](rdr)); }
+        emit_word(st, pack_neon_2misc(VNOT, R.unwrap_ok[i32, str](rdr)::u32, rn));
+        ret R.ok[bool, str](true);
+    }
+
+    # every other vector op is three-register-same `[dst, lhs, rhs]`.
+    if (mi.operand_count < 3) { ret R.err[bool, str]("encode: vector op missing operands"); }
+    val rnr: R.Result[i32, str] = resolve_fp_source(st, f, ?mi.operands[1], FP_SCRATCH0, 16);
+    if (R.is_err[i32, str](rnr)) { ret R.err[bool, str](R.unwrap_err[i32, str](rnr)); }
+    val rn: u32 = R.unwrap_ok[i32, str](rnr)::u32;
+    val rmr: R.Result[i32, str] = resolve_fp_source(st, f, ?mi.operands[2], FP_SCRATCH1, 16);
+    if (R.is_err[i32, str](rmr)) { ret R.err[bool, str](R.unwrap_err[i32, str](rmr)); }
+    val rm: u32 = R.unwrap_ok[i32, str](rmr)::u32;
+
+    val dst: *mir.MirOperand = ?mi.operands[0];
+    var rd: u32 = FP_SCRATCH0;
+    var to_slot: bool = false;
+    if (dst.kind == mir.MIR_OP_MEM) {
+        to_slot = true;
+    }
+    or {
+        val rdr: R.Result[i32, str] = req_vec(dst);
+        if (R.is_err[i32, str](rdr)) { ret R.err[bool, str](R.unwrap_err[i32, str](rdr)); }
+        rd = R.unwrap_ok[i32, str](rdr)::u32;
+    }
+
+    if (op == arm64.VEC_CMNE::u32) {
+        var eqbase: u32 = VCMEQ;
+        if (is_float) { eqbase = VFCMEQ; }
+        emit_word(st, pack_neon_3same(eqbase, size, rd, rn, rm));
+        emit_word(st, pack_neon_2misc(VNOT, rd, rd));
+    }
+    or {
+        # the logical ops (AND/ORR/EOR) are byte-agnostic - the size field is part of
+        # their opcode, not an arrangement - so they always encode at size 0 (.16b),
+        # regardless of the lane width the descriptor carries.
+        var eff_size: u32 = size;
+        if (op == arm64.VEC_AND::u32 || op == arm64.VEC_ORR::u32 || op == arm64.VEC_EOR::u32) { eff_size = 0; }
+        emit_word(st, pack_neon_3same(neon_base(op, is_float), eff_size, rd, rn, rm));
+    }
+
+    if (to_slot) { ret emit_fp_slot_store(st, f, dst, rd, 16); }
+    ret R.ok[bool, str](true);
+}
+
 # materialize a surviving float negation `[dst, src]` into `fneg
 # Sd|Dd, Sn|Dn` (an IEEE-754 sign-bit flip). the source resolves to a vector
 # register (a spilled source loaded into V31); a spilled destination computes into
@@ -2208,6 +2312,8 @@ fun encode_mir_instr(st: *encode.EncodeState, f: *mir.MirFunction, fn_base: u32,
     }
 
     # concrete A64 opcodes.
+    # NEON vector data ops (arithmetic / logical / compare) selected off vec_lane.
+    if (op >= arm64.VEC_ADD::u16 && op <= arm64.VEC_CMHS::u16) { ret encode_neon(st, f, mi); }
     if (op == arm64.ADD::u16)  { ret encode_addsub(st, mi, false); }
     if (op == arm64.SUB::u16)  { ret encode_addsub(st, mi, true); }
     if (op == arm64.MUL::u16)  { ret encode_alu3(st, mi, MUL_X, MUL_W); }
@@ -5741,5 +5847,73 @@ test "mach.lang.target.isa.arm64.encode:neon_vector_base_words" {
     if (pack_ldur(LDUR_Q_FP, 0, 0, 0x1F8::u32) != 0x3CDF8000) { bad = 1; }  # ldur q0,[x0,#-8]
     if (pack_ldst_reg(LDR_Q_REG, 0, 0, 1) != 0x3CE16800) { bad = 1; }        # ldr q0,[x0,x1]
 
+    ret bad;
+}
+
+# the NEON vector op selection (isel -> encode_neon) drives byte-exact words off
+# mi.vec_lane: the float-vs-integer form from the lane kind, the arrangement from
+# the element width, logical ops byte-agnostic (size 0), and the `!=` compare as an
+# equality word plus a NOT complement. dst v0, lhs v1, rhs v2. asserted vs llvm-mc.
+test "mach.lang.target.isa.arm64.encode:neon_vector_op_selection" {
+    var bad: i32 = 0;
+    var st: encode.EncodeState;
+    var alloc: A.Allocator;
+    tbuf(?st, ?alloc);
+    var f: mir.MirFunction;
+    var ops: [3]mir.MirOperand;
+    var mi: mir.MirInstr;
+    mi.operands = ?ops[0]; mi.operand_count = 3;
+    ops[0] = tvec(0); ops[1] = tvec(1); ops[2] = tvec(2);
+
+    # VEC_ADD: f32x4 -> FADD.4s ; i8x16 -> ADD.16b ; i32x4 -> ADD.4s.
+    mi.opcode = arm64.VEC_ADD::u32; mi.vec_lane = mir.vec_lane_make(mir.VEC_LANE_FLOAT, 4); st.buf.len = 0;
+    encode_neon(?st, ?f, ?mi); if (read_word(?st.buf, 0) != 0x4E22D420) { bad = 1; }
+    mi.vec_lane = mir.vec_lane_make(mir.VEC_LANE_INT, 1); st.buf.len = 0;
+    encode_neon(?st, ?f, ?mi); if (read_word(?st.buf, 0) != 0x4E228420) { bad = 1; }
+    mi.vec_lane = mir.vec_lane_make(mir.VEC_LANE_INT, 4); st.buf.len = 0;
+    encode_neon(?st, ?f, ?mi); if (read_word(?st.buf, 0) != 0x4EA28420) { bad = 1; }
+
+    # VEC_SUB f64x2 -> FSUB.2d ; VEC_MUL i16x8 -> MUL.8h ; VEC_DIV f32x4 -> FDIV.4s.
+    mi.opcode = arm64.VEC_SUB::u32; mi.vec_lane = mir.vec_lane_make(mir.VEC_LANE_FLOAT, 8); st.buf.len = 0;
+    encode_neon(?st, ?f, ?mi); if (read_word(?st.buf, 0) != 0x4EE2D420) { bad = 1; }
+    mi.opcode = arm64.VEC_MUL::u32; mi.vec_lane = mir.vec_lane_make(mir.VEC_LANE_INT, 2); st.buf.len = 0;
+    encode_neon(?st, ?f, ?mi); if (read_word(?st.buf, 0) != 0x4E629C20) { bad = 1; }
+    mi.opcode = arm64.VEC_DIV::u32; mi.vec_lane = mir.vec_lane_make(mir.VEC_LANE_FLOAT, 4); st.buf.len = 0;
+    encode_neon(?st, ?f, ?mi); if (read_word(?st.buf, 0) != 0x6E22FC20) { bad = 1; }
+
+    # logical: byte-agnostic (size 0 even at a wider lane). VEC_AND/ORR/EOR at i32x4.
+    mi.opcode = arm64.VEC_AND::u32; mi.vec_lane = mir.vec_lane_make(mir.VEC_LANE_INT, 4); st.buf.len = 0;
+    encode_neon(?st, ?f, ?mi); if (read_word(?st.buf, 0) != 0x4E221C20) { bad = 1; }
+    mi.opcode = arm64.VEC_ORR::u32; st.buf.len = 0;
+    encode_neon(?st, ?f, ?mi); if (read_word(?st.buf, 0) != 0x4EA21C20) { bad = 1; }
+    mi.opcode = arm64.VEC_EOR::u32; st.buf.len = 0;
+    encode_neon(?st, ?f, ?mi); if (read_word(?st.buf, 0) != 0x6E221C20) { bad = 1; }
+
+    # compares: CMEQ (float/int), signed CMGT, unsigned CMHI/CMHS, float FCMGT.
+    mi.opcode = arm64.VEC_CMEQ::u32; mi.vec_lane = mir.vec_lane_make(mir.VEC_LANE_INT, 4); st.buf.len = 0;
+    encode_neon(?st, ?f, ?mi); if (read_word(?st.buf, 0) != 0x6EA28C20) { bad = 1; }
+    mi.vec_lane = mir.vec_lane_make(mir.VEC_LANE_FLOAT, 4); st.buf.len = 0;
+    encode_neon(?st, ?f, ?mi); if (read_word(?st.buf, 0) != 0x4E22E420) { bad = 1; }
+    mi.opcode = arm64.VEC_CMGT::u32; mi.vec_lane = mir.vec_lane_make(mir.VEC_LANE_INT, 4); st.buf.len = 0;
+    encode_neon(?st, ?f, ?mi); if (read_word(?st.buf, 0) != 0x4EA23420) { bad = 1; }
+    mi.vec_lane = mir.vec_lane_make(mir.VEC_LANE_FLOAT, 4); st.buf.len = 0;
+    encode_neon(?st, ?f, ?mi); if (read_word(?st.buf, 0) != 0x6EA2E420) { bad = 1; }
+    mi.opcode = arm64.VEC_CMHI::u32; mi.vec_lane = mir.vec_lane_make(mir.VEC_LANE_INT, 4); st.buf.len = 0;
+    encode_neon(?st, ?f, ?mi); if (read_word(?st.buf, 0) != 0x6EA23420) { bad = 1; }
+    mi.opcode = arm64.VEC_CMHS::u32; mi.vec_lane = mir.vec_lane_make(mir.VEC_LANE_INT, 1); st.buf.len = 0;
+    encode_neon(?st, ?f, ?mi); if (read_word(?st.buf, 0) != 0x6E223C20) { bad = 1; }
+
+    # VEC_CMNE i8x16 -> CMEQ.16b then NOT.16b (two words).
+    mi.opcode = arm64.VEC_CMNE::u32; mi.vec_lane = mir.vec_lane_make(mir.VEC_LANE_INT, 1); st.buf.len = 0;
+    encode_neon(?st, ?f, ?mi);
+    if (read_word(?st.buf, 0) != 0x6E228C20) { bad = 1; }
+    if (read_word(?st.buf, 4) != 0x6E205800) { bad = 1; }
+
+    # VEC_NOT: two-operand `NOT v0.16b, v1.16b`.
+    ops[0] = tvec(0); ops[1] = tvec(1);
+    mi.opcode = arm64.VEC_NOT::u32; mi.operand_count = 2; mi.vec_lane = mir.vec_lane_make(mir.VEC_LANE_INT, 1); st.buf.len = 0;
+    encode_neon(?st, ?f, ?mi); if (read_word(?st.buf, 0) != 0x6E205820) { bad = 1; }
+
+    encode.buf_dnit(?st.buf);
     ret bad;
 }

--- a/src/lang/target/isa/arm64/encode.mach
+++ b/src/lang/target/isa/arm64/encode.mach
@@ -287,9 +287,12 @@ val VCMHI_U: u32 = 0x6E203400; val VCMHS_U: u32 = 0x6E203C00;    # unsigned > , 
 val VFCMEQ:  u32 = 0x4E20E400; val VFCMGT:  u32 = 0x6EA0E400; val VFCMGE: u32 = 0x6E20E400;
 # NOT Vd.16b, Vn.16b: two-register-misc (Rn[9:5], Rd[4:0]); the `!=` mask complement
 val VNOT:    u32 = 0x6E205800;
-# 128-bit load/store (scaled unsigned offset, imm12 scaled by the 16-byte access
-# size) for vector loads / stores / spills, and the Q register move (an ORR alias)
+# 128-bit load/store for vector loads / stores / spills: scaled unsigned offset
+# (imm12 scaled by the 16-byte access size), unscaled signed offset (LDUR/STUR
+# imm9), and register offset - the Q-register twins of the scalar FP forms
 val LDR_Q_OFF: u32 = 0x3DC00000; val STR_Q_OFF: u32 = 0x3D800000;
+val LDUR_Q_FP: u32 = 0x3CC00000; val STUR_Q_FP: u32 = 0x3C800000;
+val LDR_Q_REG: u32 = 0x3CE06800; val STR_Q_REG: u32 = 0x3CA06800;
 # lane extract / insert: imm5[20:16] selects the element size + lane index via
 # `neon_imm5`. UMOV / SMOV read a lane to a GP register (zero / sign extended); INS
 # writes a GP register (or another lane, `VINS_EL`, imm4[14:11] = source lane) to a
@@ -365,12 +368,6 @@ fun pack_neon_lane_read(base: u32, size: u32, index: u32, rd: u32, rn: u32) u32 
 # lane, Rn[9:5] the GP source, Rd[4:0] the destination vector
 fun pack_neon_ins_gp(size: u32, index: u32, rd: u32, rn: u32) u32 {
     ret VINS_GP | ((neon_imm5(size, index) & 0x1F) << 16) | ((rn & 0x1F) << 5) | (rd & 0x1F);
-}
-
-# a NEON 128-bit scaled load/store word (#2015): imm12[21:10] is the byte offset
-# scaled by the 16-byte access size, Rn[9:5] the base, Rt[4:0] the vector register
-fun pack_ldst_q(base: u32, rt: u32, rn: u32, imm12: u32) u32 {
-    ret base | ((imm12 & 0xFFF) << 10) | ((rn & 0x1F) << 5) | (rt & 0x1F);
 }
 
 # a SUBS XZR, Rn, Rm word (the register CMP) - Rm[20:16], Rn[9:5],
@@ -1320,8 +1317,23 @@ fun fp_mem_reg_base(use_d: bool, is_load: bool) u32 {
 # at the legalized address `[base + off]`, choosing the scaled unsigned-offset
 # (imm12), unscaled signed-offset (imm9 / LDUR-STUR), or register-offset form. an
 # offset outside both immediate ranges is materialized into IP0 and addressed
-# `[base, IP0]`. the FP analogue of `emit_mem_access`; `width` is 4 (S) or 8 (D)
+# `[base, IP0]`. the FP analogue of `emit_mem_access`; `width` is 4 (S), 8 (D), or
+# 16 (Q, a 128-bit vector load / store / spill). the Q forms are unaligned-safe, so
+# a vector spill needs no over-aligned slot
 fun emit_fp_mem(st: *encode.EncodeState, rt: u32, base: u32, off: i64, width: u8, is_load: bool) {
+    if (width == 16) {
+        if (off >= 0 && (off & 0xF) == 0 && (off >> 4) <= 4095) {
+            emit_word(st, pack_ldst(sel(is_load, LDR_Q_OFF, STR_Q_OFF), rt, base, (off >> 4)::u32));
+            ret;
+        }
+        if (off >= -256 && off <= 255) {
+            emit_word(st, pack_ldur(sel(is_load, LDUR_Q_FP, STUR_Q_FP), rt, base, off::u32 & 0x1FF));
+            ret;
+        }
+        emit_movewide_seq(st, SCRATCH0, off::u64, true);
+        emit_word(st, pack_ldst_reg(sel(is_load, LDR_Q_REG, STR_Q_REG), rt, base, SCRATCH0));
+        ret;
+    }
     val use_d: bool = width == 8;
     var sh: u32 = 2;
     if (use_d) { sh = 3; }
@@ -5720,11 +5732,14 @@ test "mach.lang.target.isa.arm64.encode:neon_vector_base_words" {
     if (pack_neon_ins_gp(2, 2, 0, 1) != 0x4E141C20) { bad = 1; }
     if (pack_neon_ins_gp(3, 1, 0, 1) != 0x4E181C20) { bad = 1; }
 
-    # 128-bit load/store with the byte offset scaled by the 16-byte access size.
-    if (pack_ldst_q(LDR_Q_OFF, 0, 0, 0) != 0x3DC00000) { bad = 1; }
-    if (pack_ldst_q(STR_Q_OFF, 0, 0, 0) != 0x3D800000) { bad = 1; }
-    if (pack_ldst_q(LDR_Q_OFF, 0, 1, 1) != 0x3DC00420) { bad = 1; }
-    if (pack_ldst_q(STR_Q_OFF, 2, 3, 2) != 0x3D800862) { bad = 1; }
+    # 128-bit load/store with the byte offset scaled by the 16-byte access size
+    # (the shared scaled-offset packer), plus the unscaled and register-offset forms.
+    if (pack_ldst(LDR_Q_OFF, 0, 0, 0) != 0x3DC00000) { bad = 1; }
+    if (pack_ldst(STR_Q_OFF, 0, 0, 0) != 0x3D800000) { bad = 1; }
+    if (pack_ldst(LDR_Q_OFF, 0, 1, 1) != 0x3DC00420) { bad = 1; }
+    if (pack_ldst(STR_Q_OFF, 2, 3, 2) != 0x3D800862) { bad = 1; }
+    if (pack_ldur(LDUR_Q_FP, 0, 0, 0x1F8::u32) != 0x3CDF8000) { bad = 1; }  # ldur q0,[x0,#-8]
+    if (pack_ldst_reg(LDR_Q_REG, 0, 0, 1) != 0x3CE16800) { bad = 1; }        # ldr q0,[x0,x1]
 
     ret bad;
 }

--- a/src/lang/target/isa/arm64/isel.mach
+++ b/src/lang/target/isa/arm64/isel.mach
@@ -129,6 +129,16 @@ pub fun is_reg_move(opcode: u32) bool {
     ret opcode == arm64.MOV::u32 || opcode == arm64.FMOV::u32 || opcode == mir.MIR_MOV;
 }
 
+# swap a comparison's lhs and rhs (operands 1 and 2), leaving the destination
+# (operand 0) in place. normalizes a generic LT/LE vector comparison to the NEON
+# GT/GE form (`a < b` == `b > a`), which is what NEON provides - there is no
+# less-than vector compare
+fun swap_cmp_operands(mi: *mir.MirInstr) {
+    val tmp: mir.MirOperand = mi.operands[1];
+    mi.operands[1] = mi.operands[2];
+    mi.operands[2] = tmp;
+}
+
 # rewrite a single generic MIR opcode in place into its concrete AArch64 encoder
 # opcode, or leave it as a surviving sentinel / pass-through
 #
@@ -140,6 +150,31 @@ pub fun is_reg_move(opcode: u32) bool {
 # ret: ok(true) on success, or an ICE error for an unmodelled opcode
 fun rewrite(fn: *mir.MirFunction, mi: *mir.MirInstr) R.Result[bool, str] {
     val o: mir.MirOpcode = mi.opcode;
+
+    # a vector-typed data op (`vec_lane != 0`) selects to a NEON opcode read off the
+    # lane shape, never the scalar A64 opcode of the same generic value. arithmetic /
+    # logical map one-to-one; a comparison normalizes its generic LT/LE to a NEON
+    # GT/GE by swapping the operands (`a < b` == `b > a`), and the signed vs unsigned
+    # integer form comes from the generic compare's signedness. the encoder reads the
+    # float-vs-int form and the arrangement from `vec_lane`. a vector move / load /
+    # store / lane op is not a data-processing op and falls through to the shared
+    # selection, which the encoder handles at the 128-bit width.
+    if (mi.vec_lane != 0) {
+        if (o == mir.MIR_ADD) { mi.opcode = arm64.VEC_ADD::u32; ret R.ok[bool, str](true); }
+        if (o == mir.MIR_SUB) { mi.opcode = arm64.VEC_SUB::u32; ret R.ok[bool, str](true); }
+        if (o == mir.MIR_MUL) { mi.opcode = arm64.VEC_MUL::u32; ret R.ok[bool, str](true); }
+        if (o == mir.MIR_DIV_U || o == mir.MIR_DIV_S) { mi.opcode = arm64.VEC_DIV::u32; ret R.ok[bool, str](true); }
+        if (o == mir.MIR_AND) { mi.opcode = arm64.VEC_AND::u32; ret R.ok[bool, str](true); }
+        if (o == mir.MIR_OR)  { mi.opcode = arm64.VEC_ORR::u32; ret R.ok[bool, str](true); }
+        if (o == mir.MIR_XOR) { mi.opcode = arm64.VEC_EOR::u32; ret R.ok[bool, str](true); }
+        if (o == mir.MIR_NOT) { mi.opcode = arm64.VEC_NOT::u32; ret R.ok[bool, str](true); }
+        if (o == mir.MIR_CMP_EQ) { mi.opcode = arm64.VEC_CMEQ::u32; ret R.ok[bool, str](true); }
+        if (o == mir.MIR_CMP_NE) { mi.opcode = arm64.VEC_CMNE::u32; ret R.ok[bool, str](true); }
+        if (o == mir.MIR_CMP_LT_S) { swap_cmp_operands(mi); mi.opcode = arm64.VEC_CMGT::u32; ret R.ok[bool, str](true); }
+        if (o == mir.MIR_CMP_LT_U) { swap_cmp_operands(mi); mi.opcode = arm64.VEC_CMHI::u32; ret R.ok[bool, str](true); }
+        if (o == mir.MIR_CMP_LE_S) { swap_cmp_operands(mi); mi.opcode = arm64.VEC_CMGE::u32; ret R.ok[bool, str](true); }
+        if (o == mir.MIR_CMP_LE_U) { swap_cmp_operands(mi); mi.opcode = arm64.VEC_CMHS::u32; ret R.ok[bool, str](true); }
+    }
 
     # the three-address integer binary ALU ops rewrite to a concrete A64
     # three-address opcode (N=1): A64 ALU is three-address, so operand 0 stays a

--- a/src/lang/target/isa/arm64/isel.mach
+++ b/src/lang/target/isa/arm64/isel.mach
@@ -174,6 +174,16 @@ fun rewrite(fn: *mir.MirFunction, mi: *mir.MirInstr) R.Result[bool, str] {
         if (o == mir.MIR_CMP_LT_U) { swap_cmp_operands(mi); mi.opcode = arm64.VEC_CMHI::u32; ret R.ok[bool, str](true); }
         if (o == mir.MIR_CMP_LE_S) { swap_cmp_operands(mi); mi.opcode = arm64.VEC_CMGE::u32; ret R.ok[bool, str](true); }
         if (o == mir.MIR_CMP_LE_U) { swap_cmp_operands(mi); mi.opcode = arm64.VEC_CMHS::u32; ret R.ok[bool, str](true); }
+
+        # vector shifts and remainder are outside the increment-1 table (#2030 removed
+        # per-lane shifts at sema; there is no vector `%` or integer `/`). a loud
+        # backstop, never a scalar-opcode fall-through, if one still reaches isel.
+        if (o == mir.MIR_SHL || o == mir.MIR_SHR_S || o == mir.MIR_SHR_U ||
+            o == mir.MIR_REM_S || o == mir.MIR_REM_U) {
+            ret R.err[bool, str]("codegen: unsupported vector operation on aarch64");
+        }
+        # a vector move / load / store / GEP / lane access is not a data-processing
+        # op and falls through to the shared selection below, handled at width 16.
     }
 
     # the three-address integer binary ALU ops rewrite to a concrete A64


### PR DESCRIPTION
## #1965 tier-1 — aarch64 NEON isel + AAPCS64 short-vector ABI

The aarch64 backend leaf of the portable-vector program: NEON instruction selection
plus the AAPCS64 short-vector ABI so the ten 128-bit seeded vector types execute one
instruction per operator, on the honest SSE2-baseline op table. `Closes #2015`.
Builds on the #2013 gate, the merged `vec_lane` MIR descriptor (#2037), the #2022
arm64 encode surface, and the merged lane substrate (#2042). Consumes `vec_lane`
(element kind + width) for the NEON arrangement.

### Landed + byte-exact unit-tested (vs `llvm-mc -triple=aarch64`)
- **NEON encode words + packers:** three-register-same (FADD/FSUB/FMUL/FDIV,
  ADD/SUB/MUL, AND/ORR/EOR, integer + float compares), the NOT `!=` complement, Q
  load/store, and lane extract/insert (UMOV/SMOV/INS). Arrangement rides `size<<22`.
- **128-bit Q load/store/spill** in `emit_fp_mem` (scaled/unscaled/register-offset),
  unaligned-safe.
- **NEON op selection:** isel rewrites a vector-typed generic MIR op to an arm64
  `VEC_*` opcode (at `0x100+`, above the surviving generic MIR range — see note);
  `encode_neon` emits the arrangement-specific word off `vec_lane`, normalizing
  LT/LE compares to GT/GE with an operand swap and `!=` to an equality word + NOT.
- **128-bit vector register move / spill** (`MOV Vd.16b` / Q load-store).
- **AAPCS64 short-vector ABI:** a vector routes as a one-member HVA — a single V
  register argument, V0 return, by-value stack spill on bank exhaustion. Neutral ABI
  marshaller carries the 16-byte move width.
- **Guard:** the target-generic vector guard is lifted for aarch64 via
  `arch_selects_vectors` (x86_64/riscv64 add their arm as they land — minimal shared
  hunk), with a loud isel backstop for any vector shift / remainder.

### Opcode-aliasing fix (worth calling out)
The `VEC_*` opcodes initially sat at 17-30 and aliased surviving generic MIR opcode
values (the conversions `MIR_TRUNC`=21..`MIR_BITCAST`=30, `MIR_FP_EXT`=25, …), so the
encoder's conversion dispatch misrouted a selected vector logical/compare op before
it reached `encode_neon`. Moved to `0x100+`, above the generic MIR range. (A
selection opcode must never collide with a generic opcode that survives isel.)

### `.16b` arrangement collapse — root cause + fix (in this branch)
Vector compares (and, latently, every other vector op) encoded as `.16b` (byte)
regardless of lane width. Bisected with instrumentation: `vec_lane` was correct
(INT/4) at MIR lowering and at isel entry, but `0` at encode. The drop was in
`rewrite_instr` (`be/codegen/regalloc.mach`), which rebuilds each `MirInstr`
field-by-field into a fresh slot during register assignment and copied `opcode` /
`width` / `operands` / `loc` / … but **not** `vec_lane` — a field the merged
`vec_lane` descriptor PR (#2037) added without updating this rebuild site. A
rewritten vector op therefore defaulted to element bytes `0`, which the NEON encoder
reads as `.16b`. Compares exposed it because their all-ones/all-zeros result differs
starkly per element width; the arithmetic ops were only *coincidentally* correct on
small operands (a `.16b` add/sub/mul with no cross-byte carry matches the `.4s`
result). Fix: `rewrite_instr` now carries `vec_lane`. Arch-neutral — it also unblocks
the x86_64 SSE2 backend (#2014), which reads the same descriptor for its packed
arrangement selection (flagged to coordinator; #2014 picks it up on rebase / once
this merges to dev).

### Runtime proof (out-of-tree, per the #2036 standard)
Self-checking programs built with the freshly-built HEAD compiler and run under
**qemu-aarch64**, lane-exact vs a scalar reference. Colocated test blocks cannot
carry vector *source* (`f32x4{...}`) — the released seed predates the vector types —
so the permanent colocated runtime suite is **#2038** (post the v3.3.2 re-seed); this
PR's colocated tests are the seed-safe byte-exact encode/isel and ABI-classify
blocks. Proofs use *initialized* vector locals (an uninitialized `var v: i32x4;`
errors until the #2043 fast-follow lands).

Values chosen to distinguish `.4s` from `.16b`: lane 1 uses `266` (`0x0000010A`) vs
`10` (`0x0000000A`) — same low byte, differing byte 1 — so a byte compare would leak
`0xFFFF00FF` where a 32-bit compare gives `0`; the add uses a cross-byte carry
(`200+100`, `70000+1`).

```
eq={ 4294967295 0 4294967295 4294967295 }   i32x4 ==   (lane1 = 0: exact .4s, not .16b's 4294901503)
gt={ 0 4294967295 0 0 }                      i32x4 >    (signed VCMGT_S)
lt={ 0 0 0 0 }                               i32x4 <    (operand-swapped VCMGT_S)
add={ 300 70001 6 8 }                        i32x4 +    (lane0 keeps the carry, not .16b's 44)
sub={ 100 69999 0 0 }                        i32x4 -
lane={ 200 70000 3 4 }                       v[i]       (lane read-back through the #2042 array-of-lanes shape)
```

Previously reported lane-exact as well: i16x8 `*`, i32x4 `&`.

### Verification bars
- **int suite** (surface + regression, linux native leg, both profiles): all pass,
  including `surface/debuginfo` debug + release (the `-g` PT_LOAD additivity +
  `dwarfdump --verify` bar).
- **aarch64 release self-host fixpoint:** `b == c` byte-identical — the aarch64/release
  compiler, run under qemu-aarch64, rebuilds itself to the exact same bytes.
- **suite count:** `598 passed, 0 failed` via the from-source HEAD compiler = dev's
  595 baseline + 3 seed-safe pipeline test blocks.
