### PR TITLE
fix(codegen): unencodable asm mnemonic renders a located diagnostic, not a blank crash (#2153)

### DIFF
--- a/src/lang/be/codegen.mach
+++ b/src/lang/be/codegen.mach
@@ -152,7 +152,7 @@ pub fun codegen_module(s: *session.Session, tgt: *target.Target,
     if (tgt == nil)   { ret R.err[of.ObjectImage, str]("codegen: nil target"); }
     if (irmod == nil) { ret R.err[of.ObjectImage, str]("codegen: nil ir module"); }
 
-    val res_lower: R.Result[mir.MirModule, str] = lower.lower_ir(tgt, irmod, s.alloc, ?s.interner);
+    val res_lower: R.Result[mir.MirModule, str] = lower.lower_ir(tgt, irmod, s.alloc, ?s.interner, ?s.sources);
     if (R.is_err[mir.MirModule, str](res_lower)) {
         ret R.err[of.ObjectImage, str](R.unwrap_err[mir.MirModule, str](res_lower));
     }

--- a/src/lang/be/codegen/encode.mach
+++ b/src/lang/be/codegen/encode.mach
@@ -35,10 +35,12 @@ use std.types.bool.false;
 use std.types.bool.true;
 use std.types.size.usize;
 use std.types.string.str;
+use std.types.string.str_len;
 
 use std.allocator.page;
 
 use A: std.allocator;
+use O: std.types.option;
 use R: std.types.result;
 
 use mach.lang.be.codegen.mir;
@@ -475,6 +477,9 @@ rec BlockOffset {
 #                 fallthrough check never fires on a terminator with no successor
 # interner:    session interner; resolves inline-asm `{name}` binding names and
 #              interns symbol names referenced from inline asm into relocations
+# srcmap:      session source map, borrowed off the MIR module so an inline-asm
+#              diagnostic can name its statement's "path:line:col" (#2153); nil
+#              in unit-test states, degrading the location prefix away
 # abi:         target ABI vtable (frame / argument model the encode hook reads)
 # os:          target OS vtable (stack-probe / commit model the encode hook reads)
 pub rec EncodeState {
@@ -505,6 +510,7 @@ pub rec EncodeState {
     next_block_id:  u32;
     has_next_block: bool;
     interner:    *intern.Interner;
+    srcmap:      *source.SourceMap;
     abi:         *abi.AbiVTable;
     os:          *tos.OsVTable;
 }
@@ -1079,6 +1085,7 @@ fun state_init(st: *EncodeState, alloc: *A.Allocator, m: *mir.MirModule, tgt: *t
     st.next_block_id  = 0;
     st.has_next_block = false;
     st.interner    = m.interner;
+    st.srcmap      = m.srcmap;
     st.abi         = tgt.abi;
     st.os          = tgt.os;
 }
@@ -1453,6 +1460,76 @@ pub fun push_inline_pc(st: *EncodeState, text_offset: u32, inline_site: u32) R.R
     ret R.ok[bool, str](true);
 }
 
+# write `n` in decimal into `buf` starting at `at`, returning the next position
+fun put_decimal(buf: *u8, at: usize, n: usize) usize {
+    var digits: [20]u8;
+    var d: usize = 0;
+    var v: usize = n;
+    if (v == 0) { digits[0] = '0'::u8; d = 1; }
+    for (v > 0) {
+        digits[d] = (v % 10)::u8 + '0'::u8;
+        v = v / 10;
+        d = d + 1;
+    }
+    var k: usize = at;
+    for (d > 0) {
+        d = d - 1;
+        buf[k] = digits[d];
+        k = k + 1;
+    }
+    ret k;
+}
+
+# prefix an inline-asm diagnostic with its statement's source position
+#
+# Resolves `loc` through the state's source map to "path:line:col: <msg>",
+# interned into the session interner so the located message outlives the encode
+# (a parallel worker's message is additionally re-homed at the pool boundary).
+# Returns `msg` unchanged when the state carries no source map or interner (the
+# encoder unit tests' minimal states), the loc names no file (a synthetic MIR),
+# or building the prefixed text fails - the diagnostic itself is never lost.
+# ---
+# st:  the encode state (source map + interner)
+# loc: the erring instruction's source location
+# msg: the diagnostic text to prefix
+# ret: "path:line:col: <msg>" when resolvable, else `msg`
+pub fun asm_located_message(st: *EncodeState, loc: source.SrcLoc, msg: str) str {
+    if (st.srcmap == nil || st.interner == nil) { ret msg; }
+    if (!source.loc_is_valid(loc)) { ret msg; }
+    val fo: O.Option[*source.SourceFile] = source.get(st.srcmap, loc.file);
+    if (!O.is_some[*source.SourceFile](fo)) { ret msg; }
+    val file: *source.SourceFile = O.unwrap[*source.SourceFile](fo);
+    val pos: source.Position = source.position(file, loc.offset);
+
+    # "<path>:<line>:<col>: <msg>" - two u64s render in at most 20 digits each.
+    val lp: usize = str_len(file.path);
+    val lm: usize = str_len(msg);
+    val total_cap: usize = lp + 1 + 20 + 1 + 20 + 2 + lm + 1;
+    val rb: R.Result[*u8, str] = A.allocate[u8](st.alloc, total_cap);
+    if (R.is_err[*u8, str](rb)) { ret msg; }
+    val buf: *u8 = R.unwrap_ok[*u8, str](rb);
+
+    var k: usize = 0;
+    var j: usize = 0;
+    for (j < lp) { buf[k] = file.path[j]::u8; k = k + 1; j = j + 1; }
+    buf[k] = ':'::u8; k = k + 1;
+    k = put_decimal(buf, k, pos.line);
+    buf[k] = ':'::u8; k = k + 1;
+    k = put_decimal(buf, k, pos.col);
+    buf[k] = ':'::u8; k = k + 1;
+    buf[k] = ' '::u8; k = k + 1;
+    j = 0;
+    for (j < lm) { buf[k] = msg[j]::u8; k = k + 1; j = j + 1; }
+    buf[k] = 0;
+
+    val ir: R.Result[intern.StrId, str] = intern.intern(st.interner, buf::str);
+    A.deallocate[u8](st.alloc, buf, total_cap);
+    if (R.is_err[intern.StrId, str](ir)) { ret msg; }
+    val nm: O.Option[str] = intern.lookup(st.interner, R.unwrap_ok[intern.StrId, str](ir));
+    if (O.is_some[str](nm)) { ret O.unwrap[str](nm); }
+    ret msg;
+}
+
 # a minimal encode state for the row / varloc / insert_text unit tests: a text sink and
 # an empty set of mark / reloc / fixup / block / row / varloc arrays, no interner or
 # vtables
@@ -1466,7 +1543,7 @@ fun t_row_state(alloc: *A.Allocator, st: *EncodeState) {
     st.rows = nil;   st.row_count = 0;   st.row_cap = 0;
     st.varlocs = nil; st.varloc_count = 0; st.varloc_cap = 0;
     st.inline_pcs = nil; st.inline_pc_count = 0; st.inline_pc_cap = 0;
-    st.interner = nil; st.abi = nil; st.os = nil;
+    st.interner = nil; st.srcmap = nil; st.abi = nil; st.os = nil;
 }
 
 # push_row drops a location naming no file, and insert_text (branch relaxation)

--- a/src/lang/be/codegen/mir.mach
+++ b/src/lang/be/codegen/mir.mach
@@ -766,12 +766,17 @@ pub rec MirFunction {
 # interner:     the session interner, threaded through so the encoder can resolve
 #               interned strings (inline-asm bodies) and intern new symbol names
 #               referenced from inline asm into relocations
+# srcmap:       the session source map, borrowed read-only so the encoder can
+#               resolve an instruction's SrcLoc to "path:line:col" in a
+#               diagnostic (#2153); nil in unit-test states, degrading the
+#               location prefix away
 # functions:    MIR functions, parallel to the source IR module's functions (owned)
 # function_len: number of functions
 # function_cap: allocated capacity for functions
 pub rec MirModule {
     alloc:        *A.Allocator;
     interner:     *intern.Interner;
+    srcmap:       *source.SourceMap;
     functions:    *MirFunction;
     function_len: u32;
     function_cap: u32;

--- a/src/lang/be/codegen/mir/lower.mach
+++ b/src/lang/be/codegen/mir/lower.mach
@@ -100,9 +100,11 @@ use target: mach.lang.target.resolved;
 #           passes a private arena, the serial path the session allocator
 # interner: session interner, recorded on the MIR module so the encoder can
 #           resolve interned strings and intern inline-asm symbol references
+# srcmap:   session source map, borrowed read-only onto the MIR module so encode
+#           diagnostics can name "path:line:col" (#2153)
 # ret:      a populated mir.MirModule (owned, release with `mir.dnit_module`), or
 #           an allocation / lowering error
-pub fun lower_ir(tgt: *target.Target, m: *ir.Module, alloc: *A.Allocator, interner: *intern.Interner) R.Result[mir.MirModule, str] {
+pub fun lower_ir(tgt: *target.Target, m: *ir.Module, alloc: *A.Allocator, interner: *intern.Interner, srcmap: *source.SourceMap) R.Result[mir.MirModule, str] {
     if (tgt == nil || m == nil) {
         ret R.err[mir.MirModule, str]("mir.lower_ir: nil target or module");
     }
@@ -114,6 +116,7 @@ pub fun lower_ir(tgt: *target.Target, m: *ir.Module, alloc: *A.Allocator, intern
     var mm: mir.MirModule;
     mm.alloc        = alloc;
     mm.interner     = interner;
+    mm.srcmap       = srcmap;
     mm.functions    = nil;
     mm.function_len = 0;
     mm.function_cap = 0;

--- a/src/lang/build/engine.mach
+++ b/src/lang/build/engine.mach
@@ -1090,6 +1090,27 @@ fun pcg_worker_teardown(w: *PcgWorker) {
     w.active = false;
 }
 
+# re-home a worker-reported error message onto the session interner
+#
+# A worker's diagnostic may be interned in its child interner (the per-mnemonic /
+# per-function messages the encoders build), whose backing arena the worker
+# teardown frees - so the message must be copied onto session-owned storage
+# before it can outlive the pool (#2153). A static-literal message re-interns
+# harmlessly. Degrades to a static message when interning itself fails, so an
+# allocation failure cannot lose the failure report.
+# ---
+# p:   the active project (its session interner outlives the failure render)
+# msg: the worker's error message, possibly backed by worker storage
+# ret: the same text on session-owned storage
+fun pcg_stable_err(p: *driver.Project, msg: str) str {
+    val ir: R.Result[intern.StrId, str] = intern.intern(?p.s.interner, msg);
+    if (R.is_ok[intern.StrId, str](ir)) {
+        val nm: O.Option[str] = intern.lookup(?p.s.interner, R.unwrap_ok[intern.StrId, str](ir));
+        if (O.is_some[str](nm)) { ret O.unwrap[str](nm); }
+    }
+    ret "parallel codegen failed, and re-homing its diagnostic off the worker arena failed in turn (allocation failure)";
+}
+
 # the worker thread body: claim a worker index, then drain stale modules from the
 # shared cursor, codegen each into this worker's arena, and record it in its slot
 #
@@ -1280,10 +1301,12 @@ fun run_codegen_parallel(p: *driver.Project) R.Result[bool, str] {
     }
 
     # first error in topo order wins - deterministic regardless of which worker hit it.
+    # the message is re-homed BEFORE the teardown below frees the child arena that
+    # may back it (#2153: returning it as-is rendered freed memory).
     var ei: u32 = 0;
     for (ei < stale_len) {
         if (slots[ei].err != nil) {
-            val msg: str = slots[ei].err;
+            val msg: str = pcg_stable_err(p, slots[ei].err);
             var wk: u32 = 0;
             for (wk < nworkers) { pcg_worker_teardown(?workers[wk]); wk = wk + 1; }
             A.deallocate[PcgWorker](p.alloc, workers, nworkers::usize);

--- a/src/lang/driver/tests.mach
+++ b/src/lang/driver/tests.mach
@@ -5132,3 +5132,82 @@ test "mach.lang.build.engine.execute_warm:unit_failure_renders_before_teardown" 
     session.dnit(?s);
     ret bad;
 }
+
+# an unencodable inline-asm mnemonic is rejected with a diagnostic that names the
+# mnemonic and the asm statement's "path:line:col" - never the pre-#2153 blank.
+# the serial codegen pass (the session-interned message path); the comptime arms
+# select the host-arch ISA tag, and `frobnicate` is a mnemonic no ISA encodes
+test "mach.lang.driver:inline_asm_unknown_mnemonic_located" {
+    var bad: i32 = 0;
+    val src: str = "#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 {\n    $if ($mach.build.arch == $mach.arch.x86_64) { asm x86_64 { frobnicate } }\n    $or ($mach.build.arch == $mach.arch.aarch64) { asm aarch64 { frobnicate } }\n    $or { asm riscv64 { frobnicate } }\n    ret 0;\n}\n";
+    # the mnemonic is named and the location prefix carries the source path.
+    if (ut_codegen_rejects(src, "'frobnicate'") != 0) { bad = 1; }
+    if (ut_codegen_rejects(src, "main.mach:") != 0)   { bad = 1; }
+    # on the primary arch, pin the full located message: line 3 column 5 (the `asm`
+    # keyword of the statement), exact text.
+    $if ($mach.build.arch == $mach.arch.x86_64) {
+        if (ut_codegen_rejects("#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 {\n    asm x86_64 { frobnicate }\n    ret 0;\n}\n",
+            "main.mach:3:5: unknown x86_64 inline-asm instruction 'frobnicate'") != 0) { bad = 1; }
+    }
+    ret bad;
+}
+
+# the parallel-codegen pool must deliver a worker's encode diagnostic INTACT: the
+# message is built in the erring worker's child interner, whose arena the pool tears
+# down before the failure renders - pre-fix the render read freed memory and printed
+# a blank `error: ` (#2153). four stale modules + jobs=2 engage the pool; the bad
+# asm rides module c so a worker (not the serial path) hits it
+test "mach.lang.build.engine.execute_warm:pool_error_message_survives_teardown" {
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    val sr: R.Result[session.Session, str] = session.init(?alloc);
+    if (R.is_err[session.Session, str](sr)) { ret 1; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](sr);
+    if (R.is_err[bool, str](driver.setup_registry(?s.registry))) { session.dnit(?s); ret 1; }
+
+    var names: [4]str;
+    names[0] = "main.mach"; names[1] = "a.mach"; names[2] = "b.mach"; names[3] = "c.mach";
+    var texts: [4]str;
+    texts[0] = ut_cc3(?alloc, "use uniontest.a.fa;\nuse uniontest.b.fb;\nuse uniontest.c.fc;\n#[symbol(\"", ut_entry_symbol(), "\")]\nfun start() i32 { ret fa() + fb() + fc(); }\n");
+    texts[1] = "pub fun fa() i32 { ret 1; }\n";
+    texts[2] = "pub fun fb() i32 { ret 2; }\n";
+    texts[3] = "pub fun fc() i32 {\n    $if ($mach.build.arch == $mach.arch.x86_64) { asm x86_64 { frobnicate } }\n    $or ($mach.build.arch == $mach.arch.aarch64) { asm aarch64 { frobnicate } }\n    $or { asm riscv64 { frobnicate } }\n    ret 3;\n}\n";
+    val root_r: R.Result[str, str] = ut_scaffold(?alloc, ?names[0], ?texts[0], 4);
+    if (R.is_err[str, str](root_r)) { session.dnit(?s); ret 1; }
+    val root: str = R.unwrap_ok[str, str](root_r);
+
+    val mr: R.Result[manifest.Manifest, str] = driver.load_manifest(?s, root);
+    if (R.is_err[manifest.Manifest, str](mr)) { fs.remove_all(?alloc, root); session.dnit(?s); ret 1; }
+    var m: manifest.Manifest = R.unwrap_ok[manifest.Manifest, str](mr);
+    var rq: request.BuildRequest = request.defaults();
+    rq.project_root = root;
+    rq.jobs         = 2;
+    val pr: R.Result[bplan.BuildPlan, outcome.Fail] = bplan.plan(?alloc, ?s.interner, ?s.registry, ?m, ?rq);
+    if (R.is_err[bplan.BuildPlan, outcome.Fail](pr)) { fs.remove_all(?alloc, root); session.dnit(?s); ret 1; }
+    var bp: bplan.BuildPlan = R.unwrap_ok[bplan.BuildPlan, outcome.Fail](pr);
+
+    var cap: UtFailCap;
+    cap.alloc = ?alloc;
+    cap.msg   = "";
+    cap.fails = 0;
+    var rd: outcome.Render;
+    rd.ctx      = (?cap)::ptr;
+    rd.fn_unit  = ut_cap_unit;
+    rd.fn_note  = ut_cap_note;
+    rd.fn_fail  = ut_cap_fail;
+    rd.fn_diags = ut_cap_diags;
+
+    var bad: i32 = 0;
+    val r: R.Result[outcome.BuildOutcome, outcome.Fail] = bengine.execute_warm(?bp, 0, ?s, ?alloc, nil, ?rd);
+    if (R.is_err[outcome.BuildOutcome, outcome.Fail](r)) { bad = 1; }
+    or {
+        if (R.unwrap_ok[outcome.BuildOutcome, outcome.Fail](r).ok) { bad = 1; }
+    }
+    if (cap.fails != 1) { bad = 1; }
+    if (!ut_str_contains(cap.msg, "'frobnicate'")) { bad = 1; }
+    if (!ut_str_contains(cap.msg, "c.mach:"))      { bad = 1; }
+
+    fs.remove_all(?alloc, root);
+    session.dnit(?s);
+    ret bad;
+}

--- a/src/lang/target/isa/arm64/encode.mach
+++ b/src/lang/target/isa/arm64/encode.mach
@@ -4040,16 +4040,19 @@ fun encode_asm_text_arm64(st: *encode.EncodeState, f: *mir.MirFunction, fn_base:
 # expand an inline-asm MIR_ASM instruction into A64 bytes.
 # substitutes `{name}` locals to `[x29, #off]`, encodes each statement, and verifies
 # every forward local-label reference was defined within the block. the A64 analogue
-# of x86-64's `encode_asm_block`
+# of x86-64's `encode_asm_block`; a rejection is located at the asm statement's
+# "path:line:col" through the instruction's stamped loc (#2153)
 fun encode_asm_block_arm64(st: *encode.EncodeState, f: *mir.MirFunction, fn_base: u32, mi: *mir.MirInstr) R.Result[bool, str] {
     if (mi.asm_block == nil) { ret R.err[bool, str]("encode: MIR_ASM has no payload"); }
     val pl: *mir.MirAsm = mi.asm_block;
     if (!str_equals(pl.isa, "aarch64")) {
-        ret R.err[bool, str]("encode: inline-asm block is not aarch64");
+        ret R.err[bool, str](encode.asm_located_message(st, mi.loc, "encode: inline-asm block is not aarch64"));
     }
 
     val sr: R.Result[str, str] = substitute_asm_locals_arm64(st.alloc, st.interner, f, pl);
-    if (R.is_err[str, str](sr)) { ret R.err[bool, str](R.unwrap_err[str, str](sr)); }
+    if (R.is_err[str, str](sr)) {
+        ret R.err[bool, str](encode.asm_located_message(st, mi.loc, R.unwrap_err[str, str](sr)));
+    }
     val text: str = R.unwrap_ok[str, str](sr);
 
     var labels: AsmLabels;
@@ -4058,11 +4061,11 @@ fun encode_asm_block_arm64(st: *encode.EncodeState, f: *mir.MirFunction, fn_base
     A.deallocate[u8](st.alloc, text::*u8, (str_len(text) + 1)::usize);
     if (R.is_err[bool, str](er)) {
         asm_labels_dnit(?labels);
-        ret er;
+        ret R.err[bool, str](encode.asm_located_message(st, mi.loc, R.unwrap_err[bool, str](er)));
     }
     if (labels.ref_count > 0) {
         asm_labels_dnit(?labels);
-        ret R.err[bool, str]("encode: inline-asm forward reference to a local label has no definition in this asm block");
+        ret R.err[bool, str](encode.asm_located_message(st, mi.loc, "encode: inline-asm forward reference to a local label has no definition in this asm block"));
     }
     asm_labels_dnit(?labels);
     ret R.ok[bool, str](true);

--- a/src/lang/target/isa/riscv64/encode.mach
+++ b/src/lang/target/isa/riscv64/encode.mach
@@ -3539,16 +3539,19 @@ fun encode_asm_text_riscv64(st: *encode.EncodeState, f: *mir.MirFunction, fn_bas
 # expand an inline-asm MIR_ASM instruction into RV64 bytes. substitutes `{name}`
 # locals to `off(s0)`, encodes each statement, and verifies every forward local-label
 # reference was defined within the block. the RV64 analogue of x86-64's
-# `encode_asm_block`
+# `encode_asm_block`; a rejection is located at the asm statement's "path:line:col"
+# through the instruction's stamped loc (#2153)
 fun encode_asm_block_riscv64(st: *encode.EncodeState, f: *mir.MirFunction, fn_base: u32, mi: *mir.MirInstr) R.Result[bool, str] {
     if (mi.asm_block == nil) { ret R.err[bool, str]("encode: MIR_ASM has no payload"); }
     val pl: *mir.MirAsm = mi.asm_block;
     if (!str_equals(pl.isa, "riscv64")) {
-        ret R.err[bool, str]("encode: inline-asm block is not riscv64");
+        ret R.err[bool, str](encode.asm_located_message(st, mi.loc, "encode: inline-asm block is not riscv64"));
     }
 
     val sr: R.Result[str, str] = substitute_asm_locals_riscv64(st.alloc, st.interner, f, pl);
-    if (R.is_err[str, str](sr)) { ret R.err[bool, str](R.unwrap_err[str, str](sr)); }
+    if (R.is_err[str, str](sr)) {
+        ret R.err[bool, str](encode.asm_located_message(st, mi.loc, R.unwrap_err[str, str](sr)));
+    }
     val text: str = R.unwrap_ok[str, str](sr);
 
     var labels: RvLabels;
@@ -3557,11 +3560,11 @@ fun encode_asm_block_riscv64(st: *encode.EncodeState, f: *mir.MirFunction, fn_ba
     A.deallocate[u8](st.alloc, text::*u8, (str_len(text) + 1)::usize);
     if (R.is_err[bool, str](er)) {
         rv_labels_dnit(?labels);
-        ret er;
+        ret R.err[bool, str](encode.asm_located_message(st, mi.loc, R.unwrap_err[bool, str](er)));
     }
     if (labels.ref_count > 0) {
         rv_labels_dnit(?labels);
-        ret R.err[bool, str]("encode: inline-asm forward reference to a local label has no definition in this asm block");
+        ret R.err[bool, str](encode.asm_located_message(st, mi.loc, "encode: inline-asm forward reference to a local label has no definition in this asm block"));
     }
     rv_labels_dnit(?labels);
     ret R.ok[bool, str](true);

--- a/src/lang/target/isa/x64/encode.mach
+++ b/src/lang/target/isa/x64/encode.mach
@@ -4973,7 +4973,8 @@ fun asm_label_error(st: *enc.EncodeState, prefix: str, number: u64, suffix: str,
 # cmach's
 # `masm_x86_parse_inline_asm`. a `call` / `jmp` / bare-symbol operand records a
 # PC32 relocation against the named symbol. an unknown mnemonic or malformed
-# operand is a hard error rather than silently dropped.
+# operand is a hard error rather than silently dropped, located at the asm
+# statement's "path:line:col" through the instruction's stamped loc (#2153).
 fun encode_asm_block(st: *enc.EncodeState, f: *mir.MirFunction, fn_base: u32, mi: *mir.MirInstr) R.Result[bool, str] {
     if (mi.asm_block == nil) { ret R.err[bool, str]("encode: MIR_ASM has no payload"); }
     val pl: *mir.MirAsm = mi.asm_block;
@@ -4981,11 +4982,13 @@ fun encode_asm_block(st: *enc.EncodeState, f: *mir.MirFunction, fn_base: u32, mi
     # only the x86_64 ISA tag is encodable here; a mismatched tag means a
     # comptime arch guard failed to select the right block.
     if (!str_equals(pl.isa, "x86_64")) {
-        ret R.err[bool, str]("encode: inline-asm block is not x86_64");
+        ret R.err[bool, str](enc.asm_located_message(st, mi.loc, "encode: inline-asm block is not x86_64"));
     }
 
     val sr: R.Result[str, str] = substitute_asm_locals(st.alloc, st.interner, f, pl);
-    if (R.is_err[str, str](sr)) { ret R.err[bool, str](R.unwrap_err[str, str](sr)); }
+    if (R.is_err[str, str](sr)) {
+        ret R.err[bool, str](enc.asm_located_message(st, mi.loc, R.unwrap_err[str, str](sr)));
+    }
     val text: str = R.unwrap_ok[str, str](sr);
 
     # numeric local labels are scoped to this block; their definitions and
@@ -4996,7 +4999,7 @@ fun encode_asm_block(st: *enc.EncodeState, f: *mir.MirFunction, fn_base: u32, mi
     A.deallocate[u8](st.alloc, text::*u8, (str_len(text) + 1)::usize);
     if (R.is_err[bool, str](er)) {
         asm_labels_dnit(?labels);
-        ret er;
+        ret R.err[bool, str](enc.asm_located_message(st, mi.loc, R.unwrap_err[bool, str](er)));
     }
 
     # a forward reference whose label was never defined in the block is a hard
@@ -5007,7 +5010,7 @@ fun encode_asm_block(st: *enc.EncodeState, f: *mir.MirFunction, fn_base: u32, mi
             "f' has no definition in this asm block",
             "encode: inline-asm forward reference to a local label has no definition in this asm block");
         asm_labels_dnit(?labels);
-        ret R.err[bool, str](msg);
+        ret R.err[bool, str](enc.asm_located_message(st, mi.loc, msg));
     }
     asm_labels_dnit(?labels);
     ret R.ok[bool, str](true);


### PR DESCRIPTION
Closes #2153.

## Root cause — not a missing message, a use-after-free at the pool boundary

The unknown-mnemonic message was never blank at its source: the x64 encoder has always produced `unknown x86_64 inline-asm instruction 'rdtsc'`. It is built by `enc_named_message`, which interns the text "so the diagnostic outlives this call" — into the **worker's child interner** when codegen runs under the parallel pool (`jobs >= 1`, which is every cold CLI build). `run_codegen_parallel` then captured the message pointer and called `pcg_worker_teardown` — freeing the child arena that backs it — **before** returning the error. The renderer printed `error: ` and segfaulted reading the freed message (exit 139). Every dynamically-built worker diagnostic (per-mnemonic, per-function, asm-label errors, on all three ISAs) hit this path; static-literal messages live in the compiler's rodata and rendered fine, which is why the class went unnoticed.

## Fix

1. **`fix(engine)`** — the class fix: re-home the first worker error into the session interner (`pcg_stable_err`) before any worker teardown, mirroring how `pcg_collect` already re-homes images. One boundary change cures every worker-storage message.
2. **`fix(encode)`** — the diagnostic-quality half of the issue: thread the session source map (read-only) through `lower_ir` → `MirModule` → `EncodeState`, and wrap every error leaving the three per-ISA `encode_asm_block*` chokepoints with the asm statement's resolved position (`asm_located_message`, shared in `encode.mach`). The result:

```
error: ./src/main.mach:7:5: unknown x86_64 inline-asm instruction 'rdtsc'
```

Same shape on aarch64/riscv64 (`unsupported aarch64 inline-asm mnemonic 'frobnicate'`, etc.) and for the whole asm reject path (malformed operands, undefined local labels, ISA-tag mismatch) — one chokepoint per ISA locates them all. Unit-test-built `EncodeState`s carry a nil map and degrade the prefix away (mach zero-inits locals, so this is well-defined).

No rdtsc encoding was added — out of scope per the issue.

## Audit results

- The only genuinely empty `R.err("")` returns are in `me/lower` (`report_asm`/`report_expr`): the **located-diagnostic sentinel** pattern — a diagnostic is pushed to the session sink first and `lower_fail` maps the empty error to `outcome.reported()`. Correct as designed, untouched.
- The unbound-`{name}` asm case is already caught at lower time with a full span diagnostic; the encode-stage rejects (mnemonic, labels, operands) were the unlocated ones and are now all prefixed.

## Tests

- `mach.lang.driver:inline_asm_unknown_mnemonic_located` — full-pipeline reject with the mnemonic named and the position prefixed (host-arch comptime arms, runs on all CI ISAs); the x86_64 lane pins the exact `main.mach:3:5: unknown x86_64 inline-asm instruction 'frobnicate'`.
- `mach.lang.build.engine.execute_warm:pool_error_message_survives_teardown` — jobs=2 over four stale modules drives the bad asm through a **worker**; the render-captured message must contain `'frobnicate'` and `c.mach:`. Pre-fix this read freed worker-arena memory.

## Verification

- **Byte-identical**: base (52ed3030) and fixed compiler compiled the identical base source tree → `cmp` byte-identical (diagnostic-only change, no codegen effect).
- **Fixpoint**: fix-built B compiled the tree again → C; `B == C` byte-identical.
- **Suite**: 761 passed, 0 failed (baseline 759; delta = exactly the two new tests).
- **int linux**: all cases pass. **int linux-riscv64** (local qemu-user): all cases pass. (One earlier local run tripped the known pre-existing 1852 nondeterminism under qemu 11 — unrelated to this branch; the rerun is fully green.)
- Cross-target manual proof on all three ISAs: unknown mnemonic, undefined forward label, ISA mismatch all render located messages, exit 1, no crash.
