### PR TITLE
test(ct): dudect timing-leak harness + planted-leak validation (#1647)

### DIFF
--- a/doc/language/secrecy.md
+++ b/doc/language/secrecy.md
@@ -97,6 +97,15 @@ blocks (which a type system cannot check). Everything else is enforced. A proof
 is always relative to a leakage model. Its fidelity to real silicon is
 empirical.
 
+## Assurance
+
+The type system proves the source respects the leakage model and `#[oblivious]`
+holds it through codegen; that the emitted code is constant-time on real hardware
+is testing-grade until the translation validator lands. The dudect-style timing
+harness at `int/ct/` measures a branchless constant-time reference against a
+deliberately-leaky control and flags the leak with Welch's t-test — run it with
+`bash int/ct/ct.sh`.
+
 ## See also
 
 - [types.md](types.md) — the compound type grammar `^` qualifies

--- a/int/ct/ct.sh
+++ b/int/ct/ct.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+# ct.sh — the constant-time timing-leak harness (#1647).
+#
+# WHAT IT MEASURES. an empirical, testing-grade check that Mach's constant-time story
+# holds on real hardware, complementing the static secret-flow gates (#1645) and the
+# #[oblivious] codegen contract (#1646). it builds two functions that do the SAME task
+# — an 8-byte comparison against a fixed reference — and times each over two input
+# classes (dudect's fixed-vs-random), applying Welch's t-test to the two timing
+# distributions:
+#   * ct_probe   — a branchless #[oblivious] compare over `^` secrets; timing must not
+#                  depend on the input, so |t| stays small.
+#   * leaky_probe — a deliberately-leaky control that early-exits on the first
+#                  mismatching byte, so its running time leaks how many bytes matched.
+# the leaky control is the planted leak: a harness that cannot catch it is decoration.
+# it is written over PUBLIC values on purpose — sema rejects a secret branch in any
+# function, so this leak is unconstructable with `^` types, which is exactly the point:
+# the static discipline forbids it, and this harness catches it the moment the
+# discipline is dropped.
+#
+# HOW TO RUN.
+#   bash int/ct/ct.sh                     # bootstrap a from-source compiler, measure
+#   bash int/ct/ct.sh /path/to/mach       # use a prebuilt CT-capable compiler
+#   bash int/ct/ct.sh /path/to/mach linux release
+#   LEAK_MIN=10 CT_WARN=10 bash int/ct/ct.sh   # override thresholds
+# the PATH `mach` seed predates the `^`/#[oblivious] surface, so the harness cannot be
+# built with it directly; omitting the compiler argument bootstraps one from source.
+#
+# WHY NOT A CI GATE. timing measurement is noise-sensitive and CI runners are shared
+# and noisy, so this is run-on-demand, not wired into CI. it lives beside the int/
+# cases but is NOT discovered by int/run.sh (which scans only surface/ and regression/),
+# so it never becomes a flaky gate. the assertion is a leak-detection smoke: the leaky
+# control MUST exceed LEAK_MIN (a wide margin — observed |t| in the hundreds against a
+# threshold of 10), while the constant-time reference is informational (its |t| is
+# reported and warned on, never failed) so ambient noise cannot break the build.
+set -euo pipefail
+
+here=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+cd "$here"
+repo_root=$(cd "$here/../.." && pwd)
+
+mach="${1:-}"
+target="${2:-linux}"
+profile="${3:-release}"
+
+# leaky |t| must clear this (hard). ct |t| above CT_WARN warns but never fails.
+LEAK_MIN="${LEAK_MIN:-10}"
+CT_WARN="${CT_WARN:-10}"
+
+fail() { echo "FAIL: $1" >&2; exit 1; }
+
+tmp=$(mktemp -d)
+trap 'rm -rf "$tmp"' EXIT
+
+# vendor the repo's std as the harness's path dependency: no network, and the exact
+# std the compiler under test was built against.
+[ -d "$repo_root/dep/mach-std" ] \
+    || fail "repo dep/mach-std missing — run 'mach dep pull' at the repo root first"
+mkdir -p dep
+ln -sfn "$repo_root/dep/mach-std" dep/mach-std
+
+# resolve a CT-capable compiler: the one given, else bootstrap from source with the
+# PATH seed.
+if [ -z "$mach" ]; then
+    echo "no compiler given — bootstrapping a from-source compiler with the PATH seed"
+    if ! mach build "$repo_root" --profile release -o "$tmp/machct" >"$tmp/boot.log" 2>&1; then
+        sed 's/^/  /' "$tmp/boot.log" >&2
+        fail "bootstrap compiler build failed"
+    fi
+    mach="$tmp/machct"
+fi
+case "$mach" in
+    /*) : ;;
+    */*) mach="$(cd "$(dirname "$mach")" && pwd)/$(basename "$mach")" ;;
+    *)  mach="$(command -v "$mach")" || fail "compiler '$1' not found on PATH" ;;
+esac
+
+echo "building the ct harness with $mach (target $target, profile $profile)"
+rm -rf out
+if ! "$mach" build . --target "$target" --profile "$profile" >"$tmp/build.log" 2>&1; then
+    if grep -q "unknown decorator" "$tmp/build.log"; then
+        fail "the compiler at '$mach' predates the #[oblivious] surface — pass a from-source compiler (post-#2137) or omit the argument to bootstrap one"
+    fi
+    sed 's/^/  /' "$tmp/build.log" >&2
+    fail "harness build failed"
+fi
+bin=$(find out -name ct_harness -type f -print -quit)
+[ -n "$bin" ] || fail "no ct_harness binary produced"
+
+echo "running the measurement (dudect / Welch's t-test)"
+out=$("$bin")
+echo "$out" | sed 's/^/  /'
+
+extract() { echo "$out" | awk -v n="$1" '$0 ~ ("name=" n " ") { for (i=1;i<=NF;i++) if ($i ~ /^abst=/) { sub("abst=","",$i); print $i } }'; }
+ct_t=$(extract ct)
+leak_t=$(extract leak)
+[ -n "$ct_t" ]   || fail "no ct result parsed from harness output"
+[ -n "$leak_t" ] || fail "no leak result parsed from harness output"
+
+echo
+rc=0
+awk -v ct="$ct_t" -v lk="$leak_t" -v lmin="$LEAK_MIN" -v cwarn="$CT_WARN" '
+BEGIN {
+    printf "constant-time reference : |t| = %s (threshold %s, informational)\n", ct, cwarn
+    printf "planted leak (control)  : |t| = %s (must exceed %s)\n", lk, lmin
+    rc = 0
+    if (lk + 0 < lmin + 0) {
+        printf "FAIL: the planted leak was NOT detected — |t| %s < %s; the harness is not measuring\n", lk, lmin
+        rc = 1
+    } else {
+        printf "OK: the planted leak was detected (|t| %s >= %s)\n", lk, lmin
+    }
+    if (ct + 0 >= cwarn + 0) {
+        printf "WARN: the constant-time reference showed |t| %s >= %s — investigate (runner noise, or a real regression)\n", ct, cwarn
+    } else {
+        printf "OK: the constant-time reference showed no input-dependent timing (|t| %s < %s)\n", ct, cwarn
+    }
+    exit rc
+}' || rc=$?
+echo
+if [ "$rc" -eq 0 ]; then
+    echo "OK: ct harness passed — planted leak caught, constant-time reference clean"
+else
+    echo "int/ct: harness FAILED"
+fi
+exit "$rc"

