### PR TITLE
feat(build): link executables from in-memory images (ELF/Mach-O)

### DIFF
--- a/src/lang/be/linker.mach
+++ b/src/lang/be/linker.mach
@@ -268,6 +268,89 @@ pub fun link_images(s: *session.Session, tgt: *target.Target, images: *of.Object
     ret link_modules(s, tgt, images, image_count, sonames, soname_count, out_path, name, mode, pie);
 }
 
+# combine the project's in-memory codegen images with on-disk external link
+# inputs into the requested artifact, parsing each external input at most once
+#
+# the relocatable executable path for a format whose in-memory image is
+# link-equivalent to its `.o` (`tgt.of.links_from_image`, i.e. elf/mach-o): the
+# project's own modules are already in memory as `of.ObjectImage`s (the back
+# end's codegen images), so they are linked straight from memory rather than
+# written to `.o` and read back through `parse_object`, while the external
+# inputs (libc, `-l`/`-L`, `.a` archives) that genuinely live on disk are read
+# and parsed here via `read_objects`. the two sets are concatenated - project
+# images first, matching the on-disk link order `write_objects` produces - and
+# handed to `link_modules`; only the parsed external images are torn down
+# afterward, never the caller-owned project images. `link_images` is the
+# no-external special case of this and `link` the no-in-memory one. an `.a`
+# archive expands to one image per member, so the external image count can
+# exceed `obj_count`.
+# ---
+# s:            shared session (allocator, interner, diagnostics)
+# tgt:          active target - selects OS base address, entry symbol, and writers
+# images:       the project's in-memory codegen images, in link order (caller-owned)
+# image_count:  number of project images
+# obj_paths:    null-terminated paths to external input objects/archives, or nil
+# obj_count:    number of external input paths
+# sonames:      interned shared-library sonames to depend on dynamically (or nil)
+# soname_count: number of shared-library dependencies
+# out_path:     null-terminated output file path
+# name:         null-terminated product name; the writer's stable signing identity
+# mode:         executable, relocatable (library), or shared
+# pie:          the build opted into a position-independent executable (`--pie`)
+# ret:          true once the artifact is written, or an error string
+pub fun link_mixed(s: *session.Session, tgt: *target.Target,
+                   images: *of.ObjectImage, image_count: u32,
+                   obj_paths: **u8, obj_count: u32,
+                   sonames: *intern.StrId, soname_count: u32,
+                   out_path: *u8, name: *u8, mode: LinkMode, pie: bool) R.Result[bool, str] {
+    if (s == nil)      { ret R.err[bool, str]("link: nil session"); }
+    if (tgt == nil)    { ret R.err[bool, str]("link: nil target"); }
+    if (tgt.of == nil) { ret R.err[bool, str]("link: target has no object-format vtable"); }
+    if (tgt.os == nil) { ret R.err[bool, str]("link: target has no OS vtable"); }
+    if (images == nil || image_count == 0) {
+        ret R.err[bool, str]("link: no input objects");
+    }
+
+    val alloc: *A.Allocator = s.alloc;
+
+    # read and parse the external inputs from disk into their own owned array; with
+    # none, this stays an empty set and the link is a pure in-memory one.
+    var ext_count: u32 = 0;
+    var ext: *of.ObjectImage = nil;
+    if (obj_paths != nil && obj_count > 0) {
+        val read_r: R.Result[*of.ObjectImage, str] = read_objects(s, tgt, obj_paths, obj_count, ?ext_count);
+        if (R.is_err[*of.ObjectImage, str](read_r)) {
+            ret R.err[bool, str](R.unwrap_err[*of.ObjectImage, str](read_r));
+        }
+        ext = R.unwrap_ok[*of.ObjectImage, str](read_r);
+    }
+
+    # concatenate project images (borrowed) ahead of the parsed external images.
+    # each `of.ObjectImage` is a shallow value over borrowed array pointers, so a
+    # value copy shares the underlying storage; `combined` is a wrapper only.
+    val total: u32 = image_count + ext_count;
+    val cr: R.Result[*of.ObjectImage, str] = A.allocate[of.ObjectImage](alloc, total::usize);
+    if (R.is_err[*of.ObjectImage, str](cr)) {
+        free_modules(alloc, ext, ext_count);
+        ret R.err[bool, str](R.unwrap_err[*of.ObjectImage, str](cr));
+    }
+    val combined: *of.ObjectImage = R.unwrap_ok[*of.ObjectImage, str](cr);
+
+    var i: u32 = 0;
+    for (i < image_count) { combined[i] = images[i]; i = i + 1; }
+    var j: u32 = 0;
+    for (j < ext_count) { combined[image_count + j] = ext[j]; j = j + 1; }
+
+    val r: R.Result[bool, str] =
+        link_modules(s, tgt, combined, total, sonames, soname_count, out_path, name, mode, pie);
+
+    # tear down only the parsed external images (the project images are caller-owned)
+    # and free the `combined` wrapper without dnit'ing its shallow-copied slots.
+    free_modules(alloc, ext, ext_count);
+    A.deallocate[of.ObjectImage](alloc, combined, total::usize);
+    ret r;
+}
+
 # combine an already-built module-image array into the requested artifact
 #
 # the shared core of `link` (disk inputs read + parsed) and `link_images`

