### PR TITLE
docs: reconcile transition compatibility and contributor setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [4.30.0] - Unreleased
 
-The compatible transition release. Every language and manifest form 4.26.x
-accepted is still accepted, the new forms are accepted beside them, and 4.30.0
-becomes the seed that builds 5.0.0. Two CLI flags are gone, listed under
-"Removed". Everything else that goes away is listed under "Planned for 5.0.0"
-at the end of this section.
+The transition release that becomes the seed for 5.0.0. Replacement language
+and manifest forms ship alongside the legacy forms retained for migration
+until 5.0.0. This is not a guarantee that every previously accepted project
+still builds:
+two CLI flags are removed, compiler and manifest checks reject invalid forms
+that previously passed, and MOS 6502 is unavailable for ordinary builds.
+The "Changed", "Fixed", and "Removed" sections describe those compatibility
+limits, including the refusal to take addresses of temporaries.
 
 ### Added
 
@@ -48,7 +51,7 @@ at the end of this section.
 
 #### Standard library
 
-The pin moves from 0.28.1 to 0.37.1.
+The pin moves from 0.28.1 to 0.37.2 (`565f40ab`).
 
 - 0.28.2: `Vector[T]` clears released storage metadata and survives repeated teardown.
 - 0.31.0: libc-free linkage. An ordinary linux binary carries no `PT_INTERP` and no dynamic section, and the compiler adopts the normalized io error surface.
@@ -59,6 +62,7 @@ The pin moves from 0.28.1 to 0.37.1.
 - 0.36.1: `R.void_of`, narrowing a result to `Void`.
 - 0.37.0: the `transaction.prepare` producer returns `Result[Void, str]`. The `ok(false)` abort arm is gone and `err` is the only abort.
 - 0.37.1: `root_remove_tree`, root-anchored recursive removal with a depth bound of 256.
+- 0.37.2: the TOML inline-table conflict path frees its parsed value through a local binding instead of taking the address of a call result. A heap-owning string test covers the release.
 
 ### Changed
 
@@ -223,7 +227,9 @@ The pin moves from 0.28.1 to 0.37.1.
 - A `mach.lock` file is rejected with a migration diagnostic.
 - `$mach.abi.sysv` is removed. Write `sysv64`.
 - Several targets, profiles, or artifacts with none marked `default = true` are refused.
