### PR TITLE
feat(codegen): leaf frame elision (#1940)

### DIFF
--- a/int/lib/produce.sh
+++ b/int/lib/produce.sh
@@ -397,6 +397,114 @@ vector_emit_scan() {
     '
 }
 
+# produce_frame_elision <runmode> <target> <binary>
+# the frame-elision observable (#1940): for each function of the case's own module,
+# whether the emitted prologue builds a frame.
+#
+# execution cannot see this. a frameless leaf and a framed one compute the same
+# answer, so a case that only runs the program is green whether the elision fires,
+# stops firing, or fires on a function that must keep its frame - the last of which
+# is a miscompile (an incoming stack parameter addressed off a frame pointer that
+# was never established). the verdict is read from the bytes for that reason.
+#
+# it disassembles the OBJECTS, not the linked binary: mach's linker emits no symbol
+# table, so per-function attribution exists only before the link. the objects sit
+# beside the artifact because the case pins `out = "out/int/build"` in its own
+# manifest, and the project id is read from that manifest rather than assumed - the
+# same arrangement produce_vector_emit uses.
+produce_frame_elision() {
+    bin=$3
+    dir=$(dirname "$(dirname "$(dirname "$bin")")")
+    id=$(sed -n 's/^[[:space:]]*id[[:space:]]*=[[:space:]]*"\([^"]*\)".*/\1/p' "$dir/mach.toml" | head -1)
+    if [ -z "$id" ]; then
+        echo "int: frame-elision: no project id in ${dir}/mach.toml" >&2; return 2
+    fi
+    objdir="$dir/out/int/build/obj/$id"
+    if [ ! -d "$objdir" ]; then
+        echo "int: frame-elision: no objects at $objdir (the case must pin out = \"out/int/build\")" >&2; return 2
+    fi
+    tool=$(resolve_objdump) || {
+        echo "int: frame-elision: llvm-objdump not found (install the 'llvm' package)" >&2; return 2
+    }
+    find "$objdir" -name '*.o' | sort | while IFS= read -r o; do
+        "$tool" -d --no-show-raw-insn "$o"
+    done | frame_elision_scan
+}
+
+# frame_elision_scan — read a disassembly on stdin, print `<function> framed|frameless`
+# sorted by function, preceded by the ISA the dispatch resolved.
+#
+# the verdict is the FIRST instruction only, which is what makes the observable
+# stable: a function's body moves with every unrelated backend change, while its
+# first instruction is the frame decision and nothing else.
+#   x86_64  — `push %rbp` opens every framed prologue.
+#   aarch64 — `stp x29, x30, [sp, #-N]!` is the record-at-top prologue.
+#   riscv64 — `addi sp, sp, -N` opens the frame allocation.
+frame_elision_scan() {
+    awk '
+    function demangle(s,   i, len, c, out) {
+        if (substr(s, 1, 2) != "_M") { return s }
+        i = 3
+        out = ""
+        while (i <= length(s)) {
+            c = substr(s, i, 1)
+            if (c == "N") { i++; continue }
+            if (c !~ /[0-9]/) { return s }
+            len = 0
+            while (i <= length(s) && substr(s, i, 1) ~ /[0-9]/) { len = len * 10 + substr(s, i, 1); i++ }
+            out = substr(s, i, len)
+            i += len
+        }
+        if (out == "") { return s }
+        return out
+    }
+    function framed(m, rest) {
+        if (isa == "x86_64")  { return m ~ /^push/ && rest ~ /%rbp/ }
+        if (isa == "aarch64") { return m == "stp" && rest ~ /x29,[[:space:]]*x30/ }
+        if (isa == "riscv64") { return m == "addi" && rest ~ /^sp,[[:space:]]*sp,[[:space:]]*-/ }
+        return 0
+    }
+    /file format/ {
+        if      ($0 ~ /x86-64/)   { isa = "x86_64" }
+        else if ($0 ~ /aarch64/)  { isa = "aarch64" }
+        else if ($0 ~ /riscv/)    { isa = "riscv64" }
+        else                      { bad = $0 }
+        next
+    }
+    /^[0-9a-f]+ <.*>:$/ {
+        sym = $0
+        sub(/^[0-9a-f]+ </, "", sym)
+        sub(/>:$/, "", sym)
+        sym = demangle(sym)
+        if (!(sym in seen)) { names[++n] = sym; seen[sym] = 1; verdict[sym] = "frameless" }
+        cur = sym
+        first = 1
+        next
+    }
+    cur != "" && first == 1 && /^[[:space:]]*[0-9a-f]+:/ {
+        line = $0
+        sub(/^[[:space:]]*[0-9a-f]+:[[:space:]]*/, "", line)
+        split(line, f, /[[:space:]]+/)
+        rest = line
+        sub(/^[^[:space:]]+[[:space:]]*/, "", rest)
+        if (framed(f[1], rest)) { verdict[cur] = "framed" }
+        first = 0
+    }
+    END {
+        if (bad != "") { print "int: frame-elision: unrecognized object format (" bad ")" > "/dev/stderr"; exit 2 }
+        # insertion-sort the names so the observable does not depend on emission order
+        for (i = 2; i <= n; i++) {
+            k = names[i]
+            j = i - 1
+            while (j >= 1 && names[j] > k) { names[j + 1] = names[j]; j-- }
+            names[j + 1] = k
+        }
+        print "arch=" isa
+        for (i = 1; i <= n; i++) { print names[i] " " verdict[names[i]] }
+    }
+    '
+}
+
 # produce <run> <runmode> <target> <binary> [<g_binary>]
 # dispatches to the producer named by <run>, forwarding the remaining arguments. the
 # debuginfo producer takes an extra `-g` artifact path run.sh built alongside the
@@ -413,6 +521,7 @@ produce() {
         built)       produce_built "$@" ;;
         debuginfo)   produce_debuginfo "$@" ;;
         vector-emit) produce_vector_emit "$@" ;;
+        frame-elision) produce_frame_elision "$@" ;;
         *) echo "int: unknown run mode '$run'" >&2; return 2 ;;
     esac
 }

--- a/int/surface/frame-elision/case.conf
+++ b/int/surface/frame-elision/case.conf
@@ -1,0 +1,20 @@
+# leaf frame elision (#1940): each function carries a verdict — `frameless` when the
+# back end must emit no prologue, `framed` when it must — read out of the disassembled
+# objects. execution cannot see this: a frameless leaf and a framed one compute the
+# same answer, so a case that only ran the program would be green whether the elision
+# fires, stops firing, or fires on a function that must keep its frame.
+#
+# `many_params` is the one the third case protects. its tail arguments arrive on the
+# caller's stack and are addressed off the frame pointer, so eliding its frame is a
+# miscompile that still returns the right answer for small inputs.
+#
+# release only: the elision itself is profile-independent, but a debug build's extra
+# spill slots leave nothing frameless to observe.
+#
+# the ELF legs only: the verdict is a property of the ISA (how many caller-saved
+# registers the allocator has before it must take a callee-saved one), not of the OS,
+# so the windows and darwin legs would re-assert their linux twins' codegen. they are
+# also the legs without a dependable llvm-objdump.
+run: frame-elision
+profiles: release
+targets: linux linux-arm64 linux-riscv64

--- a/int/surface/frame-elision/expect.linux-arm64.txt
+++ b/int/surface/frame-elision/expect.linux-arm64.txt
@@ -1,8 +1,11 @@
 arch=aarch64
+asm_and_call frameless
 asm_owned frameless
+bare_call framed
 calls_out framed
 leaf_pure frameless
 leaf_wide frameless
 leaf_with_slot framed
 main framed
 many_params framed
+stack_param framed

--- a/int/surface/frame-elision/expect.linux-arm64.txt
+++ b/int/surface/frame-elision/expect.linux-arm64.txt
@@ -1,0 +1,8 @@
+arch=aarch64
+asm_owned frameless
+calls_out framed
+leaf_pure frameless
+leaf_wide frameless
+leaf_with_slot framed
+main framed
+many_params framed

--- a/int/surface/frame-elision/expect.linux-riscv64.txt
+++ b/int/surface/frame-elision/expect.linux-riscv64.txt
@@ -1,0 +1,8 @@
+arch=riscv64
+asm_owned frameless
+calls_out framed
+leaf_pure frameless
+leaf_wide frameless
+leaf_with_slot framed
+main framed
+many_params framed

--- a/int/surface/frame-elision/expect.linux-riscv64.txt
+++ b/int/surface/frame-elision/expect.linux-riscv64.txt
@@ -1,8 +1,11 @@
 arch=riscv64
+asm_and_call frameless
 asm_owned frameless
+bare_call framed
 calls_out framed
 leaf_pure frameless
 leaf_wide frameless
 leaf_with_slot framed
 main framed
 many_params framed
+stack_param framed

--- a/int/surface/frame-elision/expect.linux.txt
+++ b/int/surface/frame-elision/expect.linux.txt
@@ -1,0 +1,8 @@
+arch=x86_64
+asm_owned frameless
+calls_out framed
+leaf_pure frameless
+leaf_wide frameless
+leaf_with_slot framed
+main framed
+many_params framed

--- a/int/surface/frame-elision/expect.linux.txt
+++ b/int/surface/frame-elision/expect.linux.txt
@@ -1,8 +1,11 @@
 arch=x86_64
+asm_and_call frameless
 asm_owned frameless
