### PR TITLE
fix(corpus): verify unsupported debug capability explicitly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -315,6 +315,8 @@ jobs:
       include: ${{ steps.gen.outputs.include }}
     steps:
       - uses: actions/checkout@v6
+      - name: corpus contract tests
+        run: python3 test/test-corpus.py
       - id: gen
         run: echo "include=$(bash test/ci-legs.sh pr)" >> "$GITHUB_OUTPUT"
 

--- a/test/README.md
+++ b/test/README.md
@@ -134,7 +134,13 @@ another layer's output.
 pipelines, plus a third `-g` build. `llvm-readobj --file-header --sections --relocs`
 must parse cleanly, and the class, machine and endianness must match the target.
 SPIR-V goes to `spirv-val` under the environment the module itself declares.
-`llvm-dwarfdump --verify` must pass on the debug build. A `raw` flat image has no
+`llvm-dwarfdump --verify` must pass on supported ELF and Mach-O debug builds.
+The registry declares debug capability separately from execution capability. For
+an unsupported target, the g build must return the specific no-debug-model refusal
+and leave neither an object nor an artifact. The matrix records that cell as SKIP
+with an explicit unsupported reason, and the run summarizes supported, unsupported,
+failed and separately declared skip cells. An unexpected successful debug build or
+another diagnostic fails the cell, so a stale declaration cannot hide new support. A `raw` flat image has no
 external structural oracle wired for it, so layer A records a skip rather than a
 pass: a target reaching this cell needs a `SKIPS` entry, the same as any other
 declared gap.

--- a/test/engines.conf
+++ b/test/engines.conf
@@ -31,15 +31,16 @@
 #           first layer A run over it found a long section-name form llvm rejected
 #           outright, making every object with a constant pool unreadable (#2952).
 #           Mach-O was in exactly that state until #2957.
+#   debug   supported | unsupported. unsupported g cells must verify the compiler refusal.
 #   note    why the row reads the way it does
 #
-# name            isa      os            abi      of   kind    entry         engine             disasm        runner            cadence  decode         note
-x86_64-linux      x86_64   linux         sysv64   -    bin     hosted        native             llvm-objdump  ubuntu-latest     pr     -              the primary host and the leg that also carries the riscv32, spirv and mos6502 columns
-aarch64-linux     aarch64  linux         aapcs64  -    bin     hosted        native             llvm-objdump  ubuntu-24.04-arm  pr     -              native arm silicon: qemu cannot settle aapcs64 or page-size questions
-riscv64-linux     riscv64  linux         lp64d    -    bin     hosted        qemu:qemu-riscv64  llvm-objdump  ubuntu-latest     pr     -              compute evidence only, never ABI evidence
-riscv32           riscv32  freestanding  ilp32d   elf  static  direct        none               llvm-objdump  ubuntu-latest     pr     -              linux declares no riscv32 support and freestanding ships no runtime, so nothing can execute it yet
-x86_64-windows    x86_64   windows       win64    -    bin     hosted        native             llvm-objdump  windows-latest    pr     -              no wine, anywhere, ever
-x86_64-darwin     x86_64   darwin        sysv64   -    bin     hosted        native             llvm-objdump  macos-15-intel    main     ubuntu-latest  metered runner, so the release merge rather than every pull request
-aarch64-darwin    aarch64  darwin        aapcs64  -    bin     hosted        native             llvm-objdump  macos-15          main     ubuntu-latest  metered runner, so the release merge rather than every pull request
-spirv             spirv    freestanding  spirv    -    bin     direct        none               spirv-dis     ubuntu-latest     pr     -              a finished GPU module, not a machine: layers A and B only. THE RUNNER IS A CONSTRAINT, not a preference: the pinned spirv-dis and spirv-val (2026.3) are installable only on linux x86_64, from the Vulkan SDK, so moving this row to ubuntu-24.04-arm needs a source build of SPIRV-Tools first. see tools.lock
-mos6502           mos6502  freestanding  mos6502  -    bin     freestanding  none               da65          ubuntu-latest     pr     -              layers A and B only, and promoting it to an execution engine is follow-up work
+# name            isa      os            abi      of   kind    entry         engine             disasm        runner            cadence  decode         debug         note
+x86_64-linux  x86_64  linux  sysv64  -  bin  hosted  native  llvm-objdump  ubuntu-latest  pr  -  supported  the primary host and the leg that also carries the riscv32, spirv and mos6502 columns
+aarch64-linux  aarch64  linux  aapcs64  -  bin  hosted  native  llvm-objdump  ubuntu-24.04-arm  pr  -  supported  native arm silicon: qemu cannot settle aapcs64 or page-size questions
+riscv64-linux  riscv64  linux  lp64d  -  bin  hosted  qemu:qemu-riscv64  llvm-objdump  ubuntu-latest  pr  -  supported  compute evidence only, never ABI evidence
+riscv32  riscv32  freestanding  ilp32d  elf  static  direct  none  llvm-objdump  ubuntu-latest  pr  -  supported  linux declares no riscv32 support and freestanding ships no runtime, so nothing can execute it yet
+x86_64-windows  x86_64  windows  win64  -  bin  hosted  native  llvm-objdump  windows-latest  pr  -  unsupported  no wine, anywhere, ever
+x86_64-darwin  x86_64  darwin  sysv64  -  bin  hosted  native  llvm-objdump  macos-15-intel  main  ubuntu-latest  supported  metered runner, so the release merge rather than every pull request
+aarch64-darwin  aarch64  darwin  aapcs64  -  bin  hosted  native  llvm-objdump  macos-15  main  ubuntu-latest  supported  metered runner, so the release merge rather than every pull request
+spirv  spirv  freestanding  spirv  -  bin  direct  none  spirv-dis  ubuntu-latest  pr  -  unsupported  a finished GPU module, not a machine: layers A and B only. THE RUNNER IS A CONSTRAINT, not a preference: the pinned spirv-dis and spirv-val (2026.3) are installable only on linux x86_64, from the Vulkan SDK, so moving this row to ubuntu-24.04-arm needs a source build of SPIRV-Tools first. see tools.lock
+mos6502  mos6502  freestanding  mos6502  -  bin  freestanding  none  da65  ubuntu-latest  pr  -  unsupported  layers A and B only, and promoting it to an execution engine is follow-up work

