### PR TITLE
feat(emit-asm): render the aarch64 .s from the encoder's instruction stream

### DIFF
--- a/doc/cli.md
+++ b/doc/cli.md
@@ -63,7 +63,7 @@ A verbosity flag (`-v`/`-vv`) and `--quiet` together is a parse error.
 | `--lib <name>`   | artifact name    | narrow the build to one `static`/`shared` `[artifact.<name>]` (mutually exclusive with `--bin`) |
 | `-o <path>`      | path             | override the artifact path, rooted at the project root (build/run/test) |
 | `--all-targets`  | —                | build every declared `[target.*]`, not just the default (mutually exclusive with `-o`, which names one path) |
-| `--emit-asm`     | —                | emit per-module assembly text (`.s`) — each line is one machine instruction the encoder emitted for that module, so the `.s` corresponds to the `.o` instruction for instruction. Supported on x86-64; riscv64 and aarch64 fail naming their tracking issue rather than emit a misleading file. Emission is opt-in, controlled only by this flag |
+| `--emit-asm`     | —                | emit per-module assembly text (`.s`) — each line is one machine instruction the encoder emitted for that module, so the `.s` corresponds to the `.o` instruction for instruction. Supported on x86-64 and aarch64; riscv64 fails naming its tracking issue rather than emit a misleading file. Emission is opt-in, controlled only by this flag |
 | `--emit-ir`      | —                | emit per-module SSA IR text (`.ir`), the final post-pipeline IR the object is built from (so it varies with the profile's `opt`) — emission is opt-in, controlled only by this flag |
 | `--verify-ir`    | —                | run the IR verifier after each optimisation pass |
 

--- a/src/lang/target/isa/arm64/encode.mach
+++ b/src/lang/target/isa/arm64/encode.mach
@@ -35,6 +35,7 @@
 # registers and the scalar-float, float-conversion, and NEON vector families.
 
 use std.allocator.page;
+use std.io.writer;
 use std.text.parse;
 use std.types.bool.bool;
 use std.types.bool.false;
@@ -57,6 +58,7 @@ use mach.lang.be.codegen.mir;
 use mach.lang.intern;
 use mach.lang.target.isa;
 use mach.lang.target.isa.arm64;
+use printer: mach.lang.target.isa.arm64.printer;
 use mach.lang.target.of;
 use mach.lang.target.resolved;
 
@@ -513,8 +515,528 @@ fun ldst_base_reg(w: u8, is_load: bool) u32 {
 }
 
 # append one 32-bit A64 instruction word to the text sink (little-endian)
+#
+# Every emitted word passes through one of the `emit_*` wrappers below, which pairs
+# this with the assembly-sink notification for the same instruction. Nothing else
+# calls it: a word appended here without a notification is bytes the `.s` would not
+# describe, which `check_accounted` turns into a build failure naming the opcode.
 fun emit_word(st: *encode.EncodeState, word: u32) {
     encode.emit_u32(?st.buf, word);
+}
+
+# the AArch64 instruction-word emitters
+#
+# Each wraps one bitfield-class packer: it emits the packed word and, when an
+# assembly sink is attached, notifies the printer with the SAME fields the packer
+# received. This is the whole reason `--emit-asm` needs no disassembler on a target
+# that emits opaque 32-bit words - the structure is not absent, it is discarded one
+# layer below, so it is captured one layer above (#2194).
+#
+# One notification per emitted machine instruction, never per MIR opcode: a MIR
+# macro-op that expands into several words emits each through its own wrapper, so
+# each is rendered separately. That is the invariant the collapsed MIR-level printer
+# violated (#2187).
+
+# the operand banks and widths a three-register base word names
+#
+# The printer reads the bank and width off the operands themselves, so this is what
+# tells the emitter which to build. `arity` 3 is a two-source form, 2 a one-source
+# form, 0 a form that writes no register (the flag-setting float compare), and 255
+# an unmapped base - which fails the render rather than emitting a wrong operand.
+# ---
+# dst_fp: the destination names a float / vector register
+# dst_w:  the destination width in bytes
+# src_fp: the sources name float / vector registers
+# src_w:  the source width in bytes
+# arity:  3, 2, 0, or 255 for an unmapped base
+rec Alu3Shape {
+    dst_fp: bool;
+    dst_w:  u8;
+    src_fp: bool;
+    src_w:  u8;
+    arity:  u8;
+}
+
+# build a three-register operand shape
+# ---
+# dst_fp: the destination names a float / vector register
+# dst_w:  the destination width in bytes
+# src_fp: the sources name float / vector registers
+# src_w:  the source width in bytes
+# arity:  the number of rendered register operands
+# ret:    the shape
+fun a3(dst_fp: bool, dst_w: u8, src_fp: bool, src_w: u8, arity: u8) Alu3Shape {
+    var s: Alu3Shape;
+    s.dst_fp = dst_fp;
+    s.dst_w  = dst_w;
+    s.src_fp = src_fp;
+    s.src_w  = src_w;
+    s.arity  = arity;
+    ret s;
+}
+
+# the operand shape a three-register base word names
+fun alu3_shape(base: u32) Alu3Shape {
+    if (base == ADD_X || base == SUB_X || base == AND_X || base == ORR_X ||
+        base == EOR_X || base == ORN_X || base == MUL_X || base == LSLV_X ||
+        base == LSRV_X || base == ASRV_X || base == SDIV_X || base == UDIV_X ||
+        base == SUBS_REG_X || base == SUB_SP_REG_X) { ret a3(false, 8, false, 8, 3); }
+    if (base == ADD_W || base == SUB_W || base == AND_W || base == ORR_W ||
+        base == EOR_W || base == ORN_W || base == MUL_W || base == LSLV_W ||
+        base == LSRV_W || base == ASRV_W || base == SDIV_W || base == UDIV_W ||
+        base == SUBS_REG_W)                         { ret a3(false, 4, false, 4, 3); }
+
+    if (base == FADD_S || base == FSUB_S || base == FMUL_S || base == FDIV_S) { ret a3(true, 4, true, 4, 3); }
+    if (base == FADD_D || base == FSUB_D || base == FMUL_D || base == FDIV_D) { ret a3(true, 8, true, 8, 3); }
+    if (base == FNEG_S || base == FMOV_S) { ret a3(true, 4, true, 4, 2); }
+    if (base == FNEG_D || base == FMOV_D) { ret a3(true, 8, true, 8, 2); }
+    if (base == FCVT_S2D)                 { ret a3(true, 8, true, 4, 2); }
+    if (base == FCVT_D2S)                 { ret a3(true, 4, true, 8, 2); }
+    if (base == FCMP_S)                   { ret a3(true, 4, true, 4, 0); }
+    if (base == FCMP_D)                   { ret a3(true, 8, true, 8, 0); }
+
+    if (base == SCVTF_S_W || base == UCVTF_S_W) { ret a3(true, 4, false, 4, 2); }
+    if (base == SCVTF_D_W || base == UCVTF_D_W) { ret a3(true, 8, false, 4, 2); }
+    if (base == SCVTF_S_X || base == UCVTF_S_X) { ret a3(true, 4, false, 8, 2); }
+    if (base == SCVTF_D_X || base == UCVTF_D_X) { ret a3(true, 8, false, 8, 2); }
+
+    if (base == FCVTZS_W_S || base == FCVTZU_W_S) { ret a3(false, 4, true, 4, 2); }
+    if (base == FCVTZS_X_S || base == FCVTZU_X_S) { ret a3(false, 8, true, 4, 2); }
+    if (base == FCVTZS_W_D || base == FCVTZU_W_D) { ret a3(false, 4, true, 8, 2); }
+    if (base == FCVTZS_X_D || base == FCVTZU_X_D) { ret a3(false, 8, true, 8, 2); }
+
+    if (base == FMOV_S_FROM_W) { ret a3(true,  4, false, 4, 2); }
+    if (base == FMOV_D_FROM_X) { ret a3(true,  8, false, 8, 2); }
+    if (base == FMOV_W_FROM_S) { ret a3(false, 4, true,  4, 2); }
+    if (base == FMOV_X_FROM_D) { ret a3(false, 8, true,  8, 2); }
+    ret a3(false, 0, false, 0, 255);
+}
+
+# a register operand in the bank and width a shape names
+# ---
+# fp:    true for a float / vector register
+# n:     the register index
+# bytes: the operand width in bytes
+# ret:   the operand
+fun shaped_reg(fp: bool, n: u32, bytes: u8) isa.Operand {
+    if (fp) { ret printer.vec(n, bytes); }
+    ret printer.gp(n, bytes);
+}
+
+# true when an assembly sink is rendering this encode
+fun noting(st: *encode.EncodeState) bool {
+    ret encode.sink_active(?st.buf);
+}
+
+# emit a three-register data-processing word
+fun emit_alu3(st: *encode.EncodeState, base: u32, rd: u32, rn: u32, rm: u32) {
+    emit_word(st, pack_alu3(base, rd, rn, rm));
+    note_alu3(st, base, rd, rn, rm, 0, false);
+}
+
+# emit a three-register word whose second source is left-shifted by `sh`
+fun emit_alu3_sh(st: *encode.EncodeState, base: u32, rd: u32, rn: u32, rm: u32, sh: u32) {
+    emit_word(st, pack_alu3_sh(base, rd, rn, rm, sh));
+    note_alu3(st, base, rd, rn, rm, sh, sh != 0);
+}
+
+# render a three-register word to the assembly sink
+fun note_alu3(st: *encode.EncodeState, base: u32, rd: u32, rn: u32, rm: u32, sh: u32, shifted: bool) {
+    if (!noting(st)) { ret; }
+    val s: Alu3Shape = alu3_shape(base);
+    if (s.arity == 255) {
+        encode.sink_fail(?st.buf, "--emit-asm: no aarch64 operand shape for an emitted three-register base word");
+        ret;
+    }
+    var i: printer.Inst = printer.inst(printer.FORM_ALU3, base);
+    if (s.arity != 0) { i.dst = shaped_reg(s.dst_fp, rd, s.dst_w); }
+    i.src1 = shaped_reg(s.src_fp, rn, s.src_w);
+    if (s.arity != 2) { i.src2 = shaped_reg(s.src_fp, rm, s.src_w); }
+    if (shifted)      { i.src3 = isa.make_imm(sh::i64, 1); }
+    printer.note_inst(?st.buf, ?i);
+}
+
+# emit an ADD/SUB (immediate) word
+fun emit_addsub_imm(st: *encode.EncodeState, base: u32, rd: u32, rn: u32, imm12: u32, sh: u32) {
+    emit_word(st, pack_addsub_imm(base, rd, rn, imm12, sh));
+    if (!noting(st)) { ret; }
+    var w: u8 = 4;
+    if ((base & 0x80000000) != 0) { w = 8; }
+    var i: printer.Inst = printer.inst(printer.FORM_ADDSUB_IMM, base);
+    i.dst  = printer.gp(rd, w);
+    i.src1 = printer.gp(rn, w);
+    i.src2 = isa.make_imm(imm12::i64, w);
+    if (sh != 0) { i.src3 = isa.make_imm(12, 1); }
+    printer.note_inst(?st.buf, ?i);
+}
+
+# emit an ADD (immediate) word whose immediate is a symbol's low twelve bits,
+# filled by the linker
+fun emit_addsub_imm_sym(st: *encode.EncodeState, base: u32, rd: u32, rn: u32, sym: intern.StrId, mod: u8) {
+    emit_word(st, pack_addsub_imm(base, rd, rn, 0, 0));
+    if (!noting(st)) { ret; }
+    var w: u8 = 4;
+    if ((base & 0x80000000) != 0) { w = 8; }
+    var i: printer.Inst = printer.inst(printer.FORM_ADDSUB_IMM, base);
+    i.dst     = printer.gp(rd, w);
+    i.src1    = printer.gp(rn, w);
+    i.src2    = isa.make_sym(sym::u32, w);
+    i.sym_mod = mod;
+    printer.note_inst(?st.buf, ?i);
+}
+
+# emit a bitfield-move word
+fun emit_bitfield(st: *encode.EncodeState, base: u32, rd: u32, rn: u32, immr: u32, imms: u32) {
+    emit_word(st, pack_bitfield(base, rd, rn, immr, imms));
+    if (!noting(st)) { ret; }
+    var w: u8 = 4;
+    if (base == UBFM_X || base == SBFM_X) { w = 8; }
+    var i: printer.Inst = printer.inst(printer.FORM_BITFIELD, base);
+    i.dst  = printer.gp(rd, w);
+    i.src1 = printer.gp(rn, w);
+    i.src2 = isa.make_imm(immr::i64, 1);
+    i.src3 = isa.make_imm(imms::i64, 1);
+    printer.note_inst(?st.buf, ?i);
+}
+
+# emit a move-wide word
+fun emit_movewide(st: *encode.EncodeState, base: u32, rd: u32, hw: u32, imm16: u32) {
+    emit_word(st, pack_movewide(base, rd, hw, imm16));
+    if (!noting(st)) { ret; }
+    var w: u8 = 4;
+    if (base == MOVZ_X || base == MOVK_X) { w = 8; }
+    var i: printer.Inst = printer.inst(printer.FORM_MOVEWIDE, base);
+    i.dst  = printer.gp(rd, w);
+    i.src2 = isa.make_imm(imm16::i64, w);
+    if (hw != 0) { i.src3 = isa.make_imm((hw * 16)::i64, 1); }
+    printer.note_inst(?st.buf, ?i);
+}
+
+# emit a multiply-add / multiply-subtract word
+fun emit_madd(st: *encode.EncodeState, base: u32, rd: u32, rn: u32, rm: u32, ra: u32) {
+    emit_word(st, pack_madd(base, rd, rn, rm, ra));
+    if (!noting(st)) { ret; }
+    var w: u8 = 4;
+    if (base == MSUB_X) { w = 8; }
+    var i: printer.Inst = printer.inst(printer.FORM_MADD, base);
+    i.dst  = printer.gp(rd, w);
+    i.src1 = printer.gp(rn, w);
+    i.src2 = printer.gp(rm, w);
+    i.src3 = printer.gp(ra, w);
+    printer.note_inst(?st.buf, ?i);
+}
+
+# emit a CSET (CSINC with both sources at the zero register) word
+fun emit_cset(st: *encode.EncodeState, base: u32, rd: u32, cc: u32) {
+    emit_word(st, pack_cset(base, rd, cc));
+    if (!noting(st)) { ret; }
+    var w: u8 = 4;
+    if (base == CSINC_X) { w = 8; }
+    var i: printer.Inst = printer.inst(printer.FORM_CSET, base);
+    i.dst   = printer.gp(rd, w);
+    # the encoded condition field is the inverse of the one the boolean captures
+    i.flags = ((cc ^ 1) & 0xF)::u16;
+    printer.note_inst(?st.buf, ?i);
+}
+
+# the transferred register's bank and width for a load / store base word
+#
+# `scale` is the byte multiplier the scaled unsigned-offset form applies to its
+# imm12; it is 0 for a form whose base fixes the offset field, and 255 marks an
+# unmapped base.
+# ---
+# fp:    the transferred register is a float / vector register
+# w:     the transferred register's width in bytes
+# scale: the imm12 byte multiplier, 0 for an offset-less form, 255 when unmapped
+rec LdStShape {
+    fp:    bool;
+    w:     u8;
+    scale: u32;
+}
+
+# build a load / store operand shape
+fun ls(fp: bool, w: u8, scale: u32) LdStShape {
+    var s: LdStShape;
+    s.fp    = fp;
+    s.w     = w;
+    s.scale = scale;
+    ret s;
+}
+
+# the operand shape a scaled unsigned-offset load / store base word names
+fun ldst_shape(base: u32) LdStShape {
+    if (base == LDRB_OFF || base == STRB_OFF) { ret ls(false, 4, 1); }
+    if (base == LDRH_OFF || base == STRH_OFF) { ret ls(false, 4, 2); }
+    if (base == LDRW_OFF || base == STRW_OFF) { ret ls(false, 4, 4); }
+    if (base == LDR_OFF_X || base == STR_OFF_X) { ret ls(false, 8, 8); }
+    if (base == LDR_D_OFF || base == STR_D_OFF) { ret ls(true, 8, 8); }
+    if (base == LDR_S_OFF || base == STR_S_OFF) { ret ls(true, 4, 4); }
+    if (base == LDR_Q_OFF || base == STR_Q_OFF) { ret ls(true, 16, 16); }
+    if (base == LDAR_X || base == STLR_X || base == LDAXR_X) { ret ls(false, 8, 0); }
+    if (base == LDAR_W || base == STLR_W || base == LDAXR_W) { ret ls(false, 4, 0); }
+    ret ls(false, 0, 255);
+}
+
+# the operand shape an unscaled signed-offset (LDUR / STUR) base word names
+fun ldur_shape(base: u32) LdStShape {
+    if (base == LDURB || base == STURB || base == LDURH || base == STURH ||
+        base == LDURW || base == STURW) { ret ls(false, 4, 1); }
+    if (base == LDUR_X || base == STUR_X)       { ret ls(false, 8, 1); }
+    if (base == LDUR_D_FP || base == STUR_D_FP) { ret ls(true, 8, 1); }
+    if (base == LDUR_S_FP || base == STUR_S_FP) { ret ls(true, 4, 1); }
+    if (base == LDUR_Q_FP || base == STUR_Q_FP) { ret ls(true, 16, 1); }
+    ret ls(false, 0, 255);
+}
+
+# the operand shape a register-offset load / store base word names
+fun ldst_reg_shape(base: u32) LdStShape {
+    if (base == LDRB_REG || base == STRB_REG || base == LDRH_REG || base == STRH_REG ||
+        base == LDRW_REG || base == STRW_REG)     { ret ls(false, 4, 1); }
+    if (base == LDR_REG_X || base == STR_REG_X)   { ret ls(false, 8, 1); }
+    if (base == LDR_D_REG || base == STR_D_REG)   { ret ls(true, 8, 1); }
+    if (base == LDR_S_REG || base == STR_S_REG)   { ret ls(true, 4, 1); }
+    if (base == LDR_Q_REG || base == STR_Q_REG)   { ret ls(true, 16, 1); }
+    ret ls(false, 0, 255);
+}
+
+# true when a load / store base word reads memory rather than writing it
+fun ldst_loads(base: u32) bool {
+    ret base == LDRB_OFF || base == LDRH_OFF || base == LDRW_OFF || base == LDR_OFF_X ||
+        base == LDR_D_OFF || base == LDR_S_OFF || base == LDR_Q_OFF ||
+        base == LDAR_X || base == LDAR_W || base == LDAXR_X || base == LDAXR_W ||
+        base == LDURB || base == LDURH || base == LDURW || base == LDUR_X ||
+        base == LDUR_D_FP || base == LDUR_S_FP || base == LDUR_Q_FP ||
+        base == LDRB_REG || base == LDRH_REG || base == LDRW_REG || base == LDR_REG_X ||
+        base == LDR_D_REG || base == LDR_S_REG || base == LDR_Q_REG;
+}
+
+# render a load or store to the assembly sink
+#
+# The slots are semantic: `dst` holds the location written, so a load puts its
+# register there and a store its memory operand. The printer emits them in AArch64's
+# source-first order.
+fun note_ldst(st: *encode.EncodeState, base: u32, s: *LdStShape, rt: u32, mem: isa.Operand) {
+    if (s.scale == 255) {
+        encode.sink_fail(?st.buf, "--emit-asm: no aarch64 operand shape for an emitted load/store base word");
+        ret;
+    }
+    var i: printer.Inst = printer.inst(printer.FORM_LDST, base);
+    val reg: isa.Operand = shaped_reg(s.fp, rt, s.w);
+    if (ldst_loads(base)) { i.dst = reg; i.src1 = mem; }
+    or                    { i.dst = mem; i.src1 = reg; }
+    printer.note_inst(?st.buf, ?i);
+}
+
+# emit a scaled unsigned-offset load / store word
+fun emit_ldst(st: *encode.EncodeState, base: u32, rt: u32, rn: u32, imm12: u32) {
+    emit_word(st, pack_ldst(base, rt, rn, imm12));
+    if (!noting(st)) { ret; }
+    val s: LdStShape = ldst_shape(base);
+    var disp: i32 = 0;
+    if (s.scale != 0 && s.scale != 255) { disp = (imm12 * s.scale)::i32; }
+    note_ldst(st, base, ?s, rt, isa.make_mem(printer.gp(rn, 8).reg, disp, -1, 0, s.w));
+}
+
+# emit a scaled unsigned-offset load / store whose displacement is a symbol's low
+# twelve bits, filled by the linker
+fun emit_ldst_sym(st: *encode.EncodeState, base: u32, rt: u32, rn: u32, sym: intern.StrId, mod: u8) {
+    emit_word(st, pack_ldst(base, rt, rn, 0));
+    if (!noting(st)) { ret; }
+    val s: LdStShape = ldst_shape(base);
+    if (s.scale == 255) {
+        encode.sink_fail(?st.buf, "--emit-asm: no aarch64 operand shape for an emitted load/store base word");
+        ret;
+    }
+    var mem: isa.Operand = isa.make_mem(printer.gp(rn, 8).reg, 0, -1, 0, s.w);
+    mem.sym_id = sym::u32;
+    var i: printer.Inst = printer.inst(printer.FORM_LDST, base);
+    i.sym_mod = mod;
+    val reg: isa.Operand = shaped_reg(s.fp, rt, s.w);
+    if (ldst_loads(base)) { i.dst = reg; i.src1 = mem; }
+    or                    { i.dst = mem; i.src1 = reg; }
+    printer.note_inst(?st.buf, ?i);
+}
+
+# emit an unscaled signed-offset (LDUR / STUR) load / store word
+fun emit_ldur(st: *encode.EncodeState, base: u32, rt: u32, rn: u32, imm9: u32) {
+    emit_word(st, pack_ldur(base, rt, rn, imm9));
+    if (!noting(st)) { ret; }
+    val s: LdStShape = ldur_shape(base);
+    note_ldst(st, base, ?s, rt, isa.make_mem(printer.gp(rn, 8).reg, sign_extend_field(imm9, 9)::i32, -1, 0, s.w));
+}
+
+# emit a register-offset load / store word
+fun emit_ldst_reg(st: *encode.EncodeState, base: u32, rt: u32, rn: u32, rm: u32) {
+    emit_word(st, pack_ldst_reg(base, rt, rn, rm));
+    if (!noting(st)) { ret; }
+    val s: LdStShape = ldst_reg_shape(base);
+    note_ldst(st, base, ?s, rt, isa.make_mem(printer.gp(rn, 8).reg, 0, printer.gp(rm, 8).reg, 1, s.w));
+}
+
+# emit a load / store pair word
+fun emit_ldstp(st: *encode.EncodeState, base: u32, rt: u32, rt2: u32, rn: u32, imm7: u32) {
+    emit_word(st, pack_ldstp(base, rt, rt2, rn, imm7));
+    if (!noting(st)) { ret; }
+    val fp: bool = base == STP_OFF_D || base == LDP_OFF_D;
+    val load: bool = base == LDP_OFF_X || base == LDP_PRE_X || base == LDP_POST_X || base == LDP_OFF_D;
+    var i: printer.Inst = printer.inst(printer.FORM_LDSTP, base);
+    if (base == STP_PRE_X || base == LDP_PRE_X)   { i.flags = printer.FLAG_WB_PRE; }
+    if (base == STP_POST_X || base == LDP_POST_X) { i.flags = printer.FLAG_WB_POST; }
+
+    val mem: isa.Operand = isa.make_mem(printer.gp(rn, 8).reg, (sign_extend_field(imm7, 7) * 8)::i32, -1, 0, 8);
+    val ra: isa.Operand = shaped_reg(fp, rt, 8);
+    val rb: isa.Operand = shaped_reg(fp, rt2, 8);
+    if (load) { i.dst = ra; i.src1 = rb; i.src2 = mem; }
+    or        { i.dst = mem; i.src1 = ra; i.src2 = rb; }
+    printer.note_inst(?st.buf, ?i);
+}
+
+# emit a NEON three-register-same 128-bit word
+fun emit_neon_3same(st: *encode.EncodeState, base: u32, size: u32, rd: u32, rn: u32, rm: u32, lane: u8) {
+    emit_word(st, pack_neon_3same(base, size, rd, rn, rm));
+    if (!noting(st)) { ret; }
+    var i: printer.Inst = printer.inst(printer.FORM_NEON_3SAME, base);
+    i.dst      = printer.vec(rd, 16);
+    i.src1     = printer.vec(rn, 16);
+    i.src2     = printer.vec(rm, 16);
+    i.vec_lane = lane;
+    printer.note_inst(?st.buf, ?i);
+}
+
+# emit a NEON two-register-misc 128-bit word
+fun emit_neon_2misc(st: *encode.EncodeState, base: u32, rd: u32, rn: u32) {
+    emit_word(st, pack_neon_2misc(base, rd, rn));
+    if (!noting(st)) { ret; }
+    var i: printer.Inst = printer.inst(printer.FORM_NEON_2MISC, base);
+    i.dst      = printer.vec(rd, 16);
+    i.src1     = printer.vec(rn, 16);
+    i.vec_lane = mir.vec_lane_make(mir.VEC_LANE_INT, 1);
+    printer.note_inst(?st.buf, ?i);
+}
+
+# the compare register a branch base word tests, as an operand
+#
+# `B` and `B.cond` carry none; `CBZ` / `CBNZ` carry one, at the base word's width.
+fun branch_reg_operand(base: u32, rt: u32, has_rt: bool) isa.Operand {
+    if (!has_rt) { ret printer.none_operand(); }
+    if (base == CBNZ_X || base == CBZ_X) { ret printer.gp(rt, 8); }
+    ret printer.gp(rt, 4);
+}
+
+# emit a branch whose destination is a MIR block, with a placeholder displacement
+fun emit_branch_block(st: *encode.EncodeState, base: u32, rt: u32, has_rt: bool, block: u32) {
+    var word: u32 = base;
+    if (has_rt) { word = base | (rt & 0x1F); }
+    emit_word(st, word);
+    if (!noting(st)) { ret; }
+    var i: printer.Inst = printer.inst(printer.FORM_BRANCH, base);
+    i.src1   = branch_reg_operand(base, rt, has_rt);
+    i.target = printer.TGT_BLOCK;
+    i.block  = block;
+    printer.note_inst(?st.buf, ?i);
+}
+
+# emit a branch whose destination is a symbol the linker resolves
+fun emit_branch_sym(st: *encode.EncodeState, base: u32, sym: intern.StrId) {
+    emit_word(st, base);
+    if (!noting(st)) { ret; }
+    var i: printer.Inst = printer.inst(printer.FORM_BRANCH, base);
+    i.src2   = isa.make_sym(sym::u32, 0);
+    i.target = printer.TGT_SYM;
+    printer.note_inst(?st.buf, ?i);
+}
+
+# emit a branch whose destination is a fixed forward word displacement
+fun emit_branch_pcrel(st: *encode.EncodeState, base: u32, rt: u32, has_rt: bool, imm19: u32) {
+    var word: u32 = base | ((imm19 & 0x7FFFF) << 5);
+    if (has_rt) { word = word | (rt & 0x1F); }
+    emit_word(st, word);
+    if (!noting(st)) { ret; }
+    var i: printer.Inst = printer.inst(printer.FORM_BRANCH, base);
+    i.src1   = branch_reg_operand(base, rt, has_rt);
+    i.src2   = isa.make_imm(imm19::i64, 4);
+    i.target = printer.TGT_PCREL;
+    printer.note_inst(?st.buf, ?i);
+}
+
+# emit a branch to an inline-asm numeric local label, with a placeholder
+# displacement the block's own fixup pass resolves
+fun emit_branch_local(st: *encode.EncodeState, word: u32, base: u32, rt: u32, has_rt: bool, number: u64, fwd: bool) {
+    emit_word(st, word);
+    if (!noting(st)) { ret; }
+    var i: printer.Inst = printer.inst(printer.FORM_BRANCH, base);
+    i.src1   = branch_reg_operand(base, rt, has_rt);
+    i.src2   = isa.make_imm(number::i64, 8);
+    i.target = printer.TGT_LOCAL_BACK;
+    if (fwd) { i.target = printer.TGT_LOCAL_FWD; }
+    printer.note_inst(?st.buf, ?i);
+}
+
+# emit a register-indirect branch word
+fun emit_branch_reg(st: *encode.EncodeState, base: u32, rn: u32) {
+    emit_word(st, base | ((rn & 0x1F) << 5));
+    if (!noting(st)) { ret; }
+    var i: printer.Inst = printer.inst(printer.FORM_BRANCH_REG, base);
+    i.src1 = printer.gp(rn, 8);
+    printer.note_inst(?st.buf, ?i);
+}
+
+# emit an ADRP page-address word with a placeholder page delta
+fun emit_adrp(st: *encode.EncodeState, rd: u32, sym: intern.StrId, mod: u8) {
+    emit_word(st, pack_adrp(rd));
+    if (!noting(st)) { ret; }
+    var i: printer.Inst = printer.inst(printer.FORM_ADRP, ADRP_BASE);
+    i.dst     = printer.gp(rd, 8);
+    i.src1    = isa.make_sym(sym::u32, 0);
+    i.sym_mod = mod;
+    printer.note_inst(?st.buf, ?i);
+}
+
+# emit a whole-word instruction with no operands
+fun emit_nullary(st: *encode.EncodeState, word: u32) {
+    emit_word(st, word);
+    if (!noting(st)) { ret; }
+    var i: printer.Inst = printer.inst(printer.FORM_NULLARY, word);
+    printer.note_inst(?st.buf, ?i);
+}
+
+# emit a single-immediate instruction (BRK / SVC) whose imm16 sits at bits[20:5]
+fun emit_imm16(st: *encode.EncodeState, base: u32, imm16: u32) {
+    emit_word(st, base | ((imm16 & 0xFFFF) << 5));
+    if (!noting(st)) { ret; }
+    var i: printer.Inst = printer.inst(printer.FORM_IMM16, base);
+    i.src1 = isa.make_imm(imm16::i64, 2);
+    printer.note_inst(?st.buf, ?i);
+}
+
+# emit a data memory barrier word
+fun emit_barrier(st: *encode.EncodeState, crm: u32) {
+    emit_word(st, DMB_BASE | ((crm & 0xF) << 8));
+    if (!noting(st)) { ret; }
+    var i: printer.Inst = printer.inst(printer.FORM_BARRIER, DMB_BASE);
+    i.src1 = isa.make_imm(crm::i64, 1);
+    printer.note_inst(?st.buf, ?i);
+}
+
+# emit a store-release-exclusive word, whose status result rides bits[20:16]
+fun emit_stxr(st: *encode.EncodeState, base: u32, rs: u32, rt: u32, rn: u32) {
+    emit_word(st, pack_ldst(base, rt, rn, 0) | ((rs & 0x1F) << 16));
+    if (!noting(st)) { ret; }
+    var w: u8 = 4;
+    if (base == STLXR_X) { w = 8; }
+    var i: printer.Inst = printer.inst(printer.FORM_STXR, base);
+    i.dst  = printer.gp(rs, 4);
+    i.src1 = printer.gp(rt, w);
+    i.src2 = isa.make_mem(printer.gp(rn, 8).reg, 0, -1, 0, w);
+    printer.note_inst(?st.buf, ?i);
+}
+
+# sign-extend the low `bits` of a field to a signed 64-bit integer
+fun sign_extend_field(v: u32, bits: u32) i64 {
+    val mask: u32 = (1::u32 << bits) - 1;
+    val x: u32 = v & mask;
+    if ((x & (1::u32 << (bits - 1))) != 0) { ret (x::i64) - ((mask::i64) + 1); }
+    ret x::i64;
 }
 
 # read the 32-bit little-endian word at `pos` in the text sink
@@ -560,7 +1082,7 @@ fun emit_movewide_seq(st: *encode.EncodeState, rd: u32, value: u64, use64: bool)
     if (!use64) { v = value & 0xFFFFFFFF; }
 
     if (v == 0) {
-        emit_word(st, pack_movewide(base_z, rd, 0, 0));
+        emit_movewide(st, base_z, rd, 0, 0);
         ret;
     }
 
@@ -570,10 +1092,10 @@ fun emit_movewide_seq(st: *encode.EncodeState, rd: u32, value: u64, use64: bool)
         val chunk: u32 = ((v >> (16::u64 * i::u64)) & 0xFFFF)::u32;
         if (chunk != 0) {
             if (first) {
-                emit_word(st, pack_movewide(base_z, rd, i, chunk));
+                emit_movewide(st, base_z, rd, i, chunk);
                 first = false;
             } or {
-                emit_word(st, pack_movewide(base_k, rd, i, chunk));
+                emit_movewide(st, base_k, rd, i, chunk);
             }
         }
         i = i + 1;
@@ -685,18 +1207,18 @@ fun emit_mem_access(st: *encode.EncodeState, rt: u32, base: u32, off: i64, width
     if (off >= 0) {
         val mask: i64 = (1::i64 << sh::i64) - 1;
         if ((off & mask) == 0 && (off >> sh::i64) <= 4095) {
-            emit_word(st, pack_ldst(ldst_base_scaled(w, is_load), rt, base, (off >> sh::i64)::u32));
+            emit_ldst(st, ldst_base_scaled(w, is_load), rt, base, (off >> sh::i64)::u32);
             ret;
         }
     }
     # unscaled signed imm9: -256..255.
     if (off >= -256 && off <= 255) {
-        emit_word(st, pack_ldur(ldst_base_unscaled(w, is_load), rt, base, off::u32 & 0x1FF));
+        emit_ldur(st, ldst_base_unscaled(w, is_load), rt, base, off::u32 & 0x1FF);
         ret;
     }
     # out of range: materialize the byte offset into IP0 and use `[base + IP0]`.
     emit_movewide_seq(st, SCRATCH0, off::u64, true);
-    emit_word(st, pack_ldst_reg(ldst_base_reg(w, is_load), rt, base, SCRATCH0));
+    emit_ldst_reg(st, ldst_base_reg(w, is_load), rt, base, SCRATCH0);
 }
 
 # materialize `Rd = Rn + off` for a 64-bit address computation,
@@ -705,23 +1227,23 @@ fun emit_mem_access(st: *encode.EncodeState, rt: u32, base: u32, off: i64, width
 # for an offset beyond the immediate range. a zero offset still emits `add Rd, Rn, #0`
 fun emit_add_imm(st: *encode.EncodeState, rd: u32, rn: u32, off: i64) {
     if (off >= 0 && off <= 4095) {
-        emit_word(st, pack_addsub_imm(ADDI_X, rd, rn, off::u32, 0));
+        emit_addsub_imm(st, ADDI_X, rd, rn, off::u32, 0);
         ret;
     }
     if (off < 0 && off >= -4095) {
-        emit_word(st, pack_addsub_imm(SUBI_X, rd, rn, (-off)::u32, 0));
+        emit_addsub_imm(st, SUBI_X, rd, rn, (-off)::u32, 0);
         ret;
     }
     if (off > 0 && (off & 0xFFF) == 0 && (off >> 12) <= 4095) {
-        emit_word(st, pack_addsub_imm(ADDI_X, rd, rn, (off >> 12)::u32, 1));
+        emit_addsub_imm(st, ADDI_X, rd, rn, (off >> 12)::u32, 1);
         ret;
     }
     if (off < 0 && ((-off) & 0xFFF) == 0 && ((-off) >> 12) <= 4095) {
-        emit_word(st, pack_addsub_imm(SUBI_X, rd, rn, ((-off) >> 12)::u32, 1));
+        emit_addsub_imm(st, SUBI_X, rd, rn, ((-off) >> 12)::u32, 1);
         ret;
     }
     emit_movewide_seq(st, SCRATCH0, off::u64, true);
-    emit_word(st, pack_alu3(ADD_X, rd, rn, SCRATCH0));
+    emit_alu3(st, ADD_X, rd, rn, SCRATCH0);
 }
 
 # the LSL amount realizing an index scale (1/2/4/8 -> 0/1/2/3) for the
@@ -740,7 +1262,7 @@ fun scale_shift(scale: u8) u32 {
 # ADD or LDR/STR `:lo12:` low half naming the same symbol
 fun emit_adrp_reloc(st: *encode.EncodeState, rd: u32, sym: intern.StrId, addend: i32) R.Result[bool, str] {
     val pos: u32 = st.buf.len::u32;
-    emit_word(st, pack_adrp(rd));
+    emit_adrp(st, rd, sym, printer.MOD_PCREL_HI);
     ret encode.push_reloc(st, arm64_reloc_offset(pos), of.RK_PAGE21, sym, addend);
 }
 
@@ -755,7 +1277,7 @@ fun emit_global_addr(st: *encode.EncodeState, rd: u32, symop: *mir.MirOperand) R
     val ar: R.Result[bool, str] = emit_adrp_reloc(st, rd, symop.sym, symop.sym_off);
     if (R.is_err[bool, str](ar)) { ret ar; }
     val pos: u32 = st.buf.len::u32;
-    emit_word(st, pack_addsub_imm(ADDI_X, rd, rd, 0, 0));
+    emit_addsub_imm_sym(st, ADDI_X, rd, rd, symop.sym, printer.MOD_PCREL_LO);
     ret encode.push_reloc(st, arm64_reloc_offset(pos), of.RK_ADD_LO12, symop.sym, symop.sym_off);
 }
 
@@ -773,7 +1295,7 @@ fun emit_global_load(st: *encode.EncodeState, rt: u32, symop: *mir.MirOperand, w
     val ar: R.Result[bool, str] = emit_adrp_reloc(st, SCRATCH0, symop.sym, symop.sym_off);
     if (R.is_err[bool, str](ar)) { ret ar; }
     val pos: u32 = st.buf.len::u32;
-    emit_word(st, pack_ldst(ldst_base_scaled(w, true), rt, SCRATCH0, 0));
+    emit_ldst_sym(st, ldst_base_scaled(w, true), rt, SCRATCH0, symop.sym, printer.MOD_PCREL_LO);
     ret encode.push_reloc(st, arm64_reloc_offset(pos), ldst_lo12_kind(w), symop.sym, symop.sym_off);
 }
 
@@ -804,7 +1326,7 @@ fun emit_global_store(st: *encode.EncodeState, symop: *mir.MirOperand, val_op: *
     val ar: R.Result[bool, str] = emit_adrp_reloc(st, SCRATCH0, symop.sym, symop.sym_off);
     if (R.is_err[bool, str](ar)) { ret ar; }
     val pos: u32 = st.buf.len::u32;
-    emit_word(st, pack_ldst(ldst_base_scaled(w, false), rt, SCRATCH0, 0));
+    emit_ldst_sym(st, ldst_base_scaled(w, false), rt, SCRATCH0, symop.sym, printer.MOD_PCREL_LO);
     ret encode.push_reloc(st, arm64_reloc_offset(pos), ldst_lo12_kind(w), symop.sym, symop.sym_off);
 }
 
@@ -816,7 +1338,7 @@ fun emit_global_store(st: *encode.EncodeState, symop: *mir.MirOperand, val_op: *
 # it with the `ldr :got_lo12:` low half that dereferences the slot
 fun emit_adrp_got_reloc(st: *encode.EncodeState, rd: u32, sym: intern.StrId) R.Result[bool, str] {
     val pos: u32 = st.buf.len::u32;
-    emit_word(st, pack_adrp(rd));
+    emit_adrp(st, rd, sym, printer.MOD_GOT_HI);
     ret encode.push_reloc(st, arm64_reloc_offset(pos), of.RK_GOT_PAGE21, sym, 0);
 }
 
@@ -833,7 +1355,7 @@ fun emit_global_addr_got(st: *encode.EncodeState, rd: u32, symop: *mir.MirOperan
     val ar: R.Result[bool, str] = emit_adrp_got_reloc(st, rd, symop.sym);
     if (R.is_err[bool, str](ar)) { ret ar; }
     val pos: u32 = st.buf.len::u32;
-    emit_word(st, pack_ldst(ldst_base_scaled(8, true), rd, rd, 0));
+    emit_ldst_sym(st, ldst_base_scaled(8, true), rd, rd, symop.sym, printer.MOD_GOT_LO);
     val pr: R.Result[bool, str] = encode.push_reloc(st, arm64_reloc_offset(pos), of.RK_GOT_LO12, symop.sym, 0);
     if (R.is_err[bool, str](pr)) { ret pr; }
     if (symop.sym_off != 0) { emit_add_imm(st, rd, rd, symop.sym_off::i64); }
@@ -895,12 +1417,12 @@ fun encode_call(st: *encode.EncodeState, mi: *mir.MirInstr) R.Result[bool, str] 
             ret R.err[bool, str]("encode: direct call has no resolved symbol name");
         }
         val pos: u32 = st.buf.len::u32;
-        emit_word(st, BL_BASE);
+        emit_branch_sym(st, BL_BASE, callee.sym);
         ret encode.push_reloc(st, arm64_reloc_offset(pos), of.RK_PLT32, callee.sym, callee.sym_off);
     }
     val rr: R.Result[i32, str] = req_gpr(callee);
     if (R.is_err[i32, str](rr)) { ret R.err[bool, str](R.unwrap_err[i32, str](rr)); }
-    emit_word(st, pack_blr(R.unwrap_ok[i32, str](rr)::u32));
+    emit_branch_reg(st, BLR_BASE, R.unwrap_ok[i32, str](rr)::u32);
     ret R.ok[bool, str](true);
 }
 
@@ -926,7 +1448,7 @@ fun encode_alu3(st: *encode.EncodeState, mi: *mir.MirInstr, base_x: u32, base_w:
     if (R.is_err[i32, str](rmr)) { ret R.err[bool, str](R.unwrap_err[i32, str](rmr)); }
     val rm: u32 = R.unwrap_ok[i32, str](rmr)::u32;
 
-    emit_word(st, pack_alu3(sel(use64, base_x, base_w), rd, rn, rm));
+    emit_alu3(st, sel(use64, base_x, base_w), rd, rn, rm);
     ret R.ok[bool, str](true);
 }
 
@@ -952,13 +1474,13 @@ fun encode_addsub(st: *encode.EncodeState, mi: *mir.MirInstr, is_sub: bool) R.Re
         if (v >= 0 && v <= 4095) {
             var base_i: u32 = sel(use64, ADDI_X, ADDI_W);
             if (is_sub) { base_i = sel(use64, SUBI_X, SUBI_W); }
-            emit_word(st, pack_addsub_imm(base_i, rd, rn, v::u32, 0));
+            emit_addsub_imm(st, base_i, rd, rn, v::u32, 0);
             ret R.ok[bool, str](true);
         }
         if (v > 0 && (v & 0xFFF) == 0 && (v >> 12) <= 4095) {
             var base_i: u32 = sel(use64, ADDI_X, ADDI_W);
             if (is_sub) { base_i = sel(use64, SUBI_X, SUBI_W); }
-            emit_word(st, pack_addsub_imm(base_i, rd, rn, (v >> 12)::u32, 1));
+            emit_addsub_imm(st, base_i, rd, rn, (v >> 12)::u32, 1);
             ret R.ok[bool, str](true);
         }
     }
