### PR TITLE
fix(sema): re-check a generic union's variants at the instance (#2225)

### DIFF
--- a/doc/language/secrecy.md
+++ b/doc/language/secrecy.md
@@ -110,6 +110,26 @@ fun erase(p: *^u8) ptr { ret p; }     # error: cannot erase a secret pointer to 
 uni Bad { a: ^u32; b: u32; }          # error: variants disagree on secrecy
 ```
 
+The union rule is a property of the union **type**, not of the syntax that
+declared it, so it holds for an inline `uni { ... }` with no declaration to hang
+a check on, and at every **instance** of a generic union. At the declaration a
+variant typed by a generic parameter says nothing about secrecy, so `uni U[T] {
+a: T; b: u32; }` agrees there and is decided where each instance is formed:
+
+```mach
+uni U[T] { a: T; b: u32; }
+rec Box[T] { u: U[T]; }
+
+var s: U[^u32];                       # error: this instantiation makes the variants disagree
+var b: Box[^u32];                     # same error: the instance need not be spelled
+var p: U[u32];                        # fine, and so is an all-secret instantiation
+```
+
+A *partially* concrete template (`U[T, ^u32]` written inside another generic) is
+a legal annotation with both legal and illegal instantiations, so it is never
+rejected where it is written — only at the arguments that actually make a pair
+mixed.
+
 The check is **deep** and **fails closed**: a secret nested anywhere inside an
 aggregate (including a generic instance's lazily-materialized fields) counts as
 secret at these boundaries, and a placement the checker cannot prove severs no
@@ -193,6 +213,11 @@ What does not hold — the known open holes:
 - a literal shift count coerces to `^T` and inherits secrecy, tripping the
   constant-time shift gate — a false positive; it fails safe
   (briar-systems/mach#2196)
+- an anonymous `uni` nested in a **generic** record does not get union layout:
+  its variants occupy distinct storage instead of overlapping
+  (briar-systems/mach#2239). A layout defect, not a secrecy one — the mixed-secrecy
+  rule rejects those instantiations either way — but it is the reason a
+  `Result[^u32, u32]` built before that rule landed leaked nothing at run time
 
 The validator's scope is the lowered MIR; it trusts instruction selection, width
 legalization, register allocation, and encoding to be timing-preserving.

--- a/src/lang/driver/tests.mach
+++ b/src/lang/driver/tests.mach
@@ -4534,6 +4534,87 @@ test "mach.lang.driver:secret_uni_secrecy_order_independent" {
     ret bad;
 }
 
+# constant-time (#2225): the union rule at a generic INSTANCE. `check_uni_secrecy` runs
+# at the DECLARATION, where a variant typed by a generic parameter is a public leaf and
+# `uni U[T] { a: T; b: u32 }` honestly agrees - so `U[^u32]` compiled clean where its
+# non-generic twin is a hard error. Each shape below is asserted at an EXACT diagnostic
+# count: the check is reached from several annotations for one mistake (an alias is
+# re-resolved per use), and reporting it two or three times is its own defect
+test "mach.lang.driver:secret_generic_uni_instance_secrecy" {
+    var bad: i32 = 0;
+
+    # the issue's reproducer: the instance is spelled outright.
+    if (ut_sema_errs("uni U[T] { a: T; b: u32; }\nfun f() u32 { var u: U[^u32]; u.a = 5; ret u.b; }\nfun main() i32 { ret 0; }\n") != 1) { bad = 1; }
+    # UNSPELLED: `Box[^u32]` materialises `U[^u32]` inside its own substituted field
+    # table and never names it, so no sweep over source annotations can see it.
+    if (ut_sema_errs("uni U[T] { a: T; b: u32; }\nrec Box[T] { u: U[T]; }\nfun f() u32 { var b: Box[^u32]; ret b.u.b; }\nfun main() i32 { ret 0; }\n") != 1) { bad = 1; }
+    # a SIGNATURE hides one too: the instance exists only inside `fun(*U[T]) u32`.
+    if (ut_sema_errs("uni U[T] { a: T; b: u32; }\nrec Box[T] { f: fun(*U[T]) u32; }\nfun g() i32 { var b: Box[^u32]; b.f = nil; ret 0; }\nfun main() i32 { ret 0; }\n") != 1) { bad = 1; }
+    # ANONYMOUS: no declaration to classify, which is how mach-std's `Result` escaped
+    # every guard keyed on "is this instance a union".
+    if (ut_sema_errs("rec Loc[T, E] { v: uni { a: T; b: E; }; }\nfun f() u32 { var l: Loc[^u32, u32]; ret l.v.b; }\nfun main() i32 { ret 0; }\n") != 1) { bad = 1; }
+    # written inside a GENERIC BODY: the module pass reads the un-substituted `{T, u32}`
+    # and agrees, so only the per-instance episode sees it.
+    if (ut_sema_errs("uni U[T] { a: T; b: u32; }\nfun sink[T](n: u32) u32 { var u: U[T]; u.b = n; ret u.b; }\nfun main() i32 { ret sink[^u32](1)::i32; }\n") != 1) { bad = 1; }
+    if (ut_sema_errs("fun sink[T](n: u32) u32 { var v: uni { a: T; b: u32; }; v.b = n; ret v.b; }\nfun main() i32 { ret sink[^u32](1)::i32; }\n") != 1) { bad = 1; }
+    # the secret is in the TEMPLATE and a plain `u32` argument is what makes the pair
+    # mixed, so the argument itself never "reaches a secret".
+    if (ut_sema_errs("uni U2[A, B] { a: A; b: B; }\nfun sink[T](n: u32) u32 { var u: U2[T, ^u32]; u.b = 0; ret n; }\nfun main() i32 { ret sink[u32](1)::i32; }\n") != 1) { bad = 1; }
+    # reached only through an instance's RETURN type, and only through a parameter the
+    # body never names (`nil` lets the caller pass one without spelling the type).
+    if (ut_sema_errs("uni U[T] { a: T; b: u32; }\nfun mk[T]() U[T] { var r: U[T]; r.b = 0; ret r; }\nfun main() i32 { ret mk[^u32]().b::i32; }\n") != 1) { bad = 1; }
+    if (ut_sema_errs("uni U[T] { a: T; b: u32; }\nfun take[T](p: *U[T]) u32 { ret 1; }\nfun main() i32 { ret take[^u32](nil)::i32; }\n") != 1) { bad = 1; }
+    # an ALIAS is re-resolved per use and the instance is reached from three annotations:
+    # one ill-formed type, one diagnostic.
+    if (ut_sema_errs("uni U[T] { a: T; b: u32; }\ndef L: U[^u32];\nfun f() u32 { var u: L; var v: L; u.b = 0; ret v.b; }\nfun main() i32 { ret 0; }\n") != 1) { bad = 1; }
+    # a recursive generic terminates and still reports.
+    if (ut_sema_errs("uni U[T] { a: T; b: u32; }\nrec Node[T] { next: *Node[T]; u: U[T]; }\nfun f() i32 { var n: Node[^u32]; n.next = nil; ret 0; }\nfun main() i32 { ret 0; }\n") != 1) { bad = 1; }
+    # an anonymous union handed to a generic as a TYPE ARGUMENT: reached by walking the
+    # argument itself, not the nominal it is substituted into.
+    if (ut_sema_errs("rec Hold[X] { x: X; }\nrec Outer[T] { h: Hold[uni { a: T; b: u32; }]; }\nfun f() i32 { var o: Outer[^u32]; o.h.x.b = 0; ret 0; }\nfun main() i32 { ret 0; }\n") != 1) { bad = 1; }
+    # two DISTINCT ill-formed instances are two diagnostics: the dedupe collapses routes
+    # to one type, never two mistakes.
+    if (ut_sema_errs("uni U[T] { a: T; b: u32; }\nrec Box[T] { u: U[T]; }\nrec Loc[T, E] { v: uni { a: T; b: E; }; }\nfun f() i32 { var b: Box[^u32]; var l: Loc[^u32, u32]; b.u.b = 0; l.v.b = 0; ret 0; }\nfun main() i32 { ret 0; }\n") != 2) { bad = 1; }
+    # the diagnostic names the instantiation, not the declaration it agreed at.
+    if (ut_vec_diag("uni U[T] { a: T; b: u32; }\nfun f() u32 { var u: U[^u32]; ret u.b; }\nfun main() i32 { ret 0; }\n", "this instantiation makes overlapping fields") != 0) { bad = 1; }
+    # a CONCRETE union still belongs to the declaration-site rule alone: one mistake, one
+    # diagnostic, not one from each rule. Named and anonymous both.
+    if (ut_sema_errs("uni N { a: ^u32; b: u32; }\nfun f() u32 { var n: N; ret n.b; }\nfun main() i32 { ret 0; }\n") != 1) { bad = 1; }
+    if (ut_sema_errs("fun f() u32 { var v: uni { a: ^u32; b: u32; }; ret v.b; }\nfun main() i32 { ret 0; }\n") != 1) { bad = 1; }
+    # the visited set is keyed on (nominal, ARGUMENTS): the same union reached first at a
+    # clean instantiation and then at a violating one is examined twice.
+    if (ut_sema_errs("uni U[T] { a: T; b: u32; }\nrec P[T] { x: U[u32]; y: U[T]; }\nfun f() i32 { var p: P[^u32]; p.y.b = 0; ret 0; }\nfun main() i32 { ret 0; }\n") != 1) { bad = 1; }
+    ret bad;
+}
+
+# constant-time (#2225): the instance rule must not over-reject. A partially concrete
+# template (`U2[T, ^u32]` inside a generic) is a legal annotation with legal
+# instantiations, so it is decided where it is FORMED, not where it is written; a record's
+# fields do not overlap, so mixed secrecy is legal there; and an untaken comptime arm is
+# never compiled, so it is never checked
+test "mach.lang.driver:secret_generic_uni_instance_accepted" {
+    var bad: i32 = 0;
+
+    # uniform instantiations of the same template.
+    if (!ut_sema_clean("uni U[T] { a: T; b: u32; }\nfun f() u32 { var u: U[u32]; ret u.b; }\nfun main() i32 { ret 0; }\n"))       { bad = 1; }
+    if (!ut_sema_clean("uni U2[A, B] { a: A; b: B; }\nfun f() i32 { var u: U2[^u32, ^u32]; u.a = 0; ret 0; }\nfun main() i32 { ret 0; }\n")) { bad = 1; }
+    if (!ut_sema_clean("uni Us[T] { a: T; b: T; }\nrec W[T] { u: Us[T]; }\nfun f() i32 { var p: W[u32]; var s: W[^u32]; p.u.a = 0; s.u.a = 0; ret 0; }\nfun main() i32 { ret 0; }\n")) { bad = 1; }
+    # PARTIALLY CONCRETE: legal at `Outer[^u32]`, rejected only at `Outer[u32]` - and the
+    # template itself, which has both, is never the site of the rejection.
+    if (!ut_sema_clean("uni U2[A, B] { a: A; b: B; }\nrec Outer[T] { u: U2[T, ^u32]; }\nfun f() i32 { var o: Outer[^u32]; o.u.a = 0; ret 0; }\nfun main() i32 { ret 0; }\n")) { bad = 1; }
+    if (ut_sema_errs("uni U2[A, B] { a: A; b: B; }\nrec Outer[T] { u: U2[T, ^u32]; }\nfun f() i32 { var o: Outer[u32]; o.u.b = 0; ret 0; }\nfun main() i32 { ret 0; }\n") != 1) { bad = 1; }
+    # a template that is never instantiated at all stays legal.
+    if (!ut_sema_clean("uni U2[A, B] { a: A; b: B; }\nrec Outer[T] { u: U2[T, ^u32]; }\nfun f() i32 { ret 0; }\nfun main() i32 { ret 0; }\n")) { bad = 1; }
+    # a RECORD's fields do not overlap.
+    if (!ut_sema_clean("rec Ctx[T] { key: T; id: u32; }\nrec N[T] { c: Ctx[T]; f: fun(*Ctx[T]) u32; }\nfun f() i32 { var n: N[^u32]; n.f = nil; ret 0; }\nfun main() i32 { ret 0; }\n")) { bad = 1; }
+    # an untaken comptime arm is not compiled, so its instantiation is not checked - the
+    # `^` elsewhere keeps the rule's own precondition live.
+    if (!ut_sema_clean("uni U[T] { a: T; b: u32; }\nfun f() i32 { var s: ^u32; s = 1; $if ($mach.build.os != $mach.build.os) { var b1: U[^u32]; b1.b = 0; } $or { var ok: U[u32]; ok.b = 0; } ret 0; }\nfun main() i32 { ret 0; }\n")) { bad = 1; }
+    # a recursive generic at uniform arguments terminates without reporting.
+    if (!ut_sema_clean("uni U[T] { a: T; b: u32; }\nrec Node[T] { next: *Node[T]; u: U[T]; }\nfun f() i32 { var s: ^u32; s = 1; var n: Node[u32]; n.next = nil; ret 0; }\nfun main() i32 { ret 0; }\n")) { bad = 1; }
+    ret bad;
+}
+
 # constant-time (#1646): floating point is variable-latency and gated by default, so
 # a secret operand of an FP add / sub / mul / compare is a sema error, while the same
 # ops on public floats are clean - the gate keys on secrecy, not shape
@@ -7110,6 +7191,30 @@ test "mach.lang.driver:pack_instance_enclosing_body_typed" {
     # onto the lowering worklist too would re-validate - and re-report - each one.
     if (ut_ct_lower_errs("#[oblivious]\nfun br[V](a: V, b: V) u32 { if (a == b) { ret 1; } ret 0; }\nfun sink[T](va: ...) u32 { var acc: u32 = 0; var x: T; var y: T; acc = acc + br[T](x, y); $each a in va { acc = acc + 1; } ret acc; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { var one: u32 = 1; sink[^u32](one); ret 0; }\n") != 1) { bad = 1; }
 
+    ret bad;
+}
+
+# constant-time (#2225): the generic-union instance rule reaches the two episodes the
+# module sema pass does not own - a deferred pack `$each` body, whose only typing pass
+# runs at monomorphization, and a template declared in ANOTHER module, where the episode
+# rebinds to the origin before it reads the annotation
+test "mach.lang.driver:secret_generic_uni_instance_deferred" {
+    var bad: i32 = 0;
+
+    # the union annotation lives inside the `$each` body: typed once, during lowering.
+    if (ut_ct_lower_diag("uni U[T] { a: T; b: u32; }\nfun sink[T](va: ...) u32 { var acc: u32 = 0; $each a in va { var u: U[T]; u.b = acc; acc = acc + u.b; } ret acc; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { var one: u32 = 1; sink[^u32](one); ret 0; }\n",
+        "this instantiation makes overlapping fields") != 0) { bad = 1; }
+    # the public twin of the same pack body stays clean.
+    if (!ut_ct_lower_clean("uni U[T] { a: T; b: u32; }\nfun sink[T](va: ...) u32 { var acc: u32 = 0; $each a in va { var u: U[T]; u.b = acc; acc = acc + u.b; } ret acc; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { var one: u32 = 1; sink[u32](one); ret 0; }\n")) { bad = 1; }
+
+    # the template in another module: the instance is formed under the instantiating
+    # module's argument but the union, and its field table, belong to the origin.
+    var xn: [2]str;
+    xn[0] = "main.mach"; xn[1] = "lib.mach";
+    var xt: [2]str;
+    xt[0] = "use uniontest.lib;\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { var b: lib.XBox[^u32]; b.u.b = 0; ret 0; }\n";
+    xt[1] = "pub uni XU[T] { a: T; b: u32; }\npub rec XBox[T] { u: XU[T]; }\n";
+    if (ut_ct_lower_diag_n(?xn[0], ?xt[0], 2, "this instantiation makes overlapping fields") != 0) { bad = 1; }
     ret bad;
 }
 

--- a/src/lang/driver/tests.mach
+++ b/src/lang/driver/tests.mach
@@ -7215,6 +7215,16 @@ test "mach.lang.driver:secret_generic_uni_instance_deferred" {
     xt[0] = "use uniontest.lib;\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { var b: lib.XBox[^u32]; b.u.b = 0; ret 0; }\n";
     xt[1] = "pub uni XU[T] { a: T; b: u32; }\npub rec XBox[T] { u: XU[T]; }\n";
     if (ut_ct_lower_diag_n(?xn[0], ?xt[0], 2, "this instantiation makes overlapping fields") != 0) { bad = 1; }
+
+    # the instantiating module names no `^` AT ALL: the secret is written in the
+    # dependency's template and reached only through its field graph, so the rule's own
+    # precondition has to be a deep reach rather than a look for a `^` in this source.
+    var yn: [2]str;
+    yn[0] = "main.mach"; yn[1] = "lib.mach";
+    var yt: [2]str;
+    yt[0] = "use uniontest.lib;\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { var o: lib.YOuter[u32]; o.u.b = 0; ret 0; }\n";
+    yt[1] = "pub uni YU[A, B] { a: A; b: B; }\npub rec YOuter[T] { u: YU[T, ^u32]; }\n";
+    if (ut_ct_lower_diag_n(?yn[0], ?yt[0], 2, "this instantiation makes overlapping fields") != 0) { bad = 1; }
     ret bad;
 }
 

--- a/src/lang/fe/sema.mach
+++ b/src/lang/fe/sema.mach
@@ -820,13 +820,6 @@ fun dnit_context(sc: *context.SemaContext) {
     context.inst_worklist_dnit(sc);
 }
 
-# resolve every syntactic AstType into its interned semantic TypeId
-#
-# Writes type_resolved_ty in source order. A type that fails to resolve becomes
-# TYPE_ERROR (set by resolve_type_ref), so this pass never errors itself.
-# ---
-# sc:  the context
-# ret: always ok
 # the #2225 precondition for a lowering-time deferred body, memoized on the worklist
 #
 # The worklist is owned across one module's lowering, so the module-local reach is
@@ -871,6 +864,13 @@ fun check_annotation_uni_secrecy_all(sc: *context.SemaContext) {
     }
 }
 
+# resolve every syntactic AstType into its interned semantic TypeId
+#
+# Writes type_resolved_ty in source order. A type that fails to resolve becomes
+# TYPE_ERROR (set by resolve_type_ref), so this pass never errors itself.
+# ---
+# sc:  the context
+# ret: always ok
 fun resolve_all_types(sc: *context.SemaContext) R.Result[bool, str] {
     if (sc.type_resolved_ty == nil) { ret R.ok[bool, str](true); }
     var i: u32 = 0;

--- a/src/lang/fe/sema.mach
+++ b/src/lang/fe/sema.mach
@@ -98,6 +98,11 @@ pub fun sema(
     own_module: session.ModuleId
 ) R.Result[context.SemaResult, str] {
     var sc: context.SemaContext;
+    # the #2225 report set lives on the frame for the whole pass: the annotation sweep
+    # below and every per-instance re-validation episode the drain runs share it, so one
+    # ill-formed instantiation reached from several annotations is reported once.
+    var uni_reports: context.UniReports;
+    uni_reports.len = 0;
 
     val res_init: R.Result[bool, str] = init_context(?sc, s, a, rr, deps, ctx, own_module);
     if (R.is_err[bool, str](res_init)) {
@@ -132,6 +137,14 @@ pub fun sema(
     # comparison reads the variants' field tables, which `infer_all_decls` has just
     # finished building, so the rule no longer depends on declaration order.
     infer.check_uni_secrecy_all(?sc);
+
+    # the same rule at every generic INSTANCE this module's annotations reach (#2225).
+    # Shares the placement and its reason: the walk reads field tables, so it runs once
+    # they all exist. Annotations inside a generic body are abstract here and deferred to
+    # the per-instance episodes below, which read them under the concrete substitution.
+    sc.has_secret  = context.session_has_secret(s);
+    sc.uni_reports = ?uni_reports;
+    check_annotation_uni_secrecy_all(?sc);
 
     # install the field / type-comparison resolvers so `comptime.eval` can fold a
     # `$each $fields(T)` body's gates during inference, selecting the live arm
@@ -259,6 +272,12 @@ pub fun reinfer_pack_each_body(
     sc.insts            = insts;
     sc.collect_insts    = true;
     sc.silent           = false;
+    sc.uni_check_fn     = generics.check_annotation_uni_secrecy;
+    # this episode is the sole typing pass over the body, so it carries the #2225 rule
+    # too. The precondition is memoized on the worklist it already owns: recomputing it
+    # per element would rescan the whole type universe once per unrolled copy.
+    sc.uni_reports      = ?insts.uni_reports;
+    sc.has_secret       = context.worklist_has_secret(insts, s);
 
     val res_body: R.Result[bool, str] = infer_stmt_list(?sc, body_start, body_len, fn_ret);
     if (R.is_err[bool, str](res_body)) { ret res_body; }
@@ -345,6 +364,11 @@ pub fun reinfer_pack_instance_body(
     sc.insts            = nil;
     sc.collect_insts    = false;
     sc.silent           = true;
+    # a re-derivation prologue reports nothing, so it runs no #2225 walk either: the same
+    # annotations are walked by the reporting episode that follows.
+    sc.uni_check_fn     = nil;
+    sc.uni_reports      = nil;
+    sc.has_secret       = false;
 
     ret infer_stmt(?sc, body, fn_ret);
 }
@@ -530,8 +554,21 @@ fun revalidate_one(sc: *context.SemaContext, deps: *context.SemaDeps, origin: se
     tsc.insts            = sc.insts;
     tsc.collect_insts    = true;
     tsc.silent           = false;
+    tsc.uni_check_fn     = generics.check_annotation_uni_secrecy;
+    tsc.uni_reports      = sc.uni_reports;
+    tsc.has_secret       = sc.has_secret;
 
     val ret_ty: type.TypeId = context.resolved_type_of(?tsc, d.data.fun_.return_type);
+
+    # the signature is part of this episode's input, not only its body: a parameter typed
+    # `U[T]` that the body never names would otherwise be typed by nobody under the
+    # instance's arguments. The return type is covered by the read above.
+    var pi: u32 = 0;
+    for (pi < d.data.fun_.params_len) {
+        val ptn: *decl.TypedName = ?oa.typed_names[d.data.fun_.params_start + pi];
+        generics.check_annotation_uni_secrecy(?tsc, ptn.ty);
+        pi = pi + 1;
+    }
 
     # fold this body's comptime gates against the origin module via the transient
     # context, then put back whatever was installed. the drain also runs during
@@ -687,6 +724,9 @@ fun init_context(
     sc.insts            = nil;
     sc.collect_insts    = true;
     sc.silent           = false;
+    sc.uni_check_fn     = generics.check_annotation_uni_secrecy;
+    sc.uni_reports      = nil;
+    sc.has_secret       = false;
 
     if (a.expr_len > 0) {
         val res_expr: R.Result[*type.TypeId, str] = typeid_array_alloc(s.alloc, a.expr_len);
@@ -787,6 +827,26 @@ fun dnit_context(sc: *context.SemaContext) {
 # ---
 # sc:  the context
 # ret: always ok
+# apply the #2225 instance union-secrecy rule to every annotation in the module
+#
+# One enumeration of one thing: each syntactic type node, at the substitution the main
+# pass carries (none). Instances the module never spells are still reached, because the
+# walk descends the field graph of the ones it does - `rec Box[T] { u: U[T]; }` at
+# `Box[^u32]` materialises `U[^u32]` inside its own substituted table and never names it.
+# A node that failed to resolve holds TYPE_ERROR (a discarded comptime arm's names are
+# never looked up), which the walk skips - so an untaken `$if` arm stays unchecked.
+# ---
+# sc: the context, with `has_secret` and `uni_reports` already installed
+fun check_annotation_uni_secrecy_all(sc: *context.SemaContext) {
+    if (!sc.has_secret)             { ret; }
+    if (sc.type_resolved_ty == nil) { ret; }
+    var i: u32 = 0;
+    for (i < sc.a.type_len::u32) {
+        generics.check_annotation_uni_secrecy(sc, i);
+        i = i + 1;
+    }
+}
+
 fun resolve_all_types(sc: *context.SemaContext) R.Result[bool, str] {
     if (sc.type_resolved_ty == nil) { ret R.ok[bool, str](true); }
     var i: u32 = 0;

--- a/src/lang/fe/sema.mach
+++ b/src/lang/fe/sema.mach
@@ -142,7 +142,7 @@ pub fun sema(
     # Shares the placement and its reason: the walk reads field tables, so it runs once
     # they all exist. Annotations inside a generic body are abstract here and deferred to
     # the per-instance episodes below, which read them under the concrete substitution.
-    sc.has_secret  = context.session_has_secret(s);
+    sc.has_secret  = generics.module_reaches_secret(s, sc.type_resolved_ty, a.type_len::u32);
     sc.uni_reports = ?uni_reports;
     check_annotation_uni_secrecy_all(?sc);
 
@@ -277,7 +277,7 @@ pub fun reinfer_pack_each_body(
     # too. The precondition is memoized on the worklist it already owns: recomputing it
     # per element would rescan the whole type universe once per unrolled copy.
     sc.uni_reports      = ?insts.uni_reports;
-    sc.has_secret       = context.worklist_has_secret(insts, s);
+    sc.has_secret       = worklist_reaches_secret(insts, s, a, sema_result);
 
     val res_body: R.Result[bool, str] = infer_stmt_list(?sc, body_start, body_len, fn_ret);
     if (R.is_err[bool, str](res_body)) { ret res_body; }
@@ -827,6 +827,30 @@ fun dnit_context(sc: *context.SemaContext) {
 # ---
 # sc:  the context
 # ret: always ok
+# the #2225 precondition for a lowering-time deferred body, memoized on the worklist
+#
+# The worklist is owned across one module's lowering, so the module-local reach is
+# computed once rather than per unrolled copy - a `$each` body is re-typed per element,
+# per instance, and each rescan would walk the whole annotation table again. Sound to
+# memoize: lowering resolves no new annotations, so the module's reach does not move.
+# ---
+# wl:          the worklist owning the memo
+# s:           the session
+# a:           the origin module's Ast
+# sema_result: the origin module's SemaResult (its resolved-annotation table)
+# ret:         true when some annotation of the origin module reaches a `^`
+fun worklist_reaches_secret(wl: *context.InstWorklist, s: *session.Session, a: *ast.Ast,
+                            sema_result: *context.SemaResult) bool {
+    if (wl == nil) { ret generics.module_reaches_secret(s, sema_result.type_resolved_ty, a.type_len::u32); }
+    if (wl.secret_state == context.SECRET_UNKNOWN) {
+        wl.secret_state = context.SECRET_ABSENT;
+        if (generics.module_reaches_secret(s, sema_result.type_resolved_ty, a.type_len::u32)) {
+            wl.secret_state = context.SECRET_PRESENT;
+        }
+    }
+    ret wl.secret_state == context.SECRET_PRESENT;
+}
+
 # apply the #2225 instance union-secrecy rule to every annotation in the module
 #
 # One enumeration of one thing: each syntactic type node, at the substitution the main

--- a/src/lang/fe/sema/context.mach
+++ b/src/lang/fe/sema/context.mach
@@ -158,7 +158,7 @@ val UNI_REPORT_CAP: u32 = 256;
 # seen: the interned instance TypeIds already reported
 # len:  number of entries
 pub rec UniReports {
-    seen: [256]type.TypeId;
+    seen: [UNI_REPORT_CAP]type.TypeId;
     len:  u32;
 }
 
@@ -182,8 +182,6 @@ pub fun uni_report_mark(ur: *UniReports, key: type.TypeId) bool {
     ur.len = ur.len + 1;
     ret true;
 }
-
-
 
 # sema's working state for one module analysis
 #

--- a/src/lang/fe/sema/context.mach
+++ b/src/lang/fe/sema/context.mach
@@ -126,6 +126,102 @@ pub rec InstWorklist {
     cap:     u32;
     drained: u32;
     alloc:   *A.Allocator;
+
+    # the #2225 rule's state for the episodes this worklist drives, so a lowering-time
+    # deferred body - which builds its own context per element, per instance - shares one
+    # report set and pays for the `^`-precondition scan once rather than per unrolled copy.
+    uni_reports:  UniReports;
+    secret_state: u8;
+}
+
+# `secret_state` values: the precondition has not been computed, or its answer
+val SECRET_UNKNOWN: u8 = 0;
+val SECRET_ABSENT:  u8 = 1;
+val SECRET_PRESENT: u8 = 2;
+
+# the `^`-precondition for the worklist's episodes, computed once and memoized (#2225)
+#
+# Sound to cache: substitution can only re-wrap a `^` that already exists, and lowering
+# resolves no new annotations, so an absent secret never becomes present after the first
+# episode this worklist drives.
+# ---
+# wl:  the worklist owning the memo
+# s:   the session (its type universe)
+# ret: true when the program uses the secret qualifier anywhere
+pub fun worklist_has_secret(wl: *InstWorklist, s: *session.Session) bool {
+    if (wl == nil) { ret session_has_secret(s); }
+    if (wl.secret_state == SECRET_UNKNOWN) {
+        wl.secret_state = SECRET_ABSENT;
+        if (session_has_secret(s)) { wl.secret_state = SECRET_PRESENT; }
+    }
+    ret wl.secret_state == SECRET_PRESENT;
+}
+
+# the number of distinct mixed-secrecy generic union instances one analysis remembers
+# having reported (#2225)
+val UNI_REPORT_CAP: u32 = 256;
+
+# the set of generic union instances already reported as mixed-secrecy (#2225)
+#
+# The rule is a property of a TYPE, not of a mention: `resolve_type_ref` is not memoized
+# and `def_underlying` re-resolves an alias per use, so one bad instantiation is reached
+# from two or three annotations and a naive check reports it that many times. Keyed by
+# the interned TYPE_INSTANCE the violating (nominal, arguments) pair denotes, so every
+# route to the same ill-formed type collapses to one diagnostic.
+#
+# Owned by the module's analysis and shared BY POINTER into every per-instance
+# re-validation episode it drives, so the sweep and the episodes dedupe against one set.
+# Past the cap it stops deduping and reports again - loud, never silent.
+# ---
+# seen: the interned instance TypeIds already reported
+# len:  number of entries
+pub rec UniReports {
+    seen: [256]type.TypeId;
+    len:  u32;
+}
+
+# record `key` as reported, answering whether this is its first report (#2225)
+#
+# A nil set (an episode that owns none) answers true every time: duplicate diagnostics
+# are a nuisance, a dropped one is a leak.
+# ---
+# ur:  the report set, or nil
+# key: the interned instance TypeId identifying the violation
+# ret: true when the caller should emit the diagnostic
+pub fun uni_report_mark(ur: *UniReports, key: type.TypeId) bool {
+    if (ur == nil) { ret true; }
+    var i: u32 = 0;
+    for (i < ur.len) {
+        if (ur.seen[i] == key) { ret false; }
+        i = i + 1;
+    }
+    if (ur.len >= UNI_REPORT_CAP) { ret true; }
+    ur.seen[ur.len] = key;
+    ur.len = ur.len + 1;
+    ret true;
+}
+
+# whether the type universe holds a secret `^` at all (#2225)
+#
+# The mixed-secrecy union rule can only fire where a `^` exists, so a program that never
+# writes one needs neither the per-annotation instance walk nor the widened
+# re-validation recording that feeds it. Every `^` a module can reach is interned by
+# `resolve_all_types` (its own and, by dependency order, every dependency's) before any
+# body is inferred, and substitution only ever re-wraps an existing one - so a false
+# answer here cannot become true later for any instance this pass records.
+# ---
+# s:   the session (its type universe)
+# ret: true when any interned type is a `^` qualifier
+pub fun session_has_secret(s: *session.Session) bool {
+    var i: u32 = 0;
+    for (i < s.types.type_len) {
+        val t_opt: O.Option[*type.Type] = type.get(?s.types, i);
+        if (O.is_some[*type.Type](t_opt)) {
+            if (O.unwrap[*type.Type](t_opt).kind == type.TYPE_SECRET) { ret true; }
+        }
+        i = i + 1;
+    }
+    ret false;
 }
 
 
@@ -213,6 +309,18 @@ pub rec SemaContext {
     subst:     *type.TypeId;
     subst_len: u32;
     subst_fn:  fun(*session.Session, type.TypeId, *type.TypeId, u32) type.TypeId;
+
+    # the mixed-secrecy union rule at a generic INSTANCE (#2225). `uni_check_fn` is
+    # `generics.check_annotation_uni_secrecy` behind a function pointer, for the same
+    # reason `subst_fn` is: this module is generics' dependency, not its dependent. It
+    # runs from `resolved_type_of` on every annotation an INSTANCE episode reads (where
+    # the substitution is what makes a union mixed); the module's own annotations are
+    # swept once by `sema` after decl inference, when every field table exists.
+    # `uni_reports` dedupes across the sweep and every episode it drives; `has_secret`
+    # is the whole rule's precondition, so a `^`-free program pays nothing.
+    uni_check_fn: fun(*SemaContext, id.TypeId);
+    uni_reports:  *UniReports;
+    has_secret:   bool;
 }
 
 # the interned semantic TypeId a syntactic AstType resolved to
@@ -227,6 +335,15 @@ pub fun resolved_type_of(sc: *SemaContext, ast_tid: id.TypeId) type.TypeId {
     if (ast_tid == id.TYPE_NIL)        { ret type.TYPE_NIL; }
     if (sc.type_resolved_ty == nil)    { ret type.TYPE_ERROR; }
     if (ast_tid >= sc.a.type_len::u32) { ret type.TYPE_ERROR; }
+    # #2225: an annotation read under a substitution is the one place a union that
+    # agreed at the template can turn mixed, so the instance rule runs here rather than
+    # off the module sweep, which sees only the un-substituted `{T, u32}` and agrees.
+    # The check reads the PRISTINE table itself and applies the substitution once, the
+    # #2254 rule: substituting the value below would compose onto an already-derived
+    # slot. Off on the main pass, whose annotations the post-decl sweep covers.
+    if (sc.has_secret && sc.subst != nil && sc.uni_check_fn != nil) {
+        sc.uni_check_fn(sc, ast_tid);
+    }
     ret apply_subst(sc, sc.type_resolved_ty[ast_tid]);
 }
 
@@ -386,6 +503,16 @@ pub fun record_instance(sc: *SemaContext, origin: session.ModuleId, decl: id.Dec
     var i: u32 = 0;
     for (i < arg_len) {
         if (arg_triggers_revalidation(sc, args[i])) { any = true; }
+        # #2225: `arg_triggers_revalidation` asks whether the ARGUMENT can reach a
+        # secret, which is the right question for every gate that needs the secret to
+        # arrive through the call. A union's variants can disagree without that: in
+        # `fun f[T]() { var u: U[T, ^u32]; }` the secret is written in the TEMPLATE and
+        # a plain `u32` argument is what makes the pair mixed. So any argument that is
+        # concrete at all records the instance once the program uses `^` anywhere - an
+        # abstract one still says nothing, and its concrete forms arrive through the
+        # enclosing instance's own re-validation.
+        if (sc.has_secret && args[i] != type.TYPE_ERROR && args[i] != type.TYPE_NIL
+            && !type_mentions_generic_param(sc, args[i])) { any = true; }
         i = i + 1;
     }
     if (!any) { ret R.ok[bool, str](true); }
@@ -448,11 +575,13 @@ pub fun inst_worklist_new(alloc: *A.Allocator) R.Result[*InstWorklist, str] {
     val wr: R.Result[*InstWorklist, str] = A.allocate[InstWorklist](alloc, 1::usize);
     if (R.is_err[*InstWorklist, str](wr)) { ret R.err[*InstWorklist, str]("internal: out of memory allocating the constant-time re-validation worklist"); }
     val wl: *InstWorklist = R.unwrap_ok[*InstWorklist, str](wr);
-    wl.items   = nil;
-    wl.len     = 0;
-    wl.cap     = 0;
-    wl.drained = 0;
-    wl.alloc   = alloc;
+    wl.items            = nil;
+    wl.len              = 0;
+    wl.cap              = 0;
+    wl.drained          = 0;
+    wl.alloc            = alloc;
+    wl.uni_reports.len  = 0;
+    wl.secret_state     = SECRET_UNKNOWN;
     ret R.ok[*InstWorklist, str](wl);
 }
 

--- a/src/lang/fe/sema/context.mach
+++ b/src/lang/fe/sema/context.mach
@@ -135,27 +135,9 @@ pub rec InstWorklist {
 }
 
 # `secret_state` values: the precondition has not been computed, or its answer
-val SECRET_UNKNOWN: u8 = 0;
-val SECRET_ABSENT:  u8 = 1;
-val SECRET_PRESENT: u8 = 2;
-
-# the `^`-precondition for the worklist's episodes, computed once and memoized (#2225)
-#
-# Sound to cache: substitution can only re-wrap a `^` that already exists, and lowering
-# resolves no new annotations, so an absent secret never becomes present after the first
-# episode this worklist drives.
-# ---
-# wl:  the worklist owning the memo
-# s:   the session (its type universe)
-# ret: true when the program uses the secret qualifier anywhere
-pub fun worklist_has_secret(wl: *InstWorklist, s: *session.Session) bool {
-    if (wl == nil) { ret session_has_secret(s); }
-    if (wl.secret_state == SECRET_UNKNOWN) {
-        wl.secret_state = SECRET_ABSENT;
-        if (session_has_secret(s)) { wl.secret_state = SECRET_PRESENT; }
-    }
-    ret wl.secret_state == SECRET_PRESENT;
-}
+pub val SECRET_UNKNOWN: u8 = 0;
+pub val SECRET_ABSENT:  u8 = 1;
+pub val SECRET_PRESENT: u8 = 2;
 
 # the number of distinct mixed-secrecy generic union instances one analysis remembers
 # having reported (#2225)
@@ -201,28 +183,6 @@ pub fun uni_report_mark(ur: *UniReports, key: type.TypeId) bool {
     ret true;
 }
 
-# whether the type universe holds a secret `^` at all (#2225)
-#
-# The mixed-secrecy union rule can only fire where a `^` exists, so a program that never
-# writes one needs neither the per-annotation instance walk nor the widened
-# re-validation recording that feeds it. Every `^` a module can reach is interned by
-# `resolve_all_types` (its own and, by dependency order, every dependency's) before any
-# body is inferred, and substitution only ever re-wraps an existing one - so a false
-# answer here cannot become true later for any instance this pass records.
-# ---
-# s:   the session (its type universe)
-# ret: true when any interned type is a `^` qualifier
-pub fun session_has_secret(s: *session.Session) bool {
-    var i: u32 = 0;
-    for (i < s.types.type_len) {
-        val t_opt: O.Option[*type.Type] = type.get(?s.types, i);
-        if (O.is_some[*type.Type](t_opt)) {
-            if (O.unwrap[*type.Type](t_opt).kind == type.TYPE_SECRET) { ret true; }
-        }
-        i = i + 1;
-    }
-    ret false;
-}
 
 
 # sema's working state for one module analysis

--- a/src/lang/fe/sema/generics.mach
+++ b/src/lang/fe/sema/generics.mach
@@ -28,6 +28,7 @@ use R: std.types.result;
 use mach.lang.fe.ast;
 use mach.lang.fe.ast.decl;
 use mach.lang.fe.ast.id;
+use atype: mach.lang.fe.ast.type;
 use sema: mach.lang.fe.sema.context;
 use mach.lang.fe.token;
 use mach.lang.intern;
@@ -570,6 +571,344 @@ fun all_secret_walk(s: *session.Session, tid: type.TypeId, scan: *type.SecretSca
     ret false;
 }
 
+# the (nominal, argument-list) pairs entered during one instance union-secrecy walk
+#
+# Keyed by the interned TYPE_INSTANCE the pair denotes, so the same nominal reached
+# under two different argument lists is examined twice (`rec P[T] { a: U[T]; b: U[u32]; }`)
+# while a recursive generic (`rec Node[T] { next: *Node[T]; }`) terminates on its second
+# entry. A graph past the bound fails CLOSED - it reports rather than returning "no
+# violation", which padding the graph would otherwise exploit.
+# ---
+# seen:          the (nominal, args) keys already entered
+# len:           number of entries
+# bound_reported: true once the depth bound has been reported on this walk
+rec UniInstScan {
+    seen:           [256]type.TypeId;
+    len:            u32;
+    bound_reported: bool;
+}
+
+# the mixed-secrecy union rule at a generic INSTANCE, run over one annotation (#2225)
+#
+# `check_uni_secrecy` runs at the union DECLARATION, where a variant typed by a generic
+# parameter is a public leaf and `uni U[T] { a: T; b: u32 }` honestly agrees. The
+# violation exists only after substitution, which never re-resolves the declaration - so
+# `U[^u32]` compiled clean while its non-generic twin was a hard error.
+#
+# This walks the annotation's PRISTINE resolved type carrying the episode's substitution,
+# rather than the substituted type, for two reasons. A substituted value has already lost
+# the template structure the rule needs (an anonymous `uni {ok: T; err: E}` becomes a
+# TYPE_INSTANCE whose `MODULE_NIL` nominal no classification can recover, which is how
+# mach-std's `Result` escaped every guard keyed on "is this instance a union"); and a
+# derived slot cannot say how many substitutions it has absorbed (#2254). Carrying the
+# substitution instead means every union is met as a NOMINAL, whose rec/uni kind is its
+# own, named or anonymous alike.
+# ---
+# sc:      the active sema context (its substitution, report set, and diagnostic sink)
+# ast_tid: the syntactic annotation being read
+pub fun check_annotation_uni_secrecy(sc: *sema.SemaContext, ast_tid: id.TypeId) {
+    if (!sc.has_secret)             { ret; }
+    if (sc.type_resolved_ty == nil) { ret; }
+    if (ast_tid >= sc.a.type_len::u32) { ret; }
+
+    val t_opt: O.Option[*atype.Type] = ast.get_type(sc.a, ast_tid);
+    if (O.is_none[*atype.Type](t_opt)) { ret; }
+
+    check_type_uni_secrecy(sc, sc.type_resolved_ty[ast_tid], sc.subst, sc.subst_len,
+                           O.unwrap[*atype.Type](t_opt).span);
+}
+
+# the mixed-secrecy union rule over one pristine type under an explicit substitution
+# ---
+# sc:      the active sema context (report set and diagnostic sink)
+# tid:     the pristine resolved type to walk
+# args:    the substitution to carry, or nil
+# arg_len: number of substitution arguments
+# span:    the source range every diagnostic this walk raises is anchored at
+pub fun check_type_uni_secrecy(sc: *sema.SemaContext, tid: type.TypeId, args: *type.TypeId,
+                               arg_len: u32, span: token.Span) {
+    if (!sc.has_secret) { ret; }
+    if (tid == type.TYPE_NIL || tid == type.TYPE_ERROR) { ret; }
+
+    var scan: UniInstScan;
+    scan.len            = 0;
+    scan.bound_reported = false;
+    uni_inst_walk(sc, tid, args, arg_len, ?scan, span);
+}
+
+# the recursive worker: descend `tid` carrying `args`, checking every union nominal
+#
+# Structural, not spine-only: a pointer, an array, a function SIGNATURE (a `Box[T]` whose
+# field is `fun(*U[T]) u32` materializes `U[^u32]` in that signature and nowhere else),
+# and every field of every aggregate. A generic-parameter leaf terminates because the
+# instantiation that bound it walks each argument in its own right, so nothing is missed
+# by not re-entering through the binding.
+fun uni_inst_walk(sc: *sema.SemaContext, tid: type.TypeId, args: *type.TypeId, arg_len: u32,
+                  scan: *UniInstScan, span: token.Span) {
+    if (tid == type.TYPE_NIL || tid == type.TYPE_ERROR) { ret; }
+    val s: *session.Session = sc.s;
+
+    val opt_t: O.Option[*type.Type] = type.get(?s.types, tid);
+    if (O.is_none[*type.Type](opt_t)) { ret; }
+    val t: *type.Type = O.unwrap[*type.Type](opt_t);
+    val k: type.TypeKind = t.kind;
+
+    # a parameter's binding argument is walked at the instantiation that supplies it.
+    if (k == type.TYPE_GENERIC_PARAM) { ret; }
+
+    # the spine cases read their base out of `t` BEFORE recursing: interning inside the
+    # recursion grows the type array and invalidates the borrow.
+    if (k == type.TYPE_SECRET) {
+        val base: type.TypeId = t.data.secret.base;
+        uni_inst_walk(sc, base, args, arg_len, scan, span);
+        ret;
+    }
+    if (k == type.TYPE_POINTER) {
+        val base: type.TypeId = t.data.pointer.base;
+        uni_inst_walk(sc, base, args, arg_len, scan, span);
+        ret;
+    }
+    if (k == type.TYPE_ARRAY) {
+        val base: type.TypeId = t.data.array.base;
+        uni_inst_walk(sc, base, args, arg_len, scan, span);
+        ret;
+    }
+
+    if (k == type.TYPE_FUN) {
+        val ret_ty:       type.TypeId = t.data.fn.ret_type;
+        val params_start: u32         = t.data.fn.params_start;
+        val params_len:   u32         = t.data.fn.params_len;
+        uni_inst_walk(sc, ret_ty, args, arg_len, scan, span);
+        var i: u32 = 0;
+        for (i < params_len) {
+            val p_opt: O.Option[type.TypeId] = type.get_param(?s.types, params_start + i);
+            if (O.is_some[type.TypeId](p_opt)) {
+                uni_inst_walk(sc, O.unwrap[type.TypeId](p_opt), args, arg_len, scan, span);
+            }
+            i = i + 1;
+        }
+        ret;
+    }
+
+    if (k == type.TYPE_INSTANCE) {
+        uni_inst_walk_instance(sc, tid, args, arg_len, scan, span);
+        ret;
+    }
+    if (k == type.TYPE_REC || k == type.TYPE_UNI) {
+        uni_inst_walk_nominal(sc, tid, args, arg_len, scan, span);
+        ret;
+    }
+}
+
+# descend a `Name[...]` instance: walk each argument, then the nominal it specializes
+# under those arguments composed with the incoming substitution
+#
+# The argument list is copied out of the param pool before anything else runs:
+# substitution appends to that pool and would invalidate a borrowed read.
+fun uni_inst_walk_instance(sc: *sema.SemaContext, tid: type.TypeId, args: *type.TypeId,
+                           arg_len: u32, scan: *UniInstScan, span: token.Span) {
+    val s: *session.Session = sc.s;
+
+    val opt_t: O.Option[*type.Type] = type.get(?s.types, tid);
+    if (O.is_none[*type.Type](opt_t)) { ret; }
+    val t: *type.Type = O.unwrap[*type.Type](opt_t);
+    val origin:     session.ModuleId = t.data.instance.target_origin;
+    val decl_id:    id.DeclId        = t.data.instance.target_decl;
+    val args_start: u32              = t.data.instance.args_start;
+    val args_len:   u32              = t.data.instance.args_len;
+
+    if (args_len == 0) { ret; }
+
+    val res_raw: R.Result[*type.TypeId, str] = A.allocate[type.TypeId](s.alloc, args_len::usize);
+    if (R.is_err[*type.TypeId, str](res_raw)) { ret; }
+    val raw: *type.TypeId = R.unwrap_ok[*type.TypeId, str](res_raw);
+
+    var i: u32 = 0;
+    for (i < args_len) {
+        val a_opt: O.Option[type.TypeId] = type.get_param(?s.types, args_start + i);
+        if (O.is_none[type.TypeId](a_opt)) {
+            A.deallocate[type.TypeId](s.alloc, raw, args_len::usize);
+            ret;
+        }
+        raw[i] = O.unwrap[type.TypeId](a_opt);
+        i = i + 1;
+    }
+
+    # each argument in its own right: an anonymous union written as a type argument is a
+    # NOMINAL here, so it is classified and checked like any other.
+    i = 0;
+    for (i < args_len) {
+        uni_inst_walk(sc, raw[i], args, arg_len, scan, span);
+        i = i + 1;
+    }
+
+    # a pristine annotation can only spell `Name[...]` over a NAMED declaration, so the
+    # nominal always resolves; an unresolvable one means a derived type reached this walk
+    # and the template structure the rule needs is already gone. Reported, never skipped.
+    val gnom: type.TypeId = generic_nominal_of(s, origin, decl_id);
+    if (gnom == type.TYPE_ERROR) {
+        sema.report(sc, span, "internal: #2225 union-secrecy instance walk: generic instance target declaration unavailable (pristine-type invariant violated)");
+        A.deallocate[type.TypeId](s.alloc, raw, args_len::usize);
+        ret;
+    }
+
+    val res_conc: R.Result[*type.TypeId, str] = A.allocate[type.TypeId](s.alloc, args_len::usize);
+    if (R.is_err[*type.TypeId, str](res_conc)) {
+        A.deallocate[type.TypeId](s.alloc, raw, args_len::usize);
+        ret;
+    }
+    val conc: *type.TypeId = R.unwrap_ok[*type.TypeId, str](res_conc);
+
+    i = 0;
+    for (i < args_len) {
+        conc[i] = subst_or_self(s, raw[i], args, arg_len);
+        i = i + 1;
+    }
+
+    uni_inst_walk_nominal(sc, gnom, conc, args_len, scan, span);
+
+    A.deallocate[type.TypeId](s.alloc, conc, args_len::usize);
+    A.deallocate[type.TypeId](s.alloc, raw, args_len::usize);
+}
+
+# check (when it is a union) and descend one nominal under `args`
+#
+# A nominal whose field graph mentions no generic parameter is fully concrete: its
+# arguments are irrelevant to it, and its own declaration-site check already owns it, so
+# it is walked once with no substitution and never re-reported here.
+fun uni_inst_walk_nominal(sc: *sema.SemaContext, nom: type.TypeId, args: *type.TypeId,
+                          arg_len: u32, scan: *UniInstScan, span: token.Span) {
+    val s: *session.Session = sc.s;
+
+    var a: *type.TypeId = args;
+    var n: u32          = arg_len;
+    val generic: bool   = nominal_has_gparam(s, nom);
+    if (!generic) {
+        a = nil;
+        n = 0;
+    }
+
+    val key: type.TypeId = nominal_visit_key(s, nom, a, n);
+    var i: u32 = 0;
+    for (i < scan.len) {
+        if (scan.seen[i] == key) { ret; }
+        i = i + 1;
+    }
+    if (scan.len >= 256) {
+        if (!scan.bound_reported) {
+            scan.bound_reported = true;
+            sema.report(sc, span, "constant-time: this type's graph is too large to prove that every generic union it reaches has variants agreeing on secrecy");
+        }
+        ret;
+    }
+    scan.seen[scan.len] = key;
+    scan.len = scan.len + 1;
+
+    val opt_nom: O.Option[*type.Type] = type.get(?s.types, nom);
+    if (O.is_none[*type.Type](opt_nom)) { ret; }
+    if (generic && O.unwrap[*type.Type](opt_nom).kind == type.TYPE_UNI) {
+        check_uni_variants(sc, nom, a, n, key, span);
+    }
+
+    val opt_tab: O.Option[*type.FieldTable] = type.field_table_for(?s.types, nom);
+    if (O.is_none[*type.FieldTable](opt_tab)) { ret; }
+    val fields_len: u32 = O.unwrap[*type.FieldTable](opt_tab).fields_len;
+
+    # the entry is re-fetched every step and its type copied out before recursing: the
+    # walk below materializes instance field tables, which grows the field pool.
+    var f: u32 = 0;
+    for (f < fields_len) {
+        val e_opt: O.Option[*type.FieldEntry] = type.field_at(?s.types, nom, f);
+        if (O.is_some[*type.FieldEntry](e_opt)) {
+            val fty: type.TypeId = O.unwrap[*type.FieldEntry](e_opt).ty;
+            uni_inst_walk(sc, fty, a, n, scan, span);
+        }
+        f = f + 1;
+    }
+}
+
+# report when union nominal `nom`'s variants disagree on secrecy once `args` is applied
+#
+# Deferred - not rejected - while any variant still mentions a generic parameter, so a
+# partially concrete template like `uni U[A, B]` written `U[T, ^u32]` inside a generic
+# stays legal: it has legal instantiations (`Outer[^u32]`) and illegal ones
+# (`Outer[u32]`), and each is decided when it is actually formed.
+fun check_uni_variants(sc: *sema.SemaContext, nom: type.TypeId, args: *type.TypeId,
+                       arg_len: u32, key: type.TypeId, span: token.Span) {
+    val s: *session.Session = sc.s;
+
+    val opt_tab: O.Option[*type.FieldTable] = type.field_table_for(?s.types, nom);
+    if (O.is_none[*type.FieldTable](opt_tab)) { ret; }
+    val fields_len: u32 = O.unwrap[*type.FieldTable](opt_tab).fields_len;
+    if (fields_len < 2) { ret; }
+
+    val first_opt: O.Option[*type.FieldEntry] = type.field_at(?s.types, nom, 0);
+    if (O.is_none[*type.FieldEntry](first_opt)) { ret; }
+    val first_raw: type.TypeId = O.unwrap[*type.FieldEntry](first_opt).ty;
+    val first:     type.TypeId = subst_or_self(s, first_raw, args, arg_len);
+    if (type_mentions_gparam(s, first)) { ret; }
+
+    var i: u32 = 1;
+    for (i < fields_len) {
+        val e_opt: O.Option[*type.FieldEntry] = type.field_at(?s.types, nom, i);
+        if (O.is_none[*type.FieldEntry](e_opt)) { ret; }
+        val raw: type.TypeId = O.unwrap[*type.FieldEntry](e_opt).ty;
+        val ty:  type.TypeId = subst_or_self(s, raw, args, arg_len);
+        if (type_mentions_gparam(s, ty)) { ret; }
+        if (!secrecy_structure_equal_deep(s, first, ty)) {
+            if (sema.uni_report_mark(sc.uni_reports, key)) {
+                sema.report(sc, span, "union variants must agree on secrecy: this instantiation makes overlapping fields part secret `^` and part public, which would alias the same storage at two classifications");
+            }
+            ret;
+        }
+        i = i + 1;
+    }
+}
+
+# the interned TYPE_INSTANCE that identifies visiting `nom` under `args`
+#
+# The bare nominal identifies itself when no substitution is carried. A failure to intern
+# degrades to the nominal, which can only make the walk stop early on a graph the
+# allocator has already failed on.
+fun nominal_visit_key(s: *session.Session, nom: type.TypeId, args: *type.TypeId, arg_len: u32) type.TypeId {
+    if (args == nil || arg_len == 0) { ret nom; }
+
+    val opt_nom: O.Option[*type.Type] = type.get(?s.types, nom);
+    if (O.is_none[*type.Type](opt_nom)) { ret nom; }
+    val t: *type.Type = O.unwrap[*type.Type](opt_nom);
+    if (t.kind != type.TYPE_REC && t.kind != type.TYPE_UNI) { ret nom; }
+    val origin:  session.ModuleId = t.data.nominal.origin;
+    val decl_id: id.DeclId        = t.data.nominal.decl;
+
+    val r: R.Result[type.TypeId, str] = type.intern_instance(?s.types, origin, decl_id, args, arg_len);
+    if (R.is_err[type.TypeId, str](r)) { ret nom; }
+    ret R.unwrap_ok[type.TypeId, str](r);
+}
+
+# `substitute`, or the type unchanged when no substitution is carried
+#
+# `substitute` maps a generic parameter through an EMPTY argument list to the poison
+# type; the walk needs the template type back instead, so the abstract-variant deferral
+# below sees a parameter rather than an error.
+fun subst_or_self(s: *session.Session, tid: type.TypeId, args: *type.TypeId, arg_len: u32) type.TypeId {
+    if (args == nil || arg_len == 0) { ret tid; }
+    ret substitute(s, tid, args, arg_len);
+}
+
+# whether `tid` is, or structurally contains, a generic parameter (owning the cycle guard)
+fun type_mentions_gparam(s: *session.Session, tid: type.TypeId) bool {
+    var scan: GParamScan;
+    scan.visited = nil;
+    scan.len     = 0;
+    scan.cap     = 0;
+
+    val mentioned: bool = mentions_gparam(s, tid, ?scan);
+    if (scan.visited != nil && scan.cap > 0) {
+        A.deallocate[type.TypeId](s.alloc, scan.visited, scan.cap::usize);
+    }
+    ret mentioned;
+}
+
 # resolve the generic nominal TypeId that instance `(origin, gdecl)` specializes
 #
 # Reads the nominal's name and rec/uni kind from the declaration in its origin
@@ -930,6 +1269,24 @@ fun mentions_gparam(s: *session.Session, tid: type.TypeId, scan: *GParamScan) bo
     if (t.kind == type.TYPE_ARRAY)         { ret mentions_gparam(s, t.data.array.base, scan); }
     if (t.kind == type.TYPE_REC || t.kind == type.TYPE_UNI) {
         ret nominal_fields_mention(s, tid, scan);
+    }
+
+    # a SIGNATURE is a position like any other: `rec Box[T] { f: fun(*U[T]) u32; }`
+    # mentions `T` only there, and a walk that stopped at the arrow called `Box` fully
+    # concrete - leaving a nested aggregate unspecialized, and hiding the `U[^u32]` the
+    # instance really materialises from the #2225 union rule (#2168 constraint 4).
+    if (t.kind == type.TYPE_FUN) {
+        val ret_ty:       type.TypeId = t.data.fn.ret_type;
+        val params_start: u32         = t.data.fn.params_start;
+        val params_len:   u32         = t.data.fn.params_len;
+        if (mentions_gparam(s, ret_ty, scan)) { ret true; }
+        var i: u32 = 0;
+        for (i < params_len) {
+            val p_opt: O.Option[type.TypeId] = type.get_param(?s.types, params_start + i);
+            if (O.is_some[type.TypeId](p_opt) && mentions_gparam(s, O.unwrap[type.TypeId](p_opt), scan)) { ret true; }
+            i = i + 1;
+        }
+        ret false;
     }
 
     if (t.kind == type.TYPE_INSTANCE) {

--- a/src/lang/fe/sema/generics.mach
+++ b/src/lang/fe/sema/generics.mach
@@ -571,6 +571,9 @@ fun all_secret_walk(s: *session.Session, tid: type.TypeId, scan: *type.SecretSca
     ret false;
 }
 
+# the number of distinct (nominal, arguments) pairs one walk enters before failing closed
+val UNI_SCAN_CAP: u32 = 256;
+
 # the (nominal, argument-list) pairs entered during one instance union-secrecy walk
 #
 # Keyed by the interned TYPE_INSTANCE the pair denotes, so the same nominal reached
@@ -583,7 +586,7 @@ fun all_secret_walk(s: *session.Session, tid: type.TypeId, scan: *type.SecretSca
 # len:                 number of entries
 # unprovable_reported: true once this walk's fail-closed exit has been reported
 rec UniInstScan {
-    seen:                [256]type.TypeId;
+    seen:                [UNI_SCAN_CAP]type.TypeId;
     len:                 u32;
     unprovable_reported: bool;
 }
@@ -598,10 +601,9 @@ rec UniInstScan {
 # contents, and so is a function of this module and its dependencies alone. Reading the
 # universe instead would make a module's diagnostics depend on which unrelated modules
 # had been analysed first, which is not a property a cached per-module result may have.
-# The reach is DEEP (`contains_secret_deep`), so a `^` that only a dependency's template
-# writes - `Outer[T]` whose field is `U[T, ^u32]` - is found through the field graph.
-# Call it once the field tables exist, or every unresolvable nominal fails closed and the
-# answer is a uniform yes.
+# The reach is DEEP, so a `^` that only a dependency's template writes - `Outer[T]` whose
+# field is `U[T, ^u32]` - is found through the field graph. Call it once the field tables
+# exist, or every unresolvable nominal fails closed and the answer is a uniform yes.
 # ---
 # s:        the session
 # resolved: the module's `type_resolved_ty` table
@@ -955,7 +957,7 @@ fun uni_inst_walk_nominal(sc: *sema.SemaContext, nom: type.TypeId, args: *type.T
     }
     # a graph past the bound FAILS CLOSED: it reports rather than answering "no
     # violation", which padding the graph past the bound would otherwise exploit.
-    if (scan.len >= 256) {
+    if (scan.len >= UNI_SCAN_CAP) {
         report_unprovable(sc, scan, span);
         ret;
     }

--- a/src/lang/fe/sema/generics.mach
+++ b/src/lang/fe/sema/generics.mach
@@ -579,13 +579,13 @@ fun all_secret_walk(s: *session.Session, tid: type.TypeId, scan: *type.SecretSca
 # entry. A graph past the bound fails CLOSED - it reports rather than returning "no
 # violation", which padding the graph would otherwise exploit.
 # ---
-# seen:          the (nominal, args) keys already entered
-# len:           number of entries
-# bound_reported: true once the depth bound has been reported on this walk
+# seen:                the (nominal, args) keys already entered
+# len:                 number of entries
+# unprovable_reported: true once this walk's fail-closed exit has been reported
 rec UniInstScan {
-    seen:           [256]type.TypeId;
-    len:            u32;
-    bound_reported: bool;
+    seen:                [256]type.TypeId;
+    len:                 u32;
+    unprovable_reported: bool;
 }
 
 # whether any type this module names reaches a secret `^` (#2225)
@@ -772,8 +772,8 @@ pub fun check_type_uni_secrecy(sc: *sema.SemaContext, tid: type.TypeId, args: *t
     if (tid == type.TYPE_NIL || tid == type.TYPE_ERROR) { ret; }
 
     var scan: UniInstScan;
-    scan.len            = 0;
-    scan.bound_reported = false;
+    scan.len                 = 0;
+    scan.unprovable_reported = false;
     uni_inst_walk(sc, tid, args, arg_len, ?scan, span);
 }
 
@@ -921,6 +921,24 @@ fun uni_inst_walk_nominal(sc: *sema.SemaContext, nom: type.TypeId, args: *type.T
                           arg_len: u32, scan: *UniInstScan, span: token.Span) {
     val s: *session.Session = sc.s;
 
+    # FAIL CLOSED on an unresolvable layout, before anything is decided from it. Every
+    # `rec` / `uni` its declaring module typed has a table (`build_field_table` opens one
+    # even at zero fields), so a missing one means the layout this rule reads is simply
+    # not there - and every question below would then answer "no violation": not generic,
+    # no variants, no fields to descend. Three separate bypasses off one absent table.
+    val opt_nom: O.Option[*type.Type] = type.get(?s.types, nom);
+    if (O.is_none[*type.Type](opt_nom)) {
+        report_unprovable(sc, scan, span);
+        ret;
+    }
+    val nom_kind: type.TypeKind = O.unwrap[*type.Type](opt_nom).kind;
+    val opt_tab: O.Option[*type.FieldTable] = type.field_table_for(?s.types, nom);
+    if (O.is_none[*type.FieldTable](opt_tab)) {
+        report_unprovable(sc, scan, span);
+        ret;
+    }
+    val fields_len: u32 = O.unwrap[*type.FieldTable](opt_tab).fields_len;
+
     var a: *type.TypeId = args;
     var n: u32          = arg_len;
     val generic: bool   = nominal_has_gparam(s, nom);
@@ -935,37 +953,44 @@ fun uni_inst_walk_nominal(sc: *sema.SemaContext, nom: type.TypeId, args: *type.T
         if (scan.seen[i] == key) { ret; }
         i = i + 1;
     }
+    # a graph past the bound FAILS CLOSED: it reports rather than answering "no
+    # violation", which padding the graph past the bound would otherwise exploit.
     if (scan.len >= 256) {
-        if (!scan.bound_reported) {
-            scan.bound_reported = true;
-            sema.report(sc, span, "constant-time: this type's graph is too large to prove that every generic union it reaches has variants agreeing on secrecy");
-        }
+        report_unprovable(sc, scan, span);
         ret;
     }
     scan.seen[scan.len] = key;
     scan.len = scan.len + 1;
 
-    val opt_nom: O.Option[*type.Type] = type.get(?s.types, nom);
-    if (O.is_none[*type.Type](opt_nom)) { ret; }
-    if (generic && O.unwrap[*type.Type](opt_nom).kind == type.TYPE_UNI) {
-        check_uni_variants(sc, nom, a, n, key, span);
+    if (generic && nom_kind == type.TYPE_UNI) {
+        check_uni_variants(sc, nom, a, n, key, scan, span);
     }
-
-    val opt_tab: O.Option[*type.FieldTable] = type.field_table_for(?s.types, nom);
-    if (O.is_none[*type.FieldTable](opt_tab)) { ret; }
-    val fields_len: u32 = O.unwrap[*type.FieldTable](opt_tab).fields_len;
 
     # the entry is re-fetched every step and its type copied out before recursing: the
     # walk below materializes instance field tables, which grows the field pool.
     var f: u32 = 0;
     for (f < fields_len) {
         val e_opt: O.Option[*type.FieldEntry] = type.field_at(?s.types, nom, f);
-        if (O.is_some[*type.FieldEntry](e_opt)) {
-            val fty: type.TypeId = O.unwrap[*type.FieldEntry](e_opt).ty;
-            uni_inst_walk(sc, fty, a, n, scan, span);
+        if (O.is_none[*type.FieldEntry](e_opt)) {
+            report_unprovable(sc, scan, span);
+            ret;
         }
+        val fty: type.TypeId = O.unwrap[*type.FieldEntry](e_opt).ty;
+        uni_inst_walk(sc, fty, a, n, scan, span);
         f = f + 1;
     }
+}
+
+# report, once per walk, that this annotation's graph could not be proved to satisfy the
+# union rule - the walk's single fail-closed exit
+#
+# Every unprovable case shares one diagnostic because they share one meaning: the layout
+# the rule reads was not available, so "no violation found" would be an answer about the
+# checker rather than about the program.
+fun report_unprovable(sc: *sema.SemaContext, scan: *UniInstScan, span: token.Span) {
+    if (scan.unprovable_reported) { ret; }
+    scan.unprovable_reported = true;
+    sema.report(sc, span, "constant-time: cannot prove that every generic union this type reaches has variants agreeing on secrecy - its field layout is unavailable or its type graph is too large");
 }
 
 # report when union nominal `nom`'s variants disagree on secrecy once `args` is applied
@@ -975,16 +1000,22 @@ fun uni_inst_walk_nominal(sc: *sema.SemaContext, nom: type.TypeId, args: *type.T
 # stays legal: it has legal instantiations (`Outer[^u32]`) and illegal ones
 # (`Outer[u32]`), and each is decided when it is actually formed.
 fun check_uni_variants(sc: *sema.SemaContext, nom: type.TypeId, args: *type.TypeId,
-                       arg_len: u32, key: type.TypeId, span: token.Span) {
+                       arg_len: u32, key: type.TypeId, scan: *UniInstScan, span: token.Span) {
     val s: *session.Session = sc.s;
 
     val opt_tab: O.Option[*type.FieldTable] = type.field_table_for(?s.types, nom);
-    if (O.is_none[*type.FieldTable](opt_tab)) { ret; }
+    if (O.is_none[*type.FieldTable](opt_tab)) {
+        report_unprovable(sc, scan, span);
+        ret;
+    }
     val fields_len: u32 = O.unwrap[*type.FieldTable](opt_tab).fields_len;
     if (fields_len < 2) { ret; }
 
     val first_opt: O.Option[*type.FieldEntry] = type.field_at(?s.types, nom, 0);
-    if (O.is_none[*type.FieldEntry](first_opt)) { ret; }
+    if (O.is_none[*type.FieldEntry](first_opt)) {
+        report_unprovable(sc, scan, span);
+        ret;
+    }
     val first_raw: type.TypeId = O.unwrap[*type.FieldEntry](first_opt).ty;
     val first:     type.TypeId = subst_or_self(s, first_raw, args, arg_len);
     if (type_mentions_gparam(s, first)) { ret; }
@@ -992,7 +1023,10 @@ fun check_uni_variants(sc: *sema.SemaContext, nom: type.TypeId, args: *type.Type
     var i: u32 = 1;
     for (i < fields_len) {
         val e_opt: O.Option[*type.FieldEntry] = type.field_at(?s.types, nom, i);
-        if (O.is_none[*type.FieldEntry](e_opt)) { ret; }
+        if (O.is_none[*type.FieldEntry](e_opt)) {
+            report_unprovable(sc, scan, span);
+            ret;
+        }
         val raw: type.TypeId = O.unwrap[*type.FieldEntry](e_opt).ty;
         val ty:  type.TypeId = subst_or_self(s, raw, args, arg_len);
         if (type_mentions_gparam(s, ty)) { ret; }

--- a/src/lang/fe/sema/generics.mach
+++ b/src/lang/fe/sema/generics.mach
@@ -588,6 +588,147 @@ rec UniInstScan {
     bound_reported: bool;
 }
 
+# whether any type this module names reaches a secret `^` (#2225)
+#
+# The precondition of the whole instance rule: a union's variants cannot disagree unless
+# a `^` is reachable, so a module that names none needs neither the per-annotation walk
+# nor the widened re-validation recording that feeds it.
+#
+# Derived from the MODULE's own resolved annotations rather than from the interner's
+# contents, and so is a function of this module and its dependencies alone. Reading the
+# universe instead would make a module's diagnostics depend on which unrelated modules
+# had been analysed first, which is not a property a cached per-module result may have.
+# The reach is DEEP (`contains_secret_deep`), so a `^` that only a dependency's template
+# writes - `Outer[T]` whose field is `U[T, ^u32]` - is found through the field graph.
+# Call it once the field tables exist, or every unresolvable nominal fails closed and the
+# answer is a uniform yes.
+# ---
+# s:        the session
+# resolved: the module's `type_resolved_ty` table
+# len:      number of entries
+# ret:      true when some annotation reaches a `^`
+pub fun module_reaches_secret(s: *session.Session, resolved: *type.TypeId, len: u32) bool {
+    if (resolved == nil) { ret false; }
+
+    # ONE visited set across every annotation, not one per annotation: a nominal explored
+    # and found secret-free stays secret-free whichever root reached it, so sharing turns
+    # the scan from (annotations x graph) into (distinct types). It grows rather than
+    # capping, because a capped scan would answer "possibly secret" for any large module
+    # and switch the whole rule on for it - paying far more than the scan saved.
+    var scan: GParamScan;
+    scan.visited = nil;
+    scan.len     = 0;
+    scan.cap     = 0;
+
+    var found: bool = false;
+    var i:     u32  = 0;
+    for (i < len) {
+        if (secret_reach_walk(s, resolved[i], ?scan)) {
+            found = true;
+            brk;
+        }
+        i = i + 1;
+    }
+
+    if (scan.visited != nil && scan.cap > 0) {
+        A.deallocate[type.TypeId](s.alloc, scan.visited, scan.cap::usize);
+    }
+    ret found;
+}
+
+# the recursive worker for `module_reaches_secret`, threading one growable visited set
+#
+# The same structural discipline as `secret_deep_walk` - pointer, array, function
+# SIGNATURE, and every field of every aggregate - and the same fail-closed default over
+# the kind space, so an unresolvable table or an unrecognized kind answers "possibly
+# secret" and switches the rule on rather than off.
+fun secret_reach_walk(s: *session.Session, tid: type.TypeId, scan: *GParamScan) bool {
+    if (tid == type.TYPE_NIL || tid == type.TYPE_ERROR) { ret false; }
+
+    val opt_t: O.Option[*type.Type] = type.get(?s.types, tid);
+    if (O.is_none[*type.Type](opt_t)) { ret false; }
+    val t: *type.Type    = O.unwrap[*type.Type](opt_t);
+    val k: type.TypeKind = t.kind;
+
+    if (k == type.TYPE_SECRET) { ret true; }
+
+    if (k == type.TYPE_POINTER) {
+        val base: type.TypeId = t.data.pointer.base;
+        ret secret_reach_walk(s, base, scan);
+    }
+    if (k == type.TYPE_ARRAY) {
+        val base: type.TypeId = t.data.array.base;
+        ret secret_reach_walk(s, base, scan);
+    }
+    if (k == type.TYPE_FUN) {
+        val ret_ty:       type.TypeId = t.data.fn.ret_type;
+        val params_start: u32         = t.data.fn.params_start;
+        val params_len:   u32         = t.data.fn.params_len;
+        if (secret_reach_walk(s, ret_ty, scan)) { ret true; }
+        var pi: u32 = 0;
+        for (pi < params_len) {
+            val p_opt: O.Option[type.TypeId] = type.get_param(?s.types, params_start + pi);
+            if (O.is_some[type.TypeId](p_opt) && secret_reach_walk(s, O.unwrap[type.TypeId](p_opt), scan)) { ret true; }
+            pi = pi + 1;
+        }
+        ret false;
+    }
+
+    # an instance is read as (arguments, template), never as its own substituted table: a
+    # `^` in that table comes from one or the other, so materializing it would build a
+    # layout the program may never need - the scan runs on every module, including the
+    # overwhelming majority that reach no secret at all and pay only this walk.
+    if (k == type.TYPE_INSTANCE) {
+        if (scan_contains(scan, tid)) { ret false; }
+        if (!scan_push(s, scan, tid)) { ret true; }
+
+        val origin:     session.ModuleId = t.data.instance.target_origin;
+        val decl_id:    id.DeclId        = t.data.instance.target_decl;
+        val args_start: u32              = t.data.instance.args_start;
+        val args_len:   u32              = t.data.instance.args_len;
+
+        var i: u32 = 0;
+        for (i < args_len) {
+            val a_opt: O.Option[type.TypeId] = type.get_param(?s.types, args_start + i);
+            if (O.is_some[type.TypeId](a_opt) && secret_reach_walk(s, O.unwrap[type.TypeId](a_opt), scan)) { ret true; }
+            i = i + 1;
+        }
+
+        val gnom: type.TypeId = generic_nominal_of(s, origin, decl_id);
+        if (gnom == type.TYPE_ERROR) { ret true; }
+        ret secret_reach_walk(s, gnom, scan);
+    }
+
+    if (k == type.TYPE_REC || k == type.TYPE_UNI) {
+        if (scan_contains(scan, tid)) { ret false; }
+        if (!scan_push(s, scan, tid)) { ret true; }
+
+        val opt_tab: O.Option[*type.FieldTable] = type.field_table_for(?s.types, tid);
+        if (O.is_none[*type.FieldTable](opt_tab)) { ret true; }
+        val fields_len: u32 = O.unwrap[*type.FieldTable](opt_tab).fields_len;
+
+        var f: u32 = 0;
+        for (f < fields_len) {
+            val e_opt: O.Option[*type.FieldEntry] = type.field_at(?s.types, tid, f);
+            if (O.is_some[*type.FieldEntry](e_opt)) {
+                val fty: type.TypeId = O.unwrap[*type.FieldEntry](e_opt).ty;
+                if (secret_reach_walk(s, fty, scan)) { ret true; }
+            }
+            f = f + 1;
+        }
+        ret false;
+    }
+
+    # a `...` pack is a comptime sequence marker, not storage: it is never a union
+    # variant nor a field, so it cannot make a pair of variants disagree. `secret_deep_walk`
+    # fails closed on it because there it guards a value crossing a boundary; here it would
+    # only switch the whole rule on for every module that declares a variadic.
+    if (k == type.TYPE_PACK) { ret false; }
+
+    if (kind_is_public_leaf(k)) { ret false; }
+    ret true;
+}
+
 # the mixed-secrecy union rule at a generic INSTANCE, run over one annotation (#2225)
 #
 # `check_uni_secrecy` runs at the union DECLARATION, where a variant typed by a generic


### PR DESCRIPTION
Closes #2225

## The gap

`check_uni_secrecy` runs at the union **declaration**, where a variant typed by a
generic parameter is a public leaf and `uni U[T] { a: T; b: u32; }` honestly agrees.
The violation exists only after substitution, which never re-resolves the declaration —
so `U[^u32]` compiled clean where its non-generic twin is a hard error.

## Shape chosen, and why

The rule walks each annotation's **pristine** resolved type carrying the episode's
substitution, rather than the substituted type. Two reasons, both from the eight
constraints:

- a substituted value has already lost the template structure the rule needs — an
  anonymous `uni { ok: T; err: E }` becomes a `TYPE_INSTANCE` whose `MODULE_NIL` nominal
  no classification can recover, which is how mach-std's `Result` escaped every guard
  keyed on "is this instance a union" (constraint 3);
- a derived slot cannot say how many substitutions it has absorbed, so it must be
  re-derived from a pristine input (#2254's rule).

Carrying the substitution instead means **every union is met as a NOMINAL**, whose
`rec`/`uni` kind is its own — anonymous and named alike, one site, no classification
step that can fail open. Constraint 3 dissolves rather than being guarded against.

One enumerator, per the #2249 frame: the module's annotations are swept once after decl
inference, and annotations inside a generic body are abstract there and decided by the
per-instance re-validation episodes, which read them under the concrete arguments. Both
are the same walk over the same table; nothing has to agree with anything else.

Supporting pieces the shape requires:

- `mentions_gparam` gains the **signature** case it was missing. A nominal whose only
  generic parameter sits inside a function-typed field read as fully concrete, which both
  hid that instance from this rule (constraint 4) and left the nested aggregate
  unspecialized — a latent substitution bug of its own.
- `record_instance` records an instance when **any argument is concrete**, not only when
  an argument can reach a secret. `arg_triggers_revalidation` asks the right question for
  every gate that needs the secret to arrive through the call; a union's variants can
  disagree without that. In `fun f[T]() { var u: U[T, ^u32]; }` the secret is written in
  the *template* and a plain `u32` argument is what makes the pair mixed.
- the visited set is keyed on **(nominal, arguments)**, so the same union reached first at
  a clean instantiation and then at a violating one is examined twice.
- report-once is a set keyed on the interned instance the violation denotes, shared by the
  sweep and every episode it drives — `resolve_type_ref` is not memoized and
  `def_underlying` re-resolves an alias per use (constraint 8).
- the walk **fails closed** through one exit: past the visited-set bound, and on a layout
  it cannot read (constraint 6).
- the whole rule is gated on a **module-local** deep reach to a `^`. Reading the interner
  instead would make a module's diagnostics depend on which unrelated modules were
  analysed first — not a property a cached per-module sema result may have.

Every walk re-fetches its field entry per step and copies the type out before recursing,
and copies an instance's arguments out of the param pool before substituting: both pools
grow under materialization (constraint 5).

## Reproduced and rejected

Built from source; the 4.2.2 PATH seed was never the test compiler. Every row below was
executed against both compilers. On `dev` **all twenty leak shapes compile with zero
diagnostics**; on this branch each is rejected at the exact count shown.

| shape | dev | branch |
|---|---|---|
| the issue's `uni U[T]` at `U[^u32]` | clean | 1 |
| mach-std `Result[^u32, u32]` | clean | 1 |
| unspelled: `rec Box[T] { u: U[T]; }` at `Box[^u32]` | clean | 1 |
| function-typed field: `rec Box[T] { f: fun(*U[T]) u32; }` | clean | 1 |
| anonymous `uni` in a generic record | clean | 1 |
| `U[T]` inside a generic function body, at `f[^u32]` | clean | 1 |
| anonymous `uni { a: T; b: u32 }` inside a generic body | clean | 1 |
| deep nest: `Outer[T]` → `Mid[T]` → `[4]*U[T]` | clean | 1 |
| template-side secret, public argument (`U2[T, ^u32]` at `f[u32]`) | clean | 1 |
| `def L: U[^u32];` used twice (three annotations, one mistake) | clean | **1** |
| `rec Outer[T] { u: U2[T, ^u32]; }` at `Outer[u32]` | clean | 1 |
| cross-module (`XU[^u32]`, `XBox[^u32]`, `XAnon[^u32,u32]`) | clean | **2** (2 distinct types) |
| inside a pack `$each` body (typed only at monomorphization) | clean | 1 |
| reached only through an instance's return type | clean | 1 |
| recursive generic (`rec Node[T] { next: *Node[T]; u: U[T]; }`) | clean | 1 |
| four distinct shapes: `*T`, `[4]T`, a record variant, a nested anon `uni` | clean | **4** |
| anonymous union as a **type argument** | clean | 1 |
| unreferenced parameter, caller passes `nil` | clean | 1 |
| dependency's template hides the `^`; consumer names none | clean | 1 |
| the same, with an unrelated local `^` present | clean | 1 |

The runtime half is **masked** — see the layout note below — so the observable is the
diagnostic, and the count is asserted, not just its presence.

## No over-rejection

Eleven controls, clean on both compilers:

all-public and all-secret instantiations; a generic union whose variants are all `T`, at
both a public and a secret argument; the partially concrete `U2[T, ^u32]` inside `Outer[T]`
at its **legal** argument `Outer[^u32]`, and never at the template itself; a template never
instantiated at all; mach-std `Result[u32, str]` end to end (built and run); `Result[^u32,
^u32]`; a **record** with mixed-secrecy fields, including one behind a function-typed field;
a mixed pair in an untaken `$if` arm, named and anonymous; a recursive generic at uniform
arguments.

One case moved from clean to rejected that is **not** an over-rejection: `uni Ud[T] { a: T;
b: Pair[T]; }` at `^u32`, where a bare `^u32` sits beside an all-secret record. Its
non-generic twin is rejected on `dev` too — the generic form now simply agrees with it.

## Report once

Asserted as a count, not a presence, on every rejection row. The alias case is the pointed
one: `def L: U[^u32]; var u: L; var v: L;` reaches the same ill-formed type from three
annotations and produces **one** diagnostic. Two genuinely distinct ill-formed instances
produce **two** — the dedupe collapses routes to one type, never two mistakes.

## Mutation testing

Fifteen mutations, each disabling exactly one guard, each rebuilt and run. Assertions are
bit-tagged so a failure names *which* ones fell.

| mutation | caught by |
|---|---|
| episode hook removed | 4 body-shape rejections + the pack body |
| module sweep removed | 9 sweep-reached rejections + `Outer[u32]` + cross-module |
| signature case dropped from `mentions_gparam` | the function-typed field |
| signature descent dropped from the walk | the function-typed field |
| recording widening removed | template-side secret at a public argument |
| dedupe disabled | the return-type and alias **counts** |
| abstract-variant deferral removed | 3 over-rejection controls + a count |
| declaration-site gate removed | the two concrete-union counts |
| per-argument walk removed | anonymous union as a type argument |
| signature walk removed from the episode | unreferenced parameter |
| visit key ignores the arguments | clean-then-violating instantiation |
| precondition forced false (kill switch) | every rejection assertion |
| precondition's field descent removed | the foreign-template shape |
| visited bound at 1, still reporting | 3 controls — proves the bound **reports** |
| visited bound at 1, silenced | rejections leak — the fail-**open** shape |

Two guards are unreachable in a healthy build and are only observable in combination: the
unresolvable-layout exit, and silencing `report_unprovable`. The bound-at-1 pair above
drives the same exit and shows both directions.

## Per-assertion discrimination

Every one of the **21** rejection assertions fails against `dev`, verified individually by
bit-tagged exit codes across three windows. The nine non-rejection controls pass on both, by
design — the mutation table is what shows they discriminate.

One fixture was wrong and the harness caught it: `$if (0)` is not a valid comptime condition
(`comptime branch condition must be a bool, found int`), so that control was passing for the
wrong reason until it was rewritten.

## Verification

- compiler suite **853 / 0** (850 baseline + the 3 tests added)
- mach-std **611 / 0** at pin `eff1e8e` (`git rev-parse HEAD` verified against `mach.lock`)
- `int/` all cases pass on `linux`, debug and release
- three-generation fixpoint **B == C == D**, byte-identical
- the pre-fix and post-fix compilers emit a **byte-identical** artifact from the same
  (`^`-free) sources: the rule is analysis only, no codegen effect
- cross-target builds from source clean for `linux-arm64` and `linux-riscv64`
- nothing in mach or mach-std is rejected by the new rule

Compile-time cost on the self-host build: **+3.5% CPU** (min of six interleaved runs,
11.272s → 11.668s user). That is the precondition's deep reach, which every module pays;
the rule itself never runs for a `^`-free program. The reach shares one visited set across
all annotations and reads a generic instance as (arguments, template) rather than
materializing its substituted table, so it builds no layout the program does not need.

## Coupling with #2239 — read before fixing that

#2239 currently **masks** this hole, and more broadly than that issue states: measured on
`dev`, a **named** generic union does not alias either. `uni U[T] { a: T; b: u32; }` at
`U[u32]` — write `a = 37`, read `b` — reads **0**, and so does `U[^u32]`. The non-generic
twin aliases correctly. So no byte leaks through a generic union instance today, of either
form.

This PR is the sema half and touches no layout. **Fixing #2239 after this lands is safe;
fixing it before would have converted a masked hole into a live leak.**
