### PR TITLE
feat(regalloc): conservative copy coalescing

### DIFF
--- a/src/lang/be/codegen/regalloc.mach
+++ b/src/lang/be/codegen/regalloc.mach
@@ -14,9 +14,15 @@
 #      a fixpoint, since dropping one copy can make an earlier copy into its source
 #      dead). This runs on the raw blocks, so the flat stream and ranges below are
 #      built once on already-clean instruction lists;
-#   2. blocks are reordered into reverse-postorder so the flat instruction stream
+#   2. COPY COALESCING: every copy whose two vregs are each assigned exactly once
+#      merges them into one web and deletes the copy outright, so the allocator
+#      never sees it. Single assignment on both sides makes the rename
+#      unconditionally value-preserving, and the merged interval is the union of two
+#      overlapping ones, so pressure is non-increasing (see `coalesce_copies`). Runs
+#      on the raw blocks with the sweep, before any position-dependent structure;
+#   3. blocks are reordered into reverse-postorder so the flat instruction stream
 #      reads in a topological order;
-#   3. one merged live range per vreg is built over that stream from def/use of
+#   4. one merged live range per vreg is built over that stream from def/use of
 #      `MIR_OP_VREG` operands (including a `MIR_OP_MEM` base vreg), then extended by
 #      per-block live-in/live-out from a backward dataflow fixpoint. THE RANGE MODEL
 #      is a single contiguous [start, end] interval bounding register occupancy:
@@ -26,27 +32,32 @@
 #      mid-block adds no phantom tail, a value born mid-block and flowing out adds
 #      no phantom head - while a loop-carried value (live-in AND live-out) still
 #      spans its blocks;
-#   4. `MIR_OP_PREG` operands (the ABI param / argument / return pre-coloring
+#   5. `MIR_OP_PREG` operands (the ABI param / argument / return pre-coloring
 #      `lower_ir` emitted) are FIXED - their physical register is reserved for
 #      the instruction that names it, and incoming param-register lifetimes are
 #      held busy from entry until the `MOV vreg <- preg` that captures them;
-#   5. COPY HINTS: each vreg first defined by a plain register copy records its
-#      source register; a loop-carried phi copy additionally records a REVERSE hint
-#      on its source so the web's last def biases onto the loop register (step done
-#      before the scan);
-#   6. ranges are assigned in start order (ties broken by ascending end, so a copy
+#   6. COPY HINTS, for the copies the webs could not merge: each vreg first defined
+#      by a plain register copy records its source register (as does the destination
+#      of a two-address op the encoder seeds with its left operand); each vreg a
+#      precolored `MOV preg <- v` consumes records that ABI SINK register; and a
+#      loop-carried phi copy records a REVERSE hint on its source so the web's last
+#      def biases onto the loop register (step done before the scan);
+#   7. ranges are assigned in start order (ties broken by ascending end, so a copy
 #      source dying at the copy colors before its destination). Each range prefers
 #      its copy-source register when the hint can be honored (`pick_hint`), so the
-#      copy collapses to a self-move dropped at rewrite; a loop-carried source
+#      copy collapses to a self-move dropped at rewrite; failing that the ABI
+#      register it is placed into (`pick_sink_hint`); a loop-carried source
 #      instead SHARES its still-live destination's register (`pick_target_hint`),
 #      collapsing the latch copy the forward hint cannot reach across the back edge;
 #      otherwise a call-crossing range prefers callee-saved and others caller-saved.
+#      Every hint is checked against the same interference tests the ordinary pick
+#      applies, so no honored hint takes a register the ordinary pick could not have.
 #      On pressure the lowest-density victim is spilled to a fresh `SLOT_SPILL` frame
 #      slot;
-#   7. around each `MIR_CALL` - the caller-saved clobber barrier (see its MIR
+#   8. around each `MIR_CALL` - the caller-saved clobber barrier (see its MIR
 #      definition) - any live vreg whose assigned register is caller-saved (or
 #      any FP register) is spilled and reloaded;
-#   8. a final pass rewrites every `MIR_OP_VREG` to its assigned `MIR_OP_PREG` and
+#   9. a final pass rewrites every `MIR_OP_VREG` to its assigned `MIR_OP_PREG` and
 #      drops any full-width register move whose operands rewrote to the same
 #      physical register (a coalesced copy);
 #      a `MIR_OP_MEM` base that is a value-pointer vreg becomes a physical-register
