### PR TITLE
feat(dwarf): vector-type DIEs (DW_AT_GNU_vector) for the seeded vectors (#2018)

### DIFF
--- a/src/lang/be/codegen/dwarf.mach
+++ b/src/lang/be/codegen/dwarf.mach
@@ -91,6 +91,11 @@ val DW_AT_call_line:       u8 = 0x59;
 val DW_AT_data_member_location: u8 = 0x38;
 val DW_AT_count:                u8 = 0x37;
 
+# the GNU extension attribute marking a DW_TAG_array_type as a hardware vector so a
+# debugger renders it lane-by-lane (#1965/#2018). wider than a u8: its abbrev attr
+# code is written as ULEB directly, since emit_attr's `at` is a u8.
+val DW_AT_GNU_vector: u16 = 0x2107;
+
 # DW_AT_inline value: this subprogram is an abstract instance that was inlined (never
 # out-of-line here); its concrete expansions are DW_TAG_inlined_subroutine DIEs that
 # reference it by DW_AT_abstract_origin.
@@ -102,6 +107,7 @@ val DW_FORM_data8:      u8 = 0x07;
 val DW_FORM_string:     u8 = 0x08;
 val DW_FORM_data1:      u8 = 0x0b;
 val DW_FORM_flag:       u8 = 0x0c;
+val DW_FORM_flag_present: u8 = 0x19;
 val DW_FORM_ref4:       u8 = 0x13;
 val DW_FORM_udata:      u8 = 0x0f;
 val DW_FORM_strp:       u8 = 0x0e;
@@ -204,6 +210,9 @@ val ABBREV_STRUCT_LEAF_ANON: u8 = 0x1b;
 val ABBREV_UNION_ANON:       u8 = 0x1c;
 val ABBREV_UNION_LEAF_ANON:  u8 = 0x1d;
 val ABBREV_MEMBER_ANON:      u8 = 0x1e;
+
+# a hardware vector: a DW_TAG_array_type flagged DW_AT_GNU_vector (#1965/#2018).
+val ABBREV_VECTOR_ARRAY:     u8 = 0x1f;
 
 # name_off sentinel marking a composite / member with no source spelling, so the emitter
 # selects the *_ANON abbrev and omits DW_AT_name rather than emitting an empty strp (#1955)
@@ -451,12 +460,14 @@ fun home_eq(k1: u8, r1: i32, o1: i64, n1: i64, k2: u8, r2: i32, o2: i64, n2: i64
 
 # a type DIE's shape kind. TK_BASE is a scalar (DW_TAG_base_type); the rest are
 # composites: TK_STRUCT / TK_UNION carry members, TK_ARRAY an element + count,
-# TK_POINTER a pointee. Every kind records its emitted DIE offset for ref4
+# TK_POINTER a pointee, TK_VECTOR an element + lane count (a DW_AT_GNU_vector array).
+# Every kind records its emitted DIE offset for ref4
 val TK_BASE:    u8 = 0;
 val TK_STRUCT:  u8 = 1;
 val TK_UNION:   u8 = 2;
 val TK_ARRAY:   u8 = 3;
 val TK_POINTER: u8 = 4;
+val TK_VECTOR:  u8 = 5;
 
 # one type DIE in the compile unit's type table. A scalar base type (TK_BASE) carries
 # `encoding` / `byte_size` and is deduplicated by source spelling; a composite carries
@@ -758,7 +769,18 @@ fun sem_base_type(s: *session.Session, tid: semtype.TypeId, address_size: u8) O.
     if (tid == semtype.TYPE_NIL || tid == semtype.TYPE_ERROR) { ret O.none[TypeDie](); }
     val to: O.Option[*semtype.Type] = semtype.get(?s.types, tid);
     if (O.is_none[*semtype.Type](to)) { ret O.none[TypeDie](); }
-    val kind: semtype.TypeKind = O.unwrap[*semtype.Type](to).kind;
+    ret base_die_of_kind(O.unwrap[*semtype.Type](to).kind, address_size);
+}
+
+# build the TK_BASE TypeDie for a primitive scalar `kind` (its DW_ATE_* encoding, source
+# spelling, and byte width), or none when `kind` is not a primitive scalar. Shared by
+# `sem_base_type` (a scalar variable's type) and the vector intern path (a vector's lane
+# base type, whose element is stored as a bare scalar TypeKind, not a TypeId)
+# ---
+# kind:         a semantic TypeKind
+# address_size: target pointer width, for the raw `ptr` base
+# ret:          the base type DIE, or none for a non-scalar kind
+fun base_die_of_kind(kind: semtype.TypeKind, address_size: u8) O.Option[TypeDie] {
     val d: semtype.PrimDesc = semtype.prim_desc(kind);
     if (d.class == semtype.PRIM_CLASS_NONE) { ret O.none[TypeDie](); }
 
@@ -1140,6 +1162,19 @@ fun build_abbrev(b: *enc.ByteBuf) {
     emit_attr(b, DW_AT_data_member_location, DW_FORM_udata);
     uleb(b, 0); uleb(b, 0);
 
+    # a hardware vector: a DW_TAG_array_type over its lane base with DW_AT_GNU_vector so a
+    # debugger renders it lane-by-lane. the flag is DW_FORM_flag_present, so its presence
+    # lives here in the abbrev and the emitted DIE body stays byte-identical to a plain
+    # array's -- only the leading abbrev code differs (#1965/#2018). the wide attr code is
+    # written as ULEB directly (emit_attr's `at` is a u8).
+    uleb(b, ABBREV_VECTOR_ARRAY::u64);
+    uleb(b, DW_TAG_array_type::u64);
+    enc.emit_byte(b, DW_CHILDREN_yes);
+    emit_attr(b, DW_AT_type, DW_FORM_ref4);
+    uleb(b, DW_AT_GNU_vector::u64);
+    uleb(b, DW_FORM_flag_present::u64);
+    uleb(b, 0); uleb(b, 0);
+
     uleb(b, 0);   # null abbrev code terminates the table
 }
 
@@ -1363,6 +1398,16 @@ fun emit_type_dies(b: *enc.ByteBuf, tc: *TypeCtx, len_pos: usize, relocs: *InfoR
             enc.emit_byte(b, ABBREV_SUBRANGE);  # the single subrange child gives the count
             uleb(b, td.count::u64);             # DW_AT_count
             enc.emit_byte(b, 0);                # null DIE terminates the array's children
+        }
+        or (td.kind == TK_VECTOR) {
+            # identical body to TK_ARRAY: the DW_AT_GNU_vector flag lives in the abbrev
+            # (DW_FORM_flag_present), so only the leading abbrev code differs (#1965/#2018).
+            enc.emit_byte(b, ABBREV_VECTOR_ARRAY);
+            push_type_fixup(fixups, nfix, b.len::u32, td.elem::u32);
+            enc.emit_u32(b, 0);                 # DW_AT_type (ref4, patched) -- the lane base
+            enc.emit_byte(b, ABBREV_SUBRANGE);  # the single subrange child gives the lane count
+            uleb(b, td.count::u64);             # DW_AT_count
+            enc.emit_byte(b, 0);                # null DIE terminates the vector's children
         }
         or {
             # a memberless aggregate uses the DW_CHILDREN_no leaf abbrev (and no
@@ -3031,6 +3076,25 @@ fun type_intern(s: *session.Session, tgt: *target.Target, irmod: *ir.Module, tc:
         ret ix;
     }
 
+    if (kind == semtype.TYPE_VECTOR) {
+        # a vector is a DW_AT_GNU_vector array over its lane scalar, deduped by semantic id
+        # like the other composites. the lane is stored as a bare scalar TypeKind (not a
+        # TypeId), so intern its base DIE directly -- a scalar base never recurses back to a
+        # composite, so no interior cycle re-dedup is needed. size is synthesized by the
+        # consumer from element x count, so byte_size stays 0 (mirroring the plain array).
+        val ekind: semtype.TypeKind = t.data.vector.element;
+        val lanes: u32              = t.data.vector.lanes;
+        val obk: O.Option[TypeDie] = base_die_of_kind(ekind, address_size);
+        if (O.is_none[TypeDie](obk)) { ret -1; }
+        val el: i32 = base_intern(tc, strtab, O.unwrap[TypeDie](obk));
+        if (el < 0) { ret -1; }
+        val ix: i32 = comp_reserve(tc, TK_VECTOR, sem);
+        if (ix < 0) { ret -1; }
+        tc.types[ix::u32].elem  = el;
+        tc.types[ix::u32].count = lanes;
+        ret ix;
+    }
+
     if (kind == semtype.TYPE_REC || kind == semtype.TYPE_UNI || kind == semtype.TYPE_INSTANCE) {
         ret struct_intern(s, tgt, irmod, tc, strtab, sem, address_size);
     }
@@ -3384,7 +3448,7 @@ test "mach.lang.be.codegen.dwarf.build_abbrev:golden" {
     page.make(?alloc);
     var b: enc.ByteBuf = enc.buf_init(?alloc);
     build_abbrev(?b);
-    var e: [345]u8;
+    var e: [355]u8;
     e[0]=0x01; e[1]=0x11; e[2]=0x01; e[3]=0x25; e[4]=0x08; e[5]=0x03; e[6]=0x08; e[7]=0x1B;
     e[8]=0x08; e[9]=0x13; e[10]=0x05; e[11]=0x11; e[12]=0x01; e[13]=0x12; e[14]=0x07; e[15]=0x10;
     e[16]=0x17; e[17]=0x00; e[18]=0x00; e[19]=0x02; e[20]=0x24; e[21]=0x00; e[22]=0x03; e[23]=0x0E;
@@ -3456,8 +3520,10 @@ test "mach.lang.be.codegen.dwarf.build_abbrev:golden" {
     e[328]=0x1d; e[329]=0x17; e[330]=0x00; e[331]=0x0B; e[332]=0x0F; e[333]=0x00; e[334]=0x00;
     # ABBREV_MEMBER_ANON (0x1e): DW_TAG_member, no children, type ref4, data_member_location udata.
     e[335]=0x1e; e[336]=0x0D; e[337]=0x00; e[338]=0x49; e[339]=0x13; e[340]=0x38; e[341]=0x0F; e[342]=0x00; e[343]=0x00;
-    e[344]=0x00;   # null abbrev code terminates the table
-    val ok: bool = buf_eq(?b, ?e[0], 345);
+    # ABBREV_VECTOR_ARRAY (0x1f): DW_TAG_array_type, children, element type ref4, DW_AT_GNU_vector (0x2107 -> uleb 0x87 0x42) flag_present.
+    e[344]=0x1f; e[345]=0x01; e[346]=0x01; e[347]=0x49; e[348]=0x13; e[349]=0x87; e[350]=0x42; e[351]=0x19; e[352]=0x00; e[353]=0x00;
+    e[354]=0x00;   # null abbrev code terminates the table
+    val ok: bool = buf_eq(?b, ?e[0], 355);
     enc.buf_dnit(?b);
     if (!ok) { ret 1; }
     ret 0;
@@ -3509,6 +3575,48 @@ test "mach.lang.be.codegen.dwarf.emit_type_dies:composite_refs" {
     if (b.data[td[4].off::usize] != ABBREV_STRUCT_LEAF) { code = 1; }
     # the pointer references the struct, the array references the base.
     if (td[2].elem != 1 || td[3].elem != 0) { code = 1; }
+
+    enc.buf_dnit(?b);
+    ret code;
+}
+
+# a TK_VECTOR emits the DW_AT_GNU_vector array abbrev over its lane base, with a single
+# DW_TAG_subrange child carrying the lane count and a DW_AT_type ref4 fixup to the lane
+# base; its DIE body is byte-identical to a plain array's -- only the leading abbrev code
+# differs, because the vector flag rides the abbrev as DW_FORM_flag_present (#2018).
+test "mach.lang.be.codegen.dwarf.emit_type_dies:vector" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+    var code: i32 = 0;
+
+    # types: [0] base i32, [1] i32x4 vector (lane base -> 0, four lanes).
+    var td: [2]TypeDie;
+    td[0].kind=TK_BASE;   td[0].off=0; td[0].sem=semtype.TYPE_NIL; td[0].name="i32"; td[0].name_off=1; td[0].encoding=DW_ATE_signed; td[0].byte_size=4; td[0].elem=-1; td[0].count=0; td[0].memb_start=0; td[0].memb_count=0;
+    td[1].kind=TK_VECTOR; td[1].off=0; td[1].sem=200; td[1].name=""; td[1].name_off=0; td[1].encoding=0; td[1].byte_size=0; td[1].elem=0; td[1].count=4; td[1].memb_start=0; td[1].memb_count=0;
+
+    var tc: TypeCtx;
+    tc.alloc=?alloc; tc.types=?td[0]; tc.ntypes=2; tc.type_cap=2; tc.membs=nil; tc.nmemb=0; tc.memb_cap=0;
+
+    var relocs: [16]InfoReloc;
+    var rc: u32 = 0;
+    var fixups: [8]TypeFixup;
+    var nfix: u32 = 0;
+    var b: enc.ByteBuf = enc.buf_init(?alloc);
+    emit_type_dies(?b, ?tc, 0, ?relocs[0], ?rc, ?fixups[0], ?nfix);
+
+    # the vector DIE opens with ABBREV_VECTOR_ARRAY, not the plain-array abbrev.
+    if (b.data[td[1].off::usize] != ABBREV_VECTOR_ARRAY) { code = 1; }
+    # exactly one ref4 fixup: the vector -> its lane base type, patched to the base's offset.
+    if (nfix != 1) { code = 1; }
+    or {
+        if (bin.read_u32_le(b.data, fixups[0].pos::usize) != td[0].off) { code = 1; }
+        if (fixups[0].target != 0)                                      { code = 1; }
+    }
+    # abbrev code (1) + DW_AT_type ref4 (4) => the subrange child opens at off+5, its
+    # DW_AT_count uleb (4) at off+6, and the null child terminator at off+7.
+    if (b.data[(td[1].off + 5)::usize] != ABBREV_SUBRANGE) { code = 1; }
+    if (b.data[(td[1].off + 6)::usize] != 4)               { code = 1; }
+    if (b.data[(td[1].off + 7)::usize] != 0)               { code = 1; }
 
     enc.buf_dnit(?b);
     ret code;


### PR DESCRIPTION
Closes #2018. Part of #1965. Tier-2 debug-info follow-up, consuming the tier-1 semantic vector type and the merged SSE2 backend (#2014).

## What

The ten seeded 128-bit vector types now have a DWARF representation, so `-g` builds describe vector-typed locals/params and a debugger prints them lane-by-lane.

Each vector emits a `DW_TAG_array_type` carrying `DW_AT_GNU_vector` (0x2107) over its lane base type, with a `DW_TAG_subrange_type` child whose `DW_AT_count` is the lane count — the established GNU encoding gdb/lldb recognize as a hardware vector. The flag rides the abbrev as `DW_FORM_flag_present`, so a vector DIE body is **byte-identical** to a plain array's; only the leading abbrev code differs.

- New `TK_VECTOR` kind reusing the array `elem`/`count` links; dedups by semantic id like the other composites.
- `type_intern` `TYPE_VECTOR` branch: the lane is stored on the vector type as a bare scalar `TypeKind` (not a `TypeId`), so it interns the lane base via a shared `base_die_of_kind` extracted from `sem_base_type`.
- `emit_type_dies` `TK_VECTOR` arm mirrors `TK_ARRAY` with `ABBREV_VECTOR_ARRAY`.
- `build_abbrev` gains `ABBREV_VECTOR_ARRAY` (0x1f) unconditionally, so the post-#2009 `.debug_abbrev` cross-module dedup stays valid.
- New wide `DW_AT_GNU_vector: u16` (its abbrev attr code is written as ULEB, since `emit_attr`'s `at` is u8) and `DW_FORM_flag_present`.

**VarLoc is unchanged.** A vector local gets its `DW_AT_location` through the existing register/frame-slot path; the per-ISA DWARF register tables already cover the vector-bearing registers (x86_64 xmm0..15 → 17..32, aarch64 v0..31 → 64..95, rv64 f0..31 → 32..63), so no register-map change was needed (confirmed, per the issue's register-table check — nothing missing).

## Verification (native x86_64, SSE2)

`llvm-dwarfdump --verify` clean and the DIEs present at both profiles. The type DIE for `i32x4`:

```
DW_TAG_array_type
  DW_AT_type       ("i32")
  DW_AT_GNU_vector (true)
  DW_TAG_subrange_type
    DW_AT_count    (4)
```

**Money proof** — gdb at a post-prologue breakpoint, an `i32x4` and an `f32x4` local, both `-g` profiles:

```
# debug
$1 = {41, 20, 300, 4000}      # i32x4
$2 = {1.5, 2.5, 3.5, 4.5}     # f32x4
# release
$1 = {41, 20, 300, 4000}
$2 = {1.5, 2.5, 3.5, 4.5}
```

Lane-by-lane, correct element rendering, at both debug and release — not `<optimized out>` or zeros.

## Tests

- `emit_type_dies:vector` — the vector DIE opens with `ABBREV_VECTOR_ARRAY`, a single ref4 fixup to the lane base, a subrange child with the count.
- `build_abbrev:golden` — the expected byte array extended for `ABBREV_VECTOR_ARRAY` (10 bytes: `DW_AT_GNU_vector` 0x2107 → uleb `0x87 0x42`), `[345]u8` → `[355]u8`.

Suite: dev 602 → 603 (+1).

## Note (out of scope)

Two vector locals simultaneously live across a call can share one register home (`DW_OP_reg17`), so gdb reads only the one currently resident correctly — the existing VarLoc single-location behavior (scalars emit the same single-exprloc form; a loclist would be needed to track a spilled value). Not introduced here and out of #2018's "VarLoc unchanged" scope; each vector reads correctly when inspected where it lives (shown above). Also noted: `sem_to_ir` treats a vector as an opaque pointer-width slot, so a struct with a vector *member* would get wrong DWARF member offsets — a latent gap orthogonal to vector locals/params; flagging rather than widening scope.
