### PR TITLE
fix(lower): key a pack instance on its generic type-args (#2251)

### DIFF
--- a/doc/language/secrecy.md
+++ b/doc/language/secrecy.md
@@ -171,10 +171,13 @@ run it with `bash int/ct/ct.sh`.
 
 What does not hold — the known open holes:
 
-- **a pack-tailed generic loses its type arguments at monomorphization**, so its
-  `$each` body is typed against the raw parameter and a value that is secret at
-  the instance is not seen as one — it reaches a variadic pack with no
-  diagnostic. Proven, security-blocking (briar-systems/mach#2251).
+- **a pack-tailed function's statements outside its `$each` are never re-typed
+  per instance**, so a `T`-typed local declared there and used inside the unroll
+  is typed against the raw parameter and a value that is secret at the instance
+  is not seen as one — it reaches a variadic pack with no diagnostic. The `$each`
+  body itself, and every parameter, are typed against the concrete arguments
+  (briar-systems/mach#2251); this is the remainder. Proven, security-blocking
+  (briar-systems/mach#2254).
 - **`$fields` reflection projection inside a generic erases a secret field's
   secrecy**, which discloses the secret. Proven, security-blocking
   (briar-systems/mach#2168).

--- a/doc/language/variadics.md
+++ b/doc/language/variadics.md
@@ -105,6 +105,19 @@ sum(10, 20)            # instance: (i64, i64)
 sum(5::u8, 1::u32)     # instance: (u8, u32)
 ```
 
+A pack tail composes with generic parameters. The instance key is then the
+**product** of the type arguments and the element type-list, so `sink[u32](x)`
+and `sink[^u32](x)` over the same elements are two instances with two bodies,
+each typed and lowered against its own type arguments:
+
+```mach
+fun sink[T](t: T, va: ...) u32 { ... }
+
+sink[u32](p, 1u32)     # instance: [u32] over (u32)
+sink[u64](p, 1u32)     # instance: [u64] over (u32)
+sink[u32](p, 1u32, 2u64)   # instance: [u32] over (u32, u64)
+```
+
 Because a pack-tailed function has no single entry point, it is **not a
 stable-ABI symbol** — it cannot be the target of `ext fun` or a function
 pointer shared across compilation units. It is source-level only.

--- a/src/lang/driver/tests.mach
+++ b/src/lang/driver/tests.mach
@@ -6716,3 +6716,297 @@ test "mach.lang.driver:deferred_each_body_instance_types" {
 
     ret bad;
 }
+
+# how many DEFINED (non-extern) functions in `m` carry `needle` in their linkage
+# name - the count of monomorphized bodies one template emitted
+fun ut_defined_fn_count(s: *session.Session, m: *ir.Module, needle: str) u32 {
+    if (m == nil) { ret 0; }
+    var hits: u32 = 0;
+    var fi: u32 = 0;
+    for (fi < m.function_len) {
+        val f: *ir.Function = ?m.functions[fi];
+        if ((f.flags & ir.FN_FLAG_EXTERN) == 0) {
+            val nm: O.Option[str] = intern.lookup(?s.interner, f.name);
+            if (O.is_some[str](nm) && ut_str_contains(O.unwrap[str](nm), needle)) { hits = hits + 1; }
+        }
+        fi = fi + 1;
+    }
+    ret hits;
+}
+
+# the interned IR signature of the first DEFINED function in `m` whose linkage
+# name carries `needle`, or IRT_NIL when there is none
+fun ut_defined_fn_sig(s: *session.Session, m: *ir.Module, needle: str) ir_type.IrTypeId {
+    if (m == nil) { ret ir_type.IRT_NIL; }
+    var fi: u32 = 0;
+    for (fi < m.function_len) {
+        val f: *ir.Function = ?m.functions[fi];
+        if ((f.flags & ir.FN_FLAG_EXTERN) == 0) {
+            val nm: O.Option[str] = intern.lookup(?s.interner, f.name);
+            if (O.is_some[str](nm) && ut_str_contains(O.unwrap[str](nm), needle)) { ret f.sig; }
+        }
+        fi = fi + 1;
+    }
+    ret ir_type.IRT_NIL;
+}
+
+# the IR kind of `sig`'s return type, or IRT_VOID when the signature is absent or
+# is not a function type
+fun ut_sig_ret_kind(m: *ir.Module, sig: ir_type.IrTypeId) ir_type.IrTypeKind {
+    if (m == nil || sig == ir_type.IRT_NIL) { ret ir_type.IRT_VOID; }
+    val t: O.Option[*ir_type.IrType] = ir_type.get(?m.types, sig);
+    if (O.is_none[*ir_type.IrType](t))                       { ret ir_type.IRT_VOID; }
+    if (O.unwrap[*ir_type.IrType](t).kind != ir_type.IRT_FN) { ret ir_type.IRT_VOID; }
+    val rt: ir_type.IrTypeId = O.unwrap[*ir_type.IrType](t).data.fn.ret_type;
+    val r: O.Option[*ir_type.IrType] = ir_type.get(?m.types, rt);
+    if (O.is_none[*ir_type.IrType](r)) { ret ir_type.IRT_VOID; }
+    ret O.unwrap[*ir_type.IrType](r).kind;
+}
+
+# the IR kind of `sig`'s parameter at ordinal `ix`, or IRT_VOID when absent
+fun ut_sig_param_kind(m: *ir.Module, sig: ir_type.IrTypeId, ix: u32) ir_type.IrTypeKind {
+    if (m == nil || sig == ir_type.IRT_NIL) { ret ir_type.IRT_VOID; }
+    val t: O.Option[*ir_type.IrType] = ir_type.get(?m.types, sig);
+    if (O.is_none[*ir_type.IrType](t)) { ret ir_type.IRT_VOID; }
+    val ft: *ir_type.IrType = O.unwrap[*ir_type.IrType](t);
+    if (ft.kind != ir_type.IRT_FN)    { ret ir_type.IRT_VOID; }
+    if (ix >= ft.data.fn.param_count) { ret ir_type.IRT_VOID; }
+    val p: O.Option[*ir_type.IrType] = ir_type.get(?m.types, ft.data.fn.params[ix]);
+    if (O.is_none[*ir_type.IrType](p)) { ret ir_type.IRT_VOID; }
+    ret O.unwrap[*ir_type.IrType](p).kind;
+}
+
+# constant-time (#2251): a pack-tailed GENERIC is monomorphized under its concrete
+# type arguments, so the `$each` body - whose per-element re-inference at
+# monomorphization is its ONLY typing pass - is typed against them
+#
+# `PackInstance` keyed on the call-site element type-list alone and the drain bound
+# the body with no substitution, so a `T`-typed value inside the unroll was the bare
+# parameter and never secret: `sink[^u32](one)` printed the secret with zero
+# diagnostics. Every shape below is rejected only because the instance's real types
+# reach the body; each is paired with the public twin that must stay clean
+test "mach.lang.driver:pack_generic_body_typed_at_instance" {
+    var bad: i32 = 0;
+
+    # the issue's reproducer: a `T`-typed LOCAL inside the `$each` body.
+    if (ut_ct_lower_diag("fun logf(va: ...) u32 { ret 0; }\nfun sink[T](va: ...) u32 { var acc: u32 = 0; $each a in va { var z: T; acc = acc + logf(z); acc = acc + a; } ret acc; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { var one: u32 = 1; sink[^u32](one); ret 0; }\n",
+        "secret value cannot be passed to a variadic") != 0) { bad = 1; }
+    # the public twin of that exact source compiles: the instantiation is what is
+    # rejected, not the shape.
+    if (!ut_ct_lower_clean("fun logf(va: ...) u32 { ret 0; }\nfun sink[T](va: ...) u32 { var acc: u32 = 0; $each a in va { var z: T; acc = acc + logf(z); acc = acc + a; } ret acc; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { var one: u32 = 1; sink[u32](one); ret 0; }\n")) { bad = 1; }
+
+    # a SECOND type parameter: the substitution is by ordinal, so binding only the
+    # first would leave this one raw.
+    if (ut_ct_lower_diag("fun logf(va: ...) u32 { ret 0; }\nfun sink[T, U](va: ...) u32 { var acc: u32 = 0; $each a in va { var z: U; acc = acc + logf(z); acc = acc + a; } ret acc; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { var one: u32 = 1; sink[u32, ^u32](one); ret 0; }\n",
+        "secret value cannot be passed to a variadic") != 0) { bad = 1; }
+    if (!ut_ct_lower_clean("fun logf(va: ...) u32 { ret 0; }\nfun sink[T, U](va: ...) u32 { var acc: u32 = 0; $each a in va { var z: U; acc = acc + logf(z); acc = acc + a; } ret acc; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { var one: u32 = 1; sink[u32, u32](one); ret 0; }\n")) { bad = 1; }
+
+    # a `T`-typed leading PARAMETER read from inside the body - the form that could
+    # not be called at all before, because the reference signature erased `T`.
+    if (ut_ct_lower_diag("fun logf(va: ...) u32 { ret 0; }\nfun sink[T](t: T, va: ...) u32 { var acc: u32 = 0; $each a in va { acc = acc + logf(t); acc = acc + a; } ret acc; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { var s: ^u32 = 9; var one: u32 = 1; sink[^u32](s, one); ret 0; }\n",
+        "secret value cannot be passed to a variadic") != 0) { bad = 1; }
+    if (!ut_ct_lower_clean("fun logf(va: ...) u32 { ret 0; }\nfun sink[T](t: T, va: ...) u32 { var acc: u32 = 0; $each a in va { acc = acc + logf(t); acc = acc + a; } ret acc; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { var p: u32 = 9; var one: u32 = 1; sink[u32](p, one); ret 0; }\n")) { bad = 1; }
+
+    # a nested GENERIC instantiated from the pack body at the enclosing instance's
+    # `T`: the #2177 re-validation episode now sees a concrete secret rather than a
+    # bare parameter.
+    if (ut_ct_lower_diag("fun probe[U](a: U, b: U) u32 { if (a == b) { ret 1; } ret 0; }\nfun sink[T](va: ...) u32 { var acc: u32 = 0; $each e in va { var x: T; var y: T; acc = acc + probe[T](x, y); } ret acc; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { var one: u32 = 1; sink[^u32](one); ret 0; }\n",
+        "secret value used as a branch condition") != 0) { bad = 1; }
+    if (!ut_ct_lower_clean("fun probe[U](a: U, b: U) u32 { if (a == b) { ret 1; } ret 0; }\nfun sink[T](va: ...) u32 { var acc: u32 = 0; $each e in va { var x: T; var y: T; acc = acc + probe[T](x, y); } ret acc; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { var one: u32 = 1; sink[u32](one); ret 0; }\n")) { bad = 1; }
+
+    # a pack body instantiating ANOTHER pack-tailed generic: the substitution has to
+    # reach the transitively-queued instance, not only the one main names.
+    if (ut_ct_lower_diag("fun logf(va: ...) u32 { ret 0; }\nfun inner[U](va: ...) u32 { var acc: u32 = 0; $each b in va { var z: U; acc = acc + logf(z); acc = acc + b; } ret acc; }\nfun outer[T](va: ...) u32 { var acc: u32 = 0; $each a in va { acc = acc + inner[T](a); } ret acc; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { var one: u32 = 1; outer[^u32](one); ret 0; }\n",
+        "secret value cannot be passed to a variadic") != 0) { bad = 1; }
+    if (!ut_ct_lower_clean("fun logf(va: ...) u32 { ret 0; }\nfun inner[U](va: ...) u32 { var acc: u32 = 0; $each b in va { var z: U; acc = acc + logf(z); acc = acc + b; } ret acc; }\nfun outer[T](va: ...) u32 { var acc: u32 = 0; $each a in va { acc = acc + inner[T](a); } ret acc; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { var one: u32 = 1; outer[u32](one); ret 0; }\n")) { bad = 1; }
+
+    # a `va...` SPREAD forward: the element type-list is borrowed from the current
+    # instance, and the type-arguments must ride along with it.
+    if (ut_ct_lower_diag("fun logf(va: ...) u32 { ret 0; }\nfun tail[U](va: ...) u32 { var acc: u32 = 0; $each b in va { var z: U; acc = acc + logf(z); acc = acc + b; } ret acc; }\nfun fwd[T](va: ...) u32 { ret tail[T](va...); }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { var one: u32 = 1; fwd[^u32](one); ret 0; }\n",
+        "secret value cannot be passed to a variadic") != 0) { bad = 1; }
+    if (!ut_ct_lower_clean("fun logf(va: ...) u32 { ret 0; }\nfun tail[U](va: ...) u32 { var acc: u32 = 0; $each b in va { var z: U; acc = acc + logf(z); acc = acc + b; } ret acc; }\nfun fwd[T](va: ...) u32 { ret tail[T](va...); }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { var one: u32 = 1; fwd[u32](one); ret 0; }\n")) { bad = 1; }
+
+    # a `$fields(T)` walk NESTED in the pack body: deferred twice over, and its owner
+    # type resolves from the same substitution.
+    if (ut_ct_lower_diag("rec P { x: ^u32; }\nfun logf(va: ...) u32 { ret 0; }\nfun sink[T](v: T, va: ...) u32 { var acc: u32 = 0; $each e in va { $each f in $fields(T) { acc = acc + logf(v.[f]); } acc = acc + e; } ret acc; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { var p: P; var one: u32 = 1; sink[P](p, one); ret 0; }\n",
+        "secret value cannot be passed to a variadic") != 0) { bad = 1; }
+    if (!ut_ct_lower_clean("rec Q { x: u32; }\nfun logf(va: ...) u32 { ret 0; }\nfun sink[T](v: T, va: ...) u32 { var acc: u32 = 0; $each e in va { $each f in $fields(T) { acc = acc + logf(v.[f]); } acc = acc + e; } ret acc; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { var q: Q; var one: u32 = 1; sink[Q](q, one); ret 0; }\n")) { bad = 1; }
+
+    # a secret reached through an AGGREGATE type argument: the deep walk keys on the
+    # instantiated record, which exists only once the substitution is bound.
+    if (ut_ct_lower_diag("rec P { x: ^u32; }\nfun logf(va: ...) u32 { ret 0; }\nfun sink[T](va: ...) u32 { var acc: u32 = 0; $each a in va { var z: T; acc = acc + logf(z); acc = acc + a; } ret acc; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { var one: u32 = 1; sink[P](one); ret 0; }\n",
+        "secret value cannot be passed to a variadic") != 0) { bad = 1; }
+    if (!ut_ct_lower_clean("rec Q { x: u32; }\nfun logf(va: ...) u32 { ret 0; }\nfun sink[T](va: ...) u32 { var acc: u32 = 0; $each a in va { var z: T; acc = acc + logf(z); acc = acc + a; } ret acc; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { var one: u32 = 1; sink[Q](one); ret 0; }\n")) { bad = 1; }
+
+    # the name carrying the type-arguments is a SECURITY property, not cosmetics:
+    # instantiate the public form FIRST, so a name that erased them - or erased the
+    # `^` on them - dedups the secret instance onto the already-emitted public body
+    # and never types it at all. this is the shape the collapse actually hid behind.
+    if (ut_ct_lower_diag("fun logf(va: ...) u32 { ret 0; }\nfun sink[T](va: ...) u32 { var acc: u32 = 0; $each a in va { var z: T; acc = acc + logf(z); acc = acc + a; } ret acc; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { var one: u32 = 1; sink[u32](one); sink[^u32](one); ret 0; }\n",
+        "secret value cannot be passed to a variadic") != 0) { bad = 1; }
+    # and in the other order, so neither emission order can be the one that works.
+    if (ut_ct_lower_diag("fun logf(va: ...) u32 { ret 0; }\nfun sink[T](va: ...) u32 { var acc: u32 = 0; $each a in va { var z: T; acc = acc + logf(z); acc = acc + a; } ret acc; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { var one: u32 = 1; sink[^u32](one); sink[u32](one); ret 0; }\n",
+        "secret value cannot be passed to a variadic") != 0) { bad = 1; }
+
+    # the `#[oblivious]` requirement names the INSTANCE symbol, so the diagnostic
+    # itself carries the secret-marked type-argument suffix the two instantiations
+    # are now distinguished by.
+    if (ut_ct_lower_diag("fun cmp[T](a: T, b: T, va: ...) u32 { var acc: u32 = 0; $each e in va { var m: ^u8 = a == b; } ret acc; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { var s: ^u32 = 1; var one: u32 = 1; cmp[^u32](s, s, one); ret 0; }\n",
+        "cmpIS3u32EQ3u32E` performs a constant-time comparison") != 0) { bad = 1; }
+
+    ret bad;
+}
+
+# a pack-tailed generic's instances are named by `(type-args x element-types)`, so
+# two instantiations the type system distinguishes get two bodies (#2251)
+#
+# The name was the element type-list alone, so `sink[u32]` and `sink[^u32]` over the
+# same element list were ONE worklist entry and ONE emitted body - the second
+# instantiation silently reused the first's substitution, which is how the secrecy
+# escape survived a per-instance re-validation that ran exactly once. The suffixes are
+# asserted literally: `I...E` carries the type-arguments (a secret marked `S`), `Q...E`
+# the element types
+test "mach.lang.driver:pack_generic_instance_names" {
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    val sr: R.Result[session.Session, str] = session.init(?alloc);
+    if (R.is_err[session.Session, str](sr)) { ret 1; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](sr);
+    var bad: i32 = 0;
+
+    # secret and public instantiations over ONE element type-list: two bodies, named
+    # apart by the `S`-marked type argument.
+    var n1: [1]str;
+    n1[0] = "main.mach";
+    var t1: [1]str;
+    t1[0] = "fun sink[T](va: ...) u32 { var acc: u32 = 0; $each a in va { acc = acc + a; } ret acc; }\nfun main() i32 { var one: u32 = 1; sink[u32](one); sink[^u32](one); ret 0; }\n";
+    val p1: R.Result[project.Project, outcome.Fail] = ut_lower_n(?s, ?alloc, ?n1[0], ?t1[0], 1);
+    if (R.is_err[project.Project, outcome.Fail](p1)) { bad = 1; }
+    or {
+        var pp: project.Project = R.unwrap_ok[project.Project, outcome.Fail](p1);
+        val m: *ir.Module = ut_ir_of(?pp, ?s, "uniontest.main");
+        if (ut_defined_fn_count(?s, m, "sinkI") != 2)             { bad = 1; }
+        if (ut_defined_fn_count(?s, m, "sinkI3u32EQ3u32E") != 1)  { bad = 1; }
+        if (ut_defined_fn_count(?s, m, "sinkIS3u32EQ3u32E") != 1) { bad = 1; }
+        project.dnit_project(?pp);
+    }
+
+    # the key is a PRODUCT: two type-arguments over two element type-lists are four
+    # instances, and a repeated instantiation still dedups to the same body.
+    var n2: [1]str;
+    n2[0] = "main.mach";
+    var t2: [1]str;
+    t2[0] = "fun sink[T](va: ...) u32 { var acc: u32 = 0; $each a in va { acc = acc + 1; } ret acc; }\nfun main() i32 { var a: u32 = 1; var b: u64 = 2; sink[u32](a); sink[u64](a); sink[u32](a, b); sink[u64](a, b); sink[u32](a); ret 0; }\n";
+    val p2: R.Result[project.Project, outcome.Fail] = ut_lower_n(?s, ?alloc, ?n2[0], ?t2[0], 1);
+    if (R.is_err[project.Project, outcome.Fail](p2)) { bad = 1; }
+    or {
+        var pp: project.Project = R.unwrap_ok[project.Project, outcome.Fail](p2);
+        val m: *ir.Module = ut_ir_of(?pp, ?s, "uniontest.main");
+        if (ut_defined_fn_count(?s, m, "sinkI") != 4)                { bad = 1; }
+        if (ut_defined_fn_count(?s, m, "sinkI3u32EQ3u32E") != 1)     { bad = 1; }
+        if (ut_defined_fn_count(?s, m, "sinkI3u64EQ3u32E") != 1)     { bad = 1; }
+        if (ut_defined_fn_count(?s, m, "sinkI3u32EQ3u323u64E") != 1) { bad = 1; }
+        if (ut_defined_fn_count(?s, m, "sinkI3u64EQ3u323u64E") != 1) { bad = 1; }
+        project.dnit_project(?pp);
+    }
+
+    # a NON-generic pack tail keeps its exact previous symbol: no `I...E` suffix at
+    # all, so no existing program's emitted names move.
+    var n3: [1]str;
+    n3[0] = "main.mach";
+    var t3: [1]str;
+    t3[0] = "fun sum(va: ...) u32 { var acc: u32 = 0; $each a in va { acc = acc + a; } ret acc; }\nfun main() i32 { var one: u32 = 1; sum(one); ret 0; }\n";
+    val p3: R.Result[project.Project, outcome.Fail] = ut_lower_n(?s, ?alloc, ?n3[0], ?t3[0], 1);
+    if (R.is_err[project.Project, outcome.Fail](p3)) { bad = 1; }
+    or {
+        var pp: project.Project = R.unwrap_ok[project.Project, outcome.Fail](p3);
+        val m: *ir.Module = ut_ir_of(?pp, ?s, "uniontest.main");
+        if (ut_defined_fn_count(?s, m, "N9sumQ3u32E") != 1) { bad = 1; }
+        if (ut_defined_fn_count(?s, m, "sumI") != 0)        { bad = 1; }
+        project.dnit_project(?pp);
+    }
+
+    # a pack-tailed generic declared in ANOTHER module: the instance is emitted under
+    # its origin's FQN, and the type-argument suffix survives the origin re-bind.
+    var n4: [2]str;
+    n4[0] = "main.mach"; n4[1] = "lib.mach";
+    var t4: [2]str;
+    t4[0] = "use uniontest.lib;\nfun main() i32 { var one: u32 = 1; lib.sink[u32](one); lib.sink[^u32](one); ret 0; }\n";
+    t4[1] = "pub fun sink[T](va: ...) u32 { var acc: u32 = 0; $each a in va { acc = acc + a; } ret acc; }\n";
+    val p4: R.Result[project.Project, outcome.Fail] = ut_lower_n(?s, ?alloc, ?n4[0], ?t4[0], 2);
+    if (R.is_err[project.Project, outcome.Fail](p4)) { bad = 1; }
+    or {
+        var pp: project.Project = R.unwrap_ok[project.Project, outcome.Fail](p4);
+        val m: *ir.Module = ut_ir_of(?pp, ?s, "uniontest.main");
+        if (ut_defined_fn_count(?s, m, "3libN") != 2)                 { bad = 1; }
+        if (ut_defined_fn_count(?s, m, "sinkI3u32EQ3u32E") != 1)      { bad = 1; }
+        if (ut_defined_fn_count(?s, m, "sinkIS3u32EQ3u32E") != 1)     { bad = 1; }
+        project.dnit_project(?pp);
+    }
+
+    session.dnit(?s);
+    ret bad;
+}
+
+# a pack-tailed generic's signature is lowered under its type arguments on BOTH
+# sides of the call (#2251)
+#
+# The reference signature erased `T` to pointer width while the call passed the
+# concrete value, so `fun f[T](t: T, va: ...)` could not be called at all - the IR
+# verifier rejected every call as a parameter-type disagreement - and an aggregate
+# `T` returned from the body was truncated to a pointer rather than miscompiled
+# loudly. Both halves are pinned: the form builds end to end, and the emitted
+# instance's IRT_FN carries the record shape
+test "mach.lang.driver:pack_generic_signature_substituted" {
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    var bad: i32 = 0;
+
+    # the leading-parameter form builds, links and records an artifact. it exports
+    # the platform entry symbol so nothing but the defect can fail the build.
+    val lead: str = ut_cc3(?alloc,
+        "fun sink[T](t: T, va: ...) u32 { var acc: u32 = 0; $each a in va { acc = acc + a; } ret acc; }\n#[symbol(\"",
+        ut_entry_symbol(), "\")]\nfun start() i32 { var t: u32 = 3; var one: u32 = 1; sink[u32](t, one); ret 0; }\n");
+    if (ut_engine_build_fails(lead) == 0) { bad = 1; }
+
+    # the NEGATIVE control for that assertion: the same shape with an ill-typed pack
+    # body must still fail the build, so "it built" is not vacuous.
+    val broken: str = ut_cc3(?alloc,
+        "fun sink[T](t: T, va: ...) u32 { var acc: *u8 = nil; $each a in va { acc = a; } ret 0; }\n#[symbol(\"",
+        ut_entry_symbol(), "\")]\nfun start() i32 { var t: u32 = 3; var one: u32 = 1; sink[u32](t, one); ret 0; }\n");
+    if (ut_engine_build_fails(broken) != 0) { bad = 1; }
+
+    # a `T`-typed value returned from inside the `$each` body is well typed at the
+    # instance, so the body's `ret` must be checked against the SUBSTITUTED return:
+    # against the raw `T` this same source is refused.
+    if (!ut_ct_lower_clean("rec Box { a: u32; b: u32; c: u32; d: u32; }\nfun mk[T](seed: T, va: ...) T { $each a in va { ret seed; } ret seed; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { var b: Box; var one: u32 = 1; mk[Box](b, one); ret 0; }\n")) { bad = 1; }
+    # and it is not a licence to accept: a body returning the WRONG type at the
+    # instance is still refused, naming the concrete types.
+    if (ut_ct_lower_diag("rec Box { a: u32; b: u32; c: u32; d: u32; }\nfun mk[T](seed: T, va: ...) T { $each a in va { ret a; } ret seed; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { var b: Box; var one: u32 = 1; mk[Box](b, one); ret 0; }\n",
+        "expected Box, found u32") != 0) { bad = 1; }
+
+    # an AGGREGATE type argument: the instance's parameter and return are the record's
+    # IR shape, not the pointer width a bare `T` erases to.
+    val sr: R.Result[session.Session, str] = session.init(?alloc);
+    if (R.is_err[session.Session, str](sr)) { ret 1; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](sr);
+
+    var names: [1]str;
+    names[0] = "main.mach";
+    var texts: [1]str;
+    texts[0] = "rec Box { a: u32; b: u32; c: u32; d: u32; }\nfun mk[T](seed: T, va: ...) T { $each a in va { ret seed; } ret seed; }\nfun main() i32 { var b: Box; var one: u32 = 1; mk[Box](b, one); ret 0; }\n";
+    val pr: R.Result[project.Project, outcome.Fail] = ut_lower_n(?s, ?alloc, ?names[0], ?texts[0], 1);
+    if (R.is_err[project.Project, outcome.Fail](pr)) { bad = 1; }
+    or {
+        var p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](pr);
+        val m: *ir.Module = ut_ir_of(?p, ?s, "uniontest.main");
+        val sig: ir_type.IrTypeId = ut_defined_fn_sig(?s, m, "mkI");
+        if (sig == ir_type.IRT_NIL)                                   { bad = 1; }
+        if (ut_sig_param_kind(m, sig, 0) != ir_type.IRT_STRUCT)       { bad = 1; }
+        if (ut_sig_ret_kind(m, sig) != ir_type.IRT_STRUCT)            { bad = 1; }
+        project.dnit_project(?p);
+    }
+
+    session.dnit(?s);
+    ret bad;
+}

--- a/src/lang/me/lower.mach
+++ b/src/lang/me/lower.mach
@@ -400,11 +400,13 @@ fun drain_pack_instances(lc: *context.LowerContext, s: *session.Session,
             val processed: u32              = lc.pinst_drained;
             val decl_id:   id.DeclId        = lc.pinsts[processed].decl;
             val origin:    session.ModuleId = lc.pinsts[processed].origin;
+            val arg_len:   u32              = lc.pinsts[processed].arg_len;
             val type_len:  u32              = lc.pinsts[processed].type_len;
             val name:      intern.StrId     = lc.pinsts[processed].name;
+            val args:      *type.TypeId     = lc.pinsts[processed].args;
             val types:     *type.TypeId     = lc.pinsts[processed].types;
 
-            val res_emit: R.Result[bool, str] = emit_one_pack_instance(lc, s, decl_id, origin, types, type_len, name);
+            val res_emit: R.Result[bool, str] = emit_one_pack_instance(lc, s, decl_id, origin, args, arg_len, types, type_len, name);
             if (R.is_err[bool, str](res_emit)) {
                 context_home_restore(lc, s, home_a, home_sema, home_rr);
                 ret res_emit;
@@ -425,26 +427,33 @@ fun drain_pack_instances(lc: *context.LowerContext, s: *session.Session,
     ret R.ok[bool, str](true);
 }
 
-# emits one pack-instance body: binds the context to the instance's origin module,
-# installs the comptime resolvers, and lowers the pack-tailed template under the
-# instance name with its concrete element type-list
+# emits one pack-instance body: binds the context to the instance's origin module
+# and its generic substitution, installs the comptime resolvers, and lowers the
+# pack-tailed template under the instance name with its concrete element type-list
 #
 # Mirrors emit_one_value_instance but without a comptime parameter frame - the
 # per-element loop-variable binding is opened and closed inside the `$each` unroll.
-# A missing origin registry is a coherence violation (the caller already emitted an
-# extern reference to this instance), so it aborts rather than silently dropping
-# the body.
+# A pack-tailed function may also be generic, so its type-arguments are bound as
+# the active substitution exactly as for a generic instance (#2251); without that
+# the body -- and the per-element `$each` re-inference that is its ONLY typing
+# pass -- saw the raw type parameter, so a `T`-typed value was never secret and
+# the #1645 gates could not fire. A missing origin registry is a coherence
+# violation (the caller already emitted an extern reference to this instance), so
+# it aborts rather than silently dropping the body.
 # ---
 # lc:       the active lowering context
 # s:        shared session (origin-module registries)
 # decl_id:  DeclId of the pack-tailed function in `origin`'s AST
 # origin:   ModuleId that declares the function
+# args:     the instance's concrete generic type-arguments, or nil
+# arg_len:  number of generic type arguments
 # types:    pack element type-list (by pack ordinal)
 # type_len: number of pack element types
 # name:     instance linkage name
 # ret:      true on success, or the first lowering error
 fun emit_one_pack_instance(lc: *context.LowerContext, s: *session.Session,
                            decl_id: id.DeclId, origin: session.ModuleId,
+                           args: *type.TypeId, arg_len: u32,
                            types: *type.TypeId, type_len: u32, name: intern.StrId) R.Result[bool, str] {
     val oa: *ast.Ast = session.module_ast(s, origin);
     if (oa == nil) { ret R.err[bool, str]("lower: pack-instance origin AST not registered"); }
@@ -462,7 +471,7 @@ fun emit_one_pack_instance(lc: *context.LowerContext, s: *session.Session,
 
     val home_ctx: *comptime.ComptimeCtx = lc.ctx;
     val home_own: session.ModuleId      = lc.own_module;
-    context_origin_bind(lc, s, origin, oa, osema, orr, octx, nil, 0);
+    context_origin_bind(lc, s, origin, oa, osema, orr, octx, args, arg_len);
 
     val res_lower: R.Result[bool, str] = decl.lower_pack_instance(lc, decl_id, d, name, types, type_len);
     lc.ctx        = home_ctx;
@@ -474,10 +483,10 @@ fun emit_one_pack_instance(lc: *context.LowerContext, s: *session.Session,
 # session registries for an instance body, then installs the comptime resolvers
 # against `octx`
 #
-# `subst` is the active generic substitution (nil for value and pack instances,
-# the concrete type-args for a generic instance). The caller saves and restores
-# lc.ctx / lc.own_module around the body; the enclosing drain restores the
-# remaining phase inputs once the worklist empties.
+# `subst` is the active generic substitution: the concrete type-args for a generic
+# or pack-tailed-generic instance, nil for a value instance and for a non-generic
+# pack tail. The caller saves and restores lc.ctx / lc.own_module around the body;
+# the enclosing drain restores the remaining phase inputs once the worklist empties.
 # ---
 # lc:        the context to rebind
 # s:         shared session

--- a/src/lang/me/lower/context.mach
+++ b/src/lang/me/lower/context.mach
@@ -103,20 +103,26 @@ pub rec ValueInstance {
 }
 
 # one collected comptime variadic-pack instance awaiting body emission: a
-# `(decl, origin, pack element type-list)` triple plus the mangled symbol name
-# the instance is emitted under. mirrors `Instance` but keys on the concrete
-# TYPES the pack absorbs at a call site, so a pack-tailed function is
-# monomorphized once per distinct trailing arg-type sequence. the worklist
-# dedups by `name`
+# `(decl, origin, generic type-args, pack element type-list)` tuple plus the
+# mangled symbol name the instance is emitted under. mirrors `Instance` but keys
+# on BOTH the call's generic type-arguments and the concrete TYPES the pack
+# absorbs, so a pack-tailed function is monomorphized once per distinct
+# `(type-args x trailing arg-types)` pair (#2251). the worklist dedups by `name`
 # ---
 # decl:     DeclId of the pack-tailed function in `origin`'s AST
 # origin:   ModuleId that declares the function
+# args:     owned copy of the concrete generic type-argument sequence (by
+#           ordinal), nil for a non-generic pack tail; the substitution the
+#           instance body is lowered and re-typed under
+# arg_len:  number of generic type arguments
 # types:    owned copy of the pack element type-list (by pack ordinal)
 # type_len: number of pack element types
-# name:     instance linkage name (mangled, with the type-list suffix)
+# name:     instance linkage name (mangled, with both suffixes)
 pub rec PackInstance {
     decl:     id.DeclId;
     origin:   session.ModuleId;
+    args:     *type.TypeId;
+    arg_len:  u32;
     types:    *type.TypeId;
     type_len: u32;
     name:     intern.StrId;
@@ -427,6 +433,9 @@ pub fun dnit_context(lc: *LowerContext) {
     if (lc.pinsts != nil && lc.pinst_cap > 0) {
         var i: u32 = 0;
         for (i < lc.pinst_len) {
+            if (lc.pinsts[i].args != nil && lc.pinsts[i].arg_len > 0) {
+                A.deallocate[type.TypeId](lc.s.alloc, lc.pinsts[i].args, lc.pinsts[i].arg_len::usize);
+            }
             if (lc.pinsts[i].types != nil && lc.pinsts[i].type_len > 0) {
                 A.deallocate[type.TypeId](lc.s.alloc, lc.pinsts[i].types, lc.pinsts[i].type_len::usize);
             }
@@ -838,19 +847,23 @@ pub fun enqueue_value_instance(lc: *LowerContext, decl: id.DeclId, origin: sessi
     ret R.ok[bool, str](true);
 }
 
-# record a comptime variadic-pack instance `(decl, origin, type-list)` on the
-# per-module worklist under its mangled `name`, deduped by name (a linear scan,
-# as `enqueue_instance`). takes an OWNED copy of `types` so the caller's buffer
-# can be reused / freed; the copy is released when the context is torn down
+# record a comptime variadic-pack instance `(decl, origin, type-args, type-list)`
+# on the per-module worklist under its mangled `name`, deduped by name (a linear
+# scan, as `enqueue_instance`). takes OWNED copies of `args` and `types` so the
+# caller's buffers can be reused / freed; the copies are released when the
+# context is torn down
 # ---
 # lc:       the context
 # decl:     DeclId of the pack-tailed function in `origin`'s AST
 # origin:   ModuleId declaring the function
+# args:     generic type-argument sequence (copied), by ordinal
+# arg_len:  number of generic type arguments (0 for a non-generic pack tail)
 # types:    pack element type-list (copied), by pack ordinal
 # type_len: number of pack element types
 # name:     instance linkage name
 # ret:      true on success, or an allocation error
 pub fun enqueue_pack_instance(lc: *LowerContext, decl: id.DeclId, origin: session.ModuleId,
+                              args: *type.TypeId, arg_len: u32,
                               types: *type.TypeId, type_len: u32, name: intern.StrId) R.Result[bool, str] {
     var i: u32 = 0;
     for (i < lc.pinst_len) {
@@ -874,10 +887,21 @@ pub fun enqueue_pack_instance(lc: *LowerContext, decl: id.DeclId, origin: sessio
         lc.pinst_cap = new_cap;
     }
 
+    var args_copy: *type.TypeId = nil;
+    if (arg_len > 0) {
+        val res_args: R.Result[*type.TypeId, str] = A.allocate[type.TypeId](lc.s.alloc, arg_len::usize);
+        if (R.is_err[*type.TypeId, str](res_args)) { ret R.err[bool, str](R.unwrap_err[*type.TypeId, str](res_args)); }
+        args_copy = R.unwrap_ok[*type.TypeId, str](res_args);
+        memory.copy[type.TypeId](args_copy, args, arg_len::usize);
+    }
+
     var types_copy: *type.TypeId = nil;
     if (type_len > 0) {
         val res_copy: R.Result[*type.TypeId, str] = A.allocate[type.TypeId](lc.s.alloc, type_len::usize);
-        if (R.is_err[*type.TypeId, str](res_copy)) { ret R.err[bool, str](R.unwrap_err[*type.TypeId, str](res_copy)); }
+        if (R.is_err[*type.TypeId, str](res_copy)) {
+            if (args_copy != nil) { A.deallocate[type.TypeId](lc.s.alloc, args_copy, arg_len::usize); }
+            ret R.err[bool, str](R.unwrap_err[*type.TypeId, str](res_copy));
+        }
         types_copy = R.unwrap_ok[*type.TypeId, str](res_copy);
         memory.copy[type.TypeId](types_copy, types, type_len::usize);
     }
@@ -885,6 +909,8 @@ pub fun enqueue_pack_instance(lc: *LowerContext, decl: id.DeclId, origin: sessio
     var inst: PackInstance;
     inst.decl     = decl;
     inst.origin   = origin;
+    inst.args     = args_copy;
+    inst.arg_len  = arg_len;
     inst.types    = types_copy;
     inst.type_len = type_len;
     inst.name     = name;
@@ -1391,16 +1417,23 @@ pub fun instance_ref_sig(lc: *LowerContext, decl_id: id.DeclId, origin: session.
 # The pack expands to `type_len` concrete element parameters after the leading
 # fixed ones, so the signature is built by `pack_instance_sig` (not the whole
 # declared function type), exactly as the drained definition builds it. Binds the
-# origin module's typing so the return and fixed-parameter types resolve against
-# the declaring module, then restores the caller's state.
+# origin module's typing AND the instance's generic substitution (as the pack
+# drain does), so a `T`-typed fixed parameter or return lowers to the concrete
+# argument here exactly as it does in the definition; without it the reference
+# erased `T` to pointer width while the call passed the concrete value, which the
+# IR verifier rejected as a call-argument type disagreement (#2251). Restores the
+# caller's state afterwards.
 # ---
 # lc:       the referencing context
 # decl_id:  DeclId of the pack-tailed template in `origin`'s AST
 # origin:   ModuleId declaring the template
+# args:     the instance's concrete generic type-arguments, or nil
+# arg_len:  number of generic type arguments
 # types:    the concrete pack element type-list (by pack ordinal)
 # type_len: number of pack element types
 # ret:      the interned IRT_FN, or an error
 pub fun pack_instance_ref_sig(lc: *LowerContext, decl_id: id.DeclId, origin: session.ModuleId,
+                              args: *type.TypeId, arg_len: u32,
                               types: *type.TypeId, type_len: u32) R.Result[ir_type.IrTypeId, str] {
     val oa: *ast.Ast = session.module_ast(lc.s, origin);
     if (oa == nil) { ret R.err[ir_type.IrTypeId, str]("lower: pack-instance-reference origin AST not registered"); }
@@ -1417,8 +1450,8 @@ pub fun pack_instance_ref_sig(lc: *LowerContext, decl_id: id.DeclId, origin: ses
     val home_subst_len: u32                = lc.subst_len;
     lc.a           = oa;
     lc.sema_result = osema;
-    lc.subst       = nil;
-    lc.subst_len   = 0;
+    lc.subst       = args;
+    lc.subst_len   = arg_len;
 
     var res_sig: R.Result[ir_type.IrTypeId, str] = R.err[ir_type.IrTypeId, str]("");
     val res_ret_ir: R.Result[ir_type.IrTypeId, str] = function_return_ir(lc, decl_id);

--- a/src/lang/me/lower/decl.mach
+++ b/src/lang/me/lower/decl.mach
@@ -238,12 +238,10 @@ pub fun lower_pack_instance(ctx: *context.LowerContext, did: id.DeclId, d: *decl
     # types and the semantic return type now; the N alloca slots are filled by
     # lower_pack_params below. the return type is read through the active
     # substitution, so a pack-tailed generic returning `T` checks its body `ret`
-    # against the instance's concrete return (#2251). the same type serves a
-    # `$fields(T)` unroll nested in this body, which reads `fn_ret_sem`.
+    # against the instance's concrete return (#2251).
     ctx.pack_types    = types;
     ctx.pack_len      = type_len;
     ctx.pack_ret_type = context.decl_ret_sem(ctx, did);
-    ctx.fn_ret_sem    = ctx.pack_ret_type;
 
     builder.set_function(?ctx.builder, ?ctx.m.functions[fn_index]);
 

--- a/src/lang/me/lower/decl.mach
+++ b/src/lang/me/lower/decl.mach
@@ -236,10 +236,14 @@ pub fun lower_pack_instance(ctx: *context.LowerContext, did: id.DeclId, d: *decl
 
     # publish the pack body state the `$each a in va` unroll reads: the N element
     # types and the semantic return type now; the N alloca slots are filled by
-    # lower_pack_params below.
+    # lower_pack_params below. the return type is read through the active
+    # substitution, so a pack-tailed generic returning `T` checks its body `ret`
+    # against the instance's concrete return (#2251). the same type serves a
+    # `$fields(T)` unroll nested in this body, which reads `fn_ret_sem`.
     ctx.pack_types    = types;
     ctx.pack_len      = type_len;
-    ctx.pack_ret_type = pack_instance_ret_sem(ctx, did);
+    ctx.pack_ret_type = context.decl_ret_sem(ctx, did);
+    ctx.fn_ret_sem    = ctx.pack_ret_type;
 
     builder.set_function(?ctx.builder, ?ctx.m.functions[fn_index]);
 
@@ -483,24 +487,6 @@ fun clear_pack_state(ctx: *context.LowerContext) {
     ctx.pack_types    = nil;
     ctx.pack_len      = 0;
     ctx.pack_ret_type = type.TYPE_NIL;
-}
-
-# the semantic return type of a pack instance, recovered from its template's
-# TYPE_FUN signature
-#
-# Supplied to the per-element body re-inference so a `ret` inside the `$each` body
-# checks against it.
-# ---
-# ctx: the context
-# did: DeclId of the pack-tailed template
-# ret: the semantic return TypeId, or TYPE_NIL when unavailable
-fun pack_instance_ret_sem(ctx: *context.LowerContext, did: id.DeclId) type.TypeId {
-    val sem: type.TypeId = context.decl_type_of(ctx, did);
-    val opt_type: O.Option[*type.Type] = type.get(?ctx.s.types, sem);
-    if (O.is_none[*type.Type](opt_type)) { ret type.TYPE_NIL; }
-    val t: *type.Type = O.unwrap[*type.Type](opt_type);
-    if (t.kind != type.TYPE_FUN) { ret type.TYPE_NIL; }
-    ret t.data.fn.ret_type;
 }
 
 # materialise the pack instance's parameters

--- a/src/lang/me/lower/expr.mach
+++ b/src/lang/me/lower/expr.mach
@@ -1923,12 +1923,46 @@ fun report_expr(ctx: *context.LowerContext, eid: id.ExprId, message: str) R.Resu
     ret R.err[value.Value, str]("");
 }
 
+# collect a call's resolved generic type-arguments into an owned buffer
+#
+# Any argument that is itself a generic parameter bound in the enclosing instance
+# body is substituted, so a transitive `allocate[T]` -> `reallocate[T]` resolves T
+# to the concrete argument. Shared by the generic and pack-tailed callee paths,
+# which key their instances on the same sequence. The caller frees the buffer;
+# `argc == 0` yields nil (a pack-tailed function need not be generic).
+# ---
+# ctx:  per-module lowering context
+# e:    the resolved call node
+# argc: number of call-site type arguments
+# ret:  the owned type-argument sequence (nil when argc is 0), or an error
+fun collect_call_type_args(ctx: *context.LowerContext, e: *expr.Expr, argc: u32) R.Result[*type.TypeId, str] {
+    if (argc == 0) { ret R.ok[*type.TypeId, str](nil); }
+
+    val res_args: R.Result[*type.TypeId, str] = A.allocate[type.TypeId](ctx.s.alloc, argc::usize);
+    if (R.is_err[*type.TypeId, str](res_args)) { ret res_args; }
+    val args: *type.TypeId = R.unwrap_ok[*type.TypeId, str](res_args);
+
+    var i: u32 = 0;
+    for (i < argc) {
+        val pool_ix: u32 = e.data.call.type_args_start + i;
+        if (pool_ix::usize >= ctx.a.type_id_len) {
+            A.deallocate[type.TypeId](ctx.s.alloc, args, argc::usize);
+            ret R.err[*type.TypeId, str]("lower: call type-argument index out of range");
+        }
+        var at: type.TypeId = context.type_resolved_of(ctx, ctx.a.type_ids[pool_ix]);
+        if (ctx.subst != nil && ctx.subst_len > 0) {
+            at = generics.substitute(ctx.s, at, ctx.subst, ctx.subst_len);
+        }
+        args[i] = at;
+        i = i + 1;
+    }
+    ret R.ok[*type.TypeId, str](args);
+}
+
 # resolve a generic call to its monomorphized instance
 #
-# Reads the call-site type arguments (substituting any that are themselves generic
-# params bound in the enclosing instance body, so a transitive `allocate[T]` ->
-# `reallocate[T]` resolves T to the concrete arg), computes the instance's mangled
-# linkage name, enqueues the instance for body emission, and returns a function
+# Reads the call-site type arguments, computes the instance's mangled linkage
+# name, enqueues the instance for body emission, and returns a function
 # reference to it. The instance lives in the generic's origin module; the back end
 # emits a name-based call the linker binds to the (weak, deduped) instance body.
 # ---
@@ -1945,24 +1979,9 @@ fun lower_generic_callee(ctx: *context.LowerContext, eid: id.ExprId, e: *expr.Ex
     val sym: *resolve.Symbol = O.unwrap[*resolve.Symbol](opt_sym);
 
     val argc: u32 = e.data.call.type_args_len;
-    val res_args: R.Result[*type.TypeId, str] = A.allocate[type.TypeId](ctx.s.alloc, argc::usize);
+    val res_args: R.Result[*type.TypeId, str] = collect_call_type_args(ctx, e, argc);
     if (R.is_err[*type.TypeId, str](res_args)) { ret R.err[value.Value, str](R.unwrap_err[*type.TypeId, str](res_args)); }
     val args: *type.TypeId = R.unwrap_ok[*type.TypeId, str](res_args);
-
-    var i: u32 = 0;
-    for (i < argc) {
-        val pool_ix: u32 = e.data.call.type_args_start + i;
-        if (pool_ix::usize >= ctx.a.type_id_len) {
-            A.deallocate[type.TypeId](ctx.s.alloc, args, argc::usize);
-            ret R.err[value.Value, str]("lower: generic call type-argument index out of range");
-        }
-        var at: type.TypeId = context.type_resolved_of(ctx, ctx.a.type_ids[pool_ix]);
-        if (ctx.subst != nil && ctx.subst_len > 0) {
-            at = generics.substitute(ctx.s, at, ctx.subst, ctx.subst_len);
-        }
-        args[i] = at;
-        i = i + 1;
-    }
 
     # the instance is owned by the generic's origin module; mangle the instance
     # name against that module's FQN so the definition (emitted by the drain) and
@@ -1970,14 +1989,14 @@ fun lower_generic_callee(ctx: *context.LowerContext, eid: id.ExprId, e: *expr.Ex
     val fqn: intern.StrId = session.module_fqn(ctx.s, sym.origin);
     val res_link: R.Result[intern.StrId, str] = mangle.instance_name(ctx.s, fqn, sym.name, args, argc);
     if (R.is_err[intern.StrId, str](res_link)) {
-        A.deallocate[type.TypeId](ctx.s.alloc, args, argc::usize);
+        free_type_args(ctx, args, argc);
         ret R.err[value.Value, str](R.unwrap_err[intern.StrId, str](res_link));
     }
     val link: intern.StrId = R.unwrap_ok[intern.StrId, str](res_link);
 
     val res_enq: R.Result[bool, str] = context.enqueue_instance(ctx, sym.decl, sym.origin, args, argc, link);
     if (R.is_err[bool, str](res_enq)) {
-        A.deallocate[type.TypeId](ctx.s.alloc, args, argc::usize);
+        free_type_args(ctx, args, argc);
         ret R.err[value.Value, str](R.unwrap_err[bool, str](res_enq));
     }
 
@@ -1986,21 +2005,26 @@ fun lower_generic_callee(ctx: *context.LowerContext, eid: id.ExprId, e: *expr.Ex
     # the declared parameters, not per-operand stamps -- computed from `args` before
     # it is freed.
     val res_sig: R.Result[ir_type.IrTypeId, str] = context.instance_ref_sig(ctx, sym.decl, sym.origin, args, argc);
-    A.deallocate[type.TypeId](ctx.s.alloc, args, argc::usize);
+    free_type_args(ctx, args, argc);
     if (R.is_err[ir_type.IrTypeId, str](res_sig)) { ret R.err[value.Value, str](R.unwrap_err[ir_type.IrTypeId, str](res_sig)); }
     ret fn_reference(ctx, link, R.unwrap_ok[ir_type.IrTypeId, str](res_sig), false);
 }
 
 # resolve a pack-tailed call to its monomorphized instance (#1475)
 #
-# Two paths:
+# The instance key is `(generic type-args x pack element types)` (#2251): a
+# pack-tailed function may also be generic, and its body -- signature, `T`-typed
+# locals, the `$each` unroll -- must be typed and emitted against the concrete
+# type-arguments, so they are part of the monomorphization key and of the symbol.
+# The type-arguments are read from the call site; the element type-list comes from
+# one of two paths:
 #   - `va...` spread: the call forwards the current pack instance; the type-list
 #     is borrowed from ctx.pack_types (enqueue copies it).
 #   - collected: the type-list is gathered from the trailing call-site arguments,
 #     with any enclosing generic substitution applied.
-# In both cases the instance's mangled linkage name is computed under the disjoint
-# `Q...E` pack namespace, the instance is enqueued for body emission, and a
-# function reference to it is returned. All arguments are passed at runtime.
+# The instance's mangled linkage name is then computed under the disjoint `Q...E`
+# pack namespace, the instance is enqueued for body emission, and a function
+# reference to it is returned. All arguments are passed at runtime.
 # ---
 # ctx: per-module lowering context
 # eid: the call expression
@@ -2014,6 +2038,13 @@ fun lower_pack_callee(ctx: *context.LowerContext, eid: id.ExprId, e: *expr.Expr,
         ret R.err[value.Value, str]("lower: unresolved pack-tailed call target");
     }
     val sym: *resolve.Symbol = O.unwrap[*resolve.Symbol](opt_sym);
+
+    # the call's generic type-arguments: the substitution the instance body is
+    # lowered under, and the first half of its monomorphization key.
+    val argc: u32 = e.data.call.type_args_len;
+    val res_args: R.Result[*type.TypeId, str] = collect_call_type_args(ctx, e, argc);
+    if (R.is_err[*type.TypeId, str](res_args)) { ret R.err[value.Value, str](R.unwrap_err[*type.TypeId, str](res_args)); }
+    val args: *type.TypeId = R.unwrap_ok[*type.TypeId, str](res_args);
 
     # the pack is the trailing parameter; every argument past the leading fixed
     # parameters is a collected pack element.
@@ -2029,12 +2060,16 @@ fun lower_pack_callee(ctx: *context.LowerContext, eid: id.ExprId, e: *expr.Expr,
         types    = ctx.pack_types;
     } or {
         if (e.data.call.args_len < fixed_len) {
+            free_type_args(ctx, args, argc);
             ret R.err[value.Value, str]("lower: pack-tailed call has fewer arguments than fixed parameters");
         }
         elem_len = e.data.call.args_len - fixed_len;
         if (elem_len > 0) {
             val res_types: R.Result[*type.TypeId, str] = A.allocate[type.TypeId](ctx.s.alloc, elem_len::usize);
-            if (R.is_err[*type.TypeId, str](res_types)) { ret R.err[value.Value, str](R.unwrap_err[*type.TypeId, str](res_types)); }
+            if (R.is_err[*type.TypeId, str](res_types)) {
+                free_type_args(ctx, args, argc);
+                ret R.err[value.Value, str](R.unwrap_err[*type.TypeId, str](res_types));
+            }
             types      = R.unwrap_ok[*type.TypeId, str](res_types);
             owns_types = true;
 
@@ -2043,6 +2078,7 @@ fun lower_pack_callee(ctx: *context.LowerContext, eid: id.ExprId, e: *expr.Expr,
                 val pool_ix: u32 = e.data.call.args_start + fixed_len + i;
                 if (pool_ix::usize >= ctx.a.expr_id_len) {
                     A.deallocate[type.TypeId](ctx.s.alloc, types, elem_len::usize);
+                    free_type_args(ctx, args, argc);
                     ret R.err[value.Value, str]("lower: pack-tailed call argument index out of range");
                 }
                 val arg_eid: id.ExprId = ctx.a.expr_ids[pool_ix];
@@ -2060,26 +2096,40 @@ fun lower_pack_callee(ctx: *context.LowerContext, eid: id.ExprId, e: *expr.Expr,
     # module's FQN so the definition (emitted by the drain) and every reference
     # agree byte-for-byte.
     val fqn: intern.StrId = session.module_fqn(ctx.s, sym.origin);
-    val res_link: R.Result[intern.StrId, str] = mangle.pack_instance_name(ctx.s, fqn, sym.name, types, elem_len);
+    val res_link: R.Result[intern.StrId, str] = mangle.pack_instance_name(ctx.s, fqn, sym.name, args, argc, types, elem_len);
     if (R.is_err[intern.StrId, str](res_link)) {
         if (owns_types && types != nil) { A.deallocate[type.TypeId](ctx.s.alloc, types, elem_len::usize); }
+        free_type_args(ctx, args, argc);
         ret R.err[value.Value, str](R.unwrap_err[intern.StrId, str](res_link));
     }
     val link: intern.StrId = R.unwrap_ok[intern.StrId, str](res_link);
 
-    val res_enq: R.Result[bool, str] = context.enqueue_pack_instance(ctx, sym.decl, sym.origin, types, elem_len, link);
+    val res_enq: R.Result[bool, str] = context.enqueue_pack_instance(ctx, sym.decl, sym.origin, args, argc, types, elem_len, link);
     if (R.is_err[bool, str](res_enq)) {
         if (owns_types && types != nil) { A.deallocate[type.TypeId](ctx.s.alloc, types, elem_len::usize); }
+        free_type_args(ctx, args, argc);
         ret R.err[value.Value, str](R.unwrap_err[bool, str](res_enq));
     }
 
     # carry the instance's true IRT_FN signature (the pack expanded to its concrete
-    # element parameters) so the call classifies its ABI from the declared
-    # parameters, not per-operand stamps -- computed from `types` before it is freed.
-    val res_sig: R.Result[ir_type.IrTypeId, str] = context.pack_instance_ref_sig(ctx, sym.decl, sym.origin, types, elem_len);
+    # element parameters, under the instance's substitution) so the call classifies
+    # its ABI from the declared parameters, not per-operand stamps -- computed from
+    # `args` / `types` before they are freed.
+    val res_sig: R.Result[ir_type.IrTypeId, str] = context.pack_instance_ref_sig(ctx, sym.decl, sym.origin, args, argc, types, elem_len);
     if (owns_types && types != nil)   { A.deallocate[type.TypeId](ctx.s.alloc, types, elem_len::usize); }
+    free_type_args(ctx, args, argc);
     if (R.is_err[ir_type.IrTypeId, str](res_sig)) { ret R.err[value.Value, str](R.unwrap_err[ir_type.IrTypeId, str](res_sig)); }
     ret fn_reference(ctx, link, R.unwrap_ok[ir_type.IrTypeId, str](res_sig), false);
+}
+
+# release a collected type-argument buffer, tolerating the nil / empty sequence a
+# non-generic pack-tailed call yields
+# ---
+# ctx:  per-module lowering context
+# args: the buffer from collect_call_type_args
+# argc: its length
+fun free_type_args(ctx: *context.LowerContext, args: *type.TypeId, argc: u32) {
+    if (args != nil && argc > 0) { A.deallocate[type.TypeId](ctx.s.alloc, args, argc::usize); }
 }
 
 # lower a binary expression

--- a/src/lang/me/lower/mangle.mach
+++ b/src/lang/me/lower/mangle.mach
@@ -144,25 +144,32 @@ pub fun value_instance_name(
 
 # the linkage name of a comptime variadic-pack instance
 #
-# The mangled base name with its pack element type-list encoded into a `Q...E`
-# suffix, so distinct type-lists (e.g. `sum(i64,i64)` vs `sum(f64)`) name
-# distinct symbols. The `Q` pack namespace is disjoint from the type-argument
-# `I...E` and value `K...E` namespaces, so a pack instance can never collide
-# with a type or value instance (which would silently merge two different WEAK
-# bodies). Element types encode through the same injective `write_encoded_type`
-# the generic `I...E` suffix uses. An instance is never exempted, so no export
-# hook.
+# A pack-tailed function is monomorphized on `(generic type-args x pack element
+# types)` (#2251), so the name carries both keys: the generic type-arguments in
+# the same `I...E` suffix a generic instance uses (omitted when the function
+# declares no type parameters), then the pack element type-list in a `Q...E`
+# suffix. Distinct type-lists (`sum(i64,i64)` vs `sum(f64)`) and distinct
+# type-argument lists (`sink[u32]` vs `sink[^u32]`) therefore name distinct
+# symbols. The trailing `Q...E` is what distinguishes a pack instance from a
+# generic instance's bare `I...E` and a value instance's `K...E`, so no two
+# instance kinds can collide (which would silently merge two different WEAK
+# bodies). Both suffixes encode through the same injective `write_encoded_type`.
+# An instance is never exempted, so no export hook.
 # ---
 # s:        shared session (interner, type universe)
 # fqn:      FQN StrId of the function's defining (origin) module
 # bare:     function's source identifier StrId
+# args:     pointer to the generic type-argument sequence (nil when arg_len is 0)
+# arg_len:  number of generic type arguments (0 for a non-generic pack tail)
 # types:    pointer to the pack element type-list
-# type_len: number of pack element types (must be > 0)
+# type_len: number of pack element types
 # ret:      the pack-instance linkage-name StrId, or an allocation error
 pub fun pack_instance_name(
     s:        *session.Session,
     fqn:      intern.StrId,
     bare:     intern.StrId,
+    args:     *type.TypeId,
+    arg_len:  u32,
     types:    *type.TypeId,
     type_len: u32
 ) R.Result[intern.StrId, str] {
@@ -174,9 +181,17 @@ pub fun pack_instance_name(
     }
     val name: str = R.unwrap_ok[str, str](res_name);
 
-    # `Q<enc(type)...>E` pack type-list suffix byte length.
+    # `[I<enc(arg)...>E]Q<enc(type)...>E` suffix byte length.
     var suffix_len: usize = 2;
     var i: u32 = 0;
+    if (arg_len > 0) {
+        suffix_len = suffix_len + 2;
+        for (i < arg_len) {
+            suffix_len = suffix_len + encoded_type_len(s, args[i]);
+            i = i + 1;
+        }
+    }
+    i = 0;
     for (i < type_len) {
         suffix_len = suffix_len + encoded_type_len(s, types[i]);
         i = i + 1;
@@ -190,6 +205,15 @@ pub fun pack_instance_name(
     val buf: *u8 = R.unwrap_ok[*u8, str](res_buf);
 
     var k: usize = prefix_write(buf, path, name, suffix_len);
+    if (arg_len > 0) {
+        buf[k] = 'I'; k = k + 1;
+        i = 0;
+        for (i < arg_len) {
+            k = write_encoded_type(s, buf, k, args[i]);
+            i = i + 1;
+        }
+        buf[k] = 'E'; k = k + 1;
+    }
     buf[k] = 'Q'; k = k + 1;
     i = 0;
     for (i < type_len) {
@@ -484,11 +508,8 @@ fun encoded_type_len(s: *session.Session, tid: type.TypeId) usize {
     if (kind == type.TYPE_POINTER) {
         ret 1 + encoded_type_len(s, t.data.pointer.base);
     }
-    # secrecy is erased at lowering (#1645), so `^T` mangles exactly as `T`: two
-    # instances differing only in secrecy lower to one machine shape and one
-    # symbol. (#1646's per-instance oblivious distinction revisits this.)
     if (kind == type.TYPE_SECRET) {
-        ret encoded_type_len(s, t.data.secret.base);
+        ret 1 + encoded_type_len(s, t.data.secret.base);
     }
     if (kind == type.TYPE_ARRAY) {
         ret 1 + decimal_len(t.data.array.count::usize) + 1 + encoded_type_len(s, t.data.array.base);
@@ -531,9 +552,14 @@ fun write_encoded_type(s: *session.Session, buf: *u8, k: usize, tid: type.TypeId
         buf[k] = 'P';
         ret write_encoded_type(s, buf, k + 1, t.data.pointer.base);
     }
-    # secrecy is erased at lowering (#1645): `^T` encodes exactly as `T`.
+    # `^T` encodes as `S<enc(T)>` (#2251). secrecy has no runtime representation,
+    # but it does change the body a monomorphized instance emits -- a secret
+    # operand carries the #1646 taint through codegen -- so erasing it here made
+    # the instance name non-injective and collapsed two distinct bodies onto one
+    # WEAK symbol.
     if (kind == type.TYPE_SECRET) {
-        ret write_encoded_type(s, buf, k, t.data.secret.base);
+        buf[k] = 'S';
+        ret write_encoded_type(s, buf, k + 1, t.data.secret.base);
     }
     if (kind == type.TYPE_ARRAY) {
         buf[k] = 'A';

--- a/src/lang/me/lower/mangle.mach
+++ b/src/lang/me/lower/mangle.mach
@@ -508,6 +508,7 @@ fun encoded_type_len(s: *session.Session, tid: type.TypeId) usize {
     if (kind == type.TYPE_POINTER) {
         ret 1 + encoded_type_len(s, t.data.pointer.base);
     }
+    # the one-byte `S` marker write_encoded_type emits for `^T`.
     if (kind == type.TYPE_SECRET) {
         ret 1 + encoded_type_len(s, t.data.secret.base);
     }


### PR DESCRIPTION
Closes #2251

## The gap

`PackInstance` keyed a pack-tailed function's monomorphization on the **call-site element type-list alone**. There was no slot for the call's generic type arguments, `enqueue_pack_instance` never read them, and `emit_one_pack_instance` bound the body with `context_origin_bind(..., nil, 0)` — no substitution at all.

The `$each` body's per-element re-inference at monomorphization is that body's **only** typing pass (#2249), so it saw the raw `T`. Three consequences, all reproduced from source on `origin/dev` @ `6de93156` (the 4.2.2 PATH seed was never the test compiler):

| shape | pre | post |
|---|---|---|
| a `T`-typed local in the `$each` body, `sink[^u32](one)` | built clean, ran, printed the secret | rejected |
| `fun f[T](t: T, va: ...)` — any call | `error: call argument typing: ...` | builds and runs |
| `sink[u32]` / `sink[^u32]` over one element list | one symbol, one body | two symbols, two bodies |

## The fix

The instance key is now `(type-args × element-types)`.

- `lower_pack_callee` collects the call's resolved type arguments through the same helper the generic path uses (factored out of `lower_generic_callee`, which duplicated it).
- `pack_instance_name` folds them into the mangled name as an `I...E` suffix ahead of the pack's `Q...E`. A pack tail with no type parameters emits **exactly its previous name** — the suffix is omitted at `arg_len == 0`.
- `PackInstance` carries an owned copy; `emit_one_pack_instance` binds it as the active substitution around the drained body, exactly as a generic instance does; `pack_instance_ref_sig` binds it too, so the reference signature and the definition agree instead of the reference erasing `T` to pointer width.
- the instance's return type is read through the substitution, so a body `ret` checks against the concrete return.

**`write_encoded_type` no longer erases `^`.** An instance name is the identity of the emitted body, and a secret operand carries the #1646 taint through codegen, so erasing secrecy made the name non-injective over the key it encodes — the same defect family as the #2162 collapse. This is load-bearing here, not cosmetic: with the *public* form instantiated first, a name that erased the type arguments (or their secrecy) deduped the secret instance onto the already-emitted public body and never typed it at all. The old comment on that branch already flagged the erasure as provisional pending #1646. Its side effect is that a plain generic instantiated at both `T` and `^T` also gets two bodies now, which is strictly more correct.

## Composition with #2249

No double-report and no double-enumeration. The CT re-validation drain is a property of the inference episode; making pack bodies carry a real substitution means that episode now sees genuine instance types, which is what makes the nested-generic and nested-pack cases fire. Diagnostic multiplicity is unchanged: a pack `$each` reports **once per element**, measured identically before and after on a non-generic two-element fixture (2 errors both ways).

## Enumerated surface — built and run, both compilers

Rejected only after the fix (leaked before): a `T`-typed local in the `$each`; a second type parameter; a `T`-typed leading parameter; a nested generic call from the pack body (secret branch condition); a nested pack-tailed generic; a `va...` spread forward; a `$fields(T)` walk nested in the pack body; a secret-carrying **record** type argument; the cross-module form (the generic declared in another module).

Correct only after the fix (**silently miscompiled** before): an aggregate `T` returned from the `$each` body printed `11 22 6 0` for a `Box` of `11 22 33 44`; a public `$fields(T)` walk in a pack body emitted **nothing** (the whole unroll body was dropped); a `ret` inside such a walk never emitted; a public `var z: T` printed an erased value rather than its zero. `#[oblivious]` on a pack-tailed generic was uncallable and now builds and runs.

Did **not** leak, before or after: a pack element whose type comes from an enclosing generic instance (`outer[^u32]` passing `x` to a plain variadic) — gated at sema; a `T`-typed local in a **plain** generic (its whole body is re-inferred by #2157); the out-of-`$each` control from the issue.

Public twins of every rejected shape still compile.

## Residual gap, filed as #2254

A `T`-typed local declared **outside** the `$each` and used inside it still escapes: a pack-tailed function's non-`$each` statements are never re-typed per instance, so `decl_type` holds the template type. Distinct root cause, distinct fix (the episode must cover the whole body), and it also refuses the well-typed `var out: T = seed; $each a in va { ret out; }` — which on `dev` compiled to the same truncated aggregate. Attempting `apply_subst` at that leaf **double-substitutes**: the `decl_type` array is shared and rewritten in place, so `Result[T, E]` became `Result[**T, *u8]` and mach-std stopped compiling. Recorded in `secrecy.md`'s open-holes list in place of #2251's entry.

## Verification

- **suites** — compiler **839 / 0** (836 baseline on `dev` @ `6de93156`, measured on a pristine tree, + the 3 tests added); mach-std **611 / 0** at pin `eff1e8e`, `git rev-parse HEAD` verified against `mach.lock`; `int/run.sh --target linux` all cases pass.
- **per-assertion discrimination** — the 3 tests hold 44 assertions; each was rebuilt as its own single-assertion test against `origin/dev`. **28 fail pre-fix**. The 16 that do not are the 7 public twins, 6 harness/project-build guards, the 2 invariants that must hold both ways (a non-generic pack tail's name is unchanged), and the negative build control.
- **mutation testing** — every guard deleted in turn, against those same 44 assertions:

  | deleted | failures |
  |---|---|
  | the body substitution (`context_origin_bind(..., args, arg_len)`) | 14 |
  | the reference-signature substitution (`pack_instance_ref_sig`) | 2 |
  | the `I...E` type-args suffix | 16 |
  | the `S` secret marker in `write_encoded_type` | 6 |
  | the substituted instance return type | 2 |

  A sixth change — publishing `fn_ret_sem` on the pack instance — survived every probe I could construct, so it was **removed** rather than kept unjustified. The `S`-marker deletion initially failed only name-shaped assertions; the public-instantiated-first case was added until it failed on a *security* assertion too.
- **fixpoint** — three generations, `B == C == D` byte-identical.
- **output delta** — the compiler's own 8.4 MB self-host binary (which links all of mach-std) is **byte-identical** built by the pre-fix and post-fix compilers, as is a program using a non-generic pack tail. Every program that instantiates a pack-tailed **generic** differs, necessarily: the symbol gains its type-argument suffix, distinct instantiations get distinct bodies, and the body is now lowered against the concrete types instead of the pointer-erased placeholder — several of those deltas are the miscompiles above being fixed.