--- a/int/ct/mach.toml
+++ b/int/ct/mach.toml
@@ -1,0 +1,41 @@
+[project]
+id = "ctharness"
+version = "0.0.0"
+src = "src"
+out = "out/{target.name}/{profile.name}"
+
+[target.linux]
+isa = "x86_64"
+os  = "linux"
+abi = "sysv64"
+
+[target.linux-arm64]
+isa = "aarch64"
+os  = "linux"
+abi = "aapcs64"
+
+[target.linux-riscv64]
+isa = "riscv64"
+os  = "linux"
+abi = "lp64"
+
+[profile.debug]
+opt = 0
+debug = false
+simd = "scalarize"
+
+[profile.release]
+opt = 2
+debug = false
+simd = "scalarize"
+
+[artifact.ct_harness]
+kind = "bin"
+entry = "main.mach"
+out = "bin/ct_harness"
+targets = ["*"]
+link = []
+need = []
+
+[dep.mach-std]
+path = "dep/mach-std"

--- a/int/ct/src/ct.mach
+++ b/int/ct/src/ct.mach
@@ -1,0 +1,37 @@
+# constant-time reference corpus (#1647).
+#
+# the primitives the harness expects to show NO input-dependent timing: each is
+# `#[oblivious]` over `^` secret operands and is branchless by construction - it
+# folds/selects with only bitwise, shift, and additive ops, so no secret ever
+# reaches a branch, a memory index, or a variable-latency instruction. the harness
+# measures the public adapter `ct_probe` and must not flag it.
+
+# branchless constant-time equality of two secret words: 1 if equal, else 0.
+# the xor difference is 0 exactly when the words are equal; `(d | (0 - d)) >> 63`
+# is 1 iff `d != 0` (for any nonzero d, either d or its two's-complement has bit 63
+# set), so the result is computed without observing the secret.
+#[oblivious]
+pub fun ct_eq(a: ^u64, b: ^u64) ^u64 {
+    val d:  ^u64 = a ^ b;
+    val nz: ^u64 = (d | (0 - d)) >> 63;
+    ret 1 - nz;
+}
+
+# branchless constant-time select: `a` when `cond == 1`, `b` when `cond == 0`.
+# the mask is all-ones or all-zero (`0 - cond`), so the choice is a bitwise blend
+# with no secret-dependent control flow.
+#[oblivious]
+pub fun ct_select(cond: ^u64, a: ^u64, b: ^u64) ^u64 {
+    val mask: ^u64 = 0 - cond;
+    ret (a & mask) | (b & ~mask);
+}
+
+# harness adapter: compare the input word (as secret material) against a fixed
+# secret reference in constant time and declassify the 0/1 verdict. the work is
+# identical for every input - all eight bytes are always folded - so timing carries
+# no information about the input, and the harness's t-statistic must stay small.
+pub fun ct_probe(x: u64) u64 {
+    val sx:  ^u64 = x;
+    val tag: ^u64 = 0;
+    ret ct_eq(sx, tag):^;
+}

