### PR TITLE
refactor(isa): one constructor for every machine instruction and operand (#2215)

### DIFF
--- a/src/lang/target/isa.mach
+++ b/src/lang/target/isa.mach
@@ -903,6 +903,17 @@ pub fun regid_index(regid: i32) i32 {
     ret regid & 0xFF;
 }
 
+# build an absent operand
+#
+# The slot a form does not use. Every field is neutral, so a consumer reading past
+# `kind` sees a defined value rather than whatever the frame held - and a field
+# added to `Operand` later is neutral here too, without visiting a single caller.
+# ---
+# ret: an Operand with kind OPK_NONE and every payload field cleared
+pub fun make_none() Operand {
+    ret operand_blank(OPK_NONE, 0);
+}
+
 # build a register operand
 # ---
 # id:   composite register id (`regid_make`): the class tag in the high byte and
@@ -1145,6 +1156,13 @@ pub fun emits_whole_module(vt: *IsaVTable) bool {
 # The shared base for the make_* operand builders: it sets `kind` and `size` and
 # zeros every payload field (register -1, no immediate, no memory base/index, no
 # symbol, no label) so each builder only writes the fields its kind uses.
+#
+# THIS IS THE ONLY PLACE AN `Operand` IS CLEARED. It stays private because every
+# populated kind has its own public `make_*`, and the empty one has `make_none`;
+# a caller that could pick a kind and a size here could build a half-formed
+# operand that no builder would ever produce. What a target needs is reachable,
+# so nothing has cause to hand-roll a clear - and a field added to `Operand` is
+# cleared everywhere by editing this function alone.
 # ---
 # kind: operand discriminant
 # size: operand width in bytes
@@ -1187,14 +1205,21 @@ pub fun make_sym_mod(sym_id: u32, size: u8, mod: SymModifier) Operand {
 #
 # Every operand absent, no flags, no clobbers - the base a target fills the fields
 # its form uses, so an unset field never reads as a live operand.
+#
+# EVERY `Inst` IN THE BACK END STARTS HERE, and that is what makes adding a field
+# additive: `var` does not zero, so a construction site that cleared its fields by
+# hand would leave any later field holding whatever the frame held. That is not
+# hypothetical - `Operand.sym_mod` was added and three hand-written clears did not
+# learn about it. One constructor means a new field is neutral at every site by
+# construction, and a target that wants a value sets it deliberately.
 # ---
 # ret: an Inst with opcode 0 and three absent operands
 pub fun inst_blank() Inst {
     var mi: Inst;
     mi.opcode   = 0;
-    mi.dst      = operand_blank(OPK_NONE, 0);
-    mi.src1     = operand_blank(OPK_NONE, 0);
-    mi.src2     = operand_blank(OPK_NONE, 0);
+    mi.dst      = make_none();
+    mi.src1     = make_none();
+    mi.src2     = make_none();
     mi.size     = 0;
     mi.flags    = 0;
     mi.clobbers = 0;
@@ -1379,7 +1404,7 @@ test "mach.lang.target.isa.buf_append:growth" {
     if (buf.cap != 0)   { buf_dnit(?buf); ret 1; }
 
     # appending past the seed capacity grows the buffer without error
-    var inst: Inst;
+    var inst: Inst = inst_blank();
     var i: i32 = 0;
     for (i < INSTBUF_INIT_CAP + 1) {
         inst.opcode = i::u16;

--- a/src/lang/target/isa/arm64/printer.mach
+++ b/src/lang/target/isa/arm64/printer.mach
@@ -191,10 +191,10 @@ pub fun inst(form: u8, base: u32) Inst {
     var i: Inst;
     i.base     = base;
     i.form     = form;
-    i.dst      = none_operand();
-    i.src1     = none_operand();
-    i.src2     = none_operand();
-    i.src3     = none_operand();
+    i.dst      = isa.make_none();
+    i.src1     = isa.make_none();
+    i.src2     = isa.make_none();
+    i.src3     = isa.make_none();
     i.flags    = 0;
     i.vec_lane = 0;
     i.sym_mod  = MOD_NONE;
@@ -205,25 +205,14 @@ pub fun inst(form: u8, base: u32) Inst {
 
 # an absent operand
 #
-# `isa` builds each populated operand through its own private blank, but exposes no
-# constructor for the empty one - x86-64 clears `kind` by hand where it needs one.
-# A public `isa.make_none()` would suit both; it is deliberately not added here,
-# since three branches are live in that file.
+# A thin name over `isa.make_none` kept for the emitter's call site. It hand-cleared
+# `isa.Operand` field by field until `isa` exposed a constructor, and missed
+# `sym_mod` when that field was added - which is exactly why the shared one is now
+# the only implementation.
 # ---
 # ret: an operand of kind OPK_NONE with every payload field neutral
 pub fun none_operand() isa.Operand {
-    var op: isa.Operand;
-    op.kind   = isa.OPK_NONE;
-    op.size   = 0;
-    op.reg    = -1;
-    op.imm    = 0;
-    op.base   = -1;
-    op.index  = -1;
-    op.scale  = 0;
-    op.disp   = 0;
-    op.sym_id = 0;
-    op.label  = nil;
-    ret op;
+    ret isa.make_none();
 }
 
 # a general-purpose register operand at `bytes` width

--- a/src/lang/target/isa/tests.mach
+++ b/src/lang/target/isa/tests.mach
@@ -1,0 +1,420 @@
+# the construction-site census for the machine-instruction model
+#
+# `Inst` and `Operand` are cleared in exactly one place each, and this module proves
+# it by reading the source rather than by trusting review. `var` does not zero, so a
+# site that builds one of these records field by field leaves whatever field it does
+# not name holding the frame's residue - and a field added later is named by no site
+# at all, on whichever target happens to have written that stack. That is not
+# hypothetical: `Operand.sym_mod` was added and three hand-written clears did not
+# learn about it.
+#
+# WHY THE INVARIANT IS TEXTUAL. Runtime cannot see this. A test can assert that a
+# constructor returns cleared fields, but that is a property of the constructor, not
+# of the hundred sites that may or may not call it, and it re-passes untouched the
+# day a site stops calling it. The property that matters is about the source, so it
+# is checked against the source.
+#
+# WHY A MISSING INITIALIZER IS THE WHOLE PROPERTY. A record can only be hand-built
+# from a declaration with no initializer - that is the only form that yields an
+# object whose fields are individually assignable from an undefined start. Every
+# other form (`var x: Inst = f();`) is a whole-record copy of a constructed value,
+# so it is complete by construction whatever `f` is, and `f` is itself subject to
+# this same census. Forbidding the bare form outside the constructors therefore
+# forbids hand-building outright, and it does so for fields that do not exist yet.
+#
+# The permitted list below IS the census of clearing sites. It is short on purpose:
+# adding to it is how a fifth place to forget a field gets introduced, so it should
+# be an argued change and not a convenience.
+#
+# An orphan test-only module: nothing imports it, and `mach test` collects it by
+# rooting at the whole source tree (as with the driver and vector-runtime suites).
+
+use std.allocator.page;
+use std.collections.vector;
+use std.types.bool.bool;
+use std.types.char.char;
+use std.types.bool.false;
+use std.types.bool.true;
+use std.types.size.usize;
+use std.types.string.str;
+use std.types.string.str_equals;
+use std.types.string.str_len;
+use std.types.string.str_region_equals;
+use std.types.string.str_ends_with;
+
+use A: std.allocator;
+use O: std.types.option;
+use R: std.types.result;
+use fs: std.filesystem;
+use std.collections.vector.Vector;
+
+# a source location that declares an `Inst` or `Operand` with no initializer
+# ---
+# path: repository-relative path of the file
+# line: 1-based line number
+# fun:  name of the enclosing function, or "<top>" outside one
+pub rec Site {
+    path: str;
+    line: usize;
+    fun:  str;
+}
+
+# the four functions permitted to declare an uninitialized `Inst` or `Operand`
+#
+# One per record that exists: `isa.Operand` and `isa.Inst` in the shared model,
+# aarch64's private machine instruction, and the inline-asm parser's operand. Each
+# is the single place its record is cleared; a fifth entry means a fifth place to
+# forget a field.
+val ALLOWED_LEN: usize = 4;
+
+# the enclosing function name of each permitted site, positionally paired with
+# `allowed_file`
+fun allowed_fun(i: usize) str {
+    if (i == 0) { ret "operand_blank"; }
+    if (i == 1) { ret "inst_blank"; }
+    if (i == 2) { ret "inst"; }
+    ret "op_none";
+}
+
+# the file of each permitted site, positionally paired with `allowed_fun`
+fun allowed_file(i: usize) str {
+    if (i == 0) { ret "src/lang/target/isa.mach"; }
+    if (i == 1) { ret "src/lang/target/isa.mach"; }
+    if (i == 2) { ret "src/lang/target/isa/arm64/printer.mach"; }
+    ret "src/lang/target/isa/asm.mach";
+}
+
+# whether a site is one of the permitted constructors
+# ---
+# path: repository-relative file path
+# name: enclosing function name
+# ret:  true if the pair appears in the permitted list
+fun is_allowed(path: str, name: str) bool {
+    var i: usize = 0;
+    for (i < ALLOWED_LEN) {
+        if (str_equals(path, allowed_file(i)) && str_equals(name, allowed_fun(i))) { ret true; }
+        i = i + 1;
+    }
+    ret false;
+}
+
+# whether a byte can appear in a mach identifier
+fun is_ident(c: char) bool {
+    if (c >= 'a' && c <= 'z') { ret true; }
+    if (c >= 'A' && c <= 'Z') { ret true; }
+    if (c >= '0' && c <= '9') { ret true; }
+    ret c == '_';
+}
+
+# advance past spaces and tabs
+# ---
+# text: the buffer being scanned
+# i:    offset to advance from
+# ret:  offset of the first non-blank byte at or after `i`
+fun skip_blank(text: str, i: usize) usize {
+    var p: usize = i;
+    for (text[p] == ' ' || text[p] == '\t') { p = p + 1; }
+    ret p;
+}
+
+# the type name a `var` declaration names, if the line is one
+#
+# Recognizes `var <ident> : <type>` and reports the offset just past `<type>`, so the
+# caller can decide whether an initializer follows. Returns none for any other line.
+# ---
+# text:  the buffer being scanned
+# start: offset of the line's first byte
+# tstart: set to the offset of the type name
+# tlen:   set to the length of the type name
+# ret:   offset just past the type name, or none if the line is not a declaration
+fun decl_type(text: str, start: usize, tstart: *usize, tlen: *usize) O.Option[usize] {
+    var p: usize = skip_blank(text, start);
+    if (!str_region_equals(text, p, 4, "var ")) { ret O.none[usize](); }
+    p = skip_blank(text, p + 3);
+
+    val name_at: usize = p;
+    for (is_ident(text[p])) { p = p + 1; }
+    if (p == name_at) { ret O.none[usize](); }
+
+    p = skip_blank(text, p);
+    if (text[p] != ':') { ret O.none[usize](); }
+    p = skip_blank(text, p + 1);
+
+    val ty_at: usize = p;
+    for (is_ident(text[p]) || text[p] == '.') { p = p + 1; }
+    if (p == ty_at) { ret O.none[usize](); }
+
+    @tstart = ty_at;
+    @tlen   = p - ty_at;
+    ret O.some[usize](p);
+}
+
+# whether a type name is one of the instruction-model records
+#
+# Matched unqualified as well as module-qualified, because a target names its own
+# record bare inside its own module and `isa.`-qualified outside it.
+# ---
+# text: the buffer being scanned
+# at:   offset of the type name
+# len:  length of the type name
+# ret:  true for Inst / Operand in any spelling this tree uses
+fun is_model_type(text: str, at: usize, len: usize) bool {
+    if (str_region_equals(text, at, len, "Inst"))         { ret true; }
+    if (str_region_equals(text, at, len, "Operand"))      { ret true; }
+    if (str_region_equals(text, at, len, "isa.Inst"))     { ret true; }
+    if (str_region_equals(text, at, len, "isa.Operand"))  { ret true; }
+    ret false;
+}
+
+# the function name a definition line introduces, if the line is one
+#
+# Only a column-zero `fun` / `pub fun` counts, which is every definition in this tree
+# and no nested expression.
+# ---
+# text:  the buffer being scanned
+# start: offset of the line's first byte
+# nstart: set to the offset of the function name
+# nlen:   set to the length of the function name
+# ret:   true if the line opens a function definition
+fun fun_name(text: str, start: usize, nstart: *usize, nlen: *usize) bool {
+    var p: usize = start;
+    if (str_region_equals(text, p, 8, "pub fun ")) { p = p + 8; }
+    or (str_region_equals(text, p, 4, "fun "))     { p = p + 4; }
+    or { ret false; }
+
+    p = skip_blank(text, p);
+    val at: usize = p;
+    for (is_ident(text[p])) { p = p + 1; }
+    if (p == at) { ret false; }
+
+    @nstart = at;
+    @nlen   = p - at;
+    ret true;
+}
+
+# scan one source file, appending every unpermitted bare declaration it holds
+# ---
+# alloc: allocator for the file buffer and the recorded names
+# path:  repository-relative path, used both to read and to report
+# sites: accumulator the violations are appended to
+# ret:   none on success, or a read error
+fun scan_file(alloc: *A.Allocator, path: str, sites: *Vector[Site]) O.Option[str] {
+    val rt: R.Result[str, str] = fs.read_string(alloc, path);
+    if (R.is_err[str, str](rt)) { ret O.some[str](R.unwrap_err[str, str](rt)); }
+    val text: str = R.unwrap_ok[str, str](rt);
+    val n: usize  = str_len(text);
+
+    var cur_at:  usize = 0;
+    var cur_len: usize = 0;
+    var has_fun: bool  = false;
+
+    var line: usize  = 1;
+    var start: usize = 0;
+    for (start < n) {
+        var end: usize = start;
+        for (end < n && text[end] != '\n') { end = end + 1; }
+
+        var na: usize = 0;
+        var nl: usize = 0;
+        if (fun_name(text, start, ?na, ?nl)) {
+            cur_at  = na;
+            cur_len = nl;
+            has_fun = true;
+        }
+
+        var ta: usize = 0;
+        var tl: usize = 0;
+        val after: O.Option[usize] = decl_type(text, start, ?ta, ?tl);
+        if (O.is_some[usize](after) && is_model_type(text, ta, tl)) {
+            # a declaration with no initializer is the only form that yields an
+            # object whose fields start undefined
+            val p: usize = skip_blank(text, O.unwrap[usize](after));
+            if (p < end && text[p] == ';') {
+                var s: Site;
+                s.path = path;
+                s.line = line;
+                s.fun  = "<top>";
+                if (has_fun) {
+                    val rn: R.Result[str, str] = str_slice(alloc, text, cur_at, cur_len);
+                    if (R.is_err[str, str](rn)) { ret O.some[str](R.unwrap_err[str, str](rn)); }
+                    s.fun = R.unwrap_ok[str, str](rn);
+                }
+                if (R.is_err[usize, str](vector.push[Site](sites, s))) {
+                    ret O.some[str]("out of memory recording a construction site");
+                }
+            }
+        }
+
+        start = end + 1;
+        line  = line + 1;
+    }
+    ret O.none[str]();
+}
+
+# copy a region of a buffer into a fresh null-terminated string
+# ---
+# alloc: allocator for the copy
+# text:  source buffer
+# at:    offset of the region
+# len:   length of the region
+# ret:   the copy, or an allocation error
+fun str_slice(alloc: *A.Allocator, text: str, at: usize, len: usize) R.Result[str, str] {
+    val rb: R.Result[*u8, str] = A.allocate[u8](alloc, len + 1);
+    if (R.is_err[*u8, str](rb)) { ret R.err[str, str]("out of memory copying a name"); }
+    val buf: *u8 = R.unwrap_ok[*u8, str](rb);
+    var i: usize = 0;
+    for (i < len) {
+        buf[i] = text[at + i]::u8;
+        i = i + 1;
+    }
+    buf[len] = 0;
+    ret R.ok[str, str](buf::str);
+}
+
+# walk a directory tree, scanning every `.mach` file under it
+# ---
+# alloc: allocator for paths, file buffers and the accumulator
+# dir:   directory to walk, repository-relative
+# sites: accumulator the violations are appended to
+# ret:   none on success, or the first error encountered
+fun scan_tree(alloc: *A.Allocator, dir: str, sites: *Vector[Site]) O.Option[str] {
+    val rd: R.Result[Vector[str], str] = fs.read_dir(alloc, dir);
+    if (R.is_err[Vector[str], str](rd)) { ret O.some[str](R.unwrap_err[Vector[str], str](rd)); }
+    var names: Vector[str] = R.unwrap_ok[Vector[str], str](rd);
+
+    var i: usize = 0;
+    for (i < names.len) {
+        val rg: R.Result[*str, str] = vector.get[str](?names, i);
+        if (R.is_err[*str, str](rg)) { ret O.some[str](R.unwrap_err[*str, str](rg)); }
+        val name: str = @R.unwrap_ok[*str, str](rg);
+        i = i + 1;
+        if (str_equals(name, ".") || str_equals(name, "..")) { cnt; }
+
+        val rj: R.Result[str, str] = join_path(alloc, dir, name);
+        if (R.is_err[str, str](rj)) { ret O.some[str](R.unwrap_err[str, str](rj)); }
+        val path: str = R.unwrap_ok[str, str](rj);
+
+        if (fs.is_dir(path)) {
+            val e: O.Option[str] = scan_tree(alloc, path, sites);
+            if (O.is_some[str](e)) { ret e; }
+            cnt;
+        }
+        if (!str_ends_with(path, ".mach")) { cnt; }
+
+        val e2: O.Option[str] = scan_file(alloc, path, sites);
+        if (O.is_some[str](e2)) { ret e2; }
+    }
+    ret O.none[str]();
+}
+
+# join a directory and a child name with a forward slash
+#
+# Forward slash only: these paths are read back to the reporter as the repository
+# spells them, and the permitted list is written the same way.
+# ---
+# alloc: allocator for the result
+# dir:   directory path
+# name:  child name
+# ret:   the joined path, or an allocation error
+fun join_path(alloc: *A.Allocator, dir: str, name: str) R.Result[str, str] {
+    val dl: usize = str_len(dir);
+    val nl: usize = str_len(name);
+    val rb: R.Result[*u8, str] = A.allocate[u8](alloc, dl + nl + 2);
+    if (R.is_err[*u8, str](rb)) { ret R.err[str, str]("out of memory joining a path"); }
+    val buf: *u8 = R.unwrap_ok[*u8, str](rb);
+
+    var i: usize = 0;
+    for (i < dl) { buf[i] = dir[i]::u8;  i = i + 1; }
+    buf[dl] = '/'::u8;
+    var j: usize = 0;
+    for (j < nl) { buf[dl + 1 + j] = name[j]::u8; j = j + 1; }
+    buf[dl + 1 + nl] = 0;
+    ret R.ok[str, str](buf::str);
+}
+
+# the root of the mach source tree, located from the working directory
+#
+# Walks upward rather than assuming the working directory, so the census runs from
+# anywhere inside the checkout. A failure to find it is REPORTED, never skipped: a
+# census that quietly passes when it cannot read the source is worse than no census,
+# because it reads as a green check.
+# ---
+# alloc: allocator for the candidate paths
+# ret:   the prefix that reaches `src/lang/target/isa.mach`, or none
+fun find_root(alloc: *A.Allocator) O.Option[str] {
+    var prefix: str = ".";
+    var depth: usize = 0;
+    for (depth < 8) {
+        val rj: R.Result[str, str] = join_path(alloc, prefix, "src/lang/target/isa.mach");
+        if (R.is_err[str, str](rj)) { ret O.none[str](); }
+        if (fs.is_file(R.unwrap_ok[str, str](rj))) { ret O.some[str](prefix); }
+
+        val ru: R.Result[str, str] = join_path(alloc, prefix, "..");
+        if (R.is_err[str, str](ru)) { ret O.none[str](); }
+        prefix = R.unwrap_ok[str, str](ru);
+        depth  = depth + 1;
+    }
+    ret O.none[str]();
+}
+
+# strip the located root's prefix, so a site is reported and matched by its
+# repository-relative path whatever directory the census ran from
+# ---
+# path: a path produced by the walk
+# root: the prefix `find_root` returned
+# ret:  the path relative to the repository root
+fun relative(path: str, root: str) str {
+    val rl: usize = str_len(root);
+    if (str_region_equals(path, 0, rl, root) && path[rl] == '/') {
+        ret (path::usize + rl + 1)::str;
+    }
+    ret path;
+}
+
+# EVERY `Inst` AND `Operand` IN THE BACK END IS BUILT BY A CONSTRUCTOR.
+#
+# The census walks `src/lang/target` and `src/lang/be` and reports every declaration
+# of one of these records that carries no initializer. Exactly four are permitted -
+# the constructors themselves, one per record - and any other is a site that clears
+# its fields by hand, which is a site that will not clear the next field added.
+#
+# To see it fail, delete the initializer at any construction site (say
+# `var ld: isa.Inst = isa.inst_blank();` in `isa/x64/encode.mach`) and re-run: the
+# count rises by one and the site is named.
+test "mach.lang.target.isa.blank:every_construction_site_is_constructed" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+
+    val rr: O.Option[str] = find_root(?alloc);
+    if (!O.is_some[str](rr)) { ret 1; }
+    val root: str = O.unwrap[str](rr);
+
+    var sites: Vector[Site] = vector.init[Site](?alloc);
+
+    val rj1: R.Result[str, str] = join_path(?alloc, root, "src/lang/target");
+    if (R.is_err[str, str](rj1)) { ret 1; }
+    if (O.is_some[str](scan_tree(?alloc, R.unwrap_ok[str, str](rj1), ?sites))) { ret 1; }
+
+    val rj2: R.Result[str, str] = join_path(?alloc, root, "src/lang/be");
+    if (R.is_err[str, str](rj2)) { ret 1; }
+    if (O.is_some[str](scan_tree(?alloc, R.unwrap_ok[str, str](rj2), ?sites))) { ret 1; }
+
+    # the walk must have found the tree: a census over zero files reports zero
+    # violations and would pass without checking anything
+    val total: usize = sites.len;
+    if (total == 0) { ret 1; }
+
+    var unpermitted: usize = 0;
+    var i: usize = 0;
+    for (i < total) {
+        val rg: R.Result[*Site, str] = vector.get[Site](?sites, i);
+        if (R.is_err[*Site, str](rg)) { ret 1; }
+        val s: *Site = R.unwrap_ok[*Site, str](rg);
+        if (!is_allowed(relative(s.path, root), s.fun)) { unpermitted = unpermitted + 1; }
+        i = i + 1;
+    }
+
+    if (unpermitted != 0)     { ret unpermitted::i32; }
+    if (total != ALLOWED_LEN) { ret 1; }
+    ret 0;
+}

--- a/src/lang/target/isa/x64/encode.mach
+++ b/src/lang/target/isa/x64/encode.mach
@@ -370,19 +370,13 @@ fun encode_alu_rm(buf: *enc.ByteBuf, opcode: u8, reg: i32, mem: *isa.Operand, si
 fun encode_alu_imm(buf: *enc.ByteBuf, opcode: u16, reg: i32, imm: i64, size: u8, flags: u16) {
     if (size == 8 && (imm < -2147483648 || imm > 2147483647)) {
         val scratch: i32 = x64.R11;
-        var ld: isa.Inst;
-        ld.opcode   = x64.MOV;
-        ld.dst      = isa.make_reg(scratch, 8);
-        ld.src1     = isa.make_imm(imm, 8);
-        ld.src2.kind = 0;
-        ld.size     = 8;
-        ld.flags    = 0;
-        ld.clobbers = 0;
-        ld.src_line = 0;
-        ld.src_file = nil;
+        var ld: isa.Inst = isa.inst_blank();
+        ld.opcode = x64.MOV;
+        ld.dst    = isa.make_reg(scratch, 8);
+        ld.src1   = isa.make_imm(imm, 8);
+        ld.size   = 8;
         encode_inst(?ld, buf);
-        var rr: isa.Inst;
-        zero_inst(?rr);
+        var rr: isa.Inst = isa.inst_blank();
         rr.opcode = opcode;
         rr.dst    = isa.make_reg(reg, 8);
         rr.src1   = isa.make_reg(scratch, 8);
@@ -655,27 +649,19 @@ fun encode_mov(mi: *isa.Inst, buf: *enc.ByteBuf) i32 {
 
     if (dst.kind == isa.OPK_MEM && src1.kind == isa.OPK_MEM) {
         val scratch: i32 = x64.R11;
-        var ld: isa.Inst;
-        ld.opcode    = mi.opcode;
-        ld.dst       = isa.make_reg(scratch, size);
-        ld.src1      = mi.src1;
-        ld.src2.kind = 0;
-        ld.size      = size;
-        ld.flags     = flags;
-        ld.clobbers  = 0;
-        ld.src_line  = 0;
-        ld.src_file  = nil;
+        var ld: isa.Inst = isa.inst_blank();
+        ld.opcode = mi.opcode;
+        ld.dst    = isa.make_reg(scratch, size);
+        ld.src1   = mi.src1;
+        ld.size   = size;
+        ld.flags  = flags;
         val ld_sz: i32 = encode_inst(?ld, buf);
-        var st: isa.Inst;
-        st.opcode    = mi.opcode;
-        st.dst       = mi.dst;
-        st.src1      = isa.make_reg(scratch, size);
-        st.src2.kind = 0;
-        st.size      = size;
-        st.flags     = flags;
-        st.clobbers  = 0;
-        st.src_line  = 0;
-        st.src_file  = nil;
+        var st: isa.Inst = isa.inst_blank();
+        st.opcode = mi.opcode;
+        st.dst    = mi.dst;
+        st.src1   = isa.make_reg(scratch, size);
+        st.size   = size;
+        st.flags  = flags;
         val st_sz: i32 = encode_inst(?st, buf);
         ret ld_sz + st_sz;
     }
@@ -689,27 +675,18 @@ fun encode_mov(mi: *isa.Inst, buf: *enc.ByteBuf) i32 {
         # the mem-mem split and the ALU-imm64 legalization in this encoder.
         if (size == 8 && (src1.imm < -2147483648 || src1.imm > 2147483647)) {
             val scratch: i32 = x64.R11;
-            var ld: isa.Inst;
+            var ld: isa.Inst = isa.inst_blank();
             ld.opcode = x64.MOVABS;
             ld.dst    = isa.make_reg(scratch, 8);
             ld.src1   = isa.make_imm(src1.imm, 8);
-            ld.src2.kind = 0;
             ld.size   = 8;
-            ld.flags  = 0;
-            ld.clobbers = 0;
-            ld.src_line = 0;
-            ld.src_file = nil;
             val ld_sz: i32 = encode_inst(?ld, buf);
-            var st: isa.Inst;
+            var st: isa.Inst = isa.inst_blank();
             st.opcode = mi.opcode;
             st.dst    = mi.dst;
             st.src1   = isa.make_reg(scratch, 8);
-            st.src2.kind = 0;
             st.size   = 8;
             st.flags  = flags;
-            st.clobbers = 0;
-            st.src_line = 0;
-            st.src_file = nil;
             val st_sz: i32 = encode_inst(?st, buf);
             ret ld_sz + st_sz;
         }
@@ -831,19 +808,13 @@ fun encode_alu(mi: *isa.Inst, buf: *enc.ByteBuf) i32 {
         # `op [mem], r11`.
         if (size == 8 && (imm < -2147483648 || imm > 2147483647)) {
             val scratch: i32 = x64.R11;
-            var ld: isa.Inst;
-            ld.opcode   = x64.MOV;
-            ld.dst      = isa.make_reg(scratch, 8);
-            ld.src1     = isa.make_imm(imm, 8);
-            ld.src2.kind = 0;
-            ld.size     = 8;
-            ld.flags    = 0;
-            ld.clobbers = 0;
-            ld.src_line = 0;
-            ld.src_file = nil;
+            var ld: isa.Inst = isa.inst_blank();
+            ld.opcode = x64.MOV;
+            ld.dst    = isa.make_reg(scratch, 8);
+            ld.src1   = isa.make_imm(imm, 8);
+            ld.size   = 8;
             encode_inst(?ld, buf);
-            var rm: isa.Inst;
-            zero_inst(?rm);
+            var rm: isa.Inst = isa.inst_blank();
             rm.opcode = opcode;
             rm.dst    = mi.dst;
             rm.src1   = isa.make_reg(scratch, 8);
@@ -1103,15 +1074,13 @@ fun encode_imul(mi: *isa.Inst, buf: *enc.ByteBuf) i32 {
         # r11), mirroring the same split in encode_alu_imm.
         if (size == 8 && (imm < -2147483648 || imm > 2147483647)) {
             val scratch: i32 = x64.R11;
-            var ld: isa.Inst;
-            zero_inst(?ld);
+            var ld: isa.Inst = isa.inst_blank();
             ld.opcode = x64.MOV;
             ld.dst    = isa.make_reg(scratch, 8);
             ld.src1   = isa.make_imm(imm, 8);
             ld.size   = 8;
             encode_inst(?ld, buf);
-            var rr: isa.Inst;
-            zero_inst(?rr);
+            var rr: isa.Inst = isa.inst_blank();
             rr.opcode = x64.IMUL;
             rr.dst    = isa.make_reg(dst.reg, size);
             rr.src1   = isa.make_reg(scratch, size);
@@ -1766,16 +1735,12 @@ fun encode_inst(mi: *isa.Inst, buf: *enc.ByteBuf) i32 {
         # XMM scratch instead. scalar widths keep R11 (reserved from GP allocation).
         var scratch: i32 = x64.R11;
         if (mi.size == 16) { scratch = FLOAT_SCRATCH0; }
-        var ld: isa.Inst;
-        ld.opcode    = x64.MOV;
-        ld.dst       = isa.make_reg(scratch, mi.size);
-        ld.src1      = mi.src1;
-        ld.src2.kind = 0;
-        ld.size      = mi.size;
-        ld.flags     = mi.flags;
-        ld.clobbers  = 0;
-        ld.src_line  = 0;
-        ld.src_file  = nil;
+        var ld: isa.Inst = isa.inst_blank();
+        ld.opcode = x64.MOV;
+        ld.dst    = isa.make_reg(scratch, mi.size);
+        ld.src1   = mi.src1;
+        ld.size   = mi.size;
+        ld.flags  = mi.flags;
         val ld_sz: i32 = encode_inst(?ld, buf);
         mi.src1 = isa.make_reg(scratch, mi.size);
         val rest: i32 = encode_inst(mi, buf);
@@ -2071,8 +2036,7 @@ fun emit_inst(st: *enc.EncodeState, mi: *isa.Inst) {
 # encode a `mov [rbp+disp], reg` saving a callee-saved register
 # into the frame
 fun emit_frame_store(st: *enc.EncodeState, reg: i32, disp: i32) {
-    var mi: isa.Inst;
-    zero_inst(?mi);
+    var mi: isa.Inst = isa.inst_blank();
     mi.opcode = x64.MOV;
     mi.dst    = isa.make_mem(x64.RBP, disp, -1, 0, 8);
     mi.src1   = isa.make_reg(reg, 8);
@@ -2084,8 +2048,7 @@ fun emit_frame_store(st: *enc.EncodeState, reg: i32, disp: i32) {
 # encode a `mov reg, [rbp+disp]` restoring a callee-saved
 # register from the frame
 fun emit_frame_load(st: *enc.EncodeState, reg: i32, disp: i32) {
-    var mi: isa.Inst;
-    zero_inst(?mi);
+    var mi: isa.Inst = isa.inst_blank();
     mi.opcode = x64.MOV;
     mi.dst    = isa.make_reg(reg, 8);
     mi.src1   = isa.make_mem(x64.RBP, disp, -1, 0, 8);
@@ -2099,8 +2062,7 @@ fun emit_frame_load(st: *enc.EncodeState, reg: i32, disp: i32) {
 # is built on its composite SSE id so the encoder selects the SSE form. `disp` must
 # be 16-aligned (the frame layout guarantees it) for the aligned MOVAPS
 fun emit_xmm_store(st: *enc.EncodeState, idx: i32, disp: i32) {
-    var mi: isa.Inst;
-    zero_inst(?mi);
+    var mi: isa.Inst = isa.inst_blank();
     mi.opcode = x64.MOVAPS;
     mi.dst    = isa.make_mem(x64.RBP, disp, -1, 0, 16);
     mi.src1   = isa.make_reg(isa.regid_make(isa.REG_CLASS_ID_XMM, idx), 16);
@@ -2111,8 +2073,7 @@ fun emit_xmm_store(st: *enc.EncodeState, idx: i32, disp: i32) {
 # encode a `movaps xmm, [rbp+disp]` restoring a callee-saved vector
 # register from the frame, mirroring emit_xmm_store
 fun emit_xmm_load(st: *enc.EncodeState, idx: i32, disp: i32) {
-    var mi: isa.Inst;
-    zero_inst(?mi);
+    var mi: isa.Inst = isa.inst_blank();
     mi.opcode = x64.MOVAPS;
     mi.dst    = isa.make_reg(isa.regid_make(isa.REG_CLASS_ID_XMM, idx), 16);
     mi.src1   = isa.make_mem(x64.RBP, disp, -1, 0, 16);
@@ -2152,8 +2113,7 @@ fun needs_stack_probe(os: *tos.OsVTable, total: usize) bool {
 # page_bytes: guard-page granularity to probe at (the OS page size; a power of two)
 fun emit_stack_probe(st: *enc.EncodeState, total: usize, page_bytes: usize) {
     # r11 = bytes still to allocate below the current RSP
-    var mov_cnt: isa.Inst;
-    zero_inst(?mov_cnt);
+    var mov_cnt: isa.Inst = isa.inst_blank();
     mov_cnt.opcode = x64.MOV;
     mov_cnt.dst    = isa.make_reg(x64.SCRATCH_REG, 8);
     mov_cnt.src1   = isa.make_imm(total::i64, 8);
@@ -2164,8 +2124,7 @@ fun emit_stack_probe(st: *enc.EncodeState, total: usize, page_bytes: usize) {
     val loop_top: usize = st.buf.len;
 
     # sub rsp, page  - descend onto the current guard page
-    var sub_sp: isa.Inst;
-    zero_inst(?sub_sp);
+    var sub_sp: isa.Inst = isa.inst_blank();
     sub_sp.opcode = x64.SUB;
     sub_sp.dst    = isa.make_reg(x64.RSP, 8);
     sub_sp.src1   = isa.make_imm(page_bytes::i64, 8);
@@ -2174,8 +2133,7 @@ fun emit_stack_probe(st: *enc.EncodeState, total: usize, page_bytes: usize) {
     emit_inst(st, ?sub_sp);
 
     # mov [rsp], r11  - touch the page so the OS commits it and arms the next guard
-    var touch: isa.Inst;
-    zero_inst(?touch);
+    var touch: isa.Inst = isa.inst_blank();
     touch.opcode = x64.MOV;
     touch.dst    = isa.make_mem(x64.RSP, 0, -1, 0, 8);
     touch.src1   = isa.make_reg(x64.SCRATCH_REG, 8);
@@ -2184,8 +2142,7 @@ fun emit_stack_probe(st: *enc.EncodeState, total: usize, page_bytes: usize) {
     emit_inst(st, ?touch);
 
     # sub r11, page
-    var sub_cnt: isa.Inst;
-    zero_inst(?sub_cnt);
+    var sub_cnt: isa.Inst = isa.inst_blank();
     sub_cnt.opcode = x64.SUB;
     sub_cnt.dst    = isa.make_reg(x64.SCRATCH_REG, 8);
     sub_cnt.src1   = isa.make_imm(page_bytes::i64, 8);
@@ -2194,8 +2151,7 @@ fun emit_stack_probe(st: *enc.EncodeState, total: usize, page_bytes: usize) {
     emit_inst(st, ?sub_cnt);
 
     # cmp r11, page  - loop while more than a full page remains
-    var cmp_cnt: isa.Inst;
-    zero_inst(?cmp_cnt);
+    var cmp_cnt: isa.Inst = isa.inst_blank();
     cmp_cnt.opcode = x64.CMP;
     cmp_cnt.dst    = isa.make_reg(x64.SCRATCH_REG, 8);
     cmp_cnt.src1   = isa.make_imm(page_bytes::i64, 8);
@@ -2206,8 +2162,7 @@ fun emit_stack_probe(st: *enc.EncodeState, total: usize, page_bytes: usize) {
     # ja loop_top  - unsigned above: another full page to probe. the rel32 is
     # backpatched to the measured backward displacement (target minus the offset of
     # the instruction following the branch).
-    var ja: isa.Inst;
-    zero_inst(?ja);
+    var ja: isa.Inst = isa.inst_blank();
     ja.opcode = x64.JA;
     ja.dst    = isa.make_label(nil);
     ja.size   = DEFAULT_OPERAND_SIZE;
@@ -2216,8 +2171,7 @@ fun emit_stack_probe(st: *enc.EncodeState, total: usize, page_bytes: usize) {
     patch_rel32(?st.buf, ja_patch, (loop_top::i64 - st.buf.len::i64)::i32);
 
     # sub rsp, r11  - allocate the final partial page (r11 in (0, page])
-    var sub_rem: isa.Inst;
-    zero_inst(?sub_rem);
+    var sub_rem: isa.Inst = isa.inst_blank();
     sub_rem.opcode = x64.SUB;
     sub_rem.dst    = isa.make_reg(x64.RSP, 8);
     sub_rem.src1   = isa.make_reg(x64.SCRATCH_REG, 8);
@@ -2245,16 +2199,14 @@ fun emit_stack_probe(st: *enc.EncodeState, total: usize, page_bytes: usize) {
 #                 (win64 only; 0 under SysV, where the XMM save path is inert)
 # outgoing_size:  bytes reserved at the bottom of the frame for stack-passed call args
 fun emit_prologue(st: *enc.EncodeState, frame_size: u32, callee_mask: u32, callee_mask_fp: u32, outgoing_size: u32) {
-    var push_rbp: isa.Inst;
-    zero_inst(?push_rbp);
+    var push_rbp: isa.Inst = isa.inst_blank();
     push_rbp.opcode = x64.PUSH;
     push_rbp.dst    = isa.make_reg(x64.RBP, 8);
     push_rbp.size   = 8;
     push_rbp.flags  = x64.FLAG_REX_W;
     emit_inst(st, ?push_rbp);
 
-    var mov_rbp: isa.Inst;
-    zero_inst(?mov_rbp);
+    var mov_rbp: isa.Inst = isa.inst_blank();
     mov_rbp.opcode = x64.MOV;
     mov_rbp.dst    = isa.make_reg(x64.RBP, 8);
     mov_rbp.src1   = isa.make_reg(x64.RSP, 8);
@@ -2272,8 +2224,7 @@ fun emit_prologue(st: *enc.EncodeState, frame_size: u32, callee_mask: u32, calle
         if (needs_stack_probe(st.os, total)) {
             emit_stack_probe(st, total, st.os.page_size::usize);
         } or {
-            var sub_rsp: isa.Inst;
-            zero_inst(?sub_rsp);
+            var sub_rsp: isa.Inst = isa.inst_blank();
             sub_rsp.opcode = x64.SUB;
             sub_rsp.dst    = isa.make_reg(x64.RSP, 8);
             sub_rsp.src1   = isa.make_imm(total::i64, 8);
@@ -2348,8 +2299,7 @@ fun emit_epilogue(st: *enc.EncodeState, frame_size: u32, callee_mask: u32, calle
         i = i + 1;
     }
 
-    var mov_rsp: isa.Inst;
-    zero_inst(?mov_rsp);
+    var mov_rsp: isa.Inst = isa.inst_blank();
     mov_rsp.opcode = x64.MOV;
     mov_rsp.dst    = isa.make_reg(x64.RSP, 8);
     mov_rsp.src1   = isa.make_reg(x64.RBP, 8);
@@ -2357,8 +2307,7 @@ fun emit_epilogue(st: *enc.EncodeState, frame_size: u32, callee_mask: u32, calle
     mov_rsp.flags  = x64.FLAG_REX_W;
     emit_inst(st, ?mov_rsp);
 
-    var pop_rbp: isa.Inst;
-    zero_inst(?pop_rbp);
+    var pop_rbp: isa.Inst = isa.inst_blank();
     pop_rbp.opcode = x64.POP;
     pop_rbp.dst    = isa.make_reg(x64.RBP, 8);
     pop_rbp.size   = 8;
@@ -2433,49 +2382,6 @@ fun x86_reloc_offset(ctx: ptr, mi: *isa.Inst, inst_size: i32) i32 {
         ret inst_size - 4;
     }
     ret -1;
-}
-
-# clear an instruction to the canonical empty state (no opcode, all
-# operands inactive with -1 base/index so they read as register-less memory)
-# ---
-# inst: instruction to reset in place
-fun zero_inst(inst: *isa.Inst) {
-    inst.opcode   = 0;
-    inst.size     = 0;
-    inst.flags    = 0;
-    inst.clobbers = 0;
-    inst.src_line = 0;
-    inst.src_file = nil;
-    inst.dst.kind   = 0;
-    inst.dst.size   = 0;
-    inst.dst.reg    = 0;
-    inst.dst.imm    = 0;
-    inst.dst.base   = -1;
-    inst.dst.index  = -1;
-    inst.dst.scale  = 0;
-    inst.dst.disp   = 0;
-    inst.dst.sym_id = 0;
-    inst.dst.label  = nil;
-    inst.src1.kind   = 0;
-    inst.src1.size   = 0;
-    inst.src1.reg    = 0;
-    inst.src1.imm    = 0;
-    inst.src1.base   = -1;
-    inst.src1.index  = -1;
-    inst.src1.scale  = 0;
-    inst.src1.disp   = 0;
-    inst.src1.sym_id = 0;
-    inst.src1.label  = nil;
-    inst.src2.kind   = 0;
-    inst.src2.size   = 0;
-    inst.src2.reg    = 0;
-    inst.src2.imm    = 0;
-    inst.src2.base   = -1;
-    inst.src2.index  = -1;
-    inst.src2.scale  = 0;
-    inst.src2.disp   = 0;
-    inst.src2.sym_id = 0;
-    inst.src2.label  = nil;
 }
 
 # canonical x86-64 machine-word width in bytes. used for address-sized and
@@ -2889,7 +2795,7 @@ fun encode_mir_instr(st: *enc.EncodeState, f: *mir.MirFunction, fn_base: u32, mi
         ret encode_asm_block(st, f, fn_base, mi);
     }
 
-    var inst: isa.Inst;
+    var inst: isa.Inst = isa.inst_blank();
     val ti: R.Result[bool, str] = mir_to_inst(f, mi, ?inst);
     if (R.is_err[bool, str](ti)) { ret ti; }
 
@@ -3009,8 +2915,7 @@ fun emit_flag_cmp(f: *mir.MirFunction, lhs_op: *mir.MirOperand, rhs_op: *mir.Mir
 
     var cmp_lhs: isa.Operand = lhs;
     if (cmp_lhs.kind == isa.OPK_IMM) {
-        var ld: isa.Inst;
-        zero_inst(?ld);
+        var ld: isa.Inst = isa.inst_blank();
         ld.opcode = x64.MOV;
         ld.dst    = isa.make_reg(x64.R11, cwidth);
         ld.src1   = lhs;
@@ -3021,8 +2926,7 @@ fun emit_flag_cmp(f: *mir.MirFunction, lhs_op: *mir.MirOperand, rhs_op: *mir.Mir
     }
 
     # CMP lhs, rhs  (flag-setting; the x86-64 two-operand form is `dst=lhs, src=rhs`)
-    var cmp: isa.Inst;
-    zero_inst(?cmp);
+    var cmp: isa.Inst = isa.inst_blank();
     cmp.opcode = x64.CMP;
     cmp.dst    = cmp_lhs;
     cmp.src1   = rhs;
@@ -3061,8 +2965,7 @@ fun encode_compare(f: *mir.MirFunction, mi: *mir.MirInstr, buf: *enc.ByteBuf) R.
     if (R.is_err[bool, str](rc)) { ret rc; }
 
     # SETcc dst  (one byte; the destination is driven at byte width)
-    var setcc: isa.Inst;
-    zero_inst(?setcc);
+    var setcc: isa.Inst = isa.inst_blank();
     setcc.opcode  = mir_setcc_opcode(mi.opcode);
     setcc.dst     = dst;
     setcc.dst.size = 1;
@@ -3072,8 +2975,7 @@ fun encode_compare(f: *mir.MirFunction, mi: *mir.MirInstr, buf: *enc.ByteBuf) R.
     # MOVZX dst, dst  (zero-extend the byte boolean to the machine word). the
     # destination is a full register holding the i8 result; zero-extending the
     # SETcc byte to the machine word clears the upper bits.
-    var movzx: isa.Inst;
-    zero_inst(?movzx);
+    var movzx: isa.Inst = isa.inst_blank();
     movzx.opcode  = x64.MOVZX;
     movzx.dst     = dst;
     movzx.dst.size = DEFAULT_OPERAND_SIZE;
@@ -3133,8 +3035,7 @@ fun emit_float_load(op: isa.Operand, xmm: i32, w: u8, buf: *enc.ByteBuf) R.Resul
     if (w == 4) { mov_op = x64.MOVSS; }
 
     if (op.kind == isa.OPK_MEM) {
-        var ld: isa.Inst;
-        zero_inst(?ld);
+        var ld: isa.Inst = isa.inst_blank();
         ld.opcode = mov_op;
         ld.dst    = isa.make_reg(xmm, 16);
         ld.src1   = op;
@@ -3143,8 +3044,7 @@ fun emit_float_load(op: isa.Operand, xmm: i32, w: u8, buf: *enc.ByteBuf) R.Resul
         ret R.ok[bool, str](true);
     }
     if (op.kind == isa.OPK_REG) {
-        var mv: isa.Inst;
-        zero_inst(?mv);
+        var mv: isa.Inst = isa.inst_blank();
         mv.opcode = mov_op;
         mv.dst    = isa.make_reg(xmm, 16);
         mv.src1   = isa.make_reg(op.reg, 16);
@@ -3153,16 +3053,14 @@ fun emit_float_load(op: isa.Operand, xmm: i32, w: u8, buf: *enc.ByteBuf) R.Resul
         ret R.ok[bool, str](true);
     }
     if (op.kind == isa.OPK_IMM) {
-        var mi_imm: isa.Inst;
-        zero_inst(?mi_imm);
+        var mi_imm: isa.Inst = isa.inst_blank();
         mi_imm.opcode = x64.MOVABS;
         mi_imm.dst    = isa.make_reg(x64.R11, 8);
         mi_imm.src1   = isa.make_imm(op.imm, 8);
         mi_imm.size   = 8;
         encode_inst(?mi_imm, buf);
 
-        var mq: isa.Inst;
-        zero_inst(?mq);
+        var mq: isa.Inst = isa.inst_blank();
         mq.opcode = x64.MOVQ;
         mq.dst    = isa.make_reg(xmm, 16);
         mq.src1   = isa.make_reg(x64.R11, 8);
@@ -3182,8 +3080,7 @@ fun emit_float_store(dst: isa.Operand, xmm: i32, w: u8, buf: *enc.ByteBuf) R.Res
     if (w == 4) { mov_op = x64.MOVSS; }
 
     if (dst.kind == isa.OPK_MEM) {
-        var st: isa.Inst;
-        zero_inst(?st);
+        var st: isa.Inst = isa.inst_blank();
         st.opcode = mov_op;
         st.dst    = dst;
         st.src1   = isa.make_reg(xmm, 16);
@@ -3192,8 +3089,7 @@ fun emit_float_store(dst: isa.Operand, xmm: i32, w: u8, buf: *enc.ByteBuf) R.Res
         ret R.ok[bool, str](true);
     }
     if (dst.kind == isa.OPK_REG) {
-        var mv: isa.Inst;
-        zero_inst(?mv);
+        var mv: isa.Inst = isa.inst_blank();
         mv.opcode = mov_op;
         mv.dst    = isa.make_reg(dst.reg, 16);
         mv.src1   = isa.make_reg(xmm, 16);
@@ -3235,8 +3131,7 @@ fun encode_float_arith(f: *mir.MirFunction, mi: *mir.MirInstr, buf: *enc.ByteBuf
     val lr: R.Result[bool, str] = emit_float_load(rhs, FLOAT_SCRATCH1, w, buf);
     if (R.is_err[bool, str](lr)) { ret lr; }
 
-    var alu: isa.Inst;
-    zero_inst(?alu);
+    var alu: isa.Inst = isa.inst_blank();
     alu.opcode = float_alu_opcode(mi.opcode, w);
     alu.dst    = isa.make_reg(FLOAT_SCRATCH0, 16);
     alu.src1   = isa.make_reg(FLOAT_SCRATCH1, 16);
@@ -3286,16 +3181,14 @@ fun encode_float_neg(f: *mir.MirFunction, mi: *mir.MirInstr, buf: *enc.ByteBuf) 
     if (R.is_err[bool, str](ld)) { ret ld; }
 
     # materialize the sign-bit mask into FLOAT_SCRATCH1 via the R11 GP scratch.
-    var mov_imm: isa.Inst;
-    zero_inst(?mov_imm);
+    var mov_imm: isa.Inst = isa.inst_blank();
     mov_imm.opcode = x64.MOVABS;
     mov_imm.dst    = isa.make_reg(x64.R11, 8);
     mov_imm.src1   = isa.make_imm(float_sign_mask(w), 8);
     mov_imm.size   = 8;
     encode_inst(?mov_imm, buf);
 
-    var movq: isa.Inst;
-    zero_inst(?movq);
+    var movq: isa.Inst = isa.inst_blank();
     movq.opcode = x64.MOVQ;
     movq.dst    = isa.make_reg(FLOAT_SCRATCH1, 16);
     movq.src1   = isa.make_reg(x64.R11, 8);
@@ -3303,8 +3196,7 @@ fun encode_float_neg(f: *mir.MirFunction, mi: *mir.MirInstr, buf: *enc.ByteBuf) 
     encode_inst(?movq, buf);
 
     # FLOAT_SCRATCH0 ^= FLOAT_SCRATCH1 (flip the sign bit), then store back.
-    var xorp: isa.Inst;
-    zero_inst(?xorp);
+    var xorp: isa.Inst = isa.inst_blank();
     xorp.opcode = x64.XORPS;
     xorp.dst    = isa.make_reg(FLOAT_SCRATCH0, 16);
     xorp.src1   = isa.make_reg(FLOAT_SCRATCH1, 16);
@@ -3330,8 +3222,7 @@ fun is_mir_float_conv(op: mir.MirOpcode) bool {
 # rejected loudly. mirrors `emit_float_store` for the GP side of a conversion
 fun emit_gp_store(dst: isa.Operand, gp: i32, w: u8, buf: *enc.ByteBuf) R.Result[bool, str] {
     if (dst.kind == isa.OPK_REG || dst.kind == isa.OPK_MEM) {
-        var st: isa.Inst;
-        zero_inst(?st);
+        var st: isa.Inst = isa.inst_blank();
         st.opcode = x64.MOV;
         st.dst    = dst;
         st.src1   = isa.make_reg(gp, w);
@@ -3347,8 +3238,7 @@ fun emit_gp_store(dst: isa.Operand, gp: i32, w: u8, buf: *enc.ByteBuf) R.Result[
 # at the given integer-side byte width (sizes REX.W for the GP operand of a
 # CVTSI2SS/SD / CVTTSS2SI/SD; a float-to-float CVTSS2SD / CVTSD2SS ignores it)
 fun emit_cvt_reg(cvt_op: u16, dst_reg: i32, src_reg: i32, int_w: u8, buf: *enc.ByteBuf) {
-    var cvt: isa.Inst;
-    zero_inst(?cvt);
+    var cvt: isa.Inst = isa.inst_blank();
     cvt.opcode = cvt_op;
     cvt.dst    = isa.make_reg(dst_reg, 16);
     cvt.src1   = isa.make_reg(src_reg, 16);
@@ -3369,8 +3259,7 @@ fun patch_rel32(buf: *enc.ByteBuf, pos: usize, disp: i32) {
 
 # emit a 64-bit register-register GP op (`opcode dst_reg, src_reg`)
 fun emit_gp_rr8(opcode: u16, dst_reg: i32, src_reg: i32, buf: *enc.ByteBuf) {
-    var mi: isa.Inst;
-    zero_inst(?mi);
+    var mi: isa.Inst = isa.inst_blank();
     mi.opcode = opcode;
     mi.dst    = isa.make_reg(dst_reg, 8);
     mi.src1   = isa.make_reg(src_reg, 8);
@@ -3381,8 +3270,7 @@ fun emit_gp_rr8(opcode: u16, dst_reg: i32, src_reg: i32, buf: *enc.ByteBuf) {
 
 # emit a 64-bit register-immediate GP op (`opcode dst_reg, imm`)
 fun emit_gp_ri8(opcode: u16, dst_reg: i32, imm: i64, buf: *enc.ByteBuf) {
-    var mi: isa.Inst;
-    zero_inst(?mi);
+    var mi: isa.Inst = isa.inst_blank();
     mi.opcode = opcode;
     mi.dst    = isa.make_reg(dst_reg, 8);
     mi.src1   = isa.make_imm(imm, 8);
@@ -3394,8 +3282,7 @@ fun emit_gp_ri8(opcode: u16, dst_reg: i32, imm: i64, buf: *enc.ByteBuf) {
 # emit a register-register SSE op (`opcode dst_reg, src_reg`) at float
 # width `w` (4 -> single, 8 -> double)
 fun emit_fp_rr(opcode: u16, dst_reg: i32, src_reg: i32, w: u8, buf: *enc.ByteBuf) {
-    var mi: isa.Inst;
-    zero_inst(?mi);
+    var mi: isa.Inst = isa.inst_blank();
     mi.opcode = opcode;
     mi.dst    = isa.make_reg(dst_reg, 16);
     mi.src1   = isa.make_reg(src_reg, 16);
@@ -3435,8 +3322,7 @@ fun emit_gp_load_ext(op: isa.Operand, gp: i32, src_w: u8, signed: bool, buf: *en
         ret R.err[bool, str]("encode: conversion integer operand is not a register, frame slot, or immediate");
     }
 
-    var ld: isa.Inst;
-    zero_inst(?ld);
+    var ld: isa.Inst = isa.inst_blank();
     ld.dst       = isa.make_reg(gp, 8);
     ld.src1      = op;
     ld.src1.size = src_w;
@@ -3465,8 +3351,7 @@ fun emit_gp_load_ext(op: isa.Operand, gp: i32, src_w: u8, signed: bool, buf: *en
 # is the halving temp. the two forward rel32 jumps are intra-instruction, patched here
 # from the measured branch lengths
 fun emit_u64_to_fp(dst: isa.Operand, dst_w: u8, cvt_op: u16, buf: *enc.ByteBuf) R.Result[bool, str] {
-    var test_inst: isa.Inst;
-    zero_inst(?test_inst);
+    var test_inst: isa.Inst = isa.inst_blank();
     test_inst.opcode = x64.TEST;
     test_inst.dst    = isa.make_reg(x64.SCRATCH_REG, 8);
     test_inst.src1   = isa.make_reg(x64.SCRATCH_REG, 8);
@@ -3474,8 +3359,7 @@ fun emit_u64_to_fp(dst: isa.Operand, dst_w: u8, cvt_op: u16, buf: *enc.ByteBuf) 
     test_inst.flags  = width_flags(8);
     encode_inst(?test_inst, buf);
 
-    var jl: isa.Inst;
-    zero_inst(?jl);
+    var jl: isa.Inst = isa.inst_blank();
     jl.opcode = x64.JL;
     jl.dst    = isa.make_label(nil);
     jl.size   = DEFAULT_OPERAND_SIZE;
@@ -3486,8 +3370,7 @@ fun emit_u64_to_fp(dst: isa.Operand, dst_w: u8, cvt_op: u16, buf: *enc.ByteBuf) 
     # value < 2^63: the signed conversion is exact.
     emit_cvt_reg(cvt_op, FLOAT_SCRATCH0, x64.SCRATCH_REG, 8, buf);
 
-    var jmp: isa.Inst;
-    zero_inst(?jmp);
+    var jmp: isa.Inst = isa.inst_blank();
     jmp.opcode = x64.JMP;
     jmp.dst    = isa.make_label(nil);
     jmp.size   = DEFAULT_OPERAND_SIZE;
@@ -3602,8 +3485,7 @@ fun encode_float_conv(f: *mir.MirFunction, mi: *mir.MirInstr, buf: *enc.ByteBuf)
 # and the XMM register `xmm`. `gp_to_xmm` selects the direction. used by the cross-
 # domain bit-reinterpret encoder to move bits across the register banks
 fun emit_movd_movq_reg(gp: i32, xmm: i32, w: u8, gp_to_xmm: bool, buf: *enc.ByteBuf) {
-    var mq: isa.Inst;
-    zero_inst(?mq);
+    var mq: isa.Inst = isa.inst_blank();
     mq.opcode = x64.MOVQ;
     mq.size   = w;
     if (gp_to_xmm) {
@@ -3692,8 +3574,7 @@ fun encode_float_cmp(f: *mir.MirFunction, mi: *mir.MirInstr, buf: *enc.ByteBuf) 
 
     # UCOMISS / UCOMISD lhs, rhs  (set CF/ZF/PF); `<` / `<=` reverse the operands so
     # the relation reads as the NaN-false `>` / `>=` of the swapped pair.
-    var ucom: isa.Inst;
-    zero_inst(?ucom);
+    var ucom: isa.Inst = isa.inst_blank();
     ucom.opcode = x64.UCOMISD;
     if (w == 4) { ucom.opcode = x64.UCOMISS; }
     ucom.dst  = isa.make_reg(FLOAT_SCRATCH0, 16);
@@ -3706,8 +3587,7 @@ fun encode_float_cmp(f: *mir.MirFunction, mi: *mir.MirInstr, buf: *enc.ByteBuf) 
     encode_inst(?ucom, buf);
 
     # SETcc dst  (one byte; the NaN-false UNSIGNED condition from the FCC_* code)
-    var setcc: isa.Inst;
-    zero_inst(?setcc);
+    var setcc: isa.Inst = isa.inst_blank();
     setcc.opcode   = float_setcc_opcode(cc);
     setcc.dst      = dst;
     setcc.dst.size = 1;
@@ -3719,8 +3599,7 @@ fun encode_float_cmp(f: *mir.MirFunction, mi: *mir.MirInstr, buf: *enc.ByteBuf) 
     # SETP for `!=` -> PF) - both SETcc read the flags before the combine clobbers
     # them - then AND (`==`: ZF & !PF) or OR (`!=`: !ZF | PF) it into the primary byte.
     if (cc == mir.FCC_EQ || cc == mir.FCC_NE) {
-        var par: isa.Inst;
-        zero_inst(?par);
+        var par: isa.Inst = isa.inst_blank();
         par.opcode   = x64.SETNP;
         if (cc == mir.FCC_NE) { par.opcode = x64.SETP; }
         par.dst      = isa.make_reg(x64.R11, 1);
@@ -3728,8 +3607,7 @@ fun encode_float_cmp(f: *mir.MirFunction, mi: *mir.MirInstr, buf: *enc.ByteBuf) 
         par.size     = 1;
         encode_inst(?par, buf);
 
-        var comb: isa.Inst;
-        zero_inst(?comb);
+        var comb: isa.Inst = isa.inst_blank();
         comb.opcode   = x64.AND;
         if (cc == mir.FCC_NE) { comb.opcode = x64.OR; }
         comb.dst      = dst;
@@ -3740,8 +3618,7 @@ fun encode_float_cmp(f: *mir.MirFunction, mi: *mir.MirInstr, buf: *enc.ByteBuf) 
     }
 
     # MOVZX dst, dst  (zero-extend the byte boolean to the machine word)
-    var movzx: isa.Inst;
-    zero_inst(?movzx);
+    var movzx: isa.Inst = isa.inst_blank();
     movzx.opcode    = x64.MOVZX;
     movzx.dst       = dst;
     movzx.dst.size  = DEFAULT_OPERAND_SIZE;
@@ -3816,8 +3693,7 @@ fun vec_reg(xmm: i32) isa.Operand {
 # src:    the source operand, or a NONE operand for a one-operand form
 fun note_packed(buf: *enc.ByteBuf, opcode: u16, dst: isa.Operand, src: isa.Operand) {
     if (!enc.sink_active(buf)) { ret; }
-    var mi: isa.Inst;
-    zero_inst(?mi);
+    var mi: isa.Inst = isa.inst_blank();
     mi.opcode = opcode;
     mi.dst    = dst;
     mi.src1   = src;
@@ -3834,8 +3710,7 @@ fun note_packed(buf: *enc.ByteBuf, opcode: u16, dst: isa.Operand, src: isa.Opera
 # imm:    the imm8 the form carries
 fun note_packed_imm(buf: *enc.ByteBuf, opcode: u16, dst: isa.Operand, src: isa.Operand, imm: u8) {
     if (!enc.sink_active(buf)) { ret; }
-    var mi: isa.Inst;
-    zero_inst(?mi);
+    var mi: isa.Inst = isa.inst_blank();
     mi.opcode = opcode;
     mi.dst    = dst;
     mi.src1   = src;
@@ -3924,8 +3799,7 @@ fun emit_movups_store(mem: isa.Operand, xmm: i32, buf: *enc.ByteBuf) {
 fun emit_vec_load(op: isa.Operand, xmm: i32, buf: *enc.ByteBuf) R.Result[bool, str] {
     if (op.kind == isa.OPK_REG) { emit_movaps_rr(xmm, op.reg, buf); ret R.ok[bool, str](true); }
     if (op.kind == isa.OPK_MEM) {
-        var ld: isa.Inst;
-        zero_inst(?ld);
+        var ld: isa.Inst = isa.inst_blank();
         ld.opcode = x64.MOVAPS;
         ld.dst    = isa.make_reg(xmm, 16);
         ld.src1   = op;
@@ -3941,8 +3815,7 @@ fun emit_vec_load(op: isa.Operand, xmm: i32, buf: *enc.ByteBuf) R.Result[bool, s
 fun emit_vec_store(dst: isa.Operand, xmm: i32, buf: *enc.ByteBuf) R.Result[bool, str] {
     if (dst.kind == isa.OPK_REG) { emit_movaps_rr(dst.reg, xmm, buf); ret R.ok[bool, str](true); }
     if (dst.kind == isa.OPK_MEM) {
-        var st: isa.Inst;
-        zero_inst(?st);
+        var st: isa.Inst = isa.inst_blank();
         st.opcode = x64.MOVAPS;
         st.dst    = dst;
         st.src1   = isa.make_reg(xmm, 16);
@@ -4140,16 +4013,14 @@ fun encode_vcmp_i64_ordering(dst: isa.Operand, lhs: isa.Operand, rhs: isa.Operan
         # CMP R10, R11  (flags for lhs - rhs)
         emit_gp_inst(x64.CMP, isa.make_reg(x64.R10, 8), isa.make_reg(x64.R11, 8), 8, x64.FLAG_REX_W, buf);
         # SETcc R10b
-        var setb: isa.Inst;
-        zero_inst(?setb);
+        var setb: isa.Inst = isa.inst_blank();
         setb.opcode   = setcc;
         setb.dst      = isa.make_reg(x64.R10, 1);
         setb.dst.size = 1;
         setb.size     = 1;
         encode_inst(?setb, buf);
         # MOVZX R10, R10b  (0/1)  then NEG R10  (0/-1)
-        var mz: isa.Inst;
-        zero_inst(?mz);
+        var mz: isa.Inst = isa.inst_blank();
         mz.opcode    = x64.MOVZX;
         mz.dst       = isa.make_reg(x64.R10, 8);
         mz.dst.size  = DEFAULT_OPERAND_SIZE;
@@ -4170,8 +4041,7 @@ fun encode_vcmp_i64_ordering(dst: isa.Operand, lhs: isa.Operand, rhs: isa.Operan
 
 # build a simple GP instruction `<opcode> dst, src` at `size` bytes and emit it
 fun emit_gp_inst(opcode: u16, dst: isa.Operand, src: isa.Operand, size: u8, flags: u16, buf: *enc.ByteBuf) {
-    var mi: isa.Inst;
-    zero_inst(?mi);
+    var mi: isa.Inst = isa.inst_blank();
     mi.opcode = opcode;
     mi.dst    = dst;
     mi.src1   = src;
@@ -4361,8 +4231,7 @@ fun encode_divide(f: *mir.MirFunction, mi: *mir.MirInstr, buf: *enc.ByteBuf) R.R
 
     # the dividend high-half setup.
     if (signed) {
-        var sext_inst: isa.Inst;
-        zero_inst(?sext_inst);
+        var sext_inst: isa.Inst = isa.inst_blank();
         sext_inst.opcode = x64.CDQ;
         if (w == 2) { sext_inst.opcode = x64.CWD; }
         or (w >= 8) { sext_inst.opcode = x64.CQO; }
@@ -4371,8 +4240,7 @@ fun encode_divide(f: *mir.MirFunction, mi: *mir.MirInstr, buf: *enc.ByteBuf) R.R
     } or {
         # XOR RDX, RDX zeroes the high half for an unsigned divide; a 4-byte XOR
         # clears the full 64-bit register with the shortest encoding.
-        var xr: isa.Inst;
-        zero_inst(?xr);
+        var xr: isa.Inst = isa.inst_blank();
         xr.opcode = x64.XOR;
         xr.dst    = isa.make_reg(x64.RDX, 4);
         xr.src1   = isa.make_reg(x64.RDX, 4);
@@ -4382,8 +4250,7 @@ fun encode_divide(f: *mir.MirFunction, mi: *mir.MirInstr, buf: *enc.ByteBuf) R.R
 
     # the single-operand IDIV / DIV reading the divisor (operand 1). `encode_div`
     # reads the divisor from `src1` and divides the RAX:RDX pair by it.
-    var dv: isa.Inst;
-    zero_inst(?dv);
+    var dv: isa.Inst = isa.inst_blank();
     dv.opcode = x64.DIV;
     if (signed) { dv.opcode = x64.IDIV; }
     dv.src1   = divisor;
@@ -4455,8 +4322,7 @@ fun encode_binary(f: *mir.MirFunction, mi: *mir.MirInstr, buf: *enc.ByteBuf) R.R
     # `mov r, r` when the destination already holds the left operand's register.
     val skip_mov: bool = lhs.kind == isa.OPK_REG && lhs.reg == dst.reg;
     if (!skip_mov) {
-        var mov: isa.Inst;
-        zero_inst(?mov);
+        var mov: isa.Inst = isa.inst_blank();
         mov.opcode = x64.MOV;
         mov.dst    = dst;
         mov.src1   = lhs;
@@ -4466,8 +4332,7 @@ fun encode_binary(f: *mir.MirFunction, mi: *mir.MirInstr, buf: *enc.ByteBuf) R.R
     }
 
     # OP dst, rhs  (the in-place two-address operation: dst = dst OP rhs)
-    var op: isa.Inst;
-    zero_inst(?op);
+    var op: isa.Inst = isa.inst_blank();
     op.opcode = mir_binary_opcode(mi.opcode);
     op.dst    = dst;
     op.src1   = rhs;
@@ -4537,8 +4402,7 @@ fun encode_shift_mir(f: *mir.MirFunction, mi: *mir.MirInstr, buf: *enc.ByteBuf) 
     # redundant `mov r, r` when the destination already holds the value's register.
     val skip_mov: bool = value.kind == isa.OPK_REG && value.reg == dst.reg;
     if (!skip_mov) {
-        var mov: isa.Inst;
-        zero_inst(?mov);
+        var mov: isa.Inst = isa.inst_blank();
         mov.opcode = x64.MOV;
         mov.dst    = dst;
         mov.src1   = value;
@@ -4548,8 +4412,7 @@ fun encode_shift_mir(f: *mir.MirFunction, mi: *mir.MirInstr, buf: *enc.ByteBuf) 
     }
 
     # shift dst, count  (the in-place two-address shift)
-    var sh: isa.Inst;
-    zero_inst(?sh);
+    var sh: isa.Inst = isa.inst_blank();
     sh.opcode = mir_shift_opcode(mi.opcode);
     sh.dst    = dst;
     sh.src1   = count;
@@ -4604,8 +4467,7 @@ fun encode_cbr(st: *enc.EncodeState, f: *mir.MirFunction, fn_base: u32, mi: *mir
     }
 
     # TEST cond, cond  (flag-setting: ZF=1 iff the condition is zero)
-    var test_inst: isa.Inst;
-    zero_inst(?test_inst);
+    var test_inst: isa.Inst = isa.inst_blank();
     test_inst.opcode = x64.TEST;
     test_inst.dst    = cond;
     test_inst.src1   = cond;
@@ -4615,8 +4477,7 @@ fun encode_cbr(st: *enc.EncodeState, f: *mir.MirFunction, fn_base: u32, mi: *mir
 
     # JNE then_block  (taken when the condition is non-zero)
     val jne_start: usize = st.buf.len;
-    var jne: isa.Inst;
-    zero_inst(?jne);
+    var jne: isa.Inst = isa.inst_blank();
     jne.opcode = x64.JNE;
     jne.dst    = isa.make_block_label(then_block);
     jne.size   = DEFAULT_OPERAND_SIZE;
@@ -4632,8 +4493,7 @@ fun encode_cbr(st: *enc.EncodeState, f: *mir.MirFunction, fn_base: u32, mi: *mir
     # falls through to it (issue #1936). the taken edge above always keeps its JNE.
     if (enc.branch_falls_through(st, else_block)) { ret R.ok[bool, str](true); }
     val jmp_start: usize = st.buf.len;
-    var jmp: isa.Inst;
-    zero_inst(?jmp);
+    var jmp: isa.Inst = isa.inst_blank();
     jmp.opcode = x64.JMP;
     jmp.dst    = isa.make_block_label(else_block);
     jmp.size   = DEFAULT_OPERAND_SIZE;
@@ -4692,8 +4552,7 @@ fun encode_fused_cbr(st: *enc.EncodeState, f: *mir.MirFunction, fn_base: u32, mi
 
     # Jcc then_block  (taken when the fused relation holds)
     val jcc_start: usize = st.buf.len;
-    var jcc: isa.Inst;
-    zero_inst(?jcc);
+    var jcc: isa.Inst = isa.inst_blank();
     jcc.opcode = fused_jcc_opcode(mi.opcode);
     jcc.dst    = isa.make_block_label(then_block);
     jcc.size   = DEFAULT_OPERAND_SIZE;
@@ -4713,8 +4572,7 @@ fun encode_fused_cbr(st: *enc.EncodeState, f: *mir.MirFunction, fn_base: u32, mi
         ret R.ok[bool, str](true);
     }
     val jmp_start: usize = st.buf.len;
-    var jmp: isa.Inst;
-    zero_inst(?jmp);
+    var jmp: isa.Inst = isa.inst_blank();
     jmp.opcode = x64.JMP;
     jmp.dst    = isa.make_block_label(else_block);
     jmp.size   = DEFAULT_OPERAND_SIZE;
@@ -4779,15 +4637,13 @@ fun width_flags(width: u8) u16 {
 fun mir_to_inst(f: *mir.MirFunction, mi: *mir.MirInstr, inst: *isa.Inst) R.Result[bool, str] {
     val dwidth: u8 = effective_width(mi.width);
     val swidth: u8 = effective_width(mi.src_width);
+    # reset through the shared constructor rather than field by field: this is the
+    # producer for every MIR-derived instruction, so whatever it leaves unwritten is
+    # what the whole encoder sees
+    @inst         = isa.inst_blank();
     inst.opcode   = concrete_opcode(mi.opcode);
     inst.size     = dwidth;
     inst.flags    = width_flags(mi.width);
-    inst.clobbers = 0;
-    inst.src_line = 0;
-    inst.src_file = nil;
-    inst.dst  = none_operand();
-    inst.src1 = none_operand();
-    inst.src2 = none_operand();
 
     if (mi.operand_count >= 1) {
         val r: R.Result[isa.Operand, str] = mir_to_operand(f, ?mi.operands[0], dwidth);
@@ -4885,7 +4741,7 @@ fun mir_to_operand(f: *mir.MirFunction, op: *mir.MirOperand, width: u8) R.Result
     if (op.kind == mir.MIR_OP_BLOCK) {
         ret R.ok[isa.Operand, str](isa.make_block_label(op.imm::u32));
     }
-    ret R.ok[isa.Operand, str](none_operand());
+    ret R.ok[isa.Operand, str](isa.make_none());
 }
 
 # the frame-pointer offset of the slot a MIR value owns, or
@@ -5368,7 +5224,7 @@ fun x64_to_isa(op: *iasm.Operand, size: u8) isa.Operand {
         if ((op.flags & iasm.AOF_MEM_SYM) != 0) { ret isa.make_mem(-1, 0, -1, 0, size); }
         ret isa.make_mem(op.reg, op.imm::i32, op.index, op.scale, size);
     }
-    ret none_operand();
+    ret isa.make_none();
 }
 
 # build the machine instruction one parsed item denotes
@@ -5376,8 +5232,7 @@ fun x64_to_isa(op: *iasm.Operand, size: u8) isa.Operand {
 # The single place a parsed x86-64 statement becomes an `isa.Inst`, so an inline-asm
 # instruction and a compiler-selected one are the same value taking the same encoder.
 fun x64_build(item: *iasm.Item) isa.Inst {
-    var mi: isa.Inst;
-    zero_inst(?mi);
+    var mi: isa.Inst = isa.inst_blank();
     mi.opcode = item.code::u16;
     var enc_flags: u16 = 0;
     if ((item.flags & X64F_LOCK) != 0) { enc_flags = x64.FLAG_LOCK::u16; }
@@ -5526,23 +5381,6 @@ fun u64_to_dec(n: u64, dst: *u8) usize {
     for (k < len) { dst[k] = tmp[len - 1 - k]; k = k + 1; }
     ret len;
 }
-
-# build an inactive (OPK_NONE) operand with no register references
-fun none_operand() isa.Operand {
-    var op: isa.Operand;
-    op.kind   = isa.OPK_NONE;
-    op.size   = 0;
-    op.reg    = -1;
-    op.imm    = 0;
-    op.base   = -1;
-    op.index  = -1;
-    op.scale  = 0;
-    op.disp   = 0;
-    op.sym_id = 0;
-    op.label  = nil;
-    ret op;
-}
-
 
 # a `{name}` binding inside a memory operand yields an actionable diagnostic
 # rather than a bare "malformed operand": a binding is a stack slot, so the
@@ -5834,8 +5672,7 @@ test "mach.lang.target.isa.x64.encode.encode_imul:imm16_not_imm32" {
     var buf: enc.ByteBuf = enc.buf_init(?alloc);
 
     # imul ax, ax, 0x1234 -> 66 69 C0 34 12 (the 0x66 prefix makes 0x69 take an imm16).
-    var mi: isa.Inst;
-    zero_inst(?mi);
+    var mi: isa.Inst = isa.inst_blank();
     mi.opcode = x64.IMUL;
     mi.dst    = isa.make_reg(x64.RAX, 2);
     mi.src1   = isa.make_imm(0x1234, 2);
@@ -5852,8 +5689,7 @@ test "mach.lang.target.isa.x64.encode.encode_imul:imm16_not_imm32" {
     or (buf.data[4] != 0x12) { bad = 1; }
 
     # a size-1 immediate IMUL has no encoding -- it must emit nothing (loud failure).
-    var mi8: isa.Inst;
-    zero_inst(?mi8);
+    var mi8: isa.Inst = isa.inst_blank();
     mi8.opcode = x64.IMUL;
     mi8.dst    = isa.make_reg(x64.RAX, 1);
     mi8.src1   = isa.make_imm(5, 1);
@@ -5895,8 +5731,7 @@ test "mach.lang.target.isa.x64.encode.encode_movzx:wide_src_uses_mov" {
     var alloc: A.Allocator;
     page.make(?alloc);
     var buf: enc.ByteBuf = enc.buf_init(?alloc);
-    var mi: isa.Inst;
-    zero_inst(?mi);
+    var mi: isa.Inst = isa.inst_blank();
     mi.opcode    = x64.MOVZX;
     mi.dst       = isa.make_reg(x64.RAX, 8);
     mi.src1      = isa.make_reg(x64.RBX, 4);
@@ -5918,8 +5753,7 @@ test "mach.lang.target.isa.x64.encode.encode_mem_operand:rbp_base_disp0" {
     var alloc: A.Allocator;
     page.make(?alloc);
     var buf: enc.ByteBuf = enc.buf_init(?alloc);
-    var mi: isa.Inst;
-    zero_inst(?mi);
+    var mi: isa.Inst = isa.inst_blank();
     mi.opcode = x64.MOV;
     mi.dst    = isa.make_reg(x64.RAX, 8);
     mi.src1   = isa.make_mem(x64.RBP, 0, -1, 0, 8);
@@ -5944,8 +5778,7 @@ test "mach.lang.target.isa.x64.encode.encode_push:imm_boundaries" {
     var bad: i32 = 0;
 
     # case 1: imm8 (127 in -128..127 -> 0x6A form)
-    var m1: isa.Inst;
-    zero_inst(?m1);
+    var m1: isa.Inst = isa.inst_blank();
     m1.opcode = x64.PUSH;
     m1.dst    = isa.make_imm(127, 1);
     m1.size   = 1;
@@ -5956,8 +5789,7 @@ test "mach.lang.target.isa.x64.encode.encode_push:imm_boundaries" {
 
     # case 2: imm32 boundary (0x1000 in signed-imm32 range -> 0x68 form)
     buf.len = 0;
-    var m2: isa.Inst;
-    zero_inst(?m2);
+    var m2: isa.Inst = isa.inst_blank();
     m2.opcode = x64.PUSH;
     m2.dst    = isa.make_imm(0x1000, 4);
     m2.size   = 4;
@@ -5967,8 +5799,7 @@ test "mach.lang.target.isa.x64.encode.encode_push:imm_boundaries" {
 
     # case 3: out-of-range (0x80000000 > INT32_MAX -> rejected, 0 bytes emitted)
     buf.len = 0;
-    var m3: isa.Inst;
-    zero_inst(?m3);
+    var m3: isa.Inst = isa.inst_blank();
     m3.opcode = x64.PUSH;
     m3.dst    = isa.make_imm(0x80000000, 8);
     m3.size   = 8;
@@ -6057,8 +5888,7 @@ test "mach.lang.target.isa.x64.encode.x86_reloc_offset:legalized_disp32" {
     # the trailing four bytes at offset 13 - not the offset-9 site the single
     # pre-legalization instruction implies (the bug this guards: a PC32 reloc landing
     # 4 bytes early, corrupting the encoding and leaving the store pointed at rip+0).
-    var big: isa.Inst;
-    zero_inst(?big);
+    var big: isa.Inst = isa.inst_blank();
     big.opcode   = x64.MOV;
     big.size     = 8;
     big.dst.kind = isa.OPK_MEM;
@@ -6068,8 +5898,7 @@ test "mach.lang.target.isa.x64.encode.x86_reloc_offset:legalized_disp32" {
 
     # an in-range store (`g = 5;`) keeps the C7 form `MOV [rip+disp32], imm32`, whose
     # disp32 precedes a trailing 4-byte immediate (patch site at offset 3).
-    var small: isa.Inst;
-    zero_inst(?small);
+    var small: isa.Inst = isa.inst_blank();
     small.opcode   = x64.MOV;
     small.size     = 8;
     small.dst.kind = isa.OPK_MEM;
@@ -6115,16 +5944,11 @@ test "mach.lang.target.isa.x64.encode.vec:mem_mem_16_stages_xmm14" {
     var alloc: A.Allocator;
     page.make(?alloc);
     var buf: enc.ByteBuf = enc.buf_init(?alloc);
-    var inst: isa.Inst;
-    inst.opcode   = x64.MOV;
-    inst.size     = 16;
-    inst.dst      = isa.make_mem(x64.RBP, -384, -1, 0, 16);
-    inst.src1     = isa.make_mem(x64.RAX, 0, -1, 0, 16);
-    inst.src2.kind = 0;
-    inst.flags    = 0;
-    inst.clobbers = 0;
-    inst.src_line = 0;
-    inst.src_file = nil;
+    var inst: isa.Inst = isa.inst_blank();
+    inst.opcode = x64.MOV;
+    inst.size   = 16;
+    inst.dst    = isa.make_mem(x64.RBP, -384, -1, 0, 16);
+    inst.src1   = isa.make_mem(x64.RAX, 0, -1, 0, 16);
     encode_inst(?inst, ?buf);
     var bad: i32 = 0;
     if (buf.len < 4)          { bad = 1; }


### PR DESCRIPTION
Closes #2215.

`isa.Inst` and `isa.Operand` were maintained by convention at each construction site rather than by one constructor. `var` does not zero, so adding a field was not additive: every site that did not clear the new field left it holding stack residue, on whichever target happened to have written that stack.

## This already happened — one PR ago

#2233 added `Operand.sym_mod`. **Three hand-written clears did not learn about it and shipped to `dev` leaving it undefined:**

| site | cleared | missed |
|---|---|---|
| `isa/x64/encode.mach:5530` `none_operand()` | 9 fields | `sym_mod` |
| `isa/x64/encode.mach:2442` `zero_inst()` | 10 fields × 3 operands | `sym_mod` on all three |
| `isa/arm64/printer.mach:214` `none_operand()` | 9 fields | `sym_mod` |

Latent, not harmless: it survived only because no x86-64 or aarch64 renderer reads `op.sym_mod` yet (aarch64 reads its *private* `Inst.sym_mod`; riscv64 reads the operand's, but builds through `isa.make_*`, so it was never exposed). The next renderer to read it would have found garbage on two targets and correct values on the third.

The issue was filed on a hypothetical. It was not one.

## The root cause was a private constructor

`operand_blank` — the only place an `Operand` is cleared — was **private**. A target that needed an empty operand physically could not reach it, so it hand-rolled the clear. `arm64/printer.mach:216` said exactly this, and deferred the fix because branches were live in the file it would have had to touch:

> `isa` builds each populated operand through its own private blank, but exposes no constructor for the empty one - x86-64 clears `kind` by hand where it needs one. A public `isa.make_none()` would suit both; it is deliberately not added here, since three branches are live in that file.

That is the mechanism that produced all three sites. `make_none()` is now public. `operand_blank` stays private with the reason stated inline: every populated kind already has its own `make_*`, and a caller free to pick an arbitrary kind and size could build a half-formed operand no builder would ever produce.

## What changed

**89 `isa.Inst` construction sites on x86-64** now start from `isa.inst_blank()` — 78 were `var X: isa.Inst; zero_inst(?X);`, 9 cleared by hand, 2 already constructed. `zero_inst()` (40 lines) and x64's `none_operand()` are deleted; `mir_to_inst` — the producer for every MIR-derived instruction — resets through `@inst = isa.inst_blank()` instead of clearing six fields and three operands itself. arm64's `none_operand()` becomes a one-line delegate (the name stays because `arm64/encode.mach` is live under #2236 and holds its only external caller).

Per-target census of what was found:

| ISA | `isa.Inst` sites | hand-rolled `Operand` | state now |
|---|---|---|---|
| x86_64 | 89 | 1 + `zero_inst` | all through `inst_blank` |
| riscv64 | 7 | 0 | already routed via `build_inst` |
| aarch64 | 0 — uses a private `printer.Inst` | 1 (**the `sym_mod` hole**) | fixed |
| mos6502 | 0 | 0 | n/a |
| spirv | 0 | 0 | n/a |
| shared `be/codegen` | 1 | 0 | already routed |

## The test asserts the property, not the current state

`src/lang/target/isa/tests.mach` is a source census, because runtime cannot see this: a test that a constructor returns cleared fields says nothing about the sites that may or may not call it, and re-passes untouched the day one stops.

A record can only be hand-built **from a declaration with no initializer** — that is the only form yielding an object whose fields start undefined. Every other form is a whole-record copy of a constructed value. So forbidding the bare form outside the constructors forbids hand-building outright, **including for fields that do not exist yet**.

The census walks `src/lang/target` and `src/lang/be` and permits exactly four bare declarations, one per record that exists: the two shared constructors, aarch64's private instruction, and the inline-asm parser's operand. That permitted list *is* the census of clearing sites — adding to it should be an argued change, not a convenience. The failure code is the count of offenders. A walk finding zero sites is also a failure, since a census over zero files would otherwise read as a green check.

**Mutation-tested:**

| tree | result |
|---|---|
| as shipped | `1 passed, 0 failed` |
| one x86-64 site reverted to `var ld: isa.Inst;` | `FAIL … (exit 1)` |
| two sites reverted | `FAIL … (exit 2)` |
| restored | `1 passed, 0 failed` |

## Verification

**Byte-identical on all five ISAs.** A pristine `git archive` corpus compiled by the baseline compiler and by this branch's compiler, per target, `--emit obj --profile release`, every object hashed. Re-run in full after merging current `dev` (`afe2f62e`), so the figures below are against the merge, not the branch point:

| | baseline | this branch |
|---|---|---|
| 208 objects × 6 declared targets = 1248 | `15719a86…` | `15719a86…` |
| mos6502 flat image | `05acbc5f…` | `05acbc5f…` |
| spirv module | `05b63aa2…` | `05b63aa2…` |

mos6502 and spirv are not declared in `mach.toml`, so they were driven through scratch projects.

That is a real result rather than a formality: the 9 hand-cleared sites set only `src2.kind = 0` and left that operand's `base` / `index` / `imm` genuinely undefined. They are now `-1 / -1 / 0`. Unchanged output measures the latency the issue asserted rather than assuming it.

**Suites** (run through the from-source compiler, not the PATH seed):
- mach `dev` baseline **857 / 0** → this branch **858 / 0**. The +1 is the census; exactly accounted for.
- mach-std **611 / 0** at `eff1e8e`, verified by `git rev-parse HEAD` against `mach.lock` rather than trusting the clone.

**Three-generation fixpoint:** A (seed-built) `cf58cdd1`, B `7722decb`, C `7722decb` — **B == C**. A ≠ B is the known seed lag and is **pre-existing**: the same two generations on untouched `dev` also differ.

## #2214 closed as superseded, not implemented

Confirmed by reading rather than assuming: `isa.Inst.src3` would have **zero readers**. aarch64 does not use `isa.Inst` at all — #2194 shipped a private `arm64.printer.Inst` that already carries `src3` (filled by `emit_madd`; `ubfm`'s second immediate rides it), riscv64 needs neither field, x86-64 puts the CMPPS imm8 on `src2`, and mos6502/spirv construct no `isa.Inst`. Detail and the pointer to the real remaining work are on #2214.

## Unblocks #2118

Adding fields in bulk across five targets is now safe, and the census keeps it that way — full readiness answer on the issue.
