### PR TITLE
feat(me): loop dependence analysis + runtime alias-check + versioning (#2140)

### DIFF
--- a/src/lang/me/analysis/dependence.mach
+++ b/src/lang/me/analysis/dependence.mach
@@ -1,0 +1,465 @@
+# mach.lang.me.analysis.dependence: cross-iteration memory-dependence analysis
+#
+# Over a counted loop recognized by `mach.lang.me.analysis.loops`, decide whether
+# the loop is a unit-stride, offset-0 element-wise map -- `dst[i] = f(src0[i], ...)`
+# -- carrying no cross-iteration memory dependence, and collect its memory accesses.
+#
+# The verdict is deliberately conservative (child 1's lesson): a positive
+# INDEPENDENT verdict is returned ONLY when every memory access in the loop is a
+# non-volatile load/store through `gep(base, iv)` -- a single index equal to the
+# loop's induction variable (offset 0, unit stride) over a loop-invariant base --
+# and the loop carries no register recurrence beyond the induction variable and no
+# opaque memory effect (call / asm / memzero). Anything unproven is DEPENDENT.
+#
+# A DEPENDENT verdict means "do not vectorize". An INDEPENDENT verdict means "safe
+# to vectorize IF the runtime alias check discharges base aliasing" -- distinct
+# pointer bases cannot be proven disjoint at compile time (mach has no `restrict`),
+# so the caller pairs this with the runtime alias guard in the versioning module.
+#
+# This module is a callable analysis; it is not wired into the pipeline (nothing
+# imports it there), so it does not affect emitted code.
+
+use std.types.bool.bool;
+use std.types.bool.false;
+use std.types.bool.true;
+use std.types.size.usize;
+use std.types.string.str;
+
+use A: std.allocator;
+use O: std.types.option;
+use R: std.types.result;
+
+use mach.lang.me.ir;
+use mach.lang.me.ir.id;
+use mach.lang.me.ir.instruction;
+use mach.lang.me.ir.value;
+use ir_type: mach.lang.me.ir.type;
+use loops: mach.lang.me.analysis.loops;
+
+# one recognized affine memory access `base[iv]` in a counted loop
+# ---
+# instr:     the load or store instruction
+# gep:       the OP_GEP computing `base[iv]` that the access dereferences
+# base:      the loop-invariant base pointer (the gep's first operand)
+# stride_ty: the gep's source pointee type -- the per-element stride, reused to
+#            compute the accessed byte range for the alias guard
+# elem_ty:   the loaded / stored value type
+# is_store:  true for a store, false for a load
+pub rec MemAccess {
+    instr:     id.InstructionId;
+    gep:       id.InstructionId;
+    base:      value.Value;
+    stride_ty: ir_type.IrTypeId;
+    elem_ty:   ir_type.IrTypeId;
+    is_store:  bool;
+}
+
+# the dependence verdict for a loop
+pub def DepVerdict: u8;
+# unit-stride offset-0 element-wise map, no cross-iteration dependence: safe to
+# vectorize once base aliasing is discharged by the runtime alias guard
+pub val DEP_INDEPENDENT: DepVerdict = 0;
+# a proven or unprovable cross-iteration dependence / opaque effect: do not vectorize
+pub val DEP_DEPENDENT:   DepVerdict = 1;
+
+# the memory-dependence analysis of one counted loop
+# ---
+# alloc:        allocator backing `accesses`
+# verdict:      DEP_INDEPENDENT or DEP_DEPENDENT
+# accesses:     the recognized element-wise accesses, meaningful only when the
+#               verdict is DEP_INDEPENDENT (owned)
+# access_count: number of accesses
+# access_cap:   allocated capacity of `accesses`
+pub rec DepInfo {
+    alloc:        *A.Allocator;
+    verdict:      DepVerdict;
+    accesses:     *MemAccess;
+    access_count: u32;
+    access_cap:   u32;
+}
+
+# analyze loop `loop_ix` for cross-iteration memory dependence
+#
+# Never mutates `fn`. Returns a DepInfo whose verdict is DEP_INDEPENDENT only for
+# the proven unit-stride offset-0 element-wise shape; every other loop (including a
+# non-counted one) is DEP_DEPENDENT. Allocation failure is the only err.
+# ---
+# fn:      the function
+# la:      the loop analysis for `fn`
+# loop_ix: index into la.loops
+# alloc:   allocator for the accesses array
+# ret:     the dependence info, or an allocation error
+pub fun analyze_dependence(fn: *ir.Function, la: *loops.LoopAnalysis, loop_ix: u32, alloc: *A.Allocator) R.Result[DepInfo, str] {
+    var d: DepInfo;
+    d.alloc        = alloc;
+    d.verdict      = DEP_DEPENDENT;
+    d.accesses     = nil;
+    d.access_count = 0;
+    d.access_cap   = 0;
+
+    if (loop_ix >= la.loop_len) { ret R.ok[DepInfo, str](d); }
+    val lp: *loops.Loop = ?la.loops[loop_ix];
+
+    # only a counted loop with a unit-stride induction variable is a candidate.
+    if (!lp.is_counted) { ret R.ok[DepInfo, str](d); }
+    if (lp.iv.step.kind != value.VAL_CONST_INT) { ret R.ok[DepInfo, str](d); }
+    if (lp.iv.step.data.int_lit != 1) { ret R.ok[DepInfo, str](d); }
+
+    # the induction variable must be the loop's ONLY register recurrence: the header
+    # carries exactly one phi (the iv) and no other loop block carries any phi. an
+    # extra phi is a reduction / scan carried across iterations (child 4's concern).
+    if (!single_iv_recurrence(fn, la, loop_ix)) { ret R.ok[DepInfo, str](d); }
+
+    # upper-bound the accesses array by the loop's instruction count.
+    var total: u32 = 0;
+    var bi: u32 = 0;
+    for (bi < lp.body_len) {
+        total = total + fn.blocks[lp.body[bi]::u32].instr_count;
+        bi = bi + 1;
+    }
+    if (total > 0) {
+        val ra: R.Result[*MemAccess, str] = A.allocate[MemAccess](alloc, total::usize);
+        if (R.is_err[*MemAccess, str](ra)) { ret R.err[DepInfo, str](R.unwrap_err[*MemAccess, str](ra)); }
+        d.accesses  = R.unwrap_ok[*MemAccess, str](ra);
+        d.access_cap = total;
+    }
+
+    # walk every body instruction; any opaque effect or non-element-wise access
+    # forces the conservative DEPENDENT verdict.
+    bi = 0;
+    for (bi < lp.body_len) {
+        val blk: *ir.Block = ?fn.blocks[lp.body[bi]::u32];
+        var ii: u32 = 0;
+        for (ii < blk.instr_count) {
+            val iid: id.InstructionId = blk.instructions[ii];
+            val opt: O.Option[*instruction.Instruction] = ir.instruction_get(fn, iid);
+            if (O.is_none[*instruction.Instruction](opt)) { dep_dnit(?d); ret dependent(alloc); }
+            val inst: *instruction.Instruction = O.unwrap[*instruction.Instruction](opt);
+
+            if (inst.kind == instruction.OP_CALL || inst.kind == instruction.OP_ASM || inst.kind == instruction.OP_MEMZERO) {
+                dep_dnit(?d); ret dependent(alloc);
+            }
+            if (inst.kind == instruction.OP_LOAD || inst.kind == instruction.OP_STORE) {
+                var acc: MemAccess;
+                if (!classify_access(fn, la, loop_ix, iid, inst, ?acc)) { dep_dnit(?d); ret dependent(alloc); }
+                d.accesses[d.access_count] = acc;
+                d.access_count = d.access_count + 1;
+            }
+            ii = ii + 1;
+        }
+        bi = bi + 1;
+    }
+
+    d.verdict = DEP_INDEPENDENT;
+    ret R.ok[DepInfo, str](d);
+}
+
+# a fresh conservative DEPENDENT verdict with no accesses
+fun dependent(alloc: *A.Allocator) R.Result[DepInfo, str] {
+    var d: DepInfo;
+    d.alloc        = alloc;
+    d.verdict      = DEP_DEPENDENT;
+    d.accesses     = nil;
+    d.access_count = 0;
+    d.access_cap   = 0;
+    ret R.ok[DepInfo, str](d);
+}
+
+# release the accesses array
+# ---
+# d: the dependence info to tear down
+pub fun dep_dnit(d: *DepInfo) {
+    if (d.accesses != nil && d.access_cap > 0) {
+        A.deallocate[MemAccess](d.alloc, d.accesses, d.access_cap::usize);
+        d.accesses = nil;
+    }
+    d.access_count = 0;
+    d.access_cap   = 0;
+}
+
+# true when the loop's only phi recurrence is the induction variable: the header
+# has exactly one phi (the iv) and no other loop block has any phi
+fun single_iv_recurrence(fn: *ir.Function, la: *loops.LoopAnalysis, loop_ix: u32) bool {
+    val lp: *loops.Loop = ?la.loops[loop_ix];
+    var bi: u32 = 0;
+    for (bi < lp.body_len) {
+        val bid: id.BlockId = lp.body[bi];
+        val blk: *ir.Block = ?fn.blocks[bid::u32];
+        if (bid == lp.header) {
+            if (blk.phi_count != 1) { ret false; }
+            if (blk.phis[0] != lp.iv.phi) { ret false; }
+        } or {
+            if (blk.phi_count != 0) { ret false; }
+        }
+        bi = bi + 1;
+    }
+    ret true;
+}
+
+# classify a load/store as an element-wise `base[iv]` access, filling `out` on
+# success. requires: non-volatile; the pointer is a single-index gep whose index is
+# exactly the induction-variable phi (offset 0, unit stride) and whose base is
+# loop-invariant.
+fun classify_access(fn: *ir.Function, la: *loops.LoopAnalysis, loop_ix: u32, iid: id.InstructionId, inst: *instruction.Instruction, out: *MemAccess) bool {
+    if ((inst.flags & instruction.INSTR_FLAG_VOLATILE) != 0) { ret false; }
+    val is_store: bool = inst.kind == instruction.OP_STORE;
+
+    # the pointer operand: LOAD = [ptr], STORE = [value, ptr]
+    var ptr: value.Value;
+    if (is_store) {
+        if (inst.operand_count < 2) { ret false; }
+        ptr = inst.operands[1];
+    } or {
+        if (inst.operand_count < 1) { ret false; }
+        ptr = inst.operands[0];
+    }
+    if (ptr.kind != value.VAL_INSTR) { ret false; }
+
+    val gopt: O.Option[*instruction.Instruction] = ir.instruction_get(fn, ptr.data.instr);
+    if (O.is_none[*instruction.Instruction](gopt)) { ret false; }
+    val gep: *instruction.Instruction = O.unwrap[*instruction.Instruction](gopt);
+    if (gep.kind != instruction.OP_GEP || gep.operand_count != 2) { ret false; }
+
+    val base: value.Value = gep.operands[0];
+    val idx:  value.Value = gep.operands[1];
+    val lp: *loops.Loop = ?la.loops[loop_ix];
+    # index must be exactly the induction variable (offset 0)
+    if (idx.kind != value.VAL_INSTR || idx.data.instr != lp.iv.phi) { ret false; }
+    # base must be loop-invariant
+    if (!loops.is_invariant(la, loop_ix, base)) { ret false; }
+
+    out.instr     = iid;
+    out.gep       = ptr.data.instr;
+    out.base      = base;
+    out.stride_ty = gep.aux_ty;
+    # a store produces no value, so its element type is the stored value's type;
+    # a load's element type is its own result type
+    if (is_store) { out.elem_ty = inst.operands[0].ty; } or { out.elem_ty = inst.ty; }
+    out.is_store  = is_store;
+    ret true;
+}
+
+use std.allocator.page;
+use mach.lang.intern;
+use mach.lang.me.ir.builder;
+
+# build a counted-loop skeleton (entry -> header -> body -> exit) with an i64
+# induction variable `{0, +, 1}` tested `iv < param0`; the caller fills `body` and
+# wires the iv's body-incoming + `br header`. Returns 0 on success.
+fun mk_skeleton(m: *ir.Module, bld: *builder.Builder, i64t: ir_type.IrTypeId, o_entry: *id.BlockId, o_header: *id.BlockId, o_body: *id.BlockId, o_exit: *id.BlockId, o_iv: *value.Value) i32 {
+    val re: R.Result[id.BlockId, str] = builder.new_block(bld);
+    if (R.is_err[id.BlockId, str](re)) { ret 1; }
+    val entry: id.BlockId = R.unwrap_ok[id.BlockId, str](re);
+    val rh: R.Result[id.BlockId, str] = builder.new_block(bld);
+    if (R.is_err[id.BlockId, str](rh)) { ret 1; }
+    val header: id.BlockId = R.unwrap_ok[id.BlockId, str](rh);
+    val rb: R.Result[id.BlockId, str] = builder.new_block(bld);
+    if (R.is_err[id.BlockId, str](rb)) { ret 1; }
+    val body: id.BlockId = R.unwrap_ok[id.BlockId, str](rb);
+    val rx: R.Result[id.BlockId, str] = builder.new_block(bld);
+    if (R.is_err[id.BlockId, str](rx)) { ret 1; }
+    val exit: id.BlockId = R.unwrap_ok[id.BlockId, str](rx);
+
+    val n: value.Value = value.param(0, i64t);
+
+    builder.set_block(bld, entry);
+    if (R.is_err[bool, str](builder.emit_br(bld, header))) { ret 1; }
+
+    builder.set_block(bld, header);
+    val rphi: R.Result[value.Value, str] = builder.emit_phi(bld, i64t);
+    if (R.is_err[value.Value, str](rphi)) { ret 1; }
+    val iv: value.Value = R.unwrap_ok[value.Value, str](rphi);
+    val rc: R.Result[value.Value, str] = builder.emit_cmp_lt_s(bld, iv, n);
+    if (R.is_err[value.Value, str](rc)) { ret 1; }
+    if (R.is_err[bool, str](builder.emit_cbr(bld, R.unwrap_ok[value.Value, str](rc), body, exit))) { ret 1; }
+
+    builder.set_block(bld, exit);
+    if (R.is_err[bool, str](builder.emit_ret_void(bld))) { ret 1; }
+
+    if (R.is_err[bool, str](builder.phi_add_incoming(bld, iv, entry, value.const_int(0, i64t)))) { ret 1; }
+
+    @o_entry = entry; @o_header = header; @o_body = body; @o_exit = exit; @o_iv = iv;
+    ret 0;
+}
+
+# emit `dst[iv] = ...` style access geps in the body; helper to keep tests terse:
+# gep(base, iv) with an i64 element stride.
+fun body_gep(bld: *builder.Builder, base: value.Value, iv: value.Value, i64t: ir_type.IrTypeId) R.Result[value.Value, str] {
+    var ix: [1]value.Value;
+    ix[0] = iv;
+    ret builder.emit_gep(bld, base, i64t, ?ix[0], 1);
+}
+
+# an element-wise `a[i] = b[i] + c[i]` over three distinct pointer-parameter bases
+# with unit stride carries no cross-iteration dependence: INDEPENDENT, three accesses.
+test "mach.lang.me.analysis.dependence:elementwise_independent" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+    val rm: R.Result[ir.Module, str] = ir.init(?alloc, intern.STR_NIL);
+    if (R.is_err[ir.Module, str](rm)) { ret 1; }
+    var m: ir.Module = R.unwrap_ok[ir.Module, str](rm);
+    val rt: R.Result[ir_type.IrTypeId, str] = ir_type.intern_int(?m.types, 64);
+    if (R.is_err[ir_type.IrTypeId, str](rt)) { ir.dnit(?m); ret 1; }
+    val i64t: ir_type.IrTypeId = R.unwrap_ok[ir_type.IrTypeId, str](rt);
+    val rp: R.Result[ir_type.IrTypeId, str] = ir_type.intern_ptr(?m.types);
+    if (R.is_err[ir_type.IrTypeId, str](rp)) { ir.dnit(?m); ret 1; }
+    val ptrt: ir_type.IrTypeId = R.unwrap_ok[ir_type.IrTypeId, str](rp);
+    val rf: R.Result[u32, str] = ir.function_add(?m, intern.STR_NIL, ir_type.IRT_NIL, 0);
+    if (R.is_err[u32, str](rf)) { ir.dnit(?m); ret 1; }
+    val fn: *ir.Function = ?m.functions[R.unwrap_ok[u32, str](rf)];
+    var bld: builder.Builder = builder.init(?m);
+    builder.set_function(?bld, fn);
+
+    var entry: id.BlockId; var header: id.BlockId; var body: id.BlockId; var exit: id.BlockId; var iv: value.Value;
+    if (mk_skeleton(?m, ?bld, i64t, ?entry, ?header, ?body, ?exit, ?iv) != 0) { ir.dnit(?m); ret 1; }
+
+    val a: value.Value = value.param(1, ptrt);
+    val b: value.Value = value.param(2, ptrt);
+    val c: value.Value = value.param(3, ptrt);
+
+    builder.set_block(?bld, body);
+    val rgb: R.Result[value.Value, str] = body_gep(?bld, b, iv, i64t);
+    if (R.is_err[value.Value, str](rgb)) { ir.dnit(?m); ret 1; }
+    val rlb: R.Result[value.Value, str] = builder.emit_load(?bld, R.unwrap_ok[value.Value, str](rgb), i64t);
+    if (R.is_err[value.Value, str](rlb)) { ir.dnit(?m); ret 1; }
+    val rgc: R.Result[value.Value, str] = body_gep(?bld, c, iv, i64t);
+    if (R.is_err[value.Value, str](rgc)) { ir.dnit(?m); ret 1; }
+    val rlc: R.Result[value.Value, str] = builder.emit_load(?bld, R.unwrap_ok[value.Value, str](rgc), i64t);
+    if (R.is_err[value.Value, str](rlc)) { ir.dnit(?m); ret 1; }
+    val rs: R.Result[value.Value, str] = builder.emit_add(?bld, R.unwrap_ok[value.Value, str](rlb), R.unwrap_ok[value.Value, str](rlc));
+    if (R.is_err[value.Value, str](rs)) { ir.dnit(?m); ret 1; }
+    val rga: R.Result[value.Value, str] = body_gep(?bld, a, iv, i64t);
+    if (R.is_err[value.Value, str](rga)) { ir.dnit(?m); ret 1; }
+    if (R.is_err[bool, str](builder.emit_store(?bld, R.unwrap_ok[value.Value, str](rs), R.unwrap_ok[value.Value, str](rga)))) { ir.dnit(?m); ret 1; }
+    val ru: R.Result[value.Value, str] = builder.emit_add(?bld, iv, value.const_int(1, i64t));
+    if (R.is_err[value.Value, str](ru)) { ir.dnit(?m); ret 1; }
+    val upd: value.Value = R.unwrap_ok[value.Value, str](ru);
+    if (R.is_err[bool, str](builder.phi_add_incoming(?bld, iv, body, upd))) { ir.dnit(?m); ret 1; }
+    if (R.is_err[bool, str](builder.emit_br(?bld, header))) { ir.dnit(?m); ret 1; }
+
+    var code: i32 = 0;
+    val ral: R.Result[loops.LoopAnalysis, str] = loops.analyze(fn, ?alloc);
+    if (R.is_err[loops.LoopAnalysis, str](ral)) { ir.dnit(?m); ret 1; }
+    var la: loops.LoopAnalysis = R.unwrap_ok[loops.LoopAnalysis, str](ral);
+    val rd: R.Result[DepInfo, str] = analyze_dependence(fn, ?la, 0, ?alloc);
+    if (R.is_err[DepInfo, str](rd)) { loops.dnit(?la); ir.dnit(?m); ret 1; }
+    var di: DepInfo = R.unwrap_ok[DepInfo, str](rd);
+    if (di.verdict != DEP_INDEPENDENT) { code = 1; }
+    if (di.access_count != 3)          { code = 1; }
+    dep_dnit(?di);
+    loops.dnit(?la);
+    ir.dnit(?m);
+    ret code;
+}
+
+# a loop-carried access `a[i] = a[i-1]` (load index iv-1, not iv) is a cross-iteration
+# dependence: DEPENDENT.
+test "mach.lang.me.analysis.dependence:loop_carried_dependent" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+    val rm: R.Result[ir.Module, str] = ir.init(?alloc, intern.STR_NIL);
+    if (R.is_err[ir.Module, str](rm)) { ret 1; }
+    var m: ir.Module = R.unwrap_ok[ir.Module, str](rm);
+    val rt: R.Result[ir_type.IrTypeId, str] = ir_type.intern_int(?m.types, 64);
+    if (R.is_err[ir_type.IrTypeId, str](rt)) { ir.dnit(?m); ret 1; }
+    val i64t: ir_type.IrTypeId = R.unwrap_ok[ir_type.IrTypeId, str](rt);
+    val rp: R.Result[ir_type.IrTypeId, str] = ir_type.intern_ptr(?m.types);
+    if (R.is_err[ir_type.IrTypeId, str](rp)) { ir.dnit(?m); ret 1; }
+    val ptrt: ir_type.IrTypeId = R.unwrap_ok[ir_type.IrTypeId, str](rp);
+    val rf: R.Result[u32, str] = ir.function_add(?m, intern.STR_NIL, ir_type.IRT_NIL, 0);
+    if (R.is_err[u32, str](rf)) { ir.dnit(?m); ret 1; }
+    val fn: *ir.Function = ?m.functions[R.unwrap_ok[u32, str](rf)];
+    var bld: builder.Builder = builder.init(?m);
+    builder.set_function(?bld, fn);
+
+    var entry: id.BlockId; var header: id.BlockId; var body: id.BlockId; var exit: id.BlockId; var iv: value.Value;
+    if (mk_skeleton(?m, ?bld, i64t, ?entry, ?header, ?body, ?exit, ?iv) != 0) { ir.dnit(?m); ret 1; }
+
+    val a: value.Value = value.param(1, ptrt);
+    builder.set_block(?bld, body);
+    val rim1: R.Result[value.Value, str] = builder.emit_add(?bld, iv, value.const_int(0xFFFFFFFFFFFFFFFF, i64t));
+    if (R.is_err[value.Value, str](rim1)) { ir.dnit(?m); ret 1; }
+    val rgs: R.Result[value.Value, str] = body_gep(?bld, a, R.unwrap_ok[value.Value, str](rim1), i64t);
+    if (R.is_err[value.Value, str](rgs)) { ir.dnit(?m); ret 1; }
+    val rl: R.Result[value.Value, str] = builder.emit_load(?bld, R.unwrap_ok[value.Value, str](rgs), i64t);
+    if (R.is_err[value.Value, str](rl)) { ir.dnit(?m); ret 1; }
+    val rgd: R.Result[value.Value, str] = body_gep(?bld, a, iv, i64t);
+    if (R.is_err[value.Value, str](rgd)) { ir.dnit(?m); ret 1; }
+    if (R.is_err[bool, str](builder.emit_store(?bld, R.unwrap_ok[value.Value, str](rl), R.unwrap_ok[value.Value, str](rgd)))) { ir.dnit(?m); ret 1; }
+    val ru: R.Result[value.Value, str] = builder.emit_add(?bld, iv, value.const_int(1, i64t));
+    if (R.is_err[value.Value, str](ru)) { ir.dnit(?m); ret 1; }
+    if (R.is_err[bool, str](builder.phi_add_incoming(?bld, iv, body, R.unwrap_ok[value.Value, str](ru)))) { ir.dnit(?m); ret 1; }
+    if (R.is_err[bool, str](builder.emit_br(?bld, header))) { ir.dnit(?m); ret 1; }
+
+    var code: i32 = 0;
+    val ral: R.Result[loops.LoopAnalysis, str] = loops.analyze(fn, ?alloc);
+    if (R.is_err[loops.LoopAnalysis, str](ral)) { ir.dnit(?m); ret 1; }
+    var la: loops.LoopAnalysis = R.unwrap_ok[loops.LoopAnalysis, str](ral);
+    val rd: R.Result[DepInfo, str] = analyze_dependence(fn, ?la, 0, ?alloc);
+    if (R.is_err[DepInfo, str](rd)) { loops.dnit(?la); ir.dnit(?m); ret 1; }
+    var di: DepInfo = R.unwrap_ok[DepInfo, str](rd);
+    if (di.verdict != DEP_DEPENDENT) { code = 1; }
+    dep_dnit(?di);
+    loops.dnit(?la);
+    ir.dnit(?m);
+    ret code;
+}
+
+# a reduction loop carries a second header phi (the accumulator) beyond the induction
+# variable: conservatively DEPENDENT (child 4 handles reductions).
+test "mach.lang.me.analysis.dependence:reduction_dependent" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+    val rm: R.Result[ir.Module, str] = ir.init(?alloc, intern.STR_NIL);
+    if (R.is_err[ir.Module, str](rm)) { ret 1; }
+    var m: ir.Module = R.unwrap_ok[ir.Module, str](rm);
+    val rt: R.Result[ir_type.IrTypeId, str] = ir_type.intern_int(?m.types, 64);
+    if (R.is_err[ir_type.IrTypeId, str](rt)) { ir.dnit(?m); ret 1; }
+    val i64t: ir_type.IrTypeId = R.unwrap_ok[ir_type.IrTypeId, str](rt);
+    val rp: R.Result[ir_type.IrTypeId, str] = ir_type.intern_ptr(?m.types);
+    if (R.is_err[ir_type.IrTypeId, str](rp)) { ir.dnit(?m); ret 1; }
+    val ptrt: ir_type.IrTypeId = R.unwrap_ok[ir_type.IrTypeId, str](rp);
+    val rf: R.Result[u32, str] = ir.function_add(?m, intern.STR_NIL, ir_type.IRT_NIL, 0);
+    if (R.is_err[u32, str](rf)) { ir.dnit(?m); ret 1; }
+    val fn: *ir.Function = ?m.functions[R.unwrap_ok[u32, str](rf)];
+    var bld: builder.Builder = builder.init(?m);
+    builder.set_function(?bld, fn);
+
+    var entry: id.BlockId; var header: id.BlockId; var body: id.BlockId; var exit: id.BlockId; var iv: value.Value;
+    if (mk_skeleton(?m, ?bld, i64t, ?entry, ?header, ?body, ?exit, ?iv) != 0) { ir.dnit(?m); ret 1; }
+
+    # add a second header phi (accumulator) -> two recurrences
+    builder.set_block(?bld, header);
+    val racc: R.Result[value.Value, str] = builder.emit_phi(?bld, i64t);
+    if (R.is_err[value.Value, str](racc)) { ir.dnit(?m); ret 1; }
+    val acc: value.Value = R.unwrap_ok[value.Value, str](racc);
+
+    val a: value.Value = value.param(1, ptrt);
+    builder.set_block(?bld, body);
+    val rg: R.Result[value.Value, str] = body_gep(?bld, a, iv, i64t);
+    if (R.is_err[value.Value, str](rg)) { ir.dnit(?m); ret 1; }
+    val rl: R.Result[value.Value, str] = builder.emit_load(?bld, R.unwrap_ok[value.Value, str](rg), i64t);
+    if (R.is_err[value.Value, str](rl)) { ir.dnit(?m); ret 1; }
+    val racu: R.Result[value.Value, str] = builder.emit_add(?bld, acc, R.unwrap_ok[value.Value, str](rl));
+    if (R.is_err[value.Value, str](racu)) { ir.dnit(?m); ret 1; }
+    val acc_upd: value.Value = R.unwrap_ok[value.Value, str](racu);
+    val ru: R.Result[value.Value, str] = builder.emit_add(?bld, iv, value.const_int(1, i64t));
+    if (R.is_err[value.Value, str](ru)) { ir.dnit(?m); ret 1; }
+    if (R.is_err[bool, str](builder.phi_add_incoming(?bld, iv, body, R.unwrap_ok[value.Value, str](ru)))) { ir.dnit(?m); ret 1; }
+    if (R.is_err[bool, str](builder.phi_add_incoming(?bld, acc, entry, value.const_int(0, i64t)))) { ir.dnit(?m); ret 1; }
+    if (R.is_err[bool, str](builder.phi_add_incoming(?bld, acc, body, acc_upd))) { ir.dnit(?m); ret 1; }
+    if (R.is_err[bool, str](builder.emit_br(?bld, header))) { ir.dnit(?m); ret 1; }
+
+    var code: i32 = 0;
+    val ral: R.Result[loops.LoopAnalysis, str] = loops.analyze(fn, ?alloc);
+    if (R.is_err[loops.LoopAnalysis, str](ral)) { ir.dnit(?m); ret 1; }
+    var la: loops.LoopAnalysis = R.unwrap_ok[loops.LoopAnalysis, str](ral);
+    val rd: R.Result[DepInfo, str] = analyze_dependence(fn, ?la, 0, ?alloc);
+    if (R.is_err[DepInfo, str](rd)) { loops.dnit(?la); ir.dnit(?m); ret 1; }
+    var di: DepInfo = R.unwrap_ok[DepInfo, str](rd);
+    if (di.verdict != DEP_DEPENDENT) { code = 1; }
+    dep_dnit(?di);
+    loops.dnit(?la);
+    ir.dnit(?m);
+    ret code;
+}

