### PR TITLE
fix: reject a dangling operand and a phi edge with no incoming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,17 @@ A textured shader emits a **byte-identical module** across the migration: the sa
 
 ### Fixed
 
+#### The compiler was silent both times a pass dropped a value and missed a use (#2930, #2931)
+`#2749` was an `i32x4` accumulator on x86-64 that came out holding the multiplier. `#2917` was a conditional float merge on riscv64 that read its register undefined. Both were silent wrong answers, both were found by running a program, and `--verify-ir` exited 0 on both reproducers. The pass mistake behind them is ordinary. Being undetectable was not.
+
+The instruction pool keeps every instruction a pass ever created, detached ones included, so an operand naming a dropped value still resolves and reads as an ordinary use. Only the block lists say what reaches the back end, and nothing measured operands against them. The one check that could have was dominance, which walked block bodies and terminators and never phi lists, and returned early for a phi on top of that, so a phi incoming naming a dropped value was invisible twice over. It also rode the `full` flag, so it ran only in the post-DCE stages.
+
+`VC_DANGLING_OPERAND` now builds the live set once per function from the block lists and scans every live instruction's operands against it. It needs no dominator tree and no reachability, so it is always on and holds at every pipeline stage rather than only some of them. Dominance no longer exempts a phi: an incoming is measured at the END of the predecessor the pair names, which is the point the value has to be live out of for the edge copy to read it.
+
+Phi destruction had the matching hole and is what turned the IR defect into wrong code rather than a build failure. `lower_block_phis` searched a phi's operand pairs for the predecessor edge it was emitting and, finding none, moved on with no copy and no error, while the four other malformed inputs in the same function each fail the build. Out-of-SSA is total, so a merge register that is not defined on every path in is a malformed input rather than a case, and it now errors with the phi's block, the predecessor and the result vreg, since the pass that dropped the incoming is well upstream of MIR lowering.
+
+Both are diagnostic. Object output is byte-identical per target across x86-64, aarch64 and riscv64.
+
 #### A shader built at `-O0` and was refused at `-O2` (#2921)
 Three sequential array loops in one function built cleanly for `spirv` at `-O0` and at `-g`, and `-O2` refused them: `a loop whose exits do not reconverge on one block is not yet supported by the SPIR-V target`. `-O2` is what ships, so a shader that only compiles at `-O0` does not work, and a profile that reorders and simplifies must not turn an expressible function into an inexpressible one.
 

--- a/src/lang/be/codegen/mir/lower.mach
+++ b/src/lang/be/codegen/mir/lower.mach
@@ -66,8 +66,11 @@
 # secret reaching a branch / index / div / mod / float operand unconstructable, and
 # SEED COMPLETENESS (every secret source marked) is what makes #1648's re-derive sound.
 
+use std.allocator.page;
 use std.collections.map;
+use std.format;
 use std.types.bool.bool;
+use std.types.string.str_contains;
 use std.types.bool.true;
 use std.types.bool.false;
 use std.types.size.usize;
@@ -85,11 +88,13 @@ use mabi: mach.lang.be.codegen.mir.abi;
 use lctx: mach.lang.be.codegen.mir.context;
 use mach.lang.intern;
 use mach.lang.me.ir;
+use mach.lang.me.ir.builder;
 use mach.lang.me.ir.id;
 use instr: mach.lang.me.ir.instruction;
 use ir_type: mach.lang.me.ir.type;
 use mach.lang.me.ir.value;
 use mach.lang.source;
+use treg: mach.lang.target;
 use target: mach.lang.target.resolved;
 
 # lower an IR module to a parallel MIR module, one MIR function per IR function
@@ -463,6 +468,15 @@ fun lower_block_phis(ctx: *lctx.LowerCtx, fn: *ir.Function, blk: *ir.Block) R.Re
                 }
                 k = k + 2;
             }
+            # out-of-SSA is total: the phi's result vreg has to be defined on EVERY
+            # path into its block, so an edge with no incoming is a malformed input
+            # like the four above it and not a case. lowering it emits no copy and
+            # leaves the merge register read undefined on that path (#2917).
+            if (!found) {
+                err_msg = phi_edge_err(ctx, blk.id::u32, pred_id, dst_vreg);
+                hi = hi + 1;
+                cnt;
+            }
             hi = hi + 1;
         }
 
@@ -478,6 +492,26 @@ fun lower_block_phis(ctx: *lctx.LowerCtx, fn: *ir.Function, blk: *ir.Block) R.Re
     A.deallocate[u8](ctx.alloc, wids, np::usize);
     if (err_msg != nil) { ret R.err[bool, str](err_msg); }
     ret R.ok[bool, str](true);
+}
+
+# build the message for a phi edge that carries no incoming value
+#
+# The pass that dropped the incoming is well upstream of MIR lowering, so the block
+# pair and the merge vreg are the only thread back to it and a static string would
+# name none of them. Built on `ctx.alloc`, the session allocator the error is read on.
+# ---
+# ctx:      the per-function lowering context (supplies the allocator)
+# block_id: the phi's own block
+# pred_id:  the predecessor edge that has no incoming
+# dst_vreg: the phi result's vreg
+# ret:      the formatted message, or a static fallback when formatting fails
+fun phi_edge_err(ctx: *lctx.LowerCtx, block_id: u32, pred_id: u32, dst_vreg: u32) str {
+    val fallback: str = "mir.lower_ir: phi has no incoming value for a predecessor edge";
+    val rj: R.Result[str, str] = format.sprint(ctx.alloc,
+        "mir.lower_ir: phi in block {} has no incoming value for predecessor block {} (result vreg {})",
+        block_id, pred_id, dst_vreg);
+    if (R.is_err[str, str](rj)) { ret fallback; }
+    ret R.unwrap_ok[str, str](rj);
 }
 
 # return the MIR block whose id equals `block_id`, or nil if absent