--- a/test/engines.conf
+++ b/test/engines.conf
@@ -34,13 +34,13 @@
 #   debug   supported | unsupported. unsupported g cells must verify the compiler refusal.
 #   note    why the row reads the way it does
 #
-# name            isa      os            abi      of   kind    entry         engine             disasm        runner            cadence  decode         debug         note
-x86_64-linux  x86_64  linux  sysv64  -  bin  hosted  native  llvm-objdump  ubuntu-latest  pr  -  supported  the primary host and the leg that also carries the riscv32, spirv and mos6502 columns
-aarch64-linux  aarch64  linux  aapcs64  -  bin  hosted  native  llvm-objdump  ubuntu-24.04-arm  pr  -  supported  native arm silicon: qemu cannot settle aapcs64 or page-size questions
-riscv64-linux  riscv64  linux  lp64d  -  bin  hosted  qemu:qemu-riscv64  llvm-objdump  ubuntu-latest  pr  -  supported  compute evidence only, never ABI evidence
-riscv32  riscv32  freestanding  ilp32d  elf  static  direct  none  llvm-objdump  ubuntu-latest  pr  -  supported  linux declares no riscv32 support and freestanding ships no runtime, so nothing can execute it yet
-x86_64-windows  x86_64  windows  win64  -  bin  hosted  native  llvm-objdump  windows-latest  pr  -  unsupported  no wine, anywhere, ever
-x86_64-darwin  x86_64  darwin  sysv64  -  bin  hosted  native  llvm-objdump  macos-15-intel  main  ubuntu-latest  supported  metered runner, so the release merge rather than every pull request
-aarch64-darwin  aarch64  darwin  aapcs64  -  bin  hosted  native  llvm-objdump  macos-15  main  ubuntu-latest  supported  metered runner, so the release merge rather than every pull request
-spirv  spirv  freestanding  spirv  -  bin  direct  none  spirv-dis  ubuntu-latest  pr  -  unsupported  a finished GPU module, not a machine: layers A and B only. THE RUNNER IS A CONSTRAINT, not a preference: the pinned spirv-dis and spirv-val (2026.3) are installable only on linux x86_64, from the Vulkan SDK, so moving this row to ubuntu-24.04-arm needs a source build of SPIRV-Tools first. see tools.lock
-mos6502  mos6502  freestanding  mos6502  -  bin  freestanding  none  da65  ubuntu-latest  pr  -  unsupported  layers A and B only, and promoting it to an execution engine is follow-up work
+# name            isa      os            abi      of   kind    entry         engine             disasm        runner            cadence  decode         debug        note
+x86_64-linux    x86_64   linux         sysv64   -    bin     hosted        native             llvm-objdump  ubuntu-latest     pr       -              supported    the primary host and the leg that also carries the riscv32, spirv and mos6502 columns
+aarch64-linux   aarch64  linux         aapcs64  -    bin     hosted        native             llvm-objdump  ubuntu-24.04-arm  pr       -              supported    native arm silicon: qemu cannot settle aapcs64 or page-size questions
+riscv64-linux   riscv64  linux         lp64d    -    bin     hosted        qemu:qemu-riscv64  llvm-objdump  ubuntu-latest     pr       -              supported    compute evidence only, never ABI evidence
+riscv32         riscv32  freestanding  ilp32d   elf  static  direct        none               llvm-objdump  ubuntu-latest     pr       -              supported    linux declares no riscv32 support and freestanding ships no runtime, so nothing can execute it yet
+x86_64-windows  x86_64   windows       win64    -    bin     hosted        native             llvm-objdump  windows-latest    pr       -              unsupported  no wine, anywhere, ever
+x86_64-darwin   x86_64   darwin        sysv64   -    bin     hosted        native             llvm-objdump  macos-15-intel    main     ubuntu-latest  supported    metered runner, so the release merge rather than every pull request
+aarch64-darwin  aarch64  darwin        aapcs64  -    bin     hosted        native             llvm-objdump  macos-15          main     ubuntu-latest  supported    metered runner, so the release merge rather than every pull request
+spirv           spirv    freestanding  spirv    -    bin     direct        none               spirv-dis     ubuntu-latest     pr       -              unsupported  a finished GPU module, not a machine: layers A and B only. THE RUNNER IS A CONSTRAINT, not a preference: the pinned spirv-dis and spirv-val (2026.3) are installable only on linux x86_64, from the Vulkan SDK, so moving this row to ubuntu-24.04-arm needs a source build of SPIRV-Tools first. see tools.lock
+mos6502         mos6502  freestanding  mos6502  -    bin     freestanding  none               da65          ubuntu-latest     pr       -              unsupported  layers A and B only, and promoting it to an execution engine is follow-up work