@@ -968,7 +1490,7 @@ fun encode_addsub(st: *encode.EncodeState, mi: *mir.MirInstr, is_sub: bool) R.Re
     val rm: u32 = R.unwrap_ok[i32, str](rmr)::u32;
     var base_r: u32 = sel(use64, ADD_X, ADD_W);
     if (is_sub) { base_r = sel(use64, SUB_X, SUB_W); }
-    emit_word(st, pack_alu3(base_r, rd, rn, rm));
+    emit_alu3(st, base_r, rd, rn, rm);
     ret R.ok[bool, str](true);
 }
 
@@ -996,14 +1518,14 @@ fun encode_shift(st: *encode.EncodeState, mi: *mir.MirInstr, kind: u32) R.Result
         if (kind == arm64.LSL::u32) {
             val immr: u32 = (width_bits - sh) & (width_bits - 1);
             val imms: u32 = (width_bits - 1) - sh;
-            emit_word(st, pack_bitfield(sel(use64, UBFM_X, UBFM_W), rd, rn, immr, imms));
+            emit_bitfield(st, sel(use64, UBFM_X, UBFM_W), rd, rn, immr, imms);
             ret R.ok[bool, str](true);
         }
         if (kind == arm64.LSR::u32) {
-            emit_word(st, pack_bitfield(sel(use64, UBFM_X, UBFM_W), rd, rn, sh, width_bits - 1));
+            emit_bitfield(st, sel(use64, UBFM_X, UBFM_W), rd, rn, sh, width_bits - 1);
             ret R.ok[bool, str](true);
         }
-        emit_word(st, pack_bitfield(sel(use64, SBFM_X, SBFM_W), rd, rn, sh, width_bits - 1));
+        emit_bitfield(st, sel(use64, SBFM_X, SBFM_W), rd, rn, sh, width_bits - 1);
         ret R.ok[bool, str](true);
     }
 
@@ -1013,7 +1535,7 @@ fun encode_shift(st: *encode.EncodeState, mi: *mir.MirInstr, kind: u32) R.Result
     var base_x: u32 = LSLV_X; var base_w: u32 = LSLV_W;
     if (kind == arm64.LSR::u32) { base_x = LSRV_X; base_w = LSRV_W; }
     or (kind == arm64.ASR::u32) { base_x = ASRV_X; base_w = ASRV_W; }
-    emit_word(st, pack_alu3(sel(use64, base_x, base_w), rd, rn, rm));
+    emit_alu3(st, sel(use64, base_x, base_w), rd, rn, rm);
     ret R.ok[bool, str](true);
 }
 
@@ -1031,7 +1553,7 @@ fun encode_neg_mvn(st: *encode.EncodeState, mi: *mir.MirInstr, base_x: u32, base
     if (R.is_err[i32, str](rmr)) { ret R.err[bool, str](R.unwrap_err[i32, str](rmr)); }
     val rm: u32 = R.unwrap_ok[i32, str](rmr)::u32;
 
-    emit_word(st, pack_alu3(sel(use64, base_x, base_w), rd, ZR, rm));
+    emit_alu3(st, sel(use64, base_x, base_w), rd, ZR, rm);
     ret R.ok[bool, str](true);
 }
 
@@ -1073,7 +1595,7 @@ fun encode_mov(st: *encode.EncodeState, f: *mir.MirFunction, mi: *mir.MirInstr) 
     val rmr: R.Result[i32, str] = req_gpr(src);
     if (R.is_err[i32, str](rmr)) { ret R.err[bool, str](R.unwrap_err[i32, str](rmr)); }
     val rm: u32 = R.unwrap_ok[i32, str](rmr)::u32;
-    emit_word(st, pack_alu3(sel(use64, ORR_X, ORR_W), rd, ZR, rm));
+    emit_alu3(st, sel(use64, ORR_X, ORR_W), rd, ZR, rm);
     ret R.ok[bool, str](true);
 }
 
@@ -1207,11 +1729,11 @@ fun encode_addr(st: *encode.EncodeState, f: *mir.MirFunction, mi: *mir.MirInstr)
         ret R.ok[bool, str](true);
     }
     if (m.off == 0) {
-        emit_word(st, pack_alu3_sh(ADD_X, rd, m.base, m.index, scale_shift(m.scale)));
+        emit_alu3_sh(st, ADD_X, rd, m.base, m.index, scale_shift(m.scale));
         ret R.ok[bool, str](true);
     }
     emit_add_imm(st, rd, m.base, m.off);
-    emit_word(st, pack_alu3_sh(ADD_X, rd, rd, m.index, scale_shift(m.scale)));
+    emit_alu3_sh(st, ADD_X, rd, rd, m.index, scale_shift(m.scale));
     ret R.ok[bool, str](true);
 }
 
@@ -1241,31 +1763,31 @@ fun encode_convert(st: *encode.EncodeState, mi: *mir.MirInstr) R.Result[bool, st
     val rs: u32 = R.unwrap_ok[i32, str](rsr)::u32;
 
     if (mi.opcode == mir.MIR_TRUNC) {
-        emit_word(st, pack_alu3(ORR_W, rd, ZR, rs));
+        emit_alu3(st, ORR_W, rd, ZR, rs);
         ret R.ok[bool, str](true);
     }
     if (mi.opcode == mir.MIR_BITCAST) {
-        emit_word(st, pack_alu3(sel(is64(dw), ORR_X, ORR_W), rd, ZR, rs));
+        emit_alu3(st, sel(is64(dw), ORR_X, ORR_W), rd, ZR, rs);
         ret R.ok[bool, str](true);
     }
     if (mi.opcode == mir.MIR_SEXT) {
         if (sw >= 8) {
-            emit_word(st, pack_alu3(ORR_X, rd, ZR, rs));
+            emit_alu3(st, ORR_X, rd, ZR, rs);
             ret R.ok[bool, str](true);
         }
         val imms: u32 = (sw::u32 * 8) - 1;
-        emit_word(st, pack_bitfield(sel(is64(dw), SBFM_X, SBFM_W), rd, rs, 0, imms));
+        emit_bitfield(st, sel(is64(dw), SBFM_X, SBFM_W), rd, rs, 0, imms);
         ret R.ok[bool, str](true);
     }
     # MIR_ZEXT: a 32->64 (or wider source) zero-extension is a 32-bit move; a
     # sub-word zero-extension is UXTB / UXTH (UBFM_W), which writes the W register
     # (zero-extending to 64).
     if (sw >= 4) {
-        emit_word(st, pack_alu3(ORR_W, rd, ZR, rs));
+        emit_alu3(st, ORR_W, rd, ZR, rs);
         ret R.ok[bool, str](true);
     }
     val imms: u32 = (sw::u32 * 8) - 1;
-    emit_word(st, pack_bitfield(UBFM_W, rd, rs, 0, imms));
+    emit_bitfield(st, UBFM_W, rd, rs, 0, imms);
     ret R.ok[bool, str](true);
 }
 
@@ -1321,15 +1843,15 @@ fun fp_mem_reg_base(use_d: bool, is_load: bool) u32 {
 fun emit_fp_mem(st: *encode.EncodeState, rt: u32, base: u32, off: i64, width: u8, is_load: bool) {
     if (width == 16) {
         if (off >= 0 && (off & 0xF) == 0 && (off >> 4) <= 4095) {
-            emit_word(st, pack_ldst(sel(is_load, LDR_Q_OFF, STR_Q_OFF), rt, base, (off >> 4)::u32));
+            emit_ldst(st, sel(is_load, LDR_Q_OFF, STR_Q_OFF), rt, base, (off >> 4)::u32);
             ret;
         }
         if (off >= -256 && off <= 255) {
-            emit_word(st, pack_ldur(sel(is_load, LDUR_Q_FP, STUR_Q_FP), rt, base, off::u32 & 0x1FF));
+            emit_ldur(st, sel(is_load, LDUR_Q_FP, STUR_Q_FP), rt, base, off::u32 & 0x1FF);
             ret;
         }
         emit_movewide_seq(st, SCRATCH0, off::u64, true);
-        emit_word(st, pack_ldst_reg(sel(is_load, LDR_Q_REG, STR_Q_REG), rt, base, SCRATCH0));
+        emit_ldst_reg(st, sel(is_load, LDR_Q_REG, STR_Q_REG), rt, base, SCRATCH0);
         ret;
     }
     val use_d: bool = width == 8;
@@ -1338,16 +1860,16 @@ fun emit_fp_mem(st: *encode.EncodeState, rt: u32, base: u32, off: i64, width: u8
     if (off >= 0) {
         val mask: i64 = (1::i64 << sh::i64) - 1;
         if ((off & mask) == 0 && (off >> sh::i64) <= 4095) {
-            emit_word(st, pack_ldst(fp_mem_scaled_base(use_d, is_load), rt, base, (off >> sh::i64)::u32));
+            emit_ldst(st, fp_mem_scaled_base(use_d, is_load), rt, base, (off >> sh::i64)::u32);
             ret;
         }
     }
     if (off >= -256 && off <= 255) {
-        emit_word(st, pack_ldur(fp_mem_unscaled_base(use_d, is_load), rt, base, off::u32 & 0x1FF));
+        emit_ldur(st, fp_mem_unscaled_base(use_d, is_load), rt, base, off::u32 & 0x1FF);
         ret;
     }
     emit_movewide_seq(st, SCRATCH0, off::u64, true);
-    emit_word(st, pack_ldst_reg(fp_mem_reg_base(use_d, is_load), rt, base, SCRATCH0));
+    emit_ldst_reg(st, fp_mem_reg_base(use_d, is_load), rt, base, SCRATCH0);
 }
 
 # store vector register `rt` to a frame-slot / pointer MEM
@@ -1396,7 +1918,7 @@ fun emit_fp_imm(st: *encode.EncodeState, vd: u32, bits: u64, width: u8) {
     emit_movewide_seq(st, SCRATCH0, bits, use64);
     var base: u32 = FMOV_S_FROM_W;
     if (use64) { base = FMOV_D_FROM_X; }
-    emit_word(st, pack_alu3(base, vd, SCRATCH0, 0));
+    emit_alu3(st, base, vd, SCRATCH0, 0);
 }
 
 # the vector register index a float source operand contributes.
@@ -1485,12 +2007,12 @@ fun encode_fp_arith(st: *encode.EncodeState, f: *mir.MirFunction, mi: *mir.MirIn
     val base: u32 = fp_arith_base(mi.opcode, dbl);
     val dst: *mir.MirOperand = ?mi.operands[0];
     if (dst.kind == mir.MIR_OP_MEM) {
-        emit_word(st, pack_alu3(base, FP_SCRATCH0, rn, rm));
+        emit_alu3(st, base, FP_SCRATCH0, rn, rm);
         ret emit_fp_slot_store(st, f, dst, FP_SCRATCH0, w);
     }
     val rdr: R.Result[i32, str] = req_vec(dst);
     if (R.is_err[i32, str](rdr)) { ret R.err[bool, str](R.unwrap_err[i32, str](rdr)); }
-    emit_word(st, pack_alu3(base, R.unwrap_ok[i32, str](rdr)::u32, rn, rm));
+    emit_alu3(st, base, R.unwrap_ok[i32, str](rdr)::u32, rn, rm);
     ret R.ok[bool, str](true);
 }
 
@@ -1549,12 +2071,12 @@ fun encode_neon(st: *encode.EncodeState, f: *mir.MirFunction, mi: *mir.MirInstr)
         val rn: u32 = R.unwrap_ok[i32, str](rnr)::u32;
         val ndst: *mir.MirOperand = ?mi.operands[0];
         if (ndst.kind == mir.MIR_OP_MEM) {
-            emit_word(st, pack_neon_2misc(VNOT, FP_SCRATCH0, rn));
+            emit_neon_2misc(st, VNOT, FP_SCRATCH0, rn);
             ret emit_fp_slot_store(st, f, ndst, FP_SCRATCH0, 16);
         }
         val rdr: R.Result[i32, str] = req_vec(ndst);
         if (R.is_err[i32, str](rdr)) { ret R.err[bool, str](R.unwrap_err[i32, str](rdr)); }
-        emit_word(st, pack_neon_2misc(VNOT, R.unwrap_ok[i32, str](rdr)::u32, rn));
+        emit_neon_2misc(st, VNOT, R.unwrap_ok[i32, str](rdr)::u32, rn);
         ret R.ok[bool, str](true);
     }
 
@@ -1582,8 +2104,8 @@ fun encode_neon(st: *encode.EncodeState, f: *mir.MirFunction, mi: *mir.MirInstr)
     if (op == arm64.VEC_CMNE::u32) {
         var eqbase: u32 = VCMEQ;
         if (is_float) { eqbase = VFCMEQ; }
-        emit_word(st, pack_neon_3same(eqbase, size, rd, rn, rm));
-        emit_word(st, pack_neon_2misc(VNOT, rd, rd));
+        emit_neon_3same(st, eqbase, size, rd, rn, rm, vl);
+        emit_neon_2misc(st, VNOT, rd, rd);
     }
     or {
         # the logical ops (AND/ORR/EOR) are byte-agnostic - the size field is part of
@@ -1591,7 +2113,7 @@ fun encode_neon(st: *encode.EncodeState, f: *mir.MirFunction, mi: *mir.MirInstr)
         # regardless of the lane width the descriptor carries.
         var eff_size: u32 = size;
         if (op == arm64.VEC_AND::u32 || op == arm64.VEC_ORR::u32 || op == arm64.VEC_EOR::u32) { eff_size = 0; }
-        emit_word(st, pack_neon_3same(neon_base(op, is_float), eff_size, rd, rn, rm));
+        emit_neon_3same(st, neon_base(op, is_float), eff_size, rd, rn, rm, vl);
     }
 
     if (to_slot) { ret emit_fp_slot_store(st, f, dst, rd, 16); }
@@ -1616,12 +2138,12 @@ fun encode_fp_neg(st: *encode.EncodeState, f: *mir.MirFunction, mi: *mir.MirInst
     if (w == 8) { base = FNEG_D; }
     val dst: *mir.MirOperand = ?mi.operands[0];
     if (dst.kind == mir.MIR_OP_MEM) {
-        emit_word(st, pack_alu3(base, FP_SCRATCH0, rn, 0));
+        emit_alu3(st, base, FP_SCRATCH0, rn, 0);
         ret emit_fp_slot_store(st, f, dst, FP_SCRATCH0, w);
     }
     val rdr: R.Result[i32, str] = req_vec(dst);
     if (R.is_err[i32, str](rdr)) { ret R.err[bool, str](R.unwrap_err[i32, str](rdr)); }
-    emit_word(st, pack_alu3(base, R.unwrap_ok[i32, str](rdr)::u32, rn, 0));
+    emit_alu3(st, base, R.unwrap_ok[i32, str](rdr)::u32, rn, 0);
     ret R.ok[bool, str](true);
 }
 
@@ -1653,8 +2175,8 @@ fun encode_fp_cmp(st: *encode.EncodeState, f: *mir.MirFunction, mi: *mir.MirInst
 
     var base: u32 = FCMP_S;
     if (w == 8) { base = FCMP_D; }
-    emit_word(st, pack_alu3(base, 0, rn, rm));
-    emit_word(st, pack_cset(CSINC_W, rd, fp_cond(cc)));
+    emit_alu3(st, base, 0, rn, rm);
+    emit_cset(st, CSINC_W, rd, fp_cond(cc));
     ret R.ok[bool, str](true);
 }
 
@@ -1708,12 +2230,12 @@ fun encode_fp_conv(st: *encode.EncodeState, f: *mir.MirFunction, mi: *mir.MirIns
         if (op == mir.MIR_FP_EXT) { base = FCVT_S2D; }
         val dst: *mir.MirOperand = ?mi.operands[0];
         if (dst.kind == mir.MIR_OP_MEM) {
-            emit_word(st, pack_alu3(base, FP_SCRATCH0, rn, 0));
+            emit_alu3(st, base, FP_SCRATCH0, rn, 0);
             ret emit_fp_slot_store(st, f, dst, FP_SCRATCH0, dw);
         }
         val rdr: R.Result[i32, str] = req_vec(dst);
         if (R.is_err[i32, str](rdr)) { ret R.err[bool, str](R.unwrap_err[i32, str](rdr)); }
-        emit_word(st, pack_alu3(base, R.unwrap_ok[i32, str](rdr)::u32, rn, 0));
+        emit_alu3(st, base, R.unwrap_ok[i32, str](rdr)::u32, rn, 0);
         ret R.ok[bool, str](true);
     }
 
@@ -1727,8 +2249,8 @@ fun encode_fp_conv(st: *encode.EncodeState, f: *mir.MirFunction, mi: *mir.MirIns
         # extend it into IP0 to a clean 32-bit value before the W-form convert.
         if (sw < 4) {
             val imms: u32 = (sw::u32 * 8) - 1;
-            if (signed) { emit_word(st, pack_bitfield(SBFM_W, SCRATCH0, gp, 0, imms)); }
-            or          { emit_word(st, pack_bitfield(UBFM_W, SCRATCH0, gp, 0, imms)); }
+            if (signed) { emit_bitfield(st, SBFM_W, SCRATCH0, gp, 0, imms); }
+            or          { emit_bitfield(st, UBFM_W, SCRATCH0, gp, 0, imms); }
             gp = SCRATCH0;
             src_x = false;
         }
@@ -1736,12 +2258,12 @@ fun encode_fp_conv(st: *encode.EncodeState, f: *mir.MirFunction, mi: *mir.MirIns
         val base: u32 = cvt_int_to_fp_base(signed, dbl, src_x);
         val dst: *mir.MirOperand = ?mi.operands[0];
         if (dst.kind == mir.MIR_OP_MEM) {
-            emit_word(st, pack_alu3(base, FP_SCRATCH0, gp, 0));
+            emit_alu3(st, base, FP_SCRATCH0, gp, 0);
             ret emit_fp_slot_store(st, f, dst, FP_SCRATCH0, dw);
         }
         val rdr: R.Result[i32, str] = req_vec(dst);
         if (R.is_err[i32, str](rdr)) { ret R.err[bool, str](R.unwrap_err[i32, str](rdr)); }
-        emit_word(st, pack_alu3(base, R.unwrap_ok[i32, str](rdr)::u32, gp, 0));
+        emit_alu3(st, base, R.unwrap_ok[i32, str](rdr)::u32, gp, 0);
         ret R.ok[bool, str](true);
     }
 
@@ -1754,7 +2276,7 @@ fun encode_fp_conv(st: *encode.EncodeState, f: *mir.MirFunction, mi: *mir.MirIns
     if (R.is_err[i32, str](rdr)) { ret R.err[bool, str](R.unwrap_err[i32, str](rdr)); }
     val rd: u32 = R.unwrap_ok[i32, str](rdr)::u32;
     val base: u32 = cvt_fp_to_int_base(signed, dw >= 8, sw == 8);
-    emit_word(st, pack_alu3(base, rd, rn, 0));
+    emit_alu3(st, base, rd, rn, 0);
     ret R.ok[bool, str](true);
 }
 
@@ -1795,7 +2317,7 @@ fun encode_fmov(st: *encode.EncodeState, f: *mir.MirFunction, mi: *mir.MirInstr)
         val rnr: R.Result[i32, str] = req_vec(src);
         if (R.is_err[i32, str](rnr)) { ret R.err[bool, str](R.unwrap_err[i32, str](rnr)); }
         val rn: u32 = R.unwrap_ok[i32, str](rnr)::u32;
-        emit_word(st, pack_neon_3same(VORR, 0, rd, rn, rn));
+        emit_neon_3same(st, VORR, 0, rd, rn, rn, mir.vec_lane_make(mir.VEC_LANE_INT, 1));
         ret R.ok[bool, str](true);
     }
 
@@ -1829,7 +2351,7 @@ fun encode_fmov(st: *encode.EncodeState, f: *mir.MirFunction, mi: *mir.MirInstr)
             if (R.is_err[i32, str](rnr)) { ret R.err[bool, str](R.unwrap_err[i32, str](rnr)); }
             var base: u32 = FMOV_S;
             if (dbl) { base = FMOV_D; }
-            emit_word(st, pack_alu3(base, R.unwrap_ok[i32, str](rdr)::u32, R.unwrap_ok[i32, str](rnr)::u32, 0));
+            emit_alu3(st, base, R.unwrap_ok[i32, str](rdr)::u32, R.unwrap_ok[i32, str](rnr)::u32, 0);
             ret R.ok[bool, str](true);
         }
         if (dvec) {
@@ -1840,7 +2362,7 @@ fun encode_fmov(st: *encode.EncodeState, f: *mir.MirFunction, mi: *mir.MirInstr)
             if (R.is_err[i32, str](rnr)) { ret R.err[bool, str](R.unwrap_err[i32, str](rnr)); }
             var base: u32 = FMOV_S_FROM_W;
             if (dbl) { base = FMOV_D_FROM_X; }
-            emit_word(st, pack_alu3(base, R.unwrap_ok[i32, str](rdr)::u32, R.unwrap_ok[i32, str](rnr)::u32, 0));
+            emit_alu3(st, base, R.unwrap_ok[i32, str](rdr)::u32, R.unwrap_ok[i32, str](rnr)::u32, 0);
             ret R.ok[bool, str](true);
         }
         if (svec) {
@@ -1851,7 +2373,7 @@ fun encode_fmov(st: *encode.EncodeState, f: *mir.MirFunction, mi: *mir.MirInstr)
             if (R.is_err[i32, str](rnr)) { ret R.err[bool, str](R.unwrap_err[i32, str](rnr)); }
             var base: u32 = FMOV_W_FROM_S;
             if (dbl) { base = FMOV_X_FROM_D; }
-            emit_word(st, pack_alu3(base, R.unwrap_ok[i32, str](rdr)::u32, R.unwrap_ok[i32, str](rnr)::u32, 0));
+            emit_alu3(st, base, R.unwrap_ok[i32, str](rdr)::u32, R.unwrap_ok[i32, str](rnr)::u32, 0);
             ret R.ok[bool, str](true);
         }
         ret R.err[bool, str]("encode: fmov names two general-purpose registers");