@@ -3012,4 +3046,106 @@ fun struct_field_type(ctx: *lctx.LowerCtx, struct_ty: ir_type.IrTypeId, ix: u32)
         ret R.err[ir_type.IrTypeId, str]("mir.lower_ir: gep struct field index out of range");
     }
     ret R.ok[ir_type.IrTypeId, str](st.data.struct_.fields[ix]);
+}
+
+# builds a one-function module whose block 3 merges a diamond through an i64 phi, and
+# lowers it for linux-x86_64. `cover_both` selects whether the phi carries an incoming
+# for BOTH predecessor edges or only for block 1, which is the malformed input
+# ---
+# out_err: set to the lowering error message when lowering fails
+# ret:     true when lowering succeeded
+fun t_lower_diamond_phi(alloc: *A.Allocator, cover_both: bool, out_err: *str) bool {
+    out_err[0] = nil;
+
+    var reg: treg.TargetRegistry = treg.registry_init();
+    if (R.is_err[bool, str](treg.register_all(?reg))) { ret false; }
+    val tr: R.Result[target.Target, str] = treg.select(?reg, "x86_64", "linux", "sysv64");
+    if (R.is_err[target.Target, str](tr)) { ret false; }
+    var tgt: target.Target = R.unwrap_ok[target.Target, str](tr);
+
+    var itn: intern.Interner  = intern.init(alloc);
+    var smap: source.SourceMap = source.init(alloc);
+
+    val mr: R.Result[ir.Module, str] = ir.init(alloc, intern.STR_NIL);
+    if (R.is_err[ir.Module, str](mr)) { ret false; }
+    var m: ir.Module = R.unwrap_ok[ir.Module, str](mr);
+
+    val it: R.Result[ir_type.IrTypeId, str] = ir_type.intern_int(?m.types, 64);
+    if (R.is_err[ir_type.IrTypeId, str](it)) { ret false; }
+    val i64ty: ir_type.IrTypeId = R.unwrap_ok[ir_type.IrTypeId, str](it);
+    val vt: R.Result[ir_type.IrTypeId, str] = ir_type.intern_void(?m.types);
+    if (R.is_err[ir_type.IrTypeId, str](vt)) { ret false; }
+    val voidty: ir_type.IrTypeId = R.unwrap_ok[ir_type.IrTypeId, str](vt);
+    val sr: R.Result[ir_type.IrTypeId, str] = ir_type.intern_fn(?m.types, voidty, nil, 0, false);
+    if (R.is_err[ir_type.IrTypeId, str](sr)) { ret false; }
+    if (R.is_err[u32, str](ir.function_add(?m, intern.STR_NIL, R.unwrap_ok[ir_type.IrTypeId, str](sr), 0))) { ret false; }
+
+    var bld: builder.Builder = builder.init(?m);
+    builder.set_function(?bld, ?m.functions[0]);
+    var bids: [4]id.BlockId;
+    var i: u32 = 0;
+    for (i < 4) {
+        val br: R.Result[id.BlockId, str] = builder.new_block(?bld);
+        if (R.is_err[id.BlockId, str](br)) { ret false; }
+        bids[i] = R.unwrap_ok[id.BlockId, str](br);
+        i = i + 1;
+    }
+    val c: value.Value = value.const_int(0, i64ty);
+
+    builder.set_block(?bld, bids[0]);
+    if (R.is_err[bool, str](builder.emit_cbr(?bld, value.const_int(1, i64ty), bids[1], bids[2]))) { ret false; }
+
+    builder.set_block(?bld, bids[1]);
+    val lv: R.Result[value.Value, str] = builder.emit_add(?bld, c, c);
+    if (R.is_err[value.Value, str](lv)) { ret false; }
+    val l: value.Value = R.unwrap_ok[value.Value, str](lv);
+    if (R.is_err[bool, str](builder.emit_br(?bld, bids[3]))) { ret false; }
+
+    builder.set_block(?bld, bids[2]);
+    val rv: R.Result[value.Value, str] = builder.emit_add(?bld, c, c);
+    if (R.is_err[value.Value, str](rv)) { ret false; }
+    val rt: value.Value = R.unwrap_ok[value.Value, str](rv);
+    if (R.is_err[bool, str](builder.emit_br(?bld, bids[3]))) { ret false; }
+
+    builder.set_block(?bld, bids[3]);
+    val pv: R.Result[value.Value, str] = builder.emit_phi(?bld, i64ty);
+    if (R.is_err[value.Value, str](pv)) { ret false; }
+    val p: value.Value = R.unwrap_ok[value.Value, str](pv);
+    if (R.is_err[bool, str](builder.phi_add_incoming(?bld, p, bids[1], l))) { ret false; }
+    if (cover_both) {
+        if (R.is_err[bool, str](builder.phi_add_incoming(?bld, p, bids[2], rt))) { ret false; }
+    }
+    if (R.is_err[value.Value, str](builder.emit_add(?bld, p, c))) { ret false; }
+    if (R.is_err[bool, str](builder.emit_ret_void(?bld)))         { ret false; }
+
+    val lr: R.Result[mir.MirModule, str] = lower_ir(?tgt, ?m, alloc, ?itn, ?smap);
+    if (R.is_err[mir.MirModule, str](lr)) {
+        out_err[0] = R.unwrap_err[mir.MirModule, str](lr);
+        ret false;
+    }
+    ret true;
+}
+
+# out-of-SSA is total: a phi's result vreg must be defined on every path into its
+# block, so a predecessor edge with no incoming is a malformed input like the four
+# already handled beside it, not a case to lower. it used to emit no copy at all and
+# leave the merge register read undefined on that path, which is how #2917 became a
+# wrong answer instead of a build failure. the message names the block pair and the
+# result vreg because the pass that dropped the incoming is well upstream of here
+test "mach.lang.be.codegen.mir.lower.lower_block_phis:missing_incoming" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+    var err: str = nil;
+
+    # positive control: the same diamond with both edges covered lowers cleanly
+    if (!t_lower_diamond_phi(?alloc, true, ?err)) { ret 1; }
+
+    if (t_lower_diamond_phi(?alloc, false, ?err)) { ret 1; }
+    if (err == nil)                                  { ret 1; }
+    if (!str_contains(err, "no incoming value"))     { ret 1; }
+    # the phi's own block, the uncovered predecessor, and the merge result
+    if (!str_contains(err, "block 3"))               { ret 1; }
+    if (!str_contains(err, "block 2"))               { ret 1; }
+    if (!str_contains(err, "result vreg"))           { ret 1; }
+    ret 0;
 }

