### PR TITLE
fix(sema): narrow vector shifts out of the increment-1 operator table (#2030)

### DIFF
--- a/src/lang/driver.mach
+++ b/src/lang/driver.mach
@@ -6482,6 +6482,13 @@ test "mach.lang.driver:vector_negative_diagnostics" {
     # scalar<->vector mixing in the reversed operand order (scalar on the left).
     if (ut_vec_diag("fun main() i32 { val a: f32x4 = f32x4{1.0, 2.0, 3.0, 4.0}; val s: f32 = 1.0; val c: f32x4 = s + a; ret 0; }\n",
         "mismatch") != 0) { bad = 1; }
+    # vector `<<` / `>>` are out of the increment-1 table (#2030), across shapes.
+    if (ut_vec_diag("fun main() i32 { val a: i32x4 = i32x4{1, 2, 3, 4}; val b: i32x4 = i32x4{1, 1, 1, 1}; val c: i32x4 = a << b; ret 0; }\n",
+        "vector shift") != 0) { bad = 1; }
+    if (ut_vec_diag("fun main() i32 { val a: u16x8 = u16x8{1, 2, 3, 4, 5, 6, 7, 8}; val b: u16x8 = u16x8{1, 1, 1, 1, 1, 1, 1, 1}; val c: u16x8 = a >> b; ret 0; }\n",
+        "not in the increment-1 operator table") != 0) { bad = 1; }
+    if (ut_vec_diag("fun main() i32 { val a: i8x16 = i8x16{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}; val b: i8x16 = i8x16{1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1}; val c: i8x16 = a << b; ret 0; }\n",
+        "vector shift") != 0) { bad = 1; }
 
     ret bad;
 }

--- a/src/lang/fe/sema/infer.mach
+++ b/src/lang/fe/sema/infer.mach
@@ -735,9 +735,18 @@ fun infer_vector_binary(sc: *context.SemaContext, op: expr.BinOp, lt: type.TypeI
         ret join_secret(sc, R.unwrap_ok[type.TypeId, str](mr), either_secret);
     }
 
-    # bitwise and shifts require integer lanes.
-    if (op == expr.BIN_BIT_AND || op == expr.BIN_BIT_OR || op == expr.BIN_BIT_XOR
-        || op == expr.BIN_SHL || op == expr.BIN_SHR) {
+    # `<<` / `>>` are out of the increment-1 table (#2030): the lowered form is a
+    # per-lane variable shift, which is AVX2-only on x86_64 (VPSLLVD-class) and has
+    # no 8-bit packed form at all, so it is not 1:1 on the SSE2 baseline. shifts
+    # return in a later increment as a deliberate choice between the uniform-count
+    # shape (SSE2-1:1 with splat) and the per-lane shape (NEON-native, AVX2-gated).
+    if (op == expr.BIN_SHL || op == expr.BIN_SHR) {
+        check.report_typed(sc, span, "vector shift `<<` / `>>` is not in the increment-1 operator table (`", lbase, "`); a per-lane variable shift is not 1:1 on the SSE2 baseline (AVX2-only, no 8-bit packed form), so shifts are deferred to a later increment", "vector shift is not in the increment-1 operator table");
+        ret type.TYPE_ERROR;
+    }
+
+    # bitwise `& | ^` require integer lanes.
+    if (op == expr.BIN_BIT_AND || op == expr.BIN_BIT_OR || op == expr.BIN_BIT_XOR) {
         if (!int_lane) {
             context.report(sc, span, "type mismatch: bitwise vector operands must have integer lanes");
             ret type.TYPE_ERROR;

--- a/src/lang/me/ir/verify.mach
+++ b/src/lang/me/ir/verify.mach
@@ -655,7 +655,8 @@ fun is_vector_compare(k: instruction.InstrKind) bool {
 }
 
 # true for a lane-wise opcode whose vector form preserves the operand shape in its
-# result (arithmetic, bitwise, shift, and the value unary ops) (#1965)
+# result (arithmetic, bitwise `& | ^`, and the value unary ops; shifts are out of
+# the increment-1 table, #2030) (#1965)
 # ---
 # k:   the opcode to classify
 # ret: true for the shape-preserving vector opcodes
@@ -663,7 +664,6 @@ fun is_vector_sameshape(k: instruction.InstrKind) bool {
     if (k == instruction.OP_ADD || k == instruction.OP_SUB || k == instruction.OP_MUL) { ret true; }
     if (k == instruction.OP_DIV_S || k == instruction.OP_DIV_U)                        { ret true; }
     if (k == instruction.OP_AND || k == instruction.OP_OR || k == instruction.OP_XOR)  { ret true; }
-    if (k == instruction.OP_SHL || k == instruction.OP_SHR_S || k == instruction.OP_SHR_U) { ret true; }
     if (k == instruction.OP_NEG || k == instruction.OP_NOT)                            { ret true; }
     ret false;
 }

--- a/src/lang/me/lower/expr.mach
+++ b/src/lang/me/lower/expr.mach
@@ -1900,12 +1900,8 @@ fun lower_vector_binary(ctx: *context.LowerContext, op: expr.BinOp, lhs: value.V
     if (op == expr.BIN_BIT_AND) { ret builder.emit_and(?ctx.builder, lhs, rhs); }
     if (op == expr.BIN_BIT_OR)  { ret builder.emit_or(?ctx.builder, lhs, rhs); }
     if (op == expr.BIN_BIT_XOR) { ret builder.emit_xor(?ctx.builder, lhs, rhs); }
-    if (op == expr.BIN_SHL)     { ret builder.emit_shl(?ctx.builder, lhs, rhs); }
-    if (op == expr.BIN_SHR) {
-        if (vector_lane_signed(ctx, lty)) { ret builder.emit_shr_s(?ctx.builder, lhs, rhs); }
-        ret builder.emit_shr_u(?ctx.builder, lhs, rhs);
-    }
 
+    # vector `<<` / `>>` are rejected in sema (#2030), so no shift reaches lowering.
     ret R.err[value.Value, str]("lower: unsupported vector binary operator");
 }
 


### PR DESCRIPTION
Follow-up to the SIMD gate (#2013 / PR #2024). Blocks the isel-guard-arm removal in #2014 and #2015.

Closes #2030.

## Problem

The merged gate admitted vector `<<` `>>` on integer-lane vectors and lowered them to same-shape two-vector-operand `OP_SHL`/`OP_SHR_*` — a **per-lane variable shift**. That contradicts the epic's honest-table premise ("what is 1:1 on the SSE2/NEON baselines"), the same criterion that kept integer `*` to 16-bit lanes and excluded 64-bit compares. Per-lane variable shift is AVX2 (`VPSLLVD`-class) on x86_64; SSE2's packed shifts move all lanes by one shared count, and 8-bit lanes have no packed shift at all — a "fixed defined sequence" would be a ~50-instruction extract/shift/insert unroll on a **capable** target, far past the short-fixed-sequence precedent.

## Fix

Narrow increment 1 to the strict bit-parallel set: `& | ^` binary and `~` unary on integer lanes. Vector `<<` `>>` are now a **specific sema error** naming the type and pointing at the per-lane-vs-uniform deferral; the vector shift lowering arm and the verifier's shift same-shape arm are removed, so no vector-typed shift op is ever produced. Forward-compatible with both a later uniform-count shape (SSE2-1:1 + splat) and a per-lane shape (NEON-native, AVX2-gated).

## Verification (from-source HEAD, 3.3.1 seed)

- `v << w` / `v >> w` on every shape (i32x4, u16x8, i8x16) → the specific diagnostic (`vector shift ... is not in the increment-1 operator table`); scalar shifts unaffected.
- No vector-typed shift op reaches IR — sema rejects them before lowering.
- Full unit suite: **588 passed, 0 failed** = dev baseline 588 + 0 new test blocks (the shift cases extend the existing `vector_negative_diagnostics` test).
- Self-host fixpoint: gen2 == gen3 byte-identical.
- -g additivity: PT_LOAD byte-identical, both profiles.
- llvm-dwarfdump --verify: clean, 21 target builds.
- int suite: all pass on linux.
