### PR TITLE
fix(codegen): x86_64 vector return through a control-flow merge truncates to low 64 bits (#2070)

### DIFF
--- a/src/lang/be/codegen/mir/abi.mach
+++ b/src/lang/be/codegen/mir/abi.mach
@@ -1635,6 +1635,10 @@ fun rt_litret() i32x4 { ret i32x4{266, 10, 70000, 40000}; }
 fun rt_localret(seed: i32) i32x4 { var v: i32x4 = i32x4{seed, 10, 70000, 40000}; ret v; }
 fun rt_add_one(a: i32x4) i32x4 { var one: i32x4 = i32x4{1, 1, 1, 1}; ret a + one; }
 fun rt_mixed(tag: i64, a: i32x4, k: i64) i32x4 { var b: i32x4 = i32x4{tag::i32, k::i32, 70000, 40000}; ret a + b; }
+# #2070: a vector returned through a control-flow merge. `r` is assigned in one arm
+# and returned, so mem2reg forms a phi and the return flows through the phi-elimination
+# copy - which must carry all 16 bytes, not the low 64 bits.
+fun rt_pick(flag: i32, a: i32x4, b: i32x4) i32x4 { var r: i32x4 = b; if (flag != 0) { r = a; } ret r; }
 fun rt_lane_ok(v: i32x4, l0: i32, l1: i32, l2: i32, l3: i32) bool {
     ret v[0] == l0 && v[1] == l1 && v[2] == l2 && v[3] == l3;
 }
@@ -1655,5 +1659,9 @@ test "mach.lang.be.codegen.mir.abi:vector_by_value_roundtrip" {
     if (!rt_lane_ok(rt_add_one(src), 267, 11, 70001, 40001)) { ret 1; }
     # mixed scalar + vector signature round-trip.
     if (!rt_lane_ok(rt_mixed(5, src, 9), 271, 19, 140000, 80000)) { ret 1; }
+    # ret through a control-flow merge (phi): the phi-elimination copy must carry all
+    # 16 bytes, never truncate to the low 64 bits (#2070).
+    if (!rt_lane_ok(rt_pick(1, src, i32x4{5, 6, 7, 8}), 266, 10, 70000, 40000)) { ret 1; }
+    if (!rt_lane_ok(rt_pick(0, i32x4{5, 6, 7, 8}, src), 266, 10, 70000, 40000)) { ret 1; }
     ret 0;
 }

--- a/src/lang/be/codegen/mir/lower.mach
+++ b/src/lang/be/codegen/mir/lower.mach
@@ -499,11 +499,14 @@ fun emit_edge_copies(ctx: *lctx.LowerCtx, pred_mb: *mir.MirBlock, dsts: *u32, sr
             for (done[c]) { c = c + 1; }
             val freed: u32 = dsts[c];
             val cls: u32 = ctx.f.vregs[freed].class;
-            val tr: R.Result[u32, str] = lctx.new_vreg(ctx, cls);
+            # preserve the freed vreg's vector-ness so the save copies the full 16 bytes
+            # of a vector (a gpr-width save would truncate it, #2070).
+            val tr: R.Result[u32, str] = lctx.new_vreg_vec(ctx, cls, ctx.f.vregs[freed].vector);
             if (R.is_err[u32, str](tr)) { err_msg = R.unwrap_err[u32, str](tr); cnt; }
             val tmp: u32 = R.unwrap_ok[u32, str](tr);
-            # the cycle-break save is a register-to-register copy of a live value,
-            # width-agnostic; carry the full register width.
+            # the cycle-break save is a register-to-register copy of a live value;
+            # insert_mov_before_terminator carries the full register width (16 for a
+            # vector via the temp's preserved flag).
             val sv: R.Result[bool, str] = insert_mov_before_terminator(ctx, pred_mb,
                 mir.op_vreg(tmp), mir.op_vreg(freed), ctx.tgt.model.gpr_width::u8);
             if (R.is_err[bool, str](sv)) { err_msg = R.unwrap_err[bool, str](sv); cnt; }
@@ -593,17 +596,24 @@ fun insert_mov_before_terminator(ctx: *lctx.LowerCtx, mb: *mir.MirBlock, dst: mi
     mi.operands      = ops;
     mi.operand_count = 2;
     # a register / symbol source transfers a value already in its target-canonical
-    # register form, so a full-width bit copy is width-agnostic and correct. an
-    # immediate source is a MATERIALIZATION of a constant, materialized at
-    # `imm_merge_width`: a 32-bit constant rides a width-4 move so the backend
-    # re-signs it to its register convention (riscv64 lp64 holds an i32
-    # sign-extended), while every other width keeps the full-register move.
+    # register form, so a full GPR-width bit copy is width-agnostic for a GP or scalar
+    # float value. a 128-bit vector vreg is the exception: it is 16 bytes, so a
+    # gpr-width copy moves only the low 64 bits and truncates the vector through the
+    # merge (#2070) - it carries the full vector width so the encoder emits the 16-byte
+    # MOVAPS. an immediate source is a MATERIALIZATION of a constant at
+    # `imm_merge_width`: a 32-bit constant rides a width-4 move so the backend re-signs
+    # it to its register convention (riscv64 lp64 holds an i32 sign-extended), while
+    # every other width keeps the full-register move.
     mi.width         = ctx.tgt.model.gpr_width::u8;
     mi.src_width     = ctx.tgt.model.gpr_width::u8;
     if (src.kind == mir.MIR_OP_IMM) {
         val iw: u8 = imm_merge_width(ctx, wid);
         mi.width     = iw;
         mi.src_width = iw;
+    }
+    or (dst.kind == mir.MIR_OP_VREG && dst.vreg < ctx.f.vreg_count && ctx.f.vregs[dst.vreg].vector) {
+        mi.width     = 16;
+        mi.src_width = 16;
     }
     # this splice bypasses lctx.push_instr, so enforce its invariants here: asm_block
     # is nil'd (struct locals are not zero-initialized, and regalloc.flatten reads a


### PR DESCRIPTION
Fixes #2070 — a residue of the #2053/#2054 by-value-vector capture-width fix. A 128-bit vector returned by value through a control-flow merge (PHI) truncated its upper two lanes.

Closes #2070.

## Root cause
`insert_mov_before_terminator` (mir/lower.mach) hard-codes a phi-elimination register copy to the GP register width, treating a full-width bit copy as width-agnostic. That's true for a GP or scalar-float value, but a vector vreg is 16 bytes — a gpr-width copy moves only the low 64 bits (an 8-byte move of an XMM-class vreg), so `pick(...) : i32x4` returning through the merge yielded `{lane0, lane1, 0, 0}`. The #2054 fix covered the straight-line capture sites (`emit_ret_slot_to_vreg`/`emit_param_slot`); this optimized merge path has its own width decision.

## Fix
Carry 16 bytes for a vector vreg in the phi-elimination copy, so the encoder emits the full MOVAPS. The cycle-break save preserves the freed vreg's vector-ness (`new_vreg_vec`) so its copy widens too. Surgical: only vector-vreg phi copies change; GP and scalar-float copies keep the gpr-width move.

## Regression test
Extends the colocated `abi:vector_by_value_roundtrip` runtime test with a phi-merge return (`rt_pick`: a vector assigned in one branch and returned). Crucially it guards in CI's standard run: mem2reg forms the phi at opt=0, and the same-module helper is not inlined there, so the case **fails pre-fix at the default debug profile** that `mach test` builds (unlike the issue's `if/ret` shape, which only forms the phi at release). Uses the suite's discriminating lane values (266/10/70000/40000).

## Verification
| bar | result |
|-----|--------|
| repro `pick` (i32x4) through the merge, both profiles | ✓ correct (was `{1,2,0,0}`) |
| runtime matrix: i32x4 / f32x4 / f64x2 / i64x2 / u8x16 phi-merge returns, both profiles | ✓ |
| colocated `abi:vector_by_value_roundtrip` (with the phi case) | ✓ fail-pre (exit 1) / pass-post, at the default debug profile |
| full unit suite | ✓ 643 / 643 |
| self-host fixpoint | ✓ g2 == g3 byte-identical |
| non-vector byte-identity (same-dev baseline vs fixed: compiler source + program) | ✓ identical, both profiles |
| int suite (linux) | ✓ all cases passed |
| llvm-dwarfdump --verify (-g build) | ✓ No errors |