--- a/src/lang/me/ir/verify.mach
+++ b/src/lang/me/ir/verify.mach
@@ -60,7 +60,7 @@ pub val VC_OPERAND_TYPE:    VerifyCheck = 6;
 # a VAL_CONST_* operand carries a type incompatible with its kind
 pub val VC_CONST_TYPE:      VerifyCheck = 7;
 # a VAL_INSTR operand references a def that does not dominate the use. a non-phi
-# operand is measured against the using instruction itself; a phi incoming is
+# operand is measured against the using instruction itself. a phi incoming is
 # measured against the END of the predecessor block the pair names, since that is
 # the point the incoming value is live out of
 pub val VC_DOMINANCE:       VerifyCheck = 8;
@@ -1771,10 +1771,11 @@ fun index_definitions(fn: *ir.Function, def_block: *u32, def_ord: *u32) {
     }
 }
 
-# checks every VAL_INSTR operand of a non-phi instruction for dominance. an
-# operand whose def was never placed (def_block DEF_BLOCK_NIL) is flagged
-# unconditionally; an inter-block dominance check is run only when the use's block
-# is reachable (an unreachable use block is already a VC_REACHABILITY)
+# checks every VAL_INSTR operand of a non-phi instruction for dominance. an operand
+# whose def was never placed has no defining block to measure from and is
+# VC_DANGLING_OPERAND's, which reports it in every run rather than only the `full`
+# ones. the dominance check is run only when the use's block is reachable (an
+# unreachable use block is already a VC_REACHABILITY)
 # ---
 # fn:            the enclosing function
 # ins:           the using instruction

--- a/src/lang/me/ir/verify.mach
+++ b/src/lang/me/ir/verify.mach
@@ -59,7 +59,10 @@ pub val VC_PHI_COVERAGE:    VerifyCheck = 5;
 pub val VC_OPERAND_TYPE:    VerifyCheck = 6;
 # a VAL_CONST_* operand carries a type incompatible with its kind
 pub val VC_CONST_TYPE:      VerifyCheck = 7;
-# a VAL_INSTR operand references a def that does not dominate the use
+# a VAL_INSTR operand references a def that does not dominate the use. a non-phi
+# operand is measured against the using instruction itself; a phi incoming is
+# measured against the END of the predecessor block the pair names, since that is
+# the point the incoming value is live out of
 pub val VC_DOMINANCE:       VerifyCheck = 8;
 # a non-entry block is unreachable (empty preds, referenced nowhere)
 pub val VC_REACHABILITY:    VerifyCheck = 9;
@@ -134,6 +137,26 @@ pub val VC_BITCAST_CLASS:   VerifyCheck = 15;
 # operand with no dataflow needed, and a conversion is exactly where a front-end
 # classification error lands, so it names the site instead of reaching codegen
 pub val VC_CONVERT_WIDTH:   VerifyCheck = 16;
+
+# a VAL_INSTR operand of a live instruction names an instruction no block list of
+# the same function holds - a value some pass detached and left a use of.
+#
+# The instruction POOL retains every instruction a pass ever created, including the
+# ones it detached, so a dangling operand still resolves through `ir.instruction_get`
+# and reads as an ordinary value everywhere downstream. Only the block lists say what
+# reaches the back end, so the live set is the one this is measured against.
+#
+# The back end lowers such an operand into a read of a register nothing ever wrote,
+# which is a silent wrong ANSWER rather than a fault: #2749 (a loop-carried i32x4
+# accumulator that came out holding the multiplier) and #2917 (a conditional float
+# merge that read its register undefined) both shipped that way, and `--verify-ir`
+# exited 0 on both reproducers. A pass that drops an instruction and misses one of its
+# uses is an ordinary mistake, and this is the invariant that makes it loud.
+#
+# Always on and O(instructions): one live-set pass over the block lists per function,
+# then one scan. Unlike VC_DOMINANCE this needs no dominator tree and no reachability,
+# so it holds at every pipeline stage rather than only the post-DCE ones
+pub val VC_DANGLING_OPERAND: VerifyCheck = 17;
 
 # one invariant failure, located as precisely as the failing check allows
 # ---
