### PR TITLE
feat(link): imported-data GOT consumer path (#2026)

### DIFF
--- a/doc/language/ext-fun.md
+++ b/doc/language/ext-fun.md
@@ -144,5 +144,6 @@ is currently implemented for the ELF (Linux) target; the PE (Windows) and Mach-O
 ## See also
 
 - [fun.md](fun.md) — regular function declarations
+- [val-var.md](val-var.md) — `ext val` / `ext var`, the data analogue (foreign data imports)
 - [visibility.md](visibility.md) — `pub` and `ext` modifiers
 - [decorators.md](decorators.md) — `symbol`, `library`, and other codegen decorators

--- a/doc/language/val-var.md
+++ b/doc/language/val-var.md
@@ -34,6 +34,29 @@ At module top level:
 
 Inside functions, they are local to the enclosing block.
 
+## `ext` — foreign data imports
+
+`ext val` / `ext var` declares a binding whose storage lives in another object,
+imported by name — the data analogue of [`ext fun`](ext-fun.md). It is a
+forward reference the linker resolves, so it is **storage-less** and carries no
+initializer:
+
+```mach
+ext var errno: i32;                        # imported mutable datum
+#[symbol("environ")] ext var env: **u8;    # renamed import
+#[library("libfoo.so")] ext val foo_flags: u32;  # library-pinned import
+```
+
+- No initializer. `ext val x: T = ...;` is an error — the definition, and its
+  value, live in the providing object (mirrors `ext fun`'s absent body).
+- The `symbol` and `library` decorators and the static/dynamic linking inputs
+  work exactly as for [`ext fun`](ext-fun.md).
+- On a dynamic target the reference is emitted GOT-indirect so the loader binds
+  it to the runtime definition (ELF: an `R_*_GLOB_DAT` GOT slot); an ordinary
+  cross-module reference to a `val`/`var` defined elsewhere in the same artifact
+  stays directly addressed. Executed dynamic-import resolution is proven on the
+  native ELF legs.
+
 ## No inference
 
 Every binding declares its type. An untyped numeric literal is checked

--- a/src/lang/be/codegen/mir/context.mach
+++ b/src/lang/be/codegen/mir/context.mach
@@ -502,15 +502,16 @@ pub fun lower_value(ctx: *LowerCtx, v: value.Value) mir.MirOperand {
     }
     if (v.kind == value.VAL_GLOBAL) {
         if (v.data.global_ix < ctx.m.global_len) {
-            # NOTE: an imported (`is_extern`) global is preemptible and would load
-            # GOT-indirect (set `o.sym_got = true` here). that wiring is withheld
-            # pending RFC #2026: with no compile-time import signal and no linker
-            # GOT relaxation, routing every `is_extern` reference through the GOT
-            # would tax all cross-module data access. `is_extern` data therefore
-            # keeps the position-independent adrp+add form for now; the GOT-indirect
-            # codegen foundation (RK_GOT_*, emit_global_addr_got, MirOperand.sym_got)
-            # ships dormant.
-            ret mir.op_sym(ctx.m.globals[v.data.global_ix].name, 0);
+            # a genuine foreign/dynamic data import (`is_import`, an `ext val`/
+            # `ext var`) is preemptible: its definition lives in another object
+            # bound at run time, so its address is loaded GOT-indirect (#2026). a
+            # plain same-artifact cross-module reference (`is_extern` but not
+            # `is_import`) is resolved within the artifact and keeps the direct,
+            # position-independent adrp+add form. the linker builds the GOT slot -
+            # GLOB_DAT for a dynamic import, a filled slot for a static definition.
+            var o: mir.MirOperand = mir.op_sym(ctx.m.globals[v.data.global_ix].name, 0);
+            if (ctx.m.globals[v.data.global_ix].is_import) { o.sym_got = true; }
+            ret o;
         }
         # an in-range global index is an IR invariant; an out-of-range one is a
         # lowering bug -- fail loudly rather than emit a STR_NIL symbol the

--- a/src/lang/be/linker.mach
+++ b/src/lang/be/linker.mach
@@ -142,6 +142,7 @@ rec DynState {
     fixup_count: u32;
     fixup_cap:   u32;
     base_reloc_cap: u32;
+    got_fixup_cap:  u32;
     active:      bool;
 }
 
@@ -2072,10 +2073,11 @@ fun patch_module_relocations(s: *session.Session, out_img: *of.ObjectImage,
             }
             or {
                 # not defined anywhere: a dynamic import, or a hard error. a
-                # pc-relative call to a FUNCTION import is deferred to the writer
-                # (only function imports get a PLT stub); any other unresolved
-                # reference - including a call kind against a data import (deferred)
-                # - is rejected as undefined.
+                # pc-relative call to a FUNCTION import is deferred to the writer as
+                # a PLT fixup; a GOT-indirect access to a DATA import is deferred as
+                # a GOT fixup (the writer builds its GOT slot + GLOB_DAT). any other
+                # unresolved reference - a call against a data import, an absolute
+                # reference to any import - is rejected as undefined.
                 val imp: R.Result[u32, str] = dynstate_import_index(dyn, r.symbol);
                 if (R.is_ok[u32, str](imp) && is_call_kind(r.kind)
                     && dynstate_import_is_func(dyn, R.unwrap_ok[u32, str](imp))) {
@@ -2083,6 +2085,14 @@ fun patch_module_relocations(s: *session.Session, out_img: *of.ObjectImage,
                         segment_index_for(out_img, out_ix), patch_off,
                         R.unwrap_ok[u32, str](imp), patch_va, r.addend);
                     if (R.is_err[bool, str](rec_r)) { ret R.err[bool, str](R.unwrap_err[bool, str](rec_r)); }
+                    ri = ri + 1; cnt;
+                }
+                if (R.is_ok[u32, str](imp) && is_got_kind(r.kind)
+                    && !dynstate_import_is_func(dyn, R.unwrap_ok[u32, str](imp))) {
+                    val rec_g: R.Result[bool, str] = dynstate_add_got_fixup(s, dyn,
+                        segment_index_for(out_img, out_ix), patch_off,
+                        R.unwrap_ok[u32, str](imp), patch_va, r.kind);
+                    if (R.is_err[bool, str](rec_g)) { ret R.err[bool, str](R.unwrap_err[bool, str](rec_g)); }
                     ri = ri + 1; cnt;
                 }
                 ret R.err[bool, str](undef_message(s, r.symbol));
@@ -2174,10 +2184,13 @@ fun init_dynstate(dyn: *DynState) {
     dyn.info.base_relocs      = nil;
     dyn.info.base_reloc_count = 0;
     dyn.info.pie              = false;
+    dyn.info.got_fixups       = nil;
+    dyn.info.got_fixup_count  = 0;
     dyn.fixups            = nil;
     dyn.fixup_count       = 0;
     dyn.fixup_cap         = 0;
     dyn.base_reloc_cap    = 0;
+    dyn.got_fixup_cap     = 0;
     dyn.active            = false;
 }
 
@@ -2198,6 +2211,9 @@ fun free_dynstate(alloc: *A.Allocator, dyn: *DynState) {
     }
     if (dyn.info.base_relocs != nil && dyn.base_reloc_cap > 0) {
         A.deallocate[of.BaseReloc](alloc, dyn.info.base_relocs, dyn.base_reloc_cap::usize);
+    }
+    if (dyn.info.got_fixups != nil && dyn.got_fixup_cap > 0) {
+        A.deallocate[of.GotFixup](alloc, dyn.info.got_fixups, dyn.got_fixup_cap::usize);
     }
     if (dyn.active) {
         map.dnit[intern.StrId, u32](?dyn.import_map);
@@ -2433,6 +2449,16 @@ fun is_call_kind(kind: of.RelocKind) bool {
     ret kind == of.RK_PC32 || kind == of.RK_PLT32;
 }
 
+# whether an abstract relocation kind is a GOT-indirect address load - the shape
+# an imported-data reference lowers to (#2026). a GOT-kind reloc against a data
+# import is resolved to the import's GOT slot by the writer, not patched here
+# ---
+# kind: the abstract relocation kind to test
+# ret:  true for a GOT-indirect kind (aarch64 page21/lo12 pair, x86_64 GOTPCREL)
+fun is_got_kind(kind: of.RelocKind) bool {
+    ret kind == of.RK_GOT_PAGE21 || kind == of.RK_GOT_LO12 || kind == of.RK_GOTPCREL;
+}
+
 # the load-segment index a merged output section maps to in the
 # writer's segment array. the writer builds one segment per loadable used section
 # in output order, so the index is the count of loadable sections before `out_ix`
@@ -2480,6 +2506,40 @@ fun dynstate_add_fixup(s: *session.Session, dyn: *DynState, seg_index: u32, seg_
     dyn.fixups[ix].patch_vaddr  = patch_vaddr;
     dyn.fixups[ix].addend       = addend;
     dyn.fixup_count = ix + 1;
+    ret R.ok[bool, str](true);
+}
+
+# append one GOT-indirect data-import access site, growing the array
+# geometrically. the writer resolves each to its import's GOT slot and emits the
+# slot's GLOB_DAT dynamic relocation (#2026)
+# ---
+# s:            shared session (allocator), backing the fixup array
+# dyn:          out - the dynamic-link state whose GOT-fixup array grows
+# seg_index:    load-segment index of the patched instruction
+# seg_offset:   byte offset of the patched instruction within its segment
+# import_index: plan import index (a data import) this access binds to
+# patch_vaddr:  the patched instruction's virtual address
+# kind:         the GOT relocation kind (page-high vs scaled-lo12 half)
+# ret:          ok(true) once recorded, or an allocation error
+fun dynstate_add_got_fixup(s: *session.Session, dyn: *DynState, seg_index: u32, seg_offset: u32,
+                           import_index: u32, patch_vaddr: u64, kind: of.RelocKind) R.Result[bool, str] {
+    val alloc: *A.Allocator = s.alloc;
+    if (dyn.info.got_fixup_count == dyn.got_fixup_cap) {
+        var new_cap: u32 = dyn.got_fixup_cap * 2;
+        if (new_cap == 0) { new_cap = 4; }
+        val gr: R.Result[*of.GotFixup, str] =
+            A.reallocate[of.GotFixup](alloc, dyn.info.got_fixups, dyn.got_fixup_cap::usize, new_cap::usize);
+        if (R.is_err[*of.GotFixup, str](gr)) { ret R.err[bool, str](R.unwrap_err[*of.GotFixup, str](gr)); }
+        dyn.info.got_fixups = R.unwrap_ok[*of.GotFixup, str](gr);
+        dyn.got_fixup_cap = new_cap;
+    }
+    val ix: u32 = dyn.info.got_fixup_count;
+    dyn.info.got_fixups[ix].seg_index    = seg_index;
+    dyn.info.got_fixups[ix].seg_offset   = seg_offset;
+    dyn.info.got_fixups[ix].import_index = import_index;
+    dyn.info.got_fixups[ix].patch_vaddr  = patch_vaddr;
+    dyn.info.got_fixups[ix].kind         = kind;
+    dyn.info.got_fixup_count = ix + 1;
     ret R.ok[bool, str](true);
 }
 

--- a/src/lang/driver.mach
+++ b/src/lang/driver.mach
@@ -1161,7 +1161,9 @@ fun bind_import_libraries(p: *Project, mid: session.ModuleId, start: u32, len: u
         val d_opt: O.Option[*decl.Decl] = ast.get_decl(m.a, did);
         if (O.is_some[*decl.Decl](d_opt)) {
             val d: *decl.Decl = O.unwrap[*decl.Decl](d_opt);
-            if (d.kind == decl.DECL_KIND_FUN && (d.flags & decl.DECL_FLAG_EXT) != 0) {
+            if ((d.kind == decl.DECL_KIND_FUN
+                 || d.kind == decl.DECL_KIND_VAL || d.kind == decl.DECL_KIND_VAR)
+                && (d.flags & decl.DECL_FLAG_EXT) != 0) {
                 val lib_opt: O.Option[intern.StrId] = session.export_library(p.s, mid, did::u32);
                 if (O.is_some[intern.StrId](lib_opt)) {
                     val name_opt: O.Option[intern.StrId] = session.export_name(p.s, mid, did::u32);
@@ -1205,6 +1207,11 @@ fun scan_export_directives(p: *Project, mid: session.ModuleId, source: str, star
             val d: *decl.Decl = O.unwrap[*decl.Decl](d_opt);
             if (d.kind == decl.DECL_KIND_FUN && (d.flags & decl.DECL_FLAG_EXT) != 0) {
                 val r: R.Result[bool, str] = register_ext_fun(p, mid, source, d, did);
+                if (R.is_err[bool, str](r)) { ret r; }
+            }
+            or ((d.kind == decl.DECL_KIND_VAL || d.kind == decl.DECL_KIND_VAR)
+                && (d.flags & decl.DECL_FLAG_EXT) != 0) {
+                val r: R.Result[bool, str] = register_ext_global(p, mid, source, d, did);
                 if (R.is_err[bool, str](r)) { ret r; }
             }
             or (d.kind == decl.DECL_KIND_COMPTIME_IF) {
@@ -1287,6 +1294,16 @@ fun register_decl_decorators(p: *Project, mid: session.ModuleId, source: str, d:
 fun register_ext_fun(p: *Project, mid: session.ModuleId, source: str, d: *decl.Decl, did: id.DeclId) R.Result[bool, str] {
     if (O.is_some[intern.StrId](session.export_name(p.s, mid, did::u32))) { ret R.ok[bool, str](true); }
     val name_r: R.Result[intern.StrId, str] = intern.intern_span(?p.s.interner, source, d.data.fun_.name);
+    if (R.is_err[intern.StrId, str](name_r)) { ret R.err[bool, str](R.unwrap_err[intern.StrId, str](name_r)); }
+    ret session.register_export_name(p.s, mid, did::u32, R.unwrap_ok[intern.StrId, str](name_r));
+}
+
+# register an `ext val`/`ext var` foreign data import's bare source name as its
+# link-name exemption, so a definition and every reference resolve to the literal
+# (unmangled) symbol - the data analogue of `register_ext_fun` (#2026)
+fun register_ext_global(p: *Project, mid: session.ModuleId, source: str, d: *decl.Decl, did: id.DeclId) R.Result[bool, str] {
+    if (O.is_some[intern.StrId](session.export_name(p.s, mid, did::u32))) { ret R.ok[bool, str](true); }
+    val name_r: R.Result[intern.StrId, str] = intern.intern_span(?p.s.interner, source, d.data.bind.name);
     if (R.is_err[intern.StrId, str](name_r)) { ret R.err[bool, str](R.unwrap_err[intern.StrId, str](name_r)); }
     ret session.register_export_name(p.s, mid, did::u32, R.unwrap_ok[intern.StrId, str](name_r));
 }

--- a/src/lang/fe/parser/decl.mach
+++ b/src/lang/fe/parser/decl.mach
@@ -600,7 +600,8 @@ fun parse_rec_uni_decl(p: *state.Parser, start: token.Span, flags: u8, kind: dec
 # parse `val name: Type [= expr];` or `var name: Type [= expr];`
 #
 # Both bindings require an explicit type annotation (Mach has no type inference);
-# `val` additionally requires an initializer.
+# `val` additionally requires an initializer, unless it is an `ext` foreign data
+# import (storage-less, like the body-less `ext fun`).
 # ---
 # p:     parser state positioned at the `val`/`var` keyword
 # start: span of the declaration's first token
@@ -621,12 +622,15 @@ fun parse_bind_decl(p: *state.Parser, start: token.Span, flags: u8, kind: decl.D
         state.error_at_current(p, "expected ':' and a type; bindings require an explicit type annotation");
     }
 
-    # `val` requires an initializer; `var` may be default-initialized
+    # `val` requires an initializer; `var` may be default-initialized. an `ext`
+    # binding is a storage-less foreign data import (#2026) whose definition lives
+    # in another object, so it carries no initializer - the exact mirror of the
+    # body-less `ext fun` exemption.
     var init: id.ExprId = id.EXPR_NIL;
     if (state.eat(p, token.KIND_EQ)) {
         init = expr.parse_expr(p);
     }
-    or (kind == decl.DECL_KIND_VAL) {
+    or (kind == decl.DECL_KIND_VAL && (flags & decl.DECL_FLAG_EXT) == 0) {
         state.error_at_current(p, "'val' requires an initializer");
     }
 
@@ -1576,6 +1580,40 @@ test "mach.lang.fe.parser.decl.parse_bind_decl:val_requires_initializer" {
 # val needs type + init; var needs a type but may default-initialize
 test "mach.lang.fe.parser.decl.parse_bind_decl:well_formed" {
     if (t_parse_module_has_errors("val c: i64 = 1; var d: i64;")) { ret 1; }
+    ret 0;
+}
+
+# `ext val`/`ext var` are storage-less foreign data imports (#2026): both parse
+# without an initializer (the `val` exemption mirrors the body-less `ext fun`),
+# carry DECL_FLAG_EXT, and the exemption is ext-only - a plain `val` without an
+# initializer still errors.
+test "mach.lang.fe.parser.decl.parse_bind_decl:ext_data_import" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+    val tr: R.Result[lexer.TokenStream, str] = lexer.tokenize("ext var g: i32; ext val h: i32;", ?alloc, 0::src.FileId);
+    if (R.is_err[lexer.TokenStream, str](tr)) { ret 1; }
+    var stream: lexer.TokenStream = R.unwrap_ok[lexer.TokenStream, str](tr);
+    var a: ast.Ast = ast.init(?alloc, 0::src.FileId);
+    var diags: diagnostic.DiagList = diagnostic.init(?alloc);
+    var p: state.Parser = state.make(?stream, ?a, ?diags);
+    parse_module(?p);
+
+    var rc: i32 = 0;
+    if (diagnostic.has_errors(?diags))                { rc = 1; }
+    or (a.decl_len < 2)                               { rc = 1; }
+    or (a.decls[0].kind != decl.DECL_KIND_VAR)        { rc = 1; }
+    or (a.decls[1].kind != decl.DECL_KIND_VAL)        { rc = 1; }
+    or ((a.decls[0].flags & decl.DECL_FLAG_EXT) == 0) { rc = 1; }
+    or ((a.decls[1].flags & decl.DECL_FLAG_EXT) == 0) { rc = 1; }
+    or (a.decls[1].data.bind.init != id.EXPR_NIL)     { rc = 1; }
+
+    diagnostic.dnit(?diags);
+    ast.dnit(?a);
+    lexer.dnit(?stream, ?alloc);
+    if (rc != 0) { ret rc; }
+
+    # the exemption is ext-only: a non-ext `val` without an initializer still errors.
+    if (!t_parse_module_has_errors("val x: i32;")) { ret 1; }
     ret 0;
 }
 

--- a/src/lang/fe/sema.mach
+++ b/src/lang/fe/sema.mach
@@ -570,6 +570,13 @@ fun infer_one_body(sc: *context.SemaContext, did: id.DeclId) R.Result[bool, str]
         ret R.ok[bool, str](true);
     }
     if (d.kind == decl.DECL_KIND_VAL || d.kind == decl.DECL_KIND_VAR) {
+        # an `ext val`/`ext var` is a foreign data import (#2026): a storage-less
+        # declaration whose definition lives in another object, so it carries no
+        # initializer - mirroring `ext fun`'s absent body.
+        if ((d.flags & decl.DECL_FLAG_EXT) != 0 && d.data.bind.init != id.EXPR_NIL) {
+            context.report(sc, d.span, "an `ext` data import cannot have an initializer");
+            ret R.ok[bool, str](true);
+        }
         ret infer_binding_init(sc, did, d);
     }
     if (d.kind == decl.DECL_KIND_COMPTIME_ATTR) {

--- a/src/lang/me/ir.mach
+++ b/src/lang/me/ir.mach
@@ -298,6 +298,11 @@ pub rec Function {
 # is_extern: true for a global defined in another module; carries no storage here
 #            and is emitted only as a relocation target (the linker binds it to
 #            the defining module's object)
+# is_import: true for a genuine foreign/dynamic data import (an `ext val`/`ext var`,
+#            or a reference to one) - a strict subset of is_extern. an is_extern that
+#            is NOT is_import is a same-artifact cross-module reference; only an
+#            is_import symbol lowers GOT-indirect on a dynamic target, since only it
+#            can be bound at run time by the loader (#2026)
 # is_local:  true for a compiler-synthesized anonymous data global (a string /
 #            byte-blob literal), which is object-private - resolved per-object and
 #            never entered into the cross-object symbol table, so two modules'
@@ -316,6 +321,7 @@ pub rec Global {
     is_mut:    bool;
     is_pub:    bool;
     is_extern: bool;
+    is_import: bool;
     is_local:  bool;
     align:     u32;
     section:   intern.StrId;
@@ -1477,6 +1483,7 @@ test "mach.lang.me.ir.dnit:frees_by_capacity_not_count" {
     gl.is_mut    = false;
     gl.is_pub    = false;
     gl.is_extern = false;
+    gl.is_import = false;
     gl.is_local  = true;
     gl.align     = 0;
     gl.section   = intern.STR_NIL;

--- a/src/lang/me/lower/context.mach
+++ b/src/lang/me/lower/context.mach
@@ -1267,15 +1267,25 @@ pub fun ensure_extern_function(lc: *LowerContext, name: intern.StrId, sig: ir_ty
 # `is_extern` declaration when none exists. a reference to a `val`/`var` defined
 # in another module resolves through this so the back end emits a name-based
 # relocation the linker binds to the defining object
+#
+# `import_flag` marks a genuine foreign/dynamic data import (a reference to an
+# `ext val`/`ext var`), which lowers GOT-indirect on a dynamic target; a plain
+# same-artifact cross-module reference passes it false and keeps direct addressing.
+# a repeated reference to a name already declared an import stays an import.
 # ---
-# lc:   the context
-# name: interned global symbol name
-# ty:   the global's IR storage type
-# ret:  the global index, or an allocation error
-pub fun ensure_extern_global(lc: *LowerContext, name: intern.StrId, ty: ir_type.IrTypeId) R.Result[u32, str] {
+# lc:          the context
+# name:        interned global symbol name
+# ty:          the global's IR storage type
+# import_flag: true for a genuine dynamic data import (#2026)
+# ret:         the global index, or an allocation error
+pub fun ensure_extern_global(lc: *LowerContext, name: intern.StrId, ty: ir_type.IrTypeId, import_flag: bool) R.Result[u32, str] {
     val m: *ir.Module = lc.m;
     val existing: O.Option[u32] = ir.global_lookup(m, name);
-    if (O.is_some[u32](existing)) { ret R.ok[u32, str](O.unwrap[u32](existing)); }
+    if (O.is_some[u32](existing)) {
+        val gi: u32 = O.unwrap[u32](existing);
+        if (import_flag) { m.globals[gi].is_import = true; }
+        ret R.ok[u32, str](gi);
+    }
 
     if (m.global_len == m.global_cap) {
         val new_cap: u32 = grow_cap(m.global_cap);
@@ -1293,6 +1303,7 @@ pub fun ensure_extern_global(lc: *LowerContext, name: intern.StrId, ty: ir_type.
     g.is_mut    = true;
     g.is_pub    = false;
     g.is_extern = true;
+    g.is_import = import_flag;
     g.is_local  = false;
     g.align     = 0;
     g.section   = intern.STR_NIL;
@@ -1334,6 +1345,7 @@ pub fun add_rodata_bytes(lc: *LowerContext, init: value.Value, pty: ir_type.IrTy
     g.is_mut    = false;
     g.is_pub    = false;
     g.is_extern = false;
+    g.is_import = false;
     g.is_local  = true;
     g.align     = 0;
     g.section   = intern.STR_NIL;

--- a/src/lang/me/lower/decl.mach
+++ b/src/lang/me/lower/decl.mach
@@ -340,6 +340,27 @@ pub fun lower_global(ctx: *context.LowerContext, did: id.DeclId, d: *decl.Decl, 
     val res_align: R.Result[u32, str] = global_align_of(ctx, d);
     if (R.is_err[u32, str](res_align)) { ret R.err[bool, str](R.unwrap_err[u32, str](res_align)); }
 
+    # an `ext val`/`ext var` is a foreign/dynamic data import: a storage-less
+    # declaration (is_extern) marked is_import, so references lower GOT-indirect on
+    # a dynamic target (#2026). its link name is the bare source name (or a
+    # `#[symbol]` override) rather than a module-path mangle, mirroring `ext fun`.
+    if ((d.flags & decl.DECL_FLAG_EXT) != 0) {
+        var gx: ir.Global;
+        gx.name      = name;
+        gx.ty        = gty;
+        gx.init      = value.const_int(0, gty);
+        gx.is_mut    = is_mut;
+        gx.is_pub    = false;
+        gx.is_extern = true;
+        gx.is_import = true;
+        gx.is_local  = false;
+        gx.align     = R.unwrap_ok[u32, str](res_align);
+        gx.section   = intern.STR_NIL;
+        val res_ext: R.Result[u32, str] = append_global(ctx, gx);
+        if (R.is_err[u32, str](res_ext)) { ret R.err[bool, str](R.unwrap_err[u32, str](res_ext)); }
+        ret R.ok[bool, str](true);
+    }
+
     var g: ir.Global;
     g.name      = name;
     g.ty        = gty;
@@ -347,6 +368,7 @@ pub fun lower_global(ctx: *context.LowerContext, did: id.DeclId, d: *decl.Decl, 
     g.is_mut    = is_mut;
     g.is_pub    = (d.flags & decl.DECL_FLAG_PUB) != 0;
     g.is_extern = false;
+    g.is_import = false;
     g.is_local  = false;
     g.align     = R.unwrap_ok[u32, str](res_align);
     g.section   = decl_section_of(ctx, d);

--- a/src/lang/me/lower/expr.mach
+++ b/src/lang/me/lower/expr.mach
@@ -586,7 +586,7 @@ fun symbol_reference(ctx: *context.LowerContext, eid: id.ExprId, sid: resolve.Sy
     # declare a storage-less extern global here and load through it; the back end
     # emits a name-based relocation the linker binds to the defining object -
     # mirroring the extern-function path above.
-    val res_xg: R.Result[u32, str] = context.ensure_extern_global(ctx, link, vty);
+    val res_xg: R.Result[u32, str] = context.ensure_extern_global(ctx, link, vty, references_import_data(ctx, sym));
     if (R.is_err[u32, str](res_xg)) { ret R.err[value.Value, str](R.unwrap_err[u32, str](res_xg)); }
     ret emit_global_rvalue(ctx, R.unwrap_ok[u32, str](res_xg), vty);
 }
@@ -604,6 +604,30 @@ pub fun references_function(ctx: *context.LowerContext, eid: id.ExprId) bool {
     val opt_t: O.Option[*type.Type] = type.get(?ctx.s.types, tid);
     if (O.is_none[*type.Type](opt_t)) { ret false; }
     ret O.unwrap[*type.Type](opt_t).kind == type.TYPE_FUN;
+}
+
+# whether a symbol names a genuine foreign/dynamic DATA import (an `ext val`/
+# `ext var`)
+#
+# Such a reference lowers GOT-indirect on a dynamic target (#2026), so a
+# storage-less extern global declared here for it must carry is_import. The
+# discriminator is the referent's origin decl: an imported symbol (SYM_IMPORTED)
+# reads its origin module's AST; a same-module ext val is already a declared
+# import global (found before this path runs), so only the cross-module case
+# reaches here. A non-binding symbol, or a binding without `ext`, is not an import.
+# ---
+# ctx: per-module lowering context
+# sym: the symbol to classify
+# ret: true when `sym` names an `ext` data binding
+fun references_import_data(ctx: *context.LowerContext, sym: *resolve.Symbol) bool {
+    if (sym.kind != resolve.SYM_IMPORTED) { ret false; }
+    val origin_ast: *ast.Ast = session.module_ast(ctx.s, sym.origin);
+    if (origin_ast == nil) { ret false; }
+    val opt_d: O.Option[*decl.Decl] = ast.get_decl(origin_ast, sym.decl);
+    if (O.is_none[*decl.Decl](opt_d)) { ret false; }
+    val d: *decl.Decl = O.unwrap[*decl.Decl](opt_d);
+    if (d.kind != decl.DECL_KIND_VAL && d.kind != decl.DECL_KIND_VAR) { ret false; }
+    ret (d.flags & decl.DECL_FLAG_EXT) != 0;
 }
 
 # whether a symbol names a function DECLARATION
@@ -665,7 +689,7 @@ fun symbol_lvalue(ctx: *context.LowerContext, eid: id.ExprId, sid: resolve.Symbo
     val res_ir: R.Result[ir_type.IrTypeId, str] = ir_type_of_expr(ctx, eid);
     if (R.is_err[ir_type.IrTypeId, str](res_ir)) { ret R.err[value.Value, str](R.unwrap_err[ir_type.IrTypeId, str](res_ir)); }
     val vty: ir_type.IrTypeId = R.unwrap_ok[ir_type.IrTypeId, str](res_ir);
-    val res_xg: R.Result[u32, str] = context.ensure_extern_global(ctx, link, vty);
+    val res_xg: R.Result[u32, str] = context.ensure_extern_global(ctx, link, vty, references_import_data(ctx, sym));
     if (R.is_err[u32, str](res_xg)) { ret R.err[value.Value, str](R.unwrap_err[u32, str](res_xg)); }
     ret global_pointer(ctx, R.unwrap_ok[u32, str](res_xg));
 }

--- a/src/lang/target/of.mach
+++ b/src/lang/target/of.mach
@@ -316,6 +316,8 @@ pub rec BaseReloc {
 # base_reloc_count: number of base relocations
 # pie:              true when the image is position-independent (sets the format's
 #                   PIE marker and selects a relocatable layout + entry)
+# got_fixups:       GOT-indirect data-import access sites (empty unless data imports)
+# got_fixup_count:  number of GOT fixups
 pub rec DynamicInfo {
     libs:      *DynLib;
     lib_count: u32;
@@ -328,6 +330,11 @@ pub rec DynamicInfo {
     base_relocs:      *BaseReloc;
     base_reloc_count: u32;
     pie:              bool;
+
+    # GOT-indirect data-import access sites the linker located during patching, for
+    # the writer to resolve to their GOT slots + emit GLOB_DAT dynamic relocs (#2026)
+    got_fixups:       *GotFixup;
+    got_fixup_count:  u32;
 }
 
 # one pc-relative call site the linker located that targets a dynamic import, to
@@ -351,6 +358,30 @@ pub rec PltFixup {
     import_index: u32;
     patch_vaddr:  u64;
     addend:       i64;
+}
+
+# one GOT-indirect data-import access site the linker located, to be resolved to
+# its GOT slot's virtual address by `emit_dyn_exec` (#2026)
+#
+# An `ext val`/`ext var` read lowers to a two-instruction GOT load (`adrp :got:`
+# + `ldr :got_lo12:`), a distinct relocation per instruction. The linker cannot
+# resolve them during patching because the GOT slot's address is part of the
+# format's dynamic layout, which the writer owns; it records each patch site here
+# and the writer fills the page-high / scaled-lo12 halves once the slot is placed
+# and emits a `GLOB_DAT` dynamic relocation binding the slot at load. `kind`
+# discriminates the two halves (the page-high on the `adrp`, the lo12 on the `ldr`).
+# ---
+# seg_index:    index into the writer's segment array of the patched segment
+# seg_offset:   byte offset of the patched instruction within that segment
+# import_index: index into `DynamicInfo.imports` of the targeted data import
+# patch_vaddr:  virtual address of the patched instruction (the page-high base)
+# kind:         the GOT relocation kind (RK_GOT_PAGE21 / RK_GOT_LO12 / RK_GOTPCREL)
+pub rec GotFixup {
+    seg_index:    u32;
+    seg_offset:   u32;
+    import_index: u32;
+    patch_vaddr:  u64;
+    kind:         RelocKind;
 }
 
 # one loadable segment of a static executable, in the format-neutral terms the

--- a/src/lang/target/of/elf.mach
+++ b/src/lang/target/of/elf.mach
@@ -2564,6 +2564,18 @@ fun jump_slot_for(arch_id: u32) u32 {
     ret R_X86_64_JUMP_SLOT;
 }
 
+# the ELF machine GLOB_DAT (GOT-slot bind) relocation type for an ISA (#2026)
+#
+# Defaults to the x86-64 type for an unrecognized ISA.
+# ---
+# arch_id: the target ISA id
+# ret:     the ELF R_*_GLOB_DAT relocation type
+fun glob_dat_for(arch_id: u32) u32 {
+    if (arch_id == isa.ARCH_AARCH64) { ret R_AARCH64_GLOB_DAT; }
+    if (arch_id == isa.ARCH_RISCV64) { ret R_RISCV_GLOB_DAT; }
+    ret R_X86_64_GLOB_DAT;
+}
+
 # the ELF machine RELATIVE (load-bias) relocation type for an ISA
 #
 # Defaults to the x86-64 type for an unrecognized ISA.
@@ -2654,9 +2666,11 @@ rec DynLayout {
     dynstr_off: usize;   dynstr_va: u64;    dynstr_size: usize;
     hash_off: usize;     hash_va: u64;      hash_size: usize;
     relaplt_off: usize;  relaplt_va: u64;   relaplt_size: usize;
+    reladyn_off: usize;  reladyn_va: u64;   reladyn_size: usize;
     plt_off: usize;      plt_va: u64;       plt_size: usize;
     rw_off: usize;       rw_va: u64;        rw_size: usize;
     gotplt_off: usize;   gotplt_va: u64;    gotplt_size: usize;
+    datagot_off: usize;  datagot_va: u64;   datagot_size: usize;
     dynamic_off: usize;  dynamic_va: u64;   dynamic_size: usize;
 }
 
@@ -2673,6 +2687,39 @@ fun func_import_count(dyn: *of.DynamicInfo) u32 {
     var i: u32 = 0;
     for (i < dyn.import_count) {
         if (dyn.imports[i].is_func) { n = n + 1; }
+        i = i + 1;
+    }
+    ret n;
+}
+
+# count the data imports in a dynamic plan
+#
+# Each data import (an `ext val`/`ext var`, #2026) gets a GOT slot bound at load
+# by an `R_*_GLOB_DAT` relocation and a `.dynsym`/`.dynstr` entry, but no PLT stub.
+# ---
+# dyn: the dynamic-link plan to scan
+# ret: the number of data imports
+fun data_import_count(dyn: *of.DynamicInfo) u32 {
+    var n: u32 = 0;
+    var i: u32 = 0;
+    for (i < dyn.import_count) {
+        if (!dyn.imports[i].is_func) { n = n + 1; }
+        i = i + 1;
+    }
+    ret n;
+}
+
+# the data-import ordinal (0-based, in plan order) of raw import index `raw`, i.e.
+# the count of data imports preceding it - selects its GOT slot and dynsym entry
+# ---
+# dyn: the dynamic-link plan
+# raw: the raw index into `dyn.imports` (a data import)
+# ret: the data-import ordinal
+fun data_import_ordinal(dyn: *of.DynamicInfo, raw: u32) u32 {
+    var n: u32 = 0;
+    var i: u32 = 0;
+    for (i < raw && i < dyn.import_count) {
+        if (!dyn.imports[i].is_func) { n = n + 1; }
         i = i + 1;
     }
     ret n;
@@ -2893,10 +2940,14 @@ fun emit_dyn_exec(alloc: *A.Allocator, itn: *intern.Interner, tgt_isa: *isa.IsaV
         lib_str = R.unwrap_ok[*usize, str](rl);
     }
 
-    # write the synthesized structures, then patch the import call sites.
+    # write the synthesized structures, then patch the import call sites and the
+    # GOT-indirect data-import access sites.
     write_dyn_structures(itn, buf, ?lay, dyn, nimp, tgt_isa.id, imp_str, lib_str);
-    val fx_r: R.Result[bool, str] =
+    var fx_r: R.Result[bool, str] =
         patch_plt_fixups(buf, ?lay, dyn, fixups, fixup_count, seg_offsets, segs, seg_count, nimp, tgt_isa.id);
+    if (R.is_ok[bool, str](fx_r)) {
+        fx_r = patch_got_fixups(buf, ?lay, dyn, seg_offsets, segs, seg_count, tgt_isa.id);
+    }
 
     if (imp_str != nil) { A.deallocate[usize](alloc, imp_str, dyn.import_count::usize); }
     if (lib_str != nil) { A.deallocate[usize](alloc, lib_str, dyn.lib_count::usize); }
@@ -2952,6 +3003,11 @@ fun compute_dyn_layout(itn: *intern.Interner, lay: *DynLayout, dyn: *of.DynamicI
                        arch_id: u32, struct_file: usize, struct_va: u64, page_size: u64) {
     val page_sz: usize = page_size::usize;
 
+    # data imports (#2026): each takes a .dynsym/.dynstr entry, a GOT slot, and a
+    # `.rela.dyn` GLOB_DAT relocation. ndata == 0 leaves the layout byte-identical
+    # to the function-only image.
+    val ndata: u32 = data_import_count(dyn);
+
     # read-only metadata segment.
     lay.ro_off = struct_file;
     lay.ro_va  = struct_va;
@@ -2966,16 +3022,19 @@ fun compute_dyn_layout(itn: *intern.Interner, lay: *DynLayout, dyn: *of.DynamicI
     off = off + lay.interp_size;
     va  = va  + lay.interp_size::u64;
 
-    # .dynsym: index 0 reserved-null, then one entry per function import.
+    # .dynsym: index 0 reserved-null, then one entry per function import, then one
+    # per data import (#2026). function imports keep their leading indices so the
+    # JUMP_SLOT relocations are unchanged.
     off = bin.align_up(off, 8);
     va  = bin.align_up_u64(va, 8);
     lay.dynsym_off = off;
     lay.dynsym_va  = va;
-    val dynsym_size: usize = (nimp + 1)::usize * SYM_SIZE;
+    val dynsym_size: usize = (nimp + ndata + 1)::usize * SYM_SIZE;
     off = off + dynsym_size;
     va  = va  + dynsym_size::u64;
 
-    # .dynstr: leading NUL, the interp path, each import name, each soname.
+    # .dynstr: leading NUL, the interp path, each import name (function then data),
+    # each soname.
     lay.dynstr_off = off;
     lay.dynstr_va  = va;
     var dynstr_size: usize = 1;
@@ -2983,6 +3042,11 @@ fun compute_dyn_layout(itn: *intern.Interner, lay: *DynLayout, dyn: *of.DynamicI
     var i: u32 = 0;
     for (i < dyn.import_count) {
         if (dyn.imports[i].is_func) { dynstr_size = dynstr_size + dynstr_name_len(itn, dyn.imports[i].symbol); }
+        i = i + 1;
+    }
+    i = 0;
+    for (i < dyn.import_count) {
+        if (!dyn.imports[i].is_func) { dynstr_size = dynstr_size + dynstr_name_len(itn, dyn.imports[i].symbol); }
         i = i + 1;
     }
     i = 0;
@@ -2997,7 +3061,7 @@ fun compute_dyn_layout(itn: *intern.Interner, lay: *DynLayout, dyn: *of.DynamicI
     va  = bin.align_up_u64(va, 8);
     lay.hash_off = off;
     lay.hash_va  = va;
-    val nchain: usize = (nimp + 1)::usize;
+    val nchain: usize = (nimp + ndata + 1)::usize;
     lay.hash_size = 8 + 4 + nchain * 4;
     off = off + lay.hash_size;
     va  = va  + lay.hash_size::u64;
@@ -3010,6 +3074,16 @@ fun compute_dyn_layout(itn: *intern.Interner, lay: *DynLayout, dyn: *of.DynamicI
     lay.relaplt_size = nimp::usize * RELA_SIZE;
     off = off + lay.relaplt_size;
     va  = va  + lay.relaplt_size::u64;
+
+    # .rela.dyn: one GLOB_DAT relocation per data import (#2026), binding its GOT
+    # slot at load. empty (and absent from .dynamic) with no data imports.
+    off = bin.align_up(off, 8);
+    va  = bin.align_up_u64(va, 8);
+    lay.reladyn_off  = off;
+    lay.reladyn_va   = va;
+    lay.reladyn_size = ndata::usize * RELA_SIZE;
+    off = off + lay.reladyn_size;
+    va  = va  + lay.reladyn_size::u64;
 
     lay.ro_size = off - lay.ro_off;
 
@@ -3035,14 +3109,24 @@ fun compute_dyn_layout(itn: *intern.Interner, lay: *DynLayout, dyn: *of.DynamicI
     off = off + lay.gotplt_size;
     va  = va  + lay.gotplt_size::u64;
 
+    # the data-import GOT (#2026): one slot per data import, loader-filled through
+    # its `.rela.dyn` GLOB_DAT. sits in the same read+write segment as .got.plt.
+    lay.datagot_off  = off;
+    lay.datagot_va   = va;
+    lay.datagot_size = ndata::usize * GOT_ENTRY_SIZE;
+    off = off + lay.datagot_size;
+    va  = va  + lay.datagot_size::u64;
+
     off = bin.align_up(off, 8);
     va  = bin.align_up_u64(va, 8);
     lay.dynamic_off = off;
     lay.dynamic_va  = va;
     # DT_NEEDED per lib + HASH,STRTAB,SYMTAB,STRSZ,SYMENT + (PLT tags when imports)
-    # + (FLAGS,BIND_NOW on the eager arches) + DT_NULL.
+    # + (RELA,RELASZ,RELAENT when data imports) + (FLAGS,BIND_NOW on the eager
+    # arches) + DT_NULL.
     var dyn_entries: u32 = dyn.lib_count + 6;
     if (nimp > 0)              { dyn_entries = dyn_entries + 4; }
+    if (ndata > 0)             { dyn_entries = dyn_entries + 3; }
     if (dyn_bind_now(arch_id)) { dyn_entries = dyn_entries + 2; }
     lay.dynamic_size = dyn_entries::usize * DYN_SIZE;
     off = off + lay.dynamic_size;
@@ -3083,8 +3167,15 @@ fun write_dyn_structures(itn: *intern.Interner, buf: *u8, lay: *DynLayout, dyn: 
         if (dyn.imports[i].is_func) {
             imp_str[i] = str_pos;
             str_pos = str_pos + bin.write_str(buf, lay.dynstr_off + str_pos, resolve(itn, dyn.imports[i].symbol));
-        } or {
-            imp_str[i] = 0;
+        }
+        i = i + 1;
+    }
+    # data-import names follow the function names, matching the .dynsym order (#2026).
+    i = 0;
+    for (i < dyn.import_count) {
+        if (!dyn.imports[i].is_func) {
+            imp_str[i] = str_pos;
+            str_pos = str_pos + bin.write_str(buf, lay.dynstr_off + str_pos, resolve(itn, dyn.imports[i].symbol));
         }
         i = i + 1;
     }
@@ -3112,14 +3203,30 @@ fun write_dyn_structures(itn: *intern.Interner, buf: *u8, lay: *DynLayout, dyn: 
         }
         i = i + 1;
     }
+    # data-import entries follow the function entries, marked STT_OBJECT (#2026);
+    # SHN_UNDEF (st_shndx 0) makes each an import the GLOB_DAT reloc binds.
+    i = 0;
+    for (i < dyn.import_count) {
+        if (!dyn.imports[i].is_func) {
+            bin.write_u32_le(buf, sym_off, imp_str[i]::u32);
+            buf[sym_off + 4] = (STB_GLOBAL << 4) | (STT_OBJECT & 0xF);
+            buf[sym_off + 5] = 0;
+            bin.write_u16_le(buf, sym_off + 6, 0);
+            bin.write_u64_le(buf, sym_off + 8, 0);
+            bin.write_u64_le(buf, sym_off + 16, 0);
+            sym_off = sym_off + SYM_SIZE;
+        }
+        i = i + 1;
+    }
 
     # .hash: a single-bucket SysV table - bucket[0] points at dynsym index 1 and
     # the chain links 1->2->...->n->0. with one bucket the loader walks the whole
     # chain, which is correct (if not fast) for the small import sets here.
-    val nchain: u32 = nimp + 1;
+    val ndata_h: u32 = data_import_count(dyn);
+    val nchain: u32 = nimp + ndata_h + 1;
     bin.write_u32_le(buf, lay.hash_off, 1);
     bin.write_u32_le(buf, lay.hash_off + 4, nchain);
-    if (nimp > 0) { bin.write_u32_le(buf, lay.hash_off + 8, 1); } or { bin.write_u32_le(buf, lay.hash_off + 8, 0); }
+    if (nimp + ndata_h > 0) { bin.write_u32_le(buf, lay.hash_off + 8, 1); } or { bin.write_u32_le(buf, lay.hash_off + 8, 0); }
     var c: u32 = 0;
     for (c < nchain) {
         var next: u32 = c + 1;
@@ -3171,8 +3278,34 @@ fun write_dyn_structures(itn: *intern.Interner, buf: *u8, lay: *DynLayout, dyn: 
         }
     }
 
+    # .rela.dyn: one GLOB_DAT per data import (#2026), binding its GOT slot to the
+    # imported datum's runtime address at load. the slot itself stays zero
+    # (loader-filled). a data import's dynsym index follows the function entries:
+    # 1 + nimp + (data ordinal). the GOT.PLT slots are function-only, so the data
+    # GOT is a distinct region and its slots need no PLT stub.
+    if (ndata_h > 0) {
+        var rd_off:  usize = lay.reladyn_off;
+        var d_sym:   u32   = nimp + 1;
+        var d_ord:   u32   = 0;
+        i = 0;
+        for (i < dyn.import_count) {
+            if (!dyn.imports[i].is_func) {
+                val slot_va: u64 = lay.datagot_va + d_ord::u64 * GOT_ENTRY_SIZE::u64;
+                bin.write_u64_le(buf, rd_off, slot_va);
+                val rd_info: u64 = (d_sym::u64 << 32) | glob_dat_for(arch_id)::u64;
+                bin.write_u64_le(buf, rd_off + 8, rd_info);
+                bin.write_u64_le(buf, rd_off + 16, 0);
+                rd_off = rd_off + RELA_SIZE;
+                d_ord = d_ord + 1;
+                d_sym = d_sym + 1;
+            }
+            i = i + 1;
+        }
+    }
+
     # .dynamic: the table the loader walks. DT_NEEDED per dependency, then the
-    # table pointers, then the PLT tags (when there are imports), then DT_NULL.
+    # table pointers, then the PLT tags (when there are imports), then the .rela.dyn
+    # tags (when there are data imports), then DT_NULL.
     var dpos: usize = lay.dynamic_off;
     i = 0;
     for (i < dyn.lib_count) {
@@ -3189,6 +3322,13 @@ fun write_dyn_structures(itn: *intern.Interner, buf: *u8, lay: *DynLayout, dyn: 
         dpos = write_dyn_entry(buf, dpos, DT_PLTRELSZ, lay.relaplt_size::u64);
         dpos = write_dyn_entry(buf, dpos, DT_PLTREL,   DT_RELA_TAG);
         dpos = write_dyn_entry(buf, dpos, DT_JMPREL,   lay.relaplt_va);
+    }
+    # the .rela.dyn GLOB_DAT table for data imports (#2026); processed eagerly at
+    # load (data relocations are never lazy).
+    if (ndata_h > 0) {
+        dpos = write_dyn_entry(buf, dpos, DT_RELA,    lay.reladyn_va);
+        dpos = write_dyn_entry(buf, dpos, DT_RELASZ,  lay.reladyn_size::u64);
+        dpos = write_dyn_entry(buf, dpos, DT_RELAENT, RELA_SIZE::u64);
     }
     # the eager arches have no lazy-resolution trampoline, so the loader must bind
     # every JUMP_SLOT at load: DT_FLAGS(DF_BIND_NOW) for modern loaders, plus the
@@ -3448,6 +3588,58 @@ fun patch_plt_fixups(buf: *u8, lay: *DynLayout, dyn: *of.DynamicInfo,
         val file_off: usize = seg_offsets[fx.seg_index] + fx.seg_offset::usize;
         val pr: R.Result[bool, str] = patch_call_site(buf, file_off, arch_id, stub_va, fx.addend, fx.patch_vaddr);
         if (R.is_err[bool, str](pr)) { ret R.err[bool, str](R.unwrap_err[bool, str](pr)); }
+        i = i + 1;
+    }
+    ret R.ok[bool, str](true);
+}
+
+# resolve each GOT-indirect data-import access site to its GOT slot (#2026)
+#
+# An `ext val`/`ext var` read lowered to `adrp :got:` + `ldr :got_lo12:` with a
+# distinct relocation per instruction, deferred by the linker as a `GotFixup`
+# because the slot's address is part of this writer's layout. Each fixup's
+# instruction word is patched to reach the data GOT slot the loader binds through
+# GLOB_DAT: the page-high half on the `adrp`, the scaled-lo12 half on the `ldr`.
+# Only aarch64 emits these paired kinds today; an unexpected kind fails loudly
+# rather than mispatch. Mirrors `patch_plt_fixups`.
+# ---
+# buf:         the output buffer
+# lay:         the resolved dynamic-structure layout (.got data-slot base)
+# dyn:         the dynamic-link plan carrying the GOT fixups
+# seg_offsets: per-segment file offset of the copied segment bytes
+# segs:        the linker's loadable segments (for the bounds check)
+# seg_count:   number of segments
+# arch_id:     the target ISA id
+# ret:         ok(true) once patched, or an error string
+fun patch_got_fixups(buf: *u8, lay: *DynLayout, dyn: *of.DynamicInfo,
+                     seg_offsets: *usize, segs: *of.LoadSegment, seg_count: u32,
+                     arch_id: u32) R.Result[bool, str] {
+    var i: u32 = 0;
+    for (i < dyn.got_fixup_count) {
+        val fx: *of.GotFixup = ?dyn.got_fixups[i];
+        if (fx.seg_index >= seg_count) {
+            ret R.err[bool, str]("elf: data-import GOT fixup references an out-of-range segment");
+        }
+        # the data-import ordinal selects the GOT slot the loader binds via GLOB_DAT.
+        val ord: u32 = data_import_ordinal(dyn, fx.import_index);
+        val slot_va: u64 = lay.datagot_va + ord::u64 * GOT_ENTRY_SIZE::u64;
+
+        # each fixup patches a single 4-byte instruction word within the segment.
+        val seg_filesz: usize = segs[fx.seg_index].filesz;
+        if (fx.seg_offset::usize + 4 > seg_filesz) {
+            ret R.err[bool, str]("elf: data-import GOT fixup offset out of range");
+        }
+        val file_off: usize = seg_offsets[fx.seg_index] + fx.seg_offset::usize;
+        # the emitted instruction carries the opcode + registers with a zero
+        # immediate (the reloc addend is 0); packing OR-s the slot displacement in.
+        val cur: u32 = bin.read_u32_le(buf, file_off);
+        if (fx.kind == of.RK_GOT_PAGE21) {
+            bin.write_u32_le(buf, file_off, arm64_adrp_word(cur, fx.patch_vaddr, slot_va));
+        } or (fx.kind == of.RK_GOT_LO12) {
+            bin.write_u32_le(buf, file_off, arm64_ldr64_lo12_word(cur, slot_va));
+        } or {
+            ret R.err[bool, str]("elf: unsupported data-import GOT relocation kind");
+        }
         i = i + 1;
     }
     ret R.ok[bool, str](true);

--- a/src/lang/target/of/elf.mach
+++ b/src/lang/target/of/elf.mach
@@ -2242,6 +2242,16 @@ fun emit_shared(alloc: *A.Allocator, itn: *intern.Interner, tgt_isa: *isa.IsaVTa
     if (path == nil)    { ret R.err[bool, str]("elf: nil shared path"); }
     if (itn == nil)     { ret R.err[bool, str]("elf: no interner for shared object"); }
 
+    # imported data GOT slots are patched only by the dynamic-executable writer
+    # (`patch_got_fixups`); this shared writer has no GOT-slot construction, so a
+    # collected GOT fixup here would ship an unpatched `adrp`/`ldr`. the shared
+    # link never activates the dynamic-import plan today (`dynamic` is executable-
+    # only), so this cannot arise, but wiring `.so`-imports-`.so` later would make
+    # it reachable - fail loudly rather than silently mispatch (#2026 is exec-only).
+    if (dyn.got_fixup_count > 0) {
+        ret R.err[bool, str]("elf: data imports in a shared object are not yet supported (#2026 is exec-only)");
+    }
+
     val nrel: u32 = dyn.base_reloc_count;
     val nexp: u32 = export_count;
 


### PR DESCRIPTION
## #2026 — imported-data access on dynamic targets (GOT consumer path)

Wires the imported-data GOT consumer path deferred from #2022/#2023, per the owner ruling (2026-07-11). Resolves the `is_extern` fork with **Design B** (explicit compile-time import signal), the recommendation from the [brief on #2026](https://github.com/briar-systems/mach/issues/2026#issuecomment-4947797062).

`Closes #2026`

### The fork, resolved

At per-module codegen every cross-module data reference is `is_extern`/`SHN_UNDEF` and indistinguishable from a genuine `.so` import, and mach's linker has no relaxation, so the instruction shape (`adrp`+`add` direct vs `adrp`+`ldr :got:` GOT-indirect) must be committed at codegen. The signal that disambiguates: an **explicit `ext` declaration for data** (`ext val`/`ext var`), the strict mirror of `ext fun`. Only `is_import` data lowers GOT-indirect; every same-artifact reference keeps the PIC-clean `adrp`+`add`.

### What it does

- **IR / ME:** `ir.Global.is_import` (a strict subset of `is_extern`); `ext val`/`ext var` lowers to a storage-less import global; `ensure_extern_global` takes an import flag; a cross-module reference derives it from the origin decl's `DECL_FLAG_EXT` (mirroring `names_function`).
- **Frontend:** `ext val` is exempt from the initializer requirement (the exact analogue of the body-less `ext fun`); sema rejects an initializer on `ext` data; the driver registers `ext`-data bare names and `#[library]` pins, reusing the `ext fun` scans.
- **isel:** an `is_import` global sets `MirOperand.sym_got` → aarch64 `adrp :got:` + `ldr :got_lo12:`.
- **Linker:** a GOT-kind reloc against a data import is deferred as a `GotFixup` (not rejected); init/free plumbing.
- **ELF dyn-exec writer:** data-import `.dynsym` (STT_OBJECT) / `.dynstr` / `.hash` entries, a `.rela.dyn` `R_AARCH64_GLOB_DAT` table (DT_RELA/RELASZ/RELAENT), a data GOT region in the RW segment, and `patch_got_fixups` resolving each access to its slot. **Function-only dynamic images stay byte-identical** (ndata==0 leaves every structure unchanged).

### Before / after (aarch64)

- **Before** — a same-artifact `is_extern` data ref: `adrp x0, sym` + `add x0, x0, :lo12:sym` (direct, PIC-clean; unchanged).
- **After** — an `is_import` `ext val` ref: `adrp x0, :got:sym` + `ldr x0, [x0, :got_lo12:sym]` (the `add`→`ldr` GOT dereference), object-level relocs `R_AARCH64_ADR_GOT_PAGE` + `R_AARCH64_LD64_GOT_LO12_NC`.

### Verification (from-source compiler, this branch)

- **End-to-end aarch64 GLOB_DAT (structural).** `libcounter.so` exports a data global `g_counter` (type D); a consumer reads it via `ext var g_counter` and links the `.so`. The consumer image: `ET_EXEC`/AArch64, `DT_NEEDED libcounter.so`, `BIND_NOW`, one `R_AARCH64_GLOB_DAT` binding GOT slot `0x450018` to `g_counter`. `RELASZ`=24 = exactly one dynamic reloc → **PIC-clean, no ABS64-in-text**. The consumer's `read_counter` disassembles to `adrp x0, 0x450000` + `ldr x0, [x0, #0x18]`, resolving to exactly `0x450018`.
- **Full `mach test`:** 644 passed, 0 failed — the dev baseline (643) **+1** (the added `parse_bind_decl:ext_data_import` block; exact accounting).
- **Self-host fixpoint:** gen2 == gen1, byte-identical (release).
- **x86_64 output byte-identical:** the baseline (dev) and this-branch compiler produce byte-identical output for a fixed non-`ext` program (x86_64 has no `sym_got` emit path).
- **`-g` additivity:** the compiler's release load image is byte-identical with/without `-g` (0 load-image body diffs; only the ELF header SHT-pointer fields differ, plus the appended debug SHT tail). Release image is program-headers-only.
- **`llvm-dwarfdump --verify`** on the `-g` build: **No errors.**
- **int suite (linux leg, native):** all cases pass. An existing aarch64 exec fixture runs correctly under qemu-aarch64 (rc 0).

### Seed-parseability (rider 1)

`ext var` parses under the 3.4.4 seed **unchanged** (`ext` was already a general decl flag). `ext val` (no initializer) needs this PR's parser exemption, so it is **not** seed-parseable — future in-tree `ext val` usage would need a re-seed first. The compiler itself uses no `ext` data, so no seed dance is required for this change, and the feature is proven with string-based parser tests + out-of-tree structural fixtures (not colocated `ext val` test blocks).

### Tracked residue

- **Executed `dlopen` resolution of a `.so`'s imported data** (the runtime `GLOB_DAT` bind) needs a native aarch64 loader/sysroot leg — **#1885**, absent in this environment. The slot/relocation/disasm are proven structurally here, matching the #2022/#2023 verification bar; runtime execution is the tracked follow-up.
- **Shared-object writer (backstop).** `patch_got_fixups` is consumed only by the dynamic-executable writer; `emit_shared` has no GOT-slot construction. This is **not reachable today** — a `LINK_SHARED` link never activates the dynamic-import plan (`dynamic` is executable-only), so `dyn.active` stays false, no GOT fixup is collected, and an `ext`-data reference in a `.so` errors loudly at patch time (undefined symbol, or the arm64 packer's unsupported-relocation error for a resolved GOT kind — verified). A loud hard error is nonetheless added in `emit_shared` (`got_fixup_count > 0` → "data imports in a shared object are not yet supported (#2026 is exec-only)") as defense-in-depth for when `.so`-imports-`.so` is wired later. The normal `.so` path stays byte-identical (guard inert at count 0).
- **x86_64 data imports** remain unwired (x64 has no `sym_got` emit path); the RFC records this shared latent gap. aarch64 is the delivered consumer.
- A **data-only** dynamic image (no function imports) carries a zero-size R+X PT_LOAD for the empty `.plt` — valid ELF (kernel/ld.so skip a zero `p_memsz` segment), a pre-existing degenerate-case shape now reachable via data-only imports.
