### PR TITLE
fix(me): default-initialize vector locals through array-shaped memzero (#2043)

### DIFF
--- a/src/lang/driver.mach
+++ b/src/lang/driver.mach
@@ -6606,6 +6606,118 @@ test "mach.lang.driver:vector_compare_operand_shape" {
     ret bad;
 }
 
+# 0 iff `p`'s lowered modules default-initialize a vector local the aggregate way:
+# at least one memzero is present and none memzeroes a vector type (its storage is
+# the `[lanes]elem` array), no gep indexes into a vector, and no VAL_CONST_INT
+# carries a vector type -- the scalar `zero_const` bug an uninitialized vector
+# local used to hit (#2043). 1 otherwise
+fun ut_vector_local_wellformed(p: *Project) i32 {
+    var seen_memzero: bool = false;
+    var bad:          bool = false;
+    var ti: u32 = 0;
+    for (ti < p.topo_len) {
+        val m: *ir.Module = p.modules[p.topo[ti]::u32].ir_module;
+        if (m != nil) {
+            var fi: u32 = 0;
+            for (fi < m.function_len) {
+                val fn: *ir.Function = ?m.functions[fi];
+                var bi: u32 = 0;
+                for (bi < fn.block_count) {
+                    val blk: *ir.Block = ?fn.blocks[bi];
+                    var ix: u32 = 0;
+                    for (ix < blk.instr_count) {
+                        val ins: *instruction.Instruction = ?fn.instrs[blk.instructions[ix]];
+                        if (ins.kind == instruction.OP_MEMZERO) {
+                            seen_memzero = true;
+                            if (ir_type.is_vector(?m.types, ins.aux_ty)) { bad = true; }
+                        }
+                        if (ins.kind == instruction.OP_GEP && ir_type.is_vector(?m.types, ins.aux_ty)) { bad = true; }
+                        var oi: u32 = 0;
+                        for (oi < ins.operand_count) {
+                            if (ins.operands[oi].kind == value.VAL_CONST_INT
+                                && ir_type.is_vector(?m.types, ins.operands[oi].ty)) { bad = true; }
+                            oi = oi + 1;
+                        }
+                        ix = ix + 1;
+                    }
+                    bi = bi + 1;
+                }
+                fi = fi + 1;
+            }
+        }
+        ti = ti + 1;
+    }
+    if (bad)          { ret 1; }
+    if (!seen_memzero) { ret 1; }
+    ret 0;
+}
+
+# an uninitialized vector local default-initializes to all-zero lanes through the
+# aggregate memzero over its array-shaped storage, on all three targets' pipelines
+# -- never the scalar zero_const that produced a vector-typed constant the verifier
+# rejected (#2043). the program reads a lane no write touched, so the memzero must
+# stay live; it holds no vector operator, so it lowers clean on every target
+test "mach.lang.driver:vector_local_default_init" {
+    val src: str = "fun f(o: *i32) { var v: i32x4; @o = v[2]; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { f(argv:~*i32); ret 0; }\n";
+    var targets: [3]str;
+    targets[0] = "linux";
+    targets[1] = "linux-arm64";
+    targets[2] = "linux-riscv64";
+    var bad: i32 = 0;
+    var t: u32 = 0;
+    for (t < 3) {
+        var alloc: A.Allocator;
+        if (O.is_some[str](page.make(?alloc))) { ret 1; }
+        val sr: R.Result[session.Session, str] = session.init(?alloc);
+        if (R.is_err[session.Session, str](sr)) { ret 1; }
+        var s: session.Session = R.unwrap_ok[session.Session, str](sr);
+        val pr: R.Result[Project, str] = ut_vec_lower(?s, ?alloc, src, targets[t]);
+        # lowering must succeed at all -- the pre-fix path failed the IR verifier.
+        if (R.is_err[Project, str](pr)) { session.dnit(?s); ret 1; }
+        var p: Project = R.unwrap_ok[Project, str](pr);
+        if (ut_vector_local_wellformed(?p) != 0) { bad = 1; }
+        dnit_project(?p);
+        session.dnit(?s);
+        t = t + 1;
+    }
+    ret bad;
+}
+
+# a vector `==` compare records its i32x4 operand shape (non-float, 4-byte) when
+# the operands arrive through STORAGE and PARAM paths, not just literal temporaries
+# -- a mutable local `var a=...; a==b` and a by-value param `fun eqv(a,b){ret a==b}`
+# -- on both capable targets (x86_64/aarch64), where the compare survives lowering.
+# these are the shapes a backend's lane-width selection depends on (#1965/#2043)
+test "mach.lang.driver:vector_compare_operands_via_storage" {
+    var srcs: [2]str;
+    srcs[0] = "fun mlcmp(out: *u32x4) { var a: i32x4 = i32x4{1, 2, 3, 4}; var b: i32x4 = i32x4{1, 2, 3, 4}; @out = a == b; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { mlcmp(argv:~*u32x4); ret 0; }\n";
+    srcs[1] = "fun eqv(a: i32x4, b: i32x4) u32x4 { ret a == b; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { val a: i32x4 = i32x4{1, 2, 3, 4}; val b: i32x4 = i32x4{1, 2, 3, 4}; val m: u32x4 = eqv(a, b); ret 0; }\n";
+    var targets: [2]str;
+    targets[0] = "linux";
+    targets[1] = "linux-arm64";
+    var bad: i32 = 0;
+    var si: u32 = 0;
+    for (si < 2) {
+        var t: u32 = 0;
+        for (t < 2) {
+            var alloc: A.Allocator;
+            if (O.is_some[str](page.make(?alloc))) { ret 1; }
+            val sr: R.Result[session.Session, str] = session.init(?alloc);
+            if (R.is_err[session.Session, str](sr)) { ret 1; }
+            var s: session.Session = R.unwrap_ok[session.Session, str](sr);
+            val pr: R.Result[Project, str] = ut_vec_lower(?s, ?alloc, srcs[si], targets[t]);
+            if (R.is_err[Project, str](pr)) { session.dnit(?s); ret 1; }
+            var p: Project = R.unwrap_ok[Project, str](pr);
+            if (!ut_has_vec_compare_operands(?p, false, 4)) { bad = 1; }
+            dnit_project(?p);
+            session.dnit(?s);
+            t = t + 1;
+        }
+        si = si + 1;
+    }
+    ret bad;
+}
+
 # a well-typed program exercising the full vector surface -- spellings in type
 # position, a full-arity literal, lane-wise arithmetic / bitwise / compare to
 # mask, 16-bit integer multiply, unary ~, and a comptime-constant lane read --

--- a/src/lang/me/lower/expr.mach
+++ b/src/lang/me/lower/expr.mach
@@ -982,9 +982,9 @@ fun lower_index_lvalue(ctx: *context.LowerContext, eid: id.ExprId, e: *expr.Expr
 
     # a vector lane `v[i]` addresses the vector's 16-byte storage through an
     # array-of-lanes shape (`[lanes]elem`, the same layout): a vector is
-    # register-class, not an aggregate, so a gep INTO the IRT_VECTOR type is
-    # rejected by aarch64 and only tolerated by x86_64 through a numeric-offset
-    # accident. the array shape composes identically on every backend (#1965).
+    # register-class, not an aggregate, so a gep INTO the IRT_VECTOR type hits the
+    # MIR lowering's non-aggregate guard and hard-errors on both capable backends
+    # (x86_64 and aarch64). the array shape composes identically everywhere (#1965).
     if (type.is_vector(?ctx.s.types, obj_ty)) {
         val opt_v: O.Option[*ir_type.IrType] = ir_type.get(?ctx.m.types, arr_ir);
         if (O.is_some[*ir_type.IrType](opt_v)) {

--- a/src/lang/me/lower/stmt.mach
+++ b/src/lang/me/lower/stmt.mach
@@ -388,13 +388,30 @@ fun lower_decl_stmt(ctx: *context.LowerContext, s: *stmt.Stmt) R.Result[bool, st
     }
     val slot_ty: ir_type.IrTypeId = R.unwrap_ok[ir_type.IrTypeId, str](res_slot_ty);
 
+    # a vector local is backed by array-shaped storage (`[lanes]elem`, the same
+    # 16-byte layout the literal and lane-access paths use): a register-class
+    # IRT_VECTOR is not address-typed, so it can be neither default-initialized
+    # through the aggregate memzero path nor lane-addressed by a gep. the array
+    # shape makes vector storage consistent with every other vector storage site
+    # (#1965/#2043). `slot_ty` stays the vector for the source-level debug type.
+    var storage_ty: ir_type.IrTypeId = slot_ty;
+    if (ir_type.is_vector(?ctx.m.types, slot_ty)) {
+        val opt_vt: O.Option[*ir_type.IrType] = ir_type.get(?ctx.m.types, slot_ty);
+        if (O.is_some[*ir_type.IrType](opt_vt)) {
+            val vt: *ir_type.IrType = O.unwrap[*ir_type.IrType](opt_vt);
+            val res_arr: R.Result[ir_type.IrTypeId, str] = ir_type.intern_array(?ctx.m.types, vt.data.vector_.element, vt.data.vector_.lanes);
+            if (R.is_err[ir_type.IrTypeId, str](res_arr)) { ret R.err[bool, str](R.unwrap_err[ir_type.IrTypeId, str](res_arr)); }
+            storage_ty = R.unwrap_ok[ir_type.IrTypeId, str](res_arr);
+        }
+    }
+
     val res_count_ty: R.Result[ir_type.IrTypeId, str] = ir_type.intern_int(?ctx.m.types, 64);
     if (R.is_err[ir_type.IrTypeId, str](res_count_ty)) {
         ret R.err[bool, str](R.unwrap_err[ir_type.IrTypeId, str](res_count_ty));
     }
     val count_ty: ir_type.IrTypeId = R.unwrap_ok[ir_type.IrTypeId, str](res_count_ty);
 
-    val res_slot: R.Result[value.Value, str] = builder.emit_alloca(?ctx.builder, slot_ty, value.const_int(1, count_ty));
+    val res_slot: R.Result[value.Value, str] = builder.emit_alloca(?ctx.builder, storage_ty, value.const_int(1, count_ty));
     if (R.is_err[value.Value, str](res_slot)) {
         ret R.err[bool, str](R.unwrap_err[value.Value, str](res_slot));
     }
@@ -420,8 +437,10 @@ fun lower_decl_stmt(ctx: *context.LowerContext, s: *stmt.Stmt) R.Result[bool, st
         if (R.is_err[bool, str](res_store)) { ret res_store; }
         birth_val = init;
     }
-    or (ir_type.is_aggregate(?ctx.m.types, slot_ty)) {
-        val res_mz: R.Result[bool, str] = builder.emit_memzero(?ctx.builder, slot, slot_ty);
+    or (ir_type.is_aggregate(?ctx.m.types, storage_ty)) {
+        # a vector's array-shaped storage is an aggregate, so a default-initialized
+        # vector local zero-fills here -- all-zero bytes is +0.0 / 0 on every lane.
+        val res_mz: R.Result[bool, str] = builder.emit_memzero(?ctx.builder, slot, storage_ty);
         if (R.is_err[bool, str](res_mz)) { ret res_mz; }
         birth_val = slot;
     }


### PR DESCRIPTION
Closes #2043. Part of #1965. Fast-follow to the merged substrate PR #2042.

## Problem

An uninitialized vector local (`var v: i32x4;`, no initializer) failed to compile: it fell through to the scalar `zero_const` default-init path, producing a `VAL_CONST_INT` carrying the vector type, which the IR verifier rejects (`VC_CONST_TYPE`). `var v: f32x4; v[0] = ...` is the natural lane-by-lane construction idiom and must work in increment 1. An *initialized* local already worked, so the gap was only default-init.

## Fix

Back a vector local with the same `[lanes]elem` array-shaped storage the literal and lane-access paths already use, so its default-init takes the aggregate `memzero` branch (all-zero bytes = `+0.0` / `0` on every lane) and every lane gep addresses an aggregate. Per the design ruling: **array-shaped storage, not blessing vector storage pointers** — a register-class `IRT_VECTOR` is neither address-typed nor memzero-able, and widening `is_address_typed` to bless vector storage pointers would weaken a load-bearing invariant to accommodate a representation mistake. The vector type is retained for the source-level debug type. No new IR op (`memzero` is existing).

Also corrects the stale lane-access comment in `expr.mach`: current dev hard-errors a gep-into-vector on **both** capable backends, not "x86_64 tolerates by numeric-offset accident" (PR #2042's own verification established this).

## Verification

- `var v: <each of the ten shapes>;` compiles on x86_64/aarch64/riscv64.
- rv64 IR: default-init lowers to `alloca [lanes]elem` + `memzero`; a lane read of an unwritten lane returns zero (`gep` + `load i32`, no gep-into-vector, no vector const).
- Regression guard proven: with the fix disabled, `vector_local_default_init` fails; with it, green.

## BUG 1 reconciliation (NEON's compare-operand symptom)

Ran NEON's two exact repro shapes plus a pointer-deref control through the post-lower IR compare-operand check — a 6-cell matrix {x86_64, aarch64} × {pointer-deref, mutable-local `var a=...; a==b`, by-value params `fun eqv(a,b){ret a==b}`}. **All 6 record the compare operands as correctly-typed i32x4 vectors on current dev.** There is no lost type lookup in the substrate for any of NEON's shapes on either target; NEON's "value_is_vector reads FALSE at :841" originates from its branch state (stale base or a local change), not the substrate. Locked in by `vector_compare_operands_via_storage` (mutable-local + by-value params, both capable targets).

## Tests (seed-safe, string-based)

- `vector_local_default_init` — memzero aggregate path, no vector const, no gep-into-vector, all three targets.
- `vector_compare_operands_via_storage` — vector operand typing for compares through storage and param paths, both capable targets.

Suite: dev 595 → 597 (+2).