@@ -269,6 +292,7 @@ pub fun describe(check: VerifyCheck) str {
     if (check == VC_DANGLING_ID)     { ret "dangling id: a block list names an out-of-range instruction id"; }
     if (check == VC_TYPE_AGREE)      { ret "type agreement: operand types violate the opcode's typing contract"; }
     if (check == VC_CALL_ARG_TYPE)   { ret "call argument typing: a call argument's type disagrees with the callee's declared parameter"; }
+    if (check == VC_DANGLING_OPERAND) { ret "dangling operand: an operand names an instruction no block list of this function holds"; }
     if (check == VC_CONVERT_WIDTH)   { ret "conversion width: a conversion's result width contradicts its opcode (a bitcast must keep the width, a truncation must narrow, an extension must widen)"; }
     ret "unknown verification check";
 }
@@ -388,6 +412,9 @@ fun verify_function(m: *ir.Module, fn: *ir.Function, fi: u32, r: *VerifyReport, 
 
     val res_lists: R.Result[bool, str] = check_block_lists(fn, fi, r);
     if (R.is_err[bool, str](res_lists)) { ret res_lists; }
+
+    val res_ops: R.Result[bool, str] = check_operand_defs(fn, fi, r);
+    if (R.is_err[bool, str](res_ops)) { ret res_ops; }
 
     var bi: u32 = 0;
     for (bi < fn.block_count) {
@@ -533,6 +560,102 @@ fun check_block_lists(fn: *ir.Function, fi: u32, r: *VerifyReport) R.Result[bool
 fun check_listed_id(fn: *ir.Function, iid: id.InstructionId, fi: u32, bid: id.BlockId, r: *VerifyReport) R.Result[bool, str] {
     if (iid == id.INSTR_NIL || iid >= fn.instr_len) {
         ret push(r, fi, bid, iid, VC_DANGLING_ID);
+    }
+    ret R.ok[bool, str](true);
+}
+
+# VC_DANGLING_OPERAND: every VAL_INSTR operand of every live instruction must name
+# an instruction that some block list of the same function still holds. the live set
+# is built once from the block lists (phis, body, terminator), then every live
+# instruction's operands are scanned against it.
+#
+# checking the instruction POOL instead would check the wrong set: the pool keeps
+# every instruction a pass ever created, detached ones included, so an operand naming
+# a dropped value resolves there and reads as an ordinary use. an out-of-range operand
+# id is reported here too - no other check looks at operand ids, only at the ids block
+# lists name.
+# ---
+# fn:  the function to check
+# fi:  index of fn into Module.functions
+# r:   the report to record into
+# ret: true on completion, or an allocation error
+fun check_operand_defs(fn: *ir.Function, fi: u32, r: *VerifyReport) R.Result[bool, str] {
+    if (fn.instr_len == 0) { ret R.ok[bool, str](true); }
+    val res_live: R.Result[*u8, str] = A.allocate[u8](r.alloc, fn.instr_len::usize);
+    if (R.is_err[*u8, str](res_live)) { ret R.err[bool, str](R.unwrap_err[*u8, str](res_live)); }
+    val live: *u8 = R.unwrap_ok[*u8, str](res_live);
+    var i: u32 = 0;
+    for (i < fn.instr_len) { live[i] = 0; i = i + 1; }
+
+    var bi: u32 = 0;
+    for (bi < fn.block_count) {
+        val blk: *ir.Block = ?fn.blocks[bi];
+        var p: u32 = 0;
+        for (p < blk.phi_count) {
+            if (blk.phis[p] < fn.instr_len) { live[blk.phis[p]] = 1; }
+            p = p + 1;
+        }
+        var ix: u32 = 0;
+        for (ix < blk.instr_count) {
+            if (blk.instructions[ix] < fn.instr_len) { live[blk.instructions[ix]] = 1; }
+            ix = ix + 1;
+        }
+        if (blk.terminator != id.INSTR_NIL && blk.terminator < fn.instr_len) {
+            live[blk.terminator] = 1;
+        }
+        bi = bi + 1;
+    }
+
+    var cb: u32 = 0;
+    for (cb < fn.block_count) {
+        val blk: *ir.Block = ?fn.blocks[cb];
+        var p: u32 = 0;
+        for (p < blk.phi_count) {
+            val rr: R.Result[bool, str] = check_uses_live(fn, live, blk.phis[p], fi, blk.id, r);
+            if (R.is_err[bool, str](rr)) { A.deallocate[u8](r.alloc, live, fn.instr_len::usize); ret rr; }
+            p = p + 1;
+        }
+        var ix: u32 = 0;
+        for (ix < blk.instr_count) {
+            val rr: R.Result[bool, str] = check_uses_live(fn, live, blk.instructions[ix], fi, blk.id, r);
+            if (R.is_err[bool, str](rr)) { A.deallocate[u8](r.alloc, live, fn.instr_len::usize); ret rr; }
+            ix = ix + 1;
+        }
+        if (blk.terminator != id.INSTR_NIL) {
+            val rr: R.Result[bool, str] = check_uses_live(fn, live, blk.terminator, fi, blk.id, r);
+            if (R.is_err[bool, str](rr)) { A.deallocate[u8](r.alloc, live, fn.instr_len::usize); ret rr; }
+        }
+        cb = cb + 1;
+    }
+
+    A.deallocate[u8](r.alloc, live, fn.instr_len::usize);
+    ret R.ok[bool, str](true);
+}
+
+# checks one live instruction's VAL_INSTR operands against the live set. an
+# out-of-range `iid` is the block list's own defect and VC_DANGLING_ID reports it
+# ---
+# fn:   the enclosing function
+# live: per-id live flag buffer, sized by fn.instr_len (1 once a block list holds it)
+# iid:  the using instruction
+# fi:   index of fn into Module.functions
+# bid:  the block holding iid (located on a violation)
+# r:    the report to record into
+# ret:  true on completion, or an allocation error
+fun check_uses_live(fn: *ir.Function, live: *u8, iid: id.InstructionId, fi: u32, bid: id.BlockId, r: *VerifyReport) R.Result[bool, str] {
+    if (iid >= fn.instr_len) { ret R.ok[bool, str](true); }
+    val ins: *instruction.Instruction = ?fn.instrs[iid];
+    var oi: u32 = 0;
+    for (oi < ins.operand_count) {
+        val op: *value.Value = ?ins.operands[oi];
+        if (op.kind == value.VAL_INSTR) {
+            val def_id: id.InstructionId = op.data.instr;
+            if (def_id >= fn.instr_len || live[def_id] == 0) {
+                val rr: R.Result[bool, str] = push(r, fi, bid, iid, VC_DANGLING_OPERAND);
+                if (R.is_err[bool, str](rr)) { ret rr; }
+            }
+        }
+        oi = oi + 1;
     }
     ret R.ok[bool, str](true);
 }
@@ -1373,10 +1496,18 @@ rec DomScratch {
 # use. dominators are computed by the near-linear Cooper-Harvey-Kennedy idom
 # algorithm over the reverse-postorder of the CFG (successors decoded through
 # ir.block_successors); each use is then checked intra-block by ordinal and
-# inter-block by an idom-chain ancestor walk. phi operands are exempt - a phi
-# legitimately uses values defined in predecessor blocks that need not dominate
-# the phi's own block. an operand whose def was never placed in any block (it
-# never executes) cannot dominate any use and is flagged.
+# inter-block by an idom-chain ancestor walk.
+#
+# A phi is not exempt, it is measured at a different point. A phi legitimately uses
+# values defined in predecessor blocks that need not dominate the phi's own block, so
+# each incoming is checked against the END of the predecessor the pair names - the
+# point the value has to be live out of for the edge copy to read it. Measuring an
+# incoming at the phi's own block would reject every ordinary merge, and exempting it
+# is what let a phi carry a use above its definition all the way to the back end.
+#
+# An operand naming an instruction no block list holds is VC_DANGLING_OPERAND's to
+# report: it has no defining block to measure from, and it is caught unconditionally
+# there rather than only in the `full` runs this check rides.
 # ---
 # fn:  the function to check
 # fi:  index of fn into Module.functions
@@ -1398,6 +1529,16 @@ fun check_dominance(fn: *ir.Function, fi: u32, r: *VerifyReport) R.Result[bool, 
     for (bi < n) {
         val blk: *ir.Block = ?fn.blocks[bi];
         val reachable: bool = sc.rpo_num[bi] != RPO_NIL;
+        var p: u32 = 0;
+        for (p < blk.phi_count) {
+            val phi_id: id.InstructionId = blk.phis[p];
+            if (phi_id < fn.instr_len) {
+                val ins: *instruction.Instruction = ?fn.instrs[phi_id];
+                val rr: R.Result[bool, str] = check_phi_incomings_dominate(fn, ins, ?sc, fi, blk.id, phi_id, r);
+                if (R.is_err[bool, str](rr)) { dom_scratch_free(r.alloc, ?sc); ret rr; }
+            }
+            p = p + 1;
+        }
         var ix: u32 = 0;
         for (ix < blk.instr_count) {
             val use_id: id.InstructionId = blk.instructions[ix];
@@ -1655,17 +1796,53 @@ fun check_operands_dominate(fn: *ir.Function, ins: *instruction.Instruction, use
             val def_id: id.InstructionId = op.data.instr;
             if (def_id < fn.instr_len) {
                 val db: u32 = sc.def_block[def_id];
-                if (db == DEF_BLOCK_NIL) {
-                    val rr: R.Result[bool, str] = push(r, fi, bid, use_id, VC_DOMINANCE);
-                    if (R.is_err[bool, str](rr)) { ret rr; }
-                }
-                or (use_reachable && !def_dominates_use(sc, db, sc.def_ord[def_id], use_block, use_ord)) {
+                if (db != DEF_BLOCK_NIL && use_reachable
+                    && !def_dominates_use(sc, db, sc.def_ord[def_id], use_block, use_ord)) {
                     val rr: R.Result[bool, str] = push(r, fi, bid, use_id, VC_DOMINANCE);
                     if (R.is_err[bool, str](rr)) { ret rr; }
                 }
             }
         }
         oi = oi + 1;
+    }
+    ret R.ok[bool, str](true);
+}
+
+# checks every incoming of one phi against the exit of the predecessor it names. an
+# incoming has to be live out of that edge, so its definition must dominate the
+# predecessor's END: either it is defined in the predecessor itself (every definition
+# there precedes the block's exit) or its block dominates the predecessor.
+#
+# An unreachable predecessor is not judged - it has no dominator relation to read, and
+# VC_REACHABILITY already reports it. An operand with no defining block is
+# VC_DANGLING_OPERAND's, and a malformed pair (a block slot that is not a block id) is
+# VC_PHI_COVERAGE's
+# ---
+# fn:     the enclosing function
+# ins:    the phi whose incomings are checked
+# sc:     the scratch record (def_block/idom/rpo_num populated)
+# fi:     index of fn into Module.functions
+# bid:    the block holding the phi (located on a violation)
+# use_id: the phi's instruction id (located on a violation)
+# r:      the report to record into
+# ret:    true on completion, or an allocation error
+fun check_phi_incomings_dominate(fn: *ir.Function, ins: *instruction.Instruction, sc: *DomScratch, fi: u32, bid: id.BlockId, use_id: id.InstructionId, r: *VerifyReport) R.Result[bool, str] {
+    if (ins.kind != instruction.OP_PHI) { ret R.ok[bool, str](true); }
+    var k: u32 = 0;
+    for (k + 1 < ins.operand_count) {
+        val pred: id.BlockId = ir.block_target(ins.operands[k]);
+        val op: *value.Value = ?ins.operands[k + 1];
+        if (op.kind == value.VAL_INSTR && pred < sc.n && sc.rpo_num[pred] != RPO_NIL) {
+            val def_id: id.InstructionId = op.data.instr;
+            if (def_id < fn.instr_len) {
+                val db: u32 = sc.def_block[def_id];
+                if (db != DEF_BLOCK_NIL && db != pred::u32 && !block_dominates(sc, db, pred::u32)) {
+                    val rr: R.Result[bool, str] = push(r, fi, bid, use_id, VC_DOMINANCE);
+                    if (R.is_err[bool, str](rr)) { ret rr; }
+                }
+            }
+        }
+        k = k + 2;
     }
     ret R.ok[bool, str](true);
 }
@@ -2951,4 +3128,168 @@ test "mach.lang.me.ir.verify.describe_located:spanless_says_so" {
     source.dnit(?smap);
     intern.dnit(?itn);
     ret code;
+}
+
+# detaches an instruction from a block's body list, leaving it in the instruction
+# pool. this is the exact state a pass that drops a value and misses one of its uses
+# leaves behind, and the state every pool-based walk reads as an ordinary instruction
+# ---
+# env: the test environment
+# b:   the block whose body list is edited
+# iid: the instruction to detach
+# ret: true when the id was found and removed
+fun t_drop(env: *TEnv, b: id.BlockId, iid: id.InstructionId) bool {
+    val fn: *ir.Function = ?env.m.functions[0];
+    if (b::u32 >= fn.block_count) { ret false; }
+    val blk: *ir.Block = ?fn.blocks[b::u32];
+    var i: u32 = 0;
+    for (i < blk.instr_count) {
+        if (blk.instructions[i] == iid) {
+            var j: u32 = i;
+            for (j + 1 < blk.instr_count) { blk.instructions[j] = blk.instructions[j + 1]; j = j + 1; }
+            blk.instr_count = blk.instr_count - 1;
+            ret true;
+        }
+        i = i + 1;
+    }
+    ret false;
+}
+
+# a use whose definition a pass detached is rejected, and the same module with the
+# definition still listed is accepted. run with `full` clear: a dangling operand is an
+# unconditional invariant, not a post-DCE one
+test "mach.lang.me.ir.verify.check_operand_defs:dropped_def" {
+    var env: TEnv;
+    if (!t_env(?env)) { ret 1; }
+    val b0: id.BlockId = t_block(?env);
+    if (b0 != 0) { ret 1; }
+    val c: value.Value = t_ci(?env, 0);
+
+    builder.set_block(?env.bld, b0);
+    val dv: R.Result[value.Value, str] = builder.emit_add(?env.bld, c, c);
+    if (R.is_err[value.Value, str](dv)) { ret 1; }
+    val d: value.Value = R.unwrap_ok[value.Value, str](dv);
+    if (R.is_err[value.Value, str](builder.emit_add(?env.bld, d, c))) { ret 1; }
+    if (R.is_err[bool, str](builder.emit_ret_void(?env.bld)))         { ret 1; }
+
+    # positive control: the same module, well formed, must still pass
+    if (t_total(?env, false, false) != 0) { ret 1; }
+
+    if (!t_drop(?env, b0, d.data.instr)) { ret 1; }
+    if (t_count(?env, false, false, VC_DANGLING_OPERAND) != 1) { ret 1; }
+    ret 0;
+}
+
+# the #2917 shape: a phi incoming naming an instruction the block lists no longer
+# hold. this is the one the old verifier accepted, since dominance skipped phis
+# outright and nothing else looked at operands at all
+test "mach.lang.me.ir.verify.check_operand_defs:dropped_phi_incoming" {
+    var env: TEnv;
+    if (!t_env(?env)) { ret 1; }
+    val b0: id.BlockId = t_block(?env);
+    val b1: id.BlockId = t_block(?env);
+    val b2: id.BlockId = t_block(?env);
+    val b3: id.BlockId = t_block(?env);
+    if (b3 != 3) { ret 1; }
+    val c: value.Value = t_ci(?env, 0);
+
+    builder.set_block(?env.bld, b0);
+    if (R.is_err[bool, str](builder.emit_cbr(?env.bld, t_ci(?env, 1), b1, b2))) { ret 1; }
+
+    builder.set_block(?env.bld, b1);
+    val lv: R.Result[value.Value, str] = builder.emit_add(?env.bld, c, c);
+    if (R.is_err[value.Value, str](lv)) { ret 1; }
+    val l: value.Value = R.unwrap_ok[value.Value, str](lv);
+    if (R.is_err[bool, str](builder.emit_br(?env.bld, b3))) { ret 1; }
+
+    builder.set_block(?env.bld, b2);
+    val rv: R.Result[value.Value, str] = builder.emit_add(?env.bld, c, c);
+    if (R.is_err[value.Value, str](rv)) { ret 1; }
+    val rt: value.Value = R.unwrap_ok[value.Value, str](rv);
+    if (R.is_err[bool, str](builder.emit_br(?env.bld, b3))) { ret 1; }
+
+    builder.set_block(?env.bld, b3);
+    val pv: R.Result[value.Value, str] = builder.emit_phi(?env.bld, env.i64ty);
+    if (R.is_err[value.Value, str](pv)) { ret 1; }
+    val p: value.Value = R.unwrap_ok[value.Value, str](pv);
+    if (R.is_err[bool, str](builder.phi_add_incoming(?env.bld, p, b1, l)))  { ret 1; }
+    if (R.is_err[bool, str](builder.phi_add_incoming(?env.bld, p, b2, rt))) { ret 1; }
+    if (R.is_err[value.Value, str](builder.emit_add(?env.bld, p, c))) { ret 1; }
+    if (R.is_err[bool, str](builder.emit_ret_void(?env.bld)))         { ret 1; }
+
+    # positive control: the well-formed merge passes every check, dominance included
+    if (t_total(?env, true, false) != 0) { ret 1; }
+
+    if (!t_drop(?env, b2, rt.data.instr)) { ret 1; }
+    if (t_count(?env, false, false, VC_DANGLING_OPERAND) != 1) { ret 1; }
+    ret 0;
+}
+
+# a phi incoming is measured at the exit of the predecessor it names: a value defined
+# in the sibling arm is not live out of the other edge, and is rejected. the
+# well-formed merge above is the paired positive control
+test "mach.lang.me.ir.verify.check_dominance:phi_incoming_not_live_out_of_pred" {
+    var env: TEnv;
+    if (!t_env(?env)) { ret 1; }
+    val b0: id.BlockId = t_block(?env);
+    val b1: id.BlockId = t_block(?env);
+    val b2: id.BlockId = t_block(?env);
+    val b3: id.BlockId = t_block(?env);
+    if (b3 != 3) { ret 1; }
+    val c: value.Value = t_ci(?env, 0);
+
+    builder.set_block(?env.bld, b0);
+    if (R.is_err[bool, str](builder.emit_cbr(?env.bld, t_ci(?env, 1), b1, b2))) { ret 1; }
+
+    builder.set_block(?env.bld, b1);
+    if (R.is_err[bool, str](builder.emit_br(?env.bld, b3))) { ret 1; }
+
+    builder.set_block(?env.bld, b2);
+    val rv: R.Result[value.Value, str] = builder.emit_add(?env.bld, c, c);
+    if (R.is_err[value.Value, str](rv)) { ret 1; }
+    val rt: value.Value = R.unwrap_ok[value.Value, str](rv);
+    if (R.is_err[bool, str](builder.emit_br(?env.bld, b3))) { ret 1; }
+
+    builder.set_block(?env.bld, b3);
+    val pv: R.Result[value.Value, str] = builder.emit_phi(?env.bld, env.i64ty);
+    if (R.is_err[value.Value, str](pv)) { ret 1; }
+    val p: value.Value = R.unwrap_ok[value.Value, str](pv);
+    # the b1 edge carries a value only the b2 arm defines
+    if (R.is_err[bool, str](builder.phi_add_incoming(?env.bld, p, b1, rt))) { ret 1; }
+    if (R.is_err[bool, str](builder.phi_add_incoming(?env.bld, p, b2, rt))) { ret 1; }
+    if (R.is_err[value.Value, str](builder.emit_add(?env.bld, p, c))) { ret 1; }
+    if (R.is_err[bool, str](builder.emit_ret_void(?env.bld)))         { ret 1; }
+
+    # the operand is live, so only the dominance check may object
+    if (t_count(?env, true, false, VC_DANGLING_OPERAND) != 0) { ret 1; }
+    if (t_count(?env, true, false, VC_DOMINANCE) != 1)        { ret 1; }
+    ret 0;
+}
+
+# a phi incoming defined in the predecessor itself is live out of that edge whatever
+# its position in the block, so it is accepted at every ordinal
+test "mach.lang.me.ir.verify.check_dominance:phi_incoming_defined_in_pred" {
+    var env: TEnv;
+    if (!t_env(?env)) { ret 1; }
+    val b0: id.BlockId = t_block(?env);
+    val b1: id.BlockId = t_block(?env);
+    if (b1 != 1) { ret 1; }
+    val c: value.Value = t_ci(?env, 0);
+
+    builder.set_block(?env.bld, b0);
+    val dv: R.Result[value.Value, str] = builder.emit_add(?env.bld, c, c);
+    if (R.is_err[value.Value, str](dv)) { ret 1; }
+    val d: value.Value = R.unwrap_ok[value.Value, str](dv);
+    if (R.is_err[bool, str](builder.emit_br(?env.bld, b1))) { ret 1; }
+
+    builder.set_block(?env.bld, b1);
+    val pv: R.Result[value.Value, str] = builder.emit_phi(?env.bld, env.i64ty);
+    if (R.is_err[value.Value, str](pv)) { ret 1; }
+    val p: value.Value = R.unwrap_ok[value.Value, str](pv);
+    if (R.is_err[bool, str](builder.phi_add_incoming(?env.bld, p, b0, d))) { ret 1; }
+    if (R.is_err[value.Value, str](builder.emit_add(?env.bld, p, c))) { ret 1; }
+    if (R.is_err[bool, str](builder.emit_ret_void(?env.bld)))         { ret 1; }
+
+    if (t_total(?env, true, false) != 0) { ret 1; }
+    ret 0;
 }


### PR DESCRIPTION
Closes #2930
Closes #2931

These are one story. #2930 is why a dropped value with a surviving use was undetectable, #2931 is why it became a wrong answer rather than a build failure, and together they are why #2917 shipped and was found by running a program.

## Root cause

**#2930.** The instruction pool retains every instruction a pass ever created, detached ones included, so an operand naming a dropped value still resolves through `ir.instruction_get` and reads as an ordinary use everywhere downstream. Only the block lists say what reaches the back end, and nothing measured operands against them.

The check that could have caught it was `VC_DOMINANCE`, and it missed the case three separate ways. `check_dominance` walked each block's body list and terminator slot and never its phi list. `check_operands_dominate` returned early for `OP_PHI` on top of that. And the whole check rode the `full` flag, so it ran only in the post-DCE stages. #2917's dangling operand was on a phi, so it was invisible.

**#2931.** `lower_block_phis` searched a phi's operand pairs for the predecessor edge it was emitting and, when `found` stayed false, moved on. No copy for that edge, no error. The four other malformed inputs in the same function (a dangling phi id, a phi with no result vreg, a predecessor with no MIR block, a predecessor with no terminator) each set `err_msg` and fail the build. This one lowered.

## Fix

`VC_DANGLING_OPERAND` (17): build the live set once per function from the block lists (phis, body, terminator), then scan every live instruction's `VAL_INSTR` operands against it. An out-of-range operand id is reported here too, since no other check looks at operand ids. It needs no dominator tree and no reachability, so it is always on and holds at every pipeline stage rather than only the post-DCE ones. The unplaced-def arm moves out of the dominance check, which has no defining block to measure from and would otherwise double-report.

`VC_DOMINANCE` no longer exempts a phi. `check_phi_incomings_dominate` measures each incoming at the END of the predecessor the pair names, which is the point the value has to be live out of for the edge copy to read it. Measuring it at the phi's own block would reject every ordinary merge. An unreachable predecessor is not judged and is `VC_REACHABILITY`'s.

`lower_block_phis` makes the missing incoming an error, the same shape as its four siblings, naming the phi's block, the predecessor block and the result vreg, since the pass that dropped the incoming is well upstream of MIR lowering and the message is the only thread back to it.

The synthesize-an-undef alternative #2931 raises is not taken. Defined-but-wrong is the same class of failure this is about.

## Dominance check verdict

Correct and cheap, and included. It is not new code so much as the removal of an exemption: the dominator scratch, the idom fixpoint and the ancestor walk were all already there and already computed for the non-phi operands, so covering phis adds one walk over phi lists and no allocation. It surfaced nothing across the sweep below.

## What the new checks surfaced

Nothing. Reported as a result rather than a claim of safety, with the counts.

| sweep | builds | modules per build | verifier findings |
|---|---|---|---|
| self-host corpus, `--verify-ir`, `{debug, release}` x `{x86_64, aarch64, riscv64}` | 6 | 225 | 0 |
| `int/` projects, `--verify-ir`, each project's own declared linux targets and profiles | 656 | varies | 0 |

101 of the 656 `int/` builds exit non-zero, and every one of them is either a case that is meant to fail (generic instantiation and depth limits, recursive type of infinite size, address of a `#[packed]` field, a handle as a record field, the SPIR-V validation refusals) or harness plumbing this sweep did not reproduce (an unresolved local `provider` dep, `--emit obj` against a flat-image format, a build-step case). None is a verifier violation. No check was weakened and nothing was filed as deferred, because nothing pre-existing turned up.

## Counterfactual

Each fix disabled in turn with the tests left in place, then restored.

| state | result |
|---|---|
| `check_operand_defs` and `check_phi_incomings_dominate` short-circuited | 1467 passed, **3 failed** - `check_operand_defs:dropped_def`, `check_operand_defs:dropped_phi_incoming`, `check_dominance:phi_incoming_not_live_out_of_pred` |
| `lower_block_phis` missing-incoming arm disabled | 1469 passed, **1 failed** - `lower_block_phis:missing_incoming` |
| restored | **1470 passed, 0 failed** |

## Tests

5 new, 1465 -> 1470. Each malformed input is built directly rather than hoped out of a pass, and each refusal is paired with a positive control.

- `check_operand_defs:dropped_def` - asserts the well-formed module verifies clean (total 0), detaches the def from the block list, asserts exactly 1 `VC_DANGLING_OPERAND` with `full` clear, which is what pins the check as unconditional
- `check_operand_defs:dropped_phi_incoming` - the #2917 shape. Asserts the well-formed diamond passes every check including dominance, then drops the arm's def and asserts exactly 1
- `check_dominance:phi_incoming_not_live_out_of_pred` - an incoming on the `b1` edge naming a value only the `b2` arm defines. Asserts 0 `VC_DANGLING_OPERAND` (the operand is live, so only dominance may object) and exactly 1 `VC_DOMINANCE`
- `check_dominance:phi_incoming_defined_in_pred` - the positive control for the measurement point: a def in the predecessor is accepted whatever its ordinal
- `lower_block_phis:missing_incoming` - lowers a real diamond through `lower_ir` for linux-x86_64, positive control with both edges covered first, then asserts the uncovered build fails and that the message names block 3, block 2 and the result vreg

## Machine output

Both changes are diagnostic, so the code the compiler generates must not move. Measured stage-2: one pristine corpus at the merge base, compiled by a release compiler built from the merge base and by one built from this branch, objects compared per target.

| comparison | linux-x86_64 | linux-arm64 | linux-riscv64 |
|---|---|---|---|
| determinism control (base compiler, twice) | 225/225 identical | 225/225 | 225/225 |
| base compiler vs this branch | **225/225 identical** | **225/225** | **225/225** |

0 differing, 0 missing, across all three targets.