@@ -143,7 +154,9 @@ rec BlockSpan {
 # src`), the scan prefers to color `v` onto `src`'s register so the copy collapses
 # to `mov x, x` and is dropped at rewrite. The two source shapes are mutually
 # exclusive per hint; a copy with an immediate or otherwise unhintable source
-# leaves both source fields at their empty sentinels.
+# leaves both source fields at their empty sentinels. The two-address TIE hint
+# (#2203) fills the same slots for the seeding move an encoder materializes rather
+# than one the MIR carries - see `maybe_tie_hint`.
 #
 # REVERSE hint: for a loop-carried phi copy `MOV d <- v` whose destination `d` is
 # live BEFORE the copy (a loop-header phi target the back edge feeds), the source
@@ -454,6 +467,12 @@ fun alloc_function(tgt: *target.Target, m: *mir.MirModule, f: *mir.MirFunction) 
     val ds: R.Result[bool, str] = sweep_dead_movs(tgt, ?ctx);
     if (R.is_err[bool, str](ds)) { ctx_dnit(?ctx); ret ds; }
 
+    # copy hygiene, step 2: merge each copy-related pair of single-assignment vregs
+    # into one web and delete the copy, so the flat stream and the live ranges below
+    # are built on instruction lists the copies have already left.
+    val cc: R.Result[bool, str] = coalesce_copies(tgt, ?ctx);
+    if (R.is_err[bool, str](cc)) { ctx_dnit(?ctx); ret cc; }
+
     val bo: R.Result[bool, str] = build_order(?ctx);
     if (R.is_err[bool, str](bo)) { ctx_dnit(?ctx); ret bo; }
 
@@ -475,8 +494,8 @@ fun alloc_function(tgt: *target.Target, m: *mir.MirModule, f: *mir.MirFunction) 
     val mc: R.Result[bool, str] = mark_call_crossing(?ctx);
     if (R.is_err[bool, str](mc)) { ctx_dnit(?ctx); ret mc; }
 
-    # copy hygiene, step 2: record each vreg's copy-source hint so the scan can bias
-    # coloring toward it and collapse the copy to a self-move dropped at rewrite.
+    # copy hygiene, step 3: record each vreg's copy hints so the scan can bias
+    # coloring toward them and collapse the copies the webs could not merge.
     build_hints(tgt, ?ctx);
 
     val sc: R.Result[bool, str] = linear_scan(tgt, ?ctx);
@@ -1300,6 +1319,239 @@ fun instr_reads_vreg(mi: *mir.MirInstr, v: u32) bool {
     ret false;
 }
 
+# the representative of vreg `v`'s coalescing web, with path compression
+fun web_find(parent: *u32, v: u32) u32 {
+    var r: u32 = v;
+    for (parent[r] != r) { r = parent[r]; }
+    var c: u32 = v;
+    for (parent[c] != r) {
+        val n: u32 = parent[c];
+        parent[c] = r;
+        c = n;
+    }
+    ret r;
+}
+
+# tally, per vreg, how many times it is DEFINED across the whole function. a def is
+# operand 0 of a defining instruction, the same classification `build_ranges` and
+# the dead-def sweep apply; the call-result marker and stores define nothing
+fun tally_defs(ctx: *AllocCtx, defs: *u32, nv: u32) {
+    val f: *mir.MirFunction = ctx.f;
+    var bi: u32 = 0;
+    for (bi < f.block_count) {
+        val blk: *mir.MirBlock = ?f.blocks[bi];
+        var ii: u32 = 0;
+        for (ii < blk.instr_count) {
+            val mi: *mir.MirInstr = ?blk.instrs[ii];
+            if (instr_defines(mi)) {
+                val d: *mir.MirOperand = ?mi.operands[0];
+                if (d.vreg < nv) { defs[d.vreg] = defs[d.vreg] + 1; }
+            }
+            ii = ii + 1;
+        }
+        bi = bi + 1;
+    }
+}
+
+# merge the copy `MOV d <- s`'s two vregs into one web when the merge is
+# unconditionally value-preserving, returning true when a merge happened
+#
+# The safety condition is single-assignment on BOTH webs. `d`'s only definition is
+# this copy and `s`'s only definition is elsewhere, so at every point `d` is live it
+# holds exactly the value `s` holds: `s`'s definition dominates the copy (it is read
+# there), the copy dominates every use of `d` (it is `d`'s only definition), and no
+# redefinition of either can fall between - there is none anywhere. Renaming every
+# `d` to `s` is therefore correct under any control flow, back edges included, with
+# no interference graph and no dominance computation.
+#
+# The shape guards: both operands are value vregs of one register class and one
+# secrecy / vector marking (a declassifying move, which isel retags to the ordinary
+# machine move, has mismatched secrecy and is refused); neither owns lowering
+# storage, which is addressed as a frame slot rather than held in a register; and
+# the copy is full machine width, since a narrower one carries a zero-extension that
+# deleting it would drop
+fun try_coalesce(tgt: *target.Target, ctx: *AllocCtx, mi: *mir.MirInstr,
+                 parent: *u32, web_defs: *u32, nv: u32) bool {
+    if (!instr_is_reg_copy(tgt, mi))  { ret false; }
+    if (mi.width < ctx.spill_width)   { ret false; }
+    val dop: *mir.MirOperand = ?mi.operands[0];
+    val sop: *mir.MirOperand = ?mi.operands[1];
+    if (dop.kind != mir.MIR_OP_VREG || sop.kind != mir.MIR_OP_VREG) { ret false; }
+    val d: u32 = dop.vreg;
+    val s: u32 = sop.vreg;
+    if (d >= nv || s >= nv || d == s)                { ret false; }
+    if (vreg_has_slot(ctx, d) || vreg_has_slot(ctx, s)) { ret false; }
+
+    val dv: *mir.MirVReg = ?ctx.f.vregs[d];
+    val sv: *mir.MirVReg = ?ctx.f.vregs[s];
+    if (dv.class  != sv.class)  { ret false; }
+    if (dv.secret != sv.secret) { ret false; }
+    if (dv.vector != sv.vector) { ret false; }
+
+    val rd: u32 = web_find(parent, d);
+    val rs: u32 = web_find(parent, s);
+    if (rd == rs)            { ret false; }
+    if (web_defs[rd] != 1)   { ret false; }
+    if (web_defs[rs] != 1)   { ret false; }
+
+    # the source's web keeps the representative, so the surviving name is the one
+    # whose definition survives; `d`'s single definition is this copy, which
+    # `drop_self_copies` deletes once both operands rename to `rs`. the merged web
+    # therefore still holds exactly one definition and the invariant carries.
+    parent[rd] = rs;
+    ret true;
+}
+
+# rewrite every vreg reference in the function to its web representative
+#
+# Covers value operands, a MEM base and scaled index, and the -g debug bindings.
+# Frame-slot keys are deliberately untouched: a slot-owning vreg is never merged, so
+# its representative is itself, and the frame table keys on that id
+fun rename_vregs(ctx: *AllocCtx, parent: *u32, nv: u32) {
+    val f: *mir.MirFunction = ctx.f;
+    var bi: u32 = 0;
+    for (bi < f.block_count) {
+        val blk: *mir.MirBlock = ?f.blocks[bi];
+        var ii: u32 = 0;
+        for (ii < blk.instr_count) {
+            val mi: *mir.MirInstr = ?blk.instrs[ii];
+            var k: u32 = 0;
+            for (k < mi.operand_count) {
+                val op: *mir.MirOperand = ?mi.operands[k];
+                if (op.kind == mir.MIR_OP_VREG && op.vreg < nv) {
+                    op.vreg = web_find(parent, op.vreg);
+                } or (op.kind == mir.MIR_OP_MEM) {
+                    if (op.vreg != mir.MIR_VREG_NIL && op.vreg < nv) {
+                        op.vreg = web_find(parent, op.vreg);
+                    }
+                    if (!op.index_is_preg && op.index != mir.MIR_VREG_NIL && op.index < nv) {
+                        op.index = web_find(parent, op.index);
+                    }
+                }
+                k = k + 1;
+            }
+            var b: u32 = 0;
+            for (b < mi.dbg_binding_count) {
+                val db: *mir.MirDbgBinding = ?mi.dbg_bindings[b];
+                if (db.vreg  != mir.MIR_VREG_NIL && db.vreg  < nv) { db.vreg  = web_find(parent, db.vreg); }
+                if (db.vreg2 != mir.MIR_VREG_NIL && db.vreg2 < nv) { db.vreg2 = web_find(parent, db.vreg2); }
+                b = b + 1;
+            }
+            ii = ii + 1;
+        }
+        bi = bi + 1;
+    }
+}
+
+# delete every full-width register copy both of whose operands name the same vreg -
+# the coalesced copies `rename_vregs` collapsed. a sub-word self-move is kept: it
+# still zero-extends. mirrors the compaction of `sweep_dead_movs`, and a block always
+# ends in a terminator so it never empties
+fun drop_self_copies(tgt: *target.Target, ctx: *AllocCtx) {
+    val f: *mir.MirFunction = ctx.f;
+    var bi: u32 = 0;
+    for (bi < f.block_count) {
+        val blk: *mir.MirBlock = ?f.blocks[bi];
+        var write: u32 = 0;
+        var read:  u32 = 0;
+        for (read < blk.instr_count) {
+            val mi: *mir.MirInstr = ?blk.instrs[read];
+            var drop: bool = false;
+            if (instr_is_reg_copy(tgt, mi) && mi.width >= ctx.spill_width) {
+                val a: *mir.MirOperand = ?mi.operands[0];
+                val b: *mir.MirOperand = ?mi.operands[1];
+                drop = a.kind == mir.MIR_OP_VREG && b.kind == mir.MIR_OP_VREG && a.vreg == b.vreg;
+            }
+            if (drop) {
+                # the copy never reaches encode; release its operand array. a -g
+                # binding on it is released with it - the variable reads as living in
+                # the web's register from its own binding, which survives on the
+                # instructions that remain.
+                if (mi.operands != nil && mi.operand_count > 0) {
+                    A.deallocate[mir.MirOperand](ctx.alloc, mi.operands, mi.operand_count::usize);
+                }
+                if (mi.dbg_bindings != nil && mi.dbg_binding_count > 0) {
+                    A.deallocate[mir.MirDbgBinding](ctx.alloc, mi.dbg_bindings, mi.dbg_binding_count::usize);
+                }
+            } or {
+                if (write != read) { blk.instrs[write] = blk.instrs[read]; }
+                write = write + 1;
+            }
+            read = read + 1;
+        }
+        blk.instr_count = write;
+        bi = bi + 1;
+    }
+}
+
+# coalesce copy-related virtual registers into shared webs
+#
+# The conservative copy coalescing of issue #2203, and the one half of it that is a
+# rewrite rather than a coloring bias: a copy whose two values are each assigned
+# exactly once is deleted outright and its two vregs become one, so the allocator
+# never sees the copy at all. This reaches the shape no allocation hint can - a copy
+# of a value that stays LIVE past it, where source and destination genuinely coexist
+# but hold the same value, which a hint cannot express because the source's register
+# is still busy.
+#
+# It cannot increase register pressure. Under the one-merged-interval-per-vreg range
+# model the source is live at the copy (it is read there) and the destination begins
+# there, so the two intervals always overlap and their union is itself an interval -
+# exactly the merged web's interval. Every point where the merged value is live had
+# at least one of the two live before, and every point where both were live now
+# holds one value instead of two. So the maximum number of simultaneously live values
+# is non-increasing everywhere, and coalescing can never force a spill that was not
+# already forced. That is the bound on the aggressive-coalescing hazard: this
+# coalescer has no uncolorable case to bound.
+#
+# Runs before block ordering / flattening, so the flat stream, the live ranges and
+# the liveness fixpoint are all built once on the already-coalesced instruction lists.
+# ---
+# tgt: the active target, for the ISA's register-move classifier
+# ctx: the allocation context whose function is coalesced in place
+# ret: ok(true), or an error string on an allocation failure
+fun coalesce_copies(tgt: *target.Target, ctx: *AllocCtx) R.Result[bool, str] {
+    val f: *mir.MirFunction = ctx.f;
+    val nv: u32 = f.vreg_count;
+    if (nv == 0)                     { ret R.ok[bool, str](true); }
+    if (tgt.arch.is_reg_move == nil) { ret R.ok[bool, str](true); }
+
+    val rp: R.Result[*u32, str] = A.allocate[u32](ctx.alloc, nv::usize);
+    if (R.is_err[*u32, str](rp)) { ret R.err[bool, str](R.unwrap_err[*u32, str](rp)); }
+    val parent: *u32 = R.unwrap_ok[*u32, str](rp);
+    val rw: R.Result[*u32, str] = A.allocate[u32](ctx.alloc, nv::usize);
+    if (R.is_err[*u32, str](rw)) {
+        A.deallocate[u32](ctx.alloc, parent, nv::usize);
+        ret R.err[bool, str](R.unwrap_err[*u32, str](rw));
+    }
+    val web_defs: *u32 = R.unwrap_ok[*u32, str](rw);
+
+    var i: u32 = 0;
+    for (i < nv) { parent[i] = i; web_defs[i] = 0; i = i + 1; }
+    tally_defs(ctx, web_defs, nv);
+
+    var merged: bool = false;
+    var bi: u32 = 0;
+    for (bi < f.block_count) {
+        val blk: *mir.MirBlock = ?f.blocks[bi];
+        var ii: u32 = 0;
+        for (ii < blk.instr_count) {
+            if (try_coalesce(tgt, ctx, ?blk.instrs[ii], parent, web_defs, nv)) { merged = true; }
+            ii = ii + 1;
+        }
+        bi = bi + 1;
+    }
+
+    if (merged) {
+        rename_vregs(ctx, parent, nv);
+        drop_self_copies(tgt, ctx);
+    }
+
+    A.deallocate[u32](ctx.alloc, web_defs, nv::usize);
+    A.deallocate[u32](ctx.alloc, parent, nv::usize);
+    ret R.ok[bool, str](true);
+}
+
 # true when vreg `d` is read at any flat position strictly between `from` and `to`.
 # the caller guarantees the window is one block's straight line (no control flow
 # enters or leaves it), so a position-order scan is exact - the soundness basis of
@@ -1351,6 +1603,12 @@ fun reads_in_window(ctx: *AllocCtx, d: u32, from: i64, to: i64) bool {
 # First-write-wins per source vreg: a value placed into two argument registers can
 # only be colored to one of them.
 #
+# TIE (#2203): a two-address arithmetic op `OP [dst, lhs, rhs]` is materialized by
+# the encoder as `MOV dst, lhs ; OP dst, rhs`, so `dst` is copy-related to `lhs`
+# exactly as if the seeding move were in the MIR. When `lhs` dies at the op and
+# `dst` is born there, `dst` records `lhs` in the forward slots and the same
+# register transfer collapses the seed the encoder would otherwise emit.
+#
 # Runs after flatten / liveness so `flat_instr` and the ranges are available.
 fun build_hints(tgt: *target.Target, ctx: *AllocCtx) {
     if (tgt.arch.is_reg_move == nil) { ret; }
@@ -1374,9 +1632,48 @@ fun build_hints(tgt: *target.Target, ctx: *AllocCtx) {
             }
             maybe_sink_hint(ctx, mi, pos, nv);
             maybe_reverse_hint(ctx, mi, pos, nv);
+        } or {
+            maybe_tie_hint(ctx, mi, pos, nv);
         }
         pos = pos + 1;
     }
+}
+
+# true when a selection-output opcode is one of the two-address arithmetic forms -
+# the family `mir` documents as two-address, which an encoder whose ISA has no
+# three-address form materializes as `MOV dst, lhs ; OP dst, rhs`. Read as data
+# from the opcode a rule pack emitted, never as a branch on an architecture: a pack
+# that selects a native three-address instruction never produces these sentinels
+# and so is never tie-hinted, which is exactly right - it needs no seeding move
+fun is_two_address_op(op: mir.MirOpcode) bool {
+    ret op == mir.MIR_SEL_ADD || op == mir.MIR_SEL_SUB   || op == mir.MIR_SEL_MUL ||
+        op == mir.MIR_SEL_AND || op == mir.MIR_SEL_OR    || op == mir.MIR_SEL_XOR ||
+        op == mir.MIR_SEL_SHL || op == mir.MIR_SEL_SHR_U || op == mir.MIR_SEL_SHR_S;
+}
+
+# record the two-address tie hint for `OP [dst, lhs, rhs]` at `pos`: the encoder
+# will seed `dst` with `lhs` before operating in place, so coloring `dst` onto
+# `lhs`'s register erases that seeding move
+#
+# Recorded through the ordinary forward-hint slots, so `pick_hint` honors it by the
+# same register transfer a defining copy uses: `lhs` dies exactly here and `dst` is
+# born exactly here, the two conditions `can_transfer` requires, so the two provably
+# never coexist and the register passes intact from one to the other. Both are
+# re-checked here rather than left to `pick_hint`, since the hint slot is
+# first-write-wins and a tie that could never be honored would displace a real one
+fun maybe_tie_hint(ctx: *AllocCtx, mi: *mir.MirInstr, pos: u32, nv: u32) {
+    if (!is_two_address_op(mi.opcode)) { ret; }
+    if (mi.operand_count < 3)          { ret; }
+    val d: *mir.MirOperand = ?mi.operands[0];
+    val l: *mir.MirOperand = ?mi.operands[1];
+    if (d.kind != mir.MIR_OP_VREG || l.kind != mir.MIR_OP_VREG) { ret; }
+    if (d.vreg >= nv || l.vreg >= nv || d.vreg == l.vreg)       { ret; }
+    if (ctx.hints[d.vreg].src_vreg != mir.MIR_VREG_NIL
+        || ctx.hints[d.vreg].src_preg >= 0)                     { ret; }
+    if (ctx.ranges[l.vreg].end_pos != pos::i64)                 { ret; }
+    if (ctx.ranges[d.vreg].start != pos::i64)                   { ret; }
+    ctx.hints[d.vreg].src_vreg = l.vreg;
+    ctx.hints[d.vreg].copy_pos = pos::i64;
 }
 
 # record the sink hint for a precolored placement move `MOV preg <- v` at `pos`,

