### PR TITLE
fix(lower): resolve a qualified module member in its declaring module

### DIFF
--- a/src/lang/driver/tests.mach
+++ b/src/lang/driver/tests.mach
@@ -5925,3 +5925,301 @@ test "mach.lang.build.engine.execute_warm:sema_phase_diagnostic_fails_build" {
     session.dnit(?s);
     ret bad;
 }
+
+# scaffold `n` modules, build for the linux target, and run sema + lower, so a
+# test can read the lowered IR of a multi-module project. mirrors ut_vec_lower,
+# which is single-file. the caller tears down the project and session
+fun ut_lower_n(s: *session.Session, alloc: *A.Allocator, names: *str, texts: *str, n: u32) R.Result[project.Project, outcome.Fail] {
+    val root_r: R.Result[str, str] = ut_scaffold(alloc, names, texts, n);
+    if (R.is_err[str, str](root_r)) { ret R.err[project.Project, outcome.Fail](outcome.user(R.unwrap_err[str, str](root_r))); }
+    val root: str = R.unwrap_ok[str, str](root_r);
+    val rr: R.Result[bool, str] = driver.setup_registry(?s.registry);
+    if (R.is_err[bool, str](rr)) { fs.remove_all(alloc, root); ret R.err[project.Project, outcome.Fail](outcome.user(R.unwrap_err[bool, str](rr))); }
+    val pr: R.Result[project.Project, outcome.Fail] = driver.build_project(s, root, "linux");
+    fs.remove_all(alloc, root);
+    if (R.is_err[project.Project, outcome.Fail](pr)) { ret pr; }
+    var p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](pr);
+    val se: R.Result[bool, outcome.Fail] = passes.run_sema_pass(?p);
+    if (R.is_err[bool, outcome.Fail](se)) { project.dnit_project(?p); ret R.err[project.Project, outcome.Fail](R.unwrap_err[bool, outcome.Fail](se)); }
+    val le: R.Result[bool, outcome.Fail] = passes.run_lower_pass(?p);
+    if (R.is_err[bool, outcome.Fail](le)) { project.dnit_project(?p); ret R.err[project.Project, outcome.Fail](R.unwrap_err[bool, outcome.Fail](le)); }
+    ret R.ok[project.Project, outcome.Fail](p);
+}
+
+# the lowered IR module of `fqn` in project `p`, or nil when absent
+fun ut_ir_of(p: *project.Project, s: *session.Session, fqn: str) *ir.Module {
+    val mid: session.ModuleId = ut_mid(p, s, fqn);
+    if (mid == session.MODULE_NIL) { ret nil; }
+    ret p.modules[mid::u32].ir_module;
+}
+
+# how many instruction operands in `m` are the integer constant `want`
+#
+# A folded constant reference shows up here; a reference that kept its storage
+# does not, so the count pins both what folded and to which value.
+fun ut_const_uses(m: *ir.Module, want: u64) u32 {
+    ret ut_operand_uses(m, value.VAL_CONST_INT, want);
+}
+
+# how many operands of `m`'s LIVE instructions are of kind `kind` carrying `want`
+# (an integer literal for VAL_CONST_INT, a global index for VAL_GLOBAL)
+#
+# Walks the block lists rather than each function's instruction pool: the pool
+# retains instructions the optimisation passes detached, so a pool scan would
+# count a rewritten operand that no longer reaches the back end
+fun ut_operand_uses(m: *ir.Module, kind: value.ValueKind, want: u64) u32 {
+    if (m == nil) { ret 0; }
+    var hits: u32 = 0;
+    var fi: u32 = 0;
+    for (fi < m.function_len) {
+        val f: *ir.Function = ?m.functions[fi];
+        var bi: u32 = 0;
+        for (bi < f.block_count) {
+            val b: *ir.Block = ?f.blocks[bi];
+            var k: u32 = 0;
+            for (k < b.phi_count) {
+                hits = hits + ut_instr_uses(f, b.phis[k], kind, want);
+                k = k + 1;
+            }
+            k = 0;
+            for (k < b.instr_count) {
+                hits = hits + ut_instr_uses(f, b.instructions[k], kind, want);
+                k = k + 1;
+            }
+            hits = hits + ut_instr_uses(f, b.terminator, kind, want);
+            bi = bi + 1;
+        }
+        fi = fi + 1;
+    }
+    ret hits;
+}
+
+# how many operands of instruction `iid` in `f` are of kind `kind` carrying `want`
+# (INSTR_NIL - a block with no terminator - contributes nothing)
+fun ut_instr_uses(f: *ir.Function, iid: ir.InstructionId, kind: value.ValueKind, want: u64) u32 {
+    val opt_ins: O.Option[*instruction.Instruction] = ir.instruction_get(f, iid);
+    if (O.is_none[*instruction.Instruction](opt_ins)) { ret 0; }
+    val ins: *instruction.Instruction = O.unwrap[*instruction.Instruction](opt_ins);
+    var hits: u32 = 0;
+    var oi: u32 = 0;
+    for (oi < ins.operand_count) {
+        val v: *value.Value = ?ins.operands[oi];
+        if (v.kind == kind) {
+            if (kind == value.VAL_CONST_INT && v.data.int_lit == want)        { hits = hits + 1; }
+            if (kind == value.VAL_GLOBAL && v.data.global_ix::u64 == want)    { hits = hits + 1; }
+        }
+        oi = oi + 1;
+    }
+    ret hits;
+}
+
+# index of `m`'s global whose linkage name contains `needle`, or -1 when none.
+# the needle is a mangled-name fragment (`_M<path>N<len><name>`), so it names the
+# DECLARING module of the referent
+fun ut_global_ix(s: *session.Session, m: *ir.Module, needle: str) i64 {
+    if (m == nil) { ret -1; }
+    var gi: u32 = 0;
+    for (gi < m.global_len) {
+        val nm: O.Option[str] = intern.lookup(?s.interner, (?m.globals[gi]).name);
+        if (O.is_some[str](nm) && ut_str_contains(O.unwrap[str](nm), needle)) { ret gi::i64; }
+        gi = gi + 1;
+    }
+    ret -1;
+}
+
+# how many live instruction operands in `m` name the global at index `gi`
+fun ut_global_uses(m: *ir.Module, gi: u32) u32 {
+    ret ut_operand_uses(m, value.VAL_GLOBAL, gi::u64);
+}
+
+# whether `m` declares a storage-less extern global whose linkage name contains
+# `needle` - the shape a cross-module `val`/`var` reference emits
+fun ut_has_extern_global(s: *session.Session, m: *ir.Module, needle: str) bool {
+    if (m == nil) { ret false; }
+    var gi: u32 = 0;
+    for (gi < m.global_len) {
+        val g: *ir.Global = ?m.globals[gi];
+        if (g.is_extern) {
+            val nm: O.Option[str] = intern.lookup(?s.interner, g.name);
+            if (O.is_some[str](nm) && ut_str_contains(O.unwrap[str](nm), needle)) { ret true; }
+        }
+        gi = gi + 1;
+    }
+    ret false;
+}
+
+# whether `m` declares a signature-only extern function whose linkage name
+# contains `needle` - the shape a cross-module call emits
+fun ut_has_extern_fn(s: *session.Session, m: *ir.Module, needle: str) bool {
+    if (m == nil) { ret false; }
+    var fi: u32 = 0;
+    for (fi < m.function_len) {
+        val f: *ir.Function = ?m.functions[fi];
+        if ((f.flags & ir.FN_FLAG_EXTERN) != 0) {
+            val nm: O.Option[str] = intern.lookup(?s.interner, f.name);
+            if (O.is_some[str](nm) && ut_str_contains(O.unwrap[str](nm), needle)) { ret true; }
+        }
+        fi = fi + 1;
+    }
+    ret false;
+}
+
+# a module-qualified `mod.CONST` folds to the constant its QUALIFIED module
+# declares, never to a file-local `val` of the same leaf name (#2223)
+#
+# main declares `val X = 707` and also reads `a.X` (909). the cross-module const
+# has no global in main's IR, so the mangled-name lookup misses and the reference
+# reaches lowering's comptime-const fold - which read main's own table, keyed by
+# the bare leaf name, and answered 707. silently, and only because the names
+# collide. the fold now reads the DECLARING module's table: 909 appears exactly
+# once (the qualified read) and 707 never appears as an instruction operand (it
+# survives only as main's own global initialiser). the same project pins the two
+# shapes that must not change: the unqualified local `X` still loads main's own
+# global, and a qualified `b.Y` with no colliding name still resolves to b
+test "mach.lang.driver:qualified_const_ignores_local_val_shadow" {
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    val sr: R.Result[session.Session, str] = session.init(?alloc);
+    if (R.is_err[session.Session, str](sr)) { ret 1; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](sr);
+
+    var names: [3]str;
+    names[0] = "main.mach"; names[1] = "a.mach"; names[2] = "b.mach";
+    var texts: [3]str;
+    texts[0] = "use uniontest.a;\nuse uniontest.b;\nval X: i64 = 707;\npub fun p1() i64 { ret a.X; }\npub fun p2() i64 { ret X; }\npub fun p3() i64 { ret b.Y; }\nfun main() i32 { ret 0; }\n";
+    texts[1] = "pub val X: i64 = 909;\n";
+    texts[2] = "pub val Y: i64 = 505;\n";
+
+    val pr: R.Result[project.Project, outcome.Fail] = ut_lower_n(?s, ?alloc, ?names[0], ?texts[0], 3);
+    if (R.is_err[project.Project, outcome.Fail](pr)) { session.dnit(?s); ret 1; }
+    var p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](pr);
+
+    var bad: i32 = 0;
+    val m: *ir.Module = ut_ir_of(?p, ?s, "uniontest.main");
+    if (m == nil) { bad = 1; }
+    or {
+        if (ut_const_uses(m, 909) != 1) { bad = 1; }  # the qualified read folded to a's value
+        if (ut_const_uses(m, 707) != 0) { bad = 1; }  # main's own const never answers for it
+
+        # the unqualified local reference still reads main's own storage.
+        val gx: i64 = ut_global_ix(?s, m, "4mainN1X");
+        if (gx < 0) { bad = 1; }
+        or {
+            if (ut_global_uses(m, gx::u32) == 0)                        { bad = 1; }
+            if ((?m.globals[gx::u32]).init.data.int_lit != 707)         { bad = 1; }
+        }
+
+        # a qualified reference with no colliding name is untouched: it keeps
+        # reading b's storage through a cross-module extern global.
+        if (!ut_has_extern_global(?s, m, "1bN1Y")) { bad = 1; }
+    }
+
+    project.dnit_project(?p);
+    session.dnit(?s);
+    ret bad;
+}
+
+# a module-qualified `mod.CONST` is not answered by a same-named constant this
+# file bare-imported from a DIFFERENT module (#2223)
+#
+# The second shape of the same defect, and it needs no local declaration at all:
+# `use uniontest.a.K;` merges a's K (303) into main's comptime table under the
+# bare leaf name, so the qualified `b.K` (606) folded to 303. the fold reads b's
+# own table now: 606 appears once and 303 never appears as an operand
+test "mach.lang.driver:qualified_const_ignores_leaf_import_shadow" {
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    val sr: R.Result[session.Session, str] = session.init(?alloc);
+    if (R.is_err[session.Session, str](sr)) { ret 1; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](sr);
+
+    var names: [3]str;
+    names[0] = "main.mach"; names[1] = "a.mach"; names[2] = "b.mach";
+    var texts: [3]str;
+    texts[0] = "use uniontest.a.K;\nuse uniontest.b;\npub fun p1() i64 { ret b.K; }\npub fun p2() i64 { ret K; }\nfun main() i32 { ret 0; }\n";
+    texts[1] = "pub val K: i64 = 303;\n";
+    texts[2] = "pub val K: i64 = 606;\n";
+
+    val pr: R.Result[project.Project, outcome.Fail] = ut_lower_n(?s, ?alloc, ?names[0], ?texts[0], 3);
+    if (R.is_err[project.Project, outcome.Fail](pr)) { session.dnit(?s); ret 1; }
+    var p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](pr);
+
+    var bad: i32 = 0;
+    val m: *ir.Module = ut_ir_of(?p, ?s, "uniontest.main");
+    if (m == nil) { bad = 1; }
+    or {
+        if (ut_const_uses(m, 606) != 1) { bad = 1; }  # the qualified read folded to b's value
+        if (ut_const_uses(m, 303) != 1) { bad = 1; }  # a's K answers only its own bare import
+    }
+
+    project.dnit_project(?p);
+    session.dnit(?s);
+    ret bad;
+}
+
+# a qualified member the module does not export is still an error, so keying the
+# constant fold on the declaring module did not turn a missing name into a
+# silent miss (#2223)
+test "mach.lang.driver:qualified_member_unexported_still_errors" {
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    val sr: R.Result[session.Session, str] = session.init(?alloc);
+    if (R.is_err[session.Session, str](sr)) { ret 1; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](sr);
+
+    # main declares its own NOPE, so only the module-scoped lookup can reject it.
+    val pr: R.Result[project.Project, outcome.Fail] = ut_sema2(?s, ?alloc,
+        "use a: uniontest.a;\nval NOPE: i64 = 1;\nfun main() i32 { ret a.NOPE::i32; }\n",
+        "pub val X: i64 = 909;\n");
+    if (R.is_err[project.Project, outcome.Fail](pr)) { session.dnit(?s); ret 1; }
+    var p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](pr);
+
+    var bad: i32 = 0;
+    if (!ut_diag_has(?p.s.diags, "no symbol")) { bad = 1; }
+
+    project.dnit_project(?p);
+    session.dnit(?s);
+    ret bad;
+}
+
+# the declaration kinds that never routed through the constant fold still bind to
+# the qualified module across a name collision (#2223)
+#
+# Only a comptime-foldable module-level `val` reaches lowering's constant fold, so
+# a `fun`, a `var`, a `def` alias and a function-local `val` were never affected -
+# this pins that, so a later change to the lookup cannot break them silently. each
+# reference must name module `a` in its mangled linkage name / folded size, not
+# main's same-named declaration
+test "mach.lang.driver:qualified_member_kinds_unaffected" {
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    val sr: R.Result[session.Session, str] = session.init(?alloc);
+    if (R.is_err[session.Session, str](sr)) { ret 1; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](sr);
+
+    var names: [2]str;
+    names[0] = "main.mach"; names[1] = "a.mach";
+    var texts: [2]str;
+    texts[0] = "use uniontest.a;\ndef T: [9]u8;\nfun f() i64 { ret 101; }\nvar G: i64 = 404;\npub fun p1() i64 { ret a.f(); }\npub fun p2() i64 { ret a.G; }\npub fun p3() u64 { ret $size_of(a.T); }\npub fun p4() i64 { val L: i64 = 808; ret a.L + L; }\nfun main() i32 { ret 0; }\n";
+    texts[1] = "pub def T: [7]u8;\npub fun f() i64 { ret 202; }\npub var G: i64 = 505;\npub val L: i64 = 606;\n";
+
+    val pr: R.Result[project.Project, outcome.Fail] = ut_lower_n(?s, ?alloc, ?names[0], ?texts[0], 2);
+    if (R.is_err[project.Project, outcome.Fail](pr)) { session.dnit(?s); ret 1; }
+    var p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](pr);
+
+    var bad: i32 = 0;
+    val m: *ir.Module = ut_ir_of(?p, ?s, "uniontest.main");
+    if (m == nil) { bad = 1; }
+    or {
+        if (!ut_has_extern_fn(?s, m, "1aN1f"))      { bad = 1; }  # the call crossed to a
+        if (!ut_has_extern_global(?s, m, "1aN1G"))  { bad = 1; }  # the var read crossed to a
+        if (ut_const_uses(m, 7) != 1)               { bad = 1; }  # $size_of(a.T) is a's [7]u8
+        if (ut_const_uses(m, 9) != 0)               { bad = 1; }  # never main's [9]u8
+        if (!ut_has_extern_global(?s, m, "1aN1L"))  { bad = 1; }  # a function-local val never shadows
+        if (ut_const_uses(m, 808) != 1)             { bad = 1; }  # and still initialises its own slot
+    }
+
+    project.dnit_project(?p);
+    session.dnit(?s);
+    ret bad;
+}