--- a/test/lib/config.py
+++ b/test/lib/config.py
@@ -43,11 +43,11 @@ def _rows(path):
 
 class Target(object):
     __slots__ = ("name", "isa", "os", "abi", "of", "kind", "entry",
-                 "engine", "engine_cmd", "disasm", "runner", "cadence", "decode", "note")
+                 "engine", "engine_cmd", "disasm", "runner", "cadence", "decode", "debug", "note")
 
     def __init__(self, fields, note):
         (self.name, self.isa, self.os, self.abi, self.of, self.kind,
-         self.entry, engine, self.disasm, self.runner, self.cadence, self.decode) = fields
+         self.entry, engine, self.disasm, self.runner, self.cadence, self.decode, self.debug) = fields
         if ":" in engine:
             self.engine, self.engine_cmd = engine.split(":", 1)
         else:
@@ -74,10 +74,12 @@ def load_engines(path):
     targets = []
     seen = set()
     for lineno, line in _rows(path):
-        fields = line.split(None, 12)
-        if len(fields) != 13:
-            raise ConfigError("%s:%d: expected 13 columns, got %d" % (path, lineno, len(fields)))
-        t = Target(fields[:12], fields[12])
+        fields = line.split(None, 13)
+        if len(fields) != 14:
+            raise ConfigError("%s:%d: expected 14 columns, got %d" % (path, lineno, len(fields)))
+        t = Target(fields[:13], fields[13])
+        if t.debug not in ("supported", "unsupported"):
+            raise ConfigError("%s:%d: debug must be supported|unsupported" % (path, lineno))
         if t.entry not in ("hosted", "direct", "freestanding"):
             raise ConfigError("%s:%d: entry must be hosted|direct|freestanding" % (path, lineno))
         if t.kind not in ("bin", "static"):