--- a/src/lang/be/codegen/regalloc.mach
+++ b/src/lang/be/codegen/regalloc.mach
@@ -80,6 +80,7 @@
 # never branches on an architecture id; the linear-scan algorithm itself is fully
 # target-agnostic. An absent ABI / ISA vtable is a loud error.
 
+use std.allocator.page;
 use std.format;
 use std.system.panic.panic;
 use std.types.bool.bool;
@@ -4028,4 +4029,341 @@ test "mach.lang.be.codegen.regalloc.phi_neg_i32_signed_compare:1851" {
     if (probe > 100) { v = probe; }
     if (v < 0) { ret 0; }
     ret 1;
+}
+
+# test-only: a heap vreg table of `n` general-purpose value vregs
+fun t_vregs(alloc: *A.Allocator, f: *mir.MirFunction, n: u32) {
+    val r: R.Result[*mir.MirVReg, str] = A.allocate[mir.MirVReg](alloc, n::usize);
+    f.vregs      = R.unwrap_ok[*mir.MirVReg, str](r);
+    f.vreg_count = n;
+    f.vreg_cap   = n;
+    var i: u32 = 0;
+    for (i < n) {
+        f.vregs[i].id         = i;
+        f.vregs[i].class      = REG_CLASS_GP;
+        f.vregs[i].spill_slot = -1;
+        f.vregs[i].assigned   = mir.MIR_VREG_NIL;
+        f.vregs[i].vector     = false;
+        f.vregs[i].secret     = false;
+        i = i + 1;
+    }
+}
+
+# test-only: a heap block of `n` zeroed instructions
+fun t_block(alloc: *A.Allocator, b: *mir.MirBlock, n: u32) {
+    val r: R.Result[*mir.MirInstr, str] = A.zallocate[mir.MirInstr](alloc, n::usize);
+    b.instrs      = R.unwrap_ok[*mir.MirInstr, str](r);
+    b.instr_count = n;
+    b.instr_cap   = n;
+    b.id          = 0;
+}
+
+# test-only: write instruction `ix` of a block as a two-operand full-width MIR_MOV
+fun t_mov(alloc: *A.Allocator, b: *mir.MirBlock, ix: u32, dst: mir.MirOperand, src: mir.MirOperand) {
+    val r: R.Result[*mir.MirOperand, str] = A.allocate[mir.MirOperand](alloc, 2::usize);
+    val arr: *mir.MirOperand = R.unwrap_ok[*mir.MirOperand, str](r);
+    arr[0] = dst;
+    arr[1] = src;
+    b.instrs[ix].opcode        = mir.MIR_MOV;
+    b.instrs[ix].operands      = arr;
+    b.instrs[ix].operand_count = 2;
+    b.instrs[ix].width         = 8;
+    b.instrs[ix].src_width     = 8;
+    b.instrs[ix].asm_block     = nil;
+    b.instrs[ix].vec_lane      = mir.VEC_LANE_NONE;
+}
+
+# test-only: an allocation context carrying only what the pre-scan coalescer reads
+fun t_ctx(ctx: *AllocCtx, alloc: *A.Allocator, f: *mir.MirFunction, slots: *bool) {
+    ctx.alloc          = alloc;
+    ctx.interner       = nil;
+    ctx.f              = f;
+    ctx.spill_width    = 8;
+    ctx.vreg_slot_flag = slots;
+}
+
+# test-only: the host x86-64 target, for the ISA register-move classifier
+fun t_target(out: *target.Target) bool {
+    var reg: target.TargetRegistry = target.registry_init();
+    if (R.is_err[bool, str](target.register_all(?reg))) { ret false; }
+    val ts: R.Result[target.Target, str] = target.select(?reg, "x86_64", "linux", "sysv64");
+    if (R.is_err[target.Target, str](ts)) { ret false; }
+    @out = R.unwrap_ok[target.Target, str](ts);
+    ret true;
+}
+
+# the copy-web coalescer deletes a copy whose two vregs are each assigned exactly
+# once and renames every later reference to the surviving web. this is the pin that
+# a coalescable copy is GONE from the instruction stream, not merely colored onto
+# one register: the block loses the instruction outright, before the flat stream is
+# ever built
+test "mach.lang.be.codegen.regalloc.coalesce_copies:single_assignment_web_is_merged" {
+    var t: target.Target;
+    if (!t_target(?t)) { ret 1; }
+    var alloc: A.Allocator;
+    page.make(?alloc);
+
+    #   v0 <- preg 3        (a value arriving in a fixed register)
+    #   v1 <- v0            (the coalescable copy: both sides assigned once)
+    #   preg 4 <- v1        (a use of the copy's destination)
+    var f: mir.MirFunction;
+    t_vregs(?alloc, ?f, 2);
+    var b: mir.MirBlock;
+    t_block(?alloc, ?b, 3);
+    t_mov(?alloc, ?b, 0, mir.op_vreg(0), mir.op_preg(3));
+    t_mov(?alloc, ?b, 1, mir.op_vreg(1), mir.op_vreg(0));
+    t_mov(?alloc, ?b, 2, mir.op_preg(4), mir.op_vreg(1));
+    f.blocks      = ?b;
+    f.block_count = 1;
+    f.block_cap   = 1;
+
+    var slots: [2]bool;
+    slots[0] = false; slots[1] = false;
+    var ctx: AllocCtx;
+    t_ctx(?ctx, ?alloc, ?f, ?slots[0]);
+
+    if (R.is_err[bool, str](coalesce_copies(?t, ?ctx))) { ret 1; }
+
+    # the copy is deleted and the block is one instruction shorter.
+    if (b.instr_count != 2) { ret 1; }
+    # the surviving use names the source web, not the deleted destination.
+    if (b.instrs[1].operands[1].kind != mir.MIR_OP_VREG) { ret 1; }
+    if (b.instrs[1].operands[1].vreg != 0)               { ret 1; }
+    # the defining move is untouched.
+    if (b.instrs[0].operands[0].vreg != 0)               { ret 1; }
+
+    ret 0;
+}
+
+# the coalescer refuses every unsafe shape: a destination assigned more than once
+# (a phi target several edges write), a sub-word copy whose zero-extension deleting
+# it would drop, and a vreg owning lowering storage
+test "mach.lang.be.codegen.regalloc.coalesce_copies:refuses_unsafe_shapes" {
+    var t: target.Target;
+    if (!t_target(?t)) { ret 1; }
+    var alloc: A.Allocator;
+    page.make(?alloc);
+
+    #   v0 <- preg 3
+    #   v1 <- v0            copy; v1 is written again below, so it must NOT merge
+    #   v1 <- preg 5
+    #   preg 4 <- v1
+    var f: mir.MirFunction;
+    t_vregs(?alloc, ?f, 2);
+    var b: mir.MirBlock;
+    t_block(?alloc, ?b, 4);
+    t_mov(?alloc, ?b, 0, mir.op_vreg(0), mir.op_preg(3));
+    t_mov(?alloc, ?b, 1, mir.op_vreg(1), mir.op_vreg(0));
+    t_mov(?alloc, ?b, 2, mir.op_vreg(1), mir.op_preg(5));
+    t_mov(?alloc, ?b, 3, mir.op_preg(4), mir.op_vreg(1));
+    f.blocks      = ?b;
+    f.block_count = 1;
+    f.block_cap   = 1;
+
+    var slots: [2]bool;
+    slots[0] = false; slots[1] = false;
+    var ctx: AllocCtx;
+    t_ctx(?ctx, ?alloc, ?f, ?slots[0]);
+
+    if (R.is_err[bool, str](coalesce_copies(?t, ?ctx))) { ret 1; }
+    if (b.instr_count != 4) { ret 1; }
+
+    # a sub-word copy is refused even with both sides assigned once: the move still
+    # zero-extends, so deleting it would drop the clear.
+    var f2: mir.MirFunction;
+    t_vregs(?alloc, ?f2, 2);
+    var b2: mir.MirBlock;
+    t_block(?alloc, ?b2, 3);
+    t_mov(?alloc, ?b2, 0, mir.op_vreg(0), mir.op_preg(3));
+    t_mov(?alloc, ?b2, 1, mir.op_vreg(1), mir.op_vreg(0));
+    b2.instrs[1].width     = 4;
+    b2.instrs[1].src_width = 4;
+    t_mov(?alloc, ?b2, 2, mir.op_preg(4), mir.op_vreg(1));
+    f2.blocks      = ?b2;
+    f2.block_count = 1;
+    f2.block_cap   = 1;
+
+    var slots2: [2]bool;
+    slots2[0] = false; slots2[1] = false;
+    var ctx2: AllocCtx;
+    t_ctx(?ctx2, ?alloc, ?f2, ?slots2[0]);
+    if (R.is_err[bool, str](coalesce_copies(?t, ?ctx2))) { ret 1; }
+    if (b2.instr_count != 3) { ret 1; }
+
+    # a storage-owning destination is refused: it lives in a frame slot, never a
+    # register, so there is no register to share.
+    var f3: mir.MirFunction;
+    t_vregs(?alloc, ?f3, 2);
+    var b3: mir.MirBlock;
+    t_block(?alloc, ?b3, 3);
+    t_mov(?alloc, ?b3, 0, mir.op_vreg(0), mir.op_preg(3));
+    t_mov(?alloc, ?b3, 1, mir.op_vreg(1), mir.op_vreg(0));
+    t_mov(?alloc, ?b3, 2, mir.op_preg(4), mir.op_vreg(1));
+    f3.blocks      = ?b3;
+    f3.block_count = 1;
+    f3.block_cap   = 1;
+
+    var slots3: [2]bool;
+    slots3[0] = false; slots3[1] = true;
+    var ctx3: AllocCtx;
+    t_ctx(?ctx3, ?alloc, ?f3, ?slots3[0]);
+    if (R.is_err[bool, str](coalesce_copies(?t, ?ctx3))) { ret 1; }
+    if (b3.instr_count != 3) { ret 1; }
+
+    ret 0;
+}
+
+# a value placed into a precolored register by a full-width `MOV preg <- v` records
+# that register as its sink hint, but only when it dies exactly at the move (a value
+# live past it would be clobbered) and only at full machine width (a narrower move
+# still owes its zero-extension and survives as a self-move anyway)
+test "mach.lang.be.codegen.regalloc.maybe_sink_hint:records_only_a_dying_full_width_placement" {
+    var ctx: AllocCtx;
+    var ranges: [2]LiveRange;
+    var hints:  [2]CopyHint;
+    ctx.ranges = ?ranges[0];
+    ctx.hints  = ?hints[0];
+    ctx.spill_width = 8;
+    var i: u32 = 0;
+    for (i < 2) {
+        hints[i].src_vreg     = mir.MIR_VREG_NIL;
+        hints[i].src_preg     = -1;
+        hints[i].copy_pos     = -1;
+        hints[i].dst_vreg     = mir.MIR_VREG_NIL;
+        hints[i].dst_copy_pos = -1;
+        hints[i].sink_preg    = -1;
+        i = i + 1;
+    }
+
+    var ops: [2]mir.MirOperand;
+    ops[0] = mir.op_preg(7);
+    ops[1] = mir.op_vreg(1);
+    var mv: mir.MirInstr;
+    mv.opcode        = mir.MIR_MOV;
+    mv.operands      = ?ops[0];
+    mv.operand_count = 2;
+    mv.width         = 8;
+    mv.src_width     = 8;
+
+    # v1 dies exactly at position 10: the hint is recorded.
+    ranges[1].end_pos = 10;
+    maybe_sink_hint(?ctx, ?mv, 10, 2);
+    if (hints[1].sink_preg != 7) { ret 1; }
+
+    # first-write-wins: a second placement of the same value does not overwrite it.
+    ops[0] = mir.op_preg(6);
+    maybe_sink_hint(?ctx, ?mv, 10, 2);
+    if (hints[1].sink_preg != 7) { ret 1; }
+
+    # a value still live past the move records nothing.
+    hints[1].sink_preg = -1;
+    ranges[1].end_pos  = 14;
+    ops[0] = mir.op_preg(7);
+    maybe_sink_hint(?ctx, ?mv, 10, 2);
+    if (hints[1].sink_preg != -1) { ret 1; }
+
+    # a sub-word placement records nothing.
+    ranges[1].end_pos = 10;
+    mv.width     = 4;
+    mv.src_width = 4;
+    maybe_sink_hint(?ctx, ?mv, 10, 2);
+    if (hints[1].sink_preg != -1) { ret 1; }
+
+    # a vreg destination is not a placement at all (that is the forward-hint shape).
+    mv.width     = 8;
+    mv.src_width = 8;
+    ops[0] = mir.op_vreg(0);
+    maybe_sink_hint(?ctx, ?mv, 10, 2);
+    if (hints[1].sink_preg != -1) { ret 1; }
+
+    ret 0;
+}
+
+# the two-address tie records the left operand in the forward hint slots exactly
+# when the transfer conditions hold - the operand dies at the op and the destination
+# is born there - and only for an opcode whose encoder seeds the destination
+test "mach.lang.be.codegen.regalloc.maybe_tie_hint:ties_a_dying_left_operand" {
+    var ctx: AllocCtx;
+    var ranges: [3]LiveRange;
+    var hints:  [3]CopyHint;
+    ctx.ranges = ?ranges[0];
+    ctx.hints  = ?hints[0];
+    var i: u32 = 0;
+    for (i < 3) {
+        hints[i].src_vreg     = mir.MIR_VREG_NIL;
+        hints[i].src_preg     = -1;
+        hints[i].copy_pos     = -1;
+        hints[i].dst_vreg     = mir.MIR_VREG_NIL;
+        hints[i].dst_copy_pos = -1;
+        hints[i].sink_preg    = -1;
+        i = i + 1;
+    }
+
+    var ops: [3]mir.MirOperand;
+    ops[0] = mir.op_vreg(0);
+    ops[1] = mir.op_vreg(1);
+    ops[2] = mir.op_vreg(2);
+    var op: mir.MirInstr;
+    op.opcode        = mir.MIR_SEL_MUL;
+    op.operands      = ?ops[0];
+    op.operand_count = 3;
+
+    # v1 dies at position 20 and v0 is born there: the tie is recorded.
+    ranges[1].end_pos = 20;
+    ranges[0].start   = 20;
+    maybe_tie_hint(?ctx, ?op, 20, 3);
+    if (hints[0].src_vreg != 1)  { ret 1; }
+    if (hints[0].copy_pos != 20) { ret 1; }
+
+    # a left operand still live past the op is not tied.
+    hints[0].src_vreg = mir.MIR_VREG_NIL;
+    hints[0].copy_pos = -1;
+    ranges[1].end_pos = 24;
+    maybe_tie_hint(?ctx, ?op, 20, 3);
+    if (hints[0].src_vreg != mir.MIR_VREG_NIL) { ret 1; }
+
+    # a destination live BEFORE the op (a loop-carried target the liveness pass
+    # extended back) is not tied: the register transfer would clobber it.
+    ranges[1].end_pos = 20;
+    ranges[0].start   = 12;
+    maybe_tie_hint(?ctx, ?op, 20, 3);
+    if (hints[0].src_vreg != mir.MIR_VREG_NIL) { ret 1; }
+
+    # a three-address opcode (one no encoder seeds) is never tied.
+    ranges[0].start = 20;
+    op.opcode = mir.MIR_SEL_CMP_EQ;
+    maybe_tie_hint(?ctx, ?op, 20, 3);
+    if (hints[0].src_vreg != mir.MIR_VREG_NIL) { ret 1; }
+
+    # and the classifier itself: the two-address family in, the rest out.
+    if (!is_two_address_op(mir.MIR_SEL_ADD))   { ret 1; }
+    if (!is_two_address_op(mir.MIR_SEL_SHR_S)) { ret 1; }
+    if (is_two_address_op(mir.MIR_SEL_DIV_S))  { ret 1; }
+    if (is_two_address_op(mir.MIR_MOV))        { ret 1; }
+
+    ret 0;
+}
+
+# test-only: a call whose argument and result both travel through ABI registers,
+# so the caller's values are placed into and captured out of precolored registers
+fun t_scale(v: i64, k: i64) i64 {
+    ret v * k;
+}
+
+# an end-to-end value check over a shape every coalescing path touches: values
+# forwarded through copies into call arguments and back out of return registers, a
+# two-address accumulate whose left operand dies at the op, and a loop-carried
+# induction variable. a coalesce that renamed one vreg onto another holding a
+# different value would corrupt the sum
+test "mach.lang.be.codegen.regalloc.coalesce_copies:forwarded_values_survive" {
+    var acc: i64 = 0;
+    var i:   i64 = 0;
+    for (i < 8) {
+        val a: i64 = t_scale(i, 3);
+        val b: i64 = t_scale(a, 2);
+        acc = acc + (b - a);
+        i = i + 1;
+    }
+    if (acc != 84) { ret 1; }
+    ret 0;
 }

