### PR TITLE
chore: release 4.26.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [4.26.5] - 2026-08-27
 
 ### Fixed
 

--- a/mach.toml
+++ b/mach.toml
@@ -1,6 +1,6 @@
 [project]
 id = "mach"
-version = "4.26.4"
+version = "4.26.5"
 src = "src"
 out = "out/{target.name}/{profile.name}"
 

--- a/src/lang/version.mach
+++ b/src/lang/version.mach
@@ -3,7 +3,7 @@
 use std.types.string.str;
 
 # the Mach compiler version, independent of the project embedding the frontend
-pub val MACH_VERSION: str = "4.26.4";
+pub val MACH_VERSION: str = "4.26.5";
 
 test "mach.lang.version:matches_project_release" {
     $if ($project.id == "mach") {


### PR DESCRIPTION
Version bump and changelog promotion for the 4.26.5 patch release.

This release selects Linux glibc interpreter paths by target ISA and rejects ELF shared inputs whose `e_machine` does not match the selected target (#3104, PR #3105).

Validation: `mach test .`, 1557 passed, 0 failed.