+bare_call framed
 calls_out framed
 leaf_pure frameless
 leaf_wide frameless
 leaf_with_slot framed
 main framed
 many_params framed
+stack_param framed

--- a/int/surface/frame-elision/mach.toml
+++ b/int/surface/frame-elision/mach.toml
@@ -1,0 +1,41 @@
+[project]
+id = "case"
+version = "0.0.0"
+src = "src"
+# a fixed out root, not the usual {target.name}/{profile.name} template: the
+# frame-elision producer disassembles the per-module objects this build leaves
+# behind, so their path must be the same on every leg. run.sh wipes out/int before
+# and after each build, so one target's objects can never be read on another's run.
+out = "out/int/build"
+
+[target.linux]
+isa = "x86_64"
+os  = "linux"
+abi = "sysv64"
+
+[target.linux-arm64]
+isa = "aarch64"
+os  = "linux"
+abi = "aapcs64"
+
+[target.linux-riscv64]
+isa = "riscv64"
+os  = "linux"
+abi = "lp64"
+
+[profile.release]
+opt = 2
+debug = false
+simd = "scalarize"
+
+[artifact.case]
+kind = "bin"
+entry = "main.mach"
+out = "bin/case"
+targets = ["*"]
+link = []
+need = []
+
+[dep.mach-std]
+git = "https://github.com/briar-systems/mach-std"
+ref = "branch/main"

--- a/int/surface/frame-elision/src/main.mach
+++ b/int/surface/frame-elision/src/main.mach
@@ -46,6 +46,17 @@ pub fun calls_out(x: i64) i64 {
     ret hook_leaf_pure(x) + 2;
 }
 
+# a DIRECT call in tail position with nothing live across it: the callee needs no
+# register to name and no value has to survive it, so the allocator takes no
+# callee-saved register and the frame is kept for the call boundary ALONE. FRAMED -
+# and the only function here that isolates the leaf requirement, since `calls_out`
+# keeps its frame for the callee-saved register holding its indirect target as well.
+# self-recursion is what keeps the call direct and still out of line.
+pub fun bare_call(x: i64) i64 {
+    if (x <= 0) { ret 0; }
+    ret bare_call(x - 1);
+}
+
 # more integer parameters than the ABI passes in registers, so the tail ones arrive
 # on the caller's stack and are addressed off the frame pointer. FRAMED even though
 # it is a leaf that allocates nothing of its own - and the case the elision would
@@ -53,6 +64,15 @@ pub fun calls_out(x: i64) i64 {
 pub fun many_params(a: i64, b: i64, c: i64, d: i64, e: i64, f: i64,
                     g: i64, h: i64, i: i64, j: i64) i64 {
     ret a + b + c + d + e + f + g + h + i + j;
+}
+
+# the same frame reference with none of the register pressure: it reads ONE
+# stack-passed parameter and returns it, so `many_params`'s callee-saved register is
+# not also holding its frame in place. FRAMED, on every target, for the frame
+# reference alone - this is the shape that pins the miscompile guard.
+pub fun stack_param(a: i64, b: i64, c: i64, d: i64, e: i64, f: i64,
+                    g: i64, h: i64, i: i64, j: i64) i64 {
+    ret j;
 }
 
 # an inline-asm body owns the stack itself, so the compiler adds no prologue even
@@ -71,12 +91,35 @@ pub fun asm_owned() {
     }
 }
 
+# an asm body that also makes a call - the one shape where the two reasons disagree.
+# the leaf rule would keep this frame; the asm rule omits it, because a body carrying
+# asm is opaque and the programmer owns the stack. FRAMELESS.
+#
+# this is the pre-existing naked-function contract, pinned rather than endorsed: with
+# no frame the stack pointer is 8 mod 16 at that call, so the callee sees a stack the
+# SysV boundary does not permit. under this rule the programmer owns that, which is
+# why the function is never called here - it exists to be compiled and read.
+pub fun asm_and_call() {
+    $if ($mach.build.arch == $mach.arch.x86_64) {
+        asm x86_64 { nop }
+    }
+    $or ($mach.build.arch == $mach.arch.aarch64) {
+        asm aarch64 { nop }
+    }
+    $or {
+        asm riscv64 { nop }
+    }
+    bare_call(0);
+}
+
 # the indirection that keeps every function above out of line
 var hook_leaf_pure: UnaryFn = leaf_pure;
 var hook_leaf_wide: UnaryFn = leaf_wide;
 var hook_with_slot: UnaryFn = leaf_with_slot;
 var hook_calls_out: UnaryFn = calls_out;
 var hook_asm_owned: NilFn   = asm_owned;
+var hook_bare_call: UnaryFn = bare_call;
+var hook_asm_call:  NilFn   = asm_and_call;
 
 # the results are summed into the exit status rather than printed: printing would
 # instantiate the stdlib's generic Result helpers into this module, and their shapes
@@ -92,6 +135,8 @@ fun main(argc: usize, argv: **u8) i64 {
     t = t + hook_with_slot(x);
     t = t + hook_calls_out(x);
     t = t + many_params(x, x, x, x, x, x, x, x, x, x);
+    t = t + stack_param(x, x, x, x, x, x, x, x, x, x);
     hook_asm_owned();
+    t = t + hook_bare_call(x);
     ret t & 1;
 }

--- a/int/surface/frame-elision/src/main.mach
+++ b/int/surface/frame-elision/src/main.mach
@@ -1,0 +1,97 @@
+# leaf frame elision (#1940): one function per reason the back end may or may not
+# emit a frame, each carrying a verdict the producer reads out of the emitted bytes.
+#
+# every function is reached through a module-scope `hook` so the inliner cannot fold
+# it into its caller: a function inlined away emits no prologue at all and its verdict
+# would silently vanish from the golden rather than fail it.
+
+use std.runtime;
+use std.types.size.usize;
+
+def UnaryFn: fun(i64) i64;
+def NilFn:   fun();
+
+# the shape the elision exists for: a leaf with no slots, no callee saves, no
+# outgoing arguments and no frame reference. FRAMELESS.
+pub fun leaf_pure(x: i64) i64 {
+    ret x + 1;
+}
+
+# a leaf holding several values live at once, but with nothing on the stack.
+# FRAMELESS while the allocator finds enough caller-saved registers, FRAMED where it
+# must take a callee-saved one - which is why the verdict is pinned per target rather
+# than shared.
+pub fun leaf_wide(x: i64) i64 {
+    val a: i64 = x + 1;
+    val b: i64 = x + 2;
+    val c: i64 = x + 3;
+    val d: i64 = x + 4;
+    ret ((a * b) ^ (c * d)) + (a ^ d);
+}
+
+# a leaf that still needs stack storage: the array is indexed by a runtime value, so
+# it cannot be promoted out of memory. FRAMED with no call involved at all.
+pub fun leaf_with_slot(x: i64) i64 {
+    var buf: [4]i64;
+    buf[0] = x;
+    buf[1] = x + 1;
+    buf[2] = x + 2;
+    buf[3] = x + 3;
+    ret buf[(x & 3)::usize];
+}
+
+# makes a call, so its stack pointer must stay 16-byte aligned at the call boundary -
+# which the frame-pointer push is what establishes. FRAMED.
+pub fun calls_out(x: i64) i64 {
+    ret hook_leaf_pure(x) + 2;
+}
+
+# more integer parameters than the ABI passes in registers, so the tail ones arrive
+# on the caller's stack and are addressed off the frame pointer. FRAMED even though
+# it is a leaf that allocates nothing of its own - and the case the elision would
+# miscompile if it ignored frame references.
+pub fun many_params(a: i64, b: i64, c: i64, d: i64, e: i64, f: i64,
+                    g: i64, h: i64, i: i64, j: i64) i64 {
+    ret a + b + c + d + e + f + g + h + i + j;
+}
+
+# an inline-asm body owns the stack itself, so the compiler adds no prologue even
+# though nothing proves the body is a leaf. FRAMELESS. this is the pre-existing
+# naked-function rule the elision now shares a mechanism with, so a change that
+# breaks it shows up here too.
+pub fun asm_owned() {
+    $if ($mach.build.arch == $mach.arch.x86_64) {
+        asm x86_64 { nop }
+    }
+    $or ($mach.build.arch == $mach.arch.aarch64) {
+        asm aarch64 { nop }
+    }
+    $or {
+        asm riscv64 { nop }
+    }
+}
+
+# the indirection that keeps every function above out of line
+var hook_leaf_pure: UnaryFn = leaf_pure;
+var hook_leaf_wide: UnaryFn = leaf_wide;
+var hook_with_slot: UnaryFn = leaf_with_slot;
+var hook_calls_out: UnaryFn = calls_out;
+var hook_asm_owned: NilFn   = asm_owned;
+
+# the results are summed into the exit status rather than printed: printing would
+# instantiate the stdlib's generic Result helpers into this module, and their shapes
+# would then ride in this case's golden and churn it on unrelated stdlib work.
+#
+# argc is a runtime value, so no call below folds at compile time.
+#[symbol("main")]
+fun main(argc: usize, argv: **u8) i64 {
+    val x: i64 = argc::i64;
+    var t: i64 = 0;
+    t = t + hook_leaf_pure(x);
+    t = t + hook_leaf_wide(x);
+    t = t + hook_with_slot(x);
+    t = t + hook_calls_out(x);
+    t = t + many_params(x, x, x, x, x, x, x, x, x, x);
+    hook_asm_owned();
+    ret t & 1;
+}