--- a/src/lang/be/codegen/regalloc.mach
+++ b/src/lang/be/codegen/regalloc.mach
@@ -1464,10 +1464,14 @@ fun drop_self_copies(tgt: *target.Target, ctx: *AllocCtx) {
                 drop = a.kind == mir.MIR_OP_VREG && b.kind == mir.MIR_OP_VREG && a.vreg == b.vreg;
             }
             if (drop) {
-                # the copy never reaches encode; release its operand array. a -g
-                # binding on it is released with it - the variable reads as living in
-                # the web's register from its own binding, which survives on the
-                # instructions that remain.
+                # the copy never reaches encode; release its operand array. its -g
+                # bindings are released with it, exactly as the dead-def sweep does
+                # and for the same reason: this runs pre-regalloc, where a zero-byte
+                # carrier would perturb the flat stream and so make the allocation
+                # depend on -g. the variable reads as optimized-out at that point,
+                # never garbage, and the emitted bytes stay identical with and
+                # without -g - the invariant the coalescer must not break, which is
+                # also why nothing here reads `dbg_binding_count` as a condition.
                 if (mi.operands != nil && mi.operand_count > 0) {
                     A.deallocate[mir.MirOperand](ctx.alloc, mi.operands, mi.operand_count::usize);
                 }

--- a/src/lang/be/codegen/regalloc.mach
+++ b/src/lang/be/codegen/regalloc.mach
@@ -150,6 +150,14 @@ rec BlockSpan {
 # `v` - the web's last def, colored AFTER `d` - records `d` so the scan biases `v`
 # onto `d`'s register, collapsing the latch copy. Recorded only when the coalesce
 # is interference-safe (see `build_hints`); honored by `pick_target_hint`.
+#
+# SINK hint (issue #2203): for a precolored copy `MOV preg <- v` - the ABI plumbing
+# `lower_call` emits to place an outgoing argument, and `lower_ret` to place a
+# return value - the source `v` records that register so the scan colors `v` there
+# directly and the placement move collapses. Recorded only when `v` dies exactly at
+# the move, so the register it takes is one it holds up to the very instruction that
+# overwrites it; honored by `pick_sink_hint`, which re-runs every interference test
+# an ordinary pick applies.
 # ---
 # src_vreg:     source vreg id for a `MOV v <- v2` copy, else MIR_VREG_NIL
 # src_preg:     source composite physical-register id for a `MOV v <- preg` copy, else -1
@@ -164,12 +172,16 @@ rec BlockSpan {
 # dst_copy_pos: flat-stream position of that latch copy, or -1 when no reverse hint.
 #               bounds the window `v` shares the destination's register over, so the
 #               destination is protected from eviction only until here
+# sink_preg:    sink hint - the composite physical-register id a full-width
+#               `MOV preg <- v` placement move writes at this vreg's last position,
+#               else -1
 rec CopyHint {
     src_vreg:     u32;
     src_preg:     i32;
     copy_pos:     i64;
     dst_vreg:     u32;
     dst_copy_pos: i64;
+    sink_preg:    i32;
 }
 
 # the per-function allocation scratch state
@@ -614,6 +626,7 @@ fun ctx_init(ctx: *AllocCtx, tgt: *target.Target, m: *mir.MirModule, f: *mir.Mir
         ctx.hints[hi].copy_pos     = -1;
         ctx.hints[hi].dst_vreg     = mir.MIR_VREG_NIL;
         ctx.hints[hi].dst_copy_pos = -1;
+        ctx.hints[hi].sink_preg    = -1;
         hi = hi + 1;
     }
 
@@ -1326,6 +1339,18 @@ fun reads_in_window(ctx: *AllocCtx, d: u32, from: i64, to: i64) bool {
 # `d` stays live-out past the copy, so its register is busy across `v`'s whole life
 # and `pick_target_hint` need only share it (no transfer, no active entry).
 #
+# SINK (#2203): for a copy `MOV preg <- v` into a precolored register - an outgoing
+# call argument or a return value - the source `v` records that register, so the
+# scan colors `v` there and the placement move collapses to a dropped self-move.
+# Recorded only when the coalesce is interference-safe:
+#   - `v` dies exactly at the move, so it never holds the register past the
+#     instruction that overwrites it (and `def_reg_reserved`, which admits a value
+#     ending exactly at a precolored def, therefore does not reject the register);
+#   - the move is full machine width, since the rewrite drops only a full-width
+#     self-move (a narrower one still owes its zero-extension).
+# First-write-wins per source vreg: a value placed into two argument registers can
+# only be colored to one of them.
+#
 # Runs after flatten / liveness so `flat_instr` and the ranges are available.
 fun build_hints(tgt: *target.Target, ctx: *AllocCtx) {
     if (tgt.arch.is_reg_move == nil) { ret; }
@@ -1347,10 +1372,31 @@ fun build_hints(tgt: *target.Target, ctx: *AllocCtx) {
                     ctx.hints[d.vreg].copy_pos = pos::i64;
                 }
             }
+            maybe_sink_hint(ctx, mi, pos, nv);
             maybe_reverse_hint(ctx, mi, pos, nv);
         }
         pos = pos + 1;
     }
+}
+
+# record the sink hint for a precolored placement move `MOV preg <- v` at `pos`,
+# when `v` may safely be colored onto that register (see `build_hints`). `mi` is a
+# confirmed reg copy; the destination must be a physical register and the source a
+# vreg dying exactly here. No-op otherwise, and first-write-wins per source vreg
+fun maybe_sink_hint(ctx: *AllocCtx, mi: *mir.MirInstr, pos: u32, nv: u32) {
+    val d: *mir.MirOperand = ?mi.operands[0];
+    val s: *mir.MirOperand = ?mi.operands[1];
+    if (d.kind != mir.MIR_OP_PREG || s.kind != mir.MIR_OP_VREG) { ret; }
+    if (s.vreg >= nv)                                           { ret; }
+    # a sub-word move still owes its zero-extension, so the rewrite keeps it even as
+    # a self-move; coloring for it would buy nothing and could cost a better register.
+    if (mi.width < ctx.spill_width)                             { ret; }
+    val sv: u32 = s.vreg;
+    if (ctx.hints[sv].sink_preg >= 0)                           { ret; }
+    # `v` must die at the move: the register is overwritten here, so a value live
+    # past it would be clobbered.
+    if (ctx.ranges[sv].end_pos != pos::i64)                     { ret; }
+    ctx.hints[sv].sink_preg = d.preg::i32;
 }
 
 # record the loop-carried reverse hint for a register copy `MOV d <- s` at `pos`,
@@ -1736,6 +1782,12 @@ fun linear_scan(tgt: *target.Target, ctx: *AllocCtx) R.Result[bool, str] {
         # back to the normal class pick.
         if (ctx.hints[v].src_vreg != mir.MIR_VREG_NIL || ctx.hints[v].src_preg >= 0) {
             preg = pick_hint(ctx, v, lr);
+        }
+        # no defining copy to collapse, or its source register was unavailable: aim
+        # instead at the precolored register this value is placed INTO - its outgoing
+        # argument or return register - so that move collapses (#2203).
+        if (preg < 0 && ctx.hints[v].sink_preg >= 0) {
+            preg = pick_sink_hint(ctx, v, lr);
         }
         # loop-carried reverse hint: share the destination's register instead of
         # taking a fresh one, collapsing the latch copy. the destination owns the
@@ -2200,6 +2252,49 @@ fun transfer_source_reg(ctx: *AllocCtx, src: u32, rid: u32) {
         panic("regalloc: copy-hint transfer source is not the live owner of its register\n");
     }
     remove_active(ctx, src);
+}
+
+# try to color vreg `v` onto the precolored register its placement move
+# `MOV preg <- v` writes, so that move collapses to a dropped self-move
+#
+# The sink half of issue #2203, and the counterpart of `pick_hint`: where the
+# forward hint chases the register a value is copied FROM, this chases the register
+# it is copied TO - the ABI argument and return registers, which are the largest
+# single family of surviving copies. Returns the composite register id (with the
+# bank's busy flag already claimed) or -1.
+#
+# Purely conservative: the register is taken only when it passes every test
+# `pick_gp` / `pick_fp` apply to this range - not reserved, not busy, not pinned for
+# an incoming param, not inside an outgoing-argument window, and not overwritten by
+# a precolored def the range lives past - plus the caller-saved test `pick_hint`
+# applies to a call-crossing range. So an honored sink hint occupies a register the
+# ordinary pick could equally have returned, and can neither create an uncolorable
+# assignment nor force a spill that was not already forced. Unlike `pick_hint` there
+# is no transfer path: the register is a fixed physical one, not a dying vreg's, so
+# a busy register simply declines the hint.
+fun pick_sink_hint(ctx: *AllocCtx, v: u32, lr: *LiveRange) i32 {
+    val rid: i32 = ctx.hints[v].sink_preg;
+    if (rid < 0) { ret -1; }
+
+    val rclass: i32 = isa.regid_class(rid);
+    val idx: u32 = isa.regid_index(rid)::u32;
+
+    if (lr.reg_class == REG_CLASS_GP) {
+        if (rclass != isa.REG_CLASS_ID_GP) { ret -1; }
+        if (idx >= ctx.gp_count)           { ret -1; }
+        if (ctx.reserved[idx])             { ret -1; }
+        if (lr.crosses_call && !ctx.callee_saved[idx]) { ret -1; }
+        if (!gp_available(ctx, idx))       { ret -1; }
+        ctx.gp_busy[idx] = true;
+        ret rid;
+    } or {
+        if (rclass != isa.REG_CLASS_ID_XMM) { ret -1; }
+        if (idx >= ctx.fp_count)            { ret -1; }
+        if (lr.crosses_call && (ctx.fp_callee_saved == nil || !ctx.fp_callee_saved[idx])) { ret -1; }
+        if (!fp_available(ctx, idx))        { ret -1; }
+        ctx.fp_busy[idx] = true;
+        ret rid;
+    }
 }
 
 # resolve the loop-carried reverse hint's target register for source vreg `v` - the


### PR DESCRIPTION
Closes #2203.

Conservative copy coalescing for the linear-scan allocator: one rewrite pass and
two new allocation hints, all confined to `be/codegen/regalloc.mach`.

## Baseline

Register-to-register copies in the compiler's own release object files, counted
from `llvm-objdump` disassembly. Same-register moves (the 32-bit zero-extension
idiom on x86-64/AArch64, the `addi rd, rd, lo12` half of a RISC-V `auipc` pair)
and frame-pointer prologue/epilogue setup are excluded — neither is an allocator
copy. Both sides compile identical source; only the compiler that produced them
differs.

| ISA | instructions | reg-reg copies | share |
|---|---|---|---|
| x86_64  | 2,290,814 | 203,646 | 8.89% |
| aarch64 | 2,729,586 | 151,793 | 5.56% |
| riscv64 | 2,859,852 | 215,255 | 7.53% |

Where the x86-64 copies come from, by context: 62,398 place a value into an ABI
argument or return register, 21,543 home an incoming parameter, 16,667 are the
two-address seed the encoder emits before an in-place ALU op, and most of the
48,092 `mov`-followed pairs are argument-setup chains. Straight vreg-to-vreg MIR
copies that no hint reaches are a minority.

## What landed, and why this flavour

**Conservative, not aggressive or iterated.** Two of the three mechanisms are
coloring biases checked against every interference test the ordinary pick already
applies, and the third is a rewrite whose merge is provably pressure-neutral. The
aggressive-coalescing hazard — creating uncolorable interference and forcing
spills that cost more than the copies removed — has no case to bound here:

1. **Copy-web coalescing** (`coalesce_copies`, a pre-scan MIR rewrite). A copy
   whose two vregs are each assigned exactly once merges them into one web and is
   deleted outright, before the flat stream and the live ranges are built. Single
   assignment on both sides makes the rename unconditionally value-preserving
   under any control flow: the source's definition dominates the copy (it is read
   there), the copy dominates every use of the destination (it is the only
   definition), and no redefinition of either exists anywhere. No interference
   graph and no dominance computation are needed.

   It cannot increase pressure. Under the one-merged-interval-per-vreg range model
   the source is live at the copy and the destination begins there, so the two
   intervals always overlap and their union *is* an interval — exactly the merged
   web's. Every point where the merged value is live had at least one of the two
   live before; every point where both were live now holds one value. Maximum
   simultaneous liveness is non-increasing everywhere, so no spill can be forced
   that was not already forced. Measured: frame-slot traffic in the compiler's own
   objects fell from 487,608 to 482,282 references.

