### PR TITLE
fix(build): gate codegen/emit/link phases on the diagnostic sink

### DIFF
--- a/src/lang/build/engine.mach
+++ b/src/lang/build/engine.mach
@@ -486,19 +486,34 @@ fun warm_fail(rd: *outcome.Render, bo: *outcome.BuildOutcome, f: outcome.Fail) R
     ret R.ok[outcome.BuildOutcome, outcome.Fail](@bo);
 }
 
-# dispatch one phase of the unit's vector
+# dispatch one phase of the unit's vector, then gate the result on the
+# diagnostic sink
+#
+# A phase's own pass may file a located diagnostic and still return success -
+# the report-and-continue shape #2168 found in `run_lower_pass` (a rejected
+# program lowered, linked, and ran with its diagnostic merely printed). Rather
+# than trust every phase to re-implement that check (three more copies of the
+# same `if` is exactly what let #2168 through in the first place), the sink is
+# checked once here, after every dispatch, so a phase added later inherits the
+# gate instead of needing its own copy. A phase that already returned an error
+# short-circuits past the check - its Fail is more specific than the generic
+# `reported()` this would otherwise produce.
 fun run_phase(ph: plan.PhaseKind, p: *driver.Project, unit: *plan.BuildUnit, st: *UnitState,
               bo: *outcome.BuildOutcome, oa: *A.Allocator,
               ev: *readout.Progress, rd: *outcome.Render) R.Result[bool, outcome.Fail] {
-    if (ph == plan.PH_STEPS)     { ret driver.run_steps_phase(p); }
-    if (ph == plan.PH_DEP_STEPS) { ret driver.run_dep_steps_phase(p); }
-    if (ph == plan.PH_LOAD)      { ret load_phase(p); }
-    if (ph == plan.PH_SEMA)      { ret sema_phase(p, st); }
-    if (ph == plan.PH_LOWER)     { ret lower_phase(p, st, rd); }
-    if (ph == plan.PH_CODEGEN)   { ret codegen_phase(p, st); }
-    if (ph == plan.PH_EMIT)      { ret emit_phase(p, unit, st, bo, ev); }
-    if (ph == plan.PH_LINK)      { ret link_phase(p, unit, st, bo, oa, ev); }
-    ret R.err[bool, outcome.Fail](outcome.internal("unknown build phase"));
+    var result: R.Result[bool, outcome.Fail] = R.err[bool, outcome.Fail](outcome.internal("unknown build phase"));
+    if (ph == plan.PH_STEPS)     { result = driver.run_steps_phase(p); }
+    if (ph == plan.PH_DEP_STEPS) { result = driver.run_dep_steps_phase(p); }
+    if (ph == plan.PH_LOAD)      { result = load_phase(p); }
+    if (ph == plan.PH_SEMA)      { result = sema_phase(p, st); }
+    if (ph == plan.PH_LOWER)     { result = lower_phase(p, st, rd); }
+    if (ph == plan.PH_CODEGEN)   { result = codegen_phase(p, st); }
+    if (ph == plan.PH_EMIT)      { result = emit_phase(p, unit, st, bo, ev); }
+    if (ph == plan.PH_LINK)      { result = link_phase(p, unit, st, bo, oa, ev); }
+
+    if (R.is_err[bool, outcome.Fail](result)) { ret result; }
+    if (diagnostic.has_errors(?p.s.diags)) { ret R.err[bool, outcome.Fail](outcome.reported()); }
+    ret result;
 }
 
 # PH_LOAD: the driver's load-and-resolve walk over the module graph
@@ -552,19 +567,13 @@ fun ensure_views(p: *driver.Project, st: *UnitState) R.Result[bool, outcome.Fail
 }
 
 # PH_SEMA: type-check the module graph; a graph with reported errors stops the