--- a/int/ct/src/dudect.mach
+++ b/int/ct/src/dudect.mach
@@ -1,0 +1,156 @@
+# dudect-style timing-leak measurement engine (#1647).
+#
+# the empirical, testing-grade layer of Mach's constant-time story: it measures the
+# wall-clock time of a function under test over two input classes and applies Welch's
+# t-test to decide whether the timing distributions differ. a large |t| means the
+# running time depends on the input - a timing leak; a small |t| is consistent with
+# constant time. this is the dudect method (Reparaz, Balasch, Verbauwhede 2016).
+#
+# the two classes are dudect's "fixed vs random": class 0 always feeds a fixed input,
+# class 1 feeds a fresh random input each round. the ONLY difference between the two
+# measured regions is the input value handed to the function - every RNG draw happens
+# outside the timed region - so any timing difference is attributable to the function,
+# not to harness overhead. classes are interleaved round by round so thermal or
+# frequency drift biases both equally.
+#
+# the timer is the monotonic clock (portable across every target); to keep each sample
+# well above the clock's resolution the function is called `INNER` times per sample and
+# the batch is timed as a whole. this measures whatever the compiler actually emits at
+# the chosen optimisation level - the property #[oblivious] must preserve end to end.
+
+use std.types.size.usize;
+use std.types.string.str;
+use std.system.os;
+use p: std.print;
+
+# calls per timed sample; keeps a sample well above monotonic-clock resolution.
+pub val INNER: u64 = 2048;
+
+# measured samples per class after warmup; more rounds tighten the estimate.
+pub val ROUNDS: u64 = 2000;
+
+# discarded leading rounds; lets caches and the branch predictor settle.
+pub val WARMUP: u64 = 64;
+
+# sink for function results; a module global the optimiser cannot prove dead, so the
+# timed calls are never eliminated.
+var SINK: u64 = 0;
+
+# online mean/variance accumulator (Welford), one per input class.
+rec Stat {
+    n:    f64;
+    mean: f64;
+    m2:   f64;
+}
+
+fun stat_init(s: *Stat) {
+    s.n    = 0.0;
+    s.mean = 0.0;
+    s.m2   = 0.0;
+}
+
+fun stat_push(s: *Stat, x: f64) {
+    s.n = s.n + 1.0;
+    val d1: f64 = x - s.mean;
+    s.mean = s.mean + d1 / s.n;
+    val d2: f64 = x - s.mean;
+    s.m2 = s.m2 + d1 * d2;
+}
+
+# sample variance, or 0 with fewer than two samples.
+fun stat_var(s: *Stat) f64 {
+    if (s.n < 2.0) { ret 0.0; }
+    ret s.m2 / (s.n - 1.0);
+}
+
+# xorshift64 pseudo-random generator; fast enough to draw outside the timed region.
+fun xnext(state: *u64) u64 {
+    var x: u64 = @state;
+    x = x ^ (x << 13);
+    x = x ^ (x >> 7);
+    x = x ^ (x << 17);
+    @state = x;
+    ret x;
+}
+
+# monotonic clock in nanoseconds.
+fun now_ns() u64 {
+    var ts: os.Timespec;
+    os.monotonic(?ts);
+    ret ts.sec::u64 * 1000000000 + ts.nsec::u64;
+}
+
+# f64 square root by Newton iteration; std math is integer-only.
+fun sqrtf(x: f64) f64 {
+    if (x <= 0.0) { ret 0.0; }
+    var g: f64 = x;
+    var i: usize = 0;
+    for (i < 64) {
+        g = 0.5 * (g + x / g);
+        i = i + 1;
+    }
+    ret g;
+}
+
+fun fabsf(x: f64) f64 {
+    if (x < 0.0) { ret 0.0 - x; }
+    ret x;
+}
+
+# time INNER calls of `fut` on a single input; the result feeds SINK so no call is
+# dropped. the input is fixed for the whole batch, so both classes execute an
+# identical harness loop and differ only in the value under test.
+fun measure_batch(fut: fun(u64) u64, input: u64) u64 {
+    var acc: u64 = 0;
+    val t0: u64 = now_ns();
+    var i: u64 = 0;
+    for (i < INNER) {
+        acc = acc + fut(input);
+        i = i + 1;
+    }
+    val t1: u64 = now_ns();
+    SINK = SINK + acc;
+    ret t1 - t0;
+}
+
+# Welch's t-statistic for two independent samples with unequal variance.
+fun welch_t(a: *Stat, b: *Stat) f64 {
+    val va: f64 = stat_var(a);
+    val vb: f64 = stat_var(b);
+    val se: f64 = va / a.n + vb / b.n;
+    if (se <= 0.0) { ret 0.0; }
+    ret (a.mean - b.mean) / sqrtf(se);
+}
+
+# measure one function under test and print a structured result line the driver
+# parses. `fixed` is the class-0 input; class-1 inputs are drawn from `seed`.
+pub fun measure(name: str, fut: fun(u64) u64, fixed: u64, seed: u64) {
+    var rng: u64 = seed;
+
+    var w: u64 = 0;
+    for (w < WARMUP) {
+        SINK = SINK + measure_batch(fut, fixed);
+        SINK = SINK + measure_batch(fut, xnext(?rng));
+        w = w + 1;
+    }
+
+    var sf: Stat;
+    var sr: Stat;
+    stat_init(?sf);
+    stat_init(?sr);
+
+    var r: u64 = 0;
+    for (r < ROUNDS) {
+        val tf: u64 = measure_batch(fut, fixed);
+        val rnd: u64 = xnext(?rng);
+        val tr: u64 = measure_batch(fut, rnd);
+        stat_push(?sf, tf::f64);
+        stat_push(?sr, tr::f64);
+        r = r + 1;
+    }
+
+    val t: f64 = welch_t(?sf, ?sr);
+    p.printlnf(
+        "ctresult name={} t={} abst={} rounds={} inner={} mean_fix={} mean_rnd={}",
+        name, t, fabsf(t), ROUNDS::i64, INNER::i64, sf.mean, sr.mean);
+}

