### PR TITLE
fix(target): select Linux ELF inputs by ISA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+#### target(linux): dynamic ELF loader and shared inputs ignored the selected ISA (#3104)
+
+Linux dynamic executables now record glibc's ISA-specific interpreter path for
+x86_64, aarch64, and riscv64. ELF shared inputs are also checked against the
+selected target's `e_machine`, so cross-links reject host-architecture libraries
+instead of retaining their SONAME in an invalid target image.
+
 ## [4.26.4] - 2026-08-23
 
 ### Fixed

--- a/src/lang/be/linker.mach
+++ b/src/lang/be/linker.mach
@@ -48,7 +48,7 @@ use std.text.string.str_free;
 use A: std.allocator;
 use O: std.types.option;
 use R: std.types.result;
-use format: std.format;
+use std.format;
 
 use mach.lang.be.obj;
 use enc: mach.lang.be.codegen.encode;
@@ -59,6 +59,7 @@ use mach.lang.intern;
 use mach.lang.session;
 use mach.lang.target;
 use mach.lang.target.isa;
+use mach.lang.target.os;
 use mach.lang.target.of;
 use mach.lang.target.of.ar;
 use mach.lang.target.of.bin;
@@ -5805,11 +5806,12 @@ fun build_dynamic_info(s: *session.Session, tgt: *target.Target, dyn: *DynState,
     # the interpreter path is the OS's run-time loader recorded into a PT_INTERP
     # (ELF); a format that embeds the loader differently (PE's import directory,
     # Mach-O's dyld bind) supplies an empty path and the format writer ignores it.
-    # the path is a plain str on the vtable; intern it here for the StrId-keyed
-    # DynInfo, mapping the empty path to STR_NIL.
+    # Resolve the target ISA through the OS policy, then intern it here for the
+    # StrId-keyed DynInfo, mapping the empty path to STR_NIL.
     dyn.info.interp = intern.STR_NIL;
-    if (!str_empty(tgt.os.dynamic_linker)) {
-        val dr: R.Result[intern.StrId, str] = intern.intern(?s.interner, tgt.os.dynamic_linker);
+    val dynamic_linker: str = os.dynamic_linker_for(tgt.os, tgt.arch_id);
+    if (!str_empty(dynamic_linker)) {
+        val dr: R.Result[intern.StrId, str] = intern.intern(?s.interner, dynamic_linker);
         if (R.is_err[intern.StrId, str](dr)) { ret R.err[bool, str](R.unwrap_err[intern.StrId, str](dr)); }
         dyn.info.interp = R.unwrap_ok[intern.StrId, str](dr);
     }
@@ -9954,6 +9956,52 @@ test "mach.lang.be.linker.unattributed_import_message:names_both_routes" {
     if (!str_contains(degraded, "static archive member"))      { ret 1; }
     if (!str_contains(degraded, "symbols = [...]"))            { ret 1; }
 
+    session.dnit(?s);
+    ret 0;
+}
+
+# dynamic planning resolves the Linux PT_INTERP through the selected ISA, not the
+# compiler host
+test "mach.lang.be.linker.build_dynamic_info:linux_interpreter_matches_target" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+    val sr: R.Result[session.Session, str] = session.init(?alloc);
+    if (R.is_err[session.Session, str](sr)) { ret 1; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](sr);
+    var reg: target.TargetRegistry = target.registry_init();
+    if (R.is_err[bool, str](target.register_all(?reg))) { ret 1; }
+
+    var locs: map.Map[intern.StrId, SymbolLoc] =
+        map.init[intern.StrId, SymbolLoc](?alloc, map.hash_u32, map.eq_u32);
+    var names: [3]str;
+    names[0] = "x86_64"; names[1] = "aarch64"; names[2] = "riscv64";
+    var abis: [3]str;
+    abis[0] = "sysv64"; abis[1] = "aapcs64"; abis[2] = "lp64d";
+    var paths: [3]str;
+    paths[0] = "/lib64/ld-linux-x86-64.so.2";
+    paths[1] = "/lib/ld-linux-aarch64.so.1";
+    paths[2] = "/lib/ld-linux-riscv64-lp64d.so.1";
+
+    var i: usize = 0;
+    for (i < 3) {
+        val tr: R.Result[target.Target, str] =
+            target.select(?reg, names[i], "linux", abis[i]);
+        if (R.is_err[target.Target, str](tr)) { ret 1; }
+        var tgt: target.Target = R.unwrap_ok[target.Target, str](tr);
+        var dyn: DynState;
+        init_dynstate(?dyn);
+        val built: R.Result[bool, str] = build_dynamic_info(
+            ?s, ?tgt, ?dyn, nil::*of.ObjectImage, 0, ?locs,
+            nil::*of.DynLib, 0, nil::*u32, nil::*AtomPlan);
+        if (R.is_err[bool, str](built)) { ret 1; }
+        val interp: O.Option[str] = intern.lookup(?s.interner, dyn.info.interp);
+        if (O.is_none[str](interp) || !str_equals(O.unwrap[str](interp), paths[i])) {
+            ret 1;
+        }
+        free_dynstate(?alloc, ?dyn);
+        i = i + 1;
+    }
+    map.dnit[intern.StrId, SymbolLoc](?locs);
     session.dnit(?s);
     ret 0;
 }

--- a/src/lang/be/linker.mach
+++ b/src/lang/be/linker.mach
@@ -5806,8 +5806,8 @@ fun build_dynamic_info(s: *session.Session, tgt: *target.Target, dyn: *DynState,
     # the interpreter path is the OS's run-time loader recorded into a PT_INTERP
     # (ELF); a format that embeds the loader differently (PE's import directory,
     # Mach-O's dyld bind) supplies an empty path and the format writer ignores it.
-    # Resolve the target ISA through the OS policy, then intern it here for the
-    # StrId-keyed DynInfo, mapping the empty path to STR_NIL.
+    # resolve the target isa through the os policy, then intern it here for the
+    # strid-keyed dyninfo, mapping the empty path to str_nil.
     dyn.info.interp = intern.STR_NIL;
     val dynamic_linker: str = os.dynamic_linker_for(tgt.os, tgt.arch_id);
     if (!str_empty(dynamic_linker)) {

--- a/src/lang/build/plan.mach
+++ b/src/lang/build/plan.mach
@@ -1055,7 +1055,7 @@ fun read_so_soname(a: *A.Allocator, so_path: *u8, machine: u32,
     if (R.is_err[Vector[u8], str](res_read)) { ret false; }
     var b: Vector[u8] = R.unwrap_ok[Vector[u8], str](res_read);
     var ok: bool = false;
-    # ELF64, little-endian, current version, ET_DYN, and the target e_machine.
+    # elf64, little-endian, current version, et_dyn, and the target e_machine.
     if (b.len >= 64 && b.data[0] == 0x7F && b.data[1] == 0x45 && b.data[2] == 0x4C
         && b.data[3] == 0x46 && b.data[4] == 2 && b.data[5] == 1 && b.data[6] == 1
         && bin.read_u16_le(b.data, 16) == 3
@@ -1758,7 +1758,7 @@ test "mach.lang.build.plan.resolve_token:linux_ignores_bare_coff_lib" {
     ret 0;
 }
 
-# ELF shared resolution rejects the build host's ISA and keeps searching for a
+# elf shared resolution rejects the build host's isa and keeps searching for a
 # matching target object. Explicit wrong-ISA inputs fail at the same boundary.
 test "mach.lang.build.plan.resolve_token:elf_shared_machine_matches_target" {
     var alloc: A.Allocator;

--- a/src/lang/build/plan.mach
+++ b/src/lang/build/plan.mach
@@ -811,10 +811,11 @@ pub fun resolve_token(a: *A.Allocator, tgt: *target.Target, dirs: *Vector[str],
     # (or basename) instead of adding it as a static object.
     if (found && is_shared_path(?buf[0])) {
         var sname: [4096]u8;
-        if (read_so_soname(a, ?buf[0], ?sname[0], 4096)) {
+        if (read_so_soname(a, ?buf[0], tgt.isa.elf_machine, ?sname[0], 4096)) {
             ret dyn_copy(a, ?sname[0]);
         }
-        ret R.err[LinkInput, outcome.Fail](outcome.user(join_msg(a, "'", (?buf[0])::str, "' is not a loadable ELF shared object (an ld script or unsupported '.so')")));
+        ret R.err[LinkInput, outcome.Fail](outcome.user(join_msg(a, "'", (?buf[0])::str,
+            "' is not a loadable ELF shared object for the selected architecture")));
     }
 
     # a bare `-l` name with no static object/archive falls back to the selected
@@ -1039,7 +1040,7 @@ fun write_named_candidate(dir: *u8, prefix: *u8, name: *u8, ext: *u8, buf: *u8, 
 
 # read a shared object's DT_SONAME and write it (null-terminated) into `out`
 #
-# Accepts only a real ELF64 shared object (magic + ET_DYN): it writes the
+# Accepts only a little-endian ELF64 shared object matching `machine`: it writes the
 # object's DT_SONAME (tag 14, parsed from the SHT_DYNAMIC section and its
 # linked string table) when present, else the path's basename, and returns
 # true. Returns false for anything that is NOT a loadable ELF shared object -
@@ -1048,14 +1049,17 @@ fun write_named_candidate(dir: *u8, prefix: *u8, name: *u8, ext: *u8, buf: *u8, 
 # the loader cannot map. The DT_SONAME is the canonical dependency name, so a
 # versioned `libc.so.6` is recorded even when the probe matched a `libc.so`
 # link.
-fun read_so_soname(a: *A.Allocator, so_path: *u8, out: *u8, cap: usize) bool {
+fun read_so_soname(a: *A.Allocator, so_path: *u8, machine: u32,
+                   out: *u8, cap: usize) bool {
     val res_read: R.Result[Vector[u8], str] = fs.read_bytes(a, so_path);
     if (R.is_err[Vector[u8], str](res_read)) { ret false; }
     var b: Vector[u8] = R.unwrap_ok[Vector[u8], str](res_read);
     var ok: bool = false;
-    # ELF64 magic and e_type == ET_DYN (3) - a loadable shared object.
+    # ELF64, little-endian, current version, ET_DYN, and the target e_machine.
     if (b.len >= 64 && b.data[0] == 0x7F && b.data[1] == 0x45 && b.data[2] == 0x4C
-        && b.data[3] == 0x46 && bin.read_u16_le(b.data, 16) == 3) {
+        && b.data[3] == 0x46 && b.data[4] == 2 && b.data[5] == 1 && b.data[6] == 1
+        && bin.read_u16_le(b.data, 16) == 3
+        && bin.read_u16_le(b.data, 18)::u32 == machine) {
         if (!extract_soname(b.data, b.len, out, cap)) {
             # a loadable shared object with no DT_SONAME: the basename is the
             # canonical dependency name.
@@ -1292,14 +1296,16 @@ fun resolve_elf_shared_into(a: *A.Allocator, tgt: *target.Target, dirs: *Vector[
                             name: *u8, buf: *u8, cap: usize) bool {
     var i: usize = 0;
     for (i < dirs.len) {
-        if (try_shared_in_dir(a, dirs.data[i]::*u8, name, buf, cap)) { ret true; }
+        if (try_shared_in_dir(a, dirs.data[i]::*u8, name, tgt.isa.elf_machine,
+                              buf, cap)) { ret true; }
         i = i + 1;
     }
     if (tgt.os != nil) {
         var li: u32 = 0;
         for (li < tgt.os.libdir_len) {
             val ld: str = tgt.os.libdirs[li];
-            if (!str_empty(ld) && try_shared_in_dir(a, ld::*u8, name, buf, cap)) { ret true; }
+            if (!str_empty(ld) && try_shared_in_dir(a, ld::*u8, name,
+                tgt.isa.elf_machine, buf, cap)) { ret true; }
             li = li + 1;
         }
     }
@@ -1428,12 +1434,15 @@ fun write_named_dylib_version(dir: *u8, name: *u8, v: u32,
 
 # probe `<dir>/lib<name>.so` then the common SONAME-bearing `lib<name>.so.<N>`
 # files for `N` in 6..0, accepting the first that is a real ELF shared object
-fun try_shared_in_dir(a: *A.Allocator, dir: *u8, name: *u8, buf: *u8, cap: usize) bool {
+fun try_shared_in_dir(a: *A.Allocator, dir: *u8, name: *u8, machine: u32,
+                      buf: *u8, cap: usize) bool {
     var cand: [4096]u8;
-    if (write_named_candidate(dir, "lib", name, "so", ?cand[0], 4096) && accept_shared(a, ?cand[0], buf, cap)) { ret true; }
+    if (write_named_candidate(dir, "lib", name, "so", ?cand[0], 4096)
+        && accept_shared(a, ?cand[0], machine, buf, cap)) { ret true; }
     var v: i64 = 6;
     for (v >= 0) {
-        if (write_named_versioned(dir, name, v::u32, ?cand[0], 4096) && accept_shared(a, ?cand[0], buf, cap)) { ret true; }
+        if (write_named_versioned(dir, name, v::u32, ?cand[0], 4096)
+            && accept_shared(a, ?cand[0], machine, buf, cap)) { ret true; }
         v = v - 1;
     }
     ret false;
@@ -1441,9 +1450,10 @@ fun try_shared_in_dir(a: *A.Allocator, dir: *u8, name: *u8, buf: *u8, cap: usize
 
 # accept `cand` as a shared dependency if it is an existing real ELF shared
 # object, writing its DT_SONAME (or, lacking one, its basename) into `buf`
-fun accept_shared(a: *A.Allocator, cand: *u8, buf: *u8, cap: usize) bool {
+fun accept_shared(a: *A.Allocator, cand: *u8, machine: u32,
+                  buf: *u8, cap: usize) bool {
     if (!fs.is_file(cand)) { ret false; }
-    if (read_so_soname(a, cand, buf, cap)) { ret true; }
+    if (read_so_soname(a, cand, machine, buf, cap)) { ret true; }
     ret false;
 }
 
@@ -1630,6 +1640,19 @@ fun ut_write_dylib(path_: str, install_name: str, cpu_type: u32) bool {
     ret O.is_none[str](fs.write_bytes(path_, ?buf[0], 128, 420));
 }
 
+# write the ELF identity and header fields needed to recognize a target shared object
+fun ut_write_elf_shared(path_: str, machine: u16) bool {
+    var elf: [64]u8;
+    var i: usize = 0;
+    for (i < 64) { elf[i] = 0; i = i + 1; }
+    elf[0] = 0x7F; elf[1] = 0x45; elf[2] = 0x4C; elf[3] = 0x46;
+    elf[4] = 2; elf[5] = 1; elf[6] = 1;
+    bin.write_u16_le(?elf[0], 16, 3);
+    bin.write_u16_le(?elf[0], 18, machine);
+    bin.write_u16_le(?elf[0], 52, 64);
+    ret O.is_none[str](fs.write_bytes(path_, ?elf[0], 64, 420));
+}
+
 # fill one 128-byte thin dylib slice at `off`
 fun ut_fill_dylib(buf: *u8, off: usize, install_name: str,
                   cpu_type: u32) bool {
@@ -1714,13 +1737,8 @@ test "mach.lang.build.plan.resolve_token:linux_ignores_bare_coff_lib" {
     }
     val lib: str = R.unwrap_ok[str, str](lib_r);
     val so: str = R.unwrap_ok[str, str](so_r);
-    var elf: [64]u8;
-    var i: usize = 0;
-    for (i < 64) { elf[i] = 0; i = i + 1; }
-    elf[0] = 0x7F; elf[1] = 0x45; elf[2] = 0x4C; elf[3] = 0x46;
-    bin.write_u16_le(?elf[0], 16, 3);
     if (O.is_some[str](fs.write_bytes(lib, "!<arch>\n", 8, 420))
-        || O.is_some[str](fs.write_bytes(so, ?elf[0], 64, 420))) {
+        || !ut_write_elf_shared(so, 62)) {
         fs.remove_all(?alloc, root); ret 1;
     }
 
@@ -1737,6 +1755,51 @@ test "mach.lang.build.plan.resolve_token:linux_ignores_bare_coff_lib" {
     if (R.is_err[LinkInput, outcome.Fail](rr) || !explicit) { ret 1; }
     val input: LinkInput = R.unwrap_ok[LinkInput, outcome.Fail](rr);
     if (input.kind != LINK_DYNAMIC || !str_equals(input.text, "libfoo.so")) { ret 1; }
+    ret 0;
+}
+
+# ELF shared resolution rejects the build host's ISA and keeps searching for a
+# matching target object. Explicit wrong-ISA inputs fail at the same boundary.
+test "mach.lang.build.plan.resolve_token:elf_shared_machine_matches_target" {
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    var reg: target.TargetRegistry = target.registry_init();
+    if (R.is_err[bool, str](target.register_all(?reg))) { ret 1; }
+    val tr: R.Result[target.Target, str] =
+        target.select(?reg, "aarch64", "linux", "aapcs64");
+    if (R.is_err[target.Target, str](tr)) { ret 1; }
+    var tgt: target.Target = R.unwrap_ok[target.Target, str](tr);
+
+    val root_r: R.Result[str, str] = ut_temp_dir(?alloc);
+    if (R.is_err[str, str](root_r)) { ret 1; }
+    val root: str = R.unwrap_ok[str, str](root_r);
+    val host_r: R.Result[str, str] = path.join(?alloc, root, "libfoo.so");
+    val target_r: R.Result[str, str] = path.join(?alloc, root, "libfoo.so.6");
+    if (R.is_err[str, str](host_r) || R.is_err[str, str](target_r)) {
+        fs.remove_all(?alloc, root);
+        ret 1;
+    }
+    val host: str = R.unwrap_ok[str, str](host_r);
+    val target_so: str = R.unwrap_ok[str, str](target_r);
+    if (!ut_write_elf_shared(host, 62) || !ut_write_elf_shared(target_so, 183)) {
+        fs.remove_all(?alloc, root);
+        ret 1;
+    }
+
+    var dirs: Vector[str] = vector.init[str](?alloc);
+    if (R.is_err[usize, str](vector.push[str](?dirs, root))) {
+        fs.remove_all(?alloc, root);
+        ret 1;
+    }
+    val named: R.Result[LinkInput, outcome.Fail] =
+        resolve_token(?alloc, ?tgt, ?dirs, "", "foo"::*u8);
+    val explicit: R.Result[LinkInput, outcome.Fail] =
+        resolve_token(?alloc, ?tgt, ?dirs, "", host::*u8);
+    fs.remove_all(?alloc, root);
+    if (R.is_err[LinkInput, outcome.Fail](named)
+        || R.is_ok[LinkInput, outcome.Fail](explicit)) { ret 1; }
+    val input: LinkInput = R.unwrap_ok[LinkInput, outcome.Fail](named);
+    if (input.kind != LINK_DYNAMIC || !str_equals(input.text, "libfoo.so.6")) { ret 1; }
     ret 0;
 }
 

--- a/src/lang/target/os.mach
+++ b/src/lang/target/os.mach
@@ -94,8 +94,8 @@ pub def PageSizeFn: fun(u32) u64;
 
 # a per-os dynamic-loader path policy, parameterized by architecture id
 #
-# Returns the interpreter path an executable records for the selected architecture.
-# Linux glibc uses a distinct path per ISA. PE and Mach-O load dynamic dependencies
+# returns the interpreter path an executable records for the selected architecture.
+# linux glibc uses a distinct path per isa. pe and mach-o load dynamic dependencies
 # through format-specific records and therefore leave this policy nil.
 # ---
 # arg 0: the target architecture id (one of isa.ARCH_*)

--- a/src/lang/target/os.mach
+++ b/src/lang/target/os.mach
@@ -92,6 +92,16 @@ pub def PieExecFn: fun(u32) bool;
 # ret:   the segment-alignment page size in bytes for that architecture
 pub def PageSizeFn: fun(u32) u64;
 
+# a per-os dynamic-loader path policy, parameterized by architecture id
+#
+# Returns the interpreter path an executable records for the selected architecture.
+# Linux glibc uses a distinct path per ISA. PE and Mach-O load dynamic dependencies
+# through format-specific records and therefore leave this policy nil.
+# ---
+# arg 0: the target architecture id (one of isa.ARCH_*)
+# ret:   the dynamic-loader path, or "" when the format has no interpreter record
+pub def DynamicLinkerFn: fun(u32) str;
+
 # a per-os native calling-convention policy, parameterized by architecture id
 #
 # Returns the name of the calling convention (an `AbiVTable.name`, e.g. "sysv64",
@@ -236,13 +246,11 @@ pub def VaListFn: fun(u32) O.Option[VaList];
 #                 libdir_len entries are populated. per-OS, so a cross-OS link
 #                 never probes the host's directories
 # libdir_len:     number of populated entries in libdirs
-# dynamic_linker: run-time dynamic-loader path the linker writes into a
-#                 dynamically-linked image's interpreter record (the ELF
-#                 PT_INTERP), interned by the linker at that point; empty ("")
-#                 when no fixed interpreter-path record applies - PE and Mach-O
-#                 still support dynamic linking, but load imports through their
-#                 own mechanisms (the import directory, LC_LOAD_DYLINKER) rather
-#                 than a PT_INTERP path
+# dynamic_linker: per-architecture run-time dynamic-loader path policy. the linker
+#                 writes its answer into a dynamically-linked image's interpreter
+#                 record (the ELF PT_INTERP). nil when no interpreter-path record
+#                 applies - PE and Mach-O still support dynamic linking, but load
+#                 imports through their own mechanisms
 # base_addr:      base virtual address the first loadable segment maps at; the
 #                 linker assigns section vaddrs upward from it
 # page_size:      virtual-memory page size in bytes the linker page-aligns
@@ -312,7 +320,7 @@ pub rec OsVTable {
     c_symbol_prefix:     str;
     libdirs:             [OS_LIBDIR_MAX]str;
     libdir_len:          u32;
-    dynamic_linker:      str;
+    dynamic_linker:      DynamicLinkerFn;
     base_addr:           u64;
     page_size:           u64;
     stack_probe:         bool;
@@ -522,6 +530,13 @@ pub fun supports_isa(vt: *OsVTable, arch_id: u32) bool {
 pub fun native_abi_for(vt: *OsVTable, arch_id: u32) str {
     if (vt.native_abi == nil) { ret ""; }
     ret vt.native_abi(arch_id);
+}
+
+# the run-time dynamic-loader path operating system `vt` uses on architecture
+# `arch_id`, or "" when its image format has no interpreter record
+pub fun dynamic_linker_for(vt: *OsVTable, arch_id: u32) str {
+    if (vt.dynamic_linker == nil) { ret ""; }
+    ret vt.dynamic_linker(arch_id);
 }
 
 # whether operating system `vt` passes a C call's whole variadic tail on the stack on

--- a/src/lang/target/os/darwin.mach
+++ b/src/lang/target/os/darwin.mach
@@ -152,7 +152,7 @@ pub fun register_darwin(reg: *os.OsRegistry) R.Result[bool, str] {
     darwin_vtable.libdir_len     = 2;
     # Mach-O loads imports through LC_LOAD_DYLINKER + dyld bind, not a PT_INTERP
     # path, so no fixed interpreter-path record applies.
-    darwin_vtable.dynamic_linker = "";
+    darwin_vtable.dynamic_linker = nil;
     darwin_vtable.base_addr      = DARWIN_BASE_ADDR;
     darwin_vtable.page_size      = DARWIN_PAGE_SIZE;
     # Darwin commits the thread stack up front and auto-grows the main thread; no

--- a/src/lang/target/os/freestanding.mach
+++ b/src/lang/target/os/freestanding.mach
@@ -110,7 +110,7 @@ pub fun register_freestanding(reg: *os.OsRegistry) R.Result[bool, str] {
     # as the object it comes from spells it.
     freestanding_vtable.c_symbol_prefix = "";
     freestanding_vtable.libdir_len     = 0;
-    freestanding_vtable.dynamic_linker = "";
+    freestanding_vtable.dynamic_linker = nil;
     freestanding_vtable.base_addr      = FREESTANDING_BASE_ADDR;
     freestanding_vtable.page_size      = FREESTANDING_PAGE_SIZE;
     # no OS to grow the stack and no guard-page commit, so no per-page probe.

--- a/src/lang/target/os/linux.mach
+++ b/src/lang/target/os/linux.mach
@@ -11,6 +11,7 @@ use std.types.bool.bool;
 use std.types.bool.false;
 use std.types.bool.true;
 use std.types.string.str;
+use std.types.string.str_equals;
 
 use O: std.types.option;
 use R: std.types.result;
@@ -45,14 +46,20 @@ fun linux_page_size(arch_id: u32) u64 {
     ret LINUX_PAGE_SIZE;
 }
 
-# the default x86-64 glibc dynamic loader. a dynamically-linked Linux ELF names
-# it in PT_INTERP so the kernel hands control to it to resolve shared
-# dependencies before the program entry runs. this is the FHS x86-64 glibc path;
-# other toolchains and layouts differ (musl uses /lib/ld-musl-x86_64.so.1, a
-# non-FHS sysroot relocates it), so this default may need to become a
-# target/sysroot-configurable setting to avoid emitting an ELF whose interpreter
-# is absent at exec time
-pub val LINUX_DYNAMIC_LINKER: str = "/lib64/ld-linux-x86-64.so.2";
+# glibc's Linux interpreter paths per supported architecture. a dynamically-linked
+# ELF names one in PT_INTERP so the kernel hands control to the target loader before
+# program entry. these are ABI paths inside the target root, not build-host paths
+pub val LINUX_DYNAMIC_LINKER_X86_64:  str = "/lib64/ld-linux-x86-64.so.2";
+pub val LINUX_DYNAMIC_LINKER_AARCH64: str = "/lib/ld-linux-aarch64.so.1";
+pub val LINUX_DYNAMIC_LINKER_RISCV64: str = "/lib/ld-linux-riscv64-lp64d.so.1";
+
+# the glibc interpreter path for a Linux architecture
+fun linux_dynamic_linker(arch_id: u32) str {
+    if (arch_id == isa.ARCH_X86_64)  { ret LINUX_DYNAMIC_LINKER_X86_64; }
+    if (arch_id == isa.ARCH_AARCH64) { ret LINUX_DYNAMIC_LINKER_AARCH64; }
+    if (arch_id == isa.ARCH_RISCV64) { ret LINUX_DYNAMIC_LINKER_RISCV64; }
+    ret "";
+}
 
 # Linux's native calling convention per architecture: the System V psABI for each
 # supported arch (SysV AMD64 on x86_64, AAPCS64 on aarch64, lp64d on riscv64).
@@ -132,7 +139,7 @@ pub fun register_linux(reg: *os.OsRegistry) R.Result[bool, str] {
     linux_vtable.libdirs[4]     = "/usr/lib";
     linux_vtable.libdirs[5]     = "/lib";
     linux_vtable.libdir_len     = 6;
-    linux_vtable.dynamic_linker = LINUX_DYNAMIC_LINKER;
+    linux_vtable.dynamic_linker = linux_dynamic_linker;
     linux_vtable.base_addr      = LINUX_BASE_ADDR;
     linux_vtable.page_size      = LINUX_PAGE_SIZE;
     # aarch64 aligns to a 64 KiB max-page so images load on 4K/16K/64K-page kernels.
@@ -166,5 +173,14 @@ test "mach.lang.target.os.linux.linux_page_size:per_arch_max_page" {
     if (linux_page_size(isa.ARCH_X86_64)  != 4096)  { bad = true; }
     if (linux_page_size(isa.ARCH_RISCV64) != 4096)  { bad = true; }
     if (bad) { ret 1; }
+    ret 0;
+}
+
+# PT_INTERP is an ABI property of the selected Linux ISA, never the build host
+test "mach.lang.target.os.linux.linux_dynamic_linker:per_arch_glibc_path" {
+    if (!str_equals(linux_dynamic_linker(isa.ARCH_X86_64), LINUX_DYNAMIC_LINKER_X86_64))   { ret 1; }
+    if (!str_equals(linux_dynamic_linker(isa.ARCH_AARCH64), LINUX_DYNAMIC_LINKER_AARCH64)) { ret 1; }
+    if (!str_equals(linux_dynamic_linker(isa.ARCH_RISCV64), LINUX_DYNAMIC_LINKER_RISCV64)) { ret 1; }
+    if (!str_equals(linux_dynamic_linker(isa.ARCH_UNKNOWN), ""))               { ret 1; }
     ret 0;
 }

--- a/src/lang/target/os/linux.mach
+++ b/src/lang/target/os/linux.mach
@@ -176,7 +176,7 @@ test "mach.lang.target.os.linux.linux_page_size:per_arch_max_page" {
     ret 0;
 }
 
-# PT_INTERP is an ABI property of the selected Linux ISA, never the build host
+# pt_interp is an abi property of the selected linux isa, never the build host
 test "mach.lang.target.os.linux.linux_dynamic_linker:per_arch_glibc_path" {
     if (!str_equals(linux_dynamic_linker(isa.ARCH_X86_64), LINUX_DYNAMIC_LINKER_X86_64))   { ret 1; }
     if (!str_equals(linux_dynamic_linker(isa.ARCH_AARCH64), LINUX_DYNAMIC_LINKER_AARCH64)) { ret 1; }

--- a/src/lang/target/os/windows.mach
+++ b/src/lang/target/os/windows.mach
@@ -4,7 +4,7 @@
 # system library directories, and the executable load parameters (ImageBase
 # 0x140000000, 4096-byte page) - so target.select composes a runnable Windows
 # target through the win64 ABI and the COFF/PE writer. PE links via the import
-# directory, not a PT_INTERP path, so `dynamic_linker` is empty (""). `register`
+# directory, not a PT_INTERP path, so `dynamic_linker` is nil. `register`
 # sets the vtable's str fields directly (no interning) and is idempotent.
 
 use std.types.bool.bool;
@@ -105,7 +105,7 @@ pub fun register_windows(reg: *os.OsRegistry) R.Result[bool, str] {
     windows_vtable.libdirs[0]     = "C:\\Windows\\System32";
     windows_vtable.libdir_len     = 1;
     # PE imports load through the import directory, not a PT_INTERP-style path.
-    windows_vtable.dynamic_linker = "";
+    windows_vtable.dynamic_linker = nil;
     # the raw 64 KiB-aligned ImageBase: Windows executables are position-independent
     # (pie_exec), so the link's one-page PIE header gap reserves RVA 0..0x1000 for the PE
     # headers and the first content segment maps one page above ImageBase -- leaving


### PR DESCRIPTION
Closes #3104

## Summary

- select the glibc `PT_INTERP` path from the Linux target ISA
- validate ELF64 class, byte order, type, and `e_machine` before accepting a shared input
- continue a named library search past wrong-architecture candidates

## Validation

- `mach test .`
- 1557 passed, 0 failed
- target tests cover x86_64, aarch64, and riscv64 interpreter paths
- planner tests cover searched and explicit mismatched ELF shared inputs
