### PR TITLE
feat(vectorize): fast-math-gated float reduction vectorization

### DIFF
--- a/doc/manifest.md
+++ b/doc/manifest.md
@@ -151,9 +151,11 @@ live here because they are variant concerns.
 | `debug` | bool    | Emit debug info (DWARF on ELF/Mach-O, CodeView on COFF) for this profile. Gates emission only, never the optimizer, so a `release` profile can keep symbols with `debug = true`. A non-boolean is a manifest error. |
 | `simd`  | string  | SIMD scalarization lever. `"scalarize"` builds for a target without hardware SIMD by emitting a defined unrolled scalar expansion of each vector operator, with a build-time note (the "skipped N target-gated modules" style). `"require"` makes a build for an incapable target a hard error naming the offending operator. Any other string is a manifest error. |
 | `vectorize` | bool | **Optional** auto-vectorization lever; absent it defaults to `true`. When `true`, the release pipeline rewrites provably-safe counted loops to 128-bit SIMD on a target with hardware vectors; `false` skips the pass, so release output stays scalar. A non-boolean is a manifest error. |
+| `float_reassoc` | bool | **Optional** permission to treat floating-point addition and multiplication as **associative**; absent it defaults to `false`. It lets the vectorizer reduce an `f32`/`f64` accumulator through lane-count partial sums, which changes the result — see [Float reassociation](#float-reassociation) for what that costs and what it buys. A non-boolean is a manifest error. |
 
 Three keys (`opt`, `debug`, `simd`) are required in a declared profile;
-`vectorize` is optional and defaults to on.
+`vectorize` and `float_reassoc` are optional, defaulting to on and off
+respectively.
 Emission of the human-readable IR and assembly side-artifacts is **not** a profile
 concern — it is controlled only by the `--emit-ir` / `--emit-asm` CLI flags (see
 [cli.md](cli.md)).
@@ -167,12 +169,78 @@ hardware vectors (riscv64) never enters the pass, so `vectorize = false` changes
 performance and never semantics. For a single function, the `#[scalar]` decorator is
 the finer-grained opt-out (see [language/decorators.md](language/decorators.md)).
 
-The `simd` and `vectorize` levers are always the **consumer's**. Consistent with the
-root-vs-dependency strictness above, a dependency's `[profile.*]` is parsed
-permissively and never read to build the consumer, so a library's values are inert —
-the effective levers come from the consumer's resolved profile. Libraries set nothing
-SIMD-specific and inherit the consumer's choice; there is no ecosystem fork and no
-dual API.
+`float_reassoc` is the one lever here that *adds*, and the only profile key that can
+change a program's computed answer. It widens that same pass to float reductions and
+does nothing else; `vectorize = false` switches the pass off wholesale and so overrides
+it.
+
+The `simd`, `vectorize` and `float_reassoc` levers are always the **consumer's**.
+Consistent with the root-vs-dependency strictness above, a dependency's `[profile.*]`
+is parsed permissively and never read to build the consumer, so a library's values are
+inert — the effective levers come from the consumer's resolved profile. Libraries set
+nothing SIMD-specific and inherit the consumer's choice; there is no ecosystem fork and
+no dual API.
+
+### Float reassociation
+
+`float_reassoc = true` grants the optimizer exactly one liberty: it may treat
+floating-point `+` and `*` as **associative**, and regroup a reduction accordingly.
+Nothing else changes. It does not license reciprocal substitution for division,
+assumptions that operands are finite or non-NaN, contraction into a fused
+multiply-add, or flushing subnormals to zero. Each of those would be its own key, with
+its own argument.
+
+What it unlocks is the reduction vectorizer. `s = s + a[i]` is a serial dependence
+chain: every iteration must wait for the previous one's rounded result, so it cannot be
+done four lanes at a time without regrouping the additions. With the key set, the loop
+becomes lane-count independent partial accumulators plus a horizontal combine at the
+end — which computes a *differently grouped*, and therefore differently rounded, sum.
+Element-wise float loops (`a[i] = b[i] * c[i]`) never needed the key and are
+unaffected: each lane performs exactly the operation the scalar loop performed.
+
+The reductions it admits are sum (`s = s + x`), product (`s = s * x`), and the dot /
+matmul inner loop (`s = s + a[i]*b[i]`). Subtraction and division reductions are not
+associative in real arithmetic either, so they are refused with the key set exactly as
+without it.
+
+**The accuracy cost, measured.** Summing one million `f64` values of `0.1`, scored
+against a compensated (Kahan) reference on x86-64:
+
+| ordering | result | relative error |
+|---|---|---|
+| strict, sequential | `100000.00000133288` | 1.33e-11 |
+| reassociated, 2 lanes | `99999.9999991058` | 8.94e-12 |
+
+The two answers differ from **each other** by 2.2e-11 relative — about 153,000 `f64`
+ULPs at that magnitude. The same experiment in `f32` (4 lanes) differs by 1.2e-2
+relative: strict gives `100958.34`, reassociated `99759.85`, against a true value of
+`100000.0`.
+
+Note the direction. In both cases the *reassociated* answer is the more accurate one,
+because splitting into per-lane partials keeps each running total smaller and so grinds
+off fewer low bits — the same reason pairwise summation beats sequential summation. But
+that is a property of this input, not a guarantee. The honest statement is that the
+result **changes**, by roughly the accumulated rounding error of the sum, in a direction
+that depends on the data. Code whose correctness depends on the exact bit pattern of a
+float reduction — a checksum, a reproducibility requirement, a comparison against a
+reference implementation — must leave the key off.
+
+Two exactness properties are preserved rather than traded away. The idle lanes are
+seeded with the op's **exact** IEEE identity — `-0.0` for addition (`x + (-0.0)` is `x`
+for every `x`, where `+0.0` would turn a negative-zero sum positive) and `1.0` for
+multiplication — so no signed-zero or NaN behaviour changes. And a trip count below the
+lane count never enters the vector loop at all, so short reductions are bit-identical
+regardless of the key.
+
+The key is profile-wide. For a single function, `#[scalar]` opts out of vectorization
+entirely and takes precedence over it, so a routine that must stay IEEE-strict inside
+an otherwise-reassociating build has a spelling. There is no per-function opt-*in*:
+whether a reduction may be reassociated is the caller's tolerance to decide, not the
+callee author's.
+
+Integer reductions are untouched by this key. They vectorize unconditionally and are
+bit-identical to the scalar reference, because integer add / xor / or / and reassociate
+exactly.
 
 The CLI selects and overrides at invocation time: `--profile <name>` picks the
 profile; `-g` forces `debug` on for one build regardless of the profile's key

--- a/int/surface/reduce/expect.txt
+++ b/int/surface/reduce/expect.txt
@@ -1,2 +1,2 @@
 mismatches=0
-acc=35066
+acc=64572

