### PR TITLE
fix(mos6502): branchless integer equality; end-to-end shift-gate reject test

### DIFF
--- a/src/lang/be/codegen/ctvalidate.mach
+++ b/src/lang/be/codegen/ctvalidate.mach
@@ -67,15 +67,25 @@
 # NOT carry `MirVReg.secret`, so the seeds are intact only here; legalization is itself a
 # constant-time-preserving width splitter (it introduces no branch, no computed address, and
 # no new variable-latency op, and rejects a wide divide / variable shift / non-constant
-# multiply loudly), and isel / regalloc / encode are trusted timing-preserving. True
-# translation-validation of the EMITTED machine code (the epic's eventual goal) needs the
-# seeds and barrier to survive to post-regalloc MIR - additive per-ISA work left as future
-# strengthening; the lowered-MIR contract does not foreclose it.
+# multiply loudly). True translation-validation of the EMITTED machine code (the epic's
+# eventual goal) needs the seeds and barrier to survive to post-regalloc MIR - additive
+# per-ISA work left as future strengthening; the lowered-MIR contract does not foreclose it.
 #
-# TRACKED FOLLOW-UPS (experimental-target-scoped, out of scope here): an 8-bit target whose
-# integer COMPARE is not data-independent needs a `ct_trust_compare` capability so a secret
-# equality feeding a branch condition gates at the compare (mos6502); and the SPIR-V backend's
-# whole-module emitter bypasses the machine pipeline, so this pass never runs on it.
+# THE TRUSTED SET, STATED PRECISELY (#2158). Everything downstream of this pass - selection,
+# register allocation, encoding - is ASSUMED timing-preserving, and that assumption is an
+# OBLIGATION ON EACH BACKEND, not a property this pass verifies. It is exactly as strong as
+# the weakest encoder: a backend that materializes a value with a data-dependent branch
+# introduces a leak nothing here can see, because the leaking instruction does not exist at
+# this layer. mos6502's `encode_cmp` did precisely that, materializing an integer equality
+# with a `BNE`, and it passed both this validator and the compile-time gate. The fix belongs
+# in the backend that broke the obligation - it is now branchless, pinned and EXECUTED over
+# every operand pair in `isa.mos6502.encode` - rather than in a capability flag that would
+# let an encoder opt out of a property its ISA can in fact provide. A capability row is right
+# only where the HARDWARE cannot do the op in constant time (`ct_trust_mul`,
+# `ct_trust_var_shift`), never where an encoder merely chose a branch.
+#
+# TRACKED FOLLOW-UP (out of scope here): the SPIR-V backend's whole-module emitter bypasses
+# the machine pipeline, so this pass never runs on it.
 
 use std.types.bool.bool;
 use std.types.bool.true;

