### PR TITLE
feat(codegen): constant-time translation validator over lowered MIR (#1648)

### DIFF
--- a/src/lang/be/codegen.mach
+++ b/src/lang/be/codegen.mach
@@ -24,6 +24,7 @@ use A: std.allocator;
 use O: std.types.option;
 use R: std.types.result;
 
+use mach.lang.be.codegen.ctvalidate;
 use mach.lang.be.codegen.dwarf;
 use mach.lang.be.codegen.encode;
 use mach.lang.be.codegen.frame;
@@ -178,6 +179,16 @@ pub fun codegen_module(s: *session.Session, tgt: *target.Target,
     val res_legalize: R.Result[bool, str] = legalize.run(tgt, ?mir_module);
     if (R.is_err[bool, str](res_legalize)) {
         ret R.err[of.ObjectImage, str](R.unwrap_err[bool, str](res_legalize));
+    }
+
+    # the constant-time translation validator (#1648): re-derive the secret taint from the
+    # #1646 seeds over the lowered, target-independent MIR - after loop rotation and
+    # legalization, before instruction selection, so it validates exactly what isel consumes -
+    # and reject a secret reaching a branch, an address, or a forbidden variable-latency op in
+    # any #[oblivious] function. pure analysis: a module with no oblivious function is untouched.
+    val res_ctvalidate: R.Result[bool, str] = ctvalidate.run(tgt, ?mir_module);
+    if (R.is_err[bool, str](res_ctvalidate)) {
+        ret R.err[of.ObjectImage, str](R.unwrap_err[bool, str](res_ctvalidate));
     }
 
     val res_isel: R.Result[bool, str] = isel.run(tgt, ?mir_module);

--- a/src/lang/be/codegen.mach
+++ b/src/lang/be/codegen.mach
@@ -176,19 +176,24 @@ pub fun codegen_module(s: *session.Session, tgt: *target.Target,
         ret R.err[of.ObjectImage, str](R.unwrap_err[bool, str](res_looprotate));
     }
 
-    val res_legalize: R.Result[bool, str] = legalize.run(tgt, ?mir_module);
-    if (R.is_err[bool, str](res_legalize)) {
-        ret R.err[of.ObjectImage, str](R.unwrap_err[bool, str](res_legalize));
-    }
-
     # the constant-time translation validator (#1648): re-derive the secret taint from the
-    # #1646 seeds over the lowered, target-independent MIR - after loop rotation and
-    # legalization, before instruction selection, so it validates exactly what isel consumes -
-    # and reject a secret reaching a branch, an address, or a forbidden variable-latency op in
-    # any #[oblivious] function. pure analysis: a module with no oblivious function is untouched.
+    # #1646 seeds over the LOWERED, TARGET-INDEPENDENT MIR - after loop rotation (so a rotated
+    # loop's cloned vregs, which carry their seed, are seen) and before width legalization (a
+    # narrow-ALU target splits a wide secret value into fresh lane vregs that do NOT carry the
+    # seed, so the intact seeds live only here) - and reject a secret reaching a branch, an
+    # address, or a forbidden variable-latency op in any #[oblivious] function. This is the
+    # same layer the compile-time gate in `mir.lower` reads, so the two enforcement points
+    # never drift; legalization is a constant-time-preserving width splitter, and isel /
+    # regalloc / encode are trusted timing-preserving. Pure analysis: a module with no
+    # oblivious function is untouched.
     val res_ctvalidate: R.Result[bool, str] = ctvalidate.run(tgt, ?mir_module);
     if (R.is_err[bool, str](res_ctvalidate)) {
         ret R.err[of.ObjectImage, str](R.unwrap_err[bool, str](res_ctvalidate));
+    }
+
+    val res_legalize: R.Result[bool, str] = legalize.run(tgt, ?mir_module);
+    if (R.is_err[bool, str](res_legalize)) {
+        ret R.err[of.ObjectImage, str](R.unwrap_err[bool, str](res_legalize));
     }
 
     val res_isel: R.Result[bool, str] = isel.run(tgt, ?mir_module);

--- a/src/lang/be/codegen/ctvalidate.mach
+++ b/src/lang/be/codegen/ctvalidate.mach
@@ -9,9 +9,8 @@
 # per-instruction taint from those stable seeds as a monotone dataflow FIXPOINT and then
 # checks, in every `#[oblivious]` function, that no secret-tainted value reaches a leaking
 # position. Because the seeds sit on sources and the taint is re-derived here, no earlier
-# transform - phi elimination, inlining, loop rotation, width legalization - can launder a
-# secret past the check: the merge / clone / copy it produces is just another operand the
-# fixpoint propagates through.
+# transform - inlining, phi elimination, loop rotation - can launder a secret past the check:
+# the merge / clone / copy it produces is just another operand the fixpoint propagates through.
 #
 # THE RE-DERIVE. `taint[v]` seeds from `MirVReg.secret` and grows by one rule:
 #   any-secret-operand -> secret-result,
@@ -48,12 +47,16 @@
 # byte-identical to a build without it.
 #
 # SCOPE (documented contract, #1646 -> #1648). The validated layer is the LOWERED,
-# pre-selection MIR: this pass runs after loop rotation and legalization and before
-# instruction selection, so it validates exactly what isel consumes and trusts
-# isel / regalloc / encode to be timing-preserving. True translation-validation of the
-# EMITTED machine code (the epic's eventual goal) needs the seeds and barrier to survive
-# to post-regalloc MIR - additive per-ISA work left as future strengthening; the lowered-
-# MIR contract does not foreclose it.
+# TARGET-INDEPENDENT, pre-selection MIR: this pass runs after loop rotation and BEFORE width
+# legalization, the same layer the compile-time gate in `mir.lower` reads. Before legalization
+# is deliberate: a narrow-ALU target splits a wide secret value into fresh lane vregs that do
+# NOT carry `MirVReg.secret`, so the seeds are intact only here; legalization is itself a
+# constant-time-preserving width splitter (it introduces no branch, no computed address, and
+# no new variable-latency op, and rejects a wide divide / variable shift / non-constant
+# multiply loudly), and isel / regalloc / encode are trusted timing-preserving. True
+# translation-validation of the EMITTED machine code (the epic's eventual goal) needs the
+# seeds and barrier to survive to post-regalloc MIR - additive per-ISA work left as future
+# strengthening; the lowered-MIR contract does not foreclose it.
 
 use std.types.bool.bool;
 use std.types.bool.true;
@@ -76,8 +79,8 @@ use target: mach.lang.target.resolved;
 
 # validate every `#[oblivious]` function of a MIR module for constant-time leakage
 #
-# The shared entry point the codegen driver calls between legalization and instruction
-# selection. Re-derives the secret taint from the #1646 seeds and rejects a secret value
+# The shared entry point the codegen driver calls after loop rotation and before width
+# legalization. Re-derives the secret taint from the #1646 seeds and rejects a secret value
 # reaching a branch condition, a memory address, or a forbidden variable-latency op inside
 # any function marked `#[oblivious]`. A function without the marker is skipped; the pass
 # never mutates the MIR, so a module with no oblivious function is validated in a single

--- a/src/lang/be/codegen/ctvalidate.mach
+++ b/src/lang/be/codegen/ctvalidate.mach
@@ -26,6 +26,14 @@
 # recomputed within the same forward walk, so a secret reaching a fixed-register operand is
 # not lost at the register boundary.
 #
+# The value seed (`MirVReg.secret`) and the barrier are the leakage re-derive's whole input.
+# `MirInstr.writes_secret` is deliberately NOT one: it marks a store / memzero writing secret
+# STORAGE, which guards a different property (a zeroizing wipe must survive dead-store
+# elimination, enforced by DSE preserving the flag - not a timing leak). A later load OF that
+# secret storage is already seeded on its own result vreg (a welded load), so re-deriving
+# memory-through-address taint would add nothing; the store's ADDRESS is covered by check (b)
+# like any memory operand, and storing a secret VALUE to a public address is not a leak.
+#
 # THE CHECK. In a function carrying `#[oblivious]` (`MirFunction.oblivious`), a secret-
 # tainted value must not reach:
 #   (a) a conditional-branch CONDITION (`MIR_CBR` operand 0) - the taken path, hence the

--- a/src/lang/be/codegen/ctvalidate.mach
+++ b/src/lang/be/codegen/ctvalidate.mach
@@ -49,6 +49,11 @@
 #       floating-point op. The same `ct` table drives the compile-time gates in
 #       `mir.lower`; this pass is the independent RELATIONAL backstop that re-derives taint
 #       and re-checks, catching whatever a future pass might slip past those gates.
+# INLINE ASSEMBLY is forbidden in an oblivious function: its body is opaque to static
+# analysis (its secret operands ride on the asm block's `{name}` bindings and it can branch
+# on or address with them invisibly), so it cannot be verified constant-time - the airtight
+# rule is to reject the unverifiable construct rather than trust it.
+#
 # A violation is a precise compile error naming the function and the leaking op. The pass
 # is CONSERVATIVE by construction (a missed taint would defeat the guarantee, so it errs
 # toward over-taint) and pure analysis: it never mutates the MIR, so a build with no
@@ -66,6 +71,11 @@
 # translation-validation of the EMITTED machine code (the epic's eventual goal) needs the
 # seeds and barrier to survive to post-regalloc MIR - additive per-ISA work left as future
 # strengthening; the lowered-MIR contract does not foreclose it.
+#
+# TRACKED FOLLOW-UPS (experimental-target-scoped, out of scope here): an 8-bit target whose
+# integer COMPARE is not data-independent needs a `ct_trust_compare` capability so a secret
+# equality feeding a branch condition gates at the compare (mos6502); and the SPIR-V backend's
+# whole-module emitter bypasses the machine pipeline, so this pass never runs on it.
 
 use std.types.bool.bool;
 use std.types.bool.true;
@@ -231,7 +241,16 @@ fun max_preg(f: *mir.MirFunction) u32 {
     ret best;
 }
 
-# reset every physical-register taint bit to public (called at each block entry)
+# reset every physical-register taint bit to public, called at each block ENTRY
+#
+# INVARIANT (load-bearing): resetting the physical-register taint per block is sound ONLY
+# because a pre-colored physical register's live range never crosses a block boundary - a
+# precolor (a division dividend, a variable shift count, a call argument) is emitted
+# immediately before its single consumer in the same block. A future pass that separated a
+# precolor from its consumer across a block would leave the consumer's physical-register
+# operand read as public here, silently under-tainting check (c) / the address check. If that
+# ever changes, this reset must become a real cross-block physical-register liveness, not a
+# per-block wipe - fail loud in review rather than silently.
 fun clear_pregs(pt: *bool, np: u32) {
     if (pt == nil) { ret; }
     var i: u32 = 0;
@@ -291,6 +310,16 @@ fun apply_instr(mi: *mir.MirInstr, vt: *bool, nv: u32, pt: *bool, np: u32) bool 
 # alloc:    allocator for the diagnostic text
 # ret:      ok(true) when the instruction leaks nothing, or the violation's error
 fun check_instr(tgt: *target.Target, f: *mir.MirFunction, mi: *mir.MirInstr, vt: *bool, nv: u32, pt: *bool, np: u32, interner: *intern.Interner, alloc: *A.Allocator) R.Result[bool, str] {
+    # inline assembly is OPAQUE to this analysis: its secret ins / outs ride on the asm block's
+    # `{name}` bindings (not the instruction's operands - MIR_ASM has none the taint sees), and
+    # its body can branch on or address with a secret invisibly. Tainting its output slots would
+    # still miss a secret-dependent branch INSIDE the body, so it is not airtight; the sound,
+    # conservative rule is to FORBID inline asm in an oblivious function outright. (A vouching
+    # mechanism for hand-audited constant-time asm is a separate future design, not built here.)
+    if (mi.opcode == mir.MIR_ASM) {
+        ret R.err[bool, str](leak_msg(alloc, interner, f.name,
+            "contains inline assembly, which cannot be verified constant-time and is not permitted in a #[oblivious] function; express the operation with the constant-time primitives, or move it to a non-oblivious function and `:^`-declassify at the boundary"));
+    }
     # (a) a conditional branch whose condition is secret leaks through the taken path.
     if (mi.opcode == mir.MIR_CBR) {
         if (mi.operand_count >= 1 && operand_secret(?mi.operands[0], vt, nv, pt, np)) {
@@ -820,6 +849,32 @@ test "mach.lang.be.codegen.ctvalidate.control:secret_indirect_call" {
     var pblocks: [1]mir.MirBlock; pblocks[0] = t_block(0, ?pi[0], 1);
     var pf: mir.MirFunction = t_fn(true, ?pblocks[0], 1, ?vregs[0], 2);
     if (!R.is_ok[bool, str](validate_function(?t, ?pf, nil, ?alloc))) { ret 1; }
+    ret 0;
+}
+
+# inline assembly is opaque to the analysis, so it is forbidden outright in an oblivious
+# function (rejected on the opcode alone, before its bindings are even inspected), and is
+# unaffected in a non-oblivious one.
+test "mach.lang.be.codegen.ctvalidate.opaque:inline_asm_forbidden" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+    var t: target.Target = t_target(false, true);
+
+    var vregs: [1]mir.MirVReg;
+    vregs[0] = t_vreg(0, false);
+
+    # a lone inline-asm block (no operands - its bindings ride on asm_block).
+    var ai: [1]mir.MirInstr; ai[0] = t_instr(mir.MIR_ASM, nil, 0);
+    var blocks: [1]mir.MirBlock; blocks[0] = t_block(0, ?ai[0], 1);
+
+    # oblivious: forbidden.
+    var of: mir.MirFunction = t_fn(true, ?blocks[0], 1, ?vregs[0], 1);
+    if (!R.is_err[bool, str](validate_function(?t, ?of, nil, ?alloc))) { ret 1; }
+
+    # non-oblivious: skipped by run, no error.
+    var funcs: [1]mir.MirFunction; funcs[0] = t_fn(false, ?blocks[0], 1, ?vregs[0], 1);
+    var mm: mir.MirModule; mm.alloc = ?alloc; mm.interner = nil; mm.functions = ?funcs[0]; mm.function_len = 1;
+    if (!R.is_ok[bool, str](run(?t, ?mm))) { ret 1; }
     ret 0;
 }
 

--- a/src/lang/be/codegen/ctvalidate.mach
+++ b/src/lang/be/codegen/ctvalidate.mach
@@ -63,6 +63,8 @@ use std.types.string.str;
 use std.types.string.str_len;
 use std.format;
 
+use std.allocator.page;
+
 use A: std.allocator;
 use O: std.types.option;
 use R: std.types.result;
@@ -411,4 +413,380 @@ fun fn_name(interner: *intern.Interner, id: intern.StrId) str {
     val o: O.Option[str] = intern.lookup(interner, id);
     if (O.is_some[str](o)) { ret O.unwrap[str](o); }
     ret "<unknown>";
+}
+
+# a virtual register with a given secret seed, other fields defaulted (test helper)
+fun t_vreg(id: u32, secret: bool) mir.MirVReg {
+    var v: mir.MirVReg;
+    v.id         = id;
+    v.class      = mir.REG_CLASS_GP;
+    v.spill_slot = -1;
+    v.assigned   = mir.MIR_VREG_NIL;
+    v.vector     = false;
+    v.secret     = secret;
+    ret v;
+}
+
+# a MIR instruction over a borrowed operand array (test helper)
+fun t_instr(op: mir.MirOpcode, ops: *mir.MirOperand, n: u32) mir.MirInstr {
+    var mi: mir.MirInstr;
+    mi.opcode        = op;
+    mi.operands      = ops;
+    mi.operand_count = n;
+    mi.width         = 8;
+    mi.src_width     = 8;
+    ret mi;
+}
+
+# a MIR block over a borrowed instruction array (test helper)
+fun t_block(id: u32, instrs: *mir.MirInstr, n: u32) mir.MirBlock {
+    var b: mir.MirBlock;
+    b.id          = id;
+    b.instrs      = instrs;
+    b.instr_count = n;
+    b.instr_cap   = n;
+    b.preds       = nil;
+    b.pred_count  = 0;
+    b.pred_cap    = 0;
+    ret b;
+}
+
+# an oblivious MIR function over borrowed block / vreg arrays (test helper)
+fun t_fn(oblivious: bool, blocks: *mir.MirBlock, nb: u32, vregs: *mir.MirVReg, nv: u32) mir.MirFunction {
+    var f: mir.MirFunction;
+    f.name        = intern.STR_NIL;
+    f.blocks      = blocks;
+    f.block_count = nb;
+    f.vregs       = vregs;
+    f.vreg_count  = nv;
+    f.oblivious   = oblivious;
+    ret f;
+}
+
+# a target trusting the named constant-time capabilities, nothing else (test helper)
+fun t_target(trust_mul: bool, trust_var_shift: bool) target.Target {
+    var t: target.Target;
+    t.model.ct_trust_mul      = trust_mul;
+    t.model.ct_trust_var_shift = trust_var_shift;
+    ret t;
+}
+
+# a secret laundered through a phi join (out-of-SSA predecessor moves into one result vreg)
+# is re-derived secret and caught feeding a conditional branch. the merge vreg is NOT seeded;
+# only the fixpoint's any-secret-operand rule, applied across both predecessor definitions,
+# taints it - the exact laundering the seed-only design missed.
+test "mach.lang.be.codegen.ctvalidate.rederive:phi_join_branch" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+    var t: target.Target = t_target(false, true);
+
+    # v0 secret source; v1 the phi-result (unseeded); v2 a public value.
+    var vregs: [3]mir.MirVReg;
+    vregs[0] = t_vreg(0, true);
+    vregs[1] = t_vreg(1, false);
+    vregs[2] = t_vreg(2, false);
+
+    # B0: v1 <- v0 (secret) ; br B2
+    var b0_mov: [2]mir.MirOperand; b0_mov[0] = mir.op_vreg(1); b0_mov[1] = mir.op_vreg(0);
+    var b0_br:  [1]mir.MirOperand; b0_br[0]  = mir.op_block(2);
+    var b0i: [2]mir.MirInstr;
+    b0i[0] = t_instr(mir.MIR_MOV, ?b0_mov[0], 2);
+    b0i[1] = t_instr(mir.MIR_BR,  ?b0_br[0], 1);
+
+    # B1: v1 <- v2 (public) ; br B2  (the merge's other predecessor)
+    var b1_mov: [2]mir.MirOperand; b1_mov[0] = mir.op_vreg(1); b1_mov[1] = mir.op_vreg(2);
+    var b1_br:  [1]mir.MirOperand; b1_br[0]  = mir.op_block(2);
+    var b1i: [2]mir.MirInstr;
+    b1i[0] = t_instr(mir.MIR_MOV, ?b1_mov[0], 2);
+    b1i[1] = t_instr(mir.MIR_BR,  ?b1_br[0], 1);
+
+    # B2: cbr v1, B0, B1  (branch on the merged value)
+    var b2_cbr: [3]mir.MirOperand; b2_cbr[0] = mir.op_vreg(1); b2_cbr[1] = mir.op_block(0); b2_cbr[2] = mir.op_block(1);
+    var b2i: [1]mir.MirInstr;
+    b2i[0] = t_instr(mir.MIR_CBR, ?b2_cbr[0], 3);
+
+    var blocks: [3]mir.MirBlock;
+    blocks[0] = t_block(0, ?b0i[0], 2);
+    blocks[1] = t_block(1, ?b1i[0], 2);
+    blocks[2] = t_block(2, ?b2i[0], 1);
+
+    var f: mir.MirFunction = t_fn(true, ?blocks[0], 3, ?vregs[0], 3);
+    val r: R.Result[bool, str] = validate_function(?t, ?f, nil, ?alloc);
+    if (!R.is_err[bool, str](r)) { ret 1; }
+    ret 0;
+}
+
+# a secret laundered through a multi-hop copy chain (an inlined return's value copies) is
+# re-derived secret and caught feeding a memory address. v3 is two moves removed from the
+# secret source and never seeded.
+test "mach.lang.be.codegen.ctvalidate.rederive:inlined_return_address" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+    var t: target.Target = t_target(false, true);
+
+    var vregs: [4]mir.MirVReg;
+    vregs[0] = t_vreg(0, true);    # secret source (callee return)
+    vregs[1] = t_vreg(1, false);
+    vregs[2] = t_vreg(2, false);
+    vregs[3] = t_vreg(3, false);   # loaded value
+
+    # v1 <- v0 ; v2 <- v1 ; v3 <- load [v2]   (a secret-derived address)
+    var mov1: [2]mir.MirOperand; mov1[0] = mir.op_vreg(1); mov1[1] = mir.op_vreg(0);
+    var mov2: [2]mir.MirOperand; mov2[0] = mir.op_vreg(2); mov2[1] = mir.op_vreg(1);
+    var load: [2]mir.MirOperand; load[0] = mir.op_vreg(3); load[1] = mir.op_mem_value(2, 0);
+    var b0i: [3]mir.MirInstr;
+    b0i[0] = t_instr(mir.MIR_MOV,  ?mov1[0], 2);
+    b0i[1] = t_instr(mir.MIR_MOV,  ?mov2[0], 2);
+    b0i[2] = t_instr(mir.MIR_LOAD, ?load[0], 2);
+
+    var blocks: [1]mir.MirBlock;
+    blocks[0] = t_block(0, ?b0i[0], 3);
+    var f: mir.MirFunction = t_fn(true, ?blocks[0], 1, ?vregs[0], 4);
+    val r: R.Result[bool, str] = validate_function(?t, ?f, nil, ?alloc);
+    if (!R.is_err[bool, str](r)) { ret 1; }
+    ret 0;
+}
+
+# a secret carried across a loop back edge (a rotated loop's cloned loop variable) taints
+# the header's branch condition. the loop variable's USE at the header textually precedes
+# its secret DEFINITION in the body, so only the whole-function fixpoint - not a forward
+# sweep - catches it. the derived value the header branches on is re-derived, never seeded.
+test "mach.lang.be.codegen.ctvalidate.rederive:rotated_loop_backedge" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+    var t: target.Target = t_target(false, true);
+
+    var vregs: [4]mir.MirVReg;
+    vregs[0] = t_vreg(0, true);    # secret source
+    vregs[1] = t_vreg(1, false);   # loop variable (unseeded, becomes secret in the body)
+    vregs[2] = t_vreg(2, false);   # public value
+    vregs[3] = t_vreg(3, false);   # the branch condition, derived from the loop variable
+
+    # B0 header: v3 <- add v1, v2 ; cbr v3, B1, B2
+    var add: [3]mir.MirOperand; add[0] = mir.op_vreg(3); add[1] = mir.op_vreg(1); add[2] = mir.op_vreg(2);
+    var hbr: [3]mir.MirOperand; hbr[0] = mir.op_vreg(3); hbr[1] = mir.op_block(1); hbr[2] = mir.op_block(2);
+    var b0i: [2]mir.MirInstr;
+    b0i[0] = t_instr(mir.MIR_ADD, ?add[0], 3);
+    b0i[1] = t_instr(mir.MIR_CBR, ?hbr[0], 3);
+
+    # B1 body: v1 <- v0 (secret) ; br B0  (the back edge)
+    var lmv: [2]mir.MirOperand; lmv[0] = mir.op_vreg(1); lmv[1] = mir.op_vreg(0);
+    var lbr: [1]mir.MirOperand; lbr[0] = mir.op_block(0);
+    var b1i: [2]mir.MirInstr;
+    b1i[0] = t_instr(mir.MIR_MOV, ?lmv[0], 2);
+    b1i[1] = t_instr(mir.MIR_BR,  ?lbr[0], 1);
+
+    # B2 exit: ret
+    var b2i: [1]mir.MirInstr;
+    b2i[0] = t_instr(mir.MIR_RET, nil, 0);
+
+    var blocks: [3]mir.MirBlock;
+    blocks[0] = t_block(0, ?b0i[0], 2);
+    blocks[1] = t_block(1, ?b1i[0], 2);
+    blocks[2] = t_block(2, ?b2i[0], 1);
+    var f: mir.MirFunction = t_fn(true, ?blocks[0], 3, ?vregs[0], 4);
+    val r: R.Result[bool, str] = validate_function(?t, ?f, nil, ?alloc);
+    if (!R.is_err[bool, str](r)) { ret 1; }
+    ret 0;
+}
+
+# a `:^` declassify is a HARD BARRIER: the result is public even though its source is
+# secret, so a value read through the barrier feeds a branch, an address, and a multiply
+# without a violation. propagation stops at MIR_DECLASSIFY.
+test "mach.lang.be.codegen.ctvalidate.barrier:declassify_stops_taint" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+    var t: target.Target = t_target(false, true);
+
+    var vregs: [4]mir.MirVReg;
+    vregs[0] = t_vreg(0, true);    # secret source
+    vregs[1] = t_vreg(1, false);   # declassified (public) result
+    vregs[2] = t_vreg(2, false);   # a derived value from the public result
+    vregs[3] = t_vreg(3, false);   # public multiplicand
+
+    # v1 <- declassify v0 ; v2 <- mul v1, v3 ; cbr v1, B0, B0 ; store [v1] <- v3
+    var dcl: [2]mir.MirOperand; dcl[0] = mir.op_vreg(1); dcl[1] = mir.op_vreg(0);
+    var mul: [3]mir.MirOperand; mul[0] = mir.op_vreg(2); mul[1] = mir.op_vreg(1); mul[2] = mir.op_vreg(3);
+    var cbr: [3]mir.MirOperand; cbr[0] = mir.op_vreg(1); cbr[1] = mir.op_block(0); cbr[2] = mir.op_block(0);
+    var st:  [2]mir.MirOperand; st[0]  = mir.op_mem_value(1, 0); st[1] = mir.op_vreg(3);
+    var b0i: [4]mir.MirInstr;
+    b0i[0] = t_instr(mir.MIR_DECLASSIFY, ?dcl[0], 2);
+    b0i[1] = t_instr(mir.MIR_MUL,        ?mul[0], 3);
+    b0i[2] = t_instr(mir.MIR_CBR,        ?cbr[0], 3);
+    b0i[3] = t_instr(mir.MIR_STORE,      ?st[0], 2);
+
+    var blocks: [1]mir.MirBlock;
+    blocks[0] = t_block(0, ?b0i[0], 4);
+    var f: mir.MirFunction = t_fn(true, ?blocks[0], 1, ?vregs[0], 4);
+    val r: R.Result[bool, str] = validate_function(?t, ?f, nil, ?alloc);
+    if (!R.is_ok[bool, str](r)) { ret 1; }
+    ret 0;
+}
+
+# a secret operand of an integer multiply is a violation on a target that does not trust a
+# data-independent multiply, and permitted on one that does - the capability gate.
+test "mach.lang.be.codegen.ctvalidate.varlat:secret_multiply_capability" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+
+    var vregs: [3]mir.MirVReg;
+    vregs[0] = t_vreg(0, true);    # secret
+    vregs[1] = t_vreg(1, false);   # public
+    vregs[2] = t_vreg(2, false);   # product
+
+    # v2 <- mul v0, v1
+    var mul: [3]mir.MirOperand; mul[0] = mir.op_vreg(2); mul[1] = mir.op_vreg(0); mul[2] = mir.op_vreg(1);
+    var b0i: [1]mir.MirInstr;
+    b0i[0] = t_instr(mir.MIR_MUL, ?mul[0], 3);
+    var blocks: [1]mir.MirBlock;
+    blocks[0] = t_block(0, ?b0i[0], 1);
+    var f: mir.MirFunction = t_fn(true, ?blocks[0], 1, ?vregs[0], 3);
+
+    # no trusted multiply: a violation.
+    var t_no: target.Target = t_target(false, true);
+    if (!R.is_err[bool, str](validate_function(?t_no, ?f, nil, ?alloc))) { ret 1; }
+    # trusted multiply: permitted.
+    var t_yes: target.Target = t_target(true, true);
+    if (!R.is_ok[bool, str](validate_function(?t_yes, ?f, nil, ?alloc))) { ret 1; }
+    ret 0;
+}
+
+# a shift by a secret COUNT leaks on a target without a barrel shifter and is permitted on
+# one with it; a secret VALUE shifted by a PUBLIC count is always constant-time. the leakage
+# model observes the count operand alone.
+test "mach.lang.be.codegen.ctvalidate.varlat:secret_shift_count_only" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+
+    var vregs: [3]mir.MirVReg;
+    vregs[0] = t_vreg(0, true);    # secret
+    vregs[1] = t_vreg(1, false);   # public
+    vregs[2] = t_vreg(2, false);   # result
+
+    # v2 <- shl v1(public value), v0(secret count)
+    var shl: [3]mir.MirOperand; shl[0] = mir.op_vreg(2); shl[1] = mir.op_vreg(1); shl[2] = mir.op_vreg(0);
+    var b0i: [1]mir.MirInstr; b0i[0] = t_instr(mir.MIR_SHL, ?shl[0], 3);
+    var blocks: [1]mir.MirBlock; blocks[0] = t_block(0, ?b0i[0], 1);
+    var f: mir.MirFunction = t_fn(true, ?blocks[0], 1, ?vregs[0], 3);
+
+    # no barrel shifter: a secret count is a violation.
+    var t_no: target.Target = t_target(false, false);
+    if (!R.is_err[bool, str](validate_function(?t_no, ?f, nil, ?alloc))) { ret 1; }
+    # barrel shifter: a variable secret count is constant-time.
+    var t_yes: target.Target = t_target(false, true);
+    if (!R.is_ok[bool, str](validate_function(?t_yes, ?f, nil, ?alloc))) { ret 1; }
+
+    # a secret VALUE shifted by a PUBLIC (immediate) count is constant-time on any target.
+    var shl2: [3]mir.MirOperand; shl2[0] = mir.op_vreg(2); shl2[1] = mir.op_vreg(0); shl2[2] = mir.op_imm(3);
+    var b0i2: [1]mir.MirInstr; b0i2[0] = t_instr(mir.MIR_SHL, ?shl2[0], 3);
+    var blocks2: [1]mir.MirBlock; blocks2[0] = t_block(0, ?b0i2[0], 1);
+    var f2: mir.MirFunction = t_fn(true, ?blocks2[0], 1, ?vregs[0], 3);
+    if (!R.is_ok[bool, str](validate_function(?t_no, ?f2, nil, ?alloc))) { ret 1; }
+    ret 0;
+}
+
+# an integer divide always leaks a secret operand (no target makes it constant-time), and a
+# secret dividend PRE-COLORED into a physical accumulator (the x86-64 RAX division form) is
+# still observed - the block-local physical-register taint follows the value across the
+# register boundary.
+test "mach.lang.be.codegen.ctvalidate.varlat:secret_divide_and_precolor" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+    var t: target.Target = t_target(true, true);   # trusts everything the flags govern
+
+    # three-address divide [dst, dividend(secret), divisor]: always a violation.
+    var vregs: [3]mir.MirVReg;
+    vregs[0] = t_vreg(0, true);
+    vregs[1] = t_vreg(1, false);
+    vregs[2] = t_vreg(2, false);
+    var dv: [3]mir.MirOperand; dv[0] = mir.op_vreg(2); dv[1] = mir.op_vreg(0); dv[2] = mir.op_vreg(1);
+    var b0i: [1]mir.MirInstr; b0i[0] = t_instr(mir.MIR_DIV_S, ?dv[0], 3);
+    var blocks: [1]mir.MirBlock; blocks[0] = t_block(0, ?b0i[0], 1);
+    var f: mir.MirFunction = t_fn(true, ?blocks[0], 1, ?vregs[0], 3);
+    if (!R.is_err[bool, str](validate_function(?t, ?f, nil, ?alloc))) { ret 1; }
+
+    # x86-64 precolor form: mov RAX <- v0(secret) ; div [RAX, v1(divisor)].
+    var mov: [2]mir.MirOperand; mov[0] = mir.op_preg(0); mov[1] = mir.op_vreg(0);
+    var dv2: [2]mir.MirOperand; dv2[0] = mir.op_preg(0); dv2[1] = mir.op_vreg(1);
+    var p0i: [2]mir.MirInstr;
+    p0i[0] = t_instr(mir.MIR_MOV,   ?mov[0], 2);
+    p0i[1] = t_instr(mir.MIR_DIV_S, ?dv2[0], 2);
+    var pblocks: [1]mir.MirBlock; pblocks[0] = t_block(0, ?p0i[0], 2);
+    var pf: mir.MirFunction = t_fn(true, ?pblocks[0], 1, ?vregs[0], 3);
+    if (!R.is_err[bool, str](validate_function(?t, ?pf, nil, ?alloc))) { ret 1; }
+    ret 0;
+}
+
+# a valid oblivious function raises no false positive: a secret copied, stored to memory at
+# a PUBLIC address, and shifted by a PUBLIC constant is entirely constant-time. storing a
+# secret VALUE is fine; only a secret ADDRESS or a variable-latency secret operand leaks.
+test "mach.lang.be.codegen.ctvalidate.clean:valid_oblivious_no_false_positive" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+    var t: target.Target = t_target(false, true);
+
+    var vregs: [4]mir.MirVReg;
+    vregs[0] = t_vreg(0, true);    # secret param
+    vregs[1] = t_vreg(1, false);   # public destination pointer
+    vregs[2] = t_vreg(2, false);   # copy of the secret
+    vregs[3] = t_vreg(3, false);   # shifted secret
+
+    # v2 <- v0 ; store [v1(public addr)] <- v2(secret value) ; v3 <- shl v2, imm 5 ; ret
+    var mov: [2]mir.MirOperand; mov[0] = mir.op_vreg(2); mov[1] = mir.op_vreg(0);
+    var st:  [2]mir.MirOperand; st[0]  = mir.op_mem_value(1, 0); st[1] = mir.op_vreg(2);
+    var shl: [3]mir.MirOperand; shl[0] = mir.op_vreg(3); shl[1] = mir.op_vreg(2); shl[2] = mir.op_imm(5);
+    var b0i: [4]mir.MirInstr;
+    b0i[0] = t_instr(mir.MIR_MOV,   ?mov[0], 2);
+    b0i[1] = t_instr(mir.MIR_STORE, ?st[0], 2);
+    b0i[2] = t_instr(mir.MIR_SHL,   ?shl[0], 3);
+    b0i[3] = t_instr(mir.MIR_RET,   nil, 0);
+    var blocks: [1]mir.MirBlock; blocks[0] = t_block(0, ?b0i[0], 4);
+    var f: mir.MirFunction = t_fn(true, ?blocks[0], 1, ?vregs[0], 4);
+    if (!R.is_ok[bool, str](validate_function(?t, ?f, nil, ?alloc))) { ret 1; }
+    ret 0;
+}
+
+# the pass is scoped to #[oblivious]: an identical secret-feeds-branch body is a violation
+# in an oblivious function and completely unaffected (skipped) in a non-oblivious one. driven
+# through `run` so the module-level scope gate is exercised.
+test "mach.lang.be.codegen.ctvalidate.scope:non_oblivious_unaffected" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+    var t: target.Target = t_target(false, true);
+
+    var vregs: [1]mir.MirVReg;
+    vregs[0] = t_vreg(0, true);   # secret
+
+    # cbr v0, B0, B0  (a secret condition)
+    var cbr: [3]mir.MirOperand; cbr[0] = mir.op_vreg(0); cbr[1] = mir.op_block(0); cbr[2] = mir.op_block(0);
+    var b0i: [1]mir.MirInstr; b0i[0] = t_instr(mir.MIR_CBR, ?cbr[0], 3);
+    var blocks: [1]mir.MirBlock; blocks[0] = t_block(0, ?b0i[0], 1);
+
+    # non-oblivious: run skips it, no error.
+    var funcs_off: [1]mir.MirFunction; funcs_off[0] = t_fn(false, ?blocks[0], 1, ?vregs[0], 1);
+    var mm_off: mir.MirModule; mm_off.alloc = ?alloc; mm_off.interner = nil; mm_off.functions = ?funcs_off[0]; mm_off.function_len = 1;
+    if (!R.is_ok[bool, str](run(?t, ?mm_off))) { ret 1; }
+
+    # oblivious: the same body is a violation.
+    var funcs_on: [1]mir.MirFunction; funcs_on[0] = t_fn(true, ?blocks[0], 1, ?vregs[0], 1);
+    var mm_on: mir.MirModule; mm_on.alloc = ?alloc; mm_on.interner = nil; mm_on.functions = ?funcs_on[0]; mm_on.function_len = 1;
+    if (!R.is_err[bool, str](run(?t, ?mm_on))) { ret 1; }
+    ret 0;
+}
+
+# the validator's MIR-opcode -> constant-time-op classifier: multiply / divide / shift /
+# float map to their leakage class, and an ordinary opcode to CT_OP_NONE. the exhaustive
+# backstop names div / mod and float, which the compile-time gate leaves to sema.
+test "mach.lang.be.codegen.ctvalidate.classify:mir_ct_op_table" {
+    if (mir_ct_op(mir.MIR_MUL)      != ct.CT_OP_INT_MUL)    { ret 1; }
+    if (mir_ct_op(mir.MIR_DIV_S)    != ct.CT_OP_INT_DIVMOD) { ret 1; }
+    if (mir_ct_op(mir.MIR_REM_U)    != ct.CT_OP_INT_DIVMOD) { ret 1; }
+    if (mir_ct_op(mir.MIR_SHL)      != ct.CT_OP_VAR_SHIFT)  { ret 1; }
+    if (mir_ct_op(mir.MIR_SHR_S)    != ct.CT_OP_VAR_SHIFT)  { ret 1; }
+    if (mir_ct_op(mir.MIR_FADD)     != ct.CT_OP_FLOAT)      { ret 1; }
+    if (mir_ct_op(mir.MIR_FCMP)     != ct.CT_OP_FLOAT)      { ret 1; }
+    if (mir_ct_op(mir.MIR_FP_TO_SI) != ct.CT_OP_FLOAT)      { ret 1; }
+    if (mir_ct_op(mir.MIR_ADD)      != ct.CT_OP_NONE)       { ret 1; }
+    if (mir_ct_op(mir.MIR_LOAD)     != ct.CT_OP_NONE)       { ret 1; }
+    ret 0;
 }

