### PR TITLE
fix(ct): refuse #[oblivious] on a whole-module-emitter target (SPIR-V)

### DIFF
--- a/doc/language/decorators.md
+++ b/doc/language/decorators.md
@@ -163,6 +163,10 @@ A function instance that *computes* on a `^` secret (arithmetic, bitwise, shift,
 comparison, negation) is **required** to carry it; an instance that only moves,
 stores, or declassifies secrets stays annotation-free.
 
+It is rejected outright for a target whose back half emits a module for a
+downstream compiler rather than the executed instructions (the experimental
+SPIR-V backend): the contract cannot be validated or upheld there.
+
 > **Experimental preview.** The constant-time guarantee is not complete and has
 > not been audited — see [secrecy.md](secrecy.md#assurance) for the known open
 > holes. Do not build production cryptography on it at this version.

--- a/doc/language/secrecy.md
+++ b/doc/language/secrecy.md
@@ -142,6 +142,13 @@ memory address, or a forbidden variable-latency op is a compile error naming the
 function and the offending operation. It is a backstop behind the compile-time
 gates, not a replacement for them.
 
+The contract is only offered where mach emits the instructions that execute.
+A target whose back half hands a module to a downstream compiler instead — the
+experimental SPIR-V backend — **rejects `#[oblivious]`**: neither that
+translation nor the device's timing behaviour is covered by the leakage model,
+so the obligation could be neither validated nor upheld. Compile constant-time
+code for a machine target and pass such a target only public data.
+
 ## Trusted base
 
 The only secret-to-public crossings are the explicit `:^` cast and inline `asm`
@@ -172,14 +179,14 @@ What does not hold — the known open holes:
   (briar-systems/mach#2168).
 - a secret integer `==` / `!=` compiles a timing branch on targets without
   comparison flags (briar-systems/mach#2158)
-- an `#[oblivious]` function compiled to SPIR-V bypasses the validator entirely
-  (briar-systems/mach#2159)
 - deep secrecy placement over-rejects differing-shape aggregates that lack field
   offsets — sound but too strict (briar-systems/mach#2167)
 
 The validator's scope is the lowered MIR; it trusts instruction selection, width
 legalization, register allocation, and encoding to be timing-preserving.
-Validation of the emitted machine code is future work.
+Validation of the emitted machine code is future work. Where mach does not own
+those stages at all — a whole-module emitter such as SPIR-V — the contract is
+refused rather than assumed.
 
 ## See also
 

--- a/src/lang/be/codegen.mach
+++ b/src/lang/be/codegen.mach
@@ -43,6 +43,7 @@ use mach.lang.me.ir.value;
 use mach.lang.session;
 use mach.lang.source;
 use mach.lang.target;
+use mach.lang.target.isa;
 use mach.lang.target.of;
 
 # a function moved out of `.text` by a `#[section("...")]` decorator
@@ -163,7 +164,15 @@ pub fun codegen_module(s: *session.Session, tgt: *target.Target,
     # the machine back half entirely - no isel / regalloc / frame / encode. the
     # machine path below is byte-identical when emit_module is nil (every register
     # machine ISA leaves it nil).
-    if (tgt.arch.emit_module != nil) {
+    if (isa.emits_whole_module(tgt.arch)) {
+        # the constant-time enforcement point of this fork (#2159): the emitter is not
+        # mach's machine pipeline, so an `#[oblivious]` contract cannot be validated or
+        # upheld past it and is refused here rather than silently emitted unchecked.
+        # secret-free code and non-oblivious functions are untouched.
+        val res_ct: R.Result[bool, str] = ctvalidate.run(tgt, ?mir_module);
+        if (R.is_err[bool, str](res_ct)) {
+            ret R.err[of.ObjectImage, str](R.unwrap_err[bool, str](res_ct));
+        }
         ret emit_spirv_image(s, tgt, irmod, ?mir_module);
     }
 

--- a/src/lang/be/codegen/ctvalidate.mach
+++ b/src/lang/be/codegen/ctvalidate.mach
@@ -72,10 +72,21 @@
 # seeds and barrier to survive to post-regalloc MIR - additive per-ISA work left as future
 # strengthening; the lowered-MIR contract does not foreclose it.
 #
-# TRACKED FOLLOW-UPS (experimental-target-scoped, out of scope here): an 8-bit target whose
+# BACKEND SCOPE (#2159). The validated layer is mach's own lowered MIR, and the guarantee it
+# carries rests on every REMAINING stage being mach's and timing-preserving. A target whose
+# back half is a whole-module emitter (`isa.emits_whole_module` - SPIR-V) breaks that chain at
+# the root: mach emits a SPIR-V module, not executed instructions, and a vendor driver
+# recompiles it to native GPU code under no constant-time contract, onto hardware whose
+# timing channels (SIMT divergence, memory coalescing, undocumented op latencies) this leakage
+# model does not describe. Re-deriving the taint over that MIR would therefore certify a
+# property of an artifact nobody executes. So `#[oblivious]` is REFUSED for such a target -
+# the same rule this pass applies to inline assembly: reject the unverifiable construct rather
+# than trust it. If a whole-module backend ever gains a documented timing model and a trusted
+# downstream toolchain, this is one predicate to relax.
+#
+# TRACKED FOLLOW-UP (experimental-target-scoped, out of scope here): an 8-bit target whose
 # integer COMPARE is not data-independent needs a `ct_trust_compare` capability so a secret
-# equality feeding a branch condition gates at the compare (mos6502); and the SPIR-V backend's
-# whole-module emitter bypasses the machine pipeline, so this pass never runs on it.
+# equality feeding a branch condition gates at the compare (mos6502).
 
 use std.types.bool.bool;
 use std.types.bool.true;
@@ -94,28 +105,40 @@ use R: std.types.result;
 use mach.lang.be.codegen.mir;
 use mach.lang.ct;
 use mach.lang.intern;
+use mach.lang.target.isa;
 use target: mach.lang.target.resolved;
 
-# validate every `#[oblivious]` function of a MIR module for constant-time leakage
+# enforce the constant-time contract of every `#[oblivious]` function of a MIR module
 #
-# The shared entry point the codegen driver calls after loop rotation and before width
-# legalization. Re-derives the secret taint from the #1646 seeds and rejects a secret value
-# reaching a branch condition, a memory address, or a forbidden variable-latency op inside
-# any function marked `#[oblivious]`. A function without the marker is skipped; the pass
-# never mutates the MIR, so a module with no oblivious function is validated in a single
-# read and emitted byte-identically.
+# The BACKEND-NEUTRAL entry point every back half calls on the lowered MIR - the machine
+# pipeline after loop rotation and before width legalization, the whole-module fork before
+# it dispatches its emitter - so no path can reach an emitter with an unenforced contract.
+# What enforcement means is decided by the target's back half:
+#   - mach's machine pipeline: re-derive the secret taint from the #1646 seeds and reject a
+#     secret value reaching a branch condition, a memory address, or a forbidden
+#     variable-latency op inside any function marked `#[oblivious]`.
+#   - a whole-module emitter (SPIR-V): refuse the `#[oblivious]` function outright, since the
+#     validated MIR is not what executes and the contract cannot be upheld (see BACKEND SCOPE).
+# A function without the marker is skipped either way; the pass never mutates the MIR, so a
+# module with no oblivious function is validated in a single read and emitted byte-identically.
 # ---
-# tgt: resolved compilation target (supplies the constant-time capability flags)
+# tgt: resolved compilation target (supplies the back half's identity and the ct capabilities)
 # m:   the MIR module to validate in place (read-only)
 # ret: ok(true) when every oblivious function is leak-free, or the first violation's error
 pub fun run(tgt: *target.Target, m: *mir.MirModule) R.Result[bool, str] {
-    if (tgt == nil) { ret R.err[bool, str]("ctvalidate: nil target"); }
-    if (m == nil)   { ret R.err[bool, str]("ctvalidate: nil mir module"); }
+    if (tgt == nil)      { ret R.err[bool, str]("ctvalidate: nil target"); }
+    if (tgt.arch == nil) { ret R.err[bool, str]("ctvalidate: target has no instruction set"); }
+    if (m == nil)        { ret R.err[bool, str]("ctvalidate: nil mir module"); }
+
+    val unverifiable: bool = isa.emits_whole_module(tgt.arch);
 
     var i: u32 = 0;
     for (i < m.function_len) {
         val f: *mir.MirFunction = ?m.functions[i];
         if (f.oblivious) {
+            if (unverifiable) {
+                ret R.err[bool, str](unverifiable_msg(m.alloc, m.interner, f.name, tgt.arch.name));
+            }
             val res: R.Result[bool, str] = validate_function(tgt, f, m.interner, m.alloc);
             if (R.is_err[bool, str](res)) { ret res; }
         }
@@ -449,13 +472,35 @@ fun leak_msg(alloc: *A.Allocator, interner: *intern.Interner, name_id: intern.St
     val name: str = fn_name(interner, name_id);
     val res: R.Result[str, str] = format.sprint(alloc, "codegen: #[oblivious] function `{}` {}", name, detail);
     if (R.is_err[str, str](res)) { ret detail; }
-    val buf: str = R.unwrap_ok[str, str](res);
+    ret stable(alloc, interner, R.unwrap_ok[str, str](res), detail);
+}
+
+# the refusal for an `#[oblivious]` function on a whole-module-emitter target (#2159)
+#
+# Names the function and the target and states why no validation is possible there, so the
+# refusal reads as a scope boundary rather than a missing feature. Degrades to the
+# target-agnostic wording when the interner is absent or an allocation fails
+fun unverifiable_msg(alloc: *A.Allocator, interner: *intern.Interner, name_id: intern.StrId, arch: str) str {
+    if (interner == nil) { ret UNVERIFIABLE_DETAIL; }
+    val name: str = fn_name(interner, name_id);
+    val res: R.Result[str, str] = format.sprint(alloc,
+        "codegen: #[oblivious] function `{}` cannot be compiled for the `{}` target: its back half emits a module for a downstream compiler to translate rather than the instructions that execute, and neither that translation nor the device's timing behaviour is covered by mach's leakage model, so the constant-time contract can be neither validated nor upheld. compile the oblivious function for a machine target and pass this one only public data",
+        name, arch);
+    if (R.is_err[str, str](res)) { ret UNVERIFIABLE_DETAIL; }
+    ret stable(alloc, interner, R.unwrap_ok[str, str](res), UNVERIFIABLE_DETAIL);
+}
+
+# the target-agnostic refusal, used when the message cannot be built with the names
+val UNVERIFIABLE_DETAIL: str = "codegen: a #[oblivious] function cannot be compiled for a target whose back half emits a module for a downstream compiler to translate rather than the instructions that execute; the constant-time contract can be neither validated nor upheld there. compile the oblivious function for a machine target and pass this one only public data";
+
+# intern `buf` to a session-stable string and release it, or `fallback` when interning fails
+fun stable(alloc: *A.Allocator, interner: *intern.Interner, buf: str, fallback: str) str {
     val ir: R.Result[intern.StrId, str] = intern.intern(interner, buf);
     A.deallocate[u8](alloc, buf, str_len(buf) + 1);
-    if (R.is_err[intern.StrId, str](ir)) { ret detail; }
+    if (R.is_err[intern.StrId, str](ir)) { ret fallback; }
     val lo: O.Option[str] = intern.lookup(interner, R.unwrap_ok[intern.StrId, str](ir));
     if (O.is_some[str](lo)) { ret O.unwrap[str](lo); }
-    ret detail;
+    ret fallback;
 }
 
 # the function's source name, or "<unknown>" when unresolved
@@ -513,12 +558,22 @@ fun t_fn(oblivious: bool, blocks: *mir.MirBlock, nb: u32, vregs: *mir.MirVReg, n
     ret f;
 }
 
-# a target trusting the named constant-time capabilities, nothing else (test helper)
+# a target trusting the named constant-time capabilities, nothing else. `arch` is left
+# unset; a test driving `run` attaches one with `t_isa` (test helper)
 fun t_target(trust_mul: bool, trust_var_shift: bool) target.Target {
     var t: target.Target;
     t.model.ct_trust_mul      = trust_mul;
     t.model.ct_trust_var_shift = trust_var_shift;
     ret t;
+}
+
+# an instruction-set vtable naming a back half: a machine pipeline when `emit_module` is
+# nil, a whole-module emitter when it is not (test helper)
+fun t_isa(name: str, emit_module: *u8) isa.IsaVTable {
+    var vt: isa.IsaVTable;
+    vt.name        = name;
+    vt.emit_module = emit_module;
+    ret vt;
 }
 
 # a secret laundered through a phi join (out-of-SSA predecessor moves into one result vreg)
@@ -803,6 +858,8 @@ test "mach.lang.be.codegen.ctvalidate.scope:non_oblivious_unaffected" {
     var alloc: A.Allocator;
     page.make(?alloc);
     var t: target.Target = t_target(false, true);
+    var vt: isa.IsaVTable = t_isa("machine", nil);
+    t.arch = ?vt;
 
     var vregs: [1]mir.MirVReg;
     vregs[0] = t_vreg(0, true);   # secret
@@ -859,6 +916,8 @@ test "mach.lang.be.codegen.ctvalidate.opaque:inline_asm_forbidden" {
     var alloc: A.Allocator;
     page.make(?alloc);
     var t: target.Target = t_target(false, true);
+    var vt: isa.IsaVTable = t_isa("machine", nil);
+    t.arch = ?vt;
 
     var vregs: [1]mir.MirVReg;
     vregs[0] = t_vreg(0, false);
@@ -875,6 +934,50 @@ test "mach.lang.be.codegen.ctvalidate.opaque:inline_asm_forbidden" {
     var funcs: [1]mir.MirFunction; funcs[0] = t_fn(false, ?blocks[0], 1, ?vregs[0], 1);
     var mm: mir.MirModule; mm.alloc = ?alloc; mm.interner = nil; mm.functions = ?funcs[0]; mm.function_len = 1;
     if (!R.is_ok[bool, str](run(?t, ?mm))) { ret 1; }
+    ret 0;
+}
+
+# the BACKEND SCOPE boundary (#2159): a body that is provably leak-free - the pass returns
+# ok for it on a machine target - is still REFUSED on a whole-module-emitter target, because
+# the validated MIR is not what that target executes. the refusal keys on the back half, not
+# on the body, and stays scoped to `#[oblivious]`: the same module with the marker cleared is
+# emitted untouched on both back halves.
+test "mach.lang.be.codegen.ctvalidate.scope:whole_module_backend_refused" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+    var t: target.Target = t_target(false, true);
+
+    # v2 <- add v0(secret), v1 ; ret   - a clean oblivious body, nothing the checks flag.
+    var vregs: [3]mir.MirVReg;
+    vregs[0] = t_vreg(0, true);
+    vregs[1] = t_vreg(1, false);
+    vregs[2] = t_vreg(2, false);
+    var add: [3]mir.MirOperand; add[0] = mir.op_vreg(2); add[1] = mir.op_vreg(0); add[2] = mir.op_vreg(1);
+    var b0i: [2]mir.MirInstr;
+    b0i[0] = t_instr(mir.MIR_ADD, ?add[0], 3);
+    b0i[1] = t_instr(mir.MIR_RET, nil, 0);
+    var blocks: [1]mir.MirBlock; blocks[0] = t_block(0, ?b0i[0], 2);
+
+    var funcs_on: [1]mir.MirFunction; funcs_on[0] = t_fn(true, ?blocks[0], 1, ?vregs[0], 3);
+    var mm_on: mir.MirModule; mm_on.alloc = ?alloc; mm_on.interner = nil; mm_on.functions = ?funcs_on[0]; mm_on.function_len = 1;
+
+    # a machine back half validates the body and finds it clean.
+    var mvt: isa.IsaVTable = t_isa("machine", nil);
+    t.arch = ?mvt;
+    if (!R.is_ok[bool, str](run(?t, ?mm_on))) { ret 1; }
+
+    # a whole-module emitter refuses the same function outright.
+    var hook: u8;
+    var wvt: isa.IsaVTable = t_isa("spirv", ?hook);
+    t.arch = ?wvt;
+    if (!R.is_err[bool, str](run(?t, ?mm_on))) { ret 1; }
+
+    # without the marker there is no contract to refuse: emitted untouched on both.
+    var funcs_off: [1]mir.MirFunction; funcs_off[0] = t_fn(false, ?blocks[0], 1, ?vregs[0], 3);
+    var mm_off: mir.MirModule; mm_off.alloc = ?alloc; mm_off.interner = nil; mm_off.functions = ?funcs_off[0]; mm_off.function_len = 1;
+    if (!R.is_ok[bool, str](run(?t, ?mm_off))) { ret 1; }
+    t.arch = ?mvt;
+    if (!R.is_ok[bool, str](run(?t, ?mm_off))) { ret 1; }
     ret 0;
 }
 

--- a/src/lang/driver/tests.mach
+++ b/src/lang/driver/tests.mach
@@ -4591,6 +4591,48 @@ test "mach.lang.driver:declassify_edge_consumers" {
     ret bad;
 }
 
+# constant-time (#2159): the SPIR-V back half is a whole-module emitter - mach hands a
+# module to a downstream compiler instead of emitting the instructions that execute - so an
+# `#[oblivious]` contract can be neither validated nor upheld there and is REFUSED. the same
+# function compiles clean for a machine target (the refusal keys on the back half, not the
+# body), and a secrecy-transparent function still compiles clean for SPIR-V (the refusal is
+# scoped to the marker, so secret-free and move-only code is unaffected).
+test "mach.lang.driver:oblivious_spirv_refused" {
+    var bad: i32 = 0;
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    val sr: R.Result[session.Session, str] = session.init(?alloc);
+    if (R.is_err[session.Session, str](sr)) { ret 1; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](sr);
+
+    val obl: str = "#[oblivious]\nfun mask(a: ^u32, b: ^u32) ^u32 { ret a ^ b; }\nfun main() i32 { ret 0; }\n";
+
+    # a machine target compiles the oblivious function all the way through codegen.
+    if (ut_codegen_target_ok(obl, "linux") != 0) { bad = 1; }
+
+    # the SPIR-V target refuses it, naming the target and the reason.
+    val ps: R.Result[project.Project, outcome.Fail] = ut_ct_edge_project(?s, ?alloc, obl, "spv");
+    if (R.is_err[project.Project, outcome.Fail](ps)) { bad = 1; }
+    or {
+        var p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](ps);
+        if (ut_run_codegen_err(?p, "cannot be compiled for the `spirv` target") != 0) { bad = 1; }
+        project.dnit_project(?p);
+    }
+
+    # a secrecy-transparent function carries no contract, so SPIR-V still emits it.
+    val pt: R.Result[project.Project, outcome.Fail] = ut_ct_edge_project(?s, ?alloc,
+        "fun down(a: ^u32) u32 { ret a:^; }\nfun main() i32 { ret 0; }\n", "spv");
+    if (R.is_err[project.Project, outcome.Fail](pt)) { bad = 1; }
+    or {
+        var p2: project.Project = R.unwrap_ok[project.Project, outcome.Fail](pt);
+        if (ut_run_codegen_ok(?p2) != 0) { bad = 1; }
+        project.dnit_project(?p2);
+    }
+
+    session.dnit(?s);
+    ret bad;
+}
+
 # count instructions of opcode `kind` across `p`'s lowered IR modules
 fun ut_count_op(p: *project.Project, kind: instruction.InstrKind) u32 {
     var n: u32 = 0;

--- a/src/lang/target/isa.mach
+++ b/src/lang/target/isa.mach
@@ -816,6 +816,22 @@ pub fun has_codegen(vt: *IsaVTable) bool {
     ret (vt.select != nil && vt.encode != nil) || vt.emit_module != nil;
 }
 
+# whether instruction set `vt` emits a whole MODULE image instead of machine code
+#
+# The named form of the back-half fork: a vtable wiring `emit_module` (SPIR-V) consumes
+# the lowered MIR and produces the finished module bytes itself, so isel / regalloc /
+# frame / encode never run and mach does not emit the instruction stream that ultimately
+# executes - a downstream consumer compiles the module the rest of the way. Every register
+# machine leaves the hook nil and reports false. `codegen_module` forks the pipeline on
+# this, and `ctvalidate` refuses to certify a constant-time contract for it: the two read
+# one predicate so the enforcement can never drift from the fork.
+# ---
+# vt:  the instruction-set vtable to test
+# ret: true when the ISA's back half is a whole-module emitter
+pub fun emits_whole_module(vt: *IsaVTable) bool {
+    ret vt.emit_module != nil;
+}
+
 # a blank operand of the given kind and width, with all payload fields cleared
 #
 # The shared base for the make_* operand builders: it sets `kind` and `size` and


### PR DESCRIPTION
Closes #2159

## The bypass

`codegen_module` forks to the SPIR-V whole-module emitter right after MIR lowering and returns before `ctvalidate.run`, so an `#[oblivious]` function compiled to spirv got the sema gates and the `mir.lower` compile-time gate but never the relational backstop — and the compiler reported success on a contract it had not enforced.

Demonstrated on a from-source 4.2.1 compiler, pre-fix:

- `#[oblivious] fun f(p: ^*u8) ^u8 { ret @p; }` — a secret pointer deref, which sema does **not** gate (it gates a secret *index*): the machine target is rejected by ctvalidate check (b) ("uses a secret value as a memory address"); the spirv build never produces that diagnostic.
- `#[oblivious] fun f(a: ^u32) ^u32 { asm x86_64 { nop } ret a; }`: machine target rejected by ctvalidate ("contains inline assembly … not permitted in a `#[oblivious]` function"); spirv reported only the emitter's unrelated "instruction is not yet supported".
- `#[oblivious] fun mask(a: ^u32, b: ^u32) ^u32 { ret a ^ b; }` compiled **clean** through codegen for spirv — contract accepted, nothing enforced.

## Why not "just run the validator there"

That closes the wiring gap and certifies nothing. The validator's guarantee rests on every stage after the validated layer being mach's and timing-preserving. On SPIR-V mach does not emit executed instructions at all: it emits a module that a vendor driver recompiles under no constant-time contract, onto hardware whose timing channels (SIMT divergence, memory coalescing, undocumented op latencies) this leakage model does not describe. A green validation there would state a property of an artifact nobody executes.

Worth recording precisely: within the SPIR-V emitter's current opcode set (straight-line integer arithmetic — no branches, calls, or memory) **every ctvalidate-catchable leak is already caught earlier**, by sema (branch / index / div / float) or by the lower-time gate (spirv sets `ct_trust_mul` and `ct_trust_var_shift` false, so it is stricter than x86-64 there). Running the validator on that path would therefore have added zero enforcement today while leaving the vacuous guarantee in place.

So the contract is **refused** — the rule the validator already applies to inline assembly: reject the unverifiable construct rather than trust it.

```
error: codegen: #[oblivious] function `mask` cannot be compiled for the `spirv` target: its
back half emits a module for a downstream compiler to translate rather than the instructions
that execute, and neither that translation nor the device's timing behaviour is covered by
mach's leakage model, so the constant-time contract can be neither validated nor upheld.
compile the oblivious function for a machine target and pass this one only public data
```

## Shape

- `isa.emits_whole_module(vt)` — the named form of the back-half fork predicate, read by both `codegen_module`'s fork and ctvalidate, so enforcement cannot drift from the fork.
- `ctvalidate.run` is now the **backend-neutral entry point** every back half calls: relational validation on mach's machine pipeline, refusal on a whole-module emitter. The spirv fork calls it before dispatching the emitter.
- Scoped to `#[oblivious]`. A secrecy-transparent function (`ret a:^`) still compiles clean for spirv; secret-free code is untouched.

## Verification

- Suites: mach **780 / 0** (baseline 778, +1 ctvalidate unit test, +1 driver end-to-end); mach-std **611 / 0** at pin `eff1e8e`. Both run through the from-source compiler.
- Machine targets byte-identical: fixed corpus compiled by the pre-fix and post-fix compilers, `diff -r` clean over 1230 artifacts across all six targets (linux x86_64 / arm64 / riscv64, windows-x86_64, darwin-x86_64, darwin-aarch64) — objects and linked binaries.
- Three-generation fixpoint: B == C byte-identical (A == B as well).
- Mutation-tested: deleting the ctvalidate refusal → 778 / 2; deleting the fork's `ctvalidate.run` call → 779 / 1. Both restored.

## Docs

`doc/language/secrecy.md` and `doc/language/decorators.md` state the backend scope; the #2159 entry is removed from the known-open-holes list.
