### PR TITLE
feat(manifest): step template target-tuple vars + MACH_TARGET env injection (#1964)

### DIFF
--- a/doc/manifest.md
+++ b/doc/manifest.md
@@ -88,7 +88,7 @@ ref = "branch/main"
 | `id`      | string | Root segment of every module path the project exposes: a file at `<src>/foo/bar.mach` is reachable as `<id>.foo.bar`. Must be a plain identifier — letters, digits, `_`, `-` — since it names the dependency store and keys step stamp files. Read by `$project.id`. |
 | `version` | string | Project version. Read by `$project.version`; the source of truth a Go-style `tag/<version>` acquisition checks. |
 | `src`     | string | Source root, project-root-relative. Module paths resolve under it. |
-| `out`     | string | The output-path template root, referenced as `{project.out}` by artifact `out`, step paths, and `cmd`s. Expanded over `{target.name}`/`{profile.name}` (see [Path templates](#path-templates)). |
+| `out`     | string | The output-path template root, referenced as `{project.out}` by artifact `out`, step paths, and `cmd`s. Expanded over `{target.name}`/`{target.isa}`/`{target.os}`/`{target.abi}`/`{profile.name}` (see [Path templates](#path-templates)). |
 
 `[project]` is exactly these four keys; `name`, `description`, and any other key
 are unknown-key errors in a root manifest.
@@ -261,6 +261,13 @@ outputs still exist is skipped; change an input or the command and it re-runs.
 consumer's output tree — exactly as a dependency's compiled modules do — and the
 dependency's own checkout is never written to.
 
+**Target environment.** Every step process additionally inherits the active
+build cell's target tuple as `MACH_TARGET_ISA`, `MACH_TARGET_OS`, and
+`MACH_TARGET_ABI`, so a `cmd` or the script it invokes can branch on the target
+without threading it through the template — e.g. `cc --target=$MACH_TARGET_ISA-…`.
+The same three values are available in the `cmd` template as the `{target.*}` keys
+(see [Path templates](#path-templates)).
+
 ## `[dep.<alias>]`
 
 Each `<alias>` names a dependency materialised under `dep/<alias>/`. The build
@@ -297,12 +304,18 @@ entries demand. Nothing else in a dependency's manifest applies to consumers.
 
 ## Path templates
 
-Paths and `cmd`s expand over a closed, final set of three variables:
+Paths and `cmd`s expand over a closed, final set of six variables:
 
 - `{project.out}` — the **root** project's expanded `[project].out`, in every
   manifest of the closure.
 - `{target.name}` — the resolved target name (never the literal `native`).
+- `{target.isa}` — the resolved target's `isa` (e.g. `x86_64`).
+- `{target.os}` — the resolved target's `os` (e.g. `linux`).
+- `{target.abi}` — the resolved target's `abi` (e.g. `sysv64`).
 - `{profile.name}` — the selected profile name.
+
+The three `{target.*}` tuple keys are also exported to every step process as
+`MACH_TARGET_ISA`/`MACH_TARGET_OS`/`MACH_TARGET_ABI` (see [build steps](#stepname--build-steps)).
 
 An artifact's `out` is relative to the expanded project `out` and is rooted there
 automatically — write `bin/demo`, not `{project.out}/bin/demo`. Step `out` lists

--- a/src/lang/driver.mach
+++ b/src/lang/driver.mach
@@ -1567,14 +1567,16 @@ fun load_config(p: *Project, project_root: str, t: *toml.Table, sel: *manifest.S
     }
     val bu: manifest.BuildUnit = R.unwrap_ok[manifest.BuildUnit, str](ur);
 
+    # the closed template-variable set for this build cell (#1964): the target tuple
+    # and profile every {target.*}/{profile.name} path and cmd expands against.
+    var cell_v: manifest.TmplVars = manifest.tmpl_vars_of(?p.s.interner, bu.target,
+        O.unwrap[str](intern.lookup(?p.s.interner, bu.profile_name)));
+
     # honest collision guard over every artifact for the selected target/profile.
-    val pn_opt: O.Option[str] = intern.lookup(?p.s.interner, bu.profile_name);
-    if (O.is_some[str](pn_opt)) {
-        val cr: R.Result[bool, str] = manifest.check_collisions(p.s.alloc, ?p.s.interner, ?m, bu.target, O.unwrap[str](pn_opt));
-        if (R.is_err[bool, str](cr)) {
-            manifest.dnit(?m, p.s.alloc);
-            ret R.err[bool, str](R.unwrap_err[bool, str](cr));
-        }
+    val cr: R.Result[bool, str] = manifest.check_collisions(p.s.alloc, ?p.s.interner, ?m, ?cell_v);
+    if (R.is_err[bool, str](cr)) {
+        manifest.dnit(?m, p.s.alloc);
+        ret R.err[bool, str](R.unwrap_err[bool, str](cr));
     }
 
     if (bu.warned) { emit_native_warning(p, bu.target_name); }
@@ -1631,10 +1633,8 @@ fun load_config(p: *Project, project_root: str, t: *toml.Table, sel: *manifest.S
     p.config.step_order       = nil;
     p.config.step_order_count = 0;
 
-    val tn_s: str = O.unwrap[str](intern.lookup(?p.s.interner, bu.target.name));
-    val pn_s: str = O.unwrap[str](intern.lookup(?p.s.interner, bu.profile_name));
     val out_tmpl_s: str = O.unwrap[str](intern.lookup(?p.s.interner, m.out_tmpl));
-    val res_project_out_str: R.Result[str, str] = manifest.expand(p.s.alloc, out_tmpl_s, "", tn_s, pn_s);
+    val res_project_out_str: R.Result[str, str] = manifest.expand(p.s.alloc, out_tmpl_s, "", ?cell_v);
     if (R.is_ok[str, str](res_project_out_str)) {
         val project_out_str: str = R.unwrap_ok[str, str](res_project_out_str);
         val res_po_id: R.Result[intern.StrId, str] = intern.intern(?p.s.interner, project_out_str);
@@ -1644,7 +1644,7 @@ fun load_config(p: *Project, project_root: str, t: *toml.Table, sel: *manifest.S
         # up-front local link path validation (#1969): a `local` entry's path must
         # match a step's `out` (demanding it) or exist on disk; anything else errors
         # here naming the entry, instead of flowing to the linker to fail at link time.
-        val vr: R.Result[bool, str] = validate_local_links(p, project_root, ?m, bu.target, project_out_str, tn_s, pn_s);
+        val vr: R.Result[bool, str] = validate_local_links(p, project_root, ?m, bu.target, project_out_str, ?cell_v);
         if (R.is_err[bool, str](vr)) { str_free(p.s.alloc, project_out_str); manifest.dnit(?m, p.s.alloc); ret R.err[bool, str](R.unwrap_err[bool, str](vr)); }
 
         # `mach test` links the union of every artifact's referenced entries (native
@@ -1653,7 +1653,7 @@ fun load_config(p: *Project, project_root: str, t: *toml.Table, sel: *manifest.S
         if (is_test) {
             var test_items: *intern.StrId = nil;
             var test_count: u32 = 0;
-            val tlr: R.Result[bool, str] = manifest.resolve_test_libs(p.s.alloc, ?p.s.interner, ?m, bu.target, project_out_str, tn_s, pn_s, ?test_items, ?test_count);
+            val tlr: R.Result[bool, str] = manifest.resolve_test_libs(p.s.alloc, ?p.s.interner, ?m, bu.target, project_out_str, ?cell_v, ?test_items, ?test_count);
             if (R.is_err[bool, str](tlr)) { str_free(p.s.alloc, project_out_str); manifest.dnit(?m, p.s.alloc); ret R.err[bool, str](R.unwrap_err[bool, str](tlr)); }
             p.config.targets[0].libs      = test_items;
             p.config.targets[0].lib_count = test_count;
@@ -1661,7 +1661,7 @@ fun load_config(p: *Project, project_root: str, t: *toml.Table, sel: *manifest.S
 
         # compute which steps this build demands, in run order (#1970). indices are
         # into m.steps, which p.config.steps mirrors 1:1 when copied below.
-        val spr: R.Result[bool, str] = compute_step_plan(p, ?m, ?bu, is_test, for_union, project_out_str, tn_s, pn_s);
+        val spr: R.Result[bool, str] = compute_step_plan(p, ?m, ?bu, is_test, for_union, project_out_str, ?cell_v);
         if (R.is_err[bool, str](spr)) { str_free(p.s.alloc, project_out_str); manifest.dnit(?m, p.s.alloc); ret R.err[bool, str](R.unwrap_err[bool, str](spr)); }
         str_free(p.s.alloc, project_out_str);
     }
@@ -1977,10 +1977,9 @@ fun local_link_error(alloc: *A.Allocator, name: str, path: str) str {
 # is_test:  a `mach test` link (union of all artifacts)
 # for_union: a multi-artifact union build
 # proj_out: the expanded project out the entry paths and step outs home against
-# tn:       the target name for template expansion
-# pn:       the profile name for template expansion
+# v:        the target/profile template variables for path expansion
 fun compute_step_plan(p: *Project, m: *manifest.Manifest, bu: *manifest.BuildUnit,
-                      is_test: bool, for_union: bool, proj_out: str, tn: str, pn: str) R.Result[bool, str] {
+                      is_test: bool, for_union: bool, proj_out: str, v: *manifest.TmplVars) R.Result[bool, str] {
     p.config.step_order       = nil;
     p.config.step_order_count = 0;
     if (m.step_count == 0) { ret R.ok[bool, str](true); }
@@ -2005,7 +2004,7 @@ fun compute_step_plan(p: *Project, m: *manifest.Manifest, bu: *manifest.BuildUni
 
     var order: *u32 = nil;
     var count: u32  = 0;
-    val r: R.Result[bool, str] = manifest.plan_steps(p.s.alloc, ?p.s.interner, m, names, ncount, bu.target, proj_out, tn, pn, ?order, ?count);
+    val r: R.Result[bool, str] = manifest.plan_steps(p.s.alloc, ?p.s.interner, m, names, ncount, bu.target, proj_out, v, ?order, ?count);
     if (owned) { A.deallocate[intern.StrId](p.s.alloc, names, m.artifact_count::usize); }
     if (R.is_err[bool, str](r)) { ret r; }
     p.config.step_order       = order;
@@ -2017,7 +2016,7 @@ fun compute_step_plan(p: *Project, m: *manifest.Manifest, bu: *manifest.BuildUni
 # step's `out` (which will produce it) or already exist on disk, else an error names
 # the entry here rather than failing at link time. paths expand against the build
 # cell; the disk check resolves relative to the project root.
-fun validate_local_links(p: *Project, project_root: str, m: *manifest.Manifest, t: *manifest.TargetDef, proj_out: str, tn: str, pn: str) R.Result[bool, str] {
+fun validate_local_links(p: *Project, project_root: str, m: *manifest.Manifest, t: *manifest.TargetDef, proj_out: str, v: *manifest.TmplVars) R.Result[bool, str] {
     val local_r: R.Result[intern.StrId, str] = intern.intern(?p.s.interner, "local");
     if (R.is_err[intern.StrId, str](local_r)) { ret R.err[bool, str](R.unwrap_err[intern.StrId, str](local_r)); }
     val local_id: intern.StrId = R.unwrap_ok[intern.StrId, str](local_r);
@@ -2035,11 +2034,11 @@ fun validate_local_links(p: *Project, project_root: str, m: *manifest.Manifest, 
             val raw_path: str = O.unwrap[str](path_opt);
             val ename:    str = O.unwrap[str](name_opt);
 
-            val exp_r: R.Result[str, str] = manifest.expand(p.s.alloc, raw_path, proj_out, tn, pn);
+            val exp_r: R.Result[str, str] = manifest.expand(p.s.alloc, raw_path, proj_out, v);
             if (R.is_err[str, str](exp_r)) { ret R.err[bool, str](R.unwrap_err[str, str](exp_r)); }
             val exp: str = R.unwrap_ok[str, str](exp_r);
 
-            var ok_: bool = manifest.local_path_demanded_by_step(p.s.alloc, ?p.s.interner, m, exp, proj_out, tn, pn);
+            var ok_: bool = manifest.local_path_demanded_by_step(p.s.alloc, ?p.s.interner, m, exp, proj_out, v);
             if (!ok_) {
                 val abs_r: R.Result[str, str] = join_path(p.s.alloc, project_root, exp);
                 if (R.is_ok[str, str](abs_r)) {
@@ -2449,9 +2448,8 @@ fun resolve_cascade_libs(p: *Project, project_root: str, isa: str, os: str, abi:
                     val p_opt: O.Option[str] = intern.lookup(?p.s.interner, l.path);
                     if (O.is_some[str](p_opt)) {
                         val root_out: str = O.unwrap[str](intern.lookup(?p.s.interner, p.config.project_out));
-                        val tn2: str = O.unwrap[str](intern.lookup(?p.s.interner, p.target_entry.name));
-                        val pn2: str = O.unwrap[str](intern.lookup(?p.s.interner, p.config.profile));
-                        val exp_r: R.Result[str, str] = manifest.expand(p.s.alloc, O.unwrap[str](p_opt), root_out, tn2, pn2);
+                        var cv: manifest.TmplVars = cell_tmpl_vars(p);
+                        val exp_r: R.Result[str, str] = manifest.expand(p.s.alloc, O.unwrap[str](p_opt), root_out, ?cv);
                         if (R.is_ok[str, str](exp_r)) {
                             val exp: str = R.unwrap_ok[str, str](exp_r);
                             lib_id = R.unwrap_ok[intern.StrId, str](intern.intern(?p.s.interner, exp));
@@ -9933,16 +9931,27 @@ fun glob_expand_pattern(alloc: *A.Allocator, project_root: str, pattern: str, ou
     ret gr;
 }
 
+# the closed template-variable set for the active build cell (#1964): the target
+# tuple (name/isa/os/abi) and profile a step path or cmd expands against.
+fun cell_tmpl_vars(p: *Project) manifest.TmplVars {
+    var v: manifest.TmplVars;
+    v.target  = O.unwrap[str](intern.lookup(?p.s.interner, p.target_entry.name));
+    v.isa     = O.unwrap[str](intern.lookup(?p.s.interner, p.target_entry.isa_name));
+    v.os      = O.unwrap[str](intern.lookup(?p.s.interner, p.target_entry.os_name));
+    v.abi     = O.unwrap[str](intern.lookup(?p.s.interner, p.target_entry.abi_name));
+    v.profile = O.unwrap[str](intern.lookup(?p.s.interner, p.config.profile));
+    ret v;
+}
+
 # expand a step's `in` list into concrete input files (templates then globs), sorted
 # for a stable order (#1970). a `*`/`**` pattern expands against `project_root` and an
 # empty match is a hard error; a plain path is taken literally. `out` receives owned
 # path strings the caller frees.
 fun collect_step_inputs(alloc: *A.Allocator, p: *Project, step: *manifest.StepDef, project_root: str, home_out: str, out: *vector.Vector[str]) R.Result[bool, str] {
-    val profile_s: str = O.unwrap[str](intern.lookup(?p.s.interner, p.config.profile));
-    val target_name_s: str = O.unwrap[str](intern.lookup(?p.s.interner, p.target_entry.name));
+    var v: manifest.TmplVars = cell_tmpl_vars(p);
     var i: u32 = 0;
     for (i < step.in_count) {
-        val exp_r: R.Result[str, str] = manifest.expand(alloc, O.unwrap[str](intern.lookup(?p.s.interner, step.in[i])), home_out, target_name_s, profile_s);
+        val exp_r: R.Result[str, str] = manifest.expand(alloc, O.unwrap[str](intern.lookup(?p.s.interner, step.in[i])), home_out, ?v);
         if (R.is_err[str, str](exp_r)) { ret R.err[bool, str](R.unwrap_err[str, str](exp_r)); }
         val exp: str = R.unwrap_ok[str, str](exp_r);
         if (!has_glob(exp)) {
@@ -10066,11 +10075,10 @@ fun stamp_matches(a: *A.Allocator, path: str, hex: str) bool {
 
 # whether every declared output of `step` exists on disk (checked from `project_root`)
 fun step_outputs_exist(a: *A.Allocator, p: *Project, step: *manifest.StepDef, project_root: str, home_out: str) bool {
-    val profile_s: str = O.unwrap[str](intern.lookup(?p.s.interner, p.config.profile));
-    val target_name_s: str = O.unwrap[str](intern.lookup(?p.s.interner, p.target_entry.name));
+    var v: manifest.TmplVars = cell_tmpl_vars(p);
     var oi: u32 = 0;
     for (oi < step.out_count) {
-        val out_r: R.Result[str, str] = manifest.expand(a, O.unwrap[str](intern.lookup(?p.s.interner, step.out[oi])), home_out, target_name_s, profile_s);
+        val out_r: R.Result[str, str] = manifest.expand(a, O.unwrap[str](intern.lookup(?p.s.interner, step.out[oi])), home_out, ?v);
         if (R.is_err[str, str](out_r)) { ret false; }
         val out_s: str = R.unwrap_ok[str, str](out_r);
         val abs_r: R.Result[str, str] = join_path(a, project_root, out_s);
@@ -10112,11 +10120,10 @@ fun parent_dir(a: *A.Allocator, path: str) str {
 fun step_make_output_dirs(a: *A.Allocator, p: *Project, step: *manifest.StepDef) R.Result[bool, str] {
     val root_out: str = O.unwrap[str](intern.lookup(?p.s.interner, p.config.project_out));
     val root_project: str = O.unwrap[str](intern.lookup(?p.s.interner, p.config.project_root));
-    val profile_s: str = O.unwrap[str](intern.lookup(?p.s.interner, p.config.profile));
-    val target_name_s: str = O.unwrap[str](intern.lookup(?p.s.interner, p.target_entry.name));
+    var v: manifest.TmplVars = cell_tmpl_vars(p);
     var oi: u32 = 0;
     for (oi < step.out_count) {
-        val out_r: R.Result[str, str] = manifest.expand(a, O.unwrap[str](intern.lookup(?p.s.interner, step.out[oi])), root_out, target_name_s, profile_s);
+        val out_r: R.Result[str, str] = manifest.expand(a, O.unwrap[str](intern.lookup(?p.s.interner, step.out[oi])), root_out, ?v);
         if (R.is_err[str, str](out_r)) { ret R.err[bool, str](R.unwrap_err[str, str](out_r)); }
         val out_s: str = R.unwrap_ok[str, str](out_r);
         val rel_dir: str = parent_dir(a, out_s);
@@ -10136,26 +10143,54 @@ fun step_make_output_dirs(a: *A.Allocator, p: *Project, step: *manifest.StepDef)
     ret R.ok[bool, str](true);
 }
 
+# the step process environment: the inherited environment plus three appended
+# "MACH_TARGET_*=..." cstrings (#1964). the three strings are owned by the caller; only
+# the returned array is allocated here (freed by step_env_free). nil on allocation
+# failure.
+fun step_env(a: *A.Allocator, isa_env: str, os_env: str, abi_env: str) **u8 {
+    val base: **u8 = sysos.environ();
+    var n: usize = 0;
+    for (base[n] != nil) { n = n + 1; }
+    val rb: R.Result[**u8, str] = A.allocate[*u8](a, n + 4);
+    if (R.is_err[**u8, str](rb)) { ret nil; }
+    val env: **u8 = R.unwrap_ok[**u8, str](rb);
+    var i: usize = 0;
+    for (i < n) { env[i] = base[i]; i = i + 1; }
+    env[n]     = isa_env::*u8;
+    env[n + 1] = os_env::*u8;
+    env[n + 2] = abi_env::*u8;
+    env[n + 3] = nil;
+    ret env;
+}
+
+# free the array step_env allocated (not the inherited entries, which the runtime owns,
+# nor the three appended cstrings, which the caller frees)
+fun step_env_free(a: *A.Allocator, env: **u8) {
+    var n: usize = 0;
+    for (env[n] != nil) { n = n + 1; }
+    A.deallocate[*u8](a, env, (n + 1)::usize);
+}
+
 # run one step from `project_root` (its shell CWD), homing `{project.out}` to
 # `home_out`. root steps home to the root out and run from the root; a dependency's
 # steps run from the dep checkout and home to a path that climbs back to the root out
 # (#1970), so `vendor/*` inputs resolve while outputs land in the consumer tree.
-# `owner_id` is the project id owning the step, keying its stamp file.
+# `owner_id` is the project id owning the step, keying its stamp file. the step process
+# inherits MACH_TARGET_ISA/OS/ABI for the active cell (#1964).
 fun run_one_step(a: *A.Allocator, p: *Project, step: *manifest.StepDef, project_root: str, home_out: str, owner_id: str) R.Result[bool, str] {
-    val profile_s: str = O.unwrap[str](intern.lookup(?p.s.interner, p.config.profile));
     val project_out_s: str = home_out;
-    val target_name_s: str = O.unwrap[str](intern.lookup(?p.s.interner, p.target_entry.name));
+    var v: manifest.TmplVars = cell_tmpl_vars(p);
     val step_name: str = O.unwrap[str](intern.lookup(?p.s.interner, step.name));
 
     # `in`/`out`/`cmd` home through the closed template set ({project.out},
-    # {target.name}, {profile.name}); an unknown `{a.b}` is a hard error and shell
-    # `$VAR` is left to the shell. `in` globs expand sorted against project_root (empty
-    # match errors).
+    # {target.name}, {target.isa}, {target.os}, {target.abi}, {profile.name}); an
+    # unknown `{a.b}` is a hard error and shell `$VAR` is left to the shell. `in` globs
+    # expand sorted against project_root (empty match errors).
     var ins: vector.Vector[str] = vector.init[str](a);
     val cir: R.Result[bool, str] = collect_step_inputs(a, p, step, project_root, home_out, ?ins);
     if (R.is_err[bool, str](cir)) { step_free_inputs(a, ?ins); ret R.err[bool, str](R.unwrap_err[bool, str](cir)); }
 
-    val cmd_r: R.Result[str, str] = manifest.expand(a, O.unwrap[str](intern.lookup(?p.s.interner, step.cmd)), project_out_s, target_name_s, profile_s);
+    val cmd_r: R.Result[str, str] = manifest.expand(a, O.unwrap[str](intern.lookup(?p.s.interner, step.cmd)), project_out_s, ?v);
     if (R.is_err[str, str](cmd_r)) { step_free_inputs(a, ?ins); ret R.err[bool, str](R.unwrap_err[str, str](cmd_r)); }
     val expanded_cmd: str = R.unwrap_ok[str, str](cmd_r);
 
@@ -10221,8 +10256,26 @@ fun run_one_step(a: *A.Allocator, p: *Project, step: *manifest.StepDef, project_
     argv[2] = full_cmd::*u8;
     argv[3] = nil;
 
-    val res_run: R.Result[exec.ExitStatus, str] = exec.run(shell_name::str, argv, sysos.environ());
+    # inject the active target tuple so a step's cmd/script can branch on it (#1964).
+    val isa_env: str = step_cc5(a, "MACH_TARGET_ISA=", v.isa, "", "", "");
+    val os_env:  str = step_cc5(a, "MACH_TARGET_OS=",  v.os,  "", "", "");
+    val abi_env: str = step_cc5(a, "MACH_TARGET_ABI=", v.abi, "", "", "");
+    val env: **u8 = step_env(a, isa_env, os_env, abi_env);
+    if (env == nil) {
+        str_free(a, isa_env); str_free(a, os_env); str_free(a, abi_env);
+        A.deallocate[*u8](a, argv, 4);
+        if (stampable) { str_free(a, hex); str_free(a, stamp_path); }
+        str_free(a, expanded_cmd);
+        str_free(a, full_cmd);
+        ret R.err[bool, str]("out of memory");
+    }
 
+    val res_run: R.Result[exec.ExitStatus, str] = exec.run(shell_name::str, argv, env);
+
+    step_env_free(a, env);
+    str_free(a, isa_env);
+    str_free(a, os_env);
+    str_free(a, abi_env);
     A.deallocate[*u8](a, argv, 4);
     str_free(a, expanded_cmd);
     str_free(a, full_cmd);
@@ -10330,8 +10383,7 @@ fun execute_dep_steps(p: *Project, isa: str, os: str, abi: str) R.Result[bool, s
 
     val root_out: str = O.unwrap[str](intern.lookup(?p.s.interner, p.config.project_out));
     val root_project: str = O.unwrap[str](intern.lookup(?p.s.interner, p.config.project_root));
-    val tn: str = O.unwrap[str](intern.lookup(?p.s.interner, p.target_entry.name));
-    val pn: str = O.unwrap[str](intern.lookup(?p.s.interner, p.config.profile));
+    var cv: manifest.TmplVars = cell_tmpl_vars(p);
 
     var i: u32 = 0;
     for (i < n) {
@@ -10354,7 +10406,7 @@ fun execute_dep_steps(p: *Project, isa: str, os: str, abi: str) R.Result[bool, s
 
         var dep_order: *u32 = nil;
         var dep_count: u32  = 0;
-        val dpr: R.Result[bool, str] = manifest.plan_export_steps(p.s.alloc, ?p.s.interner, ?mfd, ?tgt, root_out, tn, pn, ?dep_order, ?dep_count);
+        val dpr: R.Result[bool, str] = manifest.plan_export_steps(p.s.alloc, ?p.s.interner, ?mfd, ?tgt, root_out, ?cv, ?dep_order, ?dep_count);
         if (R.is_err[bool, str](dpr)) { manifest.dnit(?mfd, p.s.alloc); ret dpr; }
 
         if (dep_count > 0) {

--- a/src/lang/manifest.mach
+++ b/src/lang/manifest.mach
@@ -192,6 +192,17 @@ pub rec ResolvedProfile {
     simd:     SimdMode;
 }
 
+# the values a path/command template expands its target/profile variables against
+# (#1964): the active build cell's identity. {project.out} is passed to expand
+# separately since it varies by what a template homes against.
+pub rec TmplVars {
+    target:  str;   # {target.name}
+    isa:     str;   # {target.isa}
+    os:      str;   # {target.os}
+    abi:     str;   # {target.abi}
+    profile: str;   # {profile.name}
+}
+
 rec StrArr {
     items:   *intern.StrId;
     count:   u32;
@@ -1125,23 +1136,38 @@ fun seg_dup(alloc: *A.Allocator, tmpl: str, start: usize, end: usize) str {
 }
 
 # the #1964 template variable set is closed and final: {project.out}, {target.name},
-# {profile.name}. no {name}/{ext} or bare {target}/{profile} aliases -- an executable
-# extension is written literally into the artifact's out, per the RFC.
+# {target.isa}, {target.os}, {target.abi}, {profile.name}. no {name}/{ext} or bare
+# {target}/{profile} aliases -- an executable extension is written literally into the
+# artifact's out, per the RFC.
 fun tmpl_value(alloc: *A.Allocator, tmpl: str, start: usize, end: usize, project_out: str,
-               target_name: str, profile_name: str) R.Result[str, str] {
+               v: *TmplVars) R.Result[str, str] {
     if (seg_eq(tmpl, start, end, "project.out")) {
         # available everywhere except while expanding [project].out itself, where it
         # would be self-referential (project_out is passed empty there).
         if (str_empty(project_out)) { ret R.err[str, str]("mach.toml: '{project.out}' is not available in [project].out"); }
         ret R.ok[str, str](project_out);
     }
-    if (seg_eq(tmpl, start, end, "target.name"))  { ret R.ok[str, str](target_name); }
-    if (seg_eq(tmpl, start, end, "profile.name")) { ret R.ok[str, str](profile_name); }
+    if (seg_eq(tmpl, start, end, "target.name"))  { ret R.ok[str, str](v.target); }
+    if (seg_eq(tmpl, start, end, "target.isa"))   { ret R.ok[str, str](v.isa); }
+    if (seg_eq(tmpl, start, end, "target.os"))    { ret R.ok[str, str](v.os); }
+    if (seg_eq(tmpl, start, end, "target.abi"))   { ret R.ok[str, str](v.abi); }
+    if (seg_eq(tmpl, start, end, "profile.name")) { ret R.ok[str, str](v.profile); }
     ret R.err[str, str](cc3(alloc, "mach.toml: unknown template variable '{", seg_dup(alloc, tmpl, start, end), "}'"));
 }
 
+# the template variables target `t` under profile `pn` expands against (#1964)
+pub fun tmpl_vars_of(itn: *intern.Interner, t: *TargetDef, pn: str) TmplVars {
+    var v: TmplVars;
+    v.target  = idstr(itn, t.name);
+    v.isa     = idstr(itn, t.isa);
+    v.os      = idstr(itn, t.os);
+    v.abi     = idstr(itn, t.abi);
+    v.profile = pn;
+    ret v;
+}
+
 pub fun expand(alloc: *A.Allocator, tmpl: str, project_out: str,
-               target_name: str, profile_name: str) R.Result[str, str] {
+               v: *TmplVars) R.Result[str, str] {
     val n: usize = str_len(tmpl);
     var total: usize = 0;
     var i: usize = 0;
@@ -1150,7 +1176,7 @@ pub fun expand(alloc: *A.Allocator, tmpl: str, project_out: str,
             var ii: usize = i + 1;
             for (ii < n && tmpl[ii] != '}') { ii = ii + 1; }
             if (ii >= n) { ret R.err[str, str]("mach.toml: unterminated '{' in a path template"); }
-            val res_value: R.Result[str, str] = tmpl_value(alloc, tmpl, i + 1, ii, project_out, target_name, profile_name);
+            val res_value: R.Result[str, str] = tmpl_value(alloc, tmpl, i + 1, ii, project_out, v);
             if (R.is_err[str, str](res_value)) { ret R.err[str, str](R.unwrap_err[str, str](res_value)); }
             total = total + str_len(R.unwrap_ok[str, str](res_value));
             i = ii + 1;
@@ -1171,7 +1197,7 @@ pub fun expand(alloc: *A.Allocator, tmpl: str, project_out: str,
         if (tmpl[i] == '{') {
             var ii: usize = i + 1;
             for (ii < n && tmpl[ii] != '}') { ii = ii + 1; }
-            val res_value: R.Result[str, str] = tmpl_value(alloc, tmpl, i + 1, ii, project_out, target_name, profile_name);
+            val res_value: R.Result[str, str] = tmpl_value(alloc, tmpl, i + 1, ii, project_out, v);
             val value: str = R.unwrap_ok[str, str](res_value);
             val vl: usize = str_len(value);
             var iii: usize = 0;
@@ -1374,10 +1400,10 @@ fun join_path_canonical(alloc: *A.Allocator, a: str, b: str) str {
 # `local` source, or the library name for system/framework. filters are assumed
 # already matched; `{project.out}` and the target/profile templates in a local path
 # resolve against the given build cell.
-fun link_token(alloc: *A.Allocator, itn: *intern.Interner, l: *LinkDef, proj_out: str, tn: str, pn: str) R.Result[intern.StrId, str] {
+fun link_token(alloc: *A.Allocator, itn: *intern.Interner, l: *LinkDef, proj_out: str, v: *TmplVars) R.Result[intern.StrId, str] {
     if (l.source == intern_unwrap(itn, "local")) {
         val raw_path: str = idstr(itn, l.path);
-        val expanded_r: R.Result[str, str] = expand(alloc, raw_path, proj_out, tn, pn);
+        val expanded_r: R.Result[str, str] = expand(alloc, raw_path, proj_out, v);
         if (R.is_err[str, str](expanded_r)) { ret R.err[intern.StrId, str](R.unwrap_err[str, str](expanded_r)); }
         val expanded: str = R.unwrap_ok[str, str](expanded_r);
         val res_int: R.Result[intern.StrId, str] = intern.intern(itn, expanded);
@@ -1394,14 +1420,14 @@ fun link_token(alloc: *A.Allocator, itn: *intern.Interner, l: *LinkDef, proj_out
 # produces. `expanded_path` is already expanded; step outs are expanded here with
 # the same project out / target / profile.
 pub fun step_producing_out(alloc: *A.Allocator, itn: *intern.Interner, m: *Manifest,
-                           expanded_path: str, proj_out: str, tn: str, pn: str) i64 {
+                           expanded_path: str, proj_out: str, v: *TmplVars) i64 {
     var si: u32 = 0;
     for (si < m.step_count) {
         val s: *StepDef = ?m.steps[si];
         var oi: u32 = 0;
         for (oi < s.out_count) {
             val raw_out: str = idstr(itn, s.out[oi]);
-            val exp_r: R.Result[str, str] = expand(alloc, raw_out, proj_out, tn, pn);
+            val exp_r: R.Result[str, str] = expand(alloc, raw_out, proj_out, v);
             if (R.is_ok[str, str](exp_r)) {
                 val exp: str = R.unwrap_ok[str, str](exp_r);
                 val eq: bool = str_equals(exp, expanded_path);
@@ -1418,8 +1444,8 @@ pub fun step_producing_out(alloc: *A.Allocator, itn: *intern.Interner, m: *Manif
 # whether some declared step produces `expanded_path`, i.e. the local link entry
 # demands that step (see step_producing_out)
 pub fun local_path_demanded_by_step(alloc: *A.Allocator, itn: *intern.Interner, m: *Manifest,
-                                    expanded_path: str, proj_out: str, tn: str, pn: str) bool {
-    ret step_producing_out(alloc, itn, m, expanded_path, proj_out, tn, pn) >= 0;
+                                    expanded_path: str, proj_out: str, v: *TmplVars) bool {
+    ret step_producing_out(alloc, itn, m, expanded_path, proj_out, v) >= 0;
 }
 
 # the artifact declared as `name`, or nil
@@ -1487,13 +1513,12 @@ fun plan_visit(alloc: *A.Allocator, itn: *intern.Interner, m: *Manifest, idx: u3
 # art_count: number of entries in `art_names`
 # t:         the resolved build cell, for link-entry filtering
 # proj_out:  the expanded project out the entry paths and step outs home against
-# tn:        the target name for template expansion
-# pn:        the profile name for template expansion
+# v:         the target/profile template variables for path expansion
 # out_order: receives the owned ordered step-index array (nil when none)
 # out_count: receives the step count (0 when none)
 pub fun plan_steps(alloc: *A.Allocator, itn: *intern.Interner, m: *Manifest,
                    art_names: *intern.StrId, art_count: u32, t: *TargetDef,
-                   proj_out: str, tn: str, pn: str,
+                   proj_out: str, v: *TmplVars,
                    out_order: **u32, out_count: *u32) R.Result[bool, str] {
     @out_order = nil;
     @out_count = 0;
@@ -1519,10 +1544,10 @@ pub fun plan_steps(alloc: *A.Allocator, itn: *intern.Interner, m: *Manifest,
             for (li < a.link_count) {
                 val l: *LinkDef = find_link_by_name(m, a.link[li]);
                 if (l != nil && l.source == local_id && link_matches_target(itn, l, t)) {
-                    val exp_r: R.Result[str, str] = expand(alloc, idstr(itn, l.path), proj_out, tn, pn);
+                    val exp_r: R.Result[str, str] = expand(alloc, idstr(itn, l.path), proj_out, v);
                     if (R.is_ok[str, str](exp_r)) {
                         val exp: str = R.unwrap_ok[str, str](exp_r);
-                        val sidx: i64 = step_producing_out(alloc, itn, m, exp, proj_out, tn, pn);
+                        val sidx: i64 = step_producing_out(alloc, itn, m, exp, proj_out, v);
                         str_free(alloc, exp);
                         if (sidx >= 0) {
                             val vr: R.Result[bool, str] = plan_visit(alloc, itn, m, sidx::u32, state, order, ?order_len);
@@ -1567,12 +1592,11 @@ fun plan_free(alloc: *A.Allocator, state: *u8, order: *u32, n: u32) {
 # m:         the parsed dependency manifest
 # t:         the resolved build cell, for entry filtering
 # proj_out:  the root project's expanded out entry paths and step outs home against
-# tn:        the target name for template expansion
-# pn:        the profile name for template expansion
+# v:         the target/profile template variables for path expansion
 # out_order: receives the owned ordered step-index array (nil when none)
 # out_count: receives the step count (0 when none)
 pub fun plan_export_steps(alloc: *A.Allocator, itn: *intern.Interner, m: *Manifest,
-                          t: *TargetDef, proj_out: str, tn: str, pn: str,
+                          t: *TargetDef, proj_out: str, v: *TmplVars,
                           out_order: **u32, out_count: *u32) R.Result[bool, str] {
     @out_order = nil;
     @out_count = 0;
@@ -1594,10 +1618,10 @@ pub fun plan_export_steps(alloc: *A.Allocator, itn: *intern.Interner, m: *Manife
     for (li < m.link_count) {
         val l: *LinkDef = ?m.links[li];
         if (l.export && l.source == local_id && link_matches_target(itn, l, t)) {
-            val exp_r: R.Result[str, str] = expand(alloc, idstr(itn, l.path), proj_out, tn, pn);
+            val exp_r: R.Result[str, str] = expand(alloc, idstr(itn, l.path), proj_out, v);
             if (R.is_ok[str, str](exp_r)) {
                 val exp: str = R.unwrap_ok[str, str](exp_r);
-                val sidx: i64 = step_producing_out(alloc, itn, m, exp, proj_out, tn, pn);
+                val sidx: i64 = step_producing_out(alloc, itn, m, exp, proj_out, v);
                 str_free(alloc, exp);
                 if (sidx >= 0) {
                     val vr: R.Result[bool, str] = plan_visit(alloc, itn, m, sidx::u32, state, order, ?order_len);
@@ -1664,15 +1688,13 @@ pub fun resolve_build_unit(alloc: *A.Allocator, itn: *intern.Interner, m: *Manif
     u.defines      = nil;
     u.define_count = 0;
 
-    val res_target_name: R.Result[str, str] = must_lookup(itn, rt.target.name);
-    if (R.is_err[str, str](res_target_name)) { ret R.err[BuildUnit, str](R.unwrap_err[str, str](res_target_name)); }
     val res_profile_name: R.Result[str, str] = must_lookup(itn, rp.name);
     if (R.is_err[str, str](res_profile_name)) { ret R.err[BuildUnit, str](R.unwrap_err[str, str](res_profile_name)); }
-    val tn: str = R.unwrap_ok[str, str](res_target_name);
     val pn: str = R.unwrap_ok[str, str](res_profile_name);
+    var v: TmplVars = tmpl_vars_of(itn, rt.target, pn);
 
     # Expand project out
-    val res_project_out: R.Result[str, str] = expand(alloc, R.unwrap_ok[str, str](must_lookup(itn, m.out_tmpl)), "", tn, pn);
+    val res_project_out: R.Result[str, str] = expand(alloc, R.unwrap_ok[str, str](must_lookup(itn, m.out_tmpl)), "", ?v);
     if (R.is_err[str, str](res_project_out)) { ret R.err[BuildUnit, str](R.unwrap_err[str, str](res_project_out)); }
     val proj_out: str = R.unwrap_ok[str, str](res_project_out);
 
@@ -1698,7 +1720,7 @@ pub fun resolve_build_unit(alloc: *A.Allocator, itn: *intern.Interner, m: *Manif
             }
             if (found_l != nil) {
                 if (link_matches_target(itn, found_l, rt.target)) {
-                    val tok_r: R.Result[intern.StrId, str] = link_token(alloc, itn, found_l, proj_out, tn, pn);
+                    val tok_r: R.Result[intern.StrId, str] = link_token(alloc, itn, found_l, proj_out, ?v);
                     if (R.is_err[intern.StrId, str](tok_r)) { ret R.err[BuildUnit, str](R.unwrap_err[intern.StrId, str](tok_r)); }
                     matched_items[match_count] = R.unwrap_ok[intern.StrId, str](tok_r);
                     match_count = match_count + 1;
@@ -1734,7 +1756,7 @@ pub fun resolve_build_unit(alloc: *A.Allocator, itn: *intern.Interner, m: *Manif
 
     # Resolve artifact relative path
     val art_out_tmpl: intern.StrId = a.out;
-    val res_art_out: R.Result[str, str] = expand(alloc, R.unwrap_ok[str, str](must_lookup(itn, art_out_tmpl)), proj_out, tn, pn);
+    val res_art_out: R.Result[str, str] = expand(alloc, R.unwrap_ok[str, str](must_lookup(itn, art_out_tmpl)), proj_out, ?v);
     if (R.is_err[str, str](res_art_out)) { ret R.err[BuildUnit, str](R.unwrap_err[str, str](res_art_out)); }
     val art_out_rel: str = R.unwrap_ok[str, str](res_art_out);
 
@@ -1761,7 +1783,7 @@ fun strid_in_buf(buf: *intern.StrId, count: u32, id: intern.StrId) bool {
 # are added separately by the driver's cascade pass. on success `out_items` and
 # `out_count` receive the union (nil/0 when empty).
 pub fun resolve_test_libs(alloc: *A.Allocator, itn: *intern.Interner, m: *Manifest, t: *TargetDef,
-                          proj_out: str, tn: str, pn: str,
+                          proj_out: str, v: *TmplVars,
                           out_items: **intern.StrId, out_count: *u32) R.Result[bool, str] {
     @out_items = nil;
     @out_count = 0;
@@ -1790,7 +1812,7 @@ pub fun resolve_test_libs(alloc: *A.Allocator, itn: *intern.Interner, m: *Manife
             }
             if (found_l != nil) {
                 if (link_matches_target(itn, found_l, t)) {
-                    val tok_r: R.Result[intern.StrId, str] = link_token(alloc, itn, found_l, proj_out, tn, pn);
+                    val tok_r: R.Result[intern.StrId, str] = link_token(alloc, itn, found_l, proj_out, v);
                     if (R.is_err[intern.StrId, str](tok_r)) {
                         A.deallocate[intern.StrId](alloc, buf, max::usize);
                         ret R.err[bool, str](R.unwrap_err[intern.StrId, str](tok_r));
@@ -1845,19 +1867,15 @@ fun artifact_candidates(alloc: *A.Allocator, itn: *intern.Interner, m: *Manifest
 }
 
 pub fun check_collisions(alloc: *A.Allocator, itn: *intern.Interner, m: *Manifest,
-                         t: *TargetDef, profile_name: str) R.Result[bool, str] {
+                         v: *TmplVars) R.Result[bool, str] {
     if (m.artifact_count < 2) { ret R.ok[bool, str](true); }
-
-    val res_target_name: R.Result[str, str] = must_lookup(itn, t.name);
-    if (R.is_err[str, str](res_target_name)) { ret R.err[bool, str](R.unwrap_err[str, str](res_target_name)); }
-    val tn: str = R.unwrap_ok[str, str](res_target_name);
 
     val res_paths: R.Result[*str, str] = A.allocate[str](alloc, m.artifact_count::usize);
     if (R.is_err[*str, str](res_paths)) { ret R.err[bool, str](R.unwrap_err[*str, str](res_paths)); }
     val paths: *str = R.unwrap_ok[*str, str](res_paths);
 
     # Expand project out
-    val res_project_out: R.Result[str, str] = expand(alloc, R.unwrap_ok[str, str](must_lookup(itn, m.out_tmpl)), "", tn, profile_name);
+    val res_project_out: R.Result[str, str] = expand(alloc, R.unwrap_ok[str, str](must_lookup(itn, m.out_tmpl)), "", v);
     if (R.is_err[str, str](res_project_out)) { ret R.err[bool, str](R.unwrap_err[str, str](res_project_out)); }
     val proj_out: str = R.unwrap_ok[str, str](res_project_out);
 
@@ -1865,7 +1883,7 @@ pub fun check_collisions(alloc: *A.Allocator, itn: *intern.Interner, m: *Manifes
     for (i < m.artifact_count) {
         val a: *ArtifactDef = ?m.artifacts[i];
         val art_out_tmpl: intern.StrId = a.out;
-        val res_art_out: R.Result[str, str] = expand(alloc, R.unwrap_ok[str, str](must_lookup(itn, art_out_tmpl)), proj_out, tn, profile_name);
+        val res_art_out: R.Result[str, str] = expand(alloc, R.unwrap_ok[str, str](must_lookup(itn, art_out_tmpl)), proj_out, v);
         if (R.is_err[str, str](res_art_out)) { ret R.err[bool, str](R.unwrap_err[str, str](res_art_out)); }
         val art_out_rel: str = R.unwrap_ok[str, str](res_art_out);
         paths[i] = join_path_canonical(alloc, proj_out, art_out_rel);
@@ -1939,6 +1957,16 @@ fun mk_sel(target: str, profile: str, artifact: str, want_lib: bool, has_artifac
     s.want_lib     = want_lib;
     s.has_artifact = has_artifact;
     ret s;
+}
+
+fun mk_tv(target: str, isa: str, os: str, abi: str, profile: str) TmplVars {
+    var v: TmplVars;
+    v.target  = target;
+    v.isa     = isa;
+    v.os      = os;
+    v.abi     = abi;
+    v.profile = profile;
+    ret v;
 }
 
 fun tinit(backing: *A.Allocator, ar: *arena.Arena, alloc: *A.Allocator, itn: *intern.Interner) bool {
@@ -2292,7 +2320,8 @@ test "mach.lang.manifest.resolve_build_unit:collision_detection" {
     if (R.is_err[Manifest, str](res_manifest)) { code = 1; }
     or {
         var m: Manifest = R.unwrap_ok[Manifest, str](res_manifest);
-        val cr: R.Result[bool, str] = check_collisions(?alloc, ?itn, ?m, ?m.targets[0], "debug");
+        var v: TmplVars = tmpl_vars_of(?itn, ?m.targets[0], "debug");
+        val cr: R.Result[bool, str] = check_collisions(?alloc, ?itn, ?m, ?v);
         if (R.is_ok[bool, str](cr) || !str_equals(R.unwrap_err[bool, str](cr), "mach.toml: artifacts 'a' and 'b' collide on output path 'bin/app/app'")) { code = 1; }
     }
 
@@ -2300,7 +2329,8 @@ test "mach.lang.manifest.resolve_build_unit:collision_detection" {
     if (R.is_err[Manifest, str](res_clean)) { code = 1; }
     or {
         var m: Manifest = R.unwrap_ok[Manifest, str](res_clean);
-        val cr: R.Result[bool, str] = check_collisions(?alloc, ?itn, ?m, ?m.targets[0], "debug");
+        var v: TmplVars = tmpl_vars_of(?itn, ?m.targets[0], "debug");
+        val cr: R.Result[bool, str] = check_collisions(?alloc, ?itn, ?m, ?v);
         if (R.is_err[bool, str](cr)) { code = 1; }
     }
     arena.dnit(?ar);
@@ -2421,18 +2451,23 @@ test "mach.lang.manifest.expand:project_out" {
     var backing: A.Allocator; var ar: arena.Arena; var alloc: A.Allocator; var itn: intern.Interner;
     if (!tinit(?backing, ?ar, ?alloc, ?itn)) { ret 1; }
     var code: i32 = 0;
+    var v: TmplVars = mk_tv("linux", "x86_64", "linux", "sysv64", "release");
 
     # {project.out} substitutes the expanded project out
-    val r1: R.Result[str, str] = expand(?alloc, "{project.out}/obj/x.o", "out/linux/release", "linux", "release");
+    val r1: R.Result[str, str] = expand(?alloc, "{project.out}/obj/x.o", "out/linux/release", ?v);
     if (R.is_err[str, str](r1) || !str_equals(R.unwrap_ok[str, str](r1), "out/linux/release/obj/x.o")) { code = 1; }
 
     # referencing it while expanding [project].out itself (project_out empty) is an error
-    val r2: R.Result[str, str] = expand(?alloc, "{project.out}/x", "", "linux", "release");
+    val r2: R.Result[str, str] = expand(?alloc, "{project.out}/x", "", ?v);
     if (R.is_ok[str, str](r2) || !str_contains(R.unwrap_err[str, str](r2), "not available in [project].out")) { code = 1; }
 
     # an unknown variable is still a strict error
-    val r3: R.Result[str, str] = expand(?alloc, "{bogus}", "o", "t", "p");
+    val r3: R.Result[str, str] = expand(?alloc, "{bogus}", "o", ?v);
     if (R.is_ok[str, str](r3) || !str_contains(R.unwrap_err[str, str](r3), "unknown template variable")) { code = 1; }
+
+    # the #1964 target-tuple keys resolve from the active cell
+    val r4: R.Result[str, str] = expand(?alloc, "{target.isa}-{target.os}-{target.abi}", "o", ?v);
+    if (R.is_err[str, str](r4) || !str_equals(R.unwrap_ok[str, str](r4), "x86_64-linux-sysv64")) { code = 1; }
     arena.dnit(?ar);
     ret code;
 }
@@ -2470,12 +2505,13 @@ test "mach.lang.manifest.local_path_demanded_by_step" {
     if (R.is_err[Manifest, str](res_manifest)) { code = 1; }
     or {
         var m: Manifest = R.unwrap_ok[Manifest, str](res_manifest);
+        var v: TmplVars = mk_tv("linux", "x86_64", "linux", "sysv64", "debug");
         # a path matching the step's expanded out is demanded; a near miss is not
-        if (!local_path_demanded_by_step(?alloc, ?itn, ?m, "out/linux/obj/shim.o", "out/linux", "linux", "debug")) { code = 1; }
-        if ( local_path_demanded_by_step(?alloc, ?itn, ?m, "out/linux/obj/nope.o", "out/linux", "linux", "debug")) { code = 1; }
+        if (!local_path_demanded_by_step(?alloc, ?itn, ?m, "out/linux/obj/shim.o", "out/linux", ?v)) { code = 1; }
+        if ( local_path_demanded_by_step(?alloc, ?itn, ?m, "out/linux/obj/nope.o", "out/linux", ?v)) { code = 1; }
         # the shared predicate reports which step produces the path (the sole shim, index 0) and -1 for a miss
-        if (step_producing_out(?alloc, ?itn, ?m, "out/linux/obj/shim.o", "out/linux", "linux", "debug") != 0)  { code = 1; }
-        if (step_producing_out(?alloc, ?itn, ?m, "out/linux/obj/nope.o", "out/linux", "linux", "debug") != -1) { code = 1; }
+        if (step_producing_out(?alloc, ?itn, ?m, "out/linux/obj/shim.o", "out/linux", ?v) != 0)  { code = 1; }
+        if (step_producing_out(?alloc, ?itn, ?m, "out/linux/obj/nope.o", "out/linux", ?v) != -1) { code = 1; }
     }
     arena.dnit(?ar);
     ret code;
@@ -2501,7 +2537,8 @@ test "mach.lang.manifest.plan_steps" {
             names[0] = intern_unwrap(?itn, "app");
             var order: *u32 = nil;
             var count: u32 = 0;
-            val r: R.Result[bool, str] = plan_steps(?alloc, ?itn, ?m, ?names[0], 1, tl, "out/linux", "linux", "debug", ?order, ?count);
+            var v: TmplVars = tmpl_vars_of(?itn, tl, "debug");
+            val r: R.Result[bool, str] = plan_steps(?alloc, ?itn, ?m, ?names[0], 1, tl, "out/linux", ?v, ?order, ?count);
             if (R.is_err[bool, str](r)) { code = 1; }
             or {
                 var has_compile: bool = false; var has_gen: bool = false; var has_dep: bool = false; var has_winc: bool = false;
@@ -2544,7 +2581,8 @@ test "mach.lang.manifest.plan_steps:cycle" {
             names[0] = intern_unwrap(?itn, "app");
             var order: *u32 = nil;
             var count: u32 = 0;
-            val r: R.Result[bool, str] = plan_steps(?alloc, ?itn, ?m, ?names[0], 1, tl, "out/linux", "linux", "debug", ?order, ?count);
+            var v: TmplVars = tmpl_vars_of(?itn, tl, "debug");
+            val r: R.Result[bool, str] = plan_steps(?alloc, ?itn, ?m, ?names[0], 1, tl, "out/linux", ?v, ?order, ?count);
             # the re-entered step (a, reached a -> b -> a) is named in the diagnostic
             if (R.is_ok[bool, str](r) || !str_equals(R.unwrap_err[bool, str](r), "mach.toml: build step 'a' is part of a 'need' cycle")) { code = 1; }
         }
@@ -2570,7 +2608,8 @@ test "mach.lang.manifest.plan_export_steps" {
         or {
             var order: *u32 = nil;
             var count: u32 = 0;
-            val r: R.Result[bool, str] = plan_export_steps(?alloc, ?itn, ?m, tl, "out/linux", "linux", "debug", ?order, ?count);
+            var v: TmplVars = tmpl_vars_of(?itn, tl, "debug");
+            val r: R.Result[bool, str] = plan_export_steps(?alloc, ?itn, ?m, tl, "out/linux", ?v, ?order, ?count);
             if (R.is_err[bool, str](r)) { code = 1; }
             or {
                 # only the exported, linux-matching entry's step is demanded
@@ -2733,20 +2772,24 @@ test "mach.lang.manifest.parse:simd_consumer_overrides_library" {
     ret code;
 }
 
-# #1971: the template variable set is closed to {project.out}/{target.name}/
-# {profile.name}; the dropped {name}/{ext} aliases are now unknown (no silent empty).
+# the template variable set is closed to {project.out}/{target.name}/{target.isa}/
+# {target.os}/{target.abi}/{profile.name} (#1964); the dropped {name}/{ext} aliases
+# are still unknown (no silent empty).
 test "mach.lang.manifest.expand:closed_set" {
     var backing: A.Allocator; var ar: arena.Arena; var alloc: A.Allocator; var itn: intern.Interner;
     if (!tinit(?backing, ?ar, ?alloc, ?itn)) { ret 1; }
     var code: i32 = 0;
+    var v: TmplVars = mk_tv("linux", "x86_64", "linux", "sysv64", "release");
 
-    val ext: R.Result[str, str] = expand(?alloc, "bin/app{ext}", "out", "linux", "release");
+    val ext: R.Result[str, str] = expand(?alloc, "bin/app{ext}", "out", ?v);
     if (R.is_ok[str, str](ext) || !str_contains(R.unwrap_err[str, str](ext), "unknown template variable")) { code = 1; }
-    val nm: R.Result[str, str] = expand(?alloc, "test/{name}", "out", "linux", "release");
+    val nm: R.Result[str, str] = expand(?alloc, "test/{name}", "out", ?v);
     if (R.is_ok[str, str](nm) || !str_contains(R.unwrap_err[str, str](nm), "unknown template variable")) { code = 1; }
-    # the closed set still resolves
-    val good: R.Result[str, str] = expand(?alloc, "{project.out}/{target.name}/{profile.name}", "o", "linux", "release");
+    # the closed set still resolves, now including the target tuple keys
+    val good: R.Result[str, str] = expand(?alloc, "{project.out}/{target.name}/{profile.name}", "o", ?v);
     if (R.is_err[str, str](good) || !str_equals(R.unwrap_ok[str, str](good), "o/linux/release")) { code = 1; }
+    val tup: R.Result[str, str] = expand(?alloc, "{target.isa}/{target.os}/{target.abi}", "o", ?v);
+    if (R.is_err[str, str](tup) || !str_equals(R.unwrap_ok[str, str](tup), "x86_64/linux/sysv64")) { code = 1; }
     arena.dnit(?ar);
     ret code;
 }
@@ -2769,7 +2812,8 @@ test "mach.lang.manifest.resolve_test_libs:union" {
         or {
             var items: *intern.StrId = nil;
             var count: u32 = 0;
-            val r: R.Result[bool, str] = resolve_test_libs(?alloc, ?itn, ?m, tl, "out/linux", "linux", "debug", ?items, ?count);
+            var v: TmplVars = tmpl_vars_of(?itn, tl, "debug");
+            val r: R.Result[bool, str] = resolve_test_libs(?alloc, ?itn, ?m, tl, "out/linux", ?v, ?items, ?count);
             if (R.is_err[bool, str](r)) { code = 1; }
             or {
                 if (count != 3) { code = 1; }


### PR DESCRIPTION
Implements point 7 of RFC #1964 (the last undelivered point; merging fully reconciles and closes the RFC, per the owner-approved 2026-07-11 reconciliation comment).

## What

- **Template variables.** The closed, final manifest template set grows by exactly three keys — `{target.isa}`, `{target.os}`, `{target.abi}` — resolved from the active build cell. The full set is now `{project.out}`, `{target.name}`, `{target.isa}`, `{target.os}`, `{target.abi}`, `{profile.name}`. They resolve everywhere `manifest.expand` runs (artifact `out`, local link `path`, step `in`/`out`/`cmd`).
- **Env injection.** Every build-step process now inherits `MACH_TARGET_ISA`, `MACH_TARGET_OS`, `MACH_TARGET_ABI` for the active target, appended to the inherited environment at exec time.

`[project]` parsing is untouched — point 1 of the finalized-design comment is superseded by the shipped stricter surface, per the reconciliation.

## How

The target/profile identity a template expands against is bundled into a single `manifest.TmplVars` record (`target`/`isa`/`os`/`abi`/`profile`) threaded through `expand` and its callers, so the six-key set is uniform and future keys are one field rather than another positional argument at every call site. `{project.out}` stays a separate positional argument since it varies by what a template homes against (and the `[project].out` self-reference guard is unchanged). Driver-side, `cell_tmpl_vars(p)` builds the bundle from the active `TargetEntry`; the same three values feed both cmd expansion and the injected env.

## Tests

- `expand:project_out` and `expand:closed_set` exercise the three new keys resolving (`x86_64-linux-sysv64`) and the dropped `{name}`/`{ext}` aliases still erroring.
- Existing manifest/driver suites updated for the new signature.
- Full suite: **660 passed, 0 failed** via the from-source compiler. All CI lanes green (build/test/int/release across x86_64, aarch64, riscv64, windows).

Docs updated in `doc/manifest.md`.

## End-to-end proof

Scratch project with a step whose `cmd` uses all three keys plus `{project.out}`, and a script echoing the three env vars, built against two targets with the from-source compiler:

```
########## TARGET linux-x86_64 ##########
step probe: sh scripts/probe.sh x86_64 linux sysv64 out/linux-x86_64/debug/probe.txt
  TEMPLATE keys : isa=x86_64 os=linux abi=sysv64
  ENV inherited : MACH_TARGET_ISA=x86_64 MACH_TARGET_OS=linux MACH_TARGET_ABI=sysv64

########## TARGET linux-arm64 ##########
step probe: sh scripts/probe.sh aarch64 linux aapcs64 out/linux-arm64/debug/probe.txt
  TEMPLATE keys : isa=aarch64 os=linux abi=aapcs64
  ENV inherited : MACH_TARGET_ISA=aarch64 MACH_TARGET_OS=linux MACH_TARGET_ABI=aapcs64
```

Both the `{target.*}` template expansion (visible in the emitted `cmd`) and the injected `MACH_TARGET_*` env resolve from the active build cell and differ correctly per target. As a control, the released seed compiler (3.5.1) rejects the same manifest with `mach.toml: unknown template variable '{target.isa}'` — the feature is what makes these keys valid.

Closes #1964