--- a/src/lang/be/codegen/ctvalidate.mach
+++ b/src/lang/be/codegen/ctvalidate.mach
@@ -246,7 +246,7 @@ fun operand_secret(op: *mir.MirOperand, vt: *bool, nv: u32, pt: *bool, np: u32) 
     if (op.kind == mir.MIR_OP_PREG) { ret pt != nil && op.preg < np && pt[op.preg]; }
     if (op.kind == mir.MIR_OP_MEM) {
         if (op.vreg != mir.MIR_VREG_NIL && op.vreg < nv && vt[op.vreg])   { ret true; }
-        if (op.index != mir.MIR_VREG_NIL && op.index < nv && vt[op.index]) { ret true; }
+        if (!op.index_is_preg && op.index != mir.MIR_VREG_NIL && op.index < nv && vt[op.index]) { ret true; }
         ret false;
     }
     ret false;
@@ -328,7 +328,7 @@ fun check_instr(tgt: *target.Target, f: *mir.MirFunction, mi: *mir.MirInstr, vt:
                 ret R.err[bool, str](leak_msg(alloc, interner, f.name,
                     "uses a secret value as a memory address; a secret-dependent load or store address leaks the secret through the memory-access pattern. index at a public offset, or `:^`-declassify the pointer when disclosure is intended"));
             }
