### PR TITLE
fix(me): mem2reg aggregate promotion (#2246) and dce phi cycles (#2247)

### DIFF
--- a/src/lang/me/pass/dce.mach
+++ b/src/lang/me/pass/dce.mach
@@ -2,15 +2,21 @@
 #
 # Two cooperating sweeps run on each non-extern function:
 #
-#   1. value DCE - an instruction whose result is unused and which is removable
-#      once unused (a pure value op, or an OP_PHI, which is not `is_pure` but has
-#      no side effects) is dead. A per-instruction use count drives a worklist:
-#      removing one instruction decrements its operands' counts, which may expose
-#      further dead instructions. Volatile loads and every store/call survive
-#      even when unused, since they may carry side effects. Block lists, not the
-#      instruction pool, are the source of truth for liveness: a pool entry no
-#      longer named by any block - a ghost left by a pass that unlinked it -
-#      contributes no uses and is never seeded, so it cannot pin live values.
+#   1. value DCE - a mark-and-sweep from the roots. The roots are the block-listed
+#      instructions DCE may never remove (the terminators and every side-effecting
+#      opcode - stores, memzeros, calls, allocas, asm, loads, debug values - plus
+#      any volatile op); marking walks their value operands transitively. An
+#      instruction that is removable-when-unused (a pure value op, or an OP_PHI,
+#      which is not `is_pure` but has no side effects) and that no root reaches is
+#      dead. Reachability, not a use count, is the criterion: a use count is exact
+#      on a DAG but wrong on a cycle, where a set of phis naming only each other
+#      keeps every member's count at one and none is ever seeded (#2247). mem2reg
+#      produces such cycles routinely - a slot conditionally stored inside a loop
+#      gets a phi at the merge and another at the loop header, each naming the
+#      other and nothing else. Block lists, not the instruction pool, are the
+#      source of truth for liveness: a pool entry no longer named by any block - a
+#      ghost left by a pass that unlinked it - is neither a root nor a removal
+#      candidate, so it neither pins live values nor is reported dead.
 #   2. reachability DCE - blocks unreachable from the entry block (BlockId 0)
 #      along terminator edges are removed. The block array compacts, every
 #      BlockId reference (terminator targets, predecessor lists, phi incomings)
@@ -94,12 +100,17 @@ fun dce_marked(ctx: ptr, iid: id.InstructionId) bool {
 
 # value DCE for one function
 #
-# Builds a per-instruction use count, seeds a worklist with the unused
-# removable-when-unused instructions, and drains it: each removal decrements its
-# operands' counts and may expose further dead instructions. Block lists are the
-# source of truth for liveness - a pool entry no longer named by any block (a
-# ghost left by an earlier pass) contributes no uses and is never seeded.
-# Survivors are compacted out of their block lists in a final sweep.
+# One sweep over the block lists partitions the listed instructions: a root (an
+# instruction DCE may not remove) is marked live and pushed, a removable one is
+# flagged dead until proven otherwise. Draining the worklist marks each live
+# instruction's value operands live, clearing their dead flags, so what survives
+# is exactly the set the roots reach. A phi cycle no root reaches stays flagged
+# and is removed whole - the case a use count cannot see, since its members keep
+# each other's counts at one. Block lists are the source of truth for liveness: a
+# pool entry no longer named by any block (a ghost left by an earlier pass) is
+# neither seeded as a root nor flagged dead, so it pins nothing and is reported
+# as surviving, exactly as before. The dead instructions are compacted out of
+# their block lists in a final sweep.
 # ---
 # m:   the owning module; its allocator backs the scratch arrays
 # fn:  the function to process
@@ -108,22 +119,22 @@ fun value_dce(m: *ir.Module, fn: *ir.Function) R.Result[bool, str] {
     val ilen: u32 = fn.instr_len;
     if (ilen == 0) { ret R.ok[bool, str](true); }
 
-    val res_use_count: R.Result[*u32, str] = A.allocate[u32](m.alloc, ilen::usize);
-    if (R.is_err[*u32, str](res_use_count)) {
-        ret R.err[bool, str](R.unwrap_err[*u32, str](res_use_count));
+    val res_live: R.Result[*bool, str] = A.allocate[bool](m.alloc, ilen::usize);
+    if (R.is_err[*bool, str](res_live)) {
+        ret R.err[bool, str](R.unwrap_err[*bool, str](res_live));
     }
-    val use_count: *u32 = R.unwrap_ok[*u32, str](res_use_count);
+    val live: *bool = R.unwrap_ok[*bool, str](res_live);
 
     val res_dead: R.Result[*bool, str] = A.allocate[bool](m.alloc, ilen::usize);
     if (R.is_err[*bool, str](res_dead)) {
-        A.deallocate[u32](m.alloc, use_count, ilen::usize);
+        A.deallocate[bool](m.alloc, live, ilen::usize);
         ret R.err[bool, str](R.unwrap_err[*bool, str](res_dead));
     }
     val dead: *bool = R.unwrap_ok[*bool, str](res_dead);
 
     val res_work: R.Result[*id.InstructionId, str] = A.allocate[id.InstructionId](m.alloc, ilen::usize);
     if (R.is_err[*id.InstructionId, str](res_work)) {
-        A.deallocate[u32](m.alloc, use_count, ilen::usize);
+        A.deallocate[bool](m.alloc, live, ilen::usize);
         A.deallocate[bool](m.alloc, dead, ilen::usize);
         ret R.err[bool, str](R.unwrap_err[*id.InstructionId, str](res_work));
     }
@@ -131,14 +142,12 @@ fun value_dce(m: *ir.Module, fn: *ir.Function) R.Result[bool, str] {
 
     var i: u32 = 0;
     for (i < ilen) {
-        use_count[i] = 0;
-        dead[i]      = false;
+        live[i] = false;
+        dead[i] = false;
         i = i + 1;
     }
 
-    count_uses(fn, use_count);
-
-    # seed: every block-listed instruction that is removable-when-unused and unused.
+    # mark: seed the roots from the block lists, then close over their operands.
     var wlen: u32 = 0;
     i = 0;
     for (i < fn.block_count) {
@@ -146,25 +155,25 @@ fun value_dce(m: *ir.Module, fn: *ir.Function) R.Result[bool, str] {
 
         var ii: u32 = 0;
         for (ii < blk.phi_count) {
-            seed_if_dead(fn, blk.phis[ii], use_count, dead, work, ?wlen, ilen);
+            classify_listed(fn, blk.phis[ii], live, dead, work, ?wlen, ilen);
             ii = ii + 1;
         }
 
         ii = 0;
         for (ii < blk.instr_count) {
-            seed_if_dead(fn, blk.instructions[ii], use_count, dead, work, ?wlen, ilen);
+            classify_listed(fn, blk.instructions[ii], live, dead, work, ?wlen, ilen);
             ii = ii + 1;
         }
 
         if (blk.terminator != id.INSTR_NIL) {
-            seed_if_dead(fn, blk.terminator, use_count, dead, work, ?wlen, ilen);
+            classify_listed(fn, blk.terminator, live, dead, work, ?wlen, ilen);
         }
 
         i = i + 1;
     }
 
-    # drain: each removal decrements its operands' use counts, possibly exposing
-    # a freshly dead instruction. `work` doubles as the worklist stack.
+    # drain: a live instruction's value operands are live too. `work` doubles as
+    # the worklist stack; `live` dedups, so each id is pushed at most once.
     for (wlen > 0) {
         wlen = wlen - 1;
         val did:  u32                      = work[wlen]::u32;
@@ -175,31 +184,26 @@ fun value_dce(m: *ir.Module, fn: *ir.Function) R.Result[bool, str] {
             val opt_def: O.Option[u32] = operand_instr_use(inst, ii, ilen);
             if (O.is_some[u32](opt_def)) {
                 val def_id: u32 = O.unwrap[u32](opt_def);
-                if (use_count[def_id] > 0) {
-                    use_count[def_id] = use_count[def_id] - 1;
-                    if (use_count[def_id] == 0 && dead[def_id] == false) {
-                        val target: *instruction.Instruction = ?fn.instrs[def_id];
-                        if (is_removable_when_unused(target)) {
-                            dead[def_id] = true;
-                            work[wlen]   = def_id::id.InstructionId;
-                            wlen         = wlen + 1;
-                        }
-                    }
+                dead[def_id] = false;
+                if (live[def_id] == false) {
+                    live[def_id] = true;
+                    work[wlen]   = def_id::id.InstructionId;
+                    wlen         = wlen + 1;
                 }
             }
             ii = ii + 1;
         }
     }
 
-    # drop the dead instructions from every block's lists through the shared batch
-    # removal helper (the single free path; no private compaction).
+    # sweep: drop the still-flagged instructions from every block's lists through
+    # the shared batch removal helper (the single free path; no private compaction).
     var marks: DceMarks;
     marks.dead = dead;
     marks.ilen = ilen;
     val marks_ptr: *DceMarks = ?marks;
     val res_erase: R.Result[bool, str] = mutate.erase_marked(m, fn, marks_ptr::ptr, dce_marked);
 
-    A.deallocate[u32](m.alloc, use_count, ilen::usize);
+    A.deallocate[bool](m.alloc, live, ilen::usize);
     A.deallocate[bool](m.alloc, dead, ilen::usize);
     A.deallocate[id.InstructionId](m.alloc, work, ilen::usize);
     ret res_erase;
@@ -222,83 +226,36 @@ fun is_removable_when_unused(inst: *instruction.Instruction) bool {
     ret true;
 }
 
-# count value uses of every instruction result across `fn`'s block lists
+# classify one block-listed instruction for the mark phase: a root is marked live
+# and pushed onto the worklist, a removable one is flagged dead until the drain
+# proves a root reaches it
 #
-# Only block-listed instructions (phis, bodies, terminators) contribute; ghost
-# pool entries are skipped, so their operands never pin otherwise-dead values.
+# Only ids the block lists name reach this; a ghost pool entry is therefore
+# neither a root nor a removal candidate.
 # ---
-# fn:        the function to scan
-# use_count: per-instruction use counter, indexed by InstructionId, to fill
-fun count_uses(fn: *ir.Function, use_count: *u32) {
-    var i: u32 = 0;
-    for (i < fn.block_count) {
-        val blk: *ir.Block = ?fn.blocks[i];
-
-        var ii: u32 = 0;
-        for (ii < blk.phi_count) {
-            count_instr_uses(fn, blk.phis[ii], use_count);
-            ii = ii + 1;
-        }
-
-        ii = 0;
-        for (ii < blk.instr_count) {
-            count_instr_uses(fn, blk.instructions[ii], use_count);
-            ii = ii + 1;
-        }
-
-        if (blk.terminator != id.INSTR_NIL) {
-            count_instr_uses(fn, blk.terminator, use_count);
-        }
-
-        i = i + 1;
-    }
-}
-
-# add the value uses contributed by instruction `iid`'s operands to `use_count`
-#
-# A ghost id (not named by any live instruction) is skipped via the bounds-checked
-# lookup, so it contributes nothing.
-# ---
-# fn:        the function owning the instruction
-# iid:       the instruction whose operands to count
-# use_count: per-instruction use counter to increment
-fun count_instr_uses(fn: *ir.Function, iid: id.InstructionId, use_count: *u32) {
-    val opt_inst: O.Option[*instruction.Instruction] = ir.instruction_get(fn, iid);
-    if (O.is_none[*instruction.Instruction](opt_inst)) { ret; }
-    val inst: *instruction.Instruction = O.unwrap[*instruction.Instruction](opt_inst);
-
-    var i: u32 = 0;
-    for (i < inst.operand_count) {
-        val opt_def: O.Option[u32] = operand_instr_use(inst, i, fn.instr_len);
-        if (O.is_some[u32](opt_def)) {
-            val def_id: u32 = O.unwrap[u32](opt_def);
-            use_count[def_id] = use_count[def_id] + 1;
-        }
-        i = i + 1;
-    }
-}
-
-# seed the worklist with `iid` when it is removable-when-unused and currently
-# unused, marking it dead and pushing it
-# ---
-# fn:        the function owning the instruction
-# iid:       the candidate instruction
-# use_count: per-instruction use counts
-# dead:      per-instruction dead flags, indexed by InstructionId
-# work:      the worklist stack of dead instruction ids
-# wlen:      in/out worklist length, advanced when `iid` is seeded
-# ilen:      the instruction pool length (the bound on every per-instruction array)
-fun seed_if_dead(fn: *ir.Function, iid: id.InstructionId, use_count: *u32, dead: *bool, work: *id.InstructionId, wlen: *u32, ilen: u32) {
+# fn:   the function owning the instruction
+# iid:  the listed instruction to classify
+# live: per-instruction live marks, indexed by InstructionId
+# dead: per-instruction dead flags, indexed by InstructionId
+# work: the worklist stack of live instruction ids
+# wlen: in/out worklist length, advanced when `iid` is pushed
+# ilen: the instruction pool length (the bound on every per-instruction array)
+fun classify_listed(fn: *ir.Function, iid: id.InstructionId, live: *bool, dead: *bool, work: *id.InstructionId, wlen: *u32, ilen: u32) {
     val idx: u32 = iid::u32;
     if (idx >= ilen) { ret; }
-    if (dead[idx])   { ret; }
 
     val opt_inst: O.Option[*instruction.Instruction] = ir.instruction_get(fn, iid);
     if (O.is_none[*instruction.Instruction](opt_inst)) { ret; }
     val inst: *instruction.Instruction = O.unwrap[*instruction.Instruction](opt_inst);
 
-    if (is_removable_when_unused(inst) && use_count[idx] == 0) {
-        dead[idx]   = true;
+    if (is_removable_when_unused(inst)) {
+        dead[idx] = true;
+        ret;
+    }
+    # `live` dedups the push, so the worklist takes each id at most once and stays
+    # within its pool-length allocation.
+    if (live[idx] == false) {
+        live[idx]   = true;
         work[@wlen] = iid;
         @wlen       = @wlen + 1;
     }
@@ -630,6 +587,86 @@ test "mach.lang.me.pass.dce.run:unused_phi_removed" {
     if (R.is_err[bool, str](res_run)) { ret 1; }
 
     if ((?fn.blocks[join::u32]).phi_count != 0) { ret 1; }
+    ret 0;
+}
+
+# #2247: a phi cycle no root reaches is dead even though every member's use count
+# stays at one. this builds the shape mem2reg leaves for a slot conditionally stored
+# inside a loop - a phi at the loop header naming the merge phi, and a phi at the
+# merge naming the header phi, with nothing else naming either. the mark-and-sweep
+# removes both; the use-count seed it replaced never reaches zero on either, so
+# reverting `value_dce` to that form leaves one phi in each block and fails here.
+test "mach.lang.me.pass.dce.run:dead_phi_cycle_removed" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+
+    val res_module: R.Result[ir.Module, str] = ir.init(?alloc, intern.STR_NIL);
+    if (R.is_err[ir.Module, str](res_module)) { ret 1; }
+    var m: ir.Module = R.unwrap_ok[ir.Module, str](res_module);
+
+    val res_i64: R.Result[type.IrTypeId, str] = type.intern_int(?m.types, 64);
+    if (R.is_err[type.IrTypeId, str](res_i64)) { ret 1; }
+    val i64t: type.IrTypeId = R.unwrap_ok[type.IrTypeId, str](res_i64);
+
+    val res_fn: R.Result[u32, str] = ir.function_add(?m, intern.STR_NIL, type.IRT_NIL, 0);
+    if (R.is_err[u32, str](res_fn)) { ret 1; }
+    val fn: *ir.Function = ?m.functions[R.unwrap_ok[u32, str](res_fn)];
+
+    var bld: builder.Builder = builder.init(?m);
+    builder.set_function(?bld, fn);
+
+    # entry -> header -> body -> {then, latch}; then -> latch; latch -> header.
+    val rb0: R.Result[id.BlockId, str] = builder.new_block(?bld);
+    val rb1: R.Result[id.BlockId, str] = builder.new_block(?bld);
+    val rb2: R.Result[id.BlockId, str] = builder.new_block(?bld);
+    val rb3: R.Result[id.BlockId, str] = builder.new_block(?bld);
+    val rb4: R.Result[id.BlockId, str] = builder.new_block(?bld);
+    val rb5: R.Result[id.BlockId, str] = builder.new_block(?bld);
+    if (R.is_err[id.BlockId, str](rb0) || R.is_err[id.BlockId, str](rb1) || R.is_err[id.BlockId, str](rb2)) { ret 1; }
+    if (R.is_err[id.BlockId, str](rb3) || R.is_err[id.BlockId, str](rb4) || R.is_err[id.BlockId, str](rb5)) { ret 1; }
+    val entry:  id.BlockId = R.unwrap_ok[id.BlockId, str](rb0);
+    val header: id.BlockId = R.unwrap_ok[id.BlockId, str](rb1);
+    val body:   id.BlockId = R.unwrap_ok[id.BlockId, str](rb2);
+    val then_b: id.BlockId = R.unwrap_ok[id.BlockId, str](rb3);
+    val latch:  id.BlockId = R.unwrap_ok[id.BlockId, str](rb4);
+    val exit_b: id.BlockId = R.unwrap_ok[id.BlockId, str](rb5);
+
+    # both phis exist before either names the other.
+    builder.set_block(?bld, header);
+    val res_ph: R.Result[value.Value, str] = builder.emit_phi(?bld, i64t);
+    if (R.is_err[value.Value, str](res_ph)) { ret 1; }
+    val phi_h: value.Value = R.unwrap_ok[value.Value, str](res_ph);
+
+    builder.set_block(?bld, latch);
+    val res_pm: R.Result[value.Value, str] = builder.emit_phi(?bld, i64t);
+    if (R.is_err[value.Value, str](res_pm)) { ret 1; }
+    val phi_m: value.Value = R.unwrap_ok[value.Value, str](res_pm);
+
+    val cond: value.Value = value.param(0, i64t);
+
+    builder.set_block(?bld, entry);
+    if (R.is_err[bool, str](builder.emit_br(?bld, header)))              { ret 1; }
+    builder.set_block(?bld, header);
+    if (R.is_err[bool, str](builder.emit_cbr(?bld, cond, body, exit_b))) { ret 1; }
+    builder.set_block(?bld, body);
+    if (R.is_err[bool, str](builder.emit_cbr(?bld, cond, then_b, latch))) { ret 1; }
+    builder.set_block(?bld, then_b);
+    if (R.is_err[bool, str](builder.emit_br(?bld, latch)))               { ret 1; }
+    builder.set_block(?bld, latch);
+    if (R.is_err[bool, str](builder.emit_br(?bld, header)))              { ret 1; }
+    builder.set_block(?bld, exit_b);
+    if (R.is_err[bool, str](builder.emit_ret(?bld, value.const_int(0, i64t)))) { ret 1; }
+
+    # the cycle: header takes the latch phi, latch takes the header phi.
+    if (R.is_err[bool, str](builder.phi_add_incoming(?bld, phi_h, entry, value.const_int(0, i64t)))) { ret 1; }
+    if (R.is_err[bool, str](builder.phi_add_incoming(?bld, phi_h, latch, phi_m)))                    { ret 1; }
+    if (R.is_err[bool, str](builder.phi_add_incoming(?bld, phi_m, then_b, value.const_int(7, i64t)))) { ret 1; }
+    if (R.is_err[bool, str](builder.phi_add_incoming(?bld, phi_m, body, phi_h)))                      { ret 1; }
+
+    if (R.is_err[bool, str](run(?m))) { ret 1; }
+
+    if ((?fn.blocks[header::u32]).phi_count != 0) { ret 1; }
+    if ((?fn.blocks[latch::u32]).phi_count != 0)  { ret 1; }
     ret 0;
 }
 

--- a/src/lang/me/pass/mem2reg.mach
+++ b/src/lang/me/pass/mem2reg.mach
@@ -11,6 +11,12 @@
 # iterated frontier of each alloca's defining blocks, then rename in
 # dominator-tree order with a per-alloca value stack. Aliasing is intentionally
 # trivial -- only allocas whose address never escapes are touched.
+#
+# The pass promotes a slot into SSA *values*, and an aggregate has no SSA value
+# form in this IR: it flows by address. So an aggregate slot is promotable only in
+# the degenerate case where nothing reads it, where promotion means deleting memory
+# traffic no one can observe rather than producing a value, and it takes no phi
+# (#2246).
 
 use std.allocator.page;
 use std.collections.map;
@@ -32,6 +38,7 @@ use mach.lang.me.ir.instruction;
 use mach.lang.me.ir.mutate;
 use mach.lang.me.ir.type;
 use mach.lang.me.ir.value;
+use mach.lang.me.ir.verify;
 use mach.lang.source;
 use semtype: mach.lang.type;
 
@@ -258,13 +265,16 @@ fun phi_table_init(st: *State) R.Result[bool, str] {
 }
 
 # classify promotable allocas: an OP_ALLOCA whose result Value is referenced
-# only as the pointer operand of an OP_LOAD or OP_STORE
+# only as the pointer operand of an OP_LOAD or OP_STORE, and whose slot type is
+# either a scalar or an aggregate nothing reads
 #
 # Any other reference (the stored value of a store, a gep base, a call argument,
 # ...) means the address escaped and the alloca stays in memory. Each accepted
 # alloca's value (slot) type is recorded in the parallel alloca_ty array, derived
 # from its first (lowest-id) load/store -- the alloca's own result type is always
-# the IR pointer type.
+# the IR pointer type. An aggregate slot that is read back is rejected as well
+# (#2246): an aggregate has no SSA value form here, so there is nothing to
+# substitute a load of one with (see compact_promotable).
 #
 # Block lists are the liveness source of truth (mirroring dce): the per-
 # instruction instr_block map is filled from them first, and every sweep skips
@@ -332,19 +342,29 @@ fun collect_promotable(st: *State) R.Result[bool, str] {
     val res_escaped: R.Result[*bool, str] = A.allocate[bool](st.alloc, cand_n::usize);
     if (R.is_err[*bool, str](res_escaped)) { ret R.err[bool, str](R.unwrap_err[*bool, str](res_escaped)); }
     val escaped: *bool = R.unwrap_ok[*bool, str](res_escaped);
-    var e: u32 = 0;
-    for (e < cand_n) { escaped[e] = false; e = e + 1; }
 
-    classify_escapes(st, escaped);
-    compact_promotable(st, escaped);
+    val res_loaded: R.Result[*bool, str] = A.allocate[bool](st.alloc, cand_n::usize);
+    if (R.is_err[*bool, str](res_loaded)) {
+        A.deallocate[bool](st.alloc, escaped, cand_n::usize);
+        ret R.err[bool, str](R.unwrap_err[*bool, str](res_loaded));
+    }
+    val loaded: *bool = R.unwrap_ok[*bool, str](res_loaded);
+
+    var e: u32 = 0;
+    for (e < cand_n) { escaped[e] = false; loaded[e] = false; e = e + 1; }
+
+    classify_escapes(st, escaped, loaded);
+    compact_promotable(st, escaped, loaded);
     A.deallocate[bool](st.alloc, escaped, cand_n::usize);
+    A.deallocate[bool](st.alloc, loaded, cand_n::usize);
     if (st.alloca_count == 0) { ret R.ok[bool, str](true); }
 
     ret collect_store_blocks(st);
 }
 
 # one classification sweep over the live instructions: record each candidate's
-# slot type from its first load/store and mark every escape
+# slot type from its first load/store, mark every escape, and note which
+# candidates are read back
 #
 # An escape is any reference outside load-slot-0 / store-slot-1, or an inline-asm
 # {name} binding -- an asm-referenced alloca is addressed as [rbp + offset] at
@@ -352,7 +372,8 @@ fun collect_promotable(st: *State) R.Result[bool, str] {
 # ---
 # st:      state with the candidate set already gathered
 # escaped: per-candidate escape flags, written true where the address escapes
-fun classify_escapes(st: *State, escaped: *bool) {
+# loaded:  per-candidate read flags, written true where a load reads the slot
+fun classify_escapes(st: *State, escaped: *bool, loaded: *bool) {
     val fn: *ir.Function = st.fn;
     var c: u32 = 0;
     for (c < st.pool_len) {
@@ -378,6 +399,7 @@ fun classify_escapes(st: *State, escaped: *bool) {
                             if (ok_load == false && ok_store == false) {
                                 escaped[ai] = true;
                             } or {
+                                if (ok_load) { loaded[ai] = true; }
                                 if (st.alloca_ty[ai] == type.IRT_NIL) {
                                     if (ok_load) { st.alloca_ty[ai] = inst.ty; }
                                     or           { st.alloca_ty[ai] = inst.operands[0].ty; }
@@ -393,18 +415,27 @@ fun classify_escapes(st: *State, escaped: *bool) {
     }
 }
 
-# compact the escaped candidates out (keeping pool-id order) and retag the
+# compact the rejected candidates out (keeping pool-id order) and retag the
 # alloca_of map with the surviving indices
+#
+# A candidate is rejected when its address escapes, or when it is an aggregate slot
+# that is read back (#2246): an aggregate has no SSA value form in this IR - it flows
+# by address - so substituting a load of one with the value a store placed in the slot
+# would alias the source's storage instead of copying it. An aggregate slot that is
+# never read is still promotable, in the degenerate sense of deleting memory traffic
+# no one can observe; insert_phis places no phi for it.
 # ---
 # st:      state whose alloca_ids / alloca_ty / alloca_of are rewritten in place
 # escaped: per-candidate escape flags from classify_escapes
-fun compact_promotable(st: *State, escaped: *bool) {
+# loaded:  per-candidate read flags from classify_escapes
+fun compact_promotable(st: *State, escaped: *bool, loaded: *bool) {
     val cand_n: u32 = st.alloca_count;
     var w: u32 = 0;
     var r: u32 = 0;
     for (r < cand_n) {
         val aid: id.InstructionId = st.alloca_ids[r];
-        if (escaped[r] == false) {
+        val agg_read: bool = loaded[r] && type.is_aggregate(?st.m.types, st.alloca_ty[r]);
+        if (escaped[r] == false && agg_read == false) {
             st.alloca_ids[w]       = aid;
             st.alloca_ty[w]        = st.alloca_ty[r];
             st.alloca_of[aid::u32] = w;
@@ -885,6 +916,14 @@ fun frontier_add(st: *State, node: u32, target: id.BlockId) {
 # blocks themselves rejoin the worklist (iterated frontier). Each inserted phi
 # records the alloca it stands for in phi_alloca so rename can wire its incoming
 # values.
+#
+# An aggregate slot is skipped (#2246). A phi exists to merge a slot's value for a
+# later read, and an aggregate slot only survives collect_promotable when nothing
+# reads it, so every phi placed for one would be dead on arrival - and would be
+# stamped with the aggregate type, whose only legal operand form is an address.
+# On a path with no prior store rename has no address to offer and substitutes
+# `const_null`, which the aggregate-representation invariant (VC_AGG_ADDRESS)
+# forbids and the back end would read as a null pointer.
 # ---
 # st:  state with store blocks and dominance frontiers ready
 # ret: ok(true) once every phi is placed, or the first error encountered
@@ -914,6 +953,7 @@ fun insert_phis(st: *State) R.Result[bool, str] {
     var a: u32 = 0;
     for (a < st.alloca_count && err_msg == nil) {
         val alloca_id: id.InstructionId = st.alloca_ids[a];
+        if (type.is_aggregate(?st.m.types, st.alloca_ty[a])) { a = a + 1; cnt; }
         var i: u32 = 0;
         for (i < n) { has_phi[i] = false; on_work[i] = false; i = i + 1; }
 
@@ -1802,5 +1842,153 @@ test "mach.lang.me.pass.mem2reg.run:phi_dbg_birth" {
         i = i + 1;
     }
     if (!found) { ret 1; }
+    ret 0;
+}
+
+# count the VC_AGG_ADDRESS violations the representation checks report for `m`
+# (test helper)
+# ---
+# m:   the module to verify
+# ret: the number of aggregate-representation violations, or -1 on an allocation error
+fun agg_address_violations(m: *ir.Module) i64 {
+    val res_rep: R.Result[verify.VerifyReport, str] = verify.verify_module_ext(m, m.alloc, false, true);
+    if (R.is_err[verify.VerifyReport, str](res_rep)) { ret -1; }
+    var rep: verify.VerifyReport = R.unwrap_ok[verify.VerifyReport, str](res_rep);
+    var n: i64 = 0;
+    var i: u32 = 0;
+    for (i < rep.len) {
+        if (rep.violations[i].check == verify.VC_AGG_ADDRESS) { n = n + 1; }
+        i = i + 1;
+    }
+    verify.dnit_report(?rep);
+    ret n;
+}
+
+# #2246: an aggregate slot copied into on one arm of a diamond, never read. mem2reg
+# used to promote it, place a phi of aggregate type at the merge, and - on the arm
+# with no prior store - hand that phi a `value.const_null`, which the aggregate
+# representation invariant forbids (an aggregate operand must name storage by
+# address) and the back end would read as a null pointer. The slot is still promoted
+# (nothing reads it, so its alloca and stores are dead memory traffic), but no phi is
+# placed, so no undefined incoming can arise. Reverting either half of the fix - the
+# aggregate skip in insert_phis, or the read-back rejection in compact_promotable -
+# leaves a phi in the merge block and a VC_AGG_ADDRESS violation here.
+test "mach.lang.me.pass.mem2reg.run:aggregate_slot_takes_no_phi" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+    val res_module: R.Result[ir.Module, str] = ir.init(?alloc, intern.STR_NIL);
+    if (R.is_err[ir.Module, str](res_module)) { ret 1; }
+    var m: ir.Module = R.unwrap_ok[ir.Module, str](res_module);
+
+    val res_i64: R.Result[type.IrTypeId, str] = type.intern_int(?m.types, 64);
+    if (R.is_err[type.IrTypeId, str](res_i64)) { ret 1; }
+    var i64t: type.IrTypeId = R.unwrap_ok[type.IrTypeId, str](res_i64);
+
+    # a two-i64 struct: an aggregate, so it flows by address.
+    var fields: [2]type.IrTypeId;
+    fields[0] = i64t;
+    fields[1] = i64t;
+    val res_st: R.Result[type.IrTypeId, str] = type.intern_struct(?m.types, ?fields[0], 2, 0);
+    if (R.is_err[type.IrTypeId, str](res_st)) { ret 1; }
+    val stty: type.IrTypeId = R.unwrap_ok[type.IrTypeId, str](res_st);
+
+    val res_fn: R.Result[u32, str] = ir.function_add(?m, intern.STR_NIL, type.IRT_NIL, 0);
+    if (R.is_err[u32, str](res_fn)) { ret 1; }
+    val fn: *ir.Function = ?m.functions[R.unwrap_ok[u32, str](res_fn)];
+
+    var bld: builder.Builder = builder.init(?m);
+    builder.set_function(?bld, fn);
+
+    val rb0: R.Result[id.BlockId, str] = builder.new_block(?bld);
+    val rb1: R.Result[id.BlockId, str] = builder.new_block(?bld);
+    val rb2: R.Result[id.BlockId, str] = builder.new_block(?bld);
+    val rb3: R.Result[id.BlockId, str] = builder.new_block(?bld);
+    if (R.is_err[id.BlockId, str](rb0) || R.is_err[id.BlockId, str](rb1)) { ret 1; }
+    if (R.is_err[id.BlockId, str](rb2) || R.is_err[id.BlockId, str](rb3)) { ret 1; }
+    val entry: id.BlockId = R.unwrap_ok[id.BlockId, str](rb0);
+    val arm:   id.BlockId = R.unwrap_ok[id.BlockId, str](rb1);
+    val skip:  id.BlockId = R.unwrap_ok[id.BlockId, str](rb2);
+    val merge: id.BlockId = R.unwrap_ok[id.BlockId, str](rb3);
+
+    # entry: s = alloca St; cbr p0, arm, skip   -- no store dominates the merge.
+    builder.set_block(?bld, entry);
+    val res_alloca: R.Result[value.Value, str] = builder.emit_alloca(?bld, stty, value.const_int(1, i64t));
+    if (R.is_err[value.Value, str](res_alloca)) { ret 1; }
+    val s: value.Value = R.unwrap_ok[value.Value, str](res_alloca);
+    if (R.is_err[bool, str](builder.emit_cbr(?bld, value.param(0, i64t), arm, skip))) { ret 1; }
+
+    # arm: store p1 -> s   (a whole-aggregate copy; the parameter carries its storage)
+    builder.set_block(?bld, arm);
+    if (R.is_err[bool, str](builder.emit_store(?bld, value.param(1, stty), s))) { ret 1; }
+    if (R.is_err[bool, str](builder.emit_br(?bld, merge)))                      { ret 1; }
+
+    # skip: br merge   -- the arm the old promotion handed a const_null
+    builder.set_block(?bld, skip);
+    if (R.is_err[bool, str](builder.emit_br(?bld, merge))) { ret 1; }
+
+    # merge: ret p0    -- the slot is never read
+    builder.set_block(?bld, merge);
+    if (R.is_err[bool, str](builder.emit_ret(?bld, value.param(0, i64t)))) { ret 1; }
+
+    if (R.is_err[bool, str](run(?m))) { ret 1; }
+
+    # the dead copy still goes: the alloca and its store leave the block lists.
+    if (live_alloca_count(fn, ?fn.blocks[entry::u32]) != 0) { ret 1; }
+    # no phi of aggregate type is placed anywhere, so no undefined incoming exists.
+    var b: u32 = 0;
+    for (b < fn.block_count) {
+        if ((?fn.blocks[b]).phi_count != 0) { ret 1; }
+        b = b + 1;
+    }
+    if (agg_address_violations(?m) != 0) { ret 1; }
+    ret 0;
+}
+
+# #2246: an aggregate slot that is read back is not promotable at all. Substituting
+# the load with the value a store placed in the slot would hand the reader the
+# SOURCE's address - an alias, not the copy the store performed. The slot stays in
+# memory; dropping the read-back rejection promotes it and the alloca disappears.
+test "mach.lang.me.pass.mem2reg.run:read_aggregate_slot_stays_in_memory" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+    val res_module: R.Result[ir.Module, str] = ir.init(?alloc, intern.STR_NIL);
+    if (R.is_err[ir.Module, str](res_module)) { ret 1; }
+    var m: ir.Module = R.unwrap_ok[ir.Module, str](res_module);
+
+    val res_i64: R.Result[type.IrTypeId, str] = type.intern_int(?m.types, 64);
+    if (R.is_err[type.IrTypeId, str](res_i64)) { ret 1; }
+    var i64t: type.IrTypeId = R.unwrap_ok[type.IrTypeId, str](res_i64);
+
+    var fields: [2]type.IrTypeId;
+    fields[0] = i64t;
+    fields[1] = i64t;
+    val res_st: R.Result[type.IrTypeId, str] = type.intern_struct(?m.types, ?fields[0], 2, 0);
+    if (R.is_err[type.IrTypeId, str](res_st)) { ret 1; }
+    val stty: type.IrTypeId = R.unwrap_ok[type.IrTypeId, str](res_st);
+
+    val res_fn: R.Result[u32, str] = ir.function_add(?m, intern.STR_NIL, type.IRT_NIL, 0);
+    if (R.is_err[u32, str](res_fn)) { ret 1; }
+    val fn: *ir.Function = ?m.functions[R.unwrap_ok[u32, str](res_fn)];
+
+    var bld: builder.Builder = builder.init(?m);
+    builder.set_function(?bld, fn);
+    val res_entry: R.Result[id.BlockId, str] = builder.new_block(?bld);
+    if (R.is_err[id.BlockId, str](res_entry)) { ret 1; }
+    val entry: id.BlockId = R.unwrap_ok[id.BlockId, str](res_entry);
+    builder.set_block(?bld, entry);
+
+    # s = alloca St; store p0 -> s; v = load s; ret p1 -- v names the copy, not p0.
+    val res_alloca: R.Result[value.Value, str] = builder.emit_alloca(?bld, stty, value.const_int(1, i64t));
+    if (R.is_err[value.Value, str](res_alloca)) { ret 1; }
+    val s: value.Value = R.unwrap_ok[value.Value, str](res_alloca);
+    if (R.is_err[bool, str](builder.emit_store(?bld, value.param(0, stty), s))) { ret 1; }
+    val res_load: R.Result[value.Value, str] = builder.emit_load(?bld, s, stty);
+    if (R.is_err[value.Value, str](res_load)) { ret 1; }
+    if (R.is_err[bool, str](builder.emit_ret(?bld, value.param(1, i64t)))) { ret 1; }
+
+    if (R.is_err[bool, str](run(?m))) { ret 1; }
+
+    # the slot keeps its storage: the read must observe the copy, not its source.
+    if (live_alloca_count(fn, ?fn.blocks[entry::u32]) != 1) { ret 1; }
     ret 0;
 }


### PR DESCRIPTION
Two middle-end passes surfaced by SROA (#2205), fixed independently.

Closes #2246
Closes #2247

---

## #2246 — mem2reg promotes an aggregate slot and substitutes a null it cannot represent

### Reproduction

The promotion path is live on `dev`. A probe build of the compiler (instrumented
`mem2reg`, reporting every promoted candidate whose `alloca_ty` is an aggregate)
finds **11 sites** in a release self-build, and from source:

```mach
fun diamond(c: i64, a: Agg, b: Agg) i64 {
    var s: Agg = a;
    if (c > 0) { s = b; }
    ret c + 1;                       # s is never read
}
```

promotes an aggregate slot and **places an aggregate-typed phi** at the merge
(`stores=2 phis=1`). Both arms store, so both incomings are address-producing and
`--verify-ir` stays quiet — which is exactly the issue's "not a bug on `dev` today,
but a live trap". The `const_null` half needs the arm-only store the issue names, and
that shape is only constructible directly in IR (an aggregate local from source always
carries a memzero, and the inliner hoists a cloned callee slot into the entry block, so
the store always dominates). Built directly — an `alloca St` in the entry, a
whole-aggregate `store %p1` on one arm of a diamond, no loads — `dev`'s pass yields
**1 phi and exactly 1 VC_AGG_ADDRESS violation** (measured by asserting those counts
against the reverted pass; the test passes with `!= 1` flipped in).

### Why the obvious guard is not inert — accounted per module

Dropping every aggregate-`alloca_ty` candidate reproduces the issue's report exactly:
`fe/sema/infer`, `target/abi/{aapcs64, mos6502, spirv, sysv, win64}` — six objects,
release. The probe explains all six. **Every one of the 11 promotions has
`loads=0 stores=1 phis=0`**: it is the home slot of an **unused by-value aggregate
parameter**, e.g. `sysv.classify_arg`'s `agg: abi.AggLayout` ("lp64d-only; unused
under SysV"). The lowerer emits `%s = alloca Agg; store %pN -> %s`; mem2reg promotes
it and `strip_promoted` deletes both, so the dead copy vanishes.

With the naive guard the slot survives mem2reg, **SROA then splits it field-wise**,
and the resulting leaf loads on the parameter cannot be removed — `is_pure(OP_LOAD)`
is `false`, so DCE never drops a load. Minimal case, reduced from `classify_arg`:

```
# dev
fn @ignores(%p0: i64, %p1: {i8, [2]{i8, i32, i8}}): i64 {
  block bb0:  %5 = add i64 %p0, 1 ;  ret %5

# naive guard: +17 instructions, six dead leaf loads
  block bb0:  %9  = gep ptr %p1, 0, 0 ;  %10 = load i8 %9
              ... 6 gep/load pairs over the aggregate's leaves ...
              %5 = add i64 %p0, 1 ;  ret %5
```

### Fix

The pass promotes a slot into SSA **values**, and an aggregate has no SSA value form
in this IR — it flows by address. So:

- an aggregate slot that is **read back** is not promotable at all. Substituting the
  load with the value a store placed in the slot hands the reader the *source's*
  address — an alias, not the copy the store performed. (Not just conservative: that
  is a miscompile the pass would otherwise be free to commit.)
- what survives is an aggregate slot **nothing reads**, where promotion means deleting
  unobservable memory traffic and no phi is needed — so `insert_phis` places none, and
  no undefined incoming can arise.

### Result

The 11 promotions `dev` relies on all keep. **Objects byte-identical on all five
targets, both profiles** (208/208 each), so the six modules stay untouched:

| target | release | debug |
|---|---|---|
| linux-x86_64 | 0 differ | 0 differ |
| linux-arm64 | 0 differ | 0 differ |
| linux-riscv64 | 0 differ | 0 differ |
| windows-x86_64 | 0 differ | 0 differ |
| darwin-aarch64 | 0 differ | 0 differ |

---

## #2247 — dce's use-count sweep cannot remove a dead phi cycle

### Reproduction

```mach
fun kernel(n: i64) i64 {
    var acc: i64 = 0;  var dead: i64 = 0;  var i: i64 = 0;
    for (i < n) {
        if (i % 2 == 0) { dead = 7; }
        acc = acc + i;  i = i + 1;
    }
    ret acc;
}
```

`dev`, `--emit-ir` (release) — `%32` and `%31` name only each other, and survive:

```
block bb1:  %32 = phi i64 [bb0 0, bb6 %31]        # loop header
block bb6:  %31 = phi i64 [bb4 7, bb5 %32]        # merge
```

and in the emitted asm the cycle costs a callee-saved register (`r12`, spilled in the
prologue), plus `mov r12, rsi` / `mov r12, 7` / `mov rsi, r12` per iteration.

### Fix

Mark-and-sweep from the roots over the same removability policy: the block-listed
instructions DCE may not remove are the roots, marking walks their value operands
transitively, and a removable instruction no root reaches is dead. Ghost pool entries
stay outside both sets, so they still pin nothing and are still reported as surviving.

### Measured win

A register-pressure kernel with eight live accumulators and six conditionally-stored
dead slots (the `result_chain` cost model the issue cites), release, x86_64:

| | dev | branch |
|---|---|---|
| loop-body instructions | 119 | 30 |
| stack loads / iteration | 27 | 4 |
| stack stores / iteration | 27 | 3 |
| retired instructions | 19.27 G | 11.33 G (−41%) |
| cycles | 4.55 G | 2.08 G (−54%) |
| wall | 1.34 s | 0.61 s (**2.2x**) |

Output checksum identical on both. The dead cycles were not just extra phis: they held
enough registers to spill all eight live accumulators, which is why the win exceeds the
issue's "six loads and six stores".

Over the compiler's own source, total object bytes (same input, both compilers):

| target | release | debug |
|---|---|---|
| linux-x86_64 | −8.4% | −1.2% |
| linux-arm64 | −17.1% | −2.4% |
| linux-riscv64 | −12.6% | −1.2% |
| windows-x86_64 | −9.1% | −1.3% |
| darwin-aarch64 | −20.9% | −3.2% |

`.text` alone on linux-x86_64 release: 11,541,349 → 10,076,350 (−12.7%).

### Output delta — per target, both profiles

`dce` is in the always-on sequence, so this is **not** additive with the current debug
output, as the issue anticipated. Same source, two compilers:

| target | release | debug |
|---|---|---|
| linux-x86_64 | 107 / 208 objects | 86 / 208 |
| linux-arm64 | 107 / 208 | 86 / 208 |
| linux-riscv64 | 107 / 208 | 86 / 208 |
| windows-x86_64 | 108 / 208 | 87 / 208 |
| darwin-aarch64 | 107 / 208 | 86 / 208 |

Every change is a removal of a dead phi cycle (and the pure computation only that
cycle kept alive): every target shrinks, on both profiles, and no golden needed
re-blessing — the int observables are behavioural and all 79 linux cases plus the
full riscv64 leg pass unchanged.

`-g` additivity holds: `.text` byte-identical with and without `-g` across all 208
objects, on both profiles.

---

## Verification

- **Fixpoint** — three generations, both profiles: `B == C == D` on release and on
  debug (the seed-built generation A differs, as expected, since the 4.2.2 seed lacks
  both fixes).
- **Suites** — `dev` baseline read fresh: mach **856 / 0**, mach-std **611 / 0** at
  pin `eff1e8e` (`git rev-parse HEAD` checked against `mach.lock`). Branch: mach
  **859 / 0** (+3 new tests), mach-std **611 / 0**.
- **int** — `linux` 79 / 79 pass, `linux-riscv64` all pass under qemu, no re-bless.
  The `linux-arm64` leg is `native` in `targets.conf` and cannot execute on this
  x86_64 host; CI covers it.
- **`--verify-ir`** — clean over a full compiler self-build on both profiles, and over
  the mach-std suite.

### Mutations

| test | mutation | result |
|---|---|---|
| `dce.run:dead_phi_cycle_removed` | restore `dev`'s use-count `value_dce` | **4 passed, 1 failed** / 5 |
| `mem2reg.run:aggregate_slot_takes_no_phi` | drop the `insert_phis` aggregate skip | **5 passed, 1 failed** / 6 |
| `mem2reg.run:read_aggregate_slot_stays_in_memory` | drop the read-back rejection | **5 passed, 1 failed** / 6 |
| both mem2reg tests | restore `dev`'s whole `mem2reg` | **4 passed, 2 failed** / 6 |

With the fixes in place: 5 / 5 and 6 / 6.

---

## Note for a follow-up (no change made here)

`sroa.mach` is untouched, as scoped. Its design note records that it "builds no phis"
because an earlier snapshot-at-edges shape left six dead loop-carried phis that DCE
could not remove — the cost measured above. That cost is now gone, so the shared-slot
partition and its two extra rules (a read-only-and-local phi, self-contained incoming
slots) are no longer forced by *this* constraint and a per-incoming design may be back
on the table. Whether it is actually simpler is a SROA design question I did not
attempt; worth a follow-up issue rather than a change here.