--- a/src/lang/be/codegen.mach
+++ b/src/lang/be/codegen.mach
@@ -377,7 +377,7 @@ fun pack_image(s: *session.Session, tgt: *target.Target, irmod: *ir.Module,
             obj.dnit(?image);
             ret R.err[of.ObjectImage, str]("codegen: debug producer registered no produce hook");
         }
-        val res_dwarf: R.Result[bool, str] = tgt.debug.produce::dwarf.ProduceFn(s, tgt, irmod, ?image, enc.rows, enc.row_count, enc.varlocs, enc.varloc_count, enc.inline_pcs, enc.inline_pc_count, dbg.producer, dbg.comp_dir, text_sec);
+        val res_dwarf: R.Result[bool, str] = tgt.debug.produce::dwarf.ProduceFn(s, tgt, irmod, mirmod, ?image, enc.rows, enc.row_count, enc.varlocs, enc.varloc_count, enc.inline_pcs, enc.inline_pc_count, dbg.producer, dbg.comp_dir, text_sec);
         if (R.is_err[bool, str](res_dwarf)) {
             obj.dnit(?image);
             ret R.err[of.ObjectImage, str](R.unwrap_err[bool, str](res_dwarf));

--- a/src/lang/be/codegen/dwarf.mach
+++ b/src/lang/be/codegen/dwarf.mach
@@ -32,6 +32,7 @@ use O: std.types.option;
 use R: std.types.result;
 
 use enc: mach.lang.be.codegen.encode;
+use mach.lang.be.codegen.mir;
 use mach.lang.be.obj;
 use mach.lang.me.ir;
 use ir_type: mach.lang.me.ir.type;
@@ -326,6 +327,10 @@ fun resolve(itn: *intern.Interner, id: intern.StrId) str {
 #            void or an unresolved type (no DW_AT_type)
 # var_start: index of this function's first variable in the shared var array
 # var_count: number of variables this function contributes
+# omit:      true when the back end emitted no frame for this function
+#            (`mir.MirFrame.omit`, #1940), so its DW_AT_frame_base names the stack
+#            pointer rather than a frame-pointer register that still holds the
+#            caller's value
 rec DwFunc {
     name:      intern.StrId;
     offset:    u32;
@@ -339,6 +344,7 @@ rec DwFunc {
     ret_ty:    i32;
     var_start: u32;
     var_count: u32;
+    omit:      bool;
 }
 
 # a variable that lives in one place for its whole scope uses VLOC_REG / VLOC_FRAME /
@@ -960,17 +966,38 @@ fun sem_to_ir_nominal(s: *session.Session, dtypes: *ir_type.IrTypeTable, tid: se
 # DWARF-based targets always wire the hook, so this is defined for every arch that
 # reaches the producer
 #
-# A subprogram's DW_AT_frame_base is `DW_OP_reg<this>`, so `-g` debug info relies on
-# a retained frame pointer (the epic pins one instead of emitting CFI). The back end
-# always emits the rbp/x29/s0 prologue today; a future frame-pointer-omission
-# optimization must stay disabled under a debug build or DW_AT_fbreg locations and
-# `DW_AT_frame_base` would point at a clobbered register.
+# A subprogram's DW_AT_frame_base is `DW_OP_reg<this>`, so a function with a frame
+# resolves its `DW_AT_fbreg` variable locations against a retained frame pointer (the
+# epic pins one instead of emitting CFI). A frame-omitting function (#1940) never took
+# a frame pointer, so this register still holds the CALLER's value there and
+# `frame_base_omit_reg` supplies its base instead.
 # ---
 # tgt: the resolved target
 # ret: the frame pointer's DWARF register number
 fun frame_base_reg(tgt: *target.Target) i32 {
     val f: isa.DwarfRegFn = tgt.arch.dwarf_reg;
     ret f(tgt.arch.frame_ptr_reg);
+}
+
+# the DWARF register number a frame-omitting function's DW_AT_frame_base names -
+# the stack pointer
+#
+# A function reaches `MirFrame.omit` only with no slots, no callee saves, no
+# outgoing-argument region and no call, so nothing in its body moves the stack
+# pointer: it holds the entry value for the whole body and is the one register that
+# describes the (empty) frame truthfully. Naming the frame-pointer register instead
+# would describe the CALLER's frame.
+#
+# No `DW_AT_fbreg` location can occur inside such a function - fbreg locations come
+# from frame slots and it has none - so this base is emitted for completeness rather
+# than to be dereferenced. That is the point: a location added later resolves against
+# a true base rather than silently against the caller's.
+# ---
+# tgt: the resolved target
+# ret: the stack pointer's DWARF register number
+fun frame_base_omit_reg(tgt: *target.Target) i32 {
+    val f: isa.DwarfRegFn = tgt.arch.dwarf_reg;
+    ret f(tgt.arch.stack_ptr_reg);
 }
 
 # the largest number of distinct source files a compile unit's file table holds
@@ -1540,7 +1567,8 @@ fun resolve_type_fixups(b: *enc.ByteBuf, tc: *TypeCtx, fixups: *TypeFixup, nfix:
 # name:         DW_AT_name text (the CU's primary source path)
 # comp_dir:     DW_AT_comp_dir text
 # high_pc:      code span in bytes (high_pc - low_pc)
-# fb_reg:       frame-base DWARF register number
+# fb_reg:       frame-base DWARF register number for a function with a frame
+# fb_omit_reg:  frame-base DWARF register number for a frame-omitting function
 # funcs/nfuncs: the module's functions (with resolved decl / return metadata)
 # tc:           the gathered type table (with resolved DIE / string offsets)
 # relocs:       out - the InfoReloc list
@@ -1549,7 +1577,7 @@ fun resolve_type_fixups(b: *enc.ByteBuf, tc: *TypeCtx, fixups: *TypeFixup, nfix:
 # stmt_off:     out - byte offset of the CU 4-byte stmt_list field
 # fixups:       scratch - the type-DIE ref4 patch list (cap >= type count + member count)
 fun build_info(b: *enc.ByteBuf, address_size: u8, producer: str, name: str, comp_dir: str,
-               high_pc: u64, fb_reg: i32, funcs: *DwFunc, nfuncs: u32, tc: *TypeCtx,
+               high_pc: u64, fb_reg: i32, fb_omit_reg: i32, funcs: *DwFunc, nfuncs: u32, tc: *TypeCtx,
                vars: *DwVar, relocs: *InfoReloc, reloc_count: *u32, low_off: *u32, stmt_off: *u32,
                s: *session.Session, irmod: *ir.Module, strtab: *StrTab,
                inlines: *DwInline, ninl: u32, iranges: *DwInlineRange, fixups: *TypeFixup) {
@@ -1626,7 +1654,9 @@ fun build_info(b: *enc.ByteBuf, address_size: u8, producer: str, name: str, comp
         if (fn.external) { enc.emit_byte(b, 1); } or { enc.emit_byte(b, 0); }
         uleb(b, fn.decl_file::u64);
         uleb(b, fn.decl_line::u64);
-        emit_frame_base(b, fb_reg);
+        # a frame-omitting function never took a frame pointer, so its base is the
+        # stack pointer it did not move.
+        if (fn.omit) { emit_frame_base(b, fb_omit_reg); } or { emit_frame_base(b, fb_reg); }
         if (fn.ret_ty >= 0) { enc.emit_u32(b, tc.types[fn.ret_ty::u32].off); }   # DW_AT_type (ref4)
 
         # the subprogram's own variable / parameter children: instance-0 vars, plus any
@@ -2349,12 +2379,33 @@ fun count_funcs(image: *of.ObjectImage, text_sec: u32) u32 {
     ret n;
 }
 
+# report whether the back end emitted `name` without a frame
+#
+# The symbol name is the MIR function name (the encoder marks the entry symbol from
+# `MirFunction.name`), so the interned ids compare directly. A name with no MIR
+# function - there is none today, the symbols come from the same module - answers
+# false, the framed shape.
+# ---
+# mirmod: the laid-out MIR module
+# name:   the interned function symbol name
+# ret:    true when the function's frame was omitted (#1940)
+fun mir_omits_frame(mirmod: *mir.MirModule, name: intern.StrId) bool {
+    if (mirmod == nil) { ret false; }
+    var i: u32 = 0;
+    for (i < mirmod.function_len) {
+        if (mirmod.functions[i].name == name) { ret mirmod.functions[i].frame.omit; }
+        i = i + 1;
+    }
+    ret false;
+}
+
 # gather the module's `.text` functions into `out`, sorted by ascending offset
 # ---
 # image:    the object image whose symbols are gathered
+# mirmod:   the laid-out MIR module, for each function's frame-omission fact
 # text_sec: the `.text` section index
 # out:      destination array, sized `count_funcs`
-fun gather_funcs(image: *of.ObjectImage, text_sec: u32, out: *DwFunc) {
+fun gather_funcs(image: *of.ObjectImage, mirmod: *mir.MirModule, text_sec: u32, out: *DwFunc) {
     var n: u32 = 0;
     var i: u32 = 0;
     for (i < image.symbol_count) {
@@ -2364,6 +2415,7 @@ fun gather_funcs(image: *of.ObjectImage, text_sec: u32, out: *DwFunc) {
             out[n].offset   = sym.offset;
             out[n].external = (sym.flags & of.SYM_OBJ_FLAG_GLOBAL) != 0;
             out[n].weak     = (sym.flags & of.SYM_OBJ_FLAG_WEAK) != 0;
+            out[n].omit     = mir_omits_frame(mirmod, sym.name);
             n = n + 1;
         }
         i = i + 1;
@@ -2447,7 +2499,7 @@ fun add_reloc_addend(image: *of.ObjectImage, sec: u32, offset: u32, kind: of.Rel
 # target, the IR module, and the encoder's output - every one of which imports the
 # target layer the vtable lives in - so a typed field there would invert the
 # dependency. `be.codegen` casts `tgt.debug.produce` back to this before calling it.
-pub def ProduceFn: fun(*session.Session, *target.Target, *ir.Module,
+pub def ProduceFn: fun(*session.Session, *target.Target, *ir.Module, *mir.MirModule,
                        *of.ObjectImage, *enc.LineRow, u32,
                        *enc.VarLoc, u32,
                        *enc.InlinePc, u32,
@@ -2465,6 +2517,8 @@ pub def ProduceFn: fun(*session.Session, *target.Target, *ir.Module,
 # s:        session (source map, type universe)
 # tgt:      resolved target (address size, frame-pointer register)
 # irmod:    IR module supplying each function's source name and semantic return type
+# mirmod:   the laid-out MIR module supplying each function's frame facts (which
+#           functions the back end emitted without a frame, #1940)
 # image:    the per-module object image being built
 # rows:     the encoder's re-homed PC<->source rows
 # row_count: number of rows
@@ -2474,7 +2528,7 @@ pub def ProduceFn: fun(*session.Session, *target.Target, *ir.Module,
 # comp_dir_id: interned DW_AT_comp_dir (the project root)
 # text_sec: the `.text` section index
 # ret:      ok(true) on success, or an allocation error
-pub fun produce(s: *session.Session, tgt: *target.Target, irmod: *ir.Module,
+pub fun produce(s: *session.Session, tgt: *target.Target, irmod: *ir.Module, mirmod: *mir.MirModule,
                 image: *of.ObjectImage, rows: *enc.LineRow, row_count: u32,
                 varlocs: *enc.VarLoc, varloc_count: u32,
                 inline_pcs: *enc.InlinePc, inline_pc_count: u32,
@@ -2491,7 +2545,7 @@ pub fun produce(s: *session.Session, tgt: *target.Target, irmod: *ir.Module,
     val rf: R.Result[*DwFunc, str] = A.allocate[DwFunc](s.alloc, nfuncs::usize);
     if (R.is_err[*DwFunc, str](rf)) { ret R.err[bool, str](R.unwrap_err[*DwFunc, str](rf)); }
     val funcs: *DwFunc = R.unwrap_ok[*DwFunc, str](rf);
-    gather_funcs(image, text_sec, funcs);
+    gather_funcs(image, mirmod, text_sec, funcs);
 
     # the encoder records no per-symbol size, so a function's extent is the gap to
     # the next function (in `.text` order) and the last runs to the section end.
@@ -2731,7 +2785,8 @@ pub fun produce(s: *session.Session, tgt: *target.Target, irmod: *ir.Module,
     }
     var low_off:  u32 = 0;
     var stmt_off: u32 = 0;
-    build_info(?b_info, address_size, producer, name, comp_dir, high_pc, frame_base_reg(tgt),
+    build_info(?b_info, address_size, producer, name, comp_dir, high_pc,
+               frame_base_reg(tgt), frame_base_omit_reg(tgt),
                subs, nsub, ?tc, vars, info_relocs, ?info_reloc_count, ?low_off, ?stmt_off,
                s, irmod, ?strtab, inlines, ninl, iranges, type_fixups);
 

--- a/src/lang/be/codegen/frame.mach
+++ b/src/lang/be/codegen/frame.mach
@@ -28,6 +28,7 @@ use O: std.types.option;
 use R: std.types.result;
 
 use mach.lang.be.codegen.mir;
+use mach.lang.target.abi;
 use target: mach.lang.target.resolved;
 
 # frame alignment used when no ABI override applies; the 16-byte call-boundary minimum
@@ -52,7 +53,8 @@ pub fun run(tgt: *target.Target, m: *mir.MirModule) R.Result[bool, str] {
         layout_function(func, align);
         # the frame facts are final only now, so the omission decision follows the
         # layout rather than racing it.
-        func.frame.omit = omits_frame(tgt, func);
+        func.frame.omit = omits_frame(func, tgt.model.frame_ptr_reg::u32,
+                                      tgt.model.stack_ptr_reg::u32);
         fi = fi + 1;
     }
 
@@ -91,17 +93,15 @@ pub fun run(tgt: *target.Target, m: *mir.MirModule) R.Result[bool, str] {
 # decision is identical with and without `-g` and `.text` stays byte-identical -
 # the #1944 additivity invariant.
 # ---
-# tgt:  resolved target; supplies the frame- and stack-pointer register ids
 # func: the laid-out function to judge
+# fp:   the target's frame-pointer register id
+# sp:   the target's stack-pointer register id
 # ret:  true when the encoder must emit neither prologue nor epilogue
-pub fun omits_frame(tgt: *target.Target, func: *mir.MirFunction) bool {
+pub fun omits_frame(func: *mir.MirFunction, fp: u32, sp: u32) bool {
     if (func.frame.size != 0)          { ret false; }
     if (func.callee_mask != 0)         { ret false; }
     if (func.callee_mask_fp != 0)      { ret false; }
     if (func.frame.outgoing_size != 0) { ret false; }
-
-    val fp: u32 = tgt.model.frame_ptr_reg::u32;
-    val sp: u32 = tgt.model.stack_ptr_reg::u32;
 
     var calls: bool = false;
     var frame_ref: bool = false;
@@ -306,5 +306,245 @@ test "mach.lang.be.codegen.frame.slot_offset:alloca_and_spill_lookup" {
     if (!is_alloca_slot(?frame, 10)) { ret 1; }
     if (is_alloca_slot(?frame, 20))  { ret 1; }
     if (!is_slot(?frame, 10))        { ret 1; }
+    ret 0;
+}
+
+# the frame-pointer and stack-pointer register ids the omission tests use. arbitrary
+# distinct values: `omits_frame` compares operand register fields against whatever it
+# is handed, so the numbering matters only in being distinguishable from a third id
+# the tests use for an ordinary register.
+val TEST_FP:    u32 = 5;
+val TEST_SP:    u32 = 4;
+val TEST_OTHER: u32 = 9;
+
+# build a one-block function around `instrs`, with an otherwise empty frame
+# ---
+# blk:    caller-owned block storage
+# func:   caller-owned function storage, filled in
+# instrs: the block's instruction array
+# n:      number of instructions
+fun mk_func(blk: *mir.MirBlock, func: *mir.MirFunction, instrs: *mir.MirInstr, n: u32) {
+    blk.id          = 0;
+    blk.instrs      = instrs;
+    blk.instr_count = n;
+    blk.instr_cap   = n;
+    blk.preds       = nil;
+    blk.pred_count  = 0;
+    blk.pred_cap    = 0;
+
+    func.blocks      = blk;
+    func.block_count = 1;
+    func.block_cap   = 1;
+    func.vregs       = nil;
+    func.vreg_count  = 0;
+    func.vreg_cap    = 0;
+
+    func.frame.slots         = nil;
+    func.frame.slot_count    = 0;
+    func.frame.slot_cap      = 0;
+    func.frame.size          = 0;
+    func.frame.align         = 16;
+    func.frame.outgoing_size = 0;
+    func.frame.omit          = false;
+    func.callee_mask         = 0;
+    func.callee_mask_fp      = 0;
+}
+
+# fill `mi` as an instruction with no operands
+# ---
+# mi: the instruction to fill
+# op: its opcode
+fun mk_instr(mi: *mir.MirInstr, op: mir.MirOpcode) {
+    mi.opcode            = op;
+    mi.operands          = nil;
+    mi.operand_count     = 0;
+    mi.width             = 8;
+    mi.src_width         = 8;
+    mi.asm_block         = nil;
+    mi.dbg_bindings      = nil;
+    mi.dbg_binding_count = 0;
+    mi.inline_site       = 0;
+    mi.vec_lane          = 0;
+}
+
+# a leaf that allocates nothing and touches neither pointer omits its frame - the
+# shape #1940 exists for. mutating `omits_frame` to answer false unconditionally
+# fails here, and mutating it to answer true unconditionally fails every disqualifier
+# test below
+test "mach.lang.be.codegen.frame.omits_frame:bare_leaf_omits" {
+    var instrs: [2]mir.MirInstr;
+    mk_instr(?instrs[0], mir.MIR_ADD);
+    mk_instr(?instrs[1], mir.MIR_RET);
+
+    var blk: mir.MirBlock;
+    var func: mir.MirFunction;
+    mk_func(?blk, ?func, ?instrs[0], 2);
+
+    if (!omits_frame(?func, TEST_FP, TEST_SP)) { ret 1; }
+    ret 0;
+}
+
+# each frame fact the compiler itself allocated keeps the frame: a slot, a callee-saved
+# GP register, a callee-saved vector register, or an outgoing-argument region. deleting
+# any one of the four guards in `omits_frame` fails this test
+test "mach.lang.be.codegen.frame.omits_frame:allocated_frame_keeps_it" {
+    var instrs: [1]mir.MirInstr;
+    mk_instr(?instrs[0], mir.MIR_RET);
+
+    var blk: mir.MirBlock;
+    var func: mir.MirFunction;
+
+    mk_func(?blk, ?func, ?instrs[0], 1);
+    func.frame.size = 16;
+    if (omits_frame(?func, TEST_FP, TEST_SP)) { ret 1; }
+
+    mk_func(?blk, ?func, ?instrs[0], 1);
+    func.callee_mask = 1 << 3;
+    if (omits_frame(?func, TEST_FP, TEST_SP)) { ret 1; }
+
+    mk_func(?blk, ?func, ?instrs[0], 1);
+    func.callee_mask_fp = 1 << 6;
+    if (omits_frame(?func, TEST_FP, TEST_SP)) { ret 1; }
+
+    mk_func(?blk, ?func, ?instrs[0], 1);
+    func.frame.outgoing_size = 32;
+    if (omits_frame(?func, TEST_FP, TEST_SP)) { ret 1; }
+
+    ret 0;
+}
+
+# a call keeps the frame. entry RSP is 8 mod 16 and the frame-pointer push is what
+# restores the 16-byte call boundary, so a frame-omitting function that called
+# anything would hand its callee a misaligned stack. deleting the MIR_CALL scan fails
+# here
+test "mach.lang.be.codegen.frame.omits_frame:a_call_keeps_the_frame" {
+    var instrs: [2]mir.MirInstr;
+    mk_instr(?instrs[0], mir.MIR_CALL);
+    mk_instr(?instrs[1], mir.MIR_RET);
+
+    var blk: mir.MirBlock;
+    var func: mir.MirFunction;
+    mk_func(?blk, ?func, ?instrs[0], 2);
+
+    if (omits_frame(?func, TEST_FP, TEST_SP)) { ret 1; }
+    ret 0;
+}
+
+# a memory operand based on the frame or stack pointer keeps the frame: an incoming
+# stack parameter is lowered to `[fp + incoming_arg_base + off]` and stays addressable
+# only while the frame pointer is live. eliding such a function is a miscompile that
+# still returns the right answer for a small enough argument list, so this is the
+# guard worth mutating. an ordinary physical-register base, and a frame-slot base
+# (which carries a slot key rather than a register), both stay elidable
+test "mach.lang.be.codegen.frame.omits_frame:frame_relative_operand_keeps_the_frame" {
+    var blk: mir.MirBlock;
+    var func: mir.MirFunction;
+
+    var fp_ops: [1]mir.MirOperand;
+    fp_ops[0] = mir.op_mem_preg(TEST_FP, 16);
+    var fp_instrs: [1]mir.MirInstr;
+    mk_instr(?fp_instrs[0], mir.MIR_LOAD);
+    fp_instrs[0].operands      = ?fp_ops[0];
+    fp_instrs[0].operand_count = 1;
+    mk_func(?blk, ?func, ?fp_instrs[0], 1);
+    if (omits_frame(?func, TEST_FP, TEST_SP)) { ret 1; }
+
+    var sp_ops: [1]mir.MirOperand;
+    sp_ops[0] = mir.op_mem_preg(TEST_SP, 8);
+    var sp_instrs: [1]mir.MirInstr;
+    mk_instr(?sp_instrs[0], mir.MIR_STORE);
+    sp_instrs[0].operands      = ?sp_ops[0];
+    sp_instrs[0].operand_count = 1;
+    mk_func(?blk, ?func, ?sp_instrs[0], 1);
+    if (omits_frame(?func, TEST_FP, TEST_SP)) { ret 1; }
+
+    var ix_ops: [1]mir.MirOperand;
+    ix_ops[0] = mir.op_mem_preg(TEST_OTHER, 0);
+    ix_ops[0].index         = TEST_FP;
+    ix_ops[0].index_is_preg = true;
+    var ix_instrs: [1]mir.MirInstr;
+    mk_instr(?ix_instrs[0], mir.MIR_LOAD);
+    ix_instrs[0].operands      = ?ix_ops[0];
+    ix_instrs[0].operand_count = 1;
+    mk_func(?blk, ?func, ?ix_instrs[0], 1);
+    if (omits_frame(?func, TEST_FP, TEST_SP)) { ret 1; }
+
+    var ok_ops: [1]mir.MirOperand;
+    ok_ops[0] = mir.op_mem_preg(TEST_OTHER, 0);
+    var ok_instrs: [1]mir.MirInstr;
+    mk_instr(?ok_instrs[0], mir.MIR_LOAD);
+    ok_instrs[0].operands      = ?ok_ops[0];
+    ok_instrs[0].operand_count = 1;
+    mk_func(?blk, ?func, ?ok_instrs[0], 1);
+    if (!omits_frame(?func, TEST_FP, TEST_SP)) { ret 1; }
+
+    ret 0;
+}
+
+# an inline-asm body owns the stack, so it omits the frame on its own terms - even
+# with a call in the same body, which no other reason tolerates. this is the
+# pre-existing naked-function rule (`_start` reads the kernel-supplied stack pointer
+# directly, and a `push rbp` ahead of it would corrupt the argc/argv it extracts);
+# removing the `asm_block` arm changes the emitted entry point, not just an
+# optimization
+test "mach.lang.be.codegen.frame.omits_frame:asm_body_owns_the_stack" {
+    var payload: mir.MirAsm;
+
+    var instrs: [2]mir.MirInstr;
+    mk_instr(?instrs[0], mir.MIR_ASM);
+    instrs[0].asm_block = ?payload;
+    mk_instr(?instrs[1], mir.MIR_CALL);
+
+    var blk: mir.MirBlock;
+    var func: mir.MirFunction;
+    mk_func(?blk, ?func, ?instrs[0], 2);
+
+    if (!omits_frame(?func, TEST_FP, TEST_SP)) { ret 1; }
+
+    # an asm body still needs the frame the compiler allocated under it
+    mk_func(?blk, ?func, ?instrs[0], 2);
+    func.frame.size = 8;
+    if (omits_frame(?func, TEST_FP, TEST_SP)) { ret 1; }
+
+    ret 0;
+}
+
+# `run` writes the decision onto every function's frame, so the encoders read a fact
+# rather than re-deriving it. reverting `run` to leave `omit` untouched fails here
+test "mach.lang.be.codegen.frame.run:stamps_the_omission_decision" {
+    var leaf_instrs: [1]mir.MirInstr;
+    mk_instr(?leaf_instrs[0], mir.MIR_RET);
+
+    var call_instrs: [1]mir.MirInstr;
+    mk_instr(?call_instrs[0], mir.MIR_CALL);
+
+    var blocks: [2]mir.MirBlock;
+    var funcs: [2]mir.MirFunction;
+    mk_func(?blocks[0], ?funcs[0], ?leaf_instrs[0], 1);
+    mk_func(?blocks[1], ?funcs[1], ?call_instrs[0], 1);
+
+    var m: mir.MirModule;
+    m.alloc        = nil;
+    m.interner     = nil;
+    m.srcmap       = nil;
+    m.functions    = ?funcs[0];
+    m.function_len = 2;
+    m.function_cap = 2;
+
+    # only the two fields `run` reads are set: the ABI's stack alignment and the two
+    # register ids the frame-reference scan compares against.
+    var abi_vt: abi.AbiVTable;
+    abi_vt.stack_align = 16;
+
+    var tgt: target.Target;
+    tgt.abi                = ?abi_vt;
+    tgt.model.frame_ptr_reg = TEST_FP::i32;
+    tgt.model.stack_ptr_reg = TEST_SP::i32;
+
+    val r: R.Result[bool, str] = run(?tgt, ?m);
+    if (R.is_err[bool, str](r)) { ret 1; }
+
+    if (!funcs[0].frame.omit) { ret 1; }
+    if (funcs[1].frame.omit)  { ret 1; }
     ret 0;
 }

--- a/src/lang/be/codegen/frame.mach
+++ b/src/lang/be/codegen/frame.mach
@@ -1,4 +1,5 @@
-# assign each MIR frame slot a frame-pointer offset and size the frame
+# assign each MIR frame slot a frame-pointer offset, size the frame, and decide
+# whether the function needs a frame at all
 #
 # Assigns each MIR frame slot a negative offset from the frame pointer, sizes
 # the frame to the ABI stack alignment, and rounds the outgoing-argument region
@@ -7,9 +8,15 @@
 # materialized into `mir.MirFrame` during instruction selection; this pass only
 # computes their final offsets and the total frame size.
 #
-# Completely target-agnostic except for the stack alignment read through the ABI
-# vtable; the resulting offsets are consumed by the encoder when it forms
-# `[rbp + disp]` memory operands.
+# It then records, in `MirFrame.omit`, whether the function needs a compiler-
+# generated prologue and epilogue at all (#1940). This is the single decision
+# point for frame suppression across every target: each encoder reads the flag
+# instead of re-deriving the answer from its own copy of the rule.
+#
+# Target-agnostic but for three reads through the target - the ABI stack
+# alignment, and the frame- and stack-pointer register ids the frame-reference
+# scan recognizes. The resulting offsets are consumed by the encoder when it
+# forms `[rbp + disp]` memory operands.
 
 use std.types.bool.bool;
 use std.types.bool.false;
@@ -41,11 +48,104 @@ pub fun run(tgt: *target.Target, m: *mir.MirModule) R.Result[bool, str] {
 
     var fi: u32 = 0;
     for (fi < m.function_len) {
-        layout_function(?m.functions[fi], align);
+        val func: *mir.MirFunction = ?m.functions[fi];
+        layout_function(func, align);
+        # the frame facts are final only now, so the omission decision follows the
+        # layout rather than racing it.
+        func.frame.omit = omits_frame(tgt, func);
         fi = fi + 1;
     }
 
     ret R.ok[bool, str](true);
+}
+
+# report whether a function needs no compiler-generated prologue or epilogue
+#
+# Two disjoint reasons suppress the frame, and both require the same starting
+# point: the compiler allocated no frame of its own - no slots (`frame.size`), no
+# callee-saved GP or vector registers, and no outgoing-argument region.
+#
+#   1. An inline-asm body owns the stack. The entry point `_start` reads the
+#      kernel-supplied stack pointer directly (`mov rdi, [rsp]` = argc), so a
+#      `push rbp` ahead of it would shift RSP and corrupt the argc/argv it
+#      extracts. The programmer's asm is the prologue; the compiler adds none.
+#      A body with asm in it is opaque, so this reason stands on its own - it
+#      does not additionally require the function to be a leaf.
+#
+#   2. The frame is provably unused (#1940). A function that calls nothing and
+#      addresses nothing through the frame or stack pointer cannot observe the
+#      difference between having a frame record and not having one, so the
+#      `push rbp; mov rbp, rsp` / `mov rsp, rbp; pop rbp` pair is pure cost. The
+#      leaf requirement is load-bearing rather than conservative: entry RSP is
+#      8 mod 16, and the frame-pointer push is what restores the 16-byte call
+#      boundary the ABI demands, so a function that both omits the push and makes
+#      a call would hand its callee a misaligned stack. Making no call, it never
+#      reaches a call boundary and the alignment is unobservable.
+#
+# The frame-reference scan is what excludes an incoming stack parameter: those
+# are lowered to `[fp + incoming_arg_base + off]` (`mir.abi.emit_param_slot`) and
+# stay addressable only while the frame pointer is live.
+#
+# Nothing here can read the debug flag, and `-g` adds no MIR instruction and no
+# frame slot (its bindings ride on existing instructions as metadata), so the
+# decision is identical with and without `-g` and `.text` stays byte-identical -
+# the #1944 additivity invariant.
+# ---
+# tgt:  resolved target; supplies the frame- and stack-pointer register ids
+# func: the laid-out function to judge
+# ret:  true when the encoder must emit neither prologue nor epilogue
+pub fun omits_frame(tgt: *target.Target, func: *mir.MirFunction) bool {
+    if (func.frame.size != 0)          { ret false; }
+    if (func.callee_mask != 0)         { ret false; }
+    if (func.callee_mask_fp != 0)      { ret false; }
+    if (func.frame.outgoing_size != 0) { ret false; }
+
+    val fp: u32 = tgt.model.frame_ptr_reg::u32;
+    val sp: u32 = tgt.model.stack_ptr_reg::u32;
+
+    var calls: bool = false;
+    var frame_ref: bool = false;
+
+    var bi: u32 = 0;
+    for (bi < func.block_count) {
+        val blk: *mir.MirBlock = ?func.blocks[bi];
+        var ii: u32 = 0;
+        for (ii < blk.instr_count) {
+            val mi: *mir.MirInstr = ?blk.instrs[ii];
+            # an inline-asm block survives selection under a per-target opcode
+            # (x86-64 retags it to ASM_BLOCK), but its payload pointer is set on
+            # every target - so the payload, not the opcode, identifies it.
+            if (mi.asm_block != nil) { ret true; }
+            if (mi.opcode == mir.MIR_CALL) { calls = true; }
+            var oi: u32 = 0;
+            for (oi < mi.operand_count) {
+                if (operand_is_frame_relative(?mi.operands[oi], fp, sp)) { frame_ref = true; }
+                oi = oi + 1;
+            }
+            ii = ii + 1;
+        }
+        bi = bi + 1;
+    }
+
+    ret !calls && !frame_ref;
+}
+
+# report whether a MIR operand addresses memory through the frame or stack pointer
+#
+# A frame-slot memory operand carries a slot key in `vreg` and is resolved against
+# the layout, so it is not the shape this looks for; the physical-register base
+# form (`mir.op_mem_preg`) is. Both register fields count - a base and, when the
+# index is a physical register, the index - since either keeps the pointer live.
+# ---
+# o:   the operand to test
+# fp:  the target's frame-pointer register id
+# sp:  the target's stack-pointer register id
+# ret: true when the operand reads or writes relative to fp or sp
+fun operand_is_frame_relative(o: *mir.MirOperand, fp: u32, sp: u32) bool {
+    if (o.kind != mir.MIR_OP_MEM) { ret false; }
+    if (o.vreg == mir.MIR_VREG_NIL && (o.preg == fp || o.preg == sp)) { ret true; }
+    if (o.index_is_preg && (o.index == fp || o.index == sp))          { ret true; }
+    ret false;
 }
 
 # look up the frame-pointer offset assigned to a MIR value's slot

--- a/src/lang/be/codegen/mir.mach
+++ b/src/lang/be/codegen/mir.mach
@@ -713,6 +713,14 @@ pub rec MirSlot {
 #                locals, spills, or the callee-saved save area, and the call-site
 #                RSP stays 16-byte aligned. zero when the function makes no call
 #                with stack-passed arguments.
+# omit:          this function gets NO compiler-generated prologue or epilogue -
+#                no frame-pointer record, no stack allocation, no callee-save
+#                stores. decided once by `frame.run` (`frame.omits_frame`) from
+#                the laid-out frame facts and read by every target's encoder, so
+#                one predicate governs all three ISAs. two disjoint reasons set
+#                it: an inline-asm body that owns the stack itself, and a leaf
+#                that provably never touches the frame. `-g` cannot influence
+#                either, so `.text` stays byte-identical with and without it.
 pub rec MirFrame {
     slots:         *MirSlot;
     slot_count:    u32;
@@ -720,6 +728,7 @@ pub rec MirFrame {
     size:          u32;
     align:         u32;
     outgoing_size: u32;
+    omit:          bool;
 }
 
 # a function in MIR form - blocks, the virtual-register table, and frame layout

--- a/src/lang/be/codegen/mir/lower.mach
+++ b/src/lang/be/codegen/mir/lower.mach
@@ -173,6 +173,7 @@ fun lower_function(tgt: *target.Target, m: *ir.Module, fn: *ir.Function, alloc: 
     mf.frame.size          = 0;
     mf.frame.align         = 0;
     mf.frame.outgoing_size = 0;
+    mf.frame.omit          = false;
     mf.callee_mask         = 0;
     mf.callee_mask_fp      = 0;
     # the #[oblivious] seed for #1648: mark the MIR self-describing so the constant-time

--- a/src/lang/target/isa/arm64/encode.mach
+++ b/src/lang/target/isa/arm64/encode.mach
@@ -3041,39 +3041,14 @@ fun encode_mir_instr(st: *encode.EncodeState, f: *mir.MirFunction, fn_base: u32,
     ret R.err[bool, str]("internal compiler error: unhandled opcode in arm64 encode");
 }
 
-# a function whose inline asm owns the stack and must be emitted
-# with NO compiler prologue/epilogue - no frame (frame.size), no callee-saved GP/FP
-# registers, no outgoing-argument area, and a body containing an inline-asm block.
-# the entry-point `_start` reads the kernel-supplied SP directly (`mov x9, sp; ldr x0,
-# [x9]` = argc), so a frame-record `stp x29, x30, [sp, #-16]!` ahead of it would shift
-# SP and corrupt the argc/argv it extracts. mirrors x86-64's `function_is_naked` (the
-# asm-block opcode survives selection as `mir.MIR_ASM` on AArch64)
-fun function_is_naked(f: *mir.MirFunction) bool {
-    if (f.frame.size != 0)          { ret false; }
-    if (f.callee_mask != 0)         { ret false; }
-    if (f.callee_mask_fp != 0)      { ret false; }
-    if (f.frame.outgoing_size != 0) { ret false; }
-    var bi: u32 = 0;
-    for (bi < f.block_count) {
-        val blk: *mir.MirBlock = ?f.blocks[bi];
-        var ii: u32 = 0;
-        for (ii < blk.instr_count) {
-            val mi: *mir.MirInstr = ?blk.instrs[ii];
-            if (mi.opcode == mir.MIR_ASM) { ret true; }
-            ii = ii + 1;
-        }
-        bi = bi + 1;
-    }
-    ret false;
-}
-
 # the per-function encode hook (pass 1). marks the function
-# entry symbol, emits the record-at-top prologue (skipped for a naked asm-only
-# function, whose inline asm owns the stack), then each block - emitting the epilogue
-# before every RET - recording each block's `.text` offset for branch patching. extern
-# / body-less functions contribute no text. an oversized frame (a `SUB SP` past the
-# two-immediate range, or GP callee-saves below the STP/LDP imm7 reach) is materialized
-# through a scratch base
+# entry symbol, emits the record-at-top prologue (skipped for a frame-omitting
+# function - `frame.omit`, decided once in `frame.run` for every target - whose inline
+# asm owns the stack or which is a leaf that never touches the frame), then each block
+# - emitting the epilogue before every RET - recording each block's `.text` offset for
+# branch patching. extern / body-less functions contribute no text. an oversized frame
+# (a `SUB SP` past the two-immediate range, or GP callee-saves below the STP/LDP imm7
+# reach) is materialized through a scratch base
 fun encode_function_arm64(st: *encode.EncodeState, f: *mir.MirFunction) R.Result[bool, str] {
     val fn_base: u32 = st.buf.len::u32;
     if (f.block_count == 0) { ret R.ok[bool, str](true); }
@@ -3081,7 +3056,7 @@ fun encode_function_arm64(st: *encode.EncodeState, f: *mir.MirFunction) R.Result
     val ms: R.Result[bool, str] = encode.push_symbol(st, f.name, fn_base, of.SYM_OBJ_FLAG_FUNCTION);
     if (R.is_err[bool, str](ms)) { ret ms; }
 
-    val naked: bool = function_is_naked(f);
+    val naked: bool = f.frame.omit;
     val subsize: u32 = frame_subsize(f);
 
     if (encode.sink_active(?st.buf)) {

--- a/src/lang/target/isa/riscv64/encode.mach
+++ b/src/lang/target/isa/riscv64/encode.mach
@@ -2608,30 +2608,6 @@ fun emit_epilogue(st: *encode.EncodeState, f: *mir.MirFunction, total: u32) {
     emit_sp_adjust(st, total, false);
 }
 
-# a function whose inline asm owns the stack and must be emitted with NO compiler
-# prologue / epilogue - no frame, no callee-saved registers, no outgoing-argument
-# area, and a body containing an inline-asm block. the entry point `_start` reads the
-# kernel-supplied SP directly, so a frame allocation ahead of it would shift SP and
-# corrupt the argc / argv it extracts. mirrors x86-64 / AArch64's `function_is_naked`
-fun function_is_naked(f: *mir.MirFunction) bool {
-    if (f.frame.size != 0)          { ret false; }
-    if (f.callee_mask != 0)         { ret false; }
-    if (f.callee_mask_fp != 0)      { ret false; }
-    if (f.frame.outgoing_size != 0) { ret false; }
-    var bi: u32 = 0;
-    for (bi < f.block_count) {
-        val blk: *mir.MirBlock = ?f.blocks[bi];
-        var ii: u32 = 0;
-        for (ii < blk.instr_count) {
-            val mi: *mir.MirInstr = ?blk.instrs[ii];
-            if (mi.opcode == mir.MIR_ASM) { ret true; }
-            ii = ii + 1;
-        }
-        bi = bi + 1;
-    }
-    ret false;
-}
-
 # translate one post-regalloc MIR instruction into RV64 bytes, recording any
 # intra-module branch fixup or symbol relocation. the regalloc parallel-copy /
 # liveness pseudos emit nothing; the surviving comparison / conditional-branch /
@@ -2956,7 +2932,9 @@ fun relax_function_riscv64(st: *encode.EncodeState, fn_base: u32, fixup_start: u
 }
 
 # the per-function encode hook (pass 1). marks the function entry symbol, emits the
-# prologue (skipped for a naked asm-only function, whose inline asm owns the stack),
+# prologue (skipped for a frame-omitting function - `frame.omit`, decided once in
+# `frame.run` for every target - whose inline asm owns the stack or which is a leaf
+# that never touches the frame),
 # then each block - emitting the epilogue before every RET - recording each block's
 # `.text` offset for branch patching, and finally relaxes any branch whose body grew
 # past its displacement range. extern / body-less functions contribute no text. the
@@ -3001,7 +2979,7 @@ fun encode_function_body(st: *encode.EncodeState, f: *mir.MirFunction) R.Result[
     val ms: R.Result[bool, str] = encode.push_symbol(st, f.name, fn_base, of.SYM_OBJ_FLAG_FUNCTION);
     if (R.is_err[bool, str](ms)) { ret ms; }
 
-    val naked: bool = function_is_naked(f);
+    val naked: bool = f.frame.omit;
     val total: u32 = frame_total(f);
     if (!naked) { emit_prologue(st, f, total); }
     val rp: R.Result[bool, str] = check_accounted(st, fn_base, PROLOGUE_REGION);

--- a/src/lang/target/isa/x64/encode.mach
+++ b/src/lang/target/isa/x64/encode.mach
@@ -2554,40 +2554,14 @@ fun patch_branch_x86(st: *enc.EncodeState, fx: *enc.BranchFixup, target_off: u32
     ret R.ok[bool, str](true);
 }
 
-# true when a function carries inline asm yet needs no stack
-# frame - no locals/spills (frame.size), no callee-saved registers (callee_mask),
-# and no outgoing-argument area. such a function's inline asm owns the stack and
-# must be emitted without a compiler-generated prologue/epilogue: the entry-point
-# `_start`, for instance, reads the kernel-supplied RSP directly
-# (`mov rdi, [rsp]` = argc), so a `push rbp` ahead of it would shift RSP and
-# corrupt the argc/argv it extracts. a function with any frame (e.g. an asm body
-# preceded by a local, like `panic`) is not naked and keeps its prologue
-fun function_is_naked(f: *mir.MirFunction) bool {
-    if (f.frame.size != 0)          { ret false; }
-    if (f.callee_mask != 0)         { ret false; }
-    if (f.callee_mask_fp != 0)      { ret false; }
-    if (f.frame.outgoing_size != 0) { ret false; }
-
-    var bi: u32 = 0;
-    for (bi < f.block_count) {
-        val blk: *mir.MirBlock = ?f.blocks[bi];
-        var ii: u32 = 0;
-        for (ii < blk.instr_count) {
-            val mi: *mir.MirInstr = ?blk.instrs[ii];
-            if (mi.opcode::u16 == x64.ASM_BLOCK::u16) { ret true; }
-            ii = ii + 1;
-        }
-        bi = bi + 1;
-    }
-    ret false;
-}
-
 # encode one function: mark its entry symbol, emit the prologue, then emit each
 # block - emitting the epilogue before every RET. records the `.text` offset of
 # every block (for branch patching) as it goes. the frame size and callee-saved
 # mask come from `frame.run` / `regalloc.run`, which have already laid out the
-# function by the time the encoder sees it. a naked (asm-only) function gets
-# neither prologue nor epilogue - its inline asm owns the stack
+# function by the time the encoder sees it. a frame-omitting function
+# (`frame.omit`, decided once in `frame.run` for every target) gets neither
+# prologue nor epilogue: either its inline asm owns the stack, or it is a leaf
+# that never touches the frame
 fun encode_function(st: *enc.EncodeState, f: *mir.MirFunction) R.Result[bool, str] {
     val fn_base: u32 = st.buf.len::u32;
 
@@ -2597,7 +2571,7 @@ fun encode_function(st: *enc.EncodeState, f: *mir.MirFunction) R.Result[bool, st
     val ms: R.Result[bool, str] = enc.push_symbol(st, f.name, fn_base, of.SYM_OBJ_FLAG_FUNCTION);
     if (R.is_err[bool, str](ms)) { ret ms; }
 
-    val naked: bool = function_is_naked(f);
+    val naked: bool = f.frame.omit;
     val frame_size: u32 = f.frame.size;
     val callee_mask: u32 = f.callee_mask;
     val callee_mask_fp: u32 = f.callee_mask_fp;

--- a/src/lang/target/of/coff.mach
+++ b/src/lang/target/of/coff.mach
@@ -2284,6 +2284,14 @@ fun is_win64_nonvol_reg(reg: u8) bool {
 # decode one emitted function's canonical prologue
 # (push rbp; mov rbp,rsp; sub rsp,N; nonvolatile saves) into x64 unwind codes;
 # false when the bytes are not the recognized fixed-frame shape
+#
+# A frame-omitting function (`mir.MirFrame.omit`, #1940) has no `push rbp` to
+# find, so it falls out here and contributes no RUNTIME_FUNCTION. That is what
+# the win64 ABI requires rather than a gap in coverage: a function that
+# allocates no stack, saves no nonvolatile register and calls nothing is a leaf,
+# and leaf functions carry no unwind data. `.pdata` has always been sparse -
+# an asm-owned entry point reaches this same exit - and the elision only widens
+# the set that legitimately takes it.
 fun parse_function_unwind(uw: *FunctionUnwind, segs: *of.LoadSegment, seg_count: u32,
                           funcs: *of.ExecFunction, idx: u32) bool {
     uw.seg_index = funcs[idx].seg_index;


### PR DESCRIPTION
Closes #1940.

A leaf function that needs no stack slots no longer pushes and pops a frame
pointer. The decision is made once, in `frame.run`, and read by all three
encoders.

## Read this first: `-g` does **not** gate the elision

The issue title says "outside `-g`", and the issue body proposes retaining the
frame pointer under `-g` and eliding without it. **That plan is dead and this PR
does not implement it.** It would thread the debug flag into codegen, which is
exactly what the #1944 additivity invariant forbids: `.text` must be
byte-identical with and without `-g`. The investigation comment already on #1940
re-scoped this to Option A, which is what ships here:

- **Elide regardless of `-g`.** The decision reads only frame facts and MIR
  opcodes. `-g` adds no MIR instruction and no frame slot — its bindings ride on
  existing instructions as metadata — so the same functions elide either way.
- **Measured, not argued:** `.text` byte-identical with and without `-g` over all
  208 objects at **both** profiles — 11,527,769 bytes at release, 7,989,978 at
  debug. At the linked-image level the executable `PT_LOAD` segment is
  byte-identical too. The invariant is **preserved**, not broken.
- The DWARF producer emits `DW_OP_reg<sp>` as a frame-omitting function's
  `DW_AT_frame_base`, valid because the eligible set never moves its stack pointer.

Anyone reading the issue title alone will assume the opposite. It is the single
most likely way this change goes wrong.

## Stated deviation: the debug profile elides too

The issue's acceptance text says "at -O1+". **This ships ungated**, so
`--profile debug` also elides: **689 functions, 6,168 instructions, 12,336
`.text` bytes**, with zero unattributed changes. That is deliberate, and the
reasoning belongs next to the number rather than in a diff:

`MirFrame.omit` does not only carry the elision — it carries the **pre-existing
naked rule**, which was never opt-gated. `_start`'s inline asm reads the
kernel-supplied stack pointer directly, so it must be frameless at every
optimization level. Gating the flag on `opt > 0` gives `_start` a prologue in
debug builds and breaks every debug binary. That is measured, not feared:
mutation M1 forces `omit` false and `_start` comes out as
`pushq %rbp; movq %rsp, %rbp` ahead of its `movq %rsp, %rax`, argc/argv shift by
one slot, and all 862 unit tests fail because the test dispatcher rejects its own
index.

Gating only the leaf half therefore means splitting the predicate in two again
and threading the optimization level into a pass with no other reason to see it —
reintroducing the two-rules-for-one-decision shape this change exists to remove,
to buy a debug build 0.15% larger. Debug `-g` additivity holds and debug builds
unwind correctly (below), so it stays one rule.

## What decides it

`frame.run` already runs after `regalloc.run`, so it sees the final layout and
the callee-save masks. It records `MirFrame.omit`; each encoder reads it. That
replaces three private `function_is_naked` predicates which differed only in how
their target spells the inline-asm opcode — the payload pointer identifies an asm
block on every target, so no per-target hook was needed.

Two disjoint reasons suppress a frame, and the flag carries both:

1. **An inline-asm body owns the stack** — the pre-existing naked rule, unchanged.
2. **The frame is provably unused** — a leaf with no slots, no callee saves, no
   outgoing region, and no memory operand based on the frame or stack pointer.

The leaf requirement is load-bearing, not conservative: entry RSP is 8 mod 16 and
the frame-pointer push is what restores the 16-byte call boundary, so a
frame-omitting function that made a call would hand its callee a misaligned stack.
The frame-reference scan is what excludes an incoming stack parameter — eliding
one of those is a miscompile that still returns the right answer for a short
enough argument list.

## Measured

Baseline and elided objects built from **the same frozen `origin/dev` corpus** by
two compilers (one built from `origin/dev`, one from this branch), so the delta is
pure codegen. 208 release objects, 12,564 functions.

| ISA | elided | instructions removed | `.text` bytes removed |
|---|---|---|---|
| x86_64 | 781 | 6,790 | 13,580 (0.12%) |
| aarch64 | 1,997 | 8,273 | 33,092 (0.25%) |
| riscv64 | 1,961 | 20,457 | 81,828 (0.64%) |

Function-by-function attribution: **every** changed function was classified
elidable in the baseline, and every other function is instruction-identical
(modulo branch displacements and `adrp` page immediates, which shift because
earlier functions got shorter). **Zero unattributed changes on all three ISAs.**

x86-64 elides far fewer than the other two because SysV leaves it short of
caller-saved GPRs, so the allocator reaches for callee-saved registers in small
leaves and those functions then need a frame to save them into.

win64 also loses 782 `.pdata` RUNTIME_FUNCTIONs (`.pdata` 150,948 → 141,564
bytes). That is what the ABI requires, not a coverage gap: a function that
allocates no stack, saves no nonvolatile register and calls nothing is a leaf,
and leaf functions carry no unwind data. `.pdata` has always been sparse.

### Runtime

A call-heavy microbenchmark (160M out-of-line calls to small leaves, checksums
identical):

| | baseline | elided | delta |
|---|---|---|---|
| wall (best of 9) | 0.2896s | 0.2104s | **1.377x** |
| instructions | 1,740,005,244 | 1,100,005,210 | **−36.78%** |
| cycles | 979,280,096 | 705,166,044 | −27.99% |

640,000,034 instructions over 160,000,000 calls is **exactly 4.0 per call** — the
`push`/`mov` and `mov`/`pop` pair, accounted to the instruction.

That is the upper bound, not a typical figure. On the compiler compiling itself
the same elision is worth **−7,152,460 instructions (−0.003%)** and −1.19% cycles;
its wall time is **not measurable on this machine** — the same binary timed
against itself under the identical protocol shows a 1.106x apparent speedup, so
the 1.147x the real comparison produced is inside the noise floor and is not
claimed.

## Unwinding

mach emits **no CFI** — no `.eh_frame`, no `.debug_frame` — so a debugger falls
back to prologue analysis. Verified on real binaries under real workloads:

- **x86_64**, release `-g`: 10-frame backtrace with the elided `zero_inst` at #0,
  through `emit_prologue` → `encode_function` → … → `thread_trampoline`, across a
  thread boundary. gdb reports `Saved registers: rip at` = `rsp`, and `rbp` still
  holding the caller's frame pointer.
- **aarch64**, release `-g`, under `qemu-aarch64 -g` + gdb: 6-frame backtrace with
  the elided `str_len` at #0 up to `main`. Structurally different — the return
  address lives in `x30` and is never spilled — and resolved correctly.
- **x86_64**, `--profile debug -g`: 8-frame backtrace through the elided
  `set_block` up through `query.get`.
- **x86_64, `--profile debug` with no `-g` at all** — no DWARF, and mach's linker
  emits no symbol table, so gdb has nothing but bytes. Sampled mid-body in the
  elided leaf and in its framed `origin/dev` twin at the same source position:

  ```
  elided     #0 0x6c929e   #1 0xa9a529        <- the true caller
  framed     #0 0x6cb43a   #1 0x7fffffff4010  <- a stack address
                           #2 0xa9d219        <- the true caller, one frame late
  ```

  The **framed** build is the one that degrades. Mid-body its `[rsp]` holds the
  saved `%rbp`, which gdb reports as a return address, injecting a spurious frame.
  The elided leaf touches no stack at all, so `[rsp]` is its return address for
  the function's whole extent and gdb gets it right immediately.

**One honest caveat.** A naive `%rbp`-chain walker — not gdb, which uses `rsp`
and prologue analysis — *does* lose one frame. In an elided leaf `%rbp` is the
caller's frame base, so `[rbp+8]` is the caller's return address: walking from
the elided `set_block` yields `0xa96c03` (`lower_fun`) and skips its direct caller
`emit_function_body`. Read out of the stack, not reasoned. mach ships no such
walker — `panic` is a raw write plus `hlt`/`brk` with no stack walk — but anyone
adding backtrace-on-panic or a frame-pointer profiler should know this first.

The compiler's own 3,753 direct call sites land on 273 distinct frame-omitting
functions on x86_64 (8,354 sites on 397 functions on aarch64), so these are
reached out of line constantly, not just in principle.

## Goldens, mutation-tested

Six unit goldens on the decision plus `int/surface/frame-elision`, which reads
`framed`/`frameless` per function out of the disassembled objects on all three ELF
legs. Execution cannot see any of this: a frameless leaf and a framed one compute
the same answer.

| mutation | unit | integration |
|---|---|---|
| M1 elision disabled | 7/7 fail | 3/3 legs, 4 verdicts each |
| M2 leaf requirement removed | 2/7 fail | 3/3 legs, 1 verdict |
| M3 frame-reference scan removed | 1/7 fail | 3/3 legs, 1–2 verdicts |
| M4 inline-asm arm removed | 1/7 fail | 3/3 legs, 1 verdict |
| M5 allocated-frame guards removed | 7/7 fail | 3/3 legs, 1 verdict |

M1 and M5 fail *every* unit test rather than the one under test, because both
force a frame onto `_start` — see the deviation section.

Three of the fixtures had to be rewritten mid-review because the original
functions kept their frames for two reasons at once, so the guard under test could
be deleted without moving the verdict — see the second test commit.

`asm_and_call` is pinned, not endorsed: it is the shape where the two reasons
disagree, and its `%rsp` is 8 mod 16 at the call. Filed as **#2283**.

## Suites

- `mach test` **862 / 0** (dev baseline **856 / 0**; the delta is exactly the six
  new tests), at both profiles.
- mach-std **611 / 0** at pin `eff1e8e`.
- `int` green on `linux` and `linux-riscv64` locally, and on every leg in CI.
  `linux-arm64` reports 58 failures **identically on `dev`** locally — that leg is
  `native` in `targets.conf` and needs an aarch64 runner.

## Fixpoint

Three generations, both profiles. `A != B` is expected — the seed does not elide —
and the invariant is `B == C`:

```
release   A 12,152,832   B 11,878,400   C 11,878,400   B == C
debug      A 8,445,952   B  8,339,456   C  8,339,456   B == C
```

## Not in this PR

The issue names a second elision — functions that *do* need a frame omitting the
frame **pointer** and addressing spills off `rsp`. That rewrites operand bases in
the encoders and is not attempted here. The corpus says the remaining population
is real: 955 x86-64 functions have a bare frame record and reference it only for
incoming stack parameters.
