### PR TITLE
fix(inline): preserve callee-parameter operand type on substitution (#2035)

### DIFF
--- a/src/lang/me/pass/inline.mach
+++ b/src/lang/me/pass/inline.mach
@@ -1241,3 +1241,100 @@ test "mach.lang.me.pass.inline.callee_instr_count:dbg_value_blind" {
     if (clean + kdbg < INLINE_INSTR_THRESHOLD) { ret 1; }
     ret 0;
 }
+
+# #2035: when the inliner substitutes a callee's VAL_PARAM operand with the
+# caller's actual argument, it must preserve the operand's use-site type. a
+# by-value aggregate argument is the actual's address retyped to the aggregate;
+# a call with no signature classifies its ABI from that per-operand type, so
+# clobbering it with the actual's bare pointer type mis-sizes the argument.
+# builds `caller` calling `f(ptr-actual)`, where `f`'s body passes its parameter
+# (stamped as a 24-byte aggregate) to an extern `sink`; after inlining `f`, the
+# surviving `sink` call's argument operand must still carry the aggregate type,
+# not the actual's pointer type.
+test "mach.lang.me.pass.inline.run:preserves_aggregate_param_operand_type" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+    val res_m: R.Result[ir.Module, str] = ir.init(?alloc, intern.STR_NIL);
+    if (R.is_err[ir.Module, str](res_m)) { ret 1; }
+    var m: ir.Module = R.unwrap_ok[ir.Module, str](res_m);
+
+    val rv: R.Result[type.IrTypeId, str] = type.intern_void(?m.types);
+    if (R.is_err[type.IrTypeId, str](rv)) { ir.dnit(?m); ret 1; }
+    val voidty: type.IrTypeId = R.unwrap_ok[type.IrTypeId, str](rv);
+    val ri: R.Result[type.IrTypeId, str] = type.intern_int(?m.types, 64);
+    if (R.is_err[type.IrTypeId, str](ri)) { ir.dnit(?m); ret 1; }
+    val i64t: type.IrTypeId = R.unwrap_ok[type.IrTypeId, str](ri);
+    val rp: R.Result[type.IrTypeId, str] = type.intern_ptr(?m.types);
+    if (R.is_err[type.IrTypeId, str](rp)) { ir.dnit(?m); ret 1; }
+    val ptrt: type.IrTypeId = R.unwrap_ok[type.IrTypeId, str](rp);
+    var fields: [3]type.IrTypeId;
+    fields[0] = i64t; fields[1] = i64t; fields[2] = i64t;
+    val ra: R.Result[type.IrTypeId, str] = type.intern_struct(?m.types, ?fields[0], 3, 8);
+    if (R.is_err[type.IrTypeId, str](ra)) { ir.dnit(?m); ret 1; }
+    val aggt: type.IrTypeId = R.unwrap_ok[type.IrTypeId, str](ra);
+
+    # signatures: sink(agg), f(agg), caller(ptr) -- all returning void.
+    val rsig_a: R.Result[type.IrTypeId, str] = type.intern_fn(?m.types, voidty, ?aggt, 1);
+    if (R.is_err[type.IrTypeId, str](rsig_a)) { ir.dnit(?m); ret 1; }
+    val sig_agg: type.IrTypeId = R.unwrap_ok[type.IrTypeId, str](rsig_a);
+    var pptr: type.IrTypeId = ptrt;
+    val rsig_p: R.Result[type.IrTypeId, str] = type.intern_fn(?m.types, voidty, ?pptr, 1);
+    if (R.is_err[type.IrTypeId, str](rsig_p)) { ir.dnit(?m); ret 1; }
+    val sig_ptr: type.IrTypeId = R.unwrap_ok[type.IrTypeId, str](rsig_p);
+
+    # function 0: extern sink (no body, never inlined).
+    val r_sink: R.Result[u32, str] = ir.function_add(?m, intern.STR_NIL, sig_agg, ir.FN_FLAG_EXTERN);
+    if (R.is_err[u32, str](r_sink)) { ir.dnit(?m); ret 1; }
+    val sink_ix: u32 = R.unwrap_ok[u32, str](r_sink);
+
+    var bld: builder.Builder = builder.init(?m);
+
+    # function 1: f(p) { sink(p); ret; } -- p stamped as the aggregate at the use.
+    val r_f: R.Result[u32, str] = ir.function_add(?m, intern.STR_NIL, sig_agg, 0);
+    if (R.is_err[u32, str](r_f)) { ir.dnit(?m); ret 1; }
+    val f_ix: u32 = R.unwrap_ok[u32, str](r_f);
+    builder.set_function(?bld, ?m.functions[f_ix]);
+    val rfb: R.Result[id.BlockId, str] = builder.new_block(?bld);
+    if (R.is_err[id.BlockId, str](rfb)) { ir.dnit(?m); ret 1; }
+    builder.set_block(?bld, R.unwrap_ok[id.BlockId, str](rfb));
+    var f_arg: value.Value = value.param(0, aggt);
+    val rfc: R.Result[value.Value, str] = builder.emit_call(?bld, value.fn(sink_ix, sig_agg), ?f_arg, 1, voidty);
+    if (R.is_err[value.Value, str](rfc)) { ir.dnit(?m); ret 1; }
+    if (R.is_err[bool, str](builder.emit_ret_void(?bld))) { ir.dnit(?m); ret 1; }
+
+    # function 2: caller(q) { f(q); ret; } -- q is a bare pointer, the mis-typed actual.
+    val r_c: R.Result[u32, str] = ir.function_add(?m, intern.STR_NIL, sig_ptr, 0);
+    if (R.is_err[u32, str](r_c)) { ir.dnit(?m); ret 1; }
+    val caller_ix: u32 = R.unwrap_ok[u32, str](r_c);
+    builder.set_function(?bld, ?m.functions[caller_ix]);
+    val rcb: R.Result[id.BlockId, str] = builder.new_block(?bld);
+    if (R.is_err[id.BlockId, str](rcb)) { ir.dnit(?m); ret 1; }
+    builder.set_block(?bld, R.unwrap_ok[id.BlockId, str](rcb));
+    var c_arg: value.Value = value.param(0, ptrt);
+    val rcc: R.Result[value.Value, str] = builder.emit_call(?bld, value.fn(f_ix, sig_agg), ?c_arg, 1, voidty);
+    if (R.is_err[value.Value, str](rcc)) { ir.dnit(?m); ret 1; }
+    if (R.is_err[bool, str](builder.emit_ret_void(?bld))) { ir.dnit(?m); ret 1; }
+
+    val r_run: R.Result[bool, str] = run(?m, nil);
+    if (R.is_err[bool, str](r_run)) { ir.dnit(?m); ret 1; }
+
+    # after inlining f into caller, the surviving sink call's argument operand must
+    # still be the aggregate type. a clobbered stamp would leave it the pointer type.
+    val caller_fn: *ir.Function = ?m.functions[caller_ix];
+    var bad: i32 = 1;
+    var i: u32 = 0;
+    for (i < caller_fn.instr_len) {
+        val oi: O.Option[*instruction.Instruction] = ir.instruction_get(caller_fn, i::id.InstructionId);
+        if (O.is_some[*instruction.Instruction](oi)) {
+            val ins: *instruction.Instruction = O.unwrap[*instruction.Instruction](oi);
+            if (ins.kind == instruction.OP_CALL && ins.operand_count >= 2 &&
+                ins.operands[1].kind == value.VAL_PARAM) {
+                if (ins.operands[1].ty == aggt) { bad = 0; }
+                or { bad = 2; }
+            }
+        }
+        i = i + 1;
+    }
+    ir.dnit(?m);
+    ret bad;
+}

