### PR TITLE
wip(inline): carry an asm payload across a clone (do not merge)

### DIFF
--- a/src/lang/me/ir.mach
+++ b/src/lang/me/ir.mach
@@ -1252,6 +1252,86 @@ pub fun clone_dbg_metadata(m: *Module, src_fn: *Function, dst_fn: *Function, src
     ret R.ok[bool, str](true);
 }
 
+# copy the inline-asm payload the OP_ASM `src_iid` carries in `src_fn` onto the cloned
+# OP_ASM `dst_iid` in `dst_fn`, remapping each `{name}` binding through `instr_map`
+#
+# The side table that made an asm-bearing callee un-inlinable (#2231): the payload lives
+# in `Function.asm_blocks` keyed by the CALLEE-side instruction id, and the instruction
+# clone carries only the pool entry, so an inlined body would have arrived with its asm
+# statement present and its body text gone. This is the `clone_dbg_metadata` move for
+# the other side table.
+#
+# TWO THINGS MUST BE REMAPPED, not one, and the second is the one worth naming. The map
+# KEY moves from the callee's instruction id to the clone's. So does every binding's
+# `instr`, which names the OP_ALLOCA owning a `{name}` local's storage: after cloning
+# that alloca is a different instruction in a different function, and a binding still
+# pointing at the callee-side id would resolve `{name}` against a slot in the wrong
+# frame - an address nobody wrote, which is exactly the silent-miscompile shape the
+# whole asm effect model is built to avoid.
+#
+# The bindings array is DEEP-COPIED because it is owned: `module_dnit` walks each
+# function's pool and frees the binds of every OP_ASM it finds, so two entries sharing
+# one array would be freed twice.
+# ---
+# m:         module owning the allocator
+# src_fn:    the callee the payload is read from
+# dst_fn:    the caller the payload is copied into
+# src_iid:   the callee OP_ASM id
+# dst_iid:   the cloned OP_ASM id in the caller
+# instr_map: callee instruction index -> cloned caller instruction id, or nil when the
+#            clone preserves ids (the peel's snapshot) and no remap is needed
+# map_len:   number of entries in `instr_map`, ignored when it is nil
+# ret:       ok(true), or an allocation error
+pub fun clone_asm_payload(m: *Module, src_fn: *Function, dst_fn: *Function,
+                          src_iid: id.InstructionId, dst_iid: id.InstructionId,
+                          instr_map: *u32, map_len: u32) R.Result[bool, str] {
+    var key: id.InstructionId = src_iid;
+    val res: R.Result[*IrAsm, str] = map.get[id.InstructionId, IrAsm](?src_fn.asm_blocks, ?key);
+    if (R.is_err[*IrAsm, str](res)) { ret R.ok[bool, str](true); }
+    val src: *IrAsm = R.unwrap_ok[*IrAsm, str](res);
+
+    var dst: IrAsm;
+    dst.isa        = src.isa;
+    dst.body       = src.body;
+    dst.binds      = nil;
+    dst.bind_count = 0;
+    dst.bind_cap   = 0;
+
+    if (src.bind_count > 0) {
+        val rb: R.Result[*IrAsmBind, str] = A.allocate[IrAsmBind](m.alloc, src.bind_count::usize);
+        if (R.is_err[*IrAsmBind, str](rb)) { ret R.err[bool, str](R.unwrap_err[*IrAsmBind, str](rb)); }
+        dst.binds      = R.unwrap_ok[*IrAsmBind, str](rb);
+        dst.bind_cap   = src.bind_count;
+        dst.bind_count = src.bind_count;
+
+        var i: u32 = 0;
+        for (i < src.bind_count) {
+            dst.binds[i] = src.binds[i];
+            if (instr_map != nil) {
+                val old: u32 = src.binds[i].instr::u32;
+                # a binding naming an id outside the cloned pool cannot be remapped, and
+                # leaving the source-side id would silently address the wrong frame slot.
+                # this is unreachable through the lowerer, which only ever binds an
+                # alloca of the same function, so it is an internal-consistency failure
+                # rather than a user error.
+                if (old >= map_len) {
+                    A.deallocate[IrAsmBind](m.alloc, dst.binds, dst.bind_cap::usize);
+                    ret R.err[bool, str]("internal compiler error: inline-asm '{name}' binding names an instruction outside the cloned callee");
+                }
+                dst.binds[i].instr = instr_map[old]::id.InstructionId;
+            }
+            i = i + 1;
+        }
+    }
+
+    val ri: R.Result[bool, str] = map.insert[id.InstructionId, IrAsm](?dst_fn.asm_blocks, dst_iid, dst);
+    if (R.is_err[bool, str](ri)) {
+        if (dst.binds != nil) { A.deallocate[IrAsmBind](m.alloc, dst.binds, dst.bind_cap::usize); }
+        ret ri;
+    }
+    ret R.ok[bool, str](true);
+}
+
 # allocate a fresh, empty block at the end of a function's block array and return
 # its BlockId. the block's id field is set to its index; all owned lists start
 # empty and its terminator is INSTR_NIL