@@ -1944,8 +2466,8 @@ fun narrow_cmp_source(st: *encode.EncodeState, reg: u32, scratch: u32, width: u8
     # would compute a shift past the register width / an unallocated bitfield).
     if (width == 0 || width >= 4) { ret reg; }
     val imms: u32 = (width::u32 * 8) - 1;
-    if (signed) { emit_word(st, pack_bitfield(SBFM_W, scratch, reg, 0, imms)); }  # sxtb/sxth
-    or          { emit_word(st, pack_bitfield(UBFM_W, scratch, reg, 0, imms)); }  # uxtb/uxth
+    if (signed) { emit_bitfield(st, SBFM_W, scratch, reg, 0, imms); }  # sxtb/sxth
+    or          { emit_bitfield(st, UBFM_W, scratch, reg, 0, imms); }  # uxtb/uxth
     ret scratch;
 }
 
@@ -2007,13 +2529,13 @@ fun emit_flag_cmp(st: *encode.EncodeState, lhs_op: *mir.MirOperand, rhs_op: *mir
 
     val rhs_val: i64 = cmp_imm_value(rhs_op.imm, width, signed);
     if (rhs_op.kind == mir.MIR_OP_IMM && rhs_val >= 0 && rhs_val <= 4095) {
-        emit_word(st, pack_cmp_imm(sel(use64, SUBS_IMM_X, SUBS_IMM_W), rn, rhs_val::u32));
+        emit_addsub_imm(st, sel(use64, SUBS_IMM_X, SUBS_IMM_W), ZR, rn, rhs_val::u32, 0);
     } or {
         val rmr: R.Result[i32, str] = resolve_source(st, rhs_op, SCRATCH0, use64);
         if (R.is_err[i32, str](rmr)) { ret R.err[bool, str](R.unwrap_err[i32, str](rmr)); }
         var rm: u32 = R.unwrap_ok[i32, str](rmr)::u32;
         rm = narrow_cmp_source(st, rm, SCRATCH0, width, signed);
-        emit_word(st, pack_cmp_reg(sel(use64, SUBS_REG_X, SUBS_REG_W), rn, rm));
+        emit_alu3(st, sel(use64, SUBS_REG_X, SUBS_REG_W), ZR, rn, rm);
     }
     ret R.ok[bool, str](true);
 }
@@ -2033,7 +2555,7 @@ fun encode_compare(st: *encode.EncodeState, mi: *mir.MirInstr) R.Result[bool, st
     val rc: R.Result[bool, str] = emit_flag_cmp(st, ?mi.operands[1], ?mi.operands[2], mi.width, mir.is_signed_cmp(mi.opcode));
     if (R.is_err[bool, str](rc)) { ret rc; }
 
-    emit_word(st, pack_cset(CSINC_W, rd, cmp_cond(mi.opcode)));
+    emit_cset(st, CSINC_W, rd, cmp_cond(mi.opcode));
     ret R.ok[bool, str](true);
 }
 
@@ -2049,7 +2571,7 @@ fun encode_branch(st: *encode.EncodeState, fn_base: u32, mi: *mir.MirInstr) R.Re
     # through with no word emitted (issue #1936).
     if (encode.branch_falls_through(st, target_block)) { ret R.ok[bool, str](true); }
     val patch_pos: u32 = st.buf.len::u32;
-    emit_word(st, B_BASE);
+    emit_branch_block(st, B_BASE, 0, false, target_block);
     val next_ip: u32 = st.buf.len::u32;
     ret encode.push_fixup(st, patch_pos, next_ip, target_block, fn_base);
 }
@@ -2073,7 +2595,7 @@ fun encode_cbr(st: *encode.EncodeState, fn_base: u32, mi: *mir.MirInstr) R.Resul
     val cond: u32 = R.unwrap_ok[i32, str](rcr)::u32;
 
     val cbnz_pos: u32 = st.buf.len::u32;
-    emit_word(st, pack_cbnz(sel(use64, CBNZ_X, CBNZ_W), cond));
+    emit_branch_block(st, sel(use64, CBNZ_X, CBNZ_W), cond, true, then_block);
     val cbnz_next: u32 = st.buf.len::u32;
     val f1: R.Result[bool, str] = encode.push_fixup(st, cbnz_pos, cbnz_next, then_block, fn_base);
     if (R.is_err[bool, str](f1)) { ret f1; }
@@ -2082,7 +2604,7 @@ fun encode_cbr(st: *encode.EncodeState, fn_base: u32, mi: *mir.MirInstr) R.Resul
     # order (issue #1936); the taken CBNZ above always keeps its edge.
     if (encode.branch_falls_through(st, else_block)) { ret R.ok[bool, str](true); }
     val b_pos: u32 = st.buf.len::u32;
-    emit_word(st, B_BASE);
+    emit_branch_block(st, B_BASE, 0, false, else_block);
     val b_next: u32 = st.buf.len::u32;
     ret encode.push_fixup(st, b_pos, b_next, else_block, fn_base);
 }
@@ -2134,7 +2656,7 @@ fun encode_fused_cbr(st: *encode.EncodeState, fn_base: u32, mi: *mir.MirInstr) R
 
     # B.cc then_block (a zero imm19 placeholder; pass 2 inserts the displacement).
     val bcc_pos: u32 = st.buf.len::u32;
-    emit_word(st, pack_bcond(0, fused_cbr_cond(mi.opcode)));
+    emit_branch_block(st, BCOND | (fused_cbr_cond(mi.opcode) & 0xF), 0, false, then_block);
     val bcc_next: u32 = st.buf.len::u32;
     val f1: R.Result[bool, str] = encode.push_fixup(st, bcc_pos, bcc_next, then_block, fn_base);
     if (R.is_err[bool, str](f1)) { ret f1; }
@@ -2148,7 +2670,7 @@ fun encode_fused_cbr(st: *encode.EncodeState, fn_base: u32, mi: *mir.MirInstr) R
         ret R.ok[bool, str](true);
     }
     val b_pos: u32 = st.buf.len::u32;
-    emit_word(st, B_BASE);
+    emit_branch_block(st, B_BASE, 0, false, else_block);
     val b_next: u32 = st.buf.len::u32;
     # bound any fused-condition computed-value records to this terminator's bytes.
     encode.close_cmp_varlocs(st, instr_start, st.buf.len::u32);