--- a/test/lib/driver.py
+++ b/test/lib/driver.py
@@ -21,6 +21,10 @@ import project as projectmod
 CORPUS = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 REPO = os.path.dirname(CORPUS)
 
+NO_DEBUG_MODEL = ("error: debug info was requested, but this target registers no debug model; "
+                  "build without -g or select a target with one")
+DEBUG_UNSUPPORTED = "debug unsupported: compiler refused a target with no registered debug model"
+
 HOST_DIR = {("linux", "x86_64"): "linux-x86_64", ("linux", "aarch64"): "linux-arm64",
             ("darwin", "x86_64"): "darwin-x86_64", ("darwin", "arm64"): "darwin-aarch64",
             ("windows", "amd64"): "windows-x86_64"}
@@ -429,6 +433,16 @@ def run(out_root, matrix_path, only_targets, runner, only_cases, only_layers, bl
     m.save(matrix_path)
     sys.stdout.write(m.render(cases, [t.name for t in targets], wanted_layers) + "\n")
 
+    for t in targets:
+        debug_cells = [c for c in m.cells if c[1] == t.name and c[2:4] == ("a", "g")]
+        if debug_cells:
+            supported = sum(c[4] == "PASS" for c in debug_cells)
+            unsupported = sum(c[4] == "SKIP" and c[6] == DEBUG_UNSUPPORTED for c in debug_cells)
+            failed = sum(c[4] == "FAIL" for c in debug_cells)
+            declared = len(debug_cells) - supported - unsupported - failed
+            sys.stdout.write("debug cells %s: %d supported, %d unsupported, %d failed, %d declared skip\n"
+                             % (t.name, supported, unsupported, failed, declared))
+
     holes = gate(m, cases, targets, wanted_layers, skips)
     ok = True
     for cell in m.failures():
@@ -497,6 +511,20 @@ def layer_a_cells(proj, tools, m, t, case, built, skips):
         if cell_skip(m, skips, case, t.name, "a", profile):
             continue
         ok, log = built.get(profile)
+        if profile == "g" and t.debug == "unsupported":
+            if ok:
+                m.add(case, t.name, "a", profile, "FAIL", "",
+                      "debug build succeeded despite declared unsupported capability")
+            elif first_error(log) != NO_DEBUG_MODEL:
+                m.add(case, t.name, "a", profile, "FAIL", "",
+                      "unsupported debug request failed for another reason: " + first_error(log))
+            elif any(os.path.lexists(p) for p in (proj.object_path(case, t, profile),
+                                                  proj.artifact_path(case, t, profile))):
+                m.add(case, t.name, "a", profile, "FAIL", "",
+                      "unsupported debug request left an object or artifact")
+            else:
+                m.add(case, t.name, "a", profile, "SKIP", "", DEBUG_UNSUPPORTED)
+            continue
         if not ok:
             m.add(case, t.name, "a", profile, "FAIL", "", "build failed: " + first_error(log))
             continue

--- a/test/test-corpus.py
+++ b/test/test-corpus.py
@@ -1,0 +1,80 @@
+import os
+from pathlib import Path
+import sys
+import tempfile
+import unittest
+from unittest.mock import patch
+
+sys.path.insert(0, str(Path(__file__).parent / 'lib'))
+import config
+import driver
+import layers
+from matrix import Matrix
+
+
+class DebugCapability(unittest.TestCase):
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp.cleanup)
+        self.targets = config.load_engines(str(Path(__file__).parent / 'engines.conf'))
+        self.target = next(t for t in self.targets if t.name == 'spirv')
+        self.paths = [os.path.join(self.temp.name, 'object'), os.path.join(self.temp.name, 'artifact')]
+
+    def cells(self, g=(False, driver.NO_DEBUG_MODEL), path=None):
+        if path is not None:
+            Path(self.paths[path]).write_text('partial output')
+        class Project:
+            def object_path(inner, *args): return self.paths[0]
+            def artifact_path(inner, *args): return self.paths[1]
+        class Built:
+            def get(inner, profile): return g if profile == 'g' else (True, '')
+        matrix = Matrix()
+        with patch.object(layers, 'layer_a', return_value=layers.Outcome('PASS', 'oracle accepted')) as oracle:
+            driver.layer_a_cells(Project(), None, matrix, self.target, 'sample/case', Built(), [])
+        return matrix, oracle.call_args_list
+
+    def test_declared_support_is_explicit(self):
+        self.assertEqual({t.name for t in self.targets if t.debug == 'unsupported'},
+                         {'spirv', 'x86_64-windows', 'mos6502'})
+        conf = Path(self.temp.name) / 'engines.conf'
+        conf.write_text('sample x86_64 linux sysv64 - bin hosted native llvm-objdump ubuntu-latest pr - maybe note\n')
+        with self.assertRaisesRegex(config.ConfigError, 'debug must be'):
+            config.load_engines(str(conf))
+
+    def test_refusal_is_unsupported_not_passed(self):
+        matrix, calls = self.cells()
+        self.assertEqual(matrix.counts(), {'PASS': 2, 'FAIL': 0, 'SKIP': 1})
+        self.assertEqual(matrix.cells[-1][3:], ('g', 'SKIP', '', driver.DEBUG_UNSUPPORTED))
+        self.assertEqual(len(calls), 2)
+
+    def test_unexpected_acceptance_fails(self):
+        matrix, calls = self.cells((True, driver.NO_DEBUG_MODEL))
+        self.assertEqual(matrix.cells[-1][4], 'FAIL')
+        self.assertIn('succeeded', matrix.cells[-1][6])
+        self.assertEqual(len(calls), 2)
+
+    def test_other_diagnostic_fails(self):
+        matrix, _ = self.cells((False, 'error: unrelated defect'))
+        self.assertEqual(matrix.cells[-1][4], 'FAIL')
+        self.assertIn('another reason', matrix.cells[-1][6])
+
+    def test_either_partial_output_fails(self):
+        for path in range(2):
+            with self.subTest(path=path):
+                matrix, _ = self.cells(path=path)
+                self.assertEqual(matrix.cells[-1][4], 'FAIL')
+                self.assertIn('left an object or artifact', matrix.cells[-1][6])
+                os.unlink(self.paths[path])
+
+    def test_supported_debug_still_requires_oracle(self):
+        self.target = next(t for t in self.targets if t.name == 'x86_64-linux')
+        matrix, calls = self.cells((True, ''))
+        self.assertEqual(matrix.counts(), {'PASS': 3, 'FAIL': 0, 'SKIP': 0})
+        self.assertEqual(len(calls), 3)
+        self.assertTrue(calls[-1].kwargs['want_dwarf'])
+        matrix, _ = self.cells()
+        self.assertEqual(matrix.cells[-1][4], 'FAIL')
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
The corpus requested successful debug builds from Windows and SPIR-V even though both targets explicitly refuse debug information. This produced 91 Windows and 81 SPIR-V false failure cells.