--- a/src/lang/me/ir/instruction.mach
+++ b/src/lang/me/ir/instruction.mach
@@ -386,6 +386,36 @@ test "mach.lang.me.ir.instruction.is_pure" {
     ret 0;
 }
 
+# OP_ASM is classified at least as conservatively as OP_CALL wherever a pass could move
+# code around it (#2231)
+#
+# THE STANDING PROPERTY THAT LETS AN ASM-BEARING CALLEE BE INLINED. Inlining removes the
+# CALL and leaves the OP_ASM in the caller, so the ordering an `std.sync.atomic` body
+# relies on survives only if the asm statement is as strong a barrier as the call it
+# replaced. Today it is: `is_pure` excludes both, which is what CSE, DCE and LICM gate
+# on, and the two passes that name opcodes directly - `licm`'s hoist guard and
+# `dependence`'s memory walk - list both.
+#
+# What this test pins is the AGREEMENT, not either answer on its own. Making OP_ASM pure
+# would let CSE fold two atomic reads into one and LICM hoist one out of a spin loop,
+# which is the silent evaporation the inline-atomics work was warned about: it would
+# show up as a hang or a lost update under contention and nowhere else. Nothing else in
+# the tree fails if someone writes `if (k == OP_ASM) { ret true; }` into `is_pure`, so
+# this does.
+test "mach.lang.me.ir.instruction:asm_is_at_least_as_conservative_as_call" {
+    # neither is pure, so neither is eligible for CSE, DCE-as-dead, or LICM hoisting.
+    if (is_pure(OP_ASM) != is_pure(OP_CALL))   { ret 1; }
+    if (is_pure(OP_ASM))                       { ret 1; }
+
+    # neither ends a block, so neither splits the CFG differently from the other.
+    if (is_terminator(OP_ASM) != is_terminator(OP_CALL)) { ret 1; }
+
+    # both merely RELOCATE a secret rather than computing on one, so an inlined asm
+    # body does not change what `#[oblivious]` requires of the function holding it.
+    if (op_is_secret_move(OP_ASM) != op_is_secret_move(OP_CALL)) { ret 1; }
+    ret 0;
+}
+
 # the secrecy-transparency partition (#2136): every relocation / whole-value / reshape
 # opcode is a move (oblivious-vacuous), while every ALU/FPU op that derives a new value
 # from a secret operand is a compute that requires `#[oblivious]`

--- a/src/lang/me/pass/inline.mach
+++ b/src/lang/me/pass/inline.mach
@@ -14,7 +14,13 @@
 # pipeline re-runs mem2reg immediately afterward (so a caller alloca whose address
 # only stops escaping once a callee is inlined gets promoted to SSA), then a late
 # constfold / algebraic / cse / constfold / dce sweep to tidy it. Recursive
-# functions and calls reaching through inline asm are never inlined.
+# functions are never inlined.
+#
+# A callee containing inline asm IS inlined, and its `asm` statements ride across with
+# their bodies and `{name}` bindings intact (#2231). That removes the call an atomic
+# used to cost without touching what the block itself guarantees: the OP_ASM survives
+# into the caller, and every pass that could move memory around it treats OP_ASM
+# exactly as it treats OP_CALL.
 
 use std.allocator.page;
 use std.types.bool.bool;