2. **Sink hint** (`pick_sink_hint`). The counterpart of the existing forward hint:
   where that chases the register a value is copied *from*, this chases the one it
   is copied *to* — the ABI argument and return registers, the largest single
   family of surviving copies. Recorded only when the value dies exactly at the
   placement move and the move is full machine width; honored only when the
   register passes `gp_available`/`fp_available` plus the caller-saved test, i.e.
   every check `pick_gp`/`pick_fp` apply. An honored hint therefore occupies a
   register the ordinary pick could equally have returned.

3. **Two-address tie hint** (`maybe_tie_hint`). An op the encoder materializes as
   `MOV dst, lhs ; OP dst, rhs` has its destination copy-related to its left
   operand exactly as if that seeding move were in the MIR. The destination
   records the left operand in the existing forward-hint slots when the operand
   dies at the op and the destination is born there — the two conditions
   `can_transfer` already requires — and the encoder's own `skip_mov` then drops
   the seed. Read as data from the selection-output opcode a rule pack emitted,
   never as a branch on an architecture: a pack that selects a native
   three-address instruction produces no two-address sentinel and is never tied.

## Result

| ISA | copies before | after | removed | .text before | after | delta |
|---|---|---|---|---|---|---|
| x86_64  | 203,646 | 158,312 | **-45,334 (-22.3%)** | 11,097,063 | 10,924,793 | -172,270 B (-1.55%) |
| aarch64 | 151,793 | 151,787 | -6 | 10,918,344 | 10,918,200 | -144 B |
| riscv64 | 215,255 | 215,204 | -51 | 11,439,408 | 11,439,136 | -272 B |

