### PR TITLE
feat(constagg): fold constant cast leaves in aggregate initializers

### DIFF
--- a/int/regression/constagg-fold-leaves/expect.txt
+++ b/int/regression/constagg-fold-leaves/expect.txt
@@ -1,3 +1,6 @@
 h_nil.id=7
 h_fn.id=8 dbl(21)=42
 elems=100 200 300
+ipack=51966 200
+fnarrow_x2=7
+fwide_x4=2 1

--- a/int/regression/constagg-fold-leaves/src/main.mach
+++ b/int/regression/constagg-fold-leaves/src/main.mach
@@ -1,7 +1,10 @@
-# constant-aggregate global folding of two new leaf forms:
+# constant-aggregate global folding of new leaf forms:
 #   - a `nil` function-pointer leaf inside an aggregate (before the fix the whole
-#     aggregate bailed to a zeroed .bss placeholder, so `id` would read 0), and
-#   - a `?ARR[i]` element address, folded to a base+offset relocation.
+#     aggregate bailed to a zeroed .bss placeholder, so `id` would read 0),
+#   - a `?ARR[i]` element address, folded to a base+offset relocation, and
+#   - a constant cast leaf (`<const>::T`, incl. chains): an integer narrowing chain
+#     and widening, and a float narrowing and widening, each folded to its
+#     laid-out bytes rather than bailing the aggregate.
 
 use std.runtime;
 use p: std.print;
@@ -21,10 +24,25 @@ val P0: *i64 = ?NUMS[0];
 val P1: *i64 = ?NUMS[1];
 val P2: *i64 = ?NUMS[2];
 
+val BIG:   u32 = 0x1CAFE;
+val SMALL: u8  = 200;
+val PI64:  f64 = 3.5;
+val HALFf: f32 = 0.5;
+val QRTf:  f32 = 0.25;
+
+# BIG::u16 narrows 0x1CAFE to 0xCAFE, then ::u32 widens it; SMALL::u32 widens.
+val IPACK:   [2]u32 = [2]u32{BIG::u16::u32, SMALL::u32};
+# PI64::f32 narrows 3.5 to f32; HALFf::f64 / QRTf::f64 widen f32 to f64.
+val FNARROW: [1]f32 = [1]f32{PI64::f32};
+val FWIDE:   [2]f64 = [2]f64{HALFf::f64, QRTf::f64};
+
 #[symbol("main")]
 pub fun main(argc: i64, argv: **u8) i64 {
     p.printf("h_nil.id={}\n", H_NIL.id);
     p.printf("h_fn.id={} dbl(21)={}\n", H_FN.id, H_FN.fn(21));
     p.printf("elems={} {} {}\n", @P0, @P1, @P2);
+    p.printf("ipack={} {}\n", IPACK[0]::i64, IPACK[1]::i64);
+    p.printf("fnarrow_x2={}\n", (FNARROW[0]::f64 * 2.0)::i64);
+    p.printf("fwide_x4={} {}\n", (FWIDE[0] * 4.0)::i64, (FWIDE[1] * 4.0)::i64);
     ret 0;
 }

--- a/src/lang/driver/tests.mach
+++ b/src/lang/driver/tests.mach
@@ -1035,6 +1035,79 @@ test "mach.lang.driver:imported_pub_val_array_length" {
     ret bad;
 }
 
