### PR TITLE
feat(sema): reject aggregate-value `==`/`!=` (#2127)

### DIFF
--- a/src/lang/driver/tests.mach
+++ b/src/lang/driver/tests.mach
@@ -980,6 +980,58 @@ test "mach.lang.driver:vector_negative_diagnostics" {
     ret bad;
 }
 
+# `==`/`!=` on an aggregate VALUE -- a record, union, array, secret-qualified
+# aggregate, or a generic instance of a record/union -- is rejected with a
+# teaching diagnostic instead of silently lowering to a meaningless
+# representation-word / address compare (#2127). the `^` qualifier does not
+# change aggregate-ness; a pointer-to-aggregate is address-shaped and stays valid
+# (covered by the positive control).
+test "mach.lang.driver:aggregate_eq_rejected" {
+    var bad: i32 = 0;
+    val needle: str = "aggregate equality is not structural";
+    # a record value ==
+    if (ut_vec_diag("rec P { x: i64; y: i64; }\nfun cmp(a: P, b: P) u8 { ret a == b; }\nfun main() i32 { ret 0; }\n",
+        needle) != 0) { bad = 1; }
+    # a union value != (both operators reject)
+    if (ut_vec_diag("uni U { a: i64; b: i64; }\nfun cmp(a: U, b: U) u8 { ret a != b; }\nfun main() i32 { ret 0; }\n",
+        needle) != 0) { bad = 1; }
+    # an array value ==
+    if (ut_vec_diag("fun cmp(a: [4]u8, b: [4]u8) u8 { ret a == b; }\nfun main() i32 { ret 0; }\n",
+        needle) != 0) { bad = 1; }
+    # a secret record value == (the `^` qualifier does not change aggregate-ness)
+    if (ut_vec_diag("rec P { x: i64; y: i64; }\nfun cmp(a: ^P, b: ^P) u8 { ret a == b; }\nfun main() i32 { ret 0; }\n",
+        needle) != 0) { bad = 1; }
+    # a generic instance of a record ==
+    if (ut_vec_diag("rec Box[T] { v: T; }\nfun cmp(a: Box[i64], b: Box[i64]) u8 { ret a == b; }\nfun main() i32 { ret 0; }\n",
+        needle) != 0) { bad = 1; }
+    ret bad;
+}
+
+# `==`/`!=` stays valid for every scalar and address-shaped operand -- integer,
+# float, u8 (the `bool` backing), a typed pointer, a pointer-to-aggregate, and a
+# nested pointer -- and a field-wise / element-wise structural compare over an
+# aggregate is unaffected. none of these trip the aggregate-eq rejection (#2127),
+# so sema reports zero errors.
+test "mach.lang.driver:aggregate_eq_positive_control" {
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    val sr: R.Result[session.Session, str] = session.init(?alloc);
+    if (R.is_err[session.Session, str](sr)) { ret 1; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](sr);
+
+    val src: str = "rec P { x: i64; y: i64; }\nfun c_int(a: i64, b: i32) u8 { if (a == b) { ret 1; } ret 0; }\nfun c_flt(a: f64, b: f32) u8 { if (a == b) { ret 1; } ret 0; }\nfun c_u8(a: u8, b: u8) u8 { if (a == b) { ret 1; } ret 0; }\nfun c_ptr(a: *P, b: *P) u8 { if (a == b) { ret 1; } ret 0; }\nfun c_pp(a: **u8, b: **u8) u8 { if (a == b) { ret 1; } ret 0; }\nfun c_fld(a: P, b: P) u8 { if (a.x == b.x && a.y == b.y) { ret 1; } ret 0; }\nfun c_elem(a: [2]u8, b: [2]u8) u8 { if (a[0] == b[0] && a[1] == b[1]) { ret 1; } ret 0; }\nfun main() i32 { ret 0; }\n";
+    val pr: R.Result[project.Project, outcome.Fail] = ut_vec_sema(?s, ?alloc, src);
+    if (R.is_err[project.Project, outcome.Fail](pr)) { session.dnit(?s); ret 1; }
+    var p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](pr);
+
+    var bad: i32 = 0;
+    if (ut_count_errors(?p.s.diags) != 0) { bad = 1; }
+
+    project.dnit_project(?p);
+    session.dnit(?s);
+    ret bad;
+}
+
 # build a two-module project (main.mach + a.mach) from source, run resolve + sema,
 # and return the project so a test can inspect p.s.diags. the caller tears down the
 # project and session