--- a/src/lang/build/emit.mach
+++ b/src/lang/build/emit.mach
@@ -319,6 +319,31 @@ pub fun link_executable(p: *driver.Project, paths: **u8, len: u32,
     ret R.ok[bool, outcome.Fail](true);
 }
 
+# gather the project's per-module codegen images into a fresh contiguous array in
+# topo (link) order, so the in-memory link order matches the on-disk object order
+# `write_objects` produces
+#
+# `images` is indexed by module id; this projects it through `p.topo`. Each
+# `of.ObjectImage` is a shallow value over borrowed array pointers, so the copy
+# shares the underlying storage - only the returned wrapper array is owned, and
+# the caller frees it with `A.deallocate` without tearing down the images.
+# ---
+# p:      the project carrying the topo order and allocator
+# images: the per-module object images, indexed by module id
+# ret:    an owned topo-ordered image array (length `p.topo_len`), or an error
+fun gather_topo_images(p: *driver.Project, images: *of.ObjectImage) R.Result[*of.ObjectImage, str] {
+    val len: u32 = p.topo_len;
+    val res_ord: R.Result[*of.ObjectImage, str] = A.allocate[of.ObjectImage](p.alloc, len::usize);
+    if (R.is_err[*of.ObjectImage, str](res_ord)) { ret res_ord; }
+    val ordered: *of.ObjectImage = R.unwrap_ok[*of.ObjectImage, str](res_ord);
+    var i: u32 = 0;
+    for (i < len) {
+        ordered[i] = images[(p.topo[i])::u32];
+        i = i + 1;
+    }
+    ret R.ok[*of.ObjectImage, str](ordered);
+}
+
 # link the in-memory codegen images straight into a flat executable image,
 # bypassing the per-module `.o` emit/parse round-trip
 #
