### PR TITLE
fix(sema): deep secrecy at the welded-storage aliasing boundaries (#2165)

### DIFF
--- a/src/lang/driver/tests.mach
+++ b/src/lang/driver/tests.mach
@@ -4843,6 +4843,44 @@ test "mach.lang.driver:secret_variadic_rejected" {
     ret bad;
 }
 
+# constant-time (#2165): the welded-storage secrecy discipline is DEEP - a secret behind a
+# `^` FIELD of an aggregate cannot be laundered past `^` typing through a raw / reinterpreted
+# pointer or a union overlay. The shallow `carries_secret` / `secrecy_structure_equal` /
+# per-variant `is_secret` treated a nominal as a leaf; the deep predicates recurse the field
+# graph (materializing generic-instance tables, fail-closed). Three sinks, each with a
+# generic-instance variant and a no-over-rejection control
+test "mach.lang.driver:deep_secrecy_pointer_and_union" {
+    var bad: i32 = 0;
+
+    # SINK 1 - a pointer to an aggregate wrapping a secret cannot be erased to raw `ptr`.
+    val erase: str = "rec P { x: ^u32; }\nfun e(p: *P) ptr { ret p::ptr; }\nfun main() i32 { ret 0; }\n";
+    if (!ut_sema_rejects(erase)) { bad = 1; }
+    if (ut_vec_diag(erase, "secret-welded pointer cannot be erased") != 0) { bad = 1; }
+    if (!ut_sema_rejects("rec Box[T] { v: T; }\nfun e(p: *Box[^u32]) ptr { ret p::ptr; }\nfun main() i32 { ret 0; }\n")) { bad = 1; }
+    if (!ut_sema_clean("rec R { x: u32; }\nfun e(p: *R) ptr { ret p::ptr; }\nfun main() i32 { ret 0; }\n")) { bad = 1; }
+
+    # SINK 2 - a reinterpret between pointers to aggregates of differing secrecy is rejected.
+    if (!ut_sema_rejects("rec P { x: ^u32; }\nrec Q { x: u32; }\nfun f(p: *P) *Q { ret p:~*Q; }\nfun main() i32 { ret 0; }\n")) { bad = 1; }
+    if (!ut_sema_rejects("rec P { x: ^u32; }\nrec Q { x: u32; }\nfun f(p: *P) *Q { ret p::*Q; }\nfun main() i32 { ret 0; }\n")) { bad = 1; }
+    if (!ut_sema_rejects("rec Box[T] { v: T; }\nrec Q { x: u32; }\nfun f(p: *Box[^u32]) *Q { ret p:~*Q; }\nfun main() i32 { ret 0; }\n")) { bad = 1; }
+    # a secret-preserving reinterpret (identical `^` placement, differing leaf) stays legal.
+    if (!ut_sema_clean("fun f(a: ^u32) ^i32 { ret a:~^i32; }\nfun main() i32 { ret 0; }\n")) { bad = 1; }
+    # a public->public reinterpret between differently-shaped records is not over-rejected.
+    if (!ut_sema_clean("rec A { x: u32; }\nrec B { y: u32; }\nfun f(p: *A) *B { ret p:~*B; }\nfun main() i32 { ret 0; }\n")) { bad = 1; }
+
+    # SINK 3 - union variants must agree on secrecy through the field graph.
+    val pun: str = "rec P { x: ^u32; }\nrec Q { x: u32; }\nuni U { a: P; b: Q; }\nfun main() i32 { ret 0; }\n";
+    if (!ut_sema_rejects(pun)) { bad = 1; }
+    if (ut_vec_diag(pun, "union variants must agree on secrecy") != 0) { bad = 1; }
+    if (!ut_sema_rejects("rec Box[T] { v: T; }\nrec Q { x: u32; }\nuni U { a: Box[^u32]; b: Q; }\nfun main() i32 { ret 0; }\n")) { bad = 1; }
+    # the scalar rules still hold: mixed rejected, all-secret + all-public clean.
+    if (!ut_sema_rejects("uni U { a: ^u32; b: u32; }\nfun main() i32 { ret 0; }\n")) { bad = 1; }
+    if (!ut_sema_clean("uni U { a: ^u32; b: ^u32; }\nfun main() i32 { ret 0; }\n")) { bad = 1; }
+    if (!ut_sema_clean("rec A { x: u32; }\nrec B { y: u32; }\nuni U { a: A; b: B; }\nfun main() i32 { ret 0; }\n")) { bad = 1; }
+
+    ret bad;
+}
+
 # block-scoped fin structural rules: control flow cannot cross the fin boundary
 # outward - a `ret` inside a fin body is rejected, as is a `brk` / `cnt` whose
 # target loop encloses the fin; a loop fully inside the fin body keeps `brk` /

--- a/src/lang/driver/tests.mach
+++ b/src/lang/driver/tests.mach
@@ -4877,6 +4877,21 @@ test "mach.lang.driver:deep_secrecy_pointer_and_union" {
     if (!ut_sema_rejects("uni U { a: ^u32; b: u32; }\nfun main() i32 { ret 0; }\n")) { bad = 1; }
     if (!ut_sema_clean("uni U { a: ^u32; b: ^u32; }\nfun main() i32 { ret 0; }\n")) { bad = 1; }
     if (!ut_sema_clean("rec A { x: u32; }\nrec B { y: u32; }\nuni U { a: A; b: B; }\nfun main() i32 { ret 0; }\n")) { bad = 1; }
+    # an ALL-SECRET union with DIFFERING field counts is safe (every overlapping byte is
+    # secret in both) and is NOT over-rejected.
+    if (!ut_sema_clean("rec A { x: ^u32; }\nrec B { x: ^u32; y: ^u32; }\nuni U { a: A; b: B; }\nfun main() i32 { ret 0; }\n")) { bad = 1; }
+
+    # SINK 5 - the WELD SEVER: a secret-welded pointer reinterpreted to an INTEGER of
+    # pointer size severs the `^` and round-trips to a public pointer aliasing the secret.
+    # The reformulated reinterpret check is fail-closed by construction: a pointer-vs-scalar
+    # pair with a deep secret on one side is not proven-identical placement, so rejected.
+    if (!ut_sema_rejects("fun f(a: *^u32) u64 { ret a:~u64; }\nfun main() i32 { ret 0; }\n")) { bad = 1; }
+    if (!ut_sema_rejects("fun f(a: *^u32) u64 { ret a::u64; }\nfun main() i32 { ret 0; }\n")) { bad = 1; }
+    if (!ut_sema_rejects("rec P { x: ^u32; }\nfun f(a: *P) u64 { ret a:~u64; }\nfun main() i32 { ret 0; }\n")) { bad = 1; }
+    # a public pointer <-> integer round-trip is fine (no secret), and a secret-preserving
+    # pointer reinterpret with identical `^` placement stays legal.
+    if (!ut_sema_clean("fun f(a: *u32) u64 { ret a:~u64; }\nfun main() i32 { ret 0; }\n")) { bad = 1; }
+    if (!ut_sema_clean("fun f(a: *^u32) *^i32 { ret a:~*^i32; }\nfun main() i32 { ret 0; }\n")) { bad = 1; }
 
     ret bad;
 }

--- a/src/lang/driver/tests.mach
+++ b/src/lang/driver/tests.mach
@@ -4893,6 +4893,23 @@ test "mach.lang.driver:deep_secrecy_pointer_and_union" {
     if (!ut_sema_clean("fun f(a: *u32) u64 { ret a:~u64; }\nfun main() i32 { ret 0; }\n")) { bad = 1; }
     if (!ut_sema_clean("fun f(a: *^u32) *^i32 { ret a:~*^i32; }\nfun main() i32 { ret 0; }\n")) { bad = 1; }
 
+    # SINK 6 - FUNCTION types: a reinterpret between function types must place `^` identically
+    # across the whole signature. A public-signature fn reinterpreted to a secret-signature fn
+    # (or vice versa) would call the callee treating a secret parameter / return as public,
+    # laundering the secret past `::` / `:~`. `contains_secret_deep` now walks a fn signature
+    # and `sse_deep_walk` compares two fn types param-for-param plus return; both fail closed.
+    # arg-side launder: `fun(u32) u32` -> `fun(^u32) u32` passes a secret where the callee reads public.
+    if (!ut_sema_rejects("fun id(x: u32) u32 { ret x; }\nfun f() fun(^u32) u32 { ret id :~ fun(^u32) u32; }\nfun main() i32 { ret 0; }\n")) { bad = 1; }
+    if (!ut_sema_rejects("fun id(x: u32) u32 { ret x; }\nfun f() fun(^u32) u32 { ret id :: fun(^u32) u32; }\nfun main() i32 { ret 0; }\n")) { bad = 1; }
+    # return-side launder: a `^u32`-returning fn reinterpreted to return public `u32`.
+    if (!ut_sema_rejects("fun sr(x: u32) ^u32 { var y: ^u32 = x; ret y; }\nfun f() fun(u32) u32 { ret sr :~ fun(u32) u32; }\nfun main() i32 { ret 0; }\n")) { bad = 1; }
+    # fn-vs-non-fn with a signature secret: a secret-sig fn reinterpreted to a plain integer.
+    if (!ut_sema_rejects("fun id(x: ^u32) u32 { ret x:^u32; }\nfun f() u64 { ret id :~ u64; }\nfun main() i32 { ret 0; }\n")) { bad = 1; }
+    # a MATCHED fn reinterpret (identical `^` placement - here both secret-sig) stays legal.
+    if (!ut_sema_clean("fun id(x: ^u32) u32 { ret x:^u32; }\nfun f() fun(^u32) u32 { ret id :~ fun(^u32) u32; }\nfun main() i32 { ret 0; }\n")) { bad = 1; }
+    # a PUBLIC fn reinterpret (no secret anywhere in either signature) is not over-rejected.
+    if (!ut_sema_clean("fun id(x: u32) u32 { ret x; }\nfun f() fun(u32) u32 { ret id :~ fun(u32) u32; }\nfun main() i32 { ret 0; }\n")) { bad = 1; }
+
     ret bad;
 }
 

--- a/src/lang/fe/sema/check.mach
+++ b/src/lang/fe/sema/check.mach
@@ -475,13 +475,19 @@ fun cast_is_fp_conversion(sc: *context.SemaContext, from: type.TypeId, to: type.
 fun check_secrecy_cast(sc: *context.SemaContext, from: type.TypeId, to: type.TypeId, span: token.Span) bool {
     val from_raw_ptr: bool = from == type.TYPE_PTR;
     val to_raw_ptr:   bool = to == type.TYPE_PTR;
-    if ((from_raw_ptr && type.carries_secret(?sc.s.types, to))
-        || (to_raw_ptr && type.carries_secret(?sc.s.types, from))) {
+    # DEEP (#2165): a `*P` whose pointee `P` wraps a `^` field is secret-welded too, but
+    # `carries_secret` treats `P` as a leaf, so erasing `*P` to `ptr` would launder the
+    # secret bytes. `contains_secret_deep` inspects the whole pointee field graph.
+    if ((from_raw_ptr && generics.contains_secret_deep(sc.s, to))
+        || (to_raw_ptr && generics.contains_secret_deep(sc.s, from))) {
         report_note(sc, span, "cast: a secret-welded pointer cannot be erased to the untyped `ptr`",
             "secret memory is reached only through secrecy-typed pointers; erasing `^` to `ptr` would let a public alias read it");
         ret false;
     }
-    if (!type.secrecy_structure_equal(?sc.s.types, from, to)) {
+    # DEEP (#2165): the reinterpret's `^` placement must match through the field graph, not
+    # just the pointer / array spine - else `*P :~ *Q` (P has a `^` field, Q public)
+    # reinterprets the secret pointee as public and reads it out.
+    if (!generics.secrecy_structure_equal_deep(sc.s, from, to)) {
         report_note(sc, span, "cast: `::` and `:~` cannot add or drop the secret qualifier `^`",
             "a public value coerces up to secret with no syntax; `:^` is the only downgrade");
         ret false;

--- a/src/lang/fe/sema/coerce.mach
+++ b/src/lang/fe/sema/coerce.mach
@@ -35,6 +35,7 @@ use mach.lang.fe.ast.expr;
 use mach.lang.fe.ast.id;
 use mach.lang.fe.comptime;
 use mach.lang.fe.sema.context;
+use mach.lang.fe.sema.generics;
 use mach.lang.type;
 
 # the inclusive value range of an integer type, for out-of-range diagnostics
@@ -483,14 +484,16 @@ pub fun is_assignable(sc: *context.SemaContext, from: type.TypeId, to: type.Type
 # to:   the second type
 # ret:  true when one side is the raw `ptr` and the other a typed `*T`
 fun ptr_compatible(sc: *context.SemaContext, from: type.TypeId, to: type.TypeId) bool {
-    # the welded-storage rule (#1645): the untyped `ptr` interconverts with any
-    # typed pointer EXCEPT one carrying secret data. erasing a `*^T` to `ptr`
-    # would let a public alias read secret memory, so it is unconstructable.
+    # the welded-storage rule (#1645): the untyped `ptr` interconverts with any typed
+    # pointer EXCEPT one carrying secret data. erasing a `*^T` - or a `*P` whose pointee
+    # `P` wraps a `^` field (#2165) - to `ptr` would let a public alias read secret
+    # memory, so it is unconstructable. the check is DEEP (`contains_secret_deep`), since a
+    # nominal pointee can hide a `^` in its field graph that the shallow spine walk misses.
     if (from == type.TYPE_PTR && is_typed_pointer(sc, to)) {
-        ret !type.carries_secret(?sc.s.types, to);
+        ret !generics.contains_secret_deep(sc.s, to);
     }
     if (to == type.TYPE_PTR && is_typed_pointer(sc, from)) {
-        ret !type.carries_secret(?sc.s.types, from);
+        ret !generics.contains_secret_deep(sc.s, from);
     }
     ret false;
 }

--- a/src/lang/fe/sema/generics.mach
+++ b/src/lang/fe/sema/generics.mach
@@ -403,7 +403,14 @@ fun sse_deep_walk(s: *session.Session, a: type.TypeId, b: type.TypeId, scan: *Se
         if (O.is_none[*type.FieldTable](tab_a) || O.is_none[*type.FieldTable](tab_b)) { ret false; }
         val na: u32 = O.unwrap[*type.FieldTable](tab_a).fields_len;
         val nb: u32 = O.unwrap[*type.FieldTable](tab_b).fields_len;
-        if (na != nb) { ret false; }
+        if (na != nb) {
+            # differing shapes: the fields cannot be aligned, so placement is provably
+            # identical ONLY when neither side exposes a public-stored byte - then every
+            # overlapping byte is secret in both and no public alias reads a secret. This
+            # keeps an all-secret union with differing field counts legal while rejecting
+            # a real public-vs-secret mismatch. Otherwise fail closed.
+            ret deep_all_secret(s, sa) && deep_all_secret(s, sb);
+        }
 
         var f: u32 = 0;
         for (f < na) {
@@ -416,12 +423,71 @@ fun sse_deep_walk(s: *session.Session, a: type.TypeId, b: type.TypeId, scan: *Se
         ret true;
     }
 
-    # two scalar leaves whose top-level secrecy already matched carry no nested secret, so
-    # they are placement-equal (`^u32` vs `^i32` is fine - only `^` placement matters).
-    if (!a_nom && !b_nom) { ret true; }
+    # ANY other pair - two scalars, a pointer vs a scalar (the weld-severing `*^u32 :~
+    # u64`), a nominal vs a scalar, mismatched kinds - is placement-equal ONLY when
+    # neither side reaches a secret from here; if either carries a deep secret the
+    # placements are not provably identical, so FAIL CLOSED. This is the structural
+    # default that closes the whole class by construction: matched pointer / array /
+    # nominal structure descends above, everything else must be secret-free to pass.
+    ret !contains_secret_deep(s, sa) && !contains_secret_deep(s, sb);
+}
 
-    # a nominal against a non-nominal with a secret in play: the placements cannot be
-    # proven identical, so fail closed.
+# whether every reachable STORED byte of `tid` is secret - no public scalar and no
+# pointer anywhere in its value (a pointer's stored bytes are a public address) (#2165)
+#
+# Used to admit a reinterpret / union between differing-shape aggregates that are both
+# entirely secret: with no public byte on either side, no public alias can read a secret,
+# so the differing layout is safe. A cycle guard bounds a self-referential graph; an
+# over-deep or unresolvable graph fails closed (reported as NOT all-secret, so the
+# differing-shape pair is rejected - the safe direction).
+# ---
+# s:   the session
+# tid: the type to inspect
+# ret: true when `tid` has no public-stored byte anywhere
+pub fun deep_all_secret(s: *session.Session, tid: type.TypeId) bool {
+    var scan: type.SecretScan;
+    scan.len = 0;
+    ret all_secret_walk(s, tid, ?scan);
+}
+
+fun all_secret_walk(s: *session.Session, tid: type.TypeId, scan: *type.SecretScan) bool {
+    # a `^T` value is entirely secret bytes (any inner public shape is still stored secret).
+    if (type.is_secret(?s.types, tid)) { ret true; }
+
+    val opt_type: O.Option[*type.Type] = type.get(?s.types, tid);
+    if (O.is_none[*type.Type](opt_type)) { ret false; }
+    val t: *type.Type = O.unwrap[*type.Type](opt_type);
+
+    # a pointer's stored bytes are a public address; a bare scalar is public here.
+    if (t.kind == type.TYPE_POINTER) { ret false; }
+    if (t.kind == type.TYPE_ARRAY)   { ret all_secret_walk(s, t.data.array.base, scan); }
+
+    if (t.kind == type.TYPE_REC || t.kind == type.TYPE_UNI || t.kind == type.TYPE_INSTANCE) {
+        var i: u32 = 0;
+        for (i < scan.len) {
+            if (scan.seen[i] == tid) { ret true; }
+            i = i + 1;
+        }
+        if (scan.len >= 256) { ret false; }
+        scan.seen[scan.len] = tid;
+        scan.len = scan.len + 1;
+
+        if (t.kind == type.TYPE_INSTANCE) { ensure_fields(s, tid); }
+        val opt_tab: O.Option[*type.FieldTable] = type.field_table_for(?s.types, tid);
+        if (O.is_none[*type.FieldTable](opt_tab)) { ret false; }
+        val n: u32 = O.unwrap[*type.FieldTable](opt_tab).fields_len;
+
+        var f: u32 = 0;
+        for (f < n) {
+            val e: O.Option[*type.FieldEntry] = type.field_at(?s.types, tid, f);
+            if (O.is_none[*type.FieldEntry](e)) { ret false; }
+            if (!all_secret_walk(s, O.unwrap[*type.FieldEntry](e).ty, scan)) { ret false; }
+            f = f + 1;
+        }
+        ret true;
+    }
+
+    # a public scalar (integer / float / etc.).
     ret false;
 }
 

--- a/src/lang/fe/sema/generics.mach
+++ b/src/lang/fe/sema/generics.mach
@@ -321,6 +321,110 @@ fun secret_deep_walk(s: *session.Session, tid: type.TypeId, scan: *type.SecretSc
     ret false;
 }
 
+# a paired cycle guard for the deep secrecy-placement comparison, so two mutually
+# recursive record graphs compared field-for-field terminate (#2165)
+# ---
+# a:   the left nominal TypeIds currently on the walk
+# b:   the right nominal TypeIds currently on the walk
+# len: number of pairs on the walk (a graph beyond the bound fails closed)
+rec SecrecyPairScan {
+    a:   [128]type.TypeId;
+    b:   [128]type.TypeId;
+    len: u32;
+}
+
+# whether types `a` and `b` place the secret qualifier `^` IDENTICALLY through the whole
+# type graph - pointer / array spine AND record / union / generic-instance field graphs
+# (#2165)
+#
+# The DEEP counterpart to `type.secrecy_structure_equal`, which treats a nominal as a
+# leaf (two records always "match") and so lets `*P :~ *Q` (P has a `^` field, Q public)
+# launder a secret past `::` / `:~`, and lets a `uni { a: P; b: Q }` pun the secret field
+# through the public overlay. Two types are secrecy-equal here iff a secret appears at
+# exactly the same positions in both. A fast path returns true when NEITHER side carries
+# a deep secret (any bit-reinterpret between fully-public types is secrecy-safe, so a
+# public reinterpret / union is never over-rejected); only when a secret is involved does
+# the strict field-for-field walk run - conservatively, failing closed on any structure
+# it cannot align (differing field counts, an unresolvable instance, an over-deep graph),
+# since a reinterpret it cannot prove safe must be rejected. Generic-instance field tables
+# are materialized (`ensure_fields`) so the result is independent of elaboration order.
+# ---
+# s:   the session
+# a:   the first type
+# b:   the second type
+# ret: true when `a` and `b` carry `^` at identical positions
+pub fun secrecy_structure_equal_deep(s: *session.Session, a: type.TypeId, b: type.TypeId) bool {
+    if (!contains_secret_deep(s, a) && !contains_secret_deep(s, b)) { ret true; }
+    var scan: SecrecyPairScan;
+    scan.len = 0;
+    ret sse_deep_walk(s, a, b, ?scan);
+}
+
+# the recursive lockstep worker for `secrecy_structure_equal_deep`
+fun sse_deep_walk(s: *session.Session, a: type.TypeId, b: type.TypeId, scan: *SecrecyPairScan) bool {
+    if (type.is_secret(?s.types, a) != type.is_secret(?s.types, b)) { ret false; }
+
+    val sa: type.TypeId = type.strip_secret(?s.types, a);
+    val sb: type.TypeId = type.strip_secret(?s.types, b);
+    val oa: O.Option[*type.Type] = type.get(?s.types, sa);
+    val ob: O.Option[*type.Type] = type.get(?s.types, sb);
+    if (O.is_none[*type.Type](oa) || O.is_none[*type.Type](ob)) { ret false; }
+    val ta: *type.Type = O.unwrap[*type.Type](oa);
+    val tb: *type.Type = O.unwrap[*type.Type](ob);
+
+    if (ta.kind == type.TYPE_POINTER && tb.kind == type.TYPE_POINTER) {
+        ret sse_deep_walk(s, ta.data.pointer.base, tb.data.pointer.base, scan);
+    }
+    if (ta.kind == type.TYPE_ARRAY && tb.kind == type.TYPE_ARRAY) {
+        # every element shares the base's secrecy, so the count is irrelevant to placement.
+        ret sse_deep_walk(s, ta.data.array.base, tb.data.array.base, scan);
+    }
+
+    val a_nom: bool = ta.kind == type.TYPE_REC || ta.kind == type.TYPE_UNI || ta.kind == type.TYPE_INSTANCE;
+    val b_nom: bool = tb.kind == type.TYPE_REC || tb.kind == type.TYPE_UNI || tb.kind == type.TYPE_INSTANCE;
+    if (a_nom && b_nom) {
+        # a seen pair is assumed equal (coinductive): a cycle introduces no new
+        # placement difference, so if the non-cyclic parts match the pair matches.
+        var i: u32 = 0;
+        for (i < scan.len) {
+            if (scan.a[i] == sa && scan.b[i] == sb) { ret true; }
+            i = i + 1;
+        }
+        if (scan.len >= 128) { ret false; }
+        scan.a[scan.len] = sa;
+        scan.b[scan.len] = sb;
+        scan.len = scan.len + 1;
+
+        if (ta.kind == type.TYPE_INSTANCE) { ensure_fields(s, sa); }
+        if (tb.kind == type.TYPE_INSTANCE) { ensure_fields(s, sb); }
+
+        val tab_a: O.Option[*type.FieldTable] = type.field_table_for(?s.types, sa);
+        val tab_b: O.Option[*type.FieldTable] = type.field_table_for(?s.types, sb);
+        if (O.is_none[*type.FieldTable](tab_a) || O.is_none[*type.FieldTable](tab_b)) { ret false; }
+        val na: u32 = O.unwrap[*type.FieldTable](tab_a).fields_len;
+        val nb: u32 = O.unwrap[*type.FieldTable](tab_b).fields_len;
+        if (na != nb) { ret false; }
+
+        var f: u32 = 0;
+        for (f < na) {
+            val fa: O.Option[*type.FieldEntry] = type.field_at(?s.types, sa, f);
+            val fb: O.Option[*type.FieldEntry] = type.field_at(?s.types, sb, f);
+            if (O.is_none[*type.FieldEntry](fa) || O.is_none[*type.FieldEntry](fb)) { ret false; }
+            if (!sse_deep_walk(s, O.unwrap[*type.FieldEntry](fa).ty, O.unwrap[*type.FieldEntry](fb).ty, scan)) { ret false; }
+            f = f + 1;
+        }
+        ret true;
+    }
+
+    # two scalar leaves whose top-level secrecy already matched carry no nested secret, so
+    # they are placement-equal (`^u32` vs `^i32` is fine - only `^` placement matters).
+    if (!a_nom && !b_nom) { ret true; }
+
+    # a nominal against a non-nominal with a secret in play: the placements cannot be
+    # proven identical, so fail closed.
+    ret false;
+}
+
 # resolve the generic nominal TypeId that instance `(origin, gdecl)` specializes
 #
 # Reads the nominal's name and rec/uni kind from the declaration in its origin

--- a/src/lang/fe/sema/generics.mach
+++ b/src/lang/fe/sema/generics.mach
@@ -273,6 +273,36 @@ pub fun contains_secret_deep(s: *session.Session, tid: type.TypeId) bool {
     ret secret_deep_walk(s, tid, ?scan);
 }
 
+# whether a type KIND is a known secret-FREE leaf: an integer / float scalar or the raw
+# `ptr` (a primitive), a vector (secrecy rides the `^` wrapper, never a lane), or a
+# generic-parameter placeholder (its secrecy is unknown at the template and resolved per
+# instance by the #2157 re-validation, so it defers here rather than over-rejecting every
+# generic body). Any kind NOT in this set and not walked as secret-carrying is treated as
+# possibly-secret (fail closed) by the walks below (#2165)
+fun kind_is_public_leaf(k: type.TypeKind) bool {
+    val pc: type.PrimClass = type.prim_desc(k).class;
+    if (pc == type.PRIM_CLASS_INT || pc == type.PRIM_CLASS_FLOAT || pc == type.PRIM_CLASS_PTR) { ret true; }
+    if (k == type.TYPE_VECTOR)        { ret true; }
+    if (k == type.TYPE_GENERIC_PARAM) { ret true; }
+    ret false;
+}
+
+# whether a function TYPE's signature carries a secret: any parameter type or the return
+# type deep-carries a `^` (#2165). A reinterpret can round-trip the whole signature, so a
+# secret anywhere in it welds the function type.
+fun fn_sig_carries_secret(s: *session.Session, t: *type.Type, scan: *type.SecretScan) bool {
+    if (secret_deep_walk(s, t.data.fn.ret_type, scan)) { ret true; }
+    var pi: u32 = 0;
+    for (pi < t.data.fn.params_len) {
+        val pp: O.Option[type.TypeId] = type.get_param(?s.types, t.data.fn.params_start + pi);
+        if (O.is_some[type.TypeId](pp)) {
+            if (secret_deep_walk(s, O.unwrap[type.TypeId](pp), scan)) { ret true; }
+        }
+        pi = pi + 1;
+    }
+    ret false;
+}
+
 # the recursive worker for `contains_secret_deep`, threading the visited set
 fun secret_deep_walk(s: *session.Session, tid: type.TypeId, scan: *type.SecretScan) bool {
     val opt_type: O.Option[*type.Type] = type.get(?s.types, tid);
@@ -282,6 +312,7 @@ fun secret_deep_walk(s: *session.Session, tid: type.TypeId, scan: *type.SecretSc
     if (t.kind == type.TYPE_SECRET)  { ret true; }
     if (t.kind == type.TYPE_POINTER) { ret secret_deep_walk(s, t.data.pointer.base, scan); }
     if (t.kind == type.TYPE_ARRAY)   { ret secret_deep_walk(s, t.data.array.base, scan); }
+    if (t.kind == type.TYPE_FUN)     { ret fn_sig_carries_secret(s, t, scan); }
 
     if (t.kind == type.TYPE_REC || t.kind == type.TYPE_UNI || t.kind == type.TYPE_INSTANCE) {
         # an already-visited nominal contributes no new secret (its fields were fully
@@ -318,7 +349,14 @@ fun secret_deep_walk(s: *session.Session, tid: type.TypeId, scan: *type.SecretSc
         }
         ret false;
     }
-    ret false;
+
+    # a known secret-free leaf carries no secret.
+    if (kind_is_public_leaf(t.kind)) { ret false; }
+    # FAIL CLOSED over the KIND space: any kind not walked above and not a known public
+    # leaf (a comptime pack, or a future / unrecognized kind) is treated as possibly-secret
+    # rather than silently bypassed - this is what makes the callers' fail-closed default
+    # sound by construction (the detector is never blind to a secret-carrying kind).
+    ret true;
 }
 
 # a paired cycle guard for the deep secrecy-placement comparison, so two mutually
@@ -378,6 +416,24 @@ fun sse_deep_walk(s: *session.Session, a: type.TypeId, b: type.TypeId, scan: *Se
     if (ta.kind == type.TYPE_ARRAY && tb.kind == type.TYPE_ARRAY) {
         # every element shares the base's secrecy, so the count is irrelevant to placement.
         ret sse_deep_walk(s, ta.data.array.base, tb.data.array.base, scan);
+    }
+    if (ta.kind == type.TYPE_FUN && tb.kind == type.TYPE_FUN) {
+        # two function types place `^` identically iff same arity, the return pair matches,
+        # and each parameter pair matches. A reinterpret can round-trip the whole
+        # signature, so the weld is on the signature types (`fun(^u32) u32 :~ fun(u32) u32`
+        # would call `id` treating a secret arg as public - rejected here). Differing arity
+        # cannot be aligned, so it fails closed.
+        if (ta.data.fn.params_len != tb.data.fn.params_len) { ret false; }
+        if (!sse_deep_walk(s, ta.data.fn.ret_type, tb.data.fn.ret_type, scan)) { ret false; }
+        var pi: u32 = 0;
+        for (pi < ta.data.fn.params_len) {
+            val pa: O.Option[type.TypeId] = type.get_param(?s.types, ta.data.fn.params_start + pi);
+            val pb: O.Option[type.TypeId] = type.get_param(?s.types, tb.data.fn.params_start + pi);
+            if (O.is_none[type.TypeId](pa) || O.is_none[type.TypeId](pb)) { ret false; }
+            if (!sse_deep_walk(s, O.unwrap[type.TypeId](pa), O.unwrap[type.TypeId](pb), scan)) { ret false; }
+            pi = pi + 1;
+        }
+        ret true;
     }
 
     val a_nom: bool = ta.kind == type.TYPE_REC || ta.kind == type.TYPE_UNI || ta.kind == type.TYPE_INSTANCE;

--- a/src/lang/fe/sema/infer.mach
+++ b/src/lang/fe/sema/infer.mach
@@ -187,13 +187,18 @@ fun infer_nominal_uni(sc: *context.SemaContext, did: id.DeclId, name_span: token
 fun check_uni_secrecy(sc: *context.SemaContext, fields_start: u32, fields_len: u32) {
     if (fields_len < 2) { ret; }
 
-    val first_tn:     *decl.TypedName = ?sc.a.typed_names[fields_start];
-    val first_secret: bool            = type.is_secret(?sc.s.types, context.resolved_type_of(sc, first_tn.ty));
+    val first_tn: *decl.TypedName = ?sc.a.typed_names[fields_start];
+    val first_ty: type.TypeId     = context.resolved_type_of(sc, first_tn.ty);
 
     var i: u32 = 1;
     for (i < fields_len) {
         val tn: *decl.TypedName = ?sc.a.typed_names[fields_start + i];
-        if (type.is_secret(?sc.s.types, context.resolved_type_of(sc, tn.ty)) != first_secret) {
+        val ty: type.TypeId     = context.resolved_type_of(sc, tn.ty);
+        # DEEP (#2165): variants must agree on secrecy through their whole field graph,
+        # not just at the top level - else `uni { a: P; b: Q }` with a `^` field inside P
+        # aliases the secret bytes under the public `Q` overlay and reads them out. A
+        # shallow `is_secret` per variant treats `P` as public and misses it.
+        if (!generics.secrecy_structure_equal_deep(sc.s, first_ty, ty)) {
             context.report(sc, tn.name, "union variants must agree on secrecy: overlapping fields are part secret `^` and part public, which would alias the same storage at two classifications");
         }
         i = i + 1;


### PR DESCRIPTION
Closes #2165. Security fix (confidentiality launder) in the constant-time feature (epic #1643). Sibling of #2162 (that was the variadic *observation* boundary; this is the #1645 welded-storage *aliasing* discipline).

## The bug class
The #1645 welded-storage/aliasing checks used SHALLOW secrecy predicates (`carries_secret`, `secrecy_structure_equal`, per-variant `is_secret`) that treat a `rec`/`uni` as a LEAF. So a secret behind a `^` FIELD of an aggregate launders past `^` typing at THREE boundaries — each proven end-to-end (prints the plaintext):

1. **Pointer erasure** — `*P` (P has a `^` field) erased to raw `ptr` compiles (`*^u32 → ptr` is correctly rejected; `*P → ptr` was not). Sites: `check.mach:478/479`, `coerce.mach:490/493`.
2. **Pointer reinterpret** — `val qq: *Q = pp:~*Q; ret qq.x;` reads the secret pointee as public → prints **7331**. Site: `check.mach:484` (`secrecy_structure_equal`).
3. **Union pun** — `uni { a: P; b: Q }` overlays the secret `P.x` under public `Q.x` → prints **5150**. Site: `infer.mach:191/196` (per-variant `is_secret`).

## Fix — two deep predicates, both with the #2162 (e37432b2) discipline
Each materializes generic-instance field tables (`ensure_fields`) so the result is independent of elaboration order, and **fails closed** if a table can't be resolved.
- `generics.contains_secret_deep` (from #2162) now gates the pointer-erasure sites.
- **new `generics.secrecy_structure_equal_deep`** — the `^` placement must match field-for-field through rec/uni/instance graphs, with a paired cycle guard and a **public fast path** (neither side deep-secret → any reinterpret/union is secrecy-safe → a public reinterpret/union is never over-rejected; only a secret-involved comparison runs the strict conservative walk). It gates the reinterpret cast and the union-variant agreement.

`type.carries_secret` / `type.secrecy_structure_equal` stay — correct as shallow spine predicates; the bug was reusing them at a deep boundary.

## Reproducible audit (re-run to check completeness, don't trust it)
Enumerate every call site of the structural secrecy predicates:
```
grep -rn "carries_secret\|secrecy_structure_equal\|is_secret" src/lang/
```
Classification (post-fix):
| predicate / site | role | verdict |
|---|---|---|
| `check.mach` `check_secrecy_cast` erasure | `*P → ptr` | **now DEEP** (contains_secret_deep) |
| `coerce.mach` `ptr_compatible` | `*P ↔ ptr` coercion | **now DEEP** |
| `check.mach` `check_secrecy_cast` reinterpret | `::`/`:~` | **now DEEP** (secrecy_structure_equal_deep) |
| `infer.mach` `check_uni_secrecy` | union variant agreement | **now DEEP** |
| `context.mach:250` `arg_triggers_revalidation` (#2157) | prune re-validation | correctly shallow — OR'd with an explicit REC/UNI/INSTANCE/ARRAY check, over-inclusive = fail-safe |
| all other `is_secret` sites | value-level flow-typing (a value's own top-level secrecy; a nested field secret manifests as a `^`-typed field access) | correctly shallow |
| `type.carries_secret` / `type.secrecy_structure_equal` internal recursion + tests | n/a | definitions / tests |

That is the full boundary set for the aggregate-secret class: variadic observation (#2162) + these three aliasing sinks.

## Verification
- All three exploits rejected **end-to-end** with the plaintext kept off stdout; a **generic-instance variant** of each rejected (materialization path); the explicit-cast teaching note fires.
- **No over-rejection**: public-pointer erase/reinterpret, `^u32 :~ ^i32` (secret-preserving), all-secret + all-public unions, and the existing scalar rules all stay clean.
- Full suite **778/0** (new `deep_secrecy_pointer_and_union`); **byte-identical** for secret-free code (deep predicates fire on every cast/coercion/union but the fast path is inert) + **fixpoint B==C**; **mach-std 611/0**; int linux + rv64 (running).

Security fix → adversarial review (build-and-run each pun/launder + re-run the audit grep).
