### PR TITLE
refactor(target): split IsaVTable by target family (#2213)

### DIFF
--- a/src/lang/be/codegen.mach
+++ b/src/lang/be/codegen.mach
@@ -134,7 +134,7 @@ pub fun no_debug() DebugInfo {
 # asm_out: optional writer for the per-module assembly text (nil = none)
 # dbg:     the build's settled debug-info decision plus the DWARF CU metadata
 # ret:     the populated object image, or an error string from any pipeline stage
-# the concrete signature the erased `isa.IsaVTable.emit_module` pointer is cast
+# the concrete signature the erased `isa.ModuleEmitter.emit_module` pointer is cast
 # back to: the whole-module SPIR-V back half. consumes post-lower MIR and writes
 # the finished module bytes through the out-params, bypassing isel / regalloc /
 # frame / encode. the allocator and interner ride the MIR module, so the emitter
@@ -160,11 +160,12 @@ pub fun codegen_module(s: *session.Session, tgt: *target.Target,
     }
     var mir_module: mir.MirModule = R.unwrap_ok[mir.MirModule, str](res_lower);
 
-    # spine fork: a target that declares a whole-module emitter (spir-v) bypasses
-    # the machine back half entirely - no isel / regalloc / frame / encode. the
-    # machine path below is byte-identical when emit_module is nil (every register
-    # machine ISA leaves it nil).
-    if (isa.emits_whole_module(tgt.arch)) {
+    # spine fork: a target whose isa carries the whole-module family payload (spir-v)
+    # bypasses the machine back half entirely - no isel / regalloc / frame / encode.
+    # this is also the point past which `tgt.arch` (the register-machine contract) is
+    # guaranteed non-nil: every stage below reads it, and only a register machine
+    # reaches them.
+    if (isa.emits_whole_module(tgt.isa)) {
         # the constant-time enforcement point of this fork (#2159): the emitter is not
         # mach's machine pipeline, so an `#[oblivious]` contract cannot be validated or
         # upheld past it and is refused here rather than silently emitted unchecked.
@@ -247,7 +248,7 @@ fun emit_spirv_image(s: *session.Session, tgt: *target.Target, irmod: *ir.Module
                      mirmod: *mir.MirModule) R.Result[of.ObjectImage, str] {
     var bytes: *u8 = nil;
     var len:   u32 = 0;
-    val r: R.Result[bool, str] = tgt.arch.emit_module::EmitModuleFn(tgt, irmod, mirmod, ?bytes, ?len);
+    val r: R.Result[bool, str] = tgt.isa.emitter.emit_module::EmitModuleFn(tgt, irmod, mirmod, ?bytes, ?len);
     if (R.is_err[bool, str](r)) { ret R.err[of.ObjectImage, str](R.unwrap_err[bool, str](r)); }
 
     val res_image: R.Result[of.ObjectImage, str] = obj.init(s.alloc, ?s.interner, irmod.name);

--- a/src/lang/be/codegen/ctvalidate.mach
+++ b/src/lang/be/codegen/ctvalidate.mach
@@ -134,18 +134,20 @@ use target: mach.lang.target.resolved;
 # m:   the MIR module to validate in place (read-only)
 # ret: ok(true) when every oblivious function is leak-free, or the first violation's error
 pub fun run(tgt: *target.Target, m: *mir.MirModule) R.Result[bool, str] {
-    if (tgt == nil)      { ret R.err[bool, str]("ctvalidate: nil target"); }
-    if (tgt.arch == nil) { ret R.err[bool, str]("ctvalidate: target has no instruction set"); }
-    if (m == nil)        { ret R.err[bool, str]("ctvalidate: nil mir module"); }
+    if (tgt == nil)     { ret R.err[bool, str]("ctvalidate: nil target"); }
+    # the isa, not `tgt.arch`: this pass runs on BOTH sides of the whole-module fork,
+    # and a whole-module emitter legitimately carries no register-machine contract.
+    if (tgt.isa == nil) { ret R.err[bool, str]("ctvalidate: target has no instruction set"); }
+    if (m == nil)       { ret R.err[bool, str]("ctvalidate: nil mir module"); }
 
-    val unverifiable: bool = isa.emits_whole_module(tgt.arch);
+    val unverifiable: bool = isa.emits_whole_module(tgt.isa);
 
     var i: u32 = 0;
     for (i < m.function_len) {
         val f: *mir.MirFunction = ?m.functions[i];
         if (f.oblivious) {
             if (unverifiable) {
-                ret R.err[bool, str](unverifiable_msg(m.alloc, m.interner, f.name, tgt.arch.name));
+                ret R.err[bool, str](unverifiable_msg(m.alloc, m.interner, f.name, tgt.isa.name));
             }
             val res: R.Result[bool, str] = validate_function(tgt, f, m.interner, m.alloc);
             if (R.is_err[bool, str](res)) { ret res; }
@@ -575,12 +577,13 @@ fun t_target(trust_mul: bool, trust_var_shift: bool) target.Target {
     ret t;
 }
 
-# an instruction-set vtable naming a back half: a machine pipeline when `emit_module` is
+# an instruction-set vtable naming a back half: a register machine when `emitter` is
 # nil, a whole-module emitter when it is not (test helper)
-fun t_isa(name: str, emit_module: *u8) isa.IsaVTable {
+fun t_isa(name: str, emitter: *isa.ModuleEmitter) isa.IsaVTable {
     var vt: isa.IsaVTable;
-    vt.name        = name;
-    vt.emit_module = emit_module;
+    vt.name    = name;
+    vt.machine = nil;
+    vt.emitter = emitter;
     ret vt;
 }
 
@@ -867,7 +870,7 @@ test "mach.lang.be.codegen.ctvalidate.scope:non_oblivious_unaffected" {
     page.make(?alloc);
     var t: target.Target = t_target(false, true);
     var vt: isa.IsaVTable = t_isa("machine", nil);
-    t.arch = ?vt;
+    t.isa = ?vt;
 
     var vregs: [1]mir.MirVReg;
     vregs[0] = t_vreg(0, true);   # secret
@@ -925,7 +928,7 @@ test "mach.lang.be.codegen.ctvalidate.opaque:inline_asm_forbidden" {
     page.make(?alloc);
     var t: target.Target = t_target(false, true);
     var vt: isa.IsaVTable = t_isa("machine", nil);
-    t.arch = ?vt;
+    t.isa = ?vt;
 
     var vregs: [1]mir.MirVReg;
     vregs[0] = t_vreg(0, false);
@@ -971,20 +974,21 @@ test "mach.lang.be.codegen.ctvalidate.scope:whole_module_backend_refused" {
 
     # a machine back half validates the body and finds it clean.
     var mvt: isa.IsaVTable = t_isa("machine", nil);
-    t.arch = ?mvt;
+    t.isa = ?mvt;
     if (!R.is_ok[bool, str](run(?t, ?mm_on))) { ret 1; }
 
     # a whole-module emitter refuses the same function outright.
     var hook: u8;
-    var wvt: isa.IsaVTable = t_isa("spirv", ?hook);
-    t.arch = ?wvt;
+    var wem: isa.ModuleEmitter = isa.module_emitter(?hook);
+    var wvt: isa.IsaVTable = t_isa("spirv", ?wem);
+    t.isa = ?wvt;
     if (!R.is_err[bool, str](run(?t, ?mm_on))) { ret 1; }
 
     # without the marker there is no contract to refuse: emitted untouched on both.
     var funcs_off: [1]mir.MirFunction; funcs_off[0] = t_fn(false, ?blocks[0], 1, ?vregs[0], 3);
     var mm_off: mir.MirModule; mm_off.alloc = ?alloc; mm_off.interner = nil; mm_off.functions = ?funcs_off[0]; mm_off.function_len = 1;
     if (!R.is_ok[bool, str](run(?t, ?mm_off))) { ret 1; }
-    t.arch = ?mvt;
+    t.isa = ?mvt;
     if (!R.is_ok[bool, str](run(?t, ?mm_off))) { ret 1; }
     ret 0;
 }

--- a/src/lang/be/codegen/dwarf.mach
+++ b/src/lang/be/codegen/dwarf.mach
@@ -969,7 +969,7 @@ fun sem_to_ir_nominal(s: *session.Session, dtypes: *ir_type.IrTypeTable, tid: se
 # tgt: the resolved target
 # ret: the frame pointer's DWARF register number
 fun frame_base_reg(tgt: *target.Target) i32 {
-    val f: isa.DwarfRegFn = tgt.arch.dwarf_reg::isa.DwarfRegFn;
+    val f: isa.DwarfRegFn = tgt.arch.dwarf_reg;
     ret f(tgt.arch.frame_ptr_reg);
 }
 
@@ -1718,7 +1718,7 @@ fun varloc_home(tgt: *target.Target, vl: *enc.VarLoc, out_kind: *u8, out_reg: *i
     @out_off     = 0;
     @out_storage = false;
     if (vl.kind == enc.VARLOC_REG) {
-        val f: isa.DwarfRegFn = tgt.arch.dwarf_reg::isa.DwarfRegFn;
+        val f: isa.DwarfRegFn = tgt.arch.dwarf_reg;
         val d: i32 = f(vl.reg);
         if (d >= 0) { @out_kind = VLOC_REG; @out_reg = d; }
     } or (vl.kind == enc.VARLOC_FRAME) {
@@ -2482,7 +2482,7 @@ pub fun produce(s: *session.Session, tgt: *target.Target, irmod: *ir.Module,
     val nfuncs: u32 = count_funcs(image, text_sec);
     if (nfuncs == 0) { ret R.ok[bool, str](true); }
 
-    val address_size: u8 = tgt.arch.pointer_width::u8;
+    val address_size: u8 = tgt.isa.pointer_width::u8;
     val itn: *intern.Interner = image.interner;
     val producer: str = resolve(itn, producer_id);
     val comp_dir: str = resolve(itn, comp_dir_id);
@@ -3153,7 +3153,7 @@ fun cmp_sub_home(tgt: *target.Target, sub: u8, raw_reg: i32, raw_off: i64, out_r
     @out_reg = 0;
     @out_off = 0;
     if (sub == enc.VARLOC_REG) {
-        val f: isa.DwarfRegFn = tgt.arch.dwarf_reg::isa.DwarfRegFn;
+        val f: isa.DwarfRegFn = tgt.arch.dwarf_reg;
         val d: i32 = f(raw_reg);
         if (d < 0) { ret VLOC_NONE; }
         @out_reg = d;

--- a/src/lang/be/codegen/encode.mach
+++ b/src/lang/be/codegen/encode.mach
@@ -222,7 +222,7 @@ pub rec SymbolMark {
     flags:  u32;
 }
 
-# the concrete signature the erased `isa.IsaVTable.encode` pointer is cast back to
+# the concrete signature the erased `isa.RegMachine.encode` pointer is cast back to
 # before it is called
 #
 # The vtable stores `encode` type-erased (`*u8`) because its signature names
@@ -283,7 +283,7 @@ pub fun run(tgt: *target.Target, m: *mir.MirModule, asm_out: *writer.Writer) R.R
     ret encode(m.alloc, tgt, m);
 }
 
-# the concrete signature the erased `isa.IsaVTable.emit_asm` pointer is cast back
+# the concrete signature the erased `isa.RegMachine.emit_asm` pointer is cast back
 # to before it is called
 #
 # The vtable stores `emit_asm` type-erased (`*u8`) for the same import-cycle

--- a/src/lang/be/codegen/isel.mach
+++ b/src/lang/be/codegen/isel.mach
@@ -26,7 +26,7 @@ use R: std.types.result;
 use mach.lang.be.codegen.mir;
 use mach.lang.target;
 
-# the concrete signature the erased `isa.IsaVTable.select` pointer is cast back to
+# the concrete signature the erased `isa.RegMachine.select` pointer is cast back to
 # before it is called
 #
 # The vtable stores `select` type-erased (`*u8`) because its signature names

--- a/src/lang/be/codegen/mir/abi.mach
+++ b/src/lang/be/codegen/mir/abi.mach
@@ -53,9 +53,14 @@ val MAX_GP_ARG_REGS: i32 = 16;
 # tgt: the active target
 # ret: ok(true) when the vtable surface is present, or a loud error
 pub fun require_abi(tgt: *target.Target) R.Result[bool, str] {
-    if (tgt == nil)      { ret R.err[bool, str]("mir.lower_ir: nil target"); }
-    if (tgt.abi == nil)  { ret R.err[bool, str]("mir.lower_ir: target has no ABI vtable"); }
-    if (tgt.arch == nil) { ret R.err[bool, str]("mir.lower_ir: target has no ISA vtable"); }
+    if (tgt == nil)     { ret R.err[bool, str]("mir.lower_ir: nil target"); }
+    if (tgt.abi == nil) { ret R.err[bool, str]("mir.lower_ir: target has no ABI vtable"); }
+    # the isa, not `tgt.arch`: MIR lowering runs AHEAD of the whole-module fork, so a
+    # whole-module emitter reaches here carrying no register-machine contract. the
+    # register identities this pass needs come from `tgt.model`, the family-agnostic
+    # description, where a registerless target's -1 is a statement rather than a
+    # sentinel standing in for a contract it does not implement.
+    if (tgt.isa == nil) { ret R.err[bool, str]("mir.lower_ir: target has no ISA vtable"); }
     if (tgt.abi.arg_passing == nil || tgt.abi.ret_passing == nil) {
         ret R.err[bool, str]("mir.lower_ir: ABI vtable exposes no arg/ret classifier");
     }
@@ -1197,7 +1202,7 @@ fun emit_arg_slot(ctx: *context.LowerCtx, mb: *mir.MirBlock, slot: abi.ParamSlot
         val sr: R.Result[bool, str] = spill_vector_to_temp(ctx, mb, argop, size, ?addr);
         if (R.is_err[bool, str](sr)) { ret sr; }
         if (slot.class == abi.CLASS_VEC_STACK_BYREF) {
-            val sp: u32 = ctx.tgt.arch.stack_ptr_reg::u32;
+            val sp: u32 = ctx.tgt.model.stack_ptr_reg::u32;
             ret context.emit_store_to(ctx, mb, mir.op_mem_preg(sp, stack_off), mir.op_vreg(addr));
         }
         ret context.emit_mov(ctx, mb, mir.op_preg(slot.reg::u32), mir.op_vreg(addr));
@@ -1205,7 +1210,7 @@ fun emit_arg_slot(ctx: *context.LowerCtx, mb: *mir.MirBlock, slot: abi.ParamSlot
     if (slot.class == abi.CLASS_STACK_BYREF) {
         # win64 by-reference overflow: store the hidden aggregate pointer into the
         # outgoing stack slot, not a by-value copy of the aggregate bytes.
-        val sp: u32 = ctx.tgt.arch.stack_ptr_reg::u32;
+        val sp: u32 = ctx.tgt.model.stack_ptr_reg::u32;
         var base: u32 = mir.MIR_VREG_NIL;
         val ar: R.Result[bool, str] = context.addr_to_vreg(ctx, mb, argop, ?base);
         if (R.is_err[bool, str](ar)) { ret ar; }
@@ -1213,8 +1218,8 @@ fun emit_arg_slot(ctx: *context.LowerCtx, mb: *mir.MirBlock, slot: abi.ParamSlot
     }
     if (slot.class == abi.CLASS_STACK) {
         # outgoing stack arguments are addressed off the ISA's stack pointer
-        # (x86-64 RSP), named through `tgt.arch.stack_ptr_reg` rather than a literal.
-        val sp: u32 = ctx.tgt.arch.stack_ptr_reg::u32;
+        # (x86-64 RSP), named through `tgt.model.stack_ptr_reg` rather than a literal.
+        val sp: u32 = ctx.tgt.model.stack_ptr_reg::u32;
         if (is_aggr) {
             # the by-value aggregate is copied into the outgoing stack slot from its
             # storage; argop is a pointer to that storage.
@@ -1244,7 +1249,7 @@ fun emit_arg_slot(ctx: *context.LowerCtx, mb: *mir.MirBlock, slot: abi.ParamSlot
         plan.store      = false;
         plan.mem_base   = base;
         plan.mem_slot   = false;
-        plan.stack_base = ctx.tgt.arch.stack_ptr_reg::u32;
+        plan.stack_base = ctx.tgt.model.stack_ptr_reg::u32;
         plan.stack_off  = stack_off;
         plan.stack_ok   = true;
         ret materialize_pieces(ctx, mb, slot, plan);
@@ -1493,11 +1498,11 @@ fun emit_param_slot(ctx: *context.LowerCtx, mb: *mir.MirBlock, slot: abi.ParamSl
         # win64 by-reference overflow: the caller stored the hidden aggregate
         # pointer into this stack slot; load it so `pv` is the aggregate's address,
         # matching the register BYREF parameter form.
-        val fp: u32 = ctx.tgt.arch.frame_ptr_reg::u32;
+        val fp: u32 = ctx.tgt.model.frame_ptr_reg::u32;
         ret context.emit_mov(ctx, mb, mir.op_vreg(pv), mir.op_mem_preg(fp, arg_base + stack_off));
     }
     if (slot.class == abi.CLASS_STACK) {
-        val fp: u32 = ctx.tgt.arch.frame_ptr_reg::u32;
+        val fp: u32 = ctx.tgt.model.frame_ptr_reg::u32;
         if (is_aggr) {
             # the aggregate's bytes already sit in the caller's by-value stack copy;
             # `pv` is its address so reads / the local copy index it directly.
@@ -1521,7 +1526,7 @@ fun emit_param_slot(ctx: *context.LowerCtx, mb: *mir.MirBlock, slot: abi.ParamSl
         plan.store      = true;
         plan.mem_base   = pv;
         plan.mem_slot   = true;
-        plan.stack_base = ctx.tgt.arch.frame_ptr_reg::u32;
+        plan.stack_base = ctx.tgt.model.frame_ptr_reg::u32;
         plan.stack_off  = arg_base + stack_off;
         plan.stack_ok   = true;
         ret materialize_pieces(ctx, mb, slot, plan);

--- a/src/lang/be/codegen/mir/lower.mach
+++ b/src/lang/be/codegen/mir/lower.mach
@@ -1044,7 +1044,7 @@ fun lower_instr(ctx: *lctx.LowerCtx, fn: *ir.Function, mb: *mir.MirBlock, iid: i
     # integer division / remainder needs the dividend / remainder register wiring
     # the active ISA's division form mandates (x86-64 IDIV/DIV reads the dividend
     # in RAX and yields the quotient in RAX / remainder in RDX). the accumulator
-    # and high-half registers come from `tgt.arch.div_reg` / `div_hi_reg`; an ISA
+    # and high-half registers come from `tgt.model.div_reg` / `div_hi_reg`; an ISA
     # whose division wires no fixed register reports -1 and `lower_div` errors
     # loudly rather than emitting an un-pre-colored divide.
     if (inst.kind == instr.OP_DIV_S || inst.kind == instr.OP_DIV_U ||
@@ -1053,7 +1053,7 @@ fun lower_instr(ctx: *lctx.LowerCtx, fn: *ir.Function, mb: *mir.MirBlock, iid: i
     }
 
     # a shift (SHL / SHR_S / SHR_U): an ISA whose variable-shift form hard-wires the
-    # count register (x86-64 CL) pre-colors a runtime count into `tgt.arch.shift_count_reg`;
+    # count register (x86-64 CL) pre-colors a runtime count into `tgt.model.shift_count_reg`;
     # an ISA wiring no fixed shift-count register (-1, e.g. AArch64 LSLV/LSRV/ASRV)
     # passes the count straight through to the three-address register-shift form.
     if (inst.kind == instr.OP_SHL || inst.kind == instr.OP_SHR_S ||
@@ -1242,7 +1242,7 @@ test "mach.lang.be.codegen.mir.lower.ct_gate:mechanism" {
 fun vector_unsupported(ctx: *lctx.LowerCtx) str {
     val prefix:   str = "codegen: 128-bit vectors not yet supported on ";
     val fallback: str = "codegen: 128-bit vectors not yet supported on this target";
-    val arch:     str = ctx.tgt.arch.name;
+    val arch:     str = ctx.tgt.isa.name;
     if (arch == nil) { ret fallback; }
 
     val jr: R.Result[str, str] = str_join(ctx.alloc, prefix, arch);
@@ -1448,7 +1448,7 @@ fun lower_shift(ctx: *lctx.LowerCtx, mb: *mir.MirBlock, inst: *instr.Instruction
         # LSLV/LSRV/ASRV, which read the count from any GP register) passes the count
         # straight through to the three-address register-shift form - mirroring the
         # division's `div_reg < 0` three-address path.
-        val cnt_reg: i32 = ctx.tgt.arch.shift_count_reg;
+        val cnt_reg: i32 = ctx.tgt.model.shift_count_reg;
         if (cnt_reg >= 0) {
             val mc: R.Result[bool, str] = lctx.emit_mov_w(ctx, mb, mir.op_preg(cnt_reg::u32), count, w);
             if (R.is_err[bool, str](mc)) { ret mc; }
@@ -1524,8 +1524,8 @@ fun lower_div(ctx: *lctx.LowerCtx, mb: *mir.MirBlock, inst: *instr.Instruction, 
     # division register (`div_reg < 0` / `div_hi_reg < 0`, e.g. AArch64 SDIV/UDIV)
     # lowers to the generic three-address divide the per-ISA encoder realizes, rather
     # than this pre-coloring path.
-    val acc_reg: i32 = ctx.tgt.arch.div_reg;
-    val hi_reg:  i32 = ctx.tgt.arch.div_hi_reg;
+    val acc_reg: i32 = ctx.tgt.model.div_reg;
+    val hi_reg:  i32 = ctx.tgt.model.div_hi_reg;
     if (acc_reg < 0 || hi_reg < 0) {
         ret lower_div_three_address(ctx, mb, inst, iid, dst);
     }

--- a/src/lang/be/linker.mach
+++ b/src/lang/be/linker.mach
@@ -558,7 +558,7 @@ fun link_modules(s: *session.Session, tgt: *target.Target, modules: *of.ObjectIm
         }
 
         val patch_r: R.Result[bool, str] =
-            patch_relocations(s, ?out_img, modules, module_count, placements, sec_base, merged_to_out, ?sym_locs, ?dyn, ?strm, tgt.arch);
+            patch_relocations(s, ?out_img, modules, module_count, placements, sec_base, merged_to_out, ?sym_locs, ?dyn, ?strm, tgt.isa);
         if (R.is_err[bool, str](patch_r)) {
             free_dynstate(alloc, ?dyn);
             obj.dnit(?out_img);
@@ -884,10 +884,10 @@ fun emit_executable(s: *session.Session, tgt: *target.Target, out_img: *of.Objec
 
     var emit_r: R.Result[bool, str] = R.ok[bool, str](true);
     if (dyn == nil) {
-        emit_r = tgt.of.emit_exec(alloc, ?s.interner, tgt.arch, segs, seg_count, os_page_size(tgt), entry, funcs, func_count, dbg, dbg_count, out_path, name);
+        emit_r = tgt.of.emit_exec(alloc, ?s.interner, tgt.isa, segs, seg_count, os_page_size(tgt), entry, funcs, func_count, dbg, dbg_count, out_path, name);
     }
     or {
-        emit_r = tgt.of.emit_dyn_exec(alloc, ?s.interner, tgt.arch, segs, seg_count, os_page_size(tgt), entry,
+        emit_r = tgt.of.emit_dyn_exec(alloc, ?s.interner, tgt.isa, segs, seg_count, os_page_size(tgt), entry,
                                       funcs, func_count, ?dyn.info, dyn.fixups, dyn.fixup_count, dbg, dbg_count, out_path, name);
     }
 
@@ -960,7 +960,7 @@ fun emit_shared_object(s: *session.Session, tgt: *target.Target, out_img: *of.Ob
     val dbg: *of.Section = R.unwrap_ok[*of.Section, str](dr);
 
     val emit_r: R.Result[bool, str] =
-        tgt.of.emit_shared(alloc, ?s.interner, tgt.arch, segs, seg_count, os_page_size(tgt),
+        tgt.of.emit_shared(alloc, ?s.interner, tgt.isa, segs, seg_count, os_page_size(tgt),
                            exports, export_count, ?dyn.info, dbg, dbg_count, out_path);
 
     if (dbg != nil && dbg_count > 0) { A.deallocate[of.Section](alloc, dbg, dbg_count::usize); }
@@ -3188,7 +3188,7 @@ fun os_base_addr(tgt: *target.Target) u64 {
 # ret: true when the image must be PIE (drives the PIE writer + base-relocation set)
 fun target_requires_pie(tgt: *target.Target) bool {
     if (tgt.os == nil || tgt.os.pie_exec == nil) { ret false; }
-    ret tgt.os.pie_exec(tgt.arch.id);
+    ret tgt.os.pie_exec(tgt.isa.id);
 }
 
 # the page granularity used to align segment virtual addresses, read from the OS
@@ -3198,7 +3198,7 @@ fun target_requires_pie(tgt: *target.Target) bool {
 # tgt: active target - supplies the OS page size and architecture
 # ret: the page granularity for segment alignment
 fun os_page_size(tgt: *target.Target) u64 {
-    if (tgt.os.page_size_for != nil) { ret tgt.os.page_size_for(tgt.arch.id); }
+    if (tgt.os.page_size_for != nil) { ret tgt.os.page_size_for(tgt.isa.id); }
     ret tgt.os.page_size;
 }
 

--- a/src/lang/be/obj.mach
+++ b/src/lang/be/obj.mach
@@ -249,7 +249,7 @@ pub fun rehome_remap(dst_alloc: *A.Allocator, dst_interner: *intern.Interner,
 # serialize the image to disk through the active format's writer
 #
 # Looks up the `OfVTable` carried on `tgt.of` and invokes its `emit_object`
-# writer, passing `tgt.arch` (the ISA vtable) and the output path. This module
+# writer, passing `tgt.isa` (the ISA vtable) and the output path. This module
 # never knows the format-specific byte layout; that lives in the `target/of/`
 # writers. Fails if the target carries no object-format writer.
 # ---
@@ -261,7 +261,7 @@ pub fun emit(o: *of.ObjectImage, tgt: *target.Target, out_path: *u8) R.Result[bo
     if (tgt == nil)                { ret R.err[bool, str]("emit: nil target"); }
     if (tgt.of == nil)             { ret R.err[bool, str]("emit: target has no object-format vtable"); }
     if (tgt.of.emit_object == nil) { ret R.err[bool, str]("emit: object format has no writer"); }
-    ret tgt.of.emit_object(tgt.arch, o, out_path);
+    ret tgt.of.emit_object(tgt.isa, o, out_path);
 }
 
 # grow an exactly-sized array by one slot, allocating it fresh when empty

--- a/src/lang/driver/load.mach
+++ b/src/lang/driver/load.mach
@@ -376,7 +376,7 @@ fun register_module_slot(p: *project.Project, fqn: intern.StrId) R.Result[sessio
     if (request.release(ctx.req)) { build_mode_id = comptime.MODE_RELEASE; }
     var build_pie: u32 = 0;
     if (ctx.req.pie) { build_pie = 1; }
-    m.ctx               = comptime.init(p.alloc, p.target.os_id, p.target.arch_id, p.target.abi_id, build_mode_id, build_pie, p.target.arch.pointer_width, p.compiler_name, p.compiler_ver);
+    m.ctx               = comptime.init(p.alloc, p.target.os_id, p.target.arch_id, p.target.abi_id, build_mode_id, build_pie, p.target.isa.pointer_width, p.compiler_name, p.compiler_ver);
     # feed the manifest-derived `$project.*`/`$bin.*` roots (the selected target's
     # declared tuple lives under `$project.target.*`); the target tuple comes from
     # the selected entry (set before any module loads).

--- a/src/lang/driver/passes.mach
+++ b/src/lang/driver/passes.mach
@@ -1463,7 +1463,7 @@ fun write_build_config(fb: *dq.FpBuf, p: *project.Project) R.Result[bool, str] {
     val a0: R.Result[bool, str] = dq.fp_u32(fb, p.target.os_id);        if (R.is_err[bool, str](a0)) { ret a0; }
     val a1: R.Result[bool, str] = dq.fp_u32(fb, p.target.arch_id);      if (R.is_err[bool, str](a1)) { ret a1; }
     val a2: R.Result[bool, str] = dq.fp_u32(fb, p.target.abi_id);       if (R.is_err[bool, str](a2)) { ret a2; }
-    val a4: R.Result[bool, str] = dq.fp_u32(fb, p.target.arch.pointer_width); if (R.is_err[bool, str](a4)) { ret a4; }
+    val a4: R.Result[bool, str] = dq.fp_u32(fb, p.target.isa.pointer_width); if (R.is_err[bool, str](a4)) { ret a4; }
     val a5: R.Result[bool, str] = dq.fp_u32(fb, p.target_entry.os_name::u32);  if (R.is_err[bool, str](a5)) { ret a5; }
     val a6: R.Result[bool, str] = dq.fp_u32(fb, p.target_entry.isa_name::u32); if (R.is_err[bool, str](a6)) { ret a6; }
     val a7: R.Result[bool, str] = dq.fp_u32(fb, p.target_entry.abi_name::u32); if (R.is_err[bool, str](a7)) { ret a7; }

--- a/src/lang/driver/union.mach
+++ b/src/lang/driver/union.mach
@@ -274,7 +274,7 @@ pub fun populate_union_tuples(p: *project.Project, m: *manifest.Manifest) R.Resu
         } or {
             tuples[fill].os_id         = os_id;
             tuples[fill].arch_id       = arch_id;
-            tuples[fill].pointer_width = R.unwrap_ok[target.Target, str](sr).arch.pointer_width;
+            tuples[fill].pointer_width = R.unwrap_ok[target.Target, str](sr).isa.pointer_width;
             tuples[fill].os_name       = td.os;
             tuples[fill].isa_name      = td.isa;
             tuples[fill].abi_name      = td.abi;

--- a/src/lang/me/ir/type.mach
+++ b/src/lang/me/ir/type.mach
@@ -429,7 +429,7 @@ pub fun intern_fn(t: *IrTypeTable, ret_type: IrTypeId, params: *IrTypeId, param_
 
 # the size in bytes of an IR type for the given target
 #
-# Pointer size comes from `tgt.arch.pointer_width`. Aggregates use natural
+# Pointer size comes from `tgt.isa.pointer_width`. Aggregates use natural
 # C-style layout. A function type sizes as a pointer (a first-class `fun(...)`
 # value is a function pointer) and IRT_VOID is 0. An out-of-range id is a stale
 # handle the verifier's VC_TYPE_RESOLVE rules out, so it panics rather than
@@ -446,7 +446,7 @@ pub fun byte_size(t: *IrTypeTable, id: IrTypeId, tgt: *target.Target) u32 {
     if (ir.kind == IRT_VOID)                        { ret 0; }
     if (ir.kind == IRT_INT || ir.kind == IRT_FLOAT) { ret bits_to_bytes(ir.data.bits); }
     # a first-class `fun(...)` value is a function pointer, so it sizes as one.
-    if (ir.kind == IRT_PTR || ir.kind == IRT_FN) { ret tgt.arch.pointer_width; }
+    if (ir.kind == IRT_PTR || ir.kind == IRT_FN) { ret tgt.isa.pointer_width; }
 
     if (ir.kind == IRT_ARRAY) {
         ret byte_size(t, ir.data.array_.element, tgt) * ir.data.array_.count;
@@ -509,7 +509,7 @@ pub fun byte_align(t: *IrTypeTable, id: IrTypeId, tgt: *target.Target) u32 {
 
     if (ir.kind == IRT_INT || ir.kind == IRT_FLOAT) { ret bits_to_bytes(ir.data.bits); }
     # a function value is a function pointer; align as one.
-    if (ir.kind == IRT_PTR || ir.kind == IRT_FN) { ret tgt.arch.pointer_width; }
+    if (ir.kind == IRT_PTR || ir.kind == IRT_FN) { ret tgt.isa.pointer_width; }
     if (ir.kind == IRT_ARRAY)                    { ret byte_align(t, ir.data.array_.element, tgt); }
     # 128-bit vectors are 16-byte aligned (#1965).
     if (ir.kind == IRT_VECTOR)                   { ret 16; }
@@ -824,7 +824,7 @@ test "mach.lang.me.ir.type.byte_size:struct_i8_i64" {
     var arch: isa.IsaVTable;
     arch.pointer_width = 8;
     var tgt: target.Target;
-    tgt.arch = ?arch;
+    tgt.isa = ?arch;
 
     if (byte_size(?types, stty, ?tgt)      != 16) { dnit(?types); ret 1; }
     if (byte_align(?types, stty, ?tgt)     != 8)  { dnit(?types); ret 1; }
@@ -861,7 +861,7 @@ test "mach.lang.me.ir.type.intern_struct:align_override" {
     var arch: isa.IsaVTable;
     arch.pointer_width = 8;
     var tgt: target.Target;
-    tgt.arch = ?arch;
+    tgt.isa = ?arch;
 
     if (byte_align(?types, natty, ?tgt) != 1)  { dnit(?types); ret 1; }
     if (byte_size(?types, natty, ?tgt)  != 1)  { dnit(?types); ret 1; }
@@ -903,7 +903,7 @@ test "mach.lang.me.ir.type.intern_vector:dedup_size_align" {
     var arch: isa.IsaVTable;
     arch.pointer_width = 8;
     var tgt: target.Target;
-    tgt.arch = ?arch;
+    tgt.isa = ?arch;
 
     if (byte_size(?types, vecty, ?tgt)  != 16) { dnit(?types); ret 1; }
     if (byte_align(?types, vecty, ?tgt) != 16) { dnit(?types); ret 1; }

--- a/src/lang/me/lower/expr.mach
+++ b/src/lang/me/lower/expr.mach
@@ -3204,7 +3204,7 @@ fun ir_type_of_expr(ctx: *context.LowerContext, eid: id.ExprId) R.Result[ir_type
 # ctx: per-module lowering context
 # ret: the pointer-width IR int type, or an error
 fun index_type(ctx: *context.LowerContext) R.Result[ir_type.IrTypeId, str] {
-    ret ir_type.intern_int(?ctx.m.types, ctx.tgt.arch.pointer_width * 8);
+    ret ir_type.intern_int(?ctx.m.types, ctx.tgt.isa.pointer_width * 8);
 }
 
 # widen a runtime gep index to the pointer-width machine-word index type
@@ -3228,7 +3228,7 @@ fun widen_index(ctx: *context.LowerContext, v: value.Value, sem_ty: type.TypeId)
     val res_xty: R.Result[ir_type.IrTypeId, str] = index_type(ctx);
     if (R.is_err[ir_type.IrTypeId, str](res_xty)) { ret R.err[value.Value, str](R.unwrap_err[ir_type.IrTypeId, str](res_xty)); }
     val xty: ir_type.IrTypeId = R.unwrap_ok[ir_type.IrTypeId, str](res_xty);
-    if (scalar_bits(ctx, sem_ty) >= ctx.tgt.arch.pointer_width * 8) { ret R.ok[value.Value, str](v); }
+    if (scalar_bits(ctx, sem_ty) >= ctx.tgt.isa.pointer_width * 8) { ret R.ok[value.Value, str](v); }
     if (is_signed_type(ctx, sem_ty))    { ret builder.emit_sext(?ctx.builder, v, xty); }
     ret builder.emit_zext(?ctx.builder, v, xty);
 }
@@ -3247,7 +3247,7 @@ fun scalar_bits(ctx: *context.LowerContext, tid: type.TypeId) u32 {
     val k: type.TypeKind = O.unwrap[*type.Type](opt_t).kind;
     val d: type.PrimDesc = type.prim_desc(k);
     if (d.class == type.PRIM_CLASS_INT || d.class == type.PRIM_CLASS_FLOAT) { ret d.bits; }
-    if (k == type.TYPE_PTR || k == type.TYPE_POINTER || k == type.TYPE_FUN) { ret ctx.tgt.arch.pointer_width * 8; }
+    if (k == type.TYPE_PTR || k == type.TYPE_POINTER || k == type.TYPE_FUN) { ret ctx.tgt.isa.pointer_width * 8; }
     ret 0;
 }
 

--- a/src/lang/me/pass/scalarize.mach
+++ b/src/lang/me/pass/scalarize.mach
@@ -777,7 +777,7 @@ pub fun run(m: *ir.Module, tgt: *target.Target) R.Result[bool, str] {
     val void_ty: ir_type.IrTypeId = R.unwrap_ok[ir_type.IrTypeId, str](rv);
 
     # gep lane indices are machine-word integers; the pointer width matches the target.
-    val ri: R.Result[ir_type.IrTypeId, str] = ir_type.intern_int(?m.types, tgt.arch.pointer_width * 8);
+    val ri: R.Result[ir_type.IrTypeId, str] = ir_type.intern_int(?m.types, tgt.isa.pointer_width * 8);
     if (R.is_err[ir_type.IrTypeId, str](ri)) { ret R.err[bool, str](R.unwrap_err[ir_type.IrTypeId, str](ri)); }
     val idx_ty: ir_type.IrTypeId = R.unwrap_ok[ir_type.IrTypeId, str](ri);
 

--- a/src/lang/me/pipeline.mach
+++ b/src/lang/me/pipeline.mach
@@ -240,7 +240,7 @@ fun require_msg(m: *ir.Module, tgt: *target.Target, itn: *intern.Interner, site:
 
     val rj: R.Result[str, str] = format.sprint(m.alloc,
         "simd = \"require\": vector {} in '{}' would scalarize on {} (target has no 128-bit SIMD); set simd = \"scalarize\" to build with the scalar expansion",
-        op, fname, tgt.arch.name);
+        op, fname, tgt.isa.name);
     if (R.is_err[str, str](rj)) { ret R.unwrap_err[str, str](rj); }
     ret R.unwrap_ok[str, str](rj);
 }

--- a/src/lang/target.mach
+++ b/src/lang/target.mach
@@ -292,14 +292,17 @@ pub fun select_of(reg: *TargetRegistry, isa_name: str, os_name: str, abi_name: s
 
     var t: resolved.Target;
     t.os      = os_vt;
-    t.arch    = arch_vt;
+    t.isa     = arch_vt;
+    # the register-machine contract, or nil for a whole-module emitter. every stage
+    # that reads it runs after `codegen_module` forks on `isa.emits_whole_module`.
+    t.arch    = arch_vt.machine;
     t.abi     = abi_vt;
     t.of      = of_vt;
 
     # derive the legacy identity ids from the resolved vtables; the ~89 id-readers
     # and the comptime tag space keep reading these unchanged.
     t.os_id   = t.os.id;
-    t.arch_id = t.arch.id;
+    t.arch_id = t.isa.id;
     t.abi_id  = t.abi.id;
     t.of_id   = t.of.id;
 
@@ -326,7 +329,7 @@ pub fun select_of(reg: *TargetRegistry, isa_name: str, os_name: str, abi_name: s
     # assemble the machine model: copy the isa's model template by value, then
     # overlay the selected abi's stack scalars (these vary by convention - sysv vs
     # win64 - so the per-arch template leaves them 0 and select fills them here).
-    val model_tmpl: *isa.MachineModel = t.arch.model;
+    val model_tmpl: *isa.MachineModel = t.isa.model;
     t.model              = @model_tmpl;
     t.model.stack_align  = t.abi.stack_align;
     t.model.red_zone     = t.abi.red_zone;
@@ -566,7 +569,7 @@ test "mach.lang.target.select:linux_aarch64" {
 
     # the ISA vtable resolved and exposes the AArch64 backend entry points.
     if (t.arch == nil)                 { ret 1; }
-    if (t.arch.id != isa.ARCH_AARCH64) { ret 1; }
+    if (t.isa.id != isa.ARCH_AARCH64) { ret 1; }
     if (t.arch.select == nil)          { ret 1; }
     if (t.arch.encode == nil)          { ret 1; }
 
@@ -595,10 +598,10 @@ test "mach.lang.target.select:linux_riscv64" {
 
     # the ISA vtable resolved to the RV64 machine description.
     if (t.arch == nil)                 { ret 1; }
-    if (t.arch.id != isa.ARCH_RISCV64) { ret 1; }
-    if (t.arch.elf_machine != 243)     { ret 1; }  # EM_RISCV
+    if (t.isa.id != isa.ARCH_RISCV64) { ret 1; }
+    if (t.isa.elf_machine != 243)     { ret 1; }  # EM_RISCV
     # the pointer-width fields are in bytes: 8 bytes = 64-bit.
-    if (t.arch.pointer_width != 8)     { ret 1; }
+    if (t.isa.pointer_width != 8)     { ret 1; }
 
     # slice 3 wires the instruction selector alongside the byte encoder, so the
     # riscv64 codegen path both selects and encodes.
@@ -691,7 +694,7 @@ test "mach.lang.target.select:x86_64_freestanding_raw" {
     if (t.abi == nil)             { ret 1; }
     if (t.abi.id != abi.ABI_SYSV) { ret 1; }
     if (t.arch == nil)            { ret 1; }
-    if (t.arch.id != isa.ARCH_X86_64) { ret 1; }
+    if (t.isa.id != isa.ARCH_X86_64) { ret 1; }
 
     ret 0;
 }
@@ -762,7 +765,7 @@ test "mach.lang.target.select_of:freestanding_raw_emits_flat_image" {
 
     # enter at the image base; the raw writer rejects any other entry.
     val em: R.Result[bool, str] =
-        t.of.emit_exec(?alloc, ?itn, t.arch, ?segs[0], 1, t.os.page_size, t.os.base_addr, nil::*of.ExecFunction, 0, nil::*of.Section, 0, tpath::*u8, "selraw"::*u8);
+        t.of.emit_exec(?alloc, ?itn, t.isa, ?segs[0], 1, t.os.page_size, t.os.base_addr, nil::*of.ExecFunction, 0, nil::*of.Section, 0, tpath::*u8, "selraw"::*u8);
     if (R.is_err[bool, str](em)) { fs.temp_close_and_remove(?tf); ret 1; }
 
     val rr: R.Result[Vector[u8], str] = fs.read_bytes(?alloc, tpath);

--- a/src/lang/target/isa.mach
+++ b/src/lang/target/isa.mach
@@ -430,6 +430,23 @@ pub def CvRegFn: fun(i32) i32;
 # (x86-64 IDIV/DIV's RAX:RDX, the variable shift's CL). An ISA whose division /
 # shift forms wire no fixed register reports -1 for those fields - a description,
 # not an unset slot.
+#
+# The four optional capabilities are NOT optional in the same sense, and the
+# distinction is worth keeping straight when judging whether a new target is
+# finished:
+#
+#   cv_reg      genuinely optional. CodeView numbering is Windows-specific, so only
+#               a Windows-capable ISA has one - x86-64 alone today. aarch64 and
+#               riscv64 will never want it unless they target Windows.
+#   emit_asm    optional only because mos6502 has not implemented them yet. every
+#   asm_clobbers  ISA that is finished - x86-64, aarch64, riscv64 - declares all
+#   dwarf_reg     three. their optionality tracks target MATURITY, not a capability
+#               axis, so a new register machine leaving them unset is incomplete
+#               rather than merely different.
+#
+# They are optional rather than required because mos6502 ships without them and a
+# required slot it cannot fill would be a lie. Read a missing one as work not yet
+# done.
 # ---
 # select:               erased fn ptr - perform instruction selection for one
 #                       MirFunction in place (cast back to the arch's `SelectFn`)

--- a/src/lang/target/isa.mach
+++ b/src/lang/target/isa.mach
@@ -339,7 +339,7 @@ pub rec MachineModel {
     ct_trust_var_shift: bool;
 }
 
-# the concrete signature the erased `IsaVTable.asm_clobbers` pointer is cast back to
+# the concrete signature the erased `RegMachine.asm_clobbers` pointer is cast back to
 #
 # Given an inline-asm body's raw text (with `{name}` placeholders still present -
 # they substitute to memory operands, never registers), it sets `gp_out` to the
@@ -354,7 +354,7 @@ pub rec MachineModel {
 # fp_out: receives the vector-register clobber bitmask (index n -> bit n)
 pub def AsmClobbersFn: fun(str, *u32, *u32);
 
-# the concrete signature the erased `IsaVTable.is_reg_move` pointer is cast back to
+# the concrete signature the erased `RegMachine.is_reg_move` pointer is cast back to
 #
 # Given a post-selection concrete opcode, returns true when it is one of this
 # arch's plain full-width register-or-immediate move forms (the concrete opcode a
@@ -368,7 +368,7 @@ pub def AsmClobbersFn: fun(str, *u32, *u32);
 # opcode: the concrete post-selection opcode to classify
 pub def IsRegMoveFn: fun(u32) bool;
 
-# the concrete signature the erased `IsaVTable.dwarf_reg` pointer is cast back to
+# the concrete signature the erased `RegMachine.dwarf_reg` pointer is cast back to
 #
 # Maps a physical encoder register id - a composite `regid` (the class tag in the
 # high byte, the within-bank index in the low byte, as `regid_make` builds) - to
@@ -383,7 +383,7 @@ pub def IsRegMoveFn: fun(u32) bool;
 # regid: the composite physical register id to map
 pub def DwarfRegFn: fun(i32) i32;
 
-# the concrete signature the erased `IsaVTable.cv_reg` pointer is cast back to
+# the concrete signature the erased `RegMachine.cv_reg` pointer is cast back to
 #
 # Maps a physical encoder register id (a composite `regid`, as `DwarfRegFn` takes)
 # to its CodeView register number - the `CV_HREG_e` enumerator a COFF/CodeView
@@ -395,105 +395,52 @@ pub def DwarfRegFn: fun(i32) i32;
 # regid: the composite physical register id to map
 pub def CvRegFn: fun(i32) i32;
 
-# the ISA runtime-dispatch interface
+# the machine-code contract: everything a REGISTER MACHINE owes
 #
-# Exactly one of these exists per architecture; the backend reads pointer width,
-# register classes, and the arch-specific operation entry points through it and
-# never branches on the numeric `id`.
+# One of the two target families. A register machine runs the full machine back
+# half - isel, regalloc, frame, encode - so it owes an instruction selector, a byte
+# encoder, a move classifier, and the register identities those shared stages need
+# but cannot name without target knowledge. A whole-module emitter owes none of it
+# and has no record of this type at all; that is the point of the split. Build one
+# through `reg_machine`, which takes every required slot as a parameter, and add
+# the optional capabilities through the `with_*` setters.
 #
-# `select`, `encode`, and `emit_asm` are the target-specific backend operations.
-# They are stored type-erased (`*u8`) for the same reason the ABI vtable erases
-# its classify/arg/ret pointers and the object-format `WriterFn` takes an
-# `*IsaVTable` rather than the full `Target`: their concrete signatures name
-# `target.Target`, `mir.MirModule`, and the encoder's output / a writer, every
-# one of which imports `isa`. A typed field here would invert that dependency and
-# form an import cycle. Each consumer - the shared `isel.run` / `encode.run`
-# dispatchers, which already import `mir` and `target` - casts the erased pointer
-# back to the concrete `SelectFn` / `EncodeFn` / `EmitAsmFn` signature declared in
-# the per-arch implementation file (e.g. `target/isa/x64`), exactly as `mir` casts
-# `abi.arg_passing` back to `abi.ArgPassingFn`. `emit_asm` is the `--emit-asm`
-# variant of `encode`: it encodes the module AND renders the assembly text from
-# the instructions it emits. An ISA that supplies no printer leaves it nil and
-# `--emit-asm` fails against that architecture rather than emitting an empty file.
+# `select`, `encode`, and `emit_asm` are stored type-erased (`*u8`) for the same
+# reason the ABI vtable erases its classify/arg/ret pointers and the object-format
+# `WriterFn` takes an `*IsaVTable` rather than the full `Target`: their concrete
+# signatures name `target.Target`, `mir.MirModule`, and the encoder's output / a
+# writer, every one of which imports `isa`. A typed field here would invert that
+# dependency and form an import cycle. Each consumer - the shared `isel.run` /
+# `encode.run` dispatchers, which already import `mir` and `target` - casts the
+# erased pointer back to the concrete `SelectFn` / `EncodeFn` / `EmitAsmFn`
+# signature declared in the per-arch implementation file (e.g. `target/isa/x64`),
+# exactly as `mir` casts `abi.arg_passing` back to `abi.ArgPassingFn`. The four
+# slots whose signatures name nothing that imports `isa` - `is_reg_move`,
+# `asm_clobbers`, `dwarf_reg`, `cv_reg` - are typed, so wiring the wrong function
+# into one of them is a type error rather than a runtime crash.
 #
-# `reserved_regs`, `scratch_reg`, `scratch_reg2`, `fp_scratch_reg`,
-# `frame_ptr_reg`, `stack_ptr_reg`, `div_reg`, `div_hi_reg`, and `shift_count_reg`
-# are the arch-specific register identities the shared regalloc, frame, and
-# MIR-lowering passes need but cannot name without target knowledge: the registers
-# that must never be handed to the allocator (the stack and frame pointers), the
-# scratch registers the backend reserves for address materialization, spill
-# reloads, and the two-register-return / varargs lowering sequences, the
-# frame/stack pointers named directly when forming the incoming-parameter and
+# The register identities are the ISA's own, distinct from the ABI vtable's
+# orthogonal arg/return register files and caller/callee-saved partition: the
+# registers that must never be handed to the allocator (the stack and frame
+# pointers), the scratch registers the backend reserves for address
+# materialization, spill reloads, and the two-register-return / varargs lowering
+# sequences, the frame/stack pointers named when forming the incoming-parameter and
 # outgoing-argument stack memory operands, and the fixed accumulator / high-half /
-# shift-count registers the ISA's division and variable-shift instruction forms
-# hard-wire (e.g. x86-64 IDIV/DIV's RAX:RDX and the variable shift's CL). The ABI
-# vtable owns the orthogonal arg/return register files and the
-# caller/callee-saved partition; these are the ISA's own register identities. An
-# ISA whose division / shift forms wire no fixed register (or that is otherwise
-# unimplemented) reports -1 for the div/shift fields.
+# shift-count registers the ISA's division and variable-shift forms hard-wire
+# (x86-64 IDIV/DIV's RAX:RDX, the variable shift's CL). An ISA whose division /
+# shift forms wire no fixed register reports -1 for those fields - a description,
+# not an unset slot.
 # ---
-# id:                   architecture id (one of ARCH_*)
-# name:                 interned architecture name ("x86_64", "aarch64")
-# elf_machine:          the ELF `e_machine` machine type for this arch (an EM_*
-#                       value); the object-format writer reads it to stamp ELF
-#                       headers instead of branching on the arch id
-# pointer_width:        pointer width in bytes
-# reg_classes:          array of register classes
-# reg_class_count:      number of register classes
 # select:               erased fn ptr - perform instruction selection for one
 #                       MirFunction in place (cast back to the arch's `SelectFn`)
 # encode:               erased fn ptr - encode one fully-resolved MirFunction to
 #                       bytes + relocations + symbol marks (cast back to the arch's
 #                       `EncodeFn`); owns prologue/epilogue emission, local-label
 #                       rel32 fixups, and relocation offsets for this ISA
-# emit_asm:             erased fn ptr - encode one fully-resolved MirModule while
-#                       rendering each emitted machine instruction as assembly text
-#                       into a writer (cast back to the arch's `EmitAsmFn`); the
-#                       `--emit-asm` path, nil when the ISA supplies no printer
-# asm_clobbers:         erased fn ptr - infer the GP / vector registers an
-#                       inline-asm body writes (cast back to `AsmClobbersFn`), so
-#                       regalloc avoids leaving a live value in a register a body
-#                       clobbers and the prologue preserves any callee-saved
-#                       register a body writes. nil when the ISA supplies no
-#                       analyzer, which regalloc treats conservatively (every
-#                       register potentially clobbered)
-# is_reg_move:          erased fn ptr - classify a post-selection opcode as one of
-#                       this arch's plain register-move forms (cast back to
-#                       `IsRegMoveFn`), letting the shared regalloc copy-hygiene
-#                       passes recognize a coalescable copy without naming an
-#                       arch opcode. nil when the ISA wires no classifier, which
-#                       disables the copy-hygiene passes for that arch (they no-op)
-# apply_reloc:          erased fn ptr - apply one relocation for this arch (cast
-#                       back to the linker's `ApplyRelocFn`); nil until the
-#                       be-layer linker registrar wires it, and the linker errors
-#                       on a nil slot exactly as it does for an unregistered ISA
-# elf_reloc_type:       erased fn ptr - map an abstract `of.RelocKind` to this
-#                       arch's ELF machine relocation type number (cast back to the
-#                       ELF writer's `ElfRelocTypeFn`); returns 0 (R_*_NONE) for a
-#                       kind the arch has no width-correct ELF type for. the ELF
-#                       object writer reads it instead of branching on the arch id,
-#                       the relocation analogue of `elf_machine`. nil when the ISA
-#                       supplies no ELF relocation mapping, which the writer reports
-#                       as unsupported exactly as a nil `apply_reloc`
-# elf_attributes:       erased fn ptr - return this arch's ELF build-attributes
-#                       descriptor (cast back to the ELF writer's
-#                       `ElfAttributesFn`), or nil for an arch that emits none. the
-#                       ELF writer reads it to stamp a `.riscv.attributes`-style
-#                       ISA-string section into objects and executables so external
-#                       tools decode the full instruction set; nil leaves the
-#                       section absent, the same way a nil `elf_reloc_type` is no map
-# dwarf_reg:            erased fn ptr - map a physical register id to its DWARF
-#                       register number (cast back to `DwarfRegFn`), the
-#                       ISA-specific numbering the `DW_OP_reg*` / `DW_OP_breg*`
-#                       variable locations use; the frame register's DWARF number,
-#                       which `DW_AT_frame_base` / `DW_OP_fbreg` need, is
-#                       `dwarf_reg(frame_ptr_reg)`. nil when the ISA wires no DWARF
-#                       register table, which a debug-info producer treats as an
-#                       ISA with no location support
-# cv_reg:               erased fn ptr - map a physical register id to its CodeView
-#                       register number (cast back to `CvRegFn`); nil for an ISA
-#                       with no CodeView numbering (only the Windows-capable x86-64
-#                       wires it), the CodeView analogue of a nil `elf_reloc_type`
+# is_reg_move:          classify a post-selection opcode as one of this arch's
+#                       plain register-move forms, letting the shared regalloc
+#                       copy-hygiene passes recognize a coalescable copy without
+#                       naming an arch opcode
 # reserved_regs:        registers the allocator must never assign (stack/frame
 #                       pointers); owned by the per-arch impl for the process
 #                       lifetime
@@ -509,7 +456,8 @@ pub def CvRegFn: fun(i32) i32;
 # reload_scratch_count: number of reload-scratch registers
 # scratch_reg:          primary GP scratch register reserved by the backend
 # scratch_reg2:         secondary GP scratch register reserved by the backend
-# fp_scratch_reg:       FP/vector scratch register reserved by the backend
+# fp_scratch_reg:       FP/vector scratch register reserved by the backend, or -1
+#                       on an ISA with no float bank
 # frame_ptr_reg:        frame-pointer register id; the base of incoming
 #                       stack-parameter memory operands (`[fp + ...]`)
 # stack_ptr_reg:        stack-pointer register id; the base of outgoing
@@ -518,39 +466,40 @@ pub def CvRegFn: fun(i32) i32;
 #                       stack argument - the frame fact the prologue establishes
 #                       (x86-64 `push rbp; mov rbp, rsp` puts the saved frame
 #                       pointer at `[fp+0]` and the return address at `[fp+8]`, so
-#                       incoming stack args start at `[fp+16]`). the generic
-#                       parameter / variadic lowering reads it instead of a bare
-#                       literal so an arch with a different frame record does not
-#                       require hunting magic offsets
+#                       incoming stack args start at `[fp+16]`)
 # div_reg:              register the integer division form hard-wires as the
 #                       dividend / quotient accumulator (x86-64 RAX), or -1
 # div_hi_reg:           register the integer division form hard-wires for the
 #                       dividend high half / remainder (x86-64 RDX), or -1
 # shift_count_reg:      register a variable shift's runtime count must occupy
 #                       (x86-64 RCX, used as CL), or -1
-# model:                borrowed per-arch `MachineModel` template (widths, register
-#                       file, addressing capability, frame model); `target.select`
-#                       copies it by value and overlays the abi's stack scalars. the
-#                       data here duplicates the per-arch model until the stages are
-#                       rewired to read the model (issue #1600 group B)
-pub rec IsaVTable {
-    id:                   u32;
-    name:                 str;
-    elf_machine:          u32;
-    pointer_width:        u32;
-    reg_classes:          *RegClass;
-    reg_class_count:      u32;
+# emit_asm:             OPTIONAL capability - erased fn ptr, the `--emit-asm`
+#                       variant of `encode`: encode one fully-resolved MirModule
+#                       while rendering each emitted machine instruction as
+#                       assembly text into a writer (cast back to the arch's
+#                       `EmitAsmFn`). nil when the ISA supplies no printer, and
+#                       `--emit-asm` fails against it rather than emitting an
+#                       empty file
+# asm_clobbers:         OPTIONAL capability - infer the GP / vector registers an
+#                       inline-asm body writes, so regalloc avoids leaving a live
+#                       value in a register a body clobbers and the prologue
+#                       preserves any callee-saved register a body writes. nil when
+#                       the ISA supplies no analyzer, which regalloc treats
+#                       conservatively (every register potentially clobbered)
+# dwarf_reg:            OPTIONAL capability - map a physical register id to its
+#                       DWARF register number, the ISA-specific numbering the
+#                       `DW_OP_reg*` / `DW_OP_breg*` variable locations use; the
+#                       frame register's DWARF number, which `DW_AT_frame_base` /
+#                       `DW_OP_fbreg` need, is `dwarf_reg(frame_ptr_reg)`. nil when
+#                       the ISA wires no DWARF register table, which a debug-info
+#                       producer treats as an ISA with no location support
+# cv_reg:               OPTIONAL capability - map a physical register id to its
+#                       CodeView register number; nil for an ISA with no CodeView
+#                       numbering (only the Windows-capable x86-64 wires it)
+pub rec RegMachine {
     select:               *u8;
     encode:               *u8;
-    emit_asm:             *u8;
-    asm_clobbers:         *u8;
-    is_reg_move:          *u8;
-    emit_module:          *u8;
-    apply_reloc:          *u8;
-    elf_reloc_type:       *u8;
-    elf_attributes:       *u8;
-    dwarf_reg:            *u8;
-    cv_reg:               *u8;
+    is_reg_move:          IsRegMoveFn;
     reserved_regs:        *Register;
     reserved_reg_count:   i32;
     reload_scratch_regs:  *Register;
@@ -564,7 +513,304 @@ pub rec IsaVTable {
     div_reg:              i32;
     div_hi_reg:           i32;
     shift_count_reg:      i32;
-    model:                *MachineModel;
+
+    emit_asm:     *u8;
+    asm_clobbers: AsmClobbersFn;
+    dwarf_reg:    DwarfRegFn;
+    cv_reg:       CvRegFn;
+}
+
+# the whole-module contract: everything a WHOLE-MODULE EMITTER owes
+#
+# The other target family, and it owes exactly one thing. A whole-module emitter
+# (SPIR-V) consumes the lowered MIR and produces the finished module bytes itself,
+# so isel / regalloc / frame / encode never run and there is no linear instruction
+# stream, no register file to allocate, and no frame to lay out. It has no
+# `RegMachine`, which is why none of those slots exist to be left nil.
+# ---
+# emit_module: erased fn ptr - consume the post-lower MIR module and produce the
+#              finished module image (cast back to `codegen.EmitModuleFn`). erased
+#              for the same import-cycle reason as `select` / `encode`
+pub rec ModuleEmitter {
+    emit_module: *u8;
+}
+
+# the ISA runtime-dispatch interface
+#
+# Exactly one of these exists per architecture. It carries what BOTH families have
+# - the ISA's identity, its machine description, and the object-format seam - plus
+# exactly one family payload: `machine` for a register machine, `emitter` for a
+# whole-module emitter, never both and never neither. That pointer pair is the
+# type-level form of the back-half fork; `emits_whole_module` reads it.
+#
+# `apply_reloc`, `elf_reloc_type`, and `elf_attributes` stay here rather than on
+# `RegMachine` because they are conditioned on the OBJECT FORMAT, not the family: a
+# register machine emitting a raw flat image (mos6502) has none of them, and they
+# are handed the `IsaVTable` by writers that never see a family payload.
+# `apply_reloc` is additionally late-bound - `be.linker.register_reloc_hooks`
+# patches it on after registration - so a target cannot supply it at construction.
+# ---
+# id:              architecture id (one of ARCH_*)
+# name:            interned architecture name ("x86_64", "aarch64")
+# elf_machine:     the ELF `e_machine` machine type for this arch (an EM_* value);
+#                  the object-format writer reads it to stamp ELF headers instead
+#                  of branching on the arch id. 0 for an arch with no ELF mapping
+# pointer_width:   pointer width in bytes
+# reg_classes:     array of register classes
+# reg_class_count: number of register classes
+# apply_reloc:     erased fn ptr - apply one relocation for this arch (cast back to
+#                  the linker's `ApplyRelocFn`); nil until the be-layer linker
+#                  registrar wires it, and the linker errors on a nil slot exactly
+#                  as it does for an unregistered ISA
+# elf_reloc_type:  erased fn ptr - map an abstract `of.RelocKind` to this arch's ELF
+#                  machine relocation type number (cast back to the ELF writer's
+#                  `ElfRelocTypeFn`); returns 0 (R_*_NONE) for a kind the arch has
+#                  no width-correct ELF type for. the ELF object writer reads it
+#                  instead of branching on the arch id, the relocation analogue of
+#                  `elf_machine`. nil when the ISA supplies no ELF relocation
+#                  mapping, which the writer reports as unsupported
+# elf_attributes:  erased fn ptr - return this arch's ELF build-attributes
+#                  descriptor (cast back to the ELF writer's `ElfAttributesFn`), or
+#                  nil for an arch that emits none. the ELF writer reads it to stamp
+#                  a `.riscv.attributes`-style ISA-string section so external tools
+#                  decode the full instruction set
+# machine:         the register-machine contract, or nil when this ISA is a
+#                  whole-module emitter
+# emitter:         the whole-module contract, or nil when this ISA is a register
+#                  machine
+# model:           borrowed per-arch `MachineModel` template (widths, register file,
+#                  addressing capability, frame model); `target.select` copies it by
+#                  value and overlays the abi's stack scalars. this is the
+#                  family-agnostic DESCRIPTION every shared pre-fork stage reads, so
+#                  a registerless target describes itself honestly (-1 register ids)
+#                  instead of satisfying a machine contract with sentinels
+pub rec IsaVTable {
+    id:              u32;
+    name:            str;
+    elf_machine:     u32;
+    pointer_width:   u32;
+    reg_classes:     *RegClass;
+    reg_class_count: u32;
+    apply_reloc:     *u8;
+    elf_reloc_type:  *u8;
+    elf_attributes:  *u8;
+    machine:         *RegMachine;
+    emitter:         *ModuleEmitter;
+    model:           *MachineModel;
+}
+
+# build the register-machine contract, every required slot supplied
+#
+# The completeness mechanism for this family. mach cannot express a non-nil
+# function pointer, and a record literal is not a completeness check either - sema
+# validates only that the names a literal DOES spell exist. Taking each required
+# slot as a positional parameter is what mach can enforce: a target that omits one
+# is an arity error at build time, so the failure moves off the runtime path. It
+# guards FORGETTING a slot, not lying about one - a target may still pass nil
+# deliberately, which is what an ISA with no fixed division register does when it
+# passes -1.
+#
+# The four optional capabilities are cleared here and added afterwards through the
+# `with_*` setters, so an ISA that wires none of them still leaves no field reading
+# stack garbage (`var` does not zero).
+# ---
+# select:               instruction selector, erased (the arch's `SelectFn`)
+# encode:               byte encoder, erased (the arch's `EncodeFn`)
+# is_reg_move:          plain-register-move opcode classifier
+# reserved_regs:        registers the allocator must never assign
+# reserved_reg_count:   number of reserved registers
+# reload_scratch_regs:  the spill-reload temporary pool
+# reload_scratch_count: number of reload-scratch registers
+# scratch_reg:          primary GP scratch register
+# scratch_reg2:         secondary GP scratch register
+# fp_scratch_reg:       FP/vector scratch register, or -1 with no float bank
+# frame_ptr_reg:        frame-pointer register id
+# stack_ptr_reg:        stack-pointer register id
+# incoming_arg_base:    frame-pointer offset of the first incoming stack argument
+# div_reg:              division dividend / quotient register, or -1
+# div_hi_reg:           division high-half / remainder register, or -1
+# shift_count_reg:      variable-shift count register, or -1
+# ret:                  the contract, with every optional capability unset
+pub fun reg_machine(select: *u8, encode: *u8, is_reg_move: IsRegMoveFn,
+                    reserved_regs: *Register, reserved_reg_count: i32,
+                    reload_scratch_regs: *Register, reload_scratch_count: i32,
+                    scratch_reg: i32, scratch_reg2: i32, fp_scratch_reg: i32,
+                    frame_ptr_reg: i32, stack_ptr_reg: i32, incoming_arg_base: i64,
+                    div_reg: i32, div_hi_reg: i32, shift_count_reg: i32) RegMachine {
+    var m: RegMachine;
+    m.select               = select;
+    m.encode               = encode;
+    m.is_reg_move          = is_reg_move;
+    m.reserved_regs        = reserved_regs;
+    m.reserved_reg_count   = reserved_reg_count;
+    m.reload_scratch_regs  = reload_scratch_regs;
+    m.reload_scratch_count = reload_scratch_count;
+    m.scratch_reg          = scratch_reg;
+    m.scratch_reg2         = scratch_reg2;
+    m.fp_scratch_reg       = fp_scratch_reg;
+    m.frame_ptr_reg        = frame_ptr_reg;
+    m.stack_ptr_reg        = stack_ptr_reg;
+    m.incoming_arg_base    = incoming_arg_base;
+    m.div_reg              = div_reg;
+    m.div_hi_reg           = div_hi_reg;
+    m.shift_count_reg      = shift_count_reg;
+
+    m.emit_asm     = nil;
+    m.asm_clobbers = nil;
+    m.dwarf_reg    = nil;
+    m.cv_reg       = nil;
+    ret m;
+}
+
+# declare the optional assembly printer
+#
+# Without it `--emit-asm` fails against this architecture rather than emitting an
+# empty file.
+# ---
+# m:        the register-machine contract to extend
+# emit_asm: the printer, erased (the arch's `EmitAsmFn`)
+pub fun with_asm_printer(m: *RegMachine, emit_asm: *u8) {
+    m.emit_asm = emit_asm;
+}
+
+# declare the optional inline-asm clobber analyzer
+#
+# Without it regalloc treats every inline-asm body as clobbering every register.
+# ---
+# m: the register-machine contract to extend
+# f: the clobber analyzer
+pub fun with_asm_clobbers(m: *RegMachine, f: AsmClobbersFn) {
+    m.asm_clobbers = f;
+}
+
+# declare the optional DWARF register numbering
+#
+# Without it a debug-info producer treats this ISA as having no location support.
+# ---
+# m: the register-machine contract to extend
+# f: the DWARF register map
+pub fun with_dwarf_regs(m: *RegMachine, f: DwarfRegFn) {
+    m.dwarf_reg = f;
+}
+
+# declare the optional CodeView register numbering
+#
+# Only a Windows-capable ISA needs one.
+# ---
+# m: the register-machine contract to extend
+# f: the CodeView register map
+pub fun with_codeview_regs(m: *RegMachine, f: CvRegFn) {
+    m.cv_reg = f;
+}
+
+# build the whole-module contract
+#
+# The family owes one slot, so the constructor takes one parameter.
+# ---
+# emit_module: the whole-module emitter, erased (`codegen.EmitModuleFn`)
+# ret:         the contract
+pub fun module_emitter(emit_module: *u8) ModuleEmitter {
+    var e: ModuleEmitter;
+    e.emit_module = emit_module;
+    ret e;
+}
+
+# compose an ISA vtable for a REGISTER MACHINE
+#
+# Binds the machine contract and leaves `emitter` nil, so the family is settled by
+# construction and `emits_whole_module` reports false. The object-format seam is
+# cleared; an ELF-capable arch adds it through `with_elf` and the linker registrar
+# patches `apply_reloc` on later.
+# ---
+# id:              architecture id (one of ARCH_*)
+# name:            interned architecture name
+# elf_machine:     ELF `e_machine` value, or 0 for an arch with no ELF mapping
+# pointer_width:   pointer width in bytes
+# reg_classes:     array of register classes
+# reg_class_count: number of register classes
+# model:           borrowed per-arch machine-model template
+# machine:         borrowed register-machine contract
+# ret:             the composed vtable
+pub fun machine_isa(id: u32, name: str, elf_machine: u32, pointer_width: u32,
+                    reg_classes: *RegClass, reg_class_count: u32,
+                    model: *MachineModel, machine: *RegMachine) IsaVTable {
+    var vt: IsaVTable = isa_common(id, name, elf_machine, pointer_width,
+                                   reg_classes, reg_class_count, model);
+    vt.machine = machine;
+    vt.emitter = nil;
+    ret vt;
+}
+
+# compose an ISA vtable for a WHOLE-MODULE EMITTER
+#
+# Binds the emitter contract and leaves `machine` nil, so no machine-code slot
+# exists to be left unset and `emits_whole_module` reports true. There is no
+# `elf_machine` parameter: a whole-module image is not an ELF object.
+# ---
+# id:              architecture id (one of ARCH_*)
+# name:            interned architecture name
+# pointer_width:   pointer width in bytes
+# reg_classes:     array of nominal register classes the shared MIR lowering
+#                  classes values against; never allocated
+# reg_class_count: number of register classes
+# model:           borrowed per-arch machine-model template
+# emitter:         borrowed whole-module contract
+# ret:             the composed vtable
+pub fun emitter_isa(id: u32, name: str, pointer_width: u32,
+                    reg_classes: *RegClass, reg_class_count: u32,
+                    model: *MachineModel, emitter: *ModuleEmitter) IsaVTable {
+    var vt: IsaVTable = isa_common(id, name, 0, pointer_width,
+                                   reg_classes, reg_class_count, model);
+    vt.machine = nil;
+    vt.emitter = emitter;
+    ret vt;
+}
+
+# declare the optional ELF object-format seam
+#
+# Conditioned on the object format, not the family: an arch emitting a raw flat
+# image declares neither, and the ELF writer reports a missing map as unsupported.
+# ---
+# vt:             the vtable to extend
+# elf_reloc_type: the abstract-kind to ELF-type map (the writer's `ElfRelocTypeFn`)
+# elf_attributes: the build-attributes descriptor source, or nil for none
+pub fun with_elf(vt: *IsaVTable, elf_reloc_type: *u8, elf_attributes: *u8) {
+    vt.elf_reloc_type = elf_reloc_type;
+    vt.elf_attributes = elf_attributes;
+}
+
+# the family-agnostic half of a composed vtable: identity, description, and a
+# cleared object-format seam
+#
+# Shared by `machine_isa` and `emitter_isa` so neither can forget to clear a slot
+# the other fills - `var` does not zero, so an unwritten field reads stack garbage.
+# ---
+# id:              architecture id
+# name:            interned architecture name
+# elf_machine:     ELF `e_machine` value, 0 for none
+# pointer_width:   pointer width in bytes
+# reg_classes:     array of register classes
+# reg_class_count: number of register classes
+# model:           borrowed machine-model template
+# ret:             a vtable with both family payloads still nil
+fun isa_common(id: u32, name: str, elf_machine: u32, pointer_width: u32,
+               reg_classes: *RegClass, reg_class_count: u32,
+               model: *MachineModel) IsaVTable {
+    var vt: IsaVTable;
+    vt.id              = id;
+    vt.name            = name;
+    vt.elf_machine     = elf_machine;
+    vt.pointer_width   = pointer_width;
+    vt.reg_classes     = reg_classes;
+    vt.reg_class_count = reg_class_count;
+    vt.model           = model;
+
+    vt.apply_reloc    = nil;
+    vt.elf_reloc_type = nil;
+    vt.elf_attributes = nil;
+    vt.machine        = nil;
+    vt.emitter        = nil;
+    ret vt;
 }
 
 # maximum number of ISA implementations an IsaRegistry holds
@@ -845,33 +1091,36 @@ pub fun registered(reg: *IsaRegistry, idx: u32) O.Option[*IsaVTable] {
     ret O.some[*IsaVTable](reg.entries[idx]);
 }
 
-# whether instruction set `vt` has a wired code generator: both an instruction
-# selector and a byte encoder
+# whether instruction set `vt` has a wired code generator
 #
-# A description-only ISA (registered so composition reports it, but not yet
-# emitting) reports false, so `target.select_of` and `mach info targets` treat it
-# as not-yet-supported instead of composing a target that dies deep in codegen.
+# True once the ISA has bound a family payload: a register machine with a selector
+# and an encoder, or a whole-module emitter. A description-only ISA (registered so
+# composition reports it, but not yet emitting) has neither and reports false, so
+# `target.select_of` and `mach info targets` treat it as not-yet-supported instead
+# of composing a target that dies deep in codegen.
 # ---
 # vt:  the instruction-set vtable to test
-# ret: true when both the selector and encoder entry points are wired
+# ret: true when the ISA's back half is wired
 pub fun has_codegen(vt: *IsaVTable) bool {
-    ret (vt.select != nil && vt.encode != nil) || vt.emit_module != nil;
+    if (vt.machine != nil) { ret vt.machine.select != nil && vt.machine.encode != nil; }
+    ret vt.emitter != nil;
 }
 
 # whether instruction set `vt` emits a whole MODULE image instead of machine code
 #
-# The named form of the back-half fork: a vtable wiring `emit_module` (SPIR-V) consumes
-# the lowered MIR and produces the finished module bytes itself, so isel / regalloc /
-# frame / encode never run and mach does not emit the instruction stream that ultimately
-# executes - a downstream consumer compiles the module the rest of the way. Every register
-# machine leaves the hook nil and reports false. `codegen_module` forks the pipeline on
-# this, and `ctvalidate` refuses to certify a constant-time contract for it: the two read
-# one predicate so the enforcement can never drift from the fork.
+# The named form of the back-half fork, now a family test rather than a predicate over
+# a shared record: an ISA carrying the `emitter` payload (SPIR-V) consumes the lowered
+# MIR and produces the finished module bytes itself, so isel / regalloc / frame / encode
+# never run and mach does not emit the instruction stream that ultimately executes - a
+# downstream consumer compiles the module the rest of the way. A register machine carries
+# `machine` instead and reports false. `codegen_module` forks the pipeline on this, and
+# `ctvalidate` refuses to certify a constant-time contract for it: the two read one
+# predicate so the enforcement can never drift from the fork.
 # ---
 # vt:  the instruction-set vtable to test
 # ret: true when the ISA's back half is a whole-module emitter
 pub fun emits_whole_module(vt: *IsaVTable) bool {
-    ret vt.emit_module != nil;
+    ret vt.emitter != nil;
 }
 
 # a blank operand of the given kind and width, with all payload fields cleared
@@ -984,13 +1233,28 @@ test "mach.lang.target.isa.make_mem:fields" {
     ret 0;
 }
 
+# a register-machine contract with every required slot supplied and no optional
+# capability, the shortest a register machine can be (test helper)
+fun t_machine() RegMachine {
+    var hook: u8;
+    ret reg_machine(?hook, ?hook, t_is_reg_move,
+                    nil, 0, nil, 0,
+                    -1, -1, -1,
+                    -1, -1, 0,
+                    -1, -1, -1);
+}
+
+# a move classifier that recognizes nothing, for the test contract (test helper)
+fun t_is_reg_move(opcode: u32) bool {
+    ret false;
+}
+
 test "mach.lang.target.isa.register:write_once_and_enumerate" {
     var reg: IsaRegistry = registry_init();
     if (registered_count(?reg) != 0) { ret 1; }
 
-    var vt: IsaVTable;
-    vt.id   = ARCH_X86_64;
-    vt.name = "x86_64";
+    var m: RegMachine = t_machine();
+    var vt: IsaVTable = machine_isa(ARCH_X86_64, "x86_64", 62, 8, nil, 0, nil, ?m);
     register(?reg, ?vt);
     if (registered_count(?reg) != 1) { ret 1; }
 
@@ -999,9 +1263,8 @@ test "mach.lang.target.isa.register:write_once_and_enumerate" {
     if (O.unwrap[*IsaVTable](opt_vt) != ?vt) { ret 1; }
 
     # write-once: a second registration under the same name is ignored
-    var vt2: IsaVTable;
-    vt2.id   = ARCH_X86_64;
-    vt2.name = "x86_64";
+    var m2: RegMachine = t_machine();
+    var vt2: IsaVTable = machine_isa(ARCH_X86_64, "x86_64", 62, 8, nil, 0, nil, ?m2);
     register(?reg, ?vt2);
     if (O.unwrap[*IsaVTable](lookup(?reg, "x86_64")) != ?vt) { ret 1; }
 
@@ -1011,6 +1274,82 @@ test "mach.lang.target.isa.register:write_once_and_enumerate" {
     # enumeration yields the single installed vtable and nothing past it
     if (O.unwrap[*IsaVTable](registered(?reg, 0)) != ?vt) { ret 1; }
     if (O.is_some[*IsaVTable](registered(?reg, 1)))       { ret 1; }
+    ret 0;
+}
+
+# the two families are mutually exclusive BY CONSTRUCTION: each constructor binds
+# its own payload and nils the other, so `emits_whole_module` is a family test and
+# not a predicate over a shared record. a register machine has no `emit_module`
+# slot to leave nil, and a whole-module emitter has no machine slots at all
+test "mach.lang.target.isa.family:payloads_are_exclusive" {
+    var m: RegMachine = t_machine();
+    var mvt: IsaVTable = machine_isa(ARCH_X86_64, "x86_64", 62, 8, nil, 0, nil, ?m);
+    if (mvt.machine != ?m)         { ret 1; }
+    if (mvt.emitter != nil)        { ret 1; }
+    if (emits_whole_module(?mvt))  { ret 1; }
+
+    var hook: u8;
+    var e: ModuleEmitter = module_emitter(?hook);
+    var evt: IsaVTable = emitter_isa(ARCH_SPIRV, "spirv", 8, nil, 0, nil, ?e);
+    if (evt.emitter != ?e)         { ret 1; }
+    if (evt.machine != nil)        { ret 1; }
+    if (!emits_whole_module(?evt)) { ret 1; }
+
+    # a whole-module emitter is not an ELF object producer, so the seam stays clear
+    if (evt.elf_machine != 0)      { ret 1; }
+    if (evt.elf_reloc_type != nil) { ret 1; }
+    ret 0;
+}
+
+# `reg_machine` clears every optional capability, so an ISA that declares none
+# leaves no field reading stack garbage (`var` does not zero). each `with_*` setter
+# then turns exactly one on
+test "mach.lang.target.isa.reg_machine:optionals_cleared_then_declared" {
+    var m: RegMachine = t_machine();
+    if (m.emit_asm != nil)     { ret 1; }
+    if (m.asm_clobbers != nil) { ret 1; }
+    if (m.dwarf_reg != nil)    { ret 1; }
+    if (m.cv_reg != nil)       { ret 1; }
+
+    var hook: u8;
+    with_asm_printer(?m, ?hook);
+    if (m.emit_asm == nil)     { ret 1; }
+    if (m.asm_clobbers != nil) { ret 1; }
+
+    with_dwarf_regs(?m, t_dwarf_reg);
+    if (m.dwarf_reg == nil) { ret 1; }
+    if (m.cv_reg != nil)    { ret 1; }
+    if (m.dwarf_reg(3) != 3) { ret 1; }
+    ret 0;
+}
+
+# an identity DWARF numbering, for the optional-capability test (test helper)
+fun t_dwarf_reg(regid: i32) i32 {
+    ret regid;
+}
+
+# `has_codegen` reads the family payload: a register machine needs both a selector
+# and an encoder, a whole-module emitter needs only its emitter, and a
+# description-only ISA carrying neither payload reports false so `target.select_of`
+# refuses it up front rather than dying deep in codegen
+test "mach.lang.target.isa.has_codegen:per_family" {
+    var m: RegMachine = t_machine();
+    var mvt: IsaVTable = machine_isa(ARCH_X86_64, "x86_64", 62, 8, nil, 0, nil, ?m);
+    if (!has_codegen(?mvt)) { ret 1; }
+
+    # a register machine missing its encoder is not wired
+    m.encode = nil;
+    if (has_codegen(?mvt)) { ret 1; }
+
+    var hook: u8;
+    var e: ModuleEmitter = module_emitter(?hook);
+    var evt: IsaVTable = emitter_isa(ARCH_SPIRV, "spirv", 8, nil, 0, nil, ?e);
+    if (!has_codegen(?evt)) { ret 1; }
+
+    # description-only: registered so composition reports it, but neither family
+    # payload is bound
+    var dvt: IsaVTable = machine_isa(ARCH_MOS6502, "desc", 0, 2, nil, 0, nil, nil);
+    if (has_codegen(?dvt)) { ret 1; }
     ret 0;
 }
 

--- a/src/lang/target/isa/arm64/encode.mach
+++ b/src/lang/target/isa/arm64/encode.mach
@@ -62,7 +62,7 @@ use printer: mach.lang.target.isa.arm64.printer;
 use mach.lang.target.of;
 use mach.lang.target.resolved;
 
-# the concrete signature the erased `isa.IsaVTable.encode` pointer is
+# the concrete signature the erased `isa.RegMachine.encode` pointer is
 # cast back to, matching the shared `be.codegen.encode.EncodeFn`. the vtable stores
 # `encode` type-erased (`*u8`); the shared dispatcher casts it back to this type
 # before calling it

--- a/src/lang/target/isa/arm64/register.mach
+++ b/src/lang/target/isa/arm64/register.mach
@@ -27,6 +27,10 @@ use mach.lang.target.of.elf;
 var arm64_vtable:  isa.IsaVTable;
 var arm64_classes: [3]isa.RegClass;
 
+# process-global storage for the aarch64 register-machine contract. borrowed by
+# the installed vtable's `machine` payload for the process lifetime
+var arm64_machine: isa.RegMachine;
+
 # process-global storage for the AArch64 machine-model template. written once by
 # `register_arm64` and pointed to by the vtable's `model` field; `target.select`
 # copies it by value and overlays the selected abi's stack scalars. lives for the
@@ -89,7 +93,7 @@ val DWARF_V0: i32 = 64;
 # map a physical aarch64 register id to its DWARF register number
 #
 # The aarch64 half of the per-ISA DWARF register seam (#1693): a debug-info producer
-# reads it through `IsaVTable.dwarf_reg` so DWARF variable locations and
+# reads it through `RegMachine.dwarf_reg` so DWARF variable locations and
 # `DW_AT_frame_base` name aarch64's DWARF numbers. The numbering is "DWARF for the
 # Arm 64-bit Architecture (AArch64)", section 4.1: X0..X30 map identically to 0..30,
 # the stack pointer (id 31) is 31, and the SIMD/FP registers V0..V31 map to 64..95.
@@ -178,47 +182,37 @@ pub fun register_arm64(reg: *isa.IsaRegistry) R.Result[bool, str] {
     arm64_reload_scratch_regs[2].id   = arm64.X11;
     arm64_reload_scratch_regs[2].size = 8;
 
-    arm64_vtable.id                   = isa.ARCH_AARCH64;
-    arm64_vtable.name                 = "aarch64";
-    arm64_vtable.elf_machine          = 183;  # EM_AARCH64
-    arm64_vtable.elf_reloc_type       = arm64_elf_reloc_type::*u8;
-    # the per-ISA DWARF register map (#1693), inert until a debug-info producer
-    # consumes it. aarch64 has no CodeView numbering wired (Windows-on-ARM's
-    # CV_ARM64_* is out of scope), so cv_reg stays nil.
-    arm64_vtable.dwarf_reg            = arm64_dwarf_reg::*u8;
-    arm64_vtable.cv_reg               = nil;
-    arm64_vtable.pointer_width        = 8;
-    arm64_vtable.reg_classes          = ?arm64_classes[0];
-    arm64_vtable.reg_class_count      = 3;
-    arm64_vtable.select               = rules.select::*u8;
-    arm64_vtable.encode               = encode.encode_arm64::*u8;
-    # no assembly printer yet (#2194): registering the refusal rather than nil makes
-    # `--emit-asm` fail naming aarch64, instead of silently leaving an empty `.s`.
-    arm64_vtable.emit_asm             = encode.encode_arm64_asm::*u8;
-    arm64_vtable.asm_clobbers         = encode.asm_clobbers::*u8;
-    arm64_vtable.is_reg_move          = rules.is_reg_move::*u8;
-    arm64_vtable.reserved_regs        = ?arm64_reserved_regs[0];
-    arm64_vtable.reserved_reg_count   = 3;
-    arm64_vtable.reload_scratch_regs  = ?arm64_reload_scratch_regs[0];
-    arm64_vtable.reload_scratch_count = 3;
-    arm64_vtable.scratch_reg          = arm64.IP0;
-    arm64_vtable.scratch_reg2         = arm64.IP1;
-    # the primary vector scratch is a composite register id (class tag in the high
-    # byte), mirroring x86-64's FP_SCRATCH_REG - a raw bank index would read as a
-    # GP reg. the encoder pairs it with V30 (the second held-back scratch) for the
-    # both-sources-spilled binary float case.
-    arm64_vtable.fp_scratch_reg       = isa.regid_make(isa.REG_CLASS_ID_XMM, arm64.V31);
-    arm64_vtable.frame_ptr_reg        = arm64.FP;
-    arm64_vtable.stack_ptr_reg        = arm64.SP;
-    # the AAPCS64 frame record stores the saved FP at [fp+0] and the saved LR at
-    # [fp+8], so incoming stack arguments start at [fp+16] - same base as x86-64.
-    arm64_vtable.incoming_arg_base    = 16;
-    # AArch64 SDIV/UDIV write a normal destination register and a shift count rides
-    # any register, so the ISA wires no fixed division / shift register: -1 for all
-    # three.
-    arm64_vtable.div_reg              = -1;
-    arm64_vtable.div_hi_reg           = -1;
-    arm64_vtable.shift_count_reg      = -1;
+    # the register-machine contract. the primary vector scratch is a composite
+    # register id (class tag in the high byte), mirroring x86-64's FP_SCRATCH_REG - a
+    # raw bank index would read as a GP reg; the encoder pairs it with V30 (the second
+    # held-back scratch) for the both-sources-spilled binary float case. the AAPCS64
+    # frame record stores the saved FP at [fp+0] and the saved LR at [fp+8], so
+    # incoming stack arguments start at [fp+16] - same base as x86-64. AArch64
+    # SDIV/UDIV write a normal destination register and a shift count rides any
+    # register, so no fixed division / shift register is wired: -1 for all three.
+    arm64_machine = isa.reg_machine(
+        rules.select::*u8,
+        encode.encode_arm64::*u8,
+        rules.is_reg_move,
+        ?arm64_reserved_regs[0], 3,
+        ?arm64_reload_scratch_regs[0], 3,
+        arm64.IP0, arm64.IP1, isa.regid_make(isa.REG_CLASS_ID_XMM, arm64.V31),
+        arm64.FP, arm64.SP, 16,
+        -1, -1, -1
+    );
+    # the printer is the encoder's own sink (#2194), so the `.s` renders the
+    # instruction stream that was emitted rather than a second MIR-level walk.
+    isa.with_asm_printer(?arm64_machine, encode.encode_arm64_asm::*u8);
+    isa.with_asm_clobbers(?arm64_machine, encode.asm_clobbers);
+    # the per-ISA DWARF register map (#1693). aarch64 has no CodeView numbering wired
+    # (Windows-on-ARM's CV_ARM64_* is out of scope), so `with_codeview_regs` is not
+    # called.
+    isa.with_dwarf_regs(?arm64_machine, arm64_dwarf_reg);
+
+    # elf_machine 183 is EM_AARCH64
+    arm64_vtable = isa.machine_isa(isa.ARCH_AARCH64, "aarch64", 183, 8,
+                                   ?arm64_classes[0], 3, ?arm64_model, ?arm64_machine);
+    isa.with_elf(?arm64_vtable, arm64_elf_reloc_type::*u8, nil);
 
     # the machine-model template: every value equals today's reality so the stages
     # preserve behavior when they are rewired to read it. widths are in bytes; the
@@ -266,8 +260,6 @@ pub fun register_arm64(reg: *isa.IsaRegistry) R.Result[bool, str] {
     arm64_model.stack_align       = 0;
     arm64_model.red_zone          = 0;
     arm64_model.shadow_space      = 0;
-
-    arm64_vtable.model = ?arm64_model;
 
     isa.register(reg, ?arm64_vtable);
 

--- a/src/lang/target/isa/arm64/rules.mach
+++ b/src/lang/target/isa/arm64/rules.mach
@@ -78,7 +78,7 @@ use mach.lang.target.isa;
 use mach.lang.target.isa.arm64;
 use target: mach.lang.target.resolved;
 
-# the concrete signature the erased `isa.IsaVTable.select` pointer is cast back to,
+# the concrete signature the erased `isa.RegMachine.select` pointer is cast back to,
 # matching the shared `be.codegen.isel.SelectFn`
 #
 # The vtable stores `select` type-erased (`*u8`); the shared dispatcher casts it

--- a/src/lang/target/isa/mos6502/register.mach
+++ b/src/lang/target/isa/mos6502/register.mach
@@ -30,6 +30,10 @@ var mos6502_vtable:  isa.IsaVTable;
 var mos6502_classes: [1]isa.RegClass;
 var mos6502_model:   isa.MachineModel;
 
+# process-global storage for the 6502 register-machine contract. borrowed by the
+# installed vtable's `machine` payload for the process lifetime
+var mos6502_machine: isa.RegMachine;
+
 # the reserved zero-page registers the allocator must never assign: the frame- and
 # stack-pointer pairs, the encoder pointer pair, and the two single-byte encoder
 # scratch registers. borrowed by the vtable for the process lifetime
@@ -43,11 +47,11 @@ var mos6502_reload_scratch_regs: [3]isa.Register;
 # Declares one general-purpose register class of `GPR_COUNT` imaginary 8-bit
 # zero-page registers, reserves the frame / stack / scratch ids, and populates the
 # machine model with the 8-bit ALU (`max_alu_width` 1), 1-byte machine word, 2-byte
-# pointer, little-endian storage, and the software-stack frame facts. Wires the
-# selection pack (`select`), the byte encoder (`encode`), and the move classifier
-# (`is_reg_move`); leaves the ELF / DWARF / relocation hooks nil (the raw flat image
-# needs none). Installs the result into `reg`. Idempotent; must run at startup
-# before `target.select` requests a 6502 target.
+# pointer, little-endian storage, and the software-stack frame facts. It is a
+# REGISTER MACHINE that declares no optional capability at all, so its
+# `isa.reg_machine` call is the shortest a register machine can be. Installs the
+# result into `reg`. Idempotent; must run at startup before `target.select`
+# requests a 6502 target.
 # ---
 # reg: the ISA registry to install the vtable into
 # ret: true on success
@@ -70,44 +74,28 @@ pub fun register_mos6502(reg: *isa.IsaRegistry) R.Result[bool, str] {
     mos6502_reload_scratch_regs[1].id = mos6502.RELOAD1; mos6502_reload_scratch_regs[1].size = 1;
     mos6502_reload_scratch_regs[2].id = mos6502.RELOAD2; mos6502_reload_scratch_regs[2].size = 1;
 
-    mos6502_vtable.id              = isa.ARCH_MOS6502;
-    mos6502_vtable.name            = "mos6502";
-    # the raw flat image carries no ELF machine type, relocation map, build
-    # attributes, or debug register numbering, so every object-format hook stays nil.
-    mos6502_vtable.elf_machine     = 0;
-    mos6502_vtable.elf_reloc_type  = nil;
-    mos6502_vtable.elf_attributes  = nil;
-    mos6502_vtable.dwarf_reg       = nil;
-    mos6502_vtable.cv_reg          = nil;
-    mos6502_vtable.pointer_width   = 2;
-    mos6502_vtable.reg_classes     = ?mos6502_classes[0];
-    mos6502_vtable.reg_class_count = 1;
-
-    mos6502_vtable.select      = rules.select::*u8;
-    mos6502_vtable.encode      = encode.encode_mos6502::*u8;
-    mos6502_vtable.emit_asm    = nil;
-    # no inline-asm clobber analyzer yet; regalloc treats an asm body conservatively.
-    mos6502_vtable.asm_clobbers = nil;
-    mos6502_vtable.is_reg_move  = rules.is_reg_move::*u8;
-
-    mos6502_vtable.reserved_regs        = ?mos6502_reserved_regs[0];
-    mos6502_vtable.reserved_reg_count   = 8;
-    mos6502_vtable.reload_scratch_regs  = ?mos6502_reload_scratch_regs[0];
-    mos6502_vtable.reload_scratch_count = 3;
-    mos6502_vtable.scratch_reg          = mos6502.SCRATCH_REG;
-    mos6502_vtable.scratch_reg2         = mos6502.SCRATCH_REG2;
-    # no floating-point bank on the 6502.
-    mos6502_vtable.fp_scratch_reg       = -1;
-    mos6502_vtable.frame_ptr_reg        = mos6502.FRAME_REG;
-    mos6502_vtable.stack_ptr_reg        = mos6502.STACK_REG;
-    # the prologue establishes the frame pointer at the incoming argument base, so
+    # the register-machine contract. the 6502 declares NO optional capability - no
+    # asm printer, no clobber analyzer, no DWARF or CodeView numbering - so the
+    # constructor call is the whole of its machine wiring. `-1` for the float scratch
+    # and the division / shift registers is a description: the 6502 has no
+    # floating-point bank and no hardware multiply, divide, or variable shift. the
+    # prologue establishes the frame pointer at the incoming argument base, so
     # incoming stack arguments sit at [fp+0].
-    mos6502_vtable.incoming_arg_base    = 0;
-    # the 6502 has no hardware multiply, divide, or variable shift, so no fixed
-    # division / shift register is wired.
-    mos6502_vtable.div_reg              = -1;
-    mos6502_vtable.div_hi_reg           = -1;
-    mos6502_vtable.shift_count_reg      = -1;
+    mos6502_machine = isa.reg_machine(
+        rules.select::*u8,
+        encode.encode_mos6502::*u8,
+        rules.is_reg_move,
+        ?mos6502_reserved_regs[0], 8,
+        ?mos6502_reload_scratch_regs[0], 3,
+        mos6502.SCRATCH_REG, mos6502.SCRATCH_REG2, -1,
+        mos6502.FRAME_REG, mos6502.STACK_REG, 0,
+        -1, -1, -1
+    );
+
+    # the raw flat image carries no ELF machine type, relocation map, or build
+    # attributes, so the object-format seam stays unset (`with_elf` is not called).
+    mos6502_vtable = isa.machine_isa(isa.ARCH_MOS6502, "mos6502", 0, 2,
+                                     ?mos6502_classes[0], 1, ?mos6502_model, ?mos6502_machine);
 
     mos6502_model.pointer_width   = 2;
     mos6502_model.gpr_width       = 1;
@@ -146,8 +134,6 @@ pub fun register_mos6502(reg: *isa.IsaRegistry) R.Result[bool, str] {
     mos6502_model.stack_align       = 0;
     mos6502_model.red_zone          = 0;
     mos6502_model.shadow_space      = 0;
-
-    mos6502_vtable.model = ?mos6502_model;
 
     isa.register(reg, ?mos6502_vtable);
     ret R.ok[bool, str](true);

--- a/src/lang/target/isa/mos6502/rules.mach
+++ b/src/lang/target/isa/mos6502/rules.mach
@@ -30,7 +30,7 @@ use mach.lang.be.codegen.rules;
 use mach.lang.target.isa.mos6502;
 use target: mach.lang.target.resolved;
 
-# the concrete signature the erased `isa.IsaVTable.select` pointer is cast back to,
+# the concrete signature the erased `isa.RegMachine.select` pointer is cast back to,
 # matching the shared `be.codegen.isel.SelectFn`
 # ---
 # a:   backing allocator (threaded for the shared SelectFn contract)

--- a/src/lang/target/isa/riscv64/encode.mach
+++ b/src/lang/target/isa/riscv64/encode.mach
@@ -72,7 +72,7 @@ use printer: mach.lang.target.isa.riscv64.printer;
 use mach.lang.target.of;
 use mach.lang.target.resolved;
 
-# the concrete signature the erased `isa.IsaVTable.encode` pointer is cast back to,
+# the concrete signature the erased `isa.RegMachine.encode` pointer is cast back to,
 # matching the shared `be.codegen.encode.EncodeFn`. the vtable stores `encode`
 # type-erased (`*u8`); the shared dispatcher casts it back to this type before
 # calling it

--- a/src/lang/target/isa/riscv64/register.mach
+++ b/src/lang/target/isa/riscv64/register.mach
@@ -37,6 +37,10 @@ use mach.lang.target.of.elf;
 var riscv64_vtable:  isa.IsaVTable;
 var riscv64_classes: [2]isa.RegClass;
 
+# process-global storage for the riscv64 register-machine contract. borrowed by
+# the installed vtable's `machine` payload for the process lifetime
+var riscv64_machine: isa.RegMachine;
+
 # process-global storage for the RV64 machine-model template. written once by
 # `register_riscv64` and pointed to by the vtable's `model` field; `target.select`
 # copies it by value and overlays the selected abi's stack scalars. lives for the
@@ -123,7 +127,7 @@ val DWARF_F0: i32 = 32;
 # map a physical riscv64 register id to its DWARF register number
 #
 # The riscv64 half of the per-ISA DWARF register seam (#1693): a debug-info producer
-# reads it through `IsaVTable.dwarf_reg` so DWARF variable locations and
+# reads it through `RegMachine.dwarf_reg` so DWARF variable locations and
 # `DW_AT_frame_base` name riscv64's DWARF numbers. The numbering is the RISC-V ELF
 # psABI "DWARF Register Numbers" table: the integer registers x0..x31 map identically
 # to 0..31 and the floating-point registers f0..f31 map to 32..63. The frame pointer
@@ -208,64 +212,51 @@ pub fun register_riscv64(reg: *isa.IsaRegistry) R.Result[bool, str] {
     riscv64_reload_scratch_regs[2].id   = riscv64.T4;
     riscv64_reload_scratch_regs[2].size = 8;
 
-    riscv64_vtable.id                   = isa.ARCH_RISCV64;
-    riscv64_vtable.name                 = "riscv64";
-    riscv64_vtable.elf_machine          = 243;  # EM_RISCV
-    riscv64_vtable.elf_reloc_type       = riscv64_elf_reloc_type::*u8;
-    # the per-ISA DWARF register map (#1693), inert until a debug-info producer
-    # consumes it. riscv64 has no CodeView numbering (no Windows target), so cv_reg
-    # stays nil.
-    riscv64_vtable.dwarf_reg            = riscv64_dwarf_reg::*u8;
-    riscv64_vtable.cv_reg               = nil;
+    # the register-machine contract. the FP scratch is a composite register id (the
+    # float class tag in the high byte), mirroring x86-64's FP_SCRATCH_REG and
+    # AArch64's V31 - a raw bank index would read as an integer register; the encoder
+    # pairs it with f30 (the second held-back scratch) for the both-sources-spilled
+    # binary float case. the RV64 frame discipline sets s0/fp to the canonical frame
+    # address (the stack pointer at entry) and saves ra / old-fp below it, so incoming
+    # stack arguments sit at [fp+0] - unlike x86-64 / AArch64, whose saved frame record
+    # pushes the first to [fp+16]. RV64 div / divu / rem / remu write a normal
+    # destination register and a shift count rides the low bits of any register, so no
+    # fixed division / shift register is wired: -1 for all three.
+    riscv64_machine = isa.reg_machine(
+        rules.select::*u8,
+        encode.encode_riscv64::*u8,
+        rules.is_reg_move,
+        ?riscv64_reserved_regs[0], 6,
+        ?riscv64_reload_scratch_regs[0], 3,
+        riscv64.SCRATCH_REG, riscv64.SCRATCH_REG2,
+        isa.regid_make(isa.REG_CLASS_ID_XMM, riscv64.F31),
+        riscv64.FP, riscv64.SP, 0,
+        -1, -1, -1
+    );
+    # the printer is the encoder's own sink (#2193), so the `.s` renders the
+    # instruction stream that was emitted rather than a second MIR-level walk.
+    isa.with_asm_printer(?riscv64_machine, encode.encode_riscv64_asm::*u8);
+    isa.with_asm_clobbers(?riscv64_machine, encode.asm_clobbers);
+    # the per-ISA DWARF register map (#1693). riscv64 has no CodeView numbering (no
+    # Windows target), so `with_codeview_regs` is not called.
+    isa.with_dwarf_regs(?riscv64_machine, riscv64_dwarf_reg);
 
     # the ELF build-attributes descriptor: the writer stamps a `.riscv.attributes`
     # ISA-string section from it so external tools decode imafd with no manual
-    # `--mattr`. wired as the type-erased `elf_attributes` hook, like `elf_reloc_type`.
-    riscv64_attrs.section               = ".riscv.attributes";
-    riscv64_attrs.sht                   = elf.SHT_RISCV_ATTRIBUTES;
-    riscv64_attrs.vendor                = "riscv";
-    riscv64_attrs.arch_tag              = elf.TAG_RISCV_ARCH;
-    riscv64_attrs.arch                  = RISCV64_ARCH_STRING;
-    riscv64_vtable.elf_attributes       = riscv64_elf_attributes::*u8;
-    riscv64_vtable.pointer_width        = 8;
-    riscv64_vtable.reg_classes          = ?riscv64_classes[0];
-    riscv64_vtable.reg_class_count      = 2;
-    # slice 3 wired the instruction selector, the byte encoder, and the inline-asm
-    # clobber analyzer; slice 4 adds the assembly printer (`emit_asm`) and the ELF
-    # relocation forward map (`elf_reloc_type`). all are stored type-erased (`*u8`) and
-    # cast back to their concrete signatures by the shared dispatchers. `apply_reloc`
-    # (the linker relocation packer) is left nil here and wired by the be-layer
-    # `be.linker.register_reloc_hooks` registrar, since the packing bodies live in be/
-    # and target/ cannot depend on be/ - the same split x86_64 and aarch64 use.
-    riscv64_vtable.select               = rules.select::*u8;
-    riscv64_vtable.encode               = encode.encode_riscv64::*u8;
-    riscv64_vtable.emit_asm             = encode.encode_riscv64_asm::*u8;
-    riscv64_vtable.asm_clobbers         = encode.asm_clobbers::*u8;
-    riscv64_vtable.is_reg_move          = rules.is_reg_move::*u8;
-    riscv64_vtable.reserved_regs        = ?riscv64_reserved_regs[0];
-    riscv64_vtable.reserved_reg_count   = 6;
-    riscv64_vtable.reload_scratch_regs  = ?riscv64_reload_scratch_regs[0];
-    riscv64_vtable.reload_scratch_count = 3;
-    riscv64_vtable.scratch_reg          = riscv64.SCRATCH_REG;
-    riscv64_vtable.scratch_reg2         = riscv64.SCRATCH_REG2;
-    # the FP scratch is a composite register id (the float class tag in the high
-    # byte), mirroring x86-64's FP_SCRATCH_REG and AArch64's V31 - a raw bank index
-    # would read as an integer register. the encoder pairs it with f30 (the second
-    # held-back scratch) for the both-sources-spilled binary float case.
-    riscv64_vtable.fp_scratch_reg       = isa.regid_make(isa.REG_CLASS_ID_XMM, riscv64.F31);
-    riscv64_vtable.frame_ptr_reg        = riscv64.FP;
-    riscv64_vtable.stack_ptr_reg        = riscv64.SP;
-    # the RV64 frame discipline sets s0/fp to the canonical frame address (the stack
-    # pointer at entry) and saves ra / old-fp below it, so incoming stack arguments
-    # sit at [fp+0] - unlike x86-64 / AArch64, whose saved frame record pushes the
-    # first incoming stack argument to [fp+16].
-    riscv64_vtable.incoming_arg_base    = 0;
-    # RV64 div / divu / rem / remu write a normal destination register and a shift
-    # count rides the low bits of any register, so the ISA wires no fixed division /
-    # shift register: -1 for all three.
-    riscv64_vtable.div_reg              = -1;
-    riscv64_vtable.div_hi_reg           = -1;
-    riscv64_vtable.shift_count_reg      = -1;
+    # `--mattr`.
+    riscv64_attrs.section  = ".riscv.attributes";
+    riscv64_attrs.sht      = elf.SHT_RISCV_ATTRIBUTES;
+    riscv64_attrs.vendor   = "riscv";
+    riscv64_attrs.arch_tag = elf.TAG_RISCV_ARCH;
+    riscv64_attrs.arch     = RISCV64_ARCH_STRING;
+
+    # elf_machine 243 is EM_RISCV. `apply_reloc` (the linker relocation packer) is not
+    # supplied here: the packing bodies live in be/ and target/ cannot depend on be/,
+    # so `be.linker.register_reloc_hooks` patches it on - the same split x86_64 and
+    # aarch64 use.
+    riscv64_vtable = isa.machine_isa(isa.ARCH_RISCV64, "riscv64", 243, 8,
+                                     ?riscv64_classes[0], 2, ?riscv64_model, ?riscv64_machine);
+    isa.with_elf(?riscv64_vtable, riscv64_elf_reloc_type::*u8, riscv64_elf_attributes::*u8);
 
     # the machine-model template the shared stages read. widths are in bytes; the
     # register-file pointers borrow the same per-arch arrays the vtable does; the
@@ -319,8 +310,6 @@ pub fun register_riscv64(reg: *isa.IsaRegistry) R.Result[bool, str] {
     riscv64_model.stack_align       = 0;
     riscv64_model.red_zone          = 0;
     riscv64_model.shadow_space      = 0;
-
-    riscv64_vtable.model = ?riscv64_model;
 
     isa.register(reg, ?riscv64_vtable);
 

--- a/src/lang/target/isa/riscv64/rules.mach
+++ b/src/lang/target/isa/riscv64/rules.mach
@@ -70,7 +70,7 @@ use mach.lang.target.isa;
 use mach.lang.target.isa.riscv64;
 use target: mach.lang.target.resolved;
 
-# the concrete signature the erased `isa.IsaVTable.select` pointer is cast back
+# the concrete signature the erased `isa.RegMachine.select` pointer is cast back
 # to, matching the shared `be.codegen.isel.SelectFn`
 #
 # The vtable stores `select` type-erased (`*u8`); the shared dispatcher casts it

--- a/src/lang/target/isa/spirv/emit.mach
+++ b/src/lang/target/isa/spirv/emit.mach
@@ -89,7 +89,7 @@ rec VMaps {
 # allocated from the session allocator and handed back through the out-params; the
 # `codegen_module` fork wraps them into an object image.
 #
-# This is the concrete `EmitModuleFn` the SPIR-V `IsaVTable.emit_module` erased
+# This is the concrete `EmitModuleFn` the SPIR-V `ModuleEmitter.emit_module` erased
 # pointer is cast back to. The allocator and interner ride the MIR module.
 # ---
 # tgt:      the resolved target

--- a/src/lang/target/isa/spirv/register.mach
+++ b/src/lang/target/isa/spirv/register.mach
@@ -1,18 +1,21 @@
 # SPIR-V ISA vtable registration
 #
-# The composition seam for the SPIR-V backend. Unlike a machine ISA it wires no
-# instruction selector, register allocator, frame layout, or byte encoder: SPIR-V
-# is not linear machine code, so those stages never run. Instead it wires the
-# whole-module emitter through the `emit_module` hook. `codegen_module` reads that
-# hook's presence and forks the entire back half - after MIR lowering it calls the
-# emitter and skips isel / regalloc / frame / encode. Every machine-shaped vtable
-# field (select, encode, the register identities) stays nil / -1 because nothing
-# on the SPIR-V path consumes them.
+# The composition seam for the SPIR-V backend, and the whole of the WHOLE-MODULE
+# EMITTER family. SPIR-V is not linear machine code, so it runs no instruction
+# selection, register allocation, frame layout, or byte encoding: it consumes the
+# lowered MIR and produces the finished module bytes itself. `codegen_module` forks
+# the entire back half on the family payload this installs.
 #
-# The machine model is a minimal placeholder: `target.select` copies it by value
-# and the emitter reads only `gpr_width` (as the default value width for an
-# instruction with no natural width). It declares no vector unit, so vector ops
-# scalarize before MIR lowering and never reach the emitter.
+# It therefore has no `isa.RegMachine` at all. That is the point of the split - the
+# machine-code slots are not nil here, they are absent, so a registerless target can
+# no longer satisfy a register machine's contract with sentinel values.
+#
+# The machine model is a minimal placeholder: `target.select` copies it by value and
+# the emitter reads only `gpr_width` (as the default value width for an instruction
+# with no natural width). Its -1 register ids are read by the shared PRE-fork MIR
+# lowering, and there they are an honest description of a target with no register
+# file rather than a stand-in for a contract. It declares no vector unit, so vector
+# ops scalarize before MIR lowering and never reach the emitter.
 
 use std.types.bool.bool;
 use std.types.bool.false;
@@ -24,11 +27,12 @@ use R: std.types.result;
 use mach.lang.target.isa;
 use mach.lang.target.isa.spirv.emit;
 
-# process-global storage for the SPIR-V vtable and its machine model. written once
-# by `register_spirv` and borrowed by the vtable installed into the ISA registry;
-# lives for the process lifetime.
-var spirv_vtable: isa.IsaVTable;
-var spirv_model:  isa.MachineModel;
+# process-global storage for the SPIR-V vtable, its whole-module contract, and its
+# machine model. written once by `register_spirv` and borrowed by the vtable
+# installed into the ISA registry; lives for the process lifetime.
+var spirv_vtable:  isa.IsaVTable;
+var spirv_emitter: isa.ModuleEmitter;
+var spirv_model:   isa.MachineModel;
 
 # the two nominal register banks. the shared MIR lowering locates the
 # general-purpose bank by its RC_GENERAL kind (to class every integer / pointer
@@ -39,12 +43,11 @@ var spirv_classes: [2]isa.RegClass;
 
 # build and install the SPIR-V ISA vtable
 #
-# Wires the whole-module emitter (`emit_module`) and leaves every machine-code hook
-# nil: SPIR-V runs no instruction selection, register allocation, frame layout, or
-# byte encoding. The register-identity fields are -1 (no register file), the model
-# is a minimal logical-addressing placeholder with no vector unit. Installs the
-# result into `reg`. Idempotent: the registry entry is write-once. Must run at
-# compiler startup before `target.select` requests a spirv target.
+# Composes an `emitter_isa` - the whole-module family - so the contract is one slot:
+# the emitter. The model is a minimal logical-addressing placeholder with no vector
+# unit. Installs the result into `reg`. Idempotent: the registry entry is
+# write-once. Must run at compiler startup before `target.select` requests a spirv
+# target.
 # ---
 # reg: the ISA registry to install the vtable into
 # ret: true on success
@@ -96,42 +99,14 @@ pub fun register_spirv(reg: *isa.IsaRegistry) R.Result[bool, str] {
     spirv_model.ct_trust_mul           = false;
     spirv_model.ct_trust_var_shift     = false;
 
-    spirv_vtable.id            = isa.ARCH_SPIRV;
-    spirv_vtable.name          = "spirv";
-    spirv_vtable.elf_machine   = 0;
-    spirv_vtable.pointer_width = 8;
-    spirv_vtable.reg_classes     = ?spirv_classes[0];
-    spirv_vtable.reg_class_count = 2;
+    # the whole-module contract is the entire SPIR-V back half, and it is the whole
+    # of what this family owes. there is no `isa.RegMachine` here, so the machine
+    # slots do not exist to be nil'd - the eleven `= nil` and eight `= -1` lines this
+    # replaced were a registerless target filling in a register machine's contract.
+    spirv_emitter = isa.module_emitter(emit.emit_module::*u8);
 
-    # the whole-module emitter: the entire SPIR-V back half. `codegen_module` reads
-    # its presence to fork after MIR lowering. every machine-code hook stays nil.
-    spirv_vtable.emit_module  = emit.emit_module::*u8;
-    spirv_vtable.select       = nil;
-    spirv_vtable.encode       = nil;
-    spirv_vtable.emit_asm     = nil;
-    spirv_vtable.asm_clobbers = nil;
-    spirv_vtable.is_reg_move  = nil;
-    spirv_vtable.apply_reloc    = nil;
-    spirv_vtable.elf_reloc_type = nil;
-    spirv_vtable.elf_attributes = nil;
-    spirv_vtable.dwarf_reg      = nil;
-    spirv_vtable.cv_reg         = nil;
-
-    spirv_vtable.reserved_regs        = nil;
-    spirv_vtable.reserved_reg_count   = 0;
-    spirv_vtable.reload_scratch_regs  = nil;
-    spirv_vtable.reload_scratch_count = 0;
-    spirv_vtable.scratch_reg      = -1;
-    spirv_vtable.scratch_reg2     = -1;
-    spirv_vtable.fp_scratch_reg   = -1;
-    spirv_vtable.frame_ptr_reg    = -1;
-    spirv_vtable.stack_ptr_reg    = -1;
-    spirv_vtable.incoming_arg_base = 0;
-    spirv_vtable.div_reg          = -1;
-    spirv_vtable.div_hi_reg       = -1;
-    spirv_vtable.shift_count_reg  = -1;
-
-    spirv_vtable.model = ?spirv_model;
+    spirv_vtable = isa.emitter_isa(isa.ARCH_SPIRV, "spirv", 8,
+                                   ?spirv_classes[0], 2, ?spirv_model, ?spirv_emitter);
 
     isa.register(reg, ?spirv_vtable);
     ret R.ok[bool, str](true);

--- a/src/lang/target/isa/x64/register.mach
+++ b/src/lang/target/isa/x64/register.mach
@@ -27,6 +27,11 @@ use mach.lang.target.of.elf;
 var x64_vtable:  isa.IsaVTable;
 var x64_classes: [3]isa.RegClass;
 
+# process-global storage for the x86-64 register-machine contract - the machine
+# back half's entry points and register identities. borrowed by the installed
+# vtable's `machine` payload for the process lifetime
+var x64_machine: isa.RegMachine;
+
 # process-global storage for the x86-64 machine-model template. written once by
 # `register_x64` and pointed to by the vtable's `model` field; `target.select`
 # copies it by value and overlays the selected abi's stack scalars. lives for the
@@ -96,7 +101,7 @@ val CV_AMD64_XMM8: i32 = 252;  # first of the XMM8..XMM15 block
 # map a physical x86-64 register id to its DWARF register number
 #
 # The x86-64 half of the per-ISA DWARF register seam (#1693): a debug-info producer
-# reads it through `IsaVTable.dwarf_reg` so DWARF variable locations and
+# reads it through `RegMachine.dwarf_reg` so DWARF variable locations and
 # `DW_AT_frame_base` name the ISA's DWARF numbers rather than the encoder's physical
 # ids. The numbering is the System V AMD64 psABI "DWARF Register Number Mapping"
 # (Figure 3.36): the low eight GP registers are PERMUTED away from their ModRM/REX
@@ -135,7 +140,7 @@ fun x64_dwarf_reg(regid: i32) i32 {
 # map a physical x86-64 register id to its CodeView register number
 #
 # The x86-64 half of the per-ISA CodeView register seam (#1693): the COFF/CodeView
-# producer reads it through `IsaVTable.cv_reg` so CodeView debug records name the
+# producer reads it through `RegMachine.cv_reg` so CodeView debug records name the
 # ISA's `CV_AMD64_*` numbers. The 64-bit GP registers sit in one contiguous
 # CodeView block from CV_AMD64_RAX in CodeView's own order (rax, rbx, rcx, rdx, rsi,
 # rdi, rbp, rsp, r8..r15) - a different order from both the encoder ids and the
@@ -175,25 +180,23 @@ fun x64_cv_reg(regid: i32) i32 {
 
 # build and install the x86-64 ISA vtable
 #
-# sets the architecture and register-class names as immutable `str` constants,
-# fills the three register classes (gpr 64x16, xmm 128x14 with XMM14/XMM15 held
-# back as FP scratch, flags 64x1), populates
-# the vtable with the pointer width (8), the reserved registers (RSP/RBP), the
-# scratch register identities (R11/R10/XMM15), the
-# frame/stack pointers (RBP/RSP) the shared MIR lowering names when forming stack
-# memory operands, and the fixed division accumulator / high-half (RAX/RDX) and
-# variable-shift count (RCX) registers the x86-64 IDIV/DIV and shift forms
-# hard-wire, and installs it into `reg`. idempotent: the registry entry is
-# write-once. must be invoked at compiler startup before `target.select` requests
-# an x86-64 target.
+# x86-64 is a REGISTER MACHINE, so it fills the `isa.RegMachine` contract: the
+# three register classes (gpr 64x16, xmm 128x14 with XMM14/XMM15 held back as FP
+# scratch, flags 64x1), the reserved registers (RSP/RBP), the scratch identities
+# (R11/R10/XMM15), the frame/stack pointers (RBP/RSP) the shared lowering names
+# when forming stack memory operands, and the fixed division accumulator /
+# high-half (RAX/RDX) and variable-shift count (RCX) registers the IDIV/DIV and
+# shift forms hard-wire. It is the only ISA that wires all four optional
+# capabilities (asm printer, clobber analyzer, DWARF and CodeView numberings).
+# Idempotent: the registry entry is write-once. Must be invoked at compiler startup
+# before `target.select` requests an x86-64 target.
 #
-# the `select` and `encode` operation entry points are the x86-64 selection
-# rule pack (`x64/rules.mach`) and byte encoder (`x64/encode.mach`), stored
-# type-erased (`*u8`) and cast back to their `SelectFn` / `EncodeFn` signatures by
-# the shared `be.codegen.isel` / `be.codegen.encode` dispatchers - a nil slot is
-# the "unregistered ISA" signal those dispatchers error on. all x86-64 selection
-# and encoding logic lives under this module and is reached only through these
-# vtable slots; the shared backend drivers carry no x86-64 knowledge.
+# The `select` and `encode` entry points are the x86-64 selection rule pack
+# (`x64/rules.mach`) and byte encoder (`x64/encode.mach`), stored type-erased
+# (`*u8`) and cast back to their `SelectFn` / `EncodeFn` signatures by the shared
+# `be.codegen.isel` / `be.codegen.encode` dispatchers. All x86-64 selection and
+# encoding logic lives under this module and is reached only through these slots;
+# the shared backend drivers carry no x86-64 knowledge.
 # ---
 # reg: the ISA registry to install the vtable into
 # ret: true on success
@@ -231,39 +234,32 @@ pub fun register_x64(reg: *isa.IsaRegistry) R.Result[bool, str] {
     x64_reload_scratch_regs[2].id   = x64.R10;
     x64_reload_scratch_regs[2].size = 8;
 
-    x64_vtable.id                   = isa.ARCH_X86_64;
-    x64_vtable.name                 = "x86_64";
-    x64_vtable.elf_machine          = 62;  # EM_X86_64
-    x64_vtable.elf_reloc_type       = x64_elf_reloc_type::*u8;
-    # per-ISA debug-info register maps: x86-64 owns both a DWARF and a CodeView
-    # numbering (the only shipped ISA Windows targets). inert until a debug-info
-    # producer consumes them (#1704/#1705/#1712).
-    x64_vtable.dwarf_reg            = x64_dwarf_reg::*u8;
-    x64_vtable.cv_reg               = x64_cv_reg::*u8;
-    x64_vtable.pointer_width        = 8;
-    x64_vtable.reg_classes          = ?x64_classes[0];
-    x64_vtable.reg_class_count      = 3;
-    x64_vtable.select               = rules.select::*u8;
-    x64_vtable.encode               = encode.encode_x64::*u8;
-    x64_vtable.emit_asm             = encode.encode_x64_asm::*u8;
-    x64_vtable.asm_clobbers         = encode.asm_clobbers::*u8;
-    x64_vtable.is_reg_move          = rules.is_reg_move::*u8;
-    x64_vtable.reserved_regs        = ?x64_reserved_regs[0];
-    x64_vtable.reserved_reg_count   = 2;
-    x64_vtable.reload_scratch_regs  = ?x64_reload_scratch_regs[0];
-    x64_vtable.reload_scratch_count = 3;
-    x64_vtable.scratch_reg          = x64.SCRATCH_REG;
-    x64_vtable.scratch_reg2         = x64.SCRATCH_REG2;
-    x64_vtable.fp_scratch_reg       = x64.FP_SCRATCH_REG;
-    x64_vtable.frame_ptr_reg        = x64.FRAME_REG;
-    x64_vtable.stack_ptr_reg        = x64.STACK_REG;
+    # the register-machine contract. every required slot is a parameter, so omitting
+    # one is a build-time arity error rather than a nil slot found at runtime.
     # x86-64 `push rbp; mov rbp, rsp` saves the frame pointer at [rbp+0] and the
-    # return address at [rbp+8], so the first incoming stack argument sits at
-    # [rbp+16].
-    x64_vtable.incoming_arg_base    = 16;
-    x64_vtable.div_reg              = x64.RAX;
-    x64_vtable.div_hi_reg           = x64.RDX;
-    x64_vtable.shift_count_reg      = x64.RCX;
+    # return address at [rbp+8], so the first incoming stack argument sits at [rbp+16].
+    x64_machine = isa.reg_machine(
+        rules.select::*u8,
+        encode.encode_x64::*u8,
+        rules.is_reg_move,
+        ?x64_reserved_regs[0], 2,
+        ?x64_reload_scratch_regs[0], 3,
+        x64.SCRATCH_REG, x64.SCRATCH_REG2, x64.FP_SCRATCH_REG,
+        x64.FRAME_REG, x64.STACK_REG, 16,
+        x64.RAX, x64.RDX, x64.RCX
+    );
+    # every optional capability: x86-64 is the only ISA that wires all four.
+    isa.with_asm_printer(?x64_machine, encode.encode_x64_asm::*u8);
+    isa.with_asm_clobbers(?x64_machine, encode.asm_clobbers);
+    # per-ISA debug-info register maps: x86-64 owns both a DWARF and a CodeView
+    # numbering (the only shipped ISA Windows targets).
+    isa.with_dwarf_regs(?x64_machine, x64_dwarf_reg);
+    isa.with_codeview_regs(?x64_machine, x64_cv_reg);
+
+    # elf_machine 62 is EM_X86_64
+    x64_vtable = isa.machine_isa(isa.ARCH_X86_64, "x86_64", 62, 8,
+                                 ?x64_classes[0], 3, ?x64_model, ?x64_machine);
+    isa.with_elf(?x64_vtable, x64_elf_reloc_type::*u8, nil);
 
     # the machine-model template: every value equals today's reality so the stages
     # preserve behavior when they are rewired to read it. widths are in bytes; the
@@ -312,8 +308,6 @@ pub fun register_x64(reg: *isa.IsaRegistry) R.Result[bool, str] {
     x64_model.stack_align       = 0;
     x64_model.red_zone          = 0;
     x64_model.shadow_space      = 0;
-
-    x64_vtable.model = ?x64_model;
 
     isa.register(reg, ?x64_vtable);
 

--- a/src/lang/target/isa/x64/rules.mach
+++ b/src/lang/target/isa/x64/rules.mach
@@ -70,7 +70,7 @@ use mach.lang.source;
 use mach.lang.target.isa.x64;
 use target: mach.lang.target.resolved;
 
-# the concrete signature the erased `isa.IsaVTable.select` pointer is cast back
+# the concrete signature the erased `isa.RegMachine.select` pointer is cast back
 # to, matching the shared `be.codegen.isel.SelectFn`
 #
 # The vtable stores `select` type-erased (`*u8`); the shared dispatcher casts it

--- a/src/lang/target/resolved.mach
+++ b/src/lang/target/resolved.mach
@@ -14,7 +14,17 @@ use mach.lang.target.os;
 #
 # The `*_id` fields are comptime identity, matching the constants in
 # os/isa/abi/of. The vtable pointers are the runtime-dispatch surface the backend
-# calls through. Pointer width is read through `arch`, never duplicated here.
+# calls through. Pointer width is read through `isa`, never duplicated here.
+#
+# `isa` and `arch` are the two halves of the target-family split: `isa` is the
+# instruction set as identity and description, carried by BOTH families, while
+# `arch` is the register-machine contract and is **nil for a whole-module emitter**.
+# Nothing dereferences `arch` on that path - `codegen_module` forks on
+# `isa.emits_whole_module` after MIR lowering, ahead of every stage that reads it
+# (isel, regalloc, frame, encode, dwarf) - so a registerless target no longer
+# describes fake registers to satisfy a contract it does not implement. The shared
+# PRE-fork stages read register identities from `model`, the family-agnostic
+# description, where a -1 is an honest statement rather than a sentinel.
 # ---
 # os_id:    operating-system id (one of os.OS_*)
 # arch_id:  architecture id (one of isa.ARCH_*)
@@ -23,7 +33,10 @@ use mach.lang.target.os;
 # debug_id: debug-info model id (one of of.DBG_*), DBG_UNKNOWN when the tuple
 #           carries no debug info
 # os:       borrowed operating-system vtable
-# arch:     borrowed instruction-set vtable
+# isa:      borrowed instruction-set vtable: identity, description, object-format
+#           seam, and the one family payload
+# arch:     borrowed register-machine contract, or nil when the isa is a
+#           whole-module emitter
 # abi:      borrowed calling-convention vtable
 # of:       borrowed object-format vtable
 # debug:    borrowed debug-info producer vtable resolved from the object format's
@@ -41,7 +54,8 @@ pub rec Target {
     of_id:    u32;
     debug_id: u32;
     os:       *os.OsVTable;
-    arch:     *isa.IsaVTable;
+    isa:      *isa.IsaVTable;
+    arch:     *isa.RegMachine;
     abi:      *abi.AbiVTable;
     of:       *of.OfVTable;
     debug:    *of.DebugVTable;


### PR DESCRIPTION
Closes #2213. Part of #2212.

One flat `IsaVTable` served two fundamentally different kinds of target, so half its slots were dead for any given one. This splits it along the family line `emits_whole_module` already forked on, and makes that fork a **type-level distinction** rather than a predicate over a shared record.

## The two contracts

**`isa.RegMachine`** — isel → regalloc → frame → encode. Owes a selector, an encoder, a move classifier, and the register identities the shared stages need but cannot name without target knowledge. Four **optional capabilities** — asm printer, inline-asm clobber analyzer, DWARF numbering, CodeView numbering — are declared by name through `with_asm_printer` / `with_asm_clobbers` / `with_dwarf_regs` / `with_codeview_regs`.

**Correction to my own framing, after #2193/#2194 landed.** I designed those four as one category when only x86-64 had a printer. That is no longer the shape. Measured from source on current `dev`:

| capability | x86_64 | aarch64 | riscv64 | mos6502 |
|---|---|---|---|---|
| `with_asm_printer` | yes | yes | yes | no |
| `with_asm_clobbers` | yes | yes | yes | no |
| `with_dwarf_regs` | yes | yes | yes | no |
| `with_codeview_regs` | yes | no | no | no |

Only **`cv_reg` is optional on principle** — CodeView is Windows-specific. The other three are absent on **mos6502 alone**; every finished register machine declares all three, so their optionality tracks target *maturity*, not a capability axis. They stay optional because mos6502 ships without them and a required slot it cannot fill would be a lie, but a missing one should read as work not yet done. That distinction is now written into the `RegMachine` doc rather than left for a reader to infer.

**`isa.ModuleEmitter`** — MIR → module bytes. One slot.

**`isa.IsaVTable`** keeps what both families have — identity, machine description, object-format seam — plus **exactly one family payload** (`machine` or `emitter`, never both, never neither). `emits_whole_module` is now `vt.emitter != nil`.

SPIR-V was not made to conform to the register-machine contract. It has no `RegMachine` at all, which is the point: **its 20 sentinel slots (12 nil, 8 `-1`) are gone, not moved.**

## What enforces completeness — stated precisely

**Constructor arity, and nothing stronger.** mach cannot express a non-nil function pointer, and a record literal is not a completeness check either: `infer_struct_lit` (`fe/sema/infer.mach`) validates only that the names a literal *does* spell exist, so an omitted field is silently accepted. What mach can enforce is a call signature. `isa.reg_machine` takes all 16 required slots as positional parameters and `isa.machine_isa` the remaining 8, so **omitting one is a sema arity error at build time** instead of a nil slot found deep in codegen.

This guards **forgetting** a slot, not lying about one. A target can still pass nil deliberately — that is exactly what mos6502 and SPIR-V do for `emit_asm`, and what every ISA without a fixed division register does with `-1`. Those are declarations, and they now read as declarations. A future reader should not mistake this for a non-nil guarantee, because it is not one.

The guarantee is also only as strong as the construction path: **#2244** records that `apply_reloc` is string-matched onto the vtable *after* registration, so a target can satisfy every constructor and still silently never receive a hook.

Two secondary strengthenings: the four slots whose signatures name nothing that imports `isa` (`is_reg_move`, `asm_clobbers`, `dwarf_reg`, `cv_reg`) are now **typed** rather than `*u8`, so wiring the wrong function into one is a type error; and `reg_machine` clears every optional slot, so a contract built as a local cannot read stack garbage (`var` does not zero — the #2215 hazard; the existing per-arch vtables are module globals in BSS, so they were never exposed to it).

## The two live bugs this surfaced

**The shared MIR lowering was reading register identities on the SPIR-V path.** `mir/abi.mach` and `mir/lower.mach` read `tgt.arch.stack_ptr_reg` / `frame_ptr_reg` / `div_reg` / `div_hi_reg` / `shift_count_reg` *before* the `emits_whole_module` fork — so a target with no register file was silently satisfying a register machine's contract by supplying fake values, and nothing anywhere said so. Those seven sites now read `tgt.model`, the family-agnostic description, where a registerless target's `-1` is an honest statement. Verified byte-identical **by object diff**, not by reading that the values matched.

**Two pre-fork nil-guards would have rejected SPIR-V outright** the moment `tgt.arch` went nil for it — `mir.require_abi` and `ctvalidate.run` — and now guard `tgt.isa`.

## Blast radius: construction sites only

`resolved.Target` splits `arch` into `isa` (identity/description, both families) and `arch` (the register-machine contract, **nil for a whole-module emitter**). That naming was chosen so **`be/codegen/regalloc.mach`, `be/codegen/isel.mach` and `be/codegen/encode.mach` need zero edits** — every `tgt.arch.reserved_regs` / `.select` / `.encode` line compiles verbatim. `regalloc.mach` does not appear in this diff at all, including after rebasing onto #2222, whose ~760 new lines read only register-machine fields.

Nothing dereferences `tgt.arch` on the whole-module path: `codegen_module` forks ahead of every stage that reads it (isel, regalloc, frame, encode, dwarf).

`apply_reloc`, `elf_reloc_type` and `elf_attributes` stay on `IsaVTable`. They are conditioned on the **object format**, not the family — mos6502 is a register machine with none of them.

## The payoff, measured

Wiring statements each target must write (assignments to the vtable / contract, plus constructor and capability calls; machine-model and register-class description excluded, unchanged):

| target | before | after |
|---|---:|---:|
| x86_64 | 28 | 7 |
| aarch64 | 28 | 6 |
| riscv64 | 29 | 6 |
| mos6502 | 29 | **2** |
| spirv | 31 | **2** |

What a **new register machine** must provide, concretely:

*Before* — 31 fields on one record, with nothing indicating which applied. It had to learn by reading another target that ~29 were its, that `emit_module` must be left nil or the pipeline would fork into a whole-module path it does not implement, and that nothing checked any of it.

*After* — two calls. `isa.reg_machine(...)` names its 16 required slots and `isa.machine_isa(...)` the remaining 8; a missing one fails the build. Optional capabilities are opt-in **by name**, so declaring none is silence rather than four nils. `emit_module` is not a slot it can get wrong — it does not exist on this side of the split.

## Verification

Rebased twice, now onto `dev` @ `01b9441a` (through #2233), and **fully re-measured there each time** — #2222 moved emitted x86-64 code and #2233 rewrote part of `isa.mach`, so no earlier number was carried forward.

**Byte-identical on all five targets**, branch gen-B vs `dev` gen-B:

| corpus / target | artifacts | result |
|---|---:|---|
| compiler × linux-x86_64 | 206 | identical |
| compiler × linux-arm64 | 206 | identical |
| compiler × linux-riscv64 | 206 | identical |
| fixture × freestanding-x86_64 / -aarch64 / -riscv64 / -mos6502 | 1 each | identical |
| fixture × freestanding-spirv (`.spv`) | 1 | identical |

**The harness is sensitive enough for that to mean something**: run against identical source, the pre-#2222 seed and the post-#2222 `dev` compiler differ on **all 205/205 artifacts on each of the three self-hosting ISAs**, so `identical` is a measurement rather than a harness that cannot see a change. The artifact sets are also mutually distinct across the three ISAs, confirming real per-ISA output.

**Suites**: mach **824 / 0** against a `dev` baseline of **821 / 0** — the delta is exactly the 3 tests added here. mach-std **611 / 0** at pin `eff1e8e`, verified with `git rev-parse HEAD` against `mach.lock`.

**No test lost in either rebase**: `test "..."` name inventory diffed rev-to-rev. `dev` (821) minus branch (824) is empty — nothing from #2170, #2226, #2222, #2234, #2228, #2219, #2238 or #2233 was dropped — and branch minus `dev` is exactly the three new family tests.

**Fixpoint**: `B == C`. `A != B` is **pre-existing seed drift**, proven by running the identical three-generation fixpoint on a frozen `dev` corpus, which shows the same `A != B`, `B == C`.

Built and measured with the from-source compiler throughout; the PATH seed (4.2.2) produced generation A only.

## Rebase note

Two semantic conflicts, both the same shape and both resolved in favour of `dev`: #2194 and #2193 each repointed `emit_asm` from a standalone printer to the encoder's own sink, so the contract now declares `encode.encode_arm64_asm` and `encode.encode_riscv64_asm`. #2233's additions to `isa.mach` (`SymModifier`, `Operand.sym_mod`) sit in the operand region and auto-merged cleanly against this record split; both are present and `operand_blank` clears `sym_mod` as #2233 wrote it.

Nine further files carry **comment-only** changes (second commit), retargeting `isa.IsaVTable.select`-style doc references at their family record. The third commit is the optional-capability documentation correction above.

All 16 CI lanes pass.