--- a/src/lang/me/analysis/dependence.mach
+++ b/src/lang/me/analysis/dependence.mach
@@ -44,6 +44,8 @@ use loops: mach.lang.me.analysis.loops;
 # stride_ty: the gep's source pointee type -- the per-element stride, reused to
 #            compute the accessed byte range for the alias guard
 # elem_ty:   the loaded / stored value type
+# bytes:     the contiguous element footprint in bytes -- the gep stride and the
+#            access width, which INDEPENDENT requires to be equal (an exact tiling)
 # is_store:  true for a store, false for a load
 pub rec MemAccess {
     instr:     id.InstructionId;
@@ -51,6 +53,7 @@ pub rec MemAccess {
     base:      value.Value;
     stride_ty: ir_type.IrTypeId;
     elem_ty:   ir_type.IrTypeId;
+    bytes:     u32;
     is_store:  bool;
 }
 
@@ -87,9 +90,10 @@ pub rec DepInfo {
 # fn:      the function
 # la:      the loop analysis for `fn`
 # loop_ix: index into la.loops
+# types:   the module's IR type table, for the target-independent scalar footprints
 # alloc:   allocator for the accesses array
 # ret:     the dependence info, or an allocation error
-pub fun analyze_dependence(fn: *ir.Function, la: *loops.LoopAnalysis, loop_ix: u32, alloc: *A.Allocator) R.Result[DepInfo, str] {
+pub fun analyze_dependence(fn: *ir.Function, la: *loops.LoopAnalysis, loop_ix: u32, types: *ir_type.IrTypeTable, alloc: *A.Allocator) R.Result[DepInfo, str] {
     var d: DepInfo;
     d.alloc        = alloc;
     d.verdict      = DEP_DEPENDENT;
@@ -141,7 +145,7 @@ pub fun analyze_dependence(fn: *ir.Function, la: *loops.LoopAnalysis, loop_ix: u
             }
             if (inst.kind == instruction.OP_LOAD || inst.kind == instruction.OP_STORE) {
                 var acc: MemAccess;
-                if (!classify_access(fn, la, loop_ix, iid, inst, ?acc)) { dep_dnit(?d); ret dependent(alloc); }
+                if (!classify_access(fn, la, loop_ix, iid, inst, types, ?acc)) { dep_dnit(?d); ret dependent(alloc); }
                 d.accesses[d.access_count] = acc;
                 d.access_count = d.access_count + 1;
             }
@@ -150,8 +154,61 @@ pub fun analyze_dependence(fn: *ir.Function, la: *loops.LoopAnalysis, loop_ix: u
         bi = bi + 1;
     }
 
+    # every pair of accesses to the SAME base must have an identical footprint. with
+    # stride == width and offset 0 already enforced per access, equal bytes means the
+    # same per-iteration address window; a same-base pair with differing widths (an
+    # i8 load and an i64 store on `a`) is a genuine cross-iteration RAW and the guard
+    # cannot fix it (the ranges are not disjoint, they coincide).
+    var i: u32 = 0;
+    for (i < d.access_count) {
+        var j: u32 = i + 1;
+        for (j < d.access_count) {
+            if (equal(d.accesses[i].base, d.accesses[j].base) && d.accesses[i].bytes != d.accesses[j].bytes) {
+                dep_dnit(?d); ret dependent(alloc);
+            }
+            j = j + 1;
+        }
+        i = i + 1;
+    }
+
     d.verdict = DEP_INDEPENDENT;
     ret R.ok[DepInfo, str](d);
+}
+
+# structural equality of two values by kind and payload: same instruction /
+# parameter / global / function reference, or the same inline constant (floats by
+# bit pattern, so -0.0 and NaN behave). Borrowed byte-blob and serialized aggregate
+# constants compare unequal. Ignores the `ty` field: identity is the referent, not
+# the use-site stamp. The single value-identity predicate the auto-vectorization
+# modules share (dependence's same-base check, versioning's alias-pairing); it lives
+# here rather than in ir/value.mach so this feature stays dormant / byte-identical
+# until child 3 wires the vectorizer in (an emitted ir/value.mach helper would grow
+# the compiler binary). Mirrors the private copies in constfold / cse.
+# ---
+# a:   first value
+# b:   second value
+# ret: true when a and b denote the same value
+pub fun equal(a: value.Value, b: value.Value) bool {
+    if (a.kind != b.kind)                { ret false; }
+    if (a.kind == value.VAL_INSTR)       { ret a.data.instr == b.data.instr; }
+    if (a.kind == value.VAL_PARAM)       { ret a.data.param_ix == b.data.param_ix; }
+    if (a.kind == value.VAL_CONST_INT)   { ret a.data.int_lit == b.data.int_lit; }
+    if (a.kind == value.VAL_CONST_NULL)  { ret true; }
+    if (a.kind == value.VAL_CONST_FLOAT) { ret (a.data.float_lit:~u64) == (b.data.float_lit:~u64); }
+    if (a.kind == value.VAL_GLOBAL)      { ret a.data.global_ix == b.data.global_ix; }
+    if (a.kind == value.VAL_FN)          { ret a.data.fn_ix == b.data.fn_ix; }
+    ret false;
+}
+
+# the byte footprint of a scalar integer / float type, target-independently (bits /
+# 8); 0 for any other type (pointer, aggregate, vector, void, sub-byte), which is
+# not a vectorizable element and forces a DEPENDENT verdict
+fun scalar_bytes(types: *ir_type.IrTypeTable, id: ir_type.IrTypeId) u32 {
+    val opt: O.Option[*ir_type.IrType] = ir_type.get(types, id);
+    if (O.is_none[*ir_type.IrType](opt)) { ret 0; }
+    val t: *ir_type.IrType = O.unwrap[*ir_type.IrType](opt);
+    if (t.kind == ir_type.IRT_INT || t.kind == ir_type.IRT_FLOAT) { ret t.data.bits / 8; }
+    ret 0;
 }
 
 # a fresh conservative DEPENDENT verdict with no accesses
@@ -200,7 +257,7 @@ fun single_iv_recurrence(fn: *ir.Function, la: *loops.LoopAnalysis, loop_ix: u32
 # success. requires: non-volatile; the pointer is a single-index gep whose index is
 # exactly the induction-variable phi (offset 0, unit stride) and whose base is
 # loop-invariant.
-fun classify_access(fn: *ir.Function, la: *loops.LoopAnalysis, loop_ix: u32, iid: id.InstructionId, inst: *instruction.Instruction, out: *MemAccess) bool {
+fun classify_access(fn: *ir.Function, la: *loops.LoopAnalysis, loop_ix: u32, iid: id.InstructionId, inst: *instruction.Instruction, types: *ir_type.IrTypeTable, out: *MemAccess) bool {
     if ((inst.flags & instruction.INSTR_FLAG_VOLATILE) != 0) { ret false; }
     val is_store: bool = inst.kind == instruction.OP_STORE;
 
@@ -228,13 +285,26 @@ fun classify_access(fn: *ir.Function, la: *loops.LoopAnalysis, loop_ix: u32, iid
     # base must be loop-invariant
     if (!loops.is_invariant(la, loop_ix, base)) { ret false; }
 
+    # a store produces no value, so its element type is the stored value's type;
+    # a load's element type is its own result type
+    var elem_ty: ir_type.IrTypeId = inst.ty;
+    if (is_store) { elem_ty = inst.operands[0].ty; }
+
+    # the access must exactly tile memory: the gep's per-index stride equals the
+    # access width, both a supported scalar footprint. a wider-than-stride access
+    # (a 1-byte stride feeding an 8-byte store) overlaps its own windows across
+    # iterations; a narrower one leaves gaps -- neither is a contiguous unit map.
+    val stride_bytes: u32 = scalar_bytes(types, gep.aux_ty);
+    val width_bytes:  u32 = scalar_bytes(types, elem_ty);
+    if (stride_bytes == 0 || width_bytes == 0) { ret false; }
+    if (stride_bytes != width_bytes)           { ret false; }
+
     out.instr     = iid;
     out.gep       = ptr.data.instr;
     out.base      = base;
     out.stride_ty = gep.aux_ty;
-    # a store produces no value, so its element type is the stored value's type;
-    # a load's element type is its own result type
-    if (is_store) { out.elem_ty = inst.operands[0].ty; } or { out.elem_ty = inst.ty; }
+    out.elem_ty   = elem_ty;
+    out.bytes     = width_bytes;
     out.is_store  = is_store;
     ret true;
 }
@@ -341,7 +411,7 @@ test "mach.lang.me.analysis.dependence:elementwise_independent" {
     val ral: R.Result[loops.LoopAnalysis, str] = loops.analyze(fn, ?alloc);
     if (R.is_err[loops.LoopAnalysis, str](ral)) { ir.dnit(?m); ret 1; }
     var la: loops.LoopAnalysis = R.unwrap_ok[loops.LoopAnalysis, str](ral);
-    val rd: R.Result[DepInfo, str] = analyze_dependence(fn, ?la, 0, ?alloc);
+    val rd: R.Result[DepInfo, str] = analyze_dependence(fn, ?la, 0, ?m.types, ?alloc);
     if (R.is_err[DepInfo, str](rd)) { loops.dnit(?la); ir.dnit(?m); ret 1; }
     var di: DepInfo = R.unwrap_ok[DepInfo, str](rd);
     if (di.verdict != DEP_INDEPENDENT) { code = 1; }
@@ -395,7 +465,7 @@ test "mach.lang.me.analysis.dependence:loop_carried_dependent" {
     val ral: R.Result[loops.LoopAnalysis, str] = loops.analyze(fn, ?alloc);
     if (R.is_err[loops.LoopAnalysis, str](ral)) { ir.dnit(?m); ret 1; }
     var la: loops.LoopAnalysis = R.unwrap_ok[loops.LoopAnalysis, str](ral);
-    val rd: R.Result[DepInfo, str] = analyze_dependence(fn, ?la, 0, ?alloc);
+    val rd: R.Result[DepInfo, str] = analyze_dependence(fn, ?la, 0, ?m.types, ?alloc);
     if (R.is_err[DepInfo, str](rd)) { loops.dnit(?la); ir.dnit(?m); ret 1; }
     var di: DepInfo = R.unwrap_ok[DepInfo, str](rd);
     if (di.verdict != DEP_DEPENDENT) { code = 1; }
@@ -454,7 +524,115 @@ test "mach.lang.me.analysis.dependence:reduction_dependent" {
     val ral: R.Result[loops.LoopAnalysis, str] = loops.analyze(fn, ?alloc);
     if (R.is_err[loops.LoopAnalysis, str](ral)) { ir.dnit(?m); ret 1; }
     var la: loops.LoopAnalysis = R.unwrap_ok[loops.LoopAnalysis, str](ral);
-    val rd: R.Result[DepInfo, str] = analyze_dependence(fn, ?la, 0, ?alloc);
+    val rd: R.Result[DepInfo, str] = analyze_dependence(fn, ?la, 0, ?m.types, ?alloc);
+    if (R.is_err[DepInfo, str](rd)) { loops.dnit(?la); ir.dnit(?m); ret 1; }
+    var di: DepInfo = R.unwrap_ok[DepInfo, str](rd);
+    if (di.verdict != DEP_DEPENDENT) { code = 1; }
+    dep_dnit(?di);
+    loops.dnit(?la);
+    ir.dnit(?m);
+    ret code;
+}
+
+# two accesses to the SAME base with different element widths (an i8 store and an
+# i64 store on `a`) are not the same per-iteration address window -- a genuine
+# cross-iteration overlap the alias guard cannot fix: DEPENDENT.
+test "mach.lang.me.analysis.dependence:same_base_diff_width_dependent" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+    val rm: R.Result[ir.Module, str] = ir.init(?alloc, intern.STR_NIL);
+    if (R.is_err[ir.Module, str](rm)) { ret 1; }
+    var m: ir.Module = R.unwrap_ok[ir.Module, str](rm);
+    val rt: R.Result[ir_type.IrTypeId, str] = ir_type.intern_int(?m.types, 64);
+    if (R.is_err[ir_type.IrTypeId, str](rt)) { ir.dnit(?m); ret 1; }
+    val i64t: ir_type.IrTypeId = R.unwrap_ok[ir_type.IrTypeId, str](rt);
+    val rt8: R.Result[ir_type.IrTypeId, str] = ir_type.intern_int(?m.types, 8);
+    if (R.is_err[ir_type.IrTypeId, str](rt8)) { ir.dnit(?m); ret 1; }
+    val i8t: ir_type.IrTypeId = R.unwrap_ok[ir_type.IrTypeId, str](rt8);
+    val rp: R.Result[ir_type.IrTypeId, str] = ir_type.intern_ptr(?m.types);
+    if (R.is_err[ir_type.IrTypeId, str](rp)) { ir.dnit(?m); ret 1; }
+    val ptrt: ir_type.IrTypeId = R.unwrap_ok[ir_type.IrTypeId, str](rp);
+    val rf: R.Result[u32, str] = ir.function_add(?m, intern.STR_NIL, ir_type.IRT_NIL, 0);
+    if (R.is_err[u32, str](rf)) { ir.dnit(?m); ret 1; }
+    val fn: *ir.Function = ?m.functions[R.unwrap_ok[u32, str](rf)];
+    var bld: builder.Builder = builder.init(?m);
+    builder.set_function(?bld, fn);
+
+    var entry: id.BlockId; var header: id.BlockId; var body: id.BlockId; var exit: id.BlockId; var iv: value.Value;
+    if (mk_skeleton(?m, ?bld, i64t, ?entry, ?header, ?body, ?exit, ?iv) != 0) { ir.dnit(?m); ret 1; }
+
+    val a: value.Value = value.param(1, ptrt);
+    builder.set_block(?bld, body);
+    var ix8: [1]value.Value; ix8[0] = iv;
+    val rg8: R.Result[value.Value, str] = builder.emit_gep(?bld, a, i8t, ?ix8[0], 1);
+    if (R.is_err[value.Value, str](rg8)) { ir.dnit(?m); ret 1; }
+    if (R.is_err[bool, str](builder.emit_store(?bld, value.const_int(0, i8t), R.unwrap_ok[value.Value, str](rg8)))) { ir.dnit(?m); ret 1; }
+    var ix64: [1]value.Value; ix64[0] = iv;
+    val rg64: R.Result[value.Value, str] = builder.emit_gep(?bld, a, i64t, ?ix64[0], 1);
+    if (R.is_err[value.Value, str](rg64)) { ir.dnit(?m); ret 1; }
+    if (R.is_err[bool, str](builder.emit_store(?bld, value.const_int(0, i64t), R.unwrap_ok[value.Value, str](rg64)))) { ir.dnit(?m); ret 1; }
+    val ru: R.Result[value.Value, str] = builder.emit_add(?bld, iv, value.const_int(1, i64t));
+    if (R.is_err[value.Value, str](ru)) { ir.dnit(?m); ret 1; }
+    if (R.is_err[bool, str](builder.phi_add_incoming(?bld, iv, body, R.unwrap_ok[value.Value, str](ru)))) { ir.dnit(?m); ret 1; }
+    if (R.is_err[bool, str](builder.emit_br(?bld, header))) { ir.dnit(?m); ret 1; }
+
+    var code: i32 = 0;
+    val ral: R.Result[loops.LoopAnalysis, str] = loops.analyze(fn, ?alloc);
+    if (R.is_err[loops.LoopAnalysis, str](ral)) { ir.dnit(?m); ret 1; }
+    var la: loops.LoopAnalysis = R.unwrap_ok[loops.LoopAnalysis, str](ral);
+    val rd: R.Result[DepInfo, str] = analyze_dependence(fn, ?la, 0, ?m.types, ?alloc);
+    if (R.is_err[DepInfo, str](rd)) { loops.dnit(?la); ir.dnit(?m); ret 1; }
+    var di: DepInfo = R.unwrap_ok[DepInfo, str](rd);
+    if (di.verdict != DEP_DEPENDENT) { code = 1; }
+    dep_dnit(?di);
+    loops.dnit(?la);
+    ir.dnit(?m);
+    ret code;
+}
+
+# a wider-than-stride access (a 1-byte gep stride feeding an 8-byte store) overlaps
+# its own window across iterations, so it is not a contiguous unit map: DEPENDENT.
+test "mach.lang.me.analysis.dependence:wider_than_stride_dependent" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+    val rm: R.Result[ir.Module, str] = ir.init(?alloc, intern.STR_NIL);
+    if (R.is_err[ir.Module, str](rm)) { ret 1; }
+    var m: ir.Module = R.unwrap_ok[ir.Module, str](rm);
+    val rt: R.Result[ir_type.IrTypeId, str] = ir_type.intern_int(?m.types, 64);
+    if (R.is_err[ir_type.IrTypeId, str](rt)) { ir.dnit(?m); ret 1; }
+    val i64t: ir_type.IrTypeId = R.unwrap_ok[ir_type.IrTypeId, str](rt);
+    val rt8: R.Result[ir_type.IrTypeId, str] = ir_type.intern_int(?m.types, 8);
+    if (R.is_err[ir_type.IrTypeId, str](rt8)) { ir.dnit(?m); ret 1; }
+    val i8t: ir_type.IrTypeId = R.unwrap_ok[ir_type.IrTypeId, str](rt8);
+    val rp: R.Result[ir_type.IrTypeId, str] = ir_type.intern_ptr(?m.types);
+    if (R.is_err[ir_type.IrTypeId, str](rp)) { ir.dnit(?m); ret 1; }
+    val ptrt: ir_type.IrTypeId = R.unwrap_ok[ir_type.IrTypeId, str](rp);
+    val rf: R.Result[u32, str] = ir.function_add(?m, intern.STR_NIL, ir_type.IRT_NIL, 0);
+    if (R.is_err[u32, str](rf)) { ir.dnit(?m); ret 1; }
+    val fn: *ir.Function = ?m.functions[R.unwrap_ok[u32, str](rf)];
+    var bld: builder.Builder = builder.init(?m);
+    builder.set_function(?bld, fn);
+
+    var entry: id.BlockId; var header: id.BlockId; var body: id.BlockId; var exit: id.BlockId; var iv: value.Value;
+    if (mk_skeleton(?m, ?bld, i64t, ?entry, ?header, ?body, ?exit, ?iv) != 0) { ir.dnit(?m); ret 1; }
+
+    val a: value.Value = value.param(1, ptrt);
+    builder.set_block(?bld, body);
+    var ix: [1]value.Value; ix[0] = iv;
+    val rg: R.Result[value.Value, str] = builder.emit_gep(?bld, a, i8t, ?ix[0], 1);
+    if (R.is_err[value.Value, str](rg)) { ir.dnit(?m); ret 1; }
+    # store an 8-byte value through a 1-byte-stride gep
+    if (R.is_err[bool, str](builder.emit_store(?bld, value.const_int(0, i64t), R.unwrap_ok[value.Value, str](rg)))) { ir.dnit(?m); ret 1; }
+    val ru: R.Result[value.Value, str] = builder.emit_add(?bld, iv, value.const_int(1, i64t));
+    if (R.is_err[value.Value, str](ru)) { ir.dnit(?m); ret 1; }
+    if (R.is_err[bool, str](builder.phi_add_incoming(?bld, iv, body, R.unwrap_ok[value.Value, str](ru)))) { ir.dnit(?m); ret 1; }
+    if (R.is_err[bool, str](builder.emit_br(?bld, header))) { ir.dnit(?m); ret 1; }
+
+    var code: i32 = 0;
+    val ral: R.Result[loops.LoopAnalysis, str] = loops.analyze(fn, ?alloc);
+    if (R.is_err[loops.LoopAnalysis, str](ral)) { ir.dnit(?m); ret 1; }
+    var la: loops.LoopAnalysis = R.unwrap_ok[loops.LoopAnalysis, str](ral);
+    val rd: R.Result[DepInfo, str] = analyze_dependence(fn, ?la, 0, ?m.types, ?alloc);
     if (R.is_err[DepInfo, str](rd)) { loops.dnit(?la); ir.dnit(?m); ret 1; }
     var di: DepInfo = R.unwrap_ok[DepInfo, str](rd);
     if (di.verdict != DEP_DEPENDENT) { code = 1; }

--- a/src/lang/me/analysis/loops.mach
+++ b/src/lang/me/analysis/loops.mach
@@ -64,7 +64,16 @@ pub rec InductionVar {
 # VAL_CONST_INT whose sign drives the variable across `bound` so the test
 # terminates; and `bound` is loop-invariant.
 # ---
-# bound:            the loop-invariant value the induction variable is compared against
+# bound:            the RAW loop-invariant value the induction variable is compared
+#                   against. It is predicate-dependent: an EXCLUSIVE high index for
+#                   a `<` (LT) test, an INCLUSIVE last index for a `<=` (LE) test.
+#                   A consumer needing an address range or trip count must NOT use
+#                   this raw value; it must derive the normalized exclusive bound
+#                   from `bound` + `bound_inclusive` (one element is added for LE),
+#                   which is exactly the off-by-one footgun `bound_inclusive` exists
+#                   to close
+# bound_inclusive:  true when the predicate is `<=` (OP_CMP_LE_S / _LE_U), so `bound`
+#                   is the last INCLUDED index and the exclusive bound is `bound + 1`
 # pred:             the comparison opcode (OP_CMP_LT_S / _LT_U / _LE_S / _LE_U)
 # cmp:              the comparison instruction feeding the header's conditional branch
 # iv_on_left:       true when the induction variable is the compare's left operand
@@ -72,6 +81,7 @@ pub rec InductionVar {
 # continue_on_true: true when the branch's true edge re-enters the loop
 pub rec CountedInfo {
     bound:            value.Value;
+    bound_inclusive:  bool;
     pred:             instruction.InstrKind;
     cmp:              id.InstructionId;
     iv_on_left:       bool;
@@ -912,6 +922,7 @@ fun recognize_counted(la: *LoopAnalysis, fn: *ir.Function, loop_ix: u32) bool {
     lp.iv.update  = upd;
     lp.is_counted = true;
     lp.counted.bound            = bound;
+    lp.counted.bound_inclusive  = (cmp.kind == instruction.OP_CMP_LE_S || cmp.kind == instruction.OP_CMP_LE_U);
     lp.counted.pred             = cmp.kind;
     lp.counted.cmp              = cond.data.instr;
     lp.counted.iv_on_left       = iv_on_left;

--- a/src/lang/me/transform/versioning.mach
+++ b/src/lang/me/transform/versioning.mach
@@ -82,12 +82,13 @@ val NONE_U32: u32 = 0xFFFFFFFF;
 # writes, a single base, or all bases equal) there is no aliasing hazard and the
 # guard is a constant true.
 # ---
-# b:     builder positioned in the guard block
-# d:     the dependence info (must be DEP_INDEPENDENT)
-# init:  the induction variable's initial value (the low index)
-# bound: the loop's upper bound (the exclusive high index)
-# ret:   the i8 guard value, or an allocation error
-pub fun emit_alias_guard(b: *builder.Builder, d: *dep.DepInfo, init: value.Value, bound: value.Value) R.Result[value.Value, str] {
+# b:       builder positioned in the guard block
+# d:       the dependence info (must be DEP_INDEPENDENT)
+# init:    the induction variable's initial value (the low index)
+# counted: the counted-loop exit test; the exclusive high index is derived from it
+#          via emit_exclusive_bound, never from its raw predicate-dependent bound
+# ret:     the i8 guard value, or an allocation error
+pub fun emit_alias_guard(b: *builder.Builder, d: *dep.DepInfo, init: value.Value, counted: *loops.CountedInfo) R.Result[value.Value, str] {
     val m: *ir.Module = b.m;
     val ri8: R.Result[ir_type.IrTypeId, str] = ir_type.intern_int(?m.types, 8);
     if (R.is_err[ir_type.IrTypeId, str](ri8)) { ret R.err[value.Value, str](R.unwrap_err[ir_type.IrTypeId, str](ri8)); }
@@ -96,52 +97,90 @@ pub fun emit_alias_guard(b: *builder.Builder, d: *dep.DepInfo, init: value.Value
     val n: u32 = d.access_count;
     if (n == 0) { ret R.ok[value.Value, str](value.const_int(1, i8t)); }
 
-    # precompute each access's [start, end) once
-    val rs: R.Result[*value.Value, str] = A.allocate[value.Value](m.alloc, n::usize);
-    if (R.is_err[*value.Value, str](rs)) { ret R.err[value.Value, str](R.unwrap_err[*value.Value, str](rs)); }
-    val starts: *value.Value = R.unwrap_ok[*value.Value, str](rs);
-    val re: R.Result[*value.Value, str] = A.allocate[value.Value](m.alloc, n::usize);
-    if (R.is_err[*value.Value, str](re)) { A.deallocate[value.Value](m.alloc, starts, n::usize); ret R.err[value.Value, str](R.unwrap_err[*value.Value, str](re)); }
-    val ends: *value.Value = R.unwrap_ok[*value.Value, str](re);
-
-    var i: u32 = 0;
-    for (i < n) {
-        val acc: *dep.MemAccess = ?d.accesses[i];
-        var ixs: [1]value.Value;
-        ixs[0] = init;
-        val rst: R.Result[value.Value, str] = builder.emit_gep(b, acc.base, acc.stride_ty, ?ixs[0], 1);
-        if (R.is_err[value.Value, str](rst)) { A.deallocate[value.Value](m.alloc, starts, n::usize); A.deallocate[value.Value](m.alloc, ends, n::usize); ret rst; }
-        starts[i] = R.unwrap_ok[value.Value, str](rst);
-        var ixe: [1]value.Value;
-        ixe[0] = bound;
-        val ren: R.Result[value.Value, str] = builder.emit_gep(b, acc.base, acc.stride_ty, ?ixe[0], 1);
-        if (R.is_err[value.Value, str](ren)) { A.deallocate[value.Value](m.alloc, starts, n::usize); A.deallocate[value.Value](m.alloc, ends, n::usize); ret ren; }
-        ends[i] = R.unwrap_ok[value.Value, str](ren);
-        i = i + 1;
-    }
-
-    var have_guard: bool = false;
-    var guard: value.Value = value.const_int(1, i8t);
+    # which accesses participate in a distinct-base write/other pair; only those need
+    # range geps, so a read-only or single-base loop emits none (its guard is const-true)
+    val rpart: R.Result[*bool, str] = A.allocate[bool](m.alloc, n::usize);
+    if (R.is_err[*bool, str](rpart)) { ret R.err[value.Value, str](R.unwrap_err[*bool, str](rpart)); }
+    val part: *bool = R.unwrap_ok[*bool, str](rpart);
+    var p: u32 = 0;
+    for (p < n) { part[p] = false; p = p + 1; }
     var wi: u32 = 0;
     for (wi < n) {
         if (d.accesses[wi].is_store) {
             var oi: u32 = 0;
             for (oi < n) {
-                if (oi != wi && !values_equal(d.accesses[wi].base, d.accesses[oi].base)) {
-                    # end_w <= start_o  ||  end_o <= start_w
+                if (oi != wi && !dep.equal(d.accesses[wi].base, d.accesses[oi].base)) {
+                    part[wi] = true;
+                    part[oi] = true;
+                }
+                oi = oi + 1;
+            }
+        }
+        wi = wi + 1;
+    }
+
+    val rs: R.Result[*value.Value, str] = A.allocate[value.Value](m.alloc, n::usize);
+    if (R.is_err[*value.Value, str](rs)) { A.deallocate[bool](m.alloc, part, n::usize); ret R.err[value.Value, str](R.unwrap_err[*value.Value, str](rs)); }
+    val starts: *value.Value = R.unwrap_ok[*value.Value, str](rs);
+    val re: R.Result[*value.Value, str] = A.allocate[value.Value](m.alloc, n::usize);
+    if (R.is_err[*value.Value, str](re)) { A.deallocate[bool](m.alloc, part, n::usize); A.deallocate[value.Value](m.alloc, starts, n::usize); ret R.err[value.Value, str](R.unwrap_err[*value.Value, str](re)); }
+    val ends: *value.Value = R.unwrap_ok[*value.Value, str](re);
+
+    var has_pair: bool = false;
+    var i: u32 = 0;
+    for (i < n) { if (part[i]) { has_pair = true; } i = i + 1; }
+    if (!has_pair) {
+        guard_free3(m, part, starts, ends, n);
+        ret R.ok[value.Value, str](value.const_int(1, i8t));
+    }
+
+    # the normalized exclusive high index (LE adds one element), emitted once
+    val rbe: R.Result[value.Value, str] = emit_exclusive_bound(b, counted);
+    if (R.is_err[value.Value, str](rbe)) { guard_free3(m, part, starts, ends, n); ret rbe; }
+    val bound_ex: value.Value = R.unwrap_ok[value.Value, str](rbe);
+
+    # each participating access's byte range [base+init*sz, base+bound_ex*sz)
+    i = 0;
+    for (i < n) {
+        if (part[i]) {
+            val acc: *dep.MemAccess = ?d.accesses[i];
+            var ixs: [1]value.Value;
+            ixs[0] = init;
+            val rst: R.Result[value.Value, str] = builder.emit_gep(b, acc.base, acc.stride_ty, ?ixs[0], 1);
+            if (R.is_err[value.Value, str](rst)) { guard_free3(m, part, starts, ends, n); ret rst; }
+            starts[i] = R.unwrap_ok[value.Value, str](rst);
+            var ixe: [1]value.Value;
+            ixe[0] = bound_ex;
+            val ren: R.Result[value.Value, str] = builder.emit_gep(b, acc.base, acc.stride_ty, ?ixe[0], 1);
+            if (R.is_err[value.Value, str](ren)) { guard_free3(m, part, starts, ends, n); ret ren; }
+            ends[i] = R.unwrap_ok[value.Value, str](ren);
+        }
+        i = i + 1;
+    }
+
+    # AND each write range's disjointness `(end_w <= start_o) || (end_o <= start_w)`
+    # against every distinct-base access
+    var have_guard: bool = false;
+    var guard: value.Value = value.const_int(1, i8t);
+    wi = 0;
+    for (wi < n) {
+        if (d.accesses[wi].is_store) {
+            var oi: u32 = 0;
+            for (oi < n) {
+                if (oi != wi && !dep.equal(d.accesses[wi].base, d.accesses[oi].base)) {
                     val rc1: R.Result[value.Value, str] = builder.emit_cmp_le_u(b, ends[wi], starts[oi]);
-                    if (R.is_err[value.Value, str](rc1)) { A.deallocate[value.Value](m.alloc, starts, n::usize); A.deallocate[value.Value](m.alloc, ends, n::usize); ret rc1; }
+                    if (R.is_err[value.Value, str](rc1)) { guard_free3(m, part, starts, ends, n); ret rc1; }
                     val rc2: R.Result[value.Value, str] = builder.emit_cmp_le_u(b, ends[oi], starts[wi]);
-                    if (R.is_err[value.Value, str](rc2)) { A.deallocate[value.Value](m.alloc, starts, n::usize); A.deallocate[value.Value](m.alloc, ends, n::usize); ret rc2; }
+                    if (R.is_err[value.Value, str](rc2)) { guard_free3(m, part, starts, ends, n); ret rc2; }
                     val rp: R.Result[value.Value, str] = builder.emit_or(b, R.unwrap_ok[value.Value, str](rc1), R.unwrap_ok[value.Value, str](rc2));
-                    if (R.is_err[value.Value, str](rp)) { A.deallocate[value.Value](m.alloc, starts, n::usize); A.deallocate[value.Value](m.alloc, ends, n::usize); ret rp; }
+                    if (R.is_err[value.Value, str](rp)) { guard_free3(m, part, starts, ends, n); ret rp; }
                     val pair: value.Value = R.unwrap_ok[value.Value, str](rp);
                     if (!have_guard) {
                         guard = pair;
                         have_guard = true;
                     } or {
                         val ra: R.Result[value.Value, str] = builder.emit_and(b, guard, pair);
-                        if (R.is_err[value.Value, str](ra)) { A.deallocate[value.Value](m.alloc, starts, n::usize); A.deallocate[value.Value](m.alloc, ends, n::usize); ret ra; }
+                        if (R.is_err[value.Value, str](ra)) { guard_free3(m, part, starts, ends, n); ret ra; }
                         guard = R.unwrap_ok[value.Value, str](ra);
                     }
                 }
@@ -151,9 +190,29 @@ pub fun emit_alias_guard(b: *builder.Builder, d: *dep.DepInfo, init: value.Value
         wi = wi + 1;
     }
 
+    guard_free3(m, part, starts, ends, n);
+    ret R.ok[value.Value, str](guard);
+}
+
+# free the three working arrays of emit_alias_guard
+fun guard_free3(m: *ir.Module, part: *bool, starts: *value.Value, ends: *value.Value, n: u32) {
+    A.deallocate[bool](m.alloc, part, n::usize);
     A.deallocate[value.Value](m.alloc, starts, n::usize);
     A.deallocate[value.Value](m.alloc, ends, n::usize);
-    ret R.ok[value.Value, str](guard);
+}
+
+# emit (or return) the normalized EXCLUSIVE high index of a counted loop: the raw
+# bound for a `<` (LT) test, or `bound + 1` for a `<=` (LE) test. The single point
+# that turns child 1's predicate-dependent CountedInfo.bound into an exclusive
+# index; every consumer (the alias guard here, child 3's vector trip) routes through
+# it rather than re-deriving the LE/LT off-by-one.
+# ---
+# b:       builder positioned where the bound may be materialized
+# counted: the counted-loop exit test
+# ret:     the exclusive high index value, or an allocation error
+pub fun emit_exclusive_bound(b: *builder.Builder, counted: *loops.CountedInfo) R.Result[value.Value, str] {
+    if (!counted.bound_inclusive) { ret R.ok[value.Value, str](counted.bound); }
+    ret builder.emit_add(b, counted.bound, value.const_int(1, counted.bound.ty));
 }
 
 # version loop `loop_ix`: clone it into a runtime-guarded fast copy plus the original
@@ -217,7 +276,7 @@ pub fun version_loop(m: *ir.Module, fn: *ir.Function, la: *loops.LoopAnalysis, l
     k = 0;
     for (k < n_instrs) { instr_map[k] = NONE_U32; k = k + 1; }
 
-    # 1. a clone block per loop body block (block_add may grow fn.blocks; store ids only)
+    # a clone block per loop body block (block_add may grow fn.blocks; store ids only)
     bi = 0;
     for (bi < body_len) {
         val radd: R.Result[id.BlockId, str] = ir.block_add(m, fn);
@@ -226,7 +285,7 @@ pub fun version_loop(m: *ir.Module, fn: *ir.Function, la: *loops.LoopAnalysis, l
         bi = bi + 1;
     }
 
-    # 2. clone every instruction in each body block (fn.blocks stable now; fn.instrs grows,
+    # clone every instruction in each body block (fn.blocks stable now; fn.instrs grows,
     #    so re-fetch the src pointer immediately before each clone)
     bi = 0;
     for (bi < body_len) {
@@ -250,7 +309,7 @@ pub fun version_loop(m: *ir.Module, fn: *ir.Function, la: *loops.LoopAnalysis, l
         bi = bi + 1;
     }
 
-    # 3. populate the clone blocks' phi / instruction / terminator lists via the maps
+    # populate the clone blocks' phi / instruction / terminator lists via the maps
     bi = 0;
     for (bi < body_len) {
         val src: *ir.Block = ?fn.blocks[body[bi]::u32];
@@ -273,10 +332,10 @@ pub fun version_loop(m: *ir.Module, fn: *ir.Function, la: *loops.LoopAnalysis, l
         bi = bi + 1;
     }
 
-    # 4. remap cloned operands: loop instr -> clone, loop block target -> clone block
+    # remap cloned operands: loop instr -> clone, loop block target -> clone block
     remap_operands(fn, block_map, n_blocks, instr_map, n_instrs);
 
-    # 5. build the guard and merge blocks
+    # build the guard and merge blocks
     val rg: R.Result[id.BlockId, str] = ir.block_add(m, fn);
     if (R.is_err[id.BlockId, str](rg)) { free_maps(m, body, body_len, block_map, n_blocks, instr_map, n_instrs); ret R.err[VersionResult, str](R.unwrap_err[id.BlockId, str](rg)); }
     val guard_bid: id.BlockId = R.unwrap_ok[id.BlockId, str](rg);
@@ -291,7 +350,7 @@ pub fun version_loop(m: *ir.Module, fn: *ir.Function, la: *loops.LoopAnalysis, l
     var b: builder.Builder = builder.init(m);
     builder.set_function(?b, fn);
     builder.set_block(?b, guard_bid);
-    val rge: R.Result[value.Value, str] = emit_alias_guard(?b, d, lp.iv.init, lp.counted.bound);
+    val rge: R.Result[value.Value, str] = emit_alias_guard(?b, d, lp.iv.init, ?lp.counted);
     if (R.is_err[value.Value, str](rge)) { free_maps(m, body, body_len, block_map, n_blocks, instr_map, n_instrs); ret R.err[VersionResult, str](R.unwrap_err[value.Value, str](rge)); }
     val guard_val: value.Value = R.unwrap_ok[value.Value, str](rge);
     val rcbr: R.Result[bool, str] = builder.emit_cbr(?b, guard_val, fast_header, header);
@@ -302,23 +361,23 @@ pub fun version_loop(m: *ir.Module, fn: *ir.Function, la: *loops.LoopAnalysis, l
     val rbr: R.Result[bool, str] = builder.emit_br(?b, exit);
     if (R.is_err[bool, str](rbr)) { free_maps(m, body, body_len, block_map, n_blocks, instr_map, n_instrs); ret R.err[VersionResult, str](R.unwrap_err[bool, str](rbr)); }
 
-    # 6. redirect the preheader from the header to the guard block
+    # redirect the preheader from the header to the guard block
     redirect_terminator(fn, preheader, header, guard_bid);
 
-    # 7. both headers are now entered from the guard: relabel the preheader phi-incoming
+    # both headers are now entered from the guard: relabel the preheader phi-incoming
     relabel_phi_pred(fn, header, preheader, guard_bid);
     relabel_phi_pred(fn, fast_header, preheader, guard_bid);
 
-    # 8. route both exiting blocks through the merge, then to the exit
+    # route both exiting blocks through the merge, then to the exit
     redirect_terminator(fn, exiting, exit, merge_bid);
     redirect_terminator(fn, fast_exiting, exit, merge_bid);
     relabel_phi_pred(fn, exit, exiting, merge_bid);
 
-    # 9. rebuild predecessors after the control-flow surgery
+    # rebuild predecessors after the control-flow surgery
     val rpr: R.Result[bool, str] = ir.preds_rebuild(m, fn);
     if (R.is_err[bool, str](rpr)) { free_maps(m, body, body_len, block_map, n_blocks, instr_map, n_instrs); ret R.err[VersionResult, str](R.unwrap_err[bool, str](rpr)); }
 
-    # 10. fast_blocks parallel to the original body order
+    # fast_blocks parallel to the original body order
     val rfb: R.Result[*id.BlockId, str] = A.allocate[id.BlockId](m.alloc, body_len::usize);
     if (R.is_err[*id.BlockId, str](rfb)) { free_maps(m, body, body_len, block_map, n_blocks, instr_map, n_instrs); ret R.err[VersionResult, str](R.unwrap_err[*id.BlockId, str](rfb)); }
     val fast_blocks: *id.BlockId = R.unwrap_ok[*id.BlockId, str](rfb);
@@ -468,18 +527,6 @@ fun has_live_out(fn: *ir.Function, la: *loops.LoopAnalysis, loop_ix: u32) bool {
     ret false;
 }
 
-# structural value equality for base pointers: same param / instruction / global /
-# function reference. Conservative: an unrecognized kind compares unequal, so a
-# redundant self-disjointness check is emitted rather than a pair silently dropped.
-fun values_equal(a: value.Value, b: value.Value) bool {
-    if (a.kind != b.kind) { ret false; }
-    if (a.kind == value.VAL_PARAM)  { ret a.data.param_ix == b.data.param_ix; }
-    if (a.kind == value.VAL_INSTR)  { ret a.data.instr == b.data.instr; }
-    if (a.kind == value.VAL_GLOBAL) { ret a.data.global_ix == b.data.global_ix; }
-    if (a.kind == value.VAL_FN)     { ret a.data.fn_ix == b.data.fn_ix; }
-    ret false;
-}
-
 use std.allocator.page;
 use mach.lang.intern;
 use verify: mach.lang.me.ir.verify;
@@ -605,7 +652,7 @@ test "mach.lang.me.transform.versioning:alias_guard_shape" {
     val ral: R.Result[loops.LoopAnalysis, str] = loops.analyze(fn, ?alloc);
     if (R.is_err[loops.LoopAnalysis, str](ral)) { ir.dnit(?m); ret 1; }
     var la: loops.LoopAnalysis = R.unwrap_ok[loops.LoopAnalysis, str](ral);
-    val rd: R.Result[dep.DepInfo, str] = dep.analyze_dependence(fn, ?la, 0, ?alloc);
+    val rd: R.Result[dep.DepInfo, str] = dep.analyze_dependence(fn, ?la, 0, ?m.types, ?alloc);
     if (R.is_err[dep.DepInfo, str](rd)) { loops.dnit(?la); ir.dnit(?m); ret 1; }
     var di: dep.DepInfo = R.unwrap_ok[dep.DepInfo, str](rd);
 
@@ -614,8 +661,7 @@ test "mach.lang.me.transform.versioning:alias_guard_shape" {
     val gb: id.BlockId = R.unwrap_ok[id.BlockId, str](rg);
     builder.set_block(?bld, gb);
     val init: value.Value = la.loops[0].iv.init;
-    val bound: value.Value = la.loops[0].counted.bound;
-    val rge: R.Result[value.Value, str] = emit_alias_guard(?bld, ?di, init, bound);
+    val rge: R.Result[value.Value, str] = emit_alias_guard(?bld, ?di, init, ?la.loops[0].counted);
     if (R.is_err[value.Value, str](rge)) { dep.dep_dnit(?di); loops.dnit(?la); ir.dnit(?m); ret 1; }
 
     if (count_op(fn, gb, instruction.OP_GEP) != 6)      { code = 1; }
@@ -660,7 +706,7 @@ test "mach.lang.me.transform.versioning:version_verifier_clean" {
     val ral: R.Result[loops.LoopAnalysis, str] = loops.analyze(fn, ?alloc);
     if (R.is_err[loops.LoopAnalysis, str](ral)) { ir.dnit(?m); ret 1; }
     var la: loops.LoopAnalysis = R.unwrap_ok[loops.LoopAnalysis, str](ral);
-    val rd: R.Result[dep.DepInfo, str] = dep.analyze_dependence(fn, ?la, 0, ?alloc);
+    val rd: R.Result[dep.DepInfo, str] = dep.analyze_dependence(fn, ?la, 0, ?m.types, ?alloc);
     if (R.is_err[dep.DepInfo, str](rd)) { loops.dnit(?la); ir.dnit(?m); ret 1; }
     var di: dep.DepInfo = R.unwrap_ok[dep.DepInfo, str](rd);
 
@@ -776,7 +822,7 @@ test "mach.lang.me.transform.versioning:refuse_dependent" {
     val ral: R.Result[loops.LoopAnalysis, str] = loops.analyze(fn, ?alloc);
     if (R.is_err[loops.LoopAnalysis, str](ral)) { ir.dnit(?m); ret 1; }
     var la: loops.LoopAnalysis = R.unwrap_ok[loops.LoopAnalysis, str](ral);
-    val rd: R.Result[dep.DepInfo, str] = dep.analyze_dependence(fn, ?la, 0, ?alloc);
+    val rd: R.Result[dep.DepInfo, str] = dep.analyze_dependence(fn, ?la, 0, ?m.types, ?alloc);
     if (R.is_err[dep.DepInfo, str](rd)) { loops.dnit(?la); ir.dnit(?m); ret 1; }
     var di: dep.DepInfo = R.unwrap_ok[dep.DepInfo, str](rd);
     val rv: R.Result[VersionResult, str] = version_loop(?m, fn, ?la, 0, ?di);
@@ -863,7 +909,7 @@ test "mach.lang.me.transform.versioning:refuse_live_out" {
     val ral: R.Result[loops.LoopAnalysis, str] = loops.analyze(fn, ?alloc);
     if (R.is_err[loops.LoopAnalysis, str](ral)) { ir.dnit(?m); ret 1; }
     var la: loops.LoopAnalysis = R.unwrap_ok[loops.LoopAnalysis, str](ral);
-    val rd: R.Result[dep.DepInfo, str] = dep.analyze_dependence(fn, ?la, 0, ?alloc);
+    val rd: R.Result[dep.DepInfo, str] = dep.analyze_dependence(fn, ?la, 0, ?m.types, ?alloc);
     if (R.is_err[dep.DepInfo, str](rd)) { loops.dnit(?la); ir.dnit(?m); ret 1; }
     var di: dep.DepInfo = R.unwrap_ok[dep.DepInfo, str](rd);
     # the loop itself is dependence-independent; the refusal is specifically live-out
@@ -875,6 +921,106 @@ test "mach.lang.me.transform.versioning:refuse_live_out" {
     if (fn.block_count != blocks_before) { code = 1; }
     version_result_dnit(?vres, ?alloc);
     dep.dep_dnit(?di);
+    loops.dnit(?la);
+    ir.dnit(?m);
+    ret code;
+}
+
+# an `i <= n` (LE) loop's exclusive bound must be normalized to `n + 1` so the alias
+# guard's range covers the last accessed element (a[n]); child 1 flags bound_inclusive
+# and emit_exclusive_bound materializes the `+ 1`.
+test "mach.lang.me.transform.versioning:le_bound_exclusive" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+    val rm: R.Result[ir.Module, str] = ir.init(?alloc, intern.STR_NIL);
+    if (R.is_err[ir.Module, str](rm)) { ret 1; }
+    var m: ir.Module = R.unwrap_ok[ir.Module, str](rm);
+    val rt: R.Result[ir_type.IrTypeId, str] = ir_type.intern_int(?m.types, 64);
+    if (R.is_err[ir_type.IrTypeId, str](rt)) { ir.dnit(?m); ret 1; }
+    val i64t: ir_type.IrTypeId = R.unwrap_ok[ir_type.IrTypeId, str](rt);
+    val rp: R.Result[ir_type.IrTypeId, str] = ir_type.intern_ptr(?m.types);
+    if (R.is_err[ir_type.IrTypeId, str](rp)) { ir.dnit(?m); ret 1; }
+    val ptrt: ir_type.IrTypeId = R.unwrap_ok[ir_type.IrTypeId, str](rp);
+    var sig: ir_type.IrTypeId;
+    if (mk_sig(?m, i64t, ptrt, ?sig) != 0) { ir.dnit(?m); ret 1; }
+    val rf: R.Result[u32, str] = ir.function_add(?m, intern.STR_NIL, sig, 0);
+    if (R.is_err[u32, str](rf)) { ir.dnit(?m); ret 1; }
+    val fn: *ir.Function = ?m.functions[R.unwrap_ok[u32, str](rf)];
+    var bld: builder.Builder = builder.init(?m);
+    builder.set_function(?bld, fn);
+
+    val re: R.Result[id.BlockId, str] = builder.new_block(?bld);
+    if (R.is_err[id.BlockId, str](re)) { ir.dnit(?m); ret 1; }
+    val entry: id.BlockId = R.unwrap_ok[id.BlockId, str](re);
+    val rh: R.Result[id.BlockId, str] = builder.new_block(?bld);
+    if (R.is_err[id.BlockId, str](rh)) { ir.dnit(?m); ret 1; }
+    val header: id.BlockId = R.unwrap_ok[id.BlockId, str](rh);
+    val rb: R.Result[id.BlockId, str] = builder.new_block(?bld);
+    if (R.is_err[id.BlockId, str](rb)) { ir.dnit(?m); ret 1; }
+    val body: id.BlockId = R.unwrap_ok[id.BlockId, str](rb);
+    val rx: R.Result[id.BlockId, str] = builder.new_block(?bld);
+    if (R.is_err[id.BlockId, str](rx)) { ir.dnit(?m); ret 1; }
+    val exit: id.BlockId = R.unwrap_ok[id.BlockId, str](rx);
+    val n: value.Value = value.param(0, i64t);
+    val a: value.Value = value.param(1, ptrt);
+    val bb: value.Value = value.param(2, ptrt);
+    builder.set_block(?bld, entry);
+    if (R.is_err[bool, str](builder.emit_br(?bld, header))) { ir.dnit(?m); ret 1; }
+    builder.set_block(?bld, header);
+    val rphi: R.Result[value.Value, str] = builder.emit_phi(?bld, i64t);
+    if (R.is_err[value.Value, str](rphi)) { ir.dnit(?m); ret 1; }
+    val iv: value.Value = R.unwrap_ok[value.Value, str](rphi);
+    val rc: R.Result[value.Value, str] = builder.emit_cmp_le_s(?bld, iv, n);
+    if (R.is_err[value.Value, str](rc)) { ir.dnit(?m); ret 1; }
+    if (R.is_err[bool, str](builder.emit_cbr(?bld, R.unwrap_ok[value.Value, str](rc), body, exit))) { ir.dnit(?m); ret 1; }
+    builder.set_block(?bld, body);
+    var ixb: [1]value.Value; ixb[0] = iv;
+    val rgb: R.Result[value.Value, str] = builder.emit_gep(?bld, bb, i64t, ?ixb[0], 1);
+    if (R.is_err[value.Value, str](rgb)) { ir.dnit(?m); ret 1; }
+    val rl: R.Result[value.Value, str] = builder.emit_load(?bld, R.unwrap_ok[value.Value, str](rgb), i64t);
+    if (R.is_err[value.Value, str](rl)) { ir.dnit(?m); ret 1; }
+    var ixa: [1]value.Value; ixa[0] = iv;
+    val rga: R.Result[value.Value, str] = builder.emit_gep(?bld, a, i64t, ?ixa[0], 1);
+    if (R.is_err[value.Value, str](rga)) { ir.dnit(?m); ret 1; }
+    if (R.is_err[bool, str](builder.emit_store(?bld, R.unwrap_ok[value.Value, str](rl), R.unwrap_ok[value.Value, str](rga)))) { ir.dnit(?m); ret 1; }
+    val ru: R.Result[value.Value, str] = builder.emit_add(?bld, iv, value.const_int(1, i64t));
+    if (R.is_err[value.Value, str](ru)) { ir.dnit(?m); ret 1; }
+    if (R.is_err[bool, str](builder.emit_br(?bld, header))) { ir.dnit(?m); ret 1; }
+    builder.set_block(?bld, exit);
+    if (R.is_err[bool, str](builder.emit_ret_void(?bld))) { ir.dnit(?m); ret 1; }
+    if (R.is_err[bool, str](builder.phi_add_incoming(?bld, iv, entry, value.const_int(0, i64t)))) { ir.dnit(?m); ret 1; }
+    if (R.is_err[bool, str](builder.phi_add_incoming(?bld, iv, body, R.unwrap_ok[value.Value, str](ru)))) { ir.dnit(?m); ret 1; }
+
+    var code: i32 = 0;
+    val ral: R.Result[loops.LoopAnalysis, str] = loops.analyze(fn, ?alloc);
+    if (R.is_err[loops.LoopAnalysis, str](ral)) { ir.dnit(?m); ret 1; }
+    var la: loops.LoopAnalysis = R.unwrap_ok[loops.LoopAnalysis, str](ral);
+    if (la.loop_len != 1)                       { code = 1; }
+    if (!la.loops[0].is_counted)                { code = 1; }
+    if (!la.loops[0].counted.bound_inclusive)   { code = 1; }
+
+    # emit_exclusive_bound must materialize `n + 1`
+    val rgb2: R.Result[id.BlockId, str] = builder.new_block(?bld);
+    if (R.is_err[id.BlockId, str](rgb2)) { loops.dnit(?la); ir.dnit(?m); ret 1; }
+    val gb: id.BlockId = R.unwrap_ok[id.BlockId, str](rgb2);
+    builder.set_block(?bld, gb);
+    val rex: R.Result[value.Value, str] = emit_exclusive_bound(?bld, ?la.loops[0].counted);
+    if (R.is_err[value.Value, str](rex)) { loops.dnit(?la); ir.dnit(?m); ret 1; }
+    val bex: value.Value = R.unwrap_ok[value.Value, str](rex);
+    if (bex.kind != value.VAL_INSTR) { code = 1; }
+    or {
+        val opt: O.Option[*instruction.Instruction] = ir.instruction_get(fn, bex.data.instr);
+        if (O.is_none[*instruction.Instruction](opt)) { code = 1; }
+        or {
+            val add: *instruction.Instruction = O.unwrap[*instruction.Instruction](opt);
+            if (add.kind != instruction.OP_ADD)                 { code = 1; }
+            if (add.operands[0].kind != value.VAL_PARAM)        { code = 1; }
+            if (add.operands[0].data.param_ix != 0)             { code = 1; }
+            if (add.operands[1].kind != value.VAL_CONST_INT)    { code = 1; }
+            if (add.operands[1].data.int_lit != 1)              { code = 1; }
+        }
+    }
+
     loops.dnit(?la);
     ir.dnit(?m);
     ret code;

--- a/src/lang/me/transform/versioning.mach
+++ b/src/lang/me/transform/versioning.mach
@@ -1,0 +1,881 @@
+# mach.lang.me.transform.versioning: runtime alias-guard + loop versioning
+#
+# The safety machinery a vectorizer (briar-systems/mach#1942, child 3) consumes:
+# given a counted, dependence-independent loop (child 1 + `analysis.dependence`),
+# it (a) synthesizes a runtime alias-check guard testing that the written and read
+# address ranges are disjoint, and (b) versions the loop -- clones it into a FAST
+# copy guarded by that check, keeping the original as the SCALAR fallback, with the
+# CFG / phi surgery to splice both in. At runtime the guard picks the fast copy when
+# the ranges are disjoint, else the scalar copy.
+#
+# For this increment BOTH copies are scalar, so the transform is behavior-preserving
+# (semantically identical to the original); child 3 replaces the fast copy's body
+# with vector ops. Only loops child 1 reports as well-formed (dedicated preheader /
+# latch / dedicated exit / unique exiting block) and with NO live-out SSA value are
+# versioned -- everything else is refused conservatively.
+#
+# This module is callable API, not wired into the pipeline (nothing imports it
+# there), so it does not affect emitted code.
+
+use std.types.bool.bool;
+use std.types.bool.false;
+use std.types.bool.true;
+use std.types.size.usize;
+use std.types.string.str;
+
+use A: std.allocator;
+use O: std.types.option;
+use R: std.types.result;
+
+use mach.lang.me.ir;
+use mach.lang.me.ir.id;
+use mach.lang.me.ir.instruction;
+use mach.lang.me.ir.value;
+use ir_type: mach.lang.me.ir.type;
+use mach.lang.me.ir.builder;
+use mutate: mach.lang.me.ir.mutate;
+use loops: mach.lang.me.analysis.loops;
+use dep: mach.lang.me.analysis.dependence;
+
+# the outcome of a version_loop attempt
+pub def VersionStatus: u8;
+# the loop was versioned; the VersionResult block ids are valid
+pub val VERSION_OK:          VersionStatus = 0;
+# the loop is not a recognized counted loop
+pub val VERSION_NOT_COUNTED: VersionStatus = 1;
+# the loop lacks a dedicated preheader / latch / dedicated exit / unique exiting block
+pub val VERSION_ILL_FORMED:  VersionStatus = 2;
+# the loop carries a cross-iteration dependence (not element-wise)
+pub val VERSION_DEPENDENT:   VersionStatus = 3;
+# the loop defines a value used after the loop (a live-out this increment can't merge)
+pub val VERSION_LIVE_OUT:    VersionStatus = 4;
+
+# the result of versioning a loop
+# ---
+# status:      VERSION_OK on success, else the refusal reason (block ids are unset)
+# guard:       the guard block: computes the alias check, branches fast vs scalar
+# merge:       the merge block both versions' exits funnel through, then to the exit
+# fast_header: the fast (vectorizable) clone's header block
+# fast_blocks: the fast clone of each original loop body block, parallel to the
+#              analyzed loop's `body` order (owned); child 3 rewrites these to vectors
+# fast_len:    number of fast_blocks (equals the loop's body_len)
+pub rec VersionResult {
+    status:      VersionStatus;
+    guard:       id.BlockId;
+    merge:       id.BlockId;
+    fast_header: id.BlockId;
+    fast_blocks: *id.BlockId;
+    fast_len:    u32;
+}
+
+# sentinel for an unset block-map / instr-map slot
+val NONE_U32: u32 = 0xFFFFFFFF;
+
+# emit the runtime alias-check guard for a dependence-independent loop into the
+# builder's current block, returning the i8 value that is nonzero exactly when
+# every write range is disjoint from every distinct-base read/write range
+#
+# For each store base, against each other access with a different base, the accessed
+# byte ranges `[base+init*sz, base+bound*sz)` (per-access element stride) are tested
+# for disjointness `(end_w <= start_o) || (end_o <= start_w)` with unsigned pointer
+# compares, and all pairs are AND-ed. With no distinct-base write/read pair (no
+# writes, a single base, or all bases equal) there is no aliasing hazard and the
+# guard is a constant true.
+# ---
+# b:     builder positioned in the guard block
+# d:     the dependence info (must be DEP_INDEPENDENT)
+# init:  the induction variable's initial value (the low index)
+# bound: the loop's upper bound (the exclusive high index)
+# ret:   the i8 guard value, or an allocation error
+pub fun emit_alias_guard(b: *builder.Builder, d: *dep.DepInfo, init: value.Value, bound: value.Value) R.Result[value.Value, str] {
+    val m: *ir.Module = b.m;
+    val ri8: R.Result[ir_type.IrTypeId, str] = ir_type.intern_int(?m.types, 8);
+    if (R.is_err[ir_type.IrTypeId, str](ri8)) { ret R.err[value.Value, str](R.unwrap_err[ir_type.IrTypeId, str](ri8)); }
+    val i8t: ir_type.IrTypeId = R.unwrap_ok[ir_type.IrTypeId, str](ri8);
+
+    val n: u32 = d.access_count;
+    if (n == 0) { ret R.ok[value.Value, str](value.const_int(1, i8t)); }
+
+    # precompute each access's [start, end) once
+    val rs: R.Result[*value.Value, str] = A.allocate[value.Value](m.alloc, n::usize);
+    if (R.is_err[*value.Value, str](rs)) { ret R.err[value.Value, str](R.unwrap_err[*value.Value, str](rs)); }
+    val starts: *value.Value = R.unwrap_ok[*value.Value, str](rs);
+    val re: R.Result[*value.Value, str] = A.allocate[value.Value](m.alloc, n::usize);
+    if (R.is_err[*value.Value, str](re)) { A.deallocate[value.Value](m.alloc, starts, n::usize); ret R.err[value.Value, str](R.unwrap_err[*value.Value, str](re)); }
+    val ends: *value.Value = R.unwrap_ok[*value.Value, str](re);
+
+    var i: u32 = 0;
+    for (i < n) {
+        val acc: *dep.MemAccess = ?d.accesses[i];
+        var ixs: [1]value.Value;
+        ixs[0] = init;
+        val rst: R.Result[value.Value, str] = builder.emit_gep(b, acc.base, acc.stride_ty, ?ixs[0], 1);
+        if (R.is_err[value.Value, str](rst)) { A.deallocate[value.Value](m.alloc, starts, n::usize); A.deallocate[value.Value](m.alloc, ends, n::usize); ret rst; }
+        starts[i] = R.unwrap_ok[value.Value, str](rst);
+        var ixe: [1]value.Value;
+        ixe[0] = bound;
+        val ren: R.Result[value.Value, str] = builder.emit_gep(b, acc.base, acc.stride_ty, ?ixe[0], 1);
+        if (R.is_err[value.Value, str](ren)) { A.deallocate[value.Value](m.alloc, starts, n::usize); A.deallocate[value.Value](m.alloc, ends, n::usize); ret ren; }
+        ends[i] = R.unwrap_ok[value.Value, str](ren);
+        i = i + 1;
+    }
+
+    var have_guard: bool = false;
+    var guard: value.Value = value.const_int(1, i8t);
+    var wi: u32 = 0;
+    for (wi < n) {
+        if (d.accesses[wi].is_store) {
+            var oi: u32 = 0;
+            for (oi < n) {
+                if (oi != wi && !values_equal(d.accesses[wi].base, d.accesses[oi].base)) {
+                    # end_w <= start_o  ||  end_o <= start_w
+                    val rc1: R.Result[value.Value, str] = builder.emit_cmp_le_u(b, ends[wi], starts[oi]);
+                    if (R.is_err[value.Value, str](rc1)) { A.deallocate[value.Value](m.alloc, starts, n::usize); A.deallocate[value.Value](m.alloc, ends, n::usize); ret rc1; }
+                    val rc2: R.Result[value.Value, str] = builder.emit_cmp_le_u(b, ends[oi], starts[wi]);
+                    if (R.is_err[value.Value, str](rc2)) { A.deallocate[value.Value](m.alloc, starts, n::usize); A.deallocate[value.Value](m.alloc, ends, n::usize); ret rc2; }
+                    val rp: R.Result[value.Value, str] = builder.emit_or(b, R.unwrap_ok[value.Value, str](rc1), R.unwrap_ok[value.Value, str](rc2));
+                    if (R.is_err[value.Value, str](rp)) { A.deallocate[value.Value](m.alloc, starts, n::usize); A.deallocate[value.Value](m.alloc, ends, n::usize); ret rp; }
+                    val pair: value.Value = R.unwrap_ok[value.Value, str](rp);
+                    if (!have_guard) {
+                        guard = pair;
+                        have_guard = true;
+                    } or {
+                        val ra: R.Result[value.Value, str] = builder.emit_and(b, guard, pair);
+                        if (R.is_err[value.Value, str](ra)) { A.deallocate[value.Value](m.alloc, starts, n::usize); A.deallocate[value.Value](m.alloc, ends, n::usize); ret ra; }
+                        guard = R.unwrap_ok[value.Value, str](ra);
+                    }
+                }
+                oi = oi + 1;
+            }
+        }
+        wi = wi + 1;
+    }
+
+    A.deallocate[value.Value](m.alloc, starts, n::usize);
+    A.deallocate[value.Value](m.alloc, ends, n::usize);
+    ret R.ok[value.Value, str](guard);
+}
+
+# version loop `loop_ix`: clone it into a runtime-guarded fast copy plus the original
+# as the scalar fallback, doing the CFG / phi surgery
+#
+# Refuses (VersionResult.status != VERSION_OK, no mutation) unless the loop is
+# counted, well-formed (dedicated preheader / latch / dedicated exit / unique
+# exiting block), dependence-independent, and free of live-out SSA values. On
+# success the function is mutated in place and left verifier-clean, and both copies
+# are scalar (behavior-preserving).
+# ---
+# m:       the module owning `fn`
+# fn:      the function to transform
+# la:      the loop analysis for `fn` (computed before this call; stale afterward)
+# loop_ix: index into la.loops
+# d:       the dependence info for the loop (must be DEP_INDEPENDENT to proceed)
+# ret:     the version result, or an allocation error
+pub fun version_loop(m: *ir.Module, fn: *ir.Function, la: *loops.LoopAnalysis, loop_ix: u32, d: *dep.DepInfo) R.Result[VersionResult, str] {
+    var vr: VersionResult;
+    vr.status      = VERSION_OK;
+    vr.guard       = id.BLOCK_NIL;
+    vr.merge       = id.BLOCK_NIL;
+    vr.fast_header = id.BLOCK_NIL;
+    vr.fast_blocks = nil;
+    vr.fast_len    = 0;
+
+    if (loop_ix >= la.loop_len) { vr.status = VERSION_NOT_COUNTED; ret R.ok[VersionResult, str](vr); }
+    val lp: *loops.Loop = ?la.loops[loop_ix];
+    if (!lp.is_counted) { vr.status = VERSION_NOT_COUNTED; ret R.ok[VersionResult, str](vr); }
+    if (lp.preheader == id.BLOCK_NIL || lp.latch == id.BLOCK_NIL || lp.exit == id.BLOCK_NIL || lp.exiting == id.BLOCK_NIL) {
+        vr.status = VERSION_ILL_FORMED; ret R.ok[VersionResult, str](vr);
+    }
+    if (d.verdict != dep.DEP_INDEPENDENT) { vr.status = VERSION_DEPENDENT; ret R.ok[VersionResult, str](vr); }
+    if (has_live_out(fn, la, loop_ix)) { vr.status = VERSION_LIVE_OUT; ret R.ok[VersionResult, str](vr); }
+
+    val header:    id.BlockId = lp.header;
+    val preheader: id.BlockId = lp.preheader;
+    val exit:      id.BlockId = lp.exit;
+    val exiting:   id.BlockId = lp.exiting;
+    val body_len:  u32        = lp.body_len;
+
+    val n_blocks: u32 = fn.block_count;
+    val n_instrs: u32 = fn.instr_len;
+
+    # capture the original body block ids (lp.body is owned by la and stays valid)
+    val rbb: R.Result[*id.BlockId, str] = A.allocate[id.BlockId](m.alloc, body_len::usize);
+    if (R.is_err[*id.BlockId, str](rbb)) { ret R.err[VersionResult, str](R.unwrap_err[*id.BlockId, str](rbb)); }
+    val body: *id.BlockId = R.unwrap_ok[*id.BlockId, str](rbb);
+    var bi: u32 = 0;
+    for (bi < body_len) { body[bi] = lp.body[bi]; bi = bi + 1; }
+
+    # block_map / instr_map over the ORIGINAL block / instruction ids
+    val rbm: R.Result[*u32, str] = A.allocate[u32](m.alloc, n_blocks::usize);
+    if (R.is_err[*u32, str](rbm)) { A.deallocate[id.BlockId](m.alloc, body, body_len::usize); ret R.err[VersionResult, str](R.unwrap_err[*u32, str](rbm)); }
+    val block_map: *u32 = R.unwrap_ok[*u32, str](rbm);
+    val rim: R.Result[*u32, str] = A.allocate[u32](m.alloc, n_instrs::usize);
+    if (R.is_err[*u32, str](rim)) { A.deallocate[id.BlockId](m.alloc, body, body_len::usize); A.deallocate[u32](m.alloc, block_map, n_blocks::usize); ret R.err[VersionResult, str](R.unwrap_err[*u32, str](rim)); }
+    val instr_map: *u32 = R.unwrap_ok[*u32, str](rim);
+    var k: u32 = 0;
+    for (k < n_blocks) { block_map[k] = NONE_U32; k = k + 1; }
+    k = 0;
+    for (k < n_instrs) { instr_map[k] = NONE_U32; k = k + 1; }
+
+    # 1. a clone block per loop body block (block_add may grow fn.blocks; store ids only)
+    bi = 0;
+    for (bi < body_len) {
+        val radd: R.Result[id.BlockId, str] = ir.block_add(m, fn);
+        if (R.is_err[id.BlockId, str](radd)) { free_maps(m, body, body_len, block_map, n_blocks, instr_map, n_instrs); ret R.err[VersionResult, str](R.unwrap_err[id.BlockId, str](radd)); }
+        block_map[body[bi]::u32] = R.unwrap_ok[id.BlockId, str](radd)::u32;
+        bi = bi + 1;
+    }
+
+    # 2. clone every instruction in each body block (fn.blocks stable now; fn.instrs grows,
+    #    so re-fetch the src pointer immediately before each clone)
+    bi = 0;
+    for (bi < body_len) {
+        val blk: *ir.Block = ?fn.blocks[body[bi]::u32];
+        var p: u32 = 0;
+        for (p < blk.phi_count) {
+            val rc: R.Result[bool, str] = clone_one(m, fn, blk.phis[p], instr_map);
+            if (R.is_err[bool, str](rc)) { free_maps(m, body, body_len, block_map, n_blocks, instr_map, n_instrs); ret R.err[VersionResult, str](R.unwrap_err[bool, str](rc)); }
+            p = p + 1;
+        }
+        var ii: u32 = 0;
+        for (ii < blk.instr_count) {
+            val rc: R.Result[bool, str] = clone_one(m, fn, blk.instructions[ii], instr_map);
+            if (R.is_err[bool, str](rc)) { free_maps(m, body, body_len, block_map, n_blocks, instr_map, n_instrs); ret R.err[VersionResult, str](R.unwrap_err[bool, str](rc)); }
+            ii = ii + 1;
+        }
+        if (blk.terminator != id.INSTR_NIL) {
+            val rc: R.Result[bool, str] = clone_one(m, fn, blk.terminator, instr_map);
+            if (R.is_err[bool, str](rc)) { free_maps(m, body, body_len, block_map, n_blocks, instr_map, n_instrs); ret R.err[VersionResult, str](R.unwrap_err[bool, str](rc)); }
+        }
+        bi = bi + 1;
+    }
+
+    # 3. populate the clone blocks' phi / instruction / terminator lists via the maps
+    bi = 0;
+    for (bi < body_len) {
+        val src: *ir.Block = ?fn.blocks[body[bi]::u32];
+        val dst: *ir.Block = ?fn.blocks[block_map[body[bi]::u32]];
+        var p: u32 = 0;
+        for (p < src.phi_count) {
+            val rp: R.Result[bool, str] = ir.block_append_phi(m, dst, instr_map[src.phis[p]::u32]::id.InstructionId);
+            if (R.is_err[bool, str](rp)) { free_maps(m, body, body_len, block_map, n_blocks, instr_map, n_instrs); ret R.err[VersionResult, str](R.unwrap_err[bool, str](rp)); }
+            p = p + 1;
+        }
+        var ii: u32 = 0;
+        for (ii < src.instr_count) {
+            val ra: R.Result[bool, str] = ir.block_append_instr(m, dst, instr_map[src.instructions[ii]::u32]::id.InstructionId);
+            if (R.is_err[bool, str](ra)) { free_maps(m, body, body_len, block_map, n_blocks, instr_map, n_instrs); ret R.err[VersionResult, str](R.unwrap_err[bool, str](ra)); }
+            ii = ii + 1;
+        }
+        if (src.terminator != id.INSTR_NIL) {
+            dst.terminator = instr_map[src.terminator::u32]::id.InstructionId;
+        }
+        bi = bi + 1;
+    }
+
+    # 4. remap cloned operands: loop instr -> clone, loop block target -> clone block
+    remap_operands(fn, block_map, n_blocks, instr_map, n_instrs);
+
+    # 5. build the guard and merge blocks
+    val rg: R.Result[id.BlockId, str] = ir.block_add(m, fn);
+    if (R.is_err[id.BlockId, str](rg)) { free_maps(m, body, body_len, block_map, n_blocks, instr_map, n_instrs); ret R.err[VersionResult, str](R.unwrap_err[id.BlockId, str](rg)); }
+    val guard_bid: id.BlockId = R.unwrap_ok[id.BlockId, str](rg);
+    val rmb: R.Result[id.BlockId, str] = ir.block_add(m, fn);
+    if (R.is_err[id.BlockId, str](rmb)) { free_maps(m, body, body_len, block_map, n_blocks, instr_map, n_instrs); ret R.err[VersionResult, str](R.unwrap_err[id.BlockId, str](rmb)); }
+    val merge_bid: id.BlockId = R.unwrap_ok[id.BlockId, str](rmb);
+
+    val fast_header: id.BlockId = block_map[header::u32]::id.BlockId;
+    val fast_exiting: id.BlockId = block_map[exiting::u32]::id.BlockId;
+
+    # guard block: alias check, then cbr(guard, fast_header, scalar_header). fast on true.
+    var b: builder.Builder = builder.init(m);
+    builder.set_function(?b, fn);
+    builder.set_block(?b, guard_bid);
+    val rge: R.Result[value.Value, str] = emit_alias_guard(?b, d, lp.iv.init, lp.counted.bound);
+    if (R.is_err[value.Value, str](rge)) { free_maps(m, body, body_len, block_map, n_blocks, instr_map, n_instrs); ret R.err[VersionResult, str](R.unwrap_err[value.Value, str](rge)); }
+    val guard_val: value.Value = R.unwrap_ok[value.Value, str](rge);
+    val rcbr: R.Result[bool, str] = builder.emit_cbr(?b, guard_val, fast_header, header);
+    if (R.is_err[bool, str](rcbr)) { free_maps(m, body, body_len, block_map, n_blocks, instr_map, n_instrs); ret R.err[VersionResult, str](R.unwrap_err[bool, str](rcbr)); }
+
+    # merge block: br exit
+    builder.set_block(?b, merge_bid);
+    val rbr: R.Result[bool, str] = builder.emit_br(?b, exit);
+    if (R.is_err[bool, str](rbr)) { free_maps(m, body, body_len, block_map, n_blocks, instr_map, n_instrs); ret R.err[VersionResult, str](R.unwrap_err[bool, str](rbr)); }
+
+    # 6. redirect the preheader from the header to the guard block
+    redirect_terminator(fn, preheader, header, guard_bid);
+
+    # 7. both headers are now entered from the guard: relabel the preheader phi-incoming
+    relabel_phi_pred(fn, header, preheader, guard_bid);
+    relabel_phi_pred(fn, fast_header, preheader, guard_bid);
+
+    # 8. route both exiting blocks through the merge, then to the exit
+    redirect_terminator(fn, exiting, exit, merge_bid);
+    redirect_terminator(fn, fast_exiting, exit, merge_bid);
+    relabel_phi_pred(fn, exit, exiting, merge_bid);
+
+    # 9. rebuild predecessors after the control-flow surgery
+    val rpr: R.Result[bool, str] = ir.preds_rebuild(m, fn);
+    if (R.is_err[bool, str](rpr)) { free_maps(m, body, body_len, block_map, n_blocks, instr_map, n_instrs); ret R.err[VersionResult, str](R.unwrap_err[bool, str](rpr)); }
+
+    # 10. fast_blocks parallel to the original body order
+    val rfb: R.Result[*id.BlockId, str] = A.allocate[id.BlockId](m.alloc, body_len::usize);
+    if (R.is_err[*id.BlockId, str](rfb)) { free_maps(m, body, body_len, block_map, n_blocks, instr_map, n_instrs); ret R.err[VersionResult, str](R.unwrap_err[*id.BlockId, str](rfb)); }
+    val fast_blocks: *id.BlockId = R.unwrap_ok[*id.BlockId, str](rfb);
+    bi = 0;
+    for (bi < body_len) { fast_blocks[bi] = block_map[body[bi]::u32]::id.BlockId; bi = bi + 1; }
+
+    free_maps(m, body, body_len, block_map, n_blocks, instr_map, n_instrs);
+
+    vr.status      = VERSION_OK;
+    vr.guard       = guard_bid;
+    vr.merge       = merge_bid;
+    vr.fast_header = fast_header;
+    vr.fast_blocks = fast_blocks;
+    vr.fast_len    = body_len;
+    ret R.ok[VersionResult, str](vr);
+}
+
+# release a version result's owned array
+# ---
+# vr: the version result to tear down
+# alloc: the allocator its fast_blocks were taken from
+pub fun version_result_dnit(vr: *VersionResult, alloc: *A.Allocator) {
+    if (vr.fast_blocks != nil && vr.fast_len > 0) {
+        A.deallocate[id.BlockId](alloc, vr.fast_blocks, vr.fast_len::usize);
+        vr.fast_blocks = nil;
+    }
+    vr.fast_len = 0;
+}
+
+# free the working maps
+fun free_maps(m: *ir.Module, body: *id.BlockId, body_len: u32, block_map: *u32, n_blocks: u32, instr_map: *u32, n_instrs: u32) {
+    if (body != nil && body_len > 0)      { A.deallocate[id.BlockId](m.alloc, body, body_len::usize); }
+    if (block_map != nil && n_blocks > 0) { A.deallocate[u32](m.alloc, block_map, n_blocks::usize); }
+    if (instr_map != nil && n_instrs > 0) { A.deallocate[u32](m.alloc, instr_map, n_instrs::usize); }
+}
+
+# clone one instruction into `fn` and record src -> clone in instr_map (the src
+# pointer is fetched fresh here because a prior clone may have grown fn.instrs)
+fun clone_one(m: *ir.Module, fn: *ir.Function, src_id: id.InstructionId, instr_map: *u32) R.Result[bool, str] {
+    val src: *instruction.Instruction = ?fn.instrs[src_id::u32];
+    val rc: R.Result[id.InstructionId, str] = mutate.clone_instruction(m, fn, src);
+    if (R.is_err[id.InstructionId, str](rc)) { ret R.err[bool, str](R.unwrap_err[id.InstructionId, str](rc)); }
+    instr_map[src_id::u32] = R.unwrap_ok[id.InstructionId, str](rc)::u32;
+    ret R.ok[bool, str](true);
+}
+
+# rewrite every cloned instruction's operands: a value naming a loop instruction ->
+# its clone; a block target naming a loop block -> its clone block; everything else
+# (loop-invariant values, the preheader, the exit) is left for the wiring steps
+fun remap_operands(fn: *ir.Function, block_map: *u32, n_blocks: u32, instr_map: *u32, n_instrs: u32) {
+    var s: u32 = 0;
+    for (s < n_instrs) {
+        if (instr_map[s] != NONE_U32) {
+            val clone_id: u32 = instr_map[s];
+            val opt: O.Option[*instruction.Instruction] = ir.instruction_get(fn, clone_id::id.InstructionId);
+            if (O.is_some[*instruction.Instruction](opt)) {
+                val inst: *instruction.Instruction = O.unwrap[*instruction.Instruction](opt);
+                var o: u32 = 0;
+                for (o < inst.operand_count) {
+                    if (operand_is_block(inst.kind, o)) {
+                        val old_bid: u32 = inst.operands[o].data.int_lit::u32;
+                        if (old_bid < n_blocks && block_map[old_bid] != NONE_U32) {
+                            inst.operands[o].data.int_lit = block_map[old_bid]::u64;
+                        }
+                    } or {
+                        if (inst.operands[o].kind == value.VAL_INSTR) {
+                            val old_iid: u32 = inst.operands[o].data.instr::u32;
+                            if (old_iid < n_instrs && instr_map[old_iid] != NONE_U32) {
+                                inst.operands[o].data.instr = instr_map[old_iid]::id.InstructionId;
+                            }
+                        }
+                    }
+                    o = o + 1;
+                }
+            }
+        }
+        s = s + 1;
+    }
+}
+
+# change every block-target operand of `blk`'s terminator equal to `from` to `to`
+fun redirect_terminator(fn: *ir.Function, blk: id.BlockId, from: id.BlockId, to: id.BlockId) {
+    val b: *ir.Block = ?fn.blocks[blk::u32];
+    if (b.terminator == id.INSTR_NIL) { ret; }
+    val opt: O.Option[*instruction.Instruction] = ir.instruction_get(fn, b.terminator);
+    if (O.is_none[*instruction.Instruction](opt)) { ret; }
+    val term: *instruction.Instruction = O.unwrap[*instruction.Instruction](opt);
+    var o: u32 = 0;
+    for (o < term.operand_count) {
+        if (operand_is_block(term.kind, o) && ir.block_target(term.operands[o]) == from) {
+            term.operands[o].data.int_lit = to::u64;
+        }
+        o = o + 1;
+    }
+}
+
+# change every phi-incoming block slot of `blk` equal to `from` to `to`
+fun relabel_phi_pred(fn: *ir.Function, blk: id.BlockId, from: id.BlockId, to: id.BlockId) {
+    val b: *ir.Block = ?fn.blocks[blk::u32];
+    var pi: u32 = 0;
+    for (pi < b.phi_count) {
+        val opt: O.Option[*instruction.Instruction] = ir.instruction_get(fn, b.phis[pi]);
+        if (O.is_some[*instruction.Instruction](opt)) {
+            val phi: *instruction.Instruction = O.unwrap[*instruction.Instruction](opt);
+            var o: u32 = 0;
+            for (o < phi.operand_count) {
+                if ((o % 2) == 0 && ir.block_target(phi.operands[o]) == from) {
+                    phi.operands[o].data.int_lit = to::u64;
+                }
+                o = o + 1;
+            }
+        }
+        pi = pi + 1;
+    }
+}
+
+# true when operand slot `o` of opcode `k` is a block target (BR slot 0; CBR slots
+# 1 and 2; PHI even slots)
+fun operand_is_block(k: instruction.InstrKind, o: u32) bool {
+    if (k == instruction.OP_BR)  { ret o == 0; }
+    if (k == instruction.OP_CBR) { ret o == 1 || o == 2; }
+    if (k == instruction.OP_PHI) { ret (o % 2) == 0; }
+    ret false;
+}
+
+# true when any value defined inside the loop is used by an instruction outside it
+# (a live-out this increment cannot merge across the two versions)
+fun has_live_out(fn: *ir.Function, la: *loops.LoopAnalysis, loop_ix: u32) bool {
+    var u: u32 = 0;
+    for (u < fn.instr_len) {
+        val ub: id.BlockId = la.instr_block[u];
+        # an instruction outside the loop body (unmapped instructions are dead pool
+        # slots and cannot host a live use)
+        if (ub != id.BLOCK_NIL && !loops.loop_contains(la, loop_ix, ub)) {
+            val inst: *instruction.Instruction = ?fn.instrs[u];
+            var o: u32 = 0;
+            for (o < inst.operand_count) {
+                if (inst.operands[o].kind == value.VAL_INSTR) {
+                    val defb: id.BlockId = la.instr_block[inst.operands[o].data.instr::u32];
+                    if (defb != id.BLOCK_NIL && loops.loop_contains(la, loop_ix, defb)) { ret true; }
+                }
+                o = o + 1;
+            }
+        }
+        u = u + 1;
+    }
+    ret false;
+}
+
+# structural value equality for base pointers: same param / instruction / global /
+# function reference. Conservative: an unrecognized kind compares unequal, so a
+# redundant self-disjointness check is emitted rather than a pair silently dropped.
+fun values_equal(a: value.Value, b: value.Value) bool {
+    if (a.kind != b.kind) { ret false; }
+    if (a.kind == value.VAL_PARAM)  { ret a.data.param_ix == b.data.param_ix; }
+    if (a.kind == value.VAL_INSTR)  { ret a.data.instr == b.data.instr; }
+    if (a.kind == value.VAL_GLOBAL) { ret a.data.global_ix == b.data.global_ix; }
+    if (a.kind == value.VAL_FN)     { ret a.data.fn_ix == b.data.fn_ix; }
+    ret false;
+}
+
+use std.allocator.page;
+use mach.lang.intern;
+use verify: mach.lang.me.ir.verify;
+
+# intern a `fun(i64, ptr, ptr, ptr) void` signature (n, a, b, c)
+fun mk_sig(m: *ir.Module, i64t: ir_type.IrTypeId, ptrt: ir_type.IrTypeId, o_sig: *ir_type.IrTypeId) i32 {
+    val rv: R.Result[ir_type.IrTypeId, str] = ir_type.intern_void(?m.types);
+    if (R.is_err[ir_type.IrTypeId, str](rv)) { ret 1; }
+    var ps: [4]ir_type.IrTypeId;
+    ps[0] = i64t; ps[1] = ptrt; ps[2] = ptrt; ps[3] = ptrt;
+    val rfn: R.Result[ir_type.IrTypeId, str] = ir_type.intern_fn(?m.types, R.unwrap_ok[ir_type.IrTypeId, str](rv), ?ps[0], 4);
+    if (R.is_err[ir_type.IrTypeId, str](rfn)) { ret 1; }
+    @o_sig = R.unwrap_ok[ir_type.IrTypeId, str](rfn);
+    ret 0;
+}
+
+# build the element-wise `a[i] = b[i] + c[i]` loop (n=param0, a=param1, b=param2,
+# c=param3) into `fn`: entry -> header -> body(latch) -> exit. Returns 0 on success.
+fun build_axpy(m: *ir.Module, bld: *builder.Builder, i64t: ir_type.IrTypeId, ptrt: ir_type.IrTypeId, o_entry: *id.BlockId, o_header: *id.BlockId, o_body: *id.BlockId, o_exit: *id.BlockId, o_iv: *value.Value) i32 {
+    val re: R.Result[id.BlockId, str] = builder.new_block(bld);
+    if (R.is_err[id.BlockId, str](re)) { ret 1; }
+    val entry: id.BlockId = R.unwrap_ok[id.BlockId, str](re);
+    val rh: R.Result[id.BlockId, str] = builder.new_block(bld);
+    if (R.is_err[id.BlockId, str](rh)) { ret 1; }
+    val header: id.BlockId = R.unwrap_ok[id.BlockId, str](rh);
+    val rb: R.Result[id.BlockId, str] = builder.new_block(bld);
+    if (R.is_err[id.BlockId, str](rb)) { ret 1; }
+    val body: id.BlockId = R.unwrap_ok[id.BlockId, str](rb);
+    val rx: R.Result[id.BlockId, str] = builder.new_block(bld);
+    if (R.is_err[id.BlockId, str](rx)) { ret 1; }
+    val exit: id.BlockId = R.unwrap_ok[id.BlockId, str](rx);
+
+    val n: value.Value = value.param(0, i64t);
+    val a: value.Value = value.param(1, ptrt);
+    val b: value.Value = value.param(2, ptrt);
+    val c: value.Value = value.param(3, ptrt);
+
+    builder.set_block(bld, entry);
+    if (R.is_err[bool, str](builder.emit_br(bld, header))) { ret 1; }
+
+    builder.set_block(bld, header);
+    val rphi: R.Result[value.Value, str] = builder.emit_phi(bld, i64t);
+    if (R.is_err[value.Value, str](rphi)) { ret 1; }
+    val iv: value.Value = R.unwrap_ok[value.Value, str](rphi);
+    val rc: R.Result[value.Value, str] = builder.emit_cmp_lt_s(bld, iv, n);
+    if (R.is_err[value.Value, str](rc)) { ret 1; }
+    if (R.is_err[bool, str](builder.emit_cbr(bld, R.unwrap_ok[value.Value, str](rc), body, exit))) { ret 1; }
+
+    builder.set_block(bld, body);
+    var ixb: [1]value.Value; ixb[0] = iv;
+    val rgb: R.Result[value.Value, str] = builder.emit_gep(bld, b, i64t, ?ixb[0], 1);
+    if (R.is_err[value.Value, str](rgb)) { ret 1; }
+    val rlb: R.Result[value.Value, str] = builder.emit_load(bld, R.unwrap_ok[value.Value, str](rgb), i64t);
+    if (R.is_err[value.Value, str](rlb)) { ret 1; }
+    var ixc: [1]value.Value; ixc[0] = iv;
+    val rgc: R.Result[value.Value, str] = builder.emit_gep(bld, c, i64t, ?ixc[0], 1);
+    if (R.is_err[value.Value, str](rgc)) { ret 1; }
+    val rlc: R.Result[value.Value, str] = builder.emit_load(bld, R.unwrap_ok[value.Value, str](rgc), i64t);
+    if (R.is_err[value.Value, str](rlc)) { ret 1; }
+    val rs: R.Result[value.Value, str] = builder.emit_add(bld, R.unwrap_ok[value.Value, str](rlb), R.unwrap_ok[value.Value, str](rlc));
+    if (R.is_err[value.Value, str](rs)) { ret 1; }
+    var ixa: [1]value.Value; ixa[0] = iv;
+    val rga: R.Result[value.Value, str] = builder.emit_gep(bld, a, i64t, ?ixa[0], 1);
+    if (R.is_err[value.Value, str](rga)) { ret 1; }
+    if (R.is_err[bool, str](builder.emit_store(bld, R.unwrap_ok[value.Value, str](rs), R.unwrap_ok[value.Value, str](rga)))) { ret 1; }
+    val ru: R.Result[value.Value, str] = builder.emit_add(bld, iv, value.const_int(1, i64t));
+    if (R.is_err[value.Value, str](ru)) { ret 1; }
+    val upd: value.Value = R.unwrap_ok[value.Value, str](ru);
+    if (R.is_err[bool, str](builder.emit_br(bld, header))) { ret 1; }
+
+    builder.set_block(bld, exit);
+    if (R.is_err[bool, str](builder.emit_ret_void(bld))) { ret 1; }
+
+    if (R.is_err[bool, str](builder.phi_add_incoming(bld, iv, entry, value.const_int(0, i64t)))) { ret 1; }
+    if (R.is_err[bool, str](builder.phi_add_incoming(bld, iv, body, upd))) { ret 1; }
+
+    @o_entry = entry; @o_header = header; @o_body = body; @o_exit = exit; @o_iv = iv;
+    ret 0;
+}
+
+# count how many instructions of opcode `k` block `bid` holds
+fun count_op(fn: *ir.Function, bid: id.BlockId, k: instruction.InstrKind) u32 {
+    val blk: *ir.Block = ?fn.blocks[bid::u32];
+    var n: u32 = 0;
+    var i: u32 = 0;
+    for (i < blk.instr_count) {
+        val opt: O.Option[*instruction.Instruction] = ir.instruction_get(fn, blk.instructions[i]);
+        if (O.is_some[*instruction.Instruction](opt)) {
+            if (O.unwrap[*instruction.Instruction](opt).kind == k) { n = n + 1; }
+        }
+        i = i + 1;
+    }
+    ret n;
+}
+
+# the alias guard for `a[i]=b[i]+c[i]` pairs the write base a against b and c (two
+# distinct-base pairs): six range geps, four unsigned pointer compares, two ors, one
+# and.
+test "mach.lang.me.transform.versioning:alias_guard_shape" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+    val rm: R.Result[ir.Module, str] = ir.init(?alloc, intern.STR_NIL);
+    if (R.is_err[ir.Module, str](rm)) { ret 1; }
+    var m: ir.Module = R.unwrap_ok[ir.Module, str](rm);
+    val rt: R.Result[ir_type.IrTypeId, str] = ir_type.intern_int(?m.types, 64);
+    if (R.is_err[ir_type.IrTypeId, str](rt)) { ir.dnit(?m); ret 1; }
+    val i64t: ir_type.IrTypeId = R.unwrap_ok[ir_type.IrTypeId, str](rt);
+    val rp: R.Result[ir_type.IrTypeId, str] = ir_type.intern_ptr(?m.types);
+    if (R.is_err[ir_type.IrTypeId, str](rp)) { ir.dnit(?m); ret 1; }
+    val ptrt: ir_type.IrTypeId = R.unwrap_ok[ir_type.IrTypeId, str](rp);
+    var sig: ir_type.IrTypeId;
+    if (mk_sig(?m, i64t, ptrt, ?sig) != 0) { ir.dnit(?m); ret 1; }
+    val rf: R.Result[u32, str] = ir.function_add(?m, intern.STR_NIL, sig, 0);
+    if (R.is_err[u32, str](rf)) { ir.dnit(?m); ret 1; }
+    val fn: *ir.Function = ?m.functions[R.unwrap_ok[u32, str](rf)];
+    var bld: builder.Builder = builder.init(?m);
+    builder.set_function(?bld, fn);
+
+    var entry: id.BlockId; var header: id.BlockId; var body: id.BlockId; var exit: id.BlockId; var iv: value.Value;
+    if (build_axpy(?m, ?bld, i64t, ptrt, ?entry, ?header, ?body, ?exit, ?iv) != 0) { ir.dnit(?m); ret 1; }
+
+    var code: i32 = 0;
+    val ral: R.Result[loops.LoopAnalysis, str] = loops.analyze(fn, ?alloc);
+    if (R.is_err[loops.LoopAnalysis, str](ral)) { ir.dnit(?m); ret 1; }
+    var la: loops.LoopAnalysis = R.unwrap_ok[loops.LoopAnalysis, str](ral);
+    val rd: R.Result[dep.DepInfo, str] = dep.analyze_dependence(fn, ?la, 0, ?alloc);
+    if (R.is_err[dep.DepInfo, str](rd)) { loops.dnit(?la); ir.dnit(?m); ret 1; }
+    var di: dep.DepInfo = R.unwrap_ok[dep.DepInfo, str](rd);
+
+    val rg: R.Result[id.BlockId, str] = builder.new_block(?bld);
+    if (R.is_err[id.BlockId, str](rg)) { dep.dep_dnit(?di); loops.dnit(?la); ir.dnit(?m); ret 1; }
+    val gb: id.BlockId = R.unwrap_ok[id.BlockId, str](rg);
+    builder.set_block(?bld, gb);
+    val init: value.Value = la.loops[0].iv.init;
+    val bound: value.Value = la.loops[0].counted.bound;
+    val rge: R.Result[value.Value, str] = emit_alias_guard(?bld, ?di, init, bound);
+    if (R.is_err[value.Value, str](rge)) { dep.dep_dnit(?di); loops.dnit(?la); ir.dnit(?m); ret 1; }
+
+    if (count_op(fn, gb, instruction.OP_GEP) != 6)      { code = 1; }
+    if (count_op(fn, gb, instruction.OP_CMP_LE_U) != 4) { code = 1; }
+    if (count_op(fn, gb, instruction.OP_OR) != 2)       { code = 1; }
+    if (count_op(fn, gb, instruction.OP_AND) != 1)      { code = 1; }
+
+    dep.dep_dnit(?di);
+    loops.dnit(?la);
+    ir.dnit(?m);
+    ret code;
+}
+
+# versioning a well-formed element-wise loop clones it into a guarded fast copy plus
+# the scalar original, leaving the function VERIFIER-CLEAN: two loops, the guard's
+# cbr selects fast vs scalar, block count grows by body_len + 2.
+test "mach.lang.me.transform.versioning:version_verifier_clean" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+    val rm: R.Result[ir.Module, str] = ir.init(?alloc, intern.STR_NIL);
+    if (R.is_err[ir.Module, str](rm)) { ret 1; }
+    var m: ir.Module = R.unwrap_ok[ir.Module, str](rm);
+    val rt: R.Result[ir_type.IrTypeId, str] = ir_type.intern_int(?m.types, 64);
+    if (R.is_err[ir_type.IrTypeId, str](rt)) { ir.dnit(?m); ret 1; }
+    val i64t: ir_type.IrTypeId = R.unwrap_ok[ir_type.IrTypeId, str](rt);
+    val rp: R.Result[ir_type.IrTypeId, str] = ir_type.intern_ptr(?m.types);
+    if (R.is_err[ir_type.IrTypeId, str](rp)) { ir.dnit(?m); ret 1; }
+    val ptrt: ir_type.IrTypeId = R.unwrap_ok[ir_type.IrTypeId, str](rp);
+    var sig: ir_type.IrTypeId;
+    if (mk_sig(?m, i64t, ptrt, ?sig) != 0) { ir.dnit(?m); ret 1; }
+    val rf: R.Result[u32, str] = ir.function_add(?m, intern.STR_NIL, sig, 0);
+    if (R.is_err[u32, str](rf)) { ir.dnit(?m); ret 1; }
+    val fn: *ir.Function = ?m.functions[R.unwrap_ok[u32, str](rf)];
+    var bld: builder.Builder = builder.init(?m);
+    builder.set_function(?bld, fn);
+
+    var entry: id.BlockId; var header: id.BlockId; var body: id.BlockId; var exit: id.BlockId; var iv: value.Value;
+    if (build_axpy(?m, ?bld, i64t, ptrt, ?entry, ?header, ?body, ?exit, ?iv) != 0) { ir.dnit(?m); ret 1; }
+    val blocks_before: u32 = fn.block_count;
+
+    var code: i32 = 0;
+    val ral: R.Result[loops.LoopAnalysis, str] = loops.analyze(fn, ?alloc);
+    if (R.is_err[loops.LoopAnalysis, str](ral)) { ir.dnit(?m); ret 1; }
+    var la: loops.LoopAnalysis = R.unwrap_ok[loops.LoopAnalysis, str](ral);
+    val rd: R.Result[dep.DepInfo, str] = dep.analyze_dependence(fn, ?la, 0, ?alloc);
+    if (R.is_err[dep.DepInfo, str](rd)) { loops.dnit(?la); ir.dnit(?m); ret 1; }
+    var di: dep.DepInfo = R.unwrap_ok[dep.DepInfo, str](rd);
+
+    val rv: R.Result[VersionResult, str] = version_loop(?m, fn, ?la, 0, ?di);
+    if (R.is_err[VersionResult, str](rv)) { dep.dep_dnit(?di); loops.dnit(?la); ir.dnit(?m); ret 1; }
+    var vres: VersionResult = R.unwrap_ok[VersionResult, str](rv);
+    if (vres.status != VERSION_OK) { code = 1; }
+    if (fn.block_count != blocks_before + 4) { code = 1; }
+
+    # the guard block ends in a cbr to the fast header (true) and scalar header (false)
+    val gblk: *ir.Block = ?fn.blocks[vres.guard::u32];
+    val topt: O.Option[*instruction.Instruction] = ir.instruction_get(fn, gblk.terminator);
+    if (O.is_none[*instruction.Instruction](topt)) { code = 1; }
+    or {
+        val term: *instruction.Instruction = O.unwrap[*instruction.Instruction](topt);
+        if (term.kind != instruction.OP_CBR)                      { code = 1; }
+        if (ir.block_target(term.operands[1]) != vres.fast_header) { code = 1; }
+        if (ir.block_target(term.operands[2]) != header)          { code = 1; }
+    }
+
+    # the surgery is verifier-clean (reachability + dominance enforced)
+    val rvr: R.Result[verify.VerifyReport, str] = verify.verify_module_ext(?m, ?alloc, true, false);
+    if (R.is_err[verify.VerifyReport, str](rvr)) { code = 1; }
+    or {
+        var rep: verify.VerifyReport = R.unwrap_ok[verify.VerifyReport, str](rvr);
+        if (rep.len != 0) { code = 1; }
+        verify.dnit_report(?rep);
+    }
+
+    # two loops now (fast + scalar)
+    val ral2: R.Result[loops.LoopAnalysis, str] = loops.analyze(fn, ?alloc);
+    if (R.is_err[loops.LoopAnalysis, str](ral2)) { code = 1; }
+    or {
+        var la2: loops.LoopAnalysis = R.unwrap_ok[loops.LoopAnalysis, str](ral2);
+        if (la2.loop_len != 2) { code = 1; }
+        loops.dnit(?la2);
+    }
+
+    version_result_dnit(?vres, ?alloc);
+    dep.dep_dnit(?di);
+    loops.dnit(?la);
+    ir.dnit(?m);
+    ret code;
+}
+
+# version_loop refuses a loop-carried dependence without mutating the function
+test "mach.lang.me.transform.versioning:refuse_dependent" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+    val rm: R.Result[ir.Module, str] = ir.init(?alloc, intern.STR_NIL);
+    if (R.is_err[ir.Module, str](rm)) { ret 1; }
+    var m: ir.Module = R.unwrap_ok[ir.Module, str](rm);
+    val rt: R.Result[ir_type.IrTypeId, str] = ir_type.intern_int(?m.types, 64);
+    if (R.is_err[ir_type.IrTypeId, str](rt)) { ir.dnit(?m); ret 1; }
+    val i64t: ir_type.IrTypeId = R.unwrap_ok[ir_type.IrTypeId, str](rt);
+    val rp: R.Result[ir_type.IrTypeId, str] = ir_type.intern_ptr(?m.types);
+    if (R.is_err[ir_type.IrTypeId, str](rp)) { ir.dnit(?m); ret 1; }
+    val ptrt: ir_type.IrTypeId = R.unwrap_ok[ir_type.IrTypeId, str](rp);
+    var sig: ir_type.IrTypeId;
+    if (mk_sig(?m, i64t, ptrt, ?sig) != 0) { ir.dnit(?m); ret 1; }
+    val rf: R.Result[u32, str] = ir.function_add(?m, intern.STR_NIL, sig, 0);
+    if (R.is_err[u32, str](rf)) { ir.dnit(?m); ret 1; }
+    val fn: *ir.Function = ?m.functions[R.unwrap_ok[u32, str](rf)];
+    var bld: builder.Builder = builder.init(?m);
+    builder.set_function(?bld, fn);
+
+    # build `a[i] = a[i-1]` (loop-carried)
+    val re: R.Result[id.BlockId, str] = builder.new_block(?bld);
+    if (R.is_err[id.BlockId, str](re)) { ir.dnit(?m); ret 1; }
+    val entry: id.BlockId = R.unwrap_ok[id.BlockId, str](re);
+    val rh: R.Result[id.BlockId, str] = builder.new_block(?bld);
+    if (R.is_err[id.BlockId, str](rh)) { ir.dnit(?m); ret 1; }
+    val header: id.BlockId = R.unwrap_ok[id.BlockId, str](rh);
+    val rb: R.Result[id.BlockId, str] = builder.new_block(?bld);
+    if (R.is_err[id.BlockId, str](rb)) { ir.dnit(?m); ret 1; }
+    val body: id.BlockId = R.unwrap_ok[id.BlockId, str](rb);
+    val rx: R.Result[id.BlockId, str] = builder.new_block(?bld);
+    if (R.is_err[id.BlockId, str](rx)) { ir.dnit(?m); ret 1; }
+    val exit: id.BlockId = R.unwrap_ok[id.BlockId, str](rx);
+    val n: value.Value = value.param(0, i64t);
+    val a: value.Value = value.param(1, ptrt);
+    builder.set_block(?bld, entry);
+    if (R.is_err[bool, str](builder.emit_br(?bld, header))) { ir.dnit(?m); ret 1; }
+    builder.set_block(?bld, header);
+    val rphi: R.Result[value.Value, str] = builder.emit_phi(?bld, i64t);
+    if (R.is_err[value.Value, str](rphi)) { ir.dnit(?m); ret 1; }
+    val iv: value.Value = R.unwrap_ok[value.Value, str](rphi);
+    val rc: R.Result[value.Value, str] = builder.emit_cmp_lt_s(?bld, iv, n);
+    if (R.is_err[value.Value, str](rc)) { ir.dnit(?m); ret 1; }
+    if (R.is_err[bool, str](builder.emit_cbr(?bld, R.unwrap_ok[value.Value, str](rc), body, exit))) { ir.dnit(?m); ret 1; }
+    builder.set_block(?bld, body);
+    val rim1: R.Result[value.Value, str] = builder.emit_add(?bld, iv, value.const_int(0xFFFFFFFFFFFFFFFF, i64t));
+    if (R.is_err[value.Value, str](rim1)) { ir.dnit(?m); ret 1; }
+    var ixs: [1]value.Value; ixs[0] = R.unwrap_ok[value.Value, str](rim1);
+    val rgs: R.Result[value.Value, str] = builder.emit_gep(?bld, a, i64t, ?ixs[0], 1);
+    if (R.is_err[value.Value, str](rgs)) { ir.dnit(?m); ret 1; }
+    val rl: R.Result[value.Value, str] = builder.emit_load(?bld, R.unwrap_ok[value.Value, str](rgs), i64t);
+    if (R.is_err[value.Value, str](rl)) { ir.dnit(?m); ret 1; }
+    var ixd: [1]value.Value; ixd[0] = iv;
+    val rgd: R.Result[value.Value, str] = builder.emit_gep(?bld, a, i64t, ?ixd[0], 1);
+    if (R.is_err[value.Value, str](rgd)) { ir.dnit(?m); ret 1; }
+    if (R.is_err[bool, str](builder.emit_store(?bld, R.unwrap_ok[value.Value, str](rl), R.unwrap_ok[value.Value, str](rgd)))) { ir.dnit(?m); ret 1; }
+    val ru: R.Result[value.Value, str] = builder.emit_add(?bld, iv, value.const_int(1, i64t));
+    if (R.is_err[value.Value, str](ru)) { ir.dnit(?m); ret 1; }
+    if (R.is_err[bool, str](builder.emit_br(?bld, header))) { ir.dnit(?m); ret 1; }
+    builder.set_block(?bld, exit);
+    if (R.is_err[bool, str](builder.emit_ret_void(?bld))) { ir.dnit(?m); ret 1; }
+    if (R.is_err[bool, str](builder.phi_add_incoming(?bld, iv, entry, value.const_int(0, i64t)))) { ir.dnit(?m); ret 1; }
+    if (R.is_err[bool, str](builder.phi_add_incoming(?bld, iv, body, R.unwrap_ok[value.Value, str](ru)))) { ir.dnit(?m); ret 1; }
+
+    val blocks_before: u32 = fn.block_count;
+    var code: i32 = 0;
+    val ral: R.Result[loops.LoopAnalysis, str] = loops.analyze(fn, ?alloc);
+    if (R.is_err[loops.LoopAnalysis, str](ral)) { ir.dnit(?m); ret 1; }
+    var la: loops.LoopAnalysis = R.unwrap_ok[loops.LoopAnalysis, str](ral);
+    val rd: R.Result[dep.DepInfo, str] = dep.analyze_dependence(fn, ?la, 0, ?alloc);
+    if (R.is_err[dep.DepInfo, str](rd)) { loops.dnit(?la); ir.dnit(?m); ret 1; }
+    var di: dep.DepInfo = R.unwrap_ok[dep.DepInfo, str](rd);
+    val rv: R.Result[VersionResult, str] = version_loop(?m, fn, ?la, 0, ?di);
+    if (R.is_err[VersionResult, str](rv)) { dep.dep_dnit(?di); loops.dnit(?la); ir.dnit(?m); ret 1; }
+    var vres: VersionResult = R.unwrap_ok[VersionResult, str](rv);
+    if (vres.status != VERSION_DEPENDENT)   { code = 1; }
+    if (fn.block_count != blocks_before)    { code = 1; }
+    version_result_dnit(?vres, ?alloc);
+    dep.dep_dnit(?di);
+    loops.dnit(?la);
+    ir.dnit(?m);
+    ret code;
+}
+
+# version_loop refuses a loop with an induction variable used after the loop (a
+# live-out this increment cannot merge across the two versions), without mutating
+test "mach.lang.me.transform.versioning:refuse_live_out" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+    val rm: R.Result[ir.Module, str] = ir.init(?alloc, intern.STR_NIL);
+    if (R.is_err[ir.Module, str](rm)) { ret 1; }
+    var m: ir.Module = R.unwrap_ok[ir.Module, str](rm);
+    val rt: R.Result[ir_type.IrTypeId, str] = ir_type.intern_int(?m.types, 64);
+    if (R.is_err[ir_type.IrTypeId, str](rt)) { ir.dnit(?m); ret 1; }
+    val i64t: ir_type.IrTypeId = R.unwrap_ok[ir_type.IrTypeId, str](rt);
+    val rp: R.Result[ir_type.IrTypeId, str] = ir_type.intern_ptr(?m.types);
+    if (R.is_err[ir_type.IrTypeId, str](rp)) { ir.dnit(?m); ret 1; }
+    val ptrt: ir_type.IrTypeId = R.unwrap_ok[ir_type.IrTypeId, str](rp);
+    var sig: ir_type.IrTypeId;
+    if (mk_sig(?m, i64t, ptrt, ?sig) != 0) { ir.dnit(?m); ret 1; }
+    val rf: R.Result[u32, str] = ir.function_add(?m, intern.STR_NIL, sig, 0);
+    if (R.is_err[u32, str](rf)) { ir.dnit(?m); ret 1; }
+    val fn: *ir.Function = ?m.functions[R.unwrap_ok[u32, str](rf)];
+    var bld: builder.Builder = builder.init(?m);
+    builder.set_function(?bld, fn);
+
+    # build `a[i] = b[i]` with the induction variable also used in the exit block
+    val re: R.Result[id.BlockId, str] = builder.new_block(?bld);
+    if (R.is_err[id.BlockId, str](re)) { ir.dnit(?m); ret 1; }
+    val entry: id.BlockId = R.unwrap_ok[id.BlockId, str](re);
+    val rh: R.Result[id.BlockId, str] = builder.new_block(?bld);
+    if (R.is_err[id.BlockId, str](rh)) { ir.dnit(?m); ret 1; }
+    val header: id.BlockId = R.unwrap_ok[id.BlockId, str](rh);
+    val rb: R.Result[id.BlockId, str] = builder.new_block(?bld);
+    if (R.is_err[id.BlockId, str](rb)) { ir.dnit(?m); ret 1; }
+    val body: id.BlockId = R.unwrap_ok[id.BlockId, str](rb);
+    val rx: R.Result[id.BlockId, str] = builder.new_block(?bld);
+    if (R.is_err[id.BlockId, str](rx)) { ir.dnit(?m); ret 1; }
+    val exit: id.BlockId = R.unwrap_ok[id.BlockId, str](rx);
+    val n: value.Value = value.param(0, i64t);
+    val a: value.Value = value.param(1, ptrt);
+    val bb: value.Value = value.param(2, ptrt);
+    builder.set_block(?bld, entry);
+    if (R.is_err[bool, str](builder.emit_br(?bld, header))) { ir.dnit(?m); ret 1; }
+    builder.set_block(?bld, header);
+    val rphi: R.Result[value.Value, str] = builder.emit_phi(?bld, i64t);
+    if (R.is_err[value.Value, str](rphi)) { ir.dnit(?m); ret 1; }
+    val iv: value.Value = R.unwrap_ok[value.Value, str](rphi);
+    val rc: R.Result[value.Value, str] = builder.emit_cmp_lt_s(?bld, iv, n);
+    if (R.is_err[value.Value, str](rc)) { ir.dnit(?m); ret 1; }
+    if (R.is_err[bool, str](builder.emit_cbr(?bld, R.unwrap_ok[value.Value, str](rc), body, exit))) { ir.dnit(?m); ret 1; }
+    builder.set_block(?bld, body);
+    var ixb: [1]value.Value; ixb[0] = iv;
+    val rgb: R.Result[value.Value, str] = builder.emit_gep(?bld, bb, i64t, ?ixb[0], 1);
+    if (R.is_err[value.Value, str](rgb)) { ir.dnit(?m); ret 1; }
+    val rl: R.Result[value.Value, str] = builder.emit_load(?bld, R.unwrap_ok[value.Value, str](rgb), i64t);
+    if (R.is_err[value.Value, str](rl)) { ir.dnit(?m); ret 1; }
+    var ixa: [1]value.Value; ixa[0] = iv;
+    val rga: R.Result[value.Value, str] = builder.emit_gep(?bld, a, i64t, ?ixa[0], 1);
+    if (R.is_err[value.Value, str](rga)) { ir.dnit(?m); ret 1; }
+    if (R.is_err[bool, str](builder.emit_store(?bld, R.unwrap_ok[value.Value, str](rl), R.unwrap_ok[value.Value, str](rga)))) { ir.dnit(?m); ret 1; }
+    val ru: R.Result[value.Value, str] = builder.emit_add(?bld, iv, value.const_int(1, i64t));
+    if (R.is_err[value.Value, str](ru)) { ir.dnit(?m); ret 1; }
+    if (R.is_err[bool, str](builder.emit_br(?bld, header))) { ir.dnit(?m); ret 1; }
+    # exit: use the induction variable (the live-out) BEFORE the terminator
+    builder.set_block(?bld, exit);
+    if (R.is_err[value.Value, str](builder.emit_add(?bld, iv, value.const_int(0, i64t)))) { ir.dnit(?m); ret 1; }
+    if (R.is_err[bool, str](builder.emit_ret_void(?bld))) { ir.dnit(?m); ret 1; }
+    if (R.is_err[bool, str](builder.phi_add_incoming(?bld, iv, entry, value.const_int(0, i64t)))) { ir.dnit(?m); ret 1; }
+    if (R.is_err[bool, str](builder.phi_add_incoming(?bld, iv, body, R.unwrap_ok[value.Value, str](ru)))) { ir.dnit(?m); ret 1; }
+
+    val blocks_before: u32 = fn.block_count;
+    var code: i32 = 0;
+    val ral: R.Result[loops.LoopAnalysis, str] = loops.analyze(fn, ?alloc);
+    if (R.is_err[loops.LoopAnalysis, str](ral)) { ir.dnit(?m); ret 1; }
+    var la: loops.LoopAnalysis = R.unwrap_ok[loops.LoopAnalysis, str](ral);
+    val rd: R.Result[dep.DepInfo, str] = dep.analyze_dependence(fn, ?la, 0, ?alloc);
+    if (R.is_err[dep.DepInfo, str](rd)) { loops.dnit(?la); ir.dnit(?m); ret 1; }
+    var di: dep.DepInfo = R.unwrap_ok[dep.DepInfo, str](rd);
+    # the loop itself is dependence-independent; the refusal is specifically live-out
+    if (di.verdict != dep.DEP_INDEPENDENT) { code = 1; }
+    val rv: R.Result[VersionResult, str] = version_loop(?m, fn, ?la, 0, ?di);
+    if (R.is_err[VersionResult, str](rv)) { dep.dep_dnit(?di); loops.dnit(?la); ir.dnit(?m); ret 1; }
+    var vres: VersionResult = R.unwrap_ok[VersionResult, str](rv);
+    if (vres.status != VERSION_LIVE_OUT) { code = 1; }
+    if (fn.block_count != blocks_before) { code = 1; }
+    version_result_dnit(?vres, ?alloc);
+    dep.dep_dnit(?di);
+    loops.dnit(?la);
+    ir.dnit(?m);
+    ret code;
+}


### PR DESCRIPTION
Closes #2140. Second child of the auto-vectorization epic #1942.

The safety machinery child 3 (element-wise vectorization) will consume: three callable APIs over child 1's loop analysis, all **dormant** (nothing wired into the pipeline), so the compiler binary is unchanged.

### 1. Dependence analysis — `mach.lang.me.analysis.dependence`
Over a counted loop, a deliberately **conservative** verdict:
- `DEP_INDEPENDENT` only when every memory access is a non-volatile load/store through `gep(base, iv)` — a single index equal to the induction-variable phi (offset 0, unit stride) over a loop-invariant base — the induction variable is the loop's **sole** register recurrence, and there is no opaque memory effect (call / asm / memzero).
- `DEP_DEPENDENT` for everything else (a loop-carried `a[i]=a[i-1]`, a reduction's second phi, an unknown access, a non-counted loop).

Collects the recognized `base[iv]` accesses (base, per-element stride type, element type, store/load) for the alias guard.

### 2. Runtime alias-check — `versioning.emit_alias_guard`
Synthesizes the runtime disjointness guard: for each write base against every distinct-base access range, `(end_w <= start_o) || (end_o <= start_w)` over per-access byte ranges `[base+init*sz, base+bound*sz)` with unsigned pointer compares, AND-ed across pairs. No distinct-base pair (no writes, single base, all-equal bases) yields a constant-true guard (no hazard).

### 3. Loop versioning — `versioning.version_loop`
Clones a well-formed, dependence-independent loop into a runtime-guarded **fast** copy plus the original **scalar** fallback, with the CFG / phi surgery: dedicated guard block (alias check → `cbr` fast/scalar) and merge block, preheader→guard rewire, header phi-incoming relabeling, and exit routing through the merge. Both copies are scalar this increment, so the transform is **behavior-preserving**; child 3 replaces the fast copy's body with vector ops. **Refuses (no mutation)** any loop that is not counted, not well-formed (relying on child 1's dedicated preheader/latch/exit guarantees), dependence-dependent, or that defines a **live-out** SSA value (deferred to child 4's reduction-aware merging).

### Conservative-safety argument
Pointer-parameter loops (axpy/matmul) can't be proven non-aliasing at compile time (mach has no `restrict`), so static independence is discharged at runtime by the alias guard + versioning; a loop that can't be proven safe stays scalar. Every positive signal is fully guarded (child 1's lesson): the dependence verdict clears only the proven element-wise shape, and versioning proceeds only on child-1-well-formed loops with no live-out.

### Verification
- **Byte-identical compiler output** — built with and without both new files; same SHA256 (`f4ddf123…`). Both modules are orphan (unimported).
- **Full suite** — `mach test .` = **742 / 0** (9 new tests): dependence independent / loop-carried / reduction; the alias-guard instruction shape (6 geps + 4 compares + 2 ors + 1 and for `a[i]=b[i]+c[i]`); **versioning is verifier-clean** (a test runs the IR verifier over the versioned function — reachability + dominance enforced), two loops after versioning, guard `cbr` targets; and refusal of dependent and live-out loops without mutation.
- **Single-gen fixpoint** B == C byte-identical.
- **int** `linux` and `linux-riscv64` all-pass; **mach-std** 663 / 0 under the from-source compiler. rv64 stays scalar (no codegen change).