--- a/int/surface/reduce/src/main.mach
+++ b/int/surface/reduce/src/main.mach
@@ -71,11 +71,22 @@ fun dot_v(a: *i64, b: *i64, n: i64) i64 { var s: i64=0; var i: i64=0; for(i<n){ 
 #[scalar]
 fun dot_s(a: *i64, b: *i64, n: i64) i64 { var s: i64=0; var i: i64=0; for(i<n){ s=s+a[i]*b[i]; i=i+1; } ret s; }
 
-# a floating reduction: reassociation changes rounding, so it must stay SCALAR (bit-
-# identical to the sequential reference; a fast-math profile could opt in, future work)
+# floating reductions: reassociation changes rounding, so with `float_reassoc` absent
+# from this case's profiles — the default — every one must stay SCALAR and bit-identical
+# to the sequential reference, at both widths and in the sum, dot and product shapes.
+# The `vectorize-reassoc` case is these same shapes under a profile that sets the key.
 fun fsum_v(a: *f64, n: i64) f64 { var s: f64=0.0; var i: i64=0; for(i<n){ s=s+a[i]; i=i+1; } ret s; }
 #[scalar]
 fun fsum_s(a: *f64, n: i64) f64 { var s: f64=0.0; var i: i64=0; for(i<n){ s=s+a[i]; i=i+1; } ret s; }
+fun fsum32_v(a: *f32, n: i64) f32 { var s: f32=0.0; var i: i64=0; for(i<n){ s=s+a[i]; i=i+1; } ret s; }
+#[scalar]
+fun fsum32_s(a: *f32, n: i64) f32 { var s: f32=0.0; var i: i64=0; for(i<n){ s=s+a[i]; i=i+1; } ret s; }
+fun fdot_v(a: *f64, b: *f64, n: i64) f64 { var s: f64=0.0; var i: i64=0; for(i<n){ s=s+a[i]*b[i]; i=i+1; } ret s; }
+#[scalar]
+fun fdot_s(a: *f64, b: *f64, n: i64) f64 { var s: f64=0.0; var i: i64=0; for(i<n){ s=s+a[i]*b[i]; i=i+1; } ret s; }
+fun fprod_v(a: *f64, n: i64) f64 { var s: f64=1.0; var i: i64=0; for(i<n){ s=s*a[i]; i=i+1; } ret s; }
+#[scalar]
+fun fprod_s(a: *f64, n: i64) f64 { var s: f64=1.0; var i: i64=0; for(i<n){ s=s*a[i]; i=i+1; } ret s; }
 
 # a subtraction reduction is NOT associative and must DECLINE, staying correct
 fun subred_v(a: *i64, n: i64) i64 { var s: i64=0; var i: i64=0; for(i<n){ s=s-a[i]; i=i+1; } ret s; }
@@ -90,7 +101,7 @@ fun main(argc: usize, argv: **u8) i64 {
     var mism: i64 = 0;
     var acc: i64 = 0;
     var a: [512]i64; var b: [512]i64;
-    var u: [512]u64; var d: [512]f64;
+    var u: [512]u64; var d: [512]f64; var d2: [512]f64; var sf: [512]f32;
     var w: [512]i32; var wu: [512]u32;
     var h: [512]i16; var hu: [512]u16;
     var e: [512]i8;  var eu: [512]u8;
@@ -105,6 +116,8 @@ fun main(argc: usize, argv: **u8) i64 {
             a[i]=i*7-13; b[i]=i*3+5;
             u[i]=(i*2654435761+11400714819323198485)::u64;
             d[i]=(i::f64)*1.5-3.0;
+            d2[i]=(i::f64)*0.0625+1.25;
+            sf[i]=((i::f64)*1.5-3.0)::f32;
             w[i]=(i*7-13)::i32; wu[i]=(i*2654435761)::u32;
             h[i]=(i*3-9)::i16; hu[i]=(i*40503+7)::u16;
             e[i]=(i*7-13)::i8;  eu[i]=(i*5+1)::u8;
@@ -129,6 +142,9 @@ fun main(argc: usize, argv: **u8) i64 {
         if (sumab_v(?a[0],?a[0],n) != sumab_s(?a[0],?a[0],n)) { mism=mism+1; } acc=acc+norm(sumab_v(?a[0],?a[0],n));
         if (dot_v(?a[0],?b[0],n) != dot_s(?a[0],?b[0],n)) { mism=mism+1; } acc=acc+norm(dot_v(?a[0],?b[0],n));
         if ((fsum_v(?d[0],n):~i64) != (fsum_s(?d[0],n):~i64)) { mism=mism+1; } acc=acc+norm(fsum_v(?d[0],n):~i64);
+        if ((fsum32_v(?sf[0],n):~i32) != (fsum32_s(?sf[0],n):~i32)) { mism=mism+1; } acc=acc+norm((fsum32_v(?sf[0],n):~i32)::i64);
+        if ((fdot_v(?d[0],?d2[0],n):~i64) != (fdot_s(?d[0],?d2[0],n):~i64)) { mism=mism+1; } acc=acc+norm(fdot_v(?d[0],?d2[0],n):~i64);
+        if ((fprod_v(?d2[0],n):~i64) != (fprod_s(?d2[0],n):~i64)) { mism=mism+1; } acc=acc+norm(fprod_v(?d2[0],n):~i64);
         if (subred_v(?a[0],n) != subred_s(?a[0],n)) { mism=mism+1; } acc=acc+norm(subred_v(?a[0],n));
         ti=ti+1;
     }

--- a/int/surface/vectorize-emit/expect.linux-arm64.txt
+++ b/int/surface/vectorize-emit/expect.linux-arm64.txt
@@ -3,7 +3,12 @@ add_i32k simd
 axpy_f32 simd
 carried_i32 scalar
 cond_i32 scalar
+fdot_f32 scalar
+fdot_f64 scalar
 fneg_f64 scalar
+fprod_f64 scalar
+fsum_f32 scalar
+fsum_f64 scalar
 glob_carried scalar
 glob_f64add simd
 glob_i32add simd

--- a/int/surface/vectorize-emit/expect.linux-riscv64.txt
+++ b/int/surface/vectorize-emit/expect.linux-riscv64.txt
@@ -3,7 +3,12 @@ add_i32k scalar
 axpy_f32 scalar
 carried_i32 scalar
 cond_i32 scalar
+fdot_f32 scalar
+fdot_f64 scalar
 fneg_f64 scalar
+fprod_f64 scalar
+fsum_f32 scalar
+fsum_f64 scalar
 glob_carried scalar
 glob_f64add scalar
 glob_i32add scalar

--- a/int/surface/vectorize-emit/expect.linux.txt
+++ b/int/surface/vectorize-emit/expect.linux.txt
@@ -3,7 +3,12 @@ add_i32k simd
 axpy_f32 simd
 carried_i32 scalar
 cond_i32 scalar
+fdot_f32 scalar
+fdot_f64 scalar
 fneg_f64 scalar
+fprod_f64 scalar
+fsum_f32 scalar
+fsum_f64 scalar
 glob_carried scalar
 glob_f64add simd
 glob_i32add simd

--- a/int/surface/vectorize-emit/src/main.mach
+++ b/int/surface/vectorize-emit/src/main.mach
@@ -52,6 +52,17 @@ pub fun glob_mul_f32k(k: f32) { var i: i64=0; for(i<512){ gf_a[i]=gf_b[i]*k; i=i
 # combine); its verdict guards the reduction path alongside the element-wise one
 pub fun sum_i64(a: *i64, n: i64) i64 { var s: i64=0; var i: i64=0; for(i<n){ s=s+a[i]; i=i+1; } ret s; }
 
+# float reductions must DECLINE here: lane-partial reassociation changes IEEE rounding,
+# and this case's profile does not set `float_reassoc` (#2160). the sibling
+# `vectorize-reassoc-emit` case is these same shapes under a profile that does set it,
+# where every verdict below flips to `simd` — the two goldens together are what pin the
+# key to its effect rather than to its mere presence.
+pub fun fsum_f64(a: *f64, n: i64) f64 { var s: f64=0.0; var i: i64=0; for(i<n){ s=s+a[i]; i=i+1; } ret s; }
+pub fun fsum_f32(a: *f32, n: i64) f32 { var s: f32=0.0; var i: i64=0; for(i<n){ s=s+a[i]; i=i+1; } ret s; }
+pub fun fdot_f64(a: *f64, b: *f64, n: i64) f64 { var s: f64=0.0; var i: i64=0; for(i<n){ s=s+a[i]*b[i]; i=i+1; } ret s; }
+pub fun fdot_f32(a: *f32, b: *f32, n: i64) f32 { var s: f32=0.0; var i: i64=0; for(i<n){ s=s+a[i]*b[i]; i=i+1; } ret s; }
+pub fun fprod_f64(a: *f64, n: i64) f64 { var s: f64=1.0; var i: i64=0; for(i<n){ s=s*a[i]; i=i+1; } ret s; }
+
 # a mixed-type body (i32 add and f32 mul at the same 4-byte width) must DECLINE: one
 # uniform element TYPE is required, not merely one width
 pub fun mixed_types(a: *i32, b: *i32, x: *f32, y: *f32, n: i64) { var i: i64=0; for(i<n){ a[i]=b[i]+b[i]; x[i]=y[i]*y[i]; i=i+1; } }

--- a/int/surface/vectorize-reassoc-emit/case.conf
+++ b/int/surface/vectorize-reassoc-emit/case.conf
@@ -1,0 +1,15 @@
+# the `float_reassoc` lever's EMISSION case (#2160). the sources are deliberately the
+# float-reduction subset of `vectorize-emit`, compiled under a profile that sets the
+# key; each function whose verdict is `scalar` in that case's golden is `simd` here.
+# a lever that stopped taking effect, or one that started admitting a shape it must
+# refuse (subtraction, division, an `#[oblivious]` body, a `#[scalar]` opt-out), moves
+# a verdict and fails.
+#
+# release only: the vectorizer runs in the opt=2 pipeline, so a debug leg's verdicts
+# would be uniformly `scalar` and assert nothing about the lever.
+#
+# the ELF legs only, for the same reason the sibling case gives: the verdict is a
+# property of the ISA, and these are the legs with a dependable llvm-objdump.
+run: vector-emit
+profiles: release
+targets: linux linux-arm64 linux-riscv64

--- a/int/surface/vectorize-reassoc-emit/case.conf
+++ b/int/surface/vectorize-reassoc-emit/case.conf
@@ -10,6 +10,14 @@
 #
 # the ELF legs only, for the same reason the sibling case gives: the verdict is a
 # property of the ISA, and these are the legs with a dependable llvm-objdump.
+#
+# `--verify-ir` runs the IR verifier's representation checks after every pass. The
+# reduction transform retypes a whole instruction tree to the vector type in step with
+# its use sites, and a member it fails to retype leaves an opcode holding vector
+# operands under a scalar result stamp — which the back end happens to select correctly
+# from the operand types, so it costs nothing observable in the disassembly or the
+# answer. The verifier is the only thing that sees it.
 run: vector-emit
 profiles: release
 targets: linux linux-arm64 linux-riscv64
+build-flags: --verify-ir

--- a/int/surface/vectorize-reassoc-emit/expect.linux-arm64.txt
+++ b/int/surface/vectorize-reassoc-emit/expect.linux-arm64.txt
@@ -1,0 +1,14 @@
+arch=aarch64
+fdiv_f64 scalar
+fdot_f32 simd
+fdot_f64 simd
+fprod_f64 simd
+fsub_f64 scalar
+fsum_f32 simd
+fsum_f64 simd
+fsum_init_f64 simd
+fsum_oblivious scalar
+fsum_optout scalar
+main scalar
+sub_i64 scalar
+sum_i64 simd

--- a/int/surface/vectorize-reassoc-emit/expect.linux-riscv64.txt
+++ b/int/surface/vectorize-reassoc-emit/expect.linux-riscv64.txt
@@ -1,0 +1,14 @@
+arch=riscv64
+fdiv_f64 scalar
+fdot_f32 scalar
+fdot_f64 scalar
+fprod_f64 scalar
+fsub_f64 scalar
+fsum_f32 scalar
+fsum_f64 scalar
+fsum_init_f64 scalar
+fsum_oblivious scalar
+fsum_optout scalar
+main scalar
+sub_i64 scalar
+sum_i64 scalar

--- a/int/surface/vectorize-reassoc-emit/expect.linux.txt
+++ b/int/surface/vectorize-reassoc-emit/expect.linux.txt
@@ -1,0 +1,14 @@
+arch=x86_64
+fdiv_f64 scalar
+fdot_f32 simd
+fdot_f64 simd
+fprod_f64 simd
+fsub_f64 scalar
+fsum_f32 simd
+fsum_f64 simd
+fsum_init_f64 simd
+fsum_oblivious scalar
+fsum_optout scalar
+main scalar
+sub_i64 scalar
+sum_i64 simd

--- a/int/surface/vectorize-reassoc-emit/mach.toml
+++ b/int/surface/vectorize-reassoc-emit/mach.toml
@@ -1,0 +1,44 @@
+[project]
+id = "case"
+version = "0.0.0"
+src = "src"
+# a fixed out root, not the usual {target.name}/{profile.name} template: the
+# vector-emit producer disassembles the per-module objects this build leaves
+# behind, so their path must be the same on every leg. run.sh wipes out/int before
+# and after each build, so one target's objects can never be read on another's run.
+out = "out/int/build"
+
+[target.linux]
+isa = "x86_64"
+os  = "linux"
+abi = "sysv64"
+
+[target.linux-arm64]
+isa = "aarch64"
+os  = "linux"
+abi = "aapcs64"
+
+[target.linux-riscv64]
+isa = "riscv64"
+os  = "linux"
+abi = "lp64"
+
+# the whole point of this case: the same release profile as its `vectorize-emit`
+# sibling plus the float-reassociation opt-in (#2160)
+[profile.release]
+opt = 2
+debug = false
+simd = "scalarize"
+float_reassoc = true
+
+[artifact.case]
+kind = "bin"
+entry = "main.mach"
+out = "bin/case"
+targets = ["*"]
+link = []
+need = []
+
+[dep.mach-std]
+git = "https://github.com/briar-systems/mach-std"
+ref = "branch/main"

--- a/int/surface/vectorize-reassoc-emit/src/main.mach
+++ b/int/surface/vectorize-reassoc-emit/src/main.mach
@@ -1,0 +1,52 @@
+# float reduction vectorization under `[profile.X] float_reassoc = true` (#2160),
+# EMISSION side. every function carries a verdict the golden records — `simd` when the
+# lever must let the reduction vectorize, `scalar` when the shape must be refused
+# anyway — read out of the disassembled objects.
+#
+# the five `f*` reductions here are the same source as the ones in the sibling
+# `vectorize-emit` case, whose profile omits the key and whose golden therefore says
+# `scalar` for every one of them. Reading the two goldens side by side is the
+# assertion: the key, and only the key, is what moves them.
+#
+# every function is `pub` and nothing calls it, so each is emitted as its own
+# uninlined symbol and its verdict describes exactly the loop written below it.
+#
+# riscv64 has no 128-bit vector model, so every verdict is `scalar` there regardless of
+# the lever; that is the target's own golden, not an exemption.
+use std.runtime;
+use std.types.size.usize;
+
+# the reductions the lever admits: sum, dot (the matmul inner loop), and product, at
+# both float widths
+pub fun fsum_f64(a: *f64, n: i64) f64 { var s: f64=0.0; var i: i64=0; for(i<n){ s=s+a[i]; i=i+1; } ret s; }
+pub fun fsum_f32(a: *f32, n: i64) f32 { var s: f32=0.0; var i: i64=0; for(i<n){ s=s+a[i]; i=i+1; } ret s; }
+pub fun fdot_f64(a: *f64, b: *f64, n: i64) f64 { var s: f64=0.0; var i: i64=0; for(i<n){ s=s+a[i]*b[i]; i=i+1; } ret s; }
+pub fun fdot_f32(a: *f32, b: *f32, n: i64) f32 { var s: f32=0.0; var i: i64=0; for(i<n){ s=s+a[i]*b[i]; i=i+1; } ret s; }
+pub fun fprod_f64(a: *f64, n: i64) f64 { var s: f64=1.0; var i: i64=0; for(i<n){ s=s*a[i]; i=i+1; } ret s; }
+
+# a non-zero initial accumulator is folded into lane 0 and must still vectorize
+pub fun fsum_init_f64(a: *f64, n: i64) f64 { var s: f64=1000.0; var i: i64=0; for(i<n){ s=s+a[i]; i=i+1; } ret s; }
+
+# the lever licenses ASSOCIATIVITY and nothing else, so a non-associative float
+# recurrence must DECLINE even with it set: subtraction and division reassociate to
+# different VALUES, not merely to different rounding
+pub fun fsub_f64(a: *f64, n: i64) f64 { var s: f64=0.0; var i: i64=0; for(i<n){ s=s-a[i]; i=i+1; } ret s; }
+pub fun fdiv_f64(a: *f64, n: i64) f64 { var s: f64=1.0; var i: i64=0; for(i<n){ s=s/a[i]; i=i+1; } ret s; }
+
+# the per-function opt-out still wins over the profile-wide opt-in
+#[scalar]
+pub fun fsum_optout(a: *f64, n: i64) f64 { var s: f64=0.0; var i: i64=0; for(i<n){ s=s+a[i]; i=i+1; } ret s; }
+
+# an `#[oblivious]` body's timing shape is its contract; the lever must not reshape it
+#[oblivious]
+pub fun fsum_oblivious(a: *f64, n: i64) f64 { var s: f64=0.0; var i: i64=0; for(i<n){ s=s+a[i]; i=i+1; } ret s; }
+
+# the integer reductions are the lever's control: unconditionally vectorized, and
+# bit-identical to scalar, with the key set exactly as without it
+pub fun sum_i64(a: *i64, n: i64) i64 { var s: i64=0; var i: i64=0; for(i<n){ s=s+a[i]; i=i+1; } ret s; }
+pub fun sub_i64(a: *i64, n: i64) i64 { var s: i64=0; var i: i64=0; for(i<n){ s=s-a[i]; i=i+1; } ret s; }
+
+# the artifact is never run: the observable is the disassembly of the objects above,
+# so the entry exists only to link
+#[symbol("main")]
+fun main(argc: usize, argv: **u8) i64 { ret 0; }

--- a/int/surface/vectorize-reassoc/expect.txt
+++ b/int/surface/vectorize-reassoc/expect.txt
@@ -1,0 +1,3 @@
+loose=0
+exact=0
+checks=104

--- a/int/surface/vectorize-reassoc/mach.toml
+++ b/int/surface/vectorize-reassoc/mach.toml
@@ -1,0 +1,59 @@
+[project]
+id = "case"
+version = "0.0.0"
+src = "src"
+out = "out/{target.name}/{profile.name}"
+
+[target.linux]
+isa = "x86_64"
+os  = "linux"
+abi = "sysv64"
+
+[target.linux-arm64]
+isa = "aarch64"
+os  = "linux"
+abi = "aapcs64"
+
+[target.linux-riscv64]
+isa = "riscv64"
+os  = "linux"
+abi = "lp64"
+
+[target.windows]
+isa = "x86_64"
+os  = "windows"
+abi = "win64"
+
+[target.darwin-x86_64]
+isa = "x86_64"
+os  = "darwin"
+abi = "sysv64"
+
+[target.darwin-aarch64]
+isa = "aarch64"
+os  = "darwin"
+abi = "aapcs64"
+
+[profile.debug]
+opt = 0
+debug = false
+simd = "scalarize"
+float_reassoc = true
+
+[profile.release]
+opt = 2
+debug = false
+simd = "scalarize"
+float_reassoc = true
+
+[artifact.case]
+kind = "bin"
+entry = "main.mach"
+out = "bin/case"
+targets = ["*"]
+link = []
+need = []
+
+[dep.mach-std]
+git = "https://github.com/briar-systems/mach-std"
+ref = "branch/main"

--- a/int/surface/vectorize-reassoc/src/main.mach
+++ b/int/surface/vectorize-reassoc/src/main.mach
@@ -21,7 +21,7 @@ use std.types.size.usize;
 use p: std.print;
 
 # the IEEE-754 double bit pattern of negative zero, spelled as a pattern because the
-# `-0.0` literal folds to POSITIVE zero (briar-systems/mach#2269)
+# `-0.0` literal folds to POSITIVE zero (briar-systems/mach#2274)
 val NEG_ZERO_BITS: u64 = 0x8000000000000000;
 fun neg_zero() f64 { ret NEG_ZERO_BITS:~f64; }
 

--- a/int/surface/vectorize-reassoc/src/main.mach
+++ b/int/surface/vectorize-reassoc/src/main.mach
@@ -1,0 +1,151 @@
+# float reduction vectorization under `[profile.X] float_reassoc = true` (#2160),
+# CORRECTNESS side. the sibling `vectorize-reassoc-emit` case asserts that the lever
+# makes the pass fire; this one asserts that what it emits is still the right answer.
+#
+# a reassociated float reduction is deliberately NOT bit-identical to its `#[scalar]`
+# twin, so the observable cannot be an exact comparison the way the integer `reduce`
+# case's is. Instead each float pair is scored against a RELATIVE TOLERANCE — a
+# reassociated sum stays within a few ULPs of the sequential one, and a transform that
+# dropped an element, double-counted the user's initial value, mishandled the remainder
+# tail or seeded a wrong identity would miss it by far more than that.
+#
+# The exact-comparison assertions carry the other half: every shape the lever must NOT
+# admit (subtraction, division, a `#[scalar]` opt-out) and every integer reduction stay
+# bit-identical, and a negative-zero sum keeps its sign. Those hold on every target,
+# including riscv64 where no reduction vectorizes at all, so the golden is shared.
+use std.runtime;
+use std.types.bool.bool;
+use std.types.bool.false;
+use std.types.bool.true;
+use std.types.size.usize;
+use p: std.print;
+
+# the IEEE-754 double bit pattern of negative zero, spelled as a pattern because the
+# `-0.0` literal folds to POSITIVE zero (briar-systems/mach#2269)
+val NEG_ZERO_BITS: u64 = 0x8000000000000000;
+fun neg_zero() f64 { ret NEG_ZERO_BITS:~f64; }
+
+fun fsum64_v(a: *f64, n: i64) f64 { var s: f64=0.0; var i: i64=0; for(i<n){ s=s+a[i]; i=i+1; } ret s; }
+#[scalar]
+fun fsum64_s(a: *f64, n: i64) f64 { var s: f64=0.0; var i: i64=0; for(i<n){ s=s+a[i]; i=i+1; } ret s; }
+fun fsum32_v(a: *f32, n: i64) f32 { var s: f32=0.0; var i: i64=0; for(i<n){ s=s+a[i]; i=i+1; } ret s; }
+#[scalar]
+fun fsum32_s(a: *f32, n: i64) f32 { var s: f32=0.0; var i: i64=0; for(i<n){ s=s+a[i]; i=i+1; } ret s; }
+
+# a non-zero initial accumulator must be folded in exactly ONCE, not once per lane
+fun fsum_init_v(a: *f64, n: i64) f64 { var s: f64=1000.0; var i: i64=0; for(i<n){ s=s+a[i]; i=i+1; } ret s; }
+#[scalar]
+fun fsum_init_s(a: *f64, n: i64) f64 { var s: f64=1000.0; var i: i64=0; for(i<n){ s=s+a[i]; i=i+1; } ret s; }
+
+# the matmul / dot inner loop, the shape the lever exists for
+fun fdot64_v(a: *f64, b: *f64, n: i64) f64 { var s: f64=0.0; var i: i64=0; for(i<n){ s=s+a[i]*b[i]; i=i+1; } ret s; }
+#[scalar]
+fun fdot64_s(a: *f64, b: *f64, n: i64) f64 { var s: f64=0.0; var i: i64=0; for(i<n){ s=s+a[i]*b[i]; i=i+1; } ret s; }
+fun fdot32_v(a: *f32, b: *f32, n: i64) f32 { var s: f32=0.0; var i: i64=0; for(i<n){ s=s+a[i]*b[i]; i=i+1; } ret s; }
+#[scalar]
+fun fdot32_s(a: *f32, b: *f32, n: i64) f32 { var s: f32=0.0; var i: i64=0; for(i<n){ s=s+a[i]*b[i]; i=i+1; } ret s; }
+
+# a product reduction seeds the idle lanes with 1.0
+fun fprod_v(a: *f64, n: i64) f64 { var s: f64=1.0; var i: i64=0; for(i<n){ s=s*a[i]; i=i+1; } ret s; }
+#[scalar]
+fun fprod_s(a: *f64, n: i64) f64 { var s: f64=1.0; var i: i64=0; for(i<n){ s=s*a[i]; i=i+1; } ret s; }
+
+# non-associative float recurrences: the lever must DECLINE, so these stay EXACT
+fun fsub_v(a: *f64, n: i64) f64 { var s: f64=0.0; var i: i64=0; for(i<n){ s=s-a[i]; i=i+1; } ret s; }
+#[scalar]
+fun fsub_s(a: *f64, n: i64) f64 { var s: f64=0.0; var i: i64=0; for(i<n){ s=s-a[i]; i=i+1; } ret s; }
+fun fdiv_v(a: *f64, n: i64) f64 { var s: f64=1.0; var i: i64=0; for(i<n){ s=s/a[i]; i=i+1; } ret s; }
+#[scalar]
+fun fdiv_s(a: *f64, n: i64) f64 { var s: f64=1.0; var i: i64=0; for(i<n){ s=s/a[i]; i=i+1; } ret s; }
+
+# the per-function opt-out beats the profile-wide opt-in, so this pair is EXACT
+#[scalar]
+fun fsum_optout_v(a: *f64, n: i64) f64 { var s: f64=0.0; var i: i64=0; for(i<n){ s=s+a[i]; i=i+1; } ret s; }
+#[scalar]
+fun fsum_optout_s(a: *f64, n: i64) f64 { var s: f64=0.0; var i: i64=0; for(i<n){ s=s+a[i]; i=i+1; } ret s; }
+
+# a negative-zero seed over negative-zero elements: `x + (-0.0) == x` is exact, so the
+# lane identity must be -0.0 and the sum must stay negative. seeding the idle lanes
+# with +0.0 would return +0.0 here — a no-signed-zeros liberty the lever does not grant
+fun nzsum_v(a: *f64, z: f64, n: i64) f64 { var s: f64=z; var i: i64=0; for(i<n){ s=s+a[i]; i=i+1; } ret s; }
+
+# the integer reductions are unaffected by the lever and stay bit-identical
+fun isum_v(a: *i64, n: i64) i64 { var s: i64=0; var i: i64=0; for(i<n){ s=s+a[i]; i=i+1; } ret s; }
+#[scalar]
+fun isum_s(a: *i64, n: i64) i64 { var s: i64=0; var i: i64=0; for(i<n){ s=s+a[i]; i=i+1; } ret s; }
+fun ixor_v(a: *u64, n: i64) u64 { var s: u64=0; var i: i64=0; for(i<n){ s=s^a[i]; i=i+1; } ret s; }
+#[scalar]
+fun ixor_s(a: *u64, n: i64) u64 { var s: u64=0; var i: i64=0; for(i<n){ s=s^a[i]; i=i+1; } ret s; }
+
+fun fabs64(x: f64) f64 { if (x < 0.0) { ret 0.0 - x; } ret x; }
+
+# true when `v` is within `tol` RELATIVE of `s` (or both are the same exact value)
+fun close(v: f64, s: f64, tol: f64) bool {
+    if ((v:~i64) == (s:~i64)) { ret true; }
+    val d: f64 = fabs64(v - s);
+    val m: f64 = fabs64(s);
+    if (m == 0.0) { ret d <= tol; }
+    ret (d / m) <= tol;
+}
+
+#[symbol("main")]
+fun main(argc: usize, argv: **u8) i64 {
+    var loose: i64 = 0;   # tolerance violations on a reassociated reduction
+    var exact: i64 = 0;   # bit-identity violations where the transform must decline
+    var checks: i64 = 0;
+
+    var a: [512]f64; var b: [512]f64;
+    var f: [512]f32; var g: [512]f32;
+    var q: [512]i64; var u: [512]u64;
+    var z: [512]f64;
+    val mz: f64 = neg_zero();
+
+    # trip counts spanning multiples and non-multiples of both lane counts (2 for f64 /
+    # i64, 4 for f32), plus counts below the lane count where the vector loop is skipped
+    # entirely and the remainder does all the work
+    var trips: [8]i64;
+    trips[0]=512; trips[1]=511; trips[2]=64; trips[3]=17; trips[4]=16; trips[5]=3; trips[6]=1; trips[7]=0;
+
+    var ti: i64 = 0;
+    for (ti < 8) {
+        val n: i64 = trips[ti];
+        var i: i64 = 0;
+        for (i < n) {
+            a[i] = (i::f64) * 0.125 - 3.5;
+            b[i] = (i::f64) * 0.0625 + 1.25;
+            f[i] = ((i::f64) * 0.125 - 3.5)::f32;
+            g[i] = ((i::f64) * 0.0625 + 1.25)::f32;
+            q[i] = i * 7 - 13;
+            u[i] = (i * 2654435761 + 11400714819323198485)::u64;
+            z[i] = mz;
+            i = i + 1;
+        }
+
+        # reassociated: within tolerance of the sequential reference
+        if (!close(fsum64_v(?a[0],n), fsum64_s(?a[0],n), 0.000000001)) { loose = loose + 1; }
+        if (!close(fsum32_v(?f[0],n)::f64, fsum32_s(?f[0],n)::f64, 0.0001)) { loose = loose + 1; }
+        if (!close(fsum_init_v(?a[0],n), fsum_init_s(?a[0],n), 0.000000001)) { loose = loose + 1; }
+        if (!close(fdot64_v(?a[0],?b[0],n), fdot64_s(?a[0],?b[0],n), 0.000000001)) { loose = loose + 1; }
+        if (!close(fdot32_v(?f[0],?g[0],n)::f64, fdot32_s(?f[0],?g[0],n)::f64, 0.0001)) { loose = loose + 1; }
+        if (!close(fprod_v(?b[0],n), fprod_s(?b[0],n), 0.000000001)) { loose = loose + 1; }
+        # aliased read operands: read-only sources need no guard and must still agree
+        if (!close(fdot64_v(?a[0],?a[0],n), fdot64_s(?a[0],?a[0],n), 0.000000001)) { loose = loose + 1; }
+        checks = checks + 7;
+
+        # declined or unaffected: bit-identical
+        if ((fsub_v(?a[0],n):~i64) != (fsub_s(?a[0],n):~i64)) { exact = exact + 1; }
+        if ((fdiv_v(?b[0],n):~i64) != (fdiv_s(?b[0],n):~i64)) { exact = exact + 1; }
+        if ((fsum_optout_v(?a[0],n):~i64) != (fsum_optout_s(?a[0],n):~i64)) { exact = exact + 1; }
+        if (isum_v(?q[0],n) != isum_s(?q[0],n)) { exact = exact + 1; }
+        if (ixor_v(?u[0],n) != ixor_s(?u[0],n)) { exact = exact + 1; }
+        # a negative-zero sum keeps its sign under reassociation
+        if ((nzsum_v(?z[0],mz,n):~i64) != (mz:~i64)) { exact = exact + 1; }
+        checks = checks + 6;
+        ti = ti + 1;
+    }
+
+    p.printlnf("loose={}", loose);
+    p.printlnf("exact={}", exact);
+    p.printlnf("checks={}", checks);
+    ret 0;
+}

--- a/src/lang/build/request.mach
+++ b/src/lang/build/request.mach
@@ -154,6 +154,8 @@ pub rec LinkToken {
 # debug:        emit debug info (`-g` wins, else the profile's `debug`)
 # pie:          emit a position-independent executable (`--pie`)
 # simd:         the profile's resolved SIMD strictness posture
+# vectorize:    the profile's resolved auto-vectorization lever
+# float_reassoc: the profile's resolved permission to reassociate float arithmetic
 # verify_ir:    run the IR verifier after each optimization pass
 # jobs:         concrete codegen worker count; compose settles >= 1 (explicit
 #               `--jobs`, else the host CPU count). 0 is the serial-incremental
@@ -182,8 +184,9 @@ pub rec BuildRequest {
     opt:          u8;
     debug:        bool;
     pie:          bool;
-    simd:         manifest.SimdMode;
-    vectorize:    bool;
+    simd:          manifest.SimdMode;
+    vectorize:     bool;
+    float_reassoc: bool;
     verify_ir:    bool;
     jobs:         u32;
 
@@ -220,8 +223,9 @@ pub fun defaults() BuildRequest {
     r.opt          = pipeline.OPT_DEBUG;
     r.debug        = false;
     r.pie          = false;
-    r.simd         = manifest.SIMD_SCALARIZE;
-    r.vectorize    = true;
+    r.simd          = manifest.SIMD_SCALARIZE;
+    r.vectorize     = true;
+    r.float_reassoc = false;
     r.verify_ir    = false;
     r.jobs         = 0;
     r.emit_ir      = false;
@@ -324,8 +328,9 @@ pub fun compose(a: *A.Allocator, itn: *intern.Interner, m: *manifest.Manifest,
 
     r.debug     = cli.g || bu.debug;
     r.pie       = cli.pie;
-    r.simd      = bu.simd;
-    r.vectorize = bu.vectorize;
+    r.simd          = bu.simd;
+    r.vectorize     = bu.vectorize;
+    r.float_reassoc = bu.float_reassoc;
     r.verify_ir = cli.verify_ir;
 
     # worker count: an explicit `--jobs` wins (a positive integer); absent it
@@ -460,6 +465,7 @@ fun write_semantic_fields(e: *binary.Encoder, r: *BuildRequest) bool {
     ok = ok && hb(e, r.pie);
     ok = ok && R.is_ok[usize, str](binary.write_u8(e, r.simd));
     ok = ok && hb(e, r.vectorize);
+    ok = ok && hb(e, r.float_reassoc);
     ok = ok && hb(e, r.verify_ir);
     ok = ok && hb(e, r.include_deps);
     ret ok;

--- a/src/lang/build/testing.mach
+++ b/src/lang/build/testing.mach
@@ -306,7 +306,7 @@ fun build_dispatch_executable(p: *driver.Project, unit: *plan.BuildUnit, obj_bas
     }
     var entry_ir: ir.Module = R.unwrap_ok[ir.Module, str](res_synth);
 
-    val res_opt: R.Result[bool, str] = pipeline.run(?entry_ir, ?p.target, ctx.req.opt, ctx.req.verify_ir, ctx.req.vectorize, ctx.req.simd == manifest.SIMD_REQUIRE, ?p.s.interner);
+    val res_opt: R.Result[bool, str] = pipeline.run(?entry_ir, ?p.target, ctx.req.opt, ctx.req.verify_ir, ctx.req.vectorize, ctx.req.simd == manifest.SIMD_REQUIRE, ctx.req.float_reassoc, ?p.s.interner);
     if (R.is_err[bool, str](res_opt)) {
         ir.dnit(?entry_ir);
         ret R.err[bool, outcome.Fail](outcome.internal(R.unwrap_err[bool, str](res_opt)));

--- a/src/lang/driver/passes.mach
+++ b/src/lang/driver/passes.mach
@@ -978,7 +978,7 @@ pub fun q_lower_compute(db: *query.QueryDb, key: u64, alloc: *A.Allocator) R.Res
 
     # optimize in place: the cached artifact is the post-pipeline IR the object is
     # built from, so an unchanged optimized module reuses its codegen output.
-    val res_opt: R.Result[bool, str] = pipeline.run(?irmod, ?p.target, ctx.req.opt, ctx.req.verify_ir, ctx.req.vectorize, ctx.req.simd == manifest.SIMD_REQUIRE, ?p.s.interner);
+    val res_opt: R.Result[bool, str] = pipeline.run(?irmod, ?p.target, ctx.req.opt, ctx.req.verify_ir, ctx.req.vectorize, ctx.req.simd == manifest.SIMD_REQUIRE, ctx.req.float_reassoc, ?p.s.interner);
     if (R.is_err[bool, str](res_opt)) {
         ir.dnit(?irmod);
         ret R.err[query.QueryOutput, str](R.unwrap_err[bool, str](res_opt));

--- a/src/lang/manifest.mach
+++ b/src/lang/manifest.mach
@@ -2141,6 +2141,61 @@ test "mach.lang.manifest.parse:simd_required_and_validated" {
     ret code;
 }
 
+# the `float_reassoc` opt-in lever (#2160): optional, and its ABSENCE must resolve to
+# false. The default is the whole safety property -- a manifest that never heard of the
+# key gets IEEE-strict float reductions -- so it is asserted on the parsed profile and
+# again on the resolved one, not merely on the parser's return.
+test "mach.lang.manifest.parse:float_reassoc_optional_and_off" {
+    var backing: A.Allocator; var ar: arena.Arena; var alloc: A.Allocator; var itn: intern.Interner;
+    if (!tinit(?backing, ?ar, ?alloc, ?itn)) { ret 1; }
+    var code: i32 = 0;
+    val head: str = "[project]\nid=\"x\"\nversion=\"1\"\nsrc=\"src\"\nout=\"out\"\n";
+
+    # absent -> false
+    val a: R.Result[Manifest, str] = tparse(?alloc, ?itn, sfmt(?alloc, "{}{}", head, "[profile.p]\nopt=2\ndebug=false\nsimd=\"scalarize\"\n"));
+    if (R.is_err[Manifest, str](a)) { code = 1; }
+    or {
+        var ma: Manifest = R.unwrap_ok[Manifest, str](a);
+        if (ma.profiles[0].float_reassoc) { code = 1; }
+        val ra: R.Result[ResolvedProfile, str] = resolve_profile(?alloc, ?itn, ?ma, "p");
+        if (R.is_err[ResolvedProfile, str](ra)) { code = 1; }
+        or { if (R.unwrap_ok[ResolvedProfile, str](ra).float_reassoc) { code = 1; } }
+    }
+
+    # present and true -> true, through the resolve as well
+    val b: R.Result[Manifest, str] = tparse(?alloc, ?itn, sfmt(?alloc, "{}{}", head, "[profile.p]\nopt=2\ndebug=false\nsimd=\"scalarize\"\nfloat_reassoc=true\n"));
+    if (R.is_err[Manifest, str](b)) { code = 1; }
+    or {
+        var mb: Manifest = R.unwrap_ok[Manifest, str](b);
+        if (!mb.profiles[0].float_reassoc) { code = 1; }
+        val rb: R.Result[ResolvedProfile, str] = resolve_profile(?alloc, ?itn, ?mb, "p");
+        if (R.is_err[ResolvedProfile, str](rb)) { code = 1; }
+        or { if (!R.unwrap_ok[ResolvedProfile, str](rb).float_reassoc) { code = 1; } }
+    }
+
+    # present and false -> false (an explicit opt-out reads the same as absence)
+    val c: R.Result[Manifest, str] = tparse(?alloc, ?itn, sfmt(?alloc, "{}{}", head, "[profile.p]\nopt=2\ndebug=false\nsimd=\"scalarize\"\nfloat_reassoc=false\n"));
+    if (R.is_err[Manifest, str](c)) { code = 1; }
+    or { if (R.unwrap_ok[Manifest, str](c).profiles[0].float_reassoc) { code = 1; } }
+
+    # a non-boolean is the specific manifest error, not a silent default
+    val d: R.Result[Manifest, str] = tparse(?alloc, ?itn, sfmt(?alloc, "{}{}", head, "[profile.p]\nopt=2\ndebug=false\nsimd=\"scalarize\"\nfloat_reassoc=\"yes\"\n"));
+    if (R.is_ok[Manifest, str](d) || !str_contains(R.unwrap_err[Manifest, str](d), "float_reassoc must be a boolean")) { code = 1; }
+
+    # the default profile synthesized when none is declared is IEEE-strict too
+    val e: R.Result[Manifest, str] = tparse(?alloc, ?itn, head);
+    if (R.is_err[Manifest, str](e)) { code = 1; }
+    or {
+        var me: Manifest = R.unwrap_ok[Manifest, str](e);
+        val re: R.Result[ResolvedProfile, str] = resolve_profile(?alloc, ?itn, ?me, "");
+        if (R.is_err[ResolvedProfile, str](re)) { code = 1; }
+        or { if (R.unwrap_ok[ResolvedProfile, str](re).float_reassoc) { code = 1; } }
+    }
+
+    arena.dnit(?ar);
+    ret code;
+}
+
 test "mach.lang.manifest.parse:reserved_target_native" {
     var backing: A.Allocator; var ar: arena.Arena; var alloc: A.Allocator; var itn: intern.Interner;
     if (!tinit(?backing, ?ar, ?alloc, ?itn)) { ret 1; }

--- a/src/lang/manifest.mach
+++ b/src/lang/manifest.mach
@@ -85,13 +85,14 @@ pub rec ArtifactDef {
 }
 
 pub rec ProfileDef {
-    name:      intern.StrId;
-    opt:       MOpt;
-    emit_ir:   bool;
-    emit_asm:  bool;
-    debug:     bool;
-    simd:      SimdMode;
-    vectorize: bool;
+    name:          intern.StrId;
+    opt:           MOpt;
+    emit_ir:       bool;
+    emit_asm:      bool;
+    debug:         bool;
+    simd:          SimdMode;
+    vectorize:     bool;
+    float_reassoc: bool;
 }
 
 pub rec DepDef {
@@ -173,9 +174,10 @@ pub rec BuildUnit {
     opt:          MOpt;
     emit_ir:      bool;
     emit_asm:     bool;
-    debug:        bool;
-    simd:         SimdMode;
-    vectorize:    bool;
+    debug:         bool;
+    simd:          SimdMode;
+    vectorize:     bool;
+    float_reassoc: bool;
     is_lib:       bool;
     kind:         LibKind;
     libs:         *intern.StrId;
@@ -191,13 +193,14 @@ pub rec ResolvedTarget {
 }
 
 pub rec ResolvedProfile {
-    name:      intern.StrId;
-    opt:       MOpt;
-    emit_ir:   bool;
-    emit_asm:  bool;
-    debug:     bool;
-    simd:      SimdMode;
-    vectorize: bool;
+    name:          intern.StrId;
+    opt:           MOpt;
+    emit_ir:       bool;
+    emit_asm:      bool;
+    debug:         bool;
+    simd:          SimdMode;
+    vectorize:     bool;
+    float_reassoc: bool;
 }
 
 # the values a path/command template expands its target/profile variables against
@@ -419,6 +422,18 @@ fun parse_vectorize_flag(alloc: *A.Allocator, name: str, sub: *toml.Table) R.Res
     ret R.ok[bool, str](v.data.boolean);
 }
 
+# parse a profile's OPTIONAL `float_reassoc` lever (#2160): permission to treat
+# floating-point addition and multiplication as associative. Absent it defaults to
+# FALSE -- IEEE-strict is the default, and an absent key leaves emitted code
+# byte-identical to a build that never heard of the key. A present value must be a
+# boolean. The key name is final and documented in doc/manifest.md.
+fun parse_float_reassoc_flag(alloc: *A.Allocator, name: str, sub: *toml.Table) R.Result[bool, str] {
+    val v: *toml.Value = toml.get(sub, "float_reassoc");
+    if (v == nil)                { ret R.ok[bool, str](false); }
+    if (v.tag != toml.TYPE_BOOL) { ret R.err[bool, str](sfmt(alloc, "mach.toml: profile '{}': float_reassoc must be a boolean (got {})", name, opt_value_text(alloc, v))); }
+    ret R.ok[bool, str](v.data.boolean);
+}
+
 # parse a profile's required `simd` strictness lever (#1965), mirroring
 # parse_debug_flag's totality gate: as-root, an absent key is the same missing-
 # required-key error, and off-root (a dependency's permissively-parsed manifest)
@@ -486,6 +501,8 @@ fun key_known(kind: TableKind, k: str, as_root: bool) bool {
         if (str_equals(k, "opt") || str_equals(k, "debug") || str_equals(k, "simd")) { ret true; }
         # the optional `vectorize` opt-out lever (#2141); absent defaults to on
         if (str_equals(k, "vectorize")) { ret true; }
+        # the optional `float_reassoc` opt-in lever (#2160); absent defaults to off
+        if (str_equals(k, "float_reassoc")) { ret true; }
         # emit_ir/emit_asm are CLI-only (--emit-ir/--emit-asm); like name/description
         # they are pre-flag-day keys tolerated off-root, an unknown key as root (#1971).
         if (!as_root && (str_equals(k, "emit_ir") || str_equals(k, "emit_asm"))) { ret true; }
@@ -787,6 +804,9 @@ fun parse_profiles(alloc: *A.Allocator, itn: *intern.Interner, t: *toml.Table, m
         val res_vec: R.Result[bool, str] = parse_vectorize_flag(alloc, name, sub);
         if (R.is_err[bool, str](res_vec)) { ret R.err[bool, str](R.unwrap_err[bool, str](res_vec)); }
         pf.vectorize = R.unwrap_ok[bool, str](res_vec);
+        val res_fra: R.Result[bool, str] = parse_float_reassoc_flag(alloc, name, sub);
+        if (R.is_err[bool, str](res_fra)) { ret R.err[bool, str](R.unwrap_err[bool, str](res_fra)); }
+        pf.float_reassoc = R.unwrap_ok[bool, str](res_fra);
 
         m.profiles[i] = pf;
         i = i + 1;
@@ -1300,9 +1320,10 @@ fun profile_resolved(pf: *ProfileDef) ResolvedProfile {
     rp.opt      = pf.opt;
     rp.emit_ir  = pf.emit_ir;
     rp.emit_asm = pf.emit_asm;
-    rp.debug     = pf.debug;
-    rp.simd      = pf.simd;
-    rp.vectorize = pf.vectorize;
+    rp.debug         = pf.debug;
+    rp.simd          = pf.simd;
+    rp.vectorize     = pf.vectorize;
+    rp.float_reassoc = pf.float_reassoc;
     ret rp;
 }
 
@@ -1330,9 +1351,10 @@ pub fun resolve_profile(alloc: *A.Allocator, itn: *intern.Interner, m: *Manifest
     rp.opt      = MOPT_DEFAULT;
     rp.emit_ir  = false;
     rp.emit_asm = false;
-    rp.debug     = false;
-    rp.simd      = SIMD_SCALARIZE;
-    rp.vectorize = true;
+    rp.debug         = false;
+    rp.simd          = SIMD_SCALARIZE;
+    rp.vectorize     = true;
+    rp.float_reassoc = false;
     ret R.ok[ResolvedProfile, str](rp);
 }
 
@@ -1678,8 +1700,9 @@ pub fun resolve_build_unit(alloc: *A.Allocator, itn: *intern.Interner, m: *Manif
     u.emit_ir      = rp.emit_ir;
     u.emit_asm     = rp.emit_asm;
     u.debug        = rp.debug;
-    u.simd         = rp.simd;
-    u.vectorize    = rp.vectorize;
+    u.simd          = rp.simd;
+    u.vectorize     = rp.vectorize;
+    u.float_reassoc = rp.float_reassoc;
     u.is_lib       = a.is_lib;
     u.kind         = LIBKIND_STATIC;
     val kind_str: str = idstr(itn, a.kind);

--- a/src/lang/me/analysis/dependence.mach
+++ b/src/lang/me/analysis/dependence.mach
@@ -513,6 +513,102 @@ test "mach.lang.me.analysis.dependence:loop_carried_dependent" {
     ret code;
 }
 
+# build an `s = s OP a[i]` reduction over an f64 array into a fresh module and run
+# analyze_reduction over it under the given reassociation permission. Returns 0 when
+# the verdict matches `want_ok`, 1 otherwise (including any construction failure), and
+# on a positive verdict also checks the recovered op / floatness / lane count.
+fun float_reduction_verdict(op: instruction.InstrKind, float_reassoc: bool, want_ok: bool) i32 {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+    val rm: R.Result[ir.Module, str] = ir.init(?alloc, intern.STR_NIL);
+    if (R.is_err[ir.Module, str](rm)) { ret 1; }
+    var m: ir.Module = R.unwrap_ok[ir.Module, str](rm);
+    val rt: R.Result[ir_type.IrTypeId, str] = ir_type.intern_int(?m.types, 64);
+    if (R.is_err[ir_type.IrTypeId, str](rt)) { ir.dnit(?m); ret 1; }
+    val i64t: ir_type.IrTypeId = R.unwrap_ok[ir_type.IrTypeId, str](rt);
+    val rft: R.Result[ir_type.IrTypeId, str] = ir_type.intern_float(?m.types, 64);
+    if (R.is_err[ir_type.IrTypeId, str](rft)) { ir.dnit(?m); ret 1; }
+    val f64t: ir_type.IrTypeId = R.unwrap_ok[ir_type.IrTypeId, str](rft);
+    val rp: R.Result[ir_type.IrTypeId, str] = ir_type.intern_ptr(?m.types);
+    if (R.is_err[ir_type.IrTypeId, str](rp)) { ir.dnit(?m); ret 1; }
+    val ptrt: ir_type.IrTypeId = R.unwrap_ok[ir_type.IrTypeId, str](rp);
+    val rf: R.Result[u32, str] = ir.function_add(?m, intern.STR_NIL, ir_type.IRT_NIL, 0);
+    if (R.is_err[u32, str](rf)) { ir.dnit(?m); ret 1; }
+    val fn: *ir.Function = ?m.functions[R.unwrap_ok[u32, str](rf)];
+    var bld: builder.Builder = builder.init(?m);
+    builder.set_function(?bld, fn);
+
+    var entry: id.BlockId; var header: id.BlockId; var body: id.BlockId; var exit: id.BlockId; var iv: value.Value;
+    if (mk_skeleton(?m, ?bld, i64t, ?entry, ?header, ?body, ?exit, ?iv) != 0) { ir.dnit(?m); ret 1; }
+
+    # the f64 accumulator phi, the loop's second recurrence
+    builder.set_block(?bld, header);
+    val racc: R.Result[value.Value, str] = builder.emit_phi(?bld, f64t);
+    if (R.is_err[value.Value, str](racc)) { ir.dnit(?m); ret 1; }
+    val acc: value.Value = R.unwrap_ok[value.Value, str](racc);
+
+    # body: `s = s OP a[i]` over an f64-strided load
+    val a: value.Value = value.param(1, ptrt);
+    builder.set_block(?bld, body);
+    var ix: [1]value.Value;
+    ix[0] = iv;
+    val rg: R.Result[value.Value, str] = builder.emit_gep(?bld, a, f64t, ?ix[0], 1);
+    if (R.is_err[value.Value, str](rg)) { ir.dnit(?m); ret 1; }
+    val rl: R.Result[value.Value, str] = builder.emit_load(?bld, R.unwrap_ok[value.Value, str](rg), f64t);
+    if (R.is_err[value.Value, str](rl)) { ir.dnit(?m); ret 1; }
+    val ld: value.Value = R.unwrap_ok[value.Value, str](rl);
+    # exactly ONE update op: a second one would be another in-loop use of the
+    # accumulator and would decline for that reason rather than for the op
+    var racu: R.Result[value.Value, str];
+    if (op == instruction.OP_MUL)      { racu = builder.emit_mul(?bld, acc, ld); }
+    or (op == instruction.OP_SUB)      { racu = builder.emit_sub(?bld, acc, ld); }
+    or                                 { racu = builder.emit_add(?bld, acc, ld); }
+    if (R.is_err[value.Value, str](racu)) { ir.dnit(?m); ret 1; }
+    val acc_upd: value.Value = R.unwrap_ok[value.Value, str](racu);
+    val ru: R.Result[value.Value, str] = builder.emit_add(?bld, iv, value.const_int(1, i64t));
+    if (R.is_err[value.Value, str](ru)) { ir.dnit(?m); ret 1; }
+    if (R.is_err[bool, str](builder.phi_add_incoming(?bld, iv, body, R.unwrap_ok[value.Value, str](ru)))) { ir.dnit(?m); ret 1; }
+    if (R.is_err[bool, str](builder.phi_add_incoming(?bld, acc, entry, value.const_float(0.0, f64t)))) { ir.dnit(?m); ret 1; }
+    if (R.is_err[bool, str](builder.phi_add_incoming(?bld, acc, body, acc_upd))) { ir.dnit(?m); ret 1; }
+    if (R.is_err[bool, str](builder.emit_br(?bld, header))) { ir.dnit(?m); ret 1; }
+
+    var code: i32 = 0;
+    val ral: R.Result[loops.LoopAnalysis, str] = loops.analyze(fn, ?alloc);
+    if (R.is_err[loops.LoopAnalysis, str](ral)) { ir.dnit(?m); ret 1; }
+    var la: loops.LoopAnalysis = R.unwrap_ok[loops.LoopAnalysis, str](ral);
+    val rr: R.Result[ReductionInfo, str] = analyze_reduction(fn, ?la, 0, ?m.types, ?alloc, float_reassoc);
+    if (R.is_err[ReductionInfo, str](rr)) { loops.dnit(?la); ir.dnit(?m); ret 1; }
+    var ri: ReductionInfo = R.unwrap_ok[ReductionInfo, str](rr);
+    if (ri.ok != want_ok) { code = 1; }
+    if (ri.ok) {
+        if (ri.op != op)      { code = 1; }
+        if (!ri.is_float)     { code = 1; }
+        if (ri.bytes != 8)    { code = 1; }
+        if (ri.lanes != 2)    { code = 1; }
+        if (ri.elem_ty != f64t) { code = 1; }
+    }
+    reduction_dnit(?ri);
+    loops.dnit(?la);
+    ir.dnit(?m);
+    ret code;
+}
+
+# the `float_reassoc` gate (#2160). A float accumulator is a reduction candidate ONLY
+# with the caller's reassociation permission: without it the same loop is refused, so
+# an IEEE-strict build cannot reach the reassociating transform by any route. With it,
+# add and multiply are admitted (both associative with an exact IEEE identity) and
+# subtract is still refused (not associative at all, at any rounding).
+test "mach.lang.me.analysis.dependence:float_reduction_gated" {
+    var code: i32 = 0;
+    if (float_reduction_verdict(instruction.OP_ADD, false, false) != 0) { code = 1; }
+    if (float_reduction_verdict(instruction.OP_MUL, false, false) != 0) { code = 1; }
+    if (float_reduction_verdict(instruction.OP_ADD, true,  true)  != 0) { code = 1; }
+    if (float_reduction_verdict(instruction.OP_MUL, true,  true)  != 0) { code = 1; }
+    if (float_reduction_verdict(instruction.OP_SUB, true,  false) != 0) { code = 1; }
+    if (float_reduction_verdict(instruction.OP_SUB, false, false) != 0) { code = 1; }
+    ret code;
+}
+
 # a reduction loop carries a second header phi (the accumulator) beyond the induction
 # variable: conservatively DEPENDENT (child 4 handles reductions).
 test "mach.lang.me.analysis.dependence:reduction_dependent" {

--- a/src/lang/me/analysis/dependence.mach
+++ b/src/lang/me/analysis/dependence.mach
@@ -680,20 +680,27 @@ test "mach.lang.me.analysis.dependence:wider_than_stride_dependent" {
     ret code;
 }
 
-# the recognized integer reduction idiom of a counted loop (#2142): a loop whose ONLY
+# the recognized reduction idiom of a counted loop (#2142): a loop whose ONLY
 # cross-iteration recurrence besides the induction variable is a single accumulator
-# phi updated `acc = acc OP rv` with an ASSOCIATIVE + EXACT integer op, over loads of
-# contiguous unit-stride arrays and no stores. Partial-sum vectorization of such a
-# loop is bit-identical to the scalar reduction (integer add/xor/or/and reassociate
-# exactly). Float accumulators are rejected (reassociation changes rounding).
+# phi updated `acc = acc OP rv` with an ASSOCIATIVE op, over loads of contiguous
+# unit-stride arrays and no stores.
+#
+# For an INTEGER accumulator the op must also be EXACT (add/xor/or/and), so partial-sum
+# vectorization is bit-identical to the scalar reduction; that is unconditional. For a
+# FLOAT accumulator (add/mul) reassociation changes IEEE rounding, so it is recognized
+# only when the caller passes `float_reassoc` -- the resolved `[profile.X]
+# float_reassoc` lever (#2160). With the lever off a float reduction is not a
+# reduction at all as far as this analysis is concerned, and stays scalar.
 # ---
-# ok:           true when the loop is a vectorizable integer reduction
-# op:           the reduction opcode (OP_ADD / OP_XOR / OP_OR / OP_AND)
+# ok:           true when the loop is a vectorizable reduction
+# op:           the reduction opcode (OP_ADD / OP_XOR / OP_OR / OP_AND, or float
+#               OP_ADD / OP_MUL)
 # acc_phi:      the accumulator header phi
 # acc_update:   the `acc OP rv` instruction (the accumulator's latch value)
 # acc_init:     the accumulator's preheader-incoming value (the user's initial value)
 # rv:           the per-iteration reduction value (acc_update's non-accumulator operand)
-# elem_ty:      the accumulator's scalar element type (an integer; every load matches it)
+# elem_ty:      the accumulator's scalar element type (every load matches it)
+# is_float:     whether that element type is a float scalar
 # bytes:        its byte width
 # lanes:        the 128-bit lane count (16 / bytes), always >= 2
 # accesses:     the loop's loads, all base[iv] of `elem_ty` (owned)
@@ -708,6 +715,7 @@ pub rec ReductionInfo {
     acc_init:     value.Value;
     rv:           value.Value;
     elem_ty:      ir_type.IrTypeId;
+    is_float:     bool;
     bytes:        u32;
     lanes:        u32;
     accesses:     *MemAccess;
@@ -726,6 +734,7 @@ fun reduction_none(alloc: *A.Allocator) ReductionInfo {
     ri.rv           = value.const_null(ir_type.IRT_NIL);
     ri.acc_init     = value.const_null(ir_type.IRT_NIL);
     ri.elem_ty      = ir_type.IRT_NIL;
+    ri.is_float     = false;
     ri.bytes        = 0;
     ri.lanes        = 0;
     ri.accesses     = nil;
@@ -747,10 +756,22 @@ pub fun reduction_dnit(ri: *ReductionInfo) {
     ri.access_cap   = 0;
 }
 
-# true for the associative + exact integer reduction opcodes (add, xor, or, and);
-# subtract is excluded (not associative), and float / integer-multiply / min-max are
-# handled elsewhere or left scalar
-fun is_reduction_op(k: instruction.InstrKind) bool {
+# the reduction opcodes admitted for an accumulator of the given kind.
+#
+# INTEGER: the associative AND exact ops (add, xor, or, and). Subtract is excluded
+# (not associative) and integer multiply is excluded because no baseline vector
+# integer-multiply exists to reduce with.
+#
+# FLOAT: add and multiply -- associative in real arithmetic, and each has an EXACT
+# IEEE identity element to seed the idle lanes with (see reduction_identity), so the
+# only property the vectorized form gives up is associativity. Subtract and divide are
+# not associative and stay out; min/max are not reductions this analysis recognizes.
+fun is_reduction_op(k: instruction.InstrKind, is_float: bool) bool {
+    if (is_float) {
+        if (k == instruction.OP_ADD) { ret true; }
+        if (k == instruction.OP_MUL) { ret true; }
+        ret false;
+    }
     if (k == instruction.OP_ADD) { ret true; }
     if (k == instruction.OP_XOR) { ret true; }
     if (k == instruction.OP_OR)  { ret true; }
@@ -758,15 +779,17 @@ fun is_reduction_op(k: instruction.InstrKind) bool {
     ret false;
 }
 
-# recognize loop `loop_ix` as a vectorizable integer reduction; never mutates `fn`
+# recognize loop `loop_ix` as a vectorizable reduction; never mutates `fn`
 # ---
-# fn:      the function
-# la:      the loop analysis for `fn`
-# loop_ix: index into la.loops
-# types:   the module's IR type table
-# alloc:   allocator for the loads array
-# ret:     the reduction info (ok == false when not a reduction), or an alloc error
-pub fun analyze_reduction(fn: *ir.Function, la: *loops.LoopAnalysis, loop_ix: u32, types: *ir_type.IrTypeTable, alloc: *A.Allocator) R.Result[ReductionInfo, str] {
+# fn:            the function
+# la:            the loop analysis for `fn`
+# loop_ix:       index into la.loops
+# types:         the module's IR type table
+# alloc:         allocator for the loads array
+# float_reassoc: permission to treat float add / multiply as associative (#2160). false
+#                declines every float accumulator, leaving it IEEE-strict and scalar
+# ret:           the reduction info (ok == false when not a reduction), or an alloc error
+pub fun analyze_reduction(fn: *ir.Function, la: *loops.LoopAnalysis, loop_ix: u32, types: *ir_type.IrTypeTable, alloc: *A.Allocator, float_reassoc: bool) R.Result[ReductionInfo, str] {
     if (loop_ix >= la.loop_len) { ret R.ok[ReductionInfo, str](reduction_none(alloc)); }
     val lp: *loops.Loop = ?la.loops[loop_ix];
     if (!lp.is_counted) { ret R.ok[ReductionInfo, str](reduction_none(alloc)); }
@@ -811,12 +834,19 @@ pub fun analyze_reduction(fn: *ir.Function, la: *loops.LoopAnalysis, loop_ix: u3
     }
     if (!got_init || !got_upd || upd_val.kind != value.VAL_INSTR) { ret R.ok[ReductionInfo, str](reduction_none(alloc)); }
 
-    # the update must be `acc OP rv`, OP an associative-exact integer op, one operand
-    # the accumulator phi and the other the reduction value
+    # the accumulator's kind decides which ops are associative enough to admit. a float
+    # accumulator needs the caller's reassociation permission; without it the loop is
+    # not a reduction candidate at all and stays IEEE-strict scalar.
+    val elem_ty:  ir_type.IrTypeId = phi.ty;
+    val is_float: bool = ir_type.is_float_scalar(types, elem_ty);
+    if (is_float && !float_reassoc) { ret R.ok[ReductionInfo, str](reduction_none(alloc)); }
+
+    # the update must be `acc OP rv`, OP associative for that kind, one operand the
+    # accumulator phi and the other the reduction value
     val uopt: O.Option[*instruction.Instruction] = ir.instruction_get(fn, upd_val.data.instr);
     if (O.is_none[*instruction.Instruction](uopt)) { ret R.ok[ReductionInfo, str](reduction_none(alloc)); }
     val upd: *instruction.Instruction = O.unwrap[*instruction.Instruction](uopt);
-    if (!is_reduction_op(upd.kind) || upd.operand_count != 2) { ret R.ok[ReductionInfo, str](reduction_none(alloc)); }
+    if (!is_reduction_op(upd.kind, is_float) || upd.operand_count != 2) { ret R.ok[ReductionInfo, str](reduction_none(alloc)); }
     val a: value.Value = upd.operands[0];
     val b: value.Value = upd.operands[1];
     var rv: value.Value = b;
@@ -832,10 +862,7 @@ pub fun analyze_reduction(fn: *ir.Function, la: *loops.LoopAnalysis, loop_ix: u3
     # any out-of-loop use is fine (the reduction result).
     if (!acc_used_only_by(fn, la, loop_ix, acc_phi, upd_val.data.instr)) { ret R.ok[ReductionInfo, str](reduction_none(alloc)); }
 
-    # the accumulator element type must be an integer scalar of 1..8 bytes giving a
-    # lane count >= 2 (float accumulators reassociate -> left scalar)
-    val elem_ty: ir_type.IrTypeId = phi.ty;
-    if (ir_type.is_float_scalar(types, elem_ty)) { ret R.ok[ReductionInfo, str](reduction_none(alloc)); }
+    # the accumulator element must be a scalar of 1..8 bytes giving a lane count >= 2
     val w: u32 = scalar_bytes(types, elem_ty);
     if (w == 0 || w > 8 || (16 / w) < 2) { ret R.ok[ReductionInfo, str](reduction_none(alloc)); }
 
@@ -883,6 +910,7 @@ pub fun analyze_reduction(fn: *ir.Function, la: *loops.LoopAnalysis, loop_ix: u3
     ri.acc_init   = acc_init;
     ri.rv         = rv;
     ri.elem_ty    = elem_ty;
+    ri.is_float   = is_float;
     ri.bytes      = w;
     ri.lanes      = 16 / w;
     ret R.ok[ReductionInfo, str](ri);

--- a/src/lang/me/pipeline.mach
+++ b/src/lang/me/pipeline.mach
@@ -72,10 +72,13 @@ pub val OPT_RELEASE: OptLevel = 1;
 # simd_require: the resolved `[profile.X] simd == "require"` posture (#2017); on an
 #               incapable target it turns a would-scalarize vector op into a build
 #               error at the same gate where the scalarize pass would otherwise run
+# float_reassoc: the resolved `[profile.X] float_reassoc` lever (#2160); when true the
+#               vectorizer may reassociate a float reduction into lane partials. false
+#               (the default) keeps every float reduction scalar and IEEE-strict
 # itn:          interner, consulted only on the require-error path to name the site
 # ret:          ok(true) on a clean pipeline, or an internal-compiler-error / a
 #               require-mode build-error message
-pub fun run(m: *ir.Module, tgt: *target.Target, level: OptLevel, verify_ir: bool, vectorize_enabled: bool, simd_require: bool, itn: *intern.Interner) R.Result[bool, str] {
+pub fun run(m: *ir.Module, tgt: *target.Target, level: OptLevel, verify_ir: bool, vectorize_enabled: bool, simd_require: bool, float_reassoc: bool, itn: *intern.Interner) R.Result[bool, str] {
     # entry verification sanity-checks the lowered input. reachability and
     # dominance are not enforced here: freshly-lowered IR still carries the
     # unreachable blocks the lowerer parks after terminators, which dce removes
@@ -217,7 +220,7 @@ pub fun run(m: *ir.Module, tgt: *target.Target, level: OptLevel, verify_ir: bool
         # is intentionally not byte-identical for vectorizable loops; rv64
         # (has_v128 == false) never enters and stays scalar.
         if (tgt.model.has_v128 && vectorize_enabled) {
-            val res_vec: R.Result[bool, str] = vectorize.run(m, tgt);
+            val res_vec: R.Result[bool, str] = vectorize.run(m, tgt, float_reassoc);
             if (R.is_err[bool, str](res_vec)) { ret res_vec; }
             if (R.unwrap_ok[bool, str](res_vec)) {
                 val res_dce_vec: R.Result[bool, str] = dce.run(m);
@@ -661,7 +664,7 @@ test "mach.lang.me.pipeline.run:simd_require_gate" {
     or { if (R.is_err[bool, str](builder.emit_ret(?b, R.unwrap_ok[value.Value, str](radd)))) { code = 1; } }
 
     # require + incapable + vector -> a precise error naming op, function, and arch
-    val e1: R.Result[bool, str] = run(?m, ?rv, OPT_DEBUG, false, true, true, ?itn);
+    val e1: R.Result[bool, str] = run(?m, ?rv, OPT_DEBUG, false, true, true, false, ?itn);
     if (R.is_ok[bool, str](e1)) { code = 1; }
     or {
         val msg: str = R.unwrap_err[bool, str](e1);
@@ -685,7 +688,7 @@ test "mach.lang.me.pipeline.run:simd_require_gate" {
     if (R.is_err[id.BlockId, str](rb2)) { ir.dnit(?m2); intern.dnit(?itn); ret 1; }
     builder.set_block(?b2, R.unwrap_ok[id.BlockId, str](rb2));
     if (R.is_err[bool, str](builder.emit_ret_void(?b2))) { code = 1; }
-    if (R.is_err[bool, str](run(?m2, ?rv, OPT_DEBUG, false, true, true, ?itn))) { code = 1; }
+    if (R.is_err[bool, str](run(?m2, ?rv, OPT_DEBUG, false, true, true, false, ?itn))) { code = 1; }
     ir.dnit(?m2);
 
     intern.dnit(?itn);

--- a/src/lang/me/transform/vectorize.mach
+++ b/src/lang/me/transform/vectorize.mach
@@ -855,6 +855,11 @@ fun rv_is_vector_tree(m: *ir.Module, fn: *ir.Function, la: *loops.LoopAnalysis, 
     ret ok;
 }
 
+# the IEEE-754 double bit pattern of negative zero. Spelled as a pattern rather than
+# as the `-0.0` literal because Mach folds that literal to POSITIVE zero (#2269), which
+# would silently defeat the sign preservation reduction_identity depends on.
+val NEG_ZERO_BITS: u64 = 0x8000000000000000;
+
 # the EXACT identity element of a reduction op: what the idle lanes are seeded with,
 # absorbed without trace by the horizontal combine.
 #
@@ -869,7 +874,7 @@ fun rv_is_vector_tree(m: *ir.Module, fn: *ir.Function, la: *loops.LoopAnalysis, 
 fun reduction_identity(op: instruction.InstrKind, elem_ty: ir_type.IrTypeId, is_float: bool) value.Value {
     if (is_float) {
         if (op == instruction.OP_MUL) { ret value.const_float(1.0, elem_ty); }
-        ret value.const_float(-0.0, elem_ty);
+        ret value.const_float(NEG_ZERO_BITS:~f64, elem_ty);
     }
     if (op == instruction.OP_AND) { ret value.const_int(0xFFFFFFFFFFFFFFFF, elem_ty); }
     ret value.const_int(0, elem_ty);

--- a/src/lang/me/transform/vectorize.mach
+++ b/src/lang/me/transform/vectorize.mach
@@ -856,7 +856,7 @@ fun rv_is_vector_tree(m: *ir.Module, fn: *ir.Function, la: *loops.LoopAnalysis, 
 }
 
 # the IEEE-754 double bit pattern of negative zero. Spelled as a pattern rather than
-# as the `-0.0` literal because Mach folds that literal to POSITIVE zero (#2269), which
+# as the `-0.0` literal because Mach folds that literal to POSITIVE zero (#2274), which
 # would silently defeat the sign preservation reduction_identity depends on.
 val NEG_ZERO_BITS: u64 = 0x8000000000000000;
 

--- a/src/lang/me/transform/vectorize.mach
+++ b/src/lang/me/transform/vectorize.mach
@@ -84,10 +84,15 @@ rec SplatEntry {
 # consistent as the CFG grows, while the kept dependence info stays valid (existing
 # instructions are never moved or renumbered).
 # ---
-# m:   the module to transform in place
-# tgt: the target; consulted for the SIMD capability fact
-# ret: ok(true) if any loop was vectorized, ok(false) if none, or an error
-pub fun run(m: *ir.Module, tgt: *target.Target) R.Result[bool, str] {
+# m:             the module to transform in place
+# tgt:           the target; consulted for the SIMD capability fact
+# float_reassoc: the resolved `[profile.X] float_reassoc` lever (#2160); when true the
+#                reduction path also admits float accumulators, whose lane-partial form
+#                reassociates and so is not bit-identical to the scalar reduction. When
+#                false (the default) every float reduction stays scalar and the emitted
+#                code is exactly what a compiler without the lever emits.
+# ret:           ok(true) if any loop was vectorized, ok(false) if none, or an error
+pub fun run(m: *ir.Module, tgt: *target.Target, float_reassoc: bool) R.Result[bool, str] {
     if (!tgt.model.has_v128) { ret R.ok[bool, str](false); }
 
     var changed: bool = false;
@@ -152,7 +157,7 @@ pub fun run(m: *ir.Module, tgt: *target.Target) R.Result[bool, str] {
         # the reduction phase, over the (possibly element-wise-transformed) function;
         # reduction loops are disjoint from element-wise loops (a reduction has no
         # store), so an element-wise transform never turns one into a reduction
-        val rr: R.Result[bool, str] = run_reductions(m, fn);
+        val rr: R.Result[bool, str] = run_reductions(m, fn, float_reassoc);
         if (R.is_err[bool, str](rr)) { ret rr; }
         if (R.unwrap_ok[bool, str](rr)) { changed = true; }
         fi = fi + 1;
@@ -751,13 +756,17 @@ fun set_phi_incoming(fn: *ir.Function, blk: id.BlockId, from: id.BlockId, new_bl
     }
 }
 
-# vectorize the integer reductions in one function, in two phases like run(): collect
-# the reduction candidates (read-only, keeping each ReductionInfo), then transform
-# each, re-analyzing to relocate it. A pure reduction has no store so no alias guard
-# is needed; the transform builds a vector accumulator (lane 0 = the user's initial
+# vectorize the reductions in one function, in two phases like run(): collect the
+# reduction candidates (read-only, keeping each ReductionInfo), then transform each,
+# re-analyzing to relocate it. A pure reduction has no store so no alias guard is
+# needed; the transform builds a vector accumulator (lane 0 = the user's initial
 # value, the other lanes the op identity), a vector main loop, a horizontal combine,
 # and a scalar remainder that continues from the combined value.
-fun run_reductions(m: *ir.Module, fn: *ir.Function) R.Result[bool, str] {
+#
+# `float_reassoc` widens the candidate set to float accumulators. The transform below
+# is the SAME one either way -- there is one reduction path, and the lever only
+# decides which accumulator element types reach it.
+fun run_reductions(m: *ir.Module, fn: *ir.Function, float_reassoc: bool) R.Result[bool, str] {
     var changed: bool = false;
     val ral: R.Result[loops.LoopAnalysis, str] = loops.analyze(fn, m.alloc);
     if (R.is_err[loops.LoopAnalysis, str](ral)) { ret R.err[bool, str](R.unwrap_err[loops.LoopAnalysis, str](ral)); }
@@ -775,7 +784,7 @@ fun run_reductions(m: *ir.Module, fn: *ir.Function) R.Result[bool, str] {
     var lx: u32 = 0;
     for (lx < la.loop_len) {
         var ri: dep.ReductionInfo;
-        val rc: R.Result[bool, str] = reduction_candidate(m, fn, ?la, lx, ?ri);
+        val rc: R.Result[bool, str] = reduction_candidate(m, fn, ?la, lx, float_reassoc, ?ri);
         if (R.is_err[bool, str](rc)) { free_reds(m, headers, reds, hn, cap); loops.dnit(?la); ret rc; }
         if (R.unwrap_ok[bool, str](rc)) { headers[hn] = la.loops[lx].header; reds[hn] = ri; hn = hn + 1; }
         lx = lx + 1;
@@ -807,12 +816,12 @@ fun free_reds(m: *ir.Module, headers: *id.BlockId, reds: *dep.ReductionInfo, hn:
     A.deallocate[dep.ReductionInfo](m.alloc, reds, cap::usize);
 }
 
-# whether loop `lx` is a vectorizable integer reduction; on true the ReductionInfo is
+# whether loop `lx` is a vectorizable reduction; on true the ReductionInfo is
 # transferred to `out_ri` (caller owns / dnits it)
-fun reduction_candidate(m: *ir.Module, fn: *ir.Function, la: *loops.LoopAnalysis, lx: u32, out_ri: *dep.ReductionInfo) R.Result[bool, str] {
+fun reduction_candidate(m: *ir.Module, fn: *ir.Function, la: *loops.LoopAnalysis, lx: u32, float_reassoc: bool, out_ri: *dep.ReductionInfo) R.Result[bool, str] {
     val lp: *loops.Loop = ?la.loops[lx];
     if (!reduction_shape_ok(lp)) { ret R.ok[bool, str](false); }
-    val rr: R.Result[dep.ReductionInfo, str] = dep.analyze_reduction(fn, la, lx, ?m.types, m.alloc);
+    val rr: R.Result[dep.ReductionInfo, str] = dep.analyze_reduction(fn, la, lx, ?m.types, m.alloc, float_reassoc);
     if (R.is_err[dep.ReductionInfo, str](rr)) { ret R.err[bool, str](R.unwrap_err[dep.ReductionInfo, str](rr)); }
     var ri: dep.ReductionInfo = R.unwrap_ok[dep.ReductionInfo, str](rr);
     if (!ri.ok) { dep.reduction_dnit(?ri); ret R.ok[bool, str](false); }
@@ -840,31 +849,50 @@ fun rv_is_vector_tree(m: *ir.Module, fn: *ir.Function, la: *loops.LoopAnalysis, 
     val rset: R.Result[*bool, str] = A.allocate[bool](m.alloc, fn.instr_len::usize);
     if (R.is_err[*bool, str](rset)) { ret false; }
     val vset: *bool = R.unwrap_ok[*bool, str](rset);
-    build_vset(fn, la, lx, ri.accesses, ri.access_count, ri.elem_ty, false, false, vset);
+    build_vset(fn, la, lx, ri.accesses, ri.access_count, ri.elem_ty, ri.is_float, false, vset);
     var ok: bool = ri.rv.kind == value.VAL_INSTR && ri.rv.data.instr::u32 < fn.instr_len && vset[ri.rv.data.instr::u32];
     A.deallocate[bool](m.alloc, vset, fn.instr_len::usize);
     ret ok;
 }
 
-# the OP identity constant for a reduction op (add/xor/or -> 0; and -> all-ones)
-fun reduction_identity(op: instruction.InstrKind, elem_ty: ir_type.IrTypeId) value.Value {
+# the EXACT identity element of a reduction op: what the idle lanes are seeded with,
+# absorbed without trace by the horizontal combine.
+#
+# integer: add/xor/or -> 0, and -> all-ones.
+#
+# float add -> NEGATIVE zero, not +0.0. Under round-to-nearest `x + (-0.0)` is `x` for
+# every x, both zeros included, whereas `(-0.0) + (+0.0)` is `+0.0` -- seeding with
+# +0.0 would flip the sign of an all-negative-zero sum and so quietly buy a
+# no-signed-zeros liberty on top of the reassociation the lever licenses.
+#
+# float mul -> 1.0, an exact identity for every operand.
+fun reduction_identity(op: instruction.InstrKind, elem_ty: ir_type.IrTypeId, is_float: bool) value.Value {
+    if (is_float) {
+        if (op == instruction.OP_MUL) { ret value.const_float(1.0, elem_ty); }
+        ret value.const_float(-0.0, elem_ty);
+    }
     if (op == instruction.OP_AND) { ret value.const_int(0xFFFFFFFFFFFFFFFF, elem_ty); }
     ret value.const_int(0, elem_ty);
 }
 
-# emit the scalar reduction op `op` (add/xor/or/and) over two scalars into `b`
+# emit the scalar reduction op `op` over two scalars into `b`
 fun emit_reduction_op(b: *builder.Builder, op: instruction.InstrKind, x: value.Value, y: value.Value) R.Result[value.Value, str] {
     if (op == instruction.OP_XOR) { ret builder.emit_xor(b, x, y); }
     if (op == instruction.OP_OR)  { ret builder.emit_or(b, x, y); }
     if (op == instruction.OP_AND) { ret builder.emit_and(b, x, y); }
+    if (op == instruction.OP_MUL) { ret builder.emit_mul(b, x, y); }
     ret builder.emit_add(b, x, y);
 }
 
-# vectorize one recognized integer reduction. `ri` is its ReductionInfo from the
-# collect phase (still valid: transforms only append). Builds the vector accumulator
-# main loop + horizontal combine + scalar remainder, and rewrites the accumulator's
-# live-out uses to the remainder's result. Returns ok(true) on success, ok(false) if
-# re-analysis declines (no mutation), or an alloc / build error.
+# vectorize one recognized reduction, integer or float. `ri` is its ReductionInfo from
+# the collect phase (still valid: transforms only append). Builds the vector
+# accumulator main loop + horizontal combine + scalar remainder, and rewrites the
+# accumulator's live-out uses to the remainder's result. Returns ok(true) on success,
+# ok(false) if re-analysis declines (no mutation), or an alloc / build error.
+#
+# The element kind changes nothing structurally: the same partial-sum + horizontal-
+# combine shape serves both, and the only float-specific choices are the identity
+# constant (reduction_identity) and the ops the reduction value's tree may use.
 fun vectorize_reduction(m: *ir.Module, fn: *ir.Function, la: *loops.LoopAnalysis, lx: u32, ri: *dep.ReductionInfo) R.Result[bool, str] {
     val lp: *loops.Loop = ?la.loops[lx];
     if (!reduction_shape_ok(lp)) { ret R.ok[bool, str](false); }
@@ -879,6 +907,7 @@ fun vectorize_reduction(m: *ir.Module, fn: *ir.Function, la: *loops.LoopAnalysis
     val cmp_id:    id.InstructionId = lp.counted.cmp;
     val lanes:     u32 = ri.lanes;
     val elem_ty:   ir_type.IrTypeId = ri.elem_ty;
+    val is_float:  bool = ri.is_float;
     val red_op:    instruction.InstrKind = ri.op;
     val acc_phi:   id.InstructionId = ri.acc_phi;
     val acc_upd:   id.InstructionId = ri.acc_update;
@@ -890,6 +919,12 @@ fun vectorize_reduction(m: *ir.Module, fn: *ir.Function, la: *loops.LoopAnalysis
     val rat: R.Result[ir_type.IrTypeId, str] = ir_type.intern_array(?m.types, elem_ty, lanes);
     if (R.is_err[ir_type.IrTypeId, str](rat)) { ret R.err[bool, str](R.unwrap_err[ir_type.IrTypeId, str](rat)); }
     val arr_ty: ir_type.IrTypeId = R.unwrap_ok[ir_type.IrTypeId, str](rat);
+    # the type the lane ordinals and the alloca count carry: an ordinal is an integer,
+    # never a value of the element type (which for a float element would stamp an
+    # integer constant with a float type)
+    val rot: R.Result[ir_type.IrTypeId, str] = ir_type.intern_int(?m.types, 64);
+    if (R.is_err[ir_type.IrTypeId, str](rot)) { ret R.err[bool, str](R.unwrap_err[ir_type.IrTypeId, str](rot)); }
+    val ord_ty: ir_type.IrTypeId = R.unwrap_ok[ir_type.IrTypeId, str](rot);
 
     # phi index of the accumulator and the induction variable in the header (clone
     # preserves phi order, so the same index identifies them in the remainder header)
@@ -925,7 +960,7 @@ fun vectorize_reduction(m: *ir.Module, fn: *ir.Function, la: *loops.LoopAnalysis
     if (R.is_err[id.BlockId, str](rvp)) { ret R.err[bool, str](R.unwrap_err[id.BlockId, str](rvp)); }
     val vpre: id.BlockId = R.unwrap_ok[id.BlockId, str](rvp);
     builder.set_block(?b, vpre);
-    val rv0: R.Result[value.Value, str] = build_accumulator_init(?b, red_op, acc_init, elem_ty, arr_ty, vec_ty, lanes);
+    val rv0: R.Result[value.Value, str] = build_accumulator_init(?b, red_op, acc_init, elem_ty, is_float, arr_ty, vec_ty, ord_ty, lanes);
     if (R.is_err[value.Value, str](rv0)) { ret R.err[bool, str](R.unwrap_err[value.Value, str](rv0)); }
     val vacc0: value.Value = R.unwrap_ok[value.Value, str](rv0);
     val rbe: R.Result[value.Value, str] = ver.emit_exclusive_bound(?b, ?lp.counted);
@@ -952,7 +987,7 @@ fun vectorize_reduction(m: *ir.Module, fn: *ir.Function, la: *loops.LoopAnalysis
     if (R.is_err[id.BlockId, str](rcb)) { ret R.err[bool, str](R.unwrap_err[id.BlockId, str](rcb)); }
     val combine: id.BlockId = R.unwrap_ok[id.BlockId, str](rcb);
     builder.set_block(?b, combine);
-    val rhc: R.Result[value.Value, str] = emit_horizontal_combine(?b, red_op, value.instr(acc_phi, vec_ty), elem_ty, arr_ty, vec_ty, lanes);
+    val rhc: R.Result[value.Value, str] = emit_horizontal_combine(?b, red_op, value.instr(acc_phi, vec_ty), elem_ty, arr_ty, vec_ty, ord_ty, lanes);
     if (R.is_err[value.Value, str](rhc)) { ret R.err[bool, str](R.unwrap_err[value.Value, str](rhc)); }
     val s0: value.Value = R.unwrap_ok[value.Value, str](rhc);
     if (R.is_err[bool, str](builder.emit_br(?b, rem_header))) { ret R.err[bool, str]("reduce: combine branch"); }
@@ -971,7 +1006,7 @@ fun vectorize_reduction(m: *ir.Module, fn: *ir.Function, la: *loops.LoopAnalysis
     val rset: R.Result[*bool, str] = A.allocate[bool](m.alloc, fn.instr_len::usize);
     if (R.is_err[*bool, str](rset)) { ret R.err[bool, str](R.unwrap_err[*bool, str](rset)); }
     val vset: *bool = R.unwrap_ok[*bool, str](rset);
-    build_vset(fn, la, lx, ri.accesses, ri.access_count, elem_ty, false, false, vset);
+    build_vset(fn, la, lx, ri.accesses, ri.access_count, elem_ty, is_float, false, vset);
     vset[acc_phi::u32] = true;
     vset[acc_upd::u32] = true;
     retype_to_vector(fn, lp, vset, vec_ty);
@@ -1016,14 +1051,24 @@ fun step_iv_by_lanes(fn: *ir.Function, iv_upd: id.InstructionId, lanes: u32, iv_
 # lane 0 holds the user's initial accumulator value and whose other lanes hold the op
 # identity, loaded back as a vector. Combined horizontally at loop exit this folds the
 # user init in exactly once (identity elements are absorbed by the op).
-fun build_accumulator_init(b: *builder.Builder, op: instruction.InstrKind, acc_init: value.Value, elem_ty: ir_type.IrTypeId, arr_ty: ir_type.IrTypeId, vec_ty: ir_type.IrTypeId, lanes: u32) R.Result[value.Value, str] {
-    val ras: R.Result[value.Value, str] = builder.emit_alloca(b, arr_ty, value.const_int(1, elem_ty));
+# ---
+# b:        builder positioned in the vector preheader
+# op:       the reduction opcode
+# acc_init: the user's initial accumulator value, seeded into lane 0
+# elem_ty:  the accumulator's scalar element type
+# is_float: whether that element is a float scalar (selects the identity)
+# arr_ty:   the interned `[lanes]elem` array type of the slot
+# vec_ty:   the interned 128-bit vector type read back
+# ord_ty:   the integer type the lane ordinals and the alloca count carry
+# lanes:    the lane count
+fun build_accumulator_init(b: *builder.Builder, op: instruction.InstrKind, acc_init: value.Value, elem_ty: ir_type.IrTypeId, is_float: bool, arr_ty: ir_type.IrTypeId, vec_ty: ir_type.IrTypeId, ord_ty: ir_type.IrTypeId, lanes: u32) R.Result[value.Value, str] {
+    val ras: R.Result[value.Value, str] = builder.emit_alloca(b, arr_ty, value.const_int(1, ord_ty));
     if (R.is_err[value.Value, str](ras)) { ret ras; }
     val slot: value.Value = R.unwrap_ok[value.Value, str](ras);
-    val ident: value.Value = reduction_identity(op, elem_ty);
+    val ident: value.Value = reduction_identity(op, elem_ty, is_float);
     var lane: u32 = 0;
     for (lane < lanes) {
-        val rg: R.Result[value.Value, str] = lane_gep(b, slot, arr_ty, lane, elem_ty);
+        val rg: R.Result[value.Value, str] = lane_gep(b, slot, arr_ty, lane, ord_ty);
         if (R.is_err[value.Value, str](rg)) { ret rg; }
         var v: value.Value = ident;
         if (lane == 0) { v = acc_init; }
@@ -1034,20 +1079,22 @@ fun build_accumulator_init(b: *builder.Builder, op: instruction.InstrKind, acc_i
 }
 
 # horizontal-reduce a vector value to a scalar with `op`: store it to a 16-byte slot,
-# then combine the lanes left to right (op is associative so any order is equal)
-fun emit_horizontal_combine(b: *builder.Builder, op: instruction.InstrKind, vacc: value.Value, elem_ty: ir_type.IrTypeId, arr_ty: ir_type.IrTypeId, vec_ty: ir_type.IrTypeId, lanes: u32) R.Result[value.Value, str] {
-    val ras: R.Result[value.Value, str] = builder.emit_alloca(b, arr_ty, value.const_int(1, elem_ty));
+# then combine the lanes left to right. For an integer op any order is equal; for a
+# float op left-to-right is one arbitrary grouping among many, which is precisely the
+# reassociation the `float_reassoc` lever licenses.
+fun emit_horizontal_combine(b: *builder.Builder, op: instruction.InstrKind, vacc: value.Value, elem_ty: ir_type.IrTypeId, arr_ty: ir_type.IrTypeId, vec_ty: ir_type.IrTypeId, ord_ty: ir_type.IrTypeId, lanes: u32) R.Result[value.Value, str] {
+    val ras: R.Result[value.Value, str] = builder.emit_alloca(b, arr_ty, value.const_int(1, ord_ty));
     if (R.is_err[value.Value, str](ras)) { ret ras; }
     val slot: value.Value = R.unwrap_ok[value.Value, str](ras);
     if (R.is_err[bool, str](builder.emit_store(b, vacc, slot))) { ret R.err[value.Value, str]("reduce: combine store"); }
-    val rg0: R.Result[value.Value, str] = lane_gep(b, slot, arr_ty, 0, elem_ty);
+    val rg0: R.Result[value.Value, str] = lane_gep(b, slot, arr_ty, 0, ord_ty);
     if (R.is_err[value.Value, str](rg0)) { ret rg0; }
     val rl0: R.Result[value.Value, str] = builder.emit_load(b, R.unwrap_ok[value.Value, str](rg0), elem_ty);
     if (R.is_err[value.Value, str](rl0)) { ret rl0; }
     var acc: value.Value = R.unwrap_ok[value.Value, str](rl0);
     var lane: u32 = 1;
     for (lane < lanes) {
-        val rg: R.Result[value.Value, str] = lane_gep(b, slot, arr_ty, lane, elem_ty);
+        val rg: R.Result[value.Value, str] = lane_gep(b, slot, arr_ty, lane, ord_ty);
         if (R.is_err[value.Value, str](rg)) { ret rg; }
         val rl: R.Result[value.Value, str] = builder.emit_load(b, R.unwrap_ok[value.Value, str](rg), elem_ty);
         if (R.is_err[value.Value, str](rl)) { ret rl; }
@@ -1068,8 +1115,7 @@ fun emit_horizontal_combine(b: *builder.Builder, op: instruction.InstrKind, vacc
 # lane:   the lane ordinal
 # idx_ty: the INTEGER type the two index constants carry -- an ordinal, not a value of
 #         the element type, which for a float element would stamp an integer constant
-#         with a float type. The reduction callers pass their element type, an integer
-#         by construction; the splat, whose element may be a float, passes i64.
+#         with a float type. Every caller passes i64.
 fun lane_gep(b: *builder.Builder, slot: value.Value, arr_ty: ir_type.IrTypeId, lane: u32, idx_ty: ir_type.IrTypeId) R.Result[value.Value, str] {
     var idx: [2]value.Value;
     idx[0] = value.const_int(0, idx_ty);


### PR DESCRIPTION
Closes #2160. Follow-up to #2142, part of #1942.

Float reductions can now vectorize, behind an opt-in profile key. IEEE-strict stays the
default: with the key absent, emitted code is byte-identical to `dev` on every target.

## The key name — `float_reassoc`

**Proposed: `float_reassoc`, a boolean, optional, defaulting to `false`.**

The name states the one thing the key licenses: the compiler may **reassociate float
arithmetic**. Not "fast math" — that is the trap you named, a word that reads as
permission for six unrelated liberties. Not `ffastmath`, which is a GCC command line
quoted into a config file. `float_reassoc` names the transform a reader can go check.

Runners-up, and why they lost:

| candidate | why not |
|---|---|
| `fastmath` / `ffast_math` | the exact thing to avoid: names a *bundle*, and a GCC flag |
| `reassociate` | true but silent about *what*; integers are already reassociated freely and exactly, so the key would read as broader than it is |
| `relaxed_float` | "relaxed" how? it names a mood, not a permission |
| `float_assoc` | "assume float is associative" is the honest gloss, and it is shorter — but it reads as a *claim about floats* rather than a *permission to the compiler*, which `reassoc` gets right |
| `float_reassociate` | same meaning, four characters longer; `reassoc` is unambiguous in context |

Snake case matches the existing `emit_ir` / `emit_asm` spelling; optional-with-a-default
matches `vectorize`.

If you would rather have `float_assoc`, `reassociate`, or something else, say the word —
it is a two-line change plus the goldens, and nothing else in the branch depends on the
spelling.

## Per-function opt-in: recommend **not** adding one

`#[scalar]` is the per-function opt-*out* and it already beats the profile key (there is
a golden verdict for exactly that). A per-function opt-*in* is a different animal and I
think it is the wrong shape, for three reasons:

1. **The tolerance belongs to the caller, not the callee.** Whether a sum may be
   reassociated depends on what the *result* is used for. The manifest already states
   this principle for the neighbouring levers — "the `simd` and `vectorize` levers are
   always the consumer's" — and a decorator at the definition site inverts it: a library
   author would be deciding the numerics of code they did not write the requirements
   for.
2. **Inlining has no principled answer.** The inliner runs before the vectorizer, so a
   `#[float_reassoc]` callee inlined into a strict caller would either silently relax the
   caller or silently lose its own permission. `#[scalar]` dodges this because it
   *subtracts* — `me/pass/inline.mach` keeps a `#[scalar]` callee out of line precisely
   so its loops are never vectorized by a caller. An opt-in that *adds* a liberty across
   an inline boundary has no equally clean answer, and inventing one on spec is how a
   feature acquires a rule nobody can state.
3. **No demand yet.** Nothing in the epic asks for it, and the profile key covers every
   case in front of us.

If it turns out to be wanted, the shape is already settled by the `#[scalar]` precedent
(keep the callee out of line), so nothing here forecloses it.

## What the key does — and does not — do

Only associativity is relaxed. No reciprocal substitution, no finite/no-NaN assumption,
no FMA contraction, no subnormal flushing. Two exactness properties are actively
*preserved* rather than traded:

- **Signed zeros.** The idle lanes are seeded with the op's exact IEEE identity: `-0.0`
  for addition (`x + (-0.0)` is `x` for every `x`, where `+0.0` would turn a
  negative-zero sum positive) and `1.0` for multiply. Seeding with `+0.0` would have
  bought a no-signed-zeros liberty for free, which is what "fast math" keys usually do
  by accident. There is a golden for it, and a mutation that proves the golden bites.
- **Short reductions.** A trip count below the lane count never enters the vector loop,
  and the identity is absorbed exactly by the combine, so such reductions stay
  bit-identical with the key on.

Admitted: sum, product, and the dot / matmul inner loop, at both widths. Refused with
the key set exactly as without it: subtraction and division reductions (not associative
at all), `#[scalar]` functions, `#[oblivious]` functions, and every integer reduction
stays on its existing unconditional bit-identical path. There is one reduction path —
the key only widens which accumulator element types reach it.

## Measured speedup

`float_reassoc` build, each kernel against a `#[scalar]` twin compiled from identical
source, n = 2^20, best-of-7 round-robin, x86_64-linux (SSE2). Reference points for
scale: element-wise f64 2.07x, f32 4.90x, i64 sum 1.53x.

| kernel | vector | `#[scalar]` twin | speedup | control (key off) |
|---|---|---|---|---|
| `f64` sum | 32.0 ms | 95.3 ms | **2.97x** | 0.99x |
| `f32` sum | 15.8 ms | 94.7 ms | **5.99x** | 1.00x |
| `f64` dot (matmul inner loop) | 46.7 ms | 100.6 ms | **2.15x** | 0.96x |
| `f32` dot | 16.0 ms | 118.8 ms | **7.44x** | 1.00x |

The **control column is the load-bearing one**: identical source built under a profile
*without* the key measures 0.96–1.00x on every row, so the speedups are the vectorizer's
and not an artifact of `#[scalar]` also suppressing inlining. Across five runs the float
rows varied by under 2% (f64 sum 2.97–3.17x, f32 dot 7.44–8.03x); the machine was under
load 17 on 16 cores.

The f32 rows exceed the 4x lane count because the lane count divides the *loop overhead*
too, and per #2199 a Mach scalar loop body is mostly overhead — exactly the compounding
that epic predicts.

`isum_i64` is a control and I am **not** claiming its number: the integer reduction
vectorizes identically under both profiles (verified by disassembly — the two objects
differ only in absolute branch targets, with every relative offset equal), yet its ratio
reads 0.60x under `strict` and 1.26x under `reassoc` because the `#[scalar]` twin lands
at a different alignment in the two binaries. Pure placement noise, on a control row.

## Measured accuracy cost

Summing 1,000,000 `f64` values of `0.1`, scored against a compensated (Kahan) reference:

| ordering | result | relative error vs reference |
|---|---|---|
| strict, sequential | `100000.00000133288` | 1.33e-11 |
| reassociated, 2 lanes | `99999.9999991058` | 8.94e-12 |

**The two answers differ from each other by 2.2e-11 relative — about 153,000 `f64` ULPs
at that magnitude.** The same experiment in `f32` (4 lanes) differs by **1.2e-2
relative**: strict `100958.34`, reassociated `99759.85`, true value `100000.0`. The f64
dot product differs by 2.1e-11 (171,533 ULPs).

Note the direction: in every case here the **reassociated** answer is the more accurate
one, because per-lane partials keep each running total smaller and grind off fewer low
bits — the same reason pairwise summation beats sequential summation. That is a property
of this input, not a guarantee. The honest statement, and the one in the docs, is that
the result *changes* by roughly the accumulated rounding error of the sum, in a
data-dependent direction. Anything depending on the exact bits of a float reduction — a
checksum, a reproducibility requirement, a comparison against a reference
implementation — must leave the key off.

## Byte-identity with the key absent

The branch-base tree (`c382092c`) compiled by the base compiler and by this branch's
compiler, `cmp`-identical:

| target | debug | release |
|---|---|---|
| linux-x86_64 | identical | identical |
| linux-arm64 | identical | identical |
| linux-riscv64 | identical | identical |
| windows-x86_64 | identical | identical |
| darwin-x86_64 | identical | identical |
| darwin-aarch64 | identical | identical |

And on the int cases that actually exercise the reduction path (`reduce`, `vectorize`,
`vectorize-emit`), identical on linux / linux-arm64 / linux-riscv64 / windows.

This covers the one change that could have moved integer codegen: the reduction
builders' lane ordinals and alloca counts now carry `i64` instead of the element type,
which was an integer only while the path was integer-only. Constant gep indices and
alloca counts are read for their value alone (`lower_gep`, `lower_alloca` never consult
the stamp), so it is codegen-neutral — and now proven so rather than argued.

## Harness update

`int/surface/vectorize-emit` (#2207's case) gains the five float-reduction shapes with
`scalar` verdicts — the key is absent from its profile, so the pass must refuse them.
Only additions to the three goldens; every pre-existing verdict is untouched.

Two new sibling cases, matching the existing `vectorize` / `vectorize-emit` pairing:

- **`int/surface/vectorize-reassoc-emit`** — the same source under a profile that sets
  the key, where those five verdicts read `simd`. Reading the two goldens side by side
  *is* the assertion: the key, and only the key, moves them. It also records the shapes
  the key must not admit (`fsub_f64 scalar`, `fdiv_f64 scalar`, `fsum_optout scalar`,
  `fsum_oblivious scalar`) and the integer control (`sum_i64 simd`). riscv64's golden is
  all-`scalar`, as its own target property. Built with `--verify-ir` (see M5 below).
- **`int/surface/vectorize-reassoc`** — the runtime half. A reassociated reduction is not
  bit-identical by design, so the float pairs are scored against a relative tolerance
  while the declined shapes, the integer reductions and a negative-zero sum are asserted
  exact. Trip counts span both lane counts, non-multiples, and counts below the lane
  count where the vector loop is skipped entirely. Golden shared across targets, riscv64
  included; runs on all six legs.

`int/surface/reduce` grows f32 sum, dot and product reductions — all must stay
bit-identical with the key absent — and its stale "future work" comment is now accurate.

## Mutations, with counts

Each mutation applied to the source, compiler rebuilt, suites and int cases re-run, then
restored. Baseline is **858 / 0** unit and **82 pass / 0 fail** int on linux.

| # | mutation | caught by |
|---|---|---|
| M1 | the gate is ignored (float reductions vectorize with the key absent) | unit **857/1** — `dependence:float_reduction_gated`; int `vectorize-emit` (diff), `reduce` (diff) |
| M2 | idle lanes seeded `+0.0` instead of the exact `-0.0` identity | int `vectorize-reassoc [linux/release]` (diff) |
| M3 | float multiply reduction seeded `0.0` instead of `1.0` | int `vectorize-reassoc [linux/release]` (diff) |
| M4 | a non-associative float op (SUB) admitted to the reduction path | unit **857/1** — `dependence:float_reduction_gated`; int `vectorize-reassoc-emit` (diff) |
| M5 | reduction-value tree built with the wrong floatness | int `vectorize-reassoc-emit` (**build** — IR verifier) |
| M6 | lane ordinals carry the element type again | int `vectorize-reassoc` + `vectorize-reassoc-emit` (both **build**) |
| M7 | the *integer* AND identity weakened to 0 | int `reduce [linux/release]` (diff) |
| M8 | the key defaults ON when absent | unit **857/1** — `manifest.parse:float_reassoc_optional_and_off`; int `vectorize-emit` (diff), `reduce` (diff) |

M5 is worth calling out. On first pass it was **not caught**: building the vector set
with the wrong floatness leaves an opcode holding vector operands under a scalar result
stamp, and the back end selects that correctly from the operand types — identical
disassembly, identical answers, every golden green. The IR verifier is the only observer,
so `build-flags: --verify-ir` was added to the reassoc emit case, and M5 then fails the
build. (Aggregate-stamp family again; the transform is correct, but nothing was pinning
it.)

M7 is the integer-reduction canary: the bit-identity guarantee is still guarded by a test
that fails when it is broken, and sharing the code path with the float case did not
weaken it.

## Suites

Baseline measured on the branch base `c382092c`, not assumed.

| suite | before | after |
|---|---|---|
| mach unit | 856 / 0 | **858 / 0** (+2: the manifest key, the analysis gate) |
| mach-std @ `eff1e8e` | 611 / 0 | **611 / 0** |
| int, linux | 79 pass / 0 fail | **82 pass / 0 fail** (+3 case×profile runs) |
| int, linux-riscv64 | all pass | **all pass** |

`git rev-parse HEAD` in `dep/mach-std` verified as
`eff1e8e40686d9993047ef027bd8d7e6a7e2f5be`, matching `mach.lock`. Suites run through the
from-source compiler, not the PATH seed.

The `linux-arm64` leg is `native` in `targets.conf` and cannot execute on this host, so
the three affected cases were additionally run under `qemu-aarch64` and match their
goldens (`vectorize-reassoc` 104 checks, `vectorize` and `reduce` unchanged). The new
exec case cross-builds cleanly for all six legs including windows and both darwin tuples.

## Three-generation fixpoint

| profile | A vs B | B vs C | gen-C self-test |
|---|---|---|---|
| debug | differ (seed lag) | **identical** | 858 / 0 |
| release | differ (seed lag) | **identical** | 858 / 0 |

The A≠B seed lag is `dev`'s, not this branch's: the same three-generation run over the
pristine branch base reproduces it exactly.

## One defect found and filed, not fixed

Mach's `-0.0` literal evaluates to **+0.0** — the sign of zero is dropped, by the literal
and by a runtime negation of `+0.0` alike. Filed as **#2274** (front end; `fe/sema` is
#2225's ground, so out of scope here). It matters to this PR because `-0.0` is the exact
additive identity, so the vectorizer spells it as a bit pattern instead, with a comment
pointing at the issue. A trap for whoever fixes it: `-0.0 == 0.0` is *true* in IEEE, so a
test written with `==` passes while the bug is present — assert the bit pattern.

## Scope

Touched: `me/transform/vectorize.mach`, `me/analysis/dependence.mach`, the manifest key
and its plumbing (`manifest.mach`, `build/request.mach`, `build/testing.mach`,
`driver/passes.mach`, `me/pipeline.mach`), `doc/manifest.md`, and `int/surface/reduce` +
`int/surface/vectorize*`. Nothing in `me/pass/`, the ISA targets, `be/codegen/frame.mach`,
`fe/sema/`, `be/codegen/regalloc.mach`, `me/transform/licm.mach`,
`me/transform/sroa.mach`, or `CHANGELOG.md`.

The key participates in `request_hash`, so a warm/incremental cache cannot serve
artifacts across a flip of it.

One thing noticed but deliberately left alone: `ProjectConfig.simd` and
`ProjectConfig.vectorize` (`driver/project.mach`, `driver/config.mach`) are written and
never read. I did not mirror `float_reassoc` into them rather than add a third dead field
— flagging it rather than fixing it, since it is pre-existing and outside this issue.
