### PR TITLE
fix(sema): re-validate instances a deferred `$each` body instantiates (#2177, #2174)

### DIFF
--- a/doc/language/secrecy.md
+++ b/doc/language/secrecy.md
@@ -171,9 +171,10 @@ run it with `bash int/ct/ct.sh`.
 
 What does not hold — the known open holes:
 
-- **a generic instantiated inside a variadic-pack `$each` body is never
-  re-validated**, so it computes on a secret and prints it with no diagnostic.
-  Proven, security-blocking (briar-systems/mach#2177).
+- **a pack-tailed generic loses its type arguments at monomorphization**, so its
+  `$each` body is typed against the raw parameter and a value that is secret at
+  the instance is not seen as one — it reaches a variadic pack with no
+  diagnostic. Proven, security-blocking (briar-systems/mach#2251).
 - **`$fields` reflection projection inside a generic erases a secret field's
   secrecy**, which discloses the secret. Proven, security-blocking
   (briar-systems/mach#2168).

--- a/src/lang/driver/tests.mach
+++ b/src/lang/driver/tests.mach
@@ -6185,3 +6185,194 @@ test "mach.lang.build.engine.execute_warm:sema_phase_diagnostic_fails_build" {
     session.dnit(?s);
     ret bad;
 }
+
+# the error diagnostics `src` leaves on the sink after sema + lower, or -1 when a
+# pass returned a hard failure
+#
+# The deferred-`$each` gates report through the sink and let the pass return ok -
+# the engine's own `run_phase` gate is what fails the build - so a pack-body
+# rejection is invisible to `ut_lower_rejects` (which demands an Err) and needs the
+# sink read the engine performs. A pass that returns a hard failure carrying no
+# located diagnostic counts as one error rather than zero, or a lowering that dies
+# with a raw message would read here as a clean compile. Both passes run against one
+# scaffolded project torn down here
+fun ut_ct_lower_errs(src: str) i32 {
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret -1; }
+    val sr: R.Result[session.Session, str] = session.init(?alloc);
+    if (R.is_err[session.Session, str](sr)) { ret -1; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](sr);
+
+    var names: [1]str;
+    names[0] = "main.mach";
+    var texts: [1]str;
+    texts[0] = src;
+    val pr: R.Result[project.Project, outcome.Fail] = ut_build(?s, ?alloc, ?names[0], ?texts[0], 1);
+    if (R.is_err[project.Project, outcome.Fail](pr)) { session.dnit(?s); ret -1; }
+    var p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](pr);
+
+    var errs: i32 = -1;
+    val se: R.Result[bool, outcome.Fail] = passes.run_sema_pass(?p);
+    if (R.is_ok[bool, outcome.Fail](se)) {
+        val le: R.Result[bool, outcome.Fail] = passes.run_lower_pass(?p);
+        errs = ut_count_errors(?s.diags)::i32;
+        if (R.is_err[bool, outcome.Fail](le) && errs == 0) { errs = 1; }
+    }
+
+    project.dnit_project(?p);
+    session.dnit(?s);
+    ret errs;
+}
+
+# 0 when sema + lower leave an error diagnostic containing `needle`, 1 otherwise.
+# the needle is load-bearing: a bare "was rejected" also passes on an unrelated
+# earlier error, which is exactly how a probe in this family reported a fix that
+# was not there
+fun ut_ct_lower_diag(src: str, needle: str) i32 {
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    val sr: R.Result[session.Session, str] = session.init(?alloc);
+    if (R.is_err[session.Session, str](sr)) { ret 1; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](sr);
+
+    var names: [1]str;
+    names[0] = "main.mach";
+    var texts: [1]str;
+    texts[0] = src;
+    val pr: R.Result[project.Project, outcome.Fail] = ut_build(?s, ?alloc, ?names[0], ?texts[0], 1);
+    if (R.is_err[project.Project, outcome.Fail](pr)) { session.dnit(?s); ret 1; }
+    var p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](pr);
+
+    var code: i32 = 1;
+    val se: R.Result[bool, outcome.Fail] = passes.run_sema_pass(?p);
+    if (R.is_ok[bool, outcome.Fail](se)) {
+        val le: R.Result[bool, outcome.Fail] = passes.run_lower_pass(?p);
+        if (R.is_err[bool, outcome.Fail](le)) { code = 1; }
+        if (ut_diag_has(?p.s.diags, needle))  { code = 0; }
+    }
+
+    project.dnit_project(?p);
+    session.dnit(?s);
+    ret code;
+}
+
+# whether sema + lower leave NO error containing `needle` - the negative half of
+# `ut_ct_lower_diag`, for asserting a diagnostic does not name the template
+# parameter. a `src` that fails to build at all answers false, so a broken fixture
+# cannot pass this by vacuity
+fun ut_ct_lower_lacks(src: str, needle: str) bool {
+    ret ut_ct_lower_errs(src) >= 0 && ut_ct_lower_diag(src, needle) != 0;
+}
+
+# whether `src` passes sema + lower with an empty error sink
+fun ut_ct_lower_clean(src: str) bool { ret ut_ct_lower_errs(src) == 0; }
+
+# constant-time (#2177): a generic instantiated from inside a variadic-pack `$each`
+# body is re-validated under its concrete type arguments like every other
+# instantiation.
+#
+# A pack element's type is fixed only at monomorphization, so a pack body is typed
+# exactly once - by `reinfer_pack_each_body`, during LOWERING, after the sema drain
+# has run and freed its worklist. That episode disabled instance recording, and the
+# generic call site is the only enqueue point the drain consumes, so a generic whose
+# only call site sat inside a pack body was looked at once with recording off: never
+# enqueued, never re-inferred against its concrete secret arguments. It compiled
+# clean and printed the secret. The re-validation is now a property of the inference
+# episode rather than of the module sema pass - the pack re-inference owns the
+# module's worklist and drains it - so the gates fire on the in-pack spelling exactly
+# as on the out-of-pack twin each control here pairs it with
+test "mach.lang.driver:pack_each_body_instance_revalidated" {
+    var bad: i32 = 0;
+
+    # the reported leak: the generic hands its secret parameter to a variadic pack,
+    # an observation boundary. `printlnf` is not special - a bare pack sink leaks the
+    # same way, so the fixture uses one.
+    if (ut_ct_lower_diag("var g: ^u32 = 99;\nfun fmt(va: ...) u32 { ret 0; }\nfun show[U](s: U) u32 { ret fmt(s); }\nfun sink(va: ...) u32 { var acc: u32 = 0; $each a in va { acc = acc + show[^u32](g) + a; } ret acc; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { var one: u32 = 1; sink(one); ret 0; }\n",
+        "secret value cannot be passed to a variadic") != 0) { bad = 1; }
+
+    # the CONTROL that pins the delta to the pack body: the identical instantiation
+    # written outside one was always rejected.
+    if (ut_ct_lower_diag("var g: ^u32 = 99;\nfun fmt(va: ...) u32 { ret 0; }\nfun show[U](s: U) u32 { ret fmt(s); }\nfun sink() u32 { ret show[^u32](g); }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { sink(); ret 0; }\n",
+        "secret value cannot be passed to a variadic") != 0) { bad = 1; }
+
+    # the aggregate-`==` rejection (#2127) escaped through the same hole: a record
+    # instantiation reached only from a pack body compiled and ran.
+    if (ut_ct_lower_diag("rec Pt { x: u32; y: u32; }\nvar p: Pt;\nvar q: Pt;\nfun eq[T](a: T, b: T) u32 { if (a == b) { ret 1; } ret 0; }\nfun sink(va: ...) u32 { var acc: u32 = 0; $each e in va { acc = acc + eq[Pt](p, q) + e; } ret acc; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { var one: u32 = 1; sink(one); ret 0; }\n",
+        "aggregate equality is not structural") != 0) { bad = 1; }
+
+    # so did an implicit declassification: the instance's `^u8` compare result
+    # returned through a public `u8` result type.
+    if (ut_ct_lower_diag("var g: ^u32 = 99;\n#[oblivious]\nfun eq[T](a: T, b: T) u8 { ret a == b; }\nfun sink(va: ...) u32 { var acc: u32 = 0; $each e in va { acc = acc + eq[^u32](g, g)::u32 + e; } ret acc; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { var one: u32 = 1; sink(one); ret 0; }\n",
+        "expected u8, found ^u8") != 0) { bad = 1; }
+
+    # a secret BRANCH inside the instance. the needle names the SEMA gate, not the
+    # `#[oblivious]` codegen contract that also refuses this shape - asserting only
+    # "was rejected" passes on the codegen refusal alone while the sema gate this
+    # covers stays blind, so the template carries `#[oblivious]` to clear it.
+    if (ut_ct_lower_diag("var g: ^u32 = 99;\n#[oblivious]\nfun br[T](a: T, b: T) u32 { if (a == b) { ret 1; } ret 0; }\nfun sink(va: ...) u32 { var acc: u32 = 0; $each e in va { acc = acc + br[^u32](g, g) + e; } ret acc; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { var one: u32 = 1; sink(one); ret 0; }\n",
+        "secret value used as a branch condition") != 0) { bad = 1; }
+
+    # TRANSITIVE: a generic instantiated from within a generic instantiated from
+    # within a pack body. the drain the pack re-inference owns is cursor-based, so a
+    # re-validated body's own instances are drained on the same pass.
+    if (ut_ct_lower_diag("var g: ^u32 = 99;\n#[oblivious]\nfun inner[V](a: V, b: V) u32 { if (a == b) { ret 1; } ret 0; }\n#[oblivious]\nfun outer[U](a: U, b: U) u32 { ret inner[U](a, b); }\nfun sink(va: ...) u32 { var acc: u32 = 0; $each e in va { acc = acc + outer[^u32](g, g) + e; } ret acc; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { var one: u32 = 1; sink(one); ret 0; }\n",
+        "secret value used as a branch condition") != 0) { bad = 1; }
+
+    # NESTED packs: the instantiation sits in the inner pack body, reached only by
+    # unrolling the outer one.
+    if (ut_ct_lower_diag("var g: ^u32 = 99;\n#[oblivious]\nfun br[T](a: T, b: T) u32 { if (a == b) { ret 1; } ret 0; }\nfun inr(va: ...) u32 { var acc: u32 = 0; $each b in va { acc = acc + br[^u32](g, g) + b; } ret acc; }\nfun otr(va: ...) u32 { var acc: u32 = 0; $each a in va { acc = acc + inr(a); } ret acc; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { var one: u32 = 1; otr(one); ret 0; }\n",
+        "secret value used as a branch condition") != 0) { bad = 1; }
+
+    # a whole-pack FORWARD (`g(va...)`) into a second pack function whose body holds
+    # the instantiation.
+    if (ut_ct_lower_diag("var g: ^u32 = 99;\n#[oblivious]\nfun br[T](a: T, b: T) u32 { if (a == b) { ret 1; } ret 0; }\nfun tail(va: ...) u32 { var acc: u32 = 0; $each b in va { acc = acc + br[^u32](g, g) + b; } ret acc; }\nfun head(va: ...) u32 { ret tail(va...); }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { var one: u32 = 1; head(one); ret 0; }\n",
+        "secret value used as a branch condition") != 0) { bad = 1; }
+
+    # CONTROLS - no over-rejection. the public instantiation of the same generic in
+    # the same pack body still lowers clean, and so does an explicit `:^` declassify,
+    # the sanctioned downgrade.
+    if (!ut_ct_lower_clean("fun show[U](s: U) u32 { ret 1; }\nfun sink(va: ...) u32 { var acc: u32 = 0; $each a in va { acc = acc + show[u32](a); } ret acc; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { var one: u32 = 1; sink(one); ret 0; }\n")) { bad = 1; }
+    if (!ut_ct_lower_clean("var g: ^u32 = 99;\nfun fmt(va: ...) u32 { ret 0; }\nfun show[U](s: U) u32 { ret fmt(s:^); }\nfun sink(va: ...) u32 { var acc: u32 = 0; $each a in va { acc = acc + show[^u32](g) + a; } ret acc; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { var one: u32 = 1; sink(one); ret 0; }\n")) { bad = 1; }
+
+    # the drain runs mid-lowering against the module's OWN comptime context, the one
+    # carrying lowering's resolver installation. A pack body that both instantiates a
+    # re-validated generic and folds a `$type_of` gate afterwards only lowers if the
+    # drain puts that installation back: clearing it instead - what the sema-only drain
+    # could afford to do - loses the rest of the body's gates ("a type comparison is
+    # only comptime-evaluable after type checking"). the stdlib's `vformat` is this
+    # exact shape.
+    if (!ut_ct_lower_clean("rec Rc { a: u32; }\nvar g: Rc;\nfun take[T](x: T) u32 { ret 1u32; }\nfun sink(va: ...) u32 { var acc: u32 = 0; $each e in va { acc = acc + take[Rc](g); $if ($type_of(e) == u32) { acc = acc + e; } $or { $error(\"sink: unsupported element type\"); } } ret acc; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { var one: u32 = 1; sink(one); ret 0; }\n")) { bad = 1; }
+
+    ret bad;
+}
+
+# constant-time (#2174): a deferred `$each` body is typed against the INSTANCE types,
+# so every diagnostic it raises names the concrete type the user wrote.
+#
+# The lowering-time re-inference carried no substitution, so a body naming a generic
+# parameter was typed against the raw parameter: a diagnostic said `Tp` where the
+# call site said `Rc`, and a receiver that is perfectly well-typed at the instance
+# was refused for not having the field. Both halves are the same missing `ctx.subst`
+test "mach.lang.driver:deferred_each_body_instance_types" {
+    var bad: i32 = 0;
+
+    # a generic reached ONLY from a pack body - so the lowering-time typing is the
+    # sole reporter - raising an operand-type error from its deferred `$fields(Tp)`
+    # body. The message must name `Rc`, and must NOT name `Tp`: asserting only that
+    # the concrete name appears passes on a build where BOTH spellings are reported.
+    val src: str = "rec Rc { a: u32; b: u32; }\nvar g: Rc;\nfun walk[Tp](x: Tp) u32 { var acc: u32 = 0; $each f in $fields(Tp) { acc = acc + x; } ret acc; }\nfun sink(va: ...) u32 { var acc: u32 = 0; $each e in va { acc = acc + walk[Rc](g) + e; } ret acc; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { var one: u32 = 1; sink(one); ret 0; }\n";
+    if (ut_ct_lower_diag(src, "operand types `u32` and `Rc`") != 0) { bad = 1; }
+    if (!ut_ct_lower_lacks(src, "and `Tp`"))                        { bad = 1; }
+
+    # the acceptance half: a deferred `$fields(Tp)` body reading a NAMED field off the
+    # parameter-typed receiver is well-typed at the instance, and was rejected only
+    # because the receiver kept its template type.
+    if (!ut_ct_lower_clean("rec Rc { a: u32; b: u32; }\nvar g: Rc;\nfun walk[Tp](x: Tp) u32 { var acc: u32 = 0; $each f in $fields(Tp) { acc = acc + x.a; } ret acc; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { walk[Rc](g); ret 0; }\n")) { bad = 1; }
+
+    # and the substituted typing is not a licence to accept: the same body summing the
+    # projection is still gated when the field is secret.
+    if (ut_ct_lower_diag("rec Rc { a: ^u32; }\nvar g: Rc;\nfun walk[Tp](x: Tp) u32 { var acc: u32 = 0; $each f in $fields(Tp) { acc = acc + x.a; } ret acc; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { walk[Rc](g); ret 0; }\n",
+        "expected u32, found ^u32") != 0) { bad = 1; }
+
+    ret bad;
+}

--- a/src/lang/fe/sema.mach
+++ b/src/lang/fe/sema.mach
@@ -60,6 +60,9 @@ fwd context.SemaDeps;
 fwd context.FieldEntry;
 fwd context.FieldTable;
 fwd context.SemaContext;
+fwd context.InstWorklist;
+fwd context.inst_worklist_new;
+fwd context.inst_worklist_free;
 fwd context.resolved_type_of;
 fwd context.module_sema_for;
 fwd context.decl_type_for;
@@ -160,11 +163,12 @@ pub fun sema(
     ret build_result(?sc);
 }
 
-# re-type a `$each a in va` pack-unroll body for one concrete element (#1475)
+# re-type a deferred `$each` body for one concrete element (#1475, #1523)
 #
-# A pack element's type is fixed only at the call site, so the body cannot be
-# typed at the original sema pass. At monomorphization the monomorphizer binds
-# the loop variable in the comptime context to the element's CT_KIND_PACK_ELEM
+# A pack element's type - and a `$fields(T)` unroll over a generic parameter - is
+# fixed only at monomorphization, so the body cannot be typed at the original sema
+# pass. This is therefore the ONLY pass that ever type-checks that body. The
+# monomorphizer binds the loop variable in the comptime context to the element's
 # descriptor (so `infer_ident` types `a` to the element type) and calls this to
 # write the body expressions' types into the origin module's shared `expr_type`
 # array - exactly the array lowering then reads. Distinct elements and instances
@@ -172,6 +176,19 @@ pub fun sema(
 # typing and emission), so one shared array suffices. The transient context
 # reuses the origin SemaResult's arrays in place rather than allocating, so it
 # must not be torn down.
+#
+# Being the sole typing pass over that body, it carries both halves of per-instance
+# validation rather than deferring them to the module sema pass that already ran:
+#
+#   - the enclosing instance's substitution (#2174), so a body naming a generic
+#     parameter is typed against the concrete instance type - which makes the
+#     #1645 leakage gates fire on a secret arriving through a parameter, and names
+#     the concrete type in every diagnostic the body raises; and
+#   - the caller's constant-time re-validation worklist (#2177), drained here
+#     rather than by the sema pass, so a generic instantiated only from inside this
+#     body is re-validated under its concrete type arguments like every other
+#     instantiation. The worklist is owned across a whole module's lowering, so its
+#     `drained` cursor validates each distinct instance exactly once.
 # ---
 # s:           the origin module's session
 # a:           the origin module's Ast (declares the pack-tailed template)
@@ -183,7 +200,11 @@ pub fun sema(
 # fn_ret:      the instance's semantic return type (checks any body `ret`)
 # body_start:  index of the first `$each` body statement
 # body_len:    number of `$each` body statements
-# ret:         true once the body is typed, or the first inference error
+# subst:       the enclosing instance's generic substitution, or nil outside one
+# subst_len:   number of substitution arguments
+# insts:       the caller-owned CT re-validation worklist, drained before returning
+# ret:         true once the body is typed and its instances re-validated, or the
+#              first inference error
 pub fun reinfer_pack_each_body(
     s:           *session.Session,
     a:           *ast.Ast,
@@ -194,8 +215,16 @@ pub fun reinfer_pack_each_body(
     sema_result: *context.SemaResult,
     fn_ret:      type.TypeId,
     body_start:  u32,
-    body_len:    u32
+    body_len:    u32,
+    subst:       *type.TypeId,
+    subst_len:   u32,
+    insts:       *context.InstWorklist
 ) R.Result[bool, str] {
+    # the worklist is the caller's contract, not an optional extra: without one a
+    # generic instantiated from this body would be silently dropped from the CT
+    # re-validation - the #2177 disclosure - so a nil is a loud invariant break.
+    if (insts == nil) { ret R.err[bool, str]("internal: #2177 deferred-body re-inference: no constant-time re-validation worklist supplied (invariant violated)"); }
+
     var sc: context.SemaContext;
     sc.s          = s;
     sc.a          = a;
@@ -213,13 +242,16 @@ pub fun reinfer_pack_each_body(
     sc.in_comptime_gate = false;
     sc.in_fin           = false;
     sc.fin_loop_depth   = 0;
-    sc.subst            = nil;
-    sc.subst_len        = 0;
-    sc.subst_fn         = nil;
-    sc.insts            = nil;
-    sc.collect_insts    = false;
+    sc.subst            = subst;
+    sc.subst_len        = subst_len;
+    sc.subst_fn         = generics.substitute;
+    sc.insts            = insts;
+    sc.collect_insts    = true;
 
-    ret infer_stmt_list(?sc, body_start, body_len, fn_ret);
+    val res_body: R.Result[bool, str] = infer_stmt_list(?sc, body_start, body_len, fn_ret);
+    if (R.is_err[bool, str](res_body)) { ret res_body; }
+
+    ret drain_instances(?sc, deps);
 }
 
 # copy `n` TypeIds from `src` into `dst`
@@ -251,12 +283,35 @@ fun free_typeids(alloc: *A.Allocator, arr: *type.TypeId, n: usize) {
 # ret: true once drained, or the first internal error (gate violations are reported
 #      diagnostics, not errors)
 fun drain_revalidations(sc: *context.SemaContext) R.Result[bool, str] {
-    if (sc.insts == nil)          { ret R.ok[bool, str](true); }
-    if (sc.insts.len == 0)        { ret R.ok[bool, str](true); }
+    if (sc.insts == nil)                       { ret R.ok[bool, str](true); }
+    if (sc.insts.drained >= sc.insts.len)      { ret R.ok[bool, str](true); }
 
     val dr: R.Result[context.SemaDeps, str] = collect_module_deps(sc.s);
     if (R.is_err[context.SemaDeps, str](dr)) { ret R.err[bool, str](R.unwrap_err[context.SemaDeps, str](dr)); }
     var full_deps: context.SemaDeps = R.unwrap_ok[context.SemaDeps, str](dr);
+
+    val r: R.Result[bool, str] = drain_instances(sc, ?full_deps);
+    free_module_deps(sc.s, ?full_deps);
+    ret r;
+}
+
+# drain the worklist against an already-built module-deps snapshot (#2157, #2177)
+#
+# The drain proper, split out so an inference episode that already holds a
+# module-spanning snapshot - the lowering-time deferred-body re-inference, which
+# built one to resolve the body's cross-module references - reuses it rather than
+# rebuilding it per element. Reads each entry by value before re-validating, since
+# re-validation may grow the worklist (the owned `args` buffers are separate
+# allocations, so their pointers stay stable across that growth). The `drained`
+# cursor persists on the worklist, so repeated calls over one shared worklist
+# re-validate each distinct instance exactly once.
+# ---
+# sc:   the context owning the worklist and the diagnostic sink
+# deps: a module-spanning typing snapshot for cross-module instance bodies
+# ret:  true once drained, or the first internal error (gate violations are
+#       reported diagnostics, not errors)
+fun drain_instances(sc: *context.SemaContext, deps: *context.SemaDeps) R.Result[bool, str] {
+    if (sc.insts == nil) { ret R.ok[bool, str](true); }
 
     for (sc.insts.drained < sc.insts.len) {
         val idx:     u32              = sc.insts.drained;
@@ -266,15 +321,10 @@ fun drain_revalidations(sc: *context.SemaContext) R.Result[bool, str] {
         val args:    *type.TypeId     = sc.insts.items[idx].args;
         val arg_len: u32              = sc.insts.items[idx].arg_len;
 
-        val r: R.Result[bool, str] = revalidate_one(sc, ?full_deps, origin, decl, args, arg_len, sig);
-        if (R.is_err[bool, str](r)) {
-            free_module_deps(sc.s, ?full_deps);
-            ret r;
-        }
+        val r: R.Result[bool, str] = revalidate_one(sc, deps, origin, decl, args, arg_len, sig);
+        if (R.is_err[bool, str](r)) { ret r; }
         sc.insts.drained = sc.insts.drained + 1;
     }
-
-    free_module_deps(sc.s, ?full_deps);
     ret R.ok[bool, str](true);
 }
 
@@ -388,13 +438,20 @@ fun revalidate_one(sc: *context.SemaContext, deps: *context.SemaDeps, origin: se
     val ret_ty: type.TypeId = context.resolved_type_of(?tsc, d.data.fun_.return_type);
 
     # fold this body's comptime gates against the origin module via the transient
-    # context; restored to uninstalled afterward (the drain re-installs per instance).
-    val tscp: *context.SemaContext = ?tsc;
+    # context, then put back whatever was installed. the drain also runs during
+    # lowering (#2177), where the origin's context carries LOWERING's resolvers and
+    # the rest of that module's lowering still needs them - clearing them here would
+    # strip a live installation, so save and restore rather than clear.
+    val tscp:      *context.SemaContext = ?tsc;
+    val saved_ffn: *u8                  = octx.field_fn;
+    val saved_fd:  ptr                  = octx.field_data;
+    val saved_tfn: *u8                  = octx.type_fn;
+    val saved_td:  ptr                  = octx.type_data;
     comptime.set_field_resolver(octx, context.resolve_field_member::*u8, tscp::ptr);
     comptime.set_type_resolver(octx, context.resolve_type_comparison_operand::*u8, tscp::ptr);
     val res: R.Result[bool, str] = infer_stmt(?tsc, d.data.fun_.body, ret_ty);
-    comptime.set_field_resolver(octx, nil, nil);
-    comptime.set_type_resolver(octx, nil, nil);
+    comptime.set_field_resolver(octx, saved_ffn, saved_fd);
+    comptime.set_type_resolver(octx, saved_tfn, saved_td);
 
     free_typeids(sc.s.alloc, scratch_expr, oa.expr_len);
     free_typeids(sc.s.alloc, scratch_decl, oa.decl_len);

--- a/src/lang/fe/sema/context.mach
+++ b/src/lang/fe/sema/context.mach
@@ -163,10 +163,11 @@ pub rec SemaContext {
     # borrows the same pointer so its nested generic calls append to the one worklist.
     insts: *InstWorklist;
 
-    # gate for `record_instance` (#2157): true on the main sema pass and on a sema-time
-    # instance re-validation (which collect generic instantiations to re-validate),
-    # false on the lowering-time pack re-inference (`reinfer_pack_each_body`), which
-    # runs the same inference machinery but must not collect or drain a worklist.
+    # gate for `record_instance` (#2157): true on every inference episode that owns a
+    # worklist it will drain - the main sema pass, a sema-time instance re-validation,
+    # and the lowering-time pack / deferred-`$fields` body re-inference (#2177). false
+    # only on an episode with no worklist, where a recorded instance would never be
+    # re-validated and would leak its arguments.
     collect_insts: bool;
 
     expr_type:        *type.TypeId;
@@ -393,15 +394,9 @@ pub fun record_instance(sc: *SemaContext, origin: session.ModuleId, decl: id.Dec
     }
 
     if (sc.insts == nil) {
-        val wr: R.Result[*InstWorklist, str] = A.allocate[InstWorklist](sc.s.alloc, 1::usize);
-        if (R.is_err[*InstWorklist, str](wr)) { ret R.err[bool, str]("internal: out of memory allocating the constant-time re-validation worklist"); }
-        val wl: *InstWorklist = R.unwrap_ok[*InstWorklist, str](wr);
-        wl.items   = nil;
-        wl.len     = 0;
-        wl.cap     = 0;
-        wl.drained = 0;
-        wl.alloc   = sc.s.alloc;
-        sc.insts = wl;
+        val wr: R.Result[*InstWorklist, str] = inst_worklist_new(sc.s.alloc);
+        if (R.is_err[*InstWorklist, str](wr)) { ret R.err[bool, str](R.unwrap_err[*InstWorklist, str](wr)); }
+        sc.insts = R.unwrap_ok[*InstWorklist, str](wr);
     }
     val wl: *InstWorklist = sc.insts;
 
@@ -431,12 +426,32 @@ pub fun record_instance(sc: *SemaContext, origin: session.ModuleId, decl: id.Dec
     ret R.ok[bool, str](true);
 }
 
-# free the CT re-validation worklist and every request's owned arguments (#2157)
+# allocate an empty CT re-validation worklist (#2157)
+#
+# An inference episode that runs outside the module sema pass - the lowering-time
+# pack / deferred-`$fields` body re-inference (#2177) - owns its worklist for the
+# whole lowering of one module and hands the same pointer to every episode, so the
+# `drained` cursor validates each distinct instance exactly once.
 # ---
-# sc: the sema context whose worklist is released (nil-safe; cleared to nil)
-pub fun inst_worklist_dnit(sc: *SemaContext) {
-    if (sc.insts == nil) { ret; }
-    val wl: *InstWorklist = sc.insts;
+# alloc: allocator backing the worklist and every request's owned arguments
+# ret:   the empty worklist, or a complete user-facing allocation-failure message
+pub fun inst_worklist_new(alloc: *A.Allocator) R.Result[*InstWorklist, str] {
+    val wr: R.Result[*InstWorklist, str] = A.allocate[InstWorklist](alloc, 1::usize);
+    if (R.is_err[*InstWorklist, str](wr)) { ret R.err[*InstWorklist, str]("internal: out of memory allocating the constant-time re-validation worklist"); }
+    val wl: *InstWorklist = R.unwrap_ok[*InstWorklist, str](wr);
+    wl.items   = nil;
+    wl.len     = 0;
+    wl.cap     = 0;
+    wl.drained = 0;
+    wl.alloc   = alloc;
+    ret R.ok[*InstWorklist, str](wl);
+}
+
+# free a CT re-validation worklist and every request's owned arguments (#2157)
+# ---
+# wl: the worklist to release; nil is a no-op
+pub fun inst_worklist_free(wl: *InstWorklist) {
+    if (wl == nil) { ret; }
     var i: u32 = 0;
     for (i < wl.len) {
         val e: *InstReq = ?wl.items[i];
@@ -449,6 +464,13 @@ pub fun inst_worklist_dnit(sc: *SemaContext) {
         A.deallocate[InstReq](wl.alloc, wl.items, wl.cap::usize);
     }
     A.deallocate[InstWorklist](wl.alloc, wl, 1::usize);
+}
+
+# free the CT re-validation worklist a sema context owns (#2157)
+# ---
+# sc: the sema context whose worklist is released (nil-safe; cleared to nil)
+pub fun inst_worklist_dnit(sc: *SemaContext) {
+    inst_worklist_free(sc.insts);
     sc.insts = nil;
 }
 

--- a/src/lang/me/lower/context.mach
+++ b/src/lang/me/lower/context.mach
@@ -197,6 +197,11 @@ pub rec PackInstance {
 # pack_len:      number of expanded pack parameters (0 outside a pack instance)
 # pack_ret_type: the pack instance's semantic return type, supplied to per-
 #                element body re-inference so a body `ret` checks against it
+#
+# ct_insts:      the module's constant-time re-validation worklist (#2177), shared
+#                by every deferred-`$each` body re-inference so a generic reached
+#                only from inside one is re-validated under its concrete type
+#                arguments, and each distinct instance exactly once
 pub rec LowerContext {
     s:           *session.Session;
     tgt:         *target.Target;
@@ -248,6 +253,8 @@ pub rec LowerContext {
     pack_types:    *type.TypeId;
     pack_len:      u32;
     pack_ret_type: type.TypeId;
+
+    ct_insts: *sema.InstWorklist;
 }
 
 
@@ -355,11 +362,24 @@ pub fun init_context(
     lc.pack_len      = 0;
     lc.pack_ret_type = type.TYPE_NIL;
 
+    # the CT re-validation worklist spans the whole module's lowering so its
+    # `drained` cursor dedupes across every deferred-`$each` body (#2177).
+    val res_ct: R.Result[*sema.InstWorklist, str] = sema.inst_worklist_new(s.alloc);
+    if (R.is_err[*sema.InstWorklist, str](res_ct)) {
+        A.deallocate[id.StmtId](s.alloc, lc.fins, lc.fin_cap::usize);
+        A.deallocate[LoopFrame](s.alloc, lc.loops, lc.loop_cap::usize);
+        map.dnit[intern.StrId, value.Value](?lc.local_names);
+        map.dnit[resolve.SymbolId, value.Value](?lc.locals);
+        ret R.err[bool, str](R.unwrap_err[*sema.InstWorklist, str](res_ct));
+    }
+    lc.ct_insts = R.unwrap_ok[*sema.InstWorklist, str](res_ct);
+
     ret R.ok[bool, str](true);
 }
 
 # release the working storage held by a LowerContext (the locals maps, the loop
-# and fin stacks, and the three instance worklists) and clear the comptime
+# and fin stacks, the three instance worklists, and the constant-time re-validation
+# worklist) and clear the comptime
 # resolvers init_context installed, so the borrowed ctx never keeps a dangling
 # LowerContext pointer past this module's lowering. does not otherwise touch the
 # borrowed phase inputs or the module
@@ -414,6 +434,8 @@ pub fun dnit_context(lc: *LowerContext) {
         }
         A.deallocate[PackInstance](lc.s.alloc, lc.pinsts, lc.pinst_cap::usize);
     }
+    sema.inst_worklist_free(lc.ct_insts);
+    lc.ct_insts = nil;
 
     lc.loops    = nil;
     lc.loop_len = 0;

--- a/src/lang/me/lower/stmt.mach
+++ b/src/lang/me/lower/stmt.mach
@@ -720,7 +720,8 @@ fun lower_comptime_each(ctx: *context.LowerContext, s: *stmt.Stmt) R.Result[bool
             # re-type the body for this field (deferred at template sema), writing
             # expression types into the shared array lowering reads next.
             val res_reinfer: R.Result[bool, str] = sema.reinfer_pack_each_body(ctx.s, ctx.a, ctx.rr, ?deps, ctx.ctx,
-                ctx.own_module, ctx.sema_result, ctx.fn_ret_sem, ce.body_start, ce.body_len);
+                ctx.own_module, ctx.sema_result, ctx.fn_ret_sem, ce.body_start, ce.body_len,
+                ctx.subst, ctx.subst_len, ctx.ct_insts);
             if (R.is_err[bool, str](res_reinfer)) {
                 val res_close: R.Result[bool, str] = comptime.frame_close(ctx.ctx, mark);
                 sema.free_module_deps(ctx.s, ?deps);
@@ -791,7 +792,8 @@ fun lower_pack_each(ctx: *context.LowerContext, ce: *stmt.StmtComptimeEach) R.Re
         # re-type the body for this element (its type is fixed only here), writing
         # the body expressions' types into the shared array lowering reads next.
         val res_reinfer: R.Result[bool, str] = sema.reinfer_pack_each_body(ctx.s, ctx.a, ctx.rr, ?deps, ctx.ctx,
-            ctx.own_module, ctx.sema_result, ctx.pack_ret_type, ce.body_start, ce.body_len);
+            ctx.own_module, ctx.sema_result, ctx.pack_ret_type, ce.body_start, ce.body_len,
+            ctx.subst, ctx.subst_len, ctx.ct_insts);
         if (R.is_err[bool, str](res_reinfer)) {
             val res_close: R.Result[bool, str] = comptime.frame_close(ctx.ctx, mark);
             sema.free_module_deps(ctx.s, ?deps);


### PR DESCRIPTION
Closes #2177
Closes #2174

## The gap

A pack element's type is fixed only at monomorphization, so a pack `$each` body is type-checked **exactly once** — by `reinfer_pack_each_body`, during **lowering**, after the sema drain has run and freed its worklist. That episode set `collect_insts = false`, and `infer_generic_call` is the only enqueue point `drain_revalidations` consumes. So a generic whose only call site sat inside a pack body was looked at once with recording disabled: never enqueued, never re-inferred under its concrete type arguments.

## Shape chosen, and why

Recording there needs either a second drain in lowering or pack-body typing hoisted into sema. **The drain becomes a property of an inference episode, not of the module sema pass**: whichever pass type-checks a body drains the instances that body reaches. `sema()` already obeyed that invariant; `reinfer_pack_each_body` now does too, through the same `revalidate_one`.

Hoisting pack-body typing into sema was rejected on structure, not effort: pack monomorphization keys on the call-site element type-list and lives in lowering, and lowering must still type each element as it emits it. Sema-side validation typing would be a **second enumeration of the same instances**, and two enumerators that must agree is precisely the shape that produced this blind spot.

Supporting pieces the shape requires:

- the worklist is owned across one module's lowering (`LowerContext.ct_insts`), so its `drained` cursor validates each distinct instance exactly once regardless of element or pack-instance count;
- `drain_revalidations` splits into a deps-building wrapper and `drain_instances`, so the deferred-body drain reuses the module-spanning snapshot the unroll already built;
- `revalidate_one` **saves and restores** the origin context's comptime resolvers rather than clearing them — the drain now runs during lowering, where that context carries lowering's own installation.

#2174 falls out of the same episode: it carries the enclosing instance's substitution, so a deferred body naming a generic parameter is typed against the concrete instance type.

## Reproduction and rejection

Built from source (the 4.2.2 PATH seed was never the test compiler). On `origin/dev` @ `d4b7b191` the issue's reproducer builds with **zero diagnostics**, runs, prints `leaked = 99`. On this branch it is rejected with `error: a secret value cannot be passed to a variadic \`...\` argument` — the same diagnostic the out-of-pack twin has always produced.

**Two further escapes** through the same hole were found by probing and are closed here:

| shape reached only from a pack `$each` body | pre | post |
|---|---|---|
| secret handed to a variadic pack (the issue) | ran, `leaked = 99` | rejected |
| aggregate `==` at a record instance (#2127) | ran, `r = 1` | rejected |
| `#[oblivious]` generic returning `^u8` through a public `u8` | ran, `r = 2` | rejected |

Each is paired with its out-of-pack control, which was and stays rejected.

## Enumerated surface

`==`/`!=` and passing to a pack are the only operations a generic body can perform on a bare `T` (arithmetic on a template parameter is refused at the template pass), so the reachable surface is small and was probed exhaustively by building and running. Full results, including the shapes that did **not** leak, are in the worker report on the issue.

## Verification

- compiler suite **806 / 0** (804 baseline + the 2 tests added)
- mach-std **611 / 0** at pin `eff1e8e` (`git rev-parse HEAD` verified against `mach.lock`)
- three-generation fixpoint **B == C == D**, byte-identical
- pre-fix and post-fix compilers emit a **byte-identical** artifact from the same secret-free sources: analysis only, no codegen effect
- every new assertion confirmed to fail without the fix, per-assertion, via a bitmask build

## Out of scope, escalated

`PackInstance` carries no generic type arguments, so a **pack-tailed generic** loses its substitution entirely. `fun f[T](t: T, va: ...)` fails at lowering with `call argument typing: ...`, and `fun f[T](va: ...)` silently drops the substitution — a `T`-typed local in its pack body is not seen as secret at a `^` instantiation. Closing that means keying pack instances on (type-args × element-types), which lands in `me/lower/expr.mach` (owned by #2223). Filed separately rather than papered over.
