### PR TITLE
feat(codegen): MIR vector lane descriptor (vec_lane) (#1965)

### DIFF
--- a/src/lang/be/codegen/mir.mach
+++ b/src/lang/be/codegen/mir.mach
@@ -378,6 +378,47 @@ pub rec MirInstr {
     dbg_bindings:      *MirDbgBinding;
     dbg_binding_count: u32;
     inline_site:       u32;
+
+    # the 128-bit vector lane descriptor for a vector-typed op (#1965), or 0 for a
+    # non-vector instruction. `width` alone is 16 for every vector, so it cannot
+    # distinguish the ten shapes; this carries the lane element kind + byte-width the
+    # backend selectors need to pick a NEON arrangement / SSE packed form. built in
+    # the shared MIR lowering from the operand's IRT_VECTOR type (`vec_lane_make`),
+    # read target-locally by each backend's isel. stamped at the push_instr
+    # chokepoint like `loc`, so non-vector code is unaffected.
+    vec_lane:          u8;
+}
+
+# the vector-lane element kinds packed into `MirInstr.vec_lane`'s high nibble.
+# VEC_LANE_NONE (0) means the instruction is not vector-typed. signedness is NOT a
+# lane-descriptor field: it rides the consuming opcode (a signed vs unsigned
+# compare, an SMOV vs UMOV lane read), consistent with IRT_INT holding no
+# signedness of its own
+pub val VEC_LANE_NONE:  u8 = 0;
+pub val VEC_LANE_FLOAT: u8 = 1;  # float lanes  (f32x4 / f64x2)
+pub val VEC_LANE_INT:   u8 = 2;  # integer lanes (i*/u*; the opcode carries signedness)
+
+# pack a lane descriptor: the element kind in the high nibble, the element
+# byte-width (1/2/4/8) in the low nibble. the lane count is implied - every seeded
+# vector is 128-bit, so it is 16 / element-bytes
+pub fun vec_lane_make(kind: u8, elem_bytes: u8) u8 {
+    ret ((kind & 0xF) << 4) | (elem_bytes & 0xF);
+}
+
+# the element kind of a lane descriptor (VEC_LANE_NONE / FLOAT / INT)
+pub fun vec_lane_kind(v: u8) u8 { ret (v >> 4) & 0xF; }
+
+# the element byte-width of a lane descriptor (1/2/4/8), or 0 for a non-vector
+pub fun vec_lane_elem_bytes(v: u8) u8 { ret v & 0xF; }
+
+# whether a lane descriptor names a vector (any nonzero descriptor)
+pub fun vec_lane_is_vector(v: u8) bool { ret v != 0; }
+
+# the lane count of a vector descriptor (16 / element-bytes), or 0 for a non-vector
+pub fun vec_lane_count(v: u8) u32 {
+    val eb: u8 = vec_lane_elem_bytes(v);
+    if (eb == 0) { ret 0; }
+    ret 16 / eb::u32;
 }
 
 # one `-g` source-variable binding attached to a MirInstr: the OP_DBG_VALUE identity
@@ -858,4 +899,36 @@ fun dnit_block(a: *A.Allocator, mb: *MirBlock) {
     if (mb.preds != nil && mb.pred_cap > 0) {
         A.deallocate[u32](a, mb.preds, mb.pred_cap::usize);
     }
+}
+
+# the vec_lane descriptor packs the element kind (high nibble) and byte-width (low
+# nibble), with 0 the non-vector sentinel and the lane count implied by 16 / bytes.
+test "mach.lang.be.codegen.mir.vec_lane:pack_unpack" {
+    # the non-vector sentinel.
+    if (vec_lane_is_vector(VEC_LANE_NONE))  { ret 1; }
+    if (vec_lane_count(VEC_LANE_NONE) != 0) { ret 1; }
+
+    # f32x4: float lanes, 4-byte element, 4 lanes.
+    val f4: u8 = vec_lane_make(VEC_LANE_FLOAT, 4);
+    if (!vec_lane_is_vector(f4))             { ret 1; }
+    if (vec_lane_kind(f4) != VEC_LANE_FLOAT) { ret 1; }
+    if (vec_lane_elem_bytes(f4) != 4)        { ret 1; }
+    if (vec_lane_count(f4) != 4)             { ret 1; }
+
+    # f64x2: float lanes, 8-byte element, 2 lanes.
+    val f8: u8 = vec_lane_make(VEC_LANE_FLOAT, 8);
+    if (vec_lane_kind(f8) != VEC_LANE_FLOAT) { ret 1; }
+    if (vec_lane_count(f8) != 2)             { ret 1; }
+
+    # every integer element width recovers its lane count (i8x16 / i16x8 / i32x4 / i64x2).
+    if (vec_lane_count(vec_lane_make(VEC_LANE_INT, 1)) != 16) { ret 1; }
+    if (vec_lane_count(vec_lane_make(VEC_LANE_INT, 2)) != 8)  { ret 1; }
+    if (vec_lane_count(vec_lane_make(VEC_LANE_INT, 4)) != 4)  { ret 1; }
+    if (vec_lane_count(vec_lane_make(VEC_LANE_INT, 8)) != 2)  { ret 1; }
+
+    # kind and byte-width are independent nibbles.
+    val i2: u8 = vec_lane_make(VEC_LANE_INT, 2);
+    if (vec_lane_kind(i2) != VEC_LANE_INT) { ret 1; }
+    if (vec_lane_elem_bytes(i2) != 2)      { ret 1; }
+    ret 0;
 }

--- a/src/lang/be/codegen/mir/context.mach
+++ b/src/lang/be/codegen/mir/context.mach
@@ -97,6 +97,13 @@ pub rec LowerCtx {
     # lowering loop alongside cur_loc; 0 outside one.
     cur_inline_site: u32;
 
+    # the 128-bit vector lane descriptor of the IR instruction currently being
+    # lowered (#1965), stamped onto every MirInstr `push_instr` appends so a backend
+    # selector can read the lane element kind + width a vector op needs. set per IR
+    # instruction by the lowering loop alongside cur_loc; VEC_LANE_NONE (0) outside
+    # one and for every non-vector instruction, so non-vector code is unaffected.
+    cur_vec_lane: u8;
+
     # `-g`-only source-variable bindings awaiting attachment: an OP_DBG_VALUE records
     # its (iid, vreg) here, and the next `push_instr` attaches the whole list (in order)
     # to the instruction at whose PC the variables become live, then clears it. any
@@ -320,6 +327,44 @@ pub fun value_is_vector(ctx: *LowerCtx, ty: ir_type.IrTypeId) bool {
     ret ir_type.is_vector(ctx.types, ty);
 }
 
+# the vec_lane MIR descriptor for an IR value type (#1965)
+#
+# VEC_LANE_NONE for a non-vector; otherwise the lane element kind (float vs
+# integer) and byte-width packed for the backend selectors. Signedness is not part
+# of the shape - it rides the consuming opcode.
+# ---
+# ctx: the lowering context
+# ty:  the IR value type
+# ret: the packed vec_lane descriptor
+pub fun vec_lane_for_type(ctx: *LowerCtx, ty: ir_type.IrTypeId) u8 {
+    var is_float:   bool = false;
+    var elem_bytes: u8   = 0;
+    if (!ir_type.vector_lane(ctx.types, ty, ?is_float, ?elem_bytes)) { ret mir.VEC_LANE_NONE; }
+    var kind: u8 = mir.VEC_LANE_INT;
+    if (is_float) { kind = mir.VEC_LANE_FLOAT; }
+    ret mir.vec_lane_make(kind, elem_bytes);
+}
+
+# the vec_lane descriptor for a whole IR instruction (#1965)
+#
+# The lane shape of its first vector-typed operand - a comparison's operand carries
+# the element kind/width its unsigned-mask result does not - falling back to a
+# vector result (a load or literal has no vector operand). VEC_LANE_NONE when
+# nothing vector-typed flows through, which is every non-vector instruction.
+# ---
+# ctx:  the lowering context
+# inst: the IR instruction being lowered
+# ret:  the packed vec_lane descriptor to stamp on its MIR instructions
+pub fun compute_vec_lane(ctx: *LowerCtx, inst: *instruction.Instruction) u8 {
+    var i: u32 = 0;
+    for (i < inst.operand_count) {
+        val d: u8 = vec_lane_for_type(ctx, inst.operands[i].ty);
+        if (mir.vec_lane_is_vector(d)) { ret d; }
+        i = i + 1;
+    }
+    ret vec_lane_for_type(ctx, inst.ty);
+}
+
 # the lowered function's IR return type, read from its function type (IRT_FN)
 #
 # Returns IRT_NIL when the signature is unavailable or void so the param
@@ -534,6 +579,10 @@ pub fun push_instr(ctx: *LowerCtx, mb: *mir.MirBlock, mi: mir.MirInstr) R.Result
     # the inline instance rides beside loc, stamped at the same chokepoint for the same
     # non-zero-init reason, so every lowered instruction carries its inlined-from origin.
     ni.inline_site = ctx.cur_inline_site;
+    # the vector lane descriptor rides beside loc for the same non-zero-init reason,
+    # so every lowered instruction carries the lane shape of the IR op it came from
+    # (VEC_LANE_NONE for non-vector code, leaving those instructions unaffected).
+    ni.vec_lane = ctx.cur_vec_lane;
     # the dbg-binding list defaults empty here for the same reason (callers build
     # instructions field-by-field and never set it); any pending -g binding then
     # attaches to this instruction, the next one after its OP_DBG_VALUE.

--- a/src/lang/be/codegen/mir/lower.mach
+++ b/src/lang/be/codegen/mir/lower.mach
@@ -152,6 +152,7 @@ fun lower_function(tgt: *target.Target, m: *ir.Module, fn: *ir.Function, interne
     ctx.sret_vreg      = mir.MIR_VREG_NIL;
     ctx.cur_loc        = source.loc_nil();
     ctx.cur_inline_site = 0;
+    ctx.cur_vec_lane   = mir.VEC_LANE_NONE;
     ctx.pending        = nil;
     ctx.pending_count  = 0;
     ctx.pending_cap    = 0;
@@ -613,6 +614,10 @@ fun insert_mov_before_terminator(ctx: *lctx.LowerCtx, mb: *mir.MirBlock, dst: mi
     mi.inline_site       = ctx.cur_inline_site;
     mi.dbg_bindings      = nil;
     mi.dbg_binding_count = 0;
+    # a phi-elimination move is a full-width register copy, lane-agnostic even for a
+    # vector phi, so it carries no lane descriptor (and struct locals are not
+    # zero-initialized, so it is set explicitly like the other push_instr invariants).
+    mi.vec_lane          = mir.VEC_LANE_NONE;
 
     # grow by one, shift the terminator right, and drop the move into its place.
     val gr: R.Result[bool, str] = lctx.grow_instr(ctx, mb);
@@ -829,6 +834,10 @@ fun lower_instr(ctx: *lctx.LowerCtx, fn: *ir.Function, mb: *mir.MirBlock, iid: i
     # and its inline instance, so lowered instructions carry which inlined expansion
     # they came from (0 for the function's own body).
     ctx.cur_inline_site = ir.instr_inline_site_of(fn, iid);
+    # and its 128-bit vector lane shape, so a backend selector reads the element kind
+    # + width off each lowered MirInstr. VEC_LANE_NONE for every non-vector op, so
+    # this is inert until a backend lifts its vector guard below.
+    ctx.cur_vec_lane = lctx.compute_vec_lane(ctx, inst);
 
     # a 128-bit vector reaching MIR lowering has no backend selection yet (#1965):
     # the backend children (#2014 SSE2, #2015 NEON, #2016 rv64 scalarize) wire real

--- a/src/lang/me/ir/type.mach
+++ b/src/lang/me/ir/type.mach
@@ -271,6 +271,32 @@ pub fun is_vector(t: *IrTypeTable, id: IrTypeId) bool {
     ret O.unwrap[*IrType](opt_get).kind == IRT_VECTOR;
 }
 
+# the lane element kind and byte-width of an IRT_VECTOR type (#1965)
+#
+# Reports whether `id` is a vector and, if so, writes whether its lanes are float
+# (else integer) and the element byte-width. The element is always a scalar
+# IRT_INT / IRT_FLOAT; signedness lives on the consuming instruction, not the type,
+# so it is not reported here. Feeds the backend's `vec_lane` MIR descriptor.
+# ---
+# t:              the table
+# id:             the IrTypeId to inspect
+# out_is_float:   receives true when the lanes are float, false for integer lanes
+# out_elem_bytes: receives the element byte-width (1/2/4/8)
+# ret:            true when `id` is a vector (the out params are written), else false
+pub fun vector_lane(t: *IrTypeTable, id: IrTypeId, out_is_float: *bool, out_elem_bytes: *u8) bool {
+    val opt_get: O.Option[*IrType] = get(t, id);
+    if (O.is_none[*IrType](opt_get)) { ret false; }
+    val ir: *IrType = O.unwrap[*IrType](opt_get);
+    if (ir.kind != IRT_VECTOR) { ret false; }
+
+    val opt_el: O.Option[*IrType] = get(t, ir.data.vector_.element);
+    if (O.is_none[*IrType](opt_el)) { ret false; }
+    val el: *IrType = O.unwrap[*IrType](opt_el);
+    @out_is_float   = (el.kind == IRT_FLOAT);
+    @out_elem_bytes = bits_to_bytes(el.data.bits)::u8;
+    ret true;
+}
+
 # intern the void type
 # ---
 # t:   the table


### PR DESCRIPTION
## #1965 — MIR vector lane descriptor (`vec_lane`)

The shared substrate the parallel SIMD backend children (#2014 SSE2, #2015 NEON)
both need: a per-`MirInstr` `vec_lane: u8` carrying the 128-bit vector lane element
kind + byte-width. `width` alone is 16 for every vector, so it can't distinguish
the ten shapes; `vec_lane` gives the backend selectors the lane element the packed
form / NEON arrangement is chosen from. Standalone, zero-behavior, lands ahead of
its consumers (the shared-substrate-before-parallel-consumers pattern of the gate).
`Part of #1965.`

### What it does
- **`mir.mach`:** the `vec_lane` field + format helpers (`vec_lane_make` /
  `_kind` / `_elem_bytes` / `_is_vector` / `_count`) and the `VEC_LANE_NONE/FLOAT/INT`
  kinds. High nibble = element kind, low nibble = element byte-width; 0 = non-vector;
  lane count implied (`16 / bytes`). Unit-tested.
- **`ir/type.mach`:** `vector_lane` — reads the element kind + byte-width off an
  `IRT_VECTOR` payload.
- **`mir/context.mach` / `mir/lower.mach`:** `compute_vec_lane` (the first
  vector-typed operand's shape, else a vector result) populates `ctx.cur_vec_lane`
  per IR instruction, stamped onto every MirInstr at the `push_instr` chokepoint
  like `loc`/`inline_site`, and set explicitly in the phi-elimination splice.

### Design note (per the ruling's "extend and flag" latitude)
The ruling named a "float/**signed/unsigned**" kind tag. But `IRT_INT` carries no
signedness ("signedness is on the consuming instruction, never on the type"), so a
lane descriptor derived from the IR type can only be `{none, float, int}`. That is
sufficient: the ops that need signedness already carry it on the **opcode** — a
vector compare lowers to `OP_CMP_*_S`/`_U` (verified in `#2013`'s
`lower_vector_compare`), and an integer lane read selects `SMOV`/`UMOV` from the
extract op. So `vec_lane` is the shape (kind + width); signedness stays
opcode-carried, consistent with the scalar path. If a consumer later needs the
descriptor on `MirOperand` (an extract/insert edge), that extends cleanly.

### Bars — all green
- **Zero behavior for non-vector code:** the field is stamped but unconsumed (every
  backend guard is still in place), so emitted output is unchanged.
- Self-host **fixpoint** byte-identical (gen2 == gen1, release).
- Unit suite **589** = 588 dev baseline + **1** (the `vec_lane:pack_unpack` test).
- **int** linux green (golden-diff of emitted programs unchanged); aarch64
  cross-build unaffected; `-g` additivity holds (load image byte-identical).

Consumers #2014 and #2015 rebase and read `vec_lane` once this merges.