-            if (op.index != mir.MIR_VREG_NIL && op.index < nv && vt[op.index]) {
+            if (!op.index_is_preg && op.index != mir.MIR_VREG_NIL && op.index < nv && vt[op.index]) {
                 ret R.err[bool, str](leak_msg(alloc, interner, f.name,
                     "uses a secret value as a memory index; a secret-dependent load or store address leaks the secret through the memory-access pattern. index at a public offset, or `:^`-declassify the index when disclosure is intended"));
             }

--- a/src/lang/be/codegen/ctvalidate.mach
+++ b/src/lang/be/codegen/ctvalidate.mach
@@ -1,0 +1,414 @@
+# constant-time translation validator: the relational leakage check over lowered MIR (#1648)
+#
+# The enforcement CONSUMER of the #1646 secret-taint foundation. #1646 stamps only the
+# secret SOURCES on the lowered, target-independent MIR - a secret parameter / welded
+# load / secret call's result vreg (`MirVReg.secret`), a store or memzero into secret
+# storage (`MirInstr.writes_secret`), and a `:^` declassify lowered to a distinguishable
+# `MIR_DECLASSIFY` barrier - and deliberately does NOT thread a per-value taint through
+# the transforms (that model was fragile and non-deterministic). This pass RE-DERIVES the
+# per-instruction taint from those stable seeds as a monotone dataflow FIXPOINT and then
+# checks, in every `#[oblivious]` function, that no secret-tainted value reaches a leaking
+# position. Because the seeds sit on sources and the taint is re-derived here, no earlier
+# transform - phi elimination, inlining, loop rotation, width legalization - can launder a
+# secret past the check: the merge / clone / copy it produces is just another operand the
+# fixpoint propagates through.
+#
+# THE RE-DERIVE. `taint[v]` seeds from `MirVReg.secret` and grows by one rule:
+#   any-secret-operand -> secret-result,
+# with `MIR_DECLASSIFY` a HARD BARRIER - its result is public regardless of its secret
+# source, so propagation stops there (isel later retags the barrier to a plain move, so it
+# costs nothing at runtime; the distinction exists only for this analysis). Out-of-SSA MIR
+# lets one vreg be defined by several instructions (a phi becomes predecessor-end moves,
+# a loop-carried value is re-defined across a back edge), so the taint is a whole-function
+# fixpoint over a monotone boolean lattice, not a single forward sweep: a use that
+# textually precedes its secret definition (a loop header testing a value the body makes
+# secret) is still caught. Physical registers a value is PRE-COLORED into at lowering (an
+# x86-64 division dividend in RAX, a variable shift count in RCX) carry a block-local taint
+# recomputed within the same forward walk, so a secret reaching a fixed-register operand is
+# not lost at the register boundary.
+#
+# THE CHECK. In a function carrying `#[oblivious]` (`MirFunction.oblivious`), a secret-
+# tainted value must not reach:
+#   (a) a conditional-branch CONDITION (`MIR_CBR` operand 0) - the taken path, hence the
+#       timing, would depend on the secret;
+#   (b) a memory ADDRESS - the base or scaled-index vreg of any memory operand (a load
+#       source, a store destination, a GEP), whose access pattern leaks through the cache;
+#       the STORED VALUE being secret is fine, only the address is observed;
+#   (c) an operand of a variable-latency op the shared `mach.lang.ct` table plus the
+#       target's capabilities forbid - an integer multiply on a target with no trusted
+#       data-independent multiply, a variable shift COUNT on a target with no barrel
+#       shifter, and (always, target-independent) an integer divide / remainder or a
+#       floating-point op. The same `ct` table drives the compile-time gates in
+#       `mir.lower`; this pass is the independent RELATIONAL backstop that re-derives taint
+#       and re-checks, catching whatever a future pass might slip past those gates.
+# A violation is a precise compile error naming the function and the leaking op. The pass
+# is CONSERVATIVE by construction (a missed taint would defeat the guarantee, so it errs
+# toward over-taint) and pure analysis: it never mutates the MIR, so a build with no
+# `#[oblivious]` function - and every function within one that handles no secret - is
+# byte-identical to a build without it.
+#
+# SCOPE (documented contract, #1646 -> #1648). The validated layer is the LOWERED,
+# pre-selection MIR: this pass runs after loop rotation and legalization and before
+# instruction selection, so it validates exactly what isel consumes and trusts
+# isel / regalloc / encode to be timing-preserving. True translation-validation of the
+# EMITTED machine code (the epic's eventual goal) needs the seeds and barrier to survive
+# to post-regalloc MIR - additive per-ISA work left as future strengthening; the lowered-
+# MIR contract does not foreclose it.
+
+use std.types.bool.bool;
+use std.types.bool.true;
+use std.types.bool.false;
+use std.types.size.usize;
+use std.types.string.str;
+use std.types.string.str_len;
+use std.format;
+
+use A: std.allocator;
+use O: std.types.option;
+use R: std.types.result;
+
+use mach.lang.be.codegen.mir;
+use mach.lang.ct;
+use mach.lang.intern;
+use target: mach.lang.target.resolved;
+
+# validate every `#[oblivious]` function of a MIR module for constant-time leakage
+#
+# The shared entry point the codegen driver calls between legalization and instruction
+# selection. Re-derives the secret taint from the #1646 seeds and rejects a secret value
+# reaching a branch condition, a memory address, or a forbidden variable-latency op inside
+# any function marked `#[oblivious]`. A function without the marker is skipped; the pass
+# never mutates the MIR, so a module with no oblivious function is validated in a single
+# read and emitted byte-identically.
+# ---
+# tgt: resolved compilation target (supplies the constant-time capability flags)
+# m:   the MIR module to validate in place (read-only)
+# ret: ok(true) when every oblivious function is leak-free, or the first violation's error
+pub fun run(tgt: *target.Target, m: *mir.MirModule) R.Result[bool, str] {
+    if (tgt == nil) { ret R.err[bool, str]("ctvalidate: nil target"); }
+    if (m == nil)   { ret R.err[bool, str]("ctvalidate: nil mir module"); }
+
+    var i: u32 = 0;
+    for (i < m.function_len) {
+        val f: *mir.MirFunction = ?m.functions[i];
+        if (f.oblivious) {
+            val res: R.Result[bool, str] = validate_function(tgt, f, m.interner, m.alloc);
+            if (R.is_err[bool, str](res)) { ret res; }
+        }
+        i = i + 1;
+    }
+    ret R.ok[bool, str](true);
+}
+
+# re-derive the secret taint of one function and check it for leakage
+#
+# Seeds `taint` from `MirVReg.secret`, iterates the propagation to a fixpoint, then walks
+# every block once running the three leakage checks. The scratch taint arrays are owned
+# here and freed before return.
+# ---
+# tgt:      resolved target (constant-time capability flags)
+# f:        the function to validate
+# interner: session interner for resolving the function name in a diagnostic (may be nil)
+# alloc:    backing allocator for the scratch taint arrays and diagnostic text
+# ret:      ok(true) when leak-free, or the first violation's error
+fun validate_function(tgt: *target.Target, f: *mir.MirFunction, interner: *intern.Interner, alloc: *A.Allocator) R.Result[bool, str] {
+    val nv: u32 = f.vreg_count;
+    if (nv == 0 || f.block_count == 0) { ret R.ok[bool, str](true); }
+
+    val rv: R.Result[*bool, str] = A.allocate[bool](alloc, nv::usize);
+    if (R.is_err[*bool, str](rv)) { ret R.err[bool, str](R.unwrap_err[*bool, str](rv)); }
+    val vt: *bool = R.unwrap_ok[*bool, str](rv);
+
+    # the taint SEED: a vreg defined by a secret source starts secret (#1646). derived
+    # secrecy is re-derived below, never seeded.
+    var i: u32 = 0;
+    for (i < nv) { vt[i] = f.vregs[i].secret; i = i + 1; }
+
+    # block-local taint for the physical registers a value is pre-colored into at lowering.
+    # sized to the largest physical-register id the function names, or skipped when it
+    # pre-colors nothing.
+    val mp: u32 = max_preg(f);
+    var np: u32 = 0;
+    var pt: *bool = nil;
+    if (mp != NO_PREG) {
+        np = mp + 1;
+        val rp: R.Result[*bool, str] = A.allocate[bool](alloc, np::usize);
+        if (R.is_err[*bool, str](rp)) {
+            A.deallocate[bool](alloc, vt, nv::usize);
+            ret R.err[bool, str](R.unwrap_err[*bool, str](rp));
+        }
+        pt = R.unwrap_ok[*bool, str](rp);
+    }
+
+    # the fixpoint: propagate any-secret-operand -> secret-result over every block until no
+    # vreg's taint changes. monotone over a finite boolean lattice, so it terminates.
+    var changed: bool = true;
+    for (changed) {
+        changed = false;
+        var bi: u32 = 0;
+        for (bi < f.block_count) {
+            val blk: *mir.MirBlock = ?f.blocks[bi];
+            clear_pregs(pt, np);
+            var ii: u32 = 0;
+            for (ii < blk.instr_count) {
+                if (apply_instr(?blk.instrs[ii], vt, nv, pt, np)) { changed = true; }
+                ii = ii + 1;
+            }
+            bi = bi + 1;
+        }
+    }
+
+    # the checks: one final read-only walk. the physical-register taint is recomputed in the
+    # same forward order so a pre-colored operand is checked against the value moved into it.
+    var bj: u32 = 0;
+    for (bj < f.block_count) {
+        val blk: *mir.MirBlock = ?f.blocks[bj];
+        clear_pregs(pt, np);
+        var ij: u32 = 0;
+        for (ij < blk.instr_count) {
+            val mi: *mir.MirInstr = ?blk.instrs[ij];
+            val chk: R.Result[bool, str] = check_instr(tgt, f, mi, vt, nv, pt, np, interner, alloc);
+            if (R.is_err[bool, str](chk)) {
+                free_taint(alloc, vt, nv, pt, np);
+                ret chk;
+            }
+            # advance the block-local physical-register taint for the next instruction's reads.
+            if (apply_instr(mi, vt, nv, pt, np)) {}
+            ij = ij + 1;
+        }
+        bj = bj + 1;
+    }
+
+    free_taint(alloc, vt, nv, pt, np);
+    ret R.ok[bool, str](true);
+}
+
+# release the scratch taint arrays
+fun free_taint(alloc: *A.Allocator, vt: *bool, nv: u32, pt: *bool, np: u32) {
+    A.deallocate[bool](alloc, vt, nv::usize);
+    if (pt != nil && np > 0) { A.deallocate[bool](alloc, pt, np::usize); }
+}
+
+# sentinel "the function names no physical register"
+val NO_PREG: u32 = 0xFFFFFFFF;
+
+# the largest physical-register id any PREG operand of the function names, or NO_PREG when
+# it names none. sizes the block-local physical-register taint array
+fun max_preg(f: *mir.MirFunction) u32 {
+    var best: u32 = NO_PREG;
+    var bi: u32 = 0;
+    for (bi < f.block_count) {
+        val blk: *mir.MirBlock = ?f.blocks[bi];
+        var ii: u32 = 0;
+        for (ii < blk.instr_count) {
+            val mi: *mir.MirInstr = ?blk.instrs[ii];
+            var k: u32 = 0;
+            for (k < mi.operand_count) {
+                val op: *mir.MirOperand = ?mi.operands[k];
+                if (op.kind == mir.MIR_OP_PREG) {
+                    if (best == NO_PREG || op.preg > best) { best = op.preg; }
+                }
+                k = k + 1;
+            }
+            ii = ii + 1;
+        }
+        bi = bi + 1;
+    }
+    ret best;
+}
+
+# reset every physical-register taint bit to public (called at each block entry)
+fun clear_pregs(pt: *bool, np: u32) {
+    if (pt == nil) { ret; }
+    var i: u32 = 0;
+    for (i < np) { pt[i] = false; i = i + 1; }
+}
+
+# whether an operand reads a secret value: a tainted vreg, a tainted pre-colored physical
+# register, or a memory operand whose base or scaled-index vreg is tainted (a secret-
+# dependent address). immediates, symbols, and block targets are never secret
+fun operand_secret(op: *mir.MirOperand, vt: *bool, nv: u32, pt: *bool, np: u32) bool {
+    if (op.kind == mir.MIR_OP_VREG) { ret op.vreg < nv && vt[op.vreg]; }
+    if (op.kind == mir.MIR_OP_PREG) { ret pt != nil && op.preg < np && pt[op.preg]; }
+    if (op.kind == mir.MIR_OP_MEM) {
+        if (op.vreg != mir.MIR_VREG_NIL && op.vreg < nv && vt[op.vreg])   { ret true; }
+        if (op.index != mir.MIR_VREG_NIL && op.index < nv && vt[op.index]) { ret true; }
+        ret false;
+    }
+    ret false;
+}
+
+# propagate taint across one instruction: mark its destination secret when any operand is
+# secret, updating the vreg taint (monotone, for the fixpoint) and the block-local physical
+# register taint (overwritten, since a physical register is redefined each write). returns
+# whether a vreg's taint bit newly flipped. `MIR_DECLASSIFY` is the barrier: its result is
+# public regardless of its source, so it propagates nothing. `MIR_CALL` clobbers every
+# caller-saved physical register, so it clears the block-local physical-register taint
+fun apply_instr(mi: *mir.MirInstr, vt: *bool, nv: u32, pt: *bool, np: u32) bool {
+    if (mi.opcode == mir.MIR_CALL)       { clear_pregs(pt, np); ret false; }
+    if (mi.opcode == mir.MIR_DECLASSIFY) { ret false; }
+    if (mi.operand_count == 0)           { ret false; }
+
+    var s: bool = false;
+    var k: u32 = 0;
+    for (k < mi.operand_count) {
+        if (operand_secret(?mi.operands[k], vt, nv, pt, np)) { s = true; }
+        k = k + 1;
+    }
+
+    if (!mir.instr_defines_shape(mi)) { ret false; }
+    val d: *mir.MirOperand = ?mi.operands[0];
+    if (d.kind == mir.MIR_OP_VREG && d.vreg < nv) {
+        if (s && !vt[d.vreg]) { vt[d.vreg] = true; ret true; }
+        ret false;
+    }
+    if (d.kind == mir.MIR_OP_PREG && pt != nil && d.preg < np) { pt[d.preg] = s; }
+    ret false;
+}
+
+# run the three leakage checks on one instruction of an oblivious function
+# ---
+# tgt:      resolved target (constant-time capability flags)
+# f:        the owning function (for its name and vreg count)
+# mi:       the instruction to check
+# vt/nv:    the vreg taint array and its length
+# pt/np:    the block-local physical-register taint array and its length
+# interner: session interner for the diagnostic (may be nil)
+# alloc:    allocator for the diagnostic text
+# ret:      ok(true) when the instruction leaks nothing, or the violation's error
+fun check_instr(tgt: *target.Target, f: *mir.MirFunction, mi: *mir.MirInstr, vt: *bool, nv: u32, pt: *bool, np: u32, interner: *intern.Interner, alloc: *A.Allocator) R.Result[bool, str] {
+    # (a) a conditional branch whose condition is secret leaks through the taken path.
+    if (mi.opcode == mir.MIR_CBR) {
+        if (mi.operand_count >= 1 && operand_secret(?mi.operands[0], vt, nv, pt, np)) {
+            ret R.err[bool, str](leak_msg(alloc, interner, f.name,
+                "uses a secret value as a conditional-branch condition; the branch decides the taken path, so its timing reveals the secret. select branch-free (a masked select) over public data, or `:^`-declassify the value when disclosure is intended"));
+        }
+    }
+    # a fused compare-and-branch (produced by selection, not present at this layer) reads its
+    # two compared values in operands 0 and 1; checked defensively so a future placement stays sound.
+    if (mir.is_fused_cbr(mi.opcode)) {
+        if (mi.operand_count >= 1 && operand_secret(?mi.operands[0], vt, nv, pt, np)) {
+            ret R.err[bool, str](leak_msg(alloc, interner, f.name,
+                "compares a secret value in a conditional branch; the branch's taken path reveals the secret. select branch-free over public data, or `:^`-declassify when disclosure is intended"));
+        }
+        if (mi.operand_count >= 2 && operand_secret(?mi.operands[1], vt, nv, pt, np)) {
+            ret R.err[bool, str](leak_msg(alloc, interner, f.name,
+                "compares a secret value in a conditional branch; the branch's taken path reveals the secret. select branch-free over public data, or `:^`-declassify when disclosure is intended"));
+        }
+    }
+    # (b) a memory operand whose address (base or scaled index) is secret leaks the access.
+    var k: u32 = 0;
+    for (k < mi.operand_count) {
+        val op: *mir.MirOperand = ?mi.operands[k];
+        if (op.kind == mir.MIR_OP_MEM) {
+            if (op.vreg != mir.MIR_VREG_NIL && op.vreg < nv && vt[op.vreg]) {
+                ret R.err[bool, str](leak_msg(alloc, interner, f.name,
+                    "uses a secret value as a memory address; a secret-dependent load or store address leaks the secret through the memory-access pattern. index at a public offset, or `:^`-declassify the pointer when disclosure is intended"));
+            }
+            if (op.index != mir.MIR_VREG_NIL && op.index < nv && vt[op.index]) {
+                ret R.err[bool, str](leak_msg(alloc, interner, f.name,
+                    "uses a secret value as a memory index; a secret-dependent load or store address leaks the secret through the memory-access pattern. index at a public offset, or `:^`-declassify the index when disclosure is intended"));
+            }
+        }
+        k = k + 1;
+    }
+    # (c) a variable-latency op the target cannot do in constant time on a secret operand.
+    val cop: ct.CtOp = mir_ct_op(mi.opcode);
+    if (cop != ct.CT_OP_NONE) {
+        val cap: ct.CtCap = ct.ct_cap(cop);
+        if (!ct.target_provides(tgt.model.ct_trust_mul, tgt.model.ct_trust_var_shift, cap)) {
+            if (ct_secret_operand(mi, cop, vt, nv, pt, np)) {
+                ret R.err[bool, str](leak_msg(alloc, interner, f.name, ct_op_detail(cop)));
+            }
+        }
+    }
+    ret R.ok[bool, str](true);
+}
+
+# the constant-time op class of a generic MIR opcode, for the shared `mach.lang.ct` table
+#
+# The validator's classifier: unlike the compile-time gate (which leaves div / mod
+# unclassified because sema enforces them target-independently), this is the exhaustive
+# backstop, so it names integer divide / remainder and every floating-point op too. A
+# constant-count shift reaches here as `MIR_SHL/SHR` but its count operand is an immediate,
+# so the count-only observation finds nothing secret - only a variable secret count trips.
+# ---
+# op:  a generic (pre-selection) MIR opcode
+# ret: the CtOp class, or CT_OP_NONE for a constant-time opcode
+fun mir_ct_op(op: mir.MirOpcode) ct.CtOp {
+    if (op == mir.MIR_MUL)                                             { ret ct.CT_OP_INT_MUL; }
+    if (op == mir.MIR_DIV_S || op == mir.MIR_DIV_U ||
+        op == mir.MIR_REM_S || op == mir.MIR_REM_U)                   { ret ct.CT_OP_INT_DIVMOD; }
+    if (op == mir.MIR_SHL || op == mir.MIR_SHR_S || op == mir.MIR_SHR_U) { ret ct.CT_OP_VAR_SHIFT; }
+    if (op == mir.MIR_FP_TRUNC || op == mir.MIR_FP_EXT ||
+        op == mir.MIR_FP_TO_SI || op == mir.MIR_FP_TO_UI ||
+        op == mir.MIR_SI_TO_FP || op == mir.MIR_UI_TO_FP)             { ret ct.CT_OP_FLOAT; }
+    if (op == mir.MIR_FADD || op == mir.MIR_FSUB || op == mir.MIR_FMUL ||
+        op == mir.MIR_FDIV || op == mir.MIR_FCMP || op == mir.MIR_FNEG) { ret ct.CT_OP_FLOAT; }
+    ret ct.CT_OP_NONE;
+}
+
+# whether the leakage-observed operand of a variable-latency op is secret
+#
+# A shift leaks through its variable COUNT alone (a secret value shifted by a public count
+# is constant-time), so a count-only class observes just the count - the LAST operand of
+# the three-address `[dst, value, count]` shift. Every other class observes each INPUT
+# operand: the pure-def destination (operand 0 when a value vreg) is skipped, so a result
+# is judged by its inputs, while a read-modified physical accumulator (an x86-64 division
+# dividend in RAX at operand 0) is observed
+fun ct_secret_operand(mi: *mir.MirInstr, cop: ct.CtOp, vt: *bool, nv: u32, pt: *bool, np: u32) bool {
+    if (ct.ct_op_gates_count_only(cop)) {
+        if (mi.operand_count < 2) { ret false; }
+        ret operand_secret(?mi.operands[mi.operand_count - 1], vt, nv, pt, np);
+    }
+    val skip_def: bool = mir.instr_defines_shape(mi)
+        && mi.operand_count > 0 && mi.operands[0].kind == mir.MIR_OP_VREG;
+    var k: u32 = 0;
+    for (k < mi.operand_count) {
+        if (!(k == 0 && skip_def)) {
+            if (operand_secret(?mi.operands[k], vt, nv, pt, np)) { ret true; }
+        }
+        k = k + 1;
+    }
+    ret false;
+}
+
+# the teaching detail for a secret operand of a forbidden variable-latency op, mirroring
+# the compile-time gate's diagnostics
+fun ct_op_detail(cop: ct.CtOp) str {
+    if (cop == ct.CT_OP_VAR_SHIFT) {
+        ret "uses a secret value as a variable shift count on a target without a barrel shifter; the shift's cycle count leaks the secret amount. shift by a public count, or run on a target whose variable shift is constant-time";
+    }
+    if (cop == ct.CT_OP_FLOAT) {
+        ret "uses a secret value in a variable-latency floating-point operation; the FP unit's timing can depend on the secret operand. compute on public data, or `:^`-declassify when disclosure is intended";
+    }
+    if (cop == ct.CT_OP_INT_DIVMOD) {
+        ret "uses a secret value in an integer divide or remainder; the division unit's latency is data-dependent, so it leaks the secret operand. compute branch-free over public data";
+    }
+    ret "uses a secret value in a variable-latency integer multiply; this target documents no data-independent multiply timing, so the product's latency can leak the secret operand. compute branch-free over public data, or run on a target whose DIT/DOITM mode is trusted";
+}
+
+# build "codegen: #[oblivious] function `<name>` <detail>", interned to a stable string
+#
+# Degrades to the bare `detail` (which already names the leak precisely) when the interner
+# is absent or an allocation fails, so a diagnostic is always produced
+fun leak_msg(alloc: *A.Allocator, interner: *intern.Interner, name_id: intern.StrId, detail: str) str {
+    if (interner == nil) { ret detail; }
+    val name: str = fn_name(interner, name_id);
+    val res: R.Result[str, str] = format.sprint(alloc, "codegen: #[oblivious] function `{}` {}", name, detail);
+    if (R.is_err[str, str](res)) { ret detail; }
+    val buf: str = R.unwrap_ok[str, str](res);
+    val ir: R.Result[intern.StrId, str] = intern.intern(interner, buf);
+    A.deallocate[u8](alloc, buf, str_len(buf) + 1);
+    if (R.is_err[intern.StrId, str](ir)) { ret detail; }
+    val lo: O.Option[str] = intern.lookup(interner, R.unwrap_ok[intern.StrId, str](ir));
+    if (O.is_some[str](lo)) { ret O.unwrap[str](lo); }
+    ret detail;
+}
+
+# the function's source name, or "<unknown>" when unresolved
+fun fn_name(interner: *intern.Interner, id: intern.StrId) str {
+    val o: O.Option[str] = intern.lookup(interner, id);
+    if (O.is_some[str](o)) { ret O.unwrap[str](o); }
+    ret "<unknown>";
+}

--- a/src/lang/be/codegen/ctvalidate.mach
+++ b/src/lang/be/codegen/ctvalidate.mach
@@ -36,8 +36,9 @@
 #
 # THE CHECK. In a function carrying `#[oblivious]` (`MirFunction.oblivious`), a secret-
 # tainted value must not reach:
-#   (a) a conditional-branch CONDITION (`MIR_CBR` operand 0) - the taken path, hence the
-#       timing, would depend on the secret;
+#   (a) a secret-dependent control transfer - a conditional-branch CONDITION (`MIR_CBR`
+#       operand 0) or an indirect-call TARGET (`MIR_CALL` through a secret function pointer) -
+#       whose taken path, hence timing, would depend on the secret;
 #   (b) a memory ADDRESS - the base or scaled-index vreg of any memory operand (a load
 #       source, a store destination, a GEP), whose access pattern leaks through the cache;
 #       the STORED VALUE being secret is fine, only the address is observed;
@@ -295,6 +296,15 @@ fun check_instr(tgt: *target.Target, f: *mir.MirFunction, mi: *mir.MirInstr, vt:
         if (mi.operand_count >= 1 && operand_secret(?mi.operands[0], vt, nv, pt, np)) {
             ret R.err[bool, str](leak_msg(alloc, interner, f.name,
                 "uses a secret value as a conditional-branch condition; the branch decides the taken path, so its timing reveals the secret. select branch-free (a masked select) over public data, or `:^`-declassify the value when disclosure is intended"));
+        }
+    }
+    # an indirect call through a secret function pointer is a secret-dependent control
+    # transfer, like a branch: MIR_CALL operand 0 is the callee (a symbol for a direct call, a
+    # vreg for an indirect one).
+    if (mi.opcode == mir.MIR_CALL) {
+        if (mi.operand_count >= 1 && operand_secret(?mi.operands[0], vt, nv, pt, np)) {
+            ret R.err[bool, str](leak_msg(alloc, interner, f.name,
+                "calls through a secret function pointer; the branch target, hence the taken path and its timing, depends on the secret. dispatch on public data, or `:^`-declassify the pointer when disclosure is intended"));
         }
     }
     # a fused compare-and-branch (produced by selection, not present at this layer) reads its
@@ -782,6 +792,34 @@ test "mach.lang.be.codegen.ctvalidate.scope:non_oblivious_unaffected" {
     var funcs_on: [1]mir.MirFunction; funcs_on[0] = t_fn(true, ?blocks[0], 1, ?vregs[0], 1);
     var mm_on: mir.MirModule; mm_on.alloc = ?alloc; mm_on.interner = nil; mm_on.functions = ?funcs_on[0]; mm_on.function_len = 1;
     if (!R.is_err[bool, str](run(?t, ?mm_on))) { ret 1; }
+    ret 0;
+}
+
+# an indirect call through a secret function pointer is a secret-dependent control transfer
+# and a violation; a direct call (a symbol callee) and an indirect call through a public
+# pointer are fine.
+test "mach.lang.be.codegen.ctvalidate.control:secret_indirect_call" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+    var t: target.Target = t_target(false, true);
+
+    var vregs: [2]mir.MirVReg;
+    vregs[0] = t_vreg(0, true);    # secret function pointer
+    vregs[1] = t_vreg(1, false);   # public function pointer
+
+    # call v0 (secret target): a violation.
+    var c_sec: [1]mir.MirOperand; c_sec[0] = mir.op_vreg(0);
+    var si: [1]mir.MirInstr; si[0] = t_instr(mir.MIR_CALL, ?c_sec[0], 1);
+    var sblocks: [1]mir.MirBlock; sblocks[0] = t_block(0, ?si[0], 1);
+    var sf: mir.MirFunction = t_fn(true, ?sblocks[0], 1, ?vregs[0], 2);
+    if (!R.is_err[bool, str](validate_function(?t, ?sf, nil, ?alloc))) { ret 1; }
+
+    # call v1 (public target): fine.
+    var c_pub: [1]mir.MirOperand; c_pub[0] = mir.op_vreg(1);
+    var pi: [1]mir.MirInstr; pi[0] = t_instr(mir.MIR_CALL, ?c_pub[0], 1);
+    var pblocks: [1]mir.MirBlock; pblocks[0] = t_block(0, ?pi[0], 1);
+    var pf: mir.MirFunction = t_fn(true, ?pblocks[0], 1, ?vregs[0], 2);
+    if (!R.is_ok[bool, str](validate_function(?t, ?pf, nil, ?alloc))) { ret 1; }
     ret 0;
 }
 