Declare debug capability per target. Unsupported g cells still invoke the compiler and require the exact no-debug-model refusal with no object or artifact left behind. They appear as explicit unsupported SKIP cells and in a per-target debug summary. Unexpected acceptance, another diagnostic or partial output fails the cell. Supported debug builds retain the existing artifact and external-oracle checks. SPIR-V CFG failures and disassembly mismatches remain failures.

Validation: six Python contract tests pass, including both partial-output locations and supported DWARF validation. Five individual mutations produce runtime assertion failures for acceptance, diagnostic, partial-output, capability dispatch and declaration validation. Existing CI runner assignments remain unchanged. Native CI https://github.com/briar-systems/mach/actions/runs/33993762940 verifies **91 Windows and 81 SPIR-V g cells as explicit unsupported SKIP**, while **91 x86_64 Linux and 91 RISC-V64 Linux g cells still PASS** through their external oracles. Existing non-debug failures remain failures.

Independent released-seed comparison https://github.com/briar-systems/mach/actions/runs/33993871601 verifies the stale-declaration rule: released 4.26.5 accepts all 81 SPIR-V g builds, and the new harness marks all 81 as FAIL for unexpected acceptance. Exact audited `a958714e` refuses those requests and produces the expected 81 unsupported cells. Its 6 floating arithmetic build failures and 12 golden mismatches remain visible. No goldens changed.

Closes #3150
