### PR TITLE
feat(codegen): build wide scalars on a narrow-register target (mos6502)

### DIFF
--- a/src/lang/be/codegen/legalize.mach
+++ b/src/lang/be/codegen/legalize.mach
@@ -630,10 +630,10 @@ fun memory_piece_count(plan: *LanePlan, mi: *mir.MirInstr) R.Result[u32, str] {
     if (mi.operand_count != 2) { ret R.err[u32, str](unsupported_message(mi.opcode, mi.width)); }
     val mx: i32 = mem_operand_index(mi);
     val vx: u32 = 1 - mx::u32;
-    if (!operand_is_lane_ready(plan, ?mi.operands[vx])) {
+    var n: u32 = wide_lane_count(plan, mi);
+    if (!operand_is_lane_ready(plan, ?mi.operands[vx], n)) {
         ret R.err[u32, str](unsupported_message(mi.opcode, mi.width));
     }
-    var n: u32 = wide_lane_count(plan, mi);
     val mem: *mir.MirOperand = ?mi.operands[mx::u32];
     if (base_needs_staging(plan, mem)) {
         val pl: u32 = plan.lane_count[mem.vreg]::u32;
@@ -827,17 +827,21 @@ fun lane_operand(plan: *LanePlan, op: *mir.MirOperand, i: u32) mir.MirOperand {
     ret @op;
 }
 
-# whether one operand can be decomposed into native-width lanes
+# whether one operand can be decomposed into `nl` native-width lanes
 #
 # A lane-split vreg, an immediate, and a physical register each yield a lane
 # operand; anything else (a symbol, a block, a second memory reference) does not.
+# A vreg the plan did NOT split is its own lane 0, so it is ready for a single-lane
+# operation - the shape a narrow access through a wide pointer takes.
 # ---
 # plan: the function's lane assignment
 # op:   the operand to test
+# nl:   the number of lanes the operation spans
 # ret:  true when `lane_operand` yields a meaningful lane for it
-fun operand_is_lane_ready(plan: *LanePlan, op: *mir.MirOperand) bool {
+fun operand_is_lane_ready(plan: *LanePlan, op: *mir.MirOperand, nl: u32) bool {
     if (op.kind == mir.MIR_OP_VREG) {
-        ret op.vreg < plan.orig_count && plan.lane_base[op.vreg] != LANE_NONE;
+        if (op.vreg < plan.orig_count && plan.lane_base[op.vreg] != LANE_NONE) { ret true; }
+        ret nl == 1;
     }
     ret op.kind == mir.MIR_OP_IMM || op.kind == mir.MIR_OP_PREG;
 }
@@ -923,11 +927,11 @@ fun expand_not(alloc: *A.Allocator, plan: *LanePlan, mi: *mir.MirInstr,
 # which is what naming one register for a multi-register value means.
 fun expand_mov(alloc: *A.Allocator, plan: *LanePlan, mi: *mir.MirInstr,
                dst: *mir.MirInstr, cursor: *u32) R.Result[bool, str] {
-    if (mi.operand_count != 2 || !operand_is_lane_ready(plan, ?mi.operands[0]) ||
-        !operand_is_lane_ready(plan, ?mi.operands[1])) {
+    val nl: u32 = wide_lane_count(plan, mi);
+    if (mi.operand_count != 2 || !operand_is_lane_ready(plan, ?mi.operands[0], nl) ||
+        !operand_is_lane_ready(plan, ?mi.operands[1], nl)) {
         ret R.err[bool, str](unsupported_message(mi.opcode, mi.width));
     }
-    val nl: u32 = wide_lane_count(plan, mi);
     val lw: u8  = plan.lane_width;
     var i: u32 = 0;
     for (i < nl) {
@@ -1298,5 +1302,152 @@ test "mach.lang.be.codegen.legalize:rejects_unsupported_wide_op" {
     var mach: Machine = t_mach(1, 2);
     val r: R.Result[bool, str] = legalize_function(?alloc, ?mach, ?f);
     if (!R.is_err[bool, str](r)) { ret 1; }
+    ret 0;
+}
+
+# a wide memory access at a FIXED base - a physical register, the shape the ABI emits
+# for an incoming stack parameter - decomposes into one native access per lane at
+# successive displacements, and a move with a memory operand becomes the load it is
+test "mach.lang.be.codegen.legalize:expands_wide_access_at_a_fixed_base" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+
+    # v0 = [fp + 0] as a width-4 move, exactly `emit_param_slot`'s stack-scalar form.
+    var f: mir.MirFunction;
+    t_vregs(?alloc, ?f, 1);
+    var b: mir.MirBlock;
+    t_block(?alloc, ?b, 1);
+    var ld: [2]mir.MirOperand;
+    ld[0] = mir.op_vreg(0); ld[1] = mir.op_mem_preg(0, 0);
+    t_instr(?alloc, ?b, 0, mir.MIR_MOV, ?ld[0], 2, 4);
+    f.blocks = ?b; f.block_count = 1;
+
+    var mach: Machine = t_mach(1, 2);
+    val r: R.Result[bool, str] = legalize_function(?alloc, ?mach, ?f);
+    if (R.is_err[bool, str](r))  { ret 1; }
+    if (b.instr_count != 4)      { ret 1; }
+
+    var i: u32 = 0;
+    for (i < 4) {
+        if (b.instrs[i].opcode != mir.MIR_LOAD)             { ret 1; }
+        if (b.instrs[i].width != 1)                         { ret 1; }
+        if (b.instrs[i].operands[0].vreg != 1 + i)          { ret 1; }  # v0's byte lanes
+        if (b.instrs[i].operands[1].kind != mir.MIR_OP_MEM) { ret 1; }
+        if (b.instrs[i].operands[1].preg != 0)              { ret 1; }  # still off fp
+        if (b.instrs[i].operands[1].imm != i::i64)          { ret 1; }
+        i = i + 1;
+    }
+    ret 0;
+}
+
+# a wide value placed in a physical register decomposes onto the CONSECUTIVE register
+# run starting there - the hidden result pointer arriving in the convention's pair
+test "mach.lang.be.codegen.legalize:expands_wide_preg_move_onto_consecutive_regs" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+
+    var f: mir.MirFunction;
+    t_vregs(?alloc, ?f, 1);
+    var b: mir.MirBlock;
+    t_block(?alloc, ?b, 1);
+    var mv: [2]mir.MirOperand;
+    mv[0] = mir.op_vreg(0); mv[1] = mir.op_preg(4);
+    t_instr(?alloc, ?b, 0, mir.MIR_MOV, ?mv[0], 2, 2);
+    f.blocks = ?b; f.block_count = 1;
+
+    var mach: Machine = t_mach(1, 2);
+    val r: R.Result[bool, str] = legalize_function(?alloc, ?mach, ?f);
+    if (R.is_err[bool, str](r)) { ret 1; }
+    if (b.instr_count != 2)     { ret 1; }
+    if (b.instrs[0].operands[0].vreg != 1 || b.instrs[0].operands[1].preg != 4) { ret 1; }
+    if (b.instrs[1].operands[0].vreg != 2 || b.instrs[1].operands[1].preg != 5) { ret 1; }
+    ret 0;
+}
+
+# a memory access through a RUNTIME pointer stages the pointer's lanes into the
+# backend's reserved address pair and decomposes at that fixed base
+#
+# Both the wide access (the four bytes of a `u32`) and the NARROW one are covered: the
+# narrow case is not an optimization but a correctness requirement, since the pointer's
+# defining instruction is replaced by its lane moves and a base still naming it would
+# name a vreg nothing defines.
+test "mach.lang.be.codegen.legalize:stages_runtime_pointer_into_the_address_pair" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+
+    # v0 = the incoming pointer (2 lanes); v1 = a wide value; store v1 through v0, then
+    # read one byte back through the same pointer.
+    var f: mir.MirFunction;
+    t_vregs(?alloc, ?f, 3);
+    var b: mir.MirBlock;
+    t_block(?alloc, ?b, 4);
+    var p: [2]mir.MirOperand;
+    p[0] = mir.op_vreg(0); p[1] = mir.op_preg(4);
+    t_instr(?alloc, ?b, 0, mir.MIR_MOV, ?p[0], 2, 2);
+    var v: [2]mir.MirOperand;
+    v[0] = mir.op_vreg(1); v[1] = mir.op_imm(0x01020304);
+    t_instr(?alloc, ?b, 1, mir.MIR_MOV, ?v[0], 2, 4);
+    var stv: [2]mir.MirOperand;
+    stv[0] = mir.op_mem_value(0, 0); stv[1] = mir.op_vreg(1);
+    t_instr(?alloc, ?b, 2, mir.MIR_STORE, ?stv[0], 2, 4);
+    var ldv: [2]mir.MirOperand;
+    ldv[0] = mir.op_vreg(2); ldv[1] = mir.op_mem_value(0, 3);
+    t_instr(?alloc, ?b, 3, mir.MIR_LOAD, ?ldv[0], 2, 1);
+    f.blocks = ?b; f.block_count = 1;
+
+    var mach: Machine = t_mach(1, 2);
+    val r: R.Result[bool, str] = legalize_function(?alloc, ?mach, ?f);
+    if (R.is_err[bool, str](r)) { ret 1; }
+    # 2 pointer lanes + 4 value lanes + (2 staging + 4 stores) + (2 staging + 1 load).
+    if (b.instr_count != 15) { ret 1; }
+
+    # the wide store: staged into the reserved pair, then four byte writes off it.
+    if (b.instrs[6].operands[0].preg != 6) { ret 1; }
+    if (b.instrs[7].operands[0].preg != 7) { ret 1; }
+    var i: u32 = 0;
+    for (i < 4) {
+        val st: *mir.MirInstr = ?b.instrs[8 + i];
+        if (st.opcode != mir.MIR_STORE)             { ret 1; }
+        if (st.width != 1)                          { ret 1; }
+        if (st.operands[0].kind != mir.MIR_OP_MEM)  { ret 1; }
+        if (st.operands[0].vreg != mir.MIR_VREG_NIL){ ret 1; }
+        if (st.operands[0].preg != 6)               { ret 1; }
+        if (st.operands[0].imm != i::i64)           { ret 1; }
+        i = i + 1;
+    }
+    # the narrow load through the same pointer is staged too, keeping its displacement.
+    if (b.instrs[12].operands[0].preg != 6)          { ret 1; }
+    if (b.instrs[13].operands[0].preg != 7)          { ret 1; }
+    if (b.instrs[14].opcode != mir.MIR_LOAD)         { ret 1; }
+    if (b.instrs[14].operands[1].preg != 6)          { ret 1; }
+    if (b.instrs[14].operands[1].imm != 3)           { ret 1; }
+    ret 0;
+}
+
+# a target whose pointer is a machine word never takes the staging path: a narrow
+# access through a value base is not wide, so the function is returned untouched.
+# this is the inertness clause that keeps every wide-native target byte-identical
+test "mach.lang.be.codegen.legalize:value_base_is_inert_on_a_wide_pointer_target" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+
+    var f: mir.MirFunction;
+    t_vregs(?alloc, ?f, 2);
+    var b: mir.MirBlock;
+    t_block(?alloc, ?b, 1);
+    var ops: [2]mir.MirOperand;
+    ops[0] = mir.op_vreg(1); ops[1] = mir.op_mem_value(0, 0);
+    t_instr(?alloc, ?b, 0, mir.MIR_LOAD, ?ops[0], 2, 8);  # width 8 == native
+    f.blocks = ?b; f.block_count = 1;
+
+    val before_ptr:   *mir.MirInstr = b.instrs;
+    val before_vregs: u32           = f.vreg_count;
+
+    var mach: Machine = t_mach(8, 8);
+    val r: R.Result[bool, str] = legalize_function(?alloc, ?mach, ?f);
+    if (R.is_err[bool, str](r))       { ret 1; }
+    if (b.instrs != before_ptr)       { ret 1; }
+    if (b.instr_count != 1)           { ret 1; }
+    if (f.vreg_count != before_vregs) { ret 1; }
     ret 0;
 }

--- a/src/lang/be/codegen/legalize.mach
+++ b/src/lang/be/codegen/legalize.mach
@@ -40,12 +40,24 @@
 # forced into the selection rule engine, because they are width-driven and
 # target-blind - the same expansion serves any ISA that declares a narrow ALU.
 #
+# THE ADDRESS IS A VALUE TOO. A target whose registers are narrower than an address
+# (mos6502: 8-bit registers, 16-bit pointers) cannot hold a runtime pointer in one
+# register either, so a memory access through one is legalized as well - at ANY
+# access width, not only a wide one. The pointer's own lanes are staged into the
+# backend's reserved address-staging pair (`RegMachine.scratch_reg` /
+# `scratch_reg2`, the registers reserved for exactly this address materialization)
+# and the access is then decomposed at that FIXED base, one native-width piece per
+# lane at successive displacements. Leaving a narrow access through such a pointer
+# alone would be a silent miscompile, not merely an unimplemented case: the wide
+# pointer's defining instruction is replaced by its lane moves, so an un-rewritten
+# base would name a vreg nothing defines.
+#
 # UNSUPPORTED WIDE OPERATIONS fail loudly and specifically (never silently), the
 # same discipline the vector path uses for an unimplemented lane op: a wide
 # multiply by a non-constant, any wide divide / remainder, a variable-count wide
-# shift, a wide floating-point op, and a wide memory access through a runtime
-# pointer value (which needs the target's paired-pointer register class) are
-# rejected with a diagnostic naming the operation and width.
+# shift, a wide floating-point op, and any other operation carrying a
+# runtime-pointer memory operand are rejected with a diagnostic naming the
+# operation and width.
 
 use std.types.bool.bool;
 use std.types.bool.false;
@@ -62,6 +74,25 @@ use mach.lang.be.codegen.mir;
 use mach.lang.target.isa;
 use target: mach.lang.target.resolved;
 
+# the machine facts the pass reads, lifted off the resolved target once
+#
+# Keeping them in a record rather than threading the whole `target.Target` is what
+# lets the pass be exercised directly by its own tests, and it names the exact four
+# facts legalization depends on.
+# ---
+# lane_width: the native ALU width in bytes (`model.max_alu_width`); one lane
+# ptr_width:  an address's byte width (`model.pointer_width`)
+# stage_lo:   low half of the backend's reserved address-staging register pair
+#             (`RegMachine.scratch_reg`), the fixed base a runtime-pointer access
+#             is decomposed at
+# stage_hi:   high half of that pair (`RegMachine.scratch_reg2`)
+rec Machine {
+    lane_width: u8;
+    ptr_width:  u8;
+    stage_lo:   i32;
+    stage_hi:   i32;
+}
+
 # per-function legalization plan: the lane assignment for every wide vreg
 #
 # `lane_base[v]` is the first of a wide vreg `v`'s contiguous native-width lane
@@ -74,11 +105,13 @@ use target: mach.lang.target.resolved;
 # lane_count: lane count per original vreg (0 when not wide)
 # orig_count: the function's vreg count before lane vregs were appended
 # lane_width: the native ALU width in bytes (one lane's byte width)
+# mach:       the machine facts the expansions read
 rec LanePlan {
     lane_base:  *u32;
     lane_count: *u8;
     orig_count: u32;
     lane_width: u8;
+    mach:       Machine;
 }
 
 # sentinel "vreg is not wide" in a LanePlan's `lane_base`
@@ -105,9 +138,21 @@ pub fun run(tgt: *target.Target, m: *mir.MirModule) R.Result[bool, str] {
     # already-native so the pass stays a strict no-op rather than dividing by zero.
     if (maw == 0) { ret R.ok[bool, str](true); }
 
+    var mach: Machine;
+    mach.lane_width = maw::u8;
+    mach.ptr_width  = tgt.model.pointer_width::u8;
+    mach.stage_lo   = -1;
+    mach.stage_hi   = -1;
+    # a register machine declares the reserved scratch pair; a whole-module emitter
+    # has no RegMachine at all and never drives a rewrite that needs one.
+    if (tgt.arch != nil) {
+        mach.stage_lo = tgt.arch.scratch_reg;
+        mach.stage_hi = tgt.arch.scratch_reg2;
+    }
+
     var i: u32 = 0;
     for (i < m.function_len) {
-        val res_fn: R.Result[bool, str] = legalize_function(m.alloc, maw::u8, ?m.functions[i]);
+        val res_fn: R.Result[bool, str] = legalize_function(m.alloc, ?mach, ?m.functions[i]);
         if (R.is_err[bool, str](res_fn)) { ret res_fn; }
         i = i + 1;
     }
@@ -121,16 +166,16 @@ pub fun run(tgt: *target.Target, m: *mir.MirModule) R.Result[bool, str] {
 # vector path owns). When this returns false the function is returned untouched -
 # no allocation, no mutation - so a wide-native target's output is byte-identical.
 # ---
-# f:   the MIR function to scan
-# maw: native ALU width in bytes
-# ret: true when some scalar instruction exceeds the native width
-fun function_needs_legalize(f: *mir.MirFunction, maw: u8) bool {
+# f:    the MIR function to scan
+# mach: the machine facts (native lane width, pointer width)
+# ret:  true when some scalar instruction exceeds the native width
+fun function_needs_legalize(f: *mir.MirFunction, mach: *Machine) bool {
     var bi: u32 = 0;
     for (bi < f.block_count) {
         val b: *mir.MirBlock = ?f.blocks[bi];
         var ii: u32 = 0;
         for (ii < b.instr_count) {
-            if (instr_is_wide(f, ?b.instrs[ii], maw)) { ret true; }
+            if (instr_is_wide(f, ?b.instrs[ii], mach)) { ret true; }
             ii = ii + 1;
         }
         bi = bi + 1;
@@ -138,21 +183,48 @@ fun function_needs_legalize(f: *mir.MirFunction, maw: u8) bool {
     ret false;
 }
 
-# whether one SCALAR instruction operates wider than the native ALU
+# whether one SCALAR instruction operates wider than the native ALU, or reaches
+# memory through an address wider than one register
 #
 # A 128-bit vector instruction is never legalized here - it is the vector path's
 # concern (scalarized or selected in the middle end / vector isel). vec_lane is
 # the usual vector marker, but the phi/merge move splice in `mir.lower` carries a
 # 16-byte width WITHOUT stamping vec_lane, so the vreg table's `vector` flag is
 # the authoritative signal a value rides the vector bank; both are honored.
+#
+# The address clause is what makes a NARROW access through a runtime pointer
+# legalizable on a narrow-register target: the pointer is a wide value, so its
+# defining instruction is replaced by lane moves and a base left naming it would
+# name nothing. On every wide-native target the pointer is a machine word, the
+# clause is dead, and the gate is exactly the width test it always was.
 # ---
-# f:   the MIR function (for vreg classes / the vector flag)
-# mi:  the instruction to test
-# maw: native ALU width in bytes
-# ret: true when the instruction is a scalar op exceeding the native width
-fun instr_is_wide(f: *mir.MirFunction, mi: *mir.MirInstr, maw: u8) bool {
+# f:    the MIR function (for vreg classes / the vector flag)
+# mi:   the instruction to test
+# mach: the machine facts (native lane width, pointer width)
+# ret:  true when the instruction needs legalization
+fun instr_is_wide(f: *mir.MirFunction, mi: *mir.MirInstr, mach: *Machine) bool {
     if (instr_is_vector(f, mi)) { ret false; }
-    ret mi.width > maw || mi.src_width > maw;
+    if (mi.width > mach.lane_width || mi.src_width > mach.lane_width) { ret true; }
+    ret mach.ptr_width > mach.lane_width && instr_has_value_base(mi);
+}
+
+# whether the instruction carries a memory operand based on a value vreg
+#
+# A physical-register base (`[fp + off]`) is already a fixed base and needs no
+# rewriting. A frame-slot key rides the same field as a value base and is
+# indistinguishable here; it is admitted conservatively and the expansion, which
+# consults the lane plan, treats it as the fixed base it is.
+# ---
+# mi:  the instruction to test
+# ret: true when some operand is a MEM with a vreg base
+fun instr_has_value_base(mi: *mir.MirInstr) bool {
+    var k: u32 = 0;
+    for (k < mi.operand_count) {
+        val op: *mir.MirOperand = ?mi.operands[k];
+        if (op.kind == mir.MIR_OP_MEM && op.vreg != mir.MIR_VREG_NIL) { ret true; }
+        k = k + 1;
+    }
+    ret false;
 }
 
 # whether an instruction rides the 128-bit vector bank (via its lane descriptor or
@@ -179,14 +251,14 @@ fun instr_is_vector(f: *mir.MirFunction, mi: *mir.MirInstr) bool {
 # each wide instruction replaced by its native-width expansion.
 # ---
 # alloc: backing allocator for lane vregs and rebuilt blocks
-# maw:   native ALU width in bytes
+# mach:  the machine facts the expansions read
 # f:     the MIR function to legalize in place
 # ret:   ok(true) on success, or an error naming an unsupported wide op
-fun legalize_function(alloc: *A.Allocator, maw: u8, f: *mir.MirFunction) R.Result[bool, str] {
-    if (!function_needs_legalize(f, maw)) { ret R.ok[bool, str](true); }
+fun legalize_function(alloc: *A.Allocator, mach: *Machine, f: *mir.MirFunction) R.Result[bool, str] {
+    if (!function_needs_legalize(f, mach)) { ret R.ok[bool, str](true); }
 
     var plan: LanePlan;
-    val res_plan: R.Result[bool, str] = plan_lanes(alloc, maw, f, ?plan);
+    val res_plan: R.Result[bool, str] = plan_lanes(alloc, mach, f, ?plan);
     if (R.is_err[bool, str](res_plan)) { ret res_plan; }
 
     var bi: u32 = 0;
@@ -208,11 +280,12 @@ fun legalize_function(alloc: *A.Allocator, maw: u8, f: *mir.MirFunction) R.Resul
 # arrays are sized to the pre-expansion vreg count.
 # ---
 # alloc: backing allocator for the plan arrays and the lane vregs
-# maw:   native ALU width in bytes
+# mach:  the machine facts (supplies the native lane width)
 # f:     the MIR function
 # out:   receives the populated LanePlan
 # ret:   ok(true) on success, or an allocation error
-fun plan_lanes(alloc: *A.Allocator, maw: u8, f: *mir.MirFunction, out: *LanePlan) R.Result[bool, str] {
+fun plan_lanes(alloc: *A.Allocator, mach: *Machine, f: *mir.MirFunction, out: *LanePlan) R.Result[bool, str] {
+    val maw: u8 = mach.lane_width;
     val n: u32 = f.vreg_count;
     val res_base: R.Result[*u32, str] = A.allocate[u32](alloc, n::usize);
     if (R.is_err[*u32, str](res_base)) { ret R.err[bool, str](R.unwrap_err[*u32, str](res_base)); }
@@ -225,6 +298,7 @@ fun plan_lanes(alloc: *A.Allocator, maw: u8, f: *mir.MirFunction, out: *LanePlan
     out.lane_count = R.unwrap_ok[*u8, str](res_cnt);
     out.orig_count = n;
     out.lane_width = maw;
+    out.mach       = @mach;
 
     var v: u32 = 0;
     for (v < n) {
@@ -351,7 +425,7 @@ fun legalize_block(alloc: *A.Allocator, plan: *LanePlan, f: *mir.MirFunction, b:
     var i: u32 = 0;
     for (i < n) {
         val mi: *mir.MirInstr = ?b.instrs[i];
-        if (instr_is_wide(f, mi, plan.lane_width)) {
+        if (instr_is_wide(f, mi, ?plan.mach)) {
             val res_c: R.Result[u32, str] = expansion_count(plan, mi);
             if (R.is_err[u32, str](res_c)) { ret R.err[bool, str](R.unwrap_err[u32, str](res_c)); }
             total = total + R.unwrap_ok[u32, str](res_c);
@@ -371,7 +445,7 @@ fun legalize_block(alloc: *A.Allocator, plan: *LanePlan, f: *mir.MirFunction, b:
     i = 0;
     for (i < n) {
         val mi: *mir.MirInstr = ?b.instrs[i];
-        if (instr_is_wide(f, mi, plan.lane_width)) {
+        if (instr_is_wide(f, mi, ?plan.mach)) {
             val res_e: R.Result[bool, str] = expand_instr(alloc, plan, f, mi, dst, ?w);
             if (R.is_err[bool, str](res_e)) {
                 # the pieces already written into dst own fresh operand copies; free
@@ -449,6 +523,11 @@ fun expansion_count(plan: *LanePlan, mi: *mir.MirInstr) R.Result[u32, str] {
     val op: mir.MirOpcode = mi.opcode;
     val nl: u32 = wide_lane_count(plan, mi);
 
+    # a memory access - an explicit load / store, or the move form the ABI placement
+    # emits against a stack slot - costs one piece per lane plus the pointer's own
+    # lanes when its base must be staged into the fixed address pair.
+    if (instr_is_memory(mi)) { ret memory_piece_count(plan, mi); }
+
     if (op == mir.MIR_AND || op == mir.MIR_OR || op == mir.MIR_XOR || op == mir.MIR_NOT) {
         ret R.ok[u32, str](nl);
     }
@@ -479,11 +558,160 @@ fun expansion_count(plan: *LanePlan, mi: *mir.MirInstr) R.Result[u32, str] {
 # ---
 # plan: the function's lane assignment
 # mi:   the wide instruction
-# ret:  the number of native-width lanes the operation spans
+# ret:  the number of native-width lanes the operation spans (at least one)
 fun wide_lane_count(plan: *LanePlan, mi: *mir.MirInstr) u32 {
     var wbytes: u8 = mi.width;
     if (mi.src_width > wbytes) { wbytes = mi.src_width; }
-    ret (wbytes / plan.lane_width)::u32;
+    var n: u32 = (wbytes / plan.lane_width)::u32;
+    if (n == 0) { n = 1; }
+    ret n;
+}
+
+# whether the instruction is a memory access this pass decomposes per lane
+#
+# The explicit load / store opcodes, plus the move form the ABI placement emits
+# against a stack slot (`MOV pv <- [fp + off]` for an incoming parameter): a move
+# with a memory operand IS a load or a store, and decomposing it per lane makes it
+# one. A declassify rides the move path for the same reason it does everywhere else.
+# ---
+# mi:  the instruction to test
+# ret: true when the instruction reaches memory
+fun instr_is_memory(mi: *mir.MirInstr) bool {
+    val op: mir.MirOpcode = mi.opcode;
+    if (op == mir.MIR_LOAD || op == mir.MIR_STORE) { ret true; }
+    if (op != mir.MIR_MOV && op != mir.MIR_DECLASSIFY) { ret false; }
+    ret mem_operand_index(mi) >= 0;
+}
+
+# the index of the instruction's single memory operand, or -1 when it has none
+#
+# A load, a store, and a memory-operand move each carry exactly one; the first one
+# found is therefore the one.
+# ---
+# mi:  the instruction to inspect
+# ret: the operand index, or -1
+fun mem_operand_index(mi: *mir.MirInstr) i32 {
+    var k: u32 = 0;
+    for (k < mi.operand_count) {
+        if (mi.operands[k].kind == mir.MIR_OP_MEM) { ret k::i32; }
+        k = k + 1;
+    }
+    ret -1;
+}
+
+# whether a memory operand's base is a runtime pointer that must be staged
+#
+# True exactly when the base names a vreg the plan split into lanes - a pointer
+# wider than one register. A frame-slot key rides the same field but is never
+# defined by a wide instruction, so it is never planned and is correctly reported
+# as the fixed base it is.
+# ---
+# plan: the function's lane assignment
+# mem:  the memory operand
+# ret:  true when the base needs staging into the fixed address pair
+fun base_needs_staging(plan: *LanePlan, mem: *mir.MirOperand) bool {
+    ret mem.vreg != mir.MIR_VREG_NIL && mem.vreg < plan.orig_count &&
+        plan.lane_base[mem.vreg] != LANE_NONE;
+}
+
+# the exact piece count of a memory access's expansion, or a loud error
+#
+# One piece per access lane, plus one per pointer lane when the base is a runtime
+# pointer that must be staged into the fixed address pair. Rejects the shapes the
+# expansion cannot realize before any block is rebuilt: a value operand that is
+# neither a lane-split vreg, an immediate, nor a physical register, and a pointer
+# whose lane count does not match the two-register staging pair the backend
+# reserves.
+# ---
+# plan: the function's lane assignment
+# mi:   the memory instruction
+# ret:  the exact piece count, or an error naming the unsupported shape
+fun memory_piece_count(plan: *LanePlan, mi: *mir.MirInstr) R.Result[u32, str] {
+    if (mi.operand_count != 2) { ret R.err[u32, str](unsupported_message(mi.opcode, mi.width)); }
+    val mx: i32 = mem_operand_index(mi);
+    val vx: u32 = 1 - mx::u32;
+    if (!operand_is_lane_ready(plan, ?mi.operands[vx])) {
+        ret R.err[u32, str](unsupported_message(mi.opcode, mi.width));
+    }
+    var n: u32 = wide_lane_count(plan, mi);
+    val mem: *mir.MirOperand = ?mi.operands[mx::u32];
+    if (base_needs_staging(plan, mem)) {
+        val pl: u32 = plan.lane_count[mem.vreg]::u32;
+        if (pl != 2 || plan.mach.stage_lo < 0 || plan.mach.stage_hi < 0) {
+            ret R.err[u32, str]("legalize: a runtime pointer needs a two-register address-staging pair this target does not reserve");
+        }
+        n = n + pl;
+    }
+    ret R.ok[u32, str](n);
+}
+
+# expand a memory access into per-lane native-width accesses at a fixed base
+#
+# Stages a runtime-pointer base into the backend's reserved address pair first (one
+# native move per pointer lane), then emits one access per value lane at successive
+# displacements off that fixed base. A base that is already fixed - a physical
+# register or a frame-slot key - is used directly and only the displacement walks.
+# The pieces are always the explicit `MIR_LOAD` / `MIR_STORE` opcodes even when the
+# source was a memory-operand move, so a backend that has decomposed its addressing
+# sees one memory form rather than two.
+# ---
+# alloc:  backing allocator for piece operand arrays
+# plan:   the function's lane assignment
+# mi:     the memory instruction to expand
+# dst:    the rebuilt instruction array
+# cursor: next write index into `dst`; advanced past the emitted pieces
+# ret:    ok(true) on success, or an error naming an unsupported shape
+fun expand_memory(alloc: *A.Allocator, plan: *LanePlan, mi: *mir.MirInstr,
+                  dst: *mir.MirInstr, cursor: *u32) R.Result[bool, str] {
+    val rc: R.Result[u32, str] = memory_piece_count(plan, mi);
+    if (R.is_err[u32, str](rc)) { ret R.err[bool, str](R.unwrap_err[u32, str](rc)); }
+
+    val mx:  u32 = mem_operand_index(mi)::u32;
+    val vx:  u32 = 1 - mx;
+    val lw:  u8  = plan.lane_width;
+    val nl:  u32 = wide_lane_count(plan, mi);
+    val is_store: bool = mx == 0;
+
+    var base: mir.MirOperand = mi.operands[mx];
+    if (base_needs_staging(plan, ?base)) {
+        # stage the pointer's lanes into the reserved address pair, low half first,
+        # so the accesses below read one fixed base the backend knows how to reach.
+        val lo: u32 = plan.lane_base[base.vreg];
+        val r1: R.Result[bool, str] = emit_stage_move(alloc, dst, cursor, mi, plan.mach.stage_lo, lo, lw);
+        if (R.is_err[bool, str](r1)) { ret r1; }
+        val r2: R.Result[bool, str] = emit_stage_move(alloc, dst, cursor, mi, plan.mach.stage_hi, lo + 1, lw);
+        if (R.is_err[bool, str](r2)) { ret r2; }
+        base = mir.op_mem_preg(plan.mach.stage_lo::u32, base.imm);
+    }
+
+    var i: u32 = 0;
+    for (i < nl) {
+        var mem: mir.MirOperand = base;
+        mem.imm = base.imm + (i * lw::u32)::i64;
+        var ops: [2]mir.MirOperand;
+        var opcode: mir.MirOpcode = mir.MIR_LOAD;
+        if (is_store) {
+            opcode = mir.MIR_STORE;
+            ops[0] = mem;
+            ops[1] = lane_operand(plan, ?mi.operands[vx], i);
+        } or {
+            ops[0] = lane_operand(plan, ?mi.operands[vx], i);
+            ops[1] = mem;
+        }
+        val r: R.Result[bool, str] = emit_piece(alloc, dst, cursor, mi, opcode, ?ops[0], 2, lw);
+        if (R.is_err[bool, str](r)) { ret r; }
+        i = i + 1;
+    }
+    ret R.ok[bool, str](true);
+}
+
+# emit one `MOV preg <- lane` staging move of a pointer lane into the fixed pair
+fun emit_stage_move(alloc: *A.Allocator, dst: *mir.MirInstr, cursor: *u32, src: *mir.MirInstr,
+                    preg: i32, lane: u32, lw: u8) R.Result[bool, str] {
+    var ops: [2]mir.MirOperand;
+    ops[0] = mir.op_preg(preg::u32);
+    ops[1] = mir.op_vreg(lane);
+    ret emit_piece(alloc, dst, cursor, src, mir.MIR_MOV, ?ops[0], 2, lw);
 }
 
 # expand one wide instruction into its native-width lane sequence in `dst`
@@ -502,6 +730,9 @@ fun expand_instr(alloc: *A.Allocator, plan: *LanePlan, f: *mir.MirFunction, mi: 
                  dst: *mir.MirInstr, cursor: *u32) R.Result[bool, str] {
     val op: mir.MirOpcode = mi.opcode;
 
+    if (instr_is_memory(mi)) {
+        ret expand_memory(alloc, plan, mi, dst, cursor);
+    }
     if (op == mir.MIR_AND || op == mir.MIR_OR || op == mir.MIR_XOR) {
         ret expand_bitwise(alloc, plan, mi, dst, cursor);
     }
@@ -571,8 +802,11 @@ fun emit_piece(alloc: *A.Allocator, dst: *mir.MirInstr, cursor: *u32, src: *mir.
 # the native-width operand for lane `i` of a wide operation's operand
 #
 # A wide VREG operand yields its `i`-th lane vreg; an immediate yields its `i`-th
-# native-width byte group. Only these two kinds reach a wide integer ALU op after
-# lowering; a caller validates that before expanding.
+# native-width byte group; a PHYSICAL register yields the `i`-th register of the
+# consecutive run starting at it - a wide value placed in the register file occupies
+# consecutive register ids from its named base, which is what an ABI naming one
+# register for a multi-register value means (mos6502's `PTR_LO` names the zero-page
+# pair `PTR_LO` / `PTR_LO + 1`).
 # ---
 # plan: the function's lane assignment
 # op:   the wide operand
@@ -585,9 +819,27 @@ fun lane_operand(plan: *LanePlan, op: *mir.MirOperand, i: u32) mir.MirOperand {
     if (op.kind == mir.MIR_OP_IMM) {
         ret mir.op_imm(imm_lane(op.imm, i, plan.lane_width));
     }
+    if (op.kind == mir.MIR_OP_PREG) {
+        ret mir.op_preg(op.preg + i);
+    }
     # a native-width vreg (lane count 1) rides lane 0 directly; a caller only asks
     # for lane 0 in that case.
     ret @op;
+}
+
+# whether one operand can be decomposed into native-width lanes
+#
+# A lane-split vreg, an immediate, and a physical register each yield a lane
+# operand; anything else (a symbol, a block, a second memory reference) does not.
+# ---
+# plan: the function's lane assignment
+# op:   the operand to test
+# ret:  true when `lane_operand` yields a meaningful lane for it
+fun operand_is_lane_ready(plan: *LanePlan, op: *mir.MirOperand) bool {
+    if (op.kind == mir.MIR_OP_VREG) {
+        ret op.vreg < plan.orig_count && plan.lane_base[op.vreg] != LANE_NONE;
+    }
+    ret op.kind == mir.MIR_OP_IMM || op.kind == mir.MIR_OP_PREG;
 }
 
 # the `i`-th native-width byte group of an immediate, zero-filled above the value
@@ -664,13 +916,15 @@ fun expand_not(alloc: *A.Allocator, plan: *LanePlan, mi: *mir.MirInstr,
 }
 
 # expand a wide register / immediate copy into one native move per lane
+#
+# A precolored physical-register operand is an ABI placement of a wide value - the
+# hidden result-storage pointer arriving in, or returning through, a register the
+# convention names. It decomposes onto the consecutive register run starting there,
+# which is what naming one register for a multi-register value means.
 fun expand_mov(alloc: *A.Allocator, plan: *LanePlan, mi: *mir.MirInstr,
                dst: *mir.MirInstr, cursor: *u32) R.Result[bool, str] {
-    # a wide MOV with a precolored physical-register operand is an ABI register
-    # placement of a wide value, which needs the target's paired-register class;
-    # the mos6502 ABI passes wide values in memory, so this should not arise.
-    if (mi.operand_count != 2 || !operands_are_lane_ready(plan, mi, 1) ||
-        mi.operands[0].kind != mir.MIR_OP_VREG || plan.lane_base[mi.operands[0].vreg] == LANE_NONE) {
+    if (mi.operand_count != 2 || !operand_is_lane_ready(plan, ?mi.operands[0]) ||
+        !operand_is_lane_ready(plan, ?mi.operands[1])) {
         ret R.err[bool, str](unsupported_message(mi.opcode, mi.width));
     }
     val nl: u32 = wide_lane_count(plan, mi);
@@ -888,9 +1142,23 @@ fun unsupported_message(op: mir.MirOpcode, width: u8) str {
         ret "legalize: wide shift is not yet legalized on this target";
     }
     if (op == mir.MIR_LOAD || op == mir.MIR_STORE) {
-        ret "legalize: wide memory access is not yet legalized on this target";
+        ret "legalize: wide memory access through an unsupported operand shape on this target";
+    }
+    if (op == mir.MIR_GEP) {
+        ret "legalize: address arithmetic on a pointer wider than one register is not yet legalized on this target";
     }
     ret "legalize: operation wider than the target ALU is unsupported";
+}
+
+# test-only: the machine facts of a target with `maw`-byte lanes, a machine-word
+# pointer, and a two-register address-staging pair at ids 6 / 7 (the mos6502 shape)
+fun t_mach(maw: u8, ptr: u8) Machine {
+    var m: Machine;
+    m.lane_width = maw;
+    m.ptr_width  = ptr;
+    m.stage_lo   = 6;
+    m.stage_hi   = 7;
+    ret m;
 }
 
 # test-only: heap vreg table of `n` general-purpose vregs
@@ -954,7 +1222,8 @@ test "mach.lang.be.codegen.legalize:inert_on_native_width" {
     val before_count: u32           = b.instr_count;
     val before_vregs: u32           = f.vreg_count;
 
-    val r: R.Result[bool, str] = legalize_function(?alloc, 8, ?f);
+    var mach: Machine = t_mach(8, 8);
+    val r: R.Result[bool, str] = legalize_function(?alloc, ?mach, ?f);
     if (R.is_err[bool, str](r))         { ret 1; }
     if (b.instrs != before_ptr)         { ret 1; }  # not reallocated
     if (b.instr_count != before_count)  { ret 1; }  # not rewritten
@@ -986,7 +1255,8 @@ test "mach.lang.be.codegen.legalize:expands_wide_add_carry_chain" {
     t_instr(?alloc, ?b, 2, mir.MIR_ADD, ?ad[0], 3, 2);
     f.blocks = ?b; f.block_count = 1;
 
-    val r: R.Result[bool, str] = legalize_function(?alloc, 1, ?f);
+    var mach: Machine = t_mach(1, 2);
+    val r: R.Result[bool, str] = legalize_function(?alloc, ?mach, ?f);
     if (R.is_err[bool, str](r)) { ret 1; }
 
     # lanes are assigned in definition order (v1 -> v3,v4; v2 -> v5,v6; v0 -> v7,v8),
@@ -1025,7 +1295,8 @@ test "mach.lang.be.codegen.legalize:rejects_unsupported_wide_op" {
     t_instr(?alloc, ?b, 0, mir.MIR_DIV_U, ?ops[0], 3, 2);  # wide divide, unsupported
     f.blocks = ?b; f.block_count = 1;
 
-    val r: R.Result[bool, str] = legalize_function(?alloc, 1, ?f);
+    var mach: Machine = t_mach(1, 2);
+    val r: R.Result[bool, str] = legalize_function(?alloc, ?mach, ?f);
     if (!R.is_err[bool, str](r)) { ret 1; }
     ret 0;
 }

--- a/src/lang/be/codegen/legalize.mach
+++ b/src/lang/be/codegen/legalize.mach
@@ -1148,8 +1148,8 @@ fun unsupported_message(op: mir.MirOpcode, width: u8) str {
     if (op == mir.MIR_LOAD || op == mir.MIR_STORE) {
         ret "legalize: wide memory access through an unsupported operand shape on this target";
     }
-    if (op == mir.MIR_GEP) {
-        ret "legalize: address arithmetic on a pointer wider than one register is not yet legalized on this target";
+    if (op == mir.MIR_GEP || op == mir.MIR_ALLOCA) {
+        ret "legalize: materializing an address wider than one register is not yet legalized on this target";
     }
     ret "legalize: operation wider than the target ALU is unsupported";
 }

--- a/src/lang/be/codegen/mir/abi.mach
+++ b/src/lang/be/codegen/mir/abi.mach
@@ -884,8 +884,8 @@ pub fun lower_call(ctx: *context.LowerCtx, mb: *mir.MirBlock, inst: *instruction
         # already reserved the GP slot in `gp_used`.
         if (sret_ptr != mir.MIR_VREG_NIL) {
             val sret_reg: i32 = ctx.tgt.abi.indirect_result_reg;
-            val pre: R.Result[bool, str] = context.emit_mov(ctx, mb,
-                mir.op_preg(sret_reg::u32), mir.op_vreg(sret_ptr));
+            val pre: R.Result[bool, str] = context.emit_mov_w(ctx, mb,
+                mir.op_preg(sret_reg::u32), mir.op_vreg(sret_ptr), ptr_move_width(ctx));
             if (R.is_err[bool, str](pre)) {
                 sig_layout_free(ctx, ?layout);
                 ret pre;
@@ -1227,8 +1227,11 @@ fun emit_arg_slot(ctx: *context.LowerCtx, mb: *mir.MirBlock, slot: abi.ParamSlot
         }
         # the outgoing scalar argument is stored at `[sp + stack_off]`; the stack
         # pointer is fixed after the prologue and points at the base of the outgoing
-        # region, so the store lands in the slot frame.run reserved for it.
-        ret context.emit_store_to(ctx, mb, mir.op_mem_preg(sp, stack_off), argop);
+        # region, so the store lands in the slot frame.run reserved for it. the write
+        # is the scalar's own width when that exceeds the machine word (the read twin
+        # in `emit_param_slot`), so an 8-bit target passes all of a wide argument.
+        ret context.emit_store_to_w(ctx, mb, mir.op_mem_preg(sp, stack_off), argop,
+                                    scalar_mem_move_width(ctx, size));
     }
     if (slot.class == abi.CLASS_BYREF) {
         # the aggregate is passed by hidden pointer; move its address into the
@@ -1236,7 +1239,7 @@ fun emit_arg_slot(ctx: *context.LowerCtx, mb: *mir.MirBlock, slot: abi.ParamSlot
         var base: u32 = mir.MIR_VREG_NIL;
         val ar: R.Result[bool, str] = context.addr_to_vreg(ctx, mb, argop, ?base);
         if (R.is_err[bool, str](ar)) { ret ar; }
-        ret context.emit_mov(ctx, mb, mir.op_preg(slot.reg::u32), mir.op_vreg(base));
+        ret context.emit_mov_w(ctx, mb, mir.op_preg(slot.reg::u32), mir.op_vreg(base), ptr_move_width(ctx));
     }
     if (is_aggr) {
         # register / register-plus-stack aggregate: place each chunk from the
@@ -1333,13 +1336,52 @@ fun capture_slot_reg(ctx: *context.LowerCtx, mb: *mir.MirBlock, dst: u32, slot: 
 # register. a 32-bit value rides a width-4 move so a backend can re-extend it to the
 # register width by its own convention -- RV64 lp64 holds a 32-bit register
 # sign-extended, so a directly materialized i32 constant must be re-signed there, and
-# the carried width is what lets it. every other size keeps the full gpr-width move:
-# a 64-bit value / pointer is already register-width, and narrowing below 32 bits
-# would leave a target's upper register bits unspecified (an x86 `mov al` does not
-# clear them). value-equivalent on x86 / arm64, where a 32-bit move zero-extends
+# the carried width is what lets it. a scalar WIDER than the machine word rides its
+# own size: on a target whose register is narrower than a scalar (the 8-bit mos6502)
+# the machine word would truncate the value, and the carried width is what the width
+# legalizer splits into register-sized lanes. every other size keeps the full
+# gpr-width move: a 64-bit value / pointer is already register-width, and narrowing
+# below 32 bits would leave a target's upper register bits unspecified (an x86
+# `mov al` does not clear them). value-equivalent on x86 / arm64, where a 32-bit move
+# zero-extends; inert on every wide-native target, whose widest scalar is the machine
+# word
 fun scalar_reg_move_width(ctx: *context.LowerCtx, size: u64) u8 {
     if (size == 4) { ret 4; }
+    if (size > ctx.tgt.model.gpr_width::u64) { ret size::u8; }
     ret ctx.tgt.model.gpr_width::u8;
+}
+
+# the move width for reading / writing a scalar in its incoming / outgoing STACK
+# argument slot
+#
+# The memory twin of `scalar_reg_move_width`, and it deliberately lacks that
+# function's 32-bit special case: a stack slot is not a register, so nothing has to
+# re-extend it and the machine-word access every wide-native target already emits is
+# preserved exactly. The one rule it adds is the same: a scalar wider than the machine
+# word is accessed at its own size, so an 8-bit target reads all four bytes of a `u32`
+# stack parameter instead of its low byte.
+# ---
+# ctx:  the active lowering context (supplies the machine word)
+# size: the scalar's byte size
+# ret:  the access width in bytes
+fun scalar_mem_move_width(ctx: *context.LowerCtx, size: u64) u8 {
+    if (size > ctx.tgt.model.gpr_width::u64) { ret size::u8; }
+    ret ctx.tgt.model.gpr_width::u8;
+}
+
+# the move width for placing a hidden POINTER -- an sret result-storage address, a
+# by-reference aggregate address -- into its register or stack slot
+#
+# A pointer is `pointer_width` bytes, which equals the machine word on every
+# wide-native target and exceeds it on a target whose registers are narrower than an
+# address (mos6502's 8-bit registers, 16-bit addresses). Carrying the pointer's own
+# width is what keeps the placement from truncating the address there, and what the
+# width legalizer splits into register-sized lanes.
+# ---
+# ctx: the active lowering context (supplies the pointer width)
+# ret: the pointer move width in bytes
+fun ptr_move_width(ctx: *context.LowerCtx) u8 {
+    ret ctx.tgt.model.pointer_width::u8;
 }
 
 # grow the function's reserved outgoing-argument region to cover one call's footprint
@@ -1425,7 +1467,8 @@ pub fun lower_params(ctx: *context.LowerCtx, mb: *mir.MirBlock) R.Result[bool, s
             ret R.err[bool, str](R.unwrap_err[u32, str](svr));
         }
         val sv: u32 = R.unwrap_ok[u32, str](svr);
-        val mv: R.Result[bool, str] = context.emit_mov(ctx, mb, mir.op_vreg(sv), mir.op_preg(sret_reg::u32));
+        val mv: R.Result[bool, str] = context.emit_mov_w(ctx, mb, mir.op_vreg(sv), mir.op_preg(sret_reg::u32),
+                                                         ptr_move_width(ctx));
         if (R.is_err[bool, str](mv)) {
             sig_layout_free(ctx, ?layout);
             ret mv;
@@ -1499,7 +1542,8 @@ fun emit_param_slot(ctx: *context.LowerCtx, mb: *mir.MirBlock, slot: abi.ParamSl
         # pointer into this stack slot; load it so `pv` is the aggregate's address,
         # matching the register BYREF parameter form.
         val fp: u32 = ctx.tgt.model.frame_ptr_reg::u32;
-        ret context.emit_mov(ctx, mb, mir.op_vreg(pv), mir.op_mem_preg(fp, arg_base + stack_off));
+        ret context.emit_mov_w(ctx, mb, mir.op_vreg(pv), mir.op_mem_preg(fp, arg_base + stack_off),
+                               ptr_move_width(ctx));
     }
     if (slot.class == abi.CLASS_STACK) {
         val fp: u32 = ctx.tgt.model.frame_ptr_reg::u32;
@@ -1510,10 +1554,13 @@ fun emit_param_slot(ctx: *context.LowerCtx, mb: *mir.MirBlock, slot: abi.ParamSl
         }
         # a scalar stack argument lives above the return address and saved frame
         # pointer, addressed through the physical frame pointer at the running offset.
-        ret context.emit_mov(ctx, mb, mir.op_vreg(pv), mir.op_mem_preg(fp, arg_base + stack_off));
+        # the read is the scalar's own width when that exceeds the machine word, so an
+        # 8-bit target loads all of a wide parameter rather than its low byte.
+        ret context.emit_mov_w(ctx, mb, mir.op_vreg(pv), mir.op_mem_preg(fp, arg_base + stack_off),
+                               scalar_mem_move_width(ctx, size));
     }
     if (slot.class == abi.CLASS_BYREF) {
-        ret context.emit_mov(ctx, mb, mir.op_vreg(pv), mir.op_preg(slot.reg::u32));
+        ret context.emit_mov_w(ctx, mb, mir.op_vreg(pv), mir.op_preg(slot.reg::u32), ptr_move_width(ctx));
     }
     if (is_aggr) {
         # register / register-plus-stack aggregate: materialize a spill slot keyed on
@@ -1661,7 +1708,8 @@ pub fun lower_ret(ctx: *context.LowerCtx, mb: *mir.MirBlock, inst: *instruction.
             val sr: R.Result[bool, str] = context.emit_store_to_w(ctx, mb, mir.op_mem_value(ctx.sret_vreg, 0), rvop, rsz::u8);
             if (R.is_err[bool, str](sr)) { ret sr; }
         }
-        val mr: R.Result[bool, str] = context.emit_mov(ctx, mb, mir.op_preg(slot.reg::u32), mir.op_vreg(ctx.sret_vreg));
+        val mr: R.Result[bool, str] = context.emit_mov_w(ctx, mb, mir.op_preg(slot.reg::u32),
+                                                         mir.op_vreg(ctx.sret_vreg), ptr_move_width(ctx));
         if (R.is_err[bool, str](mr)) { ret mr; }
     } or (rag) {
         # aggregate return by address: load each register chunk from the aggregate's

--- a/src/lang/be/codegen/mir/abi.mach
+++ b/src/lang/be/codegen/mir/abi.mach
@@ -1231,7 +1231,7 @@ fun emit_arg_slot(ctx: *context.LowerCtx, mb: *mir.MirBlock, slot: abi.ParamSlot
         # is the scalar's own width when that exceeds the machine word (the read twin
         # in `emit_param_slot`), so an 8-bit target passes all of a wide argument.
         ret context.emit_store_to_w(ctx, mb, mir.op_mem_preg(sp, stack_off), argop,
-                                    scalar_mem_move_width(ctx, size));
+                                    scalar_mem_move_width(ctx.tgt.model.gpr_width, size));
     }
     if (slot.class == abi.CLASS_BYREF) {
         # the aggregate is passed by hidden pointer; move its address into the
@@ -1270,7 +1270,7 @@ fun emit_arg_slot(ctx: *context.LowerCtx, mb: *mir.MirBlock, slot: abi.ParamSlot
     # single GP register scalar argument. a 32-bit value rides a width-4 move so the
     # backend re-extends it to the register width by its own convention (RV64 lp64
     # sign-extends a 32-bit register).
-    ret context.emit_mov_w(ctx, mb, mir.op_preg(slot.reg::u32), argop, scalar_reg_move_width(ctx, size));
+    ret context.emit_mov_w(ctx, mb, mir.op_preg(slot.reg::u32), argop, scalar_reg_move_width(ctx.tgt.model.gpr_width, size));
 }
 
 # store a register-resident vector to a fresh 16-byte-aligned frame temporary and
@@ -1345,10 +1345,14 @@ fun capture_slot_reg(ctx: *context.LowerCtx, mb: *mir.MirBlock, dst: u32, slot: 
 # `mov al` does not clear them). value-equivalent on x86 / arm64, where a 32-bit move
 # zero-extends; inert on every wide-native target, whose widest scalar is the machine
 # word
-fun scalar_reg_move_width(ctx: *context.LowerCtx, size: u64) u8 {
+# ---
+# gpr_width: the target's machine word in bytes
+# size:      the scalar's byte size
+# ret:       the move width in bytes
+fun scalar_reg_move_width(gpr_width: u32, size: u64) u8 {
     if (size == 4) { ret 4; }
-    if (size > ctx.tgt.model.gpr_width::u64) { ret size::u8; }
-    ret ctx.tgt.model.gpr_width::u8;
+    if (size > gpr_width::u64) { ret size::u8; }
+    ret gpr_width::u8;
 }
 
 # the move width for reading / writing a scalar in its incoming / outgoing STACK
@@ -1361,12 +1365,12 @@ fun scalar_reg_move_width(ctx: *context.LowerCtx, size: u64) u8 {
 # word is accessed at its own size, so an 8-bit target reads all four bytes of a `u32`
 # stack parameter instead of its low byte.
 # ---
-# ctx:  the active lowering context (supplies the machine word)
-# size: the scalar's byte size
-# ret:  the access width in bytes
-fun scalar_mem_move_width(ctx: *context.LowerCtx, size: u64) u8 {
-    if (size > ctx.tgt.model.gpr_width::u64) { ret size::u8; }
-    ret ctx.tgt.model.gpr_width::u8;
+# gpr_width: the target's machine word in bytes
+# size:      the scalar's byte size
+# ret:       the access width in bytes
+fun scalar_mem_move_width(gpr_width: u32, size: u64) u8 {
+    if (size > gpr_width::u64) { ret size::u8; }
+    ret gpr_width::u8;
 }
 
 # the move width for placing a hidden POINTER -- an sret result-storage address, a
@@ -1557,7 +1561,7 @@ fun emit_param_slot(ctx: *context.LowerCtx, mb: *mir.MirBlock, slot: abi.ParamSl
         # the read is the scalar's own width when that exceeds the machine word, so an
         # 8-bit target loads all of a wide parameter rather than its low byte.
         ret context.emit_mov_w(ctx, mb, mir.op_vreg(pv), mir.op_mem_preg(fp, arg_base + stack_off),
-                               scalar_mem_move_width(ctx, size));
+                               scalar_mem_move_width(ctx.tgt.model.gpr_width, size));
     }
     if (slot.class == abi.CLASS_BYREF) {
         ret context.emit_mov_w(ctx, mb, mir.op_vreg(pv), mir.op_preg(slot.reg::u32), ptr_move_width(ctx));
@@ -1743,7 +1747,7 @@ pub fun lower_ret(ctx: *context.LowerCtx, mb: *mir.MirBlock, inst: *instruction.
         # scalar GP return: a 32-bit value rides a width-4 move so the backend
         # re-extends it to the register width by its own convention (RV64 lp64
         # sign-extends a 32-bit register).
-        val mr: R.Result[bool, str] = context.emit_mov_w(ctx, mb, mir.op_preg(slot.reg::u32), rvop, scalar_reg_move_width(ctx, rsz));
+        val mr: R.Result[bool, str] = context.emit_mov_w(ctx, mb, mir.op_preg(slot.reg::u32), rvop, scalar_reg_move_width(ctx.tgt.model.gpr_width, rsz));
         if (R.is_err[bool, str](mr)) { ret mr; }
     }
 
@@ -1767,6 +1771,37 @@ fun emit_bare_ret(ctx: *context.LowerCtx, mb: *mir.MirBlock) R.Result[bool, str]
     mi.width         = ctx.tgt.model.gpr_width::u8;
     mi.src_width     = ctx.tgt.model.gpr_width::u8;
     ret context.push_instr(ctx, mb, mi);
+}
+
+# a scalar placement carries the value's own width once it exceeds the machine word
+#
+# The register and memory sides of the same rule, and the reason `fun f(v: u32) u32`
+# could not build for an 8-bit target: every placement moved a machine word, so a 4-byte
+# stack parameter read one byte. Both halves are pinned at an 8-byte machine word too,
+# where the rule is dead and the widths are exactly what they always were - that column
+# is the byte-identity of every wide-native target.
+test "mach.lang.be.codegen.mir.abi:scalar_move_widths" {
+    # an 8-byte machine word: no scalar exceeds it, so only the 32-bit re-extension
+    # case moves the register width and the memory side is the machine word throughout.
+    if (scalar_reg_move_width(8, 1) != 8) { ret 1; }
+    if (scalar_reg_move_width(8, 2) != 8) { ret 1; }
+    if (scalar_reg_move_width(8, 4) != 4) { ret 1; }
+    if (scalar_reg_move_width(8, 8) != 8) { ret 1; }
+    if (scalar_mem_move_width(8, 1) != 8) { ret 1; }
+    if (scalar_mem_move_width(8, 4) != 8) { ret 1; }
+    if (scalar_mem_move_width(8, 8) != 8) { ret 1; }
+
+    # a 1-byte machine word: every wider scalar carries its own size, so the width
+    # legalizer downstream sees the whole value rather than its low byte.
+    if (scalar_reg_move_width(1, 1) != 1) { ret 1; }
+    if (scalar_reg_move_width(1, 2) != 2) { ret 1; }
+    if (scalar_reg_move_width(1, 4) != 4) { ret 1; }
+    if (scalar_reg_move_width(1, 8) != 8) { ret 1; }
+    if (scalar_mem_move_width(1, 1) != 1) { ret 1; }
+    if (scalar_mem_move_width(1, 2) != 2) { ret 1; }
+    if (scalar_mem_move_width(1, 4) != 4) { ret 1; }
+    if (scalar_mem_move_width(1, 8) != 8) { ret 1; }
+    ret 0;
 }
 
 # an sret return seeds a GP argument slot only when the pointer is in the argfile

--- a/src/lang/driver/tests.mach
+++ b/src/lang/driver/tests.mach
@@ -4617,8 +4617,8 @@ fun ut_ct_edge_project(s: *session.Session, alloc: *A.Allocator, src: str, targe
 # EVERY consumer of MIR_MOV, not just the rule-based ISel packs. SPIR-V is a direct
 # emitter (no isel retag), so a `:^` must emit as a value copy - not the unsupported-
 # instruction error [1]. mos6502's width-legalizer runs before isel and must expand a
-# wide `:^` like a wide move, not abort [2] (the remaining wide-memory-access error is a
-# pre-existing mos6502 limitation on wide LOADS, past the declassify legalization).
+# wide `:^` like a wide move, not abort [2]; since #2216 taught the pass to decompose a
+# wide memory access as well, [2] now compiles all the way through codegen.
 test "mach.lang.driver:declassify_edge_consumers" {
     var bad: i32 = 0;
     var alloc: A.Allocator;
@@ -4637,14 +4637,13 @@ test "mach.lang.driver:declassify_edge_consumers" {
         project.dnit_project(?p);
     }
 
-    # [2] mos6502 legalizes a wide `:^` instead of aborting on the declassify opcode: it
-    # gets PAST the declassify and fails only on the pre-existing wide-memory limitation.
+    # [2] mos6502 legalizes a wide `:^` instead of aborting on the declassify opcode.
     val pm: R.Result[project.Project, outcome.Fail] = ut_ct_edge_project(?s, ?alloc,
         "fun down(a: ^u32) u32 { ret a:^; }\nfun main() i32 { ret 0; }\n", "mos");
     if (R.is_err[project.Project, outcome.Fail](pm)) { bad = 1; }
     or {
         var p2: project.Project = R.unwrap_ok[project.Project, outcome.Fail](pm);
-        if (ut_run_codegen_err(?p2, "wide memory access") != 0) { bad = 1; }
+        if (ut_run_codegen_ok(?p2) != 0) { bad = 1; }
         project.dnit_project(?p2);
     }
 
@@ -4723,15 +4722,16 @@ test "mach.lang.driver:secret_shift_codegen_rejected_mos6502" {
 # false_positive` pins at the mechanism level - this pins that the LOWERING produces it).
 #
 # THE NEEDLES ARE ASYMMETRIC AND BOTH LOAD-BEARING. [1] asserts the leak diagnostic is
-# GONE, which is the fix. [2] pins what mos6502 says INSTEAD, so the rejection stays an
-# accurate statement of the target's own frontier rather than silently regressing to the
-# leak message; that frontier - the wide store through a runtime pointer the width
-# legalizer does not split - is #2216's, and this needle moves when #2216 lands.
+# GONE, which is the fix. [2] pinned the frontier mos6502 hit INSTEAD - the wide store
+# through a runtime pointer the width legalizer did not split - and #2216 closed it, so
+# it now asserts the callee compiles all the way through codegen.
 #
 # [3] drives the same assertions through a CALL of the wide-scalar-returning function,
 # covering the caller half of the fix: without it the call allocates no result storage and
 # passes the undefined result vreg as the hidden pointer, and returning that result
-# reproduces the same secret-as-address rejection.
+# reproduces the same secret-as-address rejection. The call itself still stops at the
+# target's remaining frontier (materializing a frame-slot ADDRESS into a pointer pair), so
+# [3] stays an absence assertion.
 test "mach.lang.driver:indirect_scalar_return_not_a_secret_address_mos6502" {
     var bad: i32 = 0;
     var alloc: A.Allocator;
@@ -4752,12 +4752,12 @@ test "mach.lang.driver:indirect_scalar_return_not_a_secret_address_mos6502" {
         project.dnit_project(?pa);
     }
 
-    # [2] and the rejection it does get names the target's real limitation.
+    # [2] and with the wide-scalar work landed the callee compiles clean end to end.
     val p2: R.Result[project.Project, outcome.Fail] = ut_ct_edge_project(?s, ?alloc, callee, "mos");
     if (R.is_err[project.Project, outcome.Fail](p2)) { bad = 1; }
     or {
         var pb: project.Project = R.unwrap_ok[project.Project, outcome.Fail](p2);
-        if (ut_run_codegen_err(?pb, "wide memory access is not yet legalized") != 0) { bad = 1; }
+        if (ut_run_codegen_ok(?pb) != 0) { bad = 1; }
         project.dnit_project(?pb);
     }
 

--- a/src/lang/driver/tests.mach
+++ b/src/lang/driver/tests.mach
@@ -4774,6 +4774,47 @@ test "mach.lang.driver:indirect_scalar_return_not_a_secret_address_mos6502" {
     ret bad;
 }
 
+# mos6502 (#2216): a function taking and returning a scalar WIDER than one byte builds
+#
+# The end-to-end claim of the wide-scalar work, on the only registered target where it
+# is non-trivial: an 8-bit ALU, an 8-bit register file, and a 16-bit address, so a `u32`
+# parameter arrives on the software stack, the return rides a hidden pointer that itself
+# does not fit a register, and every piece of it must be decomposed before selection.
+# All three widths are driven because each exercises a different lane count against the
+# same two-lane pointer, and because the defects this closes were width-conditional -
+# `scalar_reg_move_width` special-cased 4 alone, so `u16` and `u64` failed where `u32`
+# would have passed.
+#
+# This pins that the PIPELINE produces something; that what it produces is CORRECT is
+# `isa.mos6502.encode:wide_scalar_executes_constant_time`, which executes the bytes.
+test "mach.lang.driver:wide_scalar_builds_mos6502" {
+    var bad: i32 = 0;
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    val sr: R.Result[session.Session, str] = session.init(?alloc);
+    if (R.is_err[session.Session, str](sr)) { ret 1; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](sr);
+
+    var srcs: [3]str;
+    srcs[0] = "fun f(v: u16) u16 { ret v; }\nfun main() i32 { ret 0; }\n";
+    srcs[1] = "fun f(v: u32) u32 { ret v; }\nfun main() i32 { ret 0; }\n";
+    srcs[2] = "fun f(v: u64) u64 { ret v; }\nfun main() i32 { ret 0; }\n";
+    var i: u32 = 0;
+    for (i < 3) {
+        val pr: R.Result[project.Project, outcome.Fail] = ut_ct_edge_project(?s, ?alloc, srcs[i], "mos");
+        if (R.is_err[project.Project, outcome.Fail](pr)) { bad = 1; }
+        or {
+            var p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](pr);
+            if (ut_run_codegen_ok(?p) != 0) { bad = 1; }
+            project.dnit_project(?p);
+        }
+        i = i + 1;
+    }
+
+    session.dnit(?s);
+    ret bad;
+}
+
 # constant-time (#2159): the SPIR-V back half is a whole-module emitter - mach hands a
 # module to a downstream compiler instead of emitting the instructions that execute - so an
 # `#[oblivious]` contract can be neither validated nor upheld there and is REFUSED. the same

--- a/src/lang/driver/tests.mach
+++ b/src/lang/driver/tests.mach
@@ -4811,8 +4811,8 @@ test "mach.lang.driver:secret_shift_codegen_rejected_mos6502" {
 # covering the caller half of the fix: without it the call allocates no result storage and
 # passes the undefined result vreg as the hidden pointer, and returning that result
 # reproduces the same secret-as-address rejection. The call itself still stops at the
-# target's remaining frontier (materializing a frame-slot ADDRESS into a pointer pair), so
-# [3] stays an absence assertion.
+# target's remaining frontier - the caller owns the result storage, so it must materialize
+# that storage's ADDRESS into a pointer pair - which [4] pins positively.
 test "mach.lang.driver:indirect_scalar_return_not_a_secret_address_mos6502" {
     var bad: i32 = 0;
     var alloc: A.Allocator;
@@ -4849,6 +4849,18 @@ test "mach.lang.driver:indirect_scalar_return_not_a_secret_address_mos6502" {
         var pc: project.Project = R.unwrap_ok[project.Project, outcome.Fail](p3);
         if (ut_run_codegen_without(?pc, "secret value as a memory address") != 0) { bad = 1; }
         project.dnit_project(?pc);
+    }
+
+    # [4] and the frontier the caller half DOES stop at is named accurately: the caller
+    # owns the result storage, so it must materialize that storage's ADDRESS into a
+    # pointer pair, which the width legalizer does not yet build. Pinned positively so
+    # the rejection cannot silently regress to a different (or a leak) diagnostic.
+    val p4: R.Result[project.Project, outcome.Fail] = ut_ct_edge_project(?s, ?alloc, caller, "mos");
+    if (R.is_err[project.Project, outcome.Fail](p4)) { bad = 1; }
+    or {
+        var pd: project.Project = R.unwrap_ok[project.Project, outcome.Fail](p4);
+        if (ut_run_codegen_err(?pd, "materializing an address wider than one register") != 0) { bad = 1; }
+        project.dnit_project(?pd);
     }
 
     session.dnit(?s);

--- a/src/lang/target/isa/mos6502.mach
+++ b/src/lang/target/isa/mos6502.mach
@@ -23,6 +23,7 @@
 # encoder only ever handle native 1-byte operations - the smallness of the pack is
 # the point.
 
+use std.types.bool.bool;
 use std.types.string.str;
 
 # the zero-page address the general-purpose register file starts at. register id
@@ -51,14 +52,19 @@ pub val FP_HI: i32 = 1;
 pub val SP_LO: i32 = 2;
 pub val SP_HI: i32 = 3;
 
-# an encoder-owned zero-page pointer pair (id 4 / 5) for address materialization
-# and indirect access the encoder synthesizes. reserved
+# the convention's hidden-result pointer pair (id 4 / 5). a return too wide for the
+# single byte the value file passes is written through a caller-provided address
+# that arrives here, so it is the ABI's `indirect_result_reg`. reserved
 pub val PTR_LO: i32 = 4;
 pub val PTR_HI: i32 = 5;
 
-# the two single-byte encoder scratch registers (id 6 / 7). the shared regalloc
-# reserves them and draws no value allocation from them; the encoder uses them to
-# stage a value that cannot stay in A across a short sequence. reserved
+# the backend's address-staging pair (id 6 / 7), declared as the machine's
+# `scratch_reg` / `scratch_reg2`. A 16-bit address does not fit an 8-bit value
+# register, so a memory access through a RUNTIME pointer is decomposed at a fixed
+# base: the width legalizer stages the pointer's two lanes here and the encoder
+# reaches the bytes through `(zp),Y` off this pair. Distinct from `PTR_LO` on
+# purpose - a call stages its callee's hidden result pointer into `PTR_LO`, and a
+# staging pair that aliased it would clobber the pointer between the two. reserved
 pub val SCRATCH_REG:  i32 = 6;
 pub val SCRATCH_REG2: i32 = 7;
 
@@ -84,6 +90,22 @@ pub val STACK_REG: i32 = SP_LO;
 # ret: the zero-page address the id occupies
 pub fun zp_addr(id: i32) i32 {
     ret ZP_REG_BASE + id;
+}
+
+# whether a register id names the low half of a reserved zero-page POINTER PAIR
+#
+# The 6502's only indirect addressing form is `(zp),Y`, which reads a 16-bit address
+# out of two adjacent zero-page bytes. Register ids map linearly onto the zero page,
+# so `id` and `id + 1` are adjacent bytes - but only the four reserved pairs (frame,
+# stack, hidden-result, address-staging: the even ids below `RELOAD0`) are declared
+# to hold an address across the two. An ALLOCATABLE value register holds one byte and
+# its successor is an unrelated value, so it can never be a base; the encoder refuses
+# one rather than reading a neighbouring value as an address high byte.
+# ---
+# id:  the register id to classify
+# ret: true when `id` / `id + 1` are a reserved address pair
+pub fun is_ptr_pair(id: i32) bool {
+    ret id >= 0 && id < RELOAD0 && (id % 2) == 0;
 }
 
 # the MOS 6502 machine-opcode space

--- a/src/lang/target/isa/mos6502/encode.mach
+++ b/src/lang/target/isa/mos6502/encode.mach
@@ -669,70 +669,156 @@ test "mach.lang.target.isa.mos6502.encode:compare_is_branchless" {
     ret 0;
 }
 
-# execute an encoded compare sequence over a 256-byte zero page (test helper)
+# the observable state of the reference 6502 core (test helper)
+# ---
+# a:      the accumulator
+# y:      the Y index register, the displacement carrier of `(zp),Y`
+# c:      the carry flag, the only flag any sequence this encoder emits carries
+#         across an instruction
+# pc:     the program counter
+# cycles: the running cycle count
+rec Core {
+    a:      u32;
+    y:      u32;
+    c:      u32;
+    pc:     u32;
+    cycles: u32;
+}
+
+# execute encoded bytes on a reference 6502 core over a flat memory image (test helper)
 #
-# A minimal 6502 core covering exactly the opcodes `encode_cmp` emits, with the REAL
-# published flag semantics: `LDA` / `EOR` write N and Z but LEAVE CARRY ALONE, `CMP`
-# writes N, Z and C, and `ROL A` reads C into bit 0 while taking C from bit 7. Modeling
-# the flags honestly is the entire point. The sequence this replaced read as correct on
-# the page - compare, then branch on the compare's flag - but its `LDA #$00` silently
-# rewrote Z, so the branch tested a CONSTANT: every `==` answered 1 and every `!=`
-# answered 0, for every input. An identity check over the intended algebra cannot see
-# that; executing the bytes can.
+# A minimal core covering exactly the opcodes this encoder emits, with the REAL published
+# semantics and cycle counts: `LDA` / `EOR` write N and Z but LEAVE CARRY ALONE, `CMP`
+# writes N, Z and C, `ROL A` reads C into bit 0 while taking C from bit 7, `LDA (zp),Y`
+# reads a 16-bit address out of two adjacent zero-page bytes and costs an extra cycle when
+# the indexed address crosses a page (an ADDRESS-dependent cost, never a data-dependent
+# one), and `STA (zp),Y` costs a flat six. Modeling all of this honestly is the entire
+# point. The compare sequence this core was first written for read as correct on the page
+# - compare, then branch on the compare's flag - but its `LDA #$00` silently rewrote Z, so
+# the branch tested a CONSTANT: every `==` answered 1 and every `!=` answered 0, for every
+# input. An identity check over the intended algebra cannot see that; executing the bytes
+# can.
+#
+# Runs from `core.pc` until `RTS`, accumulating cycles. Any opcode outside the pinned set,
+# any access outside the image, and any run that does not terminate is a failure rather
+# than a silently truncated answer.
+# ---
+# mem:  the flat memory image (zero page at 0, code wherever `core.pc` points)
+# size: the image size in bytes
+# core: the core state; `pc` is the entry point, `cycles` accumulates
+# ret:  true when the run reached RTS inside the pinned opcode set
+fun t_exec(mem: *u8, size: usize, core: *Core) bool {
+    var steps: u32 = 0;
+    for (steps < 4096) {
+        steps = steps + 1;
+        if (core.pc::usize >= size) { ret false; }
+        val op:  u8    = mem[core.pc::usize];
+        val arg: usize = (core.pc + 1)::usize;
+        if (op == 0x60) { core.cycles = core.cycles + 6; ret true; }
+        if (arg >= size) { ret false; }
+        val imm: u32   = mem[arg]::u32;
+        val zpa: usize = mem[arg]::usize;
+
+        if (op == 0xA9)      { core.a = imm;                       core.cycles = core.cycles + 2; core.pc = core.pc + 2; }
+        or (op == 0xA5)      { core.a = mem[zpa]::u32;             core.cycles = core.cycles + 3; core.pc = core.pc + 2; }
+        or (op == 0x85)      { mem[zpa] = (core.a & 0xFF)::u8;     core.cycles = core.cycles + 3; core.pc = core.pc + 2; }
+        or (op == 0xA0)      { core.y = imm;                       core.cycles = core.cycles + 2; core.pc = core.pc + 2; }
+        or (op == 0x49)      { core.a = core.a ^ imm;              core.cycles = core.cycles + 2; core.pc = core.pc + 2; }
+        or (op == 0x45)      { core.a = core.a ^ mem[zpa]::u32;    core.cycles = core.cycles + 3; core.pc = core.pc + 2; }
+        or (op == 0x29)      { core.a = core.a & imm;              core.cycles = core.cycles + 2; core.pc = core.pc + 2; }
+        or (op == 0x25)      { core.a = core.a & mem[zpa]::u32;    core.cycles = core.cycles + 3; core.pc = core.pc + 2; }
+        or (op == 0x09)      { core.a = core.a | imm;              core.cycles = core.cycles + 2; core.pc = core.pc + 2; }
+        or (op == 0x05)      { core.a = core.a | mem[zpa]::u32;    core.cycles = core.cycles + 3; core.pc = core.pc + 2; }
+        or (op == 0xC9)      { core.c = 0; if (core.a >= imm) { core.c = 1; }                    core.cycles = core.cycles + 2; core.pc = core.pc + 2; }
+        or (op == 0xC5)      { core.c = 0; if (core.a >= mem[zpa]::u32) { core.c = 1; }          core.cycles = core.cycles + 3; core.pc = core.pc + 2; }
+        or (op == 0x2A)      { val nc: u32 = (core.a >> 7) & 1; core.a = ((core.a << 1) | core.c) & 0xFF; core.c = nc; core.cycles = core.cycles + 2; core.pc = core.pc + 1; }
+        or (op == 0x18)      { core.c = 0;                         core.cycles = core.cycles + 2; core.pc = core.pc + 1; }
+        or (op == 0x38)      { core.c = 1;                         core.cycles = core.cycles + 2; core.pc = core.pc + 1; }
+        or (op == 0xEA)      {                                     core.cycles = core.cycles + 2; core.pc = core.pc + 1; }
+        or (op == 0x69)      { val t: u32 = core.a + imm + core.c;                     core.c = (t >> 8) & 1; core.a = t & 0xFF; core.cycles = core.cycles + 2; core.pc = core.pc + 2; }
+        or (op == 0x65)      { val t: u32 = core.a + mem[zpa]::u32 + core.c;           core.c = (t >> 8) & 1; core.a = t & 0xFF; core.cycles = core.cycles + 3; core.pc = core.pc + 2; }
+        or (op == 0xE9)      { val t: u32 = (core.a + (imm ^ 0xFF) + core.c);          core.c = (t >> 8) & 1; core.a = t & 0xFF; core.cycles = core.cycles + 2; core.pc = core.pc + 2; }
+        or (op == 0xE5)      { val t: u32 = (core.a + (mem[zpa]::u32 ^ 0xFF) + core.c); core.c = (t >> 8) & 1; core.a = t & 0xFF; core.cycles = core.cycles + 3; core.pc = core.pc + 2; }
+        or (op == 0xB1 || op == 0x91) {
+            if (zpa + 1 >= size) { ret false; }
+            val ptr:  u32   = mem[zpa]::u32 | (mem[zpa + 1]::u32 << 8);
+            val addr: u32   = ptr + core.y;
+            if (addr::usize >= size) { ret false; }
+            if (op == 0xB1) {
+                core.a = mem[addr::usize]::u32;
+                core.cycles = core.cycles + 5;
+                # the published page-crossing penalty: an ADDRESS fact, not a data one.
+                if ((addr & 0xFF00) != (ptr & 0xFF00)) { core.cycles = core.cycles + 1; }
+            } or {
+                mem[addr::usize] = (core.a & 0xFF)::u8;
+                core.cycles = core.cycles + 6;
+            }
+            core.pc = core.pc + 2;
+        }
+        or { ret false; }
+    }
+    ret false;
+}
+
+# execute an encoded compare sequence over a zero page, reporting its cycle count
+# (test helper)
 # ---
 # code:   the encoded bytes to execute
 # n:      their length
-# zp:     the 256-byte zero page (operands in, result out)
+# mem:    the flat memory image, zero page at 0 (operands in, result out)
+# size:   the image size
 # cycles: receives the sequence's total cycle count
 # ret:    true when every opcode was inside the pinned set
-fun t_run_cmp(code: *u8, n: usize, zp: *u8, cycles: *u32) bool {
-    var a:  u32 = 0;
-    var c:  u32 = 0;
-    var cy: u32 = 0;
-    var i:  usize = 0;
-    for (i < n) {
-        val op:  u8    = code[i];
-        val arg: usize = i + 1;
-        if (op == 0xA9)   { a = code[arg]::u32;                       cy = cy + 2; i = i + 2; }
-        or (op == 0xA5)   { a = zp[code[arg]::usize]::u32;            cy = cy + 3; i = i + 2; }
-        or (op == 0x49)   { a = a ^ code[arg]::u32;                   cy = cy + 2; i = i + 2; }
-        or (op == 0x45)   { a = a ^ zp[code[arg]::usize]::u32;        cy = cy + 3; i = i + 2; }
-        or (op == 0xC9)   { c = 0; if (a >= code[arg]::u32) { c = 1; }             cy = cy + 2; i = i + 2; }
-        or (op == 0xC5)   { c = 0; if (a >= zp[code[arg]::usize]::u32) { c = 1; }  cy = cy + 3; i = i + 2; }
-        or (op == 0x2A)   { val nc: u32 = (a >> 7) & 1; a = ((a << 1) | c) & 0xFF; c = nc; cy = cy + 2; i = i + 1; }
-        or (op == 0x85)   { zp[code[arg]::usize] = (a & 0xFF)::u8;    cy = cy + 3; i = i + 2; }
-        or { ret false; }
-    }
-    @cycles = cy;
+fun t_run_cmp(code: *u8, n: usize, mem: *u8, size: usize, cycles: *u32) bool {
+    val base: usize = T_CODE_BASE::usize;
+    if (base + n >= size) { ret false; }
+    var i: usize = 0;
+    for (i < n) { mem[base + i] = code[i]; i = i + 1; }
+    mem[base + n] = OP_RTS;
+
+    var core: Core;
+    core.a = 0; core.y = 0; core.c = 0; core.cycles = 0;
+    core.pc = T_CODE_BASE;
+    if (!t_exec(mem, size, ?core)) { ret false; }
+    # the terminating RTS is scaffolding, not part of the sequence under test.
+    @cycles = core.cycles - 6;
     ret true;
 }
+
+# where the reference core loads an encoded sequence: clear of the zero page the value
+# registers occupy and of the data pages the round-trip tests address
+val T_CODE_BASE: u32 = 0x0200;
+
+# the reference core's memory image size, covering the zero page, the loaded code, and
+# the data pages the round-trip tests place their storage in
+val T_MEM_SIZE: usize = 0x1000;
 
 # run one encoded relation over every ordered byte pair, checking the ANSWER and that the
 # cycle count never varies with the operands (test helper)
 # ---
 # st:   the encode state holding the sequence to execute
 # want: 0 for `==`, 1 for `!=`, 2 for `<u`
+# mem:  the reference core's memory image
 # ret:  0 when every pair answers correctly at one fixed cycle count
-fun t_check_cmp(st: *enc.EncodeState, want: u32) i32 {
-    var zp: [256]u8;
+fun t_check_cmp(st: *enc.EncodeState, want: u32, mem: *u8) i32 {
     var fixed: u32 = 0;
     var x: u32 = 0;
     for (x < 256) {
         var y: u32 = 0;
         for (y < 256) {
             var k: usize = 0;
-            for (k < 256) { zp[k] = 0; k = k + 1; }
-            zp[0x18] = (x & 0xFF)::u8;
-            zp[0x19] = (y & 0xFF)::u8;
+            for (k < 256) { mem[k] = 0; k = k + 1; }
+            mem[0x18] = (x & 0xFF)::u8;
+            mem[0x19] = (y & 0xFF)::u8;
 
             var cy: u32 = 0;
-            if (!t_run_cmp(st.buf.data, st.buf.len, ?zp[0], ?cy)) { ret 1; }
+            if (!t_run_cmp(st.buf.data, st.buf.len, mem, T_MEM_SIZE, ?cy)) { ret 1; }
 
             var expect: u32 = 0;
             if (want == 0 && x == y) { expect = 1; }
             or (want == 1 && x != y) { expect = 1; }
             or (want == 2 && x <  y) { expect = 1; }
-            if (zp[0x1A]::u32 != expect) { ret 1; }
+            if (mem[0x1A]::u32 != expect) { ret 1; }
 
             # the constant-time property, EXECUTED: one cycle count for all 65536 pairs.
             if (x == 0 && y == 0) { fixed = cy; }
@@ -754,23 +840,381 @@ fun t_check_cmp(st: *enc.EncodeState, want: u32) i32 {
 test "mach.lang.target.isa.mos6502.encode:compare_executes_constant_time" {
     var alloc: A.Allocator;
     page.make(?alloc);
+    val mr: R.Result[*u8, str] = A.zallocate[u8](?alloc, T_MEM_SIZE);
+    if (R.is_err[*u8, str](mr)) { ret 1; }
+    val mem: *u8 = R.unwrap_ok[*u8, str](mr);
 
     var eq: enc.EncodeState;
     eq.buf = enc.buf_init(?alloc);
     if (R.is_err[bool, str](t_encode_cmp(?eq, mir.MIR_CMP_EQ))) { ret 1; }
-    if (t_check_cmp(?eq, 0) != 0) { ret 1; }
+    if (t_check_cmp(?eq, 0, mem) != 0) { ret 1; }
     enc.buf_dnit(?eq.buf);
 
     var ne: enc.EncodeState;
     ne.buf = enc.buf_init(?alloc);
     if (R.is_err[bool, str](t_encode_cmp(?ne, mir.MIR_CMP_NE))) { ret 1; }
-    if (t_check_cmp(?ne, 1) != 0) { ret 1; }
+    if (t_check_cmp(?ne, 1, mem) != 0) { ret 1; }
     enc.buf_dnit(?ne.buf);
 
     var lt: enc.EncodeState;
     lt.buf = enc.buf_init(?alloc);
     if (R.is_err[bool, str](t_encode_cmp(?lt, mir.MIR_CMP_LT_U))) { ret 1; }
-    if (t_check_cmp(?lt, 2) != 0) { ret 1; }
+    if (t_check_cmp(?lt, 2, mem) != 0) { ret 1; }
     enc.buf_dnit(?lt.buf);
+
+    A.deallocate[u8](?alloc, mem, T_MEM_SIZE);
+    ret 0;
+}
+
+# a memory base the 6502 cannot reach an address through is REFUSED, never mis-encoded
+#
+# The load-bearing refusal is the allocatable value register: it holds one byte, so
+# `(zp),Y` off it would read the NEXT value in the file as the address's high byte -
+# a silent miscompile that reads and writes wherever that byte happens to point. The
+# reserved pairs are accepted, an odd (high-half) id is not, and neither is a still-wide
+# access, a frame-slot base, or a displacement past the 8-bit Y index.
+test "mach.lang.target.isa.mos6502.encode:refuses_a_base_that_is_not_a_pointer_pair" {
+    # the four reserved pairs are the whole accepted set.
+    if (!mos6502.is_ptr_pair(mos6502.FP_LO))       { ret 1; }
+    if (!mos6502.is_ptr_pair(mos6502.SP_LO))       { ret 1; }
+    if (!mos6502.is_ptr_pair(mos6502.PTR_LO))      { ret 1; }
+    if (!mos6502.is_ptr_pair(mos6502.SCRATCH_REG)) { ret 1; }
+    if (mos6502.is_ptr_pair(mos6502.FP_HI))        { ret 1; }
+    if (mos6502.is_ptr_pair(mos6502.PTR_HI))       { ret 1; }
+    if (mos6502.is_ptr_pair(mos6502.RELOAD0))      { ret 1; }
+    if (mos6502.is_ptr_pair(mos6502.FIRST_VALUE_REG))     { ret 1; }
+    if (mos6502.is_ptr_pair(mos6502.FIRST_VALUE_REG + 1)) { ret 1; }
+
+    var ops: [2]mir.MirOperand;
+    var mi: mir.MirInstr;
+    mi.operands      = ?ops[0];
+    mi.operand_count = 2;
+    mi.opcode        = mir.MIR_LOAD;
+    mi.width         = 1;
+    mi.src_width     = 1;
+    var base: i32 = 0;
+    var disp: u8  = 0;
+
+    # a value-register base is refused rather than read as half an address.
+    ops[1] = mir.op_mem_preg(mos6502.FIRST_VALUE_REG::u32, 0);
+    if (!R.is_err[bool, str](mem_base_disp(?mi, ?ops[1], ?base, ?disp))) { ret 1; }
+    # so is a frame-slot base (the software frame's own addressing is not built yet).
+    ops[1] = mir.op_mem_slot(3, 0);
+    if (!R.is_err[bool, str](mem_base_disp(?mi, ?ops[1], ?base, ?disp))) { ret 1; }
+    # and a displacement past the 8-bit Y index.
+    ops[1] = mir.op_mem_preg(mos6502.FP_LO::u32, 256);
+    if (!R.is_err[bool, str](mem_base_disp(?mi, ?ops[1], ?base, ?disp))) { ret 1; }
+    # an access still wider than one byte is the legalizer's job, not this encoder's.
+    mi.width = 2;
+    ops[1] = mir.op_mem_preg(mos6502.FP_LO::u32, 0);
+    if (!R.is_err[bool, str](mem_base_disp(?mi, ?ops[1], ?base, ?disp))) { ret 1; }
+
+    # a reserved pair at a reachable displacement resolves.
+    mi.width = 1;
+    ops[1] = mir.op_mem_preg(mos6502.FP_LO::u32, 7);
+    if (R.is_err[bool, str](mem_base_disp(?mi, ?ops[1], ?base, ?disp))) { ret 1; }
+    if (base != mos6502.FP_LO || disp != 7) { ret 1; }
+    ret 0;
+}
+
+# the value register the wide-scalar round-trip holds the hidden result pointer's two
+# lanes in, and the first of the run holding the scalar's byte lanes (test helper)
+val T_PTR_REG:  i32 = mos6502.FIRST_VALUE_REG;
+val T_DATA_REG: i32 = mos6502.FIRST_VALUE_REG + 2;
+
+# write one fully-resolved instruction of the round-trip function (test helper)
+fun t_put(f: *mir.MirInstr, ops: *mir.MirOperand, ix: u32, opcode: mir.MirOpcode,
+          a: mir.MirOperand, b: mir.MirOperand, nops: u32) {
+    ops[ix * 2]     = a;
+    ops[ix * 2 + 1] = b;
+    f[ix].opcode        = opcode;
+    f[ix].operands      = ?ops[ix * 2];
+    f[ix].operand_count = nops;
+    f[ix].width         = 1;
+    f[ix].src_width     = 1;
+    f[ix].vec_lane      = mir.VEC_LANE_NONE;
+}
+
+# build the fully-resolved MIR the pipeline hands this encoder for
+# `fun f(v: uN) uN { ret v; }` on mos6502, for an N of `n` bytes (test helper)
+#
+# Every wider-than-one-byte scalar returns through the convention's hidden result
+# pointer and arrives on the software stack, so the function is: capture the pointer's
+# two lanes out of the `PTR_LO` pair, read the parameter's `n` bytes off the frame
+# pointer, stage the pointer into the address pair, write the `n` bytes through it, and
+# hand the pointer back. Post-isel every operand is a physical register, so this is
+# exactly the instruction list the encoder sees - and `wide_scalar_bytes_match_pipeline`
+# pins the result against a real `mach build --target mos` image, so a divergence
+# between this list and what the pipeline actually produces fails there.
+# ---
+# f:      receives the instructions (at least 2n + 7)
+# ops:    operand backing store (at least 4n + 14)
+# blocks: receives the single block
+# fn:     receives the function
+# n:      the scalar's byte width
+fun t_roundtrip_fn(f: *mir.MirInstr, ops: *mir.MirOperand, blocks: *mir.MirBlock,
+                   fn: *mir.MirFunction, n: u32) {
+    var ix: u32 = 0;
+    var i:  u32 = 0;
+    for (i < 2) {
+        t_put(f, ops, ix, mos6502.MOV::u32, mir.op_preg((T_PTR_REG + i::i32)::u32),
+              mir.op_preg((mos6502.PTR_LO + i::i32)::u32), 2);
+        ix = ix + 1; i = i + 1;
+    }
+    i = 0;
+    for (i < n) {
+        t_put(f, ops, ix, mir.MIR_LOAD, mir.op_preg((T_DATA_REG + i::i32)::u32),
+              mir.op_mem_preg(mos6502.FRAME_REG::u32, i::i64), 2);
+        ix = ix + 1; i = i + 1;
+    }
+    i = 0;
+    for (i < 2) {
+        t_put(f, ops, ix, mos6502.MOV::u32, mir.op_preg((mos6502.SCRATCH_REG + i::i32)::u32),
+              mir.op_preg((T_PTR_REG + i::i32)::u32), 2);
+        ix = ix + 1; i = i + 1;
+    }
+    i = 0;
+    for (i < n) {
+        t_put(f, ops, ix, mir.MIR_STORE, mir.op_mem_preg(mos6502.SCRATCH_REG::u32, i::i64),
+              mir.op_preg((T_DATA_REG + i::i32)::u32), 2);
+        ix = ix + 1; i = i + 1;
+    }
+    i = 0;
+    for (i < 2) {
+        t_put(f, ops, ix, mos6502.MOV::u32, mir.op_preg((mos6502.PTR_LO + i::i32)::u32),
+              mir.op_preg((T_PTR_REG + i::i32)::u32), 2);
+        ix = ix + 1; i = i + 1;
+    }
+    t_put(f, ops, ix, mos6502.RTS::u32, mir.op_imm(0), mir.op_imm(0), 0);
+    ix = ix + 1;
+
+    blocks[0].id          = 0;
+    blocks[0].instrs      = f;
+    blocks[0].instr_count = ix;
+    blocks[0].instr_cap   = ix;
+
+    fn.name        = intern.STR_NIL;
+    fn.blocks      = blocks;
+    fn.block_count = 1;
+    fn.block_cap   = 1;
+}
+
+# encode the `n`-byte wide-scalar round-trip through the real per-function encoder
+# (test helper)
+fun t_encode_roundtrip(st: *enc.EncodeState, n: u32) R.Result[bool, str] {
+    var instrs: [23]mir.MirInstr;
+    var ops:    [46]mir.MirOperand;
+    var blocks: [1]mir.MirBlock;
+    var fn:     mir.MirFunction;
+    t_roundtrip_fn(?instrs[0], ?ops[0], ?blocks[0], ?fn, n);
+    ret encode_function(st, ?fn);
+}
+
+# run the encoded round-trip once and report the stored bytes and the cycle count
+# (test helper)
+# ---
+# code:    the encoded bytes
+# len:     their length
+# mem:     the reference core's memory image
+# n:       the scalar's byte width
+# arg:     address the caller placed the incoming argument at
+# store:   address the caller's result storage sits at
+# value:   the scalar to round-trip
+# cycles:  receives the run's cycle count
+# ret:     true when the run completed and the stored bytes are the scalar's
+fun t_run_roundtrip(code: *u8, len: usize, mem: *u8, n: u32, arg: u32, store: u32,
+                    value: u64, cycles: *u32) bool {
+    val base: usize = T_CODE_BASE::usize;
+    if (base + len >= T_MEM_SIZE) { ret false; }
+    var i: usize = 0;
+    for (i < len) { mem[base + i] = code[i]; i = i + 1; }
+
+    # the frame pointer and the hidden result pointer, each a zero-page pair.
+    mem[mos6502.zp_addr(mos6502.FP_LO)::usize] = (arg & 0xFF)::u8;
+    mem[mos6502.zp_addr(mos6502.FP_HI)::usize] = ((arg >> 8) & 0xFF)::u8;
+    mem[mos6502.zp_addr(mos6502.PTR_LO)::usize] = (store & 0xFF)::u8;
+    mem[mos6502.zp_addr(mos6502.PTR_HI)::usize] = ((store >> 8) & 0xFF)::u8;
+
+    var k: u32 = 0;
+    for (k < n) {
+        mem[(arg + k)::usize]   = ((value >> (k * 8)::u64) & 0xFF)::u8;
+        mem[(store + k)::usize] = 0;
+        k = k + 1;
+    }
+
+    var core: Core;
+    core.a = 0; core.y = 0; core.c = 0; core.cycles = 0;
+    core.pc = T_CODE_BASE;
+    if (!t_exec(mem, T_MEM_SIZE, ?core)) { ret false; }
+    @cycles = core.cycles;
+
+    k = 0;
+    for (k < n) {
+        if (mem[(store + k)::usize]::u64 != ((value >> (k * 8)::u64) & 0xFF)) { ret false; }
+        k = k + 1;
+    }
+    # the callee hands the storage pointer back in the return pair, unchanged.
+    if (mem[mos6502.zp_addr(mos6502.PTR_LO)::usize]::u32 != (store & 0xFF))        { ret false; }
+    if (mem[mos6502.zp_addr(mos6502.PTR_HI)::usize]::u32 != ((store >> 8) & 0xFF)) { ret false; }
+    ret true;
+}
+
+# round-trip a sweep of scalars through the encoded function, checking the answer and
+# that the cycle count never varies with the VALUE (test helper)
+# ---
+# st:    the encode state holding the function's bytes
+# mem:   the reference core's memory image
+# n:     the scalar's byte width
+# arg:   address the incoming argument sits at (varied to exercise page crossing)
+# store: address of the caller's result storage
+# iters: number of sweep values
+# out:   receives the fixed cycle count the sweep settled on
+# ret:   0 when every value round-trips at one fixed cycle count
+fun t_check_roundtrip(st: *enc.EncodeState, mem: *u8, n: u32, arg: u32, store: u32,
+                      iters: u32, out: *u32) i32 {
+    var fixed: u32 = 0;
+    var seed:  u64 = 0x243F6A8885A308D3;
+    var i: u32 = 0;
+    for (i < iters) {
+        # a xorshift walk plus the all-zero, all-ones and alternating patterns, so the
+        # sweep covers both the values a carry-free copy could confuse and a wide spread.
+        seed = seed ^ (seed << 13);
+        seed = seed ^ (seed >> 7);
+        seed = seed ^ (seed << 17);
+        var v: u64 = seed;
+        if (i == 0) { v = 0; }
+        or (i == 1) { v = 0xFFFFFFFFFFFFFFFF; }
+        or (i == 2) { v = 0xAA55AA55AA55AA55; }
+        or (i == 3) { v = 0x0102040810204080; }
+
+        var cy: u32 = 0;
+        if (!t_run_roundtrip(st.buf.data, st.buf.len, mem, n, arg, store, v, ?cy)) { ret 1; }
+        # the constant-time property, EXECUTED: one cycle count for every value.
+        if (i == 0)      { fixed = cy; }
+        or (cy != fixed) { ret 1; }
+        i = i + 1;
+    }
+    @out = fixed;
+    ret 0;
+}
+
+# the encoded wide-scalar round-trip is byte-for-byte what the pipeline emits
+#
+# The instruction list `t_roundtrip_fn` builds is a claim about what the ABI placement,
+# the width legalizer, instruction selection and register allocation hand this encoder
+# for `fun f(v: u32) u32 { ret v; }`. This pins the claim: the bytes below were read out
+# of a real `mach build --target mos` image of that function, so if any stage upstream
+# stops producing this sequence, the executed-bytes proofs below stop being about the
+# real thing and this test says so.
+test "mach.lang.target.isa.mos6502.encode:wide_scalar_bytes_match_pipeline" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+
+    var st: enc.EncodeState;
+    st.alloc = ?alloc;
+    st.buf   = enc.buf_init(?alloc);
+    if (R.is_err[bool, str](t_encode_roundtrip(?st, 4))) { ret 1; }
+
+    val want: [73]u8 = [73]u8{
+        0xA5, 0x14, 0x85, 0x1B, 0xA5, 0x15, 0x85, 0x1C,
+        0xA0, 0x00, 0xB1, 0x10, 0x85, 0x1D,
+        0xA0, 0x01, 0xB1, 0x10, 0x85, 0x1E,
+        0xA0, 0x02, 0xB1, 0x10, 0x85, 0x1F,
+        0xA0, 0x03, 0xB1, 0x10, 0x85, 0x20,
+        0xA5, 0x1B, 0x85, 0x16, 0xA5, 0x1C, 0x85, 0x17,
+        0xA5, 0x1D, 0xA0, 0x00, 0x91, 0x16,
+        0xA5, 0x1E, 0xA0, 0x01, 0x91, 0x16,
+        0xA5, 0x1F, 0xA0, 0x02, 0x91, 0x16,
+        0xA5, 0x20, 0xA0, 0x03, 0x91, 0x16,
+        0xA5, 0x1B, 0x85, 0x14, 0xA5, 0x1C, 0x85, 0x15,
+        0x60,
+    };
+    if (st.buf.len != 73) { ret 1; }
+    var i: usize = 0;
+    for (i < 73) {
+        if (st.buf.data[i] != want[i]) { ret 1; }
+        i = i + 1;
+    }
+    # the round-trip is straight-line: a wide scalar carries no branch on this target.
+    if (t_has_branch(?st)) { ret 1; }
+    enc.buf_dnit(?st.buf);
+    ret 0;
+}
+
+# a wide scalar round-trips correctly and in a fixed number of cycles, EXECUTED
+#
+# `fun f(v: uN) uN { ret v; }` for a 2-, 4- and 8-byte N - the shapes that did not build
+# at all before #2216 - encoded and then RUN on the reference core: the parameter is read
+# off the frame pointer, written through the hidden result pointer, and the pointer handed
+# back. Reading the lowering cannot establish this; #2158 is the standing reminder, where
+# a compare that read correctly on the page answered wrong for all 65536 inputs.
+#
+# The cycle count is the constant-time half. Every instruction in the sequence is
+# fixed-cost and there is no branch, so the count cannot depend on the VALUE - which is
+# what `#[oblivious]` needs from a `^uN` round-trip, and is asserted here by executing the
+# bytes over a sweep rather than by inspecting them. The one variability the 6502 has in
+# this sequence is `LDA (zp),Y`'s page-crossing penalty, which is a fact about the
+# ADDRESS: `page_crossing_costs_are_address_only` pins that it moves the constant without
+# making it value-dependent.
+test "mach.lang.target.isa.mos6502.encode:wide_scalar_executes_constant_time" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+    val mr: R.Result[*u8, str] = A.zallocate[u8](?alloc, T_MEM_SIZE);
+    if (R.is_err[*u8, str](mr)) { ret 1; }
+    val mem: *u8 = R.unwrap_ok[*u8, str](mr);
+
+    var widths: [3]u32;
+    widths[0] = 2; widths[1] = 4; widths[2] = 8;
+    var w: u32 = 0;
+    for (w < 3) {
+        var st: enc.EncodeState;
+        st.alloc = ?alloc;
+        st.buf   = enc.buf_init(?alloc);
+        if (R.is_err[bool, str](t_encode_roundtrip(?st, widths[w]))) { ret 1; }
+        if (t_has_branch(?st))                                       { ret 1; }
+        var fixed: u32 = 0;
+        if (t_check_roundtrip(?st, mem, widths[w], 0x0500, 0x0600, 4096, ?fixed) != 0) { ret 1; }
+        enc.buf_dnit(?st.buf);
+        w = w + 1;
+    }
+
+    A.deallocate[u8](?alloc, mem, T_MEM_SIZE);
+    ret 0;
+}
+
+# the only cycle-count variability in the round-trip is a fact about the ADDRESS
+#
+# `LDA (zp),Y` costs an extra cycle when the indexed address crosses a page, so a
+# parameter placed to straddle a page boundary runs the round-trip at a DIFFERENT
+# constant - but still ONE constant across every value, which is the property
+# `#[oblivious]` requires. Pinning both halves keeps the constant-time claim honest: the
+# sequence is not "always N cycles", it is "N cycles for a given public address, for every
+# secret value". A model that simply forgot the penalty would pass the fixed-count test
+# and fail this one, so the guarantee rests on a faithful core rather than a lenient one.
+test "mach.lang.target.isa.mos6502.encode:page_crossing_costs_are_address_only" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+    val mr: R.Result[*u8, str] = A.zallocate[u8](?alloc, T_MEM_SIZE);
+    if (R.is_err[*u8, str](mr)) { ret 1; }
+    val mem: *u8 = R.unwrap_ok[*u8, str](mr);
+
+    var st: enc.EncodeState;
+    st.alloc = ?alloc;
+    st.buf   = enc.buf_init(?alloc);
+    if (R.is_err[bool, str](t_encode_roundtrip(?st, 4))) { ret 1; }
+
+    # a page-aligned parameter and one straddling the $0500 boundary each settle on one
+    # fixed count over the whole value sweep.
+    var aligned: u32 = 0;
+    var split:   u32 = 0;
+    if (t_check_roundtrip(?st, mem, 4, 0x0500, 0x0600, 256, ?aligned) != 0) { ret 1; }
+    if (t_check_roundtrip(?st, mem, 4, 0x04FE, 0x0600, 256, ?split)   != 0) { ret 1; }
+
+    # two of the four parameter bytes cross the page, so the straddled placement costs
+    # exactly two more cycles - address-driven, and identical for every value.
+    if (split != aligned + 2) { ret 1; }
+
+    enc.buf_dnit(?st.buf);
+    A.deallocate[u8](?alloc, mem, T_MEM_SIZE);
     ret 0;
 }

--- a/src/lang/target/isa/mos6502/encode.mach
+++ b/src/lang/target/isa/mos6502/encode.mach
@@ -68,6 +68,9 @@ val OP_CMP_IMM: u8 = 0xC9;  val OP_CMP_ZP: u8 = 0xC5;
 val OP_CLC:     u8 = 0x18;  val OP_SEC:    u8 = 0x38;
 val OP_JMP_ABS: u8 = 0x4C;  val OP_JSR_ABS: u8 = 0x20;
 val OP_RTS:     u8 = 0x60;  val OP_BRK:     u8 = 0x00;  val OP_NOP: u8 = 0xEA;
+# the indirect-indexed forms `(zp),Y` plus the Y load that carries the displacement:
+# the only addressing the 6502 offers through a runtime pointer
+val OP_LDY_IMM: u8 = 0xA0;  val OP_LDA_IND_Y: u8 = 0xB1;  val OP_STA_IND_Y: u8 = 0x91;
 # the conditional branch opcodes (pc-relative, signed 8-bit displacement)
 val OP_BEQ: u8 = 0xF0;  val OP_BNE: u8 = 0xD0;  val OP_BCC: u8 = 0x90;  val OP_BCS: u8 = 0xB0;
 # rotate the accumulator left through carry ($2A) - used to read the carry flag into
@@ -145,6 +148,8 @@ fun encode_instr(st: *enc.EncodeState, f: *mir.MirFunction, mi: *mir.MirInstr, f
         op == mir.MIR_AND || op == mir.MIR_OR || op == mir.MIR_XOR) {
         ret encode_alu(st, mi, op);
     }
+    if (op == mir.MIR_LOAD)  { ret encode_load(st, mi); }
+    if (op == mir.MIR_STORE) { ret encode_store(st, mi); }
     if (op == mir.MIR_NOT) { ret encode_not(st, mi); }
     if (op == mir.MIR_CMP_EQ || op == mir.MIR_CMP_NE || op == mir.MIR_CMP_LT_U) {
         ret encode_cmp(st, mi, op);
@@ -200,6 +205,87 @@ fun encode_alu(st: *enc.EncodeState, mi: *mir.MirInstr, op: mir.MirOpcode) R.Res
     val res_op: R.Result[bool, str] = emit_operand(st, b, imm_op, zp_op, op);
     if (R.is_err[bool, str](res_op)) { ret res_op; }
     emit_zp1(st, OP_STA_ZP, mos6502.zp_addr(dst.preg::i32));
+    ret R.ok[bool, str](true);
+}
+
+# encode a one-byte load `dst <- [ptr + disp]` as `LDY #disp ; LDA (ptr),Y ; STA dst`
+#
+# The address comes out of a reserved zero-page POINTER PAIR - the frame pointer, or
+# the staging pair the width legalizer wrote a runtime pointer's lanes into - and the
+# displacement rides Y, the 6502's only indexed-indirect form. The width legalizer
+# has already split every wider access into these one-byte pieces at successive
+# displacements, so a piece that still carries a wider width, or a base that is not a
+# declared pointer pair, is a legalization bug and is refused rather than mis-encoded.
+fun encode_load(st: *enc.EncodeState, mi: *mir.MirInstr) R.Result[bool, str] {
+    if (mi.operand_count != 2) { ret R.err[bool, str]("mos6502: malformed load"); }
+    val dst: *mir.MirOperand = ?mi.operands[0];
+    if (dst.kind != mir.MIR_OP_PREG) { ret R.err[bool, str](unencodable_message(mir.MIR_LOAD)); }
+
+    var base: i32 = 0;
+    var disp: u8  = 0;
+    val ra: R.Result[bool, str] = mem_base_disp(mi, ?mi.operands[1], ?base, ?disp);
+    if (R.is_err[bool, str](ra)) { ret ra; }
+
+    emit_imm1(st, OP_LDY_IMM, disp);
+    emit_zp1(st, OP_LDA_IND_Y, mos6502.zp_addr(base));
+    emit_zp1(st, OP_STA_ZP, mos6502.zp_addr(dst.preg::i32));
+    ret R.ok[bool, str](true);
+}
+
+# encode a one-byte store `[ptr + disp] <- src` as `LDA src ; LDY #disp ; STA (ptr),Y`
+#
+# The write twin of `encode_load`; the stored byte rides an immediate or a zero-page
+# value register into A first, since `(zp),Y` stores only the accumulator.
+fun encode_store(st: *enc.EncodeState, mi: *mir.MirInstr) R.Result[bool, str] {
+    if (mi.operand_count != 2) { ret R.err[bool, str]("mos6502: malformed store"); }
+
+    var base: i32 = 0;
+    var disp: u8  = 0;
+    val ra: R.Result[bool, str] = mem_base_disp(mi, ?mi.operands[0], ?base, ?disp);
+    if (R.is_err[bool, str](ra)) { ret ra; }
+
+    val res_ld: R.Result[bool, str] = emit_load_a(st, ?mi.operands[1]);
+    if (R.is_err[bool, str](res_ld)) { ret res_ld; }
+    emit_imm1(st, OP_LDY_IMM, disp);
+    emit_zp1(st, OP_STA_IND_Y, mos6502.zp_addr(base));
+    ret R.ok[bool, str](true);
+}
+
+# resolve a memory operand to a reserved pointer-pair base and an 8-bit displacement
+#
+# The one place the encoder's addressing contract is stated, so a load and a store
+# cannot disagree about what they accept. Every refusal names the specific shape:
+# a frame-slot base (the software frame's own addressing, not yet built), a base
+# that is an allocatable value register (one byte - reading its neighbour as an
+# address high byte would be a silent miscompile), a displacement past the 8-bit Y
+# index, and an access still wider than one byte (the legalizer's job, not this
+# encoder's).
+# ---
+# mi:       the accessing instruction (its width is checked here)
+# mem:      the memory operand to resolve
+# out_base: receives the pointer-pair register id
+# out_disp: receives the displacement in bytes
+# ret:      ok(true), or an error naming the unsupported shape
+fun mem_base_disp(mi: *mir.MirInstr, mem: *mir.MirOperand, out_base: *i32, out_disp: *u8) R.Result[bool, str] {
+    if (mem.kind != mir.MIR_OP_MEM) { ret R.err[bool, str](unencodable_message(mi.opcode)); }
+    if (mi.width > 1) {
+        ret R.err[bool, str]("mos6502: a memory access wider than one byte must be split by width legalization before encoding");
+    }
+    if (mem.index != mir.MIR_VREG_NIL) {
+        ret R.err[bool, str]("mos6502: the 6502 has no scaled-index addressing");
+    }
+    if (mem.vreg != mir.MIR_VREG_NIL) {
+        ret R.err[bool, str]("mos6502: frame-slot addressing is not yet implemented on this target");
+    }
+    val base: i32 = mem.preg::i32;
+    if (!mos6502.is_ptr_pair(base)) {
+        ret R.err[bool, str]("mos6502: a memory base must be a reserved zero-page pointer pair on this target");
+    }
+    if (mem.imm < 0 || mem.imm > 255) {
+        ret R.err[bool, str]("mos6502: a memory displacement must fit the 8-bit Y index on this target");
+    }
+    @out_base = base;
+    @out_disp = (mem.imm & 0xFF)::u8;
     ret R.ok[bool, str](true);
 }
 
@@ -431,8 +517,11 @@ fun unencodable_message(op: mir.MirOpcode) str {
     if (op == mir.MIR_FADD || op == mir.MIR_FSUB || op == mir.MIR_FMUL || op == mir.MIR_FDIV) {
         ret "mos6502: floating-point is unsupported on this target";
     }
-    if (op == mir.MIR_LOAD || op == mir.MIR_STORE || op == mir.MIR_GEP || op == mir.MIR_ALLOCA) {
-        ret "mos6502: memory access encoding is not yet implemented on this target";
+    if (op == mir.MIR_GEP || op == mir.MIR_ALLOCA) {
+        ret "mos6502: address arithmetic is not yet implemented on this target";
+    }
+    if (op == mir.MIR_LOAD || op == mir.MIR_STORE) {
+        ret "mos6502: unsupported memory operand shape on this target";
     }
     if (op == mir.MIR_CBR || op == mir.MIR_BR ||
         op == mir.MIR_CMP_EQ || op == mir.MIR_CMP_NE ||


### PR DESCRIPTION
Closes #2216

mos6502 could not compile `fun f(v: u32) u32 { ret v; }`. Four defects composed; **three of the four were shared assumptions, not target quirks** — the 8-bit target is where "a scalar fits a register" finally got tested.

## Which defects were shared, which were mos6502's

| # | Defect | Verdict |
|---|---|---|
| 1 | `emit_param_slot`'s `CLASS_STACK` scalar path moved at `gpr_width`, reading one byte of a 4-byte parameter | **shared** — the ABI placement never asked whether a scalar fits the machine word |
| 2 | `scalar_reg_move_width` special-cased only size 4, so `u16` / `u64` moved at width 1 | **shared** — same assumption, register side |
| 2b | every hidden-POINTER placement (sret, byref) moved at `gpr_width`, truncating a 2-byte address | **shared**, found while fixing 1–2; not in the original list |
| 3 | the legalizer rejected a wide load/store through a runtime pointer | **shared** — the pass had no memory decomposition at all, at any width |
| 3b | a NARROW access through a wide pointer was silently left alone | **shared**, found while fixing 3; a latent miscompile (below) |
| 4 | wide preg moves were rejected outright | **shared** — lane decomposition did not know physical registers |
| 5 | mos6502 encoded no memory access whatsoever | **mos6502-specific** |

Only #5 is really about the 6502. The rest are places the shared backend assumed a scalar, a pointer, and a register are the same size.

### 3b is a miscompile, not a gap

The wide pointer's defining instruction is replaced by its lane moves. A narrow access whose base still names the original vreg would therefore name a vreg **nothing defines** — regalloc would hand it whatever fell out, and the access would read and write at an arbitrary address. It had to be legalized, not deferred.

## Design

- **`mir/abi.mach`** — a scalar placement carries the scalar's own size when it exceeds the machine word; a pointer placement carries `pointer_width`. Both are identities on every wide-native target, whose widest scalar and pointer *are* the machine word. The register-side rule keeps its 32-bit re-extension case; the memory side deliberately does not have one (a stack slot is not a register, so nothing has to re-extend it and the machine-word access every wide-native target emits is preserved exactly).
- **`be/codegen/legalize.mach`** — `lane_operand` gained the two operand shapes it lacked: a **physical register** (lane `i` is the `i`-th of the consecutive run, which is what naming one register for a multi-register value means) and a **memory reference** (lane `i` steps the displacement). A memory access decomposes into one native piece per lane. A **runtime-pointer base** is staged into the backend's reserved address pair (`RegMachine.scratch_reg` / `scratch_reg2` — the registers whose declared purpose is exactly this address materialization) and the access decomposes at that **fixed base**. No new machine fact was needed.
- **`isa/mos6502`** — one-byte `(zp),Y` load/store off a reserved zero-page pointer pair, and a **loud refusal of any other base**: an allocatable value register holds one byte, so reaching an address through it would read the next value in the file as the high byte. The staging pair is deliberately distinct from `PTR_LO` (a call stages its callee's hidden result pointer there, and an aliasing staging pair would clobber it between the two).

## Verification

**Executed bytes.** `fun f(v: uN) uN { ret v; }` for N ∈ {u16, u32, u64} is encoded through the real per-function encoder and **run on a reference 6502 core** — parameter read off the frame pointer, written through the hidden result pointer, pointer handed back — over a 4096-value sweep per width. The 4-byte encoding is pinned **byte-for-byte against a real `mach build --target mos` image**, so the MIR the test builds cannot drift from what the pipeline emits without failing.

**Constant time, by cycle count.** One cycle count across the whole value sweep at each width, no branch in the emitted range. `#[oblivious] fun f(v: ^u32) ^u32 { ret v; }` compiles clean through codegen (so `ctvalidate` passes it) — the executed-bytes CT proof #2195 could not reach. The 6502's only variability here is `LDA (zp),Y`'s page-crossing penalty, an **address** fact: a companion test pins that it moves the constant by exactly the number of crossing bytes without making it depend on the value, and mutating the penalty out of the core fails that test — so the guarantee rests on a faithful core, not a lenient one.

**Byte identity.** x86-64 / aarch64 / riscv64, debug **and** release, **1254 output files byte-identical** between a from-source `origin/dev` compiler and this branch's, building the same input tree. `max_alu_width == pointer_width == 8` on all three, so both new clauses are provably dead there.

**Mutations** — each fix removed, the failing test named:

| mutation | fails |
|---|---|
| defect 1 reverted | `driver:wide_scalar_builds_mos6502` (+2) — 3 failed |
| defect 2 reverted | `mir.abi:scalar_move_widths` — 1 failed |
| defect 2b (mem rule) reverted | `mir.abi:scalar_move_widths` (+3) — 4 failed |
| defect 2c (pointer width) reverted | `driver:wide_scalar_builds_mos6502` (+2) — 3 failed |
| defect 3 (memory decomposition) reverted | `legalize:expands_wide_access_at_a_fixed_base` (+4) — 5 failed |
| defect 3b (staging) reverted | `legalize:stages_runtime_pointer_into_the_address_pair` (+3) — 4 failed |
| defect 3c (narrow-through-wide) reverted | `legalize:stages_runtime_pointer_into_the_address_pair` — 1 failed |
| defect 4 (consecutive pregs) reverted | `legalize:expands_wide_preg_move_onto_consecutive_regs` — 1 failed |
| defect 5 (encoder memory) reverted | `mos6502.encode:wide_scalar_bytes_match_pipeline` (+5) — 6 failed |
| value register accepted as a base | `mos6502.encode:refuses_a_base_that_is_not_a_pointer_pair` — 1 failed |
| core forgets the page-cross penalty | `mos6502.encode:page_crossing_costs_are_address_only` — 1 failed |

**Suites.** mach **878 / 0** (dev baseline 868, +10, every one of them new here — no test removed). mach-std **611 / 0** at pin `eff1e8e`. Both run through the from-source HEAD compiler, not the PATH seed.

**Fixpoint.** Three generations, `B == C`.

## Frontier left, named accurately

The **caller** of a wide-scalar-returning function owns the result storage, so it materializes that storage's **address** — which does not fit a register either. That is a distinct piece of work (address materialization, not width legalization) and now reports `legalize: materializing an address wider than one register is not yet legalized on this target`, pinned positively in the driver test so it cannot silently regress to a different diagnostic.

#2217 (variable-count wide shift) is [assessed in a comment there](https://github.com/briar-systems/mach/issues/2217#issuecomment-5077569624) rather than implemented.