-- `[project].name`, `description`, `mach` and `[profile].emit_ir`, `emit_asm` are refused.
+- `[project].name`, `description`, `mach` and `[profile.*].emit_ir`, `emit_asm` are refused.
+- `$project.name` and `$project.description` are removed with those manifest keys (#3128).
+- An artifact-less dependency no longer gets an implicit `lib.mach` entry. Declare an explicitly defaulted library artifact.
 - An `#[embed]` path outside the project root is refused.
 - The MOS 6502 target is deleted.
 - `mach dep update` proposes SemVer selection among tagged releases within one major and above every tested floor.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,8 +13,9 @@ Be respectful, constructive, and professional. Treat Mach like a passion project
 ## Getting Started
 
 ### Prerequisites
+
 - Git
-- An existing `mach` binary — Mach is self-hosting, so building from source needs one. Install the latest [release](https://github.com/briar-systems/mach/releases).
+- An existing `mach` binary. Mach is self-hosting, so building from source needs one. Install the latest [release](https://github.com/briar-systems/mach/releases).
 
 ### Building
 
@@ -27,7 +28,14 @@ mach dep pull
 mach build .
 ```
 
-The compiler is written to `out/<target>/bin/mach`. Because the language is self-hosting, the build reaches a byte-identical fixpoint — recompiling the source with the result reproduces it exactly.
+The compiler is written to `out/<target>/<profile>/bin/mach`, or `bin/mach.exe`
+on Windows. A default Linux x86_64 build writes
+`out/linux-x86_64/debug/bin/mach`.
+
+The installed compiler is the seed. Build generation A with the seed, B with
+A, and C with B. Release verification requires B and C to be byte-identical.
+A can differ from B while the installed seed carries an older code generator.
+See the [release shape](doc/design/release-shape.md) for the seed transition.
 
 ---
 
@@ -35,16 +43,16 @@ The compiler is written to `out/<target>/bin/mach`. Because the language is self
 
 We use a two-branch model:
 
-- **`main`** — Stable branch. Tagged releases only.
-- **`dev`** — Development branch. Integration point for features and fixes.
+- **`main`**: Stable branch. Tagged releases only.
+- **`dev`**: Development branch. Integration point for features and fixes.
 
-All work happens on feature branches off `dev`. When `dev` reaches a stable milestone, it is merged into `main` and tagged.
+Features and fixes branch off `dev` and return through a pull request. Releases integrate `dev` into `main` and tag the merge commit. A hotfix branches off `main` and merges into both long-lived branches.
 
 ### Branch Naming
 
-- `feat/<name>` — New features
-- `fix/<name>` — Bug fixes
-- `doc/<name>` — Documentation changes
+- `feat/<issue>`: New features
+- `fix/<issue>`: Fixes, including documentation corrections
+- `hotfix/<issue>`: Urgent release fixes
 
 ### Contributing Changes
 
@@ -53,38 +61,47 @@ All work happens on feature branches off `dev`. When `dev` reaches a stable mile
    ```bash
    git checkout dev
    git pull origin dev
-   git checkout -b feat/your-feature-name
+   git checkout -b feat/1234
    ```
 3. **Make your changes** following the coding standards below
-4. **Commit with clear messages:**
+4. **Make small, self-contained conventional commits:**
    ```
-   component: brief description
+   fix(component): brief description
 
    Longer explanation if needed.
    ```
 5. **Push to your fork:**
    ```bash
-   git push origin feat/your-feature-name
+   git push origin feat/1234
    ```
-6. **Open a Pull Request** targeting the `dev` branch
+6. **Open a draft Pull Request** targeting `dev`, then mark it ready when complete
+
+Replace `1234` with the issue number. Use `fix/1234` for a fix.
 
 **Pull Request Guidelines:**
+
 - Target `dev` branch (not `main`)
 - Provide clear description of changes
-- Link related issues
-- Ensure the compiler builds and reaches the byte-identical fixpoint
-- Run the tests with `mach test .`
+- Link the issue with `Closes #N`
+- Verify compiler changes from a detached checkout of the committed tip
+- Ensure the compiler builds and reaches the B/C byte-identical fixpoint
+- Run the built compiler's test suite in both debug and release profiles
 - Follow coding standards
+- Merge with a merge commit, without rebasing or fast-forwarding
+- Close the linked issue after a merge to a non-default branch
 
 ## Versioning
 
 Mach uses [Semantic Versioning](https://semver.org/) (`vMAJOR.MINOR.PATCH`):
 
-- **MAJOR** — Breaking changes to the language or standard library
-- **MINOR** — New features, backward-compatible additions
-- **PATCH** — Bug fixes, documentation, internal improvements
+- **MAJOR**: Breaking changes to the supported compiler surface
+- **MINOR**: New features and backward-compatible additions
+- **PATCH**: Bug fixes, documentation, and internal improvements
 
-Tags are created on `main` after merging from `dev`. The current pre-1.0 convention treats minor bumps as potentially breaking while the language stabilizes.
+Tags are created and pushed on `main` after merging from `dev`. The standard
+library is versioned separately in its own repository. The
+[4.30.0 / 5.0.0 release shape](doc/design/release-shape.md) records the current
+migration window and the compatibility limits of the transition release.
 
 A release bump updates both `[project].version` in `mach.toml` and
 `MACH_VERSION` in `src/lang/version.mach`. CI and the tag workflow require the
@@ -117,7 +134,7 @@ dev (ongoing work)
 
 ## Coding Standards
 
-### Mach Code (in `src/` and `dep/mach-std/`)
+### Mach Code (in `src/` and `dep/std/`)
 
 Mach coding standards are in flux while syntax stabilizes and the userbase grows. Follow existing patterns and refer to the [language reference](doc/language/README.md) for language features.
 
@@ -127,17 +144,23 @@ Mach coding standards are in flux while syntax stabilizes and the userbase grows
 
 ```
 mach/
-├── dep/                # dep checkouts realized by `mach dep pull` (git-ignored)
-│   └── mach-std/       # standard library
+├── dep/               # dependency realizations
+│   └── std/           # standard library, pinned by a committed gitlink
 ├── doc/               # documentation
 ├── src/               # self-hosting mach compiler
-├── out/               # build output (git-ignored); compiler at out/<target>/bin/mach
+├── out/               # ignored build output, grouped by target and profile
 └── mach.toml          # project configuration
 ```
 
-The standard library lives in a separate repository ([mach-std](https://github.com/briar-systems/mach-std)) and is realized into `dep/mach-std/` by `mach dep pull` from the pin in `mach.toml`. The dep is currently frozen at an immutable `commit/<sha>` (the v1.7 self-host seed freeze, [#1486](https://github.com/briar-systems/mach/issues/1486)); it reverts to `branch/main` after the post-v1.7 re-seed.
+The standard library lives in a separate repository
+([mach-std](https://github.com/briar-systems/mach-std)). `[dep.std]` declares
+its source and selector in `mach.toml`, `.gitmodules` records its submodule
+location, and the committed gitlink at `dep/std` pins the exact revision.
+`mach dep pull` initializes that pin in place. Builds verify the dependency
+without fetching or advancing its selector. See the
+[dependency model](doc/design/dependency-model.md).
 
-Building from source uses an existing `mach` (the latest release) — see [Getting Started](#getting-started). The original bootstrap seed ([mach-boot](https://github.com/briar-systems/mach-boot)) is no longer part of the build; it remains only as a from-scratch cold-start hatch.
+Building from source uses an existing `mach` (the latest release). See [Getting Started](#getting-started). The original bootstrap seed ([mach-boot](https://github.com/briar-systems/mach-boot)) is no longer part of the build. It remains only as a from-scratch cold-start hatch.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,10 @@ We have an official [Discord](https://discord.com/invite/dfWG9NhGj7)!
 
 Mach is a self hosted, statically-typed, compiled systems language designed to be simple, fast, verbose, and intuitive. Mach was created for projects like compilers, runtimes, operating systems, tooling, and embedded systems -- anywhere performance is a requirement and hidden behavior is a liability. The language is deliberately small and explicit: what you read is what executes, every cost is visible in the code that incurs it.
 
-Mach does not rely on any external dependencies for the compiler or during runtime -- no LLVM, no linking to libc, no system linker or other tools. The entire compiler and all base language features are written in native Mach. 
+The compiler, code generators, and linker are written in native Mach, with no
+LLVM or external assembler or linker. Ordinary Linux programs using the
+standard library need no libc. The standard library uses platform libraries
+where required, including libSystem on Darwin and Windows system DLLs.
 
 Memory is managed manually. There is no garbage collector and no hidden allocation. Memory flows through allocators that you create and pass explicitly, and the standard library is built around that style end to end: anything that allocates takes an allocator, and anything that doesn't never will. 
 
@@ -55,7 +58,9 @@ mach dep pull
 mach build .
 ```
 
-The compiler is written to `out/<target>/bin/mach`, where `<target>` is the selected target name.
+The compiler is written to `out/<target>/<profile>/bin/mach`, or `bin/mach.exe`
+on Windows. A default Linux x86_64 build writes
+`out/linux-x86_64/debug/bin/mach`.
 
 
 # Examples

--- a/doc/design/dependency-model.md
+++ b/doc/design/dependency-model.md
@@ -149,7 +149,9 @@ Dependencies declare sources only. Artifacts, tests, and steps declare which
 ids they consume; there is no scope vocabulary (no "dev" or "test"
 dependencies), because a scope is a property of the consumer, and the
 consumer already says what it consumes. Public entry is the module a
-dependency's artifacts share; there is no implicit `lib.mach`.
+dependency's artifacts share. In 4.30.0, a dependency with no artifacts still
+gets the legacy `lib.mach` entry under its source directory. 5.0.0 removes
+that fallback and requires an explicitly defaulted library artifact.
 
 Three things fit the five statements without changing them and are named as
 future slots rather than built: owner-prefixed (dotted) ids if the flat id

--- a/doc/design/release-shape.md
+++ b/doc/design/release-shape.md
@@ -1,9 +1,9 @@
 # The 4.30.0 / 5.0.0 release shape
 
 The changes that reshaped the compiler in 2026 ship as two releases with a
-fixed division of labour: **4.30.0** is the compatible transition and
-**5.0.0** carries every removal. This page records why it has to be two, and
-why the split falls where it does.
+fixed division of labour: **4.30.0** supplies the transition forms and seed,
+and **5.0.0** removes the legacy forms retained for migration. This page
+records why it has to be two, and why the split falls where it does.
 
 ## The seed forces it
 
@@ -18,11 +18,11 @@ removed the old ones could not be built by the seed that only knows the old
 ones, because its own manifest and source would already have to use the new
 forms. So:
 
-- **4.30.0** adds every new form beside the old one and removes nothing. The
-  4.26.x seed builds it, because nothing in its source or manifest is a form
-  the seed rejects. Where a 4.30.0 feature would help the compiler's own
-  source, the source waits: the compiler is written against the seed's
-  dialect, not its own.
+- **4.30.0** adds the replacement language and manifest forms while retaining
+  the specific legacy forms listed below. The 4.26.5 seed builds it, because
+  nothing in its source or manifest is a form the seed rejects. Where a
+  4.30.0 feature would help the compiler's own source, the source waits. The
+  compiler is written against the seed's dialect.
 - 4.30.0 is then published as the seed.
 - **5.0.0** removes the old forms, with a migration diagnostic naming the new
   one. The 4.30.0 seed builds it, because 5.0.0 source uses only forms
@@ -39,29 +39,42 @@ verification runs three generations for that reason.
 Additive, in 4.30.0:
 
 - the declassification cast `:>T`, beside the older `:^` and `:^T`
-  spellings ([secrecy.md](../language/secrecy.md#downgrade-with-t));
+  spellings ([secrecy.md](../language/secrecy.md#downgrade-with-t)).
 - identity-keyed dependency tables `[dep.<id>]` and the flat root-owned
-  closure, beside alias keys and nested realization
-  ([dependency-model.md](dependency-model.md));
+  closure, with migration notes for alias keys and ignored nested realization
+  ([dependency-model.md](dependency-model.md)).
 - `default = true` on targets, profiles, and artifacts, beside the
-  first-declared fallback (which warns);
+  first-declared fallback (which warns).
 - artifact requirements (`need` naming artifacts and globs), the
   `timeout_seconds` surface on `mach test`, `mach run`, and build steps,
   the `env` target key, and the other additions in the changelog.
 
 Removed, in 5.0.0:
 
-- the `:^` and `:^T` spellings;
-- alias dependency keys, nested realization, and `mach.lock`;
-- the first-declared target, profile, and artifact fallbacks;
-- the `sysv` ABI alias and the withdrawn `mos6502` target;
-- an `#[embed]` path that escapes the project root (a warning in 4.30.0);
-- plus the SemVer proposal on `mach dep update`, which is additive but
-  belongs with the finished dependency model.
+- the `:^` and `:^T` spellings.
+- alias dependency keys, nested realization, and `mach.lock`.
+- the first-declared target, profile, and artifact fallbacks.
+- the `sysv` ABI alias and the withdrawn `mos6502` target.
+- an `#[embed]` path that escapes the project root (a warning in 4.30.0).
+- the five deprecated manifest keys: `[project] name`, `description`, and
+  `mach`, plus `[profile.*] emit_ir` and `emit_asm`.
+- `$project.name` and `$project.description`, with their manifest keys
+  ([#3128](https://github.com/briar-systems/mach/issues/3128)).
+- the implicit `lib.mach` entry for a dependency that declares no artifacts.
 
-The rule for which side a change lands on is mechanical: if a manifest or a
-program that 4.26.x accepts stops working, it is 5.0.0. Nothing in 4.30.0
-breaks an existing project.
+5.0.0 also adds the SemVer proposal on `mach dep update`. It belongs with the
+finished dependency model, though it is an addition rather than a removal.
+
+Compatibility in 4.30.0 means preserving the seed path and these specific
+migration forms. It does not mean accepting every project 4.26.x accepted.
+The audited changes already remove `-O1` and `--verify-ir`, reject ignored CLI
+options, and withdraw MOS 6502 from ordinary build planning. Soundness and
+validation fixes also reject previously accepted input: address-of requires
+a place and refuses temporaries, arithmetic and non-shift bitwise binary
+operators require operands of one type, and manifest-controlled paths must
+stay within the project root. The [changelog](../../CHANGELOG.md) lists the
+immediate changes and fixes.
+The listed 5.0.0 removals remain deferred until the new seed is published.
 
 ## Why one squashed commit
 
@@ -80,11 +93,12 @@ are these pages under `doc/design/`.
 
 No release is cut from a tree whose supported public surface lacks
 docstrings or whose `doc/` pages contradict the compiler. Docstrings state
-what and how; `doc/design/` states why; the changelog states when.
+what and how, `doc/design/` states why, and the changelog states when.
 Documentation never changes generated code, and that is checked: objects
 built with `debug = false` are byte-identical across a documentation change.
 The supported surface is the editor API, the command line, and the manifest
-schema, source-stable within a major; everything else under `src/` is
-internal and carries no promise. Deprecation notices and experimental
-marking as compiler machinery were deferred as low-priority additive work;
-5.0.0 removes drift directly.
+schema. Their intended stability within a major has the explicit transition
+exceptions described above. Everything else under `src/` is internal and
+carries no promise. General deprecation attributes and experimental marking
+as compiler machinery were deferred as low-priority additive work.
+The targeted migration notes and warnings described above ship in 4.30.0.

--- a/doc/manifest.md
+++ b/doc/manifest.md
@@ -500,7 +500,7 @@ removed; use -O0 or -O2`).
 
 ## `[artifact.<name>]`
 
-Every artifact is declared explicitly and named by its table key. `$project.name`
+Every artifact is declared explicitly and named by its table key. `$bin.name`
 reads the selected artifact's name.
 
 | Key       | Required | Meaning |


### PR DESCRIPTION
4.30.0 documentation promised acceptance of every 4.26.x project despite the audited CLI removals, new validation refusals, and MOS 6502 withdrawal. Describe the specific migration window and seed compatibility, and complete the planned 5.0.0 removal list.

Update contributor setup for profile-specific output paths, the committed `dep/std` gitlink, issue branches and draft PRs, and the B/C bootstrap fixpoint. Correct `$bin.name`, document the legacy `lib.mach` fallback, qualify platform library requirements, and record the verified std v0.37.2 pin and TOML fix.

Validation: `git diff HEAD^ HEAD --check` passed. Textual checks passed for all six changed documentation files, 32 local link targets, manifest output paths, and unchanged release heading and historical changelog. The std v0.37.2 tag resolves to gitlink `565f40ab`, and its comparison with v0.37.1 confirms the TOML fix. Compiler tests were not run for this documentation-only change.

Closes #3134