Total instructions on x86-64: 2,290,814 → 2,240,183 (-50,631, -2.21%).

**Why the RISC targets barely move, and why that is the right answer.** The sink
hint fires 36,595 times on AArch64 and 39,096 on RISC-V, and the AArch64 output is
*byte-identical* — the register it asks for is already the one the ordinary pick
returns. AArch64 register ids are identity `X0..X30 -> 0..30`, so the argument
registers are the lowest indices in the bank and `pick_gp`, which scans ascending
preferring caller-saved, lands on them by construction. On x86-64 the SysV
argument registers are scattered (`rdi`=7, `rsi`=6, `rdx`=2, `rcx`=1) and `rax`=0
is scanned first, so the ordinary pick rarely lands on the right one. The
two-address seed likewise exists only where a pack emits the two-address
sentinels, which on the three shipped register machines means x86-64 alone. The
RISC deltas are the web coalescer alone, and the conservative single-assignment
rule catches few copies there: 47,349 of the 47,375 vreg-to-vreg copies AArch64
emits have a multiply-assigned destination (phi targets), which that rule refuses
by design.

## Runtime

Per-kernel isolation, one binary pair per kernel from identical source, best-of-5
`perf stat`, checksums verified equal:

| kernel | instructions | cycles |
|---|---|---|
| `i64_dot`    | **-10.00%** | +0.97% |
| `i64_triad`  | **-6.25%** | **-13.33%** |
| `i64_mixsum` | **-8.33%** | -0.54% |
| `fnv1a`      | -0.01% | +0.43% |
| `scan`       | -0.00% | +0.31% |