+# read a little-endian u32 at `off` from a laid-out aggregate blob
+fun ut_rd_u32(b: *u8, off: u32) u32 {
+    ret b[off]::u32 | (b[off + 1]::u32 << 8) | (b[off + 2]::u32 << 16) | (b[off + 3]::u32 << 24);
+}
+
+# read a little-endian u64 at `off` from a laid-out aggregate blob
+fun ut_rd_u64(b: *u8, off: u32) u64 {
+    var v: u64 = 0;
+    var i: u32 = 0;
+    for (i < 8) {
+        v = v | (b[off + i]::u64 << (i::u64 * 8::u64));
+        i = i + 1;
+    }
+    ret v;
+}
+
+# a constant cast leaf (`<const>::T`, incl. chains) inside a const aggregate global
+# folds to its laid-out bytes rather than bailing the aggregate to a hard error.
+# proves the four shapes the constagg cast-leaf fold covers: an integer narrowing
+# chain (u32 -> u16 -> u32), an integer widening (u8 -> u32), a float narrowing
+# (f64 -> f32), and a float widening (f32 -> f64). the aggregates are `pub` so
+# lowering emits and folds them; before the fix run_lower_pass fails outright
+# ("global initialiser must be a constant expression"), so a clean lower plus the
+# expected little-endian blob bytes prove both that it folded and to what (#2112)
+test "mach.lang.driver:constagg_cast_leaf_fold" {
+    val src: str = "val BIG: u32 = 0x1CAFE;\nval SMALL: u8 = 200;\nval PI64: f64 = 3.5;\nval HALFf: f32 = 0.5;\nval QRTf: f32 = 0.25;\npub val IPACK: [2]u32 = [2]u32{BIG::u16::u32, SMALL::u32};\npub val FNARROW: [1]f32 = [1]f32{PI64::f32};\npub val FWIDE: [2]f64 = [2]f64{HALFf::f64, QRTf::f64};\n#[symbol(\"main\")]\npub fun main(argc: i64, argv: **u8) i32 { ret 0; }\n";
+
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    val sr: R.Result[session.Session, str] = session.init(?alloc);
+    if (R.is_err[session.Session, str](sr)) { ret 1; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](sr);
+
+    # pre-fix this lower fails on the cast leaves; a clean lower is half the proof.
+    val pr: R.Result[project.Project, outcome.Fail] = ut_vec_lower(?s, ?alloc, src, "linux");
+    if (R.is_err[project.Project, outcome.Fail](pr)) { session.dnit(?s); ret 1; }
+    var p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](pr);
+
+    # locate each aggregate by its folded blob signature (length + content), so no
+    # mangled-name match is needed. the blobs are little-endian on every target.
+    var saw_ipack:   bool = false;
+    var saw_fnarrow: bool = false;
+    var saw_fwide:   bool = false;
+    var ti: u32 = 0;
+    for (ti < p.topo_len) {
+        val m: *ir.Module = p.modules[p.topo[ti]::u32].ir_module;
+        if (m != nil) {
+            var gi: u32 = 0;
+            for (gi < m.global_len) {
+                val g: *ir.Global = ?m.globals[gi];
+                if (g.init.kind == value.VAL_CONST_AGG) {
+                    val bytes: *u8 = g.init.data.agg.bytes;
+                    val len:   u32 = g.init.data.agg.len;
+                    if (len == 8 && ut_rd_u32(bytes, 0) == 51966 && ut_rd_u32(bytes, 4) == 200) { saw_ipack = true; }
+                    if (len == 4 && ut_rd_u32(bytes, 0) == 0x40600000) { saw_fnarrow = true; }
+                    if (len == 16 && ut_rd_u64(bytes, 0) == 0x3FE0000000000000 && ut_rd_u64(bytes, 8) == 0x3FD0000000000000) { saw_fwide = true; }
+                }
+                gi = gi + 1;
+            }
+        }
+        ti = ti + 1;
+    }
+
+    var bad: i32 = 0;
+    if (!saw_ipack)   { bad = 1; }  # int narrowing chain + widening leaves
+    if (!saw_fnarrow) { bad = 1; }  # float narrowing leaf (f64 -> f32)
+    if (!saw_fwide)   { bad = 1; }  # float widening leaves (f32 -> f64)
+
+    project.dnit_project(?p);
+    session.dnit(?s);
+    ret bad;
+}
+
 # a two-char decimal string ("00".."99") for n < 100, owned by `alloc`.
 # names the per-leaf modules of the realloc-mid-walk fixture below
 fun ut_idx2(alloc: *A.Allocator, n: u32) str {

--- a/src/lang/me/lower/constagg.mach
+++ b/src/lang/me/lower/constagg.mach
@@ -522,7 +522,10 @@ fun push_sym_reloc(ctx: *lower.LowerContext, rb: *RelocBuf, off: u32, symbol: in
 # writes its bits little-endian into the leaf's type-sized slot
 #
 # An `$size_of` / `$align_of` / `$offset_of` intrinsic call folds through the
-# same path the scalar global initializer uses; everything else folds through
+# same path the scalar global initializer uses; a constant cast leaf
+# (`<const>::T`, chains, `:~`) - which `comptime.eval` rejects for want of a
+# width / sign model - folds through the same cast path the scalar global
+# initializer uses (`place_cast_leaf`); everything else folds through
 # `comptime.eval`. A non-constant leaf falls back. A float leaf narrower than
 # f64 is re-encoded to its IEEE-754 width.
 # ---
@@ -562,7 +565,13 @@ fun place_scalar(ctx: *lower.LowerContext, eid: id.ExprId, ity: ir_type.IrTypeId
     }
 
     val res_ctval: R.Result[comptime.CTValue, str] = comptime.eval(ctx.ctx, ctx.a, lower.module_source(ctx), eid, ?ctx.s.interner);
-    if (R.is_err[comptime.CTValue, str](res_ctval)) { ret R.ok[FoldResult, str](FOLD_FALLBACK); }
+    if (R.is_err[comptime.CTValue, str](res_ctval)) {
+        # comptime.eval models no cast width / sign, so a constant cast leaf lands
+        # here rather than folding above. route it through the same cast path the
+        # scalar global initializer uses before falling back; a non-cast leaf
+        # declines in the helper and falls back exactly as before.
+        ret place_cast_leaf(ctx, eid, blob, base, size);
+    }
     val ctval: comptime.CTValue = R.unwrap_ok[comptime.CTValue, str](res_ctval);
 
     var bits: u64 = 0;
@@ -583,6 +592,54 @@ fun place_scalar(ctx: *lower.LowerContext, eid: id.ExprId, ity: ir_type.IrTypeId
 
     write_bits(blob, base, bits, size);
     ret R.ok[FoldResult, str](FOLD_OK);
+}
+
+# lays out a constant cast leaf (`<const>::T`, cast chains, `:~` reinterpret)
+#
+# `comptime.eval` rejects a cast (it models no target width / sign), so a cast
+# leaf is folded here through `expr.try_lower_comptime_cast` - the same path the
+# scalar global initializer uses (`fold_global_init`), giving identical
+# trunc / extend / convert semantics. The folded integer / float constant is
+# written little-endian into the leaf's type-sized slot, a narrower float
+# re-encoded to its IEEE-754 width exactly as the scalar path does. A leaf whose
+# operand is not a foldable scalar constant (a runtime cast, or a non-cast leaf
+# routed here on the comptime.eval-failure path) declines and falls back, and a
+# folded value of any other kind is not representable as inline scalar bits and
+# also falls back.
+# ---
+# ctx:  the lowering context
+# eid:  the cast leaf's initializer expression
+# blob: the output blob being filled
+# base: byte offset of this scalar within `blob`
+# size: the leaf's type size in bytes (1..8)
+# ret:  ok(FOLD_OK) when the cast folded; ok(FOLD_FALLBACK) on a non-constant or
+#       non-scalar leaf; err on a real failure
+fun place_cast_leaf(ctx: *lower.LowerContext, eid: id.ExprId, blob: *u8, base: u32, size: u32) R.Result[FoldResult, str] {
+    val opt_e: O.Option[*aexpr.Expr] = ast.get_expr(ctx.a, eid);
+    if (O.is_none[*aexpr.Expr](opt_e)) { ret R.ok[FoldResult, str](FOLD_FALLBACK); }
+    val e: *aexpr.Expr = O.unwrap[*aexpr.Expr](opt_e);
+
+    val opt_cast: O.Option[R.Result[value.Value, str]] = expr.try_lower_comptime_cast(ctx, eid, e);
+    if (O.is_none[R.Result[value.Value, str]](opt_cast)) { ret R.ok[FoldResult, str](FOLD_FALLBACK); }
+    val res_cast: R.Result[value.Value, str] = O.unwrap[R.Result[value.Value, str]](opt_cast);
+    if (R.is_err[value.Value, str](res_cast)) { ret R.err[FoldResult, str](R.unwrap_err[value.Value, str](res_cast)); }
+    val cv: value.Value = R.unwrap_ok[value.Value, str](res_cast);
+
+    if (cv.kind == value.VAL_CONST_INT) {
+        write_bits(blob, base, cv.data.int_lit, size);
+        ret R.ok[FoldResult, str](FOLD_OK);
+    }
+    if (cv.kind == value.VAL_CONST_FLOAT) {
+        # a comptime float carries an f64; a narrower float leaf must take the
+        # IEEE-754 pattern of its own width, matching the scalar CT_KIND_FLOAT path.
+        var fbits: u64 = 0;
+        if (size == 8) { fbits = float.f64_bits(cv.data.float_lit); }
+        or (size == 4) { fbits = float.f64_to_f32_bits(float.f64_bits(cv.data.float_lit))::u64; }
+        or             { ret R.err[FoldResult, str]("constagg: unsupported float cast-leaf width"); }
+        write_bits(blob, base, fbits, size);
+        ret R.ok[FoldResult, str](FOLD_OK);
+    }
+    ret R.ok[FoldResult, str](FOLD_FALLBACK);
 }
 
 # writes the low `size` bytes of `bits` little-endian at `blob[base..]`


### PR DESCRIPTION
Closes #2112.

## Problem
A cast expression (`<const>::T`, chains, `:~`) used as a **leaf inside a constant aggregate global initializer** did not fold — it bailed the whole aggregate to a hard error:

```
error: global initialiser of `X` must be a constant expression
```

`place_scalar` (in `me/lower/constagg.mach`) folds scalar leaves only through `comptime.eval` — which models no cast width/sign — plus the `$size_of`/intrinsic path. It never routed a cast the way the top-level scalar global initializer does (`fold_global_init` → `expr.try_lower_comptime_cast`). Every other aggregate leaf shape (nil/real fn-ptr, enum const, cross-module const, `?ARR[i]` element address, plain literals) already folds; the cast leaf was the one gap.

Because every ISA declares `pub def Opcode: u16`, this blocked the planned static instruction-selection rule packs (each retag rule's `to:` is `<isa>.<OP>::u32`).

## Fix
Route a cast leaf through `expr.try_lower_comptime_cast` on the `comptime.eval`-failure path (new `place_cast_leaf`), applying the same trunc/extend/convert semantics `fold_global_init` uses for a scalar global cast. The folded integer/float constant is written little-endian into the leaf's slot, a narrower float re-encoded to its IEEE-754 width exactly as the scalar path does.

**Strictly additive:** the new path runs only after `comptime.eval` declines (which for a cast it always does), so every currently-folding leaf keeps its exact bytes.

## Tests
- In-suite driver test `mach.lang.driver:constagg_cast_leaf_fold` — proves the four shapes fold to correct laid-out bytes: integer narrowing chain (`u32→u16→u32`), integer widening (`u8→u32`), float narrowing (`f64→f32`), float widening (`f32→f64`). Suite 714→**715/0**.
- Extended `int/regression/constagg-fold-leaves` with the same cast leaves, read at runtime — **linux + riscv64 legs green** (debug + release).
- Baseline (origin/dev) compiler confirmed to **reject** the cast-leaf case, proving the fix is load-bearing.

## Byte-identical proof (load-bearing)
The dev-baseline compiler and the fix compiler emit **byte-identical** output on the corpus for all three ISAs — no existing const aggregate's bytes change:

| target | sha256 (base == fix) |
|---|---|
| linux-x86_64 | `ffc7f75fc56ffe18b093fa3c7d420a32ff18542a87d33b64ba76caaed5373cb0` |
| linux-arm64 | `6ba6ea0aab1ea018…` |
| linux-riscv64 | `fb364a69656c50bf…` |

mach-std suite **611/0** through the fix compiler.
