### PR TITLE
feat(x86_64): SSE2 vector isel + SysV SSE-class ABI (#2014)

### DIFF
--- a/src/lang/be/codegen/mir.mach
+++ b/src/lang/be/codegen/mir.mach
@@ -460,11 +460,16 @@ pub rec MirBlock {
 # class:      index into target.arch.reg_classes selecting the register bank
 # spill_slot: stack-frame slot index when spilled (-1 while unspilled)
 # assigned:   physical register id assigned by regalloc (MIR_VREG_NIL until then)
+# vector:     true when the vreg holds a 128-bit SIMD vector; distinguishes a vector
+#             from a scalar float within the shared FP bank so regalloc 16-byte-aligns
+#             its spill slot (MOVAPS reloads require it) while scalar-float slots stay
+#             at align 8 (#2014)
 pub rec MirVReg {
     id:         u32;
     class:      u32;
     spill_slot: i32;
     assigned:   u32;
+    vector:     bool;
 }
 
 # discriminant distinguishing an addressed alloca slot from a by-value spill slot

--- a/src/lang/be/codegen/mir/context.mach
+++ b/src/lang/be/codegen/mir/context.mach
@@ -148,7 +148,7 @@ pub fun ctx_setup(ctx: *LowerCtx, tgt: *target.Target, fn: *ir.Function) R.Resul
     var i: u32 = 0;
     for (i < ctx.param_count) {
         val reg_class: u32 = reg_class_of(ctx, tgt, fn.params[i].ty);
-        val res_vreg: R.Result[u32, str] = new_vreg(ctx, reg_class);
+        val res_vreg: R.Result[u32, str] = new_vreg_vec(ctx, reg_class, value_is_vector(ctx, fn.params[i].ty));
         if (R.is_err[u32, str](res_vreg)) { ret R.err[bool, str](R.unwrap_err[u32, str](res_vreg)); }
         ctx.param_vregs[i] = R.unwrap_ok[u32, str](res_vreg);
         i = i + 1;
@@ -163,7 +163,7 @@ pub fun ctx_setup(ctx: *LowerCtx, tgt: *target.Target, fn: *ir.Function) R.Resul
             # now carries the IR pointer type (its element type rides on aux_ty),
             # so it classifies general-purpose without a special case.
             val reg_class: u32 = reg_class_of(ctx, tgt, inst.ty);
-            val res_vreg: R.Result[u32, str] = new_vreg(ctx, reg_class);
+            val res_vreg: R.Result[u32, str] = new_vreg_vec(ctx, reg_class, value_is_vector(ctx, inst.ty));
             if (R.is_err[u32, str](res_vreg)) { ret R.err[bool, str](R.unwrap_err[u32, str](res_vreg)); }
             ctx.instr_vregs[i] = R.unwrap_ok[u32, str](res_vreg);
         }
@@ -265,8 +265,23 @@ pub fun new_vreg(ctx: *LowerCtx, reg_class: u32) R.Result[u32, str] {
     f.vregs[vid].class      = reg_class;
     f.vregs[vid].spill_slot = -1;
     f.vregs[vid].assigned   = mir.MIR_VREG_NIL;
+    f.vregs[vid].vector     = false;
     f.vreg_count = f.vreg_count + 1;
     ret R.ok[u32, str](vid);
+}
+
+# append a fresh vreg that holds a 128-bit vector when `vector` is set, so regalloc
+# 16-byte-aligns its spill slot for MOVAPS reloads (#2014)
+# ---
+# ctx:       the lowering context
+# reg_class: register-class index into target.arch.reg_classes
+# vector:    whether the vreg holds a 128-bit SIMD vector
+# ret:       the new vreg id, or an allocation error
+pub fun new_vreg_vec(ctx: *LowerCtx, reg_class: u32, vector: bool) R.Result[u32, str] {
+    val r: R.Result[u32, str] = new_vreg(ctx, reg_class);
+    if (R.is_err[u32, str](r)) { ret r; }
+    ctx.f.vregs[R.unwrap_ok[u32, str](r)].vector = vector;
+    ret r;
 }
 
 # the result vreg mapped to an instruction id, or mir.MIR_VREG_NIL when the id is

--- a/src/lang/be/codegen/mir/lower.mach
+++ b/src/lang/be/codegen/mir/lower.mach
@@ -841,15 +841,26 @@ fun lower_instr(ctx: *lctx.LowerCtx, fn: *ir.Function, mb: *mir.MirBlock, iid: i
     ctx.cur_vec_lane = lctx.compute_vec_lane(ctx, inst);
 
     # a 128-bit vector reaching MIR lowering needs backend selection (#1965): a
-    # target whose backend wires it (aarch64 NEON here, x86_64 SSE2, rv64
-    # scalarization) lets it through to real lowering; a target without selection
-    # yet gets a defined per-target compile error, never an ICE or the silent 8-byte
-    # GP clamp `op_width_of` would otherwise apply. phis are eliminated and
-    # dbg-values emit no code, so neither is the erroring site.
+    # target whose backend wires it (aarch64 NEON, x86_64 SSE2, rv64 scalarization)
+    # lets it through to real lowering; a target without selection yet gets a defined
+    # per-target compile error, never an ICE or the silent 8-byte GP clamp
+    # `op_width_of` would otherwise apply. phis are eliminated and dbg-values emit no
+    # code, so neither is the erroring site.
     if (inst.kind != instr.OP_PHI && inst.kind != instr.OP_DBG_VALUE
-        && instr_touches_vector(ctx, inst)
-        && !arch_selects_vectors(ctx.tgt.arch.id)) {
-        ret R.err[bool, str](vector_unsupported(ctx));
+        && instr_touches_vector(ctx, inst)) {
+        if (!arch_selects_vectors(ctx.tgt.arch.id)) {
+            ret R.err[bool, str](vector_unsupported(ctx));
+        }
+        # x86_64: a lane-wise compute op (arithmetic / bitwise / unary not / compare-to-
+        # mask) rides the generic MIR opcodes carrying `vec_lane` directly, bypassing the
+        # scalar-specific float / divide / shift routing below (a vector float divide must
+        # not reach the integer `lower_div`); the x64 isel / encoder select the packed
+        # SSE2 form. load / store / move / call / ret / gep / alloca fall through to the
+        # shared handlers carrying the 16-byte width the vreg's `vector` flag set. aarch64
+        # (NEON) selects in its isa isel and falls through here for every vector op.
+        if (ctx.tgt.arch.id == isa.ARCH_X86_64 && is_vector_compute(inst.kind)) {
+            ret lower_generic(ctx, mb, inst, iid);
+        }
     }
 
     if (inst.kind == instr.OP_CALL) {
@@ -966,10 +977,11 @@ fun instr_touches_vector(ctx: *lctx.LowerCtx, inst: *instr.Instruction) bool {
 # whether the target arch's backend selects 128-bit vector ops to real machine
 # code, so a vector-typed instruction lowers rather than hitting the defined
 # "not yet supported" guard. each backend child flips its arch true as it wires
-# selection: aarch64 (NEON) here; x86_64 (#2014 SSE2) and riscv64 (#2016
-# scalarization) add their arm as they land.
+# selection: aarch64 (NEON) and x86_64 (#2014 SSE2). riscv64 needs no arm - its
+# scalarization pass rewrites vector ops before MIR lowering, so none reaches here.
 fun arch_selects_vectors(arch_id: u32) bool {
     if (arch_id == isa.ARCH_AARCH64) { ret true; }
+    if (arch_id == isa.ARCH_X86_64) { ret true; }
     ret false;
 }
 
@@ -1629,6 +1641,25 @@ fun is_compare_kind(k: instr.InstrKind) bool {
     ret k == instr.OP_CMP_EQ || k == instr.OP_CMP_NE ||
         k == instr.OP_CMP_LT_S || k == instr.OP_CMP_LT_U ||
         k == instr.OP_CMP_LE_S || k == instr.OP_CMP_LE_U;
+}
+
+# true for a lane-wise vector compute op that the x86_64 arm routes generically
+# rather than one of the memory / call / return ops that keep their dedicated handler.
+# a vector value flows to the generic lowering as its shared opcode carrying `vec_lane`;
+# the x64 isel / encoder select the packed SSE2 form from that descriptor (#2014). shifts
+# are rejected at sema (#2030) so none reach here, but routing them generically keeps the
+# isel loud backstop the single place a stray vector shift errors.
+# ---
+# k:   the IR instruction opcode
+# ret: true for a lane-wise compute op
+fun is_vector_compute(k: instr.InstrKind) bool {
+    if (k == instr.OP_ADD || k == instr.OP_SUB || k == instr.OP_MUL) { ret true; }
+    if (k == instr.OP_DIV_S || k == instr.OP_DIV_U ||
+        k == instr.OP_REM_S || k == instr.OP_REM_U) { ret true; }
+    if (k == instr.OP_AND || k == instr.OP_OR || k == instr.OP_XOR || k == instr.OP_NOT) { ret true; }
+    if (k == instr.OP_SHL || k == instr.OP_SHR_S || k == instr.OP_SHR_U) { ret true; }
+    if (is_compare_kind(k)) { ret true; }
+    ret false;
 }
 
 # true for the width-changing integer conversions (TRUNC / SEXT / ZEXT)

--- a/src/lang/be/codegen/regalloc.mach
+++ b/src/lang/be/codegen/regalloc.mach
@@ -2374,6 +2374,18 @@ fun class_width(lr: *LiveRange) u32 {
     ret 8;
 }
 
+# the spill-slot alignment for a spilled vreg: 16 bytes for a 128-bit vector (so its
+# MOVAPS reload is aligned), 8 bytes otherwise. keyed on the vreg's `vector` flag, so
+# scalar GP / float spill layout is unchanged and byte-identical (#2014)
+# ---
+# ctx:      the allocation context
+# value_id: the spilled vreg id
+# ret:      the slot alignment in bytes (8 or 16)
+fun spill_slot_align(ctx: *AllocCtx, value_id: u32) u32 {
+    if (value_id < ctx.f.vreg_count && ctx.f.vregs[value_id].vector) { ret 16; }
+    ret 8;
+}
+
 # append a SLOT_SPILL frame slot keyed on a vreg id and return
 # its slot index. mirrors `mir`'s param-spill slot construction so frame.run and
 # the encoder resolve the slot identically
@@ -2392,7 +2404,9 @@ fun add_spill_slot(ctx: *AllocCtx, value_id: u32, size: u32) R.Result[i32, str] 
     frame.slots[si].kind   = mir.SLOT_SPILL;
     frame.slots[si].offset = 0;
     frame.slots[si].size   = size;
-    frame.slots[si].align  = 8;
+    # a 128-bit vector spill slot is 16-byte aligned so its MOVAPS reload lands on the
+    # required boundary; scalar GP / float slots stay at align 8, byte-identical (#2014).
+    frame.slots[si].align  = spill_slot_align(ctx, value_id);
     frame.slot_count = frame.slot_count + 1;
     ret R.ok[i32, str](si::i32);
 }
@@ -2494,8 +2508,9 @@ fun fp_scratch_callee_mask(tgt: *target.Target) u32 {
 # ISA's fixed XMM scratch pair - a scalar float arithmetic / comparison / negation /
 # conversion op (the encoder routes every operand through the scratch), or a float
 # move naming a vector register (a same-bank float move loads through the scratch;
-# a both-memory float copy uses the GP scratch instead and so names no vector
-# register, correctly excluding it). a function that hits one of these clobbers the
+# a scalar both-memory float copy uses the GP scratch and names no vector register,
+# excluding it - but a width-16 both-memory move stages through the XMM scratch and
+# so is caught by width). a function that hits one of these clobbers the
 # callee-saved float scratch and must preserve it for its caller, exactly as it
 # preserves an allocated callee-saved register
 fun function_uses_fp_scratch(f: *mir.MirFunction) bool {
@@ -2514,6 +2529,9 @@ fun function_uses_fp_scratch(f: *mir.MirFunction) bool {
                 ret true;
             }
             if (o == mir.MIR_MOV) {
+                # a width-16 both-memory move stages through the XMM scratch (#2034)
+                # and names no vector operand, so width is the only signal.
+                if (mi.width == 16) { ret true; }
                 var k: u32 = 0;
                 for (k < mi.operand_count) {
                     val op: *mir.MirOperand = ?mi.operands[k];

--- a/src/lang/target.mach
+++ b/src/lang/target.mach
@@ -738,30 +738,27 @@ test "mach.lang.target.select:has_v128_capability" {
     ret 0;
 }
 
-# the neutral classify-thread vector flag is zero-behavior in the gate: no backend
-# reads is_vector yet, so an argument / return slot is byte-for-byte identical
-# whether is_vector is true or false. this pins the collision-avoidance substrate
-# as inert until the backend children (#2014/#2015/#2016) consume it (#1965)
-test "mach.lang.target.select:classify_vector_flag_zero_behavior" {
+# a 128-bit vector classifies as one SSE-class value under SysV (#2014): a single XMM
+# argument register (not the two-eightbyte split an all-float aggregate takes) and XMM0
+# for the return, both at the full 16-byte width
+test "mach.lang.target.select:classify_vector_sse_class" {
     var reg: TargetRegistry = registry_init();
     if (R.is_err[bool, str](register_all(?reg))) { ret 1; }
     val tx: R.Result[resolved.Target, str] = select_of(?reg, "x86_64", "linux", "sysv64", "");
     if (R.is_err[resolved.Target, str](tx)) { ret 1; }
     val t: resolved.Target = R.unwrap_ok[resolved.Target, str](tx);
 
+    # a 16-byte vector argument: one XMM register, size 16 (is_vector true, not aggregate).
     val arg: abi.ArgPassingFn = t.abi.arg_passing::abi.ArgPassingFn;
-    val a_no:  abi.ParamSlot = arg(0, 8, 8, false, 0, false, false, 0, 0, 0, 0, abi.agg_none());
-    val a_yes: abi.ParamSlot = arg(0, 8, 8, false, 0, false, true,  0, 0, 0, 0, abi.agg_none());
-    if (a_no.class != a_yes.class) { ret 1; }
-    if (a_no.reg != a_yes.reg)     { ret 1; }
-    if (a_no.size != a_yes.size)   { ret 1; }
+    val a: abi.ParamSlot = arg(0, 16, 16, false, 0, false, true, 0, 0, 0, 0, abi.agg_none());
+    if (a.class != abi.CLASS_FP) { ret 1; }
+    if (a.size != 16)            { ret 1; }
 
+    # a 16-byte vector return: XMM0, size 16.
     val rp: abi.RetPassingFn = t.abi.ret_passing::abi.RetPassingFn;
-    val r_no:  abi.ParamSlot = rp(8, 8, false, 0, false, false, 0, 0, abi.agg_none());
-    val r_yes: abi.ParamSlot = rp(8, 8, false, 0, false, true,  0, 0, abi.agg_none());
-    if (r_no.class != r_yes.class) { ret 1; }
-    if (r_no.reg != r_yes.reg)     { ret 1; }
-    if (r_no.size != r_yes.size)   { ret 1; }
+    val r: abi.ParamSlot = rp(16, 16, false, 0, false, true, 0, 0, abi.agg_none());
+    if (r.class != abi.CLASS_FP) { ret 1; }
+    if (r.size != 16)            { ret 1; }
 
     ret 0;
 }

--- a/src/lang/target/abi/sysv.mach
+++ b/src/lang/target/abi/sysv.mach
@@ -203,6 +203,16 @@ pub fun classify_arg(index: i32, size: u64, align: u64,
         ret abi.make_slot(abi.CLASS_STACK, -1, -1, 0, size);
     }
 
+    # a 128-bit vector is a single SSE-class value: one XMM argument register (not the
+    # two-eightbyte XMM0:XMM1 split an all-float aggregate takes), or a 16-byte by-value
+    # stack slot when the XMM argument registers are exhausted (#2014).
+    if (is_vector) {
+        if (fp_used < FP_PARAM_COUNT) {
+            ret abi.make_slot(abi.CLASS_FP, fp_param_reg(fp_used), -1, 0, size);
+        }
+        ret abi.make_slot(abi.CLASS_STACK, -1, -1, 0, size);
+    }
+
     if (is_float) {
         if (fp_used < FP_PARAM_COUNT) {
             ret abi.make_slot(abi.CLASS_FP, fp_param_reg(fp_used), -1, 0, size);
@@ -267,6 +277,12 @@ pub fun classify_return(size: u64, align: u64,
         if (eb0_sse) { r0 = ret_sse_reg(ns); ns = ns + 1; } or { r0 = ret_int_reg(ni); ni = ni + 1; }
         if (eb1_sse) { r1 = ret_sse_reg(ns); ns = ns + 1; } or { r1 = ret_int_reg(ni); ni = ni + 1; }
         ret abi.make_slot(abi.CLASS_GP, r0, r1, 0, size);
+    }
+
+    # a 128-bit vector returns in a single SSE register (XMM0), like a scalar float but
+    # at its full 16-byte width (#2014).
+    if (is_vector) {
+        ret abi.make_slot(abi.CLASS_FP, REG_XMM0, -1, 0, size);
     }
 
     if (is_float) {

--- a/src/lang/target/isa/x64.mach
+++ b/src/lang/target/isa/x64.mach
@@ -260,6 +260,56 @@ pub val SETP:      Opcode = 85;
 # ordered half of the IEEE-754 float `==` combine
 pub val SETNP:     Opcode = 86;
 
+# packed 128-bit SSE2 opcodes (#2014). the vector encoders resolve a (MIR packed op,
+# lane) pair to one of these and emit its `[66] 0F <byte> /r` form; the packed table
+# in `x64/encode.mach` maps each to its mandatory-prefix / secondary-opcode bytes.
+# packed single / double float add-sub-mul-div (ps takes no prefix, pd takes 66)
+pub val ADDPS:     Opcode = 87;
+pub val SUBPS:     Opcode = 88;
+pub val MULPS:     Opcode = 89;
+pub val DIVPS:     Opcode = 90;
+pub val ADDPD:     Opcode = 91;
+pub val SUBPD:     Opcode = 92;
+pub val MULPD:     Opcode = 93;
+pub val DIVPD:     Opcode = 94;
+# packed integer add / subtract at byte / word / dword / qword lane width
+pub val PADDB:     Opcode = 95;
+pub val PADDW:     Opcode = 96;
+pub val PADDD:     Opcode = 97;
+pub val PADDQ:     Opcode = 98;
+pub val PSUBB:     Opcode = 99;
+pub val PSUBW:     Opcode = 100;
+pub val PSUBD:     Opcode = 101;
+pub val PSUBQ:     Opcode = 102;
+# packed 16-bit integer multiply (low halves); the only baseline packed integer mul
+pub val PMULLW:    Opcode = 103;
+# packed bitwise and / or / xor (128-bit, lane-width agnostic)
+pub val PAND:      Opcode = 104;
+pub val POR:       Opcode = 105;
+pub val PXOR:      Opcode = 106;
+# packed float compare (imm8 predicate): ps no prefix, pd 66
+pub val CMPPS:     Opcode = 107;
+pub val CMPPD:     Opcode = 108;
+# packed integer equal / signed-greater compares at byte / word / dword lane width
+pub val PCMPEQB:   Opcode = 109;
+pub val PCMPEQW:   Opcode = 110;
+pub val PCMPEQD:   Opcode = 111;
+pub val PCMPGTB:   Opcode = 112;
+pub val PCMPGTW:   Opcode = 113;
+pub val PCMPGTD:   Opcode = 114;
+# unaligned packed move (128-bit load 0F 10 / store 0F 11) for pointer-to-vector
+# access whose alignment is not statically 16
+pub val MOVUPS:    Opcode = 115;
+# shuffle packed dwords by an imm8 selector (the 64-bit-lane equality compose)
+pub val PSHUFD:    Opcode = 116;
+# packed shift-left-logical dwords by imm8 (builds the 0x80000000-per-dword sign-bias
+# mask for the 32-bit-lane unsigned-ordering compare)
+pub val PSLLD:     Opcode = 117;
+# packed unsigned-saturating subtract at byte / word lane width (byte / word unsigned
+# ordering compares: `a <u b` iff `subus(b, a) != 0`)
+pub val PSUBUSB:   Opcode = 118;
+pub val PSUBUSW:   Opcode = 119;
+
 # encoding flags carried on `isa.Inst.flags`. they steer prefix and width
 # selection in the encoder independently of the opcode
 pub def EncFlag: u16;

--- a/src/lang/target/isa/x64/encode.mach
+++ b/src/lang/target/isa/x64/encode.mach
@@ -491,6 +491,28 @@ fun encode_fp_mov(mi: *isa.Inst, buf: *enc.ByteBuf) i32 {
     val start: usize = buf.len;
     val dst: *isa.Operand = ?mi.dst;
     val src1: *isa.Operand = ?mi.src1;
+
+    # a 128-bit vector move: MOVAPS between XMM registers (a copy or spill of a value in
+    # a 16-aligned slot), MOVUPS to / from memory since a pointer-to-vector load / store
+    # may not be statically 16-aligned (#2014). a vector never crosses to the GP bank.
+    if (mi.size == 16) {
+        if (dst.kind == isa.OPK_REG && src1.kind == isa.OPK_REG) {
+            emit_movaps_rr(dst.reg, src1.reg, buf);
+            ret (buf.len - start)::i32;
+        }
+        if (dst.kind == isa.OPK_REG && src1.kind == isa.OPK_MEM) {
+            emit_movups_load(dst.reg, @src1, buf);
+            ret (buf.len - start)::i32;
+        }
+        if (dst.kind == isa.OPK_MEM && src1.kind == isa.OPK_REG) {
+            emit_movups_store(@dst, src1.reg, buf);
+            ret (buf.len - start)::i32;
+        }
+        emit_movups_load(FLOAT_SCRATCH0, @src1, buf);
+        emit_movups_store(@dst, FLOAT_SCRATCH0, buf);
+        ret (buf.len - start)::i32;
+    }
+
     var w: u8 = mi.size;
     if (w != 4 && w != 8) { w = 8; }
 
@@ -529,7 +551,12 @@ fun encode_mov(mi: *isa.Inst, buf: *enc.ByteBuf) i32 {
     val size: u8 = mi.size;
     val flags: u16 = mi.flags;
 
-    if (reg_is_xmm(dst) || reg_is_xmm(src1)) {
+    # a 128-bit vector move (size 16) routes to the SSE move even when neither operand is
+    # an XMM register: a vector value spilled on BOTH sides (its result slot and its source
+    # slot) is a memory-to-memory move that the GP path would copy at the 8-byte word width,
+    # corrupting the high two lanes; the SSE path stages it through the XMM scratch with a
+    # 16-byte MOVUPS (#2014).
+    if (reg_is_xmm(dst) || reg_is_xmm(src1) || size == 16) {
         ret encode_fp_mov(mi, buf);
     }
 
@@ -1678,8 +1705,9 @@ fun encode_cvt(mi: *isa.Inst, buf: *enc.ByteBuf) i32 {
 #
 # dispatches on the x86-64 opcode to the matching encoder. pseudo-opcodes
 # (parallel copies) emit nothing. when both operands are memory the instruction
-# is first split into a load into the R11 scratch register and a recursive
-# re-encode against that register. on an unrecognized opcode it reports the
+# is first split into a load into the reserved scratch register (R11 for scalar
+# widths, the XMM scratch at width 16) and a recursive re-encode against that
+# register. on an unrecognized opcode it reports the
 # offending value to stderr and panics, since reaching here means the back end
 # emitted an instruction the encoder does not model.
 # ---
@@ -1697,7 +1725,12 @@ pub fun encode_inst(mi: *isa.Inst, buf: *enc.ByteBuf) i32 {
         opcode != x64.NOP && opcode != x64.RET && opcode != x64.SYSCALL &&
         opcode != x64.UD2 && opcode != x64.PAUSE && opcode != x64.CDQ &&
         opcode != x64.CQO && opcode != x64.MFENCE) {
-        val scratch: i32 = x64.R11;
+        # encoder staging must be non-allocatable per bank: at size 16 the GP R11
+        # id re-encodes as its XMM-bank shadow (XMM11), a live allocatable register
+        # (#2034), so a 16-byte (vector) mem-mem move stages through the reserved
+        # XMM scratch instead. scalar widths keep R11 (reserved from GP allocation).
+        var scratch: i32 = x64.R11;
+        if (mi.size == 16) { scratch = FLOAT_SCRATCH0; }
         var ld: isa.Inst;
         ld.opcode    = x64.MOV;
         ld.dst       = isa.make_reg(scratch, mi.size);
@@ -2589,6 +2622,15 @@ fun encode_mir_instr(st: *enc.EncodeState, f: *mir.MirFunction, fn_base: u32, mi
     }
     if (mi.opcode == mir.MIR_PHI) {
         ret R.err[bool, str](enc_named_message(st, "internal compiler error: phi survived register allocation in '", enc_fn_name(st, f), "'", "internal compiler error: phi survived register allocation"));
+    }
+
+    # a vector-typed ALU / compare / not (vec_lane set, and the opcode a selected packed
+    # candidate) materializes its packed SSE2 byte sequence here. this precedes the scalar
+    # compare / divide dispatch so a vector op sharing their MIR_SEL_* opcode is not encoded
+    # as its scalar integer form; a vector load / store / move keeps its concrete move
+    # opcode (not a candidate) and falls through to the width-16 SSE move below (#2014).
+    if (mir.vec_lane_is_vector(mi.vec_lane) && is_selected_vector_alu(mi.opcode)) {
+        ret encode_vector_op(f, mi, ?st.buf);
     }
 
     # the comparison family survives selection as a single `[dst, lhs, rhs]`
@@ -3522,6 +3564,495 @@ fun encode_float_cmp(f: *mir.MirFunction, mi: *mir.MirInstr, buf: *enc.ByteBuf) 
     encode_inst(?movzx, buf);
 
     ret R.ok[bool, str](true);
+}
+
+# whether a packed SSE2 opcode takes no mandatory prefix (the ps float forms, the ps
+# compare, and MOVUPS); everything else - pd float and all integer packed ops - takes 66
+fun packed_prefix66(op: u16) bool {
+    if (op == x64.ADDPS || op == x64.SUBPS || op == x64.MULPS || op == x64.DIVPS) { ret false; }
+    if (op == x64.CMPPS || op == x64.MOVUPS) { ret false; }
+    ret true;
+}
+
+# the secondary (0F-map) opcode byte for a packed SSE2 opcode
+fun packed_opbyte(op: u16) u8 {
+    if (op == x64.ADDPS || op == x64.ADDPD) { ret 0x58; }
+    if (op == x64.SUBPS || op == x64.SUBPD) { ret 0x5C; }
+    if (op == x64.MULPS || op == x64.MULPD) { ret 0x59; }
+    if (op == x64.DIVPS || op == x64.DIVPD) { ret 0x5E; }
+    if (op == x64.PADDB)  { ret 0xFC; }
+    if (op == x64.PADDW)  { ret 0xFD; }
+    if (op == x64.PADDD)  { ret 0xFE; }
+    if (op == x64.PADDQ)  { ret 0xD4; }
+    if (op == x64.PSUBB)  { ret 0xF8; }
+    if (op == x64.PSUBW)  { ret 0xF9; }
+    if (op == x64.PSUBD)  { ret 0xFA; }
+    if (op == x64.PSUBQ)  { ret 0xFB; }
+    if (op == x64.PSUBUSB) { ret 0xD8; }
+    if (op == x64.PSUBUSW) { ret 0xD9; }
+    if (op == x64.PMULLW) { ret 0xD5; }
+    if (op == x64.PAND)   { ret 0xDB; }
+    if (op == x64.POR)    { ret 0xEB; }
+    if (op == x64.PXOR)   { ret 0xEF; }
+    if (op == x64.CMPPS || op == x64.CMPPD) { ret 0xC2; }
+    if (op == x64.PCMPEQB) { ret 0x74; }
+    if (op == x64.PCMPEQW) { ret 0x75; }
+    if (op == x64.PCMPEQD) { ret 0x76; }
+    if (op == x64.PCMPGTB) { ret 0x64; }
+    if (op == x64.PCMPGTW) { ret 0x65; }
+    if (op == x64.PCMPGTD) { ret 0x66; }
+    if (op == x64.PSHUFD) { ret 0x70; }
+    if (op == x64.PSLLD)  { ret 0x72; }
+    panic("encode: unknown packed SSE2 opcode\n");
+    ret 0;
+}
+
+# a 16-byte XMM register operand for the packed helpers
+fun vec_reg(xmm: i32) isa.Operand {
+    ret isa.make_reg(xmm, 16);
+}
+
+# emit a two-operand packed op `<op> dst_xmm, src` where `src` is an XMM register or a
+# 16-byte-aligned memory operand: `[66] [REX] 0F <byte> /r`. all packed vector operands
+# are register- or 16-aligned-slot-resident, so the aligned memory form is safe
+fun emit_packed_op(op: u16, dst_xmm: i32, src: isa.Operand, buf: *enc.ByteBuf) {
+    if (packed_prefix66(op)) { enc.emit_byte(buf, 0x66); }
+    if (src.kind == isa.OPK_REG) {
+        emit_rex_if_needed(buf, 0, dst_xmm, src.reg);
+        enc.emit_byte(buf, 0x0F);
+        enc.emit_byte(buf, packed_opbyte(op));
+        enc.emit_byte(buf, encode_modrm(3, reg_bits(dst_xmm), reg_bits(src.reg)));
+        ret;
+    }
+    if (src.kind == isa.OPK_MEM) {
+        emit_rex_mem(buf, 0, dst_xmm, ?src);
+        enc.emit_byte(buf, 0x0F);
+        enc.emit_byte(buf, packed_opbyte(op));
+        encode_mem_operand(buf, dst_xmm, ?src);
+        ret;
+    }
+    panic("encode: packed vector op source is not a register or aligned frame slot\n");
+}
+
+# emit a packed reg-reg op with an imm8 (`[66] [REX] 0F <byte> /r ib`): CMPPS/PD and PSHUFD
+fun emit_packed_rri(op: u16, dst_xmm: i32, src_xmm: i32, imm: u8, buf: *enc.ByteBuf) {
+    if (packed_prefix66(op)) { enc.emit_byte(buf, 0x66); }
+    emit_rex_if_needed(buf, 0, dst_xmm, src_xmm);
+    enc.emit_byte(buf, 0x0F);
+    enc.emit_byte(buf, packed_opbyte(op));
+    enc.emit_byte(buf, encode_modrm(3, reg_bits(dst_xmm), reg_bits(src_xmm)));
+    enc.emit_byte(buf, imm);
+}
+
+# emit a packed shift-by-imm8 `<op> xmm, imm8` (group form `66 [REX] 0F <byte> /6 ib`);
+# the shifted register is the r/m operand, /6 the opcode extension in the reg field
+fun emit_packed_shift_imm(op: u16, xmm: i32, imm: u8, buf: *enc.ByteBuf) {
+    enc.emit_byte(buf, 0x66);
+    if (needs_rex(xmm)) { enc.emit_byte(buf, encode_rex(0, 0, xmm)); }
+    enc.emit_byte(buf, 0x0F);
+    enc.emit_byte(buf, packed_opbyte(op));
+    enc.emit_byte(buf, encode_modrm(3, 6, reg_bits(xmm)));
+    enc.emit_byte(buf, imm);
+}
+
+# emit a register-register MOVAPS (`0F 28 /r`) copying one 128-bit XMM to another
+fun emit_movaps_rr(dst_xmm: i32, src_xmm: i32, buf: *enc.ByteBuf) {
+    emit_rex_if_needed(buf, 0, dst_xmm, src_xmm);
+    enc.emit_byte(buf, 0x0F);
+    enc.emit_byte(buf, 0x28);
+    enc.emit_byte(buf, encode_modrm(3, reg_bits(dst_xmm), reg_bits(src_xmm)));
+}
+
+# emit an unaligned 128-bit load `MOVUPS xmm, [mem]` (`0F 10 /r`)
+fun emit_movups_load(xmm: i32, mem: isa.Operand, buf: *enc.ByteBuf) {
+    emit_rex_mem(buf, 0, xmm, ?mem);
+    enc.emit_byte(buf, 0x0F);
+    enc.emit_byte(buf, 0x10);
+    encode_mem_operand(buf, xmm, ?mem);
+}
+
+# emit an unaligned 128-bit store `MOVUPS [mem], xmm` (`0F 11 /r`)
+fun emit_movups_store(mem: isa.Operand, xmm: i32, buf: *enc.ByteBuf) {
+    emit_rex_mem(buf, 0, xmm, ?mem);
+    enc.emit_byte(buf, 0x0F);
+    enc.emit_byte(buf, 0x11);
+    encode_mem_operand(buf, xmm, ?mem);
+}
+
+# load a 16-byte vector operand into the XMM scratch `xmm` via MOVAPS (from an XMM
+# register or a 16-byte-aligned frame slot). vector operands are always register- or
+# 16-aligned-spill-slot-resident, so MOVAPS is safe; an immediate never occurs
+fun emit_vec_load(op: isa.Operand, xmm: i32, buf: *enc.ByteBuf) R.Result[bool, str] {
+    if (op.kind == isa.OPK_REG) { emit_movaps_rr(xmm, op.reg, buf); ret R.ok[bool, str](true); }
+    if (op.kind == isa.OPK_MEM) {
+        var ld: isa.Inst;
+        zero_inst(?ld);
+        ld.opcode = x64.MOVAPS;
+        ld.dst    = isa.make_reg(xmm, 16);
+        ld.src1   = op;
+        ld.size   = 16;
+        encode_inst(?ld, buf);
+        ret R.ok[bool, str](true);
+    }
+    ret R.err[bool, str]("encode: vector operand is not a register or aligned frame slot");
+}
+
+# store the XMM scratch `xmm` to a 16-byte vector destination via MOVAPS (an XMM
+# register or a 16-byte-aligned frame slot)
+fun emit_vec_store(dst: isa.Operand, xmm: i32, buf: *enc.ByteBuf) R.Result[bool, str] {
+    if (dst.kind == isa.OPK_REG) { emit_movaps_rr(dst.reg, xmm, buf); ret R.ok[bool, str](true); }
+    if (dst.kind == isa.OPK_MEM) {
+        var st: isa.Inst;
+        zero_inst(?st);
+        st.opcode = x64.MOVAPS;
+        st.dst    = dst;
+        st.src1   = isa.make_reg(xmm, 16);
+        st.size   = 16;
+        encode_inst(?st, buf);
+        ret R.ok[bool, str](true);
+    }
+    ret R.err[bool, str]("encode: vector destination is not a register or aligned frame slot");
+}
+
+# set every bit of `xmm` (`PCMPEQD xmm, xmm`) - the all-ones mask for a bitwise NOT
+fun emit_vec_all_ones(xmm: i32, buf: *enc.ByteBuf) {
+    emit_packed_op(x64.PCMPEQD, xmm, vec_reg(xmm), buf);
+}
+
+# clear `xmm` (`PXOR xmm, xmm`)
+fun emit_vec_zero(xmm: i32, buf: *enc.ByteBuf) {
+    emit_packed_op(x64.PXOR, xmm, vec_reg(xmm), buf);
+}
+
+# whether a post-isel opcode is a vector-ALU candidate the packed encoders own: the
+# high-space MIR_SEL_* arithmetic / bitwise / shift / compare forms (a scalar op carries
+# vec_lane=NONE, so the encode-site vec_lane guard keeps this to real vector ops), plus
+# the surviving MIR_NOT (a scalar NOT expands, so a surviving MIR_NOT is always vector).
+# a vector load / store / move keeps a concrete move opcode and is NOT a candidate (#2014)
+fun is_selected_vector_alu(o: mir.MirOpcode) bool {
+    if (o == mir.MIR_NOT) { ret true; }
+    if (o == mir.MIR_SEL_ADD || o == mir.MIR_SEL_SUB || o == mir.MIR_SEL_MUL) { ret true; }
+    if (o == mir.MIR_SEL_DIV_S || o == mir.MIR_SEL_DIV_U ||
+        o == mir.MIR_SEL_REM_S || o == mir.MIR_SEL_REM_U) { ret true; }
+    if (o == mir.MIR_SEL_AND || o == mir.MIR_SEL_OR || o == mir.MIR_SEL_XOR) { ret true; }
+    if (o == mir.MIR_SEL_SHL || o == mir.MIR_SEL_SHR_S || o == mir.MIR_SEL_SHR_U) { ret true; }
+    if (o == mir.MIR_SEL_CMP_EQ || o == mir.MIR_SEL_CMP_NE ||
+        o == mir.MIR_SEL_CMP_LT_S || o == mir.MIR_SEL_CMP_LT_U ||
+        o == mir.MIR_SEL_CMP_LE_S || o == mir.MIR_SEL_CMP_LE_U) { ret true; }
+    ret false;
+}
+
+# dispatch a vector-typed selected op to its packed SSE2 encoder by opcode: the MIR_SEL_*
+# arithmetic / bitwise family, the surviving MIR_NOT (unary `~`), and the MIR_SEL_* compare
+# family. a vector shift / remainder (rejected at sema #2030, so unreachable) is the defined
+# loud backstop rather than a silent integer fall-through (#2014)
+fun encode_vector_op(f: *mir.MirFunction, mi: *mir.MirInstr, buf: *enc.ByteBuf) R.Result[bool, str] {
+    val o: mir.MirOpcode = mi.opcode;
+    if (o == mir.MIR_NOT) { ret encode_vector_not(f, mi, buf); }
+    if (o == mir.MIR_SEL_CMP_EQ || o == mir.MIR_SEL_CMP_NE ||
+        o == mir.MIR_SEL_CMP_LT_S || o == mir.MIR_SEL_CMP_LT_U ||
+        o == mir.MIR_SEL_CMP_LE_S || o == mir.MIR_SEL_CMP_LE_U) { ret encode_vector_compare(f, mi, buf); }
+    if (o == mir.MIR_SEL_ADD || o == mir.MIR_SEL_SUB || o == mir.MIR_SEL_MUL ||
+        o == mir.MIR_SEL_DIV_S || o == mir.MIR_SEL_DIV_U ||
+        o == mir.MIR_SEL_AND || o == mir.MIR_SEL_OR || o == mir.MIR_SEL_XOR) { ret encode_vector_arith(f, mi, buf); }
+    ret R.err[bool, str]("encode: unsupported vector operation on x86_64 (no packed SSE2 selection)");
+}
+
+# the concrete packed arithmetic / bitwise opcode for a vector-typed selected MIR op at a
+# vec_lane descriptor (element kind + byte width), or 0xFFFF for a combination sema does
+# not admit (an unresolvable pair is a lowering bug)
+fun packed_arith_opcode(op: mir.MirOpcode, vec_lane: u8) u16 {
+    val is_float: bool = mir.vec_lane_kind(vec_lane) == mir.VEC_LANE_FLOAT;
+    val eb:       u8   = mir.vec_lane_elem_bytes(vec_lane);
+    if (op == mir.MIR_SEL_AND) { ret x64.PAND; }
+    if (op == mir.MIR_SEL_OR)  { ret x64.POR; }
+    if (op == mir.MIR_SEL_XOR) { ret x64.PXOR; }
+    if (op == mir.MIR_SEL_ADD) {
+        if (is_float) { if (eb == 4) { ret x64.ADDPS; } ret x64.ADDPD; }
+        if (eb == 1) { ret x64.PADDB; }
+        if (eb == 2) { ret x64.PADDW; }
+        if (eb == 4) { ret x64.PADDD; }
+        ret x64.PADDQ;
+    }
+    if (op == mir.MIR_SEL_SUB) {
+        if (is_float) { if (eb == 4) { ret x64.SUBPS; } ret x64.SUBPD; }
+        if (eb == 1) { ret x64.PSUBB; }
+        if (eb == 2) { ret x64.PSUBW; }
+        if (eb == 4) { ret x64.PSUBD; }
+        ret x64.PSUBQ;
+    }
+    if (op == mir.MIR_SEL_MUL) {
+        if (is_float) { if (eb == 4) { ret x64.MULPS; } ret x64.MULPD; }
+        if (eb == 2) { ret x64.PMULLW; }
+    }
+    if (op == mir.MIR_SEL_DIV_U || op == mir.MIR_SEL_DIV_S) {
+        if (is_float) { if (eb == 4) { ret x64.DIVPS; } ret x64.DIVPD; }
+    }
+    ret 0xFFFF;
+}
+
+# materialize a vector-typed packed arithmetic / bitwise op `[dst, lhs, rhs]` into its
+# SSE2 byte sequence: load `lhs` -> FLOAT_SCRATCH0, then the packed op reads `rhs`
+# directly (register or aligned slot), and the result stores back from FLOAT_SCRATCH0.
+# mirrors `encode_float_arith`; the lane shape rides on `mi.vec_lane`
+fun encode_vector_arith(f: *mir.MirFunction, mi: *mir.MirInstr, buf: *enc.ByteBuf) R.Result[bool, str] {
+    if (mi.operand_count < 3) { ret R.err[bool, str]("encode: packed vector op missing operands"); }
+    val rd: R.Result[isa.Operand, str] = mir_to_operand(f, ?mi.operands[0], 16);
+    if (R.is_err[isa.Operand, str](rd)) { ret R.err[bool, str](R.unwrap_err[isa.Operand, str](rd)); }
+    val rl: R.Result[isa.Operand, str] = mir_to_operand(f, ?mi.operands[1], 16);
+    if (R.is_err[isa.Operand, str](rl)) { ret R.err[bool, str](R.unwrap_err[isa.Operand, str](rl)); }
+    val rr: R.Result[isa.Operand, str] = mir_to_operand(f, ?mi.operands[2], 16);
+    if (R.is_err[isa.Operand, str](rr)) { ret R.err[bool, str](R.unwrap_err[isa.Operand, str](rr)); }
+    val dst: isa.Operand = R.unwrap_ok[isa.Operand, str](rd);
+    val lhs: isa.Operand = R.unwrap_ok[isa.Operand, str](rl);
+    val rhs: isa.Operand = R.unwrap_ok[isa.Operand, str](rr);
+
+    val opc: u16 = packed_arith_opcode(mi.opcode, mi.vec_lane);
+    if (opc == 0xFFFF) { ret R.err[bool, str]("encode: unsupported packed vector op / lane combination"); }
+
+    val ll: R.Result[bool, str] = emit_vec_load(lhs, FLOAT_SCRATCH0, buf);
+    if (R.is_err[bool, str](ll)) { ret ll; }
+    emit_packed_op(opc, FLOAT_SCRATCH0, rhs, buf);
+    ret emit_vec_store(dst, FLOAT_SCRATCH0, buf);
+}
+
+# materialize a vector-typed bitwise complement `MIR_NOT [dst, src]` (unary `~`): load
+# `src` -> FLOAT_SCRATCH0, XOR against an all-ones mask in FLOAT_SCRATCH1, store back
+fun encode_vector_not(f: *mir.MirFunction, mi: *mir.MirInstr, buf: *enc.ByteBuf) R.Result[bool, str] {
+    if (mi.operand_count < 2) { ret R.err[bool, str]("encode: packed vector not missing operands"); }
+    val rd: R.Result[isa.Operand, str] = mir_to_operand(f, ?mi.operands[0], 16);
+    if (R.is_err[isa.Operand, str](rd)) { ret R.err[bool, str](R.unwrap_err[isa.Operand, str](rd)); }
+    val rs: R.Result[isa.Operand, str] = mir_to_operand(f, ?mi.operands[1], 16);
+    if (R.is_err[isa.Operand, str](rs)) { ret R.err[bool, str](R.unwrap_err[isa.Operand, str](rs)); }
+    val dst: isa.Operand = R.unwrap_ok[isa.Operand, str](rd);
+    val src: isa.Operand = R.unwrap_ok[isa.Operand, str](rs);
+
+    val ll: R.Result[bool, str] = emit_vec_load(src, FLOAT_SCRATCH0, buf);
+    if (R.is_err[bool, str](ll)) { ret ll; }
+    emit_vec_all_ones(FLOAT_SCRATCH1, buf);
+    emit_packed_op(x64.PXOR, FLOAT_SCRATCH0, vec_reg(FLOAT_SCRATCH1), buf);
+    ret emit_vec_store(dst, FLOAT_SCRATCH0, buf);
+}
+
+# the PCMPEQ{B,W,D} opcode for an integer lane byte width
+fun pcmpeq_op(w: u8) u16 {
+    if (w == 1) { ret x64.PCMPEQB; }
+    if (w == 2) { ret x64.PCMPEQW; }
+    ret x64.PCMPEQD;
+}
+
+# the PCMPGT{B,W,D} opcode for an integer lane byte width
+fun pcmpgt_op(w: u8) u16 {
+    if (w == 1) { ret x64.PCMPGTB; }
+    if (w == 2) { ret x64.PCMPGTW; }
+    ret x64.PCMPGTD;
+}
+
+# leave the integer-lane equality mask (`lhs == rhs`) in FLOAT_SCRATCH0. 8/16/32-bit
+# lanes use one PCMPEQ; 64-bit lanes compose PCMPEQD + PSHUFD(0xB1) + PAND (PCMPEQQ is
+# SSE4.1, out of baseline) so each 64-bit lane is all-ones only when both halves match
+fun emit_vcmp_eq_s0(lhs: isa.Operand, rhs: isa.Operand, w: u8, buf: *enc.ByteBuf) R.Result[bool, str] {
+    val ll: R.Result[bool, str] = emit_vec_load(lhs, FLOAT_SCRATCH0, buf);
+    if (R.is_err[bool, str](ll)) { ret ll; }
+    if (w == 8) {
+        emit_packed_op(x64.PCMPEQD, FLOAT_SCRATCH0, rhs, buf);
+        emit_packed_rri(x64.PSHUFD, FLOAT_SCRATCH1, FLOAT_SCRATCH0, 0xB1, buf);
+        emit_packed_op(x64.PAND, FLOAT_SCRATCH0, vec_reg(FLOAT_SCRATCH1), buf);
+        ret R.ok[bool, str](true);
+    }
+    emit_packed_op(pcmpeq_op(w), FLOAT_SCRATCH0, rhs, buf);
+    ret R.ok[bool, str](true);
+}
+
+# the SETcc opcode realizing a 64-bit-lane ordering compare (LT/LE, signed/unsigned)
+fun i64_ordering_setcc(op: mir.MirOpcode) u16 {
+    if (op == mir.MIR_SEL_CMP_LT_S) { ret x64.SETL; }
+    if (op == mir.MIR_SEL_CMP_LE_S) { ret x64.SETLE; }
+    if (op == mir.MIR_SEL_CMP_LT_U) { ret x64.SETB; }
+    ret x64.SETBE;
+}
+
+# materialize a 64-bit-lane ordering compare as a fixed, branch-free per-lane scalar
+# sequence: spill both operands into the call-free 128-byte red zone, compare each
+# 64-bit lane in GP registers (CMP + SETcc), broadcast the 0/-1 mask back, and reload
+# the assembled result. PCMPGTQ is SSE4.2 and the packed 32-bit-half compose is
+# register-hungry, so this two-lane unrolled form is the defined baseline
+fun encode_vcmp_i64_ordering(dst: isa.Operand, lhs: isa.Operand, rhs: isa.Operand, op: mir.MirOpcode, buf: *enc.ByteBuf) R.Result[bool, str] {
+    val setcc: u16 = i64_ordering_setcc(op);
+    val lhs_slot: isa.Operand = isa.make_mem(x64.RSP, -16, -1, 0, 16);
+    val rhs_slot: isa.Operand = isa.make_mem(x64.RSP, -32, -1, 0, 16);
+    val res_slot: isa.Operand = isa.make_mem(x64.RSP, -48, -1, 0, 16);
+
+    val l0: R.Result[bool, str] = emit_vec_load(lhs, FLOAT_SCRATCH0, buf);
+    if (R.is_err[bool, str](l0)) { ret l0; }
+    val l1: R.Result[bool, str] = emit_vec_load(rhs, FLOAT_SCRATCH1, buf);
+    if (R.is_err[bool, str](l1)) { ret l1; }
+    emit_movups_store(lhs_slot, FLOAT_SCRATCH0, buf);
+    emit_movups_store(rhs_slot, FLOAT_SCRATCH1, buf);
+
+    var lane: i32 = 0;
+    for (lane < 2) {
+        val off: i32 = lane * 8;
+        # MOV R10, [rsp-16+off]  ;  MOV R11, [rsp-32+off]
+        emit_gp_inst(x64.MOV, isa.make_reg(x64.R10, 8), isa.make_mem(x64.RSP, -16 + off, -1, 0, 8), 8, x64.FLAG_REX_W, buf);
+        emit_gp_inst(x64.MOV, isa.make_reg(x64.R11, 8), isa.make_mem(x64.RSP, -32 + off, -1, 0, 8), 8, x64.FLAG_REX_W, buf);
+        # CMP R10, R11  (flags for lhs - rhs)
+        emit_gp_inst(x64.CMP, isa.make_reg(x64.R10, 8), isa.make_reg(x64.R11, 8), 8, x64.FLAG_REX_W, buf);
+        # SETcc R10b
+        var setb: isa.Inst;
+        zero_inst(?setb);
+        setb.opcode   = setcc;
+        setb.dst      = isa.make_reg(x64.R10, 1);
+        setb.dst.size = 1;
+        setb.size     = 1;
+        encode_inst(?setb, buf);
+        # MOVZX R10, R10b  (0/1)  then NEG R10  (0/-1)
+        var mz: isa.Inst;
+        zero_inst(?mz);
+        mz.opcode    = x64.MOVZX;
+        mz.dst       = isa.make_reg(x64.R10, 8);
+        mz.dst.size  = DEFAULT_OPERAND_SIZE;
+        mz.src1      = isa.make_reg(x64.R10, 1);
+        mz.src1.size = 1;
+        mz.size      = DEFAULT_OPERAND_SIZE;
+        mz.flags     = x64.FLAG_REX_W;
+        encode_inst(?mz, buf);
+        emit_gp_inst(x64.NEG, isa.make_reg(x64.R10, 8), isa.make_reg(x64.R10, 8), 8, x64.FLAG_REX_W, buf);
+        # MOV [rsp-48+off], R10
+        emit_gp_inst(x64.MOV, isa.make_mem(x64.RSP, -48 + off, -1, 0, 8), isa.make_reg(x64.R10, 8), 8, x64.FLAG_REX_W, buf);
+        lane = lane + 1;
+    }
+
+    emit_movups_load(FLOAT_SCRATCH0, res_slot, buf);
+    ret emit_vec_store(dst, FLOAT_SCRATCH0, buf);
+}
+
+# build a simple GP instruction `<opcode> dst, src` at `size` bytes and emit it
+fun emit_gp_inst(opcode: u16, dst: isa.Operand, src: isa.Operand, size: u8, flags: u16, buf: *enc.ByteBuf) {
+    var mi: isa.Inst;
+    zero_inst(?mi);
+    mi.opcode = opcode;
+    mi.dst    = dst;
+    mi.src1   = src;
+    mi.size   = size;
+    mi.flags  = flags;
+    encode_inst(?mi, buf);
+}
+
+# materialize a vector-typed compare `MIR_CMP_* [dst, lhs, rhs]` into the same-shape
+# mask. float lanes use CMPPS/PD (imm8 predicate); integer lanes use the PCMPEQ / PCMPGT
+# family plus the fixed defined sequences where SSE2 has no single form (integer !=,
+# <= / >=, unsigned orderings, and all 64-bit-lane orderings). the lane shape rides on
+# `mi.vec_lane` (the OPERAND's shape); signedness comes from the compare opcode
+fun encode_vector_compare(f: *mir.MirFunction, mi: *mir.MirInstr, buf: *enc.ByteBuf) R.Result[bool, str] {
+    if (mi.operand_count < 3) { ret R.err[bool, str]("encode: packed compare missing operands"); }
+    val rd: R.Result[isa.Operand, str] = mir_to_operand(f, ?mi.operands[0], 16);
+    if (R.is_err[isa.Operand, str](rd)) { ret R.err[bool, str](R.unwrap_err[isa.Operand, str](rd)); }
+    val rl: R.Result[isa.Operand, str] = mir_to_operand(f, ?mi.operands[1], 16);
+    if (R.is_err[isa.Operand, str](rl)) { ret R.err[bool, str](R.unwrap_err[isa.Operand, str](rl)); }
+    val rr: R.Result[isa.Operand, str] = mir_to_operand(f, ?mi.operands[2], 16);
+    if (R.is_err[isa.Operand, str](rr)) { ret R.err[bool, str](R.unwrap_err[isa.Operand, str](rr)); }
+    val dst: isa.Operand = R.unwrap_ok[isa.Operand, str](rd);
+    val lhs: isa.Operand = R.unwrap_ok[isa.Operand, str](rl);
+    val rhs: isa.Operand = R.unwrap_ok[isa.Operand, str](rr);
+    val op:   mir.MirOpcode = mi.opcode;
+    val w:    u8 = mir.vec_lane_elem_bytes(mi.vec_lane);
+
+    # float lanes: CMPPS/PD with an imm8 predicate (EQ 0, LT 1, LE 2, NEQ 4).
+    if (mir.vec_lane_kind(mi.vec_lane) == mir.VEC_LANE_FLOAT) {
+        var cmpop: u16 = x64.CMPPD;
+        if (w == 4) { cmpop = x64.CMPPS; }
+        var imm: u8 = 0;
+        if (op == mir.MIR_SEL_CMP_NE) { imm = 4; }
+        or (op == mir.MIR_SEL_CMP_LT_S || op == mir.MIR_SEL_CMP_LT_U) { imm = 1; }
+        or (op == mir.MIR_SEL_CMP_LE_S || op == mir.MIR_SEL_CMP_LE_U) { imm = 2; }
+        val fl: R.Result[bool, str] = emit_vec_load(lhs, FLOAT_SCRATCH0, buf);
+        if (R.is_err[bool, str](fl)) { ret fl; }
+        val fr: R.Result[bool, str] = emit_vec_load(rhs, FLOAT_SCRATCH1, buf);
+        if (R.is_err[bool, str](fr)) { ret fr; }
+        emit_packed_rri(cmpop, FLOAT_SCRATCH0, FLOAT_SCRATCH1, imm, buf);
+        ret emit_vec_store(dst, FLOAT_SCRATCH0, buf);
+    }
+
+    if (op == mir.MIR_SEL_CMP_EQ) {
+        val re: R.Result[bool, str] = emit_vcmp_eq_s0(lhs, rhs, w, buf);
+        if (R.is_err[bool, str](re)) { ret re; }
+        ret emit_vec_store(dst, FLOAT_SCRATCH0, buf);
+    }
+    if (op == mir.MIR_SEL_CMP_NE) {
+        val re: R.Result[bool, str] = emit_vcmp_eq_s0(lhs, rhs, w, buf);
+        if (R.is_err[bool, str](re)) { ret re; }
+        emit_vec_all_ones(FLOAT_SCRATCH1, buf);
+        emit_packed_op(x64.PXOR, FLOAT_SCRATCH0, vec_reg(FLOAT_SCRATCH1), buf);
+        ret emit_vec_store(dst, FLOAT_SCRATCH0, buf);
+    }
+
+    # 64-bit-lane orderings: fixed per-lane scalar sequence.
+    if (w == 8) { ret encode_vcmp_i64_ordering(dst, lhs, rhs, op, buf); }
+
+    if (op == mir.MIR_SEL_CMP_LT_S) {
+        # lhs < rhs (signed) = rhs > lhs = PCMPGT(rhs, lhs).
+        val ld: R.Result[bool, str] = emit_vec_load(rhs, FLOAT_SCRATCH0, buf);
+        if (R.is_err[bool, str](ld)) { ret ld; }
+        emit_packed_op(pcmpgt_op(w), FLOAT_SCRATCH0, lhs, buf);
+        ret emit_vec_store(dst, FLOAT_SCRATCH0, buf);
+    }
+    if (op == mir.MIR_SEL_CMP_LE_S) {
+        # lhs <= rhs (signed) = !(lhs > rhs).
+        val ld: R.Result[bool, str] = emit_vec_load(lhs, FLOAT_SCRATCH0, buf);
+        if (R.is_err[bool, str](ld)) { ret ld; }
+        emit_packed_op(pcmpgt_op(w), FLOAT_SCRATCH0, rhs, buf);
+        emit_vec_all_ones(FLOAT_SCRATCH1, buf);
+        emit_packed_op(x64.PXOR, FLOAT_SCRATCH0, vec_reg(FLOAT_SCRATCH1), buf);
+        ret emit_vec_store(dst, FLOAT_SCRATCH0, buf);
+    }
+    if (op == mir.MIR_SEL_CMP_LT_U) {
+        if (w == 4) {
+            # dword sign-bias then signed PCMPGTD: lhs <u rhs = biased_rhs >s biased_lhs.
+            emit_vec_all_ones(FLOAT_SCRATCH1, buf);
+            emit_packed_shift_imm(x64.PSLLD, FLOAT_SCRATCH1, 31, buf);
+            val ld: R.Result[bool, str] = emit_vec_load(lhs, FLOAT_SCRATCH0, buf);
+            if (R.is_err[bool, str](ld)) { ret ld; }
+            emit_packed_op(x64.PXOR, FLOAT_SCRATCH0, vec_reg(FLOAT_SCRATCH1), buf);
+            emit_packed_op(x64.PXOR, FLOAT_SCRATCH1, rhs, buf);
+            emit_packed_op(x64.PCMPGTD, FLOAT_SCRATCH1, vec_reg(FLOAT_SCRATCH0), buf);
+            ret emit_vec_store(dst, FLOAT_SCRATCH1, buf);
+        }
+        # byte/word: lhs <u rhs = subus(rhs, lhs) != 0.
+        val ld: R.Result[bool, str] = emit_vec_load(rhs, FLOAT_SCRATCH0, buf);
+        if (R.is_err[bool, str](ld)) { ret ld; }
+        var subus: u16 = x64.PSUBUSW;
+        if (w == 1) { subus = x64.PSUBUSB; }
+        emit_packed_op(subus, FLOAT_SCRATCH0, lhs, buf);
+        emit_vec_zero(FLOAT_SCRATCH1, buf);
+        emit_packed_op(pcmpeq_op(w), FLOAT_SCRATCH0, vec_reg(FLOAT_SCRATCH1), buf);
+        emit_vec_all_ones(FLOAT_SCRATCH1, buf);
+        emit_packed_op(x64.PXOR, FLOAT_SCRATCH0, vec_reg(FLOAT_SCRATCH1), buf);
+        ret emit_vec_store(dst, FLOAT_SCRATCH0, buf);
+    }
+    # MIR_CMP_LE_U
+    if (w == 4) {
+        # dword: lhs <=u rhs = !(lhs >u rhs) = !(biased_lhs >s biased_rhs).
+        emit_vec_all_ones(FLOAT_SCRATCH1, buf);
+        emit_packed_shift_imm(x64.PSLLD, FLOAT_SCRATCH1, 31, buf);
+        val ld: R.Result[bool, str] = emit_vec_load(lhs, FLOAT_SCRATCH0, buf);
+        if (R.is_err[bool, str](ld)) { ret ld; }
+        emit_packed_op(x64.PXOR, FLOAT_SCRATCH0, vec_reg(FLOAT_SCRATCH1), buf);
+        emit_packed_op(x64.PXOR, FLOAT_SCRATCH1, rhs, buf);
+        emit_packed_op(x64.PCMPGTD, FLOAT_SCRATCH0, vec_reg(FLOAT_SCRATCH1), buf);
+        emit_vec_all_ones(FLOAT_SCRATCH1, buf);
+        emit_packed_op(x64.PXOR, FLOAT_SCRATCH0, vec_reg(FLOAT_SCRATCH1), buf);
+        ret emit_vec_store(dst, FLOAT_SCRATCH0, buf);
+    }
+    # byte/word: lhs <=u rhs = subus(lhs, rhs) == 0.
+    val ld: R.Result[bool, str] = emit_vec_load(lhs, FLOAT_SCRATCH0, buf);
+    if (R.is_err[bool, str](ld)) { ret ld; }
+    var subus2: u16 = x64.PSUBUSW;
+    if (w == 1) { subus2 = x64.PSUBUSB; }
+    emit_packed_op(subus2, FLOAT_SCRATCH0, rhs, buf);
+    emit_vec_zero(FLOAT_SCRATCH1, buf);
+    emit_packed_op(pcmpeq_op(w), FLOAT_SCRATCH0, vec_reg(FLOAT_SCRATCH1), buf);
+    ret emit_vec_store(dst, FLOAT_SCRATCH0, buf);
 }
 
 # true when a post-isel opcode is a surviving generic integer
@@ -5725,5 +6256,52 @@ test "mach.lang.target.isa.x64.encode.x86_reloc_offset:legalized_disp32" {
     or (x86_reloc_offset(nil, ?small, small_sz) != 3) { bad = 1; }
 
     enc.buf_dnit(?st.buf);
+    ret bad;
+}
+
+# FLOAT_SCRATCH0 (XMM14) must encode with ModRM reg field 6 + REX.R in the packed move
+# helpers; a mis-encode would stage a vector memory-to-memory spill through a live XMM
+# register instead of the reserved scratch (#2014 regression guard)
+test "mach.lang.target.isa.x64.encode.vec:scratch_reg_encoding" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+    var buf: enc.ByteBuf = enc.buf_init(?alloc);
+    val mem: isa.Operand = isa.make_mem(x64.RAX, 0, -1, 0, 16);
+    emit_movups_load(FLOAT_SCRATCH0, mem, ?buf);
+    var bad: i32 = 0;
+    if (buf.len < 4)          { bad = 1; }
+    or (buf.data[0] != 0x44)  { bad = 1; }
+    or (buf.data[1] != 0x0F)  { bad = 1; }
+    or (buf.data[2] != 0x10)  { bad = 1; }
+    or (buf.data[3] != 0x30)  { bad = 1; }
+    enc.buf_dnit(?buf);
+    ret bad;
+}
+
+# a 16-byte mem-mem MOV routed through the full encode_inst split must stage
+# through XMM14 (44 0F 10 30), not the GP R11 whose id aliases live XMM11
+# (44 0F 10 18) at size 16 (#2034). exercises the dispatch, not the callee.
+test "mach.lang.target.isa.x64.encode.vec:mem_mem_16_stages_xmm14" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+    var buf: enc.ByteBuf = enc.buf_init(?alloc);
+    var inst: isa.Inst;
+    inst.opcode   = x64.MOV;
+    inst.size     = 16;
+    inst.dst      = isa.make_mem(x64.RBP, -384, -1, 0, 16);
+    inst.src1     = isa.make_mem(x64.RAX, 0, -1, 0, 16);
+    inst.src2.kind = 0;
+    inst.flags    = 0;
+    inst.clobbers = 0;
+    inst.src_line = 0;
+    inst.src_file = nil;
+    encode_inst(?inst, ?buf);
+    var bad: i32 = 0;
+    if (buf.len < 4)          { bad = 1; }
+    or (buf.data[0] != 0x44)  { bad = 1; }
+    or (buf.data[1] != 0x0F)  { bad = 1; }
+    or (buf.data[2] != 0x10)  { bad = 1; }
+    or (buf.data[3] != 0x30)  { bad = 1; }
+    enc.buf_dnit(?buf);
     ret bad;
 }

--- a/src/lang/target/isa/x64/isel.mach
+++ b/src/lang/target/isa/x64/isel.mach
@@ -246,6 +246,12 @@ fun select_block(a: *A.Allocator, b: *mir.MirBlock) R.Result[bool, str] {
 # ret: the number of concrete instructions `mi` selects to
 fun expansion_count(mi: *mir.MirInstr) u32 {
     val o: mir.MirOpcode = mi.opcode;
+    # a vector-typed bitwise complement survives as a single instruction rather than the
+    # scalar two-instruction NOT expansion; the encoder materializes the packed PXOR-with-
+    # all-ones form. every other vector ALU / compare op rides the normal rewrite to its
+    # high-space MIR_SEL_* opcode (which carries vec_lane through), so the encoder can tell
+    # a packed op from a same-low-value concrete move by the high opcode space (#2014).
+    if (mir.vec_lane_is_vector(mi.vec_lane) && o == mir.MIR_NOT) { ret 1; }
     if (o == mir.MIR_NEG) { ret 2; }
     if (o == mir.MIR_NOT) { ret 2; }
     if (is_simple(o))     { ret 1; }
@@ -325,6 +331,12 @@ fun is_simple(o: mir.MirOpcode) bool {
 # ret: ok(true) on success, or an ICE for an unmodeled opcode
 fun rewrite_simple(mi: *mir.MirInstr) R.Result[bool, str] {
     val o: mir.MirOpcode = mi.opcode;
+
+    # a vector-typed bitwise complement keeps its MIR_NOT opcode through selection (it did
+    # not expand); the encoder reads vec_lane + MIR_NOT to materialize the packed PXOR-with-
+    # all-ones. every other vector ALU / compare op rewrites to its MIR_SEL_* form below,
+    # carrying vec_lane, so the encoder dispatches the packed form from the high opcode (#2014).
+    if (mir.vec_lane_is_vector(mi.vec_lane) && o == mir.MIR_NOT) { ret R.ok[bool, str](true); }
 
     if (o == mir.MIR_ADD) { mi.opcode = mir.MIR_SEL_ADD; ret R.ok[bool, str](true); }
     if (o == mir.MIR_SUB) { mi.opcode = mir.MIR_SEL_SUB; ret R.ok[bool, str](true); }


### PR DESCRIPTION
Implements the x86_64 tier-1 backend for the portable-vector model (epic #1965): SSE2 instruction selection for the honest op table and the SysV SSE-class ABI for the ten 128-bit vector types, on the merged `vec_lane` substrate (#2037). Rebased onto dev (169fe0d9) with NEON (#2032) and the vector-local memzero `[lanes]elem` storage (#2044) merged; the x86_64 arm joins the shared `arch_selects_vectors` seam. Vector shifts are excluded (rejected at sema by #2030).

Closes #2014.

## What's implemented
- Selection keyed on the shared `vec_lane` descriptor + the surviving generic / `MIR_SEL_*` opcode — no MIR vector opcode family. Lane-wise compute ops route through the generic path carrying `vec_lane`; the x64 isel / encoder select the packed form. `MIR_SEL_*` sit at 0x1100+, clear of the generic range and the concrete x64 opcodes (no aliasing).
- Packed encoders: float `+ − × ÷`, integer `+ −` (b/w/d/q), 16-bit `×` (PMULLW), bitwise `& | ^ ~`, and compare→mask for all six operators — including the branch-free fixed sequences SSE2 has no single form for: integer `!=`, `<=`/`>=`, unsigned orderings (sign-bias / unsigned-saturating-subtract), i64x2/u64x2 `==` (PCMPEQD+PSHUFD+PAND), and the 64-bit orderings (red-zone per-lane scalar compose).
- SysV SSE-class ABI: a vector arg in one XMM (or a 16-byte by-value stack slot), returned in XMM0; mixed scalar+vector signatures keep independent GP/XMM cursors (reuses the shared 16-byte ABI move width from #2032).
- Vector spill slots 16-byte aligned (MOVAPS reload); scalar GP/float spill layout byte-identical.
- The `encode_inst` mem-mem split stages 16-byte moves through the reserved XMM scratch, not GP R11 whose id aliases the live XMM11 at size 16 (#2034); win64 companion counts a width-16 MIR_MOV. Two encoder regression tests pin the callee and the dispatch-level staging.
- Lane access reads through the shared array-of-lanes gep (#2042/#2044); the x86_64-only gep-into-vector descent is dropped.

## Verification bars (fresh, on the rebased tree)

| bar | result |
|-----|--------|
| runtime lane-exactness, discriminating values (arith incl. u8 200+100→44 / u16 300×300→24464 cross-byte carries; all six compares × every shape incl. i64x2/u64x2, unsigned orderings, float) | ✓ 0-exit |
| high-pressure spill: 16 live vectors, balanced-tree AND standalone chain, i32x4 + f32x4, distinct lanes (#2034) | ✓ 0-exit |
| comptime-const lane read + write (array-of-lanes path) | ✓ |
| SysV ABI round-trips (vector args/returns, mixed signatures, XMM-exhausting) | ✓ |
| dispatch-level encoder regression (16-byte mem-mem MOV → XMM14 staging) | ✓ fails pre-fix, passes post-fix |
| self-host fixpoint (gen1 == gen2) | ✓ byte-identical |
| scalar byte-identity (HEAD vs dev baseline, same input) | ✓ identical, both profiles |
| -g additivity (HEAD -g output vs baseline) | ✓ identical, both profiles |
| llvm-dwarfdump --verify (-g build) | ✓ No errors |
| full unit suite via fresh HEAD | ✓ 602 / 602 (dev baseline 600 → +2 encoder regression tests) |
| int suite (linux) incl. surface/debuginfo | ✓ all cases passed |
| no new int/ fixtures or root test/ | ✓ |

Runtime lane-exactness is proven by external self-checking programs (0-exit) rather than in-tree colocated `test` blocks: the seed predates the #2013 vector types and type-checks test blocks, so f32x4-bearing colocated tests break the bootstrap until the planned v3.3.2 vector-aware re-seed. The colocated runtime per-op suite lands post-re-seed as #2038. In-tree seed-safe coverage: the `vector_isel_defined` never-ICE canary + lane-access pipeline tests (#2042) + the two encoder regression tests here.
