### PR TITLE
docs: amend types/operators/policy + manifest for shipped SIMD vectors

### DIFF
--- a/doc/language/operators.md
+++ b/doc/language/operators.md
@@ -1,17 +1,14 @@
 # Operators
 
-SIMD vector operands described below are part of the planned vector
-design and are not yet implemented — see [types.md](types.md).
-
 ## Arithmetic
 
-`+` `-` `*` `/` `%` — work on integer and floating-point scalars. SIMD
-vector types are intended to support the same operators, applied lane-wise.
+`+` `-` `*` `/` `%` — work on integer and floating-point scalars. On the seeded
+vector types they apply lane-wise, with the honest per-lane table in
+[SIMD vectors](#simd-vectors) below (`+ - * /`, no vector `%`).
 
 ```mach
 val s: i64    = 10 + 20;
 val q: f32    = 1.5 * 2.0;
-val v: f32x4  = a + b;       # lane-wise add (vectors not yet implemented)
 ```
 
 `%` is the remainder. On integers it is the native truncated remainder, taking
@@ -26,13 +23,13 @@ val r: f64 = 5.5 % 3.0;      # 2.5
 
 ## Bitwise
 
-`&` `|` `^` `~` `<<` `>>` — work on integer scalars and (planned) integer
-SIMD vectors.
+`&` `|` `^` `~` `<<` `>>` — work on integer scalars. On integer-lane vectors
+`&` `|` `^` `~` apply lane-wise; the shifts `<<` `>>` are not in this increment
+(see [SIMD vectors](#simd-vectors)).
 
 ```mach
 val x: i64    = (a & b) | (c ^ d);
 val y: i64    = x << 2;
-val z: i32x4  = (m & n) ^ k;     # vectors not yet implemented
 ```
 
 ## Comparison
@@ -50,8 +47,8 @@ values**, so the result is identical in either operand order:
   `::`. An implicit widening would hide `f64` rounding above `2^53`.
 
 A pointer-like value — a pointer or a function — may be compared against `nil`
-(the null-address literal). On the planned SIMD vectors, comparison produces a
-mask vector (lane-wise).
+(the null-address literal). On the seeded vector types, a comparison produces a
+same-shape unsigned **mask** vector (lane-wise) — see [SIMD vectors](#simd-vectors).
 
 ## Logical
 
@@ -107,6 +104,52 @@ val f: f64 = b:~f64;            # 1.5                (bits read back as a float)
 Neither `::` nor `:~` may add or drop the `^` secret qualifier, and neither can
 erase a secret-welded pointer to `ptr`. The only downgrade is the `:^` strip
 cast. See [secrecy.md](secrecy.md).
+
+## SIMD vectors
+
+The seeded 128-bit vector types (see [types.md](types.md)) carry lane-wise
+operators. The table below is the honest set — what lowers to one instruction per
+operator on the SSE2 (x86_64) and NEON (aarch64) baselines. Everything in it also
+lowers to a **defined unrolled scalar expansion** with identical results on a
+target without the hardware (see [policy.md](policy.md)), so a vector operator
+means the same thing on every target.
+
+| Lane family | `+` `-` | `*` | `/` | `%` | `& \| ^ ~` | `<< >>` | `== != < > <= >=` |
+|---|---|---|---|---|---|---|---|
+| float — `f32x4`, `f64x2` | yes | yes | yes | no | — | no | → same-shape unsigned mask |
+| integer, 16-bit lanes — `i16x8`, `u16x8` | yes | yes | no | no | yes | no | → same-shape unsigned mask |
+| integer, other widths — `i8x16` `i32x4` `i64x2` (+ unsigned) | yes | no | no | no | yes | no | → same-shape unsigned mask |
+
+Both operands of a binary operator must be the **same** vector shape: there is no
+implicit scalar↔vector mixing and no cross-shape widening. Anything the table
+marks `no` is a compile error, not a silent fallback:
+
+- no vector `%` on any lane type;
+- no integer vector `/` — division is float lanes only;
+- integer vector `*` is 16-bit lanes only (32-bit `pmulld` is SSE4.1, off the SSE2
+  baseline);
+- bitwise `& | ^ ~` require integer lanes; the shifts `<< >>` are not in this
+  increment (a per-lane variable shift is AVX2-only on x86_64, with no 8-bit
+  packed form).
+
+A comparison produces the same-shape **unsigned mask** vector — one lane per input
+lane, all-ones bits (`0xFF…`) for true and all-zeros for false, exactly what the
+hardware compare yields. There is no vector-bool type. The mask element is the
+unsigned integer of the input's lane width: `f32x4` / `i32x4` / `u32x4` → `u32x4`;
+`f64x2` / `i64x2` → `u64x2`; `i16x8` → `u16x8`; `i8x16` → `u8x16`. Select/blend is
+not an operator; it is the library idiom `(mask & a) | (~mask & b)` over matching
+integer lanes (the tier-3 simd library, #2021).
+
+```mach
+val a: f32x4 = f32x4{1.0, 2.0, 3.0, 4.0};
+val b: f32x4 = f32x4{4.0, 3.0, 2.0, 1.0};
+val sum:  f32x4 = a + b;       # lane-wise -> {5.0, 5.0, 5.0, 5.0}
+val mask: u32x4 = a < b;       # -> {0xFFFFFFFF, 0xFFFFFFFF, 0, 0}
+
+val m: i32x4 = i32x4{1, 2, 3, 4};
+val n: i32x4 = i32x4{4, 3, 2, 1};
+val z: i32x4 = (m & n) ^ n;    # lane-wise bitwise on integer lanes
+```
 
 ## See also
 

--- a/doc/language/policy.md
+++ b/doc/language/policy.md
@@ -11,10 +11,16 @@ Things that need to feel like the language:
   records, unions, generics.
 - **Control flow.** `if` / `or`, `for`, `ret`, `brk`, `cnt`, `fin`,
   blocks.
-- **SIMD operators on primitive vector types.** Binary arithmetic
-  (`+ - * / %`), bitwise (`& | ^ ~ << >>`), comparison, lane indexing,
-  vector literals. The compiler emits one CPU instruction per operator
-  per supported ISA.
+- **SIMD operators on primitive vector types.** Lane-wise arithmetic,
+  bitwise, comparison-to-mask, lane indexing, and full-arity vector
+  literals over the seeded 128-bit vector types (the honest per-operator
+  table is in [operators.md](operators.md)). On a target with the hardware
+  (SSE2 on x86_64, NEON on aarch64) the compiler emits one instruction per
+  operator; on a target without it the compiler emits a **defined unrolled
+  scalar expansion** of the same operator — scalarize operators, never
+  algorithms — and reports the scalarization at build time. What to do on
+  an incapable target is the `simd` profile lever (see
+  [manifest.md](../manifest.md)), not a compiler default.
 - **`asm` parsing, encoding, and operand allocation** for each supported
   ISA.
 - **The comptime channel** — `$mach.*` reads, the closed intrinsic set,

--- a/doc/language/types.md
+++ b/doc/language/types.md
@@ -21,22 +21,56 @@ There is no compiler `bool`. `bool` is a stdlib `def bool: u8;` with `true` /
 
 ## SIMD vectors
 
-> **Not yet implemented.** The vector type grammar below describes the
-> planned design. The compiler does not seed vector types today; a name
-> like `f32x4` resolves as an ordinary (unbound) identifier, not a type.
-
-The planned design extends primitive numeric types into vectors by
-appending `x<count>`:
+Ten 128-bit vector types are compiler-seeded, each a fixed number of lanes of a
+primitive numeric element:
 
 ```mach
-f32x4           # 4 lanes of f32
-i32x8           # 8 lanes of i32
-u8x16           # 16 lanes of u8
+f32x4  f64x2                    # float lanes
+i8x16  i16x8  i32x4  i64x2      # signed integer lanes
+u8x16  u16x8  u32x4  u64x2      # unsigned integer lanes
 ```
 
-The grammar is `<u|i|f><width>(x<count>)*`. Higher dimensions
-(`f32x4x4`) are legal grammatically; the compiler ships only the entries
-its target backends can accelerate.
+These ten are the complete set. The spelling is `<u|i|f><width>x<count>` with a
+**single** `x` — there are no other vector types and no multi-`x` shapes. A name
+like `f32x4x4` is not a vector type (it resolves as an ordinary identifier); a
+matrix is an algorithm over vectors and belongs in a library over vector
+elements, not the language. A vector spelling is recognized only in type
+position, so a value may still be named `f32x4` without colliding with the type.
+
+Every seeded vector is exactly 128 bits: `$size_of` and `$align_of` are both
+`16`. Arrays of vectors (`[4]f32x4`) and pointers to vectors (`*f32x4`) are
+ordinary composite types over a vector element.
+
+**Literals** are full-arity — one initializer per lane, mirroring array literals.
+The lane count must match exactly; too few or too many lanes is a compile error.
+
+```mach
+val v: f32x4 = f32x4{1.0, 2.0, 3.0, 4.0};
+val w: i32x4 = i32x4{1, 2, 3, 4};
+```
+
+An uninitialized vector local default-initializes to all-zero lanes:
+
+```mach
+var z: i32x4;                   # every lane is 0
+```
+
+**Lane access** `v[i]` reads or writes a single lane. The index must be a
+comptime constant in `[0, lanes)` and is bounds-checked at compile time; a
+dynamic (runtime) lane index is not supported in this increment.
+
+```mach
+var v: f32x4 = f32x4{1.0, 2.0, 3.0, 4.0};
+val x: f32 = v[0];              # read lane 0
+v[3] = 9.0;                     # write lane 3
+```
+
+There are no scalar↔vector casts in this increment: neither an implicit
+scalar-to-vector conversion nor a `1.0::f32x4` reinterpret is legal. The
+lane-wise operators and the comparison-to-mask rule are in
+[operators.md](operators.md); what a target without hardware SIMD does with a
+vector operator is the `simd` profile lever ([manifest.md](manifest.md),
+[policy.md](policy.md)).
 
 ## Pointer
 

--- a/doc/manifest.md
+++ b/doc/manifest.md
@@ -64,6 +64,7 @@ abi = "sysv64"
 [profile.debug]                        # a build variant
 opt   = 0                              # 0 (debug pipeline) | 1 | 2 (release pipeline)
 debug = true                           # emit debug info for this profile
+simd  = "scalarize"                    # SIMD lever: "scalarize" | "require"
 
 [artifact.demo]                        # a produced artifact
 kind    = "bin"                        # "bin" | "static" | "shared"
@@ -148,10 +149,18 @@ live here because they are variant concerns.
 |---------|---------|---------|
 | `opt`   | integer | Optimization level: `0` selects the debug pipeline (the always-on passes only), `1` and `2` select the release pipeline. `1` and `2` currently share a pass set; `2` is where future loop/vectorization work lands. Any other integer — or a non-integer — is a manifest error. |
 | `debug` | bool    | Emit debug info (DWARF on ELF/Mach-O, CodeView on COFF) for this profile. Gates emission only, never the optimizer, so a `release` profile can keep symbols with `debug = true`. A non-boolean is a manifest error. |
+| `simd`  | string  | SIMD scalarization lever. `"scalarize"` builds for a target without hardware SIMD by emitting a defined unrolled scalar expansion of each vector operator, with a build-time note (the "skipped N target-gated modules" style). `"require"` makes a build for an incapable target a hard error naming the offending operator. Any other string is a manifest error. |
 
-Both keys are required in a declared profile. Emission of the human-readable IR and
-assembly side-artifacts is **not** a profile concern — it is controlled only by the
-`--emit-ir` / `--emit-asm` CLI flags (see [cli.md](cli.md)).
+All three keys (`opt`, `debug`, `simd`) are required in a declared profile.
+Emission of the human-readable IR and assembly side-artifacts is **not** a profile
+concern — it is controlled only by the `--emit-ir` / `--emit-asm` CLI flags (see
+[cli.md](cli.md)).
+
+The `simd` lever is always the **consumer's**. Consistent with the root-vs-dependency
+strictness above, a dependency's `[profile.*]` is parsed permissively and never read
+to build the consumer, so a library's `simd` value is inert — the effective lever
+comes from the consumer's resolved profile. Libraries set nothing SIMD-specific and
+inherit the consumer's choice; there is no ecosystem fork and no dual API.
 
 The CLI selects and overrides at invocation time: `--profile <name>` picks the
 profile; `-g` forces `debug` on for one build regardless of the profile's key
@@ -428,10 +437,12 @@ abi = "win64"
 [profile.debug]
 opt   = 0
 debug = true
+simd  = "scalarize"
 
 [profile.release]
 opt   = 2
 debug = false
+simd  = "scalarize"
 ```
 
 The `gl` and `shim-x11` entries carry `os = "linux"`, so on a windows build cell
@@ -531,10 +542,12 @@ abi = "win64"
 [profile.debug]
 opt   = 0
 debug = false
+simd  = "scalarize"
 
 [profile.release]
 opt   = 2
 debug = false
+simd  = "scalarize"
 
 [artifact.mach]
 kind    = "bin"


### PR DESCRIPTION
Closes #2020. Part of #1965 (tier 2).

Rewrites the four hand-written reference pages from "planned / not yet
implemented" to shipped reality, now that tier 1 is merged (#2013 gate, #2014
SSE2, #2015 NEON, #2016 rv64gc scalarization, #2017 lever, plus #2030 shift
narrowing and #2043 zero-init). Prose only — no `.mach` source, no manifest
fixtures.

## Pages
- **`doc/language/types.md`** — the ten seeded 128-bit types listed
  exhaustively; single-`x` `<u|i|f><width>x<count>` grammar (corrects the old
  `(x<count>)*` / `f32x4x4` claim); `$size_of`/`$align_of` both `16`;
  arrays/pointers of vectors are ordinary; full-arity literals (no splat, per the
  closed #2019); all-zero default-init (#2043); comptime-const bounds-checked
  lane access, dynamic index unsupported; no scalar↔vector casts.
- **`doc/language/operators.md`** — drops every "planned"/"not yet" hedge; adds
  the honest lane-wise op table verified against sema: float `+ - * /`; integer
  `+ -`; integer `*` 16-bit lanes only; bitwise `& | ^ ~` on integer lanes; **no
  vector shifts** (`<< >>`, per #2030); no `%`, no integer `/`; comparison → the
  same-shape **unsigned mask** vector with the per-width element mapping.
- **`doc/language/policy.md`** — replaces the "one CPU instruction per operator"
  bullet with the shipped rule: one instruction on a capable target, a defined
  unrolled scalar expansion (reported at build time) otherwise; the incapable-target
  choice is the `simd` lever, not a compiler default.
- **`doc/manifest.md`** — documents the required `simd` key (`scalarize` |
  `require`), makes all three profile keys required, adds `simd = "scalarize"` to
  every `[profile.*]` snippet on the page, and states the consumer-inherits
  (no-ecosystem-fork) rule.

## Verification (against merged dev, not the design text)
- Every claim cross-checked against merged source: the sema op table
  (`infer.mach` — shifts rejected, mask widths via `vector_mask`), 16-byte
  `byte_size`/`byte_align`, the ten `vec_shape` spellings, lane-index bounds, and
  the `simd` lever semantics I implemented in #2017.
- **Every touched vector example compiles** through a from-source HEAD compiler,
  extracted into a throwaway project and built (`--emit obj`) on x86_64 (SSE2),
  aarch64 (NEON), and riscv64 (scalarize, emits the note). The negative claims
  (shifts, casts, `%`, integer `/`, wrong arity, dynamic index) were confirmed to
  be the exact compile errors stated. The schema snippets parse under the
  required-`simd` schema.
- Cross-checked `grammar.md`: a vector spelling is an ordinary `named-type`
  (recognized at resolve time), so no grammar production changed — no edit needed.

## Bars
Doc-only change: the diff touches only `doc/**` (no `src/**`, no tracked
`mach.toml`), so the compiler is byte-identical and the unit suite, int suite,
`-g` additivity, and self-host fixpoint are unaffected by construction.
