### PR TITLE
feat(codegen): vectorize module-scope arrays and loop-invariant scalars

### DIFF
--- a/int/lib/produce.sh
+++ b/int/lib/produce.sh
@@ -25,6 +25,11 @@
 #                 image and `-g` is loadable-byte additive (PT_LOAD segments identical).
 #                 the one producer that needs external validators (llvm-dwarfdump,
 #                 readelf); it runs only on the ELF debug-info legs, which install them.
+#   vector-emit — disassemble the case's own objects and report, per function,
+#                 whether the compiler EMITTED packed SIMD (#2207). the observable
+#                 execution cannot produce: a vectorizer that silently stops firing
+#                 still computes the right answer, so a run-and-compare case stays
+#                 green while the feature is dead. needs llvm-objdump.
 #
 # build-fails is a run-mode but not a producer: it asserts the compile is REJECTED
 # and takes the compiler's 'error:' diagnostic as the observable. it is handled in
@@ -254,6 +259,144 @@ produce_debuginfo() {
     fi
 }
 
+# resolve_objdump — print an llvm-objdump on PATH, preferring the unversioned name
+# and falling back to the highest-versioned one (ubuntu ships llvm-objdump-NN, from
+# the same `llvm` package as llvm-dwarfdump). llvm-objdump decodes every ISA mach
+# targets regardless of the runner's own, which GNU objdump does not. empty output
+# (return 1) when none is installed.
+resolve_objdump() {
+    if command -v llvm-objdump >/dev/null 2>&1; then echo llvm-objdump; return 0; fi
+    newest=$(compgen -c 'llvm-objdump-' 2>/dev/null | sort -t- -k3 -n | tail -1)
+    [ -n "$newest" ] && { echo "$newest"; return 0; }
+    return 1
+}
+
+# produce_vector_emit <runmode> <target> <binary>
+# the auto-vectorizer's EMISSION observable (#2207): for each function of the case's
+# own module, whether the emitted machine code contains packed SIMD instructions.
+#
+# a vectorize case that only runs the program and compares against a `#[scalar]`
+# reference is vacuously green when the pass declines — both sides are scalar and
+# agree — so this is the only assertion that can see the pass stop firing, or start
+# firing on a shape it must refuse. it disassembles the OBJECTS rather than the
+# linked binary: mach's linker emits no symbol table, so per-function attribution
+# exists only before the link. the objects sit beside the artifact because the case
+# pins `out = "out/int/build"` in its own manifest; the project id (the directory
+# under obj/ holding the case's modules, as opposed to its dependencies') is read
+# from that same manifest rather than assumed.
+#
+# the per-function verdict, not the instruction count, is the observable: the count
+# moves with every unrelated backend change, while `simd` / `scalar` moves only when
+# the vectorizer's own decision does.
+produce_vector_emit() {
+    bin=$3
+    dir=$(dirname "$(dirname "$(dirname "$bin")")")
+    id=$(sed -n 's/^[[:space:]]*id[[:space:]]*=[[:space:]]*"\([^"]*\)".*/\1/p' "$dir/mach.toml" | head -1)
+    if [ -z "$id" ]; then
+        echo "int: vector-emit: no project id in ${dir}/mach.toml" >&2; return 2
+    fi
+    objdir="$dir/out/int/build/obj/$id"
+    if [ ! -d "$objdir" ]; then
+        echo "int: vector-emit: no objects at $objdir (the case must pin out = \"out/int/build\")" >&2; return 2
+    fi
+    tool=$(resolve_objdump) || {
+        echo "int: vector-emit: llvm-objdump not found (install the 'llvm' package)" >&2; return 2
+    }
+    find "$objdir" -name '*.o' | sort | while IFS= read -r o; do
+        "$tool" -d --no-show-raw-insn "$o"
+    done | vector_emit_scan
+}
+
+# vector_emit_scan — read a disassembly on stdin, print `<function> simd|scalar`
+# sorted by function, preceded by the ISA the dispatch resolved.
+#
+# packed-SIMD recognition is per ISA and deliberately narrow, so a scalar function
+# can never read as vectorized:
+#   x86_64  — the packed SSE opcodes, plus MOVUPS / MOVAPS / MOVDQU / MOVDQA, which
+#             the backend emits only for a 128-bit value. the scalar `*ss` / `*sd`
+#             forms and the bank-crossing MOVD / MOVQ are excluded, as is XORPS,
+#             which zeroes an XMM for scalar float negation, and PXOR, which clears
+#             one.
+#   aarch64 — any operand naming a NEON register: a `vN.<arrangement>` or a 128-bit
+#             `qN`. scalar float uses `sN` / `dN` and never matches.
+#   riscv64 — any RVV mnemonic (`v...`); no scalar riscv64 mnemonic starts with `v`.
+#             riscv64 has no 128-bit vector model, so every verdict there is scalar.
+# a case whose source writes SIMD types directly would defeat this (its packed ops
+# are not the vectorizer's); the vectorize cases use scalar element types only.
+vector_emit_scan() {
+    awk '
+    function demangle(s,   i, len, c, out) {
+        if (substr(s, 1, 2) != "_M") { return s }
+        i = 3
+        out = ""
+        while (i <= length(s)) {
+            c = substr(s, i, 1)
+            if (c == "N") { i++; continue }
+            if (c !~ /[0-9]/) { return s }
+            len = 0
+            while (i <= length(s) && substr(s, i, 1) ~ /[0-9]/) { len = len * 10 + substr(s, i, 1); i++ }
+            out = substr(s, i, len)
+            i += len
+        }
+        if (out == "") { return s }
+        return out
+    }
+    function packed(m, rest) {
+        if (isa == "x86_64") {
+            if (m ~ /^(movup[sd]|movap[sd]|movdq[au])$/) { return 1 }
+            if (m ~ /^(add|sub|mul|div|min|max|sqrt|rcp|rsqrt|hadd|hsub|unpckh|unpckl|shuf|cmp[a-z]*)p[sd]$/) { return 1 }
+            if (m ~ /^p(add|sub|and|andn|or|cmp|mul|mull|mulh|madd|min|max|avg|abs|sign|sll|srl|sra|shuf|unpck|ack)[a-z0-9]*$/) { return 1 }
+            return 0
+        }
+        if (isa == "aarch64") {
+            if (rest ~ /(^|[ ,[])v[0-9]+\.[0-9]+[bhsd]/) { return 1 }
+            if (rest ~ /(^|[ ,[])q[0-9]+([ ,\]]|$)/)     { return 1 }
+            return 0
+        }
+        if (isa == "riscv64") { return m ~ /^v[a-z]/ }
+        return 0
+    }
+    /file format/ {
+        if      ($0 ~ /x86-64/)   { isa = "x86_64" }
+        else if ($0 ~ /aarch64/)  { isa = "aarch64" }
+        else if ($0 ~ /riscv/)    { isa = "riscv64" }
+        else                      { bad = $0 }
+        next
+    }
+    /^[0-9a-f]+ <.*>:$/ {
+        sym = $0
+        sub(/^[0-9a-f]+ </, "", sym)
+        sub(/>:$/, "", sym)
+        sym = demangle(sym)
+        if (!(sym in count)) { names[++n] = sym; count[sym] = 0 }
+        cur = sym
+        next
+    }
+    cur != "" && /^[[:space:]]*[0-9a-f]+:/ {
+        line = $0
+        sub(/^[[:space:]]*[0-9a-f]+:[[:space:]]*/, "", line)
+        split(line, f, /[[:space:]]+/)
+        rest = line
+        sub(/^[^[:space:]]+[[:space:]]*/, "", rest)
+        if (packed(f[1], rest)) { count[cur]++ }
+    }
+    END {
+        if (bad != "") { print "int: vector-emit: unrecognized object format (" bad ")" > "/dev/stderr"; exit 2 }
+        # insertion-sort the names so the observable does not depend on emission order
+        for (i = 2; i <= n; i++) {
+            k = names[i]
+            j = i - 1
+            while (j >= 1 && names[j] > k) { names[j + 1] = names[j]; j-- }
+            names[j + 1] = k
+        }
+        print "arch=" isa
+        for (i = 1; i <= n; i++) {
+            print names[i] " " (count[names[i]] > 0 ? "simd" : "scalar")
+        }
+    }
+    '
+}
+
 # produce <run> <runmode> <target> <binary> [<g_binary>]
 # dispatches to the producer named by <run>, forwarding the remaining arguments. the
 # debuginfo producer takes an extra `-g` artifact path run.sh built alongside the
@@ -269,6 +412,7 @@ produce() {
         flat-loader) produce_flat_loader "$@" ;;
         built)       produce_built "$@" ;;
         debuginfo)   produce_debuginfo "$@" ;;