--- a/int/ct/src/leaky.mach
+++ b/int/ct/src/leaky.mach
@@ -1,0 +1,26 @@
+# deliberately-leaky control (#1647): the planted leak the harness must catch.
+#
+# a variable-time comparison. it handles the input as a PUBLIC value - the
+# secret-typing discipline is deliberately dropped, exactly the real-world mistake -
+# and early-exits on the first mismatching byte, so its running time depends on how
+# many leading bytes match the reference. the harness MUST flag it.
+#
+# this leak is unwritable with `^` secret types: sema rejects a secret branch or
+# loop condition in ANY function (`secret value used as a branch condition`). that is
+# the point of the pairing - the static discipline forbids the leak at the type level,
+# and this harness catches it empirically the moment the discipline is abandoned.
+
+# leaky comparison of the input word against a fixed reference, byte by byte, with an
+# early exit. returns the count of leading matching bytes - a running time the loop
+# trip count exposes.
+pub fun leaky_probe(x: u64) u64 {
+    val tag: u64 = 0;
+    var i: u64 = 0;
+    for (i < 8) {
+        val bx: u64 = (x >> (i * 8)) & 0xff;
+        val bt: u64 = (tag >> (i * 8)) & 0xff;
+        if (bx != bt) { ret i; }
+        i = i + 1;
+    }
+    ret 8;
+}