--- a/src/lang/fe/sema/infer.mach
+++ b/src/lang/fe/sema/infer.mach
@@ -688,6 +688,16 @@ fun infer_binary(sc: *context.SemaContext, eid: id.ExprId, b: *expr.ExprBinary, 
                            || (is_float(sc, lt) && is_integer(sc, rt));
 
     if (b.op == expr.BIN_EQ || b.op == expr.BIN_NEQ) {
+        # aggregate VALUES (a record, union, or array, or a generic instance of
+        # one) have no defined `==`/`!=`: equality would compare representation
+        # words or an address rather than contents, silently returning the wrong
+        # answer, so it is rejected and pointed at a structural compare. a
+        # pointer-to-aggregate is address-shaped, not an aggregate value, and
+        # still compares legitimately by address.
+        if (is_aggregate(sc, lt) || is_aggregate(sc, rt)) {
+            report_aggregate_eq(sc, span, lt, rt);
+            ret type.TYPE_ERROR;
+        }
         # equality also relates two address-shaped operands (pointers and
         # functions, both runtime code/data addresses). this covers a bare
         # `fn == fn2` where neither side is a coercible literal; a comparison
@@ -2367,6 +2377,47 @@ fun is_pointer_like(sc: *context.SemaContext, ty: type.TypeId) bool {
     ret type.is_pointer_like(?sc.s.types, ty);
 }
 
+# whether `ty`'s resolved type is an aggregate VALUE -- a record, union, or array,
+# or a generic instance of a record/union
+#
+# These have no defined `==`/`!=`: equality would compare representation words or
+# an address, not contents. A secret `^T` is classified by its inner type; a
+# pointer (including pointer-to-aggregate) is address-shaped and excluded.
+# ---
+# sc:  sema context
+# ty:  the TypeId to classify
+# ret: true for a record/union/array value or an instance of one
+fun is_aggregate(sc: *context.SemaContext, ty: type.TypeId) bool {
+    val base: type.TypeId = type.strip_secret(?sc.s.types, ty);
+    val opt:  O.Option[*type.Type] = type.get(?sc.s.types, base);
+    if (O.is_none[*type.Type](opt)) { ret false; }
+    val t: *type.Type = O.unwrap[*type.Type](opt);
+    if (t.kind == type.TYPE_REC || t.kind == type.TYPE_UNI || t.kind == type.TYPE_ARRAY) { ret true; }
+    if (t.kind == type.TYPE_INSTANCE) {
+        ret instance_is_aggregate(sc, t.data.instance.target_origin, t.data.instance.target_decl);
+    }
+    ret false;
+}
+
+# whether generic instance `(origin, dcl)` specializes a record or union
+# declaration, read from the declaring module's AST
+#
+# A function generic also interns to a TYPE_INSTANCE but never reaches equality as
+# a value operand; this keeps the aggregate predicate precise if one ever does.
+# ---
+# sc:     sema context
+# origin: module that declared the generic
+# dcl:    the generic declaration in origin's AST
+# ret:    true when the target declaration is a record or union
+fun instance_is_aggregate(sc: *context.SemaContext, origin: session.ModuleId, dcl: id.DeclId) bool {
+    val ga: *ast.Ast = session.module_ast(sc.s, origin);
+    if (ga == nil) { ret false; }
+    val od: O.Option[*decl.Decl] = ast.get_decl(ga, dcl);
+    if (O.is_none[*decl.Decl](od)) { ret false; }
+    val dk: decl.DeclKind = O.unwrap[*decl.Decl](od).kind;
+    ret dk == decl.DECL_KIND_REC || dk == decl.DECL_KIND_UNI;
+}
+
 # the AST that owns `sym`'s declaration: this module's AST when the symbol is
 # local, otherwise the origin module's AST from the session
 # ---
@@ -2424,6 +2475,23 @@ fun type_mismatch(sc: *context.SemaContext, span: token.Span, lt: type.TypeId, r
 # span: the operator span
 fun report_int_float_cmp(sc: *context.SemaContext, span: token.Span) {
     context.report(sc, span, "type mismatch: cannot compare an integer and a float; cast one operand explicitly (`::`)");
+}
+
+# report an aggregate-value `==` / `!=`
+#
+# Rejected because a record, union, or array VALUE has no defined structural
+# equality: the lowering would compare representation words or an address, not
+# contents. Names whichever operand is the aggregate and points at a field-wise
+# compare or `std.derive.eq`.
+# ---
+# sc:   sema context
+# span: the operator span
+# lt:   the left operand type
+# rt:   the right operand type
+fun report_aggregate_eq(sc: *context.SemaContext, span: token.Span, lt: type.TypeId, rt: type.TypeId) {
+    var ty: type.TypeId = lt;
+    if (!is_aggregate(sc, lt)) { ty = rt; }
+    check.report_typed(sc, span, "cannot compare `", ty, "` values with `==` / `!=`: aggregate equality is not structural. compare fields or elements individually, or use `std.derive.eq` for a derived structural comparison", "cannot compare aggregate values with `==` / `!=`: aggregate equality is not structural; compare fields or elements individually, or use `std.derive.eq` for a derived structural comparison");
 }
 
 # intern the identifier text covered by `span`, or STR_NIL for an empty span


### PR DESCRIPTION
Closes #2127.

## Problem

`record == record`, `union == union`, and `array == array` on VALUE operands type-checked but lowered to an integer/address compare, not a structural one — silently returning the wrong answer with no diagnostic. Surfaced by std.derive (mach-std #285). Owner ruled **Option 1: reject in sema** (no hidden structural compare behind `==`).

## The operand-type predicate (rejected vs kept)

Reject in the `==`/`!=` inference path when **either** operand's resolved type is an aggregate VALUE:

- **REJECT:** record (`TYPE_REC`), union (`TYPE_UNI`), array (`TYPE_ARRAY`), a secret-qualified aggregate (`^record` — the `^` is stripped first, so aggregate-ness is unchanged), and a generic instance (`TYPE_INSTANCE`) whose target declaration is a record/union (`Box[i64]`).
- **KEEP VALID:** integer, float, `u8`/`bool`, raw `ptr`, typed `*T` (including **pointer-to-aggregate** `*P` — an address compare is legitimate), nested pointers `**u8`, functions, and vectors (their own lane-wise table, untouched). Field-wise / element-wise structural compares over an aggregate are unaffected, as is `std.derive.eq`.

The instance case resolves the target decl kind from the declaring module's AST, so a (hypothetical) function-generic instance is not swept in.

## The diagnostic

```
error: cannot compare `P` values with `==` / `!=`: aggregate equality is not structural.
       compare fields or elements individually, or use `std.derive.eq` for a derived
       structural comparison
```

Names the aggregate operand (rendered through `type_to_str`, so `^P` and `Box[i64]` print faithfully).

## Surfaced latent sites

None. This removes currently-accepted-but-already-wrong code, so it can turn latent misuse into new compile errors — but building the from-source compiler AND mach-std with the reject in place surfaced **zero** sites. The meaningless behavior was unused, as expected.

## Verification

- New tests (`src/lang/driver/tests.mach`): `aggregate_eq_rejected` (record `==`, union `!=`, array `==`, secret `^record`, generic instance — each hits the teaching diagnostic) and `aggregate_eq_positive_control` (int/float/`u8`/`*P`/`**u8`/field-wise/element-wise — zero sema errors).
- Full compiler suite green through the reject compiler: **725 passed, 0 failed** (73→75 driver tests).
- mach-std suite green through the reject compiler: **663 passed, 0 failed** (identical to seed baseline).
- int **linux** (native) and **linux-riscv64** (qemu) — all cases pass.
- Single-gen fixpoint **B==C byte-identical**.
- **Byte-identical codegen for valid code**: compiling a fixed valid input (the whole origin/dev compiler source) with a baseline no-reject compiler vs the reject compiler produces byte-identical output — release and `-g`. The change is a pure sema rejection; it does not alter any accepted-code path.
- **-g additivity preserved** (debug build also byte-identical).

## Note on #2137

This lives in the binary-op inference block that PR #2137 (constant-time foundation, still open) also touches (a secret-float variable-latency gate). The two checks are distinct — an aggregate-type reject vs a secret-operand gate — and compose as independent early guards in the same block. origin/dev is unchanged from this branch's base, so no rebase was needed; whichever lands second simply adds its guard alongside.
