### PR TITLE
fix(sema): reject a secret value passed to a variadic pack (#2162)

### DIFF
--- a/src/lang/driver/tests.mach
+++ b/src/lang/driver/tests.mach
@@ -4821,6 +4821,17 @@ test "mach.lang.driver:secret_variadic_rejected" {
 
     # a PUBLIC record (no `^` anywhere in its field graph) is NOT over-rejected.
     if (!ut_sema_clean("fun logf(va: ...) u32 { ret 0; }\nrec Q { x: u32; y: u32; }\nfun f(a: Q) u32 { ret logf(a); }\nfun main() i32 { ret 0; }\n")) { bad = 1; }
+
+    # a GENERIC INSTANCE wrapping a secret is rejected regardless of whether its field
+    # table was materialized before the check (a bare local never accessed, and a call
+    # RESULT, both reach the boundary un-elaborated) - the deep walk materializes the
+    # instance's fields itself. Nested instances too; a public instance is not
+    # over-rejected (via call result and bare local).
+    if (!ut_sema_rejects("fun logf(va: ...) u32 { ret 0; }\nrec Box[T] { v: T; }\nfun mk[T](x: T) Box[T] { var b: Box[T]; b.v = x; ret b; }\nfun f(s: ^u32) u32 { ret logf(mk[^u32](s)); }\nfun main() i32 { ret 0; }\n")) { bad = 1; }
+    if (!ut_sema_rejects("fun logf(va: ...) u32 { ret 0; }\nrec Box[T] { v: T; }\nfun f(s: ^u32) u32 { var b: Box[^u32]; ret logf(b); }\nfun main() i32 { ret 0; }\n")) { bad = 1; }
+    if (!ut_sema_rejects("fun logf(va: ...) u32 { ret 0; }\nrec Box[T] { v: T; }\nfun f(s: ^u32) u32 { var b: Box[Box[^u32]]; ret logf(b); }\nfun main() i32 { ret 0; }\n")) { bad = 1; }
+    if (!ut_sema_clean("fun logf(va: ...) u32 { ret 0; }\nrec Box[T] { v: T; }\nfun mk[T](x: T) Box[T] { var b: Box[T]; b.v = x; ret b; }\nfun f() u32 { ret logf(mk[u32](5)); }\nfun main() i32 { ret 0; }\n")) { bad = 1; }
+    if (!ut_sema_clean("fun logf(va: ...) u32 { ret 0; }\nrec Box[T] { v: T; }\nfun f() u32 { var b: Box[u32]; ret logf(b); }\nfun main() i32 { ret 0; }\n")) { bad = 1; }
     # a self-referential record with a secret field terminates the deep walk and rejects;
     # the same shape without a secret is clean (the cycle guard does not over-report).
     if (!ut_sema_rejects("fun logf(va: ...) u32 { ret 0; }\nrec N { next: *N; s: ^u32; }\nfun f(a: N) u32 { ret logf(a); }\nfun main() i32 { ret 0; }\n")) { bad = 1; }

--- a/src/lang/driver/tests.mach
+++ b/src/lang/driver/tests.mach
@@ -4790,6 +4790,34 @@ test "mach.lang.driver:generic_instance_ct_reinfer" {
     ret bad;
 }
 
+# constant-time (#2162): a secret value cannot enter a `...` variadic pack. A pack's
+# monomorphized instance name erases secrecy (`^u32` and `u32` collapse to one emitted
+# body), so a secret argument would silently reuse a public instance and be observed
+# (formatted / logged / printed) with no `:^` - an undeclassified disclosure. The gate is
+# GENERAL (any variadic, not a print special-case); a `:^` argument, a public argument,
+# and a secret bound to a FIXED parameter are all unaffected
+test "mach.lang.driver:secret_variadic_rejected" {
+    var bad: i32 = 0;
+
+    # a secret into a user variadic is rejected with the teaching diagnostic.
+    val sec: str = "fun logf(va: ...) u32 { ret 0; }\nfun f(a: ^u32) u32 { ret logf(a); }\nfun main() i32 { ret 0; }\n";
+    if (!ut_sema_rejects(sec)) { bad = 1; }
+    if (ut_vec_diag(sec, "secret value cannot be passed to a variadic") != 0) { bad = 1; }
+
+    # a declassified secret is accepted (the fix path).
+    if (!ut_sema_clean("fun logf(va: ...) u32 { ret 0; }\nfun f(a: ^u32) u32 { ret logf(a:^); }\nfun main() i32 { ret 0; }\n")) { bad = 1; }
+    # a public argument is unaffected (no over-rejection).
+    if (!ut_sema_clean("fun logf(va: ...) u32 { ret 0; }\nfun f(a: u32) u32 { ret logf(a); }\nfun main() i32 { ret 0; }\n")) { bad = 1; }
+    # a secret-carrying arg (a secret-welded pointer, which the pack collapse would erase
+    # to a public pointer) is also rejected - any `^` in the argument type.
+    if (!ut_sema_rejects("fun logf(va: ...) u32 { ret 0; }\nfun f(a: *^u8) u32 { ret logf(a); }\nfun main() i32 { ret 0; }\n")) { bad = 1; }
+
+    # a secret bound to a FIXED (non-variadic) parameter is governed by ordinary
+    # assignability, not this gate - so a secret->secret fixed call stays clean.
+    if (!ut_sema_clean("fun takes(a: ^u32) u32 { ret a:^; }\nfun f(a: ^u32) u32 { ret takes(a); }\nfun main() i32 { ret 0; }\n")) { bad = 1; }
+    ret bad;
+}
+
 # block-scoped fin structural rules: control flow cannot cross the fin boundary
 # outward - a `ret` inside a fin body is rejected, as is a `brk` / `cnt` whose
 # target loop encloses the fin; a loop fully inside the fin body keeps `brk` /

--- a/src/lang/driver/tests.mach
+++ b/src/lang/driver/tests.mach
@@ -4808,9 +4808,23 @@ test "mach.lang.driver:secret_variadic_rejected" {
     if (!ut_sema_clean("fun logf(va: ...) u32 { ret 0; }\nfun f(a: ^u32) u32 { ret logf(a:^); }\nfun main() i32 { ret 0; }\n")) { bad = 1; }
     # a public argument is unaffected (no over-rejection).
     if (!ut_sema_clean("fun logf(va: ...) u32 { ret 0; }\nfun f(a: u32) u32 { ret logf(a); }\nfun main() i32 { ret 0; }\n")) { bad = 1; }
-    # a secret-carrying arg (a secret-welded pointer, which the pack collapse would erase
-    # to a public pointer) is also rejected - any `^` in the argument type.
+    # secret-CARRYING args are rejected DEEP, not just the scalar spine (`carries_secret`
+    # treats a nominal as a leaf; the pack mangling erases secrecy through the whole field
+    # graph). An aggregate that wraps a secret discloses its plaintext through the pack
+    # body, so a record with a secret field, a nested record, an all-secret union, an
+    # array of secrets, and a secret-welded pointer are all rejected.
+    if (!ut_sema_rejects("fun logf(va: ...) u32 { ret 0; }\nrec P { x: ^u32; }\nfun f(a: P) u32 { ret logf(a); }\nfun main() i32 { ret 0; }\n")) { bad = 1; }
+    if (!ut_sema_rejects("fun logf(va: ...) u32 { ret 0; }\nrec I { s: ^u32; }\nrec O { inner: I; }\nfun f(a: O) u32 { ret logf(a); }\nfun main() i32 { ret 0; }\n")) { bad = 1; }
+    if (!ut_sema_rejects("fun logf(va: ...) u32 { ret 0; }\nuni U { s: ^u32; t: ^u32; }\nfun f(a: U) u32 { ret logf(a); }\nfun main() i32 { ret 0; }\n")) { bad = 1; }
+    if (!ut_sema_rejects("fun logf(va: ...) u32 { ret 0; }\nfun f(a: [4]^u32) u32 { ret logf(a); }\nfun main() i32 { ret 0; }\n")) { bad = 1; }
     if (!ut_sema_rejects("fun logf(va: ...) u32 { ret 0; }\nfun f(a: *^u8) u32 { ret logf(a); }\nfun main() i32 { ret 0; }\n")) { bad = 1; }
+
+    # a PUBLIC record (no `^` anywhere in its field graph) is NOT over-rejected.
+    if (!ut_sema_clean("fun logf(va: ...) u32 { ret 0; }\nrec Q { x: u32; y: u32; }\nfun f(a: Q) u32 { ret logf(a); }\nfun main() i32 { ret 0; }\n")) { bad = 1; }
+    # a self-referential record with a secret field terminates the deep walk and rejects;
+    # the same shape without a secret is clean (the cycle guard does not over-report).
+    if (!ut_sema_rejects("fun logf(va: ...) u32 { ret 0; }\nrec N { next: *N; s: ^u32; }\nfun f(a: N) u32 { ret logf(a); }\nfun main() i32 { ret 0; }\n")) { bad = 1; }
+    if (!ut_sema_clean("fun logf(va: ...) u32 { ret 0; }\nrec N { next: *N; v: u32; }\nfun f(a: N) u32 { ret logf(a); }\nfun main() i32 { ret 0; }\n")) { bad = 1; }
 
     # a secret bound to a FIXED (non-variadic) parameter is governed by ordinary
     # assignability, not this gate - so a secret->secret fixed call stays clean.

--- a/src/lang/fe/sema/check.mach
+++ b/src/lang/fe/sema/check.mach
@@ -186,7 +186,12 @@ pub fun check_call(sc: *context.SemaContext, callee_sig: type.TypeId, args_start
             val parg_eid: id.ExprId = sc.a.expr_ids[args_start + pk];
             if (!arg_is_spread(sc, parg_eid)) {
                 val pactual: type.TypeId = expr_type_of(sc, parg_eid);
-                if (pactual != type.TYPE_ERROR && type.carries_secret(?sc.s.types, pactual)) {
+                # DEEP secret check (#2162): a nominal that wraps a secret (`rec P { x:
+                # ^u32 }`, a nested record, an all-secret union) carries a secret through
+                # its field graph even though `carries_secret` treats a nominal as a leaf;
+                # the pack-instance mangling erases that secrecy deeply, so the whole graph
+                # must be inspected.
+                if (pactual != type.TYPE_ERROR && type.contains_secret_deep(?sc.s.types, pactual)) {
                     report_note(sc, expr_span_of(sc, parg_eid, span),
                         "a secret value cannot be passed to a variadic `...` argument",
                         "a variadic pack erases secrecy and is an observation boundary (format / log / print); declassify with `:^` first");

--- a/src/lang/fe/sema/check.mach
+++ b/src/lang/fe/sema/check.mach
@@ -172,6 +172,30 @@ pub fun check_call(sc: *context.SemaContext, callee_sig: type.TypeId, args_start
         }
         i = i + 1;
     }
+
+    # GATE (#2162): a secret value cannot enter a `...` variadic pack. A pack's
+    # monomorphized instance name erases secrecy (`^u32` and `u32` collapse to one
+    # emitted body), so a secret argument silently reuses a public instance and is
+    # observed - and a variadic is an observation boundary (format / log / print). The
+    # secret must be declassified with `:^` before it enters the pack, uniformly for
+    # printlnf, log-style, and any user variadic. A `va...` spread forwards an existing
+    # pack, whose elements were gated at their own entry, so it is skipped.
+    if (has_pack) {
+        var pk: u32 = fixed_len;
+        for (pk < args_len) {
+            val parg_eid: id.ExprId = sc.a.expr_ids[args_start + pk];
+            if (!arg_is_spread(sc, parg_eid)) {
+                val pactual: type.TypeId = expr_type_of(sc, parg_eid);
+                if (pactual != type.TYPE_ERROR && type.carries_secret(?sc.s.types, pactual)) {
+                    report_note(sc, expr_span_of(sc, parg_eid, span),
+                        "a secret value cannot be passed to a variadic `...` argument",
+                        "a variadic pack erases secrecy and is an observation boundary (format / log / print); declassify with `:^` first");
+                    all_ok = false;
+                }
+            }
+            pk = pk + 1;
+        }
+    }
     ret all_ok;
 }
 

--- a/src/lang/fe/sema/check.mach
+++ b/src/lang/fe/sema/check.mach
@@ -187,11 +187,13 @@ pub fun check_call(sc: *context.SemaContext, callee_sig: type.TypeId, args_start
             if (!arg_is_spread(sc, parg_eid)) {
                 val pactual: type.TypeId = expr_type_of(sc, parg_eid);
                 # DEEP secret check (#2162): a nominal that wraps a secret (`rec P { x:
-                # ^u32 }`, a nested record, an all-secret union) carries a secret through
-                # its field graph even though `carries_secret` treats a nominal as a leaf;
-                # the pack-instance mangling erases that secrecy deeply, so the whole graph
-                # must be inspected.
-                if (pactual != type.TYPE_ERROR && type.contains_secret_deep(?sc.s.types, pactual)) {
+                # ^u32 }`, a nested record, an all-secret union, a `Box[^u32]`) carries a
+                # secret through its field graph even though `carries_secret` treats a
+                # nominal as a leaf; the pack-instance mangling erases that secrecy deeply.
+                # `generics.contains_secret_deep` materializes lazy generic-instance field
+                # tables before walking them (fail-closed if unresolvable), so it is not
+                # fooled by an unelaborated instance reaching the boundary.
+                if (pactual != type.TYPE_ERROR && generics.contains_secret_deep(sc.s, pactual)) {
                     report_note(sc, expr_span_of(sc, parg_eid, span),
                         "a secret value cannot be passed to a variadic `...` argument",
                         "a variadic pack erases secrecy and is an observation boundary (format / log / print); declassify with `:^` first");

--- a/src/lang/fe/sema/generics.mach
+++ b/src/lang/fe/sema/generics.mach
@@ -247,6 +247,80 @@ pub fun ensure_fields(s: *session.Session, tid: type.TypeId) {
     build_instance_table(s, tid, gnom);
 }
 
+# whether type `tid` transitively contains a secret `^` ANYWHERE (#2162)
+#
+# The DEEP counterpart to `type.carries_secret`: it follows the pointer / array spine
+# AND recurses INTO record / union / generic-instance field graphs, so an aggregate that
+# WRAPS a secret (`rec P { x: ^u32 }`, a nested record, an all-secret union, a
+# `Box[^u32]`) is caught. `carries_secret` treats a nominal as a leaf - correct for the
+# welded-storage aliasing rules it guards, but an under-approximation at any boundary
+# where a secret could be observed / aliased / erased, since the secrecy erasure there is
+# deep. Use this wherever a secret must not cross into a secrecy-erasing context.
+#
+# It lives here, not in `type`, because a generic-instance field table is materialized
+# LAZILY: a `Box[^u32]` that reaches a boundary with no prior field elaboration has no
+# registered table, and the shallow read would see zero fields and BYPASS. Each
+# TYPE_INSTANCE is materialized via `ensure_fields` before its fields are walked, so the
+# result is independent of materialization order; if a nominal's field table still cannot
+# be resolved it FAILS CLOSED (treated as possibly-secret), never bypassed.
+# ---
+# s:   the session (type universe + lazy instance field materialization)
+# tid: the type to inspect
+# ret: true when `tid` reaches a `^` through any pointer / array / field
+pub fun contains_secret_deep(s: *session.Session, tid: type.TypeId) bool {
+    var scan: type.SecretScan;
+    scan.len = 0;
+    ret secret_deep_walk(s, tid, ?scan);
+}
+
+# the recursive worker for `contains_secret_deep`, threading the visited set
+fun secret_deep_walk(s: *session.Session, tid: type.TypeId, scan: *type.SecretScan) bool {
+    val opt_type: O.Option[*type.Type] = type.get(?s.types, tid);
+    if (O.is_none[*type.Type](opt_type)) { ret false; }
+    val t: *type.Type = O.unwrap[*type.Type](opt_type);
+
+    if (t.kind == type.TYPE_SECRET)  { ret true; }
+    if (t.kind == type.TYPE_POINTER) { ret secret_deep_walk(s, t.data.pointer.base, scan); }
+    if (t.kind == type.TYPE_ARRAY)   { ret secret_deep_walk(s, t.data.array.base, scan); }
+
+    if (t.kind == type.TYPE_REC || t.kind == type.TYPE_UNI || t.kind == type.TYPE_INSTANCE) {
+        # an already-visited nominal contributes no new secret (its fields were fully
+        # explored on the first visit); this also terminates a cyclic record graph.
+        var i: u32 = 0;
+        for (i < scan.len) {
+            if (scan.seen[i] == tid) { ret false; }
+            i = i + 1;
+        }
+        # a graph beyond the visited-set bound fails CLOSED (never under-reports).
+        if (scan.len >= 256) { ret true; }
+        scan.seen[scan.len] = tid;
+        scan.len = scan.len + 1;
+
+        # materialize a generic instance's field table from its template, independent of
+        # whether/when lazy elaboration ran, so the walk never reads an absent table as
+        # "no fields".
+        if (t.kind == type.TYPE_INSTANCE) { ensure_fields(s, tid); }
+
+        # FAIL CLOSED: a nominal whose field table cannot be resolved is treated as
+        # possibly-secret rather than bypassed. A resolvable empty aggregate (a table with
+        # zero fields) is genuinely secret-free and is allowed.
+        val opt_tab: O.Option[*type.FieldTable] = type.field_table_for(?s.types, tid);
+        if (O.is_none[*type.FieldTable](opt_tab)) { ret true; }
+        val fields_len: u32 = O.unwrap[*type.FieldTable](opt_tab).fields_len;
+
+        var f: u32 = 0;
+        for (f < fields_len) {
+            val opt_e: O.Option[*type.FieldEntry] = type.field_at(?s.types, tid, f);
+            if (O.is_some[*type.FieldEntry](opt_e)) {
+                if (secret_deep_walk(s, O.unwrap[*type.FieldEntry](opt_e).ty, scan)) { ret true; }
+            }
+            f = f + 1;
+        }
+        ret false;
+    }
+    ret false;
+}
+
 # resolve the generic nominal TypeId that instance `(origin, gdecl)` specializes
 #
 # Reads the nominal's name and rec/uni kind from the declaration in its origin

--- a/src/lang/type.mach
+++ b/src/lang/type.mach
@@ -758,6 +758,75 @@ pub fun carries_secret(ti: *TypeInterner, tid: TypeId) bool {
     ret false;
 }
 
+# the cycle guard for the deep-secret walk: the set of nominal TypeIds already on the
+# walk, so a self-referential record graph terminates
+# ---
+# seen: distinct nominal / instance TypeIds visited (fixed; a graph larger than this
+#       fails closed - reported as containing a secret - so the walk never under-reports)
+# len:  number of visited entries
+pub rec SecretScan {
+    seen: [256]TypeId;
+    len:  u32;
+}
+
+# whether type `tid` transitively contains a secret `^` ANYWHERE (#2162)
+#
+# The DEEP counterpart to `carries_secret`: it follows the pointer / array spine AND
+# recurses INTO record / union / generic-instance field tables, so an aggregate that
+# wraps a secret (`rec P { x: ^u32 }`, a nested record, an all-secret union) is caught.
+# `carries_secret` treats a nominal as a leaf - correct for the welded-storage aliasing
+# rules it guards, but an under-approximation at an observation boundary (#2162), where
+# the pack-instance mangling erases secrecy through the whole field graph. Use this, not
+# `carries_secret`, wherever a secret must not cross into a secrecy-erasing context.
+# ---
+# ti:  the interner
+# tid: the type to inspect
+# ret: true when `tid` reaches a `^` through any pointer / array / field
+pub fun contains_secret_deep(ti: *TypeInterner, tid: TypeId) bool {
+    var scan: SecretScan;
+    scan.len = 0;
+    ret contains_secret_walk(ti, tid, ?scan);
+}
+
+# the recursive worker for `contains_secret_deep`, threading the visited set
+fun contains_secret_walk(ti: *TypeInterner, tid: TypeId, scan: *SecretScan) bool {
+    val opt_type: O.Option[*Type] = get(ti, tid);
+    if (O.is_none[*Type](opt_type)) { ret false; }
+    val t: *Type = O.unwrap[*Type](opt_type);
+
+    if (t.kind == TYPE_SECRET)  { ret true; }
+    if (t.kind == TYPE_POINTER) { ret contains_secret_walk(ti, t.data.pointer.base, scan); }
+    if (t.kind == TYPE_ARRAY)   { ret contains_secret_walk(ti, t.data.array.base, scan); }
+
+    if (t.kind == TYPE_REC || t.kind == TYPE_UNI || t.kind == TYPE_INSTANCE) {
+        # an already-visited nominal contributes no new secret (its fields were fully
+        # explored on the first visit); this also terminates a cyclic record graph.
+        var i: u32 = 0;
+        for (i < scan.len) {
+            if (scan.seen[i] == tid) { ret false; }
+            i = i + 1;
+        }
+        # a graph beyond the visited-set bound fails CLOSED: report a secret rather than
+        # risk under-reporting one (absurd for real code; a security predicate must not
+        # miss a deep secret).
+        if (scan.len >= 256) { ret true; }
+        scan.seen[scan.len] = tid;
+        scan.len = scan.len + 1;
+
+        val n: u32 = field_count(ti, tid);
+        var f: u32 = 0;
+        for (f < n) {
+            val opt_e: O.Option[*FieldEntry] = field_at(ti, tid, f);
+            if (O.is_some[*FieldEntry](opt_e)) {
+                if (contains_secret_walk(ti, O.unwrap[*FieldEntry](opt_e).ty, scan)) { ret true; }
+            }
+            f = f + 1;
+        }
+        ret false;
+    }
+    ret false;
+}
+
 # whether two types place the secret qualifier identically along their spines
 #
 # `::` and `:~` may neither add nor drop `^`, so a cast's operand and target must

--- a/src/lang/type.mach
+++ b/src/lang/type.mach
@@ -759,7 +759,14 @@ pub fun carries_secret(ti: *TypeInterner, tid: TypeId) bool {
 }
 
 # the cycle guard for the deep-secret walk: the set of nominal TypeIds already on the
-# walk, so a self-referential record graph terminates
+# walk, so a self-referential record graph terminates (#2162)
+#
+# Reused by `generics.contains_secret_deep`, which is the DEEP counterpart to
+# `carries_secret` (it recurses INTO record / union / generic-instance field graphs).
+# The walk lives in `generics`, not here, because a generic-instance field table is
+# materialized lazily and must be resolved (`ensure_fields`) before it is walked - a
+# dependency `type` cannot reach. `carries_secret` stays the shallow spine predicate
+# (a nominal is a leaf), correct for the welded-storage rules it guards.
 # ---
 # seen: distinct nominal / instance TypeIds visited (fixed; a graph larger than this
 #       fails closed - reported as containing a secret - so the walk never under-reports)
@@ -767,64 +774,6 @@ pub fun carries_secret(ti: *TypeInterner, tid: TypeId) bool {
 pub rec SecretScan {
     seen: [256]TypeId;
     len:  u32;
-}
-
-# whether type `tid` transitively contains a secret `^` ANYWHERE (#2162)
-#
-# The DEEP counterpart to `carries_secret`: it follows the pointer / array spine AND
-# recurses INTO record / union / generic-instance field tables, so an aggregate that
-# wraps a secret (`rec P { x: ^u32 }`, a nested record, an all-secret union) is caught.
-# `carries_secret` treats a nominal as a leaf - correct for the welded-storage aliasing
-# rules it guards, but an under-approximation at an observation boundary (#2162), where
-# the pack-instance mangling erases secrecy through the whole field graph. Use this, not
-# `carries_secret`, wherever a secret must not cross into a secrecy-erasing context.
-# ---
-# ti:  the interner
-# tid: the type to inspect
-# ret: true when `tid` reaches a `^` through any pointer / array / field
-pub fun contains_secret_deep(ti: *TypeInterner, tid: TypeId) bool {
-    var scan: SecretScan;
-    scan.len = 0;
-    ret contains_secret_walk(ti, tid, ?scan);
-}
-
-# the recursive worker for `contains_secret_deep`, threading the visited set
-fun contains_secret_walk(ti: *TypeInterner, tid: TypeId, scan: *SecretScan) bool {
-    val opt_type: O.Option[*Type] = get(ti, tid);
-    if (O.is_none[*Type](opt_type)) { ret false; }
-    val t: *Type = O.unwrap[*Type](opt_type);
-
-    if (t.kind == TYPE_SECRET)  { ret true; }
-    if (t.kind == TYPE_POINTER) { ret contains_secret_walk(ti, t.data.pointer.base, scan); }
-    if (t.kind == TYPE_ARRAY)   { ret contains_secret_walk(ti, t.data.array.base, scan); }
-
-    if (t.kind == TYPE_REC || t.kind == TYPE_UNI || t.kind == TYPE_INSTANCE) {
-        # an already-visited nominal contributes no new secret (its fields were fully
-        # explored on the first visit); this also terminates a cyclic record graph.
-        var i: u32 = 0;
-        for (i < scan.len) {
-            if (scan.seen[i] == tid) { ret false; }
-            i = i + 1;
-        }
-        # a graph beyond the visited-set bound fails CLOSED: report a secret rather than
-        # risk under-reporting one (absurd for real code; a security predicate must not
-        # miss a deep secret).
-        if (scan.len >= 256) { ret true; }
-        scan.seen[scan.len] = tid;
-        scan.len = scan.len + 1;
-
-        val n: u32 = field_count(ti, tid);
-        var f: u32 = 0;
-        for (f < n) {
-            val opt_e: O.Option[*FieldEntry] = field_at(ti, tid, f);
-            if (O.is_some[*FieldEntry](opt_e)) {
-                if (contains_secret_walk(ti, O.unwrap[*FieldEntry](opt_e).ty, scan)) { ret true; }
-            }
-            f = f + 1;
-        }
-        ret false;
-    }
-    ret false;
 }
 
 # whether two types place the secret qualifier identically along their spines


### PR DESCRIPTION
Closes #2162. Security fix in the constant-time feature (epic #1643).

## The leak
`printlnf("{}", s)` with `s: ^u32` compiled clean and printed the secret's **value** to stdout — no `:^` anywhere — plus a secret `x/10` in the itoa path. An undeclassified confidentiality disclosure that defeats the point of `^`.

## Root cause — variadic pack-instance secrecy collapse (NOT a coercion bypass)
Root-caused, correcting the issue's hypothesis: the coercion gates are **sound** (verified in isolation — `a::u64` on `^u32` and a `^u64`→public-`u64` param are both rejected, including inside pack bodies). The real cause is that a pack's monomorphized instance name erases secrecy — `pack_instance_name` mangles element types through the same `write_encoded_type` that drops `TYPE_SECRET` — so `printlnf[^u32]` and `printlnf[u32]` collapse to **one** emitted body. The pack worklist dedups by name; when a public instance wins (std's own internal public prints guarantee one), the secret call reuses the **public** body: the element is public `u32`, `$type_of` matches the int arm, `arg::u64` is public→public, itoa's `x/10` is a public div. Same secrecy-erasing collapse as #2157, here for variadic packs.

Proven: with an explicit twin, `which(pub); which(s)` → both `matched-u32` (secret reuses public body); reversed → both `matched-none`. And `write_encoded_type` demonstrably strips `^`.

## Fix (Option C — owner-approved)
A **general** sema call-site gate: a secret-carrying value passed to a `...` variadic pack is rejected, requiring `:^` first. A variadic is an observation boundary (format / log / print) and the mangling cannot carry secrecy, so a secret must be declassified before it enters. Placed at the pack-arg check in `check_call`, so it fires uniformly for `printlnf`, log-style, and any user variadic — not a print special-case. A `va...` spread is skipped (its elements were gated at their own entry). Once a secret can't enter the pack, the secret div in itoa is unreachable.

This is the epic's "`:^` before observation" rule applied at the variadic boundary. It forbids nothing that works — a constant-time variadic over secrets is already broken by the collapse (it shares the public body), so requiring `:^` removes a footgun, not a capability. No ABI / mangling change (Option A, the secrecy-aware mangling, was gate-kept for #2157 and would only yield a runtime `ERR_BAD_FORMAT`, not the compile error the guarantee needs).

## Verification
- `printlnf("{}", s)` (s: `^u32`) → **rejected** with the teaching diagnostic; `printlnf("{}", s:^)` → compiles + prints `42`; public args + declassified secrets unaffected.
- **General**: a user `fun logf(va: ...)` called with a secret is rejected; a secret bound to a **fixed** (non-variadic) parameter is unaffected (ordinary assignability governs it).
- Full suite **777/0** (new `secret_variadic_rejected` test).
- Byte-identical for secret-free code + fixpoint B==C; mach-std 611/0 (pinned); int linux + rv64. (running)

Security fix → adversarial review when green.