--- a/src/lang/be/codegen/mir.mach
+++ b/src/lang/be/codegen/mir.mach
@@ -744,6 +744,11 @@ pub rec MirFrame {
 #                 the prologue and restored in the epilogue. only conventions with
 #                 callee-saved vector registers (win64's XMM6-15) ever set bits
 #                 here; under SysV, where every XMM is caller-saved, it stays 0.
+# oblivious:      the `#[oblivious]` constant-time SEED for #1648 (mirrors the IR
+#                 function's FN_FLAG_OBLIVIOUS), stamped once at lowering so the MIR
+#                 is self-describing for the constant-time validator: the leakage
+#                 checks run only in a function marked here. pure metadata (like the
+#                 vreg / store secret seeds); a non-oblivious function is byte-identical.
 pub rec MirFunction {
     name:        intern.StrId;
 
@@ -758,6 +763,7 @@ pub rec MirFunction {
     frame:          MirFrame;
     callee_mask:    u32;
     callee_mask_fp: u32;
+    oblivious:      bool;
 }
 
 # the per-source-module unit produced by `lower_ir`

--- a/src/lang/be/codegen/mir/lower.mach
+++ b/src/lang/be/codegen/mir/lower.mach
@@ -172,6 +172,9 @@ fun lower_function(tgt: *target.Target, m: *ir.Module, fn: *ir.Function, alloc: 
     mf.frame.outgoing_size = 0;
     mf.callee_mask         = 0;
     mf.callee_mask_fp      = 0;
+    # the #[oblivious] seed for #1648: mark the MIR self-describing so the constant-time
+    # validator runs its leakage checks only in a function the source opted in.
+    mf.oblivious           = (fn.flags & ir.FN_FLAG_OBLIVIOUS) != 0;
 
     # extern / body-less functions lower to an empty mir.MirFunction shell.
     if ((fn.flags & ir.FN_FLAG_EXTERN) != 0 || fn.block_count == 0) {


### PR DESCRIPTION
Closes #1648.

The enforcement consumer of the #1646 secret-taint foundation (#2137): a constant-time **translation validator** that re-derives taint over the lowered MIR and rejects secret leakage in `#[oblivious]` functions.

## Scope (documented contract)

Issue #1648's original text aimed at emitted machine code. The #2137 foundation's documented contract narrows this increment to the **lowered, target-independent, pre-selection MIR**: re-derive taint from the seeds, validate the layer the compile-time gate already reads, and trust isel/regalloc/encode to be timing-preserving. True post-regalloc/emitted-code validation is explicitly additive future work. This PR implements the lowered-MIR layer per that contract.

## The re-derive

`#1646` stamps only the secret **sources** on the lowered MIR (`MirVReg.secret`, `MirInstr.writes_secret`, a distinguishable `MIR_DECLASSIFY` barrier) and deliberately does not thread a per-value taint through transforms. `ctvalidate` re-derives per-instruction taint as a **monotone dataflow fixpoint**:

- seed from `MirVReg.secret`;
- propagate `any-secret-operand -> secret-result`;
- `MIR_DECLASSIFY` is a **hard barrier** (result public, propagation stops);
- physical registers a value is pre-colored into at lowering (x86-64 division dividend in RAX, shift count in RCX) carry a **block-local** taint recomputed in the same forward walk, so a secret reaching a fixed-register operand is not lost at the register boundary.

Because the taint is a whole-function fixpoint (not a forward sweep), the laundering cases that broke the original hand-preserved design are handled by construction — a secret through a **phi join** (out-of-SSA predecessor moves into one result vreg), an **inlined return** (a multi-hop copy chain), or a **rotated loop's cloned vreg** (a back edge, where the use textually precedes the secret definition) all become ordinary operands the fixpoint propagates through.

`writes_secret` is deliberately **not** a leakage-check input: it guards a separate property (a zeroizing wipe surviving dead-store elimination). A later load of secret storage is already seeded on its own result vreg, so re-deriving memory-through-address taint adds nothing; the store's address is covered by check (b) like any memory operand.

## The relational check

In a function carrying `#[oblivious]` (`FN_FLAG_OBLIVIOUS`, threaded onto `MirFunction` so the MIR is self-describing), a secret-tainted value must not reach:

- **(a)** a conditional-branch condition (`MIR_CBR` operand 0);
- **(b)** a memory address (the base or scaled-index vreg of any memory operand — the stored *value* being secret is fine, only the address is observed);
- **(c)** a variable-latency op the shared `mach.lang.ct` table + target capabilities forbid — integer multiply (no trusted DIT/DOITM), variable shift count (no barrel shifter), and always integer divide/remainder and floating point.

The same `ct` table drives the compile-time gates in `mir.lower`; this pass is the independent **relational backstop** that re-derives taint and re-checks, catching whatever a future pass might slip past the gates. Conservative by construction (errs toward over-taint). A violation is a precise compile error naming the function and the leaking op.

## Placement

Runs in `codegen_module` **after loop rotation and before width legalization** — the target-independent lowered MIR, the same layer the compile-time gate reads. Before legalization is deliberate: legalization creates lane vregs with `secret = false` and does not carry a wide vreg's seed, so on a narrow-ALU target the taint would be dropped; the intact seeds live only here. Legalization is itself a constant-time-preserving width splitter (introduces no branch, computed address, or new variable-latency op; rejects wide divide/variable-shift/non-constant-multiply loudly), so trusting it alongside isel/regalloc/encode is sound. On the wide-native CI targets (x86_64, aarch64, riscv64) legalization is inert, so the validated MIR is identical either way.

## Verification

- **Byte-identical** output for secret-free code: `base(S) == mine(S)` for the whole compiler source S (secret-free), plus a self-host fixpoint (mine's output self-reproduces), proving the pass + the `oblivious` field are inert on non-`^`/`#[oblivious]` code.
- **-g additivity** preserved: the oblivious module's `.text` is byte-identical with and without `-g`.
- Full suite green (769/0) including 10 synthetic-MIR unit tests: phi-join re-derive, inlined-return chain, rotated-loop back-edge fixpoint, declassify-stops-taint, violations detected (branch/address/multiply/shift/divide incl. x86 precolored dividend), a valid oblivious function raising no false positive, and non-oblivious code unaffected.
- End-to-end (from-source compiler): int `surface/oblivious` + `surface/declassify` pass on linux and riscv64; mach-std 611/0 on its pinned commit.