--- a/int/ct/src/main.mach
+++ b/int/ct/src/main.mach
@@ -1,0 +1,25 @@
+# constant-time measurement harness entrypoint (#1647).
+#
+# runs the dudect engine over two functions that perform the SAME task - an 8-byte
+# comparison against a fixed reference - under identical conditions: a constant-time
+# reference (`ct_probe`, branchless) and a deliberately-leaky control (`leaky_probe`,
+# early-exit). both are measured in one process so they see the same ambient noise,
+# and each prints a `ctresult` line the driver asserts against:
+#   * leaky  -> large |t| (the planted leak MUST be caught)
+#   * ct     -> small |t| (informational; constant time shows no input dependence)
+
+use std.runtime;
+use std.types.size.usize;
+
+use ctharness.ct;
+use ctharness.leaky;
+use d: ctharness.dudect;
+
+#[symbol("main")]
+fun main(argc: usize, argv: **u8) i64 {
+    # fixed class feeds 0: for both probes this is the all-bytes-match reference, the
+    # slowest path through the leaky control and an ordinary input for the ct one.
+    d.measure("ct",   ct.ct_probe,       0, 0x243f6a8885a308d3);
+    d.measure("leak", leaky.leaky_probe, 0, 0x452821e638d01377);
+    ret 0;
+}


### PR DESCRIPTION
Closes #1647.

The empirical, testing-grade layer of Mach's constant-time story — a dudect-style timing-leak harness that complements the static secret-flow gates (#1645) and the `#[oblivious]` codegen contract (#1646/#2137). It measures what the compiler actually emits and, crucially, catches a planted leak.

## What it measures

