### PR TITLE
feat(spirv): freestanding-spirv builds a .spv end to end

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -345,15 +345,17 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y qemu-user
 
-      # the debuginfo case (int/surface/debuginfo) inspects the emitted DWARF host-side
-      # with llvm-dwarfdump --verify and reads PT_LOAD extents with readelf; it runs on
-      # every ELF leg (all Linux runners here). the validators read the target object
-      # regardless of the runner's own ISA. #2039.
-      - name: install debug-info validators
+      # the host-side validators the structural cases inspect artifacts with, all
+      # reading the target artifact regardless of the runner's own ISA. debuginfo
+      # (int/surface/debuginfo) verifies the emitted DWARF with llvm-dwarfdump and
+      # reads PT_LOAD extents with readelf (#2039); spirv-module
+      # (int/surface/spirv-module) validates the delivered `.spv` with the Khronos
+      # spirv-val (#2245). both run on the Linux legs.
+      - name: install artifact validators
         if: runner.os == 'Linux'
         run: |
           sudo apt-get update
-          sudo apt-get install -y llvm binutils
+          sudo apt-get install -y llvm binutils spirv-tools
 
       - name: build the from-source compiler
         if: runner.os != 'Windows'

--- a/doc/cli.md
+++ b/doc/cli.md
@@ -90,6 +90,14 @@ codegen to one relocatable object, written under the resolved object tree at
 resolved artifact path (its `out` template); for a `static`/`shared` library (or
 with `--emit obj`) the objects are the deliverable and nothing is linked.
 
+A target whose object format delivers **finished modules** — SPIR-V, whose object
+output is a complete self-contained module rather than a link input — always
+takes the second shape. Each module is written as `<out>/obj/<fqn-as-path>.spv`
+and the module tree is the artifact, so `mach build --target <spirv-target>` and
+`mach build --target <spirv-target> --emit obj` produce exactly the same files.
+There is no executable to link, no archive or shared-library form, and no test
+dispatcher to run; each is refused by name rather than attempted.
+
 The optimisation pipeline comes from the selected profile's `opt` (`--profile
 <name>`, or the first declared profile) — the profile is how a build picks its
 optimisation level.
@@ -486,8 +494,11 @@ curated, so a snapshot printed here would only drift.
 
 Each dimension is orthogonal on its own, but the joint cells are not: an
 instruction set emits only with a wired code generator, a calling convention is
-per-ISA, an object format relocates and writes only the ISAs it declares, and an
-operating system links and loads only its own object formats. `mach info targets`
+per-ISA, an object format relocates and writes only the ISAs it declares, an
+operating system links and loads only its own object formats, and an object
+format's emission shape must match the instruction set's back half — a
+whole-module emitter needs a format that carries finished modules, a register
+machine one that carries linkable objects. `mach info targets`
 keeps a `<os>-<isa>` tuple only when some registered calling convention and object
 format compose an emittable full tuple — so `windows-aarch64` is absent (COFF
 covers x86-64 only) and `darwin-riscv64` is absent (Mach-O covers x86-64 and

--- a/doc/manifest.md
+++ b/doc/manifest.md
@@ -111,26 +111,32 @@ to whichever *declared* target matches the host.
 
 | Axis  | Values |
 |-------|--------|
-| `isa` | `x86_64`, `aarch64`, `riscv64` |
+| `isa` | `x86_64`, `aarch64`, `riscv64`, `spirv`, `mos6502` |
 | `os`  | `linux`, `windows`, `darwin`, `freestanding` |
-| `abi` | `sysv64`, `win64`, `aapcs64`, `lp64` |
+| `abi` | `sysv64`, `win64`, `aapcs64`, `lp64`, `spirv`, `mos6502` |
 
 `x86_64`/`linux`/`sysv64` is the primary host and target. `aarch64`-linux builds
 and runs natively in CI on every PR; `riscv64`-linux runs under qemu and
 self-hosts (#1852). `windows` is a supported cross-compilation target (PE/COFF,
 Win64 ABI). `darwin`'s ABI and object-format support exist but the toolchain is not
 yet validated end-to-end. `freestanding` targets a raw flat image with no OS
-runtime.
+runtime. `spirv` is not a machine at all — it emits a finished GPU module rather
+than machine code (see [Finished-module targets](#finished-module-targets)).
+
+`mach info targets` prints the tuples this binary can actually build; it is
+derived from the same declarations composition reads, so it never advertises a
+tuple that would fail to resolve.
 
 A value outside its axis's set is a strict-parse error, so a typo is caught rather
 than silently never matching.
 
 ### Object-format override
 
-`of` overrides the object format an OS implies. Each os has a default format —
+`of` overrides the object format a target implies. Each os has a default format —
 `linux` → `elf`, `windows` → `coff`, `darwin` → `macho`, `freestanding` → `raw` —
 and `of` names a different one from the same closed set: `elf`, `coff`, `macho`,
-`raw`. It is the only optional key on a target; omit it to take the os default.
+`raw`, `spv`. It is the only optional key on a target; omit it to take the
+default.
 
 ```toml
 [target.metal]
