### PR TITLE
fix(codegen): rotate multi-block and memory-tested loops

### DIFF
--- a/int/regression/2211-loop-rotation-scope/expect.txt
+++ b/int/regression/2211-loop-rotation-scope/expect.txt
@@ -1,0 +1,5 @@
+mem: 0 120 496
+mem_branch: 0 12 88
+brk_branch: 0 6 56
+cnt_branch: 0 54
+nested_branch: 0 20 41

--- a/int/regression/2211-loop-rotation-scope/mach.toml
+++ b/int/regression/2211-loop-rotation-scope/mach.toml
@@ -1,0 +1,52 @@
+[project]
+id = "case2211"
+version = "0.0.0"
+src = "src"
+out = "out/{target.name}/{profile.name}"
+
+[target.linux]
+isa = "x86_64"
+os  = "linux"
+abi = "sysv64"
+
+[target.linux-arm64]
+isa = "aarch64"
+os  = "linux"
+abi = "aapcs64"
+
+[target.linux-riscv64]
+isa = "riscv64"
+os  = "linux"
+abi = "lp64"
+
+[target.windows]
+isa = "x86_64"
+os  = "windows"
+abi = "win64"
+
+[target.darwin-aarch64]
+isa = "aarch64"
+os  = "darwin"
+abi = "aapcs64"
+
+[profile.debug]
+opt = 0
+debug = false
+simd = "scalarize"
+
+[profile.release]
+opt = 2
+debug = false
+simd = "scalarize"
+
+[artifact.case]
+kind = "bin"
+entry = "main.mach"
+out = "bin/case"
+targets = ["*"]
+link = []
+need = []
+
+[dep.mach-std]
+git = "https://github.com/briar-systems/mach-std"
+ref = "branch/main"

--- a/int/regression/2211-loop-rotation-scope/src/main.mach
+++ b/int/regression/2211-loop-rotation-scope/src/main.mach
@@ -1,0 +1,128 @@
+# regression pin for the loop shapes rotation reaches (#2211)
+#
+# #1937 shipped rotation matching one shape only: a body of exactly one block,
+# and a header test built from register arithmetic. Every ordinary loop misses
+# that - an `if` in the body makes the header's then-target a branch rather than
+# the latch, and a bound held in a module-scope `val` puts a load in the test -
+# so real code shipped top-tested with an unconditional branch back. #2211
+# widened the match to the loop itself; this case pins the SEMANTICS of the
+# shapes that widening newly transforms, which the shape pin in
+# `be.codegen.looprotate`'s unit tests cannot observe.
+#
+# the hazard a wrong rotation shows as: the guard duplicates the header test into
+# the preheader, so a zero-trip loop that still runs once (a while turned into a
+# do-while), a cloned test reading a stale value, or a mishandled `brk` / `cnt`
+# edge all diverge the output. every bound rides `argc` (1 at runtime, opaque to
+# the compiler), so no profile folds a loop away and every guard and back edge
+# executes for real.
+
+use std.runtime;
+use std.types.size.usize;
+use p: std.print;
+
+# a module-scope bound: the header test loads it every iteration, so the guard
+# duplicates a load. scaling by `n` keeps the trip count runtime-derived.
+pub val LIMIT: i64 = 16;
+
+# memory-loaded bound, single-block body. n == 0 is the zero-trip case.
+fun mem_sum(n: i64) i64 {
+    var acc: i64 = 0;
+    var i: i64 = 0;
+    for (i < LIMIT * n) {
+        acc = acc + i;
+        i = i + 1;
+    }
+    ret acc;
+}
+
+# memory-loaded bound with a branch in the body: both exclusions at once, the
+# exact shape the issue reported.
+fun mem_branch(n: i64) i64 {
+    var acc: i64 = 0;
+    var i: i64 = 0;
+    for (i < LIMIT * n) {
+        if ((i & 3) == 0) { acc = acc + i; } or { acc = acc - 1; }
+        i = i + 1;
+    }
+    ret acc;
+}
+
+# a branch in the body plus `brk`: the exit block gains a second predecessor, so
+# the guard's exit edge is not the only one.
+fun brk_branch(n: i64, stop: i64) i64 {
+    var acc: i64 = 0;
+    var i: i64 = 0;
+    for (i < LIMIT * n) {
+        if (i == stop) { brk; }
+        if ((i & 1) == 0) { acc = acc + i; }
+        i = i + 1;
+    }
+    ret acc;
+}
+
+# a branch in the body plus `cnt`: the header gains a second back edge.
+fun cnt_branch(n: i64) i64 {
+    var acc: i64 = 0;
+    var i: i64 = 0;
+    for (i < LIMIT * n) {
+        val cur: i64 = i;
+        i = i + 1;
+        if ((cur % 3) == 0) { cnt; }
+        if (cur > 8) { acc = acc + cur; } or { acc = acc + 1; }
+    }
+    ret acc;
+}
+
+# nested loops whose outer body is multi-block: the outer header's then-target is
+# the inner preheader, never the latch, so only the inner level rotated before.
+fun nested_branch(n: i64, m: i64) i64 {
+    var acc: i64 = 0;
+    var i: i64 = 0;
+    for (i < n) {
+        var j: i64 = 0;
+        for (j < m) {
+            if ((j & 1) == 0) { acc = acc + 1; } or { acc = acc + 2; }
+            j = j + 1;
+        }
+        if ((i & 1) == 0) { acc = acc + 10; }
+        i = i + 1;
+    }
+    ret acc;
+}
+
+#[symbol("main")]
+fun main(argc: usize, argv: **u8) i64 {
+    # 1 at runtime; opaque to the compiler, so every bound is a real runtime read.
+    val one: i64 = argc::i64;
+
+    p.printf("mem:");
+    p.printf(" {}", mem_sum(0 * one));        # 0   (zero-trip: the guard skips)
+    p.printf(" {}", mem_sum(1 * one));        # 120 (sum 0..15)
+    p.printf(" {}", mem_sum(2 * one));        # 496 (sum 0..31)
+    p.println("");
+
+    p.printf("mem_branch:");
+    p.printf(" {}", mem_branch(0 * one));     # 0
+    p.printf(" {}", mem_branch(1 * one));     # 12
+    p.printf(" {}", mem_branch(2 * one));     # 88
+    p.println("");
+
+    p.printf("brk_branch:");
+    p.printf(" {}", brk_branch(1 * one, 0 * one));    # 0  (brk on the first iteration)
+    p.printf(" {}", brk_branch(1 * one, 5 * one));    # 6  (0+2+4)
+    p.printf(" {}", brk_branch(1 * one, 99 * one));   # 56 (brk never reached)
+    p.println("");
+
+    p.printf("cnt_branch:");
+    p.printf(" {}", cnt_branch(0 * one));     # 0
+    p.printf(" {}", cnt_branch(1 * one));     # 54
+    p.println("");
+
+    p.printf("nested_branch:");
+    p.printf(" {}", nested_branch(0 * one, 4 * one));   # 0
+    p.printf(" {}", nested_branch(3 * one, 0 * one));   # 20
+    p.printf(" {}", nested_branch(3 * one, 5 * one));   # 41
+    p.println("");
+
+    ret 0;
+}

--- a/src/lang/be/codegen/looprotate.mach
+++ b/src/lang/be/codegen/looprotate.mach
@@ -1,34 +1,50 @@
-# mach.lang.be.codegen.looprotate: MIR-level loop rotation (#1937)
+# mach.lang.be.codegen.looprotate: MIR-level loop rotation (#1937, #2211)
 #