--- a/src/lang/me/lower/context.mach
+++ b/src/lang/me/lower/context.mach
@@ -443,6 +443,24 @@ pub fun dnit_context(lc: *LowerContext) {
     lc.pack_ret_type = type.TYPE_NIL;
 }
 
+# the comptime-constant table that DECLARES `sym`
+#
+# A ComptimeCtx is keyed by bare leaf name, so it only answers for the module
+# that owns it: the declaring module's table is the one authority for a
+# reference's folded value (#2223). A symbol declared by the module being
+# lowered reads the ACTIVE context, so an open `$param` / `$each` frame stays
+# visible; anything else reads the declaring module's registered context. Nil
+# when that module registered no context (a build-graph incoherence), which
+# every caller treats as "not a foldable constant".
+# ---
+# lc:  the active lowering context
+# sym: the referenced symbol
+# ret: the ComptimeCtx that declares `sym`, or nil
+pub fun declaring_comptime_ctx(lc: *LowerContext, sym: *resolve.Symbol) *comptime.ComptimeCtx {
+    if (sym.origin == lc.own_module) { ret lc.ctx; }
+    ret (session.module_comptime_ptr(lc.s, sym.origin))::*comptime.ComptimeCtx;
+}
+
 # the `alias.CONST` member resolver lowering installs on every ComptimeCtx it
 # evaluates against (a comptime.ModuleMemberFn)
 #