@@ -139,6 +145,40 @@ os  = "freestanding"   # os default object format is "raw"
 abi = "sysv64"
 of  = "elf"            # override: emit an ELF object instead
 ```
+
+The default is a function of the whole tuple, not the os alone. An os default
+carries relocatable machine text, which a whole-module emitter does not produce,
+so a `spirv` target resolves to `spv` — the format that carries a finished
+module — regardless of the os it names.
+
+An `of` naming a format whose emission shape does not match the instruction set's
+is refused at composition (`instruction set 'spirv' emits finished modules, but
+object format 'raw' carries linkable objects`), so the override cannot compose a
+tuple that would emit nothing.
+
+### Finished-module targets
+
+A `spirv` target's object output is a complete, self-contained module rather than
+a link input. The build therefore delivers the **module tree** — one
+`<out>/obj/<fqn-as-path>.spv` per module — and runs no link phase, so a default
+build and `--emit obj` produce the same files:
+
+```toml
+[target.gpu]
+isa = "spirv"
+os  = "freestanding"
+abi = "spirv"
+# no `of`: the finished-module format resolves on its own
+```
+
+```
+mach build . --target gpu     # writes out/gpu/<profile>/obj/<module>.spv
+```
+
+The artifact's `out` template and `-o` name a linked binary, which such a target
+has none of; the module tree is delivered instead. A `static` or `shared`
+artifact kind, and `mach test`, are refused by name — there is no archive, shared
+object, or executable form for a module.
 
 ## `[profile.<name>]`
 

--- a/int/lib/produce.sh
+++ b/int/lib/produce.sh
@@ -25,6 +25,11 @@
 #                 image and `-g` is loadable-byte additive (PT_LOAD segments identical).
 #                 the one producer that needs external validators (llvm-dwarfdump,
 #                 readelf); it runs only on the ELF debug-info legs, which install them.
+#   spirv-val   — validate every `.spv` module a finished-module target delivered
+#                 with the Khronos validator (spirv-tools). the target links
+#                 nothing, so there is no binary to run and the module tree is the
+#                 artifact; the external validator is what makes this a validity
+#                 check rather than a round-trip through mach's own reader.
 #   vector-emit — disassemble the case's own objects and report, per function,
 #                 whether the compiler EMITTED packed SIMD (#2207). the observable
 #                 execution cannot produce: a vectorizer that silently stops firing
@@ -185,6 +190,32 @@ produce_built() {
         echo "int: built: artifact missing or empty" >&2
         return 2
     fi
+}
+
+# produce_spirv_val <runmode> <target> <binary>
+# validate every SPIR-V module the build delivered, with the Khronos validator.
+# a finished-module target has no linked binary: the delivery is the module tree,
+# so this globs the case's output root (the directory <binary> would have been
+# written into) and runs spirv-val over each `.spv`. an EXTERNAL validator is the
+# point — mach reading back its own bytes proves self-consistency, not validity.
+# the observable is the module count plus the verdict, so a build that silently
+# stopped emitting fails on the count rather than passing vacuously.
+produce_spirv_val() {
+    out_dir=$(dirname "$3")
+    if ! command -v spirv-val >/dev/null 2>&1; then
+        echo "int: spirv-val: the validator is not installed (spirv-tools)" >&2
+        return 2
+    fi
+    n=0
+    for m in $(find "$out_dir" -name '*.spv' | sort); do
+        spirv-val "$m" || return 1
+        n=$((n + 1))
+    done
+    if [ "$n" -eq 0 ]; then
+        echo "int: spirv-val: the build delivered no .spv module" >&2
+        return 2
+    fi
+    printf 'modules=%d validator=clean\n' "$n"
 }
 
 # resolve_dwarfdump — print an llvm-dwarfdump on PATH, preferring the unversioned
@@ -412,6 +443,7 @@ produce() {
         flat-loader) produce_flat_loader "$@" ;;
         built)       produce_built "$@" ;;
         debuginfo)   produce_debuginfo "$@" ;;
+        spirv-val)   produce_spirv_val "$@" ;;
         vector-emit) produce_vector_emit "$@" ;;
         *) echo "int: unknown run mode '$run'" >&2; return 2 ;;
     esac

--- a/int/surface/spirv-module/case.conf
+++ b/int/surface/spirv-module/case.conf
@@ -1,0 +1,6 @@
+# build the spirv target from a manifest that spells no `of` and validate the
+# delivered modules with spirv-val host-side. nothing executes: a SPIR-V module
+# is a GPU artifact, so the leg only needs the validator, not a runner.
+run: spirv-val
+targets: linux
+build-target: spirv

--- a/int/surface/spirv-module/expect.spirv.txt
+++ b/int/surface/spirv-module/expect.spirv.txt
@@ -1,0 +1,1 @@
+modules=1 validator=clean

--- a/int/surface/spirv-module/mach.toml
+++ b/int/surface/spirv-module/mach.toml
@@ -1,0 +1,34 @@
+[project]
+id = "case"
+version = "0.0.0"
+src = "src"
+# a fixed output root: the delivery is a module TREE, not a single binary, so the
+# producer finds the modules under the same directory `-o` names rather than
+# through a per-target/profile template it would have to reconstruct.
+out = "out/int"
+
+# no `of` key. that is the whole point of the case: the target spells only the
+# tuple, and the toolchain must resolve the object format that carries a finished
+# SPIR-V module on its own (#2245).
+[target.spirv]
+isa = "spirv"
+os  = "freestanding"
+abi = "spirv"
+
+[profile.debug]
+opt = 0
+debug = false
+simd = "scalarize"
+
+[profile.release]
+opt = 2
+debug = false
+simd = "scalarize"
+
+[artifact.case]
+kind = "bin"
+entry = "main.mach"
+out = "bin/case"
+targets = ["*"]
+link = []
+need = []

--- a/int/surface/spirv-module/src/main.mach
+++ b/int/surface/spirv-module/src/main.mach
@@ -1,0 +1,25 @@
+# SPIR-V module fixture: a default-manifest build delivers a valid `.spv`
+#
+# The manifest spells only isa/os/abi, so the object format is whatever the
+# toolchain derives - the case fails if that is anything but the finished-module
+# format, since no other one produces a file `spirv-val` accepts. The observable
+# is the external Khronos validator's verdict, not mach's own reader.
+#
+# The bodies stay inside the SPIR-V back half's v1 scope: straight-line scalar
+# functions. Structured control flow and OpFunctionCall are #2120, and the
+# emitter refuses them loudly, so nothing here branches or calls.
+
+fun add(a: i32, b: i32) i32 {
+    ret a + b;
+}
+
+fun mask(a: i32, b: i32) i32 {
+    var c: i32 = a - b;
+    c = c & 0x3F;
+    c = c | 0x40;
+    ret c ^ 0x11;
+}
+
+fun main() i32 {
+    ret 0;
+}

--- a/src/cli/cmd/info.mach
+++ b/src/cli/cmd/info.mach
@@ -244,3 +244,52 @@ fun os_isa_supported(reg: *target.TargetRegistry, os_vt: *os.OsVTable, isa_vt: *
     }
     ret false;
 }
+
+# every tuple this command advertises composes with NO object-format override -
+# the tuple a manifest gets when it spells only isa, os, and abi
+#
+# The display predicate keys on "SOME (abi, of) is emittable", but a manifest
+# selects the of by default, not by search. Without this the two can disagree:
+# `freestanding-spirv` was advertised through (spirv, spv) while defaulting to
+# `raw`, a flat image that refuses object output, so the listed target could
+# produce no artifact by any route (#2245). Composition is the strongest fact a
+# unit test can state - it is the exact predicate a build resolves through - so
+# an advertised cell that no longer resolves fails here.
+test "mach.cli.cmd.info.print_targets:advertised_tuples_compose_by_default" {
+    var reg: target.TargetRegistry = target.registry_init();
+    if (R.is_err[bool, str](target.register_all(?reg))) { ret 1; }
+
+    var advertised: u32 = 0;
+    var oi:     u32 = 0;
+    val os_len: u32 = os.registered_count(?reg.os);
+    for (oi < os_len) {
+        val os_vt: *os.OsVTable = O.unwrap[*os.OsVTable](os.registered(?reg.os, oi));
+        var ii:      u32 = 0;
+        val isa_len: u32 = isa.registered_count(?reg.isa);
+        for (ii < isa_len) {
+            val isa_vt: *isa.IsaVTable = O.unwrap[*isa.IsaVTable](isa.registered(?reg.isa, ii));
+            if (os_isa_supported(?reg, os_vt, isa_vt)) {
+                advertised = advertised + 1;
+
+                # the cell is printed, so some calling convention must compose it
+                # through the DEFAULT object format - no `of` spelled.
+                var composed: bool = false;
+                var ai:      u32   = 0;
+                val abi_len: u32   = abi.registered_count(?reg.abi);
+                for (ai < abi_len) {
+                    val abi_vt: *abi.AbiVTable = O.unwrap[*abi.AbiVTable](abi.registered(?reg.abi, ai));
+                    val r: R.Result[target.Target, str] = target.select(?reg, isa_vt.name, os_vt.name, abi_vt.name);
+                    if (R.is_ok[target.Target, str](r)) { composed = true; }
+                    ai = ai + 1;
+                }
+                if (!composed) { ret 1; }
+            }
+            ii = ii + 1;
+        }
+        oi = oi + 1;
+    }
+
+    # a registry that advertised nothing would pass the loop vacuously.
+    if (advertised == 0) { ret 1; }
+    ret 0;
+}

--- a/src/lang/build/emit.mach
+++ b/src/lang/build/emit.mach
@@ -651,13 +651,14 @@ fun resolve_and_store_input(p: *driver.Project, tok: *u8, paths: **u8, written: 
     ret R.ok[bool, outcome.Fail](true);
 }
 
-# write each per-module image to a relocatable object whose path mirrors the
-# module FQN under `obj_base`, collecting the owned path strings
+# write each per-module image to an object whose path mirrors the module FQN
+# under `obj_base`, collecting the owned path strings
 #
-# FQN `a.b.c` -> `<obj_base>/a/b/c.o`, creating parent directories. The owned
-# path strings - one per topo entry, in topo order - are collected into a fresh
-# `**u8` array stored through `paths_out`. On failure any paths produced so far
-# are released.
+# FQN `a.b.c` -> `<obj_base>/a/b/c.<ext>`, creating parent directories, where
+# `<ext>` is the object format's self-declared `object_ext` ("o" for a
+# relocatable object, "spv" for a finished SPIR-V module). The owned path strings
+# - one per topo entry, in topo order - are collected into a fresh `**u8` array
+# stored through `paths_out`. On failure any paths produced so far are released.
 # ---
 # p:         the project carrying the module graph and session
 # images:    the per-module object images to write
@@ -682,7 +683,7 @@ pub fun write_objects(p: *driver.Project, images: *of.ObjectImage,
             ret R.err[bool, outcome.Fail](outcome.internal("module FQN not interned"));
         }
 
-        val op_r: R.Result[str, str] = mirror_fqn(p.alloc, obj_base, O.unwrap[str](opt_fqn), "o");
+        val op_r: R.Result[str, str] = mirror_fqn(p.alloc, obj_base, O.unwrap[str](opt_fqn), p.target.of.object_ext);
         if (R.is_err[str, str](op_r)) {
             free_paths(p.alloc, paths, i, len);
             ret R.err[bool, outcome.Fail](outcome.internal("out of memory"));

--- a/src/lang/build/engine.mach
+++ b/src/lang/build/engine.mach
@@ -692,6 +692,20 @@ fun emit_phase(p: *driver.Project, unit: *plan.BuildUnit, st: *UnitState,
         ret R.err[bool, outcome.Fail](outcome.user("a flat-image object format produces only executables; library and '--emit obj' outputs are unsupported"));
     }
 
+    # a finished-module format links nothing, so there is no test dispatcher to
+    # build and nothing to execute the collected tests with.
+    if (goal == request.GOAL_TESTS && plan.finished_modules(?p.target)) {
+        ret R.err[bool, outcome.Fail](outcome.user("a finished-module object format produces no executable; this target cannot build or run tests"));
+    }
+
+    # nor is there an archive or shared-library form to gather the modules into:
+    # a `static` / `shared` artifact would otherwise deliver the module tree and
+    # silently ignore its declared kind.
+    if (plan.finished_modules(?p.target) && p.target_entry != nil
+        && p.target_entry.mode == driver.MODE_LIBRARY) {
+        ret R.err[bool, outcome.Fail](outcome.user("a finished-module object format has no archive or shared-library form; each module is its own artifact"));
+    }
+
     if (goal == request.GOAL_TESTS) {
         # the collection decides whether anything materializes: a build with no
         # tests errors, a scope that selected nothing builds nothing.
@@ -710,9 +724,11 @@ fun emit_phase(p: *driver.Project, unit: *plan.BuildUnit, st: *UnitState,
         st.obj_len = p.topo_len;
     }
 
-    # an objects goal delivers the object tree itself; the narration closes
-    # here since the unit has no link phase.
-    if (goal == request.GOAL_OBJECTS) {
+    # the object tree is the delivery for an objects goal, and for an execute goal
+    # on a finished-module format - there each emitted module is already the
+    # artifact, so no link phase follows. the narration closes here in both cases.
+    if (goal == request.GOAL_OBJECTS
+        || (goal == request.GOAL_EXECUTE && plan.finished_modules(?p.target))) {
         st.out_path = unit.out_path::*u8;
         readout.phase_end(ev, readout.PH_LINK, p.topo_len, "object", "objects");
         st.link_started = false;
@@ -875,6 +891,8 @@ fun record_artifact(p: *driver.Project, unit: *plan.BuildUnit, st: *UnitState, b
     a.kind = outcome.ART_BINARY;
     if (ctx.req.goal == request.GOAL_OBJECTS) { a.kind = outcome.ART_OBJECTS; }
     or (ctx.req.goal == request.GOAL_TESTS)   { a.kind = outcome.ART_TESTS; }
+    # a finished-module build delivers the module tree, never a linked binary.
+    or (plan.finished_modules(?p.target))     { a.kind = outcome.ART_OBJECTS; }
     or (p.target_entry != nil && p.target_entry.mode == driver.MODE_LIBRARY) {
         a.kind = outcome.ART_OBJECTS;
         if (p.target_entry.lib_kind == manifest.LIBKIND_STATIC) { a.kind = outcome.ART_ARCHIVE; }
@@ -895,8 +913,9 @@ fun record_artifact(p: *driver.Project, unit: *plan.BuildUnit, st: *UnitState, b
 # render the readout's closing recap for a finished unit
 #
 # Reports the module count and total time, plus the linked binary's size when
-# the build produced one (an executable). A library / object-only build has no
-# single binary, so the size segment is omitted.
+# the build produced one (an executable). A library / object-only build - and a
+# finished-module build, whose delivery is the module tree - has no single
+# binary, so the size segment is omitted.
 fun emit_unit_summary(p: *driver.Project, st: *UnitState, ev: *readout.Progress) {
     var out_str: str = "<output>";
     if (st.out_path != nil) { out_str = st.out_path::str; }
@@ -904,7 +923,8 @@ fun emit_unit_summary(p: *driver.Project, st: *UnitState, ev: *readout.Progress)
     val ctx: *qctx.QueryCtx = p.s.queries.ctx::*qctx.QueryCtx;
     val te: *driver.TargetEntry = p.target_entry;
     val emit_obj: bool = ctx.req.goal == request.GOAL_OBJECTS;
-    val is_lib: bool = emit_obj || (te != nil && te.mode == driver.MODE_LIBRARY);
+    val is_lib: bool = emit_obj || plan.finished_modules(?p.target)
+        || (te != nil && te.mode == driver.MODE_LIBRARY);
 
     if (!is_lib && st.out_path != nil) {
         val fi_r: R.Result[fs.Metadata, str] = fs.metadata(st.out_path::str);

--- a/src/lang/build/plan.mach
+++ b/src/lang/build/plan.mach
@@ -348,7 +348,7 @@ fun plan_unit(a: *A.Allocator, itn: *intern.Interner, reg: *target.TargetRegistr
         u.asm_dir = R.unwrap_ok[str, outcome.Fail](ab_r);
     }
 
-    val op_r: R.Result[str, outcome.Fail] = unit_out_path(a, itn, m, req, ?bu, u.obj_dir);
+    val op_r: R.Result[str, outcome.Fail] = unit_out_path(a, itn, m, req, ?bu, ?tgt, u.obj_dir);
     if (R.is_err[str, outcome.Fail](op_r)) { ret R.err[BuildUnit, outcome.Fail](R.unwrap_err[str, outcome.Fail](op_r)); }
     u.out_path = R.unwrap_ok[str, outcome.Fail](op_r);
 
@@ -394,6 +394,17 @@ fun join_template(a: *A.Allocator, itn: *intern.Interner, root: str, dir_id: int
     ret R.ok[str, outcome.Fail](R.unwrap_ok[str, str](jr));
 }
 
+# whether the target's object format delivers finished modules
+#
+# The third emission shape: `emit_object` writes a complete artifact rather than a
+# link input, so the module tree is the build's delivery and no link phase runs.
+# ---
+# tgt: the resolved target
+# ret: true when the format's object output is the finished artifact
+pub fun finished_modules(tgt: *target.Target) bool {
+    ret tgt.of != nil && tgt.of.object_is_artifact;
+}
+
 # the unit's final artifact path per goal
 #
 # An executable goal applies the `-o` precedence (absolute verbatim, relative
@@ -401,10 +412,19 @@ fun join_template(a: *A.Allocator, itn: *intern.Interner, root: str, dir_id: int
 # an objects goal delivers the object tree root; a tests goal expands the
 # `tests` template with the artifact's product name (falling back to the
 # project id); a test-list goal builds nothing and carries no path.
+#
+# A finished-module target has no linked binary to name, so its execute goal
+# delivers the object tree exactly as an objects goal does - the two produce the
+# same files, which is what makes `mach build --target spirv` and
+# `mach build --emit obj` agree (#2245).
 fun unit_out_path(a: *A.Allocator, itn: *intern.Interner, m: *manifest.Manifest,
-                  req: *request.BuildRequest, bu: *manifest.BuildUnit, obj_dir: str) R.Result[str, outcome.Fail] {
+                  req: *request.BuildRequest, bu: *manifest.BuildUnit,
+                  tgt: *target.Target, obj_dir: str) R.Result[str, outcome.Fail] {
     if (req.goal == request.GOAL_OBJECTS)   { ret R.ok[str, outcome.Fail](obj_dir); }
     if (req.goal == request.GOAL_TEST_LIST) { ret R.ok[str, outcome.Fail](""); }
+    if (req.goal == request.GOAL_EXECUTE && finished_modules(tgt)) {
+        ret R.ok[str, outcome.Fail](obj_dir);
+    }
 
     if (req.goal == request.GOAL_TESTS) {
         # the dispatcher's `{name}`: the artifact's product name, else the
@@ -461,7 +481,9 @@ fun test_exe_fail() R.Result[str, outcome.Fail] {
 # materializes on-disk per-module artifacts: the object tree (a non-flat-image
 # target with an execute, objects, or tests goal) or `.ir`/`.s` dumps.
 # PH_LINK appears for the goals that link: an executable/archive/shared
-# artifact, or the test dispatcher.
+# artifact, or the test dispatcher. A finished-module format links nothing -
+# each emitted module is already the artifact - so its execute goal ends at
+# PH_EMIT with the module tree (#2121).
 fun derive_phases(a: *A.Allocator, itn: *intern.Interner, m: *manifest.Manifest,
                   req: *request.BuildRequest, bu: *manifest.BuildUnit,
                   tgt: *target.Target, u: *BuildUnit) R.Result[bool, outcome.Fail] {
@@ -498,7 +520,7 @@ fun derive_phases(a: *A.Allocator, itn: *intern.Interner, m: *manifest.Manifest,
         val r7: R.Result[bool, outcome.Fail] = push_phase(u, PH_EMIT);
         if (R.is_err[bool, outcome.Fail](r7)) { ret r7; }
     }
-    if (req.goal == request.GOAL_EXECUTE || req.goal == request.GOAL_TESTS) {
+    if ((req.goal == request.GOAL_EXECUTE && !finished_modules(tgt)) || req.goal == request.GOAL_TESTS) {
         val r8: R.Result[bool, outcome.Fail] = push_phase(u, PH_LINK);
         if (R.is_err[bool, outcome.Fail](r8)) { ret r8; }
     }

--- a/src/lang/build/plan.mach
+++ b/src/lang/build/plan.mach
@@ -1230,6 +1230,59 @@ test "mach.lang.build.plan.plan:phases_follow_goal" {
     ret 0;
 }
 
+# a finished-module target's execute goal ends at PH_EMIT and delivers the module
+# tree: each emitted module is already the artifact, so there is nothing to link
+# and no binary path to name. the default goal and `--emit obj` therefore plan
+# identically, which is what makes `mach build --target spirv` write a `.spv`
+# from a manifest that spells no `of` (#2245, #2121)
+test "mach.lang.build.plan.plan:finished_modules_end_at_emit" {
+    var alloc: A.Allocator;
+    var itn:   intern.Interner;
+    var reg:   target.TargetRegistry;
+    var m:     manifest.Manifest;
+    if (!ut_scaffold_src(?alloc, ?itn, ?reg, ?m, "[project]\nid = \"p\"\nversion = \"0.1.0\"\nsrc = \"src\"\nout = \"out/{target.name}/{profile.name}\"\n[target.gpu]\nisa = \"spirv\"\nos = \"freestanding\"\nabi = \"spirv\"\n[profile.debug]\nopt = 0\ndebug = false\nsimd = \"scalarize\"\n[artifact.appa]\nkind = \"bin\"\nentry = \"main.mach\"\nout = \"bin/appa\"\ntargets = [\"*\"]\nlink = []\nneed = []\n")) { ret 1; }
+
+    var rq: request.BuildRequest = request.defaults();
+    rq.project_root = "/r";
+    rq.target       = "gpu";
+    rq.artifact     = "appa";
+
+    val pe: R.Result[BuildPlan, outcome.Fail] = plan(?alloc, ?itn, ?reg, ?m, ?rq);
+    if (R.is_err[BuildPlan, outcome.Fail](pe)) { ret 1; }
+    val ue: *BuildUnit = ?R.unwrap_ok[BuildPlan, outcome.Fail](pe).units.data[0];
+
+    # an execute goal, yet the plan stops at emit and delivers the object tree -
+    # not `/r/out/gpu/debug/bin/appa`, which would need a link that cannot run.
+    if (ue.goal != request.GOAL_EXECUTE)                         { ret 1; }
+    if (ue.phases.len != 5)                                      { ret 1; }
+    if (ue.phases.data[4] != PH_EMIT)                            { ret 1; }
+    if (!ut_path_eq(ue.out_path, "/r/out/gpu/debug/obj"))        { ret 1; }
+    if (!str_equals(ue.out_path, ue.obj_dir))                    { ret 1; }
+
+    # `--emit obj` plans exactly the same unit: the two routes agree.
+    rq.goal = request.GOAL_OBJECTS;
+    val po: R.Result[BuildPlan, outcome.Fail] = plan(?alloc, ?itn, ?reg, ?m, ?rq);
+    if (R.is_err[BuildPlan, outcome.Fail](po)) { ret 1; }
+    val uo: *BuildUnit = ?R.unwrap_ok[BuildPlan, outcome.Fail](po).units.data[0];
+    if (uo.phases.len != ue.phases.len)         { ret 1; }
+    if (!str_equals(uo.out_path, ue.out_path))  { ret 1; }
+
+    # a register-machine target on the same os still links its execute goal, so
+    # the shortcut is the format's declaration and not a goal-wide change.
+    var mr: manifest.Manifest;
+    if (!ut_manifest(?alloc, ?itn, ?mr)) { ret 1; }
+    var rr: request.BuildRequest = request.defaults();
+    rr.project_root = "/r";
+    rr.target       = "ta";
+    rr.artifact     = "appa";
+    val pr: R.Result[BuildPlan, outcome.Fail] = plan(?alloc, ?itn, ?reg, ?mr, ?rr);
+    if (R.is_err[BuildPlan, outcome.Fail](pr)) { ret 1; }
+    val ur: *BuildUnit = ?R.unwrap_ok[BuildPlan, outcome.Fail](pr).units.data[0];
+    if (ur.phases.data[ur.phases.len - 1] != PH_LINK) { ret 1; }
+
+    ret 0;
+}
+
 # a project carrying both a demanded step and a dependency derives its phase
 # list dependency-steps-first: a project step may consume a dep-step artifact,
 # so PH_DEP_STEPS leads PH_STEPS, both ahead of the module-graph load

--- a/src/lang/target.mach
+++ b/src/lang/target.mach
@@ -418,6 +418,7 @@ pub val TUPLE_NO_CODEGEN:   u32 = 1;  # the isa has no instruction selector / en
 pub val TUPLE_ABI_MISMATCH: u32 = 2;  # the calling convention does not target the isa
 pub val TUPLE_OS_NO_OF:     u32 = 3;  # the os cannot link / load the object format
 pub val TUPLE_OF_UNCOVERED: u32 = 4;  # the object format does not cover the isa's relocations
+pub val TUPLE_OF_SHAPE:     u32 = 5;  # the of's emission shape does not match the isa's back-half family
 
 # the joint capability of a fully-resolved (os, isa, abi, of) tuple
 #
@@ -426,8 +427,8 @@ pub val TUPLE_OF_UNCOVERED: u32 = 4;  # the object format does not cover the isa
 # for the tuple rather than one axis: `select_of` turns a non-OK code into a named
 # diagnostic, and `mach info targets` keeps a tuple only when some (abi, of) yields
 # TUPLE_OK. Every fact is self-declared on a vtable - the isa's wired codegen, the
-# abi's target isa, the os's supported formats, the of's isa coverage - so a new
-# target flows through here with no edit.
+# abi's target isa, the os's supported formats, the of's isa coverage and emission
+# shape - so a new target flows through here with no edit.
 # ---
 # os_vt:  the resolved operating-system vtable
 # isa_vt: the resolved instruction-set vtable
@@ -439,6 +440,13 @@ pub fun tuple_capability(os_vt: *os.OsVTable, isa_vt: *isa.IsaVTable, abi_vt: *a
     if (!abi.covers_isa(abi_vt, isa_vt.id)) { ret TUPLE_ABI_MISMATCH; }
     if (!os.supports_of(os_vt, of_vt.name)) { ret TUPLE_OS_NO_OF; }
     if (!of.covers_isa(of_vt, isa_vt.id))   { ret TUPLE_OF_UNCOVERED; }
+    # the two back-half families and the two object shapes pair off exactly. a
+    # whole-module emitter hands over a finished module, which only a
+    # finished-module format can carry and no linker consumes; a register machine
+    # hands over machine text, which a finished-module format has no section to
+    # hold. either crossing composes a tuple that emits nothing, which is how
+    # `freestanding-spirv` came to be advertised while defaulting to `raw` (#2245).
+    if (isa.emits_whole_module(isa_vt) != of_vt.object_is_artifact) { ret TUPLE_OF_SHAPE; }
     ret TUPLE_OK;
 }
 
@@ -479,10 +487,23 @@ fun tuple_capability_message(code: u32, os_vt: *os.OsVTable, isa_vt: *isa.IsaVTa
         if (R.is_err[str, str](r)) { ret fb; }
         ret R.unwrap_ok[str, str](r);
     }
-    # TUPLE_OF_UNCOVERED
-    val fb: str = "object format does not cover the selected instruction set's relocations";
+    if (code == TUPLE_OF_UNCOVERED) {
+        val fb: str = "object format does not cover the selected instruction set's relocations";
+        if (alloc_failed) { ret fb; }
+        val r: R.Result[str, str] = str_join(?alloc, "object format '", of_vt.name, "' does not cover ", isa_vt.name, " relocations");
+        if (R.is_err[str, str](r)) { ret fb; }
+        ret R.unwrap_ok[str, str](r);
+    }
+    # TUPLE_OF_SHAPE - name which side of the pairing the tuple crossed
+    var emits: str = "linkable objects";
+    var takes: str = "finished modules";
+    if (isa.emits_whole_module(isa_vt)) {
+        emits = "finished modules";
+        takes = "linkable objects";
+    }
+    val fb: str = "object format's emission shape does not match the instruction set's";
     if (alloc_failed) { ret fb; }
-    val r: R.Result[str, str] = str_join(?alloc, "object format '", of_vt.name, "' does not cover ", isa_vt.name, " relocations");
+    val r: R.Result[str, str] = str_join(?alloc, "instruction set '", isa_vt.name, "' emits ", emits, ", but object format '", of_vt.name, "' carries ", takes);
     if (R.is_err[str, str](r)) { ret fb; }
     ret R.unwrap_ok[str, str](r);
 }
@@ -821,6 +842,36 @@ test "mach.lang.target.select:spirv_defaults_to_the_finished_module_format" {
     val ov: R.Result[resolved.Target, str] = select_of(?reg, "x86_64", "freestanding", "sysv64", "elf");
     if (R.is_err[resolved.Target, str](ov))                        { ret 1; }
     if (R.unwrap_ok[resolved.Target, str](ov).of.id != of.OF_ELF)  { ret 1; }
+
+    ret 0;
+}
+
+# the two back-half families and the two object shapes pair off exactly, and
+# crossing them fails at composition rather than deep in emit. an ISA that hands
+# over a finished module cannot be written into a flat image or a relocatable
+# container, and a register machine's machine text has no place in a
+# finished-module format. the error names both sides and which shape each carries
+test "mach.lang.target.select_of:rejects_crossed_emission_shapes" {
+    var reg: TargetRegistry = registry_init();
+    if (R.is_err[bool, str](register_all(?reg))) { ret 1; }
+
+    # a whole-module emitter into the flat image the os would otherwise default
+    # to: `raw` lays out load segments over machine text there is none of.
+    val rw: R.Result[resolved.Target, str] = select_of(?reg, "spirv", "freestanding", "spirv", "raw");
+    if (!R.is_err[resolved.Target, str](rw)) { ret 1; }
+    val mw: str = R.unwrap_err[resolved.Target, str](rw);
+    if (!str_contains(mw, "spirv"))           { ret 1; }
+    if (!str_contains(mw, "raw"))             { ret 1; }
+    if (!str_contains(mw, "finished modules")) { ret 1; }
+
+    # and into a relocatable container, which would hand a linker a module.
+    val re: R.Result[resolved.Target, str] = select_of(?reg, "spirv", "freestanding", "spirv", "elf");
+    if (!R.is_err[resolved.Target, str](re)) { ret 1; }
+
+    # the reverse crossing: a register machine into the finished-module format,
+    # which has no section for machine text.
+    val rr: R.Result[resolved.Target, str] = select_of(?reg, "x86_64", "freestanding", "sysv64", "spv");
+    if (!R.is_err[resolved.Target, str](rr)) { ret 1; }
 
     ret 0;
 }

--- a/src/lang/target.mach
+++ b/src/lang/target.mach
@@ -787,6 +787,44 @@ test "mach.lang.target.select_of:object_format_chosen_by_name" {
     ret 0;
 }
 
+# a whole-module emitter takes its object format from the ISA, not the os: the
+# same freestanding os that defaults a register machine to the flat `raw` image
+# resolves spirv to `spv`, the format declaring a finished-module object. that is
+# the whole of #2245 - before it, a default manifest resolved spirv to raw, which
+# refuses object output, so the advertised target could emit nothing at all
+test "mach.lang.target.select:spirv_defaults_to_the_finished_module_format" {
+    var reg: TargetRegistry = registry_init();
+    if (R.is_err[bool, str](register_all(?reg))) { ret 1; }
+
+    # no `of` spelled - exactly what a manifest naming only isa/os/abi gets.
+    val r: R.Result[resolved.Target, str] = select(?reg, "spirv", "freestanding", "spirv");
+    if (R.is_err[resolved.Target, str](r)) { ret 1; }
+    val t: resolved.Target = R.unwrap_ok[resolved.Target, str](r);
+
+    # the isa is the whole-module family, and the os would have said "raw".
+    if (!isa.emits_whole_module(t.isa))      { ret 1; }
+    if (!str_equals(t.os.default_of, "raw")) { ret 1; }
+
+    # yet the resolved format is spv: a finished-module object written as `.spv`,
+    # which is what makes the build deliver the module tree instead of linking.
+    if (t.of == nil)                          { ret 1; }
+    if (t.of.id != of.OF_SPV)                 { ret 1; }
+    if (!t.of.object_is_artifact)             { ret 1; }
+    if (!str_equals(t.of.object_ext, "spv"))  { ret 1; }
+    if (t.of.emit_object == nil)              { ret 1; }
+
+    # the derivation is confined to the whole-module family: a register machine on
+    # the same os still follows the os, and a spelled-out `of` still overrides.
+    val rm: R.Result[resolved.Target, str] = select(?reg, "x86_64", "freestanding", "sysv64");
+    if (R.is_err[resolved.Target, str](rm))                        { ret 1; }
+    if (R.unwrap_ok[resolved.Target, str](rm).of.id != of.OF_RAW)  { ret 1; }
+    val ov: R.Result[resolved.Target, str] = select_of(?reg, "x86_64", "freestanding", "sysv64", "elf");
+    if (R.is_err[resolved.Target, str](ov))                        { ret 1; }
+    if (R.unwrap_ok[resolved.Target, str](ov).of.id != of.OF_ELF)  { ret 1; }
+
+    ret 0;
+}
+
 # the of-by-name path end to end: selecting freestanding with an explicit "raw" of
 # composes the flat-image writer, and emitting a one-segment program through the
 # composed writer produces a flat image - the segment's raw bytes, no container,

--- a/src/lang/target.mach
+++ b/src/lang/target.mach
@@ -9,11 +9,12 @@
 # driver) owns one, `register_all` installs every implementation into it, and
 # `select_of` composes a Target from it by name: it looks up the isa, os, abi, and
 # object-format vtables under the names the manifest spells. The object format is
-# the one substrate with an os-derived default - an empty of name defers to the
-# chosen os's `default_of`, so `select` (the common case) is `select_of` with no
-# override. The legacy os/arch/abi/of ids are derived from the resolved vtables'
-# `.id` fields and kept on the Target, so the id readers and the comptime tag space
-# are unaffected by the name-based composition.
+# the one substrate with a derived default - an empty of name defers to
+# `default_of_name`, the os's `default_of` for a register machine and the
+# finished-module format for a whole-module emitter, so `select` (the common case)
+# is `select_of` with no override. The legacy os/arch/abi/of ids are derived from
+# the resolved vtables' `.id` fields and kept on the Target, so the id readers and
+# the comptime tag space are unaffected by the name-based composition.
 
 use std.allocator.page;
 use fs: std.filesystem;
@@ -232,18 +233,18 @@ pub fun register_all(reg: *TargetRegistry) R.Result[bool, str] {
 # compose a Target from `reg` by name, with an explicit object-format override
 #
 # looks up the isa, os, and abi vtables under their names and resolves the object
-# format under `of_name` when it is non-empty, falling back to the chosen os's
-# `default_of` name when `of_name` is empty. derives the legacy os/arch/abi/of ids
-# from the resolved vtables' `.id` fields. allocates nothing - every vtable pointer
-# is borrowed. fails if any required implementation is not registered in `reg`
-# under the requested name. the of axis is the one substrate with an os-derived
-# default; isa, os, and abi are always spelled explicitly.
+# format under `of_name` when it is non-empty, falling back to `default_of_name`
+# when `of_name` is empty. derives the legacy os/arch/abi/of ids from the resolved
+# vtables' `.id` fields. allocates nothing - every vtable pointer is borrowed.
+# fails if any required implementation is not registered in `reg` under the
+# requested name. the of axis is the one substrate with a derived default; isa,
+# os, and abi are always spelled explicitly.
 # ---
 # reg:      the target registry populated by register_all
 # isa_name: instruction-set name (e.g. "x86_64", "aarch64")
 # os_name:  operating-system name (e.g. "linux", "windows")
 # abi_name: calling-convention name (e.g. "sysv64", "win64", "aapcs64")
-# of_name:  object-format name (e.g. "elf", "raw"), or "" to use the os default
+# of_name:  object-format name (e.g. "elf", "raw"), or "" for the derived default
 # ret:      the composed Target, or an error describing the missing piece
 pub fun select_of(reg: *TargetRegistry, isa_name: str, os_name: str, abi_name: str, of_name: str) R.Result[resolved.Target, str] {
     val opt_os_vt: O.Option[*os.OsVTable] = os.lookup(?reg.os, os_name);
@@ -264,20 +265,27 @@ pub fun select_of(reg: *TargetRegistry, isa_name: str, os_name: str, abi_name: s
         ret R.err[resolved.Target, str](unregistered_message("abi", abi_name, registered_names(reg, DIM_ABI, ?nb[0], 256)));
     }
 
+    val arch_vt: *isa.IsaVTable = O.unwrap[*isa.IsaVTable](opt_arch_vt);
+    val abi_vt:  *abi.AbiVTable = O.unwrap[*abi.AbiVTable](opt_abi_vt);
+
     # an explicit of name selects the object format directly; an empty name defers
-    # to the os default, so deriving the of from the os stays the default and a
+    # to the (os, isa) default, so deriving the of stays the default and a
     # spelled-out name overrides it without disturbing the other axes.
     var of_sel: str = of_name;
-    if (str_empty(of_sel)) { of_sel = os_vt.default_of; }
+    if (str_empty(of_sel)) {
+        val opt_def: O.Option[str] = default_of_name(reg, os_vt, arch_vt);
+        if (O.is_none[str](opt_def)) {
+            ret R.err[resolved.Target, str](no_module_format_message(arch_vt));
+        }
+        of_sel = O.unwrap[str](opt_def);
+    }
     val opt_of_vt: O.Option[*of.OfVTable] = of.lookup(?reg.of, of_sel);
     if (O.is_none[*of.OfVTable](opt_of_vt)) {
         var nb: [256]u8;
         ret R.err[resolved.Target, str](unregistered_message("object-format", of_sel, registered_names(reg, DIM_OF, ?nb[0], 256)));
     }
 
-    val arch_vt: *isa.IsaVTable = O.unwrap[*isa.IsaVTable](opt_arch_vt);
-    val abi_vt:  *abi.AbiVTable = O.unwrap[*abi.AbiVTable](opt_abi_vt);
-    val of_vt:   *of.OfVTable   = O.unwrap[*of.OfVTable](opt_of_vt);
+    val of_vt: *of.OfVTable = O.unwrap[*of.OfVTable](opt_of_vt);
 
     # the joint capability of the resolved tuple: a calling convention is per-ISA,
     # an object format relocates and writes only the ISAs it declares, an OS links
@@ -338,11 +346,60 @@ pub fun select_of(reg: *TargetRegistry, isa_name: str, os_name: str, abi_name: s
     ret R.ok[resolved.Target, str](t);
 }
 
-# compose a Target from `reg` by name, using the chosen os's default object format
+# the object format a target defaults to when the manifest spells no `of`
+#
+# A REGISTER MACHINE's codegen output is relocatable machine text, and which
+# container carries it is the os's business, so the os's `default_of` answers.
+# A WHOLE-MODULE EMITTER's output is a finished module: no os container carries
+# it and no linker consumes it, so the os has nothing to say and the format is
+# the registered one that declares its object output a finished artifact and
+# covers this instruction set (#2245). Both arms read only self-declarations -
+# the same ones `tuple_capability` reads - so a second whole-module family
+# resolves here with no edit.
+# ---
+# reg:    the target registry to search
+# os_vt:  the resolved operating-system vtable
+# isa_vt: the resolved instruction-set vtable
+# ret:    the default object-format name, or none when a whole-module emitter has
+#         no finished-module format registered for it
+fun default_of_name(reg: *TargetRegistry, os_vt: *os.OsVTable, isa_vt: *isa.IsaVTable) O.Option[str] {
+    if (!isa.emits_whole_module(isa_vt)) { ret O.some[str](os_vt.default_of); }
+
+    var i:   u32 = 0;
+    val len: u32 = of.registered_count(?reg.of);
+    for (i < len) {
+        val of_vt: *of.OfVTable = O.unwrap[*of.OfVTable](of.registered(?reg.of, i));
+        if (of_vt.object_is_artifact && of.covers_isa(of_vt, isa_vt.id)) {
+            ret O.some[str](of_vt.name);
+        }
+        i = i + 1;
+    }
+    ret O.none[str]();
+}
+
+# the diagnostic for a whole-module emitter with no finished-module object format
+#
+# A wiring failure, not a user error: the ISA declares it emits finished modules
+# but no registered format carries one for it, so nothing could hold the output.
+# Names the instruction set with its own `name` field, page-allocated through
+# str_join like the tuple diagnostics.
+# ---
+# isa_vt: the resolved instruction-set vtable
+# ret:    the diagnostic message
+fun no_module_format_message(isa_vt: *isa.IsaVTable) str {
+    val fb: str = "instruction set emits whole modules, but no registered object format carries one";
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret fb; }
+    val r: R.Result[str, str] = str_join(?alloc, "instruction set '", isa_vt.name, "' emits whole modules, but no registered object format carries a finished module for it");
+    if (R.is_err[str, str](r)) { ret fb; }
+    ret R.unwrap_ok[str, str](r);
+}
+
+# compose a Target from `reg` by name, using the tuple's default object format
 #
 # the common case: defers to `select_of` with an empty of name, so the object
-# format is derived from the os's `default_of`. isa, os, and abi are spelled
-# explicitly; the of axis follows the os.
+# format is derived through `default_of_name`. isa, os, and abi are spelled
+# explicitly; the of axis follows the os, or the isa for a whole-module emitter.
 # ---
 # reg:      the target registry populated by register_all
 # isa_name: instruction-set name (e.g. "x86_64", "aarch64")

--- a/src/lang/target/of.mach
+++ b/src/lang/target/of.mach
@@ -588,13 +588,16 @@ val OF_ISA_MAX: u32 = 8;
 # the abstract `RK_*` kinds to its own machine relocation types internally. It
 # never branches on `id`.
 #
-# `produces_image` declares whether the format is a container-free flat image
-# (true) or a relocatable-object format that round-trips through `.o` files
-# (false). The build driver dispatches on it: a relocatable format codegens each
-# module to a `.o` (`emit_object`), then the linker reads every input back
-# (`parse_object`) before laying out the executable; a flat-image format has no
+# `produces_image` and `object_is_artifact` name the three emission shapes the
+# build driver dispatches on, and every format is exactly one of them. A
+# RELOCATABLE format (both false: elf, coff, mach-o) codegens each module to a
+# `.o` (`emit_object`), then the linker reads every input back (`parse_object`)
+# before laying out the executable. A FLAT IMAGE (`produces_image`: raw) has no
 # relocatable container, so the driver links straight from the in-memory codegen
-# images and never calls `emit_object`/`parse_object`.
+# images and never calls `emit_object`/`parse_object`. A FINISHED MODULE
+# (`object_is_artifact`: spv) inverts the relocatable shape - `emit_object`
+# writes a complete, self-contained artifact, so the module tree is the build's
+# delivery and there is no link phase at all.
 # ---
 # id:             object-format id (one of OF_*)
 # name:           format name ("elf", "coff", "macho", "raw"); an immutable str constant
@@ -612,6 +615,18 @@ val OF_ISA_MAX: u32 = 8;
 #                 until #2125 lands (its weak-COMDAT carrier duplicates every weak
 #                 body into `.text`, so the coff image diverges from its `.o`),
 #                 keeping coff on the disk round-trip
+# object_is_artifact: true when `emit_object`'s output is a FINISHED artifact
+#                 rather than a linkable input - a self-contained module no
+#                 linker consumes (spv). the build driver reads it to end the
+#                 build at the emit phase and deliver the module tree, so the
+#                 default goal and `--emit obj` produce the same files;
+#                 `target.select_of` reads it to resolve a whole-module
+#                 emitter's object format, which the os cannot supply
+# object_ext:     the filename extension `emit_object`'s output carries, without
+#                 the dot ("o" for elf / coff / mach-o, "spv" for a finished
+#                 SPIR-V module); "" for a format that emits no object at all
+#                 (raw). the emit path names each module's object through it
+#                 rather than assuming `.o`
 # emit_object:    serializes an ObjectImage to a relocatable object file
 # parse_object:   reads a relocatable object file into an ObjectImage
 # emit_exec:      serializes laid-out load segments into a static executable
@@ -653,6 +668,8 @@ pub rec OfVTable {
     name:                str;
     produces_image:      bool;
     links_from_image:    bool;
+    object_is_artifact:  bool;
+    object_ext:          str;
     emit_object:         WriterFn;
     parse_object:        ParserFn;
     emit_exec:           ExecFn;

--- a/src/lang/target/of/coff.mach
+++ b/src/lang/target/of/coff.mach
@@ -3450,6 +3450,9 @@ pub fun register_coff(reg: *of.OfRegistry) R.Result[bool, str] {
     # copy - which the linker re-concatenates into exactly the source section bytes,
     # so linking the in-memory image matches the disk round-trip byte-for-byte.
     coff_vtable.links_from_image = true;
+    # a relocatable `.o` is a link input, never the delivered artifact.
+    coff_vtable.object_is_artifact = false;
+    coff_vtable.object_ext         = "o";
     coff_vtable.emit_object      = coff_emit_object;
     coff_vtable.parse_object     = coff_parse_object;
     coff_vtable.emit_exec        = coff_emit_exec;

--- a/src/lang/target/of/elf.mach
+++ b/src/lang/target/of/elf.mach
@@ -1139,6 +1139,9 @@ pub fun register(reg: *of.OfRegistry) R.Result[bool, str] {
     # RELA keeps the addend out-of-band, so an ELF codegen image equals its parsed
     # `.o`; the executable link consumes the project's images directly.
     elf_vtable.links_from_image = true;
+    # a relocatable `.o` is a link input, never the delivered artifact.
+    elf_vtable.object_is_artifact = false;
+    elf_vtable.object_ext         = "o";
     elf_vtable.emit_object    = emit_object;
     elf_vtable.parse_object   = parse_object;
     elf_vtable.emit_exec      = emit_exec;

--- a/src/lang/target/of/macho.mach
+++ b/src/lang/target/of/macho.mach
@@ -1365,6 +1365,9 @@ pub fun register_macho(reg: *of.OfRegistry) R.Result[bool, str] {
     # post-#1865 the abstract addend is honored uniformly, so a Mach-O codegen
     # image equals its parsed `.o`; the executable link consumes images directly.
     macho_vtable.links_from_image = true;
+    # a relocatable `.o` is a link input, never the delivered artifact.
+    macho_vtable.object_is_artifact = false;
+    macho_vtable.object_ext         = "o";
     macho_vtable.emit_object    = emit_object;
     macho_vtable.parse_object   = parse_object;
     macho_vtable.emit_exec      = emit_exec;

--- a/src/lang/target/of/raw.mach
+++ b/src/lang/target/of/raw.mach
@@ -230,6 +230,10 @@ pub fun register(reg: *of.OfRegistry) R.Result[bool, str] {
     raw_vtable.produces_image = true;
     # a flat image has no `.o` to parse, so it always links straight from memory.
     raw_vtable.links_from_image = true;
+    # a flat image emits no per-module object, so it has neither an artifact
+    # object nor an object extension.
+    raw_vtable.object_is_artifact = false;
+    raw_vtable.object_ext         = "";
     raw_vtable.emit_object    = emit_object;
     raw_vtable.parse_object   = parse_object;
     raw_vtable.emit_exec      = emit_exec;

--- a/src/lang/target/of/spv.mach
+++ b/src/lang/target/of/spv.mach
@@ -7,11 +7,13 @@
 # of the object image). This writer therefore just emits that section's bytes
 # verbatim to the output path - the `.spv` is the final artifact.
 #
-# The format declares itself relocatable-style (`produces_image` false) so the
-# build driver's object-emit path (`mach build --emit obj`) calls `emit_object`
-# once per module and stops, writing one `.spv` per module. Linking several SPIR-V
-# modules into one, and the executable path, are out of the milestone: those hooks
-# are left nil and the format supports `--emit obj` for now.
+# The format is the FINISHED-MODULE emission shape (`object_is_artifact`): it is
+# not a flat load image, and its `emit_object` output is not a link input either -
+# each `.spv` is already the deliverable. The build driver reads that declaration
+# to end the build at the emit phase, so `mach build` and `mach build --emit obj`
+# write the same module tree and there is no executable to link (#2245, #2121).
+# Linking several SPIR-V modules into one is out of the milestone, so
+# `parse_object` and the executable / shared writers are nil.
 
 use std.types.bool.bool;
 use std.types.bool.false;
@@ -81,11 +83,11 @@ fun find_module_section(image: *of.ObjectImage) *of.Section {
 
 # build and install the SPIR-V object-format vtable
 #
-# Declares the format relocatable-style so the object-emit path writes one `.spv`
-# per module through `emit_object`; the linking / executable hooks are nil (out of
-# the milestone). It covers every instruction set (a SPIR-V module carries no
-# machine relocation types) and carries no debug model. Idempotent: the registry
-# entry is write-once.
+# Declares the finished-module emission shape so the build driver writes one `.spv`
+# per module through `emit_object` and stops; the linking / executable hooks are
+# nil (out of the milestone). It covers the SPIR-V instruction set alone - the
+# module bytes come from that ISA's whole-module emitter, and no other ISA produces
+# them - and carries no debug model. Idempotent: the registry entry is write-once.
 # ---
 # reg: the object-format registry to install the vtable into
 # ret: true on success
@@ -98,6 +100,10 @@ pub fun register(reg: *of.OfRegistry) R.Result[bool, str] {
     # a SPIR-V module is never linked into an executable, so it never feeds the
     # in-memory executable-link path.
     spv_vtable.links_from_image = false;
+    # the emitted module is the finished artifact: nothing reads it back, so the
+    # build delivers the module tree instead of linking it.
+    spv_vtable.object_is_artifact = true;
+    spv_vtable.object_ext         = "spv";
     spv_vtable.emit_object    = emit_object;
     # a finished SPIR-V module is never read back, linked, or laid out as an
     # executable in this milestone.
@@ -110,9 +116,11 @@ pub fun register(reg: *of.OfRegistry) R.Result[bool, str] {
     spv_vtable.default_debug       = "";
     spv_vtable.shared_input_ext    = "";
 
-    # a SPIR-V module carries no machine relocation types, so it is isa-agnostic.
-    spv_vtable.covers_isa_any   = true;
+    # only the SPIR-V ISA's whole-module emitter produces the `.spirv` section this
+    # writer serializes, so the format covers that instruction set and no other.
+    spv_vtable.covers_isa_any   = false;
     spv_vtable.covers_isa_count = 0;
+    of.cover_isa(?spv_vtable, isa.ARCH_SPIRV);
 
     of.register(reg, ?spv_vtable);
     ret R.ok[bool, str](true);


### PR DESCRIPTION
`mach info targets` advertised `freestanding-spirv`, but the target could not
produce an artifact by either route: the executable link failed on an unresolved
`_start` (a GPU module has no entry symbol), and `--emit obj` worked only when
the manifest pinned `of = "spv"`, because `os = freestanding` defaults to `raw`,
which refuses object output.

This takes #2245's option 1 — make it work — which is also #2121.

```
mach build . --target <spirv-target>     # -> out/<target>/<profile>/obj/<module>.spv
```

Validated with `spirv-val` (SPIRV-Tools v2026.2 locally, 2025.1 on the CI leg),
not with mach's own reader.

## The third emission shape

An object format declared two shapes: relocatable (`.o` round-trip, then link)
and flat image (`produces_image`, link straight from the in-memory codegen
images). SPIR-V is neither: `emit_object` writes a complete, self-contained
module. `object_is_artifact` names that third shape, and the build driver reads
it to end the build at the emit phase and deliver the module tree — so the
default goal and `--emit obj` produce byte-identical files. `object_ext` names
the extension the object output carries, so the module lands as `.spv`.

`mach test`, and a `static`/`shared` artifact kind, are refused by name on such
a target rather than attempted — there is no executable, archive, or shared
object form for a module.

## The default object format is a function of (os, isa), not the os alone

`target.select_of` fell back to `os.default_of` whenever the manifest spelled no
`of`. That is right for a register machine — which container carries relocatable
machine text is the os's business — but a whole-module emitter's output is a
finished module no os container carries and no linker consumes, so the os has
nothing to say. `default_of_name` splits the two: `emits_whole_module` picks the
registered format that declares a finished-module object and covers the ISA.
Nothing is hardcoded; both arms read the same self-declarations
`tuple_capability` reads, so a second whole-module family resolves with no edit.

## `tuple_capability` accepted a tuple that could emit nothing

Mutation-testing the fix surfaced the deeper defect. Reverting the derivation
left `select` *succeeding* on (spirv, raw): every axis agreed — the isa's
codegen is wired, the abi targets it, freestanding supports raw, and raw covers
every isa — yet raw lays out load segments over machine text a whole-module
emitter never produces. That is precisely how the target came to be advertised
while unbuildable.

The two families and the two shapes pair off exactly, so the joint fact is an
equality: `emits_whole_module(isa) == of.object_is_artifact`. Crossing either
way now fails at composition naming both sides
(`instruction set 'spirv' emits finished modules, but object format 'raw'
carries linkable objects`). With that in place the #2245 defect is structural:
a whole-module tuple can only be advertised through a finished-module format,
and the default resolution picks exactly that format.

`spv` also narrows its ISA coverage to `spirv`. It declared `covers_isa_any`,
which advertised `of = "spv"` for x86_64 and friends — no other ISA produces the
`.spirv` section the writer serializes, and the narrowing is what keeps the
derivation general rather than "the one artifact format".

## Verification

- **Other targets byte-identical**: the dev-HEAD compiler and this one emit
  identical artifacts for all six declared targets × debug/release, plus
  identical 208-object trees for ELF and COFF.
- **Suites**: mach 860/0 (856 baseline + 4 new), mach-std 611/0 at pin
  `eff1e8e`; `int` 81/81 on the linux leg.
- **Fixpoint**: B == C, matching the dev-HEAD baseline exactly (A != B is the
  pre-existing seed lag, identical on both trees).
- **Mutation-tested**: five reverts, each killing the tests that pin it —
  the derivation (3 tests + 2 pre-existing), `finished_modules` (plan test, and
  the real build fails), `object_ext` (target test + the int case finds no
  `.spv`), the shape pairing (crossing test), and `object_is_artifact` (target +
  plan tests; `freestanding-spirv` correctly drops out of `info targets`, which
  the agreement test accepts — it measures agreement, not presence).

## Scope

Structured control flow and `OpFunctionCall` remain #2120: the emitter refuses
shapes beyond straight-line scalar code with its existing loud diagnostic. That
is the SPIR-V back half's v1 boundary, not this change's.

Closes #2245
Closes #2121
