### PR TITLE
fix(sema): fold imported pub val in type positions (#2081)

### DIFF
--- a/src/lang/driver.mach
+++ b/src/lang/driver.mach
@@ -6807,6 +6807,62 @@ test "mach.lang.driver:vector_negative_diagnostics" {
     ret bad;
 }
 
+# build a two-module project (main.mach + a.mach) from source, run resolve + sema,
+# and return the project so a test can inspect p.s.diags. the caller tears down the
+# project and session
+fun ut_sema2(s: *session.Session, alloc: *A.Allocator, main_src: str, a_src: str) R.Result[Project, str] {
+    var names: [2]str;
+    names[0] = "main.mach"; names[1] = "a.mach";
+    var texts: [2]str;
+    texts[0] = main_src; texts[1] = a_src;
+    val pr: R.Result[Project, str] = ut_build(s, alloc, ?names[0], ?texts[0], 2);
+    if (R.is_err[Project, str](pr)) { ret pr; }
+    var p: Project = R.unwrap_ok[Project, str](pr);
+    val se: R.Result[bool, str] = run_sema_pass(?p);
+    if (R.is_err[bool, str](se)) { dnit_project(?p); ret R.err[Project, str](R.unwrap_err[bool, str](se)); }
+    ret R.ok[Project, str](p);
+}
+
+# an imported `pub val` integer constant folds in a type position (an array length)
+# exactly as a local `val` does, so `[a.CAP]u8` compiles and sizes to the constant's
+# value; an imported `var` - not a comptime constant - is still rejected (#2081)
+test "mach.lang.driver:imported_pub_val_array_length" {
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    var bad: i32 = 0;
+
+    # positive: main uses a.CAP (a pub val = 16) as an array length. the 16-element
+    # `[16]u8` literal type-checks against the declared `[a.CAP]u8` only when the fold
+    # yields exactly 16, so a clean sema pass proves both that it folded and to what.
+    val sp: R.Result[session.Session, str] = session.init(?alloc);
+    if (R.is_err[session.Session, str](sp)) { ret 1; }
+    var sPos: session.Session = R.unwrap_ok[session.Session, str](sp);
+    val ppr: R.Result[Project, str] = ut_sema2(?sPos, ?alloc,
+        "use a: uniontest.a;\nfun main() i32 {\n    var buf: [a.CAP]u8 = [16]u8{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};\n    ret buf[15]::i32;\n}\n",
+        "pub val CAP: u64 = 16;\n");
+    if (R.is_err[Project, str](ppr)) { session.dnit(?sPos); ret 1; }
+    var pPos: Project = R.unwrap_ok[Project, str](ppr);
+    if (ut_count_errors(?pPos.s.diags) != 0) { bad = 1; }
+    dnit_project(?pPos);
+    session.dnit(?sPos);
+
+    # negative: an imported `var` is not a comptime constant, so the same array-length
+    # position is still rejected with the existing diagnostic.
+    val sn: R.Result[session.Session, str] = session.init(?alloc);
+    if (R.is_err[session.Session, str](sn)) { ret 1; }
+    var sNeg: session.Session = R.unwrap_ok[session.Session, str](sn);
+    val npr: R.Result[Project, str] = ut_sema2(?sNeg, ?alloc,
+        "use a: uniontest.a;\nfun main() i32 {\n    var buf: [a.CAP]u8;\n    ret 0;\n}\n",
+        "pub var CAP: u64 = 16;\n");
+    if (R.is_err[Project, str](npr)) { session.dnit(?sNeg); ret 1; }
+    var pNeg: Project = R.unwrap_ok[Project, str](npr);
+    if (!ut_diag_has(?pNeg.s.diags, "array length is not a comptime constant")) { bad = 1; }
+    dnit_project(?pNeg);
+    session.dnit(?sNeg);
+
+    ret bad;
+}
+
 # a two-char decimal string ("00".."99") for n < 100, owned by `alloc`.
 # names the per-leaf modules of the realloc-mid-walk fixture below
 fun ut_idx2(alloc: *A.Allocator, n: u32) str {

--- a/src/lang/fe/sema.mach
+++ b/src/lang/fe/sema.mach
@@ -100,7 +100,18 @@ pub fun sema(
         ret R.err[context.SemaResult, str](R.unwrap_err[bool, str](res_init));
     }
 
+    # install the module-member resolver so `comptime.eval` can fold an imported
+    # `pub val` referenced in a type position - an array length like `[a.CAP]u8` -
+    # exactly as a local `val` folds (#2081). every syntactic type node, including a
+    # function-body-local var's, is resolved here in source order, so this pass is the
+    # single authoritative site for type-position comptime evaluation; expression
+    # positions in bodies stay unresolved at sema and fold against the lowering-
+    # installed resolver instead. cleared after so the borrowed ctx never keeps a
+    # dangling `sc` pointer.
+    val scp_types: *context.SemaContext = ?sc;
+    comptime.set_member_resolver(ctx, context.resolve_module_member_const::*u8, scp_types::ptr);
     val res_types: R.Result[bool, str] = resolve_all_types(?sc);
+    comptime.set_member_resolver(ctx, nil, nil);
     if (R.is_err[bool, str](res_types)) {
         dnit_context(?sc);
         ret R.err[context.SemaResult, str](R.unwrap_err[bool, str](res_types));

--- a/src/lang/fe/sema/context.mach
+++ b/src/lang/fe/sema/context.mach
@@ -418,6 +418,47 @@ pub fun resolve_type_comparison_operand(data: ptr, eid: id.ExprId) R.Result[O.Op
     ret R.ok[O.Option[u32], str](O.some[u32](t::u32));
 }
 
+# the module-qualified member resolver (a comptime.ModuleMemberFn) sema installs on
+# the ComptimeCtx while resolving type positions, so `comptime.eval` can fold an
+# imported `pub val` referenced as an array length (`[a.CAP]u8`) exactly as a local
+# `val` folds (#2081). given a MEMBER expression it reads name resolution for the
+# member's symbol; when that symbol imports a constant from another module it
+# returns the constant's pre-folded value from the declaring module's ComptimeCtx.
+# none for anything else (a function, a `var`, a non-constant `val`, an unexported /
+# unknown member): the declaring module's ctx holds exactly its module-level comptime
+# vals, so a lookup miss there is the scope guard, and comptime.eval turns the none
+# into a loud "not a module-level constant". mirrors the lowering-installed resolver
+# (resolve_module_member_const in me.lower.context) so a type position folds
+# identically before and after lowering. topo order guarantees the origin module's
+# ctx is registered by the time a dependent's types resolve.
+# ---
+# data: the *SemaContext, erased to a ptr by the installer
+# eid:  the MEMBER expression id, valid in this module's ast
+# ret:  some(value) when the member names an imported module-level constant, else none
+pub fun resolve_module_member_const(data: ptr, eid: id.ExprId) R.Result[O.Option[comptime.CTValue], str] {
+    val sc: *SemaContext = data::*SemaContext;
+    if (sc == nil) { ret R.ok[O.Option[comptime.CTValue], str](O.none[comptime.CTValue]()); }
+    val rr: *resolve.ResolveResult = sc.rr;
+    if (rr == nil || rr.expr_resolved == nil || eid::u32 >= rr.expr_count) {
+        ret R.ok[O.Option[comptime.CTValue], str](O.none[comptime.CTValue]());
+    }
+    val sid: resolve.SymbolId = rr.expr_resolved[eid];
+    if (sid == resolve.SYMBOL_NIL || sid::u32 >= rr.symbol_count) {
+        ret R.ok[O.Option[comptime.CTValue], str](O.none[comptime.CTValue]());
+    }
+    val sym: *resolve.Symbol = ?rr.symbols[sid];
+    if (sym.kind != resolve.SYM_IMPORTED) {
+        ret R.ok[O.Option[comptime.CTValue], str](O.none[comptime.CTValue]());
+    }
+    val octx: *comptime.ComptimeCtx = (session.module_comptime_ptr(sc.s, sym.origin))::*comptime.ComptimeCtx;
+    if (octx == nil) { ret R.ok[O.Option[comptime.CTValue], str](O.none[comptime.CTValue]()); }
+    val nc: O.Option[*comptime.NamedConst] = comptime.lookup(octx, sym.name);
+    if (O.is_none[*comptime.NamedConst](nc)) {
+        ret R.ok[O.Option[comptime.CTValue], str](O.none[comptime.CTValue]());
+    }
+    ret R.ok[O.Option[comptime.CTValue], str](O.some[comptime.CTValue](O.unwrap[*comptime.NamedConst](nc).value));
+}
+
 # the declared type of a SYM_PARAM, read from the enclosing function's parameter
 # list at `sym.slot`
 #


### PR DESCRIPTION
Fixes #2081.

## Root cause

An imported `pub val` integer constant used as an array length (`var buf: [a.CAP]u8;`) was rejected while an identical local `val` compiled.

Array lengths — and every syntactic type node, including function-body-local ones — are resolved in sema's `resolve_all_types` pass, which evaluates the length through `comptime.eval`. That pass never installed the module-member resolver (`member_fn`): only lowering wired it up. So a cross-module `alias.CONST` reference in a type position could not be folded to its comptime value and `resolve_type_array` reported "array length is not a comptime constant". A local `val` works because it is bound by name into the module's comptime ctx during load.

## Fix

Wire a sema-side module-member resolver into the comptime context used for type positions:

- `sema/context.mach`: add `resolve_module_member_const`, mirroring the lowering-installed resolver but reading the `*SemaContext` (`sc.rr`, `sc.s`). It resolves the MEMBER symbol, and for an imported module-level constant returns the pre-folded value from the declaring module's ComptimeCtx. A miss (function, `var`, non-constant `val`, unexported/unknown member) returns none, which `comptime.eval` turns into the existing loud diagnostic.
- `sema.mach`: install the resolver on `ctx` around `resolve_all_types` only, and clear it after. That pass is the single authoritative site for type-position comptime evaluation; expression positions in bodies stay unresolved at sema and continue to fold against the lowering-installed resolver, so expression-position comptime semantics are unchanged.

Topo order guarantees the origin module's comptime ctx is registered by the time a dependent's types resolve, so the fold produces exactly the value lowering would — identical before and after lowering.

## Tests

Colocated two-module sema test: an imported `pub val` used as an array length type-checks to an array of the right size; the negative (imported `var`, non-comptime initializer) is still rejected with the existing diagnostic.
