### PR TITLE
fix(infra): reconcile reviewed ARM audit goldens

### DIFF
--- a/test/golden/aarch64-linux/call/call_indirect.dis
+++ b/test/golden/aarch64-linux/call/call_indirect.dis
@@ -331,14 +331,15 @@ Disassembly of section .text:
 <corpus.cases.call.call_indirect.checksum>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0x1e0
-               	stp	x19, x20, [x29, #-0x180]
-               	stp	x21, x22, [x29, #-0x190]
-               	stp	x23, x24, [x29, #-0x1a0]
-               	stp	x25, x26, [x29, #-0x1b0]
-               	stp	x27, x28, [x29, #-0x1c0]
-               	stp	d8, d9, [x29, #-0x1d0]
-               	stp	d10, d11, [x29, #-0x1e0]
+               	sub	sp, sp, #0x210
+               	stp	x19, x20, [x29, #-0x1b0]
+               	stp	x21, x22, [x29, #-0x1c0]
+               	stp	x23, x24, [x29, #-0x1d0]
+               	stp	x25, x26, [x29, #-0x1e0]
+               	stp	x27, x28, [x29, #-0x1f0]
+               	sub	x16, x29, #0x200
+               	stp	d8, d9, [x16]
+               	stp	d10, d11, [x16, #-0x10]
                	mov	x19, x0
 <L0>:
                	bl	 <L0>
@@ -448,25 +449,33 @@ Disassembly of section .text:
                	udiv	x16, x1, x0
                	msub	x28, x16, x0, x1
                	add	x9, x21, x28, lsl #3
-               	stur	x9, [x29, #-0x100]
-               	ldur	x9, [x29, #-0x100]
+               	mov	x16, #0xfed0            // =65232
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	mov	x16, #0xfed0            // =65232
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
                	ldr	x3, [x9]
                	ldr	x1, [x27]
                	mov	x0, x25
                	blr	x3
                	mov	x9, x0
-               	mov	x16, #0xfef8            // =65272
+               	mov	x16, #0xfec8            // =65224
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
-               	mov	x16, #0xfef8            // =65272
+               	mov	x16, #0xfec8            // =65224
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	mov	x0, x24
-               	mov	x16, #0xfef8            // =65272
+               	mov	x16, #0xfec8            // =65224
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -475,20 +484,24 @@ Disassembly of section .text:
 <L5>:
                	bl	 <L5>
                	mov	x9, x0
-               	mov	x16, #0xfef0            // =65264
+               	mov	x16, #0xfec0            // =65216
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
-               	mov	x16, #0xfef0            // =65264
+               	mov	x16, #0xfec0            // =65216
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
-               	ldur	x9, [x29, #-0x100]
+               	mov	x16, #0xfed0            // =65232
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
                	ldr	x5, [x9]
                	ldr	x1, [x27]
-               	mov	x16, #0xfef8            // =65272
+               	mov	x16, #0xfec8            // =65224
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -496,7 +509,7 @@ Disassembly of section .text:
                	mov	x0, x9
                	blr	x5
                	mov	x1, x0
-               	mov	x16, #0xfef0            // =65264
+               	mov	x16, #0xfec0            // =65216
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -516,25 +529,25 @@ Disassembly of section .text:
                	ldr	x28, [x0]
                	add	x0, x20, x26, lsl #3
                	ldr	x9, [x0]
-               	mov	x16, #0xfee8            // =65256
+               	mov	x16, #0xfeb8            // =65208
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
-               	mov	x16, #0xfef8            // =65272
+               	mov	x16, #0xfec8            // =65224
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	mov	x0, x9
-               	mov	x16, #0xfee8            // =65256
+               	mov	x16, #0xfeb8            // =65208
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	mov	x1, x9
                	blr	x28
-               	mov	x16, #0xfee8            // =65256
+               	mov	x16, #0xfeb8            // =65208
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -590,7 +603,7 @@ Disassembly of section .text:
 <L15>:
                	add	x0, x20, x26, lsl #3
                	ldr	x1, [x0]
-               	mov	x16, #0xfef8            // =65272
+               	mov	x16, #0xfec8            // =65224
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -603,7 +616,7 @@ Disassembly of section .text:
                	bl	 <L16>
                	add	x26, x26, #0x1
                	mov	x24, x0
-               	mov	x16, #0xfef8            // =65272
+               	mov	x16, #0xfec8            // =65224
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -687,38 +700,38 @@ Disassembly of section .text:
                	ldr	x1, [x0]
                	add	x0, x1, x25
                	sub	x9, x29, #0xe0
-               	mov	x16, #0xfee0            // =65248
+               	mov	x16, #0xfeb0            // =65200
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
-               	mov	x16, #0xfee0            // =65248
+               	mov	x16, #0xfeb0            // =65200
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	mov	x8, x9
                	blr	x2
-               	mov	x16, #0xfee0            // =65248
+               	mov	x16, #0xfeb0            // =65200
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
-               	mov	x16, #0xfee0            // =65248
+               	mov	x16, #0xfeb0            // =65200
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	ldr	x0, [x9]
                	str	x0, [x28]
-               	mov	x16, #0xfee0            // =65248
+               	mov	x16, #0xfeb0            // =65200
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	ldr	x0, [x9, #0x8]
                	str	x0, [x28, #0x8]
-               	mov	x16, #0xfee0            // =65248
+               	mov	x16, #0xfeb0            // =65200
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -729,14 +742,14 @@ Disassembly of section .text:
                	ldr	x1, [x0]
                	add	x0, x28, #0x8
                	ldr	x9, [x0]
-               	mov	x16, #0xfed8            // =65240
+               	mov	x16, #0xfea8            // =65192
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
                	add	x0, x28, #0x10
                	ldr	x9, [x0]
-               	mov	x16, #0xfed0            // =65232
+               	mov	x16, #0xfea0            // =65184
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -744,7 +757,7 @@ Disassembly of section .text:
                	mov	x0, x24
 <L26>:
                	bl	 <L26>
-               	mov	x16, #0xfed8            // =65240
+               	mov	x16, #0xfea8            // =65192
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -752,7 +765,7 @@ Disassembly of section .text:
                	mov	x1, x9
 <L27>:
                	bl	 <L27>
-               	mov	x16, #0xfed0            // =65232
+               	mov	x16, #0xfea0            // =65184
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -761,32 +774,38 @@ Disassembly of section .text:
 <L28>:
                	bl	 <L28>
                	mov	x9, x0
-               	mov	x16, #0xfec0            // =65216
+               	mov	x16, #0xfe90            // =65168
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
-               	mov	x16, #0xfec0            // =65216
+               	mov	x16, #0xfe90            // =65168
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	add	x9, x22, x27, lsl #3
-               	mov	x16, #0xfec8            // =65224
+               	mov	x16, #0xfe98            // =65176
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
-               	mov	x16, #0xfec8            // =65224
+               	mov	x16, #0xfe98            // =65176
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	ldr	x27, [x9]
-               	mov	x0, x28
+               	ldr	x0, [x28]
+               	stur	x0, [x29, #-0xf8]
+               	ldr	x0, [x28, #0x8]
+               	stur	x0, [x29, #-0xf0]
+               	ldr	x0, [x28, #0x10]
+               	stur	x0, [x29, #-0xe8]
+               	sub	x0, x29, #0xf8
                	blr	x27
                	mov	x3, x0
-               	mov	x16, #0xfec0            // =65216
+               	mov	x16, #0xfe90            // =65168
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -796,7 +815,7 @@ Disassembly of section .text:
 <L29>:
                	bl	 <L29>
                	mov	x27, x0
-               	mov	x16, #0xfec8            // =65224
+               	mov	x16, #0xfe98            // =65176
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -806,13 +825,13 @@ Disassembly of section .text:
                	ldr	x26, [x0]
                	add	x0, x20, x21, lsl #3
                	ldr	x1, [x0]
-               	sub	x9, x29, #0xf8
-               	mov	x16, #0xfeb8            // =65208
+               	sub	x9, x29, #0x110
+               	mov	x16, #0xfe88            // =65160
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
-               	mov	x16, #0xfeb8            // =65208
+               	mov	x16, #0xfe88            // =65160
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -820,17 +839,45 @@ Disassembly of section .text:
                	mov	x8, x9
                	mov	x0, x1
                	blr	x26
-               	mov	x16, #0xfeb8            // =65208
+               	mov	x16, #0xfe88            // =65160
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
-               	mov	x16, #0xfeb8            // =65208
+               	mov	x16, #0xfe88            // =65160
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
-               	mov	x0, x9
+               	ldr	x0, [x9]
+               	mov	x16, #0xfed8            // =65240
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x0, [x29, x16]
+               	mov	x16, #0xfe88            // =65160
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	ldr	x0, [x9, #0x8]
+               	mov	x16, #0xfee0            // =65248
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x0, [x29, x16]
+               	mov	x16, #0xfe88            // =65160
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	ldr	x0, [x9, #0x10]
+               	mov	x16, #0xfee8            // =65256
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x0, [x29, x16]
+               	sub	x0, x29, #0x128
                	blr	x28
                	mov	x1, x0
                	mov	x0, x27
@@ -869,7 +916,7 @@ Disassembly of section .text:
                	fdiv	d10, d0, d30
                	mov	w28, w22
                	mvn	x9, x22
-               	mov	x16, #0xfeb0            // =65200
+               	mov	x16, #0xfe80            // =65152
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -881,7 +928,7 @@ Disassembly of section .text:
                	fmov	s30, w16
                	fsub	s11, s0, s30
                	eor	x9, x22, x25
-               	mov	x16, #0xfea8            // =65192
+               	mov	x16, #0xfe78            // =65144
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -915,7 +962,7 @@ Disassembly of section .text:
                	mov	x1, x28
 <L42>:
                	bl	 <L42>
-               	mov	x16, #0xfeb0            // =65200
+               	mov	x16, #0xfe80            // =65152
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -926,7 +973,7 @@ Disassembly of section .text:
                	fmov	s0, s11
 <L44>:
                	bl	 <L44>
-               	mov	x16, #0xfea8            // =65192
+               	mov	x16, #0xfe78            // =65144
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -958,13 +1005,13 @@ Disassembly of section .text:
                	fmov	d30, x16
                	fdiv	d10, d0, d30
                	mov	w9, w22
-               	mov	x16, #0xfea0            // =65184
+               	mov	x16, #0xfe70            // =65136
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
                	mvn	x9, x22
-               	mov	x16, #0xfe98            // =65176
+               	mov	x16, #0xfe68            // =65128
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -976,7 +1023,7 @@ Disassembly of section .text:
                	fmov	s30, w16
                	fsub	s11, s0, s30
                	eor	x9, x22, x25
-               	mov	x16, #0xfe90            // =65168
+               	mov	x16, #0xfe60            // =65120
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1007,7 +1054,7 @@ Disassembly of section .text:
                	fmov	d0, d10
 <L55>:
                	bl	 <L55>
-               	mov	x16, #0xfea0            // =65184
+               	mov	x16, #0xfe70            // =65136
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1015,7 +1062,7 @@ Disassembly of section .text:
                	mov	x1, x9
 <L56>:
                	bl	 <L56>
-               	mov	x16, #0xfe98            // =65176
+               	mov	x16, #0xfe68            // =65128
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1026,7 +1073,7 @@ Disassembly of section .text:
                	fmov	s0, s11
 <L58>:
                	bl	 <L58>
-               	mov	x16, #0xfe90            // =65168
+               	mov	x16, #0xfe60            // =65120
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1044,13 +1091,14 @@ Disassembly of section .text:
                	b.lo	 <L32>
 <L61>:
                	mov	x0, x24
-               	ldp	d8, d9, [x29, #-0x1d0]
-               	ldp	d10, d11, [x29, #-0x1e0]
-               	ldp	x19, x20, [x29, #-0x180]
-               	ldp	x21, x22, [x29, #-0x190]
-               	ldp	x23, x24, [x29, #-0x1a0]
-               	ldp	x25, x26, [x29, #-0x1b0]
-               	ldp	x27, x28, [x29, #-0x1c0]
+               	sub	x16, x29, #0x200
+               	ldp	d8, d9, [x16]
+               	ldp	d10, d11, [x16, #-0x10]
+               	ldp	x19, x20, [x29, #-0x1b0]
+               	ldp	x21, x22, [x29, #-0x1c0]
+               	ldp	x23, x24, [x29, #-0x1d0]
+               	ldp	x25, x26, [x29, #-0x1e0]
+               	ldp	x27, x28, [x29, #-0x1f0]
                	mov	sp, x29
                	ldp	x29, x30, [sp], #0x10
                	ret

--- a/test/golden/aarch64-linux/call/call_mixed.dis
+++ b/test/golden/aarch64-linux/call/call_mixed.dis
@@ -308,14 +308,17 @@ Disassembly of section .text:
 <corpus.cases.call.call_mixed.checksum>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0x1b0
-               	stp	x19, x20, [x29, #-0x170]
-               	stp	x21, x22, [x29, #-0x180]
-               	mov	x16, #0xfe78            // =65144
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x23, [x29, x16]
+               	sub	sp, sp, #0x280
+               	sub	x16, x29, #0x1f0
+               	stp	x19, x20, [x16]
+               	stp	x21, x22, [x16, #-0x10]
+               	stp	x23, x24, [x16, #-0x20]
+               	stp	x25, x26, [x16, #-0x30]
+               	stp	x27, x28, [x16, #-0x40]
+               	sub	x16, x29, #0x240
+               	stp	d11, d12, [x16]
+               	stp	d13, d14, [x16, #-0x10]
+               	stur	d15, [x16, #-0x18]
                	mov	x19, x0
 <L0>:
                	bl	 <L0>
@@ -371,264 +374,320 @@ Disassembly of section .text:
                	mov	x23, #0x0               // =0
                	cmp	x23, #0x3
                	b.lo	 <L3>
-               	b	 <L6>
+               	b	 <L11>
 <L3>:
                	mov	x16, #0xb               // =11
                	mul	x0, x23, x16
-               	add	x1, x0, x19
+               	add	x24, x0, x19
                	sub	x0, x29, #0xcc
-               	add	x2, x20, #0x80
-               	ldr	x3, [x2]
+               	add	x1, x20, #0x80
+               	ldr	x2, [x1]
                	mov	x16, #0xfff             // =4095
-               	and	x2, x3, x16
-               	ucvtf	s0, x2
+               	and	x1, x2, x16
+               	ucvtf	s0, x1
                	mov	w16, #0x45000000        // =1157627904
                	fmov	s30, w16
                	fsub	s1, s0, s30
                	fmov	s30, #8.00000000
                	fdiv	s0, s1, s30
-               	add	x2, x0, #0x0
-               	str	s0, [x2]
-               	add	x2, x20, #0x88
-               	ldr	x3, [x2]
+               	add	x1, x0, #0x0
+               	str	s0, [x1]
+               	add	x1, x20, #0x88
+               	ldr	x2, [x1]
                	mov	x16, #0xfff             // =4095
-               	and	x2, x3, x16
-               	ucvtf	s0, x2
+               	and	x1, x2, x16
+               	ucvtf	s0, x1
                	mov	w16, #0x45000000        // =1157627904
                	fmov	s30, w16
                	fsub	s1, s0, s30
                	fmov	s30, #8.00000000
                	fdiv	s0, s1, s30
-               	add	x2, x0, #0x4
-               	str	s0, [x2]
-               	add	x2, x20, #0x90
-               	ldr	x3, [x2]
+               	add	x1, x0, #0x4
+               	str	s0, [x1]
+               	add	x1, x20, #0x90
+               	ldr	x2, [x1]
                	mov	x16, #0xfff             // =4095
-               	and	x2, x3, x16
-               	ucvtf	s0, x2
+               	and	x1, x2, x16
+               	ucvtf	s0, x1
                	mov	w16, #0x45000000        // =1157627904
                	fmov	s30, w16
                	fsub	s1, s0, s30
                	fmov	s30, #8.00000000
                	fdiv	s0, s1, s30
-               	add	x2, x0, #0x8
-               	str	s0, [x2]
+               	add	x1, x0, #0x8
+               	str	s0, [x1]
                	stur	xzr, [x29, #-0xe8]
                	stur	xzr, [x29, #-0xe0]
-               	ldr	x2, [x0]
-               	stur	x2, [x29, #-0xe8]
-               	ldr	w2, [x0, #0x8]
-               	stur	w2, [x29, #-0xe0]
-               	ldur	q2, [x29, #-0xe8]
+               	ldr	x1, [x0]
+               	stur	x1, [x29, #-0xe8]
+               	ldr	w1, [x0, #0x8]
+               	stur	w1, [x29, #-0xe0]
+               	ldur	q31, [x29, #-0xe8]
+               	mov	x16, #0xfec0            // =65216
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	q31, [x29, x16]
                	sub	x0, x29, #0x100
-               	add	x2, x20, #0x98
-               	ldr	x3, [x2]
+               	add	x1, x20, #0x98
+               	ldr	x2, [x1]
                	mov	x16, #0xfff             // =4095
-               	and	x2, x3, x16
-               	ucvtf	s0, x2
+               	and	x1, x2, x16
+               	ucvtf	s0, x1
                	mov	w16, #0x45000000        // =1157627904
                	fmov	s30, w16
                	fsub	s1, s0, s30
                	fmov	s30, #8.00000000
                	fdiv	s0, s1, s30
-               	add	x2, x0, #0x0
-               	str	s0, [x2]
-               	add	x2, x20, #0xa0
-               	ldr	x3, [x2]
+               	add	x1, x0, #0x0
+               	str	s0, [x1]
+               	add	x1, x20, #0xa0
+               	ldr	x2, [x1]
                	mov	x16, #0xfff             // =4095
-               	and	x2, x3, x16
-               	ucvtf	s0, x2
+               	and	x1, x2, x16
+               	ucvtf	s0, x1
                	mov	w16, #0x45000000        // =1157627904
                	fmov	s30, w16
                	fsub	s1, s0, s30
                	fmov	s30, #8.00000000
                	fdiv	s0, s1, s30
-               	add	x2, x0, #0x4
-               	str	s0, [x2]
-               	add	x2, x20, #0xa8
-               	ldr	x3, [x2]
+               	add	x1, x0, #0x4
+               	str	s0, [x1]
+               	add	x1, x20, #0xa8
+               	ldr	x2, [x1]
                	mov	x16, #0xfff             // =4095
-               	and	x2, x3, x16
-               	ucvtf	s0, x2
+               	and	x1, x2, x16
+               	ucvtf	s0, x1
                	mov	w16, #0x45000000        // =1157627904
                	fmov	s30, w16
                	fsub	s1, s0, s30
                	fmov	s30, #8.00000000
                	fdiv	s0, s1, s30
-               	add	x2, x0, #0x8
-               	str	s0, [x2]
-               	add	x2, x20, #0xb0
-               	ldr	x3, [x2]
+               	add	x1, x0, #0x8
+               	str	s0, [x1]
+               	add	x1, x20, #0xb0
+               	ldr	x2, [x1]
                	mov	x16, #0xfff             // =4095
-               	and	x2, x3, x16
-               	ucvtf	s0, x2
+               	and	x1, x2, x16
+               	ucvtf	s0, x1
                	mov	w16, #0x45000000        // =1157627904
                	fmov	s30, w16
                	fsub	s1, s0, s30
                	fmov	s30, #8.00000000
                	fdiv	s0, s1, s30
-               	add	x2, x0, #0xc
-               	str	s0, [x2]
-               	ldr	q4, [x0]
-               	sub	x0, x29, #0x128
-               	add	x2, x20, #0xb8
-               	ldr	x3, [x2]
+               	add	x1, x0, #0xc
+               	str	s0, [x1]
+               	ldr	q31, [x0]
+               	mov	x16, #0xfeb0            // =65200
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	q31, [x29, x16]
+               	sub	x25, x29, #0x128
+               	add	x0, x20, #0xb8
+               	ldr	x1, [x0]
                	mov	x16, #0xfff             // =4095
-               	and	x2, x3, x16
-               	ucvtf	s0, x2
+               	and	x0, x1, x16
+               	ucvtf	s0, x0
                	mov	w16, #0x45000000        // =1157627904
                	fmov	s30, w16
                	fsub	s1, s0, s30
                	fmov	s30, #8.00000000
                	fdiv	s0, s1, s30
-               	add	x2, x0, #0x0
-               	str	s0, [x2]
-               	add	x2, x20, #0x0
-               	ldr	x3, [x2]
-               	add	x2, x3, x1
-               	mov	x16, #0xfff             // =4095
-               	and	x3, x2, x16
-               	ucvtf	s0, x3
-               	mov	w16, #0x45000000        // =1157627904
-               	fmov	s30, w16
-               	fsub	s1, s0, s30
-               	fmov	s30, #8.00000000
-               	fdiv	s0, s1, s30
-               	add	x2, x0, #0x4
-               	str	s0, [x2]
-               	ldr	d16, [x0]
-               	add	x0, x20, #0x0
-               	ldr	x2, [x0]
-               	add	x0, x2, x1
-               	add	x2, x20, #0x8
-               	ldr	x3, [x2]
-               	mov	x16, #0xfff             // =4095
-               	and	x2, x3, x16
-               	ucvtf	s0, x2
-               	mov	w16, #0x45000000        // =1157627904
-               	fmov	s30, w16
-               	fsub	s1, s0, s30
-               	fmov	s30, #8.00000000
-               	fdiv	s0, s1, s30
-               	add	x2, x20, #0x10
-               	ldr	x3, [x2]
-               	mov	w2, w3
-               	add	x3, x20, #0x18
-               	ldr	x4, [x3]
-               	mov	x16, #0xffff            // =65535
-               	movk	x16, #0xf, lsl #16
-               	and	x3, x4, x16
-               	ucvtf	d1, x3
-               	mov	x16, #0x4120000000000000 // =4692750811720056832
-               	fmov	d30, x16
-               	fsub	d3, d1, d30
-               	mov	x16, #0x4050000000000000 // =4634204016564240384
-               	fmov	d30, x16
-               	fdiv	d1, d3, d30
-               	add	x3, x20, #0x20
-               	ldr	x4, [x3]
-               	add	x3, x20, #0x28
-               	ldr	x5, [x3]
-               	mov	x16, #0xfff             // =4095
-               	and	x3, x5, x16
-               	ucvtf	s3, x3
-               	mov	w16, #0x45000000        // =1157627904
-               	fmov	s30, w16
-               	fsub	s5, s3, s30
-               	fmov	s30, #8.00000000
-               	fdiv	s3, s5, s30
-               	add	x3, x20, #0x30
-               	ldr	x5, [x3]
-               	mov	w3, w5
-               	add	x5, x20, #0x38
-               	ldr	x6, [x5]
-               	mov	x16, #0xffff            // =65535
-               	movk	x16, #0xf, lsl #16
-               	and	x5, x6, x16
-               	ucvtf	d5, x5
-               	mov	x16, #0x4120000000000000 // =4692750811720056832
-               	fmov	d30, x16
-               	fsub	d6, d5, d30
-               	mov	x16, #0x4050000000000000 // =4634204016564240384
-               	fmov	d30, x16
-               	fdiv	d5, d6, d30
-               	add	x5, x20, #0x40
-               	ldr	x6, [x5]
-               	add	x5, x20, #0x48
-               	ldr	x7, [x5]
-               	mov	x16, #0xfff             // =4095
-               	and	x5, x7, x16
-               	ucvtf	s6, x5
-               	mov	w16, #0x45000000        // =1157627904
-               	fmov	s30, w16
-               	fsub	s7, s6, s30
-               	fmov	s30, #8.00000000
-               	fdiv	s6, s7, s30
-               	add	x5, x20, #0x50
-               	ldr	x7, [x5]
-               	mov	w5, w7
-               	add	x7, x20, #0x58
-               	ldr	x8, [x7]
-               	mov	x16, #0xffff            // =65535
-               	movk	x16, #0xf, lsl #16
-               	and	x7, x8, x16
-               	ucvtf	d7, x7
-               	mov	x16, #0x4120000000000000 // =4692750811720056832
-               	fmov	d30, x16
-               	fsub	d17, d7, d30
-               	mov	x16, #0x4050000000000000 // =4634204016564240384
-               	fmov	d30, x16
-               	fdiv	d7, d17, d30
-               	add	x7, x20, #0x60
-               	ldr	x8, [x7]
-               	add	x7, x20, #0x68
-               	ldr	x12, [x7]
-               	mov	x16, #0xfff             // =4095
-               	and	x7, x12, x16
-               	ucvtf	s17, x7
-               	mov	w16, #0x45000000        // =1157627904
-               	fmov	s30, w16
-               	fsub	s18, s17, s30
-               	fmov	s30, #8.00000000
-               	fdiv	s17, s18, s30
-               	add	x7, x20, #0x70
-               	ldr	x12, [x7]
-               	mov	w7, w12
-               	add	x12, x20, #0x78
-               	ldr	x13, [x12]
-               	mov	x16, #0xffff            // =65535
-               	movk	x16, #0xf, lsl #16
-               	and	x12, x13, x16
-               	ucvtf	d18, x12
-               	mov	x16, #0x4120000000000000 // =4692750811720056832
-               	fmov	d30, x16
-               	fsub	d19, d18, d30
-               	mov	x16, #0x4050000000000000 // =4634204016564240384
-               	fmov	d30, x16
-               	fdiv	d18, d19, d30
-               	add	x12, x20, #0x8
-               	ldr	x13, [x12]
-               	add	x12, x13, x1
-               	mov	w1, w2
-               	mov	x2, x4
-               	mov	x4, x6
-               	str	d16, [sp]
-               	mov	x6, x8
-               	str	d17, [sp, #0x8]
-               	str	d18, [sp, #0x10]
-               	str	x12, [sp, #0x18]
+               	add	x0, x25, #0x0
+               	str	s0, [x0]
+               	add	x26, x20, #0x0
+               	ldr	x0, [x26]
+               	add	x1, x0, x24
+               	mov	x0, x1
 <L4>:
                	bl	 <L4>
+               	add	x0, x25, #0x4
+               	str	s0, [x0]
+               	ldr	d31, [x25]
+               	mov	x16, #0xfea0            // =65184
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	d31, [x29, x16]
+               	ldr	x0, [x26]
+               	add	x25, x0, x24
+               	add	x0, x20, #0x8
+               	ldr	x1, [x0]
+               	mov	x0, x1
+<L5>:
+               	bl	 <L5>
+               	fmov	s11, s0
+               	add	x0, x20, #0x10
+               	ldr	x1, [x0]
+               	mov	w26, w1
+               	add	x0, x20, #0x18
+               	ldr	x1, [x0]
+               	mov	x16, #0xffff            // =65535
+               	movk	x16, #0xf, lsl #16
+               	and	x0, x1, x16
+               	ucvtf	d0, x0
+               	mov	x16, #0x4120000000000000 // =4692750811720056832
+               	fmov	d30, x16
+               	fsub	d1, d0, d30
+               	mov	x16, #0x4050000000000000 // =4634204016564240384
+               	fmov	d30, x16
+               	fdiv	d12, d1, d30
+               	add	x0, x20, #0x20
+               	ldr	x27, [x0]
+               	add	x0, x20, #0x28
+               	ldr	x1, [x0]
+               	mov	x0, x1
+<L6>:
+               	bl	 <L6>
+               	fmov	s13, s0
+               	add	x0, x20, #0x30
+               	ldr	x1, [x0]
+               	mov	w28, w1
+               	add	x0, x20, #0x38
+               	ldr	x1, [x0]
+               	mov	x16, #0xffff            // =65535
+               	movk	x16, #0xf, lsl #16
+               	and	x0, x1, x16
+               	ucvtf	d0, x0
+               	mov	x16, #0x4120000000000000 // =4692750811720056832
+               	fmov	d30, x16
+               	fsub	d1, d0, d30
+               	mov	x16, #0x4050000000000000 // =4634204016564240384
+               	fmov	d30, x16
+               	fdiv	d14, d1, d30
+               	add	x0, x20, #0x40
+               	ldr	x9, [x0]
+               	mov	x16, #0xfe98            // =65176
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	add	x0, x20, #0x48
+               	ldr	x1, [x0]
+               	mov	x0, x1
+<L7>:
+               	bl	 <L7>
+               	fmov	s15, s0
+               	add	x0, x20, #0x50
+               	ldr	x1, [x0]
+               	mov	w9, w1
+               	mov	x16, #0xfe90            // =65168
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	add	x0, x20, #0x58
+               	ldr	x1, [x0]
+               	mov	x16, #0xffff            // =65535
+               	movk	x16, #0xf, lsl #16
+               	and	x0, x1, x16
+               	ucvtf	d0, x0
+               	mov	x16, #0x4120000000000000 // =4692750811720056832
+               	fmov	d30, x16
+               	fsub	d1, d0, d30
+               	mov	x16, #0x4050000000000000 // =4634204016564240384
+               	fmov	d30, x16
+               	fdiv	d31, d1, d30
+               	mov	x16, #0xfe78            // =65144
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	d31, [x29, x16]
+               	add	x0, x20, #0x60
+               	ldr	x9, [x0]
+               	mov	x16, #0xfe88            // =65160
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	add	x0, x20, #0x68
+               	ldr	x1, [x0]
+               	mov	x0, x1
+<L8>:
+               	bl	 <L8>
+               	fmov	s16, s0
+               	add	x0, x20, #0x70
+               	ldr	x1, [x0]
+               	mov	w7, w1
+               	add	x0, x20, #0x78
+               	ldr	x1, [x0]
+               	mov	x16, #0xffff            // =65535
+               	movk	x16, #0xf, lsl #16
+               	and	x0, x1, x16
+               	ucvtf	d0, x0
+               	mov	x16, #0x4120000000000000 // =4692750811720056832
+               	fmov	d30, x16
+               	fsub	d1, d0, d30
+               	mov	x16, #0x4050000000000000 // =4634204016564240384
+               	fmov	d30, x16
+               	fdiv	d17, d1, d30
+               	add	x0, x20, #0x8
+               	ldr	x1, [x0]
+               	add	x8, x1, x24
+               	mov	x0, x25
+               	fmov	s0, s11
+               	mov	w1, w26
+               	fmov	d1, d12
+               	mov	x16, #0xfec0            // =65216
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q2, [x29, x16]
+               	mov	x2, x27
+               	fmov	s3, s13
+               	mov	x3, x28
+               	mov	x16, #0xfeb0            // =65200
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q4, [x29, x16]
+               	fmov	d5, d14
+               	mov	x16, #0xfe98            // =65176
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	mov	x4, x9
+               	fmov	s6, s15
+               	mov	x16, #0xfe90            // =65168
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	mov	x5, x9
+               	mov	x16, #0xfe78            // =65144
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	d7, [x29, x16]
+               	mov	x16, #0xfea0            // =65184
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	d31, [x29, x16]
+               	str	d31, [sp]
+               	mov	x16, #0xfe88            // =65160
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	mov	x6, x9
+               	str	d16, [sp, #0x8]
+               	str	d17, [sp, #0x10]
+               	str	x8, [sp, #0x18]
+<L9>:
+               	bl	 <L9>
                	mov	x22, x0
                	mov	x0, x21
                	mov	x1, x22
-<L5>:
-               	bl	 <L5>
+<L10>:
+               	bl	 <L10>
                	add	x23, x23, #0x1
                	mov	x21, x0
                	cmp	x23, #0x3
                	b.lo	 <L3>
-<L6>:
+<L11>:
                	sub	x0, x29, #0xd8
                	mov	x16, #0xfff             // =4095
                	and	x1, x22, x16
@@ -691,7 +750,7 @@ Disassembly of section .text:
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov	x16, #0xfec0            // =65216
+               	mov	x16, #0xfe60            // =65120
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -746,322 +805,322 @@ Disassembly of section .text:
                	add	x1, x0, #0xc
                	str	s0, [x1]
                	ldr	q31, [x0]
-               	mov	x16, #0xfeb0            // =65200
+               	mov	x16, #0xfe50            // =65104
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	sub	x0, x29, #0x130
-               	add	x1, x20, #0x40
-               	ldr	x2, [x1]
-               	mov	x16, #0xfff             // =4095
-               	and	x1, x2, x16
-               	ucvtf	s0, x1
-               	mov	w16, #0x45000000        // =1157627904
-               	fmov	s30, w16
-               	fsub	s1, s0, s30
-               	fmov	s30, #8.00000000
-               	fdiv	s0, s1, s30
-               	add	x1, x0, #0x0
-               	str	s0, [x1]
-               	add	x1, x20, #0x48
-               	ldr	x2, [x1]
-               	mov	x16, #0xfff             // =4095
-               	and	x1, x2, x16
-               	ucvtf	s0, x1
-               	mov	w16, #0x45000000        // =1157627904
-               	fmov	s30, w16
-               	fsub	s1, s0, s30
-               	fmov	s30, #8.00000000
-               	fdiv	s0, s1, s30
-               	add	x1, x0, #0x4
-               	str	s0, [x1]
-               	ldr	d31, [x0]
-               	mov	x16, #0xfea0            // =65184
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	d31, [x29, x16]
-               	add	x0, x20, #0x0
+               	sub	x19, x29, #0x130
+               	add	x0, x20, #0x40
                	ldr	x1, [x0]
-               	add	x0, x20, #0x8
-               	ldr	x2, [x0]
                	mov	x16, #0xfff             // =4095
-               	and	x0, x2, x16
+               	and	x0, x1, x16
                	ucvtf	s0, x0
                	mov	w16, #0x45000000        // =1157627904
                	fmov	s30, w16
                	fsub	s1, s0, s30
                	fmov	s30, #8.00000000
                	fdiv	s0, s1, s30
-               	add	x0, x20, #0x10
-               	ldr	x2, [x0]
-               	mov	w3, w2
-               	add	x0, x20, #0x18
-               	ldr	x2, [x0]
-               	mov	x16, #0xffff            // =65535
-               	movk	x16, #0xf, lsl #16
-               	and	x0, x2, x16
-               	ucvtf	d1, x0
-               	mov	x16, #0x4120000000000000 // =4692750811720056832
-               	fmov	d30, x16
-               	fsub	d2, d1, d30
-               	mov	x16, #0x4050000000000000 // =4634204016564240384
-               	fmov	d30, x16
-               	fdiv	d1, d2, d30
-               	add	x0, x20, #0x20
-               	ldr	x2, [x0]
-               	add	x0, x20, #0x28
-               	ldr	x4, [x0]
-               	mov	x16, #0xfff             // =4095
-               	and	x0, x4, x16
-               	ucvtf	s2, x0
-               	mov	w16, #0x45000000        // =1157627904
-               	fmov	s30, w16
-               	fsub	s3, s2, s30
-               	fmov	s30, #8.00000000
-               	fdiv	s4, s3, s30
-               	add	x0, x20, #0x30
-               	ldr	x4, [x0]
-               	mov	w5, w4
-               	add	x0, x20, #0x38
-               	ldr	x4, [x0]
-               	mov	x16, #0xffff            // =65535
-               	movk	x16, #0xf, lsl #16
-               	and	x0, x4, x16
-               	ucvtf	d2, x0
-               	mov	x16, #0x4120000000000000 // =4692750811720056832
-               	fmov	d30, x16
-               	fsub	d3, d2, d30
-               	mov	x16, #0x4050000000000000 // =4634204016564240384
-               	fmov	d30, x16
-               	fdiv	d5, d3, d30
-               	add	x0, x20, #0x40
-               	ldr	x4, [x0]
+               	add	x0, x19, #0x0
+               	str	s0, [x0]
                	add	x0, x20, #0x48
-               	ldr	x6, [x0]
-               	mov	x16, #0xfff             // =4095
-               	and	x0, x6, x16
-               	ucvtf	s2, x0
-               	mov	w16, #0x45000000        // =1157627904
-               	fmov	s30, w16
-               	fsub	s3, s2, s30
-               	fmov	s30, #8.00000000
-               	fdiv	s6, s3, s30
+               	ldr	x1, [x0]
+               	mov	x0, x1
+<L12>:
+               	bl	 <L12>
+               	add	x0, x19, #0x4
+               	str	s0, [x0]
+               	ldr	d31, [x19]
+               	mov	x16, #0xfe40            // =65088
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	d31, [x29, x16]
+               	add	x0, x20, #0x0
+               	ldr	x19, [x0]
+               	add	x0, x20, #0x8
+               	ldr	x1, [x0]
+               	mov	x0, x1
+<L13>:
+               	bl	 <L13>
+               	fmov	s11, s0
+               	add	x0, x20, #0x10
+               	ldr	x1, [x0]
+               	mov	w23, w1
+               	add	x0, x20, #0x18
+               	ldr	x1, [x0]
+               	mov	x16, #0xffff            // =65535
+               	movk	x16, #0xf, lsl #16
+               	and	x0, x1, x16
+               	ucvtf	d0, x0
+               	mov	x16, #0x4120000000000000 // =4692750811720056832
+               	fmov	d30, x16
+               	fsub	d1, d0, d30
+               	mov	x16, #0x4050000000000000 // =4634204016564240384
+               	fmov	d30, x16
+               	fdiv	d12, d1, d30
+               	add	x0, x20, #0x20
+               	ldr	x24, [x0]
+               	add	x0, x20, #0x28
+               	ldr	x1, [x0]
+               	mov	x0, x1
+<L14>:
+               	bl	 <L14>
+               	fmov	s13, s0
+               	add	x0, x20, #0x30
+               	ldr	x1, [x0]
+               	mov	w25, w1
+               	add	x0, x20, #0x38
+               	ldr	x1, [x0]
+               	mov	x16, #0xffff            // =65535
+               	movk	x16, #0xf, lsl #16
+               	and	x0, x1, x16
+               	ucvtf	d0, x0
+               	mov	x16, #0x4120000000000000 // =4692750811720056832
+               	fmov	d30, x16
+               	fsub	d1, d0, d30
+               	mov	x16, #0x4050000000000000 // =4634204016564240384
+               	fmov	d30, x16
+               	fdiv	d14, d1, d30
+               	add	x0, x20, #0x40
+               	ldr	x26, [x0]
+               	add	x0, x20, #0x48
+               	ldr	x1, [x0]
+               	mov	x0, x1
+<L15>:
+               	bl	 <L15>
+               	fmov	s15, s0
                	add	x0, x20, #0x50
-               	ldr	x6, [x0]
-               	mov	w7, w6
+               	ldr	x1, [x0]
+               	mov	w27, w1
                	add	x0, x20, #0x58
-               	ldr	x6, [x0]
+               	ldr	x1, [x0]
                	mov	x16, #0xffff            // =65535
                	movk	x16, #0xf, lsl #16
-               	and	x0, x6, x16
-               	ucvtf	d2, x0
+               	and	x0, x1, x16
+               	ucvtf	d0, x0
                	mov	x16, #0x4120000000000000 // =4692750811720056832
                	fmov	d30, x16
-               	fsub	d3, d2, d30
+               	fsub	d1, d0, d30
                	mov	x16, #0x4050000000000000 // =4634204016564240384
                	fmov	d30, x16
-               	fdiv	d7, d3, d30
+               	fdiv	d31, d1, d30
+               	mov	x16, #0xfe30            // =65072
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	d31, [x29, x16]
                	add	x0, x20, #0x60
-               	ldr	x6, [x0]
+               	ldr	x28, [x0]
                	add	x0, x20, #0x68
-               	ldr	x8, [x0]
-               	mov	x16, #0xfff             // =4095
-               	and	x0, x8, x16
-               	ucvtf	s2, x0
-               	mov	w16, #0x45000000        // =1157627904
-               	fmov	s30, w16
-               	fsub	s3, s2, s30
-               	fmov	s30, #8.00000000
-               	fdiv	s16, s3, s30
+               	ldr	x1, [x0]
+               	mov	x0, x1
+<L16>:
+               	bl	 <L16>
+               	fmov	s16, s0
                	add	x0, x20, #0x70
-               	ldr	x8, [x0]
-               	mov	w12, w8
+               	ldr	x1, [x0]
+               	mov	w7, w1
                	add	x0, x20, #0x78
-               	ldr	x8, [x0]
+               	ldr	x1, [x0]
                	mov	x16, #0xffff            // =65535
                	movk	x16, #0xf, lsl #16
-               	and	x0, x8, x16
-               	ucvtf	d2, x0
+               	and	x0, x1, x16
+               	ucvtf	d0, x0
                	mov	x16, #0x4120000000000000 // =4692750811720056832
                	fmov	d30, x16
-               	fsub	d3, d2, d30
+               	fsub	d1, d0, d30
                	mov	x16, #0x4050000000000000 // =4634204016564240384
                	fmov	d30, x16
-               	fdiv	d17, d3, d30
+               	fdiv	d17, d1, d30
                	add	x0, x20, #0x8
                	ldr	x8, [x0]
-               	mov	x0, x1
-               	mov	w1, w3
-               	mov	x16, #0xfec0            // =65216
+               	mov	x0, x19
+               	fmov	s0, s11
+               	mov	w1, w23
+               	fmov	d1, d12
+               	mov	x16, #0xfe60            // =65120
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q2, [x29, x16]
-               	fmov	s3, s4
-               	mov	x3, x5
-               	mov	x16, #0xfeb0            // =65200
+               	mov	x2, x24
+               	fmov	s3, s13
+               	mov	x3, x25
+               	mov	x16, #0xfe50            // =65104
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q4, [x29, x16]
-               	mov	x5, x7
-               	mov	x16, #0xfea0            // =65184
+               	fmov	d5, d14
+               	mov	x4, x26
+               	fmov	s6, s15
+               	mov	x5, x27
+               	mov	x16, #0xfe30            // =65072
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	d7, [x29, x16]
+               	mov	x16, #0xfe40            // =65088
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	d31, [x29, x16]
                	str	d31, [sp]
+               	mov	x6, x28
                	str	d16, [sp, #0x8]
-               	mov	w7, w12
                	str	d17, [sp, #0x10]
                	str	x8, [sp, #0x18]
-<L7>:
-               	bl	 <L7>
-               	add	x1, x20, #0x18
-               	ldr	x2, [x1]
-               	mov	x16, #0xfff             // =4095
-               	and	x1, x2, x16
-               	ucvtf	s0, x1
-               	mov	w16, #0x45000000        // =1157627904
-               	fmov	s30, w16
-               	fsub	s1, s0, s30
-               	fmov	s30, #8.00000000
-               	fdiv	s0, s1, s30
-               	add	x1, x20, #0x28
-               	ldr	x2, [x1]
-               	mov	w1, w2
-               	add	x2, x20, #0x38
-               	ldr	x3, [x2]
+<L17>:
+               	bl	 <L17>
+               	mov	x19, x0
+               	add	x0, x20, #0x18
+               	ldr	x1, [x0]
+               	mov	x0, x1
+<L18>:
+               	bl	 <L18>
+               	fmov	s11, s0
+               	add	x0, x20, #0x28
+               	ldr	x1, [x0]
+               	mov	w23, w1
+               	add	x0, x20, #0x38
+               	ldr	x1, [x0]
                	mov	x16, #0xffff            // =65535
                	movk	x16, #0xf, lsl #16
-               	and	x2, x3, x16
-               	ucvtf	d1, x2
+               	and	x0, x1, x16
+               	ucvtf	d0, x0
                	mov	x16, #0x4120000000000000 // =4692750811720056832
                	fmov	d30, x16
-               	fsub	d2, d1, d30
+               	fsub	d1, d0, d30
                	mov	x16, #0x4050000000000000 // =4634204016564240384
                	fmov	d30, x16
-               	fdiv	d1, d2, d30
-               	add	x2, x20, #0x48
-               	ldr	x3, [x2]
-               	add	x2, x20, #0x58
-               	ldr	x4, [x2]
-               	mov	x16, #0xfff             // =4095
-               	and	x2, x4, x16
-               	ucvtf	s2, x2
-               	mov	w16, #0x45000000        // =1157627904
-               	fmov	s30, w16
-               	fsub	s3, s2, s30
-               	fmov	s30, #8.00000000
-               	fdiv	s4, s3, s30
-               	add	x2, x20, #0x68
-               	ldr	x4, [x2]
-               	mov	w5, w4
-               	add	x2, x20, #0x78
-               	ldr	x4, [x2]
+               	fdiv	d12, d1, d30
+               	add	x0, x20, #0x48
+               	ldr	x24, [x0]
+               	add	x0, x20, #0x58
+               	ldr	x1, [x0]
+               	mov	x0, x1
+<L19>:
+               	bl	 <L19>
+               	fmov	s13, s0
+               	add	x0, x20, #0x68
+               	ldr	x1, [x0]
+               	mov	w25, w1
+               	add	x0, x20, #0x78
+               	ldr	x1, [x0]
                	mov	x16, #0xffff            // =65535
                	movk	x16, #0xf, lsl #16
-               	and	x2, x4, x16
-               	ucvtf	d2, x2
+               	and	x0, x1, x16
+               	ucvtf	d0, x0
                	mov	x16, #0x4120000000000000 // =4692750811720056832
                	fmov	d30, x16
-               	fsub	d3, d2, d30
+               	fsub	d1, d0, d30
                	mov	x16, #0x4050000000000000 // =4634204016564240384
                	fmov	d30, x16
-               	fdiv	d5, d3, d30
-               	add	x2, x20, #0x88
-               	ldr	x4, [x2]
-               	add	x2, x20, #0x98
-               	ldr	x6, [x2]
-               	mov	x16, #0xfff             // =4095
-               	and	x2, x6, x16
-               	ucvtf	s2, x2
-               	mov	w16, #0x45000000        // =1157627904
-               	fmov	s30, w16
-               	fsub	s3, s2, s30
-               	fmov	s30, #8.00000000
-               	fdiv	s6, s3, s30
-               	add	x2, x20, #0xa8
-               	ldr	x6, [x2]
-               	mov	w7, w6
-               	add	x2, x20, #0xb8
-               	ldr	x6, [x2]
+               	fdiv	d14, d1, d30
+               	add	x0, x20, #0x88
+               	ldr	x26, [x0]
+               	add	x0, x20, #0x98
+               	ldr	x1, [x0]
+               	mov	x0, x1
+<L20>:
+               	bl	 <L20>
+               	fmov	s15, s0
+               	add	x0, x20, #0xa8
+               	ldr	x1, [x0]
+               	mov	w27, w1
+               	add	x0, x20, #0xb8
+               	ldr	x1, [x0]
                	mov	x16, #0xffff            // =65535
                	movk	x16, #0xf, lsl #16
-               	and	x2, x6, x16
-               	ucvtf	d2, x2
+               	and	x0, x1, x16
+               	ucvtf	d0, x0
                	mov	x16, #0x4120000000000000 // =4692750811720056832
                	fmov	d30, x16
-               	fsub	d3, d2, d30
+               	fsub	d1, d0, d30
                	mov	x16, #0x4050000000000000 // =4634204016564240384
                	fmov	d30, x16
-               	fdiv	d7, d3, d30
-               	add	x2, x20, #0x10
-               	ldr	x6, [x2]
-               	add	x2, x20, #0x20
-               	ldr	x8, [x2]
-               	mov	x16, #0xfff             // =4095
-               	and	x2, x8, x16
-               	ucvtf	s2, x2
-               	mov	w16, #0x45000000        // =1157627904
-               	fmov	s30, w16
-               	fsub	s3, s2, s30
-               	fmov	s30, #8.00000000
-               	fdiv	s16, s3, s30
-               	add	x2, x20, #0x30
-               	ldr	x8, [x2]
-               	mov	w12, w8
-               	add	x2, x20, #0x40
-               	ldr	x8, [x2]
+               	fdiv	d31, d1, d30
+               	mov	x16, #0xfe20            // =65056
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	d31, [x29, x16]
+               	add	x0, x20, #0x10
+               	ldr	x28, [x0]
+               	add	x0, x20, #0x20
+               	ldr	x1, [x0]
+               	mov	x0, x1
+<L21>:
+               	bl	 <L21>
+               	fmov	s16, s0
+               	add	x0, x20, #0x30
+               	ldr	x1, [x0]
+               	mov	w7, w1
+               	add	x0, x20, #0x40
+               	ldr	x1, [x0]
                	mov	x16, #0xffff            // =65535
                	movk	x16, #0xf, lsl #16
-               	and	x2, x8, x16
-               	ucvtf	d2, x2
+               	and	x0, x1, x16
+               	ucvtf	d0, x0
                	mov	x16, #0x4120000000000000 // =4692750811720056832
                	fmov	d30, x16
-               	fsub	d3, d2, d30
+               	fsub	d1, d0, d30
                	mov	x16, #0x4050000000000000 // =4634204016564240384
                	fmov	d30, x16
-               	fdiv	d17, d3, d30
-               	mov	x16, #0xfec0            // =65216
+               	fdiv	d17, d1, d30
+               	mov	x0, x19
+               	fmov	s0, s11
+               	mov	w1, w23
+               	fmov	d1, d12
+               	mov	x16, #0xfe60            // =65120
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q2, [x29, x16]
-               	mov	x2, x3
-               	fmov	s3, s4
-               	mov	x3, x5
-               	mov	x16, #0xfeb0            // =65200
+               	mov	x2, x24
+               	fmov	s3, s13
+               	mov	x3, x25
+               	mov	x16, #0xfe50            // =65104
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q4, [x29, x16]
-               	mov	x5, x7
-               	mov	x16, #0xfea0            // =65184
+               	fmov	d5, d14
+               	mov	x4, x26
+               	fmov	s6, s15
+               	mov	x5, x27
+               	mov	x16, #0xfe20            // =65056
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	d7, [x29, x16]
+               	mov	x16, #0xfe40            // =65088
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	d31, [x29, x16]
                	str	d31, [sp]
+               	mov	x6, x28
                	str	d16, [sp, #0x8]
-               	mov	w7, w12
                	str	d17, [sp, #0x10]
                	str	x22, [sp, #0x18]
-<L8>:
-               	bl	 <L8>
+<L22>:
+               	bl	 <L22>
                	mov	x1, x0
                	mov	x0, x21
-<L9>:
-               	bl	 <L9>
-               	ldp	x19, x20, [x29, #-0x170]
-               	ldp	x21, x22, [x29, #-0x180]
-               	mov	x16, #0xfe78            // =65144
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x23, [x29, x16]
+<L23>:
+               	bl	 <L23>
+               	sub	x16, x29, #0x240
+               	ldp	d11, d12, [x16]
+               	ldp	d13, d14, [x16, #-0x10]
+               	ldur	d15, [x16, #-0x18]
+               	sub	x16, x29, #0x1f0
+               	ldp	x19, x20, [x16]
+               	ldp	x21, x22, [x16, #-0x10]
+               	ldp	x23, x24, [x16, #-0x20]
+               	ldp	x25, x26, [x16, #-0x30]
+               	ldp	x27, x28, [x16, #-0x40]
                	mov	sp, x29
                	ldp	x29, x30, [sp], #0x10
                	ret

--- a/test/golden/aarch64-linux/call/call_rec_edge.dis
+++ b/test/golden/aarch64-linux/call/call_rec_edge.dis
@@ -950,16 +950,13 @@ Disassembly of section .text:
 <corpus.cases.call.call_rec_edge.checksum>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0x240
-               	stp	x19, x20, [x29, #-0x1a0]
-               	stp	x21, x22, [x29, #-0x1b0]
-               	stp	x23, x24, [x29, #-0x1c0]
-               	stp	x25, x26, [x29, #-0x1d0]
-               	mov	x16, #0xfe28            // =65064
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x27, [x29, x16]
+               	sub	sp, sp, #0x2a0
+               	sub	x16, x29, #0x200
+               	stp	x19, x20, [x16]
+               	stp	x21, x22, [x16, #-0x10]
+               	stp	x23, x24, [x16, #-0x20]
+               	stp	x25, x26, [x16, #-0x30]
+               	stur	x27, [x16, #-0x38]
                	mov	x19, x0
 <L0>:
                	bl	 <L0>
@@ -1287,7 +1284,26 @@ Disassembly of section .text:
                	ldr	x8, [x12, #0x8]
                	str	x8, [sp, #0x8]
                	str	x13, [sp, #0x10]
-               	str	x14, [sp, #0x18]
+               	ldr	x8, [x14]
+               	mov	x16, #0xfe77            // =65143
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x8, [x29, x16]
+               	ldr	x8, [x14, #0x8]
+               	mov	x16, #0xfe7f            // =65151
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x8, [x29, x16]
+               	ldrb	w8, [x14, #0x10]
+               	mov	x16, #0xfe87            // =65159
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	strb	w8, [x29, x16]
+               	sub	x8, x29, #0x189
+               	str	x8, [sp, #0x18]
                	ldr	x8, [x15]
                	str	x8, [sp, #0x20]
                	ldrb	w8, [x15, #0x8]
@@ -1300,7 +1316,26 @@ Disassembly of section .text:
                	str	x8, [sp, #0x40]
                	ldr	x8, [x24, #0x8]
                	str	x8, [sp, #0x48]
-               	str	x25, [sp, #0x50]
+               	ldr	x8, [x25]
+               	mov	x16, #0xfe5f            // =65119
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x8, [x29, x16]
+               	ldr	x8, [x25, #0x8]
+               	mov	x16, #0xfe67            // =65127
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x8, [x29, x16]
+               	ldrb	w8, [x25, #0x10]
+               	mov	x16, #0xfe6f            // =65135
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	strb	w8, [x29, x16]
+               	sub	x8, x29, #0x1a1
+               	str	x8, [sp, #0x50]
                	str	x26, [sp, #0x58]
 <L30>:
                	bl	 <L30>
@@ -1473,7 +1508,7 @@ Disassembly of section .text:
                	str	x1, [x0]
                	add	x0, x20, #0x8
                	ldr	x1, [x0]
-               	sub	x23, x29, #0x182
+               	sub	x23, x29, #0x1b2
                	str	xzr, [x23]
                	str	xzr, [x23, #0x8]
                	strb	wzr, [x23, #0x10]
@@ -1520,7 +1555,26 @@ Disassembly of section .text:
                	ldr	x8, [x12, #0x8]
                	str	x8, [sp, #0x8]
                	str	x13, [sp, #0x10]
-               	str	x14, [sp, #0x18]
+               	ldr	x8, [x14]
+               	mov	x16, #0xfe36            // =65078
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x8, [x29, x16]
+               	ldr	x8, [x14, #0x8]
+               	mov	x16, #0xfe3e            // =65086
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x8, [x29, x16]
+               	ldrb	w8, [x14, #0x10]
+               	mov	x16, #0xfe46            // =65094
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	strb	w8, [x29, x16]
+               	sub	x8, x29, #0x1ca
+               	str	x8, [sp, #0x18]
                	ldr	x8, [x15]
                	str	x8, [sp, #0x20]
                	ldrb	w8, [x15, #0x8]
@@ -1533,7 +1587,26 @@ Disassembly of section .text:
                	str	x8, [sp, #0x40]
                	ldr	x8, [x19, #0x8]
                	str	x8, [sp, #0x48]
-               	str	x23, [sp, #0x50]
+               	ldr	x8, [x23]
+               	mov	x16, #0xfe1e            // =65054
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x8, [x29, x16]
+               	ldr	x8, [x23, #0x8]
+               	mov	x16, #0xfe26            // =65062
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x8, [x29, x16]
+               	ldrb	w8, [x23, #0x10]
+               	mov	x16, #0xfe2e            // =65070
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	strb	w8, [x29, x16]
+               	sub	x8, x29, #0x1e2
+               	str	x8, [sp, #0x50]
                	str	x20, [sp, #0x58]
 <L41>:
                	bl	 <L41>
@@ -1541,15 +1614,12 @@ Disassembly of section .text:
                	mov	x0, x21
 <L42>:
                	bl	 <L42>
-               	ldp	x19, x20, [x29, #-0x1a0]
-               	ldp	x21, x22, [x29, #-0x1b0]
-               	ldp	x23, x24, [x29, #-0x1c0]
-               	ldp	x25, x26, [x29, #-0x1d0]
-               	mov	x16, #0xfe28            // =65064
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x27, [x29, x16]
+               	sub	x16, x29, #0x200
+               	ldp	x19, x20, [x16]
+               	ldp	x21, x22, [x16, #-0x10]
+               	ldp	x23, x24, [x16, #-0x20]
+               	ldp	x25, x26, [x16, #-0x30]
+               	ldur	x27, [x16, #-0x38]
                	mov	sp, x29
                	ldp	x29, x30, [sp], #0x10
                	ret

--- a/test/golden/aarch64-linux/call/call_rec_large.dis
+++ b/test/golden/aarch64-linux/call/call_rec_large.dis
@@ -1081,14 +1081,14 @@ Disassembly of section .text:
 <corpus.cases.call.call_rec_large.checksum>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0x3f0
-               	sub	x16, x29, #0x380
+               	sub	sp, sp, #0x660
+               	sub	x16, x29, #0x5f0
                	stp	x19, x20, [x16]
                	stp	x21, x22, [x16, #-0x10]
                	stp	x23, x24, [x16, #-0x20]
                	stp	x25, x26, [x16, #-0x30]
                	stp	x27, x28, [x16, #-0x40]
-               	sub	x16, x29, #0x3d0
+               	sub	x16, x29, #0x640
                	str	d8, [x16, #0x8]
                	mov	x19, x0
 <L0>:
@@ -1260,12 +1260,12 @@ Disassembly of section .text:
                	ldr	x2, [x0]
                	add	x0, x2, x1
                	sub	x9, x29, #0x110
-               	mov	x16, #0xfcb0            // =64688
+               	mov	x16, #0xfa40            // =64064
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
-               	mov	x16, #0xfcb0            // =64688
+               	mov	x16, #0xfa40            // =64064
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1273,7 +1273,7 @@ Disassembly of section .text:
                	add	x1, x9, #0x0
                	str	x0, [x1]
                	mvn	x1, x0
-               	mov	x16, #0xfcb0            // =64688
+               	mov	x16, #0xfa40            // =64064
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1282,7 +1282,7 @@ Disassembly of section .text:
                	str	x1, [x2]
                	mov	x16, #0x5               // =5
                	mul	x1, x0, x16
-               	mov	x16, #0xfcb0            // =64688
+               	mov	x16, #0xfa40            // =64064
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1290,7 +1290,7 @@ Disassembly of section .text:
                	add	x2, x9, #0x10
                	str	x1, [x2]
                	lsr	x1, x0, #3
-               	mov	x16, #0xfcb0            // =64688
+               	mov	x16, #0xfa40            // =64064
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1300,7 +1300,7 @@ Disassembly of section .text:
                	add	x0, x20, #0x30
                	ldr	x1, [x0]
                	sub	x9, x29, #0x150
-               	mov	x16, #0xfca8            // =64680
+               	mov	x16, #0xfa38            // =64056
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1311,7 +1311,7 @@ Disassembly of section .text:
                	add	x2, x1, #0xb
                	add	x3, x0, #0x8
                	str	x2, [x3]
-               	mov	x16, #0xfca8            // =64680
+               	mov	x16, #0xfa38            // =64056
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1329,7 +1329,7 @@ Disassembly of section .text:
                	mvn	x2, x1
                	add	x1, x0, #0x8
                	str	x2, [x1]
-               	mov	x16, #0xfca8            // =64680
+               	mov	x16, #0xfa38            // =64056
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1347,12 +1347,12 @@ Disassembly of section .text:
                	add	x0, x20, #0x40
                	ldr	x1, [x0]
                	sub	x9, x29, #0x1e0
-               	mov	x16, #0xfca0            // =64672
+               	mov	x16, #0xfa30            // =64048
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
-               	mov	x16, #0xfca0            // =64672
+               	mov	x16, #0xfa30            // =64048
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1360,7 +1360,7 @@ Disassembly of section .text:
                	add	x0, x9, #0x0
                	str	x1, [x0]
                	add	x0, x1, #0x1
-               	mov	x16, #0xfca0            // =64672
+               	mov	x16, #0xfa30            // =64048
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1368,7 +1368,7 @@ Disassembly of section .text:
                	add	x2, x9, #0x8
                	str	x0, [x2]
                	add	x0, x1, #0x2
-               	mov	x16, #0xfca0            // =64672
+               	mov	x16, #0xfa30            // =64048
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1377,7 +1377,7 @@ Disassembly of section .text:
                	str	x0, [x2]
                	mov	x16, #0x9               // =9
                	mul	x0, x1, x16
-               	mov	x16, #0xfca0            // =64672
+               	mov	x16, #0xfa30            // =64048
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1385,7 +1385,7 @@ Disassembly of section .text:
                	add	x2, x9, #0x18
                	str	x0, [x2]
                	mvn	x0, x1
-               	mov	x16, #0xfca0            // =64672
+               	mov	x16, #0xfa30            // =64048
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1395,7 +1395,7 @@ Disassembly of section .text:
                	mov	x16, #0xaaaa            // =43690
                	movk	x16, #0xaaaa, lsl #16
                	eor	x0, x1, x16
-               	mov	x16, #0xfca0            // =64672
+               	mov	x16, #0xfa30            // =64048
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1405,12 +1405,12 @@ Disassembly of section .text:
                	add	x0, x20, #0x48
                	ldr	x1, [x0]
                	sub	x9, x29, #0x210
-               	mov	x16, #0xfcb8            // =64696
+               	mov	x16, #0xfa48            // =64072
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
-               	mov	x16, #0xfcb8            // =64696
+               	mov	x16, #0xfa48            // =64072
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1419,7 +1419,7 @@ Disassembly of section .text:
                	mov	x0, x1
 <L21>:
                	bl	 <L21>
-               	mov	x16, #0xfcb8            // =64696
+               	mov	x16, #0xfa48            // =64072
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1485,40 +1485,357 @@ Disassembly of section .text:
                	add	x0, x20, #0x10
                	ldr	x14, [x0]
                	mov	x0, x24
-               	mov	x1, x25
+               	ldr	x1, [x25]
+               	mov	x16, #0xfcd8            // =64728
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x1, [x29, x16]
+               	ldr	x1, [x25, #0x8]
+               	mov	x16, #0xfce0            // =64736
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x1, [x29, x16]
+               	ldr	x1, [x25, #0x10]
+               	mov	x16, #0xfce8            // =64744
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x1, [x29, x16]
+               	sub	x1, x29, #0x328
                	ldr	d0, [x26]
                	ldr	d1, [x26, #0x8]
                	ldr	d2, [x26, #0x10]
-               	mov	x2, x27
+               	ldr	x2, [x27]
+               	mov	x16, #0xfcc0            // =64704
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x2, [x29, x16]
+               	ldr	x2, [x27, #0x8]
+               	mov	x16, #0xfcc8            // =64712
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x2, [x29, x16]
+               	ldr	x2, [x27, #0x10]
+               	mov	x16, #0xfcd0            // =64720
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x2, [x29, x16]
+               	sub	x2, x29, #0x340
                	mov	w3, w28
-               	mov	x16, #0xfcb0            // =64688
+               	mov	x16, #0xfa40            // =64064
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
-               	mov	x4, x9
-               	mov	x16, #0xfca8            // =64680
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	mov	x5, x9
-               	fmov	d3, d8
+               	ldr	x15, [x9]
                	mov	x16, #0xfca0            // =64672
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	mov	x6, x9
-               	mov	x16, #0xfcb8            // =64696
+               	str	x15, [x29, x16]
+               	mov	x16, #0xfa40            // =64064
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
-               	mov	x7, x9
+               	ldr	x15, [x9, #0x8]
+               	mov	x16, #0xfca8            // =64680
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x15, [x29, x16]
+               	mov	x16, #0xfa40            // =64064
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	ldr	x15, [x9, #0x10]
+               	mov	x16, #0xfcb0            // =64688
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x15, [x29, x16]
+               	mov	x16, #0xfa40            // =64064
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	ldr	x15, [x9, #0x18]
+               	mov	x16, #0xfcb8            // =64696
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x15, [x29, x16]
+               	sub	x4, x29, #0x360
+               	mov	x16, #0xfa38            // =64056
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	ldr	x15, [x9]
+               	mov	x16, #0xfc80            // =64640
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x15, [x29, x16]
+               	mov	x16, #0xfa38            // =64056
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	ldr	x15, [x9, #0x8]
+               	mov	x16, #0xfc88            // =64648
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x15, [x29, x16]
+               	mov	x16, #0xfa38            // =64056
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	ldr	x15, [x9, #0x10]
+               	mov	x16, #0xfc90            // =64656
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x15, [x29, x16]
+               	mov	x16, #0xfa38            // =64056
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	ldr	x15, [x9, #0x18]
+               	mov	x16, #0xfc98            // =64664
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x15, [x29, x16]
+               	sub	x5, x29, #0x380
+               	fmov	d3, d8
+               	mov	x16, #0xfa30            // =64048
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	ldr	x15, [x9]
+               	mov	x16, #0xfc50            // =64592
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x15, [x29, x16]
+               	mov	x16, #0xfa30            // =64048
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	ldr	x15, [x9, #0x8]
+               	mov	x16, #0xfc58            // =64600
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x15, [x29, x16]
+               	mov	x16, #0xfa30            // =64048
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	ldr	x15, [x9, #0x10]
+               	mov	x16, #0xfc60            // =64608
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x15, [x29, x16]
+               	mov	x16, #0xfa30            // =64048
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	ldr	x15, [x9, #0x18]
+               	mov	x16, #0xfc68            // =64616
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x15, [x29, x16]
+               	mov	x16, #0xfa30            // =64048
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	ldr	x15, [x9, #0x20]
+               	mov	x16, #0xfc70            // =64624
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x15, [x29, x16]
+               	mov	x16, #0xfa30            // =64048
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	ldr	x15, [x9, #0x28]
+               	mov	x16, #0xfc78            // =64632
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x15, [x29, x16]
+               	sub	x6, x29, #0x3b0
+               	mov	x16, #0xfa48            // =64072
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	ldr	x15, [x9]
+               	mov	x16, #0xfc20            // =64544
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x15, [x29, x16]
+               	mov	x16, #0xfa48            // =64072
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	ldr	x15, [x9, #0x8]
+               	mov	x16, #0xfc28            // =64552
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x15, [x29, x16]
+               	mov	x16, #0xfa48            // =64072
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	ldr	x15, [x9, #0x10]
+               	mov	x16, #0xfc30            // =64560
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x15, [x29, x16]
+               	mov	x16, #0xfa48            // =64072
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	ldr	x15, [x9, #0x18]
+               	mov	x16, #0xfc38            // =64568
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x15, [x29, x16]
+               	mov	x16, #0xfa48            // =64072
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	ldr	x15, [x9, #0x20]
+               	mov	x16, #0xfc40            // =64576
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x15, [x29, x16]
+               	mov	x16, #0xfa48            // =64072
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	ldr	x15, [x9, #0x28]
+               	mov	x16, #0xfc48            // =64584
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x15, [x29, x16]
+               	sub	x7, x29, #0x3e0
+               	ldr	x15, [x8]
+               	mov	x16, #0xfc08            // =64520
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x15, [x29, x16]
+               	ldr	x15, [x8, #0x8]
+               	mov	x16, #0xfc10            // =64528
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x15, [x29, x16]
+               	ldr	x15, [x8, #0x10]
+               	mov	x16, #0xfc18            // =64536
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x15, [x29, x16]
+               	sub	x8, x29, #0x3f8
                	str	x8, [sp]
-               	str	x12, [sp, #0x8]
-               	str	x13, [sp, #0x10]
+               	ldr	x8, [x12]
+               	mov	x16, #0xfbe8            // =64488
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x8, [x29, x16]
+               	ldr	x8, [x12, #0x8]
+               	mov	x16, #0xfbf0            // =64496
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x8, [x29, x16]
+               	ldr	x8, [x12, #0x10]
+               	mov	x16, #0xfbf8            // =64504
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x8, [x29, x16]
+               	ldr	x8, [x12, #0x18]
+               	mov	x16, #0xfc00            // =64512
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x8, [x29, x16]
+               	sub	x8, x29, #0x418
+               	str	x8, [sp, #0x8]
+               	ldr	x8, [x13]
+               	mov	x16, #0xfbb8            // =64440
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x8, [x29, x16]
+               	ldr	x8, [x13, #0x8]
+               	mov	x16, #0xfbc0            // =64448
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x8, [x29, x16]
+               	ldr	x8, [x13, #0x10]
+               	mov	x16, #0xfbc8            // =64456
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x8, [x29, x16]
+               	ldr	x8, [x13, #0x18]
+               	mov	x16, #0xfbd0            // =64464
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x8, [x29, x16]
+               	ldr	x8, [x13, #0x20]
+               	mov	x16, #0xfbd8            // =64472
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x8, [x29, x16]
+               	ldr	x8, [x13, #0x28]
+               	mov	x16, #0xfbe0            // =64480
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x8, [x29, x16]
+               	sub	x8, x29, #0x448
+               	str	x8, [sp, #0x10]
                	str	x14, [sp, #0x18]
 <L22>:
                	bl	 <L22>
@@ -1651,12 +1968,12 @@ Disassembly of section .text:
                	add	x1, x28, #0x28
                	str	x0, [x1]
                	sub	x9, x29, #0x270
-               	mov	x16, #0xfc98            // =64664
+               	mov	x16, #0xfa28            // =64040
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
-               	mov	x16, #0xfc98            // =64664
+               	mov	x16, #0xfa28            // =64040
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1665,7 +1982,7 @@ Disassembly of section .text:
                	mov	x0, x22
 <L25>:
                	bl	 <L25>
-               	mov	x16, #0xfc98            // =64664
+               	mov	x16, #0xfa28            // =64040
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1702,7 +2019,7 @@ Disassembly of section .text:
                	str	x0, [x1]
                	add	x0, x20, #0x0
                	ldr	x1, [x0]
-               	sub	x13, x29, #0x340
+               	sub	x13, x29, #0x478
                	add	x0, x13, #0x0
                	str	x1, [x0]
                	add	x0, x1, #0x1
@@ -1731,25 +2048,287 @@ Disassembly of section .text:
                	add	x0, x20, #0x18
                	ldr	x14, [x0]
                	mov	x0, x22
-               	mov	x1, x19
+               	ldr	x1, [x19]
+               	mov	x16, #0xfb70            // =64368
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x1, [x29, x16]
+               	ldr	x1, [x19, #0x8]
+               	mov	x16, #0xfb78            // =64376
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x1, [x29, x16]
+               	ldr	x1, [x19, #0x10]
+               	mov	x16, #0xfb80            // =64384
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x1, [x29, x16]
+               	sub	x1, x29, #0x490
                	ldr	d0, [x23]
                	ldr	d1, [x23, #0x8]
                	ldr	d2, [x23, #0x10]
-               	mov	x2, x24
+               	ldr	x2, [x24]
+               	mov	x16, #0xfb58            // =64344
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x2, [x29, x16]
+               	ldr	x2, [x24, #0x8]
+               	mov	x16, #0xfb60            // =64352
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x2, [x29, x16]
+               	ldr	x2, [x24, #0x10]
+               	mov	x16, #0xfb68            // =64360
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x2, [x29, x16]
+               	sub	x2, x29, #0x4a8
                	mov	w3, w25
-               	mov	x4, x26
-               	mov	x5, x27
+               	ldr	x4, [x26]
+               	mov	x16, #0xfb38            // =64312
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x4, [x29, x16]
+               	ldr	x4, [x26, #0x8]
+               	mov	x16, #0xfb40            // =64320
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x4, [x29, x16]
+               	ldr	x4, [x26, #0x10]
+               	mov	x16, #0xfb48            // =64328
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x4, [x29, x16]
+               	ldr	x4, [x26, #0x18]
+               	mov	x16, #0xfb50            // =64336
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x4, [x29, x16]
+               	sub	x4, x29, #0x4c8
+               	ldr	x5, [x27]
+               	mov	x16, #0xfb18            // =64280
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x5, [x29, x16]
+               	ldr	x5, [x27, #0x8]
+               	mov	x16, #0xfb20            // =64288
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x5, [x29, x16]
+               	ldr	x5, [x27, #0x10]
+               	mov	x16, #0xfb28            // =64296
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x5, [x29, x16]
+               	ldr	x5, [x27, #0x18]
+               	mov	x16, #0xfb30            // =64304
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x5, [x29, x16]
+               	sub	x5, x29, #0x4e8
                	fmov	d3, d8
-               	mov	x6, x28
-               	mov	x16, #0xfc98            // =64664
+               	ldr	x6, [x28]
+               	mov	x16, #0xfae8            // =64232
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x6, [x29, x16]
+               	ldr	x6, [x28, #0x8]
+               	mov	x16, #0xfaf0            // =64240
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x6, [x29, x16]
+               	ldr	x6, [x28, #0x10]
+               	mov	x16, #0xfaf8            // =64248
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x6, [x29, x16]
+               	ldr	x6, [x28, #0x18]
+               	mov	x16, #0xfb00            // =64256
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x6, [x29, x16]
+               	ldr	x6, [x28, #0x20]
+               	mov	x16, #0xfb08            // =64264
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x6, [x29, x16]
+               	ldr	x6, [x28, #0x28]
+               	mov	x16, #0xfb10            // =64272
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x6, [x29, x16]
+               	sub	x6, x29, #0x518
+               	mov	x16, #0xfa28            // =64040
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
-               	mov	x7, x9
+               	ldr	x15, [x9]
+               	mov	x16, #0xfab8            // =64184
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x15, [x29, x16]
+               	mov	x16, #0xfa28            // =64040
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	ldr	x15, [x9, #0x8]
+               	mov	x16, #0xfac0            // =64192
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x15, [x29, x16]
+               	mov	x16, #0xfa28            // =64040
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	ldr	x15, [x9, #0x10]
+               	mov	x16, #0xfac8            // =64200
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x15, [x29, x16]
+               	mov	x16, #0xfa28            // =64040
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	ldr	x15, [x9, #0x18]
+               	mov	x16, #0xfad0            // =64208
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x15, [x29, x16]
+               	mov	x16, #0xfa28            // =64040
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	ldr	x15, [x9, #0x20]
+               	mov	x16, #0xfad8            // =64216
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x15, [x29, x16]
+               	mov	x16, #0xfa28            // =64040
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	ldr	x15, [x9, #0x28]
+               	mov	x16, #0xfae0            // =64224
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x15, [x29, x16]
+               	sub	x7, x29, #0x548
+               	ldr	x15, [x8]
+               	mov	x16, #0xfaa0            // =64160
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x15, [x29, x16]
+               	ldr	x15, [x8, #0x8]
+               	mov	x16, #0xfaa8            // =64168
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x15, [x29, x16]
+               	ldr	x15, [x8, #0x10]
+               	mov	x16, #0xfab0            // =64176
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x15, [x29, x16]
+               	sub	x8, x29, #0x560
                	str	x8, [sp]
-               	str	x12, [sp, #0x8]
-               	str	x13, [sp, #0x10]
+               	ldr	x8, [x12]
+               	mov	x16, #0xfa80            // =64128
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x8, [x29, x16]
+               	ldr	x8, [x12, #0x8]
+               	mov	x16, #0xfa88            // =64136
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x8, [x29, x16]
+               	ldr	x8, [x12, #0x10]
+               	mov	x16, #0xfa90            // =64144
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x8, [x29, x16]
+               	ldr	x8, [x12, #0x18]
+               	mov	x16, #0xfa98            // =64152
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x8, [x29, x16]
+               	sub	x8, x29, #0x580
+               	str	x8, [sp, #0x8]
+               	ldr	x8, [x13]
+               	mov	x16, #0xfa50            // =64080
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x8, [x29, x16]
+               	ldr	x8, [x13, #0x8]
+               	mov	x16, #0xfa58            // =64088
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x8, [x29, x16]
+               	ldr	x8, [x13, #0x10]
+               	mov	x16, #0xfa60            // =64096
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x8, [x29, x16]
+               	ldr	x8, [x13, #0x18]
+               	mov	x16, #0xfa68            // =64104
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x8, [x29, x16]
+               	ldr	x8, [x13, #0x20]
+               	mov	x16, #0xfa70            // =64112
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x8, [x29, x16]
+               	ldr	x8, [x13, #0x28]
+               	mov	x16, #0xfa78            // =64120
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x8, [x29, x16]
+               	sub	x8, x29, #0x5b0
+               	str	x8, [sp, #0x10]
                	str	x14, [sp, #0x18]
 <L26>:
                	bl	 <L26>
@@ -1757,9 +2336,9 @@ Disassembly of section .text:
                	mov	x0, x21
 <L27>:
                	bl	 <L27>
-               	sub	x16, x29, #0x3d0
+               	sub	x16, x29, #0x640
                	ldr	d8, [x16, #0x8]
-               	sub	x16, x29, #0x380
+               	sub	x16, x29, #0x5f0
                	ldp	x19, x20, [x16]
                	ldp	x21, x22, [x16, #-0x10]
                	ldp	x23, x24, [x16, #-0x20]

--- a/test/golden/aarch64-linux/call/call_ret_large.dis
+++ b/test/golden/aarch64-linux/call/call_ret_large.dis
@@ -879,14 +879,14 @@ Disassembly of section .text:
 <corpus.cases.call.call_ret_large.checksum>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0x4d0
-               	sub	x16, x29, #0x480
+               	sub	sp, sp, #0x690
+               	sub	x16, x29, #0x640
                	stp	x19, x20, [x16]
                	stp	x21, x22, [x16, #-0x10]
                	stp	x23, x24, [x16, #-0x20]
                	stp	x25, x26, [x16, #-0x30]
                	stp	x27, x28, [x16, #-0x40]
-               	sub	x16, x29, #0x4d0
+               	sub	x16, x29, #0x690
                	stp	d8, d9, [x16]
                	mov	x19, x0
 <L0>:
@@ -918,7 +918,7 @@ Disassembly of section .text:
                	mov	x1, #0x20               // =32
 <L9>:
                	bl	 <L9>
-               	sub	x20, x29, #0x190
+               	sub	x20, x29, #0x1c0
                	str	xzr, [x20]
                	str	xzr, [x20, #0x8]
                	str	xzr, [x20, #0x10]
@@ -1099,11 +1099,11 @@ Disassembly of section .text:
                	mov	x1, x28
 <L39>:
                	bl	 <L39>
-               	sub	x1, x29, #0x418
+               	sub	x1, x29, #0x5b0
                	mov	w2, w23
                	add	x3, x1, #0x0
                	str	w2, [x3]
-               	sub	x2, x29, #0x430
+               	sub	x2, x29, #0x5c8
                	add	x3, x2, #0x0
                	str	x23, [x3]
                	mvn	x3, x23
@@ -1121,7 +1121,7 @@ Disassembly of section .text:
                	str	x4, [x3, #0x8]
                	ldr	x4, [x2, #0x10]
                	str	x4, [x3, #0x10]
-               	sub	x2, x29, #0x440
+               	sub	x2, x29, #0x5d8
                	mov	x16, #0xb               // =11
                	mul	x3, x23, x16
                	add	x4, x2, #0x0
@@ -1134,6 +1134,43 @@ Disassembly of section .text:
                	str	x4, [x3]
                	ldr	x4, [x2, #0x8]
                	str	x4, [x3, #0x8]
+               	ldr	x2, [x1]
+               	mov	x16, #0xf9f8            // =63992
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x2, [x29, x16]
+               	ldr	x2, [x1, #0x8]
+               	mov	x16, #0xfa00            // =64000
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x2, [x29, x16]
+               	ldr	x2, [x1, #0x10]
+               	mov	x16, #0xfa08            // =64008
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x2, [x29, x16]
+               	ldr	x2, [x1, #0x18]
+               	mov	x16, #0xfa10            // =64016
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x2, [x29, x16]
+               	ldr	x2, [x1, #0x20]
+               	mov	x16, #0xfa18            // =64024
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x2, [x29, x16]
+               	ldr	x2, [x1, #0x28]
+               	mov	x16, #0xfa20            // =64032
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x2, [x29, x16]
+               	sub	x1, x29, #0x608
 <L40>:
                	bl	 <L40>
                	add	x22, x22, #0x1
@@ -1179,7 +1216,7 @@ Disassembly of section .text:
 <L46>:
                	sub	x22, x29, #0x30
                	add	x0, x19, #0x2
-               	sub	x1, x29, #0x1c0
+               	sub	x1, x29, #0x1f0
                	add	x2, x1, #0x0
                	str	x0, [x2]
                	add	x2, x0, #0x1
@@ -1221,7 +1258,19 @@ Disassembly of section .text:
                	ldr	x1, [x0]
                	sub	x24, x29, #0x60
                	mov	x8, x24
-               	mov	x0, x22
+               	ldr	x0, [x22]
+               	stur	x0, [x29, #-0x90]
+               	ldr	x0, [x22, #0x8]
+               	stur	x0, [x29, #-0x88]
+               	ldr	x0, [x22, #0x10]
+               	stur	x0, [x29, #-0x80]
+               	ldr	x0, [x22, #0x18]
+               	stur	x0, [x29, #-0x78]
+               	ldr	x0, [x22, #0x20]
+               	stur	x0, [x29, #-0x70]
+               	ldr	x0, [x22, #0x28]
+               	stur	x0, [x29, #-0x68]
+               	sub	x0, x29, #0x90
 <L48>:
                	bl	 <L48>
                	ldr	x0, [x24]
@@ -1271,7 +1320,7 @@ Disassembly of section .text:
                	cmp	x23, #0x8
                	b.lo	 <L47>
 <L55>:
-               	sub	x22, x29, #0x120
+               	sub	x22, x29, #0x150
                	str	xzr, [x22]
                	str	xzr, [x22, #0x8]
                	str	xzr, [x22, #0x10]
@@ -1304,7 +1353,7 @@ Disassembly of section .text:
                	add	x1, x20, x0, lsl #3
                	ldr	x2, [x1]
                	add	x1, x2, x19
-               	sub	x2, x29, #0x1e0
+               	sub	x2, x29, #0x210
                	add	x3, x2, #0x0
                	str	x1, [x3]
                	add	x3, x1, #0x1
@@ -1366,7 +1415,7 @@ Disassembly of section .text:
                	cmp	x23, #0x6
                	b.lo	 <L58>
 <L63>:
-               	sub	x1, x29, #0x150
+               	sub	x1, x29, #0x180
                	str	xzr, [x1]
                	str	xzr, [x1, #0x8]
                	str	xzr, [x1, #0x10]
@@ -1384,7 +1433,7 @@ Disassembly of section .text:
                	add	x4, x3, #0x1
                	add	x3, x20, #0x0
                	ldr	x5, [x3]
-               	sub	x3, x29, #0x240
+               	sub	x3, x29, #0x288
                	add	x6, x0, x5
                	add	x7, x3, #0x0
                	str	x6, [x7]
@@ -1401,7 +1450,7 @@ Disassembly of section .text:
                	str	x2, [x0, #0x8]
                	ldr	x2, [x3, #0x10]
                	str	x2, [x0, #0x10]
-               	sub	x0, x29, #0x250
+               	sub	x0, x29, #0x298
                	add	x2, x20, #0x8
                	ldr	x3, [x2]
                	add	x2, x0, #0x0
@@ -1416,6 +1465,43 @@ Disassembly of section .text:
                	ldr	x3, [x0, #0x8]
                	str	x3, [x2, #0x8]
                	mov	x0, x21
+               	ldr	x2, [x1]
+               	mov	x16, #0xfd38            // =64824
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x2, [x29, x16]
+               	ldr	x2, [x1, #0x8]
+               	mov	x16, #0xfd40            // =64832
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x2, [x29, x16]
+               	ldr	x2, [x1, #0x10]
+               	mov	x16, #0xfd48            // =64840
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x2, [x29, x16]
+               	ldr	x2, [x1, #0x18]
+               	mov	x16, #0xfd50            // =64848
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x2, [x29, x16]
+               	ldr	x2, [x1, #0x20]
+               	mov	x16, #0xfd58            // =64856
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x2, [x29, x16]
+               	ldr	x2, [x1, #0x28]
+               	mov	x16, #0xfd60            // =64864
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x2, [x29, x16]
+               	sub	x1, x29, #0x2c8
 <L64>:
                	bl	 <L64>
                	mov	x21, x0
@@ -1427,7 +1513,7 @@ Disassembly of section .text:
                	add	x0, x20, x22, lsl #3
                	ldr	x1, [x0]
                	add	x23, x1, x19
-               	sub	x0, x29, #0x1f8
+               	sub	x0, x29, #0x228
                	add	x1, x0, #0x0
                	str	x23, [x1]
                	mvn	x1, x23
@@ -1438,11 +1524,30 @@ Disassembly of section .text:
                	add	x2, x1, #0x1
                	add	x1, x0, #0x10
                	str	x2, [x1]
-               	sub	x24, x29, #0x228
+               	sub	x24, x29, #0x258
                	mov	x8, x24
+               	ldr	x1, [x0]
+               	mov	x16, #0xfd90            // =64912
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x1, [x29, x16]
+               	ldr	x1, [x0, #0x8]
+               	mov	x16, #0xfd98            // =64920
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x1, [x29, x16]
+               	ldr	x1, [x0, #0x10]
+               	mov	x16, #0xfda0            // =64928
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x1, [x29, x16]
+               	sub	x0, x29, #0x270
 <L66>:
                	bl	 <L66>
-               	sub	x0, x29, #0x280
+               	sub	x0, x29, #0x2f8
                	add	x1, x0, #0x0
                	str	x23, [x1]
                	add	x1, x23, #0x1
@@ -1463,8 +1568,45 @@ Disassembly of section .text:
                	eor	x1, x23, x16
                	add	x2, x0, #0x28
                	str	x1, [x2]
-               	sub	x25, x29, #0x298
+               	sub	x25, x29, #0x310
                	mov	x8, x25
+               	ldr	x1, [x0]
+               	mov	x16, #0xfcc0            // =64704
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x1, [x29, x16]
+               	ldr	x1, [x0, #0x8]
+               	mov	x16, #0xfcc8            // =64712
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x1, [x29, x16]
+               	ldr	x1, [x0, #0x10]
+               	mov	x16, #0xfcd0            // =64720
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x1, [x29, x16]
+               	ldr	x1, [x0, #0x18]
+               	mov	x16, #0xfcd8            // =64728
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x1, [x29, x16]
+               	ldr	x1, [x0, #0x20]
+               	mov	x16, #0xfce0            // =64736
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x1, [x29, x16]
+               	ldr	x1, [x0, #0x28]
+               	mov	x16, #0xfce8            // =64744
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x1, [x29, x16]
+               	sub	x0, x29, #0x340
 <L67>:
                	bl	 <L67>
                	add	x0, x24, #0x0
@@ -1475,14 +1617,14 @@ Disassembly of section .text:
                	ldr	x28, [x0]
                	add	x0, x24, #0x18
                	ldr	x9, [x0]
-               	mov	x16, #0xfbb8            // =64440
+               	mov	x16, #0xf9f0            // =63984
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
                	add	x0, x24, #0x20
                	ldr	x9, [x0]
-               	mov	x16, #0xfbb0            // =64432
+               	mov	x16, #0xf9e8            // =63976
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1491,14 +1633,14 @@ Disassembly of section .text:
                	ldr	x24, [x0]
                	add	x0, x25, #0x0
                	ldr	x9, [x0]
-               	mov	x16, #0xfba8            // =64424
+               	mov	x16, #0xf9e0            // =63968
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
                	add	x0, x25, #0x8
                	ldr	x9, [x0]
-               	mov	x16, #0xfba0            // =64416
+               	mov	x16, #0xf9d8            // =63960
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1516,7 +1658,7 @@ Disassembly of section .text:
                	mov	x1, x28
 <L71>:
                	bl	 <L71>
-               	mov	x16, #0xfbb8            // =64440
+               	mov	x16, #0xf9f0            // =63984
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1524,7 +1666,7 @@ Disassembly of section .text:
                	mov	x1, x9
 <L72>:
                	bl	 <L72>
-               	mov	x16, #0xfbb0            // =64432
+               	mov	x16, #0xf9e8            // =63976
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1535,7 +1677,7 @@ Disassembly of section .text:
                	mov	x1, x24
 <L74>:
                	bl	 <L74>
-               	mov	x16, #0xfba8            // =64424
+               	mov	x16, #0xf9e0            // =63968
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1543,7 +1685,7 @@ Disassembly of section .text:
                	mov	x1, x9
 <L75>:
                	bl	 <L75>
-               	mov	x16, #0xfba0            // =64416
+               	mov	x16, #0xf9d8            // =63960
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1562,7 +1704,7 @@ Disassembly of section .text:
 <L79>:
                	bl	 <L79>
                	mov	x24, x0
-               	sub	x0, x29, #0x2c8
+               	sub	x0, x29, #0x370
                	add	x1, x0, #0x0
                	str	x23, [x1]
                	add	x1, x23, #0x1
@@ -1583,13 +1725,68 @@ Disassembly of section .text:
                	eor	x1, x23, x16
                	add	x2, x0, #0x28
                	str	x1, [x2]
-               	sub	x25, x29, #0x2e0
+               	sub	x25, x29, #0x388
                	mov	x8, x25
+               	ldr	x1, [x0]
+               	mov	x16, #0xfc48            // =64584
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x1, [x29, x16]
+               	ldr	x1, [x0, #0x8]
+               	mov	x16, #0xfc50            // =64592
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x1, [x29, x16]
+               	ldr	x1, [x0, #0x10]
+               	mov	x16, #0xfc58            // =64600
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x1, [x29, x16]
+               	ldr	x1, [x0, #0x18]
+               	mov	x16, #0xfc60            // =64608
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x1, [x29, x16]
+               	ldr	x1, [x0, #0x20]
+               	mov	x16, #0xfc68            // =64616
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x1, [x29, x16]
+               	ldr	x1, [x0, #0x28]
+               	mov	x16, #0xfc70            // =64624
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x1, [x29, x16]
+               	sub	x0, x29, #0x3b8
 <L80>:
                	bl	 <L80>
-               	sub	x26, x29, #0x310
+               	sub	x26, x29, #0x3e8
                	mov	x8, x26
-               	mov	x0, x25
+               	ldr	x0, [x25]
+               	mov	x16, #0xfc00            // =64512
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x0, [x29, x16]
+               	ldr	x0, [x25, #0x8]
+               	mov	x16, #0xfc08            // =64520
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x0, [x29, x16]
+               	ldr	x0, [x25, #0x10]
+               	mov	x16, #0xfc10            // =64528
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x0, [x29, x16]
+               	sub	x0, x29, #0x400
 <L81>:
                	bl	 <L81>
                	add	x0, x26, #0x0
@@ -1602,7 +1799,7 @@ Disassembly of section .text:
                	ldr	x28, [x0]
                	add	x0, x26, #0x20
                	ldr	x9, [x0]
-               	mov	x16, #0xfb98            // =64408
+               	mov	x16, #0xf9d0            // =63952
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1621,7 +1818,7 @@ Disassembly of section .text:
                	mov	x1, x28
 <L85>:
                	bl	 <L85>
-               	mov	x16, #0xfb98            // =64408
+               	mov	x16, #0xf9d0            // =63952
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1633,7 +1830,7 @@ Disassembly of section .text:
 <L87>:
                	bl	 <L87>
                	mov	x24, x0
-               	sub	x0, x29, #0x328
+               	sub	x0, x29, #0x418
                	add	x1, x0, #0x0
                	str	x23, [x1]
                	mvn	x1, x23
@@ -1644,13 +1841,68 @@ Disassembly of section .text:
                	add	x2, x1, #0x1
                	add	x1, x0, #0x10
                	str	x2, [x1]
-               	sub	x25, x29, #0x358
+               	sub	x25, x29, #0x448
                	mov	x8, x25
+               	ldr	x1, [x0]
+               	mov	x16, #0xfba0            // =64416
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x1, [x29, x16]
+               	ldr	x1, [x0, #0x8]
+               	mov	x16, #0xfba8            // =64424
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x1, [x29, x16]
+               	ldr	x1, [x0, #0x10]
+               	mov	x16, #0xfbb0            // =64432
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x1, [x29, x16]
+               	sub	x0, x29, #0x460
 <L88>:
                	bl	 <L88>
-               	sub	x26, x29, #0x370
+               	sub	x26, x29, #0x478
                	mov	x8, x26
-               	mov	x0, x25
+               	ldr	x0, [x25]
+               	mov	x16, #0xfb58            // =64344
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x0, [x29, x16]
+               	ldr	x0, [x25, #0x8]
+               	mov	x16, #0xfb60            // =64352
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x0, [x29, x16]
+               	ldr	x0, [x25, #0x10]
+               	mov	x16, #0xfb68            // =64360
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x0, [x29, x16]
+               	ldr	x0, [x25, #0x18]
+               	mov	x16, #0xfb70            // =64368
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x0, [x29, x16]
+               	ldr	x0, [x25, #0x20]
+               	mov	x16, #0xfb78            // =64376
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x0, [x29, x16]
+               	ldr	x0, [x25, #0x28]
+               	mov	x16, #0xfb80            // =64384
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x0, [x29, x16]
+               	sub	x0, x29, #0x4a8
 <L89>:
                	bl	 <L89>
                	add	x0, x26, #0x0
@@ -1669,7 +1921,7 @@ Disassembly of section .text:
 <L92>:
                	bl	 <L92>
                	mov	x24, x0
-               	sub	x0, x29, #0x3a0
+               	sub	x0, x29, #0x4d8
                	add	x1, x0, #0x0
                	str	x23, [x1]
                	add	x1, x23, #0x1
@@ -1690,14 +1942,87 @@ Disassembly of section .text:
                	eor	x1, x23, x16
                	add	x2, x0, #0x28
                	str	x1, [x2]
-               	sub	x25, x29, #0x3d0
+               	sub	x25, x29, #0x508
                	mov	x8, x25
+               	ldr	x1, [x0]
+               	mov	x16, #0xfac8            // =64200
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x1, [x29, x16]
+               	ldr	x1, [x0, #0x8]
+               	mov	x16, #0xfad0            // =64208
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x1, [x29, x16]
+               	ldr	x1, [x0, #0x10]
+               	mov	x16, #0xfad8            // =64216
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x1, [x29, x16]
+               	ldr	x1, [x0, #0x18]
+               	mov	x16, #0xfae0            // =64224
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x1, [x29, x16]
+               	ldr	x1, [x0, #0x20]
+               	mov	x16, #0xfae8            // =64232
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x1, [x29, x16]
+               	ldr	x1, [x0, #0x28]
+               	mov	x16, #0xfaf0            // =64240
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x1, [x29, x16]
+               	sub	x0, x29, #0x538
                	mov	x1, x23
 <L93>:
                	bl	 <L93>
-               	sub	x26, x29, #0x3e8
+               	sub	x26, x29, #0x550
                	mov	x8, x26
-               	mov	x0, x25
+               	ldr	x0, [x25]
+               	mov	x16, #0xfa80            // =64128
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x0, [x29, x16]
+               	ldr	x0, [x25, #0x8]
+               	mov	x16, #0xfa88            // =64136
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x0, [x29, x16]
+               	ldr	x0, [x25, #0x10]
+               	mov	x16, #0xfa90            // =64144
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x0, [x29, x16]
+               	ldr	x0, [x25, #0x18]
+               	mov	x16, #0xfa98            // =64152
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x0, [x29, x16]
+               	ldr	x0, [x25, #0x20]
+               	mov	x16, #0xfaa0            // =64160
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x0, [x29, x16]
+               	ldr	x0, [x25, #0x28]
+               	mov	x16, #0xfaa8            // =64168
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x0, [x29, x16]
+               	sub	x0, x29, #0x580
 <L94>:
                	bl	 <L94>
                	add	x0, x26, #0x0
@@ -1725,9 +2050,9 @@ Disassembly of section .text:
                	b.lo	 <L65>
 <L98>:
                	mov	x0, x21
-               	sub	x16, x29, #0x4d0
+               	sub	x16, x29, #0x690
                	ldp	d8, d9, [x16]
-               	sub	x16, x29, #0x480
+               	sub	x16, x29, #0x640
                	ldp	x19, x20, [x16]
                	ldp	x21, x22, [x16, #-0x10]
                	ldp	x23, x24, [x16, #-0x20]

--- a/test/golden/aarch64-linux/cmp/short_circuit.dis
+++ b/test/golden/aarch64-linux/cmp/short_circuit.dis
@@ -203,22 +203,25 @@ Disassembly of section .text:
                	add	x1, x1, #0x0
                	str	x0, [x1]
                	mov	w17, #0x1               // =1
-               	eor	w1, w17, w20
+               	eor	w0, w17, w20
                	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	ldr	x0, [x16]
-               	add	x2, x0, #0x1
+               	ldr	x1, [x16]
+               	add	x2, x1, #0x1
                	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
                	str	x2, [x16]
-               	adrp	x0, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	add	x0, x0, #0x0
-               	ldr	x2, [x0]
+               	adrp	x1, 0x0 <corpus.cases.cmp.short_circuit.probe>
+               	add	x1, x1, #0x0
+               	ldr	x2, [x1]
                	add	x3, x2, #0x1
-               	str	x3, [x0]
+               	str	x3, [x1]
                	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	ldr	x0, [x16]
+               	ldr	x1, [x16]
                	adrp	x2, 0x0 <corpus.cases.cmp.short_circuit.probe>
                	add	x2, x2, #0x0
-               	str	x0, [x2]
+               	str	x1, [x2]
+               	uxtb	w17, w0
+               	cmp	w17, #0x1
+               	cset	w1, eq
                	mov	x0, x22
 <L11>:
                	bl	 <L11>
@@ -337,163 +340,46 @@ Disassembly of section .text:
                	cmp	x2, #0x4
                	b.lo	 <L25>
 <L26>:
-               	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	ldr	x0, [x16]
-               	add	x1, x0, #0x1
-               	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	str	x1, [x16]
-               	adrp	x0, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	add	x0, x0, #0x0
-               	ldr	x1, [x0]
-               	add	x2, x1, #0x1
-               	str	x2, [x0]
-               	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	ldr	x0, [x16]
-               	adrp	x1, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	add	x1, x1, #0x0
-               	str	x0, [x1]
-               	mov	w17, #0x1               // =1
-               	eor	w1, w17, w20
-               	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	ldr	x0, [x16]
-               	add	x2, x0, #0x1
-               	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	str	x2, [x16]
-               	adrp	x0, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	add	x0, x0, #0x0
-               	ldr	x2, [x0]
-               	add	x3, x2, #0x1
-               	str	x3, [x0]
-               	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	ldr	x0, [x16]
-               	adrp	x2, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	add	x2, x2, #0x0
-               	str	x0, [x2]
-               	mov	x0, x22
+               	mov	x0, #0x0                // =0
+               	mov	x1, #0x0                // =0
 <L27>:
                	bl	 <L27>
+               	uxtb	w17, w0
+               	cmp	w17, #0x1
+               	cset	w1, eq
+               	cbnz	w1,  <L28>
+               	mov	w17, #0x1               // =1
+               	eor	w0, w17, w20
                	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	ldr	x1, [x16]
+               	ldr	x2, [x16]
+               	add	x3, x2, #0x1
+               	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
+               	str	x3, [x16]
+               	adrp	x2, 0x0 <corpus.cases.cmp.short_circuit.probe>
+               	add	x2, x2, #0x0
+               	ldr	x3, [x2]
+               	add	x4, x3, #0x1
+               	str	x4, [x2]
+               	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
+               	ldr	x2, [x16]
+               	adrp	x3, 0x0 <corpus.cases.cmp.short_circuit.probe>
+               	add	x3, x3, #0x0
+               	str	x2, [x3]
+               	uxtb	w17, w0
+               	cmp	w17, #0x1
+               	cset	w2, eq
+               	b	 <L29>
 <L28>:
-               	bl	 <L28>
-               	adrp	x19, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	add	x19, x19, #0x0
-               	adrp	x21, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	add	x21, x21, #0x0
-               	mov	x22, x0
-               	mov	x23, #0x0               // =0
-               	cmp	x23, #0x4
-               	b.lo	 <L29>
-               	b	 <L32>
+               	mov	x2, x1
 <L29>:
-               	add	x0, x19, x23, lsl #3
-               	ldr	x1, [x0]
                	mov	x0, x22
+               	mov	x1, x2
 <L30>:
                	bl	 <L30>
-               	add	x1, x21, x23, lsl #3
-               	ldr	x2, [x1]
-               	mov	x1, x2
-<L31>:
-               	bl	 <L31>
-               	add	x23, x23, #0x1
-               	mov	x22, x0
-               	cmp	x23, #0x4
-               	b.lo	 <L29>
-<L32>:
-               	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	str	xzr, [x16]
-               	adrp	x0, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	add	x0, x0, #0x0
-               	adrp	x1, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	add	x1, x1, #0x0
-               	mov	x2, #0x0                // =0
-               	cmp	x2, #0x4
-               	b.lo	 <L33>
-               	b	 <L34>
-<L33>:
-               	add	x3, x0, x2, lsl #3
-               	str	xzr, [x3]
-               	add	x3, x1, x2, lsl #3
-               	str	xzr, [x3]
-               	add	x2, x2, #0x1
-               	cmp	x2, #0x4
-               	b.lo	 <L33>
-<L34>:
-               	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	ldr	x0, [x16]
-               	add	x1, x0, #0x1
-               	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	str	x1, [x16]
-               	adrp	x0, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	add	x0, x0, #0x0
-               	ldr	x1, [x0]
-               	add	x2, x1, #0x1
-               	str	x2, [x0]
-               	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	ldr	x0, [x16]
-               	adrp	x1, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	add	x1, x1, #0x0
-               	str	x0, [x1]
-               	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	ldr	x0, [x16]
-               	add	x1, x0, #0x1
-               	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	str	x1, [x16]
-               	adrp	x0, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	add	x0, x0, #0x0
-               	ldr	x1, [x0]
-               	add	x2, x1, #0x1
-               	str	x2, [x0]
-               	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	ldr	x0, [x16]
-               	adrp	x1, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	add	x1, x1, #0x0
-               	str	x0, [x1]
-               	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	ldr	x0, [x16]
-               	add	x1, x0, #0x1
-               	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	str	x1, [x16]
-               	adrp	x0, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	add	x0, x0, #0x0
-               	ldr	x1, [x0]
-               	add	x2, x1, #0x1
-               	str	x2, [x0]
-               	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	ldr	x0, [x16]
-               	adrp	x1, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	add	x1, x1, #0x0
-               	str	x0, [x1]
-               	cbnz	w20,  <L35>
-               	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	ldr	x0, [x16]
-               	add	x1, x0, #0x1
-               	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	str	x1, [x16]
-               	adrp	x0, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	add	x0, x0, #0x0
-               	ldr	x1, [x0]
-               	add	x2, x1, #0x1
-               	str	x2, [x0]
-               	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	ldr	x0, [x16]
-               	adrp	x1, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	add	x1, x1, #0x0
-               	str	x0, [x1]
-               	mov	x0, #0x1                // =1
-               	b	 <L36>
-<L35>:
-               	mov	x0, x20
-<L36>:
-               	mov	x1, x0
-               	mov	x0, x22
-<L37>:
-               	bl	 <L37>
                	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
                	ldr	x1, [x16]
-<L38>:
-               	bl	 <L38>
+<L31>:
+               	bl	 <L31>
                	adrp	x19, 0x0 <corpus.cases.cmp.short_circuit.probe>
                	add	x19, x19, #0x0
                	adrp	x21, 0x0 <corpus.cases.cmp.short_circuit.probe>
@@ -501,24 +387,24 @@ Disassembly of section .text:
                	mov	x22, x0
                	mov	x23, #0x0               // =0
                	cmp	x23, #0x4
-               	b.lo	 <L39>
-               	b	 <L42>
-<L39>:
+               	b.lo	 <L32>
+               	b	 <L35>
+<L32>:
                	add	x0, x19, x23, lsl #3
                	ldr	x1, [x0]
                	mov	x0, x22
-<L40>:
-               	bl	 <L40>
+<L33>:
+               	bl	 <L33>
                	add	x1, x21, x23, lsl #3
                	ldr	x2, [x1]
                	mov	x1, x2
-<L41>:
-               	bl	 <L41>
+<L34>:
+               	bl	 <L34>
                	add	x23, x23, #0x1
                	mov	x22, x0
                	cmp	x23, #0x4
-               	b.lo	 <L39>
-<L42>:
+               	b.lo	 <L32>
+<L35>:
                	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
                	str	xzr, [x16]
                	adrp	x0, 0x0 <corpus.cases.cmp.short_circuit.probe>
@@ -527,49 +413,25 @@ Disassembly of section .text:
                	add	x1, x1, #0x0
                	mov	x2, #0x0                // =0
                	cmp	x2, #0x4
-               	b.lo	 <L43>
-               	b	 <L44>
-<L43>:
+               	b.lo	 <L36>
+               	b	 <L37>
+<L36>:
                	add	x3, x0, x2, lsl #3
                	str	xzr, [x3]
                	add	x3, x1, x2, lsl #3
                	str	xzr, [x3]
                	add	x2, x2, #0x1
                	cmp	x2, #0x4
-               	b.lo	 <L43>
-<L44>:
-               	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	ldr	x0, [x16]
-               	add	x1, x0, #0x1
-               	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	str	x1, [x16]
-               	adrp	x0, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	add	x0, x0, #0x0
-               	ldr	x1, [x0]
-               	add	x2, x1, #0x1
-               	str	x2, [x0]
-               	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	ldr	x0, [x16]
-               	adrp	x1, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	add	x1, x1, #0x0
-               	str	x0, [x1]
-               	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	ldr	x0, [x16]
-               	add	x1, x0, #0x1
-               	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	str	x1, [x16]
-               	adrp	x0, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	add	x0, x0, #0x0
-               	ldr	x1, [x0]
-               	add	x2, x1, #0x1
-               	str	x2, [x0]
-               	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	ldr	x0, [x16]
-               	adrp	x1, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	add	x1, x1, #0x0
-               	str	x0, [x1]
-               	mov	w17, #0x1               // =1
-               	eor	w1, w17, w20
+               	b.lo	 <L36>
+<L37>:
+               	mov	x0, #0x0                // =0
+               	mov	x1, #0x0                // =0
+<L38>:
+               	bl	 <L38>
+               	uxtb	w17, w0
+               	cmp	w17, #0x1
+               	cset	w1, eq
+               	cbnz	w1,  <L39>
                	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
                	ldr	x0, [x16]
                	add	x2, x0, #0x1
@@ -585,6 +447,56 @@ Disassembly of section .text:
                	adrp	x2, 0x0 <corpus.cases.cmp.short_circuit.probe>
                	add	x2, x2, #0x0
                	str	x0, [x2]
+               	mov	x0, #0x1                // =1
+               	b	 <L40>
+<L39>:
+               	mov	x0, x1
+<L40>:
+               	cbnz	w0,  <L41>
+               	mov	x1, x0
+               	b	 <L44>
+<L41>:
+               	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
+               	ldr	x0, [x16]
+               	add	x2, x0, #0x1
+               	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
+               	str	x2, [x16]
+               	adrp	x0, 0x0 <corpus.cases.cmp.short_circuit.probe>
+               	add	x0, x0, #0x0
+               	ldr	x2, [x0]
+               	add	x3, x2, #0x1
+               	str	x3, [x0]
+               	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
+               	ldr	x0, [x16]
+               	adrp	x2, 0x0 <corpus.cases.cmp.short_circuit.probe>
+               	add	x2, x2, #0x0
+               	str	x0, [x2]
+               	uxtb	w17, w20
+               	cmp	w17, #0x1
+               	cset	w0, eq
+               	cbnz	w0,  <L42>
+               	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
+               	ldr	x2, [x16]
+               	add	x3, x2, #0x1
+               	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
+               	str	x3, [x16]
+               	adrp	x2, 0x0 <corpus.cases.cmp.short_circuit.probe>
+               	add	x2, x2, #0x0
+               	ldr	x3, [x2]
+               	add	x4, x3, #0x1
+               	str	x4, [x2]
+               	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
+               	ldr	x2, [x16]
+               	adrp	x3, 0x0 <corpus.cases.cmp.short_circuit.probe>
+               	add	x3, x3, #0x0
+               	str	x2, [x3]
+               	mov	x2, #0x1                // =1
+               	b	 <L43>
+<L42>:
+               	mov	x2, x0
+<L43>:
+               	mov	x1, x2
+<L44>:
                	mov	x0, x22
 <L45>:
                	bl	 <L45>
@@ -636,64 +548,184 @@ Disassembly of section .text:
                	cmp	x2, #0x4
                	b.lo	 <L51>
 <L52>:
-               	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	ldr	x0, [x16]
-               	add	x1, x0, #0x1
-               	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	str	x1, [x16]
-               	adrp	x0, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	add	x0, x0, #0x0
-               	ldr	x1, [x0]
-               	add	x2, x1, #0x1
-               	str	x2, [x0]
-               	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	ldr	x0, [x16]
-               	adrp	x1, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	add	x1, x1, #0x0
-               	str	x0, [x1]
-               	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	ldr	x0, [x16]
-               	add	x1, x0, #0x1
-               	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	str	x1, [x16]
-               	adrp	x0, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	add	x0, x0, #0x0
-               	ldr	x1, [x0]
-               	add	x2, x1, #0x1
-               	str	x2, [x0]
-               	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	ldr	x0, [x16]
-               	adrp	x1, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	add	x1, x1, #0x0
-               	str	x0, [x1]
-               	cbnz	w20,  <L53>
-               	b	 <L54>
+               	mov	x0, #0x0                // =0
+               	mov	x1, #0x1                // =1
 <L53>:
+               	bl	 <L53>
+               	uxtb	w17, w0
+               	cmp	w17, #0x1
+               	cset	w1, eq
+               	cbnz	w1,  <L54>
                	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
                	ldr	x0, [x16]
-               	add	x1, x0, #0x1
+               	add	x2, x0, #0x1
                	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	str	x1, [x16]
+               	str	x2, [x16]
                	adrp	x0, 0x0 <corpus.cases.cmp.short_circuit.probe>
                	add	x0, x0, #0x0
-               	ldr	x1, [x0]
-               	add	x2, x1, #0x1
-               	str	x2, [x0]
+               	ldr	x2, [x0]
+               	add	x3, x2, #0x1
+               	str	x3, [x0]
                	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
                	ldr	x0, [x16]
-               	adrp	x1, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	add	x1, x1, #0x0
-               	str	x0, [x1]
-               	mov	x20, #0x1               // =1
+               	adrp	x2, 0x0 <corpus.cases.cmp.short_circuit.probe>
+               	add	x2, x2, #0x0
+               	str	x0, [x2]
+               	mov	x0, #0x1                // =1
+               	b	 <L55>
 <L54>:
-               	mov	x0, x22
-               	mov	x1, x20
+               	mov	x0, x1
 <L55>:
-               	bl	 <L55>
+               	cbnz	w0,  <L56>
+               	mov	x1, x0
+               	b	 <L57>
+<L56>:
+               	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
+               	ldr	x0, [x16]
+               	add	x2, x0, #0x1
+               	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
+               	str	x2, [x16]
+               	adrp	x0, 0x0 <corpus.cases.cmp.short_circuit.probe>
+               	add	x0, x0, #0x0
+               	ldr	x2, [x0]
+               	add	x3, x2, #0x1
+               	str	x3, [x0]
+               	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
+               	ldr	x0, [x16]
+               	adrp	x2, 0x0 <corpus.cases.cmp.short_circuit.probe>
+               	add	x2, x2, #0x0
+               	str	x0, [x2]
+               	mov	w17, #0x1               // =1
+               	eor	w0, w17, w20
+               	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
+               	ldr	x2, [x16]
+               	add	x3, x2, #0x1
+               	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
+               	str	x3, [x16]
+               	adrp	x2, 0x0 <corpus.cases.cmp.short_circuit.probe>
+               	add	x2, x2, #0x0
+               	ldr	x3, [x2]
+               	add	x4, x3, #0x1
+               	str	x4, [x2]
+               	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
+               	ldr	x2, [x16]
+               	adrp	x3, 0x0 <corpus.cases.cmp.short_circuit.probe>
+               	add	x3, x3, #0x0
+               	str	x2, [x3]
+               	uxtb	w17, w0
+               	cmp	w17, #0x1
+               	cset	w2, eq
+               	mov	x1, x2
+<L57>:
+               	mov	x0, x22
+<L58>:
+               	bl	 <L58>
                	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
                	ldr	x1, [x16]
-<L56>:
-               	bl	 <L56>
+<L59>:
+               	bl	 <L59>
+               	adrp	x19, 0x0 <corpus.cases.cmp.short_circuit.probe>
+               	add	x19, x19, #0x0
+               	adrp	x21, 0x0 <corpus.cases.cmp.short_circuit.probe>
+               	add	x21, x21, #0x0
+               	mov	x22, x0
+               	mov	x23, #0x0               // =0
+               	cmp	x23, #0x4
+               	b.lo	 <L60>
+               	b	 <L63>
+<L60>:
+               	add	x0, x19, x23, lsl #3
+               	ldr	x1, [x0]
+               	mov	x0, x22
+<L61>:
+               	bl	 <L61>
+               	add	x1, x21, x23, lsl #3
+               	ldr	x2, [x1]
+               	mov	x1, x2
+<L62>:
+               	bl	 <L62>
+               	add	x23, x23, #0x1
+               	mov	x22, x0
+               	cmp	x23, #0x4
+               	b.lo	 <L60>
+<L63>:
+               	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
+               	str	xzr, [x16]
+               	adrp	x0, 0x0 <corpus.cases.cmp.short_circuit.probe>
+               	add	x0, x0, #0x0
+               	adrp	x1, 0x0 <corpus.cases.cmp.short_circuit.probe>
+               	add	x1, x1, #0x0
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x4
+               	b.lo	 <L64>
+               	b	 <L65>
+<L64>:
+               	add	x3, x0, x2, lsl #3
+               	str	xzr, [x3]
+               	add	x3, x1, x2, lsl #3
+               	str	xzr, [x3]
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x4
+               	b.lo	 <L64>
+<L65>:
+               	mov	x0, #0x0                // =0
+               	mov	x1, #0x0                // =0
+<L66>:
+               	bl	 <L66>
+               	uxtb	w17, w0
+               	cmp	w17, #0x1
+               	cset	w1, eq
+               	cbnz	w1,  <L67>
+               	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
+               	ldr	x0, [x16]
+               	add	x2, x0, #0x1
+               	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
+               	str	x2, [x16]
+               	adrp	x0, 0x0 <corpus.cases.cmp.short_circuit.probe>
+               	add	x0, x0, #0x0
+               	ldr	x2, [x0]
+               	add	x3, x2, #0x1
+               	str	x3, [x0]
+               	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
+               	ldr	x0, [x16]
+               	adrp	x2, 0x0 <corpus.cases.cmp.short_circuit.probe>
+               	add	x2, x2, #0x0
+               	str	x0, [x2]
+               	uxtb	w17, w20
+               	cmp	w17, #0x1
+               	cset	w0, eq
+               	b	 <L68>
+<L67>:
+               	mov	x0, x1
+<L68>:
+               	cbnz	w0,  <L69>
+               	mov	x1, x0
+               	b	 <L70>
+<L69>:
+               	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
+               	ldr	x0, [x16]
+               	add	x2, x0, #0x1
+               	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
+               	str	x2, [x16]
+               	adrp	x0, 0x0 <corpus.cases.cmp.short_circuit.probe>
+               	add	x0, x0, #0x0
+               	ldr	x2, [x0]
+               	add	x3, x2, #0x1
+               	str	x3, [x0]
+               	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
+               	ldr	x0, [x16]
+               	adrp	x2, 0x0 <corpus.cases.cmp.short_circuit.probe>
+               	add	x2, x2, #0x0
+               	str	x0, [x2]
+               	mov	x1, #0x1                // =1
+<L70>:
+               	mov	x0, x22
+<L71>:
+               	bl	 <L71>
+               	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
+               	ldr	x1, [x16]
+<L72>:
+               	bl	 <L72>
                	adrp	x19, 0x0 <corpus.cases.cmp.short_circuit.probe>
                	add	x19, x19, #0x0
                	adrp	x20, 0x0 <corpus.cases.cmp.short_circuit.probe>
@@ -701,24 +733,24 @@ Disassembly of section .text:
                	mov	x21, x0
                	mov	x22, #0x0               // =0
                	cmp	x22, #0x4
-               	b.lo	 <L57>
-               	b	 <L60>
-<L57>:
+               	b.lo	 <L73>
+               	b	 <L76>
+<L73>:
                	add	x0, x19, x22, lsl #3
                	ldr	x1, [x0]
                	mov	x0, x21
-<L58>:
-               	bl	 <L58>
+<L74>:
+               	bl	 <L74>
                	add	x1, x20, x22, lsl #3
                	ldr	x2, [x1]
                	mov	x1, x2
-<L59>:
-               	bl	 <L59>
+<L75>:
+               	bl	 <L75>
                	add	x22, x22, #0x1
                	mov	x21, x0
                	cmp	x22, #0x4
-               	b.lo	 <L57>
-<L60>:
+               	b.lo	 <L73>
+<L76>:
                	mov	x0, x21
                	ldp	x19, x20, [x29, #-0x10]
                	ldp	x21, x22, [x29, #-0x20]

--- a/test/golden/aarch64-linux/float/arith_f32.dis
+++ b/test/golden/aarch64-linux/float/arith_f32.dis
@@ -123,837 +123,1029 @@ Disassembly of section .text:
                	mov	x20, x0
 <L16>:
                	fdiv	s0, s9, s10
-               	fcmp	s0, s0
-               	cset	w0, ne
-               	cbnz	w0,  <L18>
                	mov	x0, x20
 <L17>:
                	bl	 <L17>
-               	mov	x19, x0
-               	b	 <L20>
+               	fdiv	s0, s10, s9
 <L18>:
-               	mov	x0, x20
-               	mov	w1, #0xffff             // =65535
-               	movk	w1, #0xffff, lsl #16
+               	bl	 <L18>
+               	fneg	s0, s9
 <L19>:
                	bl	 <L19>
-               	mov	x19, x0
+               	fmov	s31, wzr
+               	fsub	s10, s31, s9
+               	fmov	s0, s10
 <L20>:
-               	fdiv	s0, s10, s9
-               	fcmp	s0, s0
-               	cset	w0, ne
-               	cbnz	w0,  <L22>
-               	mov	x0, x19
+               	bl	 <L20>
+               	fsub	s0, s9, s9
 <L21>:
                	bl	 <L21>
-               	mov	x20, x0
-               	b	 <L24>
+               	fadd	s0, s10, s9
 <L22>:
-               	mov	x0, x19
-               	mov	w1, #0xffff             // =65535
-               	movk	w1, #0xffff, lsl #16
-<L23>:
-               	bl	 <L23>
-               	mov	x20, x0
-<L24>:
-               	fneg	s0, s9
-               	fcmp	s0, s0
-               	cset	w0, ne
-               	cbnz	w0,  <L26>
-               	mov	x0, x20
-<L25>:
-               	bl	 <L25>
-               	mov	x19, x0
-               	b	 <L28>
-<L26>:
-               	mov	x0, x20
-               	mov	w1, #0xffff             // =65535
-               	movk	w1, #0xffff, lsl #16
-<L27>:
-               	bl	 <L27>
-               	mov	x19, x0
-<L28>:
-               	fmov	s31, wzr
-               	fsub	s0, s31, s9
-               	fcmp	s0, s0
-               	cset	w0, ne
-               	cbnz	w0,  <L30>
-               	mov	x0, x19
-<L29>:
-               	bl	 <L29>
-               	mov	x20, x0
-               	b	 <L32>
-<L30>:
-               	mov	x0, x19
-               	mov	w1, #0xffff             // =65535
-               	movk	w1, #0xffff, lsl #16
-<L31>:
-               	bl	 <L31>
-               	mov	x20, x0
-<L32>:
-               	fsub	s0, s9, s9
-               	fcmp	s0, s0
-               	cset	w0, ne
-               	cbnz	w0,  <L34>
-               	mov	x0, x20
-<L33>:
-               	bl	 <L33>
-               	mov	x19, x0
-               	b	 <L36>
-<L34>:
-               	mov	x0, x20
-               	mov	w1, #0xffff             // =65535
-               	movk	w1, #0xffff, lsl #16
-<L35>:
-               	bl	 <L35>
-               	mov	x19, x0
-<L36>:
-               	fmov	s31, wzr
-               	fsub	s0, s31, s9
-               	fadd	s1, s0, s9
-               	fcmp	s1, s1
-               	cset	w0, ne
-               	cbnz	w0,  <L38>
-               	mov	x0, x19
-               	fmov	s0, s1
-<L37>:
-               	bl	 <L37>
-               	mov	x20, x0
-               	b	 <L40>
-<L38>:
-               	mov	x0, x19
-               	mov	w1, #0xffff             // =65535
-               	movk	w1, #0xffff, lsl #16
-<L39>:
-               	bl	 <L39>
-               	mov	x20, x0
-<L40>:
+               	bl	 <L22>
                	fmov	s31, #3.00000000
                	fmul	s9, s31, s8
                	fdiv	s10, s8, s9
-               	fcmp	s10, s10
-               	cset	w0, ne
-               	cbnz	w0,  <L42>
-               	mov	x0, x20
                	fmov	s0, s10
-<L41>:
-               	bl	 <L41>
-               	mov	x19, x0
-               	b	 <L44>
-<L42>:
-               	mov	x0, x20
-               	mov	w1, #0xffff             // =65535
-               	movk	w1, #0xffff, lsl #16
-<L43>:
-               	bl	 <L43>
-               	mov	x19, x0
-<L44>:
+<L23>:
+               	bl	 <L23>
                	fmul	s0, s10, s9
-               	fcmp	s0, s0
-               	cset	w0, ne
-               	cbnz	w0,  <L46>
-               	mov	x0, x19
-<L45>:
-               	bl	 <L45>
-               	mov	x20, x0
-               	b	 <L48>
-<L46>:
-               	mov	x0, x19
-               	mov	w1, #0xffff             // =65535
-               	movk	w1, #0xffff, lsl #16
-<L47>:
-               	bl	 <L47>
-               	mov	x20, x0
-<L48>:
+<L24>:
+               	bl	 <L24>
                	fsub	s0, s8, s10
                	fsub	s1, s0, s10
                	fsub	s0, s1, s10
-               	fcmp	s0, s0
-               	cset	w0, ne
-               	cbnz	w0,  <L50>
-               	mov	x0, x20
-<L49>:
-               	bl	 <L49>
-               	mov	x19, x0
-               	b	 <L52>
-<L50>:
-               	mov	x0, x20
-               	mov	w1, #0xffff             // =65535
-               	movk	w1, #0xffff, lsl #16
-<L51>:
-               	bl	 <L51>
-               	mov	x19, x0
-<L52>:
+<L25>:
+               	bl	 <L25>
                	mov	w16, #0x42440000        // =1111752704
                	fmov	s30, w16
                	fdiv	s0, s8, s30
-               	fcmp	s0, s0
-               	cset	w0, ne
-               	cbnz	w0,  <L54>
-               	mov	x0, x19
-<L53>:
-               	bl	 <L53>
-               	mov	x20, x0
-               	b	 <L56>
-<L54>:
-               	mov	x0, x19
-               	mov	w1, #0xffff             // =65535
-               	movk	w1, #0xffff, lsl #16
-<L55>:
-               	bl	 <L55>
-               	mov	x20, x0
-<L56>:
+<L26>:
+               	bl	 <L26>
                	adrp	x16, 0x0 <corpus.cases.float.arith_f32.opaque_f32>
                	ldr	s30, [x16]
                	fdiv	s0, s8, s30
-               	fcmp	s0, s0
-               	cset	w0, ne
-               	cbnz	w0,  <L58>
-               	mov	x0, x20
-<L57>:
-               	bl	 <L57>
-               	mov	x19, x0
-               	b	 <L60>
-<L58>:
-               	mov	x0, x20
-               	mov	w1, #0xffff             // =65535
-               	movk	w1, #0xffff, lsl #16
-<L59>:
-               	bl	 <L59>
-               	mov	x19, x0
-<L60>:
+<L27>:
+               	bl	 <L27>
                	adrp	x16, 0x0 <corpus.cases.float.arith_f32.opaque_f32>
                	ldr	s31, [x16]
                	fdiv	s0, s31, s9
-               	fcmp	s0, s0
-               	cset	w0, ne
-               	cbnz	w0,  <L62>
-               	mov	x0, x19
-<L61>:
-               	bl	 <L61>
-               	mov	x20, x0
-               	b	 <L64>
-<L62>:
-               	mov	x0, x19
-               	mov	w1, #0xffff             // =65535
-               	movk	w1, #0xffff, lsl #16
-<L63>:
-               	bl	 <L63>
-               	mov	x20, x0
-<L64>:
+<L28>:
+               	bl	 <L28>
                	mov	w16, #0x4b800000        // =1266679808
                	fmov	s31, w16
                	fmul	s9, s31, s8
-               	fadd	s0, s9, s8
-               	fcmp	s0, s0
-               	cset	w0, ne
-               	cbnz	w0,  <L66>
-               	mov	x0, x20
-<L65>:
-               	bl	 <L65>
-               	mov	x19, x0
-               	b	 <L68>
-<L66>:
-               	mov	x0, x20
-               	mov	w1, #0xffff             // =65535
-               	movk	w1, #0xffff, lsl #16
-<L67>:
-               	bl	 <L67>
-               	mov	x19, x0
-<L68>:
-               	fadd	s0, s9, s8
-               	fadd	s1, s0, s8
-               	fcmp	s1, s1
-               	cset	w0, ne
-               	cbnz	w0,  <L70>
-               	mov	x0, x19
-               	fmov	s0, s1
-<L69>:
-               	bl	 <L69>
-               	mov	x20, x0
-               	b	 <L72>
-<L70>:
-               	mov	x0, x19
-               	mov	w1, #0xffff             // =65535
-               	movk	w1, #0xffff, lsl #16
-<L71>:
-               	bl	 <L71>
-               	mov	x20, x0
-<L72>:
+               	fadd	s11, s9, s8
+               	fmov	s0, s11
+<L29>:
+               	bl	 <L29>
+               	fadd	s0, s11, s8
+<L30>:
+               	bl	 <L30>
                	fadd	s0, s8, s8
                	fadd	s1, s9, s0
-               	fcmp	s1, s1
-               	cset	w0, ne
-               	cbnz	w0,  <L74>
-               	mov	x0, x20
                	fmov	s0, s1
-<L73>:
-               	bl	 <L73>
-               	mov	x19, x0
-               	b	 <L76>
-<L74>:
-               	mov	x0, x20
-               	mov	w1, #0xffff             // =65535
-               	movk	w1, #0xffff, lsl #16
-<L75>:
-               	bl	 <L75>
-               	mov	x19, x0
-<L76>:
+<L31>:
+               	bl	 <L31>
                	fsub	s0, s9, s8
-               	fcmp	s0, s0
-               	cset	w0, ne
-               	cbnz	w0,  <L78>
-               	mov	x0, x19
-<L77>:
-               	bl	 <L77>
-               	mov	x20, x0
-               	b	 <L80>
-<L78>:
-               	mov	x0, x19
-               	mov	w1, #0xffff             // =65535
-               	movk	w1, #0xffff, lsl #16
-<L79>:
-               	bl	 <L79>
-               	mov	x20, x0
-<L80>:
-               	fadd	s0, s9, s8
-               	fsub	s1, s0, s9
-               	fcmp	s1, s1
-               	cset	w0, ne
-               	cbnz	w0,  <L82>
-               	mov	x0, x20
-               	fmov	s0, s1
-<L81>:
-               	bl	 <L81>
-               	mov	x19, x0
-               	b	 <L84>
-<L82>:
-               	mov	x0, x20
-               	mov	w1, #0xffff             // =65535
-               	movk	w1, #0xffff, lsl #16
-<L83>:
-               	bl	 <L83>
-               	mov	x19, x0
-<L84>:
+<L32>:
+               	bl	 <L32>
+               	fsub	s0, s11, s9
+<L33>:
+               	bl	 <L33>
                	fmov	s31, wzr
                	fmul	s0, s31, s8
+               	mov	x19, x0
                	fmov	d9, d0
                	mov	w20, #0x0               // =0
                	cmp	w20, #0x18
-               	b.lo	 <L85>
-               	b	 <L90>
-<L85>:
+               	b.lo	 <L34>
+               	b	 <L39>
+<L34>:
                	fadd	s0, s9, s10
                	fmov	s30, #1.50000000
                	fmul	s11, s0, s30
                	fcmp	s11, s11
                	cset	w0, ne
-               	cbnz	w0,  <L87>
+               	cbnz	w0,  <L36>
                	mov	x0, x19
                	fmov	s0, s11
-<L86>:
-               	bl	 <L86>
+<L35>:
+               	bl	 <L35>
                	mov	x22, x0
-               	b	 <L89>
-<L87>:
+               	b	 <L38>
+<L36>:
                	mov	x0, x19
                	mov	w1, #0xffff             // =65535
                	movk	w1, #0xffff, lsl #16
-<L88>:
-               	bl	 <L88>
+<L37>:
+               	bl	 <L37>
                	mov	x22, x0
-<L89>:
+<L38>:
                	add	w20, w20, #0x1
                	mov	x19, x22
                	fmov	d9, d11
                	cmp	w20, #0x18
-               	b.lo	 <L85>
-<L90>:
+               	b.lo	 <L34>
+<L39>:
                	mov	w17, #0xffff            // =65535
                	movk	w17, #0x7f7f, lsl #16
                	add	w0, w17, w21
                	fmov	s9, w0
                	fcmp	s9, s9
                	cset	w0, ne
-               	cbnz	w0,  <L92>
+               	cbnz	w0,  <L41>
                	mov	x0, x19
                	fmov	s0, s9
-<L91>:
-               	bl	 <L91>
+<L40>:
+               	bl	 <L40>
                	mov	x20, x0
-               	b	 <L94>
-<L92>:
+               	b	 <L43>
+<L41>:
                	mov	x0, x19
                	mov	w1, #0xffff             // =65535
                	movk	w1, #0xffff, lsl #16
-<L93>:
-               	bl	 <L93>
+<L42>:
+               	bl	 <L42>
                	mov	x20, x0
-<L94>:
+<L43>:
                	fmov	s30, #2.00000000
                	fdiv	s0, s9, s30
                	fcmp	s0, s0
                	cset	w0, ne
-               	cbnz	w0,  <L96>
+               	cbnz	w0,  <L45>
                	mov	x0, x20
-<L95>:
-               	bl	 <L95>
+<L44>:
+               	bl	 <L44>
                	mov	x19, x0
-               	b	 <L98>
-<L96>:
+               	b	 <L47>
+<L45>:
                	mov	x0, x20
                	mov	w1, #0xffff             // =65535
                	movk	w1, #0xffff, lsl #16
-<L97>:
-               	bl	 <L97>
+<L46>:
+               	bl	 <L46>
                	mov	x19, x0
-<L98>:
+<L47>:
                	fadd	s0, s9, s9
                	fcmp	s0, s0
                	cset	w0, ne
-               	cbnz	w0,  <L100>
+               	cbnz	w0,  <L49>
                	mov	x0, x19
-<L99>:
-               	bl	 <L99>
+<L48>:
+               	bl	 <L48>
                	mov	x20, x0
-               	b	 <L102>
-<L100>:
+               	b	 <L51>
+<L49>:
                	mov	x0, x19
                	mov	w1, #0xffff             // =65535
                	movk	w1, #0xffff, lsl #16
-<L101>:
-               	bl	 <L101>
+<L50>:
+               	bl	 <L50>
                	mov	x20, x0
-<L102>:
+<L51>:
                	fmov	s30, #2.00000000
-               	fmul	s0, s9, s30
-               	fcmp	s0, s0
-               	cset	w0, ne
-               	cbnz	w0,  <L104>
+               	fmul	s10, s9, s30
                	mov	x0, x20
-<L103>:
-               	bl	 <L103>
-               	mov	x19, x0
-               	b	 <L106>
-<L104>:
-               	mov	x0, x20
-               	mov	w1, #0xffff             // =65535
-               	movk	w1, #0xffff, lsl #16
-<L105>:
-               	bl	 <L105>
-               	mov	x19, x0
-<L106>:
-               	fmov	s30, #2.00000000
-               	fmul	s0, s9, s30
+               	fmov	s0, s10
+<L52>:
+               	bl	 <L52>
                	fmov	s31, wzr
-               	fsub	s1, s31, s0
-               	fcmp	s1, s1
-               	cset	w0, ne
-               	cbnz	w0,  <L108>
-               	mov	x0, x19
-               	fmov	s0, s1
-<L107>:
-               	bl	 <L107>
-               	mov	x20, x0
-               	b	 <L110>
-<L108>:
-               	mov	x0, x19
-               	mov	w1, #0xffff             // =65535
-               	movk	w1, #0xffff, lsl #16
-<L109>:
-               	bl	 <L109>
-               	mov	x20, x0
-<L110>:
+               	fsub	s0, s31, s10
+<L53>:
+               	bl	 <L53>
                	fmul	s0, s9, s9
-               	fcmp	s0, s0
-               	cset	w0, ne
-               	cbnz	w0,  <L112>
-               	mov	x0, x20
-<L111>:
-               	bl	 <L111>
-               	mov	x19, x0
-               	b	 <L114>
-<L112>:
-               	mov	x0, x20
-               	mov	w1, #0xffff             // =65535
-               	movk	w1, #0xffff, lsl #16
-<L113>:
-               	bl	 <L113>
-               	mov	x19, x0
-<L114>:
+<L54>:
+               	bl	 <L54>
                	fsub	s0, s9, s9
-               	fcmp	s0, s0
-               	cset	w0, ne
-               	cbnz	w0,  <L116>
-               	mov	x0, x19
-<L115>:
-               	bl	 <L115>
-               	mov	x20, x0
-               	b	 <L118>
-<L116>:
-               	mov	x0, x19
-               	mov	w1, #0xffff             // =65535
-               	movk	w1, #0xffff, lsl #16
-<L117>:
-               	bl	 <L117>
-               	mov	x20, x0
-<L118>:
+<L55>:
+               	bl	 <L55>
                	mov	w17, #0x800000          // =8388608
-               	add	w0, w17, w21
-               	fmov	s9, w0
+               	add	w1, w17, w21
+               	fmov	s9, w1
                	mov	w17, #0x1               // =1
-               	add	w0, w17, w21
-               	fmov	s10, w0
+               	add	w1, w17, w21
+               	fmov	s10, w1
                	fmov	s30, #0.50000000
                	fmul	s0, s9, s30
-               	fcmp	s0, s0
-               	cset	w0, ne
-               	cbnz	w0,  <L120>
-               	mov	x0, x20
-<L119>:
-               	bl	 <L119>
-               	mov	x19, x0
-               	b	 <L122>
-<L120>:
-               	mov	x0, x20
-               	mov	w1, #0xffff             // =65535
-               	movk	w1, #0xffff, lsl #16
-<L121>:
-               	bl	 <L121>
-               	mov	x19, x0
-<L122>:
+<L56>:
+               	bl	 <L56>
                	fmov	s30, #2.00000000
                	fdiv	s0, s9, s30
-               	fcmp	s0, s0
-               	cset	w0, ne
-               	cbnz	w0,  <L124>
-               	mov	x0, x19
-<L123>:
-               	bl	 <L123>
-               	mov	x20, x0
-               	b	 <L126>
-<L124>:
-               	mov	x0, x19
-               	mov	w1, #0xffff             // =65535
-               	movk	w1, #0xffff, lsl #16
-<L125>:
-               	bl	 <L125>
-               	mov	x20, x0
-<L126>:
+<L57>:
+               	bl	 <L57>
                	fsub	s0, s9, s10
-               	fcmp	s0, s0
-               	cset	w0, ne
-               	cbnz	w0,  <L128>
-               	mov	x0, x20
-<L127>:
-               	bl	 <L127>
-               	mov	x19, x0
-               	b	 <L130>
-<L128>:
-               	mov	x0, x20
-               	mov	w1, #0xffff             // =65535
-               	movk	w1, #0xffff, lsl #16
-<L129>:
-               	bl	 <L129>
-               	mov	x19, x0
-<L130>:
+<L58>:
+               	bl	 <L58>
                	fmul	s0, s9, s8
-               	fcmp	s0, s0
-               	cset	w0, ne
-               	cbnz	w0,  <L132>
-               	mov	x0, x19
-<L131>:
-               	bl	 <L131>
-               	mov	x20, x0
-               	b	 <L134>
-<L132>:
-               	mov	x0, x19
-               	mov	w1, #0xffff             // =65535
-               	movk	w1, #0xffff, lsl #16
-<L133>:
-               	bl	 <L133>
-               	mov	x20, x0
-<L134>:
+<L59>:
+               	bl	 <L59>
                	fadd	s0, s10, s10
-               	fcmp	s0, s0
-               	cset	w0, ne
-               	cbnz	w0,  <L136>
-               	mov	x0, x20
-<L135>:
-               	bl	 <L135>
-               	mov	x19, x0
-               	b	 <L138>
-<L136>:
-               	mov	x0, x20
-               	mov	w1, #0xffff             // =65535
-               	movk	w1, #0xffff, lsl #16
-<L137>:
-               	bl	 <L137>
-               	mov	x19, x0
-<L138>:
+<L60>:
+               	bl	 <L60>
                	fmov	s30, #0.50000000
                	fmul	s0, s10, s30
-               	fcmp	s0, s0
-               	cset	w0, ne
-               	cbnz	w0,  <L140>
-               	mov	x0, x19
-<L139>:
-               	bl	 <L139>
-               	mov	x20, x0
-               	b	 <L142>
-<L140>:
-               	mov	x0, x19
-               	mov	w1, #0xffff             // =65535
-               	movk	w1, #0xffff, lsl #16
-<L141>:
-               	bl	 <L141>
-               	mov	x20, x0
-<L142>:
+<L61>:
+               	bl	 <L61>
                	fmov	s30, #0.75000000
                	fmul	s0, s10, s30
-               	fcmp	s0, s0
-               	cset	w0, ne
-               	cbnz	w0,  <L144>
-               	mov	x0, x20
-<L143>:
-               	bl	 <L143>
-               	mov	x19, x0
-               	b	 <L146>
-<L144>:
-               	mov	x0, x20
-               	mov	w1, #0xffff             // =65535
-               	movk	w1, #0xffff, lsl #16
-<L145>:
-               	bl	 <L145>
-               	mov	x19, x0
-<L146>:
+<L62>:
+               	bl	 <L62>
                	mov	w16, #0x4b800000        // =1266679808
                	fmov	s30, w16
                	fmul	s0, s10, s30
-               	fcmp	s0, s0
-               	cset	w0, ne
-               	cbnz	w0,  <L148>
-               	mov	x0, x19
-<L147>:
-               	bl	 <L147>
-               	mov	x20, x0
-               	b	 <L150>
-<L148>:
-               	mov	x0, x19
-               	mov	w1, #0xffff             // =65535
-               	movk	w1, #0xffff, lsl #16
-<L149>:
-               	bl	 <L149>
-               	mov	x20, x0
-<L150>:
+<L63>:
+               	bl	 <L63>
                	fdiv	s0, s10, s9
-               	fcmp	s0, s0
-               	cset	w0, ne
-               	cbnz	w0,  <L152>
-               	mov	x0, x20
-<L151>:
-               	bl	 <L151>
+<L64>:
+               	bl	 <L64>
                	mov	x19, x0
-               	b	 <L154>
-<L152>:
-               	mov	x0, x20
-               	mov	w1, #0xffff             // =65535
-               	movk	w1, #0xffff, lsl #16
-<L153>:
-               	bl	 <L153>
-               	mov	x19, x0
-<L154>:
                	fmov	s31, #5.50000000
                	fmul	s9, s31, s8
                	fmov	s31, #3.00000000
                	fmul	s10, s31, s8
+               	fmov	s30, wzr
+               	fcmp	s10, s30
+               	cset	w0, eq
+               	cbnz	w0,  <L79>
+               	fmov	s30, #2.00000000
+               	fmul	s0, s9, s30
+               	fcmp	s9, s0
+               	cset	w0, eq
+               	cbnz	w0,  <L65>
+               	b	 <L66>
+<L65>:
+               	fmov	s30, wzr
+               	fcmp	s9, s30
+               	cset	w0, ne
+               	cbnz	w0,  <L79>
+<L66>:
+               	fmov	s30, wzr
+               	fcmp	s9, s30
+               	cset	w0, mi
+               	cbnz	w0,  <L67>
+               	fmov	d0, d9
+               	b	 <L68>
+<L67>:
+               	fmov	s31, wzr
+               	fsub	s0, s31, s9
+<L68>:
+               	fmov	s30, wzr
+               	fcmp	s10, s30
+               	cset	w1, mi
+               	cbnz	w1,  <L69>
+               	fmov	d1, d10
+               	b	 <L70>
+<L69>:
+               	fmov	s31, wzr
+               	fsub	s1, s31, s10
+<L70>:
+               	fmov	s30, #2.00000000
+               	fdiv	s2, s0, s30
+               	fmov	d3, d1
+<L71>:
+               	fcmp	s3, s2
+               	cset	w1, ls
+               	cbnz	w1,  <L78>
+               	fmov	d4, d0
+               	fmov	d5, d3
+<L72>:
+               	fcmp	s1, s5
+               	cset	w1, ls
+               	cbnz	w1,  <L75>
+               	cbnz	w0,  <L73>
+               	fmov	d6, d4
+               	b	 <L74>
+<L73>:
+               	fmov	s31, wzr
+               	fsub	s6, s31, s4
+<L74>:
+               	b	 <L80>
+<L75>:
+               	fcmp	s5, s4
+               	cset	w1, ls
+               	cbnz	w1,  <L76>
+               	fmov	d7, d4
+               	b	 <L77>
+<L76>:
+               	fsub	s7, s4, s5
+<L77>:
+               	fmov	s30, #2.00000000
+               	fdiv	s5, s5, s30
+               	fmov	d4, d7
+               	b	 <L72>
+<L78>:
+               	fmov	s30, #2.00000000
+               	fmul	s3, s3, s30
+               	b	 <L71>
+<L79>:
                	fdiv	s0, s9, s10
                	fcvtzs	x0, s0
                	scvtf	s0, x0
                	fmul	s1, s0, s10
-               	fsub	s0, s9, s1
-               	fcmp	s0, s0
+               	fsub	s6, s9, s1
+<L80>:
+               	fcmp	s6, s6
                	cset	w0, ne
-               	cbnz	w0,  <L156>
+               	cbnz	w0,  <L82>
                	mov	x0, x19
-<L155>:
-               	bl	 <L155>
+               	fmov	s0, s6
+<L81>:
+               	bl	 <L81>
                	mov	x20, x0
-               	b	 <L158>
-<L156>:
+               	b	 <L84>
+<L82>:
                	mov	x0, x19
                	mov	w1, #0xffff             // =65535
                	movk	w1, #0xffff, lsl #16
-<L157>:
-               	bl	 <L157>
+<L83>:
+               	bl	 <L83>
                	mov	x20, x0
-<L158>:
+<L84>:
                	fmov	s31, wzr
                	fsub	s0, s31, s9
+               	fmov	s30, wzr
+               	fcmp	s10, s30
+               	cset	w0, eq
+               	cbnz	w0,  <L99>
+               	fmov	s30, #2.00000000
+               	fmul	s1, s0, s30
+               	fcmp	s0, s1
+               	cset	w0, eq
+               	cbnz	w0,  <L85>
+               	b	 <L86>
+<L85>:
+               	fmov	s30, wzr
+               	fcmp	s0, s30
+               	cset	w0, ne
+               	cbnz	w0,  <L99>
+<L86>:
+               	fmov	s30, wzr
+               	fcmp	s0, s30
+               	cset	w0, mi
+               	cbnz	w0,  <L87>
+               	fmov	d1, d0
+               	b	 <L88>
+<L87>:
+               	fmov	s31, wzr
+               	fsub	s1, s31, s0
+<L88>:
+               	fmov	s30, wzr
+               	fcmp	s10, s30
+               	cset	w1, mi
+               	cbnz	w1,  <L89>
+               	fmov	d2, d10
+               	b	 <L90>
+<L89>:
+               	fmov	s31, wzr
+               	fsub	s2, s31, s10
+<L90>:
+               	fmov	s30, #2.00000000
+               	fdiv	s3, s1, s30
+               	fmov	d4, d2
+<L91>:
+               	fcmp	s4, s3
+               	cset	w1, ls
+               	cbnz	w1,  <L98>
+               	fmov	d5, d1
+               	fmov	d6, d4
+<L92>:
+               	fcmp	s2, s6
+               	cset	w1, ls
+               	cbnz	w1,  <L95>
+               	cbnz	w0,  <L93>
+               	fmov	d7, d5
+               	b	 <L94>
+<L93>:
+               	fmov	s31, wzr
+               	fsub	s7, s31, s5
+<L94>:
+               	b	 <L100>
+<L95>:
+               	fcmp	s6, s5
+               	cset	w1, ls
+               	cbnz	w1,  <L96>
+               	fmov	d16, d5
+               	b	 <L97>
+<L96>:
+               	fsub	s16, s5, s6
+<L97>:
+               	fmov	s30, #2.00000000
+               	fdiv	s6, s6, s30
+               	fmov	d5, d16
+               	b	 <L92>
+<L98>:
+               	fmov	s30, #2.00000000
+               	fmul	s4, s4, s30
+               	b	 <L91>
+<L99>:
                	fdiv	s1, s0, s10
                	fcvtzs	x0, s1
                	scvtf	s1, x0
                	fmul	s2, s1, s10
-               	fsub	s1, s0, s2
-               	fcmp	s1, s1
+               	fsub	s7, s0, s2
+<L100>:
+               	fcmp	s7, s7
                	cset	w0, ne
-               	cbnz	w0,  <L160>
+               	cbnz	w0,  <L102>
                	mov	x0, x20
-               	fmov	s0, s1
-<L159>:
-               	bl	 <L159>
+               	fmov	s0, s7
+<L101>:
+               	bl	 <L101>
                	mov	x19, x0
-               	b	 <L162>
-<L160>:
+               	b	 <L104>
+<L102>:
                	mov	x0, x20
                	mov	w1, #0xffff             // =65535
                	movk	w1, #0xffff, lsl #16
-<L161>:
-               	bl	 <L161>
+<L103>:
+               	bl	 <L103>
                	mov	x19, x0
-<L162>:
+<L104>:
                	fmov	s31, wzr
                	fsub	s0, s31, s10
+               	fmov	s30, wzr
+               	fcmp	s0, s30
+               	cset	w0, eq
+               	cbnz	w0,  <L119>
+               	fmov	s30, #2.00000000
+               	fmul	s1, s9, s30
+               	fcmp	s9, s1
+               	cset	w0, eq
+               	cbnz	w0,  <L105>
+               	b	 <L106>
+<L105>:
+               	fmov	s30, wzr
+               	fcmp	s9, s30
+               	cset	w0, ne
+               	cbnz	w0,  <L119>
+<L106>:
+               	fmov	s30, wzr
+               	fcmp	s9, s30
+               	cset	w0, mi
+               	cbnz	w0,  <L107>
+               	fmov	d1, d9
+               	b	 <L108>
+<L107>:
+               	fmov	s31, wzr
+               	fsub	s1, s31, s9
+<L108>:
+               	fmov	s30, wzr
+               	fcmp	s0, s30
+               	cset	w1, mi
+               	cbnz	w1,  <L109>
+               	fmov	d2, d0
+               	b	 <L110>
+<L109>:
+               	fmov	s31, wzr
+               	fsub	s2, s31, s0
+<L110>:
+               	fmov	s30, #2.00000000
+               	fdiv	s3, s1, s30
+               	fmov	d4, d2
+<L111>:
+               	fcmp	s4, s3
+               	cset	w1, ls
+               	cbnz	w1,  <L118>
+               	fmov	d5, d1
+               	fmov	d6, d4
+<L112>:
+               	fcmp	s2, s6
+               	cset	w1, ls
+               	cbnz	w1,  <L115>
+               	cbnz	w0,  <L113>
+               	fmov	d7, d5
+               	b	 <L114>
+<L113>:
+               	fmov	s31, wzr
+               	fsub	s7, s31, s5
+<L114>:
+               	b	 <L120>
+<L115>:
+               	fcmp	s6, s5
+               	cset	w1, ls
+               	cbnz	w1,  <L116>
+               	fmov	d16, d5
+               	b	 <L117>
+<L116>:
+               	fsub	s16, s5, s6
+<L117>:
+               	fmov	s30, #2.00000000
+               	fdiv	s6, s6, s30
+               	fmov	d5, d16
+               	b	 <L112>
+<L118>:
+               	fmov	s30, #2.00000000
+               	fmul	s4, s4, s30
+               	b	 <L111>
+<L119>:
                	fdiv	s1, s9, s0
                	fcvtzs	x0, s1
                	scvtf	s1, x0
                	fmul	s2, s1, s0
-               	fsub	s0, s9, s2
-               	fcmp	s0, s0
+               	fsub	s7, s9, s2
+<L120>:
+               	fcmp	s7, s7
                	cset	w0, ne
-               	cbnz	w0,  <L164>
+               	cbnz	w0,  <L122>
                	mov	x0, x19
-<L163>:
-               	bl	 <L163>
+               	fmov	s0, s7
+<L121>:
+               	bl	 <L121>
                	mov	x20, x0
-               	b	 <L166>
-<L164>:
+               	b	 <L124>
+<L122>:
                	mov	x0, x19
                	mov	w1, #0xffff             // =65535
                	movk	w1, #0xffff, lsl #16
-<L165>:
-               	bl	 <L165>
+<L123>:
+               	bl	 <L123>
                	mov	x20, x0
-<L166>:
+<L124>:
                	fmov	s31, wzr
                	fsub	s0, s31, s9
                	fmov	s31, wzr
                	fsub	s1, s31, s10
+               	fmov	s30, wzr
+               	fcmp	s1, s30
+               	cset	w0, eq
+               	cbnz	w0,  <L139>
+               	fmov	s30, #2.00000000
+               	fmul	s2, s0, s30
+               	fcmp	s0, s2
+               	cset	w0, eq
+               	cbnz	w0,  <L125>
+               	b	 <L126>
+<L125>:
+               	fmov	s30, wzr
+               	fcmp	s0, s30
+               	cset	w0, ne
+               	cbnz	w0,  <L139>
+<L126>:
+               	fmov	s30, wzr
+               	fcmp	s0, s30
+               	cset	w0, mi
+               	cbnz	w0,  <L127>
+               	fmov	d2, d0
+               	b	 <L128>
+<L127>:
+               	fmov	s31, wzr
+               	fsub	s2, s31, s0
+<L128>:
+               	fmov	s30, wzr
+               	fcmp	s1, s30
+               	cset	w1, mi
+               	cbnz	w1,  <L129>
+               	fmov	d3, d1
+               	b	 <L130>
+<L129>:
+               	fmov	s31, wzr
+               	fsub	s3, s31, s1
+<L130>:
+               	fmov	s30, #2.00000000
+               	fdiv	s4, s2, s30
+               	fmov	d5, d3
+<L131>:
+               	fcmp	s5, s4
+               	cset	w1, ls
+               	cbnz	w1,  <L138>
+               	fmov	d6, d2
+               	fmov	d7, d5
+<L132>:
+               	fcmp	s3, s7
+               	cset	w1, ls
+               	cbnz	w1,  <L135>
+               	cbnz	w0,  <L133>
+               	fmov	d16, d6
+               	b	 <L134>
+<L133>:
+               	fmov	s31, wzr
+               	fsub	s16, s31, s6
+<L134>:
+               	b	 <L140>
+<L135>:
+               	fcmp	s7, s6
+               	cset	w1, ls
+               	cbnz	w1,  <L136>
+               	fmov	d17, d6
+               	b	 <L137>
+<L136>:
+               	fsub	s17, s6, s7
+<L137>:
+               	fmov	s30, #2.00000000
+               	fdiv	s7, s7, s30
+               	fmov	d6, d17
+               	b	 <L132>
+<L138>:
+               	fmov	s30, #2.00000000
+               	fmul	s5, s5, s30
+               	b	 <L131>
+<L139>:
                	fdiv	s2, s0, s1
                	fcvtzs	x0, s2
                	scvtf	s2, x0
                	fmul	s3, s2, s1
-               	fsub	s1, s0, s3
-               	fcmp	s1, s1
+               	fsub	s16, s0, s3
+<L140>:
+               	fcmp	s16, s16
                	cset	w0, ne
-               	cbnz	w0,  <L168>
+               	cbnz	w0,  <L142>
                	mov	x0, x20
-               	fmov	s0, s1
-<L167>:
-               	bl	 <L167>
+               	fmov	s0, s16
+<L141>:
+               	bl	 <L141>
                	mov	x19, x0
-               	b	 <L170>
-<L168>:
+               	b	 <L144>
+<L142>:
                	mov	x0, x20
                	mov	w1, #0xffff             // =65535
                	movk	w1, #0xffff, lsl #16
-<L169>:
-               	bl	 <L169>
+<L143>:
+               	bl	 <L143>
                	mov	x19, x0
-<L170>:
+<L144>:
                	fmov	s31, #7.00000000
                	fmul	s0, s31, s8
+               	fmov	s31, #0.50000000
+               	fmov	s30, wzr
+               	fcmp	s31, s30
+               	cset	w0, eq
+               	cbnz	w0,  <L159>
+               	fmov	s30, #2.00000000
+               	fmul	s1, s0, s30
+               	fcmp	s0, s1
+               	cset	w0, eq
+               	cbnz	w0,  <L145>
+               	b	 <L146>
+<L145>:
+               	fmov	s30, wzr
+               	fcmp	s0, s30
+               	cset	w0, ne
+               	cbnz	w0,  <L159>
+<L146>:
+               	fmov	s30, wzr
+               	fcmp	s0, s30
+               	cset	w0, mi
+               	cbnz	w0,  <L147>
+               	fmov	d1, d0
+               	b	 <L148>
+<L147>:
+               	fmov	s31, wzr
+               	fsub	s1, s31, s0
+<L148>:
+               	fmov	s31, #0.50000000
+               	fmov	s30, wzr
+               	fcmp	s31, s30
+               	cset	w1, mi
+               	cbnz	w1,  <L149>
+               	fmov	s2, #0.50000000
+               	b	 <L150>
+<L149>:
+               	fmov	s31, wzr
+               	fmov	s30, #0.50000000
+               	fsub	s2, s31, s30
+<L150>:
+               	fmov	s30, #2.00000000
+               	fdiv	s3, s1, s30
+               	fmov	d4, d2
+<L151>:
+               	fcmp	s4, s3
+               	cset	w1, ls
+               	cbnz	w1,  <L158>
+               	fmov	d5, d1
+               	fmov	d6, d4
+<L152>:
+               	fcmp	s2, s6
+               	cset	w1, ls
+               	cbnz	w1,  <L155>
+               	cbnz	w0,  <L153>
+               	fmov	d7, d5
+               	b	 <L154>
+<L153>:
+               	fmov	s31, wzr
+               	fsub	s7, s31, s5
+<L154>:
+               	b	 <L160>
+<L155>:
+               	fcmp	s6, s5
+               	cset	w1, ls
+               	cbnz	w1,  <L156>
+               	fmov	d16, d5
+               	b	 <L157>
+<L156>:
+               	fsub	s16, s5, s6
+<L157>:
+               	fmov	s30, #2.00000000
+               	fdiv	s6, s6, s30
+               	fmov	d5, d16
+               	b	 <L152>
+<L158>:
+               	fmov	s30, #2.00000000
+               	fmul	s4, s4, s30
+               	b	 <L151>
+<L159>:
                	fmov	s30, #0.50000000
                	fdiv	s1, s0, s30
                	fcvtzs	x0, s1
                	scvtf	s1, x0
                	fmov	s30, #0.50000000
                	fmul	s2, s1, s30
-               	fsub	s1, s0, s2
-               	fcmp	s1, s1
+               	fsub	s7, s0, s2
+<L160>:
+               	fcmp	s7, s7
                	cset	w0, ne
-               	cbnz	w0,  <L172>
+               	cbnz	w0,  <L162>
                	mov	x0, x19
-               	fmov	s0, s1
-<L171>:
-               	bl	 <L171>
+               	fmov	s0, s7
+<L161>:
+               	bl	 <L161>
                	mov	x20, x0
-               	b	 <L174>
-<L172>:
+               	b	 <L164>
+<L162>:
                	mov	x0, x19
                	mov	w1, #0xffff             // =65535
                	movk	w1, #0xffff, lsl #16
-<L173>:
-               	bl	 <L173>
+<L163>:
+               	bl	 <L163>
                	mov	x20, x0
+<L164>:
+               	fmov	s30, wzr
+               	fcmp	s10, s30
+               	cset	w0, eq
+               	cbnz	w0,  <L179>
+               	fmov	s30, #2.00000000
+               	fmul	s0, s8, s30
+               	fcmp	s8, s0
+               	cset	w0, eq
+               	cbnz	w0,  <L165>
+               	b	 <L166>
+<L165>:
+               	fmov	s30, wzr
+               	fcmp	s8, s30
+               	cset	w0, ne
+               	cbnz	w0,  <L179>
+<L166>:
+               	fmov	s30, wzr
+               	fcmp	s8, s30
+               	cset	w0, mi
+               	cbnz	w0,  <L167>
+               	fmov	d0, d8
+               	b	 <L168>
+<L167>:
+               	fmov	s31, wzr
+               	fsub	s0, s31, s8
+<L168>:
+               	fmov	s30, wzr
+               	fcmp	s10, s30
+               	cset	w1, mi
+               	cbnz	w1,  <L169>
+               	fmov	d1, d10
+               	b	 <L170>
+<L169>:
+               	fmov	s31, wzr
+               	fsub	s1, s31, s10
+<L170>:
+               	fmov	s30, #2.00000000
+               	fdiv	s2, s0, s30
+               	fmov	d3, d1
+<L171>:
+               	fcmp	s3, s2
+               	cset	w1, ls
+               	cbnz	w1,  <L178>
+               	fmov	d4, d0
+               	fmov	d5, d3
+<L172>:
+               	fcmp	s1, s5
+               	cset	w1, ls
+               	cbnz	w1,  <L175>
+               	cbnz	w0,  <L173>
+               	fmov	d6, d4
+               	b	 <L174>
+<L173>:
+               	fmov	s31, wzr
+               	fsub	s6, s31, s4
 <L174>:
+               	b	 <L180>
+<L175>:
+               	fcmp	s5, s4
+               	cset	w1, ls
+               	cbnz	w1,  <L176>
+               	fmov	d7, d4
+               	b	 <L177>
+<L176>:
+               	fsub	s7, s4, s5
+<L177>:
+               	fmov	s30, #2.00000000
+               	fdiv	s5, s5, s30
+               	fmov	d4, d7
+               	b	 <L172>
+<L178>:
+               	fmov	s30, #2.00000000
+               	fmul	s3, s3, s30
+               	b	 <L171>
+<L179>:
                	fdiv	s0, s8, s10
                	fcvtzs	x0, s0
                	scvtf	s0, x0
                	fmul	s1, s0, s10
-               	fsub	s0, s8, s1
-               	fcmp	s0, s0
+               	fsub	s6, s8, s1
+<L180>:
+               	fcmp	s6, s6
                	cset	w0, ne
-               	cbnz	w0,  <L176>
+               	cbnz	w0,  <L182>
                	mov	x0, x20
-<L175>:
-               	bl	 <L175>
+               	fmov	s0, s6
+<L181>:
+               	bl	 <L181>
                	mov	x19, x0
-               	b	 <L178>
-<L176>:
+               	b	 <L184>
+<L182>:
                	mov	x0, x20
                	mov	w1, #0xffff             // =65535
                	movk	w1, #0xffff, lsl #16
-<L177>:
-               	bl	 <L177>
+<L183>:
+               	bl	 <L183>
                	mov	x19, x0
-<L178>:
+<L184>:
+               	fmov	s30, wzr
+               	fcmp	s10, s30
+               	cset	w0, eq
+               	cbnz	w0,  <L199>
+               	fmov	s30, #2.00000000
+               	fmul	s0, s10, s30
+               	fcmp	s10, s0
+               	cset	w0, eq
+               	cbnz	w0,  <L185>
+               	b	 <L186>
+<L185>:
+               	fmov	s30, wzr
+               	fcmp	s10, s30
+               	cset	w0, ne
+               	cbnz	w0,  <L199>
+<L186>:
+               	fmov	s30, wzr
+               	fcmp	s10, s30
+               	cset	w0, mi
+               	cbnz	w0,  <L187>
+               	fmov	d0, d10
+               	b	 <L188>
+<L187>:
+               	fmov	s31, wzr
+               	fsub	s0, s31, s10
+<L188>:
+               	fmov	s30, wzr
+               	fcmp	s10, s30
+               	cset	w1, mi
+               	cbnz	w1,  <L189>
+               	fmov	d1, d10
+               	b	 <L190>
+<L189>:
+               	fmov	s31, wzr
+               	fsub	s1, s31, s10
+<L190>:
+               	fmov	s30, #2.00000000
+               	fdiv	s2, s0, s30
+               	fmov	d3, d1
+<L191>:
+               	fcmp	s3, s2
+               	cset	w1, ls
+               	cbnz	w1,  <L198>
+               	fmov	d4, d0
+               	fmov	d5, d3
+<L192>:
+               	fcmp	s1, s5
+               	cset	w1, ls
+               	cbnz	w1,  <L195>
+               	cbnz	w0,  <L193>
+               	fmov	d6, d4
+               	b	 <L194>
+<L193>:
+               	fmov	s31, wzr
+               	fsub	s6, s31, s4
+<L194>:
+               	b	 <L200>
+<L195>:
+               	fcmp	s5, s4
+               	cset	w1, ls
+               	cbnz	w1,  <L196>
+               	fmov	d7, d4
+               	b	 <L197>
+<L196>:
+               	fsub	s7, s4, s5
+<L197>:
+               	fmov	s30, #2.00000000
+               	fdiv	s5, s5, s30
+               	fmov	d4, d7
+               	b	 <L192>
+<L198>:
+               	fmov	s30, #2.00000000
+               	fmul	s3, s3, s30
+               	b	 <L191>
+<L199>:
                	fdiv	s0, s10, s10
                	fcvtzs	x0, s0
                	scvtf	s0, x0
                	fmul	s1, s0, s10
-               	fsub	s0, s10, s1
-               	fcmp	s0, s0
+               	fsub	s6, s10, s1
+<L200>:
+               	fcmp	s6, s6
                	cset	w0, ne
-               	cbnz	w0,  <L180>
+               	cbnz	w0,  <L202>
                	mov	x0, x19
-<L179>:
-               	bl	 <L179>
+               	fmov	s0, s6
+<L201>:
+               	bl	 <L201>
                	mov	x20, x0
-               	b	 <L182>
-<L180>:
+               	b	 <L204>
+<L202>:
                	mov	x0, x19
                	mov	w1, #0xffff             // =65535
                	movk	w1, #0xffff, lsl #16
-<L181>:
-               	bl	 <L181>
+<L203>:
+               	bl	 <L203>
                	mov	x20, x0
-<L182>:
+<L204>:
                	mov	w16, #0x49800000        // =1233125376
                	fmov	s31, w16
                	fmul	s0, s31, s8
+               	fmov	s30, wzr
+               	fcmp	s10, s30
+               	cset	w0, eq
+               	cbnz	w0,  <L219>
+               	fmov	s30, #2.00000000
+               	fmul	s1, s0, s30
+               	fcmp	s0, s1
+               	cset	w0, eq
+               	cbnz	w0,  <L205>
+               	b	 <L206>
+<L205>:
+               	fmov	s30, wzr
+               	fcmp	s0, s30
+               	cset	w0, ne
+               	cbnz	w0,  <L219>
+<L206>:
+               	fmov	s30, wzr
+               	fcmp	s0, s30
+               	cset	w0, mi
+               	cbnz	w0,  <L207>
+               	fmov	d1, d0
+               	b	 <L208>
+<L207>:
+               	fmov	s31, wzr
+               	fsub	s1, s31, s0
+<L208>:
+               	fmov	s30, wzr
+               	fcmp	s10, s30
+               	cset	w1, mi
+               	cbnz	w1,  <L209>
+               	fmov	d2, d10
+               	b	 <L210>
+<L209>:
+               	fmov	s31, wzr
+               	fsub	s2, s31, s10
+<L210>:
+               	fmov	s30, #2.00000000
+               	fdiv	s3, s1, s30
+               	fmov	d4, d2
+<L211>:
+               	fcmp	s4, s3
+               	cset	w1, ls
+               	cbnz	w1,  <L218>
+               	fmov	d5, d1
+               	fmov	d6, d4
+<L212>:
+               	fcmp	s2, s6
+               	cset	w1, ls
+               	cbnz	w1,  <L215>
+               	cbnz	w0,  <L213>
+               	fmov	d7, d5
+               	b	 <L214>
+<L213>:
+               	fmov	s31, wzr
+               	fsub	s7, s31, s5
+<L214>:
+               	b	 <L220>
+<L215>:
+               	fcmp	s6, s5
+               	cset	w1, ls
+               	cbnz	w1,  <L216>
+               	fmov	d16, d5
+               	b	 <L217>
+<L216>:
+               	fsub	s16, s5, s6
+<L217>:
+               	fmov	s30, #2.00000000
+               	fdiv	s6, s6, s30
+               	fmov	d5, d16
+               	b	 <L212>
+<L218>:
+               	fmov	s30, #2.00000000
+               	fmul	s4, s4, s30
+               	b	 <L211>
+<L219>:
                	fdiv	s1, s0, s10
                	fcvtzs	x0, s1
                	scvtf	s1, x0
                	fmul	s2, s1, s10
-               	fsub	s1, s0, s2
-               	fcmp	s1, s1
+               	fsub	s7, s0, s2
+<L220>:
+               	fcmp	s7, s7
                	cset	w0, ne
-               	cbnz	w0,  <L184>
+               	cbnz	w0,  <L222>
                	mov	x0, x20
-               	fmov	s0, s1
-<L183>:
-               	bl	 <L183>
+               	fmov	s0, s7
+<L221>:
+               	bl	 <L221>
                	mov	x19, x0
-               	b	 <L186>
-<L184>:
+               	b	 <L224>
+<L222>:
                	mov	x0, x20
                	mov	w1, #0xffff             // =65535
                	movk	w1, #0xffff, lsl #16
-<L185>:
-               	bl	 <L185>
+<L223>:
+               	bl	 <L223>
                	mov	x19, x0
-<L186>:
+<L224>:
                	mov	x0, x19
                	ldp	d8, d9, [x29, #-0x30]
                	ldp	d10, d11, [x29, #-0x40]

--- a/test/golden/aarch64-linux/float/arith_f64.dis
+++ b/test/golden/aarch64-linux/float/arith_f64.dis
@@ -132,388 +132,113 @@ Disassembly of section .text:
                	mov	x20, x0
 <L16>:
                	fdiv	d0, d9, d10
-               	fcmp	d0, d0
-               	cset	w0, ne
-               	cbnz	w0,  <L18>
                	mov	x0, x20
 <L17>:
                	bl	 <L17>
-               	mov	x21, x0
-               	b	 <L20>
+               	fdiv	d0, d10, d9
 <L18>:
-               	mov	x0, x20
-               	mov	x1, #0xffff             // =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
+               	bl	 <L18>
+               	fneg	d0, d9
 <L19>:
                	bl	 <L19>
-               	mov	x21, x0
+               	fmov	d31, xzr
+               	fsub	d10, d31, d9
+               	fmov	d0, d10
 <L20>:
-               	fdiv	d0, d10, d9
-               	fcmp	d0, d0
-               	cset	w0, ne
-               	cbnz	w0,  <L22>
-               	mov	x0, x21
+               	bl	 <L20>
+               	fsub	d0, d9, d9
 <L21>:
                	bl	 <L21>
-               	mov	x20, x0
-               	b	 <L24>
+               	fadd	d0, d10, d9
 <L22>:
-               	mov	x0, x21
-               	mov	x1, #0xffff             // =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L23>:
-               	bl	 <L23>
-               	mov	x20, x0
-<L24>:
-               	fneg	d0, d9
-               	fcmp	d0, d0
-               	cset	w0, ne
-               	cbnz	w0,  <L26>
-               	mov	x0, x20
-<L25>:
-               	bl	 <L25>
-               	mov	x21, x0
-               	b	 <L28>
-<L26>:
-               	mov	x0, x20
-               	mov	x1, #0xffff             // =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L27>:
-               	bl	 <L27>
-               	mov	x21, x0
-<L28>:
-               	fmov	d31, xzr
-               	fsub	d0, d31, d9
-               	fcmp	d0, d0
-               	cset	w0, ne
-               	cbnz	w0,  <L30>
-               	mov	x0, x21
-<L29>:
-               	bl	 <L29>
-               	mov	x20, x0
-               	b	 <L32>
-<L30>:
-               	mov	x0, x21
-               	mov	x1, #0xffff             // =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L31>:
-               	bl	 <L31>
-               	mov	x20, x0
-<L32>:
-               	fsub	d0, d9, d9
-               	fcmp	d0, d0
-               	cset	w0, ne
-               	cbnz	w0,  <L34>
-               	mov	x0, x20
-<L33>:
-               	bl	 <L33>
-               	mov	x21, x0
-               	b	 <L36>
-<L34>:
-               	mov	x0, x20
-               	mov	x1, #0xffff             // =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L35>:
-               	bl	 <L35>
-               	mov	x21, x0
-<L36>:
-               	fmov	d31, xzr
-               	fsub	d0, d31, d9
-               	fadd	d1, d0, d9
-               	fcmp	d1, d1
-               	cset	w0, ne
-               	cbnz	w0,  <L38>
-               	mov	x0, x21
-               	fmov	d0, d1
-<L37>:
-               	bl	 <L37>
-               	mov	x20, x0
-               	b	 <L40>
-<L38>:
-               	mov	x0, x21
-               	mov	x1, #0xffff             // =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L39>:
-               	bl	 <L39>
-               	mov	x20, x0
-<L40>:
+               	bl	 <L22>
                	fmov	d31, #3.00000000
                	fmul	d9, d31, d8
                	fdiv	d10, d8, d9
-               	fcmp	d10, d10
-               	cset	w0, ne
-               	cbnz	w0,  <L42>
-               	mov	x0, x20
                	fmov	d0, d10
-<L41>:
-               	bl	 <L41>
-               	mov	x21, x0
-               	b	 <L44>
-<L42>:
-               	mov	x0, x20
-               	mov	x1, #0xffff             // =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L43>:
-               	bl	 <L43>
-               	mov	x21, x0
-<L44>:
+<L23>:
+               	bl	 <L23>
                	fmul	d0, d10, d9
-               	fcmp	d0, d0
-               	cset	w0, ne
-               	cbnz	w0,  <L46>
-               	mov	x0, x21
-<L45>:
-               	bl	 <L45>
-               	mov	x20, x0
-               	b	 <L48>
-<L46>:
-               	mov	x0, x21
-               	mov	x1, #0xffff             // =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L47>:
-               	bl	 <L47>
-               	mov	x20, x0
-<L48>:
+<L24>:
+               	bl	 <L24>
                	fsub	d0, d8, d10
                	fsub	d1, d0, d10
                	fsub	d0, d1, d10
-               	fcmp	d0, d0
-               	cset	w0, ne
-               	cbnz	w0,  <L50>
-               	mov	x0, x20
-<L49>:
-               	bl	 <L49>
-               	mov	x21, x0
-               	b	 <L52>
-<L50>:
-               	mov	x0, x20
-               	mov	x1, #0xffff             // =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L51>:
-               	bl	 <L51>
-               	mov	x21, x0
-<L52>:
+<L25>:
+               	bl	 <L25>
                	adrp	x16, 0x0 <corpus.cases.float.arith_f64.opaque_f64>
                	ldr	d30, [x16]
                	fdiv	d0, d8, d30
-               	fcmp	d0, d0
-               	cset	w0, ne
-               	cbnz	w0,  <L54>
-               	mov	x0, x21
-<L53>:
-               	bl	 <L53>
-               	mov	x20, x0
-               	b	 <L56>
-<L54>:
-               	mov	x0, x21
-               	mov	x1, #0xffff             // =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L55>:
-               	bl	 <L55>
-               	mov	x20, x0
-<L56>:
+<L26>:
+               	bl	 <L26>
                	adrp	x16, 0x0 <corpus.cases.float.arith_f64.opaque_f64>
                	ldr	d30, [x16]
                	fdiv	d0, d8, d30
-               	fcmp	d0, d0
-               	cset	w0, ne
-               	cbnz	w0,  <L58>
-               	mov	x0, x20
-<L57>:
-               	bl	 <L57>
-               	mov	x21, x0
-               	b	 <L60>
-<L58>:
-               	mov	x0, x20
-               	mov	x1, #0xffff             // =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L59>:
-               	bl	 <L59>
-               	mov	x21, x0
-<L60>:
+<L27>:
+               	bl	 <L27>
                	adrp	x16, 0x0 <corpus.cases.float.arith_f64.opaque_f64>
                	ldr	d31, [x16]
                	fdiv	d0, d31, d9
-               	fcmp	d0, d0
-               	cset	w0, ne
-               	cbnz	w0,  <L62>
-               	mov	x0, x21
-<L61>:
-               	bl	 <L61>
-               	mov	x20, x0
-               	b	 <L64>
-<L62>:
-               	mov	x0, x21
-               	mov	x1, #0xffff             // =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L63>:
-               	bl	 <L63>
-               	mov	x20, x0
-<L64>:
+<L28>:
+               	bl	 <L28>
                	mov	x16, #0x4340000000000000 // =4845873199050653696
                	fmov	d31, x16
                	fmul	d9, d31, d8
-               	fadd	d0, d9, d8
-               	fcmp	d0, d0
-               	cset	w0, ne
-               	cbnz	w0,  <L66>
-               	mov	x0, x20
-<L65>:
-               	bl	 <L65>
-               	mov	x21, x0
-               	b	 <L68>
-<L66>:
-               	mov	x0, x20
-               	mov	x1, #0xffff             // =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L67>:
-               	bl	 <L67>
-               	mov	x21, x0
-<L68>:
-               	fadd	d0, d9, d8
-               	fadd	d1, d0, d8
-               	fcmp	d1, d1
-               	cset	w0, ne
-               	cbnz	w0,  <L70>
-               	mov	x0, x21
-               	fmov	d0, d1
-<L69>:
-               	bl	 <L69>
-               	mov	x20, x0
-               	b	 <L72>
-<L70>:
-               	mov	x0, x21
-               	mov	x1, #0xffff             // =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L71>:
-               	bl	 <L71>
-               	mov	x20, x0
-<L72>:
+               	fadd	d11, d9, d8
+               	fmov	d0, d11
+<L29>:
+               	bl	 <L29>
+               	fadd	d0, d11, d8
+<L30>:
+               	bl	 <L30>
                	fadd	d0, d8, d8
                	fadd	d1, d9, d0
-               	fcmp	d1, d1
-               	cset	w0, ne
-               	cbnz	w0,  <L74>
-               	mov	x0, x20
                	fmov	d0, d1
-<L73>:
-               	bl	 <L73>
-               	mov	x21, x0
-               	b	 <L76>
-<L74>:
-               	mov	x0, x20
-               	mov	x1, #0xffff             // =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L75>:
-               	bl	 <L75>
-               	mov	x21, x0
-<L76>:
+<L31>:
+               	bl	 <L31>
                	fsub	d0, d9, d8
-               	fcmp	d0, d0
-               	cset	w0, ne
-               	cbnz	w0,  <L78>
-               	mov	x0, x21
-<L77>:
-               	bl	 <L77>
-               	mov	x20, x0
-               	b	 <L80>
-<L78>:
-               	mov	x0, x21
-               	mov	x1, #0xffff             // =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L79>:
-               	bl	 <L79>
-               	mov	x20, x0
-<L80>:
-               	fadd	d0, d9, d8
-               	fsub	d1, d0, d9
-               	fcmp	d1, d1
-               	cset	w0, ne
-               	cbnz	w0,  <L82>
-               	mov	x0, x20
-               	fmov	d0, d1
-<L81>:
-               	bl	 <L81>
-               	mov	x21, x0
-               	b	 <L84>
-<L82>:
-               	mov	x0, x20
-               	mov	x1, #0xffff             // =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L83>:
-               	bl	 <L83>
-               	mov	x21, x0
-<L84>:
+<L32>:
+               	bl	 <L32>
+               	fsub	d0, d11, d9
+<L33>:
+               	bl	 <L33>
                	fmov	d31, xzr
                	fmul	d0, d31, d8
+               	mov	x20, x0
                	fmov	d9, d0
-               	mov	x20, #0x0               // =0
-               	cmp	x20, #0x18
-               	b.lo	 <L85>
-               	b	 <L90>
-<L85>:
+               	mov	x21, #0x0               // =0
+               	cmp	x21, #0x18
+               	b.lo	 <L34>
+               	b	 <L39>
+<L34>:
                	fadd	d0, d9, d10
                	fmov	d30, #1.50000000
                	fmul	d11, d0, d30
                	fcmp	d11, d11
                	cset	w0, ne
-               	cbnz	w0,  <L87>
-               	mov	x0, x21
+               	cbnz	w0,  <L36>
+               	mov	x0, x20
                	fmov	d0, d11
-<L86>:
-               	bl	 <L86>
+<L35>:
+               	bl	 <L35>
                	mov	x22, x0
-               	b	 <L89>
-<L87>:
-               	mov	x0, x21
+               	b	 <L38>
+<L36>:
+               	mov	x0, x20
                	mov	x1, #0xffff             // =65535
                	movk	x1, #0xffff, lsl #16
                	movk	x1, #0xffff, lsl #32
                	movk	x1, #0xffff, lsl #48
-<L88>:
-               	bl	 <L88>
+<L37>:
+               	bl	 <L37>
                	mov	x22, x0
-<L89>:
-               	add	x20, x20, #0x1
-               	mov	x21, x22
+<L38>:
+               	add	x21, x21, #0x1
+               	mov	x20, x22
                	fmov	d9, d11
-               	cmp	x20, #0x18
-               	b.lo	 <L85>
-<L90>:
+               	cmp	x21, #0x18
+               	b.lo	 <L34>
+<L39>:
                	mov	x17, #0xffff            // =65535
                	movk	x17, #0xffff, lsl #16
                	movk	x17, #0xffff, lsl #32
@@ -522,533 +247,924 @@ Disassembly of section .text:
                	fmov	d9, x0
                	fcmp	d9, d9
                	cset	w0, ne
-               	cbnz	w0,  <L92>
-               	mov	x0, x21
+               	cbnz	w0,  <L41>
+               	mov	x0, x20
                	fmov	d0, d9
-<L91>:
-               	bl	 <L91>
-               	mov	x20, x0
-               	b	 <L94>
-<L92>:
-               	mov	x0, x21
+<L40>:
+               	bl	 <L40>
+               	mov	x21, x0
+               	b	 <L43>
+<L41>:
+               	mov	x0, x20
                	mov	x1, #0xffff             // =65535
                	movk	x1, #0xffff, lsl #16
                	movk	x1, #0xffff, lsl #32
                	movk	x1, #0xffff, lsl #48
-<L93>:
-               	bl	 <L93>
-               	mov	x20, x0
-<L94>:
+<L42>:
+               	bl	 <L42>
+               	mov	x21, x0
+<L43>:
                	fmov	d30, #2.00000000
                	fdiv	d0, d9, d30
                	fcmp	d0, d0
                	cset	w0, ne
-               	cbnz	w0,  <L96>
-               	mov	x0, x20
-<L95>:
-               	bl	 <L95>
-               	mov	x21, x0
-               	b	 <L98>
-<L96>:
-               	mov	x0, x20
+               	cbnz	w0,  <L45>
+               	mov	x0, x21
+<L44>:
+               	bl	 <L44>
+               	mov	x20, x0
+               	b	 <L47>
+<L45>:
+               	mov	x0, x21
                	mov	x1, #0xffff             // =65535
                	movk	x1, #0xffff, lsl #16
                	movk	x1, #0xffff, lsl #32
                	movk	x1, #0xffff, lsl #48
-<L97>:
-               	bl	 <L97>
-               	mov	x21, x0
-<L98>:
+<L46>:
+               	bl	 <L46>
+               	mov	x20, x0
+<L47>:
                	fadd	d0, d9, d9
                	fcmp	d0, d0
                	cset	w0, ne
-               	cbnz	w0,  <L100>
-               	mov	x0, x21
-<L99>:
-               	bl	 <L99>
-               	mov	x20, x0
-               	b	 <L102>
-<L100>:
-               	mov	x0, x21
-               	mov	x1, #0xffff             // =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L101>:
-               	bl	 <L101>
-               	mov	x20, x0
-<L102>:
-               	fmov	d30, #2.00000000
-               	fmul	d0, d9, d30
-               	fcmp	d0, d0
-               	cset	w0, ne
-               	cbnz	w0,  <L104>
+               	cbnz	w0,  <L49>
                	mov	x0, x20
-<L103>:
-               	bl	 <L103>
+<L48>:
+               	bl	 <L48>
                	mov	x21, x0
-               	b	 <L106>
-<L104>:
+               	b	 <L51>
+<L49>:
                	mov	x0, x20
                	mov	x1, #0xffff             // =65535
                	movk	x1, #0xffff, lsl #16
                	movk	x1, #0xffff, lsl #32
                	movk	x1, #0xffff, lsl #48
-<L105>:
-               	bl	 <L105>
+<L50>:
+               	bl	 <L50>
                	mov	x21, x0
-<L106>:
+<L51>:
                	fmov	d30, #2.00000000
-               	fmul	d0, d9, d30
+               	fmul	d10, d9, d30
+               	mov	x0, x21
+               	fmov	d0, d10
+<L52>:
+               	bl	 <L52>
                	fmov	d31, xzr
-               	fsub	d1, d31, d0
-               	fcmp	d1, d1
-               	cset	w0, ne
-               	cbnz	w0,  <L108>
-               	mov	x0, x21
-               	fmov	d0, d1
-<L107>:
-               	bl	 <L107>
-               	mov	x20, x0
-               	b	 <L110>
-<L108>:
-               	mov	x0, x21
-               	mov	x1, #0xffff             // =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L109>:
-               	bl	 <L109>
-               	mov	x20, x0
-<L110>:
+               	fsub	d0, d31, d10
+<L53>:
+               	bl	 <L53>
                	fmul	d0, d9, d9
-               	fcmp	d0, d0
-               	cset	w0, ne
-               	cbnz	w0,  <L112>
-               	mov	x0, x20
-<L111>:
-               	bl	 <L111>
-               	mov	x21, x0
-               	b	 <L114>
-<L112>:
-               	mov	x0, x20
-               	mov	x1, #0xffff             // =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L113>:
-               	bl	 <L113>
-               	mov	x21, x0
-<L114>:
+<L54>:
+               	bl	 <L54>
                	fsub	d0, d9, d9
-               	fcmp	d0, d0
-               	cset	w0, ne
-               	cbnz	w0,  <L116>
-               	mov	x0, x21
-<L115>:
-               	bl	 <L115>
-               	mov	x20, x0
-               	b	 <L118>
-<L116>:
-               	mov	x0, x21
-               	mov	x1, #0xffff             // =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L117>:
-               	bl	 <L117>
-               	mov	x20, x0
-<L118>:
+<L55>:
+               	bl	 <L55>
                	mov	x17, #0x10000000000000  // =4503599627370496
-               	add	x0, x17, x19
-               	fmov	d9, x0
+               	add	x1, x17, x19
+               	fmov	d9, x1
                	mov	x17, #0x1               // =1
-               	add	x0, x17, x19
-               	fmov	d10, x0
+               	add	x1, x17, x19
+               	fmov	d10, x1
                	fmov	d30, #0.50000000
                	fmul	d0, d9, d30
-               	fcmp	d0, d0
-               	cset	w0, ne
-               	cbnz	w0,  <L120>
-               	mov	x0, x20
-<L119>:
-               	bl	 <L119>
-               	mov	x19, x0
-               	b	 <L122>
-<L120>:
-               	mov	x0, x20
-               	mov	x1, #0xffff             // =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L121>:
-               	bl	 <L121>
-               	mov	x19, x0
-<L122>:
+<L56>:
+               	bl	 <L56>
                	fmov	d30, #2.00000000
                	fdiv	d0, d9, d30
-               	fcmp	d0, d0
-               	cset	w0, ne
-               	cbnz	w0,  <L124>
-               	mov	x0, x19
-<L123>:
-               	bl	 <L123>
-               	mov	x20, x0
-               	b	 <L126>
-<L124>:
-               	mov	x0, x19
-               	mov	x1, #0xffff             // =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L125>:
-               	bl	 <L125>
-               	mov	x20, x0
-<L126>:
+<L57>:
+               	bl	 <L57>
                	fsub	d0, d9, d10
-               	fcmp	d0, d0
-               	cset	w0, ne
-               	cbnz	w0,  <L128>
-               	mov	x0, x20
-<L127>:
-               	bl	 <L127>
-               	mov	x19, x0
-               	b	 <L130>
-<L128>:
-               	mov	x0, x20
-               	mov	x1, #0xffff             // =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L129>:
-               	bl	 <L129>
-               	mov	x19, x0
-<L130>:
+<L58>:
+               	bl	 <L58>
                	fmul	d0, d9, d8
-               	fcmp	d0, d0
-               	cset	w0, ne
-               	cbnz	w0,  <L132>
-               	mov	x0, x19
-<L131>:
-               	bl	 <L131>
-               	mov	x20, x0
-               	b	 <L134>
-<L132>:
-               	mov	x0, x19
-               	mov	x1, #0xffff             // =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L133>:
-               	bl	 <L133>
-               	mov	x20, x0
-<L134>:
+<L59>:
+               	bl	 <L59>
                	fadd	d0, d10, d10
-               	fcmp	d0, d0
-               	cset	w0, ne
-               	cbnz	w0,  <L136>
-               	mov	x0, x20
-<L135>:
-               	bl	 <L135>
-               	mov	x19, x0
-               	b	 <L138>
-<L136>:
-               	mov	x0, x20
-               	mov	x1, #0xffff             // =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L137>:
-               	bl	 <L137>
-               	mov	x19, x0
-<L138>:
+<L60>:
+               	bl	 <L60>
                	fmov	d30, #0.50000000
                	fmul	d0, d10, d30
-               	fcmp	d0, d0
-               	cset	w0, ne
-               	cbnz	w0,  <L140>
-               	mov	x0, x19
-<L139>:
-               	bl	 <L139>
-               	mov	x20, x0
-               	b	 <L142>
-<L140>:
-               	mov	x0, x19
-               	mov	x1, #0xffff             // =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L141>:
-               	bl	 <L141>
-               	mov	x20, x0
-<L142>:
+<L61>:
+               	bl	 <L61>
                	fmov	d30, #0.75000000
                	fmul	d0, d10, d30
-               	fcmp	d0, d0
-               	cset	w0, ne
-               	cbnz	w0,  <L144>
-               	mov	x0, x20
-<L143>:
-               	bl	 <L143>
-               	mov	x19, x0
-               	b	 <L146>
-<L144>:
-               	mov	x0, x20
-               	mov	x1, #0xffff             // =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L145>:
-               	bl	 <L145>
-               	mov	x19, x0
-<L146>:
+<L62>:
+               	bl	 <L62>
                	mov	x16, #0x4340000000000000 // =4845873199050653696
                	fmov	d30, x16
                	fmul	d0, d10, d30
-               	fcmp	d0, d0
-               	cset	w0, ne
-               	cbnz	w0,  <L148>
-               	mov	x0, x19
-<L147>:
-               	bl	 <L147>
-               	mov	x20, x0
-               	b	 <L150>
-<L148>:
-               	mov	x0, x19
-               	mov	x1, #0xffff             // =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L149>:
-               	bl	 <L149>
-               	mov	x20, x0
-<L150>:
+<L63>:
+               	bl	 <L63>
                	fdiv	d0, d10, d9
-               	fcmp	d0, d0
-               	cset	w0, ne
-               	cbnz	w0,  <L152>
-               	mov	x0, x20
-<L151>:
-               	bl	 <L151>
+<L64>:
+               	bl	 <L64>
                	mov	x19, x0
-               	b	 <L154>
-<L152>:
-               	mov	x0, x20
-               	mov	x1, #0xffff             // =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L153>:
-               	bl	 <L153>
-               	mov	x19, x0
-<L154>:
                	fmov	d31, #5.50000000
                	fmul	d9, d31, d8
                	fmov	d31, #3.00000000
                	fmul	d10, d31, d8
+               	fmov	d30, xzr
+               	fcmp	d10, d30
+               	cset	w0, eq
+               	cbnz	w0,  <L79>
+               	fmov	d30, #2.00000000
+               	fmul	d0, d9, d30
+               	fcmp	d9, d0
+               	cset	w0, eq
+               	cbnz	w0,  <L65>
+               	b	 <L66>
+<L65>:
+               	fmov	d30, xzr
+               	fcmp	d9, d30
+               	cset	w0, ne
+               	cbnz	w0,  <L79>
+<L66>:
+               	fmov	d30, xzr
+               	fcmp	d9, d30
+               	cset	w0, mi
+               	cbnz	w0,  <L67>
+               	fmov	d0, d9
+               	b	 <L68>
+<L67>:
+               	fmov	d31, xzr
+               	fsub	d0, d31, d9
+<L68>:
+               	fmov	d30, xzr
+               	fcmp	d10, d30
+               	cset	w1, mi
+               	cbnz	w1,  <L69>
+               	fmov	d1, d10
+               	b	 <L70>
+<L69>:
+               	fmov	d31, xzr
+               	fsub	d1, d31, d10
+<L70>:
+               	fmov	d30, #2.00000000
+               	fdiv	d2, d0, d30
+               	fmov	d3, d1
+<L71>:
+               	fcmp	d3, d2
+               	cset	w1, ls
+               	cbnz	w1,  <L78>
+               	fmov	d4, d0
+               	fmov	d5, d3
+<L72>:
+               	fcmp	d1, d5
+               	cset	w1, ls
+               	cbnz	w1,  <L75>
+               	cbnz	w0,  <L73>
+               	fmov	d6, d4
+               	b	 <L74>
+<L73>:
+               	fmov	d31, xzr
+               	fsub	d6, d31, d4
+<L74>:
+               	b	 <L80>
+<L75>:
+               	fcmp	d5, d4
+               	cset	w1, ls
+               	cbnz	w1,  <L76>
+               	fmov	d7, d4
+               	b	 <L77>
+<L76>:
+               	fsub	d7, d4, d5
+<L77>:
+               	fmov	d30, #2.00000000
+               	fdiv	d5, d5, d30
+               	fmov	d4, d7
+               	b	 <L72>
+<L78>:
+               	fmov	d30, #2.00000000
+               	fmul	d3, d3, d30
+               	b	 <L71>
+<L79>:
                	fdiv	d0, d9, d10
                	fcvtzs	x0, d0
                	scvtf	d0, x0
                	fmul	d1, d0, d10
-               	fsub	d0, d9, d1
-               	fcmp	d0, d0
+               	fsub	d6, d9, d1
+<L80>:
+               	fcmp	d6, d6
                	cset	w0, ne
-               	cbnz	w0,  <L156>
+               	cbnz	w0,  <L82>
                	mov	x0, x19
-<L155>:
-               	bl	 <L155>
+               	fmov	d0, d6
+<L81>:
+               	bl	 <L81>
                	mov	x20, x0
-               	b	 <L158>
-<L156>:
+               	b	 <L84>
+<L82>:
                	mov	x0, x19
                	mov	x1, #0xffff             // =65535
                	movk	x1, #0xffff, lsl #16
                	movk	x1, #0xffff, lsl #32
                	movk	x1, #0xffff, lsl #48
-<L157>:
-               	bl	 <L157>
+<L83>:
+               	bl	 <L83>
                	mov	x20, x0
-<L158>:
+<L84>:
                	fmov	d31, xzr
                	fsub	d0, d31, d9
+               	fmov	d30, xzr
+               	fcmp	d10, d30
+               	cset	w0, eq
+               	cbnz	w0,  <L99>
+               	fmov	d30, #2.00000000
+               	fmul	d1, d0, d30
+               	fcmp	d0, d1
+               	cset	w0, eq
+               	cbnz	w0,  <L85>
+               	b	 <L86>
+<L85>:
+               	fmov	d30, xzr
+               	fcmp	d0, d30
+               	cset	w0, ne
+               	cbnz	w0,  <L99>
+<L86>:
+               	fmov	d30, xzr
+               	fcmp	d0, d30
+               	cset	w0, mi
+               	cbnz	w0,  <L87>
+               	fmov	d1, d0
+               	b	 <L88>
+<L87>:
+               	fmov	d31, xzr
+               	fsub	d1, d31, d0
+<L88>:
+               	fmov	d30, xzr
+               	fcmp	d10, d30
+               	cset	w1, mi
+               	cbnz	w1,  <L89>
+               	fmov	d2, d10
+               	b	 <L90>
+<L89>:
+               	fmov	d31, xzr
+               	fsub	d2, d31, d10
+<L90>:
+               	fmov	d30, #2.00000000
+               	fdiv	d3, d1, d30
+               	fmov	d4, d2
+<L91>:
+               	fcmp	d4, d3
+               	cset	w1, ls
+               	cbnz	w1,  <L98>
+               	fmov	d5, d1
+               	fmov	d6, d4
+<L92>:
+               	fcmp	d2, d6
+               	cset	w1, ls
+               	cbnz	w1,  <L95>
+               	cbnz	w0,  <L93>
+               	fmov	d7, d5
+               	b	 <L94>
+<L93>:
+               	fmov	d31, xzr
+               	fsub	d7, d31, d5
+<L94>:
+               	b	 <L100>
+<L95>:
+               	fcmp	d6, d5
+               	cset	w1, ls
+               	cbnz	w1,  <L96>
+               	fmov	d16, d5
+               	b	 <L97>
+<L96>:
+               	fsub	d16, d5, d6
+<L97>:
+               	fmov	d30, #2.00000000
+               	fdiv	d6, d6, d30
+               	fmov	d5, d16
+               	b	 <L92>
+<L98>:
+               	fmov	d30, #2.00000000
+               	fmul	d4, d4, d30
+               	b	 <L91>
+<L99>:
                	fdiv	d1, d0, d10
                	fcvtzs	x0, d1
                	scvtf	d1, x0
                	fmul	d2, d1, d10
-               	fsub	d1, d0, d2
-               	fcmp	d1, d1
+               	fsub	d7, d0, d2
+<L100>:
+               	fcmp	d7, d7
                	cset	w0, ne
-               	cbnz	w0,  <L160>
+               	cbnz	w0,  <L102>
                	mov	x0, x20
-               	fmov	d0, d1
-<L159>:
-               	bl	 <L159>
+               	fmov	d0, d7
+<L101>:
+               	bl	 <L101>
                	mov	x19, x0
-               	b	 <L162>
-<L160>:
+               	b	 <L104>
+<L102>:
                	mov	x0, x20
                	mov	x1, #0xffff             // =65535
                	movk	x1, #0xffff, lsl #16
                	movk	x1, #0xffff, lsl #32
                	movk	x1, #0xffff, lsl #48
-<L161>:
-               	bl	 <L161>
+<L103>:
+               	bl	 <L103>
                	mov	x19, x0
-<L162>:
+<L104>:
                	fmov	d31, xzr
                	fsub	d0, d31, d10
+               	fmov	d30, xzr
+               	fcmp	d0, d30
+               	cset	w0, eq
+               	cbnz	w0,  <L119>
+               	fmov	d30, #2.00000000
+               	fmul	d1, d9, d30
+               	fcmp	d9, d1
+               	cset	w0, eq
+               	cbnz	w0,  <L105>
+               	b	 <L106>
+<L105>:
+               	fmov	d30, xzr
+               	fcmp	d9, d30
+               	cset	w0, ne
+               	cbnz	w0,  <L119>
+<L106>:
+               	fmov	d30, xzr
+               	fcmp	d9, d30
+               	cset	w0, mi
+               	cbnz	w0,  <L107>
+               	fmov	d1, d9
+               	b	 <L108>
+<L107>:
+               	fmov	d31, xzr
+               	fsub	d1, d31, d9
+<L108>:
+               	fmov	d30, xzr
+               	fcmp	d0, d30
+               	cset	w1, mi
+               	cbnz	w1,  <L109>
+               	fmov	d2, d0
+               	b	 <L110>
+<L109>:
+               	fmov	d31, xzr
+               	fsub	d2, d31, d0
+<L110>:
+               	fmov	d30, #2.00000000
+               	fdiv	d3, d1, d30
+               	fmov	d4, d2
+<L111>:
+               	fcmp	d4, d3
+               	cset	w1, ls
+               	cbnz	w1,  <L118>
+               	fmov	d5, d1
+               	fmov	d6, d4
+<L112>:
+               	fcmp	d2, d6
+               	cset	w1, ls
+               	cbnz	w1,  <L115>
+               	cbnz	w0,  <L113>
+               	fmov	d7, d5
+               	b	 <L114>
+<L113>:
+               	fmov	d31, xzr
+               	fsub	d7, d31, d5
+<L114>:
+               	b	 <L120>
+<L115>:
+               	fcmp	d6, d5
+               	cset	w1, ls
+               	cbnz	w1,  <L116>
+               	fmov	d16, d5
+               	b	 <L117>
+<L116>:
+               	fsub	d16, d5, d6
+<L117>:
+               	fmov	d30, #2.00000000
+               	fdiv	d6, d6, d30
+               	fmov	d5, d16
+               	b	 <L112>
+<L118>:
+               	fmov	d30, #2.00000000
+               	fmul	d4, d4, d30
+               	b	 <L111>
+<L119>:
                	fdiv	d1, d9, d0
                	fcvtzs	x0, d1
                	scvtf	d1, x0
                	fmul	d2, d1, d0
-               	fsub	d0, d9, d2
-               	fcmp	d0, d0
+               	fsub	d7, d9, d2
+<L120>:
+               	fcmp	d7, d7
                	cset	w0, ne
-               	cbnz	w0,  <L164>
+               	cbnz	w0,  <L122>
                	mov	x0, x19
-<L163>:
-               	bl	 <L163>
+               	fmov	d0, d7
+<L121>:
+               	bl	 <L121>
                	mov	x20, x0
-               	b	 <L166>
-<L164>:
+               	b	 <L124>
+<L122>:
                	mov	x0, x19
                	mov	x1, #0xffff             // =65535
                	movk	x1, #0xffff, lsl #16
                	movk	x1, #0xffff, lsl #32
                	movk	x1, #0xffff, lsl #48
-<L165>:
-               	bl	 <L165>
+<L123>:
+               	bl	 <L123>
                	mov	x20, x0
-<L166>:
+<L124>:
                	fmov	d31, xzr
                	fsub	d0, d31, d9
                	fmov	d31, xzr
                	fsub	d1, d31, d10
+               	fmov	d30, xzr
+               	fcmp	d1, d30
+               	cset	w0, eq
+               	cbnz	w0,  <L139>
+               	fmov	d30, #2.00000000
+               	fmul	d2, d0, d30
+               	fcmp	d0, d2
+               	cset	w0, eq
+               	cbnz	w0,  <L125>
+               	b	 <L126>
+<L125>:
+               	fmov	d30, xzr
+               	fcmp	d0, d30
+               	cset	w0, ne
+               	cbnz	w0,  <L139>
+<L126>:
+               	fmov	d30, xzr
+               	fcmp	d0, d30
+               	cset	w0, mi
+               	cbnz	w0,  <L127>
+               	fmov	d2, d0
+               	b	 <L128>
+<L127>:
+               	fmov	d31, xzr
+               	fsub	d2, d31, d0
+<L128>:
+               	fmov	d30, xzr
+               	fcmp	d1, d30
+               	cset	w1, mi
+               	cbnz	w1,  <L129>
+               	fmov	d3, d1
+               	b	 <L130>
+<L129>:
+               	fmov	d31, xzr
+               	fsub	d3, d31, d1
+<L130>:
+               	fmov	d30, #2.00000000
+               	fdiv	d4, d2, d30
+               	fmov	d5, d3
+<L131>:
+               	fcmp	d5, d4
+               	cset	w1, ls
+               	cbnz	w1,  <L138>
+               	fmov	d6, d2
+               	fmov	d7, d5
+<L132>:
+               	fcmp	d3, d7
+               	cset	w1, ls
+               	cbnz	w1,  <L135>
+               	cbnz	w0,  <L133>
+               	fmov	d16, d6
+               	b	 <L134>
+<L133>:
+               	fmov	d31, xzr
+               	fsub	d16, d31, d6
+<L134>:
+               	b	 <L140>
+<L135>:
+               	fcmp	d7, d6
+               	cset	w1, ls
+               	cbnz	w1,  <L136>
+               	fmov	d17, d6
+               	b	 <L137>
+<L136>:
+               	fsub	d17, d6, d7
+<L137>:
+               	fmov	d30, #2.00000000
+               	fdiv	d7, d7, d30
+               	fmov	d6, d17
+               	b	 <L132>
+<L138>:
+               	fmov	d30, #2.00000000
+               	fmul	d5, d5, d30
+               	b	 <L131>
+<L139>:
                	fdiv	d2, d0, d1
                	fcvtzs	x0, d2
                	scvtf	d2, x0
                	fmul	d3, d2, d1
-               	fsub	d1, d0, d3
-               	fcmp	d1, d1
+               	fsub	d16, d0, d3
+<L140>:
+               	fcmp	d16, d16
                	cset	w0, ne
-               	cbnz	w0,  <L168>
+               	cbnz	w0,  <L142>
                	mov	x0, x20
-               	fmov	d0, d1
-<L167>:
-               	bl	 <L167>
+               	fmov	d0, d16
+<L141>:
+               	bl	 <L141>
                	mov	x19, x0
-               	b	 <L170>
-<L168>:
+               	b	 <L144>
+<L142>:
                	mov	x0, x20
                	mov	x1, #0xffff             // =65535
                	movk	x1, #0xffff, lsl #16
                	movk	x1, #0xffff, lsl #32
                	movk	x1, #0xffff, lsl #48
-<L169>:
-               	bl	 <L169>
+<L143>:
+               	bl	 <L143>
                	mov	x19, x0
-<L170>:
+<L144>:
                	fmov	d31, #7.00000000
                	fmul	d0, d31, d8
+               	fmov	d30, #2.00000000
+               	fmul	d1, d0, d30
+               	fcmp	d0, d1
+               	cset	w0, eq
+               	cbnz	w0,  <L145>
+               	b	 <L146>
+<L145>:
+               	fmov	d30, xzr
+               	fcmp	d0, d30
+               	cset	w0, ne
+               	cbnz	w0,  <L157>
+<L146>:
+               	fmov	d30, xzr
+               	fcmp	d0, d30
+               	cset	w0, mi
+               	cbnz	w0,  <L147>
+               	fmov	d1, d0
+               	b	 <L148>
+<L147>:
+               	fmov	d31, xzr
+               	fsub	d1, d31, d0
+<L148>:
+               	fmov	d30, #2.00000000
+               	fdiv	d2, d1, d30
+               	fmov	d3, #0.50000000
+<L149>:
+               	fcmp	d3, d2
+               	cset	w1, ls
+               	cbnz	w1,  <L156>
+               	fmov	d4, d1
+               	fmov	d5, d3
+<L150>:
+               	fmov	d31, #0.50000000
+               	fcmp	d31, d5
+               	cset	w1, ls
+               	cbnz	w1,  <L153>
+               	cbnz	w0,  <L151>
+               	fmov	d6, d4
+               	b	 <L152>
+<L151>:
+               	fmov	d31, xzr
+               	fsub	d6, d31, d4
+<L152>:
+               	b	 <L158>
+<L153>:
+               	fcmp	d5, d4
+               	cset	w1, ls
+               	cbnz	w1,  <L154>
+               	fmov	d7, d4
+               	b	 <L155>
+<L154>:
+               	fsub	d7, d4, d5
+<L155>:
+               	fmov	d30, #2.00000000
+               	fdiv	d5, d5, d30
+               	fmov	d4, d7
+               	b	 <L150>
+<L156>:
+               	fmov	d30, #2.00000000
+               	fmul	d3, d3, d30
+               	b	 <L149>
+<L157>:
                	fmov	d30, #0.50000000
                	fdiv	d1, d0, d30
                	fcvtzs	x0, d1
                	scvtf	d1, x0
                	fmov	d30, #0.50000000
                	fmul	d2, d1, d30
-               	fsub	d1, d0, d2
-               	fcmp	d1, d1
+               	fsub	d6, d0, d2
+<L158>:
+               	fcmp	d6, d6
                	cset	w0, ne
-               	cbnz	w0,  <L172>
+               	cbnz	w0,  <L160>
                	mov	x0, x19
-               	fmov	d0, d1
-<L171>:
-               	bl	 <L171>
+               	fmov	d0, d6
+<L159>:
+               	bl	 <L159>
                	mov	x20, x0
-               	b	 <L174>
-<L172>:
+               	b	 <L162>
+<L160>:
                	mov	x0, x19
                	mov	x1, #0xffff             // =65535
                	movk	x1, #0xffff, lsl #16
                	movk	x1, #0xffff, lsl #32
                	movk	x1, #0xffff, lsl #48
-<L173>:
-               	bl	 <L173>
+<L161>:
+               	bl	 <L161>
                	mov	x20, x0
+<L162>:
+               	fmov	d30, xzr
+               	fcmp	d10, d30
+               	cset	w0, eq
+               	cbnz	w0,  <L177>
+               	fmov	d30, #2.00000000
+               	fmul	d0, d8, d30
+               	fcmp	d8, d0
+               	cset	w0, eq
+               	cbnz	w0,  <L163>
+               	b	 <L164>
+<L163>:
+               	fmov	d30, xzr
+               	fcmp	d8, d30
+               	cset	w0, ne
+               	cbnz	w0,  <L177>
+<L164>:
+               	fmov	d30, xzr
+               	fcmp	d8, d30
+               	cset	w0, mi
+               	cbnz	w0,  <L165>
+               	fmov	d0, d8
+               	b	 <L166>
+<L165>:
+               	fmov	d31, xzr
+               	fsub	d0, d31, d8
+<L166>:
+               	fmov	d30, xzr
+               	fcmp	d10, d30
+               	cset	w1, mi
+               	cbnz	w1,  <L167>
+               	fmov	d1, d10
+               	b	 <L168>
+<L167>:
+               	fmov	d31, xzr
+               	fsub	d1, d31, d10
+<L168>:
+               	fmov	d30, #2.00000000
+               	fdiv	d2, d0, d30
+               	fmov	d3, d1
+<L169>:
+               	fcmp	d3, d2
+               	cset	w1, ls
+               	cbnz	w1,  <L176>
+               	fmov	d4, d0
+               	fmov	d5, d3
+<L170>:
+               	fcmp	d1, d5
+               	cset	w1, ls
+               	cbnz	w1,  <L173>
+               	cbnz	w0,  <L171>
+               	fmov	d6, d4
+               	b	 <L172>
+<L171>:
+               	fmov	d31, xzr
+               	fsub	d6, d31, d4
+<L172>:
+               	b	 <L178>
+<L173>:
+               	fcmp	d5, d4
+               	cset	w1, ls
+               	cbnz	w1,  <L174>
+               	fmov	d7, d4
+               	b	 <L175>
 <L174>:
+               	fsub	d7, d4, d5
+<L175>:
+               	fmov	d30, #2.00000000
+               	fdiv	d5, d5, d30
+               	fmov	d4, d7
+               	b	 <L170>
+<L176>:
+               	fmov	d30, #2.00000000
+               	fmul	d3, d3, d30
+               	b	 <L169>
+<L177>:
                	fdiv	d0, d8, d10
                	fcvtzs	x0, d0
                	scvtf	d0, x0
                	fmul	d1, d0, d10
-               	fsub	d0, d8, d1
-               	fcmp	d0, d0
-               	cset	w0, ne
-               	cbnz	w0,  <L176>
-               	mov	x0, x20
-<L175>:
-               	bl	 <L175>
-               	mov	x19, x0
-               	b	 <L178>
-<L176>:
-               	mov	x0, x20
-               	mov	x1, #0xffff             // =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L177>:
-               	bl	 <L177>
-               	mov	x19, x0
+               	fsub	d6, d8, d1
 <L178>:
-               	fdiv	d0, d10, d10
-               	fcvtzs	x0, d0
-               	scvtf	d0, x0
-               	fmul	d1, d0, d10
-               	fsub	d0, d10, d1
-               	fcmp	d0, d0
+               	fcmp	d6, d6
                	cset	w0, ne
                	cbnz	w0,  <L180>
-               	mov	x0, x19
+               	mov	x0, x20
+               	fmov	d0, d6
 <L179>:
                	bl	 <L179>
-               	mov	x20, x0
+               	mov	x19, x0
                	b	 <L182>
 <L180>:
-               	mov	x0, x19
+               	mov	x0, x20
                	mov	x1, #0xffff             // =65535
                	movk	x1, #0xffff, lsl #16
                	movk	x1, #0xffff, lsl #32
                	movk	x1, #0xffff, lsl #48
 <L181>:
                	bl	 <L181>
-               	mov	x20, x0
+               	mov	x19, x0
 <L182>:
+               	fmov	d30, xzr
+               	fcmp	d10, d30
+               	cset	w0, eq
+               	cbnz	w0,  <L197>
+               	fmov	d30, #2.00000000
+               	fmul	d0, d10, d30
+               	fcmp	d10, d0
+               	cset	w0, eq
+               	cbnz	w0,  <L183>
+               	b	 <L184>
+<L183>:
+               	fmov	d30, xzr
+               	fcmp	d10, d30
+               	cset	w0, ne
+               	cbnz	w0,  <L197>
+<L184>:
+               	fmov	d30, xzr
+               	fcmp	d10, d30
+               	cset	w0, mi
+               	cbnz	w0,  <L185>
+               	fmov	d0, d10
+               	b	 <L186>
+<L185>:
+               	fmov	d31, xzr
+               	fsub	d0, d31, d10
+<L186>:
+               	fmov	d30, xzr
+               	fcmp	d10, d30
+               	cset	w1, mi
+               	cbnz	w1,  <L187>
+               	fmov	d1, d10
+               	b	 <L188>
+<L187>:
+               	fmov	d31, xzr
+               	fsub	d1, d31, d10
+<L188>:
+               	fmov	d30, #2.00000000
+               	fdiv	d2, d0, d30
+               	fmov	d3, d1
+<L189>:
+               	fcmp	d3, d2
+               	cset	w1, ls
+               	cbnz	w1,  <L196>
+               	fmov	d4, d0
+               	fmov	d5, d3
+<L190>:
+               	fcmp	d1, d5
+               	cset	w1, ls
+               	cbnz	w1,  <L193>
+               	cbnz	w0,  <L191>
+               	fmov	d6, d4
+               	b	 <L192>
+<L191>:
+               	fmov	d31, xzr
+               	fsub	d6, d31, d4
+<L192>:
+               	b	 <L198>
+<L193>:
+               	fcmp	d5, d4
+               	cset	w1, ls
+               	cbnz	w1,  <L194>
+               	fmov	d7, d4
+               	b	 <L195>
+<L194>:
+               	fsub	d7, d4, d5
+<L195>:
+               	fmov	d30, #2.00000000
+               	fdiv	d5, d5, d30
+               	fmov	d4, d7
+               	b	 <L190>
+<L196>:
+               	fmov	d30, #2.00000000
+               	fmul	d3, d3, d30
+               	b	 <L189>
+<L197>:
+               	fdiv	d0, d10, d10
+               	fcvtzs	x0, d0
+               	scvtf	d0, x0
+               	fmul	d1, d0, d10
+               	fsub	d6, d10, d1
+<L198>:
+               	fcmp	d6, d6
+               	cset	w0, ne
+               	cbnz	w0,  <L200>
+               	mov	x0, x19
+               	fmov	d0, d6
+<L199>:
+               	bl	 <L199>
+               	mov	x20, x0
+               	b	 <L202>
+<L200>:
+               	mov	x0, x19
+               	mov	x1, #0xffff             // =65535
+               	movk	x1, #0xffff, lsl #16
+               	movk	x1, #0xffff, lsl #32
+               	movk	x1, #0xffff, lsl #48
+<L201>:
+               	bl	 <L201>
+               	mov	x20, x0
+<L202>:
                	mov	x16, #0x4130000000000000 // =4697254411347427328
                	fmov	d31, x16
                	fmul	d0, d31, d8
+               	fmov	d30, xzr
+               	fcmp	d10, d30
+               	cset	w0, eq
+               	cbnz	w0,  <L217>
+               	fmov	d30, #2.00000000
+               	fmul	d1, d0, d30
+               	fcmp	d0, d1
+               	cset	w0, eq
+               	cbnz	w0,  <L203>
+               	b	 <L204>
+<L203>:
+               	fmov	d30, xzr
+               	fcmp	d0, d30
+               	cset	w0, ne
+               	cbnz	w0,  <L217>
+<L204>:
+               	fmov	d30, xzr
+               	fcmp	d0, d30
+               	cset	w0, mi
+               	cbnz	w0,  <L205>
+               	fmov	d1, d0
+               	b	 <L206>
+<L205>:
+               	fmov	d31, xzr
+               	fsub	d1, d31, d0
+<L206>:
+               	fmov	d30, xzr
+               	fcmp	d10, d30
+               	cset	w1, mi
+               	cbnz	w1,  <L207>
+               	fmov	d2, d10
+               	b	 <L208>
+<L207>:
+               	fmov	d31, xzr
+               	fsub	d2, d31, d10
+<L208>:
+               	fmov	d30, #2.00000000
+               	fdiv	d3, d1, d30
+               	fmov	d4, d2
+<L209>:
+               	fcmp	d4, d3
+               	cset	w1, ls
+               	cbnz	w1,  <L216>
+               	fmov	d5, d1
+               	fmov	d6, d4
+<L210>:
+               	fcmp	d2, d6
+               	cset	w1, ls
+               	cbnz	w1,  <L213>
+               	cbnz	w0,  <L211>
+               	fmov	d7, d5
+               	b	 <L212>
+<L211>:
+               	fmov	d31, xzr
+               	fsub	d7, d31, d5
+<L212>:
+               	b	 <L218>
+<L213>:
+               	fcmp	d6, d5
+               	cset	w1, ls
+               	cbnz	w1,  <L214>
+               	fmov	d16, d5
+               	b	 <L215>
+<L214>:
+               	fsub	d16, d5, d6
+<L215>:
+               	fmov	d30, #2.00000000
+               	fdiv	d6, d6, d30
+               	fmov	d5, d16
+               	b	 <L210>
+<L216>:
+               	fmov	d30, #2.00000000
+               	fmul	d4, d4, d30
+               	b	 <L209>
+<L217>:
                	fdiv	d1, d0, d10
                	fcvtzs	x0, d1
                	scvtf	d1, x0
                	fmul	d2, d1, d10
-               	fsub	d1, d0, d2
-               	fcmp	d1, d1
+               	fsub	d7, d0, d2
+<L218>:
+               	fcmp	d7, d7
                	cset	w0, ne
-               	cbnz	w0,  <L184>
+               	cbnz	w0,  <L220>
                	mov	x0, x20
-               	fmov	d0, d1
-<L183>:
-               	bl	 <L183>
+               	fmov	d0, d7
+<L219>:
+               	bl	 <L219>
                	mov	x19, x0
-               	b	 <L186>
-<L184>:
+               	b	 <L222>
+<L220>:
                	mov	x0, x20
                	mov	x1, #0xffff             // =65535
                	movk	x1, #0xffff, lsl #16
                	movk	x1, #0xffff, lsl #32
                	movk	x1, #0xffff, lsl #48
-<L185>:
-               	bl	 <L185>
+<L221>:
+               	bl	 <L221>
                	mov	x19, x0
-<L186>:
+<L222>:
                	mov	x0, x19
                	ldp	d8, d9, [x29, #-0x30]
                	ldp	d10, d11, [x29, #-0x40]

--- a/test/golden/aarch64-linux/float/cmp_f32.dis
+++ b/test/golden/aarch64-linux/float/cmp_f32.dis
@@ -227,8 +227,8 @@ Disassembly of section .text:
                	fcmp	s8, s9
                	cset	w1, mi
                	uxtb	w17, w1
-               	cmp	w17, #0x0
-               	cset	w2, eq
+               	cmp	w17, #0x1
+               	cset	w2, ne
                	mov	x1, x2
 <L27>:
                	bl	 <L27>

--- a/test/golden/aarch64-linux/float/cmp_f64.dis
+++ b/test/golden/aarch64-linux/float/cmp_f64.dis
@@ -235,8 +235,8 @@ Disassembly of section .text:
                	fcmp	d8, d9
                	cset	w1, mi
                	uxtb	w17, w1
-               	cmp	w17, #0x0
-               	cset	w2, eq
+               	cmp	w17, #0x1
+               	cset	w2, ne
                	mov	x1, x2
 <L27>:
                	bl	 <L27>

--- a/test/golden/aarch64-linux/float/special_f32.dis
+++ b/test/golden/aarch64-linux/float/special_f32.dis
@@ -221,1084 +221,288 @@ Disassembly of section .text:
                	mov	x20, x0
 <L32>:
                	fsub	s0, s11, s10
-               	fcmp	s0, s0
-               	cset	w0, ne
-               	cbnz	w0,  <L34>
                	mov	x0, x20
 <L33>:
                	bl	 <L33>
-               	mov	x19, x0
-               	b	 <L36>
+               	fsub	s0, s11, s11
 <L34>:
-               	mov	x0, x20
-               	mov	w1, #0xffff             // =65535
-               	movk	w1, #0xffff, lsl #16
+               	bl	 <L34>
+               	fmul	s0, s10, s8
 <L35>:
                	bl	 <L35>
-               	mov	x19, x0
+               	fmul	s0, s10, s9
 <L36>:
-               	fsub	s0, s11, s11
-               	fcmp	s0, s0
-               	cset	w0, ne
-               	cbnz	w0,  <L38>
-               	mov	x0, x19
+               	bl	 <L36>
+               	fmul	s0, s11, s8
 <L37>:
                	bl	 <L37>
-               	mov	x20, x0
-               	b	 <L40>
+               	fmul	s0, s11, s9
 <L38>:
-               	mov	x0, x19
-               	mov	w1, #0xffff             // =65535
-               	movk	w1, #0xffff, lsl #16
+               	bl	 <L38>
+               	fmul	s0, s11, s11
 <L39>:
                	bl	 <L39>
-               	mov	x20, x0
+               	fmul	s0, s10, s11
 <L40>:
-               	fmul	s0, s10, s8
-               	fcmp	s0, s0
-               	cset	w0, ne
-               	cbnz	w0,  <L42>
-               	mov	x0, x20
+               	bl	 <L40>
+               	fneg	s0, s10
 <L41>:
                	bl	 <L41>
-               	mov	x19, x0
-               	b	 <L44>
+               	fneg	s0, s11
 <L42>:
-               	mov	x0, x20
-               	mov	w1, #0xffff             // =65535
-               	movk	w1, #0xffff, lsl #16
+               	bl	 <L42>
+               	fdiv	s0, s10, s8
 <L43>:
                	bl	 <L43>
-               	mov	x19, x0
+               	fdiv	s0, s10, s9
 <L44>:
-               	fmul	s0, s10, s9
-               	fcmp	s0, s0
-               	cset	w0, ne
-               	cbnz	w0,  <L46>
-               	mov	x0, x19
+               	bl	 <L44>
+               	fdiv	s0, s11, s8
 <L45>:
                	bl	 <L45>
-               	mov	x20, x0
-               	b	 <L48>
-<L46>:
-               	mov	x0, x19
-               	mov	w1, #0xffff             // =65535
-               	movk	w1, #0xffff, lsl #16
-<L47>:
-               	bl	 <L47>
-               	mov	x20, x0
-<L48>:
-               	fmul	s0, s11, s8
-               	fcmp	s0, s0
-               	cset	w0, ne
-               	cbnz	w0,  <L50>
-               	mov	x0, x20
-<L49>:
-               	bl	 <L49>
-               	mov	x19, x0
-               	b	 <L52>
-<L50>:
-               	mov	x0, x20
-               	mov	w1, #0xffff             // =65535
-               	movk	w1, #0xffff, lsl #16
-<L51>:
-               	bl	 <L51>
-               	mov	x19, x0
-<L52>:
-               	fmul	s0, s11, s9
-               	fcmp	s0, s0
-               	cset	w0, ne
-               	cbnz	w0,  <L54>
-               	mov	x0, x19
-<L53>:
-               	bl	 <L53>
-               	mov	x20, x0
-               	b	 <L56>
-<L54>:
-               	mov	x0, x19
-               	mov	w1, #0xffff             // =65535
-               	movk	w1, #0xffff, lsl #16
-<L55>:
-               	bl	 <L55>
-               	mov	x20, x0
-<L56>:
-               	fmul	s0, s11, s11
-               	fcmp	s0, s0
-               	cset	w0, ne
-               	cbnz	w0,  <L58>
-               	mov	x0, x20
-<L57>:
-               	bl	 <L57>
-               	mov	x19, x0
-               	b	 <L60>
-<L58>:
-               	mov	x0, x20
-               	mov	w1, #0xffff             // =65535
-               	movk	w1, #0xffff, lsl #16
-<L59>:
-               	bl	 <L59>
-               	mov	x19, x0
-<L60>:
-               	fmul	s0, s10, s11
-               	fcmp	s0, s0
-               	cset	w0, ne
-               	cbnz	w0,  <L62>
-               	mov	x0, x19
-<L61>:
-               	bl	 <L61>
-               	mov	x20, x0
-               	b	 <L64>
-<L62>:
-               	mov	x0, x19
-               	mov	w1, #0xffff             // =65535
-               	movk	w1, #0xffff, lsl #16
-<L63>:
-               	bl	 <L63>
-               	mov	x20, x0
-<L64>:
-               	fneg	s0, s10
-               	fcmp	s0, s0
-               	cset	w0, ne
-               	cbnz	w0,  <L66>
-               	mov	x0, x20
-<L65>:
-               	bl	 <L65>
-               	mov	x19, x0
-               	b	 <L68>
-<L66>:
-               	mov	x0, x20
-               	mov	w1, #0xffff             // =65535
-               	movk	w1, #0xffff, lsl #16
-<L67>:
-               	bl	 <L67>
-               	mov	x19, x0
-<L68>:
-               	fneg	s0, s11
-               	fcmp	s0, s0
-               	cset	w0, ne
-               	cbnz	w0,  <L70>
-               	mov	x0, x19
-<L69>:
-               	bl	 <L69>
-               	mov	x20, x0
-               	b	 <L72>
-<L70>:
-               	mov	x0, x19
-               	mov	w1, #0xffff             // =65535
-               	movk	w1, #0xffff, lsl #16
-<L71>:
-               	bl	 <L71>
-               	mov	x20, x0
-<L72>:
-               	fdiv	s0, s10, s8
-               	fcmp	s0, s0
-               	cset	w0, ne
-               	cbnz	w0,  <L74>
-               	mov	x0, x20
-<L73>:
-               	bl	 <L73>
-               	mov	x19, x0
-               	b	 <L76>
-<L74>:
-               	mov	x0, x20
-               	mov	w1, #0xffff             // =65535
-               	movk	w1, #0xffff, lsl #16
-<L75>:
-               	bl	 <L75>
-               	mov	x19, x0
-<L76>:
-               	fdiv	s0, s10, s9
-               	fcmp	s0, s0
-               	cset	w0, ne
-               	cbnz	w0,  <L78>
-               	mov	x0, x19
-<L77>:
-               	bl	 <L77>
-               	mov	x20, x0
-               	b	 <L80>
-<L78>:
-               	mov	x0, x19
-               	mov	w1, #0xffff             // =65535
-               	movk	w1, #0xffff, lsl #16
-<L79>:
-               	bl	 <L79>
-               	mov	x20, x0
-<L80>:
-               	fdiv	s0, s11, s8
-               	fcmp	s0, s0
-               	cset	w0, ne
-               	cbnz	w0,  <L82>
-               	mov	x0, x20
-<L81>:
-               	bl	 <L81>
-               	mov	x19, x0
-               	b	 <L84>
-<L82>:
-               	mov	x0, x20
-               	mov	w1, #0xffff             // =65535
-               	movk	w1, #0xffff, lsl #16
-<L83>:
-               	bl	 <L83>
-               	mov	x19, x0
-<L84>:
                	fdiv	s0, s11, s9
-               	fcmp	s0, s0
-               	cset	w0, ne
-               	cbnz	w0,  <L86>
-               	mov	x0, x19
-<L85>:
-               	bl	 <L85>
-               	mov	x20, x0
-               	b	 <L88>
-<L86>:
-               	mov	x0, x19
-               	mov	w1, #0xffff             // =65535
-               	movk	w1, #0xffff, lsl #16
-<L87>:
-               	bl	 <L87>
-               	mov	x20, x0
-<L88>:
+<L46>:
+               	bl	 <L46>
                	fcmp	s10, s11
                	cset	w1, eq
-               	mov	x0, x20
-<L89>:
-               	bl	 <L89>
+<L47>:
+               	bl	 <L47>
                	fcmp	s10, s11
                	cset	w1, mi
-<L90>:
-               	bl	 <L90>
+<L48>:
+               	bl	 <L48>
                	fcmp	s11, s10
                	cset	w1, mi
-<L91>:
-               	bl	 <L91>
-               	mov	x19, x0
-               	fcmp	s12, s12
-               	cset	w0, ne
-               	cbnz	w0,  <L93>
-               	mov	x0, x19
+<L49>:
+               	bl	 <L49>
                	fmov	s0, s12
-<L92>:
-               	bl	 <L92>
-               	mov	x20, x0
-               	b	 <L95>
-<L93>:
-               	mov	x0, x19
-               	mov	w1, #0xffff             // =65535
-               	movk	w1, #0xffff, lsl #16
-<L94>:
-               	bl	 <L94>
-               	mov	x20, x0
-<L95>:
-               	fcmp	s13, s13
-               	cset	w0, ne
-               	cbnz	w0,  <L97>
-               	mov	x0, x20
+<L50>:
+               	bl	 <L50>
                	fmov	s0, s13
-<L96>:
-               	bl	 <L96>
-               	mov	x19, x0
-               	b	 <L99>
-<L97>:
-               	mov	x0, x20
-               	mov	w1, #0xffff             // =65535
-               	movk	w1, #0xffff, lsl #16
-<L98>:
-               	bl	 <L98>
-               	mov	x19, x0
-<L99>:
+<L51>:
+               	bl	 <L51>
                	fneg	s0, s12
-               	fcmp	s0, s0
-               	cset	w0, ne
-               	cbnz	w0,  <L101>
-               	mov	x0, x19
-<L100>:
-               	bl	 <L100>
-               	mov	x20, x0
-               	b	 <L103>
-<L101>:
-               	mov	x0, x19
-               	mov	w1, #0xffff             // =65535
-               	movk	w1, #0xffff, lsl #16
-<L102>:
-               	bl	 <L102>
-               	mov	x20, x0
-<L103>:
+<L52>:
+               	bl	 <L52>
                	fdiv	s0, s8, s10
-               	fcmp	s0, s0
-               	cset	w0, ne
-               	cbnz	w0,  <L105>
-               	mov	x0, x20
-<L104>:
-               	bl	 <L104>
-               	mov	x19, x0
-               	b	 <L107>
-<L105>:
-               	mov	x0, x20
-               	mov	w1, #0xffff             // =65535
-               	movk	w1, #0xffff, lsl #16
-<L106>:
-               	bl	 <L106>
-               	mov	x19, x0
-<L107>:
+<L53>:
+               	bl	 <L53>
                	fdiv	s0, s8, s11
-               	fcmp	s0, s0
-               	cset	w0, ne
-               	cbnz	w0,  <L109>
-               	mov	x0, x19
-<L108>:
-               	bl	 <L108>
-               	mov	x20, x0
-               	b	 <L111>
-<L109>:
-               	mov	x0, x19
-               	mov	w1, #0xffff             // =65535
-               	movk	w1, #0xffff, lsl #16
-<L110>:
-               	bl	 <L110>
-               	mov	x20, x0
-<L111>:
+<L54>:
+               	bl	 <L54>
                	fdiv	s0, s9, s10
-               	fcmp	s0, s0
-               	cset	w0, ne
-               	cbnz	w0,  <L113>
-               	mov	x0, x20
-<L112>:
-               	bl	 <L112>
-               	mov	x19, x0
-               	b	 <L115>
-<L113>:
-               	mov	x0, x20
-               	mov	w1, #0xffff             // =65535
-               	movk	w1, #0xffff, lsl #16
-<L114>:
-               	bl	 <L114>
-               	mov	x19, x0
-<L115>:
+<L55>:
+               	bl	 <L55>
                	fdiv	s0, s9, s11
-               	fcmp	s0, s0
-               	cset	w0, ne
-               	cbnz	w0,  <L117>
-               	mov	x0, x19
-<L116>:
-               	bl	 <L116>
-               	mov	x20, x0
-               	b	 <L119>
-<L117>:
-               	mov	x0, x19
-               	mov	w1, #0xffff             // =65535
-               	movk	w1, #0xffff, lsl #16
-<L118>:
-               	bl	 <L118>
-               	mov	x20, x0
-<L119>:
+<L56>:
+               	bl	 <L56>
                	fadd	s0, s12, s8
-               	fcmp	s0, s0
-               	cset	w0, ne
-               	cbnz	w0,  <L121>
-               	mov	x0, x20
-<L120>:
-               	bl	 <L120>
-               	mov	x19, x0
-               	b	 <L123>
-<L121>:
-               	mov	x0, x20
-               	mov	w1, #0xffff             // =65535
-               	movk	w1, #0xffff, lsl #16
-<L122>:
-               	bl	 <L122>
-               	mov	x19, x0
-<L123>:
+<L57>:
+               	bl	 <L57>
                	fadd	s0, s12, s12
-               	fcmp	s0, s0
-               	cset	w0, ne
-               	cbnz	w0,  <L125>
-               	mov	x0, x19
-<L124>:
-               	bl	 <L124>
-               	mov	x20, x0
-               	b	 <L127>
-<L125>:
-               	mov	x0, x19
-               	mov	w1, #0xffff             // =65535
-               	movk	w1, #0xffff, lsl #16
-<L126>:
-               	bl	 <L126>
-               	mov	x20, x0
-<L127>:
+<L58>:
+               	bl	 <L58>
                	fsub	s0, s12, s13
-               	fcmp	s0, s0
-               	cset	w0, ne
-               	cbnz	w0,  <L129>
-               	mov	x0, x20
-<L128>:
-               	bl	 <L128>
-               	mov	x19, x0
-               	b	 <L131>
-<L129>:
-               	mov	x0, x20
-               	mov	w1, #0xffff             // =65535
-               	movk	w1, #0xffff, lsl #16
-<L130>:
-               	bl	 <L130>
-               	mov	x19, x0
-<L131>:
+<L59>:
+               	bl	 <L59>
                	fmul	s0, s12, s12
-               	fcmp	s0, s0
-               	cset	w0, ne
-               	cbnz	w0,  <L133>
-               	mov	x0, x19
-<L132>:
-               	bl	 <L132>
-               	mov	x20, x0
-               	b	 <L135>
-<L133>:
-               	mov	x0, x19
-               	mov	w1, #0xffff             // =65535
-               	movk	w1, #0xffff, lsl #16
-<L134>:
-               	bl	 <L134>
-               	mov	x20, x0
-<L135>:
+<L60>:
+               	bl	 <L60>
                	fmul	s0, s12, s13
-               	fcmp	s0, s0
-               	cset	w0, ne
-               	cbnz	w0,  <L137>
-               	mov	x0, x20
-<L136>:
-               	bl	 <L136>
-               	mov	x19, x0
-               	b	 <L139>
-<L137>:
-               	mov	x0, x20
-               	mov	w1, #0xffff             // =65535
-               	movk	w1, #0xffff, lsl #16
-<L138>:
-               	bl	 <L138>
-               	mov	x19, x0
-<L139>:
+<L61>:
+               	bl	 <L61>
                	fmul	s0, s12, s9
-               	fcmp	s0, s0
-               	cset	w0, ne
-               	cbnz	w0,  <L141>
-               	mov	x0, x19
-<L140>:
-               	bl	 <L140>
-               	mov	x20, x0
-               	b	 <L143>
-<L141>:
-               	mov	x0, x19
-               	mov	w1, #0xffff             // =65535
-               	movk	w1, #0xffff, lsl #16
-<L142>:
-               	bl	 <L142>
-               	mov	x20, x0
-<L143>:
+<L62>:
+               	bl	 <L62>
                	fdiv	s0, s8, s12
-               	fcmp	s0, s0
-               	cset	w0, ne
-               	cbnz	w0,  <L145>
-               	mov	x0, x20
-<L144>:
-               	bl	 <L144>
-               	mov	x19, x0
-               	b	 <L147>
-<L145>:
-               	mov	x0, x20
-               	mov	w1, #0xffff             // =65535
-               	movk	w1, #0xffff, lsl #16
-<L146>:
-               	bl	 <L146>
-               	mov	x19, x0
-<L147>:
+<L63>:
+               	bl	 <L63>
                	fdiv	s0, s9, s12
-               	fcmp	s0, s0
-               	cset	w0, ne
-               	cbnz	w0,  <L149>
-               	mov	x0, x19
-<L148>:
-               	bl	 <L148>
-               	mov	x20, x0
-               	b	 <L151>
-<L149>:
-               	mov	x0, x19
-               	mov	w1, #0xffff             // =65535
-               	movk	w1, #0xffff, lsl #16
-<L150>:
-               	bl	 <L150>
-               	mov	x20, x0
-<L151>:
+<L64>:
+               	bl	 <L64>
                	fdiv	s0, s8, s13
-               	fcmp	s0, s0
-               	cset	w0, ne
-               	cbnz	w0,  <L153>
-               	mov	x0, x20
-<L152>:
-               	bl	 <L152>
-               	mov	x19, x0
-               	b	 <L155>
-<L153>:
-               	mov	x0, x20
-               	mov	w1, #0xffff             // =65535
-               	movk	w1, #0xffff, lsl #16
-<L154>:
-               	bl	 <L154>
-               	mov	x19, x0
-<L155>:
+<L65>:
+               	bl	 <L65>
                	fdiv	s0, s12, s8
-               	fcmp	s0, s0
-               	cset	w0, ne
-               	cbnz	w0,  <L157>
-               	mov	x0, x19
-<L156>:
-               	bl	 <L156>
-               	mov	x20, x0
-               	b	 <L159>
-<L157>:
-               	mov	x0, x19
-               	mov	w1, #0xffff             // =65535
-               	movk	w1, #0xffff, lsl #16
-<L158>:
-               	bl	 <L158>
-               	mov	x20, x0
-<L159>:
+<L66>:
+               	bl	 <L66>
                	fadd	s0, s15, s15
-               	fcmp	s0, s0
-               	cset	w0, ne
-               	cbnz	w0,  <L161>
-               	mov	x0, x20
-<L160>:
-               	bl	 <L160>
-               	mov	x19, x0
-               	b	 <L163>
-<L161>:
-               	mov	x0, x20
-               	mov	w1, #0xffff             // =65535
-               	movk	w1, #0xffff, lsl #16
-<L162>:
-               	bl	 <L162>
-               	mov	x19, x0
-<L163>:
+<L67>:
+               	bl	 <L67>
                	fcmp	s15, s12
                	cset	w1, mi
-               	mov	x0, x19
-<L164>:
-               	bl	 <L164>
+<L68>:
+               	bl	 <L68>
                	fmov	s31, wzr
                	fsub	s0, s31, s15
                	fcmp	s13, s0
                	cset	w1, mi
-<L165>:
-               	bl	 <L165>
-               	mov	x19, x0
+<L69>:
+               	bl	 <L69>
                	fsub	s0, s12, s12
-               	fcmp	s0, s0
-               	cset	w0, ne
-               	cbnz	w0,  <L167>
-               	mov	x0, x19
-<L166>:
-               	bl	 <L166>
-               	mov	x20, x0
-               	b	 <L169>
-<L167>:
-               	mov	x0, x19
-               	mov	w1, #0xffff             // =65535
-               	movk	w1, #0xffff, lsl #16
-<L168>:
-               	bl	 <L168>
-               	mov	x20, x0
-<L169>:
+<L70>:
+               	bl	 <L70>
                	fadd	s0, s13, s12
-               	fcmp	s0, s0
-               	cset	w0, ne
-               	cbnz	w0,  <L171>
-               	mov	x0, x20
-<L170>:
-               	bl	 <L170>
-               	mov	x19, x0
-               	b	 <L173>
-<L171>:
-               	mov	x0, x20
-               	mov	w1, #0xffff             // =65535
-               	movk	w1, #0xffff, lsl #16
-<L172>:
-               	bl	 <L172>
-               	mov	x19, x0
-<L173>:
+<L71>:
+               	bl	 <L71>
                	fmul	s0, s12, s10
-               	fcmp	s0, s0
-               	cset	w0, ne
-               	cbnz	w0,  <L175>
-               	mov	x0, x19
-<L174>:
-               	bl	 <L174>
-               	mov	x20, x0
-               	b	 <L177>
-<L175>:
-               	mov	x0, x19
-               	mov	w1, #0xffff             // =65535
-               	movk	w1, #0xffff, lsl #16
-<L176>:
-               	bl	 <L176>
-               	mov	x20, x0
-<L177>:
+<L72>:
+               	bl	 <L72>
                	fmul	s0, s13, s11
-               	fcmp	s0, s0
-               	cset	w0, ne
-               	cbnz	w0,  <L179>
-               	mov	x0, x20
-<L178>:
-               	bl	 <L178>
-               	mov	x19, x0
-               	b	 <L181>
-<L179>:
-               	mov	x0, x20
-               	mov	w1, #0xffff             // =65535
-               	movk	w1, #0xffff, lsl #16
-<L180>:
-               	bl	 <L180>
-               	mov	x19, x0
-<L181>:
+<L73>:
+               	bl	 <L73>
                	fdiv	s0, s12, s12
-               	fcmp	s0, s0
-               	cset	w0, ne
-               	cbnz	w0,  <L183>
-               	mov	x0, x19
-<L182>:
-               	bl	 <L182>
-               	mov	x20, x0
-               	b	 <L185>
-<L183>:
-               	mov	x0, x19
-               	mov	w1, #0xffff             // =65535
-               	movk	w1, #0xffff, lsl #16
-<L184>:
-               	bl	 <L184>
-               	mov	x20, x0
-<L185>:
+<L74>:
+               	bl	 <L74>
                	fdiv	s0, s10, s10
-               	fcmp	s0, s0
-               	cset	w0, ne
-               	cbnz	w0,  <L187>
-               	mov	x0, x20
-<L186>:
-               	bl	 <L186>
-               	mov	x19, x0
-               	b	 <L189>
-<L187>:
-               	mov	x0, x20
-               	mov	w1, #0xffff             // =65535
-               	movk	w1, #0xffff, lsl #16
-<L188>:
-               	bl	 <L188>
-               	mov	x19, x0
-<L189>:
+<L75>:
+               	bl	 <L75>
                	fdiv	s0, s11, s10
-               	fcmp	s0, s0
-               	cset	w0, ne
-               	cbnz	w0,  <L191>
-               	mov	x0, x19
-<L190>:
-               	bl	 <L190>
-               	mov	x20, x0
-               	b	 <L193>
-<L191>:
-               	mov	x0, x19
-               	mov	w1, #0xffff             // =65535
-               	movk	w1, #0xffff, lsl #16
-<L192>:
-               	bl	 <L192>
-               	mov	x20, x0
-<L193>:
+<L76>:
+               	bl	 <L76>
                	fmov	w1, s14
-               	mov	x0, x20
-<L194>:
-               	bl	 <L194>
+<L77>:
+               	bl	 <L77>
                	fcmp	s14, s14
                	cset	w1, ne
-<L195>:
-               	bl	 <L195>
+<L78>:
+               	bl	 <L78>
                	fcmp	s14, s14
                	cset	w1, eq
-<L196>:
-               	bl	 <L196>
+<L79>:
+               	bl	 <L79>
                	fcmp	s14, s14
                	cset	w1, mi
-<L197>:
-               	bl	 <L197>
+<L80>:
+               	bl	 <L80>
                	fcmp	s14, s14
                	cset	w1, ls
-<L198>:
-               	bl	 <L198>
+<L81>:
+               	bl	 <L81>
                	fneg	s9, s14
                	fmov	w1, s9
-<L199>:
-               	bl	 <L199>
+<L82>:
+               	bl	 <L82>
                	fneg	s0, s9
                	fmov	w1, s0
-<L200>:
-               	bl	 <L200>
-               	mov	x19, x0
+<L83>:
+               	bl	 <L83>
                	fadd	s0, s14, s8
-               	fcmp	s0, s0
-               	cset	w0, ne
-               	cbnz	w0,  <L202>
-               	mov	x0, x19
-<L201>:
-               	bl	 <L201>
-               	mov	x20, x0
-               	b	 <L204>
-<L202>:
-               	mov	x0, x19
-               	mov	w1, #0xffff             // =65535
-               	movk	w1, #0xffff, lsl #16
-<L203>:
-               	bl	 <L203>
-               	mov	x20, x0
-<L204>:
+<L84>:
+               	bl	 <L84>
                	fadd	s0, s8, s14
-               	fcmp	s0, s0
-               	cset	w0, ne
-               	cbnz	w0,  <L206>
-               	mov	x0, x20
-<L205>:
-               	bl	 <L205>
-               	mov	x19, x0
-               	b	 <L208>
-<L206>:
-               	mov	x0, x20
-               	mov	w1, #0xffff             // =65535
-               	movk	w1, #0xffff, lsl #16
-<L207>:
-               	bl	 <L207>
-               	mov	x19, x0
-<L208>:
+<L85>:
+               	bl	 <L85>
                	fmul	s0, s14, s10
-               	fcmp	s0, s0
-               	cset	w0, ne
-               	cbnz	w0,  <L210>
-               	mov	x0, x19
-<L209>:
-               	bl	 <L209>
-               	mov	x20, x0
-               	b	 <L212>
-<L210>:
-               	mov	x0, x19
-               	mov	w1, #0xffff             // =65535
-               	movk	w1, #0xffff, lsl #16
-<L211>:
-               	bl	 <L211>
-               	mov	x20, x0
-<L212>:
+<L86>:
+               	bl	 <L86>
                	fsub	s0, s14, s14
-               	fcmp	s0, s0
-               	cset	w0, ne
-               	cbnz	w0,  <L214>
-               	mov	x0, x20
-<L213>:
-               	bl	 <L213>
-               	mov	x19, x0
-               	b	 <L216>
-<L214>:
-               	mov	x0, x20
-               	mov	w1, #0xffff             // =65535
-               	movk	w1, #0xffff, lsl #16
-<L215>:
-               	bl	 <L215>
-               	mov	x19, x0
-<L216>:
+<L87>:
+               	bl	 <L87>
                	fdiv	s0, s14, s14
-               	fcmp	s0, s0
-               	cset	w0, ne
-               	cbnz	w0,  <L218>
-               	mov	x0, x19
-<L217>:
-               	bl	 <L217>
-               	mov	x20, x0
-               	b	 <L220>
-<L218>:
-               	mov	x0, x19
-               	mov	w1, #0xffff             // =65535
-               	movk	w1, #0xffff, lsl #16
-<L219>:
-               	bl	 <L219>
-               	mov	x20, x0
-<L220>:
+<L88>:
+               	bl	 <L88>
                	fdiv	s0, s14, s12
-               	fcmp	s0, s0
-               	cset	w0, ne
-               	cbnz	w0,  <L222>
-               	mov	x0, x20
-<L221>:
-               	bl	 <L221>
-               	mov	x19, x0
-               	b	 <L224>
-<L222>:
-               	mov	x0, x20
-               	mov	w1, #0xffff             // =65535
-               	movk	w1, #0xffff, lsl #16
-<L223>:
-               	bl	 <L223>
-               	mov	x19, x0
-<L224>:
-               	ldur	s31, [x29, #-0x50]
-               	ldur	s30, [x29, #-0x50]
-               	fcmp	s31, s30
-               	cset	w0, ne
-               	cbnz	w0,  <L226>
-               	mov	x0, x19
+<L89>:
+               	bl	 <L89>
                	ldur	s0, [x29, #-0x50]
-<L225>:
-               	bl	 <L225>
-               	mov	x20, x0
-               	b	 <L228>
-<L226>:
-               	mov	x0, x19
-               	mov	w1, #0xffff             // =65535
-               	movk	w1, #0xffff, lsl #16
-<L227>:
-               	bl	 <L227>
-               	mov	x20, x0
-<L228>:
-               	ldur	s31, [x29, #-0x40]
-               	ldur	s30, [x29, #-0x40]
-               	fcmp	s31, s30
-               	cset	w0, ne
-               	cbnz	w0,  <L230>
-               	mov	x0, x20
+<L90>:
+               	bl	 <L90>
                	ldur	s0, [x29, #-0x40]
-<L229>:
-               	bl	 <L229>
-               	mov	x19, x0
-               	b	 <L232>
-<L230>:
-               	mov	x0, x20
-               	mov	w1, #0xffff             // =65535
-               	movk	w1, #0xffff, lsl #16
-<L231>:
-               	bl	 <L231>
-               	mov	x19, x0
-<L232>:
-               	ldur	s31, [x29, #-0x30]
-               	ldur	s30, [x29, #-0x30]
-               	fcmp	s31, s30
-               	cset	w0, ne
-               	cbnz	w0,  <L234>
-               	mov	x0, x19
+<L91>:
+               	bl	 <L91>
                	ldur	s0, [x29, #-0x30]
-<L233>:
-               	bl	 <L233>
-               	mov	x20, x0
-               	b	 <L236>
-<L234>:
-               	mov	x0, x19
-               	mov	w1, #0xffff             // =65535
-               	movk	w1, #0xffff, lsl #16
-<L235>:
-               	bl	 <L235>
-               	mov	x20, x0
-<L236>:
+<L92>:
+               	bl	 <L92>
                	ldur	s31, [x29, #-0x40]
                	ldur	s30, [x29, #-0x50]
                	fadd	s0, s31, s30
-               	fcmp	s0, s0
-               	cset	w0, ne
-               	cbnz	w0,  <L238>
-               	mov	x0, x20
-<L237>:
-               	bl	 <L237>
-               	mov	x19, x0
-               	b	 <L240>
-<L238>:
-               	mov	x0, x20
-               	mov	w1, #0xffff             // =65535
-               	movk	w1, #0xffff, lsl #16
-<L239>:
-               	bl	 <L239>
-               	mov	x19, x0
-<L240>:
+<L93>:
+               	bl	 <L93>
                	ldur	s31, [x29, #-0x30]
                	ldur	s30, [x29, #-0x50]
                	fsub	s0, s31, s30
-               	fcmp	s0, s0
-               	cset	w0, ne
-               	cbnz	w0,  <L242>
-               	mov	x0, x19
-<L241>:
-               	bl	 <L241>
-               	mov	x20, x0
-               	b	 <L244>
-<L242>:
-               	mov	x0, x19
-               	mov	w1, #0xffff             // =65535
-               	movk	w1, #0xffff, lsl #16
-<L243>:
-               	bl	 <L243>
-               	mov	x20, x0
-<L244>:
+<L94>:
+               	bl	 <L94>
                	ldur	s31, [x29, #-0x50]
                	ldur	s30, [x29, #-0x50]
                	fadd	s0, s31, s30
-               	fcmp	s0, s0
-               	cset	w0, ne
-               	cbnz	w0,  <L246>
-               	mov	x0, x20
-<L245>:
-               	bl	 <L245>
-               	mov	x19, x0
-               	b	 <L248>
-<L246>:
-               	mov	x0, x20
-               	mov	w1, #0xffff             // =65535
-               	movk	w1, #0xffff, lsl #16
-<L247>:
-               	bl	 <L247>
-               	mov	x19, x0
-<L248>:
+<L95>:
+               	bl	 <L95>
                	ldur	s31, [x29, #-0x50]
                	fmov	s30, #1.50000000
                	fmul	s0, s31, s30
-               	fcmp	s0, s0
-               	cset	w0, ne
-               	cbnz	w0,  <L250>
-               	mov	x0, x19
-<L249>:
-               	bl	 <L249>
-               	mov	x20, x0
-               	b	 <L252>
-<L250>:
-               	mov	x0, x19
-               	mov	w1, #0xffff             // =65535
-               	movk	w1, #0xffff, lsl #16
-<L251>:
-               	bl	 <L251>
-               	mov	x20, x0
-<L252>:
+<L96>:
+               	bl	 <L96>
                	ldur	s31, [x29, #-0x50]
                	fmov	s30, #0.50000000
                	fmul	s0, s31, s30
-               	fcmp	s0, s0
-               	cset	w0, ne
-               	cbnz	w0,  <L254>
-               	mov	x0, x20
-<L253>:
-               	bl	 <L253>
-               	mov	x19, x0
-               	b	 <L256>
-<L254>:
-               	mov	x0, x20
-               	mov	w1, #0xffff             // =65535
-               	movk	w1, #0xffff, lsl #16
-<L255>:
-               	bl	 <L255>
-               	mov	x19, x0
-<L256>:
+<L97>:
+               	bl	 <L97>
                	ldur	s31, [x29, #-0x50]
                	fneg	s0, s31
-               	fcmp	s0, s0
-               	cset	w0, ne
-               	cbnz	w0,  <L258>
-               	mov	x0, x19
-<L257>:
-               	bl	 <L257>
-               	mov	x20, x0
-               	b	 <L260>
-<L258>:
-               	mov	x0, x19
-               	mov	w1, #0xffff             // =65535
-               	movk	w1, #0xffff, lsl #16
-<L259>:
-               	bl	 <L259>
-               	mov	x20, x0
-<L260>:
+<L98>:
+               	bl	 <L98>
                	ldur	s31, [x29, #-0x50]
                	mov	w16, #0x4b000000        // =1258291200
                	fmov	s30, w16
                	fmul	s0, s31, s30
-               	fcmp	s0, s0
-               	cset	w0, ne
-               	cbnz	w0,  <L262>
-               	mov	x0, x20
-<L261>:
-               	bl	 <L261>
-               	mov	x19, x0
-               	b	 <L264>
-<L262>:
-               	mov	x0, x20
-               	mov	w1, #0xffff             // =65535
-               	movk	w1, #0xffff, lsl #16
-<L263>:
-               	bl	 <L263>
-               	mov	x19, x0
-<L264>:
+<L99>:
+               	bl	 <L99>
                	ldur	s31, [x29, #-0x40]
                	ldur	s30, [x29, #-0x30]
                	fdiv	s0, s31, s30
-               	fcmp	s0, s0
-               	cset	w0, ne
-               	cbnz	w0,  <L266>
-               	mov	x0, x19
-<L265>:
-               	bl	 <L265>
-               	mov	x20, x0
-               	b	 <L268>
-<L266>:
-               	mov	x0, x19
-               	mov	w1, #0xffff             // =65535
-               	movk	w1, #0xffff, lsl #16
-<L267>:
-               	bl	 <L267>
-               	mov	x20, x0
-<L268>:
+<L100>:
+               	bl	 <L100>
                	ldur	s30, [x29, #-0x50]
                	fcmp	s10, s30
                	cset	w1, mi
-               	mov	x0, x20
-<L269>:
-               	bl	 <L269>
+<L101>:
+               	bl	 <L101>
                	ldur	s31, [x29, #-0x50]
                	fcmp	s31, s10
                	cset	w1, eq
-<L270>:
-               	bl	 <L270>
+<L102>:
+               	bl	 <L102>
                	fmov	s31, wzr
                	ldur	s30, [x29, #-0x50]
                	fsub	s0, s31, s30
                	fcmp	s0, s11
                	cset	w1, mi
-<L271>:
-               	bl	 <L271>
+<L103>:
+               	bl	 <L103>
                	mov	x19, x0
                	ldur	d9, [x29, #-0x30]
                	mov	w20, #0x0               // =0
                	cmp	w20, #0x1e
-               	b.lo	 <L272>
-               	b	 <L277>
-<L272>:
+               	b.lo	 <L104>
+               	b	 <L109>
+<L104>:
                	fmov	s30, #0.50000000
                	fmul	s11, s9, s30
                	fcmp	s11, s11
                	cset	w0, ne
-               	cbnz	w0,  <L274>
+               	cbnz	w0,  <L106>
                	mov	x0, x19
                	fmov	s0, s11
-<L273>:
-               	bl	 <L273>
+<L105>:
+               	bl	 <L105>
                	mov	x22, x0
-               	b	 <L276>
-<L274>:
+               	b	 <L108>
+<L106>:
                	mov	x0, x19
                	mov	w1, #0xffff             // =65535
                	movk	w1, #0xffff, lsl #16
-<L275>:
-               	bl	 <L275>
+<L107>:
+               	bl	 <L107>
                	mov	x22, x0
-<L276>:
+<L108>:
                	add	w20, w20, #0x1
                	mov	x19, x22
                	fmov	d9, d11
                	cmp	w20, #0x1e
-               	b.lo	 <L272>
-<L277>:
+               	b.lo	 <L104>
+<L109>:
                	sub	x20, x29, #0x20
                	str	xzr, [x20]
                	str	xzr, [x20, #0x8]
@@ -1312,7 +516,6 @@ Disassembly of section .text:
                	add	x0, x20, #0x8
                	mov	w17, #0x1               // =1
                	str	w17, [x0]
-<L278>:
                	add	x0, x20, #0xc
                	mov	w17, #0x7f800000        // =2139095040
                	str	w17, [x0]
@@ -1332,9 +535,9 @@ Disassembly of section .text:
                	str	w17, [x0]
                	mov	w22, #0x0               // =0
                	cmp	w22, #0x8
-               	b.lo	 <L279>
-               	b	 <L281>
-<L279>:
+               	b.lo	 <L110>
+               	b	 <L112>
+<L110>:
                	mov	w0, w22
                	add	x1, x20, x0, lsl #2
                	ldr	w0, [x1]
@@ -1342,13 +545,13 @@ Disassembly of section .text:
                	fmov	s0, w1
                	fmov	w1, s0
                	mov	x0, x19
-<L280>:
-               	bl	 <L280>
+<L111>:
+               	bl	 <L111>
                	add	w22, w22, #0x1
                	mov	x19, x0
                	cmp	w22, #0x8
-               	b.lo	 <L279>
-<L281>:
+               	b.lo	 <L110>
+<L112>:
                	mov	w17, #0x1000000         // =16777216
                	add	w0, w17, w21
                	mov	w17, #0x1               // =1
@@ -1368,128 +571,128 @@ Disassembly of section .text:
                	ucvtf	s0, w0
                	fcmp	s0, s0
                	cset	w0, ne
-               	cbnz	w0,  <L283>
+               	cbnz	w0,  <L114>
                	mov	x0, x19
-<L282>:
-               	bl	 <L282>
+<L113>:
+               	bl	 <L113>
                	mov	x26, x0
-               	b	 <L285>
-<L283>:
+               	b	 <L116>
+<L114>:
                	mov	x0, x19
                	mov	w1, #0xffff             // =65535
                	movk	w1, #0xffff, lsl #16
-<L284>:
-               	bl	 <L284>
+<L115>:
+               	bl	 <L115>
                	mov	x26, x0
-<L285>:
+<L116>:
                	ucvtf	s0, w20
                	fcmp	s0, s0
                	cset	w0, ne
-               	cbnz	w0,  <L287>
+               	cbnz	w0,  <L118>
                	mov	x0, x26
-<L286>:
-               	bl	 <L286>
+<L117>:
+               	bl	 <L117>
                	mov	x19, x0
-               	b	 <L289>
-<L287>:
+               	b	 <L120>
+<L118>:
                	mov	x0, x26
                	mov	w1, #0xffff             // =65535
                	movk	w1, #0xffff, lsl #16
-<L288>:
-               	bl	 <L288>
+<L119>:
+               	bl	 <L119>
                	mov	x19, x0
-<L289>:
+<L120>:
                	ucvtf	s0, w22
                	fcmp	s0, s0
                	cset	w0, ne
-               	cbnz	w0,  <L291>
+               	cbnz	w0,  <L122>
                	mov	x0, x19
-<L290>:
-               	bl	 <L290>
+<L121>:
+               	bl	 <L121>
                	mov	x20, x0
-               	b	 <L293>
-<L291>:
+               	b	 <L124>
+<L122>:
                	mov	x0, x19
                	mov	w1, #0xffff             // =65535
                	movk	w1, #0xffff, lsl #16
-<L292>:
-               	bl	 <L292>
+<L123>:
+               	bl	 <L123>
                	mov	x20, x0
-<L293>:
+<L124>:
                	ucvtf	s0, w23
                	fcmp	s0, s0
                	cset	w0, ne
-               	cbnz	w0,  <L295>
+               	cbnz	w0,  <L126>
                	mov	x0, x20
-<L294>:
-               	bl	 <L294>
+<L125>:
+               	bl	 <L125>
                	mov	x19, x0
-               	b	 <L297>
-<L295>:
+               	b	 <L128>
+<L126>:
                	mov	x0, x20
                	mov	w1, #0xffff             // =65535
                	movk	w1, #0xffff, lsl #16
-<L296>:
-               	bl	 <L296>
+<L127>:
+               	bl	 <L127>
                	mov	x19, x0
-<L297>:
+<L128>:
                	ucvtf	s0, w21
                	fcmp	s0, s0
                	cset	w0, ne
-               	cbnz	w0,  <L299>
+               	cbnz	w0,  <L130>
                	mov	x0, x19
-<L298>:
-               	bl	 <L298>
+<L129>:
+               	bl	 <L129>
                	mov	x20, x0
-               	b	 <L301>
-<L299>:
+               	b	 <L132>
+<L130>:
                	mov	x0, x19
                	mov	w1, #0xffff             // =65535
                	movk	w1, #0xffff, lsl #16
-<L300>:
-               	bl	 <L300>
+<L131>:
+               	bl	 <L131>
                	mov	x20, x0
-<L301>:
+<L132>:
                	scvtf	s0, w24
                	fcmp	s0, s0
                	cset	w0, ne
-               	cbnz	w0,  <L303>
+               	cbnz	w0,  <L134>
                	mov	x0, x20
-<L302>:
-               	bl	 <L302>
+<L133>:
+               	bl	 <L133>
                	mov	x19, x0
-               	b	 <L305>
-<L303>:
+               	b	 <L136>
+<L134>:
                	mov	x0, x20
                	mov	w1, #0xffff             // =65535
                	movk	w1, #0xffff, lsl #16
-<L304>:
-               	bl	 <L304>
+<L135>:
+               	bl	 <L135>
                	mov	x19, x0
-<L305>:
+<L136>:
                	scvtf	s0, w25
                	fcmp	s0, s0
                	cset	w0, ne
-               	cbnz	w0,  <L307>
+               	cbnz	w0,  <L138>
                	mov	x0, x19
-<L306>:
-               	bl	 <L306>
+<L137>:
+               	bl	 <L137>
                	mov	x20, x0
-               	b	 <L309>
-<L307>:
+               	b	 <L140>
+<L138>:
                	mov	x0, x19
                	mov	w1, #0xffff             // =65535
                	movk	w1, #0xffff, lsl #16
-<L308>:
-               	bl	 <L308>
+<L139>:
+               	bl	 <L139>
                	mov	x20, x0
-<L309>:
+<L140>:
                	fmov	s31, #1.50000000
                	fmul	s0, s31, s8
                	mov	w16, #0x4b800000        // =1266679808
                	fmov	s31, w16
                	fmul	s9, s31, s8
-               	adrp	x16, 0x1000 <L278>
+               	adrp	x16, 0x0 <corpus.cases.float.special_f32.opaque_f32>
                	ldr	s31, [x16]
                	fmul	s11, s31, s8
                	fmov	s31, wzr
@@ -1498,39 +701,39 @@ Disassembly of section .text:
                	fmul	s13, s31, s8
                	fcvtzu	w1, s0
                	mov	x0, x20
-<L310>:
-               	bl	 <L310>
+<L141>:
+               	bl	 <L141>
                	fcvtzu	w1, s9
-<L311>:
-               	bl	 <L311>
+<L142>:
+               	bl	 <L142>
                	fcvtzu	w1, s11
-<L312>:
-               	bl	 <L312>
+<L143>:
+               	bl	 <L143>
                	fcvtzu	w1, s13
-<L313>:
-               	bl	 <L313>
+<L144>:
+               	bl	 <L144>
                	fcvtzu	w1, s10
-<L314>:
-               	bl	 <L314>
+<L145>:
+               	bl	 <L145>
                	fcvtzs	w1, s12
-<L315>:
-               	bl	 <L315>
+<L146>:
+               	bl	 <L146>
                	fcvtzs	w1, s11
-<L316>:
-               	bl	 <L316>
+<L147>:
+               	bl	 <L147>
                	fmov	s31, wzr
                	fsub	s0, s31, s13
                	fcvtzs	w1, s0
-<L317>:
-               	bl	 <L317>
+<L148>:
+               	bl	 <L148>
                	fcvtzs	x1, s12
-<L318>:
-               	bl	 <L318>
+<L149>:
+               	bl	 <L149>
                	fmov	s31, wzr
                	fsub	s0, s31, s9
                	fcvtzs	x1, s0
-<L319>:
-               	bl	 <L319>
+<L150>:
+               	bl	 <L150>
                	ldp	d8, d9, [x29, #-0xa0]
                	ldp	d10, d11, [x29, #-0xb0]
                	ldp	d12, d13, [x29, #-0xc0]

--- a/test/golden/aarch64-linux/float/special_f64.dis
+++ b/test/golden/aarch64-linux/float/special_f64.dis
@@ -185,1255 +185,299 @@ Disassembly of section .text:
                	mov	x21, x0
 <L20>:
                	fadd	d0, d11, d11
-               	fcmp	d0, d0
-               	cset	w0, ne
-               	cbnz	w0,  <L22>
                	mov	x0, x21
 <L21>:
                	bl	 <L21>
-               	mov	x20, x0
-               	b	 <L24>
+               	fsub	d0, d10, d10
 <L22>:
-               	mov	x0, x21
-               	mov	x1, #0xffff             // =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
+               	bl	 <L22>
+               	fsub	d0, d10, d11
 <L23>:
                	bl	 <L23>
-               	mov	x20, x0
+               	fsub	d0, d11, d10
 <L24>:
-               	fsub	d0, d10, d10
-               	fcmp	d0, d0
-               	cset	w0, ne
-               	cbnz	w0,  <L26>
-               	mov	x0, x20
+               	bl	 <L24>
+               	fsub	d0, d11, d11
 <L25>:
                	bl	 <L25>
-               	mov	x21, x0
-               	b	 <L28>
+               	fmul	d0, d10, d8
 <L26>:
-               	mov	x0, x20
-               	mov	x1, #0xffff             // =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
+               	bl	 <L26>
+               	fmul	d0, d10, d9
 <L27>:
                	bl	 <L27>
-               	mov	x21, x0
+               	fmul	d0, d11, d8
 <L28>:
-               	fsub	d0, d10, d11
-               	fcmp	d0, d0
-               	cset	w0, ne
-               	cbnz	w0,  <L30>
-               	mov	x0, x21
+               	bl	 <L28>
+               	fmul	d0, d11, d9
 <L29>:
                	bl	 <L29>
-               	mov	x20, x0
-               	b	 <L32>
+               	fmul	d0, d11, d11
 <L30>:
-               	mov	x0, x21
-               	mov	x1, #0xffff             // =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
+               	bl	 <L30>
+               	fmul	d0, d10, d11
 <L31>:
                	bl	 <L31>
-               	mov	x20, x0
+               	fneg	d0, d10
 <L32>:
-               	fsub	d0, d11, d10
-               	fcmp	d0, d0
-               	cset	w0, ne
-               	cbnz	w0,  <L34>
-               	mov	x0, x20
+               	bl	 <L32>
+               	fneg	d0, d11
 <L33>:
                	bl	 <L33>
-               	mov	x21, x0
-               	b	 <L36>
+               	fdiv	d0, d10, d8
 <L34>:
-               	mov	x0, x20
-               	mov	x1, #0xffff             // =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
+               	bl	 <L34>
+               	fdiv	d0, d10, d9
 <L35>:
                	bl	 <L35>
-               	mov	x21, x0
+               	fdiv	d0, d11, d8
 <L36>:
-               	fsub	d0, d11, d11
-               	fcmp	d0, d0
-               	cset	w0, ne
-               	cbnz	w0,  <L38>
-               	mov	x0, x21
+               	bl	 <L36>
+               	fdiv	d0, d11, d9
 <L37>:
                	bl	 <L37>
-               	mov	x20, x0
-               	b	 <L40>
-<L38>:
-               	mov	x0, x21
-               	mov	x1, #0xffff             // =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L39>:
-               	bl	 <L39>
-               	mov	x20, x0
-<L40>:
-               	fmul	d0, d10, d8
-               	fcmp	d0, d0
-               	cset	w0, ne
-               	cbnz	w0,  <L42>
-               	mov	x0, x20
-<L41>:
-               	bl	 <L41>
-               	mov	x21, x0
-               	b	 <L44>
-<L42>:
-               	mov	x0, x20
-               	mov	x1, #0xffff             // =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L43>:
-               	bl	 <L43>
-               	mov	x21, x0
-<L44>:
-               	fmul	d0, d10, d9
-               	fcmp	d0, d0
-               	cset	w0, ne
-               	cbnz	w0,  <L46>
-               	mov	x0, x21
-<L45>:
-               	bl	 <L45>
-               	mov	x20, x0
-               	b	 <L48>
-<L46>:
-               	mov	x0, x21
-               	mov	x1, #0xffff             // =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L47>:
-               	bl	 <L47>
-               	mov	x20, x0
-<L48>:
-               	fmul	d0, d11, d8
-               	fcmp	d0, d0
-               	cset	w0, ne
-               	cbnz	w0,  <L50>
-               	mov	x0, x20
-<L49>:
-               	bl	 <L49>
-               	mov	x21, x0
-               	b	 <L52>
-<L50>:
-               	mov	x0, x20
-               	mov	x1, #0xffff             // =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L51>:
-               	bl	 <L51>
-               	mov	x21, x0
-<L52>:
-               	fmul	d0, d11, d9
-               	fcmp	d0, d0
-               	cset	w0, ne
-               	cbnz	w0,  <L54>
-               	mov	x0, x21
-<L53>:
-               	bl	 <L53>
-               	mov	x20, x0
-               	b	 <L56>
-<L54>:
-               	mov	x0, x21
-               	mov	x1, #0xffff             // =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L55>:
-               	bl	 <L55>
-               	mov	x20, x0
-<L56>:
-               	fmul	d0, d11, d11
-               	fcmp	d0, d0
-               	cset	w0, ne
-               	cbnz	w0,  <L58>
-               	mov	x0, x20
-<L57>:
-               	bl	 <L57>
-               	mov	x21, x0
-               	b	 <L60>
-<L58>:
-               	mov	x0, x20
-               	mov	x1, #0xffff             // =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L59>:
-               	bl	 <L59>
-               	mov	x21, x0
-<L60>:
-               	fmul	d0, d10, d11
-               	fcmp	d0, d0
-               	cset	w0, ne
-               	cbnz	w0,  <L62>
-               	mov	x0, x21
-<L61>:
-               	bl	 <L61>
-               	mov	x20, x0
-               	b	 <L64>
-<L62>:
-               	mov	x0, x21
-               	mov	x1, #0xffff             // =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L63>:
-               	bl	 <L63>
-               	mov	x20, x0
-<L64>:
-               	fneg	d0, d10
-               	fcmp	d0, d0
-               	cset	w0, ne
-               	cbnz	w0,  <L66>
-               	mov	x0, x20
-<L65>:
-               	bl	 <L65>
-               	mov	x21, x0
-               	b	 <L68>
-<L66>:
-               	mov	x0, x20
-               	mov	x1, #0xffff             // =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L67>:
-               	bl	 <L67>
-               	mov	x21, x0
-<L68>:
-               	fneg	d0, d11
-               	fcmp	d0, d0
-               	cset	w0, ne
-               	cbnz	w0,  <L70>
-               	mov	x0, x21
-<L69>:
-               	bl	 <L69>
-               	mov	x20, x0
-               	b	 <L72>
-<L70>:
-               	mov	x0, x21
-               	mov	x1, #0xffff             // =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L71>:
-               	bl	 <L71>
-               	mov	x20, x0
-<L72>:
-               	fdiv	d0, d10, d8
-               	fcmp	d0, d0
-               	cset	w0, ne
-               	cbnz	w0,  <L74>
-               	mov	x0, x20
-<L73>:
-               	bl	 <L73>
-               	mov	x21, x0
-               	b	 <L76>
-<L74>:
-               	mov	x0, x20
-               	mov	x1, #0xffff             // =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L75>:
-               	bl	 <L75>
-               	mov	x21, x0
-<L76>:
-               	fdiv	d0, d10, d9
-               	fcmp	d0, d0
-               	cset	w0, ne
-               	cbnz	w0,  <L78>
-               	mov	x0, x21
-<L77>:
-               	bl	 <L77>
-               	mov	x20, x0
-               	b	 <L80>
-<L78>:
-               	mov	x0, x21
-               	mov	x1, #0xffff             // =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L79>:
-               	bl	 <L79>
-               	mov	x20, x0
-<L80>:
-               	fdiv	d0, d11, d8
-               	fcmp	d0, d0
-               	cset	w0, ne
-               	cbnz	w0,  <L82>
-               	mov	x0, x20
-<L81>:
-               	bl	 <L81>
-               	mov	x21, x0
-               	b	 <L84>
-<L82>:
-               	mov	x0, x20
-               	mov	x1, #0xffff             // =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L83>:
-               	bl	 <L83>
-               	mov	x21, x0
-<L84>:
-               	fdiv	d0, d11, d9
-               	fcmp	d0, d0
-               	cset	w0, ne
-               	cbnz	w0,  <L86>
-               	mov	x0, x21
-<L85>:
-               	bl	 <L85>
-               	mov	x20, x0
-               	b	 <L88>
-<L86>:
-               	mov	x0, x21
-               	mov	x1, #0xffff             // =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L87>:
-               	bl	 <L87>
-               	mov	x20, x0
-<L88>:
                	fcmp	d10, d11
                	cset	w1, eq
-               	mov	x0, x20
-<L89>:
-               	bl	 <L89>
+<L38>:
+               	bl	 <L38>
                	fcmp	d10, d11
                	cset	w1, mi
-<L90>:
-               	bl	 <L90>
+<L39>:
+               	bl	 <L39>
                	fcmp	d11, d10
                	cset	w1, mi
+<L40>:
+               	bl	 <L40>
+               	fmov	d0, d12
+<L41>:
+               	bl	 <L41>
+               	fmov	d0, d13
+<L42>:
+               	bl	 <L42>
+               	fneg	d0, d12
+<L43>:
+               	bl	 <L43>
+               	fdiv	d0, d8, d10
+<L44>:
+               	bl	 <L44>
+               	fdiv	d0, d8, d11
+<L45>:
+               	bl	 <L45>
+               	fdiv	d0, d9, d10
+<L46>:
+               	bl	 <L46>
+               	fdiv	d0, d9, d11
+<L47>:
+               	bl	 <L47>
+               	fadd	d0, d12, d8
+<L48>:
+               	bl	 <L48>
+               	fadd	d0, d12, d12
+<L49>:
+               	bl	 <L49>
+               	fsub	d0, d12, d13
+<L50>:
+               	bl	 <L50>
+               	fmul	d0, d12, d12
+<L51>:
+               	bl	 <L51>
+               	fmul	d0, d12, d13
+<L52>:
+               	bl	 <L52>
+               	fmul	d0, d12, d9
+<L53>:
+               	bl	 <L53>
+               	fdiv	d0, d8, d12
+<L54>:
+               	bl	 <L54>
+               	fdiv	d0, d9, d12
+<L55>:
+               	bl	 <L55>
+               	fdiv	d0, d8, d13
+<L56>:
+               	bl	 <L56>
+               	fdiv	d0, d12, d8
+<L57>:
+               	bl	 <L57>
+               	fadd	d0, d15, d15
+<L58>:
+               	bl	 <L58>
+               	fcmp	d15, d12
+               	cset	w1, mi
+<L59>:
+               	bl	 <L59>
+               	fmov	d31, xzr
+               	fsub	d0, d31, d15
+               	fcmp	d13, d0
+               	cset	w1, mi
+<L60>:
+               	bl	 <L60>
+               	fsub	d0, d12, d12
+<L61>:
+               	bl	 <L61>
+               	fadd	d0, d13, d12
+<L62>:
+               	bl	 <L62>
+               	fmul	d0, d12, d10
+<L63>:
+               	bl	 <L63>
+               	fmul	d0, d13, d11
+<L64>:
+               	bl	 <L64>
+               	fdiv	d0, d12, d12
+<L65>:
+               	bl	 <L65>
+               	fdiv	d0, d10, d10
+<L66>:
+               	bl	 <L66>
+               	fdiv	d0, d11, d10
+<L67>:
+               	bl	 <L67>
+               	fmov	x1, d14
+<L68>:
+               	bl	 <L68>
+               	fcmp	d14, d14
+               	cset	w1, ne
+<L69>:
+               	bl	 <L69>
+               	fcmp	d14, d14
+               	cset	w1, eq
+<L70>:
+               	bl	 <L70>
+               	fcmp	d14, d14
+               	cset	w1, mi
+<L71>:
+               	bl	 <L71>
+               	fcmp	d14, d14
+               	cset	w1, ls
+<L72>:
+               	bl	 <L72>
+               	fneg	d9, d14
+               	fmov	x1, d9
+<L73>:
+               	bl	 <L73>
+               	fneg	d0, d9
+               	fmov	x1, d0
+<L74>:
+               	bl	 <L74>
+               	fadd	d0, d14, d8
+<L75>:
+               	bl	 <L75>
+               	fadd	d0, d8, d14
+<L76>:
+               	bl	 <L76>
+               	fmul	d0, d14, d10
+<L77>:
+               	bl	 <L77>
+               	fsub	d0, d14, d14
+<L78>:
+               	bl	 <L78>
+               	fdiv	d0, d14, d14
+<L79>:
+               	bl	 <L79>
+               	fdiv	d0, d14, d12
+<L80>:
+               	bl	 <L80>
+               	ldur	d0, [x29, #-0x70]
+<L81>:
+               	bl	 <L81>
+               	ldur	d0, [x29, #-0x60]
+<L82>:
+               	bl	 <L82>
+               	ldur	d0, [x29, #-0x50]
+<L83>:
+               	bl	 <L83>
+               	ldur	d31, [x29, #-0x60]
+               	ldur	d30, [x29, #-0x70]
+               	fadd	d0, d31, d30
+<L84>:
+               	bl	 <L84>
+               	ldur	d31, [x29, #-0x50]
+               	ldur	d30, [x29, #-0x70]
+               	fsub	d0, d31, d30
+<L85>:
+               	bl	 <L85>
+               	ldur	d31, [x29, #-0x70]
+               	ldur	d30, [x29, #-0x70]
+               	fadd	d0, d31, d30
+<L86>:
+               	bl	 <L86>
+               	ldur	d31, [x29, #-0x70]
+               	fmov	d30, #1.50000000
+               	fmul	d0, d31, d30
+<L87>:
+               	bl	 <L87>
+               	ldur	d31, [x29, #-0x70]
+               	fmov	d30, #0.50000000
+               	fmul	d0, d31, d30
+<L88>:
+               	bl	 <L88>
+               	ldur	d31, [x29, #-0x70]
+               	fneg	d0, d31
+<L89>:
+               	bl	 <L89>
+               	ldur	d31, [x29, #-0x70]
+               	mov	x16, #0x4330000000000000 // =4841369599423283200
+               	fmov	d30, x16
+               	fmul	d0, d31, d30
+<L90>:
+               	bl	 <L90>
+               	ldur	d31, [x29, #-0x60]
+               	ldur	d30, [x29, #-0x50]
+               	fdiv	d0, d31, d30
 <L91>:
                	bl	 <L91>
-               	mov	x20, x0
-               	fcmp	d12, d12
-               	cset	w0, ne
-               	cbnz	w0,  <L93>
-               	mov	x0, x20
-               	fmov	d0, d12
+               	ldur	d30, [x29, #-0x70]
+               	fcmp	d10, d30
+               	cset	w1, mi
 <L92>:
                	bl	 <L92>
-               	mov	x21, x0
-               	b	 <L95>
+               	ldur	d31, [x29, #-0x70]
+               	fcmp	d31, d10
+               	cset	w1, eq
 <L93>:
-               	mov	x0, x20
-               	mov	x1, #0xffff             // =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
+               	bl	 <L93>
+               	fmov	d31, xzr
+               	ldur	d30, [x29, #-0x70]
+               	fsub	d0, d31, d30
+               	fcmp	d0, d11
+               	cset	w1, mi
 <L94>:
                	bl	 <L94>
-               	mov	x21, x0
+               	mov	x20, x0
+               	ldur	d9, [x29, #-0x50]
+               	mov	x21, #0x0               // =0
+               	cmp	x21, #0x3c
+               	b.lo	 <L95>
+               	b	 <L100>
 <L95>:
-               	fcmp	d13, d13
+               	fmov	d30, #0.50000000
+               	fmul	d12, d9, d30
+               	fcmp	d12, d12
                	cset	w0, ne
                	cbnz	w0,  <L97>
-               	mov	x0, x21
-               	fmov	d0, d13
+               	mov	x0, x20
+               	fmov	d0, d12
 <L96>:
                	bl	 <L96>
-               	mov	x20, x0
+               	mov	x22, x0
                	b	 <L99>
 <L97>:
-               	mov	x0, x21
+               	mov	x0, x20
                	mov	x1, #0xffff             // =65535
                	movk	x1, #0xffff, lsl #16
                	movk	x1, #0xffff, lsl #32
                	movk	x1, #0xffff, lsl #48
 <L98>:
                	bl	 <L98>
-               	mov	x20, x0
+               	mov	x22, x0
 <L99>:
-               	fneg	d0, d12
-               	fcmp	d0, d0
-               	cset	w0, ne
-               	cbnz	w0,  <L101>
-               	mov	x0, x20
-<L100>:
-               	bl	 <L100>
-               	mov	x21, x0
-               	b	 <L103>
-<L101>:
-               	mov	x0, x20
-               	mov	x1, #0xffff             // =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L102>:
-               	bl	 <L102>
-               	mov	x21, x0
-<L103>:
-               	fdiv	d0, d8, d10
-               	fcmp	d0, d0
-               	cset	w0, ne
-               	cbnz	w0,  <L105>
-               	mov	x0, x21
-<L104>:
-               	bl	 <L104>
-               	mov	x20, x0
-               	b	 <L107>
-<L105>:
-               	mov	x0, x21
-               	mov	x1, #0xffff             // =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L106>:
-               	bl	 <L106>
-               	mov	x20, x0
-<L107>:
-               	fdiv	d0, d8, d11
-               	fcmp	d0, d0
-               	cset	w0, ne
-               	cbnz	w0,  <L109>
-               	mov	x0, x20
-<L108>:
-               	bl	 <L108>
-               	mov	x21, x0
-               	b	 <L111>
-<L109>:
-               	mov	x0, x20
-               	mov	x1, #0xffff             // =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L110>:
-               	bl	 <L110>
-               	mov	x21, x0
-<L111>:
-               	fdiv	d0, d9, d10
-               	fcmp	d0, d0
-               	cset	w0, ne
-               	cbnz	w0,  <L113>
-               	mov	x0, x21
-<L112>:
-               	bl	 <L112>
-               	mov	x20, x0
-               	b	 <L115>
-<L113>:
-               	mov	x0, x21
-               	mov	x1, #0xffff             // =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L114>:
-               	bl	 <L114>
-               	mov	x20, x0
-<L115>:
-               	fdiv	d0, d9, d11
-               	fcmp	d0, d0
-               	cset	w0, ne
-               	cbnz	w0,  <L117>
-               	mov	x0, x20
-<L116>:
-               	bl	 <L116>
-               	mov	x21, x0
-               	b	 <L119>
-<L117>:
-               	mov	x0, x20
-               	mov	x1, #0xffff             // =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L118>:
-               	bl	 <L118>
-               	mov	x21, x0
-<L119>:
-               	fadd	d0, d12, d8
-               	fcmp	d0, d0
-               	cset	w0, ne
-               	cbnz	w0,  <L121>
-               	mov	x0, x21
-<L120>:
-               	bl	 <L120>
-               	mov	x20, x0
-               	b	 <L123>
-<L121>:
-               	mov	x0, x21
-               	mov	x1, #0xffff             // =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L122>:
-               	bl	 <L122>
-               	mov	x20, x0
-<L123>:
-               	fadd	d0, d12, d12
-               	fcmp	d0, d0
-               	cset	w0, ne
-               	cbnz	w0,  <L125>
-               	mov	x0, x20
-<L124>:
-               	bl	 <L124>
-               	mov	x21, x0
-               	b	 <L127>
-<L125>:
-               	mov	x0, x20
-               	mov	x1, #0xffff             // =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L126>:
-               	bl	 <L126>
-               	mov	x21, x0
-<L127>:
-               	fsub	d0, d12, d13
-               	fcmp	d0, d0
-               	cset	w0, ne
-               	cbnz	w0,  <L129>
-               	mov	x0, x21
-<L128>:
-               	bl	 <L128>
-               	mov	x20, x0
-               	b	 <L131>
-<L129>:
-               	mov	x0, x21
-               	mov	x1, #0xffff             // =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L130>:
-               	bl	 <L130>
-               	mov	x20, x0
-<L131>:
-               	fmul	d0, d12, d12
-               	fcmp	d0, d0
-               	cset	w0, ne
-               	cbnz	w0,  <L133>
-               	mov	x0, x20
-<L132>:
-               	bl	 <L132>
-               	mov	x21, x0
-               	b	 <L135>
-<L133>:
-               	mov	x0, x20
-               	mov	x1, #0xffff             // =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L134>:
-               	bl	 <L134>
-               	mov	x21, x0
-<L135>:
-               	fmul	d0, d12, d13
-               	fcmp	d0, d0
-               	cset	w0, ne
-               	cbnz	w0,  <L137>
-               	mov	x0, x21
-<L136>:
-               	bl	 <L136>
-               	mov	x20, x0
-               	b	 <L139>
-<L137>:
-               	mov	x0, x21
-               	mov	x1, #0xffff             // =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L138>:
-               	bl	 <L138>
-               	mov	x20, x0
-<L139>:
-               	fmul	d0, d12, d9
-               	fcmp	d0, d0
-               	cset	w0, ne
-               	cbnz	w0,  <L141>
-               	mov	x0, x20
-<L140>:
-               	bl	 <L140>
-               	mov	x21, x0
-               	b	 <L143>
-<L141>:
-               	mov	x0, x20
-               	mov	x1, #0xffff             // =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L142>:
-               	bl	 <L142>
-               	mov	x21, x0
-<L143>:
-               	fdiv	d0, d8, d12
-               	fcmp	d0, d0
-               	cset	w0, ne
-               	cbnz	w0,  <L145>
-               	mov	x0, x21
-<L144>:
-               	bl	 <L144>
-               	mov	x20, x0
-               	b	 <L147>
-<L145>:
-               	mov	x0, x21
-               	mov	x1, #0xffff             // =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L146>:
-               	bl	 <L146>
-               	mov	x20, x0
-<L147>:
-               	fdiv	d0, d9, d12
-               	fcmp	d0, d0
-               	cset	w0, ne
-               	cbnz	w0,  <L149>
-               	mov	x0, x20
-<L148>:
-               	bl	 <L148>
-               	mov	x21, x0
-               	b	 <L151>
-<L149>:
-               	mov	x0, x20
-               	mov	x1, #0xffff             // =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L150>:
-               	bl	 <L150>
-               	mov	x21, x0
-<L151>:
-               	fdiv	d0, d8, d13
-               	fcmp	d0, d0
-               	cset	w0, ne
-               	cbnz	w0,  <L153>
-               	mov	x0, x21
-<L152>:
-               	bl	 <L152>
-               	mov	x20, x0
-               	b	 <L155>
-<L153>:
-               	mov	x0, x21
-               	mov	x1, #0xffff             // =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L154>:
-               	bl	 <L154>
-               	mov	x20, x0
-<L155>:
-               	fdiv	d0, d12, d8
-               	fcmp	d0, d0
-               	cset	w0, ne
-               	cbnz	w0,  <L157>
-               	mov	x0, x20
-<L156>:
-               	bl	 <L156>
-               	mov	x21, x0
-               	b	 <L159>
-<L157>:
-               	mov	x0, x20
-               	mov	x1, #0xffff             // =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L158>:
-               	bl	 <L158>
-               	mov	x21, x0
-<L159>:
-               	fadd	d0, d15, d15
-               	fcmp	d0, d0
-               	cset	w0, ne
-               	cbnz	w0,  <L161>
-               	mov	x0, x21
-<L160>:
-               	bl	 <L160>
-               	mov	x20, x0
-               	b	 <L163>
-<L161>:
-               	mov	x0, x21
-               	mov	x1, #0xffff             // =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L162>:
-               	bl	 <L162>
-               	mov	x20, x0
-<L163>:
-               	fcmp	d15, d12
-               	cset	w1, mi
-               	mov	x0, x20
-<L164>:
-               	bl	 <L164>
-               	fmov	d31, xzr
-               	fsub	d0, d31, d15
-               	fcmp	d13, d0
-               	cset	w1, mi
-<L165>:
-               	bl	 <L165>
-               	mov	x20, x0
-               	fsub	d0, d12, d12
-               	fcmp	d0, d0
-               	cset	w0, ne
-               	cbnz	w0,  <L167>
-               	mov	x0, x20
-<L166>:
-               	bl	 <L166>
-               	mov	x21, x0
-               	b	 <L169>
-<L167>:
-               	mov	x0, x20
-               	mov	x1, #0xffff             // =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L168>:
-               	bl	 <L168>
-               	mov	x21, x0
-<L169>:
-               	fadd	d0, d13, d12
-               	fcmp	d0, d0
-               	cset	w0, ne
-               	cbnz	w0,  <L171>
-               	mov	x0, x21
-<L170>:
-               	bl	 <L170>
-               	mov	x20, x0
-               	b	 <L173>
-<L171>:
-               	mov	x0, x21
-               	mov	x1, #0xffff             // =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L172>:
-               	bl	 <L172>
-               	mov	x20, x0
-<L173>:
-               	fmul	d0, d12, d10
-               	fcmp	d0, d0
-               	cset	w0, ne
-               	cbnz	w0,  <L175>
-               	mov	x0, x20
-<L174>:
-               	bl	 <L174>
-               	mov	x21, x0
-               	b	 <L177>
-<L175>:
-               	mov	x0, x20
-               	mov	x1, #0xffff             // =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L176>:
-               	bl	 <L176>
-               	mov	x21, x0
-<L177>:
-               	fmul	d0, d13, d11
-               	fcmp	d0, d0
-               	cset	w0, ne
-               	cbnz	w0,  <L179>
-               	mov	x0, x21
-<L178>:
-               	bl	 <L178>
-               	mov	x20, x0
-               	b	 <L181>
-<L179>:
-               	mov	x0, x21
-               	mov	x1, #0xffff             // =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L180>:
-               	bl	 <L180>
-               	mov	x20, x0
-<L181>:
-               	fdiv	d0, d12, d12
-               	fcmp	d0, d0
-               	cset	w0, ne
-               	cbnz	w0,  <L183>
-               	mov	x0, x20
-<L182>:
-               	bl	 <L182>
-               	mov	x21, x0
-               	b	 <L185>
-<L183>:
-               	mov	x0, x20
-               	mov	x1, #0xffff             // =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L184>:
-               	bl	 <L184>
-               	mov	x21, x0
-<L185>:
-               	fdiv	d0, d10, d10
-               	fcmp	d0, d0
-               	cset	w0, ne
-               	cbnz	w0,  <L187>
-               	mov	x0, x21
-<L186>:
-               	bl	 <L186>
-               	mov	x20, x0
-               	b	 <L189>
-<L187>:
-               	mov	x0, x21
-               	mov	x1, #0xffff             // =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L188>:
-               	bl	 <L188>
-               	mov	x20, x0
-<L189>:
-               	fdiv	d0, d11, d10
-               	fcmp	d0, d0
-               	cset	w0, ne
-               	cbnz	w0,  <L191>
-               	mov	x0, x20
-<L190>:
-               	bl	 <L190>
-               	mov	x21, x0
-               	b	 <L193>
-<L191>:
-               	mov	x0, x20
-               	mov	x1, #0xffff             // =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L192>:
-               	bl	 <L192>
-               	mov	x21, x0
-<L193>:
-               	fmov	x1, d14
-               	mov	x0, x21
-<L194>:
-               	bl	 <L194>
-               	fcmp	d14, d14
-               	cset	w1, ne
-<L195>:
-               	bl	 <L195>
-               	fcmp	d14, d14
-               	cset	w1, eq
-<L196>:
-               	bl	 <L196>
-               	fcmp	d14, d14
-               	cset	w1, mi
-<L197>:
-               	bl	 <L197>
-               	fcmp	d14, d14
-               	cset	w1, ls
-<L198>:
-               	bl	 <L198>
-               	fneg	d9, d14
-               	fmov	x1, d9
-<L199>:
-               	bl	 <L199>
-               	fneg	d0, d9
-               	fmov	x1, d0
-<L200>:
-               	bl	 <L200>
-               	mov	x20, x0
-               	fadd	d0, d14, d8
-               	fcmp	d0, d0
-               	cset	w0, ne
-               	cbnz	w0,  <L202>
-               	mov	x0, x20
-<L201>:
-               	bl	 <L201>
-               	mov	x21, x0
-               	b	 <L204>
-<L202>:
-               	mov	x0, x20
-               	mov	x1, #0xffff             // =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L203>:
-               	bl	 <L203>
-               	mov	x21, x0
-<L204>:
-               	fadd	d0, d8, d14
-               	fcmp	d0, d0
-               	cset	w0, ne
-               	cbnz	w0,  <L206>
-               	mov	x0, x21
-<L205>:
-               	bl	 <L205>
-               	mov	x20, x0
-               	b	 <L208>
-<L206>:
-               	mov	x0, x21
-               	mov	x1, #0xffff             // =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L207>:
-               	bl	 <L207>
-               	mov	x20, x0
-<L208>:
-               	fmul	d0, d14, d10
-               	fcmp	d0, d0
-               	cset	w0, ne
-               	cbnz	w0,  <L210>
-               	mov	x0, x20
-<L209>:
-               	bl	 <L209>
-               	mov	x21, x0
-               	b	 <L212>
-<L210>:
-               	mov	x0, x20
-               	mov	x1, #0xffff             // =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L211>:
-               	bl	 <L211>
-               	mov	x21, x0
-<L212>:
-               	fsub	d0, d14, d14
-               	fcmp	d0, d0
-               	cset	w0, ne
-               	cbnz	w0,  <L214>
-               	mov	x0, x21
-<L213>:
-               	bl	 <L213>
-               	mov	x20, x0
-               	b	 <L216>
-<L214>:
-               	mov	x0, x21
-               	mov	x1, #0xffff             // =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L215>:
-               	bl	 <L215>
-               	mov	x20, x0
-<L216>:
-               	fdiv	d0, d14, d14
-               	fcmp	d0, d0
-               	cset	w0, ne
-               	cbnz	w0,  <L218>
-               	mov	x0, x20
-<L217>:
-               	bl	 <L217>
-               	mov	x21, x0
-               	b	 <L220>
-<L218>:
-               	mov	x0, x20
-               	mov	x1, #0xffff             // =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L219>:
-               	bl	 <L219>
-               	mov	x21, x0
-<L220>:
-               	fdiv	d0, d14, d12
-               	fcmp	d0, d0
-               	cset	w0, ne
-               	cbnz	w0,  <L222>
-               	mov	x0, x21
-<L221>:
-               	bl	 <L221>
-               	mov	x20, x0
-               	b	 <L224>
-<L222>:
-               	mov	x0, x21
-               	mov	x1, #0xffff             // =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L223>:
-               	bl	 <L223>
-               	mov	x20, x0
-<L224>:
-               	ldur	d31, [x29, #-0x70]
-               	ldur	d30, [x29, #-0x70]
-               	fcmp	d31, d30
-               	cset	w0, ne
-               	cbnz	w0,  <L226>
-               	mov	x0, x20
-               	ldur	d0, [x29, #-0x70]
-<L225>:
-               	bl	 <L225>
-               	mov	x21, x0
-               	b	 <L228>
-<L226>:
-               	mov	x0, x20
-               	mov	x1, #0xffff             // =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L227>:
-               	bl	 <L227>
-               	mov	x21, x0
-<L228>:
-               	ldur	d31, [x29, #-0x60]
-               	ldur	d30, [x29, #-0x60]
-               	fcmp	d31, d30
-               	cset	w0, ne
-               	cbnz	w0,  <L230>
-               	mov	x0, x21
-               	ldur	d0, [x29, #-0x60]
-<L229>:
-               	bl	 <L229>
-               	mov	x20, x0
-               	b	 <L232>
-<L230>:
-               	mov	x0, x21
-               	mov	x1, #0xffff             // =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L231>:
-               	bl	 <L231>
-               	mov	x20, x0
-<L232>:
-               	ldur	d31, [x29, #-0x50]
-               	ldur	d30, [x29, #-0x50]
-               	fcmp	d31, d30
-               	cset	w0, ne
-               	cbnz	w0,  <L234>
-               	mov	x0, x20
-               	ldur	d0, [x29, #-0x50]
-<L233>:
-               	bl	 <L233>
-               	mov	x21, x0
-               	b	 <L236>
-<L234>:
-               	mov	x0, x20
-               	mov	x1, #0xffff             // =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L235>:
-               	bl	 <L235>
-               	mov	x21, x0
-<L236>:
-               	ldur	d31, [x29, #-0x60]
-               	ldur	d30, [x29, #-0x70]
-               	fadd	d0, d31, d30
-               	fcmp	d0, d0
-               	cset	w0, ne
-               	cbnz	w0,  <L238>
-               	mov	x0, x21
-<L237>:
-               	bl	 <L237>
-               	mov	x20, x0
-               	b	 <L240>
-<L238>:
-               	mov	x0, x21
-               	mov	x1, #0xffff             // =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L239>:
-               	bl	 <L239>
-               	mov	x20, x0
-<L240>:
-               	ldur	d31, [x29, #-0x50]
-               	ldur	d30, [x29, #-0x70]
-               	fsub	d0, d31, d30
-               	fcmp	d0, d0
-               	cset	w0, ne
-               	cbnz	w0,  <L242>
-               	mov	x0, x20
-<L241>:
-               	bl	 <L241>
-               	mov	x21, x0
-               	b	 <L244>
-<L242>:
-               	mov	x0, x20
-               	mov	x1, #0xffff             // =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L243>:
-               	bl	 <L243>
-               	mov	x21, x0
-<L244>:
-               	ldur	d31, [x29, #-0x70]
-               	ldur	d30, [x29, #-0x70]
-               	fadd	d0, d31, d30
-               	fcmp	d0, d0
-               	cset	w0, ne
-               	cbnz	w0,  <L246>
-               	mov	x0, x21
-<L245>:
-               	bl	 <L245>
-               	mov	x20, x0
-               	b	 <L248>
-<L246>:
-               	mov	x0, x21
-               	mov	x1, #0xffff             // =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L247>:
-               	bl	 <L247>
-               	mov	x20, x0
-<L248>:
-               	ldur	d31, [x29, #-0x70]
-               	fmov	d30, #1.50000000
-               	fmul	d0, d31, d30
-               	fcmp	d0, d0
-               	cset	w0, ne
-               	cbnz	w0,  <L250>
-               	mov	x0, x20
-<L249>:
-               	bl	 <L249>
-               	mov	x21, x0
-               	b	 <L252>
-<L250>:
-               	mov	x0, x20
-               	mov	x1, #0xffff             // =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L251>:
-               	bl	 <L251>
-               	mov	x21, x0
-<L252>:
-               	ldur	d31, [x29, #-0x70]
-               	fmov	d30, #0.50000000
-               	fmul	d0, d31, d30
-               	fcmp	d0, d0
-               	cset	w0, ne
-               	cbnz	w0,  <L254>
-               	mov	x0, x21
-<L253>:
-               	bl	 <L253>
-               	mov	x20, x0
-               	b	 <L256>
-<L254>:
-               	mov	x0, x21
-               	mov	x1, #0xffff             // =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L255>:
-               	bl	 <L255>
-               	mov	x20, x0
-<L256>:
-               	ldur	d31, [x29, #-0x70]
-               	fneg	d0, d31
-               	fcmp	d0, d0
-               	cset	w0, ne
-               	cbnz	w0,  <L258>
-               	mov	x0, x20
-<L257>:
-               	bl	 <L257>
-               	mov	x21, x0
-               	b	 <L260>
-<L258>:
-               	mov	x0, x20
-               	mov	x1, #0xffff             // =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L259>:
-               	bl	 <L259>
-               	mov	x21, x0
-<L260>:
-               	ldur	d31, [x29, #-0x70]
-               	mov	x16, #0x4330000000000000 // =4841369599423283200
-               	fmov	d30, x16
-               	fmul	d0, d31, d30
-               	fcmp	d0, d0
-               	cset	w0, ne
-               	cbnz	w0,  <L262>
-               	mov	x0, x21
-<L261>:
-               	bl	 <L261>
-               	mov	x20, x0
-               	b	 <L264>
-<L262>:
-               	mov	x0, x21
-               	mov	x1, #0xffff             // =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L263>:
-               	bl	 <L263>
-               	mov	x20, x0
-<L264>:
-               	ldur	d31, [x29, #-0x60]
-               	ldur	d30, [x29, #-0x50]
-               	fdiv	d0, d31, d30
-               	fcmp	d0, d0
-               	cset	w0, ne
-               	cbnz	w0,  <L266>
-               	mov	x0, x20
-<L265>:
-               	bl	 <L265>
-               	mov	x21, x0
-               	b	 <L268>
-<L266>:
-               	mov	x0, x20
-               	mov	x1, #0xffff             // =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L267>:
-               	bl	 <L267>
-               	mov	x21, x0
-<L268>:
-               	ldur	d30, [x29, #-0x70]
-               	fcmp	d10, d30
-               	cset	w1, mi
-               	mov	x0, x21
-<L269>:
-               	bl	 <L269>
-               	ldur	d31, [x29, #-0x70]
-               	fcmp	d31, d10
-               	cset	w1, eq
-<L270>:
-               	bl	 <L270>
-               	fmov	d31, xzr
-               	ldur	d30, [x29, #-0x70]
-               	fsub	d0, d31, d30
-               	fcmp	d0, d11
-               	cset	w1, mi
-<L271>:
-               	bl	 <L271>
-               	mov	x20, x0
-               	ldur	d9, [x29, #-0x50]
-               	mov	x21, #0x0               // =0
-               	cmp	x21, #0x3c
-               	b.lo	 <L272>
-               	b	 <L277>
-<L272>:
-               	fmov	d30, #0.50000000
-               	fmul	d12, d9, d30
-               	fcmp	d12, d12
-               	cset	w0, ne
-               	cbnz	w0,  <L274>
-               	mov	x0, x20
-               	fmov	d0, d12
-<L273>:
-               	bl	 <L273>
-               	mov	x22, x0
-               	b	 <L276>
-<L274>:
-               	mov	x0, x20
-               	mov	x1, #0xffff             // =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L275>:
-               	bl	 <L275>
-               	mov	x22, x0
-<L276>:
                	add	x21, x21, #0x1
                	mov	x20, x22
                	fmov	d9, d12
                	cmp	x21, #0x3c
-               	b.lo	 <L272>
-<L277>:
+               	b.lo	 <L95>
+<L100>:
                	sub	x21, x29, #0x40
                	str	xzr, [x21]
                	str	xzr, [x21, #0x8]
@@ -1471,22 +515,22 @@ Disassembly of section .text:
                	str	x17, [x0]
                	mov	x22, #0x0               // =0
                	cmp	x22, #0x8
-               	b.lo	 <L278>
-               	b	 <L280>
-<L278>:
+               	b.lo	 <L101>
+               	b	 <L103>
+<L101>:
                	add	x0, x21, x22, lsl #3
                	ldr	x1, [x0]
                	add	x0, x1, x19
                	fmov	d0, x0
                	fmov	x1, d0
                	mov	x0, x20
-<L279>:
-               	bl	 <L279>
+<L102>:
+               	bl	 <L102>
                	add	x22, x22, #0x1
                	mov	x20, x0
                	cmp	x22, #0x8
-               	b.lo	 <L278>
-<L280>:
+               	b.lo	 <L101>
+<L103>:
                	fcvt	s0, d15
                	ldur	d31, [x29, #-0x70]
                	fcvt	s9, d31
@@ -1508,85 +552,85 @@ Disassembly of section .text:
                	stur	s31, [x29, #-0x80]
                	fcvt	s11, d13
                	mov	x0, x20
-<L281>:
-               	bl	 <L281>
+<L104>:
+               	bl	 <L104>
                	fmov	s0, s9
-<L282>:
-               	bl	 <L282>
+<L105>:
+               	bl	 <L105>
                	fmov	s0, s12
-<L283>:
-               	bl	 <L283>
+<L106>:
+               	bl	 <L106>
                	fmov	s0, s14
-<L284>:
-               	bl	 <L284>
+<L107>:
+               	bl	 <L107>
                	fmov	s0, s15
-<L285>:
-               	bl	 <L285>
+<L108>:
+               	bl	 <L108>
                	ldur	s0, [x29, #-0x80]
-<L286>:
-               	bl	 <L286>
+<L109>:
+               	bl	 <L109>
                	fmov	s0, s11
-<L287>:
-               	bl	 <L287>
+<L110>:
+               	bl	 <L110>
                	mov	x20, x0
                	fcvt	d0, s12
                	fcmp	d0, d0
                	cset	w0, ne
-               	cbnz	w0,  <L289>
+               	cbnz	w0,  <L112>
                	mov	x0, x20
-<L288>:
-               	bl	 <L288>
+<L111>:
+               	bl	 <L111>
                	mov	x21, x0
-               	b	 <L291>
-<L289>:
+               	b	 <L114>
+<L112>:
                	mov	x0, x20
                	mov	x1, #0xffff             // =65535
                	movk	x1, #0xffff, lsl #16
                	movk	x1, #0xffff, lsl #32
                	movk	x1, #0xffff, lsl #48
-<L290>:
-               	bl	 <L290>
+<L113>:
+               	bl	 <L113>
                	mov	x21, x0
-<L291>:
+<L114>:
                	ldur	s31, [x29, #-0x80]
                	fcvt	d0, s31
                	fcmp	d0, d0
                	cset	w0, ne
-               	cbnz	w0,  <L293>
+               	cbnz	w0,  <L116>
                	mov	x0, x21
-<L292>:
-               	bl	 <L292>
+<L115>:
+               	bl	 <L115>
                	mov	x20, x0
-               	b	 <L295>
-<L293>:
+               	b	 <L118>
+<L116>:
                	mov	x0, x21
                	mov	x1, #0xffff             // =65535
                	movk	x1, #0xffff, lsl #16
                	movk	x1, #0xffff, lsl #32
                	movk	x1, #0xffff, lsl #48
-<L294>:
-               	bl	 <L294>
+<L117>:
+               	bl	 <L117>
                	mov	x20, x0
-<L295>:
+<L118>:
                	fcvt	d0, s11
                	fcmp	d0, d0
                	cset	w0, ne
-               	cbnz	w0,  <L297>
+               	cbnz	w0,  <L120>
                	mov	x0, x20
-<L296>:
-               	bl	 <L296>
+<L119>:
+               	bl	 <L119>
                	mov	x21, x0
-               	b	 <L299>
-<L297>:
+               	b	 <L122>
+<L120>:
                	mov	x0, x20
                	mov	x1, #0xffff             // =65535
                	movk	x1, #0xffff, lsl #16
                	movk	x1, #0xffff, lsl #32
                	movk	x1, #0xffff, lsl #48
-<L298>:
-               	bl	 <L298>
+<L121>:
+               	bl	 <L121>
                	mov	x21, x0
-<L299>:
+<L122>:
                	mov	x17, #0x20000000000000  // =9007199254740992
                	add	x0, x17, x19
                	mov	x17, #0x1               // =1
@@ -1610,136 +654,136 @@ Disassembly of section .text:
                	ucvtf	d0, x0
                	fcmp	d0, d0
                	cset	w0, ne
-               	cbnz	w0,  <L301>
+               	cbnz	w0,  <L124>
                	mov	x0, x21
-<L300>:
-               	bl	 <L300>
+<L123>:
+               	bl	 <L123>
                	mov	x26, x0
-               	b	 <L303>
-<L301>:
+               	b	 <L126>
+<L124>:
                	mov	x0, x21
                	mov	x1, #0xffff             // =65535
                	movk	x1, #0xffff, lsl #16
                	movk	x1, #0xffff, lsl #32
                	movk	x1, #0xffff, lsl #48
-<L302>:
-               	bl	 <L302>
+<L125>:
+               	bl	 <L125>
                	mov	x26, x0
-<L303>:
+<L126>:
                	ucvtf	d0, x20
                	fcmp	d0, d0
                	cset	w0, ne
-               	cbnz	w0,  <L305>
+               	cbnz	w0,  <L128>
                	mov	x0, x26
-<L304>:
-               	bl	 <L304>
+<L127>:
+               	bl	 <L127>
                	mov	x20, x0
-               	b	 <L307>
-<L305>:
+               	b	 <L130>
+<L128>:
                	mov	x0, x26
                	mov	x1, #0xffff             // =65535
                	movk	x1, #0xffff, lsl #16
                	movk	x1, #0xffff, lsl #32
                	movk	x1, #0xffff, lsl #48
-<L306>:
-               	bl	 <L306>
+<L129>:
+               	bl	 <L129>
                	mov	x20, x0
-<L307>:
+<L130>:
                	ucvtf	d0, x22
                	fcmp	d0, d0
                	cset	w0, ne
-               	cbnz	w0,  <L309>
+               	cbnz	w0,  <L132>
                	mov	x0, x20
-<L308>:
-               	bl	 <L308>
+<L131>:
+               	bl	 <L131>
                	mov	x21, x0
-               	b	 <L311>
-<L309>:
+               	b	 <L134>
+<L132>:
                	mov	x0, x20
                	mov	x1, #0xffff             // =65535
                	movk	x1, #0xffff, lsl #16
                	movk	x1, #0xffff, lsl #32
                	movk	x1, #0xffff, lsl #48
-<L310>:
-               	bl	 <L310>
+<L133>:
+               	bl	 <L133>
                	mov	x21, x0
-<L311>:
+<L134>:
                	ucvtf	d0, x23
                	fcmp	d0, d0
                	cset	w0, ne
-               	cbnz	w0,  <L313>
+               	cbnz	w0,  <L136>
                	mov	x0, x21
-<L312>:
-               	bl	 <L312>
+<L135>:
+               	bl	 <L135>
                	mov	x20, x0
-               	b	 <L315>
-<L313>:
+               	b	 <L138>
+<L136>:
                	mov	x0, x21
                	mov	x1, #0xffff             // =65535
                	movk	x1, #0xffff, lsl #16
                	movk	x1, #0xffff, lsl #32
                	movk	x1, #0xffff, lsl #48
-<L314>:
-               	bl	 <L314>
+<L137>:
+               	bl	 <L137>
                	mov	x20, x0
-<L315>:
+<L138>:
                	ucvtf	d0, x19
                	fcmp	d0, d0
                	cset	w0, ne
-               	cbnz	w0,  <L317>
+               	cbnz	w0,  <L140>
                	mov	x0, x20
-<L316>:
-               	bl	 <L316>
+<L139>:
+               	bl	 <L139>
                	mov	x19, x0
-               	b	 <L319>
-<L317>:
+               	b	 <L142>
+<L140>:
                	mov	x0, x20
                	mov	x1, #0xffff             // =65535
                	movk	x1, #0xffff, lsl #16
                	movk	x1, #0xffff, lsl #32
                	movk	x1, #0xffff, lsl #48
-<L318>:
-               	bl	 <L318>
+<L141>:
+               	bl	 <L141>
                	mov	x19, x0
-<L319>:
+<L142>:
                	scvtf	d0, x24
                	fcmp	d0, d0
                	cset	w0, ne
-               	cbnz	w0,  <L321>
+               	cbnz	w0,  <L144>
                	mov	x0, x19
-<L320>:
-               	bl	 <L320>
+<L143>:
+               	bl	 <L143>
                	mov	x20, x0
-               	b	 <L323>
-<L321>:
+               	b	 <L146>
+<L144>:
                	mov	x0, x19
                	mov	x1, #0xffff             // =65535
                	movk	x1, #0xffff, lsl #16
                	movk	x1, #0xffff, lsl #32
                	movk	x1, #0xffff, lsl #48
-<L322>:
-               	bl	 <L322>
+<L145>:
+               	bl	 <L145>
                	mov	x20, x0
-<L323>:
+<L146>:
                	scvtf	d0, x25
                	fcmp	d0, d0
                	cset	w0, ne
-               	cbnz	w0,  <L325>
+               	cbnz	w0,  <L148>
                	mov	x0, x20
-<L324>:
-               	bl	 <L324>
+<L147>:
+               	bl	 <L147>
                	mov	x19, x0
-               	b	 <L327>
-<L325>:
+               	b	 <L150>
+<L148>:
                	mov	x0, x20
                	mov	x1, #0xffff             // =65535
                	movk	x1, #0xffff, lsl #16
                	movk	x1, #0xffff, lsl #32
                	movk	x1, #0xffff, lsl #48
-<L326>:
-               	bl	 <L326>
+<L149>:
+               	bl	 <L149>
                	mov	x19, x0
-<L327>:
+<L150>:
                	fmov	d31, #1.50000000
                	fmul	d9, d31, d8
                	mov	x16, #0x4340000000000000 // =4845873199050653696
@@ -1754,37 +798,37 @@ Disassembly of section .text:
                	fmul	d14, d31, d8
                	fcvtzu	x1, d9
                	mov	x0, x19
-<L328>:
-               	bl	 <L328>
+<L151>:
+               	bl	 <L151>
                	fcvtzu	x1, d11
-<L329>:
-               	bl	 <L329>
+<L152>:
+               	bl	 <L152>
                	fcvtzu	x1, d12
-<L330>:
-               	bl	 <L330>
+<L153>:
+               	bl	 <L153>
                	fcvtzu	x1, d14
-<L331>:
-               	bl	 <L331>
+<L154>:
+               	bl	 <L154>
                	fcvtzu	x1, d10
-<L332>:
-               	bl	 <L332>
+<L155>:
+               	bl	 <L155>
                	fcvtzs	x1, d13
-<L333>:
-               	bl	 <L333>
+<L156>:
+               	bl	 <L156>
                	fcvtzs	x1, d12
-<L334>:
-               	bl	 <L334>
+<L157>:
+               	bl	 <L157>
                	fmov	d31, xzr
                	fsub	d0, d31, d14
                	fcvtzs	x1, d0
-<L335>:
-               	bl	 <L335>
+<L158>:
+               	bl	 <L158>
                	fcvtzs	w1, d13
-<L336>:
-               	bl	 <L336>
+<L159>:
+               	bl	 <L159>
                	fcvtzu	w1, d9
-<L337>:
-               	bl	 <L337>
+<L160>:
+               	bl	 <L160>
                	ldp	d8, d9, [x29, #-0xd0]
                	ldp	d10, d11, [x29, #-0xe0]
                	ldp	d12, d13, [x29, #-0xf0]

--- a/test/golden/aarch64-linux/mem/global_data.dis
+++ b/test/golden/aarch64-linux/mem/global_data.dis
@@ -310,9 +310,16 @@ Disassembly of section .text:
                	udiv	x16, x0, x2
                	msub	x3, x16, x2, x0
                	add	x2, x1, x3, lsl #1
-               	ldrh	w1, [x2]
-               	add	w3, w1, #0x64
-               	strh	w3, [x2]
+               	ldrh	w3, [x2]
+               	add	w2, w3, #0x64
+               	mov	x3, #0x3                // =3
+               	cbnz	x3,  <L3>
+               	brk	#0
+<L3>:
+               	udiv	x16, x0, x3
+               	msub	x4, x16, x3, x0
+               	add	x3, x1, x4, lsl #1
+               	strh	w2, [x3]
                	adrp	x1, 0x0 <corpus.cases.mem.global_data.fold_cell>
                	add	x1, x1, #0x0
                	ldr	w2, [x1]
@@ -376,7 +383,7 @@ Disassembly of section .text:
                	mov	x28, #0x0               // =0
                	cmp	x28, #0x5
                	b.lo	 <L5>
-               	b	 <L10>
+               	b	 <L11>
 <L5>:
                	add	x0, x28, #0x1
                	add	x1, x0, x19
@@ -485,20 +492,27 @@ Disassembly of section .text:
                	msub	x2, x16, x0, x1
                	add	x0, x25, x2, lsl #1
                	ldrh	w2, [x0]
-               	add	w3, w2, #0x64
-               	strh	w3, [x0]
+               	add	w0, w2, #0x64
+               	mov	x2, #0x3                // =3
+               	cbnz	x2,  <L9>
+               	brk	#0
+<L9>:
+               	udiv	x16, x1, x2
+               	msub	x3, x16, x2, x1
+               	add	x2, x25, x3, lsl #1
+               	strh	w0, [x2]
                	ldr	w0, [x26]
                	mov	w2, w1
                	sub	w1, w0, w2
                	str	w1, [x26]
                	mov	x0, x27
-<L9>:
-               	bl	 <L9>
+<L10>:
+               	bl	 <L10>
                	add	x28, x28, #0x1
                	mov	x27, x0
                	cmp	x28, #0x5
                	b.lo	 <L5>
-<L10>:
+<L11>:
                	adrp	x16, 0x0 <corpus.cases.mem.global_data.fold_cell>
                	ldr	x0, [x16]
                	mov	x16, #0x7c15            // =31765
@@ -511,8 +525,8 @@ Disassembly of section .text:
                	adrp	x16, 0x0 <corpus.cases.mem.global_data.fold_cell>
                	ldr	x1, [x16]
                	mov	x0, x27
-<L11>:
-               	bl	 <L11>
+<L12>:
+               	bl	 <L12>
                	sub	x1, x29, #0x10
                	adrp	x16, 0x0 <corpus.cases.mem.global_data.fold_cell>
                	ldr	x2, [x16]
@@ -540,16 +554,16 @@ Disassembly of section .text:
                	add	x1, x1, #0x0
                	ldr	x20, [x1]
                	mov	x1, x2
-<L12>:
-               	bl	 <L12>
-               	mov	x1, x19
 <L13>:
                	bl	 <L13>
-               	mov	x1, x20
+               	mov	x1, x19
 <L14>:
                	bl	 <L14>
+               	mov	x1, x20
 <L15>:
                	bl	 <L15>
+<L16>:
+               	bl	 <L16>
                	ldp	x19, x20, [x29, #-0x20]
                	ldp	x21, x22, [x29, #-0x30]
                	ldp	x23, x24, [x29, #-0x40]

--- a/test/golden/aarch64-linux/mem/loadstore.dis
+++ b/test/golden/aarch64-linux/mem/loadstore.dis
@@ -77,11 +77,11 @@ Disassembly of section .text:
 <corpus.cases.mem.loadstore.checksum>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0x70
-               	stp	x19, x20, [x29, #-0x40]
-               	stp	x21, x22, [x29, #-0x50]
-               	stp	x23, x24, [x29, #-0x60]
-               	stp	x25, x26, [x29, #-0x70]
+               	sub	sp, sp, #0xb0
+               	stp	x19, x20, [x29, #-0x80]
+               	stp	x21, x22, [x29, #-0x90]
+               	stp	x23, x24, [x29, #-0xa0]
+               	stp	x25, x26, [x29, #-0xb0]
                	mov	x19, x0
 <L0>:
                	bl	 <L0>
@@ -91,7 +91,13 @@ Disassembly of section .text:
                	str	xzr, [x20, #0x8]
                	str	xzr, [x20, #0x10]
                	mov	x0, x1
-               	mov	x1, x20
+               	ldr	x1, [x20]
+               	stur	x1, [x29, #-0x30]
+               	ldr	x1, [x20, #0x8]
+               	stur	x1, [x29, #-0x28]
+               	ldr	x1, [x20, #0x10]
+               	stur	x1, [x29, #-0x20]
+               	sub	x1, x29, #0x30
 <L1>:
                	bl	 <L1>
                	mov	x1, x0
@@ -128,7 +134,13 @@ Disassembly of section .text:
                	add	x2, x20, #0x10
                	str	x21, [x2]
                	mov	x0, x1
-               	mov	x1, x20
+               	ldr	x1, [x20]
+               	stur	x1, [x29, #-0x48]
+               	ldr	x1, [x20, #0x8]
+               	stur	x1, [x29, #-0x40]
+               	ldr	x1, [x20, #0x10]
+               	stur	x1, [x29, #-0x38]
+               	sub	x1, x29, #0x48
 <L2>:
                	bl	 <L2>
                	mov	x22, x0
@@ -152,7 +164,13 @@ Disassembly of section .text:
                	add	x0, x20, #0x8
                	str	w1, [x0]
                	mov	x0, x22
-               	mov	x1, x20
+               	ldr	x1, [x20]
+               	stur	x1, [x29, #-0x60]
+               	ldr	x1, [x20, #0x8]
+               	stur	x1, [x29, #-0x58]
+               	ldr	x1, [x20, #0x10]
+               	stur	x1, [x29, #-0x50]
+               	sub	x1, x29, #0x60
 <L4>:
                	bl	 <L4>
                	mov	x22, x0
@@ -211,7 +229,7 @@ Disassembly of section .text:
                	cmp	x20, #0x6
                	b.lo	 <L6>
 <L17>:
-               	sub	x19, x29, #0x28
+               	sub	x19, x29, #0x70
                	str	xzr, [x19]
                	str	xzr, [x19, #0x8]
                	mov	x0, #0x0                // =0
@@ -260,10 +278,10 @@ Disassembly of section .text:
                	add	x1, x19, #0x1
 <L24>:
                	bl	 <L24>
-               	ldp	x19, x20, [x29, #-0x40]
-               	ldp	x21, x22, [x29, #-0x50]
-               	ldp	x23, x24, [x29, #-0x60]
-               	ldp	x25, x26, [x29, #-0x70]
+               	ldp	x19, x20, [x29, #-0x80]
+               	ldp	x21, x22, [x29, #-0x90]
+               	ldp	x23, x24, [x29, #-0xa0]
+               	ldp	x25, x26, [x29, #-0xb0]
                	mov	sp, x29
                	ldp	x29, x30, [sp], #0x10
                	ret

--- a/test/golden/aarch64-linux/mem/rec_layout.dis
+++ b/test/golden/aarch64-linux/mem/rec_layout.dis
@@ -327,10 +327,11 @@ Disassembly of section .text:
 <corpus.cases.mem.rec_layout.checksum>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0xa0
-               	stp	x19, x20, [x29, #-0x80]
-               	stp	x21, x22, [x29, #-0x90]
-               	stp	x23, x24, [x29, #-0xa0]
+               	sub	sp, sp, #0x310
+               	sub	x16, x29, #0x2f0
+               	stp	x19, x20, [x16]
+               	stp	x21, x22, [x16, #-0x10]
+               	stp	x23, x24, [x16, #-0x20]
                	mov	x19, x0
 <L0>:
                	bl	 <L0>
@@ -434,7 +435,29 @@ Disassembly of section .text:
                	str	xzr, [x21, #0x48]
                	str	xzr, [x21, #0x50]
                	mov	x0, x1
-               	mov	x1, x21
+               	ldr	x1, [x21]
+               	stur	x1, [x29, #-0xb0]
+               	ldr	x1, [x21, #0x8]
+               	stur	x1, [x29, #-0xa8]
+               	ldr	x1, [x21, #0x10]
+               	stur	x1, [x29, #-0xa0]
+               	ldr	x1, [x21, #0x18]
+               	stur	x1, [x29, #-0x98]
+               	ldr	x1, [x21, #0x20]
+               	stur	x1, [x29, #-0x90]
+               	ldr	x1, [x21, #0x28]
+               	stur	x1, [x29, #-0x88]
+               	ldr	x1, [x21, #0x30]
+               	stur	x1, [x29, #-0x80]
+               	ldr	x1, [x21, #0x38]
+               	stur	x1, [x29, #-0x78]
+               	ldr	x1, [x21, #0x40]
+               	stur	x1, [x29, #-0x70]
+               	ldr	x1, [x21, #0x48]
+               	stur	x1, [x29, #-0x68]
+               	ldr	x1, [x21, #0x50]
+               	stur	x1, [x29, #-0x60]
+               	sub	x1, x29, #0xb0
 <L18>:
                	bl	 <L18>
                	add	x1, x21, #0x0
@@ -539,7 +562,33 @@ Disassembly of section .text:
                	add	w1, w17, w20
                	add	x19, x21, #0x50
                	str	w1, [x19]
-               	mov	x1, x21
+               	ldr	x1, [x21]
+               	mov	x16, #0xfef8            // =65272
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x1, [x29, x16]
+               	ldr	x1, [x21, #0x8]
+               	stur	x1, [x29, #-0x100]
+               	ldr	x1, [x21, #0x10]
+               	stur	x1, [x29, #-0xf8]
+               	ldr	x1, [x21, #0x18]
+               	stur	x1, [x29, #-0xf0]
+               	ldr	x1, [x21, #0x20]
+               	stur	x1, [x29, #-0xe8]
+               	ldr	x1, [x21, #0x28]
+               	stur	x1, [x29, #-0xe0]
+               	ldr	x1, [x21, #0x30]
+               	stur	x1, [x29, #-0xd8]
+               	ldr	x1, [x21, #0x38]
+               	stur	x1, [x29, #-0xd0]
+               	ldr	x1, [x21, #0x40]
+               	stur	x1, [x29, #-0xc8]
+               	ldr	x1, [x21, #0x48]
+               	stur	x1, [x29, #-0xc0]
+               	ldr	x1, [x21, #0x50]
+               	stur	x1, [x29, #-0xb8]
+               	sub	x1, x29, #0x108
 <L19>:
                	bl	 <L19>
                	add	x20, x21, #0x0
@@ -551,7 +600,73 @@ Disassembly of section .text:
                	movk	w16, #0xf0f0, lsl #16
                	eor	w3, w2, w16
                	str	w3, [x1]
-               	mov	x1, x21
+               	ldr	x1, [x21]
+               	mov	x16, #0xfea0            // =65184
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x1, [x29, x16]
+               	ldr	x1, [x21, #0x8]
+               	mov	x16, #0xfea8            // =65192
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x1, [x29, x16]
+               	ldr	x1, [x21, #0x10]
+               	mov	x16, #0xfeb0            // =65200
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x1, [x29, x16]
+               	ldr	x1, [x21, #0x18]
+               	mov	x16, #0xfeb8            // =65208
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x1, [x29, x16]
+               	ldr	x1, [x21, #0x20]
+               	mov	x16, #0xfec0            // =65216
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x1, [x29, x16]
+               	ldr	x1, [x21, #0x28]
+               	mov	x16, #0xfec8            // =65224
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x1, [x29, x16]
+               	ldr	x1, [x21, #0x30]
+               	mov	x16, #0xfed0            // =65232
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x1, [x29, x16]
+               	ldr	x1, [x21, #0x38]
+               	mov	x16, #0xfed8            // =65240
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x1, [x29, x16]
+               	ldr	x1, [x21, #0x40]
+               	mov	x16, #0xfee0            // =65248
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x1, [x29, x16]
+               	ldr	x1, [x21, #0x48]
+               	mov	x16, #0xfee8            // =65256
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x1, [x29, x16]
+               	ldr	x1, [x21, #0x50]
+               	mov	x16, #0xfef0            // =65264
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x1, [x29, x16]
+               	sub	x1, x29, #0x160
 <L20>:
                	bl	 <L20>
                	add	x22, x21, #0x28
@@ -561,24 +676,222 @@ Disassembly of section .text:
                	ldrb	w2, [x1]
                	add	w3, w2, #0x7
                	strb	w3, [x1]
-               	mov	x1, x21
+               	ldr	x1, [x21]
+               	mov	x16, #0xfe48            // =65096
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x1, [x29, x16]
+               	ldr	x1, [x21, #0x8]
+               	mov	x16, #0xfe50            // =65104
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x1, [x29, x16]
+               	ldr	x1, [x21, #0x10]
+               	mov	x16, #0xfe58            // =65112
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x1, [x29, x16]
+               	ldr	x1, [x21, #0x18]
+               	mov	x16, #0xfe60            // =65120
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x1, [x29, x16]
+               	ldr	x1, [x21, #0x20]
+               	mov	x16, #0xfe68            // =65128
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x1, [x29, x16]
+               	ldr	x1, [x21, #0x28]
+               	mov	x16, #0xfe70            // =65136
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x1, [x29, x16]
+               	ldr	x1, [x21, #0x30]
+               	mov	x16, #0xfe78            // =65144
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x1, [x29, x16]
+               	ldr	x1, [x21, #0x38]
+               	mov	x16, #0xfe80            // =65152
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x1, [x29, x16]
+               	ldr	x1, [x21, #0x40]
+               	mov	x16, #0xfe88            // =65160
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x1, [x29, x16]
+               	ldr	x1, [x21, #0x48]
+               	mov	x16, #0xfe90            // =65168
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x1, [x29, x16]
+               	ldr	x1, [x21, #0x50]
+               	mov	x16, #0xfe98            // =65176
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x1, [x29, x16]
+               	sub	x1, x29, #0x1b8
 <L21>:
                	bl	 <L21>
                	add	x1, x20, #0x18
                	ldr	x2, [x1]
                	lsr	x3, x2, #3
                	str	x3, [x1]
-               	mov	x1, x21
+               	ldr	x1, [x21]
+               	mov	x16, #0xfdf0            // =65008
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x1, [x29, x16]
+               	ldr	x1, [x21, #0x8]
+               	mov	x16, #0xfdf8            // =65016
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x1, [x29, x16]
+               	ldr	x1, [x21, #0x10]
+               	mov	x16, #0xfe00            // =65024
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x1, [x29, x16]
+               	ldr	x1, [x21, #0x18]
+               	mov	x16, #0xfe08            // =65032
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x1, [x29, x16]
+               	ldr	x1, [x21, #0x20]
+               	mov	x16, #0xfe10            // =65040
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x1, [x29, x16]
+               	ldr	x1, [x21, #0x28]
+               	mov	x16, #0xfe18            // =65048
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x1, [x29, x16]
+               	ldr	x1, [x21, #0x30]
+               	mov	x16, #0xfe20            // =65056
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x1, [x29, x16]
+               	ldr	x1, [x21, #0x38]
+               	mov	x16, #0xfe28            // =65064
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x1, [x29, x16]
+               	ldr	x1, [x21, #0x40]
+               	mov	x16, #0xfe30            // =65072
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x1, [x29, x16]
+               	ldr	x1, [x21, #0x48]
+               	mov	x16, #0xfe38            // =65080
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x1, [x29, x16]
+               	ldr	x1, [x21, #0x50]
+               	mov	x16, #0xfe40            // =65088
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x1, [x29, x16]
+               	sub	x1, x29, #0x210
 <L22>:
                	bl	 <L22>
                	ldr	w1, [x19]
                	mov	w16, #0x3               // =3
                	mul	w2, w1, w16
                	str	w2, [x19]
-               	mov	x1, x21
+               	ldr	x1, [x21]
+               	mov	x16, #0xfd98            // =64920
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x1, [x29, x16]
+               	ldr	x1, [x21, #0x8]
+               	mov	x16, #0xfda0            // =64928
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x1, [x29, x16]
+               	ldr	x1, [x21, #0x10]
+               	mov	x16, #0xfda8            // =64936
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x1, [x29, x16]
+               	ldr	x1, [x21, #0x18]
+               	mov	x16, #0xfdb0            // =64944
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x1, [x29, x16]
+               	ldr	x1, [x21, #0x20]
+               	mov	x16, #0xfdb8            // =64952
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x1, [x29, x16]
+               	ldr	x1, [x21, #0x28]
+               	mov	x16, #0xfdc0            // =64960
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x1, [x29, x16]
+               	ldr	x1, [x21, #0x30]
+               	mov	x16, #0xfdc8            // =64968
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x1, [x29, x16]
+               	ldr	x1, [x21, #0x38]
+               	mov	x16, #0xfdd0            // =64976
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x1, [x29, x16]
+               	ldr	x1, [x21, #0x40]
+               	mov	x16, #0xfdd8            // =64984
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x1, [x29, x16]
+               	ldr	x1, [x21, #0x48]
+               	mov	x16, #0xfde0            // =64992
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x1, [x29, x16]
+               	ldr	x1, [x21, #0x50]
+               	mov	x16, #0xfde8            // =65000
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x1, [x29, x16]
+               	sub	x1, x29, #0x268
 <L23>:
                	bl	 <L23>
-               	sub	x19, x29, #0x6c
+               	sub	x19, x29, #0x27c
                	add	x1, x22, #0x0
                	ldr	x2, [x1]
                	str	x2, [x19]
@@ -653,12 +966,79 @@ Disassembly of section .text:
                	str	x1, [x2, #0x8]
                	ldr	w1, [x19, #0x10]
                	str	w1, [x2, #0x10]
-               	mov	x1, x21
+               	ldr	x1, [x21]
+               	mov	x16, #0xfd28            // =64808
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x1, [x29, x16]
+               	ldr	x1, [x21, #0x8]
+               	mov	x16, #0xfd30            // =64816
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x1, [x29, x16]
+               	ldr	x1, [x21, #0x10]
+               	mov	x16, #0xfd38            // =64824
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x1, [x29, x16]
+               	ldr	x1, [x21, #0x18]
+               	mov	x16, #0xfd40            // =64832
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x1, [x29, x16]
+               	ldr	x1, [x21, #0x20]
+               	mov	x16, #0xfd48            // =64840
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x1, [x29, x16]
+               	ldr	x1, [x21, #0x28]
+               	mov	x16, #0xfd50            // =64848
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x1, [x29, x16]
+               	ldr	x1, [x21, #0x30]
+               	mov	x16, #0xfd58            // =64856
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x1, [x29, x16]
+               	ldr	x1, [x21, #0x38]
+               	mov	x16, #0xfd60            // =64864
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x1, [x29, x16]
+               	ldr	x1, [x21, #0x40]
+               	mov	x16, #0xfd68            // =64872
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x1, [x29, x16]
+               	ldr	x1, [x21, #0x48]
+               	mov	x16, #0xfd70            // =64880
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x1, [x29, x16]
+               	ldr	x1, [x21, #0x50]
+               	mov	x16, #0xfd78            // =64888
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x1, [x29, x16]
+               	sub	x1, x29, #0x2d8
 <L34>:
                	bl	 <L34>
-               	ldp	x19, x20, [x29, #-0x80]
-               	ldp	x21, x22, [x29, #-0x90]
-               	ldp	x23, x24, [x29, #-0xa0]
+               	sub	x16, x29, #0x2f0
+               	ldp	x19, x20, [x16]
+               	ldp	x21, x22, [x16, #-0x10]
+               	ldp	x23, x24, [x16, #-0x20]
                	mov	sp, x29
                	ldp	x29, x30, [sp], #0x10
                	ret

--- a/test/golden/aarch64-linux/vec/autovec_loop.dis
+++ b/test/golden/aarch64-linux/vec/autovec_loop.dis
@@ -161,24 +161,39 @@ Disassembly of section .text:
                	str	xzr, [x23, #0xf8]
                	str	xzr, [x23, #0x100]
                	str	wzr, [x23, #0x108]
-               	add	x1, x19, #0x0
-               	add	x2, x19, x20, lsl #2
-               	add	x3, x22, #0x0
-               	add	x4, x22, x20, lsl #2
-               	add	x5, x23, #0x0
-               	add	x6, x23, x20, lsl #2
-               	cmp	x6, x1
-               	cset	w7, ls
-               	cmp	x2, x5
+               	mov	x16, #0xffff            // =65535
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xfffe, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	cmp	x20, x16
                	cset	w1, ls
-               	orr	w2, w7, w1
-               	cmp	x6, x3
-               	cset	w1, ls
-               	cmp	x4, x5
-               	cset	w3, ls
-               	orr	w4, w1, w3
-               	and	w1, w2, w4
-               	cbnz	w1,  <L4>
+               	mov	w16, #0x1               // =1
+               	and	w2, w1, w16
+               	mov	w16, #0x1               // =1
+               	and	w1, w2, w16
+               	mov	w16, #0x1               // =1
+               	and	w2, w1, w16
+               	mov	w16, #0x1               // =1
+               	and	w1, w2, w16
+               	add	x2, x19, #0x0
+               	add	x3, x19, x20, lsl #2
+               	add	x4, x22, #0x0
+               	add	x5, x22, x20, lsl #2
+               	add	x6, x23, #0x0
+               	add	x7, x23, x20, lsl #2
+               	cmp	x7, x2
+               	cset	w8, ls
+               	cmp	x3, x6
+               	cset	w2, ls
+               	orr	w3, w8, w2
+               	cmp	x7, x4
+               	cset	w2, ls
+               	cmp	x5, x6
+               	cset	w4, ls
+               	orr	w5, w2, w4
+               	and	w2, w3, w5
+               	and	w3, w1, w2
+               	cbnz	w3,  <L4>
                	mov	x1, #0x0                // =0
                	cmp	x1, x20
                	b.lo	 <L3>
@@ -198,53 +213,54 @@ Disassembly of section .text:
                	b.lo	 <L3>
                	b	 <L8>
 <L4>:
-               	sub	x1, x20, #0x4
-               	sub	x2, x29, #0x8a8
-               	add	x3, x2, #0x0
+               	sub	x1, x29, #0x8a8
+               	add	x2, x1, #0x0
                	mov	w17, #0x3               // =3
-               	str	w17, [x3]
-               	add	x3, x2, #0x4
+               	str	w17, [x2]
+               	add	x2, x1, #0x4
                	mov	w17, #0x3               // =3
-               	str	w17, [x3]
-               	add	x3, x2, #0x8
+               	str	w17, [x2]
+               	add	x2, x1, #0x8
                	mov	w17, #0x3               // =3
-               	str	w17, [x3]
-               	add	x3, x2, #0xc
+               	str	w17, [x2]
+               	add	x2, x1, #0xc
                	mov	w17, #0x3               // =3
-               	str	w17, [x3]
-               	ldr	q0, [x2]
-               	mov	x2, #0x0                // =0
-               	cmp	x2, x1
-               	b.le	 <L5>
+               	str	w17, [x2]
+               	ldr	q0, [x1]
+               	mov	x1, #0x0                // =0
+               	add	x2, x1, #0x4
+               	cmp	x2, x20
+               	b.ls	 <L5>
                	b	 <L6>
 <L5>:
-               	add	x3, x19, x2, lsl #2
-               	ldr	q1, [x3]
+               	add	x2, x19, x1, lsl #2
+               	ldr	q1, [x2]
                	mul	v2.4s, v1.4s, v0.4s
-               	add	x3, x22, x2, lsl #2
-               	ldr	q1, [x3]
+               	add	x2, x22, x1, lsl #2
+               	ldr	q1, [x2]
                	add	v3.4s, v2.4s, v1.4s
-               	add	x3, x23, x2, lsl #2
-               	str	q3, [x3]
-               	add	x2, x2, #0x4
-               	cmp	x2, x1
-               	b.le	 <L5>
-<L6>:
+               	add	x2, x23, x1, lsl #2
+               	str	q3, [x2]
+               	add	x1, x1, #0x4
+               	add	x2, x1, #0x4
                	cmp	x2, x20
+               	b.ls	 <L5>
+<L6>:
+               	cmp	x1, x20
                	b.lo	 <L7>
                	b	 <L8>
 <L7>:
-               	add	x1, x19, x2, lsl #2
-               	ldr	w3, [x1]
+               	add	x2, x19, x1, lsl #2
+               	ldr	w3, [x2]
                	mov	w16, #0x3               // =3
-               	mul	w1, w3, w16
-               	add	x3, x22, x2, lsl #2
+               	mul	w2, w3, w16
+               	add	x3, x22, x1, lsl #2
                	ldr	w4, [x3]
-               	add	w3, w1, w4
-               	add	x1, x23, x2, lsl #2
-               	str	w3, [x1]
-               	add	x2, x2, #0x1
-               	cmp	x2, x20
+               	add	w3, w2, w4
+               	add	x2, x23, x1, lsl #2
+               	str	w3, [x2]
+               	add	x1, x1, #0x1
+               	cmp	x1, x20
                	b.lo	 <L7>
 <L8>:
                	mov	x24, x0
@@ -597,24 +613,39 @@ Disassembly of section .text:
                	str	xzr, [x23, #0x80]
                	str	xzr, [x23, #0x88]
                	str	wzr, [x23, #0x90]
-               	add	x0, x19, #0x0
-               	add	x1, x19, x21, lsl #2
-               	add	x2, x20, #0x0
-               	add	x3, x20, x21, lsl #2
-               	add	x4, x23, #0x0
-               	add	x5, x23, x21, lsl #2
-               	cmp	x5, x0
-               	cset	w6, ls
-               	cmp	x1, x4
+               	mov	x16, #0xffff            // =65535
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xfffe, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	cmp	x21, x16
                	cset	w0, ls
-               	orr	w1, w6, w0
-               	cmp	x5, x2
-               	cset	w0, ls
-               	cmp	x3, x4
-               	cset	w2, ls
-               	orr	w3, w0, w2
-               	and	w0, w1, w3
-               	cbnz	w0,  <L38>
+               	mov	w16, #0x1               // =1
+               	and	w1, w0, w16
+               	mov	w16, #0x1               // =1
+               	and	w0, w1, w16
+               	mov	w16, #0x1               // =1
+               	and	w1, w0, w16
+               	mov	w16, #0x1               // =1
+               	and	w0, w1, w16
+               	add	x1, x19, #0x0
+               	add	x2, x19, x21, lsl #2
+               	add	x3, x20, #0x0
+               	add	x4, x20, x21, lsl #2
+               	add	x5, x23, #0x0
+               	add	x6, x23, x21, lsl #2
+               	cmp	x6, x1
+               	cset	w7, ls
+               	cmp	x2, x5
+               	cset	w1, ls
+               	orr	w2, w7, w1
+               	cmp	x6, x3
+               	cset	w1, ls
+               	cmp	x4, x5
+               	cset	w3, ls
+               	orr	w4, w1, w3
+               	and	w1, w2, w4
+               	and	w2, w0, w1
+               	cbnz	w2,  <L38>
                	mov	x0, #0x0                // =0
                	cmp	x0, x21
                	b.lo	 <L37>
@@ -632,36 +663,37 @@ Disassembly of section .text:
                	b.lo	 <L37>
                	b	 <L42>
 <L38>:
-               	sub	x0, x21, #0x4
-               	mov	x1, #0x0                // =0
-               	cmp	x1, x0
-               	b.le	 <L39>
+               	mov	x0, #0x0                // =0
+               	add	x1, x0, #0x4
+               	cmp	x1, x21
+               	b.ls	 <L39>
                	b	 <L40>
 <L39>:
-               	add	x2, x19, x1, lsl #2
-               	ldr	q0, [x2]
-               	add	x2, x20, x1, lsl #2
-               	ldr	q1, [x2]
+               	add	x1, x19, x0, lsl #2
+               	ldr	q0, [x1]
+               	add	x1, x20, x0, lsl #2
+               	ldr	q1, [x1]
                	fmul	v2.4s, v0.4s, v1.4s
-               	add	x2, x23, x1, lsl #2
-               	str	q2, [x2]
-               	add	x1, x1, #0x4
-               	cmp	x1, x0
-               	b.le	 <L39>
-<L40>:
+               	add	x1, x23, x0, lsl #2
+               	str	q2, [x1]
+               	add	x0, x0, #0x4
+               	add	x1, x0, #0x4
                	cmp	x1, x21
+               	b.ls	 <L39>
+<L40>:
+               	cmp	x0, x21
                	b.lo	 <L41>
                	b	 <L42>
 <L41>:
-               	add	x0, x19, x1, lsl #2
-               	ldr	s0, [x0]
-               	add	x0, x20, x1, lsl #2
-               	ldr	s1, [x0]
+               	add	x1, x19, x0, lsl #2
+               	ldr	s0, [x1]
+               	add	x1, x20, x0, lsl #2
+               	ldr	s1, [x1]
                	fmul	s2, s0, s1
-               	add	x0, x23, x1, lsl #2
-               	str	s2, [x0]
-               	add	x1, x1, #0x1
-               	cmp	x1, x21
+               	add	x1, x23, x0, lsl #2
+               	str	s2, [x1]
+               	add	x0, x0, #0x1
+               	cmp	x0, x21
                	b.lo	 <L41>
 <L42>:
                	mov	x24, #0x0               // =0
@@ -699,24 +731,39 @@ Disassembly of section .text:
                	str	xzr, [x23, #0x80]
                	str	xzr, [x23, #0x88]
                	str	wzr, [x23, #0x90]
-               	add	x0, x19, #0x0
-               	add	x1, x19, x21, lsl #2
-               	add	x2, x20, #0x0
-               	add	x3, x20, x21, lsl #2
-               	add	x4, x23, #0x0
-               	add	x5, x23, x21, lsl #2
-               	cmp	x5, x0
-               	cset	w6, ls
-               	cmp	x1, x4
+               	mov	x16, #0xffff            // =65535
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xfffe, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	cmp	x21, x16
                	cset	w0, ls
-               	orr	w1, w6, w0
-               	cmp	x5, x2
-               	cset	w0, ls
-               	cmp	x3, x4
-               	cset	w2, ls
-               	orr	w3, w0, w2
-               	and	w0, w1, w3
-               	cbnz	w0,  <L47>
+               	mov	w16, #0x1               // =1
+               	and	w1, w0, w16
+               	mov	w16, #0x1               // =1
+               	and	w0, w1, w16
+               	mov	w16, #0x1               // =1
+               	and	w1, w0, w16
+               	mov	w16, #0x1               // =1
+               	and	w0, w1, w16
+               	add	x1, x19, #0x0
+               	add	x2, x19, x21, lsl #2
+               	add	x3, x20, #0x0
+               	add	x4, x20, x21, lsl #2
+               	add	x5, x23, #0x0
+               	add	x6, x23, x21, lsl #2
+               	cmp	x6, x1
+               	cset	w7, ls
+               	cmp	x2, x5
+               	cset	w1, ls
+               	orr	w2, w7, w1
+               	cmp	x6, x3
+               	cset	w1, ls
+               	cmp	x4, x5
+               	cset	w3, ls
+               	orr	w4, w1, w3
+               	and	w1, w2, w4
+               	and	w2, w0, w1
+               	cbnz	w2,  <L47>
                	mov	x0, #0x0                // =0
                	cmp	x0, x21
                	b.lo	 <L46>
@@ -734,36 +781,37 @@ Disassembly of section .text:
                	b.lo	 <L46>
                	b	 <L51>
 <L47>:
-               	sub	x0, x21, #0x4
-               	mov	x1, #0x0                // =0
-               	cmp	x1, x0
-               	b.le	 <L48>
+               	mov	x0, #0x0                // =0
+               	add	x1, x0, #0x4
+               	cmp	x1, x21
+               	b.ls	 <L48>
                	b	 <L49>
 <L48>:
-               	add	x2, x19, x1, lsl #2
-               	ldr	q0, [x2]
-               	add	x2, x20, x1, lsl #2
-               	ldr	q1, [x2]
+               	add	x1, x19, x0, lsl #2
+               	ldr	q0, [x1]
+               	add	x1, x20, x0, lsl #2
+               	ldr	q1, [x1]
                	fdiv	v2.4s, v0.4s, v1.4s
-               	add	x2, x23, x1, lsl #2
-               	str	q2, [x2]
-               	add	x1, x1, #0x4
-               	cmp	x1, x0
-               	b.le	 <L48>
-<L49>:
+               	add	x1, x23, x0, lsl #2
+               	str	q2, [x1]
+               	add	x0, x0, #0x4
+               	add	x1, x0, #0x4
                	cmp	x1, x21
+               	b.ls	 <L48>
+<L49>:
+               	cmp	x0, x21
                	b.lo	 <L50>
                	b	 <L51>
 <L50>:
-               	add	x0, x19, x1, lsl #2
-               	ldr	s0, [x0]
-               	add	x0, x20, x1, lsl #2
-               	ldr	s1, [x0]
+               	add	x1, x19, x0, lsl #2
+               	ldr	s0, [x1]
+               	add	x1, x20, x0, lsl #2
+               	ldr	s1, [x1]
                	fdiv	s2, s0, s1
-               	add	x0, x23, x1, lsl #2
-               	str	s2, [x0]
-               	add	x1, x1, #0x1
-               	cmp	x1, x21
+               	add	x1, x23, x0, lsl #2
+               	str	s2, [x1]
+               	add	x0, x0, #0x1
+               	cmp	x0, x21
                	b.lo	 <L50>
 <L51>:
                	mov	x19, #0x0               // =0

--- a/test/golden/aarch64-linux/vec/vec_cmp_select.dis
+++ b/test/golden/aarch64-linux/vec/vec_cmp_select.dis
@@ -284,11 +284,11 @@ Disassembly of section .text:
 <corpus.cases.vec.vec_cmp_select.checksum>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0x3e0
-               	sub	x16, x29, #0x3c0
+               	sub	sp, sp, #0x390
+               	sub	x16, x29, #0x370
                	stp	x19, x20, [x16]
                	stp	x21, x22, [x16, #-0x10]
-               	sub	x16, x29, #0x3e0
+               	sub	x16, x29, #0x390
                	str	d8, [x16, #0x8]
                	mov	x19, x0
 <L0>:
@@ -1211,34 +1211,9 @@ Disassembly of section .text:
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[0]
+               	ldr	q0, [x29, x16]
 <L73>:
                	bl	 <L73>
-               	mov	x16, #0xfdc0            // =64960
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[1]
-<L74>:
-               	bl	 <L74>
-               	mov	x16, #0xfdc0            // =64960
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[2]
-<L75>:
-               	bl	 <L75>
-               	mov	x16, #0xfdc0            // =64960
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[3]
-<L76>:
-               	bl	 <L76>
                	mov	x16, #0xfdd0            // =64976
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
@@ -1249,8 +1224,110 @@ Disassembly of section .text:
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q30, [x29, x16]
-               	fcmgt	v31.4s, v31.4s, v30.4s
+               	fcmgt	v0.4s, v31.4s, v30.4s
+<L74>:
+               	bl	 <L74>
+               	mov	x16, #0xfdd0            // =64976
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	mov	x16, #0xfde0            // =64992
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q30, [x29, x16]
+               	fcmeq	v0.4s, v31.4s, v30.4s
+<L75>:
+               	bl	 <L75>
+               	mov	x16, #0xfdd0            // =64976
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	mov	x16, #0xfde0            // =64992
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q30, [x29, x16]
+               	fcmeq	v0.4s, v31.4s, v30.4s
+               	mvn	v0.16b, v0.16b
+<L76>:
+               	bl	 <L76>
+               	mov	x16, #0xfde0            // =64992
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	mov	x16, #0xfdd0            // =64976
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q30, [x29, x16]
+               	fcmge	v0.4s, v31.4s, v30.4s
+<L77>:
+               	bl	 <L77>
+               	mov	x16, #0xfdd0            // =64976
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	mov	x16, #0xfde0            // =64992
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q30, [x29, x16]
+               	fcmge	v0.4s, v31.4s, v30.4s
+<L78>:
+               	bl	 <L78>
+               	mov	x16, #0xfdc0            // =64960
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	mov	x16, #0xfdd0            // =64976
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q30, [x29, x16]
+               	and	v0.16b, v31.16b, v30.16b
+               	mov	x16, #0xfdc0            // =64960
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	mvn	v1.16b, v31.16b
+               	mov	x16, #0xfde0            // =64992
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q30, [x29, x16]
+               	and	v2.16b, v1.16b, v30.16b
+               	orr	v31.16b, v0.16b, v2.16b
                	mov	x16, #0xfdb0            // =64944
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	q31, [x29, x16]
+               	mov	x16, #0xfdc0            // =64960
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	mov	x16, #0xfde0            // =64992
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q30, [x29, x16]
+               	and	v0.16b, v31.16b, v30.16b
+               	mov	x16, #0xfdd0            // =64976
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q30, [x29, x16]
+               	and	v2.16b, v1.16b, v30.16b
+               	orr	v31.16b, v0.16b, v2.16b
+               	mov	x16, #0xfda0            // =64928
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1260,23 +1337,7 @@ Disassembly of section .text:
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[0]
-<L77>:
-               	bl	 <L77>
-               	mov	x16, #0xfdb0            // =64944
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[1]
-<L78>:
-               	bl	 <L78>
-               	mov	x16, #0xfdb0            // =64944
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[2]
+               	mov	s0, v31.s[0]
 <L79>:
                	bl	 <L79>
                	mov	x16, #0xfdb0            // =64944
@@ -1284,39 +1345,23 @@ Disassembly of section .text:
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[3]
+               	mov	s0, v31.s[1]
 <L80>:
                	bl	 <L80>
-               	mov	x16, #0xfdd0            // =64976
+               	mov	x16, #0xfdb0            // =64944
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov	x16, #0xfde0            // =64992
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q30, [x29, x16]
-               	fcmeq	v31.4s, v31.4s, v30.4s
-               	mov	x16, #0xfda0            // =64928
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfda0            // =64928
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[0]
+               	mov	s0, v31.s[2]
 <L81>:
                	bl	 <L81>
-               	mov	x16, #0xfda0            // =64928
+               	mov	x16, #0xfdb0            // =64944
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[1]
+               	mov	s0, v31.s[3]
 <L82>:
                	bl	 <L82>
                	mov	x16, #0xfda0            // =64928
@@ -1324,7 +1369,7 @@ Disassembly of section .text:
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[2]
+               	mov	s0, v31.s[0]
 <L83>:
                	bl	 <L83>
                	mov	x16, #0xfda0            // =64928
@@ -1332,21 +1377,36 @@ Disassembly of section .text:
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[3]
+               	mov	s0, v31.s[1]
 <L84>:
                	bl	 <L84>
-               	mov	x16, #0xfdd0            // =64976
+               	mov	x16, #0xfda0            // =64928
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov	x16, #0xfde0            // =64992
+               	mov	s0, v31.s[2]
+<L85>:
+               	bl	 <L85>
+               	mov	x16, #0xfda0            // =64928
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	mov	s0, v31.s[3]
+<L86>:
+               	bl	 <L86>
+               	mov	x16, #0xfda0            // =64928
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	mov	x16, #0xfdb0            // =64944
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q30, [x29, x16]
-               	fcmeq	v31.4s, v31.4s, v30.4s
-               	mvn	v31.16b, v31.16b
+               	fsub	v31.4s, v31.4s, v30.4s
                	mov	x16, #0xfd90            // =64912
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
@@ -1357,23 +1417,7 @@ Disassembly of section .text:
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[0]
-<L85>:
-               	bl	 <L85>
-               	mov	x16, #0xfd90            // =64912
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[1]
-<L86>:
-               	bl	 <L86>
-               	mov	x16, #0xfd90            // =64912
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[2]
+               	mov	s0, v31.s[0]
 <L87>:
                	bl	 <L87>
                	mov	x16, #0xfd90            // =64912
@@ -1381,265 +1425,25 @@ Disassembly of section .text:
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[3]
+               	mov	s0, v31.s[1]
 <L88>:
                	bl	 <L88>
-               	mov	x16, #0xfde0            // =64992
+               	mov	x16, #0xfd90            // =64912
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov	x16, #0xfdd0            // =64976
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q30, [x29, x16]
-               	fcmge	v31.4s, v31.4s, v30.4s
-               	mov	x16, #0xfd80            // =64896
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfd80            // =64896
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[0]
+               	mov	s0, v31.s[2]
 <L89>:
                	bl	 <L89>
-               	mov	x16, #0xfd80            // =64896
+               	mov	x16, #0xfd90            // =64912
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[1]
+               	mov	s0, v31.s[3]
 <L90>:
                	bl	 <L90>
-               	mov	x16, #0xfd80            // =64896
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[2]
-<L91>:
-               	bl	 <L91>
-               	mov	x16, #0xfd80            // =64896
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[3]
-<L92>:
-               	bl	 <L92>
-               	mov	x16, #0xfdd0            // =64976
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x16, #0xfde0            // =64992
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q30, [x29, x16]
-               	fcmge	v31.4s, v31.4s, v30.4s
-               	mov	x16, #0xfd70            // =64880
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfd70            // =64880
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[0]
-<L93>:
-               	bl	 <L93>
-               	mov	x16, #0xfd70            // =64880
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[1]
-<L94>:
-               	bl	 <L94>
-               	mov	x16, #0xfd70            // =64880
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[2]
-<L95>:
-               	bl	 <L95>
-               	mov	x16, #0xfd70            // =64880
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[3]
-<L96>:
-               	bl	 <L96>
-               	mov	x16, #0xfde0            // =64992
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x16, #0xfdd0            // =64976
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q30, [x29, x16]
-               	fcmgt	v0.4s, v31.4s, v30.4s
-               	mov	x16, #0xfdd0            // =64976
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q30, [x29, x16]
-               	and	v1.16b, v0.16b, v30.16b
-               	mvn	v2.16b, v0.16b
-               	mov	x16, #0xfde0            // =64992
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q30, [x29, x16]
-               	and	v3.16b, v2.16b, v30.16b
-               	orr	v31.16b, v1.16b, v3.16b
-               	mov	x16, #0xfd60            // =64864
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfde0            // =64992
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q30, [x29, x16]
-               	and	v1.16b, v0.16b, v30.16b
-               	mov	x16, #0xfdd0            // =64976
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q30, [x29, x16]
-               	and	v0.16b, v2.16b, v30.16b
-               	orr	v31.16b, v1.16b, v0.16b
-               	mov	x16, #0xfd50            // =64848
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfd60            // =64864
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31.s[0]
-<L97>:
-               	bl	 <L97>
-               	mov	x16, #0xfd60            // =64864
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31.s[1]
-<L98>:
-               	bl	 <L98>
-               	mov	x16, #0xfd60            // =64864
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31.s[2]
-<L99>:
-               	bl	 <L99>
-               	mov	x16, #0xfd60            // =64864
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31.s[3]
-<L100>:
-               	bl	 <L100>
-               	mov	x16, #0xfd50            // =64848
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31.s[0]
-<L101>:
-               	bl	 <L101>
-               	mov	x16, #0xfd50            // =64848
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31.s[1]
-<L102>:
-               	bl	 <L102>
-               	mov	x16, #0xfd50            // =64848
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31.s[2]
-<L103>:
-               	bl	 <L103>
-               	mov	x16, #0xfd50            // =64848
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31.s[3]
-<L104>:
-               	bl	 <L104>
-               	mov	x16, #0xfd50            // =64848
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x16, #0xfd60            // =64864
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q30, [x29, x16]
-               	fsub	v31.4s, v31.4s, v30.4s
-               	mov	x16, #0xfd40            // =64832
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfd40            // =64832
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31.s[0]
-<L105>:
-               	bl	 <L105>
-               	mov	x16, #0xfd40            // =64832
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31.s[1]
-<L106>:
-               	bl	 <L106>
-               	mov	x16, #0xfd40            // =64832
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31.s[2]
-<L107>:
-               	bl	 <L107>
-               	mov	x16, #0xfd40            // =64832
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31.s[3]
-<L108>:
-               	bl	 <L108>
                	sub	x1, x29, #0x70
                	add	x2, x1, #0x0
                	mov	x17, #0x3ff8000000000000 // =4609434218613702656
@@ -1655,7 +1459,7 @@ Disassembly of section .text:
                	add	x2, x1, #0x8
                	str	xzr, [x2]
                	ldr	q31, [x1]
-               	mov	x16, #0xfd30            // =64816
+               	mov	x16, #0xfd80            // =64896
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1665,140 +1469,140 @@ Disassembly of section .text:
                	fadd	d3, d1, d2
                	mov	v30.16b, v0.16b
                	mov	v30.d[0], v3.d[0]
-               	mov	x16, #0xfd20            // =64800
+               	mov	x16, #0xfd70            // =64880
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q30, [x29, x16]
-               	mov	x16, #0xfd30            // =64816
+               	mov	x16, #0xfd80            // =64896
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov	x16, #0xfd20            // =64800
+               	mov	x16, #0xfd70            // =64880
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q30, [x29, x16]
                	fcmgt	v31.2d, v31.2d, v30.2d
-               	mov	x16, #0xfd10            // =64784
+               	mov	x16, #0xfd60            // =64864
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xfd10            // =64784
+               	mov	x16, #0xfd60            // =64864
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	mov	x1, v31.d[0]
-<L109>:
-               	bl	 <L109>
-               	mov	x16, #0xfd10            // =64784
+<L91>:
+               	bl	 <L91>
+               	mov	x16, #0xfd60            // =64864
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	mov	x1, v31.d[1]
-<L110>:
-               	bl	 <L110>
-               	mov	x16, #0xfd20            // =64800
+<L92>:
+               	bl	 <L92>
+               	mov	x16, #0xfd70            // =64880
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov	x16, #0xfd30            // =64816
+               	mov	x16, #0xfd80            // =64896
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q30, [x29, x16]
                	fcmeq	v31.2d, v31.2d, v30.2d
-               	mov	x16, #0xfd00            // =64768
+               	mov	x16, #0xfd50            // =64848
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xfd00            // =64768
+               	mov	x16, #0xfd50            // =64848
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	mov	x1, v31.d[0]
-<L111>:
-               	bl	 <L111>
-               	mov	x16, #0xfd00            // =64768
+<L93>:
+               	bl	 <L93>
+               	mov	x16, #0xfd50            // =64848
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	mov	x1, v31.d[1]
-<L112>:
-               	bl	 <L112>
-               	mov	x16, #0xfd20            // =64800
+<L94>:
+               	bl	 <L94>
+               	mov	x16, #0xfd70            // =64880
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov	x16, #0xfd30            // =64816
+               	mov	x16, #0xfd80            // =64896
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q30, [x29, x16]
                	fcmeq	v31.2d, v31.2d, v30.2d
                	mvn	v31.16b, v31.16b
-               	mov	x16, #0xfcf0            // =64752
+               	mov	x16, #0xfd40            // =64832
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xfcf0            // =64752
+               	mov	x16, #0xfd40            // =64832
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	mov	x1, v31.d[0]
-<L113>:
-               	bl	 <L113>
-               	mov	x16, #0xfcf0            // =64752
+<L95>:
+               	bl	 <L95>
+               	mov	x16, #0xfd40            // =64832
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	mov	x1, v31.d[1]
-<L114>:
-               	bl	 <L114>
-               	mov	x16, #0xfd20            // =64800
+<L96>:
+               	bl	 <L96>
+               	mov	x16, #0xfd70            // =64880
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov	x16, #0xfd30            // =64816
+               	mov	x16, #0xfd80            // =64896
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q30, [x29, x16]
                	fcmge	v31.2d, v31.2d, v30.2d
-               	mov	x16, #0xfce0            // =64736
+               	mov	x16, #0xfd30            // =64816
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xfce0            // =64736
+               	mov	x16, #0xfd30            // =64816
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	mov	x1, v31.d[0]
-<L115>:
-               	bl	 <L115>
-               	mov	x16, #0xfce0            // =64736
+<L97>:
+               	bl	 <L97>
+               	mov	x16, #0xfd30            // =64816
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	mov	x1, v31.d[1]
-<L116>:
-               	bl	 <L116>
+<L98>:
+               	bl	 <L98>
                	sub	x1, x29, #0x90
                	add	x2, x1, #0x0
                	mov	w17, #0x1               // =1
@@ -1854,7 +1658,7 @@ Disassembly of section .text:
                	add	w2, w1, w21
                	mov	v30.16b, v0.16b
                	mov	v30.h[0], w2
-               	mov	x16, #0xfcd0            // =64720
+               	mov	x16, #0xfd20            // =64800
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1863,89 +1667,295 @@ Disassembly of section .text:
                	add	w2, w1, w21
                	mov	v30.16b, v1.16b
                	mov	v30.h[7], w2
-               	mov	x16, #0xfcc0            // =64704
+               	mov	x16, #0xfd10            // =64784
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q30, [x29, x16]
-               	mov	x16, #0xfcc0            // =64704
+               	mov	x16, #0xfd10            // =64784
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov	x16, #0xfcd0            // =64720
+               	mov	x16, #0xfd20            // =64800
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q30, [x29, x16]
                	cmhi	v31.8h, v31.8h, v30.8h
-               	mov	x16, #0xfcb0            // =64688
+               	mov	x16, #0xfd00            // =64768
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xfcb0            // =64688
+               	mov	x16, #0xfd00            // =64768
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	umov	w1, v31.h[0]
-<L117>:
-               	bl	 <L117>
-               	mov	x16, #0xfcb0            // =64688
+<L99>:
+               	bl	 <L99>
+               	mov	x16, #0xfd00            // =64768
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	umov	w1, v31.h[1]
-<L118>:
-               	bl	 <L118>
-               	mov	x16, #0xfcb0            // =64688
+<L100>:
+               	bl	 <L100>
+               	mov	x16, #0xfd00            // =64768
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	umov	w1, v31.h[2]
-<L119>:
-               	bl	 <L119>
-               	mov	x16, #0xfcb0            // =64688
+<L101>:
+               	bl	 <L101>
+               	mov	x16, #0xfd00            // =64768
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	umov	w1, v31.h[3]
-<L120>:
-               	bl	 <L120>
-               	mov	x16, #0xfcb0            // =64688
+<L102>:
+               	bl	 <L102>
+               	mov	x16, #0xfd00            // =64768
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	umov	w1, v31.h[4]
-<L121>:
-               	bl	 <L121>
-               	mov	x16, #0xfcb0            // =64688
+<L103>:
+               	bl	 <L103>
+               	mov	x16, #0xfd00            // =64768
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	umov	w1, v31.h[5]
-<L122>:
-               	bl	 <L122>
-               	mov	x16, #0xfcb0            // =64688
+<L104>:
+               	bl	 <L104>
+               	mov	x16, #0xfd00            // =64768
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	umov	w1, v31.h[6]
-<L123>:
-               	bl	 <L123>
-               	mov	x16, #0xfcb0            // =64688
+<L105>:
+               	bl	 <L105>
+               	mov	x16, #0xfd00            // =64768
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	umov	w1, v31.h[7]
+<L106>:
+               	bl	 <L106>
+               	mov	x16, #0xfd20            // =64800
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	mov	x16, #0xfd10            // =64784
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q30, [x29, x16]
+               	cmeq	v31.8h, v31.8h, v30.8h
+               	mov	x16, #0xfcf0            // =64752
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	q31, [x29, x16]
+               	mov	x16, #0xfcf0            // =64752
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	umov	w1, v31.h[0]
+<L107>:
+               	bl	 <L107>
+               	mov	x16, #0xfcf0            // =64752
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	umov	w1, v31.h[1]
+<L108>:
+               	bl	 <L108>
+               	mov	x16, #0xfcf0            // =64752
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	umov	w1, v31.h[2]
+<L109>:
+               	bl	 <L109>
+               	mov	x16, #0xfcf0            // =64752
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	umov	w1, v31.h[3]
+<L110>:
+               	bl	 <L110>
+               	mov	x16, #0xfcf0            // =64752
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	umov	w1, v31.h[4]
+<L111>:
+               	bl	 <L111>
+               	mov	x16, #0xfcf0            // =64752
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	umov	w1, v31.h[5]
+<L112>:
+               	bl	 <L112>
+               	mov	x16, #0xfcf0            // =64752
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	umov	w1, v31.h[6]
+<L113>:
+               	bl	 <L113>
+               	mov	x16, #0xfcf0            // =64752
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	umov	w1, v31.h[7]
+<L114>:
+               	bl	 <L114>
+               	mov	x16, #0xfd20            // =64800
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	mov	x16, #0xfd10            // =64784
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q30, [x29, x16]
+               	cmhi	v31.8h, v31.8h, v30.8h
+               	mov	x16, #0xfce0            // =64736
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	q31, [x29, x16]
+               	mov	x16, #0xfce0            // =64736
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	umov	w1, v31.h[0]
+<L115>:
+               	bl	 <L115>
+               	mov	x16, #0xfce0            // =64736
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	umov	w1, v31.h[1]
+<L116>:
+               	bl	 <L116>
+               	mov	x16, #0xfce0            // =64736
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	umov	w1, v31.h[2]
+<L117>:
+               	bl	 <L117>
+               	mov	x16, #0xfce0            // =64736
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	umov	w1, v31.h[3]
+<L118>:
+               	bl	 <L118>
+               	mov	x16, #0xfce0            // =64736
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	umov	w1, v31.h[4]
+<L119>:
+               	bl	 <L119>
+               	mov	x16, #0xfce0            // =64736
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	umov	w1, v31.h[5]
+<L120>:
+               	bl	 <L120>
+               	mov	x16, #0xfce0            // =64736
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	umov	w1, v31.h[6]
+<L121>:
+               	bl	 <L121>
+               	mov	x16, #0xfce0            // =64736
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	umov	w1, v31.h[7]
+<L122>:
+               	bl	 <L122>
+               	mov	x16, #0xfd10            // =64784
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	mov	x16, #0xfd20            // =64800
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q30, [x29, x16]
+               	cmhi	v0.8h, v31.8h, v30.8h
+               	mov	x16, #0xfd20            // =64800
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q30, [x29, x16]
+               	and	v1.16b, v0.16b, v30.16b
+               	mvn	v2.16b, v0.16b
+               	mov	x16, #0xfd10            // =64784
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q30, [x29, x16]
+               	and	v0.16b, v2.16b, v30.16b
+               	orr	v31.16b, v1.16b, v0.16b
+               	mov	x16, #0xfcd0            // =64720
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	q31, [x29, x16]
+               	mov	x16, #0xfcd0            // =64720
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	umov	w1, v31.h[0]
+<L123>:
+               	bl	 <L123>
+               	mov	x16, #0xfcd0            // =64720
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	umov	w1, v31.h[1]
 <L124>:
                	bl	 <L124>
                	mov	x16, #0xfcd0            // =64720
@@ -1953,255 +1963,49 @@ Disassembly of section .text:
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov	x16, #0xfcc0            // =64704
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q30, [x29, x16]
-               	cmeq	v31.8h, v31.8h, v30.8h
-               	mov	x16, #0xfca0            // =64672
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfca0            // =64672
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[0]
+               	umov	w1, v31.h[2]
 <L125>:
                	bl	 <L125>
-               	mov	x16, #0xfca0            // =64672
+               	mov	x16, #0xfcd0            // =64720
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[1]
+               	umov	w1, v31.h[3]
 <L126>:
                	bl	 <L126>
-               	mov	x16, #0xfca0            // =64672
+               	mov	x16, #0xfcd0            // =64720
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[2]
+               	umov	w1, v31.h[4]
 <L127>:
                	bl	 <L127>
-               	mov	x16, #0xfca0            // =64672
+               	mov	x16, #0xfcd0            // =64720
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[3]
+               	umov	w1, v31.h[5]
 <L128>:
                	bl	 <L128>
-               	mov	x16, #0xfca0            // =64672
+               	mov	x16, #0xfcd0            // =64720
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[4]
+               	umov	w1, v31.h[6]
 <L129>:
                	bl	 <L129>
-               	mov	x16, #0xfca0            // =64672
+               	mov	x16, #0xfcd0            // =64720
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[5]
+               	umov	w1, v31.h[7]
 <L130>:
                	bl	 <L130>
-               	mov	x16, #0xfca0            // =64672
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[6]
-<L131>:
-               	bl	 <L131>
-               	mov	x16, #0xfca0            // =64672
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[7]
-<L132>:
-               	bl	 <L132>
-               	mov	x16, #0xfcd0            // =64720
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x16, #0xfcc0            // =64704
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q30, [x29, x16]
-               	cmhi	v31.8h, v31.8h, v30.8h
-               	mov	x16, #0xfc90            // =64656
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfc90            // =64656
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[0]
-<L133>:
-               	bl	 <L133>
-               	mov	x16, #0xfc90            // =64656
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[1]
-<L134>:
-               	bl	 <L134>
-               	mov	x16, #0xfc90            // =64656
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[2]
-<L135>:
-               	bl	 <L135>
-               	mov	x16, #0xfc90            // =64656
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[3]
-<L136>:
-               	bl	 <L136>
-               	mov	x16, #0xfc90            // =64656
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[4]
-<L137>:
-               	bl	 <L137>
-               	mov	x16, #0xfc90            // =64656
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[5]
-<L138>:
-               	bl	 <L138>
-               	mov	x16, #0xfc90            // =64656
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[6]
-<L139>:
-               	bl	 <L139>
-               	mov	x16, #0xfc90            // =64656
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[7]
-<L140>:
-               	bl	 <L140>
-               	mov	x16, #0xfcc0            // =64704
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x16, #0xfcd0            // =64720
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q30, [x29, x16]
-               	cmhi	v0.8h, v31.8h, v30.8h
-               	mov	x16, #0xfcd0            // =64720
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q30, [x29, x16]
-               	and	v1.16b, v0.16b, v30.16b
-               	mvn	v2.16b, v0.16b
-               	mov	x16, #0xfcc0            // =64704
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q30, [x29, x16]
-               	and	v0.16b, v2.16b, v30.16b
-               	orr	v31.16b, v1.16b, v0.16b
-               	mov	x16, #0xfc80            // =64640
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfc80            // =64640
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[0]
-<L141>:
-               	bl	 <L141>
-               	mov	x16, #0xfc80            // =64640
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[1]
-<L142>:
-               	bl	 <L142>
-               	mov	x16, #0xfc80            // =64640
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[2]
-<L143>:
-               	bl	 <L143>
-               	mov	x16, #0xfc80            // =64640
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[3]
-<L144>:
-               	bl	 <L144>
-               	mov	x16, #0xfc80            // =64640
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[4]
-<L145>:
-               	bl	 <L145>
-               	mov	x16, #0xfc80            // =64640
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[5]
-<L146>:
-               	bl	 <L146>
-               	mov	x16, #0xfc80            // =64640
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[6]
-<L147>:
-               	bl	 <L147>
-               	mov	x16, #0xfc80            // =64640
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[7]
-<L148>:
-               	bl	 <L148>
                	sub	x1, x29, #0xb0
                	add	x2, x1, #0x0
                	mov	w17, #0x1               // =1
@@ -2305,7 +2109,7 @@ Disassembly of section .text:
                	add	w2, w1, w22
                	mov	v30.16b, v0.16b
                	mov	v30.b[0], w2
-               	mov	x16, #0xfc70            // =64624
+               	mov	x16, #0xfcc0            // =64704
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2314,78 +2118,78 @@ Disassembly of section .text:
                	add	w2, w1, w22
                	mov	v30.16b, v1.16b
                	mov	v30.b[15], w2
-               	mov	x16, #0xfc60            // =64608
+               	mov	x16, #0xfcb0            // =64688
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q30, [x29, x16]
-               	mov	x16, #0xfc60            // =64608
+               	mov	x16, #0xfcb0            // =64688
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov	x16, #0xfc70            // =64624
+               	mov	x16, #0xfcc0            // =64704
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q30, [x29, x16]
                	cmhi	v31.16b, v31.16b, v30.16b
-               	mov	x16, #0xfc50            // =64592
+               	mov	x16, #0xfca0            // =64672
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xfc50            // =64592
+               	mov	x16, #0xfca0            // =64672
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q0, [x29, x16]
-<L149>:
-               	bl	 <L149>
-               	mov	x16, #0xfc70            // =64624
+<L131>:
+               	bl	 <L131>
+               	mov	x16, #0xfcc0            // =64704
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov	x16, #0xfc60            // =64608
+               	mov	x16, #0xfcb0            // =64688
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q30, [x29, x16]
                	cmeq	v0.16b, v31.16b, v30.16b
-<L150>:
-               	bl	 <L150>
-               	mov	x16, #0xfc70            // =64624
+<L132>:
+               	bl	 <L132>
+               	mov	x16, #0xfcc0            // =64704
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov	x16, #0xfc60            // =64608
+               	mov	x16, #0xfcb0            // =64688
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q30, [x29, x16]
                	cmhs	v0.16b, v31.16b, v30.16b
-<L151>:
-               	bl	 <L151>
-               	mov	x16, #0xfc50            // =64592
+<L133>:
+               	bl	 <L133>
+               	mov	x16, #0xfca0            // =64672
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov	x16, #0xfc70            // =64624
+               	mov	x16, #0xfcc0            // =64704
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q30, [x29, x16]
                	and	v0.16b, v31.16b, v30.16b
-               	mov	x16, #0xfc50            // =64592
+               	mov	x16, #0xfca0            // =64672
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	mvn	v1.16b, v31.16b
-               	mov	x16, #0xfc60            // =64608
+               	mov	x16, #0xfcb0            // =64688
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2393,11 +2197,11 @@ Disassembly of section .text:
                	and	v2.16b, v1.16b, v30.16b
                	orr	v1.16b, v0.16b, v2.16b
                	mov	v0.16b, v1.16b
-<L152>:
-               	bl	 <L152>
-               	sub	x16, x29, #0x3e0
+<L134>:
+               	bl	 <L134>
+               	sub	x16, x29, #0x390
                	ldr	d8, [x16, #0x8]
-               	sub	x16, x29, #0x3c0
+               	sub	x16, x29, #0x370
                	ldp	x19, x20, [x16]
                	ldp	x21, x22, [x16, #-0x10]
                	mov	sp, x29

--- a/test/golden/aarch64-linux/vec/vec_i16x4.dis
+++ b/test/golden/aarch64-linux/vec/vec_i16x4.dis
@@ -42,10 +42,13 @@ Disassembly of section .text:
 <corpus.cases.vec.vec_i16x4.checksum>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0x240
-               	sub	x16, x29, #0x230
-               	stp	x19, x20, [x16]
-               	stur	x21, [x16, #-0x8]
+               	sub	sp, sp, #0x1f0
+               	stp	x19, x20, [x29, #-0x1e0]
+               	mov	x16, #0xfe18            // =65048
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x21, [x29, x16]
                	mov	x19, x0
 <L0>:
                	bl	 <L0>
@@ -358,87 +361,96 @@ Disassembly of section .text:
                	bl	 <L40>
                	ldur	q31, [x29, #-0x80]
                	ldur	q30, [x29, #-0xa0]
-               	sub	v31.8h, v31.8h, v30.8h
-               	mov	x16, #0xfed0            // =65232
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfed0            // =65232
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[0]
+               	sub	v0.8h, v31.8h, v30.8h
 <L41>:
                	bl	 <L41>
-               	mov	x16, #0xfed0            // =65232
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[1]
-<L42>:
-               	bl	 <L42>
-               	mov	x16, #0xfed0            // =65232
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[2]
-<L43>:
-               	bl	 <L43>
-               	mov	x16, #0xfed0            // =65232
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[3]
-<L44>:
-               	bl	 <L44>
                	ldur	q31, [x29, #-0x90]
                	ldur	q30, [x29, #-0xa0]
                	and	v31.16b, v31.16b, v30.16b
-               	mov	x16, #0xfec0            // =65216
+               	mov	x16, #0xfed0            // =65232
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xfec0            // =65216
+               	mov	x16, #0xfed0            // =65232
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[0]
-<L45>:
-               	bl	 <L45>
-               	mov	x16, #0xfec0            // =65216
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[1]
-<L46>:
-               	bl	 <L46>
-               	mov	x16, #0xfec0            // =65216
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[2]
-<L47>:
-               	bl	 <L47>
-               	mov	x16, #0xfec0            // =65216
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[3]
-<L48>:
-               	bl	 <L48>
+               	ldr	q0, [x29, x16]
+<L42>:
+               	bl	 <L42>
                	ldur	q31, [x29, #-0x90]
                	ldur	q30, [x29, #-0xa0]
                	orr	v31.16b, v31.16b, v30.16b
+               	mov	x16, #0xfec0            // =65216
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	q31, [x29, x16]
+               	mov	x16, #0xfec0            // =65216
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q0, [x29, x16]
+<L43>:
+               	bl	 <L43>
+               	ldur	q31, [x29, #-0x90]
+               	ldur	q30, [x29, #-0xa0]
+               	eor	v0.16b, v31.16b, v30.16b
+<L44>:
+               	bl	 <L44>
+               	ldur	q31, [x29, #-0x90]
+               	mvn	v0.16b, v31.16b
+<L45>:
+               	bl	 <L45>
+               	ldur	q31, [x29, #-0xa0]
+               	mvn	v0.16b, v31.16b
+<L46>:
+               	bl	 <L46>
+               	mov	x16, #0xfed0            // =65232
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	mov	x16, #0xfec0            // =65216
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q30, [x29, x16]
+               	eor	v0.16b, v31.16b, v30.16b
+<L47>:
+               	bl	 <L47>
+               	mov	x19, x0
+               	ldur	q31, [x29, #-0x90]
+               	mov	x16, #0xfea0            // =65184
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	q31, [x29, x16]
+               	ldur	q31, [x29, #-0x80]
+               	mov	x16, #0xfe90            // =65168
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	q31, [x29, x16]
+               	ldur	q31, [x29, #-0x80]
+               	mov	x16, #0xfe80            // =65152
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	q31, [x29, x16]
+               	mov	x20, #0x0               // =0
+               	cmp	x20, #0x6
+               	b.lo	 <L48>
+               	b	 <L65>
+<L48>:
+               	mov	x16, #0xfea0            // =65184
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	ldur	q30, [x29, #-0x70]
+               	mul	v31.8h, v31.8h, v30.8h
                	mov	x16, #0xfeb0            // =65200
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
@@ -450,6 +462,7 @@ Disassembly of section .text:
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	umov	w1, v31.h[0]
+               	mov	x0, x19
 <L49>:
                	bl	 <L49>
                	mov	x16, #0xfeb0            // =65200
@@ -476,15 +489,23 @@ Disassembly of section .text:
                	umov	w1, v31.h[3]
 <L52>:
                	bl	 <L52>
-               	ldur	q31, [x29, #-0x90]
-               	ldur	q30, [x29, #-0xa0]
+               	mov	x16, #0xfe90            // =65168
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	mov	x16, #0xfeb0            // =65200
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q30, [x29, x16]
                	eor	v31.16b, v31.16b, v30.16b
-               	mov	x16, #0xfea0            // =65184
+               	mov	x16, #0xfe70            // =65136
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xfea0            // =65184
+               	mov	x16, #0xfe70            // =65136
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -492,7 +513,7 @@ Disassembly of section .text:
                	umov	w1, v31.h[0]
 <L53>:
                	bl	 <L53>
-               	mov	x16, #0xfea0            // =65184
+               	mov	x16, #0xfe70            // =65136
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -500,7 +521,7 @@ Disassembly of section .text:
                	umov	w1, v31.h[1]
 <L54>:
                	bl	 <L54>
-               	mov	x16, #0xfea0            // =65184
+               	mov	x16, #0xfe70            // =65136
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -508,7 +529,7 @@ Disassembly of section .text:
                	umov	w1, v31.h[2]
 <L55>:
                	bl	 <L55>
-               	mov	x16, #0xfea0            // =65184
+               	mov	x16, #0xfe70            // =65136
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -516,14 +537,23 @@ Disassembly of section .text:
                	umov	w1, v31.h[3]
 <L56>:
                	bl	 <L56>
-               	ldur	q31, [x29, #-0x90]
-               	mvn	v31.16b, v31.16b
-               	mov	x16, #0xfe90            // =65168
+               	mov	x16, #0xfe80            // =65152
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	mov	x16, #0xfea0            // =65184
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q30, [x29, x16]
+               	add	v31.8h, v31.8h, v30.8h
+               	mov	x16, #0xfe60            // =65120
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xfe90            // =65168
+               	mov	x16, #0xfe60            // =65120
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -531,7 +561,7 @@ Disassembly of section .text:
                	umov	w1, v31.h[0]
 <L57>:
                	bl	 <L57>
-               	mov	x16, #0xfe90            // =65168
+               	mov	x16, #0xfe60            // =65120
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -539,7 +569,7 @@ Disassembly of section .text:
                	umov	w1, v31.h[1]
 <L58>:
                	bl	 <L58>
-               	mov	x16, #0xfe90            // =65168
+               	mov	x16, #0xfe60            // =65120
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -547,7 +577,7 @@ Disassembly of section .text:
                	umov	w1, v31.h[2]
 <L59>:
                	bl	 <L59>
-               	mov	x16, #0xfe90            // =65168
+               	mov	x16, #0xfe60            // =65120
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -555,14 +585,19 @@ Disassembly of section .text:
                	umov	w1, v31.h[3]
 <L60>:
                	bl	 <L60>
-               	ldur	q31, [x29, #-0xa0]
-               	mvn	v31.16b, v31.16b
-               	mov	x16, #0xfe80            // =65152
+               	mov	x16, #0xfea0            // =65184
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	ldur	q30, [x29, #-0xa0]
+               	add	v31.8h, v31.8h, v30.8h
+               	mov	x16, #0xfe50            // =65104
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xfe80            // =65152
+               	mov	x16, #0xfe50            // =65104
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -570,7 +605,7 @@ Disassembly of section .text:
                	umov	w1, v31.h[0]
 <L61>:
                	bl	 <L61>
-               	mov	x16, #0xfe80            // =65152
+               	mov	x16, #0xfe50            // =65104
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -578,7 +613,7 @@ Disassembly of section .text:
                	umov	w1, v31.h[1]
 <L62>:
                	bl	 <L62>
-               	mov	x16, #0xfe80            // =65152
+               	mov	x16, #0xfe50            // =65104
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -586,7 +621,7 @@ Disassembly of section .text:
                	umov	w1, v31.h[2]
 <L63>:
                	bl	 <L63>
-               	mov	x16, #0xfe80            // =65152
+               	mov	x16, #0xfe50            // =65104
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -594,294 +629,41 @@ Disassembly of section .text:
                	umov	w1, v31.h[3]
 <L64>:
                	bl	 <L64>
-               	ldur	q31, [x29, #-0x90]
-               	ldur	q30, [x29, #-0xa0]
-               	and	v0.16b, v31.16b, v30.16b
-               	ldur	q31, [x29, #-0x90]
-               	ldur	q30, [x29, #-0xa0]
-               	orr	v1.16b, v31.16b, v30.16b
-               	eor	v31.16b, v0.16b, v1.16b
-               	mov	x16, #0xfe70            // =65136
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfe70            // =65136
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[0]
-<L65>:
-               	bl	 <L65>
-               	mov	x16, #0xfe70            // =65136
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[1]
-<L66>:
-               	bl	 <L66>
-               	mov	x16, #0xfe70            // =65136
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[2]
-<L67>:
-               	bl	 <L67>
-               	mov	x16, #0xfe70            // =65136
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[3]
-<L68>:
-               	bl	 <L68>
-               	mov	x19, x0
-               	ldur	q31, [x29, #-0x90]
-               	mov	x16, #0xfe50            // =65104
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	ldur	q31, [x29, #-0x80]
-               	mov	x16, #0xfe40            // =65088
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	ldur	q31, [x29, #-0x80]
-               	mov	x16, #0xfe30            // =65072
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x20, #0x0               // =0
-               	cmp	x20, #0x6
-               	b.lo	 <L69>
-               	b	 <L86>
-<L69>:
-               	mov	x16, #0xfe50            // =65104
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	ldur	q30, [x29, #-0x70]
-               	mul	v31.8h, v31.8h, v30.8h
-               	mov	x16, #0xfe60            // =65120
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfe60            // =65120
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[0]
-               	mov	x0, x19
-<L70>:
-               	bl	 <L70>
-               	mov	x16, #0xfe60            // =65120
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[1]
-<L71>:
-               	bl	 <L71>
-               	mov	x16, #0xfe60            // =65120
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[2]
-<L72>:
-               	bl	 <L72>
-               	mov	x16, #0xfe60            // =65120
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[3]
-<L73>:
-               	bl	 <L73>
-               	mov	x16, #0xfe40            // =65088
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x16, #0xfe60            // =65120
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q30, [x29, x16]
-               	eor	v31.16b, v31.16b, v30.16b
-               	mov	x16, #0xfe20            // =65056
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfe20            // =65056
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[0]
-<L74>:
-               	bl	 <L74>
-               	mov	x16, #0xfe20            // =65056
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[1]
-<L75>:
-               	bl	 <L75>
-               	mov	x16, #0xfe20            // =65056
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[2]
-<L76>:
-               	bl	 <L76>
-               	mov	x16, #0xfe20            // =65056
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[3]
-<L77>:
-               	bl	 <L77>
-               	mov	x16, #0xfe30            // =65072
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x16, #0xfe50            // =65104
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q30, [x29, x16]
-               	add	v31.8h, v31.8h, v30.8h
-               	mov	x16, #0xfe10            // =65040
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfe10            // =65040
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[0]
-<L78>:
-               	bl	 <L78>
-               	mov	x16, #0xfe10            // =65040
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[1]
-<L79>:
-               	bl	 <L79>
-               	mov	x16, #0xfe10            // =65040
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[2]
-<L80>:
-               	bl	 <L80>
-               	mov	x16, #0xfe10            // =65040
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[3]
-<L81>:
-               	bl	 <L81>
-               	mov	x16, #0xfe50            // =65104
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	ldur	q30, [x29, #-0xa0]
-               	add	v31.8h, v31.8h, v30.8h
-               	mov	x16, #0xfe00            // =65024
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfe00            // =65024
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[0]
-<L82>:
-               	bl	 <L82>
-               	mov	x16, #0xfe00            // =65024
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[1]
-<L83>:
-               	bl	 <L83>
-               	mov	x16, #0xfe00            // =65024
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[2]
-<L84>:
-               	bl	 <L84>
-               	mov	x16, #0xfe00            // =65024
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[3]
-<L85>:
-               	bl	 <L85>
                	add	x20, x20, #0x1
                	mov	x19, x0
-               	mov	x16, #0xfe00            // =65024
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
                	mov	x16, #0xfe50            // =65104
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfe20            // =65056
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov	x16, #0xfe40            // =65088
+               	mov	x16, #0xfea0            // =65184
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xfe10            // =65040
+               	mov	x16, #0xfe70            // =65136
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov	x16, #0xfe30            // =65072
+               	mov	x16, #0xfe90            // =65168
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	q31, [x29, x16]
+               	mov	x16, #0xfe60            // =65120
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	mov	x16, #0xfe80            // =65152
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
                	cmp	x20, #0x6
-               	b.lo	 <L69>
-<L86>:
+               	b.lo	 <L48>
+<L65>:
                	sub	x20, x29, #0x50
                	str	xzr, [x20]
                	str	xzr, [x20, #0x8]
@@ -890,13 +672,13 @@ Disassembly of section .text:
                	str	xzr, [x20, #0x20]
                	str	xzr, [x20, #0x28]
                	add	x0, x20, #0x0
-               	mov	x16, #0xfe50            // =65104
+               	mov	x16, #0xfea0            // =65184
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	d31, [x29, x16]
                	str	d31, [x0]
-               	mov	x16, #0xfe50            // =65104
+               	mov	x16, #0xfea0            // =65184
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -905,7 +687,7 @@ Disassembly of section .text:
                	add	v0.8h, v31.8h, v30.8h
                	add	x0, x20, #0x8
                	str	d0, [x0]
-               	mov	x16, #0xfe50            // =65104
+               	mov	x16, #0xfea0            // =65184
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -915,20 +697,20 @@ Disassembly of section .text:
                	add	x0, x20, #0x10
                	str	d0, [x0]
                	add	x0, x20, #0x18
-               	mov	x16, #0xfe40            // =65088
+               	mov	x16, #0xfe90            // =65168
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	d31, [x29, x16]
                	str	d31, [x0]
                	add	x0, x20, #0x20
-               	mov	x16, #0xfe30            // =65072
+               	mov	x16, #0xfe80            // =65152
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	d31, [x29, x16]
                	str	d31, [x0]
-               	mov	x16, #0xfe50            // =65104
+               	mov	x16, #0xfea0            // =65184
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -939,54 +721,54 @@ Disassembly of section .text:
                	str	d0, [x0]
                	mov	x21, #0x0               // =0
                	cmp	x21, #0x6
-               	b.lo	 <L87>
-               	b	 <L92>
-<L87>:
+               	b.lo	 <L66>
+               	b	 <L71>
+<L66>:
                	add	x0, x20, x21, lsl #3
                	ldr	d31, [x0]
-               	mov	x16, #0xfdf0            // =65008
+               	mov	x16, #0xfe40            // =65088
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	d31, [x29, x16]
-               	mov	x16, #0xfdf0            // =65008
+               	mov	x16, #0xfe40            // =65088
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	umov	w1, v31.h[0]
                	mov	x0, x19
-<L88>:
-               	bl	 <L88>
-               	mov	x16, #0xfdf0            // =65008
+<L67>:
+               	bl	 <L67>
+               	mov	x16, #0xfe40            // =65088
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	umov	w1, v31.h[1]
-<L89>:
-               	bl	 <L89>
-               	mov	x16, #0xfdf0            // =65008
+<L68>:
+               	bl	 <L68>
+               	mov	x16, #0xfe40            // =65088
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	umov	w1, v31.h[2]
-<L90>:
-               	bl	 <L90>
-               	mov	x16, #0xfdf0            // =65008
+<L69>:
+               	bl	 <L69>
+               	mov	x16, #0xfe40            // =65088
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	umov	w1, v31.h[3]
-<L91>:
-               	bl	 <L91>
+<L70>:
+               	bl	 <L70>
                	add	x21, x21, #0x1
                	mov	x19, x0
                	cmp	x21, #0x6
-               	b.lo	 <L87>
-<L92>:
+               	b.lo	 <L66>
+<L71>:
                	sub	x21, x29, #0x5c
                	str	xzr, [x21]
                	str	wzr, [x21, #0x8]
@@ -1002,54 +784,57 @@ Disassembly of section .text:
                	strb	w17, [x1]
                	ldrb	w1, [x0]
                	mov	x0, x19
-<L93>:
-               	bl	 <L93>
+<L72>:
+               	bl	 <L72>
                	ldr	d31, [x20]
-               	mov	x16, #0xfde0            // =64992
+               	mov	x16, #0xfe30            // =65072
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	d31, [x29, x16]
-               	mov	x16, #0xfde0            // =64992
+               	mov	x16, #0xfe30            // =65072
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	umov	w1, v31.h[0]
-<L94>:
-               	bl	 <L94>
-               	mov	x16, #0xfde0            // =64992
+<L73>:
+               	bl	 <L73>
+               	mov	x16, #0xfe30            // =65072
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	umov	w1, v31.h[1]
-<L95>:
-               	bl	 <L95>
-               	mov	x16, #0xfde0            // =64992
+<L74>:
+               	bl	 <L74>
+               	mov	x16, #0xfe30            // =65072
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	umov	w1, v31.h[2]
-<L96>:
-               	bl	 <L96>
-               	mov	x16, #0xfde0            // =64992
+<L75>:
+               	bl	 <L75>
+               	mov	x16, #0xfe30            // =65072
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	umov	w1, v31.h[3]
-<L97>:
-               	bl	 <L97>
+<L76>:
+               	bl	 <L76>
                	add	x1, x21, #0xa
                	ldrb	w2, [x1]
                	mov	x1, x2
-<L98>:
-               	bl	 <L98>
-               	sub	x16, x29, #0x230
-               	ldp	x19, x20, [x16]
-               	ldur	x21, [x16, #-0x8]
+<L77>:
+               	bl	 <L77>
+               	ldp	x19, x20, [x29, #-0x1e0]
+               	mov	x16, #0xfe18            // =65048
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x21, [x29, x16]
                	mov	sp, x29
                	ldp	x29, x30, [sp], #0x10
                	ret

--- a/test/golden/aarch64-linux/vec/vec_i16x8.dis
+++ b/test/golden/aarch64-linux/vec/vec_i16x8.dis
@@ -70,8 +70,8 @@ Disassembly of section .text:
 <corpus.cases.vec.vec_i16x8.checksum>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0x290
-               	sub	x16, x29, #0x280
+               	sub	sp, sp, #0x240
+               	sub	x16, x29, #0x230
                	stp	x19, x20, [x16]
                	stur	x21, [x16, #-0x8]
                	mov	x19, x0
@@ -802,7 +802,12 @@ Disassembly of section .text:
                	bl	 <L80>
                	ldur	q31, [x29, #-0xd0]
                	ldur	q30, [x29, #-0xf0]
-               	sub	v31.8h, v31.8h, v30.8h
+               	sub	v0.8h, v31.8h, v30.8h
+<L81>:
+               	bl	 <L81>
+               	ldur	q31, [x29, #-0xe0]
+               	ldur	q30, [x29, #-0xf0]
+               	and	v31.16b, v31.16b, v30.16b
                	mov	x16, #0xfe80            // =65152
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
@@ -812,48 +817,35 @@ Disassembly of section .text:
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[0]
-<L81>:
-               	bl	 <L81>
-               	mov	x16, #0xfe80            // =65152
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[1]
+               	ldr	q0, [x29, x16]
 <L82>:
                	bl	 <L82>
-               	mov	x16, #0xfe80            // =65152
+               	ldur	q31, [x29, #-0xe0]
+               	ldur	q30, [x29, #-0xf0]
+               	orr	v31.16b, v31.16b, v30.16b
+               	mov	x16, #0xfe70            // =65136
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[2]
+               	str	q31, [x29, x16]
+               	mov	x16, #0xfe70            // =65136
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q0, [x29, x16]
 <L83>:
                	bl	 <L83>
-               	mov	x16, #0xfe80            // =65152
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[3]
+               	ldur	q31, [x29, #-0xe0]
+               	ldur	q30, [x29, #-0xf0]
+               	eor	v0.16b, v31.16b, v30.16b
 <L84>:
                	bl	 <L84>
-               	mov	x16, #0xfe80            // =65152
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[4]
+               	ldur	q31, [x29, #-0xe0]
+               	mvn	v0.16b, v31.16b
 <L85>:
                	bl	 <L85>
-               	mov	x16, #0xfe80            // =65152
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[5]
+               	ldur	q31, [x29, #-0xf0]
+               	mvn	v0.16b, v31.16b
 <L86>:
                	bl	 <L86>
                	mov	x16, #0xfe80            // =65152
@@ -861,34 +853,60 @@ Disassembly of section .text:
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[6]
-<L87>:
-               	bl	 <L87>
-               	mov	x16, #0xfe80            // =65152
+               	mov	x16, #0xfe70            // =65136
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[7]
-<L88>:
-               	bl	 <L88>
+               	ldr	q30, [x29, x16]
+               	eor	v0.16b, v31.16b, v30.16b
+<L87>:
+               	bl	 <L87>
+               	mov	x19, x0
                	ldur	q31, [x29, #-0xe0]
-               	ldur	q30, [x29, #-0xf0]
-               	and	v31.16b, v31.16b, v30.16b
-               	mov	x16, #0xfe70            // =65136
+               	mov	x16, #0xfe50            // =65104
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xfe70            // =65136
+               	ldur	q31, [x29, #-0xd0]
+               	mov	x16, #0xfe40            // =65088
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	q31, [x29, x16]
+               	ldur	q31, [x29, #-0xd0]
+               	mov	x16, #0xfe30            // =65072
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	q31, [x29, x16]
+               	mov	x20, #0x0               // =0
+               	cmp	x20, #0x6
+               	b.lo	 <L88>
+               	b	 <L121>
+<L88>:
+               	mov	x16, #0xfe50            // =65104
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	ldur	q30, [x29, #-0xc0]
+               	mul	v31.8h, v31.8h, v30.8h
+               	mov	x16, #0xfe60            // =65120
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	q31, [x29, x16]
+               	mov	x16, #0xfe60            // =65120
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	umov	w1, v31.h[0]
+               	mov	x0, x19
 <L89>:
                	bl	 <L89>
-               	mov	x16, #0xfe70            // =65136
+               	mov	x16, #0xfe60            // =65120
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -896,7 +914,7 @@ Disassembly of section .text:
                	umov	w1, v31.h[1]
 <L90>:
                	bl	 <L90>
-               	mov	x16, #0xfe70            // =65136
+               	mov	x16, #0xfe60            // =65120
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -904,7 +922,7 @@ Disassembly of section .text:
                	umov	w1, v31.h[2]
 <L91>:
                	bl	 <L91>
-               	mov	x16, #0xfe70            // =65136
+               	mov	x16, #0xfe60            // =65120
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -912,7 +930,7 @@ Disassembly of section .text:
                	umov	w1, v31.h[3]
 <L92>:
                	bl	 <L92>
-               	mov	x16, #0xfe70            // =65136
+               	mov	x16, #0xfe60            // =65120
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -920,7 +938,7 @@ Disassembly of section .text:
                	umov	w1, v31.h[4]
 <L93>:
                	bl	 <L93>
-               	mov	x16, #0xfe70            // =65136
+               	mov	x16, #0xfe60            // =65120
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -928,7 +946,7 @@ Disassembly of section .text:
                	umov	w1, v31.h[5]
 <L94>:
                	bl	 <L94>
-               	mov	x16, #0xfe70            // =65136
+               	mov	x16, #0xfe60            // =65120
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -936,7 +954,7 @@ Disassembly of section .text:
                	umov	w1, v31.h[6]
 <L95>:
                	bl	 <L95>
-               	mov	x16, #0xfe70            // =65136
+               	mov	x16, #0xfe60            // =65120
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -944,15 +962,23 @@ Disassembly of section .text:
                	umov	w1, v31.h[7]
 <L96>:
                	bl	 <L96>
-               	ldur	q31, [x29, #-0xe0]
-               	ldur	q30, [x29, #-0xf0]
-               	orr	v31.16b, v31.16b, v30.16b
+               	mov	x16, #0xfe40            // =65088
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
                	mov	x16, #0xfe60            // =65120
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
+               	ldr	q30, [x29, x16]
+               	eor	v31.16b, v31.16b, v30.16b
+               	mov	x16, #0xfe20            // =65056
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xfe60            // =65120
+               	mov	x16, #0xfe20            // =65056
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -960,7 +986,7 @@ Disassembly of section .text:
                	umov	w1, v31.h[0]
 <L97>:
                	bl	 <L97>
-               	mov	x16, #0xfe60            // =65120
+               	mov	x16, #0xfe20            // =65056
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -968,7 +994,7 @@ Disassembly of section .text:
                	umov	w1, v31.h[1]
 <L98>:
                	bl	 <L98>
-               	mov	x16, #0xfe60            // =65120
+               	mov	x16, #0xfe20            // =65056
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -976,7 +1002,7 @@ Disassembly of section .text:
                	umov	w1, v31.h[2]
 <L99>:
                	bl	 <L99>
-               	mov	x16, #0xfe60            // =65120
+               	mov	x16, #0xfe20            // =65056
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -984,7 +1010,7 @@ Disassembly of section .text:
                	umov	w1, v31.h[3]
 <L100>:
                	bl	 <L100>
-               	mov	x16, #0xfe60            // =65120
+               	mov	x16, #0xfe20            // =65056
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -992,7 +1018,7 @@ Disassembly of section .text:
                	umov	w1, v31.h[4]
 <L101>:
                	bl	 <L101>
-               	mov	x16, #0xfe60            // =65120
+               	mov	x16, #0xfe20            // =65056
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1000,7 +1026,7 @@ Disassembly of section .text:
                	umov	w1, v31.h[5]
 <L102>:
                	bl	 <L102>
-               	mov	x16, #0xfe60            // =65120
+               	mov	x16, #0xfe20            // =65056
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1008,7 +1034,7 @@ Disassembly of section .text:
                	umov	w1, v31.h[6]
 <L103>:
                	bl	 <L103>
-               	mov	x16, #0xfe60            // =65120
+               	mov	x16, #0xfe20            // =65056
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1016,15 +1042,23 @@ Disassembly of section .text:
                	umov	w1, v31.h[7]
 <L104>:
                	bl	 <L104>
-               	ldur	q31, [x29, #-0xe0]
-               	ldur	q30, [x29, #-0xf0]
-               	eor	v31.16b, v31.16b, v30.16b
+               	mov	x16, #0xfe30            // =65072
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
                	mov	x16, #0xfe50            // =65104
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
+               	ldr	q30, [x29, x16]
+               	add	v31.8h, v31.8h, v30.8h
+               	mov	x16, #0xfe10            // =65040
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xfe50            // =65104
+               	mov	x16, #0xfe10            // =65040
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1032,7 +1066,7 @@ Disassembly of section .text:
                	umov	w1, v31.h[0]
 <L105>:
                	bl	 <L105>
-               	mov	x16, #0xfe50            // =65104
+               	mov	x16, #0xfe10            // =65040
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1040,7 +1074,7 @@ Disassembly of section .text:
                	umov	w1, v31.h[1]
 <L106>:
                	bl	 <L106>
-               	mov	x16, #0xfe50            // =65104
+               	mov	x16, #0xfe10            // =65040
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1048,7 +1082,7 @@ Disassembly of section .text:
                	umov	w1, v31.h[2]
 <L107>:
                	bl	 <L107>
-               	mov	x16, #0xfe50            // =65104
+               	mov	x16, #0xfe10            // =65040
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1056,7 +1090,7 @@ Disassembly of section .text:
                	umov	w1, v31.h[3]
 <L108>:
                	bl	 <L108>
-               	mov	x16, #0xfe50            // =65104
+               	mov	x16, #0xfe10            // =65040
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1064,7 +1098,7 @@ Disassembly of section .text:
                	umov	w1, v31.h[4]
 <L109>:
                	bl	 <L109>
-               	mov	x16, #0xfe50            // =65104
+               	mov	x16, #0xfe10            // =65040
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1072,7 +1106,7 @@ Disassembly of section .text:
                	umov	w1, v31.h[5]
 <L110>:
                	bl	 <L110>
-               	mov	x16, #0xfe50            // =65104
+               	mov	x16, #0xfe10            // =65040
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1080,7 +1114,7 @@ Disassembly of section .text:
                	umov	w1, v31.h[6]
 <L111>:
                	bl	 <L111>
-               	mov	x16, #0xfe50            // =65104
+               	mov	x16, #0xfe10            // =65040
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1088,14 +1122,19 @@ Disassembly of section .text:
                	umov	w1, v31.h[7]
 <L112>:
                	bl	 <L112>
-               	ldur	q31, [x29, #-0xe0]
-               	mvn	v31.16b, v31.16b
-               	mov	x16, #0xfe40            // =65088
+               	mov	x16, #0xfe50            // =65104
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	ldur	q30, [x29, #-0xf0]
+               	add	v31.8h, v31.8h, v30.8h
+               	mov	x16, #0xfe00            // =65024
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xfe40            // =65088
+               	mov	x16, #0xfe00            // =65024
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1103,7 +1142,7 @@ Disassembly of section .text:
                	umov	w1, v31.h[0]
 <L113>:
                	bl	 <L113>
-               	mov	x16, #0xfe40            // =65088
+               	mov	x16, #0xfe00            // =65024
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1111,7 +1150,7 @@ Disassembly of section .text:
                	umov	w1, v31.h[1]
 <L114>:
                	bl	 <L114>
-               	mov	x16, #0xfe40            // =65088
+               	mov	x16, #0xfe00            // =65024
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1119,7 +1158,7 @@ Disassembly of section .text:
                	umov	w1, v31.h[2]
 <L115>:
                	bl	 <L115>
-               	mov	x16, #0xfe40            // =65088
+               	mov	x16, #0xfe00            // =65024
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1127,7 +1166,7 @@ Disassembly of section .text:
                	umov	w1, v31.h[3]
 <L116>:
                	bl	 <L116>
-               	mov	x16, #0xfe40            // =65088
+               	mov	x16, #0xfe00            // =65024
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1135,7 +1174,7 @@ Disassembly of section .text:
                	umov	w1, v31.h[4]
 <L117>:
                	bl	 <L117>
-               	mov	x16, #0xfe40            // =65088
+               	mov	x16, #0xfe00            // =65024
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1143,7 +1182,7 @@ Disassembly of section .text:
                	umov	w1, v31.h[5]
 <L118>:
                	bl	 <L118>
-               	mov	x16, #0xfe40            // =65088
+               	mov	x16, #0xfe00            // =65024
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1151,7 +1190,7 @@ Disassembly of section .text:
                	umov	w1, v31.h[6]
 <L119>:
                	bl	 <L119>
-               	mov	x16, #0xfe40            // =65088
+               	mov	x16, #0xfe00            // =65024
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1159,525 +1198,41 @@ Disassembly of section .text:
                	umov	w1, v31.h[7]
 <L120>:
                	bl	 <L120>
-               	ldur	q31, [x29, #-0xf0]
-               	mvn	v31.16b, v31.16b
-               	mov	x16, #0xfe30            // =65072
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfe30            // =65072
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[0]
-<L121>:
-               	bl	 <L121>
-               	mov	x16, #0xfe30            // =65072
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[1]
-<L122>:
-               	bl	 <L122>
-               	mov	x16, #0xfe30            // =65072
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[2]
-<L123>:
-               	bl	 <L123>
-               	mov	x16, #0xfe30            // =65072
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[3]
-<L124>:
-               	bl	 <L124>
-               	mov	x16, #0xfe30            // =65072
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[4]
-<L125>:
-               	bl	 <L125>
-               	mov	x16, #0xfe30            // =65072
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[5]
-<L126>:
-               	bl	 <L126>
-               	mov	x16, #0xfe30            // =65072
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[6]
-<L127>:
-               	bl	 <L127>
-               	mov	x16, #0xfe30            // =65072
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[7]
-<L128>:
-               	bl	 <L128>
-               	ldur	q31, [x29, #-0xe0]
-               	ldur	q30, [x29, #-0xf0]
-               	and	v0.16b, v31.16b, v30.16b
-               	ldur	q31, [x29, #-0xe0]
-               	ldur	q30, [x29, #-0xf0]
-               	orr	v1.16b, v31.16b, v30.16b
-               	eor	v31.16b, v0.16b, v1.16b
-               	mov	x16, #0xfe20            // =65056
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfe20            // =65056
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[0]
-<L129>:
-               	bl	 <L129>
-               	mov	x16, #0xfe20            // =65056
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[1]
-<L130>:
-               	bl	 <L130>
-               	mov	x16, #0xfe20            // =65056
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[2]
-<L131>:
-               	bl	 <L131>
-               	mov	x16, #0xfe20            // =65056
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[3]
-<L132>:
-               	bl	 <L132>
-               	mov	x16, #0xfe20            // =65056
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[4]
-<L133>:
-               	bl	 <L133>
-               	mov	x16, #0xfe20            // =65056
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[5]
-<L134>:
-               	bl	 <L134>
-               	mov	x16, #0xfe20            // =65056
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[6]
-<L135>:
-               	bl	 <L135>
-               	mov	x16, #0xfe20            // =65056
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[7]
-<L136>:
-               	bl	 <L136>
-               	mov	x19, x0
-               	ldur	q31, [x29, #-0xe0]
-               	mov	x16, #0xfe00            // =65024
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	ldur	q31, [x29, #-0xd0]
-               	mov	x16, #0xfdf0            // =65008
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	ldur	q31, [x29, #-0xd0]
-               	mov	x16, #0xfde0            // =64992
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x20, #0x0               // =0
-               	cmp	x20, #0x6
-               	b.lo	 <L137>
-               	b	 <L170>
-<L137>:
-               	mov	x16, #0xfe00            // =65024
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	ldur	q30, [x29, #-0xc0]
-               	mul	v31.8h, v31.8h, v30.8h
-               	mov	x16, #0xfe10            // =65040
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfe10            // =65040
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[0]
-               	mov	x0, x19
-<L138>:
-               	bl	 <L138>
-               	mov	x16, #0xfe10            // =65040
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[1]
-<L139>:
-               	bl	 <L139>
-               	mov	x16, #0xfe10            // =65040
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[2]
-<L140>:
-               	bl	 <L140>
-               	mov	x16, #0xfe10            // =65040
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[3]
-<L141>:
-               	bl	 <L141>
-               	mov	x16, #0xfe10            // =65040
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[4]
-<L142>:
-               	bl	 <L142>
-               	mov	x16, #0xfe10            // =65040
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[5]
-<L143>:
-               	bl	 <L143>
-               	mov	x16, #0xfe10            // =65040
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[6]
-<L144>:
-               	bl	 <L144>
-               	mov	x16, #0xfe10            // =65040
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[7]
-<L145>:
-               	bl	 <L145>
-               	mov	x16, #0xfdf0            // =65008
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x16, #0xfe10            // =65040
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q30, [x29, x16]
-               	eor	v31.16b, v31.16b, v30.16b
-               	mov	x16, #0xfdd0            // =64976
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfdd0            // =64976
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[0]
-<L146>:
-               	bl	 <L146>
-               	mov	x16, #0xfdd0            // =64976
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[1]
-<L147>:
-               	bl	 <L147>
-               	mov	x16, #0xfdd0            // =64976
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[2]
-<L148>:
-               	bl	 <L148>
-               	mov	x16, #0xfdd0            // =64976
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[3]
-<L149>:
-               	bl	 <L149>
-               	mov	x16, #0xfdd0            // =64976
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[4]
-<L150>:
-               	bl	 <L150>
-               	mov	x16, #0xfdd0            // =64976
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[5]
-<L151>:
-               	bl	 <L151>
-               	mov	x16, #0xfdd0            // =64976
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[6]
-<L152>:
-               	bl	 <L152>
-               	mov	x16, #0xfdd0            // =64976
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[7]
-<L153>:
-               	bl	 <L153>
-               	mov	x16, #0xfde0            // =64992
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x16, #0xfe00            // =65024
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q30, [x29, x16]
-               	add	v31.8h, v31.8h, v30.8h
-               	mov	x16, #0xfdc0            // =64960
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfdc0            // =64960
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[0]
-<L154>:
-               	bl	 <L154>
-               	mov	x16, #0xfdc0            // =64960
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[1]
-<L155>:
-               	bl	 <L155>
-               	mov	x16, #0xfdc0            // =64960
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[2]
-<L156>:
-               	bl	 <L156>
-               	mov	x16, #0xfdc0            // =64960
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[3]
-<L157>:
-               	bl	 <L157>
-               	mov	x16, #0xfdc0            // =64960
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[4]
-<L158>:
-               	bl	 <L158>
-               	mov	x16, #0xfdc0            // =64960
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[5]
-<L159>:
-               	bl	 <L159>
-               	mov	x16, #0xfdc0            // =64960
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[6]
-<L160>:
-               	bl	 <L160>
-               	mov	x16, #0xfdc0            // =64960
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[7]
-<L161>:
-               	bl	 <L161>
-               	mov	x16, #0xfe00            // =65024
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	ldur	q30, [x29, #-0xf0]
-               	add	v31.8h, v31.8h, v30.8h
-               	mov	x16, #0xfdb0            // =64944
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfdb0            // =64944
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[0]
-<L162>:
-               	bl	 <L162>
-               	mov	x16, #0xfdb0            // =64944
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[1]
-<L163>:
-               	bl	 <L163>
-               	mov	x16, #0xfdb0            // =64944
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[2]
-<L164>:
-               	bl	 <L164>
-               	mov	x16, #0xfdb0            // =64944
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[3]
-<L165>:
-               	bl	 <L165>
-               	mov	x16, #0xfdb0            // =64944
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[4]
-<L166>:
-               	bl	 <L166>
-               	mov	x16, #0xfdb0            // =64944
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[5]
-<L167>:
-               	bl	 <L167>
-               	mov	x16, #0xfdb0            // =64944
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[6]
-<L168>:
-               	bl	 <L168>
-               	mov	x16, #0xfdb0            // =64944
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[7]
-<L169>:
-               	bl	 <L169>
                	add	x20, x20, #0x1
                	mov	x19, x0
-               	mov	x16, #0xfdb0            // =64944
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
                	mov	x16, #0xfe00            // =65024
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfdd0            // =64976
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov	x16, #0xfdf0            // =65008
+               	mov	x16, #0xfe50            // =65104
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xfdc0            // =64960
+               	mov	x16, #0xfe20            // =65056
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov	x16, #0xfde0            // =64992
+               	mov	x16, #0xfe40            // =65088
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	q31, [x29, x16]
+               	mov	x16, #0xfe10            // =65040
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	mov	x16, #0xfe30            // =65072
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
                	cmp	x20, #0x6
-               	b.lo	 <L137>
-<L170>:
+               	b.lo	 <L88>
+<L121>:
                	sub	x20, x29, #0x80
                	str	xzr, [x20]
                	str	xzr, [x20, #0x8]
@@ -1688,13 +1243,13 @@ Disassembly of section .text:
                	str	xzr, [x20, #0x30]
                	str	xzr, [x20, #0x38]
                	add	x0, x20, #0x0
-               	mov	x16, #0xfe00            // =65024
+               	mov	x16, #0xfe50            // =65104
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	str	q31, [x0]
-               	mov	x16, #0xfe00            // =65024
+               	mov	x16, #0xfe50            // =65104
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1703,7 +1258,7 @@ Disassembly of section .text:
                	add	v0.8h, v31.8h, v30.8h
                	add	x0, x20, #0x10
                	str	q0, [x0]
-               	mov	x16, #0xfe00            // =65024
+               	mov	x16, #0xfe50            // =65104
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1713,7 +1268,7 @@ Disassembly of section .text:
                	add	x0, x20, #0x20
                	str	q0, [x0]
                	add	x0, x20, #0x30
-               	mov	x16, #0xfdf0            // =65008
+               	mov	x16, #0xfe40            // =65088
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1721,88 +1276,88 @@ Disassembly of section .text:
                	str	q31, [x0]
                	mov	x21, #0x0               // =0
                	cmp	x21, #0x4
-               	b.lo	 <L171>
-               	b	 <L180>
-<L171>:
+               	b.lo	 <L122>
+               	b	 <L131>
+<L122>:
                	mov	x16, #0x10              // =16
                	mul	x0, x21, x16
                	add	x1, x20, x0
                	ldr	q31, [x1]
-               	mov	x16, #0xfda0            // =64928
+               	mov	x16, #0xfdf0            // =65008
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xfda0            // =64928
+               	mov	x16, #0xfdf0            // =65008
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	umov	w1, v31.h[0]
                	mov	x0, x19
-<L172>:
-               	bl	 <L172>
-               	mov	x16, #0xfda0            // =64928
+<L123>:
+               	bl	 <L123>
+               	mov	x16, #0xfdf0            // =65008
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	umov	w1, v31.h[1]
-<L173>:
-               	bl	 <L173>
-               	mov	x16, #0xfda0            // =64928
+<L124>:
+               	bl	 <L124>
+               	mov	x16, #0xfdf0            // =65008
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	umov	w1, v31.h[2]
-<L174>:
-               	bl	 <L174>
-               	mov	x16, #0xfda0            // =64928
+<L125>:
+               	bl	 <L125>
+               	mov	x16, #0xfdf0            // =65008
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	umov	w1, v31.h[3]
-<L175>:
-               	bl	 <L175>
-               	mov	x16, #0xfda0            // =64928
+<L126>:
+               	bl	 <L126>
+               	mov	x16, #0xfdf0            // =65008
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	umov	w1, v31.h[4]
-<L176>:
-               	bl	 <L176>
-               	mov	x16, #0xfda0            // =64928
+<L127>:
+               	bl	 <L127>
+               	mov	x16, #0xfdf0            // =65008
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	umov	w1, v31.h[5]
-<L177>:
-               	bl	 <L177>
-               	mov	x16, #0xfda0            // =64928
+<L128>:
+               	bl	 <L128>
+               	mov	x16, #0xfdf0            // =65008
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	umov	w1, v31.h[6]
-<L178>:
-               	bl	 <L178>
-               	mov	x16, #0xfda0            // =64928
+<L129>:
+               	bl	 <L129>
+               	mov	x16, #0xfdf0            // =65008
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	umov	w1, v31.h[7]
-<L179>:
-               	bl	 <L179>
+<L130>:
+               	bl	 <L130>
                	add	x21, x21, #0x1
                	mov	x19, x0
                	cmp	x21, #0x4
-               	b.lo	 <L171>
-<L180>:
+               	b.lo	 <L122>
+<L131>:
                	sub	x21, x29, #0xb0
                	str	xzr, [x21]
                	str	xzr, [x21, #0x8]
@@ -1824,84 +1379,84 @@ Disassembly of section .text:
                	str	w17, [x1]
                	ldr	w1, [x0]
                	mov	x0, x19
-<L181>:
-               	bl	 <L181>
+<L132>:
+               	bl	 <L132>
                	ldr	q31, [x20]
-               	mov	x16, #0xfd90            // =64912
+               	mov	x16, #0xfde0            // =64992
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xfd90            // =64912
+               	mov	x16, #0xfde0            // =64992
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	umov	w1, v31.h[0]
-<L182>:
-               	bl	 <L182>
-               	mov	x16, #0xfd90            // =64912
+<L133>:
+               	bl	 <L133>
+               	mov	x16, #0xfde0            // =64992
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	umov	w1, v31.h[1]
-<L183>:
-               	bl	 <L183>
-               	mov	x16, #0xfd90            // =64912
+<L134>:
+               	bl	 <L134>
+               	mov	x16, #0xfde0            // =64992
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	umov	w1, v31.h[2]
-<L184>:
-               	bl	 <L184>
-               	mov	x16, #0xfd90            // =64912
+<L135>:
+               	bl	 <L135>
+               	mov	x16, #0xfde0            // =64992
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	umov	w1, v31.h[3]
-<L185>:
-               	bl	 <L185>
-               	mov	x16, #0xfd90            // =64912
+<L136>:
+               	bl	 <L136>
+               	mov	x16, #0xfde0            // =64992
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	umov	w1, v31.h[4]
-<L186>:
-               	bl	 <L186>
-               	mov	x16, #0xfd90            // =64912
+<L137>:
+               	bl	 <L137>
+               	mov	x16, #0xfde0            // =64992
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	umov	w1, v31.h[5]
-<L187>:
-               	bl	 <L187>
-               	mov	x16, #0xfd90            // =64912
+<L138>:
+               	bl	 <L138>
+               	mov	x16, #0xfde0            // =64992
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	umov	w1, v31.h[6]
-<L188>:
-               	bl	 <L188>
-               	mov	x16, #0xfd90            // =64912
+<L139>:
+               	bl	 <L139>
+               	mov	x16, #0xfde0            // =64992
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	umov	w1, v31.h[7]
-<L189>:
-               	bl	 <L189>
+<L140>:
+               	bl	 <L140>
                	add	x1, x21, #0x20
                	ldr	w2, [x1]
                	mov	w1, w2
-<L190>:
-               	bl	 <L190>
-               	sub	x16, x29, #0x280
+<L141>:
+               	bl	 <L141>
+               	sub	x16, x29, #0x230
                	ldp	x19, x20, [x16]
                	ldur	x21, [x16, #-0x8]
                	mov	sp, x29

--- a/test/golden/aarch64-linux/vec/vec_i32x4.dis
+++ b/test/golden/aarch64-linux/vec/vec_i32x4.dis
@@ -42,8 +42,8 @@ Disassembly of section .text:
 <corpus.cases.vec.vec_i32x4.checksum>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0x280
-               	sub	x16, x29, #0x270
+               	sub	sp, sp, #0x230
+               	sub	x16, x29, #0x220
                	stp	x19, x20, [x16]
                	stur	x21, [x16, #-0x8]
                	mov	x19, x0
@@ -462,87 +462,90 @@ Disassembly of section .text:
                	bl	 <L40>
                	ldur	q31, [x29, #-0xd0]
                	ldur	q30, [x29, #-0xf0]
-               	sub	v31.4s, v31.4s, v30.4s
-               	mov	x16, #0xfe80            // =65152
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfe80            // =65152
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[0]
+               	sub	v0.4s, v31.4s, v30.4s
 <L41>:
                	bl	 <L41>
-               	mov	x16, #0xfe80            // =65152
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[1]
-<L42>:
-               	bl	 <L42>
-               	mov	x16, #0xfe80            // =65152
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[2]
-<L43>:
-               	bl	 <L43>
-               	mov	x16, #0xfe80            // =65152
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[3]
-<L44>:
-               	bl	 <L44>
                	ldur	q31, [x29, #-0xe0]
                	ldur	q30, [x29, #-0xf0]
                	and	v31.16b, v31.16b, v30.16b
-               	mov	x16, #0xfe70            // =65136
+               	mov	x16, #0xfe80            // =65152
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xfe70            // =65136
+               	mov	x16, #0xfe80            // =65152
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[0]
-<L45>:
-               	bl	 <L45>
-               	mov	x16, #0xfe70            // =65136
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[1]
-<L46>:
-               	bl	 <L46>
-               	mov	x16, #0xfe70            // =65136
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[2]
-<L47>:
-               	bl	 <L47>
-               	mov	x16, #0xfe70            // =65136
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[3]
-<L48>:
-               	bl	 <L48>
+               	ldr	q0, [x29, x16]
+<L42>:
+               	bl	 <L42>
                	ldur	q31, [x29, #-0xe0]
                	ldur	q30, [x29, #-0xf0]
                	orr	v31.16b, v31.16b, v30.16b
+               	mov	x16, #0xfe70            // =65136
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	q31, [x29, x16]
+               	mov	x16, #0xfe70            // =65136
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q0, [x29, x16]
+<L43>:
+               	bl	 <L43>
+               	ldur	q31, [x29, #-0xe0]
+               	ldur	q30, [x29, #-0xf0]
+               	eor	v0.16b, v31.16b, v30.16b
+<L44>:
+               	bl	 <L44>
+               	ldur	q31, [x29, #-0xe0]
+               	mvn	v0.16b, v31.16b
+<L45>:
+               	bl	 <L45>
+               	ldur	q31, [x29, #-0xf0]
+               	mvn	v0.16b, v31.16b
+<L46>:
+               	bl	 <L46>
+               	mov	x16, #0xfe80            // =65152
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	mov	x16, #0xfe70            // =65136
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q30, [x29, x16]
+               	eor	v0.16b, v31.16b, v30.16b
+<L47>:
+               	bl	 <L47>
+               	mov	x19, x0
+               	ldur	q31, [x29, #-0xe0]
+               	mov	x16, #0xfe50            // =65104
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	q31, [x29, x16]
+               	ldur	q31, [x29, #-0xd0]
+               	mov	x16, #0xfe40            // =65088
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	q31, [x29, x16]
+               	mov	x20, #0x0               // =0
+               	cmp	x20, #0x6
+               	b.lo	 <L48>
+               	b	 <L65>
+<L48>:
+               	mov	x16, #0xfe50            // =65104
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	ldur	q30, [x29, #-0xc0]
+               	mul	v31.4s, v31.4s, v30.4s
                	mov	x16, #0xfe60            // =65120
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
@@ -554,6 +557,7 @@ Disassembly of section .text:
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	mov	w1, v31.s[0]
+               	mov	x0, x19
 <L49>:
                	bl	 <L49>
                	mov	x16, #0xfe60            // =65120
@@ -580,15 +584,23 @@ Disassembly of section .text:
                	mov	w1, v31.s[3]
 <L52>:
                	bl	 <L52>
-               	ldur	q31, [x29, #-0xe0]
-               	ldur	q30, [x29, #-0xf0]
-               	eor	v31.16b, v31.16b, v30.16b
-               	mov	x16, #0xfe50            // =65104
+               	mov	x16, #0xfe40            // =65088
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	mov	x16, #0xfe60            // =65120
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q30, [x29, x16]
+               	add	v31.4s, v31.4s, v30.4s
+               	mov	x16, #0xfe30            // =65072
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xfe50            // =65104
+               	mov	x16, #0xfe30            // =65072
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -596,7 +608,7 @@ Disassembly of section .text:
                	mov	w1, v31.s[0]
 <L53>:
                	bl	 <L53>
-               	mov	x16, #0xfe50            // =65104
+               	mov	x16, #0xfe30            // =65072
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -604,7 +616,7 @@ Disassembly of section .text:
                	mov	w1, v31.s[1]
 <L54>:
                	bl	 <L54>
-               	mov	x16, #0xfe50            // =65104
+               	mov	x16, #0xfe30            // =65072
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -612,7 +624,7 @@ Disassembly of section .text:
                	mov	w1, v31.s[2]
 <L55>:
                	bl	 <L55>
-               	mov	x16, #0xfe50            // =65104
+               	mov	x16, #0xfe30            // =65072
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -620,14 +632,19 @@ Disassembly of section .text:
                	mov	w1, v31.s[3]
 <L56>:
                	bl	 <L56>
-               	ldur	q31, [x29, #-0xe0]
-               	mvn	v31.16b, v31.16b
-               	mov	x16, #0xfe40            // =65088
+               	mov	x16, #0xfe30            // =65072
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	ldur	q30, [x29, #-0xf0]
+               	eor	v31.16b, v31.16b, v30.16b
+               	mov	x16, #0xfe20            // =65056
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xfe40            // =65088
+               	mov	x16, #0xfe20            // =65056
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -635,7 +652,7 @@ Disassembly of section .text:
                	mov	w1, v31.s[0]
 <L57>:
                	bl	 <L57>
-               	mov	x16, #0xfe40            // =65088
+               	mov	x16, #0xfe20            // =65056
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -643,7 +660,7 @@ Disassembly of section .text:
                	mov	w1, v31.s[1]
 <L58>:
                	bl	 <L58>
-               	mov	x16, #0xfe40            // =65088
+               	mov	x16, #0xfe20            // =65056
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -651,7 +668,7 @@ Disassembly of section .text:
                	mov	w1, v31.s[2]
 <L59>:
                	bl	 <L59>
-               	mov	x16, #0xfe40            // =65088
+               	mov	x16, #0xfe20            // =65056
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -659,14 +676,19 @@ Disassembly of section .text:
                	mov	w1, v31.s[3]
 <L60>:
                	bl	 <L60>
-               	ldur	q31, [x29, #-0xf0]
-               	mvn	v31.16b, v31.16b
-               	mov	x16, #0xfe30            // =65072
+               	mov	x16, #0xfe50            // =65104
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	ldur	q30, [x29, #-0xf0]
+               	add	v31.4s, v31.4s, v30.4s
+               	mov	x16, #0xfe10            // =65040
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xfe30            // =65072
+               	mov	x16, #0xfe10            // =65040
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -674,7 +696,7 @@ Disassembly of section .text:
                	mov	w1, v31.s[0]
 <L61>:
                	bl	 <L61>
-               	mov	x16, #0xfe30            // =65072
+               	mov	x16, #0xfe10            // =65040
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -682,7 +704,7 @@ Disassembly of section .text:
                	mov	w1, v31.s[1]
 <L62>:
                	bl	 <L62>
-               	mov	x16, #0xfe30            // =65072
+               	mov	x16, #0xfe10            // =65040
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -690,7 +712,7 @@ Disassembly of section .text:
                	mov	w1, v31.s[2]
 <L63>:
                	bl	 <L63>
-               	mov	x16, #0xfe30            // =65072
+               	mov	x16, #0xfe10            // =65040
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -698,274 +720,31 @@ Disassembly of section .text:
                	mov	w1, v31.s[3]
 <L64>:
                	bl	 <L64>
-               	ldur	q31, [x29, #-0xe0]
-               	ldur	q30, [x29, #-0xf0]
-               	and	v0.16b, v31.16b, v30.16b
-               	ldur	q31, [x29, #-0xe0]
-               	ldur	q30, [x29, #-0xf0]
-               	orr	v1.16b, v31.16b, v30.16b
-               	eor	v31.16b, v0.16b, v1.16b
-               	mov	x16, #0xfe20            // =65056
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfe20            // =65056
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[0]
-<L65>:
-               	bl	 <L65>
-               	mov	x16, #0xfe20            // =65056
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[1]
-<L66>:
-               	bl	 <L66>
-               	mov	x16, #0xfe20            // =65056
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[2]
-<L67>:
-               	bl	 <L67>
-               	mov	x16, #0xfe20            // =65056
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[3]
-<L68>:
-               	bl	 <L68>
-               	mov	x19, x0
-               	ldur	q31, [x29, #-0xe0]
-               	mov	x16, #0xfe00            // =65024
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	ldur	q31, [x29, #-0xd0]
-               	mov	x16, #0xfdf0            // =65008
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x20, #0x0               // =0
-               	cmp	x20, #0x6
-               	b.lo	 <L69>
-               	b	 <L86>
-<L69>:
-               	mov	x16, #0xfe00            // =65024
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	ldur	q30, [x29, #-0xc0]
-               	mul	v31.4s, v31.4s, v30.4s
-               	mov	x16, #0xfe10            // =65040
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfe10            // =65040
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[0]
-               	mov	x0, x19
-<L70>:
-               	bl	 <L70>
-               	mov	x16, #0xfe10            // =65040
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[1]
-<L71>:
-               	bl	 <L71>
-               	mov	x16, #0xfe10            // =65040
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[2]
-<L72>:
-               	bl	 <L72>
-               	mov	x16, #0xfe10            // =65040
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[3]
-<L73>:
-               	bl	 <L73>
-               	mov	x16, #0xfdf0            // =65008
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x16, #0xfe10            // =65040
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q30, [x29, x16]
-               	add	v31.4s, v31.4s, v30.4s
-               	mov	x16, #0xfde0            // =64992
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfde0            // =64992
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[0]
-<L74>:
-               	bl	 <L74>
-               	mov	x16, #0xfde0            // =64992
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[1]
-<L75>:
-               	bl	 <L75>
-               	mov	x16, #0xfde0            // =64992
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[2]
-<L76>:
-               	bl	 <L76>
-               	mov	x16, #0xfde0            // =64992
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[3]
-<L77>:
-               	bl	 <L77>
-               	mov	x16, #0xfde0            // =64992
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	ldur	q30, [x29, #-0xf0]
-               	eor	v31.16b, v31.16b, v30.16b
-               	mov	x16, #0xfdd0            // =64976
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfdd0            // =64976
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[0]
-<L78>:
-               	bl	 <L78>
-               	mov	x16, #0xfdd0            // =64976
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[1]
-<L79>:
-               	bl	 <L79>
-               	mov	x16, #0xfdd0            // =64976
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[2]
-<L80>:
-               	bl	 <L80>
-               	mov	x16, #0xfdd0            // =64976
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[3]
-<L81>:
-               	bl	 <L81>
-               	mov	x16, #0xfe00            // =65024
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	ldur	q30, [x29, #-0xf0]
-               	add	v31.4s, v31.4s, v30.4s
-               	mov	x16, #0xfdc0            // =64960
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfdc0            // =64960
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[0]
-<L82>:
-               	bl	 <L82>
-               	mov	x16, #0xfdc0            // =64960
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[1]
-<L83>:
-               	bl	 <L83>
-               	mov	x16, #0xfdc0            // =64960
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[2]
-<L84>:
-               	bl	 <L84>
-               	mov	x16, #0xfdc0            // =64960
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[3]
-<L85>:
-               	bl	 <L85>
                	add	x20, x20, #0x1
                	mov	x19, x0
-               	mov	x16, #0xfdc0            // =64960
+               	mov	x16, #0xfe10            // =65040
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov	x16, #0xfe00            // =65024
+               	mov	x16, #0xfe50            // =65104
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xfdd0            // =64976
+               	mov	x16, #0xfe20            // =65056
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov	x16, #0xfdf0            // =65008
+               	mov	x16, #0xfe40            // =65088
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
                	cmp	x20, #0x6
-               	b.lo	 <L69>
-<L86>:
+               	b.lo	 <L48>
+<L65>:
                	sub	x20, x29, #0x80
                	str	xzr, [x20]
                	str	xzr, [x20, #0x8]
@@ -976,13 +755,13 @@ Disassembly of section .text:
                	str	xzr, [x20, #0x30]
                	str	xzr, [x20, #0x38]
                	add	x0, x20, #0x0
-               	mov	x16, #0xfe00            // =65024
+               	mov	x16, #0xfe50            // =65104
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	str	q31, [x0]
-               	mov	x16, #0xfe00            // =65024
+               	mov	x16, #0xfe50            // =65104
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -991,7 +770,7 @@ Disassembly of section .text:
                	add	v0.4s, v31.4s, v30.4s
                	add	x0, x20, #0x10
                	str	q0, [x0]
-               	mov	x16, #0xfe00            // =65024
+               	mov	x16, #0xfe50            // =65104
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1001,7 +780,7 @@ Disassembly of section .text:
                	add	x0, x20, #0x20
                	str	q0, [x0]
                	add	x0, x20, #0x30
-               	mov	x16, #0xfdf0            // =65008
+               	mov	x16, #0xfe40            // =65088
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1009,56 +788,56 @@ Disassembly of section .text:
                	str	q31, [x0]
                	mov	x21, #0x0               // =0
                	cmp	x21, #0x4
-               	b.lo	 <L87>
-               	b	 <L92>
-<L87>:
+               	b.lo	 <L66>
+               	b	 <L71>
+<L66>:
                	mov	x16, #0x10              // =16
                	mul	x0, x21, x16
                	add	x1, x20, x0
                	ldr	q31, [x1]
-               	mov	x16, #0xfdb0            // =64944
+               	mov	x16, #0xfe00            // =65024
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xfdb0            // =64944
+               	mov	x16, #0xfe00            // =65024
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	mov	w1, v31.s[0]
                	mov	x0, x19
-<L88>:
-               	bl	 <L88>
-               	mov	x16, #0xfdb0            // =64944
+<L67>:
+               	bl	 <L67>
+               	mov	x16, #0xfe00            // =65024
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	mov	w1, v31.s[1]
-<L89>:
-               	bl	 <L89>
-               	mov	x16, #0xfdb0            // =64944
+<L68>:
+               	bl	 <L68>
+               	mov	x16, #0xfe00            // =65024
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	mov	w1, v31.s[2]
-<L90>:
-               	bl	 <L90>
-               	mov	x16, #0xfdb0            // =64944
+<L69>:
+               	bl	 <L69>
+               	mov	x16, #0xfe00            // =65024
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	mov	w1, v31.s[3]
-<L91>:
-               	bl	 <L91>
+<L70>:
+               	bl	 <L70>
                	add	x21, x21, #0x1
                	mov	x19, x0
                	cmp	x21, #0x4
-               	b.lo	 <L87>
-<L92>:
+               	b.lo	 <L66>
+<L71>:
                	sub	x21, x29, #0xb0
                	str	xzr, [x21]
                	str	xzr, [x21, #0x8]
@@ -1080,52 +859,52 @@ Disassembly of section .text:
                	str	w17, [x1]
                	ldr	w1, [x0]
                	mov	x0, x19
-<L93>:
-               	bl	 <L93>
+<L72>:
+               	bl	 <L72>
                	ldr	q31, [x20]
-               	mov	x16, #0xfda0            // =64928
+               	mov	x16, #0xfdf0            // =65008
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xfda0            // =64928
+               	mov	x16, #0xfdf0            // =65008
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	mov	w1, v31.s[0]
-<L94>:
-               	bl	 <L94>
-               	mov	x16, #0xfda0            // =64928
+<L73>:
+               	bl	 <L73>
+               	mov	x16, #0xfdf0            // =65008
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	mov	w1, v31.s[1]
-<L95>:
-               	bl	 <L95>
-               	mov	x16, #0xfda0            // =64928
+<L74>:
+               	bl	 <L74>
+               	mov	x16, #0xfdf0            // =65008
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	mov	w1, v31.s[2]
-<L96>:
-               	bl	 <L96>
-               	mov	x16, #0xfda0            // =64928
+<L75>:
+               	bl	 <L75>
+               	mov	x16, #0xfdf0            // =65008
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	mov	w1, v31.s[3]
-<L97>:
-               	bl	 <L97>
+<L76>:
+               	bl	 <L76>
                	add	x1, x21, #0x20
                	ldr	w2, [x1]
                	mov	w1, w2
-<L98>:
-               	bl	 <L98>
-               	sub	x16, x29, #0x270
+<L77>:
+               	bl	 <L77>
+               	sub	x16, x29, #0x220
                	ldp	x19, x20, [x16]
                	ldur	x21, [x16, #-0x8]
                	mov	sp, x29

--- a/test/golden/aarch64-linux/vec/vec_i64x2.dis
+++ b/test/golden/aarch64-linux/vec/vec_i64x2.dis
@@ -28,8 +28,8 @@ Disassembly of section .text:
 <corpus.cases.vec.vec_i64x2.checksum>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0x290
-               	sub	x16, x29, #0x280
+               	sub	sp, sp, #0x240
+               	sub	x16, x29, #0x230
                	stp	x19, x20, [x16]
                	stur	x21, [x16, #-0x8]
                	mov	x19, x0
@@ -331,7 +331,12 @@ Disassembly of section .text:
                	bl	 <L20>
                	ldur	q31, [x29, #-0xd0]
                	ldur	q30, [x29, #-0xf0]
-               	sub	v31.2d, v31.2d, v30.2d
+               	sub	v0.2d, v31.2d, v30.2d
+<L21>:
+               	bl	 <L21>
+               	ldur	q31, [x29, #-0xe0]
+               	ldur	q30, [x29, #-0xf0]
+               	and	v31.16b, v31.16b, v30.16b
                	mov	x16, #0xfe80            // =65152
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
@@ -341,21 +346,12 @@ Disassembly of section .text:
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x1, v31.d[0]
-<L21>:
-               	bl	 <L21>
-               	mov	x16, #0xfe80            // =65152
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x1, v31.d[1]
+               	ldr	q0, [x29, x16]
 <L22>:
                	bl	 <L22>
                	ldur	q31, [x29, #-0xe0]
                	ldur	q30, [x29, #-0xf0]
-               	and	v31.16b, v31.16b, v30.16b
+               	orr	v31.16b, v31.16b, v30.16b
                	mov	x16, #0xfe70            // =65136
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
@@ -365,165 +361,60 @@ Disassembly of section .text:
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x1, v31.d[0]
+               	ldr	q0, [x29, x16]
 <L23>:
                	bl	 <L23>
-               	mov	x16, #0xfe70            // =65136
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x1, v31.d[1]
+               	ldur	q31, [x29, #-0xe0]
+               	ldur	q30, [x29, #-0xf0]
+               	eor	v0.16b, v31.16b, v30.16b
 <L24>:
                	bl	 <L24>
                	ldur	q31, [x29, #-0xe0]
-               	ldur	q30, [x29, #-0xf0]
-               	orr	v31.16b, v31.16b, v30.16b
-               	mov	x16, #0xfe60            // =65120
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfe60            // =65120
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x1, v31.d[0]
+               	mvn	v0.16b, v31.16b
 <L25>:
                	bl	 <L25>
+               	ldur	q31, [x29, #-0xf0]
+               	mvn	v0.16b, v31.16b
+<L26>:
+               	bl	 <L26>
+               	mov	x16, #0xfe80            // =65152
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	mov	x16, #0xfe70            // =65136
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q30, [x29, x16]
+               	eor	v0.16b, v31.16b, v30.16b
+<L27>:
+               	bl	 <L27>
+               	mov	x19, x0
+               	ldur	q31, [x29, #-0xe0]
                	mov	x16, #0xfe60            // =65120
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x1, v31.d[1]
-<L26>:
-               	bl	 <L26>
-               	ldur	q31, [x29, #-0xe0]
-               	ldur	q30, [x29, #-0xf0]
-               	eor	v31.16b, v31.16b, v30.16b
+               	str	q31, [x29, x16]
+               	ldur	q31, [x29, #-0xd0]
                	mov	x16, #0xfe50            // =65104
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfe50            // =65104
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x1, v31.d[0]
-<L27>:
-               	bl	 <L27>
-               	mov	x16, #0xfe50            // =65104
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x1, v31.d[1]
-<L28>:
-               	bl	 <L28>
-               	ldur	q31, [x29, #-0xe0]
-               	mvn	v31.16b, v31.16b
-               	mov	x16, #0xfe40            // =65088
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfe40            // =65088
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x1, v31.d[0]
-<L29>:
-               	bl	 <L29>
-               	mov	x16, #0xfe40            // =65088
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x1, v31.d[1]
-<L30>:
-               	bl	 <L30>
-               	ldur	q31, [x29, #-0xf0]
-               	mvn	v31.16b, v31.16b
-               	mov	x16, #0xfe30            // =65072
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfe30            // =65072
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x1, v31.d[0]
-<L31>:
-               	bl	 <L31>
-               	mov	x16, #0xfe30            // =65072
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x1, v31.d[1]
-<L32>:
-               	bl	 <L32>
-               	ldur	q31, [x29, #-0xe0]
-               	ldur	q30, [x29, #-0xf0]
-               	and	v0.16b, v31.16b, v30.16b
-               	ldur	q31, [x29, #-0xe0]
-               	ldur	q30, [x29, #-0xf0]
-               	orr	v1.16b, v31.16b, v30.16b
-               	eor	v31.16b, v0.16b, v1.16b
-               	mov	x16, #0xfe20            // =65056
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfe20            // =65056
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x1, v31.d[0]
-<L33>:
-               	bl	 <L33>
-               	mov	x16, #0xfe20            // =65056
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x1, v31.d[1]
-<L34>:
-               	bl	 <L34>
-               	mov	x19, x0
-               	ldur	q31, [x29, #-0xe0]
-               	mov	x16, #0xfe10            // =65040
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
                	ldur	q31, [x29, #-0xd0]
-               	mov	x16, #0xfe00            // =65024
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	ldur	q31, [x29, #-0xd0]
-               	mov	x16, #0xfdf0            // =65008
+               	mov	x16, #0xfe40            // =65088
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
                	mov	x20, #0x0               // =0
                	cmp	x20, #0x6
-               	b.lo	 <L35>
-               	b	 <L44>
-<L35>:
-               	mov	x16, #0xfe10            // =65040
+               	b.lo	 <L28>
+               	b	 <L37>
+<L28>:
+               	mov	x16, #0xfe60            // =65120
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -532,7 +423,7 @@ Disassembly of section .text:
                	ldur	q31, [x29, #-0xc0]
                	mov	x1, v31.d[0]
                	mul	x2, x0, x1
-               	mov	x16, #0xfe10            // =65040
+               	mov	x16, #0xfe60            // =65120
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -541,7 +432,7 @@ Disassembly of section .text:
                	ldur	q31, [x29, #-0xc0]
                	mov	x1, v31.d[1]
                	mul	x3, x0, x1
-               	mov	x16, #0xfe10            // =65040
+               	mov	x16, #0xfe60            // =65120
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -550,155 +441,155 @@ Disassembly of section .text:
                	mov	v0.d[0], x2
                	mov	v30.16b, v0.16b
                	mov	v30.d[1], x3
-               	mov	x16, #0xfde0            // =64992
+               	mov	x16, #0xfe30            // =65072
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q30, [x29, x16]
-               	mov	x16, #0xfde0            // =64992
+               	mov	x16, #0xfe30            // =65072
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	mov	x1, v31.d[0]
                	mov	x0, x19
-<L36>:
-               	bl	 <L36>
-               	mov	x16, #0xfde0            // =64992
+<L29>:
+               	bl	 <L29>
+               	mov	x16, #0xfe30            // =65072
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	mov	x1, v31.d[1]
-<L37>:
-               	bl	 <L37>
-               	mov	x16, #0xfe00            // =65024
+<L30>:
+               	bl	 <L30>
+               	mov	x16, #0xfe50            // =65104
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov	x16, #0xfde0            // =64992
+               	mov	x16, #0xfe30            // =65072
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q30, [x29, x16]
                	eor	v31.16b, v31.16b, v30.16b
-               	mov	x16, #0xfdd0            // =64976
+               	mov	x16, #0xfe20            // =65056
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xfdd0            // =64976
+               	mov	x16, #0xfe20            // =65056
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	mov	x1, v31.d[0]
-<L38>:
-               	bl	 <L38>
-               	mov	x16, #0xfdd0            // =64976
+<L31>:
+               	bl	 <L31>
+               	mov	x16, #0xfe20            // =65056
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	mov	x1, v31.d[1]
-<L39>:
-               	bl	 <L39>
-               	mov	x16, #0xfdf0            // =65008
+<L32>:
+               	bl	 <L32>
+               	mov	x16, #0xfe40            // =65088
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov	x16, #0xfe10            // =65040
+               	mov	x16, #0xfe60            // =65120
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q30, [x29, x16]
                	add	v31.2d, v31.2d, v30.2d
-               	mov	x16, #0xfdc0            // =64960
+               	mov	x16, #0xfe10            // =65040
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xfdc0            // =64960
+               	mov	x16, #0xfe10            // =65040
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	mov	x1, v31.d[0]
-<L40>:
-               	bl	 <L40>
-               	mov	x16, #0xfdc0            // =64960
+<L33>:
+               	bl	 <L33>
+               	mov	x16, #0xfe10            // =65040
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	mov	x1, v31.d[1]
-<L41>:
-               	bl	 <L41>
-               	mov	x16, #0xfe10            // =65040
+<L34>:
+               	bl	 <L34>
+               	mov	x16, #0xfe60            // =65120
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	ldur	q30, [x29, #-0xf0]
                	add	v31.2d, v31.2d, v30.2d
-               	mov	x16, #0xfdb0            // =64944
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfdb0            // =64944
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x1, v31.d[0]
-<L42>:
-               	bl	 <L42>
-               	mov	x16, #0xfdb0            // =64944
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x1, v31.d[1]
-<L43>:
-               	bl	 <L43>
-               	add	x20, x20, #0x1
-               	mov	x19, x0
-               	mov	x16, #0xfdb0            // =64944
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x16, #0xfe10            // =65040
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfdd0            // =64976
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
                	mov	x16, #0xfe00            // =65024
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xfdc0            // =64960
+               	mov	x16, #0xfe00            // =65024
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov	x16, #0xfdf0            // =65008
+               	mov	x1, v31.d[0]
+<L35>:
+               	bl	 <L35>
+               	mov	x16, #0xfe00            // =65024
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	mov	x1, v31.d[1]
+<L36>:
+               	bl	 <L36>
+               	add	x20, x20, #0x1
+               	mov	x19, x0
+               	mov	x16, #0xfe00            // =65024
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	mov	x16, #0xfe60            // =65120
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	q31, [x29, x16]
+               	mov	x16, #0xfe20            // =65056
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	mov	x16, #0xfe50            // =65104
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	q31, [x29, x16]
+               	mov	x16, #0xfe10            // =65040
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	mov	x16, #0xfe40            // =65088
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
                	cmp	x20, #0x6
-               	b.lo	 <L35>
-<L44>:
+               	b.lo	 <L28>
+<L37>:
                	sub	x20, x29, #0x80
                	str	xzr, [x20]
                	str	xzr, [x20, #0x8]
@@ -709,13 +600,13 @@ Disassembly of section .text:
                	str	xzr, [x20, #0x30]
                	str	xzr, [x20, #0x38]
                	add	x0, x20, #0x0
-               	mov	x16, #0xfe10            // =65040
+               	mov	x16, #0xfe60            // =65120
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	str	q31, [x0]
-               	mov	x16, #0xfe10            // =65040
+               	mov	x16, #0xfe60            // =65120
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -724,7 +615,7 @@ Disassembly of section .text:
                	add	v0.2d, v31.2d, v30.2d
                	add	x0, x20, #0x10
                	str	q0, [x0]
-               	mov	x16, #0xfe10            // =65040
+               	mov	x16, #0xfe60            // =65120
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -733,7 +624,7 @@ Disassembly of section .text:
                	ldur	q31, [x29, #-0xc0]
                	mov	x1, v31.d[0]
                	mul	x2, x0, x1
-               	mov	x16, #0xfe10            // =65040
+               	mov	x16, #0xfe60            // =65120
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -742,7 +633,7 @@ Disassembly of section .text:
                	ldur	q31, [x29, #-0xc0]
                	mov	x1, v31.d[1]
                	mul	x3, x0, x1
-               	mov	x16, #0xfe10            // =65040
+               	mov	x16, #0xfe60            // =65120
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -754,7 +645,7 @@ Disassembly of section .text:
                	add	x0, x20, #0x20
                	str	q1, [x0]
                	add	x0, x20, #0x30
-               	mov	x16, #0xfe00            // =65024
+               	mov	x16, #0xfe50            // =65104
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -762,40 +653,40 @@ Disassembly of section .text:
                	str	q31, [x0]
                	mov	x21, #0x0               // =0
                	cmp	x21, #0x4
-               	b.lo	 <L45>
-               	b	 <L48>
-<L45>:
+               	b.lo	 <L38>
+               	b	 <L41>
+<L38>:
                	mov	x16, #0x10              // =16
                	mul	x0, x21, x16
                	add	x1, x20, x0
                	ldr	q31, [x1]
-               	mov	x16, #0xfda0            // =64928
+               	mov	x16, #0xfdf0            // =65008
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xfda0            // =64928
+               	mov	x16, #0xfdf0            // =65008
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	mov	x1, v31.d[0]
                	mov	x0, x19
-<L46>:
-               	bl	 <L46>
-               	mov	x16, #0xfda0            // =64928
+<L39>:
+               	bl	 <L39>
+               	mov	x16, #0xfdf0            // =65008
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	mov	x1, v31.d[1]
-<L47>:
-               	bl	 <L47>
+<L40>:
+               	bl	 <L40>
                	add	x21, x21, #0x1
                	mov	x19, x0
                	cmp	x21, #0x4
-               	b.lo	 <L45>
-<L48>:
+               	b.lo	 <L38>
+<L41>:
                	sub	x21, x29, #0xb0
                	str	xzr, [x21]
                	str	xzr, [x21, #0x8]
@@ -817,36 +708,36 @@ Disassembly of section .text:
                	str	w17, [x1]
                	ldr	w1, [x0]
                	mov	x0, x19
-<L49>:
-               	bl	 <L49>
+<L42>:
+               	bl	 <L42>
                	ldr	q31, [x20]
-               	mov	x16, #0xfd90            // =64912
+               	mov	x16, #0xfde0            // =64992
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xfd90            // =64912
+               	mov	x16, #0xfde0            // =64992
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	mov	x1, v31.d[0]
-<L50>:
-               	bl	 <L50>
-               	mov	x16, #0xfd90            // =64912
+<L43>:
+               	bl	 <L43>
+               	mov	x16, #0xfde0            // =64992
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	mov	x1, v31.d[1]
-<L51>:
-               	bl	 <L51>
+<L44>:
+               	bl	 <L44>
                	add	x1, x21, #0x20
                	ldr	w2, [x1]
                	mov	w1, w2
-<L52>:
-               	bl	 <L52>
-               	sub	x16, x29, #0x280
+<L45>:
+               	bl	 <L45>
+               	sub	x16, x29, #0x230
                	ldp	x19, x20, [x16]
                	ldur	x21, [x16, #-0x8]
                	mov	sp, x29

--- a/test/golden/aarch64-linux/vec/vec_u16x8.dis
+++ b/test/golden/aarch64-linux/vec/vec_u16x8.dis
@@ -70,8 +70,8 @@ Disassembly of section .text:
 <corpus.cases.vec.vec_u16x8.checksum>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0x290
-               	sub	x16, x29, #0x280
+               	sub	sp, sp, #0x240
+               	sub	x16, x29, #0x230
                	stp	x19, x20, [x16]
                	stur	x21, [x16, #-0x8]
                	mov	x19, x0
@@ -802,7 +802,12 @@ Disassembly of section .text:
                	bl	 <L80>
                	ldur	q31, [x29, #-0xd0]
                	ldur	q30, [x29, #-0xf0]
-               	sub	v31.8h, v31.8h, v30.8h
+               	sub	v0.8h, v31.8h, v30.8h
+<L81>:
+               	bl	 <L81>
+               	ldur	q31, [x29, #-0xe0]
+               	ldur	q30, [x29, #-0xf0]
+               	and	v31.16b, v31.16b, v30.16b
                	mov	x16, #0xfe80            // =65152
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
@@ -812,48 +817,35 @@ Disassembly of section .text:
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[0]
-<L81>:
-               	bl	 <L81>
-               	mov	x16, #0xfe80            // =65152
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[1]
+               	ldr	q0, [x29, x16]
 <L82>:
                	bl	 <L82>
-               	mov	x16, #0xfe80            // =65152
+               	ldur	q31, [x29, #-0xe0]
+               	ldur	q30, [x29, #-0xf0]
+               	orr	v31.16b, v31.16b, v30.16b
+               	mov	x16, #0xfe70            // =65136
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[2]
+               	str	q31, [x29, x16]
+               	mov	x16, #0xfe70            // =65136
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q0, [x29, x16]
 <L83>:
                	bl	 <L83>
-               	mov	x16, #0xfe80            // =65152
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[3]
+               	ldur	q31, [x29, #-0xe0]
+               	ldur	q30, [x29, #-0xf0]
+               	eor	v0.16b, v31.16b, v30.16b
 <L84>:
                	bl	 <L84>
-               	mov	x16, #0xfe80            // =65152
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[4]
+               	ldur	q31, [x29, #-0xe0]
+               	mvn	v0.16b, v31.16b
 <L85>:
                	bl	 <L85>
-               	mov	x16, #0xfe80            // =65152
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[5]
+               	ldur	q31, [x29, #-0xf0]
+               	mvn	v0.16b, v31.16b
 <L86>:
                	bl	 <L86>
                	mov	x16, #0xfe80            // =65152
@@ -861,34 +853,60 @@ Disassembly of section .text:
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[6]
-<L87>:
-               	bl	 <L87>
-               	mov	x16, #0xfe80            // =65152
+               	mov	x16, #0xfe70            // =65136
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[7]
-<L88>:
-               	bl	 <L88>
+               	ldr	q30, [x29, x16]
+               	eor	v0.16b, v31.16b, v30.16b
+<L87>:
+               	bl	 <L87>
+               	mov	x19, x0
                	ldur	q31, [x29, #-0xe0]
-               	ldur	q30, [x29, #-0xf0]
-               	and	v31.16b, v31.16b, v30.16b
-               	mov	x16, #0xfe70            // =65136
+               	mov	x16, #0xfe50            // =65104
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xfe70            // =65136
+               	ldur	q31, [x29, #-0xd0]
+               	mov	x16, #0xfe40            // =65088
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	q31, [x29, x16]
+               	ldur	q31, [x29, #-0xd0]
+               	mov	x16, #0xfe30            // =65072
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	q31, [x29, x16]
+               	mov	x20, #0x0               // =0
+               	cmp	x20, #0x6
+               	b.lo	 <L88>
+               	b	 <L121>
+<L88>:
+               	mov	x16, #0xfe50            // =65104
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	ldur	q30, [x29, #-0xc0]
+               	mul	v31.8h, v31.8h, v30.8h
+               	mov	x16, #0xfe60            // =65120
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	q31, [x29, x16]
+               	mov	x16, #0xfe60            // =65120
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	umov	w1, v31.h[0]
+               	mov	x0, x19
 <L89>:
                	bl	 <L89>
-               	mov	x16, #0xfe70            // =65136
+               	mov	x16, #0xfe60            // =65120
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -896,7 +914,7 @@ Disassembly of section .text:
                	umov	w1, v31.h[1]
 <L90>:
                	bl	 <L90>
-               	mov	x16, #0xfe70            // =65136
+               	mov	x16, #0xfe60            // =65120
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -904,7 +922,7 @@ Disassembly of section .text:
                	umov	w1, v31.h[2]
 <L91>:
                	bl	 <L91>
-               	mov	x16, #0xfe70            // =65136
+               	mov	x16, #0xfe60            // =65120
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -912,7 +930,7 @@ Disassembly of section .text:
                	umov	w1, v31.h[3]
 <L92>:
                	bl	 <L92>
-               	mov	x16, #0xfe70            // =65136
+               	mov	x16, #0xfe60            // =65120
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -920,7 +938,7 @@ Disassembly of section .text:
                	umov	w1, v31.h[4]
 <L93>:
                	bl	 <L93>
-               	mov	x16, #0xfe70            // =65136
+               	mov	x16, #0xfe60            // =65120
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -928,7 +946,7 @@ Disassembly of section .text:
                	umov	w1, v31.h[5]
 <L94>:
                	bl	 <L94>
-               	mov	x16, #0xfe70            // =65136
+               	mov	x16, #0xfe60            // =65120
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -936,7 +954,7 @@ Disassembly of section .text:
                	umov	w1, v31.h[6]
 <L95>:
                	bl	 <L95>
-               	mov	x16, #0xfe70            // =65136
+               	mov	x16, #0xfe60            // =65120
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -944,15 +962,23 @@ Disassembly of section .text:
                	umov	w1, v31.h[7]
 <L96>:
                	bl	 <L96>
-               	ldur	q31, [x29, #-0xe0]
-               	ldur	q30, [x29, #-0xf0]
-               	orr	v31.16b, v31.16b, v30.16b
+               	mov	x16, #0xfe40            // =65088
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
                	mov	x16, #0xfe60            // =65120
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
+               	ldr	q30, [x29, x16]
+               	eor	v31.16b, v31.16b, v30.16b
+               	mov	x16, #0xfe20            // =65056
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xfe60            // =65120
+               	mov	x16, #0xfe20            // =65056
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -960,7 +986,7 @@ Disassembly of section .text:
                	umov	w1, v31.h[0]
 <L97>:
                	bl	 <L97>
-               	mov	x16, #0xfe60            // =65120
+               	mov	x16, #0xfe20            // =65056
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -968,7 +994,7 @@ Disassembly of section .text:
                	umov	w1, v31.h[1]
 <L98>:
                	bl	 <L98>
-               	mov	x16, #0xfe60            // =65120
+               	mov	x16, #0xfe20            // =65056
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -976,7 +1002,7 @@ Disassembly of section .text:
                	umov	w1, v31.h[2]
 <L99>:
                	bl	 <L99>
-               	mov	x16, #0xfe60            // =65120
+               	mov	x16, #0xfe20            // =65056
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -984,7 +1010,7 @@ Disassembly of section .text:
                	umov	w1, v31.h[3]
 <L100>:
                	bl	 <L100>
-               	mov	x16, #0xfe60            // =65120
+               	mov	x16, #0xfe20            // =65056
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -992,7 +1018,7 @@ Disassembly of section .text:
                	umov	w1, v31.h[4]
 <L101>:
                	bl	 <L101>
-               	mov	x16, #0xfe60            // =65120
+               	mov	x16, #0xfe20            // =65056
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1000,7 +1026,7 @@ Disassembly of section .text:
                	umov	w1, v31.h[5]
 <L102>:
                	bl	 <L102>
-               	mov	x16, #0xfe60            // =65120
+               	mov	x16, #0xfe20            // =65056
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1008,7 +1034,7 @@ Disassembly of section .text:
                	umov	w1, v31.h[6]
 <L103>:
                	bl	 <L103>
-               	mov	x16, #0xfe60            // =65120
+               	mov	x16, #0xfe20            // =65056
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1016,15 +1042,23 @@ Disassembly of section .text:
                	umov	w1, v31.h[7]
 <L104>:
                	bl	 <L104>
-               	ldur	q31, [x29, #-0xe0]
-               	ldur	q30, [x29, #-0xf0]
-               	eor	v31.16b, v31.16b, v30.16b
+               	mov	x16, #0xfe30            // =65072
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
                	mov	x16, #0xfe50            // =65104
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
+               	ldr	q30, [x29, x16]
+               	add	v31.8h, v31.8h, v30.8h
+               	mov	x16, #0xfe10            // =65040
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xfe50            // =65104
+               	mov	x16, #0xfe10            // =65040
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1032,7 +1066,7 @@ Disassembly of section .text:
                	umov	w1, v31.h[0]
 <L105>:
                	bl	 <L105>
-               	mov	x16, #0xfe50            // =65104
+               	mov	x16, #0xfe10            // =65040
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1040,7 +1074,7 @@ Disassembly of section .text:
                	umov	w1, v31.h[1]
 <L106>:
                	bl	 <L106>
-               	mov	x16, #0xfe50            // =65104
+               	mov	x16, #0xfe10            // =65040
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1048,7 +1082,7 @@ Disassembly of section .text:
                	umov	w1, v31.h[2]
 <L107>:
                	bl	 <L107>
-               	mov	x16, #0xfe50            // =65104
+               	mov	x16, #0xfe10            // =65040
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1056,7 +1090,7 @@ Disassembly of section .text:
                	umov	w1, v31.h[3]
 <L108>:
                	bl	 <L108>
-               	mov	x16, #0xfe50            // =65104
+               	mov	x16, #0xfe10            // =65040
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1064,7 +1098,7 @@ Disassembly of section .text:
                	umov	w1, v31.h[4]
 <L109>:
                	bl	 <L109>
-               	mov	x16, #0xfe50            // =65104
+               	mov	x16, #0xfe10            // =65040
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1072,7 +1106,7 @@ Disassembly of section .text:
                	umov	w1, v31.h[5]
 <L110>:
                	bl	 <L110>
-               	mov	x16, #0xfe50            // =65104
+               	mov	x16, #0xfe10            // =65040
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1080,7 +1114,7 @@ Disassembly of section .text:
                	umov	w1, v31.h[6]
 <L111>:
                	bl	 <L111>
-               	mov	x16, #0xfe50            // =65104
+               	mov	x16, #0xfe10            // =65040
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1088,14 +1122,19 @@ Disassembly of section .text:
                	umov	w1, v31.h[7]
 <L112>:
                	bl	 <L112>
-               	ldur	q31, [x29, #-0xe0]
-               	mvn	v31.16b, v31.16b
-               	mov	x16, #0xfe40            // =65088
+               	mov	x16, #0xfe50            // =65104
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	ldur	q30, [x29, #-0xf0]
+               	add	v31.8h, v31.8h, v30.8h
+               	mov	x16, #0xfe00            // =65024
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xfe40            // =65088
+               	mov	x16, #0xfe00            // =65024
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1103,7 +1142,7 @@ Disassembly of section .text:
                	umov	w1, v31.h[0]
 <L113>:
                	bl	 <L113>
-               	mov	x16, #0xfe40            // =65088
+               	mov	x16, #0xfe00            // =65024
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1111,7 +1150,7 @@ Disassembly of section .text:
                	umov	w1, v31.h[1]
 <L114>:
                	bl	 <L114>
-               	mov	x16, #0xfe40            // =65088
+               	mov	x16, #0xfe00            // =65024
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1119,7 +1158,7 @@ Disassembly of section .text:
                	umov	w1, v31.h[2]
 <L115>:
                	bl	 <L115>
-               	mov	x16, #0xfe40            // =65088
+               	mov	x16, #0xfe00            // =65024
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1127,7 +1166,7 @@ Disassembly of section .text:
                	umov	w1, v31.h[3]
 <L116>:
                	bl	 <L116>
-               	mov	x16, #0xfe40            // =65088
+               	mov	x16, #0xfe00            // =65024
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1135,7 +1174,7 @@ Disassembly of section .text:
                	umov	w1, v31.h[4]
 <L117>:
                	bl	 <L117>
-               	mov	x16, #0xfe40            // =65088
+               	mov	x16, #0xfe00            // =65024
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1143,7 +1182,7 @@ Disassembly of section .text:
                	umov	w1, v31.h[5]
 <L118>:
                	bl	 <L118>
-               	mov	x16, #0xfe40            // =65088
+               	mov	x16, #0xfe00            // =65024
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1151,7 +1190,7 @@ Disassembly of section .text:
                	umov	w1, v31.h[6]
 <L119>:
                	bl	 <L119>
-               	mov	x16, #0xfe40            // =65088
+               	mov	x16, #0xfe00            // =65024
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1159,525 +1198,41 @@ Disassembly of section .text:
                	umov	w1, v31.h[7]
 <L120>:
                	bl	 <L120>
-               	ldur	q31, [x29, #-0xf0]
-               	mvn	v31.16b, v31.16b
-               	mov	x16, #0xfe30            // =65072
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfe30            // =65072
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[0]
-<L121>:
-               	bl	 <L121>
-               	mov	x16, #0xfe30            // =65072
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[1]
-<L122>:
-               	bl	 <L122>
-               	mov	x16, #0xfe30            // =65072
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[2]
-<L123>:
-               	bl	 <L123>
-               	mov	x16, #0xfe30            // =65072
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[3]
-<L124>:
-               	bl	 <L124>
-               	mov	x16, #0xfe30            // =65072
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[4]
-<L125>:
-               	bl	 <L125>
-               	mov	x16, #0xfe30            // =65072
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[5]
-<L126>:
-               	bl	 <L126>
-               	mov	x16, #0xfe30            // =65072
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[6]
-<L127>:
-               	bl	 <L127>
-               	mov	x16, #0xfe30            // =65072
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[7]
-<L128>:
-               	bl	 <L128>
-               	ldur	q31, [x29, #-0xe0]
-               	ldur	q30, [x29, #-0xf0]
-               	and	v0.16b, v31.16b, v30.16b
-               	ldur	q31, [x29, #-0xe0]
-               	ldur	q30, [x29, #-0xf0]
-               	orr	v1.16b, v31.16b, v30.16b
-               	eor	v31.16b, v0.16b, v1.16b
-               	mov	x16, #0xfe20            // =65056
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfe20            // =65056
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[0]
-<L129>:
-               	bl	 <L129>
-               	mov	x16, #0xfe20            // =65056
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[1]
-<L130>:
-               	bl	 <L130>
-               	mov	x16, #0xfe20            // =65056
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[2]
-<L131>:
-               	bl	 <L131>
-               	mov	x16, #0xfe20            // =65056
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[3]
-<L132>:
-               	bl	 <L132>
-               	mov	x16, #0xfe20            // =65056
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[4]
-<L133>:
-               	bl	 <L133>
-               	mov	x16, #0xfe20            // =65056
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[5]
-<L134>:
-               	bl	 <L134>
-               	mov	x16, #0xfe20            // =65056
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[6]
-<L135>:
-               	bl	 <L135>
-               	mov	x16, #0xfe20            // =65056
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[7]
-<L136>:
-               	bl	 <L136>
-               	mov	x19, x0
-               	ldur	q31, [x29, #-0xe0]
-               	mov	x16, #0xfe00            // =65024
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	ldur	q31, [x29, #-0xd0]
-               	mov	x16, #0xfdf0            // =65008
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	ldur	q31, [x29, #-0xd0]
-               	mov	x16, #0xfde0            // =64992
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x20, #0x0               // =0
-               	cmp	x20, #0x6
-               	b.lo	 <L137>
-               	b	 <L170>
-<L137>:
-               	mov	x16, #0xfe00            // =65024
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	ldur	q30, [x29, #-0xc0]
-               	mul	v31.8h, v31.8h, v30.8h
-               	mov	x16, #0xfe10            // =65040
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfe10            // =65040
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[0]
-               	mov	x0, x19
-<L138>:
-               	bl	 <L138>
-               	mov	x16, #0xfe10            // =65040
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[1]
-<L139>:
-               	bl	 <L139>
-               	mov	x16, #0xfe10            // =65040
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[2]
-<L140>:
-               	bl	 <L140>
-               	mov	x16, #0xfe10            // =65040
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[3]
-<L141>:
-               	bl	 <L141>
-               	mov	x16, #0xfe10            // =65040
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[4]
-<L142>:
-               	bl	 <L142>
-               	mov	x16, #0xfe10            // =65040
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[5]
-<L143>:
-               	bl	 <L143>
-               	mov	x16, #0xfe10            // =65040
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[6]
-<L144>:
-               	bl	 <L144>
-               	mov	x16, #0xfe10            // =65040
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[7]
-<L145>:
-               	bl	 <L145>
-               	mov	x16, #0xfdf0            // =65008
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x16, #0xfe10            // =65040
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q30, [x29, x16]
-               	eor	v31.16b, v31.16b, v30.16b
-               	mov	x16, #0xfdd0            // =64976
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfdd0            // =64976
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[0]
-<L146>:
-               	bl	 <L146>
-               	mov	x16, #0xfdd0            // =64976
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[1]
-<L147>:
-               	bl	 <L147>
-               	mov	x16, #0xfdd0            // =64976
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[2]
-<L148>:
-               	bl	 <L148>
-               	mov	x16, #0xfdd0            // =64976
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[3]
-<L149>:
-               	bl	 <L149>
-               	mov	x16, #0xfdd0            // =64976
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[4]
-<L150>:
-               	bl	 <L150>
-               	mov	x16, #0xfdd0            // =64976
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[5]
-<L151>:
-               	bl	 <L151>
-               	mov	x16, #0xfdd0            // =64976
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[6]
-<L152>:
-               	bl	 <L152>
-               	mov	x16, #0xfdd0            // =64976
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[7]
-<L153>:
-               	bl	 <L153>
-               	mov	x16, #0xfde0            // =64992
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x16, #0xfe00            // =65024
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q30, [x29, x16]
-               	add	v31.8h, v31.8h, v30.8h
-               	mov	x16, #0xfdc0            // =64960
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfdc0            // =64960
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[0]
-<L154>:
-               	bl	 <L154>
-               	mov	x16, #0xfdc0            // =64960
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[1]
-<L155>:
-               	bl	 <L155>
-               	mov	x16, #0xfdc0            // =64960
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[2]
-<L156>:
-               	bl	 <L156>
-               	mov	x16, #0xfdc0            // =64960
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[3]
-<L157>:
-               	bl	 <L157>
-               	mov	x16, #0xfdc0            // =64960
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[4]
-<L158>:
-               	bl	 <L158>
-               	mov	x16, #0xfdc0            // =64960
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[5]
-<L159>:
-               	bl	 <L159>
-               	mov	x16, #0xfdc0            // =64960
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[6]
-<L160>:
-               	bl	 <L160>
-               	mov	x16, #0xfdc0            // =64960
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[7]
-<L161>:
-               	bl	 <L161>
-               	mov	x16, #0xfe00            // =65024
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	ldur	q30, [x29, #-0xf0]
-               	add	v31.8h, v31.8h, v30.8h
-               	mov	x16, #0xfdb0            // =64944
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfdb0            // =64944
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[0]
-<L162>:
-               	bl	 <L162>
-               	mov	x16, #0xfdb0            // =64944
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[1]
-<L163>:
-               	bl	 <L163>
-               	mov	x16, #0xfdb0            // =64944
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[2]
-<L164>:
-               	bl	 <L164>
-               	mov	x16, #0xfdb0            // =64944
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[3]
-<L165>:
-               	bl	 <L165>
-               	mov	x16, #0xfdb0            // =64944
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[4]
-<L166>:
-               	bl	 <L166>
-               	mov	x16, #0xfdb0            // =64944
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[5]
-<L167>:
-               	bl	 <L167>
-               	mov	x16, #0xfdb0            // =64944
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[6]
-<L168>:
-               	bl	 <L168>
-               	mov	x16, #0xfdb0            // =64944
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[7]
-<L169>:
-               	bl	 <L169>
                	add	x20, x20, #0x1
                	mov	x19, x0
-               	mov	x16, #0xfdb0            // =64944
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
                	mov	x16, #0xfe00            // =65024
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfdd0            // =64976
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov	x16, #0xfdf0            // =65008
+               	mov	x16, #0xfe50            // =65104
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xfdc0            // =64960
+               	mov	x16, #0xfe20            // =65056
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov	x16, #0xfde0            // =64992
+               	mov	x16, #0xfe40            // =65088
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	q31, [x29, x16]
+               	mov	x16, #0xfe10            // =65040
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	mov	x16, #0xfe30            // =65072
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
                	cmp	x20, #0x6
-               	b.lo	 <L137>
-<L170>:
+               	b.lo	 <L88>
+<L121>:
                	sub	x20, x29, #0x80
                	str	xzr, [x20]
                	str	xzr, [x20, #0x8]
@@ -1688,13 +1243,13 @@ Disassembly of section .text:
                	str	xzr, [x20, #0x30]
                	str	xzr, [x20, #0x38]
                	add	x0, x20, #0x0
-               	mov	x16, #0xfe00            // =65024
+               	mov	x16, #0xfe50            // =65104
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	str	q31, [x0]
-               	mov	x16, #0xfe00            // =65024
+               	mov	x16, #0xfe50            // =65104
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1703,7 +1258,7 @@ Disassembly of section .text:
                	add	v0.8h, v31.8h, v30.8h
                	add	x0, x20, #0x10
                	str	q0, [x0]
-               	mov	x16, #0xfe00            // =65024
+               	mov	x16, #0xfe50            // =65104
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1713,7 +1268,7 @@ Disassembly of section .text:
                	add	x0, x20, #0x20
                	str	q0, [x0]
                	add	x0, x20, #0x30
-               	mov	x16, #0xfdf0            // =65008
+               	mov	x16, #0xfe40            // =65088
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1721,88 +1276,88 @@ Disassembly of section .text:
                	str	q31, [x0]
                	mov	x21, #0x0               // =0
                	cmp	x21, #0x4
-               	b.lo	 <L171>
-               	b	 <L180>
-<L171>:
+               	b.lo	 <L122>
+               	b	 <L131>
+<L122>:
                	mov	x16, #0x10              // =16
                	mul	x0, x21, x16
                	add	x1, x20, x0
                	ldr	q31, [x1]
-               	mov	x16, #0xfda0            // =64928
+               	mov	x16, #0xfdf0            // =65008
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xfda0            // =64928
+               	mov	x16, #0xfdf0            // =65008
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	umov	w1, v31.h[0]
                	mov	x0, x19
-<L172>:
-               	bl	 <L172>
-               	mov	x16, #0xfda0            // =64928
+<L123>:
+               	bl	 <L123>
+               	mov	x16, #0xfdf0            // =65008
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	umov	w1, v31.h[1]
-<L173>:
-               	bl	 <L173>
-               	mov	x16, #0xfda0            // =64928
+<L124>:
+               	bl	 <L124>
+               	mov	x16, #0xfdf0            // =65008
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	umov	w1, v31.h[2]
-<L174>:
-               	bl	 <L174>
-               	mov	x16, #0xfda0            // =64928
+<L125>:
+               	bl	 <L125>
+               	mov	x16, #0xfdf0            // =65008
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	umov	w1, v31.h[3]
-<L175>:
-               	bl	 <L175>
-               	mov	x16, #0xfda0            // =64928
+<L126>:
+               	bl	 <L126>
+               	mov	x16, #0xfdf0            // =65008
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	umov	w1, v31.h[4]
-<L176>:
-               	bl	 <L176>
-               	mov	x16, #0xfda0            // =64928
+<L127>:
+               	bl	 <L127>
+               	mov	x16, #0xfdf0            // =65008
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	umov	w1, v31.h[5]
-<L177>:
-               	bl	 <L177>
-               	mov	x16, #0xfda0            // =64928
+<L128>:
+               	bl	 <L128>
+               	mov	x16, #0xfdf0            // =65008
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	umov	w1, v31.h[6]
-<L178>:
-               	bl	 <L178>
-               	mov	x16, #0xfda0            // =64928
+<L129>:
+               	bl	 <L129>
+               	mov	x16, #0xfdf0            // =65008
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	umov	w1, v31.h[7]
-<L179>:
-               	bl	 <L179>
+<L130>:
+               	bl	 <L130>
                	add	x21, x21, #0x1
                	mov	x19, x0
                	cmp	x21, #0x4
-               	b.lo	 <L171>
-<L180>:
+               	b.lo	 <L122>
+<L131>:
                	sub	x21, x29, #0xb0
                	str	xzr, [x21]
                	str	xzr, [x21, #0x8]
@@ -1824,84 +1379,84 @@ Disassembly of section .text:
                	str	w17, [x1]
                	ldr	w1, [x0]
                	mov	x0, x19
-<L181>:
-               	bl	 <L181>
+<L132>:
+               	bl	 <L132>
                	ldr	q31, [x20]
-               	mov	x16, #0xfd90            // =64912
+               	mov	x16, #0xfde0            // =64992
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xfd90            // =64912
+               	mov	x16, #0xfde0            // =64992
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	umov	w1, v31.h[0]
-<L182>:
-               	bl	 <L182>
-               	mov	x16, #0xfd90            // =64912
+<L133>:
+               	bl	 <L133>
+               	mov	x16, #0xfde0            // =64992
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	umov	w1, v31.h[1]
-<L183>:
-               	bl	 <L183>
-               	mov	x16, #0xfd90            // =64912
+<L134>:
+               	bl	 <L134>
+               	mov	x16, #0xfde0            // =64992
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	umov	w1, v31.h[2]
-<L184>:
-               	bl	 <L184>
-               	mov	x16, #0xfd90            // =64912
+<L135>:
+               	bl	 <L135>
+               	mov	x16, #0xfde0            // =64992
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	umov	w1, v31.h[3]
-<L185>:
-               	bl	 <L185>
-               	mov	x16, #0xfd90            // =64912
+<L136>:
+               	bl	 <L136>
+               	mov	x16, #0xfde0            // =64992
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	umov	w1, v31.h[4]
-<L186>:
-               	bl	 <L186>
-               	mov	x16, #0xfd90            // =64912
+<L137>:
+               	bl	 <L137>
+               	mov	x16, #0xfde0            // =64992
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	umov	w1, v31.h[5]
-<L187>:
-               	bl	 <L187>
-               	mov	x16, #0xfd90            // =64912
+<L138>:
+               	bl	 <L138>
+               	mov	x16, #0xfde0            // =64992
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	umov	w1, v31.h[6]
-<L188>:
-               	bl	 <L188>
-               	mov	x16, #0xfd90            // =64912
+<L139>:
+               	bl	 <L139>
+               	mov	x16, #0xfde0            // =64992
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	umov	w1, v31.h[7]
-<L189>:
-               	bl	 <L189>
+<L140>:
+               	bl	 <L140>
                	add	x1, x21, #0x20
                	ldr	w2, [x1]
                	mov	w1, w2
-<L190>:
-               	bl	 <L190>
-               	sub	x16, x29, #0x280
+<L141>:
+               	bl	 <L141>
+               	sub	x16, x29, #0x230
                	ldp	x19, x20, [x16]
                	ldur	x21, [x16, #-0x8]
                	mov	sp, x29

--- a/test/golden/aarch64-linux/vec/vec_u32x4.dis
+++ b/test/golden/aarch64-linux/vec/vec_u32x4.dis
@@ -42,8 +42,8 @@ Disassembly of section .text:
 <corpus.cases.vec.vec_u32x4.checksum>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0x290
-               	sub	x16, x29, #0x280
+               	sub	sp, sp, #0x240
+               	sub	x16, x29, #0x230
                	stp	x19, x20, [x16]
                	stur	x21, [x16, #-0x8]
                	mov	x19, x0
@@ -462,87 +462,96 @@ Disassembly of section .text:
                	bl	 <L40>
                	ldur	q31, [x29, #-0xd0]
                	ldur	q30, [x29, #-0xf0]
-               	sub	v31.4s, v31.4s, v30.4s
-               	mov	x16, #0xfe80            // =65152
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfe80            // =65152
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[0]
+               	sub	v0.4s, v31.4s, v30.4s
 <L41>:
                	bl	 <L41>
-               	mov	x16, #0xfe80            // =65152
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[1]
-<L42>:
-               	bl	 <L42>
-               	mov	x16, #0xfe80            // =65152
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[2]
-<L43>:
-               	bl	 <L43>
-               	mov	x16, #0xfe80            // =65152
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[3]
-<L44>:
-               	bl	 <L44>
                	ldur	q31, [x29, #-0xe0]
                	ldur	q30, [x29, #-0xf0]
                	and	v31.16b, v31.16b, v30.16b
-               	mov	x16, #0xfe70            // =65136
+               	mov	x16, #0xfe80            // =65152
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xfe70            // =65136
+               	mov	x16, #0xfe80            // =65152
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[0]
-<L45>:
-               	bl	 <L45>
-               	mov	x16, #0xfe70            // =65136
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[1]
-<L46>:
-               	bl	 <L46>
-               	mov	x16, #0xfe70            // =65136
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[2]
-<L47>:
-               	bl	 <L47>
-               	mov	x16, #0xfe70            // =65136
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[3]
-<L48>:
-               	bl	 <L48>
+               	ldr	q0, [x29, x16]
+<L42>:
+               	bl	 <L42>
                	ldur	q31, [x29, #-0xe0]
                	ldur	q30, [x29, #-0xf0]
                	orr	v31.16b, v31.16b, v30.16b
+               	mov	x16, #0xfe70            // =65136
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	q31, [x29, x16]
+               	mov	x16, #0xfe70            // =65136
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q0, [x29, x16]
+<L43>:
+               	bl	 <L43>
+               	ldur	q31, [x29, #-0xe0]
+               	ldur	q30, [x29, #-0xf0]
+               	eor	v0.16b, v31.16b, v30.16b
+<L44>:
+               	bl	 <L44>
+               	ldur	q31, [x29, #-0xe0]
+               	mvn	v0.16b, v31.16b
+<L45>:
+               	bl	 <L45>
+               	ldur	q31, [x29, #-0xf0]
+               	mvn	v0.16b, v31.16b
+<L46>:
+               	bl	 <L46>
+               	mov	x16, #0xfe80            // =65152
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	mov	x16, #0xfe70            // =65136
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q30, [x29, x16]
+               	eor	v0.16b, v31.16b, v30.16b
+<L47>:
+               	bl	 <L47>
+               	mov	x19, x0
+               	ldur	q31, [x29, #-0xe0]
+               	mov	x16, #0xfe50            // =65104
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	q31, [x29, x16]
+               	ldur	q31, [x29, #-0xd0]
+               	mov	x16, #0xfe40            // =65088
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	q31, [x29, x16]
+               	ldur	q31, [x29, #-0xd0]
+               	mov	x16, #0xfe30            // =65072
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	q31, [x29, x16]
+               	mov	x20, #0x0               // =0
+               	cmp	x20, #0x6
+               	b.lo	 <L48>
+               	b	 <L65>
+<L48>:
+               	mov	x16, #0xfe50            // =65104
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	ldur	q30, [x29, #-0xc0]
+               	mul	v31.4s, v31.4s, v30.4s
                	mov	x16, #0xfe60            // =65120
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
@@ -554,6 +563,7 @@ Disassembly of section .text:
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	mov	w1, v31.s[0]
+               	mov	x0, x19
 <L49>:
                	bl	 <L49>
                	mov	x16, #0xfe60            // =65120
@@ -580,15 +590,23 @@ Disassembly of section .text:
                	mov	w1, v31.s[3]
 <L52>:
                	bl	 <L52>
-               	ldur	q31, [x29, #-0xe0]
-               	ldur	q30, [x29, #-0xf0]
+               	mov	x16, #0xfe40            // =65088
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	mov	x16, #0xfe60            // =65120
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q30, [x29, x16]
                	eor	v31.16b, v31.16b, v30.16b
-               	mov	x16, #0xfe50            // =65104
+               	mov	x16, #0xfe20            // =65056
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xfe50            // =65104
+               	mov	x16, #0xfe20            // =65056
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -596,7 +614,7 @@ Disassembly of section .text:
                	mov	w1, v31.s[0]
 <L53>:
                	bl	 <L53>
-               	mov	x16, #0xfe50            // =65104
+               	mov	x16, #0xfe20            // =65056
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -604,7 +622,7 @@ Disassembly of section .text:
                	mov	w1, v31.s[1]
 <L54>:
                	bl	 <L54>
-               	mov	x16, #0xfe50            // =65104
+               	mov	x16, #0xfe20            // =65056
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -612,7 +630,7 @@ Disassembly of section .text:
                	mov	w1, v31.s[2]
 <L55>:
                	bl	 <L55>
-               	mov	x16, #0xfe50            // =65104
+               	mov	x16, #0xfe20            // =65056
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -620,14 +638,23 @@ Disassembly of section .text:
                	mov	w1, v31.s[3]
 <L56>:
                	bl	 <L56>
-               	ldur	q31, [x29, #-0xe0]
-               	mvn	v31.16b, v31.16b
-               	mov	x16, #0xfe40            // =65088
+               	mov	x16, #0xfe30            // =65072
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	mov	x16, #0xfe50            // =65104
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q30, [x29, x16]
+               	add	v31.4s, v31.4s, v30.4s
+               	mov	x16, #0xfe10            // =65040
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xfe40            // =65088
+               	mov	x16, #0xfe10            // =65040
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -635,7 +662,7 @@ Disassembly of section .text:
                	mov	w1, v31.s[0]
 <L57>:
                	bl	 <L57>
-               	mov	x16, #0xfe40            // =65088
+               	mov	x16, #0xfe10            // =65040
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -643,7 +670,7 @@ Disassembly of section .text:
                	mov	w1, v31.s[1]
 <L58>:
                	bl	 <L58>
-               	mov	x16, #0xfe40            // =65088
+               	mov	x16, #0xfe10            // =65040
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -651,7 +678,7 @@ Disassembly of section .text:
                	mov	w1, v31.s[2]
 <L59>:
                	bl	 <L59>
-               	mov	x16, #0xfe40            // =65088
+               	mov	x16, #0xfe10            // =65040
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -659,14 +686,19 @@ Disassembly of section .text:
                	mov	w1, v31.s[3]
 <L60>:
                	bl	 <L60>
-               	ldur	q31, [x29, #-0xf0]
-               	mvn	v31.16b, v31.16b
-               	mov	x16, #0xfe30            // =65072
+               	mov	x16, #0xfe50            // =65104
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	ldur	q30, [x29, #-0xf0]
+               	add	v31.4s, v31.4s, v30.4s
+               	mov	x16, #0xfe00            // =65024
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xfe30            // =65072
+               	mov	x16, #0xfe00            // =65024
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -674,7 +706,7 @@ Disassembly of section .text:
                	mov	w1, v31.s[0]
 <L61>:
                	bl	 <L61>
-               	mov	x16, #0xfe30            // =65072
+               	mov	x16, #0xfe00            // =65024
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -682,7 +714,7 @@ Disassembly of section .text:
                	mov	w1, v31.s[1]
 <L62>:
                	bl	 <L62>
-               	mov	x16, #0xfe30            // =65072
+               	mov	x16, #0xfe00            // =65024
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -690,7 +722,7 @@ Disassembly of section .text:
                	mov	w1, v31.s[2]
 <L63>:
                	bl	 <L63>
-               	mov	x16, #0xfe30            // =65072
+               	mov	x16, #0xfe00            // =65024
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -698,294 +730,41 @@ Disassembly of section .text:
                	mov	w1, v31.s[3]
 <L64>:
                	bl	 <L64>
-               	ldur	q31, [x29, #-0xe0]
-               	ldur	q30, [x29, #-0xf0]
-               	and	v0.16b, v31.16b, v30.16b
-               	ldur	q31, [x29, #-0xe0]
-               	ldur	q30, [x29, #-0xf0]
-               	orr	v1.16b, v31.16b, v30.16b
-               	eor	v31.16b, v0.16b, v1.16b
-               	mov	x16, #0xfe20            // =65056
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfe20            // =65056
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[0]
-<L65>:
-               	bl	 <L65>
-               	mov	x16, #0xfe20            // =65056
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[1]
-<L66>:
-               	bl	 <L66>
-               	mov	x16, #0xfe20            // =65056
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[2]
-<L67>:
-               	bl	 <L67>
-               	mov	x16, #0xfe20            // =65056
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[3]
-<L68>:
-               	bl	 <L68>
-               	mov	x19, x0
-               	ldur	q31, [x29, #-0xe0]
-               	mov	x16, #0xfe00            // =65024
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	ldur	q31, [x29, #-0xd0]
-               	mov	x16, #0xfdf0            // =65008
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	ldur	q31, [x29, #-0xd0]
-               	mov	x16, #0xfde0            // =64992
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x20, #0x0               // =0
-               	cmp	x20, #0x6
-               	b.lo	 <L69>
-               	b	 <L86>
-<L69>:
-               	mov	x16, #0xfe00            // =65024
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	ldur	q30, [x29, #-0xc0]
-               	mul	v31.4s, v31.4s, v30.4s
-               	mov	x16, #0xfe10            // =65040
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfe10            // =65040
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[0]
-               	mov	x0, x19
-<L70>:
-               	bl	 <L70>
-               	mov	x16, #0xfe10            // =65040
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[1]
-<L71>:
-               	bl	 <L71>
-               	mov	x16, #0xfe10            // =65040
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[2]
-<L72>:
-               	bl	 <L72>
-               	mov	x16, #0xfe10            // =65040
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[3]
-<L73>:
-               	bl	 <L73>
-               	mov	x16, #0xfdf0            // =65008
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x16, #0xfe10            // =65040
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q30, [x29, x16]
-               	eor	v31.16b, v31.16b, v30.16b
-               	mov	x16, #0xfdd0            // =64976
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfdd0            // =64976
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[0]
-<L74>:
-               	bl	 <L74>
-               	mov	x16, #0xfdd0            // =64976
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[1]
-<L75>:
-               	bl	 <L75>
-               	mov	x16, #0xfdd0            // =64976
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[2]
-<L76>:
-               	bl	 <L76>
-               	mov	x16, #0xfdd0            // =64976
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[3]
-<L77>:
-               	bl	 <L77>
-               	mov	x16, #0xfde0            // =64992
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x16, #0xfe00            // =65024
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q30, [x29, x16]
-               	add	v31.4s, v31.4s, v30.4s
-               	mov	x16, #0xfdc0            // =64960
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfdc0            // =64960
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[0]
-<L78>:
-               	bl	 <L78>
-               	mov	x16, #0xfdc0            // =64960
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[1]
-<L79>:
-               	bl	 <L79>
-               	mov	x16, #0xfdc0            // =64960
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[2]
-<L80>:
-               	bl	 <L80>
-               	mov	x16, #0xfdc0            // =64960
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[3]
-<L81>:
-               	bl	 <L81>
-               	mov	x16, #0xfe00            // =65024
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	ldur	q30, [x29, #-0xf0]
-               	add	v31.4s, v31.4s, v30.4s
-               	mov	x16, #0xfdb0            // =64944
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfdb0            // =64944
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[0]
-<L82>:
-               	bl	 <L82>
-               	mov	x16, #0xfdb0            // =64944
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[1]
-<L83>:
-               	bl	 <L83>
-               	mov	x16, #0xfdb0            // =64944
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[2]
-<L84>:
-               	bl	 <L84>
-               	mov	x16, #0xfdb0            // =64944
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[3]
-<L85>:
-               	bl	 <L85>
                	add	x20, x20, #0x1
                	mov	x19, x0
-               	mov	x16, #0xfdb0            // =64944
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
                	mov	x16, #0xfe00            // =65024
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfdd0            // =64976
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov	x16, #0xfdf0            // =65008
+               	mov	x16, #0xfe50            // =65104
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xfdc0            // =64960
+               	mov	x16, #0xfe20            // =65056
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov	x16, #0xfde0            // =64992
+               	mov	x16, #0xfe40            // =65088
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	q31, [x29, x16]
+               	mov	x16, #0xfe10            // =65040
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	mov	x16, #0xfe30            // =65072
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
                	cmp	x20, #0x6
-               	b.lo	 <L69>
-<L86>:
+               	b.lo	 <L48>
+<L65>:
                	sub	x20, x29, #0x80
                	str	xzr, [x20]
                	str	xzr, [x20, #0x8]
@@ -996,13 +775,13 @@ Disassembly of section .text:
                	str	xzr, [x20, #0x30]
                	str	xzr, [x20, #0x38]
                	add	x0, x20, #0x0
-               	mov	x16, #0xfe00            // =65024
+               	mov	x16, #0xfe50            // =65104
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	str	q31, [x0]
-               	mov	x16, #0xfe00            // =65024
+               	mov	x16, #0xfe50            // =65104
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1011,7 +790,7 @@ Disassembly of section .text:
                	add	v0.4s, v31.4s, v30.4s
                	add	x0, x20, #0x10
                	str	q0, [x0]
-               	mov	x16, #0xfe00            // =65024
+               	mov	x16, #0xfe50            // =65104
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1021,7 +800,7 @@ Disassembly of section .text:
                	add	x0, x20, #0x20
                	str	q0, [x0]
                	add	x0, x20, #0x30
-               	mov	x16, #0xfdf0            // =65008
+               	mov	x16, #0xfe40            // =65088
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1029,56 +808,56 @@ Disassembly of section .text:
                	str	q31, [x0]
                	mov	x21, #0x0               // =0
                	cmp	x21, #0x4
-               	b.lo	 <L87>
-               	b	 <L92>
-<L87>:
+               	b.lo	 <L66>
+               	b	 <L71>
+<L66>:
                	mov	x16, #0x10              // =16
                	mul	x0, x21, x16
                	add	x1, x20, x0
                	ldr	q31, [x1]
-               	mov	x16, #0xfda0            // =64928
+               	mov	x16, #0xfdf0            // =65008
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xfda0            // =64928
+               	mov	x16, #0xfdf0            // =65008
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	mov	w1, v31.s[0]
                	mov	x0, x19
-<L88>:
-               	bl	 <L88>
-               	mov	x16, #0xfda0            // =64928
+<L67>:
+               	bl	 <L67>
+               	mov	x16, #0xfdf0            // =65008
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	mov	w1, v31.s[1]
-<L89>:
-               	bl	 <L89>
-               	mov	x16, #0xfda0            // =64928
+<L68>:
+               	bl	 <L68>
+               	mov	x16, #0xfdf0            // =65008
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	mov	w1, v31.s[2]
-<L90>:
-               	bl	 <L90>
-               	mov	x16, #0xfda0            // =64928
+<L69>:
+               	bl	 <L69>
+               	mov	x16, #0xfdf0            // =65008
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	mov	w1, v31.s[3]
-<L91>:
-               	bl	 <L91>
+<L70>:
+               	bl	 <L70>
                	add	x21, x21, #0x1
                	mov	x19, x0
                	cmp	x21, #0x4
-               	b.lo	 <L87>
-<L92>:
+               	b.lo	 <L66>
+<L71>:
                	sub	x21, x29, #0xb0
                	str	xzr, [x21]
                	str	xzr, [x21, #0x8]
@@ -1100,52 +879,52 @@ Disassembly of section .text:
                	str	w17, [x1]
                	ldr	w1, [x0]
                	mov	x0, x19
-<L93>:
-               	bl	 <L93>
+<L72>:
+               	bl	 <L72>
                	ldr	q31, [x20]
-               	mov	x16, #0xfd90            // =64912
+               	mov	x16, #0xfde0            // =64992
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xfd90            // =64912
+               	mov	x16, #0xfde0            // =64992
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	mov	w1, v31.s[0]
-<L94>:
-               	bl	 <L94>
-               	mov	x16, #0xfd90            // =64912
+<L73>:
+               	bl	 <L73>
+               	mov	x16, #0xfde0            // =64992
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	mov	w1, v31.s[1]
-<L95>:
-               	bl	 <L95>
-               	mov	x16, #0xfd90            // =64912
+<L74>:
+               	bl	 <L74>
+               	mov	x16, #0xfde0            // =64992
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	mov	w1, v31.s[2]
-<L96>:
-               	bl	 <L96>
-               	mov	x16, #0xfd90            // =64912
+<L75>:
+               	bl	 <L75>
+               	mov	x16, #0xfde0            // =64992
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	mov	w1, v31.s[3]
-<L97>:
-               	bl	 <L97>
+<L76>:
+               	bl	 <L76>
                	add	x1, x21, #0x20
                	ldr	w2, [x1]
                	mov	w1, w2
-<L98>:
-               	bl	 <L98>
-               	sub	x16, x29, #0x280
+<L77>:
+               	bl	 <L77>
+               	sub	x16, x29, #0x230
                	ldp	x19, x20, [x16]
                	ldur	x21, [x16, #-0x8]
                	mov	sp, x29

--- a/test/golden/aarch64-linux/vec/vec_u64x2.dis
+++ b/test/golden/aarch64-linux/vec/vec_u64x2.dis
@@ -28,8 +28,8 @@ Disassembly of section .text:
 <corpus.cases.vec.vec_u64x2.checksum>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0x290
-               	sub	x16, x29, #0x280
+               	sub	sp, sp, #0x240
+               	sub	x16, x29, #0x230
                	stp	x19, x20, [x16]
                	stur	x21, [x16, #-0x8]
                	mov	x19, x0
@@ -330,7 +330,12 @@ Disassembly of section .text:
                	bl	 <L20>
                	ldur	q31, [x29, #-0xd0]
                	ldur	q30, [x29, #-0xf0]
-               	sub	v31.2d, v31.2d, v30.2d
+               	sub	v0.2d, v31.2d, v30.2d
+<L21>:
+               	bl	 <L21>
+               	ldur	q31, [x29, #-0xe0]
+               	ldur	q30, [x29, #-0xf0]
+               	and	v31.16b, v31.16b, v30.16b
                	mov	x16, #0xfe80            // =65152
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
@@ -340,21 +345,12 @@ Disassembly of section .text:
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x1, v31.d[0]
-<L21>:
-               	bl	 <L21>
-               	mov	x16, #0xfe80            // =65152
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x1, v31.d[1]
+               	ldr	q0, [x29, x16]
 <L22>:
                	bl	 <L22>
                	ldur	q31, [x29, #-0xe0]
                	ldur	q30, [x29, #-0xf0]
-               	and	v31.16b, v31.16b, v30.16b
+               	orr	v31.16b, v31.16b, v30.16b
                	mov	x16, #0xfe70            // =65136
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
@@ -364,165 +360,60 @@ Disassembly of section .text:
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x1, v31.d[0]
+               	ldr	q0, [x29, x16]
 <L23>:
                	bl	 <L23>
-               	mov	x16, #0xfe70            // =65136
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x1, v31.d[1]
+               	ldur	q31, [x29, #-0xe0]
+               	ldur	q30, [x29, #-0xf0]
+               	eor	v0.16b, v31.16b, v30.16b
 <L24>:
                	bl	 <L24>
                	ldur	q31, [x29, #-0xe0]
-               	ldur	q30, [x29, #-0xf0]
-               	orr	v31.16b, v31.16b, v30.16b
-               	mov	x16, #0xfe60            // =65120
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfe60            // =65120
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x1, v31.d[0]
+               	mvn	v0.16b, v31.16b
 <L25>:
                	bl	 <L25>
+               	ldur	q31, [x29, #-0xf0]
+               	mvn	v0.16b, v31.16b
+<L26>:
+               	bl	 <L26>
+               	mov	x16, #0xfe80            // =65152
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	mov	x16, #0xfe70            // =65136
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q30, [x29, x16]
+               	eor	v0.16b, v31.16b, v30.16b
+<L27>:
+               	bl	 <L27>
+               	mov	x19, x0
+               	ldur	q31, [x29, #-0xe0]
                	mov	x16, #0xfe60            // =65120
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x1, v31.d[1]
-<L26>:
-               	bl	 <L26>
-               	ldur	q31, [x29, #-0xe0]
-               	ldur	q30, [x29, #-0xf0]
-               	eor	v31.16b, v31.16b, v30.16b
+               	str	q31, [x29, x16]
+               	ldur	q31, [x29, #-0xd0]
                	mov	x16, #0xfe50            // =65104
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfe50            // =65104
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x1, v31.d[0]
-<L27>:
-               	bl	 <L27>
-               	mov	x16, #0xfe50            // =65104
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x1, v31.d[1]
-<L28>:
-               	bl	 <L28>
-               	ldur	q31, [x29, #-0xe0]
-               	mvn	v31.16b, v31.16b
-               	mov	x16, #0xfe40            // =65088
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfe40            // =65088
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x1, v31.d[0]
-<L29>:
-               	bl	 <L29>
-               	mov	x16, #0xfe40            // =65088
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x1, v31.d[1]
-<L30>:
-               	bl	 <L30>
-               	ldur	q31, [x29, #-0xf0]
-               	mvn	v31.16b, v31.16b
-               	mov	x16, #0xfe30            // =65072
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfe30            // =65072
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x1, v31.d[0]
-<L31>:
-               	bl	 <L31>
-               	mov	x16, #0xfe30            // =65072
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x1, v31.d[1]
-<L32>:
-               	bl	 <L32>
-               	ldur	q31, [x29, #-0xe0]
-               	ldur	q30, [x29, #-0xf0]
-               	and	v0.16b, v31.16b, v30.16b
-               	ldur	q31, [x29, #-0xe0]
-               	ldur	q30, [x29, #-0xf0]
-               	orr	v1.16b, v31.16b, v30.16b
-               	eor	v31.16b, v0.16b, v1.16b
-               	mov	x16, #0xfe20            // =65056
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfe20            // =65056
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x1, v31.d[0]
-<L33>:
-               	bl	 <L33>
-               	mov	x16, #0xfe20            // =65056
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x1, v31.d[1]
-<L34>:
-               	bl	 <L34>
-               	mov	x19, x0
-               	ldur	q31, [x29, #-0xe0]
-               	mov	x16, #0xfe10            // =65040
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
                	ldur	q31, [x29, #-0xd0]
-               	mov	x16, #0xfe00            // =65024
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	ldur	q31, [x29, #-0xd0]
-               	mov	x16, #0xfdf0            // =65008
+               	mov	x16, #0xfe40            // =65088
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
                	mov	x20, #0x0               // =0
                	cmp	x20, #0x6
-               	b.lo	 <L35>
-               	b	 <L44>
-<L35>:
-               	mov	x16, #0xfe10            // =65040
+               	b.lo	 <L28>
+               	b	 <L37>
+<L28>:
+               	mov	x16, #0xfe60            // =65120
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -531,7 +422,7 @@ Disassembly of section .text:
                	ldur	q31, [x29, #-0xc0]
                	mov	x1, v31.d[0]
                	mul	x2, x0, x1
-               	mov	x16, #0xfe10            // =65040
+               	mov	x16, #0xfe60            // =65120
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -540,7 +431,7 @@ Disassembly of section .text:
                	ldur	q31, [x29, #-0xc0]
                	mov	x1, v31.d[1]
                	mul	x3, x0, x1
-               	mov	x16, #0xfe10            // =65040
+               	mov	x16, #0xfe60            // =65120
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -549,155 +440,155 @@ Disassembly of section .text:
                	mov	v0.d[0], x2
                	mov	v30.16b, v0.16b
                	mov	v30.d[1], x3
-               	mov	x16, #0xfde0            // =64992
+               	mov	x16, #0xfe30            // =65072
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q30, [x29, x16]
-               	mov	x16, #0xfde0            // =64992
+               	mov	x16, #0xfe30            // =65072
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	mov	x1, v31.d[0]
                	mov	x0, x19
-<L36>:
-               	bl	 <L36>
-               	mov	x16, #0xfde0            // =64992
+<L29>:
+               	bl	 <L29>
+               	mov	x16, #0xfe30            // =65072
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	mov	x1, v31.d[1]
-<L37>:
-               	bl	 <L37>
-               	mov	x16, #0xfe00            // =65024
+<L30>:
+               	bl	 <L30>
+               	mov	x16, #0xfe50            // =65104
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov	x16, #0xfde0            // =64992
+               	mov	x16, #0xfe30            // =65072
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q30, [x29, x16]
                	eor	v31.16b, v31.16b, v30.16b
-               	mov	x16, #0xfdd0            // =64976
+               	mov	x16, #0xfe20            // =65056
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xfdd0            // =64976
+               	mov	x16, #0xfe20            // =65056
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	mov	x1, v31.d[0]
-<L38>:
-               	bl	 <L38>
-               	mov	x16, #0xfdd0            // =64976
+<L31>:
+               	bl	 <L31>
+               	mov	x16, #0xfe20            // =65056
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	mov	x1, v31.d[1]
-<L39>:
-               	bl	 <L39>
-               	mov	x16, #0xfdf0            // =65008
+<L32>:
+               	bl	 <L32>
+               	mov	x16, #0xfe40            // =65088
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov	x16, #0xfe10            // =65040
+               	mov	x16, #0xfe60            // =65120
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q30, [x29, x16]
                	add	v31.2d, v31.2d, v30.2d
-               	mov	x16, #0xfdc0            // =64960
+               	mov	x16, #0xfe10            // =65040
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xfdc0            // =64960
+               	mov	x16, #0xfe10            // =65040
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	mov	x1, v31.d[0]
-<L40>:
-               	bl	 <L40>
-               	mov	x16, #0xfdc0            // =64960
+<L33>:
+               	bl	 <L33>
+               	mov	x16, #0xfe10            // =65040
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	mov	x1, v31.d[1]
-<L41>:
-               	bl	 <L41>
-               	mov	x16, #0xfe10            // =65040
+<L34>:
+               	bl	 <L34>
+               	mov	x16, #0xfe60            // =65120
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	ldur	q30, [x29, #-0xf0]
                	add	v31.2d, v31.2d, v30.2d
-               	mov	x16, #0xfdb0            // =64944
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfdb0            // =64944
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x1, v31.d[0]
-<L42>:
-               	bl	 <L42>
-               	mov	x16, #0xfdb0            // =64944
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x1, v31.d[1]
-<L43>:
-               	bl	 <L43>
-               	add	x20, x20, #0x1
-               	mov	x19, x0
-               	mov	x16, #0xfdb0            // =64944
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x16, #0xfe10            // =65040
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfdd0            // =64976
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
                	mov	x16, #0xfe00            // =65024
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xfdc0            // =64960
+               	mov	x16, #0xfe00            // =65024
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov	x16, #0xfdf0            // =65008
+               	mov	x1, v31.d[0]
+<L35>:
+               	bl	 <L35>
+               	mov	x16, #0xfe00            // =65024
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	mov	x1, v31.d[1]
+<L36>:
+               	bl	 <L36>
+               	add	x20, x20, #0x1
+               	mov	x19, x0
+               	mov	x16, #0xfe00            // =65024
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	mov	x16, #0xfe60            // =65120
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	q31, [x29, x16]
+               	mov	x16, #0xfe20            // =65056
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	mov	x16, #0xfe50            // =65104
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	q31, [x29, x16]
+               	mov	x16, #0xfe10            // =65040
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	mov	x16, #0xfe40            // =65088
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
                	cmp	x20, #0x6
-               	b.lo	 <L35>
-<L44>:
+               	b.lo	 <L28>
+<L37>:
                	sub	x20, x29, #0x80
                	str	xzr, [x20]
                	str	xzr, [x20, #0x8]
@@ -708,13 +599,13 @@ Disassembly of section .text:
                	str	xzr, [x20, #0x30]
                	str	xzr, [x20, #0x38]
                	add	x0, x20, #0x0
-               	mov	x16, #0xfe10            // =65040
+               	mov	x16, #0xfe60            // =65120
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	str	q31, [x0]
-               	mov	x16, #0xfe10            // =65040
+               	mov	x16, #0xfe60            // =65120
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -723,7 +614,7 @@ Disassembly of section .text:
                	add	v0.2d, v31.2d, v30.2d
                	add	x0, x20, #0x10
                	str	q0, [x0]
-               	mov	x16, #0xfe10            // =65040
+               	mov	x16, #0xfe60            // =65120
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -732,7 +623,7 @@ Disassembly of section .text:
                	ldur	q31, [x29, #-0xc0]
                	mov	x1, v31.d[0]
                	mul	x2, x0, x1
-               	mov	x16, #0xfe10            // =65040
+               	mov	x16, #0xfe60            // =65120
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -741,7 +632,7 @@ Disassembly of section .text:
                	ldur	q31, [x29, #-0xc0]
                	mov	x1, v31.d[1]
                	mul	x3, x0, x1
-               	mov	x16, #0xfe10            // =65040
+               	mov	x16, #0xfe60            // =65120
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -753,7 +644,7 @@ Disassembly of section .text:
                	add	x0, x20, #0x20
                	str	q1, [x0]
                	add	x0, x20, #0x30
-               	mov	x16, #0xfe00            // =65024
+               	mov	x16, #0xfe50            // =65104
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -761,40 +652,40 @@ Disassembly of section .text:
                	str	q31, [x0]
                	mov	x21, #0x0               // =0
                	cmp	x21, #0x4
-               	b.lo	 <L45>
-               	b	 <L48>
-<L45>:
+               	b.lo	 <L38>
+               	b	 <L41>
+<L38>:
                	mov	x16, #0x10              // =16
                	mul	x0, x21, x16
                	add	x1, x20, x0
                	ldr	q31, [x1]
-               	mov	x16, #0xfda0            // =64928
+               	mov	x16, #0xfdf0            // =65008
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xfda0            // =64928
+               	mov	x16, #0xfdf0            // =65008
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	mov	x1, v31.d[0]
                	mov	x0, x19
-<L46>:
-               	bl	 <L46>
-               	mov	x16, #0xfda0            // =64928
+<L39>:
+               	bl	 <L39>
+               	mov	x16, #0xfdf0            // =65008
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	mov	x1, v31.d[1]
-<L47>:
-               	bl	 <L47>
+<L40>:
+               	bl	 <L40>
                	add	x21, x21, #0x1
                	mov	x19, x0
                	cmp	x21, #0x4
-               	b.lo	 <L45>
-<L48>:
+               	b.lo	 <L38>
+<L41>:
                	sub	x21, x29, #0xb0
                	str	xzr, [x21]
                	str	xzr, [x21, #0x8]
@@ -816,36 +707,36 @@ Disassembly of section .text:
                	str	w17, [x1]
                	ldr	w1, [x0]
                	mov	x0, x19
-<L49>:
-               	bl	 <L49>
+<L42>:
+               	bl	 <L42>
                	ldr	q31, [x20]
-               	mov	x16, #0xfd90            // =64912
+               	mov	x16, #0xfde0            // =64992
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xfd90            // =64912
+               	mov	x16, #0xfde0            // =64992
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	mov	x1, v31.d[0]
-<L50>:
-               	bl	 <L50>
-               	mov	x16, #0xfd90            // =64912
+<L43>:
+               	bl	 <L43>
+               	mov	x16, #0xfde0            // =64992
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	mov	x1, v31.d[1]
-<L51>:
-               	bl	 <L51>
+<L44>:
+               	bl	 <L44>
                	add	x1, x21, #0x20
                	ldr	w2, [x1]
                	mov	w1, w2
-<L52>:
-               	bl	 <L52>
-               	sub	x16, x29, #0x280
+<L45>:
+               	bl	 <L45>
+               	sub	x16, x29, #0x230
                	ldp	x19, x20, [x16]
                	ldur	x21, [x16, #-0x8]
                	mov	sp, x29


### PR DESCRIPTION
The audit changed ARM code generation while leaving its corpus goldens at v4.26.5. Update the 24 reviewed disassemblies for caller-owned aggregate copies, bounded inlining, strict boolean normalization, general floating remainder, conservative trapping effects, and vector-loop overflow checks.

The [per-case review in #3144](https://github.com/briar-systems/mach/issues/3144) maps every changed file to audited source sites and specific emitted instructions. It also explains frame/spill changes and stored-mask reuse. This PR changes exactly those 24 `.dis` files. The other 67 ARM goldens, compiler sources, cases, C references, tool pins, and skips remain unchanged.

Validation: detached audited a958714e with LLVM 22.1.8 reproduced exactly 67 layer B passes and 24 failures. Applying these exact reviewed outputs makes the unchanged layer B oracle pass all 91 existing objects. [Native ARM CI evidence](https://github.com/briar-systems/mach/actions/runs/33987759574/job/101364380064) independently passed 273 structural cells and all 182 o0/o2 runtime comparisons with zero skips. Fresh native ARM CI at 72df28b9 passed all 546 corpus cells with 0 failures and 0 skips, plus the ARM link leg at 24/0/0. Root independently compared all 24 committed files to the reviewed external-disassembler outputs. Other platform failures remain tracked separately in #3135, #3139, #3141 and mach-std#574. LLVM's existing space-before-tab output formatting is preserved byte for byte.

Closes #3144