Real workload — a full release build of the compiler by two compilers that differ
only in the codegen that produced them, identical work, best-of-3:
**223.884 G -> 220.492 G instructions (-1.51%)**, variance below 0.001%.

Cycles on this machine are dominated by code layout, not by the change. Inserting
a single unused function ahead of the kernels in a combined 5-kernel benchmark
swings the cycle delta from **+4.72% to -1.34%**, and moves the *baseline's own*
cycle count by 4.6% with identical code. The instruction count is the stable
signal; the one kernel where a real cycle win rises above that band is the array
triad at -13.3%.

## Register-constraint machinery

Nothing new bypasses it. `pick_sink_hint` runs `gp_available`/`fp_available`,
which consult the busy flags, the incoming-parameter pins, the outgoing-argument
windows and the precolored-def reservations — the same set `pick_gp`/`pick_fp`
use — plus the reserved-register mask (the ISA's stack/frame pointers, the
reload-scratch pool, and the division and shift registers a dividing or shifting
function reserves) and the caller-saved test for a call-crossing range. The tie
hint reaches the register only through `can_transfer`, whose destination-born and
source-dies conditions are unchanged. The web coalescer refuses any vreg owning
lowering storage, any class or secrecy or vector-marking mismatch (so a
declassifying move, which isel retags to the ordinary machine move, is refused),
and any sub-word copy whose zero-extension deleting it would drop.

