### PR TITLE
test(codegen): colocated runtime vector per-op suite (#2038)

### DIFF
--- a/src/lang/be/codegen/vector_runtime.mach
+++ b/src/lang/be/codegen/vector_runtime.mach
@@ -1,0 +1,560 @@
+# colocated runtime lane-exactness suite for the seeded 128-bit vector types
+# (#2038, part of #1965). every increment-1 table operator is exercised on every
+# legal shape and asserted lane-exact against a scalar reference, plus lane
+# read/write, ABI round-trips, and spill pressure.
+#
+# an orphan module: `mach build` never reaches it (the compiler binary is
+# unaffected, so the self-host fixpoint and byte-identity hold), while `mach test`
+# loads it as a collection root and runs it natively on the x86_64 and aarch64
+# legs. riscv64 does not run `mach test` under qemu-user (#2016), so its lane
+# coverage stays the separate int-case decision; the scalarize pass shares this
+# source once that lane exists.
+#
+# DISCRIMINATING VALUES are designed in so a wrong element arrangement can never
+# pass silently: arithmetic operands force a carry/borrow across a byte boundary
+# inside the lane (a byte-collapsed `.16b`/element-0 op drops it), comparisons use
+# operands whose low bytes collide but whose wider bytes differ (a byte compare
+# leaks a partial mask), and signed/unsigned ordering uses sign-straddling
+# operands (a wrong-signedness compare inverts the mask). see #2037 (the
+# regalloc `vec_lane` drop that made every op read `.16b`) for why this matters.
+
+# all-ones mask lane per element width.
+val M8:  u8  = 255;
+val M16: u16 = 65535;
+val M32: u32 = 4294967295;
+val M64: u64 = 18446744073709551615;
+
+test "mach.lang.be.codegen.vector_runtime.arith:f32x4" {
+    var a: f32x4 = f32x4{ 1.5, 2.0, 3.0, 4.0 };
+    var b: f32x4 = f32x4{ 0.5, 6.0, 1.0, 2.0 };
+    var s: f32x4 = a + b;
+    if (s[0] != 2.0 || s[1] != 8.0 || s[2] != 4.0 || s[3] != 6.0) { ret 1; }
+    var d: f32x4 = a - b;
+    if (d[0] != 1.0 || d[1] != -4.0 || d[2] != 2.0 || d[3] != 2.0) { ret 2; }
+    var m: f32x4 = a * b;
+    if (m[0] != 0.75 || m[1] != 12.0 || m[2] != 3.0 || m[3] != 8.0) { ret 3; }
+    var q: f32x4 = a / b;
+    if (q[0] != 3.0 || q[1] != (2.0 / 6.0) || q[2] != 3.0 || q[3] != 2.0) { ret 4; }
+    ret 0;
+}
+
+test "mach.lang.be.codegen.vector_runtime.arith:f64x2" {
+    var a: f64x2 = f64x2{ 1.5, 9.0 };
+    var b: f64x2 = f64x2{ 0.5, 3.0 };
+    var s: f64x2 = a + b;
+    if (s[0] != 2.0 || s[1] != 12.0) { ret 1; }
+    var d: f64x2 = a - b;
+    if (d[0] != 1.0 || d[1] != 6.0) { ret 2; }
+    var m: f64x2 = a * b;
+    if (m[0] != 0.75 || m[1] != 27.0) { ret 3; }
+    var q: f64x2 = a / b;
+    if (q[0] != 3.0 || q[1] != 3.0) { ret 4; }
+    ret 0;
+}
+
+# 8-bit lanes: lane 0 wraps within the byte (200+100 -> 44); lane 1 stays 0. a
+# wrong 16-bit arrangement would read [200,0] as 0x00C8, add 0x0064, and carry
+# 0x012C into byte 1 -> lane 1 = 1. asserting lane 1 == 0 rejects that.
+test "mach.lang.be.codegen.vector_runtime.arith:i8x16_add_sub" {
+    var a: i8x16 = i8x16{ -56, 0, 100, -1, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16 };
+    var b: i8x16 = i8x16{ 100, 0, 27, 1, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16 };
+    var s: i8x16 = a + b;
+    # -56 + 100 = 44; 100 + 27 = 127; -1 + 1 = 0
+    if (s[0] != 44 || s[1] != 0 || s[2] != 127 || s[3] != 0) { ret 1; }
+    if (s[15] != 32) { ret 2; }
+    var d: i8x16 = a - b;
+    # -56 - 100 = -156 -> wraps to 100 in i8; 100 - 27 = 73
+    if (d[0] != 100 || d[1] != 0 || d[2] != 73 || d[3] != -2) { ret 3; }
+    ret 0;
+}
+
+test "mach.lang.be.codegen.vector_runtime.arith:u8x16_add_sub" {
+    var a: u8x16 = u8x16{ 200, 0, 250, 1, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16 };
+    var b: u8x16 = u8x16{ 100, 0, 10, 2, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16 };
+    var s: u8x16 = a + b;
+    # 200 + 100 = 300 -> 44 (mod 256); lane 1 stays 0 (no 16-bit carry); 250+10=260->4
+    if (s[0] != 44 || s[1] != 0 || s[2] != 4 || s[3] != 3) { ret 1; }
+    var d: u8x16 = a - b;
+    # 200-100=100; 250-10=240; 1-2 = -1 -> 255
+    if (d[0] != 100 || d[1] != 0 || d[2] != 240 || d[3] != 255) { ret 2; }
+    ret 0;
+}
+
+# 16-bit lanes: 255 + 1 = 256 crosses byte 0 -> byte 1. a byte-collapsed add
+# drops the carry (lane 0 -> 0). asserting 256 rejects it. sub 256 - 1 = 255;
+# a byte op would give 0x01FF = 511.
+test "mach.lang.be.codegen.vector_runtime.arith:i16x8_add_sub" {
+    var a: i16x8 = i16x8{ 255, 256, -1, 1000, 5, 6, 7, 8 };
+    var b: i16x8 = i16x8{ 1, 1, 1, 24, 5, 6, 7, 8 };
+    var s: i16x8 = a + b;
+    if (s[0] != 256 || s[1] != 257 || s[2] != 0 || s[3] != 1024) { ret 1; }
+    var d: i16x8 = a - b;
+    if (d[0] != 254 || d[1] != 255 || d[2] != -2 || d[3] != 976) { ret 2; }
+    ret 0;
+}
+
+test "mach.lang.be.codegen.vector_runtime.arith:u16x8_add_sub" {
+    var a: u16x8 = u16x8{ 255, 256, 65535, 1000, 5, 6, 7, 8 };
+    var b: u16x8 = u16x8{ 1, 1, 1, 24, 5, 6, 7, 8 };
+    var s: u16x8 = a + b;
+    # 65535 + 1 = 0 (wraps); others exact
+    if (s[0] != 256 || s[1] != 257 || s[2] != 0 || s[3] != 1024) { ret 1; }
+    var d: u16x8 = a - b;
+    if (d[0] != 254 || d[1] != 255 || d[2] != 65534 || d[3] != 976) { ret 2; }
+    ret 0;
+}
+
+# 32-bit lanes: 65535 + 1 = 65536 crosses byte 1 -> byte 2.
+test "mach.lang.be.codegen.vector_runtime.arith:i32x4_add_sub" {
+    var a: i32x4 = i32x4{ 65535, 70000, -1, 100000 };
+    var b: i32x4 = i32x4{ 1, 1, 1, 24 };
+    var s: i32x4 = a + b;
+    if (s[0] != 65536 || s[1] != 70001 || s[2] != 0 || s[3] != 100024) { ret 1; }
+    var d: i32x4 = a - b;
+    if (d[0] != 65534 || d[1] != 69999 || d[2] != -2 || d[3] != 99976) { ret 2; }
+    ret 0;
+}
+
+test "mach.lang.be.codegen.vector_runtime.arith:u32x4_add_sub" {
+    var a: u32x4 = u32x4{ 65535, 70000, 4294967295, 100000 };
+    var b: u32x4 = u32x4{ 1, 1, 1, 24 };
+    var s: u32x4 = a + b;
+    if (s[0] != 65536 || s[1] != 70001 || s[2] != 0 || s[3] != 100024) { ret 1; }
+    var d: u32x4 = a - b;
+    if (d[0] != 65534 || d[1] != 69999 || d[2] != 4294967294 || d[3] != 99976) { ret 2; }
+    ret 0;
+}
+
+# 64-bit lanes: 4294967295 + 1 = 4294967296 crosses the 32-bit boundary.
+test "mach.lang.be.codegen.vector_runtime.arith:i64x2_add_sub" {
+    var a: i64x2 = i64x2{ 4294967295, -1 };
+    var b: i64x2 = i64x2{ 1, 1 };
+    var s: i64x2 = a + b;
+    if (s[0] != 4294967296 || s[1] != 0) { ret 1; }
+    var d: i64x2 = a - b;
+    if (d[0] != 4294967294 || d[1] != -2) { ret 2; }
+    ret 0;
+}
+
+test "mach.lang.be.codegen.vector_runtime.arith:u64x2_add_sub" {
+    var a: u64x2 = u64x2{ 4294967295, 18446744073709551615 };
+    var b: u64x2 = u64x2{ 1, 1 };
+    var s: u64x2 = a + b;
+    # 18446744073709551615 + 1 = 0 (wraps)
+    if (s[0] != 4294967296 || s[1] != 0) { ret 1; }
+    var d: u64x2 = a - b;
+    if (d[0] != 4294967294 || d[1] != 18446744073709551614) { ret 2; }
+    ret 0;
+}
+
+# integer multiply is 16-bit lanes only (32-bit pmulld is SSE4.1, off-baseline).
+# 256 * 2 = 512 crosses the byte boundary; a byte multiply gives 0.
+test "mach.lang.be.codegen.vector_runtime.arith:i16x8_mul" {
+    var a: i16x8 = i16x8{ 256, 3, -4, 100, 5, 6, 7, 8 };
+    var b: i16x8 = i16x8{ 2, 3, 5, 10, 1, 1, 1, 1 };
+    var m: i16x8 = a * b;
+    if (m[0] != 512 || m[1] != 9 || m[2] != -20 || m[3] != 1000) { ret 1; }
+    if (m[4] != 5 || m[7] != 8) { ret 2; }
+    ret 0;
+}
+
+test "mach.lang.be.codegen.vector_runtime.arith:u16x8_mul" {
+    var a: u16x8 = u16x8{ 256, 3, 1000, 100, 5, 6, 7, 8 };
+    var b: u16x8 = u16x8{ 2, 3, 60, 10, 1, 1, 1, 1 };
+    var m: u16x8 = a * b;
+    # 1000 * 60 = 60000 (fits u16); others exact
+    if (m[0] != 512 || m[1] != 9 || m[2] != 60000 || m[3] != 1000) { ret 1; }
+    ret 0;
+}
+
+# bitwise & | ^ ~ are 128-bit width-agnostic ops; each lane is cross-checked
+# against the scalar operator on the same literal operands. covered on every
+# integer shape per the table.
+test "mach.lang.be.codegen.vector_runtime.bitwise:u8x16" {
+    var a: u8x16 = u8x16{ 0xF0, 0x00, 0xFF, 0x3C, 0xAA, 0x55, 0x0F, 0x81, 1, 2, 4, 8, 16, 32, 64, 128 };
+    var b: u8x16 = u8x16{ 0x0F, 0xFF, 0x0F, 0xC3, 0x55, 0xAA, 0xF0, 0x18, 255, 254, 252, 248, 240, 224, 192, 127 };
+    var an: u8x16 = a & b;  var or: u8x16 = a | b;  var xr: u8x16 = a ^ b;  var nt: u8x16 = ~a;
+    if (an[0] != (0xF0 & 0x0F) || an[7] != (0x81 & 0x18) || an[15] != (128 & 127)) { ret 1; }
+    if (or[1] != (0x00 | 0xFF) || or[4] != (0xAA | 0x55) || or[8] != (1 | 255)) { ret 2; }
+    if (xr[2] != (0xFF ^ 0x0F) || xr[5] != (0x55 ^ 0xAA) || xr[9] != (2 ^ 254)) { ret 3; }
+    if (nt[0] != 0x0F || nt[3] != 0xC3 || nt[6] != 0xF0) { ret 4; }
+    ret 0;
+}
+
+test "mach.lang.be.codegen.vector_runtime.bitwise:u16x8" {
+    var a: u16x8 = u16x8{ 0xF0F0, 0x0000, 0xFFFF, 0x1234, 0xAAAA, 0x5555, 0x8001, 0x0F0F };
+    var b: u16x8 = u16x8{ 0x0F0F, 0xFFFF, 0x0F0F, 0x5678, 0x5555, 0xAAAA, 0x1008, 0xF0F0 };
+    var an: u16x8 = a & b;  var or: u16x8 = a | b;  var xr: u16x8 = a ^ b;  var nt: u16x8 = ~a;
+    if (an[0] != (0xF0F0 & 0x0F0F) || an[3] != (0x1234 & 0x5678)) { ret 1; }
+    if (or[1] != (0x0000 | 0xFFFF) || or[4] != (0xAAAA | 0x5555)) { ret 2; }
+    if (xr[2] != (0xFFFF ^ 0x0F0F) || xr[5] != (0x5555 ^ 0xAAAA)) { ret 3; }
+    if (nt[0] != 0x0F0F || nt[2] != 0x0000) { ret 4; }
+    ret 0;
+}
+
+test "mach.lang.be.codegen.vector_runtime.bitwise:u32x4" {
+    var a: u32x4 = u32x4{ 0xF0F0F0F0, 0x00000000, 0xFFFFFFFF, 0x12345678 };
+    var b: u32x4 = u32x4{ 0x0FF00FF0, 0xFFFFFFFF, 0x0F0F0F0F, 0x87654321 };
+    var an: u32x4 = a & b;  var or: u32x4 = a | b;  var xr: u32x4 = a ^ b;  var nt: u32x4 = ~a;
+    if (an[0] != (0xF0F0F0F0 & 0x0FF00FF0) || an[3] != (0x12345678 & 0x87654321)) { ret 1; }
+    if (or[1] != (0x00000000 | 0xFFFFFFFF) || or[2] != (0xFFFFFFFF | 0x0F0F0F0F)) { ret 2; }
+    if (xr[0] != (0xF0F0F0F0 ^ 0x0FF00FF0) || xr[3] != (0x12345678 ^ 0x87654321)) { ret 3; }
+    if (nt[2] != 0x00000000 || nt[1] != 0xFFFFFFFF) { ret 4; }
+    ret 0;
+}
+
+test "mach.lang.be.codegen.vector_runtime.bitwise:u64x2" {
+    var a: u64x2 = u64x2{ 0xF0F0F0F0F0F0F0F0, 0x123456789ABCDEF0 };
+    var b: u64x2 = u64x2{ 0x0FF00FF00FF00FF0, 0xFEDCBA9876543210 };
+    var an: u64x2 = a & b;  var or: u64x2 = a | b;  var xr: u64x2 = a ^ b;  var nt: u64x2 = ~a;
+    if (an[0] != (0xF0F0F0F0F0F0F0F0 & 0x0FF00FF00FF00FF0)) { ret 1; }
+    if (or[1] != (0x123456789ABCDEF0 | 0xFEDCBA9876543210)) { ret 2; }
+    if (xr[0] != (0xF0F0F0F0F0F0F0F0 ^ 0x0FF00FF00FF00FF0)) { ret 3; }
+    if (nt[1] != (~0x123456789ABCDEF0::u64)) { ret 4; }
+    ret 0;
+}
+
+test "mach.lang.be.codegen.vector_runtime.bitwise:i8x16" {
+    var a: i8x16 = i8x16{ -1, 0, 127, -128, 0x3C, 0x55, -16, 1, 2, 3, 4, 5, 6, 7, 8, 9 };
+    var b: i8x16 = i8x16{ 0x0F, -1, 0x0F, 0x7F, -61, 0x2A, 0x0F, 1, 2, 3, 4, 5, 6, 7, 8, 9 };
+    var an: i8x16 = a & b;  var or: i8x16 = a | b;  var xr: i8x16 = a ^ b;  var nt: i8x16 = ~a;
+    if (an[0] != (-1 & 0x0F) || an[3] != (-128 & 0x7F)) { ret 1; }
+    if (or[1] != (0 | -1) || or[6] != (-16 | 0x0F)) { ret 2; }
+    if (xr[2] != (127 ^ 0x0F)) { ret 3; }
+    if (nt[0] != 0 || nt[1] != -1) { ret 4; }
+    ret 0;
+}
+
+test "mach.lang.be.codegen.vector_runtime.bitwise:i16x8" {
+    var a: i16x8 = i16x8{ -1, 0, 0x7FFF, -32768, 0x3C3C, 0x5555, -256, 1 };
+    var b: i16x8 = i16x8{ 0x0F0F, -1, 0x0F0F, 0x7FFF, -15421, 0x2AAA, 0x0F0F, 1 };
+    var an: i16x8 = a & b;  var or: i16x8 = a | b;  var xr: i16x8 = a ^ b;  var nt: i16x8 = ~a;
+    if (an[0] != (-1 & 0x0F0F) || an[3] != (-32768 & 0x7FFF)) { ret 1; }
+    if (or[1] != (0 | -1)) { ret 2; }
+    if (xr[2] != (0x7FFF ^ 0x0F0F)) { ret 3; }
+    if (nt[0] != 0 || nt[1] != -1) { ret 4; }
+    ret 0;
+}
+
+test "mach.lang.be.codegen.vector_runtime.bitwise:i32x4" {
+    var a: i32x4 = i32x4{ -1, 0, 0x7FFFFFFF, -2147483648 };
+    var b: i32x4 = i32x4{ 0x0F0F0F0F, -1, 0x0F0F0F0F, 0x7FFFFFFF };
+    var an: i32x4 = a & b;  var or: i32x4 = a | b;  var xr: i32x4 = a ^ b;  var nt: i32x4 = ~a;
+    if (an[0] != (-1 & 0x0F0F0F0F) || an[3] != (-2147483648 & 0x7FFFFFFF)) { ret 1; }
+    if (or[1] != (0 | -1)) { ret 2; }
+    if (xr[2] != (0x7FFFFFFF ^ 0x0F0F0F0F)) { ret 3; }
+    if (nt[0] != 0 || nt[1] != -1) { ret 4; }
+    ret 0;
+}
+
+test "mach.lang.be.codegen.vector_runtime.bitwise:i64x2" {
+    var a: i64x2 = i64x2{ -1, 0x123456789ABCDEF0 };
+    var b: i64x2 = i64x2{ 0x0F0F0F0F0F0F0F0F, -1 };
+    var an: i64x2 = a & b;  var or: i64x2 = a | b;  var xr: i64x2 = a ^ b;  var nt: i64x2 = ~a;
+    if (an[0] != (-1 & 0x0F0F0F0F0F0F0F0F)) { ret 1; }
+    if (or[1] != (0x123456789ABCDEF0 | -1)) { ret 2; }
+    if (xr[0] != (-1 ^ 0x0F0F0F0F0F0F0F0F)) { ret 3; }
+    if (nt[0] != 0) { ret 4; }
+    ret 0;
+}
+
+# comparisons yield a same-shape unsigned mask (all-ones true / all-zeros false).
+# the `var m: u<w>x<n>` annotation asserts the mask shape at compile time; the
+# values assert per-lane. eq/ne operands collide in the low byte but differ above
+# it (266 vs 10) so a byte compare leaks a partial mask; signed ordering straddles
+# zero (-1 < 0 is true signed, false if mis-selected unsigned) and unsigned
+# ordering uses values above the signed max (a signed misread inverts the mask).
+test "mach.lang.be.codegen.vector_runtime.compare:i32x4" {
+    var a: i32x4 = i32x4{ 266, -1, 5, 5 };
+    var b: i32x4 = i32x4{ 10, 0, 5, 6 };
+    var eq: u32x4 = a == b;
+    if (eq[0] != 0 || eq[1] != 0 || eq[2] != M32 || eq[3] != 0) { ret 1; }
+    var ne: u32x4 = a != b;
+    if (ne[0] != M32 || ne[1] != M32 || ne[2] != 0 || ne[3] != M32) { ret 2; }
+    var lt: u32x4 = a < b;
+    if (lt[0] != 0 || lt[1] != M32 || lt[2] != 0 || lt[3] != M32) { ret 3; }
+    var le: u32x4 = a <= b;
+    if (le[0] != 0 || le[1] != M32 || le[2] != M32 || le[3] != M32) { ret 4; }
+    var gt: u32x4 = a > b;
+    if (gt[0] != M32 || gt[1] != 0 || gt[2] != 0 || gt[3] != 0) { ret 5; }
+    var ge: u32x4 = a >= b;
+    if (ge[0] != M32 || ge[1] != 0 || ge[2] != M32 || ge[3] != 0) { ret 6; }
+    ret 0;
+}
+
+test "mach.lang.be.codegen.vector_runtime.compare:u32x4" {
+    var a: u32x4 = u32x4{ 266, 4294967295, 5, 5 };
+    var b: u32x4 = u32x4{ 10, 0, 5, 6 };
+    var eq: u32x4 = a == b;
+    if (eq[0] != 0 || eq[1] != 0 || eq[2] != M32 || eq[3] != 0) { ret 1; }
+    var ne: u32x4 = a != b;
+    if (ne[0] != M32 || ne[2] != 0) { ret 2; }
+    var lt: u32x4 = a < b;
+    if (lt[0] != 0 || lt[1] != 0 || lt[2] != 0 || lt[3] != M32) { ret 3; }
+    var le: u32x4 = a <= b;
+    if (le[0] != 0 || le[1] != 0 || le[2] != M32 || le[3] != M32) { ret 4; }
+    var gt: u32x4 = a > b;
+    if (gt[0] != M32 || gt[1] != M32 || gt[2] != 0 || gt[3] != 0) { ret 5; }
+    var ge: u32x4 = a >= b;
+    if (ge[0] != M32 || ge[1] != M32 || ge[2] != M32 || ge[3] != 0) { ret 6; }
+    ret 0;
+}
+
+test "mach.lang.be.codegen.vector_runtime.compare:i16x8" {
+    var a: i16x8 = i16x8{ 266, -1, 5, 5, 100, 100, 7, 8 };
+    var b: i16x8 = i16x8{ 10, 0, 5, 6, 100, 99, 7, 8 };
+    var eq: u16x8 = a == b;
+    if (eq[0] != 0 || eq[2] != M16 || eq[4] != M16 || eq[7] != M16) { ret 1; }
+    var ne: u16x8 = a != b;
+    if (ne[0] != M16 || ne[2] != 0 || ne[5] != M16) { ret 2; }
+    var lt: u16x8 = a < b;
+    if (lt[1] != M16 || lt[3] != M16 || lt[0] != 0 || lt[5] != 0) { ret 3; }
+    var gt: u16x8 = a > b;
+    if (gt[0] != M16 || gt[5] != M16 || gt[1] != 0) { ret 4; }
+    var le: u16x8 = a <= b;
+    if (le[2] != M16 || le[0] != 0) { ret 5; }
+    var ge: u16x8 = a >= b;
+    if (ge[0] != M16 || ge[2] != M16 || ge[1] != 0) { ret 6; }
+    ret 0;
+}
+
+test "mach.lang.be.codegen.vector_runtime.compare:u16x8" {
+    var a: u16x8 = u16x8{ 266, 65535, 5, 5, 0, 0, 0, 0 };
+    var b: u16x8 = u16x8{ 10, 0, 5, 6, 0, 0, 0, 0 };
+    var eq: u16x8 = a == b;
+    if (eq[0] != 0 || eq[2] != M16 || eq[4] != M16) { ret 1; }
+    var lt: u16x8 = a < b;
+    if (lt[1] != 0 || lt[3] != M16 || lt[0] != 0) { ret 2; }
+    var gt: u16x8 = a > b;
+    if (gt[1] != M16 || gt[0] != M16 || gt[3] != 0) { ret 3; }
+    var ne: u16x8 = a != b;
+    if (ne[0] != M16 || ne[1] != M16 || ne[2] != 0 || ne[3] != M16) { ret 4; }
+    var le: u16x8 = a <= b;
+    if (le[0] != 0 || le[1] != 0 || le[2] != M16 || le[3] != M16) { ret 5; }
+    var ge: u16x8 = a >= b;
+    if (ge[0] != M16 || ge[1] != M16 || ge[2] != M16 || ge[3] != 0) { ret 6; }
+    ret 0;
+}
+
+test "mach.lang.be.codegen.vector_runtime.compare:i8x16" {
+    var a: i8x16 = i8x16{ 10, 1, -1, 5, 100, 100, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16 };
+    var b: i8x16 = i8x16{ 10, 2, 0, 5, 100, 99, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16 };
+    var eq: u8x16 = a == b;
+    if (eq[0] != M8 || eq[1] != 0 || eq[2] != 0 || eq[3] != M8 || eq[15] != M8) { ret 1; }
+    var ne: u8x16 = a != b;
+    if (ne[0] != 0 || ne[1] != M8 || ne[5] != M8) { ret 2; }
+    var lt: u8x16 = a < b;
+    if (lt[1] != M8 || lt[2] != M8 || lt[0] != 0 || lt[5] != 0) { ret 3; }
+    var gt: u8x16 = a > b;
+    if (gt[5] != M8 || gt[1] != 0 || gt[2] != 0) { ret 4; }
+    var le: u8x16 = a <= b;
+    if (le[0] != M8 || le[1] != M8 || le[2] != M8 || le[3] != M8 || le[5] != 0) { ret 5; }
+    var ge: u8x16 = a >= b;
+    if (ge[0] != M8 || ge[1] != 0 || ge[2] != 0 || ge[3] != M8 || ge[5] != M8) { ret 6; }
+    ret 0;
+}
+
+test "mach.lang.be.codegen.vector_runtime.compare:u8x16" {
+    var a: u8x16 = u8x16{ 10, 1, 255, 5, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
+    var b: u8x16 = u8x16{ 10, 2, 0, 5, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
+    var eq: u8x16 = a == b;
+    if (eq[0] != M8 || eq[1] != 0 || eq[2] != 0 || eq[3] != M8) { ret 1; }
+    var lt: u8x16 = a < b;
+    if (lt[1] != M8 || lt[2] != 0 || lt[0] != 0) { ret 2; }
+    var gt: u8x16 = a > b;
+    if (gt[2] != M8 || gt[1] != 0) { ret 3; }
+    var ne: u8x16 = a != b;
+    if (ne[0] != 0 || ne[1] != M8 || ne[2] != M8 || ne[3] != 0) { ret 4; }
+    var le: u8x16 = a <= b;
+    if (le[0] != M8 || le[1] != M8 || le[2] != 0 || le[3] != M8) { ret 5; }
+    var ge: u8x16 = a >= b;
+    if (ge[0] != M8 || ge[1] != 0 || ge[2] != M8 || ge[3] != M8) { ret 6; }
+    ret 0;
+}
+
+test "mach.lang.be.codegen.vector_runtime.compare:i64x2" {
+    var a: i64x2 = i64x2{ 266, -1 };
+    var b: i64x2 = i64x2{ 10, 0 };
+    var eq: u64x2 = a == b;
+    if (eq[0] != 0 || eq[1] != 0) { ret 1; }
+    var ne: u64x2 = a != b;
+    if (ne[0] != M64 || ne[1] != M64) { ret 2; }
+    var lt: u64x2 = a < b;
+    if (lt[0] != 0 || lt[1] != M64) { ret 3; }
+    var le: u64x2 = a <= b;
+    if (le[0] != 0 || le[1] != M64) { ret 4; }
+    var gt: u64x2 = a > b;
+    if (gt[0] != M64 || gt[1] != 0) { ret 5; }
+    var ge: u64x2 = a >= b;
+    if (ge[0] != M64 || ge[1] != 0) { ret 6; }
+    ret 0;
+}
+
+test "mach.lang.be.codegen.vector_runtime.compare:u64x2" {
+    var a: u64x2 = u64x2{ 266, 18446744073709551615 };
+    var b: u64x2 = u64x2{ 10, 0 };
+    var lt: u64x2 = a < b;
+    # 18446744073709551615 < 0 is false unsigned; a signed misread (-1 < 0) is true
+    if (lt[0] != 0 || lt[1] != 0) { ret 1; }
+    var gt: u64x2 = a > b;
+    if (gt[0] != M64 || gt[1] != M64) { ret 2; }
+    var eq: u64x2 = a == b;
+    if (eq[0] != 0 || eq[1] != 0) { ret 3; }
+    var ne: u64x2 = a != b;
+    if (ne[0] != M64 || ne[1] != M64) { ret 4; }
+    var le: u64x2 = a <= b;
+    if (le[0] != 0 || le[1] != 0) { ret 5; }
+    var ge: u64x2 = a >= b;
+    if (ge[0] != M64 || ge[1] != M64) { ret 6; }
+    ret 0;
+}
+
+test "mach.lang.be.codegen.vector_runtime.compare:f32x4" {
+    var a: f32x4 = f32x4{ 1.0, 2.0, 3.0, 3.0 };
+    var b: f32x4 = f32x4{ 2.0, 2.0, 1.0, 3.0 };
+    var eq: u32x4 = a == b;
+    if (eq[0] != 0 || eq[1] != M32 || eq[2] != 0 || eq[3] != M32) { ret 1; }
+    var ne: u32x4 = a != b;
+    if (ne[0] != M32 || ne[1] != 0 || ne[3] != 0) { ret 2; }
+    var lt: u32x4 = a < b;
+    if (lt[0] != M32 || lt[1] != 0 || lt[2] != 0 || lt[3] != 0) { ret 3; }
+    var le: u32x4 = a <= b;
+    if (le[0] != M32 || le[1] != M32 || le[2] != 0 || le[3] != M32) { ret 4; }
+    var gt: u32x4 = a > b;
+    if (gt[0] != 0 || gt[2] != M32 || gt[3] != 0) { ret 5; }
+    var ge: u32x4 = a >= b;
+    if (ge[0] != 0 || ge[1] != M32 || ge[2] != M32 || ge[3] != M32) { ret 6; }
+    ret 0;
+}
+
+test "mach.lang.be.codegen.vector_runtime.compare:f64x2" {
+    var a: f64x2 = f64x2{ 1.0, 3.0 };
+    var b: f64x2 = f64x2{ 2.0, 3.0 };
+    var eq: u64x2 = a == b;
+    if (eq[0] != 0 || eq[1] != M64) { ret 1; }
+    var ne: u64x2 = a != b;
+    if (ne[0] != M64 || ne[1] != 0) { ret 2; }
+    var lt: u64x2 = a < b;
+    if (lt[0] != M64 || lt[1] != 0) { ret 3; }
+    var le: u64x2 = a <= b;
+    if (le[0] != M64 || le[1] != M64) { ret 4; }
+    var gt: u64x2 = a > b;
+    if (gt[0] != 0 || gt[1] != 0) { ret 5; }
+    var ge: u64x2 = a >= b;
+    if (ge[0] != 0 || ge[1] != M64) { ret 6; }
+    ret 0;
+}
+
+# comptime-const lane read and write. writes route through the array-of-lanes
+# storage shape (#2042); reads are exercised throughout the suite and pinned here
+# across every element width.
+test "mach.lang.be.codegen.vector_runtime.lane:read_write_int" {
+    var a: i8x16 = i8x16{ 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15 };
+    a[0] = -128;  a[15] = 100;  a[7] = -7;
+    if (a[0] != -128 || a[7] != -7 || a[15] != 100 || a[1] != 1 || a[14] != 14) { ret 1; }
+    var b: i16x8 = i16x8{ 0, 1, 2, 3, 4, 5, 6, 7 };
+    b[0] = 300;  b[7] = -300;
+    if (b[0] != 300 || b[7] != -300 || b[3] != 3) { ret 2; }
+    var c: i32x4 = i32x4{ 0, 1, 2, 3 };
+    c[1] = 70000;  c[3] = -70000;
+    if (c[0] != 0 || c[1] != 70000 || c[3] != -70000) { ret 3; }
+    var d: i64x2 = i64x2{ 0, 1 };
+    d[0] = 4294967296;
+    if (d[0] != 4294967296 || d[1] != 1) { ret 4; }
+    ret 0;
+}
+
+test "mach.lang.be.codegen.vector_runtime.lane:read_write_float" {
+    var a: f32x4 = f32x4{ 1.0, 2.0, 3.0, 4.0 };
+    a[0] = 1.5;  a[3] = -4.5;
+    if (a[0] != 1.5 || a[1] != 2.0 || a[3] != -4.5) { ret 1; }
+    var b: f64x2 = f64x2{ 1.0, 2.0 };
+    b[1] = 9.25;
+    if (b[0] != 1.0 || b[1] != 9.25) { ret 2; }
+    ret 0;
+}
+
+# ABI round-trips: vectors as arguments and returns across real calls. the pick
+# routine mixes a scalar and two vector parameters, exercising GP + vector bank
+# allocation together; sum4 takes four vector arguments.
+fun abi_add_f32x4(a: f32x4, b: f32x4) f32x4 { ret a + b; }
+fun abi_add_i32x4(a: i32x4, b: i32x4) i32x4 { ret a + b; }
+fun abi_pick(flag: i32, a: i32x4, b: i32x4) i32x4 {
+    if (flag != 0) { ret a; }
+    ret b;
+}
+fun abi_sum4(a: i32x4, b: i32x4, c: i32x4, d: i32x4) i32x4 { ret ((a + b) + c) + d; }
+
+test "mach.lang.be.codegen.vector_runtime.abi:roundtrip" {
+    var a: f32x4 = f32x4{ 1.0, 2.0, 3.0, 4.0 };
+    var b: f32x4 = f32x4{ 10.0, 20.0, 30.0, 40.0 };
+    var s: f32x4 = abi_add_f32x4(a, b);
+    if (s[0] != 11.0 || s[1] != 22.0 || s[2] != 33.0 || s[3] != 44.0) { ret 1; }
+
+    var ia: i32x4 = i32x4{ 65535, 1, 2, 3 };
+    var ib: i32x4 = i32x4{ 1, 1, 1, 1 };
+    var isum: i32x4 = abi_add_i32x4(ia, ib);
+    if (isum[0] != 65536 || isum[1] != 2) { ret 2; }
+    ret 0;
+}
+
+test "mach.lang.be.codegen.vector_runtime.abi:mixed_and_multi" {
+    var a: i32x4 = i32x4{ 1, 2, 3, 4 };
+    var b: i32x4 = i32x4{ 5, 6, 7, 8 };
+    var p1: i32x4 = abi_pick(1, a, b);
+    if (p1[0] != 1 || p1[3] != 4) { ret 1; }
+    var p0: i32x4 = abi_pick(0, a, b);
+    if (p0[0] != 5 || p0[3] != 8) { ret 2; }
+
+    var c: i32x4 = i32x4{ 100, 200, 300, 400 };
+    var d: i32x4 = i32x4{ 1000, 2000, 3000, 4000 };
+    var q: i32x4 = abi_sum4(a, b, c, d);
+    if (q[0] != 1106 || q[1] != 2208 || q[2] != 3310 || q[3] != 4412) { ret 3; }
+    ret 0;
+}
+
+# spill pressure: more simultaneously-live 128-bit values than the register file
+# holds forces spills to the stack (the #2034 16-byte spill-slot clobber territory).
+# each vN is used twice (a forward and a reverse sum) so all sixteen stay live
+# across the accumulation; the two sums must agree and match the reference, so a
+# clobbered or misaligned spill slot corrupts a lane and fails.
+test "mach.lang.be.codegen.vector_runtime.spill:tree_16_live" {
+    var v0:  i32x4 = i32x4{ 65535, 1, 0, 0 };
+    var v1:  i32x4 = i32x4{ 1, 2, 0, 0 };
+    var v2:  i32x4 = i32x4{ 2, 3, 0, 0 };
+    var v3:  i32x4 = i32x4{ 3, 4, 0, 0 };
+    var v4:  i32x4 = i32x4{ 4, 5, 0, 0 };
+    var v5:  i32x4 = i32x4{ 5, 6, 0, 0 };
+    var v6:  i32x4 = i32x4{ 6, 7, 0, 0 };
+    var v7:  i32x4 = i32x4{ 7, 8, 0, 0 };
+    var v8:  i32x4 = i32x4{ 8, 9, 0, 0 };
+    var v9:  i32x4 = i32x4{ 9, 10, 0, 0 };
+    var v10: i32x4 = i32x4{ 10, 11, 0, 0 };
+    var v11: i32x4 = i32x4{ 11, 12, 0, 0 };
+    var v12: i32x4 = i32x4{ 12, 13, 0, 0 };
+    var v13: i32x4 = i32x4{ 13, 14, 0, 0 };
+    var v14: i32x4 = i32x4{ 14, 15, 0, 0 };
+    var v15: i32x4 = i32x4{ 15, 16, 0, 0 };
+    var fwd: i32x4 = ((((((((((((((v0 + v1) + v2) + v3) + v4) + v5) + v6) + v7) + v8) + v9) + v10) + v11) + v12) + v13) + v14) + v15;
+    var rev: i32x4 = ((((((((((((((v15 + v14) + v13) + v12) + v11) + v10) + v9) + v8) + v7) + v6) + v5) + v4) + v3) + v2) + v1) + v0;
+    # lane0: 65535 + (1+2+...+15) = 65535 + 120 = 65655; lane1: 1+2+...+16 = 136
+    if (fwd[0] != 65655 || fwd[1] != 136) { ret 1; }
+    if (rev[0] != 65655 || rev[1] != 136) { ret 2; }
+    if (fwd[0] != rev[0] || fwd[1] != rev[1] || fwd[2] != rev[2] || fwd[3] != rev[3]) { ret 3; }
+    ret 0;
+}
+
+test "mach.lang.be.codegen.vector_runtime.spill:chain_deep" {
+    var acc: i32x4 = i32x4{ 0, 0, 65535, 2147483647 };
+    var k:   i32x4 = i32x4{ 1, 2, 1, 1 };
+    var i: i32 = 0;
+    for (i < 100) {
+        acc = acc + k;
+        i = i + 1;
+    }
+    # lane0: 0 + 100*1 = 100; lane1: 200; lane2: 65535 + 100 = 65635; lane3:
+    # 2147483647 + 100 overflows i32 and wraps to -2147483549.
+    if (acc[0] != 100 || acc[1] != 200 || acc[2] != 65635) { ret 1; }
+    if (acc[3] != -2147483549) { ret 2; }
+    ret 0;
+}


### PR DESCRIPTION
## #1965 tier — colocated runtime vector per-op suite

Closes #2038. The permanent, colocated runtime lane-exactness suite for the ten
seeded 128-bit vector types, now that a vector-aware seed (v3.4.x) makes vector
source legal in colocated `test` blocks. One shared file of self-checking `test`
blocks, run natively by `mach test` on the x86_64 and aarch64 legs (and windows —
the win64 vector ABI shipped in #2059, so the ABI blocks need no gate).

### Coverage (every increment-1 table op × every legal shape, lane-exact)
- **float** `+ - * /` — `f32x4`, `f64x2`
- **integer** `+ -` — all eight widths; **`*`** — 16-bit lanes (`i16x8`, `u16x8`)
- **bitwise** `& | ^ ~` — all eight integer shapes, cross-checked against the scalar operator
- **comparisons** — all six operators on all ten shapes → same-shape unsigned mask (shape asserted by the `var m: u<w>x<n>` annotation; all-ones/all-zeros lanes asserted by value)
- **comptime-const lane read/write** across every element width
- **ABI round-trips** — by-value vector args and returns across real calls, mixed scalar+vector signatures, four-vector-argument calls
- **spill pressure** — 16 simultaneously-live vectors (forward + reverse sum must agree) and a deep accumulation chain (#2034 territory)

### Discriminating values (designed-in, so a wrong arrangement can't pass silently)
Arithmetic operands force a carry/borrow across a byte boundary inside the lane (a
byte-collapsed `.16b`/element-0 op drops it); comparison operands collide in the low
byte but differ above it (a byte compare leaks a partial mask); signed vs unsigned
ordering straddles zero (a wrong-signedness compare inverts the mask). **The suite
caught three shipped criticals across its first runs:** #2053 (by-value vector
return truncated to 64 bits, fixed #2054), #2069 (aarch64 float ordering compares
emitted integer `cmhi.16b` instead of `fcmgt.4s`, fixed #2071), and #2070 (x86_64
release by-value return through a control-flow merge, filed). The `abi:*` and
`compare:*` blocks are the permanent guards.

### Design
An **orphan module**: `mach build` never reaches it, so the compiler binary — and
thus the self-host fixpoint and byte-identity — are unaffected; `mach test` loads it
as a collection root and runs it natively. riscv64 does not run `mach test` under
qemu-user (#2016), so its lane coverage remains the separate int-case decision.

### Bars
- **36 test blocks**, all lane-exact via the freshly built HEAD `mach test` on x86_64 (debug + release) and aarch64.
- **Suite count:** `643 passed, 0 failed` = dev baseline 607 + 36.
- **int suite** (surface + regression, both profiles) green, incl. `surface/debuginfo` (-g PT_LOAD additivity + `dwarfdump --verify`).
- **Self-host fixpoint** b==c holds (orphan module — the compiler binary is byte-identical to dev).
- Rebased onto dev after the #2069 fix (#2071) merged.

### CI coverage boundary (opt-level blind spot)
`mach test` always builds the test harness in the **debug** profile, even in the
release self-host lane (`./c test .` → `out/.../debug/test/mach`). So this suite runs
under CI only at `opt=0`: a release-only (`opt=2`) miscompile is invisible to CI's
self-test. That is exactly the case for #2070 — the `abi:*` blocks fail when the
suite is built by hand with `--profile release`, but pass in CI. The suite therefore
stays un-gated (CI's debug harness never hits #2070), and #2070 needs its own fix in
the x86_64 optimized-return capture path. Flagging the boundary explicitly: the
suite's release-profile lane-exactness is proven locally, not by CI.