--- a/src/lang/me/pass/inline.mach
+++ b/src/lang/me/pass/inline.mach
@@ -761,7 +761,14 @@ fun remap_clone_operands(cx: *InlineCtx) {
                 if (op.kind == value.VAL_PARAM) {
                     val param_ix: u32 = op.data.param_ix;
                     if (param_ix < cx.arg_count) {
-                        clone.operands[ii] = cx.args[param_ix];
+                        # preserve the use-site type: the callee body's operand ty is its
+                        # ABI contract (a by-value aggregate arg is the actual's address
+                        # retyped to the aggregate). replacing it wholesale with the
+                        # actual's ty (e.g. a bare ptr) mis-classifies the call (#2035);
+                        # the VAL_INSTR arm below already preserves ty for the same reason.
+                        var sub: value.Value = cx.args[param_ix];
+                        sub.ty = op.ty;
+                        clone.operands[ii] = sub;
                     }
                 } or (op.kind == value.VAL_INSTR) {
                     val callee_iid: u32 = op.data.instr::u32;


### PR DESCRIPTION
Fixes the -O2 miscompile in #2035: a generic callee taking a by-value aggregate, whose argument reaches the call through an inlined function's parameter, was passed as a pointer while the callee homed it by value from the stack — a silent wrong value (the observed brokerd SIGSEGV is one manifestation; masked shapes ran silently wrong).

Closes #2035.

## Root cause (debugger writeup: #2035 comment 4945269260)
Generic-instance callee references carry no signature (typed bare `ptr`), so every generic call ABI-classifies each argument from its operand's own `Value.ty`. The front end keeps that correct by stamping a by-value aggregate argument's operand with the aggregate type. `remap_clone_operands` then substituted a cloned `VAL_PARAM` operand **wholesale** with the caller's actual-argument `Value` — including its type — destroying the stamp: the aggregate operand became the actual's bare `ptr`, so an inlined call passed a >8-byte aggregate in a register while the callee read it by value from the stack.

## Fix (8 lines)
Preserve the cloned use's type on `VAL_PARAM` substitution (`sub = args[pix]; sub.ty = op.ty`), matching the adjacent `VAL_INSTR` arm which already does. This closes every known miscompile path — generic direct calls and the varargs/indirect cases — at the single stamp-destroying site, with no change to the ABI classification path. Affects shipped v1.0.0–v3.4.2 at opt≥1; -O0 unaffected.

## Scope (companion "primary" deferred — ruled by team-lead)
The debugger's second fix (give generic-instance callee refs their true `IRT_FN` so calls classify from the declared signature) is intentionally **not** here. A caller-side sig computation mis-resolves nested-generic params to pointer-width (`lower_type`'s erasure fallback, because the nested generic needs the callee decl's type-param binding, unavailable in the caller's context) and regresses correct code. Verified the ABI classifier itself is sound: a non-generic function taking a `{i8,{i64,ptr}}`-shaped 24-byte aggregate by value is correct at both -O0 and -O2 (sysv `classify_arg` is shape-blind, no by-ref form). The FE already stamps operands correctly at every non-inlined site, so the inliner was the only stamp-destroyer — the companion alone fully fixes #2035. Filed as follow-ups: the primary invariant (needs the reference sig computed in the callee's lowering context) and the dual same-name instance Function entries.

## Regression test
A colocated unit test over `inline.run` (`inline.mach`): a callee passes its parameter — stamped as a 24-byte aggregate — to an extern call; the caller invokes it with a bare-pointer actual. After inlining, the surviving call's argument operand must still carry the aggregate type. Fails (exit 2) against the pre-fix wholesale substitution, passes with the type preserved. It's **opt-independent** (tests the pass directly), so it guards in CI's default `mach test` run — a runtime test can't, since the miscompile only fires at opt≥1 and CI compiles the unit suite at the default (debug/opt=0) profile.

## Verification
| bar | result |
|-----|--------|
| brokerd (mach-mqtt) at -O2 | ✓ blocks in accept (was SIGSEGV); masked variant prints `len=0` truthfully |
| mqtt suite, both profiles | ✓ 39/39 (was 38/39 under the primary fix; companion has zero regression) |
| colocated inline unit test | ✓ fail-pre (exit 2) / pass-post |
| full unit suite via fresh HEAD | ✓ 606 / 606 (baseline 605 + the regression test) |
| self-host fixpoint | ✓ g2 == g3 byte-identical (the fix is byte-neutral for the compiler — its generics don't hit the buggy inlined-aggregate-param pattern, so g1 == g2 too; deltas are surgical) |
| non-generic byte-identity (baseline vs fixed) | ✓ identical, both profiles |
| generic-pattern program (baseline vs fixed) | ✓ differs — the fix corrects the mis-typed call |
| int suite (linux) | ✓ all cases passed |
| llvm-dwarfdump --verify (-g build) | ✓ No errors |