Two functions that do the **same task** — an 8-byte comparison against a fixed reference — timed over two input classes (dudect's fixed-vs-random) and separated with Welch's t-test:

- **`ct_probe`** (`int/ct/src/ct.mach`) — a branchless `#[oblivious]` compare over `^` secrets (`ct_eq` folds the xor difference with only bitwise/shift/additive ops, declassifies the 0/1 verdict). Timing is input-independent → small `|t|`.
- **`leaky_probe`** (`int/ct/src/leaky.mach`) — the planted leak: an early-exit byte compare whose loop trip count leaks how many leading bytes matched. Large `|t|`.

The engine (`int/ct/src/dudect.mach`) draws all randomness *outside* the timed region, batches `INNER` calls per sample through a runtime function pointer (opaque to the optimiser — no hoisting/DCE, results feed a module-global sink), interleaves the two classes round-by-round so drift biases both equally, and uses the monotonic clock (portable across every target).

## The planted-leak proof

Representative run (`bash int/ct/ct.sh`), release profile, native x86_64:

```
ctresult name=ct   t=-0.075  abst=0.075   mean_fix=4490  mean_rnd=4492
ctresult name=leak t=988.8   abst=988.8   mean_fix=18380 mean_rnd=5693
```

The leaky control's `|t|` lands in the hundreds (fixed input matches all 8 bytes → 8 loop trips → slow; random input mismatches at byte 0 → fast), while the constant-time reference stays under ~1.5 across repeated runs and both profiles — a discrimination ratio in the thousands. The driver's negative self-test (`LEAK_MIN=100000`) confirms the assertion genuinely gates rather than always passing.

The leak is deliberately written over **public** values: sema rejects a secret branch in *any* function (`secret value used as a branch condition`), so this leak is unconstructable with `^` types. That is the point of the pairing — the static discipline forbids the leak at the type level, and this harness catches it empirically the moment the discipline is abandoned.

## Placement rationale

Modeled on `dep/mach-std/test/relro/verify.sh`: a self-contained, run-on-demand harness (`mach.toml` + mach probes + a bash driver), placed under `int/ct/`. It is **not** discovered by `int/run.sh` (which scans only `surface/` and `regression/`), so it never becomes a CI lane.

This is intentional and honest about the noise problem: timing measurement is noise-sensitive and CI runners are shared and noisy, so the harness is **not** wired into CI (respecting the no-new-int-lanes rule). The assertion is a leak-detection smoke — the leaky control *must* clear `LEAK_MIN` (default 10, with a wide margin), while the constant-time reference is informational (reported and warned on, never failed) so ambient noise cannot break a build.

## How to run

```
bash int/ct/ct.sh                   # bootstrap a from-source compiler, then measure
bash int/ct/ct.sh /path/to/mach     # use a prebuilt CT-capable compiler
LEAK_MIN=10 CT_WARN=10 bash int/ct/ct.sh
```

The PATH `mach` seed predates the `^`/`#[oblivious]` surface, so the harness cannot be built with it directly; omitting the compiler argument bootstraps one from source (the driver detects a stale compiler and says so).

## Scope / follow-ups (owner decision)

#1647 lists three prongs and CI wiring; this PR delivers the **dudect statistical-timing** prong plus corpora and the planted-leak validation — the first harness, per the task scope. Deferred, and worth separate issues if wanted:

- **ctgrind / Valgrind taint** — secret-taint tracking on the binary; overlaps the #1648 translation-validator territory.
- **golden-MIR/asm snapshots** — largely #1646's own acceptance (select stays branchless); the `int/surface/oblivious` case already exercises runtime behavior.
- **crypto-kernel corpus** — waits on `crypto.ct` (mach-std#304); the corpora here are self-contained reference primitives.
- **CI wiring** deliberately omitted (timing noise); if a gate is desired later it should be the leak-smoke only, on a native runner.

No compiler source touched — output is byte-identical; `int/ct/{dep,out}` are gitignored.
