### PR TITLE
feat(sema): #[oblivious]-required check + per-instance CT re-validation (#2136, #2157)

### DIFF
--- a/int/surface/declassify/src/main.mach
+++ b/int/surface/declassify/src/main.mach
@@ -11,7 +11,10 @@ use std.runtime;
 use std.types.size.usize;
 use p: std.print;
 
-# add two secrets and declassify the result with the bare `:^` strip
+# add two secrets and declassify the result with the bare `:^` strip. it COMPUTES on
+# secrets (the `a + b`), so it carries `#[oblivious]` - required per instance (#2136) of
+# any function that arithmetically derives from a secret rather than only moving it.
+#[oblivious]
 fun secret_add(a: ^u32, b: ^u32) u32 {
     val s: ^u32 = a + b;
     ret s:^;
@@ -20,13 +23,17 @@ fun secret_add(a: ^u32, b: ^u32) u32 {
 # double a secret and declassify with the typed `:^u32` strip (names the
 # operand's own stripped public type). doubles with `a + a`, not `a * 2`: a secret
 # multiply is a variable-latency leak the #1646 constant-time gate rejects, while a
-# secret add is constant-time - the discipline this whole feature enforces.
+# secret add is constant-time - the discipline this whole feature enforces. it too
+# computes on a secret, so it is `#[oblivious]` (#2136).
+#[oblivious]
 fun secret_double(a: ^u32) u32 {
     val s: ^u32 = a + a;
     ret s:^u32;
 }
 
-# up-coerce a public into a secret, then strip it straight back
+# up-coerce a public into a secret, then strip it straight back. this only MOVES the
+# value (a public up-coerce and a declassify), never computing on the secret, so it is
+# secrecy-transparent and needs no `#[oblivious]` (#2136).
 fun roundtrip(x: u32) u32 {
     val s: ^u32 = x;
     ret s:^;

--- a/src/lang/driver/passes.mach
+++ b/src/lang/driver/passes.mach
@@ -44,6 +44,7 @@ use mach.lang.fe.token;
 use mach.lang.intern;
 use mach.lang.manifest;
 use mach.lang.me.ir;
+use mach.lang.me.analysis.oblivious;
 use mach.lang.me.lower;
 use mach.lang.me.lower.testrunner;
 use mach.lang.me.pipeline;
@@ -959,6 +960,21 @@ pub fun q_lower_compute(db: *query.QueryDb, key: u64, alloc: *A.Allocator) R.Res
     val res_lower: R.Result[ir.Module, str] = lower.lower_module(s, ?p.target, a, m.fqn, mid, sr, m.resolve_result, ?m.ctx, ctx.req.debug);
     if (R.is_err[ir.Module, str](res_lower)) { ret R.err[query.QueryOutput, str](R.unwrap_err[ir.Module, str](res_lower)); }
     var irmod: ir.Module = R.unwrap_ok[ir.Module, str](res_lower);
+
+    # the `#[oblivious]`-required check (#2136): over the freshly-lowered IR, before
+    # optimization, so a dead secret compute cannot be optimized away first and the
+    # requirement is independent of the optimization level. every monomorphized instance
+    # is visible here with its concrete secret taint, which sema could not see through a
+    # generic template. a filed diagnostic makes the failure a reported user error.
+    val res_obl: R.Result[bool, str] = oblivious.check_module(?irmod, ?s.interner, ?s.diags, s.alloc);
+    if (R.is_err[bool, str](res_obl)) {
+        ir.dnit(?irmod);
+        ret R.err[query.QueryOutput, str](R.unwrap_err[bool, str](res_obl));
+    }
+    if (!R.unwrap_ok[bool, str](res_obl)) {
+        ir.dnit(?irmod);
+        ret R.err[query.QueryOutput, str]("oblivious-required check: a function computes on a secret without `#[oblivious]`");
+    }
 
     # optimize in place: the cached artifact is the post-pipeline IR the object is
     # built from, so an unchanged optimized module reuses its codegen output.

--- a/src/lang/driver/tests.mach
+++ b/src/lang/driver/tests.mach
@@ -4737,8 +4737,10 @@ test "mach.lang.driver:oblivious_required" {
 
     # a GENERIC MOVER instantiated at a secret type moves the secret through pointers and
     # is NOT flagged - the epic's core requirement that generic copy/swap/containers stay
-    # annotation-free (a generic body cannot compute on its opaque `T`, so a secret
-    # compute is never expressible in one).
+    # annotation-free. (a generic body computing on the secret via the one compute sema
+    # permits on opaque `T`, `==`/`!=`, is a KNOWN false-negative tracked upstream in
+    # #2157 - the taint is frozen public at template time; a regression test lands with
+    # that fix.)
     if (ut_lower_ok("fun copy[T](dst: *T, src: *T) { @dst = @src; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { var a: ^u32 = 5; var b: ^u32 = 0; copy[^u32](?b, ?a); ret 0; }\n") != 0) { bad = 1; }
 
     # non-secret code is wholly unaffected: a public compute needs no annotation.

--- a/src/lang/driver/tests.mach
+++ b/src/lang/driver/tests.mach
@@ -721,6 +721,65 @@ fun ut_codegen_target_rejects(src: str, target_name: str, needle: str) i32 {
     ret code;
 }
 
+# 0 only when `src` passes sema but FAILS at the LOWER stage with an error diagnostic
+# containing `needle` on the session sink; 1 on any other outcome (a clean lower, a
+# missing needle, or a sema failure). asserts the `#[oblivious]`-required check fires,
+# which runs at lower - after sema, before codegen (#2136)
+fun ut_lower_rejects(src: str, needle: str) i32 {
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    val sr: R.Result[session.Session, str] = session.init(?alloc);
+    if (R.is_err[session.Session, str](sr)) { ret 1; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](sr);
+
+    var names: [1]str;
+    names[0] = "main.mach";
+    var texts: [1]str;
+    texts[0] = src;
+    val pr: R.Result[project.Project, outcome.Fail] = ut_build(?s, ?alloc, ?names[0], ?texts[0], 1);
+    if (R.is_err[project.Project, outcome.Fail](pr)) { session.dnit(?s); ret 1; }
+    var p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](pr);
+
+    var code: i32 = 1;
+    val se: R.Result[bool, outcome.Fail] = passes.run_sema_pass(?p);
+    if (R.is_ok[bool, outcome.Fail](se)) {
+        val le: R.Result[bool, outcome.Fail] = passes.run_lower_pass(?p);
+        if (R.is_err[bool, outcome.Fail](le) && ut_diag_has(?p.s.diags, needle)) { code = 0; }
+    }
+    project.dnit_project(?p);
+    session.dnit(?s);
+    ret code;
+}
+
+# 0 when `src` passes sema + lower cleanly (no error on the sink); 1 otherwise. the
+# clean-compile sibling of `ut_lower_rejects`, for confirming a secrecy-transparent
+# instance is NOT required to carry `#[oblivious]` (#2136)
+fun ut_lower_ok(src: str) i32 {
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    val sr: R.Result[session.Session, str] = session.init(?alloc);
+    if (R.is_err[session.Session, str](sr)) { ret 1; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](sr);
+
+    var names: [1]str;
+    names[0] = "main.mach";
+    var texts: [1]str;
+    texts[0] = src;
+    val pr: R.Result[project.Project, outcome.Fail] = ut_build(?s, ?alloc, ?names[0], ?texts[0], 1);
+    if (R.is_err[project.Project, outcome.Fail](pr)) { session.dnit(?s); ret 1; }
+    var p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](pr);
+
+    var code: i32 = 1;
+    val se: R.Result[bool, outcome.Fail] = passes.run_sema_pass(?p);
+    if (R.is_ok[bool, outcome.Fail](se)) {
+        val le: R.Result[bool, outcome.Fail] = passes.run_lower_pass(?p);
+        if (R.is_ok[bool, outcome.Fail](le)) { code = 0; }
+    }
+    project.dnit_project(?p);
+    session.dnit(?s);
+    ret code;
+}
+
 # a vector op reaching instruction selection always resolves to DEFINED behavior
 # -- never an ICE, never a silent miscompile. driving real vector ops (a pointer
 # lane-wise add and a full-arity literal) through the HOST backend on each CI
@@ -4458,9 +4517,11 @@ test "mach.lang.driver:oblivious_decorator" {
 test "mach.lang.driver:secret_mul_codegen_rejected" {
     var bad: i32 = 0;
     # a secret multiply passes sema (the multiply gate is target-dependent) and is
-    # rejected at codegen with the teaching diagnostic.
+    # rejected at codegen with the teaching diagnostic. `f` computes on a secret so it
+    # carries `#[oblivious]` (required by #2136); the decorator is subtractive and grants
+    # no data-independent-multiply capability, so the target-dependent gate still fires.
     if (!ut_sema_clean("fun f(a: ^u32, b: ^u32) ^u32 { ret a * b; }\nfun main() i32 { ret 0; }\n")) { bad = 1; }
-    if (ut_codegen_rejects("fun f(a: ^u32, b: ^u32) ^u32 { ret a * b; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { f(1, 2); ret 0; }\n",
+    if (ut_codegen_rejects("#[oblivious]\nfun f(a: ^u32, b: ^u32) ^u32 { ret a * b; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { f(1, 2); ret 0; }\n",
         "variable-latency integer multiply") != 0) { bad = 1; }
     # a public multiply compiles clean (no gate) - the taint bit never fires on it.
     if (ut_vec_codegen_defined("fun f(a: u32, b: u32) u32 { ret a * b; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { f(1, 2); ret 0; }\n",
@@ -4601,7 +4662,7 @@ test "mach.lang.driver:declassify_emits_barrier" {
 # gate - closing HOLE [2], where the scalarized lanes were built fully public.
 test "mach.lang.driver:secret_vector_mul_scalarized_gated" {
     var bad: i32 = 0;
-    if (ut_codegen_target_rejects("fun f(a: ^i16x8, b: ^i16x8) ^i16x8 { ret a * b; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { ret 0; }\n",
+    if (ut_codegen_target_rejects("#[oblivious]\nfun f(a: ^i16x8, b: ^i16x8) ^i16x8 { ret a * b; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { ret 0; }\n",
         "linux-riscv64", "variable-latency integer multiply") != 0) { bad = 1; }
     # a public vector multiply scalarizes clean (the taint never fires).
     if (ut_codegen_target_rejects("fun f(a: i16x8, b: i16x8) i16x8 { ret a * b; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { ret 0; }\n",
@@ -4625,8 +4686,9 @@ test "mach.lang.driver:declassify_barrier_not_retainted" {
     if (ut_vec_codegen_defined("fun f(a: ^u32) u32 { var x: ^u32 = a; ret (x:^) * (x:^); }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { ret 0; }\n",
         "variable-latency integer multiply") != 0) { bad = 1; }
     # control: without the `:^`, the same multiply IS gated - so the barrier, not luck,
-    # is what cleared it.
-    if (ut_codegen_rejects("fun f(a: ^u32) ^u32 { var x: ^u32 = a; ret x * x; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { ret 0; }\n",
+    # is what cleared it. `f` computes on a secret, so it carries `#[oblivious]` (#2136);
+    # the subtractive decorator still leaves the target-dependent multiply gate to fire.
+    if (ut_codegen_rejects("#[oblivious]\nfun f(a: ^u32) ^u32 { var x: ^u32 = a; ret x * x; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { ret 0; }\n",
         "variable-latency integer multiply") != 0) { bad = 1; }
     ret bad;
 }
@@ -4640,6 +4702,48 @@ test "mach.lang.driver:zeroizing_secret_store_ok" {
     if (!ut_sema_clean("fun f() i32 { var k: ^[4]u8; ret 0; }\nfun main() i32 { ret 0; }\n")) { bad = 1; }
     if (ut_vec_codegen_defined("fun f() { var k: ^[4]u8; var s: ^u32; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { f(); ret 0; }\n",
         "never-appears-needle") != 0) { bad = 1; }
+    ret bad;
+}
+
+# constant-time (#2136): the `#[oblivious]`-required check. a function instance that
+# COMPUTES on a secret (arithmetic / bitwise / comparison) must carry `#[oblivious]`;
+# a secrecy-TRANSPARENT instance that only moves / stores / declassifies secrets stays
+# annotation-free. enforced per monomorphized instance over the lowered IR, so it fires
+# at the lower stage - after sema, before codegen
+test "mach.lang.driver:oblivious_required" {
+    var bad: i32 = 0;
+
+    # a bare secret compute without `#[oblivious]` is rejected with a teaching diagnostic.
+    if (ut_lower_rejects("fun f(a: ^u32, b: ^u32) ^u32 { ret a + b; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { f(1, 2); ret 0; }\n",
+        "not declared `#[oblivious]`") != 0) { bad = 1; }
+    # the diagnostic names the computing function and the operation class.
+    if (ut_lower_rejects("fun secret_add(a: ^u32, b: ^u32) ^u32 { ret a + b; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { secret_add(1, 2); ret 0; }\n",
+        "`secret_add` performs a constant-time arithmetic operation") != 0) { bad = 1; }
+    # a branchless masked select over secrets computes bitwise, equally required.
+    if (ut_lower_rejects("fun sel(m: ^u32, a: ^u32, b: ^u32) ^u32 { ret (a & m) | (b & ~m); }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { sel(1, 2, 3); ret 0; }\n",
+        "bitwise operation") != 0) { bad = 1; }
+    # a secret comparison feeding a mask is a compute, not a move.
+    if (ut_lower_rejects("fun eq(a: ^u32, b: ^u32) ^u8 { ret a == b; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { eq(1, 2); ret 0; }\n",
+        "comparison") != 0) { bad = 1; }
+
+    # adding `#[oblivious]` to the computing function clears the requirement.
+    if (ut_lower_ok("#[oblivious]\nfun f(a: ^u32, b: ^u32) ^u32 { ret a + b; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { f(1, 2); ret 0; }\n") != 0) { bad = 1; }
+
+    # secrecy-TRANSPARENT instances need no annotation: a declassify (`:^`), an up-coerce
+    # round-trip, and a zeroizing secret store all only MOVE the secret.
+    if (ut_lower_ok("fun declassify(x: ^u32) u32 { ret x:^; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { declassify(1); ret 0; }\n") != 0) { bad = 1; }
+    if (ut_lower_ok("fun roundtrip(x: u32) u32 { val s: ^u32 = x; ret s:^; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { roundtrip(7); ret 0; }\n") != 0) { bad = 1; }
+    if (ut_lower_ok("fun wipe() { var z: ^u32 = 9; z = 0; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { wipe(); ret 0; }\n") != 0) { bad = 1; }
+
+    # a GENERIC MOVER instantiated at a secret type moves the secret through pointers and
+    # is NOT flagged - the epic's core requirement that generic copy/swap/containers stay
+    # annotation-free (a generic body cannot compute on its opaque `T`, so a secret
+    # compute is never expressible in one).
+    if (ut_lower_ok("fun copy[T](dst: *T, src: *T) { @dst = @src; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { var a: ^u32 = 5; var b: ^u32 = 0; copy[^u32](?b, ?a); ret 0; }\n") != 0) { bad = 1; }
+
+    # non-secret code is wholly unaffected: a public compute needs no annotation.
+    if (ut_lower_ok("fun f(a: u32, b: u32) u32 { ret a * b + (a & b); }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { f(1, 2); ret 0; }\n") != 0) { bad = 1; }
+
     ret bad;
 }
 

--- a/src/lang/driver/tests.mach
+++ b/src/lang/driver/tests.mach
@@ -4737,14 +4737,55 @@ test "mach.lang.driver:oblivious_required" {
 
     # a GENERIC MOVER instantiated at a secret type moves the secret through pointers and
     # is NOT flagged - the epic's core requirement that generic copy/swap/containers stay
-    # annotation-free. (a generic body computing on the secret via the one compute sema
-    # permits on opaque `T`, `==`/`!=`, is a KNOWN false-negative tracked upstream in
-    # #2157 - the taint is frozen public at template time; a regression test lands with
-    # that fix.)
+    # annotation-free. (a generic body computing on the secret via `==`/`!=` - the one
+    # compute sema permits on opaque `T` - is caught per instance by #2157; see
+    # `generic_instance_ct_reinfer`.)
     if (ut_lower_ok("fun copy[T](dst: *T, src: *T) { @dst = @src; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { var a: ^u32 = 5; var b: ^u32 = 0; copy[^u32](?b, ?a); ret 0; }\n") != 0) { bad = 1; }
 
     # non-secret code is wholly unaffected: a public compute needs no annotation.
     if (ut_lower_ok("fun f(a: u32, b: u32) u32 { ret a * b + (a & b); }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { f(1, 2); ret 0; }\n") != 0) { bad = 1; }
+
+    ret bad;
+}
+
+# constant-time (#2157): per-instance re-validation of generic secrecy. `==`/`!=` is the
+# one compute sema permits on an opaque `T`, and its result secrecy was frozen at
+# generic-TEMPLATE time (public), so a secret instantiation that branched / indexed /
+# aggregate-compared through the result compiled clean - a CT false-negative upstream of
+# #2136. Sema now re-infers each secret / aggregate generic instance under its concrete
+# substitution (driven from the instantiation request, before lowering's mangle-based
+# symbol collapse), so the #1645 leakage gates and the #2127 aggregate-`==` rejection
+# fire on the instance exactly as on the equivalent non-generic function
+test "mach.lang.driver:generic_instance_ct_reinfer" {
+    var bad: i32 = 0;
+
+    # a secret branch through a generic `==` is REJECTED - same diagnostic as the concrete
+    # twin `fun(a: ^u32, b: ^u32)`, not a clean compile.
+    val cb: str = "fun cb[T](a: T, b: T) u32 { if (a == b) { ret 1; } ret 0; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { var x: ^u32 = 1; var y: ^u32 = 1; cb[^u32](x, y); ret 0; }\n";
+    if (!ut_sema_rejects(cb)) { bad = 1; }
+    if (ut_vec_diag(cb, "secret value used as a branch condition") != 0) { bad = 1; }
+
+    # the PUBLIC instantiation of the same generic still compiles (no over-rejection of
+    # a scalar generic `==`).
+    if (!ut_sema_clean("fun cb[T](a: T, b: T) u32 { if (a == b) { ret 1; } ret 0; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { var x: u32 = 1; var y: u32 = 2; cb[u32](x, y); ret 0; }\n")) { bad = 1; }
+
+    # the TWIN: both instantiations in one program - the secret one is still rejected
+    # despite sharing a mangled symbol with the public twin (the collapse-hardening).
+    if (!ut_sema_rejects("fun cb[T](a: T, b: T) u32 { if (a == b) { ret 1; } ret 0; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { var p: u32 = 1; var q: u32 = 2; var x: ^u32 = 1; var y: ^u32 = 1; cb[u32](p, q); cb[^u32](x, y); ret 0; }\n")) { bad = 1; }
+
+    # TRANSITIVE forwarding: outer[^u32] -> cb[^u32] is rejected through the nested call.
+    if (!ut_sema_rejects("fun cb[T](a: T, b: T) u32 { if (a == b) { ret 1; } ret 0; }\nfun outer[T](a: T, b: T) u32 { ret cb[T](a, b); }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { var x: ^u32 = 1; var y: ^u32 = 1; outer[^u32](x, y); ret 0; }\n")) { bad = 1; }
+
+    # aggregate `==` at a record instantiation is rejected - #2127 extended to generics.
+    if (!ut_sema_rejects("rec Pt { x: u32; y: u32; }\nfun eq[T](a: T, b: T) u32 { if (a == b) { ret 1; } ret 0; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { var p: Pt; var q: Pt; eq[Pt](p, q); ret 0; }\n")) { bad = 1; }
+
+    # a LEGAL secret compute in a generic instance - a `==` mask, never branched on -
+    # passes sema but is FLAGGED by the #2136 required-check at lower (the operand-derived
+    # taint reaches it); `#[oblivious]` on the template carries to the instance and clears
+    # it.
+    if (ut_lower_rejects("fun mk[T](a: T, b: T) ^u8 { ret a == b; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { var x: ^u32 = 1; var y: ^u32 = 1; mk[^u32](x, y); ret 0; }\n",
+        "constant-time comparison on a secret value") != 0) { bad = 1; }
+    if (ut_lower_ok("#[oblivious]\nfun mk[T](a: T, b: T) ^u8 { ret a == b; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { var x: ^u32 = 1; var y: ^u32 = 1; mk[^u32](x, y); ret 0; }\n") != 0) { bad = 1; }
 
     ret bad;
 }

--- a/src/lang/fe/sema.mach
+++ b/src/lang/fe/sema.mach
@@ -43,6 +43,7 @@ use mach.lang.fe.comptime;
 use mach.lang.fe.resolve;
 use mach.lang.fe.sema.check;
 use mach.lang.fe.sema.context;
+use mach.lang.fe.sema.generics;
 use mach.lang.fe.sema.infer;
 use mach.lang.fe.token;
 use mach.lang.intern;
@@ -135,11 +136,25 @@ pub fun sema(
     comptime.set_field_resolver(ctx, context.resolve_field_member::*u8, scp::ptr);
     comptime.set_type_resolver(ctx, context.resolve_type_comparison_operand::*u8, scp::ptr);
     val res_bodies: R.Result[bool, str] = infer_all_bodies(?sc);
-    comptime.set_field_resolver(ctx, nil, nil);
-    comptime.set_type_resolver(ctx, nil, nil);
     if (R.is_err[bool, str](res_bodies)) {
+        comptime.set_field_resolver(ctx, nil, nil);
+        comptime.set_type_resolver(ctx, nil, nil);
         dnit_context(?sc);
         ret R.err[context.SemaResult, str](R.unwrap_err[bool, str](res_bodies));
+    }
+
+    # per-instance constant-time re-validation (#2157): drain the generic-instantiation
+    # worklist collected during body inference, re-inferring each secret / aggregate
+    # instance body under its concrete substitution so the #1645 leakage gates and the
+    # #2127 aggregate-`==` rejection fire against the instance's real types. runs while
+    # the comptime resolvers are still installed (a re-inferred body may fold gates).
+    val res_reval: R.Result[bool, str] = drain_revalidations(?sc);
+    comptime.set_field_resolver(ctx, nil, nil);
+    comptime.set_type_resolver(ctx, nil, nil);
+    context.inst_worklist_dnit(?sc);
+    if (R.is_err[bool, str](res_reval)) {
+        dnit_context(?sc);
+        ret R.err[context.SemaResult, str](R.unwrap_err[bool, str](res_reval));
     }
 
     ret build_result(?sc);
@@ -198,8 +213,181 @@ pub fun reinfer_pack_each_body(
     sc.in_comptime_gate = false;
     sc.in_fin           = false;
     sc.fin_loop_depth   = 0;
+    sc.subst            = nil;
+    sc.subst_len        = 0;
+    sc.subst_fn         = nil;
+    sc.insts            = nil;
+    sc.collect_insts    = false;
 
     ret infer_stmt_list(?sc, body_start, body_len, fn_ret);
+}
+
+# copy `n` TypeIds from `src` into `dst`
+fun copy_typeids(dst: *type.TypeId, src: *type.TypeId, n: usize) {
+    var i: u32 = 0;
+    for (i < n::u32) {
+        dst[i] = src[i];
+        i = i + 1;
+    }
+}
+
+# free a TypeId array of `n` elements, or nothing when nil / empty
+fun free_typeids(alloc: *A.Allocator, arr: *type.TypeId, n: usize) {
+    if (arr != nil && n > 0) { A.deallocate[type.TypeId](alloc, arr, n); }
+}
+
+# drive the per-instance constant-time re-validation worklist to fixpoint (#2157)
+#
+# Pops each collected generic instantiation and re-validates its body under the
+# instance substitution; a body re-inferred that way appends the further instances it
+# reaches, so the cursor-based loop drains transitively-reached instances too. Each
+# entry is read by value before re-validating, since re-validation may grow the
+# worklist (the owned `args` buffers are separate allocations, so their pointers stay
+# stable across that growth). A full module-deps snapshot is built once so a
+# cross-module instance body resolves every module it references, mirroring the pack
+# re-inference at monomorphization.
+# ---
+# sc:  the main sema context, whose worklist is drained
+# ret: true once drained, or the first internal error (gate violations are reported
+#      diagnostics, not errors)
+fun drain_revalidations(sc: *context.SemaContext) R.Result[bool, str] {
+    if (sc.insts == nil)          { ret R.ok[bool, str](true); }
+    if (sc.insts.len == 0)        { ret R.ok[bool, str](true); }
+
+    val dr: R.Result[context.SemaDeps, str] = collect_module_deps(sc.s);
+    if (R.is_err[context.SemaDeps, str](dr)) { ret R.err[bool, str](R.unwrap_err[context.SemaDeps, str](dr)); }
+    var full_deps: context.SemaDeps = R.unwrap_ok[context.SemaDeps, str](dr);
+
+    for (sc.insts.drained < sc.insts.len) {
+        val idx:     u32              = sc.insts.drained;
+        val origin:  session.ModuleId = sc.insts.items[idx].origin;
+        val decl:    id.DeclId        = sc.insts.items[idx].decl;
+        val sig:     type.TypeId      = sc.insts.items[idx].sig;
+        val args:    *type.TypeId     = sc.insts.items[idx].args;
+        val arg_len: u32              = sc.insts.items[idx].arg_len;
+
+        val r: R.Result[bool, str] = revalidate_one(sc, ?full_deps, origin, decl, args, arg_len, sig);
+        if (R.is_err[bool, str](r)) {
+            free_module_deps(sc.s, ?full_deps);
+            ret r;
+        }
+        sc.insts.drained = sc.insts.drained + 1;
+    }
+
+    free_module_deps(sc.s, ?full_deps);
+    ret R.ok[bool, str](true);
+}
+
+# re-validate one generic instance body against its concrete type arguments (#2157)
+#
+# Binds a transient sema context to the instance's origin module with the substitution
+# active and SCRATCH typing arrays (so the cached template arrays lowering reads stay
+# intact - the byte-identical guarantee), then re-infers the body. The substitution
+# pushes every generic parameter to its concrete instance type at the type-source
+# leaves, so `join_secret` over concrete operands, `check_condition` / `check_index`,
+# `gate_ct_always`, and the aggregate-`==` rejection all evaluate against the real
+# instance types - firing exactly as they would on the equivalent non-generic function.
+# The transient context shares the caller's worklist, so nested generic calls in the
+# body enqueue their own instances for the drain (the transitive case). A missing
+# origin registry or non-function decl is skipped rather than erroring.
+# ---
+# sc:      the main sema context (owns the worklist and the diagnostic sink)
+# deps:    the full module-deps snapshot for cross-module resolution
+# origin:  ModuleId declaring the generic
+# decl:    the generic function's DeclId
+# args:    the concrete type arguments (borrowed; live for this call)
+# arg_len: number of type arguments
+# sig:     the substituted signature (unused directly; the return type is re-resolved)
+# ret:     true on a validated (or skipped) instance, or an allocation error
+fun revalidate_one(sc: *context.SemaContext, deps: *context.SemaDeps, origin: session.ModuleId,
+                   decl_id: id.DeclId, args: *type.TypeId, arg_len: u32, sig: type.TypeId) R.Result[bool, str] {
+    var oa:              *ast.Ast               = nil;
+    var orr:             *resolve.ResolveResult = nil;
+    var octx:            *comptime.ComptimeCtx  = nil;
+    var o_decl_type:     *type.TypeId           = nil;
+    var o_type_resolved: *type.TypeId           = nil;
+    var o_expr_type:     *type.TypeId           = nil;
+
+    if (origin == sc.own_module) {
+        oa              = sc.a;
+        orr             = sc.rr;
+        octx            = sc.ctx;
+        o_decl_type     = sc.decl_type;
+        o_type_resolved = sc.type_resolved_ty;
+        o_expr_type     = sc.expr_type;
+    } or {
+        oa = session.module_ast(sc.s, origin);
+        if (oa == nil) { ret R.ok[bool, str](true); }
+        orr  = (session.module_resolve_ptr(sc.s, origin))::*resolve.ResolveResult;
+        octx = (session.module_comptime_ptr(sc.s, origin))::*comptime.ComptimeCtx;
+        val osp: ptr = session.module_sema_ptr(sc.s, origin);
+        if (osp == nil || orr == nil || octx == nil) { ret R.ok[bool, str](true); }
+        val osr: *context.SemaResult = osp::*context.SemaResult;
+        o_decl_type     = osr.decl_type;
+        o_type_resolved = osr.type_resolved_ty;
+        o_expr_type     = osr.expr_type;
+    }
+    if (oa == nil || o_decl_type == nil) { ret R.ok[bool, str](true); }
+
+    val d_opt: O.Option[*decl.Decl] = ast.get_decl(oa, decl_id);
+    if (O.is_none[*decl.Decl](d_opt)) { ret R.ok[bool, str](true); }
+    val d: *decl.Decl = O.unwrap[*decl.Decl](d_opt);
+    if (d.kind != decl.DECL_KIND_FUN)    { ret R.ok[bool, str](true); }
+    if (d.data.fun_.body == id.STMT_NIL) { ret R.ok[bool, str](true); }
+
+    var scratch_expr: *type.TypeId = nil;
+    var scratch_decl: *type.TypeId = nil;
+    if (oa.expr_len > 0) {
+        val re: R.Result[*type.TypeId, str] = typeid_array_alloc(sc.s.alloc, oa.expr_len);
+        if (R.is_err[*type.TypeId, str](re)) { ret R.err[bool, str](R.unwrap_err[*type.TypeId, str](re)); }
+        scratch_expr = R.unwrap_ok[*type.TypeId, str](re);
+        if (o_expr_type != nil) { copy_typeids(scratch_expr, o_expr_type, oa.expr_len); }
+    }
+    if (oa.decl_len > 0) {
+        val rd: R.Result[*type.TypeId, str] = typeid_array_alloc(sc.s.alloc, oa.decl_len);
+        if (R.is_err[*type.TypeId, str](rd)) {
+            free_typeids(sc.s.alloc, scratch_expr, oa.expr_len);
+            ret R.err[bool, str](R.unwrap_err[*type.TypeId, str](rd));
+        }
+        scratch_decl = R.unwrap_ok[*type.TypeId, str](rd);
+        copy_typeids(scratch_decl, o_decl_type, oa.decl_len);
+    }
+
+    var tsc: context.SemaContext;
+    tsc.s                = sc.s;
+    tsc.a                = oa;
+    tsc.rr               = orr;
+    tsc.deps             = deps;
+    tsc.ctx              = octx;
+    tsc.own_module       = origin;
+    tsc.source           = source_text_of(sc.s, oa);
+    tsc.expr_type        = scratch_expr;
+    tsc.type_resolved_ty = o_type_resolved;
+    tsc.decl_type        = scratch_decl;
+    tsc.callee_eid       = id.EXPR_NIL;
+    tsc.in_comptime_gate = false;
+    tsc.in_fin           = false;
+    tsc.fin_loop_depth   = 0;
+    tsc.subst            = args;
+    tsc.subst_len        = arg_len;
+    tsc.subst_fn         = generics.substitute;
+    tsc.insts            = sc.insts;
+    tsc.collect_insts    = true;
+
+    val ret_ty: type.TypeId = context.resolved_type_of(?tsc, d.data.fun_.return_type);
+
+    # fold this body's comptime gates against the origin module via the transient
+    # context; restored to uninstalled afterward (the drain re-installs per instance).
+    val tscp: *context.SemaContext = ?tsc;
+    comptime.set_field_resolver(octx, context.resolve_field_member::*u8, tscp::ptr);
+    comptime.set_type_resolver(octx, context.resolve_type_comparison_operand::*u8, tscp::ptr);
+    val res: R.Result[bool, str] = infer_stmt(?tsc, d.data.fun_.body, ret_ty);
+    comptime.set_field_resolver(octx, nil, nil);
+    comptime.set_type_resolver(octx, nil, nil);
+
+    free_typeids(sc.s.alloc, scratch_expr, oa.expr_len);
+    free_typeids(sc.s.alloc, scratch_decl, oa.decl_len);
+    ret res;
 }
 
 # assemble a typing-snapshot set spanning every registered module (#1475)
@@ -329,6 +517,11 @@ fun init_context(
     sc.in_comptime_gate = false;
     sc.in_fin           = false;
     sc.fin_loop_depth   = 0;
+    sc.subst            = nil;
+    sc.subst_len        = 0;
+    sc.subst_fn         = nil;
+    sc.insts            = nil;
+    sc.collect_insts    = true;
 
     if (a.expr_len > 0) {
         val res_expr: R.Result[*type.TypeId, str] = typeid_array_alloc(s.alloc, a.expr_len);
@@ -419,6 +612,7 @@ fun dnit_context(sc: *context.SemaContext) {
     sc.expr_type        = nil;
     sc.type_resolved_ty = nil;
     sc.decl_type        = nil;
+    context.inst_worklist_dnit(sc);
 }
 
 # resolve every syntactic AstType into its interned semantic TypeId

--- a/src/lang/fe/sema.mach
+++ b/src/lang/fe/sema.mach
@@ -316,23 +316,34 @@ fun revalidate_one(sc: *context.SemaContext, deps: *context.SemaDeps, origin: se
         o_type_resolved = sc.type_resolved_ty;
         o_expr_type     = sc.expr_type;
     } or {
+        # the origin module of an instantiated generic is a dependency, so it was
+        # sema-analysed and registered before this module's pass (the compiler's
+        # dependency-ordering invariant). A missing snapshot is therefore impossible;
+        # a SECURITY check must never silently skip on a broken precondition, so it is a
+        # loud internal-compiler-error rather than a fail-open `ret ok` (#2157).
         oa = session.module_ast(sc.s, origin);
-        if (oa == nil) { ret R.ok[bool, str](true); }
+        if (oa == nil) { ret R.err[bool, str]("internal: #2157 CT re-validation: origin module AST unavailable (dependency-ordering invariant violated)"); }
         orr  = (session.module_resolve_ptr(sc.s, origin))::*resolve.ResolveResult;
         octx = (session.module_comptime_ptr(sc.s, origin))::*comptime.ComptimeCtx;
         val osp: ptr = session.module_sema_ptr(sc.s, origin);
-        if (osp == nil || orr == nil || octx == nil) { ret R.ok[bool, str](true); }
+        if (osp == nil || orr == nil || octx == nil) { ret R.err[bool, str]("internal: #2157 CT re-validation: origin module sema/resolve/comptime snapshot unavailable (dependency-ordering invariant violated)"); }
         val osr: *context.SemaResult = osp::*context.SemaResult;
         o_decl_type     = osr.decl_type;
         o_type_resolved = osr.type_resolved_ty;
         o_expr_type     = osr.expr_type;
     }
-    if (oa == nil || o_decl_type == nil) { ret R.ok[bool, str](true); }
+    # the origin declares the generic, so it has a decl table; a nil one is an invariant
+    # break, not a reason to skip the check.
+    if (oa == nil || o_decl_type == nil) { ret R.err[bool, str]("internal: #2157 CT re-validation: origin module decl table unavailable (dependency-ordering invariant violated)"); }
 
+    # the recorded instance came from a resolved generic-function call, so its decl is a
+    # function in the origin AST; anything else is an invariant break, loud not silent.
     val d_opt: O.Option[*decl.Decl] = ast.get_decl(oa, decl_id);
-    if (O.is_none[*decl.Decl](d_opt)) { ret R.ok[bool, str](true); }
+    if (O.is_none[*decl.Decl](d_opt)) { ret R.err[bool, str]("internal: #2157 CT re-validation: generic instance decl id out of range in origin AST (invariant violated)"); }
     val d: *decl.Decl = O.unwrap[*decl.Decl](d_opt);
-    if (d.kind != decl.DECL_KIND_FUN)    { ret R.ok[bool, str](true); }
+    if (d.kind != decl.DECL_KIND_FUN)    { ret R.err[bool, str]("internal: #2157 CT re-validation: generic instance decl is not a function (invariant violated)"); }
+    # a body-less generic (an extern declaration) has no statements to gate, so there is
+    # genuinely nothing to re-validate: a sound skip, not a fail-open.
     if (d.data.fun_.body == id.STMT_NIL) { ret R.ok[bool, str](true); }
 
     var scratch_expr: *type.TypeId = nil;

--- a/src/lang/fe/sema/context.mach
+++ b/src/lang/fe/sema/context.mach
@@ -8,6 +8,8 @@
 
 use std.format;
 use std.types.bool.bool;
+use std.types.bool.false;
+use std.types.bool.true;
 use std.types.char.char;
 use std.types.size.usize;
 use std.types.string.str;
@@ -82,6 +84,51 @@ pub rec SemaDeps {
 fwd type.FieldEntry;
 fwd type.FieldTable;
 
+# one requested generic-function instantiation, collected during body inference for
+# the per-instance constant-time re-validation (#2157)
+#
+# The instance is identified by (origin, decl, concrete type-args). `sig` is the
+# substituted `TYPE_FUN` signature, carried so the drain reads the instance return
+# type without re-substituting. `args` is an owned copy of the concrete type-arguments
+# (the caller's scratch buffer is freed right after the call).
+# ---
+# origin:  ModuleId declaring the generic function
+# decl:    the generic function's DeclId in `origin`
+# sig:     the substituted signature TypeId (for the instance return type)
+# args:    owned concrete type-argument array (by parameter ordinal)
+# arg_len: number of type arguments
+pub rec InstReq {
+    origin:  session.ModuleId;
+    decl:    id.DeclId;
+    sig:     type.TypeId;
+    args:    *type.TypeId;
+    arg_len: u32;
+}
+
+# the per-instance CT re-validation worklist (#2157): generic instantiations requested
+# during body inference, drained after all bodies are typed
+#
+# Heap-allocated and shared by pointer: the draining pass and each transient
+# re-inference context reference the same worklist, so a body re-inferred under
+# substitution appends the further instances it reaches onto the one list the drain
+# consumes. Deduped by (origin, decl, args) so each distinct instance is validated once
+# and mutually recursive generics terminate. The drain reads `items[i]` by index, so
+# an append that grows `items` never strands a borrowed pointer.
+# ---
+# items:   the requested instances (owned)
+# len:     number of requests
+# cap:     allocated capacity of `items`
+# drained: cursor; requests below it have been re-validated
+# alloc:   allocator backing `items` and each request's owned `args`
+pub rec InstWorklist {
+    items:   *InstReq;
+    len:     u32;
+    cap:     u32;
+    drained: u32;
+    alloc:   *A.Allocator;
+}
+
+
 # sema's working state for one module analysis
 #
 # Owned by `sema` for the duration of one pass and transferred into the returned
@@ -111,6 +158,17 @@ pub rec SemaContext {
     own_module: session.ModuleId;
     source:     str;
 
+    # the shared per-instance CT re-validation worklist (#2157), or nil when the pass
+    # collects no instances. The main pass owns it; a transient re-inference context
+    # borrows the same pointer so its nested generic calls append to the one worklist.
+    insts: *InstWorklist;
+
+    # gate for `record_instance` (#2157): true on the main sema pass and on a sema-time
+    # instance re-validation (which collect generic instantiations to re-validate),
+    # false on the lowering-time pack re-inference (`reinfer_pack_each_body`), which
+    # runs the same inference machinery but must not collect or drain a worklist.
+    collect_insts: bool;
+
     expr_type:        *type.TypeId;
     type_resolved_ty: *type.TypeId;
     decl_type:        *type.TypeId;
@@ -132,6 +190,19 @@ pub rec SemaContext {
     # keeps `brk` / `cnt` legal; a nested fin saves and resets both.
     in_fin:         bool;
     fin_loop_depth: u32;
+
+    # per-monomorphized-instance CT re-validation (#2157): while re-inferring a
+    # generic instance body, `subst` is the active generic substitution (concrete
+    # type-args by parameter ordinal) and `subst_fn` applies it to a resolved type.
+    # nil / 0 on the main sema pass, where every type-source leaf reads its template
+    # type unchanged. On re-inference, `resolved_type_of` and `generic_param_type_for`
+    # push each generic parameter to its concrete instance type through `subst_fn`
+    # (a function pointer to break the context->generics import cycle), so the body's
+    # secrecy / aggregate-ness - and thus the #1645 leakage gates and the #2127
+    # aggregate-`==` rejection - are evaluated against the instance's concrete types.
+    subst:     *type.TypeId;
+    subst_len: u32;
+    subst_fn:  fun(*session.Session, type.TypeId, *type.TypeId, u32) type.TypeId;
 }
 
 # the interned semantic TypeId a syntactic AstType resolved to
@@ -146,7 +217,152 @@ pub fun resolved_type_of(sc: *SemaContext, ast_tid: id.TypeId) type.TypeId {
     if (ast_tid == id.TYPE_NIL)        { ret type.TYPE_NIL; }
     if (sc.type_resolved_ty == nil)    { ret type.TYPE_ERROR; }
     if (ast_tid >= sc.a.type_len::u32) { ret type.TYPE_ERROR; }
-    ret sc.type_resolved_ty[ast_tid];
+    ret apply_subst(sc, sc.type_resolved_ty[ast_tid]);
+}
+
+# apply the active generic substitution (#2157) to `tid`, or return it unchanged
+#
+# A no-op on the main sema pass (`subst` nil), where a type-source leaf reads its
+# template type. While re-inferring a monomorphized instance body it pushes a
+# generic parameter (bare `T`, `*T`, `Result[T,E]`, ...) to its concrete instance
+# type via `subst_fn`, so the leaf reflects the instantiation. Called at every leaf
+# that can surface a generic-parameter type.
+# ---
+# sc:  sema context
+# tid: a resolved semantic TypeId
+# ret: `tid` substituted when a substitution is active, else `tid`
+pub fun apply_subst(sc: *SemaContext, tid: type.TypeId) type.TypeId {
+    if (sc.subst == nil || sc.subst_len == 0 || sc.subst_fn == nil) { ret tid; }
+    ret sc.subst_fn(sc.s, tid, sc.subst, sc.subst_len);
+}
+
+# whether a concrete type argument can newly trip a per-instance CT gate (#2157)
+#
+# A secret-carrying argument can make a `==` / branch / index / div operand secret at
+# the instance; an aggregate argument can make a `==` an aggregate compare (#2127). A
+# bare public scalar can do neither - the template check already covered it - so an
+# instance whose every argument is a public scalar needs no re-validation.
+# ---
+# sc:  sema context
+# tid: a concrete type argument
+# ret: true when the argument warrants re-validating the instance body
+pub fun arg_triggers_revalidation(sc: *SemaContext, tid: type.TypeId) bool {
+    if (type.carries_secret(?sc.s.types, tid)) { ret true; }
+    val t_opt: O.Option[*type.Type] = type.get(?sc.s.types, tid);
+    if (O.is_none[*type.Type](t_opt)) { ret false; }
+    val k: type.TypeKind = O.unwrap[*type.Type](t_opt).kind;
+    ret k == type.TYPE_REC || k == type.TYPE_UNI || k == type.TYPE_INSTANCE || k == type.TYPE_ARRAY;
+}
+
+# whether two concrete type-argument tuples are element-wise equal
+fun args_equal(a: *type.TypeId, b: *type.TypeId, n: u32) bool {
+    var i: u32 = 0;
+    for (i < n) {
+        if (a[i] != b[i]) { ret false; }
+        i = i + 1;
+    }
+    ret true;
+}
+
+# record a generic instantiation for per-instance CT re-validation (#2157)
+#
+# A no-op when no argument warrants re-validation (every argument a public scalar) or
+# when this exact (origin, decl, args) instance is already recorded - the dedup that
+# validates each instance once and terminates mutually recursive generics. Otherwise it
+# copies the arguments (the caller's scratch buffer is freed after the call) and appends
+# to the shared worklist, growing it on demand. The worklist is created lazily on the
+# first recorded instance.
+# ---
+# sc:      the sema context whose worklist receives the request
+# origin:  ModuleId declaring the generic
+# decl:    the generic function's DeclId
+# args:    the concrete type arguments (borrowed; copied here)
+# arg_len: number of type arguments
+# sig:     the substituted signature TypeId
+# ret:     ok(true), or err on an allocation failure
+pub fun record_instance(sc: *SemaContext, origin: session.ModuleId, decl: id.DeclId,
+                        args: *type.TypeId, arg_len: u32, sig: type.TypeId) R.Result[bool, str] {
+    if (!sc.collect_insts) { ret R.ok[bool, str](true); }
+    if (arg_len == 0)      { ret R.ok[bool, str](true); }
+
+    var any: bool = false;
+    var i: u32 = 0;
+    for (i < arg_len) {
+        if (arg_triggers_revalidation(sc, args[i])) { any = true; }
+        i = i + 1;
+    }
+    if (!any) { ret R.ok[bool, str](true); }
+
+    if (sc.insts != nil) {
+        var j: u32 = 0;
+        for (j < sc.insts.len) {
+            val e: *InstReq = ?sc.insts.items[j];
+            if (e.origin == origin && e.decl == decl && e.arg_len == arg_len
+                && args_equal(e.args, args, arg_len)) {
+                ret R.ok[bool, str](true);
+            }
+            j = j + 1;
+        }
+    }
+
+    if (sc.insts == nil) {
+        val wr: R.Result[*InstWorklist, str] = A.allocate[InstWorklist](sc.s.alloc, 1::usize);
+        if (R.is_err[*InstWorklist, str](wr)) { ret R.err[bool, str](R.unwrap_err[*InstWorklist, str](wr)); }
+        val wl: *InstWorklist = R.unwrap_ok[*InstWorklist, str](wr);
+        wl.items   = nil;
+        wl.len     = 0;
+        wl.cap     = 0;
+        wl.drained = 0;
+        wl.alloc   = sc.s.alloc;
+        sc.insts = wl;
+    }
+    val wl: *InstWorklist = sc.insts;
+
+    if (wl.len == wl.cap) {
+        var new_cap: u32 = 8;
+        if (wl.cap > 0) { new_cap = wl.cap * 2; }
+        var nr: R.Result[*InstReq, str] = A.allocate[InstReq](wl.alloc, new_cap::usize);
+        if (wl.cap > 0) { nr = A.reallocate[InstReq](wl.alloc, wl.items, wl.cap::usize, new_cap::usize); }
+        if (R.is_err[*InstReq, str](nr)) { ret R.err[bool, str](R.unwrap_err[*InstReq, str](nr)); }
+        wl.items = R.unwrap_ok[*InstReq, str](nr);
+        wl.cap   = new_cap;
+    }
+
+    val cr: R.Result[*type.TypeId, str] = A.allocate[type.TypeId](wl.alloc, arg_len::usize);
+    if (R.is_err[*type.TypeId, str](cr)) { ret R.err[bool, str](R.unwrap_err[*type.TypeId, str](cr)); }
+    val owned: *type.TypeId = R.unwrap_ok[*type.TypeId, str](cr);
+    var k: u32 = 0;
+    for (k < arg_len) { owned[k] = args[k]; k = k + 1; }
+
+    val slot: *InstReq = ?wl.items[wl.len];
+    slot.origin  = origin;
+    slot.decl    = decl;
+    slot.sig     = sig;
+    slot.args    = owned;
+    slot.arg_len = arg_len;
+    wl.len = wl.len + 1;
+    ret R.ok[bool, str](true);
+}
+
+# free the CT re-validation worklist and every request's owned arguments (#2157)
+# ---
+# sc: the sema context whose worklist is released (nil-safe; cleared to nil)
+pub fun inst_worklist_dnit(sc: *SemaContext) {
+    if (sc.insts == nil) { ret; }
+    val wl: *InstWorklist = sc.insts;
+    var i: u32 = 0;
+    for (i < wl.len) {
+        val e: *InstReq = ?wl.items[i];
+        if (e.args != nil && e.arg_len > 0) {
+            A.deallocate[type.TypeId](wl.alloc, e.args, e.arg_len::usize);
+        }
+        i = i + 1;
+    }
+    if (wl.items != nil && wl.cap > 0) {
+        A.deallocate[InstReq](wl.alloc, wl.items, wl.cap::usize);
+    }
+    A.deallocate[InstWorklist](wl.alloc, wl, 1::usize);
+    sc.insts = nil;
 }
 
 # the ModuleSema snapshot for dependency `module`, or none when it is not a dep
@@ -494,7 +710,7 @@ fun param_type_for(sc: *SemaContext, sym: *resolve.Symbol) type.TypeId {
 fun generic_param_type_for(sc: *SemaContext, sym: *resolve.Symbol) type.TypeId {
     val res_intern: R.Result[type.TypeId, str] = type.intern_generic_param(?sc.s.types, sym.name, sym.decl, sym.slot);
     if (R.is_err[type.TypeId, str](res_intern)) { ret type.TYPE_ERROR; }
-    ret R.unwrap_ok[type.TypeId, str](res_intern);
+    ret apply_subst(sc, R.unwrap_ok[type.TypeId, str](res_intern));
 }
 
 # the DeclFun payload of function DeclId `did`

--- a/src/lang/fe/sema/infer.mach
+++ b/src/lang/fe/sema/infer.mach
@@ -1570,6 +1570,22 @@ fun infer_generic_call(sc: *context.SemaContext, c: *expr.ExprCall, ct: type.Typ
     }
 
     val sig: type.TypeId = generics.substitute(sc.s, ct, args, c.type_args_len);
+
+    # enqueue this instance for per-instance constant-time re-validation (#2157): with
+    # the concrete type-args resolved here - before lowering's mangle-based collapse
+    # coalesces `foo[^u32]` and `foo[u32]` - the secret instance is visible to the sema
+    # drain even when it later shares a symbol with a public twin. a no-op on the
+    # lowering-time pack re-inference and on all-public-scalar instances (record_instance
+    # prunes). the args are copied there; free_params below still owns this scratch.
+    if (sig != type.TYPE_ERROR) {
+        val rr: R.Result[bool, str] = context.record_instance(sc, sym.origin, sym.decl, args, c.type_args_len, sig);
+        if (R.is_err[bool, str](rr)) {
+            free_params(sc, args, c.type_args_len);
+            context.report(sc, span, "internal: out of memory recording a generic instance for constant-time re-validation");
+            ret type.TYPE_ERROR;
+        }
+    }
+
     free_params(sc, args, c.type_args_len);
     if (sig == type.TYPE_ERROR) {
         # substitute collapses every failure (an out-of-range generic parameter,
@@ -1986,6 +2002,14 @@ fun infer_struct_lit(sc: *context.SemaContext, sl: *expr.ExprStructLit, span: to
 # tid: syntactic AstType id to resolve
 # ret: the interned semantic TypeId (TYPE_ERROR on failure)
 pub fun resolve_type_ref(sc: *context.SemaContext, tid: id.TypeId) type.TypeId {
+    # apply the active generic substitution (#2157) to the fresh resolution, so a
+    # type-argument or annotation naming a generic parameter (`T`, `*T`, `Result[T,E]`)
+    # resolves to its concrete instance type while re-inferring an instance body. inert
+    # on the main pass (no substitution active).
+    ret context.apply_subst(sc, resolve_type_ref_raw(sc, tid));
+}
+
+fun resolve_type_ref_raw(sc: *context.SemaContext, tid: id.TypeId) type.TypeId {
     val t_opt: O.Option[*atype.Type] = ast.get_type(sc.a, tid);
     if (O.is_none[*atype.Type](t_opt)) { ret type.TYPE_ERROR; }
     val t: *atype.Type = O.unwrap[*atype.Type](t_opt);

--- a/src/lang/me/analysis/oblivious.mach
+++ b/src/lang/me/analysis/oblivious.mach
@@ -20,18 +20,15 @@
 # (arithmetic / bitwise / shift / comparison / negation) - only moves (load / store /
 # gep / phi / call / ret / extract / insert / width-cast / declassify).
 #
-# SOUNDNESS LIMIT (briar-systems/mach#2157): this check consumes `Instruction.secret`,
-# and that taint is currently frozen at generic-template-check time for `==`/`!=` - the
-# one compute sema permits on an opaque `T` (its result secrecy is join'd over the
-# non-secret parameter into a public `u8` that the per-instance substitution cannot
-# recover). Worse, the monomorphization worklist and mangling erase secrecy, so
-# `foo[^u32]` and `foo[u32]` collapse to ONE lowered body carrying only the public
-# taint. So a secret compute reached through `==`/`!=` in a generic instance is NOT
-# stamped and this check does not see it (the earlier claim that a generic body cannot
-# compute on its opaque `T` was FALSE for `==`/`!=`). #2157 is the upstream fix -
-# operand-derived taint and/or secrecy-aware instance identity; once it lands, the taint
-# is correct per instance and this check flags the generic case. The check itself is
-# correct for correctly-stamped taint.
+# GENERIC INSTANCES (briar-systems/mach#2157): `==`/`!=` is the one compute sema permits
+# on an opaque `T`, and its `u8` result secrecy is join'd at generic-template time over
+# the non-secret parameter, so the recorded result type is frozen public at a secret
+# instantiation. #2157 closes this on two fronts: sema re-infers each secret / aggregate
+# generic instance under its concrete substitution (rejecting a secret branch / index /
+# aggregate-`==` at the earliest point, before lowering's mangle-based symbol collapse),
+# and the lowerer stamps a comparison's result taint operand-derived (`stamp_secret`), so
+# a LEGAL secret comparison mask in a generic instance carries `Instruction.secret` and
+# this check flags it here just as it flags the equivalent non-generic function.
 #
 # The check never mutates the module - it only reports - so a program that uses no `^`
 # has no secret-tainted instruction, emits no diagnostic, and lowers byte-identically.

--- a/src/lang/me/analysis/oblivious.mach
+++ b/src/lang/me/analysis/oblivious.mach
@@ -1,0 +1,192 @@
+# mach.lang.me.analysis.oblivious: the `#[oblivious]`-required check (#2136)
+#
+# The per-monomorphized-instance secrecy-transparency gate of the constant-time epic
+# (#1643). It runs over the freshly-lowered IR module - after monomorphization, before
+# optimization - and requires that any function instance which genuinely COMPUTES on a
+# secret carries `#[oblivious]`, while a secrecy-TRANSPARENT instance that only moves or
+# stores secrets stays annotation-free.
+#
+# Why here, not sema: the requirement is per INSTANCE, and secrecy is stamped onto IR
+# values/instructions per instance by the lowerer only after generic substitution
+# (#1646). A generic template is type-checked once with its parameter opaque, so sema
+# cannot see whether a given instantiation binds a secret type. The lowered module is
+# the first point every monomorphized instance is visible with its concrete taint, so
+# the check consults `Instruction.secret` there. It runs BEFORE the optimization
+# pipeline so a dead secret compute cannot be optimized away first, making the
+# requirement independent of the optimization level.
+#
+# The transparency predicate (`instruction.op_is_secret_move`): an instance is
+# transparent iff it contains NO secret-tainted instruction whose opcode COMPUTES
+# (arithmetic / bitwise / shift / comparison / negation) - only moves (load / store /
+# gep / phi / call / ret / extract / insert / width-cast / declassify). Because a
+# generic body cannot perform arithmetic on its opaque type parameter (sema rejects
+# `a + b` on an unconstrained `T`), every secret compute is over a concrete secret type
+# and appears identically in each instance, so the secrecy-erasing symbol coalescing in
+# mangling (`^T` and `T` share one symbol) cannot hide a secret compute from this check.
+#
+# The check never mutates the module - it only reports - so a program that uses no `^`
+# has no secret-tainted instruction, emits no diagnostic, and lowers byte-identically.
+
+use std.types.bool.bool;
+use std.types.bool.false;
+use std.types.bool.true;
+use std.types.string.str;
+use std.types.string.str_len;
+
+use A: std.allocator;
+use O: std.types.option;
+use R: std.types.result;
+use std.format;
+
+use mach.lang.diagnostic;
+use mach.lang.intern;
+use mach.lang.me.ir;
+use mach.lang.me.ir.instruction;
+use mach.lang.source;
+use mach.lang.fe.token;
+
+# scan every function instance in `m` and report each one that computes on a secret
+# without `#[oblivious]` (#2136)
+#
+# Reports at most one diagnostic per offending function (the first secret compute it
+# finds), naming the function, the operation class, and - for a generic instance - its
+# instantiation, with a help note pointing at the fix. Extern (body-less) and already
+# `#[oblivious]` functions are skipped. Appends to `diags` and returns ok(false) when
+# any violation was reported, ok(true) when the module is clean, or err on an internal
+# allocation failure.
+# ---
+# m:     the freshly-lowered IR module (every monomorphized instance, taint stamped)
+# itn:   interner, to resolve function names for the diagnostic
+# diags: the sink violations are reported to
+# alloc: allocator for the transient diagnostic message strings
+# ret:   ok(true) clean, ok(false) at least one violation reported, or err on failure
+pub fun check_module(m: *ir.Module, itn: *intern.Interner, diags: *diagnostic.DiagList, alloc: *A.Allocator) R.Result[bool, str] {
+    var clean: bool = true;
+    var fi: u32 = 0;
+    for (fi < m.function_len) {
+        val fn: *ir.Function = ?m.functions[fi];
+        fi = fi + 1;
+
+        # a body-less extern carries no instructions to scan; an already-oblivious
+        # function has declared its contract, so the requirement is satisfied.
+        if ((fn.flags & ir.FN_FLAG_EXTERN) != 0)    { cnt; }
+        if ((fn.flags & ir.FN_FLAG_OBLIVIOUS) != 0) { cnt; }
+
+        val hit: O.Option[*instruction.Instruction] = first_secret_compute(fn);
+        if (O.is_none[*instruction.Instruction](hit)) { cnt; }
+        val inst: *instruction.Instruction = O.unwrap[*instruction.Instruction](hit);
+
+        val rr: R.Result[bool, str] = report(fn, inst, itn, diags, alloc);
+        if (R.is_err[bool, str](rr)) { ret rr; }
+        clean = false;
+    }
+    ret R.ok[bool, str](clean);
+}
+
+# find the first instruction in `fn` that COMPUTES on a secret (a secret-tainted
+# non-move opcode), or none when the function is secrecy-transparent
+#
+# Scans the instruction pool directly rather than the block lists: the pool is the
+# complete set the function lowered, so a secret compute the source wrote is caught
+# regardless of reachability, and the scan needs no CFG walk.
+# ---
+# fn:  the function to scan
+# ret: some(first secret-compute instruction), or none when transparent
+fun first_secret_compute(fn: *ir.Function) O.Option[*instruction.Instruction] {
+    var ii: u32 = 0;
+    for (ii < fn.instr_len) {
+        val inst: *instruction.Instruction = ?fn.instrs[ii];
+        ii = ii + 1;
+        if (inst.secret && !instruction.op_is_secret_move(inst.kind)) {
+            ret O.some[*instruction.Instruction](inst);
+        }
+    }
+    ret O.none[*instruction.Instruction]();
+}
+
+# report one function's missing `#[oblivious]`, at the offending operation's location
+#
+# The primary error names the function and the operation class; a help note states the
+# transparency rule and the fix. A generic instance (weak linkage, whose readable
+# source name differs from its mangled symbol) also gets a note naming the exact
+# instantiation, so a per-instance violation is unambiguous.
+# ---
+# fn:    the offending function
+# inst:  the first secret-compute instruction (its loc anchors the diagnostic)
+# itn:   interner, to resolve the function's names
+# diags: the sink
+# alloc: allocator for the message string
+# ret:   ok(true) on a filed diagnostic, or err on an allocation failure
+fun report(fn: *ir.Function, inst: *instruction.Instruction, itn: *intern.Interner, diags: *diagnostic.DiagList, alloc: *A.Allocator) R.Result[bool, str] {
+    val name: str = name_of(fn, itn);
+    val klass: str = op_class_name(inst.kind);
+
+    var sp: token.Span;
+    sp.offset = inst.loc.offset;
+    sp.len    = 1;
+
+    val mr: R.Result[str, str] = format.sprint(alloc,
+        "`{}` performs a constant-time {} on a secret value but is not declared `#[oblivious]`",
+        name, klass);
+    if (R.is_err[str, str](mr)) { ret R.err[bool, str](R.unwrap_err[str, str](mr)); }
+    val msg: str = R.unwrap_ok[str, str](mr);
+
+    val er: R.Result[bool, str] = diagnostic.error(diags, inst.loc.file, sp, msg);
+    A.deallocate[u8](alloc, msg::*u8, str_len(msg) + 1);
+    if (R.is_err[bool, str](er)) { ret er; }
+
+    # a generic instance: name the exact instantiation so the per-instance requirement
+    # is unambiguous (the readable source name is shared across every instantiation).
+    if ((fn.flags & ir.FN_FLAG_WEAK) != 0) {
+        val ir_o: O.Option[str] = intern.lookup(itn, fn.name);
+        if (O.is_some[str](ir_o)) {
+            val nr: R.Result[str, str] = format.sprint(alloc, "in the instantiation `{}`", O.unwrap[str](ir_o));
+            if (R.is_ok[str, str](nr)) {
+                val note: str = R.unwrap_ok[str, str](nr);
+                diagnostic.attach_note(diags, note);
+                A.deallocate[u8](alloc, note::*u8, str_len(note) + 1);
+            }
+        }
+    }
+
+    diagnostic.attach_help(diags,
+        "annotate the function with `#[oblivious]` to declare its constant-time contract; only a function that merely moves or stores secrets may omit it");
+    ret R.ok[bool, str](true);
+}
+
+# the readable name of a function for the diagnostic: its bare source spelling when
+# present, else its mangled symbol, else a placeholder
+# ---
+# fn:  the function
+# itn: interner
+# ret: a printable name (never allocates; borrows the interned string)
+fun name_of(fn: *ir.Function, itn: *intern.Interner) str {
+    if (fn.disp != intern.STR_NIL) {
+        val d: O.Option[str] = intern.lookup(itn, fn.disp);
+        if (O.is_some[str](d)) { ret O.unwrap[str](d); }
+    }
+    if (fn.name != intern.STR_NIL) {
+        val n: O.Option[str] = intern.lookup(itn, fn.name);
+        if (O.is_some[str](n)) { ret O.unwrap[str](n); }
+    }
+    ret "<anonymous>";
+}
+
+# a readable class name for the secret operation a diagnostic names
+# ---
+# k:   the compute opcode
+# ret: the operation-class word
+fun op_class_name(k: instruction.InstrKind) str {
+    if (k == instruction.OP_ADD || k == instruction.OP_SUB || k == instruction.OP_MUL
+        || k == instruction.OP_DIV_S || k == instruction.OP_DIV_U
+        || k == instruction.OP_REM_S || k == instruction.OP_REM_U
+        || k == instruction.OP_NEG) { ret "arithmetic operation"; }
+    if (k == instruction.OP_AND || k == instruction.OP_OR
+        || k == instruction.OP_XOR || k == instruction.OP_NOT) { ret "bitwise operation"; }
+    if (k == instruction.OP_SHL || k == instruction.OP_SHR_S
+        || k == instruction.OP_SHR_U) { ret "shift"; }
+    if (k == instruction.OP_CMP_EQ || k == instruction.OP_CMP_NE
+        || k == instruction.OP_CMP_LT_S || k == instruction.OP_CMP_LT_U
+        || k == instruction.OP_CMP_LE_S || k == instruction.OP_CMP_LE_U) { ret "comparison"; }
+    ret "computation";
+}

--- a/src/lang/me/analysis/oblivious.mach
+++ b/src/lang/me/analysis/oblivious.mach
@@ -18,11 +18,20 @@
 # The transparency predicate (`instruction.op_is_secret_move`): an instance is
 # transparent iff it contains NO secret-tainted instruction whose opcode COMPUTES
 # (arithmetic / bitwise / shift / comparison / negation) - only moves (load / store /
-# gep / phi / call / ret / extract / insert / width-cast / declassify). Because a
-# generic body cannot perform arithmetic on its opaque type parameter (sema rejects
-# `a + b` on an unconstrained `T`), every secret compute is over a concrete secret type
-# and appears identically in each instance, so the secrecy-erasing symbol coalescing in
-# mangling (`^T` and `T` share one symbol) cannot hide a secret compute from this check.
+# gep / phi / call / ret / extract / insert / width-cast / declassify).
+#
+# SOUNDNESS LIMIT (briar-systems/mach#2157): this check consumes `Instruction.secret`,
+# and that taint is currently frozen at generic-template-check time for `==`/`!=` - the
+# one compute sema permits on an opaque `T` (its result secrecy is join'd over the
+# non-secret parameter into a public `u8` that the per-instance substitution cannot
+# recover). Worse, the monomorphization worklist and mangling erase secrecy, so
+# `foo[^u32]` and `foo[u32]` collapse to ONE lowered body carrying only the public
+# taint. So a secret compute reached through `==`/`!=` in a generic instance is NOT
+# stamped and this check does not see it (the earlier claim that a generic body cannot
+# compute on its opaque `T` was FALSE for `==`/`!=`). #2157 is the upstream fix -
+# operand-derived taint and/or secrecy-aware instance identity; once it lands, the taint
+# is correct per instance and this check flags the generic case. The check itself is
+# correct for correctly-stamped taint.
 #
 # The check never mutates the module - it only reports - so a program that uses no `^`
 # has no secret-tainted instruction, emits no diagnostic, and lowers byte-identically.

--- a/src/lang/me/ir/instruction.mach
+++ b/src/lang/me/ir/instruction.mach
@@ -269,6 +269,49 @@ pub fun is_pure(k: InstrKind) bool {
     ret true;
 }
 
+# true when opcode `k` only MOVES or reshapes a value rather than COMPUTING a new
+# one from it through an ALU/FPU operation (#2136)
+#
+# The secrecy-transparency predicate the `#[oblivious]`-required check keys on: a
+# secret-tainted instruction of a move opcode is oblivious vacuously - it relocates
+# the secret (load / store / gep / phi / call / ret / memzero / alloca), extracts or
+# inserts a whole field/element (extract / insert), reinterprets or resizes its width
+# (trunc / sext / zext / bitcast), or declassifies it (`:^`), never branching on,
+# indexing by, or arithmetically deriving from it. Every other value-producing opcode
+# - arithmetic, bitwise, shift, comparison, negation, and the leakage-gated float
+# conversions - COMPUTES on a secret operand and so requires the enclosing function
+# instance to carry `#[oblivious]`. Integer width casts match sema's ungated treatment
+# of a secret `::` (a constant-time reshape, never a leak); float conversions are gated
+# on secrets at sema, so they are compute here for defense in depth. Classifying by the
+# transparent set (not the compute set) is fail-closed: a newly added opcode is treated
+# as a compute until explicitly listed here.
+# ---
+# k:   an opcode
+# ret: true when a secret-tainted instance of `k` only moves/reshapes the secret
+pub fun op_is_secret_move(k: InstrKind) bool {
+    if (k == OP_LOAD)        { ret true; }
+    if (k == OP_STORE)       { ret true; }
+    if (k == OP_ALLOCA)      { ret true; }
+    if (k == OP_GEP)         { ret true; }
+    if (k == OP_EXTRACT)     { ret true; }
+    if (k == OP_INSERT)      { ret true; }
+    if (k == OP_PHI)         { ret true; }
+    if (k == OP_CALL)        { ret true; }
+    if (k == OP_RET)         { ret true; }
+    if (k == OP_MEMZERO)     { ret true; }
+    if (k == OP_BR)          { ret true; }
+    if (k == OP_CBR)         { ret true; }
+    if (k == OP_UNREACHABLE) { ret true; }
+    if (k == OP_ASM)         { ret true; }
+    if (k == OP_DBG_VALUE)   { ret true; }
+    if (k == OP_DECLASSIFY)  { ret true; }
+    if (k == OP_TRUNC)       { ret true; }
+    if (k == OP_SEXT)        { ret true; }
+    if (k == OP_ZEXT)        { ret true; }
+    if (k == OP_BITCAST)     { ret true; }
+    ret false;
+}
+
 # mark the SSA definition a value names as carrying secret data (#1646)
 #
 # The one place the "a secret value's defining instruction carries the taint" idiom
@@ -315,5 +358,41 @@ test "mach.lang.me.ir.instruction.is_pure" {
     if (is_pure(OP_ASM))     { ret 1; }
     if (is_pure(OP_PHI))     { ret 1; }
     if (is_pure(OP_BR))      { ret 1; }
+    ret 0;
+}
+
+# the secrecy-transparency partition (#2136): every relocation / whole-value / reshape
+# opcode is a move (oblivious-vacuous), while every ALU/FPU op that derives a new value
+# from a secret operand is a compute that requires `#[oblivious]`
+test "mach.lang.me.ir.instruction.op_is_secret_move" {
+    # relocations, whole-value ops, width reshapes, and the declassify barrier only move.
+    if (!op_is_secret_move(OP_LOAD))       { ret 1; }
+    if (!op_is_secret_move(OP_STORE))      { ret 1; }
+    if (!op_is_secret_move(OP_GEP))        { ret 1; }
+    if (!op_is_secret_move(OP_EXTRACT))    { ret 1; }
+    if (!op_is_secret_move(OP_INSERT))     { ret 1; }
+    if (!op_is_secret_move(OP_PHI))        { ret 1; }
+    if (!op_is_secret_move(OP_CALL))       { ret 1; }
+    if (!op_is_secret_move(OP_RET))        { ret 1; }
+    if (!op_is_secret_move(OP_MEMZERO))    { ret 1; }
+    if (!op_is_secret_move(OP_DECLASSIFY)) { ret 1; }
+    if (!op_is_secret_move(OP_TRUNC))      { ret 1; }
+    if (!op_is_secret_move(OP_SEXT))       { ret 1; }
+    if (!op_is_secret_move(OP_ZEXT))       { ret 1; }
+    if (!op_is_secret_move(OP_BITCAST))    { ret 1; }
+
+    # arithmetic, bitwise, shift, comparison, and negation compute on the secret.
+    if (op_is_secret_move(OP_ADD))    { ret 1; }
+    if (op_is_secret_move(OP_SUB))    { ret 1; }
+    if (op_is_secret_move(OP_MUL))    { ret 1; }
+    if (op_is_secret_move(OP_AND))    { ret 1; }
+    if (op_is_secret_move(OP_OR))     { ret 1; }
+    if (op_is_secret_move(OP_XOR))    { ret 1; }
+    if (op_is_secret_move(OP_NOT))    { ret 1; }
+    if (op_is_secret_move(OP_NEG))    { ret 1; }
+    if (op_is_secret_move(OP_SHL))    { ret 1; }
+    if (op_is_secret_move(OP_SHR_U))  { ret 1; }
+    if (op_is_secret_move(OP_CMP_EQ)) { ret 1; }
+    if (op_is_secret_move(OP_CMP_LT_S)) { ret 1; }
     ret 0;
 }

--- a/src/lang/me/lower/decl.mach
+++ b/src/lang/me/lower/decl.mach
@@ -413,7 +413,13 @@ fun lower_weak_instance(ctx: *context.LowerContext, did: id.DeclId, d: *decl.Dec
     if (R.is_err[ir_type.IrTypeId, str](res_ret_ir)) { ret R.err[bool, str](R.unwrap_err[ir_type.IrTypeId, str](res_ret_ir)); }
     val ret_ir: ir_type.IrTypeId = R.unwrap_ok[ir_type.IrTypeId, str](res_ret_ir);
 
-    val flags: u32 = ir.FN_FLAG_PUB | ir.FN_FLAG_WEAK;
+    # a generic instance inherits the template's `#[oblivious]` constant-time contract
+    # (#2157): every instantiation of an oblivious generic is oblivious, so the
+    # per-instance `#[oblivious]`-required check (#2136) is satisfied and codegen honours
+    # the contract. Inert on a secret-free instance (the flag only gates secret-tainted
+    # codegen), so it does not perturb non-secret generics.
+    var flags: u32 = ir.FN_FLAG_PUB | ir.FN_FLAG_WEAK;
+    if (decl_has_decorator(ctx, d, "oblivious")) { flags = flags | ir.FN_FLAG_OBLIVIOUS; }
     val res_idx: R.Result[u32, str] = append_function(ctx, name, sig, flags, d.data.fun_.params_len);
     if (R.is_err[u32, str](res_idx)) { ret R.err[bool, str](R.unwrap_err[u32, str](res_idx)); }
     val fn_index: u32 = R.unwrap_ok[u32, str](res_idx);

--- a/src/lang/me/lower/expr.mach
+++ b/src/lang/me/lower/expr.mach
@@ -125,7 +125,14 @@ fun lower_rvalue_kind(ctx: *context.LowerContext, eid: id.ExprId, e: *expr.Expr)
 # v:   the produced value
 # ret: `v` with its secrecy taint set from sema's flow typing
 fun stamp_secret(ctx: *context.LowerContext, eid: id.ExprId, v: value.Value) value.Value {
-    val sec: bool = context.expr_is_secret(ctx, eid);
+    var sec: bool = context.expr_is_secret(ctx, eid);
+    # operand-derived taint for a comparison (#2157): its `u8` result secrecy was join'd
+    # by sema at generic-template time over the opaque parameter, so the recorded result
+    # type is frozen public for a `==` / `!=` / ordering compare on a generic `T`. When
+    # the recorded taint is public, recover it from the operands (whose parameter-typed
+    # exprs substitute to the concrete instance type). Redundant for a concrete secret
+    # comparison (already secret) and inert for secret-free code.
+    if (!sec) { sec = compare_operand_secret(ctx, eid); }
     var out: value.Value = v;
     out.secret = sec;
     if (sec) {
@@ -133,6 +140,27 @@ fun stamp_secret(ctx: *context.LowerContext, eid: id.ExprId, v: value.Value) val
         instruction.mark_result_secret(fn.instrs, fn.instr_len, v);
     }
     ret out;
+}
+
+# whether `eid` is a comparison whose operand secrecy makes the result secret (#2157)
+#
+# The one operand-derived correction to the recorded-type taint: sema freezes a
+# comparison's `u8` result secrecy at generic-template time, so a `==` / `!=` / ordering
+# compare on a generic `T` records a public result even at a secret instantiation. The
+# operands substitute correctly, so the result is secret iff either operand is. Not a
+# branch or index (those are rejected at sema, #2157) - only a legal secret mask, which
+# the `#[oblivious]`-required check then flags.
+# ---
+# ctx: per-module lowering context (its active substitution types the operands)
+# eid: the candidate expression
+# ret: true when `eid` is a comparison with a secret operand at this instance
+fun compare_operand_secret(ctx: *context.LowerContext, eid: id.ExprId) bool {
+    val e_opt: O.Option[*expr.Expr] = ast.get_expr(ctx.a, eid);
+    if (O.is_none[*expr.Expr](e_opt)) { ret false; }
+    val e: *expr.Expr = O.unwrap[*expr.Expr](e_opt);
+    if (e.kind != expr.EXPR_KIND_BINARY)     { ret false; }
+    if (!is_compare_binop(e.data.binary.op)) { ret false; }
+    ret context.expr_is_secret(ctx, e.data.binary.lhs) || context.expr_is_secret(ctx, e.data.binary.rhs);
 }
 
 # lower an assignable expression to its lvalue: a pointer to the storage it names


### PR DESCRIPTION
Closes #2136. Closes #2157. Part of the constant-time epic #1643 (builds on #1646).

Folds the `#[oblivious]`-required check (#2136) together with the upstream generic-secrecy fix (#2157) an adversarial review of this PR uncovered, since #2136's soundness depends on it.

## #2157 — per-instance constant-time re-validation of generic secrecy (the security fix)

`==`/`!=` is the one compute sema permits on an opaque generic `T` (`operands_ok = (lt==rt)||both_int`). Its `u8` result secrecy was join'd at generic-**template** time over the non-secret parameter, so a secret instantiation that branched / indexed / aggregate-compared through the result compiled **clean** — a proven CT false-negative shipped in #2137 (`cmp_branch[^u32]` emitted a real `cbr.eq` on secret operands). The monomorphization worklist + mangling also erase secrecy, collapsing `foo[^u32]` / `foo[u32]` to one lowered body, so no post-lowering analysis could see the secret instance.

**Fix (owner-approved, no ABI / mangling change)** — the owner's `^`-is-a-type-wrapper model: a generic operation on `T` behaves at each instantiation exactly as the concrete operation would.

- `infer_generic_call` records each instantiation `(origin, decl, concrete args)` to a worklist, keyed by the concrete type-args resolved **before** lowering's mangle collapse — so the secret instance is distinct from a public twin. Pruned to secret / aggregate args; deduped for termination.
- After all bodies are typed, the worklist drains: each instance body is re-inferred under its substitution into **scratch** typing arrays (the template arrays lowering reads stay intact → byte-identical), so `join_secret` over concrete operands, `check_condition` / `check_index`, `gate_ct_always`, and the #2127 aggregate-`==` rejection fire on the instance. Nested generic calls enqueue their own instances (the transitive case).
- Substitution injects at the sema type-source leaves (`resolved_type_of` / `resolve_type_ref` / `generic_param_type_for`) via a function pointer on `SemaContext`, breaking the `context`→`generics` import cycle.

Result: `cmp_branch[^u32]` is rejected with the **same diagnostic** as the concrete twin (`secret value used as a branch condition`); `eq[u32]` still compiles; the twin case rejects the secret one despite the symbol collapse; transitive forwarding rejects; a generic `==` at `T`=record is rejected (extends #2127 to generics).

## #2136 — the `#[oblivious]`-required check

Per-monomorphized-instance secrecy-transparency gate: a function instance that **computes** on a secret (arithmetic / bitwise / shift / comparison / negation) must carry `#[oblivious]`; a **transparent** instance that only moves / stores / declassifies secrets stays annotation-free. Runs over the freshly-lowered IR before optimization; predicate `instruction.op_is_secret_move`.

Two lowering changes make it correct for the generic case:
- **operand-derived comparison taint** (`stamp_secret`): recovers a comparison's frozen `==` result secrecy from its operands, so a **legal** secret comparison mask in a generic instance carries `Instruction.secret` and #2136 flags it;
- a generic instance now **inherits its template's `#[oblivious]` flag** (previously dropped), so annotating the template clears the check.

Both are inert on secret-free code.

## Verification

- Full suite **762/0** (new `generic_instance_ct_reinfer` covering: secret branch rejected same-diagnostic; public `eq[u32]` clean; twin rejected despite collapse; transitive rejected; aggregate-`==` rejected; a legal secret mask flagged by #2136; `#[oblivious]` clears it).
- **Byte-identical** for secret-free / non-generic-`==` code: this compiler and an independent no-change baseline compiler produce byte-identical output for the same base source. **Fixpoint B == C**.
- **mach-std 611/0** (no spurious re-validation on the generic-heavy stdlib). **int linux + rv64** green.

Security-critical (the CT primitive) — the per-instance gating is exhaustive across branch / index / div / float / aggregate-`==` and the transitive + twin-collapse cases.
