### PR TITLE
chore(deps): integrate std filesystem and process repairs

### DIFF
--- a/mach.toml
+++ b/mach.toml
@@ -66,4 +66,4 @@ need = []
 
 [dep.std]
 git = "https://github.com/briar-systems/mach-std"
-ref = "branch/main"
+ref = "commit/aac7012d2c6b01dfcb7c7d1db677b0d762a4f955"

--- a/src/lang/publication.mach
+++ b/src/lang/publication.mach
@@ -147,7 +147,7 @@ pub fun writer[W](itn: *intern.Interner, a: *A.Allocator, path: str, ctx: *W,
 
 pub fun subtree(a: *A.Allocator, d: *txn.Descent, inv: *txn.Inventory, dir_mode: i32) R.Result[R.Void, str] {
     val prep_r: R.Result[txn.Transaction, txn.Error] =
-        txn.prepare_subtree(a, ?d.root, d.root_abs, d.first_missing, inv, dir_mode);
+        txn.prepare_subtree(a, ?d.root, d.first_missing, inv, dir_mode);
     if (R.is_err[txn.Transaction, txn.Error](prep_r)) {
         ret R.err[R.Void, str](txn.error_message(R.unwrap_err[txn.Transaction, txn.Error](prep_r)));
     }


### PR DESCRIPTION
Integrate the repaired filesystem transactions and Unicode process environment API from std. Update subtree publication to pass the held Root directly after removal of unused absolute-path state.

This draft pins exact std commit `aac7012d2c6b01dfcb7c7d1db677b0d762a4f955` in both the manifest and gitlink so dependent compiler fixes can be verified together. The final release change must use the tagged std release after its remaining identity precondition issue briar-systems/mach-std#583 is settled. No obsolete subtree adapter is retained.

Validation pending the combined compiler environment fixes and complete bar. `git diff --check` passes.

Closes #3149