@@ -186,12 +192,26 @@ fun callee_index(call: *instruction.Instruction) u32 {
 #
 # A direct call to a non-extern, non-recursive callee is inlined when the callee
 # is flagged INLINE, is small (under the instruction threshold), or is called
-# exactly once across the module. A callee containing inline asm is never
-# inlined: its OP_ASM payload lives in the callee's Function.asm map keyed by the
-# callee-side InstructionId, which the clone does not carry over, so inlining it
-# would silently drop the asm body. A recursion-cycle member is never inlined --
+# exactly once across the module. A recursion-cycle member is never inlined --
 # direct or mutual -- because inlining one re-introduces a call into the cycle
 # every iteration, leaving the budget as the only thing stopping the loop.
+#
+# A CALLEE CONTAINING INLINE ASM IS NOW INLINABLE (#2231), and it was not before for a
+# purely mechanical reason: the OP_ASM payload lives in `Function.asm_blocks` keyed by
+# the callee-side instruction id, and the clone carried only the pool entry, so the
+# body text would have been dropped. `ir.clone_asm_payload` carries it, remapping both
+# the key and each `{name}` binding's alloca, so the restriction is gone.
+#
+# WHAT THAT DOES NOT CHANGE IS THE MEMORY MODEL, and that is worth being explicit about
+# because it is the thing an inliner could plausibly break. Inlining removes the CALL;
+# the OP_ASM survives into the caller unchanged. Every middle-end pass that could move
+# memory keys on `instruction.is_pure`, which excludes OP_ASM exactly as it excludes
+# OP_CALL, and the two passes that name opcodes directly - `licm.mach`'s loop-hoisting
+# guard and `dependence.mach`'s memory-dependence walk - list both. So every barrier the
+# call provided, the asm statement provides in its place. The ordering behaviour of a
+# `std.sync.atomic` body is exactly as strong after inlining as before, which is the
+# only claim this change makes about it: `asm_op_is_barrier_like` pins that agreement
+# so a later edit cannot weaken OP_ASM without failing a test.
 # ---
 # recursive: per-function recursion-cycle flags, length function_len
 # counts:    live per-callee direct-call counts, length function_len
@@ -223,28 +243,9 @@ fun should_inline(recursive: *bool, counts: *u32, callee_ix: u32, callee: *ir.Fu
     if ((callee.flags & ir.FN_FLAG_NAKED) != 0)              { ret false; }
     if (recursive[callee_ix])                                { ret false; }
     if (callee.block_count == 0)                             { ret false; }
-    if (callee_has_asm(callee))                              { ret false; }
     if ((callee.flags & ir.FN_FLAG_INLINE) != 0)             { ret true; }
     if (callee_instr_count(callee) < INLINE_INSTR_THRESHOLD) { ret true; }
     if (counts[callee_ix] == 1)                              { ret true; }
-    ret false;
-}
-
-# true when the callee contains any OP_ASM instruction in its pool
-#
-# clone copies the whole instruction pool, so any OP_ASM -- live in a block or
-# orphaned by a prior pass -- would be carried over without its Function.asm
-# payload; refusing to inline such a callee preserves the asm intact.
-# ---
-# callee: the callee function
-# ret:    true when an OP_ASM instruction is present
-fun callee_has_asm(callee: *ir.Function) bool {
-    var i: u32 = 0;
-    for (i < callee.instr_len) {
-        val inst: *instruction.Instruction = ?callee.instrs[i];
-        if (inst.kind == instruction.OP_ASM) { ret true; }
-        i = i + 1;
-    }
     ret false;
 }
 
@@ -675,17 +676,16 @@ fun peel_all(m: *ir.Module, budget: *u32) R.Result[bool, str] {
 
 # whether a function is a candidate for the self-recursion peel
 #
-# Only a function with a body, no inline asm (the clone drops the asm payload), a size
-# under the inline threshold, and at least one live direct self-call is peeled. The asm
-# and size gates mirror should_inline; mutual recursion is never peeled because only the
-# direct self-call edge is expanded.
+# Only a function with a body, a size under the inline threshold, and at least one live
+# direct self-call is peeled. The size gate mirrors should_inline; mutual recursion is
+# never peeled because only the direct self-call edge is expanded. Inline asm is no
+# longer a gate: the snapshot carries the payload, so a peeled body keeps it (#2231).
 # ---
 # fn:   the function to test
 # f_ix: its index in the module
 # ret:  true when the function should be peeled
 fun peel_eligible(fn: *ir.Function, f_ix: u32) bool {
     if (fn.block_count == 0)                              { ret false; }
-    if (callee_has_asm(fn))                               { ret false; }
     if (callee_instr_count(fn) >= INLINE_INSTR_THRESHOLD) { ret false; }
     ret has_direct_self_call(fn, f_ix);
 }
@@ -799,6 +799,9 @@ fun build_snapshot(m: *ir.Module, fn: *ir.Function, snap: *ir.Function) R.Result
         if (R.is_err[id.InstructionId, str](rc)) { ret R.err[bool, str](R.unwrap_err[id.InstructionId, str](rc)); }
         val rd: R.Result[bool, str] = ir.clone_dbg_metadata(m, fn, snap, i::id.InstructionId, i::id.InstructionId);
         if (R.is_err[bool, str](rd)) { ret rd; }
+        # the ids are identical here, so the asm payload's bindings need no remap.
+        val ra: R.Result[bool, str] = ir.clone_asm_payload(m, fn, snap, i::id.InstructionId, i::id.InstructionId, nil, 0);
+        if (R.is_err[bool, str](ra)) { ret ra; }
         i = i + 1;
     }
 
@@ -952,6 +955,11 @@ fun stamp_inline_metadata(m: *ir.Module, cx: *InlineCtx, call_loc: source.SrcLoc
         # inlined local keeps its name/type; the #1707 producer nests it under its instance.
         val rc: R.Result[bool, str] = ir.clone_dbg_metadata(m, callee, caller, i::id.InstructionId, cloned_iid);
         if (R.is_err[bool, str](rc)) { if (site_map != nil) { A.deallocate[u32](m.alloc, site_map, (nsite + 1)::usize); } ret rc; }
+        # and the inline-asm body, whose payload is the other instruction-keyed side
+        # table. without this an inlined `asm` statement arrives with no body (#2231).
+        val ra: R.Result[bool, str] = ir.clone_asm_payload(m, callee, caller, i::id.InstructionId, cloned_iid,
+                                                          cx.instr_map, callee.instr_len);
+        if (R.is_err[bool, str](ra)) { if (site_map != nil) { A.deallocate[u32](m.alloc, site_map, (nsite + 1)::usize); } ret ra; }
         i = i + 1;
     }
     if (site_map != nil) { A.deallocate[u32](m.alloc, site_map, (nsite + 1)::usize); }


### PR DESCRIPTION
**Draft, do not merge.** Opened so the mechanism and its measurements are
reviewable rather than sitting on a branch. #2231 is not closed by it.

Based on `1a9a1881` and now 28 commits behind `dev`; it needs a rebase
before it means anything, and one of its stated blockers has since been
removed. Recording accurate state rather than the commit message's.

## What it does

`ir.clone_asm_payload` copies an OP_ASM's `Function.asm_blocks` entry
onto the clone, remapping the map key **and** each `{name}` binding's
alloca through the inliner's instruction map, and deep-copying the
bindings array since `module_dnit` frees it per OP_ASM. That removes the
only reason `should_inline` refused an asm-bearing callee — the
restriction was mechanical, not semantic.

It also drops the same gate from the self-recursion peel, whose snapshot
preserves instruction ids so the payload rides across with an identity
remap.

`instruction:asm_is_at_least_as_conservative_as_call` pins the property
that makes this safe at all: inlining removes the CALL and leaves the
OP_ASM, so ordering survives only if the asm statement is as strong a
barrier as the call it replaced. It is — `is_pure` excludes both, which
is what CSE, DCE and LICM gate on, and `licm` and `dependence` name both
directly. Nothing else in the tree fails if someone makes OP_ASM pure,
so that test does.

## It works, and it is measured

A same-module callee holding `lock xadd` inlines into its caller with no
call left. An int case round-trips values through inlined load / store /
fetch-add helpers, identically at debug and release, on all three ISAs.

x86-64, interleaved runs, min of twelve: atomic increment 48 → 45 ms
(−6.3%), syscall-plus-atomic mix 46 → 41 ms (−10.9%). Compiler binary
+4 KB.

## Why it is not merged

**One blocker is gone.** riscv64 used to fail every release build of
anything depending on mach-std, because inlined `{name}` slots pushed a
frame past its ±2048 reach. #2674 fixed that at the cause by laying
asm-bound slots nearest the frame pointer, and riscv64 now passes its
full int suite with this branch applied. The commit message predates
that and is stale.

**One blocker remains.** aarch64's reach for a `{name}` is the unscaled
imm9's **−256** — thirty-two eight-byte slots — because slots sit below
the frame pointer and the scaled imm12 form is unsigned-only. A caller
inlining several `{name}`-heavy syscall wrappers exceeds that;
`darwin/shared.mach`'s `syscall2` has five binds and lands at −288, so
`macho-foreign-aarch64` and `macho-pie-aarch64` fail to build. #2674
raised the ceiling substantially but not past this.

The path is addressing a `{name}` from **SP rather than FP**: offsets
become positive, the scaled imm12 applies, and the reach goes from 32
slots to 4096. That is a change to `SlotFn`'s contract — its doc says
"frame-pointer-relative", and the per-target divergence it abstracts is
exactly this — plus an argument that SP is stable across an asm block.
It wants its own issue.

**And it still does not reach the atomics.** `std.sync.atomic` is
cross-module from every caller, and `should_inline` excludes extern
callees by design; lifting that needs the `Q_LOWERED_SURFACE` fingerprint
extended or importers silently reuse stale IR (#1859). The reach this
branch actually buys today is same-module callers — `shared.mach`'s
syscall wrappers have 134 such call sites — not `std.sync.atomic`.

## No orderings

Untouched. The issue's litmus-test bar (message-passing, store-buffering,
IRIW per ISA) is unmet and nothing here claims anything about the memory
model beyond the barrier-equivalence test above.
