### PR TITLE
fix(me): vector lane-access substrate — array-of-lanes gep + transition-robust tests

### DIFF
--- a/src/lang/driver.mach
+++ b/src/lang/driver.mach
@@ -6380,10 +6380,14 @@ fun ut_vec_diag(src: str, needle: str) i32 {
     ret 1;
 }
 
-# 0 when compiling `src` through sema + lower + codegen fails at codegen with an
-# error containing `needle` -- the defined per-target isel error a vector op
-# raises until a backend wires selection (#2013 slice 7). 1 otherwise
-fun ut_vec_codegen_err(src: str, needle: str) i32 {
+# 0 when compiling `src` through sema + lower + codegen reaches a DEFINED
+# outcome -- either a clean compile, or a codegen error containing `needle` (the
+# per-target isel guard). 1 on any other result: a codegen error carrying a
+# different message, or a failure before codegen. this is the durable never-ICE
+# invariant a vector op reaching selection must satisfy -- it holds on every arch
+# and at every stage of the backend guard-lift, so it stays a permanent selection
+# ICE canary rather than dissolving once a backend wires selection (#2013 slice 7)
+fun ut_vec_codegen_defined(src: str, needle: str) i32 {
     var alloc: A.Allocator;
     if (O.is_some[str](page.make(?alloc))) { ret 1; }
     val sr: R.Result[session.Session, str] = session.init(?alloc);
@@ -6404,7 +6408,8 @@ fun ut_vec_codegen_err(src: str, needle: str) i32 {
         val le: R.Result[bool, str] = run_lower_pass(?p);
         if (R.is_ok[bool, str](le)) {
             val ce: R.Result[bool, str] = run_codegen_pass(?p);
-            if (R.is_err[bool, str](ce) && ut_str_contains(R.unwrap_err[bool, str](ce), needle)) { code = 0; }
+            if (R.is_ok[bool, str](ce)) { code = 0; }
+            or (ut_str_contains(R.unwrap_err[bool, str](ce), needle)) { code = 0; }
         }
     }
     dnit_project(?p);
@@ -6412,18 +6417,192 @@ fun ut_vec_codegen_err(src: str, needle: str) i32 {
     ret code;
 }
 
-# a vector op reaching instruction selection raises the defined per-target
-# compile error (never an ICE, never a silent miscompile): a full-arity literal
-# and a lane-wise add both lower to IRT_VECTOR values that hit the target-generic
-# MIR guard, surfacing the "not yet supported on <arch>" string (#2013 slice 7)
-test "mach.lang.driver:vector_isel_error" {
+# a vector op reaching instruction selection always resolves to DEFINED behavior
+# -- never an ICE, never a silent miscompile. driving real vector ops (a pointer
+# lane-wise add and a full-arity literal) through the HOST backend on each CI
+# runner, the outcome is either a clean compile or the defined per-target guard
+# error. that invariant holds at every stage of the backend guard-lift -- before
+# a backend wires selection it is the guard error, after it is a clean compile --
+# so this stays a permanent selection ICE canary rather than a test that dissolves
+# the moment an arch lands its backend (#2013 slice 7)
+test "mach.lang.driver:vector_isel_defined" {
     var bad: i32 = 0;
     # a lane-wise add through pointers (no literal): the add lowers to a vector op.
-    if (ut_vec_codegen_err("fun addv(a: *f32x4, b: *f32x4, out: *f32x4) { @out = @a + @b; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { addv(argv:~*f32x4, argv:~*f32x4, argv:~*f32x4); ret 0; }\n",
+    if (ut_vec_codegen_defined("fun addv(a: *f32x4, b: *f32x4, out: *f32x4) { @out = @a + @b; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { addv(argv:~*f32x4, argv:~*f32x4, argv:~*f32x4); ret 0; }\n",
         "128-bit vectors not yet supported") != 0) { bad = 1; }
-    # a full-arity literal: it lowers to an IRT_VECTOR value that also reaches the guard.
-    if (ut_vec_codegen_err("fun mk(out: *f32x4) { @out = f32x4{1.0, 2.0, 3.0, 4.0}; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { mk(argv:~*f32x4); ret 0; }\n",
+    # a full-arity literal: it lowers to an IRT_VECTOR value driven through selection.
+    if (ut_vec_codegen_defined("fun mk(out: *f32x4) { @out = f32x4{1.0, 2.0, 3.0, 4.0}; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { mk(argv:~*f32x4); ret 0; }\n",
         "128-bit vectors not yet supported") != 0) { bad = 1; }
+    ret bad;
+}
+
+# scaffold one-file `src`, select `target_name` from the fixture manifest, and run
+# resolve + sema + lower so each module's `ir_module` carries its post-lower IR (a
+# capable target keeps vector ops; an incapable one has them scalarized, since
+# pipeline.run's scalarize stage is part of Q_LOWER). the session is the caller's
+# to tear down; the temp tree is removed once the graph is in memory
+fun ut_vec_lower(s: *session.Session, alloc: *A.Allocator, src: str, target_name: str) R.Result[Project, str] {
+    var names: [1]str;
+    names[0] = "main.mach";
+    var texts: [1]str;
+    texts[0] = src;
+    val root_r: R.Result[str, str] = ut_scaffold(alloc, ?names[0], ?texts[0], 1);
+    if (R.is_err[str, str](root_r)) { ret R.err[Project, str](R.unwrap_err[str, str](root_r)); }
+    val root: str = R.unwrap_ok[str, str](root_r);
+    val rr: R.Result[bool, str] = setup_registry(?s.registry);
+    if (R.is_err[bool, str](rr)) { filesystem.remove_all(alloc, root); ret R.err[Project, str](R.unwrap_err[bool, str](rr)); }
+    val mf: str = ut_cc3(alloc, root, "/", "mach.toml");
+    val pr: R.Result[Project, str] = build_project(s, root, mf, target_name);
+    filesystem.remove_all(alloc, root);
+    if (R.is_err[Project, str](pr)) { ret pr; }
+    var p: Project = R.unwrap_ok[Project, str](pr);
+    val se: R.Result[bool, str] = run_sema_pass(?p);
+    if (R.is_err[bool, str](se)) { dnit_project(?p); ret R.err[Project, str](R.unwrap_err[bool, str](se)); }
+    val le: R.Result[bool, str] = run_lower_pass(?p);
+    if (R.is_err[bool, str](le)) { dnit_project(?p); ret R.err[Project, str](R.unwrap_err[bool, str](le)); }
+    ret R.ok[Project, str](p);
+}
+
+# tally the gep instructions across `p`'s lowered modules: `@total` counts every
+# gep, `@into_vec` counts those whose base aggregate type (`aux_ty`) is a vector.
+# #2013 lowered a lane `v[i]` to a gep INTO the register-class IRT_VECTOR type --
+# rejected by aarch64, tolerated by x86_64 only through a numeric-offset accident;
+# the fix routes lane access through an array-of-lanes shape so `@into_vec` is 0
+fun ut_count_geps_into_vector(p: *Project, total: *u32, into_vec: *u32) {
+    @total    = 0;
+    @into_vec = 0;
+    var ti: u32 = 0;
+    for (ti < p.topo_len) {
+        val m: *ir.Module = p.modules[p.topo[ti]::u32].ir_module;
+        if (m != nil) {
+            var fi: u32 = 0;
+            for (fi < m.function_len) {
+                val fn: *ir.Function = ?m.functions[fi];
+                var bi: u32 = 0;
+                for (bi < fn.block_count) {
+                    val blk: *ir.Block = ?fn.blocks[bi];
+                    var ix: u32 = 0;
+                    for (ix < blk.instr_count) {
+                        val ins: *instruction.Instruction = ?fn.instrs[blk.instructions[ix]];
+                        if (ins.kind == instruction.OP_GEP) {
+                            @total = @total + 1;
+                            if (ir_type.is_vector(?m.types, ins.aux_ty)) { @into_vec = @into_vec + 1; }
+                        }
+                        ix = ix + 1;
+                    }
+                    bi = bi + 1;
+                }
+                fi = fi + 1;
+            }
+        }
+        ti = ti + 1;
+    }
+}
+
+# true when `p`'s lowered modules hold a vector `==` compare whose two operands
+# read back as vectors with the given lane kind and element width. a compare
+# records its OPERAND shape, not its unsigned-mask result shape - the substrate a
+# capable backend reads to pick the compare's lane width. only present on a
+# capable target, where the vector compare survives lowering
+fun ut_has_vec_compare_operands(p: *Project, want_float: bool, want_bytes: u8) bool {
+    var ti: u32 = 0;
+    for (ti < p.topo_len) {
+        val m: *ir.Module = p.modules[p.topo[ti]::u32].ir_module;
+        if (m != nil) {
+            var fi: u32 = 0;
+            for (fi < m.function_len) {
+                val fn: *ir.Function = ?m.functions[fi];
+                var bi: u32 = 0;
+                for (bi < fn.block_count) {
+                    val blk: *ir.Block = ?fn.blocks[bi];
+                    var ix: u32 = 0;
+                    for (ix < blk.instr_count) {
+                        val ins: *instruction.Instruction = ?fn.instrs[blk.instructions[ix]];
+                        if (ins.kind == instruction.OP_CMP_EQ && ins.operand_count >= 2) {
+                            var f0: bool = false;
+                            var b0: u8   = 0;
+                            var f1: bool = false;
+                            var b1: u8   = 0;
+                            if (ir_type.vector_lane(?m.types, ins.operands[0].ty, ?f0, ?b0)
+                                && ir_type.vector_lane(?m.types, ins.operands[1].ty, ?f1, ?b1)
+                                && f0 == want_float && b0 == want_bytes
+                                && f1 == want_float && b1 == want_bytes) { ret true; }
+                        }
+                        ix = ix + 1;
+                    }
+                    bi = bi + 1;
+                }
+                fi = fi + 1;
+            }
+        }
+        ti = ti + 1;
+    }
+    ret false;
+}
+
+# a vector lane `v[i]` read and write lower to a slot round-trip -- a gep through
+# the vector's array-of-lanes storage, never a gep INTO the register-class
+# IRT_VECTOR type -- identically on all three targets' pipelines. x86_64/aarch64
+# keep the vector and riscv64 scalarizes it, yet the lane geps are array-shaped on
+# every one; the regression guard for the #2013 substrate bug aarch64 rejected and
+# x86_64 only tolerated through a numeric-offset accident (#1965)
+test "mach.lang.driver:vector_lane_access_round_trip" {
+    val src: str = "fun lane_rw(p: *i32x4, out: *i32) {\n    @out = (@p)[2];\n    (@p)[0] = 7;\n}\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { lane_rw(argv:~*i32x4, argv:~*i32); ret 0; }\n";
+    var targets: [3]str;
+    targets[0] = "linux";
+    targets[1] = "linux-arm64";
+    targets[2] = "linux-riscv64";
+    var bad: i32 = 0;
+    var t: u32 = 0;
+    for (t < 3) {
+        var alloc: A.Allocator;
+        if (O.is_some[str](page.make(?alloc))) { ret 1; }
+        val sr: R.Result[session.Session, str] = session.init(?alloc);
+        if (R.is_err[session.Session, str](sr)) { ret 1; }
+        var s: session.Session = R.unwrap_ok[session.Session, str](sr);
+        val pr: R.Result[Project, str] = ut_vec_lower(?s, ?alloc, src, targets[t]);
+        if (R.is_err[Project, str](pr)) { session.dnit(?s); ret 1; }
+        var p: Project = R.unwrap_ok[Project, str](pr);
+        var total:    u32 = 0;
+        var into_vec: u32 = 0;
+        ut_count_geps_into_vector(?p, ?total, ?into_vec);
+        # the lane access must materialize as a gep (base is a pointer param, so it
+        # survives optimization) and none may index into a vector.
+        if (total == 0)     { bad = 1; }
+        if (into_vec != 0)  { bad = 1; }
+        dnit_project(?p);
+        session.dnit(?s);
+        t = t + 1;
+    }
+    ret bad;
+}
+
+# a vector `==` compare records its OPERAND lane shape (float, 4-byte for f32x4),
+# not its unsigned-mask result shape, on both capable targets' pipelines
+# (x86_64/aarch64), where the vector compare survives lowering. guards the failure
+# mode where the operand shape is lost so a backend collapses every lane width to
+# bytes (riscv64 scalarizes the compare away, so it is excluded) (#1965)
+test "mach.lang.driver:vector_compare_operand_shape" {
+    val src: str = "fun vcmp(a: *f32x4, b: *f32x4, out: *u32x4) { @out = @a == @b; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { vcmp(argv:~*f32x4, argv:~*f32x4, argv:~*u32x4); ret 0; }\n";
+    var targets: [2]str;
+    targets[0] = "linux";
+    targets[1] = "linux-arm64";
+    var bad: i32 = 0;
+    var t: u32 = 0;
+    for (t < 2) {
+        var alloc: A.Allocator;
+        if (O.is_some[str](page.make(?alloc))) { ret 1; }
+        val sr: R.Result[session.Session, str] = session.init(?alloc);
+        if (R.is_err[session.Session, str](sr)) { ret 1; }
+        var s: session.Session = R.unwrap_ok[session.Session, str](sr);
+        val pr: R.Result[Project, str] = ut_vec_lower(?s, ?alloc, src, targets[t]);
+        if (R.is_err[Project, str](pr)) { session.dnit(?s); ret 1; }
+        var p: Project = R.unwrap_ok[Project, str](pr);
+        if (!ut_has_vec_compare_operands(?p, true, 4)) { bad = 1; }
+        dnit_project(?p);
+        session.dnit(?s);
+        t = t + 1;
+    }
     ret bad;
 }
 

--- a/src/lang/me/lower/expr.mach
+++ b/src/lang/me/lower/expr.mach
@@ -976,9 +976,28 @@ fun lower_index_lvalue(ctx: *context.LowerContext, eid: id.ExprId, e: *expr.Expr
     }
 
     # `[N]T[ix]` addresses element ix through the aggregate walk on the array type.
-    val res_arr_ir: R.Result[ir_type.IrTypeId, str] = context.lower_type(ctx, obj_ty);
-    if (R.is_err[ir_type.IrTypeId, str](res_arr_ir)) { ret R.err[value.Value, str](R.unwrap_err[ir_type.IrTypeId, str](res_arr_ir)); }
-    val arr_ir: ir_type.IrTypeId = R.unwrap_ok[ir_type.IrTypeId, str](res_arr_ir);
+    val res_obj_ir: R.Result[ir_type.IrTypeId, str] = context.lower_type(ctx, obj_ty);
+    if (R.is_err[ir_type.IrTypeId, str](res_obj_ir)) { ret R.err[value.Value, str](R.unwrap_err[ir_type.IrTypeId, str](res_obj_ir)); }
+    var arr_ir: ir_type.IrTypeId = R.unwrap_ok[ir_type.IrTypeId, str](res_obj_ir);
+
+    # a vector lane `v[i]` addresses the vector's 16-byte storage through an
+    # array-of-lanes shape (`[lanes]elem`, the same layout): a vector is
+    # register-class, not an aggregate, so a gep INTO the IRT_VECTOR type is
+    # rejected by aarch64 and only tolerated by x86_64 through a numeric-offset
+    # accident. the array shape composes identically on every backend (#1965).
+    if (type.is_vector(?ctx.s.types, obj_ty)) {
+        val opt_v: O.Option[*ir_type.IrType] = ir_type.get(?ctx.m.types, arr_ir);
+        if (O.is_some[*ir_type.IrType](opt_v)) {
+            val vt: *ir_type.IrType = O.unwrap[*ir_type.IrType](opt_v);
+            if (vt.kind == ir_type.IRT_VECTOR) {
+                val elem:  ir_type.IrTypeId = vt.data.vector_.element;
+                val lanes: u32              = vt.data.vector_.lanes;
+                val res_arr: R.Result[ir_type.IrTypeId, str] = ir_type.intern_array(?ctx.m.types, elem, lanes);
+                if (R.is_err[ir_type.IrTypeId, str](res_arr)) { ret R.err[value.Value, str](R.unwrap_err[ir_type.IrTypeId, str](res_arr)); }
+                arr_ir = R.unwrap_ok[ir_type.IrTypeId, str](res_arr);
+            }
+        }
+    }
 
     val res_xty: R.Result[ir_type.IrTypeId, str] = index_type(ctx);
     if (R.is_err[ir_type.IrTypeId, str](res_xty)) { ret R.err[value.Value, str](R.unwrap_err[ir_type.IrTypeId, str](res_xty)); }


### PR DESCRIPTION
Substrate fix round for the SIMD lane path (#1965), from NEON runtime verification. Two shared-lowering fixes plus the isel test rework, all backend-neutral so #2014 (SSE2) and #2015 (NEON) rebase onto one canonical lane lowering.

## What changed

**1. Vector lane access → array-of-lanes gep (`src/lang/me/lower/expr.mach`)**
`v[i]` addressed the vector's 16-byte storage by gep-ing INTO the `IRT_VECTOR` type. A vector is register-class, not an aggregate, so the MIR lowering's `gep index into a non-aggregate type` guard rejects it. The fix addresses the same storage through a `[lanes]elem` array shape (identical 16-byte layout), so the lane gep + scalar load/store compose on every backend.

Pre-fix behaviour of `v[i]` (verified against current `dev`):
- **x86_64 and aarch64**: both hard-error at `mir.lower_ir: gep index into a non-aggregate type` (a loud error, never a silent miscompile — so no accidental tolerance on x86_64).
- **riscv64**: tolerated; the scalarize pass normalized the gep-into-vector into array geps while materializing the vector into a slot.

Post-fix: array-of-lanes gep, clean codegen on all three targets. The rv64 scalarized IR is **byte-identical** pre/post-fix — the fix is transparent for rv64 and load-bearing only for the non-scalarizing (capable) backends, which were both blocked.

**2. Transition-robust isel canary (`vector_isel_error` → `vector_isel_defined`)**
The old test asserted every arch errors at the vector isel guard — a premise that dissolves once a backend lands selection (it broke on native aarch64 CI after NEON lifted the guard, and #2014 would break it identically). Reworked into a never-ICE + defined-behaviour invariant: drive a vector op through the host backend and assert the outcome is either a clean compile OR the defined guard error. That holds on every arch at every stage of the guard-lift, so it stays a permanent selection ICE canary. (Design credit: the NEON worker.)

**3. Seed-safe string-based pipeline tests**
Vector source lives only in string literals (seed-safe under 3.3.1), inspected over the post-lower IR:
- `vector_lane_access_round_trip` — on all three targets, `v[i]` read/write lowers to a gep through array-of-lanes storage, never a gep into `IRT_VECTOR`.
- `vector_compare_operand_shape` — on the capable targets (x86_64/aarch64), a vector compare records its **operand** lane shape (float, 4-byte for `f32x4`), locking in the substrate a backend reads to pick the compare's lane width. Proven to discriminate on element bits (fails if the recorded width is wrong).

## Bars

- **Suite**: dev `593` → this branch `595` (+2 pipeline tests; the isel rename is net-zero). Measured fresh against a from-source `dev` compiler.
- **Self-host fixpoint**: s2 == s3 byte-identical.
- **Non-vector byte-identity**: this compiler and the `dev` compiler produce a byte-identical `bin/mach` from the same non-vector source — the lane-lowering change is inert on non-vector code.
- **int**: all cases green on the linux leg, incl. `surface/debuginfo` (dwarfdump `--verify` + `-g` PT_LOAD additivity) in both profiles.

## Notes

- The dispatched "compare records broken operand/mask types (element-bits 0)" root does **not** reproduce in the substrate: `compute_vec_lane` and the IR operand types read back correctly on every shape/opt/path, now guarded by `vector_compare_operand_shape`. Any residual NEON `.16b`-always symptom is downstream of the substrate (in NEON isel's consumption of the descriptor), not a lost type lookup here.
- Discovered out of scope: an **uninitialized** vector local (`var v: i32x4;` with no initializer) errors at `constant typing: constant carries an incompatible type` — default-init routes a vector through the scalar `zero_const` path. An initialized local works. Surfaced separately, not fixed here.

Part of #1965. References #2013/#2014/#2015.
