### PR TITLE
fix(codegen): return an indirect scalar by value — #2195 was a real miscompile, not a validator over-taint

### DIFF
--- a/src/lang/be/codegen/mir/abi.mach
+++ b/src/lang/be/codegen/mir/abi.mach
@@ -826,6 +826,14 @@ pub fun lower_call(ctx: *context.LowerCtx, mb: *mir.MirBlock, inst: *instruction
     # a vector return is the memory (sret) class on a scalarized target: it arrives by
     # address exactly like an aggregate, so it needs caller-owned result storage.
     val ret_mem:   bool = ret_aggr || (context.value_is_vector(ctx, ret_type) && rslot.class == abi.CLASS_SRET);
+    # a SCALAR returned indirectly: a convention with no register wide enough for the
+    # value (mos6502 returns everything past one byte this way) still hands the callee
+    # caller-owned storage, but the result is a VALUE, so the storage ADDRESS rides its
+    # own vreg and the value is loaded back out after the call - the result vreg must
+    # hold the scalar, not a pointer to it (#2195). Every wide-native convention reaches
+    # CLASS_SRET only for an aggregate (lp64 also for a vector, covered by `ret_mem`),
+    # so this is false there and the lowering is byte-identical.
+    val ret_sret_scalar: bool = rslot.class == abi.CLASS_SRET && !ret_mem;
 
     # the running register / stack cursors resume from the fixed-parameter walk so
     # a variadic call's tail arguments continue against the same counters.
@@ -839,8 +847,25 @@ pub fun lower_call(ctx: *context.LowerCtx, mb: *mir.MirBlock, inst: *instruction
     # move (>16B) passes it and the two-register form (9-16B) stores each half into
     # it; downstream consumers then read the aggregate result by this pointer.
     val res_dst: u32 = context.instr_vreg(ctx, iid);
+    # the hidden result-storage pointer the callee writes through: the result vreg
+    # itself for a by-address return, a separate address vreg for an indirect scalar.
+    var sret_ptr: u32 = mir.MIR_VREG_NIL;
     if (ret_mem && res_dst != mir.MIR_VREG_NIL) {
         val ra: R.Result[bool, str] = context.alloc_result_storage(ctx, mb, res_dst, ret_size, context.ret_align(ctx, ret_type));
+        if (R.is_err[bool, str](ra)) {
+            sig_layout_free(ctx, ?layout);
+            ret ra;
+        }
+        sret_ptr = res_dst;
+    }
+    or (ret_sret_scalar && res_dst != mir.MIR_VREG_NIL) {
+        val sa: R.Result[u32, str] = context.new_vreg(ctx, mir.REG_CLASS_GP);
+        if (R.is_err[u32, str](sa)) {
+            sig_layout_free(ctx, ?layout);
+            ret R.err[bool, str](R.unwrap_err[u32, str](sa));
+        }
+        sret_ptr = R.unwrap_ok[u32, str](sa);
+        val ra: R.Result[bool, str] = context.alloc_result_storage(ctx, mb, sret_ptr, ret_size, context.ret_align(ctx, ret_type));
         if (R.is_err[bool, str](ra)) {
             sig_layout_free(ctx, ?layout);
             ret ra;
@@ -850,12 +875,12 @@ pub fun lower_call(ctx: *context.LowerCtx, mb: *mir.MirBlock, inst: *instruction
     if (rslot.class == abi.CLASS_SRET) {
         # the caller allocates the return storage (above) and passes its address in
         # the convention's indirect-result register (RDI under SysV, RCX under win64,
-        # the dedicated X8 under AAPCS64); the result vreg names that storage. for an
-        # in-argfile convention the layout already reserved the GP slot in `gp_used`.
-        if (res_dst != mir.MIR_VREG_NIL) {
+        # the dedicated X8 under AAPCS64). for an in-argfile convention the layout
+        # already reserved the GP slot in `gp_used`.
+        if (sret_ptr != mir.MIR_VREG_NIL) {
             val sret_reg: i32 = ctx.tgt.abi.indirect_result_reg;
             val pre: R.Result[bool, str] = context.emit_mov(ctx, mb,
-                mir.op_preg(sret_reg::u32), mir.op_vreg(res_dst));
+                mir.op_preg(sret_reg::u32), mir.op_vreg(sret_ptr));
             if (R.is_err[bool, str](pre)) {
                 sig_layout_free(ctx, ?layout);
                 ret pre;
@@ -1005,6 +1030,13 @@ pub fun lower_call(ctx: *context.LowerCtx, mb: *mir.MirBlock, inst: *instruction
     if (dst != mir.MIR_VREG_NIL && rslot.class != abi.CLASS_SRET) {
         val rr: R.Result[bool, str] = emit_ret_slot_to_vreg(ctx, mb, rslot, dst, ret_aggr, ret_size);
         if (R.is_err[bool, str](rr)) { ret rr; }
+    }
+    # an indirect SCALAR return: the callee stored the value into the caller-owned
+    # storage, so load it back at the scalar's own width. a by-address return needs no
+    # such reload - its result vreg already names the storage (#2195).
+    if (ret_sret_scalar && dst != mir.MIR_VREG_NIL) {
+        val lr: R.Result[bool, str] = context.emit_load_from_w(ctx, mb, dst, mir.op_mem_value(sret_ptr, 0), ret_size::u8);
+        if (R.is_err[bool, str](lr)) { ret lr; }
     }
     if (dst != mir.MIR_VREG_NIL) {
         val rres: R.Result[*mir.MirOperand, str] = A.allocate[mir.MirOperand](ctx.alloc, 1::usize);
@@ -1603,15 +1635,27 @@ pub fun lower_ret(ctx: *context.LowerCtx, mb: *mir.MirBlock, inst: *instruction.
     val rvop: mir.MirOperand = R.unwrap_ok[mir.MirOperand, str](rvr);
 
     if (slot.class == abi.CLASS_SRET) {
-        # copy the returned aggregate into the caller-owned result storage (the
-        # hidden pointer captured from the first GP argument register in
-        # `lower_params`), then return that pointer in RAX. without the copy the
-        # callee would return the address of a dead local the caller never reads.
+        # write the returned value into the caller-owned result storage (the hidden
+        # pointer captured from the indirect-result register in `lower_params`), then
+        # return that pointer in the return register. without the write the callee would
+        # return the address of a dead local the caller never reads.
         if (ctx.sret_vreg == mir.MIR_VREG_NIL) {
             ret R.err[bool, str]("mir.lower_ir: sret return without a captured result-storage pointer");
         }
-        val cr: R.Result[bool, str] = context.copy_aggregate(ctx, mb, mir.op_mem_value(ctx.sret_vreg, 0), rvop, rsz);
-        if (R.is_err[bool, str](cr)) { ret cr; }
+        # an aggregate / vector flows BY ADDRESS, so `rvop` is a pointer and the write is
+        # a memcpy out of that storage. a SCALAR returned indirectly - a convention with
+        # no register wide enough for it, mos6502's every-return-past-one-byte - is a
+        # VALUE in a register, so it is STORED at the scalar's own width: memcpy'ing from
+        # it would dereference the value as an address (#2195). Every wide-native
+        # convention reaches CLASS_SRET only for an aggregate (lp64 also for a vector),
+        # so the scalar arm is unreachable there and this is byte-identical.
+        if (rag || context.value_is_vector(ctx, rt)) {
+            val cr: R.Result[bool, str] = context.copy_aggregate(ctx, mb, mir.op_mem_value(ctx.sret_vreg, 0), rvop, rsz);
+            if (R.is_err[bool, str](cr)) { ret cr; }
+        } or {
+            val sr: R.Result[bool, str] = context.emit_store_to_w(ctx, mb, mir.op_mem_value(ctx.sret_vreg, 0), rvop, rsz::u8);
+            if (R.is_err[bool, str](sr)) { ret sr; }
+        }
         val mr: R.Result[bool, str] = context.emit_mov(ctx, mb, mir.op_preg(slot.reg::u32), mir.op_vreg(ctx.sret_vreg));
         if (R.is_err[bool, str](mr)) { ret mr; }
     } or (rag) {

--- a/src/lang/be/codegen/mir/context.mach
+++ b/src/lang/be/codegen/mir/context.mach
@@ -779,6 +779,21 @@ pub fun emit_store_to_w(ctx: *LowerCtx, mb: *mir.MirBlock, mem: mir.MirOperand, 
     ret inst2(ctx, mb, mir.MIR_STORE, mem, src, width, width);
 }
 
+# append a `mir.MIR_LOAD (dst) <- (mem)` at an explicit `width`
+#
+# The read twin of `emit_store_to_w`: used to reload an indirectly-returned SCALAR
+# out of the caller-owned result storage at the scalar's own width (#2195).
+# ---
+# ctx:   the lowering context
+# mb:    the block to append to
+# dst:   the destination value vreg
+# mem:   the memory source operand
+# width: the load width in bytes
+# ret:   true on success, or an allocation error
+pub fun emit_load_from_w(ctx: *LowerCtx, mb: *mir.MirBlock, dst: u32, mem: mir.MirOperand, width: u8) R.Result[bool, str] {
+    ret inst2(ctx, mb, mir.MIR_LOAD, mir.op_vreg(dst), mem, width, width);
+}
+
 # emit one `mir.MIR_STORE [mem] <- (src)` at an explicit byte width, used by the
 # aggregate memcpy expansion
 #

--- a/src/lang/driver/tests.mach
+++ b/src/lang/driver/tests.mach
@@ -4667,6 +4667,71 @@ test "mach.lang.driver:secret_shift_codegen_rejected_mos6502" {
     ret bad;
 }
 
+# constant-time (#2195): an indirectly-returned SCALAR is written to the caller's storage
+# BY VALUE, so a secret return never becomes a secret memory ADDRESS
+#
+# mos6502 returns everything past one byte through a caller-provided hidden pointer, the
+# only convention that classifies a plain SCALAR that way (sysv / win64 / aapcs64 reach
+# CLASS_SRET for an aggregate, lp64 also for a vector). `lower_ret` assumed a CLASS_SRET
+# value always flows BY ADDRESS and memcpy'd out of it, so a `^u32` return had its VALUE
+# dereferenced as an address - `LOAD t <- [secret]` - and #1648's validator, reading that
+# MIR exactly right, rejected the function for a program containing no memory access at
+# all. The corrected lowering emits `STORE [sret_ptr] <- v`: a secret VALUE at a PUBLIC
+# address, which the validator passes (the shape `ctvalidate.clean:valid_oblivious_no_
+# false_positive` pins at the mechanism level - this pins that the LOWERING produces it).
+#
+# THE NEEDLES ARE ASYMMETRIC AND BOTH LOAD-BEARING. [1] asserts the leak diagnostic is
+# GONE, which is the fix. [2] pins what mos6502 says INSTEAD, so the rejection stays an
+# accurate statement of the target's own frontier rather than silently regressing to the
+# leak message; that frontier - the wide store through a runtime pointer the width
+# legalizer does not split - is #2216's, and this needle moves when #2216 lands.
+#
+# [3] drives the same assertions through a CALL of the wide-scalar-returning function,
+# covering the caller half of the fix: without it the call allocates no result storage and
+# passes the undefined result vreg as the hidden pointer, and returning that result
+# reproduces the same secret-as-address rejection.
+test "mach.lang.driver:indirect_scalar_return_not_a_secret_address_mos6502" {
+    var bad: i32 = 0;
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    val sr: R.Result[session.Session, str] = session.init(?alloc);
+    if (R.is_err[session.Session, str](sr)) { ret 1; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](sr);
+
+    val callee: str = "#[oblivious]\nfun f(v: ^u32) ^u32 { ret v; }\nfun main() i32 { ret 0; }\n";
+    val caller: str = "#[oblivious]\nfun f(v: ^u32) ^u32 { ret v; }\n#[oblivious]\nfun g(v: ^u32) ^u32 { ret f(v); }\nfun main() i32 { ret 0; }\n";
+
+    # [1] the secret return is no longer read as a secret address.
+    val p1: R.Result[project.Project, outcome.Fail] = ut_ct_edge_project(?s, ?alloc, callee, "mos");
+    if (R.is_err[project.Project, outcome.Fail](p1)) { bad = 1; }
+    or {
+        var pa: project.Project = R.unwrap_ok[project.Project, outcome.Fail](p1);
+        if (ut_run_codegen_without(?pa, "secret value as a memory address") != 0) { bad = 1; }
+        project.dnit_project(?pa);
+    }
+
+    # [2] and the rejection it does get names the target's real limitation.
+    val p2: R.Result[project.Project, outcome.Fail] = ut_ct_edge_project(?s, ?alloc, callee, "mos");
+    if (R.is_err[project.Project, outcome.Fail](p2)) { bad = 1; }
+    or {
+        var pb: project.Project = R.unwrap_ok[project.Project, outcome.Fail](p2);
+        if (ut_run_codegen_err(?pb, "wide memory access is not yet legalized") != 0) { bad = 1; }
+        project.dnit_project(?pb);
+    }
+
+    # [3] the caller half: a CALL returning a wide secret scalar is equally address-free.
+    val p3: R.Result[project.Project, outcome.Fail] = ut_ct_edge_project(?s, ?alloc, caller, "mos");
+    if (R.is_err[project.Project, outcome.Fail](p3)) { bad = 1; }
+    or {
+        var pc: project.Project = R.unwrap_ok[project.Project, outcome.Fail](p3);
+        if (ut_run_codegen_without(?pc, "secret value as a memory address") != 0) { bad = 1; }
+        project.dnit_project(?pc);
+    }
+
+    session.dnit(?s);
+    ret bad;
+}
+
 # constant-time (#2159): the SPIR-V back half is a whole-module emitter - mach hands a
 # module to a downstream compiler instead of emitting the instructions that execute - so an
 # `#[oblivious]` contract can be neither validated nor upheld there and is REFUSED. the same


### PR DESCRIPTION
Closes #2195

## The premise of #2195 does not hold

There is no over-taint. `ctvalidate` was **correct**: the MIR it was handed genuinely used a secret value as a memory address. The defect is a wrong-code bug in target-independent ABI lowering that the validator surfaced.

## Evidence

The issue framed this as a `^u32` shifted by a public count. The shift is a red herring — this program, **no shift at all**, produces the identical diagnostic on mos6502:

```mach
#[oblivious]
fun f(v: ^u32) ^u32 { ret v; }
```
```
error: codegen: #[oblivious] function `_M2ct4mainN1f` uses a secret value as a memory address; ...
```

The pre-legalization MIR `ctvalidate` reads (v0 = secret param, seed set; v3 = sret pointer, public):

```
MOV   v3 <- preg4              # sret hidden pointer
MOV   v0 <- [preg0 + 0]  w=1   # the ^u32 stack param
LOAD  v4 <- [v0 + 0]     w=4   # <-- dereferences the secret VALUE as an address
STORE [v3] <- v4         w=4
MOV   preg4 <- v3
RET
```

`LOAD v4 <- [v0]` is real. It is not a legalizer spill/reload (this pass runs *before* legalization, as specified) and not a fixed frame offset. It has nothing to do with secrecy either — the public analogue `#[oblivious] fun g(a: u8, b: u8) u16 { ret a::u16 + b::u16; }` lowers to the same shape (`ADD v8; LOAD v10 <- [v8]; STORE [v9] <- v10`).

## Root cause

`mir/abi.mach: lower_ret`, the `CLASS_SRET` arm, called `copy_aggregate(dst=[sret_vreg], src=rvop, size)` — a memcpy that treats `rvop` as an **address**. Correct for an aggregate (which flows by address); wrong for a **scalar**, where `rvop` is the value itself. mos6502 is the only convention that classifies a plain scalar `CLASS_SRET` (it returns everything past one byte that way); sysv / win64 / aapcs64 reach it only for `is_aggregate`, lp64 also for `is_vector` — which `lower_call` already covered.

`lower_call` broke symmetrically: `ret_mem` gated result-storage allocation on aggregate-ness, so a scalar SRET call allocated **no storage** and passed the **undefined** result vreg as the hidden pointer, then skipped binding the result. Both sides are fixed here; half would be worse than neither.

### The corrected MIR

Callee — a secret **value** at a **public** address, which the validator passes:
```
MOV   v3 <- preg4
MOV   v0 <- [preg0 + 0]
STORE [v3] <- v0    w=4        # <-- by value
MOV   preg4 <- v3
RET
```
Caller — storage allocated, pointer passed, value reloaded (all addresses public):
```
ALLOCA v5 <- [slot]            # <-- new: caller-owned result storage
MOV    preg4 <- v5             #     hidden pointer
CALL   f
LOAD   v3 <- [v5 + 0]  w=4     # <-- new: reload the scalar VALUE
```

## Before / after on mos6502

| program | before | after |
|---|---|---|
| `fun f(v: ^u32) ^u32 { ret v; }` | `uses a secret value as a memory address` | `legalize: wide memory access is not yet legalized on this target` |
| `fun f(v: ^u32, n: u32) ^u32 { ret v << n; }` | `uses a secret value as a memory address` | `legalize: wide shift is not yet legalized on this target` |

A misleading rejection naming a construct the source does not contain becomes an accurate one naming the real target limitation.

## Scope: what this PR does not do

mos6502 still cannot *build* these programs. That is the honest state of the target, not a gap left by this change:

- the sret store is wide **through a runtime pointer**, which the legalizer explicitly rejects (needs a paired-pointer register class on a 2-byte-pointer target) — **#2216**, together with the sibling defects found in passing (wide stack params loaded at `gpr_width` = 1 byte, visible as the `w=1` above; `scalar_reg_move_width` special-casing only size 4);
- a wide **variable** shift on an 8-bit ALU needs control flow the legalizer has no machinery to emit — **#2217**.

**The executed-bytes constant-time proof therefore moves to #2216**, where mos6502 first produces executable bytes. Nothing executable is produced here, so there is nothing to run. Stating that plainly rather than leaving it as an unexplained gap.

## Verification

**Byte-identity, proved with objects.** One fixed corpus (the compiler source at `eed1fd22`) compiled by the baseline and the fixed compiler for `linux-x86_64` / `linux-arm64` / `linux-riscv64`: **615 artifacts** (612 `.o` + 3 linked binaries), `diff -r` clean. Both new arms are unreachable on every wide-native convention, and this proves it rather than asserting it from a reading of `ret_passing`.

**Suites.** mach **791 / 0** (790 baseline + the one test added here). mach-std **611 / 0** at pin `eff1e8e`, verified with `git rev-parse HEAD` against `mach.lock`.

**Three-generation fixpoint.** A == B == C, all three identical (`sha256 3175a62c…`) — full fixpoint, not merely B == C.

**Mutation tests.**
- Restore the unconditional memcpy in `lower_ret` → **790 passed, 1 failed**, exactly `mach.lang.driver:indirect_scalar_return_not_a_secret_address_mos6502`.
- Neuter check (b), the secret-address check in `ctvalidate` → **790 passed, 1 failed**, `mach.lang.be.codegen.ctvalidate.rederive:inlined_return_address`. Enforcement is live and unweakened — the strongest form being that `ctvalidate.mach` is **untouched** by this PR.

On the enforcement arm generally: a secret-dependent address is **unconstructable from mach source**, by design. `p + i` on a `^u8` index is `type mismatch: incompatible operand types`, and laundering it is `cast: `::` and `:~` cannot add or drop the secret qualifier `^``. The validator’s address check is a backstop against a future pass introducing one, which is why it is exercised at the MIR level — and that is what the mutation above kills.

## Worth saying out loud

`ctvalidate` did its job. It reported a real `LOAD v <- [secret_value]` and surfaced a wrong-code bug in shared lowering that nothing else had caught. Not a shared root cause with #2196 (that one is sema-side literal coercion; no literal is involved here).