@@ -476,7 +494,7 @@ pub fun resolve_module_member_const(data: ptr, eid: id.ExprId) R.Result[O.Option
     if (sym.kind != resolve.SYM_IMPORTED) {
         ret R.ok[O.Option[comptime.CTValue], str](O.none[comptime.CTValue]());
     }
-    val octx: *comptime.ComptimeCtx = (session.module_comptime_ptr(lc.s, sym.origin))::*comptime.ComptimeCtx;
+    val octx: *comptime.ComptimeCtx = declaring_comptime_ctx(lc, sym);
     if (octx == nil) { ret R.ok[O.Option[comptime.CTValue], str](O.none[comptime.CTValue]()); }
     val nc: O.Option[*comptime.NamedConst] = comptime.lookup(octx, sym.name);
     if (O.is_none[*comptime.NamedConst](nc)) {

--- a/src/lang/me/lower/expr.mach
+++ b/src/lang/me/lower/expr.mach
@@ -710,12 +710,28 @@ fun symbol_reference(ctx: *context.LowerContext, eid: id.ExprId, sid: resolve.Sy
     }
 
     # a comptime-const val that lives in another module has no global in this
-    # module's IR (its storage was never emitted here). such a constant; e.g.
-    # the stdlib `val true: bool = 1;` imported by name; folds to its value,
-    # read from the module's comptime context where the load walk registered it.
+    # module's IR (its storage was never emitted here), so the mangled-name
+    # lookup above finds nothing and the reference arrives here. such a
+    # constant; e.g. the stdlib `val true: bool = 1;` imported by name; folds to
+    # its value.
+    #
+    # the value comes from the module that DECLARES the referent, never from
+    # this module's same-named entry (#2223): a ComptimeCtx is keyed by bare leaf
+    # name, so reading this module's table answered a qualified `mod.X` with a
+    # file-local `val X` - silently, and only when the names happened to collide.
+    # eligibility is unchanged: the reference folds only when this module's
+    # comptime scope binds the name, which is what a bare `use pkg.mod.CONST;`
+    # merges in. a declaring module that registered no such constant (a
+    # non-foldable `val`) falls through to its storage below.
     val opt_nc: O.Option[*comptime.NamedConst] = comptime.lookup(ctx.ctx, sym.name);
     if (O.is_some[*comptime.NamedConst](opt_nc)) {
-        ret const_value_of(ctx, eid, O.unwrap[*comptime.NamedConst](opt_nc).value);
+        val dctx: *comptime.ComptimeCtx = context.declaring_comptime_ctx(ctx, sym);
+        if (dctx != nil) {
+            val opt_dc: O.Option[*comptime.NamedConst] = comptime.lookup(dctx, sym.name);
+            if (O.is_some[*comptime.NamedConst](opt_dc)) {
+                ret const_value_of(ctx, eid, O.unwrap[*comptime.NamedConst](opt_dc).value);
+            }
+        }
     }
 
     # a runtime global `val`/`var` defined in another module (imach emits one
@@ -1866,13 +1882,10 @@ fun fold_comptime_arg(ctx: *context.LowerContext, eid: id.ExprId) O.Option[compt
     val sym: *resolve.Symbol = O.unwrap[*resolve.Symbol](opt_sym);
     if (sym.kind != resolve.SYM_VAL && sym.kind != resolve.SYM_IMPORTED) { ret O.none[comptime.CTValue](); }
 
-    # the defining module's comptime context holds the folded value under the bare
-    # symbol name. the caller's own context is the same when origin == own module.
-    var dctx: *comptime.ComptimeCtx = ctx.ctx;
-    if (sym.origin != ctx.own_module) {
-        dctx = (session.module_comptime_ptr(ctx.s, sym.origin))::*comptime.ComptimeCtx;
-        if (dctx == nil) { ret O.none[comptime.CTValue](); }
-    }
+    # the declaring module's comptime context holds the folded value under the
+    # bare symbol name.
+    val dctx: *comptime.ComptimeCtx = context.declaring_comptime_ctx(ctx, sym);
+    if (dctx == nil) { ret O.none[comptime.CTValue](); }
     val opt_nc: O.Option[*comptime.NamedConst] = comptime.lookup(dctx, sym.name);
     if (O.is_none[*comptime.NamedConst](opt_nc)) { ret O.none[comptime.CTValue](); }
     ret O.some[comptime.CTValue](O.unwrap[*comptime.NamedConst](opt_nc).value);


### PR DESCRIPTION
Closes #2223.

A module-qualified `mod.CONST` silently read a same-named file-local `val`. The
defect is **not** in the resolver — the resolver is correct — and the sweep the
issue asks for is **clean**.

## Sweep first: CLEAN, and proven sensitive

No victim in mach or mach-std. The compiler is not shipping wrong code from this
defect; it is a latent footgun.

- Scope: 252 files — mach `src/` (160) and `dep/mach-std/src` (92) at pin
  `eff1e8e` (`git rev-parse HEAD` verified against `mach.lock`; mach-std's
  default branch is `dev`, which is *not* the pin).
- Coverage: 3176 `use` lines parsed, **0 unparsed, 0 unresolved**; 1596 `fwd`;
  7469 module-level decls; 1852 module aliases; 1319 leaf-symbol imports.
  Indented `$if`-gated module-level `use`/decls (mach-std's multiplatform shadow
  modules) are included — a first parser pass missed 23 of them and was fixed.
- Result: **0** collisions of the miscompiling shape referenced qualified.

A zero is only worth as much as the detector's sensitivity, so the sweep has a
self-test that injects both victim shapes into the real tree — a local
module-level `val` shadowing `isa.ENDIAN_LITTLE`, and a leaf-imported const
shadowing a qualified `b.K` — and asserts both are reported, plus a
no-collision control that stays silent.

Broad mode (every decl kind, not only the miscompiling one) finds **117** name
collisions that *are* referenced qualified — 110 fun-vs-fun, the rest rec/def.
None miscompile; the name space is simply crowded, which is what makes this
worth closing rather than a curiosity. The one val-export near-miss (mach-std
`types/path.mach` has a local `fun separator()` and references `os.separator`, a
`pub val`) was checked end-to-end: both read `'/'` (47).

## Root cause

`symbol_reference` (`src/lang/me/lower/expr.mach`) folded a constant reference
through the **importing** module's `ComptimeCtx`, which is keyed by the bare
leaf name:

```mach
val opt_nc: O.Option[*comptime.NamedConst] = comptime.lookup(ctx.ctx, sym.name);
```

The mangled-name global lookup directly above it correctly finds nothing — a
cross-module const has no global in this module's IR, its storage was never
emitted here — and **that miss is not the bug**: it is what lets the reference
reach the name-keyed table, where a same-named local answered for it.

The resolver already does its job: `bind_member_qualified` looks the leaf up in
the module's exports and errors when it is not exported. Two other places in the
tree already keyed this lookup correctly on `sym.origin`
(`me/lower/context.mach:resolve_module_member_const`,
`me/lower/expr.mach:fold_comptime_arg`), so the fix converges all three on one
`declaring_comptime_ctx` helper rather than adding a fourth spelling. A symbol
of the module being lowered still reads the active context, so an open `$param`
/ `$each` frame stays visible.

A fourth spelling remains in `fe/sema/context.mach:657`; that directory is owned
by #2170 and was left alone deliberately.

**Why the fallback existed:** to fold cross-module comptime consts that have no
storage in the importing module (`use std.types.bool.true;` and friends, merged
into the importer's table by the load walk). Nothing depends on it answering
with a *local* entry. Fold **eligibility** is deliberately unchanged — a
reference folds only when this module's comptime scope binds the name — so the
fix is correctness-only and the compiler's output is byte-identical. Widening
the fold set (folding every qualified const, which today reads storage) is a
real improvement but an output-changing optimisation with its own questions
(`str` const address identity), and belongs in its own issue.

## Second victim shape (needs no local declaration)

`use a.K;` merges a's `K` (3) into the importer's table under the bare leaf
name, so a qualified `b.K` (5) folded to **3**. Any file that bare-imports a
const by leaf name and also qualifies that same leaf off another module is
exposed. Both shapes are fixed and each has its own test.

## Verification

- **Repro returns 1** (was 2), built and run with the from-source compiler; the
  PATH seed is 4.2.2 and was not used for any check.
- **Tests** (4, one hunk in the shared `tests.mach`, all over the lowered IR):
  the repro shape (which also pins that the unqualified local still loads its
  own global, and that a qualified reference with no collision is untouched);
  the leaf-import shape; a qualified member the module does not export still
  erroring; and the kinds that never routed through the fold — `fun`, `var`,
  `def` alias, function-local `val` — still binding to the qualified module.
- **Mutation 1** — restore the fallback (value read from `ctx.ctx`): **793
  passed, 2 failed, 795 total**; both shape tests fail, independently, and
  nothing else does.
- **Mutation 2** — collapse `declaring_comptime_ctx` to the reference site
  (`ret lc.ctx;`): the compiler does not bootstrap — 15 errors, e.g.
  `global initialiser of MANIFEST must be a constant expression`. The helper is
  load-bearing for all three call sites.
- **Byte-identical output** on `linux-x86_64`, `linux-arm64`, `linux-riscv64`,
  debug **and** release: the same `dev` source tree compiled by the base and
  fixed compilers is identical in all six combinations. Correct, since the
  sweep found no victim.
- **Suites**: mach **795 / 0** (baseline 791 + 4 new). mach-std **611 / 0** at
  pin `eff1e8e`.
- **Three-generation fixpoint**: A == B == C.
