### PR TITLE
fix(driver): verify dependencies through their root-selected source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -196,6 +196,7 @@ The pin moves from 0.28.1 to 0.37.1.
 
 #### Driver and build
 
+- Root dependency overrides select the realization's source kind, URL and exact selector before verification, including when a transitive edge is visited first (#3138).
 - A required artifact planned under `mach test` was built as a test cell.
 - `--quiet` on `mach build` was ignored.
 - `BuildPlan` borrowed its request.

--- a/src/lang/driver/deps.mach
+++ b/src/lang/driver/deps.mach
@@ -469,18 +469,18 @@ fun discard_dep_entry(alloc: *A.Allocator, entry: *project.DepEntry) {
     manifest.dnit(?entry.manifest, alloc);
 }
 
-fun root_declares(root_m: *manifest.Manifest, name: intern.StrId) bool {
+fun root_dependency(root_m: *manifest.Manifest, name: intern.StrId) *manifest.DepDef {
     var i: u32 = 0;
     for (i < root_m.dep_count) {
-        if (root_m.deps[i].name == name) { ret true; }
+        if (root_m.deps[i].name == name) { ret ?root_m.deps[i]; }
         i = i + 1;
     }
-    ret false;
+    ret nil;
 }
 
 fun resolve_dep_edge(p: *project.Project, gi: *GitInspector, root_m: *manifest.Manifest, current_root: str, d: *manifest.DepDef,
                      deps: *project.DepEntry, active: *bool, dep_count_ptr: *u32, max_deps: usize,
-                     dir_dep: str, requirer_chain: str, from_root: bool) R.Result[u32, str] {
+                     dir_dep: str, requirer_chain: str) R.Result[u32, str] {
     val alias_opt: O.Option[str] = intern.lookup(?p.s.interner, d.name);
     if (O.is_none[str](alias_opt)) { ret R.err[u32, str]("dep alias StrId not interned"); }
     val alias: str = O.unwrap[str](alias_opt);
@@ -488,7 +488,10 @@ fun resolve_dep_edge(p: *project.Project, gi: *GitInspector, root_m: *manifest.M
     if (R.is_err[str, str](chain_r)) { ret R.err[u32, str](R.unwrap_err[str, str](chain_r)); }
     val chain_here: str = R.unwrap_ok[str, str](chain_r);
 
-    val rd: R.Result[project.DepEntry, str] = resolve_dep(p.s, gi, alias, current_root, dir_dep, d);
+    val root_dep: *manifest.DepDef = root_dependency(root_m, d.name);
+    var selected: *manifest.DepDef = d;
+    if (root_dep != nil) { selected = root_dep; }
+    val rd: R.Result[project.DepEntry, str] = resolve_dep(p.s, gi, alias, current_root, dir_dep, selected);
     if (R.is_err[project.DepEntry, str](rd)) {
         str_free(p.alloc, chain_here);
         ret R.err[u32, str](R.unwrap_err[project.DepEntry, str](rd));
@@ -501,8 +504,8 @@ fun resolve_dep_edge(p: *project.Project, gi: *GitInspector, root_m: *manifest.M
         ret R.err[u32, str](R.unwrap_err[intern.StrId, str](chain_id_r));
     }
     entry.chain = R.unwrap_ok[intern.StrId, str](chain_id_r);
-    entry.root_declared = from_root;
-    val overridden: bool = from_root || root_declares(root_m, d.name);
+    val overridden: bool = root_dep != nil;
+    entry.root_declared = overridden;
     var j: u32 = 0;
     for (j < dep_count_ptr[0]) {
         if (deps[j].project_id == entry.project_id) {
@@ -575,7 +578,7 @@ fun resolve_dep_edge(p: *project.Project, gi: *GitInspector, root_m: *manifest.M
         var k: u32 = 0;
         for (k < child_count) {
             val child_r: R.Result[u32, str] = resolve_dep_edge(p, gi, root_m, current_root,
-                ?deps[idx].manifest.deps[k], deps, active, dep_count_ptr, max_deps, dir_dep, chain_here, false);
+                ?deps[idx].manifest.deps[k], deps, active, dep_count_ptr, max_deps, dir_dep, chain_here);
             if (R.is_err[u32, str](child_r)) {
                 str_free(p.alloc, chain_here);
                 ret child_r;
@@ -628,7 +631,7 @@ pub fun resolve_deps(p: *project.Project, m: *manifest.Manifest, project_root: s
     var root_i: u32 = 0;
     for (root_i < m.dep_count) {
         val edge_r: R.Result[u32, str] = resolve_dep_edge(p, ?gi, m, project_root, ?m.deps[root_i],
-            deps, active, ?dep_count, max_deps, dir_dep, root_name, true);
+            deps, active, ?dep_count, max_deps, dir_dep, root_name);
         if (R.is_err[u32, str](edge_r)) {
             git_inspector_dnit(p.alloc, ?gi);
             A.deallocate[bool](p.alloc, active, max_deps);

--- a/src/lang/driver/tests.mach
+++ b/src/lang/driver/tests.mach
@@ -5019,6 +5019,121 @@ test "mach.lang.driver:dep_transitive_gitlink_resolves_flat_and_the_nested_place
     session.dnit(?s);
     ret bad;
 }
+fun ut_dep_root_override(nested: bool, root_git: bool, child_git: bool, root_first: bool) i32 {
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    val sr: R.Result[session.Session, str] = session.init(?alloc);
+    if (R.is_err[session.Session, str](sr)) { ret 1; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](sr);
+    fin { session.dnit(?s); }
+    if (R.is_err[R.Void, str](driver.setup_registry(?s.registry))) { ret 1; }
+
+    val a_decl: str = "\n[dep.a]\npath = \"./vendor/a\"\n";
+    val initial_manifest: str = ut_dep_root_one(?alloc, "a", "./vendor/a");
+    var names: [1]str; names[0] = "main.mach";
+    var texts: [1]str; texts[0] = "use a.lib;\nfun main() i32 { ret lib.v(); }\n";
+    val outer_r: R.Result[str, str] = ut_scaffold_m(?alloc, initial_manifest, ?names[0], ?texts[0], 1);
+    if (R.is_err[str, str](outer_r)) { ret 1; }
+    val outer: str = R.unwrap_ok[str, str](outer_r);
+    fin { fs.remove_all(?alloc, outer); }
+    var root: str = outer;
+    if (nested) {
+        root = ut_cc3(?alloc, outer, "/", "project");
+        if (O.is_some[str](ut_write_node(?alloc, root, initial_manifest, "main.mach", texts[0]))) { ret 2; }
+    }
+
+    val a_root: str = ut_cc3(?alloc, root, "/", "dep/a");
+    val b_root: str = ut_cc3(?alloc, root, "/", "dep/b");
+    var child_decl: str = "\n[dep.b]\npath = \"../transitive-b\"\n";
+    if (child_git) {
+        child_decl = "\n[dep.b]\ngit = \"https://example.invalid/transitive-b.git\"\nref = \"commit/0000000000000000000000000000000000000000\"\n";
+    }
+    val a_manifest: str = ut_cc3(?alloc, ut_lib_manifest(?alloc, "a"), child_decl, "");
+    if (O.is_some[str](ut_write_node(?alloc, a_root, a_manifest, "lib.mach",
+            "use b.lib;\npub fun v() i32 { ret lib.v(); }\n"))
+        || O.is_some[str](ut_write_node(?alloc, b_root, ut_lib_manifest(?alloc, "b"),
+            "lib.mach", "pub fun v() i32 { ret 42; }\n"))) { ret 3; }
+
+    val root_source: str = "https://example.invalid/root-b.git";
+    var root_ref: str = "";
+    var b_decl: str = "\n[dep.b]\npath = \"./vendor/b\"\n";
+    var root_manifest: str = ut_dep_root_one(?alloc, "b", "./vendor/b");
+    var expected_source: str = "path ./vendor/b";
+    if (root_git) {
+        if (!ut_git_repo(?alloc, b_root, root_source)
+            || !ut_write_gitmodules(?alloc, root, "b", root_source)) { ret 4; }
+        val head_r: R.Result[str, str] = ut_git_ref(?alloc, b_root, "refs/remotes/origin/main");
+        if (R.is_err[str, str](head_r)) { ret 5; }
+        root_ref = ut_cc3(?alloc, "commit/", R.unwrap_ok[str, str](head_r), "");
+        b_decl = ut_cc3(?alloc, "\n[dep.b]\ngit = \"https://example.invalid/root-b.git\"\nref = \"", root_ref, "\"\n");
+        root_manifest = ut_dep_root_git_ref(?alloc, "b", root_source, root_ref);
+        expected_source = "git https://example.invalid/root-b.git";
+    }
+    if (root_first) { root_manifest = ut_cc3(?alloc, root_manifest, a_decl, ""); }
+    or { root_manifest = ut_cc3(?alloc, initial_manifest, b_decl, ""); }
+    val root_manifest_path: str = ut_cc3(?alloc, root, "/", manifest.MANIFEST_FILE);
+    if (O.is_some[str](fs.write_bytes(root_manifest_path, root_manifest, str_len(root_manifest), 420))
+        || !ut_git_repo(?alloc, outer, "https://example.invalid/app.git")) { ret 6; }
+
+    val pr: R.Result[project.Project, outcome.Fail] = driver.build_project_union(?s, root);
+    if (R.is_err[project.Project, outcome.Fail](pr)) { ret 7; }
+    var p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](pr);
+    var bad: i32 = 0;
+    if (p.config.dep_count != 2) { bad = 8; }
+    val a_id: intern.StrId = project.intern_unwrap(?s.interner, "a");
+    val b_id: intern.StrId = project.intern_unwrap(?s.interner, "b");
+    var saw_a: bool = false;
+    var saw_b: bool = false;
+    var i: u32 = 0;
+    for (i < p.config.dep_count) {
+        val entry: *project.DepEntry = ?p.config.deps[i];
+        if (entry.project_id == a_id) {
+            saw_a = true;
+            if (entry.direct_count != 1 || entry.direct[0] != b_id) { bad = 9; }
+        }
+        if (entry.project_id == b_id) {
+            saw_b = true;
+            if (!entry.root_declared || entry.source != project.intern_unwrap(?s.interner, expected_source)) { bad = 10; }
+            if (root_git && entry.ref != project.intern_unwrap(?s.interner, root_ref)) { bad = 11; }
+            var expected_chain: str = "app -> a -> b";
+            if (root_first) { expected_chain = "app -> b"; }
+            if (entry.chain != project.intern_unwrap(?s.interner, expected_chain)) { bad = 12; }
+        }
+        i = i + 1;
+    }
+    if (!saw_a || !saw_b) { bad = 13; }
+    project.dnit_project(?p);
+
+    if (root_git) {
+        val b_source: str = ut_cc3(?alloc, b_root, "/src/", "lib.mach");
+        val dirty: str = "pub fun v() i32 { ret 7; }\n";
+        if (O.is_some[str](fs.write_bytes(b_source, dirty, str_len(dirty), 420))) { ret 14; }
+        if (!ut_dep_build_fails(?s, root, "checkout is dirty")) { bad = 15; }
+    }
+    ret bad;
+}
+
+test "mach.lang.driver:dep_root_override_path_replaces_transitive_git" {
+    if (ut_dep_root_override(false, false, true, false) != 0) { ret 1; }
+    if (ut_dep_root_override(false, false, true, true) != 0) { ret 2; }
+    if (ut_dep_root_override(true, false, true, false) != 0) { ret 3; }
+    ret ut_dep_root_override(true, false, true, true);
+}
+
+test "mach.lang.driver:dep_root_override_git_replaces_transitive_url_and_commit" {
+    if (ut_dep_root_override(false, true, true, false) != 0) { ret 1; }
+    if (ut_dep_root_override(false, true, true, true) != 0) { ret 2; }
+    if (ut_dep_root_override(true, true, true, false) != 0) { ret 3; }
+    ret ut_dep_root_override(true, true, true, true);
+}
+
+test "mach.lang.driver:dep_root_override_git_replaces_transitive_path" {
+    if (ut_dep_root_override(false, true, false, false) != 0) { ret 1; }
+    if (ut_dep_root_override(false, true, false, true) != 0) { ret 2; }
+    if (ut_dep_root_override(true, true, false, false) != 0) { ret 3; }
+    ret ut_dep_root_override(true, true, false, true);
+}
+
 test "mach.lang.driver:dep_transitive_manifest_failures_are_not_leaves" {
     var alloc: A.Allocator;
     if (O.is_some[str](page.make(?alloc))) { ret 1; }


### PR DESCRIPTION
Dependency verification used the incoming transitive declaration even when the root selected a different source. Select the complete root declaration before verification so path and Git overrides work in either declaration order, while preserving the original requirement chain in diagnostics.

Closes #3138

Validation on committed 90c9c999:

- Bar 1: 4.26.5 seed build and self-build passed. Debug and release suites each passed 2,459 tests with zero failures, exactly three additional tests covering 12 override combinations.
- Bar 2: all nine structural censuses passed.
- Bar 3: warm, source-edit, and manifest-edit incremental builds matched clean builds.
- Bar 4: seed-rooted B and C were byte-identical.
- Bar 5: baseline and fixed compilers emitted identical binaries from the same audited source for linux-x86_64, linux-arm64, and linux-riscv64.
- Bar 6: skipped because this change does not touch objects, relocations, or linking.
- Bar 7: pinned std built and passed 1,092 tests with zero failures from its root.
- Mutation: restoring transitive-source verification made all three new tests fail. Restoring the fix returned the tree to the verified commit's contents.

An overlapping release-suite/fixpoint attempt was discarded. Both checks were rerun serially in a fresh detached checkout and the results above come from those valid runs.

Platform CI still exposes separate baseline blockers in the old harnesses (#3135), Git configuration (#3139), and Windows std publication (briar-systems/mach-std#574). Those remain release blockers and are being fixed independently.
