### PR TITLE
fix(ir): print extern signatures and per-operand types in IR dump

### DIFF
--- a/src/lang/me/ir/printer.mach
+++ b/src/lang/me/ir/printer.mach
@@ -11,7 +11,7 @@
 #
 #     fn @<name>(<params>): <ret> {
 #       block bb0:
-#         %0 = add i32 %a, %b
+#         %0 = add i32 %a: i32, %b: i32
 #         cbr %1, bb1, bb2
 #       block bb1:
 #         ...
@@ -20,8 +20,14 @@
 #
 # Block labels are `bb<id>`; instruction results are `%<instr_id>`; function
 # parameters render as `%p<index>`; globals and functions as `@<name>`; phis
-# as `phi <ty> [bb0 %0, bb1 %3, ...]`. Per-instruction modifier flags render
-# as opcode suffixes (`add.nsw`, `load.volatile`).
+# as `phi <ty> [bb0 %0: i32, bb1 %3: i32, ...]`. Per-instruction modifier flags
+# render as opcode suffixes (`add.nsw`, `load.volatile`).
+#
+# Every value operand at a use site carries its own IR type as a `<value>: <ty>`
+# suffix, so a mis-typed operand (an aggregate passed as a bare pointer) is
+# visible without chasing def-use chains. An extern declaration renders its
+# signature's parameter types (`fn @<name>(<ty>, <ty>): <ret> extern`); it has no
+# materialized parameter values to name `%p<index>`.
 
 use std.format;
 use std.io.writer;
