### PR TITLE
feat: rv64gc vector scalarization + build-time note (#2016)

### DIFF
--- a/src/cli/cmd/build.mach
+++ b/src/cli/cmd/build.mach
@@ -170,6 +170,51 @@ fun fqn_name(p: *driver.Project, fqn: intern.StrId) str {
 # images:      caller-owned ObjectImage array, filled in topo order
 # image_ready: per-module flag set true once `images[mid]` holds a built image
 # ret:         ok(true) on success, or err with the first failure message
+# emit the one-shot vector-scalarization note (#2016)
+#
+# Sums the vector operators the scalarize pass expanded across every module in the
+# build; when non-zero, reports the count on stderr in the `report_skipped` style
+# (lowercase `note:`, singular/plural on the count) exactly once. A build with no
+# scalarized vectors (a capable target, or vector-free source) emits nothing and is
+# byte-identical to a pre-change build. This is the shared detection seam the profile
+# lever (#2017) turns into a `require`-mode error.
+# ---
+# p: the project whose lowered modules carry the per-module tallies
+fun report_scalarization(p: *driver.Project) {
+    var total: u32 = 0;
+    var i: u32 = 0;
+    for (i < p.topo_len) {
+        val mid: session.ModuleId    = p.topo[i];
+        val m:   *driver.ModuleEntry = ?p.modules[mid::u32];
+        total = total + m.ir_module.vector_ops_scalarized;
+        i = i + 1;
+    }
+    if (total == 0) { ret; }
+
+    var buf: [16]u8;
+    write_count(?buf[0], 16, total);
+    print.eprint("note: scalarized ");
+    print.eprint(util.cstr_str(?buf[0]));
+    if (total == 1) { print.eprint(" vector operation (target has no SIMD; simd = \"scalarize\")\n"); }
+    or             { print.eprint(" vector operations (target has no SIMD; simd = \"scalarize\")\n"); }
+}
+
+# write the decimal text of `n` into `buf`, null-terminated
+# ---
+# buf: destination buffer
+# cap: buffer capacity (must hold the digits plus the terminator)
+# n:   the value to render
+fun write_count(buf: *u8, cap: usize, n: u32) {
+    var tmp: [16]u8;
+    var t:   usize = 0;
+    var v:   u32   = n;
+    if (v == 0) { tmp[0] = '0'; t = 1; }
+    for (v > 0) { tmp[t] = (v % 10)::u8 + '0'; v = v / 10; t = t + 1; }
+    var k: usize = 0;
+    for (k < t && k + 1 < cap) { buf[k] = tmp[t - 1 - k]; k = k + 1; }
+    buf[k] = 0;
+}
+
 fun compile_modules(p: *driver.Project, level: u8, test_mode: bool, verify_ir: bool, ea: *EmitArtifacts,
                     irs: *ir.Module, ir_ready: *bool,
                     images: *of.ObjectImage, image_ready: *bool) R.Result[bool, str] {
@@ -206,6 +251,11 @@ fun compile_modules(p: *driver.Project, level: u8, test_mode: bool, verify_ir: b
     if (R.is_err[bool, str](res_lower)) {
         ret R.err[bool, str](R.unwrap_err[bool, str](res_lower));
     }
+
+    # surface the one-shot scalarization note under the default `simd = "scalarize"`
+    # posture: on a SIMD-incapable target the middle-end expanded some vector
+    # operators to per-lane scalar sequences (#2016).
+    report_scalarization(p);
 
     var i: u32 = 0;
     for (i < p.topo_len) {

--- a/src/lang/be/codegen/mir/abi.mach
+++ b/src/lang/be/codegen/mir/abi.mach
@@ -674,13 +674,14 @@ pub fun sig_layout_free(ctx: *context.LowerCtx, layout: *abi.SigLayout) {
     }
 }
 
-# the declared return type for a call: the callee signature's return type when
-# `sig` is a known IRT_FN, otherwise the call instruction's own result type
+# the declared return type for a call: the callee signature's return type only when
+# it is a vector, otherwise the call instruction's own result type
 #
 # On a scalarized target a vector-returning call's `inst.ty` is a plain pointer (the
 # 16-byte result lives in memory), so the true vector return type must come from the
-# callee's IRT_FN to classify the sret correctly. For a direct call the two agree; an
-# indirect call through an untyped function pointer has no IRT_FN and uses `fallback`.
+# callee's IRT_FN to classify the sret correctly. Every non-vector call keeps
+# `fallback` (`inst.ty`) verbatim, so this is exactly inert on a capable target -- the
+# classification, and the emitted code, are byte-identical to before.
 # ---
 # ctx:      the active lowering context
 # sig:      the call's `aux_ty` (the callee IRT_FN, or an untyped pointer)
@@ -690,7 +691,9 @@ fun call_ret_type(ctx: *context.LowerCtx, sig: type.IrTypeId, fallback: type.IrT
     val opt: O.Option[*type.IrType] = type.get(ctx.types, sig);
     if (O.is_some[*type.IrType](opt)) {
         val st: *type.IrType = O.unwrap[*type.IrType](opt);
-        if (st.kind == type.IRT_FN) { ret st.data.fn.ret_type; }
+        if (st.kind == type.IRT_FN && context.value_is_vector(ctx, st.data.fn.ret_type)) {
+            ret st.data.fn.ret_type;
+        }
     }
     ret fallback;
 }

--- a/src/lang/be/codegen/mir/abi.mach
+++ b/src/lang/be/codegen/mir/abi.mach
@@ -674,6 +674,27 @@ pub fun sig_layout_free(ctx: *context.LowerCtx, layout: *abi.SigLayout) {
     }
 }
 
+# the declared return type for a call: the callee signature's return type when
+# `sig` is a known IRT_FN, otherwise the call instruction's own result type
+#
+# On a scalarized target a vector-returning call's `inst.ty` is a plain pointer (the
+# 16-byte result lives in memory), so the true vector return type must come from the
+# callee's IRT_FN to classify the sret correctly. For a direct call the two agree; an
+# indirect call through an untyped function pointer has no IRT_FN and uses `fallback`.
+# ---
+# ctx:      the active lowering context
+# sig:      the call's `aux_ty` (the callee IRT_FN, or an untyped pointer)
+# fallback: the call instruction's own result type
+# ret:      the return type to classify the call from
+fun call_ret_type(ctx: *context.LowerCtx, sig: type.IrTypeId, fallback: type.IrTypeId) type.IrTypeId {
+    val opt: O.Option[*type.IrType] = type.get(ctx.types, sig);
+    if (O.is_some[*type.IrType](opt)) {
+        val st: *type.IrType = O.unwrap[*type.IrType](opt);
+        if (st.kind == type.IRT_FN) { ret st.data.fn.ret_type; }
+    }
+    ret fallback;
+}
+
 # expand an OP_CALL into argument pre-coloring plus the call and result pseudos
 #
 # Classifies the callee's return value and each argument through the ABI vtable,
@@ -721,7 +742,13 @@ pub fun lower_call(ctx: *context.LowerCtx, mb: *mir.MirBlock, inst: *instruction
     # function pointer yields zero fixed params, so every argument falls back to
     # per-operand classification below.
     val sig: type.IrTypeId = inst.aux_ty;
-    val ret_type: type.IrTypeId = inst.ty;
+    # the declared return type comes from the callee signature when one is known,
+    # not `inst.ty`: on a scalarized target a vector-returning call's result type is
+    # rewritten to a plain pointer (its 16-byte result lives in memory), yet the
+    # return still classifies from the true vector type in the callee's IRT_FN. for a
+    # direct call the two agree; an indirect call through an untyped pointer has no
+    # IRT_FN and falls back to `inst.ty`.
+    val ret_type: type.IrTypeId = call_ret_type(ctx, sig, inst.ty);
     var layout: abi.SigLayout;
     val cls: R.Result[bool, str] = classify_signature(ctx, sig, ret_type, ?layout);
     if (R.is_err[bool, str](cls)) { ret cls; }
@@ -731,6 +758,9 @@ pub fun lower_call(ctx: *context.LowerCtx, mb: *mir.MirBlock, inst: *instruction
     # the call's result type sizes the caller-owned aggregate result storage.
     val ret_size:  u64 = type.byte_size(ctx.types, ret_type, ctx.tgt)::u64;
     val ret_aggr:  bool = context.value_is_aggregate(ctx, ret_type);
+    # a vector return is the memory (sret) class on a scalarized target: it arrives by
+    # address exactly like an aggregate, so it needs caller-owned result storage.
+    val ret_mem:   bool = ret_aggr || (context.value_is_vector(ctx, ret_type) && rslot.class == abi.CLASS_SRET);
 
     # the running register / stack cursors resume from the fixed-parameter walk so
     # a variadic call's tail arguments continue against the same counters.
@@ -744,7 +774,7 @@ pub fun lower_call(ctx: *context.LowerCtx, mb: *mir.MirBlock, inst: *instruction
     # move (>16B) passes it and the two-register form (9-16B) stores each half into
     # it; downstream consumers then read the aggregate result by this pointer.
     val res_dst: u32 = context.instr_vreg(ctx, iid);
-    if (ret_aggr && res_dst != mir.MIR_VREG_NIL) {
+    if (ret_mem && res_dst != mir.MIR_VREG_NIL) {
         val ra: R.Result[bool, str] = context.alloc_result_storage(ctx, mb, res_dst, ret_size, context.ret_align(ctx, ret_type));
         if (R.is_err[bool, str](ra)) {
             sig_layout_free(ctx, ?layout);

--- a/src/lang/me/ir.mach
+++ b/src/lang/me/ir.mach
@@ -357,6 +357,12 @@ pub rec Module {
 
     fn_by_name:     map.Map[intern.StrId, u32];
     global_by_name: map.Map[intern.StrId, u32];
+
+    # count of lane-wise vector operators the scalarize pass expanded in this module
+    # on a SIMD-incapable target (#2016); 0 on capable targets and for vector-free
+    # modules. the build path sums it across modules to surface the one-shot
+    # scalarization note.
+    vector_ops_scalarized: u32;
 }
 
 # seed capacities for the module's growable arrays; capacity doubles on overflow
@@ -386,6 +392,7 @@ pub fun init(a: *A.Allocator, name: intern.StrId) R.Result[Module, str] {
     m.global_len   = 0;
     m.global_cap   = 0;
     m.init_fn      = O.none[u32]();
+    m.vector_ops_scalarized = 0;
 
     # the name indexes allocate nothing until first insert, so the error paths
     # below need not tear them down.
@@ -458,6 +465,7 @@ pub fun dnit(m: *Module) {
     m.global_len   = 0;
     m.global_cap   = 0;
     m.init_fn      = O.none[u32]();
+    m.vector_ops_scalarized = 0;
     m.name         = intern.STR_NIL;
     m.alloc        = nil;
 }

--- a/src/lang/me/pass/scalarize.mach
+++ b/src/lang/me/pass/scalarize.mach
@@ -25,6 +25,7 @@
 # callee receives / returns it by address, and this pass makes every body use of that
 # value a pointer to match.
 
+use std.allocator.page;
 use std.types.bool.bool;
 use std.types.bool.false;
 use std.types.bool.true;
@@ -37,6 +38,7 @@ use R: std.types.result;
 
 use mach.lang.intern;
 use mach.lang.me.ir;
+use mach.lang.me.ir.builder;
 use mach.lang.me.ir.id;
 use mach.lang.me.ir.instruction;
 use ir_type: mach.lang.me.ir.type;
@@ -776,4 +778,54 @@ fun ctx_free(m: *ir.Module, c: *Ctx) {
     c.pval = nil;
     c.pval_set = nil;
     c.is_vp = nil;
+}
+
+# detect counts only the lane-wise vector OPERATORS (a vector add and a vector mul
+# here), not the scalar add sharing the same opcode, and names the first in program
+# order -- the shared currency the note count and the require lever (#2017) both read,
+# so they can never drift. arch-independent: it inspects IR, executing no vector code
+test "mach.lang.me.pass.scalarize.detect:counts_only_vector_operators" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+    val res_m: R.Result[ir.Module, str] = ir.init(?alloc, intern.STR_NIL);
+    if (R.is_err[ir.Module, str](res_m)) { ret 1; }
+    var m: ir.Module = R.unwrap_ok[ir.Module, str](res_m);
+
+    val res_f: R.Result[ir_type.IrTypeId, str] = ir_type.intern_float(?m.types, 32);
+    if (R.is_err[ir_type.IrTypeId, str](res_f)) { ir.dnit(?m); ret 1; }
+    val f32: ir_type.IrTypeId = R.unwrap_ok[ir_type.IrTypeId, str](res_f);
+    val res_v: R.Result[ir_type.IrTypeId, str] = ir_type.intern_vector(?m.types, f32, 4);
+    if (R.is_err[ir_type.IrTypeId, str](res_v)) { ir.dnit(?m); ret 1; }
+    val vec: ir_type.IrTypeId = R.unwrap_ok[ir_type.IrTypeId, str](res_v);
+    val res_i: R.Result[ir_type.IrTypeId, str] = ir_type.intern_int(?m.types, 32);
+    if (R.is_err[ir_type.IrTypeId, str](res_i)) { ir.dnit(?m); ret 1; }
+    val i32: ir_type.IrTypeId = R.unwrap_ok[ir_type.IrTypeId, str](res_i);
+
+    val res_fn: R.Result[u32, str] = ir.function_add(?m, intern.STR_NIL, ir_type.IRT_NIL, 0);
+    if (R.is_err[u32, str](res_fn)) { ir.dnit(?m); ret 1; }
+    val fn: *ir.Function = ?m.functions[R.unwrap_ok[u32, str](res_fn)];
+
+    var bld: builder.Builder = builder.init(?m);
+    builder.set_function(?bld, fn);
+    val res_blk: R.Result[id.BlockId, str] = builder.new_block(?bld);
+    if (R.is_err[id.BlockId, str](res_blk)) { ir.dnit(?m); ret 1; }
+    builder.set_block(?bld, R.unwrap_ok[id.BlockId, str](res_blk));
+
+    val pv0: value.Value = value.param(0, vec);
+    val pv1: value.Value = value.param(1, vec);
+    val ps:  value.Value = value.param(2, i32);
+
+    # a scalar add shares the OP_ADD opcode but is not a vector operator.
+    if (R.is_err[value.Value, str](builder.emit_add(?bld, ps, ps))) { ir.dnit(?m); ret 1; }
+    # two lane-wise vector operators.
+    if (R.is_err[value.Value, str](builder.emit_add(?bld, pv0, pv1))) { ir.dnit(?m); ret 1; }
+    if (R.is_err[value.Value, str](builder.emit_mul(?bld, pv0, pv1))) { ir.dnit(?m); ret 1; }
+
+    var site: ScalarizeSite;
+    val n: u32 = detect(?m, ?site);
+    if (n != 2)                              { ir.dnit(?m); ret 1; }
+    if (site.op != instruction.OP_ADD)       { ir.dnit(?m); ret 1; }
+
+    ir.dnit(?m);
+    ret 0;
 }

--- a/src/lang/me/pass/scalarize.mach
+++ b/src/lang/me/pass/scalarize.mach
@@ -1,0 +1,712 @@
+# target-conditional vector scalarization pass (#2016)
+#
+# On a SIMD-incapable target (`MachineModel.has_v128 == false`, rv64gc the shipping
+# instance) there is no vector register file and no packed instruction for any
+# lane-wise operator, so every `IRT_VECTOR` value and operator must be lowered to a
+# defined per-lane scalar form before the back end selects instructions. This pass
+# runs as a middle-end IR legalization stage, after the always-on mem2reg / constfold
+# / dce sequence and before codegen, so that by the time MIR selection runs there are
+# no `IRT_VECTOR`-typed values left: the per-target isel guard in mir/lower.mach then
+# never fires on rv64 (it stays a loud backstop) and the existing scalar back end
+# selects the result unchanged.
+#
+# The governing rule is the epic's: scalarize OPERATORS, never algorithms. Each
+# lane-wise operator becomes a fixed, bounded per-lane unroll -- N independent scalar
+# computations, one per lane, never reordered, fused, or reassociated across lanes --
+# so the result is lane-exact-identical to the packed hardware backends, including
+# the compare -> all-ones / all-zeros mask encoding and every IEEE-754 edge case
+# (NaN, signed zero, rounding), which per-lane scalar ops reproduce for free.
+#
+# Representation: every vector value becomes a pointer to a 16-byte stack slot (an
+# `[lanes]elem` array), exactly as an aggregate flows by address. A lane is a scalar
+# load / store at its offset; an operator reads its operand lanes, computes per lane,
+# and writes its result lanes. Vector-typed function signatures are left intact: a
+# vector parameter / return is the ABI's memory (by-reference) class on rv64, so the
+# callee receives / returns it by address, and this pass makes every body use of that
+# value a pointer to match.
+
+use std.types.bool.bool;
+use std.types.bool.false;
+use std.types.bool.true;
+use std.types.size.usize;
+use std.types.string.str;
+
+use A: std.allocator;
+use O: std.types.option;
+use R: std.types.result;
+
+use mach.lang.me.ir;
+use mach.lang.me.ir.id;
+use mach.lang.me.ir.instruction;
+use ir_type: mach.lang.me.ir.type;
+use mach.lang.me.ir.value;
+use mach.lang.source;
+use mach.lang.target;
+
+# per-function rewrite state, threaded through the expansion helpers
+# ---
+# m:       the module being legalized
+# fn:      the function being legalized
+# pval:    replacement pointer Value per original instruction id (a vector result's
+#          16-byte slot address, a retyped phi / call result, meaningful where set)
+# pval_set: whether pval[iid] holds a replacement
+# n:       original instruction count (pval / pval_set are sized to it; ids >= n are
+#          freshly emitted scalar instructions that never produce a vector value)
+# is_vp:   whether parameter p is vector-typed (a body use becomes a pointer)
+# pcount:  parameter count (bounds is_vp)
+# void_ty: interned void type for stores
+# ptr_ty:  interned pointer type for slots / lane addresses
+# idx_ty:  interned integer type for gep lane indices (target pointer width)
+rec Ctx {
+    m:        *ir.Module;
+    fn:       *ir.Function;
+    pval:     *value.Value;
+    pval_set: *bool;
+    n:        u32;
+    is_vp:    *bool;
+    pcount:   u32;
+    void_ty:  ir_type.IrTypeId;
+    ptr_ty:   ir_type.IrTypeId;
+    idx_ty:   ir_type.IrTypeId;
+}
+
+# a vector type's element type, lane count, and element bit width
+# ---
+# elem:  scalar element IrTypeId
+# lanes: number of lanes
+# bits:  element bit width (a lane mask's width)
+rec VInfo {
+    elem:  ir_type.IrTypeId;
+    lanes: u32;
+    bits:  u32;
+}
+
+# whether a binary opcode is a lane-wise vector arithmetic / bitwise operator
+#
+# The full arithmetic / bitwise binary family: whenever the result is vector-typed
+# the operator expands per lane. Illegal-on-vectors opcodes (integer `/` `%`) never
+# reach here from sema, but a per-lane expansion of them is still well-defined, so
+# the classifier stays total rather than partial.
+fun is_binary_op(k: instruction.InstrKind) bool {
+    ret k == instruction.OP_ADD || k == instruction.OP_SUB || k == instruction.OP_MUL
+        || k == instruction.OP_DIV_S || k == instruction.OP_DIV_U
+        || k == instruction.OP_REM_S || k == instruction.OP_REM_U
+        || k == instruction.OP_AND || k == instruction.OP_OR || k == instruction.OP_XOR
+        || k == instruction.OP_SHL || k == instruction.OP_SHR_S || k == instruction.OP_SHR_U;
+}
+
+# whether a unary opcode is a lane-wise vector operator (bitwise not, negate)
+fun is_unary_op(k: instruction.InstrKind) bool {
+    ret k == instruction.OP_NOT || k == instruction.OP_NEG;
+}
+
+# whether an opcode is a lane-wise vector comparison (result is the same-shape mask)
+fun is_compare_op(k: instruction.InstrKind) bool {
+    ret k == instruction.OP_CMP_EQ || k == instruction.OP_CMP_NE
+        || k == instruction.OP_CMP_LT_S || k == instruction.OP_CMP_LT_U
+        || k == instruction.OP_CMP_LE_S || k == instruction.OP_CMP_LE_U;
+}
+
+# whether an instruction produces a vector result that needs a backing stack slot
+#
+# Arithmetic / unary / comparison operators and a whole-vector load each define a
+# fresh vector value; a phi / call result is a vector too but is handled by
+# retyping in place, and a store / ret consume a vector without producing one.
+fun produces_vector(m: *ir.Module, inst: *instruction.Instruction) bool {
+    if (!ir_type.is_vector(?m.types, inst.ty)) { ret false; }
+    ret is_binary_op(inst.kind) || is_unary_op(inst.kind) || is_compare_op(inst.kind)
+        || inst.kind == instruction.OP_LOAD;
+}
+
+# read a vector type's element / lane / bit-width descriptor
+# ---
+# m:   the module (its type table)
+# vty: a vector IrTypeId
+# out: filled with the descriptor on success
+# ret: ok(true), or an err if `vty` is not a resolvable vector
+fun vec_info(m: *ir.Module, vty: ir_type.IrTypeId, out: *VInfo) R.Result[bool, str] {
+    val opt_v: O.Option[*ir_type.IrType] = ir_type.get(?m.types, vty);
+    if (O.is_none[*ir_type.IrType](opt_v)) { ret R.err[bool, str]("scalarize: operand is not a resolvable IR type"); }
+    val vt: *ir_type.IrType = O.unwrap[*ir_type.IrType](opt_v);
+    if (vt.kind != ir_type.IRT_VECTOR) { ret R.err[bool, str]("scalarize: expected an IR vector type"); }
+    out.elem  = vt.data.vector_.element;
+    out.lanes = vt.data.vector_.lanes;
+
+    val opt_e: O.Option[*ir_type.IrType] = ir_type.get(?m.types, vt.data.vector_.element);
+    if (O.is_none[*ir_type.IrType](opt_e)) { ret R.err[bool, str]("scalarize: vector element type not resolvable"); }
+    out.bits = O.unwrap[*ir_type.IrType](opt_e).data.bits;
+    ret R.ok[bool, str](true);
+}
+
+# create a fresh instruction in the function's pool with owned operands
+#
+# The pool-level primitive underlying every emit: it never links the instruction into
+# a block, so the caller controls placement. Stamps `loc` for debug-line fidelity.
+# ---
+# ret: the new instruction id, or an allocation error
+fun new_instr(m: *ir.Module, fn: *ir.Function, kind: instruction.InstrKind, ty: ir_type.IrTypeId,
+              aux: ir_type.IrTypeId, ops: *value.Value, opn: u32, loc: source.SrcLoc) R.Result[id.InstructionId, str] {
+    var owned: *value.Value = nil;
+    if (opn > 0) {
+        val ro: R.Result[*value.Value, str] = A.allocate[value.Value](m.alloc, opn::usize);
+        if (R.is_err[*value.Value, str](ro)) { ret R.err[id.InstructionId, str](R.unwrap_err[*value.Value, str](ro)); }
+        owned = R.unwrap_ok[*value.Value, str](ro);
+        var i: u32 = 0;
+        for (i < opn) { owned[i] = ops[i]; i = i + 1; }
+    }
+    var ins: instruction.Instruction;
+    ins.kind          = kind;
+    ins.ty            = ty;
+    ins.operands      = owned;
+    ins.operand_count = opn;
+    ins.operand_cap   = opn;
+    ins.flags         = 0;
+    ins.aux_ty        = aux;
+    ins.loc           = loc;
+    ret ir.instruction_add(m, fn, ins);
+}
+
+# create an instruction and append it to `blk`'s body, returning its result Value
+fun push(c: *Ctx, blk: *ir.Block, kind: instruction.InstrKind, ty: ir_type.IrTypeId,
+         aux: ir_type.IrTypeId, ops: *value.Value, opn: u32, loc: source.SrcLoc) R.Result[value.Value, str] {
+    val ri: R.Result[id.InstructionId, str] = new_instr(c.m, c.fn, kind, ty, aux, ops, opn, loc);
+    if (R.is_err[id.InstructionId, str](ri)) { ret R.err[value.Value, str](R.unwrap_err[id.InstructionId, str](ri)); }
+    val iid: id.InstructionId = R.unwrap_ok[id.InstructionId, str](ri);
+    val rl: R.Result[bool, str] = ir.block_append_instr(c.m, blk, iid);
+    if (R.is_err[bool, str](rl)) { ret R.err[value.Value, str](R.unwrap_err[bool, str](rl)); }
+    ret R.ok[value.Value, str](value.instr(iid, ty));
+}
+
+# the pointer to lane `k` of the `[lanes]elem` slot at `base` (a `gep [0, k]`)
+fun lane_ptr(c: *Ctx, blk: *ir.Block, base: value.Value, arr_ty: ir_type.IrTypeId, k: u32, loc: source.SrcLoc) R.Result[value.Value, str] {
+    var ops: [3]value.Value;
+    ops[0] = base;
+    ops[1] = value.const_int(0, c.idx_ty);
+    ops[2] = value.const_int(k::u64, c.idx_ty);
+    ret push(c, blk, instruction.OP_GEP, c.ptr_ty, arr_ty, ?ops[0], 3, loc);
+}
+
+# a scalar load of `elem_ty` from `ptr`
+fun emit_load(c: *Ctx, blk: *ir.Block, ptr: value.Value, elem_ty: ir_type.IrTypeId, loc: source.SrcLoc) R.Result[value.Value, str] {
+    var ops: [1]value.Value;
+    ops[0] = ptr;
+    ret push(c, blk, instruction.OP_LOAD, elem_ty, ir_type.IRT_NIL, ?ops[0], 1, loc);
+}
+
+# a scalar store of `v` to `ptr`
+fun emit_store(c: *Ctx, blk: *ir.Block, v: value.Value, ptr: value.Value, loc: source.SrcLoc) R.Result[bool, str] {
+    var ops: [2]value.Value;
+    ops[0] = v;
+    ops[1] = ptr;
+    val r: R.Result[value.Value, str] = push(c, blk, instruction.OP_STORE, c.void_ty, ir_type.IRT_NIL, ?ops[0], 2, loc);
+    if (R.is_err[value.Value, str](r)) { ret R.err[bool, str](R.unwrap_err[value.Value, str](r)); }
+    ret R.ok[bool, str](true);
+}
+
+# a scalar binary op `kind ty a, b`
+fun emit_binop(c: *Ctx, blk: *ir.Block, kind: instruction.InstrKind, ty: ir_type.IrTypeId, a: value.Value, b: value.Value, loc: source.SrcLoc) R.Result[value.Value, str] {
+    var ops: [2]value.Value;
+    ops[0] = a;
+    ops[1] = b;
+    ret push(c, blk, kind, ty, ir_type.IRT_NIL, ?ops[0], 2, loc);
+}
+
+# a scalar unary op `kind ty a`
+fun emit_unop(c: *Ctx, blk: *ir.Block, kind: instruction.InstrKind, ty: ir_type.IrTypeId, a: value.Value, loc: source.SrcLoc) R.Result[value.Value, str] {
+    var ops: [1]value.Value;
+    ops[0] = a;
+    ret push(c, blk, kind, ty, ir_type.IRT_NIL, ?ops[0], 1, loc);
+}
+
+# resolve a value to its scalarized replacement
+#
+# A vector-typed instruction result resolves to its slot pointer; a vector parameter
+# resolves to the same-index pointer parameter (byref on rv64, so the register holds
+# the address); everything else passes through unchanged.
+fun resolve(c: *Ctx, v: value.Value) value.Value {
+    if (v.kind == value.VAL_INSTR) {
+        val iid: u32 = v.data.instr::u32;
+        if (iid < c.n && c.pval_set[iid]) { ret c.pval[iid]; }
+        ret v;
+    }
+    if (v.kind == value.VAL_PARAM) {
+        val p: u32 = v.data.param_ix;
+        if (p < c.pcount && c.is_vp[p]) { ret value.param(p, c.ptr_ty); }
+        ret v;
+    }
+    ret v;
+}
+
+# rewrite every operand of `inst` through `resolve`, in place
+#
+# Used for the kept instructions, the phi value operands, and the terminator: a
+# vector value naming a scalarized producer becomes its slot pointer. Block-target
+# operands ride in VAL_CONST_INT slots and pass through untouched.
+fun rewrite_ops(c: *Ctx, inst: *instruction.Instruction) {
+    var i: u32 = 0;
+    for (i < inst.operand_count) {
+        inst.operands[i] = resolve(c, inst.operands[i]);
+        i = i + 1;
+    }
+}
+
+# expand a lane-wise arithmetic / bitwise binary vector operator into N scalar ops
+#
+# reads lane k of each operand slot, applies the scalar op, stores lane k of the
+# result slot -- N independent computations, no cross-lane interaction.
+fun expand_binary(c: *Ctx, blk: *ir.Block, kind: instruction.InstrKind, dst: value.Value, a: value.Value, b: value.Value, vi: VInfo, loc: source.SrcLoc) R.Result[bool, str] {
+    val ra: R.Result[ir_type.IrTypeId, str] = ir_type.intern_array(?c.m.types, vi.elem, vi.lanes);
+    if (R.is_err[ir_type.IrTypeId, str](ra)) { ret R.err[bool, str](R.unwrap_err[ir_type.IrTypeId, str](ra)); }
+    val arr: ir_type.IrTypeId = R.unwrap_ok[ir_type.IrTypeId, str](ra);
+
+    var k: u32 = 0;
+    for (k < vi.lanes) {
+        val pa: R.Result[value.Value, str] = lane_ptr(c, blk, a, arr, k, loc);
+        if (R.is_err[value.Value, str](pa)) { ret R.err[bool, str](R.unwrap_err[value.Value, str](pa)); }
+        val va: R.Result[value.Value, str] = emit_load(c, blk, R.unwrap_ok[value.Value, str](pa), vi.elem, loc);
+        if (R.is_err[value.Value, str](va)) { ret R.err[bool, str](R.unwrap_err[value.Value, str](va)); }
+
+        val pb: R.Result[value.Value, str] = lane_ptr(c, blk, b, arr, k, loc);
+        if (R.is_err[value.Value, str](pb)) { ret R.err[bool, str](R.unwrap_err[value.Value, str](pb)); }
+        val vb: R.Result[value.Value, str] = emit_load(c, blk, R.unwrap_ok[value.Value, str](pb), vi.elem, loc);
+        if (R.is_err[value.Value, str](vb)) { ret R.err[bool, str](R.unwrap_err[value.Value, str](vb)); }
+
+        val vr: R.Result[value.Value, str] = emit_binop(c, blk, kind, vi.elem, R.unwrap_ok[value.Value, str](va), R.unwrap_ok[value.Value, str](vb), loc);
+        if (R.is_err[value.Value, str](vr)) { ret R.err[bool, str](R.unwrap_err[value.Value, str](vr)); }
+
+        val pr: R.Result[value.Value, str] = lane_ptr(c, blk, dst, arr, k, loc);
+        if (R.is_err[value.Value, str](pr)) { ret R.err[bool, str](R.unwrap_err[value.Value, str](pr)); }
+        val rs: R.Result[bool, str] = emit_store(c, blk, R.unwrap_ok[value.Value, str](vr), R.unwrap_ok[value.Value, str](pr), loc);
+        if (R.is_err[bool, str](rs)) { ret rs; }
+        k = k + 1;
+    }
+    ret R.ok[bool, str](true);
+}
+
+# expand a lane-wise unary vector operator (bitwise not, negate) into N scalar ops
+fun expand_unary(c: *Ctx, blk: *ir.Block, kind: instruction.InstrKind, dst: value.Value, a: value.Value, vi: VInfo, loc: source.SrcLoc) R.Result[bool, str] {
+    val ra: R.Result[ir_type.IrTypeId, str] = ir_type.intern_array(?c.m.types, vi.elem, vi.lanes);
+    if (R.is_err[ir_type.IrTypeId, str](ra)) { ret R.err[bool, str](R.unwrap_err[ir_type.IrTypeId, str](ra)); }
+    val arr: ir_type.IrTypeId = R.unwrap_ok[ir_type.IrTypeId, str](ra);
+
+    var k: u32 = 0;
+    for (k < vi.lanes) {
+        val pa: R.Result[value.Value, str] = lane_ptr(c, blk, a, arr, k, loc);
+        if (R.is_err[value.Value, str](pa)) { ret R.err[bool, str](R.unwrap_err[value.Value, str](pa)); }
+        val va: R.Result[value.Value, str] = emit_load(c, blk, R.unwrap_ok[value.Value, str](pa), vi.elem, loc);
+        if (R.is_err[value.Value, str](va)) { ret R.err[bool, str](R.unwrap_err[value.Value, str](va)); }
+
+        val vr: R.Result[value.Value, str] = emit_unop(c, blk, kind, vi.elem, R.unwrap_ok[value.Value, str](va), loc);
+        if (R.is_err[value.Value, str](vr)) { ret R.err[bool, str](R.unwrap_err[value.Value, str](vr)); }
+
+        val pr: R.Result[value.Value, str] = lane_ptr(c, blk, dst, arr, k, loc);
+        if (R.is_err[value.Value, str](pr)) { ret R.err[bool, str](R.unwrap_err[value.Value, str](pr)); }
+        val rs: R.Result[bool, str] = emit_store(c, blk, R.unwrap_ok[value.Value, str](vr), R.unwrap_ok[value.Value, str](pr), loc);
+        if (R.is_err[bool, str](rs)) { ret rs; }
+        k = k + 1;
+    }
+    ret R.ok[bool, str](true);
+}
+
+# expand a lane-wise vector comparison into N scalar compares each writing a full-width
+# mask lane (all-ones for true, all-zeros for false)
+#
+# The operand element carries the compared values (`op`); the result mask element is a
+# same-width integer. Per lane: a scalar compare yields a 0/1 boolean, widened to the
+# mask width and negated (`0 - z`) so a true lane is all-ones in two's complement --
+# lane-for-lane identical to CMPPS / FCMEQ, including the NaN outcome the scalar
+# ordered / unordered compare reproduces.
+fun expand_compare(c: *Ctx, blk: *ir.Block, kind: instruction.InstrKind, dst: value.Value, a: value.Value, b: value.Value,
+                   op: VInfo, mask: VInfo, i8_ty: ir_type.IrTypeId, loc: source.SrcLoc) R.Result[bool, str] {
+    val rao: R.Result[ir_type.IrTypeId, str] = ir_type.intern_array(?c.m.types, op.elem, op.lanes);
+    if (R.is_err[ir_type.IrTypeId, str](rao)) { ret R.err[bool, str](R.unwrap_err[ir_type.IrTypeId, str](rao)); }
+    val arr_op: ir_type.IrTypeId = R.unwrap_ok[ir_type.IrTypeId, str](rao);
+    val ram: R.Result[ir_type.IrTypeId, str] = ir_type.intern_array(?c.m.types, mask.elem, mask.lanes);
+    if (R.is_err[ir_type.IrTypeId, str](ram)) { ret R.err[bool, str](R.unwrap_err[ir_type.IrTypeId, str](ram)); }
+    val arr_mask: ir_type.IrTypeId = R.unwrap_ok[ir_type.IrTypeId, str](ram);
+
+    var k: u32 = 0;
+    for (k < op.lanes) {
+        val pa: R.Result[value.Value, str] = lane_ptr(c, blk, a, arr_op, k, loc);
+        if (R.is_err[value.Value, str](pa)) { ret R.err[bool, str](R.unwrap_err[value.Value, str](pa)); }
+        val va: R.Result[value.Value, str] = emit_load(c, blk, R.unwrap_ok[value.Value, str](pa), op.elem, loc);
+        if (R.is_err[value.Value, str](va)) { ret R.err[bool, str](R.unwrap_err[value.Value, str](va)); }
+
+        val pb: R.Result[value.Value, str] = lane_ptr(c, blk, b, arr_op, k, loc);
+        if (R.is_err[value.Value, str](pb)) { ret R.err[bool, str](R.unwrap_err[value.Value, str](pb)); }
+        val vb: R.Result[value.Value, str] = emit_load(c, blk, R.unwrap_ok[value.Value, str](pb), op.elem, loc);
+        if (R.is_err[value.Value, str](vb)) { ret R.err[bool, str](R.unwrap_err[value.Value, str](vb)); }
+
+        # a scalar compare of the two lanes yields an 8-bit 0/1 boolean.
+        val cmp: R.Result[value.Value, str] = emit_binop(c, blk, kind, i8_ty, R.unwrap_ok[value.Value, str](va), R.unwrap_ok[value.Value, str](vb), loc);
+        if (R.is_err[value.Value, str](cmp)) { ret R.err[bool, str](R.unwrap_err[value.Value, str](cmp)); }
+        var wide: value.Value = R.unwrap_ok[value.Value, str](cmp);
+
+        # widen the boolean to the mask lane width (identity when the mask is 8-bit).
+        if (mask.bits != 8) {
+            val z: R.Result[value.Value, str] = emit_unop(c, blk, instruction.OP_ZEXT, mask.elem, wide, loc);
+            if (R.is_err[value.Value, str](z)) { ret R.err[bool, str](R.unwrap_err[value.Value, str](z)); }
+            wide = R.unwrap_ok[value.Value, str](z);
+        }
+
+        # negate: 0 - {0,1} is {0, all-ones} in two's complement at the mask width.
+        val neg: R.Result[value.Value, str] = emit_binop(c, blk, instruction.OP_SUB, mask.elem, value.const_int(0, mask.elem), wide, loc);
+        if (R.is_err[value.Value, str](neg)) { ret R.err[bool, str](R.unwrap_err[value.Value, str](neg)); }
+
+        val pr: R.Result[value.Value, str] = lane_ptr(c, blk, dst, arr_mask, k, loc);
+        if (R.is_err[value.Value, str](pr)) { ret R.err[bool, str](R.unwrap_err[value.Value, str](pr)); }
+        val rs: R.Result[bool, str] = emit_store(c, blk, R.unwrap_ok[value.Value, str](neg), R.unwrap_ok[value.Value, str](pr), loc);
+        if (R.is_err[bool, str](rs)) { ret rs; }
+        k = k + 1;
+    }
+    ret R.ok[bool, str](true);
+}
+
+# copy the 16 bytes of a vector from `src` to `dst`, lane by lane (a whole-vector
+# load's snapshot, or a whole-vector store)
+fun copy_vector(c: *Ctx, blk: *ir.Block, dst: value.Value, src: value.Value, vi: VInfo, loc: source.SrcLoc) R.Result[bool, str] {
+    val ra: R.Result[ir_type.IrTypeId, str] = ir_type.intern_array(?c.m.types, vi.elem, vi.lanes);
+    if (R.is_err[ir_type.IrTypeId, str](ra)) { ret R.err[bool, str](R.unwrap_err[ir_type.IrTypeId, str](ra)); }
+    val arr: ir_type.IrTypeId = R.unwrap_ok[ir_type.IrTypeId, str](ra);
+
+    var k: u32 = 0;
+    for (k < vi.lanes) {
+        val ps: R.Result[value.Value, str] = lane_ptr(c, blk, src, arr, k, loc);
+        if (R.is_err[value.Value, str](ps)) { ret R.err[bool, str](R.unwrap_err[value.Value, str](ps)); }
+        val v: R.Result[value.Value, str] = emit_load(c, blk, R.unwrap_ok[value.Value, str](ps), vi.elem, loc);
+        if (R.is_err[value.Value, str](v)) { ret R.err[bool, str](R.unwrap_err[value.Value, str](v)); }
+
+        val pd: R.Result[value.Value, str] = lane_ptr(c, blk, dst, arr, k, loc);
+        if (R.is_err[value.Value, str](pd)) { ret R.err[bool, str](R.unwrap_err[value.Value, str](pd)); }
+        val rs: R.Result[bool, str] = emit_store(c, blk, R.unwrap_ok[value.Value, str](v), R.unwrap_ok[value.Value, str](pd), loc);
+        if (R.is_err[bool, str](rs)) { ret rs; }
+        k = k + 1;
+    }
+    ret R.ok[bool, str](true);
+}
+
+# create a fresh `[lanes]elem` stack slot for `vty` in the entry block's alloca set,
+# returning its pointer Value
+#
+# The slot is emitted into `entry`'s body front later (it must dominate every use);
+# here it is only created in the pool and its id recorded in `slots`.
+fun make_slot(c: *Ctx, vty: ir_type.IrTypeId, slots: *id.InstructionId, slot_len: *u32) R.Result[value.Value, str] {
+    var vi: VInfo;
+    val vr: R.Result[bool, str] = vec_info(c.m, vty, ?vi);
+    if (R.is_err[bool, str](vr)) { ret R.err[value.Value, str](R.unwrap_err[bool, str](vr)); }
+    val ra: R.Result[ir_type.IrTypeId, str] = ir_type.intern_array(?c.m.types, vi.elem, vi.lanes);
+    if (R.is_err[ir_type.IrTypeId, str](ra)) { ret R.err[value.Value, str](R.unwrap_err[ir_type.IrTypeId, str](ra)); }
+    val arr: ir_type.IrTypeId = R.unwrap_ok[ir_type.IrTypeId, str](ra);
+
+    var ops: [1]value.Value;
+    ops[0] = value.const_int(1, c.idx_ty);
+    val ri: R.Result[id.InstructionId, str] = new_instr(c.m, c.fn, instruction.OP_ALLOCA, c.ptr_ty, arr, ?ops[0], 1, source.loc(source.FILE_NIL, 0));
+    if (R.is_err[id.InstructionId, str](ri)) { ret R.err[value.Value, str](R.unwrap_err[id.InstructionId, str](ri)); }
+    val iid: id.InstructionId = R.unwrap_ok[id.InstructionId, str](ri);
+    slots[@slot_len] = iid;
+    @slot_len = @slot_len + 1;
+    ret R.ok[value.Value, str](value.instr(iid, c.ptr_ty));
+}
+
+# retype an alloca / gep whose aggregate type is a vector to the equivalent
+# `[lanes]elem` array, so the back end strides and sizes it as ordinary array memory
+# and no `IRT_VECTOR` is referenced after the pass
+fun retype_aux(c: *Ctx, inst: *instruction.Instruction) R.Result[bool, str] {
+    if (inst.aux_ty == ir_type.IRT_NIL) { ret R.ok[bool, str](true); }
+    if (!ir_type.is_vector(?c.m.types, inst.aux_ty)) { ret R.ok[bool, str](true); }
+    var vi: VInfo;
+    val vr: R.Result[bool, str] = vec_info(c.m, inst.aux_ty, ?vi);
+    if (R.is_err[bool, str](vr)) { ret vr; }
+    val ra: R.Result[ir_type.IrTypeId, str] = ir_type.intern_array(?c.m.types, vi.elem, vi.lanes);
+    if (R.is_err[ir_type.IrTypeId, str](ra)) { ret R.err[bool, str](R.unwrap_err[ir_type.IrTypeId, str](ra)); }
+    inst.aux_ty = R.unwrap_ok[ir_type.IrTypeId, str](ra);
+    ret R.ok[bool, str](true);
+}
+
+# legalize one function, returning the number of vector OPERATORS scalarized
+#
+# The operator tally counts arithmetic / unary / comparison expansions only; the
+# supporting loads, stores, and moves are not operators.
+fun scalarize_function(c: *Ctx, i8_ty: ir_type.IrTypeId) R.Result[u32, str] {
+    val fn: *ir.Function = c.fn;
+
+    # slot ids created in the pre-pass, prepended to the entry block in the fill pass.
+    var slots:    *id.InstructionId = nil;
+    var slot_len: u32 = 0;
+    if (c.n > 0) {
+        val rs: R.Result[*id.InstructionId, str] = A.allocate[id.InstructionId](c.m.alloc, c.n::usize);
+        if (R.is_err[*id.InstructionId, str](rs)) { ret R.err[u32, str](R.unwrap_err[*id.InstructionId, str](rs)); }
+        slots = R.unwrap_ok[*id.InstructionId, str](rs);
+    }
+
+    # pre-pass: give every vector-producing instruction its pointer representation,
+    # and retype vector allocas / geps to array form. iterate the pool by id so a
+    # phi's incoming producers are mapped before the fill pass reads them.
+    var iid: u32 = 0;
+    for (iid < c.n) {
+        val inst: *instruction.Instruction = ?fn.instrs[iid];
+        if (inst.kind == instruction.OP_ALLOCA || inst.kind == instruction.OP_GEP) {
+            val rr: R.Result[bool, str] = retype_aux(c, inst);
+            if (R.is_err[bool, str](rr)) { slots_free(c, slots); ret R.err[u32, str](R.unwrap_err[bool, str](rr)); }
+        } or (produces_vector(c.m, inst)) {
+            val vty: ir_type.IrTypeId = inst.ty;
+            val ms: R.Result[value.Value, str] = make_slot(c, vty, slots, ?slot_len);
+            if (R.is_err[value.Value, str](ms)) { slots_free(c, slots); ret R.err[u32, str](R.unwrap_err[value.Value, str](ms)); }
+            c.pval[iid]     = R.unwrap_ok[value.Value, str](ms);
+            c.pval_set[iid] = true;
+        } or (inst.kind == instruction.OP_PHI && ir_type.is_vector(?c.m.types, inst.ty)) {
+            inst.ty         = c.ptr_ty;
+            c.pval[iid]     = value.instr(iid::id.InstructionId, c.ptr_ty);
+            c.pval_set[iid] = true;
+        } or (inst.kind == instruction.OP_CALL && ir_type.is_vector(?c.m.types, inst.ty)) {
+            inst.ty         = c.ptr_ty;
+            c.pval[iid]     = value.instr(iid::id.InstructionId, c.ptr_ty);
+            c.pval_set[iid] = true;
+        }
+        iid = iid + 1;
+    }
+
+    # fill pass: rewrite each block's body, expanding operators and copying loads /
+    # stores; rewrite phi value operands and the terminator in place.
+    var count: u32 = 0;
+    var bi: u32 = 0;
+    for (bi < fn.block_count) {
+        val blk: *ir.Block = ?fn.blocks[bi];
+        val rf: R.Result[u32, str] = fill_block(c, blk, bi == 0, slots, slot_len, i8_ty, count);
+        if (R.is_err[u32, str](rf)) { slots_free(c, slots); ret rf; }
+        count = R.unwrap_ok[u32, str](rf);
+        bi = bi + 1;
+    }
+
+    slots_free(c, slots);
+    ret R.ok[u32, str](count);
+}
+
+# free the pre-pass slot-id scratch array
+fun slots_free(c: *Ctx, slots: *id.InstructionId) {
+    if (slots != nil && c.n > 0) {
+        A.deallocate[id.InstructionId](c.m.alloc, slots, c.n::usize);
+    }
+}
+
+# rebuild one block's body, expanding vector operators; returns the running operator tally
+fun fill_block(c: *Ctx, blk: *ir.Block, is_entry: bool, slots: *id.InstructionId, slot_len: u32, i8_ty: ir_type.IrTypeId, count_in: u32) R.Result[u32, str] {
+    val fn: *ir.Function = c.fn;
+    var count: u32 = count_in;
+
+    # snapshot the old body ids: the fill re-appends into a cleared body, and emits
+    # fresh instructions between them, so the original order is preserved.
+    val old_len: u32 = blk.instr_count;
+    var old: *id.InstructionId = nil;
+    if (old_len > 0) {
+        val ro: R.Result[*id.InstructionId, str] = A.allocate[id.InstructionId](c.m.alloc, old_len::usize);
+        if (R.is_err[*id.InstructionId, str](ro)) { ret R.err[u32, str](R.unwrap_err[*id.InstructionId, str](ro)); }
+        old = R.unwrap_ok[*id.InstructionId, str](ro);
+        var i: u32 = 0;
+        for (i < old_len) { old[i] = blk.instructions[i]; i = i + 1; }
+    }
+    blk.instr_count = 0;
+
+    # the entry block's alloca slots dominate every use, so they lead the body.
+    if (is_entry) {
+        var s: u32 = 0;
+        for (s < slot_len) {
+            val ra: R.Result[bool, str] = ir.block_append_instr(c.m, blk, slots[s]);
+            if (R.is_err[bool, str](ra)) { body_free(c, old, old_len); ret R.err[u32, str](R.unwrap_err[bool, str](ra)); }
+            s = s + 1;
+        }
+    }
+
+    var oi: u32 = 0;
+    for (oi < old_len) {
+        val cur: id.InstructionId = old[oi];
+        val rr: R.Result[u32, str] = fill_one(c, blk, cur, i8_ty, count);
+        if (R.is_err[u32, str](rr)) { body_free(c, old, old_len); ret rr; }
+        count = R.unwrap_ok[u32, str](rr);
+        oi = oi + 1;
+    }
+
+    body_free(c, old, old_len);
+
+    # phis carry value operands from predecessors; retype vector incomings to pointers.
+    var p: u32 = 0;
+    for (p < blk.phi_count) {
+        rewrite_ops(c, ?fn.instrs[blk.phis[p]::u32]);
+        p = p + 1;
+    }
+    # the terminator (a vector `ret`) consumes a vector value by address.
+    if (blk.terminator != id.INSTR_NIL) {
+        rewrite_ops(c, ?fn.instrs[blk.terminator::u32]);
+    }
+    ret R.ok[u32, str](count);
+}
+
+# free the snapshot body-id array
+fun body_free(c: *Ctx, old: *id.InstructionId, old_len: u32) {
+    if (old != nil && old_len > 0) {
+        A.deallocate[id.InstructionId](c.m.alloc, old, old_len::usize);
+    }
+}
+
+# process one original body instruction: expand a vector operator, copy a vector
+# load / store, or keep and operand-rewrite anything else
+fun fill_one(c: *Ctx, blk: *ir.Block, cur: id.InstructionId, i8_ty: ir_type.IrTypeId, count_in: u32) R.Result[u32, str] {
+    val fn: *ir.Function = c.fn;
+    var count: u32 = count_in;
+
+    # copy out everything read from the instruction: emitting fresh instructions can
+    # reallocate the pool and invalidate this pointer.
+    val ip: *instruction.Instruction = ?fn.instrs[cur::u32];
+    val kind: instruction.InstrKind = ip.kind;
+    val ty:   ir_type.IrTypeId = ip.ty;
+    val loc:  source.SrcLoc = ip.loc;
+    val is_vec_ty: bool = ir_type.is_vector(?c.m.types, ty);
+
+    # a vector arithmetic / unary / comparison operator, or a whole-vector load.
+    if (is_vec_ty && (is_binary_op(kind) || is_unary_op(kind) || is_compare_op(kind) || kind == instruction.OP_LOAD)) {
+        val dst: value.Value = c.pval[cur::u32];
+        if (is_compare_op(kind)) {
+            val op0: value.Value = resolve(c, ip.operands[0]);
+            val op1: value.Value = resolve(c, ip.operands[1]);
+            val op0ty: ir_type.IrTypeId = ip.operands[0].ty;
+            var opi: VInfo;
+            val re: R.Result[bool, str] = vec_info(c.m, op0ty, ?opi);
+            if (R.is_err[bool, str](re)) { ret R.err[u32, str](R.unwrap_err[bool, str](re)); }
+            var mi: VInfo;
+            val rm: R.Result[bool, str] = vec_info(c.m, ty, ?mi);
+            if (R.is_err[bool, str](rm)) { ret R.err[u32, str](R.unwrap_err[bool, str](rm)); }
+            val rx: R.Result[bool, str] = expand_compare(c, blk, kind, dst, op0, op1, opi, mi, i8_ty, loc);
+            if (R.is_err[bool, str](rx)) { ret R.err[u32, str](R.unwrap_err[bool, str](rx)); }
+            ret R.ok[u32, str](count + 1);
+        }
+        var vi: VInfo;
+        val rv: R.Result[bool, str] = vec_info(c.m, ty, ?vi);
+        if (R.is_err[bool, str](rv)) { ret R.err[u32, str](R.unwrap_err[bool, str](rv)); }
+        if (kind == instruction.OP_LOAD) {
+            val src: value.Value = resolve(c, ip.operands[0]);
+            val rc: R.Result[bool, str] = copy_vector(c, blk, dst, src, vi, loc);
+            if (R.is_err[bool, str](rc)) { ret R.err[u32, str](R.unwrap_err[bool, str](rc)); }
+            ret R.ok[u32, str](count);
+        }
+        if (is_unary_op(kind)) {
+            val a: value.Value = resolve(c, ip.operands[0]);
+            val ru: R.Result[bool, str] = expand_unary(c, blk, kind, dst, a, vi, loc);
+            if (R.is_err[bool, str](ru)) { ret R.err[u32, str](R.unwrap_err[bool, str](ru)); }
+            ret R.ok[u32, str](count + 1);
+        }
+        val a: value.Value = resolve(c, ip.operands[0]);
+        val b: value.Value = resolve(c, ip.operands[1]);
+        val rb: R.Result[bool, str] = expand_binary(c, blk, kind, dst, a, b, vi, loc);
+        if (R.is_err[bool, str](rb)) { ret R.err[u32, str](R.unwrap_err[bool, str](rb)); }
+        ret R.ok[u32, str](count + 1);
+    }
+
+    # a whole-vector store: copy the source slot's 16 bytes to the destination.
+    if (kind == instruction.OP_STORE && ir_type.is_vector(?c.m.types, ip.operands[0].ty)) {
+        val srcv: value.Value = resolve(c, ip.operands[0]);
+        val dstp: value.Value = resolve(c, ip.operands[1]);
+        val vty:  ir_type.IrTypeId = ip.operands[0].ty;
+        var vi: VInfo;
+        val rv: R.Result[bool, str] = vec_info(c.m, vty, ?vi);
+        if (R.is_err[bool, str](rv)) { ret R.err[u32, str](R.unwrap_err[bool, str](rv)); }
+        val rc: R.Result[bool, str] = copy_vector(c, blk, dstp, srcv, vi, loc);
+        if (R.is_err[bool, str](rc)) { ret R.err[u32, str](R.unwrap_err[bool, str](rc)); }
+        ret R.ok[u32, str](count);
+    }
+
+    # everything else is kept: rewrite its operands to the pointer representation and
+    # re-link it into the rebuilt body in its original position.
+    rewrite_ops(c, ?fn.instrs[cur::u32]);
+    val rl: R.Result[bool, str] = ir.block_append_instr(c.m, blk, cur);
+    if (R.is_err[bool, str](rl)) { ret R.err[u32, str](R.unwrap_err[bool, str](rl)); }
+    ret R.ok[u32, str](count);
+}
+
+# scalarize every lane-wise vector value and operator in `m` for a SIMD-incapable
+# target; a no-op on a capable target (`has_v128 == true`)
+#
+# Records the number of vector operators scalarized (summed across the module's
+# functions) on `m.vector_ops_scalarized`, which the build path reads to surface the
+# one-shot scalarization note. This is the shared detection seam the profile lever
+# (#2017) turns into a `require`-mode error.
+# ---
+# m:   the module to legalize in place
+# tgt: the target, consulted for the SIMD capability fact
+# ret: ok(true) on success, or an allocation / internal error
+pub fun run(m: *ir.Module, tgt: *target.Target) R.Result[bool, str] {
+    if (tgt.model.has_v128) { ret R.ok[bool, str](true); }
+
+    val rp: R.Result[ir_type.IrTypeId, str] = ir_type.intern_ptr(?m.types);
+    if (R.is_err[ir_type.IrTypeId, str](rp)) { ret R.err[bool, str](R.unwrap_err[ir_type.IrTypeId, str](rp)); }
+    val ptr_ty: ir_type.IrTypeId = R.unwrap_ok[ir_type.IrTypeId, str](rp);
+
+    val rv: R.Result[ir_type.IrTypeId, str] = ir_type.intern_void(?m.types);
+    if (R.is_err[ir_type.IrTypeId, str](rv)) { ret R.err[bool, str](R.unwrap_err[ir_type.IrTypeId, str](rv)); }
+    val void_ty: ir_type.IrTypeId = R.unwrap_ok[ir_type.IrTypeId, str](rv);
+
+    # gep lane indices are machine-word integers; the pointer width matches the target.
+    val ri: R.Result[ir_type.IrTypeId, str] = ir_type.intern_int(?m.types, tgt.arch.pointer_width * 8);
+    if (R.is_err[ir_type.IrTypeId, str](ri)) { ret R.err[bool, str](R.unwrap_err[ir_type.IrTypeId, str](ri)); }
+    val idx_ty: ir_type.IrTypeId = R.unwrap_ok[ir_type.IrTypeId, str](ri);
+
+    val r8: R.Result[ir_type.IrTypeId, str] = ir_type.intern_int(?m.types, 8);
+    if (R.is_err[ir_type.IrTypeId, str](r8)) { ret R.err[bool, str](R.unwrap_err[ir_type.IrTypeId, str](r8)); }
+    val i8_ty: ir_type.IrTypeId = R.unwrap_ok[ir_type.IrTypeId, str](r8);
+
+    var total: u32 = 0;
+    var fi: u32 = 0;
+    for (fi < m.function_len) {
+        val fn: *ir.Function = ?m.functions[fi];
+        if ((fn.flags & ir.FN_FLAG_EXTERN) == 0 && fn.instr_len > 0) {
+            var c: Ctx;
+            c.m       = m;
+            c.fn      = fn;
+            c.n       = fn.instr_len;
+            c.pcount  = fn.param_count;
+            c.void_ty = void_ty;
+            c.ptr_ty  = ptr_ty;
+            c.idx_ty  = idx_ty;
+
+            val rpv: R.Result[*value.Value, str] = A.allocate[value.Value](m.alloc, c.n::usize);
+            if (R.is_err[*value.Value, str](rpv)) { ret R.err[bool, str](R.unwrap_err[*value.Value, str](rpv)); }
+            c.pval = R.unwrap_ok[*value.Value, str](rpv);
+            val rps: R.Result[*bool, str] = A.allocate[bool](m.alloc, c.n::usize);
+            if (R.is_err[*bool, str](rps)) { A.deallocate[value.Value](m.alloc, c.pval, c.n::usize); ret R.err[bool, str](R.unwrap_err[*bool, str](rps)); }
+            c.pval_set = R.unwrap_ok[*bool, str](rps);
+
+            var iid: u32 = 0;
+            for (iid < c.n) { c.pval_set[iid] = false; iid = iid + 1; }
+
+            c.is_vp = nil;
+            if (c.pcount > 0) {
+                val rvp: R.Result[*bool, str] = A.allocate[bool](m.alloc, c.pcount::usize);
+                if (R.is_err[*bool, str](rvp)) { ctx_free(m, ?c); ret R.err[bool, str](R.unwrap_err[*bool, str](rvp)); }
+                c.is_vp = R.unwrap_ok[*bool, str](rvp);
+                var p: u32 = 0;
+                for (p < c.pcount) {
+                    c.is_vp[p] = ir_type.is_vector(?m.types, fn.params[p].ty);
+                    p = p + 1;
+                }
+            }
+
+            val rf: R.Result[u32, str] = scalarize_function(?c, i8_ty);
+            ctx_free(m, ?c);
+            if (R.is_err[u32, str](rf)) { ret R.err[bool, str](R.unwrap_err[u32, str](rf)); }
+            total = total + R.unwrap_ok[u32, str](rf);
+        }
+        fi = fi + 1;
+    }
+
+    m.vector_ops_scalarized = total;
+    ret R.ok[bool, str](true);
+}
+
+# free a Ctx's owned scratch arrays
+fun ctx_free(m: *ir.Module, c: *Ctx) {
+    if (c.pval != nil && c.n > 0)     { A.deallocate[value.Value](m.alloc, c.pval, c.n::usize); }
+    if (c.pval_set != nil && c.n > 0) { A.deallocate[bool](m.alloc, c.pval_set, c.n::usize); }
+    if (c.is_vp != nil && c.pcount > 0) { A.deallocate[bool](m.alloc, c.is_vp, c.pcount::usize); }
+    c.pval = nil;
+    c.pval_set = nil;
+    c.is_vp = nil;
+}

--- a/src/lang/me/pass/scalarize.mach
+++ b/src/lang/me/pass/scalarize.mach
@@ -685,6 +685,11 @@ pub fun run(m: *ir.Module, tgt: *target.Target) R.Result[bool, str] {
                 var p: u32 = 0;
                 for (p < c.pcount) {
                     c.is_vp[p] = ir_type.is_vector(?m.types, fn.params[p].ty);
+                    # a vector parameter is byref (memory class) on a scalarized target:
+                    # its register holds a pointer, so retype the parameter value to
+                    # `ptr` and its vreg lands in the GP bank. the signature (fn.sig)
+                    # keeps the vector type for ABI classification.
+                    if (c.is_vp[p]) { fn.params[p] = value.retype(fn.params[p], ptr_ty); }
                     p = p + 1;
                 }
             }

--- a/src/lang/me/pass/scalarize.mach
+++ b/src/lang/me/pass/scalarize.mach
@@ -35,6 +35,7 @@ use A: std.allocator;
 use O: std.types.option;
 use R: std.types.result;
 
+use mach.lang.intern;
 use mach.lang.me.ir;
 use mach.lang.me.ir.id;
 use mach.lang.me.ir.instruction;
@@ -81,23 +82,33 @@ rec VInfo {
     bits:  u32;
 }
 
-# whether a binary opcode is a lane-wise vector arithmetic / bitwise operator
+# whether a binary opcode is a lane-wise vector arithmetic / bitwise operator in the
+# increment-1 table
 #
-# The full arithmetic / bitwise binary family: whenever the result is vector-typed
-# the operator expands per lane. Illegal-on-vectors opcodes (integer `/` `%`) never
-# reach here from sema, but a per-lane expansion of them is still well-defined, so
-# the classifier stays total rather than partial.
+# The legal set (#1965, narrowed by #2030): float `+ - * /` (float `/` lowers to
+# OP_DIV_U), integer `+ -` at all widths, integer `*` on 16-bit lanes, and bitwise
+# `& | ^`. Integer `/` `%` and shifts are NOT in the table -- `is_disallowed_op`
+# rejects them loudly rather than silently expanding a form the language does not
+# admit.
 fun is_binary_op(k: instruction.InstrKind) bool {
     ret k == instruction.OP_ADD || k == instruction.OP_SUB || k == instruction.OP_MUL
-        || k == instruction.OP_DIV_S || k == instruction.OP_DIV_U
-        || k == instruction.OP_REM_S || k == instruction.OP_REM_U
-        || k == instruction.OP_AND || k == instruction.OP_OR || k == instruction.OP_XOR
-        || k == instruction.OP_SHL || k == instruction.OP_SHR_S || k == instruction.OP_SHR_U;
+        || k == instruction.OP_DIV_U
+        || k == instruction.OP_AND || k == instruction.OP_OR || k == instruction.OP_XOR;
 }
 
-# whether a unary opcode is a lane-wise vector operator (bitwise not, negate)
+# whether a unary opcode is a lane-wise vector operator (bitwise not)
 fun is_unary_op(k: instruction.InstrKind) bool {
-    ret k == instruction.OP_NOT || k == instruction.OP_NEG;
+    ret k == instruction.OP_NOT;
+}
+
+# whether an opcode is a vector operator OUTSIDE the increment-1 table: a shift
+# (per-lane variable shift is AVX2/NEON-only, deferred by #2030), integer `/` `%`,
+# or negate. A vector value carrying one is a defined loud error, never a silent
+# expansion of a form sema is meant to reject.
+fun is_disallowed_op(k: instruction.InstrKind) bool {
+    ret k == instruction.OP_SHL || k == instruction.OP_SHR_S || k == instruction.OP_SHR_U
+        || k == instruction.OP_DIV_S || k == instruction.OP_REM_S || k == instruction.OP_REM_U
+        || k == instruction.OP_NEG;
 }
 
 # whether an opcode is a lane-wise vector comparison (result is the same-shape mask)
@@ -105,6 +116,16 @@ fun is_compare_op(k: instruction.InstrKind) bool {
     ret k == instruction.OP_CMP_EQ || k == instruction.OP_CMP_NE
         || k == instruction.OP_CMP_LT_S || k == instruction.OP_CMP_LT_U
         || k == instruction.OP_CMP_LE_S || k == instruction.OP_CMP_LE_U;
+}
+
+# whether an instruction is a lane-wise vector OPERATOR (the unit the note counts and
+# the require lever names)
+#
+# Exactly the arithmetic / unary / comparison operators the pass expands per lane;
+# loads, stores, phis, and calls carry vectors but are not operators.
+fun is_operator(m: *ir.Module, inst: *instruction.Instruction) bool {
+    if (!ir_type.is_vector(?m.types, inst.ty)) { ret false; }
+    ret is_binary_op(inst.kind) || is_unary_op(inst.kind) || is_compare_op(inst.kind);
 }
 
 # whether an instruction produces a vector result that needs a backing stack slot
@@ -116,6 +137,58 @@ fun produces_vector(m: *ir.Module, inst: *instruction.Instruction) bool {
     if (!ir_type.is_vector(?m.types, inst.ty)) { ret false; }
     ret is_binary_op(inst.kind) || is_unary_op(inst.kind) || is_compare_op(inst.kind)
         || inst.kind == instruction.OP_LOAD;
+}
+
+# a single would-scalarize site: the operator's opcode and its containing function
+#
+# The shared detection currency between this child's build-time note and the profile
+# lever's (#2017) `require`-mode error, so both name the same operators by
+# construction rather than re-deriving them from two independent walks.
+pub rec ScalarizeSite {
+    fn_name: intern.StrId;
+    op:      instruction.InstrKind;
+}
+
+# count the lane-wise vector operators in `m` that would scalarize on a SIMD-incapable
+# target, filling `first` with the earliest one in program order
+#
+# Read-only: it inspects the IR without transforming it, so the profile lever can
+# call it under `require` (where the pass must not run) and this child calls it to set
+# the note count -- both over the identical operator set. Walks block-listed
+# instructions (the ones the pass would expand); phis / calls / loads / stores carry
+# vectors but are not operators and are not counted.
+# ---
+# m:     the module to inspect
+# first: filled with the first operator's { containing function name, opcode } when
+#        the returned count is > 0; left unset when the count is 0
+# ret:   the number of would-scalarize vector operators in the module
+pub fun detect(m: *ir.Module, first: *ScalarizeSite) u32 {
+    var count: u32 = 0;
+    var fi: u32 = 0;
+    for (fi < m.function_len) {
+        val fn: *ir.Function = ?m.functions[fi];
+        if ((fn.flags & ir.FN_FLAG_EXTERN) == 0) {
+            var bi: u32 = 0;
+            for (bi < fn.block_count) {
+                val blk: *ir.Block = ?fn.blocks[bi];
+                var ii: u32 = 0;
+                for (ii < blk.instr_count) {
+                    val inst: *instruction.Instruction = ?fn.instrs[blk.instructions[ii]::u32];
+                    if (is_operator(m, inst)) {
+                        if (count == 0) {
+                            first.fn_name = fn.name;
+                            first.op      = inst.kind;
+                        }
+                        count = count + 1;
+                    }
+                    ii = ii + 1;
+                }
+                bi = bi + 1;
+            }
+        }
+        fi = fi + 1;
+    }
+    ret count;
 }
 
 # read a vector type's element / lane / bit-width descriptor
@@ -423,11 +496,8 @@ fun retype_aux(c: *Ctx, inst: *instruction.Instruction) R.Result[bool, str] {
     ret R.ok[bool, str](true);
 }
 
-# legalize one function, returning the number of vector OPERATORS scalarized
-#
-# The operator tally counts arithmetic / unary / comparison expansions only; the
-# supporting loads, stores, and moves are not operators.
-fun scalarize_function(c: *Ctx, i8_ty: ir_type.IrTypeId) R.Result[u32, str] {
+# legalize one function: no IRT_VECTOR value or operand survives afterward
+fun scalarize_function(c: *Ctx, i8_ty: ir_type.IrTypeId) R.Result[bool, str] {
     val fn: *ir.Function = c.fn;
 
     # slot ids created in the pre-pass, prepended to the entry block in the fill pass.
@@ -435,7 +505,7 @@ fun scalarize_function(c: *Ctx, i8_ty: ir_type.IrTypeId) R.Result[u32, str] {
     var slot_len: u32 = 0;
     if (c.n > 0) {
         val rs: R.Result[*id.InstructionId, str] = A.allocate[id.InstructionId](c.m.alloc, c.n::usize);
-        if (R.is_err[*id.InstructionId, str](rs)) { ret R.err[u32, str](R.unwrap_err[*id.InstructionId, str](rs)); }
+        if (R.is_err[*id.InstructionId, str](rs)) { ret R.err[bool, str](R.unwrap_err[*id.InstructionId, str](rs)); }
         slots = R.unwrap_ok[*id.InstructionId, str](rs);
     }
 
@@ -445,13 +515,19 @@ fun scalarize_function(c: *Ctx, i8_ty: ir_type.IrTypeId) R.Result[u32, str] {
     var iid: u32 = 0;
     for (iid < c.n) {
         val inst: *instruction.Instruction = ?fn.instrs[iid];
+        # a vector operator outside the increment-1 table (a shift, integer `/` `%`,
+        # negate) is a defined loud error, never a silent expansion (#2030).
+        if (ir_type.is_vector(?c.m.types, inst.ty) && is_disallowed_op(inst.kind)) {
+            slots_free(c, slots);
+            ret R.err[bool, str]("scalarize: vector operator is not in the increment-1 table (shift / integer div-rem / negate)");
+        }
         if (inst.kind == instruction.OP_ALLOCA || inst.kind == instruction.OP_GEP) {
             val rr: R.Result[bool, str] = retype_aux(c, inst);
-            if (R.is_err[bool, str](rr)) { slots_free(c, slots); ret R.err[u32, str](R.unwrap_err[bool, str](rr)); }
+            if (R.is_err[bool, str](rr)) { slots_free(c, slots); ret rr; }
         } or (produces_vector(c.m, inst)) {
             val vty: ir_type.IrTypeId = inst.ty;
             val ms: R.Result[value.Value, str] = make_slot(c, vty, slots, ?slot_len);
-            if (R.is_err[value.Value, str](ms)) { slots_free(c, slots); ret R.err[u32, str](R.unwrap_err[value.Value, str](ms)); }
+            if (R.is_err[value.Value, str](ms)) { slots_free(c, slots); ret R.err[bool, str](R.unwrap_err[value.Value, str](ms)); }
             c.pval[iid]     = R.unwrap_ok[value.Value, str](ms);
             c.pval_set[iid] = true;
         } or (inst.kind == instruction.OP_PHI && ir_type.is_vector(?c.m.types, inst.ty)) {
@@ -468,18 +544,16 @@ fun scalarize_function(c: *Ctx, i8_ty: ir_type.IrTypeId) R.Result[u32, str] {
 
     # fill pass: rewrite each block's body, expanding operators and copying loads /
     # stores; rewrite phi value operands and the terminator in place.
-    var count: u32 = 0;
     var bi: u32 = 0;
     for (bi < fn.block_count) {
         val blk: *ir.Block = ?fn.blocks[bi];
-        val rf: R.Result[u32, str] = fill_block(c, blk, bi == 0, slots, slot_len, i8_ty, count);
-        if (R.is_err[u32, str](rf)) { slots_free(c, slots); ret rf; }
-        count = R.unwrap_ok[u32, str](rf);
+        val rf: R.Result[bool, str] = fill_block(c, blk, bi == 0, slots, slot_len, i8_ty);
+        if (R.is_err[bool, str](rf)) { slots_free(c, slots); ret rf; }
         bi = bi + 1;
     }
 
     slots_free(c, slots);
-    ret R.ok[u32, str](count);
+    ret R.ok[bool, str](true);
 }
 
 # free the pre-pass slot-id scratch array
@@ -489,10 +563,9 @@ fun slots_free(c: *Ctx, slots: *id.InstructionId) {
     }
 }
 
-# rebuild one block's body, expanding vector operators; returns the running operator tally
-fun fill_block(c: *Ctx, blk: *ir.Block, is_entry: bool, slots: *id.InstructionId, slot_len: u32, i8_ty: ir_type.IrTypeId, count_in: u32) R.Result[u32, str] {
+# rebuild one block's body, expanding vector operators into per-lane scalar sequences
+fun fill_block(c: *Ctx, blk: *ir.Block, is_entry: bool, slots: *id.InstructionId, slot_len: u32, i8_ty: ir_type.IrTypeId) R.Result[bool, str] {
     val fn: *ir.Function = c.fn;
-    var count: u32 = count_in;
 
     # snapshot the old body ids: the fill re-appends into a cleared body, and emits
     # fresh instructions between them, so the original order is preserved.
@@ -500,7 +573,7 @@ fun fill_block(c: *Ctx, blk: *ir.Block, is_entry: bool, slots: *id.InstructionId
     var old: *id.InstructionId = nil;
     if (old_len > 0) {
         val ro: R.Result[*id.InstructionId, str] = A.allocate[id.InstructionId](c.m.alloc, old_len::usize);
-        if (R.is_err[*id.InstructionId, str](ro)) { ret R.err[u32, str](R.unwrap_err[*id.InstructionId, str](ro)); }
+        if (R.is_err[*id.InstructionId, str](ro)) { ret R.err[bool, str](R.unwrap_err[*id.InstructionId, str](ro)); }
         old = R.unwrap_ok[*id.InstructionId, str](ro);
         var i: u32 = 0;
         for (i < old_len) { old[i] = blk.instructions[i]; i = i + 1; }
@@ -512,7 +585,7 @@ fun fill_block(c: *Ctx, blk: *ir.Block, is_entry: bool, slots: *id.InstructionId
         var s: u32 = 0;
         for (s < slot_len) {
             val ra: R.Result[bool, str] = ir.block_append_instr(c.m, blk, slots[s]);
-            if (R.is_err[bool, str](ra)) { body_free(c, old, old_len); ret R.err[u32, str](R.unwrap_err[bool, str](ra)); }
+            if (R.is_err[bool, str](ra)) { body_free(c, old, old_len); ret ra; }
             s = s + 1;
         }
     }
@@ -520,9 +593,8 @@ fun fill_block(c: *Ctx, blk: *ir.Block, is_entry: bool, slots: *id.InstructionId
     var oi: u32 = 0;
     for (oi < old_len) {
         val cur: id.InstructionId = old[oi];
-        val rr: R.Result[u32, str] = fill_one(c, blk, cur, i8_ty, count);
-        if (R.is_err[u32, str](rr)) { body_free(c, old, old_len); ret rr; }
-        count = R.unwrap_ok[u32, str](rr);
+        val rr: R.Result[bool, str] = fill_one(c, blk, cur, i8_ty);
+        if (R.is_err[bool, str](rr)) { body_free(c, old, old_len); ret rr; }
         oi = oi + 1;
     }
 
@@ -538,7 +610,7 @@ fun fill_block(c: *Ctx, blk: *ir.Block, is_entry: bool, slots: *id.InstructionId
     if (blk.terminator != id.INSTR_NIL) {
         rewrite_ops(c, ?fn.instrs[blk.terminator::u32]);
     }
-    ret R.ok[u32, str](count);
+    ret R.ok[bool, str](true);
 }
 
 # free the snapshot body-id array
@@ -550,9 +622,8 @@ fun body_free(c: *Ctx, old: *id.InstructionId, old_len: u32) {
 
 # process one original body instruction: expand a vector operator, copy a vector
 # load / store, or keep and operand-rewrite anything else
-fun fill_one(c: *Ctx, blk: *ir.Block, cur: id.InstructionId, i8_ty: ir_type.IrTypeId, count_in: u32) R.Result[u32, str] {
+fun fill_one(c: *Ctx, blk: *ir.Block, cur: id.InstructionId, i8_ty: ir_type.IrTypeId) R.Result[bool, str] {
     val fn: *ir.Function = c.fn;
-    var count: u32 = count_in;
 
     # copy out everything read from the instruction: emitting fresh instructions can
     # reallocate the pool and invalidate this pointer.
@@ -571,34 +642,26 @@ fun fill_one(c: *Ctx, blk: *ir.Block, cur: id.InstructionId, i8_ty: ir_type.IrTy
             val op0ty: ir_type.IrTypeId = ip.operands[0].ty;
             var opi: VInfo;
             val re: R.Result[bool, str] = vec_info(c.m, op0ty, ?opi);
-            if (R.is_err[bool, str](re)) { ret R.err[u32, str](R.unwrap_err[bool, str](re)); }
+            if (R.is_err[bool, str](re)) { ret re; }
             var mi: VInfo;
             val rm: R.Result[bool, str] = vec_info(c.m, ty, ?mi);
-            if (R.is_err[bool, str](rm)) { ret R.err[u32, str](R.unwrap_err[bool, str](rm)); }
-            val rx: R.Result[bool, str] = expand_compare(c, blk, kind, dst, op0, op1, opi, mi, i8_ty, loc);
-            if (R.is_err[bool, str](rx)) { ret R.err[u32, str](R.unwrap_err[bool, str](rx)); }
-            ret R.ok[u32, str](count + 1);
+            if (R.is_err[bool, str](rm)) { ret rm; }
+            ret expand_compare(c, blk, kind, dst, op0, op1, opi, mi, i8_ty, loc);
         }
         var vi: VInfo;
         val rv: R.Result[bool, str] = vec_info(c.m, ty, ?vi);
-        if (R.is_err[bool, str](rv)) { ret R.err[u32, str](R.unwrap_err[bool, str](rv)); }
+        if (R.is_err[bool, str](rv)) { ret rv; }
         if (kind == instruction.OP_LOAD) {
             val src: value.Value = resolve(c, ip.operands[0]);
-            val rc: R.Result[bool, str] = copy_vector(c, blk, dst, src, vi, loc);
-            if (R.is_err[bool, str](rc)) { ret R.err[u32, str](R.unwrap_err[bool, str](rc)); }
-            ret R.ok[u32, str](count);
+            ret copy_vector(c, blk, dst, src, vi, loc);
         }
         if (is_unary_op(kind)) {
             val a: value.Value = resolve(c, ip.operands[0]);
-            val ru: R.Result[bool, str] = expand_unary(c, blk, kind, dst, a, vi, loc);
-            if (R.is_err[bool, str](ru)) { ret R.err[u32, str](R.unwrap_err[bool, str](ru)); }
-            ret R.ok[u32, str](count + 1);
+            ret expand_unary(c, blk, kind, dst, a, vi, loc);
         }
         val a: value.Value = resolve(c, ip.operands[0]);
         val b: value.Value = resolve(c, ip.operands[1]);
-        val rb: R.Result[bool, str] = expand_binary(c, blk, kind, dst, a, b, vi, loc);
-        if (R.is_err[bool, str](rb)) { ret R.err[u32, str](R.unwrap_err[bool, str](rb)); }
-        ret R.ok[u32, str](count + 1);
+        ret expand_binary(c, blk, kind, dst, a, b, vi, loc);
     }
 
     # a whole-vector store: copy the source slot's 16 bytes to the destination.
@@ -608,33 +671,35 @@ fun fill_one(c: *Ctx, blk: *ir.Block, cur: id.InstructionId, i8_ty: ir_type.IrTy
         val vty:  ir_type.IrTypeId = ip.operands[0].ty;
         var vi: VInfo;
         val rv: R.Result[bool, str] = vec_info(c.m, vty, ?vi);
-        if (R.is_err[bool, str](rv)) { ret R.err[u32, str](R.unwrap_err[bool, str](rv)); }
-        val rc: R.Result[bool, str] = copy_vector(c, blk, dstp, srcv, vi, loc);
-        if (R.is_err[bool, str](rc)) { ret R.err[u32, str](R.unwrap_err[bool, str](rc)); }
-        ret R.ok[u32, str](count);
+        if (R.is_err[bool, str](rv)) { ret rv; }
+        ret copy_vector(c, blk, dstp, srcv, vi, loc);
     }
 
     # everything else is kept: rewrite its operands to the pointer representation and
     # re-link it into the rebuilt body in its original position.
     rewrite_ops(c, ?fn.instrs[cur::u32]);
-    val rl: R.Result[bool, str] = ir.block_append_instr(c.m, blk, cur);
-    if (R.is_err[bool, str](rl)) { ret R.err[u32, str](R.unwrap_err[bool, str](rl)); }
-    ret R.ok[u32, str](count);
+    ret ir.block_append_instr(c.m, blk, cur);
 }
 
 # scalarize every lane-wise vector value and operator in `m` for a SIMD-incapable
 # target; a no-op on a capable target (`has_v128 == true`)
 #
-# Records the number of vector operators scalarized (summed across the module's
-# functions) on `m.vector_ops_scalarized`, which the build path reads to surface the
-# one-shot scalarization note. This is the shared detection seam the profile lever
-# (#2017) turns into a `require`-mode error.
+# Records the number of vector operators scalarized on `m.vector_ops_scalarized` from
+# the shared `detect` walk (the same operator set the pass expands), which the build
+# path reads to surface the one-shot scalarization note. `detect` is the shared seam
+# the profile lever (#2017) turns into a `require`-mode error, so the note and that
+# error name the identical operators by construction.
 # ---
 # m:   the module to legalize in place
 # tgt: the target, consulted for the SIMD capability fact
 # ret: ok(true) on success, or an allocation / internal error
 pub fun run(m: *ir.Module, tgt: *target.Target) R.Result[bool, str] {
     if (tgt.model.has_v128) { ret R.ok[bool, str](true); }
+
+    # record the operator count for the note from the same read-only walk the require
+    # lever consumes, before any expansion mutates the IR.
+    var first: ScalarizeSite;
+    m.vector_ops_scalarized = detect(m, ?first);
 
     val rp: R.Result[ir_type.IrTypeId, str] = ir_type.intern_ptr(?m.types);
     if (R.is_err[ir_type.IrTypeId, str](rp)) { ret R.err[bool, str](R.unwrap_err[ir_type.IrTypeId, str](rp)); }
@@ -653,7 +718,6 @@ pub fun run(m: *ir.Module, tgt: *target.Target) R.Result[bool, str] {
     if (R.is_err[ir_type.IrTypeId, str](r8)) { ret R.err[bool, str](R.unwrap_err[ir_type.IrTypeId, str](r8)); }
     val i8_ty: ir_type.IrTypeId = R.unwrap_ok[ir_type.IrTypeId, str](r8);
 
-    var total: u32 = 0;
     var fi: u32 = 0;
     for (fi < m.function_len) {
         val fn: *ir.Function = ?m.functions[fi];
@@ -694,15 +758,13 @@ pub fun run(m: *ir.Module, tgt: *target.Target) R.Result[bool, str] {
                 }
             }
 
-            val rf: R.Result[u32, str] = scalarize_function(?c, i8_ty);
+            val rf: R.Result[bool, str] = scalarize_function(?c, i8_ty);
             ctx_free(m, ?c);
-            if (R.is_err[u32, str](rf)) { ret R.err[bool, str](R.unwrap_err[u32, str](rf)); }
-            total = total + R.unwrap_ok[u32, str](rf);
+            if (R.is_err[bool, str](rf)) { ret rf; }
         }
         fi = fi + 1;
     }
 
-    m.vector_ops_scalarized = total;
     ret R.ok[bool, str](true);
 }
 

--- a/src/lang/me/pipeline.mach
+++ b/src/lang/me/pipeline.mach
@@ -35,6 +35,7 @@ use mach.lang.me.pass.cse;
 use mach.lang.me.pass.dce;
 use mach.lang.me.pass.inline;
 use mach.lang.me.pass.mem2reg;
+use mach.lang.me.pass.scalarize;
 use mach.lang.source;
 use mach.lang.target;
 
@@ -155,6 +156,16 @@ pub fun run(m: *ir.Module, tgt: *target.Target, level: OptLevel, verify_ir: bool
         val res_verify_dce2: R.Result[bool, str] = verify_stage(m, true, verify_ir);
         if (R.is_err[bool, str](res_verify_dce2)) { ret res_verify_dce2; }
     }
+
+    # target-conditional vector scalarization: on a SIMD-incapable target every
+    # IRT_VECTOR value and lane-wise operator is lowered to a defined per-lane scalar
+    # form over 16-byte stack slots, so no vector survives to MIR selection (#2016).
+    # a no-op on a capable target. runs last, after all optimization, so it legalizes
+    # the final IR the back end consumes; the verifier then re-checks the result.
+    val res_scalarize: R.Result[bool, str] = scalarize.run(m, tgt);
+    if (R.is_err[bool, str](res_scalarize)) { ret res_scalarize; }
+    val res_verify_scalarize: R.Result[bool, str] = verify_stage(m, true, verify_ir);
+    if (R.is_err[bool, str](res_verify_scalarize)) { ret res_verify_scalarize; }
 
     # exit verification: full invariant check before the backend takes over.
     ret run_verify(m, true, false);

--- a/src/lang/target/abi/lp64.mach
+++ b/src/lang/target/abi/lp64.mach
@@ -205,8 +205,10 @@ pub fun classify(size: u64, align: u64, is_float: bool, fp_eightbytes: u8,
 # is_float:      true if the argument is a scalar float
 # fp_eightbytes: per-eightbyte SSE mask (unused -- lp64d routes scalars by is_float)
 # is_aggregate:  true if the argument is an aggregate
-# is_vector:     true for a 128-bit SIMD vector (#1965); neutral, unread here (the
-#                lp64 memory-class vector branch is #2016)
+# is_vector:     true for a 128-bit SIMD vector (#1965); rv64gc has no vector unit,
+#                so a vector is the memory (by-reference) class -- the caller copies
+#                it to memory and passes the pointer, the same path a >16-byte
+#                aggregate takes (#2016)
 # gp_used:       integer registers already consumed
 # fp_used:       float registers already consumed
 # hfa_members:   homogeneous-float member count; 1 or 2 selects the lp64d hard-float
@@ -220,6 +222,16 @@ pub fun classify_arg(index: i32, size: u64, align: u64,
                      is_float: bool, fp_eightbytes: u8, is_aggregate: bool, is_vector: bool,
                      gp_used: i32, fp_used: i32, hfa_members: u8, hfa_elem: u8,
                      agg: abi.AggLayout) abi.ParamSlot {
+    # a 128-bit vector has no register file on rv64gc: pass it by hidden reference,
+    # the pointer in the next integer register, or on the stack once the integer bank
+    # is exhausted -- the same memory class a >16-byte aggregate takes (#2016).
+    if (is_vector) {
+        if (gp_used < GP_PARAM_COUNT) {
+            ret abi.make_slot(abi.CLASS_BYREF, gp_param_reg(gp_used), -1, 0, 8);
+        }
+        ret abi.make_slot(abi.CLASS_STACK_BYREF, -1, -1, 0, 8);
+    }
+
     if (is_aggregate && size > MAX_REG_RET) {
         if (gp_used < GP_PARAM_COUNT) {
             ret abi.make_slot(abi.CLASS_BYREF, gp_param_reg(gp_used), -1, 0, 8);
@@ -319,8 +331,10 @@ pub fun classify_arg(index: i32, size: u64, align: u64,
 # is_float:      true if the value is a scalar float
 # fp_eightbytes: per-eightbyte SSE mask (unused -- lp64d routes scalars by is_float)
 # is_aggregate:  true if the value is an aggregate
-# is_vector:     true for a 128-bit SIMD vector (#1965); neutral, unread here (the
-#                lp64 memory-class vector-return branch is #2016)
+# is_vector:     true for a 128-bit SIMD vector (#1965); rv64gc has no vector unit,
+#                so a vector returns through a hidden sret pointer -- the caller passes
+#                the result-storage address in a0 and the callee returns it there,
+#                the same path a >16-byte aggregate takes (#2016)
 # hfa_members:   homogeneous-float member count; 1 or 2 selects the lp64d hard-float
 #                flattening (0 or > 2 falls to the integer convention)
 # hfa_elem:      homogeneous-float fundamental member width (the per-fa-register width)
@@ -333,6 +347,11 @@ pub fun classify_return(size: u64, align: u64,
                         hfa_members: u8, hfa_elem: u8, agg: abi.AggLayout) abi.ParamSlot {
     if (size == 0) {
         ret abi.make_slot(abi.CLASS_GP, -1, -1, 0, 0);
+    }
+
+    # a 128-bit vector returns by hidden reference on rv64gc (no vector register file).
+    if (is_vector) {
+        ret abi.make_slot(abi.CLASS_SRET, REG_A0, -1, 0, 8);
     }
 
     if (is_aggregate && size > MAX_REG_RET) {


### PR DESCRIPTION
Implements the rv64gc backend instance for the portable-vector model (epic #1965, tier 1): a target-conditional middle-end IR legalization pass that lowers every `IRT_VECTOR` value and lane-wise operator to a defined per-lane scalar form on a SIMD-incapable target, the memory-class lp64 ABI wiring, the build-time scalarization note, and the shared detection seam the profile lever (#2017) builds on.

Closes #2016.

## Design

- **Scalarize pass** (`src/lang/me/pass/scalarize.mach`), gated on `MachineModel.has_v128 == false`, runs as the final middle-end stage (after mem2reg/constfold/dce, before codegen). Every vector value becomes a pointer to a 16-byte `[lanes]elem` stack slot — exactly how an aggregate flows by address — and each lane-wise operator expands to a fixed, bounded per-lane scalar sequence (N independent computations, never reordered or fused across lanes), so results are lane-exact-identical to the packed backends including compare→all-ones/all-zeros masks and IEEE-754 edge cases. No `IRT_VECTOR` survives to MIR selection, so the per-target isel guard never fires on rv64 (it stays a loud backstop). Vector params/returns/calls/phis are de-vectorized to pointers; the function signature keeps the vector type for ABI classification. A vector operator outside the increment-1 table (shift / integer div-rem / negate, per #2030) is a defined loud error.
- **Memory-class lp64 ABI**: a vector arg/return routes to the by-reference class (`CLASS_BYREF`/`CLASS_STACK_BYREF`/`CLASS_SRET`) — the same path a >16-byte aggregate takes. The abi.mach driver reads a call's vector return type from the callee `IRT_FN` (so a scalarized `ptr`-typed call result still classifies as sret) and allocates caller-owned result storage; a vector parameter is retyped to `ptr` so its vreg lands in the GP bank. Restricted to vector returns, so non-vector codegen is byte-identical.
- **Build-time note + detection seam**: `scalarize.detect(m, *ScalarizeSite)` (read-only; counts would-scalarize operators and names the first) is the shared currency; `run()` sets `m.vector_ops_scalarized` from it, and the build path surfaces `note: scalarized N vector operation(s) (target has no SIMD; simd = "scalarize")` once on stderr when N > 0. Absent for capable targets / vector-free builds. #2017's `require` gate consumes the same `detect()` (contract recorded on #2016/#2017).

## Verification

- **Full unit suite**: 590 passed via freshly built HEAD (dev baseline 589 + 1 new arch-independent `detect()` unit test).
- **x86_64 byte-identity**: object trees identical to a dev-baseline build for a non-vector program; x86_64 self-host fixpoint byte-identical (gen2 == gen3).
- **-g additivity**: compiler release self-additive (5 PT_LOAD segments identical); the vector rv64 binary is additive at both debug and release (5 PT_LOAD segments identical each).
- **`llvm-dwarfdump --verify`**: clean on all 21 dbg fixture builds (x86_64/aarch64/riscv64) and on the vector rv64 `-g` binary.
- **int suite**: green on linux and the riscv64 leg under qemu (including `1852-rv64-self-host`, the rv64 self-host reproduction). All PR CI checks pass.

### Runtime lane-exactness on rv64gc under qemu

Built with the HEAD compiler for `linux-riscv64` and run under `qemu-riscv64`. Emitting the program produces exactly `note: scalarized 18 vector operations (target has no SIMD; simd = "scalarize")` on stderr (one per lane-wise operator below; the note count == `detect()`'s count). The `fadd/fsub/fmul/fdiv` calls also exercise the memory-class ABI (byref vector params, sret vector returns). A `-1` result is the all-ones mask lane, `0` the all-zeros lane.

| operator | shape | lane observable | expected | actual |
|---|---|---|---|---|
| `+` | f32x4 | `(a+b)[0]*10`, `(a+b)[3]*10` | 90, 60 | 90, 60 |
| `-` | f32x4 | `(a-b)[0]*10` | -70 | -70 |
| `*` | f32x4 | `(a*b)[1]*10` | 120 | 120 |
| `/` | f32x4 | `(b/a)[2]*10` | 13 | 13 |
| `+` | i32x4 | `(ia+ib)[2]` | 33 | 33 |
| `-` | i32x4 | `(ia-ib)[3]` | 36 | 36 |
| `*` | i16x8 | `(ha*hb)[7]` | 27 | 27 |
| `&` | u32x4 | `(ba&bb)[0]` | 8 | 8 |
| `\|` | u32x4 | `(ba\|bb)[1]` | 14 | 14 |
| `^` | u32x4 | `(ba^bb)[2]` | 240 | 240 |
| `~` | u32x4 | `(~ba)[3]` | -2 | -2 |
| `<` | i32x4→mask | `(ca<cb)[0]`, `(ca<cb)[1]` | -1, 0 | -1, 0 |
| `==` | i32x4→mask | `(ca==cb)[1]` | -1 | -1 |
| `>=` | i32x4→mask | `(ca>=cb)[3]` | -1 | -1 |
| `!=` | i32x4→mask | `(ca!=cb)[0]` | -1 | -1 |
| `>` | i32x4→mask | `(ca>cb)[3]` | -1 | -1 |
| `<=` | i32x4→mask | `(ca<=cb)[1]` | -1 | -1 |
| `<=` | f32x4→mask (ordered) | `(fa<=fb)[0]`, `(fa<=fb)[2]` | -1, 0 | -1, 0 |

Reproduce (the standalone program is the exact per-op suite; source below):

```
mach build . --target linux-riscv64 -o vt      # emits the scalarization note on stderr
qemu-riscv64 ./vt                              # prints the observables above
```

<details><summary>standalone program</summary>

```mach
use std.runtime;
use std.types.size.usize;
use p: std.print;

fun fadd(a: f32x4, b: f32x4) f32x4 { ret a + b; }
fun fsub(a: f32x4, b: f32x4) f32x4 { ret a - b; }
fun fmul(a: f32x4, b: f32x4) f32x4 { ret a * b; }
fun fdiv(a: f32x4, b: f32x4) f32x4 { ret a / b; }

#[symbol("main")]
fun main(argc: usize, argv: **u8) i64 {
    val a: f32x4 = f32x4{1.0, 2.0, 3.0, 4.0};
    val b: f32x4 = f32x4{8.0, 6.0, 4.0, 2.0};
    val s: f32x4 = fadd(a, b);   p.printlnf("fadd={}",  (s[0]*10.0)::i64); p.printlnf("fadd3={}", (s[3]*10.0)::i64);
    val d: f32x4 = fsub(a, b);   p.printlnf("fsub={}",  (d[0]*10.0)::i64);
    val m: f32x4 = fmul(a, b);   p.printlnf("fmul={}",  (m[1]*10.0)::i64);
    val q: f32x4 = fdiv(b, a);   p.printlnf("fdiv={}",  (q[2]*10.0)::i64);
    val ia: i32x4 = i32x4{10, 20, 30, 40};
    val ib: i32x4 = i32x4{1, 2, 3, 4};
    val isum: i32x4 = ia + ib;   p.printlnf("iadd={}", isum[2]::i64);
    val idif: i32x4 = ia - ib;   p.printlnf("isub={}", idif[3]::i64);
    val ha: i16x8 = i16x8{2, 3, 4, 5, 6, 7, 8, 9};
    val hb: i16x8 = i16x8{3, 3, 3, 3, 3, 3, 3, 3};
    val hp: i16x8 = ha * hb;     p.printlnf("imul={}", hp[7]::i64);
    val ba: u32x4 = u32x4{12, 10, 255, 1};
    val bb: u32x4 = u32x4{10, 6, 15, 3};
    val vand: u32x4 = ba & bb;   p.printlnf("and={}", vand[0]::i64);
    val vor:  u32x4 = ba | bb;   p.printlnf("or={}",  vor[1]::i64);
    val vxor: u32x4 = ba ^ bb;   p.printlnf("xor={}", vxor[2]::i64);
    val vnot: u32x4 = ~ba;       p.printlnf("not={}", vnot[3]::i32::i64);
    val ca: i32x4 = i32x4{1, 5, 3, 9};
    val cb: i32x4 = i32x4{4, 5, 2, 1};
    val vlt: u32x4 = ca < cb;    p.printlnf("lt0={}", vlt[0]::i32::i64); p.printlnf("lt1={}", vlt[1]::i32::i64);
    val veq: u32x4 = ca == cb;   p.printlnf("eq={}",  veq[1]::i32::i64);
    val vge: u32x4 = ca >= cb;   p.printlnf("ge={}",  vge[3]::i32::i64);
    val vne: u32x4 = ca != cb;   p.printlnf("ne={}",  vne[0]::i32::i64);
    val vgt: u32x4 = ca > cb;    p.printlnf("gt={}",  vgt[3]::i32::i64);
    val vle: u32x4 = ca <= cb;   p.printlnf("le={}",  vle[1]::i32::i64);
    val fa: f32x4 = f32x4{1.0, 2.0, 3.0, 4.0};
    val fb: f32x4 = f32x4{1.0, 5.0, 1.0, 4.0};
    val vfle: u32x4 = fa <= fb;  p.printlnf("fle0={}", vfle[0]::i32::i64); p.printlnf("fle2={}", vfle[2]::i32::i64);
    ret 0;
}
```
</details>

### Coverage boundary (honest)

Permanent CI execution of scalarized vector code on rv64 is **pending an owner decision on a single `int/surface` vectors case** (adding integration fixtures is owner-gated in this repo). `mach test` cannot run under qemu-user — the rv64 compiler returns `error: invalid argument` because the test dispatcher's per-test fork/exec is not emulable, which is why the int harness runs int *cases* (not `mach test`) for rv64 — so committed vector `test` blocks cannot execute on rv64 in CI. Until that case lands, this PR's runtime lane-exactness is proven by the reproducible run above and guarded structurally by the IR verifier's vector shape rules, the loud isel backstop (any surviving `IRT_VECTOR` at codegen is a defined error), and the `detect()` unit test.

The **shared per-op runtime `test` suite intentionally rides #2014/#2015**: ungated vector `test` blocks would break the x86_64 suite until a capable backend lands (the isel guard fires today), so the capable-backend children add the ungated suite that runs on x86_64/aarch64 (and rv64 once a lane exists).
