### PR TITLE
fix(abi): win64 classifies 128-bit vectors (XMM); ungate the by-value proof (#2055)

### DIFF
--- a/src/lang/be/codegen/mir/abi.mach
+++ b/src/lang/be/codegen/mir/abi.mach
@@ -1640,26 +1640,20 @@ fun rt_lane_ok(v: i32x4, l0: i32, l1: i32, l2: i32, l3: i32) bool {
 }
 
 test "mach.lang.be.codegen.mir.abi:vector_by_value_roundtrip" {
-    # win64's vector-by-value ABI is a separate, never-implemented gap (#2055): win64
-    # is the only classifier without an `is_vector` branch, so a 128-bit vector is
-    # mis-passed as CLASS_GP. skip the by-value exercise on windows until #2055 lands;
-    # the SysV/NEON capture-width fix (#2053) this guards is unaffected by it.
-    $if ($mach.build.os == $mach.os.windows) {
-        ret 0;
-    } $or {
-        val src: i32x4 = i32x4{266, 10, 70000, 40000};
-        # ret-of-arg (passthru): the arg is loaded from a slot into the arg register.
-        if (!rt_lane_ok(rt_passthru(src), 266, 10, 70000, 40000)) { ret 1; }
-        # ret-of-literal: a slot-materialized literal captured into the return register.
-        if (!rt_lane_ok(rt_litret(), 266, 10, 70000, 40000)) { ret 1; }
-        # ret-of-local.
-        if (!rt_lane_ok(rt_localret(266), 266, 10, 70000, 40000)) { ret 1; }
-        # ret-of-call-result: a returned vector captured, then passed and returned again.
-        if (!rt_lane_ok(rt_passthru(rt_litret()), 266, 10, 70000, 40000)) { ret 1; }
-        # op-result return (register-resident -- the path tier-1 already proved).
-        if (!rt_lane_ok(rt_add_one(src), 267, 11, 70001, 40001)) { ret 1; }
-        # mixed scalar + vector signature round-trip.
-        if (!rt_lane_ok(rt_mixed(5, src, 9), 271, 19, 140000, 80000)) { ret 1; }
-        ret 0;
-    }
+    # runs on every target now that win64 classifies vectors in XMM (#2055), same as
+    # the SysV / AAPCS64 by-value-in-a-vector-register convention this already proved.
+    val src: i32x4 = i32x4{266, 10, 70000, 40000};
+    # ret-of-arg (passthru): the arg is loaded from a slot into the arg register.
+    if (!rt_lane_ok(rt_passthru(src), 266, 10, 70000, 40000)) { ret 1; }
+    # ret-of-literal: a slot-materialized literal captured into the return register.
+    if (!rt_lane_ok(rt_litret(), 266, 10, 70000, 40000)) { ret 1; }
+    # ret-of-local.
+    if (!rt_lane_ok(rt_localret(266), 266, 10, 70000, 40000)) { ret 1; }
+    # ret-of-call-result: a returned vector captured, then passed and returned again.
+    if (!rt_lane_ok(rt_passthru(rt_litret()), 266, 10, 70000, 40000)) { ret 1; }
+    # op-result return (register-resident -- the path tier-1 already proved).
+    if (!rt_lane_ok(rt_add_one(src), 267, 11, 70001, 40001)) { ret 1; }
+    # mixed scalar + vector signature round-trip.
+    if (!rt_lane_ok(rt_mixed(5, src, 9), 271, 19, 140000, 80000)) { ret 1; }
+    ret 0;
 }

--- a/src/lang/target/abi/win64.mach
+++ b/src/lang/target/abi/win64.mach
@@ -192,7 +192,7 @@ pub fun classify(size: u64, align: u64, is_float: bool, fp_eightbytes: u8,
 # is_float:      true if the argument goes in FP registers (scalar floats)
 # fp_eightbytes: per-eightbyte SSE mask (unused -- win64 aggregates ride GP)
 # is_aggregate:  true if the argument is an aggregate
-# is_vector:     true for a 128-bit SIMD vector (#1965); neutral, unread here
+# is_vector:     true for a 128-bit SIMD vector (#1965); routed to an XMM register (#2055)
 # gp_used:       GP registers already consumed
 # fp_used:       FP registers already consumed
 # hfa_members:   HFA member count (AAPCS64-only; unused under win64)
@@ -204,6 +204,21 @@ pub fun classify_arg(index: i32, size: u64, align: u64,
                      gp_used: i32, fp_used: i32, hfa_members: u8, hfa_elem: u8,
                      agg: abi.AggLayout) abi.ParamSlot {
     val slot: i32 = slot_index(gp_used, fp_used);
+
+    # DELIBERATE DEVIATION (#2055): mach passes its own 128-bit vector types in an XMM
+    # argument register (spilling by value to the stack once XMM0-3 are exhausted),
+    # matching the SysV / AAPCS64 internal convention and consistent across all four
+    # ABIs. This is NOT the Microsoft x64 __m128 convention, which passes 16-byte
+    # vectors BY REFERENCE (a caller-allocated copy's pointer). mach's vectors have no
+    # C FFI surface today, so every vector call is mach->mach and XMM is correct for all
+    # of them; C interop with a vector-typed `ext` fun on windows is not ABI-conformant
+    # until the by-reference marshalling of RFC #2058 is ruled in.
+    if (is_vector) {
+        if (slot < PARAM_SLOT_COUNT) {
+            ret abi.make_slot(abi.CLASS_FP, slot_fp_reg(slot), -1, 0, size);
+        }
+        ret abi.make_slot(abi.CLASS_STACK, -1, -1, 0, size);
+    }
 
     if (is_aggregate) {
         # 1/2/4/8-byte aggregates ride one integer register by value; every other
@@ -253,7 +268,7 @@ pub fun classify_arg(index: i32, size: u64, align: u64,
 # is_float:      true if the value is returned in FP registers (scalar floats)
 # fp_eightbytes: per-eightbyte SSE mask (unused -- win64 returns aggregates in RAX)
 # is_aggregate:  true if the value is an aggregate
-# is_vector:     true for a 128-bit SIMD vector (#1965); neutral, unread here
+# is_vector:     true for a 128-bit SIMD vector (#1965); routed to an XMM register (#2055)
 # hfa_members:   HFA member count (AAPCS64-only; unused under win64)
 # hfa_elem:      HFA fundamental member width (AAPCS64-only; unused under win64)
 # agg:           the flattened-aggregate descriptor (lp64d-only; unused under win64)
@@ -263,6 +278,13 @@ pub fun classify_return(size: u64, align: u64,
                         hfa_members: u8, hfa_elem: u8, agg: abi.AggLayout) abi.ParamSlot {
     if (size == 0) {
         ret abi.make_slot(abi.CLASS_GP, -1, -1, 0, 0);
+    }
+
+    # a 128-bit vector returns in XMM0 (#2055). This matches BOTH the deliberate
+    # internal-XMM argument convention above AND the Microsoft x64 __m128 return rule,
+    # which happens to agree on the return side (only the argument side deviates).
+    if (is_vector) {
+        ret abi.make_slot(abi.CLASS_FP, REG_XMM0, -1, 0, size);
     }
 
     if (is_aggregate) {


### PR DESCRIPTION
Closes #2055. Part of #1965. Fixes the shipped win64 vector miscompile surfaced by #2054's colocated test.

## Bug

`win64.mach` was the **only** ABI classifier without an `is_vector` branch (sysv/aapcs64/lp64 all have one). A native 128-bit vector (`has_v128` is true on the x64 ISA) has `is_aggregate == false` and `is_float == false`, so it fell through to `CLASS_GP` and was mis-passed in a single 8-byte GP register — silent garbage for any by-value vector arg/return on windows-x86_64, shipped in v3.4.0 and v3.4.1.

## Fix (per team ruling: XMM, not MS by-ref)

Classify a win64 vector in an **XMM** argument register (spilling by value to the stack past XMM0-3) and **return it in XMM0** — the same by-value-in-a-vector-register convention as SysV / AAPCS64, consistent across all four ABIs and riding the merged #2053 capture path with zero new machinery.

This is a **deliberate deviation** from the Microsoft x64 `__m128` by-reference argument convention, documented in the `win64.mach` branch. mach's vector types have no C FFI surface, so every vector call is mach→mach where XMM is correct. I evaluated MS-conformant by-reference and it needs substantial two-sided machinery (caller materialization of register-class vectors + a callee by-ref-vector value model, since `CLASS_BYREF` assumes memory-resident aggregates); that's deferred to **RFC #2058** (win64 vector ABI conformance, owner-blocked — proposes boundary-only marshalling at `ext` calls if C vector FFI ever matters).

## Verification

- The #2054 colocated test `abi:vector_by_value_roundtrip` is **ungated off windows** and now runs on every target as the win64 proof (passthru / ret-of-literal / ret-of-local / ret-of-call-result / op-result / mixed signature, discriminating lanes).
- **Full suite 605/605 on linux AND on windows-x86_64 under wine.**
- Self-host fixpoint; non-vector byte-identity (the `is_vector` branch is inert for non-vector code, and win64.mach doesn't affect linux); int green on linux.

## Useful discovery for future windows fixes

`mach test --target windows-x86_64` **executes the produced PE under wine** on the linux host — so win64 behavior is provable locally, not CI-only. This is how the win64 proof above was run. Worth reusing for any future windows codegen/ABI fix.