@@ -120,21 +126,30 @@ pub fun print_function(out: *writer.Writer, m: *ir.Module, fn: *ir.Function, int
     val res_open: R.Result[bool, str] = emit_str(out, "(");
     if (R.is_err[bool, str](res_open)) { ret res_open; }
 
-    var i: u32 = 0;
-    for (i < fn.param_count) {
-        if (i > 0) {
-            val res_sep: R.Result[bool, str] = emit_str(out, ", ");
-            if (R.is_err[bool, str](res_sep)) { ret res_sep; }
+    if ((fn.flags & ir.FN_FLAG_EXTERN) != 0) {
+        # an extern decl carries a signature but no materialized VAL_PARAM values;
+        # render the parameter types from the signature so the dump shows the real
+        # arity and types instead of an empty `()`.
+        val res_sig: R.Result[bool, str] = print_signature_params(out, m, fn.sig);
+        if (R.is_err[bool, str](res_sig)) { ret res_sig; }
+    }
+    or {
+        var i: u32 = 0;
+        for (i < fn.param_count) {
+            if (i > 0) {
+                val res_sep: R.Result[bool, str] = emit_str(out, ", ");
+                if (R.is_err[bool, str](res_sep)) { ret res_sep; }
+            }
+            val res_marker: R.Result[bool, str] = emit_str(out, "%p");
+            if (R.is_err[bool, str](res_marker)) { ret res_marker; }
+            val res_index: R.Result[bool, str] = emit_u64(out, i::u64);
+            if (R.is_err[bool, str](res_index)) { ret res_index; }
+            val res_colon: R.Result[bool, str] = emit_str(out, ": ");
+            if (R.is_err[bool, str](res_colon)) { ret res_colon; }
+            val res_ty: R.Result[bool, str] = print_type(out, m, fn.params[i].ty);
+            if (R.is_err[bool, str](res_ty)) { ret res_ty; }
+            i = i + 1;
         }
-        val res_marker: R.Result[bool, str] = emit_str(out, "%p");
-        if (R.is_err[bool, str](res_marker)) { ret res_marker; }
-        val res_index: R.Result[bool, str] = emit_u64(out, i::u64);
-        if (R.is_err[bool, str](res_index)) { ret res_index; }
-        val res_colon: R.Result[bool, str] = emit_str(out, ": ");
-        if (R.is_err[bool, str](res_colon)) { ret res_colon; }
-        val res_ty: R.Result[bool, str] = print_type(out, m, fn.params[i].ty);
-        if (R.is_err[bool, str](res_ty)) { ret res_ty; }
-        i = i + 1;
     }
 
     val res_close: R.Result[bool, str] = emit_str(out, "): ");
@@ -149,7 +164,7 @@ pub fun print_function(out: *writer.Writer, m: *ir.Module, fn: *ir.Function, int
     val res_brace: R.Result[bool, str] = emit_str(out, " {\n");
     if (R.is_err[bool, str](res_brace)) { ret res_brace; }
 
-    i = 0;
+    var i: u32 = 0;
     for (i < fn.block_count) {
         val res_block: R.Result[bool, str] = print_block(out, m, fn, ?fn.blocks[i], interner);
         if (R.is_err[bool, str](res_block)) { ret res_block; }
@@ -495,12 +510,32 @@ fun print_operands(out: *writer.Writer, m: *ir.Module, fn: *ir.Function, ins: *i
             if (R.is_err[bool, str](res_id)) { ret res_id; }
         }
         or {
-            val res_val: R.Result[bool, str] = print_value(out, m, op, interner);
-            if (R.is_err[bool, str](res_val)) { ret res_val; }
+            val res_op: R.Result[bool, str] = print_operand(out, m, op, interner);
+            if (R.is_err[bool, str](res_op)) { ret res_op; }
         }
         i = i + 1;
     }
     ret R.ok[bool, str](true);
+}
+
+# render one value operand followed by its IR type as `<value>: <ty>`
+#
+# The per-operand type is what makes a mis-typed operand visible in a dump (an
+# aggregate passed as a bare pointer, a wrong-width integer): the Value carries
+# its own `ty`, independent of the referenced definition's result type. Used at
+# every value use site (flat operand lists, phi incomings).
+# ---
+# out:      destination writer
+# m:        the owning module (for global / function name lookup and the type table)
+# v:        the operand value to render
+# interner: interner for recovering names
+# ret:      ok(true) on success, or a write error
+fun print_operand(out: *writer.Writer, m: *ir.Module, v: *value.Value, interner: *intern.Interner) R.Result[bool, str] {
+    val res_val: R.Result[bool, str] = print_value(out, m, v, interner);
+    if (R.is_err[bool, str](res_val)) { ret res_val; }
+    val res_colon: R.Result[bool, str] = emit_str(out, ": ");
+    if (R.is_err[bool, str](res_colon)) { ret res_colon; }
+    ret print_type(out, m, v.ty);
 }
 
 # render a phi's `[bbN %v, bbM %w, ...]` incoming list
@@ -530,11 +565,41 @@ fun print_phi_operands(out: *writer.Writer, m: *ir.Module, fn: *ir.Function, ins
         if (R.is_err[bool, str](res_id)) { ret res_id; }
         val res_space: R.Result[bool, str] = emit_str(out, " ");
         if (R.is_err[bool, str](res_space)) { ret res_space; }
-        val res_val: R.Result[bool, str] = print_value(out, m, ?ins.operands[i + 1], interner);
+        val res_val: R.Result[bool, str] = print_operand(out, m, ?ins.operands[i + 1], interner);
         if (R.is_err[bool, str](res_val)) { ret res_val; }
         i = i + 2;
     }
     ret emit_str(out, "]");
+}
+
+# render a function signature's parameter types from its IRT_FN type id as a bare
+# comma list `T0, T1, ...`
+#
+# Used for an extern declaration, which carries a signature but no materialized
+# VAL_PARAM values to name `%pN`. Writes nothing for a missing or non-function
+# type id (malformed IR) or a zero-parameter signature.
+# ---
+# out: destination writer
+# m:   the owning module (for the IR type table)
+# sig: the function's signature type id
+# ret: ok(true) on success, or a write error
+fun print_signature_params(out: *writer.Writer, m: *ir.Module, sig: type.IrTypeId) R.Result[bool, str] {
+    val opt_type: O.Option[*type.IrType] = type.get(?m.types, sig);
+    if (O.is_none[*type.IrType](opt_type)) { ret R.ok[bool, str](true); }
+    val t: *type.IrType = O.unwrap[*type.IrType](opt_type);
+    if (t.kind != type.IRT_FN) { ret R.ok[bool, str](true); }
+
+    var i: u32 = 0;
+    for (i < t.data.fn.param_count) {
+        if (i > 0) {
+            val res_sep: R.Result[bool, str] = emit_str(out, ", ");
+            if (R.is_err[bool, str](res_sep)) { ret res_sep; }
+        }
+        val res_ty: R.Result[bool, str] = print_type(out, m, t.data.fn.params[i]);
+        if (R.is_err[bool, str](res_ty)) { ret res_ty; }
+        i = i + 1;
+    }
+    ret R.ok[bool, str](true);
 }
 
 # render a function signature's return type from its IRT_FN type id


### PR DESCRIPTION
Closes #2065.

## Problem

`--emit-ir` hid two things the IR actually carries, which made structurally-broken IR read as correct twice during the #2035 investigation:

- **Extern declarations dropped their signature.** `print_function` renders parameters from `fn.params`, which is empty for an extern (no body is emitted), so an extern printed as `fn @name(): ret extern` with no parameter types — even though `fn.sig` holds the full `IRT_FN`.
- **No per-operand types at use sites.** Every operand `Value` records its own `ty`, but the printer showed only the bare `%n` / `@name` / constant, so a mis-typed operand (an aggregate passed as a bare pointer) was invisible.

## Fix (printer-only, `src/lang/me/ir/printer.mach`)

- Render an extern's parameter types from its `IRT_FN` signature (`print_signature_params`).
- Suffix every value operand at a use site with its own IR type as `value: ty`, shared by the flat operand list and phi incomings (`print_operand`). Branch targets (`bb<n>`) and phi block ids stay untyped.
- Updated the module-level format doc to match.

No IR data-model or lowering change; the printer renders richer types automatically once #2063 lands real `IRT_FN` signatures on generic-instance callee references.

## Before / after

Source:
```
ext fun write(p0: i32, p1: ptr, p2: u64) i64;
fun add3(a: i32, b: i32, c: i32) i32 { val s: i32 = a + b; ret s + c; }
fun main(argc: i64, argv: ptr) i64 {
    val r: i32 = add3(1, 2, 3);
    val w: i64 = write(1, argv, r::u64);
    ret w;
}
```

Before:
```
  fn @write(): i64 extern

  fn @_M6irdemo4mainN4add3(%p0: i32, %p1: i32, %p2: i32): i32 {
    block bb0:
      %9 = add i32 %p0, %p1
      %13 = add i32 %9, %p2
      ret %13
  }

  fn @_M6irdemo4mainN4main(%p0: i64, %p1: ptr): i64 {
    block bb0:
      %5 = call i32 @_M6irdemo4mainN4add3, 1, 2, 3
      %10 = sext i64 %5
      %11 = call i64 @write, 1, %p1, %10
      ret %11
  }
```

After:
```
  fn @write(i32, ptr, i64): i64 extern

  fn @_M6irdemo4mainN4add3(%p0: i32, %p1: i32, %p2: i32): i32 {
    block bb0:
      %9 = add i32 %p0: i32, %p1: i32
      %13 = add i32 %9: i32, %p2: i32
      ret %13: i32
  }

  fn @_M6irdemo4mainN4main(%p0: i64, %p1: ptr): i64 {
    block bb0:
      %5 = call i32 @_M6irdemo4mainN4add3: fn(i32, i32, i32) -> i32, 1: i32, 2: i32, 3: i32
      %10 = sext i64 %5: i32
      %11 = call i64 @write: fn(i32, ptr, i64) -> i64, 1: i32, %p1: ptr, %10: i64
      ret %11: i64
  }
```

Control flow keeps branch targets untyped and types phi incomings:
```
    block bb1:
      %21 = phi i32 [bb0 0: i32, bb2 %13: i32]
      %9 = cmp_lt_s i8 %22: i32, %p0: i32
      cbr %9: i8, bb2, bb3
    block bb2:
      %13 = add i32 %21: i32, %22: i32
      br bb1
```

## Verification

Built the compiler from this branch and verified with **that** binary (not the PATH seed):
- `mach test .` — 643 passed, 0 failed.
- Self-host byte-identical fixpoint holds (stage-2 built by the from-source compiler is `cmp`-identical to stage-1).
- Before/after samples above produced by the from-source compiler via `--emit-ir`.