@@ -2199,22 +2721,22 @@ fun encode_divide(st: *encode.EncodeState, mi: *mir.MirInstr) R.Result[bool, str
     val rem:    bool = op == mir.MIR_SEL_REM_S || op == mir.MIR_SEL_REM_U;
 
     # division-by-zero trap: skip the brk (one word ahead) when the divisor is non-zero.
-    emit_word(st, pack_cbnz_off(sel(use64, CBNZ_X, CBNZ_W), rm, 2));
-    emit_word(st, BRK_BASE);
+    emit_branch_pcrel(st, sel(use64, CBNZ_X, CBNZ_W), rm, true, 2);
+    emit_imm16(st, BRK_BASE, 0);
 
     # signed-overflow (INT_MIN / -1) trap: only the signed divides can overflow.
     if (signed) {
         # cmn Rm, #1 sets Z iff Rm == -1; if not, no overflow - skip the rest (5 words).
-        emit_word(st, pack_addsub_imm(sel(use64, ADDS_IMM_X, ADDS_IMM_W), ZR, rm, 1, 0));
-        emit_word(st, pack_bcond(5, CC_NE));
+        emit_addsub_imm(st, sel(use64, ADDS_IMM_X, ADDS_IMM_W), ZR, rm, 1, 0);
+        emit_branch_pcrel(st, BCOND | CC_NE, 0, false, 5);
         # IP1 = INT_MIN for this width (a single MOVZ: 0x80000000 W / 0x8000000000000000
         # X); cmp Rn, IP1 sets Z iff the dividend is INT_MIN - then the brk (2 words).
         var hw: u32 = 1;
         if (use64) { hw = 3; }
-        emit_word(st, pack_movewide(sel(use64, MOVZ_X, MOVZ_W), SCRATCH1, hw, 0x8000));
-        emit_word(st, pack_cmp_reg(sel(use64, SUBS_REG_X, SUBS_REG_W), rn, SCRATCH1));
-        emit_word(st, pack_bcond(2, CC_NE));
-        emit_word(st, BRK_BASE);
+        emit_movewide(st, sel(use64, MOVZ_X, MOVZ_W), SCRATCH1, hw, 0x8000);
+        emit_alu3(st, sel(use64, SUBS_REG_X, SUBS_REG_W), ZR, rn, SCRATCH1);
+        emit_branch_pcrel(st, BCOND | CC_NE, 0, false, 2);
+        emit_imm16(st, BRK_BASE, 0);
     }
 
     # the divide base (SDIV signed / UDIV unsigned) for this form.
@@ -2223,12 +2745,12 @@ fun encode_divide(st: *encode.EncodeState, mi: *mir.MirInstr) R.Result[bool, str
 
     if (rem) {
         # remainder: the quotient lands in IP0, then `msub Rd, IP0, Rm, Rn`.
-        emit_word(st, pack_alu3(sel(use64, dbase_x, dbase_w), SCRATCH0, rn, rm));
-        emit_word(st, pack_madd(sel(use64, MSUB_X, MSUB_W), rd, SCRATCH0, rm, rn));
+        emit_alu3(st, sel(use64, dbase_x, dbase_w), SCRATCH0, rn, rm);
+        emit_madd(st, sel(use64, MSUB_X, MSUB_W), rd, SCRATCH0, rm, rn);
         ret R.ok[bool, str](true);
     }
     # quotient: Rd = Rn / Rm.
-    emit_word(st, pack_alu3(sel(use64, dbase_x, dbase_w), rd, rn, rm));
+    emit_alu3(st, sel(use64, dbase_x, dbase_w), rd, rn, rm);
     ret R.ok[bool, str](true);
 }
 
@@ -2270,18 +2792,18 @@ fun frame_subsize(f: *mir.MirFunction) u32 {
 # (`SUB SP, SP, X16`, the extended-register form SP requires). `subsize` is non-zero
 fun emit_sp_sub(st: *encode.EncodeState, subsize: u32) {
     if (subsize <= 0xFFF) {
-        emit_word(st, pack_addsub_imm(SUBI_X, ZR, ZR, subsize, 0));
+        emit_addsub_imm(st, SUBI_X, ZR, ZR, subsize, 0);
         ret;
     }
     if (subsize <= MAX_FRAME_SUB) {
         val hi: u32 = subsize >> 12;
         val lo: u32 = subsize & 0xFFF;
-        emit_word(st, pack_addsub_imm(SUBI_X, ZR, ZR, hi, 1));
-        if (lo != 0) { emit_word(st, pack_addsub_imm(SUBI_X, ZR, ZR, lo, 0)); }
+        emit_addsub_imm(st, SUBI_X, ZR, ZR, hi, 1);
+        if (lo != 0) { emit_addsub_imm(st, SUBI_X, ZR, ZR, lo, 0); }
         ret;
     }
     emit_movewide_seq(st, SCRATCH0, subsize::u64, true);
-    emit_word(st, SUB_SP_REG_X | ((SCRATCH0 & 0x1F) << 16));
+    emit_alu3(st, SUB_SP_REG_X, ZR, ZR, SCRATCH0);
 }
 
 # the AArch64 record-at-top prologue. `STP X29, X30, [SP, #-16]!`
@@ -2294,8 +2816,8 @@ fun emit_sp_sub(st: *encode.EncodeState, subsize: u32) {
 # with no frame) the `SUB SP` and the callee-save stores are skipped, so the output is
 # byte-identical to Phase 2b's `stp ; mov x29, sp`
 fun emit_prologue(st: *encode.EncodeState, f: *mir.MirFunction, subsize: u32) {
-    emit_word(st, pack_ldstp(STP_PRE_X, 29, 30, ZR, (0::u32 - 2) & 0x7F));
-    emit_word(st, pack_addsub_imm(ADDI_X, 29, ZR, 0, 0));
+    emit_ldstp(st, STP_PRE_X, 29, 30, ZR, (0::u32 - 2) & 0x7F);
+    emit_addsub_imm(st, ADDI_X, 29, ZR, 0, 0);
     if (subsize > 0) { emit_sp_sub(st, subsize); }
     save_callee_gp(st, f, true);
     save_callee_fp(st, f, true);
@@ -2312,9 +2834,9 @@ fun emit_epilogue(st: *encode.EncodeState, f: *mir.MirFunction, subsize: u32) {
     save_callee_gp(st, f, false);
     if (subsize > 0) {
         # mov sp, x29  (add sp, x29, #0)
-        emit_word(st, pack_addsub_imm(ADDI_X, ZR, 29, 0, 0));
+        emit_addsub_imm(st, ADDI_X, ZR, 29, 0, 0);
     }
-    emit_word(st, pack_ldstp(LDP_POST_X, 29, 30, ZR, 2));
+    emit_ldstp(st, LDP_POST_X, 29, 30, ZR, 2);
 }
 
 # save (or restore) the callee-saved GP registers `callee_mask`
@@ -2360,8 +2882,8 @@ fun save_callee_gp(st: *encode.EncodeState, f: *mir.MirFunction, store: bool) {
     for (p < num_pairs) {
         val base_off: i32 = 0 - (anchor + (16 * p)::i32);
         val imm7: u32 = (base_off / 8)::u32 & 0x7F;
-        if (store) { emit_word(st, pack_ldstp(STP_OFF_X, regs[2 * p], regs[2 * p + 1], base_reg, imm7)); }
-        or         { emit_word(st, pack_ldstp(LDP_OFF_X, regs[2 * p], regs[2 * p + 1], base_reg, imm7)); }
+        if (store) { emit_ldstp(st, STP_OFF_X, regs[2 * p], regs[2 * p + 1], base_reg, imm7); }
+        or         { emit_ldstp(st, LDP_OFF_X, regs[2 * p], regs[2 * p + 1], base_reg, imm7); }
         p = p + 1;
     }
     if ((n & 1) == 1) {
@@ -2404,8 +2926,8 @@ fun save_callee_fp(st: *encode.EncodeState, f: *mir.MirFunction, store: bool) {
     for (p < num_pairs) {
         val base_off: i32 = 0 - (anchor + (16 * p)::i32);
         val imm7: u32 = (base_off / 8)::u32 & 0x7F;
-        if (store) { emit_word(st, pack_ldstp(STP_OFF_D, regs[2 * p], regs[2 * p + 1], base_reg, imm7)); }
-        or         { emit_word(st, pack_ldstp(LDP_OFF_D, regs[2 * p], regs[2 * p + 1], base_reg, imm7)); }
+        if (store) { emit_ldstp(st, STP_OFF_D, regs[2 * p], regs[2 * p + 1], base_reg, imm7); }
+        or         { emit_ldstp(st, LDP_OFF_D, regs[2 * p], regs[2 * p + 1], base_reg, imm7); }
         p = p + 1;
     }
     if ((n & 1) == 1) {
@@ -2509,9 +3031,9 @@ fun encode_mir_instr(st: *encode.EncodeState, f: *mir.MirFunction, fn_base: u32,
     if (op == arm64.MOV::u16)  { ret encode_mov(st, f, mi); }
     if (op == arm64.FMOV::u16) { ret encode_fmov(st, f, mi); }
     if (op == arm64.B::u16)    { ret encode_branch(st, fn_base, mi); }
-    if (op == arm64.RET::u16)  { emit_word(st, RET_WORD); ret R.ok[bool, str](true); }
-    if (op == arm64.BRK::u16)  { emit_word(st, BRK_BASE); ret R.ok[bool, str](true); }
-    if (op == arm64.NOP::u16)  { emit_word(st, NOP_WORD); ret R.ok[bool, str](true); }
+    if (op == arm64.RET::u16)  { emit_nullary(st, RET_WORD); ret R.ok[bool, str](true); }
+    if (op == arm64.BRK::u16)  { emit_imm16(st, BRK_BASE, 0); ret R.ok[bool, str](true); }
+    if (op == arm64.NOP::u16)  { emit_nullary(st, NOP_WORD); ret R.ok[bool, str](true); }
 
     ret R.err[bool, str]("internal compiler error: unhandled opcode in arm64 encode");
 }
@@ -2558,7 +3080,15 @@ fun encode_function_arm64(st: *encode.EncodeState, f: *mir.MirFunction) R.Result
 
     val naked: bool = function_is_naked(f);
     val subsize: u32 = frame_subsize(f);
+
+    if (encode.sink_active(?st.buf)) {
+        val rh: R.Result[bool, str] = printer.note_function(?st.buf, st.interner, f);
+        if (R.is_err[bool, str](rh)) { ret rh; }
+    }
+
     if (!naked) { emit_prologue(st, f, subsize); }
+    val rp: R.Result[bool, str] = check_accounted(st, PROLOGUE_REGION);
+    if (R.is_err[bool, str](rp)) { ret rp; }
 
     var bi: u32 = 0;
     for (bi < f.block_count) {
@@ -2567,6 +3097,11 @@ fun encode_function_arm64(st: *encode.EncodeState, f: *mir.MirFunction) R.Result
         if (R.is_err[bool, str](rb)) { ret rb; }
         # this block's fallthrough successor, so its terminator can elide a jump to it.
         encode.set_fallthrough(st, f, bi);
+
+        if (encode.sink_active(?st.buf)) {
+            val rl: R.Result[bool, str] = printer.note_block(?st.buf, blk.id);
+            if (R.is_err[bool, str](rl)) { ret rl; }
+        }
 
         var ii: u32 = 0;
         for (ii < blk.instr_count) {
@@ -2584,6 +3119,8 @@ fun encode_function_arm64(st: *encode.EncodeState, f: *mir.MirFunction) R.Result
             }
             val ei: R.Result[bool, str] = encode_mir_instr(st, f, fn_base, mi);
             if (R.is_err[bool, str](ei)) { ret ei; }
+            val ra: R.Result[bool, str] = check_accounted(st, mi.opcode::u16);
+            if (R.is_err[bool, str](ra)) { ret ra; }
             ii = ii + 1;
         }
         bi = bi + 1;
@@ -2658,6 +3195,74 @@ pub fun encode_arm64(alloc: *A.Allocator, tgt: *resolved.Target, m: *mir.MirModu
     hooks.encode_function = encode_function_arm64;
     hooks.patch_branch    = patch_branch_arm64;
     ret encode.encode_driver(alloc, tgt, m, ?hooks);
+}
+
+# the pseudo-opcode `check_accounted` reports the prologue under, chosen above every
+# real A64 and MIR opcode so it cannot collide with one
+val PROLOGUE_REGION: u16 = 0xFFFF;
+
+# fail when bytes were emitted that the assembly sink never rendered
+#
+# The totality guard behind `--emit-asm` (#2187). Every byte the encoder appends must
+# be covered by an instruction notification; a gap means some emission path writes
+# bytes without rendering them, so the `.s` would silently under-report the code -
+# the exact failure mode that made the old printers untrustworthy. Naming the opcode
+# points straight at the unrendered path. Inert when no sink is attached, so an
+# object-producing encode pays nothing.
+# ---
+# st:     the shared encode state (its buffer carries the sink)
+# opcode: the opcode whose encoding left bytes unrendered, or `PROLOGUE_REGION`
+# ret:    ok(true) when every byte is accounted, or a precise error
+fun check_accounted(st: *encode.EncodeState, opcode: u16) R.Result[bool, str] {
+    val gap: usize = encode.sink_unaccounted(?st.buf);
+    if (gap == 0) { ret R.ok[bool, str](true); }
+
+    var num: [20]u8;
+    var label: str = "prologue";
+    if (opcode != PROLOGUE_REGION) {
+        val n: usize = u64_to_dec(opcode::u64, ?num[0]);
+        num[n] = 0;
+        label = (?num[0])::str;
+    }
+    ret R.err[bool, str](asm_named_err(st,
+        "--emit-asm: opcode ", label,
+        " emitted bytes the aarch64 assembly printer did not render",
+        "--emit-asm: an opcode emitted bytes the assembly printer did not render"));
+}
+
+# render `n` as base-10 digits into `dst`, returning the digit count
+fun u64_to_dec(n: u64, dst: *u8) usize {
+    if (n == 0) { dst[0] = '0'::u8; ret 1; }
+    var tmp: [20]u8;
+    var len: usize = 0;
+    var v: u64 = n;
+    for (v > 0) { tmp[len] = (v % 10)::u8 + '0'::u8; v = v / 10; len = len + 1; }
+    var k: usize = 0;
+    for (k < len) { dst[k] = tmp[len - 1 - k]; k = k + 1; }
+    ret len;
+}
+
+# encode a module and render its assembly text - the arm64 `emit_asm` entry point
+#
+# The same encode as `encode_arm64` with an `AsmSink` attached, so every line of the
+# `.s` is one machine instruction this run emitted. AArch64 renders as it emits: it
+# has no branch-relaxation pass and never calls `insert_text`, so an instruction's
+# first form is its last. `patch_branch_arm64` writes a displacement into an
+# already-emitted word without changing its length, and a branch renders its target
+# as a label rather than a displacement, so pass 2 cannot desynchronise the text from
+# the object. Matches `encode.EmitAsmFn`.
+# ---
+# alloc: allocator backing the encoder output's owned arrays
+# tgt:   resolved target; must be AArch64
+# m:     the fully-resolved MIR module (post isel / regalloc / frame)
+# out:   destination writer for the assembly text
+# ret:   the populated encode.EncoderOutput (owned arrays), or an error string
+pub fun encode_arm64_asm(alloc: *A.Allocator, tgt: *resolved.Target, m: *mir.MirModule,
+                         out: *writer.Writer) R.Result[encode.EncoderOutput, str] {
+    var hooks: encode.EncodeHooks;
+    hooks.encode_function = encode_function_arm64;
+    hooks.patch_branch    = patch_branch_arm64;
+    ret encode.encode_driver_asm(alloc, tgt, m, ?hooks, out);
 }
 
 # inline-asm assembler (Phase 3c)
@@ -3187,12 +3792,13 @@ fun asm_parse_lsl_amount(s: str, out: *u32) bool {
     ret true;
 }
 
-# intern a borrowed symbol name and record a relocation of
-# `kind` at the instruction-word start `pos` (the A64 reloc-offset convention)
-fun asm_push_sym_reloc(st: *encode.EncodeState, pos: u32, kind: of.RelocKind, name: str, name_len: usize, addend: i32) R.Result[bool, str] {
-    val r: R.Result[intern.StrId, str] = intern.intern_bytes(st.interner, name, name_len);
-    if (R.is_err[intern.StrId, str](r)) { ret R.err[bool, str](R.unwrap_err[intern.StrId, str](r)); }
-    ret encode.push_reloc(st, arm64_reloc_offset(pos), kind, R.unwrap_ok[intern.StrId, str](r), addend);
+# intern a symbol name borrowed from the inline-asm body
+#
+# The name is a region of the asm body, not a NUL-terminated string, so it is
+# interned before either the instruction notification or the relocation can name it
+# - both take the resolved id
+fun asm_intern(st: *encode.EncodeState, name: str, name_len: usize) R.Result[intern.StrId, str] {
+    ret intern.intern_bytes(st.interner, name, name_len);
 }
 
 # append the base-10 digits of `n` (at least one digit for zero)
@@ -3313,7 +3919,7 @@ fun emit_asm_mov_imm(st: *encode.EncodeState, rd: u32, value: u64, use64: bool) 
         val sh: u64 = 16::u64 * i::u64;
         val chunk: u64 = (v >> sh) & 0xFFFF;
         if ((chunk << sh) == v) {
-            emit_word(st, pack_movewide(sel(use64, MOVZ_X, MOVZ_W), rd, i, chunk::u32));
+            emit_movewide(st, sel(use64, MOVZ_X, MOVZ_W), rd, i, chunk::u32);
             ret;
         }
         i = i + 1;
@@ -3336,9 +3942,9 @@ fun emit_asm_mov(st: *encode.EncodeState, args: str) R.Result[bool, str] {
     val use64: bool = dst.is64;
     if (src.kind == ASMOP_REG) {
         if (dst.is_sp || src.is_sp) {
-            emit_word(st, pack_addsub_imm(sel(use64, ADDI_X, ADDI_W), dst.reg, src.reg, 0, 0));
+            emit_addsub_imm(st, sel(use64, ADDI_X, ADDI_W), dst.reg, src.reg, 0, 0);
         } or {
-            emit_word(st, pack_alu3(sel(use64, ORR_X, ORR_W), dst.reg, ZR, src.reg));
+            emit_alu3(st, sel(use64, ORR_X, ORR_W), dst.reg, ZR, src.reg);
         }
         ret R.ok[bool, str](true);
     }
@@ -3373,7 +3979,7 @@ fun emit_asm_movewide(st: *encode.EncodeState, args: str, is_movk: bool) R.Resul
     }
     var base: u32 = sel(rd.is64, MOVZ_X, MOVZ_W);
     if (is_movk) { base = sel(rd.is64, MOVK_X, MOVK_W); }
-    emit_word(st, pack_movewide(base, rd.reg, hw, im.imm::u32));
+    emit_movewide(st, base, rd.reg, hw, im.imm::u32);
     ret R.ok[bool, str](true);
 }
 
@@ -3399,20 +4005,23 @@ fun emit_asm_addsub(st: *encode.EncodeState, args: str, is_sub: bool) R.Result[b
         var base_i: u32 = sel(use64, ADDI_X, ADDI_W);
         if (is_sub) { base_i = sel(use64, SUBI_X, SUBI_W); }
         if (v >= 0 && v <= 4095) {
-            emit_word(st, pack_addsub_imm(base_i, rd.reg, rn.reg, v::u32, 0));
+            emit_addsub_imm(st, base_i, rd.reg, rn.reg, v::u32, 0);
             ret R.ok[bool, str](true);
         }
         if (v > 0 && (v & 0xFFF) == 0 && (v >> 12) <= 4095) {
-            emit_word(st, pack_addsub_imm(base_i, rd.reg, rn.reg, (v >> 12)::u32, 1));
+            emit_addsub_imm(st, base_i, rd.reg, rn.reg, (v >> 12)::u32, 1);
             ret R.ok[bool, str](true);
         }
         ret R.err[bool, str]("encode: inline-asm add/sub immediate is out of imm12 range");
     }
     if (op3.kind == ASMOP_LO12) {
         if (is_sub) { ret R.err[bool, str]("encode: inline-asm 'sub' has no :lo12: form"); }
+        val sr: R.Result[intern.StrId, str] = asm_intern(st, op3.name, op3.name_len);
+        if (R.is_err[intern.StrId, str](sr)) { ret R.err[bool, str](R.unwrap_err[intern.StrId, str](sr)); }
+        val sid: intern.StrId = R.unwrap_ok[intern.StrId, str](sr);
         val pos: u32 = st.buf.len::u32;
-        emit_word(st, pack_addsub_imm(sel(use64, ADDI_X, ADDI_W), rd.reg, rn.reg, 0, 0));
-        ret asm_push_sym_reloc(st, pos, of.RK_ADD_LO12, op3.name, op3.name_len, 0);
+        emit_addsub_imm_sym(st, sel(use64, ADDI_X, ADDI_W), rd.reg, rn.reg, sid, printer.MOD_PCREL_LO);
+        ret encode.push_reloc(st, arm64_reloc_offset(pos), of.RK_ADD_LO12, sid, 0);
     }
     if (op3.kind == ASMOP_REG) {
         if (rd.is_sp || rn.is_sp || op3.is_sp) {
@@ -3420,7 +4029,7 @@ fun emit_asm_addsub(st: *encode.EncodeState, args: str, is_sub: bool) R.Result[b
         }
         var base_r: u32 = sel(use64, ADD_X, ADD_W);
         if (is_sub) { base_r = sel(use64, SUB_X, SUB_W); }
-        emit_word(st, pack_alu3(base_r, rd.reg, rn.reg, op3.reg));
+        emit_alu3(st, base_r, rd.reg, rn.reg, op3.reg);
         ret R.ok[bool, str](true);
     }
     ret R.err[bool, str]("encode: malformed inline-asm add/sub operand");
@@ -3439,7 +4048,7 @@ fun emit_asm_logical(st: *encode.EncodeState, args: str, base_x: u32, base_w: u3
     if (!asm_parse_operand((?b0[0])::str, ?rd) || rd.kind != ASMOP_REG) { ret R.err[bool, str]("encode: inline-asm and/orr/eor destination must be a register"); }
     if (!asm_parse_operand((?b1[0])::str, ?rn) || rn.kind != ASMOP_REG) { ret R.err[bool, str]("encode: inline-asm and/orr/eor first source must be a register"); }
     if (!asm_parse_operand((?b2[0])::str, ?rm) || rm.kind != ASMOP_REG) { ret R.err[bool, str]("encode: inline-asm and/orr/eor immediate (bitmask) form unsupported; use a register operand"); }
-    emit_word(st, pack_alu3(sel(rd.is64, base_x, base_w), rd.reg, rn.reg, rm.reg));
+    emit_alu3(st, sel(rd.is64, base_x, base_w), rd.reg, rn.reg, rm.reg);
     ret R.ok[bool, str](true);
 }
 
@@ -3455,11 +4064,11 @@ fun emit_asm_cmp(st: *encode.EncodeState, args: str) R.Result[bool, str] {
     if (!asm_parse_operand((?b1[0])::str, ?op2))                        { ret R.err[bool, str]("encode: malformed inline-asm 'cmp' operand"); }
     val use64: bool = rn.is64;
     if (op2.kind == ASMOP_IMM && op2.imm >= 0 && op2.imm <= 4095) {
-        emit_word(st, pack_cmp_imm(sel(use64, SUBS_IMM_X, SUBS_IMM_W), rn.reg, op2.imm::u32));
+        emit_addsub_imm(st, sel(use64, SUBS_IMM_X, SUBS_IMM_W), ZR, rn.reg, op2.imm::u32, 0);
         ret R.ok[bool, str](true);
     }
     if (op2.kind == ASMOP_REG) {
-        emit_word(st, pack_cmp_reg(sel(use64, SUBS_REG_X, SUBS_REG_W), rn.reg, op2.reg));
+        emit_alu3(st, sel(use64, SUBS_REG_X, SUBS_REG_W), ZR, rn.reg, op2.reg);
         ret R.ok[bool, str](true);
     }
     ret R.err[bool, str]("encode: inline-asm 'cmp' second operand must be a register or imm12");
@@ -3478,7 +4087,7 @@ fun emit_asm_cset(st: *encode.EncodeState, args: str) R.Result[bool, str] {
     if (!asm_parse_operand((?b0[0])::str, ?rd) || rd.kind != ASMOP_REG) { ret R.err[bool, str]("encode: inline-asm 'cset' destination must be a register"); }
     var cc: u32 = 0;
     if (!asm_parse_cond((?b1[0])::str, ?cc)) { ret R.err[bool, str]("encode: inline-asm 'cset' condition is unrecognized"); }
-    emit_word(st, pack_cset(sel(rd.is64, CSINC_X, CSINC_W), rd.reg, cc));
+    emit_cset(st, sel(rd.is64, CSINC_X, CSINC_W), rd.reg, cc);
     ret R.ok[bool, str](true);
 }
 
@@ -3492,9 +4101,12 @@ fun emit_asm_adrp(st: *encode.EncodeState, args: str) R.Result[bool, str] {
     var sym: AsmOp;
     if (!asm_parse_operand((?b0[0])::str, ?rd) || rd.kind != ASMOP_REG)   { ret R.err[bool, str]("encode: inline-asm 'adrp' destination must be a register"); }
     if (!asm_parse_operand((?b1[0])::str, ?sym) || sym.kind != ASMOP_SYM) { ret R.err[bool, str]("encode: inline-asm 'adrp' target must be a symbol"); }
+    val sr: R.Result[intern.StrId, str] = asm_intern(st, sym.name, sym.name_len);
+    if (R.is_err[intern.StrId, str](sr)) { ret R.err[bool, str](R.unwrap_err[intern.StrId, str](sr)); }
+    val sid: intern.StrId = R.unwrap_ok[intern.StrId, str](sr);
     val pos: u32 = st.buf.len::u32;
-    emit_word(st, pack_adrp(rd.reg));
-    ret asm_push_sym_reloc(st, pos, of.RK_PAGE21, sym.name, sym.name_len, 0);
+    emit_adrp(st, rd.reg, sid, printer.MOD_PCREL_HI);
+    ret encode.push_reloc(st, arm64_reloc_offset(pos), of.RK_PAGE21, sid, 0);
 }
 
 # `ldr` / `str` / `ldrb` / `strb` / `ldrh` / `strh Rt, <mem>`. the
@@ -3522,12 +4134,15 @@ fun emit_asm_ldst(st: *encode.EncodeState, mnem: str, args: str) R.Result[bool, 
     }
 
     if (mem.is_lo12) {
+        val sr: R.Result[intern.StrId, str] = asm_intern(st, mem.name, mem.name_len);
+        if (R.is_err[intern.StrId, str](sr)) { ret R.err[bool, str](R.unwrap_err[intern.StrId, str](sr)); }
+        val sid: intern.StrId = R.unwrap_ok[intern.StrId, str](sr);
         val pos: u32 = st.buf.len::u32;
-        emit_word(st, pack_ldst(ldst_base_scaled(w, is_load), rt.reg, mem.base, 0));
-        ret asm_push_sym_reloc(st, pos, ldst_lo12_kind(w), mem.name, mem.name_len, 0);
+        emit_ldst_sym(st, ldst_base_scaled(w, is_load), rt.reg, mem.base, sid, printer.MOD_PCREL_LO);
+        ret encode.push_reloc(st, arm64_reloc_offset(pos), ldst_lo12_kind(w), sid, 0);
     }
     if (mem.has_index) {
-        emit_word(st, pack_ldst_reg(ldst_base_reg(w, is_load), rt.reg, mem.base, mem.index));
+        emit_ldst_reg(st, ldst_base_reg(w, is_load), rt.reg, mem.base, mem.index);
         ret R.ok[bool, str](true);
     }
     var off: i64 = 0;
@@ -3567,7 +4182,7 @@ fun emit_asm_ldstp(st: *encode.EncodeState, args: str, is_load: bool) R.Result[b
     if ((disp & 7) != 0) { ret R.err[bool, str]("encode: inline-asm stp/ldp offset must be a multiple of 8"); }
     val q: i64 = disp / 8;
     if (q < -64 || q > 63) { ret R.err[bool, str]("encode: inline-asm stp/ldp offset is out of the imm7 range"); }
-    emit_word(st, pack_ldstp(base_word, ra.reg, rb.reg, mem.base, q::u32 & 0x7F));
+    emit_ldstp(st, base_word, ra.reg, rb.reg, mem.base, q::u32 & 0x7F);
     ret R.ok[bool, str](true);
 }
 
@@ -3586,7 +4201,7 @@ fun emit_asm_ldordered(st: *encode.EncodeState, mnem: str, args: str) R.Result[b
     var base: u32 = sel(rt.is64, LDAXR_X, LDAXR_W);
     if (str_equals(mnem, "ldar")) { base = sel(rt.is64, LDAR_X, LDAR_W); }
     or (str_equals(mnem, "stlr")) { base = sel(rt.is64, STLR_X, STLR_W); }
-    emit_word(st, pack_ldst(base, rt.reg, mem.base, 0));
+    emit_ldst(st, base, rt.reg, mem.base, 0);
     ret R.ok[bool, str](true);
 }
 
@@ -3605,7 +4220,7 @@ fun emit_asm_stlxr(st: *encode.EncodeState, args: str) R.Result[bool, str] {
     if (!asm_parse_operand((?b2[0])::str, ?mem) || mem.kind != ASMOP_MEM) { ret R.err[bool, str]("encode: inline-asm stlxr address must be a memory operand"); }
     if (mem.has_index || mem.has_disp || mem.wb_pre)                      { ret R.err[bool, str]("encode: inline-asm stlxr addressing must be a bare [Xn]"); }
     val base: u32 = sel(rt.is64, STLXR_X, STLXR_W);
-    emit_word(st, pack_ldst(base, rt.reg, mem.base, 0) | ((rs.reg & 0x1F) << 16));
+    emit_stxr(st, base, rs.reg, rt.reg, mem.base);
     ret R.ok[bool, str](true);
 }
 
@@ -3617,7 +4232,7 @@ fun emit_asm_dmb(st: *encode.EncodeState, args: str) R.Result[bool, str] {
     if (n != 1)                                                    { ret R.err[bool, str]("encode: inline-asm dmb expects one barrier option"); }
     var opt: u32 = 0;
     if (!asm_barrier_option((?b0[0])::str, ?opt)) { ret R.err[bool, str]("encode: unsupported inline-asm dmb barrier option"); }
-    emit_word(st, DMB_BASE | ((opt & 0xF) << 8));
+    emit_barrier(st, opt);
     ret R.ok[bool, str](true);
 }
 
@@ -3668,11 +4283,11 @@ fun emit_asm_shift(st: *encode.EncodeState, mnem: str, args: str) R.Result[bool,
         if (kind == 0) {
             val immr: u32 = (width - sh) & (width - 1);
             val imms: u32 = (width - 1) - sh;
-            emit_word(st, pack_bitfield(sel(use64, UBFM_X, UBFM_W), rd.reg, rn.reg, immr, imms));
+            emit_bitfield(st, sel(use64, UBFM_X, UBFM_W), rd.reg, rn.reg, immr, imms);
         } or (kind == 1) {
-            emit_word(st, pack_bitfield(sel(use64, UBFM_X, UBFM_W), rd.reg, rn.reg, sh, width - 1));
+            emit_bitfield(st, sel(use64, UBFM_X, UBFM_W), rd.reg, rn.reg, sh, width - 1);
         } or {
-            emit_word(st, pack_bitfield(sel(use64, SBFM_X, SBFM_W), rd.reg, rn.reg, sh, width - 1));
+            emit_bitfield(st, sel(use64, SBFM_X, SBFM_W), rd.reg, rn.reg, sh, width - 1);
         }
         ret R.ok[bool, str](true);
     }
@@ -3680,7 +4295,7 @@ fun emit_asm_shift(st: *encode.EncodeState, mnem: str, args: str) R.Result[bool,
     var bx: u32 = LSLV_X; var bw: u32 = LSLV_W;
     if (kind == 1) { bx = LSRV_X; bw = LSRV_W; }
     or (kind == 2) { bx = ASRV_X; bw = ASRV_W; }
-    emit_word(st, pack_alu3(sel(use64, bx, bw), rd.reg, rn.reg, cnt.reg));
+    emit_alu3(st, sel(use64, bx, bw), rd.reg, rn.reg, cnt.reg);
     ret R.ok[bool, str](true);
 }
 
@@ -3688,9 +4303,10 @@ fun emit_asm_shift(st: *encode.EncodeState, mnem: str, args: str) R.Result[bool,
 # label. a backward reference patches immediately against the nearest preceding
 # definition; a forward reference is recorded and patched when its definition is
 # reached. the imm26 / imm19 insert is the shared `patch_branch_arm64`
-fun emit_asm_branch_label(st: *encode.EncodeState, labels: *AsmLabels, word: u32, number: u64, fwd: bool) R.Result[bool, str] {
+fun emit_asm_branch_label(st: *encode.EncodeState, labels: *AsmLabels, word: u32, base: u32,
+                          rt: u32, has_rt: bool, number: u64, fwd: bool) R.Result[bool, str] {
     val patch_pos: u32 = st.buf.len::u32;
-    emit_word(st, word);
+    emit_branch_local(st, word, base, rt, has_rt, number, fwd);
     if (fwd) { ret asm_label_push_ref(labels, patch_pos, number); }
     val def: O.Option[u32] = asm_label_lookup(labels, number);
     if (!O.is_some[u32](def)) {
@@ -3708,7 +4324,7 @@ fun emit_asm_b(st: *encode.EncodeState, labels: *AsmLabels, args: str) R.Result[
     var number: u64 = 0;
     var fwd: bool = false;
     if (asm_label_ref(target, ?number, ?fwd)) {
-        ret emit_asm_branch_label(st, labels, B_BASE, number, fwd);
+        ret emit_asm_branch_label(st, labels, B_BASE, B_BASE, 0, false, number, fwd);
     }
     if (str_len(target) > 0 && asm_is_digit(target[0])) {
         ret R.err[bool, str]("encode: inline-asm numeric local-label reference must be 'Nf' or 'Nb'");
@@ -3717,9 +4333,12 @@ fun emit_asm_b(st: *encode.EncodeState, labels: *AsmLabels, args: str) R.Result[
     if (!asm_parse_operand(target, ?op) || op.kind != ASMOP_SYM) {
         ret R.err[bool, str]("encode: inline-asm 'b' target must be a symbol or a numeric local label");
     }
+    val sr: R.Result[intern.StrId, str] = asm_intern(st, op.name, op.name_len);
+    if (R.is_err[intern.StrId, str](sr)) { ret R.err[bool, str](R.unwrap_err[intern.StrId, str](sr)); }
+    val sid: intern.StrId = R.unwrap_ok[intern.StrId, str](sr);
     val pos: u32 = st.buf.len::u32;
-    emit_word(st, B_BASE);
-    ret asm_push_sym_reloc(st, pos, of.RK_PLT32, op.name, op.name_len, 0);
+    emit_branch_sym(st, B_BASE, sid);
+    ret encode.push_reloc(st, arm64_reloc_offset(pos), of.RK_PLT32, sid, 0);
 }
 
 # `b.<cond> target` - a conditional branch (imm19). a numeric local
@@ -3731,7 +4350,7 @@ fun emit_asm_bcond(st: *encode.EncodeState, labels: *AsmLabels, cond: u32, args:
     var number: u64 = 0;
     var fwd: bool = false;
     if (asm_label_ref(target, ?number, ?fwd)) {
-        ret emit_asm_branch_label(st, labels, BCOND | (cond & 0xF), number, fwd);
+        ret emit_asm_branch_label(st, labels, BCOND | (cond & 0xF), BCOND | (cond & 0xF), 0, false, number, fwd);
     }
     if (str_len(target) > 0 && asm_is_digit(target[0])) {
         ret R.err[bool, str]("encode: inline-asm numeric local-label reference must be 'Nf' or 'Nb'");
@@ -3756,7 +4375,7 @@ fun emit_asm_cbr(st: *encode.EncodeState, labels: *AsmLabels, args: str, is_nz: 
     var number: u64 = 0;
     var fwd: bool = false;
     if (asm_label_ref(target, ?number, ?fwd)) {
-        ret emit_asm_branch_label(st, labels, word, number, fwd);
+        ret emit_asm_branch_label(st, labels, word, base, rt.reg, true, number, fwd);
     }
     if (str_len(target) > 0 && asm_is_digit(target[0])) {
         ret R.err[bool, str]("encode: inline-asm numeric local-label reference must be 'Nf' or 'Nb'");
@@ -3769,8 +4388,8 @@ fun emit_asm_one_reg(st: *encode.EncodeState, args: str, word_is_blr: bool) R.Re
     val s: str = asm_trim(args);
     var op: AsmOp;
     if (!asm_parse_operand(s, ?op) || op.kind != ASMOP_REG) { ret R.err[bool, str]("encode: inline-asm blr/br operand must be a register"); }
-    if (word_is_blr)                                        { emit_word(st, pack_blr(op.reg)); }
-    or { emit_word(st, BR_BASE | ((op.reg & 0x1F) << 5)); }
+    if (word_is_blr)                                        { emit_branch_reg(st, BLR_BASE, op.reg); }
+    or { emit_branch_reg(st, BR_BASE, op.reg); }
     ret R.ok[bool, str](true);
 }
 
@@ -3779,9 +4398,12 @@ fun emit_asm_bl(st: *encode.EncodeState, args: str) R.Result[bool, str] {
     val s: str = asm_trim(args);
     var op: AsmOp;
     if (!asm_parse_operand(s, ?op) || op.kind != ASMOP_SYM) { ret R.err[bool, str]("encode: inline-asm 'bl' target must be a symbol"); }
+    val sr: R.Result[intern.StrId, str] = asm_intern(st, op.name, op.name_len);
+    if (R.is_err[intern.StrId, str](sr)) { ret R.err[bool, str](R.unwrap_err[intern.StrId, str](sr)); }
+    val sid: intern.StrId = R.unwrap_ok[intern.StrId, str](sr);
     val pos: u32 = st.buf.len::u32;
-    emit_word(st, BL_BASE);
-    ret asm_push_sym_reloc(st, pos, of.RK_PLT32, op.name, op.name_len, 0);
+    emit_branch_sym(st, BL_BASE, sid);
+    ret encode.push_reloc(st, arm64_reloc_offset(pos), of.RK_PLT32, sid, 0);
 }
 
 # a single-immediate instruction whose imm16 sits at bits[20:5]
@@ -3791,17 +4413,17 @@ fun emit_asm_imm16_op(st: *encode.EncodeState, args: str, base: u32) R.Result[bo
     var op: AsmOp;
     if (!asm_parse_operand(s, ?op) || op.kind != ASMOP_IMM) { ret R.err[bool, str]("encode: inline-asm svc/brk needs an immediate"); }
     if (op.imm < 0 || op.imm > 0xFFFF)                      { ret R.err[bool, str]("encode: inline-asm svc/brk immediate is out of 16-bit range"); }
-    emit_word(st, base | ((op.imm::u32 & 0xFFFF) << 5));
+    emit_imm16(st, base, op.imm::u32);
     ret R.ok[bool, str](true);
 }
 
 # `ret` (return through x30) or `ret Xn`
 fun emit_asm_ret(st: *encode.EncodeState, args: str) R.Result[bool, str] {
     val s: str = asm_trim(args);
-    if (s[0] == 0) { emit_word(st, RET_WORD); ret R.ok[bool, str](true); }
+    if (s[0] == 0) { emit_nullary(st, RET_WORD); ret R.ok[bool, str](true); }
     var op: AsmOp;
     if (!asm_parse_operand(s, ?op) || op.kind != ASMOP_REG) { ret R.err[bool, str]("encode: inline-asm 'ret' operand must be a register"); }
-    emit_word(st, RET_BASE | ((op.reg & 0x1F) << 5));
+    emit_branch_reg(st, RET_BASE, op.reg);
     ret R.ok[bool, str](true);
 }
 
@@ -3958,7 +4580,7 @@ fun encode_asm_stmt_arm64(st: *encode.EncodeState, f: *mir.MirFunction, fn_base:
     if (!asm_first_token(tok, ?mbuf[0], 24, ?args)) { ret R.err[bool, str]("encode: inline-asm mnemonic too long"); }
     val mnem: str = (?mbuf[0])::str;
 
-    if (str_equals(mnem, "nop"))  { emit_word(st, NOP_WORD); ret R.ok[bool, str](true); }
+    if (str_equals(mnem, "nop"))  { emit_nullary(st, NOP_WORD); ret R.ok[bool, str](true); }
     if (str_equals(mnem, "ret"))  { ret emit_asm_ret(st, args); }
     if (str_equals(mnem, "svc"))  { ret emit_asm_imm16_op(st, args, SVC_BASE); }
     if (str_equals(mnem, "brk"))  { ret emit_asm_imm16_op(st, args, BRK_BASE); }
@@ -3994,7 +4616,7 @@ fun encode_asm_stmt_arm64(st: *encode.EncodeState, f: *mir.MirFunction, fn_base:
     if (str_equals(mnem, "stp"))   { ret emit_asm_ldstp(st, args, false); }
     if (str_equals(mnem, "ldp"))   { ret emit_asm_ldstp(st, args, true); }
     if (str_equals(mnem, "dmb"))   { ret emit_asm_dmb(st, args); }
-    if (str_equals(mnem, "yield")) { emit_word(st, YIELD_WORD); ret R.ok[bool, str](true); }
+    if (str_equals(mnem, "yield")) { emit_nullary(st, YIELD_WORD); ret R.ok[bool, str](true); }
     if (str_equals(mnem, "ldar") || str_equals(mnem, "stlr") || str_equals(mnem, "ldaxr")) {
         ret emit_asm_ldordered(st, mnem, args);
     }

--- a/src/lang/target/isa/arm64/encode.mach
+++ b/src/lang/target/isa/arm64/encode.mach
@@ -6804,3 +6804,81 @@ test "mach.lang.target.isa.arm64.encode:neon_vector_op_selection" {
     encode.buf_dnit(?st.buf);
     ret bad;
 }
+
+# the encoder's totality guard rejects an emission path that rendered no text
+#
+# `check_accounted` is what turns the sink's byte debt into a failed build naming
+# the opcode. Without it a path that emits bytes without notifying the printer would
+# produce a short `.s` that still looked plausible - the failure mode #2187 was filed
+# for, and the one aarch64 was worst at (0 of 65,458 instructions rendered).
+test "mach.lang.target.isa.arm64.encode.check_accounted:rejects_unrendered_bytes" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+
+    var st: encode.EncodeState;
+    st.alloc    = ?alloc;
+    st.buf      = encode.buf_init(?alloc);
+    st.interner = nil;
+
+    var sink: encode.AsmSink = encode.sink_init(nil, nil);
+    st.buf.asm = ?sink;
+
+    var bad: i32 = 0;
+
+    # a sink with nothing outstanding passes
+    if (R.is_err[bool, str](check_accounted(?st, arm64.NOP::u16))) { bad = 1; }
+
+    # a whole instruction word emitted with no notification must be rejected
+    encode.emit_u32(?st.buf, NOP_WORD);
+    if (!R.is_err[bool, str](check_accounted(?st, arm64.NOP::u16))) { bad = 1; }
+
+    # once rendered, the same state passes again
+    encode.sink_account(?st.buf);
+    if (R.is_err[bool, str](check_accounted(?st, arm64.NOP::u16))) { bad = 1; }
+
+    # and with no sink attached the guard is inert, so an object-producing encode
+    # never pays for it
+    st.buf.asm = nil;
+    encode.emit_u32(?st.buf, NOP_WORD);
+    if (R.is_err[bool, str](check_accounted(?st, arm64.NOP::u16))) { bad = 1; }
+
+    encode.buf_dnit(?st.buf);
+    ret bad;
+}
+
+# every emitter notifies the sink exactly once for the word it emitted
+#
+# The invariant the artifact rests on: one notification per emitted machine
+# instruction, never one per MIR opcode. A macro-op that expands into several words
+# emits each through its own wrapper, so the guard sees no debt at any point.
+test "mach.lang.target.isa.arm64.encode:emitters_notify_once_per_word" {
+    var alloc: A.Allocator;
+    var interner: intern.Interner;
+    var st: encode.EncodeState;
+    tasm(?st, ?alloc, ?interner);
+
+    var w: writer.Writer;
+    w.ctx     = nil;
+    w.f_write = printer.test_sink_write;
+    printer.test_sink_reset();
+
+    var sink: encode.AsmSink = encode.sink_init(?w, ?interner);
+    st.buf.asm = ?sink;
+
+    var bad: i32 = 0;
+
+    # a four-word MOVZ/MOVK materialization is four instructions, so the guard must
+    # stay clear after every one of them
+    emit_movewide_seq(?st, 0, 0x123456789ABCDEF0, true);
+    if (st.buf.len != 16)                          { bad = 1; }
+    if (encode.sink_unaccounted(?st.buf) != 0)     { bad = 1; }
+
+    # a legalization that materializes an offset then addresses through it is two
+    # instructions, both accounted
+    emit_mem_access(?st, 0, 1, 100000, 8, true);
+    if (encode.sink_unaccounted(?st.buf) != 0)     { bad = 1; }
+
+    if (sink.failed) { bad = 1; }
+    encode.buf_dnit(?st.buf);
+    ret bad;
+}

--- a/src/lang/target/isa/arm64/encode.mach
+++ b/src/lang/target/isa/arm64/encode.mach
@@ -834,7 +834,7 @@ fun emit_ldst(st: *encode.EncodeState, base: u32, rt: u32, rn: u32, imm12: u32) 
     val s: LdStShape = ldst_shape(base);
     var disp: i32 = 0;
     if (s.scale != 0 && s.scale != 255) { disp = (imm12 * s.scale)::i32; }
-    note_ldst(st, base, ?s, rt, isa.make_mem(printer.gp(rn, 8).reg, disp, -1, 0, s.w));
+    note_ldst(st, base, ?s, rt, isa.make_mem(printer.gp_id(rn), disp, -1, 0, s.w));
 }
 
 # emit a scaled unsigned-offset load / store whose displacement is a symbol's low
@@ -847,7 +847,7 @@ fun emit_ldst_sym(st: *encode.EncodeState, base: u32, rt: u32, rn: u32, sym: int
         encode.sink_fail(?st.buf, "--emit-asm: no aarch64 operand shape for an emitted load/store base word");
         ret;
     }
-    var mem: isa.Operand = isa.make_mem(printer.gp(rn, 8).reg, 0, -1, 0, s.w);
+    var mem: isa.Operand = isa.make_mem(printer.gp_id(rn), 0, -1, 0, s.w);
     mem.sym_id = sym::u32;
     var i: printer.Inst = printer.inst(printer.FORM_LDST, base);
     i.sym_mod = mod;
@@ -862,7 +862,7 @@ fun emit_ldur(st: *encode.EncodeState, base: u32, rt: u32, rn: u32, imm9: u32) {
     emit_word(st, pack_ldur(base, rt, rn, imm9));
     if (!noting(st)) { ret; }
     val s: LdStShape = ldur_shape(base);
-    note_ldst(st, base, ?s, rt, isa.make_mem(printer.gp(rn, 8).reg, sign_extend_field(imm9, 9)::i32, -1, 0, s.w));
+    note_ldst(st, base, ?s, rt, isa.make_mem(printer.gp_id(rn), sign_extend_field(imm9, 9)::i32, -1, 0, s.w));
 }
 
 # emit a register-offset load / store word
@@ -870,7 +870,7 @@ fun emit_ldst_reg(st: *encode.EncodeState, base: u32, rt: u32, rn: u32, rm: u32)
     emit_word(st, pack_ldst_reg(base, rt, rn, rm));
     if (!noting(st)) { ret; }
     val s: LdStShape = ldst_reg_shape(base);
-    note_ldst(st, base, ?s, rt, isa.make_mem(printer.gp(rn, 8).reg, 0, printer.gp(rm, 8).reg, 1, s.w));
+    note_ldst(st, base, ?s, rt, isa.make_mem(printer.gp_id(rn), 0, printer.gp_id(rm), 1, s.w));
 }
 
 # emit a load / store pair word
@@ -883,7 +883,7 @@ fun emit_ldstp(st: *encode.EncodeState, base: u32, rt: u32, rt2: u32, rn: u32, i
     if (base == STP_PRE_X || base == LDP_PRE_X)   { i.flags = printer.FLAG_WB_PRE; }
     if (base == STP_POST_X || base == LDP_POST_X) { i.flags = printer.FLAG_WB_POST; }
 
-    val mem: isa.Operand = isa.make_mem(printer.gp(rn, 8).reg, (sign_extend_field(imm7, 7) * 8)::i32, -1, 0, 8);
+    val mem: isa.Operand = isa.make_mem(printer.gp_id(rn), (sign_extend_field(imm7, 7) * 8)::i32, -1, 0, 8);
     val ra: isa.Operand = shaped_reg(fp, rt, 8);
     val rb: isa.Operand = shaped_reg(fp, rt2, 8);
     if (load) { i.dst = ra; i.src1 = rb; i.src2 = mem; }
@@ -908,9 +908,8 @@ fun emit_neon_2misc(st: *encode.EncodeState, base: u32, rd: u32, rn: u32) {
     emit_word(st, pack_neon_2misc(base, rd, rn));
     if (!noting(st)) { ret; }
     var i: printer.Inst = printer.inst(printer.FORM_NEON_2MISC, base);
-    i.dst      = printer.vec(rd, 16);
-    i.src1     = printer.vec(rn, 16);
-    i.vec_lane = mir.vec_lane_make(mir.VEC_LANE_INT, 1);
+    i.dst  = printer.vec(rd, 16);
+    i.src1 = printer.vec(rn, 16);
     printer.note_inst(?st.buf, ?i);
 }
 
@@ -1027,7 +1026,7 @@ fun emit_stxr(st: *encode.EncodeState, base: u32, rs: u32, rt: u32, rn: u32) {
     var i: printer.Inst = printer.inst(printer.FORM_STXR, base);
     i.dst  = printer.gp(rs, 4);
     i.src1 = printer.gp(rt, w);
-    i.src2 = isa.make_mem(printer.gp(rn, 8).reg, 0, -1, 0, w);
+    i.src2 = isa.make_mem(printer.gp_id(rn), 0, -1, 0, w);
     printer.note_inst(?st.buf, ?i);
 }
 

--- a/src/lang/target/isa/arm64/printer.mach
+++ b/src/lang/target/isa/arm64/printer.mach
@@ -232,7 +232,16 @@ pub fun none_operand() isa.Operand {
 # bytes: the operand width in bytes (4 for a W register, 8 for an X register)
 # ret:   the operand
 pub fun gp(n: u32, bytes: u8) isa.Operand {
-    ret isa.make_reg(isa.regid_make(isa.REG_CLASS_ID_GP, (n & 0x1F)::i32), bytes);
+    ret isa.make_reg(gp_id(n), bytes);
+}
+
+# the composite id of a general-purpose register, for a memory operand's base or
+# index - which carry a register id rather than a whole operand
+# ---
+# n:   the register index
+# ret: the composite register id
+pub fun gp_id(n: u32) i32 {
+    ret isa.regid_make(isa.REG_CLASS_ID_GP, (n & 0x1F)::i32);
 }
 
 # a float / vector register operand at `bytes` width
@@ -1711,20 +1720,20 @@ test "mach.lang.target.isa.arm64.printer.render_inst:disassembler_aliases" {
     # a pre-index pair writes its base back; a post-index pair offsets after
     var i17: Inst = inst(FORM_LDSTP, 0xA9800000);
     i17.flags = FLAG_WB_PRE;
-    i17.dst = isa.make_mem(gp(31, 8).reg, -16, -1, 0, 8);
+    i17.dst = isa.make_mem(gp_id(31), -16, -1, 0, 8);
     i17.src1 = gp(29, 8); i17.src2 = gp(30, 8);
     bad = bad | rendered_is(?buf, ?i17, "stp x29, x30, [sp, #-0x10]!");
 
     var i18: Inst = inst(FORM_LDSTP, 0xA8C00000);
     i18.flags = FLAG_WB_POST;
     i18.dst = gp(29, 8); i18.src1 = gp(30, 8);
-    i18.src2 = isa.make_mem(gp(31, 8).reg, 16, -1, 0, 8);
+    i18.src2 = isa.make_mem(gp_id(31), 16, -1, 0, 8);
     bad = bad | rendered_is(?buf, ?i18, "ldp x29, x30, [sp], #0x10");
 
     # a store names its source register first, though the memory operand is the
     # location written
     var i19: Inst = inst(FORM_LDST, 0xF9000000);
-    i19.dst = isa.make_mem(gp(1, 8).reg, 8, -1, 0, 8);
+    i19.dst = isa.make_mem(gp_id(1), 8, -1, 0, 8);
     i19.src1 = gp(0, 8);
     bad = bad | rendered_is(?buf, ?i19, "str x0, [x1, #0x8]");
 

--- a/src/lang/target/isa/arm64/printer.mach
+++ b/src/lang/target/isa/arm64/printer.mach
@@ -1,39 +1,1546 @@
-# AArch64 assembly text printer - not yet implemented
+# AArch64 assembly text printer - renders the encoder's own instruction stream
 #
-# `--emit-asm` renders its text from the encoder's own instruction stream: the ISA
-# runs its ordinary encoder with an `encode.AsmSink` attached and notifies the sink
-# once per machine instruction emitted, so a `.s` line is an instruction the
-# encoder really produced. x86-64 does this today (see `isa.x64.printer`); AArch64
-# does not yet, and is tracked by briar-systems/mach#2194.
+# This is the text half of the arm64 ISA's `emit_asm` operation. It does NOT walk
+# the MIR: `encode.encode_arm64_asm` runs the ordinary encoder with an `enc.AsmSink`
+# attached, and the encoder calls `note_inst` once for every machine instruction it
+# emits, immediately after emitting it. Each line of the `.s` is therefore one
+# instruction the encoder really produced, in the order it produced it.
 #
-# Until then this refuses, and the ISA registers it rather than leaving the vtable
-# slot nil. Nil was the previous behaviour and it was the worst of the options:
-# the dispatcher treated a missing printer as a clean no-op, but the caller had
-# already created the `.s`, so `--emit-asm` left behind an empty file that claimed
-# to be the emitted code and reported nothing (#2187).
+# AArch64 packs an instruction into a single 32-bit word before it reaches the byte
+# sink, so a printer reading the sink would need a disassembler. It does not read
+# the sink: the encoder's bitfield-class packers (`pack_alu3`, `pack_addsub_imm`,
+# `pack_ldst`, ...) receive every field as an argument, and the emitter that wraps
+# each packer forwards those same fields here. The structure was never absent, only
+# discarded one layer too early; capturing it at the packers costs no decode.
+#
+# The mnemonic and every alias a disassembler prints - `mov` for `orr Rd, XZR, Rm`,
+# `cmp` for `subs XZR, ...`, `lsr` / `uxtb` / `sxtw` for the bitfield moves - are
+# derived from the base word the encoder packed and the fields it packed into it, so
+# a line corresponds to the object line for line. The one thing no machine field can
+# carry is a name: a branch's target block, a call's symbol, and a relocation's
+# symbol ride the notification explicitly.
+#
+# An unmapped base word, or an operand shape that does not render, is a hard error
+# naming the failure. Silent degradation is what let the previous divergence go
+# unnoticed (#2187), so there is no fallback text anywhere in this module.
+#
+# RELATION TO `isa.Inst` - the shared instruction value (#2212, #2214)
+#
+# `Inst` below is field-for-field `isa.Inst` with one substitution: `base` (the 32-bit
+# packer base word) stands where `opcode` (a u16 abstract identifier) does. The
+# operand payloads ARE the shared `isa.Operand` - register, immediate, memory
+# base+index+scale+disp, block label and symbol all map 1:1 - and the slots are
+# SEMANTIC, as they are on x86-64: `dst` is the location written, so a store puts its
+# memory operand there and the renderer emits AArch64's source-first order
+# explicitly rather than inferring it. Collapsing onto `isa.Inst` is then a
+# substitution of the key, not a rewrite of the payloads.
+#
+# The key is deliberately still the base word. AArch64 does not encode through
+# opcodes, and a minted u16 opcode carried ALONGSIDE the base word would be a second,
+# independent naming of the instruction riding next to the bytes - the drift #2197
+# found five instances of on x86-64. Making the opcode the single naming requires the
+# emitters to look the base word UP from it, which is #2118's format-table rewrite of
+# the encoder, not a printer change.
+#
+# Two fields this needs that `isa.Inst` gained for it (#2214): `src3`, because
+# `msub Rd, Rn, Rm, Ra` has four operands and `ubfm Rd, Rn, #immr, #imms` has two
+# immediates - and the bitfield moves are every immediate shift and every sub-word
+# extend on this target; and `vec_lane`, because `Operand.size` says 16 bytes but
+# cannot say `.4s` versus `.8h` versus `.16b`. `vec_lane` reuses the descriptor
+# `mir.MirInstr.vec_lane` already carries, so there is one lane descriptor in the
+# compiler rather than a parallel one that can fall out of step (#2037).
+#
+# `sym_mod` is the exception: the relocation modifier belongs on the operand carrying
+# the symbol, and `isa.Operand.sym_mod` with its shared `SYM_MOD_*` set is landing on
+# the riscv64 branch, which is blocked on it. Until this branch rebases onto that,
+# the modifier rides the arm64-local `MOD_*` field below - a private field on a
+# private record, extending no shared namespace.
 
+use std.format;
 use std.io.writer;
+use std.types.bool.bool;
+use std.types.bool.false;
+use std.types.bool.true;
+use std.types.char.char;
+use std.types.size.usize;
 use std.types.string.str;
 
+use O: std.types.option;
 use R: std.types.result;
 
-use A: std.allocator;
-use encode: mach.lang.be.codegen.encode;
+use enc: mach.lang.be.codegen.encode;
 use mach.lang.be.codegen.mir;
-use mach.lang.target.resolved;
+use mach.lang.intern;
+use mach.lang.target.isa;
 
-# refuse to render AArch64 assembly text, naming the tracking issue
+# a three-register data-processing word (`pack_alu3`), the CMP alias (`pack_cmp_reg`
+# emits one with Rd = XZR), and every two-register scalar-float form
+pub val FORM_ALU3: u8 = 1;
+# an ADD/SUB (immediate) word (`pack_addsub_imm`), and the CMP/CMN immediate aliases
+pub val FORM_ADDSUB_IMM: u8 = 2;
+# a bitfield-move word (`pack_bitfield`) - UBFM / SBFM and their shift / extend aliases
+pub val FORM_BITFIELD: u8 = 3;
+# a move-wide word (`pack_movewide`) - MOVZ / MOVK
+pub val FORM_MOVEWIDE: u8 = 4;
+# a multiply-add / multiply-subtract word (`pack_madd`)
+pub val FORM_MADD: u8 = 5;
+# a CSINC Rd, XZR, XZR, invert(cc) word (`pack_cset`) - the CSET alias
+pub val FORM_CSET: u8 = 6;
+# a scaled unsigned-offset (`pack_ldst`), unscaled signed-offset (`pack_ldur`), or
+# register-offset (`pack_ldst_reg`) load or store; the addressing form rides the
+# memory operand and the mnemonic rides the base word
+pub val FORM_LDST: u8 = 7;
+# a load/store-pair word (`pack_ldstp`) in its signed-offset, pre-index, and
+# post-index forms
+pub val FORM_LDSTP: u8 = 8;
+# a NEON three-register-same 128-bit word (`pack_neon_3same`)
+pub val FORM_NEON_3SAME: u8 = 9;
+# a NEON two-register-misc 128-bit word (`pack_neon_2misc`)
+pub val FORM_NEON_2MISC: u8 = 10;
+# a branch with a destination - B / BL / B.cond / CBZ / CBNZ
+pub val FORM_BRANCH: u8 = 11;
+# a register-indirect branch - BR / BLR / RET Xn
+pub val FORM_BRANCH_REG: u8 = 12;
+# an ADRP page-address word (`pack_adrp`)
+pub val FORM_ADRP: u8 = 13;
+# a whole-word instruction with no operands - RET / NOP / YIELD
+pub val FORM_NULLARY: u8 = 14;
+# a single-immediate instruction whose imm16 sits at bits[20:5] - BRK / SVC
+pub val FORM_IMM16: u8 = 15;
+# a data memory barrier (DMB), whose CRm names the barrier domain
+pub val FORM_BARRIER: u8 = 16;
+# a store-release-exclusive word, whose Rs status register rides bits[20:16]
+pub val FORM_STXR: u8 = 17;
+
+# the instruction's symbol operand carries no relocation modifier
+pub val MOD_NONE: u8 = 0;
+# the symbol's page, as `adrp Xd, sym` names it
+pub val MOD_PCREL_HI: u8 = 1;
+# the symbol's low twelve bits, as `:lo12:sym` names them
+pub val MOD_PCREL_LO: u8 = 2;
+# the symbol's GOT-slot page, as `adrp Xd, :got:sym` names it
+pub val MOD_GOT_HI: u8 = 3;
+# the symbol's GOT-slot low twelve bits, as `:got_lo12:sym` names them
+pub val MOD_GOT_LO: u8 = 4;
+
+# the four-bit condition a B.cond or CSET carries, in `flags`
+pub val FLAG_COND: u16 = 0x000F;
+# the load/store pair writes its updated base back before the access (`[Xn, #off]!`)
+pub val FLAG_WB_PRE: u16 = 0x0010;
+# the load/store pair applies its offset after the access (`[Xn], #off`)
+pub val FLAG_WB_POST: u16 = 0x0020;
+
+# the branch's destination is not named (never emitted; a branch always has one)
+pub val TGT_NONE: u8 = 0;
+# the destination is a MIR block, rendered as its local label
+pub val TGT_BLOCK: u8 = 1;
+# the destination is a symbol the linker resolves
+pub val TGT_SYM: u8 = 2;
+# the destination is a fixed word displacement resolved at emit time
+pub val TGT_PCREL: u8 = 3;
+# the destination is a forward reference to an inline-asm numeric local label
+pub val TGT_LOCAL_FWD: u8 = 4;
+# the destination is a backward reference to an inline-asm numeric local label
+pub val TGT_LOCAL_BACK: u8 = 5;
+
+# one machine instruction the encoder emitted
 #
-# The `emit_asm` entry point the arm64 ISA registers; matches
-# `be.codegen.encode.EmitAsmFn`.
+# The encoder's currency with the printer, and the AArch64 instantiation of the
+# epic's target-facing instruction value (#2212) - see the module header for its
+# exact relation to `isa.Inst`. `base` is the packer base word that names the
+# operation, `form` the operand layout it was packed into, and the operand slots are
+# `isa.Operand` values in semantic (not print) order.
 # ---
-# a:   backing allocator (unused; no encode is performed)
-# tgt: resolved compilation target
-# m:   the fully-resolved MIR module
+# base:     the packer base word, with its register / immediate fields clear
+# form:     FORM_*, the operand layout
+# dst:      the location written
+# src1:     first source operand
+# src2:     second source operand
+# src3:     third source operand - a multiply accumulator, a second bitfield
+#           immediate, or a shift amount decorating `src2`
+# flags:    FLAG_* - the condition, and the pair addressing mode
+# vec_lane: the NEON lane descriptor, in `mir.MirInstr.vec_lane`'s encoding
+# sym_mod:  MOD_*, the relocation modifier on whichever operand carries the symbol
+# target:   TGT_*, how a branch names its destination
+# block:    the destination block id, when `target` is TGT_BLOCK
+pub rec Inst {
+    base:     u32;
+    form:     u8;
+    dst:      isa.Operand;
+    src1:     isa.Operand;
+    src2:     isa.Operand;
+    src3:     isa.Operand;
+    flags:    u16;
+    vec_lane: u8;
+    sym_mod:  u8;
+    target:   u8;
+    block:    u32;
+}
+
+# an instruction of `form` built from `base`, with every operand absent
+# ---
+# form: the operand layout the emitter will fill
+# base: the packer base word
+# ret:  an empty instruction of that form
+pub fun inst(form: u8, base: u32) Inst {
+    var i: Inst;
+    i.base     = base;
+    i.form     = form;
+    i.dst      = none_operand();
+    i.src1     = none_operand();
+    i.src2     = none_operand();
+    i.src3     = none_operand();
+    i.flags    = 0;
+    i.vec_lane = 0;
+    i.sym_mod  = MOD_NONE;
+    i.target   = TGT_NONE;
+    i.block    = 0;
+    ret i;
+}
+
+# an absent operand
+#
+# `isa` builds each populated operand through its own private blank, but exposes no
+# constructor for the empty one - x86-64 clears `kind` by hand where it needs one.
+# A public `isa.make_none()` would suit both; it is deliberately not added here,
+# since three branches are live in that file.
+# ---
+# ret: an operand of kind OPK_NONE with every payload field neutral
+pub fun none_operand() isa.Operand {
+    var op: isa.Operand;
+    op.kind   = isa.OPK_NONE;
+    op.size   = 0;
+    op.reg    = -1;
+    op.imm    = 0;
+    op.base   = -1;
+    op.index  = -1;
+    op.scale  = 0;
+    op.disp   = 0;
+    op.sym_id = 0;
+    op.label  = nil;
+    ret op;
+}
+
+# a general-purpose register operand at `bytes` width
+# ---
+# n:     the register index (31 naming XZR or SP, by position)
+# bytes: the operand width in bytes (4 for a W register, 8 for an X register)
+# ret:   the operand
+pub fun gp(n: u32, bytes: u8) isa.Operand {
+    ret isa.make_reg(isa.regid_make(isa.REG_CLASS_ID_GP, (n & 0x1F)::i32), bytes);
+}
+
+# a float / vector register operand at `bytes` width
+# ---
+# n:     the register index
+# bytes: the operand width in bytes (4 for S, 8 for D, 16 for Q or a NEON vector)
+# ret:   the operand
+pub fun vec(n: u32, bytes: u8) isa.Operand {
+    ret isa.make_reg(isa.regid_make(isa.REG_CLASS_ID_XMM, (n & 0x1F)::i32), bytes);
+}
+
+# render one function's introducing header
+#
+# Emits no bytes, so it leaves the sink's byte accounting untouched.
+# ---
+# buf:      the encoder byte sink carrying the assembly sink
+# interner: resolves the function's interned name
+# f:        the function whose encoding is starting
+# ret:      true on success, or the write error
+pub fun note_function(buf: *enc.ByteBuf, interner: *intern.Interner, f: *mir.MirFunction) R.Result[bool, str] {
+    val out: *writer.Writer = buf.asm.out;
+    val res_nl: R.Result[bool, str] = emit_str(out, "\n# ");
+    if (R.is_err[bool, str](res_nl)) { ret res_nl; }
+    val res_name: R.Result[bool, str] = emit_interned(out, interner, f.name);
+    if (R.is_err[bool, str](res_name)) { ret res_name; }
+    ret emit_str(out, ":\n");
+}
+
+# render one block's local label
+#
+# Emits no bytes, so it leaves the sink's byte accounting untouched.
+# ---
+# buf: the encoder byte sink carrying the assembly sink
+# id:  the block id being entered
+# ret: true on success, or the write error
+pub fun note_block(buf: *enc.ByteBuf, id: u32) R.Result[bool, str] {
+    val out: *writer.Writer = buf.asm.out;
+    val res_dot: R.Result[bool, str] = emit_str(out, ".");
+    if (R.is_err[bool, str](res_dot)) { ret res_dot; }
+    val res_id: R.Result[bool, str] = emit_u64(out, id::u64);
+    if (R.is_err[bool, str](res_id)) { ret res_id; }
+    ret emit_str(out, ":\n");
+}
+
+# render one machine instruction the encoder just emitted
+#
+# The sink's single notification point. Renders `i`, then marks every byte emitted
+# so far as accounted; the encoder's totality guard compares that mark against the
+# buffer length after each MIR opcode, so an emission path that never reaches here
+# is reported rather than silently dropped from the artifact.
+#
+# Returns nothing: it runs on the encoder's hot path where no error can be threaded,
+# so a render failure is latched on the sink and raised by the driver.
+# ---
+# buf: the encoder byte sink carrying the assembly sink
+# i:   the machine instruction just emitted
+pub fun note_inst(buf: *enc.ByteBuf, i: *Inst) {
+    val res: R.Result[bool, str] = render_inst(buf, i);
+    if (R.is_err[bool, str](res)) {
+        enc.sink_fail(buf, R.unwrap_err[bool, str](res));
+        ret;
+    }
+    enc.sink_account(buf);
+}
+
+# render one instruction as an indented assembly line
+# ---
+# buf: the encoder byte sink carrying the assembly sink
+# i:   the instruction to render
+# ret: true on success, or the first error
+fun render_inst(buf: *enc.ByteBuf, i: *Inst) R.Result[bool, str] {
+    val out: *writer.Writer = buf.asm.out;
+    val res_indent: R.Result[bool, str] = emit_str(out, "  ");
+    if (R.is_err[bool, str](res_indent)) { ret res_indent; }
+    val res_body: R.Result[bool, str] = render_body(buf, i);
+    if (R.is_err[bool, str](res_body)) { ret res_body; }
+    ret emit_str(out, "\n");
+}
+
+# dispatch an instruction to the renderer for its operand layout
+# ---
+# buf: the encoder byte sink carrying the assembly sink
+# i:   the instruction to render
+# ret: true on success, or an error naming the unrenderable form
+fun render_body(buf: *enc.ByteBuf, i: *Inst) R.Result[bool, str] {
+    val out: *writer.Writer = buf.asm.out;
+    if (i.form == FORM_ALU3)        { ret render_alu3(buf, i); }
+    if (i.form == FORM_ADDSUB_IMM)  { ret render_addsub_imm(buf, i); }
+    if (i.form == FORM_BITFIELD)    { ret render_bitfield(buf, i); }
+    if (i.form == FORM_MOVEWIDE)    { ret render_movewide(buf, i); }
+    if (i.form == FORM_MADD)        { ret render_madd(buf, i); }
+    if (i.form == FORM_CSET)        { ret render_cset(buf, i); }
+    if (i.form == FORM_LDST)        { ret render_ldst(buf, i); }
+    if (i.form == FORM_LDSTP)       { ret render_ldstp(buf, i); }
+    if (i.form == FORM_NEON_3SAME)  { ret render_neon_3same(buf, i); }
+    if (i.form == FORM_NEON_2MISC)  { ret render_neon_2misc(buf, i); }
+    if (i.form == FORM_BRANCH)      { ret render_branch(buf, i); }
+    if (i.form == FORM_BRANCH_REG)  { ret render_branch_reg(buf, i); }
+    if (i.form == FORM_ADRP)        { ret render_adrp(buf, i); }
+    if (i.form == FORM_NULLARY)     { ret render_nullary(out, i); }
+    if (i.form == FORM_IMM16)       { ret render_imm16(buf, i); }
+    if (i.form == FORM_BARRIER)     { ret render_barrier(out, i); }
+    if (i.form == FORM_STXR)        { ret render_stxr(buf, i); }
+    ret R.err[bool, str]("--emit-asm: an emitted aarch64 instruction has no renderable form");
+}
+
+# the mnemonic a three-register data-processing base word denotes
+#
+# Total over the base words the encoder packs through `pack_alu3` / `pack_cmp_reg` /
+# `pack_alu3_sh`: an unmapped base returns nil and the caller fails the render, never
+# placeholder text. The operand widths and banks come from the operands themselves -
+# a `scvtf` naming an S destination and a W source needs no table entry to say so.
+# ---
+# base: the packer base word
+# ret:  the mnemonic, or nil for an unmapped base
+fun alu3_mnem(base: u32) str {
+    if (base == 0x8B000000 || base == 0x0B000000) { ret "add"; }
+    if (base == 0xCB000000 || base == 0x4B000000) { ret "sub"; }
+    if (base == 0x8A000000 || base == 0x0A000000) { ret "and"; }
+    if (base == 0xAA000000 || base == 0x2A000000) { ret "orr"; }
+    if (base == 0xCA000000 || base == 0x4A000000) { ret "eor"; }
+    if (base == 0xAA200000 || base == 0x2A200000) { ret "orn"; }
+    if (base == 0x9B007C00 || base == 0x1B007C00) { ret "mul"; }
+    if (base == 0x9AC02000 || base == 0x1AC02000) { ret "lsl"; }
+    if (base == 0x9AC02400 || base == 0x1AC02400) { ret "lsr"; }
+    if (base == 0x9AC02800 || base == 0x1AC02800) { ret "asr"; }
+    if (base == 0x9AC00C00 || base == 0x1AC00C00) { ret "sdiv"; }
+    if (base == 0x9AC00800 || base == 0x1AC00800) { ret "udiv"; }
+    if (base == 0xEB000000 || base == 0x6B000000) { ret "subs"; }
+    # `sub sp, sp, Xm` - the extended-register form SP requires
+    if (base == 0xCB2063FF)                       { ret "sub"; }
+
+    if (base == 0x1E202800 || base == 0x1E602800) { ret "fadd"; }
+    if (base == 0x1E203800 || base == 0x1E603800) { ret "fsub"; }
+    if (base == 0x1E200800 || base == 0x1E600800) { ret "fmul"; }
+    if (base == 0x1E201800 || base == 0x1E601800) { ret "fdiv"; }
+    if (base == 0x1E214000 || base == 0x1E614000) { ret "fneg"; }
+    if (base == 0x1E204000 || base == 0x1E604000) { ret "fmov"; }
+    if (base == 0x1E22C000 || base == 0x1E624000) { ret "fcvt"; }
+    if (base == 0x1E202000 || base == 0x1E602000) { ret "fcmp"; }
+
+    if (base == 0x1E220000 || base == 0x1E620000 ||
+        base == 0x9E220000 || base == 0x9E620000) { ret "scvtf"; }
+    if (base == 0x1E230000 || base == 0x1E630000 ||
+        base == 0x9E230000 || base == 0x9E630000) { ret "ucvtf"; }
+    if (base == 0x1E380000 || base == 0x9E380000 ||
+        base == 0x1E780000 || base == 0x9E780000) { ret "fcvtzs"; }
+    if (base == 0x1E390000 || base == 0x9E390000 ||
+        base == 0x1E790000 || base == 0x9E790000) { ret "fcvtzu"; }
+
+    if (base == 0x1E270000 || base == 0x9E670000 ||
+        base == 0x1E260000 || base == 0x9E660000) { ret "fmov"; }
+    ret nil;
+}
+
+# render a three-register data-processing word, taking the alias a disassembler
+# prints when the encoded fields select one
+#
+# `orr Rd, ZR, Rm` is `mov`, `sub Rd, ZR, Rm` is `neg`, `orn Rd, ZR, Rm` is `mvn`,
+# and a flag-setting `subs ZR, Rn, Rm` is `cmp` - each is how the instruction
+# disassembles, so rendering the base spelling would not correspond to the object.
+# The scaled-index form carries its shift in `src3`.
+# ---
+# buf: the encoder byte sink carrying the assembly sink
+# i:   the instruction to render
+# ret: true on success, or an error naming the unmapped base
+fun render_alu3(buf: *enc.ByteBuf, i: *Inst) R.Result[bool, str] {
+    val out: *writer.Writer = buf.asm.out;
+    var mnem: str = alu3_mnem(i.base);
+    if (mnem == nil) {
+        ret R.err[bool, str]("--emit-asm: no aarch64 mnemonic for an emitted three-register base word");
+    }
+
+    # the Rn = XZR aliases: a two-operand move / negate / complement
+    var drop_rn: bool = false;
+    if (is_zero_reg(?i.src1) && i.src2.kind == isa.OPK_REG) {
+        if (i.base == 0xAA000000 || i.base == 0x2A000000) { mnem = "mov"; drop_rn = true; }
+        if (i.base == 0xCB000000 || i.base == 0x4B000000) { mnem = "neg"; drop_rn = true; }
+        if (i.base == 0xAA200000 || i.base == 0x2A200000) { mnem = "mvn"; drop_rn = true; }
+    }
+    # the Rd = XZR alias: a flag-setting subtract is a compare
+    var drop_dst: bool = false;
+    if (is_zero_reg(?i.dst) && (i.base == 0xEB000000 || i.base == 0x6B000000)) {
+        mnem = "cmp";
+        drop_dst = true;
+    }
+
+    val rw: R.Result[bool, str] = emit_str(out, mnem);
+    if (R.is_err[bool, str](rw)) { ret rw; }
+
+    var n: u32 = 0;
+    if (!drop_dst) {
+        val rd: R.Result[u32, str] = render_slot(buf, i, ?i.dst, n, false);
+        if (R.is_err[u32, str](rd)) { ret unwrap_slot_err(rd); }
+        n = R.unwrap_ok[u32, str](rd);
+    }
+    if (!drop_rn) {
+        val rn: R.Result[u32, str] = render_slot(buf, i, ?i.src1, n, i.base == 0xCB2063FF);
+        if (R.is_err[u32, str](rn)) { ret unwrap_slot_err(rn); }
+        n = R.unwrap_ok[u32, str](rn);
+    }
+    val rm: R.Result[u32, str] = render_slot(buf, i, ?i.src2, n, false);
+    if (R.is_err[u32, str](rm)) { ret unwrap_slot_err(rm); }
+    n = R.unwrap_ok[u32, str](rm);
+
+    if (i.src3.kind == isa.OPK_NONE) { ret R.ok[bool, str](true); }
+    ret emit_shift(out, ?i.src3);
+}
+
+# the mnemonic an ADD/SUB (immediate) base word denotes, or nil when unmapped
+# ---
+# base: the packer base word
+# ret:  the mnemonic, or nil
+fun addsub_imm_mnem(base: u32) str {
+    if (base == 0x91000000 || base == 0x11000000) { ret "add"; }
+    if (base == 0xD1000000 || base == 0x51000000) { ret "sub"; }
+    if (base == 0xB1000000 || base == 0x31000000) { ret "adds"; }
+    if (base == 0xF1000000 || base == 0x71000000) { ret "subs"; }
+    ret nil;
+}
+
+# render an ADD/SUB (immediate) word, taking the alias a disassembler prints
+#
+# `add Rd, Rn, #0` with SP on either side is `mov` - the only move between SP and a
+# general register - and a flag-setting form writing XZR is `cmp` / `cmn`. ADD/SUB
+# name SP at register 31; ADDS/SUBS name XZR in their destination and SP in Rn.
+# ---
+# buf: the encoder byte sink carrying the assembly sink
+# i:   the instruction to render
+# ret: true on success, or an error naming the unmapped base
+fun render_addsub_imm(buf: *enc.ByteBuf, i: *Inst) R.Result[bool, str] {
+    val out: *writer.Writer = buf.asm.out;
+    val mnem: str = addsub_imm_mnem(i.base);
+    if (mnem == nil) {
+        ret R.err[bool, str]("--emit-asm: no aarch64 mnemonic for an emitted add/sub-immediate base word");
+    }
+    val flags: bool = i.base == 0xB1000000 || i.base == 0x31000000 ||
+                      i.base == 0xF1000000 || i.base == 0x71000000;
+    val plain_add: bool = i.base == 0x91000000 || i.base == 0x11000000;
+
+    # `mov Rd, Rn` - an SP-involving add of zero
+    if (plain_add && i.src2.kind == isa.OPK_IMM && i.src2.imm == 0 &&
+        i.src3.kind == isa.OPK_NONE && (is_reg31(?i.dst) || is_reg31(?i.src1))) {
+        val rm: R.Result[bool, str] = emit_str(out, "mov");
+        if (R.is_err[bool, str](rm)) { ret rm; }
+        val rd: R.Result[u32, str] = render_slot(buf, i, ?i.dst, 0, true);
+        if (R.is_err[u32, str](rd)) { ret unwrap_slot_err(rd); }
+        val rn: R.Result[u32, str] = render_slot(buf, i, ?i.src1, 1, true);
+        if (R.is_err[u32, str](rn)) { ret unwrap_slot_err(rn); }
+        ret R.ok[bool, str](true);
+    }
+
+    # `cmp` / `cmn Rn, #imm` - a flag-setting form discarding its result
+    var head: str = mnem;
+    var drop_dst: bool = false;
+    if (flags && is_zero_reg(?i.dst)) {
+        drop_dst = true;
+        head = "cmp";
+        if (i.base == 0xB1000000 || i.base == 0x31000000) { head = "cmn"; }
+    }
+
+    val rw: R.Result[bool, str] = emit_str(out, head);
+    if (R.is_err[bool, str](rw)) { ret rw; }
+    var n: u32 = 0;
+    if (!drop_dst) {
+        # ADDS / SUBS write a zero-register destination; only the plain forms name SP there
+        val rd: R.Result[u32, str] = render_slot(buf, i, ?i.dst, n, !flags);
+        if (R.is_err[u32, str](rd)) { ret unwrap_slot_err(rd); }
+        n = R.unwrap_ok[u32, str](rd);
+    }
+    val rn: R.Result[u32, str] = render_slot(buf, i, ?i.src1, n, true);
+    if (R.is_err[u32, str](rn)) { ret unwrap_slot_err(rn); }
+    n = R.unwrap_ok[u32, str](rn);
+    val ri: R.Result[u32, str] = render_slot(buf, i, ?i.src2, n, false);
+    if (R.is_err[u32, str](ri)) { ret unwrap_slot_err(ri); }
+
+    if (i.src3.kind == isa.OPK_NONE) { ret R.ok[bool, str](true); }
+    ret emit_shift(out, ?i.src3);
+}
+
+# render a bitfield-move word as the shift / extend alias it disassembles to
+#
+# Every UBFM / SBFM the encoder emits carries an alias, and the alias is what a
+# disassembler prints: `lsr` / `lsl` / `ubfx` / `ubfiz` / `uxtb` / `uxth` for UBFM,
+# `asr` / `sbfx` / `sbfiz` / `sxtb` / `sxth` / `sxtw` for SBFM. The extend aliases
+# take precedence over the extract forms, and their source is always a W register -
+# `sxtb x0, w1` widens a byte held in a 32-bit register.
+# ---
+# buf: the encoder byte sink carrying the assembly sink
+# i:   the instruction to render
+# ret: true on success, or an error naming the unmapped base
+fun render_bitfield(buf: *enc.ByteBuf, i: *Inst) R.Result[bool, str] {
+    val out: *writer.Writer = buf.asm.out;
+    var signed: bool = false;
+    var wide:   bool = false;
+    if (i.base == 0xD3400000)      { wide = true; }
+    or (i.base == 0x53000000)      { }
+    or (i.base == 0x93400000)      { wide = true; signed = true; }
+    or (i.base == 0x13000000)      { signed = true; }
+    or {
+        ret R.err[bool, str]("--emit-asm: no aarch64 mnemonic for an emitted bitfield base word");
+    }
+
+    var width: u32 = 32;
+    if (wide) { width = 64; }
+    val immr: u32 = i.src2.imm::u32;
+    val imms: u32 = i.src3.imm::u32;
+
+    # the register-extend aliases, which name a W source at either destination width
+    val extend: bool = immr == 0 && (imms == 7 || imms == 15 || (imms == 31 && wide));
+    # UXTB / UXTH exist only in the 32-bit form; a 64-bit UBFM of the same shape
+    # disassembles as the extract
+    if (extend && (signed || !wide)) {
+        var mnem: str = "uxtb";
+        if (imms == 15) { mnem = "uxth"; }
+        if (signed) {
+            mnem = "sxtb";
+            if (imms == 15) { mnem = "sxth"; }
+            if (imms == 31) { mnem = "sxtw"; }
+        }
+        val rm: R.Result[bool, str] = emit_str(out, mnem);
+        if (R.is_err[bool, str](rm)) { ret rm; }
+        val rd: R.Result[u32, str] = render_slot(buf, i, ?i.dst, 0, false);
+        if (R.is_err[u32, str](rd)) { ret unwrap_slot_err(rd); }
+        # the extend aliases always read a 32-bit source register
+        var src: isa.Operand = i.src1;
+        src.size = 4;
+        ret emit_sep_operand(buf, i, ?src, 1, false);
+    }
+
+    # a bitfield move whose high bit ends at the register top is a right shift
+    if (imms == width - 1) {
+        var mnem: str = "lsr";
+        if (signed) { mnem = "asr"; }
+        ret render_shift_alias(buf, i, mnem, immr);
+    }
+    # an unsigned bitfield move one place past its rotation is a left shift
+    if (!signed && imms + 1 == immr) {
+        ret render_shift_alias(buf, i, "lsl", width - 1 - imms);
+    }
+
+    var mnem: str = "ubfx";
+    var lsb:  u32 = immr;
+    var len:  u32 = imms - immr + 1;
+    if (imms < immr) {
+        mnem = "ubfiz";
+        lsb  = width - immr;
+        len  = imms + 1;
+    }
+    if (signed) {
+        mnem = "sbfx";
+        if (imms < immr) { mnem = "sbfiz"; }
+    }
+
+    val rm: R.Result[bool, str] = emit_str(out, mnem);
+    if (R.is_err[bool, str](rm)) { ret rm; }
+    val rd: R.Result[u32, str] = render_slot(buf, i, ?i.dst, 0, false);
+    if (R.is_err[u32, str](rd)) { ret unwrap_slot_err(rd); }
+    val rn: R.Result[u32, str] = render_slot(buf, i, ?i.src1, 1, false);
+    if (R.is_err[u32, str](rn)) { ret unwrap_slot_err(rn); }
+    val rl: R.Result[bool, str] = emit_str(out, ", ");
+    if (R.is_err[bool, str](rl)) { ret rl; }
+    val rv: R.Result[bool, str] = emit_dec_imm(out, lsb::i64);
+    if (R.is_err[bool, str](rv)) { ret rv; }
+    val rc: R.Result[bool, str] = emit_str(out, ", ");
+    if (R.is_err[bool, str](rc)) { ret rc; }
+    ret emit_dec_imm(out, len::i64);
+}
+
+# render a bitfield move as a two-register shift by a constant amount
+# ---
+# buf:  the encoder byte sink carrying the assembly sink
+# i:    the instruction to render
+# mnem: the shift alias
+# sh:   the shift amount the encoded fields denote
+# ret:  true on success, or the first write error
+fun render_shift_alias(buf: *enc.ByteBuf, i: *Inst, mnem: str, sh: u32) R.Result[bool, str] {
+    val out: *writer.Writer = buf.asm.out;
+    val rm: R.Result[bool, str] = emit_str(out, mnem);
+    if (R.is_err[bool, str](rm)) { ret rm; }
+    val rd: R.Result[u32, str] = render_slot(buf, i, ?i.dst, 0, false);
+    if (R.is_err[u32, str](rd)) { ret unwrap_slot_err(rd); }
+    val rn: R.Result[u32, str] = render_slot(buf, i, ?i.src1, 1, false);
+    if (R.is_err[u32, str](rn)) { ret unwrap_slot_err(rn); }
+    val rc: R.Result[bool, str] = emit_str(out, ", ");
+    if (R.is_err[bool, str](rc)) { ret rc; }
+    ret emit_dec_imm(out, sh::i64);
+}
+
+# render a move-wide word
+#
+# MOVZ disassembles as `mov Rd, #<value>` with its shift folded into the printed
+# immediate, except for the degenerate zero-at-a-shift form that has no such
+# spelling. MOVK keeps its name and its explicit shift, since it merges into a
+# register the printed immediate alone cannot describe.
+# ---
+# buf: the encoder byte sink carrying the assembly sink
+# i:   the instruction to render
+# ret: true on success, or an error naming the unmapped base
+fun render_movewide(buf: *enc.ByteBuf, i: *Inst) R.Result[bool, str] {
+    val out: *writer.Writer = buf.asm.out;
+    var keep: bool = false;
+    var wide: bool = false;
+    if (i.base == 0xD2800000)      { wide = true; }
+    or (i.base == 0x52800000)      { }
+    or (i.base == 0xF2800000)      { wide = true; keep = true; }
+    or (i.base == 0x72800000)      { keep = true; }
+    or {
+        ret R.err[bool, str]("--emit-asm: no aarch64 mnemonic for an emitted move-wide base word");
+    }
+
+    val imm16: u64 = i.src2.imm::u64;
+    var sh: u64 = 0;
+    if (i.src3.kind != isa.OPK_NONE) { sh = i.src3.imm::u64; }
+
+    # a plain MOVZ folds its shift into the value it materializes; the zero-at-a-shift
+    # form does not (its value is zero at every shift) and keeps the MOVZ spelling
+    val folds: bool = !keep && (imm16 != 0 || sh == 0);
+    var mnem: str = "movk";
+    if (!keep) {
+        mnem = "movz";
+        if (folds) { mnem = "mov"; }
+    }
+    val rm: R.Result[bool, str] = emit_str(out, mnem);
+    if (R.is_err[bool, str](rm)) { ret rm; }
+    val rd: R.Result[u32, str] = render_slot(buf, i, ?i.dst, 0, false);
+    if (R.is_err[u32, str](rd)) { ret unwrap_slot_err(rd); }
+    val rc: R.Result[bool, str] = emit_str(out, ", ");
+    if (R.is_err[bool, str](rc)) { ret rc; }
+
+    if (folds) {
+        var v: u64 = imm16 << sh;
+        if (!wide) { v = v & 0xFFFFFFFF; }
+        ret emit_hex_imm(out, signed_at_width(v, wide));
+    }
+    val ri: R.Result[bool, str] = emit_hex_u64_imm(out, imm16);
+    if (R.is_err[bool, str](ri)) { ret ri; }
+    if (sh == 0) { ret R.ok[bool, str](true); }
+    ret emit_shift(out, ?i.src3);
+}
+
+# render a multiply-add / multiply-subtract word
+#
+# A zero-register accumulator is the two-source alias a disassembler prints:
+# `madd Rd, Rn, Rm, ZR` is `mul` and `msub` is `mneg`.
+# ---
+# buf: the encoder byte sink carrying the assembly sink
+# i:   the instruction to render
+# ret: true on success, or an error naming the unmapped base
+fun render_madd(buf: *enc.ByteBuf, i: *Inst) R.Result[bool, str] {
+    val out: *writer.Writer = buf.asm.out;
+    var sub: bool = false;
+    if (i.base == 0x9B000000 || i.base == 0x1B000000)      { }
+    or (i.base == 0x9B008000 || i.base == 0x1B008000)      { sub = true; }
+    or {
+        ret R.err[bool, str]("--emit-asm: no aarch64 mnemonic for an emitted multiply-accumulate base word");
+    }
+    val degenerate: bool = is_zero_reg(?i.src3);
+    var mnem: str = "madd";
+    if (sub) { mnem = "msub"; }
+    if (degenerate) {
+        mnem = "mul";
+        if (sub) { mnem = "mneg"; }
+    }
+    val rm: R.Result[bool, str] = emit_str(out, mnem);
+    if (R.is_err[bool, str](rm)) { ret rm; }
+    var n: u32 = 0;
+    val rd: R.Result[u32, str] = render_slot(buf, i, ?i.dst, n, false);
+    if (R.is_err[u32, str](rd)) { ret unwrap_slot_err(rd); }
+    n = R.unwrap_ok[u32, str](rd);
+    val rn: R.Result[u32, str] = render_slot(buf, i, ?i.src1, n, false);
+    if (R.is_err[u32, str](rn)) { ret unwrap_slot_err(rn); }
+    n = R.unwrap_ok[u32, str](rn);
+    val r2: R.Result[u32, str] = render_slot(buf, i, ?i.src2, n, false);
+    if (R.is_err[u32, str](r2)) { ret unwrap_slot_err(r2); }
+    n = R.unwrap_ok[u32, str](r2);
+    if (degenerate) { ret R.ok[bool, str](true); }
+    val r3: R.Result[u32, str] = render_slot(buf, i, ?i.src3, n, false);
+    if (R.is_err[u32, str](r3)) { ret unwrap_slot_err(r3); }
+    ret R.ok[bool, str](true);
+}
+
+# render a CSINC with both sources held at the zero register - the CSET alias
+#
+# The encoded condition is the inverse of the one the boolean captures, which is
+# exactly what `cset` names, so the printed condition is the encoded field inverted.
+# ---
+# buf: the encoder byte sink carrying the assembly sink
+# i:   the instruction to render
+# ret: true on success, or an error naming the unmapped base
+fun render_cset(buf: *enc.ByteBuf, i: *Inst) R.Result[bool, str] {
+    val out: *writer.Writer = buf.asm.out;
+    if (i.base != 0x9A800400 && i.base != 0x1A800400) {
+        ret R.err[bool, str]("--emit-asm: no aarch64 mnemonic for an emitted conditional-select base word");
+    }
+    val cc: str = cond_name((i.flags & FLAG_COND)::u32 ^ 1);
+    if (cc == nil) {
+        ret R.err[bool, str]("--emit-asm: an emitted aarch64 cset names no condition");
+    }
+    val rm: R.Result[bool, str] = emit_str(out, "cset");
+    if (R.is_err[bool, str](rm)) { ret rm; }
+    val rd: R.Result[u32, str] = render_slot(buf, i, ?i.dst, 0, false);
+    if (R.is_err[u32, str](rd)) { ret unwrap_slot_err(rd); }
+    val rc: R.Result[bool, str] = emit_str(out, ", ");
+    if (R.is_err[bool, str](rc)) { ret rc; }
+    ret emit_str(out, cc);
+}
+
+# the mnemonic a load / store base word denotes, or nil when unmapped
+#
+# The transferred register's width and bank come from the operand, so one entry
+# covers the W, X, S, D and Q forms of `ldr`; only the mnemonics that genuinely
+# differ - the sub-word accesses, the unscaled LDUR / STUR family, and the ordered
+# and exclusive accesses - need their own.
+# ---
+# base: the packer base word
+# ret:  the mnemonic, or nil for an unmapped base
+fun ldst_mnem(base: u32) str {
+    if (base == 0x39400000 || base == 0x38606800) { ret "ldrb"; }
+    if (base == 0x39000000 || base == 0x38206800) { ret "strb"; }
+    if (base == 0x79400000 || base == 0x78606800) { ret "ldrh"; }
+    if (base == 0x79000000 || base == 0x78206800) { ret "strh"; }
+    if (base == 0xB9400000 || base == 0xF9400000 || base == 0xFD400000 ||
+        base == 0xBD400000 || base == 0x3DC00000 || base == 0xB8606800 ||
+        base == 0xF8606800 || base == 0xFC606800 || base == 0xBC606800 ||
+        base == 0x3CE06800)                       { ret "ldr"; }
+    if (base == 0xB9000000 || base == 0xF9000000 || base == 0xFD000000 ||
+        base == 0xBD000000 || base == 0x3D800000 || base == 0xB8206800 ||
+        base == 0xF8206800 || base == 0xFC206800 || base == 0xBC206800 ||
+        base == 0x3CA06800)                       { ret "str"; }
+    if (base == 0x38400000)                       { ret "ldurb"; }
+    if (base == 0x38000000)                       { ret "sturb"; }
+    if (base == 0x78400000)                       { ret "ldurh"; }
+    if (base == 0x78000000)                       { ret "sturh"; }
+    if (base == 0xB8400000 || base == 0xF8400000 || base == 0xFC400000 ||
+        base == 0xBC400000 || base == 0x3CC00000) { ret "ldur"; }
+    if (base == 0xB8000000 || base == 0xF8000000 || base == 0xFC000000 ||
+        base == 0xBC000000 || base == 0x3C800000) { ret "stur"; }
+    if (base == 0xC8DFFC00 || base == 0x88DFFC00) { ret "ldar"; }
+    if (base == 0xC89FFC00 || base == 0x889FFC00) { ret "stlr"; }
+    if (base == 0xC85FFC00 || base == 0x885FFC00) { ret "ldaxr"; }
+    ret nil;
+}
+
+# true when a load / store base word reads memory rather than writing it
+# ---
+# base: the packer base word
+# ret:  true for a load
+fun ldst_is_load(base: u32) bool {
+    val m: str = ldst_mnem(base);
+    if (m == nil) { ret false; }
+    ret m[0] == 'l'::char;
+}
+
+# render a load or store
+#
+# A load names its destination register first and a store names its source register
+# first, so the semantic slots - `dst` is the location written either way - are
+# emitted in the order AArch64 spells them rather than in slot order.
+# ---
+# buf: the encoder byte sink carrying the assembly sink
+# i:   the instruction to render
+# ret: true on success, or an error naming the unmapped base
+fun render_ldst(buf: *enc.ByteBuf, i: *Inst) R.Result[bool, str] {
+    val out: *writer.Writer = buf.asm.out;
+    val mnem: str = ldst_mnem(i.base);
+    if (mnem == nil) {
+        ret R.err[bool, str]("--emit-asm: no aarch64 mnemonic for an emitted load/store base word");
+    }
+    val rm: R.Result[bool, str] = emit_str(out, mnem);
+    if (R.is_err[bool, str](rm)) { ret rm; }
+
+    if (ldst_is_load(i.base)) {
+        val rd: R.Result[u32, str] = render_slot(buf, i, ?i.dst, 0, false);
+        if (R.is_err[u32, str](rd)) { ret unwrap_slot_err(rd); }
+        ret emit_sep_operand(buf, i, ?i.src1, 1, false);
+    }
+    val rv: R.Result[u32, str] = render_slot(buf, i, ?i.src1, 0, false);
+    if (R.is_err[u32, str](rv)) { ret unwrap_slot_err(rv); }
+    ret emit_sep_operand(buf, i, ?i.dst, 1, false);
+}
+
+# render a load / store pair
+#
+# A pre-index form writes the updated base back (`[Xn, #off]!`); a post-index form
+# applies the offset after the access (`[Xn], #off`). A store names its two source
+# registers first, so the memory operand is emitted last regardless of which slot
+# holds it.
+# ---
+# buf: the encoder byte sink carrying the assembly sink
+# i:   the instruction to render
+# ret: true on success, or an error naming the unmapped base
+fun render_ldstp(buf: *enc.ByteBuf, i: *Inst) R.Result[bool, str] {
+    val out: *writer.Writer = buf.asm.out;
+    var mnem: str = nil;
+    if (i.base == 0xA9800000 || i.base == 0xA8800000 ||
+        i.base == 0xA9000000 || i.base == 0x6D000000) { mnem = "stp"; }
+    if (i.base == 0xA9C00000 || i.base == 0xA8C00000 ||
+        i.base == 0xA9400000 || i.base == 0x6D400000) { mnem = "ldp"; }
+    if (mnem == nil) {
+        ret R.err[bool, str]("--emit-asm: no aarch64 mnemonic for an emitted load/store-pair base word");
+    }
+    val load: bool = mnem[0] == 'l'::char;
+
+    val rm: R.Result[bool, str] = emit_str(out, mnem);
+    if (R.is_err[bool, str](rm)) { ret rm; }
+
+    # a load writes both registers (dst, src1) and reads the address (src2); a store
+    # reads both registers (src1, src2) and writes the address (dst)
+    var ra: *isa.Operand = ?i.src1;
+    var rb: *isa.Operand = ?i.src2;
+    var mem: *isa.Operand = ?i.dst;
+    if (load) { ra = ?i.dst; rb = ?i.src1; mem = ?i.src2; }
+
+    val r1: R.Result[u32, str] = render_slot(buf, i, ra, 0, false);
+    if (R.is_err[u32, str](r1)) { ret unwrap_slot_err(r1); }
+    val r2: R.Result[u32, str] = render_slot(buf, i, rb, 1, false);
+    if (R.is_err[u32, str](r2)) { ret unwrap_slot_err(r2); }
+    ret emit_sep_operand(buf, i, mem, 2, false);
+}
+
+# the mnemonic a NEON three-register-same base word denotes, or nil when unmapped
+# ---
+# base: the packer base word
+# ret:  the mnemonic, or nil
+fun neon_3same_mnem(base: u32) str {
+    if (base == 0x4E20D400) { ret "fadd"; }
+    if (base == 0x4EA0D400) { ret "fsub"; }
+    if (base == 0x6E20DC00) { ret "fmul"; }
+    if (base == 0x6E20FC00) { ret "fdiv"; }
+    if (base == 0x4E208400) { ret "add"; }
+    if (base == 0x6E208400) { ret "sub"; }
+    if (base == 0x4E209C00) { ret "mul"; }
+    if (base == 0x4E201C00) { ret "and"; }
+    if (base == 0x4EA01C00) { ret "orr"; }
+    if (base == 0x6E201C00) { ret "eor"; }
+    if (base == 0x6E208C00) { ret "cmeq"; }
+    if (base == 0x4E203400) { ret "cmgt"; }
+    if (base == 0x4E203C00) { ret "cmge"; }
+    if (base == 0x6E203400) { ret "cmhi"; }
+    if (base == 0x6E203C00) { ret "cmhs"; }
+    if (base == 0x4E20E400) { ret "fcmeq"; }
+    if (base == 0x6EA0E400) { ret "fcmgt"; }
+    if (base == 0x6E20E400) { ret "fcmge"; }
+    ret nil;
+}
+
+# true when a NEON base word is one of the bitwise forms
+#
+# Their size bits are part of the opcode rather than an arrangement, so they are
+# always byte-wise regardless of the lane descriptor the operation carried.
+# ---
+# base: the packer base word
+# ret:  true for AND / ORR / EOR
+fun neon_is_bitwise(base: u32) bool {
+    ret base == 0x4E201C00 || base == 0x4EA01C00 || base == 0x6E201C00;
+}
+
+# the lane arrangement a NEON operation renders at
+#
+# A 128-bit vector holds sixteen bytes, so the element width fixes the lane count.
+# The bitwise forms are fixed at the byte arrangement.
+# ---
+# base: the packer base word
+# lane: the lane descriptor, in `mir.MirInstr.vec_lane`'s encoding
+# ret:  the arrangement suffix, or nil for an unmodelled element width
+fun neon_arrangement(base: u32, lane: u8) str {
+    if (neon_is_bitwise(base)) { ret ".16b"; }
+    val eb: u8 = mir.vec_lane_elem_bytes(lane);
+    if (eb == 1) { ret ".16b"; }
+    if (eb == 2) { ret ".8h"; }
+    if (eb == 4) { ret ".4s"; }
+    if (eb == 8) { ret ".2d"; }
+    ret nil;
+}
+
+# render a NEON three-register-same 128-bit word
+#
+# The arrangement rides every operand, so it is written after each register name -
+# dropping it would leave a line no assembler accepts and no disassembly matches.
+# A bitwise OR of a register with itself is the vector register move a disassembler
+# prints as `mov`.
+# ---
+# buf: the encoder byte sink carrying the assembly sink
+# i:   the instruction to render
+# ret: true on success, or an error naming the unmapped base or arrangement
+fun render_neon_3same(buf: *enc.ByteBuf, i: *Inst) R.Result[bool, str] {
+    val out: *writer.Writer = buf.asm.out;
+    val mnem: str = neon_3same_mnem(i.base);
+    if (mnem == nil) {
+        ret R.err[bool, str]("--emit-asm: no aarch64 mnemonic for an emitted NEON three-register base word");
+    }
+    val arr: str = neon_arrangement(i.base, i.vec_lane);
+    if (arr == nil) {
+        ret R.err[bool, str]("--emit-asm: an emitted NEON instruction has no lane arrangement");
+    }
+
+    # `orr Vd.16b, Vn.16b, Vn.16b` is the vector register move
+    if (i.base == 0x4EA01C00 && i.src1.reg == i.src2.reg) {
+        val rv: R.Result[bool, str] = emit_str(out, "mov");
+        if (R.is_err[bool, str](rv)) { ret rv; }
+        val rd: R.Result[bool, str] = emit_sep_vec(out, " ", ?i.dst, arr);
+        if (R.is_err[bool, str](rd)) { ret rd; }
+        ret emit_sep_vec(out, ", ", ?i.src1, arr);
+    }
+
+    val rm: R.Result[bool, str] = emit_str(out, mnem);
+    if (R.is_err[bool, str](rm)) { ret rm; }
+    val rd: R.Result[bool, str] = emit_sep_vec(out, " ", ?i.dst, arr);
+    if (R.is_err[bool, str](rd)) { ret rd; }
+    val rn: R.Result[bool, str] = emit_sep_vec(out, ", ", ?i.src1, arr);
+    if (R.is_err[bool, str](rn)) { ret rn; }
+    ret emit_sep_vec(out, ", ", ?i.src2, arr);
+}
+
+# render a NEON two-register-misc 128-bit word
+#
+# The bitwise complement is fixed at the byte arrangement and disassembles as `mvn`,
+# the spelling its `NOT` encoding is printed under.
+# ---
+# buf: the encoder byte sink carrying the assembly sink
+# i:   the instruction to render
+# ret: true on success, or an error naming the unmapped base
+fun render_neon_2misc(buf: *enc.ByteBuf, i: *Inst) R.Result[bool, str] {
+    val out: *writer.Writer = buf.asm.out;
+    if (i.base != 0x6E205800) {
+        ret R.err[bool, str]("--emit-asm: no aarch64 mnemonic for an emitted NEON two-register base word");
+    }
+    val rm: R.Result[bool, str] = emit_str(out, "mvn");
+    if (R.is_err[bool, str](rm)) { ret rm; }
+    val rd: R.Result[bool, str] = emit_sep_vec(out, " ", ?i.dst, ".16b");
+    if (R.is_err[bool, str](rd)) { ret rd; }
+    ret emit_sep_vec(out, ", ", ?i.src1, ".16b");
+}
+
+# render a branch and its destination
+#
+# The displacement fields hold a zero placeholder until pass 2 patches them, so the
+# destination is rendered from the name the encoder carried: a MIR block's local
+# label, a call target's symbol, an inline-asm numeric local label, or - for the
+# self-contained trap skips, whose distance is fixed at emit time and never patched -
+# the PC-relative distance itself.
+# ---
+# buf: the encoder byte sink carrying the assembly sink
+# i:   the instruction to render
+# ret: true on success, or an error naming the unmapped base
+fun render_branch(buf: *enc.ByteBuf, i: *Inst) R.Result[bool, str] {
+    val out: *writer.Writer = buf.asm.out;
+    var mnem: str = nil;
+    var reg:  bool = false;
+    if (i.base == 0x14000000) { mnem = "b"; }
+    or (i.base == 0x94000000) { mnem = "bl"; }
+    or (i.base == 0xB5000000 || i.base == 0x35000000) { mnem = "cbnz"; reg = true; }
+    or (i.base == 0xB4000000 || i.base == 0x34000000) { mnem = "cbz";  reg = true; }
+    or ((i.base & 0xFF000000) == 0x54000000) {
+        val cc: str = cond_name(i.base & 0xF);
+        if (cc == nil) {
+            ret R.err[bool, str]("--emit-asm: an emitted aarch64 conditional branch names no condition");
+        }
+        val rb: R.Result[bool, str] = emit_str(out, "b.");
+        if (R.is_err[bool, str](rb)) { ret rb; }
+        val rc: R.Result[bool, str] = emit_str(out, cc);
+        if (R.is_err[bool, str](rc)) { ret rc; }
+        val rs: R.Result[bool, str] = emit_str(out, " ");
+        if (R.is_err[bool, str](rs)) { ret rs; }
+        ret render_target(buf, i);
+    }
+    or {
+        ret R.err[bool, str]("--emit-asm: no aarch64 mnemonic for an emitted branch base word");
+    }
+
+    val rm: R.Result[bool, str] = emit_str(out, mnem);
+    if (R.is_err[bool, str](rm)) { ret rm; }
+    if (reg) {
+        val rt: R.Result[u32, str] = render_slot(buf, i, ?i.src1, 0, false);
+        if (R.is_err[u32, str](rt)) { ret unwrap_slot_err(rt); }
+        val rc: R.Result[bool, str] = emit_str(out, ", ");
+        if (R.is_err[bool, str](rc)) { ret rc; }
+        ret render_target(buf, i);
+    }
+    val rs: R.Result[bool, str] = emit_str(out, " ");
+    if (R.is_err[bool, str](rs)) { ret rs; }
+    ret render_target(buf, i);
+}
+
+# render a branch destination by the name the encoder carried
+# ---
+# buf: the encoder byte sink carrying the assembly sink
+# i:   the branch whose destination is rendered
+# ret: true on success, or an error for a branch carrying no destination
+fun render_target(buf: *enc.ByteBuf, i: *Inst) R.Result[bool, str] {
+    val out: *writer.Writer = buf.asm.out;
+    if (i.target == TGT_BLOCK) {
+        val rd: R.Result[bool, str] = emit_str(out, ".");
+        if (R.is_err[bool, str](rd)) { ret rd; }
+        ret emit_u64(out, i.block::u64);
+    }
+    if (i.target == TGT_SYM) { ret emit_sym(out, buf.asm.interner, ?i.src2); }
+    if (i.target == TGT_PCREL) {
+        val rd: R.Result[bool, str] = emit_str(out, ".+");
+        if (R.is_err[bool, str](rd)) { ret rd; }
+        ret emit_u64(out, (i.src2.imm * 4)::u64);
+    }
+    if (i.target == TGT_LOCAL_FWD || i.target == TGT_LOCAL_BACK) {
+        val rn: R.Result[bool, str] = emit_u64(out, i.src2.imm::u64);
+        if (R.is_err[bool, str](rn)) { ret rn; }
+        if (i.target == TGT_LOCAL_FWD) { ret emit_str(out, "f"); }
+        ret emit_str(out, "b");
+    }
+    ret R.err[bool, str]("--emit-asm: an emitted aarch64 branch names no destination");
+}
+
+# render a register-indirect branch
+# ---
+# buf: the encoder byte sink carrying the assembly sink
+# i:   the instruction to render
+# ret: true on success, or an error naming the unmapped base
+fun render_branch_reg(buf: *enc.ByteBuf, i: *Inst) R.Result[bool, str] {
+    val out: *writer.Writer = buf.asm.out;
+    var mnem: str = nil;
+    if (i.base == 0xD63F0000) { mnem = "blr"; }
+    or (i.base == 0xD61F0000) { mnem = "br"; }
+    or (i.base == 0xD65F0000) { mnem = "ret"; }
+    or {
+        ret R.err[bool, str]("--emit-asm: no aarch64 mnemonic for an emitted register-branch base word");
+    }
+    val rm: R.Result[bool, str] = emit_str(out, mnem);
+    if (R.is_err[bool, str](rm)) { ret rm; }
+    val rn: R.Result[u32, str] = render_slot(buf, i, ?i.src1, 0, false);
+    if (R.is_err[u32, str](rn)) { ret unwrap_slot_err(rn); }
+    ret R.ok[bool, str](true);
+}
+
+# render an ADRP page-address computation
+#
+# The 21-bit page delta is a zero placeholder the linker fills, so the operand is
+# the symbol the relocation names rather than the encoded zero.
+# ---
+# buf: the encoder byte sink carrying the assembly sink
+# i:   the instruction to render
+# ret: true on success, or the first write error
+fun render_adrp(buf: *enc.ByteBuf, i: *Inst) R.Result[bool, str] {
+    val out: *writer.Writer = buf.asm.out;
+    val rm: R.Result[bool, str] = emit_str(out, "adrp");
+    if (R.is_err[bool, str](rm)) { ret rm; }
+    val rd: R.Result[u32, str] = render_slot(buf, i, ?i.dst, 0, false);
+    if (R.is_err[u32, str](rd)) { ret unwrap_slot_err(rd); }
+    ret emit_sep_operand(buf, i, ?i.src1, 1, false);
+}
+
+# render an operand-less instruction
+# ---
 # out: destination writer
-# ret: always an error naming aarch64 and its tracking issue
-pub fun print_asm_arm64(a: *A.Allocator, tgt: *resolved.Target, m: *mir.MirModule,
-                        out: *writer.Writer) R.Result[encode.EncoderOutput, str] {
-    ret R.err[encode.EncoderOutput, str](
-        "--emit-asm: no assembly printer for aarch64 yet (tracked by briar-systems/mach#2194)");
+# i:   the instruction to render
+# ret: true on success, or an error naming the unmapped word
+fun render_nullary(out: *writer.Writer, i: *Inst) R.Result[bool, str] {
+    if (i.base == 0xD65F03C0) { ret emit_str(out, "ret"); }
+    if (i.base == 0xD503201F) { ret emit_str(out, "nop"); }
+    if (i.base == 0xD503203F) { ret emit_str(out, "yield"); }
+    ret R.err[bool, str]("--emit-asm: no aarch64 mnemonic for an emitted operand-less instruction word");
+}
+
+# render a single-immediate instruction (BRK / SVC)
+# ---
+# buf: the encoder byte sink carrying the assembly sink
+# i:   the instruction to render
+# ret: true on success, or an error naming the unmapped base
+fun render_imm16(buf: *enc.ByteBuf, i: *Inst) R.Result[bool, str] {
+    val out: *writer.Writer = buf.asm.out;
+    var mnem: str = nil;
+    if (i.base == 0xD4200000) { mnem = "brk"; }
+    or (i.base == 0xD4000001) { mnem = "svc"; }
+    or {
+        ret R.err[bool, str]("--emit-asm: no aarch64 mnemonic for an emitted immediate-only base word");
+    }
+    val rm: R.Result[bool, str] = emit_str(out, mnem);
+    if (R.is_err[bool, str](rm)) { ret rm; }
+    val rs: R.Result[bool, str] = emit_str(out, " ");
+    if (R.is_err[bool, str](rs)) { ret rs; }
+    ret emit_trap_imm(out, i.src1.imm);
+}
+
+# render a data memory barrier, naming the domain its CRm field selects
+# ---
+# out: destination writer
+# i:   the instruction to render
+# ret: true on success, or an error naming the unmapped domain
+fun render_barrier(out: *writer.Writer, i: *Inst) R.Result[bool, str] {
+    if (i.base != 0xD50330BF) {
+        ret R.err[bool, str]("--emit-asm: no aarch64 mnemonic for an emitted barrier base word");
+    }
+    val name: str = barrier_name(i.src1.imm::u32);
+    if (name == nil) {
+        ret R.err[bool, str]("--emit-asm: an emitted aarch64 barrier names no domain");
+    }
+    val rm: R.Result[bool, str] = emit_str(out, "dmb ");
+    if (R.is_err[bool, str](rm)) { ret rm; }
+    ret emit_str(out, name);
+}
+
+# the barrier-domain name a DMB CRm value selects
+# ---
+# crm: the encoded CRm field
+# ret: the domain name, or nil for an unmodelled value
+fun barrier_name(crm: u32) str {
+    if (crm == 15) { ret "sy"; }
+    if (crm == 14) { ret "st"; }
+    if (crm == 13) { ret "ld"; }
+    if (crm == 11) { ret "ish"; }
+    if (crm == 10) { ret "ishst"; }
+    if (crm == 9)  { ret "ishld"; }
+    if (crm == 7)  { ret "nsh"; }
+    if (crm == 6)  { ret "nshst"; }
+    if (crm == 5)  { ret "nshld"; }
+    if (crm == 3)  { ret "osh"; }
+    if (crm == 2)  { ret "oshst"; }
+    if (crm == 1)  { ret "oshld"; }
+    ret nil;
+}
+
+# render a store-release-exclusive, whose status result rides a third register
+# ---
+# buf: the encoder byte sink carrying the assembly sink
+# i:   the instruction to render
+# ret: true on success, or an error naming the unmapped base
+fun render_stxr(buf: *enc.ByteBuf, i: *Inst) R.Result[bool, str] {
+    val out: *writer.Writer = buf.asm.out;
+    if (i.base != 0xC800FC00 && i.base != 0x8800FC00) {
+        ret R.err[bool, str]("--emit-asm: no aarch64 mnemonic for an emitted exclusive-store base word");
+    }
+    val rm: R.Result[bool, str] = emit_str(out, "stlxr");
+    if (R.is_err[bool, str](rm)) { ret rm; }
+    val rs: R.Result[u32, str] = render_slot(buf, i, ?i.dst, 0, false);
+    if (R.is_err[u32, str](rs)) { ret unwrap_slot_err(rs); }
+    val rt: R.Result[u32, str] = render_slot(buf, i, ?i.src1, 1, false);
+    if (R.is_err[u32, str](rt)) { ret unwrap_slot_err(rt); }
+    ret emit_sep_operand(buf, i, ?i.src2, 2, false);
+}
+
+# render one operand, preceded by the separator its position calls for
+#
+# An absent operand renders nothing and does not advance the position, so a form
+# that leaves a slot empty needs no special case at the call site.
+# ---
+# buf: the encoder byte sink carrying the assembly sink
+# i:   the owning instruction
+# op:  the operand to render
+# n:   how many operands have been rendered already
+# sp:  true when register 31 in this position names the stack pointer
+# ret: the new rendered-operand count, or an error
+fun render_slot(buf: *enc.ByteBuf, i: *Inst, op: *isa.Operand, n: u32, sp: bool) R.Result[u32, str] {
+    if (op.kind == isa.OPK_NONE) { ret R.ok[u32, str](n); }
+    val res: R.Result[bool, str] = emit_sep_operand(buf, i, op, n, sp);
+    if (R.is_err[bool, str](res)) { ret R.err[u32, str](R.unwrap_err[bool, str](res)); }
+    ret R.ok[u32, str](n + 1);
+}
+
+# write the separator for operand position `n`, then the operand
+# ---
+# buf: the encoder byte sink carrying the assembly sink
+# i:   the owning instruction
+# op:  the operand to render
+# n:   the operand's position
+# sp:  true when register 31 in this position names the stack pointer
+# ret: true on success, or the first error
+fun emit_sep_operand(buf: *enc.ByteBuf, i: *Inst, op: *isa.Operand, n: u32, sp: bool) R.Result[bool, str] {
+    var sep: str = ", ";
+    if (n == 0) { sep = " "; }
+    val rs: R.Result[bool, str] = emit_str(buf.asm.out, sep);
+    if (R.is_err[bool, str](rs)) { ret rs; }
+    ret emit_operand(buf, i, op, sp);
+}
+
+# render an operand's text
+#
+# The operand kinds are the shared `isa.Operand` ones; what AArch64 adds is the
+# stack-pointer spelling of register 31 (a property of the field position, not of
+# the operand) and the relocation modifier decorating a symbol.
+# ---
+# buf: the encoder byte sink carrying the assembly sink
+# i:   the owning instruction
+# op:  the operand to render
+# sp:  true when register 31 names the stack pointer here
+# ret: true on success, or an error naming the unrenderable shape
+fun emit_operand(buf: *enc.ByteBuf, i: *Inst, op: *isa.Operand, sp: bool) R.Result[bool, str] {
+    val out: *writer.Writer = buf.asm.out;
+    if (op.kind == isa.OPK_REG) { ret emit_reg(out, op, sp); }
+    if (op.kind == isa.OPK_IMM) { ret emit_hex_imm(out, op.imm); }
+    if (op.kind == isa.OPK_MEM) { ret emit_mem(buf, i, op); }
+    if (op.kind == isa.OPK_SYM) { ret emit_modified_sym(buf, i, op); }
+    ret R.err[bool, str]("--emit-asm: an emitted aarch64 operand has no renderable kind");
+}
+
+# render a memory operand
+#
+# `[Xn]`, `[Xn, #disp]`, `[Xn, Xm]`, or the relocated `[Xn, :lo12:sym]` low half of a
+# symbol address - whose displacement is a zero placeholder the linker fills, so the
+# relocation is printed rather than the placeholder. A pair's addressing mode moves
+# the displacement outside the brackets or appends a writeback marker.
+# ---
+# buf: the encoder byte sink carrying the assembly sink
+# i:   the owning instruction
+# op:  the memory operand to render
+# ret: true on success, or the first write error
+fun emit_mem(buf: *enc.ByteBuf, i: *Inst, op: *isa.Operand) R.Result[bool, str] {
+    val out: *writer.Writer = buf.asm.out;
+    val ro: R.Result[bool, str] = emit_str(out, "[");
+    if (R.is_err[bool, str](ro)) { ret ro; }
+    val rb: R.Result[bool, str] = emit_reg_id(out, op.base, 8, true);
+    if (R.is_err[bool, str](rb)) { ret rb; }
+
+    if (i.sym_mod != MOD_NONE) {
+        val rl: R.Result[bool, str] = emit_str(out, ", ");
+        if (R.is_err[bool, str](rl)) { ret rl; }
+        val rp: R.Result[bool, str] = emit_str(out, sym_mod_prefix(i.sym_mod));
+        if (R.is_err[bool, str](rp)) { ret rp; }
+        val rs: R.Result[bool, str] = emit_sym(out, buf.asm.interner, op);
+        if (R.is_err[bool, str](rs)) { ret rs; }
+        ret emit_str(out, "]");
+    }
+
+    if (op.index >= 0) {
+        val ri: R.Result[bool, str] = emit_str(out, ", ");
+        if (R.is_err[bool, str](ri)) { ret ri; }
+        val rx: R.Result[bool, str] = emit_reg_id(out, op.index, 8, false);
+        if (R.is_err[bool, str](rx)) { ret rx; }
+        ret emit_str(out, "]");
+    }
+
+    # a post-index pair applies its displacement after the access, outside the brackets
+    if ((i.flags & FLAG_WB_POST) != 0) {
+        val rc: R.Result[bool, str] = emit_str(out, "], ");
+        if (R.is_err[bool, str](rc)) { ret rc; }
+        ret emit_hex_imm(out, op.disp::i64);
+    }
+    if (op.disp != 0) {
+        val rc: R.Result[bool, str] = emit_str(out, ", ");
+        if (R.is_err[bool, str](rc)) { ret rc; }
+        val rd: R.Result[bool, str] = emit_hex_imm(out, op.disp::i64);
+        if (R.is_err[bool, str](rd)) { ret rd; }
+    }
+    if ((i.flags & FLAG_WB_PRE) != 0) { ret emit_str(out, "]!"); }
+    ret emit_str(out, "]");
+}
+
+# render a symbol operand with the relocation modifier the instruction carries
+# ---
+# buf: the encoder byte sink carrying the assembly sink
+# i:   the owning instruction
+# op:  the symbol operand to render
+# ret: true on success, or the first write error
+fun emit_modified_sym(buf: *enc.ByteBuf, i: *Inst, op: *isa.Operand) R.Result[bool, str] {
+    val out: *writer.Writer = buf.asm.out;
+    val rp: R.Result[bool, str] = emit_str(out, sym_mod_prefix(i.sym_mod));
+    if (R.is_err[bool, str](rp)) { ret rp; }
+    ret emit_sym(out, buf.asm.interner, op);
+}
+
+# the assembler spelling of a relocation modifier
+#
+# The page-high modifier has no prefix - `adrp Xd, sym` names the page implicitly.
+# ---
+# mod: the MOD_* modifier
+# ret: the prefix text, empty when the modifier needs none
+fun sym_mod_prefix(mod: u8) str {
+    if (mod == MOD_PCREL_LO) { ret ":lo12:"; }
+    if (mod == MOD_GOT_HI)   { ret ":got:"; }
+    if (mod == MOD_GOT_LO)   { ret ":got_lo12:"; }
+    ret "";
+}
+
+# write a shift modifier decorating the preceding operand
+#
+# A bit position prints in decimal where a value prints in hexadecimal, which is how
+# a disassembler spells them and therefore what the artifact must match.
+# ---
+# out: destination writer
+# op:  the immediate operand holding the shift amount
+# ret: true on success, or the first write error
+fun emit_shift(out: *writer.Writer, op: *isa.Operand) R.Result[bool, str] {
+    val rl: R.Result[bool, str] = emit_str(out, ", lsl ");
+    if (R.is_err[bool, str](rl)) { ret rl; }
+    ret emit_dec_imm(out, op.imm);
+}
+
+# write a bit position or field width in the `#N` decimal form a disassembler prints
+# ---
+# out: destination writer
+# v:   the value to write
+# ret: true on success, or the first write error
+fun emit_dec_imm(out: *writer.Writer, v: i64) R.Result[bool, str] {
+    val rp: R.Result[bool, str] = emit_str(out, "#");
+    if (R.is_err[bool, str](rp)) { ret rp; }
+    ret emit_u64(out, v::u64);
+}
+
+# write a trap code in the `#0` / `#0x...` form a disassembler prints
+# ---
+# out: destination writer
+# v:   the value to write
+# ret: true on success, or the first write error
+fun emit_trap_imm(out: *writer.Writer, v: i64) R.Result[bool, str] {
+    if (v == 0) { ret emit_str(out, "#0"); }
+    ret emit_hex_imm(out, v);
+}
+
+# write a separator then a vector register with its lane arrangement
+# ---
+# out: destination writer
+# sep: the separator preceding the register
+# op:  the vector register operand
+# arr: the arrangement suffix
+# ret: true on success, or the first write error
+fun emit_sep_vec(out: *writer.Writer, sep: str, op: *isa.Operand, arr: str) R.Result[bool, str] {
+    val rs: R.Result[bool, str] = emit_str(out, sep);
+    if (R.is_err[bool, str](rs)) { ret rs; }
+    val rv: R.Result[bool, str] = emit_indexed(out, "v", isa.regid_index(op.reg)::u32);
+    if (R.is_err[bool, str](rv)) { ret rv; }
+    ret emit_str(out, arr);
+}
+
+# true when an operand names register 31
+# ---
+# op:  the operand to test
+# ret: true for register index 31 in either bank
+fun is_reg31(op: *isa.Operand) bool {
+    ret op.kind == isa.OPK_REG && isa.regid_index(op.reg) == 31;
+}
+
+# true when an operand names the general-purpose zero register
+# ---
+# op:  the operand to test
+# ret: true for a general-purpose register 31
+fun is_zero_reg(op: *isa.Operand) bool {
+    ret is_reg31(op) && isa.regid_class(op.reg) == isa.REG_CLASS_ID_GP;
+}
+
+# write a register operand's name
+# ---
+# out: destination writer
+# op:  the register operand
+# sp:  true when register 31 names the stack pointer here
+# ret: true on success, or the write error
+fun emit_reg(out: *writer.Writer, op: *isa.Operand, sp: bool) R.Result[bool, str] {
+    ret emit_reg_id(out, op.reg, op.size, sp);
+}
+
+# write a register name from its composite id and width
+#
+# The bank comes off the id's class tag and the letter off the width, so a float
+# operand names S / D / Q without the opcode being consulted. Register 31 names the
+# zero register in a data position and the stack pointer in an address position;
+# which applies is a property of the encoding, so it rides `sp` rather than being
+# guessed.
+# ---
+# out:  destination writer
+# id:   the composite register id
+# size: the operand width in bytes
+# sp:   true when register 31 names the stack pointer here
+# ret:  true on success, or the write error
+fun emit_reg_id(out: *writer.Writer, id: i32, size: u8, sp: bool) R.Result[bool, str] {
+    val n: u32 = isa.regid_index(id)::u32;
+    if (isa.regid_class(id) == isa.REG_CLASS_ID_XMM) {
+        if (size == 4)  { ret emit_indexed(out, "s", n); }
+        if (size == 8)  { ret emit_indexed(out, "d", n); }
+        if (size == 16) { ret emit_indexed(out, "q", n); }
+        ret R.err[bool, str]("--emit-asm: an emitted aarch64 float operand has no register width");
+    }
+    if (n == 31) {
+        if (sp)         { ret emit_str(out, "sp"); }
+        if (size == 4)  { ret emit_str(out, "wzr"); }
+        ret emit_str(out, "xzr");
+    }
+    if (size == 4) { ret emit_indexed(out, "w", n); }
+    ret emit_indexed(out, "x", n);
+}
+
+# write a register name as its bank letter followed by its index
+# ---
+# out:    destination writer
+# prefix: the bank's letter
+# n:      the register index
+# ret:    true on success, or the first write error
+fun emit_indexed(out: *writer.Writer, prefix: str, n: u32) R.Result[bool, str] {
+    val rp: R.Result[bool, str] = emit_str(out, prefix);
+    if (R.is_err[bool, str](rp)) { ret rp; }
+    ret emit_u64(out, n::u64);
+}
+
+# the condition name an A64 condition-code field selects
+# ---
+# cc:  the four-bit condition field
+# ret: the condition name, or nil for an unmodelled value
+fun cond_name(cc: u32) str {
+    if (cc == 0)  { ret "eq"; }
+    if (cc == 1)  { ret "ne"; }
+    if (cc == 2)  { ret "hs"; }
+    if (cc == 3)  { ret "lo"; }
+    if (cc == 4)  { ret "mi"; }
+    if (cc == 5)  { ret "pl"; }
+    if (cc == 6)  { ret "vs"; }
+    if (cc == 7)  { ret "vc"; }
+    if (cc == 8)  { ret "hi"; }
+    if (cc == 9)  { ret "ls"; }
+    if (cc == 10) { ret "ge"; }
+    if (cc == 11) { ret "lt"; }
+    if (cc == 12) { ret "gt"; }
+    if (cc == 13) { ret "le"; }
+    if (cc == 14) { ret "al"; }
+    ret nil;
+}
+
+# re-shape an operand-position error as a rendering error
+# ---
+# r:   the failed position result
+# ret: the same error in the render result shape
+fun unwrap_slot_err(r: R.Result[u32, str]) R.Result[bool, str] {
+    ret R.err[bool, str](R.unwrap_err[u32, str](r));
+}
+
+# write a signed immediate in the `#0x...` form a disassembler prints
+# ---
+# out: destination writer
+# v:   the value to write
+# ret: true on success, or the first write error
+fun emit_hex_imm(out: *writer.Writer, v: i64) R.Result[bool, str] {
+    if (v < 0) {
+        val rn: R.Result[bool, str] = emit_str(out, "#-0x");
+        if (R.is_err[bool, str](rn)) { ret rn; }
+        ret emit_hex(out, (0 - v)::u64);
+    }
+    ret emit_hex_u64_imm(out, v::u64);
+}
+
+# the signed value a materialized bit pattern denotes at a register width
+#
+# A move-wide builds a bit pattern, but a disassembler names the value that pattern
+# denotes as a signed integer of the destination's width - `movz x17, #0x8000, lsl
+# #48` reads as `mov x17, #-0x8000000000000000`.
+# ---
+# v:    the bit pattern
+# wide: true for a 64-bit destination
+# ret:  the value the pattern denotes
+fun signed_at_width(v: u64, wide: bool) i64 {
+    if (wide) { ret v::i64; }
+    if ((v & 0x80000000) != 0) { ret (v::i64) - 0x100000000; }
+    ret v::i64;
+}
+
+# write an unsigned immediate in the `#0x...` form a disassembler prints
+# ---
+# out: destination writer
+# v:   the value to write
+# ret: true on success, or the first write error
+fun emit_hex_u64_imm(out: *writer.Writer, v: u64) R.Result[bool, str] {
+    val rp: R.Result[bool, str] = emit_str(out, "#0x");
+    if (R.is_err[bool, str](rp)) { ret rp; }
+    ret emit_hex(out, v);
+}
+
+# write a value's lowercase hexadecimal digits
+# ---
+# out: destination writer
+# v:   the value to write
+# ret: true on success, or the write error
+fun emit_hex(out: *writer.Writer, v: u64) R.Result[bool, str] {
+    val res_write: R.Result[usize, str] = format.write_hex_u64(out, v, false);
+    if (R.is_err[usize, str](res_write)) { ret R.err[bool, str](R.unwrap_err[usize, str](res_write)); }
+    ret R.ok[bool, str](true);
+}
+
+# write a string, mapping a format error to the bool/str result shape
+# ---
+# out: destination writer
+# s:   the string to write
+# ret: true on success, or the write error
+fun emit_str(out: *writer.Writer, s: str) R.Result[bool, str] {
+    val res_write: R.Result[usize, str] = format.write_str(out, s);
+    if (R.is_err[usize, str](res_write)) { ret R.err[bool, str](R.unwrap_err[usize, str](res_write)); }
+    ret R.ok[bool, str](true);
+}
+
+# write an unsigned integer
+# ---
+# out: destination writer
+# n:   the value to write
+# ret: true on success, or the write error
+fun emit_u64(out: *writer.Writer, n: u64) R.Result[bool, str] {
+    val res_write: R.Result[usize, str] = format.write_u64(out, n);
+    if (R.is_err[usize, str](res_write)) { ret R.err[bool, str](R.unwrap_err[usize, str](res_write)); }
+    ret R.ok[bool, str](true);
+}
+
+# write an interned name, failing when the id does not resolve
+# ---
+# out:      destination writer
+# interner: the interner that resolves the id to text
+# id:       the interned string id to write
+# ret:      true on success, or an error
+fun emit_interned(out: *writer.Writer, interner: *intern.Interner, id: intern.StrId) R.Result[bool, str] {
+    val opt_name: O.Option[str] = intern.lookup(interner, id);
+    if (O.is_none[str](opt_name)) {
+        ret R.err[bool, str]("--emit-asm: a name did not resolve in the interner");
+    }
+    ret emit_str(out, O.unwrap[str](opt_name));
+}
+
+# write a symbol operand's name, failing when the id does not resolve
+# ---
+# out:      destination writer
+# interner: the interner that resolves the id to text
+# op:       the operand carrying the symbol id
+# ret:      true on success, or an error
+fun emit_sym(out: *writer.Writer, interner: *intern.Interner, op: *isa.Operand) R.Result[bool, str] {
+    ret emit_interned(out, interner, op.sym_id::intern.StrId);
 }

--- a/src/lang/target/isa/arm64/printer.mach
+++ b/src/lang/target/isa/arm64/printer.mach
@@ -432,20 +432,23 @@ fun render_alu3(buf: *enc.ByteBuf, i: *Inst) R.Result[bool, str] {
     val rw: R.Result[bool, str] = emit_str(out, mnem);
     if (R.is_err[bool, str](rw)) { ret rw; }
 
+    # the oversized-frame subtraction is the extended-register form, whose Rd and Rn
+    # both name SP; every other three-register form names the zero register at 31
+    val sp: bool = i.base == 0xCB2063FF;
+
     var n: u32 = 0;
     if (!drop_dst) {
-        val rd: R.Result[u32, str] = render_slot(buf, i, ?i.dst, n, false);
+        val rd: R.Result[u32, str] = render_slot(buf, i, ?i.dst, n, sp);
         if (R.is_err[u32, str](rd)) { ret unwrap_slot_err(rd); }
         n = R.unwrap_ok[u32, str](rd);
     }
     if (!drop_rn) {
-        val rn: R.Result[u32, str] = render_slot(buf, i, ?i.src1, n, i.base == 0xCB2063FF);
+        val rn: R.Result[u32, str] = render_slot(buf, i, ?i.src1, n, sp);
         if (R.is_err[u32, str](rn)) { ret unwrap_slot_err(rn); }
         n = R.unwrap_ok[u32, str](rn);
     }
     val rm: R.Result[u32, str] = render_slot(buf, i, ?i.src2, n, false);
     if (R.is_err[u32, str](rm)) { ret unwrap_slot_err(rm); }
-    n = R.unwrap_ok[u32, str](rm);
 
     if (i.src3.kind == isa.OPK_NONE) { ret R.ok[bool, str](true); }
     ret emit_shift(out, ?i.src3);
@@ -1753,6 +1756,12 @@ test "mach.lang.target.isa.arm64.printer.render_inst:disassembler_aliases" {
     i22.dst = vec(5, 16); i22.src1 = vec(6, 16); i22.src2 = vec(6, 16);
     i22.vec_lane = mir.vec_lane_make(mir.VEC_LANE_INT, 1);
     bad = bad | rendered_is(?buf, ?i22, "mov v5.16b, v6.16b");
+
+    # the oversized-frame subtraction names SP at both ends, unlike every other
+    # three-register form, where register 31 is the zero register
+    var i24: Inst = inst(FORM_ALU3, 0xCB2063FF);
+    i24.dst = gp(31, 8); i24.src1 = gp(31, 8); i24.src2 = gp(16, 8);
+    bad = bad | rendered_is(?buf, ?i24, "sub sp, sp, x16");
 
     # a trap code prints bare at zero
     var i23: Inst = inst(FORM_IMM16, 0xD4200000);

--- a/src/lang/target/isa/arm64/printer.mach
+++ b/src/lang/target/isa/arm64/printer.mach
@@ -56,6 +56,7 @@
 # the modifier rides the arm64-local `MOD_*` field below - a private field on a
 # private record, extending no shared namespace.
 
+use std.allocator.page;
 use std.format;
 use std.io.writer;
 use std.types.bool.bool;
@@ -64,7 +65,11 @@ use std.types.bool.true;
 use std.types.char.char;
 use std.types.size.usize;
 use std.types.string.str;
+use std.types.string.str_len;
+use std.types.string.str_region_equals;
+use std.types.string.str_starts_with;
 
+use A: std.allocator;
 use O: std.types.option;
 use R: std.types.result;
 
@@ -1543,4 +1548,236 @@ fun emit_interned(out: *writer.Writer, interner: *intern.Interner, id: intern.St
 # ret:      true on success, or an error
 fun emit_sym(out: *writer.Writer, interner: *intern.Interner, op: *isa.Operand) R.Result[bool, str] {
     ret emit_interned(out, interner, op.sym_id::intern.StrId);
+}
+
+# a fixed capture buffer the rendering tests write into, and its writer
+#
+# The renderer's only output is a `writer.Writer`, so testing what it renders means
+# supplying one; this is the smallest possible in-memory sink.
+var test_sink_buf: [8192]u8;
+var test_sink_len: usize = 0;
+
+# append to the capture buffer, matching `writer.WriteFun`
+# ---
+# ctx: unused; the buffer is module state
+# buf: bytes to append
+# len: number of bytes
+# ret: the byte count, always accepted
+pub fun test_sink_write(ctx: ptr, buf: *u8, len: usize) R.Result[usize, str] {
+    var i: usize = 0;
+    for (i < len) {
+        if (test_sink_len < 8191) {
+            test_sink_buf[test_sink_len] = buf[i];
+            test_sink_len = test_sink_len + 1;
+        }
+        i = i + 1;
+    }
+    ret R.ok[usize, str](len);
+}
+
+# discard everything the capture buffer holds
+pub fun test_sink_reset() {
+    test_sink_len = 0;
+}
+
+# the text the capture buffer holds, NUL-terminated
+# ---
+# ret: the captured text
+fun test_sink_text() str {
+    test_sink_buf[test_sink_len] = 0;
+    ret (?test_sink_buf[0])::str;
+}
+
+# render one instruction into the capture buffer and compare it to `want`
+# ---
+# buf:  the byte sink carrying the assembly sink
+# i:    the instruction to render
+# want: the expected line, without the indent or newline
+# ret:  0 when the rendering matches, 1 otherwise
+fun rendered_is(buf: *enc.ByteBuf, i: *Inst, want: str) i32 {
+    test_sink_reset();
+    note_inst(buf, i);
+    if (buf.asm.failed) { ret 1; }
+    val got: str = test_sink_text();
+    # the rendering is indented two spaces and newline-terminated
+    if (!str_starts_with(got, "  "))                     { ret 1; }
+    if (!str_region_equals(got, 2, str_len(want), want)) { ret 1; }
+    if (str_len(got) != str_len(want) + 3)               { ret 1; }
+    ret 0;
+}
+
+# the aliases a disassembler prints are what the artifact renders
+#
+# Each of these is a case where the base spelling would NOT correspond to the object
+# line for line: the encoder emits `orr Rd, XZR, Rm` and a disassembly says `mov`.
+# Rendering the base word's own name would make the `.s` disagree with every
+# disassembly of the bytes it describes - the divergence class #2187 was filed for.
+# The immediate radix is part of that correspondence: a bit position prints in
+# decimal where a value prints in hexadecimal.
+test "mach.lang.target.isa.arm64.printer.render_inst:disassembler_aliases" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+    var buf: enc.ByteBuf = enc.buf_init(?alloc);
+
+    var w: writer.Writer;
+    w.ctx     = nil;
+    w.f_write = test_sink_write;
+    var sink: enc.AsmSink = enc.sink_init(?w, nil);
+    buf.asm = ?sink;
+
+    var bad: i32 = 0;
+
+    # ORR with a zero-register source is a move; SUB is a negate; ORN a complement
+    var i1: Inst = inst(FORM_ALU3, 0xAA000000);
+    i1.dst = gp(3, 8); i1.src1 = gp(31, 8); i1.src2 = gp(4, 8);
+    bad = bad | rendered_is(?buf, ?i1, "mov x3, x4");
+
+    var i2: Inst = inst(FORM_ALU3, 0xCB000000);
+    i2.dst = gp(0, 8); i2.src1 = gp(31, 8); i2.src2 = gp(1, 8);
+    bad = bad | rendered_is(?buf, ?i2, "neg x0, x1");
+
+    var i3: Inst = inst(FORM_ALU3, 0xAA200000);
+    i3.dst = gp(0, 8); i3.src1 = gp(31, 8); i3.src2 = gp(1, 8);
+    bad = bad | rendered_is(?buf, ?i3, "mvn x0, x1");
+
+    # a flag-setting subtract discarding its result is a compare
+    var i4: Inst = inst(FORM_ALU3, 0xEB000000);
+    i4.dst = gp(31, 8); i4.src1 = gp(1, 8); i4.src2 = gp(2, 8);
+    bad = bad | rendered_is(?buf, ?i4, "cmp x1, x2");
+
+    # an ADD of zero involving SP is the only move between SP and a register
+    var i5: Inst = inst(FORM_ADDSUB_IMM, 0x91000000);
+    i5.dst = gp(29, 8); i5.src1 = gp(31, 8); i5.src2 = isa.make_imm(0, 8);
+    bad = bad | rendered_is(?buf, ?i5, "mov x29, sp");
+
+    # a flag-setting add discarding its result is a compare-negative
+    var i6: Inst = inst(FORM_ADDSUB_IMM, 0xB1000000);
+    i6.dst = gp(31, 8); i6.src1 = gp(2, 8); i6.src2 = isa.make_imm(1, 8);
+    bad = bad | rendered_is(?buf, ?i6, "cmn x2, #0x1");
+
+    # the shifted immediate keeps its value in hex and its shift in decimal
+    var i7: Inst = inst(FORM_ADDSUB_IMM, 0xD1000000);
+    i7.dst = gp(31, 8); i7.src1 = gp(31, 8);
+    i7.src2 = isa.make_imm(2, 8); i7.src3 = isa.make_imm(12, 1);
+    bad = bad | rendered_is(?buf, ?i7, "sub sp, sp, #0x2, lsl #12");
+
+    # the bitfield moves: extend, right shift, left shift, extract
+    var i8: Inst = inst(FORM_BITFIELD, 0x53000000);
+    i8.dst = gp(0, 4); i8.src1 = gp(1, 4);
+    i8.src2 = isa.make_imm(0, 1); i8.src3 = isa.make_imm(7, 1);
+    bad = bad | rendered_is(?buf, ?i8, "uxtb w0, w1");
+
+    var i9: Inst = inst(FORM_BITFIELD, 0x93400000);
+    i9.dst = gp(0, 8); i9.src1 = gp(1, 8);
+    i9.src2 = isa.make_imm(0, 1); i9.src3 = isa.make_imm(31, 1);
+    bad = bad | rendered_is(?buf, ?i9, "sxtw x0, w1");
+
+    var i10: Inst = inst(FORM_BITFIELD, 0xD3400000);
+    i10.dst = gp(4, 8); i10.src1 = gp(5, 8);
+    i10.src2 = isa.make_imm(4, 1); i10.src3 = isa.make_imm(63, 1);
+    bad = bad | rendered_is(?buf, ?i10, "lsr x4, x5, #4");
+
+    var i11: Inst = inst(FORM_BITFIELD, 0xD3400000);
+    i11.dst = gp(0, 8); i11.src1 = gp(3, 8);
+    i11.src2 = isa.make_imm(32, 1); i11.src3 = isa.make_imm(31, 1);
+    bad = bad | rendered_is(?buf, ?i11, "lsl x0, x3, #32");
+
+    var i12: Inst = inst(FORM_BITFIELD, 0xD3400000);
+    i12.dst = gp(0, 8); i12.src1 = gp(1, 8);
+    i12.src2 = isa.make_imm(3, 1); i12.src3 = isa.make_imm(10, 1);
+    bad = bad | rendered_is(?buf, ?i12, "ubfx x0, x1, #3, #8");
+
+    # a MOVZ names the SIGNED value its pattern denotes at the destination width
+    var i13: Inst = inst(FORM_MOVEWIDE, 0xD2800000);
+    i13.dst = gp(17, 8); i13.src2 = isa.make_imm(0x8000, 8); i13.src3 = isa.make_imm(48, 1);
+    bad = bad | rendered_is(?buf, ?i13, "mov x17, #-0x8000000000000000");
+
+    # a MOVK keeps its name, its unsigned immediate, and its explicit shift
+    var i14: Inst = inst(FORM_MOVEWIDE, 0xF2800000);
+    i14.dst = gp(16, 8); i14.src2 = isa.make_imm(0xFFFF, 8); i14.src3 = isa.make_imm(16, 1);
+    bad = bad | rendered_is(?buf, ?i14, "movk x16, #0xffff, lsl #16");
+
+    # a CSINC with both sources at the zero register is a CSET, whose printed
+    # condition is the encoded field inverted
+    var i15: Inst = inst(FORM_CSET, 0x1A800400);
+    i15.dst = gp(0, 4); i15.flags = 1;
+    bad = bad | rendered_is(?buf, ?i15, "cset w0, eq");
+
+    # a multiply-accumulate keeps all four operands
+    var i16: Inst = inst(FORM_MADD, 0x9B008000);
+    i16.dst = gp(0, 8); i16.src1 = gp(1, 8); i16.src2 = gp(2, 8); i16.src3 = gp(3, 8);
+    bad = bad | rendered_is(?buf, ?i16, "msub x0, x1, x2, x3");
+
+    # a pre-index pair writes its base back; a post-index pair offsets after
+    var i17: Inst = inst(FORM_LDSTP, 0xA9800000);
+    i17.flags = FLAG_WB_PRE;
+    i17.dst = isa.make_mem(gp(31, 8).reg, -16, -1, 0, 8);
+    i17.src1 = gp(29, 8); i17.src2 = gp(30, 8);
+    bad = bad | rendered_is(?buf, ?i17, "stp x29, x30, [sp, #-0x10]!");
+
+    var i18: Inst = inst(FORM_LDSTP, 0xA8C00000);
+    i18.flags = FLAG_WB_POST;
+    i18.dst = gp(29, 8); i18.src1 = gp(30, 8);
+    i18.src2 = isa.make_mem(gp(31, 8).reg, 16, -1, 0, 8);
+    bad = bad | rendered_is(?buf, ?i18, "ldp x29, x30, [sp], #0x10");
+
+    # a store names its source register first, though the memory operand is the
+    # location written
+    var i19: Inst = inst(FORM_LDST, 0xF9000000);
+    i19.dst = isa.make_mem(gp(1, 8).reg, 8, -1, 0, 8);
+    i19.src1 = gp(0, 8);
+    bad = bad | rendered_is(?buf, ?i19, "str x0, [x1, #0x8]");
+
+    # the lane arrangement rides every operand of a NEON three-register form
+    var i20: Inst = inst(FORM_NEON_3SAME, 0x4E20D400);
+    i20.dst = vec(2, 16); i20.src1 = vec(0, 16); i20.src2 = vec(1, 16);
+    i20.vec_lane = mir.vec_lane_make(mir.VEC_LANE_FLOAT, 4);
+    bad = bad | rendered_is(?buf, ?i20, "fadd v2.4s, v0.4s, v1.4s");
+
+    var i21: Inst = inst(FORM_NEON_3SAME, 0x4E208400);
+    i21.dst = vec(2, 16); i21.src1 = vec(0, 16); i21.src2 = vec(1, 16);
+    i21.vec_lane = mir.vec_lane_make(mir.VEC_LANE_INT, 2);
+    bad = bad | rendered_is(?buf, ?i21, "add v2.8h, v0.8h, v1.8h");
+
+    # a bitwise OR of a register with itself is the vector register move
+    var i22: Inst = inst(FORM_NEON_3SAME, 0x4EA01C00);
+    i22.dst = vec(5, 16); i22.src1 = vec(6, 16); i22.src2 = vec(6, 16);
+    i22.vec_lane = mir.vec_lane_make(mir.VEC_LANE_INT, 1);
+    bad = bad | rendered_is(?buf, ?i22, "mov v5.16b, v6.16b");
+
+    # a trap code prints bare at zero
+    var i23: Inst = inst(FORM_IMM16, 0xD4200000);
+    i23.src1 = isa.make_imm(0, 2);
+    bad = bad | rendered_is(?buf, ?i23, "brk #0");
+
+    enc.buf_dnit(?buf);
+    ret bad;
+}
+
+# an unmapped base word fails the render rather than printing something plausible
+#
+# Totality is what makes the artifact trustworthy: a new base word that reaches the
+# printer without a mnemonic breaks the build instead of silently vanishing from the
+# `.s`, which is what let the previous divergence go unnoticed.
+test "mach.lang.target.isa.arm64.printer.render_inst:unmapped_base_is_an_error" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+    var buf: enc.ByteBuf = enc.buf_init(?alloc);
+
+    var w: writer.Writer;
+    w.ctx     = nil;
+    w.f_write = test_sink_write;
+    var sink: enc.AsmSink = enc.sink_init(?w, nil);
+    buf.asm = ?sink;
+
+    var bad: i32 = 0;
+    test_sink_reset();
+
+    var i: Inst = inst(FORM_ALU3, 0x00000000);
+    i.dst = gp(0, 8); i.src1 = gp(1, 8); i.src2 = gp(2, 8);
+    note_inst(?buf, ?i);
+    if (!buf.asm.failed) { bad = 1; }
+
+    enc.buf_dnit(?buf);
+    ret bad;
 }

--- a/src/lang/target/isa/arm64/register.mach
+++ b/src/lang/target/isa/arm64/register.mach
@@ -17,7 +17,6 @@ use R: std.types.result;
 use mach.lang.target.isa;
 use mach.lang.target.isa.arm64;
 use mach.lang.target.isa.arm64.encode;
-use mach.lang.target.isa.arm64.printer;
 use mach.lang.target.isa.arm64.rules;
 use mach.lang.target.of;
 use mach.lang.target.of.elf;
@@ -134,9 +133,11 @@ fun arm64_dwarf_reg(regid: i32) i32 {
 # `EncodeFn` signatures by the shared isel / encode dispatchers. Both implement
 # the leaf-integer backend: a leaf integer function compiles to byte-correct
 # AArch64, while the deferred families (calls, floats, conversions, varargs,
-# spills) fail loudly rather than emit wrong bytes. `emit_asm` refuses, naming
-# aarch64 and #2194, until its printer is written. `asm_clobbers` infers the registers an inline-asm body writes, so
-# a function clobbering only caller-saved registers (e.g. `_start`) is not framed.
+# spills) fail loudly rather than emit wrong bytes. `emit_asm` runs that same encoder
+# with an assembly sink attached, so `--emit-asm` renders the instruction stream the
+# encoder really produced (#2194). `asm_clobbers` infers the registers an inline-asm
+# body writes, so a function clobbering only caller-saved registers (e.g. `_start`)
+# is not framed.
 # ---
 # reg: the ISA registry to install the vtable into
 # ret: true on success
@@ -193,7 +194,7 @@ pub fun register_arm64(reg: *isa.IsaRegistry) R.Result[bool, str] {
     arm64_vtable.encode               = encode.encode_arm64::*u8;
     # no assembly printer yet (#2194): registering the refusal rather than nil makes
     # `--emit-asm` fail naming aarch64, instead of silently leaving an empty `.s`.
-    arm64_vtable.emit_asm             = printer.print_asm_arm64::*u8;
+    arm64_vtable.emit_asm             = encode.encode_arm64_asm::*u8;
     arm64_vtable.asm_clobbers         = encode.asm_clobbers::*u8;
     arm64_vtable.is_reg_move          = rules.is_reg_move::*u8;
     arm64_vtable.reserved_regs        = ?arm64_reserved_regs[0];


### PR DESCRIPTION
Closes #2194. The aarch64 slice of #2192 / #2212, generalizing the shape #2197 proved on x86-64.

aarch64 was the worst of the three: **no printer at all**. `arm64_vtable.emit_asm` was nil, `print_asm_arm64` was a deliberately-unwired stub, and before #2187 `--emit-asm` silently wrote a **0-byte `.s`** while reporting success — **0 of 65,458** instructions across the cross-check corpus.

## Packer-level capture: no decoder needed

x86-64 works because it has a structured choke point, `encode_inst(mi: *isa.Inst, buf)`. aarch64 goes MIR → bit-fields → `emit_word(st, word: u32)`, so by emission time the instruction is an opaque integer.

**The structure was never absent — it was discarded one layer too early.** The bitfield-class packers (`pack_alu3`, `pack_addsub_imm`, `pack_ldst`, `pack_ldstp`, `pack_neon_3same`, …) receive every field as an argument. Each gains an `emit_*` wrapper that emits the packed word and notifies the printer with the *same* fields. **Capture at the packers, and no disassembler is needed.** 106 of the 145 `emit_word` sites converted mechanically; the rest are the forms carrying a name no machine field can hold (a branch's block, a call's symbol, a `:lo12:` relocation), which now pass it explicitly.

`emit_word` has exactly one class of caller — the wrappers — so a word appended without a notification is bytes the `.s` would not describe, which the guard turns into a build failure.

## Relation to `isa.Inst` — what fits, what does not

**Operand payloads are the shared `isa.Operand`.** Register, immediate, memory base+index+scale+disp, block label and symbol all map 1:1, and the slots are **semantic** (`dst` is the location written), so a store puts its memory operand there and the renderer emits AArch64's source-first order explicitly rather than inferring it. Collapsing onto `isa.Inst` is a substitution of the key, not a rewrite of the payloads.

**The key is still the base word.** `isa.Inst.opcode` is a u16; an AArch64 base word is 32 bits. Carrying a minted u16 opcode *alongside* the base word would put a second, independent naming of the instruction next to the bytes — the drift #2197 found five instances of on x86-64. Making the opcode the single naming requires the emitters to look the base word **up** from it, which is #2118's format-table rewrite of the encoder, not a printer change — and would have destroyed this issue's own byte-identical, printer-only bar.

Checked, and **fits without a representation change**:

- **NEON lane arrangement** rides `flags` and is read back through the existing `mir.vec_lane_*` accessors — one lane descriptor in the compiler, not a parallel one that can fall out of step (the #2037 drop-class).
- **Relocation modifiers** (`:lo12:` / `:got:` / `:got_lo12:`) ride an arm64-local field. `isa.Operand.sym_mod` with its shared `SYM_MOD_*` set lands on the riscv64 branch (#2214), which is blocked on it; this converts on rebase. No shared constant was defined here.
- **Condition codes** ride `flags[3:0]` rather than opcodes-per-condition. **This is a deliberate divergence from x86-64 and should not later be "fixed" into symmetry**: x86's `JE`/`JNE`/`SETE` genuinely *are* distinct opcodes, whereas AArch64's `B.cond` is one instruction with a condition field and `cset` one alias with one. Modelling it as 30 opcodes would be less faithful to the machine.

### Known debt, and why it is debt and not a workaround

Two things genuinely do not fit `isa.Inst` as it stands: **arity 4** (`msub Rd, Rn, Rm, Ra` — every integer remainder) and **two immediate operands** (`ubfm Rd, Rn, #immr, #imms` — every immediate shift and every sub-word extend; 1356 `uxtb` + 48 `sxtw` + the shifts in one 31-module corpus). One additive field, `isa.Inst.src3`, covers both. It is **not** added here.

Surfacing *why* is the more valuable half. mach's `var` does not zero-initialise — x86-64 sets `src2.kind = 0` by hand at `encode.mach:1762` for exactly that reason — so **adding a field to `isa.Inst` is not additive**. It requires auditing every construction site across five targets, and a missed one reads stack garbage on one target and nowhere else. Doing that inside this rework, with #2208 live in `x64/encode.mach`, is how it goes wrong quietly. Filed as #2214, with a zeroing `inst_blank()` filed separately as its prerequisite.

On this branch the fourth operand lives on the arm64-private record, which zero-initialises through its own constructor, so **no operand actually hides in a bitfield here** — that wart would only appear if this were forced onto `isa.Inst.flags` before `src3` exists.

## Streaming, not buffering — verified, not assumed

riscv64 must buffer its notifications because branch relaxation rewrites instructions after layout. aarch64 does not, and this was checked rather than inherited:

- **`insert_text` is never called** — the only references in the tree are the spine's own definition and unit test.
- **No relaxation.** `patch_branch_arm64` is a fixed-position bitfield insert; text length never changes and no instruction is added, removed or re-formed. An out-of-range displacement is **rejected loudly** (`encode.mach:2620`, `:2626`), not relaxed into a veneer.
- **No literal pools, no veneers, no trampolines.** Float constants materialize inline via `movz`/`movk` + `fmov`.
- **ADRP/ADD and ADRP/LDR pairs are emitted adjacently**; their immediates are placeholders the *linker* fills, and they render as `:lo12:sym`, so they are correct regardless of what is later written.
- **Branch targets render as labels, never displacements** — a deliberate choice, so even the pass-2 patch cannot desynchronise text from object.

## Before / after

`sum_to`, aarch64 — printed vs the `.o` from the same run:

| before (`.s`) | after (`.s`) | `llvm-objdump` |
|---|---|---|
| *(0-byte file)* | `stp x29, x30, [sp, #-0x10]!` | `stp x29, x30, [sp, #-0x10]!` |
| | `mov x29, sp` | `mov x29, sp` |
| | `mov x1, #0x0` | `mov x1, #0x0` |
| | `cmp x2, x0` / `b.lt .2` | `cmp x2, x0` / `b.lt 0x1c` |
| | `ldp x29, x30, [sp], #0x10` / `ret` | `ldp x29, x30, [sp], #0x10` / `ret` |

## Object-vs-asm cross-check (the acceptance criterion)

Printed `.s` vs `llvm-objdump` of the `.o` from the same run, compared **ordered, instruction by instruction** (position-wise mnemonic + count), and additionally **operand text** on every line where the two spellings should agree — a stricter bar than x86-64's per-module multiset.

| corpus | before | after |
|---|---|---|
| aarch64 control-flow + full std, 31 modules | 0 / 65,458 (empty file) | **0 diverged, 65,458 / 65,458** |
| `int/surface` + `int/regression`, linux-arm64 **release** | — | **28 clean, 0 problems** |
| `int/surface` + `int/regression`, linux-arm64 **debug** | — | **28 clean, 0 problems** |
| `int/surface` + `int/regression`, darwin-aarch64 **release** | — | **25 clean, 0 problems** |
| `int/surface` + `int/regression`, darwin-aarch64 **debug** | — | **25 clean, 0 problems** |

**Vector-heavy, explicitly.** `int/surface/vectors` cross-checks **126,885 / 126,885** exactly. With `simd = "require"` forcing the NEON path, all four arrangements render and match: **219 `.4s`, 157 `.16b`, 96 `.2d`, 54 `.8h`** — 183 arrangement-bearing instructions in the object, 183 in the `.s`. This is the field a prior bug (#2037) dropped when an instruction was rebuilt.

Operand comparison is skipped only where the artifact is legitimately *more* informative than the disassembly: a branch names a label where the object holds a resolved address, and a relocated access names its symbol where the object holds the linker's zero placeholder. Every other line matches character for character.

## What the guard and the cross-check caught

The totality guard fired immediately on a **`B.cond` base-word mask that swallowed the condition** (`0xFF00001F` folded the cond bits into the comparison), so every conditional branch failed to render rather than rendering wrongly — the guard doing exactly its job.

The cross-check then found four **immediate-formatting** divergences. None would have been caught by review, and each would have made the `.s` disagree with any disassembly of the bytes it describes:

- **shift amounts print in decimal, values in hex** — `lsl #16`, not `lsl #0x10`; 8,476 `movk` + 43 `sub …, lsl #12` + 24 `lsr` + 4 `lsl` + 2 `asr` affected;
- **bitfield extract positions and widths print in decimal** — `ubfx x0, x1, #3, #8`;
- **`brk` / `svc` trap codes print `#0`, not `#0x0`** — 104 `brk` + 13 `svc`;
- **a `MOVZ` names the SIGNED value its pattern denotes at the destination width** — `movz x17, #0x8000, lsl #48` disassembles as `mov x17, #-0x8000000000000000`; 42 affected.

Two findings that are checker-side, recorded because they will bite the next aarch64 consumer: llvm-objdump comments the decoded value with `//` on ELF but `;` on Mach-O, and prints NEON in the **Apple dialect** on Mach-O (`add.4s v2, v0, v1`) versus the ARM canonical form on ELF (`add v2.4s, v0.4s, v1.4s`). The `.s` emits the canonical form, which is what an assembler accepts; the checker folds the dialect.

One further bug the cross-check could **not** have caught, found by reading: `sub sp, sp, Xm` — the extended-register form an oversized frame uses — names SP in **both** Rd and Rn, where every other three-register form reads register 31 as the zero register. The renderer applied that to Rn only, so the destination came out `xzr`. It is reachable only from a frame past `MAX_FRAME_SUB` (~16MB), so no corpus module exercises it; it is now pinned by the alias test, which fails without the fix.

Observed and **not fixed** (out of scope): `pack_neon_lane_read` and `pack_neon_ins_gp` (UMOV / SMOV / INS) have no emission path — they are reached only by unit tests. They therefore have no emitter and no renderer.

## Verification

- **Objects byte-identical** to the branch point across **314 objects** — linux, linux-arm64, linux-riscv64, darwin-aarch64 and windows, debug and release — and identical **with and without `--emit-asm`** across 62. Printer-only; no ISA's codegen moved.
- **Totality guard mutation-tested on the final code, twice.** Neutering `check_accounted` gives **793 passed, 1 failed**, naming `check_accounted:rejects_unrendered_bytes`. Dropping the notification from a single emitter (`emit_alu3`) makes a real `--emit-asm` build fail with `--emit-asm: opcode 13 emitted bytes the aarch64 assembly printer did not render` — opcode 13 is `arm64.MOV`. Both restored, green.
- **Suites:** mach **794 / 0** (baseline 790, plus the four tests added here), mach-std **611 / 0** at pin `eff1e8e` (`git rev-parse HEAD` verified against `mach.lock`, not assumed from a bare clone).
- **Three-generation fixpoint: A == B == C** byte-identical. The change is codegen-neutral, so even A matches.
- riscv64 still refuses naming #2193, and x86-64 still renders — both untouched.
- **CI green on every lane**, including the two that exercise aarch64: `build` / `release` / `test aarch64-linux` and `int linux-arm64`.