@@ -334,23 +359,52 @@ pub fun link_executable(p: *driver.Project, paths: **u8, len: u32,
 # exe_path: the executable path to link into
 # ret:      ok(true) on success, or the failure as a Fail
 pub fun link_flat_images(p: *driver.Project, images: *of.ObjectImage, exe_path: *u8) R.Result[bool, outcome.Fail] {
-    # gather the topo-ordered images into a contiguous array. each `of.ObjectImage`
-    # is a shallow value carrying borrowed array pointers, so copying it shares the
-    # underlying storage; only this wrapper array is freed, never the images.
-    val len: u32 = p.topo_len;
-    val res_ord: R.Result[*of.ObjectImage, str] = A.allocate[of.ObjectImage](p.alloc, len::usize);
+    val res_ord: R.Result[*of.ObjectImage, str] = gather_topo_images(p, images);
     if (R.is_err[*of.ObjectImage, str](res_ord)) { ret R.err[bool, outcome.Fail](outcome.internal("out of memory")); }
     val ordered: *of.ObjectImage = R.unwrap_ok[*of.ObjectImage, str](res_ord);
-    var i: u32 = 0;
-    for (i < len) {
-        ordered[i] = images[(p.topo[i])::u32];
-        i = i + 1;
-    }
 
     val ctx: *qctx.QueryCtx = p.s.queries.ctx::*qctx.QueryCtx;
     val res_link: R.Result[bool, str] =
-        linker.link_images(p.s, ?p.target, ordered, len, nil::*intern.StrId, 0, exe_path, artifact_product_name(p), linker.LINK_EXE, ctx.req.pie);
-    A.deallocate[of.ObjectImage](p.alloc, ordered, len::usize);
+        linker.link_images(p.s, ?p.target, ordered, p.topo_len, nil::*intern.StrId, 0, exe_path, artifact_product_name(p), linker.LINK_EXE, ctx.req.pie);
+    A.deallocate[of.ObjectImage](p.alloc, ordered, p.topo_len::usize);
+    if (R.is_err[bool, str](res_link)) {
+        ret R.err[bool, outcome.Fail](outcome.user(R.unwrap_err[bool, str](res_link)));
+    }
+    ret R.ok[bool, outcome.Fail](true);
+}
+
+# link the project's in-memory codegen images plus the external on-disk inputs
+# straight into the executable, re-parsing only the external inputs
+#
+# The relocatable executable step for a format whose codegen image is
+# link-equivalent to its `.o` (`tgt.of.links_from_image`, i.e. elf/mach-o): the
+# project's own per-module objects were written as the deliverable / incremental
+# cache but are linked from memory here, so only the external inputs (libc,
+# `-l`/`-L`, archives) are read back from disk. The project images are gathered
+# into a contiguous topo-ordered array (matching the on-disk link order) and
+# handed to `linker.link_mixed` ahead of the parsed external inputs; the wrapper
+# array is freed afterward, never the images (the caller owns them).
+# ---
+# p:          the project carrying the module graph and session
+# images:     the per-module codegen images, indexed by module id
+# ext_paths:  external link-input paths (on-disk objects/archives), or nil
+# ext_count:  number of external link-input paths
+# sonames:    the dynamic-dependency soname list
+# soname_len: number of sonames
+# exe_path:   the executable path to link into
+# ret:        ok(true) on success, or the failure as a Fail
+pub fun link_mixed_images(p: *driver.Project, images: *of.ObjectImage,
+                          ext_paths: **u8, ext_count: u32,
+                          sonames: *intern.StrId, soname_len: u32, exe_path: *u8) R.Result[bool, outcome.Fail] {
+    val res_ord: R.Result[*of.ObjectImage, str] = gather_topo_images(p, images);
+    if (R.is_err[*of.ObjectImage, str](res_ord)) { ret R.err[bool, outcome.Fail](outcome.internal("out of memory")); }
+    val ordered: *of.ObjectImage = R.unwrap_ok[*of.ObjectImage, str](res_ord);
+
+    val ctx: *qctx.QueryCtx = p.s.queries.ctx::*qctx.QueryCtx;
+    val res_link: R.Result[bool, str] =
+        linker.link_mixed(p.s, ?p.target, ordered, p.topo_len, ext_paths, ext_count,
+                          sonames, soname_len, exe_path, artifact_product_name(p), linker.LINK_EXE, ctx.req.pie);
+    A.deallocate[of.ObjectImage](p.alloc, ordered, p.topo_len::usize);
     if (R.is_err[bool, str](res_link)) {
         ret R.err[bool, outcome.Fail](outcome.user(R.unwrap_err[bool, str](res_link)));
     }

--- a/src/lang/build/engine.mach
+++ b/src/lang/build/engine.mach
@@ -794,7 +794,19 @@ fun link_phase(p: *driver.Project, unit: *plan.BuildUnit, st: *UnitState,
         ret R.ok[bool, outcome.Fail](true);
     }
 
-    val res_link: R.Result[bool, outcome.Fail] = emit.link_executable(p, st.obj_paths, st.obj_len, st.sonames, st.soname_len, artifact::*u8);
+    # a format whose codegen image is link-equivalent to its `.o` links the
+    # project's own modules straight from their in-memory images (already written
+    # above as the deliverable / cache), re-parsing only the external inputs at
+    # obj_paths[ext_from..obj_len). a format that is not yet link-equivalent - coff
+    # until #2125 - stays on the full disk round-trip, re-parsing every path.
+    val from_image: bool = p.target.of.links_from_image;
+    var res_link: R.Result[bool, outcome.Fail] = R.ok[bool, outcome.Fail](true);
+    if (from_image) {
+        res_link = emit.link_mixed_images(p, st.images, ?st.obj_paths[ext_from], ext_count, st.sonames, st.soname_len, artifact::*u8);
+    }
+    if (!from_image) {
+        res_link = emit.link_executable(p, st.obj_paths, st.obj_len, st.sonames, st.soname_len, artifact::*u8);
+    }
     if (R.is_err[bool, outcome.Fail](res_link)) { ret res_link; }
 
     st.out_path = artifact::*u8;

--- a/src/lang/target/of.mach
+++ b/src/lang/target/of.mach
@@ -600,6 +600,18 @@ val OF_ISA_MAX: u32 = 8;
 # name:           format name ("elf", "coff", "macho", "raw"); an immutable str constant
 # produces_image: true for a container-free flat image, false for a relocatable
 #                 object format that round-trips through `.o` files
+# links_from_image: true when the linker may consume this format's in-memory
+#                 codegen image directly for an executable link, byte-identically
+#                 to parsing the `.o` it would emit. always true for a flat image
+#                 (no `.o` exists to parse); for a relocatable format it asserts
+#                 the emit->parse round-trip is an identity on the abstract image,
+#                 so an executable build links the project's own modules straight
+#                 from memory and re-parses only the external inputs. true for elf
+#                 and mach-o (#1865: the abstract relocation addend is honored
+#                 uniformly, so the image equals its parsed object); false for coff
+#                 until #2125 lands (its weak-COMDAT carrier duplicates every weak
+#                 body into `.text`, so the coff image diverges from its `.o`),
+#                 keeping coff on the disk round-trip
 # emit_object:    serializes an ObjectImage to a relocatable object file
 # parse_object:   reads a relocatable object file into an ObjectImage
 # emit_exec:      serializes laid-out load segments into a static executable
@@ -640,6 +652,7 @@ pub rec OfVTable {
     id:                  u32;
     name:                str;
     produces_image:      bool;
+    links_from_image:    bool;
     emit_object:         WriterFn;
     parse_object:        ParserFn;
     emit_exec:           ExecFn;

--- a/src/lang/target/of/coff.mach
+++ b/src/lang/target/of/coff.mach
@@ -2959,6 +2959,10 @@ pub fun register_coff(reg: *of.OfRegistry) R.Result[bool, str] {
     coff_vtable.id               = of.OF_COFF;
     coff_vtable.name             = "coff";
     coff_vtable.produces_image   = false;
+    # the COFF codegen image is NOT yet link-equivalent to its `.o`: the weak-COMDAT
+    # carrier duplicates every weak body into `.text` (#2125), so linking the image
+    # directly diverges from the disk round-trip. keep COFF on paths until #2125.
+    coff_vtable.links_from_image = false;
     coff_vtable.emit_object      = coff_emit_object;
     coff_vtable.parse_object     = coff_parse_object;
     coff_vtable.emit_exec        = coff_emit_exec;

--- a/src/lang/target/of/elf.mach
+++ b/src/lang/target/of/elf.mach
@@ -1136,6 +1136,9 @@ pub fun register(reg: *of.OfRegistry) R.Result[bool, str] {
     elf_vtable.id             = of.OF_ELF;
     elf_vtable.name           = "elf";
     elf_vtable.produces_image = false;
+    # RELA keeps the addend out-of-band, so an ELF codegen image equals its parsed
+    # `.o`; the executable link consumes the project's images directly.
+    elf_vtable.links_from_image = true;
     elf_vtable.emit_object    = emit_object;
     elf_vtable.parse_object   = parse_object;
     elf_vtable.emit_exec      = emit_exec;

--- a/src/lang/target/of/macho.mach
+++ b/src/lang/target/of/macho.mach
@@ -1194,6 +1194,9 @@ pub fun register_macho(reg: *of.OfRegistry) R.Result[bool, str] {
     macho_vtable.name           = "macho";
     # Mach-O round-trips a relocatable .o, so it is not a flat-image format.
     macho_vtable.produces_image = false;
+    # post-#1865 the abstract addend is honored uniformly, so a Mach-O codegen
+    # image equals its parsed `.o`; the executable link consumes images directly.
+    macho_vtable.links_from_image = true;
     macho_vtable.emit_object    = emit_object;
     macho_vtable.parse_object   = parse_object;
     macho_vtable.emit_exec      = emit_exec;

--- a/src/lang/target/of/raw.mach
+++ b/src/lang/target/of/raw.mach
@@ -228,6 +228,8 @@ pub fun register(reg: *of.OfRegistry) R.Result[bool, str] {
     raw_vtable.id             = of.OF_RAW;
     raw_vtable.name           = "raw";
     raw_vtable.produces_image = true;
+    # a flat image has no `.o` to parse, so it always links straight from memory.
+    raw_vtable.links_from_image = true;
     raw_vtable.emit_object    = emit_object;
     raw_vtable.parse_object   = parse_object;
     raw_vtable.emit_exec      = emit_exec;

--- a/src/lang/target/of/spv.mach
+++ b/src/lang/target/of/spv.mach
@@ -95,6 +95,9 @@ pub fun register(reg: *of.OfRegistry) R.Result[bool, str] {
     # not a flat load image: the object-emit path writes one module per file and
     # never lays out load segments.
     spv_vtable.produces_image = false;
+    # a SPIR-V module is never linked into an executable, so it never feeds the
+    # in-memory executable-link path.
+    spv_vtable.links_from_image = false;
     spv_vtable.emit_object    = emit_object;
     # a finished SPIR-V module is never read back, linked, or laid out as an
     # executable in this milestone.


### PR DESCRIPTION
Closes #1828.

## What

On the relocatable-object executable path, an executable build wrote every module's `of.ObjectImage` to a `.o`, then handed the linker the **file paths** so it re-parsed from disk the objects that were, moments earlier, in memory. This switches the executable link to consume the project's in-memory codegen images directly, re-parsing only the genuinely-on-disk external inputs (libc, `-l`/`-L`, archives, shared libs). The `.o` tree is still written (library deliverable + incremental cache); only the linker's re-read of the project's own just-written objects is dropped.

## Design

- `OfVTable.links_from_image` — a declared per-format capability: true when the format's in-memory codegen image is link-equivalent to the `.o` it emits-and-parses, so the executable link may consume it directly. true for **elf** and **mach-o** (#1865: the abstract relocation addend / SK_RELRO now round-trip, image == parsed object), true for **raw** (a flat image has no `.o`), **false for coff** (pending #2125) and **spv**.
- `linker.link_mixed` — parses only the external on-disk inputs via the shared `read_objects`, concatenates the project's borrowed in-memory images ahead of them (project first, matching the on-disk link order `write_objects` produces), links the combined set through the shared `link_modules`, and tears down only the parsed externals. `link_images` is its no-external special case; `link` its no-in-memory one.
- `emit.link_mixed_images` gathers the topo-ordered project images and drives `link_mixed`. `gather_topo_images` is factored out and shared with `link_flat_images`.
- The build engine's executable link dispatches on `links_from_image`: elf/mach-o link from memory, coff stays on the full disk round-trip until #2125.

## COFF excluded pending #2125

#2125 (weak-COMDAT `.text` duplication) is not yet fixed, so the COFF in-memory image is not yet link-equivalent to its `.o`. COFF stays on the disk round-trip; when #2125 lands, `coff_vtable.links_from_image` flips to true and the gate goes uniform. Verified below: the windows/COFF binary is **unchanged** (byte-identical old vs new), so the gating is intact.

## Verification

Same source built by the current disk-reparse compiler (`old`) vs the in-memory compiler (`new`); only the link path differs. Both compilers built on the merged base that includes #1865.

**Byte-identical linked executable (compiler self-build corpus):**

| target | format | result |
|---|---|---|
| linux-x86_64 | ELF | IDENTICAL |
| linux-arm64 | ELF (aarch64) | IDENTICAL |
| linux-riscv64 | ELF | IDENTICAL |
| darwin-x86_64 | Mach-O | IDENTICAL |
| darwin-aarch64 | Mach-O | IDENTICAL |
| windows-x86_64 | COFF | IDENTICAL (unchanged — disk path) |

- **Mixed path** (project in-memory image + external static `.o` parsed from disk), ELF x86_64: IDENTICAL, and the linked program runs correctly (cross-object symbol resolved).
- **Release profile**, ELF x86_64: IDENTICAL.
- **Single-gen fixpoint** B==C: holds.
- Full suite `mach test .`: **717 passed / 0 failed**. mach-std: **611 / 0**, builds clean. int **linux** + **linux-riscv64**: all cases pass. darwin (x2) + windows cross-build: clean.

**Build-time win** (native linux-x86_64 self-build, 159 objects, zero external inputs — the reparse elimination):

- Link phase (folds object-emit + link, `-v` readout): **298 ms -> 262 ms** min over 7 cold runs (~12% faster, tight variance).
- Total cold self-build wall time: 5060 ms -> 5045 ms (the parallel codegen dominates the wall clock, so the serial link savings are mostly hidden at the whole-build level; the isolated link-phase number is the honest metric — modest, exactly as #1828 predicted).
