### PR TITLE
fix(dwarf): correct DWARF member offsets for a struct with a vector member (#2051)

### DIFF
--- a/src/lang/be/codegen/dwarf.mach
+++ b/src/lang/be/codegen/dwarf.mach
@@ -845,6 +845,19 @@ fun sem_to_ir(s: *session.Session, irmod: *ir.Module, sem: semtype.TypeId) R.Res
         ret ir_type.intern_array(?irmod.types, R.unwrap_ok[ir_type.IrTypeId, str](rb), ecount);
     }
 
+    # a vector bridges to an IRT_VECTOR over its lowered lane scalar, exactly as
+    # `lower_type` does, so a vector struct member is laid out at its true 16-byte size
+    # and its DWARF member offset agrees with the emitted code -- not the pointer-width
+    # slot the fallthrough would give (#2051). the lane is a bare scalar TypeKind.
+    if (k == semtype.TYPE_VECTOR) {
+        val ed: semtype.PrimDesc = semtype.prim_desc(t.data.vector.element);
+        val lanes: u32 = t.data.vector.lanes;
+        var res_elem: R.Result[ir_type.IrTypeId, str] = ir_type.intern_int(?irmod.types, ed.bits);
+        if (ed.class == semtype.PRIM_CLASS_FLOAT) { res_elem = ir_type.intern_float(?irmod.types, ed.bits); }
+        if (R.is_err[ir_type.IrTypeId, str](res_elem)) { ret res_elem; }
+        ret ir_type.intern_vector(?irmod.types, R.unwrap_ok[ir_type.IrTypeId, str](res_elem), lanes);
+    }
+
     if (k == semtype.TYPE_REC || k == semtype.TYPE_UNI || k == semtype.TYPE_INSTANCE) {
         ret sem_to_ir_nominal(s, irmod, sem, k == semtype.TYPE_UNI);
     }
@@ -3619,6 +3632,45 @@ test "mach.lang.be.codegen.dwarf.emit_type_dies:vector" {
     if (b.data[(td[1].off + 7)::usize] != 0)               { code = 1; }
 
     enc.buf_dnit(?b);
+    ret code;
+}
+
+# sem_to_ir bridges a vector to an IRT_VECTOR of its lane scalar (16 bytes for the seeded
+# shapes), not the pointer-width slot the fallthrough gave -- so a vector struct member is
+# laid out at its true size and its DWARF DW_AT_data_member_location agrees with the code
+# the backend emitted, rather than shifting every later member by 8 bytes (#2051).
+test "mach.lang.be.codegen.dwarf.sem_to_ir:vector" {
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    val sr: R.Result[session.Session, str] = session.init(?alloc);
+    if (R.is_err[session.Session, str](sr)) { ret 1; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](sr);
+
+    var code: i32 = 0;
+    val rv: R.Result[semtype.TypeId, str] = semtype.intern_vector(?s.types, semtype.TYPE_F32, 4);
+    if (R.is_err[semtype.TypeId, str](rv)) { code = 1; }
+    or {
+        val vec_sem: semtype.TypeId = R.unwrap_ok[semtype.TypeId, str](rv);
+        val im: R.Result[ir.Module, str] = ir.init(?alloc, intern.STR_NIL);
+        if (R.is_err[ir.Module, str](im)) { code = 1; }
+        or {
+            var m: ir.Module = R.unwrap_ok[ir.Module, str](im);
+            val ri: R.Result[ir_type.IrTypeId, str] = sem_to_ir(?s, ?m, vec_sem);
+            if (R.is_err[ir_type.IrTypeId, str](ri)) { code = 1; }
+            or {
+                val ot: O.Option[*ir_type.IrType] = ir_type.get(?m.types, R.unwrap_ok[ir_type.IrTypeId, str](ri));
+                if (O.is_none[*ir_type.IrType](ot)) { code = 1; }
+                or {
+                    val it: *ir_type.IrType = O.unwrap[*ir_type.IrType](ot);
+                    # pre-fix this was IRT_PTR (8 bytes); it must be a 4-lane vector.
+                    if (it.kind != ir_type.IRT_VECTOR)  { code = 1; }
+                    if (it.data.vector_.lanes != 4)     { code = 1; }
+                }
+            }
+            ir.dnit(?m);
+        }
+    }
+    session.dnit(?s);
     ret code;
 }
 


### PR DESCRIPTION
Closes #2051. Part of #1965. The debug-info-only gap surfaced while triaging PR #2050 (#2018).

## Problem

`sem_to_ir` in `dwarf.mach` — the bridge that gives `struct_intern` an IR type per member to compute DWARF `DW_AT_data_member_location` — had no `TYPE_VECTOR` branch, so a vector member fell through to `intern_ptr` (pointer-width, 8 bytes). `struct_intern` then laid out the DWARF members on that wrong model, shifting the vector member and every member after it. The **runtime layout was always correct** (`lower_type`, the layout authority, sizes a vector at 16 bytes) — this was strictly a debug-info bug: a debugger reading a struct with a vector member got wrong offsets.

For `rec S { tag: i32; v: f32x4; tail: i64 }` the DWARF member offsets were `tag@0, v@8, tail@16` while the real layout is `tag@0, v@16, tail@32` (size 48). `llvm-dwarfdump --verify` passed anyway — it doesn't cross-check offsets against the real layout.

## Fix

Add the `TYPE_VECTOR` branch to `sem_to_ir`, mirroring `lower_type`: bridge to `ir_type.intern_vector` over the lowered lane scalar. The DWARF member offset now comes from the same 16-byte layout the code emits.

After the fix, `S`'s member offsets: `tag@0, v@16, tail@32` — matching the runtime layout, `--verify` still clean.

## Verification

- The `rec S` fixture, `-g` debug: DWARF `DW_AT_data_member_location` now `0 / 16 / 32` (was `0 / 8 / 16`); `--verify` clean; runtime unchanged (`sizeof_S=48`, all member/lane reads exact through the struct and a pointer).
- Guard test `sem_to_ir:vector` asserts a vector bridges to an `IRT_VECTOR` (not a pointer); proven to fail with the fix disabled.

## Bars

- Suite: dev 603 → 604 (+1).
- Non-vector byte-identity: my compiler and the dev compiler produce a byte-identical `bin/mach` from dev source (the change only fires under `-g`, so non-`g` output is unchanged).
- Self-host fixpoint s2==s3. `-g` self-host `llvm-dwarfdump --verify` clean. int green on linux incl. `surface/debuginfo`.