-# unit here so lowering and codegen never run off a broken AST
+# unit here (via run_phase's sink gate) so lowering and codegen never run off
+# a broken AST
 fun sema_phase(p: *driver.Project, st: *UnitState) R.Result[bool, outcome.Fail] {
     val vr: R.Result[bool, outcome.Fail] = ensure_views(p, st);
     if (R.is_err[bool, outcome.Fail](vr)) { ret vr; }
 
-    val res_sema: R.Result[bool, outcome.Fail] = driver.run_sema_pass(p);
-    if (R.is_err[bool, outcome.Fail](res_sema)) { ret res_sema; }
-
-    # sema filed located diagnostics; the flush is the user-facing message.
-    if (diagnostic.has_errors(?p.s.diags)) {
-        ret R.err[bool, outcome.Fail](outcome.reported());
-    }
-    ret R.ok[bool, outcome.Fail](true);
+    ret driver.run_sema_pass(p);
 }
 
 # PH_LOWER: lower + optimize every module, fill the IR views, and surface the

--- a/src/lang/driver/tests.mach
+++ b/src/lang/driver/tests.mach
@@ -25,6 +25,7 @@ use std.types.string.str_len;
 use A: std.allocator;
 use O: std.types.option;
 use R: std.types.result;
+use ctime: std.chrono.time;
 
 use mach.lang.build.outcome;
 use mach.lang.build.qctx;
@@ -34,6 +35,7 @@ use mach.lang.fe.ast;
 use mach.lang.fe.comptime;
 use mach.lang.fe.resolve;
 use mach.lang.fe.sema;
+use mach.lang.fe.token;
 use mach.lang.intern;
 use mach.lang.manifest;
 use mach.lang.me.ir;
@@ -42,6 +44,7 @@ use mach.lang.me.ir.value;
 use ir_type: mach.lang.me.ir.type;
 use mach.lang.me.pass.inline;
 use mach.lang.query;
+use mach.lang.readout;
 use mach.lang.session;
 use src: mach.lang.source;
 use mach.lang.target;
@@ -5476,6 +5479,267 @@ test "mach.lang.build.engine.execute_warm:pool_error_message_survives_teardown" 
     if (cap.fails != 1) { bad = 1; }
     if (!ut_str_contains(cap.msg, "'frobnicate'")) { bad = 1; }
     if (!ut_str_contains(cap.msg, "c.mach:"))      { bad = 1; }
