### PR TITLE
feat(abi): win64 marshals ext-boundary vector args by reference (#2058)

### DIFF
--- a/doc/language/ext-fun.md
+++ b/doc/language/ext-fun.md
@@ -77,6 +77,24 @@ not bound to a single dependency, so `library` has no effect on the emitted
 binary — the value is still validated against the link's dependencies, but every
 dependency is searched at load time regardless.
 
+## Vector arguments and the C ABI
+
+A 128-bit vector (`f32x4`, `i32x4`, …) crossing an `ext` boundary follows the
+target's **C** vector convention, not Mach's internal one, so the call is
+bit-compatible with a C `__m128` parameter:
+
+- **x86_64-windows (Microsoft x64):** the caller passes each vector argument **by
+  reference** — it stores the vector to a 16-byte-aligned temporary and passes that
+  temporary's address in the parameter's integer register (RCX/RDX/R8/R9) or, once
+  those are exhausted, on the stack. A variadic vector argument is passed the same
+  way. Vector **returns** ride XMM0, which both conventions already agree on.
+- **Every other target** (System V, AAPCS64, RISC-V lp64d): the C convention already
+  matches Mach's internal one, so nothing special happens at the boundary.
+
+Only a *direct* call to a declared `ext fun` marshals — an ordinary Mach→Mach call
+always keeps the internal convention (a vector in a vector register). A call through
+a function *pointer* does not yet carry the `ext` fact, so it is not covered.
+
 ## Linking external objects
 
 An `ext fun` is only a forward reference — its definition must be supplied at

--- a/src/lang/be/codegen/mir/abi.mach
+++ b/src/lang/be/codegen/mir/abi.mach
@@ -494,13 +494,28 @@ fun round_up_i64(value: i64, align: u64) i64 {
 # <=8-aligned, so this is always eight and the round-up is identity; AAPCS64 honors
 # a 16-byte-aligned by-value argument.
 # ---
-# class: the slot's classification (CLASS_STACK or CLASS_STACK_BYREF)
+# class: the slot's classification (CLASS_STACK, CLASS_STACK_BYREF, or CLASS_VEC_STACK_BYREF)
 # align: the value's natural alignment in bytes
 # ret:   the slot's stack alignment in bytes
 fun stack_arg_align(class: abi.ParamClass, align: u64) u64 {
-    if (class == abi.CLASS_STACK_BYREF) { ret 8; }
-    if (align < 8)                      { ret 8; }
+    # both by-reference stack spills carry only an 8-byte pointer, so they round to 8
+    # regardless of the referent's alignment (CLASS_VEC_STACK_BYREF's referent is the
+    # spilled vector temp, aligned at its own frame slot, not this outgoing pointer slot).
+    if (class == abi.CLASS_STACK_BYREF)     { ret 8; }
+    if (class == abi.CLASS_VEC_STACK_BYREF) { ret 8; }
+    if (align < 8)                          { ret 8; }
     ret align;
+}
+
+# whether a placement occupies an outgoing stack slot the signature walk assigns and
+# advances a stack offset for (a by-value stack argument or either by-reference stack
+# spill). the register and register-plus-stack-split placements are handled off the
+# register-cursor path instead
+# ---
+# class: the slot's classification
+# ret:   true when the slot is a pure stack placement
+fun is_stack_slot_class(class: abi.ParamClass) bool {
+    ret class == abi.CLASS_STACK || class == abi.CLASS_STACK_BYREF || class == abi.CLASS_VEC_STACK_BYREF;
 }
 
 # classify a whole function ABI in one left-to-right walk into a `SigLayout`
@@ -533,10 +548,15 @@ fun stack_arg_align(class: abi.ParamClass, align: u64) u64 {
 # ctx:      the active lowering context (supplies the IR type oracle and target)
 # sig:      the function signature (an IRT_FN id; non-IRT_FN yields zero fixed params)
 # ret_type: the declared return type to classify the return / sret reservation from
+# is_ext:   true when classifying a call to a declared `ext` (foreign C) function, so
+#           each argument follows the foreign convention at the boundary (win64
+#           marshals a 128-bit vector by reference, #2058); false for an internal call
+#           and for a callee's own parameter / return classification (a compiled mach
+#           function is never itself `ext`)
 # out:      receives the assembled SigLayout (`params` is owned - free it with
 #           `sig_layout_free`)
 # ret:      ok(true) on success, or a loud error from the ABI vtable surface
-pub fun classify_signature(ctx: *context.LowerCtx, sig: type.IrTypeId, ret_type: type.IrTypeId,
+pub fun classify_signature(ctx: *context.LowerCtx, sig: type.IrTypeId, ret_type: type.IrTypeId, is_ext: bool,
                            out: *abi.SigLayout) R.Result[bool, str] {
     val rok: R.Result[bool, str] = require_abi(ctx.tgt);
     if (R.is_err[bool, str](rok)) { ret rok; }
@@ -620,7 +640,7 @@ pub fun classify_signature(ctx: *context.LowerCtx, sig: type.IrTypeId, ret_type:
         var pagg: abi.AggLayout = abi.agg_none();
         if (wants_agg) { pagg = agg_layout(ctx, pty, pag); }
         val pvec: bool = context.value_is_vector(ctx, pty);
-        var slot: abi.ParamSlot = classify_arg(i::i32, psz, pal, pfl, peb, pag, pvec, gp_used, fp_used, phm, phe, pagg);
+        var slot: abi.ParamSlot = classify_arg(i::i32, psz, pal, pfl, peb, pag, pvec, is_ext, gp_used, fp_used, phm, phe, pagg);
 
         # record the real outgoing stack offset on the slot (the ABI classifier
         # returns a sizing-only slot with offset 0); the param / call lowering
@@ -631,7 +651,7 @@ pub fun classify_signature(ctx: *context.LowerCtx, sig: type.IrTypeId, ret_type:
         # GP/SSE aggregate consumes one of each). a by-value stack slot is first
         # rounded up to the value's alignment (identity on x86, where every stack
         # argument is <=8-aligned; honors a 16-aligned AAPCS64 by-value argument).
-        if (slot.class == abi.CLASS_STACK || slot.class == abi.CLASS_STACK_BYREF) {
+        if (is_stack_slot_class(slot.class)) {
             stack_off   = round_up_i64(stack_off, stack_arg_align(slot.class, pal));
             slot.offset = stack_off;
             stack_off   = stack_off + context.stack_slot_bytes(slot.size);
@@ -698,6 +718,27 @@ fun call_ret_type(ctx: *context.LowerCtx, sig: type.IrTypeId, fallback: type.IrT
     ret fallback;
 }
 
+# report whether an OP_CALL targets a declared `ext` (foreign C) function
+#
+# The classification signal for boundary marshalling (#2058) is the callee's is_import
+# fact -- true only for a declared `ext fun`, the strict subset of extern that excludes
+# a same-artifact cross-module reference (a generic instance drained in another object).
+# Only a DIRECT call (operand 0 a VAL_FN naming a module function) can be ext; an
+# indirect call through a function pointer carries no callee identity in today's IR, so
+# it is never marshalled -- the recorded #2058 boundary (function-pointer types would
+# carry the rule).
+# ---
+# ctx:  the active lowering context (supplies the source IR module)
+# inst: the OP_CALL instruction (operand 0 is the callee)
+# ret:  true when the callee is a declared `ext` function
+fun call_targets_ext(ctx: *context.LowerCtx, inst: *instruction.Instruction) bool {
+    if (inst.operand_count == 0)                   { ret false; }
+    val callee: value.Value = inst.operands[0];
+    if (callee.kind != value.VAL_FN)               { ret false; }
+    if (callee.data.fn_ix >= ctx.m.function_len)   { ret false; }
+    ret ctx.m.functions[callee.data.fn_ix].is_import;
+}
+
 # expand an OP_CALL into argument pre-coloring plus the call and result pseudos
 #
 # Classifies the callee's return value and each argument through the ABI vtable,
@@ -752,8 +793,11 @@ pub fun lower_call(ctx: *context.LowerCtx, mb: *mir.MirBlock, inst: *instruction
     # direct call the two agree; an indirect call through an untyped pointer has no
     # IRT_FN and falls back to `inst.ty`.
     val ret_type: type.IrTypeId = call_ret_type(ctx, sig, inst.ty);
+    # a call to a declared `ext` function marshals its arguments to the foreign
+    # convention at the boundary (#2058); an internal call keeps mach's convention.
+    val is_ext: bool = call_targets_ext(ctx, inst);
     var layout: abi.SigLayout;
-    val cls: R.Result[bool, str] = classify_signature(ctx, sig, ret_type, ?layout);
+    val cls: R.Result[bool, str] = classify_signature(ctx, sig, ret_type, is_ext, ?layout);
     if (R.is_err[bool, str](cls)) { ret cls; }
 
     val rslot: abi.ParamSlot = layout.ret_slot;
@@ -830,12 +874,14 @@ pub fun lower_call(ctx: *context.LowerCtx, mb: *mir.MirBlock, inst: *instruction
             # (agg_none): the va_arg read path walks the GP register-save / overflow
             # areas, so the caller and callee stay consistent. SSE-eightbyte, HFA
             # V-register, and lp64d fa-register passing are for fixed parameters and
-            # returns (the C-FFI boundary), not the varargs tail.
-            slot = classify_arg(pidx::i32, asz, aal, afl, 0, aag, avec, gp_used, fp_used, 0, 0, abi.agg_none());
+            # returns (the C-FFI boundary), not the varargs tail. is_ext still applies:
+            # MS passes an __m128 vararg by reference too, so a tail vector at an ext
+            # boundary marshals exactly like a fixed one (#2058).
+            slot = classify_arg(pidx::i32, asz, aal, afl, 0, aag, avec, is_ext, gp_used, fp_used, 0, 0, abi.agg_none());
             # round a stack-passed tail argument up to its slot alignment before
             # placing it (identity on x86; honors a 16-aligned AAPCS64 by-value arg).
             # a register-plus-stack split's tail stack chunk is eight-byte-granular.
-            if (slot.class == abi.CLASS_STACK || slot.class == abi.CLASS_STACK_BYREF) {
+            if (is_stack_slot_class(slot.class)) {
                 stack_off = round_up_i64(stack_off, stack_arg_align(slot.class, aal));
             } or (slot_has_stack_piece(?slot)) {
                 stack_off = round_up_i64(stack_off, 8);
@@ -883,7 +929,7 @@ pub fun lower_call(ctx: *context.LowerCtx, mb: *mir.MirBlock, inst: *instruction
         # cursors were already consumed by `classify_signature`. a register slot
         # advances each assigned register's bank; a stack slot advances the offset.
         if (pidx >= layout.param_count) {
-            if (slot.class == abi.CLASS_STACK || slot.class == abi.CLASS_STACK_BYREF) {
+            if (is_stack_slot_class(slot.class)) {
                 stack_off = stack_off + context.stack_slot_bytes(slot.size);
             } or {
                 advance_arg_cursors(?slot, ?gp_used, ?fp_used);
@@ -1088,6 +1134,22 @@ fun materialize_pieces(ctx: *context.LowerCtx, mb: *mir.MirBlock, slot: abi.Para
 # ret:       ok(true) on success, or a loud error
 fun emit_arg_slot(ctx: *context.LowerCtx, mb: *mir.MirBlock, slot: abi.ParamSlot, argop: mir.MirOperand,
                   stack_off: i64, is_aggr: bool, size: u64) R.Result[bool, str] {
+    # a register-resident value marshalled by reference (a 128-bit vector at a win64 `ext`
+    # boundary, #2058): unlike an aggregate or a scalarized rv64 vector -- already
+    # memory-resident, its argop a storage pointer -- the value is in a register, so the
+    # address does not yet exist. store it to a 16-byte-aligned temp and pass the temp's
+    # ADDRESS: into the slot's GP register (CLASS_VEC_BYREF) or, once the register slots
+    # are exhausted, spilled as an 8-byte pointer (CLASS_VEC_STACK_BYREF).
+    if (slot.class == abi.CLASS_VEC_BYREF || slot.class == abi.CLASS_VEC_STACK_BYREF) {
+        var addr: u32 = mir.MIR_VREG_NIL;
+        val sr: R.Result[bool, str] = spill_vector_to_temp(ctx, mb, argop, size, ?addr);
+        if (R.is_err[bool, str](sr)) { ret sr; }
+        if (slot.class == abi.CLASS_VEC_STACK_BYREF) {
+            val sp: u32 = ctx.tgt.arch.stack_ptr_reg::u32;
+            ret context.emit_store_to(ctx, mb, mir.op_mem_preg(sp, stack_off), mir.op_vreg(addr));
+        }
+        ret context.emit_mov(ctx, mb, mir.op_preg(slot.reg::u32), mir.op_vreg(addr));
+    }
     if (slot.class == abi.CLASS_STACK_BYREF) {
         # win64 by-reference overflow: store the hidden aggregate pointer into the
         # outgoing stack slot, not a by-value copy of the aggregate bytes.
@@ -1149,6 +1211,35 @@ fun emit_arg_slot(ctx: *context.LowerCtx, mb: *mir.MirBlock, slot: abi.ParamSlot
     # backend re-extends it to the register width by its own convention (RV64 lp64
     # sign-extends a 32-bit register).
     ret context.emit_mov_w(ctx, mb, mir.op_preg(slot.reg::u32), argop, scalar_reg_move_width(ctx, size));
+}
+
+# store a register-resident vector to a fresh 16-byte-aligned frame temporary and
+# return the temporary's address in a vreg
+#
+# The win64 ext-boundary marshal (#2058) needs a 128-bit vector's ADDRESS, but the
+# vector is a value in a vector register. This allocates an aligned frame slot (its
+# alignment the vector's own size, so a 16-byte __m128 lands on a 16-byte boundary),
+# stores the whole vector into it at full width (a MOVAPS-class store, the same form
+# `materialize_pieces` uses for an FP chunk), and LEAs the slot address into `out_addr`.
+# ---
+# ctx:      the active lowering context
+# mb:       the MIR block the store / address materialization are appended to
+# val_op:   the vector value operand (a vector-register vreg)
+# size:     the vector's byte size (its temp alignment and store width)
+# out_addr: receives the vreg holding the temporary's address
+# ret:      ok(true) on success, or a loud error
+fun spill_vector_to_temp(ctx: *context.LowerCtx, mb: *mir.MirBlock, val_op: mir.MirOperand, size: u64, out_addr: *u32) R.Result[bool, str] {
+    val res_key: R.Result[u32, str] = context.new_vreg(ctx, mir.REG_CLASS_GP);
+    if (R.is_err[u32, str](res_key)) { ret R.err[bool, str](R.unwrap_err[u32, str](res_key)); }
+    val sk: u32 = R.unwrap_ok[u32, str](res_key);
+
+    val sr: R.Result[bool, str] = context.add_spill_slot_aligned(ctx, sk, size, size::u32);
+    if (R.is_err[bool, str](sr)) { ret sr; }
+
+    val st: R.Result[bool, str] = context.emit_store_to_w(ctx, mb, mir.op_mem_slot(sk, 0), val_op, size::u8);
+    if (R.is_err[bool, str](st)) { ret st; }
+
+    ret context.emit_lea_slot(ctx, mb, mir.op_mem_slot(sk, 0), out_addr);
 }
 
 # the SSE move width (4 for f32, 8 for f64) for a CLASS_FP scalar of `size` bytes
@@ -1260,7 +1351,9 @@ pub fun lower_params(ctx: *context.LowerCtx, mb: *mir.MirBlock) R.Result[bool, s
     # carry their real `[rbp + 16 + offset]` stack offsets.
     val ret_type: type.IrTypeId = context.fn_return_type(ctx);
     var layout: abi.SigLayout;
-    val cls: R.Result[bool, str] = classify_signature(ctx, ctx.fn.sig, ret_type, ?layout);
+    # a compiled mach function is never itself `ext`, so its own parameters always use
+    # mach's internal convention (is_ext false); only calls TO an ext function marshal.
+    val cls: R.Result[bool, str] = classify_signature(ctx, ctx.fn.sig, ret_type, false, ?layout);
     if (R.is_err[bool, str](cls)) { ret cls; }
 
     # an sret return: the caller passes the hidden result-storage pointer in the
@@ -1476,7 +1569,9 @@ pub fun lower_ret(ctx: *context.LowerCtx, mb: *mir.MirBlock, inst: *instruction.
     val rsz:  u64  = type.byte_size(ctx.types, rt, ctx.tgt)::u64;
     val rag:  bool = context.value_is_aggregate(ctx, rt);
     var layout: abi.SigLayout;
-    val cls: R.Result[bool, str] = classify_signature(ctx, ctx.fn.sig, rt, ?layout);
+    # the return classifies from the function's own signature (is_ext false); a vector
+    # return conforms to MS under both conventions (XMM0), so it is never marshalled.
+    val cls: R.Result[bool, str] = classify_signature(ctx, ctx.fn.sig, rt, false, ?layout);
     if (R.is_err[bool, str](cls)) { ret cls; }
     val slot: abi.ParamSlot = layout.ret_slot;
     sig_layout_free(ctx, ?layout);

--- a/src/lang/be/codegen/mir/context.mach
+++ b/src/lang/be/codegen/mir/context.mach
@@ -1159,7 +1159,7 @@ fun gp_class_index(tgt: *target.Target) u32 {
 # size:     the aggregate size in bytes
 # align:    the slot alignment in bytes (0 falls back to 1)
 # ret:      true on success, or an allocation error
-fun add_spill_slot_aligned(ctx: *LowerCtx, value_id: u32, size: u64, align: u32) R.Result[bool, str] {
+pub fun add_spill_slot_aligned(ctx: *LowerCtx, value_id: u32, size: u64, align: u32) R.Result[bool, str] {
     var al: u32 = align;
     if (al == 0) { al = 1; }
     var sz: u32 = ((size + 7) & ~7::u64)::u32;

--- a/src/lang/me/ir.mach
+++ b/src/lang/me/ir.mach
@@ -217,6 +217,13 @@ pub rec Block {
 # instr_len:   number of instructions in the pool
 # instr_cap:   allocated capacity for the instruction pool
 # flags:       bitwise-or of FN_FLAG_* bits
+# is_import:   true for a genuine foreign import (a declared `ext fun`), a strict
+#              subset of FN_FLAG_EXTERN: a same-artifact cross-module reference (a
+#              generic instance drained in another object, a forward reference) is
+#              FN_FLAG_EXTERN but NOT is_import. only an is_import callee marshals its
+#              arguments to the foreign C convention at the boundary (win64 passes a
+#              128-bit vector by reference, #2058); every same-artifact call keeps
+#              mach's internal convention. the exact function twin of Global.is_import
 # label:       printable source label, carried for an FN_FLAG_TEST function so the
 #              test runner reports it directly instead of inverse-parsing the
 #              mangled linkage name; STR_NIL for every non-test function
@@ -262,6 +269,7 @@ pub rec Function {
     instr_cap:   u32;
 
     flags:       u32;
+    is_import:   bool;
     label:       intern.StrId;
     line:        u32;
     section:     intern.StrId;
@@ -600,6 +608,7 @@ pub fun function_new(alloc: *A.Allocator, name: intern.StrId, sig: type.IrTypeId
     f.instr_len   = 0;
     f.instr_cap   = 0;
     f.flags       = flags;
+    f.is_import   = false;
     f.label       = intern.STR_NIL;
     f.line        = 0;
     f.section     = intern.STR_NIL;

--- a/src/lang/me/lower/context.mach
+++ b/src/lang/me/lower/context.mach
@@ -1403,15 +1403,27 @@ pub fun symbol_of(lc: *LowerContext, sid: resolve.SymbolId) O.Option[*resolve.Sy
 # reference resolves through this so the back end emits a name-based call
 # relocation against the imported symbol (the linker binds it to the defining
 # module's object)
+#
+# `import_flag` marks a genuine foreign C import (a reference to a declared
+# `ext fun`), whose calls marshal their arguments to the foreign convention at the
+# boundary (#2058); a plain same-artifact cross-module reference (a generic instance
+# drained elsewhere, a forward reference) passes it false and keeps mach's internal
+# convention. a repeated reference to a name already declared an import stays an
+# import, mirroring `ensure_extern_global`.
 # ---
-# lc:   the context
-# name: interned function symbol name
-# sig:  the function's IR type
-# ret:  the function index, or an allocation error
-pub fun ensure_extern_function(lc: *LowerContext, name: intern.StrId, sig: ir_type.IrTypeId) R.Result[u32, str] {
+# lc:          the context
+# name:        interned function symbol name
+# sig:         the function's IR type
+# import_flag: true for a genuine foreign C import (a declared `ext fun`)
+# ret:         the function index, or an allocation error
+pub fun ensure_extern_function(lc: *LowerContext, name: intern.StrId, sig: ir_type.IrTypeId, import_flag: bool) R.Result[u32, str] {
     val m: *ir.Module = lc.m;
     val existing: O.Option[u32] = ir.function_lookup(m, name);
-    if (O.is_some[u32](existing)) { ret R.ok[u32, str](O.unwrap[u32](existing)); }
+    if (O.is_some[u32](existing)) {
+        val fi: u32 = O.unwrap[u32](existing);
+        if (import_flag) { m.functions[fi].is_import = true; }
+        ret R.ok[u32, str](fi);
+    }
 
     if (m.function_len == m.function_cap) {
         val new_cap: u32 = grow_cap(m.function_cap);
@@ -1423,6 +1435,7 @@ pub fun ensure_extern_function(lc: *LowerContext, name: intern.StrId, sig: ir_ty
 
     val idx: u32 = m.function_len;
     m.functions[idx] = ir.function_new(m.alloc, name, sig, ir.FN_FLAG_EXTERN);
+    m.functions[idx].is_import = import_flag;
     m.function_len   = m.function_len + 1;
     val res_reg: R.Result[bool, str] = ir.function_register(m, name, idx);
     if (R.is_err[bool, str](res_reg)) { ret R.err[u32, str](R.unwrap_err[bool, str](res_reg)); }

--- a/src/lang/me/lower/decl.mach
+++ b/src/lang/me/lower/decl.mach
@@ -133,6 +133,13 @@ pub fun lower_fun(ctx: *context.LowerContext, did: id.DeclId, d: *decl.Decl, is_
 
     ctx.m.functions[fn_index].section = decl_section_of(ctx, d);
 
+    # a declared `ext fun` is a genuine foreign C import (a strict subset of the
+    # FN_FLAG_EXTERN this function also carries): its calls marshal their arguments to
+    # the foreign convention at the boundary (#2058). a bodiless non-`ext` function is
+    # extern but not an import. mirrors the cross-module reference's is_import in
+    # `ensure_extern_function`.
+    ctx.m.functions[fn_index].is_import = (d.flags & decl.DECL_FLAG_EXT) != 0;
+
     # retain the source name and semantic return type for the DWARF producer: the
     # bare spelling gives a readable DW_AT_name, and the semantic return keeps the
     # signedness the IR type erases so the return base type is accurate.

--- a/src/lang/me/lower/expr.mach
+++ b/src/lang/me/lower/expr.mach
@@ -561,7 +561,7 @@ fun symbol_reference(ctx: *context.LowerContext, eid: id.ExprId, sid: resolve.Sy
     # reference; it falls through to the global-load path below, so a call
     # through it loads the stored pointer and dispatches indirectly.
     if (names_function(ctx, sym)) {
-        ret fn_reference(ctx, link, vty);
+        ret fn_reference(ctx, link, vty, references_import_function(ctx, sym));
     }
 
     # global val / var: a load from the global's storage pointer, except for
@@ -627,6 +627,31 @@ fun references_import_data(ctx: *context.LowerContext, sym: *resolve.Symbol) boo
     if (O.is_none[*decl.Decl](opt_d)) { ret false; }
     val d: *decl.Decl = O.unwrap[*decl.Decl](opt_d);
     if (d.kind != decl.DECL_KIND_VAL && d.kind != decl.DECL_KIND_VAR) { ret false; }
+    ret (d.flags & decl.DECL_FLAG_EXT) != 0;
+}
+
+# whether a symbol names a genuine foreign C function import (a declared `ext fun`)
+#
+# A call to such a function marshals its arguments to the foreign convention at the
+# boundary (win64 passes a 128-bit vector by reference, #2058), so the storage-less
+# extern declared here for it must carry is_import. The discriminator is the same one
+# `references_import_data` uses for data: an imported symbol (SYM_IMPORTED) whose
+# origin decl is an `ext`-flagged function. A same-module `ext fun` is already a local
+# FN_FLAG_EXTERN entry (found by `find_function` before this path runs), so only the
+# cross-module case reaches here; its is_import is set at its own decl lowering. A
+# non-function symbol, or a function without `ext`, is not an import.
+# ---
+# ctx: per-module lowering context
+# sym: the symbol to classify
+# ret: true when `sym` names a declared `ext fun`
+fun references_import_function(ctx: *context.LowerContext, sym: *resolve.Symbol) bool {
+    if (sym.kind != resolve.SYM_IMPORTED) { ret false; }
+    val origin_ast: *ast.Ast = session.module_ast(ctx.s, sym.origin);
+    if (origin_ast == nil) { ret false; }
+    val opt_d: O.Option[*decl.Decl] = ast.get_decl(origin_ast, sym.decl);
+    if (O.is_none[*decl.Decl](opt_d)) { ret false; }
+    val d: *decl.Decl = O.unwrap[*decl.Decl](opt_d);
+    if (d.kind != decl.DECL_KIND_FUN) { ret false; }
     ret (d.flags & decl.DECL_FLAG_EXT) != 0;
 }
 
@@ -1633,7 +1658,7 @@ fun lower_value_callee(ctx: *context.LowerContext, eid: id.ExprId, e: *expr.Expr
     # its ABI from the declared parameters, not per-operand stamps.
     val res_sig: R.Result[ir_type.IrTypeId, str] = context.instance_ref_sig(ctx, sym.decl, sym.origin, nil, 0);
     if (R.is_err[ir_type.IrTypeId, str](res_sig)) { ret R.err[value.Value, str](R.unwrap_err[ir_type.IrTypeId, str](res_sig)); }
-    ret fn_reference(ctx, link, R.unwrap_ok[ir_type.IrTypeId, str](res_sig));
+    ret fn_reference(ctx, link, R.unwrap_ok[ir_type.IrTypeId, str](res_sig), false);
 }
 
 # fold a comptime call argument to a CTValue
@@ -1770,7 +1795,7 @@ fun lower_generic_callee(ctx: *context.LowerContext, eid: id.ExprId, e: *expr.Ex
     val res_sig: R.Result[ir_type.IrTypeId, str] = context.instance_ref_sig(ctx, sym.decl, sym.origin, args, argc);
     A.deallocate[type.TypeId](ctx.s.alloc, args, argc::usize);
     if (R.is_err[ir_type.IrTypeId, str](res_sig)) { ret R.err[value.Value, str](R.unwrap_err[ir_type.IrTypeId, str](res_sig)); }
-    ret fn_reference(ctx, link, R.unwrap_ok[ir_type.IrTypeId, str](res_sig));
+    ret fn_reference(ctx, link, R.unwrap_ok[ir_type.IrTypeId, str](res_sig), false);
 }
 
 # resolve a pack-tailed call to its monomorphized instance (#1475)
@@ -1861,7 +1886,7 @@ fun lower_pack_callee(ctx: *context.LowerContext, eid: id.ExprId, e: *expr.Expr,
     val res_sig: R.Result[ir_type.IrTypeId, str] = context.pack_instance_ref_sig(ctx, sym.decl, sym.origin, types, elem_len);
     if (owns_types && types != nil)   { A.deallocate[type.TypeId](ctx.s.alloc, types, elem_len::usize); }
     if (R.is_err[ir_type.IrTypeId, str](res_sig)) { ret R.err[value.Value, str](R.unwrap_err[ir_type.IrTypeId, str](res_sig)); }
-    ret fn_reference(ctx, link, R.unwrap_ok[ir_type.IrTypeId, str](res_sig));
+    ret fn_reference(ctx, link, R.unwrap_ok[ir_type.IrTypeId, str](res_sig), false);
 }
 
 # lower a binary expression
@@ -2885,18 +2910,22 @@ fun emit_global_rvalue(ctx: *context.LowerContext, global_ix: u32, vty: ir_type.
 #
 # A module-local function resolves to its module index; otherwise a signature-only
 # extern declaration is created so the back end emits a name-based call relocation
-# the linker binds to the defining object.
+# the linker binds to the defining object. `is_import` marks a genuine foreign C
+# import (a cross-module `ext fun`), carried onto the extern so its calls marshal to
+# the foreign convention at the boundary (#2058); a mach instance reference passes
+# false.
 # ---
-# ctx:  per-module lowering context
-# link: the function's linkage name
-# vty:  the function-reference IR type
-# ret:  a VAL_FN Value, or an error
-fun fn_reference(ctx: *context.LowerContext, link: intern.StrId, vty: ir_type.IrTypeId) R.Result[value.Value, str] {
+# ctx:       per-module lowering context
+# link:      the function's linkage name
+# vty:       the function-reference IR type
+# is_import: true when the reference names a declared `ext fun`
+# ret:       a VAL_FN Value, or an error
+fun fn_reference(ctx: *context.LowerContext, link: intern.StrId, vty: ir_type.IrTypeId, is_import: bool) R.Result[value.Value, str] {
     val opt_fi: O.Option[u32] = find_function(ctx, link);
     if (O.is_some[u32](opt_fi)) {
         ret R.ok[value.Value, str](value.fn(O.unwrap[u32](opt_fi), vty));
     }
-    val res_xfn: R.Result[u32, str] = context.ensure_extern_function(ctx, link, vty);
+    val res_xfn: R.Result[u32, str] = context.ensure_extern_function(ctx, link, vty, is_import);
     if (R.is_err[u32, str](res_xfn)) { ret R.err[value.Value, str](R.unwrap_err[u32, str](res_xfn)); }
     ret R.ok[value.Value, str](value.fn(R.unwrap_ok[u32, str](res_xfn), vty));
 }

--- a/src/lang/target.mach
+++ b/src/lang/target.mach
@@ -532,10 +532,10 @@ test "mach.lang.target.select:linux_riscv64" {
     if (t.abi == nil)            { ret 1; }
     if (t.abi.id != abi.ABI_LP64) { ret 1; }
     val arg: abi.ArgPassingFn = t.abi.arg_passing::abi.ArgPassingFn;
-    val ai: abi.ParamSlot = arg(0, 8, 8, false, 0, false, false, 0, 0, 0, 0, abi.agg_none());
+    val ai: abi.ParamSlot = arg(0, 8, 8, false, 0, false, false, false, 0, 0, 0, 0, abi.agg_none());
     if (ai.class != abi.CLASS_GP) { ret 1; }
     if (ai.reg != 10)             { ret 1; }  # a0 = x10
-    val af: abi.ParamSlot = arg(0, 8, 8, true, 0, false, false, 0, 0, 0, 0, abi.agg_none());
+    val af: abi.ParamSlot = arg(0, 8, 8, true, 0, false, false, false, 0, 0, 0, 0, abi.agg_none());
     if (af.class != abi.CLASS_FP)                                  { ret 1; }
     if (af.reg != isa.regid_make(isa.REG_CLASS_ID_XMM, 10))        { ret 1; }  # fa0 = f10
     val rp: abi.RetPassingFn = t.abi.ret_passing::abi.RetPassingFn;
@@ -750,7 +750,7 @@ test "mach.lang.target.select:classify_vector_sse_class" {
 
     # a 16-byte vector argument: one XMM register, size 16 (is_vector true, not aggregate).
     val arg: abi.ArgPassingFn = t.abi.arg_passing::abi.ArgPassingFn;
-    val a: abi.ParamSlot = arg(0, 16, 16, false, 0, false, true, 0, 0, 0, 0, abi.agg_none());
+    val a: abi.ParamSlot = arg(0, 16, 16, false, 0, false, true, false, 0, 0, 0, 0, abi.agg_none());
     if (a.class != abi.CLASS_FP) { ret 1; }
     if (a.size != 16)            { ret 1; }
 

--- a/src/lang/target/abi.mach
+++ b/src/lang/target/abi.mach
@@ -66,6 +66,17 @@ pub val CLASS_BYREF:       ParamClass = 4;
 # stack slot holds the 8-byte pointer rather than the aggregate's bytes. distinct
 # from CLASS_STACK, whose slot holds the value itself
 pub val CLASS_STACK_BYREF: ParamClass = 5;
+# a REGISTER-resident value passed by reference: the caller must first spill it to a
+# fresh aligned temporary, then pass that temporary's address in a GP register. distinct
+# from CLASS_BYREF, whose value is already memory-resident (its operand IS a pointer):
+# here the operand is a value in a register, so the address does not yet exist. used for
+# a 128-bit vector marshalled at a win64 `ext` boundary (#2058), where the vector rides
+# a vector register rather than memory (unlike the scalarized rv64 vector, which is
+# already memory-resident and stays CLASS_BYREF)
+pub val CLASS_VEC_BYREF: ParamClass = 6;
+# the stack-overflow form of CLASS_VEC_BYREF: the register file was exhausted, so the
+# spilled temporary's 8-byte address is placed on the stack rather than in a GP register
+pub val CLASS_VEC_STACK_BYREF: ParamClass = 7;
 
 # how one location of a multi-location aggregate placement is filled
 #
@@ -200,6 +211,11 @@ pub def ClassifyFn: fun(u64, u64, bool, u8, bool, i32, i32, u8, u8) ParamSlot;
 #                children (#2014/#2015/#2016) each add only their own psABI
 #                vector-class branch without racing on this shared signature; no
 #                backend reads it yet
+# is_ext:        true when the call crosses a declared `ext` (foreign C) boundary, so
+#                the argument follows the foreign convention rather than mach's
+#                internal one. win64 marshals a 128-bit vector by reference at an ext
+#                boundary (#2058); every other convention agrees with mach internally
+#                and ignores it. false for an internal (mach->mach) call
 # gp_used:       GP registers already consumed
 # fp_used:       FP registers already consumed
 # hfa_members:   HFA member count (1-4), or 0 if the argument is not an HFA
@@ -209,7 +225,7 @@ pub def ClassifyFn: fun(u64, u64, bool, u8, bool, i32, i32, u8, u8) ParamSlot;
 #                is 0 for any value the descriptor does not apply to, which the AMD64
 #                and AAPCS64 conventions ignore
 # ret:           the placement decision
-pub def ArgPassingFn: fun(i32, u64, u64, bool, u8, bool, bool, i32, i32, u8, u8, AggLayout) ParamSlot;
+pub def ArgPassingFn: fun(i32, u64, u64, bool, u8, bool, bool, bool, i32, i32, u8, u8, AggLayout) ParamSlot;
 
 # assign the registers or sret slot for a return value. arch-specific by
 # selection; `fp_eightbytes` and the HFA descriptor carry the same meaning as in

--- a/src/lang/target/abi/aapcs64.mach
+++ b/src/lang/target/abi/aapcs64.mach
@@ -167,7 +167,7 @@ pub fun fp_param_reg(index: i32) i32 {
 pub fun classify(size: u64, align: u64, is_float: bool, fp_eightbytes: u8,
                  is_aggregate: bool, gp_used: i32, fp_used: i32,
                  hfa_members: u8, hfa_elem: u8) abi.ParamSlot {
-    ret classify_arg(0, size, align, is_float, fp_eightbytes, is_aggregate, false, gp_used, fp_used, hfa_members, hfa_elem, abi.agg_none());
+    ret classify_arg(0, size, align, is_float, fp_eightbytes, is_aggregate, false, false, gp_used, fp_used, hfa_members, hfa_elem, abi.agg_none());
 }
 
 # assign registers or a stack slot for one argument (AAPCS64)
@@ -196,6 +196,8 @@ pub fun classify(size: u64, align: u64, is_float: bool, fp_eightbytes: u8,
 # is_aggregate:  true if the argument is an aggregate
 # is_vector:     true for a 128-bit SIMD vector (#1965): placed in a single V
 #                register as a one-member short-vector aggregate
+# is_ext:        true at a declared `ext` boundary (#2058); ignored under AAPCS64, whose
+#                convention already matches mach's internal one
 # gp_used:       GP registers already consumed
 # fp_used:       FP registers already consumed
 # hfa_members:   HFA member count (1-4), or 0 if the argument is not an HFA
@@ -203,7 +205,7 @@ pub fun classify(size: u64, align: u64, is_float: bool, fp_eightbytes: u8,
 # agg:           the flattened-aggregate descriptor (lp64d-only; unused under AAPCS64)
 # ret:           the placement decision
 pub fun classify_arg(index: i32, size: u64, align: u64,
-                     is_float: bool, fp_eightbytes: u8, is_aggregate: bool, is_vector: bool,
+                     is_float: bool, fp_eightbytes: u8, is_aggregate: bool, is_vector: bool, is_ext: bool,
                      gp_used: i32, fp_used: i32, hfa_members: u8, hfa_elem: u8,
                      agg: abi.AggLayout) abi.ParamSlot {
     if (is_aggregate && hfa_members > 0) {
@@ -454,10 +456,10 @@ pub fun register(reg: *abi.AbiRegistry) R.Result[bool, str] {
 
 # a scalar integer takes a GP register; a float takes a V register
 test "mach.lang.target.abi.aapcs64.classify_arg:scalar_register_banks" {
-    val i: abi.ParamSlot = classify_arg(0, 8, 8, false, 0, false, false, 0, 0, 0, 0, abi.agg_none());
+    val i: abi.ParamSlot = classify_arg(0, 8, 8, false, 0, false, false, false, 0, 0, 0, 0, abi.agg_none());
     if (i.class != abi.CLASS_GP) { ret 1; }
     if (i.reg != REG_X0)         { ret 1; }
-    val f: abi.ParamSlot = classify_arg(0, 8, 8, true, 0, false, false, 0, 0, 0, 0, abi.agg_none());
+    val f: abi.ParamSlot = classify_arg(0, 8, 8, true, 0, false, false, false, 0, 0, 0, 0, abi.agg_none());
     if (f.class != abi.CLASS_FP)  { ret 1; }
     if (f.reg != fp_param_reg(0)) { ret 1; }
     ret 0;
@@ -466,12 +468,12 @@ test "mach.lang.target.abi.aapcs64.classify_arg:scalar_register_banks" {
 # a 16-byte integer aggregate rides a consecutive GP pair; an 8-byte one a single
 # GP register
 test "mach.lang.target.abi.aapcs64.classify_arg:integer_aggregate_gp" {
-    val s: abi.ParamSlot = classify_arg(0, 16, 8, false, 0, true, false, 0, 0, 0, 0, abi.agg_none());
+    val s: abi.ParamSlot = classify_arg(0, 16, 8, false, 0, true, false, false, 0, 0, 0, 0, abi.agg_none());
     if (s.class != abi.CLASS_GP)    { ret 1; }
     if (s.piece_count   != 2)       { ret 1; }
     if (s.pieces[0].reg != REG_X0)  { ret 1; }
     if (s.pieces[1].reg != REG_X1)  { ret 1; }
-    val o: abi.ParamSlot = classify_arg(0, 8, 8, false, 0, true, false, 0, 0, 0, 0, abi.agg_none());
+    val o: abi.ParamSlot = classify_arg(0, 8, 8, false, 0, true, false, false, 0, 0, 0, 0, abi.agg_none());
     if (o.class != abi.CLASS_GP)    { ret 1; }
     if (o.piece_count   != 1)       { ret 1; }
     if (o.pieces[0].reg != REG_X0)  { ret 1; }
@@ -482,11 +484,11 @@ test "mach.lang.target.abi.aapcs64.classify_arg:integer_aggregate_gp" {
 # bank is exhausted
 test "mach.lang.target.abi.aapcs64.classify_arg:large_aggregate_byref" {
     # a GP register remains: the hidden pointer rides it.
-    val s: abi.ParamSlot = classify_arg(0, 32, 8, false, 0, true, false, 0, 0, 0, 0, abi.agg_none());
+    val s: abi.ParamSlot = classify_arg(0, 32, 8, false, 0, true, false, false, 0, 0, 0, 0, abi.agg_none());
     if (s.class != abi.CLASS_BYREF) { ret 1; }
     if (s.reg   != REG_X0)          { ret 1; }
     # GP bank exhausted: the pointer is passed on the stack.
-    val e: abi.ParamSlot = classify_arg(0, 32, 8, false, 0, true, false, 8, 0, 0, 0, abi.agg_none());
+    val e: abi.ParamSlot = classify_arg(0, 32, 8, false, 0, true, false, false, 8, 0, 0, 0, abi.agg_none());
     if (e.class != abi.CLASS_STACK_BYREF) { ret 1; }
     ret 0;
 }
@@ -495,24 +497,24 @@ test "mach.lang.target.abi.aapcs64.classify_arg:large_aggregate_byref" {
 # the run cannot fit
 test "mach.lang.target.abi.aapcs64.classify_arg:hfa_v_run" {
     # struct { f32, f32 } -> 2 members of 4 bytes in V0:V1.
-    val s: abi.ParamSlot = classify_arg(0, 8, 4, false, 0, true, false, 0, 0, 2, 4, abi.agg_none());
+    val s: abi.ParamSlot = classify_arg(0, 8, 4, false, 0, true, false, false, 0, 0, 2, 4, abi.agg_none());
     if (s.piece_count     != 2)               { ret 1; }
     if (s.pieces[0].reg   != fp_param_reg(0)) { ret 1; }
     if (s.pieces[0].width != 4)               { ret 1; }
     if (s.pieces[1].reg   != fp_param_reg(1)) { ret 1; }
     if (s.size != 8)                          { ret 1; }
     # a 4xf64 HFA is 32 bytes yet still rides V0..V3 (HFA precedes the byref rule).
-    val q: abi.ParamSlot = classify_arg(0, 32, 8, false, 0, true, false, 0, 0, 4, 8, abi.agg_none());
+    val q: abi.ParamSlot = classify_arg(0, 32, 8, false, 0, true, false, false, 0, 0, 4, 8, abi.agg_none());
     if (q.piece_count     != 4)               { ret 1; }
     if (q.pieces[0].reg   != fp_param_reg(0)) { ret 1; }
     if (q.pieces[0].width != 8)               { ret 1; }
     if (q.pieces[3].reg   != fp_param_reg(3)) { ret 1; }
     # the run starts at the next free V register (NSRN cursor honored).
-    val a: abi.ParamSlot = classify_arg(0, 8, 4, false, 0, true, false, 0, 5, 2, 4, abi.agg_none());
+    val a: abi.ParamSlot = classify_arg(0, 8, 4, false, 0, true, false, false, 0, 5, 2, 4, abi.agg_none());
     if (a.pieces[0].reg != fp_param_reg(5)) { ret 1; }
     # all-or-memory: a 3-member HFA cannot fit when only two V registers remain, so
     # the WHOLE aggregate spills by value (no partial V placement).
-    val m: abi.ParamSlot = classify_arg(0, 12, 4, false, 0, true, false, 0, 6, 3, 4, abi.agg_none());
+    val m: abi.ParamSlot = classify_arg(0, 12, 4, false, 0, true, false, false, 0, 6, 3, 4, abi.agg_none());
     if (m.class != abi.CLASS_STACK) { ret 1; }
     ret 0;
 }
@@ -522,16 +524,16 @@ test "mach.lang.target.abi.aapcs64.classify_arg:hfa_v_run" {
 # by-value stack spill once the V bank is exhausted. the member width is the full 16
 # bytes (a single Q register), distinct from an f32/f64-member HFA.
 test "mach.lang.target.abi.aapcs64.classify_arg:short_vector_hva" {
-    val v: abi.ParamSlot = classify_arg(0, 16, 16, false, 0, false, true, 0, 0, 0, 0, abi.agg_none());
+    val v: abi.ParamSlot = classify_arg(0, 16, 16, false, 0, false, true, false, 0, 0, 0, 0, abi.agg_none());
     if (v.class != abi.CLASS_FP)  { ret 1; }
     if (v.reg != fp_param_reg(0)) { ret 1; }
     if (v.piece_count != 1)       { ret 1; }
     if (v.pieces[0].width != 16)  { ret 1; }
     # rides the next free V register after prior FP/vector args.
-    val v2: abi.ParamSlot = classify_arg(1, 16, 16, false, 0, false, true, 0, 3, 0, 0, abi.agg_none());
+    val v2: abi.ParamSlot = classify_arg(1, 16, 16, false, 0, false, true, false, 0, 3, 0, 0, abi.agg_none());
     if (v2.reg != fp_param_reg(3)) { ret 1; }
     # the whole V bank consumed -> spill by value.
-    val vs: abi.ParamSlot = classify_arg(2, 16, 16, false, 0, false, true, 0, 8, 0, 0, abi.agg_none());
+    val vs: abi.ParamSlot = classify_arg(2, 16, 16, false, 0, false, true, false, 0, 8, 0, 0, abi.agg_none());
     if (vs.class != abi.CLASS_STACK) { ret 1; }
     # a vector returns in V0 as a 16-byte one-member HVA.
     val r: abi.ParamSlot = classify_return(16, 16, false, 0, false, true, 0, 0, abi.agg_none());
@@ -544,14 +546,14 @@ test "mach.lang.target.abi.aapcs64.classify_arg:short_vector_hva" {
 # the GP and FP argument banks advance independently
 test "mach.lang.target.abi.aapcs64.classify_arg:banks_independent" {
     # seven GP registers used: a scalar integer still has X7, a float still has V0.
-    val i: abi.ParamSlot = classify_arg(0, 8, 8, false, 0, false, false, 7, 0, 0, 0, abi.agg_none());
+    val i: abi.ParamSlot = classify_arg(0, 8, 8, false, 0, false, false, false, 7, 0, 0, 0, abi.agg_none());
     if (i.class != abi.CLASS_GP) { ret 1; }
     if (i.reg != REG_X7)         { ret 1; }
-    val f: abi.ParamSlot = classify_arg(0, 8, 8, true, 0, false, false, 7, 0, 0, 0, abi.agg_none());
+    val f: abi.ParamSlot = classify_arg(0, 8, 8, true, 0, false, false, false, 7, 0, 0, 0, abi.agg_none());
     if (f.class != abi.CLASS_FP)  { ret 1; }
     if (f.reg != fp_param_reg(0)) { ret 1; }
     # GP exhausted spills an integer to the stack; the FP bank is untouched.
-    val s: abi.ParamSlot = classify_arg(0, 8, 8, false, 0, false, false, 8, 0, 0, 0, abi.agg_none());
+    val s: abi.ParamSlot = classify_arg(0, 8, 8, false, 0, false, false, false, 8, 0, 0, 0, abi.agg_none());
     if (s.class != abi.CLASS_STACK) { ret 1; }
     ret 0;
 }

--- a/src/lang/target/abi/lp64.mach
+++ b/src/lang/target/abi/lp64.mach
@@ -180,7 +180,7 @@ fun make_two_leaf_slot(agg: abi.AggLayout, nf: u32, fp0: i32, fp1: i32, gp0: i32
 pub fun classify(size: u64, align: u64, is_float: bool, fp_eightbytes: u8,
                  is_aggregate: bool, gp_used: i32, fp_used: i32,
                  hfa_members: u8, hfa_elem: u8) abi.ParamSlot {
-    ret classify_arg(0, size, align, is_float, fp_eightbytes, is_aggregate, false, gp_used, fp_used, hfa_members, hfa_elem, abi.agg_none());
+    ret classify_arg(0, size, align, is_float, fp_eightbytes, is_aggregate, false, false, gp_used, fp_used, hfa_members, hfa_elem, abi.agg_none());
 }
 
 # assign registers or a stack slot for one argument (lp64d)
@@ -209,6 +209,8 @@ pub fun classify(size: u64, align: u64, is_float: bool, fp_eightbytes: u8,
 #                so a vector is the memory (by-reference) class -- the caller copies
 #                it to memory and passes the pointer, the same path a >16-byte
 #                aggregate takes (#2016)
+# is_ext:        true at a declared `ext` boundary (#2058); ignored under lp64d, whose
+#                convention already matches mach's internal one
 # gp_used:       integer registers already consumed
 # fp_used:       float registers already consumed
 # hfa_members:   homogeneous-float member count; 1 or 2 selects the lp64d hard-float
@@ -219,7 +221,7 @@ pub fun classify(size: u64, align: u64, is_float: bool, fp_eightbytes: u8,
 #                and different-width float-pair rules, field_count 0 otherwise
 # ret:           the placement decision
 pub fun classify_arg(index: i32, size: u64, align: u64,
-                     is_float: bool, fp_eightbytes: u8, is_aggregate: bool, is_vector: bool,
+                     is_float: bool, fp_eightbytes: u8, is_aggregate: bool, is_vector: bool, is_ext: bool,
                      gp_used: i32, fp_used: i32, hfa_members: u8, hfa_elem: u8,
                      agg: abi.AggLayout) abi.ParamSlot {
     # a 128-bit vector has no register file on rv64gc: pass it by hidden reference,
@@ -552,10 +554,10 @@ pub fun register(reg: *abi.AbiRegistry) R.Result[bool, str] {
 # a scalar integer takes an integer argument register; a scalar float takes an fa
 # register
 test "mach.lang.target.abi.lp64.classify_arg:scalar_register_banks" {
-    val i: abi.ParamSlot = classify_arg(0, 8, 8, false, 0, false, false, 0, 0, 0, 0, abi.agg_none());
+    val i: abi.ParamSlot = classify_arg(0, 8, 8, false, 0, false, false, false, 0, 0, 0, 0, abi.agg_none());
     if (i.class != abi.CLASS_GP) { ret 1; }
     if (i.reg != REG_A0)         { ret 1; }
-    val f: abi.ParamSlot = classify_arg(0, 8, 8, true, 0, false, false, 0, 0, 0, 0, abi.agg_none());
+    val f: abi.ParamSlot = classify_arg(0, 8, 8, true, 0, false, false, false, 0, 0, 0, 0, abi.agg_none());
     if (f.class != abi.CLASS_FP)  { ret 1; }
     if (f.reg != fp_param_reg(0)) { ret 1; }
     ret 0;
@@ -566,18 +568,18 @@ test "mach.lang.target.abi.lp64.classify_arg:scalar_register_banks" {
 test "mach.lang.target.abi.lp64.classify_arg:banks_independent_and_float_fallback" {
     # seven integer registers used: a scalar integer still has a7, a float still
     # has fa0.
-    val i: abi.ParamSlot = classify_arg(0, 8, 8, false, 0, false, false, 7, 0, 0, 0, abi.agg_none());
+    val i: abi.ParamSlot = classify_arg(0, 8, 8, false, 0, false, false, false, 7, 0, 0, 0, abi.agg_none());
     if (i.class != abi.CLASS_GP) { ret 1; }
     if (i.reg != REG_A0 + 7)     { ret 1; }
-    val f: abi.ParamSlot = classify_arg(0, 8, 8, true, 0, false, false, 7, 0, 0, 0, abi.agg_none());
+    val f: abi.ParamSlot = classify_arg(0, 8, 8, true, 0, false, false, false, 7, 0, 0, 0, abi.agg_none());
     if (f.class != abi.CLASS_FP)  { ret 1; }
     if (f.reg != fp_param_reg(0)) { ret 1; }
     # fa bank exhausted, an integer register remains: the float rides it.
-    val g: abi.ParamSlot = classify_arg(0, 8, 8, true, 0, false, false, 0, 8, 0, 0, abi.agg_none());
+    val g: abi.ParamSlot = classify_arg(0, 8, 8, true, 0, false, false, false, 0, 8, 0, 0, abi.agg_none());
     if (g.class != abi.CLASS_GP) { ret 1; }
     if (g.reg != REG_A0)         { ret 1; }
     # both banks exhausted: the float spills to the stack.
-    val s: abi.ParamSlot = classify_arg(0, 8, 8, true, 0, false, false, 8, 8, 0, 0, abi.agg_none());
+    val s: abi.ParamSlot = classify_arg(0, 8, 8, true, 0, false, false, false, 8, 8, 0, 0, abi.agg_none());
     if (s.class != abi.CLASS_STACK) { ret 1; }
     ret 0;
 }
@@ -586,21 +588,21 @@ test "mach.lang.target.abi.lp64.classify_arg:banks_independent_and_float_fallbac
 # single integer register; a >16-byte aggregate is passed by reference, on the
 # stack once the integer bank is exhausted
 test "mach.lang.target.abi.lp64.classify_arg:aggregate_placement" {
-    val s: abi.ParamSlot = classify_arg(0, 16, 8, false, 0, true, false, 0, 0, 0, 0, abi.agg_none());
+    val s: abi.ParamSlot = classify_arg(0, 16, 8, false, 0, true, false, false, 0, 0, 0, 0, abi.agg_none());
     if (s.class != abi.CLASS_GP)    { ret 1; }
     if (s.piece_count   != 2)       { ret 1; }
     if (s.pieces[0].reg != REG_A0)  { ret 1; }
     if (s.pieces[1].reg != REG_A1)  { ret 1; }
-    val o: abi.ParamSlot = classify_arg(0, 8, 8, false, 0, true, false, 0, 0, 0, 0, abi.agg_none());
+    val o: abi.ParamSlot = classify_arg(0, 8, 8, false, 0, true, false, false, 0, 0, 0, 0, abi.agg_none());
     if (o.class != abi.CLASS_GP)    { ret 1; }
     if (o.piece_count   != 1)       { ret 1; }
     if (o.pieces[0].reg != REG_A0)  { ret 1; }
     # >16 bytes with an integer register free: the pointer rides it.
-    val b: abi.ParamSlot = classify_arg(0, 32, 8, false, 0, true, false, 0, 0, 0, 0, abi.agg_none());
+    val b: abi.ParamSlot = classify_arg(0, 32, 8, false, 0, true, false, false, 0, 0, 0, 0, abi.agg_none());
     if (b.class != abi.CLASS_BYREF) { ret 1; }
     if (b.reg   != REG_A0)          { ret 1; }
     # >16 bytes with the integer bank exhausted: the pointer is passed on the stack.
-    val e: abi.ParamSlot = classify_arg(0, 32, 8, false, 0, true, false, 8, 0, 0, 0, abi.agg_none());
+    val e: abi.ParamSlot = classify_arg(0, 32, 8, false, 0, true, false, false, 8, 0, 0, 0, abi.agg_none());
     if (e.class != abi.CLASS_STACK_BYREF) { ret 1; }
     ret 0;
 }
@@ -611,7 +613,7 @@ test "mach.lang.target.abi.lp64.classify_arg:aggregate_placement" {
 test "mach.lang.target.abi.lp64.classify_arg:aggregate_register_stack_split" {
     # seven integer registers used (a7 free): the low eightbyte rides a7, the high
     # eightbyte rides an outgoing stack slot.
-    val sp: abi.ParamSlot = classify_arg(0, 16, 8, false, 0, true, false, 7, 0, 0, 0, abi.agg_none());
+    val sp: abi.ParamSlot = classify_arg(0, 16, 8, false, 0, true, false, false, 7, 0, 0, 0, abi.agg_none());
     if (sp.class            != abi.CLASS_GP)    { ret 1; }
     if (sp.piece_count      != 2)               { ret 1; }
     if (sp.pieces[0].kind   != abi.PIECE_GP)    { ret 1; }
@@ -620,7 +622,7 @@ test "mach.lang.target.abi.lp64.classify_arg:aggregate_register_stack_split" {
     if (sp.pieces[1].kind   != abi.PIECE_STACK) { ret 1; }
     if (sp.pieces[1].src_off != 8)              { ret 1; }
     # no integer register left (all eight used): the whole aggregate spills by value.
-    val st: abi.ParamSlot = classify_arg(0, 16, 8, false, 0, true, false, 8, 0, 0, 0, abi.agg_none());
+    val st: abi.ParamSlot = classify_arg(0, 16, 8, false, 0, true, false, false, 8, 0, 0, 0, abi.agg_none());
     if (st.class != abi.CLASS_STACK)            { ret 1; }
     ret 0;
 }
@@ -630,29 +632,29 @@ test "mach.lang.target.abi.lp64.classify_arg:aggregate_register_stack_split" {
 # falls back to the integer convention
 test "mach.lang.target.abi.lp64.classify_arg:hard_float_struct_flattening" {
     # a single-float struct (8 bytes, one f64 member) rides fa0.
-    val one: abi.ParamSlot = classify_arg(0, 8, 8, false, 0, true, false, 0, 0, 1, 8, abi.agg_none());
+    val one: abi.ParamSlot = classify_arg(0, 8, 8, false, 0, true, false, false, 0, 0, 1, 8, abi.agg_none());
     if (one.piece_count     != 1)               { ret 1; }
     if (one.pieces[0].reg   != fp_param_reg(0)) { ret 1; }
     if (one.pieces[0].width != 8)               { ret 1; }
     # a two-float struct (two f32 members) rides fa0:fa1, each 4 bytes.
-    val two: abi.ParamSlot = classify_arg(0, 8, 4, false, 0, true, false, 0, 0, 2, 4, abi.agg_none());
+    val two: abi.ParamSlot = classify_arg(0, 8, 4, false, 0, true, false, false, 0, 0, 2, 4, abi.agg_none());
     if (two.piece_count     != 2)               { ret 1; }
     if (two.pieces[0].reg   != fp_param_reg(0)) { ret 1; }
     if (two.pieces[0].width != 4)               { ret 1; }
     if (two.pieces[1].reg   != fp_param_reg(1)) { ret 1; }
     # the float bank advances independently of the integer bank: with six fa
     # registers used, a two-float struct rides the last fa pair (fa6:fa7).
-    val mid: abi.ParamSlot = classify_arg(0, 16, 8, false, 0, true, false, 3, 6, 2, 8, abi.agg_none());
+    val mid: abi.ParamSlot = classify_arg(0, 16, 8, false, 0, true, false, false, 3, 6, 2, 8, abi.agg_none());
     if (mid.piece_count   != 2)               { ret 1; }
     if (mid.pieces[0].reg != fp_param_reg(6)) { ret 1; }
     # the fa bank lacks two registers (seven used): the struct falls back to the
     # integer convention (a 9-16 byte pair here), not a cross-bank split.
-    val fall: abi.ParamSlot = classify_arg(0, 16, 8, false, 0, true, false, 0, 7, 2, 8, abi.agg_none());
+    val fall: abi.ParamSlot = classify_arg(0, 16, 8, false, 0, true, false, false, 0, 7, 2, 8, abi.agg_none());
     if (fall.class != abi.CLASS_GP)    { ret 1; }
     if (fall.pieces[0].reg != REG_A0)  { ret 1; }
     if (fall.pieces[1].reg != REG_A1)  { ret 1; }
     # a three-float struct is not flattened (hfa_members > 2): the integer convention.
-    val three: abi.ParamSlot = classify_arg(0, 16, 4, false, 0, true, false, 0, 0, 3, 4, abi.agg_none());
+    val three: abi.ParamSlot = classify_arg(0, 16, 4, false, 0, true, false, false, 0, 0, 3, 4, abi.agg_none());
     if (three.class != abi.CLASS_GP) { ret 1; }
     ret 0;
 }
@@ -671,7 +673,7 @@ test "mach.lang.target.abi.lp64.classify_arg:mixed_and_diff_width_float_pairs" {
     ff.fields[1].is_float = true;
     ff.fields[1].offset   = 8;
     ff.fields[1].width    = 8;
-    val fp: abi.ParamSlot = classify_arg(0, 16, 8, false, 0, true, false, 0, 0, 0, 0, ff);
+    val fp: abi.ParamSlot = classify_arg(0, 16, 8, false, 0, true, false, false, 0, 0, 0, 0, ff);
     if (fp.class             != abi.CLASS_FP)    { ret 1; }
     if (fp.piece_count       != 2)               { ret 1; }
     if (fp.pieces[0].kind    != abi.PIECE_FP)    { ret 1; }
@@ -692,7 +694,7 @@ test "mach.lang.target.abi.lp64.classify_arg:mixed_and_diff_width_float_pairs" {
     fi.fields[1].is_float = false;
     fi.fields[1].offset   = 8;
     fi.fields[1].width    = 8;
-    val mx: abi.ParamSlot = classify_arg(0, 16, 8, false, 0, true, false, 0, 0, 0, 0, fi);
+    val mx: abi.ParamSlot = classify_arg(0, 16, 8, false, 0, true, false, false, 0, 0, 0, 0, fi);
     if (mx.class             != abi.CLASS_GP)    { ret 1; }
     if (mx.piece_count       != 2)               { ret 1; }
     if (mx.pieces[0].kind    != abi.PIECE_FP)    { ret 1; }
@@ -704,7 +706,7 @@ test "mach.lang.target.abi.lp64.classify_arg:mixed_and_diff_width_float_pairs" {
 
     # the fa bank is exhausted for the mixed case (fp_used = 8): fall back to the
     # integer convention (a 9-16 byte a0:a1 pair), not a cross-bank piece slot.
-    val fb: abi.ParamSlot = classify_arg(0, 16, 8, false, 0, true, false, 0, 8, 0, 0, fi);
+    val fb: abi.ParamSlot = classify_arg(0, 16, 8, false, 0, true, false, false, 0, 8, 0, 0, fi);
     if (fb.class           != abi.CLASS_GP) { ret 1; }
     if (fb.pieces[0].reg   != REG_A0)       { ret 1; }
     if (fb.pieces[1].reg   != REG_A1)       { ret 1; }
@@ -725,7 +727,7 @@ test "mach.lang.target.abi.lp64.classify_arg:mixed_subword_gp_width" {
     fi.fields[1].is_float = false;
     fi.fields[1].offset   = 4;
     fi.fields[1].width    = 4;
-    val a: abi.ParamSlot = classify_arg(0, 8, 4, false, 0, true, false, 0, 0, 0, 0, fi);
+    val a: abi.ParamSlot = classify_arg(0, 8, 4, false, 0, true, false, false, 0, 0, 0, 0, fi);
     if (a.class             != abi.CLASS_GP)    { ret 1; }
     if (a.piece_count       != 2)               { ret 1; }
     if (a.pieces[0].kind    != abi.PIECE_FP)    { ret 1; }

--- a/src/lang/target/abi/sysv.mach
+++ b/src/lang/target/abi/sysv.mach
@@ -116,7 +116,7 @@ pub fun fp_param_reg(index: i32) i32 {
 pub fun classify(size: u64, align: u64, is_float: bool, fp_eightbytes: u8,
                  is_aggregate: bool, gp_used: i32, fp_used: i32,
                  hfa_members: u8, hfa_elem: u8) abi.ParamSlot {
-    ret classify_arg(0, size, align, is_float, fp_eightbytes, is_aggregate, false,
+    ret classify_arg(0, size, align, is_float, fp_eightbytes, is_aggregate, false, false,
                      gp_used, fp_used, hfa_members, hfa_elem, abi.agg_none());
 }
 
@@ -148,6 +148,8 @@ pub fun classify(size: u64, align: u64, is_float: bool, fp_eightbytes: u8,
 # is_aggregate:  true if the argument is an aggregate
 # is_vector:     true for a 128-bit SIMD vector (#1965); neutral, unread here (the
 #                SSE-class vector branch is #2014)
+# is_ext:        true at a declared `ext` boundary (#2058); ignored under SysV, whose
+#                convention already matches mach's internal one
 # gp_used:       GP registers already consumed
 # fp_used:       FP registers already consumed
 # hfa_members:   HFA member count (AAPCS64-only; unused under SysV)
@@ -155,7 +157,7 @@ pub fun classify(size: u64, align: u64, is_float: bool, fp_eightbytes: u8,
 # agg:           the flattened-aggregate descriptor (lp64d-only; unused under SysV)
 # ret:           the placement decision
 pub fun classify_arg(index: i32, size: u64, align: u64,
-                     is_float: bool, fp_eightbytes: u8, is_aggregate: bool, is_vector: bool,
+                     is_float: bool, fp_eightbytes: u8, is_aggregate: bool, is_vector: bool, is_ext: bool,
                      gp_used: i32, fp_used: i32, hfa_members: u8, hfa_elem: u8,
                      agg: abi.AggLayout) abi.ParamSlot {
     if (is_aggregate && size > MAX_REG_RET) {
@@ -450,7 +452,7 @@ pub fun register(reg: *abi.AbiRegistry) R.Result[bool, str] {
 
 # {f64; f64} -> both eightbytes SSE -> the two vector argument registers
 test "mach.lang.target.abi.sysv.classify_arg:all_float_16byte_rides_xmm_pair" {
-    val s: abi.ParamSlot = classify_arg(0, 16, 8, false, 3, true, false, 0, 0, 0, 0, abi.agg_none());
+    val s: abi.ParamSlot = classify_arg(0, 16, 8, false, 3, true, false, false, 0, 0, 0, 0, abi.agg_none());
     if (s.class != abi.CLASS_GP)            { ret 1; }
     if (s.piece_count   != 2)               { ret 1; }
     if (s.pieces[0].reg != fp_param_reg(0)) { ret 1; }
@@ -460,7 +462,7 @@ test "mach.lang.target.abi.sysv.classify_arg:all_float_16byte_rides_xmm_pair" {
 
 # {f32; f32} (8 bytes) -> one SSE eightbyte -> XMM0
 test "mach.lang.target.abi.sysv.classify_arg:all_float_8byte_rides_one_xmm" {
-    val s: abi.ParamSlot = classify_arg(0, 8, 4, false, 1, true, false, 0, 0, 0, 0, abi.agg_none());
+    val s: abi.ParamSlot = classify_arg(0, 8, 4, false, 1, true, false, false, 0, 0, 0, 0, abi.agg_none());
     if (s.class != abi.CLASS_GP)            { ret 1; }
     if (s.piece_count   != 1)               { ret 1; }
     if (s.pieces[0].reg != fp_param_reg(0)) { ret 1; }
@@ -470,10 +472,10 @@ test "mach.lang.target.abi.sysv.classify_arg:all_float_8byte_rides_one_xmm" {
 # {i64; f64} -> eightbyte 0 INTEGER (RDI), eightbyte 1 SSE (XMM0); the reverse
 # {f64; i64} fills the banks independently, so the integer eightbyte takes RDI
 test "mach.lang.target.abi.sysv.classify_arg:mixed_int_sse_rides_rdi_xmm" {
-    val s: abi.ParamSlot = classify_arg(0, 16, 8, false, 2, true, false, 0, 0, 0, 0, abi.agg_none());
+    val s: abi.ParamSlot = classify_arg(0, 16, 8, false, 2, true, false, false, 0, 0, 0, 0, abi.agg_none());
     if (s.pieces[0].reg != REG_RDI)         { ret 1; }
     if (s.pieces[1].reg != fp_param_reg(0)) { ret 1; }
-    val r: abi.ParamSlot = classify_arg(0, 16, 8, false, 1, true, false, 0, 0, 0, 0, abi.agg_none());
+    val r: abi.ParamSlot = classify_arg(0, 16, 8, false, 1, true, false, false, 0, 0, 0, 0, abi.agg_none());
     if (r.pieces[0].reg != fp_param_reg(0)) { ret 1; }
     if (r.pieces[1].reg != REG_RDI)         { ret 1; }
     ret 0;
@@ -481,7 +483,7 @@ test "mach.lang.target.abi.sysv.classify_arg:mixed_int_sse_rides_rdi_xmm" {
 
 # {i64; i64} (mask 0) -> RDI:RSI, exactly as before SSE classification
 test "mach.lang.target.abi.sysv.classify_arg:all_integer_rides_gp_pair" {
-    val s: abi.ParamSlot = classify_arg(0, 16, 8, false, 0, true, false, 0, 0, 0, 0, abi.agg_none());
+    val s: abi.ParamSlot = classify_arg(0, 16, 8, false, 0, true, false, false, 0, 0, 0, 0, abi.agg_none());
     if (s.pieces[0].reg != REG_RDI) { ret 1; }
     if (s.pieces[1].reg != REG_RSI) { ret 1; }
     ret 0;
@@ -490,7 +492,7 @@ test "mach.lang.target.abi.sysv.classify_arg:all_integer_rides_gp_pair" {
 # with seven XMM registers already used, a two-SSE aggregate needs two but only
 # one remains, so the whole aggregate spills to the stack by value
 test "mach.lang.target.abi.sysv.classify_arg:sse_bank_exhaustion_spills" {
-    val s: abi.ParamSlot = classify_arg(0, 16, 8, false, 3, true, false, 0, 7, 0, 0, abi.agg_none());
+    val s: abi.ParamSlot = classify_arg(0, 16, 8, false, 3, true, false, false, 0, 7, 0, 0, abi.agg_none());
     if (s.class != abi.CLASS_STACK) { ret 1; }
     if (s.size  != 16)              { ret 1; }
     ret 0;
@@ -518,10 +520,10 @@ test "mach.lang.target.abi.sysv.classify_return:banks_fill_in_order" {
 
 # a scalar float takes an XMM register, a scalar integer a GP register
 test "mach.lang.target.abi.sysv.classify_arg:scalar_float_xmm_integer_gp" {
-    val f: abi.ParamSlot = classify_arg(0, 8, 8, true, 0, false, false, 0, 0, 0, 0, abi.agg_none());
+    val f: abi.ParamSlot = classify_arg(0, 8, 8, true, 0, false, false, false, 0, 0, 0, 0, abi.agg_none());
     if (f.class != abi.CLASS_FP)    { ret 1; }
     if (f.reg   != fp_param_reg(0)) { ret 1; }
-    val i: abi.ParamSlot = classify_arg(0, 8, 8, false, 0, false, false, 0, 0, 0, 0, abi.agg_none());
+    val i: abi.ParamSlot = classify_arg(0, 8, 8, false, 0, false, false, false, 0, 0, 0, 0, abi.agg_none());
     if (i.class != abi.CLASS_GP) { ret 1; }
     if (i.reg   != REG_RDI)      { ret 1; }
     ret 0;
@@ -545,19 +547,19 @@ test "mach.lang.target.abi.sysv.register:indirect_result_in_argfile" {
 # return, never an argument
 test "mach.lang.target.abi.sysv.classify_arg:large_aggregate_memory_class_by_value" {
     # all six GP argument registers free: still by value on the stack, no register.
-    val s0: abi.ParamSlot = classify_arg(0, 32, 8, false, 0, true, false, 0, 0, 0, 0, abi.agg_none());
+    val s0: abi.ParamSlot = classify_arg(0, 32, 8, false, 0, true, false, false, 0, 0, 0, 0, abi.agg_none());
     if (s0.class != abi.CLASS_STACK) { ret 1; }
     if (s0.reg   != -1)              { ret 1; }
     if (s0.size  != 32)              { ret 1; }
 
     # one GP argument register still free: no hidden pointer, by value on the stack.
-    val s1: abi.ParamSlot = classify_arg(0, 32, 8, false, 0, true, false, 5, 0, 0, 0, abi.agg_none());
+    val s1: abi.ParamSlot = classify_arg(0, 32, 8, false, 0, true, false, false, 5, 0, 0, 0, abi.agg_none());
     if (s1.class != abi.CLASS_STACK) { ret 1; }
     if (s1.reg   != -1)              { ret 1; }
     if (s1.size  != 32)              { ret 1; }
 
     # GP argument registers exhausted: by value on the stack, the odd size carried through.
-    val s2: abi.ParamSlot = classify_arg(0, 17, 8, false, 0, true, false, 6, 0, 0, 0, abi.agg_none());
+    val s2: abi.ParamSlot = classify_arg(0, 17, 8, false, 0, true, false, false, 6, 0, 0, 0, abi.agg_none());
     if (s2.class != abi.CLASS_STACK) { ret 1; }
     if (s2.reg   != -1)              { ret 1; }
     if (s2.size  != 17)              { ret 1; }

--- a/src/lang/target/abi/win64.mach
+++ b/src/lang/target/abi/win64.mach
@@ -165,7 +165,7 @@ pub fun float_dup_gp_reg(index: i32) i32 {
 pub fun classify(size: u64, align: u64, is_float: bool, fp_eightbytes: u8,
                  is_aggregate: bool, gp_used: i32, fp_used: i32,
                  hfa_members: u8, hfa_elem: u8) abi.ParamSlot {
-    ret classify_arg(0, size, align, is_float, fp_eightbytes, is_aggregate, false, gp_used, fp_used, hfa_members, hfa_elem, abi.agg_none());
+    ret classify_arg(0, size, align, is_float, fp_eightbytes, is_aggregate, false, false, gp_used, fp_used, hfa_members, hfa_elem, abi.agg_none());
 }
 
 # assign a register or stack slot for one argument (win64)
@@ -193,6 +193,10 @@ pub fun classify(size: u64, align: u64, is_float: bool, fp_eightbytes: u8,
 # fp_eightbytes: per-eightbyte SSE mask (unused -- win64 aggregates ride GP)
 # is_aggregate:  true if the argument is an aggregate
 # is_vector:     true for a 128-bit SIMD vector (#1965); routed to an XMM register (#2055)
+#                internally, or by reference when `is_ext` (#2058)
+# is_ext:        true when the call crosses a declared `ext` (foreign C) boundary; a
+#                vector argument then follows the Microsoft x64 __m128 convention
+#                (by reference) instead of mach's internal XMM one (#2058)
 # gp_used:       GP registers already consumed
 # fp_used:       FP registers already consumed
 # hfa_members:   HFA member count (AAPCS64-only; unused under win64)
@@ -200,20 +204,32 @@ pub fun classify(size: u64, align: u64, is_float: bool, fp_eightbytes: u8,
 # agg:           the flattened-aggregate descriptor (lp64d-only; unused under win64)
 # ret:           the placement decision
 pub fun classify_arg(index: i32, size: u64, align: u64,
-                     is_float: bool, fp_eightbytes: u8, is_aggregate: bool, is_vector: bool,
+                     is_float: bool, fp_eightbytes: u8, is_aggregate: bool, is_vector: bool, is_ext: bool,
                      gp_used: i32, fp_used: i32, hfa_members: u8, hfa_elem: u8,
                      agg: abi.AggLayout) abi.ParamSlot {
     val slot: i32 = slot_index(gp_used, fp_used);
 
-    # DELIBERATE DEVIATION (#2055): mach passes its own 128-bit vector types in an XMM
-    # argument register (spilling by value to the stack once XMM0-3 are exhausted),
-    # matching the SysV / AAPCS64 internal convention and consistent across all four
-    # ABIs. This is NOT the Microsoft x64 __m128 convention, which passes 16-byte
-    # vectors BY REFERENCE (a caller-allocated copy's pointer). mach's vectors have no
-    # C FFI surface today, so every vector call is mach->mach and XMM is correct for all
-    # of them; C interop with a vector-typed `ext` fun on windows is not ABI-conformant
-    # until the by-reference marshalling of RFC #2058 is ruled in.
     if (is_vector) {
+        # CONFORMANT MARSHALLING (#2058): a call to a declared `ext` function follows the
+        # Microsoft x64 convention, which passes a 128-bit vector BY REFERENCE -- the
+        # caller stores it to a 16-byte-aligned temporary and passes that temporary's
+        # address. mach's vector rides a vector register here (x86_64 is SIMD-capable, so
+        # it is never scalarized to memory), so the placement is CLASS_VEC_BYREF -- the
+        # caller spills the register value to the temp before taking its address -- rather
+        # than the memory-resident CLASS_BYREF. the address rides the slot's integer
+        # register, or spills as an 8-byte pointer once the four slots are exhausted.
+        if (is_ext) {
+            if (slot < PARAM_SLOT_COUNT) {
+                ret abi.make_slot(abi.CLASS_VEC_BYREF, slot_gp_reg(slot), -1, 0, 8);
+            }
+            ret abi.make_slot(abi.CLASS_VEC_STACK_BYREF, -1, -1, 0, 8);
+        }
+        # DELIBERATE DEVIATION (#2055): an internal (mach->mach) call passes mach's own
+        # 128-bit vector types in an XMM argument register (spilling by value to the stack
+        # once XMM0-3 are exhausted), matching the SysV / AAPCS64 internal convention and
+        # consistent across all four ABIs. This is NOT the Microsoft x64 __m128 argument
+        # convention above; it is mach's own, correct for every mach->mach call, which is
+        # every non-ext call. The return side agrees with MS regardless (XMM0).
         if (slot < PARAM_SLOT_COUNT) {
             ret abi.make_slot(abi.CLASS_FP, slot_fp_reg(slot), -1, 0, size);
         }
@@ -485,18 +501,18 @@ pub fun register_win64(reg: *abi.AbiRegistry) R.Result[bool, str] {
 # scalar integers fill RCX, RDX, R8, R9 in order, then the fifth spills to the
 # stack by value
 test "mach.lang.target.abi.win64.classify_arg:scalar_integers_then_spill" {
-    val s0: abi.ParamSlot = classify_arg(0, 8, 8, false, 0, false, false, 0, 0, 0, 0, abi.agg_none());
+    val s0: abi.ParamSlot = classify_arg(0, 8, 8, false, 0, false, false, false, 0, 0, 0, 0, abi.agg_none());
     if (s0.class != abi.CLASS_GP) { ret 1; }
     if (s0.reg   != REG_RCX)      { ret 1; }
 
-    val s1: abi.ParamSlot = classify_arg(1, 8, 8, false, 0, false, false, 1, 0, 0, 0, abi.agg_none());
+    val s1: abi.ParamSlot = classify_arg(1, 8, 8, false, 0, false, false, false, 1, 0, 0, 0, abi.agg_none());
     if (s1.reg != REG_RDX) { ret 1; }
-    val s2: abi.ParamSlot = classify_arg(2, 8, 8, false, 0, false, false, 2, 0, 0, 0, abi.agg_none());
+    val s2: abi.ParamSlot = classify_arg(2, 8, 8, false, 0, false, false, false, 2, 0, 0, 0, abi.agg_none());
     if (s2.reg != REG_R8) { ret 1; }
-    val s3: abi.ParamSlot = classify_arg(3, 8, 8, false, 0, false, false, 3, 0, 0, 0, abi.agg_none());
+    val s3: abi.ParamSlot = classify_arg(3, 8, 8, false, 0, false, false, false, 3, 0, 0, 0, abi.agg_none());
     if (s3.reg != REG_R9) { ret 1; }
 
-    val s4: abi.ParamSlot = classify_arg(4, 8, 8, false, 0, false, false, 4, 0, 0, 0, abi.agg_none());
+    val s4: abi.ParamSlot = classify_arg(4, 8, 8, false, 0, false, false, false, 4, 0, 0, 0, abi.agg_none());
     if (s4.class != abi.CLASS_STACK) { ret 1; }
     if (s4.reg   != -1)              { ret 1; }
     if (s4.size  != 8)               { ret 1; }
@@ -505,15 +521,15 @@ test "mach.lang.target.abi.win64.classify_arg:scalar_integers_then_spill" {
 
 # floats fill XMM0-XMM3 in order, then the fifth positional argument spills
 test "mach.lang.target.abi.win64.classify_arg:floats_then_spill" {
-    val f0: abi.ParamSlot = classify_arg(0, 8, 8, true, 0, false, false, 0, 0, 0, 0, abi.agg_none());
+    val f0: abi.ParamSlot = classify_arg(0, 8, 8, true, 0, false, false, false, 0, 0, 0, 0, abi.agg_none());
     if (f0.class != abi.CLASS_FP)                            { ret 1; }
     if (f0.reg   != isa.regid_make(isa.REG_CLASS_ID_XMM, 0)) { ret 1; }
 
-    val f3: abi.ParamSlot = classify_arg(3, 4, 4, true, 0, false, false, 0, 3, 0, 0, abi.agg_none());
+    val f3: abi.ParamSlot = classify_arg(3, 4, 4, true, 0, false, false, false, 0, 3, 0, 0, abi.agg_none());
     if (f3.class != abi.CLASS_FP)                            { ret 1; }
     if (f3.reg   != isa.regid_make(isa.REG_CLASS_ID_XMM, 3)) { ret 1; }
 
-    val f4: abi.ParamSlot = classify_arg(4, 8, 8, true, 0, false, false, 0, 4, 0, 0, abi.agg_none());
+    val f4: abi.ParamSlot = classify_arg(4, 8, 8, true, 0, false, false, false, 0, 4, 0, 0, abi.agg_none());
     if (f4.class != abi.CLASS_STACK) { ret 1; }
     ret 0;
 }
@@ -521,15 +537,15 @@ test "mach.lang.target.abi.win64.classify_arg:floats_then_spill" {
 # an integer and a float share one positional slot per argument: an integer in
 # slot 0 (RCX) pushes a following float to slot 1 (XMM1), and vice versa
 test "mach.lang.target.abi.win64.classify_arg:shared_positional_slot" {
-    val i0: abi.ParamSlot = classify_arg(0, 8, 8, false, 0, false, false, 0, 0, 0, 0, abi.agg_none());
+    val i0: abi.ParamSlot = classify_arg(0, 8, 8, false, 0, false, false, false, 0, 0, 0, 0, abi.agg_none());
     if (i0.reg != REG_RCX) { ret 1; }
-    val f1: abi.ParamSlot = classify_arg(1, 8, 8, true, 0, false, false, 1, 0, 0, 0, abi.agg_none());
+    val f1: abi.ParamSlot = classify_arg(1, 8, 8, true, 0, false, false, false, 1, 0, 0, 0, abi.agg_none());
     if (f1.class != abi.CLASS_FP)                            { ret 1; }
     if (f1.reg   != isa.regid_make(isa.REG_CLASS_ID_XMM, 1)) { ret 1; }
 
-    val g0: abi.ParamSlot = classify_arg(0, 8, 8, true, 0, false, false, 0, 0, 0, 0, abi.agg_none());
+    val g0: abi.ParamSlot = classify_arg(0, 8, 8, true, 0, false, false, false, 0, 0, 0, 0, abi.agg_none());
     if (g0.reg != isa.regid_make(isa.REG_CLASS_ID_XMM, 0)) { ret 1; }
-    val g1: abi.ParamSlot = classify_arg(1, 8, 8, false, 0, false, false, 0, 1, 0, 0, abi.agg_none());
+    val g1: abi.ParamSlot = classify_arg(1, 8, 8, false, 0, false, false, false, 0, 1, 0, 0, abi.agg_none());
     if (g1.class != abi.CLASS_GP) { ret 1; }
     if (g1.reg   != REG_RDX)      { ret 1; }
     ret 0;
@@ -548,20 +564,20 @@ test "mach.lang.target.abi.win64.float_dup_gp_reg:variadic_duplicate" {
 # 1/2/4/8-byte aggregates ride one integer register by value; every other size is
 # passed by hidden reference, the pointer (8 bytes) in the slot's GP register
 test "mach.lang.target.abi.win64.classify_arg:aggregate_by_value_or_ref" {
-    val by_val: abi.ParamSlot = classify_arg(0, 8, 8, false, 0, true, false, 0, 0, 0, 0, abi.agg_none());
+    val by_val: abi.ParamSlot = classify_arg(0, 8, 8, false, 0, true, false, false, 0, 0, 0, 0, abi.agg_none());
     if (by_val.class != abi.CLASS_GP) { ret 1; }
     if (by_val.reg   != REG_RCX)      { ret 1; }
     if (by_val.size  != 8)            { ret 1; }
 
-    val four: abi.ParamSlot = classify_arg(0, 4, 4, false, 0, true, false, 0, 0, 0, 0, abi.agg_none());
+    val four: abi.ParamSlot = classify_arg(0, 4, 4, false, 0, true, false, false, 0, 0, 0, 0, abi.agg_none());
     if (four.class != abi.CLASS_GP) { ret 1; }
 
-    val by_ref3: abi.ParamSlot = classify_arg(0, 3, 1, false, 0, true, false, 0, 0, 0, 0, abi.agg_none());
+    val by_ref3: abi.ParamSlot = classify_arg(0, 3, 1, false, 0, true, false, false, 0, 0, 0, 0, abi.agg_none());
     if (by_ref3.class != abi.CLASS_BYREF) { ret 1; }
     if (by_ref3.reg   != REG_RCX)         { ret 1; }
     if (by_ref3.size  != 8)               { ret 1; }
 
-    val by_ref16: abi.ParamSlot = classify_arg(0, 16, 8, false, 0, true, false, 0, 0, 0, 0, abi.agg_none());
+    val by_ref16: abi.ParamSlot = classify_arg(0, 16, 8, false, 0, true, false, false, 0, 0, 0, 0, abi.agg_none());
     if (by_ref16.class != abi.CLASS_BYREF) { ret 1; }
     if (by_ref16.reg   != REG_RCX)         { ret 1; }
     ret 0;
@@ -571,18 +587,56 @@ test "mach.lang.target.abi.win64.classify_arg:aggregate_by_value_or_ref" {
 # hidden pointer as CLASS_STACK_BYREF (for both a 16-byte and a 3-byte aggregate),
 # while an exhausted by-value-size aggregate spills its own bytes as CLASS_STACK
 test "mach.lang.target.abi.win64.classify_arg:exhausted_byref_spills_pointer" {
-    val s: abi.ParamSlot = classify_arg(4, 16, 8, false, 0, true, false, 4, 0, 0, 0, abi.agg_none());
+    val s: abi.ParamSlot = classify_arg(4, 16, 8, false, 0, true, false, false, 4, 0, 0, 0, abi.agg_none());
     if (s.class != abi.CLASS_STACK_BYREF) { ret 1; }
     if (s.reg   != -1)                    { ret 1; }
     if (s.size  != 8)                     { ret 1; }
 
-    val s3: abi.ParamSlot = classify_arg(4, 3, 1, false, 0, true, false, 4, 0, 0, 0, abi.agg_none());
+    val s3: abi.ParamSlot = classify_arg(4, 3, 1, false, 0, true, false, false, 4, 0, 0, 0, abi.agg_none());
     if (s3.class != abi.CLASS_STACK_BYREF) { ret 1; }
     if (s3.size  != 8)                     { ret 1; }
 
-    val sv: abi.ParamSlot = classify_arg(4, 8, 8, false, 0, true, false, 4, 0, 0, 0, abi.agg_none());
+    val sv: abi.ParamSlot = classify_arg(4, 8, 8, false, 0, true, false, false, 4, 0, 0, 0, abi.agg_none());
     if (sv.class != abi.CLASS_STACK) { ret 1; }
     if (sv.size  != 8)               { ret 1; }
+    ret 0;
+}
+
+# a 128-bit vector argument marshals by reference at a declared `ext` boundary (#2058):
+# its address rides the slot's integer register (CLASS_BYREF, size 8), or spills as an
+# 8-byte pointer once the four slots are exhausted (CLASS_STACK_BYREF). an internal
+# (non-ext) call keeps the vector in an XMM register (the #2055 deviation, unchanged).
+test "mach.lang.target.abi.win64.classify_arg:ext_vector_by_reference" {
+    # internal call: the vector rides XMM0 by value (unchanged).
+    val internal: abi.ParamSlot = classify_arg(0, 16, 16, false, 0, false, true, false, 0, 0, 0, 0, abi.agg_none());
+    if (internal.class != abi.CLASS_FP)                            { ret 1; }
+    if (internal.reg   != isa.regid_make(isa.REG_CLASS_ID_XMM, 0)) { ret 1; }
+
+    # ext call, slot 0: the temp's address rides RCX (CLASS_VEC_BYREF, 8-byte pointer).
+    val e0: abi.ParamSlot = classify_arg(0, 16, 16, false, 0, false, true, true, 0, 0, 0, 0, abi.agg_none());
+    if (e0.class != abi.CLASS_VEC_BYREF) { ret 1; }
+    if (e0.reg   != REG_RCX)             { ret 1; }
+    if (e0.size  != 8)                   { ret 1; }
+
+    # ext call, slot 3: the address rides R9, the last integer argument register.
+    val e3: abi.ParamSlot = classify_arg(3, 16, 16, false, 0, false, true, true, 3, 0, 0, 0, abi.agg_none());
+    if (e3.class != abi.CLASS_VEC_BYREF) { ret 1; }
+    if (e3.reg   != REG_R9)              { ret 1; }
+
+    # ext call, slots exhausted: the 8-byte pointer spills to the stack.
+    val es: abi.ParamSlot = classify_arg(4, 16, 16, false, 0, false, true, true, 4, 0, 0, 0, abi.agg_none());
+    if (es.class != abi.CLASS_VEC_STACK_BYREF) { ret 1; }
+    if (es.reg   != -1)                        { ret 1; }
+    if (es.size  != 8)                         { ret 1; }
+    ret 0;
+}
+
+# a 128-bit vector RETURN is XMM0 under both conventions, so an `ext` boundary never
+# marshals it -- the return side already conforms to Microsoft x64 (#2055, #2058).
+test "mach.lang.target.abi.win64.classify_return:vector_xmm0" {
+    val v: abi.ParamSlot = classify_return(16, 16, false, 0, false, true, 0, 0, abi.agg_none());
+    if (v.class != abi.CLASS_FP) { ret 1; }
+    if (v.reg   != REG_XMM0)     { ret 1; }
     ret 0;
 }
 
@@ -625,7 +679,7 @@ test "mach.lang.target.abi.win64.classify_return:aggregate_rax_or_sret" {
 test "mach.lang.target.abi.win64.classify_return:sret_reserves_first_slot" {
     val ret_slot: abi.ParamSlot = classify_return(24, 8, false, 0, true, false, 0, 0, abi.agg_none());
     if (ret_slot.class != abi.CLASS_SRET) { ret 1; }
-    val first_arg: abi.ParamSlot = classify_arg(0, 8, 8, false, 0, false, false, 1, 0, 0, 0, abi.agg_none());
+    val first_arg: abi.ParamSlot = classify_arg(0, 8, 8, false, 0, false, false, false, 1, 0, 0, 0, abi.agg_none());
     if (first_arg.class != abi.CLASS_GP) { ret 1; }
     if (first_arg.reg   != REG_RDX)      { ret 1; }
     ret 0;


### PR DESCRIPTION
## #2058 — win64 vector-argument marshaling at `ext` boundaries only

Implements the owner ruling (2026-07-11) on RFC #2058: on `x86_64-windows`, a call to a declared `ext` function passes each 128-bit vector argument per the Microsoft x64 convention — the caller stores the vector to a 16-byte-aligned temporary and passes its address in the parameter's GP register / stack slot. Internal (mach→mach) calls keep mach's convention (vectors in XMM, #2055), byte-identical on every target. Vector **returns** already conform (XMM0 under both conventions) and are untouched.

`Closes #2058`

### Design

- **Classification signal is the declared `ext` fact, not `FN_FLAG_EXTERN`.** A new `ir.Function.is_import` (the exact function twin of `Global.is_import` from #2079) is a strict subset of `FN_FLAG_EXTERN`: true only for a declared `ext fun`. A same-artifact cross-module reference — a generic instance drained in another object, a forward reference — is `FN_FLAG_EXTERN` but **not** `is_import`, so it never marshals. Derived at every function reference from the origin decl's `DECL_FLAG_EXT`, mirroring `references_import_data`.
- **One classification rule in the win64 module.** An `is_ext` boundary fact is threaded through the shared `ArgPassingFn` (the same neutral-substrate pattern `is_vector` used); only win64's `classify_arg` consumes it. `ext`-ness is **not** baked into `IRT_FN` type identity — the callee's `is_import` is read at the call site.
- **Distinct placement class, so rv64 is untouched.** A win64 ext vector is `CLASS_VEC_BYREF` / `CLASS_VEC_STACK_BYREF` — a *register-resident value* passed by reference, so the caller must spill it to an aligned temp before its address exists. This is deliberately distinct from `CLASS_BYREF`: a scalarized rv64 (lp64) vector is already memory-resident (its operand IS a pointer) and stays `CLASS_BYREF`. Reusing `CLASS_BYREF` would have corrupted rv64's existing vector lowering.
- The variadic tail follows the same rule (MS passes `__m128` varargs by reference too). `lower_params`/`lower_ret` pass `is_ext=false`: a compiled mach function is never itself `ext`.

### Verification (from-source compiler on this branch, never the PATH seed)

_Rebased onto current `dev` (v3.5.0, carrying #2083/#2084/#2088/#2089) and re-verified end to end. The rebase composes cleanly with #2089's new `AbiVTable.fp_callee_saved_full_vector` — an orthogonal callee-saved-width field on the vtable rec / registration sites, distinct from this PR's `ArgPassingFn` threading._

- **Full `mach test`:** 656/656 pass (adds a win64 classifier test for the register, later-slot, and exhausted cases, plus a vector-return XMM0 conformance test).
- **`mach test --target windows-x86_64` under wine:** 656/656 pass (includes the vector-runtime lane-exactness tests executed under wine).
- **Structural conformance (disasm of an `ext` vector call, 5 vector args).** The internal call keeps XMM; the ext call marshals each vector by reference per MS x64:
  ```
  movups XMMWORD PTR [rbp-0x40], xmm0   ; store vector to 16-byte-aligned temp
  lea    rcx, [rbp-0x40]                ; arg0 address -> RCX
  movups XMMWORD PTR [rbp-0x60], xmm6
  lea    rdx, [rbp-0x60]                ; arg1 -> RDX
  ... -> R8, R9 ...
  movups XMMWORD PTR [rbp-0xc0], xmm0
  lea    rbx, [rbp-0xc0]
  mov    QWORD PTR [rsp+0x20], rbx      ; arg4 address spilled to stack (above shadow space)
  call   c_sink
  ```
  Temps are 16-byte aligned (rbp is 16-aligned on entry; offsets are multiples of 16); stores are genuine 128-bit `movups`. The internal `local_use` call uses `movaps xmm0/xmm1` (mach convention, unchanged).
- **Byte-identity (base compiler at the merge-base vs this branch, same fixed corpus):** object trees **byte-identical on all four targets** — `linux-x86_64`, `linux-arm64`, `linux-riscv64`, and `windows-x86_64` (a corpus with no ext-vector calls). A **vector-bearing** program (`vecext`, internal + ext vector calls) is likewise byte-identical on `linux-x86_64`, `linux-arm64`, and `linux-riscv64` — the direct proof that the distinct `CLASS_VEC_*` class leaves rv64's memory-resident vector lowering untouched.

### Honest limits

- **No true MSVC-compiled callee tested** (no MSVC toolchain locally). A *self-consistent* wine round-trip is inherently infeasible in mach's type system: the caller must see a vector signature (to trigger marshaling) while the callee reads a pointer, and aliasing one symbol to both signatures is rejected by the always-on call-arg-type verifier. The structural disasm above is the conformance proof.
- **riscv64 (lp64):** untouched *by construction* (it produces `CLASS_BYREF`/`CLASS_STACK_BYREF`; this PR's new branch keys only on the win64-only `CLASS_VEC_*` classes, and its classifier ignores `is_ext`) and **machine-confirmed**. Cross-building the compiler to riscv64 is a first-class path (rv64 self-host #1742, CI-proven under qemu #1852). On the rebased head the from-source x86_64 compiler cross-builds the **compiler itself for `linux-riscv64` (163 objects)** and the object tree is byte-identical to the base — as is the vector-bearing `vecext` program. (A cross-build against my *original* merge-base failed with an always-on call-arg verifier error; that was the since-fixed #2086 false-positive on scalarized vector call args, which predates #2088 — not this change and not an unsupported path.)
- Function *pointers* are bare `ptr` in today's IR, so an ext-typed function pointer cannot carry the rule (the recorded #2058 boundary). Direct `ext` calls — the actual C-interop surface — are covered.
- **Sequencing:** #2064 (dual same-name instance Function entries) has not yet merged to `dev`; this branch composes with its future in-place extern reuse (the `is_import` assignment at the `ext fun` decl is authoritative and independent of how `append_function` allocates the entry).