-# Rotates a top-test counted loop into bottom-test form so the steady state runs
-# one taken branch per iteration instead of two. A `for (cond)` lowers with the
-# test in the loop header and the body branching back to it, so each iteration
-# takes two taken branches: the header's conditional into the body and the body's
-# unconditional back edge. This pass duplicates the header test into the
-# preheader as an entry guard, which both preserves the zero-trip semantics (the
-# guard skips the loop when the condition is initially false) and, once the
-# preheader branches straight to the body, lets the register allocator's
-# reverse-postorder layout place the exit after the body: the body then falls
-# through into the test and the single conditional back edge is the only taken
-# branch. It composes with the fallthrough elision of #1936, which drops the
-# body's now-redundant branch to the test.
+# Rotates a top-test loop into bottom-test form so the steady state runs one taken
+# branch per iteration instead of two. A `for (cond)` lowers with the test in the
+# loop header and the body branching back to it, so each iteration takes two taken
+# branches: the header's conditional into the body and the body's unconditional
+# back edge. This pass duplicates the header test into the preheader as an entry
+# guard, which both preserves the zero-trip semantics (the guard skips the loop
+# when the condition is initially false) and, once the preheader branches straight
+# to the body, lets the register allocator's reverse-postorder layout place the
+# exit after the latch: the latch then falls through into the test and the single
+# conditional back edge is the only taken branch. It composes with the fallthrough
+# elision of #1936, which drops the latch's now-redundant branch to the test.
 #
 # Why MIR, not IR: at this point `mir.lower_ir` has already destroyed SSA phis
 # into ordinary register copies placed at the ends of the predecessor blocks. The
-# loop-carried updates therefore already live at the end of the body (which ends
+# loop-carried updates therefore already live at the end of the latch (which ends
 # in an unconditional back edge) and the initial values at the end of the
 # preheader. Adding the guard needs no phi surgery and creates no critical edge
 # that the backend would split into a detour block - the two properties that make
 # an IR-level rotate regress under the backend's unconditional critical-edge
 # splitting. The transform is a target-neutral CFG rewrite over the shared MIR.
 #
-# Scope (v1): only the canonical single-block counted loop is rotated - a header
-# `H` ending in a conditional branch whose two predecessors are exactly the clean
-# preheader `P` (a `br H`) and the body latch `B` (a `br H`), with the body and
-# the exit each entered only from `H`, and `H`'s test computed by clonable
-# register-only instructions. Loops with `cnt` back edges, `brk` into the exit,
-# multi-block bodies, or memory / call conditions do not match and are left
-# untouched (correctness preserved, optimization skipped).
+# Scope: the loop must have one entry (the header `H`), one preheader `P` and one
+# exit block `E`, and `H`'s test must be duplicable. Concretely:
+#
+#   - `H` ends in a conditional branch `cbr cond, B, E`;
+#   - the loop is every block reachable from `B` without re-entering `H` or
+#     leaving through `E`. Exactly one of `H`'s predecessors lies outside it - the
+#     preheader `P`, which must end in `br H` - and at least one inside it (a back
+#     edge). A multi-block body, a nested loop, `cnt`'s second back edge and
+#     `brk`'s early exit into `E` all satisfy this;
+#   - every instruction of `H` before the terminator is duplicable computation -
+#     register arithmetic, compares, conversions, moves, and the address / load
+#     reads that a `for (i < LIMIT)` over a module-scope bound lowers to - and one
+#     of them defines `cond`. A store, a call, an alloca or inline asm is not
+#     duplicable and declines the loop;
+#   - no value `H` defines is read outside `H`, since the rotated entry path
+#     branches around `H` and would leave such a read undefined.
+#
+# The duplicated test is evaluated in `P` exactly where `H`'s first evaluation ran
+# (`P` unconditionally entered `H`), so a cloned load reads the same memory at the
+# same point and can neither fault nor observe a body write that the original did
+# not. `H` ends in a conditional branch, so `mir.lower_ir` split every critical
+# edge out of it: `H` carries no phi-destruction copies, and the new `P -> B` /
+# `P -> E` edges need none either. A loop that does not match is left untouched -
+# correctness preserved, optimization skipped.
 
 use std.types.bool.bool;
 use std.types.bool.false;
@@ -36,13 +52,16 @@ use std.types.bool.true;
 use std.types.size.usize;
 use std.types.string.str;
 
+use std.allocator.page;
+
 use A: std.allocator;
 use R: std.types.result;
 
 use mir: mach.lang.be.codegen.mir;
+use mach.lang.source;
 use mach.lang.target;
 
-# rotate every rotatable counted loop in every function of a MIR module in place
+# rotate every rotatable loop in every function of a MIR module in place
 #
 # Target-neutral: the transform reads and rewrites only the shared MIR CFG, so it
 # runs once before instruction selection for every register-machine ISA.
@@ -61,6 +80,25 @@ pub fun run(tgt: *target.Target, m: *mir.MirModule) R.Result[bool, str] {
     ret R.ok[bool, str](true);
 }
 
+# per-function scratch shared by every shape match in one function
+#
+# Block ids and the block count are stable across the pass (rotation rewrites a
+# terminator, never adds or removes a block), so one allocation serves every
+# candidate header.
+# ---
+# id_index:     block id -> index into `f.blocks`; MIR_VREG_NIL where no block owns the id
+# id_index_cap: length of `id_index` (the largest block id plus one)
+# in_loop:      per-block-index mark: true when the block lies inside the candidate loop
+# stack:        the loop-reachability DFS work stack, one slot per block
+# block_count:  length of `in_loop` and `stack`
+rec LoopScratch {
+    id_index:     *u32;
+    id_index_cap: u32;
+    in_loop:      *bool;
+    stack:        *u32;
+    block_count:  u32;
+}
+
 # rotate every rotatable loop header in one function
 #
 # Predecessor lists are the source of truth for the shape match and for the