`rewrite_instr` is untouched — the field-drop hazard of the `vec_lane` regression
does not recur. `rename_vregs` is the one new pass that walks operands, and it
covers value operands, MEM bases, MEM scaled indices and both `-g` debug-binding
vreg fields; frame-slot keys are deliberately left alone, since a slot-owning vreg
is never merged and the frame table keys on that id.

## Verification

- **Suites:** 795 passed / 0 failed (790 baseline + 5 new tests), run through the
  freshly built HEAD compiler. mach-std **611 / 0** at pin `eff1e8e`, verified with
  `git rev-parse HEAD` against `mach.lock`.
- **int lanes:** `linux` green, `linux-riscv64` green under qemu, `linux-arm64`
  green (run locally under qemu-user; the CI leg is a native arm runner).
- **Three-generation fixpoint:** gen2 == gen3 == gen4 byte-identical on **both**
  profiles — `release` `ac977a73…`, `debug` `080a08e0…`.
- **mos6502 and SPIR-V:** both target suites green (7 and 5 tests). SPIR-V has no
  regalloc and is structurally unaffected; mos6502 emits no two-address sentinels
  and takes only the target-neutral web coalescer.
- **`-g` additivity:** all **204** objects emit a byte-identical `.text` with and
  without `-g`. The coalescer never reads `dbg_binding_count` as a condition, and a
  coalesced copy releases its bindings exactly as the dead-def sweep does — a
  zero-byte carrier pre-regalloc would perturb the flat stream and make allocation
  depend on `-g`, which is the invariant #1944 established.
- **Mutation testing.** Each mechanism disabled in turn; x86-64 copy counts against
  the unmutated control of **158,949**:

  | mutation | copies | delta | failing test |
  |---|---|---|---|
  | web coalescing off | 161,227 | +2,278 | `coalesce_copies:single_assignment_web_is_merged` |
  | sink hint off | 190,411 | **+31,462** | `maybe_sink_hint:records_only_a_dying_full_width_placement` |
  | tie hint off | 170,314 | +11,365 | `maybe_tie_hint:ties_a_dying_left_operand` |
  | restored | 158,949 | — | 12 / 12 pass |

## Not fixed here — #2237

The `f32_saxpy` listing in #2203 is **not** an allocator defect and this branch
leaves that loop byte-identical, which is the cleanest possible proof of where it
lives. The MIR reaching the encoder is a clean three-address `FMUL v2, v0, v1`
with all three operands in allocated XMM registers; `encode_float_arith` in
`isa/x64/encode.mach` then routes every operand through the fixed XMM scratch pair
unconditionally, turning each op into four instructions. There is nothing to
coalesce — the copies do not exist until the encoder emits them. Filed as **#2237**
under the same epic, with the fix scoped to the encoder's register-register case.
