### PR TITLE
feat(asm): one inline-asm parser for all three ISAs (riscv64 + aarch64)

### DIFF
--- a/src/lang/target/isa/arm64/encode.mach
+++ b/src/lang/target/isa/arm64/encode.mach
@@ -28,11 +28,14 @@
 # GP BITCAST), the direct (`BL` + RK_PLT32->CALL26) and indirect (`BLR Xn`) call, the
 # folded-global load/store (`ADRP IP0` + `LDR/STR :lo12:`, RK_PAGE21 + the per-width
 # RK_LDST*_LO12), and the address-of rvalue (`ADRP` + `ADD :lo12:`, RK_PAGE21 +
-# RK_ADD_LO12). Phase 3c adds the inline-asm assembler (`encode_asm_block_arm64`):
-# it parses an `asm aarch64 { ... }` body, resolves `{name}` locals to `[x29, #off]`
-# frame slots and bare-symbol / `:lo12:` operands to the #1163 relocations, and
-# emits A64 words for the std `_start` / syscall path. Also encoded: callee-saved FP
-# registers and the scalar-float, float-conversion, and NEON vector families.
+# RK_ADD_LO12). Phase 3c adds the inline-asm assembler, which since #2232 is the
+# aarch64 half of the SHARED parser in `isa.asm`: this module supplies the mnemonic
+# table, the operand lexer and the emitter (`a64_grammar`), and the shared spine owns
+# the statement cursor, the byte accounting, numeric local labels, `{name}` binding
+# and the effect model. There is no second reading of the text anywhere - the
+# register set `asm_clobbers` reports and the bytes `encode_asm_block_arm64` emits
+# come from one parse of one grammar. Also encoded: callee-saved FP registers and the
+# scalar-float, float-conversion, and NEON vector families.
 
 use std.allocator.page;
 use std.io.writer;
@@ -57,6 +60,7 @@ use mach.lang.be.codegen.encode;
 use mach.lang.be.codegen.mir;
 use mach.lang.intern;
 use mach.lang.target.isa;
+use iasm: mach.lang.target.isa.asm;
 use mach.lang.target.isa.arm64;
 use printer: mach.lang.target.isa.arm64.printer;
 use mach.lang.target.of;
@@ -3223,7 +3227,7 @@ fun check_accounted(st: *encode.EncodeState, opcode: u16) R.Result[bool, str] {
         num[n] = 0;
         label = (?num[0])::str;
     }
-    ret R.err[bool, str](asm_named_err(st,
+    ret R.err[bool, str](iasm.named_message(st.alloc, st.interner,
         "--emit-asm: opcode ", label,
         " emitted bytes the aarch64 assembly printer did not render",
         "--emit-asm: an opcode emitted bytes the assembly printer did not render"));
@@ -3273,490 +3277,6 @@ pub fun encode_arm64_asm(alloc: *A.Allocator, tgt: *resolved.Target, m: *mir.Mir
 # imm26 / imm19 displacement insert reuses the shared `patch_branch_arm64`. an
 # unrecognized mnemonic or malformed operand is a hard error rather than wrong bytes.
 
-# a parsed inline-asm operand. distinguishes a register / immediate / memory form
-# (encoded directly) from a bare symbol or `:lo12:sym` (resolved to a relocation)
-# ---
-# kind:      one of ASMOP_*
-# reg:       register index (0..31) for ASMOP_REG
-# is64:      true for an X register / 64-bit form, false for W
-# is_sp:     true when register 31 names SP/WSP (false when it names XZR/WZR)
-# imm:       immediate (ASMOP_IMM) or memory displacement (ASMOP_MEM)
-# base:      memory base register index (ASMOP_MEM)
-# base_sp:   true when the memory base register 31 is SP
-# index:     memory scaled-index register index (ASMOP_MEM, when has_index)
-# index64:   true when the index register is an X register
-# has_index: true when an ASMOP_MEM carries a `[Xn, Xm]` index
-# has_disp:  true when an ASMOP_MEM carries a `[Xn, #imm]` displacement
-# wb_pre:    true when an ASMOP_MEM is a pre-index writeback `[Xn, #imm]!`
-# is_lo12:   true when the operand (or the memory offset) is `:lo12:sym`
-# name:      borrowed symbol name (ASMOP_SYM / ASMOP_LO12 / lo12 memory offset)
-# name_len:  length of `name`
-rec AsmOp {
-    kind:      u8;
-    reg:       u32;
-    is64:      bool;
-    is_sp:     bool;
-    imm:       i64;
-    base:      u32;
-    base_sp:   bool;
-    index:     u32;
-    index64:   bool;
-    has_index: bool;
-    has_disp:  bool;
-    wb_pre:    bool;
-    is_lo12:   bool;
-    name:      str;
-    name_len:  usize;
-}
-
-# no operand parsed
-val ASMOP_NONE: u8 = 0;
-# a register operand
-val ASMOP_REG:  u8 = 1;
-# an immediate constant
-val ASMOP_IMM:  u8 = 2;
-# a `[base (, #imm | , Xm | , :lo12:sym)?]` memory operand
-val ASMOP_MEM:  u8 = 3;
-# a bare symbol / branch-target name (resolved to a relocation)
-val ASMOP_SYM:  u8 = 4;
-# a `:lo12:sym` relocation specifier (the low-half ADD / LDR/STR operand)
-val ASMOP_LO12: u8 = 5;
-
-# reset an operand to the empty (ASMOP_NONE) state
-fun asm_op_clear(op: *AsmOp) {
-    op.kind = ASMOP_NONE; op.reg = 0; op.is64 = false; op.is_sp = false;
-    op.imm = 0; op.base = 0; op.base_sp = false; op.index = 0; op.index64 = false;
-    op.has_index = false; op.has_disp = false; op.wb_pre = false;
-    op.is_lo12 = false; op.name = nil; op.name_len = 0;
-}
-
-# initial capacity for the numeric local-label definition / forward-ref arrays
-val ASM_LABEL_INIT_CAP: u32 = 8;
-
-# a numeric local label's nearest definition: the label number and its `.text` offset
-# ---
-# number: the numeric label
-# offset: byte offset of the definition within `.text`
-rec AsmLabelDef { number: u64; offset: u32; }
-
-# a pending forward reference to a numeric local label: the placeholder branch word
-# is at `patch_pos`, resolved by `patch_branch_arm64` when the definition is reached
-# ---
-# patch_pos: byte offset of the branch instruction word within `.text`
-# number:    the referenced numeric label
-rec AsmLabelRef { patch_pos: u32; number: u64; }
-
-# per-asm-block numeric-local-label scope (1:/1f/1b). owns its def / forward-ref
-# arrays, freed when the block finishes. the displacement insert reuses the shared
-# `patch_branch_arm64` (imm26 for B, imm19 for B.cond/CBZ/CBNZ - distinguished there
-# by the placeholder word's top bits), so this bookkeeping carries no encoding
-# ---
-# alloc:     backing allocator
-# defs:      recorded label definitions (latest offset per number)
-# def_count: number of definitions
-# def_cap:   capacity of `defs`
-# refs:      pending forward references
-# ref_count: number of pending forward references
-# ref_cap:   capacity of `refs`
-rec AsmLabels {
-    alloc:     *A.Allocator;
-    defs:      *AsmLabelDef;
-    def_count: u32;
-    def_cap:   u32;
-    refs:      *AsmLabelRef;
-    ref_count: u32;
-    ref_cap:   u32;
-}
-
-# initialize an empty numeric-local-label scope backed by `alloc`
-fun asm_labels_init(labels: *AsmLabels, alloc: *A.Allocator) {
-    labels.alloc = alloc;
-    labels.defs = nil; labels.def_count = 0; labels.def_cap = 0;
-    labels.refs = nil; labels.ref_count = 0; labels.ref_cap = 0;
-}
-
-# release a label scope's owned arrays
-fun asm_labels_dnit(labels: *AsmLabels) {
-    if (labels.defs != nil && labels.def_cap > 0) {
-        A.deallocate[AsmLabelDef](labels.alloc, labels.defs, labels.def_cap::usize);
-        labels.defs = nil; labels.def_cap = 0; labels.def_count = 0;
-    }
-    if (labels.refs != nil && labels.ref_cap > 0) {
-        A.deallocate[AsmLabelRef](labels.alloc, labels.refs, labels.ref_cap::usize);
-        labels.refs = nil; labels.ref_cap = 0; labels.ref_count = 0;
-    }
-}
-
-# grow the label-definition array (or allocate it on first use)
-fun grow_asm_defs(labels: *AsmLabels) R.Result[bool, str] {
-    if (labels.defs == nil) {
-        val r: R.Result[*AsmLabelDef, str] = A.allocate[AsmLabelDef](labels.alloc, ASM_LABEL_INIT_CAP::usize);
-        if (R.is_err[*AsmLabelDef, str](r)) { ret R.err[bool, str](R.unwrap_err[*AsmLabelDef, str](r)); }
-        labels.defs = R.unwrap_ok[*AsmLabelDef, str](r); labels.def_cap = ASM_LABEL_INIT_CAP;
-        ret R.ok[bool, str](true);
-    }
-    val nc: u32 = labels.def_cap * 2;
-    val r: R.Result[*AsmLabelDef, str] = A.reallocate[AsmLabelDef](labels.alloc, labels.defs, labels.def_cap::usize, nc::usize);
-    if (R.is_err[*AsmLabelDef, str](r)) { ret R.err[bool, str](R.unwrap_err[*AsmLabelDef, str](r)); }
-    labels.defs = R.unwrap_ok[*AsmLabelDef, str](r); labels.def_cap = nc;
-    ret R.ok[bool, str](true);
-}
-
-# grow the forward-reference array (or allocate it on first use)
-fun grow_asm_refs(labels: *AsmLabels) R.Result[bool, str] {
-    if (labels.refs == nil) {
-        val r: R.Result[*AsmLabelRef, str] = A.allocate[AsmLabelRef](labels.alloc, ASM_LABEL_INIT_CAP::usize);
-        if (R.is_err[*AsmLabelRef, str](r)) { ret R.err[bool, str](R.unwrap_err[*AsmLabelRef, str](r)); }
-        labels.refs = R.unwrap_ok[*AsmLabelRef, str](r); labels.ref_cap = ASM_LABEL_INIT_CAP;
-        ret R.ok[bool, str](true);
-    }
-    val nc: u32 = labels.ref_cap * 2;
-    val r: R.Result[*AsmLabelRef, str] = A.reallocate[AsmLabelRef](labels.alloc, labels.refs, labels.ref_cap::usize, nc::usize);
-    if (R.is_err[*AsmLabelRef, str](r)) { ret R.err[bool, str](R.unwrap_err[*AsmLabelRef, str](r)); }
-    labels.refs = R.unwrap_ok[*AsmLabelRef, str](r); labels.ref_cap = nc;
-    ret R.ok[bool, str](true);
-}
-
-# the nearest preceding definition offset of `number`, or none
-fun asm_label_lookup(labels: *AsmLabels, number: u64) O.Option[u32] {
-    var i: u32 = 0;
-    for (i < labels.def_count) {
-        if (labels.defs[i].number == number) { ret O.some[u32](labels.defs[i].offset); }
-        i = i + 1;
-    }
-    ret O.none[u32]();
-}
-
-# record a pending forward reference to `number` whose branch
-# word is at `patch_pos`
-fun asm_label_push_ref(labels: *AsmLabels, patch_pos: u32, number: u64) R.Result[bool, str] {
-    if (labels.ref_count >= labels.ref_cap) {
-        val gr: R.Result[bool, str] = grow_asm_refs(labels);
-        if (R.is_err[bool, str](gr)) { ret gr; }
-    }
-    labels.refs[labels.ref_count].patch_pos = patch_pos;
-    labels.refs[labels.ref_count].number    = number;
-    labels.ref_count = labels.ref_count + 1;
-    ret R.ok[bool, str](true);
-}
-
-# record a definition of `number` at `.text` offset `off`,
-# patching (and dropping) every pending forward reference to it through the shared
-# `patch_branch_arm64`, and updating the nearest-preceding-definition offset
-fun asm_label_record_def(st: *encode.EncodeState, labels: *AsmLabels, number: u64, off: u32) R.Result[bool, str] {
-    var w: u32 = 0;
-    var r: u32 = 0;
-    for (r < labels.ref_count) {
-        if (labels.refs[r].number == number) {
-            var fx: encode.BranchFixup;
-            fx.patch_pos = labels.refs[r].patch_pos; fx.next_ip = 0;
-            fx.target_block = 0; fx.fn_text_base = 0;
-            val pr: R.Result[bool, str] = patch_branch_arm64(st, ?fx, off);
-            if (R.is_err[bool, str](pr)) { ret pr; }
-        } or {
-            labels.refs[w].patch_pos = labels.refs[r].patch_pos;
-            labels.refs[w].number    = labels.refs[r].number;
-            w = w + 1;
-        }
-        r = r + 1;
-    }
-    labels.ref_count = w;
-
-    var i: u32 = 0;
-    for (i < labels.def_count) {
-        if (labels.defs[i].number == number) { labels.defs[i].offset = off; ret R.ok[bool, str](true); }
-        i = i + 1;
-    }
-    if (labels.def_count >= labels.def_cap) {
-        val gr: R.Result[bool, str] = grow_asm_defs(labels);
-        if (R.is_err[bool, str](gr)) { ret gr; }
-    }
-    labels.defs[labels.def_count].number = number;
-    labels.defs[labels.def_count].offset = off;
-    labels.def_count = labels.def_count + 1;
-    ret R.ok[bool, str](true);
-}
-
-# true for the ASCII whitespace the asm tokenizer trims
-fun asm_is_space(c: char) bool { ret c == ' '::char || c == '\t'::char || c == '\r'::char; }
-
-# true for an ASCII decimal digit
-fun asm_is_digit(c: char) bool { ret c >= '0'::char && c <= '9'::char; }
-
-# true for a character valid inside a bare symbol name
-fun asm_is_sym_char(c: char) bool {
-    ret c == '_'::char || c == '.'::char ||
-        (c >= 'a'::char && c <= 'z'::char) ||
-        (c >= 'A'::char && c <= 'Z'::char) ||
-        (c >= '0'::char && c <= '9'::char);
-}
-
-# true when `tok[0..len)` is a valid bare symbol name (leading
-# char a letter / underscore, the rest symbol characters)
-fun asm_is_sym_token(tok: str, len: usize) bool {
-    if (len == 0) { ret false; }
-    val c0: char = tok[0];
-    if (!(c0 == '_'::char || (c0 >= 'a'::char && c0 <= 'z'::char) || (c0 >= 'A'::char && c0 <= 'Z'::char))) {
-        ret false;
-    }
-    var i: usize = 1;
-    for (i < len) { if (!asm_is_sym_char(tok[i])) { ret false; } i = i + 1; }
-    ret true;
-}
-
-# a pointer past leading whitespace in `s` (trailing whitespace already
-# stripped by the statement tokenizer)
-fun asm_trim(s: str) str {
-    var i: usize = 0;
-    for (s[i] != 0 && asm_is_space(s[i])) { i = i + 1; }
-    ret (s::usize + i)::str;
-}
-
-# copy `s[lo..hi)` (trimming surrounding whitespace) into `dst` as
-# a NUL-terminated string. returns false on an empty or oversized slice
-fun asm_copy_region(s: str, lo: usize, hi: usize, dst: *u8, cap: usize) bool {
-    var a: usize = lo;
-    var b: usize = hi;
-    for (a < b && asm_is_space(s[a])) { a = a + 1; }
-    for (b > a && asm_is_space(s[b - 1])) { b = b - 1; }
-    val n: usize = b - a;
-    if (n == 0 || n + 1 > cap) { ret false; }
-    var i: usize = 0;
-    for (i < n) { dst[i] = s[a + i]::u8; i = i + 1; }
-    dst[n] = 0;
-    ret true;
-}
-
-# true when `tok[s..e)` begins with the `:lo12:` prefix
-fun asm_region_is_lo12(tok: str, s: usize, e: usize) bool {
-    if (e - s < 6) { ret false; }
-    ret tok[s] == ':'::char && tok[s + 1] == 'l'::char && tok[s + 2] == 'o'::char &&
-        tok[s + 3] == '1'::char && tok[s + 4] == '2'::char && tok[s + 5] == ':'::char;
-}
-
-# if `tok` begins with `<digits>:`, return the prefix length
-# (through the colon) and the parsed number via `num_out`; otherwise return 0
-fun asm_label_def_len(tok: str, num_out: *u64) usize {
-    if (!asm_is_digit(tok[0])) { ret 0; }
-    var i: usize = 0;
-    var n: u64 = 0;
-    for (asm_is_digit(tok[i])) { n = n * 10 + (tok[i]::u64 - '0'::u64); i = i + 1; }
-    if (tok[i] != ':'::char) { ret 0; }
-    @num_out = n;
-    ret i + 1;
-}
-
-# parse a numeric local-label reference `<digits>f` / `<digits>b`
-# into its number and direction. returns false when `tok` is not that shape
-fun asm_label_ref(tok: str, num_out: *u64, fwd_out: *bool) bool {
-    val len: usize = str_len(tok);
-    if (len < 2)               { ret false; }
-    if (!asm_is_digit(tok[0])) { ret false; }
-    var n: u64 = 0;
-    var i: usize = 0;
-    for (i < len - 1) {
-        if (!asm_is_digit(tok[i])) { ret false; }
-        n = n * 10 + (tok[i]::u64 - '0'::u64);
-        i = i + 1;
-    }
-    val suf: char = tok[len - 1];
-    if (suf == 'f'::char) { @fwd_out = true; }
-    or (suf == 'b'::char) { @fwd_out = false; }
-    or { ret false; }
-    @num_out = n;
-    ret true;
-}
-
-# copy the first whitespace-delimited token of `tok` (the mnemonic)
-# into `mbuf` NUL-terminated and set `args_out` to the trimmed remainder. returns
-# false when the mnemonic exceeds `cap`
-fun asm_first_token(tok: str, mbuf: *u8, cap: usize, args_out: *str) bool {
-    var i: usize = 0;
-    for (tok[i] != 0 && asm_is_space(tok[i])) { i = i + 1; }
-    var k: usize = 0;
-    for (tok[i] != 0 && !asm_is_space(tok[i])) {
-        if (k + 1 >= cap) { ret false; }
-        mbuf[k] = tok[i]::u8; k = k + 1; i = i + 1;
-    }
-    mbuf[k] = 0;
-    for (tok[i] != 0 && asm_is_space(tok[i])) { i = i + 1; }
-    @args_out = (tok::usize + i)::str;
-    ret true;
-}
-
-# build "<prefix><name><suffix>" interned into the session interner so
-# the diagnostic outlives this call; degrades to `fallback` when interning is
-# unavailable. mirrors the x86-64 `enc_named_message`
-fun asm_named_err(st: *encode.EncodeState, prefix: str, name: str, suffix: str, fallback: str) str {
-    if (st.interner == nil || name == nil) { ret fallback; }
-    val lp: usize = str_len(prefix);
-    val ln: usize = str_len(name);
-    val ls: usize = str_len(suffix);
-    val total: usize = lp + ln + ls;
-    val r: R.Result[*u8, str] = A.allocate[u8](st.alloc, total + 1);
-    if (R.is_err[*u8, str](r)) { ret fallback; }
-    val buf: *u8 = R.unwrap_ok[*u8, str](r);
-    var k: usize = 0;
-    var j: usize = 0;
-    for (j < lp) { buf[k] = prefix[j]::u8; k = k + 1; j = j + 1; }
-    j = 0;
-    for (j < ln) { buf[k] = name[j]::u8; k = k + 1; j = j + 1; }
-    j = 0;
-    for (j < ls) { buf[k] = suffix[j]::u8; k = k + 1; j = j + 1; }
-    buf[total] = 0;
-    val ir: R.Result[intern.StrId, str] = intern.intern(st.interner, buf::str);
-    A.deallocate[u8](st.alloc, buf, total + 1);
-    if (R.is_err[intern.StrId, str](ir)) { ret fallback; }
-    val nm: O.Option[str] = intern.lookup(st.interner, R.unwrap_ok[intern.StrId, str](ir));
-    if (O.is_some[str](nm)) { ret O.unwrap[str](nm); }
-    ret fallback;
-}
-
-# map a register token to its (index, width, SP-ness). recognizes
-# x0-x30 / w0-w30, sp / wsp (register 31, SP), and xzr / wzr (register 31, zero)
-fun asm_parse_reg(name: str, op: *AsmOp) bool {
-    val len: usize = str_len(name);
-    if (len == 0)                { ret false; }
-    if (str_equals(name, "xzr")) { op.kind = ASMOP_REG; op.reg = 31; op.is64 = true;  op.is_sp = false; ret true; }
-    if (str_equals(name, "wzr")) { op.kind = ASMOP_REG; op.reg = 31; op.is64 = false; op.is_sp = false; ret true; }
-    if (str_equals(name, "sp"))  { op.kind = ASMOP_REG; op.reg = 31; op.is64 = true;  op.is_sp = true;  ret true; }
-    if (str_equals(name, "wsp")) { op.kind = ASMOP_REG; op.reg = 31; op.is64 = false; op.is_sp = true;  ret true; }
-    val c0: char = name[0];
-    if (c0 != 'x'::char && c0 != 'w'::char) { ret false; }
-    if (len < 2 || len > 3)                 { ret false; }
-    var n: u32 = 0;
-    var i: usize = 1;
-    for (i < len) {
-        if (!asm_is_digit(name[i])) { ret false; }
-        n = n * 10 + (name[i]::u32 - '0'::u32);
-        i = i + 1;
-    }
-    if (n > 30) { ret false; }
-    op.kind = ASMOP_REG; op.reg = n; op.is64 = (c0 == 'x'::char); op.is_sp = false;
-    ret true;
-}
-
-# parse the inner text of a `[...]` memory operand into `op`. forms:
-# `[Xn]`, `[Xn, #imm]`, `[Xn, #imm]!` (pre-index writeback), `[Xn, Xm]` (register
-# offset), and `[Xn, :lo12:sym]` (folded-global low half). the `:lo12:` symbol name
-# is recorded as a borrowed slice of `tok` (stable for the statement)
-fun asm_parse_mem(tok: str, len: usize, op: *AsmOp) bool {
-    op.kind = ASMOP_MEM;
-    var hi: usize = len;
-    if (tok[hi - 1] == '!'::char)                        { op.wb_pre = true; hi = hi - 1; }
-    if (hi < 2)                                          { ret false; }
-    if (tok[0] != '['::char || tok[hi - 1] != ']'::char) { ret false; }
-    val ilo: usize = 1;
-    val ihi: usize = hi - 1;
-
-    var comma: usize = ihi;
-    var found: bool = false;
-    var i: usize = ilo;
-    for (i < ihi && !found) {
-        if (tok[i] == ','::char) { comma = i; found = true; }
-        i = i + 1;
-    }
-
-    var bbuf: [16]u8;
-    if (!asm_copy_region(tok, ilo, comma, ?bbuf[0], 16)) { ret false; }
-    var bop: AsmOp;
-    if (!asm_parse_reg((?bbuf[0])::str, ?bop)) { ret false; }
-    op.base = bop.reg; op.base_sp = bop.is_sp;
-    if (!found) { ret true; }
-
-    var s: usize = comma + 1;
-    var e: usize = ihi;
-    for (s < e && asm_is_space(tok[s])) { s = s + 1; }
-    for (e > s && asm_is_space(tok[e - 1])) { e = e - 1; }
-    if (e <= s) { ret false; }
-
-    # the `:lo12:sym` folded-global low half (symbol name borrowed from `tok`).
-    if (asm_region_is_lo12(tok, s, e)) {
-        op.is_lo12 = true;
-        op.name = (tok::usize + s + 6)::str;
-        op.name_len = e - (s + 6);
-        if (op.name_len == 0) { ret false; }
-        ret true;
-    }
-    # a scaled-index register `[Xn, Xm]`, else a displacement. the displacement is
-    # written bare (`[Xn, 8]`) - `#` is the inline-asm comment character, stripped at
-    # lower time - though a leading `#` is also tolerated here.
-    var ibuf: [32]u8;
-    var ds: usize = s;
-    if (tok[ds] == '#'::char)                       { ds = ds + 1; }
-    if (!asm_copy_region(tok, ds, e, ?ibuf[0], 32)) { ret false; }
-    var iop: AsmOp;
-    if (tok[s] != '#'::char && asm_parse_reg((?ibuf[0])::str, ?iop)) {
-        op.has_index = true; op.index = iop.reg; op.index64 = iop.is64;
-        ret true;
-    }
-    val r: R.Result[i64, str] = parse.parse_i64_exact((?ibuf[0])::str, 0);
-    if (R.is_err[i64, str](r)) { ret false; }
-    op.imm = R.unwrap_ok[i64, str](r); op.has_disp = true;
-    ret true;
-}
-
-# parse one trimmed operand token into `op` - a register, an
-# `#imm` / bare immediate, a `[...]` memory reference, a `:lo12:sym` low-half
-# specifier, or a bare symbol. returns false when the token matches none
-fun asm_parse_operand(tok: str, op: *AsmOp) bool {
-    asm_op_clear(op);
-    val len: usize = str_len(tok);
-    if (len == 0)               { ret false; }
-    if (asm_parse_reg(tok, op)) { ret true; }
-    asm_op_clear(op);
-    if (tok[0] == '['::char) { ret asm_parse_mem(tok, len, op); }
-    if (tok[0] == '#'::char) {
-        val r: R.Result[i64, str] = parse.parse_i64_exact((tok::usize + 1)::str, 0);
-        if (R.is_ok[i64, str](r)) { op.kind = ASMOP_IMM; op.imm = R.unwrap_ok[i64, str](r); ret true; }
-        ret false;
-    }
-    if (str_starts_with(tok, ":lo12:")) {
-        op.kind = ASMOP_LO12; op.is_lo12 = true;
-        op.name = (tok::usize + 6)::str; op.name_len = len - 6;
-        if (op.name_len == 0) { ret false; }
-        ret true;
-    }
-    if (asm_is_sym_token(tok, len)) {
-        op.kind = ASMOP_SYM; op.name = tok; op.name_len = len;
-        ret true;
-    }
-    val r2: R.Result[i64, str] = parse.parse_i64_exact(tok, 0);
-    if (R.is_ok[i64, str](r2)) { op.kind = ASMOP_IMM; op.imm = R.unwrap_ok[i64, str](r2); ret true; }
-    ret false;
-}
-
-# split `args` into trimmed top-level operand tokens (commas outside
-# `[...]`), copying each NUL-terminated into `b0`..`b3` (each `cap` bytes). returns
-# false on more than four operands, an empty token, or an oversized token
-fun asm_split(args: str, b0: *u8, b1: *u8, b2: *u8, b3: *u8, cap: usize, count_out: *u32) bool {
-    val len: usize = str_len(args);
-    var count: u32 = 0;
-    var depth: i32 = 0;
-    var start: usize = 0;
-    var i: usize = 0;
-    for (i <= len) {
-        var is_sep: bool = false;
-        if (i == len)                           { is_sep = true; }
-        or (args[i] == '['::char)               { depth = depth + 1; }
-        or (args[i] == ']'::char)               { depth = depth - 1; }
-        or (args[i] == ','::char && depth == 0) { is_sep = true; }
-        if (is_sep) {
-            if (count >= 4) { ret false; }
-            var dst: *u8 = b0;
-            if (count == 1)                                 { dst = b1; }
-            or (count == 2)                                 { dst = b2; }
-            or (count == 3)                                 { dst = b3; }
-            if (!asm_copy_region(args, start, i, dst, cap)) { ret false; }
-            count = count + 1;
-            start = i + 1;
-        }
-        i = i + 1;
-    }
-    @count_out = count;
-    ret true;
-}
-
 # map an A64 condition mnemonic (eq/ne/cs/hs/cc/lo/.../le/al) to its
 # 4-bit condition code, or return false for an unknown condition
 fun asm_parse_cond(s: str, out: *u32) bool {
@@ -3778,11 +3298,15 @@ fun asm_parse_cond(s: str, out: *u32) bool {
     ret false;
 }
 
-# parse a `lsl #N` (or `lsl N`) shift token into the amount
+# parse a `lsl N` shift token into the amount
+#
+# The `#` a hand assembler writes before an immediate never reaches here: `#` is the
+# mach inline-asm comment character and the lowering strips it, so the token is bare.
 fun asm_parse_lsl_amount(s: str, out: *u32) bool {
     if (!str_starts_with(s, "lsl")) { ret false; }
-    var rest: str = asm_trim((s::usize + 3)::str);
-    if (rest[0] == '#'::char) { rest = (rest::usize + 1)::str; }
+    var i: usize = 3;
+    for (s[i] != 0 && iasm.is_space(s[i])) { i = i + 1; }
+    val rest: str = (s::usize + i)::str;
     val r: R.Result[i64, str] = parse.parse_i64_exact(rest, 0);
     if (R.is_err[i64, str](r)) { ret false; }
     val v: i64 = R.unwrap_ok[i64, str](r);
@@ -3791,117 +3315,21 @@ fun asm_parse_lsl_amount(s: str, out: *u32) bool {
     ret true;
 }
 
-# intern a symbol name borrowed from the inline-asm body
-#
-# The name is a region of the asm body, not a NUL-terminated string, so it is
-# interned before either the instruction notification or the relocation can name it
-# - both take the resolved id
-fun asm_intern(st: *encode.EncodeState, name: str, name_len: usize) R.Result[intern.StrId, str] {
-    ret intern.intern_bytes(st.interner, name, name_len);
-}
-
-# append the base-10 digits of `n` (at least one digit for zero)
-fun asm_emit_dec(out: *encode.ByteBuf, n: u64) {
-    if (n == 0) { encode.emit_byte(out, '0'::u8); ret; }
-    var tmp: [20]u8;
-    var len: usize = 0;
-    var v: u64 = n;
-    for (v > 0) { tmp[len] = (v % 10)::u8 + '0'::u8; v = v / 10; len = len + 1; }
-    var k: usize = 0;
-    for (k < len) { encode.emit_byte(out, tmp[len - 1 - k]); k = k + 1; }
-}
-
-# append the `[x29, #off]` / `[x29, #-off]` text for a local's
-# frame-slot displacement (the AArch64 analogue of x86-64's `[rbp+off]`)
-fun asm_emit_frame_ref(out: *encode.ByteBuf, off: i64) {
-    encode.emit_byte(out, '['::u8); encode.emit_byte(out, 'x'::u8); encode.emit_byte(out, '2'::u8); encode.emit_byte(out, '9'::u8);
-    encode.emit_byte(out, ','::u8); encode.emit_byte(out, ' '::u8); encode.emit_byte(out, '#'::u8);
-    var mag: i64 = off;
-    if (off < 0) { encode.emit_byte(out, '-'::u8); mag = -off; }
-    asm_emit_dec(out, mag::u64);
-    encode.emit_byte(out, ']'::u8);
-}
-
-# true when the interned binding name equals `body[start..start+n)`
-fun asm_bind_name_eq(interner: *intern.Interner, name: intern.StrId, body: str, start: usize, name_len: usize) bool {
-    val nopt: O.Option[str] = intern.lookup(interner, name);
-    if (!O.is_some[str](nopt)) { ret false; }
-    ret str_region_equals(body, start, name_len, O.unwrap[str](nopt));
-}
-
-# release a byte buffer's backing storage on an error path
-fun asm_free_buf(b: *encode.ByteBuf) {
-    if (b.data != nil && b.cap > 0) {
-        A.deallocate[u8](b.alloc, b.data, b.cap);
-        b.data = nil; b.cap = 0; b.len = 0;
-    }
-}
-
-# produce a NUL-terminated copy of the asm body with
-# each `{name}` replaced by its local's `[x29, #off]` frame-slot text. the offset
-# comes from the slot-vreg binding resolved against the laid-out frame. an unbound
-# `{name}` is a hard error. mirrors x86-64's `substitute_asm_locals`
-fun substitute_asm_locals_arm64(alloc: *A.Allocator, interner: *intern.Interner, f: *mir.MirFunction, pl: *mir.MirAsm) R.Result[str, str] {
-    var out: encode.ByteBuf = encode.buf_init(alloc);
-    val body: str = pl.body;
-    var i: usize = 0;
-    for (body[i] != 0) {
-        if (body[i] != '{'::char) {
-            encode.emit_byte(?out, body[i]::u8);
-            i = i + 1;
-            cnt;
-        }
-        val name_start: usize = i + 1;
-        var j: usize = name_start;
-        for (body[j] != 0 && body[j] != '}'::char) { j = j + 1; }
-        if (body[j] == 0) {
-            asm_free_buf(?out);
-            ret R.err[str, str]("encode: unterminated '{' in inline asm body");
-        }
-        val name_len: usize = j - name_start;
-
-        var off: i64 = 0;
-        var found: bool = false;
-        var b: u32 = 0;
-        for (b < pl.bind_count) {
-            if (asm_bind_name_eq(interner, pl.binds[b].name, body, name_start, name_len)) {
-                val so: O.Option[i64] = frame_slot_offset(f, pl.binds[b].slot_vreg);
-                if (!O.is_some[i64](so)) {
-                    asm_free_buf(?out);
-                    ret R.err[str, str]("encode: inline-asm '{name}' local has no frame slot");
-                }
-                off = O.unwrap[i64](so);
-                found = true;
-                b = pl.bind_count;
-            } or {
-                b = b + 1;
-            }
-        }
-        if (!found) {
-            asm_free_buf(?out);
-            ret R.err[str, str]("encode: unknown local in inline asm '{name}' reference");
-        }
-
-        asm_emit_frame_ref(?out, off);
-        i = j + 1;
-    }
-    encode.emit_byte(?out, 0);
-
-    if (out.data == nil || out.len == 0) {
-        asm_free_buf(?out);
-        val r: R.Result[*u8, str] = A.allocate[u8](alloc, 1::usize);
-        if (R.is_err[*u8, str](r)) { ret R.err[str, str](R.unwrap_err[*u8, str](r)); }
-        val one: *u8 = R.unwrap_ok[*u8, str](r);
-        one[0] = 0;
-        ret R.ok[str, str](one::str);
-    }
-    if (out.cap != out.len) {
-        val r: R.Result[*u8, str] = A.reallocate[u8](alloc, out.data, out.cap, out.len);
-        if (R.is_err[*u8, str](r)) { ret R.err[str, str](R.unwrap_err[*u8, str](r)); }
-        out.data = R.unwrap_ok[*u8, str](r);
-        out.cap  = out.len;
-    }
-    ret R.ok[str, str](out.data::str);
+# the CRm value for a dmb barrier-domain name
+fun asm_barrier_option(name: str, out: *u32) bool {
+    if (str_equals(name, "sy"))    { @out = 15; ret true; }
+    if (str_equals(name, "st"))    { @out = 14; ret true; }
+    if (str_equals(name, "ld"))    { @out = 13; ret true; }
+    if (str_equals(name, "ish"))   { @out = 11; ret true; }
+    if (str_equals(name, "ishst")) { @out = 10; ret true; }
+    if (str_equals(name, "ishld")) { @out = 9;  ret true; }
+    if (str_equals(name, "nsh"))   { @out = 7;  ret true; }
+    if (str_equals(name, "nshst")) { @out = 6;  ret true; }
+    if (str_equals(name, "nshld")) { @out = 5;  ret true; }
+    if (str_equals(name, "osh"))   { @out = 3;  ret true; }
+    if (str_equals(name, "oshst")) { @out = 2;  ret true; }
+    if (str_equals(name, "oshld")) { @out = 1;  ret true; }
+    ret false;
 }
 
 # materialize `mov Rd, #imm`. a value representable as a single
@@ -3926,478 +3354,812 @@ fun emit_asm_mov_imm(st: *encode.EncodeState, rd: u32, value: u64, use64: bool) 
     emit_movewide_seq(st, rd, value, use64);
 }
 
-# `mov Rd, Rm` (an `add` when SP is involved, else `orr Rd, XZR, Rm`)
-# or `mov Rd, #imm` (MOVZ / MOVZ+MOVK)
-fun emit_asm_mov(st: *encode.EncodeState, args: str) R.Result[bool, str] {
-    var b0: [128]u8; var b1: [128]u8; var b2: [128]u8; var b3: [128]u8;
-    var n: u32 = 0;
-    if (!asm_split(args, ?b0[0], ?b1[0], ?b2[0], ?b3[0], 128, ?n)) { ret R.err[bool, str]("encode: malformed inline-asm 'mov' operands"); }
-    if (n != 2)                                                    { ret R.err[bool, str]("encode: inline-asm 'mov' expects two operands"); }
-    var dst: AsmOp;
-    var src: AsmOp;
-    if (!asm_parse_operand((?b0[0])::str, ?dst)) { ret R.err[bool, str]("encode: malformed inline-asm 'mov' destination"); }
-    if (!asm_parse_operand((?b1[0])::str, ?src)) { ret R.err[bool, str]("encode: malformed inline-asm 'mov' source"); }
-    if (dst.kind != ASMOP_REG)                   { ret R.err[bool, str]("encode: inline-asm 'mov' destination must be a register"); }
-    val use64: bool = dst.is64;
-    if (src.kind == ASMOP_REG) {
-        if (dst.is_sp || src.is_sp) {
-            emit_addsub_imm(st, sel(use64, ADDI_X, ADDI_W), dst.reg, src.reg, 0, 0);
-        } or {
-            emit_alu3(st, sel(use64, ORR_X, ORR_W), dst.reg, ZR, src.reg);
-        }
-        ret R.ok[bool, str](true);
-    }
-    if (src.kind == ASMOP_IMM) {
-        emit_asm_mov_imm(st, dst.reg, src.imm::u64, use64);
-        ret R.ok[bool, str](true);
-    }
-    ret R.err[bool, str]("encode: inline-asm 'mov' source must be a register or immediate");
+# the AArch64 inline-assembly grammar
+#
+# The aarch64 half of the shared parser (`isa.asm`): the instructions an
+# `asm aarch64 { ... }` body may name, what each one writes, and how its operands and
+# bytes are formed. Everything above an operand token - statement splitting, byte
+# accounting, numeric local labels, `{name}` binding, the effect fold and the block
+# driver - is the shared spine's and appears nowhere here.
+#
+# `Mnemonic.code` names the MNEMONIC (`A64M_*`), not an encoding. AArch64 does not
+# encode through opcodes: `ldr` is six base words picked by the transferred
+# register's width and the addressing form, and `add` is four picked by width and
+# operand kind. Resolving mnemonic + operands to a base word is what an assembler
+# front end does, and the base word the emitter picks is the ONLY naming that reaches
+# the bytes and the printer - there is no second identifier riding beside them
+# (#2226).
+#
+# Condition codes ride `flags[11:8]` rather than becoming per-condition mnemonics,
+# matching the encoder: `b.<cond>` is one instruction with a condition field, and
+# `cset` one alias with one.
+
+# the operand pattern a mnemonic's fields follow, carried in `Mnemonic.flags[7:0]`
+val A64P_NULLARY:  u16 = 1;   # a whole-word instruction with no operands
+val A64P_RET_REG:  u16 = 2;   # `ret Xn`
+val A64P_IMM16:    u16 = 3;   # `svc` / `brk #imm`
+val A64P_MOV:      u16 = 4;   # `mov Rd, Rm | #imm`
+val A64P_MOVEWIDE: u16 = 5;   # `movz` / `movk Rd, #imm [, lsl #N]`
+val A64P_ADDSUB:   u16 = 6;   # `add` / `sub Rd, Rn, #imm | Rm | :lo12:sym`
+val A64P_LOGICAL:  u16 = 7;   # `and` / `orr` / `eor Rd, Rn, Rm`
+val A64P_CMP:      u16 = 8;   # `cmp Rn, #imm | Rm`
+val A64P_CSET:     u16 = 9;   # `cset Rd, <cond>`
+val A64P_ADRP:     u16 = 10;  # `adrp Xd, sym` / `adrp Xd, :got:sym`
+val A64P_BL:       u16 = 11;  # `bl sym`
+val A64P_BR_REG:   u16 = 12;  # `blr` / `br Xn`
+val A64P_B:        u16 = 13;  # `b <local | sym>`
+val A64P_BCOND:    u16 = 14;  # `b.<cond> <local>`
+val A64P_CBR:      u16 = 15;  # `cbz` / `cbnz Rt, <local>`
+val A64P_LDST:     u16 = 16;  # `ldr` / `str` family
+val A64P_LDSTP:    u16 = 17;  # `ldp` / `stp`
+val A64P_DMB:      u16 = 18;  # `dmb <option>`
+val A64P_LDORD:    u16 = 19;  # `ldar` / `stlr` / `ldaxr Rt, [Xn]`
+val A64P_STLXR:    u16 = 20;  # `stlxr Ws, Rt, [Xn]`
+val A64P_SHIFT:    u16 = 21;  # `lsl` / `lsr` / `asr` and their variable forms
+
+# the four-bit condition a `b.<cond>` or `cset` carries, in `Mnemonic.flags[11:8]`
+val A64F_COND_SHIFT: u16 = 8;
+val A64F_COND_MASK:  u16 = 0x0F00;
+
+# the mnemonic a row names
+#
+# The text-level identity of an instruction, which on AArch64 is genuinely coarser
+# than an encoding: one mnemonic covers several base words the emitter picks from the
+# operands.
+val A64M_NOP:   u32 = 0;
+val A64M_YIELD: u32 = 1;
+val A64M_RET:   u32 = 2;
+val A64M_SVC:   u32 = 3;
+val A64M_BRK:   u32 = 4;
+val A64M_MOV:   u32 = 5;
+val A64M_MOVZ:  u32 = 6;
+val A64M_MOVK:  u32 = 7;
+val A64M_ADD:   u32 = 8;
+val A64M_SUB:   u32 = 9;
+val A64M_AND:   u32 = 10;
+val A64M_ORR:   u32 = 11;
+val A64M_EOR:   u32 = 12;
+val A64M_CMP:   u32 = 13;
+val A64M_CSET:  u32 = 14;
+val A64M_ADRP:  u32 = 15;
+val A64M_BL:    u32 = 16;
+val A64M_BLR:   u32 = 17;
+val A64M_BR:    u32 = 18;
+val A64M_B:     u32 = 19;
+val A64M_CBZ:   u32 = 20;
+val A64M_CBNZ:  u32 = 21;
+val A64M_LDR:   u32 = 22;
+val A64M_STR:   u32 = 23;
+val A64M_LDRB:  u32 = 24;
+val A64M_STRB:  u32 = 25;
+val A64M_LDRH:  u32 = 26;
+val A64M_STRH:  u32 = 27;
+val A64M_LDP:   u32 = 28;
+val A64M_STP:   u32 = 29;
+val A64M_DMB:   u32 = 30;
+val A64M_LDAR:  u32 = 31;
+val A64M_STLR:  u32 = 32;
+val A64M_LDAXR: u32 = 33;
+val A64M_STLXR: u32 = 34;
+val A64M_LSL:   u32 = 35;
+val A64M_LSR:   u32 = 36;
+val A64M_ASR:   u32 = 37;
+val A64M_LSLV:  u32 = 38;
+val A64M_LSRV:  u32 = 39;
+val A64M_ASRV:  u32 = 40;
+
+# the caller-saved general-purpose file (x0-x18 and x30), which a call destroys
+#
+# None of it is callee-saved, so a call inside an inline-asm block adds no frame; the
+# allocator simply holds nothing across it.
+val A64_CALLER_SAVED: u32 = 0x4007FFFF;
+
+# number of rows in the AArch64 inline-asm mnemonic table
+val A64_MNEMONIC_COUNT: usize = 42;
+
+# the AArch64 inline-asm instruction surface
+#
+# Exactly the instructions an `asm aarch64` body may name, beyond the `b.<cond>`
+# family `a64_decode_bcond` synthesizes. A mnemonic absent from both is refused with a
+# diagnostic naming it - there is no permissive path, so the effect model can never be
+# asked about an instruction nobody described.
+#
+# `ret` takes two rows because it is the one mnemonic with both a no-operand and a
+# one-operand form; the two match disjoint statements.
+val A64_MNEMONICS: [A64_MNEMONIC_COUNT]iasm.Mnemonic = [A64_MNEMONIC_COUNT]iasm.Mnemonic{
+    # no-operand forms, and the register return. `ret` jumps through a link register
+    # without writing one; the barriers and the trap write nothing.
+    iasm.Mnemonic{ name: "nop",   code: A64M_NOP,   form: iasm.AF_NONE, writes: iasm.AW_NONE, implicit: 0, flags: A64P_NULLARY, words: 1 },
+    iasm.Mnemonic{ name: "yield", code: A64M_YIELD, form: iasm.AF_NONE, writes: iasm.AW_NONE, implicit: 0, flags: A64P_NULLARY, words: 1 },
+    iasm.Mnemonic{ name: "ret",   code: A64M_RET,   form: iasm.AF_NONE, writes: iasm.AW_NONE, implicit: 0, flags: A64P_NULLARY, words: 1 },
+    iasm.Mnemonic{ name: "ret",   code: A64M_RET,   form: iasm.AF_OPS,  writes: iasm.AW_NONE, implicit: 0, flags: A64P_RET_REG, words: 1 },
+
+    # the supervisor call takes the kernel's return register; a trap writes nothing.
+    iasm.Mnemonic{ name: "svc", code: A64M_SVC, form: iasm.AF_OPS, writes: iasm.AW_NONE, implicit: 1, flags: A64P_IMM16, words: 1 },
+    iasm.Mnemonic{ name: "brk", code: A64M_BRK, form: iasm.AF_OPS, writes: iasm.AW_NONE, implicit: 0, flags: A64P_IMM16, words: 1 },
+
+    # data processing. each writes its destination register.
+    iasm.Mnemonic{ name: "movz", code: A64M_MOVZ, form: iasm.AF_OPS, writes: iasm.AW_OP0, implicit: 0, flags: A64P_MOVEWIDE, words: 1 },
+    iasm.Mnemonic{ name: "movk", code: A64M_MOVK, form: iasm.AF_OPS, writes: iasm.AW_OP0, implicit: 0, flags: A64P_MOVEWIDE, words: 1 },
+    iasm.Mnemonic{ name: "mov",  code: A64M_MOV,  form: iasm.AF_OPS, writes: iasm.AW_OP0, implicit: 0, flags: A64P_MOV,      words: iasm.WORDS_VARIABLE },
+    iasm.Mnemonic{ name: "add",  code: A64M_ADD,  form: iasm.AF_OPS, writes: iasm.AW_OP0, implicit: 0, flags: A64P_ADDSUB,   words: 1 },
+    iasm.Mnemonic{ name: "sub",  code: A64M_SUB,  form: iasm.AF_OPS, writes: iasm.AW_OP0, implicit: 0, flags: A64P_ADDSUB,   words: 1 },
+    iasm.Mnemonic{ name: "and",  code: A64M_AND,  form: iasm.AF_OPS, writes: iasm.AW_OP0, implicit: 0, flags: A64P_LOGICAL,  words: 1 },
+    iasm.Mnemonic{ name: "orr",  code: A64M_ORR,  form: iasm.AF_OPS, writes: iasm.AW_OP0, implicit: 0, flags: A64P_LOGICAL,  words: 1 },
+    iasm.Mnemonic{ name: "eor",  code: A64M_EOR,  form: iasm.AF_OPS, writes: iasm.AW_OP0, implicit: 0, flags: A64P_LOGICAL,  words: 1 },
+    iasm.Mnemonic{ name: "cset", code: A64M_CSET, form: iasm.AF_OPS, writes: iasm.AW_OP0, implicit: 0, flags: A64P_CSET,     words: 1 },
+    iasm.Mnemonic{ name: "adrp", code: A64M_ADRP, form: iasm.AF_OPS, writes: iasm.AW_OP0, implicit: 0, flags: A64P_ADRP,     words: 1 },
+
+    # compare writes only the flags, which hold no allocatable value.
+    iasm.Mnemonic{ name: "cmp", code: A64M_CMP, form: iasm.AF_OPS, writes: iasm.AW_NONE, implicit: 0, flags: A64P_CMP, words: 1 },
+
+    # control transfers. a linking branch destroys the caller-saved file; a plain or
+    # conditional branch writes nothing.
+    iasm.Mnemonic{ name: "blr",  code: A64M_BLR,  form: iasm.AF_OPS, writes: iasm.AW_NONE, implicit: A64_CALLER_SAVED, flags: A64P_BR_REG, words: 1 },
+    iasm.Mnemonic{ name: "bl",   code: A64M_BL,   form: iasm.AF_OPS, writes: iasm.AW_NONE, implicit: A64_CALLER_SAVED, flags: A64P_BL,     words: 1 },
+    iasm.Mnemonic{ name: "br",   code: A64M_BR,   form: iasm.AF_OPS, writes: iasm.AW_NONE, implicit: A64_CALLER_SAVED, flags: A64P_BR_REG, words: 1 },
+    iasm.Mnemonic{ name: "b",    code: A64M_B,    form: iasm.AF_OPS, writes: iasm.AW_NONE, implicit: 0,                flags: A64P_B,      words: 1 },
+    iasm.Mnemonic{ name: "cbz",  code: A64M_CBZ,  form: iasm.AF_OPS, writes: iasm.AW_NONE, implicit: 0,                flags: A64P_CBR,    words: 1 },
+    iasm.Mnemonic{ name: "cbnz", code: A64M_CBNZ, form: iasm.AF_OPS, writes: iasm.AW_NONE, implicit: 0,                flags: A64P_CBR,    words: 1 },
+
+    # loads write their transferred register; stores write memory and no register.
+    # a displacement declares no word count: the encoder legalizes an offset outside
+    # the immediate ranges into a materialize-plus-register-offset pair.
+    iasm.Mnemonic{ name: "ldrb", code: A64M_LDRB, form: iasm.AF_OPS, writes: iasm.AW_OP0,  implicit: 0, flags: A64P_LDST, words: 1 },
+    iasm.Mnemonic{ name: "strb", code: A64M_STRB, form: iasm.AF_OPS, writes: iasm.AW_NONE, implicit: 0, flags: A64P_LDST, words: 1 },
+    iasm.Mnemonic{ name: "ldrh", code: A64M_LDRH, form: iasm.AF_OPS, writes: iasm.AW_OP0,  implicit: 0, flags: A64P_LDST, words: 1 },
+    iasm.Mnemonic{ name: "strh", code: A64M_STRH, form: iasm.AF_OPS, writes: iasm.AW_NONE, implicit: 0, flags: A64P_LDST, words: 1 },
+    iasm.Mnemonic{ name: "ldr",  code: A64M_LDR,  form: iasm.AF_OPS, writes: iasm.AW_OP0,  implicit: 0, flags: A64P_LDST, words: 1 },
+    iasm.Mnemonic{ name: "str",  code: A64M_STR,  form: iasm.AF_OPS, writes: iasm.AW_NONE, implicit: 0, flags: A64P_LDST, words: 1 },
+
+    # a load pair writes both loaded registers; either pair form in a writeback
+    # addressing mode also writes its base.
+    iasm.Mnemonic{ name: "ldp", code: A64M_LDP, form: iasm.AF_OPS, writes: iasm.AW_OP0 | iasm.AW_OP1 | iasm.AW_WB_BASE, implicit: 0, flags: A64P_LDSTP, words: 1 },
+    iasm.Mnemonic{ name: "stp", code: A64M_STP, form: iasm.AF_OPS, writes: iasm.AW_WB_BASE,                             implicit: 0, flags: A64P_LDSTP, words: 1 },
+
+    # the ordered accesses: a load-acquire writes its destination, a store-release
+    # writes memory, and a store-release-exclusive writes its status register.
+    iasm.Mnemonic{ name: "ldaxr", code: A64M_LDAXR, form: iasm.AF_OPS, writes: iasm.AW_OP0,  implicit: 0, flags: A64P_LDORD, words: 1 },
+    iasm.Mnemonic{ name: "ldar",  code: A64M_LDAR,  form: iasm.AF_OPS, writes: iasm.AW_OP0,  implicit: 0, flags: A64P_LDORD, words: 1 },
+    iasm.Mnemonic{ name: "stlxr", code: A64M_STLXR, form: iasm.AF_OPS, writes: iasm.AW_OP0,  implicit: 0, flags: A64P_STLXR, words: 1 },
+    iasm.Mnemonic{ name: "stlr",  code: A64M_STLR,  form: iasm.AF_OPS, writes: iasm.AW_NONE, implicit: 0, flags: A64P_LDORD, words: 1 },
+    iasm.Mnemonic{ name: "dmb",   code: A64M_DMB,   form: iasm.AF_OPS, writes: iasm.AW_NONE, implicit: 0, flags: A64P_DMB,   words: 1 },
+
+    # the shifts, in their immediate (bitfield-move alias) and variable forms.
+    iasm.Mnemonic{ name: "lslv", code: A64M_LSLV, form: iasm.AF_OPS, writes: iasm.AW_OP0, implicit: 0, flags: A64P_SHIFT, words: 1 },
+    iasm.Mnemonic{ name: "lsrv", code: A64M_LSRV, form: iasm.AF_OPS, writes: iasm.AW_OP0, implicit: 0, flags: A64P_SHIFT, words: 1 },
+    iasm.Mnemonic{ name: "asrv", code: A64M_ASRV, form: iasm.AF_OPS, writes: iasm.AW_OP0, implicit: 0, flags: A64P_SHIFT, words: 1 },
+    iasm.Mnemonic{ name: "lsl",  code: A64M_LSL,  form: iasm.AF_OPS, writes: iasm.AW_OP0, implicit: 0, flags: A64P_SHIFT, words: 1 },
+    iasm.Mnemonic{ name: "lsr",  code: A64M_LSR,  form: iasm.AF_OPS, writes: iasm.AW_OP0, implicit: 0, flags: A64P_SHIFT, words: 1 },
+    iasm.Mnemonic{ name: "asr",  code: A64M_ASR,  form: iasm.AF_OPS, writes: iasm.AW_OP0, implicit: 0, flags: A64P_SHIFT, words: 1 },
+};
+
+# the operand pattern half of a mnemonic row's flags
+fun a64_pattern(flags: u16) u16 { ret flags & 0x00FF; }
+
+# the condition half of a mnemonic row's flags
+fun a64_cond(flags: u16) u32 { ret ((flags & A64F_COND_MASK) >> A64F_COND_SHIFT)::u32; }
+
+# decode a `b.<cond>` mnemonic the table cannot enumerate
+#
+# Fifteen conditions over one instruction. The condition rides the synthesized row's
+# flags rather than becoming fifteen mnemonics, so the parser models what the machine
+# encodes: one conditional branch with a condition field.
+fun a64_decode_bcond(body: str, lo: usize, hi: usize, m: *iasm.Mnemonic, n_out: *usize) bool {
+    var end: usize = lo;
+    for (end < hi && !iasm.is_space(body[end])) { end = end + 1; }
+    val len: usize = end - lo;
+    if (len < 4)                                  { ret false; }
+    if (!str_region_equals(body, lo, 2, "b."))    { ret false; }
+
+    var buf: [8]u8;
+    if (!iasm.copy_region(body, lo + 2, end, ?buf[0], 8)) { ret false; }
+    var cc: u32 = 0;
+    if (!asm_parse_cond((?buf[0])::str, ?cc)) { ret false; }
+
+    m.name     = nil;
+    m.code     = A64M_B;
+    m.form     = iasm.AF_OPS;
+    m.writes   = iasm.AW_NONE;
+    m.implicit = 0;
+    m.flags    = A64P_BCOND | ((cc::u16 << A64F_COND_SHIFT) & A64F_COND_MASK);
+    m.words    = 1;
+    @n_out     = len;
+    ret true;
 }
 
-# `movz` / `movk Rd, #imm16 [, lsl #N]`
-fun emit_asm_movewide(st: *encode.EncodeState, args: str, is_movk: bool) R.Result[bool, str] {
-    var b0: [128]u8; var b1: [128]u8; var b2: [128]u8; var b3: [128]u8;
-    var n: u32 = 0;
-    if (!asm_split(args, ?b0[0], ?b1[0], ?b2[0], ?b3[0], 128, ?n)) { ret R.err[bool, str]("encode: malformed inline-asm movz/movk operands"); }
-    if (n < 2 || n > 3)                                            { ret R.err[bool, str]("encode: inline-asm movz/movk expects Rd, #imm [, lsl #N]"); }
-    var rd: AsmOp;
-    var im: AsmOp;
-    if (!asm_parse_operand((?b0[0])::str, ?rd) || rd.kind != ASMOP_REG) { ret R.err[bool, str]("encode: inline-asm movz/movk destination must be a register"); }
-    if (!asm_parse_operand((?b1[0])::str, ?im) || im.kind != ASMOP_IMM) { ret R.err[bool, str]("encode: inline-asm movz/movk needs an immediate"); }
-    if (im.imm < 0 || im.imm > 0xFFFF)                                  { ret R.err[bool, str]("encode: inline-asm movz/movk immediate is out of 16-bit range"); }
-    var hw: u32 = 0;
-    if (n == 3) {
-        if (!asm_parse_lsl_amount((?b2[0])::str, ?hw)) { ret R.err[bool, str]("encode: inline-asm movz/movk shift must be 'lsl #N'"); }
-        if ((hw & 0xF) != 0)                           { ret R.err[bool, str]("encode: inline-asm movz/movk shift must be a multiple of 16"); }
-        hw = hw / 16;
-        if (rd.is64) {
-            if (hw > 3) { ret R.err[bool, str]("encode: inline-asm movz/movk 64-bit shift exceeds lsl #48"); }
-        } or {
-            if (hw > 1) { ret R.err[bool, str]("encode: inline-asm movz/movk 32-bit shift exceeds lsl #16"); }
+# the operand index a pattern reads as a name rather than as a machine operand
+#
+# A branch target, a condition, a barrier domain and a `lsl N` shift decoration are
+# all bare words the operand lexer would either refuse or mistake for a symbol, so the
+# pattern names their position and the lexer skips them.
+fun a64_name_operand(pat: u16) u32 {
+    if (pat == A64P_B || pat == A64P_BCOND || pat == A64P_DMB)  { ret 0; }
+    if (pat == A64P_CBR || pat == A64P_CSET)                    { ret 1; }
+    if (pat == A64P_MOVEWIDE)                                   { ret 2; }
+    ret 0xFFFFFFFF;
+}
+
+# parse one AArch64 operand token into `op`
+#
+# The A64 operand syntax: an X / W register (or SP / ZR at index 31), a bare integer
+# immediate, a `[Xn {, #imm | , Xm | , :mod:sym}] {!}` address, a `:mod:sym`
+# relocation specifier, a bare symbol, or a `{name}` local binding.
+#
+# There is no `#imm` spelling: `#` is the mach inline-asm comment character and the
+# lowering strips it before the body reaches any backend, so an immediate is written
+# bare and a `#` can never arrive here.
+fun a64_operand(c: *iasm.Cursor, lo: usize, hi: usize, op: *iasm.Operand) R.Result[bool, str] {
+    @op = iasm.op_none();
+    if (hi <= lo) { ret R.err[bool, str]("encode: malformed inline-asm operand"); }
+
+    # a `{name}` local: with a laid-out frame it becomes the `[x29, off]` stack slot
+    # it denotes; without one the displacement is genuinely unknown, and the operand
+    # stays a binding - it names a stack slot either way, so it can never be a
+    # register and the effect model reads it exactly as it reads memory.
+    if (c.body[lo] == '{'::char) {
+        var off: i64 = 0;
+        val br: R.Result[bool, str] = iasm.bind_offset(c, lo, hi, ?off);
+        if (R.is_err[bool, str](br)) { ret br; }
+        if (R.unwrap_ok[bool, str](br)) {
+            @op = iasm.op_mem(arm64.FP, off, -1, 0, 8);
+            op.flags = iasm.AOF_HAS_DISP;
+            ret R.ok[bool, str](true);
         }
+        op.kind     = iasm.AOP_BIND;
+        op.size     = 8;
+        op.name_off = lo + 1;
+        op.name_len = hi - lo - 2;
+        ret R.ok[bool, str](true);
     }
-    var base: u32 = sel(rd.is64, MOVZ_X, MOVZ_W);
-    if (is_movk) { base = sel(rd.is64, MOVK_X, MOVK_W); }
-    emit_movewide(st, base, rd.reg, hw, im.imm::u32);
+
+    if (c.body[lo] == '['::char) { ret a64_mem(c, lo, hi, op); }
+    if (c.body[lo] == ':'::char) { ret a64_modifier(c, lo, hi, op); }
+
+    var buf: [64]u8;
+    if (!iasm.copy_region(c.body, lo, hi, ?buf[0], 64)) { ret R.err[bool, str]("encode: malformed inline-asm operand"); }
+    val tok: str = (?buf[0])::str;
+
+    if (a64_reg(tok, op)) { ret R.ok[bool, str](true); }
+
+    val iv: O.Option[i64] = iasm.region_i64(c.body, lo, hi);
+    if (O.is_some[i64](iv)) { @op = iasm.op_imm(O.unwrap[i64](iv), 8); ret R.ok[bool, str](true); }
+
+    if (iasm.is_sym_region(c.body, lo, hi)) {
+        @op = iasm.op_sym(lo, hi - lo, isa.SYM_MOD_NONE, 8);
+        ret R.ok[bool, str](true);
+    }
+    ret R.err[bool, str]("encode: malformed inline-asm operand");
+}
+
+# map a register token to its index, width and stack-pointer-ness
+#
+# Recognizes x0-x30 / w0-w30, `sp` / `wsp` (register 31 naming the stack pointer) and
+# `xzr` / `wzr` (register 31 naming the zero register). The two readings of 31 are a
+# real distinction the encoding makes, so the operand carries which one was written.
+fun a64_reg(name: str, op: *iasm.Operand) bool {
+    if (str_equals(name, "xzr")) { @op = iasm.op_reg(31, 8); ret true; }
+    if (str_equals(name, "wzr")) { @op = iasm.op_reg(31, 4); ret true; }
+    if (str_equals(name, "sp"))  { @op = iasm.op_reg(31, 8); op.flags = iasm.AOF_STACK_PTR; ret true; }
+    if (str_equals(name, "wsp")) { @op = iasm.op_reg(31, 4); op.flags = iasm.AOF_STACK_PTR; ret true; }
+
+    val len: usize = str_len(name);
+    if (len < 2 || len > 3) { ret false; }
+    val c0: char = name[0];
+    if (c0 != 'x'::char && c0 != 'w'::char) { ret false; }
+    var n: u32 = 0;
+    var i: usize = 1;
+    for (i < len) {
+        if (!iasm.is_digit(name[i])) { ret false; }
+        n = n * 10 + (name[i]::u32 - '0'::u32);
+        i = i + 1;
+    }
+    if (n > 30) { ret false; }
+    var w: u8 = 4;
+    if (c0 == 'x'::char) { w = 8; }
+    @op = iasm.op_reg(n::i32, w);
+    ret true;
+}
+
+# parse a `:lo12:sym` / `:got:sym` / `:got_lo12:sym` relocation specifier
+#
+# The modifier belongs to the symbol REFERENCE, so it rides `Operand.mod` with the
+# shared `isa.SYM_MOD_*` values the encoder's own notifications carry.
+fun a64_modifier(c: *iasm.Cursor, lo: usize, hi: usize, op: *iasm.Operand) R.Result[bool, str] {
+    var close: usize = lo + 1;
+    var found: bool = false;
+    for (close < hi && !found) {
+        if (c.body[close] == ':'::char) { found = true; } or { close = close + 1; }
+    }
+    if (!found) { ret R.err[bool, str]("encode: malformed inline-asm relocation modifier"); }
+    val nlen: usize = close - lo - 1;
+
+    var mod: isa.SymModifier = isa.SYM_MOD_NONE;
+    if (str_region_equals(c.body, lo + 1, nlen, "lo12"))      { mod = isa.SYM_MOD_PCREL_LO; }
+    or (str_region_equals(c.body, lo + 1, nlen, "got"))       { mod = isa.SYM_MOD_GOT_HI; }
+    or (str_region_equals(c.body, lo + 1, nlen, "got_lo12"))  { mod = isa.SYM_MOD_GOT_LO; }
+    or {
+        ret R.err[bool, str](iasm.span_message(c,
+            "encode: unsupported aarch64 inline-asm relocation modifier '", lo, hi, "'",
+            "encode: unsupported aarch64 inline-asm relocation modifier"));
+    }
+    if (!iasm.is_sym_region(c.body, close + 1, hi)) {
+        ret R.err[bool, str]("encode: malformed inline-asm relocation modifier");
+    }
+    @op = iasm.op_sym(close + 1, hi - close - 1, mod, 8);
     ret R.ok[bool, str](true);
 }
 
-# `add` / `sub Rd, Rn, (#imm | Rm | :lo12:sym)`. an immediate folds
-# into the imm12 (or imm12<<12) form; a `:lo12:sym` (add only) emits the low-half ADD
-# with RK_ADD_LO12; a register uses the shifted-register form. SP with a register
-# operand needs the extended-register form (unsupported, rejected loud)
-fun emit_asm_addsub(st: *encode.EncodeState, args: str, is_sub: bool) R.Result[bool, str] {
-    var b0: [128]u8; var b1: [128]u8; var b2: [128]u8; var b3: [128]u8;
-    var n: u32 = 0;
-    if (!asm_split(args, ?b0[0], ?b1[0], ?b2[0], ?b3[0], 128, ?n)) { ret R.err[bool, str]("encode: malformed inline-asm add/sub operands"); }
-    if (n != 3)                                                    { ret R.err[bool, str]("encode: inline-asm add/sub expects three operands"); }
-    var rd: AsmOp;
-    var rn: AsmOp;
-    var op3: AsmOp;
-    if (!asm_parse_operand((?b0[0])::str, ?rd) || rd.kind != ASMOP_REG) { ret R.err[bool, str]("encode: inline-asm add/sub destination must be a register"); }
-    if (!asm_parse_operand((?b1[0])::str, ?rn) || rn.kind != ASMOP_REG) { ret R.err[bool, str]("encode: inline-asm add/sub first source must be a register"); }
-    if (!asm_parse_operand((?b2[0])::str, ?op3))                        { ret R.err[bool, str]("encode: malformed inline-asm add/sub operand"); }
-    val use64: bool = rd.is64;
+# parse a `[Xn {, #imm | , Xm | , :mod:sym}] {!}` address
+fun a64_mem(c: *iasm.Cursor, lo: usize, hi: usize, op: *iasm.Operand) R.Result[bool, str] {
+    @op = iasm.op_none();
+    op.kind = iasm.AOP_MEM;
+    op.size = 8;
 
-    if (op3.kind == ASMOP_IMM) {
+    var end: usize = hi;
+    if (c.body[end - 1] == '!'::char) { op.flags = op.flags | iasm.AOF_WRITEBACK; end = end - 1; }
+    if (end < lo + 2 || c.body[end - 1] != ']'::char) { ret R.err[bool, str]("encode: malformed inline-asm memory operand"); }
+
+    val ilo: usize = lo + 1;
+    val ihi: usize = end - 1;
+    var comma: usize = ilo;
+    var found: bool = false;
+    for (comma < ihi && !found) {
+        if (c.body[comma] == ','::char) { found = true; } or { comma = comma + 1; }
+    }
+
+    var bbuf: [24]u8;
+    var bend: usize = ihi;
+    if (found) { bend = comma; }
+    if (!iasm.copy_region(c.body, ilo, bend, ?bbuf[0], 24)) { ret R.err[bool, str]("encode: malformed inline-asm memory operand"); }
+    var base: iasm.Operand = iasm.op_none();
+    if (!a64_reg((?bbuf[0])::str, ?base)) { ret R.err[bool, str]("encode: malformed inline-asm memory operand"); }
+    op.reg   = base.reg;
+    op.flags = op.flags | (base.flags & iasm.AOF_STACK_PTR);
+    if (!found) { ret R.ok[bool, str](true); }
+
+    var s: usize = comma + 1;
+    var e: usize = ihi;
+    for (s < e && iasm.is_space(c.body[s])) { s = s + 1; }
+    for (e > s && iasm.is_space(c.body[e - 1])) { e = e - 1; }
+    if (e <= s) { ret R.err[bool, str]("encode: malformed inline-asm memory operand"); }
+
+    # a `:mod:sym` folded-symbol offset, the low half of a page-relative pair.
+    if (c.body[s] == ':'::char) {
+        var sym: iasm.Operand = iasm.op_none();
+        val mr: R.Result[bool, str] = a64_modifier(c, s, e, ?sym);
+        if (R.is_err[bool, str](mr)) { ret mr; }
+        op.flags    = op.flags | iasm.AOF_MEM_SYM;
+        op.mod      = sym.mod;
+        op.name_off = sym.name_off;
+        op.name_len = sym.name_len;
+        ret R.ok[bool, str](true);
+    }
+
+    # a scaled-index register, else a displacement.
+    var ibuf: [24]u8;
+    if (iasm.copy_region(c.body, s, e, ?ibuf[0], 24)) {
+        var idx: iasm.Operand = iasm.op_none();
+        if (a64_reg((?ibuf[0])::str, ?idx)) {
+            op.flags = op.flags | iasm.AOF_HAS_INDEX;
+            op.index = idx.reg;
+            if (idx.size == 8) { op.flags = op.flags | iasm.AOF_WIDE; }
+            ret R.ok[bool, str](true);
+        }
+    }
+    val dv: O.Option[i64] = iasm.region_i64(c.body, s, e);
+    if (!O.is_some[i64](dv)) { ret R.err[bool, str]("encode: malformed inline-asm memory operand"); }
+    op.imm   = O.unwrap[i64](dv);
+    op.flags = op.flags | iasm.AOF_HAS_DISP;
+    ret R.ok[bool, str](true);
+}
+
+# a memory-position operand: an address, or an unresolved `{name}` whose displacement
+# the emitter's parse will supply
+fun a64_is_addr(op: *iasm.Operand) bool {
+    ret op.kind == iasm.AOP_MEM || op.kind == iasm.AOP_BIND;
+}
+
+# true when an operand names a 64-bit register
+fun a64_is64(op: *iasm.Operand) bool { ret op.size == 8; }
+
+# true when an operand names the stack pointer rather than the zero register
+fun a64_is_sp(op: *iasm.Operand) bool { ret (op.flags & iasm.AOF_STACK_PTR) != 0; }
+
+# turn one resolved AArch64 statement into a parsed item
+#
+# Reads each operand token in the shape its mnemonic's pattern names, refusing any
+# other shape. Operand-count and operand-kind checks are the whole validation: an
+# instruction that parses is one this grammar can encode.
+fun a64_parse(c: *iasm.Cursor, s: *iasm.Stmt, item: *iasm.Item) R.Result[bool, str] {
+    val pat: u16 = a64_pattern(s.m.flags);
+    val n: u32 = s.nargs;
+    val name_at: u32 = a64_name_operand(pat);
+
+    var i: u32 = 0;
+    for (i < n) {
+        if (i != name_at) {
+            val r: R.Result[bool, str] = a64_operand(c, s.arg_lo[i::usize], s.arg_hi[i::usize], ?item.ops[i::usize]);
+            if (R.is_err[bool, str](r)) { ret r; }
+        }
+        i = i + 1;
+    }
+
+    if (pat == A64P_NULLARY) {
+        if (n != 0) { ret R.err[bool, str]("encode: inline-asm instruction takes no operands"); }
+        ret R.ok[bool, str](true);
+    }
+    if (pat == A64P_RET_REG || pat == A64P_BR_REG) {
+        if (n != 1)                            { ret R.err[bool, str]("encode: inline-asm instruction expects one register"); }
+        if (item.ops[0].kind != iasm.AOP_REG)  { ret R.err[bool, str]("encode: inline-asm ret/blr/br operand must be a register"); }
+        ret R.ok[bool, str](true);
+    }
+    if (pat == A64P_IMM16) {
+        if (n != 1)                           { ret R.err[bool, str]("encode: inline-asm svc/brk needs an immediate"); }
+        if (item.ops[0].kind != iasm.AOP_IMM) { ret R.err[bool, str]("encode: inline-asm svc/brk needs an immediate"); }
+        if (item.ops[0].imm < 0 || item.ops[0].imm > 0xFFFF) {
+            ret R.err[bool, str]("encode: inline-asm svc/brk immediate is out of 16-bit range");
+        }
+        ret R.ok[bool, str](true);
+    }
+    if (pat == A64P_MOV) {
+        if (n != 2)                           { ret R.err[bool, str]("encode: inline-asm 'mov' expects two operands"); }
+        if (item.ops[0].kind != iasm.AOP_REG) { ret R.err[bool, str]("encode: inline-asm 'mov' destination must be a register"); }
+        # a register move is one instruction; an immediate is a materialization
+        # sequence whose length is a property of the value.
+        if (item.ops[1].kind == iasm.AOP_REG) { item.words = 1; ret R.ok[bool, str](true); }
+        if (item.ops[1].kind == iasm.AOP_IMM) { ret R.ok[bool, str](true); }
+        ret R.err[bool, str]("encode: inline-asm 'mov' source must be a register or immediate");
+    }
+    if (pat == A64P_MOVEWIDE) {
+        if (n < 2 || n > 3)                   { ret R.err[bool, str]("encode: inline-asm movz/movk expects Rd, imm [, lsl N]"); }
+        if (item.ops[0].kind != iasm.AOP_REG) { ret R.err[bool, str]("encode: inline-asm movz/movk destination must be a register"); }
+        if (item.ops[1].kind != iasm.AOP_IMM) { ret R.err[bool, str]("encode: inline-asm movz/movk needs an immediate"); }
+        if (item.ops[1].imm < 0 || item.ops[1].imm > 0xFFFF) {
+            ret R.err[bool, str]("encode: inline-asm movz/movk immediate is out of 16-bit range");
+        }
+        if (n == 3) { ret a64_shift_amount(c, s, item, 2); }
+        ret R.ok[bool, str](true);
+    }
+    if (pat == A64P_ADDSUB || pat == A64P_LOGICAL || pat == A64P_SHIFT) {
+        if (n != 3)                           { ret R.err[bool, str]("encode: inline-asm instruction expects three operands"); }
+        if (item.ops[0].kind != iasm.AOP_REG) { ret R.err[bool, str]("encode: inline-asm destination must be a register"); }
+        if (item.ops[1].kind != iasm.AOP_REG) { ret R.err[bool, str]("encode: inline-asm first source must be a register"); }
+        if (pat == A64P_LOGICAL && item.ops[2].kind != iasm.AOP_REG) {
+            ret R.err[bool, str]("encode: inline-asm and/orr/eor immediate (bitmask) form unsupported; use a register operand");
+        }
+        if (pat == A64P_SHIFT && item.ops[2].kind != iasm.AOP_REG && item.ops[2].kind != iasm.AOP_IMM) {
+            ret R.err[bool, str]("encode: inline-asm shift count must be a register or immediate");
+        }
+        ret R.ok[bool, str](true);
+    }
+    if (pat == A64P_CMP) {
+        if (n != 2)                           { ret R.err[bool, str]("encode: inline-asm 'cmp' expects two operands"); }
+        if (item.ops[0].kind != iasm.AOP_REG) { ret R.err[bool, str]("encode: inline-asm 'cmp' first operand must be a register"); }
+        if (item.ops[1].kind != iasm.AOP_REG && item.ops[1].kind != iasm.AOP_IMM) {
+            ret R.err[bool, str]("encode: inline-asm 'cmp' second operand must be a register or imm12");
+        }
+        ret R.ok[bool, str](true);
+    }
+    if (pat == A64P_CSET) {
+        if (n != 2)                           { ret R.err[bool, str]("encode: inline-asm 'cset' expects Rd, cond"); }
+        if (item.ops[0].kind != iasm.AOP_REG) { ret R.err[bool, str]("encode: inline-asm 'cset' destination must be a register"); }
+        var buf: [8]u8;
+        var cc: u32 = 0;
+        if (!iasm.copy_region(c.body, s.arg_lo[1], s.arg_hi[1], ?buf[0], 8) || !asm_parse_cond((?buf[0])::str, ?cc)) {
+            ret R.err[bool, str]("encode: inline-asm 'cset' condition is unrecognized");
+        }
+        item.flags = item.flags | ((cc::u16 << A64F_COND_SHIFT) & A64F_COND_MASK);
+        ret R.ok[bool, str](true);
+    }
+    if (pat == A64P_ADRP) {
+        if (n != 2)                           { ret R.err[bool, str]("encode: inline-asm 'adrp' expects Xd, symbol"); }
+        if (item.ops[0].kind != iasm.AOP_REG) { ret R.err[bool, str]("encode: inline-asm 'adrp' destination must be a register"); }
+        if (item.ops[1].kind != iasm.AOP_SYM) { ret R.err[bool, str]("encode: inline-asm 'adrp' target must be a symbol"); }
+        ret R.ok[bool, str](true);
+    }
+    if (pat == A64P_BL) {
+        if (n != 1)                           { ret R.err[bool, str]("encode: inline-asm 'bl' expects a symbol"); }
+        if (item.ops[0].kind != iasm.AOP_SYM) { ret R.err[bool, str]("encode: inline-asm 'bl' target must be a symbol"); }
+        ret R.ok[bool, str](true);
+    }
+    if (pat == A64P_B) {
+        if (n != 1) { ret R.err[bool, str]("encode: inline-asm 'b' expects a target"); }
+        ret a64_branch_target(c, s, item, 0, true);
+    }
+    if (pat == A64P_BCOND) {
+        if (n != 1) { ret R.err[bool, str]("encode: inline-asm conditional branch expects a target"); }
+        ret a64_branch_target(c, s, item, 0, false);
+    }
+    if (pat == A64P_CBR) {
+        if (n != 2)                           { ret R.err[bool, str]("encode: inline-asm cbz/cbnz expects Rt, target"); }
+        if (item.ops[0].kind != iasm.AOP_REG) { ret R.err[bool, str]("encode: inline-asm cbz/cbnz first operand must be a register"); }
+        ret a64_branch_target(c, s, item, 1, false);
+    }
+    if (pat == A64P_LDST) {
+        if (n != 2)                           { ret R.err[bool, str]("encode: inline-asm ldr/str expects Rt, [mem]"); }
+        if (item.ops[0].kind != iasm.AOP_REG) { ret R.err[bool, str]("encode: inline-asm ldr/str value must be a register"); }
+        if (!a64_is_addr(?item.ops[1]))       { ret R.err[bool, str]("encode: inline-asm ldr/str address must be a memory operand"); }
+        if ((item.ops[1].flags & iasm.AOF_WRITEBACK) != 0) {
+            ret R.err[bool, str]("encode: inline-asm ldr/str writeback addressing unsupported");
+        }
+        # a displacement may legalize into a materialize-plus-register-offset pair,
+        # so only the offset-less forms declare a word count.
+        if ((item.ops[1].flags & iasm.AOF_HAS_DISP) != 0) { item.words = iasm.WORDS_VARIABLE; }
+        ret R.ok[bool, str](true);
+    }
+    if (pat == A64P_LDSTP) {
+        if (n < 3 || n > 4) { ret R.err[bool, str]("encode: inline-asm stp/ldp expects Xa, Xb, [mem] [, imm]"); }
+        if (item.ops[0].kind != iasm.AOP_REG || !a64_is64(?item.ops[0])) { ret R.err[bool, str]("encode: inline-asm stp/ldp registers must be X registers"); }
+        if (item.ops[1].kind != iasm.AOP_REG || !a64_is64(?item.ops[1])) { ret R.err[bool, str]("encode: inline-asm stp/ldp registers must be X registers"); }
+        if (item.ops[2].kind != iasm.AOP_MEM)                            { ret R.err[bool, str]("encode: inline-asm stp/ldp address must be a memory operand"); }
+        if ((item.ops[2].flags & (iasm.AOF_HAS_INDEX | iasm.AOF_MEM_SYM)) != 0) {
+            ret R.err[bool, str]("encode: inline-asm stp/ldp address must be [Xn] or [Xn, imm]");
+        }
+        if (n == 4) {
+            if ((item.ops[2].flags & (iasm.AOF_HAS_DISP | iasm.AOF_WRITEBACK)) != 0) {
+                ret R.err[bool, str]("encode: inline-asm stp/ldp post-index base must be a bare [Xn]");
+            }
+            if (item.ops[3].kind != iasm.AOP_IMM) { ret R.err[bool, str]("encode: inline-asm stp/ldp post-index needs an immediate"); }
+            # a post-index writes its base back just as a pre-index does, so the
+            # effect model sees one writeback fact rather than two spellings.
+            item.ops[2].flags = item.ops[2].flags | iasm.AOF_WRITEBACK;
+        }
+        ret R.ok[bool, str](true);
+    }
+    if (pat == A64P_DMB) {
+        if (n != 1) { ret R.err[bool, str]("encode: inline-asm dmb expects one barrier option"); }
+        var buf: [8]u8;
+        var opt: u32 = 0;
+        if (!iasm.copy_region(c.body, s.arg_lo[0], s.arg_hi[0], ?buf[0], 8) || !asm_barrier_option((?buf[0])::str, ?opt)) {
+            ret R.err[bool, str]("encode: unsupported inline-asm dmb barrier option");
+        }
+        item.ops[0] = iasm.op_imm(opt::i64, 1);
+        ret R.ok[bool, str](true);
+    }
+    if (pat == A64P_LDORD) {
+        if (n != 2)                           { ret R.err[bool, str]("encode: inline-asm ldar/stlr/ldaxr expects Rt, [Xn]"); }
+        if (item.ops[0].kind != iasm.AOP_REG) { ret R.err[bool, str]("encode: inline-asm ldar/stlr/ldaxr value must be a register"); }
+        ret a64_bare_addr(?item.ops[1]);
+    }
+    if (pat == A64P_STLXR) {
+        if (n != 3)                           { ret R.err[bool, str]("encode: inline-asm stlxr expects Ws, Rt, [Xn]"); }
+        if (item.ops[0].kind != iasm.AOP_REG) { ret R.err[bool, str]("encode: inline-asm stlxr status must be a register"); }
+        if (item.ops[1].kind != iasm.AOP_REG) { ret R.err[bool, str]("encode: inline-asm stlxr value must be a register"); }
+        ret a64_bare_addr(?item.ops[2]);
+    }
+    ret R.err[bool, str]("internal compiler error: inline-asm aarch64 form has no parser");
+}
+
+# the ordered accesses address the bare base register only
+fun a64_bare_addr(op: *iasm.Operand) R.Result[bool, str] {
+    if (op.kind != iasm.AOP_MEM) { ret R.err[bool, str]("encode: inline-asm ordered access address must be a memory operand"); }
+    if ((op.flags & (iasm.AOF_HAS_INDEX | iasm.AOF_HAS_DISP | iasm.AOF_WRITEBACK | iasm.AOF_MEM_SYM)) != 0) {
+        ret R.err[bool, str]("encode: inline-asm ordered access addressing must be a bare [Xn]");
+    }
+    ret R.ok[bool, str](true);
+}
+
+# read a `lsl N` shift decoration into operand `idx` as its amount
+fun a64_shift_amount(c: *iasm.Cursor, s: *iasm.Stmt, item: *iasm.Item, idx: u32) R.Result[bool, str] {
+    var buf: [24]u8;
+    var hw: u32 = 0;
+    if (!iasm.copy_region(c.body, s.arg_lo[idx::usize], s.arg_hi[idx::usize], ?buf[0], 24)
+        || !asm_parse_lsl_amount((?buf[0])::str, ?hw)) {
+        ret R.err[bool, str]("encode: inline-asm movz/movk shift must be 'lsl N'");
+    }
+    if ((hw & 0xF) != 0) { ret R.err[bool, str]("encode: inline-asm movz/movk shift must be a multiple of 16"); }
+    hw = hw / 16;
+    if (a64_is64(?item.ops[0])) {
+        if (hw > 3) { ret R.err[bool, str]("encode: inline-asm movz/movk 64-bit shift exceeds lsl 48"); }
+    } or {
+        if (hw > 1) { ret R.err[bool, str]("encode: inline-asm movz/movk 32-bit shift exceeds lsl 16"); }
+    }
+    item.ops[idx::usize] = iasm.op_imm(hw::i64, 1);
+    ret R.ok[bool, str](true);
+}
+
+# resolve operand `idx` as a branch target
+#
+# A numeric local label resolves within the block. Only the unconditional `b` may
+# name a symbol: the conditional forms encode an imm19, for which the object format
+# carries no relocation kind, so a symbol there is refused with the fix rather than
+# silently branching nowhere.
+fun a64_branch_target(c: *iasm.Cursor, s: *iasm.Stmt, item: *iasm.Item, idx: u32, allow_sym: bool) R.Result[bool, str] {
+    val lo: usize = s.arg_lo[idx::usize];
+    val hi: usize = s.arg_hi[idx::usize];
+    var num: u64 = 0;
+    var fwd: bool = false;
+    if (iasm.label_ref_span(c.body, lo, hi, ?num, ?fwd)) {
+        item.ref     = iasm.AR_LOCAL;
+        item.ref_num = num;
+        item.ref_fwd = fwd;
+        ret R.ok[bool, str](true);
+    }
+    if (iasm.is_digit(c.body[lo])) {
+        ret R.err[bool, str]("encode: inline-asm numeric local-label reference must be 'Nf' or 'Nb'");
+    }
+    if (!allow_sym) {
+        ret R.err[bool, str]("encode: inline-asm conditional branch to a symbol is unsupported (no imm19 relocation kind); branch to a numeric local label instead");
+    }
+    if (!iasm.is_sym_region(c.body, lo, hi)) {
+        ret R.err[bool, str]("encode: inline-asm 'b' target must be a symbol or a numeric local label");
+    }
+    item.ref     = iasm.AR_SYM;
+    item.ref_off = lo;
+    item.ref_len = hi - lo;
+    ret R.ok[bool, str](true);
+}
+
+# emit one parsed AArch64 item
+#
+# Every instruction goes through the same base-word emitters the instruction selector
+# drives, so an inline-asm instruction and a selected one are the same bytes and the
+# same notification.
+fun a64_emit(st: *encode.EncodeState, c: *iasm.Cursor, l: *iasm.Labels, item: *iasm.Item) R.Result[bool, str] {
+    val pat: u16 = a64_pattern(item.flags);
+
+    if (pat == A64P_NULLARY) {
+        if (item.code == A64M_NOP)   { emit_nullary(st, NOP_WORD);   ret R.ok[bool, str](true); }
+        if (item.code == A64M_YIELD) { emit_nullary(st, YIELD_WORD); ret R.ok[bool, str](true); }
+        emit_nullary(st, RET_WORD);
+        ret R.ok[bool, str](true);
+    }
+    if (pat == A64P_RET_REG) { emit_branch_reg(st, RET_BASE, item.ops[0].reg::u32); ret R.ok[bool, str](true); }
+    if (pat == A64P_BR_REG) {
+        var base: u32 = BR_BASE;
+        if (item.code == A64M_BLR) { base = BLR_BASE; }
+        emit_branch_reg(st, base, item.ops[0].reg::u32);
+        ret R.ok[bool, str](true);
+    }
+    if (pat == A64P_IMM16) {
+        var base: u32 = BRK_BASE;
+        if (item.code == A64M_SVC) { base = SVC_BASE; }
+        emit_imm16(st, base, item.ops[0].imm::u32);
+        ret R.ok[bool, str](true);
+    }
+    if (pat == A64P_MOV)      { ret a64_emit_mov(st, item); }
+    if (pat == A64P_MOVEWIDE) { ret a64_emit_movewide(st, item); }
+    if (pat == A64P_ADDSUB)   { ret a64_emit_addsub(st, c, item); }
+    if (pat == A64P_LOGICAL)  { ret a64_emit_logical(st, item); }
+    if (pat == A64P_CMP)      { ret a64_emit_cmp(st, item); }
+    if (pat == A64P_CSET) {
+        val use64: bool = a64_is64(?item.ops[0]);
+        emit_cset(st, sel(use64, CSINC_X, CSINC_W), item.ops[0].reg::u32, a64_cond(item.flags));
+        ret R.ok[bool, str](true);
+    }
+    if (pat == A64P_ADRP)  { ret a64_emit_adrp(st, c, item); }
+    if (pat == A64P_BL)    { ret a64_emit_call(st, c, item); }
+    if (pat == A64P_B || pat == A64P_BCOND || pat == A64P_CBR) { ret a64_emit_branch(st, c, l, item); }
+    if (pat == A64P_LDST)  { ret a64_emit_ldst(st, c, item); }
+    if (pat == A64P_LDSTP) { ret a64_emit_ldstp(st, item); }
+    if (pat == A64P_DMB)   { emit_barrier(st, item.ops[0].imm::u32); ret R.ok[bool, str](true); }
+    if (pat == A64P_LDORD) { ret a64_emit_ldord(st, item); }
+    if (pat == A64P_STLXR) {
+        val base: u32 = sel(a64_is64(?item.ops[1]), STLXR_X, STLXR_W);
+        emit_stxr(st, base, item.ops[0].reg::u32, item.ops[1].reg::u32, item.ops[2].reg::u32);
+        ret R.ok[bool, str](true);
+    }
+    if (pat == A64P_SHIFT) { ret a64_emit_shift(st, item); }
+    ret R.err[bool, str]("internal compiler error: inline-asm aarch64 form has no emitter");
+}
+
+# `mov Rd, Rm` (an ADD when SP is involved, else `orr Rd, ZR, Rm`) or `mov Rd, imm`
+# (a MOVZ, or the MOVZ / MOVK sequence for a value no single chunk expresses)
+fun a64_emit_mov(st: *encode.EncodeState, item: *iasm.Item) R.Result[bool, str] {
+    val dst: *iasm.Operand = ?item.ops[0];
+    val src: *iasm.Operand = ?item.ops[1];
+    val use64: bool = a64_is64(dst);
+    if (src.kind == iasm.AOP_REG) {
+        if (a64_is_sp(dst) || a64_is_sp(src)) {
+            emit_addsub_imm(st, sel(use64, ADDI_X, ADDI_W), dst.reg::u32, src.reg::u32, 0, 0);
+        } or {
+            emit_alu3(st, sel(use64, ORR_X, ORR_W), dst.reg::u32, ZR, src.reg::u32);
+        }
+        ret R.ok[bool, str](true);
+    }
+    emit_asm_mov_imm(st, dst.reg::u32, src.imm::u64, use64);
+    ret R.ok[bool, str](true);
+}
+
+# `movz` / `movk Rd, imm16 [, lsl N]`
+fun a64_emit_movewide(st: *encode.EncodeState, item: *iasm.Item) R.Result[bool, str] {
+    val use64: bool = a64_is64(?item.ops[0]);
+    var hw: u32 = 0;
+    if (item.nops == 3) { hw = item.ops[2].imm::u32; }
+    var base: u32 = sel(use64, MOVZ_X, MOVZ_W);
+    if (item.code == A64M_MOVK) { base = sel(use64, MOVK_X, MOVK_W); }
+    emit_movewide(st, base, item.ops[0].reg::u32, hw, item.ops[1].imm::u32);
+    ret R.ok[bool, str](true);
+}
+
+# `add` / `sub Rd, Rn, imm | Rm | :lo12:sym`
+#
+# An immediate folds into the imm12 (or imm12<<12) form; a `:lo12:sym` (add only)
+# emits the low-half ADD with RK_ADD_LO12; a register uses the shifted-register form.
+# SP with a register operand needs the extended-register form, which is refused loud.
+fun a64_emit_addsub(st: *encode.EncodeState, c: *iasm.Cursor, item: *iasm.Item) R.Result[bool, str] {
+    val rd: *iasm.Operand = ?item.ops[0];
+    val rn: *iasm.Operand = ?item.ops[1];
+    val op3: *iasm.Operand = ?item.ops[2];
+    val use64: bool = a64_is64(rd);
+    val is_sub: bool = item.code == A64M_SUB;
+
+    if (op3.kind == iasm.AOP_IMM) {
+        var base: u32 = sel(use64, ADDI_X, ADDI_W);
+        if (is_sub) { base = sel(use64, SUBI_X, SUBI_W); }
         val v: i64 = op3.imm;
-        var base_i: u32 = sel(use64, ADDI_X, ADDI_W);
-        if (is_sub) { base_i = sel(use64, SUBI_X, SUBI_W); }
         if (v >= 0 && v <= 4095) {
-            emit_addsub_imm(st, base_i, rd.reg, rn.reg, v::u32, 0);
+            emit_addsub_imm(st, base, rd.reg::u32, rn.reg::u32, v::u32, 0);
             ret R.ok[bool, str](true);
         }
         if (v > 0 && (v & 0xFFF) == 0 && (v >> 12) <= 4095) {
-            emit_addsub_imm(st, base_i, rd.reg, rn.reg, (v >> 12)::u32, 1);
+            emit_addsub_imm(st, base, rd.reg::u32, rn.reg::u32, (v >> 12)::u32, 1);
             ret R.ok[bool, str](true);
         }
         ret R.err[bool, str]("encode: inline-asm add/sub immediate is out of imm12 range");
     }
-    if (op3.kind == ASMOP_LO12) {
-        if (is_sub) { ret R.err[bool, str]("encode: inline-asm 'sub' has no :lo12: form"); }
-        val sr: R.Result[intern.StrId, str] = asm_intern(st, op3.name, op3.name_len);
+    if (op3.kind == iasm.AOP_SYM) {
+        if (is_sub)                            { ret R.err[bool, str]("encode: inline-asm 'sub' has no :lo12: form"); }
+        if (op3.mod != isa.SYM_MOD_PCREL_LO)   { ret R.err[bool, str]("encode: inline-asm 'add' symbol operand must be a ':lo12:sym'"); }
+        val sr: R.Result[intern.StrId, str] = a64_intern(st, c, op3);
         if (R.is_err[intern.StrId, str](sr)) { ret R.err[bool, str](R.unwrap_err[intern.StrId, str](sr)); }
         val sid: intern.StrId = R.unwrap_ok[intern.StrId, str](sr);
         val pos: u32 = st.buf.len::u32;
-        emit_addsub_imm_sym(st, sel(use64, ADDI_X, ADDI_W), rd.reg, rn.reg, sid, printer.MOD_PCREL_LO);
+        emit_addsub_imm_sym(st, sel(use64, ADDI_X, ADDI_W), rd.reg::u32, rn.reg::u32, sid, printer.MOD_PCREL_LO);
         ret encode.push_reloc(st, arm64_reloc_offset(pos), of.RK_ADD_LO12, sid, 0);
     }
-    if (op3.kind == ASMOP_REG) {
-        if (rd.is_sp || rn.is_sp || op3.is_sp) {
-            ret R.err[bool, str]("encode: inline-asm add/sub with SP and a register operand requires the extended-register form (unsupported)");
-        }
-        var base_r: u32 = sel(use64, ADD_X, ADD_W);
-        if (is_sub) { base_r = sel(use64, SUB_X, SUB_W); }
-        emit_alu3(st, base_r, rd.reg, rn.reg, op3.reg);
-        ret R.ok[bool, str](true);
+    if (a64_is_sp(rd) || a64_is_sp(rn) || a64_is_sp(op3)) {
+        ret R.err[bool, str]("encode: inline-asm add/sub with SP and a register operand requires the extended-register form (unsupported)");
     }
-    ret R.err[bool, str]("encode: malformed inline-asm add/sub operand");
-}
-
-# `and` / `orr` / `eor Rd, Rn, Rm` (register form). the logical
-# immediate (bitmask) form is unsupported and rejected loud
-fun emit_asm_logical(st: *encode.EncodeState, args: str, base_x: u32, base_w: u32) R.Result[bool, str] {
-    var b0: [128]u8; var b1: [128]u8; var b2: [128]u8; var b3: [128]u8;
-    var n: u32 = 0;
-    if (!asm_split(args, ?b0[0], ?b1[0], ?b2[0], ?b3[0], 128, ?n)) { ret R.err[bool, str]("encode: malformed inline-asm logical operands"); }
-    if (n != 3)                                                    { ret R.err[bool, str]("encode: inline-asm and/orr/eor expects three operands"); }
-    var rd: AsmOp;
-    var rn: AsmOp;
-    var rm: AsmOp;
-    if (!asm_parse_operand((?b0[0])::str, ?rd) || rd.kind != ASMOP_REG) { ret R.err[bool, str]("encode: inline-asm and/orr/eor destination must be a register"); }
-    if (!asm_parse_operand((?b1[0])::str, ?rn) || rn.kind != ASMOP_REG) { ret R.err[bool, str]("encode: inline-asm and/orr/eor first source must be a register"); }
-    if (!asm_parse_operand((?b2[0])::str, ?rm) || rm.kind != ASMOP_REG) { ret R.err[bool, str]("encode: inline-asm and/orr/eor immediate (bitmask) form unsupported; use a register operand"); }
-    emit_alu3(st, sel(rd.is64, base_x, base_w), rd.reg, rn.reg, rm.reg);
+    var base_r: u32 = sel(use64, ADD_X, ADD_W);
+    if (is_sub) { base_r = sel(use64, SUB_X, SUB_W); }
+    emit_alu3(st, base_r, rd.reg::u32, rn.reg::u32, op3.reg::u32);
     ret R.ok[bool, str](true);
 }
 
-# `cmp Rn, (#imm | Rm)` - the SUBS XZR alias
-fun emit_asm_cmp(st: *encode.EncodeState, args: str) R.Result[bool, str] {
-    var b0: [128]u8; var b1: [128]u8; var b2: [128]u8; var b3: [128]u8;
-    var n: u32 = 0;
-    if (!asm_split(args, ?b0[0], ?b1[0], ?b2[0], ?b3[0], 128, ?n)) { ret R.err[bool, str]("encode: malformed inline-asm 'cmp' operands"); }
-    if (n != 2)                                                    { ret R.err[bool, str]("encode: inline-asm 'cmp' expects two operands"); }
-    var rn: AsmOp;
-    var op2: AsmOp;
-    if (!asm_parse_operand((?b0[0])::str, ?rn) || rn.kind != ASMOP_REG) { ret R.err[bool, str]("encode: inline-asm 'cmp' first operand must be a register"); }
-    if (!asm_parse_operand((?b1[0])::str, ?op2))                        { ret R.err[bool, str]("encode: malformed inline-asm 'cmp' operand"); }
-    val use64: bool = rn.is64;
-    if (op2.kind == ASMOP_IMM && op2.imm >= 0 && op2.imm <= 4095) {
-        emit_addsub_imm(st, sel(use64, SUBS_IMM_X, SUBS_IMM_W), ZR, rn.reg, op2.imm::u32, 0);
-        ret R.ok[bool, str](true);
-    }
-    if (op2.kind == ASMOP_REG) {
-        emit_alu3(st, sel(use64, SUBS_REG_X, SUBS_REG_W), ZR, rn.reg, op2.reg);
-        ret R.ok[bool, str](true);
-    }
-    ret R.err[bool, str]("encode: inline-asm 'cmp' second operand must be a register or imm12");
-}
-
-# `cset Rd, <cond>` - the CSINC Rd, XZR, XZR, invert(cond) alias. the
-# condition resolves through asm_parse_cond (the table b.<cond> shares); both X and W
-# destination widths are supported. darwin's aarch64 syscall wrappers use this to
-# materialize the carry-on-error flag (`cset x9, cs`)
-fun emit_asm_cset(st: *encode.EncodeState, args: str) R.Result[bool, str] {
-    var b0: [128]u8; var b1: [128]u8; var b2: [128]u8; var b3: [128]u8;
-    var n: u32 = 0;
-    if (!asm_split(args, ?b0[0], ?b1[0], ?b2[0], ?b3[0], 128, ?n)) { ret R.err[bool, str]("encode: malformed inline-asm 'cset' operands"); }
-    if (n != 2)                                                    { ret R.err[bool, str]("encode: inline-asm 'cset' expects Rd, <cond>"); }
-    var rd: AsmOp;
-    if (!asm_parse_operand((?b0[0])::str, ?rd) || rd.kind != ASMOP_REG) { ret R.err[bool, str]("encode: inline-asm 'cset' destination must be a register"); }
-    var cc: u32 = 0;
-    if (!asm_parse_cond((?b1[0])::str, ?cc)) { ret R.err[bool, str]("encode: inline-asm 'cset' condition is unrecognized"); }
-    emit_cset(st, sel(rd.is64, CSINC_X, CSINC_W), rd.reg, cc);
+# `and` / `orr` / `eor Rd, Rn, Rm` - the register form; the logical immediate
+# (bitmask) encoding is not modeled and was refused at the parse
+fun a64_emit_logical(st: *encode.EncodeState, item: *iasm.Item) R.Result[bool, str] {
+    val use64: bool = a64_is64(?item.ops[0]);
+    var bx: u32 = AND_X;
+    var bw: u32 = AND_W;
+    if (item.code == A64M_ORR)      { bx = ORR_X; bw = ORR_W; }
+    or (item.code == A64M_EOR)      { bx = EOR_X; bw = EOR_W; }
+    emit_alu3(st, sel(use64, bx, bw), item.ops[0].reg::u32, item.ops[1].reg::u32, item.ops[2].reg::u32);
     ret R.ok[bool, str](true);
 }
 
-# `adrp Xd, sym` - the page-relative high half, RK_PAGE21
-fun emit_asm_adrp(st: *encode.EncodeState, args: str) R.Result[bool, str] {
-    var b0: [128]u8; var b1: [128]u8; var b2: [128]u8; var b3: [128]u8;
-    var n: u32 = 0;
-    if (!asm_split(args, ?b0[0], ?b1[0], ?b2[0], ?b3[0], 128, ?n)) { ret R.err[bool, str]("encode: malformed inline-asm 'adrp' operands"); }
-    if (n != 2)                                                    { ret R.err[bool, str]("encode: inline-asm 'adrp' expects Xd, symbol"); }
-    var rd: AsmOp;
-    var sym: AsmOp;
-    if (!asm_parse_operand((?b0[0])::str, ?rd) || rd.kind != ASMOP_REG)   { ret R.err[bool, str]("encode: inline-asm 'adrp' destination must be a register"); }
-    if (!asm_parse_operand((?b1[0])::str, ?sym) || sym.kind != ASMOP_SYM) { ret R.err[bool, str]("encode: inline-asm 'adrp' target must be a symbol"); }
-    val sr: R.Result[intern.StrId, str] = asm_intern(st, sym.name, sym.name_len);
+# `cmp Rn, imm | Rm` - the SUBS-into-ZR alias
+fun a64_emit_cmp(st: *encode.EncodeState, item: *iasm.Item) R.Result[bool, str] {
+    val rn: *iasm.Operand = ?item.ops[0];
+    val op2: *iasm.Operand = ?item.ops[1];
+    val use64: bool = a64_is64(rn);
+    if (op2.kind == iasm.AOP_IMM) {
+        if (op2.imm < 0 || op2.imm > 4095) { ret R.err[bool, str]("encode: inline-asm 'cmp' second operand must be a register or imm12"); }
+        emit_addsub_imm(st, sel(use64, SUBS_IMM_X, SUBS_IMM_W), ZR, rn.reg::u32, op2.imm::u32, 0);
+        ret R.ok[bool, str](true);
+    }
+    emit_alu3(st, sel(use64, SUBS_REG_X, SUBS_REG_W), ZR, rn.reg::u32, op2.reg::u32);
+    ret R.ok[bool, str](true);
+}
+
+# `adrp Xd, sym` (RK_PAGE21) or `adrp Xd, :got:sym` (RK_GOT_PAGE21)
+fun a64_emit_adrp(st: *encode.EncodeState, c: *iasm.Cursor, item: *iasm.Item) R.Result[bool, str] {
+    val sym: *iasm.Operand = ?item.ops[1];
+    if (sym.mod == isa.SYM_MOD_PCREL_LO || sym.mod == isa.SYM_MOD_GOT_LO) {
+        ret R.err[bool, str]("encode: inline-asm 'adrp' names a page, so its symbol takes no low-half modifier");
+    }
+    val sr: R.Result[intern.StrId, str] = a64_intern(st, c, sym);
     if (R.is_err[intern.StrId, str](sr)) { ret R.err[bool, str](R.unwrap_err[intern.StrId, str](sr)); }
     val sid: intern.StrId = R.unwrap_ok[intern.StrId, str](sr);
-    val pos: u32 = st.buf.len::u32;
-    emit_adrp(st, rd.reg, sid, printer.MOD_PCREL_HI);
-    ret encode.push_reloc(st, arm64_reloc_offset(pos), of.RK_PAGE21, sid, 0);
-}
-
-# `ldr` / `str` / `ldrb` / `strb` / `ldrh` / `strh Rt, <mem>`. the
-# `[Xn, :lo12:sym]` form emits the per-width RK_LDST*_LO12 folded-global low half;
-# `[Xn, Xm]` the register-offset form; `[Xn]` / `[Xn, #imm]` legalize through
-# `emit_mem_access`. writeback (`!`) is rejected
-fun emit_asm_ldst(st: *encode.EncodeState, mnem: str, args: str) R.Result[bool, str] {
-    var b0: [128]u8; var b1: [128]u8; var b2: [128]u8; var b3: [128]u8;
-    var n: u32 = 0;
-    if (!asm_split(args, ?b0[0], ?b1[0], ?b2[0], ?b3[0], 128, ?n)) { ret R.err[bool, str]("encode: malformed inline-asm ldr/str operands"); }
-    if (n != 2)                                                    { ret R.err[bool, str]("encode: inline-asm ldr/str expects Rt, [mem]"); }
-    var rt: AsmOp;
-    var mem: AsmOp;
-    if (!asm_parse_operand((?b0[0])::str, ?rt) || rt.kind != ASMOP_REG)   { ret R.err[bool, str]("encode: inline-asm ldr/str value must be a register"); }
-    if (!asm_parse_operand((?b1[0])::str, ?mem) || mem.kind != ASMOP_MEM) { ret R.err[bool, str]("encode: inline-asm ldr/str address must be a memory operand"); }
-    if (mem.wb_pre)                                                       { ret R.err[bool, str]("encode: inline-asm ldr/str writeback addressing unsupported"); }
-
-    val is_load: bool = mnem[0] == 'l'::char;
-    var w: u8 = 4;
-    if (rt.is64) { w = 8; }
-    if (str_len(mnem) == 4) {
-        if (mnem[3] == 'b'::char) { w = 1; }
-        or (mnem[3] == 'h'::char) { w = 2; }
-        or { ret R.err[bool, str]("encode: unsupported aarch64 inline-asm load/store width"); }
-    }
-
-    if (mem.is_lo12) {
-        val sr: R.Result[intern.StrId, str] = asm_intern(st, mem.name, mem.name_len);
-        if (R.is_err[intern.StrId, str](sr)) { ret R.err[bool, str](R.unwrap_err[intern.StrId, str](sr)); }
-        val sid: intern.StrId = R.unwrap_ok[intern.StrId, str](sr);
-        val pos: u32 = st.buf.len::u32;
-        emit_ldst_sym(st, ldst_base_scaled(w, is_load), rt.reg, mem.base, sid, printer.MOD_PCREL_LO);
-        ret encode.push_reloc(st, arm64_reloc_offset(pos), ldst_lo12_kind(w), sid, 0);
-    }
-    if (mem.has_index) {
-        emit_ldst_reg(st, ldst_base_reg(w, is_load), rt.reg, mem.base, mem.index);
-        ret R.ok[bool, str](true);
-    }
-    var off: i64 = 0;
-    if (mem.has_disp) { off = mem.imm; }
-    emit_mem_access(st, rt.reg, mem.base, off, w, is_load);
-    ret R.ok[bool, str](true);
-}
-
-# `stp` / `ldp Xa, Xb, <mem>` for the signed-offset, pre-index, and
-# post-index 64-bit forms. the W-register pair forms are unsupported
-fun emit_asm_ldstp(st: *encode.EncodeState, args: str, is_load: bool) R.Result[bool, str] {
-    var b0: [128]u8; var b1: [128]u8; var b2: [128]u8; var b3: [128]u8;
-    var n: u32 = 0;
-    if (!asm_split(args, ?b0[0], ?b1[0], ?b2[0], ?b3[0], 128, ?n)) { ret R.err[bool, str]("encode: malformed inline-asm stp/ldp operands"); }
-    if (n < 3 || n > 4)                                            { ret R.err[bool, str]("encode: inline-asm stp/ldp expects Xa, Xb, [mem] [, #imm]"); }
-    var ra: AsmOp;
-    var rb: AsmOp;
-    if (!asm_parse_operand((?b0[0])::str, ?ra) || ra.kind != ASMOP_REG || !ra.is64) { ret R.err[bool, str]("encode: inline-asm stp/ldp registers must be X registers"); }
-    if (!asm_parse_operand((?b1[0])::str, ?rb) || rb.kind != ASMOP_REG || !rb.is64) { ret R.err[bool, str]("encode: inline-asm stp/ldp registers must be X registers"); }
-    var mem: AsmOp;
-    if (!asm_parse_operand((?b2[0])::str, ?mem) || mem.kind != ASMOP_MEM) { ret R.err[bool, str]("encode: inline-asm stp/ldp address must be a memory operand"); }
-    if (mem.has_index || mem.is_lo12)                                     { ret R.err[bool, str]("encode: inline-asm stp/ldp address must be [Xn] or [Xn, #imm]"); }
-
-    var disp: i64 = 0;
-    var base_word: u32 = sel(is_load, LDP_OFF_X, STP_OFF_X);
-    if (n == 4) {
-        if (mem.has_disp || mem.wb_pre) { ret R.err[bool, str]("encode: inline-asm stp/ldp post-index base must be a bare [Xn]"); }
-        var imo: AsmOp;
-        if (!asm_parse_operand((?b3[0])::str, ?imo) || imo.kind != ASMOP_IMM) { ret R.err[bool, str]("encode: inline-asm stp/ldp post-index needs an immediate"); }
-        disp = imo.imm;
-        base_word = sel(is_load, LDP_POST_X, STP_POST_X);
-    } or {
-        if (mem.has_disp) { disp = mem.imm; }
-        if (mem.wb_pre)   { base_word = sel(is_load, LDP_PRE_X, STP_PRE_X); }
-    }
-
-    if ((disp & 7) != 0) { ret R.err[bool, str]("encode: inline-asm stp/ldp offset must be a multiple of 8"); }
-    val q: i64 = disp / 8;
-    if (q < -64 || q > 63) { ret R.err[bool, str]("encode: inline-asm stp/ldp offset is out of the imm7 range"); }
-    emit_ldstp(st, base_word, ra.reg, rb.reg, mem.base, q::u32 & 0x7F);
-    ret R.ok[bool, str](true);
-}
-
-# `ldar` / `stlr` / `ldaxr Rt, [Xn]` - acquire/release ordered
-# load-store or load-acquire-exclusive, addressing the bare base register only
-fun emit_asm_ldordered(st: *encode.EncodeState, mnem: str, args: str) R.Result[bool, str] {
-    var b0: [128]u8; var b1: [128]u8; var b2: [128]u8; var b3: [128]u8;
-    var n: u32 = 0;
-    if (!asm_split(args, ?b0[0], ?b1[0], ?b2[0], ?b3[0], 128, ?n)) { ret R.err[bool, str]("encode: malformed inline-asm ldar/stlr/ldaxr operands"); }
-    if (n != 2)                                                    { ret R.err[bool, str]("encode: inline-asm ldar/stlr/ldaxr expects Rt, [Xn]"); }
-    var rt: AsmOp;
-    var mem: AsmOp;
-    if (!asm_parse_operand((?b0[0])::str, ?rt) || rt.kind != ASMOP_REG)   { ret R.err[bool, str]("encode: inline-asm ldar/stlr/ldaxr value must be a register"); }
-    if (!asm_parse_operand((?b1[0])::str, ?mem) || mem.kind != ASMOP_MEM) { ret R.err[bool, str]("encode: inline-asm ldar/stlr/ldaxr address must be a memory operand"); }
-    if (mem.has_index || mem.has_disp || mem.wb_pre)                      { ret R.err[bool, str]("encode: inline-asm ldar/stlr/ldaxr addressing must be a bare [Xn]"); }
-    var base: u32 = sel(rt.is64, LDAXR_X, LDAXR_W);
-    if (str_equals(mnem, "ldar")) { base = sel(rt.is64, LDAR_X, LDAR_W); }
-    or (str_equals(mnem, "stlr")) { base = sel(rt.is64, STLR_X, STLR_W); }
-    emit_ldst(st, base, rt.reg, mem.base, 0);
-    ret R.ok[bool, str](true);
-}
-
-# `stlxr Ws, Rt, [Xn]` - store-release exclusive; the 32-bit status
-# result Ws is Rs[20:16], the stored value Rt sizes the op
-fun emit_asm_stlxr(st: *encode.EncodeState, args: str) R.Result[bool, str] {
-    var b0: [128]u8; var b1: [128]u8; var b2: [128]u8; var b3: [128]u8;
-    var n: u32 = 0;
-    if (!asm_split(args, ?b0[0], ?b1[0], ?b2[0], ?b3[0], 128, ?n)) { ret R.err[bool, str]("encode: malformed inline-asm stlxr operands"); }
-    if (n != 3)                                                    { ret R.err[bool, str]("encode: inline-asm stlxr expects Ws, Rt, [Xn]"); }
-    var rs: AsmOp;
-    var rt: AsmOp;
-    var mem: AsmOp;
-    if (!asm_parse_operand((?b0[0])::str, ?rs) || rs.kind != ASMOP_REG)   { ret R.err[bool, str]("encode: inline-asm stlxr status must be a register"); }
-    if (!asm_parse_operand((?b1[0])::str, ?rt) || rt.kind != ASMOP_REG)   { ret R.err[bool, str]("encode: inline-asm stlxr value must be a register"); }
-    if (!asm_parse_operand((?b2[0])::str, ?mem) || mem.kind != ASMOP_MEM) { ret R.err[bool, str]("encode: inline-asm stlxr address must be a memory operand"); }
-    if (mem.has_index || mem.has_disp || mem.wb_pre)                      { ret R.err[bool, str]("encode: inline-asm stlxr addressing must be a bare [Xn]"); }
-    val base: u32 = sel(rt.is64, STLXR_X, STLXR_W);
-    emit_stxr(st, base, rs.reg, rt.reg, mem.base);
-    ret R.ok[bool, str](true);
-}
-
-# `dmb <option>` - data memory barrier; the option name selects CRm[11:8]
-fun emit_asm_dmb(st: *encode.EncodeState, args: str) R.Result[bool, str] {
-    var b0: [128]u8; var b1: [128]u8; var b2: [128]u8; var b3: [128]u8;
-    var n: u32 = 0;
-    if (!asm_split(args, ?b0[0], ?b1[0], ?b2[0], ?b3[0], 128, ?n)) { ret R.err[bool, str]("encode: malformed inline-asm dmb operand"); }
-    if (n != 1)                                                    { ret R.err[bool, str]("encode: inline-asm dmb expects one barrier option"); }
-    var opt: u32 = 0;
-    if (!asm_barrier_option((?b0[0])::str, ?opt)) { ret R.err[bool, str]("encode: unsupported inline-asm dmb barrier option"); }
-    emit_barrier(st, opt);
-    ret R.ok[bool, str](true);
-}
-
-# the CRm value for a dmb barrier-domain name
-fun asm_barrier_option(name: str, out: *u32) bool {
-    if (str_equals(name, "sy"))    { @out = 15; ret true; }
-    if (str_equals(name, "st"))    { @out = 14; ret true; }
-    if (str_equals(name, "ld"))    { @out = 13; ret true; }
-    if (str_equals(name, "ish"))   { @out = 11; ret true; }
-    if (str_equals(name, "ishst")) { @out = 10; ret true; }
-    if (str_equals(name, "ishld")) { @out = 9;  ret true; }
-    if (str_equals(name, "nsh"))   { @out = 7;  ret true; }
-    if (str_equals(name, "nshst")) { @out = 6;  ret true; }
-    if (str_equals(name, "nshld")) { @out = 5;  ret true; }
-    if (str_equals(name, "osh"))   { @out = 3;  ret true; }
-    if (str_equals(name, "oshst")) { @out = 2;  ret true; }
-    if (str_equals(name, "oshld")) { @out = 1;  ret true; }
-    ret false;
-}
-
-# `lsl`/`lsr`/`asr Rd, Rn, #imm|Rm` and the register-only
-# `lslv`/`lsrv`/`asrv Rd, Rn, Rm`. an immediate count emits the UBFM (lsl/lsr) /
-# SBFM (asr) bitfield alias - immr=(W-sh)&(W-1), imms=W-1-sh for lsl; immr=sh,
-# imms=W-1 for lsr/asr - the register form the LSLV/LSRV/ASRV variable shift,
-# mirroring the MIR `encode_shift`
-fun emit_asm_shift(st: *encode.EncodeState, mnem: str, args: str) R.Result[bool, str] {
-    var b0: [128]u8; var b1: [128]u8; var b2: [128]u8; var b3: [128]u8;
-    var n: u32 = 0;
-    if (!asm_split(args, ?b0[0], ?b1[0], ?b2[0], ?b3[0], 128, ?n)) { ret R.err[bool, str]("encode: malformed inline-asm shift operands"); }
-    if (n != 3)                                                    { ret R.err[bool, str]("encode: inline-asm shift expects Rd, Rn, Rm|#imm"); }
-    var rd: AsmOp; var rn: AsmOp; var cnt: AsmOp;
-    if (!asm_parse_operand((?b0[0])::str, ?rd) || rd.kind != ASMOP_REG) { ret R.err[bool, str]("encode: inline-asm shift destination must be a register"); }
-    if (!asm_parse_operand((?b1[0])::str, ?rn) || rn.kind != ASMOP_REG) { ret R.err[bool, str]("encode: inline-asm shift source must be a register"); }
-    if (!asm_parse_operand((?b2[0])::str, ?cnt))                        { ret R.err[bool, str]("encode: malformed inline-asm shift count"); }
-    val use64: bool = rd.is64;
-    var width: u32 = 32;
-    if (use64) { width = 64; }
-    # kind: 0 = lsl, 1 = lsr, 2 = asr; the `v` mnemonics are register-only.
-    var kind: u32 = 0;
-    var vform: bool = false;
-    if (str_equals(mnem, "lsr"))  { kind = 1; }
-    or (str_equals(mnem, "asr"))  { kind = 2; }
-    or (str_equals(mnem, "lslv")) { kind = 0; vform = true; }
-    or (str_equals(mnem, "lsrv")) { kind = 1; vform = true; }
-    or (str_equals(mnem, "asrv")) { kind = 2; vform = true; }
-    if (cnt.kind == ASMOP_IMM && !vform) {
-        val sh: u32 = (cnt.imm::u32) & (width - 1);
-        if (kind == 0) {
-            val immr: u32 = (width - sh) & (width - 1);
-            val imms: u32 = (width - 1) - sh;
-            emit_bitfield(st, sel(use64, UBFM_X, UBFM_W), rd.reg, rn.reg, immr, imms);
-        } or (kind == 1) {
-            emit_bitfield(st, sel(use64, UBFM_X, UBFM_W), rd.reg, rn.reg, sh, width - 1);
-        } or {
-            emit_bitfield(st, sel(use64, SBFM_X, SBFM_W), rd.reg, rn.reg, sh, width - 1);
-        }
-        ret R.ok[bool, str](true);
-    }
-    if (cnt.kind != ASMOP_REG) { ret R.err[bool, str]("encode: inline-asm shift count must be a register or immediate"); }
-    var bx: u32 = LSLV_X; var bw: u32 = LSLV_W;
-    if (kind == 1) { bx = LSRV_X; bw = LSRV_W; }
-    or (kind == 2) { bx = ASRV_X; bw = ASRV_W; }
-    emit_alu3(st, sel(use64, bx, bw), rd.reg, rn.reg, cnt.reg);
-    ret R.ok[bool, str](true);
-}
-
-# emit a branch (B / B.cond / CBZ / CBNZ) to a numeric local
-# label. a backward reference patches immediately against the nearest preceding
-# definition; a forward reference is recorded and patched when its definition is
-# reached. the imm26 / imm19 insert is the shared `patch_branch_arm64`
-fun emit_asm_branch_label(st: *encode.EncodeState, labels: *AsmLabels, word: u32, base: u32,
-                          rt: u32, has_rt: bool, number: u64, fwd: bool) R.Result[bool, str] {
-    val patch_pos: u32 = st.buf.len::u32;
-    emit_branch_local(st, word, base, rt, has_rt, number, fwd);
-    if (fwd) { ret asm_label_push_ref(labels, patch_pos, number); }
-    val def: O.Option[u32] = asm_label_lookup(labels, number);
-    if (!O.is_some[u32](def)) {
-        ret R.err[bool, str]("encode: inline-asm backward reference to a local label has no preceding definition in this asm block");
-    }
-    var fx: encode.BranchFixup;
-    fx.patch_pos = patch_pos; fx.next_ip = 0; fx.target_block = 0; fx.fn_text_base = 0;
-    ret patch_branch_arm64(st, ?fx, O.unwrap[u32](def));
-}
-
-# `b target` - an unconditional branch to a numeric local label (imm26
-# fixup) or a bare symbol (RK_PLT32, the branch26 the linker resolves)
-fun emit_asm_b(st: *encode.EncodeState, labels: *AsmLabels, args: str) R.Result[bool, str] {
-    val target: str = asm_trim(args);
-    var number: u64 = 0;
-    var fwd: bool = false;
-    if (asm_label_ref(target, ?number, ?fwd)) {
-        ret emit_asm_branch_label(st, labels, B_BASE, B_BASE, 0, false, number, fwd);
-    }
-    if (str_len(target) > 0 && asm_is_digit(target[0])) {
-        ret R.err[bool, str]("encode: inline-asm numeric local-label reference must be 'Nf' or 'Nb'");
-    }
-    var op: AsmOp;
-    if (!asm_parse_operand(target, ?op) || op.kind != ASMOP_SYM) {
-        ret R.err[bool, str]("encode: inline-asm 'b' target must be a symbol or a numeric local label");
-    }
-    val sr: R.Result[intern.StrId, str] = asm_intern(st, op.name, op.name_len);
-    if (R.is_err[intern.StrId, str](sr)) { ret R.err[bool, str](R.unwrap_err[intern.StrId, str](sr)); }
-    val sid: intern.StrId = R.unwrap_ok[intern.StrId, str](sr);
-    val pos: u32 = st.buf.len::u32;
-    emit_branch_sym(st, B_BASE, sid);
-    ret encode.push_reloc(st, arm64_reloc_offset(pos), of.RK_PLT32, sid, 0);
-}
-
-# `b.<cond> target` - a conditional branch (imm19). a numeric local
-# label resolves in-block; a bare symbol has no imm19 relocation kind in the object
-# format and is rejected loud (x86-64 resolves the analogous `jz <sym>` with a
-# PC32 relocation, which the A64 conditional-branch field cannot express)
-fun emit_asm_bcond(st: *encode.EncodeState, labels: *AsmLabels, cond: u32, args: str) R.Result[bool, str] {
-    val target: str = asm_trim(args);
-    var number: u64 = 0;
-    var fwd: bool = false;
-    if (asm_label_ref(target, ?number, ?fwd)) {
-        ret emit_asm_branch_label(st, labels, BCOND | (cond & 0xF), BCOND | (cond & 0xF), 0, false, number, fwd);
-    }
-    if (str_len(target) > 0 && asm_is_digit(target[0])) {
-        ret R.err[bool, str]("encode: inline-asm numeric local-label reference must be 'Nf' or 'Nb'");
-    }
-    ret R.err[bool, str]("encode: inline-asm conditional branch to a symbol is unsupported (no imm19 relocation kind); branch to a numeric local label instead");
-}
-
-# `cbz` / `cbnz Rt, target` (imm19). a numeric local label resolves
-# in-block; a bare symbol is rejected loud (no imm19 relocation kind)
-fun emit_asm_cbr(st: *encode.EncodeState, labels: *AsmLabels, args: str, is_nz: bool) R.Result[bool, str] {
-    var b0: [128]u8; var b1: [128]u8; var b2: [128]u8; var b3: [128]u8;
-    var n: u32 = 0;
-    if (!asm_split(args, ?b0[0], ?b1[0], ?b2[0], ?b3[0], 128, ?n)) { ret R.err[bool, str]("encode: malformed inline-asm cbz/cbnz operands"); }
-    if (n != 2)                                                    { ret R.err[bool, str]("encode: inline-asm cbz/cbnz expects Rt, target"); }
-    var rt: AsmOp;
-    if (!asm_parse_operand((?b0[0])::str, ?rt) || rt.kind != ASMOP_REG) { ret R.err[bool, str]("encode: inline-asm cbz/cbnz first operand must be a register"); }
-    var base: u32 = sel(rt.is64, CBZ_X, CBZ_W);
-    if (is_nz) { base = sel(rt.is64, CBNZ_X, CBNZ_W); }
-    val word: u32 = pack_cbnz(base, rt.reg);
-
-    val target: str = asm_trim((?b1[0])::str);
-    var number: u64 = 0;
-    var fwd: bool = false;
-    if (asm_label_ref(target, ?number, ?fwd)) {
-        ret emit_asm_branch_label(st, labels, word, base, rt.reg, true, number, fwd);
-    }
-    if (str_len(target) > 0 && asm_is_digit(target[0])) {
-        ret R.err[bool, str]("encode: inline-asm numeric local-label reference must be 'Nf' or 'Nb'");
-    }
-    ret R.err[bool, str]("encode: inline-asm cbz/cbnz to a symbol is unsupported (no imm19 relocation kind); branch to a numeric local label instead");
-}
-
-# a single-register-operand instruction (`blr Xn` / `br Xn`)
-fun emit_asm_one_reg(st: *encode.EncodeState, args: str, word_is_blr: bool) R.Result[bool, str] {
-    val s: str = asm_trim(args);
-    var op: AsmOp;
-    if (!asm_parse_operand(s, ?op) || op.kind != ASMOP_REG) { ret R.err[bool, str]("encode: inline-asm blr/br operand must be a register"); }
-    if (word_is_blr)                                        { emit_branch_reg(st, BLR_BASE, op.reg); }
-    or { emit_branch_reg(st, BR_BASE, op.reg); }
-    ret R.ok[bool, str](true);
+    if (sym.mod == isa.SYM_MOD_GOT_HI) { ret emit_adrp_got_reloc(st, item.ops[0].reg::u32, sid); }
+    ret emit_adrp_reloc(st, item.ops[0].reg::u32, sid, 0);
 }
 
 # `bl sym` - a direct call, RK_PLT32 (the CALL26 the linker resolves)
-fun emit_asm_bl(st: *encode.EncodeState, args: str) R.Result[bool, str] {
-    val s: str = asm_trim(args);
-    var op: AsmOp;
-    if (!asm_parse_operand(s, ?op) || op.kind != ASMOP_SYM) { ret R.err[bool, str]("encode: inline-asm 'bl' target must be a symbol"); }
-    val sr: R.Result[intern.StrId, str] = asm_intern(st, op.name, op.name_len);
+fun a64_emit_call(st: *encode.EncodeState, c: *iasm.Cursor, item: *iasm.Item) R.Result[bool, str] {
+    val sr: R.Result[intern.StrId, str] = a64_intern(st, c, ?item.ops[0]);
     if (R.is_err[intern.StrId, str](sr)) { ret R.err[bool, str](R.unwrap_err[intern.StrId, str](sr)); }
     val sid: intern.StrId = R.unwrap_ok[intern.StrId, str](sr);
     val pos: u32 = st.buf.len::u32;
@@ -4405,292 +4167,225 @@ fun emit_asm_bl(st: *encode.EncodeState, args: str) R.Result[bool, str] {
     ret encode.push_reloc(st, arm64_reloc_offset(pos), of.RK_PLT32, sid, 0);
 }
 
-# a single-immediate instruction whose imm16 sits at bits[20:5]
-# (`svc #imm` / `brk #imm`). the value must fit 16 bits
-fun emit_asm_imm16_op(st: *encode.EncodeState, args: str, base: u32) R.Result[bool, str] {
-    val s: str = asm_trim(args);
-    var op: AsmOp;
-    if (!asm_parse_operand(s, ?op) || op.kind != ASMOP_IMM) { ret R.err[bool, str]("encode: inline-asm svc/brk needs an immediate"); }
-    if (op.imm < 0 || op.imm > 0xFFFF)                      { ret R.err[bool, str]("encode: inline-asm svc/brk immediate is out of 16-bit range"); }
-    emit_imm16(st, base, op.imm::u32);
+# emit a branch to a numeric local label, or `b sym` to a symbol
+fun a64_emit_branch(st: *encode.EncodeState, c: *iasm.Cursor, l: *iasm.Labels, item: *iasm.Item) R.Result[bool, str] {
+    val pat: u16 = a64_pattern(item.flags);
+
+    if (item.ref == iasm.AR_SYM) {
+        val name: str = (c.body::usize + item.ref_off)::str;
+        val sr: R.Result[intern.StrId, str] = intern.intern_bytes(st.interner, name, item.ref_len);
+        if (R.is_err[intern.StrId, str](sr)) { ret R.err[bool, str](R.unwrap_err[intern.StrId, str](sr)); }
+        val sid: intern.StrId = R.unwrap_ok[intern.StrId, str](sr);
+        val pos: u32 = st.buf.len::u32;
+        emit_branch_sym(st, B_BASE, sid);
+        ret encode.push_reloc(st, arm64_reloc_offset(pos), of.RK_PLT32, sid, 0);
+    }
+
+    var base: u32 = B_BASE;
+    var word: u32 = B_BASE;
+    var rt: u32 = 0;
+    var has_rt: bool = false;
+    if (pat == A64P_BCOND) {
+        base = BCOND | (a64_cond(item.flags) & 0xF);
+        word = base;
+    }
+    or (pat == A64P_CBR) {
+        val use64: bool = a64_is64(?item.ops[0]);
+        base = sel(use64, CBZ_X, CBZ_W);
+        if (item.code == A64M_CBNZ) { base = sel(use64, CBNZ_X, CBNZ_W); }
+        rt     = item.ops[0].reg::u32;
+        has_rt = true;
+        word   = pack_cbnz(base, rt);
+    }
+
+    val pos: u32 = st.buf.len::u32;
+    emit_branch_local(st, word, base, rt, has_rt, item.ref_num, item.ref_fwd);
+    ret iasm.resolve_local(st, c.g, l, pos, item.ref_num, item.ref_fwd);
+}
+
+# `ldr` / `str` and their sub-word forms
+#
+# A `:lo12:sym` offset emits the per-width folded-global low half; `[Xn, Xm]` the
+# register-offset form; `[Xn]` / `[Xn, imm]` legalize through `emit_mem_access`.
+fun a64_emit_ldst(st: *encode.EncodeState, c: *iasm.Cursor, item: *iasm.Item) R.Result[bool, str] {
+    val rt: *iasm.Operand = ?item.ops[0];
+    val mem: *iasm.Operand = ?item.ops[1];
+    if (mem.kind != iasm.AOP_MEM) { ret R.err[bool, str]("internal compiler error: inline-asm statement reached the encoder unresolved"); }
+
+    val is_load: bool = item.code == A64M_LDR || item.code == A64M_LDRB || item.code == A64M_LDRH;
+    var w: u8 = 4;
+    if (a64_is64(rt))                                          { w = 8; }
+    if (item.code == A64M_LDRB || item.code == A64M_STRB)      { w = 1; }
+    or (item.code == A64M_LDRH || item.code == A64M_STRH)      { w = 2; }
+
+    if ((mem.flags & iasm.AOF_MEM_SYM) != 0) {
+        if (mem.mod != isa.SYM_MOD_PCREL_LO && mem.mod != isa.SYM_MOD_GOT_LO) {
+            ret R.err[bool, str]("encode: inline-asm ldr/str symbol offset must be a ':lo12:sym' or ':got_lo12:sym'");
+        }
+        val sr: R.Result[intern.StrId, str] = a64_intern(st, c, mem);
+        if (R.is_err[intern.StrId, str](sr)) { ret R.err[bool, str](R.unwrap_err[intern.StrId, str](sr)); }
+        val sid: intern.StrId = R.unwrap_ok[intern.StrId, str](sr);
+        val pos: u32 = st.buf.len::u32;
+        if (mem.mod == isa.SYM_MOD_GOT_LO) {
+            if (!is_load || w != 8) { ret R.err[bool, str]("encode: inline-asm ':got_lo12:' offset takes a 64-bit load"); }
+            emit_ldst_sym(st, ldst_base_scaled(8, true), rt.reg::u32, mem.reg::u32, sid, printer.MOD_GOT_LO);
+            ret encode.push_reloc(st, arm64_reloc_offset(pos), of.RK_GOT_LO12, sid, 0);
+        }
+        emit_ldst_sym(st, ldst_base_scaled(w, is_load), rt.reg::u32, mem.reg::u32, sid, printer.MOD_PCREL_LO);
+        ret encode.push_reloc(st, arm64_reloc_offset(pos), ldst_lo12_kind(w), sid, 0);
+    }
+    if ((mem.flags & iasm.AOF_HAS_INDEX) != 0) {
+        emit_ldst_reg(st, ldst_base_reg(w, is_load), rt.reg::u32, mem.reg::u32, mem.index::u32);
+        ret R.ok[bool, str](true);
+    }
+    emit_mem_access(st, rt.reg::u32, mem.reg::u32, mem.imm, w, is_load);
     ret R.ok[bool, str](true);
 }
 
-# `ret` (return through x30) or `ret Xn`
-fun emit_asm_ret(st: *encode.EncodeState, args: str) R.Result[bool, str] {
-    val s: str = asm_trim(args);
-    if (s[0] == 0) { emit_nullary(st, RET_WORD); ret R.ok[bool, str](true); }
-    var op: AsmOp;
-    if (!asm_parse_operand(s, ?op) || op.kind != ASMOP_REG) { ret R.err[bool, str]("encode: inline-asm 'ret' operand must be a register"); }
-    emit_branch_reg(st, RET_BASE, op.reg);
+# `stp` / `ldp Xa, Xb, [mem]` in the signed-offset, pre-index and post-index forms
+fun a64_emit_ldstp(st: *encode.EncodeState, item: *iasm.Item) R.Result[bool, str] {
+    val mem: *iasm.Operand = ?item.ops[2];
+    val is_load: bool = item.code == A64M_LDP;
+    var disp: i64 = 0;
+    var base_word: u32 = sel(is_load, LDP_OFF_X, STP_OFF_X);
+    if (item.nops == 4) {
+        disp      = item.ops[3].imm;
+        base_word = sel(is_load, LDP_POST_X, STP_POST_X);
+    } or {
+        disp = mem.imm;
+        if ((mem.flags & iasm.AOF_WRITEBACK) != 0) { base_word = sel(is_load, LDP_PRE_X, STP_PRE_X); }
+    }
+    if ((disp & 7) != 0)   { ret R.err[bool, str]("encode: inline-asm stp/ldp offset must be a multiple of 8"); }
+    val q: i64 = disp / 8;
+    if (q < -64 || q > 63) { ret R.err[bool, str]("encode: inline-asm stp/ldp offset is out of the imm7 range"); }
+    emit_ldstp(st, base_word, item.ops[0].reg::u32, item.ops[1].reg::u32, mem.reg::u32, q::u32 & 0x7F);
     ret R.ok[bool, str](true);
 }
 
-# the AsmClobbersFn the arm64 ISA vtable exposes - infer the registers
-# an inline-asm body writes, so the allocator leaves no live value in one and the
-# prologue preserves any callee-saved register the body clobbers. without this hook a
-# nil slot forced a conservative all-register clobber, framing every asm function
-# (e.g. `_start`, whose frame `sub sp` then mis-reads argc off the entry stack).
-# mirrors x86-64's `asm_clobbers` for the grammar encode_asm_stmt_arm64 accepts:
-# `{name}` locals substitute to `[x29,#off]` memory (never registers) and contribute
-# nothing; the grammar has no FP mnemonic, so `fp_out` stays empty; an unrecognized
-# statement is opaque and conservatively clobbers every register
+# `ldar` / `stlr` / `ldaxr Rt, [Xn]` - the acquire / release ordered accesses
+fun a64_emit_ldord(st: *encode.EncodeState, item: *iasm.Item) R.Result[bool, str] {
+    val use64: bool = a64_is64(?item.ops[0]);
+    var base: u32 = sel(use64, LDAXR_X, LDAXR_W);
+    if (item.code == A64M_LDAR)      { base = sel(use64, LDAR_X, LDAR_W); }
+    or (item.code == A64M_STLR)      { base = sel(use64, STLR_X, STLR_W); }
+    emit_ldst(st, base, item.ops[0].reg::u32, item.ops[1].reg::u32, 0);
+    ret R.ok[bool, str](true);
+}
+
+# `lsl` / `lsr` / `asr Rd, Rn, imm | Rm` and the register-only variable forms
+#
+# An immediate count emits the UBFM (lsl / lsr) / SBFM (asr) bitfield alias; a
+# register count the LSLV / LSRV / ASRV variable shift, mirroring the MIR path.
+fun a64_emit_shift(st: *encode.EncodeState, item: *iasm.Item) R.Result[bool, str] {
+    val rd: *iasm.Operand = ?item.ops[0];
+    val rn: *iasm.Operand = ?item.ops[1];
+    val cnt: *iasm.Operand = ?item.ops[2];
+    val use64: bool = a64_is64(rd);
+    var width: u32 = 32;
+    if (use64) { width = 64; }
+
+    val vform: bool = item.code == A64M_LSLV || item.code == A64M_LSRV || item.code == A64M_ASRV;
+    val is_lsr: bool = item.code == A64M_LSR || item.code == A64M_LSRV;
+    val is_asr: bool = item.code == A64M_ASR || item.code == A64M_ASRV;
+
+    if (cnt.kind == iasm.AOP_IMM && !vform) {
+        val sh: u32 = cnt.imm::u32 & (width - 1);
+        if (is_asr) {
+            emit_bitfield(st, sel(use64, SBFM_X, SBFM_W), rd.reg::u32, rn.reg::u32, sh, width - 1);
+        } or (is_lsr) {
+            emit_bitfield(st, sel(use64, UBFM_X, UBFM_W), rd.reg::u32, rn.reg::u32, sh, width - 1);
+        } or {
+            val immr: u32 = (width - sh) & (width - 1);
+            val imms: u32 = (width - 1) - sh;
+            emit_bitfield(st, sel(use64, UBFM_X, UBFM_W), rd.reg::u32, rn.reg::u32, immr, imms);
+        }
+        ret R.ok[bool, str](true);
+    }
+    if (cnt.kind != iasm.AOP_REG) { ret R.err[bool, str]("encode: inline-asm shift count must be a register or immediate"); }
+    var bx: u32 = LSLV_X;
+    var bw: u32 = LSLV_W;
+    if (is_lsr)      { bx = LSRV_X; bw = LSRV_W; }
+    or (is_asr)      { bx = ASRV_X; bw = ASRV_W; }
+    emit_alu3(st, sel(use64, bx, bw), rd.reg::u32, rn.reg::u32, cnt.reg::u32);
+    ret R.ok[bool, str](true);
+}
+
+# intern the symbol name an operand spans out of the asm body
+#
+# The name is a region of the body, not a NUL-terminated string, so it is interned
+# before either the notification or the relocation can name it - both take the id.
+fun a64_intern(st: *encode.EncodeState, c: *iasm.Cursor, op: *iasm.Operand) R.Result[intern.StrId, str] {
+    ret intern.intern_bytes(st.interner, (c.body::usize + op.name_off)::str, op.name_len);
+}
+
+# insert the displacement from an inline-asm branch to a numeric local label
+#
+# The imm26 / imm19 insert is the shared `patch_branch_arm64`, which dispatches on the
+# placeholder word's top bits, so this carries no encoding.
+fun a64_patch(st: *encode.EncodeState, patch_pos: u32, target_off: u32) R.Result[bool, str] {
+    var fx: encode.BranchFixup;
+    fx.patch_pos    = patch_pos;
+    fx.next_ip      = 0;
+    fx.target_block = 0;
+    fx.fn_text_base = 0;
+    ret patch_branch_arm64(st, ?fx, target_off);
+}
+
+# the AArch64 inline-assembly grammar
+fun a64_grammar() iasm.Grammar {
+    var g: iasm.Grammar;
+    g.isa       = "aarch64";
+    g.rows      = ?A64_MNEMONICS[0];
+    g.row_count = A64_MNEMONIC_COUNT;
+    g.decode    = a64_decode_bcond;
+    g.parse     = a64_parse;
+    g.emit      = a64_emit;
+    g.patch     = a64_patch;
+    g.slot      = frame_slot_offset;
+    g.all_gp    = 0xFFFFFFFF;
+    g.all_fp    = 0xFFFFFFFF;
+    g.word      = 4;
+    ret g;
+}
+
+# the `AsmClobbersFn` the arm64 ISA vtable exposes - the registers an inline-asm body
+# writes, derived from the instructions the body parses to
+#
+# Without this hook a nil slot forces a conservative all-register clobber, framing
+# every asm function (`_start`, whose `sub sp` then mis-reads argc off the entry
+# stack). The derivation runs the same parser the assembler runs, so the register set
+# and the emitted bytes describe one instruction stream.
+# ---
+# body:   the inline-asm body text
+# gp_out: out - the GP registers the body writes (bit n = register n)
+# fp_out: out - the FP registers the body writes (bit n = register n)
 pub fun asm_clobbers(body: str, gp_out: *u32, fp_out: *u32) {
-    var gp: u32 = 0;
-    var fp: u32 = 0;
-    val len: usize = str_len(body);
-    var start: usize = 0;
-    for (start < len) {
-        var end: usize = start;
-        for (end < len && body[end] != '\n'::char && body[end] != ';'::char) { end = end + 1; }
-        var lo: usize = start;
-        for (lo < end && asm_is_space(body[lo])) { lo = lo + 1; }
-        var hi: usize = end;
-        for (hi > lo && asm_is_space(body[hi - 1])) { hi = hi - 1; }
-        if (hi > lo) {
-            var line: [512]u8;
-            val ll: usize = hi - lo;
-            if (ll >= 512) { gp = 0xFFFFFFFF; fp = 0xFFFFFFFF; }
-            or {
-                var c: usize = 0;
-                for (c < ll) { line[c] = body[lo + c]::u8; c = c + 1; }
-                line[ll] = 0;
-                asm_stmt_clobbers((?line[0])::str, ?gp, ?fp);
-            }
-        }
-        start = end + 1;
-    }
-    @gp_out = gp;
-    @fp_out = fp;
+    var g: iasm.Grammar = a64_grammar();
+    iasm.clobbers(?g, body, gp_out, fp_out);
 }
 
-# OR the GP register named by operand `idx` of `args` into `@gp`. a non-
-# register operand (memory / immediate / barrier option / symbol) writes no register;
-# a malformed operand list the encoder will reject clobbers conservatively
-fun asm_mark_op(args: str, idx: u32, gp: *u32) {
-    var b0: [128]u8; var b1: [128]u8; var b2: [128]u8; var b3: [128]u8;
-    var n: u32 = 0;
-    if (!asm_split(args, ?b0[0], ?b1[0], ?b2[0], ?b3[0], 128, ?n)) { @gp = @gp | 0xFFFFFFFF; ret; }
-    if (idx >= n)                                                  { ret; }
-    var bp: *u8 = ?b0[0];
-    if (idx == 1) { bp = ?b1[0]; } or (idx == 2) { bp = ?b2[0]; } or (idx == 3) { bp = ?b3[0]; }
-    var op: AsmOp;
-    if (asm_parse_operand((bp)::str, ?op) && op.kind == ASMOP_REG && op.reg < 32) {
-        @gp = @gp | (1::u32 << op.reg);
-    }
-}
-
-# OR the writeback base register of an `ldp`/`stp` into `@gp` when the
-# addressing form mutates it - pre-index `[Xn, #imm]!` (the MEM operand's `wb_pre`) or
-# post-index `[Xn], #imm` (a trailing immediate operand after the bare MEM). a plain
-# `[Xn{, #imm}]` writes no base. operand 2 is the MEM; operand 3 (post-index only) is the
-# displacement
-fun asm_mark_ldstp_wb(args: str, gp: *u32) {
-    var b0: [128]u8; var b1: [128]u8; var b2: [128]u8; var b3: [128]u8;
-    var n: u32 = 0;
-    if (!asm_split(args, ?b0[0], ?b1[0], ?b2[0], ?b3[0], 128, ?n)) { @gp = @gp | 0xFFFFFFFF; ret; }
-    if (n < 3)                                                     { ret; }
-    var mem: AsmOp;
-    if (!asm_parse_operand((?b2[0])::str, ?mem) || mem.kind != ASMOP_MEM) { ret; }
-    var wb: bool = mem.wb_pre;
-    if (n >= 4) {
-        var disp: AsmOp;
-        if (asm_parse_operand((?b3[0])::str, ?disp) && disp.kind == ASMOP_IMM) { wb = true; }
-    }
-    if (wb && mem.base < 32) { @gp = @gp | (1::u32 << mem.base); }
-}
-
-# OR the registers one trimmed aarch64 inline-asm statement writes
-# into `@gp` (the grammar has no FP write). a dest-writing form clobbers operand 0 (ldp
-# both loaded registers; stlxr the status result); ldp/stp in a pre/post-index writeback
-# form also clobber the base register; a `bl`/`blr`/`br` call clobbers the caller-saved
-# file (x0-x18, x30) and `svc` clobbers x0 - none callee-saved, so they add no frame;
-# compares / branches / barriers and non-writeback stores write nothing. an unrecognized
-# statement conservatively clobbers everything
-fun asm_stmt_clobbers(stmt: str, gp: *u32, fp: *u32) {
-    var lnum: u64 = 0;
-    val dlen: usize = asm_label_def_len(stmt, ?lnum);
-    if (dlen > 0) {
-        val rest: str = asm_trim((stmt::usize + dlen)::str);
-        if (rest[0] == 0) { ret; }
-        asm_stmt_clobbers(rest, gp, fp);
-        ret;
-    }
-    var mbuf: [24]u8;
-    var args: str;
-    if (!asm_first_token(stmt, ?mbuf[0], 24, ?args)) { @gp = @gp | 0xFFFFFFFF; @fp = @fp | 0xFFFFFFFF; ret; }
-    val mnem: str = (?mbuf[0])::str;
-
-    # write nothing: barriers, return, trap, compare, stores, plain/conditional branches.
-    if (str_equals(mnem, "nop") || str_equals(mnem, "yield") || str_equals(mnem, "dmb") ||
-        str_equals(mnem, "ret") || str_equals(mnem, "brk") || str_equals(mnem, "cmp") ||
-        str_equals(mnem, "str") || str_equals(mnem, "strb") || str_equals(mnem, "strh") ||
-        str_equals(mnem, "stlr") ||
-        str_equals(mnem, "b") || str_equals(mnem, "cbz") || str_equals(mnem, "cbnz")) { ret; }
-    if (str_starts_with(mnem, "b.")) { ret; }
-
-    # a call clobbers the caller-saved file (+ LR); svc clobbers x0. none callee-saved.
-    if (str_equals(mnem, "bl") || str_equals(mnem, "blr") || str_equals(mnem, "br")) {
-        @gp = @gp | 0x4007FFFF;
-        ret;
-    }
-    if (str_equals(mnem, "svc")) { @gp = @gp | 0x1; ret; }
-
-    # ldp writes both loaded registers (+ the base in a writeback form); stp writes only
-    # the base, and only in a writeback form.
-    if (str_equals(mnem, "ldp")) { asm_mark_op(args, 0, gp); asm_mark_op(args, 1, gp); asm_mark_ldstp_wb(args, gp); ret; }
-    if (str_equals(mnem, "stp")) { asm_mark_ldstp_wb(args, gp); ret; }
-
-    # dest = operand 0: data-processing / load / shift forms, cset, and stlxr's status reg.
-    if (str_equals(mnem, "mov") || str_equals(mnem, "movz") || str_equals(mnem, "movk") ||
-        str_equals(mnem, "add") || str_equals(mnem, "sub") || str_equals(mnem, "and") ||
-        str_equals(mnem, "orr") || str_equals(mnem, "eor") || str_equals(mnem, "adrp") ||
-        str_equals(mnem, "cset") ||
-        str_equals(mnem, "ldr") || str_equals(mnem, "ldrb") || str_equals(mnem, "ldrh") ||
-        str_equals(mnem, "ldar") || str_equals(mnem, "ldaxr") || str_equals(mnem, "stlxr") ||
-        str_equals(mnem, "lsl") || str_equals(mnem, "lsr") || str_equals(mnem, "asr") ||
-        str_equals(mnem, "lslv") || str_equals(mnem, "lsrv") || str_equals(mnem, "asrv")) {
-        asm_mark_op(args, 0, gp);
-        ret;
-    }
-
-    # unrecognized: opaque, clobber everything (a sound over-approximation).
-    @gp = @gp | 0xFFFFFFFF;
-    @fp = @fp | 0xFFFFFFFF;
-}
-
-# parse and encode one trimmed inline-asm statement. a numeric
-# local-label definition `<digits>:` records the current offset (resolving forward
-# references) and re-dispatches any instruction following it. an unrecognized
-# mnemonic is a hard error so the assembler is cleanly extensible
-fun encode_asm_stmt_arm64(st: *encode.EncodeState, f: *mir.MirFunction, fn_base: u32, labels: *AsmLabels, tok: str) R.Result[bool, str] {
-    var label_num: u64 = 0;
-    val dlen: usize = asm_label_def_len(tok, ?label_num);
-    if (dlen > 0) {
-        val dr: R.Result[bool, str] = asm_label_record_def(st, labels, label_num, st.buf.len::u32);
-        if (R.is_err[bool, str](dr)) { ret dr; }
-        val rest: str = asm_trim((tok::usize + dlen)::str);
-        if (rest[0] == 0) { ret R.ok[bool, str](true); }
-        ret encode_asm_stmt_arm64(st, f, fn_base, labels, rest);
-    }
-
-    var mbuf: [24]u8;
-    var args: str;
-    if (!asm_first_token(tok, ?mbuf[0], 24, ?args)) { ret R.err[bool, str]("encode: inline-asm mnemonic too long"); }
-    val mnem: str = (?mbuf[0])::str;
-
-    if (str_equals(mnem, "nop"))  { emit_nullary(st, NOP_WORD); ret R.ok[bool, str](true); }
-    if (str_equals(mnem, "ret"))  { ret emit_asm_ret(st, args); }
-    if (str_equals(mnem, "svc"))  { ret emit_asm_imm16_op(st, args, SVC_BASE); }
-    if (str_equals(mnem, "brk"))  { ret emit_asm_imm16_op(st, args, BRK_BASE); }
-    if (str_equals(mnem, "mov"))  { ret emit_asm_mov(st, args); }
-    if (str_equals(mnem, "movz")) { ret emit_asm_movewide(st, args, false); }
-    if (str_equals(mnem, "movk")) { ret emit_asm_movewide(st, args, true); }
-    if (str_equals(mnem, "add"))  { ret emit_asm_addsub(st, args, false); }
-    if (str_equals(mnem, "sub"))  { ret emit_asm_addsub(st, args, true); }
-    if (str_equals(mnem, "and"))  { ret emit_asm_logical(st, args, AND_X, AND_W); }
-    if (str_equals(mnem, "orr"))  { ret emit_asm_logical(st, args, ORR_X, ORR_W); }
-    if (str_equals(mnem, "eor"))  { ret emit_asm_logical(st, args, EOR_X, EOR_W); }
-    if (str_equals(mnem, "cmp"))  { ret emit_asm_cmp(st, args); }
-    if (str_equals(mnem, "cset")) { ret emit_asm_cset(st, args); }
-    if (str_equals(mnem, "adrp")) { ret emit_asm_adrp(st, args); }
-    if (str_equals(mnem, "bl"))   { ret emit_asm_bl(st, args); }
-    if (str_equals(mnem, "blr"))  { ret emit_asm_one_reg(st, args, true); }
-    if (str_equals(mnem, "br"))   { ret emit_asm_one_reg(st, args, false); }
-    if (str_equals(mnem, "b"))    { ret emit_asm_b(st, labels, args); }
-    if (str_starts_with(mnem, "b.")) {
-        var cond: u32 = 0;
-        if (!asm_parse_cond((mnem::usize + 2)::str, ?cond)) {
-            ret R.err[bool, str](asm_named_err(st, "unsupported aarch64 inline-asm condition '", mnem, "'", "unsupported aarch64 inline-asm condition"));
-        }
-        ret emit_asm_bcond(st, labels, cond, args);
-    }
-    if (str_equals(mnem, "cbz"))  { ret emit_asm_cbr(st, labels, args, false); }
-    if (str_equals(mnem, "cbnz")) { ret emit_asm_cbr(st, labels, args, true); }
-    if (str_equals(mnem, "ldr") || str_equals(mnem, "str") ||
-        str_equals(mnem, "ldrb") || str_equals(mnem, "strb") ||
-        str_equals(mnem, "ldrh") || str_equals(mnem, "strh")) {
-        ret emit_asm_ldst(st, mnem, args);
-    }
-    if (str_equals(mnem, "stp"))   { ret emit_asm_ldstp(st, args, false); }
-    if (str_equals(mnem, "ldp"))   { ret emit_asm_ldstp(st, args, true); }
-    if (str_equals(mnem, "dmb"))   { ret emit_asm_dmb(st, args); }
-    if (str_equals(mnem, "yield")) { emit_nullary(st, YIELD_WORD); ret R.ok[bool, str](true); }
-    if (str_equals(mnem, "ldar") || str_equals(mnem, "stlr") || str_equals(mnem, "ldaxr")) {
-        ret emit_asm_ldordered(st, mnem, args);
-    }
-    if (str_equals(mnem, "stlxr")) { ret emit_asm_stlxr(st, args); }
-    if (str_equals(mnem, "lsl") || str_equals(mnem, "lsr") || str_equals(mnem, "asr") ||
-        str_equals(mnem, "lslv") || str_equals(mnem, "lsrv") || str_equals(mnem, "asrv")) {
-        ret emit_asm_shift(st, mnem, args);
-    }
-
-    ret R.err[bool, str](asm_named_err(st, "unsupported aarch64 inline-asm mnemonic '", mnem, "'", "unsupported aarch64 inline-asm mnemonic"));
-}
-
-# tokenize the (already `{name}`-substituted) asm body on
-# newlines / `;`, trim each statement, and encode it. `#` line comments were stripped
-# at lower time, so none reach here. mirrors x86-64's `encode_asm_text`
-fun encode_asm_text_arm64(st: *encode.EncodeState, f: *mir.MirFunction, fn_base: u32, labels: *AsmLabels, text: str) R.Result[bool, str] {
-    val len: usize = str_len(text);
-    var start: usize = 0;
-    for (start < len) {
-        var end: usize = start;
-        for (end < len && text[end] != '\n'::char && text[end] != ';'::char) { end = end + 1; }
-
-        var lo: usize = start;
-        for (lo < end && asm_is_space(text[lo])) { lo = lo + 1; }
-        var hi: usize = end;
-        for (hi > lo && asm_is_space(text[hi - 1])) { hi = hi - 1; }
-
-        if (hi > lo) {
-            var line: [512]u8;
-            val ll: usize = hi - lo;
-            if (ll >= 512) { ret R.err[bool, str]("encode: inline asm statement too long"); }
-            var c: usize = 0;
-            for (c < ll) { line[c] = text[lo + c]::u8; c = c + 1; }
-            line[ll] = 0;
-            val er: R.Result[bool, str] = encode_asm_stmt_arm64(st, f, fn_base, labels, (?line[0])::str);
-            if (R.is_err[bool, str](er)) { ret er; }
-        }
-        start = end + 1;
-    }
-    ret R.ok[bool, str](true);
-}
-
-# expand an inline-asm MIR_ASM instruction into A64 bytes.
-# substitutes `{name}` locals to `[x29, #off]`, encodes each statement, and verifies
-# every forward local-label reference was defined within the block. the A64 analogue
-# of x86-64's `encode_asm_block`; a rejection is located at the asm statement's
-# "path:line:col" through the instruction's stamped loc (#2153)
+# expand an inline-asm MIR_ASM instruction into A64 bytes
+#
+# The aarch64 instantiation of the shared block driver: it supplies the grammar and
+# the driver does the rest, so `{name}` resolution, numeric local labels, byte
+# accounting and the located diagnostic are the same code every target runs.
 fun encode_asm_block_arm64(st: *encode.EncodeState, f: *mir.MirFunction, fn_base: u32, mi: *mir.MirInstr) R.Result[bool, str] {
-    if (mi.asm_block == nil) { ret R.err[bool, str]("encode: MIR_ASM has no payload"); }
-    val pl: *mir.MirAsm = mi.asm_block;
-    if (!str_equals(pl.isa, "aarch64")) {
-        ret R.err[bool, str](encode.asm_located_message(st, mi.loc, "encode: inline-asm block is not aarch64"));
-    }
-
-    val sr: R.Result[str, str] = substitute_asm_locals_arm64(st.alloc, st.interner, f, pl);
-    if (R.is_err[str, str](sr)) {
-        ret R.err[bool, str](encode.asm_located_message(st, mi.loc, R.unwrap_err[str, str](sr)));
-    }
-    val text: str = R.unwrap_ok[str, str](sr);
-
-    var labels: AsmLabels;
-    asm_labels_init(?labels, st.alloc);
-    val er: R.Result[bool, str] = encode_asm_text_arm64(st, f, fn_base, ?labels, text);
-    A.deallocate[u8](st.alloc, text::*u8, (str_len(text) + 1)::usize);
-    if (R.is_err[bool, str](er)) {
-        asm_labels_dnit(?labels);
-        ret R.err[bool, str](encode.asm_located_message(st, mi.loc, R.unwrap_err[bool, str](er)));
-    }
-    if (labels.ref_count > 0) {
-        asm_labels_dnit(?labels);
-        ret R.err[bool, str](encode.asm_located_message(st, mi.loc, "encode: inline-asm forward reference to a local label has no definition in this asm block"));
-    }
-    asm_labels_dnit(?labels);
-    ret R.ok[bool, str](true);
+    var g: iasm.Grammar = a64_grammar();
+    ret iasm.encode_block(st, ?g, f, mi);
 }
+
+# assemble `text` as an inline-asm body into `st`, with no `{name}` bindings
+#
+# The encoder tests' entry point: it drives the same cursor and the same driver the
+# block path does, so a byte-exact golden is a fact about the shipping parser rather
+# than about a test-only path beside it.
+fun a64_asm_text(st: *encode.EncodeState, f: *mir.MirFunction, l: *iasm.Labels, text: str) R.Result[bool, str] {
+    var g: iasm.Grammar = a64_grammar();
+    var c: iasm.Cursor;
+    iasm.cursor_init(?c, ?g, text, st.alloc, st.interner, f, nil);
+    ret iasm.run(st, ?g, ?c, l);
+}
+
 
 # a fresh page-backed EncodeState carrying only a byte sink, for exercising
 # the emit-level helpers (prologue / epilogue / branch patch) directly
@@ -6221,36 +5916,36 @@ test "mach.lang.target.isa.arm64.encode:inline_asm_data_processing_forms" {
     var alloc: A.Allocator;
     var interner: intern.Interner;
     tasm(?st, ?alloc, ?interner);
-    var labels: AsmLabels;
-    asm_labels_init(?labels, ?alloc);
+    var labels: iasm.Labels;
+    iasm.labels_init(?labels, ?alloc);
     var f: mir.MirFunction;
 
-    encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "nop");                    # 0
-    encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "ret");                    # 4
-    encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "svc #0");                 # 8
-    encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "svc 0x1");               # 12
-    encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "brk #0");                # 16
-    encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "mov x0, x1");           # 20
-    encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "mov sp, x0");           # 24
-    encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "mov x0, sp");           # 28
-    encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "mov w0, w1");           # 32
-    encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "mov x8, #93");          # 36
-    encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "mov x0, #0");           # 40
-    encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "movz x0, #0x1234");     # 44
-    encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "movz x0, #0x1234, lsl #16"); # 48
-    encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "movk x0, #0x5678, lsl #16"); # 52
-    encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "add x0, x1, #5");       # 56
-    encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "add x0, x1, x2");       # 60
-    encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "sub x0, x1, #5");       # 64
-    encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "sub sp, sp, #16");      # 68
-    encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "and x0, x1, x2");       # 72
-    encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "orr x0, x1, x2");       # 76
-    encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "eor x0, x1, x2");       # 80
-    encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "cmp x0, #5");           # 84
-    encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "cmp x0, x1");           # 88
-    encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "cmp w0, w1");           # 92
-    encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "blr x0");              # 96
-    encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "br x0");               # 100
+    a64_asm_text(?st, ?f, ?labels, "nop");                    # 0
+    a64_asm_text(?st, ?f, ?labels, "ret");                    # 4
+    a64_asm_text(?st, ?f, ?labels, "svc 0");                 # 8
+    a64_asm_text(?st, ?f, ?labels, "svc 0x1");               # 12
+    a64_asm_text(?st, ?f, ?labels, "brk 0");                # 16
+    a64_asm_text(?st, ?f, ?labels, "mov x0, x1");           # 20
+    a64_asm_text(?st, ?f, ?labels, "mov sp, x0");           # 24
+    a64_asm_text(?st, ?f, ?labels, "mov x0, sp");           # 28
+    a64_asm_text(?st, ?f, ?labels, "mov w0, w1");           # 32
+    a64_asm_text(?st, ?f, ?labels, "mov x8, 93");          # 36
+    a64_asm_text(?st, ?f, ?labels, "mov x0, 0");           # 40
+    a64_asm_text(?st, ?f, ?labels, "movz x0, 0x1234");     # 44
+    a64_asm_text(?st, ?f, ?labels, "movz x0, 0x1234, lsl 16"); # 48
+    a64_asm_text(?st, ?f, ?labels, "movk x0, 0x5678, lsl 16"); # 52
+    a64_asm_text(?st, ?f, ?labels, "add x0, x1, 5");       # 56
+    a64_asm_text(?st, ?f, ?labels, "add x0, x1, x2");       # 60
+    a64_asm_text(?st, ?f, ?labels, "sub x0, x1, 5");       # 64
+    a64_asm_text(?st, ?f, ?labels, "sub sp, sp, 16");      # 68
+    a64_asm_text(?st, ?f, ?labels, "and x0, x1, x2");       # 72
+    a64_asm_text(?st, ?f, ?labels, "orr x0, x1, x2");       # 76
+    a64_asm_text(?st, ?f, ?labels, "eor x0, x1, x2");       # 80
+    a64_asm_text(?st, ?f, ?labels, "cmp x0, 5");           # 84
+    a64_asm_text(?st, ?f, ?labels, "cmp x0, x1");           # 88
+    a64_asm_text(?st, ?f, ?labels, "cmp w0, w1");           # 92
+    a64_asm_text(?st, ?f, ?labels, "blr x0");              # 96
+    a64_asm_text(?st, ?f, ?labels, "br x0");               # 100
 
     if (read_word(?st.buf, 0)   != 0xD503201F) { bad = 1; }
     if (read_word(?st.buf, 4)   != 0xD65F03C0) { bad = 1; }
@@ -6279,7 +5974,7 @@ test "mach.lang.target.isa.arm64.encode:inline_asm_data_processing_forms" {
     if (read_word(?st.buf, 96)  != 0xD63F0000) { bad = 1; }
     if (read_word(?st.buf, 100) != 0xD61F0000) { bad = 1; }
 
-    asm_labels_dnit(?labels);
+    iasm.labels_dnit(?labels);
     encode.buf_dnit(?st.buf);
     ret bad;
 }
@@ -6293,20 +5988,20 @@ test "mach.lang.target.isa.arm64.encode:inline_asm_cset_forms" {
     var alloc: A.Allocator;
     var interner: intern.Interner;
     tasm(?st, ?alloc, ?interner);
-    var labels: AsmLabels;
-    asm_labels_init(?labels, ?alloc);
+    var labels: iasm.Labels;
+    iasm.labels_init(?labels, ?alloc);
     var f: mir.MirFunction;
 
-    encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "cset x9, cs");   # 0
-    encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "cset w9, cs");   # 4
-    encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "cset x0, eq");   # 8
-    encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "cset w0, eq");   # 12
-    encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "cset x5, ne");   # 16
-    encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "cset w5, ne");   # 20
-    encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "cset x9, lt");   # 24
-    encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "cset w19, le");  # 28
-    encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "cset x3, hi");   # 32
-    encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "cset w7, ge");   # 36
+    a64_asm_text(?st, ?f, ?labels, "cset x9, cs");   # 0
+    a64_asm_text(?st, ?f, ?labels, "cset w9, cs");   # 4
+    a64_asm_text(?st, ?f, ?labels, "cset x0, eq");   # 8
+    a64_asm_text(?st, ?f, ?labels, "cset w0, eq");   # 12
+    a64_asm_text(?st, ?f, ?labels, "cset x5, ne");   # 16
+    a64_asm_text(?st, ?f, ?labels, "cset w5, ne");   # 20
+    a64_asm_text(?st, ?f, ?labels, "cset x9, lt");   # 24
+    a64_asm_text(?st, ?f, ?labels, "cset w19, le");  # 28
+    a64_asm_text(?st, ?f, ?labels, "cset x3, hi");   # 32
+    a64_asm_text(?st, ?f, ?labels, "cset w7, ge");   # 36
 
     if (read_word(?st.buf, 0)  != 0x9A9F37E9) { bad = 1; }  # cset x9, cs (hs)
     if (read_word(?st.buf, 4)  != 0x1A9F37E9) { bad = 1; }  # cset w9, cs (hs)
@@ -6319,7 +6014,7 @@ test "mach.lang.target.isa.arm64.encode:inline_asm_cset_forms" {
     if (read_word(?st.buf, 32) != 0x9A9F97E3) { bad = 1; }  # cset x3, hi
     if (read_word(?st.buf, 36) != 0x1A9FB7E7) { bad = 1; }  # cset w7, ge
 
-    asm_labels_dnit(?labels);
+    iasm.labels_dnit(?labels);
     encode.buf_dnit(?st.buf);
     ret bad;
 }
@@ -6333,27 +6028,27 @@ test "mach.lang.target.isa.arm64.encode:inline_asm_load_store_forms" {
     var alloc: A.Allocator;
     var interner: intern.Interner;
     tasm(?st, ?alloc, ?interner);
-    var labels: AsmLabels;
-    asm_labels_init(?labels, ?alloc);
+    var labels: iasm.Labels;
+    iasm.labels_init(?labels, ?alloc);
     var f: mir.MirFunction;
 
-    encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "ldr x0, [x1]");          # 0
-    encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "ldr x0, [x1, #8]");      # 4
-    encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "ldr x0, [x1, x2]");      # 8
-    encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "str w0, [x1, #4]");      # 12
-    encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "ldrb w0, [x1]");         # 16
-    encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "ldrh w0, [x1, #2]");     # 20
-    encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "strb w0, [x1, #1]");     # 24
-    encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "ldr x0, [x1, #-8]");     # 28
-    encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "str x0, [sp, #8]");      # 32
-    encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "ldr x0, [sp]");          # 36
-    encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "stp x29, x30, [sp, #-16]!"); # 40
-    encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "ldp x29, x30, [sp], #16");   # 44
-    encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "stp x19, x20, [sp, #16]");   # 48
-    encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "ldp x19, x20, [sp, #16]");   # 52
-    encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "stp x0, x1, [sp]");          # 56
-    encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "stp x0, x1, [sp], #16");     # 60
-    encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "ldp x0, x1, [sp, #16]!");    # 64
+    a64_asm_text(?st, ?f, ?labels, "ldr x0, [x1]");          # 0
+    a64_asm_text(?st, ?f, ?labels, "ldr x0, [x1, 8]");      # 4
+    a64_asm_text(?st, ?f, ?labels, "ldr x0, [x1, x2]");      # 8
+    a64_asm_text(?st, ?f, ?labels, "str w0, [x1, 4]");      # 12
+    a64_asm_text(?st, ?f, ?labels, "ldrb w0, [x1]");         # 16
+    a64_asm_text(?st, ?f, ?labels, "ldrh w0, [x1, 2]");     # 20
+    a64_asm_text(?st, ?f, ?labels, "strb w0, [x1, 1]");     # 24
+    a64_asm_text(?st, ?f, ?labels, "ldr x0, [x1, -8]");     # 28
+    a64_asm_text(?st, ?f, ?labels, "str x0, [sp, 8]");      # 32
+    a64_asm_text(?st, ?f, ?labels, "ldr x0, [sp]");          # 36
+    a64_asm_text(?st, ?f, ?labels, "stp x29, x30, [sp, -16]!"); # 40
+    a64_asm_text(?st, ?f, ?labels, "ldp x29, x30, [sp], 16");   # 44
+    a64_asm_text(?st, ?f, ?labels, "stp x19, x20, [sp, 16]");   # 48
+    a64_asm_text(?st, ?f, ?labels, "ldp x19, x20, [sp, 16]");   # 52
+    a64_asm_text(?st, ?f, ?labels, "stp x0, x1, [sp]");          # 56
+    a64_asm_text(?st, ?f, ?labels, "stp x0, x1, [sp], 16");     # 60
+    a64_asm_text(?st, ?f, ?labels, "ldp x0, x1, [sp, 16]!");    # 64
 
     if (read_word(?st.buf, 0)  != 0xF9400020) { bad = 1; }
     if (read_word(?st.buf, 4)  != 0xF9400420) { bad = 1; }
@@ -6373,7 +6068,7 @@ test "mach.lang.target.isa.arm64.encode:inline_asm_load_store_forms" {
     if (read_word(?st.buf, 60) != 0xA88107E0) { bad = 1; }
     if (read_word(?st.buf, 64) != 0xA9C107E0) { bad = 1; }
 
-    asm_labels_dnit(?labels);
+    iasm.labels_dnit(?labels);
     encode.buf_dnit(?st.buf);
     ret bad;
 }
@@ -6388,20 +6083,20 @@ test "mach.lang.target.isa.arm64.encode:inline_asm_atomic_barrier_forms" {
     var alloc: A.Allocator;
     var interner: intern.Interner;
     tasm(?st, ?alloc, ?interner);
-    var labels: AsmLabels;
-    asm_labels_init(?labels, ?alloc);
+    var labels: iasm.Labels;
+    iasm.labels_init(?labels, ?alloc);
     var f: mir.MirFunction;
 
-    encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "dmb ish");           # 0
-    encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "yield");            # 4
-    encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "ldar x0, [x1]");    # 8
-    encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "ldar w0, [x1]");    # 12
-    encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "stlr x0, [x1]");    # 16
-    encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "stlr w0, [x1]");    # 20
-    encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "ldaxr x0, [x1]");   # 24
-    encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "ldaxr w0, [x1]");   # 28
-    encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "stlxr w2, x0, [x1]"); # 32
-    encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "stlxr w2, w0, [x1]"); # 36
+    a64_asm_text(?st, ?f, ?labels, "dmb ish");           # 0
+    a64_asm_text(?st, ?f, ?labels, "yield");            # 4
+    a64_asm_text(?st, ?f, ?labels, "ldar x0, [x1]");    # 8
+    a64_asm_text(?st, ?f, ?labels, "ldar w0, [x1]");    # 12
+    a64_asm_text(?st, ?f, ?labels, "stlr x0, [x1]");    # 16
+    a64_asm_text(?st, ?f, ?labels, "stlr w0, [x1]");    # 20
+    a64_asm_text(?st, ?f, ?labels, "ldaxr x0, [x1]");   # 24
+    a64_asm_text(?st, ?f, ?labels, "ldaxr w0, [x1]");   # 28
+    a64_asm_text(?st, ?f, ?labels, "stlxr w2, x0, [x1]"); # 32
+    a64_asm_text(?st, ?f, ?labels, "stlxr w2, w0, [x1]"); # 36
 
     if (read_word(?st.buf, 0)  != 0xD5033BBF) { bad = 1; }
     if (read_word(?st.buf, 4)  != 0xD503203F) { bad = 1; }
@@ -6414,7 +6109,7 @@ test "mach.lang.target.isa.arm64.encode:inline_asm_atomic_barrier_forms" {
     if (read_word(?st.buf, 32) != 0xC802FC20) { bad = 1; }
     if (read_word(?st.buf, 36) != 0x8802FC20) { bad = 1; }
 
-    asm_labels_dnit(?labels);
+    iasm.labels_dnit(?labels);
     encode.buf_dnit(?st.buf);
     ret bad;
 }
@@ -6429,20 +6124,20 @@ test "mach.lang.target.isa.arm64.encode:inline_asm_shift_forms" {
     var alloc: A.Allocator;
     var interner: intern.Interner;
     tasm(?st, ?alloc, ?interner);
-    var labels: AsmLabels;
-    asm_labels_init(?labels, ?alloc);
+    var labels: iasm.Labels;
+    iasm.labels_init(?labels, ?alloc);
     var f: mir.MirFunction;
 
-    encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "lsl x10, x10, #3"); # 0
-    encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "lsl w0, w1, #3");   # 4
-    encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "lsr x0, x1, #3");   # 8
-    encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "lsr w0, w1, #3");   # 12
-    encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "asr x0, x1, #3");   # 16
-    encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "asr w0, w1, #3");   # 20
-    encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "lsl x0, x1, x2");   # 24
-    encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "lsr x0, x1, x2");   # 28
-    encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "asr x0, x1, x2");   # 32
-    encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "lslv x0, x1, x2");  # 36
+    a64_asm_text(?st, ?f, ?labels, "lsl x10, x10, 3"); # 0
+    a64_asm_text(?st, ?f, ?labels, "lsl w0, w1, 3");   # 4
+    a64_asm_text(?st, ?f, ?labels, "lsr x0, x1, 3");   # 8
+    a64_asm_text(?st, ?f, ?labels, "lsr w0, w1, 3");   # 12
+    a64_asm_text(?st, ?f, ?labels, "asr x0, x1, 3");   # 16
+    a64_asm_text(?st, ?f, ?labels, "asr w0, w1, 3");   # 20
+    a64_asm_text(?st, ?f, ?labels, "lsl x0, x1, x2");   # 24
+    a64_asm_text(?st, ?f, ?labels, "lsr x0, x1, x2");   # 28
+    a64_asm_text(?st, ?f, ?labels, "asr x0, x1, x2");   # 32
+    a64_asm_text(?st, ?f, ?labels, "lslv x0, x1, x2");  # 36
 
     if (read_word(?st.buf, 0)  != 0xD37DF14A) { bad = 1; }
     if (read_word(?st.buf, 4)  != 0x531D7020) { bad = 1; }
@@ -6455,7 +6150,7 @@ test "mach.lang.target.isa.arm64.encode:inline_asm_shift_forms" {
     if (read_word(?st.buf, 32) != 0x9AC22820) { bad = 1; }
     if (read_word(?st.buf, 36) != 0x9AC22020) { bad = 1; }
 
-    asm_labels_dnit(?labels);
+    iasm.labels_dnit(?labels);
     encode.buf_dnit(?st.buf);
     ret bad;
 }
@@ -6470,8 +6165,8 @@ test "mach.lang.target.isa.arm64.encode:inline_asm_symbol_relocations_record_116
     var alloc: A.Allocator;
     var interner: intern.Interner;
     tasm(?st, ?alloc, ?interner);
-    var labels: AsmLabels;
-    asm_labels_init(?labels, ?alloc);
+    var labels: iasm.Labels;
+    iasm.labels_init(?labels, ?alloc);
     var f: mir.MirFunction;
 
     val gr: R.Result[intern.StrId, str] = intern.intern(?interner, "gsym");
@@ -6480,12 +6175,12 @@ test "mach.lang.target.isa.arm64.encode:inline_asm_symbol_relocations_record_116
     val g: intern.StrId    = R.unwrap_ok[intern.StrId, str](gr);
     val fsym: intern.StrId = R.unwrap_ok[intern.StrId, str](fr);
 
-    encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "adrp x0, gsym");            # 0
-    encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "add x0, x0, :lo12:gsym");   # 4
-    encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "bl fsym");                  # 8
-    encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "ldr x0, [x16, :lo12:gsym]"); # 12
-    encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "str w1, [x16, :lo12:gsym]"); # 16
-    encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "ldrb w0, [x16, :lo12:gsym]"); # 20
+    a64_asm_text(?st, ?f, ?labels, "adrp x0, gsym");            # 0
+    a64_asm_text(?st, ?f, ?labels, "add x0, x0, :lo12:gsym");   # 4
+    a64_asm_text(?st, ?f, ?labels, "bl fsym");                  # 8
+    a64_asm_text(?st, ?f, ?labels, "ldr x0, [x16, :lo12:gsym]"); # 12
+    a64_asm_text(?st, ?f, ?labels, "str w1, [x16, :lo12:gsym]"); # 16
+    a64_asm_text(?st, ?f, ?labels, "ldrb w0, [x16, :lo12:gsym]"); # 20
 
     if (read_word(?st.buf, 0)  != 0x90000000) { bad = 1; }
     if (read_word(?st.buf, 4)  != 0x91000000) { bad = 1; }
@@ -6507,7 +6202,7 @@ test "mach.lang.target.isa.arm64.encode:inline_asm_symbol_relocations_record_116
     if (st.relocs != nil && st.reloc_cap > 0) {
         A.deallocate[encode.PendingReloc](?alloc, st.relocs, st.reloc_cap::usize);
     }
-    asm_labels_dnit(?labels);
+    iasm.labels_dnit(?labels);
     encode.buf_dnit(?st.buf);
     ret bad;
 }
@@ -6523,16 +6218,16 @@ test "mach.lang.target.isa.arm64.encode:inline_asm_branches_to_numeric_local_lab
     var alloc: A.Allocator;
     var interner: intern.Interner;
     tasm(?st, ?alloc, ?interner);
-    var labels: AsmLabels;
-    asm_labels_init(?labels, ?alloc);
+    var labels: iasm.Labels;
+    iasm.labels_init(?labels, ?alloc);
     var f: mir.MirFunction;
 
-    encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "nop");          # 0
-    encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "cbz x0, 1f");   # 4  (forward)
-    encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "b.eq 1f");      # 8  (forward)
-    encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "1: nop");       # 12 (define label 1; patch fwd refs)
-    encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "b 1b");         # 16 (backward, imm26)
-    encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "cbnz w1, 1b");  # 20 (backward, imm19)
+    a64_asm_text(?st, ?f, ?labels, "nop");          # 0
+    a64_asm_text(?st, ?f, ?labels, "cbz x0, 1f");   # 4  (forward)
+    a64_asm_text(?st, ?f, ?labels, "b.eq 1f");      # 8  (forward)
+    a64_asm_text(?st, ?f, ?labels, "1: nop");       # 12 (define label 1; patch fwd refs)
+    a64_asm_text(?st, ?f, ?labels, "b 1b");         # 16 (backward, imm26)
+    a64_asm_text(?st, ?f, ?labels, "cbnz w1, 1b");  # 20 (backward, imm19)
 
     # cbz x0 @4 -> 12: disp 8, imm19=2 -> 0xb4000040
     if (read_word(?st.buf, 4)  != 0xB4000040) { bad = 1; }
@@ -6543,9 +6238,9 @@ test "mach.lang.target.isa.arm64.encode:inline_asm_branches_to_numeric_local_lab
     # cbnz w1 @20 -> 12: disp -8, imm19 -> 0x35ffffc1
     if (read_word(?st.buf, 20) != 0x35FFFFC1) { bad = 1; }
     # all forward references resolved.
-    if (labels.ref_count != 0) { bad = 1; }
+    if (labels.fixup_count != 0) { bad = 1; }
 
-    asm_labels_dnit(?labels);
+    iasm.labels_dnit(?labels);
     encode.buf_dnit(?st.buf);
     ret bad;
 }
@@ -6613,19 +6308,19 @@ test "mach.lang.target.isa.arm64.encode:inline_asm_bare_immediates" {
     var alloc: A.Allocator;
     var interner: intern.Interner;
     tasm(?st, ?alloc, ?interner);
-    var labels: AsmLabels;
-    asm_labels_init(?labels, ?alloc);
+    var labels: iasm.Labels;
+    iasm.labels_init(?labels, ?alloc);
     var f: mir.MirFunction;
 
-    encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "mov x8, 93");              # 0  0xd2800ba8
-    encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "add x0, x1, 5");          # 4  0x91001420
-    encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "cmp x0, 5");              # 8  0xf100141f
-    encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "svc 0");                  # 12 0xd4000001
-    encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "movz x0, 0x1234, lsl 16"); # 16 0xd2a24680
-    encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "ldr x0, [x1, 8]");        # 20 0xf9400420
-    encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "str x0, [x1, -8]");       # 24 0xf81f8020
-    encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "stp x29, x30, [sp, -16]!"); # 28 0xa9bf7bfd
-    encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "ldp x29, x30, [sp], 16");   # 32 0xa8c17bfd
+    a64_asm_text(?st, ?f, ?labels, "mov x8, 93");              # 0  0xd2800ba8
+    a64_asm_text(?st, ?f, ?labels, "add x0, x1, 5");          # 4  0x91001420
+    a64_asm_text(?st, ?f, ?labels, "cmp x0, 5");              # 8  0xf100141f
+    a64_asm_text(?st, ?f, ?labels, "svc 0");                  # 12 0xd4000001
+    a64_asm_text(?st, ?f, ?labels, "movz x0, 0x1234, lsl 16"); # 16 0xd2a24680
+    a64_asm_text(?st, ?f, ?labels, "ldr x0, [x1, 8]");        # 20 0xf9400420
+    a64_asm_text(?st, ?f, ?labels, "str x0, [x1, -8]");       # 24 0xf81f8020
+    a64_asm_text(?st, ?f, ?labels, "stp x29, x30, [sp, -16]!"); # 28 0xa9bf7bfd
+    a64_asm_text(?st, ?f, ?labels, "ldp x29, x30, [sp], 16");   # 32 0xa8c17bfd
 
     if (read_word(?st.buf, 0)  != 0xD2800BA8) { bad = 1; }
     if (read_word(?st.buf, 4)  != 0x91001420) { bad = 1; }
@@ -6637,7 +6332,7 @@ test "mach.lang.target.isa.arm64.encode:inline_asm_bare_immediates" {
     if (read_word(?st.buf, 28) != 0xA9BF7BFD) { bad = 1; }
     if (read_word(?st.buf, 32) != 0xA8C17BFD) { bad = 1; }
 
-    asm_labels_dnit(?labels);
+    iasm.labels_dnit(?labels);
     encode.buf_dnit(?st.buf);
     ret bad;
 }
@@ -6652,23 +6347,143 @@ test "mach.lang.target.isa.arm64.encode:inline_asm_rejects_unknown_mnemonic_and_
     var alloc: A.Allocator;
     var interner: intern.Interner;
     tasm(?st, ?alloc, ?interner);
-    var labels: AsmLabels;
-    asm_labels_init(?labels, ?alloc);
+    var labels: iasm.Labels;
+    iasm.labels_init(?labels, ?alloc);
     var f: mir.MirFunction;
 
-    val r1: R.Result[bool, str] = encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "frobnicate x0, x1");
+    val r1: R.Result[bool, str] = a64_asm_text(?st, ?f, ?labels, "frobnicate x0, x1");
     if (!R.is_err[bool, str](r1))                                                                   { bad = 1; }
-    or { if (!str_contains(R.unwrap_err[bool, str](r1), "unsupported aarch64 inline-asm mnemonic")) { bad = 1; } }
+    or { if (!str_contains(R.unwrap_err[bool, str](r1), "unknown aarch64 inline-asm instruction")) { bad = 1; } }
 
-    val r2: R.Result[bool, str] = encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "cbz x0, some_symbol");
+    val r2: R.Result[bool, str] = a64_asm_text(?st, ?f, ?labels, "cbz x0, some_symbol");
     if (!R.is_err[bool, str](r2))                                                    { bad = 1; }
     or { if (!str_contains(R.unwrap_err[bool, str](r2), "no imm19 relocation kind")) { bad = 1; } }
 
-    val r3: R.Result[bool, str] = encode_asm_stmt_arm64(?st, ?f, 0, ?labels, "b.eq some_symbol");
+    val r3: R.Result[bool, str] = a64_asm_text(?st, ?f, ?labels, "b.eq some_symbol");
     if (!R.is_err[bool, str](r3)) { bad = 1; }
 
-    asm_labels_dnit(?labels);
+    iasm.labels_dnit(?labels);
     encode.buf_dnit(?st.buf);
+    ret bad;
+}
+
+# the inline-asm effect model classifies the A64 statement grammar: a linking branch
+# destroys the caller-saved file, `svc` the kernel's return register, a
+# destination-writing form its first operand, a pair load both of its loaded
+# registers plus the base it writes back, and a body the assembler could not read
+# everything
+test "mach.lang.target.isa.arm64.encode:asm_clobbers_classification" {
+    var bad: i32 = 0;
+    var gp: u32 = 0;
+    var fp: u32 = 0;
+
+    # a load + store + call body: ldr writes x0, str writes memory, the call destroys
+    # the caller-saved file.
+    asm_clobbers("ldr x0, [x1]\nstr x0, [x1, 8]\nbl main", ?gp, ?fp);
+    if ((gp & 1) == 0)                              { bad = 1; }  # x0 written by ldr
+    if ((gp & A64_CALLER_SAVED) != A64_CALLER_SAVED) { bad = 1; }
+    if (fp != 0) { bad = 1; }
+
+    # a supervisor call writes the kernel's return register and nothing else.
+    gp = 0; fp = 0;
+    asm_clobbers("mov x8, 93\nsvc 0", ?gp, ?fp);
+    if (gp != ((1::u32 << 8) | 1)) { bad = 1; }
+
+    # a `{name}` binding is a stack slot, so it names no register; the destination
+    # register beside it is still credited even before the frame is laid out.
+    gp = 0; fp = 0;
+    asm_clobbers("ldr x0, {v}\nstr x1, {out}", ?gp, ?fp);
+    if (gp != 1) { bad = 1; }
+
+    # a store-release-exclusive writes its status register; a compare, a barrier and
+    # a plain store write none.
+    gp = 0; fp = 0;
+    asm_clobbers("dmb ish\ncmp x0, x1\nstlr x9, [x12]\nstlxr w11, x10, [x12]", ?gp, ?fp);
+    if (gp != (1::u32 << 11)) { bad = 1; }
+
+    # a pair load writes both loaded registers, and a writeback form its base too.
+    gp = 0; fp = 0;
+    asm_clobbers("ldp x1, x2, [sp], 16", ?gp, ?fp);
+    if (gp != ((1::u32 << 1) | (1::u32 << 2) | (1::u32 << 31))) { bad = 1; }
+    gp = 0; fp = 0;
+    asm_clobbers("stp x1, x2, [sp, -16]!", ?gp, ?fp);
+    if (gp != (1::u32 << 31)) { bad = 1; }
+    gp = 0; fp = 0;
+    asm_clobbers("stp x1, x2, [sp, 16]", ?gp, ?fp);
+    if (gp != 0) { bad = 1; }
+
+    # an unrecognized statement conservatively clobbers everything.
+    gp = 0; fp = 0;
+    asm_clobbers("frobnicate x0, x1", ?gp, ?fp);
+    if (gp != 0xFFFFFFFF) { bad = 1; }
+    if (fp != 0xFFFFFFFF) { bad = 1; }
+    ret bad;
+}
+
+# the parse accounts for every byte of a statement or refuses it: an operand the
+# grammar does not reach cannot be silently dropped
+test "mach.lang.target.isa.arm64.encode:asm_byte_accounting" {
+    var bad: i32 = 0;
+    var gp: u32 = 0;
+    var fp: u32 = 0;
+
+    # a trailing token no operand claims fails the accounting.
+    asm_clobbers("add x0, x1, x2 junk", ?gp, ?fp);
+    if (gp != 0xFFFFFFFF) { bad = 1; }
+
+    # a no-operand form given operands is refused rather than assembled bare.
+    gp = 0; fp = 0;
+    asm_clobbers("nop 1", ?gp, ?fp);
+    if (gp != 0xFFFFFFFF) { bad = 1; }
+
+    # a well-formed statement claims all of itself, separators and whitespace aside.
+    gp = 0; fp = 0;
+    asm_clobbers("  add x0 , x1 , x2  ;  mov x3, x4  ", ?gp, ?fp);
+    if (gp != (1 | (1::u32 << 3))) { bad = 1; }
+    ret bad;
+}
+
+# a relocation modifier is read back into the shared `isa.SymModifier` the encoder's
+# own notifications carry, so what `--emit-asm` prints for a page-relative symbol
+# pair is what this parser reads. the GOT-indirect pair (#2026) has both halves
+test "mach.lang.target.isa.arm64.encode:asm_relocation_modifiers" {
+    var bad: i32 = 0;
+    var st: encode.EncodeState;
+    var alloc: A.Allocator;
+    var interner: intern.Interner;
+    tasm(?st, ?alloc, ?interner);
+    var labels: iasm.Labels;
+    iasm.labels_init(?labels, ?alloc);
+    var f: mir.MirFunction;
+
+    # adrp x0, :got:foo = 0x90000000 (RK_GOT_PAGE21);
+    # ldr x0, [x0, :got_lo12:foo] = 0xf9400000 (RK_GOT_LO12).
+    val ar: R.Result[bool, str] = a64_asm_text(?st, ?f, ?labels, "adrp x0, :got:foo");
+    if (R.is_err[bool, str](ar)) { bad = 1; }
+    val lr: R.Result[bool, str] = a64_asm_text(?st, ?f, ?labels, "ldr x0, [x0, :got_lo12:foo]");
+    if (R.is_err[bool, str](lr)) { bad = 1; }
+    if (read_word(?st.buf, 0) != 0x90000000) { bad = 1; }
+    if (read_word(?st.buf, 4) != 0xF9400000) { bad = 1; }
+    if (st.reloc_count != 2) { bad = 1; }
+    or {
+        if (st.relocs[0].kind != of.RK_GOT_PAGE21) { bad = 1; }
+        if (st.relocs[1].kind != of.RK_GOT_LO12)   { bad = 1; }
+    }
+
+    # an unknown modifier is refused by name rather than read as a bare symbol.
+    val br: R.Result[bool, str] = a64_asm_text(?st, ?f, ?labels, "adrp x0, :bogus:foo");
+    if (!R.is_err[bool, str](br)) { bad = 1; }
+    or { if (!str_contains(R.unwrap_err[bool, str](br), "unsupported aarch64 inline-asm relocation modifier")) { bad = 1; } }
+
+    # `adrp` names a page, so a low-half modifier on it is a mistake, not a page.
+    val lo: R.Result[bool, str] = a64_asm_text(?st, ?f, ?labels, "adrp x0, :lo12:foo");
+    if (!R.is_err[bool, str](lo)) { bad = 1; }
+
+    iasm.labels_dnit(?labels);
+    encode.buf_dnit(?st.buf);
+    if (st.relocs != nil && st.reloc_cap > 0) {
+        A.deallocate[encode.PendingReloc](?alloc, st.relocs, st.reloc_cap::usize);
+    }
     ret bad;
 }
 

--- a/src/lang/target/isa/arm64/encode.mach
+++ b/src/lang/target/isa/arm64/encode.mach
@@ -4335,6 +4335,7 @@ fun a64_patch(st: *encode.EncodeState, patch_pos: u32, target_off: u32) R.Result
 fun a64_grammar() iasm.Grammar {
     var g: iasm.Grammar;
     g.isa       = "aarch64";
+    g.unknown   = "unknown aarch64 inline-asm instruction '";
     g.rows      = ?A64_MNEMONICS[0];
     g.row_count = A64_MNEMONIC_COUNT;
     g.decode    = a64_decode_bcond;

--- a/src/lang/target/isa/asm.mach
+++ b/src/lang/target/isa/asm.mach
@@ -47,6 +47,7 @@ use std.types.bool.true;
 use std.types.char.char;
 use std.types.size.usize;
 use std.types.string.str;
+use std.types.string.str_equals;
 use std.types.string.str_len;
 use std.types.string.str_region_equals;
 
@@ -200,6 +201,12 @@ pub val AR_LOCAL: u8 = 2;  # a numeric local label within this block
 # turns its write facts plus its operands into a register set. `src_off` / `src_len`
 # are the body bytes this item claims, which is what makes the parse's totality
 # checkable rather than assumed.
+#
+# `writes` and `words` start as the mnemonic row's defaults and the ISA's parser may
+# refine either once it knows the operand shape - `jalr rs` links through a register
+# the row cannot name, and an aarch64 `mov` is one instruction or a materialization
+# sequence depending on its source. The refinement is stated where the shape is
+# known; nothing downstream re-derives it.
 # ---
 # kind:       one of AI_*
 # code:       the instruction the item denotes, in the ISA's own space
@@ -437,7 +444,7 @@ pub fun is_digit(c: char) bool { ret c >= '0'::char && c <= '9'::char; }
 
 # true for a character allowed inside a bare symbol name
 pub fun is_sym_char(c: char) bool {
-    ret c == '_'::char || c == '.'::char || c == '$'::char ||
+    ret c == '_'::char || c == '.'::char ||
         (c >= 'a'::char && c <= 'z'::char) ||
         (c >= 'A'::char && c <= 'Z'::char) ||
         (c >= '0'::char && c <= '9'::char);
@@ -1232,7 +1239,7 @@ pub fun encode_block(st: *encode.EncodeState, g: *Grammar, f: *mir.MirFunction, 
 
     # only this ISA's tag is encodable here; a mismatched tag means a comptime arch
     # guard failed to select the right block.
-    if (!str_region_equals(pl.isa, 0, str_len(g.isa), g.isa) || str_len(pl.isa) != str_len(g.isa)) {
+    if (!str_equals(pl.isa, g.isa)) {
         ret R.err[bool, str](encode.asm_located_message(st, mi.loc,
             named_message(st.alloc, st.interner, "encode: inline-asm block is not ", g.isa, "",
                           "encode: inline-asm block is not for this target")));

--- a/src/lang/target/isa/asm.mach
+++ b/src/lang/target/isa/asm.mach
@@ -1,0 +1,1345 @@
+# the shared inline-assembly parser - text back into the machine model
+#
+# One parser, parameterized per ISA, rather than one per target. `asm x86_64 { ... }`,
+# `asm riscv64 { ... }` and `asm aarch64 { ... }` are the same grammar with three
+# instruction sets: statements separated by newlines and `;`, a mnemonic, a
+# comma-separated operand list, GNU-as numeric local labels (`1:` / `1f` / `1b`), and
+# `{name}` references binding the block to the function's locals. Everything in that
+# sentence lives here; what differs per target is the instruction set, the operand
+# syntax, and the register names.
+#
+# The split, stated once so a target cannot quietly re-implement the shared half:
+#
+#   SHARED (this module)          the statement cursor and its byte accounting, the
+#                                 mnemonic table walk, top-level operand splitting,
+#                                 numeric-local-label scope and resolution, `{name}`
+#                                 binding, the effect (clobber) fold, the block
+#                                 driver, and every diagnostic.
+#   PER-ISA (the `Grammar`)       the mnemonic table (what each mnemonic denotes, its
+#                                 register-write facts, how many words it emits),
+#                                 the operand lexer (register names, `[base + i*s +
+#                                 d]` versus `d(base)` versus `[Xn, #d]`, relocation
+#                                 modifiers), and the emitter.
+#
+# TOTALITY IS CHECKED, NOT ASSUMED. Every byte of a body must be claimed by exactly
+# one parsed item, with only whitespace and statement separators between claims, or
+# the block is refused naming the instruction that failed to account for itself.
+# There is no permissive path and no silent fallback: a body the parser cannot read
+# in full is a build error, never bytes nobody described.
+#
+# A fixed-width target admits a second, stronger invariant on the emit side: a
+# mnemonic row declares how many instruction words its form emits, and the driver
+# refuses a form that emitted a different number. What that does NOT catch is a form
+# declaring `WORDS_VARIABLE` (riscv64's `li`, whose length is a property of the
+# immediate), and it does not apply at all to a variable-length encoding like
+# x86-64's, where no such count exists ahead of the encoder.
+#
+# CONSERVATIVE BY DEFAULT. An unrecognized mnemonic refuses the block. A byte stream
+# the parser cannot read (a raw `.byte` payload) writes every register in every bank.
+# Precision is earned per mnemonic, on that mnemonic's own table row, and never
+# credited by category - `opaque-and-slow` is safe, `modeled-and-wrong` is a
+# miscompile.
+
+use std.text.parse;
+use std.types.bool.bool;
+use std.types.bool.false;
+use std.types.bool.true;
+use std.types.char.char;
+use std.types.size.usize;
+use std.types.string.str;
+use std.types.string.str_len;
+use std.types.string.str_region_equals;
+
+use A: std.allocator;
+use O: std.types.option;
+use R: std.types.result;
+
+use mach.lang.be.codegen.encode;
+use mach.lang.be.codegen.mir;
+use mach.lang.intern;
+use mach.lang.target.isa;
+
+# the widest operand list the shared splitter accepts
+#
+# Four is the widest form any supported target spells: aarch64's post-index
+# `ldp Xa, Xb, [Xn], #imm`. A statement naming more is refused rather than truncated.
+pub val MAX_OPS: usize = 4;
+
+# longest inline-asm statement the parser accepts, in bytes
+pub val STMT_MAX: usize = 512;
+
+# most raw bytes one `.byte` directive can carry
+#
+# Derived, not chosen: a value needs at least a digit and a separator, so a statement
+# bounded by `STMT_MAX` can never name more than half that many.
+pub val BYTES_MAX: usize = STMT_MAX / 2;
+
+# the kind of a parsed inline-asm operand
+#
+# The parse-time superset of `isa.Operand`: it additionally names a bare symbol
+# (which the encoder resolves to a relocation rather than to an addressing mode) and
+# an unresolved `{name}` binding, whose frame slot is only known once the frame is
+# laid out.
+pub val AOP_NONE: u8 = 0;  # no operand parsed
+pub val AOP_REG:  u8 = 1;  # a register
+pub val AOP_IMM:  u8 = 2;  # an immediate constant
+pub val AOP_MEM:  u8 = 3;  # a memory reference
+pub val AOP_SYM:  u8 = 4;  # a bare symbol / branch-target name
+pub val AOP_BIND: u8 = 5;  # a `{name}` local whose frame slot is not yet known
+
+# operand decorations an ISA's lexer sets and its emitter reads
+#
+# The addressing facts the shared model needs to know about (does this memory operand
+# name a symbol, does it write its base back) plus the two register facts a target
+# cannot express in `reg` alone. A bit not listed here does not exist: two ISAs each
+# appending "the next flag" to a private space is how two unrelated flags have already
+# landed on the same bit (#2137).
+pub val AOF_MEM_SYM:   u8 = 0x01;  # a memory operand addresses a symbol (`name_off` set)
+pub val AOF_HAS_DISP:  u8 = 0x02;  # a memory operand carries an explicit displacement
+pub val AOF_HAS_INDEX: u8 = 0x04;  # a memory operand carries an index register
+pub val AOF_WRITEBACK: u8 = 0x08;  # the access writes its updated base register back
+pub val AOF_STACK_PTR: u8 = 0x10;  # the register names the stack pointer, not the zero register
+pub val AOF_WIDE:      u8 = 0x20;  # the index register is the wide (64-bit) form
+
+# a parsed inline-asm operand
+#
+# Names are spans into the asm body, not copies, so the interned body is the single
+# backing store for a parse.
+# ---
+# kind:     one of AOP_*
+# reg:      register id for AOP_REG, or the base register for AOP_MEM (-1 when none)
+# size:     operand width in bytes
+# imm:      immediate value for AOP_IMM, or the displacement for AOP_MEM
+# index:    scaled-index register for AOP_MEM (-1 when none)
+# scale:    index scale for AOP_MEM (1, 2, 4 or 8; 0 when no index)
+# mod:      the relocation modifier a symbol-bearing operand carries
+# flags:    AOF_* decorations
+# name_off: body offset of the symbol or binding name this operand carries
+# name_len: length in bytes of that name
+pub rec Operand {
+    kind:     u8;
+    reg:      i32;
+    size:     u8;
+    imm:      i64;
+    index:    i32;
+    scale:    u8;
+    mod:      isa.SymModifier;
+    flags:    u8;
+    name_off: usize;
+    name_len: usize;
+}
+
+# the operand shape a mnemonic takes, as the shared cursor reads it
+#
+# The cursor distinguishes only three cases: a mnemonic that is the whole statement,
+# a raw byte directive, and everything else (split the operand list and hand it to
+# the ISA). A target's finer distinctions - one operand versus two, a branch target
+# versus a register - are its own, carried in `Mnemonic.code` and read by its parser.
+pub val AF_NONE:  u8 = 0;  # no operands; the mnemonic is the whole statement
+pub val AF_OPS:   u8 = 1;  # a comma-separated operand list the ISA parses
+pub val AF_BYTES: u8 = 2;  # a `.byte b, b, ...` raw payload
+
+# a form whose emitted instruction-word count is a property of its operands rather
+# than of the mnemonic, so no count can be checked against it
+pub val WORDS_VARIABLE: u8 = 0;
+
+# the registers a mnemonic writes, as a flag set over its own operands
+#
+# Every fact is stated per mnemonic, never per category, and always relative to the
+# operands as written. Condition flags are not modeled - the allocator holds no value
+# in them. Registers a form writes regardless of its operands (a syscall's return
+# register, a call's caller-saved file) ride `Mnemonic.implicit` instead.
+pub val AW_NONE:    u8 = 0x00;  # writes no register (flags, memory or control only)
+pub val AW_OP0:     u8 = 0x01;  # writes its first operand
+pub val AW_OP1:     u8 = 0x02;  # writes its second operand
+pub val AW_WB_BASE: u8 = 0x04;  # writes the base of a writeback memory operand
+
+# one mnemonic: its text, the instruction it denotes, its operand shape, and its
+# register-write facts
+#
+# The single table the parser, the emitter and the effect model all read, so an
+# instruction's encoding and its effects can never describe different instructions.
+# An alias (`jz` for `je`, `mv` for `addi rd, rs, 0`) is its own row naming the same
+# instruction.
+# ---
+# name:     the mnemonic text as written (nil for a row a decoder synthesized)
+# code:     the instruction the mnemonic denotes, in the ISA's own space
+# form:     AF_*, the operand shape the cursor reads
+# writes:   AW_*, the registers the form writes among its own operands
+# implicit: registers the form writes regardless of its operands, as a bitmask
+# flags:    encoding flags the mnemonic itself implies, in the ISA's own space
+# words:    instruction words the form emits, or WORDS_VARIABLE
+pub rec Mnemonic {
+    name:     str;
+    code:     u32;
+    form:     u8;
+    writes:   u8;
+    implicit: u32;
+    flags:    u16;
+    words:    u8;
+}
+
+# the parse outcomes one statement can have
+pub val AI_INST:   u8 = 0;  # a modeled machine instruction
+pub val AI_LABEL:  u8 = 1;  # a numeric local-label definition
+pub val AI_BYTES:  u8 = 2;  # a raw byte directive's payload
+# a statement whose mnemonic is known but whose operands are not resolvable - a
+# `{name}` binding parsed before the frame is laid out, on a target whose effect
+# model does not attempt to model one. the instruction is not modeled, so its
+# effects fall back to everything the target's inline grammar can reach
+pub val AI_OPAQUE: u8 = 3;
+
+# what a parsed instruction still needs the encoder to resolve
+pub val AR_NONE:  u8 = 0;  # nothing: the instruction is self-contained
+pub val AR_SYM:   u8 = 1;  # a named symbol the linker resolves
+pub val AR_LOCAL: u8 = 2;  # a numeric local label within this block
+
+# one parsed inline-asm statement
+#
+# The unit both consumers read: the emitter turns it into bytes, the effect model
+# turns its write facts plus its operands into a register set. `src_off` / `src_len`
+# are the body bytes this item claims, which is what makes the parse's totality
+# checkable rather than assumed.
+# ---
+# kind:       one of AI_*
+# code:       the instruction the item denotes, in the ISA's own space
+# flags:      encoding flags, in the ISA's own space
+# writes:     AW_* register-write facts
+# implicit:   registers written regardless of the operands
+# words:      instruction words the form emits, or WORDS_VARIABLE
+# ops:        the parsed operands
+# nops:       number of operands parsed
+# ref:        what the emitter must still resolve (AR_*)
+# ref_off:    body offset of the referenced symbol name (AR_SYM)
+# ref_len:    length of that name
+# ref_mod:    the relocation modifier that symbol reference carries
+# ref_num:    the numeric local label (AR_LOCAL, or the label AI_LABEL defines)
+# ref_fwd:    true when an AR_LOCAL reference is forward (`<digits>f`)
+# bytes:      the raw byte payload (AI_BYTES)
+# byte_count: number of payload bytes
+# src_off:    body offset of the statement text this item claims
+# src_len:    length of that text
+pub rec Item {
+    kind:       u8;
+    code:       u32;
+    flags:      u16;
+    writes:     u8;
+    implicit:   u32;
+    words:      u8;
+    ops:        [MAX_OPS]Operand;
+    nops:       u32;
+    ref:        u8;
+    ref_off:    usize;
+    ref_len:    usize;
+    ref_mod:    isa.SymModifier;
+    ref_num:    u64;
+    ref_fwd:    bool;
+    bytes:      [BYTES_MAX]u8;
+    byte_count: usize;
+    src_off:    usize;
+    src_len:    usize;
+}
+
+# one statement as the shared cursor resolved it, before the ISA reads its operands
+#
+# The cursor has already matched the mnemonic, claimed its bytes, and split and
+# claimed the operand tokens; the ISA's parser turns those spans into operands.
+# ---
+# m:      the matched mnemonic row
+# lo:     body offset the statement starts at
+# hi:     body offset just past the statement
+# arg_lo: body offset each operand token starts at
+# arg_hi: body offset just past each operand token
+# nargs:  number of operand tokens
+pub rec Stmt {
+    m:      Mnemonic;
+    lo:     usize;
+    hi:     usize;
+    arg_lo: [MAX_OPS]usize;
+    arg_hi: [MAX_OPS]usize;
+    nargs:  u32;
+}
+
+# a cursor over an inline-asm body, yielding one `Item` per statement
+#
+# The parse runs twice over the same text through the same code: once before
+# register allocation to derive the block's effects, and once after frame layout to
+# emit bytes. That is what makes the instructions the compiler reasons about and the
+# ones it emits the same instructions.
+#
+# `f` / `pl` supply the `{name}` binding context. They are nil before the frame is
+# laid out, where a binding's stack displacement genuinely is not yet known.
+#
+# `claimed` is the accounting watermark - the body offset through which every byte
+# has been claimed by exactly one item. Anything below it that no item claimed must
+# be inter-statement whitespace or a separator, or the block is refused.
+# ---
+# body:     the comment-stripped inline-asm body text
+# len:      length of the body
+# pos:      cursor: the next body byte to consider
+# claimed:  accounting watermark
+# alloc:    allocator for diagnostic construction, or nil
+# interner: interner diagnostics are built in, or nil (messages degrade to a fixed
+#           form the encoder later reissues located)
+# f:        the function whose laid-out frame resolves a `{name}`, or nil
+# pl:       the block's `{name}` bindings, or nil
+# g:        the target's grammar
+pub rec Cursor {
+    body:     str;
+    len:      usize;
+    pos:      usize;
+    claimed:  usize;
+    alloc:    *A.Allocator;
+    interner: *intern.Interner;
+    f:        *mir.MirFunction;
+    pl:       *mir.MirAsm;
+    g:        *Grammar;
+}
+
+# decode a mnemonic the table cannot enumerate, synthesizing its row
+#
+# The escape hatch for a suffixed family whose spelling is combinatorial:
+# riscv64's `amoadd.d.aqrl` (base x width x ordering) and aarch64's `b.<cond>`. It
+# reads `body[lo..hi)`, and on a match fills the row and the mnemonic's byte length.
+# A target with no such family leaves this nil.
+pub def DecodeFn: fun(str, usize, usize, *Mnemonic, *usize) bool;
+
+# turn one resolved statement into a parsed item
+#
+# The ISA's operand lexer. The mnemonic and every operand token have already been
+# matched and claimed, so this reads spans and fills `Item`; it must not claim.
+pub def ParseFn: fun(*Cursor, *Stmt, *Item) R.Result[bool, str];
+
+# emit one parsed item's machine bytes
+#
+# The ISA's assembler. It runs after frame layout, through the same emitters the
+# instruction selector drives, so an inline-asm instruction and a compiler-selected
+# one are the same value taking the same path.
+pub def EmitFn: fun(*encode.EncodeState, *Cursor, *Labels, *Item) R.Result[bool, str];
+
+# insert the displacement from a branch at `patch_pos` to a target at `target_off`
+#
+# The ISA's branch-fixup hook, reached when a numeric local label resolves. Both
+# offsets are `.text`-relative.
+pub def PatchFn: fun(*encode.EncodeState, u32, u32) R.Result[bool, str];
+
+# the frame-pointer-relative offset of the slot a MIR value owns, or none
+#
+# Per-ISA and not an accident: the offset a slot sits at relative to the frame
+# pointer depends on what that target's prologue reserves between the two - x86-64
+# reserves nothing below RBP, riscv64 pins s0 at the frame top with the ra / s0
+# record and the callee-saved areas beneath it. A shared implementation would resolve
+# `{name}` to a different address than the same target's own loads and stores.
+pub def SlotFn: fun(*mir.MirFunction, u32) O.Option[i64];
+
+# one target's inline-assembly grammar
+#
+# Everything the shared parser needs that is not the same on every machine. A target
+# that accepts inline asm builds one of these; a target that does not (`mos6502`
+# today, spir-v by construction) needs none, which is what makes the parser a
+# capability rather than a tax on every new target (#2212).
+# ---
+# isa:       the ISA tag the `asm` block spells, and the name diagnostics use
+# rows:      the mnemonic table
+# row_count: number of rows
+# decode:    the suffixed-family decoder, or nil
+# parse:     the operand lexer
+# emit:      the assembler
+# patch:     the branch-displacement insert
+# slot:      the frame-pointer-relative offset of a local's stack slot
+# all_gp:    every general-purpose register the grammar can reach
+# all_fp:    every float / vector register an unreadable byte stream could reach
+# word:      the instruction word size in bytes, or 0 for a variable-length encoding
+pub rec Grammar {
+    isa:       str;
+    rows:      *Mnemonic;
+    row_count: usize;
+    decode:    DecodeFn;
+    parse:     ParseFn;
+    emit:      EmitFn;
+    patch:     PatchFn;
+    slot:      SlotFn;
+    all_gp:    u32;
+    all_fp:    u32;
+    word:      u8;
+}
+
+# an operand in the neutral state each lexer fills in
+pub fun op_none() Operand {
+    var op: Operand;
+    op.kind     = AOP_NONE;
+    op.reg      = -1;
+    op.size     = 0;
+    op.imm      = 0;
+    op.index    = -1;
+    op.scale    = 0;
+    op.mod      = isa.SYM_MOD_NONE;
+    op.flags    = 0;
+    op.name_off = 0;
+    op.name_len = 0;
+    ret op;
+}
+
+# a register operand
+pub fun op_reg(reg: i32, size: u8) Operand {
+    var op: Operand = op_none();
+    op.kind = AOP_REG;
+    op.reg  = reg;
+    op.size = size;
+    ret op;
+}
+
+# an immediate operand
+pub fun op_imm(v: i64, size: u8) Operand {
+    var op: Operand = op_none();
+    op.kind = AOP_IMM;
+    op.imm  = v;
+    op.size = size;
+    ret op;
+}
+
+# a `base + index*scale + disp` memory operand
+pub fun op_mem(base: i32, disp: i64, index: i32, scale: u8, size: u8) Operand {
+    var op: Operand = op_none();
+    op.kind  = AOP_MEM;
+    op.reg   = base;
+    op.imm   = disp;
+    op.index = index;
+    op.scale = scale;
+    op.size  = size;
+    ret op;
+}
+
+# a bare symbol operand carrying `mod`
+pub fun op_sym(name_off: usize, name_len: usize, mod: isa.SymModifier, size: u8) Operand {
+    var op: Operand = op_none();
+    op.kind     = AOP_SYM;
+    op.name_off = name_off;
+    op.name_len = name_len;
+    op.mod      = mod;
+    op.size     = size;
+    ret op;
+}
+
+# true for the ASCII whitespace the asm tokenizer trims
+pub fun is_space(c: char) bool {
+    ret c == ' '::char || c == '\t'::char || c == '\r'::char;
+}
+
+# true for a byte that may lie between statements: whitespace, a newline, or the `;`
+# statement separator. every other byte must be claimed by an item
+pub fun is_skip(c: char) bool {
+    ret is_space(c) || c == '\n'::char || c == ';'::char;
+}
+
+# true for an ASCII decimal digit
+pub fun is_digit(c: char) bool { ret c >= '0'::char && c <= '9'::char; }
+
+# true for a character allowed inside a bare symbol name
+pub fun is_sym_char(c: char) bool {
+    ret c == '_'::char || c == '.'::char || c == '$'::char ||
+        (c >= 'a'::char && c <= 'z'::char) ||
+        (c >= 'A'::char && c <= 'Z'::char) ||
+        (c >= '0'::char && c <= '9'::char);
+}
+
+# true when `s[lo..hi)` is a valid bare symbol name: the leading character a letter
+# or underscore, the rest symbol characters
+pub fun is_sym_region(s: str, lo: usize, hi: usize) bool {
+    if (hi <= lo) { ret false; }
+    val c0: char = s[lo];
+    if (!(c0 == '_'::char || (c0 >= 'a'::char && c0 <= 'z'::char) || (c0 >= 'A'::char && c0 <= 'Z'::char))) {
+        ret false;
+    }
+    var i: usize = lo + 1;
+    for (i < hi) {
+        if (!is_sym_char(s[i])) { ret false; }
+        i = i + 1;
+    }
+    ret true;
+}
+
+# copy `s[lo..hi)`, trimming surrounding whitespace, into `dst` as a NUL-terminated
+# string. returns false on an empty or oversized slice
+pub fun copy_region(s: str, lo: usize, hi: usize, dst: *u8, cap: usize) bool {
+    var a: usize = lo;
+    var b: usize = hi;
+    for (a < b && is_space(s[a])) { a = a + 1; }
+    for (b > a && is_space(s[b - 1])) { b = b - 1; }
+    val n: usize = b - a;
+    if (n == 0 || n + 1 > cap) { ret false; }
+    var i: usize = 0;
+    for (i < n) { dst[i] = s[a + i]::u8; i = i + 1; }
+    dst[n] = 0;
+    ret true;
+}
+
+# parse `s[lo..hi)` as a signed integer literal in any base the shared literal
+# reader accepts, returning none when the region is not exactly one
+pub fun region_i64(s: str, lo: usize, hi: usize) O.Option[i64] {
+    var buf: [40]u8;
+    if (!copy_region(s, lo, hi, ?buf[0], 40)) { ret O.none[i64](); }
+    val r: R.Result[i64, str] = parse.parse_i64_exact((?buf[0])::str, 0);
+    if (R.is_err[i64, str](r)) { ret O.none[i64](); }
+    ret O.some[i64](R.unwrap_ok[i64, str](r));
+}
+
+# build "<prefix><name><suffix>", interned so the message outlives this call
+#
+# Degrades to `fallback` when no interner is available - the effect derivation, whose
+# caller reports nothing; the encoder re-parses the same body and reissues the
+# message with its source location.
+# ---
+# alloc:    allocator the message is built in
+# interner: interner the message is interned into, or nil
+# prefix:   text before the name
+# name:     the named entity (an instruction, an operand, a symbol)
+# suffix:   text after the name
+# fallback: the message to use when no interner is available or building fails
+pub fun named_message(alloc: *A.Allocator, interner: *intern.Interner, prefix: str, name: str,
+                      suffix: str, fallback: str) str {
+    if (interner == nil || name == nil) { ret fallback; }
+    val lp: usize = str_len(prefix);
+    val ln: usize = str_len(name);
+    val ls: usize = str_len(suffix);
+    val total: usize = lp + ln + ls;
+
+    val r: R.Result[*u8, str] = A.allocate[u8](alloc, total + 1);
+    if (R.is_err[*u8, str](r)) { ret fallback; }
+    val buf: *u8 = R.unwrap_ok[*u8, str](r);
+    var k: usize = 0;
+    var j: usize = 0;
+    for (j < lp) { buf[k] = prefix[j]::u8; k = k + 1; j = j + 1; }
+    j = 0;
+    for (j < ln) { buf[k] = name[j]::u8; k = k + 1; j = j + 1; }
+    j = 0;
+    for (j < ls) { buf[k] = suffix[j]::u8; k = k + 1; j = j + 1; }
+    buf[total] = 0;
+
+    val ir: R.Result[intern.StrId, str] = intern.intern(interner, buf::str);
+    A.deallocate[u8](alloc, buf, total + 1);
+    if (R.is_err[intern.StrId, str](ir)) { ret fallback; }
+    val nm: O.Option[str] = intern.lookup(interner, R.unwrap_ok[intern.StrId, str](ir));
+    if (O.is_some[str](nm)) { ret O.unwrap[str](nm); }
+    ret fallback;
+}
+
+# build "<prefix><body[lo..hi)><suffix>" for a span of the body being parsed
+pub fun span_message(c: *Cursor, prefix: str, lo: usize, hi: usize, suffix: str, fallback: str) str {
+    if (c.interner == nil) { ret fallback; }
+    var buf: [STMT_MAX]u8;
+    if (!copy_region(c.body, lo, hi, ?buf[0], STMT_MAX)) { ret fallback; }
+    ret named_message(c.alloc, c.interner, prefix, (?buf[0])::str, suffix, fallback);
+}
+
+# start a parse over `body`
+#
+# `f` and `pl` are the binding context: pass both to resolve `{name}` against a
+# laid-out frame, or nil to parse before the frame exists.
+# ---
+# c:        the cursor to initialize
+# g:        the target's grammar
+# body:     the comment-stripped inline-asm body
+# alloc:    allocator for diagnostics, or nil
+# interner: interner for diagnostics, or nil
+# f:        function supplying the laid-out frame, or nil
+# pl:       the block's inline-asm payload carrying its bindings, or nil
+pub fun cursor_init(c: *Cursor, g: *Grammar, body: str, alloc: *A.Allocator,
+                    interner: *intern.Interner, f: *mir.MirFunction, pl: *mir.MirAsm) {
+    c.body     = body;
+    c.len      = str_len(body);
+    c.pos      = 0;
+    c.claimed  = 0;
+    c.alloc    = alloc;
+    c.interner = interner;
+    c.f        = f;
+    c.pl       = pl;
+    c.g        = g;
+}
+
+# claim `body[off .. off+len)` for the item being parsed
+#
+# The accounting guard. It refuses a claim overlapping an earlier one, and refuses a
+# gap of unclaimed bytes that are not inter-statement filler - so at the end of a
+# parse every byte of the body is claimed by exactly one item or is whitespace. This
+# is what makes "the parse is total" a checked property rather than a hope.
+# ---
+# c:   the cursor
+# off: body offset the claim starts at
+# len: number of bytes claimed
+# ret: ok(true), or the coverage error naming the offending text
+pub fun claim(c: *Cursor, off: usize, len: usize) R.Result[bool, str] {
+    if (off < c.claimed) { ret R.err[bool, str](coverage_error(c, off, off + len)); }
+    var i: usize = c.claimed;
+    for (i < off) {
+        if (!is_skip(c.body[i])) { ret R.err[bool, str](coverage_error(c, c.claimed, off)); }
+        i = i + 1;
+    }
+    c.claimed = off + len;
+    ret R.ok[bool, str](true);
+}
+
+# the diagnostic for a body byte no parsed instruction claims
+fun coverage_error(c: *Cursor, lo: usize, hi: usize) str {
+    ret span_message(c,
+        "encode: inline-asm instruction '", lo, hi,
+        "' does not account for every byte of its statement",
+        "encode: an inline-asm instruction does not account for every byte of its statement");
+}
+
+# reset an item to the neutral state each parse fills in
+fun item_reset(item: *Item) {
+    item.kind       = AI_INST;
+    item.code       = 0;
+    item.flags      = 0;
+    item.writes     = AW_NONE;
+    item.implicit   = 0;
+    item.words      = WORDS_VARIABLE;
+    item.nops       = 0;
+    item.ref        = AR_NONE;
+    item.ref_off    = 0;
+    item.ref_len    = 0;
+    item.ref_mod    = isa.SYM_MOD_NONE;
+    item.ref_num    = 0;
+    item.ref_fwd    = false;
+    item.byte_count = 0;
+    item.src_off    = 0;
+    item.src_len    = 0;
+    var i: usize = 0;
+    for (i < MAX_OPS) { item.ops[i] = op_none(); i = i + 1; }
+}
+
+# if `body[lo..hi)` begins with a numeric local-label definition `<digits>:`, return
+# the byte length of that prefix (through the colon) and the parsed number; else 0
+pub fun label_def_span(body: str, lo: usize, hi: usize, num_out: *u64) usize {
+    if (lo >= hi)                { ret 0; }
+    if (!is_digit(body[lo]))     { ret 0; }
+    var i: usize = lo;
+    var n: u64 = 0;
+    for (i < hi && is_digit(body[i])) {
+        n = n * 10 + (body[i]::u64 - '0'::u64);
+        i = i + 1;
+    }
+    if (i >= hi)              { ret 0; }
+    if (body[i] != ':'::char) { ret 0; }
+    @num_out = n;
+    ret i + 1 - lo;
+}
+
+# true when `body[lo..hi)` is a numeric local-label reference `<digits>f` /
+# `<digits>b`, yielding its number and direction. false for any other token shape
+pub fun label_ref_span(body: str, lo: usize, hi: usize, num_out: *u64, fwd_out: *bool) bool {
+    if (hi < lo + 2)         { ret false; }
+    if (!is_digit(body[lo])) { ret false; }
+    var n: u64 = 0;
+    var i: usize = lo;
+    for (i < hi - 1) {
+        if (!is_digit(body[i])) { ret false; }
+        n = n * 10 + (body[i]::u64 - '0'::u64);
+        i = i + 1;
+    }
+    val suf: char = body[hi - 1];
+    if (suf == 'f'::char) { @fwd_out = true; }
+    or (suf == 'b'::char) { @fwd_out = false; }
+    or { ret false; }
+    @num_out = n;
+    ret true;
+}
+
+# the index of the mnemonic row `body[lo..hi)` names, or -1
+#
+# A zero-operand mnemonic matches the whole statement; every other form matches a
+# prefix followed by a space, so `mov` never shadows `movzx` and `cmp` never shadows
+# `cmpxchg`. Rows are tried in table order, so a longer spelling sharing a prefix
+# with a shorter one (`lock cmpxchg` before `cmpxchg`) is placed first.
+fun row_lookup(g: *Grammar, body: str, lo: usize, hi: usize) i32 {
+    var i: usize = 0;
+    for (i < g.row_count) {
+        val m: *Mnemonic = ?g.rows[i];
+        val mlen: usize = str_len(m.name);
+        if (m.form == AF_NONE) {
+            if (str_region_equals(body, lo, hi - lo, m.name)) { ret i::i32; }
+        } or {
+            if (lo + mlen < hi && str_region_equals(body, lo, mlen, m.name)
+                && body[lo + mlen] == ' '::char) { ret i::i32; }
+        }
+        i = i + 1;
+    }
+    ret -1;
+}
+
+# split `body[lo..hi)` into trimmed top-level operand token spans, claiming each
+# token and each separating comma
+#
+# Depth is tracked across `(`, `[` and `{` so a comma inside an addressing form
+# (`[x29, #16]`) does not separate operands.
+fun split_ops(c: *Cursor, lo: usize, hi: usize, s: *Stmt) R.Result[bool, str] {
+    s.nargs = 0;
+    var a: usize = lo;
+    for (a < hi && is_space(c.body[a])) { a = a + 1; }
+    if (a >= hi) { ret R.ok[bool, str](true); }
+
+    var depth: i32 = 0;
+    var start: usize = a;
+    var i: usize = a;
+    for (i <= hi) {
+        var sep: bool = false;
+        if (i == hi) { sep = true; }
+        or (c.body[i] == '('::char || c.body[i] == '['::char || c.body[i] == '{'::char) { depth = depth + 1; }
+        or (c.body[i] == ')'::char || c.body[i] == ']'::char || c.body[i] == '}'::char) { depth = depth - 1; }
+        or (c.body[i] == ','::char && depth == 0) { sep = true; }
+
+        if (sep) {
+            if (s.nargs::usize >= MAX_OPS) {
+                ret R.err[bool, str](span_message(c,
+                    "encode: inline-asm instruction '", lo, hi, "' names too many operands",
+                    "encode: an inline-asm instruction names too many operands"));
+            }
+            var ta: usize = start;
+            var tb: usize = i;
+            for (ta < tb && is_space(c.body[ta])) { ta = ta + 1; }
+            for (tb > ta && is_space(c.body[tb - 1])) { tb = tb - 1; }
+            if (tb <= ta) { ret R.err[bool, str]("encode: malformed inline-asm operand"); }
+            val cr: R.Result[bool, str] = claim(c, ta, tb - ta);
+            if (R.is_err[bool, str](cr)) { ret cr; }
+            s.arg_lo[s.nargs::usize] = ta;
+            s.arg_hi[s.nargs::usize] = tb;
+            s.nargs = s.nargs + 1;
+            if (i < hi) {
+                val cc: R.Result[bool, str] = claim(c, i, 1);
+                if (R.is_err[bool, str](cc)) { ret cc; }
+            }
+            start = i + 1;
+        }
+        i = i + 1;
+    }
+    ret R.ok[bool, str](true);
+}
+
+# decode a raw byte directive's payload, claiming each value and separator
+fun parse_bytes(c: *Cursor, s: *Stmt, item: *Item) R.Result[bool, str] {
+    item.kind = AI_BYTES;
+    var i: u32 = 0;
+    for (i < s.nargs) {
+        val v: O.Option[i64] = region_i64(c.body, s.arg_lo[i::usize], s.arg_hi[i::usize]);
+        if (!O.is_some[i64](v)) { ret R.err[bool, str]("encode: malformed inline-asm .byte value"); }
+        item.bytes[item.byte_count] = O.unwrap[i64](v)::u8;
+        item.byte_count = item.byte_count + 1;
+        i = i + 1;
+    }
+    if (item.byte_count == 0) { ret R.err[bool, str]("encode: malformed inline-asm .byte value"); }
+    ret R.ok[bool, str](true);
+}
+
+# parse the next statement of the body into `item`
+#
+# Returns ok(true) with `item` filled, ok(false) at the end of the body (after
+# checking every trailing byte is skippable), or an error naming the instruction that
+# could not be parsed or accounted for.
+# ---
+# c:    the cursor
+# item: receives the parsed statement
+# ret:  ok(true) on an item, ok(false) at end of body, or a refusal
+pub fun next(c: *Cursor, item: *Item) R.Result[bool, str] {
+    for (c.pos < c.len && is_skip(c.body[c.pos])) { c.pos = c.pos + 1; }
+    if (c.pos >= c.len) { ret finish(c); }
+
+    val lo: usize = c.pos;
+    var end: usize = lo;
+    for (end < c.len && c.body[end] != '\n'::char && c.body[end] != ';'::char) { end = end + 1; }
+    var hi: usize = end;
+    for (hi > lo && is_space(c.body[hi - 1])) { hi = hi - 1; }
+    if (hi - lo >= STMT_MAX) { ret R.err[bool, str]("encode: inline asm statement too long"); }
+
+    item_reset(item);
+    item.src_off = lo;
+
+    val pr: R.Result[usize, str] = parse_stmt(c, lo, hi, item);
+    if (R.is_err[usize, str](pr)) { ret R.err[bool, str](R.unwrap_err[usize, str](pr)); }
+    val consumed: usize = R.unwrap_ok[usize, str](pr);
+
+    # the statement is only parsed when every one of its bytes was claimed.
+    if (c.claimed != consumed) { ret R.err[bool, str](coverage_error(c, lo, hi)); }
+
+    item.src_len = consumed - lo;
+    c.pos        = consumed;
+    ret R.ok[bool, str](true);
+}
+
+# end-of-body check: the bytes past the last claim must all be skippable
+fun finish(c: *Cursor) R.Result[bool, str] {
+    var i: usize = c.claimed;
+    for (i < c.len) {
+        if (!is_skip(c.body[i])) { ret R.err[bool, str](coverage_error(c, i, c.len)); }
+        i = i + 1;
+    }
+    ret R.ok[bool, str](false);
+}
+
+# parse one statement `body[lo..hi)`, returning the offset it consumed through
+#
+# A numeric local-label definition is its own item and consumes only its `<digits>:`
+# prefix, so an instruction sharing the line is parsed by the next call and claims
+# its own bytes.
+fun parse_stmt(c: *Cursor, lo: usize, hi: usize, item: *Item) R.Result[usize, str] {
+    var num: u64 = 0;
+    val dlen: usize = label_def_span(c.body, lo, hi, ?num);
+    if (dlen > 0) {
+        val cr: R.Result[bool, str] = claim(c, lo, dlen);
+        if (R.is_err[bool, str](cr)) { ret R.err[usize, str](R.unwrap_err[bool, str](cr)); }
+        item.kind    = AI_LABEL;
+        item.ref_num = num;
+        ret R.ok[usize, str](lo + dlen);
+    }
+
+    var s: Stmt;
+    s.lo    = lo;
+    s.hi    = hi;
+    s.nargs = 0;
+
+    var mlen: usize = 0;
+    val ri: i32 = row_lookup(c.g, c.body, lo, hi);
+    if (ri >= 0) {
+        s.m  = c.g.rows[ri::usize];
+        mlen = str_len(s.m.name);
+    } or {
+        if (c.g.decode == nil || !c.g.decode(c.body, lo, hi, ?s.m, ?mlen)) {
+            ret R.err[usize, str](unknown_message(c, lo, hi));
+        }
+    }
+
+    val cr: R.Result[bool, str] = claim(c, lo, mlen);
+    if (R.is_err[bool, str](cr)) { ret R.err[usize, str](R.unwrap_err[bool, str](cr)); }
+
+    item.code     = s.m.code;
+    item.flags    = s.m.flags;
+    item.writes   = s.m.writes;
+    item.implicit = s.m.implicit;
+    item.words    = s.m.words;
+
+    if (s.m.form != AF_NONE) {
+        val sr: R.Result[bool, str] = split_ops(c, lo + mlen, hi, ?s);
+        if (R.is_err[bool, str](sr)) { ret R.err[usize, str](R.unwrap_err[bool, str](sr)); }
+    }
+
+    if (s.m.form == AF_BYTES) {
+        val br: R.Result[bool, str] = parse_bytes(c, ?s, item);
+        if (R.is_err[bool, str](br)) { ret R.err[usize, str](R.unwrap_err[bool, str](br)); }
+        ret R.ok[usize, str](hi);
+    }
+
+    item.nops = s.nargs;
+    val pr: R.Result[bool, str] = c.g.parse(c, ?s, item);
+    if (R.is_err[bool, str](pr)) { ret R.err[usize, str](R.unwrap_err[bool, str](pr)); }
+    ret R.ok[usize, str](hi);
+}
+
+# "unknown <isa> inline-asm instruction '<text>'"
+fun unknown_message(c: *Cursor, lo: usize, hi: usize) str {
+    var pre: [64]u8;
+    val head: str = "unknown ";
+    var k: usize = 0;
+    var j: usize = 0;
+    val lh: usize = str_len(head);
+    val li: usize = str_len(c.g.isa);
+    if (lh + li + 32 >= 64) { ret "unknown inline-asm instruction"; }
+    for (j < lh) { pre[k] = head[j]::u8; k = k + 1; j = j + 1; }
+    j = 0;
+    for (j < li) { pre[k] = c.g.isa[j]::u8; k = k + 1; j = j + 1; }
+    val tail: str = " inline-asm instruction '";
+    val lt: usize = str_len(tail);
+    j = 0;
+    for (j < lt) { pre[k] = tail[j]::u8; k = k + 1; j = j + 1; }
+    pre[k] = 0;
+    ret span_message(c, (?pre[0])::str, lo, hi, "'", "unknown inline-asm instruction");
+}
+
+# resolve a `{name}` reference spanning `body[lo..hi)` to its frame-slot offset
+#
+# The shared half of a local binding: the token shape, the lookup against the block's
+# bindings, and the laid-out frame's slot offset. What the offset BECOMES is the
+# target's - `[rbp + off]`, `off(s0)`, `[x29, #off]` - so the ISA's lexer calls this
+# and builds its own memory operand.
+#
+# Returns none when the parse carries no binding context: before the frame is laid
+# out a binding's displacement genuinely is unknown, and the ISA decides whether its
+# effect model can still describe the statement.
+# ---
+# c:   the cursor
+# lo:  body offset of the `{`
+# hi:  body offset just past the `}`
+# off: receives the frame-pointer-relative slot offset
+# ret: ok(true) when resolved, ok(false) when there is no binding context, or the
+#      refusal naming the malformed or unbound reference
+pub fun bind_offset(c: *Cursor, lo: usize, hi: usize, off: *i64) R.Result[bool, str] {
+    if (hi <= lo || c.body[lo] != '{'::char) { ret R.err[bool, str]("encode: malformed inline-asm operand"); }
+    var close: usize = lo;
+    var found: bool = false;
+    for (close < hi && !found) {
+        if (c.body[close] == '}'::char) { found = true; } or { close = close + 1; }
+    }
+    if (!found)          { ret R.err[bool, str]("encode: unterminated '{' in inline asm body"); }
+    if (close != hi - 1) { ret R.err[bool, str]("encode: malformed inline-asm operand"); }
+
+    val name_off: usize = lo + 1;
+    val name_len: usize = close - name_off;
+    if (name_len == 0) { ret R.err[bool, str]("encode: unknown local in inline asm '{name}' reference"); }
+    if (c.pl == nil || c.f == nil) { ret R.ok[bool, str](false); }
+
+    var i: u32 = 0;
+    for (i < c.pl.bind_count) {
+        if (bind_name_eq(c.interner, c.pl.binds[i].name, c.body, name_off, name_len)) {
+            val so: O.Option[i64] = c.g.slot(c.f, c.pl.binds[i].slot_vreg);
+            if (!O.is_some[i64](so)) { ret R.err[bool, str]("encode: inline-asm '{name}' local has no frame slot"); }
+            @off = O.unwrap[i64](so);
+            ret R.ok[bool, str](true);
+        }
+        i = i + 1;
+    }
+    ret R.err[bool, str]("encode: unknown local in inline asm '{name}' reference");
+}
+
+# true when the interned binding name equals the `name_len` bytes of `body` at `start`
+fun bind_name_eq(interner: *intern.Interner, name: intern.StrId, body: str, start: usize, name_len: usize) bool {
+    val nopt: O.Option[str] = intern.lookup(interner, name);
+    if (!O.is_some[str](nopt)) { ret false; }
+    ret str_region_equals(body, start, name_len, O.unwrap[str](nopt));
+}
+
+# the registers one parsed item writes, folded into the running masks
+#
+# The whole effect model. A modeled instruction writes exactly the registers its
+# mnemonic's facts name; an item the parser could not model writes worst-case. An
+# unreadable byte stream reaches every bank, while an unresolved statement is bounded
+# by the general-purpose bank - no target's inline grammar names a vector register.
+# ---
+# g:    the target's grammar
+# item: the parsed statement
+# gp:   accumulated general-purpose write mask (index n -> bit n)
+# fp:   accumulated float / vector write mask (index n -> bit n)
+pub fun fold_clobbers(g: *Grammar, item: *Item, gp: *u32, fp: *u32) {
+    if (item.kind == AI_LABEL) { ret; }
+    if (item.kind == AI_BYTES) {
+        @gp = @gp | g.all_gp;
+        @fp = @fp | g.all_fp;
+        ret;
+    }
+    if (item.kind == AI_OPAQUE) {
+        @gp = @gp | g.all_gp;
+        ret;
+    }
+    @gp = @gp | item.implicit;
+    if ((item.writes & AW_OP0) != 0 && item.nops > 0) { mark_written(?item.ops[0], gp); }
+    if ((item.writes & AW_OP1) != 0 && item.nops > 1) { mark_written(?item.ops[1], gp); }
+    if ((item.writes & AW_WB_BASE) != 0) {
+        var i: u32 = 0;
+        for (i < item.nops) {
+            val op: *Operand = ?item.ops[i::usize];
+            if (op.kind == AOP_MEM && (op.flags & AOF_WRITEBACK) != 0 && op.reg >= 0 && op.reg < 32) {
+                @gp = @gp | (1::u32 << op.reg::u32);
+            }
+            i = i + 1;
+        }
+    }
+}
+
+# OR a written operand's register bit into `@gp`
+#
+# Only a register destination writes a register: a memory destination writes memory
+# and merely reads its base, an immediate writes nothing, and a `{name}` binding is a
+# stack slot, so it can never name one.
+fun mark_written(op: *Operand, gp: *u32) {
+    if (op.kind == AOP_REG && op.reg >= 0 && op.reg < 32) {
+        @gp = @gp | (1::u32 << op.reg::u32);
+    }
+}
+
+# the registers an inline-asm body writes, derived from the instructions it parses to
+#
+# Runs before register allocation, on the same parser the emitter later runs on the
+# same text, so the clobber set is a property of the parsed instruction stream rather
+# than a second reading of it. A body the parser refuses is opaque: the emitter
+# rejects it with a located diagnostic, and until then no register may hold a live
+# value. The result is always a sound over-approximation - a register the body merely
+# reads may be reported, a written one is never omitted.
+# ---
+# g:      the target's grammar
+# body:   raw inline-asm body text
+# gp_out: receives the general-purpose clobber bitmask (index n -> bit n)
+# fp_out: receives the float / vector clobber bitmask (index n -> bit n)
+pub fun clobbers(g: *Grammar, body: str, gp_out: *u32, fp_out: *u32) {
+    var gp: u32 = 0;
+    var fp: u32 = 0;
+
+    var c: Cursor;
+    cursor_init(?c, g, body, nil, nil, nil, nil);
+
+    var item: Item;
+    var done: bool = false;
+    for (!done) {
+        val pr: R.Result[bool, str] = next(?c, ?item);
+        if (R.is_err[bool, str](pr)) {
+            gp   = g.all_gp;
+            fp   = g.all_fp;
+            done = true;
+        }
+        or (!R.unwrap_ok[bool, str](pr)) { done = true; }
+        or { fold_clobbers(g, ?item, ?gp, ?fp); }
+    }
+
+    @gp_out = gp;
+    @fp_out = fp;
+}
+
+# initial capacity for the numeric local-label definition / fixup arrays
+val LABEL_INIT_CAP: u32 = 16;
+
+# a numeric local label's most recent definition: the label number and the `.text`
+# offset its `N:` definition marks. a redefinition updates `offset`, so a backward
+# `Nb` reference always binds to the nearest preceding definition
+# ---
+# number: the numeric label
+# offset: byte offset of the definition within `.text`
+pub rec LabelDef {
+    number: u64;
+    offset: u32;
+}
+
+# a pending forward reference to a numeric local label: the branch at `patch_pos`
+# targets the nearest following definition of `number`. resolved when that definition
+# is reached; an entry still pending at the end of the block is an undefined-label
+# error
+# ---
+# patch_pos: byte offset of the branch instruction within `.text`
+# number:    the referenced numeric label
+pub rec LabelFixup {
+    patch_pos: u32;
+    number:    u64;
+}
+
+# per-block numeric-local-label scope
+#
+# `defs` tracks the nearest preceding definition of each number for backward
+# references; `fixups` holds forward references awaiting theirs. The displacement
+# insert itself is the ISA's `patch` hook, so this bookkeeping carries no encoding.
+# ---
+# alloc:       backing allocator
+# defs:        recorded label definitions (latest offset per number)
+# def_count:   number of definitions
+# def_cap:     capacity of `defs`
+# fixups:      pending forward references
+# fixup_count: number of pending forward references
+# fixup_cap:   capacity of `fixups`
+pub rec Labels {
+    alloc:       *A.Allocator;
+    defs:        *LabelDef;
+    def_count:   u32;
+    def_cap:     u32;
+    fixups:      *LabelFixup;
+    fixup_count: u32;
+    fixup_cap:   u32;
+}
+
+# initialize an empty numeric-local-label scope backed by `alloc`
+pub fun labels_init(l: *Labels, alloc: *A.Allocator) {
+    l.alloc       = alloc;
+    l.defs        = nil;
+    l.def_count   = 0;
+    l.def_cap     = 0;
+    l.fixups      = nil;
+    l.fixup_count = 0;
+    l.fixup_cap   = 0;
+}
+
+# release a label scope's owned arrays
+pub fun labels_dnit(l: *Labels) {
+    if (l.defs != nil && l.def_cap > 0) {
+        A.deallocate[LabelDef](l.alloc, l.defs, l.def_cap::usize);
+        l.defs      = nil;
+        l.def_cap   = 0;
+        l.def_count = 0;
+    }
+    if (l.fixups != nil && l.fixup_cap > 0) {
+        A.deallocate[LabelFixup](l.alloc, l.fixups, l.fixup_cap::usize);
+        l.fixups      = nil;
+        l.fixup_cap   = 0;
+        l.fixup_count = 0;
+    }
+}
+
+# grow the label-definition array (or allocate it on first use)
+fun grow_defs(l: *Labels) R.Result[bool, str] {
+    if (l.defs == nil) {
+        val r: R.Result[*LabelDef, str] = A.allocate[LabelDef](l.alloc, LABEL_INIT_CAP::usize);
+        if (R.is_err[*LabelDef, str](r)) { ret R.err[bool, str](R.unwrap_err[*LabelDef, str](r)); }
+        l.defs    = R.unwrap_ok[*LabelDef, str](r);
+        l.def_cap = LABEL_INIT_CAP;
+        ret R.ok[bool, str](true);
+    }
+    val nc: u32 = l.def_cap * 2;
+    val r: R.Result[*LabelDef, str] = A.reallocate[LabelDef](l.alloc, l.defs, l.def_cap::usize, nc::usize);
+    if (R.is_err[*LabelDef, str](r)) { ret R.err[bool, str](R.unwrap_err[*LabelDef, str](r)); }
+    l.defs    = R.unwrap_ok[*LabelDef, str](r);
+    l.def_cap = nc;
+    ret R.ok[bool, str](true);
+}
+
+# grow the label-fixup array (or allocate it on first use)
+fun grow_fixups(l: *Labels) R.Result[bool, str] {
+    if (l.fixups == nil) {
+        val r: R.Result[*LabelFixup, str] = A.allocate[LabelFixup](l.alloc, LABEL_INIT_CAP::usize);
+        if (R.is_err[*LabelFixup, str](r)) { ret R.err[bool, str](R.unwrap_err[*LabelFixup, str](r)); }
+        l.fixups    = R.unwrap_ok[*LabelFixup, str](r);
+        l.fixup_cap = LABEL_INIT_CAP;
+        ret R.ok[bool, str](true);
+    }
+    val nc: u32 = l.fixup_cap * 2;
+    val r: R.Result[*LabelFixup, str] = A.reallocate[LabelFixup](l.alloc, l.fixups, l.fixup_cap::usize, nc::usize);
+    if (R.is_err[*LabelFixup, str](r)) { ret R.err[bool, str](R.unwrap_err[*LabelFixup, str](r)); }
+    l.fixups    = R.unwrap_ok[*LabelFixup, str](r);
+    l.fixup_cap = nc;
+    ret R.ok[bool, str](true);
+}
+
+# the nearest preceding definition offset of `number`, or none
+pub fun label_lookup(l: *Labels, number: u64) O.Option[u32] {
+    var i: u32 = 0;
+    for (i < l.def_count) {
+        if (l.defs[i].number == number) { ret O.some[u32](l.defs[i].offset); }
+        i = i + 1;
+    }
+    ret O.none[u32]();
+}
+
+# record a pending forward reference to `number` whose branch is at `patch_pos`
+pub fun label_push_fixup(l: *Labels, patch_pos: u32, number: u64) R.Result[bool, str] {
+    if (l.fixup_count >= l.fixup_cap) {
+        val gr: R.Result[bool, str] = grow_fixups(l);
+        if (R.is_err[bool, str](gr)) { ret gr; }
+    }
+    l.fixups[l.fixup_count].patch_pos = patch_pos;
+    l.fixups[l.fixup_count].number    = number;
+    l.fixup_count = l.fixup_count + 1;
+    ret R.ok[bool, str](true);
+}
+
+# record a definition of `number` at `.text` offset `off`
+#
+# Patches every pending forward reference to it (this is their nearest following
+# definition) through the ISA's `patch` hook, and updates the nearest-preceding
+# definition backward references resolve against. A redefinition is allowed.
+pub fun label_record_def(st: *encode.EncodeState, g: *Grammar, l: *Labels, number: u64, off: u32) R.Result[bool, str] {
+    var w: u32 = 0;
+    var r: u32 = 0;
+    for (r < l.fixup_count) {
+        if (l.fixups[r].number == number) {
+            val pr: R.Result[bool, str] = g.patch(st, l.fixups[r].patch_pos, off);
+            if (R.is_err[bool, str](pr)) { ret pr; }
+        } or {
+            l.fixups[w].patch_pos = l.fixups[r].patch_pos;
+            l.fixups[w].number    = l.fixups[r].number;
+            w = w + 1;
+        }
+        r = r + 1;
+    }
+    l.fixup_count = w;
+
+    var i: u32 = 0;
+    for (i < l.def_count) {
+        if (l.defs[i].number == number) {
+            l.defs[i].offset = off;
+            ret R.ok[bool, str](true);
+        }
+        i = i + 1;
+    }
+    if (l.def_count >= l.def_cap) {
+        val gr: R.Result[bool, str] = grow_defs(l);
+        if (R.is_err[bool, str](gr)) { ret gr; }
+    }
+    l.defs[l.def_count].number = number;
+    l.defs[l.def_count].offset = off;
+    l.def_count                = l.def_count + 1;
+    ret R.ok[bool, str](true);
+}
+
+# resolve a branch just emitted at `patch_pos` against a numeric local label
+#
+# A forward reference is recorded as a fixup patched when its definition is reached;
+# a backward one is patched immediately against the label's nearest preceding
+# definition, and an undefined one is a hard error.
+pub fun resolve_local(st: *encode.EncodeState, g: *Grammar, l: *Labels, patch_pos: u32,
+                      number: u64, fwd: bool) R.Result[bool, str] {
+    if (fwd) { ret label_push_fixup(l, patch_pos, number); }
+    val def: O.Option[u32] = label_lookup(l, number);
+    if (!O.is_some[u32](def)) {
+        ret R.err[bool, str](label_message(st,
+            "encode: inline-asm backward reference to local label '", number,
+            "b' has no preceding definition in this asm block",
+            "encode: inline-asm backward reference to a local label has no preceding definition in this asm block"));
+    }
+    ret g.patch(st, patch_pos, O.unwrap[u32](def));
+}
+
+# write the decimal digits of `n` into `dst` (at least one digit) and return the
+# digit count; `dst` must hold at least 20 bytes
+fun u64_to_dec(n: u64, dst: *u8) usize {
+    if (n == 0) { dst[0] = '0'::u8; ret 1; }
+    var tmp: [20]u8;
+    var len: usize = 0;
+    var v: u64 = n;
+    for (v > 0) {
+        tmp[len] = (v % 10)::u8 + '0'::u8;
+        v        = v / 10;
+        len      = len + 1;
+    }
+    var k: usize = 0;
+    for (k < len) { dst[k] = tmp[len - 1 - k]; k = k + 1; }
+    ret len;
+}
+
+# build an interned error naming a numeric local label, e.g. "<prefix>1<suffix>"
+fun label_message(st: *encode.EncodeState, prefix: str, number: u64, suffix: str, fallback: str) str {
+    var buf: [24]u8;
+    val len: usize = u64_to_dec(number, ?buf[0]);
+    buf[len] = 0;
+    ret named_message(st.alloc, st.interner, prefix, (?buf[0])::str, suffix, fallback);
+}
+
+# expand an inline-asm MIR_ASM instruction into machine bytes
+#
+# Parses the body into the target's own instruction stream and emits each
+# instruction through the encoder the instruction selector drives, so an inline-asm
+# instruction and a compiler-selected one are the same value taking the same path.
+# `{name}` references resolve against the laid-out frame during the parse; a branch
+# or symbol operand records its relocation. An unknown mnemonic, a malformed operand,
+# or a statement byte no instruction claims is a hard error located at the asm
+# statement's "path:line:col" (#2153).
+#
+# On a fixed-width target the driver additionally checks each item emitted exactly
+# the number of instruction words its mnemonic declares, so a form silently emitting
+# two instructions under one mnemonic - or none - fails the build naming it. A form
+# declaring `WORDS_VARIABLE`, and every form on a variable-length encoding, is
+# checked only by the parse-side accounting.
+# ---
+# st: the shared encode state
+# g:  the target's grammar
+# f:  the function being encoded, whose frame resolves a `{name}`
+# mi: the MIR_ASM instruction
+# ret: ok(true), or the located refusal
+pub fun encode_block(st: *encode.EncodeState, g: *Grammar, f: *mir.MirFunction, mi: *mir.MirInstr) R.Result[bool, str] {
+    if (mi.asm_block == nil) { ret R.err[bool, str]("encode: MIR_ASM has no payload"); }
+    val pl: *mir.MirAsm = mi.asm_block;
+
+    # only this ISA's tag is encodable here; a mismatched tag means a comptime arch
+    # guard failed to select the right block.
+    if (!str_region_equals(pl.isa, 0, str_len(g.isa), g.isa) || str_len(pl.isa) != str_len(g.isa)) {
+        ret R.err[bool, str](encode.asm_located_message(st, mi.loc,
+            named_message(st.alloc, st.interner, "encode: inline-asm block is not ", g.isa, "",
+                          "encode: inline-asm block is not for this target")));
+    }
+
+    var l: Labels;
+    labels_init(?l, st.alloc);
+
+    var c: Cursor;
+    cursor_init(?c, g, pl.body, st.alloc, st.interner, f, pl);
+
+    val rr: R.Result[bool, str] = run(st, g, ?c, ?l);
+    var fail: str = nil;
+    if (R.is_err[bool, str](rr)) { fail = R.unwrap_err[bool, str](rr); }
+
+    # a forward reference whose label was never defined in the block is a hard error,
+    # not a silently zero-displacement branch.
+    or (l.fixup_count > 0) {
+        fail = label_message(st,
+            "encode: inline-asm forward reference to local label '", l.fixups[0].number,
+            "f' has no definition in this asm block",
+            "encode: inline-asm forward reference to a local label has no definition in this asm block");
+    }
+    labels_dnit(?l);
+    if (fail != nil) { ret R.err[bool, str](encode.asm_located_message(st, mi.loc, fail)); }
+    ret R.ok[bool, str](true);
+}
+
+# parse and emit every statement a cursor still holds
+#
+# The driver proper, split out so a caller that already owns a cursor and a label
+# scope (an encoder test assembling a body a statement at a time) reaches the same
+# loop the block path does rather than a second one. It leaves unresolved forward
+# references pending in `l`; whether that is an error is the block's question, since
+# the definition may sit in a later part of the same block.
+# ---
+# st: the shared encode state
+# g:  the target's grammar
+# c:  the cursor, already initialized over the body
+# l:  the block's numeric-local-label scope
+# ret: ok(true), or the unlocated refusal
+pub fun run(st: *encode.EncodeState, g: *Grammar, c: *Cursor, l: *Labels) R.Result[bool, str] {
+    var item: Item;
+    var done: bool = false;
+    for (!done) {
+        val pr: R.Result[bool, str] = next(c, ?item);
+        if (R.is_err[bool, str](pr))     { ret pr; }
+        or (!R.unwrap_ok[bool, str](pr)) { done = true; }
+        or {
+            val before: usize = st.buf.len;
+            val er: R.Result[bool, str] = emit_one(st, g, c, l, ?item);
+            if (R.is_err[bool, str](er)) { ret er; }
+            val wf: str = check_words(c, ?item, st.buf.len - before);
+            if (wf != nil) { ret R.err[bool, str](wf); }
+        }
+    }
+    ret R.ok[bool, str](true);
+}
+
+# emit one parsed item
+#
+# A label definition records the current offset (resolving pending forward references
+# to it), a raw byte payload is written verbatim, and an instruction goes to the
+# target's assembler.
+fun emit_one(st: *encode.EncodeState, g: *Grammar, c: *Cursor, l: *Labels, item: *Item) R.Result[bool, str] {
+    if (item.kind == AI_LABEL) {
+        ret label_record_def(st, g, l, item.ref_num, st.buf.len::u32);
+    }
+    if (item.kind == AI_BYTES) {
+        var i: usize = 0;
+        for (i < item.byte_count) {
+            encode.emit_byte(?st.buf, item.bytes[i]);
+            i = i + 1;
+        }
+        ret R.ok[bool, str](true);
+    }
+    # the emitter always parses with a binding context, so every `{name}` either
+    # resolved or failed the parse; an unresolved statement here is a parser bug.
+    if (item.kind == AI_OPAQUE) {
+        ret R.err[bool, str]("internal compiler error: inline-asm statement reached the encoder unresolved");
+    }
+    ret g.emit(st, c, l, item);
+}
+
+# check an emitted instruction against the word count its mnemonic declares
+#
+# The emit-side half of the totality guard, available only where an instruction has a
+# fixed width. Returns nil when the item is accounted for, else the refusal naming
+# the statement whose emission did not match its declared form.
+fun check_words(c: *Cursor, item: *Item, emitted: usize) str {
+    if (item.kind != AI_INST)         { ret nil; }
+    if (c.g.word == 0)                { ret nil; }
+    if (item.words == WORDS_VARIABLE) {
+        if (emitted == 0 || emitted % c.g.word::usize != 0) {
+            ret words_message(c, item);
+        }
+        ret nil;
+    }
+    if (emitted != item.words::usize * c.g.word::usize) { ret words_message(c, item); }
+    ret nil;
+}
+
+# the diagnostic for an instruction that emitted a different number of words than its
+# mnemonic declares
+fun words_message(c: *Cursor, item: *Item) str {
+    ret span_message(c,
+        "encode: inline-asm instruction '", item.src_off, item.src_off + item.src_len,
+        "' emitted a different number of instruction words than its form declares",
+        "encode: an inline-asm instruction emitted a different number of instruction words than its form declares");
+}

--- a/src/lang/target/isa/asm.mach
+++ b/src/lang/target/isa/asm.mach
@@ -346,7 +346,10 @@ pub def SlotFn: fun(*mir.MirFunction, u32) O.Option[i64];
 # today, spir-v by construction) needs none, which is what makes the parser a
 # capability rather than a tax on every new target (#2212).
 # ---
-# isa:       the ISA tag the `asm` block spells, and the name diagnostics use
+# isa:       the ISA tag the `asm` block spells
+# unknown:   the refusal prefix an unrecognized mnemonic takes, up to its opening
+#            quote - spelled out rather than composed, so naming the target in a
+#            diagnostic needs no buffer and can never degrade to a vaguer message
 # rows:      the mnemonic table
 # row_count: number of rows
 # decode:    the suffixed-family decoder, or nil
@@ -359,6 +362,7 @@ pub def SlotFn: fun(*mir.MirFunction, u32) O.Option[i64];
 # word:      the instruction word size in bytes, or 0 for a variable-length encoding
 pub rec Grammar {
     isa:       str;
+    unknown:   str;
     rows:      *Mnemonic;
     row_count: usize;
     decode:    DecodeFn;
@@ -843,22 +847,7 @@ fun parse_stmt(c: *Cursor, lo: usize, hi: usize, item: *Item) R.Result[usize, st
 
 # "unknown <isa> inline-asm instruction '<text>'"
 fun unknown_message(c: *Cursor, lo: usize, hi: usize) str {
-    var pre: [64]u8;
-    val head: str = "unknown ";
-    var k: usize = 0;
-    var j: usize = 0;
-    val lh: usize = str_len(head);
-    val li: usize = str_len(c.g.isa);
-    if (lh + li + 32 >= 64) { ret "unknown inline-asm instruction"; }
-    for (j < lh) { pre[k] = head[j]::u8; k = k + 1; j = j + 1; }
-    j = 0;
-    for (j < li) { pre[k] = c.g.isa[j]::u8; k = k + 1; j = j + 1; }
-    val tail: str = " inline-asm instruction '";
-    val lt: usize = str_len(tail);
-    j = 0;
-    for (j < lt) { pre[k] = tail[j]::u8; k = k + 1; j = j + 1; }
-    pre[k] = 0;
-    ret span_message(c, (?pre[0])::str, lo, hi, "'", "unknown inline-asm instruction");
+    ret span_message(c, c.g.unknown, lo, hi, "'", "unknown inline-asm instruction");
 }
 
 # resolve a `{name}` reference spanning `body[lo..hi)` to its frame-slot offset

--- a/src/lang/target/isa/asm.mach
+++ b/src/lang/target/isa/asm.mach
@@ -1343,3 +1343,27 @@ fun words_message(c: *Cursor, item: *Item) str {
         "' emitted a different number of instruction words than its form declares",
         "encode: an inline-asm instruction emitted a different number of instruction words than its form declares");
 }
+
+# numeric local-label definitions and references are recognized by token shape, the
+# same shape on every target
+test "mach.lang.target.isa.asm:label_token_shapes" {
+    var num: u64 = 0;
+    var bad: i32 = 0;
+
+    # `<digits>:` is a definition; the prefix length includes the colon.
+    if (label_def_span("1:", 0, 2, ?num) != 2 || num != 1)                 { bad = 1; }
+    if (label_def_span("42: mov rax, rbx", 0, 16, ?num) != 3 || num != 42) { bad = 1; }
+    # not a definition: no colon, or a non-digit lead.
+    if (label_def_span("mov rax, rbx", 0, 12, ?num) != 0) { bad = 1; }
+    if (label_def_span("1f", 0, 2, ?num) != 0)            { bad = 1; }
+
+    var fwd: bool = false;
+    # `<digits>f` is a forward reference, `<digits>b` a backward one.
+    if (!label_ref_span("1f", 0, 2, ?num, ?fwd) || num != 1 || !fwd)   { bad = 1; }
+    if (!label_ref_span("23b", 0, 3, ?num, ?fwd) || num != 23 || fwd)  { bad = 1; }
+    # a bare symbol, a digit-led non-f/b token, and a too-short token are not refs.
+    if (label_ref_span("loop", 0, 4, ?num, ?fwd)) { bad = 1; }
+    if (label_ref_span("1x", 0, 2, ?num, ?fwd))   { bad = 1; }
+    if (label_ref_span("1", 0, 1, ?num, ?fwd))    { bad = 1; }
+    ret bad;
+}

--- a/src/lang/target/isa/riscv64/encode.mach
+++ b/src/lang/target/isa/riscv64/encode.mach
@@ -4165,6 +4165,7 @@ fun rv_patch(st: *encode.EncodeState, patch_pos: u32, target_off: u32) R.Result[
 fun rv_grammar() iasm.Grammar {
     var g: iasm.Grammar;
     g.isa       = "riscv64";
+    g.unknown   = "unknown riscv64 inline-asm instruction '";
     g.rows      = ?RV_MNEMONICS[0];
     g.row_count = RV_MNEMONIC_COUNT;
     g.decode    = rv_decode_amo;

--- a/src/lang/target/isa/riscv64/encode.mach
+++ b/src/lang/target/isa/riscv64/encode.mach
@@ -31,9 +31,13 @@
 # `addi`/load/store `%pcrel_lo`) for an address-of (`emit_global_addr`), a folded-global
 # load (`emit_global_load`), and a folded-global store (`emit_global_store`), each
 # recording the RK_PCREL_HI20 + RK_PCREL_LO12_I / _S markers the linker / ELF relocation
-# seam packs. The final slice adds the inline-asm assembler (`encode_asm_block_riscv64`),
-# which substitutes `{name}` locals to `off(s0)` and encodes each RV64 statement through
-# the `rv_*` helpers.
+# seam packs. The final slice adds the inline-asm assembler, which since #2232 is the
+# riscv64 half of the SHARED parser in `isa.asm`: this module supplies the mnemonic
+# table, the operand lexer and the emitter (`rv_grammar`), and the shared spine owns
+# the statement cursor, the byte accounting, numeric local labels, `{name}` binding
+# and the effect model. There is no second reading of the text anywhere - the
+# register set `asm_clobbers` reports and the bytes `encode_asm_block_riscv64` emits
+# come from one parse of one grammar.
 #
 # WIDTH-HONESTY: the 32-bit instruction-word format machinery (pack_r/i/s/b/u/j),
 # the register field positions, the immediate bit-scatter, and the branch / jump
@@ -66,6 +70,7 @@ use mach.lang.be.codegen.encode;
 use mach.lang.be.codegen.mir;
 use mach.lang.intern;
 use mach.lang.target.isa;
+use iasm: mach.lang.target.isa.asm;
 use mach.lang.target.isa.riscv64;
 use mach.lang.target.isa.riscv64.inst;
 use printer: mach.lang.target.isa.riscv64.printer;
@@ -569,7 +574,7 @@ fun unnamed_form_message(st: *encode.EncodeState, fmt: str, opcode: u32) str {
     buf[i] = ' '::u8; i = i + 1;
     i = i + rv_dec_into(?buf[i], opcode::u64);
     buf[i] = 0;
-    ret rv_named_err(st,
+    ret iasm.named_message(st.alloc, st.interner,
         "--emit-asm: no riscv64 mnemonic for an emitted ", (?buf[0])::str, " instruction",
         "--emit-asm: no riscv64 mnemonic for an emitted instruction");
 }
@@ -3091,7 +3096,7 @@ fun check_accounted(st: *encode.EncodeState, fn_base: u32, opcode: u16) R.Result
         num[n] = 0;
         label = (?num[0])::str;
     }
-    ret R.err[bool, str](rv_named_err(st,
+    ret R.err[bool, str](iasm.named_message(st.alloc, st.interner,
         "--emit-asm: ", label, " emitted instructions the riscv64 assembly printer did not render",
         "--emit-asm: an opcode emitted instructions the riscv64 assembly printer did not render"));
 }
@@ -3249,1297 +3254,968 @@ fun asm_reg_index(tok: str) i32 {
     ret -1;
 }
 
-# copy the first whitespace / comma-delimited token of `s` into `out` (null-
-# terminated) and report the index in `s` just past it. used to lift the mnemonic and
-# the first operand of an inline-asm statement
-fun asm_token(s: str, start: usize, out: *u8, cap: usize, next: *usize) bool {
-    var i: usize = start;
-    for (s[i] != 0 && asm_is_space(s[i])) { i = i + 1; }
-    var j: usize = 0;
-    for (s[i] != 0 && !asm_is_space(s[i]) && s[i] != ','::char && j < cap - 1) {
-        out[j] = s[i]::u8;
-        i = i + 1;
-        j = j + 1;
-    }
-    out[j] = 0;
-    @next = i;
-    ret j > 0;
+# the RV64 inline-assembly grammar
+#
+# The riscv64 half of the shared parser (`isa.asm`): the instructions an
+# `asm riscv64 { ... }` body may name, what each one writes, and how its operands
+# and bytes are formed. Everything above an operand token - statement splitting,
+# byte accounting, numeric local labels, `{name}` binding, the effect fold and the
+# block driver - is the shared spine's and appears nowhere here.
+#
+# RV64 spells addresses `off(base)`, so the operand lexer differs from x86-64's
+# bracketed form; it accepts the psABI register names through `asm_reg_index`, and
+# it reads the `%pcrel_hi` / `%pcrel_lo` / `%got_pcrel_hi` relocation modifiers back
+# into `isa.SymModifier` - the same values the encoder's own notifications carry, so
+# what `--emit-asm` prints for a symbol pair is what this parser reads.
+#
+# A pseudo-instruction is not a separate concept here: it is a real instruction plus
+# an operand pattern. `mv rd, rs` is `addi rd, rs, 0`, `ret` is `jalr zero, 0(ra)`,
+# `neg rd, rs` is `sub rd, zero, rs`. The row names the real instruction, so the
+# effect model and `--emit-asm` see the machine, never the spelling.
+
+# the operand pattern a mnemonic's fields follow, carried in `Mnemonic.flags[7:0]`
+#
+# The instruction the row names (`Mnemonic.code`, an `inst.MachOp`) fixes the format
+# and the funct fields; the pattern says which written operand becomes which field
+# and what fills the rest.
+val RVP_ECALL:     u16 = 1;   # `ecall`
+val RVP_EBREAK:    u16 = 2;   # `ebreak`
+val RVP_NOP:       u16 = 3;   # `nop`  -> addi zero, zero, 0
+val RVP_RET:       u16 = 4;   # `ret`  -> jalr zero, 0(ra)
+val RVP_FENCE:     u16 = 5;   # `fence` -> the full-barrier predecessor / successor set
+val RVP_PAUSE:     u16 = 6;   # `pause` -> the `fence w, 0` hint encoding
+val RVP_RRR:       u16 = 7;   # rd, rs1, rs2
+val RVP_RRI:       u16 = 8;   # rd, rs1, imm12
+val RVP_SHIFT:     u16 = 9;   # rd, rs1, shamt
+val RVP_LOAD:      u16 = 10;  # rd, off(rs1)
+val RVP_STORE:     u16 = 11;  # rs2, off(rs1)
+val RVP_UIMM:      u16 = 12;  # rd, imm20
+val RVP_BRANCH:    u16 = 13;  # rs1, rs2, label
+val RVP_BRANCH_SW: u16 = 14;  # rs2, rs1, label - the reversed pseudo branches
+val RVP_BRANCH_Z1: u16 = 15;  # rs1, label with rs2 = zero
+val RVP_BRANCH_Z2: u16 = 16;  # rs2, label with rs1 = zero
+val RVP_J:         u16 = 17;  # label, linking through zero
+val RVP_JAL:       u16 = 18;  # label | rd, label
+val RVP_JR:        u16 = 19;  # rs, linking through zero
+val RVP_JALR:      u16 = 20;  # rs | rd, rs, imm
+val RVP_MV:        u16 = 21;  # rd, rs -> <op> rd, rs, 0
+val RVP_NOT:       u16 = 22;  # rd, rs -> xori rd, rs, -1
+val RVP_SEQZ:      u16 = 23;  # rd, rs -> sltiu rd, rs, 1
+val RVP_NEG:       u16 = 24;  # rd, rs -> <op> rd, zero, rs
+val RVP_SNEZ:      u16 = 25;  # rd, rs -> sltu rd, zero, rs
+val RVP_LI:        u16 = 26;  # rd, imm - a materialization sequence
+val RVP_LA:        u16 = 27;  # rd, sym - the pc-relative address-of pair
+val RVP_CALL:      u16 = 28;  # sym, linking through ra
+val RVP_TAIL:      u16 = 29;  # sym, linking through t1 and returning nowhere
+val RVP_AMO:       u16 = 30;  # rd, rs2, (rs1)
+val RVP_AMO_LR:    u16 = 31;  # rd, (rs1)
+
+# the RV64A ordering bits an atomic's mnemonic suffix names, in `Mnemonic.flags[15:8]`
+#
+# An atomic's acquire / release bits ARE its memory-ordering guarantee, so they ride
+# the row the decoder synthesizes rather than being recovered from the text twice.
+val RVF_AQ: u16 = 0x0100;  # the atomic acquires (`.aq`)
+val RVF_RL: u16 = 0x0200;  # the atomic releases (`.rl`)
+
+# the operand pattern half of a mnemonic row's flags
+fun rv_pattern(flags: u16) u16 { ret flags & 0x00FF; }
+
+# number of rows in the RV64 inline-asm mnemonic table
+val RV_MNEMONIC_COUNT: usize = 91;
+
+# the RV64 inline-asm instruction surface
+#
+# Exactly the instructions an `asm riscv64` body may name, beyond the RV64A atomic
+# family `rv_decode_amo` synthesizes. A mnemonic absent from both is refused with a
+# diagnostic naming it - there is no permissive path, so the effect model can never
+# be asked about an instruction nobody described.
+#
+# Rows are matched in order, and a mnemonic matches only when followed by a space (or
+# is the whole statement, for a no-operand form), so `add` never shadows `addi` and
+# `j` never shadows `jal`.
+val RV_MNEMONICS: [RV_MNEMONIC_COUNT]iasm.Mnemonic = [RV_MNEMONIC_COUNT]iasm.Mnemonic{
+    # no-operand forms. the environment calls, the barriers and the returns write no
+    # register: `ret` jumps through ra without linking, and a fence orders memory.
+    iasm.Mnemonic{ name: "ecall",  code: inst.ECALL::u32, form: iasm.AF_NONE, writes: iasm.AW_NONE, implicit: 0, flags: RVP_ECALL,  words: 1 },
+    iasm.Mnemonic{ name: "ebreak", code: inst.EBREAK::u32, form: iasm.AF_NONE, writes: iasm.AW_NONE, implicit: 0, flags: RVP_EBREAK, words: 1 },
+    iasm.Mnemonic{ name: "nop",    code: inst.ADDI::u32, form: iasm.AF_NONE, writes: iasm.AW_NONE, implicit: 0, flags: RVP_NOP,    words: 1 },
+    iasm.Mnemonic{ name: "ret",    code: inst.JALR::u32, form: iasm.AF_NONE, writes: iasm.AW_NONE, implicit: 0, flags: RVP_RET,    words: 1 },
+    iasm.Mnemonic{ name: "fence",  code: inst.FENCE::u32, form: iasm.AF_NONE, writes: iasm.AW_NONE, implicit: 0, flags: RVP_FENCE,  words: 1 },
+    iasm.Mnemonic{ name: "pause",  code: inst.PAUSE::u32, form: iasm.AF_NONE, writes: iasm.AW_NONE, implicit: 0, flags: RVP_PAUSE,  words: 1 },
+
+    # register-register integer ALU, and its RV64 word twins. each writes rd.
+    iasm.Mnemonic{ name: "addw",   code: inst.ADDW::u32, form: iasm.AF_OPS, writes: iasm.AW_OP0, implicit: 0, flags: RVP_RRR, words: 1 },
+    iasm.Mnemonic{ name: "subw",   code: inst.SUBW::u32, form: iasm.AF_OPS, writes: iasm.AW_OP0, implicit: 0, flags: RVP_RRR, words: 1 },
+    iasm.Mnemonic{ name: "sllw",   code: inst.SLLW::u32, form: iasm.AF_OPS, writes: iasm.AW_OP0, implicit: 0, flags: RVP_RRR, words: 1 },
+    iasm.Mnemonic{ name: "srlw",   code: inst.SRLW::u32, form: iasm.AF_OPS, writes: iasm.AW_OP0, implicit: 0, flags: RVP_RRR, words: 1 },
+    iasm.Mnemonic{ name: "sraw",   code: inst.SRAW::u32, form: iasm.AF_OPS, writes: iasm.AW_OP0, implicit: 0, flags: RVP_RRR, words: 1 },
+    iasm.Mnemonic{ name: "mulw",   code: inst.MULW::u32, form: iasm.AF_OPS, writes: iasm.AW_OP0, implicit: 0, flags: RVP_RRR, words: 1 },
+    iasm.Mnemonic{ name: "divuw",  code: inst.DIVUW::u32, form: iasm.AF_OPS, writes: iasm.AW_OP0, implicit: 0, flags: RVP_RRR, words: 1 },
+    iasm.Mnemonic{ name: "divw",   code: inst.DIVW::u32, form: iasm.AF_OPS, writes: iasm.AW_OP0, implicit: 0, flags: RVP_RRR, words: 1 },
+    iasm.Mnemonic{ name: "remuw",  code: inst.REMUW::u32, form: iasm.AF_OPS, writes: iasm.AW_OP0, implicit: 0, flags: RVP_RRR, words: 1 },
+    iasm.Mnemonic{ name: "remw",   code: inst.REMW::u32, form: iasm.AF_OPS, writes: iasm.AW_OP0, implicit: 0, flags: RVP_RRR, words: 1 },
+    iasm.Mnemonic{ name: "add",    code: inst.ADD::u32,  form: iasm.AF_OPS, writes: iasm.AW_OP0, implicit: 0, flags: RVP_RRR, words: 1 },
+    iasm.Mnemonic{ name: "sub",    code: inst.SUB::u32,  form: iasm.AF_OPS, writes: iasm.AW_OP0, implicit: 0, flags: RVP_RRR, words: 1 },
+    iasm.Mnemonic{ name: "sll",    code: inst.SLL::u32,  form: iasm.AF_OPS, writes: iasm.AW_OP0, implicit: 0, flags: RVP_RRR, words: 1 },
+    iasm.Mnemonic{ name: "sltu",   code: inst.SLTU::u32,  form: iasm.AF_OPS, writes: iasm.AW_OP0, implicit: 0, flags: RVP_RRR, words: 1 },
+    iasm.Mnemonic{ name: "slt",    code: inst.SLT::u32,  form: iasm.AF_OPS, writes: iasm.AW_OP0, implicit: 0, flags: RVP_RRR, words: 1 },
+    iasm.Mnemonic{ name: "xor",    code: inst.XOR::u32,  form: iasm.AF_OPS, writes: iasm.AW_OP0, implicit: 0, flags: RVP_RRR, words: 1 },
+    iasm.Mnemonic{ name: "srl",    code: inst.SRL::u32,  form: iasm.AF_OPS, writes: iasm.AW_OP0, implicit: 0, flags: RVP_RRR, words: 1 },
+    iasm.Mnemonic{ name: "sra",    code: inst.SRA::u32,  form: iasm.AF_OPS, writes: iasm.AW_OP0, implicit: 0, flags: RVP_RRR, words: 1 },
+    iasm.Mnemonic{ name: "or",     code: inst.OR::u32,  form: iasm.AF_OPS, writes: iasm.AW_OP0, implicit: 0, flags: RVP_RRR, words: 1 },
+    iasm.Mnemonic{ name: "and",    code: inst.AND::u32, form: iasm.AF_OPS, writes: iasm.AW_OP0, implicit: 0, flags: RVP_RRR, words: 1 },
+    iasm.Mnemonic{ name: "mulhsu", code: inst.MULHSU::u32, form: iasm.AF_OPS, writes: iasm.AW_OP0, implicit: 0, flags: RVP_RRR, words: 1 },
+    iasm.Mnemonic{ name: "mulhu",  code: inst.MULHU::u32, form: iasm.AF_OPS, writes: iasm.AW_OP0, implicit: 0, flags: RVP_RRR, words: 1 },
+    iasm.Mnemonic{ name: "mulh",   code: inst.MULH::u32, form: iasm.AF_OPS, writes: iasm.AW_OP0, implicit: 0, flags: RVP_RRR, words: 1 },
+    iasm.Mnemonic{ name: "mul",    code: inst.MUL::u32, form: iasm.AF_OPS, writes: iasm.AW_OP0, implicit: 0, flags: RVP_RRR, words: 1 },
+    iasm.Mnemonic{ name: "divu",   code: inst.DIVU::u32, form: iasm.AF_OPS, writes: iasm.AW_OP0, implicit: 0, flags: RVP_RRR, words: 1 },
+    iasm.Mnemonic{ name: "div",    code: inst.DIV::u32, form: iasm.AF_OPS, writes: iasm.AW_OP0, implicit: 0, flags: RVP_RRR, words: 1 },
+    iasm.Mnemonic{ name: "remu",   code: inst.REMU::u32, form: iasm.AF_OPS, writes: iasm.AW_OP0, implicit: 0, flags: RVP_RRR, words: 1 },
+    iasm.Mnemonic{ name: "rem",    code: inst.REM::u32, form: iasm.AF_OPS, writes: iasm.AW_OP0, implicit: 0, flags: RVP_RRR, words: 1 },
+
+    # register-immediate integer ALU. the shifts take a shift amount rather than a
+    # signed twelve-bit immediate, so they carry their own pattern.
+    iasm.Mnemonic{ name: "addiw", code: inst.ADDIW::u32, form: iasm.AF_OPS, writes: iasm.AW_OP0, implicit: 0, flags: RVP_RRI,   words: 1 },
+    iasm.Mnemonic{ name: "addi",  code: inst.ADDI::u32, form: iasm.AF_OPS, writes: iasm.AW_OP0, implicit: 0, flags: RVP_RRI,   words: 1 },
+    iasm.Mnemonic{ name: "andi",  code: inst.ANDI::u32, form: iasm.AF_OPS, writes: iasm.AW_OP0, implicit: 0, flags: RVP_RRI,   words: 1 },
+    iasm.Mnemonic{ name: "ori",   code: inst.ORI::u32, form: iasm.AF_OPS, writes: iasm.AW_OP0, implicit: 0, flags: RVP_RRI,   words: 1 },
+    iasm.Mnemonic{ name: "xori",  code: inst.XORI::u32, form: iasm.AF_OPS, writes: iasm.AW_OP0, implicit: 0, flags: RVP_RRI,   words: 1 },
+    iasm.Mnemonic{ name: "sltiu", code: inst.SLTIU::u32, form: iasm.AF_OPS, writes: iasm.AW_OP0, implicit: 0, flags: RVP_RRI,   words: 1 },
+    iasm.Mnemonic{ name: "slti",  code: inst.SLTI::u32, form: iasm.AF_OPS, writes: iasm.AW_OP0, implicit: 0, flags: RVP_RRI,   words: 1 },
+    iasm.Mnemonic{ name: "slliw", code: inst.SLLIW::u32, form: iasm.AF_OPS, writes: iasm.AW_OP0, implicit: 0, flags: RVP_SHIFT, words: 1 },
+    iasm.Mnemonic{ name: "srliw", code: inst.SRLIW::u32, form: iasm.AF_OPS, writes: iasm.AW_OP0, implicit: 0, flags: RVP_SHIFT, words: 1 },
+    iasm.Mnemonic{ name: "sraiw", code: inst.SRAIW::u32, form: iasm.AF_OPS, writes: iasm.AW_OP0, implicit: 0, flags: RVP_SHIFT, words: 1 },
+    iasm.Mnemonic{ name: "slli",  code: inst.SLLI::u32, form: iasm.AF_OPS, writes: iasm.AW_OP0, implicit: 0, flags: RVP_SHIFT, words: 1 },
+    iasm.Mnemonic{ name: "srli",  code: inst.SRLI::u32, form: iasm.AF_OPS, writes: iasm.AW_OP0, implicit: 0, flags: RVP_SHIFT, words: 1 },
+    iasm.Mnemonic{ name: "srai",  code: inst.SRAI::u32, form: iasm.AF_OPS, writes: iasm.AW_OP0, implicit: 0, flags: RVP_SHIFT, words: 1 },
+
+    # integer loads write their destination; integer stores write memory and no
+    # register.
+    iasm.Mnemonic{ name: "lbu", code: inst.LBU::u32, form: iasm.AF_OPS, writes: iasm.AW_OP0, implicit: 0, flags: RVP_LOAD, words: 1 },
+    iasm.Mnemonic{ name: "lhu", code: inst.LHU::u32, form: iasm.AF_OPS, writes: iasm.AW_OP0, implicit: 0, flags: RVP_LOAD, words: 1 },
+    iasm.Mnemonic{ name: "lwu", code: inst.LWU::u32, form: iasm.AF_OPS, writes: iasm.AW_OP0, implicit: 0, flags: RVP_LOAD, words: 1 },
+    iasm.Mnemonic{ name: "lb",  code: inst.LB::u32, form: iasm.AF_OPS, writes: iasm.AW_OP0, implicit: 0, flags: RVP_LOAD, words: 1 },
+    iasm.Mnemonic{ name: "lh",  code: inst.LH::u32, form: iasm.AF_OPS, writes: iasm.AW_OP0, implicit: 0, flags: RVP_LOAD, words: 1 },
+    iasm.Mnemonic{ name: "lw",  code: inst.LW::u32, form: iasm.AF_OPS, writes: iasm.AW_OP0, implicit: 0, flags: RVP_LOAD, words: 1 },
+    iasm.Mnemonic{ name: "ld",  code: inst.LD::u32, form: iasm.AF_OPS, writes: iasm.AW_OP0, implicit: 0, flags: RVP_LOAD, words: 1 },
+    iasm.Mnemonic{ name: "sb",  code: inst.SB::u32, form: iasm.AF_OPS, writes: iasm.AW_NONE, implicit: 0, flags: RVP_STORE, words: 1 },
+    iasm.Mnemonic{ name: "sh",  code: inst.SH::u32, form: iasm.AF_OPS, writes: iasm.AW_NONE, implicit: 0, flags: RVP_STORE, words: 1 },
+    iasm.Mnemonic{ name: "sw",  code: inst.SW::u32, form: iasm.AF_OPS, writes: iasm.AW_NONE, implicit: 0, flags: RVP_STORE, words: 1 },
+    iasm.Mnemonic{ name: "sd",  code: inst.SD::u32, form: iasm.AF_OPS, writes: iasm.AW_NONE, implicit: 0, flags: RVP_STORE, words: 1 },
+
+    # upper-immediate address formation writes its destination.
+    iasm.Mnemonic{ name: "lui",   code: inst.LUI::u32, form: iasm.AF_OPS, writes: iasm.AW_OP0, implicit: 0, flags: RVP_UIMM, words: 1 },
+    iasm.Mnemonic{ name: "auipc", code: inst.AUIPC::u32, form: iasm.AF_OPS, writes: iasm.AW_OP0, implicit: 0, flags: RVP_UIMM, words: 1 },
+
+    # conditional branches to a numeric local label, including the reversed and
+    # compare-against-zero pseudo spellings. a branch writes no register.
+    iasm.Mnemonic{ name: "beqz", code: inst.BEQ::u32, form: iasm.AF_OPS, writes: iasm.AW_NONE, implicit: 0, flags: RVP_BRANCH_Z1, words: 1 },
+    iasm.Mnemonic{ name: "bnez", code: inst.BNE::u32, form: iasm.AF_OPS, writes: iasm.AW_NONE, implicit: 0, flags: RVP_BRANCH_Z1, words: 1 },
+    iasm.Mnemonic{ name: "bltz", code: inst.BLT::u32, form: iasm.AF_OPS, writes: iasm.AW_NONE, implicit: 0, flags: RVP_BRANCH_Z1, words: 1 },
+    iasm.Mnemonic{ name: "bgez", code: inst.BGE::u32, form: iasm.AF_OPS, writes: iasm.AW_NONE, implicit: 0, flags: RVP_BRANCH_Z1, words: 1 },
+    iasm.Mnemonic{ name: "blez", code: inst.BGE::u32, form: iasm.AF_OPS, writes: iasm.AW_NONE, implicit: 0, flags: RVP_BRANCH_Z2, words: 1 },
+    iasm.Mnemonic{ name: "bgtz", code: inst.BLT::u32, form: iasm.AF_OPS, writes: iasm.AW_NONE, implicit: 0, flags: RVP_BRANCH_Z2, words: 1 },
+    iasm.Mnemonic{ name: "bltu", code: inst.BLTU::u32, form: iasm.AF_OPS, writes: iasm.AW_NONE, implicit: 0, flags: RVP_BRANCH,    words: 1 },
+    iasm.Mnemonic{ name: "bgeu", code: inst.BGEU::u32, form: iasm.AF_OPS, writes: iasm.AW_NONE, implicit: 0, flags: RVP_BRANCH,    words: 1 },
+    iasm.Mnemonic{ name: "bgtu", code: inst.BLTU::u32, form: iasm.AF_OPS, writes: iasm.AW_NONE, implicit: 0, flags: RVP_BRANCH_SW, words: 1 },
+    iasm.Mnemonic{ name: "bleu", code: inst.BGEU::u32, form: iasm.AF_OPS, writes: iasm.AW_NONE, implicit: 0, flags: RVP_BRANCH_SW, words: 1 },
+    iasm.Mnemonic{ name: "beq",  code: inst.BEQ::u32, form: iasm.AF_OPS, writes: iasm.AW_NONE, implicit: 0, flags: RVP_BRANCH,    words: 1 },
+    iasm.Mnemonic{ name: "bne",  code: inst.BNE::u32, form: iasm.AF_OPS, writes: iasm.AW_NONE, implicit: 0, flags: RVP_BRANCH,    words: 1 },
+    iasm.Mnemonic{ name: "blt",  code: inst.BLT::u32, form: iasm.AF_OPS, writes: iasm.AW_NONE, implicit: 0, flags: RVP_BRANCH,    words: 1 },
+    iasm.Mnemonic{ name: "bge",  code: inst.BGE::u32, form: iasm.AF_OPS, writes: iasm.AW_NONE, implicit: 0, flags: RVP_BRANCH,    words: 1 },
+    iasm.Mnemonic{ name: "bgt",  code: inst.BLT::u32, form: iasm.AF_OPS, writes: iasm.AW_NONE, implicit: 0, flags: RVP_BRANCH_SW, words: 1 },
+    iasm.Mnemonic{ name: "ble",  code: inst.BGE::u32, form: iasm.AF_OPS, writes: iasm.AW_NONE, implicit: 0, flags: RVP_BRANCH_SW, words: 1 },
+
+    # jumps and calls. a linking jump destroys the caller-saved file, which is what
+    # licenses the allocator to hold nothing across it; a non-linking one (`j`, `jr`)
+    # transfers control and writes nothing.
+    iasm.Mnemonic{ name: "jalr", code: inst.JALR::u32, form: iasm.AF_OPS, writes: iasm.AW_NONE, implicit: CALLER_SAVED_GP, flags: RVP_JALR, words: 1 },
+    iasm.Mnemonic{ name: "jal",  code: inst.JAL::u32, form: iasm.AF_OPS, writes: iasm.AW_OP0,  implicit: CALLER_SAVED_GP, flags: RVP_JAL,  words: 1 },
+    iasm.Mnemonic{ name: "jr",   code: inst.JALR::u32, form: iasm.AF_OPS, writes: iasm.AW_NONE, implicit: 0,          flags: RVP_JR,   words: 1 },
+    iasm.Mnemonic{ name: "j",    code: inst.JAL::u32, form: iasm.AF_OPS, writes: iasm.AW_NONE, implicit: 0,          flags: RVP_J,    words: 1 },
+    iasm.Mnemonic{ name: "call", code: inst.AUIPC::u32, form: iasm.AF_OPS, writes: iasm.AW_NONE, implicit: CALLER_SAVED_GP, flags: RVP_CALL, words: 2 },
+    iasm.Mnemonic{ name: "tail", code: inst.AUIPC::u32, form: iasm.AF_OPS, writes: iasm.AW_NONE, implicit: CALLER_SAVED_GP, flags: RVP_TAIL, words: 2 },
+
+    # the pseudo data-movement and unary forms, each naming the real instruction it
+    # spells.
+    iasm.Mnemonic{ name: "li",     code: inst.LUI::u32, form: iasm.AF_OPS, writes: iasm.AW_OP0, implicit: 0, flags: RVP_LI,   words: iasm.WORDS_VARIABLE },
+    iasm.Mnemonic{ name: "la",     code: inst.AUIPC::u32, form: iasm.AF_OPS, writes: iasm.AW_OP0, implicit: 0, flags: RVP_LA,   words: 2 },
+    iasm.Mnemonic{ name: "mv",     code: inst.ADDI::u32, form: iasm.AF_OPS, writes: iasm.AW_OP0, implicit: 0, flags: RVP_MV,   words: 1 },
+    iasm.Mnemonic{ name: "sext.w", code: inst.ADDIW::u32, form: iasm.AF_OPS, writes: iasm.AW_OP0, implicit: 0, flags: RVP_MV,   words: 1 },
+    iasm.Mnemonic{ name: "negw",   code: inst.SUBW::u32, form: iasm.AF_OPS, writes: iasm.AW_OP0, implicit: 0, flags: RVP_NEG,  words: 1 },
+    iasm.Mnemonic{ name: "neg",    code: inst.SUB::u32,  form: iasm.AF_OPS, writes: iasm.AW_OP0, implicit: 0, flags: RVP_NEG,  words: 1 },
+    iasm.Mnemonic{ name: "not",    code: inst.XORI::u32, form: iasm.AF_OPS, writes: iasm.AW_OP0, implicit: 0, flags: RVP_NOT,  words: 1 },
+    iasm.Mnemonic{ name: "seqz",   code: inst.SLTIU::u32, form: iasm.AF_OPS, writes: iasm.AW_OP0, implicit: 0, flags: RVP_SEQZ, words: 1 },
+    iasm.Mnemonic{ name: "snez",   code: inst.SLTU::u32,  form: iasm.AF_OPS, writes: iasm.AW_OP0, implicit: 0, flags: RVP_SNEZ, words: 1 },
+};
+
+# decode an RV64A atomic mnemonic the table cannot enumerate
+#
+# `lr` / `sc` / `amo<op>` cross a width suffix (`.w` / `.d`) with an ordering suffix
+# (none / `.aq` / `.rl` / `.aqrl`), which is a hundred-odd spellings of twenty-two
+# instructions - a family, not a list. The decoder names the concrete instruction and
+# carries the ordering in the row's flags, so `amoswap.d.rl` can never render or
+# model as a plain exchange.
+# ---
+# body:  the asm body
+# lo:    body offset the statement starts at
+# hi:    body offset just past the statement
+# m:     receives the synthesized row
+# n_out: receives the mnemonic's byte length
+# ret:   true when the statement names an atomic
+fun rv_decode_amo(body: str, lo: usize, hi: usize, m: *iasm.Mnemonic, n_out: *usize) bool {
+    var end: usize = lo;
+    for (end < hi && !iasm.is_space(body[end])) { end = end + 1; }
+    var len: usize = end - lo;
+    if (len < 4) { ret false; }
+
+    var order: u16 = 0;
+    if (len >= 5 && str_region_equals(body, lo + len - 5, 5, ".aqrl")) { order = RVF_AQ | RVF_RL; len = len - 5; }
+    or (len >= 3 && str_region_equals(body, lo + len - 3, 3, ".aq"))   { order = RVF_AQ;           len = len - 3; }
+    or (len >= 3 && str_region_equals(body, lo + len - 3, 3, ".rl"))   { order = RVF_RL;           len = len - 3; }
+    if (len < 4) { ret false; }
+
+    var word: bool = false;
+    if (str_region_equals(body, lo + len - 2, 2, ".w"))      { word = true; }
+    or (str_region_equals(body, lo + len - 2, 2, ".d"))      { word = false; }
+    or { ret false; }
+    val blen: usize = len - 2;
+
+    var code: u32 = 0;
+    var pat: u16 = RVP_AMO;
+    if (str_region_equals(body, lo, blen, "lr"))           { code = inst.LR_W::u32; pat = RVP_AMO_LR; }
+    or (str_region_equals(body, lo, blen, "sc"))           { code = inst.SC_W::u32; }
+    or (str_region_equals(body, lo, blen, "amoswap"))      { code = inst.AMOSWAP_W::u32; }
+    or (str_region_equals(body, lo, blen, "amoadd"))       { code = inst.AMOADD_W::u32; }
+    or (str_region_equals(body, lo, blen, "amoxor"))       { code = inst.AMOXOR_W::u32; }
+    or (str_region_equals(body, lo, blen, "amoand"))       { code = inst.AMOAND_W::u32; }
+    or (str_region_equals(body, lo, blen, "amoor"))        { code = inst.AMOOR_W::u32; }
+    or (str_region_equals(body, lo, blen, "amominu"))      { code = inst.AMOMINU_W::u32; }
+    or (str_region_equals(body, lo, blen, "amomaxu"))      { code = inst.AMOMAXU_W::u32; }
+    or (str_region_equals(body, lo, blen, "amomin"))       { code = inst.AMOMIN_W::u32; }
+    or (str_region_equals(body, lo, blen, "amomax"))       { code = inst.AMOMAX_W::u32; }
+    or { ret false; }
+    # the table pairs each atomic as (word form, doubleword form) in that order.
+    if (!word) { code = code + 1; }
+
+    m.name     = nil;
+    m.code     = code;
+    m.form     = iasm.AF_OPS;
+    m.writes   = iasm.AW_OP0;
+    m.implicit = 0;
+    m.flags    = pat | order;
+    m.words    = 1;
+    @n_out     = end - lo;
+    ret true;
 }
 
-# true when `mnem` names an RV64A atomic (lr / sc / amo*). the width (.w/.d) and
-# ordering (.aq/.rl/.aqrl) suffixes ride along, so a prefix test classifies the whole
-# family. used by the clobber classifier - lr / sc / amo* all write their rd operand
-fun rv_mnem_is_amo(mnem: str) bool {
-    val len: usize = str_len(mnem);
-    if (len >= 3 && mnem[0] == 'l'::char && mnem[1] == 'r'::char && mnem[2] == '.'::char) { ret true; }
-    if (len >= 3 && mnem[0] == 's'::char && mnem[1] == 'c'::char && mnem[2] == '.'::char) { ret true; }
-    if (len >= 3 && mnem[0] == 'a'::char && mnem[1] == 'm'::char && mnem[2] == 'o'::char) { ret true; }
+# the instruction format an RV64 instruction takes
+val RVFMT_R: u8 = 0;  # register-register
+val RVFMT_I: u8 = 1;  # register-immediate
+val RVFMT_S: u8 = 2;  # store
+val RVFMT_B: u8 = 3;  # conditional branch
+val RVFMT_U: u8 = 4;  # upper immediate
+val RVFMT_J: u8 = 5;  # jump
+
+# the format and funct fields an RV64 instruction encodes to
+#
+# The inverse of the encoder's `classify_*` family: those name an instruction FROM
+# the fields a packer received, this recovers the fields FROM the instruction. The
+# two are proved mutually inverse by a test over every instruction this grammar can
+# name, so an assembled instruction and the one the printer renders cannot drift.
+# This is the direction #2118 makes the encoder's only one.
+# ---
+# op:     the instruction
+# fmt:    receives the instruction format (RVFMT_*)
+# opcode: receives the seven-bit major opcode
+# f3:     receives the funct3 field
+# f7:     receives the funct7 field
+# ret:    true when the instruction is one this grammar encodes
+fun rv_fields(op: inst.MachOp, fmt: *u8, opcode: *u32, f3: *u32, f7: *u32) bool {
+    @fmt = RVFMT_R; @opcode = 0; @f3 = 0; @f7 = F7_ZERO;
+
+    # register-register integer ALU (OP), and the RV64 word forms (OP_32).
+    if (op == inst.ADD)  { @opcode = OPC_OP; @f3 = F3_ADD;  ret true; }
+    if (op == inst.SLL)  { @opcode = OPC_OP; @f3 = F3_SLL;  ret true; }
+    if (op == inst.SLT)  { @opcode = OPC_OP; @f3 = F3_SLT;  ret true; }
+    if (op == inst.SLTU) { @opcode = OPC_OP; @f3 = F3_SLTU; ret true; }
+    if (op == inst.XOR)  { @opcode = OPC_OP; @f3 = F3_XOR;  ret true; }
+    if (op == inst.SRL)  { @opcode = OPC_OP; @f3 = F3_SRL;  ret true; }
+    if (op == inst.OR)   { @opcode = OPC_OP; @f3 = F3_OR;   ret true; }
+    if (op == inst.AND)  { @opcode = OPC_OP; @f3 = F3_AND;  ret true; }
+    if (op == inst.SUB)  { @opcode = OPC_OP; @f3 = F3_ADD; @f7 = F7_SUB; ret true; }
+    if (op == inst.SRA)  { @opcode = OPC_OP; @f3 = F3_SRL; @f7 = F7_SUB; ret true; }
+    if (op == inst.ADDW) { @opcode = OPC_OP_32; @f3 = F3_ADD; ret true; }
+    if (op == inst.SLLW) { @opcode = OPC_OP_32; @f3 = F3_SLL; ret true; }
+    if (op == inst.SRLW) { @opcode = OPC_OP_32; @f3 = F3_SRL; ret true; }
+    if (op == inst.SUBW) { @opcode = OPC_OP_32; @f3 = F3_ADD; @f7 = F7_SUB; ret true; }
+    if (op == inst.SRAW) { @opcode = OPC_OP_32; @f3 = F3_SRL; @f7 = F7_SUB; ret true; }
+
+    # the M extension, and its RV64 word forms.
+    if (op == inst.MUL)    { @opcode = OPC_OP; @f3 = F3_ADD;  @f7 = F7_MULDIV; ret true; }
+    if (op == inst.MULH)   { @opcode = OPC_OP; @f3 = F3_SLL;  @f7 = F7_MULDIV; ret true; }
+    if (op == inst.MULHSU) { @opcode = OPC_OP; @f3 = F3_SLT;  @f7 = F7_MULDIV; ret true; }
+    if (op == inst.MULHU)  { @opcode = OPC_OP; @f3 = F3_SLTU; @f7 = F7_MULDIV; ret true; }
+    if (op == inst.DIV)    { @opcode = OPC_OP; @f3 = F3_DIV;  @f7 = F7_MULDIV; ret true; }
+    if (op == inst.DIVU)   { @opcode = OPC_OP; @f3 = F3_DIVU; @f7 = F7_MULDIV; ret true; }
+    if (op == inst.REM)    { @opcode = OPC_OP; @f3 = F3_REM;  @f7 = F7_MULDIV; ret true; }
+    if (op == inst.REMU)   { @opcode = OPC_OP; @f3 = F3_REMU; @f7 = F7_MULDIV; ret true; }
+    if (op == inst.MULW)   { @opcode = OPC_OP_32; @f3 = F3_ADD;  @f7 = F7_MULDIV; ret true; }
+    if (op == inst.DIVW)   { @opcode = OPC_OP_32; @f3 = F3_DIV;  @f7 = F7_MULDIV; ret true; }
+    if (op == inst.DIVUW)  { @opcode = OPC_OP_32; @f3 = F3_DIVU; @f7 = F7_MULDIV; ret true; }
+    if (op == inst.REMW)   { @opcode = OPC_OP_32; @f3 = F3_REM;  @f7 = F7_MULDIV; ret true; }
+    if (op == inst.REMUW)  { @opcode = OPC_OP_32; @f3 = F3_REMU; @f7 = F7_MULDIV; ret true; }
+
+    # register-immediate integer ALU (OP_IMM / OP_IMM_32). the arithmetic right
+    # shifts share a funct3 with the logical ones and are selected by imm[10], which
+    # the emitter sets from the instruction.
+    if (op == inst.ADDI)  { @fmt = RVFMT_I; @opcode = OPC_OP_IMM; @f3 = F3_ADD;  ret true; }
+    if (op == inst.SLTI)  { @fmt = RVFMT_I; @opcode = OPC_OP_IMM; @f3 = F3_SLT;  ret true; }
+    if (op == inst.SLTIU) { @fmt = RVFMT_I; @opcode = OPC_OP_IMM; @f3 = F3_SLTU; ret true; }
+    if (op == inst.XORI)  { @fmt = RVFMT_I; @opcode = OPC_OP_IMM; @f3 = F3_XOR;  ret true; }
+    if (op == inst.ORI)   { @fmt = RVFMT_I; @opcode = OPC_OP_IMM; @f3 = F3_OR;   ret true; }
+    if (op == inst.ANDI)  { @fmt = RVFMT_I; @opcode = OPC_OP_IMM; @f3 = F3_AND;  ret true; }
+    if (op == inst.SLLI)  { @fmt = RVFMT_I; @opcode = OPC_OP_IMM; @f3 = F3_SLL;  ret true; }
+    if (op == inst.SRLI)  { @fmt = RVFMT_I; @opcode = OPC_OP_IMM; @f3 = F3_SRL;  ret true; }
+    if (op == inst.SRAI)  { @fmt = RVFMT_I; @opcode = OPC_OP_IMM; @f3 = F3_SRL;  ret true; }
+    if (op == inst.ADDIW) { @fmt = RVFMT_I; @opcode = OPC_OP_IMM_32; @f3 = F3_ADD; ret true; }
+    if (op == inst.SLLIW) { @fmt = RVFMT_I; @opcode = OPC_OP_IMM_32; @f3 = F3_SLL; ret true; }
+    if (op == inst.SRLIW) { @fmt = RVFMT_I; @opcode = OPC_OP_IMM_32; @f3 = F3_SRL; ret true; }
+    if (op == inst.SRAIW) { @fmt = RVFMT_I; @opcode = OPC_OP_IMM_32; @f3 = F3_SRL; ret true; }
+
+    # integer loads and stores, and the register-indirect jump, which is a load-form
+    # instruction taking an `off(base)` address.
+    if (op == inst.LB)   { @fmt = RVFMT_I; @opcode = OPC_LOAD; @f3 = 0x0; ret true; }
+    if (op == inst.LH)   { @fmt = RVFMT_I; @opcode = OPC_LOAD; @f3 = 0x1; ret true; }
+    if (op == inst.LW)   { @fmt = RVFMT_I; @opcode = OPC_LOAD; @f3 = 0x2; ret true; }
+    if (op == inst.LD)   { @fmt = RVFMT_I; @opcode = OPC_LOAD; @f3 = 0x3; ret true; }
+    if (op == inst.LBU)  { @fmt = RVFMT_I; @opcode = OPC_LOAD; @f3 = 0x4; ret true; }
+    if (op == inst.LHU)  { @fmt = RVFMT_I; @opcode = OPC_LOAD; @f3 = 0x5; ret true; }
+    if (op == inst.LWU)  { @fmt = RVFMT_I; @opcode = OPC_LOAD; @f3 = 0x6; ret true; }
+    if (op == inst.JALR) { @fmt = RVFMT_I; @opcode = OPC_JALR; @f3 = F3_ADD; ret true; }
+    if (op == inst.SB) { @fmt = RVFMT_S; @opcode = OPC_STORE; @f3 = 0x0; ret true; }
+    if (op == inst.SH) { @fmt = RVFMT_S; @opcode = OPC_STORE; @f3 = 0x1; ret true; }
+    if (op == inst.SW) { @fmt = RVFMT_S; @opcode = OPC_STORE; @f3 = 0x2; ret true; }
+    if (op == inst.SD) { @fmt = RVFMT_S; @opcode = OPC_STORE; @f3 = 0x3; ret true; }
+
+    # the environment and memory-ordering forms, whose immediate the emitter supplies.
+    if (op == inst.ECALL || op == inst.EBREAK) { @fmt = RVFMT_I; @opcode = OPC_SYSTEM;   @f3 = F3_ADD; ret true; }
+    if (op == inst.FENCE || op == inst.PAUSE)  { @fmt = RVFMT_I; @opcode = OPC_MISC_MEM; @f3 = F3_ADD; ret true; }
+
+    # conditional branches, upper-immediate address formation and the direct jump.
+    if (op == inst.BEQ)  { @fmt = RVFMT_B; @opcode = OPC_BRANCH; @f3 = F3_BEQ;  ret true; }
+    if (op == inst.BNE)  { @fmt = RVFMT_B; @opcode = OPC_BRANCH; @f3 = F3_BNE;  ret true; }
+    if (op == inst.BLT)  { @fmt = RVFMT_B; @opcode = OPC_BRANCH; @f3 = F3_BLT;  ret true; }
+    if (op == inst.BGE)  { @fmt = RVFMT_B; @opcode = OPC_BRANCH; @f3 = F3_BGE;  ret true; }
+    if (op == inst.BLTU) { @fmt = RVFMT_B; @opcode = OPC_BRANCH; @f3 = F3_BLTU; ret true; }
+    if (op == inst.BGEU) { @fmt = RVFMT_B; @opcode = OPC_BRANCH; @f3 = F3_BGEU; ret true; }
+    if (op == inst.LUI)   { @fmt = RVFMT_U; @opcode = OPC_LUI;   ret true; }
+    if (op == inst.AUIPC) { @fmt = RVFMT_U; @opcode = OPC_AUIPC; ret true; }
+    if (op == inst.JAL)   { @fmt = RVFMT_J; @opcode = OPC_JAL;   ret true; }
+
+    # the A extension. the ordering bits are the emitter's, from the row's flags.
+    if (op >= inst.LR_W && op <= inst.AMOMAXU_D) {
+        @opcode = OPC_AMO;
+        @f3     = F3_AMO_D;
+        if (rv_amo_is_word(op)) { @f3 = F3_AMO_W; }
+        @f7 = rv_amo_funct5(op) << 2;
+        ret true;
+    }
     ret false;
 }
 
-# OR the registers one trimmed RISC-V inline-asm statement writes into `@gp`. a
-# leading `label:` is stripped and the remainder re-dispatched. a call clobbers the
-# caller-saved file; the stores / branches / system / fence / pause / return forms write
-# nothing; the recognized destination-writing forms (including the RV64A atomics) clobber
-# their first register operand; an unrecognized statement conservatively clobbers
-# everything
-fun asm_stmt_clobbers(s: str, gp: *u32, fp: *u32) {
-    var mbuf: [32]u8;
-    var after: usize = 0;
-    if (!asm_token(s, 0, ?mbuf[0], 32, ?after)) { ret; }
-    var mnem: str = (?mbuf[0])::str;
-
-    # a `label:` prefix (named or numeric) carries no write; re-dispatch the rest.
-    val mlen: usize = str_len(mnem);
-    if (mlen > 0 && mnem[mlen - 1] == ':'::char) {
-        var rest: usize = after;
-        for (s[rest] != 0 && asm_is_space(s[rest])) { rest = rest + 1; }
-        if (s[rest] != 0) { asm_stmt_clobbers((s::usize + rest)::str, gp, fp); }
-        ret;
-    }
-
-    # write nothing: stores, conditional branches (including the pseudo-branch
-    # spellings), unconditional jumps, return, system, fence, nop.
-    if (str_equals(mnem, "sb") || str_equals(mnem, "sh") || str_equals(mnem, "sw") ||
-        str_equals(mnem, "sd") || str_equals(mnem, "nop") || str_equals(mnem, "ret") ||
-        str_equals(mnem, "ecall") || str_equals(mnem, "ebreak") || str_equals(mnem, "fence") ||
-        str_equals(mnem, "pause") ||
-        str_equals(mnem, "j") || str_equals(mnem, "jr") ||
-        str_equals(mnem, "beq") || str_equals(mnem, "bne") || str_equals(mnem, "blt") ||
-        str_equals(mnem, "bge") || str_equals(mnem, "bltu") || str_equals(mnem, "bgeu") ||
-        str_equals(mnem, "bgt") || str_equals(mnem, "ble") || str_equals(mnem, "bgtu") ||
-        str_equals(mnem, "bleu") || str_equals(mnem, "beqz") || str_equals(mnem, "bnez") ||
-        str_equals(mnem, "bltz") || str_equals(mnem, "bgez") || str_equals(mnem, "blez") ||
-        str_equals(mnem, "bgtz")) {
-        ret;
-    }
-
-    # a call clobbers the caller-saved file (ra, t0-t6, a0-a7); none callee-saved.
-    if (str_equals(mnem, "call") || str_equals(mnem, "tail") ||
-        str_equals(mnem, "jal") || str_equals(mnem, "jalr")) {
-        @gp = @gp | CALLER_SAVED_GP;
-        ret;
-    }
-
-    # the destination-writing forms clobber their first register operand (rd). the
-    # RV64A atomics (lr / sc / amo*) join this set: each writes rd, the leftmost operand.
-    if (rv_mnem_is_amo(mnem) ||
-        str_equals(mnem, "li") || str_equals(mnem, "la") || str_equals(mnem, "lui") ||
-        str_equals(mnem, "auipc") || str_equals(mnem, "mv") || str_equals(mnem, "neg") ||
-        str_equals(mnem, "not") || str_equals(mnem, "seqz") || str_equals(mnem, "snez") ||
-        str_equals(mnem, "add") || str_equals(mnem, "addi") || str_equals(mnem, "sub") ||
-        str_equals(mnem, "and") || str_equals(mnem, "andi") || str_equals(mnem, "or") ||
-        str_equals(mnem, "ori") || str_equals(mnem, "xor") || str_equals(mnem, "xori") ||
-        str_equals(mnem, "sll") || str_equals(mnem, "slli") || str_equals(mnem, "srl") ||
-        str_equals(mnem, "srli") || str_equals(mnem, "sra") || str_equals(mnem, "srai") ||
-        str_equals(mnem, "slt") || str_equals(mnem, "slti") || str_equals(mnem, "sltu") ||
-        str_equals(mnem, "sltiu") || str_equals(mnem, "addw") || str_equals(mnem, "addiw") ||
-        str_equals(mnem, "subw") || str_equals(mnem, "sllw") || str_equals(mnem, "slliw") ||
-        str_equals(mnem, "srlw") || str_equals(mnem, "srliw") || str_equals(mnem, "sraw") ||
-        str_equals(mnem, "sraiw") || str_equals(mnem, "negw") || str_equals(mnem, "sext.w") ||
-        str_equals(mnem, "mul") || str_equals(mnem, "mulw") || str_equals(mnem, "mulh") ||
-        str_equals(mnem, "mulhu") || str_equals(mnem, "mulhsu") || str_equals(mnem, "div") ||
-        str_equals(mnem, "divu") || str_equals(mnem, "divw") || str_equals(mnem, "rem") ||
-        str_equals(mnem, "remu") || str_equals(mnem, "remw") || str_equals(mnem, "lb") ||
-        str_equals(mnem, "lh") || str_equals(mnem, "lw") || str_equals(mnem, "ld") ||
-        str_equals(mnem, "lbu") || str_equals(mnem, "lhu") || str_equals(mnem, "lwu")) {
-        var rbuf: [32]u8;
-        var rnext: usize = 0;
-        if (asm_token(s, after, ?rbuf[0], 32, ?rnext)) {
-            val ri: i32 = asm_reg_index((?rbuf[0])::str);
-            if (ri >= 0 && ri < 32) { @gp = @gp | (1::u32 << ri::u32); }
-        }
-        ret;
-    }
-
-    # unrecognized: opaque, clobber everything (a sound over-approximation).
-    @gp = @gp | 0xFFFFFFFF;
-    @fp = @fp | 0xFFFFFFFF;
+# true when an A-extension instruction is the 32-bit (`.w`) form
+#
+# The list pairs each atomic as (word, doubleword), so the word form is the even
+# member of its pair counting from `LR_W`.
+fun rv_amo_is_word(op: inst.MachOp) bool {
+    ret ((op - inst.LR_W) & 1) == 0;
 }
 
-# the AsmClobbersFn the RV64 ISA vtable exposes - infer the GP registers an
-# inline-asm body writes, so the allocator leaves no live value in one and the
-# prologue preserves any callee-saved register the body clobbers. without this hook a
-# nil slot forces a conservative all-register clobber, framing every asm function
-# (e.g. `_start`, whose frame allocation then mis-reads argc off the entry stack). the
-# body is split into statements on newline / `;`, each trimmed and classified. the
-# grammar has no FP write yet, so `fp_out` stays empty unless an unrecognized
-# statement forces the conservative all-clobber
+# the five-bit operation field an A-extension instruction encodes
+fun rv_amo_funct5(op: inst.MachOp) u32 {
+    if (op == inst.LR_W || op == inst.LR_D)             { ret A5_LR; }
+    if (op == inst.SC_W || op == inst.SC_D)             { ret A5_SC; }
+    if (op == inst.AMOSWAP_W || op == inst.AMOSWAP_D)   { ret A5_AMOSWAP; }
+    if (op == inst.AMOADD_W || op == inst.AMOADD_D)     { ret A5_AMOADD; }
+    if (op == inst.AMOXOR_W || op == inst.AMOXOR_D)     { ret A5_AMOXOR; }
+    if (op == inst.AMOAND_W || op == inst.AMOAND_D)     { ret A5_AMOAND; }
+    if (op == inst.AMOOR_W || op == inst.AMOOR_D)       { ret A5_AMOOR; }
+    if (op == inst.AMOMIN_W || op == inst.AMOMIN_D)     { ret A5_AMOMIN; }
+    if (op == inst.AMOMAX_W || op == inst.AMOMAX_D)     { ret A5_AMOMAX; }
+    if (op == inst.AMOMINU_W || op == inst.AMOMINU_D)   { ret A5_AMOMINU; }
+    ret A5_AMOMAXU;
+}
+
+# parse one RV64 operand token into `op`
+#
+# The RV64 operand syntax: a psABI or `xN` register name, an `off(base)` address, a
+# bare or `%mod(sym)` symbol reference, a `{name}` local binding, or an integer
+# literal.
+# ---
+# c:  the cursor
+# lo: body offset the token starts at
+# hi: body offset just past it
+# op: receives the parsed operand
+# ret: ok(true), or the refusal naming the malformed operand
+fun rv_operand(c: *iasm.Cursor, lo: usize, hi: usize, op: *iasm.Operand) R.Result[bool, str] {
+    @op = iasm.op_none();
+    if (hi <= lo) { ret R.err[bool, str]("encode: malformed inline-asm operand"); }
+
+    # a `{name}` local: with a laid-out frame it becomes the `off(s0)` stack slot it
+    # denotes; without one the displacement is genuinely unknown, and the operand
+    # stays a binding - it names a stack slot either way, so it can never be a
+    # register and the effect model reads it exactly as it reads memory.
+    if (c.body[lo] == '{'::char) {
+        var off: i64 = 0;
+        val br: R.Result[bool, str] = iasm.bind_offset(c, lo, hi, ?off);
+        if (R.is_err[bool, str](br)) { ret br; }
+        if (R.unwrap_ok[bool, str](br)) {
+            @op = iasm.op_mem(RFP::i32, off, -1, 0, 8);
+            ret R.ok[bool, str](true);
+        }
+        op.kind     = iasm.AOP_BIND;
+        op.size     = 8;
+        op.name_off = lo + 1;
+        op.name_len = hi - lo - 2;
+        ret R.ok[bool, str](true);
+    }
+
+    var buf: [64]u8;
+    if (!iasm.copy_region(c.body, lo, hi, ?buf[0], 64)) { ret R.err[bool, str]("encode: malformed inline-asm operand"); }
+    val tok: str = (?buf[0])::str;
+
+    val ri: i32 = asm_reg_index(tok);
+    if (ri >= 0) { @op = iasm.op_reg(ri, 8); ret R.ok[bool, str](true); }
+
+    # a relocation modifier `%mod(sym)`, the spelling the printer emits for the two
+    # halves of a pc-relative symbol pair.
+    if (c.body[lo] == '%'::char) { ret rv_modifier(c, lo, hi, op); }
+
+    # an `off(base)` address; `(base)` is the zero-displacement form atomics require.
+    if (c.body[hi - 1] == ')'::char) { ret rv_mem(c, lo, hi, op); }
+
+    val iv: O.Option[i64] = iasm.region_i64(c.body, lo, hi);
+    if (O.is_some[i64](iv)) { @op = iasm.op_imm(O.unwrap[i64](iv), 8); ret R.ok[bool, str](true); }
+
+    if (iasm.is_sym_region(c.body, lo, hi)) {
+        @op = iasm.op_sym(lo, hi - lo, isa.SYM_MOD_NONE, 8);
+        ret R.ok[bool, str](true);
+    }
+    ret R.err[bool, str]("encode: malformed inline-asm operand");
+}
+
+# parse a `%pcrel_hi(sym)` / `%pcrel_lo(sym)` / `%got_pcrel_hi(sym)` operand
+#
+# The modifier belongs to the symbol REFERENCE, so it rides `Operand.mod` with the
+# shared `isa.SYM_MOD_*` values the encoder's own notifications carry. This backend
+# forms a pc-relative pair against the symbol itself rather than against the paired
+# `auipc`'s label, and the low half here names the symbol for the same reason.
+fun rv_modifier(c: *iasm.Cursor, lo: usize, hi: usize, op: *iasm.Operand) R.Result[bool, str] {
+    if (c.body[hi - 1] != ')'::char) { ret R.err[bool, str]("encode: malformed inline-asm relocation modifier"); }
+    var open: usize = lo;
+    var found: bool = false;
+    for (open < hi && !found) {
+        if (c.body[open] == '('::char) { found = true; } or { open = open + 1; }
+    }
+    if (!found) { ret R.err[bool, str]("encode: malformed inline-asm relocation modifier"); }
+
+    var mod: isa.SymModifier = isa.SYM_MOD_NONE;
+    val nlen: usize = open - lo - 1;
+    if (str_region_equals(c.body, lo + 1, nlen, "pcrel_hi") && nlen == 8)      { mod = isa.SYM_MOD_PCREL_HI; }
+    or (str_region_equals(c.body, lo + 1, nlen, "pcrel_lo") && nlen == 8)      { mod = isa.SYM_MOD_PCREL_LO; }
+    or (str_region_equals(c.body, lo + 1, nlen, "got_pcrel_hi") && nlen == 12) { mod = isa.SYM_MOD_GOT_HI; }
+    or {
+        ret R.err[bool, str](iasm.span_message(c,
+            "encode: unsupported riscv64 inline-asm relocation modifier '", lo, hi, "'",
+            "encode: unsupported riscv64 inline-asm relocation modifier"));
+    }
+    if (!iasm.is_sym_region(c.body, open + 1, hi - 1)) {
+        ret R.err[bool, str]("encode: malformed inline-asm relocation modifier");
+    }
+    @op = iasm.op_sym(open + 1, hi - 1 - (open + 1), mod, 8);
+    ret R.ok[bool, str](true);
+}
+
+# parse an `off(base)` address, the only memory shape RV64 load / store forms take
+fun rv_mem(c: *iasm.Cursor, lo: usize, hi: usize, op: *iasm.Operand) R.Result[bool, str] {
+    var open: usize = lo;
+    var found: bool = false;
+    for (open < hi && !found) {
+        if (c.body[open] == '('::char) { found = true; } or { open = open + 1; }
+    }
+    if (!found) { ret R.err[bool, str]("encode: malformed inline-asm memory operand"); }
+
+    var bbuf: [24]u8;
+    if (!iasm.copy_region(c.body, open + 1, hi - 1, ?bbuf[0], 24)) { ret R.err[bool, str]("encode: malformed inline-asm memory operand"); }
+    val base: i32 = asm_reg_index((?bbuf[0])::str);
+    if (base < 0) { ret R.err[bool, str]("encode: malformed inline-asm memory operand"); }
+
+    var disp: i64 = 0;
+    var flags: u8 = 0;
+    var a: usize = lo;
+    var b: usize = open;
+    for (a < b && iasm.is_space(c.body[a])) { a = a + 1; }
+    for (b > a && iasm.is_space(c.body[b - 1])) { b = b - 1; }
+    if (b > a) {
+        val dv: O.Option[i64] = iasm.region_i64(c.body, a, b);
+        if (!O.is_some[i64](dv)) { ret R.err[bool, str]("encode: malformed inline-asm memory operand"); }
+        disp  = O.unwrap[i64](dv);
+        flags = iasm.AOF_HAS_DISP;
+    }
+    @op = iasm.op_mem(base, disp, -1, 0, 8);
+    op.flags = flags;
+    ret R.ok[bool, str](true);
+}
+
+# a memory-position operand: an `off(base)` address, or an unresolved `{name}` whose
+# displacement the emitter's parse will supply
+fun rv_is_addr(op: *iasm.Operand) bool {
+    ret op.kind == iasm.AOP_MEM || op.kind == iasm.AOP_BIND;
+}
+
+# the operand index a pattern's branch target occupies, or a value no index reaches
+#
+# The last operand of every branching form is its label; `jal` takes one either
+# alone or after a link register, so the position follows the operand count.
+fun rv_label_operand(pat: u16, n: u32) u32 {
+    if (pat == RVP_BRANCH || pat == RVP_BRANCH_SW)       { ret 2; }
+    if (pat == RVP_BRANCH_Z1 || pat == RVP_BRANCH_Z2)    { ret 1; }
+    if (pat == RVP_J)                                    { ret 0; }
+    if (pat == RVP_JAL)                                  { ret n - 1; }
+    ret 0xFFFFFFFF;
+}
+
+# turn one resolved RV64 statement into a parsed item
+#
+# Reads each operand token in the shape its mnemonic's pattern names, refusing any
+# other shape. Operand-count and operand-kind checks are the whole validation: an
+# instruction that parses is one this grammar can encode.
+fun rv_parse(c: *iasm.Cursor, s: *iasm.Stmt, item: *iasm.Item) R.Result[bool, str] {
+    val pat: u16 = rv_pattern(s.m.flags);
+    val n: u32 = s.nargs;
+
+    # a branch target is a numeric local label, not a machine operand, so it is read
+    # by `rv_local_target` and skipped here - `1b` is neither a register nor a symbol
+    # nor an integer, and the operand lexer would rightly refuse it.
+    val label_at: u32 = rv_label_operand(pat, n);
+    var i: u32 = 0;
+    for (i < n) {
+        if (i != label_at) {
+            val r: R.Result[bool, str] = rv_operand(c, s.arg_lo[i::usize], s.arg_hi[i::usize], ?item.ops[i::usize]);
+            if (R.is_err[bool, str](r)) { ret r; }
+        }
+        i = i + 1;
+    }
+
+    if (pat == RVP_RRR || pat == RVP_RRI || pat == RVP_SHIFT) {
+        if (n != 3) { ret R.err[bool, str]("encode: inline-asm instruction expects three operands"); }
+        if (item.ops[0].kind != iasm.AOP_REG || item.ops[1].kind != iasm.AOP_REG) {
+            ret R.err[bool, str]("encode: inline-asm instruction operand must be a register");
+        }
+        if (pat == RVP_RRR) {
+            if (item.ops[2].kind != iasm.AOP_REG) { ret R.err[bool, str]("encode: inline-asm instruction source must be a register"); }
+            ret R.ok[bool, str](true);
+        }
+        # a register-immediate ALU form also spells the low half of a pc-relative
+        # symbol pair, whose twelve bits the linker fills.
+        if (pat == RVP_RRI && item.ops[2].kind == iasm.AOP_SYM) { ret R.ok[bool, str](true); }
+        if (item.ops[2].kind != iasm.AOP_IMM) { ret R.err[bool, str]("encode: inline-asm operand must be an immediate"); }
+        ret R.ok[bool, str](true);
+    }
+    if (pat == RVP_LOAD || pat == RVP_STORE) {
+        if (n != 2) { ret R.err[bool, str]("encode: inline-asm load/store expects rd, off(base)"); }
+        if (item.ops[0].kind != iasm.AOP_REG) { ret R.err[bool, str]("encode: inline-asm load/store value must be a register"); }
+        if (!rv_is_addr(?item.ops[1]))        { ret R.err[bool, str]("encode: inline-asm load/store address must be off(base)"); }
+        ret R.ok[bool, str](true);
+    }
+    if (pat == RVP_UIMM) {
+        if (n != 2) { ret R.err[bool, str]("encode: inline-asm lui/auipc expects rd, imm"); }
+        if (item.ops[0].kind != iasm.AOP_REG) { ret R.err[bool, str]("encode: inline-asm destination must be a register"); }
+        if (item.ops[1].kind == iasm.AOP_SYM) { ret R.ok[bool, str](true); }
+        if (item.ops[1].kind != iasm.AOP_IMM) { ret R.err[bool, str]("encode: inline-asm lui/auipc needs an immediate"); }
+        ret R.ok[bool, str](true);
+    }
+    if (pat == RVP_BRANCH || pat == RVP_BRANCH_SW) {
+        if (n != 3) { ret R.err[bool, str]("encode: inline-asm branch expects rs1, rs2, label"); }
+        if (item.ops[0].kind != iasm.AOP_REG || item.ops[1].kind != iasm.AOP_REG) {
+            ret R.err[bool, str]("encode: inline-asm branch operand must be a register");
+        }
+        ret rv_local_target(c, s, item, 2);
+    }
+    if (pat == RVP_BRANCH_Z1 || pat == RVP_BRANCH_Z2) {
+        if (n != 2) { ret R.err[bool, str]("encode: inline-asm branch expects rs, label"); }
+        if (item.ops[0].kind != iasm.AOP_REG) { ret R.err[bool, str]("encode: inline-asm branch operand must be a register"); }
+        ret rv_local_target(c, s, item, 1);
+    }
+    if (pat == RVP_J) {
+        if (n != 1) { ret R.err[bool, str]("encode: inline-asm jump expects a label"); }
+        ret rv_local_target(c, s, item, 0);
+    }
+    if (pat == RVP_JAL) {
+        if (n == 1) { item.writes = iasm.AW_NONE; ret rv_local_target(c, s, item, 0); }
+        if (n != 2) { ret R.err[bool, str]("encode: inline-asm jump expects label or rd, label"); }
+        if (item.ops[0].kind != iasm.AOP_REG) { ret R.err[bool, str]("encode: inline-asm 'jal' destination must be a register"); }
+        ret rv_local_target(c, s, item, 1);
+    }
+    if (pat == RVP_JR) {
+        if (n != 1) { ret R.err[bool, str]("encode: inline-asm 'jr' expects a register"); }
+        if (item.ops[0].kind != iasm.AOP_REG) { ret R.err[bool, str]("encode: inline-asm jr/jalr operand must be a register"); }
+        ret R.ok[bool, str](true);
+    }
+    if (pat == RVP_JALR) {
+        # `jalr rs` links through ra, which the caller-saved mask already names; the
+        # three-operand form names its own link register, so only then is operand 0
+        # a destination.
+        if (n == 1) {
+            if (item.ops[0].kind != iasm.AOP_REG) { ret R.err[bool, str]("encode: inline-asm jr/jalr operand must be a register"); }
+            ret R.ok[bool, str](true);
+        }
+        if (n != 3) { ret R.err[bool, str]("encode: inline-asm jalr expects rs or rd, rs, imm"); }
+        if (item.ops[0].kind != iasm.AOP_REG || item.ops[1].kind != iasm.AOP_REG) {
+            ret R.err[bool, str]("encode: inline-asm jalr operand must be a register");
+        }
+        if (item.ops[2].kind != iasm.AOP_IMM) { ret R.err[bool, str]("encode: inline-asm jalr needs an immediate"); }
+        item.writes = iasm.AW_OP0;
+        ret R.ok[bool, str](true);
+    }
+    if (pat == RVP_MV || pat == RVP_NOT || pat == RVP_SEQZ || pat == RVP_NEG || pat == RVP_SNEZ) {
+        if (n != 2) { ret R.err[bool, str]("encode: inline-asm instruction expects rd, rs"); }
+        if (item.ops[0].kind != iasm.AOP_REG || item.ops[1].kind != iasm.AOP_REG) {
+            ret R.err[bool, str]("encode: inline-asm instruction operand must be a register");
+        }
+        ret R.ok[bool, str](true);
+    }
+    if (pat == RVP_LI) {
+        if (n != 2) { ret R.err[bool, str]("encode: inline-asm 'li' expects rd, imm"); }
+        if (item.ops[0].kind != iasm.AOP_REG) { ret R.err[bool, str]("encode: inline-asm 'li' destination must be a register"); }
+        if (item.ops[1].kind != iasm.AOP_IMM) { ret R.err[bool, str]("encode: inline-asm 'li' needs an immediate"); }
+        ret R.ok[bool, str](true);
+    }
+    if (pat == RVP_LA) {
+        if (n != 2) { ret R.err[bool, str]("encode: inline-asm 'la' expects rd, sym"); }
+        if (item.ops[0].kind != iasm.AOP_REG) { ret R.err[bool, str]("encode: inline-asm 'la' destination must be a register"); }
+        if (item.ops[1].kind != iasm.AOP_SYM) { ret R.err[bool, str]("encode: inline-asm 'la' target must be a symbol"); }
+        ret R.ok[bool, str](true);
+    }
+    if (pat == RVP_CALL || pat == RVP_TAIL) {
+        if (n != 1)                           { ret R.err[bool, str]("encode: inline-asm call/tail expects a symbol"); }
+        if (item.ops[0].kind != iasm.AOP_SYM) { ret R.err[bool, str]("encode: inline-asm call/tail target must be a symbol"); }
+        ret R.ok[bool, str](true);
+    }
+    if (pat == RVP_AMO) {
+        if (n != 3) { ret R.err[bool, str]("encode: inline-asm atomic expects rd, rs2, (rs1)"); }
+        if (item.ops[0].kind != iasm.AOP_REG || item.ops[1].kind != iasm.AOP_REG) {
+            ret R.err[bool, str]("encode: inline-asm atomic operand must be a register");
+        }
+        ret rv_amo_addr(?item.ops[2]);
+    }
+    if (pat == RVP_AMO_LR) {
+        if (n != 2)                           { ret R.err[bool, str]("encode: inline-asm 'lr' expects rd, (rs1)"); }
+        if (item.ops[0].kind != iasm.AOP_REG) { ret R.err[bool, str]("encode: inline-asm 'lr' destination must be a register"); }
+        ret rv_amo_addr(?item.ops[1]);
+    }
+    # every no-operand form.
+    if (n != 0) { ret R.err[bool, str]("encode: inline-asm instruction takes no operands"); }
+    ret R.ok[bool, str](true);
+}
+
+# an atomic's address must be the bare `(rs1)` form, never a displacement
+fun rv_amo_addr(op: *iasm.Operand) R.Result[bool, str] {
+    if (!rv_is_addr(op))                   { ret R.err[bool, str]("encode: inline-asm atomic address must be (rs1)"); }
+    if ((op.flags & iasm.AOF_HAS_DISP) != 0 || op.imm != 0) {
+        ret R.err[bool, str]("encode: inline-asm atomic address takes no displacement");
+    }
+    ret R.ok[bool, str](true);
+}
+
+# resolve operand `idx` as a numeric local-label reference
+#
+# A riscv conditional branch reaches only +-4 KiB and there is no in-block relocation
+# kind for a symbol target, so a branch names a numeric local label and nothing else.
+fun rv_local_target(c: *iasm.Cursor, s: *iasm.Stmt, item: *iasm.Item, idx: u32) R.Result[bool, str] {
+    var num: u64 = 0;
+    var fwd: bool = false;
+    if (!iasm.label_ref_span(c.body, s.arg_lo[idx::usize], s.arg_hi[idx::usize], ?num, ?fwd)) {
+        ret R.err[bool, str]("encode: inline-asm branch/jump target must be a numeric local label (Nf / Nb)");
+    }
+    item.ref     = iasm.AR_LOCAL;
+    item.ref_num = num;
+    item.ref_fwd = fwd;
+    ret R.ok[bool, str](true);
+}
+
+# the register field an operand denotes, or the zero register when it names none
+fun rv_reg(op: *iasm.Operand) u32 {
+    if (op.kind != iasm.AOP_REG || op.reg < 0) { ret RZERO; }
+    ret op.reg::u32;
+}
+
+# emit one parsed RV64 item
+#
+# Every instruction goes through the same `emit_r` / `emit_i` / `emit_s` / `emit_b` /
+# `emit_u` / `emit_j` packers the instruction selector drives, so an inline-asm
+# instruction and a selected one are the same bytes and the same notification.
+fun rv_emit(st: *encode.EncodeState, c: *iasm.Cursor, l: *iasm.Labels, item: *iasm.Item) R.Result[bool, str] {
+    val pat: u16 = rv_pattern(item.flags);
+    val op: inst.MachOp = item.code::inst.MachOp;
+
+    var fmt: u8 = 0;
+    var opcode: u32 = 0;
+    var f3: u32 = 0;
+    var f7: u32 = 0;
+    if (pat != RVP_LI && pat != RVP_LA && pat != RVP_CALL && pat != RVP_TAIL) {
+        if (!rv_fields(op, ?fmt, ?opcode, ?f3, ?f7)) {
+            ret R.err[bool, str]("internal compiler error: inline-asm riscv64 instruction has no encoding");
+        }
+    }
+
+    if (pat == RVP_ECALL)  { emit_i(st, OPC_SYSTEM, F3_ADD, RZERO, RZERO, 0); ret R.ok[bool, str](true); }
+    if (pat == RVP_EBREAK) { emit_i(st, OPC_SYSTEM, F3_ADD, RZERO, RZERO, 1); ret R.ok[bool, str](true); }
+    if (pat == RVP_NOP)    { emit_i(st, OPC_OP_IMM, F3_ADD, RZERO, RZERO, 0); ret R.ok[bool, str](true); }
+    if (pat == RVP_RET)    { emit_i(st, OPC_JALR, F3_ADD, RZERO, RRA, 0); ret R.ok[bool, str](true); }
+    if (pat == RVP_FENCE)  { emit_i(st, OPC_MISC_MEM, F3_ADD, RZERO, RZERO, 0xFF); ret R.ok[bool, str](true); }
+    if (pat == RVP_PAUSE)  { emit_i(st, OPC_MISC_MEM, F3_ADD, RZERO, RZERO, 0x010); ret R.ok[bool, str](true); }
+
+    if (pat == RVP_RRR) {
+        emit_r(st, opcode, f3, f7, rv_reg(?item.ops[0]), rv_reg(?item.ops[1]), rv_reg(?item.ops[2]));
+        ret R.ok[bool, str](true);
+    }
+    if (pat == RVP_RRI) {
+        if (item.ops[2].kind == iasm.AOP_SYM) { ret rv_emit_pcrel_lo(st, c, item, opcode, f3); }
+        val v: i64 = item.ops[2].imm;
+        if (v < -2048 || v > 2047) { ret R.err[bool, str]("encode: inline-asm immediate is out of the 12-bit signed range"); }
+        emit_i(st, opcode, f3, rv_reg(?item.ops[0]), rv_reg(?item.ops[1]), v::u32 & 0xFFF);
+        ret R.ok[bool, str](true);
+    }
+    if (pat == RVP_SHIFT) {
+        var mask: u32 = 0x3F;
+        if (opcode == OPC_OP_IMM_32) { mask = 0x1F; }
+        val v: i64 = item.ops[2].imm;
+        if (v < 0 || v::u32 > mask) { ret R.err[bool, str]("encode: inline-asm shift amount is out of range"); }
+        var imm: u32 = v::u32 & mask;
+        if (op == inst.SRAI || op == inst.SRAIW) { imm = imm | 0x400; }
+        emit_i(st, opcode, f3, rv_reg(?item.ops[0]), rv_reg(?item.ops[1]), imm);
+        ret R.ok[bool, str](true);
+    }
+    if (pat == RVP_LOAD || pat == RVP_STORE) {
+        val mem: *iasm.Operand = ?item.ops[1];
+        if (mem.kind != iasm.AOP_MEM) { ret R.err[bool, str]("internal compiler error: inline-asm statement reached the encoder unresolved"); }
+        if (mem.imm < -2048 || mem.imm > 2047) { ret R.err[bool, str]("encode: inline-asm load/store offset is out of the 12-bit signed range"); }
+        if (pat == RVP_LOAD) {
+            emit_i(st, opcode, f3, rv_reg(?item.ops[0]), mem.reg::u32, mem.imm::u32 & 0xFFF);
+        } or {
+            emit_s(st, opcode, f3, mem.reg::u32, rv_reg(?item.ops[0]), mem.imm::u32 & 0xFFF);
+        }
+        ret R.ok[bool, str](true);
+    }
+    if (pat == RVP_UIMM) { ret rv_emit_uimm(st, c, item, opcode); }
+    if (pat == RVP_BRANCH || pat == RVP_BRANCH_SW || pat == RVP_BRANCH_Z1 || pat == RVP_BRANCH_Z2) {
+        var rs1: u32 = RZERO;
+        var rs2: u32 = RZERO;
+        if (pat == RVP_BRANCH)         { rs1 = rv_reg(?item.ops[0]); rs2 = rv_reg(?item.ops[1]); }
+        or (pat == RVP_BRANCH_SW)      { rs1 = rv_reg(?item.ops[1]); rs2 = rv_reg(?item.ops[0]); }
+        or (pat == RVP_BRANCH_Z1)      { rs1 = rv_reg(?item.ops[0]); }
+        or                             { rs2 = rv_reg(?item.ops[0]); }
+        val pos: u32 = st.buf.len::u32;
+        emit_b(st, opcode, f3, rs1, rs2, 0);
+        note_local_target(st, item.ref_num, item.ref_fwd);
+        ret iasm.resolve_local(st, c.g, l, pos, item.ref_num, item.ref_fwd);
+    }
+    if (pat == RVP_J || pat == RVP_JAL) {
+        var rd: u32 = RZERO;
+        if (pat == RVP_JAL) {
+            rd = RRA;
+            if (item.nops == 2) { rd = rv_reg(?item.ops[0]); }
+        }
+        val pos: u32 = st.buf.len::u32;
+        emit_j(st, OPC_JAL, rd, 0);
+        note_local_target(st, item.ref_num, item.ref_fwd);
+        ret iasm.resolve_local(st, c.g, l, pos, item.ref_num, item.ref_fwd);
+    }
+    if (pat == RVP_JR)   { emit_i(st, OPC_JALR, F3_ADD, RZERO, rv_reg(?item.ops[0]), 0); ret R.ok[bool, str](true); }
+    if (pat == RVP_JALR) {
+        if (item.nops == 1) { emit_i(st, OPC_JALR, F3_ADD, RRA, rv_reg(?item.ops[0]), 0); ret R.ok[bool, str](true); }
+        val v: i64 = item.ops[2].imm;
+        if (v < -2048 || v > 2047) { ret R.err[bool, str]("encode: inline-asm jalr offset is out of the 12-bit signed range"); }
+        emit_i(st, OPC_JALR, F3_ADD, rv_reg(?item.ops[0]), rv_reg(?item.ops[1]), v::u32 & 0xFFF);
+        ret R.ok[bool, str](true);
+    }
+    if (pat == RVP_MV)   { emit_i(st, opcode, f3, rv_reg(?item.ops[0]), rv_reg(?item.ops[1]), 0); ret R.ok[bool, str](true); }
+    if (pat == RVP_NOT)  { emit_i(st, opcode, f3, rv_reg(?item.ops[0]), rv_reg(?item.ops[1]), 0xFFF); ret R.ok[bool, str](true); }
+    if (pat == RVP_SEQZ) { emit_i(st, opcode, f3, rv_reg(?item.ops[0]), rv_reg(?item.ops[1]), 1); ret R.ok[bool, str](true); }
+    if (pat == RVP_NEG)  { emit_r(st, opcode, f3, f7, rv_reg(?item.ops[0]), RZERO, rv_reg(?item.ops[1])); ret R.ok[bool, str](true); }
+    if (pat == RVP_SNEZ) { emit_r(st, opcode, f3, f7, rv_reg(?item.ops[0]), RZERO, rv_reg(?item.ops[1])); ret R.ok[bool, str](true); }
+    if (pat == RVP_LI)   { emit_li(st, rv_reg(?item.ops[0]), item.ops[1].imm); ret R.ok[bool, str](true); }
+    if (pat == RVP_LA)   { ret rv_emit_la(st, c, item); }
+    if (pat == RVP_CALL) { ret rv_emit_call(st, c, item, RRA, RRA); }
+    if (pat == RVP_TAIL) { ret rv_emit_call(st, c, item, SCRATCH2, RZERO); }
+    if (pat == RVP_AMO || pat == RVP_AMO_LR) {
+        var f7o: u32 = f7;
+        if ((item.flags & RVF_AQ) != 0) { f7o = f7o | 0x2; }
+        if ((item.flags & RVF_RL) != 0) { f7o = f7o | 0x1; }
+        if (pat == RVP_AMO_LR) {
+            emit_r(st, opcode, f3, f7o, rv_reg(?item.ops[0]), item.ops[1].reg::u32, RZERO);
+            ret R.ok[bool, str](true);
+        }
+        emit_r(st, opcode, f3, f7o, rv_reg(?item.ops[0]), item.ops[2].reg::u32, rv_reg(?item.ops[1]));
+        ret R.ok[bool, str](true);
+    }
+    ret R.err[bool, str]("internal compiler error: inline-asm riscv64 form has no emitter");
+}
+
+# emit a `lui` / `auipc`, whose immediate may be a `%mod(sym)` reference the linker
+# fills rather than a written constant
+#
+# Only the high half of a pc-relative pair is expressible as one instruction, so
+# `auipc rd, %pcrel_hi(sym)` is the sole symbol form here; `%pcrel_lo` belongs to the
+# paired low instruction, and `%got_pcrel_hi` has no riscv64 relocation kind in this
+# backend at all - both are refused by name rather than encoded as something else.
+fun rv_emit_uimm(st: *encode.EncodeState, c: *iasm.Cursor, item: *iasm.Item, opcode: u32) R.Result[bool, str] {
+    val src: *iasm.Operand = ?item.ops[1];
+    if (src.kind == iasm.AOP_SYM) {
+        if (src.mod == isa.SYM_MOD_GOT_HI) {
+            ret R.err[bool, str]("encode: riscv64 has no GOT-relative relocation kind, so inline-asm '%got_pcrel_hi' cannot be encoded");
+        }
+        if (opcode != OPC_AUIPC || src.mod != isa.SYM_MOD_PCREL_HI) {
+            ret R.err[bool, str]("encode: inline-asm upper-immediate symbol reference must be an 'auipc rd, %pcrel_hi(sym)'");
+        }
+        val sr: R.Result[intern.StrId, str] = rv_intern(st, c, src);
+        if (R.is_err[intern.StrId, str](sr)) { ret R.err[bool, str](R.unwrap_err[intern.StrId, str](sr)); }
+        ret emit_pcrel_hi(st, rv_reg(?item.ops[0]), R.unwrap_ok[intern.StrId, str](sr), 0);
+    }
+    if (src.imm < 0 || src.imm > 0xFFFFF) { ret R.err[bool, str]("encode: inline-asm lui/auipc immediate is out of the 20-bit range"); }
+    emit_u(st, opcode, rv_reg(?item.ops[0]), src.imm::u32 & 0xFFFFF);
+    ret R.ok[bool, str](true);
+}
+
+# emit the low half of a pc-relative symbol pair, `addi rd, rs1, %pcrel_lo(sym)`
+#
+# The immediate is a zero placeholder the RK_PCREL_LO12_I relocation fills. This
+# backend forms the pair against the symbol itself rather than against the paired
+# `auipc`'s label - the same convention `la` and every compiler-emitted global
+# reference use - so what the printer writes for one half is what this reads back.
+fun rv_emit_pcrel_lo(st: *encode.EncodeState, c: *iasm.Cursor, item: *iasm.Item, opcode: u32, f3: u32) R.Result[bool, str] {
+    val src: *iasm.Operand = ?item.ops[2];
+    if (src.mod != isa.SYM_MOD_PCREL_LO) {
+        ret R.err[bool, str]("encode: inline-asm register-immediate symbol reference must be a '%pcrel_lo(sym)'");
+    }
+    val sr: R.Result[intern.StrId, str] = rv_intern(st, c, src);
+    if (R.is_err[intern.StrId, str](sr)) { ret R.err[bool, str](R.unwrap_err[intern.StrId, str](sr)); }
+    val sym: intern.StrId = R.unwrap_ok[intern.StrId, str](sr);
+    val pos: u32 = st.buf.len::u32;
+    emit_i(st, opcode, f3, rv_reg(?item.ops[0]), rv_reg(?item.ops[1]), 0);
+    note_sym_target(st, sym, isa.SYM_MOD_PCREL_LO);
+    ret encode.push_reloc(st, pos, of.RK_PCREL_LO12_I, sym, 0);
+}
+
+# `la rd, sym` - the pc-relative address-of pair `auipc rd, %pcrel_hi(sym)` then
+# `addi rd, rd, %pcrel_lo(sym)`, with zero placeholders and both relocations
+fun rv_emit_la(st: *encode.EncodeState, c: *iasm.Cursor, item: *iasm.Item) R.Result[bool, str] {
+    val sr: R.Result[intern.StrId, str] = rv_intern(st, c, ?item.ops[1]);
+    if (R.is_err[intern.StrId, str](sr)) { ret R.err[bool, str](R.unwrap_err[intern.StrId, str](sr)); }
+    val sym: intern.StrId = R.unwrap_ok[intern.StrId, str](sr);
+    val rd: u32 = rv_reg(?item.ops[0]);
+    val hr: R.Result[bool, str] = emit_pcrel_hi(st, rd, sym, 0);
+    if (R.is_err[bool, str](hr)) { ret hr; }
+    val lo_pos: u32 = st.buf.len::u32;
+    emit_i(st, OPC_OP_IMM, F3_ADD, rd, rd, 0);
+    note_sym_target(st, sym, isa.SYM_MOD_PCREL_LO);
+    ret encode.push_reloc(st, lo_pos, of.RK_PCREL_LO12_I, sym, 0);
+}
+
+# a direct call to a symbol - `auipc <link>, 0` then `jalr <ret>, <link>, 0` with a
+# zero placeholder pair and an RK_PLT32 marker at the auipc (the abstract
+# direct-call kind the linker maps to R_RISCV_CALL_PLT). `call` links through ra;
+# `tail` links through t1 and returns nowhere (rd = x0), the standard tail-call form
+fun rv_emit_call(st: *encode.EncodeState, c: *iasm.Cursor, item: *iasm.Item, link: u32, ret_reg: u32) R.Result[bool, str] {
+    val sr: R.Result[intern.StrId, str] = rv_intern(st, c, ?item.ops[0]);
+    if (R.is_err[intern.StrId, str](sr)) { ret R.err[bool, str](R.unwrap_err[intern.StrId, str](sr)); }
+    val sym: intern.StrId = R.unwrap_ok[intern.StrId, str](sr);
+    val pos: u32 = st.buf.len::u32;
+    emit_u(st, OPC_AUIPC, link, 0);
+    note_sym_target(st, sym, isa.SYM_MOD_PCREL_HI);
+    emit_i(st, OPC_JALR, F3_ADD, ret_reg, link, 0);
+    note_sym_target(st, sym, isa.SYM_MOD_PCREL_LO);
+    ret encode.push_reloc(st, pos, of.RK_PLT32, sym, 0);
+}
+
+# intern the symbol name an operand spans out of the asm body
+#
+# The name is a region of the body, not a NUL-terminated string, so it is interned
+# before either the notification or the relocation can name it - both take the id.
+fun rv_intern(st: *encode.EncodeState, c: *iasm.Cursor, op: *iasm.Operand) R.Result[intern.StrId, str] {
+    ret intern.intern_bytes(st.interner, (c.body::usize + op.name_off)::str, op.name_len);
+}
+
+# insert the displacement from an inline-asm branch to a numeric local label
+#
+# The B-type / J-type immediate scatter is the shared `patch_branch_riscv64`, which
+# dispatches on the placeholder word's opcode, so this carries no encoding.
+fun rv_patch(st: *encode.EncodeState, patch_pos: u32, target_off: u32) R.Result[bool, str] {
+    var fx: encode.BranchFixup;
+    fx.patch_pos    = patch_pos;
+    fx.next_ip      = 0;
+    fx.target_block = 0;
+    fx.fn_text_base = 0;
+    ret patch_branch_riscv64(st, ?fx, target_off);
+}
+
+# the RV64 inline-assembly grammar
+fun rv_grammar() iasm.Grammar {
+    var g: iasm.Grammar;
+    g.isa       = "riscv64";
+    g.rows      = ?RV_MNEMONICS[0];
+    g.row_count = RV_MNEMONIC_COUNT;
+    g.decode    = rv_decode_amo;
+    g.parse     = rv_parse;
+    g.emit      = rv_emit;
+    g.patch     = rv_patch;
+    g.slot      = frame_slot_offset;
+    g.all_gp    = 0xFFFFFFFF;
+    g.all_fp    = 0xFFFFFFFF;
+    g.word      = 4;
+    ret g;
+}
+
+# the `AsmClobbersFn` the RV64 ISA vtable exposes - the registers an inline-asm body
+# writes, derived from the instructions the body parses to
+#
+# Without this hook a nil slot forces a conservative all-register clobber, framing
+# every asm function (`_start`, whose frame allocation then mis-reads argc off the
+# entry stack). The derivation runs the same parser the assembler runs, so the
+# register set and the emitted bytes describe one instruction stream.
 # ---
 # body:   the inline-asm body text
 # gp_out: out - the GP registers the body writes (bit n = register n)
 # fp_out: out - the FP registers the body writes (bit n = register n)
 pub fun asm_clobbers(body: str, gp_out: *u32, fp_out: *u32) {
-    var gp: u32 = 0;
-    var fp: u32 = 0;
-    val len: usize = str_len(body);
-    var start: usize = 0;
-    for (start < len) {
-        var end: usize = start;
-        for (end < len && body[end] != '\n'::char && body[end] != ';'::char) { end = end + 1; }
-        var lo: usize = start;
-        for (lo < end && asm_is_space(body[lo])) { lo = lo + 1; }
-        var hi: usize = end;
-        for (hi > lo && asm_is_space(body[hi - 1])) { hi = hi - 1; }
-        if (hi > lo) {
-            var line: [512]u8;
-            val ll: usize = hi - lo;
-            if (ll >= 512) { gp = 0xFFFFFFFF; fp = 0xFFFFFFFF; }
-            or {
-                var c: usize = 0;
-                for (c < ll) { line[c] = body[lo + c]::u8; c = c + 1; }
-                line[ll] = 0;
-                asm_stmt_clobbers((?line[0])::str, ?gp, ?fp);
-            }
-        }
-        start = end + 1;
-    }
-    @gp_out = gp;
-    @fp_out = fp;
+    var g: iasm.Grammar = rv_grammar();
+    iasm.clobbers(?g, body, gp_out, fp_out);
 }
 
-# inline-asm assembler
+# expand an inline-asm MIR_ASM instruction into RV64 bytes
 #
-# parses an `asm riscv64 { ... }` body line-by-line and emits RV64 words, resolving
-# `{name}` locals to their frame slots (`off(s0)`) and bare-symbol operands to the
-# riscv relocations - the RV64 analogue of x86-64's `encode_asm_block` and
-# AArch64's `encode_asm_block_arm64`. it reuses the slice-2 R/I/S/B/U/J packers and
-# the slice-2 register-name resolver (`asm_reg_index`). numeric local labels
-# (`1:` / `1f` / `1b`) resolve within the block; the B-type / J-type displacement
-# insert reuses the shared `patch_branch_riscv64`. an unrecognized mnemonic or a
-# malformed operand is a hard error rather than wrong bytes.
-
-# a parsed RV64 inline-asm operand. distinguishes a register / immediate / `off(base)`
-# memory form (encoded directly) from a bare symbol (resolved to a relocation)
-# ---
-# kind:     one of RVOP_*
-# reg:      register index for RVOP_REG, or the base register for RVOP_MEM
-# imm:      immediate (RVOP_IMM) or the memory displacement (RVOP_MEM)
-# name:     borrowed symbol name (RVOP_SYM)
-# name_len: length of `name`
-rec RvAsmOp {
-    kind:     u8;
-    reg:      i32;
-    imm:      i64;
-    name:     str;
-    name_len: usize;
-}
-
-# no operand parsed
-val RVOP_NONE: u8 = 0;
-# a register operand
-val RVOP_REG:  u8 = 1;
-# an immediate constant
-val RVOP_IMM:  u8 = 2;
-# an `off(base)` memory operand (the load / store address form)
-val RVOP_MEM:  u8 = 3;
-# a bare symbol / branch-target name (resolved to a relocation)
-val RVOP_SYM:  u8 = 4;
-
-# initial capacity for the numeric local-label definition / forward-ref arrays
-val RV_LABEL_INIT_CAP: u32 = 8;
-
-# a numeric local label's nearest definition: the label number and its `.text` offset
-# ---
-# number: the numeric label
-# offset: byte offset of the definition within `.text`
-rec RvLabelDef { number: u64; offset: u32; }
-
-# a pending forward reference to a numeric local label: the placeholder branch word is
-# at `patch_pos`, resolved by `patch_branch_riscv64` when the definition is reached
-# ---
-# patch_pos: byte offset of the branch instruction word within `.text`
-# number:    the referenced numeric label
-rec RvLabelRef { patch_pos: u32; number: u64; }
-
-# per-asm-block numeric-local-label scope (`1:` / `1f` / `1b`). owns its def /
-# forward-ref arrays, freed when the block finishes. the displacement insert reuses
-# the shared `patch_branch_riscv64` (J-type for j / jal, B-type for the branches -
-# distinguished there by the placeholder word's opcode), so this bookkeeping carries
-# no encoding
-# ---
-# alloc:     backing allocator
-# defs:      recorded label definitions (latest offset per number)
-# def_count: number of definitions
-# def_cap:   capacity of `defs`
-# refs:      pending forward references
-# ref_count: number of pending forward references
-# ref_cap:   capacity of `refs`
-rec RvLabels {
-    alloc:     *A.Allocator;
-    defs:      *RvLabelDef;
-    def_count: u32;
-    def_cap:   u32;
-    refs:      *RvLabelRef;
-    ref_count: u32;
-    ref_cap:   u32;
-}
-
-# initialize an empty numeric-local-label scope backed by `alloc`
-fun rv_labels_init(labels: *RvLabels, alloc: *A.Allocator) {
-    labels.alloc = alloc;
-    labels.defs = nil; labels.def_count = 0; labels.def_cap = 0;
-    labels.refs = nil; labels.ref_count = 0; labels.ref_cap = 0;
-}
-
-# release a label scope's owned arrays
-fun rv_labels_dnit(labels: *RvLabels) {
-    if (labels.defs != nil && labels.def_cap > 0) {
-        A.deallocate[RvLabelDef](labels.alloc, labels.defs, labels.def_cap::usize);
-        labels.defs = nil; labels.def_cap = 0; labels.def_count = 0;
-    }
-    if (labels.refs != nil && labels.ref_cap > 0) {
-        A.deallocate[RvLabelRef](labels.alloc, labels.refs, labels.ref_cap::usize);
-        labels.refs = nil; labels.ref_cap = 0; labels.ref_count = 0;
-    }
-}
-
-# grow the label-definition array (or allocate it on first use)
-fun grow_rv_defs(labels: *RvLabels) R.Result[bool, str] {
-    if (labels.defs == nil) {
-        val r: R.Result[*RvLabelDef, str] = A.allocate[RvLabelDef](labels.alloc, RV_LABEL_INIT_CAP::usize);
-        if (R.is_err[*RvLabelDef, str](r)) { ret R.err[bool, str](R.unwrap_err[*RvLabelDef, str](r)); }
-        labels.defs = R.unwrap_ok[*RvLabelDef, str](r); labels.def_cap = RV_LABEL_INIT_CAP;
-        ret R.ok[bool, str](true);
-    }
-    val nc: u32 = labels.def_cap * 2;
-    val r: R.Result[*RvLabelDef, str] = A.reallocate[RvLabelDef](labels.alloc, labels.defs, labels.def_cap::usize, nc::usize);
-    if (R.is_err[*RvLabelDef, str](r)) { ret R.err[bool, str](R.unwrap_err[*RvLabelDef, str](r)); }
-    labels.defs = R.unwrap_ok[*RvLabelDef, str](r); labels.def_cap = nc;
-    ret R.ok[bool, str](true);
-}
-
-# grow the forward-reference array (or allocate it on first use)
-fun grow_rv_refs(labels: *RvLabels) R.Result[bool, str] {
-    if (labels.refs == nil) {
-        val r: R.Result[*RvLabelRef, str] = A.allocate[RvLabelRef](labels.alloc, RV_LABEL_INIT_CAP::usize);
-        if (R.is_err[*RvLabelRef, str](r)) { ret R.err[bool, str](R.unwrap_err[*RvLabelRef, str](r)); }
-        labels.refs = R.unwrap_ok[*RvLabelRef, str](r); labels.ref_cap = RV_LABEL_INIT_CAP;
-        ret R.ok[bool, str](true);
-    }
-    val nc: u32 = labels.ref_cap * 2;
-    val r: R.Result[*RvLabelRef, str] = A.reallocate[RvLabelRef](labels.alloc, labels.refs, labels.ref_cap::usize, nc::usize);
-    if (R.is_err[*RvLabelRef, str](r)) { ret R.err[bool, str](R.unwrap_err[*RvLabelRef, str](r)); }
-    labels.refs = R.unwrap_ok[*RvLabelRef, str](r); labels.ref_cap = nc;
-    ret R.ok[bool, str](true);
-}
-
-# the nearest preceding definition offset of `number`, or none
-fun rv_label_lookup(labels: *RvLabels, number: u64) O.Option[u32] {
-    var i: u32 = 0;
-    for (i < labels.def_count) {
-        if (labels.defs[i].number == number) { ret O.some[u32](labels.defs[i].offset); }
-        i = i + 1;
-    }
-    ret O.none[u32]();
-}
-
-# record a pending forward reference to `number` whose branch word is at `patch_pos`
-fun rv_label_push_ref(labels: *RvLabels, patch_pos: u32, number: u64) R.Result[bool, str] {
-    if (labels.ref_count >= labels.ref_cap) {
-        val gr: R.Result[bool, str] = grow_rv_refs(labels);
-        if (R.is_err[bool, str](gr)) { ret gr; }
-    }
-    labels.refs[labels.ref_count].patch_pos = patch_pos;
-    labels.refs[labels.ref_count].number    = number;
-    labels.ref_count = labels.ref_count + 1;
-    ret R.ok[bool, str](true);
-}
-
-# record a definition of `number` at `.text` offset `off`, patching (and dropping)
-# every pending forward reference to it through the shared `patch_branch_riscv64`, and
-# updating the nearest-preceding-definition offset
-fun rv_label_record_def(st: *encode.EncodeState, labels: *RvLabels, number: u64, off: u32) R.Result[bool, str] {
-    var w: u32 = 0;
-    var r: u32 = 0;
-    for (r < labels.ref_count) {
-        if (labels.refs[r].number == number) {
-            var fx: encode.BranchFixup;
-            fx.patch_pos = labels.refs[r].patch_pos; fx.next_ip = 0;
-            fx.target_block = 0; fx.fn_text_base = 0;
-            val pr: R.Result[bool, str] = patch_branch_riscv64(st, ?fx, off);
-            if (R.is_err[bool, str](pr)) { ret pr; }
-        } or {
-            labels.refs[w].patch_pos = labels.refs[r].patch_pos;
-            labels.refs[w].number    = labels.refs[r].number;
-            w = w + 1;
-        }
-        r = r + 1;
-    }
-    labels.ref_count = w;
-
-    var i: u32 = 0;
-    for (i < labels.def_count) {
-        if (labels.defs[i].number == number) { labels.defs[i].offset = off; ret R.ok[bool, str](true); }
-        i = i + 1;
-    }
-    if (labels.def_count >= labels.def_cap) {
-        val gr: R.Result[bool, str] = grow_rv_defs(labels);
-        if (R.is_err[bool, str](gr)) { ret gr; }
-    }
-    labels.defs[labels.def_count].number = number;
-    labels.defs[labels.def_count].offset = off;
-    labels.def_count = labels.def_count + 1;
-    ret R.ok[bool, str](true);
-}
-
-# true for an ASCII decimal digit
-fun rv_is_digit(c: char) bool { ret c >= '0'::char && c <= '9'::char; }
-
-# true for a character valid inside a bare symbol name
-fun rv_is_sym_char(c: char) bool {
-    ret c == '_'::char || c == '.'::char ||
-        (c >= 'a'::char && c <= 'z'::char) ||
-        (c >= 'A'::char && c <= 'Z'::char) ||
-        (c >= '0'::char && c <= '9'::char);
-}
-
-# true when `tok[0..len)` is a valid bare symbol name (leading char a letter /
-# underscore, the rest symbol characters)
-fun rv_is_sym_token(tok: str, len: usize) bool {
-    if (len == 0) { ret false; }
-    val c0: char = tok[0];
-    if (!(c0 == '_'::char || (c0 >= 'a'::char && c0 <= 'z'::char) || (c0 >= 'A'::char && c0 <= 'Z'::char))) {
-        ret false;
-    }
-    var i: usize = 1;
-    for (i < len) { if (!rv_is_sym_char(tok[i])) { ret false; } i = i + 1; }
-    ret true;
-}
-
-# a pointer past leading whitespace in `s` (trailing whitespace already stripped by
-# the statement tokenizer)
-fun rv_trim(s: str) str {
-    var i: usize = 0;
-    for (s[i] != 0 && asm_is_space(s[i])) { i = i + 1; }
-    ret (s::usize + i)::str;
-}
-
-# copy `s[lo..hi)` (trimming surrounding whitespace) into `dst` as a NUL-terminated
-# string. returns false on an empty or oversized slice
-fun rv_copy_region(s: str, lo: usize, hi: usize, dst: *u8, cap: usize) bool {
-    var a: usize = lo;
-    var b: usize = hi;
-    for (a < b && asm_is_space(s[a])) { a = a + 1; }
-    for (b > a && asm_is_space(s[b - 1])) { b = b - 1; }
-    val n: usize = b - a;
-    if (n == 0 || n + 1 > cap) { ret false; }
-    var i: usize = 0;
-    for (i < n) { dst[i] = s[a + i]::u8; i = i + 1; }
-    dst[n] = 0;
-    ret true;
-}
-
-# if `tok` begins with `<digits>:`, return the prefix length (through the colon) and
-# the parsed number via `num_out`; otherwise return 0
-fun rv_label_def_len(tok: str, num_out: *u64) usize {
-    if (!rv_is_digit(tok[0])) { ret 0; }
-    var i: usize = 0;
-    var n: u64 = 0;
-    for (rv_is_digit(tok[i])) { n = n * 10 + (tok[i]::u64 - '0'::u64); i = i + 1; }
-    if (tok[i] != ':'::char) { ret 0; }
-    @num_out = n;
-    ret i + 1;
-}
-
-# parse a numeric local-label reference `<digits>f` / `<digits>b` into its number and
-# direction. returns false when `tok` is not that shape
-fun rv_label_ref(tok: str, num_out: *u64, fwd_out: *bool) bool {
-    val len: usize = str_len(tok);
-    if (len < 2)              { ret false; }
-    if (!rv_is_digit(tok[0])) { ret false; }
-    var n: u64 = 0;
-    var i: usize = 0;
-    for (i < len - 1) {
-        if (!rv_is_digit(tok[i])) { ret false; }
-        n = n * 10 + (tok[i]::u64 - '0'::u64);
-        i = i + 1;
-    }
-    val suf: char = tok[len - 1];
-    if (suf == 'f'::char) { @fwd_out = true; }
-    or (suf == 'b'::char) { @fwd_out = false; }
-    or { ret false; }
-    @num_out = n;
-    ret true;
-}
-
-# copy the first whitespace-delimited token of `tok` (the mnemonic) into `mbuf`
-# NUL-terminated and set `args_out` to the trimmed remainder. returns false when the
-# mnemonic exceeds `cap`
-fun rv_first_token(tok: str, mbuf: *u8, cap: usize, args_out: *str) bool {
-    var i: usize = 0;
-    for (tok[i] != 0 && asm_is_space(tok[i])) { i = i + 1; }
-    var k: usize = 0;
-    for (tok[i] != 0 && !asm_is_space(tok[i])) {
-        if (k + 1 >= cap) { ret false; }
-        mbuf[k] = tok[i]::u8; k = k + 1; i = i + 1;
-    }
-    mbuf[k] = 0;
-    for (tok[i] != 0 && asm_is_space(tok[i])) { i = i + 1; }
-    @args_out = (tok::usize + i)::str;
-    ret true;
-}
-
-# build "<prefix><name><suffix>" interned into the session interner so the
-# diagnostic outlives this call; degrades to `fallback` when interning is unavailable.
-# mirrors the AArch64 `asm_named_err`
-fun rv_named_err(st: *encode.EncodeState, prefix: str, name: str, suffix: str, fallback: str) str {
-    if (st.interner == nil || name == nil) { ret fallback; }
-    val lp: usize = str_len(prefix);
-    val ln: usize = str_len(name);
-    val ls: usize = str_len(suffix);
-    val total: usize = lp + ln + ls;
-    val r: R.Result[*u8, str] = A.allocate[u8](st.alloc, total + 1);
-    if (R.is_err[*u8, str](r)) { ret fallback; }
-    val buf: *u8 = R.unwrap_ok[*u8, str](r);
-    var k: usize = 0;
-    var j: usize = 0;
-    for (j < lp) { buf[k] = prefix[j]::u8; k = k + 1; j = j + 1; }
-    j = 0;
-    for (j < ln) { buf[k] = name[j]::u8; k = k + 1; j = j + 1; }
-    j = 0;
-    for (j < ls) { buf[k] = suffix[j]::u8; k = k + 1; j = j + 1; }
-    buf[total] = 0;
-    val ir: R.Result[intern.StrId, str] = intern.intern(st.interner, buf::str);
-    A.deallocate[u8](st.alloc, buf, total + 1);
-    if (R.is_err[intern.StrId, str](ir)) { ret fallback; }
-    val nm: O.Option[str] = intern.lookup(st.interner, R.unwrap_ok[intern.StrId, str](ir));
-    if (O.is_some[str](nm)) { ret O.unwrap[str](nm); }
-    ret fallback;
-}
-
-# map a register token to its index through the slice-2 `asm_reg_index` resolver
-fun rv_parse_reg(tok: str, op: *RvAsmOp) bool {
-    val idx: i32 = asm_reg_index(tok);
-    if (idx < 0) { ret false; }
-    op.kind = RVOP_REG; op.reg = idx; op.imm = 0; op.name = nil; op.name_len = 0;
-    ret true;
-}
-
-# parse the `off(base)` memory operand form (the only memory shape RV64 load / store
-# instructions take). `off` defaults to 0 when omitted (`(base)`); the base must be a
-# register. returns false on any other shape
-fun rv_parse_mem(tok: str, len: usize, op: *RvAsmOp) bool {
-    var lp: usize = 0;
-    var found: bool = false;
-    var i: usize = 0;
-    for (i < len && !found) {
-        if (tok[i] == '('::char) { lp = i; found = true; }
-        i = i + 1;
-    }
-    if (!found)                    { ret false; }
-    if (tok[len - 1] != ')'::char) { ret false; }
-
-    var bbuf: [16]u8;
-    if (!rv_copy_region(tok, lp + 1, len - 1, ?bbuf[0], 16)) { ret false; }
-    val bidx: i32 = asm_reg_index((?bbuf[0])::str);
-    if (bidx < 0) { ret false; }
-
-    var off: i64 = 0;
-    var a: usize = 0;
-    var b: usize = lp;
-    for (a < b && asm_is_space(tok[a])) { a = a + 1; }
-    for (b > a && asm_is_space(tok[b - 1])) { b = b - 1; }
-    if (b > a) {
-        var obuf: [32]u8;
-        if (!rv_copy_region(tok, a, b, ?obuf[0], 32)) { ret false; }
-        val r: R.Result[i64, str] = parse.parse_i64_exact((?obuf[0])::str, 0);
-        if (R.is_err[i64, str](r)) { ret false; }
-        off = R.unwrap_ok[i64, str](r);
-    }
-    op.kind = RVOP_MEM; op.reg = bidx; op.imm = off; op.name = nil; op.name_len = 0;
-    ret true;
-}
-
-# parse one trimmed operand token into `op` - a register, an `off(base)` memory
-# reference, an immediate, or a bare symbol. returns false when the token matches none
-fun rv_parse_operand(tok: str, op: *RvAsmOp) bool {
-    op.kind = RVOP_NONE; op.reg = -1; op.imm = 0; op.name = nil; op.name_len = 0;
-    val len: usize = str_len(tok);
-    if (len == 0)               { ret false; }
-    if (rv_parse_reg(tok, op))  { ret true; }
-
-    var has_paren: bool = false;
-    var i: usize = 0;
-    for (i < len && !has_paren) { if (tok[i] == '('::char) { has_paren = true; } i = i + 1; }
-    if (has_paren && tok[len - 1] == ')'::char) { ret rv_parse_mem(tok, len, op); }
-
-    val r: R.Result[i64, str] = parse.parse_i64_exact(tok, 0);
-    if (R.is_ok[i64, str](r)) {
-        op.kind = RVOP_IMM; op.imm = R.unwrap_ok[i64, str](r);
-        ret true;
-    }
-    if (rv_is_sym_token(tok, len)) {
-        op.kind = RVOP_SYM; op.name = tok; op.name_len = len;
-        ret true;
-    }
-    ret false;
-}
-
-# split `args` into trimmed top-level operand tokens (commas outside `(...)`),
-# copying each NUL-terminated into `b0`..`b3` (each `cap` bytes). returns false on more
-# than four operands, an empty token, or an oversized token
-fun rv_split(args: str, b0: *u8, b1: *u8, b2: *u8, b3: *u8, cap: usize, count_out: *u32) bool {
-    val len: usize = str_len(args);
-    var count: u32 = 0;
-    var depth: i32 = 0;
-    var start: usize = 0;
-    var i: usize = 0;
-    for (i <= len) {
-        var is_sep: bool = false;
-        if (i == len)                           { is_sep = true; }
-        or (args[i] == '('::char)               { depth = depth + 1; }
-        or (args[i] == ')'::char)               { depth = depth - 1; }
-        or (args[i] == ','::char && depth == 0) { is_sep = true; }
-        if (is_sep) {
-            if (count >= 4) { ret false; }
-            var dst: *u8 = b0;
-            if (count == 1) { dst = b1; } or (count == 2) { dst = b2; } or (count == 3) { dst = b3; }
-            if (!rv_copy_region(args, start, i, dst, cap)) { ret false; }
-            count = count + 1;
-            start = i + 1;
-        }
-        i = i + 1;
-    }
-    @count_out = count;
-    ret true;
-}
-
-# parse exactly two register operands from `args` into `r0` / `r1`. used by the
-# two-register pseudo forms (mv / neg / not / seqz / snez / sext.w / negw)
-fun rv_two_reg_args(args: str, r0: *u32, r1: *u32) bool {
-    var b0: [64]u8; var b1: [64]u8; var b2: [64]u8; var b3: [64]u8;
-    var n: u32 = 0;
-    if (!rv_split(args, ?b0[0], ?b1[0], ?b2[0], ?b3[0], 64, ?n)) { ret false; }
-    if (n != 2)                                                  { ret false; }
-    var a: RvAsmOp; var b: RvAsmOp;
-    if (!rv_parse_operand((?b0[0])::str, ?a) || a.kind != RVOP_REG) { ret false; }
-    if (!rv_parse_operand((?b1[0])::str, ?b) || b.kind != RVOP_REG) { ret false; }
-    @r0 = a.reg::u32; @r1 = b.reg::u32;
-    ret true;
-}
-
-# a three-register R-type form `rd, rs1, rs2`
-fun rv_three_reg(st: *encode.EncodeState, args: str, opcode: u32, funct3: u32, funct7: u32) R.Result[bool, str] {
-    var b0: [64]u8; var b1: [64]u8; var b2: [64]u8; var b3: [64]u8;
-    var n: u32 = 0;
-    if (!rv_split(args, ?b0[0], ?b1[0], ?b2[0], ?b3[0], 64, ?n)) { ret R.err[bool, str]("encode: malformed inline-asm operands"); }
-    if (n != 3)                                                  { ret R.err[bool, str]("encode: inline-asm instruction expects rd, rs1, rs2"); }
-    var rd: RvAsmOp; var rs1: RvAsmOp; var rs2: RvAsmOp;
-    if (!rv_parse_operand((?b0[0])::str, ?rd) || rd.kind != RVOP_REG)   { ret R.err[bool, str]("encode: inline-asm destination must be a register"); }
-    if (!rv_parse_operand((?b1[0])::str, ?rs1) || rs1.kind != RVOP_REG) { ret R.err[bool, str]("encode: inline-asm source must be a register"); }
-    if (!rv_parse_operand((?b2[0])::str, ?rs2) || rs2.kind != RVOP_REG) { ret R.err[bool, str]("encode: inline-asm source must be a register"); }
-    emit_r(st, opcode, funct3, funct7, rd.reg::u32, rs1.reg::u32, rs2.reg::u32);
-    ret R.ok[bool, str](true);
-}
-
-# a register-immediate I-type ALU form `rd, rs1, imm` (the immediate within the 12-bit
-# signed reach)
-fun rv_imm_alu(st: *encode.EncodeState, args: str, opcode: u32, funct3: u32) R.Result[bool, str] {
-    var b0: [64]u8; var b1: [64]u8; var b2: [64]u8; var b3: [64]u8;
-    var n: u32 = 0;
-    if (!rv_split(args, ?b0[0], ?b1[0], ?b2[0], ?b3[0], 64, ?n)) { ret R.err[bool, str]("encode: malformed inline-asm operands"); }
-    if (n != 3)                                                  { ret R.err[bool, str]("encode: inline-asm instruction expects rd, rs1, imm"); }
-    var rd: RvAsmOp; var rs1: RvAsmOp; var im: RvAsmOp;
-    if (!rv_parse_operand((?b0[0])::str, ?rd) || rd.kind != RVOP_REG)   { ret R.err[bool, str]("encode: inline-asm destination must be a register"); }
-    if (!rv_parse_operand((?b1[0])::str, ?rs1) || rs1.kind != RVOP_REG) { ret R.err[bool, str]("encode: inline-asm source must be a register"); }
-    if (!rv_parse_operand((?b2[0])::str, ?im) || im.kind != RVOP_IMM)   { ret R.err[bool, str]("encode: inline-asm operand must be an immediate"); }
-    if (im.imm < -2048 || im.imm > 2047)                               { ret R.err[bool, str]("encode: inline-asm immediate is out of the 12-bit signed range"); }
-    emit_i(st, opcode, funct3, rd.reg::u32, rs1.reg::u32, im.imm::u32 & 0xFFF);
-    ret R.ok[bool, str](true);
-}
-
-# an immediate shift I-type form `rd, rs1, shamt` (slli / srli / srai and their RV64
-# word twins). `word` selects the 5-bit word shift amount, else the 6-bit full-register
-# amount; `arith` folds the srai funct7 into imm[10]
-fun rv_shift_imm(st: *encode.EncodeState, args: str, opcode: u32, funct3: u32, arith: bool, word: bool) R.Result[bool, str] {
-    var b0: [64]u8; var b1: [64]u8; var b2: [64]u8; var b3: [64]u8;
-    var n: u32 = 0;
-    if (!rv_split(args, ?b0[0], ?b1[0], ?b2[0], ?b3[0], 64, ?n)) { ret R.err[bool, str]("encode: malformed inline-asm operands"); }
-    if (n != 3)                                                  { ret R.err[bool, str]("encode: inline-asm shift expects rd, rs1, shamt"); }
-    var rd: RvAsmOp; var rs1: RvAsmOp; var sh: RvAsmOp;
-    if (!rv_parse_operand((?b0[0])::str, ?rd) || rd.kind != RVOP_REG)   { ret R.err[bool, str]("encode: inline-asm destination must be a register"); }
-    if (!rv_parse_operand((?b1[0])::str, ?rs1) || rs1.kind != RVOP_REG) { ret R.err[bool, str]("encode: inline-asm source must be a register"); }
-    if (!rv_parse_operand((?b2[0])::str, ?sh) || sh.kind != RVOP_IMM)   { ret R.err[bool, str]("encode: inline-asm shift amount must be an immediate"); }
-    var mask: u32 = 0x3F;
-    if (word) { mask = 0x1F; }
-    if (sh.imm < 0 || sh.imm::u32 > mask) { ret R.err[bool, str]("encode: inline-asm shift amount is out of range"); }
-    var imm: u32 = sh.imm::u32 & mask;
-    if (arith) { imm = imm | 0x400; }
-    emit_i(st, opcode, funct3, rd.reg::u32, rs1.reg::u32, imm);
-    ret R.ok[bool, str](true);
-}
-
-# a load I-type form `rd, off(base)` with the explicit (sign / zero) funct3 the
-# mnemonic names - not the width-driven zero-extending `load_funct3`, since inline asm
-# spells the exact load
-fun rv_load(st: *encode.EncodeState, args: str, funct3: u32) R.Result[bool, str] {
-    var b0: [64]u8; var b1: [64]u8; var b2: [64]u8; var b3: [64]u8;
-    var n: u32 = 0;
-    if (!rv_split(args, ?b0[0], ?b1[0], ?b2[0], ?b3[0], 64, ?n)) { ret R.err[bool, str]("encode: malformed inline-asm load operands"); }
-    if (n != 2)                                                  { ret R.err[bool, str]("encode: inline-asm load expects rd, off(base)"); }
-    var rd: RvAsmOp; var mem: RvAsmOp;
-    if (!rv_parse_operand((?b0[0])::str, ?rd) || rd.kind != RVOP_REG)    { ret R.err[bool, str]("encode: inline-asm load destination must be a register"); }
-    if (!rv_parse_operand((?b1[0])::str, ?mem) || mem.kind != RVOP_MEM)  { ret R.err[bool, str]("encode: inline-asm load address must be off(base)"); }
-    if (mem.imm < -2048 || mem.imm > 2047)                              { ret R.err[bool, str]("encode: inline-asm load offset is out of the 12-bit signed range"); }
-    emit_i(st, OPC_LOAD, funct3, rd.reg::u32, mem.reg::u32, mem.imm::u32 & 0xFFF);
-    ret R.ok[bool, str](true);
-}
-
-# a store S-type form `rs2, off(base)`
-fun rv_store(st: *encode.EncodeState, args: str, funct3: u32) R.Result[bool, str] {
-    var b0: [64]u8; var b1: [64]u8; var b2: [64]u8; var b3: [64]u8;
-    var n: u32 = 0;
-    if (!rv_split(args, ?b0[0], ?b1[0], ?b2[0], ?b3[0], 64, ?n)) { ret R.err[bool, str]("encode: malformed inline-asm store operands"); }
-    if (n != 2)                                                  { ret R.err[bool, str]("encode: inline-asm store expects rs, off(base)"); }
-    var rs: RvAsmOp; var mem: RvAsmOp;
-    if (!rv_parse_operand((?b0[0])::str, ?rs) || rs.kind != RVOP_REG)    { ret R.err[bool, str]("encode: inline-asm store value must be a register"); }
-    if (!rv_parse_operand((?b1[0])::str, ?mem) || mem.kind != RVOP_MEM)  { ret R.err[bool, str]("encode: inline-asm store address must be off(base)"); }
-    if (mem.imm < -2048 || mem.imm > 2047)                             { ret R.err[bool, str]("encode: inline-asm store offset is out of the 12-bit signed range"); }
-    emit_s(st, OPC_STORE, funct3, mem.reg::u32, rs.reg::u32, mem.imm::u32 & 0xFFF);
-    ret R.ok[bool, str](true);
-}
-
-# a U-type form `rd, imm20` (lui / auipc). the immediate is the raw 20-bit upper field
-fun rv_uimm(st: *encode.EncodeState, args: str, opcode: u32) R.Result[bool, str] {
-    var b0: [64]u8; var b1: [64]u8; var b2: [64]u8; var b3: [64]u8;
-    var n: u32 = 0;
-    if (!rv_split(args, ?b0[0], ?b1[0], ?b2[0], ?b3[0], 64, ?n)) { ret R.err[bool, str]("encode: malformed inline-asm operands"); }
-    if (n != 2)                                                  { ret R.err[bool, str]("encode: inline-asm lui/auipc expects rd, imm"); }
-    var rd: RvAsmOp; var im: RvAsmOp;
-    if (!rv_parse_operand((?b0[0])::str, ?rd) || rd.kind != RVOP_REG) { ret R.err[bool, str]("encode: inline-asm destination must be a register"); }
-    if (!rv_parse_operand((?b1[0])::str, ?im) || im.kind != RVOP_IMM) { ret R.err[bool, str]("encode: inline-asm lui/auipc needs an immediate"); }
-    if (im.imm < 0 || im.imm > 0xFFFFF)                              { ret R.err[bool, str]("encode: inline-asm lui/auipc immediate is out of the 20-bit range"); }
-    emit_u(st, opcode, rd.reg::u32, im.imm::u32 & 0xFFFFF);
-    ret R.ok[bool, str](true);
-}
-
-# `li rd, imm` - materialize the signed immediate through the slice-2 `emit_li`
-fun rv_li(st: *encode.EncodeState, args: str) R.Result[bool, str] {
-    var b0: [64]u8; var b1: [64]u8; var b2: [64]u8; var b3: [64]u8;
-    var n: u32 = 0;
-    if (!rv_split(args, ?b0[0], ?b1[0], ?b2[0], ?b3[0], 64, ?n)) { ret R.err[bool, str]("encode: malformed inline-asm 'li' operands"); }
-    if (n != 2)                                                  { ret R.err[bool, str]("encode: inline-asm 'li' expects rd, imm"); }
-    var rd: RvAsmOp; var im: RvAsmOp;
-    if (!rv_parse_operand((?b0[0])::str, ?rd) || rd.kind != RVOP_REG) { ret R.err[bool, str]("encode: inline-asm 'li' destination must be a register"); }
-    if (!rv_parse_operand((?b1[0])::str, ?im) || im.kind != RVOP_IMM) { ret R.err[bool, str]("encode: inline-asm 'li' needs an immediate"); }
-    emit_li(st, rd.reg::u32, im.imm);
-    ret R.ok[bool, str](true);
-}
-
-# `la rd, sym` - the pc-relative address-of `auipc rd, %pcrel_hi(sym)` (RK_PCREL_HI20)
-# ; `addi rd, rd, %pcrel_lo(sym)` (RK_PCREL_LO12_I) sequence with zero placeholders
-fun rv_la(st: *encode.EncodeState, args: str) R.Result[bool, str] {
-    var b0: [64]u8; var b1: [64]u8; var b2: [64]u8; var b3: [64]u8;
-    var n: u32 = 0;
-    if (!rv_split(args, ?b0[0], ?b1[0], ?b2[0], ?b3[0], 64, ?n)) { ret R.err[bool, str]("encode: malformed inline-asm 'la' operands"); }
-    if (n != 2)                                                  { ret R.err[bool, str]("encode: inline-asm 'la' expects rd, sym"); }
-    var rd: RvAsmOp; var sym: RvAsmOp;
-    if (!rv_parse_operand((?b0[0])::str, ?rd) || rd.kind != RVOP_REG)   { ret R.err[bool, str]("encode: inline-asm 'la' destination must be a register"); }
-    if (!rv_parse_operand((?b1[0])::str, ?sym) || sym.kind != RVOP_SYM) { ret R.err[bool, str]("encode: inline-asm 'la' target must be a symbol"); }
-    val symr: R.Result[intern.StrId, str] = intern.intern_bytes(st.interner, sym.name, sym.name_len);
-    if (R.is_err[intern.StrId, str](symr)) { ret R.err[bool, str](R.unwrap_err[intern.StrId, str](symr)); }
-    val symid: intern.StrId = R.unwrap_ok[intern.StrId, str](symr);
-    val hr: R.Result[bool, str] = emit_pcrel_hi(st, rd.reg::u32, symid, 0);
-    if (R.is_err[bool, str](hr)) { ret hr; }
-    val lo_pos: u32 = st.buf.len::u32;
-    emit_i(st, OPC_OP_IMM, F3_ADD, rd.reg::u32, rd.reg::u32, 0);
-    note_sym_target(st, symid, isa.SYM_MOD_PCREL_LO);
-    ret encode.push_reloc(st, lo_pos, of.RK_PCREL_LO12_I, symid, 0);
-}
-
-# a direct call to a symbol - `auipc <link>, 0` ; `jalr <ret>, <link>, 0` with a zero
-# placeholder pair and an RK_PLT32 marker at the auipc (the abstract direct-call kind
-# the linker maps to R_RISCV_CALL_PLT). `call` links through ra; `tail` links through
-# t1 and returns nowhere (rd = x0), the standard tail-call form
-fun rv_call_sym(st: *encode.EncodeState, args: str, link: u32, ret_reg: u32) R.Result[bool, str] {
-    var op: RvAsmOp;
-    if (!rv_parse_operand(rv_trim(args), ?op) || op.kind != RVOP_SYM) {
-        ret R.err[bool, str]("encode: inline-asm call/tail target must be a symbol");
-    }
-    val symr: R.Result[intern.StrId, str] = intern.intern_bytes(st.interner, op.name, op.name_len);
-    if (R.is_err[intern.StrId, str](symr)) { ret R.err[bool, str](R.unwrap_err[intern.StrId, str](symr)); }
-    val symid: intern.StrId = R.unwrap_ok[intern.StrId, str](symr);
-    val pos: u32 = st.buf.len::u32;
-    emit_u(st, OPC_AUIPC, link, 0);
-    note_sym_target(st, symid, isa.SYM_MOD_PCREL_HI);
-    emit_i(st, OPC_JALR, F3_ADD, ret_reg, link, 0);
-    note_sym_target(st, symid, isa.SYM_MOD_PCREL_LO);
-    ret encode.push_reloc(st, pos, of.RK_PLT32, symid, 0);
-}
-
-# resolve a branch / jump target token to a numeric local label
-#
-# A symbol target is rejected loud - a riscv conditional branch reaches only +-4 KiB
-# and there is no in-block relocation kind for it, so branch to a numeric local label
-# instead (the AArch64 conditional-branch path makes the same restriction)
-# ---
-# target_tok: the target token as written
-# number:     out - the local label's number
-# fwd:        out - true for a forward reference (`Nf`)
-# ret:        true when the token names a local label, or an error
-fun rv_local_target(target_tok: str, number: *u64, fwd: *bool) R.Result[bool, str] {
-    if (rv_label_ref(rv_trim(target_tok), number, fwd)) { ret R.ok[bool, str](true); }
-    ret R.err[bool, str]("encode: inline-asm branch/jump target must be a numeric local label (Nf / Nb)");
-}
-
-# resolve the displacement of a branch just emitted against a numeric local label
-#
-# A backward reference patches immediately against the nearest preceding definition;
-# a forward reference is recorded and patched when its definition is reached. The
-# B-type / J-type displacement insert is the shared `patch_branch_riscv64` (it
-# dispatches on the placeholder word's opcode)
-# ---
-# st:        encoder driver state
-# labels:    the asm block's local-label scope
-# patch_pos: the emitted branch's `.text` offset
-# number:    the local label's number
-# fwd:       true for a forward reference
-# ret:       ok(true), or an error naming the unresolved reference
-fun rv_resolve_local(st: *encode.EncodeState, labels: *RvLabels, patch_pos: u32, number: u64, fwd: bool) R.Result[bool, str] {
-    if (fwd) { ret rv_label_push_ref(labels, patch_pos, number); }
-    val def: O.Option[u32] = rv_label_lookup(labels, number);
-    if (!O.is_some[u32](def)) {
-        ret R.err[bool, str]("encode: inline-asm backward reference to a local label has no preceding definition in this asm block");
-    }
-    var fx: encode.BranchFixup;
-    fx.patch_pos = patch_pos; fx.next_ip = 0; fx.target_block = 0; fx.fn_text_base = 0;
-    ret patch_branch_riscv64(st, ?fx, O.unwrap[u32](def));
-}
-
-# emit a B-type conditional branch to a numeric local label
-# ---
-# st:         encoder driver state
-# labels:     the asm block's local-label scope
-# funct3:     the relation field
-# rs1:        the first compared register
-# rs2:        the second compared register
-# target_tok: the target token as written
-# ret:        ok(true), or an error
-fun rv_branch_local(st: *encode.EncodeState, labels: *RvLabels, funct3: u32, rs1: u32, rs2: u32, target_tok: str) R.Result[bool, str] {
-    var number: u64 = 0;
-    var fwd:    bool = false;
-    val tr: R.Result[bool, str] = rv_local_target(target_tok, ?number, ?fwd);
-    if (R.is_err[bool, str](tr)) { ret tr; }
-    val patch_pos: u32 = st.buf.len::u32;
-    emit_b(st, OPC_BRANCH, funct3, rs1, rs2, 0);
-    note_local_target(st, number, fwd);
-    ret rv_resolve_local(st, labels, patch_pos, number, fwd);
-}
-
-# emit a J-type jump to a numeric local label
-# ---
-# st:         encoder driver state
-# labels:     the asm block's local-label scope
-# rd:         the link register field
-# target_tok: the target token as written
-# ret:        ok(true), or an error
-fun rv_jump_local(st: *encode.EncodeState, labels: *RvLabels, rd: u32, target_tok: str) R.Result[bool, str] {
-    var number: u64 = 0;
-    var fwd:    bool = false;
-    val tr: R.Result[bool, str] = rv_local_target(target_tok, ?number, ?fwd);
-    if (R.is_err[bool, str](tr)) { ret tr; }
-    val patch_pos: u32 = st.buf.len::u32;
-    emit_j(st, OPC_JAL, rd, 0);
-    note_local_target(st, number, fwd);
-    ret rv_resolve_local(st, labels, patch_pos, number, fwd);
-}
-
-# a two-register conditional branch `rs1, rs2, label`. `swap` exchanges the operands
-# for the reversed pseudo forms (bgt / ble / bgtu / bleu)
-fun rv_branch2(st: *encode.EncodeState, labels: *RvLabels, args: str, funct3: u32, swap: bool) R.Result[bool, str] {
-    var b0: [64]u8; var b1: [64]u8; var b2: [64]u8; var b3: [64]u8;
-    var n: u32 = 0;
-    if (!rv_split(args, ?b0[0], ?b1[0], ?b2[0], ?b3[0], 64, ?n)) { ret R.err[bool, str]("encode: malformed inline-asm branch operands"); }
-    if (n != 3)                                                  { ret R.err[bool, str]("encode: inline-asm branch expects rs1, rs2, label"); }
-    var ra_: RvAsmOp; var rb: RvAsmOp;
-    if (!rv_parse_operand((?b0[0])::str, ?ra_) || ra_.kind != RVOP_REG) { ret R.err[bool, str]("encode: inline-asm branch operand must be a register"); }
-    if (!rv_parse_operand((?b1[0])::str, ?rb) || rb.kind != RVOP_REG)   { ret R.err[bool, str]("encode: inline-asm branch operand must be a register"); }
-    var rs1: u32 = ra_.reg::u32;
-    var rs2: u32 = rb.reg::u32;
-    if (swap) { val t: u32 = rs1; rs1 = rs2; rs2 = t; }
-    ret rv_branch_local(st, labels, funct3, rs1, rs2, (?b2[0])::str);
-}
-
-# a compare-against-zero pseudo branch `rs, label`. `reg_is_rs1` puts the register in
-# rs1 (x0 in rs2) for beqz / bnez / bgez / bltz, else in rs2 for blez / bgtz
-fun rv_branchz(st: *encode.EncodeState, labels: *RvLabels, args: str, funct3: u32, reg_is_rs1: bool) R.Result[bool, str] {
-    var b0: [64]u8; var b1: [64]u8; var b2: [64]u8; var b3: [64]u8;
-    var n: u32 = 0;
-    if (!rv_split(args, ?b0[0], ?b1[0], ?b2[0], ?b3[0], 64, ?n)) { ret R.err[bool, str]("encode: malformed inline-asm branch operands"); }
-    if (n != 2)                                                  { ret R.err[bool, str]("encode: inline-asm branch expects rs, label"); }
-    var rs: RvAsmOp;
-    if (!rv_parse_operand((?b0[0])::str, ?rs) || rs.kind != RVOP_REG) { ret R.err[bool, str]("encode: inline-asm branch operand must be a register"); }
-    var rs1: u32 = RZERO;
-    var rs2: u32 = RZERO;
-    if (reg_is_rs1) { rs1 = rs.reg::u32; } or { rs2 = rs.reg::u32; }
-    ret rv_branch_local(st, labels, funct3, rs1, rs2, (?b1[0])::str);
-}
-
-# `j label` / `jal label` / `jal rd, label` - a J-type jump to a numeric local label,
-# linking through `rd` (x0 for `j`, ra for `jal label`, the named register otherwise)
-fun rv_jump(st: *encode.EncodeState, labels: *RvLabels, args: str, default_rd: u32) R.Result[bool, str] {
-    var b0: [64]u8; var b1: [64]u8; var b2: [64]u8; var b3: [64]u8;
-    var n: u32 = 0;
-    if (!rv_split(args, ?b0[0], ?b1[0], ?b2[0], ?b3[0], 64, ?n)) { ret R.err[bool, str]("encode: malformed inline-asm jump operands"); }
-    if (n == 1) {
-        ret rv_jump_local(st, labels, default_rd, (?b0[0])::str);
-    }
-    if (n == 2) {
-        var rd: RvAsmOp;
-        if (!rv_parse_operand((?b0[0])::str, ?rd) || rd.kind != RVOP_REG) { ret R.err[bool, str]("encode: inline-asm 'jal' destination must be a register"); }
-        ret rv_jump_local(st, labels, rd.reg::u32, (?b1[0])::str);
-    }
-    ret R.err[bool, str]("encode: inline-asm jump expects label or rd, label");
-}
-
-# `jr rs` (jalr x0, rs, 0) or `jalr rs` (jalr ra, rs, 0) / `jalr rd, rs, imm`
-fun rv_jalr(st: *encode.EncodeState, args: str, default_rd: u32) R.Result[bool, str] {
-    var b0: [64]u8; var b1: [64]u8; var b2: [64]u8; var b3: [64]u8;
-    var n: u32 = 0;
-    if (!rv_split(args, ?b0[0], ?b1[0], ?b2[0], ?b3[0], 64, ?n)) { ret R.err[bool, str]("encode: malformed inline-asm jalr operands"); }
-    if (n == 1) {
-        var rs: RvAsmOp;
-        if (!rv_parse_operand((?b0[0])::str, ?rs) || rs.kind != RVOP_REG) { ret R.err[bool, str]("encode: inline-asm jr/jalr operand must be a register"); }
-        emit_i(st, OPC_JALR, F3_ADD, default_rd, rs.reg::u32, 0);
-        ret R.ok[bool, str](true);
-    }
-    if (n == 3) {
-        var rd: RvAsmOp; var rs: RvAsmOp; var im: RvAsmOp;
-        if (!rv_parse_operand((?b0[0])::str, ?rd) || rd.kind != RVOP_REG)  { ret R.err[bool, str]("encode: inline-asm jalr destination must be a register"); }
-        if (!rv_parse_operand((?b1[0])::str, ?rs) || rs.kind != RVOP_REG)  { ret R.err[bool, str]("encode: inline-asm jalr base must be a register"); }
-        if (!rv_parse_operand((?b2[0])::str, ?im) || im.kind != RVOP_IMM)  { ret R.err[bool, str]("encode: inline-asm jalr needs an immediate"); }
-        if (im.imm < -2048 || im.imm > 2047)                             { ret R.err[bool, str]("encode: inline-asm jalr offset is out of the 12-bit signed range"); }
-        emit_i(st, OPC_JALR, F3_ADD, rd.reg::u32, rs.reg::u32, im.imm::u32 & 0xFFF);
-        ret R.ok[bool, str](true);
-    }
-    ret R.err[bool, str]("encode: inline-asm jalr expects rs or rd, rs, imm");
-}
-
-# strip a trailing RV64A ordering suffix (`.aqrl` / `.aq` / `.rl`) from atomic mnemonic
-# `mnem` of length `len`, returning the length without the suffix and setting the aq / rl
-# bits. an atomic with no ordering suffix leaves both clear
-fun rv_amo_ordering(mnem: str, len: usize, aq_out: *bool, rl_out: *bool) usize {
-    @aq_out = false; @rl_out = false;
-    if (len >= 5 && str_region_equals(mnem, len - 5, 5, ".aqrl")) { @aq_out = true; @rl_out = true; ret len - 5; }
-    if (len >= 3 && str_region_equals(mnem, len - 3, 3, ".aq"))   { @aq_out = true; ret len - 3; }
-    if (len >= 3 && str_region_equals(mnem, len - 3, 3, ".rl"))   { @rl_out = true; ret len - 3; }
-    ret len;
-}
-
-# map an atomic base name `mnem[0..len)` (the mnemonic with its width and ordering
-# suffixes already stripped) to its 5-bit funct5, setting `is_lr_out` for the two-operand
-# `lr` form. returns false when the base is not an RV64A atomic
-fun rv_amo_base(mnem: str, len: usize, funct5_out: *u32, is_lr_out: *bool) bool {
-    @is_lr_out = false;
-    if (str_region_equals(mnem, 0, len, "lr"))      { @funct5_out = A5_LR; @is_lr_out = true; ret true; }
-    if (str_region_equals(mnem, 0, len, "sc"))      { @funct5_out = A5_SC;      ret true; }
-    if (str_region_equals(mnem, 0, len, "amoswap")) { @funct5_out = A5_AMOSWAP; ret true; }
-    if (str_region_equals(mnem, 0, len, "amoadd"))  { @funct5_out = A5_AMOADD;  ret true; }
-    if (str_region_equals(mnem, 0, len, "amoand"))  { @funct5_out = A5_AMOAND;  ret true; }
-    if (str_region_equals(mnem, 0, len, "amoor"))   { @funct5_out = A5_AMOOR;   ret true; }
-    if (str_region_equals(mnem, 0, len, "amoxor"))  { @funct5_out = A5_AMOXOR;  ret true; }
-    if (str_region_equals(mnem, 0, len, "amomax"))  { @funct5_out = A5_AMOMAX;  ret true; }
-    if (str_region_equals(mnem, 0, len, "amomin"))  { @funct5_out = A5_AMOMIN;  ret true; }
-    if (str_region_equals(mnem, 0, len, "amomaxu")) { @funct5_out = A5_AMOMAXU; ret true; }
-    if (str_region_equals(mnem, 0, len, "amominu")) { @funct5_out = A5_AMOMINU; ret true; }
-    ret false;
-}
-
-# encode one RV64A atomic statement (the OPC_AMO major opcode, R-type with the aq / rl
-# ordering bits folded into funct7). `lr` is `rd, (rs1)` with rs2 forced to x0; `sc` and
-# the `amo*` read-modify-writes are `rd, rs2, (rs1)`. the address is the base-only
-# `(rs1)` form atomics require - a displacement is rejected, unlike a regular load /
-# store. `matched` is set only when `mnem` decodes to a real atomic, so an unrelated
-# mnemonic falls through to the dispatch's unsupported-mnemonic error
-fun rv_amo(st: *encode.EncodeState, mnem: str, args: str, matched: *bool) R.Result[bool, str] {
-    @matched = false;
-    val len: usize = str_len(mnem);
-    var aq: bool = false; var rl: bool = false;
-    val wlen: usize = rv_amo_ordering(mnem, len, ?aq, ?rl);
-    if (wlen < 4) { ret R.ok[bool, str](true); }
-    var funct3: u32 = 0;
-    if (str_region_equals(mnem, wlen - 2, 2, ".w")) { funct3 = F3_AMO_W; }
-    or (str_region_equals(mnem, wlen - 2, 2, ".d")) { funct3 = F3_AMO_D; }
-    or { ret R.ok[bool, str](true); }
-    var funct5: u32 = 0; var is_lr: bool = false;
-    if (!rv_amo_base(mnem, wlen - 2, ?funct5, ?is_lr)) { ret R.ok[bool, str](true); }
-    @matched = true;
-
-    var funct7: u32 = funct5 << 2;
-    if (aq) { funct7 = funct7 | 0x2; }
-    if (rl) { funct7 = funct7 | 0x1; }
-
-    var b0: [64]u8; var b1: [64]u8; var b2: [64]u8; var b3: [64]u8;
-    var n: u32 = 0;
-    if (!rv_split(args, ?b0[0], ?b1[0], ?b2[0], ?b3[0], 64, ?n)) { ret R.err[bool, str]("encode: malformed inline-asm atomic operands"); }
-
-    if (is_lr) {
-        if (n != 2)                                                         { ret R.err[bool, str]("encode: inline-asm 'lr' expects rd, (rs1)"); }
-        var rd: RvAsmOp; var mem: RvAsmOp;
-        if (!rv_parse_operand((?b0[0])::str, ?rd) || rd.kind != RVOP_REG)   { ret R.err[bool, str]("encode: inline-asm 'lr' destination must be a register"); }
-        if (!rv_parse_operand((?b1[0])::str, ?mem) || mem.kind != RVOP_MEM) { ret R.err[bool, str]("encode: inline-asm 'lr' address must be (rs1)"); }
-        if (mem.imm != 0)                                                   { ret R.err[bool, str]("encode: inline-asm atomic address takes no displacement"); }
-        emit_r(st, OPC_AMO, funct3, funct7, rd.reg::u32, mem.reg::u32, RZERO);
-        ret R.ok[bool, str](true);
-    }
-
-    if (n != 3)                                                        { ret R.err[bool, str]("encode: inline-asm atomic expects rd, rs2, (rs1)"); }
-    var rd: RvAsmOp; var rs2: RvAsmOp; var mem: RvAsmOp;
-    if (!rv_parse_operand((?b0[0])::str, ?rd) || rd.kind != RVOP_REG)   { ret R.err[bool, str]("encode: inline-asm atomic destination must be a register"); }
-    if (!rv_parse_operand((?b1[0])::str, ?rs2) || rs2.kind != RVOP_REG) { ret R.err[bool, str]("encode: inline-asm atomic source must be a register"); }
-    if (!rv_parse_operand((?b2[0])::str, ?mem) || mem.kind != RVOP_MEM) { ret R.err[bool, str]("encode: inline-asm atomic address must be (rs1)"); }
-    if (mem.imm != 0)                                                   { ret R.err[bool, str]("encode: inline-asm atomic address takes no displacement"); }
-    emit_r(st, OPC_AMO, funct3, funct7, rd.reg::u32, mem.reg::u32, rs2.reg::u32);
-    ret R.ok[bool, str](true);
-}
-
-# parse and encode one trimmed inline-asm statement. a numeric local-label definition
-# `<digits>:` records the current offset (resolving forward references) and re-dispatches
-# any instruction following it. an unrecognized mnemonic is a hard error so the
-# assembler is cleanly extensible
-fun encode_asm_stmt_riscv64(st: *encode.EncodeState, f: *mir.MirFunction, fn_base: u32, labels: *RvLabels, tok: str) R.Result[bool, str] {
-    var label_num: u64 = 0;
-    val dlen: usize = rv_label_def_len(tok, ?label_num);
-    if (dlen > 0) {
-        val dr: R.Result[bool, str] = rv_label_record_def(st, labels, label_num, st.buf.len::u32);
-        if (R.is_err[bool, str](dr)) { ret dr; }
-        val rest: str = rv_trim((tok::usize + dlen)::str);
-        if (rest[0] == 0) { ret R.ok[bool, str](true); }
-        ret encode_asm_stmt_riscv64(st, f, fn_base, labels, rest);
-    }
-
-    var mbuf: [24]u8;
-    var args: str;
-    if (!rv_first_token(tok, ?mbuf[0], 24, ?args)) { ret R.err[bool, str]("encode: inline-asm mnemonic too long"); }
-    val mnem: str = (?mbuf[0])::str;
-
-    # zero-operand forms.
-    if (str_equals(mnem, "ecall"))  { emit_i(st, OPC_SYSTEM, F3_ADD, RZERO, RZERO, 0); ret R.ok[bool, str](true); }
-    if (str_equals(mnem, "ebreak")) { emit_i(st, OPC_SYSTEM, F3_ADD, RZERO, RZERO, 1); ret R.ok[bool, str](true); }
-    if (str_equals(mnem, "nop"))    { emit_i(st, OPC_OP_IMM, F3_ADD, RZERO, RZERO, 0); ret R.ok[bool, str](true); }
-    if (str_equals(mnem, "ret"))    { emit_i(st, OPC_JALR, F3_ADD, RZERO, RRA, 0); ret R.ok[bool, str](true); }
-    if (str_equals(mnem, "fence"))  { emit_i(st, OPC_MISC_MEM, F3_ADD, RZERO, RZERO, 0xFF); ret R.ok[bool, str](true); }
-    if (str_equals(mnem, "pause"))  { emit_i(st, OPC_MISC_MEM, F3_ADD, RZERO, RZERO, 0x010); ret R.ok[bool, str](true); }
-
-    # register-register ALU (R-type).
-    if (str_equals(mnem, "add"))    { ret rv_three_reg(st, args, OPC_OP, F3_ADD, F7_ZERO); }
-    if (str_equals(mnem, "sub"))    { ret rv_three_reg(st, args, OPC_OP, F3_ADD, F7_SUB); }
-    if (str_equals(mnem, "and"))    { ret rv_three_reg(st, args, OPC_OP, F3_AND, F7_ZERO); }
-    if (str_equals(mnem, "or"))     { ret rv_three_reg(st, args, OPC_OP, F3_OR, F7_ZERO); }
-    if (str_equals(mnem, "xor"))    { ret rv_three_reg(st, args, OPC_OP, F3_XOR, F7_ZERO); }
-    if (str_equals(mnem, "sll"))    { ret rv_three_reg(st, args, OPC_OP, F3_SLL, F7_ZERO); }
-    if (str_equals(mnem, "srl"))    { ret rv_three_reg(st, args, OPC_OP, F3_SRL, F7_ZERO); }
-    if (str_equals(mnem, "sra"))    { ret rv_three_reg(st, args, OPC_OP, F3_SRL, F7_SUB); }
-    if (str_equals(mnem, "slt"))    { ret rv_three_reg(st, args, OPC_OP, F3_SLT, F7_ZERO); }
-    if (str_equals(mnem, "sltu"))   { ret rv_three_reg(st, args, OPC_OP, F3_SLTU, F7_ZERO); }
-    if (str_equals(mnem, "mul"))    { ret rv_three_reg(st, args, OPC_OP, F3_ADD, F7_MULDIV); }
-    if (str_equals(mnem, "mulh"))   { ret rv_three_reg(st, args, OPC_OP, F3_SLL, F7_MULDIV); }
-    if (str_equals(mnem, "mulhsu")) { ret rv_three_reg(st, args, OPC_OP, F3_SLT, F7_MULDIV); }
-    if (str_equals(mnem, "mulhu"))  { ret rv_three_reg(st, args, OPC_OP, F3_SLTU, F7_MULDIV); }
-    if (str_equals(mnem, "div"))    { ret rv_three_reg(st, args, OPC_OP, F3_DIV, F7_MULDIV); }
-    if (str_equals(mnem, "divu"))   { ret rv_three_reg(st, args, OPC_OP, F3_DIVU, F7_MULDIV); }
-    if (str_equals(mnem, "rem"))    { ret rv_three_reg(st, args, OPC_OP, F3_REM, F7_MULDIV); }
-    if (str_equals(mnem, "remu"))   { ret rv_three_reg(st, args, OPC_OP, F3_REMU, F7_MULDIV); }
-    if (str_equals(mnem, "addw"))   { ret rv_three_reg(st, args, OPC_OP_32, F3_ADD, F7_ZERO); }
-    if (str_equals(mnem, "subw"))   { ret rv_three_reg(st, args, OPC_OP_32, F3_ADD, F7_SUB); }
-    if (str_equals(mnem, "sllw"))   { ret rv_three_reg(st, args, OPC_OP_32, F3_SLL, F7_ZERO); }
-    if (str_equals(mnem, "srlw"))   { ret rv_three_reg(st, args, OPC_OP_32, F3_SRL, F7_ZERO); }
-    if (str_equals(mnem, "sraw"))   { ret rv_three_reg(st, args, OPC_OP_32, F3_SRL, F7_SUB); }
-    if (str_equals(mnem, "mulw"))   { ret rv_three_reg(st, args, OPC_OP_32, F3_ADD, F7_MULDIV); }
-    if (str_equals(mnem, "divw"))   { ret rv_three_reg(st, args, OPC_OP_32, F3_DIV, F7_MULDIV); }
-    if (str_equals(mnem, "divuw"))  { ret rv_three_reg(st, args, OPC_OP_32, F3_DIVU, F7_MULDIV); }
-    if (str_equals(mnem, "remw"))   { ret rv_three_reg(st, args, OPC_OP_32, F3_REM, F7_MULDIV); }
-    if (str_equals(mnem, "remuw"))  { ret rv_three_reg(st, args, OPC_OP_32, F3_REMU, F7_MULDIV); }
-
-    # register-immediate ALU (I-type).
-    if (str_equals(mnem, "addi"))  { ret rv_imm_alu(st, args, OPC_OP_IMM, F3_ADD); }
-    if (str_equals(mnem, "andi"))  { ret rv_imm_alu(st, args, OPC_OP_IMM, F3_AND); }
-    if (str_equals(mnem, "ori"))   { ret rv_imm_alu(st, args, OPC_OP_IMM, F3_OR); }
-    if (str_equals(mnem, "xori"))  { ret rv_imm_alu(st, args, OPC_OP_IMM, F3_XOR); }
-    if (str_equals(mnem, "slti"))  { ret rv_imm_alu(st, args, OPC_OP_IMM, F3_SLT); }
-    if (str_equals(mnem, "sltiu")) { ret rv_imm_alu(st, args, OPC_OP_IMM, F3_SLTU); }
-    if (str_equals(mnem, "addiw")) { ret rv_imm_alu(st, args, OPC_OP_IMM_32, F3_ADD); }
-
-    # immediate shifts (I-type, shamt).
-    if (str_equals(mnem, "slli"))  { ret rv_shift_imm(st, args, OPC_OP_IMM, F3_SLL, false, false); }
-    if (str_equals(mnem, "srli"))  { ret rv_shift_imm(st, args, OPC_OP_IMM, F3_SRL, false, false); }
-    if (str_equals(mnem, "srai"))  { ret rv_shift_imm(st, args, OPC_OP_IMM, F3_SRL, true, false); }
-    if (str_equals(mnem, "slliw")) { ret rv_shift_imm(st, args, OPC_OP_IMM_32, F3_SLL, false, true); }
-    if (str_equals(mnem, "srliw")) { ret rv_shift_imm(st, args, OPC_OP_IMM_32, F3_SRL, false, true); }
-    if (str_equals(mnem, "sraiw")) { ret rv_shift_imm(st, args, OPC_OP_IMM_32, F3_SRL, true, true); }
-
-    # loads (I-type) - the explicit signed / zero funct3 the mnemonic names.
-    if (str_equals(mnem, "lb"))  { ret rv_load(st, args, 0x0); }
-    if (str_equals(mnem, "lh"))  { ret rv_load(st, args, 0x1); }
-    if (str_equals(mnem, "lw"))  { ret rv_load(st, args, 0x2); }
-    if (str_equals(mnem, "ld"))  { ret rv_load(st, args, 0x3); }
-    if (str_equals(mnem, "lbu")) { ret rv_load(st, args, 0x4); }
-    if (str_equals(mnem, "lhu")) { ret rv_load(st, args, 0x5); }
-    if (str_equals(mnem, "lwu")) { ret rv_load(st, args, 0x6); }
-
-    # stores (S-type).
-    if (str_equals(mnem, "sb")) { ret rv_store(st, args, 0x0); }
-    if (str_equals(mnem, "sh")) { ret rv_store(st, args, 0x1); }
-    if (str_equals(mnem, "sw")) { ret rv_store(st, args, 0x2); }
-    if (str_equals(mnem, "sd")) { ret rv_store(st, args, 0x3); }
-
-    # upper-immediate (U-type).
-    if (str_equals(mnem, "lui"))   { ret rv_uimm(st, args, OPC_LUI); }
-    if (str_equals(mnem, "auipc")) { ret rv_uimm(st, args, OPC_AUIPC); }
-
-    # conditional branches (B-type) to a numeric local label.
-    if (str_equals(mnem, "beq"))  { ret rv_branch2(st, labels, args, F3_BEQ, false); }
-    if (str_equals(mnem, "bne"))  { ret rv_branch2(st, labels, args, F3_BNE, false); }
-    if (str_equals(mnem, "blt"))  { ret rv_branch2(st, labels, args, 0x4, false); }
-    if (str_equals(mnem, "bge"))  { ret rv_branch2(st, labels, args, 0x5, false); }
-    if (str_equals(mnem, "bltu")) { ret rv_branch2(st, labels, args, 0x6, false); }
-    if (str_equals(mnem, "bgeu")) { ret rv_branch2(st, labels, args, 0x7, false); }
-    # reversed two-register pseudo branches.
-    if (str_equals(mnem, "bgt"))  { ret rv_branch2(st, labels, args, 0x4, true); }
-    if (str_equals(mnem, "ble"))  { ret rv_branch2(st, labels, args, 0x5, true); }
-    if (str_equals(mnem, "bgtu")) { ret rv_branch2(st, labels, args, 0x6, true); }
-    if (str_equals(mnem, "bleu")) { ret rv_branch2(st, labels, args, 0x7, true); }
-    # compare-against-zero pseudo branches.
-    if (str_equals(mnem, "beqz")) { ret rv_branchz(st, labels, args, F3_BEQ, true); }
-    if (str_equals(mnem, "bnez")) { ret rv_branchz(st, labels, args, F3_BNE, true); }
-    if (str_equals(mnem, "bgez")) { ret rv_branchz(st, labels, args, 0x5, true); }
-    if (str_equals(mnem, "bltz")) { ret rv_branchz(st, labels, args, 0x4, true); }
-    if (str_equals(mnem, "blez")) { ret rv_branchz(st, labels, args, 0x5, false); }
-    if (str_equals(mnem, "bgtz")) { ret rv_branchz(st, labels, args, 0x4, false); }
-
-    # jumps and calls.
-    if (str_equals(mnem, "j"))    { ret rv_jump(st, labels, args, RZERO); }
-    if (str_equals(mnem, "jal"))  { ret rv_jump(st, labels, args, RRA); }
-    if (str_equals(mnem, "jr"))   { ret rv_jalr(st, args, RZERO); }
-    if (str_equals(mnem, "jalr")) { ret rv_jalr(st, args, RRA); }
-    if (str_equals(mnem, "call")) { ret rv_call_sym(st, args, RRA, RRA); }
-    if (str_equals(mnem, "tail")) { ret rv_call_sym(st, args, SCRATCH2, RZERO); }
-
-    # pseudo data-movement / unary forms.
-    if (str_equals(mnem, "li")) { ret rv_li(st, args); }
-    if (str_equals(mnem, "la")) { ret rv_la(st, args); }
-    if (str_equals(mnem, "mv")) {
-        var rd: u32 = 0; var rs: u32 = 0;
-        if (!rv_two_reg_args(args, ?rd, ?rs)) { ret R.err[bool, str]("encode: inline-asm 'mv' expects rd, rs"); }
-        emit_i(st, OPC_OP_IMM, F3_ADD, rd, rs, 0);
-        ret R.ok[bool, str](true);
-    }
-    if (str_equals(mnem, "neg")) {
-        var rd: u32 = 0; var rs: u32 = 0;
-        if (!rv_two_reg_args(args, ?rd, ?rs)) { ret R.err[bool, str]("encode: inline-asm 'neg' expects rd, rs"); }
-        emit_r(st, OPC_OP, F3_ADD, F7_SUB, rd, RZERO, rs);
-        ret R.ok[bool, str](true);
-    }
-    if (str_equals(mnem, "negw")) {
-        var rd: u32 = 0; var rs: u32 = 0;
-        if (!rv_two_reg_args(args, ?rd, ?rs)) { ret R.err[bool, str]("encode: inline-asm 'negw' expects rd, rs"); }
-        emit_r(st, OPC_OP_32, F3_ADD, F7_SUB, rd, RZERO, rs);
-        ret R.ok[bool, str](true);
-    }
-    if (str_equals(mnem, "not")) {
-        var rd: u32 = 0; var rs: u32 = 0;
-        if (!rv_two_reg_args(args, ?rd, ?rs)) { ret R.err[bool, str]("encode: inline-asm 'not' expects rd, rs"); }
-        emit_i(st, OPC_OP_IMM, F3_XOR, rd, rs, 0xFFF);
-        ret R.ok[bool, str](true);
-    }
-    if (str_equals(mnem, "seqz")) {
-        var rd: u32 = 0; var rs: u32 = 0;
-        if (!rv_two_reg_args(args, ?rd, ?rs)) { ret R.err[bool, str]("encode: inline-asm 'seqz' expects rd, rs"); }
-        emit_i(st, OPC_OP_IMM, F3_SLTU, rd, rs, 1);
-        ret R.ok[bool, str](true);
-    }
-    if (str_equals(mnem, "snez")) {
-        var rd: u32 = 0; var rs: u32 = 0;
-        if (!rv_two_reg_args(args, ?rd, ?rs)) { ret R.err[bool, str]("encode: inline-asm 'snez' expects rd, rs"); }
-        emit_r(st, OPC_OP, F3_SLTU, F7_ZERO, rd, RZERO, rs);
-        ret R.ok[bool, str](true);
-    }
-    if (str_equals(mnem, "sext.w")) {
-        var rd: u32 = 0; var rs: u32 = 0;
-        if (!rv_two_reg_args(args, ?rd, ?rs)) { ret R.err[bool, str]("encode: inline-asm 'sext.w' expects rd, rs"); }
-        emit_i(st, OPC_OP_IMM_32, F3_ADD, rd, rs, 0);
-        ret R.ok[bool, str](true);
-    }
-
-    # atomics (RV64A) - lr / sc / amo* with their width (.w/.d) and ordering
-    # (.aq/.rl/.aqrl) suffixes parsed inline; only a real atomic claims the dispatch.
-    var amo_matched: bool = false;
-    val amo_r: R.Result[bool, str] = rv_amo(st, mnem, args, ?amo_matched);
-    if (amo_matched) { ret amo_r; }
-
-    ret R.err[bool, str](rv_named_err(st, "encode: unsupported riscv64 inline-asm mnemonic '", mnem, "'", "encode: unsupported riscv64 inline-asm mnemonic"));
-}
-
-# append the base-10 digits of `n` (at least one digit for zero)
-fun rv_emit_dec(out: *encode.ByteBuf, n: u64) {
-    if (n == 0) { encode.emit_byte(out, '0'::u8); ret; }
-    var tmp: [20]u8;
-    var len: usize = 0;
-    var v: u64 = n;
-    for (v > 0) { tmp[len] = (v % 10)::u8 + '0'::u8; v = v / 10; len = len + 1; }
-    var k: usize = 0;
-    for (k < len) { encode.emit_byte(out, tmp[len - 1 - k]); k = k + 1; }
-}
-
-# append the `off(s0)` / `-off(s0)` text for a local's frame-slot displacement (the
-# RV64 analogue of x86-64's `[rbp+off]` and AArch64's `[x29, #off]`). a `{name}` local
-# resolves to this load / store address form against the frame pointer s0
-fun rv_emit_frame_ref(out: *encode.ByteBuf, off: i64) {
-    var mag: i64 = off;
-    if (off < 0) { encode.emit_byte(out, '-'::u8); mag = -off; }
-    rv_emit_dec(out, mag::u64);
-    encode.emit_byte(out, '('::u8);
-    encode.emit_byte(out, 's'::u8);
-    encode.emit_byte(out, '0'::u8);
-    encode.emit_byte(out, ')'::u8);
-}
-
-# true when the interned binding name equals `body[start..start+n)`
-fun rv_bind_name_eq(interner: *intern.Interner, name: intern.StrId, body: str, start: usize, name_len: usize) bool {
-    val nopt: O.Option[str] = intern.lookup(interner, name);
-    if (!O.is_some[str](nopt)) { ret false; }
-    ret str_region_equals(body, start, name_len, O.unwrap[str](nopt));
-}
-
-# release a byte buffer's backing storage on an error path
-fun rv_free_buf(b: *encode.ByteBuf) {
-    if (b.data != nil && b.cap > 0) {
-        A.deallocate[u8](b.alloc, b.data, b.cap);
-        b.data = nil; b.cap = 0; b.len = 0;
-    }
-}
-
-# produce a NUL-terminated copy of the asm body with each `{name}` replaced by its
-# local's `off(s0)` frame-slot text. the offset comes from the slot-vreg binding
-# resolved against the laid-out frame. an unbound `{name}` is a hard error. mirrors
-# x86-64's `substitute_asm_locals`
-fun substitute_asm_locals_riscv64(alloc: *A.Allocator, interner: *intern.Interner, f: *mir.MirFunction, pl: *mir.MirAsm) R.Result[str, str] {
-    var out: encode.ByteBuf = encode.buf_init(alloc);
-    val body: str = pl.body;
-    var i: usize = 0;
-    for (body[i] != 0) {
-        if (body[i] != '{'::char) {
-            encode.emit_byte(?out, body[i]::u8);
-            i = i + 1;
-            cnt;
-        }
-        val name_start: usize = i + 1;
-        var j: usize = name_start;
-        for (body[j] != 0 && body[j] != '}'::char) { j = j + 1; }
-        if (body[j] == 0) {
-            rv_free_buf(?out);
-            ret R.err[str, str]("encode: unterminated '{' in inline asm body");
-        }
-        val name_len: usize = j - name_start;
-
-        var off: i64 = 0;
-        var found: bool = false;
-        var b: u32 = 0;
-        for (b < pl.bind_count) {
-            if (rv_bind_name_eq(interner, pl.binds[b].name, body, name_start, name_len)) {
-                val so: O.Option[i64] = frame_slot_offset(f, pl.binds[b].slot_vreg);
-                if (!O.is_some[i64](so)) {
-                    rv_free_buf(?out);
-                    ret R.err[str, str]("encode: inline-asm '{name}' local has no frame slot");
-                }
-                off = O.unwrap[i64](so);
-                found = true;
-                b = pl.bind_count;
-            } or {
-                b = b + 1;
-            }
-        }
-        if (!found) {
-            rv_free_buf(?out);
-            ret R.err[str, str]("encode: unknown local in inline asm '{name}' reference");
-        }
-
-        rv_emit_frame_ref(?out, off);
-        i = j + 1;
-    }
-    encode.emit_byte(?out, 0);
-
-    if (out.data == nil || out.len == 0) {
-        rv_free_buf(?out);
-        val r: R.Result[*u8, str] = A.allocate[u8](alloc, 1::usize);
-        if (R.is_err[*u8, str](r)) { ret R.err[str, str](R.unwrap_err[*u8, str](r)); }
-        val one: *u8 = R.unwrap_ok[*u8, str](r);
-        one[0] = 0;
-        ret R.ok[str, str](one::str);
-    }
-    if (out.cap != out.len) {
-        val r: R.Result[*u8, str] = A.reallocate[u8](alloc, out.data, out.cap, out.len);
-        if (R.is_err[*u8, str](r)) { ret R.err[str, str](R.unwrap_err[*u8, str](r)); }
-        out.data = R.unwrap_ok[*u8, str](r);
-        out.cap  = out.len;
-    }
-    ret R.ok[str, str](out.data::str);
-}
-
-# tokenize the (already `{name}`-substituted) asm body on newlines / `;`, trim each
-# statement, and encode it. `#` line comments were stripped at lower time, so none reach
-# here. mirrors x86-64's `encode_asm_text`
-fun encode_asm_text_riscv64(st: *encode.EncodeState, f: *mir.MirFunction, fn_base: u32, labels: *RvLabels, text: str) R.Result[bool, str] {
-    val len: usize = str_len(text);
-    var start: usize = 0;
-    for (start < len) {
-        var end: usize = start;
-        for (end < len && text[end] != '\n'::char && text[end] != ';'::char) { end = end + 1; }
-
-        var lo: usize = start;
-        for (lo < end && asm_is_space(text[lo])) { lo = lo + 1; }
-        var hi: usize = end;
-        for (hi > lo && asm_is_space(text[hi - 1])) { hi = hi - 1; }
-
-        if (hi > lo) {
-            var line: [512]u8;
-            val ll: usize = hi - lo;
-            if (ll >= 512) { ret R.err[bool, str]("encode: inline asm statement too long"); }
-            var c: usize = 0;
-            for (c < ll) { line[c] = text[lo + c]::u8; c = c + 1; }
-            line[ll] = 0;
-            val er: R.Result[bool, str] = encode_asm_stmt_riscv64(st, f, fn_base, labels, (?line[0])::str);
-            if (R.is_err[bool, str](er)) { ret er; }
-        }
-        start = end + 1;
-    }
-    ret R.ok[bool, str](true);
-}
-
-# expand an inline-asm MIR_ASM instruction into RV64 bytes. substitutes `{name}`
-# locals to `off(s0)`, encodes each statement, and verifies every forward local-label
-# reference was defined within the block. the RV64 analogue of x86-64's
-# `encode_asm_block`; a rejection is located at the asm statement's "path:line:col"
-# through the instruction's stamped loc (#2153)
+# The riscv64 instantiation of the shared block driver: it supplies the grammar and
+# the driver does the rest, so `{name}` resolution, numeric local labels, byte
+# accounting and the located diagnostic are the same code every target runs.
 fun encode_asm_block_riscv64(st: *encode.EncodeState, f: *mir.MirFunction, fn_base: u32, mi: *mir.MirInstr) R.Result[bool, str] {
-    if (mi.asm_block == nil) { ret R.err[bool, str]("encode: MIR_ASM has no payload"); }
-    val pl: *mir.MirAsm = mi.asm_block;
-    if (!str_equals(pl.isa, "riscv64")) {
-        ret R.err[bool, str](encode.asm_located_message(st, mi.loc, "encode: inline-asm block is not riscv64"));
-    }
-
-    val sr: R.Result[str, str] = substitute_asm_locals_riscv64(st.alloc, st.interner, f, pl);
-    if (R.is_err[str, str](sr)) {
-        ret R.err[bool, str](encode.asm_located_message(st, mi.loc, R.unwrap_err[str, str](sr)));
-    }
-    val text: str = R.unwrap_ok[str, str](sr);
-
-    var labels: RvLabels;
-    rv_labels_init(?labels, st.alloc);
-    val er: R.Result[bool, str] = encode_asm_text_riscv64(st, f, fn_base, ?labels, text);
-    A.deallocate[u8](st.alloc, text::*u8, (str_len(text) + 1)::usize);
-    if (R.is_err[bool, str](er)) {
-        rv_labels_dnit(?labels);
-        ret R.err[bool, str](encode.asm_located_message(st, mi.loc, R.unwrap_err[bool, str](er)));
-    }
-    if (labels.ref_count > 0) {
-        rv_labels_dnit(?labels);
-        ret R.err[bool, str](encode.asm_located_message(st, mi.loc, "encode: inline-asm forward reference to a local label has no definition in this asm block"));
-    }
-    rv_labels_dnit(?labels);
-    ret R.ok[bool, str](true);
+    var g: iasm.Grammar = rv_grammar();
+    ret iasm.encode_block(st, ?g, f, mi);
 }
+
+# assemble `text` as an inline-asm body into `st`, with no `{name}` bindings
+#
+# The encoder tests' entry point: it drives the same cursor and the same driver the
+# block path does, so a byte-exact golden is a fact about the shipping parser rather
+# than about a test-only path beside it.
+fun rv_asm_text(st: *encode.EncodeState, f: *mir.MirFunction, l: *iasm.Labels, text: str) R.Result[bool, str] {
+    var g: iasm.Grammar = rv_grammar();
+    var c: iasm.Cursor;
+    iasm.cursor_init(?c, ?g, text, st.alloc, st.interner, f, nil);
+    ret iasm.run(st, ?g, ?c, l);
+}
+
 
 # a fresh page-backed EncodeState carrying only a byte sink, for exercising the
 # emit-level helpers (packers / prologue / epilogue / branch patch) directly
@@ -5299,18 +4975,18 @@ test "mach.lang.target.isa.riscv64.encode:global_la_sequences" {
     ret bad;
 }
 
-# the inline-asm clobber analyzer classifies the RISC-V statement grammar: a call
+# the inline-asm effect model classifies the RISC-V statement grammar: a call
 # clobbers the caller-saved file, destination-writing forms their first register, the
-# store / branch / system / fence forms nothing, and an unrecognized statement
-# conservatively clobbers everything
+# store / branch / system / fence forms nothing, and a body the assembler could not
+# read conservatively clobbers everything
 test "mach.lang.target.isa.riscv64.encode:asm_clobbers_classification" {
     var bad: i32 = 0;
     var gp: u32 = 0;
     var fp: u32 = 0;
 
-    # a load + store + jal call body: ld writes a0(10), addi writes a1(11), the call
-    # clobbers the caller-saved file; sd writes nothing.
-    asm_clobbers("ld a0, 0(sp)\naddi a1, sp, 8\nsd a0, 0(a1)\njal main", ?gp, ?fp);
+    # a load + store + linking jump body: ld writes a0(10), addi writes a1(11), the
+    # linking jump destroys the caller-saved file; sd writes nothing.
+    asm_clobbers("ld a0, 0(sp)\naddi a1, sp, 8\nsd a0, 0(a1)\ncall main", ?gp, ?fp);
     if ((gp & (1::u32 << 10)) == 0) { bad = 1; }  # a0 written by ld
     if ((gp & (1::u32 << 11)) == 0) { bad = 1; }  # a1 written by addi
     if ((gp & CALLER_SAVED_GP) != CALLER_SAVED_GP) { bad = 1; }  # call clobbers caller-saved
@@ -5318,14 +4994,28 @@ test "mach.lang.target.isa.riscv64.encode:asm_clobbers_classification" {
 
     # a pure store / branch / ecall body writes no register.
     gp = 0; fp = 0;
-    asm_clobbers("sd a0, 0(sp)\nbeq a0, a1, end\necall", ?gp, ?fp);
+    asm_clobbers("sd a0, 0(sp)\nbeq a0, a1, 1f\necall\n1:", ?gp, ?fp);
     if (gp != 0) { bad = 1; }
 
-    # a label prefix is skipped; the following addi still writes its destination.
+    # a `{name}` binding is a stack slot, so it names no register; the destination
+    # register beside it is still credited even before the frame is laid out.
     gp = 0; fp = 0;
-    asm_clobbers("loop: addi t0, t0, 1", ?gp, ?fp);
+    asm_clobbers("ld a0, {v}\nsd a1, {out}", ?gp, ?fp);
+    if (gp != (1::u32 << 10)) { bad = 1; }
+
+    # a numeric local-label definition is its own statement; the instruction sharing
+    # its line still writes its destination.
+    gp = 0; fp = 0;
+    asm_clobbers("1: addi t0, t0, 1", ?gp, ?fp);
     if ((gp & (1::u32 << 5)) == 0) { bad = 1; }  # t0 = x5
     if ((gp & ~(1::u32 << 5)) != 0) { bad = 1; } # nothing else
+
+    # the effect model and the assembler read one grammar: a branch to a symbol is
+    # not encodable on riscv64, so it is not modeled either - the body is opaque
+    # rather than described as writing nothing.
+    gp = 0; fp = 0;
+    asm_clobbers("beq a0, a1, end", ?gp, ?fp);
+    if (gp != 0xFFFFFFFF) { bad = 1; }
 
     # the RV64A atomics write their rd operand (the leftmost register); pause writes
     # nothing. lr / sc / amo* must classify precisely, not fall to the all-clobber path.
@@ -5379,39 +5069,39 @@ test "mach.lang.target.isa.riscv64.encode:inline_asm_core_forms" {
     var alloc: A.Allocator;
     var interner: intern.Interner;
     tasm(?st, ?alloc, ?interner);
-    var labels: RvLabels;
-    rv_labels_init(?labels, ?alloc);
+    var labels: iasm.Labels;
+    iasm.labels_init(?labels, ?alloc);
     var f: mir.MirFunction;
 
-    encode_asm_stmt_riscv64(?st, ?f, 0, ?labels, "ecall");           # 0
-    encode_asm_stmt_riscv64(?st, ?f, 0, ?labels, "ebreak");          # 4
-    encode_asm_stmt_riscv64(?st, ?f, 0, ?labels, "nop");             # 8
-    encode_asm_stmt_riscv64(?st, ?f, 0, ?labels, "ret");             # 12
-    encode_asm_stmt_riscv64(?st, ?f, 0, ?labels, "fence");           # 16
-    encode_asm_stmt_riscv64(?st, ?f, 0, ?labels, "li a7, 93");       # 20
-    encode_asm_stmt_riscv64(?st, ?f, 0, ?labels, "li a0, 0");        # 24
-    encode_asm_stmt_riscv64(?st, ?f, 0, ?labels, "mv a0, a1");       # 28
-    encode_asm_stmt_riscv64(?st, ?f, 0, ?labels, "add a0, a1, a2");  # 32
-    encode_asm_stmt_riscv64(?st, ?f, 0, ?labels, "sub a0, a1, a2");  # 36
-    encode_asm_stmt_riscv64(?st, ?f, 0, ?labels, "addi a0, a1, 5");  # 40
-    encode_asm_stmt_riscv64(?st, ?f, 0, ?labels, "ld a0, 8(sp)");    # 44
-    encode_asm_stmt_riscv64(?st, ?f, 0, ?labels, "sd a0, 16(sp)");   # 48
-    encode_asm_stmt_riscv64(?st, ?f, 0, ?labels, "lw a0, 0(a1)");    # 52
-    encode_asm_stmt_riscv64(?st, ?f, 0, ?labels, "lbu a0, 0(a1)");   # 56
-    encode_asm_stmt_riscv64(?st, ?f, 0, ?labels, "sb a0, 0(a1)");    # 60
-    encode_asm_stmt_riscv64(?st, ?f, 0, ?labels, "lui a0, 0x12345"); # 64
-    encode_asm_stmt_riscv64(?st, ?f, 0, ?labels, "auipc a0, 0");     # 68
-    encode_asm_stmt_riscv64(?st, ?f, 0, ?labels, "slli a0, a1, 3");  # 72
-    encode_asm_stmt_riscv64(?st, ?f, 0, ?labels, "srai a0, a1, 3");  # 76
-    encode_asm_stmt_riscv64(?st, ?f, 0, ?labels, "addiw a0, a1, 1"); # 80
-    encode_asm_stmt_riscv64(?st, ?f, 0, ?labels, "neg a0, a1");      # 84
-    encode_asm_stmt_riscv64(?st, ?f, 0, ?labels, "not a0, a1");      # 88
-    encode_asm_stmt_riscv64(?st, ?f, 0, ?labels, "sext.w a0, a1");   # 92
-    encode_asm_stmt_riscv64(?st, ?f, 0, ?labels, "seqz a0, a1");     # 96
-    encode_asm_stmt_riscv64(?st, ?f, 0, ?labels, "snez a0, a1");     # 100
-    encode_asm_stmt_riscv64(?st, ?f, 0, ?labels, "mul a0, a1, a2");  # 104
-    encode_asm_stmt_riscv64(?st, ?f, 0, ?labels, "divu a0, a1, a2"); # 108
-    encode_asm_stmt_riscv64(?st, ?f, 0, ?labels, "addw a0, a1, a2"); # 112
+    rv_asm_text(?st, ?f, ?labels, "ecall");           # 0
+    rv_asm_text(?st, ?f, ?labels, "ebreak");          # 4
+    rv_asm_text(?st, ?f, ?labels, "nop");             # 8
+    rv_asm_text(?st, ?f, ?labels, "ret");             # 12
+    rv_asm_text(?st, ?f, ?labels, "fence");           # 16
+    rv_asm_text(?st, ?f, ?labels, "li a7, 93");       # 20
+    rv_asm_text(?st, ?f, ?labels, "li a0, 0");        # 24
+    rv_asm_text(?st, ?f, ?labels, "mv a0, a1");       # 28
+    rv_asm_text(?st, ?f, ?labels, "add a0, a1, a2");  # 32
+    rv_asm_text(?st, ?f, ?labels, "sub a0, a1, a2");  # 36
+    rv_asm_text(?st, ?f, ?labels, "addi a0, a1, 5");  # 40
+    rv_asm_text(?st, ?f, ?labels, "ld a0, 8(sp)");    # 44
+    rv_asm_text(?st, ?f, ?labels, "sd a0, 16(sp)");   # 48
+    rv_asm_text(?st, ?f, ?labels, "lw a0, 0(a1)");    # 52
+    rv_asm_text(?st, ?f, ?labels, "lbu a0, 0(a1)");   # 56
+    rv_asm_text(?st, ?f, ?labels, "sb a0, 0(a1)");    # 60
+    rv_asm_text(?st, ?f, ?labels, "lui a0, 0x12345"); # 64
+    rv_asm_text(?st, ?f, ?labels, "auipc a0, 0");     # 68
+    rv_asm_text(?st, ?f, ?labels, "slli a0, a1, 3");  # 72
+    rv_asm_text(?st, ?f, ?labels, "srai a0, a1, 3");  # 76
+    rv_asm_text(?st, ?f, ?labels, "addiw a0, a1, 1"); # 80
+    rv_asm_text(?st, ?f, ?labels, "neg a0, a1");      # 84
+    rv_asm_text(?st, ?f, ?labels, "not a0, a1");      # 88
+    rv_asm_text(?st, ?f, ?labels, "sext.w a0, a1");   # 92
+    rv_asm_text(?st, ?f, ?labels, "seqz a0, a1");     # 96
+    rv_asm_text(?st, ?f, ?labels, "snez a0, a1");     # 100
+    rv_asm_text(?st, ?f, ?labels, "mul a0, a1, a2");  # 104
+    rv_asm_text(?st, ?f, ?labels, "divu a0, a1, a2"); # 108
+    rv_asm_text(?st, ?f, ?labels, "addw a0, a1, a2"); # 112
 
     if (read_word(?st.buf, 0)   != 0x00000073) { bad = 1; }
     if (read_word(?st.buf, 4)   != 0x00100073) { bad = 1; }
@@ -5443,7 +5133,7 @@ test "mach.lang.target.isa.riscv64.encode:inline_asm_core_forms" {
     if (read_word(?st.buf, 108) != 0x02C5D533) { bad = 1; }
     if (read_word(?st.buf, 112) != 0x00C5853B) { bad = 1; }
 
-    rv_labels_dnit(?labels);
+    iasm.labels_dnit(?labels);
     encode.buf_dnit(?st.buf);
     ret bad;
 }
@@ -5458,8 +5148,8 @@ test "mach.lang.target.isa.riscv64.encode:inline_asm_local_labels" {
     var alloc: A.Allocator;
     var interner: intern.Interner;
     tasm(?st, ?alloc, ?interner);
-    var labels: RvLabels;
-    rv_labels_init(?labels, ?alloc);
+    var labels: iasm.Labels;
+    iasm.labels_init(?labels, ?alloc);
     var f: mir.MirFunction;
 
     # 1: addi a0, a0, 1   (label def at 0, addi at 0)
@@ -5467,13 +5157,13 @@ test "mach.lang.target.isa.riscv64.encode:inline_asm_local_labels" {
     # j 2f                (offset 8, forward to 16 -> disp +8)
     # nop                 (offset 12)
     # 2: ret              (label def at 16, ret at 16)
-    encode_asm_stmt_riscv64(?st, ?f, 0, ?labels, "1:");
-    encode_asm_stmt_riscv64(?st, ?f, 0, ?labels, "addi a0, a0, 1");
-    encode_asm_stmt_riscv64(?st, ?f, 0, ?labels, "bne a0, a1, 1b");
-    encode_asm_stmt_riscv64(?st, ?f, 0, ?labels, "j 2f");
-    encode_asm_stmt_riscv64(?st, ?f, 0, ?labels, "nop");
-    encode_asm_stmt_riscv64(?st, ?f, 0, ?labels, "2:");
-    encode_asm_stmt_riscv64(?st, ?f, 0, ?labels, "ret");
+    rv_asm_text(?st, ?f, ?labels, "1:");
+    rv_asm_text(?st, ?f, ?labels, "addi a0, a0, 1");
+    rv_asm_text(?st, ?f, ?labels, "bne a0, a1, 1b");
+    rv_asm_text(?st, ?f, ?labels, "j 2f");
+    rv_asm_text(?st, ?f, ?labels, "nop");
+    rv_asm_text(?st, ?f, ?labels, "2:");
+    rv_asm_text(?st, ?f, ?labels, "ret");
 
     # addi a0, a0, 1 = 0x00150513
     if (read_word(?st.buf, 0)  != 0x00150513) { bad = 1; }
@@ -5486,9 +5176,9 @@ test "mach.lang.target.isa.riscv64.encode:inline_asm_local_labels" {
     # ret = 0x00008067
     if (read_word(?st.buf, 16) != 0x00008067) { bad = 1; }
     # every forward reference resolved.
-    if (labels.ref_count != 0) { bad = 1; }
+    if (labels.fixup_count != 0) { bad = 1; }
 
-    rv_labels_dnit(?labels);
+    iasm.labels_dnit(?labels);
     encode.buf_dnit(?st.buf);
     ret bad;
 }
@@ -5502,12 +5192,12 @@ test "mach.lang.target.isa.riscv64.encode:inline_asm_symbol_relocs" {
     var alloc: A.Allocator;
     var interner: intern.Interner;
     tasm(?st, ?alloc, ?interner);
-    var labels: RvLabels;
-    rv_labels_init(?labels, ?alloc);
+    var labels: iasm.Labels;
+    iasm.labels_init(?labels, ?alloc);
     var f: mir.MirFunction;
 
     # call foo: auipc ra,0 = 0x00000097 ; jalr ra,ra,0 = 0x000080E7, RK_PLT32 @0.
-    encode_asm_stmt_riscv64(?st, ?f, 0, ?labels, "call foo");
+    rv_asm_text(?st, ?f, ?labels, "call foo");
     if (read_word(?st.buf, 0) != 0x00000097) { bad = 1; }
     if (read_word(?st.buf, 4) != 0x000080E7) { bad = 1; }
     if (st.reloc_count != 1) { bad = 1; }
@@ -5517,7 +5207,7 @@ test "mach.lang.target.isa.riscv64.encode:inline_asm_symbol_relocs" {
     }
 
     # tail foo: auipc t1,0 = 0x00000317 ; jalr x0,t1,0 = 0x00030067, RK_PLT32 @8.
-    encode_asm_stmt_riscv64(?st, ?f, 0, ?labels, "tail foo");
+    rv_asm_text(?st, ?f, ?labels, "tail foo");
     if (read_word(?st.buf, 8)  != 0x00000317) { bad = 1; }
     if (read_word(?st.buf, 12) != 0x00030067) { bad = 1; }
     if (st.reloc_count != 2) { bad = 1; }
@@ -5527,7 +5217,7 @@ test "mach.lang.target.isa.riscv64.encode:inline_asm_symbol_relocs" {
     }
 
     # la a0, foo: auipc a0,0 = 0x00000517 ; addi a0,a0,0 = 0x00050513, HI20 @16 + LO12_I @20.
-    encode_asm_stmt_riscv64(?st, ?f, 0, ?labels, "la a0, foo");
+    rv_asm_text(?st, ?f, ?labels, "la a0, foo");
     if (read_word(?st.buf, 16) != 0x00000517) { bad = 1; }
     if (read_word(?st.buf, 20) != 0x00050513) { bad = 1; }
     if (st.reloc_count != 4) { bad = 1; }
@@ -5539,11 +5229,11 @@ test "mach.lang.target.isa.riscv64.encode:inline_asm_symbol_relocs" {
     }
 
     # an unknown mnemonic is a hard error, not silent bytes.
-    val ur: R.Result[bool, str] = encode_asm_stmt_riscv64(?st, ?f, 0, ?labels, "frobnicate a0, a1");
+    val ur: R.Result[bool, str] = rv_asm_text(?st, ?f, ?labels, "frobnicate a0, a1");
     if (!R.is_err[bool, str](ur)) { bad = 1; }
-    or { if (!str_contains(R.unwrap_err[bool, str](ur), "unsupported riscv64 inline-asm mnemonic")) { bad = 1; } }
+    or { if (!str_contains(R.unwrap_err[bool, str](ur), "unknown riscv64 inline-asm instruction")) { bad = 1; } }
 
-    rv_labels_dnit(?labels);
+    iasm.labels_dnit(?labels);
     encode.buf_dnit(?st.buf);
     ret bad;
 }
@@ -5558,46 +5248,46 @@ test "mach.lang.target.isa.riscv64.encode:inline_asm_atomics" {
     var alloc: A.Allocator;
     var interner: intern.Interner;
     tasm(?st, ?alloc, ?interner);
-    var labels: RvLabels;
-    rv_labels_init(?labels, ?alloc);
+    var labels: iasm.Labels;
+    iasm.labels_init(?labels, ?alloc);
     var f: mir.MirFunction;
 
-    encode_asm_stmt_riscv64(?st, ?f, 0, ?labels, "lr.w a0, (a1)");           # 0
-    encode_asm_stmt_riscv64(?st, ?f, 0, ?labels, "lr.d a0, (a1)");           # 4
-    encode_asm_stmt_riscv64(?st, ?f, 0, ?labels, "sc.w a0, a2, (a1)");       # 8
-    encode_asm_stmt_riscv64(?st, ?f, 0, ?labels, "sc.d a0, a2, (a1)");       # 12
-    encode_asm_stmt_riscv64(?st, ?f, 0, ?labels, "amoswap.w a0, a2, (a1)");  # 16
-    encode_asm_stmt_riscv64(?st, ?f, 0, ?labels, "amoswap.d a0, a2, (a1)");  # 20
-    encode_asm_stmt_riscv64(?st, ?f, 0, ?labels, "amoadd.w a0, a2, (a1)");   # 24
-    encode_asm_stmt_riscv64(?st, ?f, 0, ?labels, "amoadd.d a0, a2, (a1)");   # 28
-    encode_asm_stmt_riscv64(?st, ?f, 0, ?labels, "amoand.w a0, a2, (a1)");   # 32
-    encode_asm_stmt_riscv64(?st, ?f, 0, ?labels, "amoand.d a0, a2, (a1)");   # 36
-    encode_asm_stmt_riscv64(?st, ?f, 0, ?labels, "amoor.w a0, a2, (a1)");    # 40
-    encode_asm_stmt_riscv64(?st, ?f, 0, ?labels, "amoor.d a0, a2, (a1)");    # 44
-    encode_asm_stmt_riscv64(?st, ?f, 0, ?labels, "amoxor.w a0, a2, (a1)");   # 48
-    encode_asm_stmt_riscv64(?st, ?f, 0, ?labels, "amoxor.d a0, a2, (a1)");   # 52
-    encode_asm_stmt_riscv64(?st, ?f, 0, ?labels, "amomax.w a0, a2, (a1)");   # 56
-    encode_asm_stmt_riscv64(?st, ?f, 0, ?labels, "amomax.d a0, a2, (a1)");   # 60
-    encode_asm_stmt_riscv64(?st, ?f, 0, ?labels, "amomin.w a0, a2, (a1)");   # 64
-    encode_asm_stmt_riscv64(?st, ?f, 0, ?labels, "amomin.d a0, a2, (a1)");   # 68
-    encode_asm_stmt_riscv64(?st, ?f, 0, ?labels, "amomaxu.w a0, a2, (a1)");  # 72
-    encode_asm_stmt_riscv64(?st, ?f, 0, ?labels, "amomaxu.d a0, a2, (a1)");  # 76
-    encode_asm_stmt_riscv64(?st, ?f, 0, ?labels, "amominu.w a0, a2, (a1)");  # 80
-    encode_asm_stmt_riscv64(?st, ?f, 0, ?labels, "amominu.d a0, a2, (a1)");  # 84
-    encode_asm_stmt_riscv64(?st, ?f, 0, ?labels, "lr.w.aq a0, (a1)");        # 88
-    encode_asm_stmt_riscv64(?st, ?f, 0, ?labels, "lr.d.aq a0, (a1)");        # 92
-    encode_asm_stmt_riscv64(?st, ?f, 0, ?labels, "lr.w.aqrl a0, (a1)");      # 96
-    encode_asm_stmt_riscv64(?st, ?f, 0, ?labels, "sc.w.rl a0, a2, (a1)");    # 100
-    encode_asm_stmt_riscv64(?st, ?f, 0, ?labels, "sc.d.rl a0, a2, (a1)");    # 104
-    encode_asm_stmt_riscv64(?st, ?f, 0, ?labels, "sc.d.aqrl a0, a2, (a1)");  # 108
-    encode_asm_stmt_riscv64(?st, ?f, 0, ?labels, "amoswap.w.aq a0, a2, (a1)");  # 112
-    encode_asm_stmt_riscv64(?st, ?f, 0, ?labels, "amoswap.d.rl a0, a2, (a1)");  # 116
-    encode_asm_stmt_riscv64(?st, ?f, 0, ?labels, "amoadd.w.aqrl a0, a2, (a1)"); # 120
-    encode_asm_stmt_riscv64(?st, ?f, 0, ?labels, "amoadd.d.aq a0, a2, (a1)");   # 124
-    encode_asm_stmt_riscv64(?st, ?f, 0, ?labels, "amoadd.d.rl a0, a2, (a1)");   # 128
-    encode_asm_stmt_riscv64(?st, ?f, 0, ?labels, "amoadd.d.aqrl a0, a2, (a1)"); # 132
-    encode_asm_stmt_riscv64(?st, ?f, 0, ?labels, "amomaxu.d.aqrl a0, a2, (a1)");# 136
-    encode_asm_stmt_riscv64(?st, ?f, 0, ?labels, "pause");                   # 140
+    rv_asm_text(?st, ?f, ?labels, "lr.w a0, (a1)");           # 0
+    rv_asm_text(?st, ?f, ?labels, "lr.d a0, (a1)");           # 4
+    rv_asm_text(?st, ?f, ?labels, "sc.w a0, a2, (a1)");       # 8
+    rv_asm_text(?st, ?f, ?labels, "sc.d a0, a2, (a1)");       # 12
+    rv_asm_text(?st, ?f, ?labels, "amoswap.w a0, a2, (a1)");  # 16
+    rv_asm_text(?st, ?f, ?labels, "amoswap.d a0, a2, (a1)");  # 20
+    rv_asm_text(?st, ?f, ?labels, "amoadd.w a0, a2, (a1)");   # 24
+    rv_asm_text(?st, ?f, ?labels, "amoadd.d a0, a2, (a1)");   # 28
+    rv_asm_text(?st, ?f, ?labels, "amoand.w a0, a2, (a1)");   # 32
+    rv_asm_text(?st, ?f, ?labels, "amoand.d a0, a2, (a1)");   # 36
+    rv_asm_text(?st, ?f, ?labels, "amoor.w a0, a2, (a1)");    # 40
+    rv_asm_text(?st, ?f, ?labels, "amoor.d a0, a2, (a1)");    # 44
+    rv_asm_text(?st, ?f, ?labels, "amoxor.w a0, a2, (a1)");   # 48
+    rv_asm_text(?st, ?f, ?labels, "amoxor.d a0, a2, (a1)");   # 52
+    rv_asm_text(?st, ?f, ?labels, "amomax.w a0, a2, (a1)");   # 56
+    rv_asm_text(?st, ?f, ?labels, "amomax.d a0, a2, (a1)");   # 60
+    rv_asm_text(?st, ?f, ?labels, "amomin.w a0, a2, (a1)");   # 64
+    rv_asm_text(?st, ?f, ?labels, "amomin.d a0, a2, (a1)");   # 68
+    rv_asm_text(?st, ?f, ?labels, "amomaxu.w a0, a2, (a1)");  # 72
+    rv_asm_text(?st, ?f, ?labels, "amomaxu.d a0, a2, (a1)");  # 76
+    rv_asm_text(?st, ?f, ?labels, "amominu.w a0, a2, (a1)");  # 80
+    rv_asm_text(?st, ?f, ?labels, "amominu.d a0, a2, (a1)");  # 84
+    rv_asm_text(?st, ?f, ?labels, "lr.w.aq a0, (a1)");        # 88
+    rv_asm_text(?st, ?f, ?labels, "lr.d.aq a0, (a1)");        # 92
+    rv_asm_text(?st, ?f, ?labels, "lr.w.aqrl a0, (a1)");      # 96
+    rv_asm_text(?st, ?f, ?labels, "sc.w.rl a0, a2, (a1)");    # 100
+    rv_asm_text(?st, ?f, ?labels, "sc.d.rl a0, a2, (a1)");    # 104
+    rv_asm_text(?st, ?f, ?labels, "sc.d.aqrl a0, a2, (a1)");  # 108
+    rv_asm_text(?st, ?f, ?labels, "amoswap.w.aq a0, a2, (a1)");  # 112
+    rv_asm_text(?st, ?f, ?labels, "amoswap.d.rl a0, a2, (a1)");  # 116
+    rv_asm_text(?st, ?f, ?labels, "amoadd.w.aqrl a0, a2, (a1)"); # 120
+    rv_asm_text(?st, ?f, ?labels, "amoadd.d.aq a0, a2, (a1)");   # 124
+    rv_asm_text(?st, ?f, ?labels, "amoadd.d.rl a0, a2, (a1)");   # 128
+    rv_asm_text(?st, ?f, ?labels, "amoadd.d.aqrl a0, a2, (a1)"); # 132
+    rv_asm_text(?st, ?f, ?labels, "amomaxu.d.aqrl a0, a2, (a1)");# 136
+    rv_asm_text(?st, ?f, ?labels, "pause");                   # 140
 
     if (read_word(?st.buf, 0)   != 0x1005A52F) { bad = 1; }
     if (read_word(?st.buf, 4)   != 0x1005B52F) { bad = 1; }
@@ -5637,18 +5327,137 @@ test "mach.lang.target.isa.riscv64.encode:inline_asm_atomics" {
     if (read_word(?st.buf, 140) != 0x0100000F) { bad = 1; }
 
     # an atomic address takes no displacement, unlike a regular load / store.
-    val dr: R.Result[bool, str] = encode_asm_stmt_riscv64(?st, ?f, 0, ?labels, "lr.d a0, 8(a1)");
+    val dr: R.Result[bool, str] = rv_asm_text(?st, ?f, ?labels, "lr.d a0, 8(a1)");
     if (!R.is_err[bool, str](dr)) { bad = 1; }
     or { if (!str_contains(R.unwrap_err[bool, str](dr), "no displacement")) { bad = 1; } }
 
     # a non-atomic mnemonic that shares the `amo` prefix is still unsupported, not
     # silently swallowed by the atomic dispatch.
-    val ur: R.Result[bool, str] = encode_asm_stmt_riscv64(?st, ?f, 0, ?labels, "amobogus.q a0, a2, (a1)");
+    val ur: R.Result[bool, str] = rv_asm_text(?st, ?f, ?labels, "amobogus.q a0, a2, (a1)");
     if (!R.is_err[bool, str](ur)) { bad = 1; }
-    or { if (!str_contains(R.unwrap_err[bool, str](ur), "unsupported riscv64 inline-asm mnemonic")) { bad = 1; } }
+    or { if (!str_contains(R.unwrap_err[bool, str](ur), "unknown riscv64 inline-asm instruction")) { bad = 1; } }
 
-    rv_labels_dnit(?labels);
+    iasm.labels_dnit(?labels);
     encode.buf_dnit(?st.buf);
+    ret bad;
+}
+
+# the instruction a mnemonic row names must survive a round trip through the
+# encoding: `rv_fields` recovers the format fields from the instruction, and the
+# encoder's own `classify_*` names the instruction back from those same fields. This
+# is the conformance check that keeps the assembler and the printer from drifting -
+# an instruction they disagree about fails here rather than in an object file
+test "mach.lang.target.isa.riscv64.encode:asm_fields_classify_round_trip" {
+    var bad: i32 = 0;
+    var i: usize = 0;
+    for (i < RV_MNEMONIC_COUNT) {
+        val op: inst.MachOp = RV_MNEMONICS[i].code::inst.MachOp;
+        var fmt: u8 = 0;
+        var opcode: u32 = 0;
+        var f3: u32 = 0;
+        var f7: u32 = 0;
+        if (!rv_fields(op, ?fmt, ?opcode, ?f3, ?f7)) { bad = 1; }
+        or {
+            # the immediate the classifier reads to separate forms sharing a funct3.
+            var imm: u32 = 0;
+            if (op == inst.SRAI || op == inst.SRAIW) { imm = 0x400; }
+            or (op == inst.EBREAK)                   { imm = 1; }
+            or (op == inst.PAUSE)                    { imm = 0x010; }
+            or (op == inst.FENCE)                    { imm = 0xFF; }
+
+            var back: inst.MachOp = inst.MOP_NONE;
+            if (fmt == RVFMT_R)      { back = classify_r(opcode, f3, f7, 0); }
+            or (fmt == RVFMT_I)      { back = classify_i(opcode, f3, imm); }
+            or (fmt == RVFMT_S)      { back = classify_s(opcode, f3); }
+            or (fmt == RVFMT_B)      { back = classify_b(opcode, f3); }
+            or (fmt == RVFMT_U)      { back = classify_u(opcode); }
+            or                       { back = classify_j(opcode); }
+            if (back != op) { bad = 1; }
+        }
+        i = i + 1;
+    }
+
+    # every A-extension form the suffix decoder can synthesize, across both widths.
+    var op2: inst.MachOp = inst.LR_W;
+    for (op2 <= inst.AMOMAXU_D) {
+        var fmt: u8 = 0;
+        var opcode: u32 = 0;
+        var f3: u32 = 0;
+        var f7: u32 = 0;
+        if (!rv_fields(op2, ?fmt, ?opcode, ?f3, ?f7)) { bad = 1; }
+        or { if (classify_r(opcode, f3, f7 | 0x3, 0) != op2) { bad = 1; } }
+        op2 = op2 + 1;
+    }
+    ret bad;
+}
+
+# the parse accounts for every byte of a statement or refuses it: an operand the
+# grammar does not reach cannot be silently dropped, and the diagnostic names the
+# statement rather than the file
+test "mach.lang.target.isa.riscv64.encode:asm_byte_accounting" {
+    var bad: i32 = 0;
+    var gp: u32 = 0;
+    var fp: u32 = 0;
+
+    # `fence` takes no operands here, so a fence with an ordering set is refused
+    # rather than assembled as a bare full barrier with the operands ignored.
+    asm_clobbers("fence rw, rw", ?gp, ?fp);
+    if (gp != 0xFFFFFFFF) { bad = 1; }
+
+    # a trailing token no operand claims fails the accounting.
+    gp = 0; fp = 0;
+    asm_clobbers("addi a0, a1, 1 junk", ?gp, ?fp);
+    if (gp != 0xFFFFFFFF) { bad = 1; }
+
+    # a well-formed statement claims all of itself, separators and whitespace aside.
+    gp = 0; fp = 0;
+    asm_clobbers("  addi a0 , a1 , 1  ;  mv a2, a3  ", ?gp, ?fp);
+    if (gp != ((1::u32 << 10) | (1::u32 << 12))) { bad = 1; }
+    ret bad;
+}
+
+# a relocation modifier is read back into the shared `isa.SymModifier` the encoder's
+# own notifications carry, so the two halves of a pc-relative symbol pair round-trip
+# between the printer and the parser. `%got_pcrel_hi` parses but has no riscv64
+# relocation kind in this backend, and is refused by name rather than encoded as a
+# plain pc-relative reference
+test "mach.lang.target.isa.riscv64.encode:asm_relocation_modifiers" {
+    var bad: i32 = 0;
+    var st: encode.EncodeState;
+    var alloc: A.Allocator;
+    var interner: intern.Interner;
+    tasm(?st, ?alloc, ?interner);
+    var labels: iasm.Labels;
+    iasm.labels_init(?labels, ?alloc);
+    var f: mir.MirFunction;
+
+    # auipc a0, %pcrel_hi(foo) = 0x00000517 with RK_PCREL_HI20 at 0;
+    # addi a0, a0, %pcrel_lo(foo) = 0x00050513 with RK_PCREL_LO12_I at 4.
+    val hr: R.Result[bool, str] = rv_asm_text(?st, ?f, ?labels, "auipc a0, %pcrel_hi(foo)");
+    if (R.is_err[bool, str](hr)) { bad = 1; }
+    val lr: R.Result[bool, str] = rv_asm_text(?st, ?f, ?labels, "addi a0, a0, %pcrel_lo(foo)");
+    if (R.is_err[bool, str](lr)) { bad = 1; }
+    if (read_word(?st.buf, 0) != 0x00000517) { bad = 1; }
+    if (read_word(?st.buf, 4) != 0x00050513) { bad = 1; }
+    if (st.reloc_count != 2) { bad = 1; }
+    or {
+        if (st.relocs[0].kind != of.RK_PCREL_HI20)   { bad = 1; }
+        if (st.relocs[1].kind != of.RK_PCREL_LO12_I) { bad = 1; }
+    }
+
+    val gr: R.Result[bool, str] = rv_asm_text(?st, ?f, ?labels, "auipc a0, %got_pcrel_hi(foo)");
+    if (!R.is_err[bool, str](gr)) { bad = 1; }
+    or { if (!str_contains(R.unwrap_err[bool, str](gr), "no GOT-relative relocation kind")) { bad = 1; } }
+
+    val br: R.Result[bool, str] = rv_asm_text(?st, ?f, ?labels, "auipc a0, %bogus(foo)");
+    if (!R.is_err[bool, str](br)) { bad = 1; }
+    or { if (!str_contains(R.unwrap_err[bool, str](br), "unsupported riscv64 inline-asm relocation modifier")) { bad = 1; } }
+
+    iasm.labels_dnit(?labels);
+    encode.buf_dnit(?st.buf);
+    if (st.relocs != nil && st.reloc_cap > 0) {
+        A.deallocate[encode.PendingReloc](?alloc, st.relocs, st.reloc_cap::usize);
+    }
     ret bad;
 }
 

--- a/src/lang/target/isa/x64/encode.mach
+++ b/src/lang/target/isa/x64/encode.mach
@@ -20,11 +20,16 @@
 # precise bytes the System V x86-64 toolchain expects, including the byte-register
 # REX special cases and the RBP/R13/RSP/R12 addressing-mode quirks.
 #
-# It also owns the other direction: `AsmParser` reads a user `asm x86_64` body
-# into the same `isa.Inst` values selection produces (#2229), so an inline-asm
-# instruction and a compiler-selected one are one representation taking one path.
-# The encoder and the `asm_clobbers` effect model are both consumers of that
-# parse - there is no second reading of the text for either to disagree with.
+# It also owns the other direction: a user `asm x86_64` body parses into the same
+# `isa.Inst` values selection produces (#2229), so an inline-asm instruction and a
+# compiler-selected one are one representation taking one path. The encoder and the
+# `asm_clobbers` effect model are both consumers of that parse - there is no second
+# reading of the text for either to disagree with.
+#
+# Since #2232 the parse itself is the SHARED one in `isa.asm`: this module supplies
+# the mnemonic table, the operand lexer and the emitter (`x64_grammar`), and the
+# shared spine owns the statement cursor, the byte accounting, numeric local labels,
+# `{name}` binding and the effect model - the same code riscv64 and aarch64 run.
 
 use std.allocator.page;
 use std.io.writer;
@@ -51,6 +56,7 @@ use mach.lang.be.codegen.mir;
 use mach.lang.intern;
 use mach.lang.target.abi;
 use mach.lang.target.isa;
+use iasm: mach.lang.target.isa.asm;
 use mach.lang.target.isa.x64;
 use printer: mach.lang.target.isa.x64.printer;
 use mach.lang.target.of;
@@ -4899,1254 +4905,242 @@ fun frame_slot_offset(f: *mir.MirFunction, v: u32) O.Option[i64] {
     ret O.none[i64]();
 }
 
-# a parsed inline-asm operand
+# the x86-64 inline-assembly grammar
 #
-# The parse-time superset of `isa.Operand`: it additionally names a bare symbol
-# (which the encoder resolves to a relocation rather than an addressing mode) and
-# a `{name}` local binding, whose frame slot is only known once the frame is laid
-# out. Names are spans into the asm body, not copies, so the interned body is the
-# single backing store for a parse.
-# ---
-# kind:     one of ASMOP_*
-# reg:      register id for ASMOP_REG, or the base register for ASMOP_MEM (-1 when
-#           the memory operand has no base, e.g. a rip-relative symbol)
-# size:     operand width in bytes
-# imm:      immediate value for ASMOP_IMM, or the displacement for ASMOP_MEM
-# index:    scaled-index register for ASMOP_MEM (-1 when none)
-# scale:    index scale for ASMOP_MEM (1, 2, 4, or 8; 0 when no index)
-# name_off: body offset of the bare symbol name (ASMOP_SYM), of the rip-relative
-#           symbol of a `[symbol]` ASMOP_MEM, or of the local name (ASMOP_BIND)
-# name_len: length in bytes of that name
-# mem_sym:  true when an ASMOP_MEM addresses a symbol rip-relatively (`name` set)
-rec AsmOperand {
-    kind:     u8;
-    reg:      i32;
-    size:     u8;
-    imm:      i64;
-    index:    i32;
-    scale:    u8;
-    name_off: usize;
-    name_len: usize;
-    mem_sym:  bool;
-}
-
-# no operand parsed
-val ASMOP_NONE: u8 = 0;
-# a register operand
-val ASMOP_REG:  u8 = 1;
-# an immediate constant
-val ASMOP_IMM:  u8 = 2;
-# a `[base + index*scale + disp]` memory operand (or a rip-relative symbol)
-val ASMOP_MEM:  u8 = 3;
-# a bare symbol / branch-target name (resolved to a relocation)
-val ASMOP_SYM:  u8 = 4;
-# a `{name}` local binding whose frame slot is not yet known. only produced when
-# the parse runs without a laid-out frame; with one, a binding parses straight to
-# the ASMOP_MEM its stack slot denotes
-val ASMOP_BIND: u8 = 5;
-
-# the operand shape an inline-asm mnemonic takes
-val AF_NONE:   u8 = 0;  # no operands
-val AF_ONE:    u8 = 1;  # one operand
-val AF_TWO:    u8 = 2;  # `dst, src`
-val AF_BRANCH: u8 = 3;  # a branch target: a named symbol or a numeric local label
-val AF_BYTES:  u8 = 4;  # `.byte b, b, ...` raw bytes
-
-# the registers an inline-asm mnemonic writes, as a flag set
+# The x86-64 half of the shared parser (`isa.asm`): the instructions an
+# `asm x86_64 { ... }` body may name, what each one writes, and how its operands and
+# bytes are formed. Everything above an operand token - statement splitting, byte
+# accounting, numeric local labels, `{name}` binding, the effect fold and the block
+# driver - is the shared spine's and appears nowhere here.
 #
-# Every fact here is stated per mnemonic, never per category: a form is credited
-# with a write only where the instruction's semantics are known to produce one.
-# Condition flags are not modeled - the allocator holds no value in them.
-val AW_NONE:    u8 = 0x00;  # writes no register (flags, memory or control only)
-val AW_DST:     u8 = 0x01;  # writes its destination operand
-val AW_SRC:     u8 = 0x02;  # writes its source operand too (the exchange forms)
-val AW_RAX:     u8 = 0x04;  # implicitly writes RAX (the compare-exchange forms)
-val AW_SYSCALL: u8 = 0x08;  # implicitly writes RAX, RCX and R11 (the syscall ABI)
+# x86-64 is the one supported target with a variable-length encoding, so the emit-side
+# word-count guard the RISC targets get does not apply: no instruction length exists
+# ahead of the encoder. The parse-side accounting - every byte of the body claimed by
+# exactly one item - is the whole of the totality check here.
 
-# one inline-asm mnemonic: its text, the instruction it denotes, its operand
-# shape, and the registers it writes
+# the operand pattern a mnemonic's operands follow, carried in `Mnemonic.flags[7:0]`
+val X64P_NONE:   u16 = 1;  # the mnemonic is the whole statement
+val X64P_ONE:    u16 = 2;  # one operand
+val X64P_TWO:    u16 = 3;  # `dst, src`
+val X64P_BRANCH: u16 = 4;  # a branch target: a symbol or a numeric local label
+
+# the mnemonic carries a LOCK prefix, in `Mnemonic.flags[15:8]`
 #
-# The single table the parser and the clobber model both read, so an instruction's
-# encoding and its effects can never describe different instructions. An alias
-# (`jz` for `je`) is its own row carrying the same opcode.
-# ---
-# name:   the mnemonic text, including any `lock` prefix
-# opcode: the x86-64 opcode the mnemonic denotes (unused for `.byte`)
-# form:   the operand shape (AF_*)
-# writes: the registers the form writes (AW_* flag set)
-# flags:  encoding flags the mnemonic itself implies (e.g. FLAG_LOCK)
-rec AsmMnemonic {
-    name:   str;
-    opcode: u16;
-    form:   u8;
-    writes: u8;
-    flags:  u16;
-}
+# Private to this grammar; the emitter translates it to the encoder's own
+# `x64.FLAG_LOCK`, whose value sits in the pattern's byte and must not be mixed here.
+val X64F_LOCK: u16 = 0x0100;
 
-# number of rows in the inline-asm mnemonic table
-val ASM_MNEMONIC_COUNT: usize = 48;
+# the registers the syscall ABI destroys: the kernel's return register plus the two
+# the instruction itself overwrites (RAX, RCX, R11)
+val X64_SYSCALL_WRITES: u32 = 0x803;
+# the implicit accumulator a compare-exchange writes (RAX)
+val X64_RAX_WRITE: u32 = 0x1;
+
+# every general-purpose register the x86-64 inline-asm grammar can name
+val X64_ALL_GP: u32 = 0xFFFF;
+# every vector register an unreadable instruction stream could reach
+val X64_ALL_FP: u32 = 0xFFFF;
+
+# the operand pattern half of a mnemonic row's flags
+fun x64_pattern(flags: u16) u16 { ret flags & 0x00FF; }
+
+# number of rows in the x86-64 inline-asm mnemonic table
+val X64_MNEMONIC_COUNT: usize = 48;
 
 # the x86-64 inline-asm instruction surface
 #
-# Exactly the instructions an `asm x86_64` body may name. A mnemonic absent here
-# is refused with a diagnostic naming it - there is no permissive path, so the
-# effect model can never be asked about an instruction nobody described.
-val ASM_MNEMONICS: [ASM_MNEMONIC_COUNT]AsmMnemonic = [ASM_MNEMONIC_COUNT]AsmMnemonic{
-    # zero-operand forms. `syscall` writes the kernel's return register plus the
-    # two the instruction itself destroys; the fences and traps write nothing.
-    AsmMnemonic{ name: "syscall", opcode: x64.SYSCALL, form: AF_NONE, writes: AW_SYSCALL, flags: 0 },
-    AsmMnemonic{ name: "ret",     opcode: x64.RET,     form: AF_NONE, writes: AW_NONE,    flags: 0 },
-    AsmMnemonic{ name: "hlt",     opcode: x64.HLT,     form: AF_NONE, writes: AW_NONE,    flags: 0 },
-    AsmMnemonic{ name: "mfence",  opcode: x64.MFENCE,  form: AF_NONE, writes: AW_NONE,    flags: 0 },
-    AsmMnemonic{ name: "pause",   opcode: x64.PAUSE,   form: AF_NONE, writes: AW_NONE,    flags: 0 },
-    AsmMnemonic{ name: "nop",     opcode: x64.NOP,     form: AF_NONE, writes: AW_NONE,    flags: 0 },
+# Exactly the instructions an `asm x86_64` body may name. A mnemonic absent here is
+# refused with a diagnostic naming it - there is no permissive path, so the effect
+# model can never be asked about an instruction nobody described.
+#
+# Rows are matched in order and a mnemonic matches only when followed by a space (or
+# is the whole statement, for a no-operand form), so `mov` never shadows `movzx`; the
+# `lock`-prefixed spellings are placed before their bare twins.
+val X64_MNEMONICS: [X64_MNEMONIC_COUNT]iasm.Mnemonic = [X64_MNEMONIC_COUNT]iasm.Mnemonic{
+    # zero-operand forms. `syscall` writes the kernel's return register plus the two
+    # the instruction itself destroys; the fences and traps write nothing.
+    iasm.Mnemonic{ name: "syscall", code: x64.SYSCALL::u32, form: iasm.AF_NONE, writes: iasm.AW_NONE, implicit: X64_SYSCALL_WRITES, flags: X64P_NONE, words: 0 },
+    iasm.Mnemonic{ name: "ret",     code: x64.RET::u32,     form: iasm.AF_NONE, writes: iasm.AW_NONE, implicit: 0, flags: X64P_NONE, words: 0 },
+    iasm.Mnemonic{ name: "hlt",     code: x64.HLT::u32,     form: iasm.AF_NONE, writes: iasm.AW_NONE, implicit: 0, flags: X64P_NONE, words: 0 },
+    iasm.Mnemonic{ name: "mfence",  code: x64.MFENCE::u32,  form: iasm.AF_NONE, writes: iasm.AW_NONE, implicit: 0, flags: X64P_NONE, words: 0 },
+    iasm.Mnemonic{ name: "pause",   code: x64.PAUSE::u32,   form: iasm.AF_NONE, writes: iasm.AW_NONE, implicit: 0, flags: X64P_NONE, words: 0 },
+    iasm.Mnemonic{ name: "nop",     code: x64.NOP::u32,     form: iasm.AF_NONE, writes: iasm.AW_NONE, implicit: 0, flags: X64P_NONE, words: 0 },
 
     # control transfers. a call's caller-saved clobbers are already covered by the
     # asm block's own barrier, and no branch form writes a register itself.
-    AsmMnemonic{ name: "call", opcode: x64.CALL, form: AF_BRANCH, writes: AW_NONE, flags: 0 },
-    AsmMnemonic{ name: "jmp",  opcode: x64.JMP,  form: AF_BRANCH, writes: AW_NONE, flags: 0 },
-    AsmMnemonic{ name: "je",   opcode: x64.JE,   form: AF_BRANCH, writes: AW_NONE, flags: 0 },
-    AsmMnemonic{ name: "jz",   opcode: x64.JE,   form: AF_BRANCH, writes: AW_NONE, flags: 0 },
-    AsmMnemonic{ name: "jne",  opcode: x64.JNE,  form: AF_BRANCH, writes: AW_NONE, flags: 0 },
-    AsmMnemonic{ name: "jnz",  opcode: x64.JNE,  form: AF_BRANCH, writes: AW_NONE, flags: 0 },
+    iasm.Mnemonic{ name: "call", code: x64.CALL::u32, form: iasm.AF_OPS, writes: iasm.AW_NONE, implicit: 0, flags: X64P_BRANCH, words: 0 },
+    iasm.Mnemonic{ name: "jmp",  code: x64.JMP::u32,  form: iasm.AF_OPS, writes: iasm.AW_NONE, implicit: 0, flags: X64P_BRANCH, words: 0 },
+    iasm.Mnemonic{ name: "je",   code: x64.JE::u32,   form: iasm.AF_OPS, writes: iasm.AW_NONE, implicit: 0, flags: X64P_BRANCH, words: 0 },
+    iasm.Mnemonic{ name: "jz",   code: x64.JE::u32,   form: iasm.AF_OPS, writes: iasm.AW_NONE, implicit: 0, flags: X64P_BRANCH, words: 0 },
+    iasm.Mnemonic{ name: "jne",  code: x64.JNE::u32,  form: iasm.AF_OPS, writes: iasm.AW_NONE, implicit: 0, flags: X64P_BRANCH, words: 0 },
+    iasm.Mnemonic{ name: "jnz",  code: x64.JNE::u32,  form: iasm.AF_OPS, writes: iasm.AW_NONE, implicit: 0, flags: X64P_BRANCH, words: 0 },
     # carry-flag conditionals: jc == jb (CF=1), jnc == jae == jnb (CF=0).
-    AsmMnemonic{ name: "jc",   opcode: x64.JB,   form: AF_BRANCH, writes: AW_NONE, flags: 0 },
-    AsmMnemonic{ name: "jb",   opcode: x64.JB,   form: AF_BRANCH, writes: AW_NONE, flags: 0 },
-    AsmMnemonic{ name: "jnc",  opcode: x64.JAE,  form: AF_BRANCH, writes: AW_NONE, flags: 0 },
-    AsmMnemonic{ name: "jae",  opcode: x64.JAE,  form: AF_BRANCH, writes: AW_NONE, flags: 0 },
-    AsmMnemonic{ name: "jnb",  opcode: x64.JAE,  form: AF_BRANCH, writes: AW_NONE, flags: 0 },
+    iasm.Mnemonic{ name: "jc",   code: x64.JB::u32,   form: iasm.AF_OPS, writes: iasm.AW_NONE, implicit: 0, flags: X64P_BRANCH, words: 0 },
+    iasm.Mnemonic{ name: "jb",   code: x64.JB::u32,   form: iasm.AF_OPS, writes: iasm.AW_NONE, implicit: 0, flags: X64P_BRANCH, words: 0 },
+    iasm.Mnemonic{ name: "jnc",  code: x64.JAE::u32,  form: iasm.AF_OPS, writes: iasm.AW_NONE, implicit: 0, flags: X64P_BRANCH, words: 0 },
+    iasm.Mnemonic{ name: "jae",  code: x64.JAE::u32,  form: iasm.AF_OPS, writes: iasm.AW_NONE, implicit: 0, flags: X64P_BRANCH, words: 0 },
+    iasm.Mnemonic{ name: "jnb",  code: x64.JAE::u32,  form: iasm.AF_OPS, writes: iasm.AW_NONE, implicit: 0, flags: X64P_BRANCH, words: 0 },
 
     # conditional set writes its single byte-register destination: setc == setb
     # (CF=1), setnc == setae == setnb (CF=0).
-    AsmMnemonic{ name: "setc",  opcode: x64.SETB,  form: AF_ONE, writes: AW_DST, flags: 0 },
-    AsmMnemonic{ name: "setb",  opcode: x64.SETB,  form: AF_ONE, writes: AW_DST, flags: 0 },
-    AsmMnemonic{ name: "setnc", opcode: x64.SETAE, form: AF_ONE, writes: AW_DST, flags: 0 },
-    AsmMnemonic{ name: "setae", opcode: x64.SETAE, form: AF_ONE, writes: AW_DST, flags: 0 },
-    AsmMnemonic{ name: "setnb", opcode: x64.SETAE, form: AF_ONE, writes: AW_DST, flags: 0 },
+    iasm.Mnemonic{ name: "setc",  code: x64.SETB::u32,  form: iasm.AF_OPS, writes: iasm.AW_OP0, implicit: 0, flags: X64P_ONE, words: 0 },
+    iasm.Mnemonic{ name: "setb",  code: x64.SETB::u32,  form: iasm.AF_OPS, writes: iasm.AW_OP0, implicit: 0, flags: X64P_ONE, words: 0 },
+    iasm.Mnemonic{ name: "setnc", code: x64.SETAE::u32, form: iasm.AF_OPS, writes: iasm.AW_OP0, implicit: 0, flags: X64P_ONE, words: 0 },
+    iasm.Mnemonic{ name: "setae", code: x64.SETAE::u32, form: iasm.AF_OPS, writes: iasm.AW_OP0, implicit: 0, flags: X64P_ONE, words: 0 },
+    iasm.Mnemonic{ name: "setnb", code: x64.SETAE::u32, form: iasm.AF_OPS, writes: iasm.AW_OP0, implicit: 0, flags: X64P_ONE, words: 0 },
 
     # the `lock`-prefixed read-modify-write forms. compare-exchange also writes the
     # implicit RAX accumulator; the exchange-and-add forms write both operands.
-    AsmMnemonic{ name: "lock cmpxchg", opcode: x64.CMPXCHG, form: AF_TWO, writes: AW_DST | AW_RAX, flags: x64.FLAG_LOCK::u16 },
-    AsmMnemonic{ name: "lock xadd",    opcode: x64.XADD,    form: AF_TWO, writes: AW_DST | AW_SRC, flags: x64.FLAG_LOCK::u16 },
-    AsmMnemonic{ name: "cmpxchg",      opcode: x64.CMPXCHG, form: AF_TWO, writes: AW_DST | AW_RAX, flags: 0 },
-    AsmMnemonic{ name: "xadd",         opcode: x64.XADD,    form: AF_TWO, writes: AW_DST | AW_SRC, flags: 0 },
+    iasm.Mnemonic{ name: "lock cmpxchg", code: x64.CMPXCHG::u32, form: iasm.AF_OPS, writes: iasm.AW_OP0,                 implicit: X64_RAX_WRITE, flags: X64P_TWO | X64F_LOCK, words: 0 },
+    iasm.Mnemonic{ name: "lock xadd",    code: x64.XADD::u32,    form: iasm.AF_OPS, writes: iasm.AW_OP0 | iasm.AW_OP1,   implicit: 0,             flags: X64P_TWO | X64F_LOCK, words: 0 },
+    iasm.Mnemonic{ name: "cmpxchg",      code: x64.CMPXCHG::u32, form: iasm.AF_OPS, writes: iasm.AW_OP0,                 implicit: X64_RAX_WRITE, flags: X64P_TWO, words: 0 },
+    iasm.Mnemonic{ name: "xadd",         code: x64.XADD::u32,    form: iasm.AF_OPS, writes: iasm.AW_OP0 | iasm.AW_OP1,   implicit: 0,             flags: X64P_TWO, words: 0 },
 
     # the two-operand move / ALU family writes its destination.
-    AsmMnemonic{ name: "mov",   opcode: x64.MOV,   form: AF_TWO, writes: AW_DST, flags: 0 },
-    AsmMnemonic{ name: "lea",   opcode: x64.LEA,   form: AF_TWO, writes: AW_DST, flags: 0 },
-    AsmMnemonic{ name: "add",   opcode: x64.ADD,   form: AF_TWO, writes: AW_DST, flags: 0 },
-    AsmMnemonic{ name: "sub",   opcode: x64.SUB,   form: AF_TWO, writes: AW_DST, flags: 0 },
-    AsmMnemonic{ name: "and",   opcode: x64.AND,   form: AF_TWO, writes: AW_DST, flags: 0 },
-    AsmMnemonic{ name: "or",    opcode: x64.OR,    form: AF_TWO, writes: AW_DST, flags: 0 },
-    AsmMnemonic{ name: "xor",   opcode: x64.XOR,   form: AF_TWO, writes: AW_DST, flags: 0 },
-    AsmMnemonic{ name: "shl",   opcode: x64.SHL,   form: AF_TWO, writes: AW_DST, flags: 0 },
-    AsmMnemonic{ name: "shr",   opcode: x64.SHR,   form: AF_TWO, writes: AW_DST, flags: 0 },
-    AsmMnemonic{ name: "sar",   opcode: x64.SAR,   form: AF_TWO, writes: AW_DST, flags: 0 },
-    AsmMnemonic{ name: "movzx", opcode: x64.MOVZX, form: AF_TWO, writes: AW_DST, flags: 0 },
-    AsmMnemonic{ name: "movsx", opcode: x64.MOVSX, form: AF_TWO, writes: AW_DST, flags: 0 },
+    iasm.Mnemonic{ name: "movzx", code: x64.MOVZX::u32, form: iasm.AF_OPS, writes: iasm.AW_OP0, implicit: 0, flags: X64P_TWO, words: 0 },
+    iasm.Mnemonic{ name: "movsx", code: x64.MOVSX::u32, form: iasm.AF_OPS, writes: iasm.AW_OP0, implicit: 0, flags: X64P_TWO, words: 0 },
+    iasm.Mnemonic{ name: "mov",   code: x64.MOV::u32,   form: iasm.AF_OPS, writes: iasm.AW_OP0, implicit: 0, flags: X64P_TWO, words: 0 },
+    iasm.Mnemonic{ name: "lea",   code: x64.LEA::u32,   form: iasm.AF_OPS, writes: iasm.AW_OP0, implicit: 0, flags: X64P_TWO, words: 0 },
+    iasm.Mnemonic{ name: "add",   code: x64.ADD::u32,   form: iasm.AF_OPS, writes: iasm.AW_OP0, implicit: 0, flags: X64P_TWO, words: 0 },
+    iasm.Mnemonic{ name: "sub",   code: x64.SUB::u32,   form: iasm.AF_OPS, writes: iasm.AW_OP0, implicit: 0, flags: X64P_TWO, words: 0 },
+    iasm.Mnemonic{ name: "and",   code: x64.AND::u32,   form: iasm.AF_OPS, writes: iasm.AW_OP0, implicit: 0, flags: X64P_TWO, words: 0 },
+    iasm.Mnemonic{ name: "or",    code: x64.OR::u32,    form: iasm.AF_OPS, writes: iasm.AW_OP0, implicit: 0, flags: X64P_TWO, words: 0 },
+    iasm.Mnemonic{ name: "xor",   code: x64.XOR::u32,   form: iasm.AF_OPS, writes: iasm.AW_OP0, implicit: 0, flags: X64P_TWO, words: 0 },
+    iasm.Mnemonic{ name: "shl",   code: x64.SHL::u32,   form: iasm.AF_OPS, writes: iasm.AW_OP0, implicit: 0, flags: X64P_TWO, words: 0 },
+    iasm.Mnemonic{ name: "shr",   code: x64.SHR::u32,   form: iasm.AF_OPS, writes: iasm.AW_OP0, implicit: 0, flags: X64P_TWO, words: 0 },
+    iasm.Mnemonic{ name: "sar",   code: x64.SAR::u32,   form: iasm.AF_OPS, writes: iasm.AW_OP0, implicit: 0, flags: X64P_TWO, words: 0 },
 
     # compare and test write only the flags; the plain exchange writes both sides.
-    AsmMnemonic{ name: "cmp",  opcode: x64.CMP,  form: AF_TWO, writes: AW_NONE,          flags: 0 },
-    AsmMnemonic{ name: "test", opcode: x64.TEST, form: AF_TWO, writes: AW_NONE,          flags: 0 },
-    AsmMnemonic{ name: "xchg", opcode: x64.XCHG, form: AF_TWO, writes: AW_DST | AW_SRC, flags: 0 },
+    iasm.Mnemonic{ name: "cmp",  code: x64.CMP::u32,  form: iasm.AF_OPS, writes: iasm.AW_NONE,               implicit: 0, flags: X64P_TWO, words: 0 },
+    iasm.Mnemonic{ name: "test", code: x64.TEST::u32, form: iasm.AF_OPS, writes: iasm.AW_NONE,               implicit: 0, flags: X64P_TWO, words: 0 },
+    iasm.Mnemonic{ name: "xchg", code: x64.XCHG::u32, form: iasm.AF_OPS, writes: iasm.AW_OP0 | iasm.AW_OP1,  implicit: 0, flags: X64P_TWO, words: 0 },
 
     # one-operand forms. `push` reads its operand and adjusts the reserved stack
     # pointer, so it writes no allocatable register; `pop` writes its destination.
-    AsmMnemonic{ name: "neg",  opcode: x64.NEG,  form: AF_ONE, writes: AW_DST,  flags: 0 },
-    AsmMnemonic{ name: "not",  opcode: x64.NOT,  form: AF_ONE, writes: AW_DST,  flags: 0 },
-    AsmMnemonic{ name: "inc",  opcode: x64.INC,  form: AF_ONE, writes: AW_DST,  flags: 0 },
-    AsmMnemonic{ name: "dec",  opcode: x64.DEC,  form: AF_ONE, writes: AW_DST,  flags: 0 },
-    AsmMnemonic{ name: "push", opcode: x64.PUSH, form: AF_ONE, writes: AW_NONE, flags: 0 },
-    AsmMnemonic{ name: "pop",  opcode: x64.POP,  form: AF_ONE, writes: AW_DST,  flags: 0 },
+    iasm.Mnemonic{ name: "neg",  code: x64.NEG::u32,  form: iasm.AF_OPS, writes: iasm.AW_OP0,  implicit: 0, flags: X64P_ONE, words: 0 },
+    iasm.Mnemonic{ name: "not",  code: x64.NOT::u32,  form: iasm.AF_OPS, writes: iasm.AW_OP0,  implicit: 0, flags: X64P_ONE, words: 0 },
+    iasm.Mnemonic{ name: "inc",  code: x64.INC::u32,  form: iasm.AF_OPS, writes: iasm.AW_OP0,  implicit: 0, flags: X64P_ONE, words: 0 },
+    iasm.Mnemonic{ name: "dec",  code: x64.DEC::u32,  form: iasm.AF_OPS, writes: iasm.AW_OP0,  implicit: 0, flags: X64P_ONE, words: 0 },
+    iasm.Mnemonic{ name: "push", code: x64.PUSH::u32, form: iasm.AF_OPS, writes: iasm.AW_NONE, implicit: 0, flags: X64P_ONE, words: 0 },
+    iasm.Mnemonic{ name: "pop",  code: x64.POP::u32,  form: iasm.AF_OPS, writes: iasm.AW_OP0,  implicit: 0, flags: X64P_ONE, words: 0 },
 
     # raw bytes are an instruction stream the parser cannot read, so the payload is
     # carried verbatim and its effects are worst-case.
-    AsmMnemonic{ name: ".byte", opcode: 0, form: AF_BYTES, writes: AW_NONE, flags: 0 },
+    iasm.Mnemonic{ name: ".byte", code: 0, form: iasm.AF_BYTES, writes: iasm.AW_NONE, implicit: 0, flags: X64P_NONE, words: 0 },
 };
 
-# the parse outcomes one inline-asm statement can have
-val AI_INST:   u8 = 0;  # a fully modeled machine instruction
-val AI_LABEL:  u8 = 1;  # a numeric local-label definition
-val AI_BYTES:  u8 = 2;  # a `.byte` directive's raw payload
-# a statement whose mnemonic is known but whose operands are not yet resolvable -
-# a `{name}` binding parsed before the frame is laid out. the instruction is not
-# modeled, so its effects fall back to everything the x86-64 inline grammar can
-# reach (the general-purpose bank; the grammar names no vector register)
-val AI_OPAQUE: u8 = 3;
-
-# what a parsed instruction still needs the encoder to resolve
-val AR_NONE:  u8 = 0;  # nothing: the instruction is self-contained
-val AR_SYM:   u8 = 1;  # a named symbol (a branch target or a rip-relative `[sym]`)
-val AR_LOCAL: u8 = 2;  # a numeric local label within this block
-
-# longest inline-asm statement the parser accepts, in bytes
-val ASM_STMT_MAX: usize = 256;
-
-# most raw bytes one `.byte` directive can carry
+# map a register name to its (id, size), or false when the token names no register
 #
-# Derived, not chosen: a value needs at least a digit and a separator, so a
-# statement bounded by `ASM_STMT_MAX` can never name more than half that many.
-val ASM_BYTES_MAX: usize = ASM_STMT_MAX / 2;
-
-# every general-purpose register the x86-64 inline-asm grammar can name
-val ASM_ALL_GP: u32 = 0xFFFF;
-# every vector register an unreadable instruction stream could reach
-val ASM_ALL_FP: u32 = 0xFFFF;
-
-# one parsed inline-asm statement
-#
-# The unit both consumers read: the encoder turns `inst` into bytes, the clobber
-# model turns `writes` plus `inst`'s operands into a register set. `src_off` /
-# `src_len` are the body bytes this item claims, which is what makes the parse's
-# totality checkable rather than assumed.
-# ---
-# kind:       one of AI_*
-# inst:       the modeled machine instruction (AI_INST)
-# writes:     the mnemonic's register-write facts (AW_* flag set)
-# ref:        what the encoder must still resolve (AR_*)
-# ref_off:    body offset of the referenced symbol name (AR_SYM)
-# ref_len:    length of that name
-# ref_num:    the numeric local label (AR_LOCAL, or the label AI_LABEL defines)
-# ref_fwd:    true when an AR_LOCAL reference is forward (`<digits>f`)
-# bytes:      the `.byte` payload (AI_BYTES)
-# byte_count: number of payload bytes
-# src_off:    body offset of the statement text this item claims
-# src_len:    length of that text
-rec AsmItem {
-    kind:       u8;
-    inst:       isa.Inst;
-    writes:     u8;
-    ref:        u8;
-    ref_off:    usize;
-    ref_len:    usize;
-    ref_num:    u64;
-    ref_fwd:    bool;
-    bytes:      [ASM_BYTES_MAX]u8;
-    byte_count: usize;
-    src_off:    usize;
-    src_len:    usize;
-}
-
-# a cursor over an inline-asm body, yielding one `AsmItem` per statement
-#
-# The single x86-64 inline-asm parser. `asm_clobbers` drives it before register
-# allocation to derive the block's clobber set, and `encode_asm_block` drives it
-# after frame layout to emit bytes, so the instructions the compiler reasons about
-# and the ones it emits are the same instructions.
-#
-# `f` / `pl` supply the `{name}` binding context. They are nil before the frame is
-# laid out, where a binding's stack displacement genuinely is not yet known: such a
-# statement parses to AI_OPAQUE rather than to a half-known instruction.
-#
-# `claimed` is the accounting watermark - the body offset through which every byte
-# has been claimed by exactly one item. Anything else must be inter-statement
-# whitespace or a separator, or the block is refused.
-# ---
-# body:     the comment-stripped inline-asm body text
-# len:      length of the body
-# pos:      cursor: the next body byte to consider
-# claimed:  accounting watermark; every byte below it is claimed or skippable
-# alloc:    allocator for diagnostic construction, or nil
-# interner: interner diagnostics are built in, or nil (messages degrade to a fixed
-#           form the encoder later reissues located)
-# f:        the function whose laid-out frame resolves a `{name}`, or nil
-# pl:       the block's `{name}` bindings, or nil
-rec AsmParser {
-    body:     str;
-    len:      usize;
-    pos:      usize;
-    claimed:  usize;
-    alloc:    *A.Allocator;
-    interner: *intern.Interner;
-    f:        *mir.MirFunction;
-    pl:       *mir.MirAsm;
-}
-
-# start a parse over `body`
-#
-# `f` and `pl` are the binding context: pass both to resolve `{name}` against a
-# laid-out frame, or nil to parse before the frame exists.
-# ---
-# p:        the parser to initialize
-# body:     the comment-stripped inline-asm body
-# alloc:    allocator for diagnostics, or nil
-# interner: interner for diagnostics, or nil
-# f:        function supplying the laid-out frame, or nil
-# pl:       the block's inline-asm payload carrying its bindings, or nil
-fun asm_parser_init(p: *AsmParser, body: str, alloc: *A.Allocator, interner: *intern.Interner,
-                    f: *mir.MirFunction, pl: *mir.MirAsm) {
-    p.body     = body;
-    p.len      = str_len(body);
-    p.pos      = 0;
-    p.claimed  = 0;
-    p.alloc    = alloc;
-    p.interner = interner;
-    p.f        = f;
-    p.pl       = pl;
-}
-
-# true for a byte that may lie between statements: ASCII whitespace, a newline, or
-# the `;` statement separator. every other byte must be claimed by an item
-fun is_asm_skip(c: char) bool {
-    ret is_asm_space(c) || c == '\n'::char || c == ';'::char;
-}
-
-# claim `body[off .. off+len)` for the item being parsed
-#
-# The accounting guard. It refuses a claim that overlaps an earlier one, and
-# refuses a gap of unclaimed bytes that are not inter-statement filler - so at the
-# end of a parse every byte of the body is claimed by exactly one item or is
-# whitespace. This is what makes "the parse is total" a checked property instead of
-# a hope.
-# ---
-# p:   the parser
-# off: body offset the claim starts at
-# len: number of bytes claimed
-# ret: ok(true), or the coverage error naming the offending text
-fun asm_claim(p: *AsmParser, off: usize, len: usize) R.Result[bool, str] {
-    if (off < p.claimed) { ret R.err[bool, str](asm_coverage_error(p, off, off + len)); }
-    var i: usize = p.claimed;
-    for (i < off) {
-        if (!is_asm_skip(p.body[i])) { ret R.err[bool, str](asm_coverage_error(p, p.claimed, off)); }
-        i = i + 1;
-    }
-    p.claimed = off + len;
-    ret R.ok[bool, str](true);
-}
-
-# the diagnostic for a body byte no parsed instruction claims
-fun asm_coverage_error(p: *AsmParser, lo: usize, hi: usize) str {
-    ret asm_span_message(p,
-        "encode: inline-asm instruction '", lo, hi,
-        "' does not account for every byte of its statement",
-        "encode: an inline-asm instruction does not account for every byte of its statement");
-}
-
-# build "<prefix><body[lo..hi)><suffix>", interned so it outlives the parse
-#
-# Degrades to `fallback` when the parse carries no interner - the clobber
-# derivation, whose caller reports nothing; the encoder re-parses the same body and
-# reissues the message with its source location.
-fun asm_span_message(p: *AsmParser, prefix: str, lo: usize, hi: usize, suffix: str, fallback: str) str {
-    if (p.interner == nil) { ret fallback; }
-    var buf: [ASM_STMT_MAX]u8;
-    if (!copy_trimmed(p.body, lo, hi, ?buf[0], ASM_STMT_MAX)) { ret fallback; }
-    ret named_message(p.alloc, p.interner, prefix, (?buf[0])::str, suffix, fallback);
-}
-
-# reset an item to the neutral state each parse fills in
-fun asm_item_reset(item: *AsmItem) {
-    item.kind       = AI_INST;
-    item.writes     = AW_NONE;
-    item.ref        = AR_NONE;
-    item.ref_off    = 0;
-    item.ref_len    = 0;
-    item.ref_num    = 0;
-    item.ref_fwd    = false;
-    item.byte_count = 0;
-    item.src_off    = 0;
-    item.src_len    = 0;
-    zero_inst(?item.inst);
-}
-
-# parse the next statement of the body into `item`
-#
-# Returns ok(true) with `item` filled, ok(false) at the end of the body (after
-# checking the trailing bytes are all skippable), or an error naming the
-# instruction that could not be parsed or accounted for.
-# ---
-# p:    the parser
-# item: receives the parsed statement
-# ret:  ok(true) on an item, ok(false) at end of body, or a refusal
-fun asm_parse_next(p: *AsmParser, item: *AsmItem) R.Result[bool, str] {
-    for (p.pos < p.len && is_asm_skip(p.body[p.pos])) { p.pos = p.pos + 1; }
-    if (p.pos >= p.len) { ret asm_parse_finish(p); }
-
-    val lo: usize = p.pos;
-    var end: usize = lo;
-    for (end < p.len && p.body[end] != '\n'::char && p.body[end] != ';'::char) { end = end + 1; }
-    var hi: usize = end;
-    for (hi > lo && is_asm_space(p.body[hi - 1])) { hi = hi - 1; }
-    if (hi - lo >= ASM_STMT_MAX) { ret R.err[bool, str]("encode: inline asm statement too long"); }
-
-    asm_item_reset(item);
-    item.src_off = lo;
-
-    val pr: R.Result[usize, str] = asm_parse_stmt(p, lo, hi, item);
-    if (R.is_err[usize, str](pr)) { ret R.err[bool, str](R.unwrap_err[usize, str](pr)); }
-    val consumed: usize = R.unwrap_ok[usize, str](pr);
-
-    # the statement is only parsed when every one of its bytes was claimed.
-    if (p.claimed != consumed) { ret R.err[bool, str](asm_coverage_error(p, lo, hi)); }
-
-    item.src_len = consumed - lo;
-    p.pos        = consumed;
-    ret R.ok[bool, str](true);
-}
-
-# end-of-body check: the bytes past the last claim must all be skippable
-fun asm_parse_finish(p: *AsmParser) R.Result[bool, str] {
-    var i: usize = p.claimed;
-    for (i < p.len) {
-        if (!is_asm_skip(p.body[i])) { ret R.err[bool, str](asm_coverage_error(p, i, p.len)); }
-        i = i + 1;
-    }
-    ret R.ok[bool, str](false);
-}
-
-# parse one statement `body[lo..hi)`, returning the offset it consumed through
-#
-# A numeric local-label definition is its own item and consumes only its
-# `<digits>:` prefix, so an instruction sharing the line is parsed by the next
-# call and claims its own bytes.
-fun asm_parse_stmt(p: *AsmParser, lo: usize, hi: usize, item: *AsmItem) R.Result[usize, str] {
-    var num: u64 = 0;
-    val dlen: usize = asm_label_def_span(p.body, lo, hi, ?num);
-    if (dlen > 0) {
-        val cr: R.Result[bool, str] = asm_claim(p, lo, dlen);
-        if (R.is_err[bool, str](cr)) { ret R.err[usize, str](R.unwrap_err[bool, str](cr)); }
-        item.kind    = AI_LABEL;
-        item.ref_num = num;
-        ret R.ok[usize, str](lo + dlen);
-    }
-
-    val mi: i32 = asm_mnemonic_lookup(p.body, lo, hi);
-    if (mi < 0) {
-        ret R.err[usize, str](asm_span_message(p,
-            "unknown x86_64 inline-asm instruction '", lo, hi, "'",
-            "unknown x86_64 inline-asm instruction"));
-    }
-    val m: *AsmMnemonic = ?ASM_MNEMONICS[mi];
-    val mlen: usize = str_len(m.name);
-    val cr: R.Result[bool, str] = asm_claim(p, lo, mlen);
-    if (R.is_err[bool, str](cr)) { ret R.err[usize, str](R.unwrap_err[bool, str](cr)); }
-
-    item.writes = m.writes;
-    if (m.form == AF_NONE)   { ret asm_parse_none(m, item, hi); }
-    if (m.form == AF_BRANCH) { ret asm_parse_branch(p, m, lo + mlen, hi, item); }
-    if (m.form == AF_ONE)    { ret asm_parse_one(p, m, lo + mlen, hi, item); }
-    if (m.form == AF_TWO)    { ret asm_parse_two(p, m, lo + mlen, hi, item); }
-    ret asm_parse_bytes(p, lo + mlen, hi, item);
-}
-
-# the index of the mnemonic table row `body[lo..hi)` names, or -1
-#
-# A zero-operand mnemonic matches the whole statement; every other form matches a
-# prefix followed by a space, so `mov` never shadows `movzx` and `cmp` never
-# shadows `cmpxchg`.
-fun asm_mnemonic_lookup(body: str, lo: usize, hi: usize) i32 {
-    var i: usize = 0;
-    for (i < ASM_MNEMONIC_COUNT) {
-        val m: *AsmMnemonic = ?ASM_MNEMONICS[i];
-        val mlen: usize = str_len(m.name);
-        if (m.form == AF_NONE) {
-            if (str_region_equals(body, lo, hi - lo, m.name)) { ret i::i32; }
-        } or {
-            if (lo + mlen < hi && str_region_equals(body, lo, mlen, m.name)
-                && body[lo + mlen] == ' '::char) { ret i::i32; }
-        }
-        i = i + 1;
-    }
-    ret -1;
-}
-
-# a zero-operand instruction: the mnemonic is the whole statement
-fun asm_parse_none(m: *AsmMnemonic, item: *AsmItem, hi: usize) R.Result[usize, str] {
-    item.kind        = AI_INST;
-    item.inst.opcode = m.opcode;
-    ret R.ok[usize, str](hi);
-}
-
-# a CALL / JMP / Jcc whose target is a numeric local label or a named symbol
-fun asm_parse_branch(p: *AsmParser, m: *AsmMnemonic, at: usize, hi: usize, item: *AsmItem) R.Result[usize, str] {
-    var a: usize = at;
-    for (a < hi && is_asm_space(p.body[a])) { a = a + 1; }
-    val cr: R.Result[bool, str] = asm_claim(p, a, hi - a);
-    if (R.is_err[bool, str](cr)) { ret R.err[usize, str](R.unwrap_err[bool, str](cr)); }
-
-    item.kind        = AI_INST;
-    item.inst.opcode = m.opcode;
-
-    var num: u64 = 0;
-    var fwd: bool = false;
-    if (asm_label_ref_span(p.body, a, hi, ?num, ?fwd)) {
-        item.ref     = AR_LOCAL;
-        item.ref_num = num;
-        item.ref_fwd = fwd;
-        ret R.ok[usize, str](hi);
-    }
-    # a bare symbol never starts with a digit, so a digit-led token that is not a
-    # `<digits>f` / `<digits>b` reference is a malformed local label, not a symbol.
-    if (is_asm_digit(p.body[a])) {
-        ret R.err[usize, str]("encode: inline-asm numeric local-label reference must be '<digits>f' or '<digits>b'");
-    }
-    if (!is_token_sym_region(p.body, a, hi)) {
-        ret R.err[usize, str]("encode: inline-asm branch target is not a symbol");
-    }
-    item.ref     = AR_SYM;
-    item.ref_off = a;
-    item.ref_len = hi - a;
-    ret R.ok[usize, str](hi);
-}
-
-# a single-operand instruction (neg / not / inc / dec / push / pop / setcc)
-fun asm_parse_one(p: *AsmParser, m: *AsmMnemonic, at: usize, hi: usize, item: *AsmItem) R.Result[usize, str] {
-    var op: AsmOperand;
-    val r: R.Result[bool, str] = asm_parse_operand(p, at, hi, "", ?op);
-    if (R.is_err[bool, str](r)) { ret R.err[usize, str](R.unwrap_err[bool, str](r)); }
-
-    if (op.kind == ASMOP_SYM || (op.kind == ASMOP_MEM && op.mem_sym)) {
-        ret R.err[usize, str]("encode: inline-asm one-operand symbol form unsupported");
-    }
-    if (op.kind == ASMOP_BIND) {
-        item.kind = AI_OPAQUE;
-        ret R.ok[usize, str](hi);
-    }
-
-    item.kind        = AI_INST;
-    item.inst.opcode = m.opcode;
-    item.inst.size   = op.size;
-    item.inst.flags  = width_flags_for(op.size) | m.flags;
-    item.inst.dst    = asm_to_isa(?op, op.size);
-    ret R.ok[usize, str](hi);
-}
-
-# a two-operand instruction `op dst, src`
-#
-# The operation width comes from whichever side is a register (a memory or
-# immediate operand inherits it); a `[symbol]` on either side becomes the
-# instruction's pending relocation.
-fun asm_parse_two(p: *AsmParser, m: *AsmMnemonic, at: usize, hi: usize, item: *AsmItem) R.Result[usize, str] {
-    var comma: usize = at;
-    var found: bool = false;
-    for (comma < hi && !found) {
-        if (p.body[comma] == ','::char) { found = true; } or { comma = comma + 1; }
-    }
-    if (!found) {
-        ret R.err[usize, str](asm_span_message(p,
-            "encode: malformed inline-asm two-operand instruction '", at, hi, "'",
-            "encode: malformed inline-asm two-operand instruction"));
-    }
-
-    var dst: AsmOperand;
-    val rd: R.Result[bool, str] = asm_parse_operand(p, at, comma, "destination ", ?dst);
-    if (R.is_err[bool, str](rd)) { ret R.err[usize, str](R.unwrap_err[bool, str](rd)); }
-    val rc: R.Result[bool, str] = asm_claim(p, comma, 1);
-    if (R.is_err[bool, str](rc)) { ret R.err[usize, str](R.unwrap_err[bool, str](rc)); }
-    var src: AsmOperand;
-    val rs: R.Result[bool, str] = asm_parse_operand(p, comma + 1, hi, "source ", ?src);
-    if (R.is_err[bool, str](rs)) { ret R.err[usize, str](R.unwrap_err[bool, str](rs)); }
-
-    if (dst.kind == ASMOP_SYM || src.kind == ASMOP_SYM) {
-        ret R.err[usize, str]("encode: inline-asm bare-symbol operand unsupported (use [symbol])");
-    }
-    if (dst.kind == ASMOP_BIND || src.kind == ASMOP_BIND) {
-        item.kind = AI_OPAQUE;
-        ret R.ok[usize, str](hi);
-    }
-
-    var size: u8 = 8;
-    if (dst.kind == ASMOP_REG) { size = dst.size; }
-    or (src.kind == ASMOP_REG) { size = src.size; }
-
-    item.kind        = AI_INST;
-    item.inst.opcode = m.opcode;
-    item.inst.size   = size;
-    item.inst.flags  = width_flags_for(size) | m.flags;
-    item.inst.dst    = asm_to_isa(?dst, size);
-    item.inst.src1   = asm_to_isa(?src, size);
-
-    if (dst.mem_sym) { item.ref = AR_SYM; item.ref_off = dst.name_off; item.ref_len = dst.name_len; }
-    or (src.mem_sym) { item.ref = AR_SYM; item.ref_off = src.name_off; item.ref_len = src.name_len; }
-    ret R.ok[usize, str](hi);
-}
-
-# a `.byte b, b, ...` directive: the payload is decoded once, here
-fun asm_parse_bytes(p: *AsmParser, at: usize, hi: usize, item: *AsmItem) R.Result[usize, str] {
-    item.kind = AI_BYTES;
-    var start: usize = at;
-    for (start < hi) {
-        var end: usize = start;
-        for (end < hi && p.body[end] != ','::char) { end = end + 1; }
-
-        var a: usize = start;
-        var b: usize = end;
-        for (a < b && is_asm_space(p.body[a])) { a = a + 1; }
-        for (b > a && is_asm_space(p.body[b - 1])) { b = b - 1; }
-        if (b <= a) { ret R.err[usize, str]("encode: malformed inline-asm .byte value"); }
-
-        val cv: R.Result[bool, str] = asm_claim(p, a, b - a);
-        if (R.is_err[bool, str](cv)) { ret R.err[usize, str](R.unwrap_err[bool, str](cv)); }
-
-        var buf: [24]u8;
-        if (!copy_trimmed(p.body, a, b, ?buf[0], 24)) { ret R.err[usize, str]("encode: malformed inline-asm .byte value"); }
-        val br: R.Result[i64, str] = parse.parse_i64_exact((?buf[0])::str, 0);
-        if (R.is_err[i64, str](br)) { ret R.err[usize, str]("encode: malformed inline-asm .byte value"); }
-        item.bytes[item.byte_count] = R.unwrap_ok[i64, str](br)::u8;
-        item.byte_count = item.byte_count + 1;
-
-        if (end < hi) {
-            val cc: R.Result[bool, str] = asm_claim(p, end, 1);
-            if (R.is_err[bool, str](cc)) { ret R.err[usize, str](R.unwrap_err[bool, str](cc)); }
-        }
-        start = end + 1;
-    }
-    ret R.ok[usize, str](hi);
-}
-
-# the GP / vector registers one parsed item writes
-#
-# The whole effect model. A modeled instruction writes exactly the registers its
-# mnemonic's facts name; an item the parser could not model writes worst-case. An
-# unreadable byte stream reaches every bank, while an unresolved statement is still
-# bounded by the general-purpose bank - the x86-64 inline grammar names no vector
-# register, so no mnemonic in the table can write one.
-# ---
-# item: the parsed statement
-# gp:   accumulated general-purpose write mask (index n -> bit n)
-# fp:   accumulated vector write mask (index n -> bit n)
-fun asm_item_clobbers(item: *AsmItem, gp: *u32, fp: *u32) {
-    if (item.kind == AI_LABEL) { ret; }
-    if (item.kind == AI_BYTES) {
-        @gp = @gp | ASM_ALL_GP;
-        @fp = @fp | ASM_ALL_FP;
-        ret;
-    }
-    if (item.kind == AI_OPAQUE) {
-        @gp = @gp | ASM_ALL_GP;
-        ret;
-    }
-    if ((item.writes & AW_SYSCALL) != 0) {
-        @gp = @gp | (1::u32 << x64.RAX::u32) | (1::u32 << x64.RCX::u32) | (1::u32 << x64.R11::u32);
-    }
-    if ((item.writes & AW_RAX) != 0) { @gp = @gp | (1::u32 << x64.RAX::u32); }
-    if ((item.writes & AW_DST) != 0) { asm_clobber_operand(?item.inst.dst, gp); }
-    if ((item.writes & AW_SRC) != 0) { asm_clobber_operand(?item.inst.src1, gp); }
-}
-
-# OR a written operand's register bit into `@gp`
-#
-# Only a register destination writes a register: a memory destination writes
-# memory and merely reads its base, and an immediate writes nothing.
-fun asm_clobber_operand(op: *isa.Operand, gp: *u32) {
-    if (op.kind == isa.OPK_REG && op.reg >= 0 && op.reg < 16) {
-        @gp = @gp | (1::u32 << op.reg::u32);
-    }
-}
-
-# initial capacity for the inline-asm numeric-label definition / fixup arrays
-val ASM_LABEL_INIT_CAP: u32 = 16;
-
-# a numeric local label's most recent definition within an asm block: the label
-# `number` and the `.text` offset its `N:` definition marks. a redefinition of the
-# same number updates `offset`, so a backward `Nb` reference always binds to the
-# nearest preceding definition
-# ---
-# number: the numeric label
-# offset: byte offset of the definition within `.text`
-rec AsmLabelDef {
-    number: u64;
-    offset: u32;
-}
-
-# a pending forward reference to a numeric local label: the branch's rel32 field is
-# at `patch_pos`, the byte after the branch is `next_ip`, and the target is the
-# nearest following definition of `number`. resolved when that definition is
-# reached; an entry still pending at the end of the block is an undefined-label
-# error
-# ---
-# patch_pos: byte offset of the rel32 field within `.text`
-# next_ip:   byte offset of the instruction after the branch within `.text`
-# number:    the referenced numeric label
-rec AsmLabelFixup {
-    patch_pos: u32;
-    next_ip:   u32;
-    number:    u64;
-}
-
-# per-asm-block numeric-local-label scope. `defs` tracks the nearest preceding
-# definition of each number for backward references; `fixups` holds forward
-# references awaiting their definition. both arrays are owned and freed when the
-# block finishes encoding
-# ---
-# alloc:       backing allocator
-# defs:        recorded label definitions (latest offset per number)
-# def_count:   number of definitions
-# def_cap:     capacity of `defs`
-# fixups:      pending forward references
-# fixup_count: number of pending forward references
-# fixup_cap:   capacity of `fixups`
-rec AsmLabelState {
-    alloc:       *A.Allocator;
-    defs:        *AsmLabelDef;
-    def_count:   u32;
-    def_cap:     u32;
-    fixups:      *AsmLabelFixup;
-    fixup_count: u32;
-    fixup_cap:   u32;
-}
-
-# initialize an empty numeric-local-label scope backed by `alloc`
-fun asm_labels_init(labels: *AsmLabelState, alloc: *A.Allocator) {
-    labels.alloc       = alloc;
-    labels.defs        = nil;
-    labels.def_count   = 0;
-    labels.def_cap     = 0;
-    labels.fixups      = nil;
-    labels.fixup_count = 0;
-    labels.fixup_cap   = 0;
-}
-
-# release a label scope's owned arrays
-fun asm_labels_dnit(labels: *AsmLabelState) {
-    if (labels.defs != nil && labels.def_cap > 0) {
-        A.deallocate[AsmLabelDef](labels.alloc, labels.defs, labels.def_cap::usize);
-        labels.defs      = nil;
-        labels.def_cap   = 0;
-        labels.def_count = 0;
-    }
-    if (labels.fixups != nil && labels.fixup_cap > 0) {
-        A.deallocate[AsmLabelFixup](labels.alloc, labels.fixups, labels.fixup_cap::usize);
-        labels.fixups      = nil;
-        labels.fixup_cap   = 0;
-        labels.fixup_count = 0;
-    }
-}
-
-# true for an ASCII decimal digit
-fun is_asm_digit(c: char) bool { ret c >= '0'::char && c <= '9'::char; }
-
-# if `body[lo..hi)` begins with a numeric local-label definition
-# `<digits>:`, return the byte length of that prefix (through the colon) and the
-# parsed number via `num_out`; otherwise return 0
-fun asm_label_def_span(body: str, lo: usize, hi: usize, num_out: *u64) usize {
-    if (lo >= hi)                { ret 0; }
-    if (!is_asm_digit(body[lo])) { ret 0; }
-    var i: usize = lo;
-    var n: u64 = 0;
-    for (i < hi && is_asm_digit(body[i])) {
-        n = n * 10 + (body[i]::u64 - '0'::u64);
-        i = i + 1;
-    }
-    if (i >= hi)                { ret 0; }
-    if (body[i] != ':'::char)   { ret 0; }
-    @num_out = n;
-    ret i + 1 - lo;
-}
-
-# true when `body[lo..hi)` is a numeric local-label reference
-# `<digits>f` / `<digits>b`, yielding its number and direction. false for any
-# other token shape (a non-digit lead, a non-digit body, or another suffix)
-fun asm_label_ref_span(body: str, lo: usize, hi: usize, num_out: *u64, fwd_out: *bool) bool {
-    if (hi < lo + 2)             { ret false; }
-    if (!is_asm_digit(body[lo])) { ret false; }
-    var n: u64 = 0;
-    var i: usize = lo;
-    for (i < hi - 1) {
-        if (!is_asm_digit(body[i])) { ret false; }
-        n = n * 10 + (body[i]::u64 - '0'::u64);
-        i = i + 1;
-    }
-    val suf: char = body[hi - 1];
-    if (suf == 'f'::char) { @fwd_out = true; }
-    or (suf == 'b'::char) { @fwd_out = false; }
-    or { ret false; }
-    @num_out = n;
-    ret true;
-}
-
-# record a definition of `number` at `.text` offset `off`,
-# patching every pending forward reference to it (this is their nearest following
-# definition) and updating the nearest-preceding-definition offset backward
-# references resolve against. a redefinition of the same number is allowed
-fun asm_label_record_def(labels: *AsmLabelState, buf: *enc.ByteBuf, number: u64, off: u32) R.Result[bool, str] {
-    # patch and drop every pending forward fixup for this number.
-    var w: u32 = 0;
-    var r: u32 = 0;
-    for (r < labels.fixup_count) {
-        if (labels.fixups[r].number == number) {
-            val disp: i32 = off::i32 - labels.fixups[r].next_ip::i32;
-            patch_rel32(buf, labels.fixups[r].patch_pos::usize, disp);
-        } or {
-            labels.fixups[w].patch_pos = labels.fixups[r].patch_pos;
-            labels.fixups[w].next_ip   = labels.fixups[r].next_ip;
-            labels.fixups[w].number    = labels.fixups[r].number;
-            w = w + 1;
-        }
-        r = r + 1;
-    }
-    labels.fixup_count = w;
-
-    # update (or insert) the nearest-preceding-definition offset.
-    var i: u32 = 0;
-    for (i < labels.def_count) {
-        if (labels.defs[i].number == number) {
-            labels.defs[i].offset = off;
-            ret R.ok[bool, str](true);
-        }
-        i = i + 1;
-    }
-    if (labels.def_count >= labels.def_cap) {
-        val gr: R.Result[bool, str] = grow_asm_label_defs(labels);
-        if (R.is_err[bool, str](gr)) { ret gr; }
-    }
-    labels.defs[labels.def_count].number = number;
-    labels.defs[labels.def_count].offset = off;
-    labels.def_count                     = labels.def_count + 1;
-    ret R.ok[bool, str](true);
-}
-
-# the nearest preceding definition offset of `number`, or
-# none when the number has not yet been defined in this block
-fun asm_label_lookup_def(labels: *AsmLabelState, number: u64) O.Option[u32] {
-    var i: u32 = 0;
-    for (i < labels.def_count) {
-        if (labels.defs[i].number == number) { ret O.some[u32](labels.defs[i].offset); }
-        i = i + 1;
-    }
-    ret O.none[u32]();
-}
-
-# record a pending forward reference to `number` whose rel32
-# field is at `patch_pos` (the byte after the branch is `next_ip`)
-fun asm_label_push_fixup(labels: *AsmLabelState, patch_pos: u32, next_ip: u32, number: u64) R.Result[bool, str] {
-    if (labels.fixup_count >= labels.fixup_cap) {
-        val gr: R.Result[bool, str] = grow_asm_label_fixups(labels);
-        if (R.is_err[bool, str](gr)) { ret gr; }
-    }
-    labels.fixups[labels.fixup_count].patch_pos = patch_pos;
-    labels.fixups[labels.fixup_count].next_ip   = next_ip;
-    labels.fixups[labels.fixup_count].number    = number;
-    labels.fixup_count = labels.fixup_count + 1;
-    ret R.ok[bool, str](true);
-}
-
-# grow the label-definition array (or allocate it on first use)
-fun grow_asm_label_defs(labels: *AsmLabelState) R.Result[bool, str] {
-    if (labels.defs == nil) {
-        val r: R.Result[*AsmLabelDef, str] = A.allocate[AsmLabelDef](labels.alloc, ASM_LABEL_INIT_CAP::usize);
-        if (R.is_err[*AsmLabelDef, str](r)) { ret R.err[bool, str](R.unwrap_err[*AsmLabelDef, str](r)); }
-        labels.defs    = R.unwrap_ok[*AsmLabelDef, str](r);
-        labels.def_cap = ASM_LABEL_INIT_CAP;
-        ret R.ok[bool, str](true);
-    }
-    val nc: u32 = labels.def_cap * 2;
-    val r: R.Result[*AsmLabelDef, str] = A.reallocate[AsmLabelDef](labels.alloc, labels.defs, labels.def_cap::usize, nc::usize);
-    if (R.is_err[*AsmLabelDef, str](r)) { ret R.err[bool, str](R.unwrap_err[*AsmLabelDef, str](r)); }
-    labels.defs    = R.unwrap_ok[*AsmLabelDef, str](r);
-    labels.def_cap = nc;
-    ret R.ok[bool, str](true);
-}
-
-# grow the label-fixup array (or allocate it on first use)
-fun grow_asm_label_fixups(labels: *AsmLabelState) R.Result[bool, str] {
-    if (labels.fixups == nil) {
-        val r: R.Result[*AsmLabelFixup, str] = A.allocate[AsmLabelFixup](labels.alloc, ASM_LABEL_INIT_CAP::usize);
-        if (R.is_err[*AsmLabelFixup, str](r)) { ret R.err[bool, str](R.unwrap_err[*AsmLabelFixup, str](r)); }
-        labels.fixups    = R.unwrap_ok[*AsmLabelFixup, str](r);
-        labels.fixup_cap = ASM_LABEL_INIT_CAP;
-        ret R.ok[bool, str](true);
-    }
-    val nc: u32 = labels.fixup_cap * 2;
-    val r: R.Result[*AsmLabelFixup, str] = A.reallocate[AsmLabelFixup](labels.alloc, labels.fixups, labels.fixup_cap::usize, nc::usize);
-    if (R.is_err[*AsmLabelFixup, str](r)) { ret R.err[bool, str](R.unwrap_err[*AsmLabelFixup, str](r)); }
-    labels.fixups    = R.unwrap_ok[*AsmLabelFixup, str](r);
-    labels.fixup_cap = nc;
-    ret R.ok[bool, str](true);
-}
-
-# write the decimal digits of `n` into `dst` (at least one digit) and
-# return the digit count; `dst` must hold at least 20 bytes
-fun u64_to_dec(n: u64, dst: *u8) usize {
-    if (n == 0) { dst[0] = '0'::u8; ret 1; }
-    var tmp: [20]u8;
-    var len: usize = 0;
-    var v: u64 = n;
-    for (v > 0) {
-        tmp[len] = (v % 10)::u8 + '0'::u8;
-        v        = v / 10;
-        len      = len + 1;
-    }
-    var k: usize = 0;
-    for (k < len) { dst[k] = tmp[len - 1 - k]; k = k + 1; }
-    ret len;
-}
-
-# build an interned encode error naming the numeric local label
-# `number`, e.g. "<prefix>1<suffix>"; falls back to `fallback` when interning fails
-fun asm_label_error(st: *enc.EncodeState, prefix: str, number: u64, suffix: str, fallback: str) str {
-    var buf: [24]u8;
-    val len: usize = u64_to_dec(number, ?buf[0]);
-    buf[len] = 0;
-    ret enc_named_message(st, prefix, (?buf[0])::str, suffix, fallback);
-}
-
-# expand an inline-asm MIR_ASM instruction into machine bytes
-#
-# Parses the body into the same `isa.Inst` stream the rest of the back end emits
-# and encodes each instruction through `encode_inst`, so an inline-asm instruction
-# and a compiler-selected one are the same value taking the same path. `{name}`
-# references resolve against the laid-out frame during the parse; a `call` / `jmp`
-# or `[symbol]` operand records a PC32 relocation against the named symbol. An
-# unknown mnemonic, a malformed operand, or a statement byte no instruction claims
-# is a hard error located at the asm statement's "path:line:col" (#2153).
-fun encode_asm_block(st: *enc.EncodeState, f: *mir.MirFunction, fn_base: u32, mi: *mir.MirInstr) R.Result[bool, str] {
-    if (mi.asm_block == nil) { ret R.err[bool, str]("encode: MIR_ASM has no payload"); }
-    val pl: *mir.MirAsm = mi.asm_block;
-
-    # only the x86_64 ISA tag is encodable here; a mismatched tag means a
-    # comptime arch guard failed to select the right block.
-    if (!str_equals(pl.isa, "x86_64")) {
-        ret R.err[bool, str](enc.asm_located_message(st, mi.loc, "encode: inline-asm block is not x86_64"));
-    }
-
-    # numeric local labels are scoped to this block; their definitions and
-    # references resolve within it before the block finishes encoding.
-    var labels: AsmLabelState;
-    asm_labels_init(?labels, st.alloc);
-
-    var p: AsmParser;
-    asm_parser_init(?p, pl.body, st.alloc, st.interner, f, pl);
-
-    var item: AsmItem;
-    var done: bool = false;
-    var fail: str = nil;
-    for (!done && fail == nil) {
-        val pr: R.Result[bool, str] = asm_parse_next(?p, ?item);
-        if (R.is_err[bool, str](pr))     { fail = R.unwrap_err[bool, str](pr); }
-        or (!R.unwrap_ok[bool, str](pr)) { done = true; }
-        or {
-            val er: R.Result[bool, str] = asm_emit_item(st, ?p, ?labels, ?item);
-            if (R.is_err[bool, str](er)) { fail = R.unwrap_err[bool, str](er); }
-        }
-    }
-
-    # a forward reference whose label was never defined in the block is a hard
-    # error, not a silently zero-displacement branch.
-    if (fail == nil && labels.fixup_count > 0) {
-        fail = asm_label_error(st,
-            "encode: inline-asm forward reference to local label '", labels.fixups[0].number,
-            "f' has no definition in this asm block",
-            "encode: inline-asm forward reference to a local label has no definition in this asm block");
-    }
-    asm_labels_dnit(?labels);
-    if (fail != nil) { ret R.err[bool, str](enc.asm_located_message(st, mi.loc, fail)); }
-    ret R.ok[bool, str](true);
-}
-
-# emit one parsed inline-asm item
-#
-# A label definition records the current offset (resolving pending forward
-# references to it), a `.byte` payload is written verbatim, and an instruction
-# goes through `encode_inst` and then takes its pending relocation or local-label
-# fixup.
-# ---
-# st:     the shared encode state
-# p:      the parser the item came from; supplies the body a symbol name spans
-# labels: the block's numeric-local-label scope
-# item:   the item to emit
-# ret:    ok(true), or the encode error
-fun asm_emit_item(st: *enc.EncodeState, p: *AsmParser, labels: *AsmLabelState, item: *AsmItem) R.Result[bool, str] {
-    if (item.kind == AI_LABEL) {
-        ret asm_label_record_def(labels, ?st.buf, item.ref_num, st.buf.len::u32);
-    }
-    if (item.kind == AI_BYTES) {
-        var i: usize = 0;
-        for (i < item.byte_count) {
-            enc.emit_byte(?st.buf, item.bytes[i]);
-            i = i + 1;
-        }
-        ret R.ok[bool, str](true);
-    }
-    # the encoder always parses with a binding context, so every `{name}` either
-    # resolved or failed the parse; an unresolved statement here is a parser bug.
-    if (item.kind == AI_OPAQUE) {
-        ret R.err[bool, str]("internal compiler error: inline-asm statement reached the encoder unresolved");
-    }
-
-    val inst_start: usize = st.buf.len;
-    val n: i32 = encode_inst(?item.inst, ?st.buf);
-    if (n <= 0) { ret R.err[bool, str]("encode: inline-asm instruction encoded to no bytes"); }
-
-    if (item.ref == AR_LOCAL) { ret asm_emit_local_ref(st, labels, item, inst_start, n); }
-    if (item.ref == AR_SYM)   { ret asm_emit_sym_ref(st, p, item, inst_start, n); }
-    ret R.ok[bool, str](true);
-}
-
-# resolve a branch to a numeric local label
-#
-# A forward reference is recorded as a fixup patched when its definition is
-# reached; a backward one is patched immediately against the label's nearest
-# preceding definition, and an undefined one is a hard error.
-fun asm_emit_local_ref(st: *enc.EncodeState, labels: *AsmLabelState, item: *AsmItem,
-                       inst_start: usize, n: i32) R.Result[bool, str] {
-    val patch_pos: u32 = (inst_start + (n - 4)::usize)::u32;
-    val next_ip:   u32 = (inst_start + n::usize)::u32;
-    if (item.ref_fwd) { ret asm_label_push_fixup(labels, patch_pos, next_ip, item.ref_num); }
-
-    val def: O.Option[u32] = asm_label_lookup_def(labels, item.ref_num);
-    if (!O.is_some[u32](def)) {
-        ret R.err[bool, str](asm_label_error(st,
-            "encode: inline-asm backward reference to local label '", item.ref_num,
-            "b' has no preceding definition in this asm block",
-            "encode: inline-asm backward reference to a local label has no preceding definition in this asm block"));
-    }
-    patch_rel32(?st.buf, patch_pos::usize, O.unwrap[u32](def)::i32 - next_ip::i32);
-    ret R.ok[bool, str](true);
-}
-
-# record the PC32 relocation a symbol-referencing instruction needs
-#
-# The patch site comes from the same `x86_reloc_offset` query the compiler-emitted
-# instructions use: a direct branch relocates its trailing rel32, a rip-relative
-# `[symbol]` its ModR/M disp32 (stepping back over a trailing store immediate).
-fun asm_emit_sym_ref(st: *enc.EncodeState, p: *AsmParser, item: *AsmItem,
-                     inst_start: usize, n: i32) R.Result[bool, str] {
-    val patch: i32 = x86_reloc_offset(nil, ?item.inst, n);
-    if (patch < 0) {
-        ret R.err[bool, str]("internal compiler error: inline-asm symbol reference has no relocation field");
-    }
-    val name: str = (p.body::usize + item.ref_off)::str;
-    val symr: R.Result[intern.StrId, str] = intern.intern_bytes(st.interner, name, item.ref_len);
-    if (R.is_err[intern.StrId, str](symr)) { ret R.err[bool, str](R.unwrap_err[intern.StrId, str](symr)); }
-    val sym: intern.StrId = R.unwrap_ok[intern.StrId, str](symr);
-
-    # PC32: S + A - P, where the addend corrects the patch site to the next ip.
-    ret enc.push_reloc(st, (inst_start + patch::usize)::u32, of.RK_PC32, sym, -(n - patch));
-}
-
-# true when the interned binding name equals the `name_len` bytes
-# of `body` starting at `start`. resolves the StrId to its text and compares
-# byte-for-byte (requiring an exact-length match)
-fun bind_name_eq(interner: *intern.Interner, name: intern.StrId, body: str, start: usize, name_len: usize) bool {
-    val nopt: O.Option[str] = intern.lookup(interner, name);
-    if (!O.is_some[str](nopt)) { ret false; }
-    ret str_region_equals(body, start, name_len, O.unwrap[str](nopt));
-}
-
-# true for ASCII whitespace the asm tokenizer trims
-fun is_asm_space(c: char) bool {
-    ret c == ' '::char || c == '\t'::char || c == '\r'::char;
-}
-
-# map a register name to its (id, size), leaving `op` untouched when
-# the token names no register. covers the 64/32/16/8-bit general-purpose register
-# names the x86-64 inline-asm grammar accepts
-fun parse_asm_reg(name: str, op: *AsmOperand) bool {
-    asm_operand_reset(op);
-    op.kind = ASMOP_REG;
+# Covers the 64/32/16/8-bit general-purpose register names the x86-64 inline-asm
+# grammar accepts. It names no vector register, which is why an unresolved statement's
+# effects stay bounded by the general-purpose bank.
+fun x64_reg(name: str, op: *iasm.Operand) bool {
     # 64-bit
-    if (str_equals(name, "rax")) { op.reg = x64.RAX; op.size = 8; ret true; }
-    if (str_equals(name, "rbx")) { op.reg = x64.RBX; op.size = 8; ret true; }
-    if (str_equals(name, "rcx")) { op.reg = x64.RCX; op.size = 8; ret true; }
-    if (str_equals(name, "rdx")) { op.reg = x64.RDX; op.size = 8; ret true; }
-    if (str_equals(name, "rsi")) { op.reg = x64.RSI; op.size = 8; ret true; }
-    if (str_equals(name, "rdi")) { op.reg = x64.RDI; op.size = 8; ret true; }
-    if (str_equals(name, "rbp")) { op.reg = x64.RBP; op.size = 8; ret true; }
-    if (str_equals(name, "rsp")) { op.reg = x64.RSP; op.size = 8; ret true; }
-    if (str_equals(name, "r8"))  { op.reg = x64.R8;  op.size = 8; ret true; }
-    if (str_equals(name, "r9"))  { op.reg = x64.R9;  op.size = 8; ret true; }
-    if (str_equals(name, "r10")) { op.reg = x64.R10; op.size = 8; ret true; }
-    if (str_equals(name, "r11")) { op.reg = x64.R11; op.size = 8; ret true; }
-    if (str_equals(name, "r12")) { op.reg = x64.R12; op.size = 8; ret true; }
-    if (str_equals(name, "r13")) { op.reg = x64.R13; op.size = 8; ret true; }
-    if (str_equals(name, "r14")) { op.reg = x64.R14; op.size = 8; ret true; }
-    if (str_equals(name, "r15")) { op.reg = x64.R15; op.size = 8; ret true; }
+    if (str_equals(name, "rax")) { @op = iasm.op_reg(x64.RAX, 8); ret true; }
+    if (str_equals(name, "rbx")) { @op = iasm.op_reg(x64.RBX, 8); ret true; }
+    if (str_equals(name, "rcx")) { @op = iasm.op_reg(x64.RCX, 8); ret true; }
+    if (str_equals(name, "rdx")) { @op = iasm.op_reg(x64.RDX, 8); ret true; }
+    if (str_equals(name, "rsi")) { @op = iasm.op_reg(x64.RSI, 8); ret true; }
+    if (str_equals(name, "rdi")) { @op = iasm.op_reg(x64.RDI, 8); ret true; }
+    if (str_equals(name, "rbp")) { @op = iasm.op_reg(x64.RBP, 8); ret true; }
+    if (str_equals(name, "rsp")) { @op = iasm.op_reg(x64.RSP, 8); ret true; }
+    if (str_equals(name, "r8"))  { @op = iasm.op_reg(x64.R8,  8); ret true; }
+    if (str_equals(name, "r9"))  { @op = iasm.op_reg(x64.R9,  8); ret true; }
+    if (str_equals(name, "r10")) { @op = iasm.op_reg(x64.R10, 8); ret true; }
+    if (str_equals(name, "r11")) { @op = iasm.op_reg(x64.R11, 8); ret true; }
+    if (str_equals(name, "r12")) { @op = iasm.op_reg(x64.R12, 8); ret true; }
+    if (str_equals(name, "r13")) { @op = iasm.op_reg(x64.R13, 8); ret true; }
+    if (str_equals(name, "r14")) { @op = iasm.op_reg(x64.R14, 8); ret true; }
+    if (str_equals(name, "r15")) { @op = iasm.op_reg(x64.R15, 8); ret true; }
     # 32-bit
-    if (str_equals(name, "eax"))  { op.reg = x64.RAX; op.size = 4; ret true; }
-    if (str_equals(name, "ebx"))  { op.reg = x64.RBX; op.size = 4; ret true; }
-    if (str_equals(name, "ecx"))  { op.reg = x64.RCX; op.size = 4; ret true; }
-    if (str_equals(name, "edx"))  { op.reg = x64.RDX; op.size = 4; ret true; }
-    if (str_equals(name, "esi"))  { op.reg = x64.RSI; op.size = 4; ret true; }
-    if (str_equals(name, "edi"))  { op.reg = x64.RDI; op.size = 4; ret true; }
-    if (str_equals(name, "ebp"))  { op.reg = x64.RBP; op.size = 4; ret true; }
-    if (str_equals(name, "esp"))  { op.reg = x64.RSP; op.size = 4; ret true; }
-    if (str_equals(name, "r8d"))  { op.reg = x64.R8;  op.size = 4; ret true; }
-    if (str_equals(name, "r9d"))  { op.reg = x64.R9;  op.size = 4; ret true; }
-    if (str_equals(name, "r10d")) { op.reg = x64.R10; op.size = 4; ret true; }
-    if (str_equals(name, "r11d")) { op.reg = x64.R11; op.size = 4; ret true; }
-    if (str_equals(name, "r12d")) { op.reg = x64.R12; op.size = 4; ret true; }
-    if (str_equals(name, "r13d")) { op.reg = x64.R13; op.size = 4; ret true; }
-    if (str_equals(name, "r14d")) { op.reg = x64.R14; op.size = 4; ret true; }
-    if (str_equals(name, "r15d")) { op.reg = x64.R15; op.size = 4; ret true; }
+    if (str_equals(name, "eax"))  { @op = iasm.op_reg(x64.RAX, 4); ret true; }
+    if (str_equals(name, "ebx"))  { @op = iasm.op_reg(x64.RBX, 4); ret true; }
+    if (str_equals(name, "ecx"))  { @op = iasm.op_reg(x64.RCX, 4); ret true; }
+    if (str_equals(name, "edx"))  { @op = iasm.op_reg(x64.RDX, 4); ret true; }
+    if (str_equals(name, "esi"))  { @op = iasm.op_reg(x64.RSI, 4); ret true; }
+    if (str_equals(name, "edi"))  { @op = iasm.op_reg(x64.RDI, 4); ret true; }
+    if (str_equals(name, "ebp"))  { @op = iasm.op_reg(x64.RBP, 4); ret true; }
+    if (str_equals(name, "esp"))  { @op = iasm.op_reg(x64.RSP, 4); ret true; }
+    if (str_equals(name, "r8d"))  { @op = iasm.op_reg(x64.R8,  4); ret true; }
+    if (str_equals(name, "r9d"))  { @op = iasm.op_reg(x64.R9,  4); ret true; }
+    if (str_equals(name, "r10d")) { @op = iasm.op_reg(x64.R10, 4); ret true; }
+    if (str_equals(name, "r11d")) { @op = iasm.op_reg(x64.R11, 4); ret true; }
+    if (str_equals(name, "r12d")) { @op = iasm.op_reg(x64.R12, 4); ret true; }
+    if (str_equals(name, "r13d")) { @op = iasm.op_reg(x64.R13, 4); ret true; }
+    if (str_equals(name, "r14d")) { @op = iasm.op_reg(x64.R14, 4); ret true; }
+    if (str_equals(name, "r15d")) { @op = iasm.op_reg(x64.R15, 4); ret true; }
     # 16-bit
-    if (str_equals(name, "ax")) { op.reg = x64.RAX; op.size = 2; ret true; }
-    if (str_equals(name, "bx")) { op.reg = x64.RBX; op.size = 2; ret true; }
-    if (str_equals(name, "cx")) { op.reg = x64.RCX; op.size = 2; ret true; }
-    if (str_equals(name, "dx")) { op.reg = x64.RDX; op.size = 2; ret true; }
-    if (str_equals(name, "si")) { op.reg = x64.RSI; op.size = 2; ret true; }
-    if (str_equals(name, "di")) { op.reg = x64.RDI; op.size = 2; ret true; }
-    if (str_equals(name, "bp")) { op.reg = x64.RBP; op.size = 2; ret true; }
-    if (str_equals(name, "sp")) { op.reg = x64.RSP; op.size = 2; ret true; }
+    if (str_equals(name, "ax")) { @op = iasm.op_reg(x64.RAX, 2); ret true; }
+    if (str_equals(name, "bx")) { @op = iasm.op_reg(x64.RBX, 2); ret true; }
+    if (str_equals(name, "cx")) { @op = iasm.op_reg(x64.RCX, 2); ret true; }
+    if (str_equals(name, "dx")) { @op = iasm.op_reg(x64.RDX, 2); ret true; }
+    if (str_equals(name, "si")) { @op = iasm.op_reg(x64.RSI, 2); ret true; }
+    if (str_equals(name, "di")) { @op = iasm.op_reg(x64.RDI, 2); ret true; }
+    if (str_equals(name, "bp")) { @op = iasm.op_reg(x64.RBP, 2); ret true; }
+    if (str_equals(name, "sp")) { @op = iasm.op_reg(x64.RSP, 2); ret true; }
     # 8-bit low
-    if (str_equals(name, "al"))   { op.reg = x64.RAX; op.size = 1; ret true; }
-    if (str_equals(name, "bl"))   { op.reg = x64.RBX; op.size = 1; ret true; }
-    if (str_equals(name, "cl"))   { op.reg = x64.RCX; op.size = 1; ret true; }
-    if (str_equals(name, "dl"))   { op.reg = x64.RDX; op.size = 1; ret true; }
-    if (str_equals(name, "sil"))  { op.reg = x64.RSI; op.size = 1; ret true; }
-    if (str_equals(name, "dil"))  { op.reg = x64.RDI; op.size = 1; ret true; }
-    if (str_equals(name, "bpl"))  { op.reg = x64.RBP; op.size = 1; ret true; }
-    if (str_equals(name, "spl"))  { op.reg = x64.RSP; op.size = 1; ret true; }
-    if (str_equals(name, "r8b"))  { op.reg = x64.R8;  op.size = 1; ret true; }
-    if (str_equals(name, "r9b"))  { op.reg = x64.R9;  op.size = 1; ret true; }
-    if (str_equals(name, "r10b")) { op.reg = x64.R10; op.size = 1; ret true; }
-    if (str_equals(name, "r11b")) { op.reg = x64.R11; op.size = 1; ret true; }
-    if (str_equals(name, "r12b")) { op.reg = x64.R12; op.size = 1; ret true; }
-    if (str_equals(name, "r13b")) { op.reg = x64.R13; op.size = 1; ret true; }
-    if (str_equals(name, "r14b")) { op.reg = x64.R14; op.size = 1; ret true; }
-    if (str_equals(name, "r15b")) { op.reg = x64.R15; op.size = 1; ret true; }
+    if (str_equals(name, "al"))   { @op = iasm.op_reg(x64.RAX, 1); ret true; }
+    if (str_equals(name, "bl"))   { @op = iasm.op_reg(x64.RBX, 1); ret true; }
+    if (str_equals(name, "cl"))   { @op = iasm.op_reg(x64.RCX, 1); ret true; }
+    if (str_equals(name, "dl"))   { @op = iasm.op_reg(x64.RDX, 1); ret true; }
+    if (str_equals(name, "sil"))  { @op = iasm.op_reg(x64.RSI, 1); ret true; }
+    if (str_equals(name, "dil"))  { @op = iasm.op_reg(x64.RDI, 1); ret true; }
+    if (str_equals(name, "bpl"))  { @op = iasm.op_reg(x64.RBP, 1); ret true; }
+    if (str_equals(name, "spl"))  { @op = iasm.op_reg(x64.RSP, 1); ret true; }
+    if (str_equals(name, "r8b"))  { @op = iasm.op_reg(x64.R8,  1); ret true; }
+    if (str_equals(name, "r9b"))  { @op = iasm.op_reg(x64.R9,  1); ret true; }
+    if (str_equals(name, "r10b")) { @op = iasm.op_reg(x64.R10, 1); ret true; }
+    if (str_equals(name, "r11b")) { @op = iasm.op_reg(x64.R11, 1); ret true; }
+    if (str_equals(name, "r12b")) { @op = iasm.op_reg(x64.R12, 1); ret true; }
+    if (str_equals(name, "r13b")) { @op = iasm.op_reg(x64.R13, 1); ret true; }
+    if (str_equals(name, "r14b")) { @op = iasm.op_reg(x64.R14, 1); ret true; }
+    if (str_equals(name, "r15b")) { @op = iasm.op_reg(x64.R15, 1); ret true; }
     ret false;
 }
 
-# true for a character allowed in a bare symbol / label name
-# (alphanumeric, underscore, or '.'); the leading char must not be a digit
-fun is_sym_char(c: char) bool {
-    ret c == '_'::char || c == '.'::char ||
-        (c >= 'a'::char && c <= 'z'::char) ||
-        (c >= 'A'::char && c <= 'Z'::char) ||
-        (c >= '0'::char && c <= '9'::char);
-}
-
-# parse one operand from `body[lo..hi)` and claim its bytes
+# parse one x86-64 operand token into `op`
 #
-# Recognizes a register, a `[base + index*scale + disp]` / `[symbol]` memory
-# reference, an immediate, a `{name}` local binding, or a bare symbol name. `role`
-# prefixes the diagnostic for a binding misused as a memory base ("destination " /
-# "source " / "" for a single-operand form).
-# ---
-# p:    the parser
-# lo:   body offset the operand text starts at (leading whitespace allowed)
-# hi:   body offset the operand text ends at (trailing whitespace allowed)
-# role: diagnostic prefix naming which operand this is
-# op:   receives the parsed operand
-# ret:  ok(true), or the refusal naming the malformed operand
-fun asm_parse_operand(p: *AsmParser, lo: usize, hi: usize, role: str, op: *AsmOperand) R.Result[bool, str] {
-    var a: usize = lo;
-    var b: usize = hi;
-    for (a < b && is_asm_space(p.body[a])) { a = a + 1; }
-    for (b > a && is_asm_space(p.body[b - 1])) { b = b - 1; }
-    if (b <= a) { ret R.err[bool, str]("encode: malformed inline-asm operand"); }
+# A register, a `[base + index*scale + disp]` / `[symbol]` memory reference, an
+# immediate, a `{name}` local binding, or a bare symbol name.
+fun x64_operand(c: *iasm.Cursor, lo: usize, hi: usize, role: str, op: *iasm.Operand) R.Result[bool, str] {
+    @op = iasm.op_none();
+    if (hi <= lo) { ret R.err[bool, str]("encode: malformed inline-asm operand"); }
 
-    val cr: R.Result[bool, str] = asm_claim(p, a, b - a);
-    if (R.is_err[bool, str](cr)) { ret cr; }
-
-    asm_operand_reset(op);
-    val len: usize = b - a;
-
-    # a `{name}` local binding: resolved against the laid-out frame when there is
-    # one, else left unresolved for the caller to treat as opaque.
-    if (p.body[a] == '{'::char) { ret asm_parse_bind(p, a, b, op); }
-
-    var buf: [128]u8;
-    if (!copy_trimmed(p.body, a, b, ?buf[0], 128)) { ret R.err[bool, str]("encode: malformed inline-asm operand"); }
-    val tok: str = (?buf[0])::str;
-
-    if (parse_asm_reg(tok, op)) { ret R.ok[bool, str](true); }
-
-    if (len >= 3 && p.body[a] == '['::char && p.body[b - 1] == ']'::char) {
-        ret asm_parse_mem(p, a, b, role, op);
-    }
-
-    val ir: R.Result[i64, str] = parse.parse_i64_exact(tok, 0);
-    if (R.is_ok[i64, str](ir)) {
-        op.kind = ASMOP_IMM;
-        op.size = 8;
-        op.imm  = R.unwrap_ok[i64, str](ir);
+    # a `{name}` local binding: resolved against the laid-out frame when there is one,
+    # else left unresolved for the caller to treat as opaque.
+    if (c.body[lo] == '{'::char) {
+        var off: i64 = 0;
+        val br: R.Result[bool, str] = iasm.bind_offset(c, lo, hi, ?off);
+        if (R.is_err[bool, str](br)) { ret br; }
+        if (R.unwrap_ok[bool, str](br)) {
+            @op = iasm.op_mem(x64.RBP, off, -1, 0, 8);
+            ret R.ok[bool, str](true);
+        }
+        op.kind     = iasm.AOP_BIND;
+        op.size     = 8;
+        op.name_off = lo + 1;
+        op.name_len = hi - lo - 2;
         ret R.ok[bool, str](true);
     }
 
-    if (is_token_sym_region(p.body, a, b)) {
-        op.kind     = ASMOP_SYM;
-        op.size     = 8;
-        op.name_off = a;
-        op.name_len = len;
+    var buf: [128]u8;
+    if (!iasm.copy_region(c.body, lo, hi, ?buf[0], 128)) { ret R.err[bool, str]("encode: malformed inline-asm operand"); }
+    val tok: str = (?buf[0])::str;
+
+    if (x64_reg(tok, op)) { ret R.ok[bool, str](true); }
+
+    if (hi - lo >= 3 && c.body[lo] == '['::char && c.body[hi - 1] == ']'::char) {
+        ret x64_mem(c, lo, hi, role, op);
+    }
+
+    val iv: O.Option[i64] = iasm.region_i64(c.body, lo, hi);
+    if (O.is_some[i64](iv)) { @op = iasm.op_imm(O.unwrap[i64](iv), 8); ret R.ok[bool, str](true); }
+
+    if (iasm.is_sym_region(c.body, lo, hi)) {
+        @op = iasm.op_sym(lo, hi - lo, isa.SYM_MOD_NONE, 8);
         ret R.ok[bool, str](true);
     }
     ret R.err[bool, str]("encode: malformed inline-asm operand");
-}
-
-# clear an operand to the neutral state each parse fills in
-fun asm_operand_reset(op: *AsmOperand) {
-    op.kind     = ASMOP_NONE;
-    op.reg      = -1;
-    op.size     = 8;
-    op.imm      = 0;
-    op.index    = -1;
-    op.scale    = 0;
-    op.name_off = 0;
-    op.name_len = 0;
-    op.mem_sym  = false;
-}
-
-# parse a `{name}` local reference spanning `body[lo..hi)`
-#
-# With a binding context the reference resolves to the `[rbp + offset]` memory
-# operand its stack slot denotes. Without one - before the frame is laid out - the
-# displacement genuinely is unknown, so the operand stays ASMOP_BIND and its
-# statement is not modeled.
-fun asm_parse_bind(p: *AsmParser, lo: usize, hi: usize, op: *AsmOperand) R.Result[bool, str] {
-    var close: usize = lo;
-    var found: bool = false;
-    for (close < hi && !found) {
-        if (p.body[close] == '}'::char) { found = true; } or { close = close + 1; }
-    }
-    if (!found)          { ret R.err[bool, str]("encode: unterminated '{' in inline asm body"); }
-    if (close != hi - 1) { ret R.err[bool, str]("encode: malformed inline-asm operand"); }
-
-    val name_off: usize = lo + 1;
-    val name_len: usize = close - name_off;
-    if (name_len == 0) { ret R.err[bool, str]("encode: unknown local in inline asm '{name}' reference"); }
-
-    op.kind     = ASMOP_BIND;
-    op.size     = 8;
-    op.name_off = name_off;
-    op.name_len = name_len;
-    if (p.pl == nil || p.f == nil) { ret R.ok[bool, str](true); }
-
-    var i: u32 = 0;
-    for (i < p.pl.bind_count) {
-        if (bind_name_eq(p.interner, p.pl.binds[i].name, p.body, name_off, name_len)) {
-            val so: O.Option[i64] = frame_slot_offset(p.f, p.pl.binds[i].slot_vreg);
-            if (!O.is_some[i64](so)) { ret R.err[bool, str]("encode: inline-asm '{name}' local has no frame slot"); }
-            op.kind = ASMOP_MEM;
-            op.reg  = x64.RBP;
-            op.imm  = O.unwrap[i64](so);
-            ret R.ok[bool, str](true);
-        }
-        i = i + 1;
-    }
-    ret R.err[bool, str]("encode: unknown local in inline asm '{name}' reference");
-}
-
-# true when `tok[lo..hi)` is a valid bare symbol name
-# (leading char a letter / underscore, the rest symbol characters)
-fun is_token_sym_region(tok: str, lo: usize, hi: usize) bool {
-    if (hi <= lo) { ret false; }
-    val c0: char = tok[lo];
-    if (!(c0 == '_'::char || (c0 >= 'a'::char && c0 <= 'z'::char) || (c0 >= 'A'::char && c0 <= 'Z'::char))) {
-        ret false;
-    }
-    var s: usize = lo + 1;
-    for (s < hi) {
-        if (!is_sym_char(tok[s])) { ret false; }
-        s = s + 1;
-    }
-    ret true;
-}
-
-# copy `tok[lo..hi]` (trimming surrounding whitespace) into `dst`
-# as a NUL-terminated string. returns false on empty or oversized slices
-fun copy_trimmed(tok: str, lo: usize, hi: usize, dst: *u8, cap: usize) bool {
-    var a: usize = lo;
-    var b: usize = hi;
-    for (a < b && is_asm_space(tok[a])) { a = a + 1; }
-    for (b > a && is_asm_space(tok[b - 1])) { b = b - 1; }
-    val n: usize = b - a;
-    if (n == 0 || n + 1 > cap) { ret false; }
-    var i: usize = 0;
-    for (i < n) { dst[i] = tok[a + i]::u8; i = i + 1; }
-    dst[n] = 0;
-    ret true;
 }
 
 # parse the `[...]` memory operand spanning `body[lo..hi)`
@@ -6155,17 +5149,17 @@ fun copy_trimmed(tok: str, lo: usize, hi: usize, dst: *u8, cap: usize) bool {
 # `[base+index*scale+disp]`, and `[symbol]` (a rip-relative reference the caller
 # relocates). A `{name}` binding inside the brackets is a stack slot used as an
 # address, which no addressing mode expresses - it is refused with the fix.
-fun asm_parse_mem(p: *AsmParser, lo: usize, hi: usize, role: str, op: *AsmOperand) R.Result[bool, str] {
-    op.kind = ASMOP_MEM;
+fun x64_mem(c: *iasm.Cursor, lo: usize, hi: usize, role: str, op: *iasm.Operand) R.Result[bool, str] {
+    @op = iasm.op_none();
+    op.kind = iasm.AOP_MEM;
+    op.size = 8;
 
     val inner_lo: usize = lo + 1;
     val inner_hi: usize = hi - 1;
 
     var q: usize = inner_lo;
     for (q < inner_hi) {
-        if (p.body[q] == '{'::char) {
-            ret R.err[bool, str](asm_bind_base_message(p, role));
-        }
+        if (c.body[q] == '{'::char) { ret R.err[bool, str](x64_bind_base_message(c, role)); }
         q = q + 1;
     }
 
@@ -6174,12 +5168,12 @@ fun asm_parse_mem(p: *AsmParser, lo: usize, hi: usize, role: str, op: *AsmOperan
     var has_star: bool = false;
     var s: usize = inner_lo;
     for (s < inner_hi) {
-        if (p.body[s] == '*'::char) { star = s; has_star = true; }
+        if (c.body[s] == '*'::char) { star = s; has_star = true; }
         s = s + 1;
     }
 
-    # the displacement separator is the last `+` / `-` at or after the index term
-    # (or after the base when there is no index).
+    # the displacement separator is the last `+` / `-` at or after the index term (or
+    # after the base when there is no index).
     var sep: usize = inner_hi;
     var has_sep: bool = false;
     var neg: bool = false;
@@ -6188,8 +5182,8 @@ fun asm_parse_mem(p: *AsmParser, lo: usize, hi: usize, role: str, op: *AsmOperan
     var r: usize = inner_hi;
     for (r > search_from && !has_sep) {
         r = r - 1;
-        if (p.body[r] == '+'::char) { sep = r; has_sep = true; neg = false; }
-        or (p.body[r] == '-'::char) { sep = r; has_sep = true; neg = true; }
+        if (c.body[r] == '+'::char) { sep = r; has_sep = true; neg = false; }
+        or (c.body[r] == '-'::char) { sep = r; has_sep = true; neg = true; }
     }
 
     var bi_hi: usize = inner_hi;
@@ -6203,24 +5197,23 @@ fun asm_parse_mem(p: *AsmParser, lo: usize, hi: usize, role: str, op: *AsmOperan
         var k: usize = star;
         for (k > inner_lo && !found_bplus) {
             k = k - 1;
-            if (p.body[k] == '+'::char) { bplus = k; found_bplus = true; }
+            if (c.body[k] == '+'::char) { bplus = k; found_bplus = true; }
         }
         if (!found_bplus) { ret R.err[bool, str]("encode: malformed inline-asm memory operand"); }
 
-        if (!copy_trimmed(p.body, inner_lo, bplus, ?buf[0], 32)) { ret R.err[bool, str]("encode: malformed inline-asm memory operand"); }
-        var base_op: AsmOperand;
-        if (!parse_asm_reg((?buf[0])::str, ?base_op)) { ret R.err[bool, str]("encode: malformed inline-asm memory operand"); }
+        if (!iasm.copy_region(c.body, inner_lo, bplus, ?buf[0], 32)) { ret R.err[bool, str]("encode: malformed inline-asm memory operand"); }
+        var base_op: iasm.Operand = iasm.op_none();
+        if (!x64_reg((?buf[0])::str, ?base_op)) { ret R.err[bool, str]("encode: malformed inline-asm memory operand"); }
         op.reg = base_op.reg;
 
-        if (!copy_trimmed(p.body, bplus + 1, star, ?buf[0], 32)) { ret R.err[bool, str]("encode: malformed inline-asm memory operand"); }
-        var idx_op: AsmOperand;
-        if (!parse_asm_reg((?buf[0])::str, ?idx_op)) { ret R.err[bool, str]("encode: malformed inline-asm memory operand"); }
+        if (!iasm.copy_region(c.body, bplus + 1, star, ?buf[0], 32)) { ret R.err[bool, str]("encode: malformed inline-asm memory operand"); }
+        var idx_op: iasm.Operand = iasm.op_none();
+        if (!x64_reg((?buf[0])::str, ?idx_op)) { ret R.err[bool, str]("encode: malformed inline-asm memory operand"); }
         op.index = idx_op.reg;
 
-        if (!copy_trimmed(p.body, star + 1, bi_hi, ?buf[0], 32)) { ret R.err[bool, str]("encode: malformed inline-asm memory operand"); }
-        val scr: R.Result[i64, str] = parse.parse_i64_exact((?buf[0])::str, 0);
-        if (R.is_err[i64, str](scr)) { ret R.err[bool, str]("encode: malformed inline-asm memory operand"); }
-        val scale_val: i64 = R.unwrap_ok[i64, str](scr);
+        val sv: O.Option[i64] = iasm.region_i64(c.body, star + 1, bi_hi);
+        if (!O.is_some[i64](sv)) { ret R.err[bool, str]("encode: malformed inline-asm memory operand"); }
+        val scale_val: i64 = O.unwrap[i64](sv);
         # the x86 SIB scale field encodes 1/2/4/8 only; any other scale is refused
         # here rather than silently encoding *8.
         if (scale_val != 1 && scale_val != 2 && scale_val != 4 && scale_val != 8) {
@@ -6228,9 +5221,9 @@ fun asm_parse_mem(p: *AsmParser, lo: usize, hi: usize, role: str, op: *AsmOperan
         }
         op.scale = scale_val::u8;
     } or {
-        if (!copy_trimmed(p.body, inner_lo, bi_hi, ?buf[0], 32)) { ret R.err[bool, str]("encode: malformed inline-asm memory operand"); }
-        var base_op: AsmOperand;
-        if (parse_asm_reg((?buf[0])::str, ?base_op)) {
+        if (!iasm.copy_region(c.body, inner_lo, bi_hi, ?buf[0], 32)) { ret R.err[bool, str]("encode: malformed inline-asm memory operand"); }
+        var base_op: iasm.Operand = iasm.op_none();
+        if (x64_reg((?buf[0])::str, ?base_op)) {
             op.reg = base_op.reg;
         } or {
             # a bare name in brackets is a rip-relative symbol reference, valid only
@@ -6238,10 +5231,10 @@ fun asm_parse_mem(p: *AsmParser, lo: usize, hi: usize, role: str, op: *AsmOperan
             if (has_sep) { ret R.err[bool, str]("encode: malformed inline-asm memory operand"); }
             var a: usize = inner_lo;
             var b: usize = bi_hi;
-            for (a < b && is_asm_space(p.body[a])) { a = a + 1; }
-            for (b > a && is_asm_space(p.body[b - 1])) { b = b - 1; }
-            if (!is_token_sym_region(p.body, a, b)) { ret R.err[bool, str]("encode: malformed inline-asm memory operand"); }
-            op.mem_sym  = true;
+            for (a < b && iasm.is_space(c.body[a])) { a = a + 1; }
+            for (b > a && iasm.is_space(c.body[b - 1])) { b = b - 1; }
+            if (!iasm.is_sym_region(c.body, a, b)) { ret R.err[bool, str]("encode: malformed inline-asm memory operand"); }
+            op.flags    = iasm.AOF_MEM_SYM;
             op.reg      = -1;
             op.name_off = a;
             op.name_len = b - a;
@@ -6249,12 +5242,12 @@ fun asm_parse_mem(p: *AsmParser, lo: usize, hi: usize, role: str, op: *AsmOperan
     }
 
     if (has_sep) {
-        if (!copy_trimmed(p.body, sep + 1, inner_hi, ?buf[0], 32)) { ret R.err[bool, str]("encode: malformed inline-asm memory operand"); }
-        val dr: R.Result[i64, str] = parse.parse_i64_exact((?buf[0])::str, 0);
-        if (R.is_err[i64, str](dr)) { ret R.err[bool, str]("encode: malformed inline-asm memory operand"); }
-        var disp: i64 = R.unwrap_ok[i64, str](dr);
+        val dv: O.Option[i64] = iasm.region_i64(c.body, sep + 1, inner_hi);
+        if (!O.is_some[i64](dv)) { ret R.err[bool, str]("encode: malformed inline-asm memory operand"); }
+        var disp: i64 = O.unwrap[i64](dv);
         if (neg) { disp = -disp; }
-        op.imm = disp;
+        op.imm   = disp;
+        op.flags = op.flags | iasm.AOF_HAS_DISP;
     }
     ret R.ok[bool, str](true);
 }
@@ -6263,65 +5256,250 @@ fun asm_parse_mem(p: *AsmParser, lo: usize, hi: usize, role: str, op: *AsmOperan
 #
 # A binding is a stack slot, so `[{name}]` would address the slot's contents as an
 # address; the fix is always to load it into a register first.
-fun asm_bind_base_message(p: *AsmParser, role: str) str {
-    if (p.interner == nil) {
+fun x64_bind_base_message(c: *iasm.Cursor, role: str) str {
+    if (c.interner == nil) {
         ret "encode: inline-asm stack-slot binding cannot be used inside a memory operand; load it into a register first";
     }
-    ret named_message(p.alloc, p.interner,
+    ret iasm.named_message(c.alloc, c.interner,
         "encode: inline-asm ", role,
         "operand uses a stack-slot binding inside a memory operand ([{name}]); load it into a register first",
         "encode: inline-asm stack-slot binding cannot be used inside a memory operand; load it into a register first");
 }
 
-# convert a parsed register / immediate / memory operand into `isa.Operand`
+# turn one resolved x86-64 statement into a parsed item
+#
+# The operation width comes from whichever side is a register (a memory or immediate
+# operand inherits it); a `[symbol]` on either side becomes the instruction's pending
+# relocation. A statement carrying an unresolved `{name}` is not modeled: before the
+# frame is laid out its displacement genuinely is unknown, and the effect model falls
+# back to the general-purpose bank rather than describing a half-known instruction.
+fun x64_parse(c: *iasm.Cursor, s: *iasm.Stmt, item: *iasm.Item) R.Result[bool, str] {
+    val pat: u16 = x64_pattern(s.m.flags);
+    val n: u32 = s.nargs;
+
+    if (pat == X64P_NONE) {
+        if (n != 0) { ret R.err[bool, str]("encode: inline-asm instruction takes no operands"); }
+        ret R.ok[bool, str](true);
+    }
+    if (pat == X64P_BRANCH) {
+        if (n != 1) { ret R.err[bool, str]("encode: inline-asm branch expects one target"); }
+        ret x64_branch_target(c, s, item);
+    }
+
+    var i: u32 = 0;
+    for (i < n) {
+        var role: str = "";
+        if (pat == X64P_TWO && i == 0) { role = "destination "; }
+        or (pat == X64P_TWO)           { role = "source "; }
+        val r: R.Result[bool, str] = x64_operand(c, s.arg_lo[i::usize], s.arg_hi[i::usize], role, ?item.ops[i::usize]);
+        if (R.is_err[bool, str](r)) { ret r; }
+        i = i + 1;
+    }
+
+    if (pat == X64P_ONE) {
+        if (n != 1) { ret R.err[bool, str]("encode: inline-asm instruction expects one operand"); }
+        val op: *iasm.Operand = ?item.ops[0];
+        if (op.kind == iasm.AOP_SYM || (op.kind == iasm.AOP_MEM && (op.flags & iasm.AOF_MEM_SYM) != 0)) {
+            ret R.err[bool, str]("encode: inline-asm one-operand symbol form unsupported");
+        }
+        if (op.kind == iasm.AOP_BIND) { item.kind = iasm.AI_OPAQUE; ret R.ok[bool, str](true); }
+        ret R.ok[bool, str](true);
+    }
+
+    if (n != 2) {
+        ret R.err[bool, str](iasm.span_message(c,
+            "encode: malformed inline-asm two-operand instruction '", s.lo, s.hi, "'",
+            "encode: malformed inline-asm two-operand instruction"));
+    }
+    if (item.ops[0].kind == iasm.AOP_SYM || item.ops[1].kind == iasm.AOP_SYM) {
+        ret R.err[bool, str]("encode: inline-asm bare-symbol operand unsupported (use [symbol])");
+    }
+    if (item.ops[0].kind == iasm.AOP_BIND || item.ops[1].kind == iasm.AOP_BIND) {
+        item.kind = iasm.AI_OPAQUE;
+        ret R.ok[bool, str](true);
+    }
+    if ((item.ops[0].flags & iasm.AOF_MEM_SYM) != 0) {
+        item.ref     = iasm.AR_SYM;
+        item.ref_off = item.ops[0].name_off;
+        item.ref_len = item.ops[0].name_len;
+    }
+    or ((item.ops[1].flags & iasm.AOF_MEM_SYM) != 0) {
+        item.ref     = iasm.AR_SYM;
+        item.ref_off = item.ops[1].name_off;
+        item.ref_len = item.ops[1].name_len;
+    }
+    ret R.ok[bool, str](true);
+}
+
+# resolve a CALL / JMP / Jcc target: a numeric local label or a named symbol
+fun x64_branch_target(c: *iasm.Cursor, s: *iasm.Stmt, item: *iasm.Item) R.Result[bool, str] {
+    val lo: usize = s.arg_lo[0];
+    val hi: usize = s.arg_hi[0];
+    var num: u64 = 0;
+    var fwd: bool = false;
+    if (iasm.label_ref_span(c.body, lo, hi, ?num, ?fwd)) {
+        item.ref     = iasm.AR_LOCAL;
+        item.ref_num = num;
+        item.ref_fwd = fwd;
+        ret R.ok[bool, str](true);
+    }
+    # a bare symbol never starts with a digit, so a digit-led token that is not a
+    # `<digits>f` / `<digits>b` reference is a malformed local label, not a symbol.
+    if (iasm.is_digit(c.body[lo])) {
+        ret R.err[bool, str]("encode: inline-asm numeric local-label reference must be '<digits>f' or '<digits>b'");
+    }
+    if (!iasm.is_sym_region(c.body, lo, hi)) {
+        ret R.err[bool, str]("encode: inline-asm branch target is not a symbol");
+    }
+    item.ref     = iasm.AR_SYM;
+    item.ref_off = lo;
+    item.ref_len = hi - lo;
+    ret R.ok[bool, str](true);
+}
+
+# convert a parsed operand into the `isa.Operand` the encoder takes
 #
 # A rip-relative `[symbol]` becomes the `[rip + disp32]` form (no base, no index)
 # whose disp32 the caller patches with a PC32 relocation.
-fun asm_to_isa(op: *AsmOperand, size: u8) isa.Operand {
-    if (op.kind == ASMOP_REG) { ret isa.make_reg(op.reg, size); }
-    if (op.kind == ASMOP_IMM) { ret isa.make_imm(op.imm, size); }
-    if (op.kind == ASMOP_MEM) {
-        if (op.mem_sym) { ret isa.make_mem(-1, 0, -1, 0, size); }
+fun x64_to_isa(op: *iasm.Operand, size: u8) isa.Operand {
+    if (op.kind == iasm.AOP_REG) { ret isa.make_reg(op.reg, size); }
+    if (op.kind == iasm.AOP_IMM) { ret isa.make_imm(op.imm, size); }
+    if (op.kind == iasm.AOP_MEM) {
+        if ((op.flags & iasm.AOF_MEM_SYM) != 0) { ret isa.make_mem(-1, 0, -1, 0, size); }
         ret isa.make_mem(op.reg, op.imm::i32, op.index, op.scale, size);
     }
     ret none_operand();
 }
 
-# the `AsmClobbersFn` the x86-64 ISA vtable exposes - the registers an inline-asm
-# body writes, derived from the instructions the body parses to
+# build the machine instruction one parsed item denotes
 #
-# Runs before register allocation, on the same parser the encoder later runs on the
-# same text, so the clobber set is a property of the parsed instruction stream
-# rather than a second reading of it. A body the parser refuses is opaque: the
-# encoder rejects it with a located diagnostic, and until then no register may hold
-# a live value. The result is always a sound over-approximation - a register the
-# body merely reads may be reported, a written one is never omitted.
+# The single place a parsed x86-64 statement becomes an `isa.Inst`, so an inline-asm
+# instruction and a compiler-selected one are the same value taking the same encoder.
+fun x64_build(item: *iasm.Item) isa.Inst {
+    var mi: isa.Inst;
+    zero_inst(?mi);
+    mi.opcode = item.code::u16;
+    var enc_flags: u16 = 0;
+    if ((item.flags & X64F_LOCK) != 0) { enc_flags = x64.FLAG_LOCK::u16; }
+
+    val pat: u16 = x64_pattern(item.flags);
+    if (pat == X64P_NONE || pat == X64P_BRANCH) {
+        mi.flags = enc_flags;
+        ret mi;
+    }
+
+    var size: u8 = 8;
+    if (item.ops[0].kind == iasm.AOP_REG)                       { size = item.ops[0].size; }
+    or (item.nops > 1 && item.ops[1].kind == iasm.AOP_REG)      { size = item.ops[1].size; }
+
+    mi.size  = size;
+    mi.flags = width_flags_for(size) | enc_flags;
+    mi.dst   = x64_to_isa(?item.ops[0], size);
+    if (pat == X64P_TWO) { mi.src1 = x64_to_isa(?item.ops[1], size); }
+    ret mi;
+}
+
+# emit one parsed x86-64 item
+fun x64_emit(st: *enc.EncodeState, c: *iasm.Cursor, l: *iasm.Labels, item: *iasm.Item) R.Result[bool, str] {
+    var mi: isa.Inst = x64_build(item);
+
+    val inst_start: usize = st.buf.len;
+    val n: i32 = encode_inst(?mi, ?st.buf);
+    if (n <= 0) { ret R.err[bool, str]("encode: inline-asm instruction encoded to no bytes"); }
+
+    if (item.ref == iasm.AR_LOCAL) {
+        # the rel32 is the branch's trailing four bytes, so the byte after it - which
+        # the displacement is measured from - is always four past the patch site.
+        ret iasm.resolve_local(st, c.g, l, (inst_start + (n - 4)::usize)::u32, item.ref_num, item.ref_fwd);
+    }
+    if (item.ref == iasm.AR_SYM) { ret x64_emit_sym_ref(st, c, ?mi, item, inst_start, n); }
+    ret R.ok[bool, str](true);
+}
+
+# record the PC32 relocation a symbol-referencing instruction needs
+#
+# The patch site comes from the same `x86_reloc_offset` query the compiler-emitted
+# instructions use: a direct branch relocates its trailing rel32, a rip-relative
+# `[symbol]` its ModR/M disp32 (stepping back over a trailing store immediate).
+fun x64_emit_sym_ref(st: *enc.EncodeState, c: *iasm.Cursor, mi: *isa.Inst, item: *iasm.Item,
+                     inst_start: usize, n: i32) R.Result[bool, str] {
+    val patch: i32 = x86_reloc_offset(nil, mi, n);
+    if (patch < 0) {
+        ret R.err[bool, str]("internal compiler error: inline-asm symbol reference has no relocation field");
+    }
+    val name: str = (c.body::usize + item.ref_off)::str;
+    val symr: R.Result[intern.StrId, str] = intern.intern_bytes(st.interner, name, item.ref_len);
+    if (R.is_err[intern.StrId, str](symr)) { ret R.err[bool, str](R.unwrap_err[intern.StrId, str](symr)); }
+    val sym: intern.StrId = R.unwrap_ok[intern.StrId, str](symr);
+
+    # PC32: S + A - P, where the addend corrects the patch site to the next ip.
+    ret enc.push_reloc(st, (inst_start + patch::usize)::u32, of.RK_PC32, sym, -(n - patch));
+}
+
+# insert the displacement from an inline-asm branch to a numeric local label
+#
+# The rel32 field is the branch's trailing four bytes and is measured from the byte
+# after it, so the target is `patch_pos + 4` away from the reference point.
+fun x64_patch(st: *enc.EncodeState, patch_pos: u32, target_off: u32) R.Result[bool, str] {
+    patch_rel32(?st.buf, patch_pos::usize, target_off::i32 - (patch_pos + 4)::i32);
+    ret R.ok[bool, str](true);
+}
+
+# the x86-64 inline-assembly grammar
+fun x64_grammar() iasm.Grammar {
+    var g: iasm.Grammar;
+    g.isa       = "x86_64";
+    g.rows      = ?X64_MNEMONICS[0];
+    g.row_count = X64_MNEMONIC_COUNT;
+    g.decode    = nil;
+    g.parse     = x64_parse;
+    g.emit      = x64_emit;
+    g.patch     = x64_patch;
+    g.slot      = frame_slot_offset;
+    g.all_gp    = X64_ALL_GP;
+    g.all_fp    = X64_ALL_FP;
+    g.word      = 0;
+    ret g;
+}
+
+# the `AsmClobbersFn` the x86-64 ISA vtable exposes - the registers an inline-asm body
+# writes, derived from the instructions the body parses to
+#
+# Runs before register allocation, on the same parser the emitter later runs on the
+# same text, so the clobber set is a property of the parsed instruction stream rather
+# than a second reading of it. A body the parser refuses is opaque: the emitter
+# rejects it with a located diagnostic, and until then no register may hold a live
+# value. The result is always a sound over-approximation - a register the body merely
+# reads may be reported, a written one is never omitted.
 # ---
 # body:   raw inline-asm body text
 # gp_out: receives the GP-register clobber bitmask (index n -> bit n)
 # fp_out: receives the vector-register clobber bitmask (index n -> bit n)
 pub fun asm_clobbers(body: str, gp_out: *u32, fp_out: *u32) {
-    var gp: u32 = 0;
-    var fp: u32 = 0;
+    var g: iasm.Grammar = x64_grammar();
+    iasm.clobbers(?g, body, gp_out, fp_out);
+}
 
-    var p: AsmParser;
-    asm_parser_init(?p, body, nil, nil, nil, nil);
+# expand an inline-asm MIR_ASM instruction into machine bytes
+#
+# The x86-64 instantiation of the shared block driver: it supplies the grammar and the
+# driver does the rest, so `{name}` resolution, numeric local labels, byte accounting
+# and the located diagnostic are the same code every target runs.
+fun encode_asm_block(st: *enc.EncodeState, f: *mir.MirFunction, fn_base: u32, mi: *mir.MirInstr) R.Result[bool, str] {
+    var g: iasm.Grammar = x64_grammar();
+    ret iasm.encode_block(st, ?g, f, mi);
+}
 
-    var item: AsmItem;
-    var done: bool = false;
-    for (!done) {
-        val pr: R.Result[bool, str] = asm_parse_next(?p, ?item);
-        if (R.is_err[bool, str](pr)) {
-            gp   = ASM_ALL_GP;
-            fp   = ASM_ALL_FP;
-            done = true;
-        }
-        or (!R.unwrap_ok[bool, str](pr)) { done = true; }
-        or { asm_item_clobbers(?item, ?gp, ?fp); }
-    }
-
-    @gp_out = gp;
-    @fp_out = fp;
+# assemble `text` as an inline-asm body into `st`, with no `{name}` bindings
+#
+# The encoder tests' entry point: it drives the same cursor and the same driver the
+# block path does, so a byte-exact golden is a fact about the shipping parser rather
+# than about a test-only path beside it.
+fun x64_asm_text(st: *enc.EncodeState, f: *mir.MirFunction, l: *iasm.Labels, text: str) R.Result[bool, str] {
+    var g: iasm.Grammar = x64_grammar();
+    var c: iasm.Cursor;
+    iasm.cursor_init(?c, ?g, text, st.alloc, st.interner, f, nil);
+    ret iasm.run(st, ?g, ?c, l);
 }
 
 # the REX.W / 0x66 encoding flags an operand width implies
@@ -6329,6 +5507,23 @@ fun width_flags_for(size: u8) u16 {
     if (size == 8) { ret x64.FLAG_REX_W::u16; }
     if (size == 2) { ret x64.FLAG_16BIT::u16; }
     ret 0;
+}
+
+# write the decimal digits of `n` into `dst` (at least one digit) and return the digit
+# count; `dst` must hold at least 20 bytes
+fun u64_to_dec(n: u64, dst: *u8) usize {
+    if (n == 0) { dst[0] = '0'::u8; ret 1; }
+    var tmp: [20]u8;
+    var len: usize = 0;
+    var v: u64 = n;
+    for (v > 0) {
+        tmp[len] = (v % 10)::u8 + '0'::u8;
+        v        = v / 10;
+        len      = len + 1;
+    }
+    var k: usize = 0;
+    for (k < len) { dst[k] = tmp[len - 1 - k]; k = k + 1; }
+    ret len;
 }
 
 # build an inactive (OPK_NONE) operand with no register references
@@ -6347,14 +5542,16 @@ fun none_operand() isa.Operand {
     ret op;
 }
 
+
 # a `{name}` binding inside a memory operand yields an actionable diagnostic
 # rather than a bare "malformed operand": a binding is a stack slot, so the
 # address has to be staged through a register first
-test "mach.lang.target.isa.x64.encode.asm_parse_mem:stack_slot_base_diagnostic" {
-    var p: AsmParser;
-    asm_parser_init(?p, "mov [{ptr}], rax", nil, nil, nil, nil);
-    var item: AsmItem;
-    val r: R.Result[bool, str] = asm_parse_next(?p, ?item);
+test "mach.lang.target.isa.x64.encode.x64_mem:stack_slot_base_diagnostic" {
+    var g: iasm.Grammar = x64_grammar();
+    var c: iasm.Cursor;
+    iasm.cursor_init(?c, ?g, "mov [{ptr}], rax", nil, nil, nil, nil);
+    var item: iasm.Item;
+    val r: R.Result[bool, str] = iasm.next(?c, ?item);
     if (!R.is_err[bool, str](r)) { ret 1; }
     val msg: str = R.unwrap_err[bool, str](r);
     if (!str_contains(msg, "stack-slot binding"))                          { ret 1; }
@@ -6363,60 +5560,39 @@ test "mach.lang.target.isa.x64.encode.asm_parse_mem:stack_slot_base_diagnostic" 
     ret 0;
 }
 
-# numeric local-label definitions and references are recognized by token shape
-test "mach.lang.target.isa.x64.encode:asm_label_token_shapes" {
-    var num: u64 = 0;
-    var bad: i32 = 0;
-
-    # `<digits>:` is a definition; the prefix length includes the colon.
-    if (asm_label_def_span("1:", 0, 2, ?num) != 2 || num != 1)                 { bad = 1; }
-    if (asm_label_def_span("42: mov rax, rbx", 0, 16, ?num) != 3 || num != 42) { bad = 1; }
-    # not a definition: no colon, or a non-digit lead.
-    if (asm_label_def_span("mov rax, rbx", 0, 12, ?num) != 0) { bad = 1; }
-    if (asm_label_def_span("1f", 0, 2, ?num) != 0)            { bad = 1; }
-
-    var fwd: bool = false;
-    # `<digits>f` is a forward reference, `<digits>b` a backward one.
-    if (!asm_label_ref_span("1f", 0, 2, ?num, ?fwd) || num != 1 || !fwd)   { bad = 1; }
-    if (!asm_label_ref_span("23b", 0, 3, ?num, ?fwd) || num != 23 || fwd)  { bad = 1; }
-    # a bare symbol, a digit-led non-f/b token, and a too-short token are not refs.
-    if (asm_label_ref_span("loop", 0, 4, ?num, ?fwd)) { bad = 1; }
-    if (asm_label_ref_span("1x", 0, 2, ?num, ?fwd))   { bad = 1; }
-    if (asm_label_ref_span("1", 0, 1, ?num, ?fwd))    { bad = 1; }
-    ret bad;
-}
-
 # local-label branches encode a block-local rel32 in both directions
-test "mach.lang.target.isa.x64.encode.asm_emit_local_ref:local_label_rel32" {
+test "mach.lang.target.isa.x64.encode.x64_emit:local_label_rel32" {
     var alloc: A.Allocator;
     page.make(?alloc);
     var st: enc.EncodeState;
     st.alloc    = ?alloc;
     st.buf      = enc.buf_init(?alloc);
-    # the undefined-backward error formats through enc_named_message; a nil
+    # the undefined-backward error formats through the shared named message; a nil
     # interner makes it return the plain fallback string instead of interning.
     st.interner = nil;
 
-    var labels: AsmLabelState;
-    asm_labels_init(?labels, ?alloc);
+    var g: iasm.Grammar = x64_grammar();
+    var labels: iasm.Labels;
+    iasm.labels_init(?labels, ?alloc);
+    var c: iasm.Cursor;
+    iasm.cursor_init(?c, ?g, "", ?alloc, nil, nil, nil);
 
-    var p: AsmParser;
-    asm_parser_init(?p, "", ?alloc, nil, nil, nil);
-
-    var jm: AsmItem;
-    asm_item_reset(?jm);
-    jm.inst.opcode = x64.JMP;
-    jm.ref         = AR_LOCAL;
+    var jm: iasm.Item;
+    jm.kind  = iasm.AI_INST;
+    jm.code  = x64.JMP::u32;
+    jm.flags = X64P_BRANCH;
+    jm.nops  = 0;
+    jm.ref   = iasm.AR_LOCAL;
 
     var bad: i32 = 0;
 
     # define label 1 at offset 0, then `jmp 1b`: a 5-byte E9 rel32 at offset 0
     # whose rel32 (offset 1) is 0 - 5 = -5 (0xFFFFFFFB).
-    val dr: R.Result[bool, str] = asm_label_record_def(?labels, ?st.buf, 1, 0);
+    val dr: R.Result[bool, str] = iasm.label_record_def(?st, ?g, ?labels, 1, 0);
     if (R.is_err[bool, str](dr)) { bad = 1; }
     jm.ref_num = 1;
     jm.ref_fwd = false;
-    val br: R.Result[bool, str] = asm_emit_item(?st, ?p, ?labels, ?jm);
+    val br: R.Result[bool, str] = x64_emit(?st, ?c, ?labels, ?jm);
     if (R.is_err[bool, str](br)) { bad = 1; }
     if (st.buf.len != 5)         { bad = 1; }
     or (st.buf.data[0] != 0xE9)  { bad = 1; }
@@ -6429,10 +5605,10 @@ test "mach.lang.target.isa.x64.encode.asm_emit_local_ref:local_label_rel32" {
     # offset (10) patches the rel32 (offset 6) to 10 - 10 = 0.
     jm.ref_num = 2;
     jm.ref_fwd = true;
-    val fr: R.Result[bool, str] = asm_emit_item(?st, ?p, ?labels, ?jm);
+    val fr: R.Result[bool, str] = x64_emit(?st, ?c, ?labels, ?jm);
     if (R.is_err[bool, str](fr)) { bad = 1; }
     if (labels.fixup_count != 1) { bad = 1; }
-    val dr2: R.Result[bool, str] = asm_label_record_def(?labels, ?st.buf, 2, st.buf.len::u32);
+    val dr2: R.Result[bool, str] = iasm.label_record_def(?st, ?g, ?labels, 2, st.buf.len::u32);
     if (R.is_err[bool, str](dr2)) { bad = 1; }
     if (labels.fixup_count != 0)  { bad = 1; }
     or (st.buf.data[5] != 0xE9)   { bad = 1; }
@@ -6444,10 +5620,10 @@ test "mach.lang.target.isa.x64.encode.asm_emit_local_ref:local_label_rel32" {
     # a backward reference to an undefined number is a hard error.
     jm.ref_num = 9;
     jm.ref_fwd = false;
-    val ur: R.Result[bool, str] = asm_emit_item(?st, ?p, ?labels, ?jm);
+    val ur: R.Result[bool, str] = x64_emit(?st, ?c, ?labels, ?jm);
     if (!R.is_err[bool, str](ur)) { bad = 1; }
 
-    asm_labels_dnit(?labels);
+    iasm.labels_dnit(?labels);
     enc.buf_dnit(?st.buf);
     ret bad;
 }
@@ -6455,43 +5631,46 @@ test "mach.lang.target.isa.x64.encode.asm_emit_local_ref:local_label_rel32" {
 # an inline-asm body parses into the same `isa.Inst` values the compiler emits -
 # the representation the encoder, the clobber model, and instruction selection all
 # share, rather than text each reads for itself
-test "mach.lang.target.isa.x64.encode.asm_parse_next:body_to_inst" {
-    var p: AsmParser;
-    asm_parser_init(?p, "mov rax, rbx\nlock xadd [rcx], rax\nsyscall\n1:\njmp 1b", nil, nil, nil, nil);
-    var item: AsmItem;
+test "mach.lang.target.isa.x64.encode.x64_parse:body_to_inst" {
+    var g: iasm.Grammar = x64_grammar();
+    var c: iasm.Cursor;
+    iasm.cursor_init(?c, ?g, "mov rax, rbx\nlock xadd [rcx], rax\nsyscall\n1:\njmp 1b", nil, nil, nil, nil);
+    var item: iasm.Item;
     var bad: i32 = 0;
 
-    if (R.is_err[bool, str](asm_parse_next(?p, ?item)))     { ret 1; }
-    if (item.kind != AI_INST)                               { bad = 1; }
-    if (item.inst.opcode != x64.MOV)                        { bad = 1; }
-    if (item.inst.size != 8)                                { bad = 1; }
-    if ((item.inst.flags & x64.FLAG_REX_W::u16) == 0)       { bad = 1; }
-    if (item.inst.dst.kind != isa.OPK_REG)                  { bad = 1; }
-    if (item.inst.dst.reg != x64.RAX)                       { bad = 1; }
-    if (item.inst.src1.reg != x64.RBX)                      { bad = 1; }
+    if (R.is_err[bool, str](iasm.next(?c, ?item)))          { ret 1; }
+    if (item.kind != iasm.AI_INST)                          { bad = 1; }
+    var mi: isa.Inst = x64_build(?item);
+    if (mi.opcode != x64.MOV)                               { bad = 1; }
+    if (mi.size != 8)                                       { bad = 1; }
+    if ((mi.flags & x64.FLAG_REX_W::u16) == 0)              { bad = 1; }
+    if (mi.dst.kind != isa.OPK_REG)                         { bad = 1; }
+    if (mi.dst.reg != x64.RAX)                              { bad = 1; }
+    if (mi.src1.reg != x64.RBX)                             { bad = 1; }
     # the statement claims every one of its bytes and nothing beyond them.
     if (item.src_off != 0 || item.src_len != 12)            { bad = 1; }
 
-    if (R.is_err[bool, str](asm_parse_next(?p, ?item)))     { ret 1; }
-    if (item.inst.opcode != x64.XADD)                       { bad = 1; }
-    if ((item.inst.flags & x64.FLAG_LOCK::u16) == 0)        { bad = 1; }
-    if (item.inst.dst.kind != isa.OPK_MEM)                  { bad = 1; }
-    if (item.inst.dst.base != x64.RCX)                      { bad = 1; }
-    if (item.inst.src1.reg != x64.RAX)                      { bad = 1; }
+    if (R.is_err[bool, str](iasm.next(?c, ?item)))          { ret 1; }
+    mi = x64_build(?item);
+    if (mi.opcode != x64.XADD)                              { bad = 1; }
+    if ((mi.flags & x64.FLAG_LOCK::u16) == 0)               { bad = 1; }
+    if (mi.dst.kind != isa.OPK_MEM)                         { bad = 1; }
+    if (mi.dst.base != x64.RCX)                             { bad = 1; }
+    if (mi.src1.reg != x64.RAX)                             { bad = 1; }
 
-    if (R.is_err[bool, str](asm_parse_next(?p, ?item)))     { ret 1; }
-    if (item.inst.opcode != x64.SYSCALL)                    { bad = 1; }
+    if (R.is_err[bool, str](iasm.next(?c, ?item)))          { ret 1; }
+    if (x64_build(?item).opcode != x64.SYSCALL)             { bad = 1; }
 
-    if (R.is_err[bool, str](asm_parse_next(?p, ?item)))     { ret 1; }
-    if (item.kind != AI_LABEL || item.ref_num != 1)         { bad = 1; }
+    if (R.is_err[bool, str](iasm.next(?c, ?item)))          { ret 1; }
+    if (item.kind != iasm.AI_LABEL || item.ref_num != 1)    { bad = 1; }
 
-    if (R.is_err[bool, str](asm_parse_next(?p, ?item)))     { ret 1; }
-    if (item.inst.opcode != x64.JMP)                        { bad = 1; }
-    if (item.ref != AR_LOCAL)                               { bad = 1; }
+    if (R.is_err[bool, str](iasm.next(?c, ?item)))          { ret 1; }
+    if (x64_build(?item).opcode != x64.JMP)                 { bad = 1; }
+    if (item.ref != iasm.AR_LOCAL)                          { bad = 1; }
     if (item.ref_num != 1 || item.ref_fwd)                  { bad = 1; }
 
     # the body is exhausted, with every trailing byte accounted for.
-    val last: R.Result[bool, str] = asm_parse_next(?p, ?item);
+    val last: R.Result[bool, str] = iasm.next(?c, ?item);
     if (R.is_err[bool, str](last))    { ret 1; }
     if (R.unwrap_ok[bool, str](last)) { bad = 1; }
     ret bad;
@@ -6527,40 +5706,41 @@ test "mach.lang.target.isa.x64.encode.asm_clobbers:derived_from_parse" {
     # out, so the instruction is not modeled: worst case within the bank the
     # grammar can reach, which names no vector register.
     asm_clobbers("mov rax, {v}", ?gp, ?fp);
-    if (gp != ASM_ALL_GP) { bad = 1; }
+    if (gp != X64_ALL_GP) { bad = 1; }
     if (fp != 0)          { bad = 1; }
 
     # raw bytes and an instruction nobody described are unreadable: every bank.
     asm_clobbers(".byte 0x90", ?gp, ?fp);
-    if (gp != ASM_ALL_GP || fp != ASM_ALL_FP) { bad = 1; }
+    if (gp != X64_ALL_GP || fp != X64_ALL_FP) { bad = 1; }
     asm_clobbers("frobnicate rax, rbx", ?gp, ?fp);
-    if (gp != ASM_ALL_GP || fp != ASM_ALL_FP) { bad = 1; }
+    if (gp != X64_ALL_GP || fp != X64_ALL_FP) { bad = 1; }
     asm_clobbers("frobnicate", ?gp, ?fp);
-    if (gp != ASM_ALL_GP || fp != ASM_ALL_FP) { bad = 1; }
+    if (gp != X64_ALL_GP || fp != X64_ALL_FP) { bad = 1; }
     ret bad;
 }
 
 # the accounting guard refuses a body byte no parsed instruction claims
 #
-# `asm_parse_next` runs it after every statement, so a form that under-claims its
-# text fails the build naming the instruction instead of silently encoding less
-# than the source says.
+# `iasm.next` runs it after every statement, so a form that under-claims its text
+# fails the build naming the instruction instead of silently encoding less than the
+# source says.
 test "mach.lang.target.isa.x64.encode.asm_claim:refuses_unclaimed_byte" {
     var bad: i32 = 0;
+    var g: iasm.Grammar = x64_grammar();
 
-    var p: AsmParser;
-    asm_parser_init(?p, "mov rax, rbx", nil, nil, nil, nil);
+    var c: iasm.Cursor;
+    iasm.cursor_init(?c, ?g, "mov rax, rbx", nil, nil, nil, nil);
     # claiming the mnemonic and then the second operand leaves ` rax,` unaccounted.
-    if (R.is_err[bool, str](asm_claim(?p, 0, 3)))   { bad = 1; }
-    if (!R.is_err[bool, str](asm_claim(?p, 9, 3)))  { bad = 1; }
+    if (R.is_err[bool, str](iasm.claim(?c, 0, 3)))   { bad = 1; }
+    if (!R.is_err[bool, str](iasm.claim(?c, 9, 3)))  { bad = 1; }
 
     # whitespace between claims is legitimate inter-statement filler.
-    var q: AsmParser;
-    asm_parser_init(?q, "mov rax", nil, nil, nil, nil);
-    if (R.is_err[bool, str](asm_claim(?q, 0, 3)))  { bad = 1; }
-    if (R.is_err[bool, str](asm_claim(?q, 4, 3)))  { bad = 1; }
+    var q: iasm.Cursor;
+    iasm.cursor_init(?q, ?g, "mov rax", nil, nil, nil, nil);
+    if (R.is_err[bool, str](iasm.claim(?q, 0, 3)))  { bad = 1; }
+    if (R.is_err[bool, str](iasm.claim(?q, 4, 3)))  { bad = 1; }
     # a claim overlapping an earlier one is refused too.
-    if (!R.is_err[bool, str](asm_claim(?q, 5, 2))) { bad = 1; }
+    if (!R.is_err[bool, str](iasm.claim(?q, 5, 2))) { bad = 1; }
     ret bad;
 }
 

--- a/src/lang/target/isa/x64/encode.mach
+++ b/src/lang/target/isa/x64/encode.mach
@@ -5449,6 +5449,7 @@ fun x64_patch(st: *enc.EncodeState, patch_pos: u32, target_off: u32) R.Result[bo
 fun x64_grammar() iasm.Grammar {
     var g: iasm.Grammar;
     g.isa       = "x86_64";
+    g.unknown   = "unknown x86_64 inline-asm instruction '";
     g.rows      = ?X64_MNEMONICS[0];
     g.row_count = X64_MNEMONIC_COUNT;
     g.decode    = nil;


### PR DESCRIPTION
Closes #2232.

`text -> the machine model` for riscv64 and aarch64. The brief asked whether #2243's x86-64 parser was liftable; it was, almost entirely — so this is **one parser parameterized per ISA**, not two more ports beside it. x86-64 moves onto the same spine, which is why the diff deletes about as much as it adds.

## The split, and why

`src/lang/target/isa/asm.mach` — **shared**, once:

- the statement cursor and its **byte accounting** (every body byte claimed by exactly one item)
- statement splitting on newline / `;`, trimming, the length bound
- the mnemonic table walk (whole-statement for a no-operand form, prefix + space otherwise) and a per-ISA hook for suffixed families
- top-level operand splitting, depth-aware across `()`, `[]`, `{}`
- GNU-as numeric local labels: token shapes, the per-block scope, forward fixups, backward resolution
- **`{name}` binding** — the token shape, the lookup against the block's bindings, "unresolved means no displacement yet"
- the **effect model**: `AW_OP0` / `AW_OP1` / `AW_WB_BASE` folded over the parsed operands, plus the row's implicit mask
- the block driver, and every diagnostic

The **`Grammar`** a target supplies:

| | x86_64 | riscv64 | aarch64 |
|---|---|---|---|
| mnemonic table | 48 rows | 91 rows + an atomic-suffix decoder | 42 rows + a `b.<cond>` decoder |
| what `code` names | an `x64.Opcode` | an `inst.MachOp` | the **mnemonic** (`A64M_*`) |
| memory syntax | `[b + i*s + d]`, `[sym]` | `d(base)` | `[Xn{, d\|Xm\|:mod:sym}]{!}` |
| modifiers | — | `%pcrel_hi` / `%pcrel_lo` | `:lo12:` / `:got:` / `:got_lo12:` |
| `{name}` becomes | `[rbp + off]` | `off(s0)` | `[x29, off]` |
| instruction word | variable | 4 | 4 |

Three things turned out to be **genuinely per-ISA**, and each is now a named hook rather than a copied function:

1. **The frame-slot offset.** riscv64 pins `s0` at the frame top and biases every slot down past the ra/s0 record and the callee-saved areas; x86-64 and aarch64 do not. A shared implementation resolved `{name}` to a different address than the target's own loads — caught by byte-identity on the first run, which is exactly what that bar is for.
2. **Branch patching.** rel32-from-next-ip versus the imm26/imm19/B-type/J-type scatter.
3. **The `{name}` effect model.** riscv64 and aarch64 model the statement around an unresolved binding (a stack slot is not a register, so `ld a0, {v}` still credits `a0`); x86-64 treats the whole statement as unmodeled. That difference is **pre-existing and load-bearing** — unifying it changes what regalloc sees — so it stays a stated per-target fact, decided in each target's parse hook, rather than a silent change riding a refactor.

**`Mnemonic.code` names the mnemonic on aarch64, not an encoding.** `ldr` is six base words the emitter picks from the transferred register's width and the addressing form. The base word it picks stays the only naming that reaches the bytes and the printer — there is no second identifier riding beside them, which is the thing #2226 warned against.

On riscv64 the row names a real `inst.MachOp`, and **`rv_fields` recovers the format fields from it** — the inverse of the encoder's `classify_*`, and the direction #2118 makes the encoder's only one. A test round-trips every instruction the grammar names through both, so the assembler and the printer cannot drift.

A pseudo-instruction is not a concept here: it is a real instruction plus an operand pattern. `mv` is `addi rd, rs, 0`, `ret` is `jalr zero, 0(ra)`, `neg` is `sub rd, zero, rs`. The row names the real instruction, so the effect model and `--emit-asm` see the machine, never the spelling.

Deleted, not joined by a third reader: `asm_stmt_clobbers` and `encode_asm_stmt_riscv64` (riscv64); `asm_stmt_clobbers`, `asm_mark_op`, `asm_mark_ldstp_wb` and `encode_asm_stmt_arm64` (aarch64); both `substitute_asm_locals_*` and their `off(s0)` / `[x29, #off]` text round-trips.

## Totality: a stronger guard where the machine allows one

**Parse side, all three:** every byte of a body claimed by exactly one item, only whitespace and separators between claims, or the block is refused naming the instruction.

**Emit side, riscv64 and aarch64:** a mnemonic row declares how many instruction words its form emits and the driver refuses a form that emitted a different number.

**What it does not catch**, stated plainly:

- riscv64 `li`, whose length is a property of its immediate, declares `WORDS_VARIABLE`; the guard falls back to "a nonzero whole number of words".
- aarch64 `mov Rd, imm` (a MOVZ/MOVK materialization) and `ldr`/`str` **carrying a displacement** are likewise variable — the encoder legalizes an out-of-range offset into a materialize-plus-register-offset pair. The offset-less, register-offset and `:lo12:` forms declare 1.
- x86-64 declares no word size at all: with a variable-length encoding no count exists ahead of the encoder, so the parse-side accounting is the whole of its check. That is #2243's position, unchanged.

This is a different guard from #2250's `sink_unaccounted`, and it does not fix that one: this checks the *parse* against the *emission*, not the notification stream against the byte stream.

## Verification

**Corpus.** mach-std at pin `eff1e8e` — **43 x86_64 / 42 aarch64 / 28 riscv64** blocks (264 / 255 / 147 statements); mach's own src 5 / 5 / 4 (the `frobnicate` negative cases); `int/` 3 / 2 / 1. Every block builds across **6 targets x 2 profiles** — a refusal is a hard error, so a clean build *is* the parse. **Zero refusals**, on any target.

**Byte-identity.** dev's compiler and this branch's compiler emitting the same tree agree on **2472 objects** (6 targets x 2 profiles). Zero differences. `--emit-asm` output likewise: **2472 `.s` files identical**, so the instruction notifications the printer reads are unchanged instruction-for-instruction.

**Clobber equivalence, by the shadow method, on all three targets.** For each, the deleted reader was restored verbatim into a temporary shadow module (riscv64 and aarch64: the text scanner; x86-64: dev's own parser-derived `asm_clobbers`, 85 symbols renamed under an `sx_` namespace), run *beside* the new derivation over the whole corpus, armed to panic on any mismatch. **No mismatch on any target.** Each shadow was then **negative-controlled** — a one-bit perturbation of the new derivation, and each build failed with `ASM CLOBBER SHADOW MISMATCH` — so the equivalence run was live, not vacuous. All three shadows were deleted before the commits.

**Mutation, per target.**

| mutation | target | result |
|---|---|---|
| stop claiming an operand token | x86_64 | `panic.mach:18:13: inline-asm instruction 'eax' does not account for every byte of its statement` |
| " | aarch64 | `panic.mach:27:13: ... 'x8' does not account for every byte ...` |
| " | riscv64 | `panic.mach:36:13: ... 'a7' does not account for every byte ...` |
| declare `sd` as 2 words | riscv64 | `shared.mach:437:9: inline-asm instruction 'sd a0, {out}' emitted a different number of instruction words than its form declares` |
| declare `str` as 2 words | aarch64 | `aarch64.mach:68:5: ... 'str x0, [x11, :lo12:_rt_argc]' emitted a different number ...` |

All restored; the tree is clean.

**Suites.** mach **840 / 0** (dev baseline 834, +7 new, −1 moved into the shared module). mach-std **611 / 0** at `eff1e8e`, verified by `git rev-parse HEAD` against `mach.lock`.

**int/.** `linux` and `linux-riscv64` legs: all cases pass. The `linux-arm64` leg is `native` in `targets.conf` and cannot execute on this x86_64 host (52 `Exec format error` + 2 `relro_write=exit126`); **dev's compiler fails those identically**, so it is the host, not the branch.

**Fixpoint.** `A != B`, `B == C`. `A != B` reproduced on **unmodified dev** with the same harness — the known seed-lag condition, unchanged by this branch.

## Also in here

- `%pcrel_hi(sym)` / `%pcrel_lo(sym)` and `:lo12:` / `:got:` / `:got_lo12:` now **read back** into the shared `isa.SYM_MOD_*` the encoder's own notifications carry, so a page- or pc-relative pair round-trips between what `--emit-asm` prints and what this parses. aarch64's GOT-indirect pair (#2026) gained both halves as inline-asm surface; riscv64's `%got_pcrel_hi` **parses and is then refused by name**, because this backend has no GOT-relative riscv64 relocation kind and inventing one is not this issue.
- `#imm` is **dropped, not ported**: `#` is the mach inline-asm comment character and the lowering strips the rest of the line, so a `#` could never reach a backend. The aarch64 tests that spelled it were exercising an unreachable path.
- Two riscv64 statements the old scanner treated as opaque (`divuw`, `remuw`) are now modeled, and several the old scanner described but the assembler could never encode (a branch to a symbol, a *named* `label:`) are now opaque on both sides. Neither class appears in the corpus — the shadow proves it — and the direction of change is toward the two halves agreeing.
- `STMT_MAX` is 512 on every target; x86-64's was 256. More permissive, no corpus effect.
- The unknown-mnemonic refusal spells its target name from a `Grammar` field rather than composing it into a fixed buffer behind a bound check that fell back to a vaguer message. A diagnostic that degrades is still a fallback; it is gone rather than unreachable.

## Not in this issue

The capability is **not turned on**: no atomic inlining (#2231), no `asm` inside `#[oblivious]` (#2230), no relaxed regalloc staging. `std.sync.atomic` keeps its exact source and the derived clobber set is bit-for-bit what regalloc saw before, on all three targets.

Child of #2212.