+        vector-emit) produce_vector_emit "$@" ;;
         *) echo "int: unknown run mode '$run'" >&2; return 2 ;;
     esac
 }

--- a/int/surface/vectorize-emit/case.conf
+++ b/int/surface/vectorize-emit/case.conf
@@ -1,0 +1,17 @@
+# the auto-vectorizer's EMISSION case (#2207): each function below carries a verdict
+# — `simd` when the pass must vectorize it, `scalar` when it must decline — read out
+# of the disassembled objects, so a pass that silently stops firing (or starts firing
+# on a shape it must refuse) fails here. the sibling `vectorize` case asserts the
+# other half, that a vectorized loop's output is bit-identical to a `#[scalar]` twin;
+# neither replaces the other.
+#
+# release only: the vectorizer runs in the opt=2 pipeline, so a debug leg's verdicts
+# would be uniformly `scalar` and assert nothing about the pass.
+#
+# the ELF legs only: the verdict is a property of the ISA (x86_64 SSE, aarch64 NEON,
+# riscv64 with no 128-bit vector model at all), not of the OS, so the windows and
+# darwin legs would re-assert their linux twins' codegen. they are also the legs
+# without a dependable llvm-objdump.
+run: vector-emit
+profiles: release
+targets: linux linux-arm64 linux-riscv64

--- a/int/surface/vectorize-emit/expect.linux-arm64.txt
+++ b/int/surface/vectorize-emit/expect.linux-arm64.txt
@@ -1,0 +1,17 @@
+arch=aarch64
+add_i32k simd
+axpy_f32 simd
+carried_i32 scalar
+cond_i32 scalar
+fneg_f64 scalar
+glob_carried scalar
+glob_f64add simd
+glob_i32add simd
+glob_mul_f32k simd
+main scalar
+mixed_types scalar
+mul_f32k simd
+mul_kf32 simd
+ptr_i32add simd
+reload_i32 scalar
+sum_i64 simd

--- a/int/surface/vectorize-emit/expect.linux-riscv64.txt
+++ b/int/surface/vectorize-emit/expect.linux-riscv64.txt
@@ -1,0 +1,17 @@
+arch=riscv64
+add_i32k scalar
+axpy_f32 scalar
+carried_i32 scalar
+cond_i32 scalar
+fneg_f64 scalar
+glob_carried scalar
+glob_f64add scalar
+glob_i32add scalar
+glob_mul_f32k scalar
+main scalar
+mixed_types scalar
+mul_f32k scalar
+mul_kf32 scalar
+ptr_i32add scalar
+reload_i32 scalar
+sum_i64 scalar

--- a/int/surface/vectorize-emit/expect.linux.txt
+++ b/int/surface/vectorize-emit/expect.linux.txt
@@ -1,0 +1,17 @@
+arch=x86_64
+add_i32k simd
+axpy_f32 simd
+carried_i32 scalar
+cond_i32 scalar
+fneg_f64 scalar
+glob_carried scalar
+glob_f64add simd
+glob_i32add simd
+glob_mul_f32k simd
+main scalar
+mixed_types scalar
+mul_f32k simd
+mul_kf32 simd
+ptr_i32add simd
+reload_i32 scalar
+sum_i64 simd

--- a/int/surface/vectorize-emit/mach.toml
+++ b/int/surface/vectorize-emit/mach.toml
@@ -1,0 +1,41 @@
+[project]
+id = "case"
+version = "0.0.0"
+src = "src"
+# a fixed out root, not the usual {target.name}/{profile.name} template: the
+# vector-emit producer disassembles the per-module objects this build leaves
+# behind, so their path must be the same on every leg. run.sh wipes out/int before
+# and after each build, so one target's objects can never be read on another's run.
+out = "out/int/build"
+
+[target.linux]
+isa = "x86_64"
+os  = "linux"
+abi = "sysv64"
+
+[target.linux-arm64]
+isa = "aarch64"
+os  = "linux"
+abi = "aapcs64"
+
+[target.linux-riscv64]
+isa = "riscv64"
+os  = "linux"
+abi = "lp64"
+
+[profile.release]
+opt = 2
+debug = false
+simd = "scalarize"
+
+[artifact.case]
+kind = "bin"
+entry = "main.mach"
+out = "bin/case"
+targets = ["*"]
+link = []
+need = []
+
+[dep.mach-std]
+git = "https://github.com/briar-systems/mach-std"
+ref = "branch/main"

--- a/int/surface/vectorize-emit/src/main.mach
+++ b/int/surface/vectorize-emit/src/main.mach
@@ -1,0 +1,79 @@
+# element-wise loop auto-vectorization, EMISSION side (#2207). every function here
+# carries a verdict the golden records — `simd` when the pass must vectorize it,
+# `scalar` when it must decline — read out of the disassembled objects rather than
+# from the program's output, because a declining vectorizer still computes the right
+# answer. the sibling `vectorize` case asserts the correctness half (bit-identical to
+# a `#[scalar]` twin); this one asserts the pass fired at all.
+#
+# every function is `pub` and nothing calls it: an exported function with no call
+# site is emitted as its own symbol and never inlined, so each verdict describes
+# exactly the loop written below it. a caller would have the inliner fold these
+# bodies into it, and the entry's verdict would then track inlining decisions rather
+# than the vectorizer's.
+#
+# riscv64 has no 128-bit vector model, so every verdict is `scalar` there; that is
+# the target's own golden, not an exemption.
+use std.runtime;
+use std.types.size.usize;
+
+val GN: i64 = 512;
+
+var gi_a: [512]i32;
+var gi_b: [512]i32;
+var gi_c: [512]i32;
+var gd_a: [512]f64;
+var gd_b: [512]f64;
+var gd_c: [512]f64;
+var gf_a: [512]f32;
+var gf_b: [512]f32;
+
+# the pointer-parameter form the pass has always handled: the regression canary that
+# distinguishes "the vectorizer is off" from "these shapes are unsupported"
+pub fun ptr_i32add(a: *i32, b: *i32, c: *i32, n: i64) { var i: i64=0; for(i<n){ a[i]=b[i]+c[i]; i=i+1; } }
+
+# module-scope arrays, indexed directly (#2201): the same loop reached through a
+# two-index array-decay gep instead of a pointer parameter
+pub fun glob_i32add() { var i: i64=0; for(i<GN){ gi_a[i]=gi_b[i]+gi_c[i]; i=i+1; } }
+pub fun glob_f64add() { var i: i64=0; for(i<GN){ gd_a[i]=gd_b[i]+gd_c[i]; i=i+1; } }
+
+# a loop-invariant scalar operand (#2202), which needs a preheader splat: scaling in
+# both operand orders, the fused multiply-add shape, and an integer lane type
+pub fun mul_f32k(a: *f32, b: *f32, k: f32, n: i64) { var i: i64=0; for(i<n){ a[i]=b[i]*k; i=i+1; } }
+pub fun mul_kf32(a: *f32, b: *f32, k: f32, n: i64) { var i: i64=0; for(i<n){ a[i]=k*b[i]; i=i+1; } }
+pub fun axpy_f32(a: *f32, b: *f32, c: *f32, k: f32, n: i64) { var i: i64=0; for(i<n){ a[i]=k*b[i]+c[i]; i=i+1; } }
+pub fun add_i32k(a: *i32, b: *i32, k: i32, n: i64) { var i: i64=0; for(i<n){ a[i]=b[i]+k; i=i+1; } }
+
+# both gaps in one loop: a module-scope array scaled by an invariant scalar
+pub fun glob_mul_f32k(k: f32) { var i: i64=0; for(i<GN){ gf_a[i]=gf_b[i]*k; i=i+1; } }
+
+# the integer reduction the pass also vectorizes (partial sums, then a horizontal
+# combine); its verdict guards the reduction path alongside the element-wise one
+pub fun sum_i64(a: *i64, n: i64) i64 { var s: i64=0; var i: i64=0; for(i<n){ s=s+a[i]; i=i+1; } ret s; }
+
+# a mixed-type body (i32 add and f32 mul at the same 4-byte width) must DECLINE: one
+# uniform element TYPE is required, not merely one width
+pub fun mixed_types(a: *i32, b: *i32, x: *f32, y: *f32, n: i64) { var i: i64=0; for(i<n){ a[i]=b[i]+b[i]; x[i]=y[i]*y[i]; i=i+1; } }
+
+# float negate must DECLINE: there is no vector-negate lowering, and the scalar
+# sign-mask path would be a bitwise integer negation of the IEEE pattern
+pub fun fneg_f64(a: *f64, b: *f64, n: i64) { var i: i64=0; for(i<n){ a[i]=-b[i]; i=i+1; } }
+
+# a conditional store must DECLINE: its branch makes the body more than the single
+# block the element-wise shape admits
+pub fun cond_i32(a: *i32, b: *i32, c: *i32, n: i64) { var i: i64=0; for(i<n){ if (b[i] < 50) { a[i]=b[i]+c[i]; } i=i+1; } }
+
+# a loop-carried dependence must DECLINE, through a pointer parameter and through a
+# module-scope array alike: widening the gate to the array form must not bypass the
+# dependence proof
+pub fun carried_i32(a: *i32, n: i64) { var i: i64=1; for(i<n){ a[i]=a[i-1]+1; i=i+1; } }
+pub fun glob_carried() { var i: i64=1; for(i<GN){ gi_a[i]=gi_a[i-1]+1; i=i+1; } }
+
+# a scalar operand the loop reloads from memory it also writes through must DECLINE:
+# the value is not loop-invariant, so there is nothing to splat once in the preheader
+var gk: i32;
+pub fun reload_i32(a: *i32, b: *i32, n: i64) { var i: i64=0; for(i<n){ a[i]=b[i]+gk; i=i+1; } }
+
+# the artifact is never run: the observable is the disassembly of the objects above,
+# so the entry exists only to link
+#[symbol("main")]
+fun main(argc: usize, argv: **u8) i64 { ret 0; }

