### PR TITLE
fix(arm64): select the float ordered compare for vector < <= > >= (#2069)

### DIFF
--- a/src/lang/target/isa/arm64/isel.mach
+++ b/src/lang/target/isa/arm64/isel.mach
@@ -170,10 +170,24 @@ fun rewrite(fn: *mir.MirFunction, mi: *mir.MirInstr) R.Result[bool, str] {
         if (o == mir.MIR_NOT) { mi.opcode = arm64.VEC_NOT::u32; ret R.ok[bool, str](true); }
         if (o == mir.MIR_CMP_EQ) { mi.opcode = arm64.VEC_CMEQ::u32; ret R.ok[bool, str](true); }
         if (o == mir.MIR_CMP_NE) { mi.opcode = arm64.VEC_CMNE::u32; ret R.ok[bool, str](true); }
+        # float ordering has no signed/unsigned split: a float operand is not
+        # "signed", so its ordering compare arrives in the generic `_U` form, but the
+        # NEON float compare (FCMGT/FCMGE) is the one true ordered compare. route the
+        # unsigned form to the float opcode when the lane is float; only genuine
+        # integer lanes take the unsigned CMHI/CMHS.
+        val isf: bool = mir.vec_lane_kind(mi.vec_lane) == mir.VEC_LANE_FLOAT;
         if (o == mir.MIR_CMP_LT_S) { swap_cmp_operands(mi); mi.opcode = arm64.VEC_CMGT::u32; ret R.ok[bool, str](true); }
-        if (o == mir.MIR_CMP_LT_U) { swap_cmp_operands(mi); mi.opcode = arm64.VEC_CMHI::u32; ret R.ok[bool, str](true); }
+        if (o == mir.MIR_CMP_LT_U) {
+            swap_cmp_operands(mi);
+            if (isf) { mi.opcode = arm64.VEC_CMGT::u32; } or { mi.opcode = arm64.VEC_CMHI::u32; }
+            ret R.ok[bool, str](true);
+        }
         if (o == mir.MIR_CMP_LE_S) { swap_cmp_operands(mi); mi.opcode = arm64.VEC_CMGE::u32; ret R.ok[bool, str](true); }
-        if (o == mir.MIR_CMP_LE_U) { swap_cmp_operands(mi); mi.opcode = arm64.VEC_CMHS::u32; ret R.ok[bool, str](true); }
+        if (o == mir.MIR_CMP_LE_U) {
+            swap_cmp_operands(mi);
+            if (isf) { mi.opcode = arm64.VEC_CMGE::u32; } or { mi.opcode = arm64.VEC_CMHS::u32; }
+            ret R.ok[bool, str](true);
+        }
 
         # vector shifts and remainder are outside the increment-1 table (#2030 removed
         # per-lane shifts at sema; there is no vector `%` or integer `/`). a loud
@@ -389,5 +403,34 @@ test "mach.lang.target.isa.arm64.isel:is_reg_move" {
     if (!is_reg_move(arm64.FMOV::u32)) { ret 1; }
     if (!is_reg_move(mir.MIR_MOV))     { ret 1; }
     if (is_reg_move(arm64.ADD::u32))   { ret 1; }
+    ret 0;
+}
+
+# a float ordering compare arrives in the generic unsigned form (a float operand
+# is not "signed"), and must select the float ordered compare (FCMGT/FCMGE), not
+# the unsigned integer compare (CMHI/CMHS). integer unsigned compares are
+# unaffected. regression guard for the aarch64 float `< <= > >=` miscompile.
+test "mach.lang.target.isa.arm64.isel:float_ordering_compare_selects_float" {
+    var f: mir.MirFunction;
+    var ops: [3]mir.MirOperand;
+    var mi: mir.MirInstr;
+    mi.operands = ?ops[0]; mi.operand_count = 3;
+
+    mi.opcode = mir.MIR_CMP_LT_U; mi.vec_lane = mir.vec_lane_make(mir.VEC_LANE_FLOAT, 4);
+    rewrite(?f, ?mi);
+    if (mi.opcode != arm64.VEC_CMGT::u32) { ret 1; }
+
+    mi.opcode = mir.MIR_CMP_LT_U; mi.vec_lane = mir.vec_lane_make(mir.VEC_LANE_INT, 4);
+    rewrite(?f, ?mi);
+    if (mi.opcode != arm64.VEC_CMHI::u32) { ret 2; }
+
+    mi.opcode = mir.MIR_CMP_LE_U; mi.vec_lane = mir.vec_lane_make(mir.VEC_LANE_FLOAT, 8);
+    rewrite(?f, ?mi);
+    if (mi.opcode != arm64.VEC_CMGE::u32) { ret 3; }
+
+    mi.opcode = mir.MIR_CMP_LE_U; mi.vec_lane = mir.vec_lane_make(mir.VEC_LANE_INT, 2);
+    rewrite(?f, ?mi);
+    if (mi.opcode != arm64.VEC_CMHS::u32) { ret 4; }
+
     ret 0;
 }


### PR DESCRIPTION
Closes #2069. A float vector ordering compare (`< <= > >=`) was mis-selected on aarch64 to the unsigned integer compare `cmhi`/`cmhs` at `.16b` instead of the float `fcmgt`/`fcmge` at `.4s`/`.2d`, silently producing wrong byte-arranged masks. Float `==`/`!=` and all integer compares were correct; x86_64 was correct.

**Root cause:** a float operand is not "signed", so its ordering compare lowers to the generic unsigned form (`MIR_CMP_LT_U`/`MIR_CMP_LE_U`); the NEON isel mapped those straight to `VEC_CMHI`/`VEC_CMHS`, which have no float form. **Fix:** when the lane is float, route the unsigned ordering form to the float `VEC_CMGT`/`VEC_CMGE`; integer lanes keep `CMHI`/`CMHS`.

**Verified:** objdump shows `fcmp_lt`/`fcmp_gt` now emit `fcmgt v.4s` (was `cmhi v.16b`); qemu-aarch64 runtime masks are lane-exact; new isel regression test `float_ordering_compare_selects_float`; full suite green. Found by the #2038 runtime suite (`compare:f32x4`/`compare:f64x2`).