+
+    fs.remove_all(?alloc, root);
+    session.dnit(?s);
+    ret bad;
+}
+
+# which `readout.Progress` callback fires a `UtDiagInject`'s synthetic error
+val UT_HOOK_PHASE_BEGIN: u8 = 0;
+val UT_HOOK_PHASE_END:   u8 = 1;
+val UT_HOOK_ITEM:        u8 = 2;
+
+# a fault injector driven through the `readout.Progress` seam (#2173): the
+# engine's own phase gate has no live trigger today - codegen, emit, and link
+# file no diagnostics yet, which is exactly the fail-open-by-omission the gate
+# closes - so the regression tests below fire a synthetic diagnostic through
+# the progress callback the target phase already invokes, proving the gate
+# closes the CLASS of bug (a phase that reports and returns success) rather
+# than waiting on one specific instance of it
+# ---
+# diags: the session sink to file the synthetic diagnostic onto
+# hook:  which callback fires the injection (a UT_HOOK_* constant)
+# ph:    the readout.PH_* phase id the hook must match
+# sev:   the injected diagnostic's severity
+# msg:   the synthetic diagnostic's message
+# fired: set once fired, so a hook invoked more than once files only one
+rec UtDiagInject {
+    diags: *diagnostic.DiagList;
+    hook:  u8;
+    ph:    u8;
+    sev:   diagnostic.Severity;
+    msg:   str;
+    fired: bool;
+}
+
+# file the injector's synthetic diagnostic when `hook`/`ph` match and it has
+# not already fired
+fun ut_diag_inject_fire(ctx: ptr, hook: u8, ph: u8) {
+    val inj: *UtDiagInject = ctx::*UtDiagInject;
+    if (inj.fired || hook != inj.hook || ph != inj.ph) { ret; }
+    inj.fired = true;
+    var sp: token.Span;
+    sp.offset = 0;
+    sp.len    = 0;
+    if (inj.sev == diagnostic.SEVERITY_ERROR) { diagnostic.error(inj.diags, 0::src.FileId, sp, inj.msg); }
+    or { diagnostic.warning(inj.diags, 0::src.FileId, sp, inj.msg); }
+}
+
+fun ut_pinj_phase_begin(ctx: ptr, ph: u8) { ut_diag_inject_fire(ctx, UT_HOOK_PHASE_BEGIN, ph); }
+
+fun ut_pinj_item_begin(ctx: ptr) ctime.Time {
+    var t: ctime.Time;
+    t.sec  = 0;
+    t.nsec = 0;
+    ret t;
+}
+
+fun ut_pinj_item(ctx: ptr, ph: u8, name: str, start: ctime.Time) { ut_diag_inject_fire(ctx, UT_HOOK_ITEM, ph); }
+
+fun ut_pinj_phase_end(ctx: ptr, ph: u8, count: u32, noun_one: str, noun_many: str) { ut_diag_inject_fire(ctx, UT_HOOK_PHASE_END, ph); }
+
+fun ut_pinj_summary(ctx: ptr, path: str, n: u32, mag: i64, unit: str, show: bool) { }
+
+# build a one-file, no-std host-native program end to end through
+# `execute_warm`, injecting a synthetic error diagnostic at the given
+# hook/phase; the shared body of the per-phase gate regressions below (#2173)
+# ---
+# hook: a UT_HOOK_* constant naming which progress callback fires the injection
+# ph:   the readout.PH_* phase id the hook must match
+# ret:  0 when the build failed and recorded no artifact (the gate caught the
+#       injected error), 1 otherwise
+fun ut_phase_gate_case(hook: u8, ph: u8) i32 {
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    val sr: R.Result[session.Session, str] = session.init(?alloc);
+    if (R.is_err[session.Session, str](sr)) { ret 1; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](sr);
+    if (R.is_err[bool, str](driver.setup_registry(?s.registry))) { session.dnit(?s); ret 1; }
+
+    var names: [1]str;
+    names[0] = "main.mach";
+    var texts: [1]str;
+    texts[0] = ut_cc3(?alloc, "#[symbol(\"", ut_entry_symbol(), "\")]\nfun start() i32 { ret 0; }\n");
+    val root_r: R.Result[str, str] = ut_scaffold(?alloc, ?names[0], ?texts[0], 1);
+    if (R.is_err[str, str](root_r)) { session.dnit(?s); ret 1; }
+    val root: str = R.unwrap_ok[str, str](root_r);
+
+    val mr: R.Result[manifest.Manifest, str] = driver.load_manifest(?s, root);
+    if (R.is_err[manifest.Manifest, str](mr)) { fs.remove_all(?alloc, root); session.dnit(?s); ret 1; }
+    var m: manifest.Manifest = R.unwrap_ok[manifest.Manifest, str](mr);
+    var rq: request.BuildRequest = request.defaults();
+    rq.project_root = root;
+    val pr: R.Result[bplan.BuildPlan, outcome.Fail] = bplan.plan(?alloc, ?s.interner, ?s.registry, ?m, ?rq);
+    if (R.is_err[bplan.BuildPlan, outcome.Fail](pr)) { fs.remove_all(?alloc, root); session.dnit(?s); ret 1; }
+    var bp: bplan.BuildPlan = R.unwrap_ok[bplan.BuildPlan, outcome.Fail](pr);
+
+    var inj: UtDiagInject;
+    inj.diags = ?s.diags;
+    inj.hook  = hook;
+    inj.ph    = ph;
+    inj.sev   = diagnostic.SEVERITY_ERROR;
+    inj.msg   = "ut synthetic: phase reported an error but returned success (#2173)";
+    inj.fired = false;
+
+    var ev: readout.Progress;
+    ev.ctx            = (?inj)::ptr;
+    ev.fn_phase_begin = ut_pinj_phase_begin;
+    ev.fn_item_begin  = ut_pinj_item_begin;
+    ev.fn_item        = ut_pinj_item;
+    ev.fn_phase_end   = ut_pinj_phase_end;
+    ev.fn_summary     = ut_pinj_summary;
+
+    var bad: i32 = 0;
+    val r: R.Result[outcome.BuildOutcome, outcome.Fail] = bengine.execute_warm(?bp, 0, ?s, ?alloc, ?ev, nil);
+    if (R.is_err[outcome.BuildOutcome, outcome.Fail](r)) { bad = 1; }
+    or {
+        val bo: outcome.BuildOutcome = R.unwrap_ok[outcome.BuildOutcome, outcome.Fail](r);
+        if (bo.ok)                 { bad = 1; }
+        if (bo.artifacts.len != 0) { bad = 1; }
+    }
+    if (!inj.fired) { bad = 1; }
+
+    fs.remove_all(?alloc, root);
+    session.dnit(?s);
+    ret bad;
+}
+
+# a diagnostic filed during PH_CODEGEN (#2173): `codegen_phase` adopts every
+# module's object image and returns success with no look at the sink, so an
+# error filed there - synthetically, at `run_codegen_pass`'s own PH_CODEGEN
+# `phase_end` narration, exactly where a future codegen-side check would file
+# one - must still fail the build before PH_EMIT ever writes an object. no
+# object or link narration has fired by the injection point, so nothing is
+# written to disk on the caught path.
+test "mach.lang.build.engine.execute_warm:codegen_phase_diagnostic_fails_build" {
+    ret ut_phase_gate_case(UT_HOOK_PHASE_END, readout.PH_CODEGEN);
+}
+
+# a diagnostic filed during PH_EMIT (#2173): `emit_phase` writes the per-module
+# `.ir`/`.s` dumps and objects with no look at the sink, so an error filed at
+# its very first statement - the link-narration span's `phase_begin`, which
+# `begin_link_narration` fires unconditionally for a GOAL_EXECUTE unit - must
+# still fail the build before PH_LINK ever runs.
+test "mach.lang.build.engine.execute_warm:emit_phase_diagnostic_fails_build" {
+    ret ut_phase_gate_case(UT_HOOK_PHASE_BEGIN, readout.PH_LINK);
+}
+
+# a diagnostic filed during PH_LINK (#2173): `link_phase` narrates its produced
+# binary's `item` event, then returns success, with no look at the sink - the
+# exact shape #2168 found in `run_lower_pass` (a rejected program linked and ran
+# because the phase that owned the diagnostic returned ok anyway). injecting at
+# that `item` event, right where a future link-side check would file one, must
+# still leave the build's outcome failed with no recorded artifact, even though
+# the binary bytes are already on disk by then - matching #2168's own shape,
+# where the artifact existed and only the reported OUTCOME was wrong.
+test "mach.lang.build.engine.execute_warm:link_phase_diagnostic_fails_build" {
+    ret ut_phase_gate_case(UT_HOOK_ITEM, readout.PH_LINK);
+}
+
+# over-rejection control (#2173): `diagnostic.has_errors` counts only
+# SEVERITY_ERROR, so a WARNING left on the sink by a phase - the same
+# `readout.Progress` injection the regressions above use, at PH_CODEGEN's
+# `phase_end` - must not trip run_phase's gate. A legitimate program may not
+# start failing because a recoverable diagnostic sits on the sink.
+test "mach.lang.build.engine.execute_warm:warning_only_sink_does_not_fail_build" {
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    val sr: R.Result[session.Session, str] = session.init(?alloc);
+    if (R.is_err[session.Session, str](sr)) { ret 1; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](sr);
+    if (R.is_err[bool, str](driver.setup_registry(?s.registry))) { session.dnit(?s); ret 1; }
+
+    var names: [1]str;
+    names[0] = "main.mach";
+    var texts: [1]str;
+    texts[0] = ut_cc3(?alloc, "#[symbol(\"", ut_entry_symbol(), "\")]\nfun start() i32 { ret 0; }\n");
+    val root_r: R.Result[str, str] = ut_scaffold(?alloc, ?names[0], ?texts[0], 1);
+    if (R.is_err[str, str](root_r)) { session.dnit(?s); ret 1; }
+    val root: str = R.unwrap_ok[str, str](root_r);
+
+    val mr: R.Result[manifest.Manifest, str] = driver.load_manifest(?s, root);
+    if (R.is_err[manifest.Manifest, str](mr)) { fs.remove_all(?alloc, root); session.dnit(?s); ret 1; }
+    var m: manifest.Manifest = R.unwrap_ok[manifest.Manifest, str](mr);
+    var rq: request.BuildRequest = request.defaults();
+    rq.project_root = root;
+    val pr: R.Result[bplan.BuildPlan, outcome.Fail] = bplan.plan(?alloc, ?s.interner, ?s.registry, ?m, ?rq);
+    if (R.is_err[bplan.BuildPlan, outcome.Fail](pr)) { fs.remove_all(?alloc, root); session.dnit(?s); ret 1; }
+    var bp: bplan.BuildPlan = R.unwrap_ok[bplan.BuildPlan, outcome.Fail](pr);
+
+    var inj: UtDiagInject;
+    inj.diags = ?s.diags;
+    inj.hook  = UT_HOOK_PHASE_END;
+    inj.ph    = readout.PH_CODEGEN;
+    inj.sev   = diagnostic.SEVERITY_WARNING;
+    inj.msg   = "ut synthetic: a recoverable diagnostic that must not fail the build (#2173)";
+    inj.fired = false;
+
+    var ev: readout.Progress;
+    ev.ctx            = (?inj)::ptr;
+    ev.fn_phase_begin = ut_pinj_phase_begin;
+    ev.fn_item_begin  = ut_pinj_item_begin;
+    ev.fn_item        = ut_pinj_item;
+    ev.fn_phase_end   = ut_pinj_phase_end;
+    ev.fn_summary     = ut_pinj_summary;
+
+    var bad: i32 = 0;
+    val r: R.Result[outcome.BuildOutcome, outcome.Fail] = bengine.execute_warm(?bp, 0, ?s, ?alloc, ?ev, nil);
+    if (R.is_err[outcome.BuildOutcome, outcome.Fail](r)) { bad = 1; }
+    or {
+        val bo: outcome.BuildOutcome = R.unwrap_ok[outcome.BuildOutcome, outcome.Fail](r);
+        if (!bo.ok)                { bad = 1; }
+        if (bo.artifacts.len != 1) { bad = 1; }
+        or (!fs.is_file(bo.artifacts.data[0].path)) { bad = 1; }
+    }
+    # the warning must actually have fired (else this proves nothing) and the
+    # sink must still hold it, unpromoted to an error.
+    if (!inj.fired)                      { bad = 1; }
+    if (diagnostic.has_errors(?s.diags)) { bad = 1; }
+    if (s.diags.len == 0)                { bad = 1; }
+
+    fs.remove_all(?alloc, root);
+    session.dnit(?s);
+    ret bad;
+}
+
+# sema's engine-level gate, still exercised end to end through `execute_warm`
+# now that `sema_phase` no longer carries its own inline sink check (#2173
+# folded it into run_phase's generic gate, which subsumes it): a real type
+# error must still fail the build before lowering or codegen ever run.
+test "mach.lang.build.engine.execute_warm:sema_phase_diagnostic_fails_build" {
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    val sr: R.Result[session.Session, str] = session.init(?alloc);
+    if (R.is_err[session.Session, str](sr)) { ret 1; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](sr);
+    if (R.is_err[bool, str](driver.setup_registry(?s.registry))) { session.dnit(?s); ret 1; }
+
+    var names: [1]str;
+    names[0] = "main.mach";
+    var texts: [1]str;
+    texts[0] = ut_cc3(?alloc, "#[symbol(\"", ut_entry_symbol(), "\")]\nfun start() i32 { val x: u32 = \"not a u32\"; ret 0; }\n");
+    val root_r: R.Result[str, str] = ut_scaffold(?alloc, ?names[0], ?texts[0], 1);
+    if (R.is_err[str, str](root_r)) { session.dnit(?s); ret 1; }
+    val root: str = R.unwrap_ok[str, str](root_r);
+
+    val mr: R.Result[manifest.Manifest, str] = driver.load_manifest(?s, root);
+    if (R.is_err[manifest.Manifest, str](mr)) { fs.remove_all(?alloc, root); session.dnit(?s); ret 1; }
+    var m: manifest.Manifest = R.unwrap_ok[manifest.Manifest, str](mr);
+    var rq: request.BuildRequest = request.defaults();
+    rq.project_root = root;
+    val pr: R.Result[bplan.BuildPlan, outcome.Fail] = bplan.plan(?alloc, ?s.interner, ?s.registry, ?m, ?rq);
+    if (R.is_err[bplan.BuildPlan, outcome.Fail](pr)) { fs.remove_all(?alloc, root); session.dnit(?s); ret 1; }
+    var bp: bplan.BuildPlan = R.unwrap_ok[bplan.BuildPlan, outcome.Fail](pr);
+
+    var bad: i32 = 0;
+    val r: R.Result[outcome.BuildOutcome, outcome.Fail] = bengine.execute_warm(?bp, 0, ?s, ?alloc, nil, nil);
+    if (R.is_err[outcome.BuildOutcome, outcome.Fail](r)) { bad = 1; }
+    or {
+        val bo: outcome.BuildOutcome = R.unwrap_ok[outcome.BuildOutcome, outcome.Fail](r);
+        if (bo.ok)                 { bad = 1; }
+        if (bo.artifacts.len != 0) { bad = 1; }
+    }
 
     fs.remove_all(?alloc, root);
     session.dnit(?s);


### PR DESCRIPTION
## Summary

`codegen_phase`, `emit_phase`, and `link_phase` in `src/lang/build/engine.mach` returned success while an error diagnostic sat on the sink - the same fail-open-by-omission #2168 found in `run_lower_pass` (PR #2170 gates that one, in `driver/passes.mach`). `sema_phase` already gated correctly.

**Shape chosen:** structural, not three more inline copies of the same `if`. `run_phase` - the single dispatch point every phase already flows through - now checks `diagnostic.has_errors` once, after every phase's dispatch, converting a report-and-continue success into `outcome.reported()`. This covers all eight phases (STEPS/DEP_STEPS/LOAD/SEMA/LOWER/CODEGEN/EMIT/LINK) uniformly, so a phase added later inherits the gate automatically. `sema_phase`'s own inline check became redundant under the generic gate and was folded away (own check removed; behavior unchanged, one less copy of the `if`).

**Audit:** the only other phase-dispatch loop in the codebase is `run_phase` itself (CLI build/test, `editor.mach`, and the union-load-only path all route through `engine.execute`/`execute_warm`/`execute_warm_all`, which share it). `driver.run_lower_pass`'s own gap is PR #2170's to close (not touched here - out of this PR's scope per the coordinating session). No other pass-level report-and-continue gap was found; the codegen/emit/link backends file no diagnostics today (confirmed by grep), which is exactly why the class was latent rather than live.

## Test plan

- [x] Built from source (seed 4.2.1); 3-generation self-host fixpoint reached (A == B == C, byte-identical - even tighter than the required B == C)
- [x] Regression test per phase (`src/lang/driver/tests.mach`), via a `readout.Progress`-driven fault injector (no live diagnostic exists yet in codegen/emit/link, so the injector proves the gate closes the *class* of bug): `codegen_phase_diagnostic_fails_build`, `emit_phase_diagnostic_fails_build`, `link_phase_diagnostic_fails_build` - each proven to fail pre-fix (780 passed / 3 failed / 783 total against the reverted engine.mach)
- [x] Mutation test: deleting the added gate line reproduces 4 failures (the 3 above + `sema_phase_diagnostic_fails_build`, since sema's own check now folds into the same gate) - 779 passed / 4 failed / 783 total; gate restored, 783/0
- [x] Over-rejection control: a warning-severity diagnostic on the sink (`warning_only_sink_does_not_fail_build`) does not fail the build - `diagnostic.has_errors` only counts `SEVERITY_ERROR`
- [x] Full suite: `mach test .` 783 passed / 0 failed (778 baseline + 5 new)
- [x] `mach-std` at pin `eff1e8e` (verified via `git rev-parse HEAD`): 611 passed / 0 failed