--- a/int/surface/vectorize-emit/src/main.mach
+++ b/int/surface/vectorize-emit/src/main.mach
@@ -16,8 +16,10 @@
 use std.runtime;
 use std.types.size.usize;
 
-val GN: i64 = 512;
-
+# the module-scope loops spell their trip count as a literal: a module-scope `val`
+# is not constant-folded (#2206), so it reaches the loop header as a LOAD, and a
+# load the analysis cannot classify as `base[iv]` forces the conservative dependent
+# verdict. that is the constant-folding child's ground, not this case's.
 var gi_a: [512]i32;
 var gi_b: [512]i32;
 var gi_c: [512]i32;
@@ -33,8 +35,8 @@ pub fun ptr_i32add(a: *i32, b: *i32, c: *i32, n: i64) { var i: i64=0; for(i<n){ 
 
 # module-scope arrays, indexed directly (#2201): the same loop reached through a
 # two-index array-decay gep instead of a pointer parameter
-pub fun glob_i32add() { var i: i64=0; for(i<GN){ gi_a[i]=gi_b[i]+gi_c[i]; i=i+1; } }
-pub fun glob_f64add() { var i: i64=0; for(i<GN){ gd_a[i]=gd_b[i]+gd_c[i]; i=i+1; } }
+pub fun glob_i32add() { var i: i64=0; for(i<512){ gi_a[i]=gi_b[i]+gi_c[i]; i=i+1; } }
+pub fun glob_f64add() { var i: i64=0; for(i<512){ gd_a[i]=gd_b[i]+gd_c[i]; i=i+1; } }
 
 # a loop-invariant scalar operand (#2202), which needs a preheader splat: scaling in
 # both operand orders, the fused multiply-add shape, and an integer lane type
@@ -44,7 +46,7 @@ pub fun axpy_f32(a: *f32, b: *f32, c: *f32, k: f32, n: i64) { var i: i64=0; for(
 pub fun add_i32k(a: *i32, b: *i32, k: i32, n: i64) { var i: i64=0; for(i<n){ a[i]=b[i]+k; i=i+1; } }
 
 # both gaps in one loop: a module-scope array scaled by an invariant scalar
-pub fun glob_mul_f32k(k: f32) { var i: i64=0; for(i<GN){ gf_a[i]=gf_b[i]*k; i=i+1; } }
+pub fun glob_mul_f32k(k: f32) { var i: i64=0; for(i<512){ gf_a[i]=gf_b[i]*k; i=i+1; } }
 
 # the integer reduction the pass also vectorizes (partial sums, then a horizontal
 # combine); its verdict guards the reduction path alongside the element-wise one
@@ -66,7 +68,7 @@ pub fun cond_i32(a: *i32, b: *i32, c: *i32, n: i64) { var i: i64=0; for(i<n){ if
 # module-scope array alike: widening the gate to the array form must not bypass the
 # dependence proof
 pub fun carried_i32(a: *i32, n: i64) { var i: i64=1; for(i<n){ a[i]=a[i-1]+1; i=i+1; } }
-pub fun glob_carried() { var i: i64=1; for(i<GN){ gi_a[i]=gi_a[i-1]+1; i=i+1; } }
+pub fun glob_carried() { var i: i64=1; for(i<512){ gi_a[i]=gi_a[i-1]+1; i=i+1; } }
 
 # a scalar operand the loop reloads from memory it also writes through must DECLINE:
 # the value is not loop-invariant, so there is nothing to splat once in the preheader

--- a/int/surface/vectorize/expect.txt
+++ b/int/surface/vectorize/expect.txt
@@ -1,2 +1,2 @@
 mismatches=0
-acc=91725
+acc=53494

--- a/int/surface/vectorize/src/main.mach
+++ b/int/surface/vectorize/src/main.mach
@@ -27,6 +27,41 @@ fun f32mul_v(a: *f32, b: *f32, c: *f32, n: i64) { var i: i64=0; for(i<n){ a[i]=b
 #[scalar]
 fun f32mul_s(a: *f32, b: *f32, c: *f32, n: i64) { var i: i64=0; for(i<n){ a[i]=b[i]*c[i]; i=i+1; } }
 
+# module-scope arrays (#2201), reached through the two-index array-decay gep rather
+# than a pointer parameter. the two versions write separate destinations so both
+# results survive the comparison; the sources are shared.
+var gsrc0: [512]i32; var gsrc1: [512]i32; var gdst_v: [512]i32; var gdst_s: [512]i32;
+fun gi32add_v(n: i64) { var i: i64=0; for(i<n){ gdst_v[i]=gsrc0[i]+gsrc1[i]; i=i+1; } }
+#[scalar]
+fun gi32add_s(n: i64) { var i: i64=0; for(i<n){ gdst_s[i]=gsrc0[i]+gsrc1[i]; i=i+1; } }
+
+# both scope gaps in one loop: a module-scope array scaled by a loop-invariant scalar
+var gfsrc: [512]f64; var gfdst_v: [512]f64; var gfdst_s: [512]f64;
+fun gf64scale_v(k: f64, n: i64) { var i: i64=0; for(i<n){ gfdst_v[i]=gfsrc[i]*k; i=i+1; } }
+#[scalar]
+fun gf64scale_s(k: f64, n: i64) { var i: i64=0; for(i<n){ gfdst_s[i]=gfsrc[i]*k; i=i+1; } }
+
+# a loop-carried dependence over module-scope arrays must still DECLINE: the wider gep
+# shape must not bypass the dependence proof. seeded identically, both must agree.
+fun gcarried_v(n: i64) { var i: i64=1; for(i<n){ gdst_v[i]=gdst_v[i-1]+1; i=i+1; } }
+#[scalar]
+fun gcarried_s(n: i64) { var i: i64=1; for(i<n){ gdst_s[i]=gdst_s[i-1]+1; i=i+1; } }
+
+# a loop-invariant scalar operand (#2202), broadcast once into the preheader: scaling
+# in both operand orders, the fused multiply-add shape, and an integer lane type
+fun f32scale_v(a: *f32, b: *f32, k: f32, n: i64) { var i: i64=0; for(i<n){ a[i]=b[i]*k; i=i+1; } }
+#[scalar]
+fun f32scale_s(a: *f32, b: *f32, k: f32, n: i64) { var i: i64=0; for(i<n){ a[i]=b[i]*k; i=i+1; } }
+fun f32scalec_v(a: *f32, b: *f32, k: f32, n: i64) { var i: i64=0; for(i<n){ a[i]=k*b[i]; i=i+1; } }
+#[scalar]
+fun f32scalec_s(a: *f32, b: *f32, k: f32, n: i64) { var i: i64=0; for(i<n){ a[i]=k*b[i]; i=i+1; } }
+fun f32axpy_v(a: *f32, b: *f32, c: *f32, k: f32, n: i64) { var i: i64=0; for(i<n){ a[i]=k*b[i]+c[i]; i=i+1; } }
+#[scalar]
+fun f32axpy_s(a: *f32, b: *f32, c: *f32, k: f32, n: i64) { var i: i64=0; for(i<n){ a[i]=k*b[i]+c[i]; i=i+1; } }
+fun i32bias_v(a: *i32, b: *i32, k: i32, n: i64) { var i: i64=0; for(i<n){ a[i]=b[i]+k; i=i+1; } }
+#[scalar]
+fun i32bias_s(a: *i32, b: *i32, k: i32, n: i64) { var i: i64=0; for(i<n){ a[i]=b[i]+k; i=i+1; } }
+
 # a mixed-type loop (i32 add + f32 mul in ONE body, same 4-byte width) must DECLINE
 # to vectorize (uniform element TYPE is required, not just width) and stay correct
 fun mixed_v(a: *i32, b: *i32, x: *f32, y: *f32, n: i64) { var i: i64=0; for(i<n){ a[i]=b[i]+b[i]; x[i]=y[i]*y[i]; i=i+1; } }
@@ -98,6 +133,22 @@ fun main(argc: usize, argv: **u8) i64 {
         var ii2: i64 = 0;
         for (ii2 < n) { wv[ii2]=0-1; ws[ii2]=0-1; ii2=ii2+1; }
         cond_v(?wv[0],?bw[0],?cw[0],n); cond_s(?ws[0],?bw[0],?cw[0],n); if(ck32(?wv[0],n)!=ck32(?ws[0],n)){mism=mism+1;} acc=acc+norm(ck32(?wv[0],n));
+
+        # a loop-invariant scalar operand, splatted once: both operand orders, the
+        # fused multiply-add, and an integer lane type
+        f32scale_v(?fv[0],?bf[0],1.25,n); f32scale_s(?fs[0],?bf[0],1.25,n); if(ckf32(?fv[0],n)!=ckf32(?fs[0],n)){mism=mism+1;} acc=acc+norm(ckf32(?fv[0],n));
+        f32scalec_v(?fv[0],?bf[0],1.25,n); f32scalec_s(?fs[0],?bf[0],1.25,n); if(ckf32(?fv[0],n)!=ckf32(?fs[0],n)){mism=mism+1;} acc=acc+norm(ckf32(?fv[0],n));
+        f32axpy_v(?fv[0],?bf[0],?cf[0],1.25,n); f32axpy_s(?fs[0],?bf[0],?cf[0],1.25,n); if(ckf32(?fv[0],n)!=ckf32(?fs[0],n)){mism=mism+1;} acc=acc+norm(ckf32(?fv[0],n));
+        i32bias_v(?wv[0],?bw[0],0-9,n); i32bias_s(?ws[0],?bw[0],0-9,n); if(ck32(?wv[0],n)!=ck32(?ws[0],n)){mism=mism+1;} acc=acc+norm(ck32(?wv[0],n));
+
+        # module-scope arrays, plain and scaled, then a loop-carried dependence over
+        # the same arrays that must stay scalar
+        var gi: i64 = 0;
+        for (gi < n) { gsrc0[gi]=(gi*7-13)::i32; gsrc1[gi]=(gi*3+5)::i32; gfsrc[gi]=(gi::f64)*1.5-7.0; gi=gi+1; }
+        gi32add_v(n); gi32add_s(n); if(ck32(?gdst_v[0],n)!=ck32(?gdst_s[0],n)){mism=mism+1;} acc=acc+norm(ck32(?gdst_v[0],n));
+        gf64scale_v(0.75,n); gf64scale_s(0.75,n); if(ckf64(?gfdst_v[0],n)!=ckf64(?gfdst_s[0],n)){mism=mism+1;} acc=acc+norm(ckf64(?gfdst_v[0],n));
+        gi=0; for (gi < n) { gdst_v[gi]=(gi*2+1)::i32; gdst_s[gi]=(gi*2+1)::i32; gi=gi+1; }
+        gcarried_v(n); gcarried_s(n); if(ck32(?gdst_v[0],n)!=ck32(?gdst_s[0],n)){mism=mism+1;} acc=acc+norm(ck32(?gdst_v[0],n));
         ti=ti+1;
     }
     # aliasing hazard: dst overlaps src0 by one element -> the runtime guard must
@@ -109,6 +160,14 @@ fun main(argc: usize, argv: **u8) i64 {
     i32add_v(?arr[1], ?arr[0], ?cc[0], 128);
     i32add_s(?arr2[1], ?arr2[0], ?cc[0], 128);
     if (ck32(?arr[0],130) != ck32(?arr2[0],130)) { mism = mism + 1; }
+
+    # the same hazard through a splatted loop: the guard is unchanged by the splat, so
+    # an overlapping dst / src still takes the scalar fallback
+    var fr: [130]f32; var fr2: [130]f32;
+    j=0; for (j<130){ fr[j]=(j::f32)*0.5+1.0; fr2[j]=(j::f32)*0.5+1.0; j=j+1; }
+    f32scale_v(?fr[1], ?fr[0], 1.25, 128);
+    f32scale_s(?fr2[1], ?fr2[0], 1.25, 128);
+    if (ckf32(?fr[0],130) != ckf32(?fr2[0],130)) { mism = mism + 1; }
 
     p.printlnf("mismatches={}", mism);
     p.printlnf("acc={}", norm(acc));

--- a/src/lang/me/analysis/dependence.mach
+++ b/src/lang/me/analysis/dependence.mach
@@ -253,10 +253,47 @@ fun single_iv_recurrence(fn: *ir.Function, la: *loops.LoopAnalysis, loop_ix: u32
     ret true;
 }
 
+# the address shape of an element-wise access: `base + iv * elem`, reached through
+# either admitted gep form, with the per-element stride type resolved
+#
+# `gep(base, iv)` indexes a pointer directly (a pointer parameter), and its source
+# pointee type IS the element. `gep(base, 0, iv)` is an array indexed in place (a
+# module-scope or local array, which never decays to a pointer): the leading 0
+# selects the array itself and the second index descends into it, so the stride is
+# the array's ELEMENT type, not the array type the gep carries. Both denote the same
+# addresses; refusing the second is what kept module-scope arrays out of the
+# vectorizer (#2201).
+# ---
+# gep:       the OP_GEP to decompose
+# types:     the module's IR type table
+# out_base:  receives the base pointer operand
+# out_idx:   receives the index operand
+# out_sty:   receives the per-element stride type
+# ret:       true when the gep is one of the two admitted forms
+fun gep_elem_shape(gep: *instruction.Instruction, types: *ir_type.IrTypeTable, out_base: *value.Value, out_idx: *value.Value, out_sty: *ir_type.IrTypeId) bool {
+    if (gep.kind != instruction.OP_GEP) { ret false; }
+    if (gep.operand_count == 2) {
+        @out_base = gep.operands[0];
+        @out_idx  = gep.operands[1];
+        @out_sty  = gep.aux_ty;
+        ret true;
+    }
+    if (gep.operand_count != 3) { ret false; }
+    if (gep.operands[1].kind != value.VAL_CONST_INT || gep.operands[1].data.int_lit != 0) { ret false; }
+    val aopt: O.Option[*ir_type.IrType] = ir_type.get(types, gep.aux_ty);
+    if (O.is_none[*ir_type.IrType](aopt)) { ret false; }
+    val at: *ir_type.IrType = O.unwrap[*ir_type.IrType](aopt);
+    if (at.kind != ir_type.IRT_ARRAY) { ret false; }
+    @out_base = gep.operands[0];
+    @out_idx  = gep.operands[2];
+    @out_sty  = at.data.array_.element;
+    ret true;
+}
+
 # classify a load/store as an element-wise `base[iv]` access, filling `out` on
-# success. requires: non-volatile; the pointer is a single-index gep whose index is
-# exactly the induction-variable phi (offset 0, unit stride) and whose base is
-# loop-invariant.
+# success. requires: non-volatile; the pointer is a gep of one of the two element
+# shapes whose index is exactly the induction-variable phi (offset 0, unit stride)
+# and whose base is loop-invariant.
 fun classify_access(fn: *ir.Function, la: *loops.LoopAnalysis, loop_ix: u32, iid: id.InstructionId, inst: *instruction.Instruction, types: *ir_type.IrTypeTable, out: *MemAccess) bool {
     if ((inst.flags & instruction.INSTR_FLAG_VOLATILE) != 0) { ret false; }
     val is_store: bool = inst.kind == instruction.OP_STORE;
@@ -275,10 +312,11 @@ fun classify_access(fn: *ir.Function, la: *loops.LoopAnalysis, loop_ix: u32, iid
     val gopt: O.Option[*instruction.Instruction] = ir.instruction_get(fn, ptr.data.instr);
     if (O.is_none[*instruction.Instruction](gopt)) { ret false; }
     val gep: *instruction.Instruction = O.unwrap[*instruction.Instruction](gopt);
-    if (gep.kind != instruction.OP_GEP || gep.operand_count != 2) { ret false; }
 
-    val base: value.Value = gep.operands[0];
-    val idx:  value.Value = gep.operands[1];
+    var base: value.Value;
+    var idx:  value.Value;
+    var stride_ty: ir_type.IrTypeId;
+    if (!gep_elem_shape(gep, types, ?base, ?idx, ?stride_ty)) { ret false; }
     val lp: *loops.Loop = ?la.loops[loop_ix];
     # index must be exactly the induction variable (offset 0)
     if (idx.kind != value.VAL_INSTR || idx.data.instr != lp.iv.phi) { ret false; }
@@ -294,7 +332,7 @@ fun classify_access(fn: *ir.Function, la: *loops.LoopAnalysis, loop_ix: u32, iid
     # access width, both a supported scalar footprint. a wider-than-stride access
     # (a 1-byte stride feeding an 8-byte store) overlaps its own windows across
     # iterations; a narrower one leaves gaps -- neither is a contiguous unit map.
-    val stride_bytes: u32 = scalar_bytes(types, gep.aux_ty);
+    val stride_bytes: u32 = scalar_bytes(types, stride_ty);
     val width_bytes:  u32 = scalar_bytes(types, elem_ty);
     if (stride_bytes == 0 || width_bytes == 0) { ret false; }
     if (stride_bytes != width_bytes)           { ret false; }
@@ -302,7 +340,7 @@ fun classify_access(fn: *ir.Function, la: *loops.LoopAnalysis, loop_ix: u32, iid
     out.instr     = iid;
     out.gep       = ptr.data.instr;
     out.base      = base;
-    out.stride_ty = gep.aux_ty;
+    out.stride_ty = stride_ty;
     out.elem_ty   = elem_ty;
     out.bytes     = width_bytes;
     out.is_store  = is_store;

--- a/src/lang/me/transform/vectorize.mach
+++ b/src/lang/me/transform/vectorize.mach
@@ -53,6 +53,27 @@ rec MapShape {
     is_float: bool;
 }
 
+# one operand slot naming a loop-invariant scalar, awaiting its preheader splat
+# ---
+# instr: the vectorized instruction holding the slot
+# slot:  the operand index within it
+# val:   the invariant scalar the slot names
+rec SplatSite {
+    instr: id.InstructionId;
+    slot:  u32;
+    val:   value.Value;
+}
+
+# one emitted splat: the invariant scalar and the vector it was broadcast into, so a
+# scalar used by several operands is broadcast once
+# ---
+# key: the invariant scalar
+# vec: its vector-typed broadcast, defined in the vector preheader
+rec SplatEntry {
+    key: value.Value;
+    vec: value.Value;
+}
+
 # run element-wise vectorization over every function in `m`
 #
 # A no-op on an incapable target (has_v128 == false), on a function carrying the
@@ -244,7 +265,7 @@ fun stores_are_pure_trees(m: *ir.Module, fn: *ir.Function, la: *loops.LoopAnalys
     val rset: R.Result[*bool, str] = A.allocate[bool](m.alloc, fn.instr_len::usize);
     if (R.is_err[*bool, str](rset)) { ret R.err[bool, str](R.unwrap_err[*bool, str](rset)); }
     val vset: *bool = R.unwrap_ok[*bool, str](rset);
-    build_vset(fn, la, lx, d.accesses, d.access_count, shape.elem_ty, shape.is_float, vset);
+    build_vset(fn, la, lx, d.accesses, d.access_count, shape.elem_ty, shape.is_float, true, vset);
 
     var ok: bool = true;
     var i: u32 = 0;
@@ -266,11 +287,16 @@ fun stores_are_pure_trees(m: *ir.Module, fn: *ir.Function, la: *loops.LoopAnalys
 
 # fill `vset` with the loop-body instructions that vectorize: the loads (seeds) and,
 # to a fixpoint, every supported lane op whose result type is exactly the element
-# type and whose operands are all already in the set. A scalar / loop-invariant /
-# induction-variable operand keeps an op out (that would need a splat), the
-# result-type check keeps any width- or kind-changing op out, and the walk skips the
-# header block so only true body computation is admitted.
-fun build_vset(fn: *ir.Function, la: *loops.LoopAnalysis, lx: u32, accesses: *dep.MemAccess, access_count: u32, elem_ty: ir_type.IrTypeId, is_float: bool, vset: *bool) {
+# type and whose operands are all vectorizable. The result-type check keeps any width-
+# or kind-changing op out, and the walk skips the header block so only true body
+# computation is admitted.
+#
+# `allow_splat` admits an operand that is a loop-invariant scalar of the element type
+# alongside the vector-set operands, on the promise that the caller broadcasts it in
+# the loop's preheader (#2202). The element-wise transform makes good on that promise
+# via splat_invariants; the reduction transform has no such step, so it passes false
+# and keeps its strict all-operands-vectorized rule.
+fun build_vset(fn: *ir.Function, la: *loops.LoopAnalysis, lx: u32, accesses: *dep.MemAccess, access_count: u32, elem_ty: ir_type.IrTypeId, is_float: bool, allow_splat: bool, vset: *bool) {
     var i: u32 = 0;
     for (i < fn.instr_len) { vset[i] = false; i = i + 1; }
     i = 0;
@@ -293,7 +319,7 @@ fun build_vset(fn: *ir.Function, la: *loops.LoopAnalysis, lx: u32, accesses: *de
                     val opt: O.Option[*instruction.Instruction] = ir.instruction_get(fn, iid);
                     if (O.is_some[*instruction.Instruction](opt)) {
                         val inst: *instruction.Instruction = O.unwrap[*instruction.Instruction](opt);
-                        if (supported_vector_op(inst.kind, is_float) && inst.ty == elem_ty && all_operands_in_set(inst, fn, vset)) {
+                        if (supported_vector_op(inst.kind, is_float) && inst.ty == elem_ty && operands_vectorizable(inst, fn, la, lx, elem_ty, allow_splat, vset)) {
                             vset[iid::u32] = true;
                             changed = true;
                         }
@@ -306,17 +332,36 @@ fun build_vset(fn: *ir.Function, la: *loops.LoopAnalysis, lx: u32, accesses: *de
     }
 }
 
-# true when every operand of `inst` is a VAL_INSTR already in the vector set (so no
-# constant / parameter / induction-variable operand -- those would need a splat)
-fun all_operands_in_set(inst: *instruction.Instruction, fn: *ir.Function, vset: *bool) bool {
+# true when `inst`'s operands are all vectorizable: each is either a VAL_INSTR already
+# in the vector set or, when `allow_splat`, a splattable loop-invariant scalar. At
+# least one operand must come from the vector set -- an op over invariants alone is
+# itself invariant, and broadcasting its operands would compute a loop-invariant value
+# once per lane rather than hoisting it.
+fun operands_vectorizable(inst: *instruction.Instruction, fn: *ir.Function, la: *loops.LoopAnalysis, lx: u32, elem_ty: ir_type.IrTypeId, allow_splat: bool, vset: *bool) bool {
     if (inst.operand_count == 0) { ret false; }
+    var from_set: bool = false;
     var o: u32 = 0;
     for (o < inst.operand_count) {
         val op: value.Value = inst.operands[o];
-        if (op.kind != value.VAL_INSTR || op.data.instr::u32 >= fn.instr_len || !vset[op.data.instr::u32]) { ret false; }
+        if (op.kind == value.VAL_INSTR && op.data.instr::u32 < fn.instr_len && vset[op.data.instr::u32]) {
+            from_set = true;
+        } or {
+            if (!allow_splat || !splattable(op, la, lx, elem_ty)) { ret false; }
+        }
         o = o + 1;
     }
-    ret true;
+    ret from_set;
+}
+
+# true when `v` is a loop-invariant scalar of the element type that one preheader
+# broadcast can stand in for: a constant, a parameter, or a value defined outside the
+# loop. The type stamp must be exactly the element type -- a differently typed operand
+# would be splatted into the wrong lane width -- and pointer / global / function
+# values are excluded, since they are addresses rather than lane values.
+fun splattable(v: value.Value, la: *loops.LoopAnalysis, lx: u32, elem_ty: ir_type.IrTypeId) bool {
+    if (v.ty != elem_ty) { ret false; }
+    if (v.kind != value.VAL_CONST_INT && v.kind != value.VAL_CONST_FLOAT && v.kind != value.VAL_PARAM && v.kind != value.VAL_INSTR) { ret false; }
+    ret loops.is_invariant(la, lx, v);
 }
 
 # the lane-wise element-wise ops whose 128-bit vector form is selectable on the
@@ -432,13 +477,16 @@ fun vectorize_one(m: *ir.Module, fn: *ir.Function, la: *loops.LoopAnalysis, lx: 
     if (R.is_err[bool, str](rcl)) { A.deallocate[id.BlockId](m.alloc, fbody, body_len::usize); A.deallocate[id.BlockId](m.alloc, rem_blocks, body_len::usize); dep.dep_dnit(?fd); loops.dnit(?fla); ret R.err[bool, str](R.unwrap_err[bool, str](rcl)); }
     val rem_header: id.BlockId = rem_blocks[ver.region_index(fbody, body_len, fast_header)];
 
-    # vectorize the fast body: retype loads + ops to the vector type
+    # vectorize the fast body: retype loads + ops to the vector type, then broadcast
+    # every loop-invariant scalar operand the vector set admitted into the preheader
     val rset: R.Result[*bool, str] = A.allocate[bool](m.alloc, fn.instr_len::usize);
     if (R.is_err[*bool, str](rset)) { A.deallocate[id.BlockId](m.alloc, fbody, body_len::usize); A.deallocate[id.BlockId](m.alloc, rem_blocks, body_len::usize); dep.dep_dnit(?fd); loops.dnit(?fla); ret R.err[bool, str](R.unwrap_err[*bool, str](rset)); }
     val vset: *bool = R.unwrap_ok[*bool, str](rset);
-    build_vset(fn, ?fla, flx, fd.accesses, fd.access_count, fshape.elem_ty, fshape.is_float, vset);
+    build_vset(fn, ?fla, flx, fd.accesses, fd.access_count, fshape.elem_ty, fshape.is_float, true, vset);
     retype_to_vector(fn, flp, vset, vec_ty);
+    val rsp: R.Result[bool, str] = splat_invariants(m, fn, flp, vset, vpre, fast_header, ?fshape, vec_ty);
     A.deallocate[bool](m.alloc, vset, fn.instr_len::usize);
+    if (R.is_err[bool, str](rsp)) { A.deallocate[id.BlockId](m.alloc, fbody, body_len::usize); A.deallocate[id.BlockId](m.alloc, rem_blocks, body_len::usize); dep.dep_dnit(?fd); loops.dnit(?fla); ret rsp; }
 
     # step the induction variable by the lane count (the +1 update becomes +lanes)
     val uopt: O.Option[*instruction.Instruction] = ir.instruction_get(fn, fast_iv_upd);
@@ -514,6 +562,171 @@ fun retype_to_vector(fn: *ir.Function, lp: *loops.Loop, vset: *bool, vec_ty: ir_
         }
         bi = bi + 1;
     }
+}
+
+# the total operand count over a loop body's instructions -- an upper bound on the
+# splat sites one vectorized body can hold
+fun body_operand_slots(fn: *ir.Function, lp: *loops.Loop) u32 {
+    var n: u32 = 0;
+    var bi: u32 = 0;
+    for (bi < lp.body_len) {
+        val blk: *ir.Block = ?fn.blocks[lp.body[bi]::u32];
+        var ii: u32 = 0;
+        for (ii < blk.instr_count) {
+            n = n + fn.instrs[blk.instructions[ii]::u32].operand_count;
+            ii = ii + 1;
+        }
+        bi = bi + 1;
+    }
+    ret n;
+}
+
+# broadcast the vectorized body's loop-invariant scalar operands ahead of the loop
+#
+# Every operand of a vector-set instruction that is not itself a vector-set value is a
+# splattable loop-invariant scalar -- build_vset admits nothing else -- so each is
+# replaced by a vector whose lanes all hold it, built once before the loop is entered.
+# The broadcast is loop-invariant by construction, so the body gains no per-iteration
+# work: `a[i] = b[i] * k` costs one splat per call, not per iteration (#2202).
+#
+# The splats go in a block of their own, spliced between the vector preheader and the
+# fast header, because the preheader is already terminated by the time the fast loop
+# has re-confirmed its shape. The block is created only when there is a splat to make,
+# so a loop with no invariant operand keeps exactly the control flow it had.
+#
+# Only the lane ops are scanned. A load's operand is its address gep, which is not a
+# lane value and must never be broadcast; a store's value operand is already required
+# to be in the vector set. The sites are collected before anything is emitted, since
+# emitting grows the instruction pool and invalidates every borrowed instruction
+# pointer.
+# ---
+# m:           the module owning `fn`
+# fn:          the function being transformed
+# lp:          the fast (vector) loop
+# vset:        the vector set over `fn`'s instructions
+# vpre:        the vector preheader, which dominates the fast loop
+# fast_header: the fast loop's header, the preheader's successor
+# shape:       the loop's element shape
+# vec_ty:      the interned 128-bit vector type of the element
+# ret:         ok(true), or an allocation / build error
+fun splat_invariants(m: *ir.Module, fn: *ir.Function, lp: *loops.Loop, vset: *bool, vpre: id.BlockId, fast_header: id.BlockId, shape: *MapShape, vec_ty: ir_type.IrTypeId) R.Result[bool, str] {
+    val cap: u32 = body_operand_slots(fn, lp);
+    if (cap == 0) { ret R.ok[bool, str](true); }
+    val rss: R.Result[*SplatSite, str] = A.allocate[SplatSite](m.alloc, cap::usize);
+    if (R.is_err[*SplatSite, str](rss)) { ret R.err[bool, str](R.unwrap_err[*SplatSite, str](rss)); }
+    val sites: *SplatSite = R.unwrap_ok[*SplatSite, str](rss);
+    val rse: R.Result[*SplatEntry, str] = A.allocate[SplatEntry](m.alloc, cap::usize);
+    if (R.is_err[*SplatEntry, str](rse)) { A.deallocate[SplatSite](m.alloc, sites, cap::usize); ret R.err[bool, str](R.unwrap_err[*SplatEntry, str](rse)); }
+    val cache: *SplatEntry = R.unwrap_ok[*SplatEntry, str](rse);
+
+    var n: u32 = 0;
+    var bi: u32 = 0;
+    for (bi < lp.body_len) {
+        val blk: *ir.Block = ?fn.blocks[lp.body[bi]::u32];
+        var ii: u32 = 0;
+        for (ii < blk.instr_count) {
+            val iid: id.InstructionId = blk.instructions[ii];
+            val inst: *instruction.Instruction = ?fn.instrs[iid::u32];
+            if (vset[iid::u32] && supported_vector_op(inst.kind, shape.is_float)) {
+                var o: u32 = 0;
+                for (o < inst.operand_count) {
+                    val op: value.Value = inst.operands[o];
+                    if (op.kind != value.VAL_INSTR || op.data.instr::u32 >= fn.instr_len || !vset[op.data.instr::u32]) {
+                        sites[n].instr = iid;
+                        sites[n].slot  = o;
+                        sites[n].val   = op;
+                        n = n + 1;
+                    }
+                    o = o + 1;
+                }
+            }
+            ii = ii + 1;
+        }
+        bi = bi + 1;
+    }
+    if (n == 0) { splat_free(m, sites, cache, cap); ret R.ok[bool, str](true); }
+
+    val rat: R.Result[ir_type.IrTypeId, str] = ir_type.intern_array(?m.types, shape.elem_ty, shape.lanes);
+    if (R.is_err[ir_type.IrTypeId, str](rat)) { splat_free(m, sites, cache, cap); ret R.err[bool, str](R.unwrap_err[ir_type.IrTypeId, str](rat)); }
+    val arr_ty: ir_type.IrTypeId = R.unwrap_ok[ir_type.IrTypeId, str](rat);
+
+    val rsb: R.Result[id.BlockId, str] = ir.block_add(m, fn);
+    if (R.is_err[id.BlockId, str](rsb)) { splat_free(m, sites, cache, cap); ret R.err[bool, str](R.unwrap_err[id.BlockId, str](rsb)); }
+    val spre: id.BlockId = R.unwrap_ok[id.BlockId, str](rsb);
+    var b: builder.Builder = builder.init(m);
+    builder.set_function(?b, fn);
+    builder.set_block(?b, spre);
+    var cn: u32 = 0;
+    var i: u32 = 0;
+    for (i < n) {
+        if (splat_lookup(cache, cn, sites[i].val) == ver.NONE_U32) {
+            val rsv: R.Result[value.Value, str] = emit_splat(?b, sites[i].val, arr_ty, vec_ty, shape.lanes);
+            if (R.is_err[value.Value, str](rsv)) { splat_free(m, sites, cache, cap); ret R.err[bool, str](R.unwrap_err[value.Value, str](rsv)); }
+            cache[cn].key = sites[i].val;
+            cache[cn].vec = R.unwrap_ok[value.Value, str](rsv);
+            cn = cn + 1;
+        }
+        i = i + 1;
+    }
+    if (R.is_err[bool, str](builder.emit_br(?b, fast_header))) { splat_free(m, sites, cache, cap); ret R.err[bool, str]("vectorize: splat block branch"); }
+    ver.redirect_terminator(fn, vpre, fast_header, spre);
+    ver.relabel_phi_pred(fn, fast_header, vpre, spre);
+
+    i = 0;
+    for (i < n) {
+        val ci: u32 = splat_lookup(cache, cn, sites[i].val);
+        if (ci != ver.NONE_U32) {
+            val inst: *instruction.Instruction = ?fn.instrs[sites[i].instr::u32];
+            inst.operands[sites[i].slot] = cache[ci].vec;
+        }
+        i = i + 1;
+    }
+    splat_free(m, sites, cache, cap);
+    ret R.ok[bool, str](true);
+}
+
+# release the splat working arrays
+fun splat_free(m: *ir.Module, sites: *SplatSite, cache: *SplatEntry, cap: u32) {
+    A.deallocate[SplatSite](m.alloc, sites, cap::usize);
+    A.deallocate[SplatEntry](m.alloc, cache, cap::usize);
+}
+
+# the cache index whose key is the same value as `v`, or NONE_U32
+fun splat_lookup(cache: *SplatEntry, cn: u32, v: value.Value) u32 {
+    var i: u32 = 0;
+    for (i < cn) {
+        if (dep.equal(cache[i].key, v)) { ret i; }
+        i = i + 1;
+    }
+    ret ver.NONE_U32;
+}
+
+# broadcast a scalar into every lane of a vector, in the builder's current block: a
+# lanes-wide slot written lane by lane and read back as one vector. The same
+# construction the reduction accumulator's initial vector uses, so the splat needs no
+# lowering of its own -- it is a store / load pair the back end already emits.
+# ---
+# b:      builder positioned in the block the splat is built in
+# v:      the scalar to broadcast
+# arr_ty: the interned `[lanes]elem` array type of the slot
+# vec_ty: the interned 128-bit vector type read back
+# lanes:  the lane count
+# ret:    the vector-typed broadcast, or a build error
+fun emit_splat(b: *builder.Builder, v: value.Value, arr_ty: ir_type.IrTypeId, vec_ty: ir_type.IrTypeId, lanes: u32) R.Result[value.Value, str] {
+    val rit: R.Result[ir_type.IrTypeId, str] = ir_type.intern_int(?b.m.types, 64);
+    if (R.is_err[ir_type.IrTypeId, str](rit)) { ret R.err[value.Value, str](R.unwrap_err[ir_type.IrTypeId, str](rit)); }
+    val idx_ty: ir_type.IrTypeId = R.unwrap_ok[ir_type.IrTypeId, str](rit);
+    val ras: R.Result[value.Value, str] = builder.emit_alloca(b, arr_ty, value.const_int(1, idx_ty));
+    if (R.is_err[value.Value, str](ras)) { ret ras; }
+    val slot: value.Value = R.unwrap_ok[value.Value, str](ras);
+    var lane: u32 = 0;
+    for (lane < lanes) {
+        val rg: R.Result[value.Value, str] = lane_gep(b, slot, arr_ty, lane, idx_ty);
+        if (R.is_err[value.Value, str](rg)) { ret rg; }
+        if (R.is_err[bool, str](builder.emit_store(b, v, R.unwrap_ok[value.Value, str](rg)))) { ret R.err[value.Value, str]("vectorize: splat store"); }
+        lane = lane + 1;
+    }
+    ret builder.emit_load(b, slot, vec_ty);
 }
 
 # change the phi incoming of `blk` from predecessor `from` to come from `new_block`
@@ -627,7 +840,7 @@ fun rv_is_vector_tree(m: *ir.Module, fn: *ir.Function, la: *loops.LoopAnalysis, 
     val rset: R.Result[*bool, str] = A.allocate[bool](m.alloc, fn.instr_len::usize);
     if (R.is_err[*bool, str](rset)) { ret false; }
     val vset: *bool = R.unwrap_ok[*bool, str](rset);
-    build_vset(fn, la, lx, ri.accesses, ri.access_count, ri.elem_ty, false, vset);
+    build_vset(fn, la, lx, ri.accesses, ri.access_count, ri.elem_ty, false, false, vset);
     var ok: bool = ri.rv.kind == value.VAL_INSTR && ri.rv.data.instr::u32 < fn.instr_len && vset[ri.rv.data.instr::u32];
     A.deallocate[bool](m.alloc, vset, fn.instr_len::usize);
     ret ok;
@@ -758,7 +971,7 @@ fun vectorize_reduction(m: *ir.Module, fn: *ir.Function, la: *loops.LoopAnalysis
     val rset: R.Result[*bool, str] = A.allocate[bool](m.alloc, fn.instr_len::usize);
     if (R.is_err[*bool, str](rset)) { ret R.err[bool, str](R.unwrap_err[*bool, str](rset)); }
     val vset: *bool = R.unwrap_ok[*bool, str](rset);
-    build_vset(fn, la, lx, ri.accesses, ri.access_count, elem_ty, false, vset);
+    build_vset(fn, la, lx, ri.accesses, ri.access_count, elem_ty, false, false, vset);
     vset[acc_phi::u32] = true;
     vset[acc_upd::u32] = true;
     retype_to_vector(fn, lp, vset, vec_ty);
@@ -848,10 +1061,19 @@ fun emit_horizontal_combine(b: *builder.Builder, op: instruction.InstrKind, vacc
 
 # a `gep(slot, 0, lane)` addressing lane `lane` of a `[lanes]elem` slot (the array
 # shape a vector's 16-byte storage aliases, per the v[i] lowering)
-fun lane_gep(b: *builder.Builder, slot: value.Value, arr_ty: ir_type.IrTypeId, lane: u32, elem_ty: ir_type.IrTypeId) R.Result[value.Value, str] {
+# ---
+# b:      builder positioned where the gep is emitted
+# slot:   the slot's address
+# arr_ty: the interned `[lanes]elem` array type
+# lane:   the lane ordinal
+# idx_ty: the INTEGER type the two index constants carry -- an ordinal, not a value of
+#         the element type, which for a float element would stamp an integer constant
+#         with a float type. The reduction callers pass their element type, an integer
+#         by construction; the splat, whose element may be a float, passes i64.
+fun lane_gep(b: *builder.Builder, slot: value.Value, arr_ty: ir_type.IrTypeId, lane: u32, idx_ty: ir_type.IrTypeId) R.Result[value.Value, str] {
     var idx: [2]value.Value;
-    idx[0] = value.const_int(0, elem_ty);
-    idx[1] = value.const_int(lane::u64, elem_ty);
+    idx[0] = value.const_int(0, idx_ty);
+    idx[1] = value.const_int(lane::u64, idx_ty);
     ret builder.emit_gep(b, slot, arr_ty, ?idx[0], 2);
 }
 


### PR DESCRIPTION
Closes #2201
Closes #2202
Closes #2207

Part of #2199. The two vectorizer scope gaps, and the instrument that makes them
observable. #2207 landed first, on purpose: a test that cannot see the vectorizer
decline is why both gaps shipped green, and fixing the pass first would have left
nothing to prove the fix with.

## The instrument (#2207)

`int/surface/vectorize` asserts each function's output is bit-identical to a
`#[scalar]` twin. That is vacuously true when the pass declines — both sides compile
scalar and agree — so it can see neither a vectorizer that stopped firing nor one
that started firing on a shape it must refuse.

`int/lib/produce.sh` gains a **`vector-emit`** producer that disassembles the case's
own objects (`llvm-objdump`) and reports, per function, whether packed SIMD was
emitted. Objects, not the linked binary: mach's linker emits no symbol table, so
per-function attribution exists only before the link. The per-function verdict, not
the instruction count, is the observable — the count moves with every unrelated
backend change, the verdict only with the vectorizer's own decision.

`int/surface/vectorize-emit` pins a verdict per shape, per target. Every function is
`pub` and uncalled, so nothing is inlined into a caller and each verdict describes
exactly the loop written under it. riscv64 has no 128-bit vector model, so its golden
is all-scalar — the control proving the producer reads the target's real ISA.

**Mutation-tested.** With `vectorize = false` in the profile, the case fails with all
nine `simd` verdicts flipping to `scalar`. With `#[scalar]` on one function, it fails
on exactly that function. Nothing else in the suite notices either mutation.

## #2201 — module-scope arrays

The dependence analysis accepted one address shape, `gep(base, iv)`. A pointer
parameter indexes that way; an array indexed in place — module-scope or local,
neither of which decays to a pointer — reaches its element through `gep(base, 0, iv)`.
Every such access failed to classify, so every loop holding one was DEPENDENT.

`gep_elem_shape` decomposes either form and resolves the per-element stride type: the
source pointee for the pointer form, the array element for the decayed form. Nothing
else moves — the index must still be exactly the induction phi, the base must still
be loop-invariant, the stride must still equal the access width. The alias guard needs
no change, since it builds each range from the access's base and stride type.

## #2202 — loop-invariant scalar operands

Any operand that was not itself a vector value disqualified the op holding it, so
`a[i] = b[i] * k` and `y[i] = a*x[i] + y[i]` had no path to a splat.

An invariant scalar of the element type is now admitted and broadcast once ahead of
the loop, using the construction the reduction accumulator already uses (a lanes-wide
slot written lane by lane, read back as one vector) so it needs no lowering of its
own. The splats go in a block spliced between the vector preheader and the fast
header, created only when there is a splat to make — a loop with no invariant operand
keeps exactly the control flow, and the bytes, it had.

The admission is narrow: at least one operand must still come from the vector set;
the operand's type stamp must be exactly the element type; pointer / global / function
values are excluded; only lane ops are scanned for splat sites (a load's operand is
its address gep and must never be broadcast); and the allowance is opt-in per caller,
so the reduction transform, which has no splat step, keeps its strict rule.

## Evidence

**Before**, from the disassembled object, `glob_i32add` and `mul_f32k` are plain
scalar loops with no guard, no versioning, one element per iteration (`movl`/`addl`,
`movss`/`mulss`). **After**, both carry the alias guard, a packed main loop
(`movups`/`paddd`, `movups`/`mulps` with the splat loaded once in the preheader) and
the scalar remainder. On aarch64 the same loops emit `ldr q` / `add v.4s` and
`fmul v.4s`.

Speedup against a `#[scalar]` twin, x86_64, 65536 elements, best of 7 × 200 reps,
machine under load:

| kernel | speedup |
|---|---|
| ref f64 add (pointer, pre-existing) | 1.85x |
| ref f32 mul (pointer, pre-existing) | 3.77x |
| **#2201** i32 add over module-scope arrays | **4.22x** |
| **#2201** f64 add over module-scope arrays | **3.00x** |
| **#2202** f32 `a[i]=b[i]*k` | **4.43x** |
| **#2202** f32 `a[i]=k*b[i]+c[i]` | **4.25x** |
| **#2202** i32 `a[i]=b[i]+k` | **3.40x** |
| both, f64 global × k | **2.97x** |

Correctness: `int/surface/vectorize` gains all the new shapes against `#[scalar]`
twins plus a loop-carried dependence over module-scope arrays that must stay scalar.
Its release (vectorized), debug (never vectorized) and riscv64 (no vector model) runs
all print `mismatches=0 acc=53494` — the same number three ways.

Suites: **790/0** compiler, **611/0** mach-std at pin `eff1e8e`, int **73/73** linux
and **58/58** riscv64. Three-generation fixpoint A == B == C. Debug builds are
byte-identical to `dev`; at release only three functions in the compiler itself change
(`edit_distance`, its inlined caller, and one doc test — a `prev[t] = curr[t]` row copy
over two local arrays, exactly the #2201 shape).

Not taken on: #2160 (fast-math float reductions) is untouched. A module-scope `val`
trip count still declines, because it reaches the loop header as an unclassifiable
load rather than a constant — that is #2206. An invariant computed *inside* the loop
body is still not invariant to the analysis and still declines; hoisting it is #2204.