--- a/src/lang/be/codegen/mir/lower.mach
+++ b/src/lang/be/codegen/mir/lower.mach
@@ -1192,9 +1192,9 @@ fun secret_ct_op_unsupported(cop: ct.CtOp) str {
 # the target-dependent constant-time gate mechanism (#1646): every value-producing
 # opcode classifies through the shared ct table (generality [11]), and the shift gate
 # observes ONLY the count operand while the multiply gate observes any operand. The
-# shift REJECTION on a no-barrel-shifter target is not end-to-end buildable (mos6502 /
-# spirv are the only ct_trust_var_shift=false targets and neither codegens in a unit
-# test), so it is proven here at the mechanism level plus the ct-table test.
+# shift REJECTION on a no-barrel-shifter target is driven end to end by the driver's
+# `secret_shift_codegen_rejected_mos6502` (#2149); this pins the classification and the
+# count-only observation the gate is built from.
 test "mach.lang.be.codegen.mir.lower.ct_gate:mechanism" {
     # opcode -> CtOp classification (one table, no bespoke per-op code).
     if (opcode_ct_op(instr.OP_MUL)   != ct.CT_OP_INT_MUL)   { ret 1; }

--- a/src/lang/driver/tests.mach
+++ b/src/lang/driver/tests.mach
@@ -622,6 +622,22 @@ fun ut_run_codegen_err(p: *project.Project, needle: str) i32 {
     ret 1;
 }
 
+# 0 when project `p` passes sema + lower and its codegen outcome - clean OR failing -
+# carries no `needle`; 1 when the needle appears, or on a pre-codegen failure. the
+# negative sibling of `ut_run_codegen_err`, for asserting a gate does NOT observe a
+# construct it must ignore, without pinning whatever unrelated frontier the target
+# happens to hit next (a partially-implemented backend's missing encoding) (#2149).
+fun ut_run_codegen_without(p: *project.Project, needle: str) i32 {
+    val se: R.Result[bool, outcome.Fail] = passes.run_sema_pass(p);
+    if (R.is_err[bool, outcome.Fail](se)) { ret 1; }
+    val le: R.Result[bool, outcome.Fail] = passes.run_lower_pass(p);
+    if (R.is_err[bool, outcome.Fail](le)) { ret 1; }
+    val ce: R.Result[bool, outcome.Fail] = passes.run_codegen_pass(p);
+    if (R.is_ok[bool, outcome.Fail](ce)) { ret 0; }
+    if (ut_str_contains(R.unwrap_err[bool, outcome.Fail](ce).message, needle)) { ret 1; }
+    ret 0;
+}
+
 # 0 when project `p` passes sema + lower + codegen cleanly; 1 on any error. asserts a
 # program compiles all the way through codegen for a given target (#1646).
 fun ut_run_codegen_ok(p: *project.Project) i32 {
@@ -4585,6 +4601,63 @@ test "mach.lang.driver:declassify_edge_consumers" {
         var p2: project.Project = R.unwrap_ok[project.Project, outcome.Fail](pm);
         if (ut_run_codegen_err(?p2, "wide memory access") != 0) { bad = 1; }
         project.dnit_project(?p2);
+    }
+
+    session.dnit(?s);
+    ret bad;
+}
+
+# constant-time (#2149): the variable-shift gate rejects a secret shift COUNT end to end
+# on a real no-barrel-shifter target, not merely at the mechanism level
+#
+# The multiply gate has had a full compile-reject since #1646 (`secret_mul_codegen_rejected`)
+# because every mainstream target sets `ct_trust_mul = false`. The SHIFT gate had none: the
+# only `ct_trust_var_shift = false` targets are mos6502 and spirv, so the rejection was
+# proven only by the ct-table test plus the gate-mechanism test. This closes that gap by
+# driving a secret shift through the ct-edge manifest's mos6502 target - the gate lives at
+# MIR lowering, ahead of width legalization and selection, so an experimental backend
+# reaches it regardless of what it cannot yet encode.
+#
+# Both halves matter: the gate must FIRE on a secret count [1], and must NOT fire on a
+# secret VALUE shifted by a public count [2], which is constant-time on any target. [2] is
+# asserted as an ABSENCE so it keeps holding once mos6502 learns to encode a shift.
+# `^u8` keeps the operands inside the 8-bit ALU, so the reject under test is the ct gate
+# rather than the target's wide-value handling.
+#
+# THE NEEDLES ARE DELIBERATELY ASYMMETRIC. Two independent enforcement points reject a
+# secret shift and both say "barrel shifter": the compile-time gate in `mir.lower` ("secret
+# value USED AS a variable shift count") and the #1648 validator's backstop ("`f` USES a
+# secret value as a variable shift count"). [1] therefore pins the LOWERING GATE's own
+# wording - a broad "barrel shifter" needle passes on the validator alone, so deleting the
+# gate's wiring would leave this test green. [2] wants the broad needle, because the
+# absence being asserted is that NEITHER point observes a public count.
+test "mach.lang.driver:secret_shift_codegen_rejected_mos6502" {
+    var bad: i32 = 0;
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    val sr: R.Result[session.Session, str] = session.init(?alloc);
+    if (R.is_err[session.Session, str](sr)) { ret 1; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](sr);
+
+    # [1] a secret shift COUNT is rejected at codegen by the compile-time gate itself.
+    val p1: R.Result[project.Project, outcome.Fail] = ut_ct_edge_project(?s, ?alloc,
+        "#[oblivious]\nfun f(v: ^u8, n: ^u8) ^u8 { ret v << n; }\nfun main() i32 { ret 0; }\n", "mos");
+    if (R.is_err[project.Project, outcome.Fail](p1)) { bad = 1; }
+    or {
+        var pa: project.Project = R.unwrap_ok[project.Project, outcome.Fail](p1);
+        if (ut_run_codegen_err(?pa, "secret value used as a variable shift count on a target without a barrel shifter") != 0) { bad = 1; }
+        project.dnit_project(?pa);
+    }
+
+    # [2] a secret VALUE shifted by a PUBLIC count is constant-time, so the gate stays
+    # silent - the count-only precision, on the same target that rejects [1].
+    val p2: R.Result[project.Project, outcome.Fail] = ut_ct_edge_project(?s, ?alloc,
+        "#[oblivious]\nfun f(v: ^u8, n: u8) ^u8 { ret v << n; }\nfun main() i32 { ret 0; }\n", "mos");
+    if (R.is_err[project.Project, outcome.Fail](p2)) { bad = 1; }
+    or {
+        var pb: project.Project = R.unwrap_ok[project.Project, outcome.Fail](p2);
+        if (ut_run_codegen_without(?pb, "barrel shifter") != 0) { bad = 1; }
+        project.dnit_project(?pb);
     }
 
     session.dnit(?s);

--- a/src/lang/target/isa/mos6502/encode.mach
+++ b/src/lang/target/isa/mos6502/encode.mach
@@ -527,10 +527,10 @@ fun t_has_branch(st: *enc.EncodeState) bool {
 # The load-bearing property: a secret `==` reaches this encoder as an ordinary
 # MIR_CMP_EQ, and NEITHER the `#[oblivious]` compile-time gate NOR the #1648 validator
 # can see what happens here - both read pre-selection MIR - so materializing the 0 / 1
-# boolean with a `BNE` over a `LDA #1` (2 cycles not-taken vs 3 taken) is a
-# secret-dependent timing branch invisible to every other check. Each relation is pinned
-# byte-exact against the published opcode matrix AND the encoded range is scanned for a
-# conditional-branch opcode, so the invariant survives a rewrite of the sequence.
+# boolean with a conditional branch puts a secret-dependent instruction stream past every
+# other check in the compiler. Each relation is pinned byte-exact against the published
+# opcode matrix AND the encoded range is scanned for a conditional-branch opcode, so the
+# invariant is asserted directly and survives a rewrite of the sequence.
 test "mach.lang.target.isa.mos6502.encode:compare_is_branchless" {
     var alloc: A.Allocator;
     page.make(?alloc);
@@ -603,7 +603,7 @@ fun t_run_cmp(code: *u8, n: usize, zp: *u8, cycles: *u32) bool {
     var i:  usize = 0;
     for (i < n) {
         val op:  u8    = code[i];
-        val arg: usize = (i + 1);
+        val arg: usize = i + 1;
         if (op == 0xA9)   { a = code[arg]::u32;                       cy = cy + 2; i = i + 2; }
         or (op == 0xA5)   { a = zp[code[arg]::usize]::u32;            cy = cy + 3; i = i + 2; }
         or (op == 0x49)   { a = a ^ code[arg]::u32;                   cy = cy + 2; i = i + 2; }

--- a/src/lang/target/isa/mos6502/encode.mach
+++ b/src/lang/target/isa/mos6502/encode.mach
@@ -21,10 +21,24 @@
 # the backend's scorecard (conditional branches, memory access through the software
 # frame, and the 16-bit-pointer forms) reach the encoder as passed-through generic
 # opcodes and are rejected with a loud, specific diagnostic rather than mis-encoded.
+#
+# TIMING OBLIGATION (#2158). The constant-time guarantee treats selection, register
+# allocation, and encoding as timing-PRESERVING: the `#[oblivious]` gate and the #1648
+# validator both read pre-selection MIR, so a leak this encoder introduces is invisible
+# to them. That makes it this file's standing obligation - an instruction NOT itself a
+# control transfer must encode to a fixed-cycle sequence, never a data-dependent branch.
+# `encode_cmp` once broke it, materializing the equality boolean with a `BNE` over a
+# `LDA #1`; every relation now goes through the branchless carry read instead. A
+# conditional branch remains legitimate only where the MIR op IS the branch
+# (`encode_sel_cbr`), which the validator observes directly. The guard is not a reading
+# of the code: `compare_executes_constant_time` below EXECUTES the emitted bytes over
+# every operand pair, because that broken sequence also silently answered wrong and no
+# amount of re-reading it had caught either fault.
 
 use std.types.bool.bool;
 use std.types.bool.false;
 use std.types.bool.true;
+use std.types.size.usize;
 use std.types.string.str;
 
 use std.allocator.page;
@@ -203,10 +217,24 @@ fun encode_not(st: *enc.EncodeState, mi: *mir.MirInstr) R.Result[bool, str] {
 
 # encode a standalone comparison `dst = (a rel b)` producing a 0 / 1 byte boolean
 #
-# The unsigned less-than form is what the legalizer's carry chain emits per byte
-# lane: `LDA a ; CMP b` leaves carry set when a >= b, so `LDA #0 ; ROL A ; EOR #1`
-# reads the complement (a < b) into a 0 / 1 result. Equality / inequality branch
-# over a `LDA #1`. Signed and <= forms are a documented frontier.
+# BRANCHLESS for every relation encoded here, so a comparison of SECRET values is
+# constant-time (#2158). The 6502 has no SETcc, but every relation lands in the
+# carry flag and `LDA #0 ; ROL A` reads carry into a 0 / 1 byte without a branch:
+#
+#   a <u b   LDA a ; CMP b        -> C = (a >= b), the complement, so EOR #1 flips it
+#   a != b   LDA a ; EOR b ; CMP #1 -> A is 0 exactly when equal, so C = (a != b)
+#   a == b   the same, then EOR #1
+#
+# Every form is a fixed-cycle immediate / zero-page / accumulator instruction, so the
+# sequence's cycle count is operand-INDEPENDENT, which is what `#[oblivious]` needs.
+#
+# THE CARRY IS THE ONLY FLAG THAT MAY CROSS an instruction here, and `LDA` / `EOR` do not
+# write it. The equality form this replaced ended `CMP b ; LDA #$00 ; BNE +2 ; LDA #$01`,
+# reading the compare's ZERO flag after a `LDA` - which sets Z from the byte it loads. Z
+# was therefore always 1 at the branch, so the branch was a constant and the compare
+# answered 1 for every `==` and 0 for every `!=`, regardless of its operands. A
+# secret-dependent branch in an `#[oblivious]` function on top of a compare that never
+# looked at its inputs. Signed and <= forms are a documented frontier.
 fun encode_cmp(st: *enc.EncodeState, mi: *mir.MirInstr, op: mir.MirOpcode) R.Result[bool, str] {
     if (mi.operand_count != 3) { ret R.err[bool, str]("mos6502: malformed compare"); }
     val dst: *mir.MirOperand = ?mi.operands[0];
@@ -215,27 +243,45 @@ fun encode_cmp(st: *enc.EncodeState, mi: *mir.MirInstr, op: mir.MirOpcode) R.Res
     val res_ld: R.Result[bool, str] = emit_load_a(st, ?mi.operands[1]);
     if (R.is_err[bool, str](res_ld)) { ret res_ld; }
     val b: *mir.MirOperand = ?mi.operands[2];
-    if (b.kind == mir.MIR_OP_IMM)  { emit_imm1(st, OP_CMP_IMM, (b.imm & 0xFF)::u8); }
-    or (b.kind == mir.MIR_OP_PREG) { emit_zp1(st, OP_CMP_ZP, mos6502.zp_addr(b.preg::i32)); }
-    or { ret R.err[bool, str]("mos6502: unsupported compare operand"); }
 
     if (op == mir.MIR_CMP_LT_U) {
-        # A = carry (a >= b), then flip to (a < b).
-        emit_imm1(st, OP_LDA_IMM, 0x00);
-        enc.emit_byte(?st.buf, OP_ROL_A);
-        emit_imm1(st, OP_EOR_IMM, 0x01);
+        # CMP leaves carry set when a >= b.
+        val res_c: R.Result[bool, str] = emit_cmp_operand(st, b, OP_CMP_IMM, OP_CMP_ZP);
+        if (R.is_err[bool, str](res_c)) { ret res_c; }
     }
     or {
-        # equality: start 0, branch over the `LDA #1` on the appropriate flag.
-        emit_imm1(st, OP_LDA_IMM, 0x00);
-        var skip_branch: u8 = OP_BNE;   # CMP_EQ: not-equal keeps 0
-        if (op == mir.MIR_CMP_NE) { skip_branch = OP_BEQ; }
-        enc.emit_byte(?st.buf, skip_branch);
-        enc.emit_byte(?st.buf, 0x02);   # skip the 2-byte `LDA #1`
-        emit_imm1(st, OP_LDA_IMM, 0x01);
+        # difference-to-zero: the accumulator is zero exactly when the operands are
+        # equal, so comparing it against 1 puts (a != b) in the carry.
+        val res_x: R.Result[bool, str] = emit_cmp_operand(st, b, OP_EOR_IMM, OP_EOR_ZP);
+        if (R.is_err[bool, str](res_x)) { ret res_x; }
+        emit_imm1(st, OP_CMP_IMM, 0x01);
     }
+
+    # read the carry into a 0 / 1 boolean; LDA leaves the carry untouched.
+    emit_imm1(st, OP_LDA_IMM, 0x00);
+    enc.emit_byte(?st.buf, OP_ROL_A);
+    # CMP_NE wants the carry as-is; a < b and a == b are both its complement.
+    if (op != mir.MIR_CMP_NE) { emit_imm1(st, OP_EOR_IMM, 0x01); }
+
     emit_zp1(st, OP_STA_ZP, mos6502.zp_addr(dst.preg::i32));
     ret R.ok[bool, str](true);
+}
+
+# emit a compare's right operand in its immediate or zero-page form
+#
+# The one dispatch both the standalone compare and the fused compare-and-branch read
+# their second operand through, so the accepted operand shapes and the diagnostic for
+# an unexpected one cannot drift between them.
+# ---
+# st:     the shared encode state
+# b:      the operand to emit
+# imm_op: the operation's immediate-mode opcode
+# zp_op:  the operation's zero-page opcode
+# ret:    ok(true), or an error naming the unsupported operand shape
+fun emit_cmp_operand(st: *enc.EncodeState, b: *mir.MirOperand, imm_op: u8, zp_op: u8) R.Result[bool, str] {
+    if (b.kind == mir.MIR_OP_IMM)  { emit_imm1(st, imm_op, (b.imm & 0xFF)::u8); ret R.ok[bool, str](true); }
+    if (b.kind == mir.MIR_OP_PREG) { emit_zp1(st, zp_op, mos6502.zp_addr(b.preg::i32)); ret R.ok[bool, str](true); }
+    ret R.err[bool, str]("mos6502: unsupported compare operand");
 }
 
 # encode an unconditional branch `MIR_BR [block]` as `JMP block` (absolute)
@@ -288,9 +334,8 @@ fun encode_sel_cbr(st: *enc.EncodeState, mi: *mir.MirInstr, fn_base: u32) R.Resu
 
     val res_ld: R.Result[bool, str] = emit_load_a(st, load_op);
     if (R.is_err[bool, str](res_ld)) { ret res_ld; }
-    if (cmp_op.kind == mir.MIR_OP_IMM)  { emit_imm1(st, OP_CMP_IMM, (cmp_op.imm & 0xFF)::u8); }
-    or (cmp_op.kind == mir.MIR_OP_PREG) { emit_zp1(st, OP_CMP_ZP, mos6502.zp_addr(cmp_op.preg::i32)); }
-    or { ret R.err[bool, str]("mos6502: unsupported compare operand"); }
+    val res_c: R.Result[bool, str] = emit_cmp_operand(st, cmp_op, OP_CMP_IMM, OP_CMP_ZP);
+    if (R.is_err[bool, str](res_c)) { ret res_c; }
 
     # inverted branch over the 3-byte then-JMP (fixed +3, no fixup needed).
     enc.emit_byte(?st.buf, inv_branch);
@@ -447,5 +492,196 @@ test "mach.lang.target.isa.mos6502.encode:byte_pins" {
     if (OP_JMP_ABS != 0x4C) { ret 1; }
 
     enc.buf_dnit(?st.buf);
+    ret 0;
+}
+
+# encode one standalone `dst = a rel b` over zero-page value registers 8 / 9 -> 10 and
+# report the bytes through `st` (test helper)
+fun t_encode_cmp(st: *enc.EncodeState, op: mir.MirOpcode) R.Result[bool, str] {
+    var ops: [3]mir.MirOperand;
+    ops[0] = mir.op_preg(10);
+    ops[1] = mir.op_preg(8);
+    ops[2] = mir.op_preg(9);
+    var mi: mir.MirInstr;
+    mi.opcode        = op;
+    mi.operands      = ?ops[0];
+    mi.operand_count = 3;
+    mi.width         = 1;
+    mi.src_width     = 1;
+    ret encode_cmp(st, ?mi, op);
+}
+
+# whether the encoded range holds any pc-relative conditional-branch opcode
+fun t_has_branch(st: *enc.EncodeState) bool {
+    var i: usize = 0;
+    for (i < st.buf.len) {
+        val b: u8 = st.buf.data[i];
+        if (b == OP_BEQ || b == OP_BNE || b == OP_BCC || b == OP_BCS) { ret true; }
+        i = i + 1;
+    }
+    ret false;
+}
+
+# a standalone compare encodes BRANCHLESS on every relation (#2158)
+#
+# The load-bearing property: a secret `==` reaches this encoder as an ordinary
+# MIR_CMP_EQ, and NEITHER the `#[oblivious]` compile-time gate NOR the #1648 validator
+# can see what happens here - both read pre-selection MIR - so materializing the 0 / 1
+# boolean with a `BNE` over a `LDA #1` (2 cycles not-taken vs 3 taken) is a
+# secret-dependent timing branch invisible to every other check. Each relation is pinned
+# byte-exact against the published opcode matrix AND the encoded range is scanned for a
+# conditional-branch opcode, so the invariant survives a rewrite of the sequence.
+test "mach.lang.target.isa.mos6502.encode:compare_is_branchless" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+
+    # a == b -> LDA $18 ; EOR $19 ; CMP #$01 ; LDA #$00 ; ROL A ; EOR #$01 ; STA $1A
+    var eq: enc.EncodeState;
+    eq.buf = enc.buf_init(?alloc);
+    if (R.is_err[bool, str](t_encode_cmp(?eq, mir.MIR_CMP_EQ))) { ret 1; }
+    if (eq.buf.len != 13)                                            { ret 1; }
+    if (eq.buf.data[0]  != 0xA5 || eq.buf.data[1]  != 0x18)          { ret 1; }
+    if (eq.buf.data[2]  != 0x45 || eq.buf.data[3]  != 0x19)          { ret 1; }
+    if (eq.buf.data[4]  != 0xC9 || eq.buf.data[5]  != 0x01)          { ret 1; }
+    if (eq.buf.data[6]  != 0xA9 || eq.buf.data[7]  != 0x00)          { ret 1; }
+    if (eq.buf.data[8]  != 0x2A)                                     { ret 1; }
+    if (eq.buf.data[9]  != 0x49 || eq.buf.data[10] != 0x01)          { ret 1; }
+    if (eq.buf.data[11] != 0x85 || eq.buf.data[12] != 0x1A)          { ret 1; }
+    if (t_has_branch(?eq)) { ret 1; }
+    enc.buf_dnit(?eq.buf);
+
+    # a != b -> the same carry read without the final complement.
+    var ne: enc.EncodeState;
+    ne.buf = enc.buf_init(?alloc);
+    if (R.is_err[bool, str](t_encode_cmp(?ne, mir.MIR_CMP_NE))) { ret 1; }
+    if (ne.buf.len != 11)                                            { ret 1; }
+    if (ne.buf.data[0] != 0xA5 || ne.buf.data[1] != 0x18)            { ret 1; }
+    if (ne.buf.data[2] != 0x45 || ne.buf.data[3] != 0x19)            { ret 1; }
+    if (ne.buf.data[4] != 0xC9 || ne.buf.data[5] != 0x01)            { ret 1; }
+    if (ne.buf.data[6] != 0xA9 || ne.buf.data[7] != 0x00)            { ret 1; }
+    if (ne.buf.data[8] != 0x2A)                                      { ret 1; }
+    if (ne.buf.data[9] != 0x85 || ne.buf.data[10] != 0x1A)           { ret 1; }
+    if (t_has_branch(?ne)) { ret 1; }
+    enc.buf_dnit(?ne.buf);
+
+    # a <u b -> CMP straight into the carry, complemented (unchanged by #2158).
+    var lt: enc.EncodeState;
+    lt.buf = enc.buf_init(?alloc);
+    if (R.is_err[bool, str](t_encode_cmp(?lt, mir.MIR_CMP_LT_U))) { ret 1; }
+    if (lt.buf.len != 11)                                            { ret 1; }
+    if (lt.buf.data[0] != 0xA5 || lt.buf.data[1] != 0x18)            { ret 1; }
+    if (lt.buf.data[2] != 0xC5 || lt.buf.data[3] != 0x19)            { ret 1; }
+    if (lt.buf.data[4] != 0xA9 || lt.buf.data[5] != 0x00)            { ret 1; }
+    if (lt.buf.data[6] != 0x2A)                                      { ret 1; }
+    if (lt.buf.data[7] != 0x49 || lt.buf.data[8] != 0x01)            { ret 1; }
+    if (lt.buf.data[9] != 0x85 || lt.buf.data[10] != 0x1A)           { ret 1; }
+    if (t_has_branch(?lt)) { ret 1; }
+    enc.buf_dnit(?lt.buf);
+    ret 0;
+}
+
+# execute an encoded compare sequence over a 256-byte zero page (test helper)
+#
+# A minimal 6502 core covering exactly the opcodes `encode_cmp` emits, with the REAL
+# published flag semantics: `LDA` / `EOR` write N and Z but LEAVE CARRY ALONE, `CMP`
+# writes N, Z and C, and `ROL A` reads C into bit 0 while taking C from bit 7. Modeling
+# the flags honestly is the entire point. The sequence this replaced read as correct on
+# the page - compare, then branch on the compare's flag - but its `LDA #$00` silently
+# rewrote Z, so the branch tested a CONSTANT: every `==` answered 1 and every `!=`
+# answered 0, for every input. An identity check over the intended algebra cannot see
+# that; executing the bytes can.
+# ---
+# code:   the encoded bytes to execute
+# n:      their length
+# zp:     the 256-byte zero page (operands in, result out)
+# cycles: receives the sequence's total cycle count
+# ret:    true when every opcode was inside the pinned set
+fun t_run_cmp(code: *u8, n: usize, zp: *u8, cycles: *u32) bool {
+    var a:  u32 = 0;
+    var c:  u32 = 0;
+    var cy: u32 = 0;
+    var i:  usize = 0;
+    for (i < n) {
+        val op:  u8    = code[i];
+        val arg: usize = (i + 1);
+        if (op == 0xA9)   { a = code[arg]::u32;                       cy = cy + 2; i = i + 2; }
+        or (op == 0xA5)   { a = zp[code[arg]::usize]::u32;            cy = cy + 3; i = i + 2; }
+        or (op == 0x49)   { a = a ^ code[arg]::u32;                   cy = cy + 2; i = i + 2; }
+        or (op == 0x45)   { a = a ^ zp[code[arg]::usize]::u32;        cy = cy + 3; i = i + 2; }
+        or (op == 0xC9)   { c = 0; if (a >= code[arg]::u32) { c = 1; }             cy = cy + 2; i = i + 2; }
+        or (op == 0xC5)   { c = 0; if (a >= zp[code[arg]::usize]::u32) { c = 1; }  cy = cy + 3; i = i + 2; }
+        or (op == 0x2A)   { val nc: u32 = (a >> 7) & 1; a = ((a << 1) | c) & 0xFF; c = nc; cy = cy + 2; i = i + 1; }
+        or (op == 0x85)   { zp[code[arg]::usize] = (a & 0xFF)::u8;    cy = cy + 3; i = i + 2; }
+        or { ret false; }
+    }
+    @cycles = cy;
+    ret true;
+}
+
+# run one encoded relation over every ordered byte pair, checking the ANSWER and that the
+# cycle count never varies with the operands (test helper)
+# ---
+# st:   the encode state holding the sequence to execute
+# want: 0 for `==`, 1 for `!=`, 2 for `<u`
+# ret:  0 when every pair answers correctly at one fixed cycle count
+fun t_check_cmp(st: *enc.EncodeState, want: u32) i32 {
+    var zp: [256]u8;
+    var fixed: u32 = 0;
+    var x: u32 = 0;
+    for (x < 256) {
+        var y: u32 = 0;
+        for (y < 256) {
+            var k: usize = 0;
+            for (k < 256) { zp[k] = 0; k = k + 1; }
+            zp[0x18] = (x & 0xFF)::u8;
+            zp[0x19] = (y & 0xFF)::u8;
+
+            var cy: u32 = 0;
+            if (!t_run_cmp(st.buf.data, st.buf.len, ?zp[0], ?cy)) { ret 1; }
+
+            var expect: u32 = 0;
+            if (want == 0 && x == y) { expect = 1; }
+            or (want == 1 && x != y) { expect = 1; }
+            or (want == 2 && x <  y) { expect = 1; }
+            if (zp[0x1A]::u32 != expect) { ret 1; }
+
+            # the constant-time property, EXECUTED: one cycle count for all 65536 pairs.
+            if (x == 0 && y == 0) { fixed = cy; }
+            or (cy != fixed)      { ret 1; }
+            y = y + 1;
+        }
+        x = x + 1;
+    }
+    ret 0;
+}
+
+# the encoded compare answers correctly and in a fixed number of cycles for every one of
+# the 65536 ordered byte pairs, per relation (#2158)
+#
+# Executes the bytes `encode_cmp` actually produced under the published flag semantics,
+# so this is a check of the MACHINE CODE, not of the algebra it was meant to implement.
+# It is the guard that catches both halves of what the branch form got wrong: a
+# data-dependent cycle count, and a compare whose answer never depended on its operands.
+test "mach.lang.target.isa.mos6502.encode:compare_executes_constant_time" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+
+    var eq: enc.EncodeState;
+    eq.buf = enc.buf_init(?alloc);
+    if (R.is_err[bool, str](t_encode_cmp(?eq, mir.MIR_CMP_EQ))) { ret 1; }
+    if (t_check_cmp(?eq, 0) != 0) { ret 1; }
+    enc.buf_dnit(?eq.buf);
+
+    var ne: enc.EncodeState;
+    ne.buf = enc.buf_init(?alloc);
+    if (R.is_err[bool, str](t_encode_cmp(?ne, mir.MIR_CMP_NE))) { ret 1; }
+    if (t_check_cmp(?ne, 1) != 0) { ret 1; }
+    enc.buf_dnit(?ne.buf);
+
+    var lt: enc.EncodeState;
+    lt.buf = enc.buf_init(?alloc);
+    if (R.is_err[bool, str](t_encode_cmp(?lt, mir.MIR_CMP_LT_U))) { ret 1; }
+    if (t_check_cmp(?lt, 2) != 0) { ret 1; }
+    enc.buf_dnit(?lt.buf);
     ret 0;
 }


### PR DESCRIPTION
Closes #2158
Closes #2149

## #2158 — secret `==` / `!=` compiled a timing branch on mos6502

Reproduced from real emitted machine code, not from reading the lowering. `#[oblivious] fun eq(a: ^u8, b: ^u8) ^u8 { ret a == b; }` built for `isa = "mos6502" / os = "freestanding" / abi = "mos6502"`, disassembled from the flat image:

```
0005: A5 1B     LDA $1B
0007: C5 1C     CMP $1C
0009: A9 00     LDA #$00
000B: D0 02     BNE +2      <== secret-dependent branch
000D: A9 01     LDA #$01
000F: 85 1D     STA $1D
```

The build succeeds: both the compile-time ct gate and the #1648 validator pass it clean, because both read pre-selection MIR and the trusted-set claim assumes encoders are timing-preserving. `lt` in the same program was already branchless (`LDA #0 ; ROL A ; EOR #1`), so only eq/ne were affected — matching the issue.

### Approach: branchless lowering, not a `ct_trust_compare` rejection

The 6502 is fully capable of a constant-time compare — `encode_cmp`'s own `CMP_LT_U` arm already used the branchless carry read. A `ct_trust_compare = false` for mos6502 would assert something false about the ISA, and since no other registered target would set it false, the capability row would ship with no user on any target. A capability row is right where the **hardware** cannot do the op in constant time (`ct_trust_mul`, `ct_trust_var_shift`); it is the wrong tool where an encoder merely chose a branch. Fixing the encoder is the honest fix, and it keeps secret compares usable on the target instead of rejecting them.

Every relation now lands in the carry and is read out branchlessly:

```
a <u b   LDA a ; CMP b          -> C = (a >= b), complemented by EOR #1
a != b   LDA a ; EOR b ; CMP #1 -> A is 0 iff equal, so C = (a != b)
a == b   the same, then EOR #1
```

After, same program:

```
0005: A5 1B     LDA $1B                     [3 cy]
0007: 45 1C     EOR $1C                     [3 cy]
0009: C9 01     CMP #$01                    [2 cy]
000B: A9 00     LDA #$00                    [2 cy]   ; LDA does not touch carry
000D: 2A        ROL A                       [2 cy]
000E: 49 01     EOR #$01                    [2 cy]
0010: 85 1D     STA $1D                     [3 cy]
```

All fixed-cycle immediate / zero-page / accumulator forms. No branch opcode anywhere in the image.

### The branch form was also a hard miscompile

Executing the emitted bytes (rather than reading them) surfaced a second fault. The branch read the compare's **zero** flag — but it sat after `LDA #$00`, and [LDA sets Z from the byte it loads](https://www.masswerk.at/6502/6502_instruction_set.html). Z was therefore always 1 at the branch, so the branch was a constant: `==` answered 1 and `!=` answered 0 for **every** input. 65280 of 65536 ordered byte pairs wrong, on both relations. The branchless sequence fixes both faults at once; a 65536-pair execution of the new bytes is clean at a single fixed cycle count per relation.

## #2149 — end-to-end shift-gate compile-reject

Completed. The issue's premise ("neither codegens in a unit-test build") is outdated: mos6502 does reach MIR lowering in a unit-test build — `declassify_edge_consumers` already drives it through `run_codegen_pass` via `ut_ct_edge_project` — and the ct gate sits at MIR lowering, ahead of width legalization and selection. So no `int/` case and **no new CI lane**; it belongs in the in-source unit suite, which is where it went (`mach.lang.driver:secret_shift_codegen_rejected_mos6502`).

Both halves are asserted: the gate **fires** on a secret shift COUNT, and stays **silent** on a secret VALUE shifted by a public count. The needles are deliberately asymmetric — two independent enforcement points reject a secret shift and both say "barrel shifter" (the compile-time gate, and the #1648 validator backstop), so a broad needle passes on the validator alone and leaves the gate's wiring untested. That was caught by mutation, not by inspection: with the shift dropped from the lowering gate's wiring the broad needle stayed green, so [1] now pins the gate's own wording.

## Verification

**Mutation testing** (baseline 790 / 0, re-run on the merged tree):

| Mutation | Result | Catches |
|---|---|---|
| M1 restore the `BNE` branch form | **788 / 2** | `compare_is_branchless`, `compare_executes_constant_time` |
| M2 wrong compare immediate, byte pin updated to match | **789 / 1** | `compare_executes_constant_time` only — the executed guard catches wrongness the shape pin cannot |
| M3 shift capability provided by every target | **786 / 4** | new e2e test + 3 pre-existing mechanism tests |
| M3b shift dropped from the lowering gate's wiring only | **789 / 1** | **new e2e test alone** — every pre-existing test stays green; exactly the gap #2149 named |
| M4 gate observes all operands, not the count alone | **788 / 2** | new e2e test's precision half + mechanism test |

Sources restored after each; the restored tree rebuilds byte-identical to the pushed state.

**Byte identity, three main ISAs.** The merge-base compiler (`2c1ae310`) and this branch's compiler each compiled the same unmodified tree for all three ISAs and both profiles; every emitted object is identical:

```
IDENTICAL  linux-x86_64/debug    (204 objects)   IDENTICAL  linux-x86_64/release    (204 objects)
IDENTICAL  linux-arm64/debug     (204 objects)   IDENTICAL  linux-arm64/release     (204 objects)
IDENTICAL  linux-riscv64/debug   (204 objects)   IDENTICAL  linux-riscv64/release   (204 objects)
```

Cross-compiling the two *source trees* likewise differs in exactly one object — `mos6502/encode.o` — on all three ISAs. The ct capability table is untouched, so no other target's behaviour moves.

**Fixpoint.** A == B == C byte-identical (`7e4557881aaeefff`), B == C as required.

**Suites** (generation-C compiler): mach **790 / 0** (787 at merge base + 3 new), mach-std **611 / 0** at pin `eff1e8e`.

**Merge note.** `dev` moved under this branch; #2189 (SPIR-V ct scope) and this PR had each closed one half of the same `TRACKED FOLLOW-UP` note in `ctvalidate.mach`, and both added a test at the same spot in `tests.mach`. Resolved by keeping both scope paragraphs and both tests, and dropping the follow-up note entirely — both halves are now fixed.
