### PR TITLE
fix(emit-asm): render the riscv64 .s from the encoder's instruction stream

### DIFF
--- a/doc/cli.md
+++ b/doc/cli.md
@@ -63,7 +63,7 @@ A verbosity flag (`-v`/`-vv`) and `--quiet` together is a parse error.
 | `--lib <name>`   | artifact name    | narrow the build to one `static`/`shared` `[artifact.<name>]` (mutually exclusive with `--bin`) |
 | `-o <path>`      | path             | override the artifact path, rooted at the project root (build/run/test) |
 | `--all-targets`  | —                | build every declared `[target.*]`, not just the default (mutually exclusive with `-o`, which names one path) |
-| `--emit-asm`     | —                | emit per-module assembly text (`.s`) — each line is one machine instruction the encoder emitted for that module, so the `.s` corresponds to the `.o` instruction for instruction. Supported on x86-64; riscv64 and aarch64 fail naming their tracking issue rather than emit a misleading file. Emission is opt-in, controlled only by this flag |
+| `--emit-asm`     | —                | emit per-module assembly text (`.s`) — each line is one machine instruction the encoder emitted for that module, so the `.s` corresponds to the `.o` instruction for instruction. Supported on x86-64 and riscv64; aarch64 fails naming its tracking issue rather than emit a misleading file. Emission is opt-in, controlled only by this flag |
 | `--emit-ir`      | —                | emit per-module SSA IR text (`.ir`), the final post-pipeline IR the object is built from (so it varies with the profile's `opt`) — emission is opt-in, controlled only by this flag |
 | `--verify-ir`    | —                | run the IR verifier after each optimisation pass |
 

--- a/src/lang/be/codegen/encode.mach
+++ b/src/lang/be/codegen/encode.mach
@@ -47,6 +47,7 @@ use mach.lang.be.codegen.mir;
 use mach.lang.intern;
 use mach.lang.source;
 use mach.lang.target.abi;
+use mach.lang.target.isa;
 use mach.lang.target.of;
 use tos: mach.lang.target.os;
 use target: mach.lang.target.resolved;
@@ -351,21 +352,76 @@ pub rec ByteBuf {
 # dispatch. A renderer reads it only to name what the machine operand cannot carry
 # (a call's target symbol, a branch's block label - `mir_to_operand` erases both),
 # never to choose a mnemonic or an operand.
+#
+# A notification may be RENDERED IMMEDIATELY or BUFFERED. An architecture whose
+# instruction's first form is its last renders on the spot and needs nothing more
+# than `sink_account`. One whose final form is settled later - RISC-V, whose branch
+# relaxation rewrites an over-range conditional into an inverted guard plus a jump
+# after the whole function is laid out - buffers its notifications as `AsmNote`s
+# here, lets the relaxation pass edit them exactly as it edits the text, and renders
+# once the layout is final. Streaming such a target would print the instruction it
+# first planned rather than the one the object holds, which is the divergence this
+# whole mechanism exists to make unrepresentable (#2187).
+#
+# The note offsets are one more table that must stay consistent with the text, so
+# they live beside the block / fixup / symbol / relocation tables `insert_text`
+# already shifts rather than in ISA-private memory that a future shift path could
+# forget. A target that renders as it goes never pushes a note and pays nothing.
 # ---
-# out:       destination writer for the rendered text
-# accounted: `ByteBuf.len` as of the last instruction notification
-# failed:    a write error occurred; the first one is kept in `err`
-# err:       the first write error, empty until `failed`
-# mi:        the MIR instruction being encoded, for symbol / label annotation
-# interner:  resolves symbol ids to their source names
+# The buffer is backed by the owning `ByteBuf`'s allocator, so buffering costs the
+# sink no extra construction argument and a target that never pushes a note never
+# allocates.
+# ---
+# out:        destination writer for the rendered text
+# accounted:  `ByteBuf.len` as of the last instruction notification
+# failed:     a write error occurred; the first one is kept in `err`
+# err:        the first write error, empty until `failed`
+# mi:         the MIR instruction being encoded, for symbol / label annotation
+# interner:   resolves symbol ids to their source names
+# notes:      buffered notifications, in emission order (nil until the first push)
+# note_count: number of buffered notifications
+# note_cap:   capacity of `notes`
+# note_insts: how many of the buffered notifications are instructions
 pub rec AsmSink {
-    out:       *writer.Writer;
-    accounted: usize;
-    failed:    bool;
-    err:       str;
-    mi:        *mir.MirInstr;
-    interner:  *intern.Interner;
+    out:        *writer.Writer;
+    accounted:  usize;
+    failed:     bool;
+    err:        str;
+    mi:         *mir.MirInstr;
+    interner:   *intern.Interner;
+    notes:      *AsmNote;
+    note_count: u32;
+    note_cap:   u32;
+    note_insts: u32;
 }
+
+# what one buffered notification stands for
+pub val ASM_NOTE_INST:  u8 = 0;  # one emitted machine instruction
+pub val ASM_NOTE_FUNC:  u8 = 1;  # a function's heading; emits no bytes
+pub val ASM_NOTE_BLOCK: u8 = 2;  # a block's local label; emits no bytes
+
+# one buffered notification: a machine instruction the encoder emitted, or a
+# function / block heading
+#
+# `off` is the instruction's `.text` offset, kept correct by `insert_text` exactly
+# as the block and fixup offsets are, so a relaxation pass can find the note whose
+# text it is about to rewrite after any number of earlier growths.
+# ---
+# kind: ASM_NOTE_INST / ASM_NOTE_FUNC / ASM_NOTE_BLOCK
+# off:  `.text` byte offset of the instruction's first byte
+# inst: the emitted machine instruction (ASM_NOTE_INST)
+# name: the function's interned name (ASM_NOTE_FUNC)
+# id:   the block id (ASM_NOTE_BLOCK)
+pub rec AsmNote {
+    kind: u8;
+    off:  u32;
+    inst: isa.Inst;
+    name: intern.StrId;
+    id:   u32;
+}
+
+# initial capacity of a sink's note buffer
+val ASM_NOTE_INIT_CAP: u32 = 64;
 
 # construct a sink rendering into `out`
 # ---
@@ -374,13 +430,188 @@ pub rec AsmSink {
 # ret:      an armed sink with nothing yet accounted
 pub fun sink_init(out: *writer.Writer, interner: *intern.Interner) AsmSink {
     var s: AsmSink;
-    s.out       = out;
-    s.accounted = 0;
-    s.failed    = false;
-    s.err       = "";
-    s.mi        = nil;
-    s.interner  = interner;
+    s.out        = out;
+    s.accounted  = 0;
+    s.failed     = false;
+    s.err        = "";
+    s.mi         = nil;
+    s.interner   = interner;
+    s.notes      = nil;
+    s.note_count = 0;
+    s.note_cap   = 0;
+    s.note_insts = 0;
     ret s;
+}
+
+# construct a cleared instruction notification
+# ---
+# ret: an ASM_NOTE_INST note with an empty instruction
+pub fun note_blank() AsmNote {
+    var n: AsmNote;
+    n.kind = ASM_NOTE_INST;
+    n.off  = 0;
+    n.inst = isa.inst_blank();
+    n.name = intern.STR_NIL;
+    n.id   = 0;
+    ret n;
+}
+
+# buffer one notification, marking the bytes it covers as accounted
+#
+# An instruction note advances the totality guard exactly as an immediate render
+# does: the guard compares `accounted` against the buffer length, so a byte no
+# notification covers is still reported whether the ISA streams or buffers.
+# ---
+# buf: the encoder byte sink carrying the assembly sink
+# n:   the notification to buffer
+# ret: true on success, or an allocation error
+pub fun note_push(buf: *ByteBuf, n: *AsmNote) R.Result[bool, str] {
+    if (!sink_active(buf)) { ret R.ok[bool, str](true); }
+    val s: *AsmSink = buf.asm;
+    if (s.note_count >= s.note_cap) {
+        val res_grow: R.Result[bool, str] = grow_notes(s, buf.alloc);
+        if (R.is_err[bool, str](res_grow)) { ret res_grow; }
+    }
+    s.notes[s.note_count] = @n;
+    s.note_count = s.note_count + 1;
+    if (n.kind == ASM_NOTE_INST) {
+        s.note_insts = s.note_insts + 1;
+        sink_account(buf);
+    }
+    ret R.ok[bool, str](true);
+}
+
+# insert one notification after the note at `idx`
+#
+# The relaxation counterpart of writing an instruction into a gap `insert_text` just
+# opened: the new word is a real emitted instruction and must be rendered as one.
+# ---
+# buf: the encoder byte sink carrying the assembly sink
+# idx: the note the new one follows
+# n:   the notification to insert (its `off` is already set)
+# ret: true on success, or an allocation error
+pub fun note_insert_after(buf: *ByteBuf, idx: u32, n: *AsmNote) R.Result[bool, str] {
+    if (!sink_active(buf)) { ret R.ok[bool, str](true); }
+    val s: *AsmSink = buf.asm;
+    if (idx >= s.note_count) {
+        ret R.err[bool, str]("--emit-asm: an instruction notification was inserted after an unknown one");
+    }
+    if (s.note_count >= s.note_cap) {
+        val res_grow: R.Result[bool, str] = grow_notes(s, buf.alloc);
+        if (R.is_err[bool, str](res_grow)) { ret res_grow; }
+    }
+    var i: u32 = s.note_count;
+    val at: u32 = idx + 1;
+    for (i > at) {
+        s.notes[i] = s.notes[i - 1];
+        i = i - 1;
+    }
+    s.notes[at] = @n;
+    s.note_count = s.note_count + 1;
+    if (n.kind == ASM_NOTE_INST) {
+        s.note_insts = s.note_insts + 1;
+        sink_account(buf);
+    }
+    ret R.ok[bool, str](true);
+}
+
+# the number of buffered notifications
+# ---
+# buf: the encoder byte sink
+# ret: the note count, or 0 when no sink is buffering
+pub fun note_count(buf: *ByteBuf) u32 {
+    if (!sink_active(buf)) { ret 0; }
+    ret buf.asm.note_count;
+}
+
+# the buffered notification at `idx`, or nil
+# ---
+# buf: the encoder byte sink
+# idx: the note index
+# ret: the note, or nil when the index is out of range
+pub fun note_at(buf: *ByteBuf, idx: u32) *AsmNote {
+    if (!sink_active(buf)) { ret nil; }
+    if (idx >= buf.asm.note_count) { ret nil; }
+    ret ?buf.asm.notes[idx];
+}
+
+# the index of the buffered instruction whose bytes begin at `off`, or -1
+#
+# A relaxation pass works in `.text` offsets; this is how it reaches the note whose
+# instruction it is rewriting.
+# ---
+# buf: the encoder byte sink
+# off: the `.text` offset to look up
+# ret: the note index, or -1 when no instruction begins there
+pub fun note_index_at(buf: *ByteBuf, off: u32) i32 {
+    if (!sink_active(buf)) { ret -1; }
+    val s: *AsmSink = buf.asm;
+    var i: u32 = 0;
+    for (i < s.note_count) {
+        if (s.notes[i].kind == ASM_NOTE_INST && s.notes[i].off == off) { ret i::i32; }
+        i = i + 1;
+    }
+    ret -1;
+}
+
+# drop every buffered notification, keeping the allocated capacity
+#
+# Called once a function's notes have been rendered, so the buffer is reused across
+# functions rather than reallocated per function.
+# ---
+# buf: the encoder byte sink
+pub fun notes_reset(buf: *ByteBuf) {
+    if (buf == nil || buf.asm == nil) { ret; }
+    buf.asm.note_count = 0;
+    buf.asm.note_insts = 0;
+}
+
+# how many buffered notifications are instructions
+#
+# A fixed-width ISA turns this into an EXACT totality check - emitted bytes must
+# equal the instruction count times the instruction width - which is strictly
+# stronger than the byte-accounting `sink_unaccounted` a variable-width ISA can
+# manage. Byte accounting alone lets a later notification absorb an earlier missing
+# one, because `accounted` only ever moves forward to the buffer length; counting
+# instructions does not.
+# ---
+# buf: the encoder byte sink
+# ret: the instruction-notification count, or 0 when no sink is buffering
+pub fun note_inst_count(buf: *ByteBuf) u32 {
+    if (!sink_active(buf)) { ret 0; }
+    ret buf.asm.note_insts;
+}
+
+# release a sink's note buffer
+# ---
+# buf: the encoder byte sink; safe when no sink or no buffer was ever used
+pub fun notes_free(buf: *ByteBuf) {
+    if (buf == nil || buf.asm == nil) { ret; }
+    val s: *AsmSink = buf.asm;
+    if (s.notes == nil || s.note_cap == 0) { ret; }
+    A.deallocate[AsmNote](buf.alloc, s.notes, s.note_cap::usize);
+    s.notes      = nil;
+    s.note_count = 0;
+    s.note_cap   = 0;
+    s.note_insts = 0;
+}
+
+# double a sink's note-buffer capacity
+# ---
+# s:     the sink whose buffer grows
+# alloc: the owning byte sink's allocator
+# ret:   true on success, or an allocation error
+fun grow_notes(s: *AsmSink, alloc: *A.Allocator) R.Result[bool, str] {
+    var new_cap: u32 = ASM_NOTE_INIT_CAP;
+    if (s.note_cap > 0) { new_cap = s.note_cap * 2; }
+    val res_realloc: R.Result[*AsmNote, str] =
+        A.reallocate[AsmNote](alloc, s.notes, s.note_cap::usize, new_cap::usize);
+    if (R.is_err[*AsmNote, str](res_realloc)) {
+        ret R.err[bool, str](R.unwrap_err[*AsmNote, str](res_realloc));
+    }
+    s.notes    = R.unwrap_ok[*AsmNote, str](res_realloc);
+    s.note_cap = new_cap;
+    ret R.ok[bool, str](true);
 }
 
 # record a write failure so the encode driver can report it
@@ -735,6 +966,7 @@ pub fun encode_driver_asm(alloc: *A.Allocator, tgt: *target.Target, m: *mir.MirM
         st.last_inline_site = 0;
         val res_encode: R.Result[bool, str] = hooks.encode_function(?st, ?m.functions[fi]);
         if (R.is_err[bool, str](res_encode)) {
+            notes_free(?st.buf);
             state_dnit(?st);
             ret R.err[EncoderOutput, str](R.unwrap_err[bool, str](res_encode));
         }
@@ -742,9 +974,11 @@ pub fun encode_driver_asm(alloc: *A.Allocator, tgt: *target.Target, m: *mir.MirM
     }
 
     if (sink.failed) {
+        notes_free(?st.buf);
         state_dnit(?st);
         ret R.err[EncoderOutput, str](sink.err);
     }
+    notes_free(?st.buf);
 
     val res_patch: R.Result[bool, str] = patch_branches(?st, hooks);
     if (R.is_err[bool, str](res_patch)) {
@@ -1450,6 +1684,17 @@ pub fun insert_text(st: *EncodeState, pos: u32, nbytes: u32) R.Result[bool, str]
     for (ipi < st.inline_pc_count) {
         if (st.inline_pcs[ipi].text_offset >= pos) { st.inline_pcs[ipi].text_offset = st.inline_pcs[ipi].text_offset + nbytes; }
         ipi = ipi + 1;
+    }
+    # a buffered assembly notification names the instruction at an offset, so it
+    # shifts with the text exactly as the block and fixup offsets do; a note left
+    # behind would have the relaxation pass rewrite the wrong instruction on its next
+    # iteration and the artifact would name a form the object does not hold.
+    if (st.buf.asm != nil) {
+        var ni: u32 = 0;
+        for (ni < st.buf.asm.note_count) {
+            if (st.buf.asm.notes[ni].off >= pos) { st.buf.asm.notes[ni].off = st.buf.asm.notes[ni].off + nbytes; }
+            ni = ni + 1;
+        }
     }
     ret R.ok[bool, str](true);
 }

--- a/src/lang/target/isa.mach
+++ b/src/lang/target/isa.mach
@@ -93,32 +93,56 @@ pub rec RegisterFile {
     count: i32;
 }
 
+# the relocation modifier a symbol reference carries
+#
+# A target that cannot reach a symbol in one instruction forms its address as a
+# pair, and the two halves take different relocations and DIFFERENT ASSEMBLY TEXT:
+# riscv64 emits `auipc rd, %pcrel_hi(sym)` then `addi rd, rd, %pcrel_lo(sym)`;
+# aarch64 emits `adrp x16, sym` then `ldr x0, [x16, :lo12:sym]`. The modifier
+# belongs to the symbol REFERENCE, not to the instruction - an instruction may carry
+# more than one operand, and it is the operand that is relocated.
+#
+# The set is named once, in full, for every target that forms addresses this way:
+# two branches each appending "the next value" to a shared constant space is how two
+# unrelated flags have already silently landed on the same bit. A target consumes
+# these rather than extending them; a genuinely new modifier is a change here, with
+# every caller visible.
+pub def SymModifier: u8;
+pub val SYM_MOD_NONE:     SymModifier = 0;  # the reference is unmodified
+pub val SYM_MOD_PCREL_HI: SymModifier = 1;  # rv64 `%pcrel_hi`, aarch64 `adrp` page-high
+pub val SYM_MOD_PCREL_LO: SymModifier = 2;  # rv64 `%pcrel_lo`, aarch64 `:lo12:`
+pub val SYM_MOD_GOT_HI:   SymModifier = 3;  # rv64 `%got_pcrel_hi`, aarch64 `:got:`
+pub val SYM_MOD_GOT_LO:   SymModifier = 4;  # aarch64 `:got_lo12:`
+
 # a single machine-instruction operand
 #
 # The active fields depend on `kind`: REG uses `reg`; IMM uses `imm`; MEM uses
 # `base` / `index` / `scale` / `disp`; LABEL uses `label`; SYM uses `sym_id`.
 # ---
-# kind:   operand discriminant
-# size:   operand width in bytes
-# reg:    register id for OPK_REG (or base for some forms)
-# imm:    immediate value for OPK_IMM
-# base:   base register id for OPK_MEM (-1 if none)
-# index:  index register id for OPK_MEM (-1 if none)
-# scale:  index scale for OPK_MEM (1, 2, 4, or 8)
-# disp:   displacement for OPK_MEM
-# sym_id: symbol id for OPK_SYM
-# label:  label name for OPK_LABEL
+# kind:    operand discriminant
+# size:    operand width in bytes
+# reg:     register id for OPK_REG (or base for some forms)
+# imm:     immediate value for OPK_IMM
+# base:    base register id for OPK_MEM (-1 if none)
+# index:   index register id for OPK_MEM (-1 if none)
+# scale:   index scale for OPK_MEM (1, 2, 4, or 8)
+# disp:    displacement for OPK_MEM
+# sym_id:  symbol id for OPK_SYM
+# label:   label name for OPK_LABEL
+# sym_mod: the relocation modifier a symbol reference carries (SYM_MOD_NONE for an
+#          unmodified reference and for every non-symbol operand)
 pub rec Operand {
-    kind:   OperandKind;
-    size:   u8;
-    reg:    i32;
-    imm:    i64;
-    base:   i32;
-    index:  i32;
-    scale:  u8;
-    disp:   i32;
-    sym_id: u32;
-    label:  str;
+    kind:    OperandKind;
+    size:    u8;
+    reg:     i32;
+    imm:     i64;
+    base:    i32;
+    index:   i32;
+    scale:   u8;
+    disp:    i32;
+    sym_id:  u32;
+    label:   str;
+    sym_mod: SymModifier;
 }
 
 # a single machine instruction in the target-agnostic model
@@ -871,7 +895,46 @@ fun operand_blank(kind: OperandKind, size: u8) Operand {
     op.disp   = 0;
     op.sym_id = 0;
     op.label  = nil;
+    # every operand starts unmodified, so a target that never forms a symbol address
+    # as a pair reads SYM_MOD_NONE by construction rather than by leaving a field unset
+    op.sym_mod = SYM_MOD_NONE;
     ret op;
+}
+
+# build a symbol-reference operand carrying a relocation modifier
+#
+# The half-of-a-pair form: a target that reaches a symbol through two instructions
+# gives each half its modifier, so the rendered text names the relocation the
+# assembler would apply rather than a bare symbol that assembles to something else.
+# ---
+# sym_id: symbol id resolved by the linker
+# size:   reference width in bytes
+# mod:    the relocation modifier (one of SYM_MOD_*)
+# ret:    an Operand with kind OPK_SYM
+pub fun make_sym_mod(sym_id: u32, size: u8, mod: SymModifier) Operand {
+    var op: Operand = make_sym(sym_id, size);
+    op.sym_mod = mod;
+    ret op;
+}
+
+# build a cleared machine instruction
+#
+# Every operand absent, no flags, no clobbers - the base a target fills the fields
+# its form uses, so an unset field never reads as a live operand.
+# ---
+# ret: an Inst with opcode 0 and three absent operands
+pub fun inst_blank() Inst {
+    var mi: Inst;
+    mi.opcode   = 0;
+    mi.dst      = operand_blank(OPK_NONE, 0);
+    mi.src1     = operand_blank(OPK_NONE, 0);
+    mi.src2     = operand_blank(OPK_NONE, 0);
+    mi.size     = 0;
+    mi.flags    = 0;
+    mi.clobbers = 0;
+    mi.src_line = 0;
+    mi.src_file = nil;
+    ret mi;
 }
 
 test "mach.lang.target.isa.arch_id_for:name_roundtrip" {

--- a/src/lang/target/isa/riscv64/encode.mach
+++ b/src/lang/target/isa/riscv64/encode.mach
@@ -38,13 +38,14 @@
 # WIDTH-HONESTY: the 32-bit instruction-word format machinery (pack_r/i/s/b/u/j),
 # the register field positions, the immediate bit-scatter, and the branch / jump
 # fixups are IDENTICAL across RV32 and RV64 and carry no XLEN assumption. The
-# RV64-specific choices - the `*W` word ALU (OP_32 / OP_IMM_32), the LD / SD memory
+# RV64-specific choices - the `*W` word ALU (OPC_OP_32 / OPC_OP_IMM_32), the LD / SD memory
 # width, and the 64-bit `li` length - are each driven off the operation's OPERAND
 # SIZE (read from the MIR width, itself derived from the machine model) and are
 # localized and commented, so an RV32 (ilp32) sibling extracts cleanly by changing
 # only those width branches.
 
 use std.allocator.page;
+use std.io.writer;
 use std.text.parse;
 use std.types.bool.bool;
 use std.types.bool.false;
@@ -66,6 +67,8 @@ use mach.lang.be.codegen.mir;
 use mach.lang.intern;
 use mach.lang.target.isa;
 use mach.lang.target.isa.riscv64;
+use mach.lang.target.isa.riscv64.inst;
+use printer: mach.lang.target.isa.riscv64.printer;
 use mach.lang.target.of;
 use mach.lang.target.resolved;
 
@@ -81,22 +84,27 @@ use mach.lang.target.resolved;
 pub def EncodeFn: fun(*A.Allocator, *resolved.Target, *mir.MirModule) R.Result[encode.EncoderOutput, str];
 
 # the seven-bit major opcodes (instruction bits [6:0]). these are the same on RV32
-# and RV64 EXCEPT OP_32 / OP_IMM_32, which name the RV64 word (`*W`) ALU groups an
+# and RV64 EXCEPT OPC_OP_32 / OPC_OP_IMM_32, which name the RV64 word (`*W`) ALU groups an
 # RV32 sibling does not have - the only XLEN-specific major opcodes here
-val OP:        u32 = 0x33;  # register ALU (add/sub/and/or/xor/sll/srl/sra/slt + M-ext)
-val OP_IMM:    u32 = 0x13;  # immediate ALU (addi/andi/ori/xori/slli/srli/srai/slti)
-val OP_32:     u32 = 0x3B;  # RV64 word register ALU (addw/subw/sllw/srlw/sraw/mulw)
-val OP_IMM_32: u32 = 0x1B;  # RV64 word immediate ALU (addiw/slliw/srliw/sraiw)
-val LOAD:      u32 = 0x03;  # loads (lb/lh/lw/ld/lbu/lhu/lwu)
-val STORE:     u32 = 0x23;  # stores (sb/sh/sw/sd)
-val BRANCH:    u32 = 0x63;  # conditional branches (beq/bne/blt/bge/bltu/bgeu)
-val JAL:       u32 = 0x6F;  # jump and link (J-type)
-val JALR:      u32 = 0x67;  # jump and link register (I-type)
-val LUI:       u32 = 0x37;  # load upper immediate (U-type)
-val AUIPC:     u32 = 0x17;  # add upper immediate to pc (U-type)
-val SYSTEM:    u32 = 0x73;  # ecall / ebreak
-val MISC_MEM:  u32 = 0x0F;  # fence / pause (the inline-asm consumers of this group)
-val AMO:       u32 = 0x2F;  # RV64A atomics (lr / sc / amo*), R-type with aq/rl bits
+#
+# the `OPC_` prefix keeps the encoding-FIELD group distinct from the instructions
+# themselves (`isa.riscv64.inst`), whose names overlap it: the manual calls both the
+# `JAL` opcode field value and the `jal` instruction by the same name, and they are
+# not the same thing - one is a seven-bit field, the other a whole instruction
+val OPC_OP:        u32 = 0x33;  # register ALU (add/sub/and/or/xor/sll/srl/sra/slt + M-ext)
+val OPC_OP_IMM:    u32 = 0x13;  # immediate ALU (addi/andi/ori/xori/slli/srli/srai/slti)
+val OPC_OP_32:     u32 = 0x3B;  # RV64 word register ALU (addw/subw/sllw/srlw/sraw/mulw)
+val OPC_OP_IMM_32: u32 = 0x1B;  # RV64 word immediate ALU (addiw/slliw/srliw/sraiw)
+val OPC_LOAD:      u32 = 0x03;  # loads (lb/lh/lw/ld/lbu/lhu/lwu)
+val OPC_STORE:     u32 = 0x23;  # stores (sb/sh/sw/sd)
+val OPC_BRANCH:    u32 = 0x63;  # conditional branches (beq/bne/blt/bge/bltu/bgeu)
+val OPC_JAL:       u32 = 0x6F;  # jump and link (J-type)
+val OPC_JALR:      u32 = 0x67;  # jump and link register (I-type)
+val OPC_LUI:       u32 = 0x37;  # load upper immediate (U-type)
+val OPC_AUIPC:     u32 = 0x17;  # add upper immediate to pc (U-type)
+val OPC_SYSTEM:    u32 = 0x73;  # ecall / ebreak
+val OPC_MISC_MEM:  u32 = 0x0F;  # fence / pause (the inline-asm consumers of this group)
+val OPC_AMO:       u32 = 0x2F;  # RV64A atomics (lr / sc / amo*), R-type with aq/rl bits
 
 # the three-bit funct3 selectors. for the ALU groups these name the operation; for
 # loads / stores / branches they name the access width / relation (see the width
@@ -132,14 +140,14 @@ val F3_DIVU: u32 = 0x5;  # divu (unsigned quotient)
 val F3_REM:  u32 = 0x6;  # rem  (signed remainder)
 val F3_REMU: u32 = 0x7;  # remu (unsigned remainder)
 
-# the F/D-extension major opcodes. OP_FP carries every register float op (the funct7
+# the F/D-extension major opcodes. OPC_OP_FP carries every register float op (the funct7
 # names the operation and its precision, the rs2 field the source format for a
-# conversion); LOAD_FP / STORE_FP carry the float loads / stores. these are the same
+# conversion); OPC_LOAD_FP / OPC_STORE_FP carry the float loads / stores. these are the same
 # on RV32 and RV64; the F-extension single-precision forms exist on a bare RV32F /
 # RV64F, the D forms add the double-precision twins, so nothing here is XLEN-specific
-val OP_FP:    u32 = 0x53;
-val LOAD_FP:  u32 = 0x07;  # flw / fld
-val STORE_FP: u32 = 0x27;  # fsw / fsd
+val OPC_OP_FP:    u32 = 0x53;
+val OPC_LOAD_FP:  u32 = 0x07;  # flw / fld
+val OPC_STORE_FP: u32 = 0x27;  # fsw / fsd
 
 # the float instruction-word funct7 selectors. each is the 5-bit operation in
 # bits [6:2] with the 2-bit format in bits [1:0] (00 = single, 01 = double), so the
@@ -162,7 +170,7 @@ val F3_FLE: u32 = 0x0;  # fle (less-or-equal)
 val F3_FLT: u32 = 0x1;  # flt (less-than)
 val F3_FEQ: u32 = 0x2;  # feq (equal)
 
-# the rounding-mode field (funct3 of an arithmetic / conversion OP_FP word).
+# the rounding-mode field (funct3 of an arithmetic / conversion OPC_OP_FP word).
 # RM_RNE is round-to-nearest-even (the field is don't-care for an exact conversion,
 # where it matches the assembler's canonical choice); RM_RTZ is round-toward-zero
 # (mach's defined float->int cast rule); RM_DYN defers to the fcsr (the
@@ -196,12 +204,12 @@ val FMT_D: u32 = 0x1;
 val FP_SCRATCH:  u32 = 31;
 val FP_SCRATCH2: u32 = 30;
 
-# the RV64A atomic width selector (funct3 of an AMO word): W is the 32-bit form, D the
+# the RV64A atomic width selector (funct3 of an OPC_AMO word): W is the 32-bit form, D the
 # 64-bit form. an rv32 reuses the W forms, so this split is the only XLEN-specific bit
 val F3_AMO_W: u32 = 0x2;
 val F3_AMO_D: u32 = 0x3;
 
-# the RV64A atomic operation selectors (the 5-bit funct5 in an AMO word's bits [31:27]).
+# the RV64A atomic operation selectors (the 5-bit funct5 in an OPC_AMO word's bits [31:27]).
 # the aq / rl ordering bits sit just below in [26:25], so the assembled funct7 is
 # `(funct5 << 2) | (aq << 1) | rl`. lr / sc are the load-reserved / store-conditional
 # pair; the amo* forms are the read-modify-write atomics
@@ -297,6 +305,664 @@ fun emit_word(st: *encode.EncodeState, word: u32) {
     encode.emit_u32(?st.buf, word);
 }
 
+# the width of every RISC-V instruction word (the C compressed extension is not emitted)
+val WORD_SIZE: u32 = 4;
+
+# the operand layout a concrete RV64 instruction takes
+#
+# The shape says which `isa.Operand` each instruction-format field becomes and in
+# which register bank, so the sink receives a filled `isa.Inst` and the printer
+# renders it without knowing an RV64 encoding. Deriving the shape here rather than
+# in the printer keeps the ISA's encoding knowledge in the encoder: the printer
+# walks `dst` / `src1` / `src2` and nothing else.
+val SH_NONE:    u8 = 0;   # no operands
+val SH_RRR:     u8 = 1;   # rd, rs1, rs2
+val SH_RRI:     u8 = 2;   # rd, rs1, imm
+val SH_RU:      u8 = 3;   # rd, imm
+val SH_LOAD:    u8 = 4;   # rd, imm(rs1)
+val SH_FLOAD:   u8 = 5;   # fd, imm(rs1)
+val SH_STORE:   u8 = 6;   # rs2, imm(rs1)  (the memory operand is the destination)
+val SH_FSTORE:  u8 = 7;   # fs2, imm(rs1)
+val SH_BRANCH:  u8 = 8;   # rs1, rs2, label
+val SH_JUMP:    u8 = 9;   # rd, label
+val SH_FFF:     u8 = 10;  # fd, fs1, fs2
+val SH_FF:      u8 = 11;  # fd, fs1
+val SH_GFF:     u8 = 12;  # rd, fs1, fs2   (a float compare writing a GP boolean)
+val SH_GF:      u8 = 13;  # rd, fs1        (float -> GP convert / reinterpret)
+val SH_FG:      u8 = 14;  # fd, rs1        (GP -> float convert / reinterpret)
+val SH_AMO:     u8 = 15;  # rd, rs2, (rs1)
+val SH_AMO_LR:  u8 = 16;  # rd, (rs1)
+
+# build a general-purpose register operand from a raw five-bit register field
+#
+# The GP bank is register class 0, so a composite id is numerically its own index
+# and every GP-keyed table in the back end is unchanged.
+# ---
+# idx: the register field's value
+# ret: an OPK_REG operand naming that integer register
+fun gpr(idx: u32) isa.Operand {
+    ret isa.make_reg(idx::i32, 8);
+}
+
+# build a float register operand from a raw five-bit register field
+#
+# Tagged with the float bank so the operand is self-describing: the printer names
+# `fa0` rather than `a0` from the id alone, without consulting the opcode.
+# ---
+# idx: the register field's value
+# ret: an OPK_REG operand naming that float register
+fun fpr(idx: u32) isa.Operand {
+    ret isa.make_reg(isa.regid_make(isa.REG_CLASS_ID_XMM, idx::i32), 8);
+}
+
+# lay one classified instruction's fields out into an `isa.Inst`
+#
+# The single place an RV64 instruction-format field becomes a machine operand.
+# ---
+# op:   the concrete instruction
+# rd:   the rd field
+# rs1:  the rs1 field
+# rs2:  the rs2 field
+# imm:  the immediate field, already sign-corrected for its form
+# ret:  the filled instruction
+fun build_inst(op: inst.MachOp, rd: u32, rs1: u32, rs2: u32, imm: i64) isa.Inst {
+    var mi: isa.Inst = isa.inst_blank();
+    mi.opcode = op::u16;
+    mi.size   = WORD_SIZE::u8;
+
+    val shape: u8 = shape_of(op);
+    if (shape == SH_RRR) { mi.dst = gpr(rd); mi.src1 = gpr(rs1); mi.src2 = gpr(rs2); ret mi; }
+    if (shape == SH_RRI) { mi.dst = gpr(rd); mi.src1 = gpr(rs1); mi.src2 = isa.make_imm(imm, 8); ret mi; }
+    if (shape == SH_RU)  { mi.dst = gpr(rd); mi.src1 = isa.make_imm(imm, 8); ret mi; }
+    if (shape == SH_LOAD)   { mi.dst = gpr(rd); mi.src1 = isa.make_mem(rs1::i32, imm::i32, -1, 0, 8); ret mi; }
+    if (shape == SH_FLOAD)  { mi.dst = fpr(rd); mi.src1 = isa.make_mem(rs1::i32, imm::i32, -1, 0, 8); ret mi; }
+    if (shape == SH_STORE)  { mi.dst = isa.make_mem(rs1::i32, imm::i32, -1, 0, 8); mi.src1 = gpr(rs2); ret mi; }
+    if (shape == SH_FSTORE) { mi.dst = isa.make_mem(rs1::i32, imm::i32, -1, 0, 8); mi.src1 = fpr(rs2); ret mi; }
+    if (shape == SH_BRANCH) { mi.dst = gpr(rs1); mi.src1 = gpr(rs2); mi.src2 = isa.make_block_label(0); ret mi; }
+    if (shape == SH_JUMP)   { mi.dst = gpr(rd); mi.src1 = isa.make_block_label(0); ret mi; }
+    if (shape == SH_FFF) { mi.dst = fpr(rd); mi.src1 = fpr(rs1); mi.src2 = fpr(rs2); ret mi; }
+    if (shape == SH_FF)  { mi.dst = fpr(rd); mi.src1 = fpr(rs1); ret mi; }
+    if (shape == SH_GFF) { mi.dst = gpr(rd); mi.src1 = fpr(rs1); mi.src2 = fpr(rs2); ret mi; }
+    if (shape == SH_GF)  { mi.dst = gpr(rd); mi.src1 = fpr(rs1); ret mi; }
+    if (shape == SH_FG)  { mi.dst = fpr(rd); mi.src1 = gpr(rs1); ret mi; }
+    if (shape == SH_AMO) {
+        mi.dst  = gpr(rd);
+        mi.src1 = gpr(rs2);
+        mi.src2 = isa.make_mem(rs1::i32, 0, -1, 0, 8);
+        ret mi;
+    }
+    if (shape == SH_AMO_LR) { mi.dst = gpr(rd); mi.src1 = isa.make_mem(rs1::i32, 0, -1, 0, 8); ret mi; }
+    ret mi;
+}
+
+# the operand layout a concrete RV64 instruction takes
+# ---
+# op:  the concrete instruction
+# ret: one of the SH_* layouts
+fun shape_of(op: inst.MachOp) u8 {
+    if (op >= inst.ADD && op <= inst.REMUW) { ret SH_RRR; }
+    if (op >= inst.ADDI && op <= inst.SRAIW) { ret SH_RRI; }
+    if (op >= inst.LB && op <= inst.LWU) { ret SH_LOAD; }
+    if (op >= inst.SB && op <= inst.SD) { ret SH_STORE; }
+    if (op >= inst.BEQ && op <= inst.BGEU) { ret SH_BRANCH; }
+    if (op == inst.JAL)  { ret SH_JUMP; }
+    if (op == inst.JALR) { ret SH_LOAD; }
+    if (op == inst.LUI || op == inst.AUIPC) { ret SH_RU; }
+    if (op >= inst.ECALL && op <= inst.PAUSE) { ret SH_NONE; }
+    if (op == inst.FLW || op == inst.FLD) { ret SH_FLOAD; }
+    if (op == inst.FSW || op == inst.FSD) { ret SH_FSTORE; }
+    if (op >= inst.FADD_S && op <= inst.FSGNJX_D) { ret SH_FFF; }
+    if (op >= inst.FEQ_S && op <= inst.FLE_D) { ret SH_GFF; }
+    if (op == inst.FCVT_S_D || op == inst.FCVT_D_S) { ret SH_FF; }
+    if (op >= inst.FCVT_W_S && op <= inst.FCVT_LU_D) { ret SH_GF; }
+    if (op >= inst.FCVT_S_W && op <= inst.FCVT_D_LU) { ret SH_FG; }
+    if (op == inst.FMV_X_W || op == inst.FMV_X_D) { ret SH_GF; }
+    if (op == inst.FMV_W_X || op == inst.FMV_D_X) { ret SH_FG; }
+    if (op == inst.LR_W || op == inst.LR_D) { ret SH_AMO_LR; }
+    if (op >= inst.SC_W && op <= inst.AMOMAXU_D) { ret SH_AMO; }
+    ret SH_NONE;
+}
+
+# emit one R-type instruction word and notify the assembly sink
+#
+# The `--emit-asm` tee for the register-register formats. `pack_r` already receives
+# every field of the word, so the notification is built from those same arguments -
+# the structure is captured AT the packer rather than recovered from the encoded
+# integer, which is what makes a faithful `.s` need no RV64 decoder (#2193). One
+# notification per emitted word, never one per MIR opcode: the macro-ops this
+# encoder expands (a fused compare-and-branch, a 64-bit `li`, a prologue) each reach
+# here once per instruction they really produce.
+# ---
+# st:     encoder driver state (its buffer carries the sink)
+# opcode: the seven-bit major opcode
+# funct3: the funct3 field
+# funct7: the funct7 field
+# rd:     the destination register field
+# rs1:    the first source register field
+# rs2:    the second source register field
+fun emit_r(st: *encode.EncodeState, opcode: u32, funct3: u32, funct7: u32, rd: u32, rs1: u32, rs2: u32) {
+    emit_word(st, pack_r(opcode, funct3, funct7, rd, rs1, rs2));
+    if (!encode.sink_active(?st.buf)) { ret; }
+    val op: inst.MachOp = classify_r(opcode, funct3, funct7, rs2);
+    var mi: isa.Inst = build_inst(op, rd, rs1, rs2, 0);
+    if (opcode == OPC_AMO) { mi.flags = amo_ordering_flags(funct7); }
+    note(st, op, ?mi, "R", opcode);
+}
+
+# emit one I-type instruction word and notify the assembly sink
+# ---
+# st:     encoder driver state (its buffer carries the sink)
+# opcode: the seven-bit major opcode
+# funct3: the funct3 field
+# rd:     the destination register field
+# rs1:    the source register field
+# imm12:  the twelve-bit immediate field as encoded
+fun emit_i(st: *encode.EncodeState, opcode: u32, funct3: u32, rd: u32, rs1: u32, imm12: u32) {
+    emit_word(st, pack_i(opcode, funct3, rd, rs1, imm12));
+    if (!encode.sink_active(?st.buf)) { ret; }
+    val op: inst.MachOp = classify_i(opcode, funct3, imm12);
+    var mi: isa.Inst = build_inst(op, rd, rs1, 0, imm_of_i(op, imm12));
+    note(st, op, ?mi, "I", opcode);
+}
+
+# emit one S-type store word and notify the assembly sink
+# ---
+# st:     encoder driver state (its buffer carries the sink)
+# opcode: the seven-bit major opcode
+# funct3: the funct3 field
+# rs1:    the base register field
+# rs2:    the stored register field
+# imm12:  the twelve-bit displacement as encoded
+fun emit_s(st: *encode.EncodeState, opcode: u32, funct3: u32, rs1: u32, rs2: u32, imm12: u32) {
+    emit_word(st, pack_s(opcode, funct3, rs1, rs2, imm12));
+    if (!encode.sink_active(?st.buf)) { ret; }
+    val op: inst.MachOp = classify_s(opcode, funct3);
+    var mi: isa.Inst = build_inst(op, 0, rs1, rs2, sext12(imm12::i64));
+    note(st, op, ?mi, "S", opcode);
+}
+
+# emit one B-type conditional branch and notify the assembly sink
+# ---
+# st:     encoder driver state (its buffer carries the sink)
+# opcode: the seven-bit major opcode
+# funct3: the relation field
+# rs1:    the first compared register
+# rs2:    the second compared register
+# imm:    the signed byte displacement as encoded
+fun emit_b(st: *encode.EncodeState, opcode: u32, funct3: u32, rs1: u32, rs2: u32, imm: u32) {
+    emit_word(st, pack_b(opcode, funct3, rs1, rs2, imm));
+    if (!encode.sink_active(?st.buf)) { ret; }
+    val op: inst.MachOp = classify_b(opcode, funct3);
+    var mi: isa.Inst = build_inst(op, 0, rs1, rs2, 0);
+    note(st, op, ?mi, "B", opcode);
+}
+
+# emit one U-type upper-immediate instruction and notify the assembly sink
+# ---
+# st:     encoder driver state (its buffer carries the sink)
+# opcode: the seven-bit major opcode
+# rd:     the destination register field
+# imm20:  the twenty-bit upper immediate
+fun emit_u(st: *encode.EncodeState, opcode: u32, rd: u32, imm20: u32) {
+    emit_word(st, pack_u(opcode, rd, imm20));
+    if (!encode.sink_active(?st.buf)) { ret; }
+    val op: inst.MachOp = classify_u(opcode);
+    var mi: isa.Inst = build_inst(op, rd, 0, 0, (imm20 & 0xFFFFF)::i64);
+    note(st, op, ?mi, "U", opcode);
+}
+
+# emit one J-type jump and notify the assembly sink
+# ---
+# st:     encoder driver state (its buffer carries the sink)
+# opcode: the seven-bit major opcode
+# rd:     the link register field
+# imm:    the signed byte displacement as encoded
+fun emit_j(st: *encode.EncodeState, opcode: u32, rd: u32, imm: u32) {
+    emit_word(st, pack_j(opcode, rd, imm));
+    if (!encode.sink_active(?st.buf)) { ret; }
+    val op: inst.MachOp = classify_j(opcode);
+    var mi: isa.Inst = build_inst(op, rd, 0, 0, 0);
+    note(st, op, ?mi, "J", opcode);
+}
+
+# buffer one classified instruction, or fail the render naming the form
+#
+# A field combination the classifier does not name is a hard error rather than
+# placeholder text: an unnamed form printed as `???` is exactly the silent
+# degradation that let the previous printer's divergence go unnoticed (#2187). The
+# form is named by its instruction format and major opcode, which points straight at
+# the emitting path.
+# ---
+# st:     encoder driver state (its buffer carries the sink)
+# op:     the classified instruction
+# mi:     the built machine instruction
+# fmt:    the instruction format letter, for the diagnostic
+# opcode: the major opcode, for the diagnostic
+fun note(st: *encode.EncodeState, op: inst.MachOp, mi: *isa.Inst, fmt: str, opcode: u32) {
+    if (op == inst.MOP_NONE) {
+        encode.sink_fail(?st.buf, unnamed_form_message(st, fmt, opcode));
+        ret;
+    }
+    var n: encode.AsmNote = encode.note_blank();
+    n.off  = st.buf.len::u32 - WORD_SIZE;
+    n.inst = @mi;
+    val res: R.Result[bool, str] = encode.note_push(?st.buf, ?n);
+    if (R.is_err[bool, str](res)) { encode.sink_fail(?st.buf, R.unwrap_err[bool, str](res)); }
+}
+
+# "no riscv64 mnemonic for an emitted <fmt>-type <opcode> instruction", interned so
+# the diagnostic outlives this call
+# ---
+# st:     encoder driver state (its interner holds the message)
+# fmt:    the instruction format letter
+# opcode: the major opcode
+# ret:    the diagnostic text
+fun unnamed_form_message(st: *encode.EncodeState, fmt: str, opcode: u32) str {
+    var buf: [32]u8;
+    var i: usize = 0;
+    for (fmt[i] != 0) { buf[i] = fmt[i]::u8; i = i + 1; }
+    buf[i] = '-'::u8; i = i + 1;
+    buf[i] = 't'::u8; i = i + 1;
+    buf[i] = 'y'::u8; i = i + 1;
+    buf[i] = 'p'::u8; i = i + 1;
+    buf[i] = 'e'::u8; i = i + 1;
+    buf[i] = ' '::u8; i = i + 1;
+    i = i + rv_dec_into(?buf[i], opcode::u64);
+    buf[i] = 0;
+    ret rv_named_err(st,
+        "--emit-asm: no riscv64 mnemonic for an emitted ", (?buf[0])::str, " instruction",
+        "--emit-asm: no riscv64 mnemonic for an emitted instruction");
+}
+
+# write the base-10 digits of `n` at `dst`, returning how many were written
+# ---
+# dst: destination bytes (at least 20 available)
+# n:   the value to render
+# ret: the number of digits written
+fun rv_dec_into(dst: *u8, n: u64) usize {
+    var tmp: [20]u8;
+    var len: usize = 0;
+    var v: u64 = n;
+    if (v == 0) { tmp[0] = '0'::u8; len = 1; }
+    for (v > 0) {
+        tmp[len] = ('0'::u64 + (v % 10))::u8;
+        v = v / 10;
+        len = len + 1;
+    }
+    var i: usize = 0;
+    for (i < len) {
+        dst[i] = tmp[len - 1 - i];
+        i = i + 1;
+    }
+    ret len;
+}
+
+# the acquire / release ordering an atomic's funct7 carries, as instruction flags
+#
+# The ordering bits ARE the operation's memory-ordering guarantee, so they ride the
+# instruction rather than being dropped: an `amoswap.d.rl` rendered as `amoswap.d`
+# would read as a plain exchange.
+# ---
+# funct7: the funct5 / aq / rl field
+# ret:    the riscv64 instruction flags
+fun amo_ordering_flags(funct7: u32) u16 {
+    var flags: u16 = 0;
+    if ((funct7 & 0x2) != 0) { flags = flags | inst.FLAG_AQ; }
+    if ((funct7 & 0x1) != 0) { flags = flags | inst.FLAG_RL; }
+    ret flags;
+}
+
+# the immediate an I-type instruction renders with
+#
+# Every I-type form but the immediate shifts carries a signed twelve-bit
+# displacement. A shift instead carries a shift amount in the low bits, six wide at
+# full register width and five in the RV64 word forms, with imm[10] already consumed
+# by the classifier to pick the arithmetic form.
+# ---
+# op:    the classified instruction
+# imm12: the twelve-bit immediate field as encoded
+# ret:   the immediate to render
+fun imm_of_i(op: inst.MachOp, imm12: u32) i64 {
+    if (op == inst.SLLI || op == inst.SRLI || op == inst.SRAI) { ret (imm12 & 0x3F)::i64; }
+    if (op == inst.SLLIW || op == inst.SRLIW || op == inst.SRAIW) { ret (imm12 & 0x1F)::i64; }
+    ret sext12(imm12::i64);
+}
+
+# name the R-type instruction a (major opcode, funct3, funct7) triple encodes
+#
+# The register-register integer ALU and its RV64 word twins, the M extension, the
+# RV64D scalar float forms and the RV64A atomics all share this format and are
+# distinguished only by these fields - so this is the whole R-type surface the
+# encoder can produce, keyed exactly as the packer writes it
+# ---
+# opcode: the seven-bit major opcode
+# funct3: the funct3 field
+# funct7: the funct7 field
+# rs2:    the rs2 field, which selects the width variant of an `fcvt`
+# ret:    the concrete instruction, or inst.MOP_NONE for a combination that names none
+fun classify_r(opcode: u32, funct3: u32, funct7: u32, rs2: u32) inst.MachOp {
+    if (opcode == OPC_OP_FP) { ret classify_fp(funct3, funct7, rs2); }
+    if (opcode == OPC_AMO)   { ret classify_amo(funct3, funct7); }
+    if (opcode != OPC_OP && opcode != OPC_OP_32) { ret inst.MOP_NONE; }
+    val word: bool = opcode == OPC_OP_32;
+
+    if (funct7 == F7_MULDIV) {
+        if (funct3 == F3_ADD)  { if (word) { ret inst.MULW; }  ret inst.MUL; }
+        if (funct3 == F3_DIV)  { if (word) { ret inst.DIVW; }  ret inst.DIV; }
+        if (funct3 == F3_DIVU) { if (word) { ret inst.DIVUW; } ret inst.DIVU; }
+        if (funct3 == F3_REM)  { if (word) { ret inst.REMW; }  ret inst.REM; }
+        if (funct3 == F3_REMU) { if (word) { ret inst.REMUW; } ret inst.REMU; }
+        if (word) { ret inst.MOP_NONE; }
+        if (funct3 == F3_SLL)  { ret inst.MULH; }
+        if (funct3 == F3_SLT)  { ret inst.MULHSU; }
+        if (funct3 == F3_SLTU) { ret inst.MULHU; }
+        ret inst.MOP_NONE;
+    }
+    if (funct7 == F7_SUB) {
+        if (funct3 == F3_ADD) { if (word) { ret inst.SUBW; } ret inst.SUB; }
+        if (funct3 == F3_SRL) { if (word) { ret inst.SRAW; } ret inst.SRA; }
+        ret inst.MOP_NONE;
+    }
+    if (funct7 != F7_ZERO) { ret inst.MOP_NONE; }
+    if (funct3 == F3_ADD) { if (word) { ret inst.ADDW; } ret inst.ADD; }
+    if (funct3 == F3_SLL) { if (word) { ret inst.SLLW; } ret inst.SLL; }
+    if (funct3 == F3_SRL) { if (word) { ret inst.SRLW; } ret inst.SRL; }
+    if (word) { ret inst.MOP_NONE; }
+    if (funct3 == F3_SLT)  { ret inst.SLT; }
+    if (funct3 == F3_SLTU) { ret inst.SLTU; }
+    if (funct3 == F3_XOR)  { ret inst.XOR; }
+    if (funct3 == F3_OR)   { ret inst.OR; }
+    if (funct3 == F3_AND)  { ret inst.AND; }
+    ret inst.MOP_NONE;
+}
+
+# name an RV64D scalar float instruction from its funct7 (the operation, bit 0
+# selecting the double form), funct3 (the rounding mode, or the relation for a
+# compare and the sign-injection variant for `fsgnj`) and rs2 (the width selector of
+# an integer conversion)
+# ---
+# funct3: the funct3 field
+# funct7: the funct7 field
+# rs2:    the rs2 field
+# ret:    the concrete instruction, or inst.MOP_NONE
+fun classify_fp(funct3: u32, funct7: u32, rs2: u32) inst.MachOp {
+    val dbl: bool = (funct7 & 1) != 0;
+    val base: u32 = funct7 & 0xFE;
+
+    if (base == F7_FADD) { if (dbl) { ret inst.FADD_D; } ret inst.FADD_S; }
+    if (base == F7_FSUB) { if (dbl) { ret inst.FSUB_D; } ret inst.FSUB_S; }
+    if (base == F7_FMUL) { if (dbl) { ret inst.FMUL_D; } ret inst.FMUL_S; }
+    if (base == F7_FDIV) { if (dbl) { ret inst.FDIV_D; } ret inst.FDIV_S; }
+    if (base == F7_FSGNJ) {
+        if (funct3 == 0) { if (dbl) { ret inst.FSGNJ_D; }  ret inst.FSGNJ_S; }
+        if (funct3 == 1) { if (dbl) { ret inst.FSGNJN_D; } ret inst.FSGNJN_S; }
+        if (funct3 == 2) { if (dbl) { ret inst.FSGNJX_D; } ret inst.FSGNJX_S; }
+        ret inst.MOP_NONE;
+    }
+    if (base == F7_FCMP) {
+        if (funct3 == F3_FLE) { if (dbl) { ret inst.FLE_D; } ret inst.FLE_S; }
+        if (funct3 == F3_FLT) { if (dbl) { ret inst.FLT_D; } ret inst.FLT_S; }
+        if (funct3 == F3_FEQ) { if (dbl) { ret inst.FEQ_D; } ret inst.FEQ_S; }
+        ret inst.MOP_NONE;
+    }
+    if (base == F7_FCVT_F2F) { if (dbl) { ret inst.FCVT_D_S; } ret inst.FCVT_S_D; }
+    if (base == F7_FCVT_F2I) {
+        if (rs2 == FCVT_W)  { if (dbl) { ret inst.FCVT_W_D; }  ret inst.FCVT_W_S; }
+        if (rs2 == FCVT_WU) { if (dbl) { ret inst.FCVT_WU_D; } ret inst.FCVT_WU_S; }
+        if (rs2 == FCVT_L)  { if (dbl) { ret inst.FCVT_L_D; }  ret inst.FCVT_L_S; }
+        if (rs2 == FCVT_LU) { if (dbl) { ret inst.FCVT_LU_D; } ret inst.FCVT_LU_S; }
+        ret inst.MOP_NONE;
+    }
+    if (base == F7_FCVT_I2F) {
+        if (rs2 == FCVT_W)  { if (dbl) { ret inst.FCVT_D_W; }  ret inst.FCVT_S_W; }
+        if (rs2 == FCVT_WU) { if (dbl) { ret inst.FCVT_D_WU; } ret inst.FCVT_S_WU; }
+        if (rs2 == FCVT_L)  { if (dbl) { ret inst.FCVT_D_L; }  ret inst.FCVT_S_L; }
+        if (rs2 == FCVT_LU) { if (dbl) { ret inst.FCVT_D_LU; } ret inst.FCVT_S_LU; }
+        ret inst.MOP_NONE;
+    }
+    if (base == F7_FMV_F2I) { if (dbl) { ret inst.FMV_X_D; } ret inst.FMV_X_W; }
+    if (base == F7_FMV_I2F) { if (dbl) { ret inst.FMV_D_X; } ret inst.FMV_W_X; }
+    ret inst.MOP_NONE;
+}
+
+# name an RV64A atomic from its funct3 (the access width) and funct7 (the funct5
+# operation with the ordering bits in the low two, which the flags carry separately)
+# ---
+# funct3: the width field
+# funct7: the funct5 / aq / rl field
+# ret:    the concrete instruction, or inst.MOP_NONE
+fun classify_amo(funct3: u32, funct7: u32) inst.MachOp {
+    if (funct3 != F3_AMO_W && funct3 != F3_AMO_D) { ret inst.MOP_NONE; }
+    val word: bool = funct3 == F3_AMO_W;
+    val funct5: u32 = (funct7 >> 2) & 0x1F;
+
+    if (funct5 == A5_LR)      { if (word) { ret inst.LR_W; }      ret inst.LR_D; }
+    if (funct5 == A5_SC)      { if (word) { ret inst.SC_W; }      ret inst.SC_D; }
+    if (funct5 == A5_AMOSWAP) { if (word) { ret inst.AMOSWAP_W; } ret inst.AMOSWAP_D; }
+    if (funct5 == A5_AMOADD)  { if (word) { ret inst.AMOADD_W; }  ret inst.AMOADD_D; }
+    if (funct5 == A5_AMOXOR)  { if (word) { ret inst.AMOXOR_W; }  ret inst.AMOXOR_D; }
+    if (funct5 == A5_AMOAND)  { if (word) { ret inst.AMOAND_W; }  ret inst.AMOAND_D; }
+    if (funct5 == A5_AMOOR)   { if (word) { ret inst.AMOOR_W; }   ret inst.AMOOR_D; }
+    if (funct5 == A5_AMOMIN)  { if (word) { ret inst.AMOMIN_W; }  ret inst.AMOMIN_D; }
+    if (funct5 == A5_AMOMAX)  { if (word) { ret inst.AMOMAX_W; }  ret inst.AMOMAX_D; }
+    if (funct5 == A5_AMOMINU) { if (word) { ret inst.AMOMINU_W; } ret inst.AMOMINU_D; }
+    if (funct5 == A5_AMOMAXU) { if (word) { ret inst.AMOMAXU_W; } ret inst.AMOMAXU_D; }
+    ret inst.MOP_NONE;
+}
+
+# name the I-type instruction a (major opcode, funct3, immediate) triple encodes
+# ---
+# opcode: the seven-bit major opcode
+# funct3: the funct3 field
+# imm12:  the twelve-bit immediate field as encoded
+# ret:    the concrete instruction, or inst.MOP_NONE
+fun classify_i(opcode: u32, funct3: u32, imm12: u32) inst.MachOp {
+    if (opcode == OPC_LOAD) {
+        if (funct3 == 0x0) { ret inst.LB; }
+        if (funct3 == 0x1) { ret inst.LH; }
+        if (funct3 == 0x2) { ret inst.LW; }
+        if (funct3 == 0x3) { ret inst.LD; }
+        if (funct3 == 0x4) { ret inst.LBU; }
+        if (funct3 == 0x5) { ret inst.LHU; }
+        if (funct3 == 0x6) { ret inst.LWU; }
+        ret inst.MOP_NONE;
+    }
+    if (opcode == OPC_LOAD_FP) {
+        if (funct3 == 0x2) { ret inst.FLW; }
+        if (funct3 == 0x3) { ret inst.FLD; }
+        ret inst.MOP_NONE;
+    }
+    if (opcode == OPC_JALR)   { ret inst.JALR; }
+    if (opcode == OPC_SYSTEM) {
+        if (imm12 == 0) { ret inst.ECALL; }
+        if (imm12 == 1) { ret inst.EBREAK; }
+        ret inst.MOP_NONE;
+    }
+    if (opcode == OPC_MISC_MEM) {
+        # `pause` is the `fence w, 0` encoding; every other fence spells the barrier
+        if (imm12 == 0x010) { ret inst.PAUSE; }
+        ret inst.FENCE;
+    }
+    if (opcode != OPC_OP_IMM && opcode != OPC_OP_IMM_32) { ret inst.MOP_NONE; }
+    val word: bool = opcode == OPC_OP_IMM_32;
+
+    if (funct3 == F3_SLL) { if (word) { ret inst.SLLIW; } ret inst.SLLI; }
+    if (funct3 == F3_SRL) {
+        # imm[10] selects the arithmetic right shift, which is how `srai` and `srli`
+        # share a funct3
+        if ((imm12 & 0x400) != 0) { if (word) { ret inst.SRAIW; } ret inst.SRAI; }
+        if (word) { ret inst.SRLIW; }
+        ret inst.SRLI;
+    }
+    if (funct3 == F3_ADD) { if (word) { ret inst.ADDIW; } ret inst.ADDI; }
+    if (word) { ret inst.MOP_NONE; }
+    if (funct3 == F3_SLT)  { ret inst.SLTI; }
+    if (funct3 == F3_SLTU) { ret inst.SLTIU; }
+    if (funct3 == F3_XOR)  { ret inst.XORI; }
+    if (funct3 == F3_OR)   { ret inst.ORI; }
+    if (funct3 == F3_AND)  { ret inst.ANDI; }
+    ret inst.MOP_NONE;
+}
+
+# name the S-type store a (major opcode, funct3) pair encodes
+# ---
+# opcode: the seven-bit major opcode
+# funct3: the width field
+# ret:    the concrete instruction, or inst.MOP_NONE
+fun classify_s(opcode: u32, funct3: u32) inst.MachOp {
+    if (opcode == OPC_STORE) {
+        if (funct3 == 0x0) { ret inst.SB; }
+        if (funct3 == 0x1) { ret inst.SH; }
+        if (funct3 == 0x2) { ret inst.SW; }
+        if (funct3 == 0x3) { ret inst.SD; }
+        ret inst.MOP_NONE;
+    }
+    if (opcode == OPC_STORE_FP) {
+        if (funct3 == 0x2) { ret inst.FSW; }
+        if (funct3 == 0x3) { ret inst.FSD; }
+        ret inst.MOP_NONE;
+    }
+    ret inst.MOP_NONE;
+}
+
+# name the B-type conditional branch a funct3 relation encodes
+# ---
+# opcode: the seven-bit major opcode
+# funct3: the relation field
+# ret:    the concrete instruction, or inst.MOP_NONE
+fun classify_b(opcode: u32, funct3: u32) inst.MachOp {
+    if (opcode != OPC_BRANCH) { ret inst.MOP_NONE; }
+    if (funct3 == F3_BEQ)  { ret inst.BEQ; }
+    if (funct3 == F3_BNE)  { ret inst.BNE; }
+    if (funct3 == F3_BLT)  { ret inst.BLT; }
+    if (funct3 == F3_BGE)  { ret inst.BGE; }
+    if (funct3 == F3_BLTU) { ret inst.BLTU; }
+    if (funct3 == F3_BGEU) { ret inst.BGEU; }
+    ret inst.MOP_NONE;
+}
+
+# name the U-type upper-immediate instruction a major opcode encodes
+# ---
+# opcode: the seven-bit major opcode
+# ret:    the concrete instruction, or inst.MOP_NONE
+fun classify_u(opcode: u32) inst.MachOp {
+    if (opcode == OPC_LUI)   { ret inst.LUI; }
+    if (opcode == OPC_AUIPC) { ret inst.AUIPC; }
+    ret inst.MOP_NONE;
+}
+
+# name the J-type jump a major opcode encodes
+# ---
+# opcode: the seven-bit major opcode
+# ret:    the concrete instruction, or inst.MOP_NONE
+fun classify_j(opcode: u32) inst.MachOp {
+    if (opcode != OPC_JAL) { ret inst.MOP_NONE; }
+    ret inst.JAL;
+}
+
+# the instruction most recently buffered, or nil when nothing is being rendered
+# ---
+# st:  encoder driver state (its buffer carries the sink)
+# ret: the last notification's instruction, or nil
+fun last_inst(st: *encode.EncodeState) *isa.Inst {
+    val count: u32 = encode.note_count(?st.buf);
+    if (count == 0) { ret nil; }
+    val n: *encode.AsmNote = encode.note_at(?st.buf, count - 1);
+    if (n == nil || n.kind != encode.ASM_NOTE_INST) { ret nil; }
+    ret ?n.inst;
+}
+
+# the operand carrying a just-emitted instruction's address or target field
+#
+# The field a branch's block, a symbol reference and a local label all land in. Its
+# position follows the operand layout, so the annotating call sites name only what
+# the target IS, never where it sits.
+# ---
+# mi:  the instruction whose target operand is wanted
+# ret: the target operand, or nil for a form with none
+fun target_operand(mi: *isa.Inst) *isa.Operand {
+    val shape: u8 = shape_of(mi.opcode::inst.MachOp);
+    if (shape == SH_RRI || shape == SH_BRANCH) { ret ?mi.src2; }
+    if (shape == SH_RU || shape == SH_JUMP || shape == SH_LOAD || shape == SH_FLOAD) { ret ?mi.src1; }
+    if (shape == SH_STORE || shape == SH_FSTORE) { ret ?mi.dst; }
+    ret nil;
+}
+
+# name the MIR block a just-emitted branch targets
+#
+# The encoded displacement is a zero placeholder pass 2 resolves from the block's
+# `.text` offset, so the block id is what identifies the edge.
+# ---
+# st:    encoder driver state (its buffer carries the sink)
+# block: the target block's id
+fun note_block_target(st: *encode.EncodeState, block: u32) {
+    val mi: *isa.Inst = last_inst(st);
+    if (mi == nil) { ret; }
+    val op: *isa.Operand = target_operand(mi);
+    if (op == nil) { ret; }
+    @op = isa.make_block_label(block);
+}
+
+# mark a just-emitted branch as jumping over a relaxation trampoline
+#
+# The inverted guard of a relaxed conditional targets no block: it skips the
+# trampoline carrying the far target, a purely local distance the relaxation pass
+# resolves itself.
+# ---
+# st:    encoder driver state (its buffer carries the sink)
+# bytes: the forward distance the branch skips
+fun note_skip_target(st: *encode.EncodeState, bytes: i64) {
+    val mi: *isa.Inst = last_inst(st);
+    if (mi == nil) { ret; }
+    val op: *isa.Operand = target_operand(mi);
+    if (op == nil) { ret; }
+    @op = isa.make_block_label(0);
+    op.imm = bytes;
+    mi.flags = mi.flags | inst.FLAG_LABEL_SKIP;
+}
+
+# name the inline-asm numeric local label a just-emitted branch targets
+# ---
+# st:     encoder driver state (its buffer carries the sink)
+# number: the local label's number
+# fwd:    true for a forward reference (`Nf`), false for a backward one (`Nb`)
+fun note_local_target(st: *encode.EncodeState, number: u64, fwd: bool) {
+    val mi: *isa.Inst = last_inst(st);
+    if (mi == nil) { ret; }
+    val op: *isa.Operand = target_operand(mi);
+    if (op == nil) { ret; }
+    @op = isa.make_block_label(0);
+    op.imm   = number::i64;
+    mi.flags = mi.flags | inst.FLAG_LABEL_LOCAL;
+    if (fwd) { mi.flags = mi.flags | inst.FLAG_LABEL_FWD; }
+}
+
+# name the symbol a just-emitted instruction's address field refers to
+#
+# riscv64 reaches a symbol through an instruction PAIR - `auipc rd, %pcrel_hi(sym)`
+# then an `addi` / load / store taking `%pcrel_lo(sym)` - and the two halves take
+# different relocations and different text. The modifier rides the operand carrying
+# the symbol, so each half renders as the assembler would spell it.
+# ---
+# st:  encoder driver state (its buffer carries the sink)
+# sym: the referenced symbol
+# mod: the relocation modifier the half takes
+fun note_sym_target(st: *encode.EncodeState, sym: intern.StrId, mod: isa.SymModifier) {
+    val mi: *isa.Inst = last_inst(st);
+    if (mi == nil) { ret; }
+    val op: *isa.Operand = target_operand(mi);
+    if (op == nil) { ret; }
+    if (op.kind == isa.OPK_MEM) {
+        # an address field that is part of a memory operand keeps its base register
+        # and takes the symbol in place of its displacement
+        op.sym_id  = sym::u32;
+        op.sym_mod = mod;
+        op.disp    = 0;
+        ret;
+    }
+    @op = isa.make_sym_mod(sym::u32, 8, mod);
+}
+
 # read the 32-bit little-endian word at `pos` in the text sink
 fun read_word(buf: *encode.ByteBuf, pos: usize) u32 {
     ret buf.data[pos]::u32 |
@@ -314,18 +980,18 @@ fun write_word(buf: *encode.ByteBuf, pos: usize, word: u32) {
 }
 
 # the major opcode of the register ALU group for an operation width. RV64-SPECIFIC:
-# a 32-bit operation selects the word ALU (OP_32 -> addw/subw/...), every other
-# width the full-register ALU (OP). an RV32 sibling always returns OP here
+# a 32-bit operation selects the word ALU (OPC_OP_32 -> addw/subw/...), every other
+# width the full-register ALU (OPC_OP). an RV32 sibling always returns OPC_OP here
 fun alu_opcode(width: u8) u32 {
-    if (width == 4) { ret OP_32; }
-    ret OP;
+    if (width == 4) { ret OPC_OP_32; }
+    ret OPC_OP;
 }
 
 # the major opcode of the immediate ALU group for an operation width. RV64-SPECIFIC:
-# a 32-bit operation selects OP_IMM_32 (addiw/slliw/...), every other width OP_IMM
+# a 32-bit operation selects OPC_OP_IMM_32 (addiw/slliw/...), every other width OPC_OP_IMM
 fun alu_imm_opcode(width: u8) u32 {
-    if (width == 4) { ret OP_IMM_32; }
-    ret OP_IMM;
+    if (width == 4) { ret OPC_OP_IMM_32; }
+    ret OPC_OP_IMM;
 }
 
 # the load funct3 for an access width. a 32-bit load is the SIGN-extending `lw` to
@@ -378,8 +1044,8 @@ fun sext12(v: i64) i64 {
 fun emit_li32(st: *encode.EncodeState, rd: u32, v: i32) {
     val hi20: u32 = ((v + 0x800) >> 12)::u32 & 0xFFFFF;
     val lo12: u32 = v::u32 & 0xFFF;
-    emit_word(st, pack_u(LUI, rd, hi20));
-    if (lo12 != 0) { emit_word(st, pack_i(OP_IMM_32, F3_ADD, rd, rd, lo12)); }
+    emit_u(st, OPC_LUI, rd, hi20);
+    if (lo12 != 0) { emit_i(st, OPC_OP_IMM_32, F3_ADD, rd, rd, lo12); }
 }
 
 # materialize the signed immediate `value` into GP register `rd`. a value within the
@@ -390,7 +1056,7 @@ fun emit_li32(st: *encode.EncodeState, rd: u32, v: i32) {
 # immediate is 32-bit and it stops at the `lui ; addiw` path above
 fun emit_li(st: *encode.EncodeState, rd: u32, value: i64) {
     if (value >= -2048 && value <= 2047) {
-        emit_word(st, pack_i(OP_IMM, F3_ADD, rd, RZERO, value::u32 & 0xFFF));
+        emit_i(st, OPC_OP_IMM, F3_ADD, rd, RZERO, value::u32 & 0xFFF);
         ret;
     }
     if (value >= -2147483648 && value <= 2147483647) {
@@ -400,8 +1066,8 @@ fun emit_li(st: *encode.EncodeState, rd: u32, value: i64) {
     val lo12: i64 = sext12(value);
     val hi: i64 = (value - lo12) >> 12;
     emit_li(st, rd, hi);
-    emit_word(st, pack_i(OP_IMM, F3_SLL, rd, rd, 12));  # slli rd, rd, 12
-    if (lo12 != 0) { emit_word(st, pack_i(OP_IMM, F3_ADD, rd, rd, lo12::u32 & 0xFFF)); }
+    emit_i(st, OPC_OP_IMM, F3_SLL, rd, rd, 12);  # slli rd, rd, 12
+    if (lo12 != 0) { emit_i(st, OPC_OP_IMM, F3_ADD, rd, rd, lo12::u32 & 0xFFF); }
 }
 
 # re-sign a width-typed integer immediate to the lp64 register convention before it
@@ -438,11 +1104,11 @@ fun resolve_source(st: *encode.EncodeState, op: *mir.MirOperand, scratch: u32, w
 # scratch register and added with a full-register `add`
 fun emit_addi(st: *encode.EncodeState, rd: u32, rs1: u32, off: i64) {
     if (off >= -2048 && off <= 2047) {
-        emit_word(st, pack_i(OP_IMM, F3_ADD, rd, rs1, off::u32 & 0xFFF));
+        emit_i(st, OPC_OP_IMM, F3_ADD, rd, rs1, off::u32 & 0xFFF);
         ret;
     }
     emit_li(st, SCRATCH, off);
-    emit_word(st, pack_r(OP, F3_ADD, F7_ZERO, rd, rs1, SCRATCH));
+    emit_r(st, OPC_OP, F3_ADD, F7_ZERO, rd, rs1, SCRATCH);
 }
 
 # emit a width-sized integer load or store of register `rt` at `[base + off]`. a
@@ -455,15 +1121,15 @@ fun emit_mem_access(st: *encode.EncodeState, rt: u32, base: u32, off: i64, width
     var d: i64 = off;
     if (off < -2048 || off > 2047) {
         emit_li(st, SCRATCH2, off);
-        emit_word(st, pack_r(OP, F3_ADD, F7_ZERO, SCRATCH2, base, SCRATCH2));
+        emit_r(st, OPC_OP, F3_ADD, F7_ZERO, SCRATCH2, base, SCRATCH2);
         b = SCRATCH2;
         d = 0;
     }
     if (is_load) {
-        emit_word(st, pack_i(LOAD, load_funct3(width), rt, b, d::u32 & 0xFFF));
+        emit_i(st, OPC_LOAD, load_funct3(width), rt, b, d::u32 & 0xFFF);
         ret;
     }
-    emit_word(st, pack_s(STORE, store_funct3(width), b, rt, d::u32 & 0xFFF));
+    emit_s(st, OPC_STORE, store_funct3(width), b, rt, d::u32 & 0xFFF);
 }
 
 # the bytes the prologue reserves at the top of the frame, just below the frame
@@ -563,9 +1229,9 @@ fun scale_shift(scale: u8) u32 {
 # a three-address integer ALU op `op rd, rs1, rs2`. the operands resolve to
 # registers (an immediate source is materialized into the scratch register).
 # `word_form` selects whether a 32-bit operation uses the RV64 word group: `mul` has
-# a `mulw` word form, so it sets it and `alu_opcode` picks OP_32 at 32-bit width; the
+# a `mulw` word form, so it sets it and `alu_opcode` picks OPC_OP_32 at 32-bit width; the
 # bitwise `and` / `or` / `xor` have NO word form (RISC-V defines no andw / orw /
-# xorw), so they clear it and always encode as the full-register OP. a bitwise op of
+# xorw), so they clear it and always encode as the full-register OPC_OP. a bitwise op of
 # two consistently extended 32-bit operands yields a consistently extended result, so
 # the full-register form is correct at every width
 fun encode_alu3(st: *encode.EncodeState, mi: *mir.MirInstr, funct3: u32, funct7: u32, word_form: bool) R.Result[bool, str] {
@@ -583,9 +1249,9 @@ fun encode_alu3(st: *encode.EncodeState, mi: *mir.MirInstr, funct3: u32, funct7:
     if (R.is_err[i32, str](rmr)) { ret R.err[bool, str](R.unwrap_err[i32, str](rmr)); }
     val rs2: u32 = R.unwrap_ok[i32, str](rmr)::u32;
 
-    var opcode: u32 = OP;
+    var opcode: u32 = OPC_OP;
     if (word_form) { opcode = alu_opcode(mi.width); }
-    emit_word(st, pack_r(opcode, funct3, funct7, rd, rs1, rs2));
+    emit_r(st, opcode, funct3, funct7, rd, rs1, rs2);
     ret R.ok[bool, str](true);
 }
 
@@ -609,7 +1275,7 @@ fun encode_addsub(st: *encode.EncodeState, mi: *mir.MirInstr, is_sub: bool) R.Re
         var v: i64 = rhs.imm;
         if (is_sub) { v = 0 - v; }
         if (v >= -2048 && v <= 2047) {
-            emit_word(st, pack_i(alu_imm_opcode(mi.width), F3_ADD, rd, rs1, v::u32 & 0xFFF));
+            emit_i(st, alu_imm_opcode(mi.width), F3_ADD, rd, rs1, v::u32 & 0xFFF);
             ret R.ok[bool, str](true);
         }
     }
@@ -620,7 +1286,7 @@ fun encode_addsub(st: *encode.EncodeState, mi: *mir.MirInstr, is_sub: bool) R.Re
 
     var f7: u32 = F7_ZERO;
     if (is_sub) { f7 = F7_SUB; }
-    emit_word(st, pack_r(alu_opcode(mi.width), F3_ADD, f7, rd, rs1, rs2));
+    emit_r(st, alu_opcode(mi.width), F3_ADD, f7, rd, rs1, rs2);
     ret R.ok[bool, str](true);
 }
 
@@ -649,7 +1315,7 @@ fun encode_shift(st: *encode.EncodeState, mi: *mir.MirInstr, funct3: u32, is_ari
         if (mi.width == 4) { mask = 0x1F; }
         var imm: u32 = rhs.imm::u32 & mask;
         if (is_arith) { imm = imm | 0x400; }  # funct7 0x20 -> imm[10]
-        emit_word(st, pack_i(alu_imm_opcode(mi.width), funct3, rd, rs1, imm));
+        emit_i(st, alu_imm_opcode(mi.width), funct3, rd, rs1, imm);
         ret R.ok[bool, str](true);
     }
 
@@ -659,7 +1325,7 @@ fun encode_shift(st: *encode.EncodeState, mi: *mir.MirInstr, funct3: u32, is_ari
 
     var f7: u32 = F7_ZERO;
     if (is_arith) { f7 = F7_SUB; }
-    emit_word(st, pack_r(alu_opcode(mi.width), funct3, f7, rd, rs1, rs2));
+    emit_r(st, alu_opcode(mi.width), funct3, f7, rd, rs1, rs2);
     ret R.ok[bool, str](true);
 }
 
@@ -673,7 +1339,7 @@ fun encode_neg(st: *encode.EncodeState, mi: *mir.MirInstr) R.Result[bool, str] {
     val rsr: R.Result[i32, str] = req_gpr(?mi.operands[1]);
     if (R.is_err[i32, str](rsr)) { ret R.err[bool, str](R.unwrap_err[i32, str](rsr)); }
     val rs: u32 = R.unwrap_ok[i32, str](rsr)::u32;
-    emit_word(st, pack_r(alu_opcode(mi.width), F3_ADD, F7_SUB, rd, RZERO, rs));
+    emit_r(st, alu_opcode(mi.width), F3_ADD, F7_SUB, rd, RZERO, rs);
     ret R.ok[bool, str](true);
 }
 
@@ -687,7 +1353,7 @@ fun encode_not(st: *encode.EncodeState, mi: *mir.MirInstr) R.Result[bool, str] {
     val rsr: R.Result[i32, str] = req_gpr(?mi.operands[1]);
     if (R.is_err[i32, str](rsr)) { ret R.err[bool, str](R.unwrap_err[i32, str](rsr)); }
     val rs: u32 = R.unwrap_ok[i32, str](rsr)::u32;
-    emit_word(st, pack_i(OP_IMM, F3_XOR, rd, rs, 0xFFF));  # xori rd, rs, -1
+    emit_i(st, OPC_OP_IMM, F3_XOR, rd, rs, 0xFFF);  # xori rd, rs, -1
     ret R.ok[bool, str](true);
 }
 
@@ -722,7 +1388,7 @@ fun encode_mov(st: *encode.EncodeState, f: *mir.MirFunction, mi: *mir.MirInstr) 
     val rsr: R.Result[i32, str] = req_gpr(src);
     if (R.is_err[i32, str](rsr)) { ret R.err[bool, str](R.unwrap_err[i32, str](rsr)); }
     val rs: u32 = R.unwrap_ok[i32, str](rsr)::u32;
-    emit_word(st, pack_i(OP_IMM, F3_ADD, rd, rs, 0));  # mv rd, rs
+    emit_i(st, OPC_OP_IMM, F3_ADD, rd, rs, 0);  # mv rd, rs
     ret R.ok[bool, str](true);
 }
 
@@ -781,7 +1447,8 @@ fun emit_store_mem(st: *encode.EncodeState, f: *mir.MirFunction, dst_mem: *mir.M
 # the same symbol, which the linker measures from this auipc one word back
 fun emit_pcrel_hi(st: *encode.EncodeState, rd: u32, sym: intern.StrId, addend: i32) R.Result[bool, str] {
     val pos: u32 = st.buf.len::u32;
-    emit_word(st, pack_u(AUIPC, rd, 0));
+    emit_u(st, OPC_AUIPC, rd, 0);
+    note_sym_target(st, sym, isa.SYM_MOD_PCREL_HI);
     ret encode.push_reloc(st, pos, of.RK_PCREL_HI20, sym, addend);
 }
 
@@ -796,7 +1463,8 @@ fun emit_global_addr(st: *encode.EncodeState, rd: u32, symop: *mir.MirOperand) R
     val hr: R.Result[bool, str] = emit_pcrel_hi(st, rd, symop.sym, symop.sym_off);
     if (R.is_err[bool, str](hr)) { ret hr; }
     val lo_pos: u32 = st.buf.len::u32;
-    emit_word(st, pack_i(OP_IMM, F3_ADD, rd, rd, 0));   # addi rd, rd, %pcrel_lo(sym)
+    emit_i(st, OPC_OP_IMM, F3_ADD, rd, rd, 0);   # addi rd, rd, %pcrel_lo(sym)
+    note_sym_target(st, symop.sym, isa.SYM_MOD_PCREL_LO);
     ret encode.push_reloc(st, lo_pos, of.RK_PCREL_LO12_I, symop.sym, symop.sym_off);
 }
 
@@ -812,7 +1480,8 @@ fun emit_global_load(st: *encode.EncodeState, rt: u32, symop: *mir.MirOperand, w
     val hr: R.Result[bool, str] = emit_pcrel_hi(st, SCRATCH, symop.sym, symop.sym_off);
     if (R.is_err[bool, str](hr)) { ret hr; }
     val lo_pos: u32 = st.buf.len::u32;
-    emit_word(st, pack_i(LOAD, load_funct3(width), rt, SCRATCH, 0));
+    emit_i(st, OPC_LOAD, load_funct3(width), rt, SCRATCH, 0);
+    note_sym_target(st, symop.sym, isa.SYM_MOD_PCREL_LO);
     ret encode.push_reloc(st, lo_pos, of.RK_PCREL_LO12_I, symop.sym, symop.sym_off);
 }
 
@@ -839,7 +1508,8 @@ fun emit_global_store(st: *encode.EncodeState, symop: *mir.MirOperand, val_op: *
     val hr: R.Result[bool, str] = emit_pcrel_hi(st, SCRATCH, symop.sym, symop.sym_off);
     if (R.is_err[bool, str](hr)) { ret hr; }
     val lo_pos: u32 = st.buf.len::u32;
-    emit_word(st, pack_s(STORE, store_funct3(width), SCRATCH, rt, 0));
+    emit_s(st, OPC_STORE, store_funct3(width), SCRATCH, rt, 0);
+    note_sym_target(st, symop.sym, isa.SYM_MOD_PCREL_LO);
     ret encode.push_reloc(st, lo_pos, of.RK_PCREL_LO12_S, symop.sym, symop.sym_off);
 }
 
@@ -918,10 +1588,10 @@ fun encode_addr(st: *encode.EncodeState, f: *mir.MirFunction, mi: *mir.MirInstr)
         var idx: u32 = m.index;
         val sh: u32 = scale_shift(m.scale);
         if (sh != 0) {
-            emit_word(st, pack_i(OP_IMM, F3_SLL, SCRATCH, m.index, sh));  # slli t0, index, sh
+            emit_i(st, OPC_OP_IMM, F3_SLL, SCRATCH, m.index, sh);  # slli t0, index, sh
             idx = SCRATCH;
         }
-        emit_word(st, pack_r(OP, F3_ADD, F7_ZERO, rd, m.base, idx));      # add rd, base, idx
+        emit_r(st, OPC_OP, F3_ADD, F7_ZERO, rd, m.base, idx);      # add rd, base, idx
         if (m.off != 0) { emit_addi(st, rd, rd, m.off); }
         ret R.ok[bool, str](true);
     }
@@ -963,16 +1633,16 @@ fun narrow_cmp_source(st: *encode.EncodeState, reg: u32, scratch: u32, width: u8
     if (width == 0 || width >= 4) { ret reg; }
     val sh: u32 = 64 - (width::u32 * 8);
     if (signed) {
-        emit_word(st, pack_i(OP_IMM, F3_SLL, scratch, reg, sh));                # slli scratch, reg, sh
-        emit_word(st, pack_i(OP_IMM, F3_SRL, scratch, scratch, sh | 0x400));    # srai scratch, scratch, sh
+        emit_i(st, OPC_OP_IMM, F3_SLL, scratch, reg, sh);                # slli scratch, reg, sh
+        emit_i(st, OPC_OP_IMM, F3_SRL, scratch, scratch, sh | 0x400);    # srai scratch, scratch, sh
         ret scratch;
     }
     if (width == 1) {
-        emit_word(st, pack_i(OP_IMM, F3_AND, scratch, reg, 0xFF));              # andi scratch, reg, 0xff
+        emit_i(st, OPC_OP_IMM, F3_AND, scratch, reg, 0xFF);              # andi scratch, reg, 0xff
         ret scratch;
     }
-    emit_word(st, pack_i(OP_IMM, F3_SLL, scratch, reg, sh));                    # slli scratch, reg, sh
-    emit_word(st, pack_i(OP_IMM, F3_SRL, scratch, scratch, sh));                # srli scratch, scratch, sh
+    emit_i(st, OPC_OP_IMM, F3_SLL, scratch, reg, sh);                    # slli scratch, reg, sh
+    emit_i(st, OPC_OP_IMM, F3_SRL, scratch, scratch, sh);                # srli scratch, scratch, sh
     ret scratch;
 }
 
@@ -1030,31 +1700,31 @@ fun encode_compare(st: *encode.EncodeState, mi: *mir.MirInstr) R.Result[bool, st
 
     val op: mir.MirOpcode = mi.opcode;
     if (op == mir.MIR_SEL_CMP_EQ) {
-        emit_word(st, pack_r(OP, F3_XOR, F7_ZERO, rd, lhs, rhs));   # xor rd, lhs, rhs
-        emit_word(st, pack_i(OP_IMM, F3_SLTU, rd, rd, 1));          # seqz rd, rd
+        emit_r(st, OPC_OP, F3_XOR, F7_ZERO, rd, lhs, rhs);   # xor rd, lhs, rhs
+        emit_i(st, OPC_OP_IMM, F3_SLTU, rd, rd, 1);          # seqz rd, rd
         ret R.ok[bool, str](true);
     }
     if (op == mir.MIR_SEL_CMP_NE) {
-        emit_word(st, pack_r(OP, F3_XOR, F7_ZERO, rd, lhs, rhs));   # xor rd, lhs, rhs
-        emit_word(st, pack_r(OP, F3_SLTU, F7_ZERO, rd, RZERO, rd)); # snez rd, rd
+        emit_r(st, OPC_OP, F3_XOR, F7_ZERO, rd, lhs, rhs);   # xor rd, lhs, rhs
+        emit_r(st, OPC_OP, F3_SLTU, F7_ZERO, rd, RZERO, rd); # snez rd, rd
         ret R.ok[bool, str](true);
     }
     if (op == mir.MIR_SEL_CMP_LT_S) {
-        emit_word(st, pack_r(OP, F3_SLT, F7_ZERO, rd, lhs, rhs));   # slt rd, lhs, rhs
+        emit_r(st, OPC_OP, F3_SLT, F7_ZERO, rd, lhs, rhs);   # slt rd, lhs, rhs
         ret R.ok[bool, str](true);
     }
     if (op == mir.MIR_SEL_CMP_LT_U) {
-        emit_word(st, pack_r(OP, F3_SLTU, F7_ZERO, rd, lhs, rhs));  # sltu rd, lhs, rhs
+        emit_r(st, OPC_OP, F3_SLTU, F7_ZERO, rd, lhs, rhs);  # sltu rd, lhs, rhs
         ret R.ok[bool, str](true);
     }
     if (op == mir.MIR_SEL_CMP_LE_S) {
-        emit_word(st, pack_r(OP, F3_SLT, F7_ZERO, rd, rhs, lhs));   # slt rd, rhs, lhs
-        emit_word(st, pack_i(OP_IMM, F3_XOR, rd, rd, 1));           # xori rd, rd, 1
+        emit_r(st, OPC_OP, F3_SLT, F7_ZERO, rd, rhs, lhs);   # slt rd, rhs, lhs
+        emit_i(st, OPC_OP_IMM, F3_XOR, rd, rd, 1);           # xori rd, rd, 1
         ret R.ok[bool, str](true);
     }
     # MIR_SEL_CMP_LE_U
-    emit_word(st, pack_r(OP, F3_SLTU, F7_ZERO, rd, rhs, lhs));      # sltu rd, rhs, lhs
-    emit_word(st, pack_i(OP_IMM, F3_XOR, rd, rd, 1));               # xori rd, rd, 1
+    emit_r(st, OPC_OP, F3_SLTU, F7_ZERO, rd, rhs, lhs);      # sltu rd, rhs, lhs
+    emit_i(st, OPC_OP_IMM, F3_XOR, rd, rd, 1);               # xori rd, rd, 1
     ret R.ok[bool, str](true);
 }
 
@@ -1070,7 +1740,8 @@ fun encode_branch(st: *encode.EncodeState, fn_base: u32, mi: *mir.MirInstr) R.Re
     # through with no word emitted (issue #1936).
     if (encode.branch_falls_through(st, target_block)) { ret R.ok[bool, str](true); }
     val patch_pos: u32 = st.buf.len::u32;
-    emit_word(st, pack_j(JAL, RZERO, 0));
+    emit_j(st, OPC_JAL, RZERO, 0);
+    note_block_target(st, target_block);
     val next_ip: u32 = st.buf.len::u32;
     ret encode.push_fixup(st, patch_pos, next_ip, target_block, fn_base);
 }
@@ -1092,7 +1763,8 @@ fun encode_cbr(st: *encode.EncodeState, fn_base: u32, mi: *mir.MirInstr) R.Resul
     val cond: u32 = R.unwrap_ok[i32, str](rcr)::u32;
 
     val bne_pos: u32 = st.buf.len::u32;
-    emit_word(st, pack_b(BRANCH, F3_BNE, cond, RZERO, 0));
+    emit_b(st, OPC_BRANCH, F3_BNE, cond, RZERO, 0);
+    note_block_target(st, then_block);
     val bne_next: u32 = st.buf.len::u32;
     val f1: R.Result[bool, str] = encode.push_fixup(st, bne_pos, bne_next, then_block, fn_base);
     if (R.is_err[bool, str](f1)) { ret f1; }
@@ -1101,7 +1773,8 @@ fun encode_cbr(st: *encode.EncodeState, fn_base: u32, mi: *mir.MirInstr) R.Resul
     # order (issue #1936); the taken bne above always keeps its edge.
     if (encode.branch_falls_through(st, else_block)) { ret R.ok[bool, str](true); }
     val j_pos: u32 = st.buf.len::u32;
-    emit_word(st, pack_j(JAL, RZERO, 0));
+    emit_j(st, OPC_JAL, RZERO, 0);
+    note_block_target(st, else_block);
     val j_next: u32 = st.buf.len::u32;
     ret encode.push_fixup(st, j_pos, j_next, else_block, fn_base);
 }
@@ -1168,7 +1841,8 @@ fun encode_fused_cbr(st: *encode.EncodeState, fn_base: u32, mi: *mir.MirInstr) R
     }
 
     val bcc_pos: u32 = st.buf.len::u32;
-    emit_word(st, pack_b(BRANCH, funct3, rs1, rs2, 0));
+    emit_b(st, OPC_BRANCH, funct3, rs1, rs2, 0);
+    note_block_target(st, then_block);
     val bcc_next: u32 = st.buf.len::u32;
     val f1: R.Result[bool, str] = encode.push_fixup(st, bcc_pos, bcc_next, then_block, fn_base);
     if (R.is_err[bool, str](f1)) { ret f1; }
@@ -1181,7 +1855,8 @@ fun encode_fused_cbr(st: *encode.EncodeState, fn_base: u32, mi: *mir.MirInstr) R
         ret R.ok[bool, str](true);
     }
     val j_pos: u32 = st.buf.len::u32;
-    emit_word(st, pack_j(JAL, RZERO, 0));
+    emit_j(st, OPC_JAL, RZERO, 0);
+    note_block_target(st, else_block);
     val j_next: u32 = st.buf.len::u32;
     # bound any fused-condition computed-value records to this terminator's bytes.
     # branch RELAXATION may later widen the terminator; insert_text shifts a
@@ -1204,13 +1879,15 @@ fun encode_call(st: *encode.EncodeState, mi: *mir.MirInstr) R.Result[bool, str] 
             ret R.err[bool, str]("encode: direct call has no resolved symbol name");
         }
         val pos: u32 = st.buf.len::u32;
-        emit_word(st, pack_u(AUIPC, RRA, 0));
-        emit_word(st, pack_i(JALR, F3_ADD, RRA, RRA, 0));
+        emit_u(st, OPC_AUIPC, RRA, 0);
+        note_sym_target(st, callee.sym, isa.SYM_MOD_PCREL_HI);
+        emit_i(st, OPC_JALR, F3_ADD, RRA, RRA, 0);
+        note_sym_target(st, callee.sym, isa.SYM_MOD_PCREL_LO);
         ret encode.push_reloc(st, pos, of.RK_PLT32, callee.sym, callee.sym_off);
     }
     val rr: R.Result[i32, str] = req_gpr(callee);
     if (R.is_err[i32, str](rr)) { ret R.err[bool, str](R.unwrap_err[i32, str](rr)); }
-    emit_word(st, pack_i(JALR, F3_ADD, RRA, R.unwrap_ok[i32, str](rr)::u32, 0));
+    emit_i(st, OPC_JALR, F3_ADD, RRA, R.unwrap_ok[i32, str](rr)::u32, 0);
     ret R.ok[bool, str](true);
 }
 
@@ -1251,7 +1928,7 @@ fun encode_divide(st: *encode.EncodeState, mi: *mir.MirInstr) R.Result[bool, str
     if (R.is_err[i32, str](rmr)) { ret R.err[bool, str](R.unwrap_err[i32, str](rmr)); }
     val rs2: u32 = R.unwrap_ok[i32, str](rmr)::u32;
 
-    emit_word(st, pack_r(alu_opcode(mi.width), divide_funct3(mi.opcode), F7_MULDIV, rd, rs1, rs2));
+    emit_r(st, alu_opcode(mi.width), divide_funct3(mi.opcode), F7_MULDIV, rd, rs1, rs2);
     ret R.ok[bool, str](true);
 }
 
@@ -1279,34 +1956,34 @@ fun encode_convert(st: *encode.EncodeState, mi: *mir.MirInstr) R.Result[bool, st
     val rs: u32 = R.unwrap_ok[i32, str](rsr)::u32;
 
     if (mi.opcode == mir.MIR_TRUNC) {
-        emit_word(st, pack_i(OP_IMM_32, F3_ADD, rd, rs, 0));  # sext.w rd, rs (addiw rd,rs,0)
+        emit_i(st, OPC_OP_IMM_32, F3_ADD, rd, rs, 0);  # sext.w rd, rs (addiw rd,rs,0)
         ret R.ok[bool, str](true);
     }
     if (mi.opcode == mir.MIR_BITCAST) {
         # a same-width reinterpret: an 8-byte value copies all 64 bits (`mv`); a
         # 32-bit value canonicalizes to its sign-extended form (`sext.w`).
-        if (dw >= 8) { emit_word(st, pack_i(OP_IMM, F3_ADD, rd, rs, 0)); }      # mv rd, rs
-        or           { emit_word(st, pack_i(OP_IMM_32, F3_ADD, rd, rs, 0)); }   # sext.w rd, rs
+        if (dw >= 8) { emit_i(st, OPC_OP_IMM, F3_ADD, rd, rs, 0); }      # mv rd, rs
+        or           { emit_i(st, OPC_OP_IMM_32, F3_ADD, rd, rs, 0); }   # sext.w rd, rs
         ret R.ok[bool, str](true);
     }
     if (mi.opcode == mir.MIR_SEXT) {
-        if (sw >= 8) { emit_word(st, pack_i(OP_IMM, F3_ADD, rd, rs, 0)); ret R.ok[bool, str](true); }  # mv
-        if (sw == 4) { emit_word(st, pack_i(OP_IMM_32, F3_ADD, rd, rs, 0)); ret R.ok[bool, str](true); }  # sext.w
+        if (sw >= 8) { emit_i(st, OPC_OP_IMM, F3_ADD, rd, rs, 0); ret R.ok[bool, str](true); }  # mv
+        if (sw == 4) { emit_i(st, OPC_OP_IMM_32, F3_ADD, rd, rs, 0); ret R.ok[bool, str](true); }  # sext.w
         # sign-extend a 1 / 2-byte source: shift its sign bit to bit 63 then back.
         val sh: u32 = 64 - (sw::u32 * 8);
-        emit_word(st, pack_i(OP_IMM, F3_SLL, rd, rs, sh));            # slli rd, rs, sh
-        emit_word(st, pack_i(OP_IMM, F3_SRL, rd, rd, sh | 0x400));    # srai rd, rd, sh
+        emit_i(st, OPC_OP_IMM, F3_SLL, rd, rs, sh);            # slli rd, rs, sh
+        emit_i(st, OPC_OP_IMM, F3_SRL, rd, rd, sh | 0x400);    # srai rd, rd, sh
         ret R.ok[bool, str](true);
     }
     # MIR_ZEXT: a byte source masks with `andi`; a 2 / 4-byte source shifts left then
     # logical-right to clear the high bits (RV64 has no base zero-extend-word).
     if (sw == 1) {
-        emit_word(st, pack_i(OP_IMM, F3_AND, rd, rs, 0xFF));  # andi rd, rs, 0xFF
+        emit_i(st, OPC_OP_IMM, F3_AND, rd, rs, 0xFF);  # andi rd, rs, 0xFF
         ret R.ok[bool, str](true);
     }
     val sh: u32 = 64 - (sw::u32 * 8);
-    emit_word(st, pack_i(OP_IMM, F3_SLL, rd, rs, sh));  # slli rd, rs, sh
-    emit_word(st, pack_i(OP_IMM, F3_SRL, rd, rd, sh));  # srli rd, rd, sh
+    emit_i(st, OPC_OP_IMM, F3_SLL, rd, rs, sh);  # slli rd, rs, sh
+    emit_i(st, OPC_OP_IMM, F3_SRL, rd, rd, sh);  # srli rd, rd, sh
     ret R.ok[bool, str](true);
 }
 
@@ -1349,15 +2026,15 @@ fun emit_fp_mem(st: *encode.EncodeState, rt: u32, base: u32, off: i64, width: u8
     var d: i64 = off;
     if (off < -2048 || off > 2047) {
         emit_li(st, SCRATCH2, off);
-        emit_word(st, pack_r(OP, F3_ADD, F7_ZERO, SCRATCH2, base, SCRATCH2));
+        emit_r(st, OPC_OP, F3_ADD, F7_ZERO, SCRATCH2, base, SCRATCH2);
         b = SCRATCH2;
         d = 0;
     }
     if (is_load) {
-        emit_word(st, pack_i(LOAD_FP, fp_mem_funct3(width), rt, b, d::u32 & 0xFFF));
+        emit_i(st, OPC_LOAD_FP, fp_mem_funct3(width), rt, b, d::u32 & 0xFFF);
         ret;
     }
-    emit_word(st, pack_s(STORE_FP, fp_mem_funct3(width), b, rt, d::u32 & 0xFFF));
+    emit_s(st, OPC_STORE_FP, fp_mem_funct3(width), b, rt, d::u32 & 0xFFF);
 }
 
 # store float register `rt` to a frame-slot / pointer MEM destination at float
@@ -1414,7 +2091,7 @@ fun fmv_f2i_funct7(width: u8) u32 {
 # materialization never collides with a live value. `width` is 4 (S) or 8 (D)
 fun emit_fp_imm(st: *encode.EncodeState, vd: u32, bits: i64, width: u8) {
     emit_li(st, SCRATCH, bits);
-    emit_word(st, pack_r(OP_FP, RM_RNE, fmv_i2f_funct7(width), vd, SCRATCH, 0));
+    emit_r(st, OPC_OP_FP, RM_RNE, fmv_i2f_funct7(width), vd, SCRATCH, 0);
 }
 
 # the float register index a float source operand contributes. a physical float
@@ -1439,7 +2116,7 @@ fun resolve_fp_source(st: *encode.EncodeState, f: *mir.MirFunction, op: *mir.Mir
     ret req_fpr(op);
 }
 
-# the OP_FP funct7 for a binary float arithmetic MIR opcode and precision (the double
+# the OPC_OP_FP funct7 for a binary float arithmetic MIR opcode and precision (the double
 # form is the single form set with bit 0)
 fun fp_arith_funct7(op: mir.MirOpcode, dbl: bool) u32 {
     var base: u32 = F7_FADD;
@@ -1488,12 +2165,12 @@ fun encode_fp_arith(st: *encode.EncodeState, f: *mir.MirFunction, mi: *mir.MirIn
     val f7: u32 = fp_arith_funct7(mi.opcode, dbl);
     val dst: *mir.MirOperand = ?mi.operands[0];
     if (dst.kind == mir.MIR_OP_MEM) {
-        emit_word(st, pack_r(OP_FP, RM_DYN, f7, FP_SCRATCH, rn, rm));
+        emit_r(st, OPC_OP_FP, RM_DYN, f7, FP_SCRATCH, rn, rm);
         ret emit_fp_slot_store(st, f, dst, FP_SCRATCH, w);
     }
     val rdr: R.Result[i32, str] = req_fpr(dst);
     if (R.is_err[i32, str](rdr)) { ret R.err[bool, str](R.unwrap_err[i32, str](rdr)); }
-    emit_word(st, pack_r(OP_FP, RM_DYN, f7, R.unwrap_ok[i32, str](rdr)::u32, rn, rm));
+    emit_r(st, OPC_OP_FP, RM_DYN, f7, R.unwrap_ok[i32, str](rdr)::u32, rn, rm);
     ret R.ok[bool, str](true);
 }
 
@@ -1516,12 +2193,12 @@ fun encode_fp_neg(st: *encode.EncodeState, f: *mir.MirFunction, mi: *mir.MirInst
 
     val dst: *mir.MirOperand = ?mi.operands[0];
     if (dst.kind == mir.MIR_OP_MEM) {
-        emit_word(st, pack_r(OP_FP, F3_FLT, f7, FP_SCRATCH, rn, rn));  # fsgnjn (fneg)
+        emit_r(st, OPC_OP_FP, F3_FLT, f7, FP_SCRATCH, rn, rn);  # fsgnjn (fneg)
         ret emit_fp_slot_store(st, f, dst, FP_SCRATCH, w);
     }
     val rdr: R.Result[i32, str] = req_fpr(dst);
     if (R.is_err[i32, str](rdr)) { ret R.err[bool, str](R.unwrap_err[i32, str](rdr)); }
-    emit_word(st, pack_r(OP_FP, F3_FLT, f7, R.unwrap_ok[i32, str](rdr)::u32, rn, rn));
+    emit_r(st, OPC_OP_FP, F3_FLT, f7, R.unwrap_ok[i32, str](rdr)::u32, rn, rn);
     ret R.ok[bool, str](true);
 }
 
@@ -1578,8 +2255,8 @@ fun encode_fp_cmp(st: *encode.EncodeState, f: *mir.MirFunction, mi: *mir.MirInst
     var a: u32 = rn;
     var b: u32 = rm;
     if (swap) { a = rm; b = rn; }
-    emit_word(st, pack_r(OP_FP, funct3, f7, rd, a, b));
-    if (invert) { emit_word(st, pack_i(OP_IMM, F3_XOR, rd, rd, 1)); }  # xori rd, rd, 1
+    emit_r(st, OPC_OP_FP, funct3, f7, rd, a, b);
+    if (invert) { emit_i(st, OPC_OP_IMM, F3_XOR, rd, rd, 1); }  # xori rd, rd, 1
     ret R.ok[bool, str](true);
 }
 
@@ -1624,12 +2301,12 @@ fun encode_fp_conv(st: *encode.EncodeState, f: *mir.MirFunction, mi: *mir.MirIns
         }
         val dst: *mir.MirOperand = ?mi.operands[0];
         if (dst.kind == mir.MIR_OP_MEM) {
-            emit_word(st, pack_r(OP_FP, rm, f7, FP_SCRATCH, rn, rs2));
+            emit_r(st, OPC_OP_FP, rm, f7, FP_SCRATCH, rn, rs2);
             ret emit_fp_slot_store(st, f, dst, FP_SCRATCH, dw);
         }
         val rdr: R.Result[i32, str] = req_fpr(dst);
         if (R.is_err[i32, str](rdr)) { ret R.err[bool, str](R.unwrap_err[i32, str](rdr)); }
-        emit_word(st, pack_r(OP_FP, rm, f7, R.unwrap_ok[i32, str](rdr)::u32, rn, rs2));
+        emit_r(st, OPC_OP_FP, rm, f7, R.unwrap_ok[i32, str](rdr)::u32, rn, rs2);
         ret R.ok[bool, str](true);
     }
 
@@ -1644,13 +2321,13 @@ fun encode_fp_conv(st: *encode.EncodeState, f: *mir.MirFunction, mi: *mir.MirIns
         if (sw < 4) {
             val shamt: u32 = 64 - (sw::u32 * 8);
             if (signed) {
-                emit_word(st, pack_i(OP_IMM, F3_SLL, SCRATCH, gp, shamt));
-                emit_word(st, pack_i(OP_IMM, F3_SRL, SCRATCH, SCRATCH, shamt | 0x400));  # srai
+                emit_i(st, OPC_OP_IMM, F3_SLL, SCRATCH, gp, shamt);
+                emit_i(st, OPC_OP_IMM, F3_SRL, SCRATCH, SCRATCH, shamt | 0x400);  # srai
             } or (sw == 1) {
-                emit_word(st, pack_i(OP_IMM, F3_AND, SCRATCH, gp, 0xFF));                # andi
+                emit_i(st, OPC_OP_IMM, F3_AND, SCRATCH, gp, 0xFF);                # andi
             } or {
-                emit_word(st, pack_i(OP_IMM, F3_SLL, SCRATCH, gp, shamt));
-                emit_word(st, pack_i(OP_IMM, F3_SRL, SCRATCH, SCRATCH, shamt));          # srli
+                emit_i(st, OPC_OP_IMM, F3_SLL, SCRATCH, gp, shamt);
+                emit_i(st, OPC_OP_IMM, F3_SRL, SCRATCH, SCRATCH, shamt);          # srli
             }
             gp = SCRATCH;
             src_word = true;
@@ -1665,12 +2342,12 @@ fun encode_fp_conv(st: *encode.EncodeState, f: *mir.MirFunction, mi: *mir.MirIns
         val rm: u32 = int_to_fp_rm(dbl, src_word);
         val dst: *mir.MirOperand = ?mi.operands[0];
         if (dst.kind == mir.MIR_OP_MEM) {
-            emit_word(st, pack_r(OP_FP, rm, f7, FP_SCRATCH, gp, rs2));
+            emit_r(st, OPC_OP_FP, rm, f7, FP_SCRATCH, gp, rs2);
             ret emit_fp_slot_store(st, f, dst, FP_SCRATCH, dw);
         }
         val rdr: R.Result[i32, str] = req_fpr(dst);
         if (R.is_err[i32, str](rdr)) { ret R.err[bool, str](R.unwrap_err[i32, str](rdr)); }
-        emit_word(st, pack_r(OP_FP, rm, f7, R.unwrap_ok[i32, str](rdr)::u32, gp, rs2));
+        emit_r(st, OPC_OP_FP, rm, f7, R.unwrap_ok[i32, str](rdr)::u32, gp, rs2);
         ret R.ok[bool, str](true);
     }
 
@@ -1688,7 +2365,7 @@ fun encode_fp_conv(st: *encode.EncodeState, f: *mir.MirFunction, mi: *mir.MirIns
     if (dw <= 4 && signed)   { rs2 = FCVT_W; }
     or (dw <= 4 && !signed)  { rs2 = FCVT_WU; }
     or (dw > 4 && !signed)   { rs2 = FCVT_LU; }
-    emit_word(st, pack_r(OP_FP, RM_RTZ, f7, rd, rn, rs2));
+    emit_r(st, OPC_OP_FP, RM_RTZ, f7, rd, rn, rs2);
     ret R.ok[bool, str](true);
 }
 
@@ -1737,7 +2414,7 @@ fun encode_fmov(st: *encode.EncodeState, f: *mir.MirFunction, mi: *mir.MirInstr)
             var f7: u32 = F7_FSGNJ;
             if (dbl) { f7 = F7_FSGNJ | 1; }
             val rn: u32 = R.unwrap_ok[i32, str](rnr)::u32;
-            emit_word(st, pack_r(OP_FP, F3_FLE, f7, R.unwrap_ok[i32, str](rdr)::u32, rn, rn));
+            emit_r(st, OPC_OP_FP, F3_FLE, f7, R.unwrap_ok[i32, str](rdr)::u32, rn, rn);
             ret R.ok[bool, str](true);
         }
         if (dfp) {
@@ -1746,7 +2423,7 @@ fun encode_fmov(st: *encode.EncodeState, f: *mir.MirFunction, mi: *mir.MirInstr)
             if (R.is_err[i32, str](rdr)) { ret R.err[bool, str](R.unwrap_err[i32, str](rdr)); }
             val rnr: R.Result[i32, str] = req_gpr(src);
             if (R.is_err[i32, str](rnr)) { ret R.err[bool, str](R.unwrap_err[i32, str](rnr)); }
-            emit_word(st, pack_r(OP_FP, RM_RNE, fmv_i2f_funct7(w), R.unwrap_ok[i32, str](rdr)::u32, R.unwrap_ok[i32, str](rnr)::u32, 0));
+            emit_r(st, OPC_OP_FP, RM_RNE, fmv_i2f_funct7(w), R.unwrap_ok[i32, str](rdr)::u32, R.unwrap_ok[i32, str](rnr)::u32, 0);
             ret R.ok[bool, str](true);
         }
         if (sfp) {
@@ -1755,7 +2432,7 @@ fun encode_fmov(st: *encode.EncodeState, f: *mir.MirFunction, mi: *mir.MirInstr)
             if (R.is_err[i32, str](rdr)) { ret R.err[bool, str](R.unwrap_err[i32, str](rdr)); }
             val rnr: R.Result[i32, str] = req_fpr(src);
             if (R.is_err[i32, str](rnr)) { ret R.err[bool, str](R.unwrap_err[i32, str](rnr)); }
-            emit_word(st, pack_r(OP_FP, RM_RNE, fmv_f2i_funct7(w), R.unwrap_ok[i32, str](rdr)::u32, R.unwrap_ok[i32, str](rnr)::u32, 0));
+            emit_r(st, OPC_OP_FP, RM_RNE, fmv_f2i_funct7(w), R.unwrap_ok[i32, str](rdr)::u32, R.unwrap_ok[i32, str](rnr)::u32, 0);
             ret R.ok[bool, str](true);
         }
         ret R.err[bool, str]("encode: fmov names two general-purpose registers");
@@ -1840,12 +2517,12 @@ fun emit_sp_adjust(st: *encode.EncodeState, delta: u32, subtract: bool) {
     var signed: i64 = delta::i64;
     if (subtract) { signed = 0 - signed; }
     if (signed >= -2048 && signed <= 2047) {
-        emit_word(st, pack_i(OP_IMM, F3_ADD, RSP, RSP, signed::u32 & 0xFFF));
+        emit_i(st, OPC_OP_IMM, F3_ADD, RSP, RSP, signed::u32 & 0xFFF);
         ret;
     }
     emit_li(st, SCRATCH, delta::i64);
-    if (subtract) { emit_word(st, pack_r(OP, F3_ADD, F7_SUB, RSP, RSP, SCRATCH)); }
-    or            { emit_word(st, pack_r(OP, F3_ADD, F7_ZERO, RSP, RSP, SCRATCH)); }
+    if (subtract) { emit_r(st, OPC_OP, F3_ADD, F7_SUB, RSP, RSP, SCRATCH); }
+    or            { emit_r(st, OPC_OP, F3_ADD, F7_ZERO, RSP, RSP, SCRATCH); }
 }
 
 # save (or restore) the callee-saved GP registers `callee_mask` selects, in ascending
@@ -2027,9 +2704,9 @@ fun encode_mir_instr(st: *encode.EncodeState, f: *mir.MirFunction, fn_base: u32,
     if (op == riscv64.MOV::u16)    { ret encode_mov(st, f, mi); }
     if (op == riscv64.FMV::u16)    { ret encode_fmov(st, f, mi); }
     if (op == riscv64.JMP::u16)    { ret encode_branch(st, fn_base, mi); }
-    if (op == riscv64.RET::u16)    { emit_word(st, pack_i(JALR, F3_ADD, RZERO, RRA, 0)); ret R.ok[bool, str](true); }
-    if (op == riscv64.NOP::u16)    { emit_word(st, pack_i(OP_IMM, F3_ADD, RZERO, RZERO, 0)); ret R.ok[bool, str](true); }
-    if (op == riscv64.EBREAK::u16) { emit_word(st, pack_i(SYSTEM, F3_ADD, RZERO, RZERO, 1)); ret R.ok[bool, str](true); }
+    if (op == riscv64.RET::u16)    { emit_i(st, OPC_JALR, F3_ADD, RZERO, RRA, 0); ret R.ok[bool, str](true); }
+    if (op == riscv64.NOP::u16)    { emit_i(st, OPC_OP_IMM, F3_ADD, RZERO, RZERO, 0); ret R.ok[bool, str](true); }
+    if (op == riscv64.EBREAK::u16) { emit_i(st, OPC_SYSTEM, F3_ADD, RZERO, RZERO, 1); ret R.ok[bool, str](true); }
 
     ret R.err[bool, str]("encode: unhandled opcode in riscv64 encode");
 }
@@ -2060,7 +2737,109 @@ fun write_inverted_guard(buf: *encode.ByteBuf, pos: usize, bne_word: u32, disp: 
     val funct3: u32 = ((bne_word >> 12) & 0x7) ^ 0x1;
     val rs1: u32 = (bne_word >> 15) & 0x1F;
     val rs2: u32 = (bne_word >> 20) & 0x1F;
-    write_word(buf, pos, pack_b(BRANCH, funct3, rs1, rs2, disp));
+    write_word(buf, pos, pack_b(OPC_BRANCH, funct3, rs1, rs2, disp));
+}
+
+# the conditional branch that tests the opposite relation
+#
+# `funct3 ^ 1` flips every eq/ne, lt/ge and ltu/geu pair in the encoding, so the
+# instruction-level inversion is the same three-way pairing over the named forms.
+# ---
+# op:  the branch to invert
+# ret: the opposite branch, or inst.MOP_NONE when `op` is not a conditional branch
+fun invert_branch(op: inst.MachOp) inst.MachOp {
+    if (op == inst.BEQ)  { ret inst.BNE; }
+    if (op == inst.BNE)  { ret inst.BEQ; }
+    if (op == inst.BLT)  { ret inst.BGE; }
+    if (op == inst.BGE)  { ret inst.BLT; }
+    if (op == inst.BLTU) { ret inst.BGEU; }
+    if (op == inst.BGEU) { ret inst.BLTU; }
+    ret inst.MOP_NONE;
+}
+
+# re-notify a conditional branch that relaxation just rewrote into an inverted guard
+# plus a reaching `jal`
+#
+# The bytes at `guard_pos` are no longer the branch that was notified when they were
+# emitted, so the notification must follow: the guard keeps the compared registers
+# but tests the opposite relation and skips the trampoline, and the `jal` written
+# into the opened gap inherits the block the original branch targeted. Leaving the
+# original notification in place would render a `blt` the object does not contain and
+# omit a `jal` it does - #2187 by a different route, inside its own fix.
+# ---
+# st:           encoder driver state (its buffer carries the sink)
+# guard_pos:    the guard's `.text` offset
+# jal_pos:      the inserted jump's `.text` offset
+# target_block: the block the original branch targeted
+# ret:          ok(true), or an error naming a notification that could not be found
+fun renote_relaxed_branch(st: *encode.EncodeState, guard_pos: u32, jal_pos: u32, target_block: u32) R.Result[bool, str] {
+    if (!encode.sink_active(?st.buf)) { ret R.ok[bool, str](true); }
+    val idx: i32 = encode.note_index_at(?st.buf, guard_pos);
+    if (idx < 0) {
+        ret R.err[bool, str]("--emit-asm: riscv64 branch relaxation found no notification for the branch it widened");
+    }
+    val guard: *encode.AsmNote = encode.note_at(?st.buf, idx::u32);
+    val inverted: inst.MachOp = invert_branch(guard.inst.opcode::inst.MachOp);
+    if (inverted == inst.MOP_NONE) {
+        ret R.err[bool, str]("--emit-asm: riscv64 branch relaxation widened an instruction that is not a conditional branch");
+    }
+
+    var jump: encode.AsmNote = encode.note_blank();
+    jump.off  = jal_pos;
+    jump.inst = build_inst(inst.JAL, RZERO, 0, 0, 0);
+    jump.inst.src1 = isa.make_block_label(target_block);
+
+    guard.inst.opcode = inverted::u16;
+    guard.inst.src2   = isa.make_block_label(0);
+    guard.inst.src2.imm = 8;
+    guard.inst.flags  = guard.inst.flags | inst.FLAG_LABEL_SKIP;
+
+    ret encode.note_insert_after(?st.buf, idx::u32, ?jump);
+}
+
+# re-notify a `jal` that relaxation just rewrote into an `auipc` / `jalr` trampoline
+#
+# The two words reach the full 32-bit pc-relative range and take the same
+# high / low split an assembler spells with `%pcrel_hi` / `%pcrel_lo`, so each half
+# names the target block under its own modifier.
+# ---
+# st:           encoder driver state (its buffer carries the sink)
+# auipc_pos:    the trampoline's `.text` offset
+# jalr_pos:     the second word's `.text` offset
+# target_block: the block the jump targets
+# ret:          ok(true), or an error naming a notification that could not be found
+fun renote_trampoline(st: *encode.EncodeState, auipc_pos: u32, jalr_pos: u32, target_block: u32) R.Result[bool, str] {
+    if (!encode.sink_active(?st.buf)) { ret R.ok[bool, str](true); }
+    val idx: i32 = encode.note_index_at(?st.buf, auipc_pos);
+    if (idx < 0) {
+        ret R.err[bool, str]("--emit-asm: riscv64 branch relaxation found no notification for the jump it widened");
+    }
+    val hi: *encode.AsmNote = encode.note_at(?st.buf, idx::u32);
+    hi.inst = build_inst(inst.AUIPC, SCRATCH, 0, 0, 0);
+    hi.inst.src1 = isa.make_block_label(target_block);
+    hi.inst.src1.sym_mod = isa.SYM_MOD_PCREL_HI;
+
+    var lo: encode.AsmNote = encode.note_blank();
+    lo.off  = jalr_pos;
+    lo.inst = build_inst(inst.JALR, RZERO, SCRATCH, 0, 0);
+    lo.inst.src1.sym_mod = isa.SYM_MOD_PCREL_LO;
+    lo.inst.src1.imm     = target_block::i64;
+    lo.inst.flags        = inst.FLAG_TARGET_BLOCK;
+
+    ret encode.note_insert_after(?st.buf, idx::u32, ?lo);
+}
+
+# widen the skip a relaxed conditional's guard renders, after its trampoline grew
+# ---
+# st:        encoder driver state (its buffer carries the sink)
+# guard_pos: the guard's `.text` offset
+# disp:      the guard's new forward distance
+fun renote_guard_skip(st: *encode.EncodeState, guard_pos: u32, disp: i64) {
+    if (!encode.sink_active(?st.buf)) { ret; }
+    val idx: i32 = encode.note_index_at(?st.buf, guard_pos);
+    if (idx < 0) { ret; }
+    val guard: *encode.AsmNote = encode.note_at(?st.buf, idx::u32);
+    guard.inst.src2.imm = disp;
 }
 
 # relax every out-of-range intra-function branch this function just emitted into a
@@ -2108,30 +2887,35 @@ fun relax_function_riscv64(st: *encode.EncodeState, fn_base: u32, fixup_start: u
             val opcode: u32 = word & 0x7F;
             val sdisp: i64 = (target_off::i64) - (fx.patch_pos::i64);
 
-            if (opcode == BRANCH && (sdisp < B_DISP_MIN || sdisp > B_DISP_MAX)) {
+            if (opcode == OPC_BRANCH && (sdisp < B_DISP_MIN || sdisp > B_DISP_MAX)) {
                 val guard_pos: u32 = fx.patch_pos;
                 val jal_pos: u32 = fx.patch_pos + 4;
                 val ins: R.Result[bool, str] = encode.insert_text(st, jal_pos, 4);
                 if (R.is_err[bool, str](ins)) { ret R.err[bool, str](R.unwrap_err[bool, str](ins)); }
                 write_inverted_guard(?st.buf, guard_pos::usize, word, 8);
-                write_word(?st.buf, jal_pos::usize, pack_j(JAL, RZERO, 0));
+                write_word(?st.buf, jal_pos::usize, pack_j(OPC_JAL, RZERO, 0));
+                val rn: R.Result[bool, str] = renote_relaxed_branch(st, guard_pos, jal_pos, fx.target_block);
+                if (R.is_err[bool, str](rn)) { ret rn; }
                 fx.patch_pos = jal_pos;
                 fx.next_ip   = jal_pos + 4;
                 relaxed[i - fixup_start] = 1;
                 changed = true;
                 brk;
             }
-            if (opcode == JAL && (sdisp < J_DISP_MIN || sdisp > J_DISP_MAX)) {
+            if (opcode == OPC_JAL && (sdisp < J_DISP_MIN || sdisp > J_DISP_MAX)) {
                 val auipc_pos: u32 = fx.patch_pos;
                 val jalr_pos: u32 = fx.patch_pos + 4;
                 val ins: R.Result[bool, str] = encode.insert_text(st, jalr_pos, 4);
                 if (R.is_err[bool, str](ins)) { ret R.err[bool, str](R.unwrap_err[bool, str](ins)); }
-                write_word(?st.buf, auipc_pos::usize, pack_u(AUIPC, SCRATCH, 0));
-                write_word(?st.buf, jalr_pos::usize, pack_i(JALR, F3_ADD, RZERO, SCRATCH, 0));
+                write_word(?st.buf, auipc_pos::usize, pack_u(OPC_AUIPC, SCRATCH, 0));
+                write_word(?st.buf, jalr_pos::usize, pack_i(OPC_JALR, F3_ADD, RZERO, SCRATCH, 0));
+                val rn: R.Result[bool, str] = renote_trampoline(st, auipc_pos, jalr_pos, fx.target_block);
+                if (R.is_err[bool, str](rn)) { ret rn; }
                 fx.next_ip = auipc_pos + 8;
                 if (relaxed[i - fixup_start] != 0) {
                     val guard_pos: u32 = auipc_pos - 4;
                     set_branch_disp(?st.buf, guard_pos::usize, fx.next_ip - guard_pos);
+                    renote_guard_skip(st, guard_pos, (fx.next_ip - guard_pos)::i64);
                 }
                 changed = true;
                 brk;
@@ -2151,8 +2935,39 @@ fun relax_function_riscv64(st: *encode.EncodeState, fn_base: u32, fixup_start: u
 # callee-saved GP and FP registers are spilled / reloaded by the prologue / epilogue
 # from the frame facts
 fun encode_function_riscv64(st: *encode.EncodeState, f: *mir.MirFunction) R.Result[bool, str] {
-    val fn_base: u32 = st.buf.len::u32;
     if (f.block_count == 0) { ret R.ok[bool, str](true); }
+    if (!encode.sink_active(?st.buf)) { ret encode_function_body(st, f); }
+
+    var head: encode.AsmNote = encode.note_blank();
+    head.kind = encode.ASM_NOTE_FUNC;
+    head.off  = st.buf.len::u32;
+    head.name = f.name;
+    val rh: R.Result[bool, str] = encode.note_push(?st.buf, ?head);
+    if (R.is_err[bool, str](rh)) { ret rh; }
+
+    val res: R.Result[bool, str] = encode_function_body(st, f);
+    if (R.is_err[bool, str](res)) {
+        encode.notes_reset(?st.buf);
+        ret res;
+    }
+    # the layout is final only now: relaxation has run, so every buffered notification
+    # names the instruction the object holds rather than the one first planned.
+    val rr: R.Result[bool, str] = printer.render_notes(?st.buf);
+    encode.notes_reset(?st.buf);
+    ret rr;
+}
+
+# emit one function's bytes
+#
+# The body `encode_function_riscv64` wraps. Split out so the notification buffer is
+# opened and closed in exactly one place regardless of which error path the encode
+# takes.
+# ---
+# st:  the shared encode state
+# f:   the function to encode
+# ret: ok(true) on success, or an error string
+fun encode_function_body(st: *encode.EncodeState, f: *mir.MirFunction) R.Result[bool, str] {
+    val fn_base: u32 = st.buf.len::u32;
     val fixup_start: u32 = st.fixup_count;
 
     val ms: R.Result[bool, str] = encode.push_symbol(st, f.name, fn_base, of.SYM_OBJ_FLAG_FUNCTION);
@@ -2161,6 +2976,8 @@ fun encode_function_riscv64(st: *encode.EncodeState, f: *mir.MirFunction) R.Resu
     val naked: bool = function_is_naked(f);
     val total: u32 = frame_total(f);
     if (!naked) { emit_prologue(st, f, total); }
+    val rp: R.Result[bool, str] = check_accounted(st, fn_base, PROLOGUE_REGION);
+    if (R.is_err[bool, str](rp)) { ret rp; }
 
     var bi: u32 = 0;
     for (bi < f.block_count) {
@@ -2169,6 +2986,15 @@ fun encode_function_riscv64(st: *encode.EncodeState, f: *mir.MirFunction) R.Resu
         if (R.is_err[bool, str](rb)) { ret rb; }
         # this block's fallthrough successor, so its terminator can elide a jump to it.
         encode.set_fallthrough(st, f, bi);
+
+        if (encode.sink_active(?st.buf)) {
+            var label: encode.AsmNote = encode.note_blank();
+            label.kind = encode.ASM_NOTE_BLOCK;
+            label.off  = st.buf.len::u32;
+            label.id   = blk.id;
+            val rl: R.Result[bool, str] = encode.note_push(?st.buf, ?label);
+            if (R.is_err[bool, str](rl)) { ret rl; }
+        }
 
         var ii: u32 = 0;
         for (ii < blk.instr_count) {
@@ -2187,11 +3013,64 @@ fun encode_function_riscv64(st: *encode.EncodeState, f: *mir.MirFunction) R.Resu
             }
             val ei: R.Result[bool, str] = encode_mir_instr(st, f, fn_base, mi);
             if (R.is_err[bool, str](ei)) { ret ei; }
+            val ra: R.Result[bool, str] = check_accounted(st, fn_base, mi.opcode::u16);
+            if (R.is_err[bool, str](ra)) { ret ra; }
             ii = ii + 1;
         }
         bi = bi + 1;
     }
-    ret relax_function_riscv64(st, fn_base, fixup_start);
+
+    val rx: R.Result[bool, str] = relax_function_riscv64(st, fn_base, fixup_start);
+    if (R.is_err[bool, str](rx)) { ret rx; }
+    ret check_accounted(st, fn_base, RELAX_REGION);
+}
+
+# the pseudo-opcodes `check_accounted` reports the two regions outside a MIR
+# instruction under, chosen above every real riscv64 and MIR opcode so neither can
+# collide with one
+val PROLOGUE_REGION: u16 = 0xFFFF;
+val RELAX_REGION:    u16 = 0xFFFE;
+
+# fail when the bytes emitted so far do not match the instructions notified
+#
+# The totality guard behind `--emit-asm` (#2187). RISC-V instructions are a fixed
+# four bytes wide and the encoder notifies once per instruction, so the two counts
+# must agree EXACTLY: bytes emitted in this function equal four times the
+# instructions notified. An emission path that writes a word without notifying, or
+# one notification standing for two emitted instructions, breaks the equality and
+# fails the build naming the opcode. It covers branch relaxation too - a widened
+# branch that grows the text without re-notifying leaves the counts unequal.
+#
+# The EXACT count is what makes this stronger than the shared byte-accounting guard
+# (`encode.sink_unaccounted`) a variable-width ISA has to settle for. That one marks
+# every byte written so far as covered at each notification, so a missing
+# notification in the middle of a sequence is absorbed by the next one and only a
+# missing notification at the END of a MIR opcode is caught. Counting instructions
+# has no such blind spot: a dropped notification stays one short forever.
+#
+# Inert when no sink is attached, so an object-producing encode pays nothing.
+# ---
+# st:      the shared encode state (its buffer carries the sink)
+# fn_base: the `.text` offset the current function started at
+# opcode:  the opcode whose encoding broke the equality, or a region pseudo-opcode
+# ret:     ok(true) when every emitted instruction was notified, or a precise error
+fun check_accounted(st: *encode.EncodeState, fn_base: u32, opcode: u16) R.Result[bool, str] {
+    if (!encode.sink_active(?st.buf)) { ret R.ok[bool, str](true); }
+    val emitted:  u32 = st.buf.len::u32 - fn_base;
+    val notified: u32 = encode.note_inst_count(?st.buf) * WORD_SIZE;
+    if (emitted == notified) { ret R.ok[bool, str](true); }
+
+    var num: [24]u8;
+    var label: str = "prologue";
+    if (opcode == RELAX_REGION) { label = "branch relaxation"; }
+    or (opcode != PROLOGUE_REGION) {
+        val n: usize = rv_dec_into(?num[0], opcode::u64);
+        num[n] = 0;
+        label = (?num[0])::str;
+    }
+    ret R.err[bool, str](rv_named_err(st,
+        "--emit-asm: ", label, " emitted instructions the riscv64 assembly printer did not render",
+        "--emit-asm: an opcode emitted instructions the riscv64 assembly printer did not render"));
 }
 
 # the per-branch patch hook (pass 2). reads the placeholder instruction word at the
@@ -2217,7 +3096,7 @@ fun patch_branch_riscv64(st: *encode.EncodeState, fx: *encode.BranchFixup, targe
     val disp: u32 = target_off - fx.patch_pos;
     val opcode: u32 = word & 0x7F;
 
-    if (opcode == JAL) {
+    if (opcode == OPC_JAL) {
         # J-type: +-1 MiB. the non-immediate bits are rd[11:7] and opcode[6:0].
         if (sdisp < J_DISP_MIN || sdisp > J_DISP_MAX) {
             ret R.err[bool, str]("encode: riscv64 jump displacement exceeds the +-1MiB range");
@@ -2225,7 +3104,7 @@ fun patch_branch_riscv64(st: *encode.EncodeState, fx: *encode.BranchFixup, targe
         write_word(?st.buf, pos, (word & 0xFFF) | j_imm(disp));
         ret R.ok[bool, str](true);
     }
-    if (opcode == BRANCH) {
+    if (opcode == OPC_BRANCH) {
         # B-type: +-4 KiB. the kept bits are rs2 / rs1 / funct3 / opcode.
         if (sdisp < B_DISP_MIN || sdisp > B_DISP_MAX) {
             ret R.err[bool, str]("encode: riscv64 branch displacement exceeds the +-4KiB range");
@@ -2233,7 +3112,7 @@ fun patch_branch_riscv64(st: *encode.EncodeState, fx: *encode.BranchFixup, targe
         write_word(?st.buf, pos, (word & 0x01FFF07F) | b_imm(disp));
         ret R.ok[bool, str](true);
     }
-    if (opcode == AUIPC) {
+    if (opcode == OPC_AUIPC) {
         # relaxed far trampoline: `auipc t0,%hi(disp) ; jalr x0,t0,%lo(disp)`, both
         # pc-relative from the auipc, so the displacement spans the 32-bit signed
         # range (the +0x800 rounding folds the signed low 12 back into the high 20).
@@ -2245,8 +3124,8 @@ fun patch_branch_riscv64(st: *encode.EncodeState, fx: *encode.BranchFixup, targe
         }
         val hi20: u32 = ((disp + 0x800) >> 12) & 0xFFFFF;
         val lo12: u32 = disp & 0xFFF;
-        write_word(?st.buf, pos, pack_u(AUIPC, SCRATCH, hi20));
-        write_word(?st.buf, pos + 4, pack_i(JALR, F3_ADD, RZERO, SCRATCH, lo12));
+        write_word(?st.buf, pos, pack_u(OPC_AUIPC, SCRATCH, hi20));
+        write_word(?st.buf, pos + 4, pack_i(OPC_JALR, F3_ADD, RZERO, SCRATCH, lo12));
         ret R.ok[bool, str](true);
     }
     ret R.err[bool, str]("encode: branch fixup site is not a B-type, J-type, or trampoline instruction");
@@ -2268,6 +3147,26 @@ pub fun encode_riscv64(alloc: *A.Allocator, tgt: *resolved.Target, m: *mir.MirMo
     hooks.encode_function = encode_function_riscv64;
     hooks.patch_branch    = patch_branch_riscv64;
     ret encode.encode_driver(alloc, tgt, m, ?hooks);
+}
+
+# encode a module and render its assembly text - the riscv64 `emit_asm` entry point
+#
+# The same encode as `encode_riscv64` with an `AsmSink` attached, so every line of
+# the `.s` is one machine instruction this run emitted. The sink never influences a
+# byte, so the object this path produces is identical to the one the plain path
+# does. Matches `encode.EmitAsmFn`.
+# ---
+# alloc: allocator backing the encoder output's owned arrays
+# tgt:   resolved target; must be RISC-V
+# m:     the fully-resolved MIR module (post isel / regalloc / frame)
+# out:   destination writer for the assembly text
+# ret:   the populated encode.EncoderOutput (owned arrays), or an error string
+pub fun encode_riscv64_asm(alloc: *A.Allocator, tgt: *resolved.Target, m: *mir.MirModule,
+                           out: *writer.Writer) R.Result[encode.EncoderOutput, str] {
+    var hooks: encode.EncodeHooks;
+    hooks.encode_function = encode_function_riscv64;
+    hooks.patch_branch    = patch_branch_riscv64;
+    ret encode.encode_driver_asm(alloc, tgt, m, ?hooks, out);
 }
 
 # true when `c` is inline-asm intra-line whitespace
@@ -2907,7 +3806,7 @@ fun rv_three_reg(st: *encode.EncodeState, args: str, opcode: u32, funct3: u32, f
     if (!rv_parse_operand((?b0[0])::str, ?rd) || rd.kind != RVOP_REG)   { ret R.err[bool, str]("encode: inline-asm destination must be a register"); }
     if (!rv_parse_operand((?b1[0])::str, ?rs1) || rs1.kind != RVOP_REG) { ret R.err[bool, str]("encode: inline-asm source must be a register"); }
     if (!rv_parse_operand((?b2[0])::str, ?rs2) || rs2.kind != RVOP_REG) { ret R.err[bool, str]("encode: inline-asm source must be a register"); }
-    emit_word(st, pack_r(opcode, funct3, funct7, rd.reg::u32, rs1.reg::u32, rs2.reg::u32));
+    emit_r(st, opcode, funct3, funct7, rd.reg::u32, rs1.reg::u32, rs2.reg::u32);
     ret R.ok[bool, str](true);
 }
 
@@ -2923,7 +3822,7 @@ fun rv_imm_alu(st: *encode.EncodeState, args: str, opcode: u32, funct3: u32) R.R
     if (!rv_parse_operand((?b1[0])::str, ?rs1) || rs1.kind != RVOP_REG) { ret R.err[bool, str]("encode: inline-asm source must be a register"); }
     if (!rv_parse_operand((?b2[0])::str, ?im) || im.kind != RVOP_IMM)   { ret R.err[bool, str]("encode: inline-asm operand must be an immediate"); }
     if (im.imm < -2048 || im.imm > 2047)                               { ret R.err[bool, str]("encode: inline-asm immediate is out of the 12-bit signed range"); }
-    emit_word(st, pack_i(opcode, funct3, rd.reg::u32, rs1.reg::u32, im.imm::u32 & 0xFFF));
+    emit_i(st, opcode, funct3, rd.reg::u32, rs1.reg::u32, im.imm::u32 & 0xFFF);
     ret R.ok[bool, str](true);
 }
 
@@ -2944,7 +3843,7 @@ fun rv_shift_imm(st: *encode.EncodeState, args: str, opcode: u32, funct3: u32, a
     if (sh.imm < 0 || sh.imm::u32 > mask) { ret R.err[bool, str]("encode: inline-asm shift amount is out of range"); }
     var imm: u32 = sh.imm::u32 & mask;
     if (arith) { imm = imm | 0x400; }
-    emit_word(st, pack_i(opcode, funct3, rd.reg::u32, rs1.reg::u32, imm));
+    emit_i(st, opcode, funct3, rd.reg::u32, rs1.reg::u32, imm);
     ret R.ok[bool, str](true);
 }
 
@@ -2960,7 +3859,7 @@ fun rv_load(st: *encode.EncodeState, args: str, funct3: u32) R.Result[bool, str]
     if (!rv_parse_operand((?b0[0])::str, ?rd) || rd.kind != RVOP_REG)    { ret R.err[bool, str]("encode: inline-asm load destination must be a register"); }
     if (!rv_parse_operand((?b1[0])::str, ?mem) || mem.kind != RVOP_MEM)  { ret R.err[bool, str]("encode: inline-asm load address must be off(base)"); }
     if (mem.imm < -2048 || mem.imm > 2047)                              { ret R.err[bool, str]("encode: inline-asm load offset is out of the 12-bit signed range"); }
-    emit_word(st, pack_i(LOAD, funct3, rd.reg::u32, mem.reg::u32, mem.imm::u32 & 0xFFF));
+    emit_i(st, OPC_LOAD, funct3, rd.reg::u32, mem.reg::u32, mem.imm::u32 & 0xFFF);
     ret R.ok[bool, str](true);
 }
 
@@ -2974,7 +3873,7 @@ fun rv_store(st: *encode.EncodeState, args: str, funct3: u32) R.Result[bool, str
     if (!rv_parse_operand((?b0[0])::str, ?rs) || rs.kind != RVOP_REG)    { ret R.err[bool, str]("encode: inline-asm store value must be a register"); }
     if (!rv_parse_operand((?b1[0])::str, ?mem) || mem.kind != RVOP_MEM)  { ret R.err[bool, str]("encode: inline-asm store address must be off(base)"); }
     if (mem.imm < -2048 || mem.imm > 2047)                             { ret R.err[bool, str]("encode: inline-asm store offset is out of the 12-bit signed range"); }
-    emit_word(st, pack_s(STORE, funct3, mem.reg::u32, rs.reg::u32, mem.imm::u32 & 0xFFF));
+    emit_s(st, OPC_STORE, funct3, mem.reg::u32, rs.reg::u32, mem.imm::u32 & 0xFFF);
     ret R.ok[bool, str](true);
 }
 
@@ -2988,7 +3887,7 @@ fun rv_uimm(st: *encode.EncodeState, args: str, opcode: u32) R.Result[bool, str]
     if (!rv_parse_operand((?b0[0])::str, ?rd) || rd.kind != RVOP_REG) { ret R.err[bool, str]("encode: inline-asm destination must be a register"); }
     if (!rv_parse_operand((?b1[0])::str, ?im) || im.kind != RVOP_IMM) { ret R.err[bool, str]("encode: inline-asm lui/auipc needs an immediate"); }
     if (im.imm < 0 || im.imm > 0xFFFFF)                              { ret R.err[bool, str]("encode: inline-asm lui/auipc immediate is out of the 20-bit range"); }
-    emit_word(st, pack_u(opcode, rd.reg::u32, im.imm::u32 & 0xFFFFF));
+    emit_u(st, opcode, rd.reg::u32, im.imm::u32 & 0xFFFFF);
     ret R.ok[bool, str](true);
 }
 
@@ -3021,7 +3920,8 @@ fun rv_la(st: *encode.EncodeState, args: str) R.Result[bool, str] {
     val hr: R.Result[bool, str] = emit_pcrel_hi(st, rd.reg::u32, symid, 0);
     if (R.is_err[bool, str](hr)) { ret hr; }
     val lo_pos: u32 = st.buf.len::u32;
-    emit_word(st, pack_i(OP_IMM, F3_ADD, rd.reg::u32, rd.reg::u32, 0));
+    emit_i(st, OPC_OP_IMM, F3_ADD, rd.reg::u32, rd.reg::u32, 0);
+    note_sym_target(st, symid, isa.SYM_MOD_PCREL_LO);
     ret encode.push_reloc(st, lo_pos, of.RK_PCREL_LO12_I, symid, 0);
 }
 
@@ -3038,18 +3938,42 @@ fun rv_call_sym(st: *encode.EncodeState, args: str, link: u32, ret_reg: u32) R.R
     if (R.is_err[intern.StrId, str](symr)) { ret R.err[bool, str](R.unwrap_err[intern.StrId, str](symr)); }
     val symid: intern.StrId = R.unwrap_ok[intern.StrId, str](symr);
     val pos: u32 = st.buf.len::u32;
-    emit_word(st, pack_u(AUIPC, link, 0));
-    emit_word(st, pack_i(JALR, F3_ADD, ret_reg, link, 0));
+    emit_u(st, OPC_AUIPC, link, 0);
+    note_sym_target(st, symid, isa.SYM_MOD_PCREL_HI);
+    emit_i(st, OPC_JALR, F3_ADD, ret_reg, link, 0);
+    note_sym_target(st, symid, isa.SYM_MOD_PCREL_LO);
     ret encode.push_reloc(st, pos, of.RK_PLT32, symid, 0);
 }
 
-# emit a branch / jump to a numeric local label. a backward reference patches
-# immediately against the nearest preceding definition; a forward reference is recorded
-# and patched when its definition is reached. the B-type / J-type displacement insert
-# is the shared `patch_branch_riscv64` (it dispatches on the placeholder word's opcode)
-fun rv_emit_branch_label(st: *encode.EncodeState, labels: *RvLabels, word: u32, number: u64, fwd: bool) R.Result[bool, str] {
-    val patch_pos: u32 = st.buf.len::u32;
-    emit_word(st, word);
+# resolve a branch / jump target token to a numeric local label
+#
+# A symbol target is rejected loud - a riscv conditional branch reaches only +-4 KiB
+# and there is no in-block relocation kind for it, so branch to a numeric local label
+# instead (the AArch64 conditional-branch path makes the same restriction)
+# ---
+# target_tok: the target token as written
+# number:     out - the local label's number
+# fwd:        out - true for a forward reference (`Nf`)
+# ret:        true when the token names a local label, or an error
+fun rv_local_target(target_tok: str, number: *u64, fwd: *bool) R.Result[bool, str] {
+    if (rv_label_ref(rv_trim(target_tok), number, fwd)) { ret R.ok[bool, str](true); }
+    ret R.err[bool, str]("encode: inline-asm branch/jump target must be a numeric local label (Nf / Nb)");
+}
+
+# resolve the displacement of a branch just emitted against a numeric local label
+#
+# A backward reference patches immediately against the nearest preceding definition;
+# a forward reference is recorded and patched when its definition is reached. The
+# B-type / J-type displacement insert is the shared `patch_branch_riscv64` (it
+# dispatches on the placeholder word's opcode)
+# ---
+# st:        encoder driver state
+# labels:    the asm block's local-label scope
+# patch_pos: the emitted branch's `.text` offset
+# number:    the local label's number
+# fwd:       true for a forward reference
+# ret:       ok(true), or an error naming the unresolved reference
+fun rv_resolve_local(st: *encode.EncodeState, labels: *RvLabels, patch_pos: u32, number: u64, fwd: bool) R.Result[bool, str] {
     if (fwd) { ret rv_label_push_ref(labels, patch_pos, number); }
     val def: O.Option[u32] = rv_label_lookup(labels, number);
     if (!O.is_some[u32](def)) {
@@ -3060,18 +3984,42 @@ fun rv_emit_branch_label(st: *encode.EncodeState, labels: *RvLabels, word: u32, 
     ret patch_branch_riscv64(st, ?fx, O.unwrap[u32](def));
 }
 
-# resolve a branch / jump target token to a numeric local label and emit `word`
-# against it. a symbol target is rejected loud - a riscv conditional branch reaches
-# only +-4 KiB and there is no in-block relocation kind for it, so branch to a numeric
-# local label instead (the AArch64 conditional-branch path makes the same restriction)
-fun rv_emit_branch_target(st: *encode.EncodeState, labels: *RvLabels, word: u32, target_tok: str) R.Result[bool, str] {
-    val target: str = rv_trim(target_tok);
+# emit a B-type conditional branch to a numeric local label
+# ---
+# st:         encoder driver state
+# labels:     the asm block's local-label scope
+# funct3:     the relation field
+# rs1:        the first compared register
+# rs2:        the second compared register
+# target_tok: the target token as written
+# ret:        ok(true), or an error
+fun rv_branch_local(st: *encode.EncodeState, labels: *RvLabels, funct3: u32, rs1: u32, rs2: u32, target_tok: str) R.Result[bool, str] {
     var number: u64 = 0;
-    var fwd: bool = false;
-    if (rv_label_ref(target, ?number, ?fwd)) {
-        ret rv_emit_branch_label(st, labels, word, number, fwd);
-    }
-    ret R.err[bool, str]("encode: inline-asm branch/jump target must be a numeric local label (Nf / Nb)");
+    var fwd:    bool = false;
+    val tr: R.Result[bool, str] = rv_local_target(target_tok, ?number, ?fwd);
+    if (R.is_err[bool, str](tr)) { ret tr; }
+    val patch_pos: u32 = st.buf.len::u32;
+    emit_b(st, OPC_BRANCH, funct3, rs1, rs2, 0);
+    note_local_target(st, number, fwd);
+    ret rv_resolve_local(st, labels, patch_pos, number, fwd);
+}
+
+# emit a J-type jump to a numeric local label
+# ---
+# st:         encoder driver state
+# labels:     the asm block's local-label scope
+# rd:         the link register field
+# target_tok: the target token as written
+# ret:        ok(true), or an error
+fun rv_jump_local(st: *encode.EncodeState, labels: *RvLabels, rd: u32, target_tok: str) R.Result[bool, str] {
+    var number: u64 = 0;
+    var fwd:    bool = false;
+    val tr: R.Result[bool, str] = rv_local_target(target_tok, ?number, ?fwd);
+    if (R.is_err[bool, str](tr)) { ret tr; }
+    val patch_pos: u32 = st.buf.len::u32;
+    emit_j(st, OPC_JAL, rd, 0);
+    note_local_target(st, number, fwd);
+    ret rv_resolve_local(st, labels, patch_pos, number, fwd);
 }
 
 # a two-register conditional branch `rs1, rs2, label`. `swap` exchanges the operands
@@ -3087,7 +4035,7 @@ fun rv_branch2(st: *encode.EncodeState, labels: *RvLabels, args: str, funct3: u3
     var rs1: u32 = ra_.reg::u32;
     var rs2: u32 = rb.reg::u32;
     if (swap) { val t: u32 = rs1; rs1 = rs2; rs2 = t; }
-    ret rv_emit_branch_target(st, labels, pack_b(BRANCH, funct3, rs1, rs2, 0), (?b2[0])::str);
+    ret rv_branch_local(st, labels, funct3, rs1, rs2, (?b2[0])::str);
 }
 
 # a compare-against-zero pseudo branch `rs, label`. `reg_is_rs1` puts the register in
@@ -3102,7 +4050,7 @@ fun rv_branchz(st: *encode.EncodeState, labels: *RvLabels, args: str, funct3: u3
     var rs1: u32 = RZERO;
     var rs2: u32 = RZERO;
     if (reg_is_rs1) { rs1 = rs.reg::u32; } or { rs2 = rs.reg::u32; }
-    ret rv_emit_branch_target(st, labels, pack_b(BRANCH, funct3, rs1, rs2, 0), (?b1[0])::str);
+    ret rv_branch_local(st, labels, funct3, rs1, rs2, (?b1[0])::str);
 }
 
 # `j label` / `jal label` / `jal rd, label` - a J-type jump to a numeric local label,
@@ -3112,12 +4060,12 @@ fun rv_jump(st: *encode.EncodeState, labels: *RvLabels, args: str, default_rd: u
     var n: u32 = 0;
     if (!rv_split(args, ?b0[0], ?b1[0], ?b2[0], ?b3[0], 64, ?n)) { ret R.err[bool, str]("encode: malformed inline-asm jump operands"); }
     if (n == 1) {
-        ret rv_emit_branch_target(st, labels, pack_j(JAL, default_rd, 0), (?b0[0])::str);
+        ret rv_jump_local(st, labels, default_rd, (?b0[0])::str);
     }
     if (n == 2) {
         var rd: RvAsmOp;
         if (!rv_parse_operand((?b0[0])::str, ?rd) || rd.kind != RVOP_REG) { ret R.err[bool, str]("encode: inline-asm 'jal' destination must be a register"); }
-        ret rv_emit_branch_target(st, labels, pack_j(JAL, rd.reg::u32, 0), (?b1[0])::str);
+        ret rv_jump_local(st, labels, rd.reg::u32, (?b1[0])::str);
     }
     ret R.err[bool, str]("encode: inline-asm jump expects label or rd, label");
 }
@@ -3130,7 +4078,7 @@ fun rv_jalr(st: *encode.EncodeState, args: str, default_rd: u32) R.Result[bool, 
     if (n == 1) {
         var rs: RvAsmOp;
         if (!rv_parse_operand((?b0[0])::str, ?rs) || rs.kind != RVOP_REG) { ret R.err[bool, str]("encode: inline-asm jr/jalr operand must be a register"); }
-        emit_word(st, pack_i(JALR, F3_ADD, default_rd, rs.reg::u32, 0));
+        emit_i(st, OPC_JALR, F3_ADD, default_rd, rs.reg::u32, 0);
         ret R.ok[bool, str](true);
     }
     if (n == 3) {
@@ -3139,7 +4087,7 @@ fun rv_jalr(st: *encode.EncodeState, args: str, default_rd: u32) R.Result[bool, 
         if (!rv_parse_operand((?b1[0])::str, ?rs) || rs.kind != RVOP_REG)  { ret R.err[bool, str]("encode: inline-asm jalr base must be a register"); }
         if (!rv_parse_operand((?b2[0])::str, ?im) || im.kind != RVOP_IMM)  { ret R.err[bool, str]("encode: inline-asm jalr needs an immediate"); }
         if (im.imm < -2048 || im.imm > 2047)                             { ret R.err[bool, str]("encode: inline-asm jalr offset is out of the 12-bit signed range"); }
-        emit_word(st, pack_i(JALR, F3_ADD, rd.reg::u32, rs.reg::u32, im.imm::u32 & 0xFFF));
+        emit_i(st, OPC_JALR, F3_ADD, rd.reg::u32, rs.reg::u32, im.imm::u32 & 0xFFF);
         ret R.ok[bool, str](true);
     }
     ret R.err[bool, str]("encode: inline-asm jalr expects rs or rd, rs, imm");
@@ -3175,7 +4123,7 @@ fun rv_amo_base(mnem: str, len: usize, funct5_out: *u32, is_lr_out: *bool) bool 
     ret false;
 }
 
-# encode one RV64A atomic statement (the AMO major opcode, R-type with the aq / rl
+# encode one RV64A atomic statement (the OPC_AMO major opcode, R-type with the aq / rl
 # ordering bits folded into funct7). `lr` is `rd, (rs1)` with rs2 forced to x0; `sc` and
 # the `amo*` read-modify-writes are `rd, rs2, (rs1)`. the address is the base-only
 # `(rs1)` form atomics require - a displacement is rejected, unlike a regular load /
@@ -3209,7 +4157,7 @@ fun rv_amo(st: *encode.EncodeState, mnem: str, args: str, matched: *bool) R.Resu
         if (!rv_parse_operand((?b0[0])::str, ?rd) || rd.kind != RVOP_REG)   { ret R.err[bool, str]("encode: inline-asm 'lr' destination must be a register"); }
         if (!rv_parse_operand((?b1[0])::str, ?mem) || mem.kind != RVOP_MEM) { ret R.err[bool, str]("encode: inline-asm 'lr' address must be (rs1)"); }
         if (mem.imm != 0)                                                   { ret R.err[bool, str]("encode: inline-asm atomic address takes no displacement"); }
-        emit_word(st, pack_r(AMO, funct3, funct7, rd.reg::u32, mem.reg::u32, RZERO));
+        emit_r(st, OPC_AMO, funct3, funct7, rd.reg::u32, mem.reg::u32, RZERO);
         ret R.ok[bool, str](true);
     }
 
@@ -3219,7 +4167,7 @@ fun rv_amo(st: *encode.EncodeState, mnem: str, args: str, matched: *bool) R.Resu
     if (!rv_parse_operand((?b1[0])::str, ?rs2) || rs2.kind != RVOP_REG) { ret R.err[bool, str]("encode: inline-asm atomic source must be a register"); }
     if (!rv_parse_operand((?b2[0])::str, ?mem) || mem.kind != RVOP_MEM) { ret R.err[bool, str]("encode: inline-asm atomic address must be (rs1)"); }
     if (mem.imm != 0)                                                   { ret R.err[bool, str]("encode: inline-asm atomic address takes no displacement"); }
-    emit_word(st, pack_r(AMO, funct3, funct7, rd.reg::u32, mem.reg::u32, rs2.reg::u32));
+    emit_r(st, OPC_AMO, funct3, funct7, rd.reg::u32, mem.reg::u32, rs2.reg::u32);
     ret R.ok[bool, str](true);
 }
 
@@ -3244,59 +4192,59 @@ fun encode_asm_stmt_riscv64(st: *encode.EncodeState, f: *mir.MirFunction, fn_bas
     val mnem: str = (?mbuf[0])::str;
 
     # zero-operand forms.
-    if (str_equals(mnem, "ecall"))  { emit_word(st, pack_i(SYSTEM, F3_ADD, RZERO, RZERO, 0)); ret R.ok[bool, str](true); }
-    if (str_equals(mnem, "ebreak")) { emit_word(st, pack_i(SYSTEM, F3_ADD, RZERO, RZERO, 1)); ret R.ok[bool, str](true); }
-    if (str_equals(mnem, "nop"))    { emit_word(st, pack_i(OP_IMM, F3_ADD, RZERO, RZERO, 0)); ret R.ok[bool, str](true); }
-    if (str_equals(mnem, "ret"))    { emit_word(st, pack_i(JALR, F3_ADD, RZERO, RRA, 0)); ret R.ok[bool, str](true); }
-    if (str_equals(mnem, "fence"))  { emit_word(st, pack_i(MISC_MEM, F3_ADD, RZERO, RZERO, 0xFF)); ret R.ok[bool, str](true); }
-    if (str_equals(mnem, "pause"))  { emit_word(st, pack_i(MISC_MEM, F3_ADD, RZERO, RZERO, 0x010)); ret R.ok[bool, str](true); }
+    if (str_equals(mnem, "ecall"))  { emit_i(st, OPC_SYSTEM, F3_ADD, RZERO, RZERO, 0); ret R.ok[bool, str](true); }
+    if (str_equals(mnem, "ebreak")) { emit_i(st, OPC_SYSTEM, F3_ADD, RZERO, RZERO, 1); ret R.ok[bool, str](true); }
+    if (str_equals(mnem, "nop"))    { emit_i(st, OPC_OP_IMM, F3_ADD, RZERO, RZERO, 0); ret R.ok[bool, str](true); }
+    if (str_equals(mnem, "ret"))    { emit_i(st, OPC_JALR, F3_ADD, RZERO, RRA, 0); ret R.ok[bool, str](true); }
+    if (str_equals(mnem, "fence"))  { emit_i(st, OPC_MISC_MEM, F3_ADD, RZERO, RZERO, 0xFF); ret R.ok[bool, str](true); }
+    if (str_equals(mnem, "pause"))  { emit_i(st, OPC_MISC_MEM, F3_ADD, RZERO, RZERO, 0x010); ret R.ok[bool, str](true); }
 
     # register-register ALU (R-type).
-    if (str_equals(mnem, "add"))    { ret rv_three_reg(st, args, OP, F3_ADD, F7_ZERO); }
-    if (str_equals(mnem, "sub"))    { ret rv_three_reg(st, args, OP, F3_ADD, F7_SUB); }
-    if (str_equals(mnem, "and"))    { ret rv_three_reg(st, args, OP, F3_AND, F7_ZERO); }
-    if (str_equals(mnem, "or"))     { ret rv_three_reg(st, args, OP, F3_OR, F7_ZERO); }
-    if (str_equals(mnem, "xor"))    { ret rv_three_reg(st, args, OP, F3_XOR, F7_ZERO); }
-    if (str_equals(mnem, "sll"))    { ret rv_three_reg(st, args, OP, F3_SLL, F7_ZERO); }
-    if (str_equals(mnem, "srl"))    { ret rv_three_reg(st, args, OP, F3_SRL, F7_ZERO); }
-    if (str_equals(mnem, "sra"))    { ret rv_three_reg(st, args, OP, F3_SRL, F7_SUB); }
-    if (str_equals(mnem, "slt"))    { ret rv_three_reg(st, args, OP, F3_SLT, F7_ZERO); }
-    if (str_equals(mnem, "sltu"))   { ret rv_three_reg(st, args, OP, F3_SLTU, F7_ZERO); }
-    if (str_equals(mnem, "mul"))    { ret rv_three_reg(st, args, OP, F3_ADD, F7_MULDIV); }
-    if (str_equals(mnem, "mulh"))   { ret rv_three_reg(st, args, OP, F3_SLL, F7_MULDIV); }
-    if (str_equals(mnem, "mulhsu")) { ret rv_three_reg(st, args, OP, F3_SLT, F7_MULDIV); }
-    if (str_equals(mnem, "mulhu"))  { ret rv_three_reg(st, args, OP, F3_SLTU, F7_MULDIV); }
-    if (str_equals(mnem, "div"))    { ret rv_three_reg(st, args, OP, F3_DIV, F7_MULDIV); }
-    if (str_equals(mnem, "divu"))   { ret rv_three_reg(st, args, OP, F3_DIVU, F7_MULDIV); }
-    if (str_equals(mnem, "rem"))    { ret rv_three_reg(st, args, OP, F3_REM, F7_MULDIV); }
-    if (str_equals(mnem, "remu"))   { ret rv_three_reg(st, args, OP, F3_REMU, F7_MULDIV); }
-    if (str_equals(mnem, "addw"))   { ret rv_three_reg(st, args, OP_32, F3_ADD, F7_ZERO); }
-    if (str_equals(mnem, "subw"))   { ret rv_three_reg(st, args, OP_32, F3_ADD, F7_SUB); }
-    if (str_equals(mnem, "sllw"))   { ret rv_three_reg(st, args, OP_32, F3_SLL, F7_ZERO); }
-    if (str_equals(mnem, "srlw"))   { ret rv_three_reg(st, args, OP_32, F3_SRL, F7_ZERO); }
-    if (str_equals(mnem, "sraw"))   { ret rv_three_reg(st, args, OP_32, F3_SRL, F7_SUB); }
-    if (str_equals(mnem, "mulw"))   { ret rv_three_reg(st, args, OP_32, F3_ADD, F7_MULDIV); }
-    if (str_equals(mnem, "divw"))   { ret rv_three_reg(st, args, OP_32, F3_DIV, F7_MULDIV); }
-    if (str_equals(mnem, "divuw"))  { ret rv_three_reg(st, args, OP_32, F3_DIVU, F7_MULDIV); }
-    if (str_equals(mnem, "remw"))   { ret rv_three_reg(st, args, OP_32, F3_REM, F7_MULDIV); }
-    if (str_equals(mnem, "remuw"))  { ret rv_three_reg(st, args, OP_32, F3_REMU, F7_MULDIV); }
+    if (str_equals(mnem, "add"))    { ret rv_three_reg(st, args, OPC_OP, F3_ADD, F7_ZERO); }
+    if (str_equals(mnem, "sub"))    { ret rv_three_reg(st, args, OPC_OP, F3_ADD, F7_SUB); }
+    if (str_equals(mnem, "and"))    { ret rv_three_reg(st, args, OPC_OP, F3_AND, F7_ZERO); }
+    if (str_equals(mnem, "or"))     { ret rv_three_reg(st, args, OPC_OP, F3_OR, F7_ZERO); }
+    if (str_equals(mnem, "xor"))    { ret rv_three_reg(st, args, OPC_OP, F3_XOR, F7_ZERO); }
+    if (str_equals(mnem, "sll"))    { ret rv_three_reg(st, args, OPC_OP, F3_SLL, F7_ZERO); }
+    if (str_equals(mnem, "srl"))    { ret rv_three_reg(st, args, OPC_OP, F3_SRL, F7_ZERO); }
+    if (str_equals(mnem, "sra"))    { ret rv_three_reg(st, args, OPC_OP, F3_SRL, F7_SUB); }
+    if (str_equals(mnem, "slt"))    { ret rv_three_reg(st, args, OPC_OP, F3_SLT, F7_ZERO); }
+    if (str_equals(mnem, "sltu"))   { ret rv_three_reg(st, args, OPC_OP, F3_SLTU, F7_ZERO); }
+    if (str_equals(mnem, "mul"))    { ret rv_three_reg(st, args, OPC_OP, F3_ADD, F7_MULDIV); }
+    if (str_equals(mnem, "mulh"))   { ret rv_three_reg(st, args, OPC_OP, F3_SLL, F7_MULDIV); }
+    if (str_equals(mnem, "mulhsu")) { ret rv_three_reg(st, args, OPC_OP, F3_SLT, F7_MULDIV); }
+    if (str_equals(mnem, "mulhu"))  { ret rv_three_reg(st, args, OPC_OP, F3_SLTU, F7_MULDIV); }
+    if (str_equals(mnem, "div"))    { ret rv_three_reg(st, args, OPC_OP, F3_DIV, F7_MULDIV); }
+    if (str_equals(mnem, "divu"))   { ret rv_three_reg(st, args, OPC_OP, F3_DIVU, F7_MULDIV); }
+    if (str_equals(mnem, "rem"))    { ret rv_three_reg(st, args, OPC_OP, F3_REM, F7_MULDIV); }
+    if (str_equals(mnem, "remu"))   { ret rv_three_reg(st, args, OPC_OP, F3_REMU, F7_MULDIV); }
+    if (str_equals(mnem, "addw"))   { ret rv_three_reg(st, args, OPC_OP_32, F3_ADD, F7_ZERO); }
+    if (str_equals(mnem, "subw"))   { ret rv_three_reg(st, args, OPC_OP_32, F3_ADD, F7_SUB); }
+    if (str_equals(mnem, "sllw"))   { ret rv_three_reg(st, args, OPC_OP_32, F3_SLL, F7_ZERO); }
+    if (str_equals(mnem, "srlw"))   { ret rv_three_reg(st, args, OPC_OP_32, F3_SRL, F7_ZERO); }
+    if (str_equals(mnem, "sraw"))   { ret rv_three_reg(st, args, OPC_OP_32, F3_SRL, F7_SUB); }
+    if (str_equals(mnem, "mulw"))   { ret rv_three_reg(st, args, OPC_OP_32, F3_ADD, F7_MULDIV); }
+    if (str_equals(mnem, "divw"))   { ret rv_three_reg(st, args, OPC_OP_32, F3_DIV, F7_MULDIV); }
+    if (str_equals(mnem, "divuw"))  { ret rv_three_reg(st, args, OPC_OP_32, F3_DIVU, F7_MULDIV); }
+    if (str_equals(mnem, "remw"))   { ret rv_three_reg(st, args, OPC_OP_32, F3_REM, F7_MULDIV); }
+    if (str_equals(mnem, "remuw"))  { ret rv_three_reg(st, args, OPC_OP_32, F3_REMU, F7_MULDIV); }
 
     # register-immediate ALU (I-type).
-    if (str_equals(mnem, "addi"))  { ret rv_imm_alu(st, args, OP_IMM, F3_ADD); }
-    if (str_equals(mnem, "andi"))  { ret rv_imm_alu(st, args, OP_IMM, F3_AND); }
-    if (str_equals(mnem, "ori"))   { ret rv_imm_alu(st, args, OP_IMM, F3_OR); }
-    if (str_equals(mnem, "xori"))  { ret rv_imm_alu(st, args, OP_IMM, F3_XOR); }
-    if (str_equals(mnem, "slti"))  { ret rv_imm_alu(st, args, OP_IMM, F3_SLT); }
-    if (str_equals(mnem, "sltiu")) { ret rv_imm_alu(st, args, OP_IMM, F3_SLTU); }
-    if (str_equals(mnem, "addiw")) { ret rv_imm_alu(st, args, OP_IMM_32, F3_ADD); }
+    if (str_equals(mnem, "addi"))  { ret rv_imm_alu(st, args, OPC_OP_IMM, F3_ADD); }
+    if (str_equals(mnem, "andi"))  { ret rv_imm_alu(st, args, OPC_OP_IMM, F3_AND); }
+    if (str_equals(mnem, "ori"))   { ret rv_imm_alu(st, args, OPC_OP_IMM, F3_OR); }
+    if (str_equals(mnem, "xori"))  { ret rv_imm_alu(st, args, OPC_OP_IMM, F3_XOR); }
+    if (str_equals(mnem, "slti"))  { ret rv_imm_alu(st, args, OPC_OP_IMM, F3_SLT); }
+    if (str_equals(mnem, "sltiu")) { ret rv_imm_alu(st, args, OPC_OP_IMM, F3_SLTU); }
+    if (str_equals(mnem, "addiw")) { ret rv_imm_alu(st, args, OPC_OP_IMM_32, F3_ADD); }
 
     # immediate shifts (I-type, shamt).
-    if (str_equals(mnem, "slli"))  { ret rv_shift_imm(st, args, OP_IMM, F3_SLL, false, false); }
-    if (str_equals(mnem, "srli"))  { ret rv_shift_imm(st, args, OP_IMM, F3_SRL, false, false); }
-    if (str_equals(mnem, "srai"))  { ret rv_shift_imm(st, args, OP_IMM, F3_SRL, true, false); }
-    if (str_equals(mnem, "slliw")) { ret rv_shift_imm(st, args, OP_IMM_32, F3_SLL, false, true); }
-    if (str_equals(mnem, "srliw")) { ret rv_shift_imm(st, args, OP_IMM_32, F3_SRL, false, true); }
-    if (str_equals(mnem, "sraiw")) { ret rv_shift_imm(st, args, OP_IMM_32, F3_SRL, true, true); }
+    if (str_equals(mnem, "slli"))  { ret rv_shift_imm(st, args, OPC_OP_IMM, F3_SLL, false, false); }
+    if (str_equals(mnem, "srli"))  { ret rv_shift_imm(st, args, OPC_OP_IMM, F3_SRL, false, false); }
+    if (str_equals(mnem, "srai"))  { ret rv_shift_imm(st, args, OPC_OP_IMM, F3_SRL, true, false); }
+    if (str_equals(mnem, "slliw")) { ret rv_shift_imm(st, args, OPC_OP_IMM_32, F3_SLL, false, true); }
+    if (str_equals(mnem, "srliw")) { ret rv_shift_imm(st, args, OPC_OP_IMM_32, F3_SRL, false, true); }
+    if (str_equals(mnem, "sraiw")) { ret rv_shift_imm(st, args, OPC_OP_IMM_32, F3_SRL, true, true); }
 
     # loads (I-type) - the explicit signed / zero funct3 the mnemonic names.
     if (str_equals(mnem, "lb"))  { ret rv_load(st, args, 0x0); }
@@ -3314,8 +4262,8 @@ fun encode_asm_stmt_riscv64(st: *encode.EncodeState, f: *mir.MirFunction, fn_bas
     if (str_equals(mnem, "sd")) { ret rv_store(st, args, 0x3); }
 
     # upper-immediate (U-type).
-    if (str_equals(mnem, "lui"))   { ret rv_uimm(st, args, LUI); }
-    if (str_equals(mnem, "auipc")) { ret rv_uimm(st, args, AUIPC); }
+    if (str_equals(mnem, "lui"))   { ret rv_uimm(st, args, OPC_LUI); }
+    if (str_equals(mnem, "auipc")) { ret rv_uimm(st, args, OPC_AUIPC); }
 
     # conditional branches (B-type) to a numeric local label.
     if (str_equals(mnem, "beq"))  { ret rv_branch2(st, labels, args, F3_BEQ, false); }
@@ -3351,43 +4299,43 @@ fun encode_asm_stmt_riscv64(st: *encode.EncodeState, f: *mir.MirFunction, fn_bas
     if (str_equals(mnem, "mv")) {
         var rd: u32 = 0; var rs: u32 = 0;
         if (!rv_two_reg_args(args, ?rd, ?rs)) { ret R.err[bool, str]("encode: inline-asm 'mv' expects rd, rs"); }
-        emit_word(st, pack_i(OP_IMM, F3_ADD, rd, rs, 0));
+        emit_i(st, OPC_OP_IMM, F3_ADD, rd, rs, 0);
         ret R.ok[bool, str](true);
     }
     if (str_equals(mnem, "neg")) {
         var rd: u32 = 0; var rs: u32 = 0;
         if (!rv_two_reg_args(args, ?rd, ?rs)) { ret R.err[bool, str]("encode: inline-asm 'neg' expects rd, rs"); }
-        emit_word(st, pack_r(OP, F3_ADD, F7_SUB, rd, RZERO, rs));
+        emit_r(st, OPC_OP, F3_ADD, F7_SUB, rd, RZERO, rs);
         ret R.ok[bool, str](true);
     }
     if (str_equals(mnem, "negw")) {
         var rd: u32 = 0; var rs: u32 = 0;
         if (!rv_two_reg_args(args, ?rd, ?rs)) { ret R.err[bool, str]("encode: inline-asm 'negw' expects rd, rs"); }
-        emit_word(st, pack_r(OP_32, F3_ADD, F7_SUB, rd, RZERO, rs));
+        emit_r(st, OPC_OP_32, F3_ADD, F7_SUB, rd, RZERO, rs);
         ret R.ok[bool, str](true);
     }
     if (str_equals(mnem, "not")) {
         var rd: u32 = 0; var rs: u32 = 0;
         if (!rv_two_reg_args(args, ?rd, ?rs)) { ret R.err[bool, str]("encode: inline-asm 'not' expects rd, rs"); }
-        emit_word(st, pack_i(OP_IMM, F3_XOR, rd, rs, 0xFFF));
+        emit_i(st, OPC_OP_IMM, F3_XOR, rd, rs, 0xFFF);
         ret R.ok[bool, str](true);
     }
     if (str_equals(mnem, "seqz")) {
         var rd: u32 = 0; var rs: u32 = 0;
         if (!rv_two_reg_args(args, ?rd, ?rs)) { ret R.err[bool, str]("encode: inline-asm 'seqz' expects rd, rs"); }
-        emit_word(st, pack_i(OP_IMM, F3_SLTU, rd, rs, 1));
+        emit_i(st, OPC_OP_IMM, F3_SLTU, rd, rs, 1);
         ret R.ok[bool, str](true);
     }
     if (str_equals(mnem, "snez")) {
         var rd: u32 = 0; var rs: u32 = 0;
         if (!rv_two_reg_args(args, ?rd, ?rs)) { ret R.err[bool, str]("encode: inline-asm 'snez' expects rd, rs"); }
-        emit_word(st, pack_r(OP, F3_SLTU, F7_ZERO, rd, RZERO, rs));
+        emit_r(st, OPC_OP, F3_SLTU, F7_ZERO, rd, RZERO, rs);
         ret R.ok[bool, str](true);
     }
     if (str_equals(mnem, "sext.w")) {
         var rd: u32 = 0; var rs: u32 = 0;
         if (!rv_two_reg_args(args, ?rd, ?rs)) { ret R.err[bool, str]("encode: inline-asm 'sext.w' expects rd, rs"); }
-        emit_word(st, pack_i(OP_IMM_32, F3_ADD, rd, rs, 0));
+        emit_i(st, OPC_OP_IMM_32, F3_ADD, rd, rs, 0);
         ret R.ok[bool, str](true);
     }
 
@@ -3582,37 +4530,37 @@ fun tbuf(st: *encode.EncodeState, alloc: *A.Allocator) {
 test "mach.lang.target.isa.riscv64.encode:rtype_itype_stype_utype_packers" {
     var bad: i32 = 0;
     # add a0, a1, a2 = 0x00c58533 ; sub = 0x40c58533 ; addw = 0x00c5853b ; subw = 0x40c5853b
-    if (pack_r(OP, F3_ADD, F7_ZERO, 10, 11, 12)  != 0x00C58533) { bad = 1; }
-    if (pack_r(OP, F3_ADD, F7_SUB, 10, 11, 12)   != 0x40C58533) { bad = 1; }
-    if (pack_r(OP_32, F3_ADD, F7_ZERO, 10, 11, 12) != 0x00C5853B) { bad = 1; }
-    if (pack_r(OP_32, F3_ADD, F7_SUB, 10, 11, 12)  != 0x40C5853B) { bad = 1; }
+    if (pack_r(OPC_OP, F3_ADD, F7_ZERO, 10, 11, 12)  != 0x00C58533) { bad = 1; }
+    if (pack_r(OPC_OP, F3_ADD, F7_SUB, 10, 11, 12)   != 0x40C58533) { bad = 1; }
+    if (pack_r(OPC_OP_32, F3_ADD, F7_ZERO, 10, 11, 12) != 0x00C5853B) { bad = 1; }
+    if (pack_r(OPC_OP_32, F3_ADD, F7_SUB, 10, 11, 12)  != 0x40C5853B) { bad = 1; }
     # and/or/xor a0,a1,a2 = 0x00c5f533 / 0x00c5e533 / 0x00c5c533
-    if (pack_r(OP, F3_AND, F7_ZERO, 10, 11, 12) != 0x00C5F533) { bad = 1; }
-    if (pack_r(OP, F3_OR, F7_ZERO, 10, 11, 12)  != 0x00C5E533) { bad = 1; }
-    if (pack_r(OP, F3_XOR, F7_ZERO, 10, 11, 12) != 0x00C5C533) { bad = 1; }
+    if (pack_r(OPC_OP, F3_AND, F7_ZERO, 10, 11, 12) != 0x00C5F533) { bad = 1; }
+    if (pack_r(OPC_OP, F3_OR, F7_ZERO, 10, 11, 12)  != 0x00C5E533) { bad = 1; }
+    if (pack_r(OPC_OP, F3_XOR, F7_ZERO, 10, 11, 12) != 0x00C5C533) { bad = 1; }
     # mul a0,a1,a2 = 0x02c58533 ; sll = 0x00c59533 ; srl = 0x00c5d533 ; sra = 0x40c5d533
-    if (pack_r(OP, F3_ADD, F7_MULDIV, 10, 11, 12) != 0x02C58533) { bad = 1; }
-    if (pack_r(OP, F3_SLL, F7_ZERO, 10, 11, 12)   != 0x00C59533) { bad = 1; }
-    if (pack_r(OP, F3_SRL, F7_ZERO, 10, 11, 12)   != 0x00C5D533) { bad = 1; }
-    if (pack_r(OP, F3_SRL, F7_SUB, 10, 11, 12)    != 0x40C5D533) { bad = 1; }
+    if (pack_r(OPC_OP, F3_ADD, F7_MULDIV, 10, 11, 12) != 0x02C58533) { bad = 1; }
+    if (pack_r(OPC_OP, F3_SLL, F7_ZERO, 10, 11, 12)   != 0x00C59533) { bad = 1; }
+    if (pack_r(OPC_OP, F3_SRL, F7_ZERO, 10, 11, 12)   != 0x00C5D533) { bad = 1; }
+    if (pack_r(OPC_OP, F3_SRL, F7_SUB, 10, 11, 12)    != 0x40C5D533) { bad = 1; }
     # addi a0,a1,5 = 0x00558513 ; andi a0,a1,5 = 0x0055f513 ; addiw = 0x0055851b
-    if (pack_i(OP_IMM, F3_ADD, 10, 11, 5) != 0x00558513) { bad = 1; }
-    if (pack_i(OP_IMM, F3_AND, 10, 11, 5) != 0x0055F513) { bad = 1; }
-    if (pack_i(OP_IMM_32, F3_ADD, 10, 11, 5) != 0x0055851B) { bad = 1; }
+    if (pack_i(OPC_OP_IMM, F3_ADD, 10, 11, 5) != 0x00558513) { bad = 1; }
+    if (pack_i(OPC_OP_IMM, F3_AND, 10, 11, 5) != 0x0055F513) { bad = 1; }
+    if (pack_i(OPC_OP_IMM_32, F3_ADD, 10, 11, 5) != 0x0055851B) { bad = 1; }
     # ld a0,16(a1) = 0x0105b503 ; lw a0,16(a1) = 0x0105a503 ; lbu a0,16(a1) = 0x0105c503
-    if (pack_i(LOAD, F3_SLTU, 10, 11, 16) != 0x0105B503) { bad = 1; }
-    if (pack_i(LOAD, F3_SLT, 10, 11, 16)  != 0x0105A503) { bad = 1; }
-    if (pack_i(LOAD, F3_XOR, 10, 11, 16)  != 0x0105C503) { bad = 1; }
+    if (pack_i(OPC_LOAD, F3_SLTU, 10, 11, 16) != 0x0105B503) { bad = 1; }
+    if (pack_i(OPC_LOAD, F3_SLT, 10, 11, 16)  != 0x0105A503) { bad = 1; }
+    if (pack_i(OPC_LOAD, F3_XOR, 10, 11, 16)  != 0x0105C503) { bad = 1; }
     # jalr ra,a0,0 = 0x000500e7 ; ret = jalr x0,ra,0 = 0x00008067
-    if (pack_i(JALR, F3_ADD, 1, 10, 0) != 0x000500E7) { bad = 1; }
-    if (pack_i(JALR, F3_ADD, 0, 1, 0)  != 0x00008067) { bad = 1; }
+    if (pack_i(OPC_JALR, F3_ADD, 1, 10, 0) != 0x000500E7) { bad = 1; }
+    if (pack_i(OPC_JALR, F3_ADD, 0, 1, 0)  != 0x00008067) { bad = 1; }
     # sd a0,16(a1) = 0x00a5b823 ; sw a0,16(a1) = 0x00a5a823 ; sb a0,16(a1) = 0x00a58823
-    if (pack_s(STORE, F3_SLTU, 11, 10, 16) != 0x00A5B823) { bad = 1; }
-    if (pack_s(STORE, F3_SLT, 11, 10, 16)  != 0x00A5A823) { bad = 1; }
-    if (pack_s(STORE, F3_ADD, 11, 10, 16)  != 0x00A58823) { bad = 1; }
+    if (pack_s(OPC_STORE, F3_SLTU, 11, 10, 16) != 0x00A5B823) { bad = 1; }
+    if (pack_s(OPC_STORE, F3_SLT, 11, 10, 16)  != 0x00A5A823) { bad = 1; }
+    if (pack_s(OPC_STORE, F3_ADD, 11, 10, 16)  != 0x00A58823) { bad = 1; }
     # lui a0,0x12345 = 0x12345537 ; auipc a0,0 = 0x00000517
-    if (pack_u(LUI, 10, 0x12345) != 0x12345537) { bad = 1; }
-    if (pack_u(AUIPC, 10, 0)     != 0x00000517) { bad = 1; }
+    if (pack_u(OPC_LUI, 10, 0x12345) != 0x12345537) { bad = 1; }
+    if (pack_u(OPC_AUIPC, 10, 0)     != 0x00000517) { bad = 1; }
     ret bad;
 }
 
@@ -3620,18 +4568,18 @@ test "mach.lang.target.isa.riscv64.encode:rtype_itype_stype_utype_packers" {
 test "mach.lang.target.isa.riscv64.encode:btype_jtype_immediate_scatter" {
     var bad: i32 = 0;
     # beq a0,a1,0 = 0x00b50063 ; beq a0,a1,16 = 0x00b50863 ; bne a0,a1,16 = 0x00b51863
-    if (pack_b(BRANCH, F3_BEQ, 10, 11, 0)  != 0x00B50063) { bad = 1; }
-    if (pack_b(BRANCH, F3_BEQ, 10, 11, 16) != 0x00B50863) { bad = 1; }
-    if (pack_b(BRANCH, F3_BNE, 10, 11, 16) != 0x00B51863) { bad = 1; }
+    if (pack_b(OPC_BRANCH, F3_BEQ, 10, 11, 0)  != 0x00B50063) { bad = 1; }
+    if (pack_b(OPC_BRANCH, F3_BEQ, 10, 11, 16) != 0x00B50863) { bad = 1; }
+    if (pack_b(OPC_BRANCH, F3_BNE, 10, 11, 16) != 0x00B51863) { bad = 1; }
     # beq a0,a1,-4 (0xFFC) = 0x feb50ee3 (backward); bne a0,x0,8 = 0x00051463
-    if (pack_b(BRANCH, F3_BEQ, 10, 11, (0 - 4)::u32) != 0xFEB50EE3) { bad = 1; }
-    if (pack_b(BRANCH, F3_BNE, 10, 0, 8) != 0x00051463) { bad = 1; }
+    if (pack_b(OPC_BRANCH, F3_BEQ, 10, 11, (0 - 4)::u32) != 0xFEB50EE3) { bad = 1; }
+    if (pack_b(OPC_BRANCH, F3_BNE, 10, 0, 8) != 0x00051463) { bad = 1; }
     # jal ra,0 = 0x000000ef ; jal ra,16 = 0x010000ef ; jal x0,0 (j) = 0x0000006f
-    if (pack_j(JAL, 1, 0)  != 0x000000EF) { bad = 1; }
-    if (pack_j(JAL, 1, 16) != 0x010000EF) { bad = 1; }
-    if (pack_j(JAL, 0, 0)  != 0x0000006F) { bad = 1; }
+    if (pack_j(OPC_JAL, 1, 0)  != 0x000000EF) { bad = 1; }
+    if (pack_j(OPC_JAL, 1, 16) != 0x010000EF) { bad = 1; }
+    if (pack_j(OPC_JAL, 0, 0)  != 0x0000006F) { bad = 1; }
     # jal ra,-4 (backward) = 0xffdff0ef
-    if (pack_j(JAL, 1, (0 - 4)::u32) != 0xFFDFF0EF) { bad = 1; }
+    if (pack_j(OPC_JAL, 1, (0 - 4)::u32) != 0xFFDFF0EF) { bad = 1; }
     ret bad;
 }
 
@@ -3706,11 +4654,11 @@ test "mach.lang.target.isa.riscv64.encode:width_driven_loads_stores_and_alu" {
     if (read_word(?st.buf, 12) != 0x00A5B023) { bad = 1; }
 
     # alu_opcode / alu_imm_opcode select the RV64 word group only at 32-bit width.
-    if (alu_opcode(8) != OP)         { bad = 1; }
-    if (alu_opcode(4) != OP_32)      { bad = 1; }
-    if (alu_opcode(1) != OP)         { bad = 1; }
-    if (alu_imm_opcode(8) != OP_IMM) { bad = 1; }
-    if (alu_imm_opcode(4) != OP_IMM_32) { bad = 1; }
+    if (alu_opcode(8) != OPC_OP)         { bad = 1; }
+    if (alu_opcode(4) != OPC_OP_32)      { bad = 1; }
+    if (alu_opcode(1) != OPC_OP)         { bad = 1; }
+    if (alu_imm_opcode(8) != OPC_OP_IMM) { bad = 1; }
+    if (alu_imm_opcode(4) != OPC_OP_IMM_32) { bad = 1; }
 
     encode.buf_dnit(?st.buf);
     ret bad;
@@ -4172,8 +5120,8 @@ test "mach.lang.target.isa.riscv64.encode:branch_fixups_scatter_and_range" {
     tbuf(?st, ?alloc);
 
     # j placeholder at 0, bne a0,x0 placeholder at 4.
-    emit_word(?st, pack_j(JAL, RZERO, 0));            # off 0
-    emit_word(?st, pack_b(BRANCH, F3_BNE, 10, 0, 0)); # off 4
+    emit_word(?st, pack_j(OPC_JAL, RZERO, 0));            # off 0
+    emit_word(?st, pack_b(OPC_BRANCH, F3_BNE, 10, 0, 0)); # off 4
 
     var fx: encode.BranchFixup;
     # j at 0 -> target 16: disp 16 -> jal x0,16 = 0x0100006f
@@ -4187,21 +5135,21 @@ test "mach.lang.target.isa.riscv64.encode:branch_fixups_scatter_and_range" {
 
     # backward j at 4 -> target 0: disp -4 -> jal x0,-4 = 0xffdff06f
     fx.patch_pos = 4; fx.next_ip = 8;
-    emit_word(?st, pack_j(JAL, RZERO, 0));
+    emit_word(?st, pack_j(OPC_JAL, RZERO, 0));
     st.buf.data[4] = 0x6F; st.buf.data[5] = 0; st.buf.data[6] = 0; st.buf.data[7] = 0;
     patch_branch_riscv64(?st, ?fx, 0);
     if (read_word(?st.buf, 4) != 0xFFDFF06F) { bad = 1; }
 
     # an out-of-range branch (past +-4KiB) is rejected.
     st.buf.len = 0;
-    emit_word(?st, pack_b(BRANCH, F3_BNE, 10, 0, 0));
+    emit_word(?st, pack_b(OPC_BRANCH, F3_BNE, 10, 0, 0));
     fx.patch_pos = 0; fx.next_ip = 4;
     val r1: R.Result[bool, str] = patch_branch_riscv64(?st, ?fx, 8192);
     if (!R.is_err[bool, str](r1)) { bad = 1; }
 
     # an out-of-range jump (past +-1MiB) is rejected.
     st.buf.len = 0;
-    emit_word(?st, pack_j(JAL, RZERO, 0));
+    emit_word(?st, pack_j(OPC_JAL, RZERO, 0));
     fx.patch_pos = 0; fx.next_ip = 4;
     val r2: R.Result[bool, str] = patch_branch_riscv64(?st, ?fx, 2000000);
     if (!R.is_err[bool, str](r2)) { bad = 1; }
@@ -4577,7 +5525,7 @@ test "mach.lang.target.isa.riscv64.encode:inline_asm_symbol_relocs" {
     ret bad;
 }
 
-# the RV64A atomic family (lr / sc / amo*) selects the AMO opcode, the .w / .d width
+# the RV64A atomic family (lr / sc / amo*) selects the OPC_AMO opcode, the .w / .d width
 # funct3, the per-operation funct5, and the .aq / .rl / .aqrl ordering bits, all
 # byte-exact against `llvm-mc -triple=riscv64 -mattr=+a --show-encoding`. `pause` is the
 # fence hint. registers a0/a1/a2 = x10/x11/x12; the address is the base-only `(a1)` form
@@ -4932,3 +5880,4 @@ test "mach.lang.target.isa.riscv64.encode:fmov_and_float_memory" {
     encode.buf_dnit(?st.buf);
     ret bad;
 }
+

--- a/src/lang/target/isa/riscv64/encode.mach
+++ b/src/lang/target/isa/riscv64/encode.mach
@@ -877,6 +877,11 @@ fun last_inst(st: *encode.EncodeState) *isa.Inst {
 # The field a branch's block, a symbol reference and a local label all land in. Its
 # position follows the operand layout, so the annotating call sites name only what
 # the target IS, never where it sits.
+#
+# A form with no such field cannot be annotated, and reaching here with one is a
+# wiring bug in the emitting path rather than a condition to absorb: the annotation
+# would be dropped and the branch would render block `.0`. The caller fails the
+# render instead.
 # ---
 # mi:  the instruction whose target operand is wanted
 # ret: the target operand, or nil for a form with none
@@ -888,6 +893,26 @@ fun target_operand(mi: *isa.Inst) *isa.Operand {
     ret nil;
 }
 
+# the target operand of the instruction most recently buffered, or nil when nothing
+# is being rendered
+#
+# Fails the render when the last instruction has no target field, so an annotation
+# never goes quietly missing.
+# ---
+# st:  encoder driver state (its buffer carries the sink)
+# ret: the target operand, or nil when no sink is buffering
+fun last_target(st: *encode.EncodeState) *isa.Operand {
+    val mi: *isa.Inst = last_inst(st);
+    if (mi == nil) { ret nil; }
+    val op: *isa.Operand = target_operand(mi);
+    if (op == nil) {
+        encode.sink_fail(?st.buf,
+            "--emit-asm: a riscv64 instruction with no target field was given a branch or symbol target");
+        ret nil;
+    }
+    ret op;
+}
+
 # name the MIR block a just-emitted branch targets
 #
 # The encoded displacement is a zero placeholder pass 2 resolves from the block's
@@ -896,9 +921,7 @@ fun target_operand(mi: *isa.Inst) *isa.Operand {
 # st:    encoder driver state (its buffer carries the sink)
 # block: the target block's id
 fun note_block_target(st: *encode.EncodeState, block: u32) {
-    val mi: *isa.Inst = last_inst(st);
-    if (mi == nil) { ret; }
-    val op: *isa.Operand = target_operand(mi);
+    val op: *isa.Operand = last_target(st);
     if (op == nil) { ret; }
     @op = isa.make_block_label(block);
 }
@@ -912,13 +935,11 @@ fun note_block_target(st: *encode.EncodeState, block: u32) {
 # st:    encoder driver state (its buffer carries the sink)
 # bytes: the forward distance the branch skips
 fun note_skip_target(st: *encode.EncodeState, bytes: i64) {
-    val mi: *isa.Inst = last_inst(st);
-    if (mi == nil) { ret; }
-    val op: *isa.Operand = target_operand(mi);
+    val op: *isa.Operand = last_target(st);
     if (op == nil) { ret; }
     @op = isa.make_block_label(0);
     op.imm = bytes;
-    mi.flags = mi.flags | inst.FLAG_LABEL_SKIP;
+    last_inst(st).flags = last_inst(st).flags | inst.FLAG_LABEL_SKIP;
 }
 
 # name the inline-asm numeric local label a just-emitted branch targets
@@ -927,10 +948,9 @@ fun note_skip_target(st: *encode.EncodeState, bytes: i64) {
 # number: the local label's number
 # fwd:    true for a forward reference (`Nf`), false for a backward one (`Nb`)
 fun note_local_target(st: *encode.EncodeState, number: u64, fwd: bool) {
-    val mi: *isa.Inst = last_inst(st);
-    if (mi == nil) { ret; }
-    val op: *isa.Operand = target_operand(mi);
+    val op: *isa.Operand = last_target(st);
     if (op == nil) { ret; }
+    val mi: *isa.Inst = last_inst(st);
     @op = isa.make_block_label(0);
     op.imm   = number::i64;
     mi.flags = mi.flags | inst.FLAG_LABEL_LOCAL;
@@ -948,9 +968,7 @@ fun note_local_target(st: *encode.EncodeState, number: u64, fwd: bool) {
 # sym: the referenced symbol
 # mod: the relocation modifier the half takes
 fun note_sym_target(st: *encode.EncodeState, sym: intern.StrId, mod: isa.SymModifier) {
-    val mi: *isa.Inst = last_inst(st);
-    if (mi == nil) { ret; }
-    val op: *isa.Operand = target_operand(mi);
+    val op: *isa.Operand = last_target(st);
     if (op == nil) { ret; }
     if (op.kind == isa.OPK_MEM) {
         # an address field that is part of a memory operand keeps its base register
@@ -2834,12 +2852,16 @@ fun renote_trampoline(st: *encode.EncodeState, auipc_pos: u32, jalr_pos: u32, ta
 # st:        encoder driver state (its buffer carries the sink)
 # guard_pos: the guard's `.text` offset
 # disp:      the guard's new forward distance
-fun renote_guard_skip(st: *encode.EncodeState, guard_pos: u32, disp: i64) {
-    if (!encode.sink_active(?st.buf)) { ret; }
+# ret:       ok(true), or an error naming a notification that could not be found
+fun renote_guard_skip(st: *encode.EncodeState, guard_pos: u32, disp: i64) R.Result[bool, str] {
+    if (!encode.sink_active(?st.buf)) { ret R.ok[bool, str](true); }
     val idx: i32 = encode.note_index_at(?st.buf, guard_pos);
-    if (idx < 0) { ret; }
+    if (idx < 0) {
+        ret R.err[bool, str]("--emit-asm: riscv64 branch relaxation found no notification for the guard it widened");
+    }
     val guard: *encode.AsmNote = encode.note_at(?st.buf, idx::u32);
     guard.inst.src2.imm = disp;
+    ret R.ok[bool, str](true);
 }
 
 # relax every out-of-range intra-function branch this function just emitted into a
@@ -2915,7 +2937,8 @@ fun relax_function_riscv64(st: *encode.EncodeState, fn_base: u32, fixup_start: u
                 if (relaxed[i - fixup_start] != 0) {
                     val guard_pos: u32 = auipc_pos - 4;
                     set_branch_disp(?st.buf, guard_pos::usize, fx.next_ip - guard_pos);
-                    renote_guard_skip(st, guard_pos, (fx.next_ip - guard_pos)::i64);
+                    val rg: R.Result[bool, str] = renote_guard_skip(st, guard_pos, (fx.next_ip - guard_pos)::i64);
+                    if (R.is_err[bool, str](rg)) { ret rg; }
                 }
                 changed = true;
                 brk;

--- a/src/lang/target/isa/riscv64/inst.mach
+++ b/src/lang/target/isa/riscv64/inst.mach
@@ -1,0 +1,247 @@
+# the RV64 machine-instruction surface: the concrete forms the encoder emits
+#
+# `riscv64.Opcode` is NOT this. Those values (`riscv64.ADD`, `MOV`, `JMP`, `RET`,
+# ...) are INSTRUCTION-SELECTION tags: seventeen logical operations the selector
+# produces and the encoder realizes, deliberately XLEN- and form-independent.
+# `riscv64.MOV` is not an instruction (`mv rd, rs` is `addi rd, rs, 0`) and
+# `riscv64.RET` is not one either (`ret` is `jalr zero, 0(ra)`); a single `ADD` tag
+# becomes `add`, `addw`, `addi` or `addiw` depending on width and operand shape.
+# So riscv64 had no name for the instructions it actually emits - the closest thing
+# was the (major opcode, funct3, funct7) triple passed to a packer and discarded.
+#
+# This module names them. Each value is one concrete RV64 instruction: one mnemonic,
+# one encoding, one operand shape. It is the target-facing currency of #2212 - the
+# type the encoder produces, the printer renders, and an assembly parser would
+# produce - carried as `isa.Inst.opcode`, exactly as `x64.Opcode` is on x86-64.
+#
+# TODAY the arrow runs backwards relative to x86-64. x64 selects an opcode and the
+# encoder derives the bytes from it; riscv64 derives the bytes from the format
+# fields and the opcode is classified FROM those same fields, at the packer, in one
+# place per instruction format. That is a projection of the encoding rather than a
+# second implementation of it, and the object-vs-asm cross-check is what proves the
+# projection right. #2118 (format tables + a shared packer) reverses the arrow: the
+# encoder becomes `Opcode -> format table -> bytes` and the classification
+# disappears. This list is the table key that increment needs.
+#
+# The list covers RV64I, the M (multiply / divide), A (atomic) and F/D (scalar
+# float) extensions - every form `riscv64.encode` can produce, from the selector and
+# from the inline-asm assembler alike. No pseudo-instruction appears: `li`, `mv`,
+# `j`, `ret`, `neg`, `not`, `seqz` and friends are spellings of real instructions in
+# this list, and naming the real one is the point of the artifact.
+
+# a concrete RV64 machine instruction. distinct from `riscv64.Opcode`, which names a
+# selection tag; the two spaces never mix in one `isa.Inst`
+pub def MachOp: u16;
+
+# the sentinel a cleared instruction carries, naming no form
+pub val MOP_NONE: MachOp = 0;
+
+# RV64I register-register integer ALU (OP)
+pub val ADD:  MachOp = 1;
+pub val SUB:  MachOp = 2;
+pub val SLL:  MachOp = 3;
+pub val SLT:  MachOp = 4;
+pub val SLTU: MachOp = 5;
+pub val XOR:  MachOp = 6;
+pub val SRL:  MachOp = 7;
+pub val SRA:  MachOp = 8;
+pub val OR:   MachOp = 9;
+pub val AND:  MachOp = 10;
+
+# RV64I word (32-bit) register-register ALU (OP_32), which RV32 has no counterpart to
+pub val ADDW: MachOp = 11;
+pub val SUBW: MachOp = 12;
+pub val SLLW: MachOp = 13;
+pub val SRLW: MachOp = 14;
+pub val SRAW: MachOp = 15;
+
+# the M extension's multiply / divide / remainder
+pub val MUL:    MachOp = 16;
+pub val MULH:   MachOp = 17;
+pub val MULHSU: MachOp = 18;
+pub val MULHU:  MachOp = 19;
+pub val DIV:    MachOp = 20;
+pub val DIVU:   MachOp = 21;
+pub val REM:    MachOp = 22;
+pub val REMU:   MachOp = 23;
+
+# the M extension's RV64 word forms
+pub val MULW:  MachOp = 24;
+pub val DIVW:  MachOp = 25;
+pub val DIVUW: MachOp = 26;
+pub val REMW:  MachOp = 27;
+pub val REMUW: MachOp = 28;
+
+# RV64I register-immediate integer ALU (OP_IMM)
+pub val ADDI:  MachOp = 29;
+pub val SLTI:  MachOp = 30;
+pub val SLTIU: MachOp = 31;
+pub val XORI:  MachOp = 32;
+pub val ORI:   MachOp = 33;
+pub val ANDI:  MachOp = 34;
+pub val SLLI:  MachOp = 35;
+pub val SRLI:  MachOp = 36;
+pub val SRAI:  MachOp = 37;
+
+# RV64I word register-immediate ALU (OP_IMM_32)
+pub val ADDIW: MachOp = 38;
+pub val SLLIW: MachOp = 39;
+pub val SRLIW: MachOp = 40;
+pub val SRAIW: MachOp = 41;
+
+# RV64I integer loads. LD / LWU are RV64-only
+pub val LB:  MachOp = 42;
+pub val LH:  MachOp = 43;
+pub val LW:  MachOp = 44;
+pub val LD:  MachOp = 45;
+pub val LBU: MachOp = 46;
+pub val LHU: MachOp = 47;
+pub val LWU: MachOp = 48;
+
+# RV64I integer stores. SD is RV64-only
+pub val SB: MachOp = 49;
+pub val SH: MachOp = 50;
+pub val SW: MachOp = 51;
+pub val SD: MachOp = 52;
+
+# RV64I conditional branches, +-4 KiB reach
+pub val BEQ:  MachOp = 53;
+pub val BNE:  MachOp = 54;
+pub val BLT:  MachOp = 55;
+pub val BGE:  MachOp = 56;
+pub val BLTU: MachOp = 57;
+pub val BGEU: MachOp = 58;
+
+# RV64I jumps: JAL reaches +-1 MiB, JALR the register-indirect full range
+pub val JAL:  MachOp = 59;
+pub val JALR: MachOp = 60;
+
+# RV64I upper-immediate address formation
+pub val LUI:   MachOp = 61;
+pub val AUIPC: MachOp = 62;
+
+# RV64I environment and memory-ordering forms
+pub val ECALL:  MachOp = 63;
+pub val EBREAK: MachOp = 64;
+pub val FENCE:  MachOp = 65;
+pub val PAUSE:  MachOp = 66;
+
+# F/D extension float loads and stores
+pub val FLW: MachOp = 67;
+pub val FLD: MachOp = 68;
+pub val FSW: MachOp = 69;
+pub val FSD: MachOp = 70;
+
+# F/D extension binary arithmetic
+pub val FADD_S: MachOp = 71;
+pub val FADD_D: MachOp = 72;
+pub val FSUB_S: MachOp = 73;
+pub val FSUB_D: MachOp = 74;
+pub val FMUL_S: MachOp = 75;
+pub val FMUL_D: MachOp = 76;
+pub val FDIV_S: MachOp = 77;
+pub val FDIV_D: MachOp = 78;
+
+# F/D extension sign injection - the copy (`fmv`), negate (`fneg`) and absolute
+# (`fabs`) pseudo-forms are these three with both sources the same register
+pub val FSGNJ_S:  MachOp = 79;
+pub val FSGNJ_D:  MachOp = 80;
+pub val FSGNJN_S: MachOp = 81;
+pub val FSGNJN_D: MachOp = 82;
+pub val FSGNJX_S: MachOp = 83;
+pub val FSGNJX_D: MachOp = 84;
+
+# F/D extension comparisons, which write a general-purpose boolean directly
+pub val FEQ_S: MachOp = 85;
+pub val FEQ_D: MachOp = 86;
+pub val FLT_S: MachOp = 87;
+pub val FLT_D: MachOp = 88;
+pub val FLE_S: MachOp = 89;
+pub val FLE_D: MachOp = 90;
+
+# F/D extension float-to-float conversion
+pub val FCVT_S_D: MachOp = 91;
+pub val FCVT_D_S: MachOp = 92;
+
+# F/D extension float-to-integer conversion (round toward zero as the encoder emits it)
+pub val FCVT_W_S:  MachOp = 93;
+pub val FCVT_WU_S: MachOp = 94;
+pub val FCVT_L_S:  MachOp = 95;
+pub val FCVT_LU_S: MachOp = 96;
+pub val FCVT_W_D:  MachOp = 97;
+pub val FCVT_WU_D: MachOp = 98;
+pub val FCVT_L_D:  MachOp = 99;
+pub val FCVT_LU_D: MachOp = 100;
+
+# F/D extension integer-to-float conversion
+pub val FCVT_S_W:  MachOp = 101;
+pub val FCVT_S_WU: MachOp = 102;
+pub val FCVT_S_L:  MachOp = 103;
+pub val FCVT_S_LU: MachOp = 104;
+pub val FCVT_D_W:  MachOp = 105;
+pub val FCVT_D_WU: MachOp = 106;
+pub val FCVT_D_L:  MachOp = 107;
+pub val FCVT_D_LU: MachOp = 108;
+
+# F/D extension cross-bank bit reinterprets
+pub val FMV_X_W: MachOp = 109;
+pub val FMV_X_D: MachOp = 110;
+pub val FMV_W_X: MachOp = 111;
+pub val FMV_D_X: MachOp = 112;
+
+# the A extension's load-reserved / store-conditional pair
+pub val LR_W: MachOp = 113;
+pub val LR_D: MachOp = 114;
+pub val SC_W: MachOp = 115;
+pub val SC_D: MachOp = 116;
+
+# the A extension's read-modify-write atomics
+pub val AMOSWAP_W: MachOp = 117;
+pub val AMOSWAP_D: MachOp = 118;
+pub val AMOADD_W:  MachOp = 119;
+pub val AMOADD_D:  MachOp = 120;
+pub val AMOXOR_W:  MachOp = 121;
+pub val AMOXOR_D:  MachOp = 122;
+pub val AMOAND_W:  MachOp = 123;
+pub val AMOAND_D:  MachOp = 124;
+pub val AMOOR_W:   MachOp = 125;
+pub val AMOOR_D:   MachOp = 126;
+pub val AMOMIN_W:  MachOp = 127;
+pub val AMOMIN_D:  MachOp = 128;
+pub val AMOMAX_W:  MachOp = 129;
+pub val AMOMAX_D:  MachOp = 130;
+pub val AMOMINU_W: MachOp = 131;
+pub val AMOMINU_D: MachOp = 132;
+pub val AMOMAXU_W: MachOp = 133;
+pub val AMOMAXU_D: MachOp = 134;
+
+# instruction-level encoding flags in riscv64's own space
+#
+# `isa.Inst.flags` is an ISA-owned bitfield (x86-64 carries its `LOCK` prefix there);
+# these are riscv64's. The shared bits `isa.ISA_FLAG_DST_READ` (0x8000) and
+# `isa.ISA_FLAG_FP_COPY` (0x4000) sit at the top of the field and are not reused.
+#
+# An atomic's acquire / release bits ARE its memory-ordering guarantee, so they are
+# carried rather than dropped: an `amoswap.d.rl` rendered as `amoswap.d` reads as a
+# plain exchange. A symbol reference's relocation modifier is NOT here - that belongs
+# to the operand carrying the symbol (`isa.Operand.sym_mod`).
+pub val FLAG_AQ: u16 = 0x0001;  # the atomic acquires (`.aq`)
+pub val FLAG_RL: u16 = 0x0002;  # the atomic releases (`.rl`)
+
+# a branch-target label operand's flavour, in riscv64's own flag space
+#
+# An intra-function branch names its MIR block (`isa.make_block_label`) and needs no
+# flag. The inline-asm assembler's numeric local labels (`1f` / `1b`) and the
+# relaxation pass's internal skip are the two targets that have no block to name, so
+# they mark themselves here and carry their number / distance in the label operand's
+# immediate.
+pub val FLAG_LABEL_LOCAL: u16 = 0x0004;  # the label names an inline-asm numeric local label
+pub val FLAG_LABEL_FWD:   u16 = 0x0008;  # that local reference is forward (`Nf`), else backward (`Nb`)
+pub val FLAG_LABEL_SKIP:  u16 = 0x0010;  # the label is a relaxation-internal skip of `imm` bytes
+
+# the modified address field names a MIR block, not a symbol
+#
+# A relaxed far jump's `auipc` / `jalr` trampoline takes the same `%pcrel_hi` /
+# `%pcrel_lo` split a symbol reference does, but its target is an intra-function
+# block the encoder resolves itself. The block id rides the operand's immediate.
+pub val FLAG_TARGET_BLOCK: u16 = 0x0020;

--- a/src/lang/target/isa/riscv64/printer.mach
+++ b/src/lang/target/isa/riscv64/printer.mach
@@ -1,44 +1,692 @@
-# RISC-V (RV64) assembly text printer - not yet implemented
+# RISC-V (RV64) assembly text renderer - renders the encoder's own instruction stream
 #
-# `--emit-asm` renders its text from the encoder's own instruction stream: the ISA
-# runs its ordinary encoder with an `encode.AsmSink` attached and notifies the sink
-# once per machine instruction emitted, so a `.s` line is an instruction the
-# encoder really produced. x86-64 does this today (see `isa.x64.printer`); RV64
-# does not yet, and is tracked by briar-systems/mach#2193.
+# This is the text half of the riscv64 ISA's `emit_asm` operation. It does NOT walk
+# the MIR: `encode.encode_riscv64_asm` runs the ordinary encoder with an
+# `enc.AsmSink` attached, and the encoder notifies the sink once for every machine
+# instruction it emits, immediately after emitting it. Each line of the `.s` is
+# therefore one instruction the encoder really produced, in the order it produced it.
 #
-# Until then this refuses. It does NOT fall back to the previous printer, which
-# walked the post-regalloc MIR and rendered each MIR macro-op as one pseudo-
-# mnemonic line: on RV64 that hid 52% of the emitted instructions - `cbr.lt_s`
-# standing in for a `blt` plus a `j`, `mv` where the encoder emits `li`, `add`
-# where it emits `addi`, and the prologue's register saves and the whole epilogue
-# absent - while presenting itself as the assembly that became the object (#2187).
-# An artifact that wrong is worse than none: it sends every investigation that
-# reads it down a false path. Refusing names the gap; printing would hide it.
+# What this module may read is correspondingly narrow: the `isa.Inst` the encoder
+# built, and nothing else. Same type x86-64's printer renders, so there is one
+# representation of "what did this MIR become" and nothing for a second one to
+# disagree with (#2212). The structure reaches it from the instruction-format
+# packers - `pack_r` / `pack_i` / ... each receive every field of the word as an
+# argument, and `riscv64.encode` classifies those arguments into a concrete
+# `inst.MachOp` at the packer - so no RV64 decoder exists anywhere.
+#
+# UNLIKE x86-64, notifications are BUFFERED and rendered when the function's layout
+# is final. RV64's branch relaxation rewrites an over-range conditional into an
+# inverted guard plus a `jal`, and an over-range `jal` into an `auipc` / `jalr`
+# trampoline, AFTER the whole function is emitted - so an instruction's first form is
+# not always its last. The relaxation pass edits the buffered notifications exactly
+# as it edits the text, and rendering happens once afterwards, so a `.s` line is the
+# instruction that ended up in the object rather than the one first planned.
+#
+# The previous printer was a second, independent renderer walking the post-regalloc
+# MIR, so a MIR macro-op the encoder expands into several machine instructions
+# printed as a single pseudo-mnemonic line - `cbr.lt_s a2, a0, .2, .3` standing in
+# for a `blt` plus a `j`, `add a2, a2, 1` for an `addi`, a `j .1` that existed in no
+# object, the register saves and the whole epilogue absent. It accounted for 49,380
+# of 102,503 emitted instructions and every module diverged (#2187). Rendering from
+# the encoder makes that class of divergence unrepresentable.
+#
+# NO PSEUDO-INSTRUCTIONS. The text names the instruction that was encoded: `addi a0,
+# zero, 5`, not `li a0, 5`; `jalr zero, 0(ra)`, not `ret`. A pseudo spelling hides
+# which real instruction - or how many - the encoder chose, which is the property
+# this artifact exists to show.
+#
+# An opcode with no mnemonic, or an operand shape that does not render, is a hard
+# error naming the opcode. Silent degradation is what let the old divergence go
+# unnoticed, so there is no fallback text anywhere in this module.
 
+use std.format;
 use std.io.writer;
+use std.types.bool.bool;
+use std.types.bool.false;
+use std.types.bool.true;
+use std.types.size.usize;
 use std.types.string.str;
+use std.types.string.str_equals;
 
+use O: std.types.option;
 use R: std.types.result;
 
-use A: std.allocator;
-use encode: mach.lang.be.codegen.encode;
-use mach.lang.be.codegen.mir;
-use mach.lang.target.resolved;
+use enc: mach.lang.be.codegen.encode;
+use mach.lang.intern;
+use mach.lang.target.isa;
+use mach.lang.target.isa.riscv64.inst;
 
-# refuse to render RV64 assembly text, naming the tracking issue
+# render one function's buffered notifications
 #
-# The `emit_asm` entry point the riscv64 ISA registers; matches
-# `be.codegen.encode.EmitAsmFn`. Registering a refusal rather than leaving the
-# vtable slot nil keeps the failure specific: the shared dispatcher's nil path
-# reports only that the architecture has no printer.
+# Called once the function's layout is final - after branch relaxation has settled -
+# so every line names the instruction that ended up in the object.
 # ---
-# a:   backing allocator (unused; no encode is performed)
-# tgt: resolved compilation target
-# m:   the fully-resolved MIR module
+# buf: the encoder byte sink carrying the assembly sink
+# ret: true on success, or the first write error
+pub fun render_notes(buf: *enc.ByteBuf) R.Result[bool, str] {
+    val out: *writer.Writer = buf.asm.out;
+    val count: u32 = enc.note_count(buf);
+    var i: u32 = 0;
+    for (i < count) {
+        val res: R.Result[bool, str] = render_note(out, buf.asm.interner, enc.note_at(buf, i));
+        if (R.is_err[bool, str](res)) { ret res; }
+        i = i + 1;
+    }
+    ret R.ok[bool, str](true);
+}
+
+# render one buffered notification
+# ---
+# out:      destination writer
+# interner: resolves function and symbol ids to their source names
+# n:        the notification to render
+# ret:      true on success, or the first write error
+fun render_note(out: *writer.Writer, interner: *intern.Interner, n: *enc.AsmNote) R.Result[bool, str] {
+    if (n.kind == enc.ASM_NOTE_FUNC) {
+        val res_open: R.Result[bool, str] = emit_str(out, "\n# ");
+        if (R.is_err[bool, str](res_open)) { ret res_open; }
+        val res_name: R.Result[bool, str] = emit_name(out, interner, n.name);
+        if (R.is_err[bool, str](res_name)) { ret res_name; }
+        ret emit_str(out, ":\n");
+    }
+    if (n.kind == enc.ASM_NOTE_BLOCK) {
+        val res_label: R.Result[bool, str] = emit_block(out, n.id);
+        if (R.is_err[bool, str](res_label)) { ret res_label; }
+        ret emit_str(out, ":\n");
+    }
+    ret render_inst(out, interner, ?n.inst);
+}
+
+# render `<mnemonic> <operands>` for one machine instruction
+#
+# An atomic's acquire / release ordering rides the mnemonic because that is where an
+# assembler spells it, and because the ordering IS the operation's guarantee: an
+# `amoswap.d.rl` rendered as `amoswap.d` reads as a plain exchange.
+# ---
+# out:      destination writer
+# interner: resolves symbol ids to their source names
+# mi:       the machine instruction to render
+# ret:      true on success, or the first error
+fun render_inst(out: *writer.Writer, interner: *intern.Interner, mi: *isa.Inst) R.Result[bool, str] {
+    val res_indent: R.Result[bool, str] = emit_str(out, "  ");
+    if (R.is_err[bool, str](res_indent)) { ret res_indent; }
+
+    val mnem: str = mnemonic(mi.opcode::inst.MachOp);
+    if (mnem == nil) {
+        ret R.err[bool, str]("--emit-asm: no riscv64 mnemonic for the emitted opcode");
+    }
+    val res_mnem: R.Result[bool, str] = emit_str(out, mnem);
+    if (R.is_err[bool, str](res_mnem)) { ret res_mnem; }
+    val res_order: R.Result[bool, str] = emit_str(out, ordering_suffix(mi.flags));
+    if (R.is_err[bool, str](res_order)) { ret res_order; }
+
+    val res_ops: R.Result[bool, str] = render_operands(out, interner, mi);
+    if (R.is_err[bool, str](res_ops)) { ret res_ops; }
+    ret emit_str(out, "\n");
+}
+
+# render an instruction's operands, left to right
+#
+# ONE riscv64 SYNTAX RULE lives here: a store's destination is its memory operand,
+# but RISC-V writes the transferred register first (`sd a0, 8(sp)`), so a memory
+# destination is rendered after its source. Everything else is the operand order the
+# encoder built.
+# ---
+# out:      destination writer
+# interner: resolves symbol ids to their source names
+# mi:       the instruction whose operands are rendered
+# ret:      true on success, or an error naming an unrenderable shape
+fun render_operands(out: *writer.Writer, interner: *intern.Interner, mi: *isa.Inst) R.Result[bool, str] {
+    if (mi.dst.kind == isa.OPK_MEM) {
+        var printed: u32 = 0;
+        val res_src: R.Result[u32, str] = render_operand(out, interner, mi, ?mi.src1, printed);
+        if (R.is_err[u32, str](res_src)) { ret R.err[bool, str](R.unwrap_err[u32, str](res_src)); }
+        printed = R.unwrap_ok[u32, str](res_src);
+        val res_dst: R.Result[u32, str] = render_operand(out, interner, mi, ?mi.dst, printed);
+        if (R.is_err[u32, str](res_dst)) { ret R.err[bool, str](R.unwrap_err[u32, str](res_dst)); }
+        ret R.ok[bool, str](true);
+    }
+
+    var printed: u32 = 0;
+    val res_dst: R.Result[u32, str] = render_operand(out, interner, mi, ?mi.dst, printed);
+    if (R.is_err[u32, str](res_dst)) { ret R.err[bool, str](R.unwrap_err[u32, str](res_dst)); }
+    printed = R.unwrap_ok[u32, str](res_dst);
+
+    val res_src1: R.Result[u32, str] = render_operand(out, interner, mi, ?mi.src1, printed);
+    if (R.is_err[u32, str](res_src1)) { ret R.err[bool, str](R.unwrap_err[u32, str](res_src1)); }
+    printed = R.unwrap_ok[u32, str](res_src1);
+
+    val res_src2: R.Result[u32, str] = render_operand(out, interner, mi, ?mi.src2, printed);
+    if (R.is_err[u32, str](res_src2)) { ret R.err[bool, str](R.unwrap_err[u32, str](res_src2)); }
+    ret R.ok[bool, str](true);
+}
+
+# render one operand, prefixed by the right separator for its position
+# ---
+# out:      destination writer
+# interner: resolves symbol ids to their source names
+# mi:       the owning instruction (supplies the label flavour)
+# op:       the operand to render
+# printed:  how many operands have been rendered already
+# ret:      the new rendered-operand count, or an error
+fun render_operand(out: *writer.Writer, interner: *intern.Interner, mi: *isa.Inst,
+                   op: *isa.Operand, printed: u32) R.Result[u32, str] {
+    if (op.kind == isa.OPK_NONE) { ret R.ok[u32, str](printed); }
+
+    var sep: str = ", ";
+    if (printed == 0) { sep = " "; }
+    val res_sep: R.Result[bool, str] = emit_str(out, sep);
+    if (R.is_err[bool, str](res_sep)) { ret R.err[u32, str](R.unwrap_err[bool, str](res_sep)); }
+
+    val res: R.Result[bool, str] = render_operand_body(out, interner, mi, op);
+    if (R.is_err[bool, str](res)) { ret R.err[u32, str](R.unwrap_err[bool, str](res)); }
+    ret R.ok[u32, str](printed + 1);
+}
+
+# render an operand's text
+#
+# A register names its psABI mnemonic in its own bank - the composite register id
+# carries its class, so a float id prints `fa0` without the opcode being consulted. A
+# memory operand renders `<displacement>(<base>)`, RISC-V's address syntax, where the
+# displacement may itself be a modified symbol reference (`%pcrel_lo(sym)(t0)`).
+# ---
+# out:      destination writer
+# interner: resolves symbol ids to their source names
+# mi:       the owning instruction
+# op:       the operand to render
+# ret:      true on success, or an error naming the unrenderable shape
+fun render_operand_body(out: *writer.Writer, interner: *intern.Interner, mi: *isa.Inst,
+                        op: *isa.Operand) R.Result[bool, str] {
+    if (op.kind == isa.OPK_REG)   { ret emit_str(out, reg_name(op.reg)); }
+    if (op.kind == isa.OPK_IMM)   { ret emit_i64(out, op.imm); }
+    if (op.kind == isa.OPK_SYM)   { ret emit_sym(out, interner, op); }
+    if (op.kind == isa.OPK_LABEL) { ret emit_target(out, interner, mi, op); }
+    if (op.kind == isa.OPK_MEM) {
+        val res_disp: R.Result[bool, str] = emit_mem_disp(out, interner, mi, op);
+        if (R.is_err[bool, str](res_disp)) { ret res_disp; }
+        val res_open: R.Result[bool, str] = emit_str(out, "(");
+        if (R.is_err[bool, str](res_open)) { ret res_open; }
+        val res_base: R.Result[bool, str] = emit_str(out, reg_name(op.base));
+        if (R.is_err[bool, str](res_base)) { ret res_base; }
+        ret emit_str(out, ")");
+    }
+    ret R.err[bool, str]("--emit-asm: riscv64 instruction operand has no renderable kind");
+}
+
+# render a memory operand's displacement
+#
+# A plain access prints its byte displacement. An access reaching a global through
+# the low half of a pc-relative pair prints the modified symbol instead, and a
+# relaxed far jump's trampoline the modified block its target lies in - in both cases
+# the encoded displacement is a placeholder the linker or the branch patcher fills,
+# so the name is what identifies the target.
+# ---
+# out:      destination writer
+# interner: resolves symbol ids to their source names
+# mi:       the owning instruction (its flags say whether the target is a block)
+# op:       the memory operand
+# ret:      true on success, or the first write error
+fun emit_mem_disp(out: *writer.Writer, interner: *intern.Interner, mi: *isa.Inst, op: *isa.Operand) R.Result[bool, str] {
+    if (op.sym_mod == isa.SYM_MOD_NONE) { ret emit_i64(out, op.disp::i64); }
+    if ((mi.flags & inst.FLAG_TARGET_BLOCK) == 0) { ret emit_sym(out, interner, op); }
+
+    val res_open: R.Result[bool, str] = emit_str(out, modifier_text(op.sym_mod));
+    if (R.is_err[bool, str](res_open)) { ret res_open; }
+    val res_blk: R.Result[bool, str] = emit_block(out, op.imm::u32);
+    if (R.is_err[bool, str](res_blk)) { ret res_blk; }
+    ret emit_str(out, ")");
+}
+
+# render a branch target
+#
+# A block-target branch names its destination block (`.N`). The two targets that name
+# no block mark themselves in the instruction's flags: an inline-asm numeric local
+# label carries its number and direction (`1f` / `1b`), and a relaxation-internal
+# guard carries the byte distance it skips (`.+8`). A relaxed far trampoline names
+# its block under a pc-relative modifier, exactly as an assembler would spell it.
+# ---
+# out:      destination writer
+# interner: resolves symbol ids to their source names
+# mi:       the owning instruction (its flags carry the label flavour)
+# op:       the label operand to render
+# ret:      true on success, or the write error
+fun emit_target(out: *writer.Writer, interner: *intern.Interner, mi: *isa.Inst, op: *isa.Operand) R.Result[bool, str] {
+    if ((mi.flags & inst.FLAG_LABEL_SKIP) != 0) {
+        val res_dot: R.Result[bool, str] = emit_str(out, ".+");
+        if (R.is_err[bool, str](res_dot)) { ret res_dot; }
+        ret emit_i64(out, op.imm);
+    }
+    if ((mi.flags & inst.FLAG_LABEL_LOCAL) != 0 && op.sym_mod == isa.SYM_MOD_NONE) {
+        val res_num: R.Result[bool, str] = emit_u64(out, op.imm::u64);
+        if (R.is_err[bool, str](res_num)) { ret res_num; }
+        if ((mi.flags & inst.FLAG_LABEL_FWD) != 0) { ret emit_str(out, "f"); }
+        ret emit_str(out, "b");
+    }
+    if (op.sym_mod == isa.SYM_MOD_NONE) { ret emit_block(out, op.imm::u32); }
+
+    val res_open: R.Result[bool, str] = emit_str(out, modifier_text(op.sym_mod));
+    if (R.is_err[bool, str](res_open)) { ret res_open; }
+    val res_blk: R.Result[bool, str] = emit_block(out, op.imm::u32);
+    if (R.is_err[bool, str](res_blk)) { ret res_blk; }
+    ret emit_str(out, ")");
+}
+
+# render a symbol reference under its relocation modifier
+#
+# riscv64 reaches a symbol through an instruction pair whose halves take different
+# relocations, so the modifier is what makes each line assemble back to the
+# instruction it came from.
+# ---
+# out:      destination writer
+# interner: the interner that resolves the id to text
+# op:       the symbol-carrying operand
+# ret:      true on success, or an error
+fun emit_sym(out: *writer.Writer, interner: *intern.Interner, op: *isa.Operand) R.Result[bool, str] {
+    if (op.sym_mod == isa.SYM_MOD_NONE) { ret emit_name(out, interner, op.sym_id::intern.StrId); }
+    val res_open: R.Result[bool, str] = emit_str(out, modifier_text(op.sym_mod));
+    if (R.is_err[bool, str](res_open)) { ret res_open; }
+    val res_name: R.Result[bool, str] = emit_name(out, interner, op.sym_id::intern.StrId);
+    if (R.is_err[bool, str](res_name)) { ret res_name; }
+    ret emit_str(out, ")");
+}
+
+# the RISC-V assembler spelling of a relocation modifier, with its opening paren
+# ---
+# mod: the modifier (one of isa.SYM_MOD_*)
+# ret: the opening text, or an empty string for no modifier
+fun modifier_text(mod: isa.SymModifier) str {
+    if (mod == isa.SYM_MOD_PCREL_HI) { ret "%pcrel_hi("; }
+    if (mod == isa.SYM_MOD_PCREL_LO) { ret "%pcrel_lo("; }
+    if (mod == isa.SYM_MOD_GOT_HI)   { ret "%got_pcrel_hi("; }
+    if (mod == isa.SYM_MOD_GOT_LO)   { ret "%got_pcrel_lo("; }
+    ret "";
+}
+
+# the acquire / release suffix an atomic's flags spell
+# ---
+# flags: the instruction's flags
+# ret:   the suffix, empty for an unordered access
+fun ordering_suffix(flags: u16) str {
+    val aq: bool = (flags & inst.FLAG_AQ) != 0;
+    val rl: bool = (flags & inst.FLAG_RL) != 0;
+    if (aq && rl) { ret ".aqrl"; }
+    if (aq)       { ret ".aq"; }
+    if (rl)       { ret ".rl"; }
+    ret "";
+}
+
+# render a block's local label `.N`
+# ---
 # out: destination writer
-# ret: always an error naming riscv64 and its tracking issue
-pub fun print_asm_riscv64(a: *A.Allocator, tgt: *resolved.Target, m: *mir.MirModule,
-                          out: *writer.Writer) R.Result[encode.EncoderOutput, str] {
-    ret R.err[encode.EncoderOutput, str](
-        "--emit-asm: no assembly printer for riscv64 yet (tracked by briar-systems/mach#2193)");
+# id:  the block id
+# ret: true on success, or the first write error
+fun emit_block(out: *writer.Writer, id: u32) R.Result[bool, str] {
+    val res_dot: R.Result[bool, str] = emit_str(out, ".");
+    if (R.is_err[bool, str](res_dot)) { ret res_dot; }
+    ret emit_u64(out, id::u64);
+}
+
+# the psABI mnemonic a composite register id names, in its own bank
+#
+# The id carries its class, so a float register names `fa0` regardless of the opcode
+# and never aliases the integer register of the same index.
+# ---
+# id:  the composite register id
+# ret: the psABI register name
+fun reg_name(id: i32) str {
+    if (isa.regid_class(id) == isa.REG_CLASS_ID_XMM) { ret fp_name(isa.regid_index(id)::u32); }
+    ret gp_name(id::u32);
+}
+
+# the RISC-V psABI integer-register mnemonic for a register index (x0-x31)
+# ---
+# idx: the integer register index
+# ret: the psABI name, or `x?` for an out-of-range index
+pub fun gp_name(idx: u32) str {
+    if (idx == 0)  { ret "zero"; }
+    if (idx == 1)  { ret "ra"; }
+    if (idx == 2)  { ret "sp"; }
+    if (idx == 3)  { ret "gp"; }
+    if (idx == 4)  { ret "tp"; }
+    if (idx == 5)  { ret "t0"; }
+    if (idx == 6)  { ret "t1"; }
+    if (idx == 7)  { ret "t2"; }
+    if (idx == 8)  { ret "s0"; }
+    if (idx == 9)  { ret "s1"; }
+    if (idx == 10) { ret "a0"; }
+    if (idx == 11) { ret "a1"; }
+    if (idx == 12) { ret "a2"; }
+    if (idx == 13) { ret "a3"; }
+    if (idx == 14) { ret "a4"; }
+    if (idx == 15) { ret "a5"; }
+    if (idx == 16) { ret "a6"; }
+    if (idx == 17) { ret "a7"; }
+    if (idx == 18) { ret "s2"; }
+    if (idx == 19) { ret "s3"; }
+    if (idx == 20) { ret "s4"; }
+    if (idx == 21) { ret "s5"; }
+    if (idx == 22) { ret "s6"; }
+    if (idx == 23) { ret "s7"; }
+    if (idx == 24) { ret "s8"; }
+    if (idx == 25) { ret "s9"; }
+    if (idx == 26) { ret "s10"; }
+    if (idx == 27) { ret "s11"; }
+    if (idx == 28) { ret "t3"; }
+    if (idx == 29) { ret "t4"; }
+    if (idx == 30) { ret "t5"; }
+    if (idx == 31) { ret "t6"; }
+    ret "x?";
+}
+
+# the RISC-V psABI float-register mnemonic for a register index (f0-f31)
+# ---
+# idx: the float register index
+# ret: the psABI name, or `f?` for an out-of-range index
+pub fun fp_name(idx: u32) str {
+    if (idx == 0)  { ret "ft0"; }
+    if (idx == 1)  { ret "ft1"; }
+    if (idx == 2)  { ret "ft2"; }
+    if (idx == 3)  { ret "ft3"; }
+    if (idx == 4)  { ret "ft4"; }
+    if (idx == 5)  { ret "ft5"; }
+    if (idx == 6)  { ret "ft6"; }
+    if (idx == 7)  { ret "ft7"; }
+    if (idx == 8)  { ret "fs0"; }
+    if (idx == 9)  { ret "fs1"; }
+    if (idx == 10) { ret "fa0"; }
+    if (idx == 11) { ret "fa1"; }
+    if (idx == 12) { ret "fa2"; }
+    if (idx == 13) { ret "fa3"; }
+    if (idx == 14) { ret "fa4"; }
+    if (idx == 15) { ret "fa5"; }
+    if (idx == 16) { ret "fa6"; }
+    if (idx == 17) { ret "fa7"; }
+    if (idx == 18) { ret "fs2"; }
+    if (idx == 19) { ret "fs3"; }
+    if (idx == 20) { ret "fs4"; }
+    if (idx == 21) { ret "fs5"; }
+    if (idx == 22) { ret "fs6"; }
+    if (idx == 23) { ret "fs7"; }
+    if (idx == 24) { ret "fs8"; }
+    if (idx == 25) { ret "fs9"; }
+    if (idx == 26) { ret "fs10"; }
+    if (idx == 27) { ret "fs11"; }
+    if (idx == 28) { ret "ft8"; }
+    if (idx == 29) { ret "ft9"; }
+    if (idx == 30) { ret "ft10"; }
+    if (idx == 31) { ret "ft11"; }
+    ret "f?";
+}
+
+# the mnemonic for a concrete RV64 machine instruction, or nil when unmapped
+#
+# Total over the instruction surface by construction: an unmapped opcode returns nil
+# and the caller fails the build, never placeholder text. A form that reaches the
+# encoder without being named here breaks the render rather than printing something
+# an assembler would reject.
+# ---
+# op:  the concrete instruction to name
+# ret: the mnemonic text, or nil for an opcode with no mapping
+pub fun mnemonic(op: inst.MachOp) str {
+    if (op == inst.ADD)  { ret "add"; }
+    if (op == inst.SUB)  { ret "sub"; }
+    if (op == inst.SLL)  { ret "sll"; }
+    if (op == inst.SLT)  { ret "slt"; }
+    if (op == inst.SLTU) { ret "sltu"; }
+    if (op == inst.XOR)  { ret "xor"; }
+    if (op == inst.SRL)  { ret "srl"; }
+    if (op == inst.SRA)  { ret "sra"; }
+    if (op == inst.OR)   { ret "or"; }
+    if (op == inst.AND)  { ret "and"; }
+
+    if (op == inst.ADDW) { ret "addw"; }
+    if (op == inst.SUBW) { ret "subw"; }
+    if (op == inst.SLLW) { ret "sllw"; }
+    if (op == inst.SRLW) { ret "srlw"; }
+    if (op == inst.SRAW) { ret "sraw"; }
+
+    if (op == inst.MUL)    { ret "mul"; }
+    if (op == inst.MULH)   { ret "mulh"; }
+    if (op == inst.MULHSU) { ret "mulhsu"; }
+    if (op == inst.MULHU)  { ret "mulhu"; }
+    if (op == inst.DIV)    { ret "div"; }
+    if (op == inst.DIVU)   { ret "divu"; }
+    if (op == inst.REM)    { ret "rem"; }
+    if (op == inst.REMU)   { ret "remu"; }
+
+    if (op == inst.MULW)  { ret "mulw"; }
+    if (op == inst.DIVW)  { ret "divw"; }
+    if (op == inst.DIVUW) { ret "divuw"; }
+    if (op == inst.REMW)  { ret "remw"; }
+    if (op == inst.REMUW) { ret "remuw"; }
+
+    if (op == inst.ADDI)  { ret "addi"; }
+    if (op == inst.SLTI)  { ret "slti"; }
+    if (op == inst.SLTIU) { ret "sltiu"; }
+    if (op == inst.XORI)  { ret "xori"; }
+    if (op == inst.ORI)   { ret "ori"; }
+    if (op == inst.ANDI)  { ret "andi"; }
+    if (op == inst.SLLI)  { ret "slli"; }
+    if (op == inst.SRLI)  { ret "srli"; }
+    if (op == inst.SRAI)  { ret "srai"; }
+
+    if (op == inst.ADDIW) { ret "addiw"; }
+    if (op == inst.SLLIW) { ret "slliw"; }
+    if (op == inst.SRLIW) { ret "srliw"; }
+    if (op == inst.SRAIW) { ret "sraiw"; }
+
+    if (op == inst.LB)  { ret "lb"; }
+    if (op == inst.LH)  { ret "lh"; }
+    if (op == inst.LW)  { ret "lw"; }
+    if (op == inst.LD)  { ret "ld"; }
+    if (op == inst.LBU) { ret "lbu"; }
+    if (op == inst.LHU) { ret "lhu"; }
+    if (op == inst.LWU) { ret "lwu"; }
+
+    if (op == inst.SB) { ret "sb"; }
+    if (op == inst.SH) { ret "sh"; }
+    if (op == inst.SW) { ret "sw"; }
+    if (op == inst.SD) { ret "sd"; }
+
+    if (op == inst.BEQ)  { ret "beq"; }
+    if (op == inst.BNE)  { ret "bne"; }
+    if (op == inst.BLT)  { ret "blt"; }
+    if (op == inst.BGE)  { ret "bge"; }
+    if (op == inst.BLTU) { ret "bltu"; }
+    if (op == inst.BGEU) { ret "bgeu"; }
+
+    if (op == inst.JAL)  { ret "jal"; }
+    if (op == inst.JALR) { ret "jalr"; }
+
+    if (op == inst.LUI)   { ret "lui"; }
+    if (op == inst.AUIPC) { ret "auipc"; }
+
+    if (op == inst.ECALL)  { ret "ecall"; }
+    if (op == inst.EBREAK) { ret "ebreak"; }
+    if (op == inst.FENCE)  { ret "fence"; }
+    if (op == inst.PAUSE)  { ret "pause"; }
+
+    if (op == inst.FLW) { ret "flw"; }
+    if (op == inst.FLD) { ret "fld"; }
+    if (op == inst.FSW) { ret "fsw"; }
+    if (op == inst.FSD) { ret "fsd"; }
+
+    if (op == inst.FADD_S) { ret "fadd.s"; }
+    if (op == inst.FADD_D) { ret "fadd.d"; }
+    if (op == inst.FSUB_S) { ret "fsub.s"; }
+    if (op == inst.FSUB_D) { ret "fsub.d"; }
+    if (op == inst.FMUL_S) { ret "fmul.s"; }
+    if (op == inst.FMUL_D) { ret "fmul.d"; }
+    if (op == inst.FDIV_S) { ret "fdiv.s"; }
+    if (op == inst.FDIV_D) { ret "fdiv.d"; }
+
+    if (op == inst.FSGNJ_S)  { ret "fsgnj.s"; }
+    if (op == inst.FSGNJ_D)  { ret "fsgnj.d"; }
+    if (op == inst.FSGNJN_S) { ret "fsgnjn.s"; }
+    if (op == inst.FSGNJN_D) { ret "fsgnjn.d"; }
+    if (op == inst.FSGNJX_S) { ret "fsgnjx.s"; }
+    if (op == inst.FSGNJX_D) { ret "fsgnjx.d"; }
+
+    if (op == inst.FEQ_S) { ret "feq.s"; }
+    if (op == inst.FEQ_D) { ret "feq.d"; }
+    if (op == inst.FLT_S) { ret "flt.s"; }
+    if (op == inst.FLT_D) { ret "flt.d"; }
+    if (op == inst.FLE_S) { ret "fle.s"; }
+    if (op == inst.FLE_D) { ret "fle.d"; }
+
+    if (op == inst.FCVT_S_D) { ret "fcvt.s.d"; }
+    if (op == inst.FCVT_D_S) { ret "fcvt.d.s"; }
+
+    if (op == inst.FCVT_W_S)  { ret "fcvt.w.s"; }
+    if (op == inst.FCVT_WU_S) { ret "fcvt.wu.s"; }
+    if (op == inst.FCVT_L_S)  { ret "fcvt.l.s"; }
+    if (op == inst.FCVT_LU_S) { ret "fcvt.lu.s"; }
+    if (op == inst.FCVT_W_D)  { ret "fcvt.w.d"; }
+    if (op == inst.FCVT_WU_D) { ret "fcvt.wu.d"; }
+    if (op == inst.FCVT_L_D)  { ret "fcvt.l.d"; }
+    if (op == inst.FCVT_LU_D) { ret "fcvt.lu.d"; }
+
+    if (op == inst.FCVT_S_W)  { ret "fcvt.s.w"; }
+    if (op == inst.FCVT_S_WU) { ret "fcvt.s.wu"; }
+    if (op == inst.FCVT_S_L)  { ret "fcvt.s.l"; }
+    if (op == inst.FCVT_S_LU) { ret "fcvt.s.lu"; }
+    if (op == inst.FCVT_D_W)  { ret "fcvt.d.w"; }
+    if (op == inst.FCVT_D_WU) { ret "fcvt.d.wu"; }
+    if (op == inst.FCVT_D_L)  { ret "fcvt.d.l"; }
+    if (op == inst.FCVT_D_LU) { ret "fcvt.d.lu"; }
+
+    if (op == inst.FMV_X_W) { ret "fmv.x.w"; }
+    if (op == inst.FMV_X_D) { ret "fmv.x.d"; }
+    if (op == inst.FMV_W_X) { ret "fmv.w.x"; }
+    if (op == inst.FMV_D_X) { ret "fmv.d.x"; }
+
+    if (op == inst.LR_W) { ret "lr.w"; }
+    if (op == inst.LR_D) { ret "lr.d"; }
+    if (op == inst.SC_W) { ret "sc.w"; }
+    if (op == inst.SC_D) { ret "sc.d"; }
+
+    if (op == inst.AMOSWAP_W) { ret "amoswap.w"; }
+    if (op == inst.AMOSWAP_D) { ret "amoswap.d"; }
+    if (op == inst.AMOADD_W)  { ret "amoadd.w"; }
+    if (op == inst.AMOADD_D)  { ret "amoadd.d"; }
+    if (op == inst.AMOXOR_W)  { ret "amoxor.w"; }
+    if (op == inst.AMOXOR_D)  { ret "amoxor.d"; }
+    if (op == inst.AMOAND_W)  { ret "amoand.w"; }
+    if (op == inst.AMOAND_D)  { ret "amoand.d"; }
+    if (op == inst.AMOOR_W)   { ret "amoor.w"; }
+    if (op == inst.AMOOR_D)   { ret "amoor.d"; }
+    if (op == inst.AMOMIN_W)  { ret "amomin.w"; }
+    if (op == inst.AMOMIN_D)  { ret "amomin.d"; }
+    if (op == inst.AMOMAX_W)  { ret "amomax.w"; }
+    if (op == inst.AMOMAX_D)  { ret "amomax.d"; }
+    if (op == inst.AMOMINU_W) { ret "amominu.w"; }
+    if (op == inst.AMOMINU_D) { ret "amominu.d"; }
+    if (op == inst.AMOMAXU_W) { ret "amomaxu.w"; }
+    if (op == inst.AMOMAXU_D) { ret "amomaxu.d"; }
+    ret nil;
+}
+
+# write a string, mapping a format error to the bool/str result shape
+# ---
+# out: destination writer
+# s:   the string to write
+# ret: true on success, or the write error
+fun emit_str(out: *writer.Writer, s: str) R.Result[bool, str] {
+    val res_write: R.Result[usize, str] = format.write_str(out, s);
+    if (R.is_err[usize, str](res_write)) { ret R.err[bool, str](R.unwrap_err[usize, str](res_write)); }
+    ret R.ok[bool, str](true);
+}
+
+# write an unsigned integer
+# ---
+# out: destination writer
+# n:   the value to write
+# ret: true on success, or the write error
+fun emit_u64(out: *writer.Writer, n: u64) R.Result[bool, str] {
+    val res_write: R.Result[usize, str] = format.write_u64(out, n);
+    if (R.is_err[usize, str](res_write)) { ret R.err[bool, str](R.unwrap_err[usize, str](res_write)); }
+    ret R.ok[bool, str](true);
+}
+
+# write a signed integer
+# ---
+# out: destination writer
+# n:   the value to write
+# ret: true on success, or the write error
+fun emit_i64(out: *writer.Writer, n: i64) R.Result[bool, str] {
+    val res_write: R.Result[usize, str] = format.write_i64(out, n);
+    if (R.is_err[usize, str](res_write)) { ret R.err[bool, str](R.unwrap_err[usize, str](res_write)); }
+    ret R.ok[bool, str](true);
+}
+
+# write an interned name, failing when the id does not resolve
+# ---
+# out:      destination writer
+# interner: the interner that resolves the id to text
+# id:       the interned string id to write
+# ret:      true on success, or an error
+fun emit_name(out: *writer.Writer, interner: *intern.Interner, id: intern.StrId) R.Result[bool, str] {
+    val opt_name: O.Option[str] = intern.lookup(interner, id);
+    if (O.is_none[str](opt_name)) {
+        ret R.err[bool, str]("--emit-asm: a symbol name did not resolve in the interner");
+    }
+    ret emit_str(out, O.unwrap[str](opt_name));
+}
+
+# the psABI register mnemonics name each bank's roles, so a rendered operand reads as
+# the assembler spells it and an out-of-range index degrades to a marker rather than
+# an invented name
+test "mach.lang.target.isa.riscv64.printer.names:abi_mnemonics" {
+    if (!str_equals(gp_name(0), "zero"))  { ret 1; }
+    if (!str_equals(gp_name(1), "ra"))    { ret 1; }
+    if (!str_equals(gp_name(2), "sp"))    { ret 1; }
+    if (!str_equals(gp_name(8), "s0"))    { ret 1; }
+    if (!str_equals(gp_name(10), "a0"))   { ret 1; }
+    if (!str_equals(gp_name(5), "t0"))    { ret 1; }
+    if (!str_equals(gp_name(17), "a7"))   { ret 1; }
+    if (!str_equals(gp_name(31), "t6"))   { ret 1; }
+    if (!str_equals(gp_name(99), "x?"))   { ret 1; }
+
+    if (!str_equals(fp_name(0), "ft0"))   { ret 1; }
+    if (!str_equals(fp_name(8), "fs0"))   { ret 1; }
+    if (!str_equals(fp_name(10), "fa0"))  { ret 1; }
+    if (!str_equals(fp_name(31), "ft11")) { ret 1; }
+    if (!str_equals(fp_name(99), "f?"))   { ret 1; }
+    ret 0;
+}
+
+# every concrete instruction the encoder can emit names a real RV64 mnemonic, and an
+# opcode outside the surface names none - a form reaching the encoder unnamed breaks
+# the render rather than printing text no assembler would accept
+test "mach.lang.target.isa.riscv64.printer.mnemonic:opcode_names" {
+    # the RV64 word forms are distinct instructions, not width variants of a name
+    if (!str_equals(mnemonic(inst.ADD), "add"))     { ret 1; }
+    if (!str_equals(mnemonic(inst.ADDW), "addw"))   { ret 1; }
+    if (!str_equals(mnemonic(inst.ADDI), "addi"))   { ret 1; }
+    if (!str_equals(mnemonic(inst.ADDIW), "addiw")) { ret 1; }
+
+    # the forms the old MIR-level printer collapsed into pseudo-mnemonics
+    if (!str_equals(mnemonic(inst.JAL), "jal"))   { ret 1; }
+    if (!str_equals(mnemonic(inst.JALR), "jalr")) { ret 1; }
+    if (!str_equals(mnemonic(inst.BLT), "blt"))   { ret 1; }
+    if (!str_equals(mnemonic(inst.SD), "sd"))     { ret 1; }
+    if (!str_equals(mnemonic(inst.LD), "ld"))     { ret 1; }
+
+    # the float bank spells its precision, and a cross-bank reinterpret its direction
+    if (!str_equals(mnemonic(inst.FADD_D), "fadd.d"))     { ret 1; }
+    if (!str_equals(mnemonic(inst.FSGNJN_S), "fsgnjn.s")) { ret 1; }
+    if (!str_equals(mnemonic(inst.FCVT_W_D), "fcvt.w.d")) { ret 1; }
+    if (!str_equals(mnemonic(inst.FMV_X_W), "fmv.x.w"))   { ret 1; }
+
+    # an atomic names its width; the ordering rides the flags, not the table
+    if (!str_equals(mnemonic(inst.AMOADD_D), "amoadd.d")) { ret 1; }
+    if (!str_equals(mnemonic(inst.LR_W), "lr.w"))         { ret 1; }
+    if (!str_equals(ordering_suffix(inst.FLAG_AQ), ".aq")) { ret 1; }
+    if (!str_equals(ordering_suffix(inst.FLAG_AQ | inst.FLAG_RL), ".aqrl")) { ret 1; }
+    if (!str_equals(ordering_suffix(0), "")) { ret 1; }
+
+    # an opcode outside the surface has no name, so the render fails rather than
+    # inventing one
+    if (mnemonic(inst.MOP_NONE) != nil) { ret 1; }
+    ret 0;
 }

--- a/src/lang/target/isa/riscv64/register.mach
+++ b/src/lang/target/isa/riscv64/register.mach
@@ -25,7 +25,6 @@ use R: std.types.result;
 use mach.lang.target.isa;
 use mach.lang.target.isa.riscv64;
 use mach.lang.target.isa.riscv64.encode;
-use mach.lang.target.isa.riscv64.printer;
 use mach.lang.target.isa.riscv64.rules;
 use mach.lang.target.of;
 use mach.lang.target.of.elf;
@@ -240,7 +239,7 @@ pub fun register_riscv64(reg: *isa.IsaRegistry) R.Result[bool, str] {
     # and target/ cannot depend on be/ - the same split x86_64 and aarch64 use.
     riscv64_vtable.select               = rules.select::*u8;
     riscv64_vtable.encode               = encode.encode_riscv64::*u8;
-    riscv64_vtable.emit_asm             = printer.print_asm_riscv64::*u8;
+    riscv64_vtable.emit_asm             = encode.encode_riscv64_asm::*u8;
     riscv64_vtable.asm_clobbers         = encode.asm_clobbers::*u8;
     riscv64_vtable.is_reg_move          = rules.is_reg_move::*u8;
     riscv64_vtable.reserved_regs        = ?riscv64_reserved_regs[0];


### PR DESCRIPTION
Closes #2193. The riscv64 slice of #2192 / #2212, generalizing the shape #2197 proved on x86-64. Also lands the `Operand.sym_mod` slice of #2214 (aarch64, merged in #2226, carries a target-local one and can migrate onto it).

Merged with `dev` after #2226 landed; verification below is re-run on the merged tree.

## The finding: riscv64 had no machine-instruction surface

`riscv64.ADD` / `MOV` / `JMP` / `RET` are instruction-**selection** tags, deliberately width- and form-independent. `riscv64.MOV` is not an instruction — `mv` is `addi rd, rs, 0`. `riscv64.RET` is not one either — `ret` is `jalr zero, 0(ra)`. A single `ADD` tag becomes `add`, `addw`, `addi` or `addiw` depending on width and operand shape.

So the closest thing riscv64 had to a name for an emitted instruction was the `(major opcode, funct3, funct7)` triple passed to a packer and discarded one layer above the bytes. That is the missing half a shared assembler needs, not scaffolding for a printer, and it is the concrete thing #2213 can write the register-machine contract from.

`isa/riscv64/inst.mach` names them: the RV64I/M/A/FD forms the encoder can actually produce.

## The structure was never lost, only discarded early

`pack_r(opcode, funct3, funct7, rd, rs1, rs2)` receives every field of the word as an argument. Capturing at the packer rather than at `emit_word` means **no RV64 decoder exists anywhere**: `emit_r` / `emit_i` / `emit_s` / `emit_b` / `emit_u` / `emit_j` classify the same arguments that produce the bytes into a concrete instruction and notify. 119 call sites, a mechanical rename.

riscv64 now notifies with the same `isa.Inst` x86-64 does. One representation, three consumers — nothing for a second one to disagree with.

## What did not fit, and what it cost

| x64 assumption | riscv64 need | resolution |
|---|---|---|
| 3 operands | R-type `rd, rs1, rs2` is the widest form | fits |
| composite class-tagged `reg` | float bank must not alias the integer one | fits — `REG_CLASS_ID_XMM`, self-describing |
| `OPK_MEM` base+index+scale+disp | base+disp only | fits, strict subset |
| `OPK_LABEL` block ids | same | fits |
| **no relocation modifier** | `%pcrel_hi` / `%pcrel_lo` on the two halves of every global reference | **`isa.Operand.sym_mod`** (#2214) |
| renders at emit time | branch relaxation rewrites instructions *after* layout | **buffered notifications in the shared sink** |

The two things that stayed riscv64-local are rendering syntax, not representation: a store prints its transferred register before its address, and memory prints `disp(base)` rather than `[base + disp]`.

## Relaxation: the hazard, handled

An over-range conditional becomes an inverted guard plus a `jal`; an over-range `jal` becomes an `auipc`/`jalr` trampoline — **after** the function is laid out. Render at emit time and the `.s` says `blt` where the object holds `bge` + `jal`: #2187 recurring inside its own fix. So notifications buffer, the relax pass edits them exactly as it edits the text, and rendering happens once the layout is final. `insert_text` shifts note offsets alongside the block / fixup / symbol / relocation tables it already shifts — next to the tables they must stay consistent with, not in ISA-private memory a future shift path could forget.

Forced all three paths with a generated 1 MB function — guard, trampoline, and the guard widening from `.+8` to `.+12` on the second pass:

```
  bge a2, a0, .+12                 |    bge  a2, a0, 0x107af4
  auipc t0, %pcrel_hi(.2)          |    auipc t0, 0xffef8
  jalr zero, %pcrel_lo(.2)(t0)     |    jr   0x538(t0)
```

## Before / after

`sum_to`, riscv64 — printed vs the `.o` from the same run:

| before (`.s`) | after (`.s`) | `llvm-objdump` |
|---|---|---|
| `cbr.lt_s a2, a0, .2, .3` | `blt a2, a0, .2` / `jal zero, .3` | `blt` / `j` |
| `add a2, a2, 1` | `addi a2, a2, 1` | `addi` |
| `mv a0, a1` | `addi a0, a1, 0` | `mv` (alias of `addi`) |
| `j .1` (does not exist) | *(absent)* | *(elided)* |
| *(no epilogue)* | `ld ra, 8(sp)` / `ld s0, 0(sp)` / `addi sp, sp, 16` / `jalr zero, 0(ra)` | matches |

**No pseudo-instructions.** The text names what was encoded — `addi a0, zero, 5`, not `li a0, 5` — because a pseudo spelling hides which real instruction, or how many, the encoder chose. That is the property this artifact exists to show.

## Object-vs-asm cross-check (the acceptance criterion)

Printed `.s` vs `llvm-objdump` of the `.o` the same run produced — per-module mnemonic multiset and instruction count, with objdump's pseudo-mnemonics normalized to their base forms.

| corpus | before | after |
|---|---|---|
| riscv64, control-flow + full std | 26/26 diverged, 49,380 / 102,503 | **0 diverged, 102,503 / 102,503** |
| riscv64, `int/surface` + `int/regression`, **debug** | — | **903 modules, 0 diverged, 2,995,196 / 2,995,196** |
| riscv64, same, **release** | — | **903 modules, 0 diverged, 3,938,366 / 3,938,366** |
| riscv64, `vectorize-emit` (own `out` layout, checked separately) | — | 17 modules, 0 diverged, 32,045 / 32,045 |
| riscv64, `freestanding-riscv64` flat image (emits no `.o`) | — | 17 / 17, verified against the wrapped image |
| x86-64 regression check (spine touched) | — | **889 modules, 0 diverged, 1,985,637 / 1,985,637** |
| aarch64 regression check (#2226 runs under the same spine) | — | **872 modules, 0 diverged, 1,858,315 / 1,858,315** |

The checker was validated against x86-64's known-good `0 diverged, 69,976 / 69,976` from #2197 *before* any change, so the instrument was calibrated first.

## Byte identity

Printer-only, proven rather than argued. Baseline is a compiler built from `origin/dev` at the merge point.

| check | result |
|---|---|
| pre/post, riscv64 debug + release | 903 + 903 objects identical, 0 differ |
| pre/post, x86-64 debug + release | 889 + 889 objects identical, 0 differ |
| pre/post, aarch64 debug + release | 872 + 872 objects identical, 0 differ |
| with vs without `--emit-asm`, riscv64 debug + release | 903 + 903 objects identical, 0 differ |

## The guard, and what mutation-testing changed about it

The mutation test **found a real weakness, and the guard is stronger for it.** Dropping exactly one notification did *not* fail the build under byte accounting: `sink_unaccounted` only ever moves `accounted` forward to the buffer length, so a missing notification mid-sequence is absorbed by the next one, and only a miss at the *end* of a MIR opcode is caught.

RISC-V instructions are a fixed four bytes and the encoder notifies once per instruction, so the check can be exact: **emitted bytes must equal four times the instructions notified.** No blind spot — a dropped notification stays one short forever.

Mutation, on the final code:

| state | result |
|---|---|
| one notification dropped, guard **on** | build fails: `--emit-asm: prologue emitted instructions the riscv64 assembly printer did not render` |
| one notification dropped, guard **off** | ships quietly — cross-check catches it: **1 diverged, 102,502 / 102,503** |
| guard restored | 0 diverged, 102,503 / 102,503 |

## Suites and fixpoint

- mach: **814 / 0** — `dev`'s 812 plus the two printer tests deleted in #2197, restored
- mach-std: **611 / 0** at pin `eff1e8e`, confirmed by `git rev-parse HEAD` against `mach.lock`
- three-generation fixpoint seeded by a `dev`-current compiler: **A == B == C**, byte-identical (`30c57f5…`)
- seeded by the 4.2.2 PATH seed, A ≠ B — reproduced identically on **clean `dev`**, so it is `dev`'s codegen having moved past the seed, not this branch

## The `OPC_` prefix is deliberate — do not revert it as scaffolding

It separates the encoding FIELD values from the instructions, whose names overlap them: the RISC-V manual calls both the `JAL` opcode field value and the `jal` instruction by the same name, and after this PR both live in the riscv64 target.

It was *introduced* because the resolver defect in #2223 (found on this branch) made the collision silently miscompile. **That defect is fixed and merged, and the prefix stays anyway** — reviewed and ruled on that basis. The compiler bug made the ambiguity dangerous; the human ambiguity was there first and remains, and #2214 and #2118 will both add more names to the same space. 274 mechanical occurrences inside one file is a cheap price for making a collision that already bit once structurally impossible.

So: it stands on readability, not on necessity, and it is not dead scaffolding left over from a bug that no longer exists.

## Follow-up filed

**#2250 — the byte-accounting guard has a blind spot.** `sink_unaccounted` only moves `accounted` forward to the buffer length, so a dropped notification mid-sequence is absorbed by the next one and only an end-of-opcode miss is caught. Found by mutation-testing this PR's guard; the exact `bytes == 4 × notifications` check here closes it for RISC-V but **does not transfer** — x86-64 is variable-width and aarch64 has multi-word paths.

The artifacts from #2197, #2226 and this PR are not suspect: each was independently verified by an object-vs-asm cross-check at 0 diverged. What the blind spot costs is future protection. The guard-off measurement here (**1 diverged, 102,502 / 102,503**) is the demonstration that the cross-check catches what the guard misses — an argument for keeping both rather than treating either as sufficient.

## Note for #2118

The `classify_*` functions are a **hand-written inverse of a format table that does not exist yet**: they map `(major opcode, funct3, funct7, rs2)` to an opcode, the reverse of what #2118 would build. RV64I/M is a dense 3-key lookup and the A extension is funct5 × width with ordering falling out as flags — both transcribe straight across. **F/D does not:** `funct7` encodes operation *and* precision in bit 0, `funct3` is the rounding mode for arithmetic but the relation for compares and the sign-injection variant for `fsgnj`, and `rs2` is a width *selector* rather than a register in the `fcvt` family. A format table wants those three as explicit per-form fields, not as a uniform key. Budget for it.