@@ -71,23 +109,120 @@ pub fun run(tgt: *target.Target, m: *mir.MirModule) R.Result[bool, str] {
 # f:     the MIR function to rotate in place
 # ret:   ok(true) on success, or an allocation error
 fun rotate_function(alloc: *A.Allocator, f: *mir.MirFunction) R.Result[bool, str] {
-    val rp: R.Result[bool, str] = rebuild_preds(alloc, f);
-    if (R.is_err[bool, str](rp)) { ret rp; }
+    if (f.block_count == 0) { ret R.ok[bool, str](true); }
+
+    var sc: LoopScratch;
+    val si: R.Result[bool, str] = scratch_init(alloc, f, ?sc);
+    if (R.is_err[bool, str](si)) { ret si; }
+
+    val rp: R.Result[bool, str] = rebuild_preds(alloc, f, ?sc);
+    if (R.is_err[bool, str](rp)) { scratch_dnit(alloc, ?sc); ret rp; }
 
     var bi: u32 = 0;
     for (bi < f.block_count) {
-        val r: R.Result[bool, str] = try_rotate_header(alloc, f, ?f.blocks[bi]);
-        if (R.is_err[bool, str](r)) { ret r; }
+        val r: R.Result[bool, str] = try_rotate_header(alloc, f, ?sc, ?f.blocks[bi]);
+        if (R.is_err[bool, str](r)) { scratch_dnit(alloc, ?sc); ret r; }
         if (R.unwrap_ok[bool, str](r)) {
-            val rp2: R.Result[bool, str] = rebuild_preds(alloc, f);
-            if (R.is_err[bool, str](rp2)) { ret rp2; }
+            val rp2: R.Result[bool, str] = rebuild_preds(alloc, f, ?sc);
+            if (R.is_err[bool, str](rp2)) { scratch_dnit(alloc, ?sc); ret rp2; }
         }
         bi = bi + 1;
     }
+
+    scratch_dnit(alloc, ?sc);
     ret R.ok[bool, str](true);
 }
 
-# match the canonical counted-loop shape at header `h` and rotate it when it fits
+# allocate the per-function scratch and fill the block-id -> index map
+# ---
+# alloc: the function's backing allocator
+# f:     the function the scratch describes
+# sc:    the scratch to initialize (owned by the caller, freed with `scratch_dnit`)
+# ret:   ok(true) on success, or an allocation error (the scratch is left freed)
+fun scratch_init(alloc: *A.Allocator, f: *mir.MirFunction, sc: *LoopScratch) R.Result[bool, str] {
+    sc.id_index     = nil;
+    sc.id_index_cap = 0;
+    sc.in_loop      = nil;
+    sc.stack        = nil;
+    sc.block_count  = f.block_count;
+
+    var max_id: u32 = 0;
+    var i: u32 = 0;
+    for (i < f.block_count) {
+        if (f.blocks[i].id > max_id) { max_id = f.blocks[i].id; }
+        i = i + 1;
+    }
+
+    val cap: u32 = max_id + 1;
+    val ri: R.Result[*u32, str] = A.allocate[u32](alloc, cap::usize);
+    if (R.is_err[*u32, str](ri)) { ret R.err[bool, str](R.unwrap_err[*u32, str](ri)); }
+    sc.id_index     = R.unwrap_ok[*u32, str](ri);
+    sc.id_index_cap = cap;
+    var k: u32 = 0;
+    for (k < cap) { sc.id_index[k] = mir.MIR_VREG_NIL; k = k + 1; }
+    k = 0;
+    for (k < f.block_count) { sc.id_index[f.blocks[k].id] = k; k = k + 1; }
+
+    val rb: R.Result[*bool, str] = A.allocate[bool](alloc, f.block_count::usize);
+    if (R.is_err[*bool, str](rb)) {
+        scratch_dnit(alloc, sc);
+        ret R.err[bool, str](R.unwrap_err[*bool, str](rb));
+    }
+    sc.in_loop = R.unwrap_ok[*bool, str](rb);
+
+    val rs: R.Result[*u32, str] = A.allocate[u32](alloc, f.block_count::usize);
+    if (R.is_err[*u32, str](rs)) {
+        scratch_dnit(alloc, sc);
+        ret R.err[bool, str](R.unwrap_err[*u32, str](rs));
+    }
+    sc.stack = R.unwrap_ok[*u32, str](rs);
+
+    ret R.ok[bool, str](true);
+}
+
+# free every scratch array and reset the handles
+# ---
+# alloc: the allocator the scratch was taken from
+# sc:    the scratch to release
+fun scratch_dnit(alloc: *A.Allocator, sc: *LoopScratch) {
+    if (sc.id_index != nil) {
+        A.deallocate[u32](alloc, sc.id_index, sc.id_index_cap::usize);
+        sc.id_index     = nil;
+        sc.id_index_cap = 0;
+    }
+    if (sc.in_loop != nil) {
+        A.deallocate[bool](alloc, sc.in_loop, sc.block_count::usize);
+        sc.in_loop = nil;
+    }
+    if (sc.stack != nil) {
+        A.deallocate[u32](alloc, sc.stack, sc.block_count::usize);
+        sc.stack = nil;
+    }
+}
+
+# the index into `f.blocks` of the block whose id is `id`, or MIR_VREG_NIL
+# ---
+# sc: the scratch holding the id map
+# id: the block id to resolve
+# ret: the block index, or MIR_VREG_NIL when no block owns the id
+fun block_index(sc: *LoopScratch, id: u32) u32 {
+    if (id >= sc.id_index_cap) { ret mir.MIR_VREG_NIL; }
+    ret sc.id_index[id];
+}
+
+# the block whose id equals `id`, or nil when none matches
+# ---
+# f:   the function to search
+# sc:  the scratch holding the id map
+# id:  the block id to find
+# ret: the matching block, or nil
+fun find_block(f: *mir.MirFunction, sc: *LoopScratch, id: u32) *mir.MirBlock {
+    val ix: u32 = block_index(sc, id);
+    if (ix == mir.MIR_VREG_NIL) { ret nil; }
+    ret ?f.blocks[ix];
+}
+
+# match the rotatable loop shape at header `h` and rotate it when it fits
 #
 # Returns ok(true) when a rotation was performed, ok(false) when `h` is not a
 # rotatable header (the loop is left untouched), or an error on allocation
@@ -95,9 +230,11 @@ fun rotate_function(alloc: *A.Allocator, f: *mir.MirFunction) R.Result[bool, str
 # ---
 # alloc: the function's backing allocator
 # f:     the owning MIR function
+# sc:    the per-function scratch
 # h:     the candidate loop header block
 # ret:   ok(true) rotated, ok(false) not a match, or an allocation error
-fun try_rotate_header(alloc: *A.Allocator, f: *mir.MirFunction, h: *mir.MirBlock) R.Result[bool, str] {
+fun try_rotate_header(alloc: *A.Allocator, f: *mir.MirFunction, sc: *LoopScratch,
+                      h: *mir.MirBlock) R.Result[bool, str] {
     if (h.instr_count == 0) { ret R.ok[bool, str](false); }
     val term: *mir.MirInstr = ?h.instrs[h.instr_count - 1];
     if (term.opcode != mir.MIR_CBR)   { ret R.ok[bool, str](false); }
@@ -109,47 +246,99 @@ fun try_rotate_header(alloc: *A.Allocator, f: *mir.MirFunction, h: *mir.MirBlock
     if (term.operands[2].kind != mir.MIR_OP_BLOCK) { ret R.ok[bool, str](false); }
 
     val cond_vreg: u32 = cond_op.vreg;
-    val b_id: u32 = term.operands[1].imm::u32;  # then: the loop body
+    val b_id: u32 = term.operands[1].imm::u32;  # then: the loop body's first block
     val e_id: u32 = term.operands[2].imm::u32;  # else: the loop exit
     if (b_id == e_id)  { ret R.ok[bool, str](false); }
     if (b_id == h.id)  { ret R.ok[bool, str](false); }
     if (e_id == h.id)  { ret R.ok[bool, str](false); }
 
-    # H's two predecessors must be exactly the back edge from B and the preheader P.
-    if (h.pred_count != 2) { ret R.ok[bool, str](false); }
+    # a loop header is entered from outside and from at least one back edge.
+    if (h.pred_count < 2) { ret R.ok[bool, str](false); }
+
+    # H's test must be clonable computation defining the branch condition, and none
+    # of the values it defines may be read outside H: the rotated entry path
+    # branches around H, so such a read would see an undefined register.
+    if (!test_clonable(h, cond_vreg)) { ret R.ok[bool, str](false); }
+    if (!defs_confined(f, h))         { ret R.ok[bool, str](false); }
+
+    # partition H's predecessors against the loop: exactly one outside it is the
+    # preheader P, and at least one inside it is a back edge.
+    if (!mark_loop(f, sc, b_id, h.id, e_id)) { ret R.ok[bool, str](false); }
     var p_id: u32 = mir.MIR_VREG_NIL;
-    if (h.preds[0] == b_id)      { p_id = h.preds[1]; }
-    or (h.preds[1] == b_id)      { p_id = h.preds[0]; }
-    or { ret R.ok[bool, str](false); }
-    if (p_id == b_id) { ret R.ok[bool, str](false); }
+    var outside: u32 = 0;
+    var inside: u32 = 0;
+    var pi: u32 = 0;
+    for (pi < h.pred_count) {
+        val px: u32 = block_index(sc, h.preds[pi]);
+        if (px != mir.MIR_VREG_NIL && sc.in_loop[px]) {
+            inside = inside + 1;
+        } or {
+            outside = outside + 1;
+            p_id = h.preds[pi];
+        }
+        pi = pi + 1;
+    }
+    if (outside != 1) { ret R.ok[bool, str](false); }
+    if (inside == 0)  { ret R.ok[bool, str](false); }
     if (p_id == h.id) { ret R.ok[bool, str](false); }
     if (p_id == e_id) { ret R.ok[bool, str](false); }
 
-    # B: a single-block latch entered only from H, branching unconditionally to H.
-    val b: *mir.MirBlock = find_block(f, b_id);
-    if (b == nil)                  { ret R.ok[bool, str](false); }
-    if (!ends_in_br_to(b, h.id))   { ret R.ok[bool, str](false); }
-    if (b.pred_count != 1)         { ret R.ok[bool, str](false); }
-    if (b.preds[0] != h.id)        { ret R.ok[bool, str](false); }
-
-    # E: the exit, entered only from H (no brk edge), so it carries no phi copies
-    # that the new P->E edge would leave undefined.
-    val e: *mir.MirBlock = find_block(f, e_id);
-    if (e == nil)           { ret R.ok[bool, str](false); }
-    if (e.pred_count != 1)  { ret R.ok[bool, str](false); }
-    if (e.preds[0] != h.id) { ret R.ok[bool, str](false); }
-
-    # P: a clean preheader whose sole successor is H.
-    val p: *mir.MirBlock = find_block(f, p_id);
+    # P: a clean preheader whose sole successor is H, so its terminator can be
+    # replaced by the guard outright.
+    val p: *mir.MirBlock = find_block(f, sc, p_id);
     if (p == nil)                { ret R.ok[bool, str](false); }
     if (!ends_in_br_to(p, h.id)) { ret R.ok[bool, str](false); }
-    if (p.instr_count == 0)      { ret R.ok[bool, str](false); }
-
-    # H's test must be clonable register-only computation that defines the branch
-    # condition, so duplicating it into P re-evaluates the condition on entry.
-    if (!body_clonable(h, cond_vreg)) { ret R.ok[bool, str](false); }
 
     ret rotate(alloc, f, h, p, b_id, e_id, cond_vreg);
+}
+
+# mark every block of the loop entered at `b_id` into `sc.in_loop`
+#
+# The loop is what a forward walk from the header's body target reaches without
+# re-entering the header or leaving through the exit block, so `cnt`'s back-edge
+# block and a nested loop are inside it while everything past the exit is not.
+# ---
+# f:    the owning function
+# sc:   the scratch whose `in_loop` marks and `stack` the walk uses
+# b_id: the header's body target, the walk's root
+# h_id: the header id, a walk barrier
+# e_id: the exit id, a walk barrier
+# ret:  true when the walk ran (false when `b_id` names no block)
+fun mark_loop(f: *mir.MirFunction, sc: *LoopScratch, b_id: u32, h_id: u32, e_id: u32) bool {
+    var i: u32 = 0;
+    for (i < sc.block_count) { sc.in_loop[i] = false; i = i + 1; }
+
+    val root: u32 = block_index(sc, b_id);
+    if (root == mir.MIR_VREG_NIL) { ret false; }
+    sc.in_loop[root] = true;
+    sc.stack[0] = root;
+    var sp: u32 = 1;
+
+    for (sp > 0) {
+        sp = sp - 1;
+        val bx: u32 = sc.stack[sp];
+        val mb: *mir.MirBlock = ?f.blocks[bx];
+        if (mb.instr_count > 0) {
+            val t: *mir.MirInstr = ?mb.instrs[mb.instr_count - 1];
+            var k: u32 = 0;
+            for (k < t.operand_count) {
+                val op: *mir.MirOperand = ?t.operands[k];
+                if (op.kind == mir.MIR_OP_BLOCK) {
+                    val tid: u32 = op.imm::u32;
+                    if (tid != h_id && tid != e_id) {
+                        val tx: u32 = block_index(sc, tid);
+                        if (tx != mir.MIR_VREG_NIL && !sc.in_loop[tx]) {
+                            sc.in_loop[tx] = true;
+                            sc.stack[sp] = tx;
+                            sp = sp + 1;
+                        }
+                    }
+                }
+                k = k + 1;
+            }
+        }
+    }
+    ret true;
 }
 
 # perform the rotation once the shape is confirmed: duplicate H's test and its
@@ -158,7 +347,7 @@ fun try_rotate_header(alloc: *A.Allocator, f: *mir.MirFunction, h: *mir.MirBlock
 # The guard's clones read the loop-carried registers at their preheader values
 # (the initial-value copies already sitting at the end of P), so the guard tests
 # the first iteration's condition exactly as H's original entry evaluation did.
-# H is left intact, now reached only by the body's back edge.
+# H is left intact, now reached only by the loop's back edges.
 # ---
 # alloc:     the function's backing allocator
 # f:         the owning MIR function
@@ -206,14 +395,14 @@ fun rotate(alloc: *A.Allocator, f: *mir.MirFunction, h: *mir.MirBlock, p: *mir.M
     ret R.ok[bool, str](true);
 }
 
-# whether every instruction of `h`'s body (all but the terminator) is a clonable
-# register-only computation defining a value vreg, and one of them defines
-# `cond_vreg` (so the cloned guard re-derives the branch condition)
+# whether every instruction of `h`'s test (all but the terminator) is a clonable
+# computation defining a value vreg, and one of them defines `cond_vreg` (so the
+# cloned guard re-derives the branch condition)
 # ---
 # h:         the header block whose test is inspected
-# cond_vreg: the branch-condition vreg that must be defined within the body
+# cond_vreg: the branch-condition vreg that must be defined within the test
 # ret:       true when the test can be safely duplicated into the guard
-fun body_clonable(h: *mir.MirBlock, cond_vreg: u32) bool {
+fun test_clonable(h: *mir.MirBlock, cond_vreg: u32) bool {
     var defines_cond: bool = false;
     var i: u32 = 0;
     for (i < h.instr_count - 1) {
@@ -228,15 +417,83 @@ fun body_clonable(h: *mir.MirBlock, cond_vreg: u32) bool {
     ret defines_cond;
 }
 
-# whether a generic MIR opcode is a pure register computation safe to duplicate:
-# the integer arithmetic / logic / compare / conversion family (0..MIR_BITCAST)
-# plus a plain register move. memory, calls, allocas, and branches are excluded,
-# so a clone has no side effect and reads only its register / immediate operands
+# whether no value `h`'s test defines is named by an instruction outside `h`
+#
+# The rotated entry path runs the guard and branches straight to the body or the
+# exit, so `h` no longer executes on the first iteration: any value it defines
+# that another block names would be read undefined. `h` ends in a conditional
+# branch, so `lower_ir` never placed a phi-destruction copy in it and its
+# definitions are unique - a name that reappears elsewhere is a genuine read.
+# ---
+# f:   the owning function
+# h:   the header whose test definitions are checked
+# ret: true when every test definition is confined to `h`
+fun defs_confined(f: *mir.MirFunction, h: *mir.MirBlock) bool {
+    var bi: u32 = 0;
+    for (bi < f.block_count) {
+        val mb: *mir.MirBlock = ?f.blocks[bi];
+        if (mb.id != h.id) {
+            var k: u32 = 0;
+            for (k < mb.instr_count) {
+                if (names_test_def(h, ?mb.instrs[k])) { ret false; }
+                k = k + 1;
+            }
+        }
+        bi = bi + 1;
+    }
+    ret true;
+}
+
+# whether any operand of `ins` names a vreg that `h`'s test defines
+# ---
+# h:   the header whose test definitions are the search set
+# ins: the instruction to inspect
+# ret: true when `ins` names one of them
+fun names_test_def(h: *mir.MirBlock, ins: *mir.MirInstr) bool {
+    var k: u32 = 0;
+    for (k < ins.operand_count) {
+        val op: *mir.MirOperand = ?ins.operands[k];
+        if (op.kind == mir.MIR_OP_VREG && test_defines(h, op.vreg)) { ret true; }
+        if (op.kind == mir.MIR_OP_MEM) {
+            if (test_defines(h, op.vreg))                       { ret true; }
+            if (!op.index_is_preg && test_defines(h, op.index)) { ret true; }
+        }
+        k = k + 1;
+    }
+    ret false;
+}
+
+# whether one of `h`'s test instructions defines vreg `v`
+# ---
+# h:   the header whose test is scanned
+# v:   the vreg id to look for
+# ret: true when a test instruction writes `v`
+fun test_defines(h: *mir.MirBlock, v: u32) bool {
+    if (v == mir.MIR_VREG_NIL) { ret false; }
+    var i: u32 = 0;
+    for (i < h.instr_count - 1) {
+        val ins: *mir.MirInstr = ?h.instrs[i];
+        if (ins.operand_count > 0 && ins.operands[0].kind == mir.MIR_OP_VREG &&
+            ins.operands[0].vreg == v) { ret true; }
+        i = i + 1;
+    }
+    ret false;
+}
+
+# whether a generic MIR opcode is a computation safe to duplicate into the guard:
+# the arithmetic / logic / compare / conversion family (0..MIR_BITCAST), a plain
+# register move, and the address / load reads a bound fetched from memory lowers
+# to. Stores, calls, allocas, inline asm and branches are excluded, so a clone has
+# no side effect. A load is duplicable because the guard sits exactly where the
+# header's first evaluation ran - it reads the same address at the same point,
+# faults where the original faulted, and cannot observe a body write
 # ---
 # op:  the opcode to classify
 # ret: true when duplicating an instruction with this opcode is side-effect-free
 fun clonable_opcode(op: mir.MirOpcode) bool {
     if (op <= mir.MIR_BITCAST) { ret true; }
+    if (op == mir.MIR_LOAD)    { ret true; }
+    if (op == mir.MIR_GEP)     { ret true; }
     if (op == mir.MIR_MOV)     { ret true; }
     ret false;
 }
@@ -256,18 +513,21 @@ fun clone_compute(alloc: *A.Allocator, f: *mir.MirFunction, src: *mir.MirInstr,
     val nd: R.Result[u32, str] = add_vreg_like(alloc, f, old_dest);
     if (R.is_err[u32, str](nd)) { ret R.err[mir.MirInstr, str](R.unwrap_err[u32, str](nd)); }
     val new_dest: u32 = R.unwrap_ok[u32, str](nd);
-    remap[old_dest] = new_dest;
 
     val ro: R.Result[*mir.MirOperand, str] = A.allocate[mir.MirOperand](alloc, src.operand_count::usize);
     if (R.is_err[*mir.MirOperand, str](ro)) { ret R.err[mir.MirInstr, str](R.unwrap_err[*mir.MirOperand, str](ro)); }
     val ops: *mir.MirOperand = R.unwrap_ok[*mir.MirOperand, str](ro);
 
-    ops[0] = mir.op_vreg(new_dest);
+    # the sources are remapped BEFORE the destination is recorded, so an
+    # instruction that reads its own destination register reads the value the
+    # earlier clones produced rather than its own fresh one.
     var k: u32 = 1;
     for (k < src.operand_count) {
         ops[k] = remap_operand(src.operands[k], remap, orig_vregs);
         k = k + 1;
     }
+    remap[old_dest] = new_dest;
+    ops[0] = mir.op_vreg(new_dest);
 
     ret R.ok[mir.MirInstr, str](make_instr(src, ops, src.operand_count));
 }
@@ -399,22 +659,6 @@ fun append_instr(alloc: *A.Allocator, mb: *mir.MirBlock, mi: mir.MirInstr) R.Res
     ret R.ok[bool, str](true);
 }
 
-# the block whose id equals `id`, or nil when none matches. MIR block ids are not
-# necessarily their array index (critical-edge splits append higher ids), so this
-# scans rather than indexing
-# ---
-# f:  the function to search
-# id: the block id to find
-# ret: the matching block, or nil
-fun find_block(f: *mir.MirFunction, id: u32) *mir.MirBlock {
-    var i: u32 = 0;
-    for (i < f.block_count) {
-        if (f.blocks[i].id == id) { ret ?f.blocks[i]; }
-        i = i + 1;
-    }
-    ret nil;
-}
-
 # whether block `mb` ends in an unconditional `MIR_BR` to block id `target`
 # ---
 # mb:     the block to inspect
@@ -435,8 +679,9 @@ fun ends_in_br_to(mb: *mir.MirBlock, target: u32) bool {
 # ---
 # alloc: the function's allocator
 # f:     the function whose predecessor lists are rebuilt
+# sc:    the per-function scratch holding the block-id map
 # ret:   ok(true) on success, or an allocation error
-fun rebuild_preds(alloc: *A.Allocator, f: *mir.MirFunction) R.Result[bool, str] {
+fun rebuild_preds(alloc: *A.Allocator, f: *mir.MirFunction, sc: *LoopScratch) R.Result[bool, str] {
     var i: u32 = 0;
     for (i < f.block_count) { f.blocks[i].pred_count = 0; i = i + 1; }
 
@@ -449,7 +694,7 @@ fun rebuild_preds(alloc: *A.Allocator, f: *mir.MirFunction) R.Result[bool, str] 
             for (k < t.operand_count) {
                 val op: *mir.MirOperand = ?t.operands[k];
                 if (op.kind == mir.MIR_OP_BLOCK) {
-                    val succ: *mir.MirBlock = find_block(f, op.imm::u32);
+                    val succ: *mir.MirBlock = find_block(f, sc, op.imm::u32);
                     if (succ != nil) {
                         val ap: R.Result[bool, str] = pred_append(alloc, succ, mb.id);
                         if (R.is_err[bool, str](ap)) { ret ap; }
@@ -483,4 +728,303 @@ fun pred_append(alloc: *A.Allocator, mb: *mir.MirBlock, pred: u32) R.Result[bool
     mb.preds[mb.pred_count] = pred;
     mb.pred_count = mb.pred_count + 1;
     ret R.ok[bool, str](true);
+}
+
+# a heap operand array holding a copy of `src` (test helper)
+#
+# The pass frees the preheader terminator's operand array, so a test's blocks must
+# own heap operands rather than borrow a stack array.
+fun t_ops(alloc: *A.Allocator, src: *mir.MirOperand, n: u32) *mir.MirOperand {
+    val r: R.Result[*mir.MirOperand, str] = A.allocate[mir.MirOperand](alloc, n::usize);
+    val out: *mir.MirOperand = R.unwrap_ok[*mir.MirOperand, str](r);
+    var i: u32 = 0;
+    for (i < n) { out[i] = src[i]; i = i + 1; }
+    ret out;
+}
+
+# a MIR instruction over a heap-copied operand array (test helper)
+fun t_instr(alloc: *A.Allocator, op: mir.MirOpcode, ops: *mir.MirOperand, n: u32) mir.MirInstr {
+    var mi: mir.MirInstr;
+    mi.opcode            = op;
+    mi.operands          = t_ops(alloc, ops, n);
+    mi.operand_count     = n;
+    mi.width             = 8;
+    mi.src_width         = 8;
+    mi.asm_block         = nil;
+    mi.loc               = source.loc_nil();
+    mi.dbg_bindings      = nil;
+    mi.dbg_binding_count = 0;
+    mi.inline_site       = 0;
+    mi.vec_lane          = mir.VEC_LANE_NONE;
+    mi.writes_secret     = false;
+    ret mi;
+}
+
+# a MIR block over a heap-copied instruction array (test helper)
+#
+# The guard grows the preheader through `append_instr`, which reallocates the
+# array, so a test's blocks must own heap instructions rather than borrow a stack
+# array.
+fun t_block(alloc: *A.Allocator, id: u32, instrs: *mir.MirInstr, n: u32) mir.MirBlock {
+    val r: R.Result[*mir.MirInstr, str] = A.allocate[mir.MirInstr](alloc, n::usize);
+    val own: *mir.MirInstr = R.unwrap_ok[*mir.MirInstr, str](r);
+    var i: u32 = 0;
+    for (i < n) { own[i] = instrs[i]; i = i + 1; }
+
+    var b: mir.MirBlock;
+    b.id          = id;
+    b.instrs      = own;
+    b.instr_count = n;
+    b.instr_cap   = n;
+    b.preds       = nil;
+    b.pred_count  = 0;
+    b.pred_cap    = 0;
+    ret b;
+}
+
+# a MIR function over borrowed block / vreg arrays (test helper)
+fun t_fn(alloc: *A.Allocator, blocks: *mir.MirBlock, nb: u32, nv: u32) mir.MirFunction {
+    var f: mir.MirFunction;
+    f.blocks      = blocks;
+    f.block_count = nb;
+    f.block_cap   = nb;
+    val r: R.Result[*mir.MirVReg, str] = A.allocate[mir.MirVReg](alloc, nv::usize);
+    f.vregs      = R.unwrap_ok[*mir.MirVReg, str](r);
+    f.vreg_count = nv;
+    f.vreg_cap   = nv;
+    var i: u32 = 0;
+    for (i < nv) {
+        f.vregs[i].id         = i;
+        f.vregs[i].class      = mir.REG_CLASS_GP;
+        f.vregs[i].spill_slot = -1;
+        f.vregs[i].assigned   = mir.MIR_VREG_NIL;
+        f.vregs[i].vector     = false;
+        f.vregs[i].secret     = false;
+        i = i + 1;
+    }
+    ret f;
+}
+
+# whether `mb`'s terminator is a `cbr` branching to `then_id` / `else_id` (test helper)
+fun t_ends_in_cbr_to(mb: *mir.MirBlock, then_id: u32, else_id: u32) bool {
+    if (mb.instr_count == 0) { ret false; }
+    val t: *mir.MirInstr = ?mb.instrs[mb.instr_count - 1];
+    if (t.opcode != mir.MIR_CBR)  { ret false; }
+    if (t.operand_count != 3)     { ret false; }
+    if (t.operands[1].kind != mir.MIR_OP_BLOCK || t.operands[1].imm::u32 != then_id) { ret false; }
+    if (t.operands[2].kind != mir.MIR_OP_BLOCK || t.operands[2].imm::u32 != else_id) { ret false; }
+    ret true;
+}
+
+# a loop whose body is more than one block - the shape a `for` with an `if` inside
+# lowers to - rotates. B0 preheader -> B1 header (`cmp`, `cbr B2, B5`); B2 body
+# branches to B3 or B4, both of which reach the B4 latch; B5 exit. The v1 matcher
+# required the header's then-target to BE the latch, so every real loop carrying a
+# branch declined and shipped top-tested (#2211).
+test "mach.lang.be.codegen.looprotate.try_rotate_header:multi_block_body" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+
+    # v0 induction, v1 bound, v2 condition, v3 body scratch.
+    var mov:  [2]mir.MirOperand; mov[0]  = mir.op_vreg(0); mov[1]  = mir.op_imm(0);
+    var pbr:  [1]mir.MirOperand; pbr[0]  = mir.op_block(1);
+    var b0i:  [2]mir.MirInstr;
+    b0i[0] = t_instr(?alloc, mir.MIR_MOV, ?mov[0], 2);
+    b0i[1] = t_instr(?alloc, mir.MIR_BR,  ?pbr[0], 1);
+
+    var cmp:  [3]mir.MirOperand; cmp[0]  = mir.op_vreg(2); cmp[1] = mir.op_vreg(0); cmp[2] = mir.op_vreg(1);
+    var hcbr: [3]mir.MirOperand; hcbr[0] = mir.op_vreg(2); hcbr[1] = mir.op_block(2); hcbr[2] = mir.op_block(5);
+    var b1i:  [2]mir.MirInstr;
+    b1i[0] = t_instr(?alloc, mir.MIR_CMP_LT_S, ?cmp[0], 3);
+    b1i[1] = t_instr(?alloc, mir.MIR_CBR,      ?hcbr[0], 3);
+
+    var icbr: [3]mir.MirOperand; icbr[0] = mir.op_vreg(3); icbr[1] = mir.op_block(3); icbr[2] = mir.op_block(4);
+    var b2i:  [1]mir.MirInstr;
+    b2i[0] = t_instr(?alloc, mir.MIR_CBR, ?icbr[0], 3);
+
+    var tbr:  [1]mir.MirOperand; tbr[0] = mir.op_block(4);
+    var b3i:  [1]mir.MirInstr;
+    b3i[0] = t_instr(?alloc, mir.MIR_BR, ?tbr[0], 1);
+
+    var inc:  [3]mir.MirOperand; inc[0] = mir.op_vreg(0); inc[1] = mir.op_vreg(0); inc[2] = mir.op_imm(1);
+    var lbr:  [1]mir.MirOperand; lbr[0] = mir.op_block(1);
+    var b4i:  [2]mir.MirInstr;
+    b4i[0] = t_instr(?alloc, mir.MIR_ADD, ?inc[0], 3);
+    b4i[1] = t_instr(?alloc, mir.MIR_BR,  ?lbr[0], 1);
+
+    var b5i:  [1]mir.MirInstr;
+    b5i[0] = t_instr(?alloc, mir.MIR_RET, nil, 0);
+
+    var blocks: [6]mir.MirBlock;
+    blocks[0] = t_block(?alloc, 0, ?b0i[0], 2);
+    blocks[1] = t_block(?alloc, 1, ?b1i[0], 2);
+    blocks[2] = t_block(?alloc, 2, ?b2i[0], 1);
+    blocks[3] = t_block(?alloc, 3, ?b3i[0], 1);
+    blocks[4] = t_block(?alloc, 4, ?b4i[0], 2);
+    blocks[5] = t_block(?alloc, 5, ?b5i[0], 1);
+
+    var f: mir.MirFunction = t_fn(?alloc, ?blocks[0], 6, 4);
+    val r: R.Result[bool, str] = rotate_function(?alloc, ?f);
+    if (R.is_err[bool, str](r)) { ret 1; }
+
+    # the preheader keeps its init move and gains the cloned compare plus the guard.
+    if (f.blocks[0].instr_count != 3)                       { ret 1; }
+    if (f.blocks[0].instrs[1].opcode != mir.MIR_CMP_LT_S)   { ret 1; }
+    if (!t_ends_in_cbr_to(?f.blocks[0], 2, 5))              { ret 1; }
+    # the guard branches on the CLONE of the condition, not the header's vreg.
+    if (f.blocks[0].instrs[2].operands[0].vreg != 4)        { ret 1; }
+    if (f.blocks[0].instrs[1].operands[0].vreg != 4)        { ret 1; }
+
+    # the header is now reached only by the latch's back edge.
+    if (f.blocks[1].pred_count != 1) { ret 1; }
+    if (f.blocks[1].preds[0] != 4)   { ret 1; }
+    if (f.blocks[1].instr_count != 2) { ret 1; }
+    ret 0;
+}
+
+# a header testing a bound fetched from memory - what `for (i < LIMIT)` over a
+# module-scope `val` lowers to - rotates, with the load duplicated into the guard.
+# the v1 clonable set stopped at MIR_BITCAST, so any loop whose bound was not
+# already in a register declined (#2211).
+test "mach.lang.be.codegen.looprotate.try_rotate_header:memory_bound_test" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+
+    # v0 induction, v1 bound pointer, v2 loaded bound, v3 condition.
+    var mov:  [2]mir.MirOperand; mov[0]  = mir.op_vreg(0); mov[1]  = mir.op_imm(0);
+    var pbr:  [1]mir.MirOperand; pbr[0]  = mir.op_block(1);
+    var b0i:  [2]mir.MirInstr;
+    b0i[0] = t_instr(?alloc, mir.MIR_MOV, ?mov[0], 2);
+    b0i[1] = t_instr(?alloc, mir.MIR_BR,  ?pbr[0], 1);
+
+    var ld:   [2]mir.MirOperand; ld[0]   = mir.op_vreg(2); ld[1]  = mir.op_mem_value(1, 0);
+    var cmp:  [3]mir.MirOperand; cmp[0]  = mir.op_vreg(3); cmp[1] = mir.op_vreg(0); cmp[2] = mir.op_vreg(2);
+    var hcbr: [3]mir.MirOperand; hcbr[0] = mir.op_vreg(3); hcbr[1] = mir.op_block(2); hcbr[2] = mir.op_block(3);
+    var b1i:  [3]mir.MirInstr;
+    b1i[0] = t_instr(?alloc, mir.MIR_LOAD,     ?ld[0], 2);
+    b1i[1] = t_instr(?alloc, mir.MIR_CMP_LT_S, ?cmp[0], 3);
+    b1i[2] = t_instr(?alloc, mir.MIR_CBR,      ?hcbr[0], 3);
+
+    var inc:  [3]mir.MirOperand; inc[0] = mir.op_vreg(0); inc[1] = mir.op_vreg(0); inc[2] = mir.op_imm(1);
+    var lbr:  [1]mir.MirOperand; lbr[0] = mir.op_block(1);
+    var b2i:  [2]mir.MirInstr;
+    b2i[0] = t_instr(?alloc, mir.MIR_ADD, ?inc[0], 3);
+    b2i[1] = t_instr(?alloc, mir.MIR_BR,  ?lbr[0], 1);
+
+    var b3i:  [1]mir.MirInstr;
+    b3i[0] = t_instr(?alloc, mir.MIR_RET, nil, 0);
+
+    var blocks: [4]mir.MirBlock;
+    blocks[0] = t_block(?alloc, 0, ?b0i[0], 2);
+    blocks[1] = t_block(?alloc, 1, ?b1i[0], 3);
+    blocks[2] = t_block(?alloc, 2, ?b2i[0], 2);
+    blocks[3] = t_block(?alloc, 3, ?b3i[0], 1);
+
+    var f: mir.MirFunction = t_fn(?alloc, ?blocks[0], 4, 4);
+    val r: R.Result[bool, str] = rotate_function(?alloc, ?f);
+    if (R.is_err[bool, str](r)) { ret 1; }
+
+    # init move + cloned load + cloned compare + guard.
+    if (f.blocks[0].instr_count != 4)                     { ret 1; }
+    if (f.blocks[0].instrs[1].opcode != mir.MIR_LOAD)     { ret 1; }
+    if (f.blocks[0].instrs[2].opcode != mir.MIR_CMP_LT_S) { ret 1; }
+    if (!t_ends_in_cbr_to(?f.blocks[0], 2, 3))            { ret 1; }
+    # the cloned compare reads the CLONED load's destination, not the header's v2.
+    if (f.blocks[0].instrs[1].operands[0].vreg != 4)      { ret 1; }
+    if (f.blocks[0].instrs[2].operands[2].vreg != 4)      { ret 1; }
+    if (f.blocks[1].pred_count != 1)                      { ret 1; }
+    ret 0;
+}
+
+# a header whose test result is also read in the loop body is left alone: the
+# rotated entry path branches around the header, so the body would read a register
+# the guard only ever wrote under a fresh name.
+test "mach.lang.be.codegen.looprotate.try_rotate_header:declines_escaping_test_def" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+
+    var mov:  [2]mir.MirOperand; mov[0]  = mir.op_vreg(0); mov[1]  = mir.op_imm(0);
+    var pbr:  [1]mir.MirOperand; pbr[0]  = mir.op_block(1);
+    var b0i:  [2]mir.MirInstr;
+    b0i[0] = t_instr(?alloc, mir.MIR_MOV, ?mov[0], 2);
+    b0i[1] = t_instr(?alloc, mir.MIR_BR,  ?pbr[0], 1);
+
+    var cmp:  [3]mir.MirOperand; cmp[0]  = mir.op_vreg(2); cmp[1] = mir.op_vreg(0); cmp[2] = mir.op_vreg(1);
+    var hcbr: [3]mir.MirOperand; hcbr[0] = mir.op_vreg(2); hcbr[1] = mir.op_block(2); hcbr[2] = mir.op_block(3);
+    var b1i:  [2]mir.MirInstr;
+    b1i[0] = t_instr(?alloc, mir.MIR_CMP_LT_S, ?cmp[0], 3);
+    b1i[1] = t_instr(?alloc, mir.MIR_CBR,      ?hcbr[0], 3);
+
+    # the latch reads v2, the header's compare result.
+    var use:  [3]mir.MirOperand; use[0] = mir.op_vreg(0); use[1] = mir.op_vreg(0); use[2] = mir.op_vreg(2);
+    var lbr:  [1]mir.MirOperand; lbr[0] = mir.op_block(1);
+    var b2i:  [2]mir.MirInstr;
+    b2i[0] = t_instr(?alloc, mir.MIR_ADD, ?use[0], 3);
+    b2i[1] = t_instr(?alloc, mir.MIR_BR,  ?lbr[0], 1);
+
+    var b3i:  [1]mir.MirInstr;
+    b3i[0] = t_instr(?alloc, mir.MIR_RET, nil, 0);
+
+    var blocks: [4]mir.MirBlock;
+    blocks[0] = t_block(?alloc, 0, ?b0i[0], 2);
+    blocks[1] = t_block(?alloc, 1, ?b1i[0], 2);
+    blocks[2] = t_block(?alloc, 2, ?b2i[0], 2);
+    blocks[3] = t_block(?alloc, 3, ?b3i[0], 1);
+
+    var f: mir.MirFunction = t_fn(?alloc, ?blocks[0], 4, 3);
+    val r: R.Result[bool, str] = rotate_function(?alloc, ?f);
+    if (R.is_err[bool, str](r)) { ret 1; }
+
+    # untouched: the preheader still ends in its unconditional branch.
+    if (f.blocks[0].instr_count != 2)      { ret 1; }
+    if (!ends_in_br_to(?f.blocks[0], 1))   { ret 1; }
+    if (f.blocks[1].pred_count != 2)       { ret 1; }
+    ret 0;
+}
+
+# a header with two entries from outside the loop has no single preheader to hold
+# the guard, and is left alone.
+test "mach.lang.be.codegen.looprotate.try_rotate_header:declines_two_entries" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+
+    # B0 and B1 both branch into the header B2; B3 body / latch; B4 exit.
+    var e0br: [1]mir.MirOperand; e0br[0] = mir.op_block(2);
+    var b0i:  [1]mir.MirInstr;
+    b0i[0] = t_instr(?alloc, mir.MIR_BR, ?e0br[0], 1);
+
+    var e1br: [1]mir.MirOperand; e1br[0] = mir.op_block(2);
+    var b1i:  [1]mir.MirInstr;
+    b1i[0] = t_instr(?alloc, mir.MIR_BR, ?e1br[0], 1);
+
+    var cmp:  [3]mir.MirOperand; cmp[0]  = mir.op_vreg(2); cmp[1] = mir.op_vreg(0); cmp[2] = mir.op_vreg(1);
+    var hcbr: [3]mir.MirOperand; hcbr[0] = mir.op_vreg(2); hcbr[1] = mir.op_block(3); hcbr[2] = mir.op_block(4);
+    var b2i:  [2]mir.MirInstr;
+    b2i[0] = t_instr(?alloc, mir.MIR_CMP_LT_S, ?cmp[0], 3);
+    b2i[1] = t_instr(?alloc, mir.MIR_CBR,      ?hcbr[0], 3);
+
+    var inc:  [3]mir.MirOperand; inc[0] = mir.op_vreg(0); inc[1] = mir.op_vreg(0); inc[2] = mir.op_imm(1);
+    var lbr:  [1]mir.MirOperand; lbr[0] = mir.op_block(2);
+    var b3i:  [2]mir.MirInstr;
+    b3i[0] = t_instr(?alloc, mir.MIR_ADD, ?inc[0], 3);
+    b3i[1] = t_instr(?alloc, mir.MIR_BR,  ?lbr[0], 1);
+
+    var b4i:  [1]mir.MirInstr;
+    b4i[0] = t_instr(?alloc, mir.MIR_RET, nil, 0);
+
+    var blocks: [5]mir.MirBlock;
+    blocks[0] = t_block(?alloc, 0, ?b0i[0], 1);
+    blocks[1] = t_block(?alloc, 1, ?b1i[0], 1);
+    blocks[2] = t_block(?alloc, 2, ?b2i[0], 2);
+    blocks[3] = t_block(?alloc, 3, ?b3i[0], 2);
+    blocks[4] = t_block(?alloc, 4, ?b4i[0], 1);
+
+    var f: mir.MirFunction = t_fn(?alloc, ?blocks[0], 5, 3);
+    val r: R.Result[bool, str] = rotate_function(?alloc, ?f);
+    if (R.is_err[bool, str](r)) { ret 1; }
+
+    if (f.blocks[0].instr_count != 1)    { ret 1; }
+    if (f.blocks[1].instr_count != 1)    { ret 1; }
+    if (f.blocks[2].pred_count != 3)     { ret 1; }
+    ret 0;
 }


### PR DESCRIPTION
Closes #2211.

## Root cause: shape recognition, not a missing or undone pass

Rotation runs and fires — `looprotate.run` sits where #1937 put it and rotates
`for (i < n) { s = s + i; i = i + 1; }` correctly on 4.2.2. What it will not
match is anything else. The v1 matcher required the header's *then* target to
**be** the latch (a body of exactly one block) and a test built only from
opcodes `<= MIR_BITCAST` plus `MIR_MOV`. Two independent exclusions, each of
which covers most real code:

- **any `if` in the body** — the then-target is a branch block, not a `br H`
  latch, so `ends_in_br_to(b, h.id)` / `b.pred_count != 1` decline;
- **a bound not already in a register** — `for (i < N_BYTES)` over a
  module-scope `val` puts a `MIR_LOAD` in the header, which `clonable_opcode`
  refused.

Nested loops (the outer body is multi-block), non-inlined calls, `cnt` (a
second back edge) and `brk` (a second exit predecessor) decline for the same
reasons. Probing the two axes separately isolates them: a register-bound
single-block loop rotates on 4.2.2; the same loop with a module-scope bound does
not; the same loop with an `if` in the body does not.

## Fix

Match the loop rather than one hard-coded block shape:

- walk forward from the header's body target, stopping at the header and the
  exit block, to find the loop;
- partition the header's predecessors against it — exactly one outside is the
  preheader (it must end `br H`), at least one inside is a back edge. `cnt`'s
  second back edge and `brk`'s early exit both satisfy this;
- admit `MIR_LOAD` / `MIR_GEP` into the duplicable test. The guard sits exactly
  where the header's first evaluation ran (the preheader entered the header
  unconditionally), so a cloned load reads the same address at the same point:
  it cannot fault where the original did not, nor observe a body write;
- new safety condition the narrow matcher got for free: **no value the header
  defines may be read outside it**, since the rotated entry path branches around
  the header and would leave such a read undefined.

The header ends in a conditional branch, so `mir.lower_ir` split every critical
edge out of it: it carries no phi-destruction copies, and the new `P -> B` /
`P -> E` edges need none either. That is what makes widening past the
single-block body safe.

## Emitted shape

The issue's kernel, `--emit-asm`, x86_64 release. Before — header-tested, the
body ends in an unconditional `jmp` back, two taken branches per iteration:

```asm
.0: mov rcx, 0
    mov rdx, 0
.1: mov rax, qword [rip + N_BYTES]     # header: re-entered every iteration
    cmp rdx, rax
    jl .2                              #   taken forward into the body
.3: ...epilogue...
.2: ...body...
    jmp .1                             #   taken backward: the second branch
```

After — the test is duplicated into the preheader as a guard, and the body falls
through into the bottom test:

```asm
.0: mov rax, 0
    mov rcx, 0
    mov rdx, qword [rip + N_BYTES]     # entry guard (once)
    cmp rcx, rdx
    jl .2
    jmp .3
.2: ...body...
.6: add rcx, 1
    mov rax, rdx                       #   falls through into the test
.1: mov rdx, qword [rip + N_BYTES]
    cmp rcx, rdx
    jl .2                              #   the ONLY taken branch per iteration
.3: ...epilogue...
```

Same on the other two ISAs (disassembled `.o`, since `--emit-asm` refuses
there). aarch64 before ends `b 0xe4`, after ends `b.lt 0x108` with the exit
falling through; riscv64 before ends `j 0x108`, after ends `blt a1, a2, 0x120`.

## Measured

`briar-systems/mach-bench` (19 kernels), same corpus the epic measured, built
once with `dev` (4.2.2) and once with this branch, run round-robin best-of-5
rounds x 7 reps. Every checksum stays `=`.

| | before | after | after/before |
|---|---|---|---|
| geomean, array loops | | | **0.904x** |
| geomean, general codegen | | | **0.987x** |
| geomean, all 19 | | | **0.942x** |
| `f32_matmul` | 2901.70 us | 1866.48 us | 0.643x |
| `i64_prefix_sum` | 60.23 us | 42.14 us | 0.700x |
| `i32_filter_sum` | 267.79 us | 249.21 us | 0.931x |
| `u64_fnv1a` (control) | 309.45 us | 309.52 us | 1.000x |

The load-independent number, `perf stat` over the whole suite:

| counter | before | after | delta |
|---|---|---|---|
| branches | 2,413,963,387 | 1,662,759,749 | **-31.1%** |
| instructions | 20,247,752,583 | 19,486,556,154 | -3.8% |
| branch-misses | 112,400,551 | 111,840,417 | -0.5% |
| cycles | 10,383,572,813 | 10,181,644,259 | -1.9% |

31% of all retired branches are gone and the miss count is flat — exactly the
signature of removing a perfectly-predicted unconditional back edge from every
loop. (The machine was under background load, so treat the microsecond figures
as ratios, not absolutes; the counter deltas are load-independent.)

## Tests

Four unit tests in `be.codegen.looprotate` pin the rotated CFG, two per axis
plus two decline pins. Mutation-tested, one axis at a time:

| mutation | result |
|---|---|
| restore the v1 single-block-body requirement | `...:multi_block_body` fails — **793 passed, 1 failed, 794 total** |
| restore the v1 clonable-opcode set | `...:memory_bound_test` fails — **793 passed, 1 failed, 794 total** |
| both restored | **794 passed, 0 failed, 794 total** |

`int/regression/2211-loop-rotation-scope` pins the *semantics* of the shapes the
widening newly transforms (memory-loaded bound, branch in the body, `brk`,
`cnt`, nested multi-block). Its golden is computed independently of the compiler
and passes on the pre-fix compiler too, so it encodes semantics rather than the
transform.

## Verification

- `mach test .` — **794 / 0** (790 baseline + 4 new)
- `mach test .` in `dep/mach-std` at pin `eff1e8e` — **611 / 0**
- `int/run.sh` — all cases pass on `linux` and `linux-riscv64` locally; CI green
  on all four legs (`linux`, `linux-arm64`, `linux-riscv64`, `windows`)
- three-generation fixpoint — B == C == D, `89010e63...41ae`
- cross-builds clean for `linux-arm64`, `linux-riscv64`, `windows-x86_64`,
  `darwin-aarch64`
- aarch64 semantics spot-checked under `qemu-aarch64` (both rotation int cases
  match their goldens)

## ISAs

All three move together, as an arch-neutral MIR CFG rewrite should: x86_64,
aarch64 and riscv64 all go from two taken branches per iteration to one on the
same loops.
