### PR TITLE
test(codegen): reconcile reviewed x64 and RV64 audit goldens

### DIFF
--- a/test/golden/riscv64-linux/call/call_indirect.dis
+++ b/test/golden/riscv64-linux/call/call_indirect.dis
@@ -373,25 +373,25 @@ Disassembly of section .text:
                	ret
 
 <corpus.cases.call.call_indirect.checksum>:
-               	addi	sp, sp, -0x1d0
-               	sd	ra, 0x1c8(sp)
-               	sd	s0, 0x1c0(sp)
-               	addi	s0, sp, 0x1d0
-               	sd	s1, 0x1b8(sp)
-               	sd	s2, 0x1b0(sp)
-               	sd	s3, 0x1a8(sp)
-               	sd	s4, 0x1a0(sp)
-               	sd	s5, 0x198(sp)
-               	sd	s6, 0x190(sp)
-               	sd	s7, 0x188(sp)
-               	sd	s8, 0x180(sp)
-               	sd	s9, 0x178(sp)
-               	sd	s10, 0x170(sp)
-               	sd	s11, 0x168(sp)
-               	fsd	fs0, 0x160(sp)
-               	fsd	fs1, 0x158(sp)
-               	fsd	fs2, 0x150(sp)
-               	fsd	fs3, 0x148(sp)
+               	addi	sp, sp, -0x200
+               	sd	ra, 0x1f8(sp)
+               	sd	s0, 0x1f0(sp)
+               	addi	s0, sp, 0x200
+               	sd	s1, 0x1e8(sp)
+               	sd	s2, 0x1e0(sp)
+               	sd	s3, 0x1d8(sp)
+               	sd	s4, 0x1d0(sp)
+               	sd	s5, 0x1c8(sp)
+               	sd	s6, 0x1c0(sp)
+               	sd	s7, 0x1b8(sp)
+               	sd	s8, 0x1b0(sp)
+               	sd	s9, 0x1a8(sp)
+               	sd	s10, 0x1a0(sp)
+               	sd	s11, 0x198(sp)
+               	fsd	fs0, 0x190(sp)
+               	fsd	fs1, 0x188(sp)
+               	fsd	fs2, 0x180(sp)
+               	fsd	fs3, 0x178(sp)
                	mv	s1, a0
                	auipc	ra, 0x0
                	jalr	ra <corpus.cases.call.call_indirect.checksum+0x50>
@@ -516,12 +516,14 @@ Disassembly of section .text:
                	li	s8, 0x0
                	li	t0, 0xc
                	bltu	s8, t0, 0x708 <.Lpcrel_hi.15+0x28>
-               	j	0x8a4 <.Lpcrel_hi.21+0x48>
+               	j	0x8bc <.Lpcrel_hi.21+0x48>
                	slli	t0, s8, 0x3
                	add	s9, s2, t0
                	ld	a0, 0x0(s9)
                	add	a1, a0, s1
                	li	a0, 0x6
+               	bnez	a0, 0x724 <.Lpcrel_hi.15+0x44>
+               	ebreak
                	remu	s10, a1, a0
                	slli	t0, s10, 0x3
                	add	s11, s3, t0
@@ -530,29 +532,31 @@ Disassembly of section .text:
                	mv	a0, s7
                	jalr	a2
                	mv	t2, a0
-               	sd	t2, -0x188(s0)
-               	ld	t2, -0x188(s0)
+               	sd	t2, -0x1b8(s0)
+               	ld	t2, -0x1b8(s0)
                	mv	a0, s6
-               	ld	t2, -0x188(s0)
+               	ld	t2, -0x1b8(s0)
                	mv	a1, t2
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.15+0x70>
+               	jalr	ra <.Lpcrel_hi.15+0x78>
                	mv	t2, a0
-               	sd	t2, -0x190(s0)
-               	ld	t2, -0x190(s0)
+               	sd	t2, -0x1c0(s0)
+               	ld	t2, -0x1c0(s0)
                	ld	a4, 0x0(s11)
                	ld	a1, 0x0(s9)
-               	ld	t2, -0x188(s0)
+               	ld	t2, -0x1b8(s0)
                	mv	a0, t2
                	jalr	a4
                	mv	a1, a0
-               	ld	t2, -0x190(s0)
+               	ld	t2, -0x1c0(s0)
                	mv	a0, t2
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.15+0xa4>
+               	jalr	ra <.Lpcrel_hi.15+0xac>
                	mv	s9, a0
                	addi	a0, s10, 0x1
                	li	a1, 0x6
+               	bnez	a1, 0x7a8 <.Lpcrel_hi.15+0xc8>
+               	ebreak
                	remu	a3, a0, a1
                	slli	t0, a3, 0x3
                	add	a0, s3, t0
@@ -560,7 +564,7 @@ Disassembly of section .text:
                	slli	t0, s8, 0x3
                	add	a0, s2, t0
                	ld	s11, 0x0(a0)
-               	ld	t2, -0x188(s0)
+               	ld	t2, -0x1b8(s0)
                	mv	a0, t2
                	mv	a1, s11
                	jalr	s10
@@ -569,49 +573,51 @@ Disassembly of section .text:
                	mv	a1, a0
                	mv	a0, s9
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.15+0xf4>
+               	jalr	ra <.Lpcrel_hi.15+0x104>
                	mv	s9, a0
                	slli	t0, s8, 0x3
                	add	a0, s2, t0
                	ld	a1, 0x0(a0)
                	add	a0, a1, s1
                	li	a1, 0x6
+               	bnez	a1, 0x80c <.Lpcrel_hi.15+0x12c>
+               	ebreak
                	remu	a3, a0, a1
                	li	t0, 0x0
-               	beq	a3, t0, 0x85c <.Lpcrel_hi.21>
+               	beq	a3, t0, 0x874 <.Lpcrel_hi.21>
                	li	t0, 0x1
-               	beq	a3, t0, 0x850 <.Lpcrel_hi.20>
+               	beq	a3, t0, 0x868 <.Lpcrel_hi.20>
                	li	t0, 0x2
-               	beq	a3, t0, 0x844 <.Lpcrel_hi.19>
+               	beq	a3, t0, 0x85c <.Lpcrel_hi.19>
                	li	t0, 0x3
-               	beq	a3, t0, 0x838 <.Lpcrel_hi.18>
+               	beq	a3, t0, 0x850 <.Lpcrel_hi.18>
                	li	t0, 0x4
-               	beq	a3, t0, 0x82c <.Lpcrel_hi.17>
+               	beq	a3, t0, 0x844 <.Lpcrel_hi.17>
 
 <.Lpcrel_hi.16>:
                	auipc	s10, 0x0
                	mv	s10, s10
-               	j	0x864 <.Lpcrel_hi.21+0x8>
+               	j	0x87c <.Lpcrel_hi.21+0x8>
 
 <.Lpcrel_hi.17>:
                	auipc	s10, 0x0
                	mv	s10, s10
-               	j	0x864 <.Lpcrel_hi.21+0x8>
+               	j	0x87c <.Lpcrel_hi.21+0x8>
 
 <.Lpcrel_hi.18>:
                	auipc	s10, 0x0
                	mv	s10, s10
-               	j	0x864 <.Lpcrel_hi.21+0x8>
+               	j	0x87c <.Lpcrel_hi.21+0x8>
 
 <.Lpcrel_hi.19>:
                	auipc	s10, 0x0
                	mv	s10, s10
-               	j	0x864 <.Lpcrel_hi.21+0x8>
+               	j	0x87c <.Lpcrel_hi.21+0x8>
 
 <.Lpcrel_hi.20>:
                	auipc	s10, 0x0
                	mv	s10, s10
-               	j	0x864 <.Lpcrel_hi.21+0x8>
+               	j	0x87c <.Lpcrel_hi.21+0x8>
 
 <.Lpcrel_hi.21>:
                	auipc	s10, 0x0
@@ -619,7 +625,7 @@ Disassembly of section .text:
                	slli	t0, s8, 0x3
                	add	a0, s2, t0
                	ld	a1, 0x0(a0)
-               	ld	t2, -0x188(s0)
+               	ld	t2, -0x1b8(s0)
                	mv	a0, t2
                	jalr	s10
                	mv	a1, a0
@@ -628,7 +634,7 @@ Disassembly of section .text:
                	jalr	ra <.Lpcrel_hi.21+0x28>
                	addi	s8, s8, 0x1
                	mv	s6, a0
-               	ld	t2, -0x188(s0)
+               	ld	t2, -0x1b8(s0)
                	mv	s7, t2
                	li	t0, 0xc
                	bltu	s8, t0, 0x708 <.Lpcrel_hi.15+0x28>
@@ -636,6 +642,8 @@ Disassembly of section .text:
                	ld	a1, 0x0(a0)
                	add	a0, a1, s1
                	li	a1, 0x6
+               	bnez	a1, 0x8d4 <.Lpcrel_hi.21+0x60>
+               	ebreak
                	remu	a2, a0, a1
                	slli	t0, a2, 0x3
                	add	a0, s3, t0
@@ -643,14 +651,16 @@ Disassembly of section .text:
                	li	s8, 0x0
                	mv	s9, a1
                	li	t0, 0x8
-               	bltu	s8, t0, 0x8d8 <.Lpcrel_hi.21+0x7c>
-               	j	0x940 <.Lpcrel_hi.21+0xe4>
+               	bltu	s8, t0, 0x8f8 <.Lpcrel_hi.21+0x84>
+               	j	0x968 <.Lpcrel_hi.21+0xf4>
                	slli	t0, s8, 0x3
                	add	a0, s2, t0
                	ld	a1, 0x0(a0)
                	add	a2, a1, s1
                	add	a1, a2, s8
                	li	a2, 0x6
+               	bnez	a2, 0x918 <.Lpcrel_hi.21+0xa4>
+               	ebreak
                	remu	a3, a1, a2
                	slli	t0, a3, 0x3
                	add	a1, s3, t0
@@ -665,26 +675,30 @@ Disassembly of section .text:
                	mv	a0, s6
                	mv	a1, s7
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.21+0xc8>
+               	jalr	ra <.Lpcrel_hi.21+0xd8>
                	addi	s8, s8, 0x1
                	mv	s6, a0
                	mv	s9, s10
                	li	t0, 0x8
-               	bltu	s8, t0, 0x8d8 <.Lpcrel_hi.21+0x7c>
+               	bltu	s8, t0, 0x8f8 <.Lpcrel_hi.21+0x84>
                	li	s3, 0x0
                	li	t0, 0x8
-               	bltu	s3, t0, 0x950 <.Lpcrel_hi.21+0xf4>
-               	j	0xaa0 <.Lpcrel_hi.21+0x244>
+               	bltu	s3, t0, 0x978 <.Lpcrel_hi.21+0x104>
+               	j	0xb08 <.Lpcrel_hi.21+0x294>
                	slli	t0, s3, 0x3
                	add	a0, s2, t0
                	ld	a1, 0x0(a0)
                	add	a2, a1, s1
                	li	a1, 0x2
+               	bnez	a1, 0x994 <.Lpcrel_hi.21+0x120>
+               	ebreak
                	remu	s8, a2, a1
                	ld	a1, 0x0(a0)
                	add	a2, a1, s1
                	addi	a1, a2, 0x1
                	li	a2, 0x2
+               	bnez	a2, 0x9b0 <.Lpcrel_hi.21+0x13c>
+               	ebreak
                	remu	s9, a1, a2
                	addi	s10, s0, -0x150
                	slli	t0, s8, 0x3
@@ -693,19 +707,19 @@ Disassembly of section .text:
                	ld	a1, 0x0(a0)
                	add	a2, a1, s7
                	addi	t2, s0, -0x168
-               	sd	t2, -0x198(s0)
-               	ld	t2, -0x198(s0)
+               	sd	t2, -0x1c8(s0)
+               	ld	t2, -0x1c8(s0)
                	mv	a0, t2
                	mv	a1, a2
                	jalr	s11
-               	ld	t2, -0x198(s0)
-               	ld	t2, -0x198(s0)
+               	ld	t2, -0x1c8(s0)
+               	ld	t2, -0x1c8(s0)
                	ld	a0, 0x0(t2)
                	sd	a0, 0x0(s10)
-               	ld	t2, -0x198(s0)
+               	ld	t2, -0x1c8(s0)
                	ld	a0, 0x8(t2)
                	sd	a0, 0x8(s10)
-               	ld	t2, -0x198(s0)
+               	ld	t2, -0x1c8(s0)
                	ld	a0, 0x10(t2)
                	sd	a0, 0x10(s10)
                	mv	a0, s10
@@ -714,31 +728,37 @@ Disassembly of section .text:
                	ld	s11, 0x0(a0)
                	addi	a0, s10, 0x10
                	ld	t2, 0x0(a0)
-               	sd	t2, -0x1a0(s0)
+               	sd	t2, -0x1d0(s0)
                	mv	a0, s6
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.21+0x198>
+               	jalr	ra <.Lpcrel_hi.21+0x1b8>
                	mv	a1, s11
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.21+0x1a4>
-               	ld	t2, -0x1a0(s0)
+               	jalr	ra <.Lpcrel_hi.21+0x1c4>
+               	ld	t2, -0x1d0(s0)
                	mv	a1, t2
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.21+0x1b4>
+               	jalr	ra <.Lpcrel_hi.21+0x1d4>
                	mv	s11, a0
                	slli	t0, s9, 0x3
                	add	t2, s4, t0
-               	sd	t2, -0x1a8(s0)
-               	ld	t2, -0x1a8(s0)
+               	sd	t2, -0x1d8(s0)
+               	ld	t2, -0x1d8(s0)
                	ld	s9, 0x0(t2)
-               	mv	a0, s10
+               	ld	a0, 0x0(s10)
+               	sd	a0, -0x180(s0)
+               	ld	a0, 0x8(s10)
+               	sd	a0, -0x178(s0)
+               	ld	a0, 0x10(s10)
+               	sd	a0, -0x170(s0)
+               	addi	a0, s0, -0x180
                	jalr	s9
                	mv	a1, a0
                	mv	a0, s11
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.21+0x1e4>
+               	jalr	ra <.Lpcrel_hi.21+0x21c>
                	mv	s9, a0
-               	ld	t2, -0x1a8(s0)
+               	ld	t2, -0x1d8(s0)
                	ld	s10, 0x0(t2)
                	slli	t0, s8, 0x3
                	add	a0, s5, t0
@@ -746,23 +766,29 @@ Disassembly of section .text:
                	slli	t0, s3, 0x3
                	add	a0, s2, t0
                	ld	a1, 0x0(a0)
-               	addi	s11, s0, -0x180
+               	addi	s11, s0, -0x198
                	mv	a0, s11
                	jalr	s8
-               	mv	a0, s11
+               	ld	a0, 0x0(s11)
+               	sd	a0, -0x1b0(s0)
+               	ld	a0, 0x8(s11)
+               	sd	a0, -0x1a8(s0)
+               	ld	a0, 0x10(s11)
+               	sd	a0, -0x1a0(s0)
+               	addi	a0, s0, -0x1b0
                	jalr	s10
                	mv	a1, a0
                	mv	a0, s9
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.21+0x22c>
+               	jalr	ra <.Lpcrel_hi.21+0x27c>
                	addi	s3, s3, 0x1
                	mv	s6, a0
                	li	t0, 0x8
-               	bltu	s3, t0, 0x950 <.Lpcrel_hi.21+0xf4>
+               	bltu	s3, t0, 0x978 <.Lpcrel_hi.21+0x104>
                	li	s3, 0x0
                	li	t0, 0x4
-               	bltu	s3, t0, 0xab0 <.Lpcrel_hi.21+0x254>
-               	j	0xd2c <.Lpcrel_hi.25+0xf8>
+               	bltu	s3, t0, 0xb18 <.Lpcrel_hi.21+0x2a4>
+               	j	0xd94 <.Lpcrel_hi.25+0xf8>
                	slli	t0, s3, 0x3
                	add	a0, s2, t0
                	ld	a1, 0x0(a0)
@@ -801,7 +827,7 @@ Disassembly of section .text:
                	fmv.w.x	ft10, t0
                	fsub.s	fs3, ft0, ft10
                	xor	t2, s4, s7
-               	sd	t2, -0x1b0(s0)
+               	sd	t2, -0x1e0(s0)
                	auipc	ra, 0x0
                	jalr	ra <.Lpcrel_hi.23+0x34>
                	mv	a1, s4
@@ -837,7 +863,7 @@ Disassembly of section .text:
                	fmv.s	fa0, fs3
                	auipc	ra, 0x0
                	jalr	ra <.Lpcrel_hi.23+0xb8>
-               	ld	t2, -0x1b0(s0)
+               	ld	t2, -0x1e0(s0)
                	mv	a1, t2
                	auipc	ra, 0x0
                	jalr	ra <.Lpcrel_hi.23+0xc8>
@@ -873,7 +899,7 @@ Disassembly of section .text:
                	fdiv.d	fs2, ft0, ft10
                	sext.w	s11, s4
                	not	t2, s4
-               	sd	t2, -0x1b8(s0)
+               	sd	t2, -0x1e8(s0)
                	li	t0, 0x3ff
                	and	a0, s4, t0
                	fcvt.s.lu	ft0, a0
@@ -881,7 +907,7 @@ Disassembly of section .text:
                	fmv.w.x	ft10, t0
                	fsub.s	fs3, ft0, ft10
                	xor	t2, s4, s7
-               	sd	t2, -0x1c0(s0)
+               	sd	t2, -0x1f0(s0)
                	auipc	ra, 0x0
                	jalr	ra <.Lpcrel_hi.25+0x38>
                	mv	a1, s4
@@ -911,14 +937,14 @@ Disassembly of section .text:
                	mv	a1, s11
                	auipc	ra, 0x0
                	jalr	ra <.Lpcrel_hi.25+0xa4>
-               	ld	t2, -0x1b8(s0)
+               	ld	t2, -0x1e8(s0)
                	mv	a1, t2
                	auipc	ra, 0x0
                	jalr	ra <.Lpcrel_hi.25+0xb4>
                	fmv.s	fa0, fs3
                	auipc	ra, 0x0
                	jalr	ra <.Lpcrel_hi.25+0xc0>
-               	ld	t2, -0x1c0(s0)
+               	ld	t2, -0x1f0(s0)
                	mv	a1, t2
                	auipc	ra, 0x0
                	jalr	ra <.Lpcrel_hi.25+0xd0>
@@ -929,24 +955,24 @@ Disassembly of section .text:
                	addi	s3, s3, 0x1
                	mv	s6, a0
                	li	t0, 0x4
-               	bltu	s3, t0, 0xab0 <.Lpcrel_hi.21+0x254>
+               	bltu	s3, t0, 0xb18 <.Lpcrel_hi.21+0x2a4>
                	mv	a0, s6
-               	ld	s1, 0x1b8(sp)
-               	ld	s2, 0x1b0(sp)
-               	ld	s3, 0x1a8(sp)
-               	ld	s4, 0x1a0(sp)
-               	ld	s5, 0x198(sp)
-               	ld	s6, 0x190(sp)
-               	ld	s7, 0x188(sp)
-               	ld	s8, 0x180(sp)
-               	ld	s9, 0x178(sp)
-               	ld	s10, 0x170(sp)
-               	ld	s11, 0x168(sp)
-               	fld	fs0, 0x160(sp)
-               	fld	fs1, 0x158(sp)
-               	fld	fs2, 0x150(sp)
-               	fld	fs3, 0x148(sp)
-               	ld	ra, 0x1c8(sp)
-               	ld	s0, 0x1c0(sp)
-               	addi	sp, sp, 0x1d0
+               	ld	s1, 0x1e8(sp)
+               	ld	s2, 0x1e0(sp)
+               	ld	s3, 0x1d8(sp)
+               	ld	s4, 0x1d0(sp)
+               	ld	s5, 0x1c8(sp)
+               	ld	s6, 0x1c0(sp)
+               	ld	s7, 0x1b8(sp)
+               	ld	s8, 0x1b0(sp)
+               	ld	s9, 0x1a8(sp)
+               	ld	s10, 0x1a0(sp)
+               	ld	s11, 0x198(sp)
+               	fld	fs0, 0x190(sp)
+               	fld	fs1, 0x188(sp)
+               	fld	fs2, 0x180(sp)
+               	fld	fs3, 0x178(sp)
+               	ld	ra, 0x1f8(sp)
+               	ld	s0, 0x1f0(sp)
+               	addi	sp, sp, 0x200
                	ret

--- a/test/golden/riscv64-linux/call/call_mixed.dis
+++ b/test/golden/riscv64-linux/call/call_mixed.dis
@@ -400,40 +400,46 @@ Disassembly of section .text:
                	ret
 
 <corpus.cases.call.call_mixed.checksum>:
-               	addi	sp, sp, -0x260
-               	sd	ra, 0x258(sp)
-               	sd	s0, 0x250(sp)
-               	addi	s0, sp, 0x260
-               	sd	s1, 0x248(sp)
-               	sd	s2, 0x240(sp)
-               	sd	s3, 0x238(sp)
-               	sd	s4, 0x230(sp)
-               	sd	s5, 0x228(sp)
-               	sd	s6, 0x220(sp)
-               	sd	s7, 0x218(sp)
-               	sd	s8, 0x210(sp)
-               	sd	s9, 0x208(sp)
-               	sd	s10, 0x200(sp)
-               	sd	s11, 0x1f8(sp)
+               	addi	sp, sp, -0x310
+               	sd	ra, 0x308(sp)
+               	sd	s0, 0x300(sp)
+               	addi	s0, sp, 0x310
+               	sd	s1, 0x2f8(sp)
+               	sd	s2, 0x2f0(sp)
+               	sd	s3, 0x2e8(sp)
+               	sd	s4, 0x2e0(sp)
+               	sd	s5, 0x2d8(sp)
+               	sd	s6, 0x2d0(sp)
+               	sd	s7, 0x2c8(sp)
+               	sd	s8, 0x2c0(sp)
+               	sd	s9, 0x2b8(sp)
+               	sd	s10, 0x2b0(sp)
+               	sd	s11, 0x2a8(sp)
+               	fsd	fs0, 0x2a0(sp)
+               	fsd	fs1, 0x298(sp)
+               	fsd	fs2, 0x290(sp)
+               	fsd	fs3, 0x288(sp)
+               	fsd	fs4, 0x280(sp)
+               	fsd	fs5, 0x278(sp)
                	mv	s1, a0
-               	addi	s2, s0, -0x74
-               	addi	s3, s0, -0x84
-               	addi	s4, s0, -0x8c
-               	addi	a1, s0, -0x98
-               	addi	a1, s0, -0xa8
-               	addi	a1, s0, -0xb0
-               	addi	s5, s0, -0xbc
-               	addi	s6, s0, -0xcc
-               	addi	s7, s0, -0xd4
+               	addi	s2, s0, -0xa4
+               	addi	s3, s0, -0xb4
+               	addi	s4, s0, -0xbc
+               	addi	a1, s0, -0xc8
+               	addi	a1, s0, -0xd8
                	addi	a1, s0, -0xe0
-               	addi	a1, s0, -0xf0
-               	addi	a1, s0, -0xf8
-               	addi	a1, s0, -0x104
-               	addi	a1, s0, -0x114
-               	addi	a1, s0, -0x11c
+               	addi	s5, s0, -0xec
+               	addi	s6, s0, -0xfc
+               	addi	s7, s0, -0x104
+               	addi	a1, s0, -0x110
+               	addi	a1, s0, -0x120
+               	addi	a1, s0, -0x128
+               	addi	a1, s0, -0x134
+               	addi	a1, s0, -0x144
+               	addi	a1, s0, -0x14c
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_mixed.checksum+0x7c>
-               	addi	s8, s0, -0x1e0
+               	jalr	ra <corpus.cases.call.call_mixed.checksum+0x94>
+               	addi	s8, s0, -0x210
                	sd	zero, 0x0(s8)
                	sd	zero, 0x8(s8)
                	sd	zero, 0x10(s8)
@@ -460,8 +466,8 @@ Disassembly of section .text:
                	sd	zero, 0xb8(s8)
                	li	a1, 0x0
                	li	t0, 0x18
-               	bltu	a1, t0, 0x6fc <corpus.cases.call.call_mixed.checksum+0xf8>
-               	j	0x760 <corpus.cases.call.call_mixed.checksum+0x15c>
+               	bltu	a1, t0, 0x714 <corpus.cases.call.call_mixed.checksum+0x110>
+               	j	0x778 <corpus.cases.call.call_mixed.checksum+0x174>
                	lui	t0, 0x5852
                	addiw	t0, t0, -0xbd
                	slli	t0, t0, 0xc
@@ -486,17 +492,18 @@ Disassembly of section .text:
                	sd	a2, 0x0(a3)
                	addi	a1, a1, 0x1
                	li	t0, 0x18
-               	bltu	a1, t0, 0x6fc <corpus.cases.call.call_mixed.checksum+0xf8>
+               	bltu	a1, t0, 0x714 <corpus.cases.call.call_mixed.checksum+0x110>
                	mv	s9, a0
                	li	s10, 0x0
                	li	s11, 0x0
                	li	t0, 0x3
-               	bltu	s11, t0, 0x778 <corpus.cases.call.call_mixed.checksum+0x174>
-               	j	0xc74 <.Lpcrel_hi.9+0x8c>
+               	bltu	s11, t0, 0x790 <corpus.cases.call.call_mixed.checksum+0x18c>
+               	j	0xc84 <.Lpcrel_hi.9+0xbc>
                	li	t0, 0xb
                	mul	a0, s11, t0
-               	add	a1, a0, s1
-               	addi	a0, s0, -0x1ec
+               	add	t2, a0, s1
+               	sd	t2, -0x278(s0)
+               	addi	a0, s0, -0x21c
                	addi	a2, s8, 0x80
                	ld	a3, 0x0(a2)
                	lui	t0, 0x1
@@ -551,7 +558,7 @@ Disassembly of section .text:
                	flw	ft0, 0x0(a2)
                	addi	a0, s2, 0x8
                	fsw	ft0, 0x0(a0)
-               	addi	a0, s0, -0x208
+               	addi	a0, s0, -0x238
                	addi	a2, s8, 0x98
                	ld	a3, 0x0(a2)
                	lui	t0, 0x1
@@ -624,211 +631,208 @@ Disassembly of section .text:
                	flw	ft0, 0x0(a2)
                	addi	a0, s3, 0xc
                	fsw	ft0, 0x0(a0)
-               	addi	a0, s0, -0x220
-               	addi	a2, s8, 0xb8
-               	ld	a3, 0x0(a2)
+               	addi	t2, s0, -0x250
+               	sd	t2, -0x280(s0)
+               	addi	a0, s8, 0xb8
+               	ld	a3, 0x0(a0)
                	lui	t0, 0x1
                	addiw	t0, t0, -0x1
-               	and	a2, a3, t0
-               	fcvt.s.lu	ft0, a2
+               	and	a0, a3, t0
+               	fcvt.s.lu	ft0, a0
                	lui	t0, 0x45000
                	fmv.w.x	ft10, t0
                	fsub.s	ft1, ft0, ft10
                	lui	t0, 0x41000
                	fmv.w.x	ft10, t0
                	fdiv.s	ft0, ft1, ft10
-               	mv	a2, a0
-               	fsw	ft0, 0x0(a2)
-               	mv	a2, s8
-               	ld	a3, 0x0(a2)
-               	add	a2, a3, a1
-               	lui	t0, 0x1
-               	addiw	t0, t0, -0x1
-               	and	a3, a2, t0
-               	fcvt.s.lu	ft0, a3
-               	lui	t0, 0x45000
-               	fmv.w.x	ft10, t0
-               	fsub.s	ft1, ft0, ft10
-               	lui	t0, 0x41000
-               	fmv.w.x	ft10, t0
-               	fdiv.s	ft0, ft1, ft10
-               	addi	a2, a0, 0x4
-               	fsw	ft0, 0x0(a2)
-               	mv	a2, a0
-               	flw	ft0, 0x0(a2)
-               	mv	a2, s4
-               	fsw	ft0, 0x0(a2)
-               	addi	a2, a0, 0x4
-               	flw	ft0, 0x0(a2)
+               	ld	t2, -0x280(s0)
+               	mv	a0, t2
+               	fsw	ft0, 0x0(a0)
+               	mv	t2, s8
+               	sd	t2, -0x288(s0)
+               	ld	t2, -0x288(s0)
+               	ld	a0, 0x0(t2)
+               	ld	t2, -0x278(s0)
+               	add	a4, a0, t2
+               	mv	a0, a4
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.call.call_mixed.checksum+0x3fc>
+               	ld	t2, -0x280(s0)
+               	addi	a0, t2, 0x4
+               	fsw	fa0, 0x0(a0)
+               	ld	t2, -0x280(s0)
+               	mv	a0, t2
+               	flw	ft0, 0x0(a0)
+               	mv	a0, s4
+               	fsw	ft0, 0x0(a0)
+               	ld	t2, -0x280(s0)
+               	addi	a0, t2, 0x4
+               	flw	ft0, 0x0(a0)
                	addi	a0, s4, 0x4
                	fsw	ft0, 0x0(a0)
-               	mv	a0, s8
-               	ld	a2, 0x0(a0)
-               	add	a0, a2, a1
-               	addi	a2, s8, 0x8
-               	ld	a3, 0x0(a2)
-               	lui	t0, 0x1
-               	addiw	t0, t0, -0x1
-               	and	a2, a3, t0
-               	fcvt.s.lu	ft0, a2
-               	lui	t0, 0x45000
-               	fmv.w.x	ft10, t0
-               	fsub.s	ft1, ft0, ft10
-               	lui	t0, 0x41000
-               	fmv.w.x	ft10, t0
-               	fdiv.s	ft0, ft1, ft10
-               	addi	a2, s8, 0x10
-               	ld	a3, 0x0(a2)
-               	sext.w	a2, a3
-               	addi	a3, s8, 0x18
-               	ld	a4, 0x0(a3)
+               	ld	t2, -0x288(s0)
+               	ld	a0, 0x0(t2)
+               	ld	t3, -0x278(s0)
+               	add	t2, a0, t3
+               	sd	t2, -0x290(s0)
+               	addi	a0, s8, 0x8
+               	ld	a3, 0x0(a0)
+               	mv	a0, a3
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.call.call_mixed.checksum+0x458>
+               	fmv.s	fs0, fa0
+               	addi	a0, s8, 0x10
+               	ld	a3, 0x0(a0)
+               	sext.w	t2, a3
+               	sd	t2, -0x298(s0)
+               	addi	a0, s8, 0x18
+               	ld	a3, 0x0(a0)
                	lui	t0, 0x100
                	addiw	t0, t0, -0x1
-               	and	a3, a4, t0
-               	fcvt.d.lu	ft1, a3
+               	and	a0, a3, t0
+               	fcvt.d.lu	ft0, a0
 
 <.Lpcrel_hi.2>:
                	auipc	t0, 0x0
                	fld	ft10, 0x0(t0)
-               	fsub.d	ft2, ft1, ft10
+               	fsub.d	ft1, ft0, ft10
 
 <.Lpcrel_hi.3>:
                	auipc	t0, 0x0
                	fld	ft10, 0x0(t0)
-               	fdiv.d	fa1, ft2, ft10
-               	addi	a3, s8, 0x20
-               	ld	a4, 0x0(a3)
-               	addi	a3, s8, 0x28
-               	ld	a5, 0x0(a3)
-               	lui	t0, 0x1
-               	addiw	t0, t0, -0x1
-               	and	a3, a5, t0
-               	fcvt.s.lu	ft1, a3
-               	lui	t0, 0x45000
-               	fmv.w.x	ft10, t0
-               	fsub.s	ft2, ft1, ft10
-               	lui	t0, 0x41000
-               	fmv.w.x	ft10, t0
-               	fdiv.s	ft1, ft2, ft10
-               	addi	a3, s8, 0x30
-               	ld	a5, 0x0(a3)
-               	sext.w	a6, a5
-               	addi	a3, s8, 0x38
-               	ld	a5, 0x0(a3)
+               	fdiv.d	fs1, ft1, ft10
+               	addi	a0, s8, 0x20
+               	ld	t2, 0x0(a0)
+               	sd	t2, -0x2a0(s0)
+               	addi	a0, s8, 0x28
+               	ld	a5, 0x0(a0)
+               	mv	a0, a5
+               	auipc	ra, 0x0
+               	jalr	ra <.Lpcrel_hi.3+0x24>
+               	fmv.s	fs2, fa0
+               	addi	a0, s8, 0x30
+               	ld	a5, 0x0(a0)
+               	sext.w	t2, a5
+               	sd	t2, -0x2a8(s0)
+               	addi	a0, s8, 0x38
+               	ld	a5, 0x0(a0)
                	lui	t0, 0x100
                	addiw	t0, t0, -0x1
-               	and	a3, a5, t0
-               	fcvt.d.lu	ft2, a3
+               	and	a0, a5, t0
+               	fcvt.d.lu	ft0, a0
 
 <.Lpcrel_hi.4>:
                	auipc	t0, 0x0
                	fld	ft10, 0x0(t0)
-               	fsub.d	ft3, ft2, ft10
+               	fsub.d	ft1, ft0, ft10
 
 <.Lpcrel_hi.5>:
                	auipc	t0, 0x0
                	fld	ft10, 0x0(t0)
-               	fdiv.d	fa3, ft3, ft10
-               	addi	a3, s8, 0x40
-               	ld	a7, 0x0(a3)
-               	addi	a3, s8, 0x48
-               	ld	a5, 0x0(a3)
-               	lui	t0, 0x1
-               	addiw	t0, t0, -0x1
-               	and	a3, a5, t0
-               	fcvt.s.lu	ft2, a3
-               	lui	t0, 0x45000
-               	fmv.w.x	ft10, t0
-               	fsub.s	ft3, ft2, ft10
-               	lui	t0, 0x41000
-               	fmv.w.x	ft10, t0
-               	fdiv.s	ft2, ft3, ft10
-               	addi	a3, s8, 0x50
-               	ld	a5, 0x0(a3)
-               	sext.w	t5, a5
-               	addi	a3, s8, 0x58
-               	ld	a5, 0x0(a3)
+               	fdiv.d	fs3, ft1, ft10
+               	addi	a0, s8, 0x40
+               	ld	t2, 0x0(a0)
+               	sd	t2, -0x2b0(s0)
+               	addi	a0, s8, 0x48
+               	ld	a5, 0x0(a0)
+               	mv	a0, a5
+               	auipc	ra, 0x0
+               	jalr	ra <.Lpcrel_hi.5+0x24>
+               	fmv.s	fs4, fa0
+               	addi	a0, s8, 0x50
+               	ld	a5, 0x0(a0)
+               	sext.w	t2, a5
+               	sd	t2, -0x2b8(s0)
+               	addi	a0, s8, 0x58
+               	ld	a5, 0x0(a0)
                	lui	t0, 0x100
                	addiw	t0, t0, -0x1
-               	and	a3, a5, t0
-               	fcvt.d.lu	ft3, a3
+               	and	a0, a5, t0
+               	fcvt.d.lu	ft0, a0
 
 <.Lpcrel_hi.6>:
                	auipc	t0, 0x0
                	fld	ft10, 0x0(t0)
-               	fsub.d	ft4, ft3, ft10
+               	fsub.d	ft1, ft0, ft10
 
 <.Lpcrel_hi.7>:
                	auipc	t0, 0x0
                	fld	ft10, 0x0(t0)
-               	fdiv.d	fa5, ft4, ft10
-               	addi	a3, s8, 0x60
-               	ld	t6, 0x0(a3)
-               	addi	a3, s8, 0x68
-               	ld	a5, 0x0(a3)
-               	lui	t0, 0x1
-               	addiw	t0, t0, -0x1
-               	and	a3, a5, t0
-               	fcvt.s.lu	ft3, a3
-               	lui	t0, 0x45000
-               	fmv.w.x	ft10, t0
-               	fsub.s	ft4, ft3, ft10
-               	lui	t0, 0x41000
-               	fmv.w.x	ft10, t0
-               	fdiv.s	ft3, ft4, ft10
-               	addi	a3, s8, 0x70
-               	ld	a5, 0x0(a3)
+               	fdiv.d	fs5, ft1, ft10
+               	addi	a0, s8, 0x60
+               	ld	t2, 0x0(a0)
+               	sd	t2, -0x2c0(s0)
+               	addi	a0, s8, 0x68
+               	ld	a5, 0x0(a0)
+               	mv	a0, a5
+               	auipc	ra, 0x0
+               	jalr	ra <.Lpcrel_hi.7+0x24>
+               	fmv.s	ft0, fa0
+               	addi	a0, s8, 0x70
+               	ld	a5, 0x0(a0)
                	sext.w	t2, a5
-               	sd	t2, -0x230(s0)
-               	addi	a3, s8, 0x78
-               	ld	a5, 0x0(a3)
+               	sd	t2, -0x260(s0)
+               	addi	a0, s8, 0x78
+               	ld	a5, 0x0(a0)
                	lui	t0, 0x100
                	addiw	t0, t0, -0x1
-               	and	a3, a5, t0
-               	fcvt.d.lu	ft4, a3
+               	and	a0, a5, t0
+               	fcvt.d.lu	ft1, a0
 
 <.Lpcrel_hi.8>:
                	auipc	t0, 0x0
                	fld	ft10, 0x0(t0)
-               	fsub.d	ft5, ft4, ft10
+               	fsub.d	ft2, ft1, ft10
 
 <.Lpcrel_hi.9>:
                	auipc	t0, 0x0
                	fld	ft10, 0x0(t0)
-               	fdiv.d	fa7, ft5, ft10
-               	addi	a3, s8, 0x8
-               	ld	a5, 0x0(a3)
-               	add	t2, a5, a1
-               	sd	t2, -0x238(s0)
-               	fmv.s	fa0, ft0
-               	mv	a1, a2
+               	fdiv.d	fa7, ft2, ft10
+               	addi	a0, s8, 0x8
+               	ld	a5, 0x0(a0)
+               	ld	t3, -0x278(s0)
+               	add	t2, a5, t3
+               	sd	t2, -0x268(s0)
+               	ld	t2, -0x290(s0)
+               	mv	a0, t2
+               	fmv.s	fa0, fs0
+               	ld	t2, -0x298(s0)
+               	mv	a1, t2
+               	fmv.d	fa1, fs1
                	mv	a2, s2
-               	mv	a3, a4
-               	fmv.s	fa2, ft1
-               	mv	a4, a6
+               	ld	t2, -0x2a0(s0)
+               	mv	a3, t2
+               	fmv.s	fa2, fs2
+               	ld	t2, -0x2a8(s0)
+               	mv	a4, t2
                	mv	a5, s3
-               	mv	a6, a7
-               	fmv.s	fa4, ft2
-               	mv	a7, t5
+               	fmv.d	fa3, fs3
+               	ld	t2, -0x2b0(s0)
+               	mv	a6, t2
+               	fmv.s	fa4, fs4
+               	ld	t2, -0x2b8(s0)
+               	mv	a7, t2
+               	fmv.d	fa5, fs5
                	sd	s4, 0x0(sp)
-               	sd	t6, 0x8(sp)
-               	fmv.s	fa6, ft3
-               	ld	t2, -0x230(s0)
+               	ld	t2, -0x2c0(s0)
+               	sd	t2, 0x8(sp)
+               	fmv.s	fa6, ft0
+               	ld	t2, -0x260(s0)
                	sd	t2, 0x10(sp)
-               	ld	t2, -0x238(s0)
+               	ld	t2, -0x268(s0)
                	sd	t2, 0x18(sp)
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.9+0x60>
+               	jalr	ra <.Lpcrel_hi.9+0x90>
                	mv	s10, a0
                	mv	a0, s9
                	mv	a1, s10
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.9+0x74>
+               	jalr	ra <.Lpcrel_hi.9+0xa4>
                	addi	s11, s11, 0x1
                	mv	s9, a0
                	li	t0, 0x3
-               	bltu	s11, t0, 0x778 <corpus.cases.call.call_mixed.checksum+0x174>
-               	addi	a0, s0, -0x1f8
+               	bltu	s11, t0, 0x790 <corpus.cases.call.call_mixed.checksum+0x18c>
+               	addi	a0, s0, -0x228
                	lui	t0, 0x1
                	addiw	t0, t0, -0x1
                	and	a1, s10, t0
@@ -881,7 +885,7 @@ Disassembly of section .text:
                	flw	ft0, 0x0(a1)
                	addi	a0, s5, 0x8
                	fsw	ft0, 0x0(a0)
-               	addi	a0, s0, -0x218
+               	addi	a0, s0, -0x248
                	addi	a1, s8, 0x20
                	ld	a2, 0x0(a1)
                	lui	t0, 0x1
@@ -954,50 +958,12 @@ Disassembly of section .text:
                	flw	ft0, 0x0(a1)
                	addi	a0, s6, 0xc
                	fsw	ft0, 0x0(a0)
-               	addi	a0, s0, -0x228
-               	addi	a1, s8, 0x40
-               	ld	a2, 0x0(a1)
-               	lui	t0, 0x1
-               	addiw	t0, t0, -0x1
-               	and	a1, a2, t0
-               	fcvt.s.lu	ft0, a1
-               	lui	t0, 0x45000
-               	fmv.w.x	ft10, t0
-               	fsub.s	ft1, ft0, ft10
-               	lui	t0, 0x41000
-               	fmv.w.x	ft10, t0
-               	fdiv.s	ft0, ft1, ft10
-               	mv	a1, a0
-               	fsw	ft0, 0x0(a1)
-               	addi	a1, s8, 0x48
-               	ld	a2, 0x0(a1)
-               	lui	t0, 0x1
-               	addiw	t0, t0, -0x1
-               	and	a1, a2, t0
-               	fcvt.s.lu	ft0, a1
-               	lui	t0, 0x45000
-               	fmv.w.x	ft10, t0
-               	fsub.s	ft1, ft0, ft10
-               	lui	t0, 0x41000
-               	fmv.w.x	ft10, t0
-               	fdiv.s	ft0, ft1, ft10
-               	addi	a1, a0, 0x4
-               	fsw	ft0, 0x0(a1)
-               	mv	a1, a0
-               	flw	ft0, 0x0(a1)
-               	mv	a1, s7
-               	fsw	ft0, 0x0(a1)
-               	addi	a1, a0, 0x4
-               	flw	ft0, 0x0(a1)
-               	addi	a0, s7, 0x4
-               	fsw	ft0, 0x0(a0)
-               	mv	a0, s8
+               	addi	s1, s0, -0x258
+               	addi	a0, s8, 0x40
                	ld	a1, 0x0(a0)
-               	addi	a0, s8, 0x8
-               	ld	a2, 0x0(a0)
                	lui	t0, 0x1
                	addiw	t0, t0, -0x1
-               	and	a0, a2, t0
+               	and	a0, a1, t0
                	fcvt.s.lu	ft0, a0
                	lui	t0, 0x45000
                	fmv.w.x	ft10, t0
@@ -1005,301 +971,314 @@ Disassembly of section .text:
                	lui	t0, 0x41000
                	fmv.w.x	ft10, t0
                	fdiv.s	ft0, ft1, ft10
+               	mv	a0, s1
+               	fsw	ft0, 0x0(a0)
+               	addi	a0, s8, 0x48
+               	ld	a1, 0x0(a0)
+               	mv	a0, a1
+               	auipc	ra, 0x0
+               	jalr	ra <.Lpcrel_hi.9+0x2fc>
+               	addi	a0, s1, 0x4
+               	fsw	fa0, 0x0(a0)
+               	mv	a0, s1
+               	flw	ft0, 0x0(a0)
+               	mv	a0, s7
+               	fsw	ft0, 0x0(a0)
+               	addi	a0, s1, 0x4
+               	flw	ft0, 0x0(a0)
+               	addi	a0, s7, 0x4
+               	fsw	ft0, 0x0(a0)
+               	mv	a0, s8
+               	ld	s1, 0x0(a0)
+               	addi	a0, s8, 0x8
+               	ld	a1, 0x0(a0)
+               	mv	a0, a1
+               	auipc	ra, 0x0
+               	jalr	ra <.Lpcrel_hi.9+0x340>
+               	fmv.s	fs0, fa0
                	addi	a0, s8, 0x10
-               	ld	a2, 0x0(a0)
-               	sext.w	a3, a2
+               	ld	a1, 0x0(a0)
+               	sext.w	s2, a1
                	addi	a0, s8, 0x18
-               	ld	a2, 0x0(a0)
+               	ld	a1, 0x0(a0)
                	lui	t0, 0x100
                	addiw	t0, t0, -0x1
-               	and	a0, a2, t0
-               	fcvt.d.lu	ft1, a0
+               	and	a0, a1, t0
+               	fcvt.d.lu	ft0, a0
 
 <.Lpcrel_hi.10>:
                	auipc	t0, 0x0
                	fld	ft10, 0x0(t0)
-               	fsub.d	ft2, ft1, ft10
+               	fsub.d	ft1, ft0, ft10
 
 <.Lpcrel_hi.11>:
                	auipc	t0, 0x0
                	fld	ft10, 0x0(t0)
-               	fdiv.d	fa1, ft2, ft10
+               	fdiv.d	fs1, ft1, ft10
                	addi	a0, s8, 0x20
-               	ld	a4, 0x0(a0)
+               	ld	s3, 0x0(a0)
                	addi	a0, s8, 0x28
-               	ld	a2, 0x0(a0)
-               	lui	t0, 0x1
-               	addiw	t0, t0, -0x1
-               	and	a0, a2, t0
-               	fcvt.s.lu	ft1, a0
-               	lui	t0, 0x45000
-               	fmv.w.x	ft10, t0
-               	fsub.s	ft2, ft1, ft10
-               	lui	t0, 0x41000
-               	fmv.w.x	ft10, t0
-               	fdiv.s	ft1, ft2, ft10
+               	ld	a1, 0x0(a0)
+               	mv	a0, a1
+               	auipc	ra, 0x0
+               	jalr	ra <.Lpcrel_hi.11+0x20>
+               	fmv.s	fs2, fa0
                	addi	a0, s8, 0x30
-               	ld	a2, 0x0(a0)
-               	sext.w	a5, a2
+               	ld	a1, 0x0(a0)
+               	sext.w	s4, a1
                	addi	a0, s8, 0x38
-               	ld	a2, 0x0(a0)
+               	ld	a1, 0x0(a0)
                	lui	t0, 0x100
                	addiw	t0, t0, -0x1
-               	and	a0, a2, t0
-               	fcvt.d.lu	ft2, a0
+               	and	a0, a1, t0
+               	fcvt.d.lu	ft0, a0
 
 <.Lpcrel_hi.12>:
                	auipc	t0, 0x0
                	fld	ft10, 0x0(t0)
-               	fsub.d	ft3, ft2, ft10
+               	fsub.d	ft1, ft0, ft10
 
 <.Lpcrel_hi.13>:
                	auipc	t0, 0x0
                	fld	ft10, 0x0(t0)
-               	fdiv.d	fa3, ft3, ft10
+               	fdiv.d	fs3, ft1, ft10
                	addi	a0, s8, 0x40
-               	ld	a6, 0x0(a0)
+               	ld	s11, 0x0(a0)
                	addi	a0, s8, 0x48
-               	ld	a2, 0x0(a0)
-               	lui	t0, 0x1
-               	addiw	t0, t0, -0x1
-               	and	a0, a2, t0
-               	fcvt.s.lu	ft2, a0
-               	lui	t0, 0x45000
-               	fmv.w.x	ft10, t0
-               	fsub.s	ft3, ft2, ft10
-               	lui	t0, 0x41000
-               	fmv.w.x	ft10, t0
-               	fdiv.s	ft2, ft3, ft10
+               	ld	a1, 0x0(a0)
+               	mv	a0, a1
+               	auipc	ra, 0x0
+               	jalr	ra <.Lpcrel_hi.13+0x20>
+               	fmv.s	fs4, fa0
                	addi	a0, s8, 0x50
-               	ld	a2, 0x0(a0)
-               	sext.w	a7, a2
+               	ld	a1, 0x0(a0)
+               	sext.w	t2, a1
+               	sd	t2, -0x2c8(s0)
                	addi	a0, s8, 0x58
-               	ld	a2, 0x0(a0)
+               	ld	a1, 0x0(a0)
                	lui	t0, 0x100
                	addiw	t0, t0, -0x1
-               	and	a0, a2, t0
-               	fcvt.d.lu	ft3, a0
+               	and	a0, a1, t0
+               	fcvt.d.lu	ft0, a0
 
 <.Lpcrel_hi.14>:
                	auipc	t0, 0x0
                	fld	ft10, 0x0(t0)
-               	fsub.d	ft4, ft3, ft10
+               	fsub.d	ft1, ft0, ft10
 
 <.Lpcrel_hi.15>:
                	auipc	t0, 0x0
                	fld	ft10, 0x0(t0)
-               	fdiv.d	fa5, ft4, ft10
+               	fdiv.d	fs5, ft1, ft10
                	addi	a0, s8, 0x60
-               	ld	t5, 0x0(a0)
+               	ld	t2, 0x0(a0)
+               	sd	t2, -0x2d0(s0)
                	addi	a0, s8, 0x68
-               	ld	a2, 0x0(a0)
-               	lui	t0, 0x1
-               	addiw	t0, t0, -0x1
-               	and	a0, a2, t0
-               	fcvt.s.lu	ft3, a0
-               	lui	t0, 0x45000
-               	fmv.w.x	ft10, t0
-               	fsub.s	ft4, ft3, ft10
-               	lui	t0, 0x41000
-               	fmv.w.x	ft10, t0
-               	fdiv.s	ft3, ft4, ft10
+               	ld	a1, 0x0(a0)
+               	mv	a0, a1
+               	auipc	ra, 0x0
+               	jalr	ra <.Lpcrel_hi.15+0x24>
+               	fmv.s	ft0, fa0
                	addi	a0, s8, 0x70
-               	ld	a2, 0x0(a0)
-               	sext.w	t6, a2
+               	ld	a1, 0x0(a0)
+               	sext.w	t6, a1
                	addi	a0, s8, 0x78
-               	ld	a2, 0x0(a0)
+               	ld	a1, 0x0(a0)
                	lui	t0, 0x100
                	addiw	t0, t0, -0x1
-               	and	a0, a2, t0
-               	fcvt.d.lu	ft4, a0
+               	and	a0, a1, t0
+               	fcvt.d.lu	ft1, a0
 
 <.Lpcrel_hi.16>:
                	auipc	t0, 0x0
                	fld	ft10, 0x0(t0)
-               	fsub.d	ft5, ft4, ft10
+               	fsub.d	ft2, ft1, ft10
 
 <.Lpcrel_hi.17>:
                	auipc	t0, 0x0
                	fld	ft10, 0x0(t0)
-               	fdiv.d	fa7, ft5, ft10
+               	fdiv.d	fa7, ft2, ft10
                	addi	a0, s8, 0x8
-               	ld	s1, 0x0(a0)
-               	mv	a0, a1
-               	fmv.s	fa0, ft0
-               	mv	a1, a3
+               	ld	t2, 0x0(a0)
+               	sd	t2, -0x270(s0)
+               	mv	a0, s1
+               	fmv.s	fa0, fs0
+               	mv	a1, s2
+               	fmv.d	fa1, fs1
                	mv	a2, s5
-               	mv	a3, a4
-               	fmv.s	fa2, ft1
-               	mv	a4, a5
+               	mv	a3, s3
+               	fmv.s	fa2, fs2
+               	mv	a4, s4
                	mv	a5, s6
-               	fmv.s	fa4, ft2
+               	fmv.d	fa3, fs3
+               	mv	a6, s11
+               	fmv.s	fa4, fs4
+               	ld	t2, -0x2c8(s0)
+               	mv	a7, t2
+               	fmv.d	fa5, fs5
                	sd	s7, 0x0(sp)
-               	sd	t5, 0x8(sp)
-               	fmv.s	fa6, ft3
+               	ld	t2, -0x2d0(s0)
+               	sd	t2, 0x8(sp)
+               	fmv.s	fa6, ft0
                	sd	t6, 0x10(sp)
-               	sd	s1, 0x18(sp)
+               	ld	t2, -0x270(s0)
+               	sd	t2, 0x18(sp)
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.17+0x4c>
-               	addi	a1, s8, 0x18
-               	ld	a2, 0x0(a1)
-               	lui	t0, 0x1
-               	addiw	t0, t0, -0x1
-               	and	a1, a2, t0
-               	fcvt.s.lu	ft0, a1
-               	lui	t0, 0x45000
-               	fmv.w.x	ft10, t0
-               	fsub.s	ft1, ft0, ft10
-               	lui	t0, 0x41000
-               	fmv.w.x	ft10, t0
-               	fdiv.s	ft0, ft1, ft10
-               	addi	a1, s8, 0x28
-               	ld	a2, 0x0(a1)
-               	sext.w	a1, a2
-               	addi	a2, s8, 0x38
-               	ld	a3, 0x0(a2)
+               	jalr	ra <.Lpcrel_hi.17+0x70>
+               	mv	s1, a0
+               	addi	a0, s8, 0x18
+               	ld	a1, 0x0(a0)
+               	mv	a0, a1
+               	auipc	ra, 0x0
+               	jalr	ra <.Lpcrel_hi.17+0x88>
+               	fmv.s	fs0, fa0
+               	addi	a0, s8, 0x28
+               	ld	a1, 0x0(a0)
+               	sext.w	s2, a1
+               	addi	a0, s8, 0x38
+               	ld	a1, 0x0(a0)
                	lui	t0, 0x100
                	addiw	t0, t0, -0x1
-               	and	a2, a3, t0
-               	fcvt.d.lu	ft1, a2
+               	and	a0, a1, t0
+               	fcvt.d.lu	ft0, a0
 
 <.Lpcrel_hi.18>:
                	auipc	t0, 0x0
                	fld	ft10, 0x0(t0)
-               	fsub.d	ft2, ft1, ft10
+               	fsub.d	ft1, ft0, ft10
 
 <.Lpcrel_hi.19>:
                	auipc	t0, 0x0
                	fld	ft10, 0x0(t0)
-               	fdiv.d	fa1, ft2, ft10
-               	addi	a2, s8, 0x48
-               	ld	a3, 0x0(a2)
-               	addi	a2, s8, 0x58
-               	ld	a4, 0x0(a2)
-               	lui	t0, 0x1
-               	addiw	t0, t0, -0x1
-               	and	a2, a4, t0
-               	fcvt.s.lu	ft1, a2
-               	lui	t0, 0x45000
-               	fmv.w.x	ft10, t0
-               	fsub.s	ft2, ft1, ft10
-               	lui	t0, 0x41000
-               	fmv.w.x	ft10, t0
-               	fdiv.s	ft1, ft2, ft10
-               	addi	a2, s8, 0x68
-               	ld	a4, 0x0(a2)
-               	sext.w	a5, a4
-               	addi	a2, s8, 0x78
-               	ld	a4, 0x0(a2)
+               	fdiv.d	fs1, ft1, ft10
+               	addi	a0, s8, 0x48
+               	ld	s3, 0x0(a0)
+               	addi	a0, s8, 0x58
+               	ld	a1, 0x0(a0)
+               	mv	a0, a1
+               	auipc	ra, 0x0
+               	jalr	ra <.Lpcrel_hi.19+0x20>
+               	fmv.s	fs2, fa0
+               	addi	a0, s8, 0x68
+               	ld	a1, 0x0(a0)
+               	sext.w	s4, a1
+               	addi	a0, s8, 0x78
+               	ld	a1, 0x0(a0)
                	lui	t0, 0x100
                	addiw	t0, t0, -0x1
-               	and	a2, a4, t0
-               	fcvt.d.lu	ft2, a2
+               	and	a0, a1, t0
+               	fcvt.d.lu	ft0, a0
 
 <.Lpcrel_hi.20>:
                	auipc	t0, 0x0
                	fld	ft10, 0x0(t0)
-               	fsub.d	ft3, ft2, ft10
+               	fsub.d	ft1, ft0, ft10
 
 <.Lpcrel_hi.21>:
                	auipc	t0, 0x0
                	fld	ft10, 0x0(t0)
-               	fdiv.d	fa3, ft3, ft10
-               	addi	a2, s8, 0x88
-               	ld	a6, 0x0(a2)
-               	addi	a2, s8, 0x98
-               	ld	a4, 0x0(a2)
-               	lui	t0, 0x1
-               	addiw	t0, t0, -0x1
-               	and	a2, a4, t0
-               	fcvt.s.lu	ft2, a2
-               	lui	t0, 0x45000
-               	fmv.w.x	ft10, t0
-               	fsub.s	ft3, ft2, ft10
-               	lui	t0, 0x41000
-               	fmv.w.x	ft10, t0
-               	fdiv.s	ft2, ft3, ft10
-               	addi	a2, s8, 0xa8
-               	ld	a4, 0x0(a2)
-               	sext.w	a7, a4
-               	addi	a2, s8, 0xb8
-               	ld	a4, 0x0(a2)
+               	fdiv.d	fs3, ft1, ft10
+               	addi	a0, s8, 0x88
+               	ld	s11, 0x0(a0)
+               	addi	a0, s8, 0x98
+               	ld	a1, 0x0(a0)
+               	mv	a0, a1
+               	auipc	ra, 0x0
+               	jalr	ra <.Lpcrel_hi.21+0x20>
+               	fmv.s	fs4, fa0
+               	addi	a0, s8, 0xa8
+               	ld	a1, 0x0(a0)
+               	sext.w	t2, a1
+               	sd	t2, -0x2d8(s0)
+               	addi	a0, s8, 0xb8
+               	ld	a1, 0x0(a0)
                	lui	t0, 0x100
                	addiw	t0, t0, -0x1
-               	and	a2, a4, t0
-               	fcvt.d.lu	ft3, a2
+               	and	a0, a1, t0
+               	fcvt.d.lu	ft0, a0
 
 <.Lpcrel_hi.22>:
                	auipc	t0, 0x0
                	fld	ft10, 0x0(t0)
-               	fsub.d	ft4, ft3, ft10
+               	fsub.d	ft1, ft0, ft10
 
 <.Lpcrel_hi.23>:
                	auipc	t0, 0x0
                	fld	ft10, 0x0(t0)
-               	fdiv.d	fa5, ft4, ft10
-               	addi	a2, s8, 0x10
-               	ld	t5, 0x0(a2)
-               	addi	a2, s8, 0x20
-               	ld	a4, 0x0(a2)
-               	lui	t0, 0x1
-               	addiw	t0, t0, -0x1
-               	and	a2, a4, t0
-               	fcvt.s.lu	ft3, a2
-               	lui	t0, 0x45000
-               	fmv.w.x	ft10, t0
-               	fsub.s	ft4, ft3, ft10
-               	lui	t0, 0x41000
-               	fmv.w.x	ft10, t0
-               	fdiv.s	ft3, ft4, ft10
-               	addi	a2, s8, 0x30
-               	ld	a4, 0x0(a2)
-               	sext.w	t6, a4
-               	addi	a2, s8, 0x40
-               	ld	a4, 0x0(a2)
+               	fdiv.d	fs5, ft1, ft10
+               	addi	a0, s8, 0x10
+               	ld	t2, 0x0(a0)
+               	sd	t2, -0x2e0(s0)
+               	addi	a0, s8, 0x20
+               	ld	a1, 0x0(a0)
+               	mv	a0, a1
+               	auipc	ra, 0x0
+               	jalr	ra <.Lpcrel_hi.23+0x24>
+               	fmv.s	ft0, fa0
+               	addi	a0, s8, 0x30
+               	ld	a1, 0x0(a0)
+               	sext.w	t6, a1
+               	addi	a0, s8, 0x40
+               	ld	a1, 0x0(a0)
                	lui	t0, 0x100
                	addiw	t0, t0, -0x1
-               	and	a2, a4, t0
-               	fcvt.d.lu	ft4, a2
+               	and	a0, a1, t0
+               	fcvt.d.lu	ft1, a0
 
 <.Lpcrel_hi.24>:
                	auipc	t0, 0x0
                	fld	ft10, 0x0(t0)
-               	fsub.d	ft5, ft4, ft10
+               	fsub.d	ft2, ft1, ft10
 
 <.Lpcrel_hi.25>:
                	auipc	t0, 0x0
                	fld	ft10, 0x0(t0)
-               	fdiv.d	fa7, ft5, ft10
-               	fmv.s	fa0, ft0
+               	fdiv.d	fa7, ft2, ft10
+               	mv	a0, s1
+               	fmv.s	fa0, fs0
+               	mv	a1, s2
+               	fmv.d	fa1, fs1
                	mv	a2, s5
-               	fmv.s	fa2, ft1
-               	mv	a4, a5
+               	mv	a3, s3
+               	fmv.s	fa2, fs2
+               	mv	a4, s4
                	mv	a5, s6
-               	fmv.s	fa4, ft2
+               	fmv.d	fa3, fs3
+               	mv	a6, s11
+               	fmv.s	fa4, fs4
+               	ld	t2, -0x2d8(s0)
+               	mv	a7, t2
+               	fmv.d	fa5, fs5
                	sd	s7, 0x0(sp)
-               	sd	t5, 0x8(sp)
-               	fmv.s	fa6, ft3
+               	ld	t2, -0x2e0(s0)
+               	sd	t2, 0x8(sp)
+               	fmv.s	fa6, ft0
                	sd	t6, 0x10(sp)
                	sd	s10, 0x18(sp)
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.25+0x38>
+               	jalr	ra <.Lpcrel_hi.25+0x60>
                	mv	a1, a0
                	mv	a0, s9
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.25+0x48>
-               	ld	s1, 0x248(sp)
-               	ld	s2, 0x240(sp)
-               	ld	s3, 0x238(sp)
-               	ld	s4, 0x230(sp)
-               	ld	s5, 0x228(sp)
-               	ld	s6, 0x220(sp)
-               	ld	s7, 0x218(sp)
-               	ld	s8, 0x210(sp)
-               	ld	s9, 0x208(sp)
-               	ld	s10, 0x200(sp)
-               	ld	s11, 0x1f8(sp)
-               	ld	ra, 0x258(sp)
-               	ld	s0, 0x250(sp)
-               	addi	sp, sp, 0x260
+               	jalr	ra <.Lpcrel_hi.25+0x70>
+               	ld	s1, 0x2f8(sp)
+               	ld	s2, 0x2f0(sp)
+               	ld	s3, 0x2e8(sp)
+               	ld	s4, 0x2e0(sp)
+               	ld	s5, 0x2d8(sp)
+               	ld	s6, 0x2d0(sp)
+               	ld	s7, 0x2c8(sp)
+               	ld	s8, 0x2c0(sp)
+               	ld	s9, 0x2b8(sp)
+               	ld	s10, 0x2b0(sp)
+               	ld	s11, 0x2a8(sp)
+               	fld	fs0, 0x2a0(sp)
+               	fld	fs1, 0x298(sp)
+               	fld	fs2, 0x290(sp)
+               	fld	fs3, 0x288(sp)
+               	fld	fs4, 0x280(sp)
+               	fld	fs5, 0x278(sp)
+               	ld	ra, 0x308(sp)
+               	ld	s0, 0x300(sp)
+               	addi	sp, sp, 0x310
                	ret

--- a/test/golden/riscv64-linux/call/call_rec_edge.dis
+++ b/test/golden/riscv64-linux/call/call_rec_edge.dis
@@ -921,21 +921,21 @@ Disassembly of section .text:
                	ret
 
 <corpus.cases.call.call_rec_edge.checksum>:
-               	addi	sp, sp, -0x270
-               	sd	ra, 0x268(sp)
-               	sd	s0, 0x260(sp)
-               	addi	s0, sp, 0x270
-               	sd	s1, 0x258(sp)
-               	sd	s2, 0x250(sp)
-               	sd	s3, 0x248(sp)
-               	sd	s4, 0x240(sp)
-               	sd	s5, 0x238(sp)
-               	sd	s6, 0x230(sp)
-               	sd	s7, 0x228(sp)
-               	sd	s8, 0x220(sp)
-               	sd	s9, 0x218(sp)
-               	sd	s10, 0x210(sp)
-               	sd	s11, 0x208(sp)
+               	addi	sp, sp, -0x2d0
+               	sd	ra, 0x2c8(sp)
+               	sd	s0, 0x2c0(sp)
+               	addi	s0, sp, 0x2d0
+               	sd	s1, 0x2b8(sp)
+               	sd	s2, 0x2b0(sp)
+               	sd	s3, 0x2a8(sp)
+               	sd	s4, 0x2a0(sp)
+               	sd	s5, 0x298(sp)
+               	sd	s6, 0x290(sp)
+               	sd	s7, 0x288(sp)
+               	sd	s8, 0x280(sp)
+               	sd	s9, 0x278(sp)
+               	sd	s10, 0x270(sp)
+               	sd	s11, 0x268(sp)
                	mv	s1, a0
                	auipc	ra, 0x0
                	jalr	ra <corpus.cases.call.call_rec_edge.checksum+0x40>
@@ -1040,14 +1040,14 @@ Disassembly of section .text:
                	li	s5, 0x0
                	li	t0, 0x3
                	bltu	s5, t0, 0xfa8 <corpus.cases.call.call_rec_edge.checksum+0x1e0>
-               	j	0x13b0 <.Lpcrel_hi.5+0x280>
+               	j	0x13e8 <.Lpcrel_hi.5+0x2b8>
                	li	t0, 0x11
                	mul	a0, s5, t0
                	add	a1, a0, s1
                	mv	a0, s2
                	ld	a2, 0x0(a0)
                	add	t2, a2, a1
-               	sd	t2, -0x1f8(s0)
+               	sd	t2, -0x258(s0)
                	addi	a2, s2, 0x8
                	ld	a3, 0x0(a2)
                	addi	a2, s0, -0xd1
@@ -1075,7 +1075,7 @@ Disassembly of section .text:
                	addi	a3, s2, 0x10
                	ld	a4, 0x0(a3)
                	sext.w	t2, a4
-               	sd	t2, -0x200(s0)
+               	sd	t2, -0x260(s0)
                	addi	a4, s2, 0x18
                	ld	a5, 0x0(a4)
                	addi	a6, s0, -0xe8
@@ -1259,12 +1259,12 @@ Disassembly of section .text:
                	fcvt.s.lu	ft0, a0
                	addi	a0, s2, 0x18
                	ld	t2, 0x0(a0)
-               	sd	t2, -0x208(s0)
-               	ld	t2, -0x1f8(s0)
+               	sd	t2, -0x268(s0)
+               	ld	t2, -0x258(s0)
                	mv	a0, t2
                	ld	a1, 0x0(a2)
                	ld	a2, 0x8(a2)
-               	ld	t2, -0x200(s0)
+               	ld	t2, -0x260(s0)
                	mv	a3, t2
                	ld	a4, 0x0(a6)
                	ld	a5, 0x8(a6)
@@ -1277,7 +1277,14 @@ Disassembly of section .text:
                	ld	t5, 0x8(t6)
                	sd	t5, 0x8(sp)
                	sd	s6, 0x10(sp)
-               	sd	s7, 0x18(sp)
+               	ld	t5, 0x0(s7)
+               	sd	t5, -0x1f1(s0)
+               	ld	t5, 0x8(s7)
+               	sd	t5, -0x1e9(s0)
+               	lbu	t5, 0x10(s7)
+               	sb	t5, -0x1e1(s0)
+               	addi	t5, s0, -0x1f1
+               	sd	t5, 0x18(sp)
                	ld	t5, 0x0(s8)
                	sd	t5, 0x20(sp)
                	lbu	t5, 0x8(s8)
@@ -1290,17 +1297,24 @@ Disassembly of section .text:
                	sd	t5, 0x40(sp)
                	ld	t5, 0x8(s10)
                	sd	t5, 0x48(sp)
-               	sd	s11, 0x50(sp)
+               	ld	t5, 0x0(s11)
+               	sd	t5, -0x209(s0)
+               	ld	t5, 0x8(s11)
+               	sd	t5, -0x201(s0)
+               	lbu	t5, 0x10(s11)
+               	sb	t5, -0x1f9(s0)
+               	addi	t5, s0, -0x209
+               	sd	t5, 0x50(sp)
                	fmv.s	fa3, ft0
-               	ld	t2, -0x208(s0)
+               	ld	t2, -0x268(s0)
                	sd	t2, 0x58(sp)
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.5+0x254>
+               	jalr	ra <.Lpcrel_hi.5+0x28c>
                	mv	s4, a0
                	mv	a0, s3
                	mv	a1, s4
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.5+0x268>
+               	jalr	ra <.Lpcrel_hi.5+0x2a0>
                	addi	s5, s5, 0x1
                	mv	s3, a0
                	li	t0, 0x3
@@ -1313,8 +1327,8 @@ Disassembly of section .text:
                	sb	a0, 0x0(a1)
                	li	a0, 0x0
                	li	t0, 0x8
-               	bltu	a0, t0, 0x13d8 <.Lpcrel_hi.5+0x2a8>
-               	j	0x1408 <.Lpcrel_hi.5+0x2d8>
+               	bltu	a0, t0, 0x1410 <.Lpcrel_hi.5+0x2e0>
+               	j	0x1440 <.Lpcrel_hi.5+0x310>
                	li	t0, 0x8
                	mul	a1, a0, t0
                	srl	a3, s4, a1
@@ -1326,7 +1340,7 @@ Disassembly of section .text:
                	sb	a4, 0x0(a3)
                	addi	a0, a0, 0x1
                	li	t0, 0x8
-               	bltu	a0, t0, 0x13d8 <.Lpcrel_hi.5+0x2a8>
+               	bltu	a0, t0, 0x1410 <.Lpcrel_hi.5+0x2e0>
                	sext.w	a3, s4
                	addi	a5, s0, -0xf4
                	sext.w	a0, s4
@@ -1403,8 +1417,8 @@ Disassembly of section .text:
                	sb	a1, 0x0(a0)
                	li	a0, 0x0
                	li	t0, 0x10
-               	bltu	a0, t0, 0x1528 <.Lpcrel_hi.8+0x4c>
-               	j	0x1558 <.Lpcrel_hi.8+0x7c>
+               	bltu	a0, t0, 0x1560 <.Lpcrel_hi.8+0x4c>
+               	j	0x1590 <.Lpcrel_hi.8+0x7c>
                	li	t0, 0x4
                	mul	a1, a0, t0
                	srl	a4, s4, a1
@@ -1416,7 +1430,7 @@ Disassembly of section .text:
                	sb	a6, 0x0(a4)
                	addi	a0, a0, 0x1
                	li	t0, 0x10
-               	bltu	a0, t0, 0x1528 <.Lpcrel_hi.8+0x4c>
+               	bltu	a0, t0, 0x1560 <.Lpcrel_hi.8+0x4c>
                	addi	a0, s2, 0x50
                	ld	a1, 0x0(a0)
                	addi	s6, s0, -0x18c
@@ -1427,8 +1441,8 @@ Disassembly of section .text:
                	sb	a0, 0x0(a4)
                	li	a0, 0x0
                	li	t0, 0x8
-               	bltu	a0, t0, 0x1588 <.Lpcrel_hi.8+0xac>
-               	j	0x15b8 <.Lpcrel_hi.8+0xdc>
+               	bltu	a0, t0, 0x15c0 <.Lpcrel_hi.8+0xac>
+               	j	0x15f0 <.Lpcrel_hi.8+0xdc>
                	li	t0, 0x8
                	mul	a4, a0, t0
                	srl	a6, a1, a4
@@ -1440,7 +1454,7 @@ Disassembly of section .text:
                	sb	s7, 0x0(a6)
                	addi	a0, a0, 0x1
                	li	t0, 0x8
-               	bltu	a0, t0, 0x1588 <.Lpcrel_hi.8+0xac>
+               	bltu	a0, t0, 0x15c0 <.Lpcrel_hi.8+0xac>
                	addi	a0, s2, 0x58
                	ld	a1, 0x0(a0)
                	addi	s7, s0, -0x1a4
@@ -1467,7 +1481,7 @@ Disassembly of section .text:
                	sd	a1, 0x0(a0)
                	addi	a0, s2, 0x8
                	ld	a1, 0x0(a0)
-               	addi	s9, s0, -0x1ea
+               	addi	s9, s0, -0x21a
                	sd	zero, 0x0(s9)
                	sd	zero, 0x8(s9)
                	sb	zero, 0x10(s9)
@@ -1477,8 +1491,8 @@ Disassembly of section .text:
                	sb	a4, 0x0(a0)
                	li	a0, 0x0
                	li	t0, 0x10
-               	bltu	a0, t0, 0x1650 <.Lpcrel_hi.8+0x174>
-               	j	0x1680 <.Lpcrel_hi.8+0x1a4>
+               	bltu	a0, t0, 0x1688 <.Lpcrel_hi.8+0x174>
+               	j	0x16b8 <.Lpcrel_hi.8+0x1a4>
                	li	t0, 0x4
                	mul	a4, a0, t0
                	srl	a6, a1, a4
@@ -1490,7 +1504,7 @@ Disassembly of section .text:
                	sb	s10, 0x0(a6)
                	addi	a0, a0, 0x1
                	li	t0, 0x10
-               	bltu	a0, t0, 0x1650 <.Lpcrel_hi.8+0x174>
+               	bltu	a0, t0, 0x1688 <.Lpcrel_hi.8+0x174>
                	addi	a0, s2, 0x10
                	ld	a1, 0x0(a0)
                	li	t0, 0xff
@@ -1512,7 +1526,14 @@ Disassembly of section .text:
                	ld	t5, 0x8(t6)
                	sd	t5, 0x8(sp)
                	sd	s1, 0x10(sp)
-               	sd	s5, 0x18(sp)
+               	ld	t5, 0x0(s5)
+               	sd	t5, -0x232(s0)
+               	ld	t5, 0x8(s5)
+               	sd	t5, -0x22a(s0)
+               	lbu	t5, 0x10(s5)
+               	sb	t5, -0x222(s0)
+               	addi	t5, s0, -0x232
+               	sd	t5, 0x18(sp)
                	ld	t5, 0x0(s6)
                	sd	t5, 0x20(sp)
                	lbu	t5, 0x8(s6)
@@ -1525,27 +1546,34 @@ Disassembly of section .text:
                	sd	t5, 0x40(sp)
                	ld	t5, 0x8(s8)
                	sd	t5, 0x48(sp)
-               	sd	s9, 0x50(sp)
+               	ld	t5, 0x0(s9)
+               	sd	t5, -0x24a(s0)
+               	ld	t5, 0x8(s9)
+               	sd	t5, -0x242(s0)
+               	lbu	t5, 0x10(s9)
+               	sb	t5, -0x23a(s0)
+               	addi	t5, s0, -0x24a
+               	sd	t5, 0x50(sp)
                	fmv.s	fa3, ft0
                	sd	s2, 0x58(sp)
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.8+0x238>
+               	jalr	ra <.Lpcrel_hi.8+0x270>
                	mv	a1, a0
                	mv	a0, s3
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.8+0x248>
-               	ld	s1, 0x258(sp)
-               	ld	s2, 0x250(sp)
-               	ld	s3, 0x248(sp)
-               	ld	s4, 0x240(sp)
-               	ld	s5, 0x238(sp)
-               	ld	s6, 0x230(sp)
-               	ld	s7, 0x228(sp)
-               	ld	s8, 0x220(sp)
-               	ld	s9, 0x218(sp)
-               	ld	s10, 0x210(sp)
-               	ld	s11, 0x208(sp)
-               	ld	ra, 0x268(sp)
-               	ld	s0, 0x260(sp)
-               	addi	sp, sp, 0x270
+               	jalr	ra <.Lpcrel_hi.8+0x280>
+               	ld	s1, 0x2b8(sp)
+               	ld	s2, 0x2b0(sp)
+               	ld	s3, 0x2a8(sp)
+               	ld	s4, 0x2a0(sp)
+               	ld	s5, 0x298(sp)
+               	ld	s6, 0x290(sp)
+               	ld	s7, 0x288(sp)
+               	ld	s8, 0x280(sp)
+               	ld	s9, 0x278(sp)
+               	ld	s10, 0x270(sp)
+               	ld	s11, 0x268(sp)
+               	ld	ra, 0x2c8(sp)
+               	ld	s0, 0x2c0(sp)
+               	addi	sp, sp, 0x2d0
                	ret

--- a/test/golden/riscv64-linux/call/call_rec_large.dis
+++ b/test/golden/riscv64-linux/call/call_rec_large.dis
@@ -1167,22 +1167,22 @@ Disassembly of section .text:
                	ret
 
 <corpus.cases.call.call_rec_large.checksum>:
-               	addi	sp, sp, -0x420
-               	sd	ra, 0x418(sp)
-               	sd	s0, 0x410(sp)
-               	addi	s0, sp, 0x420
-               	sd	s1, 0x408(sp)
-               	sd	s2, 0x400(sp)
-               	sd	s3, 0x3f8(sp)
-               	sd	s4, 0x3f0(sp)
-               	sd	s5, 0x3e8(sp)
-               	sd	s6, 0x3e0(sp)
-               	sd	s7, 0x3d8(sp)
-               	sd	s8, 0x3d0(sp)
-               	sd	s9, 0x3c8(sp)
-               	sd	s10, 0x3c0(sp)
-               	sd	s11, 0x3b8(sp)
-               	fsd	fs0, 0x3b0(sp)
+               	addi	sp, sp, -0x6c0
+               	sd	ra, 0x6b8(sp)
+               	sd	s0, 0x6b0(sp)
+               	addi	s0, sp, 0x6c0
+               	sd	s1, 0x6a8(sp)
+               	sd	s2, 0x6a0(sp)
+               	sd	s3, 0x698(sp)
+               	sd	s4, 0x690(sp)
+               	sd	s5, 0x688(sp)
+               	sd	s6, 0x680(sp)
+               	sd	s7, 0x678(sp)
+               	sd	s8, 0x670(sp)
+               	sd	s9, 0x668(sp)
+               	sd	s10, 0x660(sp)
+               	sd	s11, 0x658(sp)
+               	fsd	fs0, 0x650(sp)
                	mv	s1, a0
                	auipc	ra, 0x0
                	jalr	ra <corpus.cases.call.call_rec_large.checksum+0x44>
@@ -1284,7 +1284,7 @@ Disassembly of section .text:
                	li	s5, 0x0
                	li	t0, 0x3
                	bltu	s5, t0, 0x1350 <corpus.cases.call.call_rec_large.checksum+0x1d8>
-               	j	0x1798 <.Lpcrel_hi.9+0x358>
+               	j	0x194c <.Lpcrel_hi.9+0x50c>
                	li	t0, 0x13
                	mul	a0, s5, t0
                	add	a1, a0, s1
@@ -1387,14 +1387,14 @@ Disassembly of section .text:
                	addi	a0, s2, 0x30
                	ld	a1, 0x0(a0)
                	addi	t2, s0, -0x1c0
-               	sd	t2, -0x3e0(s0)
+               	sd	t2, -0x680(s0)
                	addi	a0, s0, -0x1d0
                	mv	a2, a0
                	sd	a1, 0x0(a2)
                	addi	a2, a1, 0xb
                	addi	a3, a0, 0x8
                	sd	a2, 0x0(a3)
-               	ld	t2, -0x3e0(s0)
+               	ld	t2, -0x680(s0)
                	mv	a2, t2
                	ld	a3, 0x0(a0)
                	sd	a3, 0x0(a2)
@@ -1408,7 +1408,7 @@ Disassembly of section .text:
                	not	a2, a1
                	addi	a1, a0, 0x8
                	sd	a2, 0x0(a1)
-               	ld	t2, -0x3e0(s0)
+               	ld	t2, -0x680(s0)
                	addi	a1, t2, 0x10
                	ld	a2, 0x0(a0)
                	sd	a2, 0x0(a1)
@@ -1422,25 +1422,25 @@ Disassembly of section .text:
                	addi	a0, s2, 0x40
                	ld	a1, 0x0(a0)
                	addi	t2, s0, -0x250
-               	sd	t2, -0x3e8(s0)
-               	ld	t2, -0x3e8(s0)
+               	sd	t2, -0x688(s0)
+               	ld	t2, -0x688(s0)
                	mv	a0, t2
                	sd	a1, 0x0(a0)
                	addi	a0, a1, 0x1
-               	ld	t2, -0x3e8(s0)
+               	ld	t2, -0x688(s0)
                	addi	a2, t2, 0x8
                	sd	a0, 0x0(a2)
                	addi	a0, a1, 0x2
-               	ld	t2, -0x3e8(s0)
+               	ld	t2, -0x688(s0)
                	addi	a2, t2, 0x10
                	sd	a0, 0x0(a2)
                	li	t0, 0x9
                	mul	a0, a1, t0
-               	ld	t2, -0x3e8(s0)
+               	ld	t2, -0x688(s0)
                	addi	a2, t2, 0x18
                	sd	a0, 0x0(a2)
                	not	a0, a1
-               	ld	t2, -0x3e8(s0)
+               	ld	t2, -0x688(s0)
                	addi	a2, t2, 0x20
                	sd	a0, 0x0(a2)
                	lui	t0, 0xab
@@ -1448,18 +1448,18 @@ Disassembly of section .text:
                	slli	t0, t0, 0xc
                	addi	t0, t0, -0x556
                	xor	a0, a1, t0
-               	ld	t2, -0x3e8(s0)
+               	ld	t2, -0x688(s0)
                	addi	a1, t2, 0x28
                	sd	a0, 0x0(a1)
                	addi	a0, s2, 0x48
                	ld	a1, 0x0(a0)
                	addi	t2, s0, -0x280
-               	sd	t2, -0x3d8(s0)
-               	ld	t2, -0x3d8(s0)
+               	sd	t2, -0x678(s0)
+               	ld	t2, -0x678(s0)
                	mv	a0, t2
                	auipc	ra, 0x0
                	jalr	ra <.Lpcrel_hi.9+0x1a0>
-               	ld	t2, -0x3d8(s0)
+               	ld	t2, -0x678(s0)
                	addi	a0, s2, 0x50
                	ld	a1, 0x0(a0)
                	addi	t6, s0, -0x2f8
@@ -1478,45 +1478,45 @@ Disassembly of section .text:
                	addi	a0, s2, 0x58
                	ld	a1, 0x0(a0)
                	addi	t2, s0, -0x330
-               	sd	t2, -0x3b8(s0)
-               	ld	t2, -0x3b8(s0)
+               	sd	t2, -0x658(s0)
+               	ld	t2, -0x658(s0)
                	mv	a0, t2
                	sd	a1, 0x0(a0)
                	not	a0, a1
-               	ld	t2, -0x3b8(s0)
+               	ld	t2, -0x658(s0)
                	addi	a2, t2, 0x8
                	sd	a0, 0x0(a2)
                	li	t0, 0x5
                	mul	a0, a1, t0
-               	ld	t2, -0x3b8(s0)
+               	ld	t2, -0x658(s0)
                	addi	a2, t2, 0x10
                	sd	a0, 0x0(a2)
                	srli	a0, a1, 0x3
-               	ld	t2, -0x3b8(s0)
+               	ld	t2, -0x658(s0)
                	addi	a1, t2, 0x18
                	sd	a0, 0x0(a1)
                	mv	a0, s2
                	ld	a1, 0x0(a0)
                	addi	t2, s0, -0x380
-               	sd	t2, -0x3c0(s0)
-               	ld	t2, -0x3c0(s0)
+               	sd	t2, -0x660(s0)
+               	ld	t2, -0x660(s0)
                	mv	a0, t2
                	sd	a1, 0x0(a0)
                	addi	a0, a1, 0x1
-               	ld	t2, -0x3c0(s0)
+               	ld	t2, -0x660(s0)
                	addi	a2, t2, 0x8
                	sd	a0, 0x0(a2)
                	addi	a0, a1, 0x2
-               	ld	t2, -0x3c0(s0)
+               	ld	t2, -0x660(s0)
                	addi	a2, t2, 0x10
                	sd	a0, 0x0(a2)
                	li	t0, 0x9
                	mul	a0, a1, t0
-               	ld	t2, -0x3c0(s0)
+               	ld	t2, -0x660(s0)
                	addi	a2, t2, 0x18
                	sd	a0, 0x0(a2)
                	not	a0, a1
-               	ld	t2, -0x3c0(s0)
+               	ld	t2, -0x660(s0)
                	addi	a2, t2, 0x20
                	sd	a0, 0x0(a2)
                	lui	t0, 0xab
@@ -1524,7 +1524,7 @@ Disassembly of section .text:
                	slli	t0, t0, 0xc
                	addi	t0, t0, -0x556
                	xor	a0, a1, t0
-               	ld	t2, -0x3c0(s0)
+               	ld	t2, -0x660(s0)
                	addi	a1, t2, 0x28
                	sd	a0, 0x0(a1)
                	addi	a0, s2, 0x8
@@ -1534,35 +1534,144 @@ Disassembly of section .text:
                	fcvt.s.lu	ft0, a0
                	addi	a0, s2, 0x10
                	ld	t2, 0x0(a0)
-               	sd	t2, -0x3c8(s0)
+               	sd	t2, -0x668(s0)
                	mv	a0, s6
-               	mv	a1, s7
-               	mv	a2, s8
-               	mv	a3, s9
+               	ld	a1, 0x0(s7)
+               	sd	a1, -0x398(s0)
+               	ld	a1, 0x8(s7)
+               	sd	a1, -0x390(s0)
+               	ld	a1, 0x10(s7)
+               	sd	a1, -0x388(s0)
+               	addi	a1, s0, -0x398
+               	ld	a2, 0x0(s8)
+               	sd	a2, -0x3b0(s0)
+               	ld	a2, 0x8(s8)
+               	sd	a2, -0x3a8(s0)
+               	ld	a2, 0x10(s8)
+               	sd	a2, -0x3a0(s0)
+               	addi	a2, s0, -0x3b0
+               	ld	a3, 0x0(s9)
+               	sd	a3, -0x3c8(s0)
+               	ld	a3, 0x8(s9)
+               	sd	a3, -0x3c0(s0)
+               	ld	a3, 0x10(s9)
+               	sd	a3, -0x3b8(s0)
+               	addi	a3, s0, -0x3c8
                	mv	a4, s10
-               	mv	a5, s11
-               	ld	t2, -0x3e0(s0)
-               	mv	a6, t2
+               	ld	a5, 0x0(s11)
+               	sd	a5, -0x3e8(s0)
+               	ld	a5, 0x8(s11)
+               	sd	a5, -0x3e0(s0)
+               	ld	a5, 0x10(s11)
+               	sd	a5, -0x3d8(s0)
+               	ld	a5, 0x18(s11)
+               	sd	a5, -0x3d0(s0)
+               	addi	a5, s0, -0x3e8
+               	ld	t2, -0x680(s0)
+               	ld	s6, 0x0(t2)
+               	sd	s6, -0x408(s0)
+               	ld	t2, -0x680(s0)
+               	ld	s6, 0x8(t2)
+               	sd	s6, -0x400(s0)
+               	ld	t2, -0x680(s0)
+               	ld	s6, 0x10(t2)
+               	sd	s6, -0x3f8(s0)
+               	ld	t2, -0x680(s0)
+               	ld	s6, 0x18(t2)
+               	sd	s6, -0x3f0(s0)
+               	addi	a6, s0, -0x408
                	fmv.d	fa0, fs0
-               	ld	t2, -0x3e8(s0)
-               	mv	a7, t2
-               	ld	t2, -0x3d8(s0)
-               	sd	t2, 0x0(sp)
-               	sd	t6, 0x8(sp)
-               	ld	t2, -0x3b8(s0)
-               	sd	t2, 0x10(sp)
-               	ld	t2, -0x3c0(s0)
-               	sd	t2, 0x18(sp)
+               	ld	t2, -0x688(s0)
+               	ld	s6, 0x0(t2)
+               	sd	s6, -0x438(s0)
+               	ld	t2, -0x688(s0)
+               	ld	s6, 0x8(t2)
+               	sd	s6, -0x430(s0)
+               	ld	t2, -0x688(s0)
+               	ld	s6, 0x10(t2)
+               	sd	s6, -0x428(s0)
+               	ld	t2, -0x688(s0)
+               	ld	s6, 0x18(t2)
+               	sd	s6, -0x420(s0)
+               	ld	t2, -0x688(s0)
+               	ld	s6, 0x20(t2)
+               	sd	s6, -0x418(s0)
+               	ld	t2, -0x688(s0)
+               	ld	s6, 0x28(t2)
+               	sd	s6, -0x410(s0)
+               	addi	a7, s0, -0x438
+               	ld	t2, -0x678(s0)
+               	ld	s6, 0x0(t2)
+               	sd	s6, -0x468(s0)
+               	ld	t2, -0x678(s0)
+               	ld	s6, 0x8(t2)
+               	sd	s6, -0x460(s0)
+               	ld	t2, -0x678(s0)
+               	ld	s6, 0x10(t2)
+               	sd	s6, -0x458(s0)
+               	ld	t2, -0x678(s0)
+               	ld	s6, 0x18(t2)
+               	sd	s6, -0x450(s0)
+               	ld	t2, -0x678(s0)
+               	ld	s6, 0x20(t2)
+               	sd	s6, -0x448(s0)
+               	ld	t2, -0x678(s0)
+               	ld	s6, 0x28(t2)
+               	sd	s6, -0x440(s0)
+               	addi	t5, s0, -0x468
+               	sd	t5, 0x0(sp)
+               	ld	t5, 0x0(t6)
+               	sd	t5, -0x480(s0)
+               	ld	t5, 0x8(t6)
+               	sd	t5, -0x478(s0)
+               	ld	t5, 0x10(t6)
+               	sd	t5, -0x470(s0)
+               	addi	t5, s0, -0x480
+               	sd	t5, 0x8(sp)
+               	ld	t2, -0x658(s0)
+               	ld	t5, 0x0(t2)
+               	sd	t5, -0x4a0(s0)
+               	ld	t2, -0x658(s0)
+               	ld	t5, 0x8(t2)
+               	sd	t5, -0x498(s0)
+               	ld	t2, -0x658(s0)
+               	ld	t5, 0x10(t2)
+               	sd	t5, -0x490(s0)
+               	ld	t2, -0x658(s0)
+               	ld	t5, 0x18(t2)
+               	sd	t5, -0x488(s0)
+               	addi	t5, s0, -0x4a0
+               	sd	t5, 0x10(sp)
+               	ld	t2, -0x660(s0)
+               	ld	t5, 0x0(t2)
+               	sd	t5, -0x4d0(s0)
+               	ld	t2, -0x660(s0)
+               	ld	t5, 0x8(t2)
+               	sd	t5, -0x4c8(s0)
+               	ld	t2, -0x660(s0)
+               	ld	t5, 0x10(t2)
+               	sd	t5, -0x4c0(s0)
+               	ld	t2, -0x660(s0)
+               	ld	t5, 0x18(t2)
+               	sd	t5, -0x4b8(s0)
+               	ld	t2, -0x660(s0)
+               	ld	t5, 0x20(t2)
+               	sd	t5, -0x4b0(s0)
+               	ld	t2, -0x660(s0)
+               	ld	t5, 0x28(t2)
+               	sd	t5, -0x4a8(s0)
+               	addi	t5, s0, -0x4d0
+               	sd	t5, 0x18(sp)
                	fmv.s	fa1, ft0
-               	ld	t2, -0x3c8(s0)
+               	ld	t2, -0x668(s0)
                	sd	t2, 0x20(sp)
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.9+0x32c>
+               	jalr	ra <.Lpcrel_hi.9+0x4e0>
                	mv	s4, a0
                	mv	a0, s3
                	mv	a1, s4
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.9+0x340>
+               	jalr	ra <.Lpcrel_hi.9+0x4f4>
                	addi	s5, s5, 0x1
                	mv	s3, a0
                	li	t0, 0x3
@@ -1737,26 +1846,26 @@ Disassembly of section .text:
                	sd	a0, 0x0(a1)
                	mv	a0, s2
                	ld	a1, 0x0(a0)
-               	addi	t2, s0, -0x3b0
-               	sd	t2, -0x3d0(s0)
-               	ld	t2, -0x3d0(s0)
+               	addi	t2, s0, -0x500
+               	sd	t2, -0x670(s0)
+               	ld	t2, -0x670(s0)
                	mv	a0, t2
                	sd	a1, 0x0(a0)
                	addi	a0, a1, 0x1
-               	ld	t2, -0x3d0(s0)
+               	ld	t2, -0x670(s0)
                	addi	a2, t2, 0x8
                	sd	a0, 0x0(a2)
                	addi	a0, a1, 0x2
-               	ld	t2, -0x3d0(s0)
+               	ld	t2, -0x670(s0)
                	addi	a2, t2, 0x10
                	sd	a0, 0x0(a2)
                	li	t0, 0x9
                	mul	a0, a1, t0
-               	ld	t2, -0x3d0(s0)
+               	ld	t2, -0x670(s0)
                	addi	a2, t2, 0x18
                	sd	a0, 0x0(a2)
                	not	a0, a1
-               	ld	t2, -0x3d0(s0)
+               	ld	t2, -0x670(s0)
                	addi	a2, t2, 0x20
                	sd	a0, 0x0(a2)
                	lui	t0, 0xab
@@ -1764,7 +1873,7 @@ Disassembly of section .text:
                	slli	t0, t0, 0xc
                	addi	t0, t0, -0x556
                	xor	a0, a1, t0
-               	ld	t2, -0x3d0(s0)
+               	ld	t2, -0x670(s0)
                	addi	a1, t2, 0x28
                	sd	a0, 0x0(a1)
                	addi	a0, s2, 0x8
@@ -1775,40 +1884,133 @@ Disassembly of section .text:
                	addi	a0, s2, 0x18
                	ld	s2, 0x0(a0)
                	mv	a0, s4
-               	mv	a1, s1
-               	mv	a2, s5
-               	mv	a3, s6
+               	ld	a1, 0x0(s1)
+               	sd	a1, -0x518(s0)
+               	ld	a1, 0x8(s1)
+               	sd	a1, -0x510(s0)
+               	ld	a1, 0x10(s1)
+               	sd	a1, -0x508(s0)
+               	addi	a1, s0, -0x518
+               	ld	a2, 0x0(s5)
+               	sd	a2, -0x530(s0)
+               	ld	a2, 0x8(s5)
+               	sd	a2, -0x528(s0)
+               	ld	a2, 0x10(s5)
+               	sd	a2, -0x520(s0)
+               	addi	a2, s0, -0x530
+               	ld	a3, 0x0(s6)
+               	sd	a3, -0x548(s0)
+               	ld	a3, 0x8(s6)
+               	sd	a3, -0x540(s0)
+               	ld	a3, 0x10(s6)
+               	sd	a3, -0x538(s0)
+               	addi	a3, s0, -0x548
                	mv	a4, s7
-               	mv	a5, s8
-               	mv	a6, s9
+               	ld	a5, 0x0(s8)
+               	sd	a5, -0x568(s0)
+               	ld	a5, 0x8(s8)
+               	sd	a5, -0x560(s0)
+               	ld	a5, 0x10(s8)
+               	sd	a5, -0x558(s0)
+               	ld	a5, 0x18(s8)
+               	sd	a5, -0x550(s0)
+               	addi	a5, s0, -0x568
+               	ld	a6, 0x0(s9)
+               	sd	a6, -0x588(s0)
+               	ld	a6, 0x8(s9)
+               	sd	a6, -0x580(s0)
+               	ld	a6, 0x10(s9)
+               	sd	a6, -0x578(s0)
+               	ld	a6, 0x18(s9)
+               	sd	a6, -0x570(s0)
+               	addi	a6, s0, -0x588
                	fmv.d	fa0, fs0
-               	mv	a7, s10
-               	sd	s11, 0x0(sp)
+               	ld	a7, 0x0(s10)
+               	sd	a7, -0x5b8(s0)
+               	ld	a7, 0x8(s10)
+               	sd	a7, -0x5b0(s0)
+               	ld	a7, 0x10(s10)
+               	sd	a7, -0x5a8(s0)
+               	ld	a7, 0x18(s10)
+               	sd	a7, -0x5a0(s0)
+               	ld	a7, 0x20(s10)
+               	sd	a7, -0x598(s0)
+               	ld	a7, 0x28(s10)
+               	sd	a7, -0x590(s0)
+               	addi	a7, s0, -0x5b8
+               	ld	s1, 0x0(s11)
+               	sd	s1, -0x5e8(s0)
+               	ld	s1, 0x8(s11)
+               	sd	s1, -0x5e0(s0)
+               	ld	s1, 0x10(s11)
+               	sd	s1, -0x5d8(s0)
+               	ld	s1, 0x18(s11)
+               	sd	s1, -0x5d0(s0)
+               	ld	s1, 0x20(s11)
+               	sd	s1, -0x5c8(s0)
+               	ld	s1, 0x28(s11)
+               	sd	s1, -0x5c0(s0)
+               	addi	s1, s0, -0x5e8
+               	sd	s1, 0x0(sp)
+               	ld	s1, 0x0(t5)
+               	sd	s1, -0x600(s0)
+               	ld	s1, 0x8(t5)
+               	sd	s1, -0x5f8(s0)
+               	ld	s1, 0x10(t5)
+               	sd	s1, -0x5f0(s0)
+               	addi	t5, s0, -0x600
                	sd	t5, 0x8(sp)
-               	sd	t6, 0x10(sp)
-               	ld	t2, -0x3d0(s0)
-               	sd	t2, 0x18(sp)
+               	ld	t5, 0x0(t6)
+               	sd	t5, -0x620(s0)
+               	ld	t5, 0x8(t6)
+               	sd	t5, -0x618(s0)
+               	ld	t5, 0x10(t6)
+               	sd	t5, -0x610(s0)
+               	ld	t5, 0x18(t6)
+               	sd	t5, -0x608(s0)
+               	addi	t5, s0, -0x620
+               	sd	t5, 0x10(sp)
+               	ld	t2, -0x670(s0)
+               	ld	t5, 0x0(t2)
+               	sd	t5, -0x650(s0)
+               	ld	t2, -0x670(s0)
+               	ld	t5, 0x8(t2)
+               	sd	t5, -0x648(s0)
+               	ld	t2, -0x670(s0)
+               	ld	t5, 0x10(t2)
+               	sd	t5, -0x640(s0)
+               	ld	t2, -0x670(s0)
+               	ld	t5, 0x18(t2)
+               	sd	t5, -0x638(s0)
+               	ld	t2, -0x670(s0)
+               	ld	t5, 0x20(t2)
+               	sd	t5, -0x630(s0)
+               	ld	t2, -0x670(s0)
+               	ld	t5, 0x28(t2)
+               	sd	t5, -0x628(s0)
+               	addi	t5, s0, -0x650
+               	sd	t5, 0x18(sp)
                	fmv.s	fa1, ft0
                	sd	s2, 0x20(sp)
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.13+0x29c>
+               	jalr	ra <.Lpcrel_hi.13+0x410>
                	mv	a1, a0
                	mv	a0, s3
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.13+0x2ac>
-               	ld	s1, 0x408(sp)
-               	ld	s2, 0x400(sp)
-               	ld	s3, 0x3f8(sp)
-               	ld	s4, 0x3f0(sp)
-               	ld	s5, 0x3e8(sp)
-               	ld	s6, 0x3e0(sp)
-               	ld	s7, 0x3d8(sp)
-               	ld	s8, 0x3d0(sp)
-               	ld	s9, 0x3c8(sp)
-               	ld	s10, 0x3c0(sp)
-               	ld	s11, 0x3b8(sp)
-               	fld	fs0, 0x3b0(sp)
-               	ld	ra, 0x418(sp)
-               	ld	s0, 0x410(sp)
-               	addi	sp, sp, 0x420
+               	jalr	ra <.Lpcrel_hi.13+0x420>
+               	ld	s1, 0x6a8(sp)
+               	ld	s2, 0x6a0(sp)
+               	ld	s3, 0x698(sp)
+               	ld	s4, 0x690(sp)
+               	ld	s5, 0x688(sp)
+               	ld	s6, 0x680(sp)
+               	ld	s7, 0x678(sp)
+               	ld	s8, 0x670(sp)
+               	ld	s9, 0x668(sp)
+               	ld	s10, 0x660(sp)
+               	ld	s11, 0x658(sp)
+               	fld	fs0, 0x650(sp)
+               	ld	ra, 0x6b8(sp)
+               	ld	s0, 0x6b0(sp)
+               	addi	sp, sp, 0x6c0
                	ret

--- a/test/golden/riscv64-linux/call/call_ret_large.dis
+++ b/test/golden/riscv64-linux/call/call_ret_large.dis
@@ -978,23 +978,23 @@ Disassembly of section .text:
                	ret
 
 <corpus.cases.call.call_ret_large.checksum>:
-               	addi	sp, sp, -0x4e0
-               	sd	ra, 0x4d8(sp)
-               	sd	s0, 0x4d0(sp)
-               	addi	s0, sp, 0x4e0
-               	sd	s1, 0x4c8(sp)
-               	sd	s2, 0x4c0(sp)
-               	sd	s3, 0x4b8(sp)
-               	sd	s4, 0x4b0(sp)
-               	sd	s5, 0x4a8(sp)
-               	sd	s6, 0x4a0(sp)
-               	sd	s7, 0x498(sp)
-               	sd	s8, 0x490(sp)
-               	sd	s9, 0x488(sp)
-               	sd	s10, 0x480(sp)
-               	sd	s11, 0x478(sp)
-               	fsd	fs0, 0x470(sp)
-               	fsd	fs1, 0x468(sp)
+               	addi	sp, sp, -0x6a0
+               	sd	ra, 0x698(sp)
+               	sd	s0, 0x690(sp)
+               	addi	s0, sp, 0x6a0
+               	sd	s1, 0x688(sp)
+               	sd	s2, 0x680(sp)
+               	sd	s3, 0x678(sp)
+               	sd	s4, 0x670(sp)
+               	sd	s5, 0x668(sp)
+               	sd	s6, 0x660(sp)
+               	sd	s7, 0x658(sp)
+               	sd	s8, 0x650(sp)
+               	sd	s9, 0x648(sp)
+               	sd	s10, 0x640(sp)
+               	sd	s11, 0x638(sp)
+               	fsd	fs0, 0x630(sp)
+               	fsd	fs1, 0x628(sp)
                	mv	s1, a0
                	auipc	ra, 0x0
                	jalr	ra <corpus.cases.call.call_ret_large.checksum+0x48>
@@ -1025,7 +1025,7 @@ Disassembly of section .text:
                	li	a1, 0x20
                	auipc	ra, 0x0
                	jalr	ra <corpus.cases.call.call_ret_large.checksum+0xb4>
-               	addi	s2, s0, -0x208
+               	addi	s2, s0, -0x238
                	sd	zero, 0x0(s2)
                	sd	zero, 0x8(s2)
                	sd	zero, 0x10(s2)
@@ -1067,7 +1067,7 @@ Disassembly of section .text:
                	li	s4, 0x0
                	li	t0, 0x8
                	bltu	s4, t0, 0xfd4 <corpus.cases.call.call_ret_large.checksum+0x168>
-               	j	0x12d4 <.Lpcrel_hi.9+0x170>
+               	j	0x1308 <.Lpcrel_hi.9+0x1a4>
                	slli	t0, s4, 0x3
                	add	a0, s2, t0
                	ld	a1, 0x0(a0)
@@ -1229,11 +1229,11 @@ Disassembly of section .text:
                	mv	a1, s10
                	auipc	ra, 0x0
                	jalr	ra <.Lpcrel_hi.9+0xc4>
-               	addi	a1, s0, -0x490
+               	addi	a1, s0, -0x628
                	sext.w	a2, s5
                	mv	a3, a1
                	sw	a2, 0x0(a3)
-               	addi	a2, s0, -0x4a8
+               	addi	a2, s0, -0x640
                	mv	a3, a2
                	sd	s5, 0x0(a3)
                	not	a3, s5
@@ -1251,7 +1251,7 @@ Disassembly of section .text:
                	sd	a4, 0x8(a3)
                	ld	a4, 0x10(a2)
                	sd	a4, 0x10(a3)
-               	addi	a2, s0, -0x4b8
+               	addi	a2, s0, -0x650
                	li	t0, 0xb
                	mul	a3, s5, t0
                	mv	a4, a2
@@ -1264,8 +1264,21 @@ Disassembly of section .text:
                	sd	a4, 0x0(a3)
                	ld	a4, 0x8(a2)
                	sd	a4, 0x8(a3)
+               	ld	a2, 0x0(a1)
+               	sd	a2, -0x680(s0)
+               	ld	a2, 0x8(a1)
+               	sd	a2, -0x678(s0)
+               	ld	a2, 0x10(a1)
+               	sd	a2, -0x670(s0)
+               	ld	a2, 0x18(a1)
+               	sd	a2, -0x668(s0)
+               	ld	a2, 0x20(a1)
+               	sd	a2, -0x660(s0)
+               	ld	a2, 0x28(a1)
+               	sd	a2, -0x658(s0)
+               	addi	a1, s0, -0x680
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.9+0x158>
+               	jalr	ra <.Lpcrel_hi.9+0x18c>
                	addi	s4, s4, 0x1
                	mv	s3, a0
                	li	t0, 0x8
@@ -1280,8 +1293,8 @@ Disassembly of section .text:
                	mv	s6, a1
                	mv	s7, a3
                	li	t0, 0x8
-               	bltu	s4, t0, 0x1304 <.Lpcrel_hi.9+0x1a0>
-               	j	0x1360 <.Lpcrel_hi.9+0x1fc>
+               	bltu	s4, t0, 0x1338 <.Lpcrel_hi.9+0x1d4>
+               	j	0x1394 <.Lpcrel_hi.9+0x230>
                	slli	t0, s4, 0x3
                	add	a0, s2, t0
                	ld	a1, 0x0(a0)
@@ -1291,23 +1304,23 @@ Disassembly of section .text:
                	mv	a0, s3
                	mv	a1, s8
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.9+0x1c0>
+               	jalr	ra <.Lpcrel_hi.9+0x1f4>
                	mv	a1, s9
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.9+0x1cc>
+               	jalr	ra <.Lpcrel_hi.9+0x200>
                	mv	a1, s10
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.9+0x1d8>
+               	jalr	ra <.Lpcrel_hi.9+0x20c>
                	addi	s4, s4, 0x1
                	mv	s3, a0
                	mv	s5, s8
                	mv	s6, s9
                	mv	s7, s10
                	li	t0, 0x8
-               	bltu	s4, t0, 0x1304 <.Lpcrel_hi.9+0x1a0>
+               	bltu	s4, t0, 0x1338 <.Lpcrel_hi.9+0x1d4>
                	addi	s4, s0, -0xa8
                	addi	a0, s1, 0x2
-               	addi	a1, s0, -0x238
+               	addi	a1, s0, -0x268
                	mv	a2, a1
                	sd	a0, 0x0(a2)
                	addi	a2, a0, 0x1
@@ -1344,16 +1357,28 @@ Disassembly of section .text:
                	sd	a0, 0x28(s4)
                	li	s5, 0x0
                	li	t0, 0x8
-               	bltu	s5, t0, 0x1404 <.Lpcrel_hi.9+0x2a0>
-               	j	0x14dc <.Lpcrel_hi.9+0x378>
+               	bltu	s5, t0, 0x1438 <.Lpcrel_hi.9+0x2d4>
+               	j	0x1540 <.Lpcrel_hi.9+0x3dc>
                	slli	t0, s5, 0x3
                	add	a0, s2, t0
                	ld	a2, 0x0(a0)
                	addi	s6, s0, -0xd8
                	mv	a0, s6
-               	mv	a1, s4
+               	ld	a1, 0x0(s4)
+               	sd	a1, -0x108(s0)
+               	ld	a1, 0x8(s4)
+               	sd	a1, -0x100(s0)
+               	ld	a1, 0x10(s4)
+               	sd	a1, -0xf8(s0)
+               	ld	a1, 0x18(s4)
+               	sd	a1, -0xf0(s0)
+               	ld	a1, 0x20(s4)
+               	sd	a1, -0xe8(s0)
+               	ld	a1, 0x28(s4)
+               	sd	a1, -0xe0(s0)
+               	addi	a1, s0, -0x108
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.9+0x2b8>
+               	jalr	ra <.Lpcrel_hi.9+0x31c>
                	ld	a0, 0x0(s6)
                	sd	a0, 0x0(s4)
                	ld	a0, 0x8(s6)
@@ -1380,27 +1405,27 @@ Disassembly of section .text:
                	ld	s10, 0x0(a0)
                	mv	a0, s3
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.9+0x324>
+               	jalr	ra <.Lpcrel_hi.9+0x388>
                	mv	a1, s6
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.9+0x330>
+               	jalr	ra <.Lpcrel_hi.9+0x394>
                	mv	a1, s7
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.9+0x33c>
+               	jalr	ra <.Lpcrel_hi.9+0x3a0>
                	mv	a1, s8
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.9+0x348>
+               	jalr	ra <.Lpcrel_hi.9+0x3ac>
                	mv	a1, s9
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.9+0x354>
+               	jalr	ra <.Lpcrel_hi.9+0x3b8>
                	mv	a1, s10
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.9+0x360>
+               	jalr	ra <.Lpcrel_hi.9+0x3c4>
                	addi	s5, s5, 0x1
                	mv	s3, a0
                	li	t0, 0x8
-               	bltu	s5, t0, 0x1404 <.Lpcrel_hi.9+0x2a0>
-               	addi	s4, s0, -0x198
+               	bltu	s5, t0, 0x1438 <.Lpcrel_hi.9+0x2d4>
+               	addi	s4, s0, -0x1c8
                	sd	zero, 0x0(s4)
                	sd	zero, 0x8(s4)
                	sd	zero, 0x10(s4)
@@ -1427,13 +1452,13 @@ Disassembly of section .text:
                	sd	zero, 0xb8(s4)
                	li	a0, 0x0
                	li	t0, 0x6
-               	bltu	a0, t0, 0x1550 <.Lpcrel_hi.9+0x3ec>
-               	j	0x15cc <.Lpcrel_hi.9+0x468>
+               	bltu	a0, t0, 0x15b4 <.Lpcrel_hi.9+0x450>
+               	j	0x1630 <.Lpcrel_hi.9+0x4cc>
                	slli	t0, a0, 0x3
                	add	a1, s2, t0
                	ld	a2, 0x0(a1)
                	add	a1, a2, s1
-               	addi	a2, s0, -0x258
+               	addi	a2, s0, -0x288
                	mv	a3, a2
                	sd	a1, 0x0(a3)
                	addi	a3, a1, 0x1
@@ -1459,11 +1484,11 @@ Disassembly of section .text:
                	sd	a1, 0x18(a3)
                	addi	a0, a0, 0x1
                	li	t0, 0x6
-               	bltu	a0, t0, 0x1550 <.Lpcrel_hi.9+0x3ec>
+               	bltu	a0, t0, 0x15b4 <.Lpcrel_hi.9+0x450>
                	li	s5, 0x0
                	li	t0, 0x6
-               	bltu	s5, t0, 0x15dc <.Lpcrel_hi.9+0x478>
-               	j	0x164c <.Lpcrel_hi.9+0x4e8>
+               	bltu	s5, t0, 0x1640 <.Lpcrel_hi.9+0x4dc>
+               	j	0x16b0 <.Lpcrel_hi.9+0x54c>
                	li	t0, 0x20
                	mul	a0, s5, t0
                	add	a1, s4, a0
@@ -1478,21 +1503,21 @@ Disassembly of section .text:
                	mv	a0, s3
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.9+0x4ac>
+               	jalr	ra <.Lpcrel_hi.9+0x510>
                	mv	a1, s6
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.9+0x4b8>
+               	jalr	ra <.Lpcrel_hi.9+0x51c>
                	mv	a1, s7
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.9+0x4c4>
+               	jalr	ra <.Lpcrel_hi.9+0x528>
                	mv	a1, s8
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.9+0x4d0>
+               	jalr	ra <.Lpcrel_hi.9+0x534>
                	addi	s5, s5, 0x1
                	mv	s3, a0
                	li	t0, 0x6
-               	bltu	s5, t0, 0x15dc <.Lpcrel_hi.9+0x478>
-               	addi	a1, s0, -0x1c8
+               	bltu	s5, t0, 0x1640 <.Lpcrel_hi.9+0x4dc>
+               	addi	a1, s0, -0x1f8
                	sd	zero, 0x0(a1)
                	sd	zero, 0x8(a1)
                	sd	zero, 0x10(a1)
@@ -1510,7 +1535,7 @@ Disassembly of section .text:
                	addi	a4, a3, 0x1
                	mv	a3, s2
                	ld	a5, 0x0(a3)
-               	addi	a3, s0, -0x2b8
+               	addi	a3, s0, -0x300
                	add	a6, a0, a5
                	mv	a7, a3
                	sd	a6, 0x0(a7)
@@ -1527,7 +1552,7 @@ Disassembly of section .text:
                	sd	a2, 0x8(a0)
                	ld	a2, 0x10(a3)
                	sd	a2, 0x10(a0)
-               	addi	a0, s0, -0x2c8
+               	addi	a0, s0, -0x310
                	addi	a2, s2, 0x8
                	ld	a3, 0x0(a2)
                	mv	a2, a0
@@ -1542,18 +1567,31 @@ Disassembly of section .text:
                	ld	a3, 0x8(a0)
                	sd	a3, 0x8(a2)
                	mv	a0, s3
+               	ld	a2, 0x0(a1)
+               	sd	a2, -0x340(s0)
+               	ld	a2, 0x8(a1)
+               	sd	a2, -0x338(s0)
+               	ld	a2, 0x10(a1)
+               	sd	a2, -0x330(s0)
+               	ld	a2, 0x18(a1)
+               	sd	a2, -0x328(s0)
+               	ld	a2, 0x20(a1)
+               	sd	a2, -0x320(s0)
+               	ld	a2, 0x28(a1)
+               	sd	a2, -0x318(s0)
+               	addi	a1, s0, -0x340
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.9+0x5b0>
+               	jalr	ra <.Lpcrel_hi.9+0x648>
                	mv	s3, a0
                	li	s4, 0x0
                	li	t0, 0x4
-               	bltu	s4, t0, 0x1730 <.Lpcrel_hi.9+0x5cc>
-               	j	0x1b48 <.Lpcrel_hi.9+0x9e4>
+               	bltu	s4, t0, 0x17c8 <.Lpcrel_hi.9+0x664>
+               	j	0x1d2c <.Lpcrel_hi.9+0xbc8>
                	slli	t0, s4, 0x3
                	add	a0, s2, t0
                	ld	a1, 0x0(a0)
                	add	s5, a1, s1
-               	addi	a1, s0, -0x270
+               	addi	a1, s0, -0x2a0
                	mv	a0, a1
                	sd	s5, 0x0(a0)
                	not	a0, s5
@@ -1564,11 +1602,18 @@ Disassembly of section .text:
                	addi	a2, a0, 0x1
                	addi	a0, a1, 0x10
                	sd	a2, 0x0(a0)
-               	addi	s6, s0, -0x2a0
+               	addi	s6, s0, -0x2d0
                	mv	a0, s6
+               	ld	a2, 0x0(a1)
+               	sd	a2, -0x2e8(s0)
+               	ld	a2, 0x8(a1)
+               	sd	a2, -0x2e0(s0)
+               	ld	a2, 0x10(a1)
+               	sd	a2, -0x2d8(s0)
+               	addi	a1, s0, -0x2e8
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.9+0x610>
-               	addi	a1, s0, -0x2f8
+               	jalr	ra <.Lpcrel_hi.9+0x6c4>
+               	addi	a1, s0, -0x370
                	mv	a0, a1
                	sd	s5, 0x0(a0)
                	addi	a0, s5, 0x1
@@ -1591,10 +1636,23 @@ Disassembly of section .text:
                	xor	a0, s5, t0
                	addi	a2, a1, 0x28
                	sd	a0, 0x0(a2)
-               	addi	s7, s0, -0x310
+               	addi	s7, s0, -0x388
                	mv	a0, s7
+               	ld	a2, 0x0(a1)
+               	sd	a2, -0x3b8(s0)
+               	ld	a2, 0x8(a1)
+               	sd	a2, -0x3b0(s0)
+               	ld	a2, 0x10(a1)
+               	sd	a2, -0x3a8(s0)
+               	ld	a2, 0x18(a1)
+               	sd	a2, -0x3a0(s0)
+               	ld	a2, 0x20(a1)
+               	sd	a2, -0x398(s0)
+               	ld	a2, 0x28(a1)
+               	sd	a2, -0x390(s0)
+               	addi	a1, s0, -0x3b8
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.9+0x67c>
+               	jalr	ra <.Lpcrel_hi.9+0x764>
                	mv	a0, s6
                	ld	s8, 0x0(a0)
                	addi	a0, s6, 0x8
@@ -1605,58 +1663,58 @@ Disassembly of section .text:
                	ld	s11, 0x0(a0)
                	addi	a0, s6, 0x20
                	ld	t2, 0x0(a0)
-               	sd	t2, -0x4c0(s0)
+               	sd	t2, -0x688(s0)
                	addi	a0, s6, 0x28
                	ld	s6, 0x0(a0)
                	mv	a0, s7
                	ld	t2, 0x0(a0)
-               	sd	t2, -0x4c8(s0)
+               	sd	t2, -0x690(s0)
                	addi	a0, s7, 0x8
                	ld	t2, 0x0(a0)
-               	sd	t2, -0x4d0(s0)
+               	sd	t2, -0x698(s0)
                	addi	a0, s7, 0x10
                	ld	s7, 0x0(a0)
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.9+0x6d8>
+               	jalr	ra <.Lpcrel_hi.9+0x7c0>
                	mv	a1, s8
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.9+0x6e4>
+               	jalr	ra <.Lpcrel_hi.9+0x7cc>
                	mv	a1, s9
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.9+0x6f0>
+               	jalr	ra <.Lpcrel_hi.9+0x7d8>
                	mv	a1, s10
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.9+0x6fc>
+               	jalr	ra <.Lpcrel_hi.9+0x7e4>
                	mv	a1, s11
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.9+0x708>
-               	ld	t2, -0x4c0(s0)
+               	jalr	ra <.Lpcrel_hi.9+0x7f0>
+               	ld	t2, -0x688(s0)
                	mv	a1, t2
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.9+0x718>
+               	jalr	ra <.Lpcrel_hi.9+0x800>
                	mv	a1, s6
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.9+0x724>
-               	ld	t2, -0x4c8(s0)
+               	jalr	ra <.Lpcrel_hi.9+0x80c>
+               	ld	t2, -0x690(s0)
                	mv	a1, t2
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.9+0x734>
-               	ld	t2, -0x4d0(s0)
+               	jalr	ra <.Lpcrel_hi.9+0x81c>
+               	ld	t2, -0x698(s0)
                	mv	a1, t2
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.9+0x744>
+               	jalr	ra <.Lpcrel_hi.9+0x82c>
                	mv	a1, s7
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.9+0x750>
+               	jalr	ra <.Lpcrel_hi.9+0x838>
                	mv	a1, s5
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.9+0x75c>
+               	jalr	ra <.Lpcrel_hi.9+0x844>
                	mv	a1, a0
                	mv	a0, s3
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.9+0x76c>
+               	jalr	ra <.Lpcrel_hi.9+0x854>
                	mv	s6, a0
-               	addi	a1, s0, -0x340
+               	addi	a1, s0, -0x3e8
                	mv	a0, a1
                	sd	s5, 0x0(a0)
                	addi	a0, s5, 0x1
@@ -1679,15 +1737,34 @@ Disassembly of section .text:
                	xor	a0, s5, t0
                	addi	a2, a1, 0x28
                	sd	a0, 0x0(a2)
-               	addi	s7, s0, -0x358
+               	addi	s7, s0, -0x400
                	mv	a0, s7
+               	ld	a2, 0x0(a1)
+               	sd	a2, -0x430(s0)
+               	ld	a2, 0x8(a1)
+               	sd	a2, -0x428(s0)
+               	ld	a2, 0x10(a1)
+               	sd	a2, -0x420(s0)
+               	ld	a2, 0x18(a1)
+               	sd	a2, -0x418(s0)
+               	ld	a2, 0x20(a1)
+               	sd	a2, -0x410(s0)
+               	ld	a2, 0x28(a1)
+               	sd	a2, -0x408(s0)
+               	addi	a1, s0, -0x430
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.9+0x7dc>
-               	addi	s8, s0, -0x388
+               	jalr	ra <.Lpcrel_hi.9+0x8f8>
+               	addi	s8, s0, -0x460
                	mv	a0, s8
-               	mv	a1, s7
+               	ld	a1, 0x0(s7)
+               	sd	a1, -0x478(s0)
+               	ld	a1, 0x8(s7)
+               	sd	a1, -0x470(s0)
+               	ld	a1, 0x10(s7)
+               	sd	a1, -0x468(s0)
+               	addi	a1, s0, -0x478
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.9+0x7f0>
+               	jalr	ra <.Lpcrel_hi.9+0x924>
                	mv	a0, s8
                	ld	a1, 0x0(a0)
                	addi	a0, s8, 0x8
@@ -1702,24 +1779,24 @@ Disassembly of section .text:
                	ld	s8, 0x0(a0)
                	mv	a0, s6
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.9+0x82c>
+               	jalr	ra <.Lpcrel_hi.9+0x960>
                	mv	a1, s7
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.9+0x838>
+               	jalr	ra <.Lpcrel_hi.9+0x96c>
                	mv	a1, s9
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.9+0x844>
+               	jalr	ra <.Lpcrel_hi.9+0x978>
                	mv	a1, s10
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.9+0x850>
+               	jalr	ra <.Lpcrel_hi.9+0x984>
                	mv	a1, s11
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.9+0x85c>
+               	jalr	ra <.Lpcrel_hi.9+0x990>
                	mv	a1, s8
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.9+0x868>
+               	jalr	ra <.Lpcrel_hi.9+0x99c>
                	mv	s6, a0
-               	addi	a1, s0, -0x3a0
+               	addi	a1, s0, -0x490
                	mv	a0, a1
                	sd	s5, 0x0(a0)
                	not	a0, s5
@@ -1730,15 +1807,34 @@ Disassembly of section .text:
                	addi	a2, a0, 0x1
                	addi	a0, a1, 0x10
                	sd	a2, 0x0(a0)
-               	addi	s7, s0, -0x3d0
+               	addi	s7, s0, -0x4c0
                	mv	a0, s7
+               	ld	a2, 0x0(a1)
+               	sd	a2, -0x4d8(s0)
+               	ld	a2, 0x8(a1)
+               	sd	a2, -0x4d0(s0)
+               	ld	a2, 0x10(a1)
+               	sd	a2, -0x4c8(s0)
+               	addi	a1, s0, -0x4d8
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.9+0x8a8>
-               	addi	s8, s0, -0x3e8
+               	jalr	ra <.Lpcrel_hi.9+0x9f8>
+               	addi	s8, s0, -0x4f0
                	mv	a0, s8
-               	mv	a1, s7
+               	ld	a1, 0x0(s7)
+               	sd	a1, -0x520(s0)
+               	ld	a1, 0x8(s7)
+               	sd	a1, -0x518(s0)
+               	ld	a1, 0x10(s7)
+               	sd	a1, -0x510(s0)
+               	ld	a1, 0x18(s7)
+               	sd	a1, -0x508(s0)
+               	ld	a1, 0x20(s7)
+               	sd	a1, -0x500(s0)
+               	ld	a1, 0x28(s7)
+               	sd	a1, -0x4f8(s0)
+               	addi	a1, s0, -0x520
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.9+0x8bc>
+               	jalr	ra <.Lpcrel_hi.9+0xa3c>
                	mv	a0, s8
                	ld	a1, 0x0(a0)
                	addi	a0, s8, 0x8
@@ -1747,15 +1843,15 @@ Disassembly of section .text:
                	ld	s8, 0x0(a0)
                	mv	a0, s6
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.9+0x8e0>
+               	jalr	ra <.Lpcrel_hi.9+0xa60>
                	mv	a1, s7
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.9+0x8ec>
+               	jalr	ra <.Lpcrel_hi.9+0xa6c>
                	mv	a1, s8
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.9+0x8f8>
+               	jalr	ra <.Lpcrel_hi.9+0xa78>
                	mv	s6, a0
-               	addi	a1, s0, -0x418
+               	addi	a1, s0, -0x550
                	mv	a0, a1
                	sd	s5, 0x0(a0)
                	addi	a0, s5, 0x1
@@ -1778,16 +1874,41 @@ Disassembly of section .text:
                	xor	a0, s5, t0
                	addi	a2, a1, 0x28
                	sd	a0, 0x0(a2)
-               	addi	s7, s0, -0x448
+               	addi	s7, s0, -0x580
                	mv	a0, s7
+               	ld	a2, 0x0(a1)
+               	sd	a2, -0x5b0(s0)
+               	ld	a2, 0x8(a1)
+               	sd	a2, -0x5a8(s0)
+               	ld	a2, 0x10(a1)
+               	sd	a2, -0x5a0(s0)
+               	ld	a2, 0x18(a1)
+               	sd	a2, -0x598(s0)
+               	ld	a2, 0x20(a1)
+               	sd	a2, -0x590(s0)
+               	ld	a2, 0x28(a1)
+               	sd	a2, -0x588(s0)
+               	addi	a1, s0, -0x5b0
                	mv	a2, s5
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.9+0x96c>
-               	addi	s8, s0, -0x460
+               	jalr	ra <.Lpcrel_hi.9+0xb20>
+               	addi	s8, s0, -0x5c8
                	mv	a0, s8
-               	mv	a1, s7
+               	ld	a1, 0x0(s7)
+               	sd	a1, -0x5f8(s0)
+               	ld	a1, 0x8(s7)
+               	sd	a1, -0x5f0(s0)
+               	ld	a1, 0x10(s7)
+               	sd	a1, -0x5e8(s0)
+               	ld	a1, 0x18(s7)
+               	sd	a1, -0x5e0(s0)
+               	ld	a1, 0x20(s7)
+               	sd	a1, -0x5d8(s0)
+               	ld	a1, 0x28(s7)
+               	sd	a1, -0x5d0(s0)
+               	addi	a1, s0, -0x5f8
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.9+0x980>
+               	jalr	ra <.Lpcrel_hi.9+0xb64>
                	mv	a0, s8
                	ld	a1, 0x0(a0)
                	addi	a0, s8, 0x8
@@ -1800,32 +1921,32 @@ Disassembly of section .text:
                	mv	a0, s6
                	mv	a1, a4
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.9+0x9b4>
+               	jalr	ra <.Lpcrel_hi.9+0xb98>
                	mv	a1, s7
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.9+0x9c0>
+               	jalr	ra <.Lpcrel_hi.9+0xba4>
                	mv	a1, s5
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.9+0x9cc>
+               	jalr	ra <.Lpcrel_hi.9+0xbb0>
                	addi	s4, s4, 0x1
                	mv	s3, a0
                	li	t0, 0x4
-               	bltu	s4, t0, 0x1730 <.Lpcrel_hi.9+0x5cc>
+               	bltu	s4, t0, 0x17c8 <.Lpcrel_hi.9+0x664>
                	mv	a0, s3
-               	ld	s1, 0x4c8(sp)
-               	ld	s2, 0x4c0(sp)
-               	ld	s3, 0x4b8(sp)
-               	ld	s4, 0x4b0(sp)
-               	ld	s5, 0x4a8(sp)
-               	ld	s6, 0x4a0(sp)
-               	ld	s7, 0x498(sp)
-               	ld	s8, 0x490(sp)
-               	ld	s9, 0x488(sp)
-               	ld	s10, 0x480(sp)
-               	ld	s11, 0x478(sp)
-               	fld	fs0, 0x470(sp)
-               	fld	fs1, 0x468(sp)
-               	ld	ra, 0x4d8(sp)
-               	ld	s0, 0x4d0(sp)
-               	addi	sp, sp, 0x4e0
+               	ld	s1, 0x688(sp)
+               	ld	s2, 0x680(sp)
+               	ld	s3, 0x678(sp)
+               	ld	s4, 0x670(sp)
+               	ld	s5, 0x668(sp)
+               	ld	s6, 0x660(sp)
+               	ld	s7, 0x658(sp)
+               	ld	s8, 0x650(sp)
+               	ld	s9, 0x648(sp)
+               	ld	s10, 0x640(sp)
+               	ld	s11, 0x638(sp)
+               	fld	fs0, 0x630(sp)
+               	fld	fs1, 0x628(sp)
+               	ld	ra, 0x698(sp)
+               	ld	s0, 0x690(sp)
+               	addi	sp, sp, 0x6a0
                	ret

--- a/test/golden/riscv64-linux/cmp/short_circuit.dis
+++ b/test/golden/riscv64-linux/cmp/short_circuit.dis
@@ -269,35 +269,40 @@ Disassembly of section .text:
                	mv	a1, a1
                	sd	a0, 0x0(a1)
                	li	t1, 0x1
-               	xor	a1, t1, s2
+               	xor	a0, t1, s2
 
 <.Lpcrel_hi.30>:
                	auipc	t0, 0x0
-               	ld	a0, 0x0(t0)
-               	addi	a2, a0, 0x1
+               	ld	a1, 0x0(t0)
+               	addi	a2, a1, 0x1
 
 <.Lpcrel_hi.31>:
                	auipc	t0, 0x0
                	sd	a2, 0x0(t0)
 
 <.Lpcrel_hi.32>:
-               	auipc	a0, 0x0
-               	mv	a0, a0
-               	ld	a2, 0x0(a0)
+               	auipc	a1, 0x0
+               	mv	a1, a1
+               	ld	a2, 0x0(a1)
                	addi	a3, a2, 0x1
-               	sd	a3, 0x0(a0)
+               	sd	a3, 0x0(a1)
 
 <.Lpcrel_hi.33>:
                	auipc	t0, 0x0
-               	ld	a0, 0x0(t0)
+               	ld	a1, 0x0(t0)
 
 <.Lpcrel_hi.34>:
                	auipc	a2, 0x0
                	mv	a2, a2
-               	sd	a0, 0x0(a2)
+               	sd	a1, 0x0(a2)
+               	li	t0, 0x1
+               	zext.b	t1, a0
+               	zext.b	t0, t0
+               	xor	a1, t1, t0
+               	seqz	a1, a1
                	mv	a0, s4
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.34+0x10>
+               	jalr	ra <.Lpcrel_hi.34+0x24>
 
 <.Lpcrel_hi.35>:
                	auipc	t0, 0x0
@@ -315,8 +320,8 @@ Disassembly of section .text:
                	mv	s4, a0
                	li	s5, 0x0
                	li	t0, 0x4
-               	bltu	s5, t0, 0x3b0 <.Lpcrel_hi.37+0x1c>
-               	j	0x3f0 <.Lpcrel_hi.38>
+               	bltu	s5, t0, 0x3c4 <.Lpcrel_hi.37+0x1c>
+               	j	0x404 <.Lpcrel_hi.38>
                	slli	t0, s5, 0x3
                	add	a0, s1, t0
                	ld	a1, 0x0(a0)
@@ -332,7 +337,7 @@ Disassembly of section .text:
                	addi	s5, s5, 0x1
                	mv	s4, a0
                	li	t0, 0x4
-               	bltu	s5, t0, 0x3b0 <.Lpcrel_hi.37+0x1c>
+               	bltu	s5, t0, 0x3c4 <.Lpcrel_hi.37+0x1c>
 
 <.Lpcrel_hi.38>:
                	auipc	t0, 0x0
@@ -347,8 +352,8 @@ Disassembly of section .text:
                	mv	a1, a1
                	li	a2, 0x0
                	li	t0, 0x4
-               	bltu	a2, t0, 0x418 <.Lpcrel_hi.40+0x18>
-               	j	0x43c <.Lpcrel_hi.41>
+               	bltu	a2, t0, 0x42c <.Lpcrel_hi.40+0x18>
+               	j	0x450 <.Lpcrel_hi.41>
                	slli	t0, a2, 0x3
                	add	a3, a0, t0
                	sd	zero, 0x0(a3)
@@ -357,7 +362,7 @@ Disassembly of section .text:
                	sd	zero, 0x0(a3)
                	addi	a2, a2, 0x1
                	li	t0, 0x4
-               	bltu	a2, t0, 0x418 <.Lpcrel_hi.40+0x18>
+               	bltu	a2, t0, 0x42c <.Lpcrel_hi.40+0x18>
 
 <.Lpcrel_hi.41>:
                	auipc	t0, 0x0
@@ -404,8 +409,8 @@ Disassembly of section .text:
                	mv	s4, a0
                	li	s5, 0x0
                	li	t0, 0x4
-               	bltu	s5, t0, 0x4bc <.Lpcrel_hi.48+0x1c>
-               	j	0x4fc <.Lpcrel_hi.49>
+               	bltu	s5, t0, 0x4d0 <.Lpcrel_hi.48+0x1c>
+               	j	0x510 <.Lpcrel_hi.49>
                	slli	t0, s5, 0x3
                	add	a0, s1, t0
                	ld	a1, 0x0(a0)
@@ -421,7 +426,7 @@ Disassembly of section .text:
                	addi	s5, s5, 0x1
                	mv	s4, a0
                	li	t0, 0x4
-               	bltu	s5, t0, 0x4bc <.Lpcrel_hi.48+0x1c>
+               	bltu	s5, t0, 0x4d0 <.Lpcrel_hi.48+0x1c>
 
 <.Lpcrel_hi.49>:
                	auipc	t0, 0x0
@@ -436,8 +441,8 @@ Disassembly of section .text:
                	mv	a1, a1
                	li	a2, 0x0
                	li	t0, 0x4
-               	bltu	a2, t0, 0x524 <.Lpcrel_hi.51+0x18>
-               	j	0x548 <.Lpcrel_hi.52>
+               	bltu	a2, t0, 0x538 <.Lpcrel_hi.51+0x18>
+               	j	0x55c <.Lpcrel_hi.51+0x3c>
                	slli	t0, a2, 0x3
                	add	a3, a0, t0
                	sd	zero, 0x0(a3)
@@ -446,281 +451,270 @@ Disassembly of section .text:
                	sd	zero, 0x0(a3)
                	addi	a2, a2, 0x1
                	li	t0, 0x4
-               	bltu	a2, t0, 0x524 <.Lpcrel_hi.51+0x18>
+               	bltu	a2, t0, 0x538 <.Lpcrel_hi.51+0x18>
+               	li	a0, 0x0
+               	li	a1, 0x0
+               	auipc	ra, 0x0
+               	jalr	ra <.Lpcrel_hi.51+0x44>
+               	li	t0, 0x1
+               	zext.b	t1, a0
+               	zext.b	t0, t0
+               	xor	a1, t1, t0
+               	seqz	a1, a1
+               	bnez	a1, 0x5e0 <.Lpcrel_hi.56+0x24>
+               	li	t1, 0x1
+               	xor	a0, t1, s2
 
 <.Lpcrel_hi.52>:
                	auipc	t0, 0x0
-               	ld	a0, 0x0(t0)
-               	addi	a1, a0, 0x1
+               	ld	a2, 0x0(t0)
+               	addi	a3, a2, 0x1
 
 <.Lpcrel_hi.53>:
                	auipc	t0, 0x0
-               	sd	a1, 0x0(t0)
+               	sd	a3, 0x0(t0)
 
 <.Lpcrel_hi.54>:
-               	auipc	a0, 0x0
-               	mv	a0, a0
-               	ld	a1, 0x0(a0)
-               	addi	a2, a1, 0x1
-               	sd	a2, 0x0(a0)
+               	auipc	a2, 0x0
+               	mv	a2, a2
+               	ld	a3, 0x0(a2)
+               	addi	a4, a3, 0x1
+               	sd	a4, 0x0(a2)
 
 <.Lpcrel_hi.55>:
                	auipc	t0, 0x0
-               	ld	a0, 0x0(t0)
+               	ld	a2, 0x0(t0)
 
 <.Lpcrel_hi.56>:
-               	auipc	a1, 0x0
-               	mv	a1, a1
-               	sd	a0, 0x0(a1)
-               	li	t1, 0x1
-               	xor	a1, t1, s2
+               	auipc	a3, 0x0
+               	mv	a3, a3
+               	sd	a2, 0x0(a3)
+               	li	t0, 0x1
+               	zext.b	t1, a0
+               	zext.b	t0, t0
+               	xor	a2, t1, t0
+               	seqz	a2, a2
+               	j	0x5e4 <.Lpcrel_hi.56+0x28>
+               	mv	a2, a1
+               	mv	a0, s4
+               	mv	a1, a2
+               	auipc	ra, 0x0
+               	jalr	ra <.Lpcrel_hi.56+0x30>
 
 <.Lpcrel_hi.57>:
+               	auipc	t0, 0x0
+               	ld	a1, 0x0(t0)
+               	auipc	ra, 0x0
+               	jalr	ra <.Lpcrel_hi.57+0x8>
+
+<.Lpcrel_hi.58>:
+               	auipc	s1, 0x0
+               	mv	s1, s1
+
+<.Lpcrel_hi.59>:
+               	auipc	s3, 0x0
+               	mv	s3, s3
+               	mv	s4, a0
+               	li	s5, 0x0
+               	li	t0, 0x4
+               	bltu	s5, t0, 0x628 <.Lpcrel_hi.59+0x1c>
+               	j	0x668 <.Lpcrel_hi.60>
+               	slli	t0, s5, 0x3
+               	add	a0, s1, t0
+               	ld	a1, 0x0(a0)
+               	mv	a0, s4
+               	auipc	ra, 0x0
+               	jalr	ra <.Lpcrel_hi.59+0x2c>
+               	slli	t0, s5, 0x3
+               	add	a1, s3, t0
+               	ld	a2, 0x0(a1)
+               	mv	a1, a2
+               	auipc	ra, 0x0
+               	jalr	ra <.Lpcrel_hi.59+0x44>
+               	addi	s5, s5, 0x1
+               	mv	s4, a0
+               	li	t0, 0x4
+               	bltu	s5, t0, 0x628 <.Lpcrel_hi.59+0x1c>
+
+<.Lpcrel_hi.60>:
+               	auipc	t0, 0x0
+               	sd	zero, 0x0(t0)
+
+<.Lpcrel_hi.61>:
+               	auipc	a0, 0x0
+               	mv	a0, a0
+
+<.Lpcrel_hi.62>:
+               	auipc	a1, 0x0
+               	mv	a1, a1
+               	li	a2, 0x0
+               	li	t0, 0x4
+               	bltu	a2, t0, 0x690 <.Lpcrel_hi.62+0x18>
+               	j	0x6b4 <.Lpcrel_hi.62+0x3c>
+               	slli	t0, a2, 0x3
+               	add	a3, a0, t0
+               	sd	zero, 0x0(a3)
+               	slli	t0, a2, 0x3
+               	add	a3, a1, t0
+               	sd	zero, 0x0(a3)
+               	addi	a2, a2, 0x1
+               	li	t0, 0x4
+               	bltu	a2, t0, 0x690 <.Lpcrel_hi.62+0x18>
+               	li	a0, 0x0
+               	li	a1, 0x0
+               	auipc	ra, 0x0
+               	jalr	ra <.Lpcrel_hi.62+0x44>
+               	li	t0, 0x1
+               	zext.b	t1, a0
+               	zext.b	t0, t0
+               	xor	a1, t1, t0
+               	seqz	a1, a1
+               	bnez	a1, 0x720 <.Lpcrel_hi.67+0x14>
+
+<.Lpcrel_hi.63>:
                	auipc	t0, 0x0
                	ld	a0, 0x0(t0)
                	addi	a2, a0, 0x1
 
-<.Lpcrel_hi.58>:
+<.Lpcrel_hi.64>:
                	auipc	t0, 0x0
                	sd	a2, 0x0(t0)
 
-<.Lpcrel_hi.59>:
+<.Lpcrel_hi.65>:
                	auipc	a0, 0x0
                	mv	a0, a0
                	ld	a2, 0x0(a0)
                	addi	a3, a2, 0x1
                	sd	a3, 0x0(a0)
 
-<.Lpcrel_hi.60>:
+<.Lpcrel_hi.66>:
                	auipc	t0, 0x0
                	ld	a0, 0x0(t0)
 
-<.Lpcrel_hi.61>:
+<.Lpcrel_hi.67>:
                	auipc	a2, 0x0
                	mv	a2, a2
                	sd	a0, 0x0(a2)
-               	mv	a0, s4
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.61+0x10>
-
-<.Lpcrel_hi.62>:
-               	auipc	t0, 0x0
-               	ld	a1, 0x0(t0)
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.62+0x8>
-
-<.Lpcrel_hi.63>:
-               	auipc	s1, 0x0
-               	mv	s1, s1
-
-<.Lpcrel_hi.64>:
-               	auipc	s3, 0x0
-               	mv	s3, s3
-               	mv	s4, a0
-               	li	s5, 0x0
-               	li	t0, 0x4
-               	bltu	s5, t0, 0x608 <.Lpcrel_hi.64+0x1c>
-               	j	0x648 <.Lpcrel_hi.65>
-               	slli	t0, s5, 0x3
-               	add	a0, s1, t0
-               	ld	a1, 0x0(a0)
-               	mv	a0, s4
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.64+0x2c>
-               	slli	t0, s5, 0x3
-               	add	a1, s3, t0
-               	ld	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.64+0x44>
-               	addi	s5, s5, 0x1
-               	mv	s4, a0
-               	li	t0, 0x4
-               	bltu	s5, t0, 0x608 <.Lpcrel_hi.64+0x1c>
-
-<.Lpcrel_hi.65>:
-               	auipc	t0, 0x0
-               	sd	zero, 0x0(t0)
-
-<.Lpcrel_hi.66>:
-               	auipc	a0, 0x0
-               	mv	a0, a0
-
-<.Lpcrel_hi.67>:
-               	auipc	a1, 0x0
-               	mv	a1, a1
-               	li	a2, 0x0
-               	li	t0, 0x4
-               	bltu	a2, t0, 0x670 <.Lpcrel_hi.67+0x18>
-               	j	0x694 <.Lpcrel_hi.68>
-               	slli	t0, a2, 0x3
-               	add	a3, a0, t0
-               	sd	zero, 0x0(a3)
-               	slli	t0, a2, 0x3
-               	add	a3, a1, t0
-               	sd	zero, 0x0(a3)
-               	addi	a2, a2, 0x1
-               	li	t0, 0x4
-               	bltu	a2, t0, 0x670 <.Lpcrel_hi.67+0x18>
+               	li	a0, 0x1
+               	j	0x724 <.Lpcrel_hi.67+0x18>
+               	mv	a0, a1
+               	bnez	a0, 0x730 <.Lpcrel_hi.68>
+               	mv	a1, a0
+               	j	0x7d0 <.Lpcrel_hi.77+0x1c>
 
 <.Lpcrel_hi.68>:
                	auipc	t0, 0x0
                	ld	a0, 0x0(t0)
-               	addi	a1, a0, 0x1
+               	addi	a2, a0, 0x1
 
 <.Lpcrel_hi.69>:
                	auipc	t0, 0x0
-               	sd	a1, 0x0(t0)
+               	sd	a2, 0x0(t0)
 
 <.Lpcrel_hi.70>:
                	auipc	a0, 0x0
                	mv	a0, a0
-               	ld	a1, 0x0(a0)
-               	addi	a2, a1, 0x1
-               	sd	a2, 0x0(a0)
+               	ld	a2, 0x0(a0)
+               	addi	a3, a2, 0x1
+               	sd	a3, 0x0(a0)
 
 <.Lpcrel_hi.71>:
                	auipc	t0, 0x0
                	ld	a0, 0x0(t0)
 
 <.Lpcrel_hi.72>:
-               	auipc	a1, 0x0
-               	mv	a1, a1
-               	sd	a0, 0x0(a1)
+               	auipc	a2, 0x0
+               	mv	a2, a2
+               	sd	a0, 0x0(a2)
+               	li	t0, 0x1
+               	zext.b	t1, s2
+               	zext.b	t0, t0
+               	xor	a0, t1, t0
+               	seqz	a0, a0
+               	bnez	a0, 0x7c8 <.Lpcrel_hi.77+0x14>
 
 <.Lpcrel_hi.73>:
                	auipc	t0, 0x0
-               	ld	a0, 0x0(t0)
-               	addi	a1, a0, 0x1
+               	ld	a2, 0x0(t0)
+               	addi	a3, a2, 0x1
 
 <.Lpcrel_hi.74>:
                	auipc	t0, 0x0
-               	sd	a1, 0x0(t0)
+               	sd	a3, 0x0(t0)
 
 <.Lpcrel_hi.75>:
-               	auipc	a0, 0x0
-               	mv	a0, a0
-               	ld	a1, 0x0(a0)
-               	addi	a2, a1, 0x1
-               	sd	a2, 0x0(a0)
+               	auipc	a2, 0x0
+               	mv	a2, a2
+               	ld	a3, 0x0(a2)
+               	addi	a4, a3, 0x1
+               	sd	a4, 0x0(a2)
 
 <.Lpcrel_hi.76>:
                	auipc	t0, 0x0
-               	ld	a0, 0x0(t0)
+               	ld	a2, 0x0(t0)
 
 <.Lpcrel_hi.77>:
-               	auipc	a1, 0x0
-               	mv	a1, a1
-               	sd	a0, 0x0(a1)
+               	auipc	a3, 0x0
+               	mv	a3, a3
+               	sd	a2, 0x0(a3)
+               	li	a2, 0x1
+               	j	0x7cc <.Lpcrel_hi.77+0x18>
+               	mv	a2, a0
+               	mv	a1, a2
+               	mv	a0, s4
+               	auipc	ra, 0x0
+               	jalr	ra <.Lpcrel_hi.77+0x20>
 
 <.Lpcrel_hi.78>:
                	auipc	t0, 0x0
-               	ld	a0, 0x0(t0)
-               	addi	a1, a0, 0x1
-
-<.Lpcrel_hi.79>:
-               	auipc	t0, 0x0
-               	sd	a1, 0x0(t0)
-
-<.Lpcrel_hi.80>:
-               	auipc	a0, 0x0
-               	mv	a0, a0
-               	ld	a1, 0x0(a0)
-               	addi	a2, a1, 0x1
-               	sd	a2, 0x0(a0)
-
-<.Lpcrel_hi.81>:
-               	auipc	t0, 0x0
-               	ld	a0, 0x0(t0)
-
-<.Lpcrel_hi.82>:
-               	auipc	a1, 0x0
-               	mv	a1, a1
-               	sd	a0, 0x0(a1)
-               	bnez	s2, 0x790 <.Lpcrel_hi.87+0x14>
-
-<.Lpcrel_hi.83>:
-               	auipc	t0, 0x0
-               	ld	a0, 0x0(t0)
-               	addi	a1, a0, 0x1
-
-<.Lpcrel_hi.84>:
-               	auipc	t0, 0x0
-               	sd	a1, 0x0(t0)
-
-<.Lpcrel_hi.85>:
-               	auipc	a0, 0x0
-               	mv	a0, a0
-               	ld	a1, 0x0(a0)
-               	addi	a2, a1, 0x1
-               	sd	a2, 0x0(a0)
-
-<.Lpcrel_hi.86>:
-               	auipc	t0, 0x0
-               	ld	a0, 0x0(t0)
-
-<.Lpcrel_hi.87>:
-               	auipc	a1, 0x0
-               	mv	a1, a1
-               	sd	a0, 0x0(a1)
-               	li	a0, 0x1
-               	j	0x794 <.Lpcrel_hi.87+0x18>
-               	mv	a0, s2
-               	mv	a1, a0
-               	mv	a0, s4
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.87+0x20>
-
-<.Lpcrel_hi.88>:
-               	auipc	t0, 0x0
                	ld	a1, 0x0(t0)
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.88+0x8>
+               	jalr	ra <.Lpcrel_hi.78+0x8>
 
-<.Lpcrel_hi.89>:
+<.Lpcrel_hi.79>:
                	auipc	s1, 0x0
                	mv	s1, s1
 
-<.Lpcrel_hi.90>:
+<.Lpcrel_hi.80>:
                	auipc	s3, 0x0
                	mv	s3, s3
                	mv	s4, a0
                	li	s5, 0x0
                	li	t0, 0x4
-               	bltu	s5, t0, 0x7d8 <.Lpcrel_hi.90+0x1c>
-               	j	0x818 <.Lpcrel_hi.91>
+               	bltu	s5, t0, 0x810 <.Lpcrel_hi.80+0x1c>
+               	j	0x850 <.Lpcrel_hi.81>
                	slli	t0, s5, 0x3
                	add	a0, s1, t0
                	ld	a1, 0x0(a0)
                	mv	a0, s4
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.90+0x2c>
+               	jalr	ra <.Lpcrel_hi.80+0x2c>
                	slli	t0, s5, 0x3
                	add	a1, s3, t0
                	ld	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.90+0x44>
+               	jalr	ra <.Lpcrel_hi.80+0x44>
                	addi	s5, s5, 0x1
                	mv	s4, a0
                	li	t0, 0x4
-               	bltu	s5, t0, 0x7d8 <.Lpcrel_hi.90+0x1c>
+               	bltu	s5, t0, 0x810 <.Lpcrel_hi.80+0x1c>
 
-<.Lpcrel_hi.91>:
+<.Lpcrel_hi.81>:
                	auipc	t0, 0x0
                	sd	zero, 0x0(t0)
 
-<.Lpcrel_hi.92>:
+<.Lpcrel_hi.82>:
                	auipc	a0, 0x0
                	mv	a0, a0
 
-<.Lpcrel_hi.93>:
+<.Lpcrel_hi.83>:
                	auipc	a1, 0x0
                	mv	a1, a1
                	li	a2, 0x0
                	li	t0, 0x4
-               	bltu	a2, t0, 0x840 <.Lpcrel_hi.93+0x18>
-               	j	0x864 <.Lpcrel_hi.94>
+               	bltu	a2, t0, 0x878 <.Lpcrel_hi.83+0x18>
+               	j	0x89c <.Lpcrel_hi.83+0x3c>
                	slli	t0, a2, 0x3
                	add	a3, a0, t0
                	sd	zero, 0x0(a3)
@@ -729,138 +723,160 @@ Disassembly of section .text:
                	sd	zero, 0x0(a3)
                	addi	a2, a2, 0x1
                	li	t0, 0x4
-               	bltu	a2, t0, 0x840 <.Lpcrel_hi.93+0x18>
+               	bltu	a2, t0, 0x878 <.Lpcrel_hi.83+0x18>
+               	li	a0, 0x0
+               	li	a1, 0x1
+               	auipc	ra, 0x0
+               	jalr	ra <.Lpcrel_hi.83+0x44>
+               	li	t0, 0x1
+               	zext.b	t1, a0
+               	zext.b	t0, t0
+               	xor	a1, t1, t0
+               	seqz	a1, a1
+               	bnez	a1, 0x908 <.Lpcrel_hi.88+0x14>
 
-<.Lpcrel_hi.94>:
-               	auipc	t0, 0x0
-               	ld	a0, 0x0(t0)
-               	addi	a1, a0, 0x1
-
-<.Lpcrel_hi.95>:
-               	auipc	t0, 0x0
-               	sd	a1, 0x0(t0)
-
-<.Lpcrel_hi.96>:
-               	auipc	a0, 0x0
-               	mv	a0, a0
-               	ld	a1, 0x0(a0)
-               	addi	a2, a1, 0x1
-               	sd	a2, 0x0(a0)
-
-<.Lpcrel_hi.97>:
-               	auipc	t0, 0x0
-               	ld	a0, 0x0(t0)
-
-<.Lpcrel_hi.98>:
-               	auipc	a1, 0x0
-               	mv	a1, a1
-               	sd	a0, 0x0(a1)
-
-<.Lpcrel_hi.99>:
-               	auipc	t0, 0x0
-               	ld	a0, 0x0(t0)
-               	addi	a1, a0, 0x1
-
-<.Lpcrel_hi.100>:
-               	auipc	t0, 0x0
-               	sd	a1, 0x0(t0)
-
-<.Lpcrel_hi.101>:
-               	auipc	a0, 0x0
-               	mv	a0, a0
-               	ld	a1, 0x0(a0)
-               	addi	a2, a1, 0x1
-               	sd	a2, 0x0(a0)
-
-<.Lpcrel_hi.102>:
-               	auipc	t0, 0x0
-               	ld	a0, 0x0(t0)
-
-<.Lpcrel_hi.103>:
-               	auipc	a1, 0x0
-               	mv	a1, a1
-               	sd	a0, 0x0(a1)
-               	li	t1, 0x1
-               	xor	a1, t1, s2
-
-<.Lpcrel_hi.104>:
+<.Lpcrel_hi.84>:
                	auipc	t0, 0x0
                	ld	a0, 0x0(t0)
                	addi	a2, a0, 0x1
 
-<.Lpcrel_hi.105>:
+<.Lpcrel_hi.85>:
                	auipc	t0, 0x0
                	sd	a2, 0x0(t0)
 
-<.Lpcrel_hi.106>:
+<.Lpcrel_hi.86>:
                	auipc	a0, 0x0
                	mv	a0, a0
                	ld	a2, 0x0(a0)
                	addi	a3, a2, 0x1
                	sd	a3, 0x0(a0)
 
-<.Lpcrel_hi.107>:
+<.Lpcrel_hi.87>:
                	auipc	t0, 0x0
                	ld	a0, 0x0(t0)
 
-<.Lpcrel_hi.108>:
+<.Lpcrel_hi.88>:
                	auipc	a2, 0x0
                	mv	a2, a2
                	sd	a0, 0x0(a2)
+               	li	a0, 0x1
+               	j	0x90c <.Lpcrel_hi.88+0x18>
+               	mv	a0, a1
+               	bnez	a0, 0x918 <.Lpcrel_hi.89>
+               	mv	a1, a0
+               	j	0x9b0 <.Lpcrel_hi.98+0x24>
+
+<.Lpcrel_hi.89>:
+               	auipc	t0, 0x0
+               	ld	a0, 0x0(t0)
+               	addi	a2, a0, 0x1
+
+<.Lpcrel_hi.90>:
+               	auipc	t0, 0x0
+               	sd	a2, 0x0(t0)
+
+<.Lpcrel_hi.91>:
+               	auipc	a0, 0x0
+               	mv	a0, a0
+               	ld	a2, 0x0(a0)
+               	addi	a3, a2, 0x1
+               	sd	a3, 0x0(a0)
+
+<.Lpcrel_hi.92>:
+               	auipc	t0, 0x0
+               	ld	a0, 0x0(t0)
+
+<.Lpcrel_hi.93>:
+               	auipc	a2, 0x0
+               	mv	a2, a2
+               	sd	a0, 0x0(a2)
+               	li	t1, 0x1
+               	xor	a0, t1, s2
+
+<.Lpcrel_hi.94>:
+               	auipc	t0, 0x0
+               	ld	a2, 0x0(t0)
+               	addi	a3, a2, 0x1
+
+<.Lpcrel_hi.95>:
+               	auipc	t0, 0x0
+               	sd	a3, 0x0(t0)
+
+<.Lpcrel_hi.96>:
+               	auipc	a2, 0x0
+               	mv	a2, a2
+               	ld	a3, 0x0(a2)
+               	addi	a4, a3, 0x1
+               	sd	a4, 0x0(a2)
+
+<.Lpcrel_hi.97>:
+               	auipc	t0, 0x0
+               	ld	a2, 0x0(t0)
+
+<.Lpcrel_hi.98>:
+               	auipc	a3, 0x0
+               	mv	a3, a3
+               	sd	a2, 0x0(a3)
+               	li	t0, 0x1
+               	zext.b	t1, a0
+               	zext.b	t0, t0
+               	xor	a2, t1, t0
+               	seqz	a2, a2
+               	mv	a1, a2
                	mv	a0, s4
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.108+0x10>
+               	jalr	ra <.Lpcrel_hi.98+0x28>
 
-<.Lpcrel_hi.109>:
+<.Lpcrel_hi.99>:
                	auipc	t0, 0x0
                	ld	a1, 0x0(t0)
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.109+0x8>
+               	jalr	ra <.Lpcrel_hi.99+0x8>
 
-<.Lpcrel_hi.110>:
+<.Lpcrel_hi.100>:
                	auipc	s1, 0x0
                	mv	s1, s1
 
-<.Lpcrel_hi.111>:
+<.Lpcrel_hi.101>:
                	auipc	s3, 0x0
                	mv	s3, s3
                	mv	s4, a0
                	li	s5, 0x0
                	li	t0, 0x4
-               	bltu	s5, t0, 0x960 <.Lpcrel_hi.111+0x1c>
-               	j	0x9a0 <.Lpcrel_hi.112>
+               	bltu	s5, t0, 0x9f0 <.Lpcrel_hi.101+0x1c>
+               	j	0xa30 <.Lpcrel_hi.102>
                	slli	t0, s5, 0x3
                	add	a0, s1, t0
                	ld	a1, 0x0(a0)
                	mv	a0, s4
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.111+0x2c>
+               	jalr	ra <.Lpcrel_hi.101+0x2c>
                	slli	t0, s5, 0x3
                	add	a1, s3, t0
                	ld	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.111+0x44>
+               	jalr	ra <.Lpcrel_hi.101+0x44>
                	addi	s5, s5, 0x1
                	mv	s4, a0
                	li	t0, 0x4
-               	bltu	s5, t0, 0x960 <.Lpcrel_hi.111+0x1c>
+               	bltu	s5, t0, 0x9f0 <.Lpcrel_hi.101+0x1c>
 
-<.Lpcrel_hi.112>:
+<.Lpcrel_hi.102>:
                	auipc	t0, 0x0
                	sd	zero, 0x0(t0)
 
-<.Lpcrel_hi.113>:
+<.Lpcrel_hi.103>:
                	auipc	a0, 0x0
                	mv	a0, a0
 
-<.Lpcrel_hi.114>:
+<.Lpcrel_hi.104>:
                	auipc	a1, 0x0
                	mv	a1, a1
                	li	a2, 0x0
                	li	t0, 0x4
-               	bltu	a2, t0, 0x9c8 <.Lpcrel_hi.114+0x18>
-               	j	0x9ec <.Lpcrel_hi.115>
+               	bltu	a2, t0, 0xa58 <.Lpcrel_hi.104+0x18>
+               	j	0xa7c <.Lpcrel_hi.104+0x3c>
                	slli	t0, a2, 0x3
                	add	a3, a0, t0
                	sd	zero, 0x0(a3)
@@ -869,124 +885,116 @@ Disassembly of section .text:
                	sd	zero, 0x0(a3)
                	addi	a2, a2, 0x1
                	li	t0, 0x4
-               	bltu	a2, t0, 0x9c8 <.Lpcrel_hi.114+0x18>
+               	bltu	a2, t0, 0xa58 <.Lpcrel_hi.104+0x18>
+               	li	a0, 0x0
+               	li	a1, 0x0
+               	auipc	ra, 0x0
+               	jalr	ra <.Lpcrel_hi.104+0x44>
+               	li	t0, 0x1
+               	zext.b	t1, a0
+               	zext.b	t0, t0
+               	xor	a1, t1, t0
+               	seqz	a1, a1
+               	bnez	a1, 0xaf8 <.Lpcrel_hi.109+0x24>
+
+<.Lpcrel_hi.105>:
+               	auipc	t0, 0x0
+               	ld	a0, 0x0(t0)
+               	addi	a2, a0, 0x1
+
+<.Lpcrel_hi.106>:
+               	auipc	t0, 0x0
+               	sd	a2, 0x0(t0)
+
+<.Lpcrel_hi.107>:
+               	auipc	a0, 0x0
+               	mv	a0, a0
+               	ld	a2, 0x0(a0)
+               	addi	a3, a2, 0x1
+               	sd	a3, 0x0(a0)
+
+<.Lpcrel_hi.108>:
+               	auipc	t0, 0x0
+               	ld	a0, 0x0(t0)
+
+<.Lpcrel_hi.109>:
+               	auipc	a2, 0x0
+               	mv	a2, a2
+               	sd	a0, 0x0(a2)
+               	li	t0, 0x1
+               	zext.b	t1, s2
+               	zext.b	t0, t0
+               	xor	a0, t1, t0
+               	seqz	a0, a0
+               	j	0xafc <.Lpcrel_hi.109+0x28>
+               	mv	a0, a1
+               	bnez	a0, 0xb08 <.Lpcrel_hi.110>
+               	mv	a1, a0
+               	j	0xb48 <.Lpcrel_hi.114+0x10>
+
+<.Lpcrel_hi.110>:
+               	auipc	t0, 0x0
+               	ld	a0, 0x0(t0)
+               	addi	a2, a0, 0x1
+
+<.Lpcrel_hi.111>:
+               	auipc	t0, 0x0
+               	sd	a2, 0x0(t0)
+
+<.Lpcrel_hi.112>:
+               	auipc	a0, 0x0
+               	mv	a0, a0
+               	ld	a2, 0x0(a0)
+               	addi	a3, a2, 0x1
+               	sd	a3, 0x0(a0)
+
+<.Lpcrel_hi.113>:
+               	auipc	t0, 0x0
+               	ld	a0, 0x0(t0)
+
+<.Lpcrel_hi.114>:
+               	auipc	a2, 0x0
+               	mv	a2, a2
+               	sd	a0, 0x0(a2)
+               	li	a1, 0x1
+               	mv	a0, s4
+               	auipc	ra, 0x0
+               	jalr	ra <.Lpcrel_hi.114+0x14>
 
 <.Lpcrel_hi.115>:
                	auipc	t0, 0x0
-               	ld	a0, 0x0(t0)
-               	addi	a1, a0, 0x1
-
-<.Lpcrel_hi.116>:
-               	auipc	t0, 0x0
-               	sd	a1, 0x0(t0)
-
-<.Lpcrel_hi.117>:
-               	auipc	a0, 0x0
-               	mv	a0, a0
-               	ld	a1, 0x0(a0)
-               	addi	a2, a1, 0x1
-               	sd	a2, 0x0(a0)
-
-<.Lpcrel_hi.118>:
-               	auipc	t0, 0x0
-               	ld	a0, 0x0(t0)
-
-<.Lpcrel_hi.119>:
-               	auipc	a1, 0x0
-               	mv	a1, a1
-               	sd	a0, 0x0(a1)
-
-<.Lpcrel_hi.120>:
-               	auipc	t0, 0x0
-               	ld	a0, 0x0(t0)
-               	addi	a1, a0, 0x1
-
-<.Lpcrel_hi.121>:
-               	auipc	t0, 0x0
-               	sd	a1, 0x0(t0)
-
-<.Lpcrel_hi.122>:
-               	auipc	a0, 0x0
-               	mv	a0, a0
-               	ld	a1, 0x0(a0)
-               	addi	a2, a1, 0x1
-               	sd	a2, 0x0(a0)
-
-<.Lpcrel_hi.123>:
-               	auipc	t0, 0x0
-               	ld	a0, 0x0(t0)
-
-<.Lpcrel_hi.124>:
-               	auipc	a1, 0x0
-               	mv	a1, a1
-               	sd	a0, 0x0(a1)
-               	bnez	s2, 0xa6c <.Lpcrel_hi.125>
-               	j	0xaac <.Lpcrel_hi.129+0x10>
-
-<.Lpcrel_hi.125>:
-               	auipc	t0, 0x0
-               	ld	a0, 0x0(t0)
-               	addi	a1, a0, 0x1
-
-<.Lpcrel_hi.126>:
-               	auipc	t0, 0x0
-               	sd	a1, 0x0(t0)
-
-<.Lpcrel_hi.127>:
-               	auipc	a0, 0x0
-               	mv	a0, a0
-               	ld	a1, 0x0(a0)
-               	addi	a2, a1, 0x1
-               	sd	a2, 0x0(a0)
-
-<.Lpcrel_hi.128>:
-               	auipc	t0, 0x0
-               	ld	a0, 0x0(t0)
-
-<.Lpcrel_hi.129>:
-               	auipc	a1, 0x0
-               	mv	a1, a1
-               	sd	a0, 0x0(a1)
-               	li	s2, 0x1
-               	mv	a0, s4
-               	mv	a1, s2
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.129+0x18>
-
-<.Lpcrel_hi.130>:
-               	auipc	t0, 0x0
                	ld	a1, 0x0(t0)
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.130+0x8>
+               	jalr	ra <.Lpcrel_hi.115+0x8>
 
-<.Lpcrel_hi.131>:
+<.Lpcrel_hi.116>:
                	auipc	s1, 0x0
                	mv	s1, s1
 
-<.Lpcrel_hi.132>:
+<.Lpcrel_hi.117>:
                	auipc	s2, 0x0
                	mv	s2, s2
                	mv	s3, a0
                	li	s4, 0x0
                	li	t0, 0x4
-               	bltu	s4, t0, 0xaf0 <.Lpcrel_hi.132+0x1c>
-               	j	0xb30 <.Lpcrel_hi.132+0x5c>
+               	bltu	s4, t0, 0xb88 <.Lpcrel_hi.117+0x1c>
+               	j	0xbc8 <.Lpcrel_hi.117+0x5c>
                	slli	t0, s4, 0x3
                	add	a0, s1, t0
                	ld	a1, 0x0(a0)
                	mv	a0, s3
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.132+0x2c>
+               	jalr	ra <.Lpcrel_hi.117+0x2c>
                	slli	t0, s4, 0x3
                	add	a1, s2, t0
                	ld	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.132+0x44>
+               	jalr	ra <.Lpcrel_hi.117+0x44>
                	addi	s4, s4, 0x1
                	mv	s3, a0
                	li	t0, 0x4
-               	bltu	s4, t0, 0xaf0 <.Lpcrel_hi.132+0x1c>
+               	bltu	s4, t0, 0xb88 <.Lpcrel_hi.117+0x1c>
                	mv	a0, s3
                	ld	s1, 0x28(sp)
                	ld	s2, 0x20(sp)

--- a/test/golden/riscv64-linux/float/cmp_f32.dis
+++ b/test/golden/riscv64-linux/float/cmp_f32.dis
@@ -205,11 +205,11 @@ Disassembly of section .text:
                	auipc	ra, 0x0
                	jalr	ra <corpus.cases.float.cmp_f32.checksum+0x2ac>
                	flt.s	a1, fs0, fs1
-               	li	t0, 0x0
+               	li	t0, 0x1
                	zext.b	t1, a1
                	zext.b	t0, t0
                	xor	a2, t1, t0
-               	seqz	a2, a2
+               	snez	a2, a2
                	mv	a1, a2
                	auipc	ra, 0x0
                	jalr	ra <corpus.cases.float.cmp_f32.checksum+0x2d0>

--- a/test/golden/riscv64-linux/float/cmp_f64.dis
+++ b/test/golden/riscv64-linux/float/cmp_f64.dis
@@ -237,11 +237,11 @@ Disassembly of section .text:
                	auipc	ra, 0x0
                	jalr	ra <corpus.cases.float.cmp_f64.checksum+0x32c>
                	flt.d	a1, fs0, fs1
-               	li	t0, 0x0
+               	li	t0, 0x1
                	zext.b	t1, a1
                	zext.b	t0, t0
                	xor	a2, t1, t0
-               	seqz	a2, a2
+               	snez	a2, a2
                	mv	a1, a2
                	auipc	ra, 0x0
                	jalr	ra <corpus.cases.float.cmp_f64.checksum+0x350>

--- a/test/golden/riscv64-linux/float/special_f32.dis
+++ b/test/golden/riscv64-linux/float/special_f32.dis
@@ -217,932 +217,310 @@ Disassembly of section .text:
                	jalr	ra <corpus.cases.float.special_f32.checksum+0x2c0>
                	mv	s2, a0
                	fsub.s	ft0, fs3, fs2
-               	feq.s	a0, ft0, ft0
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0x36c <corpus.cases.float.special_f32.checksum+0x2f4>
                	mv	a0, s2
                	fmv.s	fa0, ft0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0x2e4>
-               	mv	s1, a0
-               	j	0x380 <corpus.cases.float.special_f32.checksum+0x308>
-               	mv	a0, s2
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0x2fc>
-               	mv	s1, a0
+               	jalr	ra <corpus.cases.float.special_f32.checksum+0x2d8>
                	fsub.s	ft0, fs3, fs3
-               	feq.s	a0, ft0, ft0
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0x3a8 <corpus.cases.float.special_f32.checksum+0x330>
-               	mv	a0, s1
                	fmv.s	fa0, ft0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0x320>
-               	mv	s2, a0
-               	j	0x3bc <corpus.cases.float.special_f32.checksum+0x344>
-               	mv	a0, s1
-               	li	a1, -0x1
+               	jalr	ra <corpus.cases.float.special_f32.checksum+0x2e8>
+               	fmul.s	ft0, fs2, fs0
+               	fmv.s	fa0, ft0
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.float.special_f32.checksum+0x2f8>
+               	fmul.s	ft0, fs2, fs1
+               	fmv.s	fa0, ft0
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.float.special_f32.checksum+0x308>
+               	fmul.s	ft0, fs3, fs0
+               	fmv.s	fa0, ft0
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.float.special_f32.checksum+0x318>
+               	fmul.s	ft0, fs3, fs1
+               	fmv.s	fa0, ft0
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.float.special_f32.checksum+0x328>
+               	fmul.s	ft0, fs3, fs3
+               	fmv.s	fa0, ft0
                	auipc	ra, 0x0
                	jalr	ra <corpus.cases.float.special_f32.checksum+0x338>
-               	mv	s2, a0
-               	fmul.s	ft0, fs2, fs0
-               	feq.s	a0, ft0, ft0
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0x3e4 <corpus.cases.float.special_f32.checksum+0x36c>
-               	mv	a0, s2
+               	fmul.s	ft0, fs2, fs3
                	fmv.s	fa0, ft0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0x35c>
-               	mv	s1, a0
-               	j	0x3f8 <corpus.cases.float.special_f32.checksum+0x380>
-               	mv	a0, s2
-               	li	a1, -0x1
+               	jalr	ra <corpus.cases.float.special_f32.checksum+0x348>
+               	fneg.s	ft0, fs2
+               	fmv.s	fa0, ft0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0x374>
-               	mv	s1, a0
-               	fmul.s	ft0, fs2, fs1
-               	feq.s	a0, ft0, ft0
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0x420 <corpus.cases.float.special_f32.checksum+0x3a8>
-               	mv	a0, s1
+               	jalr	ra <corpus.cases.float.special_f32.checksum+0x358>
+               	fneg.s	ft0, fs3
+               	fmv.s	fa0, ft0
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.float.special_f32.checksum+0x368>
+               	fdiv.s	ft0, fs2, fs0
+               	fmv.s	fa0, ft0
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.float.special_f32.checksum+0x378>
+               	fdiv.s	ft0, fs2, fs1
+               	fmv.s	fa0, ft0
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.float.special_f32.checksum+0x388>
+               	fdiv.s	ft0, fs3, fs0
                	fmv.s	fa0, ft0
                	auipc	ra, 0x0
                	jalr	ra <corpus.cases.float.special_f32.checksum+0x398>
-               	mv	s2, a0
-               	j	0x434 <corpus.cases.float.special_f32.checksum+0x3bc>
-               	mv	a0, s1
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0x3b0>
-               	mv	s2, a0
-               	fmul.s	ft0, fs3, fs0
-               	feq.s	a0, ft0, ft0
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0x45c <corpus.cases.float.special_f32.checksum+0x3e4>
-               	mv	a0, s2
+               	fdiv.s	ft0, fs3, fs1
                	fmv.s	fa0, ft0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0x3d4>
-               	mv	s1, a0
-               	j	0x470 <corpus.cases.float.special_f32.checksum+0x3f8>
-               	mv	a0, s2
-               	li	a1, -0x1
+               	jalr	ra <corpus.cases.float.special_f32.checksum+0x3a8>
+               	feq.s	a1, fs2, fs3
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0x3ec>
-               	mv	s1, a0
-               	fmul.s	ft0, fs3, fs1
-               	feq.s	a0, ft0, ft0
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0x498 <corpus.cases.float.special_f32.checksum+0x420>
-               	mv	a0, s1
+               	jalr	ra <corpus.cases.float.special_f32.checksum+0x3b4>
+               	flt.s	a1, fs2, fs3
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.float.special_f32.checksum+0x3c0>
+               	flt.s	a1, fs3, fs2
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.float.special_f32.checksum+0x3cc>
+               	fmv.s	fa0, fs4
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.float.special_f32.checksum+0x3d8>
+               	fmv.s	fa0, fs5
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.float.special_f32.checksum+0x3e4>
+               	fneg.s	ft0, fs4
                	fmv.s	fa0, ft0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0x410>
-               	mv	s2, a0
-               	j	0x4ac <corpus.cases.float.special_f32.checksum+0x434>
-               	mv	a0, s1
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0x428>
-               	mv	s2, a0
-               	fmul.s	ft0, fs3, fs3
-               	feq.s	a0, ft0, ft0
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0x4d4 <corpus.cases.float.special_f32.checksum+0x45c>
-               	mv	a0, s2
+               	jalr	ra <corpus.cases.float.special_f32.checksum+0x3f4>
+               	fdiv.s	ft0, fs0, fs2
                	fmv.s	fa0, ft0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0x44c>
-               	mv	s1, a0
-               	j	0x4e8 <corpus.cases.float.special_f32.checksum+0x470>
-               	mv	a0, s2
-               	li	a1, -0x1
+               	jalr	ra <corpus.cases.float.special_f32.checksum+0x404>
+               	fdiv.s	ft0, fs0, fs3
+               	fmv.s	fa0, ft0
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.float.special_f32.checksum+0x414>
+               	fdiv.s	ft0, fs1, fs2
+               	fmv.s	fa0, ft0
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.float.special_f32.checksum+0x424>
+               	fdiv.s	ft0, fs1, fs3
+               	fmv.s	fa0, ft0
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.float.special_f32.checksum+0x434>
+               	fadd.s	ft0, fs4, fs0
+               	fmv.s	fa0, ft0
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.float.special_f32.checksum+0x444>
+               	fadd.s	ft0, fs4, fs4
+               	fmv.s	fa0, ft0
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.float.special_f32.checksum+0x454>
+               	fsub.s	ft0, fs4, fs5
+               	fmv.s	fa0, ft0
                	auipc	ra, 0x0
                	jalr	ra <corpus.cases.float.special_f32.checksum+0x464>
-               	mv	s1, a0
-               	fmul.s	ft0, fs2, fs3
-               	feq.s	a0, ft0, ft0
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0x510 <corpus.cases.float.special_f32.checksum+0x498>
-               	mv	a0, s1
+               	fmul.s	ft0, fs4, fs4
                	fmv.s	fa0, ft0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0x488>
-               	mv	s2, a0
-               	j	0x524 <corpus.cases.float.special_f32.checksum+0x4ac>
-               	mv	a0, s1
-               	li	a1, -0x1
+               	jalr	ra <corpus.cases.float.special_f32.checksum+0x474>
+               	fmul.s	ft0, fs4, fs5
+               	fmv.s	fa0, ft0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0x4a0>
-               	mv	s2, a0
-               	fneg.s	ft0, fs2
-               	feq.s	a0, ft0, ft0
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0x54c <corpus.cases.float.special_f32.checksum+0x4d4>
-               	mv	a0, s2
+               	jalr	ra <corpus.cases.float.special_f32.checksum+0x484>
+               	fmul.s	ft0, fs4, fs1
+               	fmv.s	fa0, ft0
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.float.special_f32.checksum+0x494>
+               	fdiv.s	ft0, fs0, fs4
+               	fmv.s	fa0, ft0
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.float.special_f32.checksum+0x4a4>
+               	fdiv.s	ft0, fs1, fs4
+               	fmv.s	fa0, ft0
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.float.special_f32.checksum+0x4b4>
+               	fdiv.s	ft0, fs0, fs5
                	fmv.s	fa0, ft0
                	auipc	ra, 0x0
                	jalr	ra <corpus.cases.float.special_f32.checksum+0x4c4>
-               	mv	s1, a0
-               	j	0x560 <corpus.cases.float.special_f32.checksum+0x4e8>
-               	mv	a0, s2
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0x4dc>
-               	mv	s1, a0
-               	fneg.s	ft0, fs3
-               	feq.s	a0, ft0, ft0
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0x588 <corpus.cases.float.special_f32.checksum+0x510>
-               	mv	a0, s1
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0x500>
-               	mv	s2, a0
-               	j	0x59c <corpus.cases.float.special_f32.checksum+0x524>
-               	mv	a0, s1
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0x518>
-               	mv	s2, a0
-               	fdiv.s	ft0, fs2, fs0
-               	feq.s	a0, ft0, ft0
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0x5c4 <corpus.cases.float.special_f32.checksum+0x54c>
-               	mv	a0, s2
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0x53c>
-               	mv	s1, a0
-               	j	0x5d8 <corpus.cases.float.special_f32.checksum+0x560>
-               	mv	a0, s2
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0x554>
-               	mv	s1, a0
-               	fdiv.s	ft0, fs2, fs1
-               	feq.s	a0, ft0, ft0
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0x600 <corpus.cases.float.special_f32.checksum+0x588>
-               	mv	a0, s1
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0x578>
-               	mv	s2, a0
-               	j	0x614 <corpus.cases.float.special_f32.checksum+0x59c>
-               	mv	a0, s1
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0x590>
-               	mv	s2, a0
-               	fdiv.s	ft0, fs3, fs0
-               	feq.s	a0, ft0, ft0
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0x63c <corpus.cases.float.special_f32.checksum+0x5c4>
-               	mv	a0, s2
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0x5b4>
-               	mv	s1, a0
-               	j	0x650 <corpus.cases.float.special_f32.checksum+0x5d8>
-               	mv	a0, s2
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0x5cc>
-               	mv	s1, a0
-               	fdiv.s	ft0, fs3, fs1
-               	feq.s	a0, ft0, ft0
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0x678 <corpus.cases.float.special_f32.checksum+0x600>
-               	mv	a0, s1
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0x5f0>
-               	mv	s2, a0
-               	j	0x68c <corpus.cases.float.special_f32.checksum+0x614>
-               	mv	a0, s1
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0x608>
-               	mv	s2, a0
-               	feq.s	a1, fs2, fs3
-               	mv	a0, s2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0x61c>
-               	flt.s	a1, fs2, fs3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0x628>
-               	flt.s	a1, fs3, fs2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0x634>
-               	mv	s1, a0
-               	feq.s	a0, fs4, fs4
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0x6dc <corpus.cases.float.special_f32.checksum+0x664>
-               	mv	a0, s1
-               	fmv.s	fa0, fs4
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0x654>
-               	mv	s2, a0
-               	j	0x6f0 <corpus.cases.float.special_f32.checksum+0x678>
-               	mv	a0, s1
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0x66c>
-               	mv	s2, a0
-               	feq.s	a0, fs5, fs5
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0x714 <corpus.cases.float.special_f32.checksum+0x69c>
-               	mv	a0, s2
-               	fmv.s	fa0, fs5
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0x68c>
-               	mv	s1, a0
-               	j	0x728 <corpus.cases.float.special_f32.checksum+0x6b0>
-               	mv	a0, s2
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0x6a4>
-               	mv	s1, a0
-               	fneg.s	ft0, fs4
-               	feq.s	a0, ft0, ft0
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0x750 <corpus.cases.float.special_f32.checksum+0x6d8>
-               	mv	a0, s1
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0x6c8>
-               	mv	s2, a0
-               	j	0x764 <corpus.cases.float.special_f32.checksum+0x6ec>
-               	mv	a0, s1
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0x6e0>
-               	mv	s2, a0
-               	fdiv.s	ft0, fs0, fs2
-               	feq.s	a0, ft0, ft0
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0x78c <corpus.cases.float.special_f32.checksum+0x714>
-               	mv	a0, s2
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0x704>
-               	mv	s1, a0
-               	j	0x7a0 <corpus.cases.float.special_f32.checksum+0x728>
-               	mv	a0, s2
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0x71c>
-               	mv	s1, a0
-               	fdiv.s	ft0, fs0, fs3
-               	feq.s	a0, ft0, ft0
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0x7c8 <corpus.cases.float.special_f32.checksum+0x750>
-               	mv	a0, s1
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0x740>
-               	mv	s2, a0
-               	j	0x7dc <corpus.cases.float.special_f32.checksum+0x764>
-               	mv	a0, s1
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0x758>
-               	mv	s2, a0
-               	fdiv.s	ft0, fs1, fs2
-               	feq.s	a0, ft0, ft0
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0x804 <corpus.cases.float.special_f32.checksum+0x78c>
-               	mv	a0, s2
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0x77c>
-               	mv	s1, a0
-               	j	0x818 <corpus.cases.float.special_f32.checksum+0x7a0>
-               	mv	a0, s2
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0x794>
-               	mv	s1, a0
-               	fdiv.s	ft0, fs1, fs3
-               	feq.s	a0, ft0, ft0
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0x840 <corpus.cases.float.special_f32.checksum+0x7c8>
-               	mv	a0, s1
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0x7b8>
-               	mv	s2, a0
-               	j	0x854 <corpus.cases.float.special_f32.checksum+0x7dc>
-               	mv	a0, s1
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0x7d0>
-               	mv	s2, a0
-               	fadd.s	ft0, fs4, fs0
-               	feq.s	a0, ft0, ft0
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0x87c <corpus.cases.float.special_f32.checksum+0x804>
-               	mv	a0, s2
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0x7f4>
-               	mv	s1, a0
-               	j	0x890 <corpus.cases.float.special_f32.checksum+0x818>
-               	mv	a0, s2
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0x80c>
-               	mv	s1, a0
-               	fadd.s	ft0, fs4, fs4
-               	feq.s	a0, ft0, ft0
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0x8b8 <corpus.cases.float.special_f32.checksum+0x840>
-               	mv	a0, s1
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0x830>
-               	mv	s2, a0
-               	j	0x8cc <corpus.cases.float.special_f32.checksum+0x854>
-               	mv	a0, s1
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0x848>
-               	mv	s2, a0
-               	fsub.s	ft0, fs4, fs5
-               	feq.s	a0, ft0, ft0
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0x8f4 <corpus.cases.float.special_f32.checksum+0x87c>
-               	mv	a0, s2
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0x86c>
-               	mv	s1, a0
-               	j	0x908 <corpus.cases.float.special_f32.checksum+0x890>
-               	mv	a0, s2
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0x884>
-               	mv	s1, a0
-               	fmul.s	ft0, fs4, fs4
-               	feq.s	a0, ft0, ft0
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0x930 <corpus.cases.float.special_f32.checksum+0x8b8>
-               	mv	a0, s1
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0x8a8>
-               	mv	s2, a0
-               	j	0x944 <corpus.cases.float.special_f32.checksum+0x8cc>
-               	mv	a0, s1
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0x8c0>
-               	mv	s2, a0
-               	fmul.s	ft0, fs4, fs5
-               	feq.s	a0, ft0, ft0
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0x96c <corpus.cases.float.special_f32.checksum+0x8f4>
-               	mv	a0, s2
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0x8e4>
-               	mv	s1, a0
-               	j	0x980 <corpus.cases.float.special_f32.checksum+0x908>
-               	mv	a0, s2
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0x8fc>
-               	mv	s1, a0
-               	fmul.s	ft0, fs4, fs1
-               	feq.s	a0, ft0, ft0
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0x9a8 <corpus.cases.float.special_f32.checksum+0x930>
-               	mv	a0, s1
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0x920>
-               	mv	s2, a0
-               	j	0x9bc <corpus.cases.float.special_f32.checksum+0x944>
-               	mv	a0, s1
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0x938>
-               	mv	s2, a0
-               	fdiv.s	ft0, fs0, fs4
-               	feq.s	a0, ft0, ft0
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0x9e4 <corpus.cases.float.special_f32.checksum+0x96c>
-               	mv	a0, s2
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0x95c>
-               	mv	s1, a0
-               	j	0x9f8 <corpus.cases.float.special_f32.checksum+0x980>
-               	mv	a0, s2
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0x974>
-               	mv	s1, a0
-               	fdiv.s	ft0, fs1, fs4
-               	feq.s	a0, ft0, ft0
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0xa20 <corpus.cases.float.special_f32.checksum+0x9a8>
-               	mv	a0, s1
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0x998>
-               	mv	s2, a0
-               	j	0xa34 <corpus.cases.float.special_f32.checksum+0x9bc>
-               	mv	a0, s1
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0x9b0>
-               	mv	s2, a0
-               	fdiv.s	ft0, fs0, fs5
-               	feq.s	a0, ft0, ft0
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0xa5c <corpus.cases.float.special_f32.checksum+0x9e4>
-               	mv	a0, s2
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0x9d4>
-               	mv	s1, a0
-               	j	0xa70 <corpus.cases.float.special_f32.checksum+0x9f8>
-               	mv	a0, s2
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0x9ec>
-               	mv	s1, a0
                	fdiv.s	ft0, fs4, fs0
-               	feq.s	a0, ft0, ft0
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0xa98 <corpus.cases.float.special_f32.checksum+0xa20>
-               	mv	a0, s1
                	fmv.s	fa0, ft0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0xa10>
-               	mv	s2, a0
-               	j	0xaac <corpus.cases.float.special_f32.checksum+0xa34>
-               	mv	a0, s1
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0xa28>
-               	mv	s2, a0
+               	jalr	ra <corpus.cases.float.special_f32.checksum+0x4d4>
                	fadd.s	ft0, fs7, fs7
-               	feq.s	a0, ft0, ft0
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0xad4 <corpus.cases.float.special_f32.checksum+0xa5c>
-               	mv	a0, s2
                	fmv.s	fa0, ft0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0xa4c>
-               	mv	s1, a0
-               	j	0xae8 <corpus.cases.float.special_f32.checksum+0xa70>
-               	mv	a0, s2
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0xa64>
-               	mv	s1, a0
+               	jalr	ra <corpus.cases.float.special_f32.checksum+0x4e4>
                	flt.s	a1, fs7, fs4
-               	mv	a0, s1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0xa78>
+               	jalr	ra <corpus.cases.float.special_f32.checksum+0x4f0>
                	fmv.w.x	ft11, zero
                	fsub.s	ft0, ft11, fs7
                	flt.s	a1, fs5, ft0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0xa8c>
-               	mv	s1, a0
+               	jalr	ra <corpus.cases.float.special_f32.checksum+0x504>
                	fsub.s	ft0, fs4, fs4
-               	feq.s	a0, ft0, ft0
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0xb38 <corpus.cases.float.special_f32.checksum+0xac0>
-               	mv	a0, s1
                	fmv.s	fa0, ft0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0xab0>
-               	mv	s2, a0
-               	j	0xb4c <corpus.cases.float.special_f32.checksum+0xad4>
-               	mv	a0, s1
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0xac8>
-               	mv	s2, a0
+               	jalr	ra <corpus.cases.float.special_f32.checksum+0x514>
                	fadd.s	ft0, fs5, fs4
-               	feq.s	a0, ft0, ft0
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0xb74 <corpus.cases.float.special_f32.checksum+0xafc>
-               	mv	a0, s2
                	fmv.s	fa0, ft0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0xaec>
-               	mv	s1, a0
-               	j	0xb88 <corpus.cases.float.special_f32.checksum+0xb10>
-               	mv	a0, s2
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0xb04>
-               	mv	s1, a0
+               	jalr	ra <corpus.cases.float.special_f32.checksum+0x524>
                	fmul.s	ft0, fs4, fs2
-               	feq.s	a0, ft0, ft0
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0xbb0 <corpus.cases.float.special_f32.checksum+0xb38>
-               	mv	a0, s1
                	fmv.s	fa0, ft0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0xb28>
-               	mv	s2, a0
-               	j	0xbc4 <corpus.cases.float.special_f32.checksum+0xb4c>
-               	mv	a0, s1
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0xb40>
-               	mv	s2, a0
+               	jalr	ra <corpus.cases.float.special_f32.checksum+0x534>
                	fmul.s	ft0, fs5, fs3
-               	feq.s	a0, ft0, ft0
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0xbec <corpus.cases.float.special_f32.checksum+0xb74>
-               	mv	a0, s2
                	fmv.s	fa0, ft0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0xb64>
-               	mv	s1, a0
-               	j	0xc00 <corpus.cases.float.special_f32.checksum+0xb88>
-               	mv	a0, s2
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0xb7c>
-               	mv	s1, a0
+               	jalr	ra <corpus.cases.float.special_f32.checksum+0x544>
                	fdiv.s	ft0, fs4, fs4
-               	feq.s	a0, ft0, ft0
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0xc28 <corpus.cases.float.special_f32.checksum+0xbb0>
-               	mv	a0, s1
                	fmv.s	fa0, ft0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0xba0>
-               	mv	s2, a0
-               	j	0xc3c <corpus.cases.float.special_f32.checksum+0xbc4>
-               	mv	a0, s1
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0xbb8>
-               	mv	s2, a0
+               	jalr	ra <corpus.cases.float.special_f32.checksum+0x554>
                	fdiv.s	ft0, fs2, fs2
-               	feq.s	a0, ft0, ft0
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0xc64 <corpus.cases.float.special_f32.checksum+0xbec>
-               	mv	a0, s2
                	fmv.s	fa0, ft0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0xbdc>
-               	mv	s1, a0
-               	j	0xc78 <corpus.cases.float.special_f32.checksum+0xc00>
-               	mv	a0, s2
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0xbf4>
-               	mv	s1, a0
+               	jalr	ra <corpus.cases.float.special_f32.checksum+0x564>
                	fdiv.s	ft0, fs3, fs2
-               	feq.s	a0, ft0, ft0
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0xca0 <corpus.cases.float.special_f32.checksum+0xc28>
-               	mv	a0, s1
                	fmv.s	fa0, ft0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0xc18>
-               	mv	s2, a0
-               	j	0xcb4 <corpus.cases.float.special_f32.checksum+0xc3c>
-               	mv	a0, s1
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0xc30>
-               	mv	s2, a0
+               	jalr	ra <corpus.cases.float.special_f32.checksum+0x574>
                	fmv.x.w	a1, fs6
-               	mv	a0, s2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0xc44>
+               	jalr	ra <corpus.cases.float.special_f32.checksum+0x580>
                	feq.s	a1, fs6, fs6
                	xori	a1, a1, 0x1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0xc54>
+               	jalr	ra <corpus.cases.float.special_f32.checksum+0x590>
                	feq.s	a1, fs6, fs6
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0xc60>
+               	jalr	ra <corpus.cases.float.special_f32.checksum+0x59c>
                	flt.s	a1, fs6, fs6
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0xc6c>
+               	jalr	ra <corpus.cases.float.special_f32.checksum+0x5a8>
                	fle.s	a1, fs6, fs6
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0xc78>
+               	jalr	ra <corpus.cases.float.special_f32.checksum+0x5b4>
                	fneg.s	fs1, fs6
                	fmv.x.w	a1, fs1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0xc88>
+               	jalr	ra <corpus.cases.float.special_f32.checksum+0x5c4>
                	fneg.s	ft0, fs1
                	fmv.x.w	a1, ft0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0xc98>
-               	mv	s1, a0
+               	jalr	ra <corpus.cases.float.special_f32.checksum+0x5d4>
                	fadd.s	ft0, fs6, fs0
-               	feq.s	a0, ft0, ft0
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0xd44 <corpus.cases.float.special_f32.checksum+0xccc>
-               	mv	a0, s1
                	fmv.s	fa0, ft0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0xcbc>
-               	mv	s2, a0
-               	j	0xd58 <corpus.cases.float.special_f32.checksum+0xce0>
-               	mv	a0, s1
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0xcd4>
-               	mv	s2, a0
+               	jalr	ra <corpus.cases.float.special_f32.checksum+0x5e4>
                	fadd.s	ft0, fs0, fs6
-               	feq.s	a0, ft0, ft0
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0xd80 <corpus.cases.float.special_f32.checksum+0xd08>
-               	mv	a0, s2
                	fmv.s	fa0, ft0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0xcf8>
-               	mv	s1, a0
-               	j	0xd94 <corpus.cases.float.special_f32.checksum+0xd1c>
-               	mv	a0, s2
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0xd10>
-               	mv	s1, a0
+               	jalr	ra <corpus.cases.float.special_f32.checksum+0x5f4>
                	fmul.s	ft0, fs6, fs2
-               	feq.s	a0, ft0, ft0
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0xdbc <corpus.cases.float.special_f32.checksum+0xd44>
-               	mv	a0, s1
                	fmv.s	fa0, ft0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0xd34>
-               	mv	s2, a0
-               	j	0xdd0 <corpus.cases.float.special_f32.checksum+0xd58>
-               	mv	a0, s1
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0xd4c>
-               	mv	s2, a0
+               	jalr	ra <corpus.cases.float.special_f32.checksum+0x604>
                	fsub.s	ft0, fs6, fs6
-               	feq.s	a0, ft0, ft0
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0xdf8 <corpus.cases.float.special_f32.checksum+0xd80>
-               	mv	a0, s2
                	fmv.s	fa0, ft0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0xd70>
-               	mv	s1, a0
-               	j	0xe0c <corpus.cases.float.special_f32.checksum+0xd94>
-               	mv	a0, s2
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0xd88>
-               	mv	s1, a0
+               	jalr	ra <corpus.cases.float.special_f32.checksum+0x614>
                	fdiv.s	ft0, fs6, fs6
-               	feq.s	a0, ft0, ft0
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0xe34 <corpus.cases.float.special_f32.checksum+0xdbc>
-               	mv	a0, s1
                	fmv.s	fa0, ft0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0xdac>
-               	mv	s2, a0
-               	j	0xe48 <corpus.cases.float.special_f32.checksum+0xdd0>
-               	mv	a0, s1
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0xdc4>
-               	mv	s2, a0
+               	jalr	ra <corpus.cases.float.special_f32.checksum+0x624>
                	fdiv.s	ft0, fs6, fs4
-               	feq.s	a0, ft0, ft0
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0xe70 <corpus.cases.float.special_f32.checksum+0xdf8>
-               	mv	a0, s2
                	fmv.s	fa0, ft0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0xde8>
-               	mv	s1, a0
-               	j	0xe84 <corpus.cases.float.special_f32.checksum+0xe0c>
-               	mv	a0, s2
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0xe00>
-               	mv	s1, a0
-               	feq.s	a0, fs10, fs10
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0xea8 <corpus.cases.float.special_f32.checksum+0xe30>
-               	mv	a0, s1
+               	jalr	ra <corpus.cases.float.special_f32.checksum+0x634>
                	fmv.s	fa0, fs10
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0xe20>
-               	mv	s2, a0
-               	j	0xebc <corpus.cases.float.special_f32.checksum+0xe44>
-               	mv	a0, s1
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0xe38>
-               	mv	s2, a0
-               	feq.s	a0, fs9, fs9
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0xee0 <corpus.cases.float.special_f32.checksum+0xe68>
-               	mv	a0, s2
+               	jalr	ra <corpus.cases.float.special_f32.checksum+0x640>
                	fmv.s	fa0, fs9
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0xe58>
-               	mv	s1, a0
-               	j	0xef4 <corpus.cases.float.special_f32.checksum+0xe7c>
-               	mv	a0, s2
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0xe70>
-               	mv	s1, a0
-               	feq.s	a0, fs8, fs8
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0xf18 <corpus.cases.float.special_f32.checksum+0xea0>
-               	mv	a0, s1
+               	jalr	ra <corpus.cases.float.special_f32.checksum+0x64c>
                	fmv.s	fa0, fs8
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0xe90>
-               	mv	s2, a0
-               	j	0xf2c <corpus.cases.float.special_f32.checksum+0xeb4>
-               	mv	a0, s1
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0xea8>
-               	mv	s2, a0
+               	jalr	ra <corpus.cases.float.special_f32.checksum+0x658>
                	fadd.s	ft0, fs9, fs10
-               	feq.s	a0, ft0, ft0
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0xf54 <corpus.cases.float.special_f32.checksum+0xedc>
-               	mv	a0, s2
                	fmv.s	fa0, ft0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0xecc>
-               	mv	s1, a0
-               	j	0xf68 <corpus.cases.float.special_f32.checksum+0xef0>
-               	mv	a0, s2
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0xee4>
-               	mv	s1, a0
+               	jalr	ra <corpus.cases.float.special_f32.checksum+0x668>
                	fsub.s	ft0, fs8, fs10
-               	feq.s	a0, ft0, ft0
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0xf90 <corpus.cases.float.special_f32.checksum+0xf18>
-               	mv	a0, s1
                	fmv.s	fa0, ft0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0xf08>
-               	mv	s2, a0
-               	j	0xfa4 <corpus.cases.float.special_f32.checksum+0xf2c>
-               	mv	a0, s1
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0xf20>
-               	mv	s2, a0
+               	jalr	ra <corpus.cases.float.special_f32.checksum+0x678>
                	fadd.s	ft0, fs10, fs10
-               	feq.s	a0, ft0, ft0
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0xfcc <corpus.cases.float.special_f32.checksum+0xf54>
-               	mv	a0, s2
                	fmv.s	fa0, ft0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0xf44>
-               	mv	s1, a0
-               	j	0xfe0 <corpus.cases.float.special_f32.checksum+0xf68>
-               	mv	a0, s2
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0xf5c>
-               	mv	s1, a0
+               	jalr	ra <corpus.cases.float.special_f32.checksum+0x688>
                	lui	t0, 0x3fc00
                	fmv.w.x	ft10, t0
                	fmul.s	ft0, fs10, ft10
-               	feq.s	a0, ft0, ft0
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0x1010 <corpus.cases.float.special_f32.checksum+0xf98>
-               	mv	a0, s1
                	fmv.s	fa0, ft0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0xf88>
-               	mv	s2, a0
-               	j	0x1024 <corpus.cases.float.special_f32.checksum+0xfac>
-               	mv	a0, s1
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0xfa0>
-               	mv	s2, a0
+               	jalr	ra <corpus.cases.float.special_f32.checksum+0x6a0>
                	lui	t0, 0x3f000
                	fmv.w.x	ft10, t0
                	fmul.s	ft0, fs10, ft10
-               	feq.s	a0, ft0, ft0
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0x1054 <corpus.cases.float.special_f32.checksum+0xfdc>
-               	mv	a0, s2
                	fmv.s	fa0, ft0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0xfcc>
-               	mv	s1, a0
-               	j	0x1068 <corpus.cases.float.special_f32.checksum+0xff0>
-               	mv	a0, s2
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0xfe4>
-               	mv	s1, a0
+               	jalr	ra <corpus.cases.float.special_f32.checksum+0x6b8>
                	fneg.s	ft0, fs10
-               	feq.s	a0, ft0, ft0
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0x1090 <corpus.cases.float.special_f32.checksum+0x1018>
-               	mv	a0, s1
                	fmv.s	fa0, ft0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0x1008>
-               	mv	s2, a0
-               	j	0x10a4 <corpus.cases.float.special_f32.checksum+0x102c>
-               	mv	a0, s1
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0x1020>
-               	mv	s2, a0
+               	jalr	ra <corpus.cases.float.special_f32.checksum+0x6c8>
                	lui	t0, 0x4b000
                	fmv.w.x	ft10, t0
                	fmul.s	ft0, fs10, ft10
-               	feq.s	a0, ft0, ft0
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0x10d4 <corpus.cases.float.special_f32.checksum+0x105c>
-               	mv	a0, s2
                	fmv.s	fa0, ft0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0x104c>
-               	mv	s1, a0
-               	j	0x10e8 <corpus.cases.float.special_f32.checksum+0x1070>
-               	mv	a0, s2
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0x1064>
-               	mv	s1, a0
+               	jalr	ra <corpus.cases.float.special_f32.checksum+0x6e0>
                	fdiv.s	ft0, fs9, fs8
-               	feq.s	a0, ft0, ft0
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0x1110 <corpus.cases.float.special_f32.checksum+0x1098>
-               	mv	a0, s1
                	fmv.s	fa0, ft0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0x1088>
-               	mv	s2, a0
-               	j	0x1124 <corpus.cases.float.special_f32.checksum+0x10ac>
-               	mv	a0, s1
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0x10a0>
-               	mv	s2, a0
+               	jalr	ra <corpus.cases.float.special_f32.checksum+0x6f0>
                	flt.s	a1, fs2, fs10
-               	mv	a0, s2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0x10b4>
+               	jalr	ra <corpus.cases.float.special_f32.checksum+0x6fc>
                	feq.s	a1, fs10, fs2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0x10c0>
+               	jalr	ra <corpus.cases.float.special_f32.checksum+0x708>
                	fmv.w.x	ft11, zero
                	fsub.s	ft0, ft11, fs10
                	flt.s	a1, ft0, fs3
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0x10d4>
+               	jalr	ra <corpus.cases.float.special_f32.checksum+0x71c>
                	mv	s1, a0
                	li	s2, 0x0
                	li	t0, 0x1e
-               	bltu	s2, t0, 0x1168 <corpus.cases.float.special_f32.checksum+0x10f0>
-               	j	0x11c0 <corpus.cases.float.special_f32.checksum+0x1148>
+               	bltu	s2, t0, 0x7b0 <corpus.cases.float.special_f32.checksum+0x738>
+               	j	0x808 <corpus.cases.float.special_f32.checksum+0x790>
                	lui	t0, 0x3f000
                	fmv.w.x	ft10, t0
                	fmul.s	fs1, fs8, ft10
                	feq.s	a0, fs1, fs1
                	xori	a0, a0, 0x1
-               	bnez	a0, 0x1198 <corpus.cases.float.special_f32.checksum+0x1120>
+               	bnez	a0, 0x7e0 <corpus.cases.float.special_f32.checksum+0x768>
                	mv	a0, s1
                	fmv.s	fa0, fs1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0x1110>
+               	jalr	ra <corpus.cases.float.special_f32.checksum+0x758>
                	mv	s4, a0
-               	j	0x11ac <corpus.cases.float.special_f32.checksum+0x1134>
+               	j	0x7f4 <corpus.cases.float.special_f32.checksum+0x77c>
                	mv	a0, s1
                	li	a1, -0x1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0x1128>
+               	jalr	ra <corpus.cases.float.special_f32.checksum+0x770>
                	mv	s4, a0
                	addiw	s2, s2, 0x1
                	mv	s1, s4
                	fmv.d	fs8, fs1
                	li	t0, 0x1e
-               	bltu	s2, t0, 0x1168 <corpus.cases.float.special_f32.checksum+0x10f0>
+               	bltu	s2, t0, 0x7b0 <corpus.cases.float.special_f32.checksum+0x738>
                	addi	s2, s0, -0xc8
                	sd	zero, 0x0(s2)
                	sd	zero, 0x8(s2)
@@ -1180,8 +558,8 @@ Disassembly of section .text:
                	sw	t0, 0x0(a0)
                	li	s4, 0x0
                	li	t0, 0x8
-               	bltu	s4, t0, 0x125c <corpus.cases.float.special_f32.checksum+0x11e4>
-               	j	0x1298 <corpus.cases.float.special_f32.checksum+0x1220>
+               	bltu	s4, t0, 0x8a4 <corpus.cases.float.special_f32.checksum+0x82c>
+               	j	0x8e0 <corpus.cases.float.special_f32.checksum+0x868>
                	slli	a0, s4, 0x20
                	srli	a0, a0, 0x20
                	slli	t0, a0, 0x2
@@ -1192,11 +570,11 @@ Disassembly of section .text:
                	fmv.x.w	a1, ft0
                	mv	a0, s1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0x1208>
+               	jalr	ra <corpus.cases.float.special_f32.checksum+0x850>
                	addiw	s4, s4, 0x1
                	mv	s1, a0
                	li	t0, 0x8
-               	bltu	s4, t0, 0x125c <corpus.cases.float.special_f32.checksum+0x11e4>
+               	bltu	s4, t0, 0x8a4 <corpus.cases.float.special_f32.checksum+0x82c>
                	lui	t1, 0x1000
                	addw	a0, t1, s3
                	lui	t1, 0x1000
@@ -1215,107 +593,107 @@ Disassembly of section .text:
                	fcvt.s.wu	ft0, a0
                	feq.s	a0, ft0, ft0
                	xori	a0, a0, 0x1
-               	bnez	a0, 0x12fc <corpus.cases.float.special_f32.checksum+0x1284>
+               	bnez	a0, 0x944 <corpus.cases.float.special_f32.checksum+0x8cc>
                	mv	a0, s1
                	fmv.s	fa0, ft0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0x1274>
+               	jalr	ra <corpus.cases.float.special_f32.checksum+0x8bc>
                	mv	s8, a0
-               	j	0x1310 <corpus.cases.float.special_f32.checksum+0x1298>
+               	j	0x958 <corpus.cases.float.special_f32.checksum+0x8e0>
                	mv	a0, s1
                	li	a1, -0x1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0x128c>
+               	jalr	ra <corpus.cases.float.special_f32.checksum+0x8d4>
                	mv	s8, a0
                	fcvt.s.wu	ft0, s2
                	feq.s	a0, ft0, ft0
                	xori	a0, a0, 0x1
-               	bnez	a0, 0x1338 <corpus.cases.float.special_f32.checksum+0x12c0>
+               	bnez	a0, 0x980 <corpus.cases.float.special_f32.checksum+0x908>
                	mv	a0, s8
                	fmv.s	fa0, ft0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0x12b0>
+               	jalr	ra <corpus.cases.float.special_f32.checksum+0x8f8>
                	mv	s1, a0
-               	j	0x134c <corpus.cases.float.special_f32.checksum+0x12d4>
+               	j	0x994 <corpus.cases.float.special_f32.checksum+0x91c>
                	mv	a0, s8
                	li	a1, -0x1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0x12c8>
+               	jalr	ra <corpus.cases.float.special_f32.checksum+0x910>
                	mv	s1, a0
                	fcvt.s.wu	ft0, s4
                	feq.s	a0, ft0, ft0
                	xori	a0, a0, 0x1
-               	bnez	a0, 0x1374 <corpus.cases.float.special_f32.checksum+0x12fc>
+               	bnez	a0, 0x9bc <corpus.cases.float.special_f32.checksum+0x944>
                	mv	a0, s1
                	fmv.s	fa0, ft0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0x12ec>
+               	jalr	ra <corpus.cases.float.special_f32.checksum+0x934>
                	mv	s2, a0
-               	j	0x1388 <corpus.cases.float.special_f32.checksum+0x1310>
+               	j	0x9d0 <corpus.cases.float.special_f32.checksum+0x958>
                	mv	a0, s1
                	li	a1, -0x1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0x1304>
+               	jalr	ra <corpus.cases.float.special_f32.checksum+0x94c>
                	mv	s2, a0
                	fcvt.s.wu	ft0, s5
                	feq.s	a0, ft0, ft0
                	xori	a0, a0, 0x1
-               	bnez	a0, 0x13b0 <corpus.cases.float.special_f32.checksum+0x1338>
+               	bnez	a0, 0x9f8 <corpus.cases.float.special_f32.checksum+0x980>
                	mv	a0, s2
                	fmv.s	fa0, ft0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0x1328>
+               	jalr	ra <corpus.cases.float.special_f32.checksum+0x970>
                	mv	s1, a0
-               	j	0x13c4 <corpus.cases.float.special_f32.checksum+0x134c>
+               	j	0xa0c <corpus.cases.float.special_f32.checksum+0x994>
                	mv	a0, s2
                	li	a1, -0x1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0x1340>
+               	jalr	ra <corpus.cases.float.special_f32.checksum+0x988>
                	mv	s1, a0
                	fcvt.s.wu	ft0, s3
                	feq.s	a0, ft0, ft0
                	xori	a0, a0, 0x1
-               	bnez	a0, 0x13ec <corpus.cases.float.special_f32.checksum+0x1374>
+               	bnez	a0, 0xa34 <corpus.cases.float.special_f32.checksum+0x9bc>
                	mv	a0, s1
                	fmv.s	fa0, ft0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0x1364>
+               	jalr	ra <corpus.cases.float.special_f32.checksum+0x9ac>
                	mv	s2, a0
-               	j	0x1400 <corpus.cases.float.special_f32.checksum+0x1388>
+               	j	0xa48 <corpus.cases.float.special_f32.checksum+0x9d0>
                	mv	a0, s1
                	li	a1, -0x1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0x137c>
+               	jalr	ra <corpus.cases.float.special_f32.checksum+0x9c4>
                	mv	s2, a0
                	fcvt.s.w	ft0, s6
                	feq.s	a0, ft0, ft0
                	xori	a0, a0, 0x1
-               	bnez	a0, 0x1428 <corpus.cases.float.special_f32.checksum+0x13b0>
+               	bnez	a0, 0xa70 <corpus.cases.float.special_f32.checksum+0x9f8>
                	mv	a0, s2
                	fmv.s	fa0, ft0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0x13a0>
+               	jalr	ra <corpus.cases.float.special_f32.checksum+0x9e8>
                	mv	s1, a0
-               	j	0x143c <corpus.cases.float.special_f32.checksum+0x13c4>
+               	j	0xa84 <corpus.cases.float.special_f32.checksum+0xa0c>
                	mv	a0, s2
                	li	a1, -0x1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0x13b8>
+               	jalr	ra <corpus.cases.float.special_f32.checksum+0xa00>
                	mv	s1, a0
                	fcvt.s.w	ft0, s7
                	feq.s	a0, ft0, ft0
                	xori	a0, a0, 0x1
-               	bnez	a0, 0x1464 <corpus.cases.float.special_f32.checksum+0x13ec>
+               	bnez	a0, 0xaac <corpus.cases.float.special_f32.checksum+0xa34>
                	mv	a0, s1
                	fmv.s	fa0, ft0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0x13dc>
+               	jalr	ra <corpus.cases.float.special_f32.checksum+0xa24>
                	mv	s2, a0
-               	j	0x1478 <corpus.cases.float.special_f32.checksum+0x1400>
+               	j	0xac0 <corpus.cases.float.special_f32.checksum+0xa48>
                	mv	a0, s1
                	li	a1, -0x1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0x13f4>
+               	jalr	ra <corpus.cases.float.special_f32.checksum+0xa3c>
                	mv	s2, a0
                	lui	t0, 0x3fc00
                	fmv.w.x	ft11, t0

--- a/test/golden/riscv64-linux/float/special_f64.dis
+++ b/test/golden/riscv64-linux/float/special_f64.dis
@@ -191,907 +191,252 @@ Disassembly of section .text:
                	jalr	ra <corpus.cases.float.special_f64.checksum+0x25c>
                	mv	s3, a0
                	fadd.d	fa0, fs3, fs3
-               	feq.d	a0, fa0, fa0
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0x300 <corpus.cases.float.special_f64.checksum+0x28c>
                	mv	a0, s3
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.float.special_f64.checksum+0x270>
+               	fsub.d	fa0, fs2, fs2
                	auipc	ra, 0x0
                	jalr	ra <corpus.cases.float.special_f64.checksum+0x27c>
-               	mv	s2, a0
-               	j	0x314 <corpus.cases.float.special_f64.checksum+0x2a0>
-               	mv	a0, s3
-               	li	a1, -0x1
+               	fsub.d	fa0, fs2, fs3
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.float.special_f64.checksum+0x288>
+               	fsub.d	fa0, fs3, fs2
                	auipc	ra, 0x0
                	jalr	ra <corpus.cases.float.special_f64.checksum+0x294>
-               	mv	s2, a0
-               	fsub.d	fa0, fs2, fs2
-               	feq.d	a0, fa0, fa0
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0x338 <corpus.cases.float.special_f64.checksum+0x2c4>
-               	mv	a0, s2
+               	fsub.d	fa0, fs3, fs3
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f64.checksum+0x2b4>
-               	mv	s3, a0
-               	j	0x34c <corpus.cases.float.special_f64.checksum+0x2d8>
-               	mv	a0, s2
-               	li	a1, -0x1
+               	jalr	ra <corpus.cases.float.special_f64.checksum+0x2a0>
+               	fmul.d	fa0, fs2, fs0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f64.checksum+0x2cc>
-               	mv	s3, a0
-               	fsub.d	fa0, fs2, fs3
-               	feq.d	a0, fa0, fa0
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0x370 <corpus.cases.float.special_f64.checksum+0x2fc>
-               	mv	a0, s3
+               	jalr	ra <corpus.cases.float.special_f64.checksum+0x2ac>
+               	fmul.d	fa0, fs2, fs1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f64.checksum+0x2ec>
-               	mv	s2, a0
-               	j	0x384 <corpus.cases.float.special_f64.checksum+0x310>
-               	mv	a0, s3
-               	li	a1, -0x1
+               	jalr	ra <corpus.cases.float.special_f64.checksum+0x2b8>
+               	fmul.d	fa0, fs3, fs0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f64.checksum+0x304>
-               	mv	s2, a0
-               	fsub.d	fa0, fs3, fs2
-               	feq.d	a0, fa0, fa0
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0x3a8 <corpus.cases.float.special_f64.checksum+0x334>
-               	mv	a0, s2
+               	jalr	ra <corpus.cases.float.special_f64.checksum+0x2c4>
+               	fmul.d	fa0, fs3, fs1
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.float.special_f64.checksum+0x2d0>
+               	fmul.d	fa0, fs3, fs3
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.float.special_f64.checksum+0x2dc>
+               	fmul.d	fa0, fs2, fs3
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.float.special_f64.checksum+0x2e8>
+               	fneg.d	fa0, fs2
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.float.special_f64.checksum+0x2f4>
+               	fneg.d	fa0, fs3
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.float.special_f64.checksum+0x300>
+               	fdiv.d	fa0, fs2, fs0
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.float.special_f64.checksum+0x30c>
+               	fdiv.d	fa0, fs2, fs1
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.float.special_f64.checksum+0x318>
+               	fdiv.d	fa0, fs3, fs0
                	auipc	ra, 0x0
                	jalr	ra <corpus.cases.float.special_f64.checksum+0x324>
-               	mv	s3, a0
-               	j	0x3bc <corpus.cases.float.special_f64.checksum+0x348>
-               	mv	a0, s2
-               	li	a1, -0x1
+               	fdiv.d	fa0, fs3, fs1
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.float.special_f64.checksum+0x330>
+               	feq.d	a1, fs2, fs3
                	auipc	ra, 0x0
                	jalr	ra <corpus.cases.float.special_f64.checksum+0x33c>
-               	mv	s3, a0
-               	fsub.d	fa0, fs3, fs3
-               	feq.d	a0, fa0, fa0
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0x3e0 <corpus.cases.float.special_f64.checksum+0x36c>
-               	mv	a0, s3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f64.checksum+0x35c>
-               	mv	s2, a0
-               	j	0x3f4 <corpus.cases.float.special_f64.checksum+0x380>
-               	mv	a0, s3
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f64.checksum+0x374>
-               	mv	s2, a0
-               	fmul.d	fa0, fs2, fs0
-               	feq.d	a0, fa0, fa0
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0x418 <corpus.cases.float.special_f64.checksum+0x3a4>
-               	mv	a0, s2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f64.checksum+0x394>
-               	mv	s3, a0
-               	j	0x42c <corpus.cases.float.special_f64.checksum+0x3b8>
-               	mv	a0, s2
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f64.checksum+0x3ac>
-               	mv	s3, a0
-               	fmul.d	fa0, fs2, fs1
-               	feq.d	a0, fa0, fa0
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0x450 <corpus.cases.float.special_f64.checksum+0x3dc>
-               	mv	a0, s3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f64.checksum+0x3cc>
-               	mv	s2, a0
-               	j	0x464 <corpus.cases.float.special_f64.checksum+0x3f0>
-               	mv	a0, s3
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f64.checksum+0x3e4>
-               	mv	s2, a0
-               	fmul.d	fa0, fs3, fs0
-               	feq.d	a0, fa0, fa0
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0x488 <corpus.cases.float.special_f64.checksum+0x414>
-               	mv	a0, s2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f64.checksum+0x404>
-               	mv	s3, a0
-               	j	0x49c <corpus.cases.float.special_f64.checksum+0x428>
-               	mv	a0, s2
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f64.checksum+0x41c>
-               	mv	s3, a0
-               	fmul.d	fa0, fs3, fs1
-               	feq.d	a0, fa0, fa0
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0x4c0 <corpus.cases.float.special_f64.checksum+0x44c>
-               	mv	a0, s3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f64.checksum+0x43c>
-               	mv	s2, a0
-               	j	0x4d4 <corpus.cases.float.special_f64.checksum+0x460>
-               	mv	a0, s3
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f64.checksum+0x454>
-               	mv	s2, a0
-               	fmul.d	fa0, fs3, fs3
-               	feq.d	a0, fa0, fa0
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0x4f8 <corpus.cases.float.special_f64.checksum+0x484>
-               	mv	a0, s2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f64.checksum+0x474>
-               	mv	s3, a0
-               	j	0x50c <corpus.cases.float.special_f64.checksum+0x498>
-               	mv	a0, s2
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f64.checksum+0x48c>
-               	mv	s3, a0
-               	fmul.d	fa0, fs2, fs3
-               	feq.d	a0, fa0, fa0
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0x530 <corpus.cases.float.special_f64.checksum+0x4bc>
-               	mv	a0, s3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f64.checksum+0x4ac>
-               	mv	s2, a0
-               	j	0x544 <corpus.cases.float.special_f64.checksum+0x4d0>
-               	mv	a0, s3
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f64.checksum+0x4c4>
-               	mv	s2, a0
-               	fneg.d	fa0, fs2
-               	feq.d	a0, fa0, fa0
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0x568 <corpus.cases.float.special_f64.checksum+0x4f4>
-               	mv	a0, s2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f64.checksum+0x4e4>
-               	mv	s3, a0
-               	j	0x57c <corpus.cases.float.special_f64.checksum+0x508>
-               	mv	a0, s2
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f64.checksum+0x4fc>
-               	mv	s3, a0
-               	fneg.d	fa0, fs3
-               	feq.d	a0, fa0, fa0
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0x5a0 <corpus.cases.float.special_f64.checksum+0x52c>
-               	mv	a0, s3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f64.checksum+0x51c>
-               	mv	s2, a0
-               	j	0x5b4 <corpus.cases.float.special_f64.checksum+0x540>
-               	mv	a0, s3
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f64.checksum+0x534>
-               	mv	s2, a0
-               	fdiv.d	fa0, fs2, fs0
-               	feq.d	a0, fa0, fa0
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0x5d8 <corpus.cases.float.special_f64.checksum+0x564>
-               	mv	a0, s2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f64.checksum+0x554>
-               	mv	s3, a0
-               	j	0x5ec <corpus.cases.float.special_f64.checksum+0x578>
-               	mv	a0, s2
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f64.checksum+0x56c>
-               	mv	s3, a0
-               	fdiv.d	fa0, fs2, fs1
-               	feq.d	a0, fa0, fa0
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0x610 <corpus.cases.float.special_f64.checksum+0x59c>
-               	mv	a0, s3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f64.checksum+0x58c>
-               	mv	s2, a0
-               	j	0x624 <corpus.cases.float.special_f64.checksum+0x5b0>
-               	mv	a0, s3
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f64.checksum+0x5a4>
-               	mv	s2, a0
-               	fdiv.d	fa0, fs3, fs0
-               	feq.d	a0, fa0, fa0
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0x648 <corpus.cases.float.special_f64.checksum+0x5d4>
-               	mv	a0, s2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f64.checksum+0x5c4>
-               	mv	s3, a0
-               	j	0x65c <corpus.cases.float.special_f64.checksum+0x5e8>
-               	mv	a0, s2
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f64.checksum+0x5dc>
-               	mv	s3, a0
-               	fdiv.d	fa0, fs3, fs1
-               	feq.d	a0, fa0, fa0
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0x680 <corpus.cases.float.special_f64.checksum+0x60c>
-               	mv	a0, s3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f64.checksum+0x5fc>
-               	mv	s2, a0
-               	j	0x694 <corpus.cases.float.special_f64.checksum+0x620>
-               	mv	a0, s3
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f64.checksum+0x614>
-               	mv	s2, a0
-               	feq.d	a1, fs2, fs3
-               	mv	a0, s2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f64.checksum+0x628>
                	flt.d	a1, fs2, fs3
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f64.checksum+0x634>
+               	jalr	ra <corpus.cases.float.special_f64.checksum+0x348>
                	flt.d	a1, fs3, fs2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f64.checksum+0x640>
-               	mv	s2, a0
-               	feq.d	a0, fs4, fs4
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0x6e4 <corpus.cases.float.special_f64.checksum+0x670>
-               	mv	a0, s2
+               	jalr	ra <corpus.cases.float.special_f64.checksum+0x354>
                	fmv.d	fa0, fs4
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f64.checksum+0x660>
-               	mv	s3, a0
-               	j	0x6f8 <corpus.cases.float.special_f64.checksum+0x684>
-               	mv	a0, s2
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f64.checksum+0x678>
-               	mv	s3, a0
-               	feq.d	a0, fs5, fs5
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0x71c <corpus.cases.float.special_f64.checksum+0x6a8>
-               	mv	a0, s3
+               	jalr	ra <corpus.cases.float.special_f64.checksum+0x360>
                	fmv.d	fa0, fs5
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f64.checksum+0x698>
-               	mv	s2, a0
-               	j	0x730 <corpus.cases.float.special_f64.checksum+0x6bc>
-               	mv	a0, s3
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f64.checksum+0x6b0>
-               	mv	s2, a0
+               	jalr	ra <corpus.cases.float.special_f64.checksum+0x36c>
                	fneg.d	fa0, fs4
-               	feq.d	a0, fa0, fa0
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0x754 <corpus.cases.float.special_f64.checksum+0x6e0>
-               	mv	a0, s2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f64.checksum+0x6d0>
-               	mv	s3, a0
-               	j	0x768 <corpus.cases.float.special_f64.checksum+0x6f4>
-               	mv	a0, s2
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f64.checksum+0x6e8>
-               	mv	s3, a0
+               	jalr	ra <corpus.cases.float.special_f64.checksum+0x378>
                	fdiv.d	fa0, fs0, fs2
-               	feq.d	a0, fa0, fa0
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0x78c <corpus.cases.float.special_f64.checksum+0x718>
-               	mv	a0, s3
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f64.checksum+0x708>
-               	mv	s2, a0
-               	j	0x7a0 <corpus.cases.float.special_f64.checksum+0x72c>
-               	mv	a0, s3
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f64.checksum+0x720>
-               	mv	s2, a0
+               	jalr	ra <corpus.cases.float.special_f64.checksum+0x384>
                	fdiv.d	fa0, fs0, fs3
-               	feq.d	a0, fa0, fa0
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0x7c4 <corpus.cases.float.special_f64.checksum+0x750>
-               	mv	a0, s2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f64.checksum+0x740>
-               	mv	s3, a0
-               	j	0x7d8 <corpus.cases.float.special_f64.checksum+0x764>
-               	mv	a0, s2
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f64.checksum+0x758>
-               	mv	s3, a0
+               	jalr	ra <corpus.cases.float.special_f64.checksum+0x390>
                	fdiv.d	fa0, fs1, fs2
-               	feq.d	a0, fa0, fa0
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0x7fc <corpus.cases.float.special_f64.checksum+0x788>
-               	mv	a0, s3
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f64.checksum+0x778>
-               	mv	s2, a0
-               	j	0x810 <corpus.cases.float.special_f64.checksum+0x79c>
-               	mv	a0, s3
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f64.checksum+0x790>
-               	mv	s2, a0
+               	jalr	ra <corpus.cases.float.special_f64.checksum+0x39c>
                	fdiv.d	fa0, fs1, fs3
-               	feq.d	a0, fa0, fa0
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0x834 <corpus.cases.float.special_f64.checksum+0x7c0>
-               	mv	a0, s2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f64.checksum+0x7b0>
-               	mv	s3, a0
-               	j	0x848 <corpus.cases.float.special_f64.checksum+0x7d4>
-               	mv	a0, s2
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f64.checksum+0x7c8>
-               	mv	s3, a0
+               	jalr	ra <corpus.cases.float.special_f64.checksum+0x3a8>
                	fadd.d	fa0, fs4, fs0
-               	feq.d	a0, fa0, fa0
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0x86c <corpus.cases.float.special_f64.checksum+0x7f8>
-               	mv	a0, s3
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f64.checksum+0x7e8>
-               	mv	s2, a0
-               	j	0x880 <corpus.cases.float.special_f64.checksum+0x80c>
-               	mv	a0, s3
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f64.checksum+0x800>
-               	mv	s2, a0
+               	jalr	ra <corpus.cases.float.special_f64.checksum+0x3b4>
                	fadd.d	fa0, fs4, fs4
-               	feq.d	a0, fa0, fa0
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0x8a4 <corpus.cases.float.special_f64.checksum+0x830>
-               	mv	a0, s2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f64.checksum+0x820>
-               	mv	s3, a0
-               	j	0x8b8 <corpus.cases.float.special_f64.checksum+0x844>
-               	mv	a0, s2
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f64.checksum+0x838>
-               	mv	s3, a0
+               	jalr	ra <corpus.cases.float.special_f64.checksum+0x3c0>
                	fsub.d	fa0, fs4, fs5
-               	feq.d	a0, fa0, fa0
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0x8dc <corpus.cases.float.special_f64.checksum+0x868>
-               	mv	a0, s3
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f64.checksum+0x858>
-               	mv	s2, a0
-               	j	0x8f0 <corpus.cases.float.special_f64.checksum+0x87c>
-               	mv	a0, s3
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f64.checksum+0x870>
-               	mv	s2, a0
+               	jalr	ra <corpus.cases.float.special_f64.checksum+0x3cc>
                	fmul.d	fa0, fs4, fs4
-               	feq.d	a0, fa0, fa0
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0x914 <corpus.cases.float.special_f64.checksum+0x8a0>
-               	mv	a0, s2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f64.checksum+0x890>
-               	mv	s3, a0
-               	j	0x928 <corpus.cases.float.special_f64.checksum+0x8b4>
-               	mv	a0, s2
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f64.checksum+0x8a8>
-               	mv	s3, a0
+               	jalr	ra <corpus.cases.float.special_f64.checksum+0x3d8>
                	fmul.d	fa0, fs4, fs5
-               	feq.d	a0, fa0, fa0
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0x94c <corpus.cases.float.special_f64.checksum+0x8d8>
-               	mv	a0, s3
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f64.checksum+0x8c8>
-               	mv	s2, a0
-               	j	0x960 <corpus.cases.float.special_f64.checksum+0x8ec>
-               	mv	a0, s3
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f64.checksum+0x8e0>
-               	mv	s2, a0
+               	jalr	ra <corpus.cases.float.special_f64.checksum+0x3e4>
                	fmul.d	fa0, fs4, fs1
-               	feq.d	a0, fa0, fa0
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0x984 <corpus.cases.float.special_f64.checksum+0x910>
-               	mv	a0, s2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f64.checksum+0x900>
-               	mv	s3, a0
-               	j	0x998 <corpus.cases.float.special_f64.checksum+0x924>
-               	mv	a0, s2
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f64.checksum+0x918>
-               	mv	s3, a0
+               	jalr	ra <corpus.cases.float.special_f64.checksum+0x3f0>
                	fdiv.d	fa0, fs0, fs4
-               	feq.d	a0, fa0, fa0
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0x9bc <corpus.cases.float.special_f64.checksum+0x948>
-               	mv	a0, s3
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f64.checksum+0x938>
-               	mv	s2, a0
-               	j	0x9d0 <corpus.cases.float.special_f64.checksum+0x95c>
-               	mv	a0, s3
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f64.checksum+0x950>
-               	mv	s2, a0
+               	jalr	ra <corpus.cases.float.special_f64.checksum+0x3fc>
                	fdiv.d	fa0, fs1, fs4
-               	feq.d	a0, fa0, fa0
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0x9f4 <corpus.cases.float.special_f64.checksum+0x980>
-               	mv	a0, s2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f64.checksum+0x970>
-               	mv	s3, a0
-               	j	0xa08 <corpus.cases.float.special_f64.checksum+0x994>
-               	mv	a0, s2
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f64.checksum+0x988>
-               	mv	s3, a0
+               	jalr	ra <corpus.cases.float.special_f64.checksum+0x408>
                	fdiv.d	fa0, fs0, fs5
-               	feq.d	a0, fa0, fa0
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0xa2c <corpus.cases.float.special_f64.checksum+0x9b8>
-               	mv	a0, s3
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f64.checksum+0x9a8>
-               	mv	s2, a0
-               	j	0xa40 <corpus.cases.float.special_f64.checksum+0x9cc>
-               	mv	a0, s3
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f64.checksum+0x9c0>
-               	mv	s2, a0
+               	jalr	ra <corpus.cases.float.special_f64.checksum+0x414>
                	fdiv.d	fa0, fs4, fs0
-               	feq.d	a0, fa0, fa0
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0xa64 <corpus.cases.float.special_f64.checksum+0x9f0>
-               	mv	a0, s2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f64.checksum+0x9e0>
-               	mv	s3, a0
-               	j	0xa78 <corpus.cases.float.special_f64.checksum+0xa04>
-               	mv	a0, s2
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f64.checksum+0x9f8>
-               	mv	s3, a0
+               	jalr	ra <corpus.cases.float.special_f64.checksum+0x420>
                	fadd.d	fa0, fs7, fs7
-               	feq.d	a0, fa0, fa0
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0xa9c <corpus.cases.float.special_f64.checksum+0xa28>
-               	mv	a0, s3
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f64.checksum+0xa18>
-               	mv	s2, a0
-               	j	0xab0 <corpus.cases.float.special_f64.checksum+0xa3c>
-               	mv	a0, s3
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f64.checksum+0xa30>
-               	mv	s2, a0
+               	jalr	ra <corpus.cases.float.special_f64.checksum+0x42c>
                	flt.d	a1, fs7, fs4
-               	mv	a0, s2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f64.checksum+0xa44>
+               	jalr	ra <corpus.cases.float.special_f64.checksum+0x438>
                	fmv.d.x	ft11, zero
                	fsub.d	ft0, ft11, fs7
                	flt.d	a1, fs5, ft0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f64.checksum+0xa58>
-               	mv	s2, a0
+               	jalr	ra <corpus.cases.float.special_f64.checksum+0x44c>
                	fsub.d	fa0, fs4, fs4
-               	feq.d	a0, fa0, fa0
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0xafc <corpus.cases.float.special_f64.checksum+0xa88>
-               	mv	a0, s2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f64.checksum+0xa78>
-               	mv	s3, a0
-               	j	0xb10 <corpus.cases.float.special_f64.checksum+0xa9c>
-               	mv	a0, s2
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f64.checksum+0xa90>
-               	mv	s3, a0
+               	jalr	ra <corpus.cases.float.special_f64.checksum+0x458>
                	fadd.d	fa0, fs5, fs4
-               	feq.d	a0, fa0, fa0
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0xb34 <corpus.cases.float.special_f64.checksum+0xac0>
-               	mv	a0, s3
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f64.checksum+0xab0>
-               	mv	s2, a0
-               	j	0xb48 <corpus.cases.float.special_f64.checksum+0xad4>
-               	mv	a0, s3
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f64.checksum+0xac8>
-               	mv	s2, a0
+               	jalr	ra <corpus.cases.float.special_f64.checksum+0x464>
                	fmul.d	fa0, fs4, fs2
-               	feq.d	a0, fa0, fa0
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0xb6c <corpus.cases.float.special_f64.checksum+0xaf8>
-               	mv	a0, s2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f64.checksum+0xae8>
-               	mv	s3, a0
-               	j	0xb80 <corpus.cases.float.special_f64.checksum+0xb0c>
-               	mv	a0, s2
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f64.checksum+0xb00>
-               	mv	s3, a0
+               	jalr	ra <corpus.cases.float.special_f64.checksum+0x470>
                	fmul.d	fa0, fs5, fs3
-               	feq.d	a0, fa0, fa0
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0xba4 <corpus.cases.float.special_f64.checksum+0xb30>
-               	mv	a0, s3
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f64.checksum+0xb20>
-               	mv	s2, a0
-               	j	0xbb8 <corpus.cases.float.special_f64.checksum+0xb44>
-               	mv	a0, s3
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f64.checksum+0xb38>
-               	mv	s2, a0
+               	jalr	ra <corpus.cases.float.special_f64.checksum+0x47c>
                	fdiv.d	fa0, fs4, fs4
-               	feq.d	a0, fa0, fa0
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0xbdc <corpus.cases.float.special_f64.checksum+0xb68>
-               	mv	a0, s2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f64.checksum+0xb58>
-               	mv	s3, a0
-               	j	0xbf0 <corpus.cases.float.special_f64.checksum+0xb7c>
-               	mv	a0, s2
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f64.checksum+0xb70>
-               	mv	s3, a0
+               	jalr	ra <corpus.cases.float.special_f64.checksum+0x488>
                	fdiv.d	fa0, fs2, fs2
-               	feq.d	a0, fa0, fa0
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0xc14 <corpus.cases.float.special_f64.checksum+0xba0>
-               	mv	a0, s3
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f64.checksum+0xb90>
-               	mv	s2, a0
-               	j	0xc28 <corpus.cases.float.special_f64.checksum+0xbb4>
-               	mv	a0, s3
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f64.checksum+0xba8>
-               	mv	s2, a0
+               	jalr	ra <corpus.cases.float.special_f64.checksum+0x494>
                	fdiv.d	fa0, fs3, fs2
-               	feq.d	a0, fa0, fa0
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0xc4c <corpus.cases.float.special_f64.checksum+0xbd8>
-               	mv	a0, s2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f64.checksum+0xbc8>
-               	mv	s3, a0
-               	j	0xc60 <corpus.cases.float.special_f64.checksum+0xbec>
-               	mv	a0, s2
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f64.checksum+0xbe0>
-               	mv	s3, a0
+               	jalr	ra <corpus.cases.float.special_f64.checksum+0x4a0>
                	fmv.x.d	a1, fs6
-               	mv	a0, s3
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f64.checksum+0xbf4>
+               	jalr	ra <corpus.cases.float.special_f64.checksum+0x4ac>
                	feq.d	a1, fs6, fs6
                	xori	a1, a1, 0x1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f64.checksum+0xc04>
+               	jalr	ra <corpus.cases.float.special_f64.checksum+0x4bc>
                	feq.d	a1, fs6, fs6
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f64.checksum+0xc10>
+               	jalr	ra <corpus.cases.float.special_f64.checksum+0x4c8>
                	flt.d	a1, fs6, fs6
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f64.checksum+0xc1c>
+               	jalr	ra <corpus.cases.float.special_f64.checksum+0x4d4>
                	fle.d	a1, fs6, fs6
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f64.checksum+0xc28>
+               	jalr	ra <corpus.cases.float.special_f64.checksum+0x4e0>
                	fneg.d	fs1, fs6
                	fmv.x.d	a1, fs1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f64.checksum+0xc38>
+               	jalr	ra <corpus.cases.float.special_f64.checksum+0x4f0>
                	fneg.d	ft0, fs1
                	fmv.x.d	a1, ft0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f64.checksum+0xc48>
-               	mv	s2, a0
+               	jalr	ra <corpus.cases.float.special_f64.checksum+0x500>
                	fadd.d	fa0, fs6, fs0
-               	feq.d	a0, fa0, fa0
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0xcec <corpus.cases.float.special_f64.checksum+0xc78>
-               	mv	a0, s2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f64.checksum+0xc68>
-               	mv	s3, a0
-               	j	0xd00 <corpus.cases.float.special_f64.checksum+0xc8c>
-               	mv	a0, s2
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f64.checksum+0xc80>
-               	mv	s3, a0
+               	jalr	ra <corpus.cases.float.special_f64.checksum+0x50c>
                	fadd.d	fa0, fs0, fs6
-               	feq.d	a0, fa0, fa0
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0xd24 <corpus.cases.float.special_f64.checksum+0xcb0>
-               	mv	a0, s3
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f64.checksum+0xca0>
-               	mv	s2, a0
-               	j	0xd38 <corpus.cases.float.special_f64.checksum+0xcc4>
-               	mv	a0, s3
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f64.checksum+0xcb8>
-               	mv	s2, a0
+               	jalr	ra <corpus.cases.float.special_f64.checksum+0x518>
                	fmul.d	fa0, fs6, fs2
-               	feq.d	a0, fa0, fa0
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0xd5c <corpus.cases.float.special_f64.checksum+0xce8>
-               	mv	a0, s2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f64.checksum+0xcd8>
-               	mv	s3, a0
-               	j	0xd70 <corpus.cases.float.special_f64.checksum+0xcfc>
-               	mv	a0, s2
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f64.checksum+0xcf0>
-               	mv	s3, a0
+               	jalr	ra <corpus.cases.float.special_f64.checksum+0x524>
                	fsub.d	fa0, fs6, fs6
-               	feq.d	a0, fa0, fa0
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0xd94 <corpus.cases.float.special_f64.checksum+0xd20>
-               	mv	a0, s3
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f64.checksum+0xd10>
-               	mv	s2, a0
-               	j	0xda8 <corpus.cases.float.special_f64.checksum+0xd34>
-               	mv	a0, s3
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f64.checksum+0xd28>
-               	mv	s2, a0
+               	jalr	ra <corpus.cases.float.special_f64.checksum+0x530>
                	fdiv.d	fa0, fs6, fs6
-               	feq.d	a0, fa0, fa0
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0xdcc <corpus.cases.float.special_f64.checksum+0xd58>
-               	mv	a0, s2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f64.checksum+0xd48>
-               	mv	s3, a0
-               	j	0xde0 <corpus.cases.float.special_f64.checksum+0xd6c>
-               	mv	a0, s2
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f64.checksum+0xd60>
-               	mv	s3, a0
+               	jalr	ra <corpus.cases.float.special_f64.checksum+0x53c>
                	fdiv.d	fa0, fs6, fs4
-               	feq.d	a0, fa0, fa0
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0xe04 <corpus.cases.float.special_f64.checksum+0xd90>
-               	mv	a0, s3
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f64.checksum+0xd80>
-               	mv	s2, a0
-               	j	0xe18 <corpus.cases.float.special_f64.checksum+0xda4>
-               	mv	a0, s3
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f64.checksum+0xd98>
-               	mv	s2, a0
-               	feq.d	a0, fs10, fs10
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0xe3c <corpus.cases.float.special_f64.checksum+0xdc8>
-               	mv	a0, s2
+               	jalr	ra <corpus.cases.float.special_f64.checksum+0x548>
                	fmv.d	fa0, fs10
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f64.checksum+0xdb8>
-               	mv	s3, a0
-               	j	0xe50 <corpus.cases.float.special_f64.checksum+0xddc>
-               	mv	a0, s2
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f64.checksum+0xdd0>
-               	mv	s3, a0
-               	feq.d	a0, fs9, fs9
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0xe74 <corpus.cases.float.special_f64.checksum+0xe00>
-               	mv	a0, s3
+               	jalr	ra <corpus.cases.float.special_f64.checksum+0x554>
                	fmv.d	fa0, fs9
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f64.checksum+0xdf0>
-               	mv	s2, a0
-               	j	0xe88 <corpus.cases.float.special_f64.checksum+0xe14>
-               	mv	a0, s3
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f64.checksum+0xe08>
-               	mv	s2, a0
-               	feq.d	a0, fs8, fs8
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0xeac <corpus.cases.float.special_f64.checksum+0xe38>
-               	mv	a0, s2
+               	jalr	ra <corpus.cases.float.special_f64.checksum+0x560>
                	fmv.d	fa0, fs8
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f64.checksum+0xe28>
-               	mv	s3, a0
-               	j	0xec0 <corpus.cases.float.special_f64.checksum+0xe4c>
-               	mv	a0, s2
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f64.checksum+0xe40>
-               	mv	s3, a0
+               	jalr	ra <corpus.cases.float.special_f64.checksum+0x56c>
                	fadd.d	fa0, fs9, fs10
-               	feq.d	a0, fa0, fa0
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0xee4 <corpus.cases.float.special_f64.checksum+0xe70>
-               	mv	a0, s3
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f64.checksum+0xe60>
-               	mv	s2, a0
-               	j	0xef8 <corpus.cases.float.special_f64.checksum+0xe84>
-               	mv	a0, s3
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f64.checksum+0xe78>
-               	mv	s2, a0
+               	jalr	ra <corpus.cases.float.special_f64.checksum+0x578>
                	fsub.d	fa0, fs8, fs10
-               	feq.d	a0, fa0, fa0
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0xf1c <corpus.cases.float.special_f64.checksum+0xea8>
-               	mv	a0, s2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f64.checksum+0xe98>
-               	mv	s3, a0
-               	j	0xf30 <corpus.cases.float.special_f64.checksum+0xebc>
-               	mv	a0, s2
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f64.checksum+0xeb0>
-               	mv	s3, a0
+               	jalr	ra <corpus.cases.float.special_f64.checksum+0x584>
                	fadd.d	fa0, fs10, fs10
-               	feq.d	a0, fa0, fa0
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0xf54 <corpus.cases.float.special_f64.checksum+0xee0>
-               	mv	a0, s3
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f64.checksum+0xed0>
-               	mv	s2, a0
-               	j	0xf68 <.Lpcrel_hi.0>
-               	mv	a0, s3
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f64.checksum+0xee8>
-               	mv	s2, a0
+               	jalr	ra <corpus.cases.float.special_f64.checksum+0x590>
 
 <.Lpcrel_hi.0>:
                	auipc	t0, 0x0
                	fld	ft10, 0x0(t0)
                	fmul.d	fa0, fs10, ft10
-               	feq.d	a0, fa0, fa0
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0xf94 <.Lpcrel_hi.0+0x2c>
-               	mv	a0, s2
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.0+0x1c>
-               	mv	s3, a0
-               	j	0xfa8 <.Lpcrel_hi.1>
-               	mv	a0, s2
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.0+0x34>
-               	mv	s3, a0
+               	jalr	ra <.Lpcrel_hi.0+0xc>
 
 <.Lpcrel_hi.1>:
                	auipc	t0, 0x0
                	fld	ft10, 0x0(t0)
                	fmul.d	fa0, fs10, ft10
-               	feq.d	a0, fa0, fa0
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0xfd4 <.Lpcrel_hi.1+0x2c>
-               	mv	a0, s3
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.1+0x1c>
-               	mv	s2, a0
-               	j	0xfe8 <.Lpcrel_hi.1+0x40>
-               	mv	a0, s3
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.1+0x34>
-               	mv	s2, a0
+               	jalr	ra <.Lpcrel_hi.1+0xc>
                	fneg.d	fa0, fs10
-               	feq.d	a0, fa0, fa0
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0x100c <.Lpcrel_hi.1+0x64>
-               	mv	a0, s2
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.1+0x54>
-               	mv	s3, a0
-               	j	0x1020 <.Lpcrel_hi.2>
-               	mv	a0, s2
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.1+0x6c>
-               	mv	s3, a0
+               	jalr	ra <.Lpcrel_hi.1+0x18>
 
 <.Lpcrel_hi.2>:
                	auipc	t0, 0x0
                	fld	ft10, 0x0(t0)
                	fmul.d	fa0, fs10, ft10
-               	feq.d	a0, fa0, fa0
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0x104c <.Lpcrel_hi.2+0x2c>
-               	mv	a0, s3
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.2+0x1c>
-               	mv	s2, a0
-               	j	0x1060 <.Lpcrel_hi.2+0x40>
-               	mv	a0, s3
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.2+0x34>
-               	mv	s2, a0
+               	jalr	ra <.Lpcrel_hi.2+0xc>
                	fdiv.d	fa0, fs9, fs8
-               	feq.d	a0, fa0, fa0
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0x1084 <.Lpcrel_hi.2+0x64>
-               	mv	a0, s2
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.2+0x54>
-               	mv	s3, a0
-               	j	0x1098 <.Lpcrel_hi.2+0x78>
-               	mv	a0, s2
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.2+0x6c>
-               	mv	s3, a0
+               	jalr	ra <.Lpcrel_hi.2+0x18>
                	flt.d	a1, fs2, fs10
-               	mv	a0, s3
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.2+0x80>
+               	jalr	ra <.Lpcrel_hi.2+0x24>
                	feq.d	a1, fs10, fs2
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.2+0x8c>
+               	jalr	ra <.Lpcrel_hi.2+0x30>
                	fmv.d.x	ft11, zero
                	fsub.d	ft0, ft11, fs10
                	flt.d	a1, ft0, fs3
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.2+0xa0>
+               	jalr	ra <.Lpcrel_hi.2+0x44>
                	mv	s2, a0
                	li	s3, 0x0
                	li	t0, 0x3c
-               	bltu	s3, t0, 0x10dc <.Lpcrel_hi.3>
-               	j	0x1134 <.Lpcrel_hi.3+0x58>
+               	bltu	s3, t0, 0x6a0 <.Lpcrel_hi.3>
+               	j	0x6f8 <.Lpcrel_hi.3+0x58>
 
 <.Lpcrel_hi.3>:
                	auipc	t0, 0x0
@@ -1099,13 +444,13 @@ Disassembly of section .text:
                	fmul.d	fs1, fs8, ft10
                	feq.d	a0, fs1, fs1
                	xori	a0, a0, 0x1
-               	bnez	a0, 0x110c <.Lpcrel_hi.3+0x30>
+               	bnez	a0, 0x6d0 <.Lpcrel_hi.3+0x30>
                	mv	a0, s2
                	fmv.d	fa0, fs1
                	auipc	ra, 0x0
                	jalr	ra <.Lpcrel_hi.3+0x20>
                	mv	s4, a0
-               	j	0x1120 <.Lpcrel_hi.3+0x44>
+               	j	0x6e4 <.Lpcrel_hi.3+0x44>
                	mv	a0, s2
                	li	a1, -0x1
                	auipc	ra, 0x0
@@ -1115,7 +460,7 @@ Disassembly of section .text:
                	mv	s2, s4
                	fmv.d	fs8, fs1
                	li	t0, 0x3c
-               	bltu	s3, t0, 0x10dc <.Lpcrel_hi.3>
+               	bltu	s3, t0, 0x6a0 <.Lpcrel_hi.3>
                	addi	s3, s0, -0xe8
                	sd	zero, 0x0(s3)
                	sd	zero, 0x8(s3)
@@ -1170,8 +515,8 @@ Disassembly of section .text:
                	sd	t0, 0x0(a0)
                	li	s4, 0x0
                	li	t0, 0x8
-               	bltu	s4, t0, 0x1214 <.Lpcrel_hi.3+0x138>
-               	j	0x1248 <.Lpcrel_hi.3+0x16c>
+               	bltu	s4, t0, 0x7d8 <.Lpcrel_hi.3+0x138>
+               	j	0x80c <.Lpcrel_hi.3+0x16c>
                	slli	t0, s4, 0x3
                	add	a0, s3, t0
                	ld	a1, 0x0(a0)
@@ -1184,7 +529,7 @@ Disassembly of section .text:
                	addi	s4, s4, 0x1
                	mv	s2, a0
                	li	t0, 0x8
-               	bltu	s4, t0, 0x1214 <.Lpcrel_hi.3+0x138>
+               	bltu	s4, t0, 0x7d8 <.Lpcrel_hi.3+0x138>
                	fcvt.s.d	ft0, fs7
                	fcvt.s.d	fs1, fs10
                	lui	t1, 0x36a0
@@ -1238,12 +583,12 @@ Disassembly of section .text:
                	fcvt.d.s	fa0, fs4
                	feq.d	a0, fa0, fa0
                	xori	a0, a0, 0x1
-               	bnez	a0, 0x1334 <.Lpcrel_hi.3+0x258>
+               	bnez	a0, 0x8f8 <.Lpcrel_hi.3+0x258>
                	mv	a0, s2
                	auipc	ra, 0x0
                	jalr	ra <.Lpcrel_hi.3+0x248>
                	mv	s3, a0
-               	j	0x1348 <.Lpcrel_hi.3+0x26c>
+               	j	0x90c <.Lpcrel_hi.3+0x26c>
                	mv	a0, s2
                	li	a1, -0x1
                	auipc	ra, 0x0
@@ -1252,12 +597,12 @@ Disassembly of section .text:
                	fcvt.d.s	fa0, fs8
                	feq.d	a0, fa0, fa0
                	xori	a0, a0, 0x1
-               	bnez	a0, 0x136c <.Lpcrel_hi.3+0x290>
+               	bnez	a0, 0x930 <.Lpcrel_hi.3+0x290>
                	mv	a0, s3
                	auipc	ra, 0x0
                	jalr	ra <.Lpcrel_hi.3+0x280>
                	mv	s2, a0
-               	j	0x1380 <.Lpcrel_hi.3+0x2a4>
+               	j	0x944 <.Lpcrel_hi.3+0x2a4>
                	mv	a0, s3
                	li	a1, -0x1
                	auipc	ra, 0x0
@@ -1266,12 +611,12 @@ Disassembly of section .text:
                	fcvt.d.s	fa0, fs3
                	feq.d	a0, fa0, fa0
                	xori	a0, a0, 0x1
-               	bnez	a0, 0x13a4 <.Lpcrel_hi.3+0x2c8>
+               	bnez	a0, 0x968 <.Lpcrel_hi.3+0x2c8>
                	mv	a0, s2
                	auipc	ra, 0x0
                	jalr	ra <.Lpcrel_hi.3+0x2b8>
                	mv	s3, a0
-               	j	0x13b8 <.Lpcrel_hi.3+0x2dc>
+               	j	0x97c <.Lpcrel_hi.3+0x2dc>
                	mv	a0, s2
                	li	a1, -0x1
                	auipc	ra, 0x0
@@ -1306,12 +651,12 @@ Disassembly of section .text:
                	fcvt.d.lu	fa0, a0
                	feq.d	a0, fa0, fa0
                	xori	a0, a0, 0x1
-               	bnez	a0, 0x1444 <.Lpcrel_hi.3+0x368>
+               	bnez	a0, 0xa08 <.Lpcrel_hi.3+0x368>
                	mv	a0, s3
                	auipc	ra, 0x0
                	jalr	ra <.Lpcrel_hi.3+0x358>
                	mv	s8, a0
-               	j	0x1458 <.Lpcrel_hi.3+0x37c>
+               	j	0xa1c <.Lpcrel_hi.3+0x37c>
                	mv	a0, s3
                	li	a1, -0x1
                	auipc	ra, 0x0
@@ -1320,12 +665,12 @@ Disassembly of section .text:
                	fcvt.d.lu	fa0, s2
                	feq.d	a0, fa0, fa0
                	xori	a0, a0, 0x1
-               	bnez	a0, 0x147c <.Lpcrel_hi.3+0x3a0>
+               	bnez	a0, 0xa40 <.Lpcrel_hi.3+0x3a0>
                	mv	a0, s8
                	auipc	ra, 0x0
                	jalr	ra <.Lpcrel_hi.3+0x390>
                	mv	s2, a0
-               	j	0x1490 <.Lpcrel_hi.3+0x3b4>
+               	j	0xa54 <.Lpcrel_hi.3+0x3b4>
                	mv	a0, s8
                	li	a1, -0x1
                	auipc	ra, 0x0
@@ -1334,12 +679,12 @@ Disassembly of section .text:
                	fcvt.d.lu	fa0, s4
                	feq.d	a0, fa0, fa0
                	xori	a0, a0, 0x1
-               	bnez	a0, 0x14b4 <.Lpcrel_hi.3+0x3d8>
+               	bnez	a0, 0xa78 <.Lpcrel_hi.3+0x3d8>
                	mv	a0, s2
                	auipc	ra, 0x0
                	jalr	ra <.Lpcrel_hi.3+0x3c8>
                	mv	s3, a0
-               	j	0x14c8 <.Lpcrel_hi.3+0x3ec>
+               	j	0xa8c <.Lpcrel_hi.3+0x3ec>
                	mv	a0, s2
                	li	a1, -0x1
                	auipc	ra, 0x0
@@ -1348,12 +693,12 @@ Disassembly of section .text:
                	fcvt.d.lu	fa0, s5
                	feq.d	a0, fa0, fa0
                	xori	a0, a0, 0x1
-               	bnez	a0, 0x14ec <.Lpcrel_hi.3+0x410>
+               	bnez	a0, 0xab0 <.Lpcrel_hi.3+0x410>
                	mv	a0, s3
                	auipc	ra, 0x0
                	jalr	ra <.Lpcrel_hi.3+0x400>
                	mv	s2, a0
-               	j	0x1500 <.Lpcrel_hi.3+0x424>
+               	j	0xac4 <.Lpcrel_hi.3+0x424>
                	mv	a0, s3
                	li	a1, -0x1
                	auipc	ra, 0x0
@@ -1362,12 +707,12 @@ Disassembly of section .text:
                	fcvt.d.lu	fa0, s1
                	feq.d	a0, fa0, fa0
                	xori	a0, a0, 0x1
-               	bnez	a0, 0x1524 <.Lpcrel_hi.3+0x448>
+               	bnez	a0, 0xae8 <.Lpcrel_hi.3+0x448>
                	mv	a0, s2
                	auipc	ra, 0x0
                	jalr	ra <.Lpcrel_hi.3+0x438>
                	mv	s1, a0
-               	j	0x1538 <.Lpcrel_hi.3+0x45c>
+               	j	0xafc <.Lpcrel_hi.3+0x45c>
                	mv	a0, s2
                	li	a1, -0x1
                	auipc	ra, 0x0
@@ -1376,12 +721,12 @@ Disassembly of section .text:
                	fcvt.d.l	fa0, s6
                	feq.d	a0, fa0, fa0
                	xori	a0, a0, 0x1
-               	bnez	a0, 0x155c <.Lpcrel_hi.3+0x480>
+               	bnez	a0, 0xb20 <.Lpcrel_hi.3+0x480>
                	mv	a0, s1
                	auipc	ra, 0x0
                	jalr	ra <.Lpcrel_hi.3+0x470>
                	mv	s2, a0
-               	j	0x1570 <.Lpcrel_hi.3+0x494>
+               	j	0xb34 <.Lpcrel_hi.3+0x494>
                	mv	a0, s1
                	li	a1, -0x1
                	auipc	ra, 0x0
@@ -1390,12 +735,12 @@ Disassembly of section .text:
                	fcvt.d.l	fa0, s7
                	feq.d	a0, fa0, fa0
                	xori	a0, a0, 0x1
-               	bnez	a0, 0x1594 <.Lpcrel_hi.3+0x4b8>
+               	bnez	a0, 0xb58 <.Lpcrel_hi.3+0x4b8>
                	mv	a0, s2
                	auipc	ra, 0x0
                	jalr	ra <.Lpcrel_hi.3+0x4a8>
                	mv	s1, a0
-               	j	0x15a8 <.Lpcrel_hi.4>
+               	j	0xb6c <.Lpcrel_hi.4>
                	mv	a0, s2
                	li	a1, -0x1
                	auipc	ra, 0x0

--- a/test/golden/riscv64-linux/frame/frame_large.dis
+++ b/test/golden/riscv64-linux/frame/frame_large.dis
@@ -2339,39 +2339,45 @@ Disassembly of section .text:
                	li	s6, 0x0
                	li	t0, 0x40
                	bltu	s6, t0, 0x2484 <corpus.cases.frame.frame_large.checksum+0x2484>
-               	j	0x2514 <corpus.cases.frame.frame_large.checksum+0x2514>
+               	j	0x252c <corpus.cases.frame.frame_large.checksum+0x252c>
                	li	t0, 0x9
                	mul	a0, s6, t0
                	add	a1, a0, s1
                	li	a0, 0x280
+               	bnez	a0, 0x249c <corpus.cases.frame.frame_large.checksum+0x249c>
+               	ebreak
                	remu	a2, a1, a0
                	slli	t0, a2, 0x3
                	add	a0, s2, t0
                	ld	a1, 0x0(a0)
                	mv	a0, s5
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.frame.frame_large.checksum+0x24a8>
+               	jalr	ra <corpus.cases.frame.frame_large.checksum+0x24b0>
                	li	t0, 0xd
                	mul	a1, s6, t0
                	add	a2, a1, s1
                	li	a1, 0x200
+               	bnez	a1, 0x24d0 <corpus.cases.frame.frame_large.checksum+0x24d0>
+               	ebreak
                	remu	a3, a2, a1
                	slli	t0, a3, 0x2
                	add	a1, s3, t0
                	lw	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.frame.frame_large.checksum+0x24d4>
+               	jalr	ra <corpus.cases.frame.frame_large.checksum+0x24e4>
                	li	t0, 0x1d
                	mul	a1, s6, t0
                	add	a2, a1, s1
                	li	a1, 0x400
+               	bnez	a1, 0x2504 <corpus.cases.frame.frame_large.checksum+0x2504>
+               	ebreak
                	remu	a3, a2, a1
                	add	a1, s4, a3
                	lbu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.frame.frame_large.checksum+0x24fc>
+               	jalr	ra <corpus.cases.frame.frame_large.checksum+0x2514>
                	addi	s6, s6, 0x1
                	mv	s5, a0
                	li	t0, 0x40
@@ -2413,26 +2419,26 @@ Disassembly of section .text:
                	ld	a1, 0x0(a0)
                	mv	a0, s5
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.frame.frame_large.checksum+0x25a4>
+               	jalr	ra <corpus.cases.frame.frame_large.checksum+0x25bc>
                	ld	a1, 0x0(s6)
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.frame.frame_large.checksum+0x25b0>
+               	jalr	ra <corpus.cases.frame.frame_large.checksum+0x25c8>
                	addi	a1, s3, 0x7f0
                	lw	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.frame.frame_large.checksum+0x25c4>
+               	jalr	ra <corpus.cases.frame.frame_large.checksum+0x25dc>
                	lw	a1, 0x0(s7)
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.frame.frame_large.checksum+0x25d0>
+               	jalr	ra <corpus.cases.frame.frame_large.checksum+0x25e8>
                	addi	a1, s4, 0x3f8
                	lbu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.frame.frame_large.checksum+0x25e4>
+               	jalr	ra <corpus.cases.frame.frame_large.checksum+0x25fc>
                	lbu	a1, 0x0(s8)
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.frame.frame_large.checksum+0x25f0>
+               	jalr	ra <corpus.cases.frame.frame_large.checksum+0x2608>
                	lui	t1, 0x2
                	addiw	t1, t1, 0x38
                	add	t1, sp, t1

--- a/test/golden/riscv64-linux/imm/imm_addr.dis
+++ b/test/golden/riscv64-linux/imm/imm_addr.dis
@@ -17402,18 +17402,24 @@ Disassembly of section .text:
                	mv	a1, a0
                	lui	a2, 0x1
                	addiw	a2, a2, 0x80
+               	bnez	a2, 0x10fe4 <corpus.cases.imm.imm_addr.checksum+0x10fe4>
+               	ebreak
                	remu	a3, s1, a2
                	lui	t0, 0x1
                	addiw	t0, t0, -0x1
                	add	a2, s1, t0
                	lui	a4, 0x1
                	addiw	a4, a4, 0x80
+               	bnez	a4, 0x11004 <corpus.cases.imm.imm_addr.checksum+0x11004>
+               	ebreak
                	remu	a5, a2, a4
                	lui	t0, 0x1
                	addiw	t0, t0, -0x800
                	add	a2, s1, t0
                	lui	a4, 0x1
                	addiw	a4, a4, 0x80
+               	bnez	a4, 0x11024 <corpus.cases.imm.imm_addr.checksum+0x11024>
+               	ebreak
                	remu	a6, a2, a4
                	slli	t0, a3, 0x3
                	add	a2, s2, t0
@@ -17434,24 +17440,28 @@ Disassembly of section .text:
                	mv	a0, a1
                	mv	a1, a3
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.imm.imm_addr.checksum+0x11058>
+               	jalr	ra <corpus.cases.imm.imm_addr.checksum+0x11070>
                	mv	a1, a0
                	ld	a2, 0x0(s4)
                	mv	a0, a1
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.imm.imm_addr.checksum+0x11070>
+               	jalr	ra <corpus.cases.imm.imm_addr.checksum+0x11088>
                	mv	a1, a0
                	ld	a2, 0x0(s5)
                	mv	a0, a1
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.imm.imm_addr.checksum+0x11088>
+               	jalr	ra <corpus.cases.imm.imm_addr.checksum+0x110a0>
                	mv	a1, a0
                	li	a2, 0x60
+               	bnez	a2, 0x110b8 <corpus.cases.imm.imm_addr.checksum+0x110b8>
+               	ebreak
                	remu	a3, s1, a2
                	addi	a2, s1, 0x3f
                	li	a4, 0x60
+               	bnez	a4, 0x110cc <corpus.cases.imm.imm_addr.checksum+0x110cc>
+               	ebreak
                	remu	a5, a2, a4
                	li	t0, 0x28
                	mul	a2, a3, t0
@@ -17502,61 +17512,61 @@ Disassembly of section .text:
                	mv	a0, a1
                	mv	a1, a3
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.imm.imm_addr.checksum+0x11168>
+               	jalr	ra <corpus.cases.imm.imm_addr.checksum+0x11190>
                	mv	a1, a0
                	ld	a2, 0x0(s2)
                	mv	a0, a1
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.imm.imm_addr.checksum+0x11180>
+               	jalr	ra <corpus.cases.imm.imm_addr.checksum+0x111a8>
                	mv	a1, a0
                	ld	a2, 0x0(s4)
                	mv	a0, a1
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.imm.imm_addr.checksum+0x11198>
+               	jalr	ra <corpus.cases.imm.imm_addr.checksum+0x111c0>
                	mv	a1, a0
                	ld	a2, 0x0(s5)
                	mv	a0, a1
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.imm.imm_addr.checksum+0x111b0>
+               	jalr	ra <corpus.cases.imm.imm_addr.checksum+0x111d8>
                	mv	a1, a0
                	lw	a2, 0x0(s7)
                	mv	a0, a1
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.imm.imm_addr.checksum+0x111c8>
+               	jalr	ra <corpus.cases.imm.imm_addr.checksum+0x111f0>
                	mv	a1, a0
                	lw	a2, 0x0(s3)
                	mv	a0, a1
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.imm.imm_addr.checksum+0x111e0>
+               	jalr	ra <corpus.cases.imm.imm_addr.checksum+0x11208>
                	mv	a1, a0
                	ld	a2, 0x0(s8)
                	mv	a0, a1
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.imm.imm_addr.checksum+0x111f8>
+               	jalr	ra <corpus.cases.imm.imm_addr.checksum+0x11220>
                	mv	a1, a0
                	ld	a2, 0x0(s9)
                	mv	a0, a1
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.imm.imm_addr.checksum+0x11210>
+               	jalr	ra <corpus.cases.imm.imm_addr.checksum+0x11238>
                	mv	a1, a0
                	ld	a2, 0x0(s1)
                	mv	a0, a1
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.imm.imm_addr.checksum+0x11228>
+               	jalr	ra <corpus.cases.imm.imm_addr.checksum+0x11250>
                	mv	a1, a0
                	lw	a2, 0x0(s10)
                	mv	a0, a1
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.imm.imm_addr.checksum+0x11240>
+               	jalr	ra <corpus.cases.imm.imm_addr.checksum+0x11268>
                	mv	a1, a0
                	ld	a2, 0x0(s6)
                	addi	a3, a2, 0x10
@@ -17565,7 +17575,7 @@ Disassembly of section .text:
                	mv	a0, a1
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.imm.imm_addr.checksum+0x11264>
+               	jalr	ra <corpus.cases.imm.imm_addr.checksum+0x1128c>
                	lui	t1, 0x9
                	addiw	t1, t1, 0x348
                	add	t1, sp, t1

--- a/test/golden/riscv64-linux/imm/imm_mov.dis
+++ b/test/golden/riscv64-linux/imm/imm_mov.dis
@@ -80,50 +80,56 @@ Disassembly of section .text:
                	slli	t0, t0, 0xc
                	sd	t0, 0x0(a1)
                	li	a1, 0x3
+               	bnez	a1, 0x13c <corpus.cases.imm.imm_mov.checksum+0x13c>
+               	ebreak
                	remu	s3, s1, a1
                	slli	t0, s3, 0x3
                	add	a1, s2, t0
                	ld	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.imm.imm_mov.checksum+0x148>
+               	jalr	ra <corpus.cases.imm.imm_mov.checksum+0x150>
                	addi	a1, s3, 0x1
                	li	a2, 0x3
+               	bnez	a2, 0x168 <corpus.cases.imm.imm_mov.checksum+0x168>
+               	ebreak
                	remu	a3, a1, a2
                	slli	t0, a3, 0x3
                	add	a1, s2, t0
                	ld	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.imm.imm_mov.checksum+0x16c>
+               	jalr	ra <corpus.cases.imm.imm_mov.checksum+0x17c>
                	addi	a1, s3, 0x2
                	li	a2, 0x3
+               	bnez	a2, 0x194 <corpus.cases.imm.imm_mov.checksum+0x194>
+               	ebreak
                	remu	a3, a1, a2
                	slli	t0, a3, 0x3
                	add	a1, s2, t0
                	ld	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.imm.imm_mov.checksum+0x190>
+               	jalr	ra <corpus.cases.imm.imm_mov.checksum+0x1a8>
                	sext.w	a1, s1
                	li	t1, 0x7ff
                	addw	a2, t1, a1
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.imm.imm_mov.checksum+0x1a8>
+               	jalr	ra <corpus.cases.imm.imm_mov.checksum+0x1c0>
                	lui	a1, 0x80000
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.imm.imm_mov.checksum+0x1b4>
+               	jalr	ra <corpus.cases.imm.imm_mov.checksum+0x1cc>
                	lui	a1, 0xf8000
                	slli	a1, a1, 0xc
                	slli	a1, a1, 0xc
                	slli	a1, a1, 0xc
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.imm.imm_mov.checksum+0x1cc>
+               	jalr	ra <corpus.cases.imm.imm_mov.checksum+0x1e4>
                	lui	a1, 0x55555
                	addiw	a1, a1, 0x555
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.imm.imm_mov.checksum+0x1dc>
+               	jalr	ra <corpus.cases.imm.imm_mov.checksum+0x1f4>
                	ld	s1, 0x38(sp)
                	ld	s2, 0x30(sp)
                	ld	s3, 0x28(sp)

--- a/test/golden/riscv64-linux/mem/addr_modes.dis
+++ b/test/golden/riscv64-linux/mem/addr_modes.dis
@@ -5166,20 +5166,22 @@ Disassembly of section .text:
                	jalr	ra <corpus.cases.mem.addr_modes.checksum+0x509c>
                	addi	a1, s1, 0x2bc
                	li	a2, 0x400
+               	bnez	a2, 0x50b4 <corpus.cases.mem.addr_modes.checksum+0x50b4>
+               	ebreak
                	remu	a3, a1, a2
                	slli	t0, a3, 0x3
                	add	a1, s3, t0
                	ld	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.addr_modes.checksum+0x50c0>
+               	jalr	ra <corpus.cases.mem.addr_modes.checksum+0x50c8>
                	lui	t0, 0x2
                	addiw	t0, t0, 0x8
                	add	a1, s2, t0
                	lw	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.addr_modes.checksum+0x50dc>
+               	jalr	ra <corpus.cases.mem.addr_modes.checksum+0x50e4>
                	lui	t0, 0x2
                	addiw	t0, t0, 0xc
                	add	s3, s2, t0
@@ -5187,49 +5189,51 @@ Disassembly of section .text:
                	lw	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.addr_modes.checksum+0x50fc>
+               	jalr	ra <corpus.cases.mem.addr_modes.checksum+0x5104>
                	addi	a1, s3, 0x7fc
                	lw	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.addr_modes.checksum+0x5110>
+               	jalr	ra <corpus.cases.mem.addr_modes.checksum+0x5118>
                	addi	a1, s1, 0x12c
                	li	a2, 0x200
+               	bnez	a2, 0x5130 <corpus.cases.mem.addr_modes.checksum+0x5130>
+               	ebreak
                	remu	a3, a1, a2
                	slli	t0, a3, 0x2
                	add	a1, s3, t0
                	lw	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.addr_modes.checksum+0x5134>
+               	jalr	ra <corpus.cases.mem.addr_modes.checksum+0x5144>
                	lui	t0, 0x3
                	addiw	t0, t0, -0x7f4
                	add	a1, s2, t0
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.addr_modes.checksum+0x5150>
+               	jalr	ra <corpus.cases.mem.addr_modes.checksum+0x5160>
                	lui	a1, 0x2
                	addiw	a1, a1, 0x8
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.addr_modes.checksum+0x5160>
+               	jalr	ra <corpus.cases.mem.addr_modes.checksum+0x5170>
                	lui	a1, 0x2
                	addiw	a1, a1, 0xc
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.addr_modes.checksum+0x5170>
+               	jalr	ra <corpus.cases.mem.addr_modes.checksum+0x5180>
                	lui	a1, 0x3
                	addiw	a1, a1, -0x7f4
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.addr_modes.checksum+0x5180>
+               	jalr	ra <corpus.cases.mem.addr_modes.checksum+0x5190>
                	lui	a1, 0x3
                	addiw	a1, a1, -0x7f0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.addr_modes.checksum+0x5190>
+               	jalr	ra <corpus.cases.mem.addr_modes.checksum+0x51a0>
                	li	a1, 0x0
                	li	a2, 0x0
                	li	t0, 0x400
-               	bltu	a1, t0, 0x51ac <corpus.cases.mem.addr_modes.checksum+0x51ac>
-               	j	0x51d0 <corpus.cases.mem.addr_modes.checksum+0x51d0>
+               	bltu	a1, t0, 0x51bc <corpus.cases.mem.addr_modes.checksum+0x51bc>
+               	j	0x51e0 <corpus.cases.mem.addr_modes.checksum+0x51e0>
                	addi	a3, s2, 0x8
                	slli	t0, a1, 0x3
                	add	a4, a3, t0
@@ -5238,15 +5242,15 @@ Disassembly of section .text:
                	mul	a4, a3, a1
                	xor	a2, a2, a4
                	li	t0, 0x400
-               	bltu	a1, t0, 0x51ac <corpus.cases.mem.addr_modes.checksum+0x51ac>
+               	bltu	a1, t0, 0x51bc <corpus.cases.mem.addr_modes.checksum+0x51bc>
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.addr_modes.checksum+0x51d4>
+               	jalr	ra <corpus.cases.mem.addr_modes.checksum+0x51e4>
                	li	a1, 0x0
                	li	a2, 0x0
                	li	t0, 0x200
-               	bltu	a1, t0, 0x51f0 <corpus.cases.mem.addr_modes.checksum+0x51f0>
-               	j	0x5228 <corpus.cases.mem.addr_modes.checksum+0x5228>
+               	bltu	a1, t0, 0x5200 <corpus.cases.mem.addr_modes.checksum+0x5200>
+               	j	0x5238 <corpus.cases.mem.addr_modes.checksum+0x5238>
                	lui	t0, 0x2
                	addiw	t0, t0, 0xc
                	add	a3, s2, t0
@@ -5260,10 +5264,10 @@ Disassembly of section .text:
                	add	a2, a2, a5
                	addi	a1, a1, 0x1
                	li	t0, 0x200
-               	bltu	a1, t0, 0x51f0 <corpus.cases.mem.addr_modes.checksum+0x51f0>
+               	bltu	a1, t0, 0x5200 <corpus.cases.mem.addr_modes.checksum+0x5200>
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.addr_modes.checksum+0x522c>
+               	jalr	ra <corpus.cases.mem.addr_modes.checksum+0x523c>
                	lui	t1, 0x3
                	addiw	t1, t1, 0x428
                	add	t1, sp, t1

--- a/test/golden/riscv64-linux/mem/array_index.dis
+++ b/test/golden/riscv64-linux/mem/array_index.dis
@@ -364,23 +364,29 @@ Disassembly of section .text:
                	jalr	ra <corpus.cases.mem.array_index.checksum+0x500>
                	addi	a1, s1, 0x1
                	li	a2, 0x3
+               	bnez	a2, 0x5a4 <corpus.cases.mem.array_index.checksum+0x518>
+               	ebreak
                	remu	a3, a1, a2
                	li	t0, 0x9
                	mul	a1, a3, t0
                	add	a2, s3, a1
                	addi	a1, s1, 0x2
                	li	a3, 0x3
+               	bnez	a3, 0x5c4 <corpus.cases.mem.array_index.checksum+0x538>
+               	ebreak
                	remu	a4, a1, a3
                	li	t0, 0x3
                	mul	a1, a4, t0
                	add	a3, a2, a1
                	li	a1, 0x3
+               	bnez	a1, 0x5e0 <corpus.cases.mem.array_index.checksum+0x554>
+               	ebreak
                	remu	a2, s1, a1
                	add	a1, a3, a2
                	lbu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.array_index.checksum+0x54c>
+               	jalr	ra <corpus.cases.mem.array_index.checksum+0x564>
                	addi	s3, s0, -0x190
                	sd	zero, 0x0(s3)
                	sd	zero, 0x8(s3)
@@ -394,8 +400,8 @@ Disassembly of section .text:
                	sd	zero, 0x48(s3)
                	li	a1, 0x0
                	li	t0, 0x5
-               	bltu	a1, t0, 0x61c <corpus.cases.mem.array_index.checksum+0x590>
-               	j	0x67c <corpus.cases.mem.array_index.checksum+0x5f0>
+               	bltu	a1, t0, 0x634 <corpus.cases.mem.array_index.checksum+0x5a8>
+               	j	0x694 <corpus.cases.mem.array_index.checksum+0x608>
                	li	t0, 0x3
                	mul	a2, a1, t0
                	addi	a3, a2, 0x1
@@ -419,12 +425,12 @@ Disassembly of section .text:
                	addi	a2, a4, 0x8
                	sd	a3, 0x0(a2)
                	li	t0, 0x5
-               	bltu	a1, t0, 0x61c <corpus.cases.mem.array_index.checksum+0x590>
+               	bltu	a1, t0, 0x634 <corpus.cases.mem.array_index.checksum+0x5a8>
                	mv	s4, a0
                	li	s5, 0x0
                	li	t0, 0x5
-               	bltu	s5, t0, 0x690 <corpus.cases.mem.array_index.checksum+0x604>
-               	j	0x6ec <corpus.cases.mem.array_index.checksum+0x660>
+               	bltu	s5, t0, 0x6a8 <corpus.cases.mem.array_index.checksum+0x61c>
+               	j	0x704 <corpus.cases.mem.array_index.checksum+0x678>
                	li	t0, 0x10
                	mul	a0, s5, t0
                	add	a1, s3, a0
@@ -437,19 +443,21 @@ Disassembly of section .text:
                	mv	a0, s4
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.array_index.checksum+0x630>
+               	jalr	ra <corpus.cases.mem.array_index.checksum+0x648>
                	mv	a1, s6
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.array_index.checksum+0x63c>
+               	jalr	ra <corpus.cases.mem.array_index.checksum+0x654>
                	mv	a1, s7
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.array_index.checksum+0x648>
+               	jalr	ra <corpus.cases.mem.array_index.checksum+0x660>
                	addi	s5, s5, 0x1
                	mv	s4, a0
                	li	t0, 0x5
-               	bltu	s5, t0, 0x690 <corpus.cases.mem.array_index.checksum+0x604>
+               	bltu	s5, t0, 0x6a8 <corpus.cases.mem.array_index.checksum+0x61c>
                	addi	a0, s1, 0x3
                	li	a1, 0x5
+               	bnez	a1, 0x714 <corpus.cases.mem.array_index.checksum+0x688>
+               	ebreak
                	remu	a2, a0, a1
                	li	t0, 0x10
                	mul	a0, a2, t0
@@ -463,20 +471,22 @@ Disassembly of section .text:
                	mv	a0, s4
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.array_index.checksum+0x698>
+               	jalr	ra <corpus.cases.mem.array_index.checksum+0x6b8>
                	mv	a1, s5
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.array_index.checksum+0x6a4>
+               	jalr	ra <corpus.cases.mem.array_index.checksum+0x6c4>
                	mv	a1, s6
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.array_index.checksum+0x6b0>
+               	jalr	ra <corpus.cases.mem.array_index.checksum+0x6d0>
                	addi	a1, s3, 0x40
                	addi	a2, a1, 0x8
                	ld	a1, 0x0(a2)
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.array_index.checksum+0x6c4>
+               	jalr	ra <corpus.cases.mem.array_index.checksum+0x6e4>
                	addi	a1, s1, 0x1
                	li	a2, 0x5
+               	bnez	a2, 0x788 <corpus.cases.mem.array_index.checksum+0x6fc>
+               	ebreak
                	remu	a3, a1, a2
                	li	t0, 0x10
                	mul	a1, a3, t0
@@ -485,10 +495,10 @@ Disassembly of section .text:
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.array_index.checksum+0x6f0>
+               	jalr	ra <corpus.cases.mem.array_index.checksum+0x718>
                	li	a1, 0x10
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.array_index.checksum+0x6fc>
+               	jalr	ra <corpus.cases.mem.array_index.checksum+0x724>
                	sd	zero, 0x0(s2)
                	sd	zero, 0x8(s2)
                	sd	zero, 0x10(s2)
@@ -496,8 +506,8 @@ Disassembly of section .text:
                	sext.w	a1, s1
                	li	a2, 0x0
                	li	t0, 0x7
-               	bltu	a2, t0, 0x7b4 <corpus.cases.mem.array_index.checksum+0x728>
-               	j	0x7e0 <corpus.cases.mem.array_index.checksum+0x754>
+               	bltu	a2, t0, 0x7dc <corpus.cases.mem.array_index.checksum+0x750>
+               	j	0x808 <corpus.cases.mem.array_index.checksum+0x77c>
                	sext.w	a3, a2
                	lui	t0, 0x12345
                	addiw	t0, t0, 0x678
@@ -508,38 +518,40 @@ Disassembly of section .text:
                	sw	a3, 0x0(a4)
                	addi	a2, a2, 0x1
                	li	t0, 0x7
-               	bltu	a2, t0, 0x7b4 <corpus.cases.mem.array_index.checksum+0x728>
+               	bltu	a2, t0, 0x7dc <corpus.cases.mem.array_index.checksum+0x750>
                	li	a1, 0x11
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.array_index.checksum+0x758>
+               	jalr	ra <corpus.cases.mem.array_index.checksum+0x780>
                	mv	s3, a0
                	li	s4, 0x0
                	li	t0, 0x7
-               	bltu	s4, t0, 0x800 <corpus.cases.mem.array_index.checksum+0x774>
-               	j	0x83c <corpus.cases.mem.array_index.checksum+0x7b0>
+               	bltu	s4, t0, 0x828 <corpus.cases.mem.array_index.checksum+0x79c>
+               	j	0x86c <corpus.cases.mem.array_index.checksum+0x7e0>
                	li	t0, 0x3
                	mul	a0, s4, t0
                	add	a1, a0, s1
                	li	a0, 0x7
+               	bnez	a0, 0x840 <corpus.cases.mem.array_index.checksum+0x7b4>
+               	ebreak
                	remu	a2, a1, a0
                	slli	t0, a2, 0x2
                	add	a0, s2, t0
                	lw	a1, 0x0(a0)
                	mv	a0, s3
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.array_index.checksum+0x798>
+               	jalr	ra <corpus.cases.mem.array_index.checksum+0x7c8>
                	addi	s4, s4, 0x1
                	mv	s3, a0
                	li	t0, 0x7
-               	bltu	s4, t0, 0x800 <corpus.cases.mem.array_index.checksum+0x774>
+               	bltu	s4, t0, 0x828 <corpus.cases.mem.array_index.checksum+0x79c>
                	mv	a0, s3
                	lui	a1, 0x1
                	addiw	a1, a1, 0x234
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.array_index.checksum+0x7bc>
+               	jalr	ra <corpus.cases.mem.array_index.checksum+0x7ec>
                	li	a1, 0x4
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.array_index.checksum+0x7c8>
+               	jalr	ra <corpus.cases.mem.array_index.checksum+0x7f8>
                	mv	a1, s2
                	lw	a2, 0x0(a1)
                	addi	a1, s2, 0x4
@@ -560,17 +572,17 @@ Disassembly of section .text:
                	lw	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.array_index.checksum+0x81c>
+               	jalr	ra <corpus.cases.mem.array_index.checksum+0x84c>
                	mv	a1, s1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.array_index.checksum+0x828>
+               	jalr	ra <corpus.cases.mem.array_index.checksum+0x858>
                	li	a1, 0x11
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.array_index.checksum+0x834>
+               	jalr	ra <corpus.cases.mem.array_index.checksum+0x864>
                	lui	a1, 0x1
                	addiw	a1, a1, 0x234
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.array_index.checksum+0x844>
+               	jalr	ra <corpus.cases.mem.array_index.checksum+0x874>
                	ld	s1, 0x188(sp)
                	ld	s2, 0x180(sp)
                	ld	s3, 0x178(sp)

--- a/test/golden/riscv64-linux/mem/global_data.dis
+++ b/test/golden/riscv64-linux/mem/global_data.dis
@@ -406,12 +406,20 @@ Disassembly of section .text:
                	auipc	a1, 0x0
                	mv	a1, a1
                	li	a2, 0x3
+               	bnez	a2, 0x4d4 <.Lpcrel_hi.46+0x14>
+               	ebreak
                	remu	a3, a0, a2
                	slli	t0, a3, 0x1
                	add	a2, a1, t0
-               	lhu	a1, 0x0(a2)
-               	addiw	a3, a1, 0x64
-               	sh	a3, 0x0(a2)
+               	lhu	a3, 0x0(a2)
+               	addiw	a2, a3, 0x64
+               	li	a3, 0x3
+               	bnez	a3, 0x4f4 <.Lpcrel_hi.46+0x34>
+               	ebreak
+               	remu	a4, a0, a3
+               	slli	t0, a4, 0x1
+               	add	a3, a1, t0
+               	sh	a2, 0x0(a3)
 
 <.Lpcrel_hi.47>:
                	auipc	a1, 0x0
@@ -503,8 +511,8 @@ Disassembly of section .text:
                	mv	s9, a0
                	li	s10, 0x0
                	li	t0, 0x5
-               	bltu	s10, t0, 0x608 <.Lpcrel_hi.55+0x1c>
-               	j	0x7e4 <.Lpcrel_hi.80>
+               	bltu	s10, t0, 0x628 <.Lpcrel_hi.55+0x1c>
+               	j	0x824 <.Lpcrel_hi.80>
                	addi	a0, s10, 0x1
                	add	a1, a0, s1
 
@@ -618,8 +626,8 @@ Disassembly of section .text:
                	sext.w	a0, a1
                	li	a2, 0x0
                	li	t0, 0x6
-               	bltu	a2, t0, 0x724 <.Lpcrel_hi.77+0x20>
-               	j	0x750 <.Lpcrel_hi.77+0x4c>
+               	bltu	a2, t0, 0x744 <.Lpcrel_hi.77+0x20>
+               	j	0x770 <.Lpcrel_hi.77+0x4c>
                	slli	t0, a2, 0x2
                	add	a3, s2, t0
                	lw	a4, 0x0(a3)
@@ -630,7 +638,7 @@ Disassembly of section .text:
                	sw	a6, 0x0(a3)
                	addi	a2, a2, 0x1
                	li	t0, 0x6
-               	bltu	a2, t0, 0x724 <.Lpcrel_hi.77+0x20>
+               	bltu	a2, t0, 0x744 <.Lpcrel_hi.77+0x20>
                	lhu	a0, 0x0(s3)
                	sext.w	a2, a1
                	addw	a3, a0, a2
@@ -655,23 +663,31 @@ Disassembly of section .text:
                	ld	a0, 0x0(t0)
                	sd	a0, 0x8(s6)
                	li	a0, 0x3
+               	bnez	a0, 0x7c8 <.Lpcrel_hi.79+0x18>
+               	ebreak
                	remu	a2, a1, a0
                	slli	t0, a2, 0x1
                	add	a0, s7, t0
                	lhu	a2, 0x0(a0)
-               	addiw	a3, a2, 0x64
-               	sh	a3, 0x0(a0)
+               	addiw	a0, a2, 0x64
+               	li	a2, 0x3
+               	bnez	a2, 0x7e8 <.Lpcrel_hi.79+0x38>
+               	ebreak
+               	remu	a3, a1, a2
+               	slli	t0, a3, 0x1
+               	add	a2, s7, t0
+               	sh	a0, 0x0(a2)
                	lw	a0, 0x0(s8)
                	sext.w	a2, a1
                	subw	a1, a0, a2
                	sw	a1, 0x0(s8)
                	mv	a0, s9
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.79+0x3c>
+               	jalr	ra <.Lpcrel_hi.79+0x5c>
                	addi	s10, s10, 0x1
                	mv	s9, a0
                	li	t0, 0x5
-               	bltu	s10, t0, 0x608 <.Lpcrel_hi.55+0x1c>
+               	bltu	s10, t0, 0x628 <.Lpcrel_hi.55+0x1c>
 
 <.Lpcrel_hi.80>:
                	auipc	t0, 0x0

--- a/test/golden/riscv64-linux/mem/global_zero.dis
+++ b/test/golden/riscv64-linux/mem/global_zero.dis
@@ -445,6 +445,8 @@ Disassembly of section .text:
                	jalr	ra <.Lpcrel_hi.30+0x10>
                	addi	a1, s1, 0x1f4
                	li	a2, 0x200
+               	bnez	a2, 0x5e8 <.Lpcrel_hi.30+0x28>
+               	ebreak
                	remu	a3, a1, a2
 
 <.Lpcrel_hi.31>:
@@ -461,22 +463,22 @@ Disassembly of section .text:
                	mv	a1, a1
                	li	a2, 0x0
                	li	t0, 0x200
-               	bltu	a2, t0, 0x618 <.Lpcrel_hi.32+0x18>
-               	j	0x630 <.Lpcrel_hi.33>
+               	bltu	a2, t0, 0x620 <.Lpcrel_hi.32+0x18>
+               	j	0x638 <.Lpcrel_hi.33>
                	slli	t0, a2, 0x2
                	add	a3, a1, t0
                	sw	zero, 0x0(a3)
                	addi	a2, a2, 0x1
                	li	t0, 0x200
-               	bltu	a2, t0, 0x618 <.Lpcrel_hi.32+0x18>
+               	bltu	a2, t0, 0x620 <.Lpcrel_hi.32+0x18>
 
 <.Lpcrel_hi.33>:
                	auipc	a1, 0x0
                	mv	a1, a1
                	li	a2, 0x0
                	li	t0, 0x8
-               	bltu	a2, t0, 0x648 <.Lpcrel_hi.33+0x18>
-               	j	0x68c <.Lpcrel_hi.34>
+               	bltu	a2, t0, 0x650 <.Lpcrel_hi.33+0x18>
+               	j	0x694 <.Lpcrel_hi.34>
                	addi	a3, s0, -0x28
                	mv	a4, a3
                	sh	zero, 0x0(a4)
@@ -493,7 +495,7 @@ Disassembly of section .text:
                	sd	a4, 0x8(a5)
                	addi	a2, a2, 0x1
                	li	t0, 0x8
-               	bltu	a2, t0, 0x648 <.Lpcrel_hi.33+0x18>
+               	bltu	a2, t0, 0x650 <.Lpcrel_hi.33+0x18>
 
 <.Lpcrel_hi.34>:
                	auipc	t0, 0x0
@@ -553,14 +555,14 @@ Disassembly of section .text:
                	mv	a1, a1
                	li	a2, 0x0
                	li	t0, 0x4
-               	bltu	a2, t0, 0x728 <.Lpcrel_hi.44+0x18>
-               	j	0x740 <.Lpcrel_hi.45>
+               	bltu	a2, t0, 0x730 <.Lpcrel_hi.44+0x18>
+               	j	0x748 <.Lpcrel_hi.45>
                	slli	t0, a2, 0x3
                	add	a3, a1, t0
                	sd	zero, 0x0(a3)
                	addi	a2, a2, 0x1
                	li	t0, 0x4
-               	bltu	a2, t0, 0x728 <.Lpcrel_hi.44+0x18>
+               	bltu	a2, t0, 0x730 <.Lpcrel_hi.44+0x18>
 
 <.Lpcrel_hi.45>:
                	auipc	a1, 0x0

--- a/test/golden/riscv64-linux/mem/loadstore.dis
+++ b/test/golden/riscv64-linux/mem/loadstore.dis
@@ -83,18 +83,18 @@ Disassembly of section .text:
                	ret
 
 <corpus.cases.mem.loadstore.checksum>:
-               	addi	sp, sp, -0x80
-               	sd	ra, 0x78(sp)
-               	sd	s0, 0x70(sp)
-               	addi	s0, sp, 0x80
-               	sd	s1, 0x68(sp)
-               	sd	s2, 0x60(sp)
-               	sd	s3, 0x58(sp)
-               	sd	s4, 0x50(sp)
-               	sd	s5, 0x48(sp)
-               	sd	s6, 0x40(sp)
-               	sd	s7, 0x38(sp)
-               	sd	s8, 0x30(sp)
+               	addi	sp, sp, -0xc0
+               	sd	ra, 0xb8(sp)
+               	sd	s0, 0xb0(sp)
+               	addi	s0, sp, 0xc0
+               	sd	s1, 0xa8(sp)
+               	sd	s2, 0xa0(sp)
+               	sd	s3, 0x98(sp)
+               	sd	s4, 0x90(sp)
+               	sd	s5, 0x88(sp)
+               	sd	s6, 0x80(sp)
+               	sd	s7, 0x78(sp)
+               	sd	s8, 0x70(sp)
                	mv	s1, a0
                	auipc	ra, 0x0
                	jalr	ra <corpus.cases.mem.loadstore.checksum+0x34>
@@ -104,9 +104,15 @@ Disassembly of section .text:
                	sd	zero, 0x8(s2)
                	sd	zero, 0x10(s2)
                	mv	a0, a1
-               	mv	a1, s2
+               	ld	a1, 0x0(s2)
+               	sd	a1, -0x80(s0)
+               	ld	a1, 0x8(s2)
+               	sd	a1, -0x78(s0)
+               	ld	a1, 0x10(s2)
+               	sd	a1, -0x70(s0)
+               	addi	a1, s0, -0x80
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.loadstore.checksum+0x58>
+               	jalr	ra <corpus.cases.mem.loadstore.checksum+0x70>
                	mv	a1, a0
                	lui	t1, 0xffedd
                	addiw	t1, t1, -0x456
@@ -145,14 +151,20 @@ Disassembly of section .text:
                	addi	a2, s2, 0x10
                	sd	s3, 0x0(a2)
                	mv	a0, a1
-               	mv	a1, s2
+               	ld	a1, 0x0(s2)
+               	sd	a1, -0x98(s0)
+               	ld	a1, 0x8(s2)
+               	sd	a1, -0x90(s0)
+               	ld	a1, 0x10(s2)
+               	sd	a1, -0x88(s0)
+               	addi	a1, s0, -0x98
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.loadstore.checksum+0xfc>
+               	jalr	ra <corpus.cases.mem.loadstore.checksum+0x12c>
                	mv	s4, a0
                	li	s5, 0x0
                	li	t0, 0x8
-               	bltu	s5, t0, 0x250 <corpus.cases.mem.loadstore.checksum+0x118>
-               	j	0x2a4 <corpus.cases.mem.loadstore.checksum+0x16c>
+               	bltu	s5, t0, 0x280 <corpus.cases.mem.loadstore.checksum+0x148>
+               	j	0x2ec <corpus.cases.mem.loadstore.checksum+0x1b4>
                	addi	s5, s5, 0x1
                	mul	a0, s3, s5
                	add	a1, a0, s1
@@ -168,16 +180,22 @@ Disassembly of section .text:
                	addi	a0, s2, 0x8
                	sw	a1, 0x0(a0)
                	mv	a0, s4
-               	mv	a1, s2
+               	ld	a1, 0x0(s2)
+               	sd	a1, -0xb0(s0)
+               	ld	a1, 0x8(s2)
+               	sd	a1, -0xa8(s0)
+               	ld	a1, 0x10(s2)
+               	sd	a1, -0xa0(s0)
+               	addi	a1, s0, -0xb0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.loadstore.checksum+0x158>
+               	jalr	ra <corpus.cases.mem.loadstore.checksum+0x1a0>
                	mv	s4, a0
                	li	t0, 0x8
-               	bltu	s5, t0, 0x250 <corpus.cases.mem.loadstore.checksum+0x118>
+               	bltu	s5, t0, 0x280 <corpus.cases.mem.loadstore.checksum+0x148>
                	li	s2, 0x0
                	li	t0, 0x6
-               	bltu	s2, t0, 0x2b4 <corpus.cases.mem.loadstore.checksum+0x17c>
-               	j	0x38c <corpus.cases.mem.loadstore.checksum+0x254>
+               	bltu	s2, t0, 0x2fc <corpus.cases.mem.loadstore.checksum+0x1c4>
+               	j	0x3d4 <corpus.cases.mem.loadstore.checksum+0x29c>
                	addi	s2, s2, 0x1
                	lui	t1, 0xf9e37
                	addiw	t1, t1, 0x79c
@@ -197,48 +215,48 @@ Disassembly of section .text:
                	mv	a0, s4
                	mv	a1, s6
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.loadstore.checksum+0x1c4>
+               	jalr	ra <corpus.cases.mem.loadstore.checksum+0x20c>
                	mv	a1, s7
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.loadstore.checksum+0x1d0>
+               	jalr	ra <corpus.cases.mem.loadstore.checksum+0x218>
                	mv	a1, s8
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.loadstore.checksum+0x1dc>
+               	jalr	ra <corpus.cases.mem.loadstore.checksum+0x224>
                	mv	a1, s5
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.loadstore.checksum+0x1e8>
+               	jalr	ra <corpus.cases.mem.loadstore.checksum+0x230>
                	slli	a1, s6, 0x38
                	srai	a1, a1, 0x38
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.loadstore.checksum+0x1f8>
+               	jalr	ra <corpus.cases.mem.loadstore.checksum+0x240>
                	slli	a1, s7, 0x30
                	srai	a1, a1, 0x30
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.loadstore.checksum+0x208>
+               	jalr	ra <corpus.cases.mem.loadstore.checksum+0x250>
                	sext.w	a1, s8
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.loadstore.checksum+0x214>
+               	jalr	ra <corpus.cases.mem.loadstore.checksum+0x25c>
                	zext.b	a1, s6
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.loadstore.checksum+0x220>
+               	jalr	ra <corpus.cases.mem.loadstore.checksum+0x268>
                	slli	a1, s7, 0x30
                	srli	a1, a1, 0x30
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.loadstore.checksum+0x230>
+               	jalr	ra <corpus.cases.mem.loadstore.checksum+0x278>
                	slli	a1, s8, 0x20
                	srli	a1, a1, 0x20
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.loadstore.checksum+0x240>
+               	jalr	ra <corpus.cases.mem.loadstore.checksum+0x288>
                	mv	s4, a0
                	li	t0, 0x6
-               	bltu	s2, t0, 0x2b4 <corpus.cases.mem.loadstore.checksum+0x17c>
-               	addi	s1, s0, -0x78
+               	bltu	s2, t0, 0x2fc <corpus.cases.mem.loadstore.checksum+0x1c4>
+               	addi	s1, s0, -0xc0
                	sd	zero, 0x0(s1)
                	sd	zero, 0x8(s1)
                	li	a0, 0x0
                	li	t0, 0x10
-               	bltu	a0, t0, 0x3a8 <corpus.cases.mem.loadstore.checksum+0x270>
-               	j	0x3dc <corpus.cases.mem.loadstore.checksum+0x2a4>
+               	bltu	a0, t0, 0x3f0 <corpus.cases.mem.loadstore.checksum+0x2b8>
+               	j	0x424 <corpus.cases.mem.loadstore.checksum+0x2ec>
                	li	t0, 0x7
                	and	a1, a0, t0
                	li	t0, 0x8
@@ -251,20 +269,20 @@ Disassembly of section .text:
                	sb	a3, 0x0(a1)
                	addi	a0, a0, 0x1
                	li	t0, 0x10
-               	bltu	a0, t0, 0x3a8 <corpus.cases.mem.loadstore.checksum+0x270>
+               	bltu	a0, t0, 0x3f0 <corpus.cases.mem.loadstore.checksum+0x2b8>
                	li	s2, 0x0
                	li	t0, 0x10
-               	bltu	s2, t0, 0x3ec <corpus.cases.mem.loadstore.checksum+0x2b4>
-               	j	0x410 <corpus.cases.mem.loadstore.checksum+0x2d8>
+               	bltu	s2, t0, 0x434 <corpus.cases.mem.loadstore.checksum+0x2fc>
+               	j	0x458 <corpus.cases.mem.loadstore.checksum+0x320>
                	add	a0, s1, s2
                	lbu	a1, 0x0(a0)
                	mv	a0, s4
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.loadstore.checksum+0x2c0>
+               	jalr	ra <corpus.cases.mem.loadstore.checksum+0x308>
                	addi	s2, s2, 0x1
                	mv	s4, a0
                	li	t0, 0x10
-               	bltu	s2, t0, 0x3ec <corpus.cases.mem.loadstore.checksum+0x2b4>
+               	bltu	s2, t0, 0x434 <corpus.cases.mem.loadstore.checksum+0x2fc>
                	lui	t0, 0xf9e37
                	addiw	t0, t0, 0x79c
                	slli	t0, t0, 0xc
@@ -277,19 +295,19 @@ Disassembly of section .text:
                	mv	a0, s4
                	mv	a1, s1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.loadstore.checksum+0x304>
+               	jalr	ra <corpus.cases.mem.loadstore.checksum+0x34c>
                	addi	a1, s1, 0x1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.loadstore.checksum+0x310>
-               	ld	s1, 0x68(sp)
-               	ld	s2, 0x60(sp)
-               	ld	s3, 0x58(sp)
-               	ld	s4, 0x50(sp)
-               	ld	s5, 0x48(sp)
-               	ld	s6, 0x40(sp)
-               	ld	s7, 0x38(sp)
-               	ld	s8, 0x30(sp)
-               	ld	ra, 0x78(sp)
-               	ld	s0, 0x70(sp)
-               	addi	sp, sp, 0x80
+               	jalr	ra <corpus.cases.mem.loadstore.checksum+0x358>
+               	ld	s1, 0xa8(sp)
+               	ld	s2, 0xa0(sp)
+               	ld	s3, 0x98(sp)
+               	ld	s4, 0x90(sp)
+               	ld	s5, 0x88(sp)
+               	ld	s6, 0x80(sp)
+               	ld	s7, 0x78(sp)
+               	ld	s8, 0x70(sp)
+               	ld	ra, 0xb8(sp)
+               	ld	s0, 0xb0(sp)
+               	addi	sp, sp, 0xc0
                	ret

--- a/test/golden/riscv64-linux/mem/rec_layout.dis
+++ b/test/golden/riscv64-linux/mem/rec_layout.dis
@@ -357,16 +357,16 @@ Disassembly of section .text:
                	ret
 
 <corpus.cases.mem.rec_layout.checksum>:
-               	addi	sp, sp, -0xb0
-               	sd	ra, 0xa8(sp)
-               	sd	s0, 0xa0(sp)
-               	addi	s0, sp, 0xb0
-               	sd	s1, 0x98(sp)
-               	sd	s2, 0x90(sp)
-               	sd	s3, 0x88(sp)
-               	sd	s4, 0x80(sp)
-               	sd	s5, 0x78(sp)
-               	sd	s6, 0x70(sp)
+               	addi	sp, sp, -0x320
+               	sd	ra, 0x318(sp)
+               	sd	s0, 0x310(sp)
+               	addi	s0, sp, 0x320
+               	sd	s1, 0x308(sp)
+               	sd	s2, 0x300(sp)
+               	sd	s3, 0x2f8(sp)
+               	sd	s4, 0x2f0(sp)
+               	sd	s5, 0x2e8(sp)
+               	sd	s6, 0x2e0(sp)
                	mv	s1, a0
                	auipc	ra, 0x0
                	jalr	ra <corpus.cases.mem.rec_layout.checksum+0x2c>
@@ -470,9 +470,31 @@ Disassembly of section .text:
                	sd	zero, 0x48(s3)
                	sd	zero, 0x50(s3)
                	mv	a0, a1
-               	mv	a1, s3
+               	ld	a1, 0x0(s3)
+               	sd	a1, -0xf0(s0)
+               	ld	a1, 0x8(s3)
+               	sd	a1, -0xe8(s0)
+               	ld	a1, 0x10(s3)
+               	sd	a1, -0xe0(s0)
+               	ld	a1, 0x18(s3)
+               	sd	a1, -0xd8(s0)
+               	ld	a1, 0x20(s3)
+               	sd	a1, -0xd0(s0)
+               	ld	a1, 0x28(s3)
+               	sd	a1, -0xc8(s0)
+               	ld	a1, 0x30(s3)
+               	sd	a1, -0xc0(s0)
+               	ld	a1, 0x38(s3)
+               	sd	a1, -0xb8(s0)
+               	ld	a1, 0x40(s3)
+               	sd	a1, -0xb0(s0)
+               	ld	a1, 0x48(s3)
+               	sd	a1, -0xa8(s0)
+               	ld	a1, 0x50(s3)
+               	sd	a1, -0xa0(s0)
+               	addi	a1, s0, -0xf0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.rec_layout.checksum+0x1c8>
+               	jalr	ra <corpus.cases.mem.rec_layout.checksum+0x220>
                	mv	a1, s3
                	mv	a2, a1
                	li	t1, 0xa
@@ -579,9 +601,31 @@ Disassembly of section .text:
                	addw	a1, t1, s2
                	addi	s1, s3, 0x50
                	sw	a1, 0x0(s1)
-               	mv	a1, s3
+               	ld	a1, 0x0(s3)
+               	sd	a1, -0x148(s0)
+               	ld	a1, 0x8(s3)
+               	sd	a1, -0x140(s0)
+               	ld	a1, 0x10(s3)
+               	sd	a1, -0x138(s0)
+               	ld	a1, 0x18(s3)
+               	sd	a1, -0x130(s0)
+               	ld	a1, 0x20(s3)
+               	sd	a1, -0x128(s0)
+               	ld	a1, 0x28(s3)
+               	sd	a1, -0x120(s0)
+               	ld	a1, 0x30(s3)
+               	sd	a1, -0x118(s0)
+               	ld	a1, 0x38(s3)
+               	sd	a1, -0x110(s0)
+               	ld	a1, 0x40(s3)
+               	sd	a1, -0x108(s0)
+               	ld	a1, 0x48(s3)
+               	sd	a1, -0x100(s0)
+               	ld	a1, 0x50(s3)
+               	sd	a1, -0xf8(s0)
+               	addi	a1, s0, -0x148
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.rec_layout.checksum+0x37c>
+               	jalr	ra <corpus.cases.mem.rec_layout.checksum+0x42c>
                	mv	s2, s3
                	mv	a1, s2
                	addi	a2, a1, 0x4
@@ -591,9 +635,31 @@ Disassembly of section .text:
                	addiw	t0, t0, 0xf0
                	xor	a3, a2, t0
                	sw	a3, 0x0(a1)
-               	mv	a1, s3
+               	ld	a1, 0x0(s3)
+               	sd	a1, -0x1a0(s0)
+               	ld	a1, 0x8(s3)
+               	sd	a1, -0x198(s0)
+               	ld	a1, 0x10(s3)
+               	sd	a1, -0x190(s0)
+               	ld	a1, 0x18(s3)
+               	sd	a1, -0x188(s0)
+               	ld	a1, 0x20(s3)
+               	sd	a1, -0x180(s0)
+               	ld	a1, 0x28(s3)
+               	sd	a1, -0x178(s0)
+               	ld	a1, 0x30(s3)
+               	sd	a1, -0x170(s0)
+               	ld	a1, 0x38(s3)
+               	sd	a1, -0x168(s0)
+               	ld	a1, 0x40(s3)
+               	sd	a1, -0x160(s0)
+               	ld	a1, 0x48(s3)
+               	sd	a1, -0x158(s0)
+               	ld	a1, 0x50(s3)
+               	sd	a1, -0x150(s0)
+               	addi	a1, s0, -0x1a0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.rec_layout.checksum+0x3ac>
+               	jalr	ra <corpus.cases.mem.rec_layout.checksum+0x4b4>
                	addi	s4, s3, 0x28
                	addi	a1, s4, 0x14
                	addi	a2, a1, 0x4
@@ -601,24 +667,90 @@ Disassembly of section .text:
                	lbu	a2, 0x0(a1)
                	addiw	a3, a2, 0x7
                	sb	a3, 0x0(a1)
-               	mv	a1, s3
+               	ld	a1, 0x0(s3)
+               	sd	a1, -0x1f8(s0)
+               	ld	a1, 0x8(s3)
+               	sd	a1, -0x1f0(s0)
+               	ld	a1, 0x10(s3)
+               	sd	a1, -0x1e8(s0)
+               	ld	a1, 0x18(s3)
+               	sd	a1, -0x1e0(s0)
+               	ld	a1, 0x20(s3)
+               	sd	a1, -0x1d8(s0)
+               	ld	a1, 0x28(s3)
+               	sd	a1, -0x1d0(s0)
+               	ld	a1, 0x30(s3)
+               	sd	a1, -0x1c8(s0)
+               	ld	a1, 0x38(s3)
+               	sd	a1, -0x1c0(s0)
+               	ld	a1, 0x40(s3)
+               	sd	a1, -0x1b8(s0)
+               	ld	a1, 0x48(s3)
+               	sd	a1, -0x1b0(s0)
+               	ld	a1, 0x50(s3)
+               	sd	a1, -0x1a8(s0)
+               	addi	a1, s0, -0x1f8
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.rec_layout.checksum+0x3d4>
+               	jalr	ra <corpus.cases.mem.rec_layout.checksum+0x534>
                	addi	a1, s2, 0x18
                	ld	a2, 0x0(a1)
                	srli	a3, a2, 0x3
                	sd	a3, 0x0(a1)
-               	mv	a1, s3
+               	ld	a1, 0x0(s3)
+               	sd	a1, -0x250(s0)
+               	ld	a1, 0x8(s3)
+               	sd	a1, -0x248(s0)
+               	ld	a1, 0x10(s3)
+               	sd	a1, -0x240(s0)
+               	ld	a1, 0x18(s3)
+               	sd	a1, -0x238(s0)
+               	ld	a1, 0x20(s3)
+               	sd	a1, -0x230(s0)
+               	ld	a1, 0x28(s3)
+               	sd	a1, -0x228(s0)
+               	ld	a1, 0x30(s3)
+               	sd	a1, -0x220(s0)
+               	ld	a1, 0x38(s3)
+               	sd	a1, -0x218(s0)
+               	ld	a1, 0x40(s3)
+               	sd	a1, -0x210(s0)
+               	ld	a1, 0x48(s3)
+               	sd	a1, -0x208(s0)
+               	ld	a1, 0x50(s3)
+               	sd	a1, -0x200(s0)
+               	addi	a1, s0, -0x250
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.rec_layout.checksum+0x3f0>
+               	jalr	ra <corpus.cases.mem.rec_layout.checksum+0x5a8>
                	lw	a1, 0x0(s1)
                	li	t0, 0x3
                	mulw	a2, a1, t0
                	sw	a2, 0x0(s1)
-               	mv	a1, s3
+               	ld	a1, 0x0(s3)
+               	sd	a1, -0x2a8(s0)
+               	ld	a1, 0x8(s3)
+               	sd	a1, -0x2a0(s0)
+               	ld	a1, 0x10(s3)
+               	sd	a1, -0x298(s0)
+               	ld	a1, 0x18(s3)
+               	sd	a1, -0x290(s0)
+               	ld	a1, 0x20(s3)
+               	sd	a1, -0x288(s0)
+               	ld	a1, 0x28(s3)
+               	sd	a1, -0x280(s0)
+               	ld	a1, 0x30(s3)
+               	sd	a1, -0x278(s0)
+               	ld	a1, 0x38(s3)
+               	sd	a1, -0x270(s0)
+               	ld	a1, 0x40(s3)
+               	sd	a1, -0x268(s0)
+               	ld	a1, 0x48(s3)
+               	sd	a1, -0x260(s0)
+               	ld	a1, 0x50(s3)
+               	sd	a1, -0x258(s0)
+               	addi	a1, s0, -0x2a8
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.rec_layout.checksum+0x40c>
-               	addi	s1, s0, -0xac
+               	jalr	ra <corpus.cases.mem.rec_layout.checksum+0x61c>
+               	addi	s1, s0, -0x2bc
                	mv	a1, s4
                	ld	a2, 0x0(a1)
                	sd	a2, 0x0(s1)
@@ -644,19 +776,19 @@ Disassembly of section .text:
                	lbu	s6, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.rec_layout.checksum+0x478>
+               	jalr	ra <corpus.cases.mem.rec_layout.checksum+0x688>
                	mv	a1, s2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.rec_layout.checksum+0x484>
+               	jalr	ra <corpus.cases.mem.rec_layout.checksum+0x694>
                	mv	a1, s4
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.rec_layout.checksum+0x490>
+               	jalr	ra <corpus.cases.mem.rec_layout.checksum+0x6a0>
                	mv	a1, s5
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.rec_layout.checksum+0x49c>
+               	jalr	ra <corpus.cases.mem.rec_layout.checksum+0x6ac>
                	mv	a1, s6
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.rec_layout.checksum+0x4a8>
+               	jalr	ra <corpus.cases.mem.rec_layout.checksum+0x6b8>
                	addi	a1, s3, 0x28
                	mv	a2, a1
                	mv	a1, a2
@@ -672,19 +804,19 @@ Disassembly of section .text:
                	lbu	s6, 0x0(a1)
                	mv	a1, a3
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.rec_layout.checksum+0x4e8>
+               	jalr	ra <corpus.cases.mem.rec_layout.checksum+0x6f8>
                	mv	a1, s2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.rec_layout.checksum+0x4f4>
+               	jalr	ra <corpus.cases.mem.rec_layout.checksum+0x704>
                	mv	a1, s4
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.rec_layout.checksum+0x500>
+               	jalr	ra <corpus.cases.mem.rec_layout.checksum+0x710>
                	mv	a1, s5
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.rec_layout.checksum+0x50c>
+               	jalr	ra <corpus.cases.mem.rec_layout.checksum+0x71c>
                	mv	a1, s6
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.rec_layout.checksum+0x518>
+               	jalr	ra <corpus.cases.mem.rec_layout.checksum+0x728>
                	addi	a1, s3, 0x28
                	mv	a2, a1
                	ld	a1, 0x0(s1)
@@ -693,16 +825,38 @@ Disassembly of section .text:
                	sd	a1, 0x8(a2)
                	lw	a1, 0x10(s1)
                	sw	a1, 0x10(a2)
-               	mv	a1, s3
+               	ld	a1, 0x0(s3)
+               	sd	a1, -0x318(s0)
+               	ld	a1, 0x8(s3)
+               	sd	a1, -0x310(s0)
+               	ld	a1, 0x10(s3)
+               	sd	a1, -0x308(s0)
+               	ld	a1, 0x18(s3)
+               	sd	a1, -0x300(s0)
+               	ld	a1, 0x20(s3)
+               	sd	a1, -0x2f8(s0)
+               	ld	a1, 0x28(s3)
+               	sd	a1, -0x2f0(s0)
+               	ld	a1, 0x30(s3)
+               	sd	a1, -0x2e8(s0)
+               	ld	a1, 0x38(s3)
+               	sd	a1, -0x2e0(s0)
+               	ld	a1, 0x40(s3)
+               	sd	a1, -0x2d8(s0)
+               	ld	a1, 0x48(s3)
+               	sd	a1, -0x2d0(s0)
+               	ld	a1, 0x50(s3)
+               	sd	a1, -0x2c8(s0)
+               	addi	a1, s0, -0x318
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.rec_layout.checksum+0x544>
-               	ld	s1, 0x98(sp)
-               	ld	s2, 0x90(sp)
-               	ld	s3, 0x88(sp)
-               	ld	s4, 0x80(sp)
-               	ld	s5, 0x78(sp)
-               	ld	s6, 0x70(sp)
-               	ld	ra, 0xa8(sp)
-               	ld	s0, 0xa0(sp)
-               	addi	sp, sp, 0xb0
+               	jalr	ra <corpus.cases.mem.rec_layout.checksum+0x7ac>
+               	ld	s1, 0x308(sp)
+               	ld	s2, 0x300(sp)
+               	ld	s3, 0x2f8(sp)
+               	ld	s4, 0x2f0(sp)
+               	ld	s5, 0x2e8(sp)
+               	ld	s6, 0x2e0(sp)
+               	ld	ra, 0x318(sp)
+               	ld	s0, 0x310(sp)
+               	addi	sp, sp, 0x320
                	ret

--- a/test/golden/riscv64-linux/scalar/divrem_i32.dis
+++ b/test/golden/riscv64-linux/scalar/divrem_i32.dis
@@ -26,25 +26,43 @@ Disassembly of section .text:
                	li	s4, 0x0
                	li	t0, 0x10
                	blt	s4, t0, 0x60 <corpus.cases.scalar.divrem_i32.checksum+0x60>
-               	j	0xbc <corpus.cases.scalar.divrem_i32.checksum+0xbc>
+               	j	0x104 <corpus.cases.scalar.divrem_i32.checksum+0x104>
                	li	t0, 0x83
                	mulw	a0, s4, t0
                	addiw	a1, a0, 0x3
                	addw	s5, a1, s2
+               	sext.w	t0, s5
+               	bnez	t0, 0x7c <corpus.cases.scalar.divrem_i32.checksum+0x7c>
+               	ebreak
+               	addiw	t0, s5, 0x1
+               	bnez	t0, 0x94 <corpus.cases.scalar.divrem_i32.checksum+0x94>
+               	lui	t0, 0x80000
+               	subw	t0, s3, t0
+               	bnez	t0, 0x94 <corpus.cases.scalar.divrem_i32.checksum+0x94>
+               	ebreak
                	divw	s6, s3, s5
+               	sext.w	t0, s5
+               	bnez	t0, 0xa4 <corpus.cases.scalar.divrem_i32.checksum+0xa4>
+               	ebreak
+               	addiw	t0, s5, 0x1
+               	bnez	t0, 0xbc <corpus.cases.scalar.divrem_i32.checksum+0xbc>
+               	lui	t0, 0x80000
+               	subw	t0, s3, t0
+               	bnez	t0, 0xbc <corpus.cases.scalar.divrem_i32.checksum+0xbc>
+               	ebreak
                	remw	s7, s3, s5
                	mv	a0, s1
                	mv	a1, s6
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.divrem_i32.checksum+0x80>
+               	jalr	ra <corpus.cases.scalar.divrem_i32.checksum+0xc8>
                	mv	a1, s7
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.divrem_i32.checksum+0x8c>
+               	jalr	ra <corpus.cases.scalar.divrem_i32.checksum+0xd4>
                	mulw	a1, s5, s6
                	addw	a2, a1, s7
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.divrem_i32.checksum+0xa0>
+               	jalr	ra <corpus.cases.scalar.divrem_i32.checksum+0xe8>
                	subw	s3, s3, s5
                	addiw	s4, s4, 0x1
                	mv	s1, a0
@@ -58,63 +76,117 @@ Disassembly of section .text:
                	li	s3, 0x0
                	mv	s4, a1
                	li	t0, 0x8
-               	blt	s3, t0, 0xe4 <corpus.cases.scalar.divrem_i32.checksum+0xe4>
-               	j	0x140 <corpus.cases.scalar.divrem_i32.checksum+0x140>
+               	blt	s3, t0, 0x12c <corpus.cases.scalar.divrem_i32.checksum+0x12c>
+               	j	0x1d0 <corpus.cases.scalar.divrem_i32.checksum+0x1d0>
                	li	t0, 0xc5
                	mulw	a0, s3, t0
                	addiw	a1, a0, 0x5
                	addw	s5, a1, s2
+               	sext.w	t0, s5
+               	bnez	t0, 0x148 <corpus.cases.scalar.divrem_i32.checksum+0x148>
+               	ebreak
+               	addiw	t0, s5, 0x1
+               	bnez	t0, 0x160 <corpus.cases.scalar.divrem_i32.checksum+0x160>
+               	lui	t0, 0x80000
+               	subw	t0, s4, t0
+               	bnez	t0, 0x160 <corpus.cases.scalar.divrem_i32.checksum+0x160>
+               	ebreak
                	divw	s6, s4, s5
+               	sext.w	t0, s5
+               	bnez	t0, 0x170 <corpus.cases.scalar.divrem_i32.checksum+0x170>
+               	ebreak
+               	addiw	t0, s5, 0x1
+               	bnez	t0, 0x188 <corpus.cases.scalar.divrem_i32.checksum+0x188>
+               	lui	t0, 0x80000
+               	subw	t0, s4, t0
+               	bnez	t0, 0x188 <corpus.cases.scalar.divrem_i32.checksum+0x188>
+               	ebreak
                	remw	s7, s4, s5
                	mv	a0, s1
                	mv	a1, s6
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.divrem_i32.checksum+0x104>
+               	jalr	ra <corpus.cases.scalar.divrem_i32.checksum+0x194>
                	mv	a1, s7
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.divrem_i32.checksum+0x110>
+               	jalr	ra <corpus.cases.scalar.divrem_i32.checksum+0x1a0>
                	mulw	a1, s5, s6
                	addw	a2, a1, s7
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.divrem_i32.checksum+0x124>
+               	jalr	ra <corpus.cases.scalar.divrem_i32.checksum+0x1b4>
                	addw	s4, s4, s5
                	addiw	s3, s3, 0x1
                	mv	s1, a0
                	li	t0, 0x8
-               	blt	s3, t0, 0xe4 <corpus.cases.scalar.divrem_i32.checksum+0xe4>
+               	blt	s3, t0, 0x12c <corpus.cases.scalar.divrem_i32.checksum+0x12c>
                	lui	t1, 0x80000
                	addiw	t1, t1, -0x4
                	addw	s3, t1, s2
                	li	t1, 0x3
                	addw	s4, t1, s2
+               	sext.w	t0, s4
+               	bnez	t0, 0x1f0 <corpus.cases.scalar.divrem_i32.checksum+0x1f0>
+               	ebreak
+               	addiw	t0, s4, 0x1
+               	bnez	t0, 0x208 <corpus.cases.scalar.divrem_i32.checksum+0x208>
+               	lui	t0, 0x80000
+               	subw	t0, s3, t0
+               	bnez	t0, 0x208 <corpus.cases.scalar.divrem_i32.checksum+0x208>
+               	ebreak
                	divw	s2, s3, s4
+               	sext.w	t0, s4
+               	bnez	t0, 0x218 <corpus.cases.scalar.divrem_i32.checksum+0x218>
+               	ebreak
+               	addiw	t0, s4, 0x1
+               	bnez	t0, 0x230 <corpus.cases.scalar.divrem_i32.checksum+0x230>
+               	lui	t0, 0x80000
+               	subw	t0, s3, t0
+               	bnez	t0, 0x230 <corpus.cases.scalar.divrem_i32.checksum+0x230>
+               	ebreak
                	remw	s5, s3, s4
                	mv	a0, s1
                	mv	a1, s2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.divrem_i32.checksum+0x164>
+               	jalr	ra <corpus.cases.scalar.divrem_i32.checksum+0x23c>
                	mv	a1, s5
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.divrem_i32.checksum+0x170>
+               	jalr	ra <corpus.cases.scalar.divrem_i32.checksum+0x248>
                	mulw	a1, s4, s2
                	addw	a2, a1, s5
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.divrem_i32.checksum+0x184>
+               	jalr	ra <corpus.cases.scalar.divrem_i32.checksum+0x25c>
+               	sext.w	t0, s3
+               	bnez	t0, 0x270 <corpus.cases.scalar.divrem_i32.checksum+0x270>
+               	ebreak
+               	addiw	t0, s3, 0x1
+               	bnez	t0, 0x288 <corpus.cases.scalar.divrem_i32.checksum+0x288>
+               	lui	t0, 0x80000
+               	subw	t0, s4, t0
+               	bnez	t0, 0x288 <corpus.cases.scalar.divrem_i32.checksum+0x288>
+               	ebreak
                	divw	s1, s4, s3
+               	sext.w	t0, s3
+               	bnez	t0, 0x298 <corpus.cases.scalar.divrem_i32.checksum+0x298>
+               	ebreak
+               	addiw	t0, s3, 0x1
+               	bnez	t0, 0x2b0 <corpus.cases.scalar.divrem_i32.checksum+0x2b0>
+               	lui	t0, 0x80000
+               	subw	t0, s4, t0
+               	bnez	t0, 0x2b0 <corpus.cases.scalar.divrem_i32.checksum+0x2b0>
+               	ebreak
                	remw	s2, s4, s3
                	mv	a1, s1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.divrem_i32.checksum+0x198>
+               	jalr	ra <corpus.cases.scalar.divrem_i32.checksum+0x2b8>
                	mv	a1, s2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.divrem_i32.checksum+0x1a4>
+               	jalr	ra <corpus.cases.scalar.divrem_i32.checksum+0x2c4>
                	mulw	a1, s3, s1
                	addw	a2, a1, s2
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.divrem_i32.checksum+0x1b8>
+               	jalr	ra <corpus.cases.scalar.divrem_i32.checksum+0x2d8>
                	ld	s1, 0x38(sp)
                	ld	s2, 0x30(sp)
                	ld	s3, 0x28(sp)

--- a/test/golden/riscv64-linux/scalar/divrem_i64.dis
+++ b/test/golden/riscv64-linux/scalar/divrem_i64.dis
@@ -30,25 +30,43 @@ Disassembly of section .text:
                	li	s4, 0x0
                	li	t0, 0x10
                	blt	s4, t0, 0x70 <corpus.cases.scalar.divrem_i64.checksum+0x70>
-               	j	0xcc <corpus.cases.scalar.divrem_i64.checksum+0xcc>
+               	j	0x114 <corpus.cases.scalar.divrem_i64.checksum+0x114>
                	li	t0, 0x83
                	mul	a0, s4, t0
                	addi	a1, a0, 0x3
                	add	s5, a1, s1
+               	bnez	s5, 0x88 <corpus.cases.scalar.divrem_i64.checksum+0x88>
+               	ebreak
+               	addi	t0, s5, 0x1
+               	bnez	t0, 0xa4 <corpus.cases.scalar.divrem_i64.checksum+0xa4>
+               	li	t0, 0x1
+               	slli	t0, t0, 0x3f
+               	sub	t0, s3, t0
+               	bnez	t0, 0xa4 <corpus.cases.scalar.divrem_i64.checksum+0xa4>
+               	ebreak
                	div	s6, s3, s5
+               	bnez	s5, 0xb0 <corpus.cases.scalar.divrem_i64.checksum+0xb0>
+               	ebreak
+               	addi	t0, s5, 0x1
+               	bnez	t0, 0xcc <corpus.cases.scalar.divrem_i64.checksum+0xcc>
+               	li	t0, 0x1
+               	slli	t0, t0, 0x3f
+               	sub	t0, s3, t0
+               	bnez	t0, 0xcc <corpus.cases.scalar.divrem_i64.checksum+0xcc>
+               	ebreak
                	rem	s7, s3, s5
                	mv	a0, s2
                	mv	a1, s6
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.divrem_i64.checksum+0x90>
+               	jalr	ra <corpus.cases.scalar.divrem_i64.checksum+0xd8>
                	mv	a1, s7
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.divrem_i64.checksum+0x9c>
+               	jalr	ra <corpus.cases.scalar.divrem_i64.checksum+0xe4>
                	mul	a1, s5, s6
                	add	a2, a1, s7
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.divrem_i64.checksum+0xb0>
+               	jalr	ra <corpus.cases.scalar.divrem_i64.checksum+0xf8>
                	sub	s3, s3, s5
                	addi	s4, s4, 0x1
                	mv	s2, a0
@@ -67,31 +85,49 @@ Disassembly of section .text:
                	li	s3, 0x0
                	mv	s4, a1
                	li	t0, 0x8
-               	blt	s3, t0, 0x108 <corpus.cases.scalar.divrem_i64.checksum+0x108>
-               	j	0x164 <corpus.cases.scalar.divrem_i64.checksum+0x164>
+               	blt	s3, t0, 0x150 <corpus.cases.scalar.divrem_i64.checksum+0x150>
+               	j	0x1f4 <corpus.cases.scalar.divrem_i64.checksum+0x1f4>
                	li	t0, 0xc5
                	mul	a0, s3, t0
                	addi	a1, a0, 0x5
                	add	s5, a1, s1
+               	bnez	s5, 0x168 <corpus.cases.scalar.divrem_i64.checksum+0x168>
+               	ebreak
+               	addi	t0, s5, 0x1
+               	bnez	t0, 0x184 <corpus.cases.scalar.divrem_i64.checksum+0x184>
+               	li	t0, 0x1
+               	slli	t0, t0, 0x3f
+               	sub	t0, s4, t0
+               	bnez	t0, 0x184 <corpus.cases.scalar.divrem_i64.checksum+0x184>
+               	ebreak
                	div	s6, s4, s5
+               	bnez	s5, 0x190 <corpus.cases.scalar.divrem_i64.checksum+0x190>
+               	ebreak
+               	addi	t0, s5, 0x1
+               	bnez	t0, 0x1ac <corpus.cases.scalar.divrem_i64.checksum+0x1ac>
+               	li	t0, 0x1
+               	slli	t0, t0, 0x3f
+               	sub	t0, s4, t0
+               	bnez	t0, 0x1ac <corpus.cases.scalar.divrem_i64.checksum+0x1ac>
+               	ebreak
                	rem	s7, s4, s5
                	mv	a0, s2
                	mv	a1, s6
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.divrem_i64.checksum+0x128>
+               	jalr	ra <corpus.cases.scalar.divrem_i64.checksum+0x1b8>
                	mv	a1, s7
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.divrem_i64.checksum+0x134>
+               	jalr	ra <corpus.cases.scalar.divrem_i64.checksum+0x1c4>
                	mul	a1, s5, s6
                	add	a2, a1, s7
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.divrem_i64.checksum+0x148>
+               	jalr	ra <corpus.cases.scalar.divrem_i64.checksum+0x1d8>
                	add	s4, s4, s5
                	addi	s3, s3, 0x1
                	mv	s2, a0
                	li	t0, 0x8
-               	blt	s3, t0, 0x108 <corpus.cases.scalar.divrem_i64.checksum+0x108>
+               	blt	s3, t0, 0x150 <corpus.cases.scalar.divrem_i64.checksum+0x150>
                	lui	t1, 0xf8000
                	slli	t1, t1, 0xc
                	slli	t1, t1, 0xc
@@ -100,33 +136,69 @@ Disassembly of section .text:
                	add	s3, t1, s1
                	li	t1, 0x3
                	add	s4, t1, s1
+               	bnez	s4, 0x21c <corpus.cases.scalar.divrem_i64.checksum+0x21c>
+               	ebreak
+               	addi	t0, s4, 0x1
+               	bnez	t0, 0x238 <corpus.cases.scalar.divrem_i64.checksum+0x238>
+               	li	t0, 0x1
+               	slli	t0, t0, 0x3f
+               	sub	t0, s3, t0
+               	bnez	t0, 0x238 <corpus.cases.scalar.divrem_i64.checksum+0x238>
+               	ebreak
                	div	s1, s3, s4
+               	bnez	s4, 0x244 <corpus.cases.scalar.divrem_i64.checksum+0x244>
+               	ebreak
+               	addi	t0, s4, 0x1
+               	bnez	t0, 0x260 <corpus.cases.scalar.divrem_i64.checksum+0x260>
+               	li	t0, 0x1
+               	slli	t0, t0, 0x3f
+               	sub	t0, s3, t0
+               	bnez	t0, 0x260 <corpus.cases.scalar.divrem_i64.checksum+0x260>
+               	ebreak
                	rem	s5, s3, s4
                	mv	a0, s2
                	mv	a1, s1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.divrem_i64.checksum+0x194>
+               	jalr	ra <corpus.cases.scalar.divrem_i64.checksum+0x26c>
                	mv	a1, s5
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.divrem_i64.checksum+0x1a0>
+               	jalr	ra <corpus.cases.scalar.divrem_i64.checksum+0x278>
                	mul	a1, s4, s1
                	add	a2, a1, s5
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.divrem_i64.checksum+0x1b4>
+               	jalr	ra <corpus.cases.scalar.divrem_i64.checksum+0x28c>
+               	bnez	s3, 0x29c <corpus.cases.scalar.divrem_i64.checksum+0x29c>
+               	ebreak
+               	addi	t0, s3, 0x1
+               	bnez	t0, 0x2b8 <corpus.cases.scalar.divrem_i64.checksum+0x2b8>
+               	li	t0, 0x1
+               	slli	t0, t0, 0x3f
+               	sub	t0, s4, t0
+               	bnez	t0, 0x2b8 <corpus.cases.scalar.divrem_i64.checksum+0x2b8>
+               	ebreak
                	div	s1, s4, s3
+               	bnez	s3, 0x2c4 <corpus.cases.scalar.divrem_i64.checksum+0x2c4>
+               	ebreak
+               	addi	t0, s3, 0x1
+               	bnez	t0, 0x2e0 <corpus.cases.scalar.divrem_i64.checksum+0x2e0>
+               	li	t0, 0x1
+               	slli	t0, t0, 0x3f
+               	sub	t0, s4, t0
+               	bnez	t0, 0x2e0 <corpus.cases.scalar.divrem_i64.checksum+0x2e0>
+               	ebreak
                	rem	s2, s4, s3
                	mv	a1, s1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.divrem_i64.checksum+0x1c8>
+               	jalr	ra <corpus.cases.scalar.divrem_i64.checksum+0x2e8>
                	mv	a1, s2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.divrem_i64.checksum+0x1d4>
+               	jalr	ra <corpus.cases.scalar.divrem_i64.checksum+0x2f4>
                	mul	a1, s3, s1
                	add	a2, a1, s2
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.divrem_i64.checksum+0x1e8>
+               	jalr	ra <corpus.cases.scalar.divrem_i64.checksum+0x308>
                	ld	s1, 0x38(sp)
                	ld	s2, 0x30(sp)
                	ld	s3, 0x28(sp)

--- a/test/golden/riscv64-linux/scalar/divrem_u32.dis
+++ b/test/golden/riscv64-linux/scalar/divrem_u32.dis
@@ -25,25 +25,31 @@ Disassembly of section .text:
                	li	s4, 0x0
                	li	t0, 0x10
                	bltu	s4, t0, 0x5c <corpus.cases.scalar.divrem_u32.checksum+0x5c>
-               	j	0xb8 <corpus.cases.scalar.divrem_u32.checksum+0xb8>
+               	j	0xd0 <corpus.cases.scalar.divrem_u32.checksum+0xd0>
                	li	t0, 0x83
                	mulw	a0, s4, t0
                	addiw	a1, a0, 0x3
                	addw	s5, a1, s2
+               	sext.w	t0, s5
+               	bnez	t0, 0x78 <corpus.cases.scalar.divrem_u32.checksum+0x78>
+               	ebreak
                	divuw	s6, s3, s5
+               	sext.w	t0, s5
+               	bnez	t0, 0x88 <corpus.cases.scalar.divrem_u32.checksum+0x88>
+               	ebreak
                	remuw	s7, s3, s5
                	mv	a0, s1
                	mv	a1, s6
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.divrem_u32.checksum+0x7c>
+               	jalr	ra <corpus.cases.scalar.divrem_u32.checksum+0x94>
                	mv	a1, s7
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.divrem_u32.checksum+0x88>
+               	jalr	ra <corpus.cases.scalar.divrem_u32.checksum+0xa0>
                	mulw	a1, s5, s6
                	addw	a2, a1, s7
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.divrem_u32.checksum+0x9c>
+               	jalr	ra <corpus.cases.scalar.divrem_u32.checksum+0xb4>
                	subw	s3, s3, s5
                	addiw	s4, s4, 0x1
                	mv	s1, a0
@@ -53,33 +59,45 @@ Disassembly of section .text:
                	addw	s3, t1, s2
                	li	t1, 0x3
                	addw	s4, t1, s2
+               	sext.w	t0, s4
+               	bnez	t0, 0xec <corpus.cases.scalar.divrem_u32.checksum+0xec>
+               	ebreak
                	divuw	s2, s3, s4
+               	sext.w	t0, s4
+               	bnez	t0, 0xfc <corpus.cases.scalar.divrem_u32.checksum+0xfc>
+               	ebreak
                	remuw	s5, s3, s4
                	mv	a0, s1
                	mv	a1, s2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.divrem_u32.checksum+0xd8>
+               	jalr	ra <corpus.cases.scalar.divrem_u32.checksum+0x108>
                	mv	a1, s5
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.divrem_u32.checksum+0xe4>
+               	jalr	ra <corpus.cases.scalar.divrem_u32.checksum+0x114>
                	mulw	a1, s4, s2
                	addw	a2, a1, s5
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.divrem_u32.checksum+0xf8>
+               	jalr	ra <corpus.cases.scalar.divrem_u32.checksum+0x128>
+               	sext.w	t0, s3
+               	bnez	t0, 0x13c <corpus.cases.scalar.divrem_u32.checksum+0x13c>
+               	ebreak
                	divuw	s1, s4, s3
+               	sext.w	t0, s3
+               	bnez	t0, 0x14c <corpus.cases.scalar.divrem_u32.checksum+0x14c>
+               	ebreak
                	remuw	s2, s4, s3
                	mv	a1, s1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.divrem_u32.checksum+0x10c>
+               	jalr	ra <corpus.cases.scalar.divrem_u32.checksum+0x154>
                	mv	a1, s2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.divrem_u32.checksum+0x118>
+               	jalr	ra <corpus.cases.scalar.divrem_u32.checksum+0x160>
                	mulw	a1, s3, s1
                	addw	a2, a1, s2
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.divrem_u32.checksum+0x12c>
+               	jalr	ra <corpus.cases.scalar.divrem_u32.checksum+0x174>
                	ld	s1, 0x38(sp)
                	ld	s2, 0x30(sp)
                	ld	s3, 0x28(sp)

--- a/test/golden/riscv64-linux/scalar/divrem_u64.dis
+++ b/test/golden/riscv64-linux/scalar/divrem_u64.dis
@@ -24,25 +24,29 @@ Disassembly of section .text:
                	li	s4, 0x0
                	li	t0, 0x10
                	bltu	s4, t0, 0x58 <corpus.cases.scalar.divrem_u64.checksum+0x58>
-               	j	0xb4 <corpus.cases.scalar.divrem_u64.checksum+0xb4>
+               	j	0xc4 <corpus.cases.scalar.divrem_u64.checksum+0xc4>
                	li	t0, 0x83
                	mul	a0, s4, t0
                	addi	a1, a0, 0x3
                	add	s5, a1, s1
+               	bnez	s5, 0x70 <corpus.cases.scalar.divrem_u64.checksum+0x70>
+               	ebreak
                	divu	s6, s3, s5
+               	bnez	s5, 0x7c <corpus.cases.scalar.divrem_u64.checksum+0x7c>
+               	ebreak
                	remu	s7, s3, s5
                	mv	a0, s2
                	mv	a1, s6
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.divrem_u64.checksum+0x78>
+               	jalr	ra <corpus.cases.scalar.divrem_u64.checksum+0x88>
                	mv	a1, s7
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.divrem_u64.checksum+0x84>
+               	jalr	ra <corpus.cases.scalar.divrem_u64.checksum+0x94>
                	mul	a1, s5, s6
                	add	a2, a1, s7
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.divrem_u64.checksum+0x98>
+               	jalr	ra <corpus.cases.scalar.divrem_u64.checksum+0xa8>
                	sub	s3, s3, s5
                	addi	s4, s4, 0x1
                	mv	s2, a0
@@ -52,33 +56,41 @@ Disassembly of section .text:
                	add	s3, t1, s1
                	li	t1, 0x3
                	add	s4, t1, s1
+               	bnez	s4, 0xdc <corpus.cases.scalar.divrem_u64.checksum+0xdc>
+               	ebreak
                	divu	s1, s3, s4
+               	bnez	s4, 0xe8 <corpus.cases.scalar.divrem_u64.checksum+0xe8>
+               	ebreak
                	remu	s5, s3, s4
                	mv	a0, s2
                	mv	a1, s1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.divrem_u64.checksum+0xd4>
+               	jalr	ra <corpus.cases.scalar.divrem_u64.checksum+0xf4>
                	mv	a1, s5
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.divrem_u64.checksum+0xe0>
+               	jalr	ra <corpus.cases.scalar.divrem_u64.checksum+0x100>
                	mul	a1, s4, s1
                	add	a2, a1, s5
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.divrem_u64.checksum+0xf4>
+               	jalr	ra <corpus.cases.scalar.divrem_u64.checksum+0x114>
+               	bnez	s3, 0x124 <corpus.cases.scalar.divrem_u64.checksum+0x124>
+               	ebreak
                	divu	s1, s4, s3
+               	bnez	s3, 0x130 <corpus.cases.scalar.divrem_u64.checksum+0x130>
+               	ebreak
                	remu	s2, s4, s3
                	mv	a1, s1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.divrem_u64.checksum+0x108>
+               	jalr	ra <corpus.cases.scalar.divrem_u64.checksum+0x138>
                	mv	a1, s2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.divrem_u64.checksum+0x114>
+               	jalr	ra <corpus.cases.scalar.divrem_u64.checksum+0x144>
                	mul	a1, s3, s1
                	add	a2, a1, s2
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.divrem_u64.checksum+0x128>
+               	jalr	ra <corpus.cases.scalar.divrem_u64.checksum+0x158>
                	ld	s1, 0x38(sp)
                	ld	s2, 0x30(sp)
                	ld	s3, 0x28(sp)

--- a/test/golden/riscv64-linux/vec/vec_cmp_select.dis
+++ b/test/golden/riscv64-linux/vec/vec_cmp_select.dis
@@ -341,70 +341,70 @@ Disassembly of section .text:
 
 <corpus.cases.vec.vec_cmp_select.checksum>:
                	lui	t0, 0x2
-               	addiw	t0, t0, -0x650
+               	addiw	t0, t0, -0x7e0
                	sub	sp, sp, t0
                	lui	t1, 0x2
-               	addiw	t1, t1, -0x658
+               	addiw	t1, t1, -0x7e8
                	add	t1, sp, t1
                	sd	ra, 0x0(t1)
                	lui	t1, 0x2
-               	addiw	t1, t1, -0x660
+               	addiw	t1, t1, -0x7f0
                	add	t1, sp, t1
                	sd	s0, 0x0(t1)
                	lui	t0, 0x2
-               	addiw	t0, t0, -0x650
+               	addiw	t0, t0, -0x7e0
                	add	s0, sp, t0
                	lui	t1, 0x2
-               	addiw	t1, t1, -0x668
+               	addiw	t1, t1, -0x7f8
                	add	t1, sp, t1
                	sd	s1, 0x0(t1)
                	lui	t1, 0x2
-               	addiw	t1, t1, -0x670
+               	addiw	t1, t1, -0x800
                	add	t1, sp, t1
                	sd	s2, 0x0(t1)
-               	lui	t1, 0x2
-               	addiw	t1, t1, -0x678
+               	lui	t1, 0x1
+               	addiw	t1, t1, 0x7f8
                	add	t1, sp, t1
                	sd	s3, 0x0(t1)
-               	lui	t1, 0x2
-               	addiw	t1, t1, -0x680
+               	lui	t1, 0x1
+               	addiw	t1, t1, 0x7f0
                	add	t1, sp, t1
                	sd	s4, 0x0(t1)
-               	lui	t1, 0x2
-               	addiw	t1, t1, -0x688
+               	lui	t1, 0x1
+               	addiw	t1, t1, 0x7e8
                	add	t1, sp, t1
                	sd	s5, 0x0(t1)
-               	lui	t1, 0x2
-               	addiw	t1, t1, -0x690
+               	lui	t1, 0x1
+               	addiw	t1, t1, 0x7e0
                	add	t1, sp, t1
                	sd	s6, 0x0(t1)
-               	lui	t1, 0x2
-               	addiw	t1, t1, -0x698
+               	lui	t1, 0x1
+               	addiw	t1, t1, 0x7d8
                	add	t1, sp, t1
                	sd	s7, 0x0(t1)
-               	lui	t1, 0x2
-               	addiw	t1, t1, -0x6a0
+               	lui	t1, 0x1
+               	addiw	t1, t1, 0x7d0
                	add	t1, sp, t1
                	sd	s8, 0x0(t1)
-               	lui	t1, 0x2
-               	addiw	t1, t1, -0x6a8
+               	lui	t1, 0x1
+               	addiw	t1, t1, 0x7c8
                	add	t1, sp, t1
                	sd	s9, 0x0(t1)
-               	lui	t1, 0x2
-               	addiw	t1, t1, -0x6b0
+               	lui	t1, 0x1
+               	addiw	t1, t1, 0x7c0
                	add	t1, sp, t1
                	sd	s10, 0x0(t1)
-               	lui	t1, 0x2
-               	addiw	t1, t1, -0x6b8
+               	lui	t1, 0x1
+               	addiw	t1, t1, 0x7b8
                	add	t1, sp, t1
                	sd	s11, 0x0(t1)
-               	lui	t1, 0x2
-               	addiw	t1, t1, -0x6c0
+               	lui	t1, 0x1
+               	addiw	t1, t1, 0x7b0
                	add	t1, sp, t1
                	fsd	fs0, 0x0(t1)
                	mv	t2, a0
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x738
+               	addiw	t1, t1, -0x5b8
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	s2, s0, -0x80
@@ -436,51 +436,51 @@ Disassembly of section .text:
                	addi	a1, s0, -0x220
                	addi	a1, s0, -0x230
                	addi	t2, s0, -0x240
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x690
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x7e8
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	a1, s0, -0x250
                	addi	a1, s0, -0x260
                	addi	t2, s0, -0x270
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x688
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x7f0
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	a1, s0, -0x280
                	addi	t2, s0, -0x290
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x680
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x7f8
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	a1, s0, -0x2a0
                	addi	t2, s0, -0x2b0
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x678
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x800
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	t2, s0, -0x2c0
                	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x670
+               	addiw	t1, t1, 0x7f8
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	a1, s0, -0x2d0
                	addi	a1, s0, -0x2e0
                	addi	t2, s0, -0x2f0
                	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x668
+               	addiw	t1, t1, 0x7f0
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	a1, s0, -0x300
                	addi	t2, s0, -0x310
                	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x660
+               	addiw	t1, t1, 0x7e8
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	a1, s0, -0x320
                	addi	t2, s0, -0x330
                	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x658
+               	addiw	t1, t1, 0x7e0
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	s1, s0, -0x340
@@ -489,113 +489,113 @@ Disassembly of section .text:
                	addi	a1, s0, -0x370
                	addi	t2, s0, -0x380
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x740
+               	addiw	t1, t1, -0x5c0
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	t2, s0, -0x390
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x748
+               	addiw	t1, t1, -0x5c8
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	a1, s0, -0x3a0
                	addi	t2, s0, -0x3b0
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x750
+               	addiw	t1, t1, -0x5d0
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	a1, s0, -0x3c0
                	addi	a1, s0, -0x3d0
                	addi	t2, s0, -0x3e0
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x758
+               	addiw	t1, t1, -0x5d8
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	t2, s0, -0x3f0
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x760
+               	addiw	t1, t1, -0x5e0
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	t2, s0, -0x400
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x768
+               	addiw	t1, t1, -0x5e8
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	t2, s0, -0x410
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x770
+               	addiw	t1, t1, -0x5f0
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	a1, s0, -0x420
                	addi	a1, s0, -0x430
                	addi	t2, s0, -0x440
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x778
+               	addiw	t1, t1, -0x5f8
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	a1, s0, -0x450
                	addi	a1, s0, -0x460
                	addi	t2, s0, -0x470
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x780
+               	addiw	t1, t1, -0x600
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	a1, s0, -0x480
                	addi	a1, s0, -0x490
                	addi	t2, s0, -0x4a0
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x788
+               	addiw	t1, t1, -0x608
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	a1, s0, -0x4b0
                	addi	a1, s0, -0x4c0
                	addi	t2, s0, -0x4d0
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x790
+               	addiw	t1, t1, -0x610
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	a1, s0, -0x4e0
                	addi	a1, s0, -0x4f0
                	addi	t2, s0, -0x500
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x798
+               	addiw	t1, t1, -0x618
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	a1, s0, -0x510
                	addi	a1, s0, -0x520
                	addi	t2, s0, -0x530
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7a0
+               	addiw	t1, t1, -0x620
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	a1, s0, -0x540
                	addi	a1, s0, -0x550
                	addi	t2, s0, -0x560
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7a8
+               	addiw	t1, t1, -0x628
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	a1, s0, -0x570
                	addi	a1, s0, -0x580
                	addi	t2, s0, -0x590
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7b0
+               	addiw	t1, t1, -0x630
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	t2, s0, -0x5a0
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7b8
+               	addiw	t1, t1, -0x638
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	t2, s0, -0x5b0
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7c0
+               	addiw	t1, t1, -0x640
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	a1, s0, -0x5c0
                	addi	a1, s0, -0x5d0
                	addi	t2, s0, -0x5e0
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7c8
+               	addiw	t1, t1, -0x648
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	a1, s0, -0x5f0
@@ -604,80 +604,76 @@ Disassembly of section .text:
                	addi	a1, s0, -0x620
                	addi	t2, s0, -0x630
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7d0
+               	addiw	t1, t1, -0x650
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	a1, s0, -0x640
                	addi	a1, s0, -0x650
                	addi	t2, s0, -0x660
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7d8
+               	addiw	t1, t1, -0x658
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	a1, s0, -0x670
                	addi	a1, s0, -0x680
                	addi	t2, s0, -0x690
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7e0
+               	addiw	t1, t1, -0x660
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	a1, s0, -0x6a0
                	addi	a1, s0, -0x6b0
                	addi	t2, s0, -0x6c0
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7e8
+               	addiw	t1, t1, -0x668
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	a1, s0, -0x6d0
                	addi	a1, s0, -0x6e0
                	addi	t2, s0, -0x6f0
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7f0
+               	addiw	t1, t1, -0x670
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	a1, s0, -0x700
                	addi	a1, s0, -0x710
                	addi	t2, s0, -0x720
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7f8
+               	addiw	t1, t1, -0x678
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	a1, s0, -0x730
                	addi	a1, s0, -0x740
-               	addi	t2, s0, -0x750
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x800
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
+               	addi	a1, s0, -0x750
                	addi	a1, s0, -0x760
                	addi	a1, s0, -0x770
                	addi	t2, s0, -0x780
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x7f8
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x680
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	a1, s0, -0x790
                	addi	t2, s0, -0x7a0
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x7f0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x688
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	a1, s0, -0x7b0
                	addi	t2, s0, -0x7c0
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x7e8
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x690
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	t2, s0, -0x7d0
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x7e0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x698
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	a1, s0, -0x7e0
                	addi	a1, s0, -0x7f0
                	addi	t2, s0, -0x800
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x7d8
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x6a0
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	lui	t0, 0xfffff
@@ -692,15 +688,15 @@ Disassembly of section .text:
                	lui	t0, 0xfffff
                	addiw	t0, t0, 0x7c0
                	add	t2, s0, t0
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x7d0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x6a8
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	lui	t0, 0xfffff
                	addiw	t0, t0, 0x7b0
                	add	t2, s0, t0
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x7c8
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x6b0
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	lui	t0, 0xfffff
@@ -718,22 +714,22 @@ Disassembly of section .text:
                	lui	t0, 0xfffff
                	addiw	t0, t0, 0x760
                	add	t2, s0, t0
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x7c0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x6b8
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	lui	t0, 0xfffff
                	addiw	t0, t0, 0x750
                	add	t2, s0, t0
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x7b8
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x6c0
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	lui	t0, 0xfffff
                	addiw	t0, t0, 0x740
                	add	t2, s0, t0
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x7b0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x6c8
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	lui	t0, 0xfffff
@@ -745,8 +741,8 @@ Disassembly of section .text:
                	lui	t0, 0xfffff
                	addiw	t0, t0, 0x710
                	add	t2, s0, t0
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x7a8
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x6d0
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	lui	t0, 0xfffff
@@ -758,8 +754,8 @@ Disassembly of section .text:
                	lui	t0, 0xfffff
                	addiw	t0, t0, 0x6e0
                	add	t2, s0, t0
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x7a0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x6d8
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	lui	t0, 0xfffff
@@ -771,8 +767,8 @@ Disassembly of section .text:
                	lui	t0, 0xfffff
                	addiw	t0, t0, 0x6b0
                	add	t2, s0, t0
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x798
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x6e0
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	lui	t0, 0xfffff
@@ -784,8 +780,8 @@ Disassembly of section .text:
                	lui	t0, 0xfffff
                	addiw	t0, t0, 0x680
                	add	t2, s0, t0
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x790
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x6e8
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	lui	t0, 0xfffff
@@ -797,22 +793,22 @@ Disassembly of section .text:
                	lui	t0, 0xfffff
                	addiw	t0, t0, 0x650
                	add	t2, s0, t0
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x788
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x6f0
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	lui	t0, 0xfffff
                	addiw	t0, t0, 0x640
                	add	t2, s0, t0
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x780
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x6f8
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	lui	t0, 0xfffff
                	addiw	t0, t0, 0x630
                	add	t2, s0, t0
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x778
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x700
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	lui	t0, 0xfffff
@@ -824,8 +820,8 @@ Disassembly of section .text:
                	lui	t0, 0xfffff
                	addiw	t0, t0, 0x600
                	add	t2, s0, t0
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x770
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x708
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	lui	t0, 0xfffff
@@ -837,8 +833,8 @@ Disassembly of section .text:
                	lui	t0, 0xfffff
                	addiw	t0, t0, 0x5d0
                	add	t2, s0, t0
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x768
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x710
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	lui	t0, 0xfffff
@@ -850,8 +846,8 @@ Disassembly of section .text:
                	lui	t0, 0xfffff
                	addiw	t0, t0, 0x5a0
                	add	t2, s0, t0
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x760
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x718
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	lui	t0, 0xfffff
@@ -863,8 +859,8 @@ Disassembly of section .text:
                	lui	t0, 0xfffff
                	addiw	t0, t0, 0x570
                	add	t2, s0, t0
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x758
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x720
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	lui	t0, 0xfffff
@@ -876,8 +872,8 @@ Disassembly of section .text:
                	lui	t0, 0xfffff
                	addiw	t0, t0, 0x540
                	add	t2, s0, t0
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x750
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x728
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	lui	t0, 0xfffff
@@ -889,8 +885,8 @@ Disassembly of section .text:
                	lui	t0, 0xfffff
                	addiw	t0, t0, 0x510
                	add	t2, s0, t0
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x748
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x730
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	lui	t0, 0xfffff
@@ -902,8 +898,8 @@ Disassembly of section .text:
                	lui	t0, 0xfffff
                	addiw	t0, t0, 0x4e0
                	add	t2, s0, t0
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x740
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x738
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	lui	t0, 0xfffff
@@ -912,8 +908,8 @@ Disassembly of section .text:
                	lui	t0, 0xfffff
                	addiw	t0, t0, 0x4c0
                	add	t2, s0, t0
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x738
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x740
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	lui	t0, 0xfffff
@@ -922,29 +918,29 @@ Disassembly of section .text:
                	lui	t0, 0xfffff
                	addiw	t0, t0, 0x4a0
                	add	t2, s0, t0
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x730
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x748
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	lui	t0, 0xfffff
                	addiw	t0, t0, 0x490
                	add	t2, s0, t0
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x728
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x750
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	lui	t0, 0xfffff
                	addiw	t0, t0, 0x480
                	add	t2, s0, t0
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x720
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x758
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	lui	t0, 0xfffff
                	addiw	t0, t0, 0x470
                	add	t2, s0, t0
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x718
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x760
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	lui	t0, 0xfffff
@@ -956,8 +952,8 @@ Disassembly of section .text:
                	lui	t0, 0xfffff
                	addiw	t0, t0, 0x440
                	add	t2, s0, t0
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x710
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x768
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	lui	t0, 0xfffff
@@ -969,8 +965,8 @@ Disassembly of section .text:
                	lui	t0, 0xfffff
                	addiw	t0, t0, 0x410
                	add	t2, s0, t0
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x708
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x770
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	lui	t0, 0xfffff
@@ -982,8 +978,8 @@ Disassembly of section .text:
                	lui	t0, 0xfffff
                	addiw	t0, t0, 0x3e0
                	add	t2, s0, t0
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x700
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x778
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	lui	t0, 0xfffff
@@ -995,8 +991,8 @@ Disassembly of section .text:
                	lui	t0, 0xfffff
                	addiw	t0, t0, 0x3b0
                	add	t2, s0, t0
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x6f8
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x780
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	lui	t0, 0xfffff
@@ -1008,8 +1004,8 @@ Disassembly of section .text:
                	lui	t0, 0xfffff
                	addiw	t0, t0, 0x380
                	add	t2, s0, t0
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x6f0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x788
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	lui	t0, 0xfffff
@@ -1030,8 +1026,8 @@ Disassembly of section .text:
                	lui	t0, 0xfffff
                	addiw	t0, t0, 0x320
                	add	t2, s0, t0
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x6e8
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x790
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	lui	t0, 0xfffff
@@ -1040,8 +1036,8 @@ Disassembly of section .text:
                	lui	t0, 0xfffff
                	addiw	t0, t0, 0x300
                	add	t2, s0, t0
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x6e0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x798
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	lui	t0, 0xfffff
@@ -1050,15 +1046,15 @@ Disassembly of section .text:
                	lui	t0, 0xfffff
                	addiw	t0, t0, 0x2e0
                	add	t2, s0, t0
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x6d8
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x7a0
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	lui	t0, 0xfffff
                	addiw	t0, t0, 0x2d0
                	add	t2, s0, t0
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x6d0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x7a8
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	lui	t0, 0xfffff
@@ -1432,151 +1428,79 @@ Disassembly of section .text:
                	lui	t0, 0xfffff
                	addiw	t0, t0, -0x4f0
                	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x500
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x510
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x520
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x530
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x540
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x550
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x560
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x570
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x580
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x590
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x5a0
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x5b0
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x5c0
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x5d0
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x5e0
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x5f0
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x600
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x610
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x620
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x630
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x640
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x650
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x660
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x670
-               	add	a1, s0, t0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x1230>
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x1100>
                	mv	t2, a0
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x6b0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x7c8
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x6b0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x7c8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x738
+               	addiw	t1, t1, -0x5b8
                	add	t1, s0, t1
                	ld	t3, 0x0(t1)
                	sext.w	t2, t3
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x6c8
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x7b0
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x738
+               	addiw	t1, t1, -0x5b8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	fcvt.s.lu	fs0, t2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x738
+               	addiw	t1, t1, -0x5b8
                	add	t1, s0, t1
                	ld	t3, 0x0(t1)
                	sext.w	t2, t3
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x6c0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x7b8
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x738
+               	addiw	t1, t1, -0x5b8
                	add	t1, s0, t1
                	ld	t3, 0x0(t1)
                	sext.w	t2, t3
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x6b8
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x7c0
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x680
+               	addiw	t0, t0, -0x500
                	add	t2, s0, t0
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x6a8
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x7d0
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x6a8
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x7d0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a0, t2
                	li	t0, 0xa
                	sw	t0, 0x0(a0)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x6a8
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x7d0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a0, t2, 0x4
                	li	t0, 0x14
                	sw	t0, 0x0(a0)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x6a8
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x7d0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a0, t2, 0x8
                	li	t0, 0x1e
                	sw	t0, 0x0(a0)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x6a8
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x7d0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a0, t2, 0xc
@@ -1584,32 +1508,32 @@ Disassembly of section .text:
                	slli	t0, t0, 0xc
                	addi	t0, t0, -0x1
                	sw	t0, 0x0(a0)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x6a8
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x7d0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a0, t2
                	lw	a1, 0x0(a0)
                	mv	a0, s2
                	sw	a1, 0x0(a0)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x6a8
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x7d0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a0, t2, 0x4
                	lw	a1, 0x0(a0)
                	addi	a0, s2, 0x4
                	sw	a1, 0x0(a0)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x6a8
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x7d0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a0, t2, 0x8
                	lw	a1, 0x0(a0)
                	addi	a0, s2, 0x8
                	sw	a1, 0x0(a0)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x6a8
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x7d0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a0, t2, 0xc
@@ -1617,66 +1541,66 @@ Disassembly of section .text:
                	addi	a0, s2, 0xc
                	sw	a1, 0x0(a0)
                	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x690
+               	addiw	t0, t0, -0x510
                	add	t2, s0, t0
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x6a0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x7d8
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x6a0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x7d8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	li	t0, 0x14
                	sw	t0, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x6a0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x7d8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	li	t0, 0x14
                	sw	t0, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x6a0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x7d8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	li	t0, 0xa
                	sw	t0, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x6a0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x7d8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	li	t0, 0x1
                	sw	t0, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x6a0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x7d8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	lw	a0, 0x0(a1)
                	mv	a1, s3
                	sw	a0, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x6a0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x7d8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a0, t2, 0x4
                	lw	a1, 0x0(a0)
                	addi	a0, s3, 0x4
                	sw	a1, 0x0(a0)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x6a0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x7d8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a0, t2, 0x8
                	lw	a1, 0x0(a0)
                	addi	a0, s3, 0x8
                	sw	a1, 0x0(a0)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x6a0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x7d8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a0, t2, 0xc
@@ -1685,13 +1609,13 @@ Disassembly of section .text:
                	sw	a1, 0x0(a0)
                	mv	a0, s2
                	lw	a1, 0x0(a0)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x6c8
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x7b0
                	add	t1, s0, t1
                	ld	t3, 0x0(t1)
                	addw	t2, a1, t3
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x698
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x7e0
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	mv	a1, s2
@@ -1711,15 +1635,15 @@ Disassembly of section .text:
                	addi	a0, s4, 0xc
                	sw	a1, 0x0(a0)
                	mv	a0, s4
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x698
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x7e0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	sw	t2, 0x0(a0)
                	addi	a0, s3, 0xc
                	lw	a1, 0x0(a0)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x6c8
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x7b0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addw	a0, a1, t2
@@ -1783,28 +1707,28 @@ Disassembly of section .text:
                	sw	a0, 0x0(a1)
                	mv	a0, s6
                	lw	a1, 0x0(a0)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x6b0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x7c8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a0, t2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x16a0>
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x1570>
                	addi	a1, s6, 0x4
                	lw	s2, 0x0(a1)
                	mv	a1, s2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x16b4>
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x1584>
                	addi	a1, s6, 0x8
                	lw	s2, 0x0(a1)
                	mv	a1, s2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x16c8>
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x1598>
                	addi	a1, s6, 0xc
                	lw	s2, 0x0(a1)
                	mv	a1, s2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x16dc>
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x15ac>
                	mv	a1, s5
                	lw	s2, 0x0(a1)
                	mv	a1, s4
@@ -1849,22 +1773,22 @@ Disassembly of section .text:
                	lw	s2, 0x0(a1)
                	mv	a1, s2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x1790>
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x1660>
                	addi	a1, s7, 0x4
                	lw	s2, 0x0(a1)
                	mv	a1, s2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x17a4>
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x1674>
                	addi	a1, s7, 0x8
                	lw	s2, 0x0(a1)
                	mv	a1, s2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x17b8>
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x1688>
                	addi	a1, s7, 0xc
                	lw	s2, 0x0(a1)
                	mv	a1, s2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x17cc>
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x169c>
                	mv	a1, s4
                	lw	s2, 0x0(a1)
                	mv	a1, s5
@@ -1913,22 +1837,22 @@ Disassembly of section .text:
                	lw	s2, 0x0(a1)
                	mv	a1, s2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x1890>
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x1760>
                	addi	a1, s8, 0x4
                	lw	s2, 0x0(a1)
                	mv	a1, s2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x18a4>
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x1774>
                	addi	a1, s8, 0x8
                	lw	s2, 0x0(a1)
                	mv	a1, s2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x18b8>
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x1788>
                	addi	a1, s8, 0xc
                	lw	s2, 0x0(a1)
                	mv	a1, s2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x18cc>
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x179c>
                	mv	a1, s4
                	lw	s2, 0x0(a1)
                	mv	a1, s5
@@ -1977,22 +1901,22 @@ Disassembly of section .text:
                	lw	s2, 0x0(a1)
                	mv	a1, s2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x1990>
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x1860>
                	addi	a1, s9, 0x4
                	lw	s2, 0x0(a1)
                	mv	a1, s2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x19a4>
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x1874>
                	addi	a1, s9, 0x8
                	lw	s2, 0x0(a1)
                	mv	a1, s2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x19b8>
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x1888>
                	addi	a1, s9, 0xc
                	lw	s2, 0x0(a1)
                	mv	a1, s2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x19cc>
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x189c>
                	mv	a1, s4
                	lw	s2, 0x0(a1)
                	mv	a1, s5
@@ -2041,22 +1965,22 @@ Disassembly of section .text:
                	lw	s2, 0x0(a1)
                	mv	a1, s2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x1a90>
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x1960>
                	addi	a1, s10, 0x4
                	lw	s2, 0x0(a1)
                	mv	a1, s2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x1aa4>
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x1974>
                	addi	a1, s10, 0x8
                	lw	s2, 0x0(a1)
                	mv	a1, s2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x1ab8>
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x1988>
                	addi	a1, s10, 0xc
                	lw	s2, 0x0(a1)
                	mv	a1, s2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x1acc>
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x199c>
                	mv	a1, s5
                	lw	s2, 0x0(a1)
                	mv	a1, s4
@@ -2105,22 +2029,22 @@ Disassembly of section .text:
                	lw	s2, 0x0(a1)
                	mv	a1, s2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x1b90>
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x1a60>
                	addi	a1, s11, 0x4
                	lw	s2, 0x0(a1)
                	mv	a1, s2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x1ba4>
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x1a74>
                	addi	a1, s11, 0x8
                	lw	s2, 0x0(a1)
                	mv	a1, s2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x1bb8>
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x1a88>
                	addi	a1, s11, 0xc
                	lw	s2, 0x0(a1)
                	mv	a1, s2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x1bcc>
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x1a9c>
                	mv	a1, s4
                	lw	s2, 0x0(a1)
                	mv	a1, s5
@@ -2129,8 +2053,8 @@ Disassembly of section .text:
                	zext.b	s2, a1
                	li	t1, 0x0
                	subw	a1, t1, s2
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x690
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x7e8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	s2, t2
@@ -2143,8 +2067,8 @@ Disassembly of section .text:
                	zext.b	s2, a1
                	li	t1, 0x0
                	subw	a1, t1, s2
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x690
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x7e8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	s2, t2, 0x4
@@ -2157,8 +2081,8 @@ Disassembly of section .text:
                	zext.b	s2, a1
                	li	t1, 0x0
                	subw	a1, t1, s2
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x690
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x7e8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	s2, t2, 0x8
@@ -2171,14 +2095,14 @@ Disassembly of section .text:
                	zext.b	s2, a1
                	li	t1, 0x0
                	subw	a1, t1, s2
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x690
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x7e8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	s2, t2, 0xc
                	sw	a1, 0x0(s2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x690
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x7e8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
@@ -2186,14 +2110,14 @@ Disassembly of section .text:
                	mv	a1, s4
                	lw	s3, 0x0(a1)
                	and	a1, s2, s3
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x688
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x7f0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	s2, t2
                	sw	a1, 0x0(s2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x690
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x7e8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
@@ -2201,14 +2125,14 @@ Disassembly of section .text:
                	addi	a1, s4, 0x4
                	lw	s3, 0x0(a1)
                	and	a1, s2, s3
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x688
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x7f0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	s2, t2, 0x4
                	sw	a1, 0x0(s2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x690
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x7e8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
@@ -2216,14 +2140,14 @@ Disassembly of section .text:
                	addi	a1, s4, 0x8
                	lw	s3, 0x0(a1)
                	and	a1, s2, s3
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x688
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x7f0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	s2, t2, 0x8
                	sw	a1, 0x0(s2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x690
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x7e8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
@@ -2231,66 +2155,66 @@ Disassembly of section .text:
                	addi	a1, s4, 0xc
                	lw	s3, 0x0(a1)
                	and	a1, s2, s3
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x688
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x7f0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	s2, t2, 0xc
                	sw	a1, 0x0(s2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x690
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x7e8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	lw	s2, 0x0(a1)
                	not	a1, s2
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x680
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x7f8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	s2, t2
                	sw	a1, 0x0(s2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x690
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x7e8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	lw	s2, 0x0(a1)
                	not	a1, s2
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x680
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x7f8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	s2, t2, 0x4
                	sw	a1, 0x0(s2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x690
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x7e8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	lw	s2, 0x0(a1)
                	not	a1, s2
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x680
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x7f8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	s2, t2, 0x8
                	sw	a1, 0x0(s2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x690
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x7e8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	lw	s2, 0x0(a1)
                	not	a1, s2
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x680
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x7f8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	s2, t2, 0xc
                	sw	a1, 0x0(s2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x680
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x7f8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
@@ -2298,14 +2222,14 @@ Disassembly of section .text:
                	mv	a1, s5
                	lw	s3, 0x0(a1)
                	and	a1, s2, s3
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x678
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x800
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	s2, t2
                	sw	a1, 0x0(s2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x680
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x7f8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
@@ -2313,14 +2237,14 @@ Disassembly of section .text:
                	addi	a1, s5, 0x4
                	lw	s3, 0x0(a1)
                	and	a1, s2, s3
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x678
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x800
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	s2, t2, 0x4
                	sw	a1, 0x0(s2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x680
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x7f8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
@@ -2328,14 +2252,14 @@ Disassembly of section .text:
                	addi	a1, s5, 0x8
                	lw	s3, 0x0(a1)
                	and	a1, s2, s3
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x678
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x800
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	s2, t2, 0x8
                	sw	a1, 0x0(s2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x680
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x7f8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
@@ -2343,126 +2267,126 @@ Disassembly of section .text:
                	addi	a1, s5, 0xc
                	lw	s2, 0x0(a1)
                	and	a1, a4, s2
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x678
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x800
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a4, t2, 0xc
                	sw	a1, 0x0(a4)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x688
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x7f0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	lw	a4, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x678
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x800
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	lw	s2, 0x0(a1)
                	or	a1, a4, s2
                	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x670
+               	addiw	t1, t1, 0x7f8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a4, t2
                	sw	a1, 0x0(a4)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x688
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x7f0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	lw	a4, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x678
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x800
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	lw	s2, 0x0(a1)
                	or	a1, a4, s2
                	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x670
+               	addiw	t1, t1, 0x7f8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a4, t2, 0x4
                	sw	a1, 0x0(a4)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x688
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x7f0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	lw	a4, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x678
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x800
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	lw	s2, 0x0(a1)
                	or	a1, a4, s2
                	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x670
+               	addiw	t1, t1, 0x7f8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a4, t2, 0x8
                	sw	a1, 0x0(a4)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x688
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x7f0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	lw	a3, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x678
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x800
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	lw	a4, 0x0(a1)
                	or	a1, a3, a4
                	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x670
+               	addiw	t1, t1, 0x7f8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a3, t2, 0xc
                	sw	a1, 0x0(a3)
                	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x670
+               	addiw	t1, t1, 0x7f8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	lw	a3, 0x0(a1)
                	mv	a1, a3
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x20b0>
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x1f80>
                	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x670
+               	addiw	t1, t1, 0x7f8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	lw	a3, 0x0(a1)
                	mv	a1, a3
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x20d4>
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x1fa4>
                	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x670
+               	addiw	t1, t1, 0x7f8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	lw	a3, 0x0(a1)
                	mv	a1, a3
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x20f8>
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x1fc8>
                	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x670
+               	addiw	t1, t1, 0x7f8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	lw	a3, 0x0(a1)
                	mv	a1, a3
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x211c>
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x690
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x1fec>
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x7e8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
@@ -2471,13 +2395,13 @@ Disassembly of section .text:
                	lw	a4, 0x0(a1)
                	and	a1, a3, a4
                	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x668
+               	addiw	t1, t1, 0x7f0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a3, t2
                	sw	a1, 0x0(a3)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x690
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x7e8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
@@ -2486,13 +2410,13 @@ Disassembly of section .text:
                	lw	a4, 0x0(a1)
                	and	a1, a3, a4
                	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x668
+               	addiw	t1, t1, 0x7f0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a3, t2, 0x4
                	sw	a1, 0x0(a3)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x690
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x7e8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
@@ -2501,13 +2425,13 @@ Disassembly of section .text:
                	lw	a4, 0x0(a1)
                	and	a1, a3, a4
                	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x668
+               	addiw	t1, t1, 0x7f0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a3, t2, 0x8
                	sw	a1, 0x0(a3)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x690
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x7e8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
@@ -2516,65 +2440,65 @@ Disassembly of section .text:
                	lw	a4, 0x0(a1)
                	and	a1, a3, a4
                	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x668
+               	addiw	t1, t1, 0x7f0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a3, t2, 0xc
                	sw	a1, 0x0(a3)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x690
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x7e8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	lw	a3, 0x0(a1)
                	not	a1, a3
                	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x660
+               	addiw	t1, t1, 0x7e8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a3, t2
                	sw	a1, 0x0(a3)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x690
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x7e8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	lw	a3, 0x0(a1)
                	not	a1, a3
                	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x660
+               	addiw	t1, t1, 0x7e8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a3, t2, 0x4
                	sw	a1, 0x0(a3)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x690
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x7e8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	lw	a3, 0x0(a1)
                	not	a1, a3
                	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x660
+               	addiw	t1, t1, 0x7e8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a3, t2, 0x8
                	sw	a1, 0x0(a3)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x690
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x7e8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	lw	a3, 0x0(a1)
                	not	a1, a3
                	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x660
+               	addiw	t1, t1, 0x7e8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a3, t2, 0xc
                	sw	a1, 0x0(a3)
                	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x660
+               	addiw	t1, t1, 0x7e8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
@@ -2583,13 +2507,13 @@ Disassembly of section .text:
                	lw	a4, 0x0(a1)
                	and	a1, a3, a4
                	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x658
+               	addiw	t1, t1, 0x7e0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a3, t2
                	sw	a1, 0x0(a3)
                	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x660
+               	addiw	t1, t1, 0x7e8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
@@ -2598,13 +2522,13 @@ Disassembly of section .text:
                	lw	a4, 0x0(a1)
                	and	a1, a3, a4
                	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x658
+               	addiw	t1, t1, 0x7e0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a3, t2, 0x4
                	sw	a1, 0x0(a3)
                	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x660
+               	addiw	t1, t1, 0x7e8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
@@ -2613,13 +2537,13 @@ Disassembly of section .text:
                	lw	a4, 0x0(a1)
                	and	a1, a3, a4
                	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x658
+               	addiw	t1, t1, 0x7e0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a3, t2, 0x8
                	sw	a1, 0x0(a3)
                	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x660
+               	addiw	t1, t1, 0x7e8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
@@ -2628,19 +2552,19 @@ Disassembly of section .text:
                	lw	a4, 0x0(a1)
                	and	a1, a3, a4
                	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x658
+               	addiw	t1, t1, 0x7e0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a3, t2, 0xc
                	sw	a1, 0x0(a3)
                	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x668
+               	addiw	t1, t1, 0x7f0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	lw	a3, 0x0(a1)
                	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x658
+               	addiw	t1, t1, 0x7e0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
@@ -2649,13 +2573,13 @@ Disassembly of section .text:
                	mv	a3, s1
                	sw	a1, 0x0(a3)
                	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x668
+               	addiw	t1, t1, 0x7f0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	lw	a3, 0x0(a1)
                	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x658
+               	addiw	t1, t1, 0x7e0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
@@ -2664,13 +2588,13 @@ Disassembly of section .text:
                	addi	a3, s1, 0x4
                	sw	a1, 0x0(a3)
                	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x668
+               	addiw	t1, t1, 0x7f0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	lw	a3, 0x0(a1)
                	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x658
+               	addiw	t1, t1, 0x7e0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
@@ -2679,13 +2603,13 @@ Disassembly of section .text:
                	addi	a3, s1, 0x8
                	sw	a1, 0x0(a3)
                	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x668
+               	addiw	t1, t1, 0x7f0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	lw	a3, 0x0(a1)
                	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x658
+               	addiw	t1, t1, 0x7e0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
@@ -2697,29 +2621,29 @@ Disassembly of section .text:
                	lw	a3, 0x0(a1)
                	mv	a1, a3
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x24d0>
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x23a0>
                	addi	a1, s1, 0x4
                	lw	a3, 0x0(a1)
                	mv	a1, a3
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x24e4>
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x23b4>
                	addi	a1, s1, 0x8
                	lw	a3, 0x0(a1)
                	mv	a1, a3
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x24f8>
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x23c8>
                	addi	a1, s1, 0xc
                	lw	a3, 0x0(a1)
                	mv	a1, a3
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x250c>
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x23dc>
                	mv	a1, s4
                	lw	a3, 0x0(a1)
                	mv	a1, s5
                	lw	a4, 0x0(a1)
                	addw	a1, a3, a4
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x740
+               	addiw	t1, t1, -0x5c0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a3, t2
@@ -2730,7 +2654,7 @@ Disassembly of section .text:
                	lw	a4, 0x0(a1)
                	addw	a1, a3, a4
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x740
+               	addiw	t1, t1, -0x5c0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a3, t2, 0x4
@@ -2741,7 +2665,7 @@ Disassembly of section .text:
                	lw	a4, 0x0(a1)
                	addw	a1, a3, a4
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x740
+               	addiw	t1, t1, -0x5c0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a3, t2, 0x8
@@ -2752,171 +2676,171 @@ Disassembly of section .text:
                	lw	a4, 0x0(a1)
                	addw	a1, a3, a4
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x740
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a3, t2, 0xc
-               	sw	a1, 0x0(a3)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x690
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	lw	a3, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x740
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	lw	a4, 0x0(a1)
-               	and	a1, a3, a4
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x748
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a3, t2
-               	sw	a1, 0x0(a3)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x690
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	lw	a3, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x740
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	lw	a4, 0x0(a1)
-               	and	a1, a3, a4
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x748
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a3, t2, 0x4
-               	sw	a1, 0x0(a3)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x690
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	lw	a3, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x740
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	lw	a4, 0x0(a1)
-               	and	a1, a3, a4
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x748
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a3, t2, 0x8
-               	sw	a1, 0x0(a3)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x690
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	lw	a3, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x740
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	lw	a4, 0x0(a1)
-               	and	a1, a3, a4
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x748
+               	addiw	t1, t1, -0x5c0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a3, t2, 0xc
                	sw	a1, 0x0(a3)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x748
+               	addiw	t1, t1, -0x7e8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	lw	a3, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x5c0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	lw	a4, 0x0(a1)
+               	and	a1, a3, a4
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x5c8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a3, t2
+               	sw	a1, 0x0(a3)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x7e8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x4
+               	lw	a3, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x5c0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x4
+               	lw	a4, 0x0(a1)
+               	and	a1, a3, a4
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x5c8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a3, t2, 0x4
+               	sw	a1, 0x0(a3)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x7e8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x8
+               	lw	a3, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x5c0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x8
+               	lw	a4, 0x0(a1)
+               	and	a1, a3, a4
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x5c8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a3, t2, 0x8
+               	sw	a1, 0x0(a3)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x7e8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0xc
+               	lw	a3, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x5c0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0xc
+               	lw	a4, 0x0(a1)
+               	and	a1, a3, a4
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x5c8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a3, t2, 0xc
+               	sw	a1, 0x0(a3)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x5c8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	lw	a3, 0x0(a1)
                	mv	a1, a3
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x2710>
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x25e0>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x748
+               	addiw	t1, t1, -0x5c8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	lw	a3, 0x0(a1)
                	mv	a1, a3
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x2734>
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x2604>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x748
+               	addiw	t1, t1, -0x5c8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	lw	a3, 0x0(a1)
                	mv	a1, a3
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x2758>
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x2628>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x748
+               	addiw	t1, t1, -0x5c8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	lw	a3, 0x0(a1)
                	mv	a1, a3
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x277c>
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x690
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x264c>
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x7e8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	lw	a3, 0x0(a1)
                	not	a1, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x750
+               	addiw	t1, t1, -0x5d0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a3, t2
                	sw	a1, 0x0(a3)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x690
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x7e8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	lw	a3, 0x0(a1)
                	not	a1, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x750
+               	addiw	t1, t1, -0x5d0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a3, t2, 0x4
                	sw	a1, 0x0(a3)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x690
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x7e8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	lw	a3, 0x0(a1)
                	not	a1, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x750
+               	addiw	t1, t1, -0x5d0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a3, t2, 0x8
                	sw	a1, 0x0(a3)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x690
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x7e8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	lw	a2, 0x0(a1)
                	not	a1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x750
+               	addiw	t1, t1, -0x5d0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xc
@@ -2927,7 +2851,7 @@ Disassembly of section .text:
                	lw	a3, 0x0(a1)
                	subw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x758
+               	addiw	t1, t1, -0x5d8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
@@ -2938,7 +2862,7 @@ Disassembly of section .text:
                	lw	a3, 0x0(a1)
                	subw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x758
+               	addiw	t1, t1, -0x5d8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x4
@@ -2949,7 +2873,7 @@ Disassembly of section .text:
                	lw	a3, 0x0(a1)
                	subw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x758
+               	addiw	t1, t1, -0x5d8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
@@ -2960,125 +2884,125 @@ Disassembly of section .text:
                	lw	a3, 0x0(a1)
                	subw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x758
+               	addiw	t1, t1, -0x5d8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xc
                	sw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x750
+               	addiw	t1, t1, -0x5d0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	lw	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x758
+               	addiw	t1, t1, -0x5d8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	lw	a3, 0x0(a1)
                	or	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x760
+               	addiw	t1, t1, -0x5e0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
                	sw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x750
+               	addiw	t1, t1, -0x5d0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	lw	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x758
+               	addiw	t1, t1, -0x5d8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	lw	a3, 0x0(a1)
                	or	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x760
+               	addiw	t1, t1, -0x5e0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x4
                	sw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x750
+               	addiw	t1, t1, -0x5d0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	lw	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x758
+               	addiw	t1, t1, -0x5d8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	lw	a3, 0x0(a1)
                	or	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x760
+               	addiw	t1, t1, -0x5e0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
                	sw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x750
+               	addiw	t1, t1, -0x5d0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	lw	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x758
+               	addiw	t1, t1, -0x5d8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	lw	a3, 0x0(a1)
                	or	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x760
+               	addiw	t1, t1, -0x5e0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xc
                	sw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x760
+               	addiw	t1, t1, -0x5e0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	lw	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x2a50>
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x2920>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x760
+               	addiw	t1, t1, -0x5e0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	lw	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x2a74>
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x2944>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x760
+               	addiw	t1, t1, -0x5e0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	lw	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x2a98>
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x2968>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x760
+               	addiw	t1, t1, -0x5e0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	lw	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x2abc>
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x298c>
                	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x6a0
+               	addiw	t0, t0, -0x520
                	add	a1, s0, t0
                	mv	a2, a1
                	lui	t0, 0x100
@@ -3100,7 +3024,7 @@ Disassembly of section .text:
                	mv	a2, a1
                	lw	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x768
+               	addiw	t1, t1, -0x5e8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
@@ -3108,7 +3032,7 @@ Disassembly of section .text:
                	addi	a2, a1, 0x4
                	lw	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x768
+               	addiw	t1, t1, -0x5e8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x4
@@ -3116,7 +3040,7 @@ Disassembly of section .text:
                	addi	a2, a1, 0x8
                	lw	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x768
+               	addiw	t1, t1, -0x5e8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
@@ -3124,13 +3048,13 @@ Disassembly of section .text:
                	addi	a2, a1, 0xc
                	lw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x768
+               	addiw	t1, t1, -0x5e8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xc
                	sw	a1, 0x0(a2)
                	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x6b0
+               	addiw	t0, t0, -0x530
                	add	a1, s0, t0
                	mv	a2, a1
                	li	t0, 0x1
@@ -3150,7 +3074,7 @@ Disassembly of section .text:
                	mv	a2, a1
                	lw	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x770
+               	addiw	t1, t1, -0x5f0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
@@ -3158,7 +3082,7 @@ Disassembly of section .text:
                	addi	a2, a1, 0x4
                	lw	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x770
+               	addiw	t1, t1, -0x5f0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x4
@@ -3166,7 +3090,7 @@ Disassembly of section .text:
                	addi	a2, a1, 0x8
                	lw	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x770
+               	addiw	t1, t1, -0x5f0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
@@ -3174,149 +3098,149 @@ Disassembly of section .text:
                	addi	a2, a1, 0xc
                	lw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x770
+               	addiw	t1, t1, -0x5f0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xc
                	sw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x768
+               	addiw	t1, t1, -0x5e8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	lw	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x6c8
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x7b0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addw	a1, a2, t2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x768
+               	addiw	t1, t1, -0x5e8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
                	lw	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x778
+               	addiw	t1, t1, -0x5f8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
                	sw	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x768
+               	addiw	t1, t1, -0x5e8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x4
                	lw	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x778
+               	addiw	t1, t1, -0x5f8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x4
                	sw	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x768
+               	addiw	t1, t1, -0x5e8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
                	lw	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x778
+               	addiw	t1, t1, -0x5f8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
                	sw	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x768
+               	addiw	t1, t1, -0x5e8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xc
                	lw	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x778
+               	addiw	t1, t1, -0x5f8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xc
                	sw	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x778
+               	addiw	t1, t1, -0x5f8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
                	sw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x770
+               	addiw	t1, t1, -0x5f0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	lw	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x6c8
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x7b0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addw	a1, a2, t2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x770
+               	addiw	t1, t1, -0x5f0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
                	lw	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x780
+               	addiw	t1, t1, -0x600
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
                	sw	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x770
+               	addiw	t1, t1, -0x5f0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x4
                	lw	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x780
+               	addiw	t1, t1, -0x600
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x4
                	sw	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x770
+               	addiw	t1, t1, -0x5f0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
                	lw	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x780
+               	addiw	t1, t1, -0x600
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
                	sw	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x770
+               	addiw	t1, t1, -0x5f0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xc
                	lw	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x780
+               	addiw	t1, t1, -0x600
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xc
                	sw	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x780
+               	addiw	t1, t1, -0x600
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xc
                	sw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x778
+               	addiw	t1, t1, -0x5f8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	lw	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x780
+               	addiw	t1, t1, -0x600
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
@@ -3326,19 +3250,19 @@ Disassembly of section .text:
                	li	t1, 0x0
                	subw	a1, t1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x788
+               	addiw	t1, t1, -0x608
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
                	sw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x778
+               	addiw	t1, t1, -0x5f8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	lw	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x780
+               	addiw	t1, t1, -0x600
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
@@ -3348,19 +3272,19 @@ Disassembly of section .text:
                	li	t1, 0x0
                	subw	a1, t1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x788
+               	addiw	t1, t1, -0x608
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x4
                	sw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x778
+               	addiw	t1, t1, -0x5f8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	lw	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x780
+               	addiw	t1, t1, -0x600
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
@@ -3370,19 +3294,19 @@ Disassembly of section .text:
                	li	t1, 0x0
                	subw	a1, t1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x788
+               	addiw	t1, t1, -0x608
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
                	sw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x778
+               	addiw	t1, t1, -0x5f8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	lw	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x780
+               	addiw	t1, t1, -0x600
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
@@ -3392,55 +3316,55 @@ Disassembly of section .text:
                	li	t1, 0x0
                	subw	a1, t1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x788
+               	addiw	t1, t1, -0x608
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xc
                	sw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x788
+               	addiw	t1, t1, -0x608
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	lw	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x2fe0>
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x2eb0>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x788
+               	addiw	t1, t1, -0x608
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	lw	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x3004>
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x2ed4>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x788
+               	addiw	t1, t1, -0x608
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	lw	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x3028>
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x2ef8>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x788
+               	addiw	t1, t1, -0x608
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	lw	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x304c>
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x2f1c>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x780
+               	addiw	t1, t1, -0x600
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	lw	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x778
+               	addiw	t1, t1, -0x5f8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
@@ -3450,19 +3374,19 @@ Disassembly of section .text:
                	li	t1, 0x0
                	subw	a1, t1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x790
+               	addiw	t1, t1, -0x610
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
                	sw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x780
+               	addiw	t1, t1, -0x600
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	lw	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x778
+               	addiw	t1, t1, -0x5f8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
@@ -3472,19 +3396,19 @@ Disassembly of section .text:
                	li	t1, 0x0
                	subw	a1, t1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x790
+               	addiw	t1, t1, -0x610
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x4
                	sw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x780
+               	addiw	t1, t1, -0x600
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	lw	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x778
+               	addiw	t1, t1, -0x5f8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
@@ -3494,19 +3418,19 @@ Disassembly of section .text:
                	li	t1, 0x0
                	subw	a1, t1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x790
+               	addiw	t1, t1, -0x610
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
                	sw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x780
+               	addiw	t1, t1, -0x600
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	lw	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x778
+               	addiw	t1, t1, -0x5f8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
@@ -3516,55 +3440,55 @@ Disassembly of section .text:
                	li	t1, 0x0
                	subw	a1, t1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x790
+               	addiw	t1, t1, -0x610
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xc
                	sw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x790
+               	addiw	t1, t1, -0x610
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	lw	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x31d0>
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x30a0>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x790
+               	addiw	t1, t1, -0x610
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	lw	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x31f4>
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x30c4>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x790
+               	addiw	t1, t1, -0x610
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	lw	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x3218>
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x30e8>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x790
+               	addiw	t1, t1, -0x610
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	lw	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x323c>
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x310c>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x778
+               	addiw	t1, t1, -0x5f8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	lw	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x780
+               	addiw	t1, t1, -0x600
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
@@ -3575,19 +3499,19 @@ Disassembly of section .text:
                	li	t1, 0x0
                	subw	a1, t1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x798
+               	addiw	t1, t1, -0x618
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
                	sw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x778
+               	addiw	t1, t1, -0x5f8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	lw	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x780
+               	addiw	t1, t1, -0x600
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
@@ -3598,19 +3522,19 @@ Disassembly of section .text:
                	li	t1, 0x0
                	subw	a1, t1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x798
+               	addiw	t1, t1, -0x618
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x4
                	sw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x778
+               	addiw	t1, t1, -0x5f8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	lw	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x780
+               	addiw	t1, t1, -0x600
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
@@ -3621,19 +3545,19 @@ Disassembly of section .text:
                	li	t1, 0x0
                	subw	a1, t1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x798
+               	addiw	t1, t1, -0x618
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
                	sw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x778
+               	addiw	t1, t1, -0x5f8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	lw	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x780
+               	addiw	t1, t1, -0x600
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
@@ -3644,55 +3568,55 @@ Disassembly of section .text:
                	li	t1, 0x0
                	subw	a1, t1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x798
+               	addiw	t1, t1, -0x618
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xc
                	sw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x798
+               	addiw	t1, t1, -0x618
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	lw	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x33d0>
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x32a0>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x798
+               	addiw	t1, t1, -0x618
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	lw	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x33f4>
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x32c4>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x798
+               	addiw	t1, t1, -0x618
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	lw	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x3418>
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x32e8>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x798
+               	addiw	t1, t1, -0x618
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	lw	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x343c>
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x330c>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x778
+               	addiw	t1, t1, -0x5f8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	lw	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x780
+               	addiw	t1, t1, -0x600
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
@@ -3703,19 +3627,19 @@ Disassembly of section .text:
                	li	t1, 0x0
                	subw	a1, t1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7a0
+               	addiw	t1, t1, -0x620
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
                	sw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x778
+               	addiw	t1, t1, -0x5f8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	lw	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x780
+               	addiw	t1, t1, -0x600
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
@@ -3726,19 +3650,19 @@ Disassembly of section .text:
                	li	t1, 0x0
                	subw	a1, t1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7a0
+               	addiw	t1, t1, -0x620
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x4
                	sw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x778
+               	addiw	t1, t1, -0x5f8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	lw	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x780
+               	addiw	t1, t1, -0x600
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
@@ -3749,19 +3673,19 @@ Disassembly of section .text:
                	li	t1, 0x0
                	subw	a1, t1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7a0
+               	addiw	t1, t1, -0x620
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
                	sw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x778
+               	addiw	t1, t1, -0x5f8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	lw	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x780
+               	addiw	t1, t1, -0x600
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
@@ -3772,55 +3696,55 @@ Disassembly of section .text:
                	li	t1, 0x0
                	subw	a1, t1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7a0
+               	addiw	t1, t1, -0x620
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xc
                	sw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7a0
+               	addiw	t1, t1, -0x620
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	lw	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x35d0>
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x34a0>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7a0
+               	addiw	t1, t1, -0x620
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	lw	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x35f4>
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x34c4>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7a0
+               	addiw	t1, t1, -0x620
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	lw	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x3618>
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x34e8>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7a0
+               	addiw	t1, t1, -0x620
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	lw	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x363c>
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x350c>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x778
+               	addiw	t1, t1, -0x5f8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	lw	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x780
+               	addiw	t1, t1, -0x600
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
@@ -3831,19 +3755,19 @@ Disassembly of section .text:
                	li	t1, 0x0
                	subw	a1, t1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7a8
+               	addiw	t1, t1, -0x628
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
                	sw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x778
+               	addiw	t1, t1, -0x5f8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	lw	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x780
+               	addiw	t1, t1, -0x600
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
@@ -3854,19 +3778,19 @@ Disassembly of section .text:
                	li	t1, 0x0
                	subw	a1, t1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7a8
+               	addiw	t1, t1, -0x628
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x4
                	sw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x778
+               	addiw	t1, t1, -0x5f8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	lw	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x780
+               	addiw	t1, t1, -0x600
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
@@ -3877,19 +3801,19 @@ Disassembly of section .text:
                	li	t1, 0x0
                	subw	a1, t1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7a8
+               	addiw	t1, t1, -0x628
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
                	sw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x778
+               	addiw	t1, t1, -0x5f8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	lw	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x780
+               	addiw	t1, t1, -0x600
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
@@ -3900,55 +3824,55 @@ Disassembly of section .text:
                	li	t1, 0x0
                	subw	a1, t1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7a8
+               	addiw	t1, t1, -0x628
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xc
                	sw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7a8
+               	addiw	t1, t1, -0x628
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	lw	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x37d0>
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x36a0>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7a8
+               	addiw	t1, t1, -0x628
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	lw	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x37f4>
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x36c4>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7a8
+               	addiw	t1, t1, -0x628
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	lw	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x3818>
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x36e8>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7a8
+               	addiw	t1, t1, -0x628
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	lw	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x383c>
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x370c>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x780
+               	addiw	t1, t1, -0x600
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	lw	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x778
+               	addiw	t1, t1, -0x5f8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
@@ -3959,19 +3883,19 @@ Disassembly of section .text:
                	li	t1, 0x0
                	subw	a1, t1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7b0
+               	addiw	t1, t1, -0x630
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
                	sw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x780
+               	addiw	t1, t1, -0x600
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	lw	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x778
+               	addiw	t1, t1, -0x5f8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
@@ -3982,19 +3906,19 @@ Disassembly of section .text:
                	li	t1, 0x0
                	subw	a1, t1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7b0
+               	addiw	t1, t1, -0x630
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x4
                	sw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x780
+               	addiw	t1, t1, -0x600
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	lw	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x778
+               	addiw	t1, t1, -0x5f8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
@@ -4005,19 +3929,19 @@ Disassembly of section .text:
                	li	t1, 0x0
                	subw	a1, t1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7b0
+               	addiw	t1, t1, -0x630
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
                	sw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x780
+               	addiw	t1, t1, -0x600
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	lw	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x778
+               	addiw	t1, t1, -0x5f8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
@@ -4028,49 +3952,49 @@ Disassembly of section .text:
                	li	t1, 0x0
                	subw	a1, t1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7b0
+               	addiw	t1, t1, -0x630
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xc
                	sw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7b0
+               	addiw	t1, t1, -0x630
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	lw	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x39d0>
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x38a0>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7b0
+               	addiw	t1, t1, -0x630
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	lw	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x39f4>
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x38c4>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7b0
+               	addiw	t1, t1, -0x630
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	lw	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x3a18>
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x38e8>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7b0
+               	addiw	t1, t1, -0x630
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	lw	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x3a3c>
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x390c>
                	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x6c0
+               	addiw	t0, t0, -0x540
                	add	a1, s0, t0
                	mv	a2, a1
                	lui	t0, 0x3fc00
@@ -4090,7 +4014,7 @@ Disassembly of section .text:
                	mv	a2, a1
                	flw	ft0, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7b8
+               	addiw	t1, t1, -0x638
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
@@ -4098,7 +4022,7 @@ Disassembly of section .text:
                	addi	a2, a1, 0x4
                	flw	ft0, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7b8
+               	addiw	t1, t1, -0x638
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x4
@@ -4106,7 +4030,7 @@ Disassembly of section .text:
                	addi	a2, a1, 0x8
                	flw	ft0, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7b8
+               	addiw	t1, t1, -0x638
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
@@ -4114,13 +4038,13 @@ Disassembly of section .text:
                	addi	a2, a1, 0xc
                	flw	ft0, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7b8
+               	addiw	t1, t1, -0x638
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	fsw	ft0, 0x0(a1)
                	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x6d0
+               	addiw	t0, t0, -0x550
                	add	a1, s0, t0
                	mv	a2, a1
                	lui	t0, 0x40200
@@ -4138,7 +4062,7 @@ Disassembly of section .text:
                	mv	a2, a1
                	flw	ft0, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7c0
+               	addiw	t1, t1, -0x640
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
@@ -4146,7 +4070,7 @@ Disassembly of section .text:
                	addi	a2, a1, 0x4
                	flw	ft0, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7c0
+               	addiw	t1, t1, -0x640
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x4
@@ -4154,7 +4078,7 @@ Disassembly of section .text:
                	addi	a2, a1, 0x8
                	flw	ft0, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7c0
+               	addiw	t1, t1, -0x640
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
@@ -4162,152 +4086,152 @@ Disassembly of section .text:
                	addi	a2, a1, 0xc
                	flw	ft0, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7c0
+               	addiw	t1, t1, -0x640
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	fsw	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7b8
+               	addiw	t1, t1, -0x638
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	flw	ft0, 0x0(a1)
                	fadd.s	ft1, ft0, fs0
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7b8
+               	addiw	t1, t1, -0x638
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	flw	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7c8
+               	addiw	t1, t1, -0x648
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	fsw	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7b8
+               	addiw	t1, t1, -0x638
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	flw	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7c8
+               	addiw	t1, t1, -0x648
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	fsw	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7b8
+               	addiw	t1, t1, -0x638
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	flw	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7c8
+               	addiw	t1, t1, -0x648
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	fsw	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7b8
+               	addiw	t1, t1, -0x638
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	flw	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7c8
+               	addiw	t1, t1, -0x648
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	fsw	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7c8
+               	addiw	t1, t1, -0x648
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	fsw	ft1, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7c8
+               	addiw	t1, t1, -0x648
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	flw	ft0, 0x0(a1)
                	fmv.s	fa0, ft0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x3cdc>
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x3bac>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7c8
+               	addiw	t1, t1, -0x648
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	flw	ft0, 0x0(a1)
                	fmv.s	fa0, ft0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x3d00>
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x3bd0>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7c8
+               	addiw	t1, t1, -0x648
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	flw	ft0, 0x0(a1)
                	fmv.s	fa0, ft0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x3d24>
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x3bf4>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7c8
+               	addiw	t1, t1, -0x648
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	flw	ft0, 0x0(a1)
                	fmv.s	fa0, ft0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x3d48>
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x3c18>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7c0
+               	addiw	t1, t1, -0x640
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	flw	ft0, 0x0(a1)
                	fmv.s	fa0, ft0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x3d6c>
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x3c3c>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7c0
+               	addiw	t1, t1, -0x640
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	flw	ft0, 0x0(a1)
                	fmv.s	fa0, ft0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x3d90>
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x3c60>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7c0
+               	addiw	t1, t1, -0x640
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	flw	ft0, 0x0(a1)
                	fmv.s	fa0, ft0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x3db4>
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x3c84>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7c0
+               	addiw	t1, t1, -0x640
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	flw	ft0, 0x0(a1)
                	fmv.s	fa0, ft0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x3dd8>
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x3ca8>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7c8
+               	addiw	t1, t1, -0x648
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	flw	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7c0
+               	addiw	t1, t1, -0x640
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
@@ -4317,19 +4241,19 @@ Disassembly of section .text:
                	li	t1, 0x0
                	subw	a1, t1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7d0
+               	addiw	t1, t1, -0x650
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
                	sw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7c8
+               	addiw	t1, t1, -0x648
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	flw	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7c0
+               	addiw	t1, t1, -0x640
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
@@ -4339,19 +4263,19 @@ Disassembly of section .text:
                	li	t1, 0x0
                	subw	a1, t1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7d0
+               	addiw	t1, t1, -0x650
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x4
                	sw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7c8
+               	addiw	t1, t1, -0x648
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	flw	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7c0
+               	addiw	t1, t1, -0x640
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
@@ -4361,19 +4285,19 @@ Disassembly of section .text:
                	li	t1, 0x0
                	subw	a1, t1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7d0
+               	addiw	t1, t1, -0x650
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
                	sw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7c8
+               	addiw	t1, t1, -0x648
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	flw	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7c0
+               	addiw	t1, t1, -0x640
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
@@ -4383,55 +4307,26 @@ Disassembly of section .text:
                	li	t1, 0x0
                	subw	a1, t1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7d0
+               	addiw	t1, t1, -0x650
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xc
                	sw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7d0
+               	addiw	t1, t1, -0x650
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x3f5c>
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x3e24>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7d0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x3f80>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7d0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x3fa4>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7d0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x3fc8>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7c0
+               	addiw	t1, t1, -0x640
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	flw	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7c8
+               	addiw	t1, t1, -0x648
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
@@ -4441,19 +4336,19 @@ Disassembly of section .text:
                	li	t1, 0x0
                	subw	a1, t1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7d8
+               	addiw	t1, t1, -0x658
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
                	sw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7c0
+               	addiw	t1, t1, -0x640
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	flw	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7c8
+               	addiw	t1, t1, -0x648
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
@@ -4463,19 +4358,19 @@ Disassembly of section .text:
                	li	t1, 0x0
                	subw	a1, t1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7d8
+               	addiw	t1, t1, -0x658
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x4
                	sw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7c0
+               	addiw	t1, t1, -0x640
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	flw	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7c8
+               	addiw	t1, t1, -0x648
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
@@ -4485,19 +4380,19 @@ Disassembly of section .text:
                	li	t1, 0x0
                	subw	a1, t1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7d8
+               	addiw	t1, t1, -0x658
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
                	sw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7c0
+               	addiw	t1, t1, -0x640
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	flw	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7c8
+               	addiw	t1, t1, -0x648
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
@@ -4507,55 +4402,26 @@ Disassembly of section .text:
                	li	t1, 0x0
                	subw	a1, t1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7d8
+               	addiw	t1, t1, -0x658
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xc
                	sw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7d8
+               	addiw	t1, t1, -0x658
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x414c>
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x3fa0>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7d8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x4170>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7d8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x4194>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7d8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x41b8>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7c8
+               	addiw	t1, t1, -0x648
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	flw	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7c0
+               	addiw	t1, t1, -0x640
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
@@ -4565,19 +4431,19 @@ Disassembly of section .text:
                	li	t1, 0x0
                	subw	a1, t1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7e0
+               	addiw	t1, t1, -0x660
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
                	sw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7c8
+               	addiw	t1, t1, -0x648
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	flw	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7c0
+               	addiw	t1, t1, -0x640
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
@@ -4587,19 +4453,19 @@ Disassembly of section .text:
                	li	t1, 0x0
                	subw	a1, t1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7e0
+               	addiw	t1, t1, -0x660
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x4
                	sw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7c8
+               	addiw	t1, t1, -0x648
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	flw	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7c0
+               	addiw	t1, t1, -0x640
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
@@ -4609,19 +4475,19 @@ Disassembly of section .text:
                	li	t1, 0x0
                	subw	a1, t1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7e0
+               	addiw	t1, t1, -0x660
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
                	sw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7c8
+               	addiw	t1, t1, -0x648
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	flw	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7c0
+               	addiw	t1, t1, -0x640
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
@@ -4631,55 +4497,26 @@ Disassembly of section .text:
                	li	t1, 0x0
                	subw	a1, t1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7e0
+               	addiw	t1, t1, -0x660
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xc
                	sw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7e0
+               	addiw	t1, t1, -0x660
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x433c>
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x411c>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7e0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x4360>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7e0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x4384>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7e0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x43a8>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7c8
+               	addiw	t1, t1, -0x648
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	flw	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7c0
+               	addiw	t1, t1, -0x640
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
@@ -4690,19 +4527,19 @@ Disassembly of section .text:
                	li	t1, 0x0
                	subw	a1, t1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7e8
+               	addiw	t1, t1, -0x668
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
                	sw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7c8
+               	addiw	t1, t1, -0x648
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	flw	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7c0
+               	addiw	t1, t1, -0x640
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
@@ -4713,19 +4550,19 @@ Disassembly of section .text:
                	li	t1, 0x0
                	subw	a1, t1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7e8
+               	addiw	t1, t1, -0x668
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x4
                	sw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7c8
+               	addiw	t1, t1, -0x648
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	flw	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7c0
+               	addiw	t1, t1, -0x640
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
@@ -4736,19 +4573,19 @@ Disassembly of section .text:
                	li	t1, 0x0
                	subw	a1, t1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7e8
+               	addiw	t1, t1, -0x668
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
                	sw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7c8
+               	addiw	t1, t1, -0x648
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	flw	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7c0
+               	addiw	t1, t1, -0x640
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
@@ -4759,55 +4596,26 @@ Disassembly of section .text:
                	li	t1, 0x0
                	subw	a1, t1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7e8
+               	addiw	t1, t1, -0x668
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xc
                	sw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7e8
+               	addiw	t1, t1, -0x668
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x453c>
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x42a8>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7e8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x4560>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7e8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x4584>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7e8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x45a8>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7c8
+               	addiw	t1, t1, -0x648
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	flw	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7c0
+               	addiw	t1, t1, -0x640
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
@@ -4817,19 +4625,19 @@ Disassembly of section .text:
                	li	t1, 0x0
                	subw	a1, t1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7f0
+               	addiw	t1, t1, -0x670
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
                	sw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7c8
+               	addiw	t1, t1, -0x648
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	flw	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7c0
+               	addiw	t1, t1, -0x640
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
@@ -4839,19 +4647,19 @@ Disassembly of section .text:
                	li	t1, 0x0
                	subw	a1, t1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7f0
+               	addiw	t1, t1, -0x670
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x4
                	sw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7c8
+               	addiw	t1, t1, -0x648
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	flw	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7c0
+               	addiw	t1, t1, -0x640
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
@@ -4861,19 +4669,19 @@ Disassembly of section .text:
                	li	t1, 0x0
                	subw	a1, t1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7f0
+               	addiw	t1, t1, -0x670
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
                	sw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7c8
+               	addiw	t1, t1, -0x648
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	flw	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7c0
+               	addiw	t1, t1, -0x640
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
@@ -4883,55 +4691,26 @@ Disassembly of section .text:
                	li	t1, 0x0
                	subw	a1, t1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7f0
+               	addiw	t1, t1, -0x670
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xc
                	sw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7f0
+               	addiw	t1, t1, -0x670
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x472c>
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x4424>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7f0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x4750>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7f0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x4774>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7f0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x4798>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7c0
+               	addiw	t1, t1, -0x640
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	flw	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7c8
+               	addiw	t1, t1, -0x648
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
@@ -4941,19 +4720,19 @@ Disassembly of section .text:
                	li	t1, 0x0
                	subw	a1, t1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7f8
+               	addiw	t1, t1, -0x678
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
                	sw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7c0
+               	addiw	t1, t1, -0x640
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	flw	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7c8
+               	addiw	t1, t1, -0x648
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
@@ -4963,19 +4742,19 @@ Disassembly of section .text:
                	li	t1, 0x0
                	subw	a1, t1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7f8
+               	addiw	t1, t1, -0x678
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x4
                	sw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7c0
+               	addiw	t1, t1, -0x640
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	flw	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7c8
+               	addiw	t1, t1, -0x648
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
@@ -4985,19 +4764,19 @@ Disassembly of section .text:
                	li	t1, 0x0
                	subw	a1, t1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7f8
+               	addiw	t1, t1, -0x678
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
                	sw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7c0
+               	addiw	t1, t1, -0x640
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	flw	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7c8
+               	addiw	t1, t1, -0x648
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
@@ -5007,829 +4786,712 @@ Disassembly of section .text:
                	li	t1, 0x0
                	subw	a1, t1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7f8
+               	addiw	t1, t1, -0x678
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xc
                	sw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7f8
+               	addiw	t1, t1, -0x678
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x45a0>
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x650
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x491c>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7f8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x4940>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7f8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x4964>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7f8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x4988>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7c8
+               	addiw	t1, t1, -0x648
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
-               	flw	ft0, 0x0(a1)
+               	lw	a3, 0x0(a1)
+               	and	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7c0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	flw	ft1, 0x0(a1)
-               	flt.s	a1, ft0, ft1
-               	zext.b	a2, a1
-               	li	t1, 0x0
-               	subw	a1, t1, a2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x800
+               	addiw	t1, t1, -0x680
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
                	sw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7c8
+               	addiw	t1, t1, -0x650
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
-               	flw	ft0, 0x0(a1)
+               	lw	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7c0
+               	addiw	t1, t1, -0x648
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
-               	flw	ft1, 0x0(a1)
-               	flt.s	a1, ft0, ft1
-               	zext.b	a2, a1
-               	li	t1, 0x0
-               	subw	a1, t1, a2
+               	lw	a3, 0x0(a1)
+               	and	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x800
+               	addiw	t1, t1, -0x680
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x4
                	sw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7c8
+               	addiw	t1, t1, -0x650
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
-               	flw	ft0, 0x0(a1)
+               	lw	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7c0
+               	addiw	t1, t1, -0x648
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
-               	flw	ft1, 0x0(a1)
-               	flt.s	a1, ft0, ft1
-               	zext.b	a2, a1
-               	li	t1, 0x0
-               	subw	a1, t1, a2
+               	lw	a3, 0x0(a1)
+               	and	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x800
+               	addiw	t1, t1, -0x680
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
                	sw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7c8
+               	addiw	t1, t1, -0x650
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
-               	flw	ft0, 0x0(a1)
+               	lw	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7c0
+               	addiw	t1, t1, -0x648
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
-               	flw	ft1, 0x0(a1)
-               	flt.s	a1, ft0, ft1
-               	zext.b	a2, a1
-               	li	t1, 0x0
-               	subw	a1, t1, a2
+               	lw	a3, 0x0(a1)
+               	and	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x800
+               	addiw	t1, t1, -0x680
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xc
                	sw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x800
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	lw	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7c8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	lw	a3, 0x0(a1)
-               	and	a1, a2, a3
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x7f8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a2, t2
-               	sw	a1, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x800
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	lw	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7c8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	lw	a3, 0x0(a1)
-               	and	a1, a2, a3
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x7f8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x4
-               	sw	a1, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x800
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	lw	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7c8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	lw	a3, 0x0(a1)
-               	and	a1, a2, a3
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x7f8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x8
-               	sw	a1, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x800
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	lw	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7c8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	lw	a3, 0x0(a1)
-               	and	a1, a2, a3
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x7f8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0xc
-               	sw	a1, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x800
+               	addiw	t1, t1, -0x650
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	lw	a2, 0x0(a1)
                	not	a1, a2
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x7f0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x688
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
                	sw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x800
+               	addiw	t1, t1, -0x650
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	lw	a2, 0x0(a1)
                	not	a1, a2
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x7f0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x688
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x4
                	sw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x800
+               	addiw	t1, t1, -0x650
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	lw	a2, 0x0(a1)
                	not	a1, a2
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x7f0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x688
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
                	sw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x800
+               	addiw	t1, t1, -0x650
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	lw	a2, 0x0(a1)
                	not	a1, a2
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x7f0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0xc
-               	sw	a1, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x7f0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	lw	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7c0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	lw	a3, 0x0(a1)
-               	and	a1, a2, a3
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x7e8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a2, t2
-               	sw	a1, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x7f0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	lw	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7c0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	lw	a3, 0x0(a1)
-               	and	a1, a2, a3
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x7e8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x4
-               	sw	a1, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x7f0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	lw	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7c0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	lw	a3, 0x0(a1)
-               	and	a1, a2, a3
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x7e8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x8
-               	sw	a1, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x7f0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	lw	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7c0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	lw	a3, 0x0(a1)
-               	and	a1, a2, a3
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x7e8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0xc
-               	sw	a1, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x7f8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	lw	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x7e8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	lw	a3, 0x0(a1)
-               	or	a1, a2, a3
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x7e0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a2, t2
-               	sw	a1, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x7f8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	lw	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x7e8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	lw	a3, 0x0(a1)
-               	or	a1, a2, a3
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x7e0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x4
-               	sw	a1, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x7f8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	lw	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x7e8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	lw	a3, 0x0(a1)
-               	or	a1, a2, a3
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x7e0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x8
-               	sw	a1, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x7f8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	lw	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x7e8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	lw	a3, 0x0(a1)
-               	or	a1, a2, a3
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x7e0
+               	addiw	t1, t1, -0x688
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xc
                	sw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x800
+               	addiw	t1, t1, -0x688
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	lw	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7c0
+               	addiw	t1, t1, -0x640
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	lw	a3, 0x0(a1)
                	and	a1, a2, a3
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x7d8
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x690
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
                	sw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x800
+               	addiw	t1, t1, -0x688
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	lw	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7c0
+               	addiw	t1, t1, -0x640
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	lw	a3, 0x0(a1)
                	and	a1, a2, a3
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x7d8
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x690
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x4
                	sw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x800
+               	addiw	t1, t1, -0x688
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	lw	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7c0
+               	addiw	t1, t1, -0x640
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	lw	a3, 0x0(a1)
                	and	a1, a2, a3
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x7d8
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x690
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
                	sw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x800
+               	addiw	t1, t1, -0x688
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	lw	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7c0
+               	addiw	t1, t1, -0x640
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	lw	a3, 0x0(a1)
                	and	a1, a2, a3
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x7d8
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x690
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xc
                	sw	a1, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x7f0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x680
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	lw	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7c8
+               	addiw	t1, t1, -0x690
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	lw	a3, 0x0(a1)
-               	and	a1, a2, a3
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x7d0
+               	or	a1, a2, a3
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x698
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
                	sw	a1, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x7f0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x680
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	lw	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7c8
+               	addiw	t1, t1, -0x690
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	lw	a3, 0x0(a1)
-               	and	a1, a2, a3
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x7d0
+               	or	a1, a2, a3
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x698
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x4
                	sw	a1, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x7f0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x680
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	lw	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7c8
+               	addiw	t1, t1, -0x690
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	lw	a3, 0x0(a1)
-               	and	a1, a2, a3
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x7d0
+               	or	a1, a2, a3
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x698
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
                	sw	a1, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x7f0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x680
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	lw	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7c8
+               	addiw	t1, t1, -0x690
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	lw	a3, 0x0(a1)
-               	and	a1, a2, a3
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x7d0
+               	or	a1, a2, a3
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x698
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xc
                	sw	a1, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x7d8
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x650
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	lw	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x7d0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x640
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	lw	a3, 0x0(a1)
-               	or	a1, a2, a3
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x7c8
+               	and	a1, a2, a3
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x6a0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
                	sw	a1, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x7d8
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x650
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	lw	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x7d0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x640
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	lw	a3, 0x0(a1)
-               	or	a1, a2, a3
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x7c8
+               	and	a1, a2, a3
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x6a0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x4
                	sw	a1, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x7d8
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x650
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	lw	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x7d0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x640
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	lw	a3, 0x0(a1)
-               	or	a1, a2, a3
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x7c8
+               	and	a1, a2, a3
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x6a0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
                	sw	a1, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x7d8
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x650
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	lw	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x7d0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x640
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0xc
+               	lw	a3, 0x0(a1)
+               	and	a1, a2, a3
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x6a0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a2, t2, 0xc
+               	sw	a1, 0x0(a2)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x688
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	lw	a2, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x648
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	lw	a3, 0x0(a1)
+               	and	a1, a2, a3
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x6a8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a2, t2
+               	sw	a1, 0x0(a2)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x688
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x4
+               	lw	a2, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x648
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x4
+               	lw	a3, 0x0(a1)
+               	and	a1, a2, a3
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x6a8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a2, t2, 0x4
+               	sw	a1, 0x0(a2)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x688
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x8
+               	lw	a2, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x648
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x8
+               	lw	a3, 0x0(a1)
+               	and	a1, a2, a3
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x6a8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a2, t2, 0x8
+               	sw	a1, 0x0(a2)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x688
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0xc
+               	lw	a2, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x648
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0xc
+               	lw	a3, 0x0(a1)
+               	and	a1, a2, a3
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x6a8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a2, t2, 0xc
+               	sw	a1, 0x0(a2)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x6a0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	lw	a2, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x6a8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	lw	a3, 0x0(a1)
+               	or	a1, a2, a3
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x6b0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a2, t2
+               	sw	a1, 0x0(a2)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x6a0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x4
+               	lw	a2, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x6a8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x4
+               	lw	a3, 0x0(a1)
+               	or	a1, a2, a3
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x6b0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a2, t2, 0x4
+               	sw	a1, 0x0(a2)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x6a0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x8
+               	lw	a2, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x6a8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x8
+               	lw	a3, 0x0(a1)
+               	or	a1, a2, a3
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x6b0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a2, t2, 0x8
+               	sw	a1, 0x0(a2)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x6a0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0xc
+               	lw	a2, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x6a8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	lw	a3, 0x0(a1)
                	or	a1, a2, a3
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x7c8
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x6b0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xc
                	sw	a1, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x7e0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x698
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	flw	ft0, 0x0(a1)
                	fmv.s	fa0, ft0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x52fc>
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x7e0
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x4db4>
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x698
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	flw	ft0, 0x0(a1)
                	fmv.s	fa0, ft0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x5320>
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x7e0
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x4dd8>
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x698
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	flw	ft0, 0x0(a1)
                	fmv.s	fa0, ft0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x5344>
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x7e0
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x4dfc>
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x698
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	flw	ft0, 0x0(a1)
                	fmv.s	fa0, ft0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x5368>
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x7c8
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x4e20>
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x6b0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	flw	ft0, 0x0(a1)
                	fmv.s	fa0, ft0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x538c>
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x7c8
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x4e44>
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x6b0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	flw	ft0, 0x0(a1)
                	fmv.s	fa0, ft0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x53b0>
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x7c8
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x4e68>
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x6b0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	flw	ft0, 0x0(a1)
                	fmv.s	fa0, ft0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x53d4>
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x7c8
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x4e8c>
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x6b0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	flw	ft0, 0x0(a1)
                	fmv.s	fa0, ft0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x53f8>
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x7c8
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x4eb0>
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x6b0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	flw	ft0, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x7e0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x698
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	flw	ft1, 0x0(a1)
                	fsub.s	ft2, ft0, ft1
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x7c0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x6b8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	fsw	ft2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x7c8
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x6b0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	flw	ft0, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x7e0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x698
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	flw	ft1, 0x0(a1)
                	fsub.s	ft2, ft0, ft1
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x7c0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x6b8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	fsw	ft2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x7c8
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x6b0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	flw	ft0, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x7e0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x698
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	flw	ft1, 0x0(a1)
                	fsub.s	ft2, ft0, ft1
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x7c0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x6b8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	fsw	ft2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x7c8
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x6b0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	flw	ft0, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x7e0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x698
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	flw	ft1, 0x0(a1)
                	fsub.s	ft2, ft0, ft1
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x7c0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x6b8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	fsw	ft2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x7c0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x6b8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	flw	ft0, 0x0(a1)
                	fmv.s	fa0, ft0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x554c>
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x7c0
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x5004>
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x6b8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	flw	ft0, 0x0(a1)
                	fmv.s	fa0, ft0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x5570>
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x7c0
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x5028>
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x6b8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	flw	ft0, 0x0(a1)
                	fmv.s	fa0, ft0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x5594>
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x7c0
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x504c>
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x6b8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	flw	ft0, 0x0(a1)
                	fmv.s	fa0, ft0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x55b8>
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x5070>
                	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x6e0
+               	addiw	t0, t0, -0x560
                	add	a1, s0, t0
                	mv	a2, a1
                	lui	t0, 0x3ff8
@@ -5845,22 +5507,22 @@ Disassembly of section .text:
                	sd	t0, 0x0(a2)
                	mv	a2, a1
                	fld	ft0, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x7b8
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x6c0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
                	fsd	ft0, 0x0(a2)
                	addi	a2, a1, 0x8
                	fld	ft0, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x7b8
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x6c0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	fsd	ft0, 0x0(a1)
                	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x6f0
+               	addiw	t0, t0, -0x570
                	add	a1, s0, t0
                	mv	a2, a1
                	lui	t0, 0x4004
@@ -5872,70 +5534,70 @@ Disassembly of section .text:
                	sd	zero, 0x0(a2)
                	mv	a2, a1
                	fld	ft0, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x7b0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x6c8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
                	fsd	ft0, 0x0(a2)
                	addi	a2, a1, 0x8
                	fld	ft0, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x7b0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x6c8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	fsd	ft0, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x7b8
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x6c0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	fld	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x738
+               	addiw	t1, t1, -0x5b8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	fcvt.d.lu	ft1, t2
                	fadd.d	ft2, ft0, ft1
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x7b8
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x6c0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	fld	ft0, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x7a8
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x6d0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	fsd	ft0, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x7b8
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x6c0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	fld	ft0, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x7a8
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x6d0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	fsd	ft0, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x7a8
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x6d0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	fsd	ft2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x7a8
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x6d0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	fld	ft0, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x7b0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x6c8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
@@ -5944,20 +5606,20 @@ Disassembly of section .text:
                	zext.b	a2, a1
                	li	t1, 0x0
                	sub	a1, t1, a2
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x7a0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x6d8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
                	sd	a1, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x7a8
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x6d0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	fld	ft0, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x7b0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x6c8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
@@ -5966,38 +5628,38 @@ Disassembly of section .text:
                	zext.b	a2, a1
                	li	t1, 0x0
                	sub	a1, t1, a2
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x7a0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x6d8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
                	sd	a1, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x7a0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x6d8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	ld	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x581c>
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x7a0
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x52d4>
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x6d8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	ld	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x5840>
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x7a8
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x52f8>
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x6d0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	fld	ft0, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x7b0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x6c8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
@@ -6006,20 +5668,20 @@ Disassembly of section .text:
                	zext.b	a2, a1
                	li	t1, 0x0
                	sub	a1, t1, a2
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x798
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x6e0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
                	sd	a1, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x7a8
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x6d0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	fld	ft0, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x7b0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x6c8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
@@ -6028,38 +5690,38 @@ Disassembly of section .text:
                	zext.b	a2, a1
                	li	t1, 0x0
                	sub	a1, t1, a2
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x798
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x6e0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
                	sd	a1, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x798
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x6e0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	ld	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x5914>
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x798
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x53cc>
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x6e0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	ld	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x5938>
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x7a8
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x53f0>
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x6d0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	fld	ft0, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x7b0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x6c8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
@@ -6069,20 +5731,20 @@ Disassembly of section .text:
                	zext.b	a2, a1
                	li	t1, 0x0
                	sub	a1, t1, a2
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x790
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x6e8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
                	sd	a1, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x7a8
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x6d0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	fld	ft0, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x7b0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x6c8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
@@ -6092,38 +5754,38 @@ Disassembly of section .text:
                	zext.b	a2, a1
                	li	t1, 0x0
                	sub	a1, t1, a2
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x790
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x6e8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
                	sd	a1, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x790
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x6e8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	ld	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x5a14>
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x790
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x54cc>
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x6e8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	ld	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x5a38>
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x7b0
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x54f0>
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x6c8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	fld	ft0, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x7a8
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x6d0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
@@ -6132,20 +5794,20 @@ Disassembly of section .text:
                	zext.b	a2, a1
                	li	t1, 0x0
                	sub	a1, t1, a2
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x788
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x6f0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
                	sd	a1, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x7b0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x6c8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	fld	ft0, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x7a8
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x6d0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
@@ -6154,32 +5816,32 @@ Disassembly of section .text:
                	zext.b	a2, a1
                	li	t1, 0x0
                	sub	a1, t1, a2
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x788
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x6f0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
                	sd	a1, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x788
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x6f0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	ld	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x5b0c>
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x788
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x55c4>
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x6f0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	ld	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x5b30>
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x55e8>
                	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x700
+               	addiw	t0, t0, -0x580
                	add	a1, s0, t0
                	mv	a2, a1
                	li	t0, 0x1
@@ -6208,70 +5870,70 @@ Disassembly of section .text:
                	sh	t0, 0x0(a2)
                	mv	a2, a1
                	lhu	a3, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x780
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x6f8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
                	sh	a3, 0x0(a2)
                	addi	a2, a1, 0x2
                	lhu	a3, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x780
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x6f8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x2
                	sh	a3, 0x0(a2)
                	addi	a2, a1, 0x4
                	lhu	a3, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x780
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x6f8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x4
                	sh	a3, 0x0(a2)
                	addi	a2, a1, 0x6
                	lhu	a3, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x780
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x6f8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x6
                	sh	a3, 0x0(a2)
                	addi	a2, a1, 0x8
                	lhu	a3, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x780
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x6f8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
                	sh	a3, 0x0(a2)
                	addi	a2, a1, 0xa
                	lhu	a3, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x780
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x6f8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xa
                	sh	a3, 0x0(a2)
                	addi	a2, a1, 0xc
                	lhu	a3, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x780
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x6f8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xc
                	sh	a3, 0x0(a2)
                	addi	a2, a1, 0xe
                	lhu	a1, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x780
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x6f8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xe
                	sh	a1, 0x0(a2)
                	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x710
+               	addiw	t0, t0, -0x590
                	add	a1, s0, t0
                	mv	a2, a1
                	li	t0, 0x2
@@ -6302,302 +5964,302 @@ Disassembly of section .text:
                	sh	t0, 0x0(a2)
                	mv	a2, a1
                	lhu	a3, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x778
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x700
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
                	sh	a3, 0x0(a2)
                	addi	a2, a1, 0x2
                	lhu	a3, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x778
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x700
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x2
                	sh	a3, 0x0(a2)
                	addi	a2, a1, 0x4
                	lhu	a3, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x778
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x700
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x4
                	sh	a3, 0x0(a2)
                	addi	a2, a1, 0x6
                	lhu	a3, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x778
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x700
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x6
                	sh	a3, 0x0(a2)
                	addi	a2, a1, 0x8
                	lhu	a3, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x778
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x700
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
                	sh	a3, 0x0(a2)
                	addi	a2, a1, 0xa
                	lhu	a3, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x778
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x700
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xa
                	sh	a3, 0x0(a2)
                	addi	a2, a1, 0xc
                	lhu	a3, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x778
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x700
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xc
                	sh	a3, 0x0(a2)
                	addi	a2, a1, 0xe
                	lhu	a1, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x778
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x700
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xe
                	sh	a1, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x780
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x6f8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	lhu	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x6c0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x7b8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addw	a1, a2, t2
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x780
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x6f8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
                	lhu	a3, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x770
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x708
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
                	sh	a3, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x780
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x6f8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x2
                	lhu	a3, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x770
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x708
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x2
                	sh	a3, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x780
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x6f8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x4
                	lhu	a3, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x770
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x708
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x4
                	sh	a3, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x780
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x6f8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x6
                	lhu	a3, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x770
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x708
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x6
                	sh	a3, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x780
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x6f8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
                	lhu	a3, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x770
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x708
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
                	sh	a3, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x780
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x6f8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xa
                	lhu	a3, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x770
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x708
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xa
                	sh	a3, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x780
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x6f8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xc
                	lhu	a3, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x770
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x708
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xc
                	sh	a3, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x780
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x6f8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xe
                	lhu	a3, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x770
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x708
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xe
                	sh	a3, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x770
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x708
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
                	sh	a1, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x778
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x700
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xe
                	lhu	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x6c0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x7b8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addw	a1, a2, t2
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x778
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x700
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
                	lhu	a3, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x768
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x710
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
                	sh	a3, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x778
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x700
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x2
                	lhu	a3, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x768
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x710
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x2
                	sh	a3, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x778
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x700
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x4
                	lhu	a3, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x768
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x710
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x4
                	sh	a3, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x778
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x700
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x6
                	lhu	a3, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x768
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x710
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x6
                	sh	a3, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x778
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x700
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
                	lhu	a3, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x768
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x710
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
                	sh	a3, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x778
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x700
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xa
                	lhu	a3, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x768
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x710
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xa
                	sh	a3, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x778
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x700
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xc
                	lhu	a3, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x768
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x710
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xc
                	sh	a3, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x778
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x700
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xe
                	lhu	a3, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x768
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x710
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xe
                	sh	a3, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x768
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x710
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xe
                	sh	a1, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x770
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x708
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	lhu	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x768
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x710
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
@@ -6610,20 +6272,20 @@ Disassembly of section .text:
                	zext.b	a2, a1
                	li	t1, 0x0
                	subw	a1, t1, a2
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x760
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x718
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
                	sh	a1, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x770
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x708
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x2
                	lhu	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x768
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x710
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x2
@@ -6636,20 +6298,20 @@ Disassembly of section .text:
                	zext.b	a2, a1
                	li	t1, 0x0
                	subw	a1, t1, a2
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x760
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x718
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x2
                	sh	a1, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x770
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x708
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	lhu	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x768
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x710
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
@@ -6662,20 +6324,20 @@ Disassembly of section .text:
                	zext.b	a2, a1
                	li	t1, 0x0
                	subw	a1, t1, a2
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x760
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x718
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x4
                	sh	a1, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x770
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x708
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x6
                	lhu	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x768
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x710
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x6
@@ -6688,20 +6350,20 @@ Disassembly of section .text:
                	zext.b	a2, a1
                	li	t1, 0x0
                	subw	a1, t1, a2
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x760
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x718
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x6
                	sh	a1, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x770
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x708
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	lhu	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x768
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x710
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
@@ -6714,20 +6376,20 @@ Disassembly of section .text:
                	zext.b	a2, a1
                	li	t1, 0x0
                	subw	a1, t1, a2
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x760
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x718
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
                	sh	a1, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x770
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x708
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xa
                	lhu	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x768
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x710
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xa
@@ -6740,20 +6402,20 @@ Disassembly of section .text:
                	zext.b	a2, a1
                	li	t1, 0x0
                	subw	a1, t1, a2
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x760
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x718
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xa
                	sh	a1, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x770
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x708
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	lhu	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x768
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x710
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
@@ -6766,20 +6428,20 @@ Disassembly of section .text:
                	zext.b	a2, a1
                	li	t1, 0x0
                	subw	a1, t1, a2
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x760
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x718
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xc
                	sh	a1, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x770
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x708
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xe
                	lhu	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x768
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x710
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xe
@@ -6792,92 +6454,92 @@ Disassembly of section .text:
                	zext.b	a2, a1
                	li	t1, 0x0
                	subw	a1, t1, a2
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x760
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x718
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xe
                	sh	a1, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x760
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x718
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x6504>
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x760
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x5fbc>
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x718
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x2
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x6528>
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x760
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x5fe0>
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x718
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x654c>
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x760
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x6004>
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x718
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x6
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x6570>
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x760
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x6028>
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x718
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x6594>
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x760
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x604c>
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x718
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xa
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x65b8>
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x760
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x6070>
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x718
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x65dc>
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x760
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x6094>
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x718
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xe
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x6600>
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x770
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x60b8>
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x708
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	lhu	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x768
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x710
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
@@ -6891,20 +6553,20 @@ Disassembly of section .text:
                	zext.b	a2, a1
                	li	t1, 0x0
                	subw	a1, t1, a2
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x758
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x720
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
                	sh	a1, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x770
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x708
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x2
                	lhu	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x768
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x710
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x2
@@ -6918,20 +6580,20 @@ Disassembly of section .text:
                	zext.b	a2, a1
                	li	t1, 0x0
                	subw	a1, t1, a2
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x758
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x720
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x2
                	sh	a1, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x770
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x708
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	lhu	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x768
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x710
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
@@ -6945,20 +6607,20 @@ Disassembly of section .text:
                	zext.b	a2, a1
                	li	t1, 0x0
                	subw	a1, t1, a2
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x758
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x720
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x4
                	sh	a1, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x770
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x708
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x6
                	lhu	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x768
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x710
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x6
@@ -6972,20 +6634,20 @@ Disassembly of section .text:
                	zext.b	a2, a1
                	li	t1, 0x0
                	subw	a1, t1, a2
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x758
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x720
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x6
                	sh	a1, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x770
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x708
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	lhu	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x768
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x710
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
@@ -6999,20 +6661,20 @@ Disassembly of section .text:
                	zext.b	a2, a1
                	li	t1, 0x0
                	subw	a1, t1, a2
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x758
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x720
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
                	sh	a1, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x770
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x708
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xa
                	lhu	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x768
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x710
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xa
@@ -7026,20 +6688,20 @@ Disassembly of section .text:
                	zext.b	a2, a1
                	li	t1, 0x0
                	subw	a1, t1, a2
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x758
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x720
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xa
                	sh	a1, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x770
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x708
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	lhu	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x768
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x710
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
@@ -7053,20 +6715,20 @@ Disassembly of section .text:
                	zext.b	a2, a1
                	li	t1, 0x0
                	subw	a1, t1, a2
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x758
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x720
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xc
                	sh	a1, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x770
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x708
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xe
                	lhu	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x768
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x710
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xe
@@ -7080,92 +6742,92 @@ Disassembly of section .text:
                	zext.b	a2, a1
                	li	t1, 0x0
                	subw	a1, t1, a2
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x758
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x720
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xe
                	sh	a1, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x758
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x720
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x6984>
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x758
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x643c>
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x720
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x2
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x69a8>
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x758
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x6460>
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x720
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x69cc>
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x758
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x6484>
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x720
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x6
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x69f0>
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x758
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x64a8>
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x720
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x6a14>
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x758
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x64cc>
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x720
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xa
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x6a38>
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x758
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x64f0>
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x720
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x6a5c>
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x758
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x6514>
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x720
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xe
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x6a80>
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x768
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x6538>
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x710
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	lhu	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x770
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x708
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
@@ -7178,20 +6840,20 @@ Disassembly of section .text:
                	zext.b	a2, a1
                	li	t1, 0x0
                	subw	a1, t1, a2
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x750
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x728
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
                	sh	a1, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x768
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x710
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x2
                	lhu	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x770
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x708
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x2
@@ -7204,20 +6866,20 @@ Disassembly of section .text:
                	zext.b	a2, a1
                	li	t1, 0x0
                	subw	a1, t1, a2
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x750
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x728
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x2
                	sh	a1, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x768
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x710
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	lhu	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x770
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x708
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
@@ -7230,20 +6892,20 @@ Disassembly of section .text:
                	zext.b	a2, a1
                	li	t1, 0x0
                	subw	a1, t1, a2
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x750
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x728
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x4
                	sh	a1, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x768
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x710
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x6
                	lhu	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x770
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x708
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x6
@@ -7256,20 +6918,20 @@ Disassembly of section .text:
                	zext.b	a2, a1
                	li	t1, 0x0
                	subw	a1, t1, a2
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x750
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x728
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x6
                	sh	a1, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x768
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x710
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	lhu	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x770
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x708
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
@@ -7282,20 +6944,20 @@ Disassembly of section .text:
                	zext.b	a2, a1
                	li	t1, 0x0
                	subw	a1, t1, a2
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x750
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x728
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
                	sh	a1, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x768
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x710
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xa
                	lhu	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x770
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x708
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xa
@@ -7308,20 +6970,20 @@ Disassembly of section .text:
                	zext.b	a2, a1
                	li	t1, 0x0
                	subw	a1, t1, a2
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x750
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x728
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xa
                	sh	a1, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x768
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x710
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	lhu	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x770
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x708
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
@@ -7334,20 +6996,20 @@ Disassembly of section .text:
                	zext.b	a2, a1
                	li	t1, 0x0
                	subw	a1, t1, a2
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x750
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x728
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xc
                	sh	a1, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x768
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x710
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xe
                	lhu	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x770
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x708
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xe
@@ -7360,92 +7022,92 @@ Disassembly of section .text:
                	zext.b	a2, a1
                	li	t1, 0x0
                	subw	a1, t1, a2
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x750
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x728
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xe
                	sh	a1, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x750
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x728
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x6de4>
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x750
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x689c>
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x728
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x2
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x6e08>
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x750
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x68c0>
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x728
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x6e2c>
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x750
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x68e4>
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x728
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x6
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x6e50>
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x750
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x6908>
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x728
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x6e74>
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x750
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x692c>
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x728
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xa
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x6e98>
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x750
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x6950>
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x728
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x6ebc>
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x750
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x6974>
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x728
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xe
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x6ee0>
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x770
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x6998>
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x708
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	lhu	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x768
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x710
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
@@ -7458,20 +7120,20 @@ Disassembly of section .text:
                	zext.b	a2, a1
                	li	t1, 0x0
                	subw	a1, t1, a2
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x748
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x730
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
                	sh	a1, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x770
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x708
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x2
                	lhu	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x768
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x710
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x2
@@ -7484,20 +7146,20 @@ Disassembly of section .text:
                	zext.b	a2, a1
                	li	t1, 0x0
                	subw	a1, t1, a2
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x748
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x730
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x2
                	sh	a1, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x770
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x708
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	lhu	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x768
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x710
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
@@ -7510,20 +7172,20 @@ Disassembly of section .text:
                	zext.b	a2, a1
                	li	t1, 0x0
                	subw	a1, t1, a2
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x748
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x730
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x4
                	sh	a1, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x770
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x708
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x6
                	lhu	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x768
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x710
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x6
@@ -7536,20 +7198,20 @@ Disassembly of section .text:
                	zext.b	a2, a1
                	li	t1, 0x0
                	subw	a1, t1, a2
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x748
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x730
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x6
                	sh	a1, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x770
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x708
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	lhu	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x768
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x710
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
@@ -7562,20 +7224,20 @@ Disassembly of section .text:
                	zext.b	a2, a1
                	li	t1, 0x0
                	subw	a1, t1, a2
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x748
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x730
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
                	sh	a1, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x770
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x708
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xa
                	lhu	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x768
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x710
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xa
@@ -7588,20 +7250,20 @@ Disassembly of section .text:
                	zext.b	a2, a1
                	li	t1, 0x0
                	subw	a1, t1, a2
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x748
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x730
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xa
                	sh	a1, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x770
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x708
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	lhu	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x768
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x710
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
@@ -7614,20 +7276,20 @@ Disassembly of section .text:
                	zext.b	a2, a1
                	li	t1, 0x0
                	subw	a1, t1, a2
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x748
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x730
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xc
                	sh	a1, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x770
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x708
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xe
                	lhu	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x768
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x710
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xe
@@ -7640,646 +7302,646 @@ Disassembly of section .text:
                	zext.b	a2, a1
                	li	t1, 0x0
                	subw	a1, t1, a2
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x748
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x730
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xe
                	sh	a1, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x748
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x730
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	lhu	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x770
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x708
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	lhu	a3, 0x0(a1)
                	and	a1, a2, a3
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x740
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x738
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
                	sh	a1, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x748
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x730
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x2
                	lhu	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x770
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x708
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x2
                	lhu	a3, 0x0(a1)
                	and	a1, a2, a3
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x740
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x738
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x2
                	sh	a1, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x748
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x730
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	lhu	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x770
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x708
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	lhu	a3, 0x0(a1)
                	and	a1, a2, a3
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x740
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x738
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x4
                	sh	a1, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x748
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x730
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x6
                	lhu	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x770
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x708
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x6
                	lhu	a3, 0x0(a1)
                	and	a1, a2, a3
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x740
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x738
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x6
                	sh	a1, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x748
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x730
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	lhu	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x770
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x708
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	lhu	a3, 0x0(a1)
                	and	a1, a2, a3
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x740
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x738
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
                	sh	a1, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x748
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x730
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xa
                	lhu	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x770
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x708
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xa
                	lhu	a3, 0x0(a1)
                	and	a1, a2, a3
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x740
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x738
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xa
                	sh	a1, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x748
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x730
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	lhu	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x770
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x708
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	lhu	a3, 0x0(a1)
                	and	a1, a2, a3
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x740
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x738
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xc
                	sh	a1, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x748
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x730
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xe
                	lhu	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x770
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x708
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xe
                	lhu	a3, 0x0(a1)
                	and	a1, a2, a3
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x740
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x738
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xe
                	sh	a1, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x748
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x730
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	lhu	a2, 0x0(a1)
                	not	a1, a2
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x738
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x740
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
                	sh	a1, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x748
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x730
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x2
                	lhu	a2, 0x0(a1)
                	not	a1, a2
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x738
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x740
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x2
                	sh	a1, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x748
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x730
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	lhu	a2, 0x0(a1)
                	not	a1, a2
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x738
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x740
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x4
                	sh	a1, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x748
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x730
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x6
                	lhu	a2, 0x0(a1)
                	not	a1, a2
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x738
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x740
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x6
                	sh	a1, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x748
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x730
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	lhu	a2, 0x0(a1)
                	not	a1, a2
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x738
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x740
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
                	sh	a1, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x748
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x730
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xa
                	lhu	a2, 0x0(a1)
                	not	a1, a2
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x738
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x740
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xa
                	sh	a1, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x748
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x730
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	lhu	a2, 0x0(a1)
                	not	a1, a2
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x738
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x740
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xc
                	sh	a1, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x748
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x730
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xe
                	lhu	a2, 0x0(a1)
                	not	a1, a2
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x738
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x740
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xe
                	sh	a1, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x738
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x740
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	lhu	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x768
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x710
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	lhu	a3, 0x0(a1)
                	and	a1, a2, a3
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x730
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x748
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
                	sh	a1, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x738
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x740
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x2
                	lhu	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x768
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x710
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x2
                	lhu	a3, 0x0(a1)
                	and	a1, a2, a3
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x730
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x748
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x2
                	sh	a1, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x738
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x740
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	lhu	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x768
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x710
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	lhu	a3, 0x0(a1)
                	and	a1, a2, a3
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x730
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x748
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x4
                	sh	a1, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x738
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x740
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x6
                	lhu	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x768
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x710
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x6
                	lhu	a3, 0x0(a1)
                	and	a1, a2, a3
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x730
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x748
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x6
                	sh	a1, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x738
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x740
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	lhu	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x768
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x710
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	lhu	a3, 0x0(a1)
                	and	a1, a2, a3
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x730
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x748
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
                	sh	a1, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x738
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x740
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xa
                	lhu	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x768
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x710
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xa
                	lhu	a3, 0x0(a1)
                	and	a1, a2, a3
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x730
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x748
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xa
                	sh	a1, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x738
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x740
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	lhu	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x768
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x710
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	lhu	a3, 0x0(a1)
                	and	a1, a2, a3
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x730
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x748
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xc
                	sh	a1, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x738
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x740
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xe
                	lhu	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x768
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x710
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xe
                	lhu	a3, 0x0(a1)
                	and	a1, a2, a3
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x730
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x748
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xe
                	sh	a1, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x740
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x738
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	lhu	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x730
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x748
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	lhu	a3, 0x0(a1)
                	or	a1, a2, a3
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x728
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x750
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
                	sh	a1, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x740
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x738
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x2
                	lhu	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x730
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x748
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x2
                	lhu	a3, 0x0(a1)
                	or	a1, a2, a3
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x728
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x750
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x2
                	sh	a1, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x740
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x738
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	lhu	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x730
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x748
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	lhu	a3, 0x0(a1)
                	or	a1, a2, a3
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x728
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x750
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x4
                	sh	a1, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x740
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x738
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x6
                	lhu	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x730
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x748
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x6
                	lhu	a3, 0x0(a1)
                	or	a1, a2, a3
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x728
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x750
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x6
                	sh	a1, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x740
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x738
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	lhu	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x730
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x748
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	lhu	a3, 0x0(a1)
                	or	a1, a2, a3
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x728
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x750
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
                	sh	a1, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x740
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x738
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xa
                	lhu	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x730
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x748
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xa
                	lhu	a3, 0x0(a1)
                	or	a1, a2, a3
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x728
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x750
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xa
                	sh	a1, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x740
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x738
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	lhu	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x730
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x748
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	lhu	a3, 0x0(a1)
                	or	a1, a2, a3
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x728
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x750
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xc
                	sh	a1, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x740
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x738
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xe
                	lhu	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x730
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x748
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xe
                	lhu	a3, 0x0(a1)
                	or	a1, a2, a3
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x728
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x750
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xe
                	sh	a1, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x728
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x750
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x7b04>
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x728
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x75bc>
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x750
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x2
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x7b28>
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x728
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x75e0>
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x750
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x7b4c>
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x728
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x7604>
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x750
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x6
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x7b70>
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x728
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x7628>
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x750
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x7b94>
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x728
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x764c>
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x750
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xa
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x7bb8>
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x728
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x7670>
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x750
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x7bdc>
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x728
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x7694>
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x750
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xe
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x7c00>
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x76b8>
                	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x720
+               	addiw	t0, t0, -0x5a0
                	add	a1, s0, t0
                	mv	a2, a1
                	li	t0, 0x1
@@ -8330,134 +7992,134 @@ Disassembly of section .text:
                	sb	t0, 0x0(a2)
                	mv	a2, a1
                	lbu	a3, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x720
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x758
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
                	sb	a3, 0x0(a2)
                	addi	a2, a1, 0x1
                	lbu	a3, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x720
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x758
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x1
                	sb	a3, 0x0(a2)
                	addi	a2, a1, 0x2
                	lbu	a3, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x720
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x758
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x2
                	sb	a3, 0x0(a2)
                	addi	a2, a1, 0x3
                	lbu	a3, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x720
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x758
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x3
                	sb	a3, 0x0(a2)
                	addi	a2, a1, 0x4
                	lbu	a3, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x720
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x758
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x4
                	sb	a3, 0x0(a2)
                	addi	a2, a1, 0x5
                	lbu	a3, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x720
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x758
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x5
                	sb	a3, 0x0(a2)
                	addi	a2, a1, 0x6
                	lbu	a3, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x720
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x758
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x6
                	sb	a3, 0x0(a2)
                	addi	a2, a1, 0x7
                	lbu	a3, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x720
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x758
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x7
                	sb	a3, 0x0(a2)
                	addi	a2, a1, 0x8
                	lbu	a3, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x720
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x758
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
                	sb	a3, 0x0(a2)
                	addi	a2, a1, 0x9
                	lbu	a3, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x720
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x758
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x9
                	sb	a3, 0x0(a2)
                	addi	a2, a1, 0xa
                	lbu	a3, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x720
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x758
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xa
                	sb	a3, 0x0(a2)
                	addi	a2, a1, 0xb
                	lbu	a3, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x720
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x758
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xb
                	sb	a3, 0x0(a2)
                	addi	a2, a1, 0xc
                	lbu	a3, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x720
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x758
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xc
                	sb	a3, 0x0(a2)
                	addi	a2, a1, 0xd
                	lbu	a3, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x720
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x758
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xd
                	sb	a3, 0x0(a2)
                	addi	a2, a1, 0xe
                	lbu	a3, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x720
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x758
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xe
                	sb	a3, 0x0(a2)
                	addi	a2, a1, 0xf
                	lbu	a1, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x720
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x758
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xf
                	sb	a1, 0x0(a2)
                	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x730
+               	addiw	t0, t0, -0x5b0
                	add	a1, s0, t0
                	mv	a2, a1
                	li	t0, 0x2
@@ -8509,558 +8171,558 @@ Disassembly of section .text:
                	sb	t0, 0x0(a2)
                	mv	a2, a1
                	lbu	a3, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x718
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x760
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
                	sb	a3, 0x0(a2)
                	addi	a2, a1, 0x1
                	lbu	a3, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x718
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x760
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x1
                	sb	a3, 0x0(a2)
                	addi	a2, a1, 0x2
                	lbu	a3, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x718
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x760
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x2
                	sb	a3, 0x0(a2)
                	addi	a2, a1, 0x3
                	lbu	a3, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x718
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x760
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x3
                	sb	a3, 0x0(a2)
                	addi	a2, a1, 0x4
                	lbu	a3, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x718
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x760
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x4
                	sb	a3, 0x0(a2)
                	addi	a2, a1, 0x5
                	lbu	a3, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x718
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x760
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x5
                	sb	a3, 0x0(a2)
                	addi	a2, a1, 0x6
                	lbu	a3, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x718
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x760
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x6
                	sb	a3, 0x0(a2)
                	addi	a2, a1, 0x7
                	lbu	a3, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x718
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x760
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x7
                	sb	a3, 0x0(a2)
                	addi	a2, a1, 0x8
                	lbu	a3, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x718
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x760
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
                	sb	a3, 0x0(a2)
                	addi	a2, a1, 0x9
                	lbu	a3, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x718
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x760
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x9
                	sb	a3, 0x0(a2)
                	addi	a2, a1, 0xa
                	lbu	a3, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x718
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x760
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xa
                	sb	a3, 0x0(a2)
                	addi	a2, a1, 0xb
                	lbu	a3, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x718
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x760
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xb
                	sb	a3, 0x0(a2)
                	addi	a2, a1, 0xc
                	lbu	a3, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x718
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x760
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xc
                	sb	a3, 0x0(a2)
                	addi	a2, a1, 0xd
                	lbu	a3, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x718
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x760
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xd
                	sb	a3, 0x0(a2)
                	addi	a2, a1, 0xe
                	lbu	a3, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x718
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x760
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xe
                	sb	a3, 0x0(a2)
                	addi	a2, a1, 0xf
                	lbu	a1, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x718
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x760
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xf
                	sb	a1, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x720
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x758
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	lbu	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x6b8
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x7c0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addw	a1, a2, t2
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x720
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x758
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
                	lbu	a3, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x710
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x768
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
                	sb	a3, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x720
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x758
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x1
                	lbu	a3, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x710
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x768
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x1
                	sb	a3, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x720
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x758
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x2
                	lbu	a3, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x710
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x768
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x2
                	sb	a3, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x720
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x758
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x3
                	lbu	a3, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x710
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x768
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x3
                	sb	a3, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x720
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x758
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x4
                	lbu	a3, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x710
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x768
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x4
                	sb	a3, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x720
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x758
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x5
                	lbu	a3, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x710
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x768
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x5
                	sb	a3, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x720
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x758
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x6
                	lbu	a3, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x710
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x768
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x6
                	sb	a3, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x720
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x758
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x7
                	lbu	a3, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x710
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x768
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x7
                	sb	a3, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x720
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x758
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
                	lbu	a3, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x710
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x768
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
                	sb	a3, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x720
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x758
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x9
                	lbu	a3, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x710
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x768
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x9
                	sb	a3, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x720
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x758
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xa
                	lbu	a3, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x710
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x768
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xa
                	sb	a3, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x720
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x758
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xb
                	lbu	a3, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x710
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x768
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xb
                	sb	a3, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x720
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x758
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xc
                	lbu	a3, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x710
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x768
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xc
                	sb	a3, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x720
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x758
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xd
                	lbu	a3, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x710
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x768
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xd
                	sb	a3, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x720
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x758
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xe
                	lbu	a3, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x710
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x768
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xe
                	sb	a3, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x720
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x758
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xf
                	lbu	a3, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x710
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x768
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xf
                	sb	a3, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x710
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x768
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
                	sb	a1, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x718
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x760
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xf
                	lbu	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x6b8
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x7c0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addw	a1, a2, t2
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x718
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x760
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
                	lbu	a3, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x708
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x770
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
                	sb	a3, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x718
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x760
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x1
                	lbu	a3, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x708
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x770
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x1
                	sb	a3, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x718
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x760
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x2
                	lbu	a3, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x708
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x770
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x2
                	sb	a3, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x718
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x760
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x3
                	lbu	a3, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x708
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x770
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x3
                	sb	a3, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x718
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x760
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x4
                	lbu	a3, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x708
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x770
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x4
                	sb	a3, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x718
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x760
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x5
                	lbu	a3, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x708
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x770
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x5
                	sb	a3, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x718
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x760
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x6
                	lbu	a3, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x708
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x770
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x6
                	sb	a3, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x718
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x760
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x7
                	lbu	a3, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x708
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x770
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x7
                	sb	a3, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x718
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x760
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
                	lbu	a3, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x708
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x770
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
                	sb	a3, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x718
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x760
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x9
                	lbu	a3, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x708
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x770
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x9
                	sb	a3, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x718
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x760
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xa
                	lbu	a3, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x708
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x770
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xa
                	sb	a3, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x718
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x760
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xb
                	lbu	a3, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x708
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x770
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xb
                	sb	a3, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x718
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x760
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xc
                	lbu	a3, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x708
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x770
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xc
                	sb	a3, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x718
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x760
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xd
                	lbu	a3, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x708
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x770
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xd
                	sb	a3, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x718
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x760
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xe
                	lbu	a3, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x708
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x770
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xe
                	sb	a3, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x718
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x760
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xf
                	lbu	a3, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x708
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x770
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xf
                	sb	a3, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x708
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x770
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xf
                	sb	a1, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x710
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x768
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	lbu	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x708
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x770
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
@@ -9070,20 +8732,20 @@ Disassembly of section .text:
                	sltu	a1, t1, t0
                	li	t1, 0x0
                	subw	a2, t1, a1
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x700
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x778
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	sb	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x710
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x768
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x1
                	lbu	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x708
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x770
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x1
@@ -9093,20 +8755,20 @@ Disassembly of section .text:
                	sltu	a1, t1, t0
                	li	t1, 0x0
                	subw	a2, t1, a1
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x700
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x778
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x1
                	sb	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x710
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x768
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x2
                	lbu	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x708
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x770
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x2
@@ -9116,20 +8778,20 @@ Disassembly of section .text:
                	sltu	a1, t1, t0
                	li	t1, 0x0
                	subw	a2, t1, a1
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x700
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x778
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x2
                	sb	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x710
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x768
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x3
                	lbu	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x708
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x770
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x3
@@ -9139,20 +8801,20 @@ Disassembly of section .text:
                	sltu	a1, t1, t0
                	li	t1, 0x0
                	subw	a2, t1, a1
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x700
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x778
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x3
                	sb	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x710
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x768
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	lbu	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x708
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x770
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
@@ -9162,20 +8824,20 @@ Disassembly of section .text:
                	sltu	a1, t1, t0
                	li	t1, 0x0
                	subw	a2, t1, a1
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x700
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x778
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	sb	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x710
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x768
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x5
                	lbu	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x708
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x770
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x5
@@ -9185,20 +8847,20 @@ Disassembly of section .text:
                	sltu	a1, t1, t0
                	li	t1, 0x0
                	subw	a2, t1, a1
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x700
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x778
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x5
                	sb	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x710
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x768
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x6
                	lbu	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x708
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x770
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x6
@@ -9208,20 +8870,20 @@ Disassembly of section .text:
                	sltu	a1, t1, t0
                	li	t1, 0x0
                	subw	a2, t1, a1
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x700
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x778
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x6
                	sb	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x710
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x768
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x7
                	lbu	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x708
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x770
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x7
@@ -9231,20 +8893,20 @@ Disassembly of section .text:
                	sltu	a1, t1, t0
                	li	t1, 0x0
                	subw	a2, t1, a1
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x700
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x778
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x7
                	sb	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x710
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x768
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	lbu	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x708
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x770
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
@@ -9254,20 +8916,20 @@ Disassembly of section .text:
                	sltu	a1, t1, t0
                	li	t1, 0x0
                	subw	a2, t1, a1
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x700
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x778
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	sb	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x710
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x768
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x9
                	lbu	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x708
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x770
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x9
@@ -9277,20 +8939,20 @@ Disassembly of section .text:
                	sltu	a1, t1, t0
                	li	t1, 0x0
                	subw	a2, t1, a1
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x700
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x778
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x9
                	sb	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x710
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x768
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xa
                	lbu	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x708
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x770
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xa
@@ -9300,20 +8962,20 @@ Disassembly of section .text:
                	sltu	a1, t1, t0
                	li	t1, 0x0
                	subw	a2, t1, a1
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x700
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x778
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xa
                	sb	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x710
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x768
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xb
                	lbu	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x708
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x770
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xb
@@ -9323,20 +8985,20 @@ Disassembly of section .text:
                	sltu	a1, t1, t0
                	li	t1, 0x0
                	subw	a2, t1, a1
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x700
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x778
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xb
                	sb	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x710
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x768
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	lbu	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x708
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x770
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
@@ -9346,20 +9008,20 @@ Disassembly of section .text:
                	sltu	a1, t1, t0
                	li	t1, 0x0
                	subw	a2, t1, a1
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x700
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x778
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	sb	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x710
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x768
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xd
                	lbu	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x708
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x770
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xd
@@ -9369,20 +9031,20 @@ Disassembly of section .text:
                	sltu	a1, t1, t0
                	li	t1, 0x0
                	subw	a2, t1, a1
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x700
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x778
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xd
                	sb	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x710
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x768
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xe
                	lbu	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x708
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x770
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xe
@@ -9392,20 +9054,20 @@ Disassembly of section .text:
                	sltu	a1, t1, t0
                	li	t1, 0x0
                	subw	a2, t1, a1
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x700
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x778
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xe
                	sb	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x710
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x768
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xf
                	lbu	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x708
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x770
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xf
@@ -9415,27 +9077,27 @@ Disassembly of section .text:
                	sltu	a1, t1, t0
                	li	t1, 0x0
                	subw	a2, t1, a1
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x700
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x778
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xf
                	sb	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x700
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x778
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x8df8>
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x710
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x88b0>
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x768
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	lbu	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x708
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x770
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
@@ -9446,20 +9108,20 @@ Disassembly of section .text:
                	seqz	a1, a1
                	li	t1, 0x0
                	subw	a2, t1, a1
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x6f8
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x780
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	sb	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x710
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x768
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x1
                	lbu	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x708
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x770
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x1
@@ -9470,20 +9132,20 @@ Disassembly of section .text:
                	seqz	a1, a1
                	li	t1, 0x0
                	subw	a2, t1, a1
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x6f8
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x780
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x1
                	sb	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x710
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x768
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x2
                	lbu	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x708
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x770
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x2
@@ -9494,20 +9156,20 @@ Disassembly of section .text:
                	seqz	a1, a1
                	li	t1, 0x0
                	subw	a2, t1, a1
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x6f8
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x780
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x2
                	sb	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x710
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x768
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x3
                	lbu	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x708
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x770
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x3
@@ -9518,20 +9180,20 @@ Disassembly of section .text:
                	seqz	a1, a1
                	li	t1, 0x0
                	subw	a2, t1, a1
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x6f8
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x780
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x3
                	sb	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x710
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x768
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	lbu	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x708
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x770
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
@@ -9542,20 +9204,20 @@ Disassembly of section .text:
                	seqz	a1, a1
                	li	t1, 0x0
                	subw	a2, t1, a1
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x6f8
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x780
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	sb	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x710
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x768
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x5
                	lbu	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x708
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x770
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x5
@@ -9566,20 +9228,20 @@ Disassembly of section .text:
                	seqz	a1, a1
                	li	t1, 0x0
                	subw	a2, t1, a1
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x6f8
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x780
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x5
                	sb	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x710
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x768
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x6
                	lbu	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x708
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x770
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x6
@@ -9590,20 +9252,20 @@ Disassembly of section .text:
                	seqz	a1, a1
                	li	t1, 0x0
                	subw	a2, t1, a1
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x6f8
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x780
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x6
                	sb	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x710
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x768
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x7
                	lbu	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x708
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x770
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x7
@@ -9614,20 +9276,20 @@ Disassembly of section .text:
                	seqz	a1, a1
                	li	t1, 0x0
                	subw	a2, t1, a1
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x6f8
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x780
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x7
                	sb	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x710
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x768
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	lbu	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x708
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x770
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
@@ -9638,20 +9300,20 @@ Disassembly of section .text:
                	seqz	a1, a1
                	li	t1, 0x0
                	subw	a2, t1, a1
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x6f8
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x780
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	sb	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x710
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x768
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x9
                	lbu	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x708
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x770
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x9
@@ -9662,20 +9324,20 @@ Disassembly of section .text:
                	seqz	a1, a1
                	li	t1, 0x0
                	subw	a2, t1, a1
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x6f8
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x780
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x9
                	sb	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x710
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x768
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xa
                	lbu	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x708
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x770
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xa
@@ -9686,20 +9348,20 @@ Disassembly of section .text:
                	seqz	a1, a1
                	li	t1, 0x0
                	subw	a2, t1, a1
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x6f8
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x780
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xa
                	sb	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x710
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x768
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xb
                	lbu	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x708
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x770
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xb
@@ -9710,20 +9372,20 @@ Disassembly of section .text:
                	seqz	a1, a1
                	li	t1, 0x0
                	subw	a2, t1, a1
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x6f8
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x780
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xb
                	sb	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x710
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x768
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	lbu	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x708
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x770
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
@@ -9734,20 +9396,20 @@ Disassembly of section .text:
                	seqz	a1, a1
                	li	t1, 0x0
                	subw	a2, t1, a1
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x6f8
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x780
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	sb	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x710
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x768
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xd
                	lbu	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x708
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x770
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xd
@@ -9758,20 +9420,20 @@ Disassembly of section .text:
                	seqz	a1, a1
                	li	t1, 0x0
                	subw	a2, t1, a1
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x6f8
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x780
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xd
                	sb	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x710
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x768
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xe
                	lbu	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x708
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x770
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xe
@@ -9782,20 +9444,20 @@ Disassembly of section .text:
                	seqz	a1, a1
                	li	t1, 0x0
                	subw	a2, t1, a1
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x6f8
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x780
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xe
                	sb	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x710
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x768
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xf
                	lbu	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x708
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x770
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xf
@@ -9806,27 +9468,27 @@ Disassembly of section .text:
                	seqz	a1, a1
                	li	t1, 0x0
                	subw	a2, t1, a1
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x6f8
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x780
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xf
                	sb	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x6f8
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x780
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x9414>
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x708
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x8ecc>
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x770
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	lbu	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x710
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x768
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
@@ -9837,20 +9499,20 @@ Disassembly of section .text:
                	xori	a1, a1, 0x1
                	li	t1, 0x0
                	subw	a2, t1, a1
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x6f0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x788
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	sb	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x708
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x770
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x1
                	lbu	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x710
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x768
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x1
@@ -9861,20 +9523,20 @@ Disassembly of section .text:
                	xori	a1, a1, 0x1
                	li	t1, 0x0
                	subw	a2, t1, a1
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x6f0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x788
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x1
                	sb	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x708
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x770
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x2
                	lbu	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x710
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x768
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x2
@@ -9885,20 +9547,20 @@ Disassembly of section .text:
                	xori	a1, a1, 0x1
                	li	t1, 0x0
                	subw	a2, t1, a1
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x6f0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x788
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x2
                	sb	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x708
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x770
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x3
                	lbu	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x710
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x768
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x3
@@ -9909,20 +9571,20 @@ Disassembly of section .text:
                	xori	a1, a1, 0x1
                	li	t1, 0x0
                	subw	a2, t1, a1
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x6f0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x788
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x3
                	sb	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x708
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x770
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	lbu	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x710
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x768
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
@@ -9933,20 +9595,20 @@ Disassembly of section .text:
                	xori	a1, a1, 0x1
                	li	t1, 0x0
                	subw	a2, t1, a1
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x6f0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x788
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	sb	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x708
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x770
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x5
                	lbu	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x710
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x768
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x5
@@ -9957,20 +9619,20 @@ Disassembly of section .text:
                	xori	a1, a1, 0x1
                	li	t1, 0x0
                	subw	a2, t1, a1
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x6f0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x788
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x5
                	sb	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x708
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x770
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x6
                	lbu	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x710
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x768
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x6
@@ -9981,20 +9643,20 @@ Disassembly of section .text:
                	xori	a1, a1, 0x1
                	li	t1, 0x0
                	subw	a2, t1, a1
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x6f0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x788
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x6
                	sb	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x708
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x770
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x7
                	lbu	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x710
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x768
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x7
@@ -10005,20 +9667,20 @@ Disassembly of section .text:
                	xori	a1, a1, 0x1
                	li	t1, 0x0
                	subw	a2, t1, a1
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x6f0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x788
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x7
                	sb	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x708
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x770
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	lbu	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x710
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x768
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
@@ -10029,20 +9691,20 @@ Disassembly of section .text:
                	xori	a1, a1, 0x1
                	li	t1, 0x0
                	subw	a2, t1, a1
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x6f0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x788
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	sb	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x708
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x770
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x9
                	lbu	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x710
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x768
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x9
@@ -10053,20 +9715,20 @@ Disassembly of section .text:
                	xori	a1, a1, 0x1
                	li	t1, 0x0
                	subw	a2, t1, a1
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x6f0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x788
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x9
                	sb	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x708
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x770
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xa
                	lbu	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x710
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x768
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xa
@@ -10077,20 +9739,20 @@ Disassembly of section .text:
                	xori	a1, a1, 0x1
                	li	t1, 0x0
                	subw	a2, t1, a1
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x6f0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x788
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xa
                	sb	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x708
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x770
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xb
                	lbu	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x710
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x768
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xb
@@ -10101,20 +9763,20 @@ Disassembly of section .text:
                	xori	a1, a1, 0x1
                	li	t1, 0x0
                	subw	a2, t1, a1
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x6f0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x788
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xb
                	sb	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x708
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x770
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	lbu	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x710
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x768
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
@@ -10125,20 +9787,20 @@ Disassembly of section .text:
                	xori	a1, a1, 0x1
                	li	t1, 0x0
                	subw	a2, t1, a1
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x6f0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x788
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	sb	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x708
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x770
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xd
                	lbu	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x710
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x768
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xd
@@ -10149,20 +9811,20 @@ Disassembly of section .text:
                	xori	a1, a1, 0x1
                	li	t1, 0x0
                	subw	a2, t1, a1
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x6f0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x788
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xd
                	sb	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x708
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x770
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xe
                	lbu	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x710
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x768
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xe
@@ -10173,20 +9835,20 @@ Disassembly of section .text:
                	xori	a1, a1, 0x1
                	li	t1, 0x0
                	subw	a2, t1, a1
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x6f0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x788
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xe
                	sb	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x708
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x770
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xf
                	lbu	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x710
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x768
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xf
@@ -10197,1203 +9859,1203 @@ Disassembly of section .text:
                	xori	a1, a1, 0x1
                	li	t1, 0x0
                	subw	a2, t1, a1
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x6f0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x788
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xf
                	sb	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x6f0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x788
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x9a30>
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x700
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x94e8>
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x778
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	lbu	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x710
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x768
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	lbu	a3, 0x0(a1)
                	and	a1, a2, a3
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x6e8
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x790
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
                	sb	a1, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x700
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x778
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x1
                	lbu	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x710
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x768
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x1
                	lbu	a3, 0x0(a1)
                	and	a1, a2, a3
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x6e8
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x790
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x1
                	sb	a1, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x700
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x778
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x2
                	lbu	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x710
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x768
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x2
                	lbu	a3, 0x0(a1)
                	and	a1, a2, a3
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x6e8
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x790
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x2
                	sb	a1, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x700
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x778
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x3
                	lbu	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x710
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x768
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x3
                	lbu	a3, 0x0(a1)
                	and	a1, a2, a3
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x6e8
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x790
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x3
                	sb	a1, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x700
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x778
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	lbu	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x710
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x768
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	lbu	a3, 0x0(a1)
                	and	a1, a2, a3
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x6e8
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x790
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x4
                	sb	a1, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x700
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x778
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x5
                	lbu	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x710
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x768
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x5
                	lbu	a3, 0x0(a1)
                	and	a1, a2, a3
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x6e8
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x790
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x5
                	sb	a1, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x700
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x778
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x6
                	lbu	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x710
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x768
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x6
                	lbu	a3, 0x0(a1)
                	and	a1, a2, a3
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x6e8
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x790
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x6
                	sb	a1, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x700
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x778
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x7
                	lbu	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x710
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x768
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x7
                	lbu	a3, 0x0(a1)
                	and	a1, a2, a3
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x6e8
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x790
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x7
                	sb	a1, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x700
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x778
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	lbu	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x710
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x768
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	lbu	a3, 0x0(a1)
                	and	a1, a2, a3
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x6e8
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x790
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
                	sb	a1, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x700
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x778
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x9
                	lbu	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x710
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x768
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x9
                	lbu	a3, 0x0(a1)
                	and	a1, a2, a3
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x6e8
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x790
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x9
                	sb	a1, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x700
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x778
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xa
                	lbu	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x710
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x768
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xa
                	lbu	a3, 0x0(a1)
                	and	a1, a2, a3
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x6e8
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x790
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xa
                	sb	a1, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x700
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x778
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xb
                	lbu	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x710
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x768
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xb
                	lbu	a3, 0x0(a1)
                	and	a1, a2, a3
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x6e8
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x790
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xb
                	sb	a1, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x700
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x778
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	lbu	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x710
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x768
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	lbu	a3, 0x0(a1)
                	and	a1, a2, a3
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x6e8
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x790
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xc
                	sb	a1, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x700
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x778
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xd
                	lbu	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x710
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x768
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xd
                	lbu	a3, 0x0(a1)
                	and	a1, a2, a3
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x6e8
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x790
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xd
                	sb	a1, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x700
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x778
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xe
                	lbu	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x710
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x768
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xe
                	lbu	a3, 0x0(a1)
                	and	a1, a2, a3
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x6e8
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x790
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xe
                	sb	a1, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x700
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x778
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xf
                	lbu	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x710
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x768
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xf
                	lbu	a3, 0x0(a1)
                	and	a1, a2, a3
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x6e8
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x790
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xf
                	sb	a1, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x700
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x778
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	lbu	a2, 0x0(a1)
                	not	a1, a2
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x6e0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x798
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
                	sb	a1, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x700
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x778
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x1
                	lbu	a2, 0x0(a1)
                	not	a1, a2
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x6e0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x798
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x1
                	sb	a1, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x700
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x778
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x2
                	lbu	a2, 0x0(a1)
                	not	a1, a2
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x6e0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x798
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x2
                	sb	a1, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x700
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x778
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x3
                	lbu	a2, 0x0(a1)
                	not	a1, a2
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x6e0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x798
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x3
                	sb	a1, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x700
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x778
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	lbu	a2, 0x0(a1)
                	not	a1, a2
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x6e0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x798
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x4
                	sb	a1, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x700
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x778
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x5
                	lbu	a2, 0x0(a1)
                	not	a1, a2
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x6e0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x798
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x5
                	sb	a1, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x700
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x778
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x6
                	lbu	a2, 0x0(a1)
                	not	a1, a2
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x6e0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x798
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x6
                	sb	a1, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x700
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x778
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x7
                	lbu	a2, 0x0(a1)
                	not	a1, a2
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x6e0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x798
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x7
                	sb	a1, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x700
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x778
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	lbu	a2, 0x0(a1)
                	not	a1, a2
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x6e0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x798
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
                	sb	a1, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x700
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x778
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x9
                	lbu	a2, 0x0(a1)
                	not	a1, a2
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x6e0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x798
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x9
                	sb	a1, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x700
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x778
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xa
                	lbu	a2, 0x0(a1)
                	not	a1, a2
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x6e0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x798
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xa
                	sb	a1, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x700
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x778
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xb
                	lbu	a2, 0x0(a1)
                	not	a1, a2
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x6e0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x798
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xb
                	sb	a1, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x700
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x778
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	lbu	a2, 0x0(a1)
                	not	a1, a2
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x6e0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x798
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xc
                	sb	a1, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x700
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x778
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xd
                	lbu	a2, 0x0(a1)
                	not	a1, a2
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x6e0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x798
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xd
                	sb	a1, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x700
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x778
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xe
                	lbu	a2, 0x0(a1)
                	not	a1, a2
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x6e0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x798
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xe
                	sb	a1, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x700
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x778
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xf
                	lbu	a2, 0x0(a1)
                	not	a1, a2
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x6e0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x798
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xf
                	sb	a1, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x6e0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x798
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	lbu	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x708
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x770
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	lbu	a3, 0x0(a1)
                	and	a1, a2, a3
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x6d8
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x7a0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
                	sb	a1, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x6e0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x798
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x1
                	lbu	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x708
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x770
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x1
                	lbu	a3, 0x0(a1)
                	and	a1, a2, a3
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x6d8
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x7a0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x1
                	sb	a1, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x6e0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x798
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x2
                	lbu	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x708
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x770
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x2
                	lbu	a3, 0x0(a1)
                	and	a1, a2, a3
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x6d8
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x7a0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x2
                	sb	a1, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x6e0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x798
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x3
                	lbu	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x708
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x770
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x3
                	lbu	a3, 0x0(a1)
                	and	a1, a2, a3
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x6d8
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x7a0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x3
                	sb	a1, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x6e0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x798
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	lbu	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x708
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x770
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	lbu	a3, 0x0(a1)
                	and	a1, a2, a3
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x6d8
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x7a0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x4
                	sb	a1, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x6e0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x798
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x5
                	lbu	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x708
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x770
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x5
                	lbu	a3, 0x0(a1)
                	and	a1, a2, a3
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x6d8
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x7a0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x5
                	sb	a1, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x6e0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x798
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x6
                	lbu	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x708
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x770
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x6
                	lbu	a3, 0x0(a1)
                	and	a1, a2, a3
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x6d8
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x7a0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x6
                	sb	a1, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x6e0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x798
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x7
                	lbu	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x708
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x770
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x7
                	lbu	a3, 0x0(a1)
                	and	a1, a2, a3
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x6d8
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x7a0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x7
                	sb	a1, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x6e0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x798
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	lbu	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x708
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x770
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	lbu	a3, 0x0(a1)
                	and	a1, a2, a3
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x6d8
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x7a0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
                	sb	a1, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x6e0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x798
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x9
                	lbu	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x708
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x770
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x9
                	lbu	a3, 0x0(a1)
                	and	a1, a2, a3
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x6d8
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x7a0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x9
                	sb	a1, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x6e0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x798
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xa
                	lbu	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x708
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x770
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xa
                	lbu	a3, 0x0(a1)
                	and	a1, a2, a3
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x6d8
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x7a0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xa
                	sb	a1, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x6e0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x798
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xb
                	lbu	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x708
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x770
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xb
                	lbu	a3, 0x0(a1)
                	and	a1, a2, a3
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x6d8
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x7a0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xb
                	sb	a1, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x6e0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x798
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	lbu	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x708
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x770
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	lbu	a3, 0x0(a1)
                	and	a1, a2, a3
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x6d8
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x7a0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xc
                	sb	a1, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x6e0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x798
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xd
                	lbu	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x708
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x770
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xd
                	lbu	a3, 0x0(a1)
                	and	a1, a2, a3
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x6d8
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x7a0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xd
                	sb	a1, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x6e0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x798
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xe
                	lbu	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x708
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x770
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xe
                	lbu	a3, 0x0(a1)
                	and	a1, a2, a3
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x6d8
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x7a0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xe
                	sb	a1, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x6e0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x798
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xf
                	lbu	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x708
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x770
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xf
                	lbu	a3, 0x0(a1)
                	and	a1, a2, a3
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x6d8
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x7a0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xf
                	sb	a1, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x6e8
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x790
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	lbu	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x6d8
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x7a0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	lbu	a3, 0x0(a1)
                	or	a1, a2, a3
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x6d0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x7a8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
                	sb	a1, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x6e8
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x790
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x1
                	lbu	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x6d8
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x7a0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x1
                	lbu	a3, 0x0(a1)
                	or	a1, a2, a3
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x6d0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x7a8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x1
                	sb	a1, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x6e8
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x790
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x2
                	lbu	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x6d8
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x7a0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x2
                	lbu	a3, 0x0(a1)
                	or	a1, a2, a3
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x6d0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x7a8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x2
                	sb	a1, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x6e8
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x790
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x3
                	lbu	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x6d8
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x7a0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x3
                	lbu	a3, 0x0(a1)
                	or	a1, a2, a3
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x6d0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x7a8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x3
                	sb	a1, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x6e8
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x790
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	lbu	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x6d8
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x7a0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	lbu	a3, 0x0(a1)
                	or	a1, a2, a3
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x6d0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x7a8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x4
                	sb	a1, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x6e8
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x790
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x5
                	lbu	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x6d8
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x7a0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x5
                	lbu	a3, 0x0(a1)
                	or	a1, a2, a3
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x6d0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x7a8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x5
                	sb	a1, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x6e8
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x790
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x6
                	lbu	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x6d8
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x7a0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x6
                	lbu	a3, 0x0(a1)
                	or	a1, a2, a3
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x6d0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x7a8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x6
                	sb	a1, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x6e8
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x790
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x7
                	lbu	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x6d8
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x7a0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x7
                	lbu	a3, 0x0(a1)
                	or	a1, a2, a3
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x6d0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x7a8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x7
                	sb	a1, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x6e8
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x790
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	lbu	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x6d8
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x7a0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	lbu	a3, 0x0(a1)
                	or	a1, a2, a3
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x6d0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x7a8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
                	sb	a1, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x6e8
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x790
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x9
                	lbu	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x6d8
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x7a0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x9
                	lbu	a3, 0x0(a1)
                	or	a1, a2, a3
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x6d0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x7a8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x9
                	sb	a1, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x6e8
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x790
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xa
                	lbu	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x6d8
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x7a0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xa
                	lbu	a3, 0x0(a1)
                	or	a1, a2, a3
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x6d0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x7a8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xa
                	sb	a1, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x6e8
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x790
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xb
                	lbu	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x6d8
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x7a0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xb
                	lbu	a3, 0x0(a1)
                	or	a1, a2, a3
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x6d0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x7a8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xb
                	sb	a1, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x6e8
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x790
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	lbu	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x6d8
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x7a0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	lbu	a3, 0x0(a1)
                	or	a1, a2, a3
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x6d0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x7a8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xc
                	sb	a1, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x6e8
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x790
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xd
                	lbu	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x6d8
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x7a0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xd
                	lbu	a3, 0x0(a1)
                	or	a1, a2, a3
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x6d0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x7a8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xd
                	sb	a1, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x6e8
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x790
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xe
                	lbu	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x6d8
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x7a0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xe
                	lbu	a3, 0x0(a1)
                	or	a1, a2, a3
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x6d0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x7a8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xe
                	sb	a1, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x6e8
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x790
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xf
                	lbu	a2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x6d8
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x7a0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xf
                	lbu	a3, 0x0(a1)
                	or	a1, a2, a3
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x6d0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x7a8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xf
                	sb	a1, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x6d0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x7a8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0xabcc>
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0xa684>
                	lui	t1, 0x2
-               	addiw	t1, t1, -0x668
+               	addiw	t1, t1, -0x7f8
                	add	t1, sp, t1
                	ld	s1, 0x0(t1)
                	lui	t1, 0x2
-               	addiw	t1, t1, -0x670
+               	addiw	t1, t1, -0x800
                	add	t1, sp, t1
                	ld	s2, 0x0(t1)
-               	lui	t1, 0x2
-               	addiw	t1, t1, -0x678
+               	lui	t1, 0x1
+               	addiw	t1, t1, 0x7f8
                	add	t1, sp, t1
                	ld	s3, 0x0(t1)
-               	lui	t1, 0x2
-               	addiw	t1, t1, -0x680
+               	lui	t1, 0x1
+               	addiw	t1, t1, 0x7f0
                	add	t1, sp, t1
                	ld	s4, 0x0(t1)
-               	lui	t1, 0x2
-               	addiw	t1, t1, -0x688
+               	lui	t1, 0x1
+               	addiw	t1, t1, 0x7e8
                	add	t1, sp, t1
                	ld	s5, 0x0(t1)
-               	lui	t1, 0x2
-               	addiw	t1, t1, -0x690
+               	lui	t1, 0x1
+               	addiw	t1, t1, 0x7e0
                	add	t1, sp, t1
                	ld	s6, 0x0(t1)
-               	lui	t1, 0x2
-               	addiw	t1, t1, -0x698
+               	lui	t1, 0x1
+               	addiw	t1, t1, 0x7d8
                	add	t1, sp, t1
                	ld	s7, 0x0(t1)
-               	lui	t1, 0x2
-               	addiw	t1, t1, -0x6a0
+               	lui	t1, 0x1
+               	addiw	t1, t1, 0x7d0
                	add	t1, sp, t1
                	ld	s8, 0x0(t1)
-               	lui	t1, 0x2
-               	addiw	t1, t1, -0x6a8
+               	lui	t1, 0x1
+               	addiw	t1, t1, 0x7c8
                	add	t1, sp, t1
                	ld	s9, 0x0(t1)
-               	lui	t1, 0x2
-               	addiw	t1, t1, -0x6b0
+               	lui	t1, 0x1
+               	addiw	t1, t1, 0x7c0
                	add	t1, sp, t1
                	ld	s10, 0x0(t1)
-               	lui	t1, 0x2
-               	addiw	t1, t1, -0x6b8
+               	lui	t1, 0x1
+               	addiw	t1, t1, 0x7b8
                	add	t1, sp, t1
                	ld	s11, 0x0(t1)
-               	lui	t1, 0x2
-               	addiw	t1, t1, -0x6c0
+               	lui	t1, 0x1
+               	addiw	t1, t1, 0x7b0
                	add	t1, sp, t1
                	fld	fs0, 0x0(t1)
                	lui	t1, 0x2
-               	addiw	t1, t1, -0x658
+               	addiw	t1, t1, -0x7e8
                	add	t1, sp, t1
                	ld	ra, 0x0(t1)
                	lui	t1, 0x2
-               	addiw	t1, t1, -0x660
+               	addiw	t1, t1, -0x7f0
                	add	t1, sp, t1
                	ld	s0, 0x0(t1)
                	lui	t0, 0x2
-               	addiw	t0, t0, -0x650
+               	addiw	t0, t0, -0x7e0
                	add	sp, sp, t0
                	ret

--- a/test/golden/riscv64-linux/vec/vec_i16x4.dis
+++ b/test/golden/riscv64-linux/vec/vec_i16x4.dis
@@ -48,21 +48,21 @@ Disassembly of section .text:
                	ret
 
 <corpus.cases.vec.vec_i16x4.checksum>:
-               	addi	sp, sp, -0x7b0
-               	sd	ra, 0x7a8(sp)
-               	sd	s0, 0x7a0(sp)
-               	addi	s0, sp, 0x7b0
-               	sd	s1, 0x798(sp)
-               	sd	s2, 0x790(sp)
-               	sd	s3, 0x788(sp)
-               	sd	s4, 0x780(sp)
-               	sd	s5, 0x778(sp)
-               	sd	s6, 0x770(sp)
-               	sd	s7, 0x768(sp)
-               	sd	s8, 0x760(sp)
-               	sd	s9, 0x758(sp)
-               	sd	s10, 0x750(sp)
-               	sd	s11, 0x748(sp)
+               	addi	sp, sp, -0x6c0
+               	sd	ra, 0x6b8(sp)
+               	sd	s0, 0x6b0(sp)
+               	addi	s0, sp, 0x6c0
+               	sd	s1, 0x6a8(sp)
+               	sd	s2, 0x6a0(sp)
+               	sd	s3, 0x698(sp)
+               	sd	s4, 0x690(sp)
+               	sd	s5, 0x688(sp)
+               	sd	s6, 0x680(sp)
+               	sd	s7, 0x678(sp)
+               	sd	s8, 0x670(sp)
+               	sd	s9, 0x668(sp)
+               	sd	s10, 0x660(sp)
+               	sd	s11, 0x658(sp)
                	mv	s1, a0
                	addi	s2, s0, -0x70
                	addi	s3, s0, -0x78
@@ -91,105 +91,103 @@ Disassembly of section .text:
                	addi	a1, s0, -0x130
                	addi	a1, s0, -0x138
                	addi	t2, s0, -0x140
-               	sd	t2, -0x770(s0)
+               	sd	t2, -0x680(s0)
                	addi	a1, s0, -0x148
                	addi	a1, s0, -0x150
                	addi	t2, s0, -0x158
-               	sd	t2, -0x778(s0)
+               	sd	t2, -0x688(s0)
                	addi	a1, s0, -0x160
                	addi	a1, s0, -0x168
                	addi	t2, s0, -0x170
-               	sd	t2, -0x780(s0)
+               	sd	t2, -0x690(s0)
                	addi	a1, s0, -0x178
                	addi	a1, s0, -0x180
                	addi	t2, s0, -0x188
-               	sd	t2, -0x788(s0)
+               	sd	t2, -0x698(s0)
                	addi	a1, s0, -0x190
                	addi	a1, s0, -0x198
                	addi	t2, s0, -0x1a0
-               	sd	t2, -0x790(s0)
+               	sd	t2, -0x6a0(s0)
                	addi	a1, s0, -0x1a8
                	addi	t2, s0, -0x1b0
-               	sd	t2, -0x798(s0)
+               	sd	t2, -0x6a8(s0)
                	addi	a1, s0, -0x1b8
                	addi	a1, s0, -0x1c0
                	addi	t2, s0, -0x1c8
-               	sd	t2, -0x7a0(s0)
+               	sd	t2, -0x6b0(s0)
                	addi	a1, s0, -0x1d0
                	addi	a1, s0, -0x1d8
                	addi	t2, s0, -0x1e0
-               	sd	t2, -0x7a8(s0)
+               	sd	t2, -0x6b8(s0)
                	addi	a1, s0, -0x1e8
                	addi	a1, s0, -0x1f0
                	addi	t2, s0, -0x1f8
-               	sd	t2, -0x6d0(s0)
+               	sd	t2, -0x5f0(s0)
                	addi	a1, s0, -0x200
                	addi	a1, s0, -0x208
                	addi	t2, s0, -0x210
-               	sd	t2, -0x6d8(s0)
+               	sd	t2, -0x5f8(s0)
                	addi	a1, s0, -0x218
                	addi	a1, s0, -0x220
                	addi	t2, s0, -0x228
-               	sd	t2, -0x6e0(s0)
+               	sd	t2, -0x600(s0)
                	addi	a1, s0, -0x230
                	addi	t2, s0, -0x238
-               	sd	t2, -0x6e8(s0)
+               	sd	t2, -0x608(s0)
                	addi	a1, s0, -0x240
                	addi	t2, s0, -0x248
-               	sd	t2, -0x6f0(s0)
+               	sd	t2, -0x610(s0)
                	addi	a1, s0, -0x250
                	addi	a1, s0, -0x258
-               	addi	t2, s0, -0x260
-               	sd	t2, -0x6f8(s0)
+               	addi	a1, s0, -0x260
                	addi	a1, s0, -0x268
                	addi	a1, s0, -0x270
-               	addi	t2, s0, -0x278
-               	sd	t2, -0x700(s0)
+               	addi	a1, s0, -0x278
                	addi	t2, s0, -0x280
-               	sd	t2, -0x708(s0)
+               	sd	t2, -0x618(s0)
                	addi	a1, s0, -0x288
                	addi	a1, s0, -0x290
                	addi	a1, s0, -0x298
                	addi	a1, s0, -0x2a0
                	addi	t2, s0, -0x2a8
-               	sd	t2, -0x710(s0)
+               	sd	t2, -0x620(s0)
                	addi	a1, s0, -0x2b0
                	addi	a1, s0, -0x2b8
                	addi	a1, s0, -0x2c0
                	addi	t2, s0, -0x2c8
-               	sd	t2, -0x718(s0)
+               	sd	t2, -0x628(s0)
                	addi	a1, s0, -0x2d0
                	addi	a1, s0, -0x2d8
                	addi	a1, s0, -0x2e0
                	addi	t2, s0, -0x2e8
-               	sd	t2, -0x720(s0)
+               	sd	t2, -0x630(s0)
                	addi	a1, s0, -0x2f0
                	addi	a1, s0, -0x2f8
                	addi	a1, s0, -0x300
                	addi	t2, s0, -0x308
-               	sd	t2, -0x728(s0)
+               	sd	t2, -0x638(s0)
                	addi	a1, s0, -0x310
                	addi	a1, s0, -0x318
                	addi	a1, s0, -0x320
                	addi	a1, s0, -0x328
                	addi	t2, s0, -0x330
-               	sd	t2, -0x730(s0)
+               	sd	t2, -0x640(s0)
                	addi	a1, s0, -0x338
                	addi	a1, s0, -0x340
                	addi	t2, s0, -0x348
-               	sd	t2, -0x738(s0)
+               	sd	t2, -0x648(s0)
                	addi	a1, s0, -0x350
                	addi	a1, s0, -0x358
                	addi	a1, s0, -0x360
                	addi	a1, s0, -0x368
                	addi	t2, s0, -0x370
-               	sd	t2, -0x740(s0)
+               	sd	t2, -0x650(s0)
                	addi	t2, s0, -0x378
-               	sd	t2, -0x748(s0)
+               	sd	t2, -0x658(s0)
                	addi	t2, s0, -0x380
-               	sd	t2, -0x750(s0)
+               	sd	t2, -0x660(s0)
                	addi	t2, s0, -0x388
-               	sd	t2, -0x758(s0)
+               	sd	t2, -0x668(s0)
                	addi	a1, s0, -0x390
                	addi	a1, s0, -0x398
                	addi	a1, s0, -0x3a0
@@ -254,42 +252,14 @@ Disassembly of section .text:
                	addi	a1, s0, -0x578
                	addi	a1, s0, -0x580
                	addi	a1, s0, -0x588
-               	addi	a1, s0, -0x590
-               	addi	a1, s0, -0x598
-               	addi	a1, s0, -0x5a0
-               	addi	a1, s0, -0x5a8
-               	addi	a1, s0, -0x5b0
-               	addi	a1, s0, -0x5b8
-               	addi	a1, s0, -0x5c0
-               	addi	a1, s0, -0x5c8
-               	addi	a1, s0, -0x5d0
-               	addi	a1, s0, -0x5d8
-               	addi	a1, s0, -0x5e0
-               	addi	a1, s0, -0x5e8
-               	addi	a1, s0, -0x5f0
-               	addi	a1, s0, -0x5f8
-               	addi	a1, s0, -0x600
-               	addi	a1, s0, -0x608
-               	addi	a1, s0, -0x610
-               	addi	a1, s0, -0x618
-               	addi	a1, s0, -0x620
-               	addi	a1, s0, -0x628
-               	addi	a1, s0, -0x630
-               	addi	a1, s0, -0x638
-               	addi	a1, s0, -0x640
-               	addi	a1, s0, -0x648
-               	addi	a1, s0, -0x650
-               	addi	a1, s0, -0x658
-               	addi	a1, s0, -0x660
-               	addi	a1, s0, -0x668
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0x3a8>
+               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0x330>
                	mv	t2, a0
-               	sd	t2, -0x760(s0)
-               	ld	t2, -0x760(s0)
+               	sd	t2, -0x670(s0)
+               	ld	t2, -0x670(s0)
                	sext.w	t2, s1
-               	sd	t2, -0x768(s0)
-               	addi	s1, s0, -0x670
+               	sd	t2, -0x678(s0)
+               	addi	s1, s0, -0x590
                	mv	a0, s1
                	li	t0, 0x3e9
                	sh	t0, 0x0(a0)
@@ -320,7 +290,7 @@ Disassembly of section .text:
                	lhu	a1, 0x0(a0)
                	addi	a0, s2, 0x6
                	sh	a1, 0x0(a0)
-               	addi	a0, s0, -0x678
+               	addi	a0, s0, -0x598
                	mv	a1, a0
                	li	t0, 0xd
                	sh	t0, 0x0(a1)
@@ -351,7 +321,7 @@ Disassembly of section .text:
                	lhu	a0, 0x0(a1)
                	addi	a1, s3, 0x6
                	sh	a0, 0x0(a1)
-               	addi	a0, s0, -0x680
+               	addi	a0, s0, -0x5a0
                	mv	a1, a0
                	li	t0, 0x1
                	sh	t0, 0x0(a1)
@@ -380,7 +350,7 @@ Disassembly of section .text:
                	lhu	a0, 0x0(a1)
                	addi	a1, s4, 0x6
                	sh	a0, 0x0(a1)
-               	addi	a0, s0, -0x688
+               	addi	a0, s0, -0x5a8
                	mv	a1, a0
                	sh	zero, 0x0(a1)
                	addi	a1, a0, 0x2
@@ -407,7 +377,7 @@ Disassembly of section .text:
                	sh	a0, 0x0(a1)
                	mv	a0, s2
                	lhu	a1, 0x0(a0)
-               	ld	t2, -0x768(s0)
+               	ld	t2, -0x678(s0)
                	addw	a0, a1, t2
                	mv	a1, s2
                	lhu	s1, 0x0(a1)
@@ -429,7 +399,7 @@ Disassembly of section .text:
                	sh	a0, 0x0(a1)
                	addi	a0, s6, 0x6
                	lhu	a1, 0x0(a0)
-               	ld	t2, -0x768(s0)
+               	ld	t2, -0x678(s0)
                	addw	a0, a1, t2
                	mv	a1, s6
                	lhu	s1, 0x0(a1)
@@ -451,7 +421,7 @@ Disassembly of section .text:
                	sh	a0, 0x0(a1)
                	addi	a0, s3, 0x2
                	lhu	a1, 0x0(a0)
-               	ld	t2, -0x768(s0)
+               	ld	t2, -0x678(s0)
                	addw	a0, a1, t2
                	mv	a1, s3
                	lhu	s1, 0x0(a1)
@@ -473,7 +443,7 @@ Disassembly of section .text:
                	sh	a0, 0x0(a1)
                	addi	a0, s8, 0x4
                	lhu	a1, 0x0(a0)
-               	ld	t2, -0x768(s0)
+               	ld	t2, -0x678(s0)
                	addw	a0, a1, t2
                	mv	a1, s8
                	lhu	s1, 0x0(a1)
@@ -495,45 +465,45 @@ Disassembly of section .text:
                	sh	a0, 0x0(a1)
                	mv	a0, s7
                	lhu	a1, 0x0(a0)
-               	ld	t2, -0x760(s0)
+               	ld	t2, -0x670(s0)
                	mv	a0, t2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0x704>
+               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0x68c>
                	addi	a1, s7, 0x2
                	lhu	s1, 0x0(a1)
                	mv	a1, s1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0x718>
+               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0x6a0>
                	addi	a1, s7, 0x4
                	lhu	s1, 0x0(a1)
                	mv	a1, s1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0x72c>
+               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0x6b4>
                	addi	a1, s7, 0x6
                	lhu	s1, 0x0(a1)
                	mv	a1, s1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0x740>
+               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0x6c8>
                	mv	a1, s9
                	lhu	s1, 0x0(a1)
                	mv	a1, s1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0x754>
+               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0x6dc>
                	addi	a1, s9, 0x2
                	lhu	s1, 0x0(a1)
                	mv	a1, s1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0x768>
+               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0x6f0>
                	addi	a1, s9, 0x4
                	lhu	s1, 0x0(a1)
                	mv	a1, s1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0x77c>
+               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0x704>
                	addi	a1, s9, 0x6
                	lhu	s1, 0x0(a1)
                	mv	a1, s1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0x790>
+               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0x718>
                	mv	a1, s7
                	lhu	s1, 0x0(a1)
                	mv	a1, s9
@@ -566,22 +536,22 @@ Disassembly of section .text:
                	lhu	s1, 0x0(a1)
                	mv	a1, s1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0x814>
+               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0x79c>
                	addi	a1, s10, 0x2
                	lhu	s1, 0x0(a1)
                	mv	a1, s1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0x828>
+               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0x7b0>
                	addi	a1, s10, 0x4
                	lhu	s1, 0x0(a1)
                	mv	a1, s1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0x83c>
+               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0x7c4>
                	addi	a1, s10, 0x6
                	lhu	s1, 0x0(a1)
                	mv	a1, s1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0x850>
+               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0x7d8>
                	mv	a1, s7
                	lhu	s1, 0x0(a1)
                	mv	a1, s9
@@ -614,28 +584,28 @@ Disassembly of section .text:
                	lhu	s1, 0x0(a1)
                	mv	a1, s1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0x8d4>
+               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0x85c>
                	addi	a1, s11, 0x2
                	lhu	s1, 0x0(a1)
                	mv	a1, s1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0x8e8>
+               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0x870>
                	addi	a1, s11, 0x4
                	lhu	s1, 0x0(a1)
                	mv	a1, s1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0x8fc>
+               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0x884>
                	addi	a1, s11, 0x6
                	lhu	s1, 0x0(a1)
                	mv	a1, s1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0x910>
+               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0x898>
                	mv	a1, s9
                	lhu	s1, 0x0(a1)
                	mv	a1, s7
                	lhu	s2, 0x0(a1)
                	subw	a1, s1, s2
-               	ld	t2, -0x770(s0)
+               	ld	t2, -0x680(s0)
                	mv	s1, t2
                	sh	a1, 0x0(s1)
                	addi	a1, s9, 0x2
@@ -643,7 +613,7 @@ Disassembly of section .text:
                	addi	a1, s7, 0x2
                	lhu	s2, 0x0(a1)
                	subw	a1, s1, s2
-               	ld	t2, -0x770(s0)
+               	ld	t2, -0x680(s0)
                	addi	s1, t2, 0x2
                	sh	a1, 0x0(s1)
                	addi	a1, s9, 0x4
@@ -651,7 +621,7 @@ Disassembly of section .text:
                	addi	a1, s7, 0x4
                	lhu	s2, 0x0(a1)
                	subw	a1, s1, s2
-               	ld	t2, -0x770(s0)
+               	ld	t2, -0x680(s0)
                	addi	s1, t2, 0x4
                	sh	a1, 0x0(s1)
                	addi	a1, s9, 0x6
@@ -659,39 +629,39 @@ Disassembly of section .text:
                	addi	a1, s7, 0x6
                	lhu	s2, 0x0(a1)
                	subw	a1, s1, s2
-               	ld	t2, -0x770(s0)
+               	ld	t2, -0x680(s0)
                	addi	s1, t2, 0x6
                	sh	a1, 0x0(s1)
-               	ld	t2, -0x770(s0)
+               	ld	t2, -0x680(s0)
                	mv	a1, t2
                	lhu	s1, 0x0(a1)
                	mv	a1, s1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0x9a8>
-               	ld	t2, -0x770(s0)
+               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0x930>
+               	ld	t2, -0x680(s0)
                	addi	a1, t2, 0x2
                	lhu	s1, 0x0(a1)
                	mv	a1, s1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0x9c0>
-               	ld	t2, -0x770(s0)
+               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0x948>
+               	ld	t2, -0x680(s0)
                	addi	a1, t2, 0x4
                	lhu	s1, 0x0(a1)
                	mv	a1, s1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0x9d8>
-               	ld	t2, -0x770(s0)
+               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0x960>
+               	ld	t2, -0x680(s0)
                	addi	a1, t2, 0x6
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0x9f0>
+               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0x978>
                	mv	a1, s7
                	lhu	a2, 0x0(a1)
                	mv	a1, s9
                	lhu	s1, 0x0(a1)
                	mulw	a1, a2, s1
-               	ld	t2, -0x778(s0)
+               	ld	t2, -0x688(s0)
                	mv	a2, t2
                	sh	a1, 0x0(a2)
                	addi	a1, s7, 0x2
@@ -699,7 +669,7 @@ Disassembly of section .text:
                	addi	a1, s9, 0x2
                	lhu	s1, 0x0(a1)
                	mulw	a1, a2, s1
-               	ld	t2, -0x778(s0)
+               	ld	t2, -0x688(s0)
                	addi	a2, t2, 0x2
                	sh	a1, 0x0(a2)
                	addi	a1, s7, 0x4
@@ -707,7 +677,7 @@ Disassembly of section .text:
                	addi	a1, s9, 0x4
                	lhu	s1, 0x0(a1)
                	mulw	a1, a2, s1
-               	ld	t2, -0x778(s0)
+               	ld	t2, -0x688(s0)
                	addi	a2, t2, 0x4
                	sh	a1, 0x0(a2)
                	addi	a1, s7, 0x6
@@ -715,39 +685,39 @@ Disassembly of section .text:
                	addi	a1, s9, 0x6
                	lhu	s1, 0x0(a1)
                	mulw	a1, a2, s1
-               	ld	t2, -0x778(s0)
+               	ld	t2, -0x688(s0)
                	addi	a2, t2, 0x6
                	sh	a1, 0x0(a2)
-               	ld	t2, -0x778(s0)
+               	ld	t2, -0x688(s0)
                	mv	a1, t2
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0xa88>
-               	ld	t2, -0x778(s0)
+               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0xa10>
+               	ld	t2, -0x688(s0)
                	addi	a1, t2, 0x2
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0xaa0>
-               	ld	t2, -0x778(s0)
+               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0xa28>
+               	ld	t2, -0x688(s0)
                	addi	a1, t2, 0x4
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0xab8>
-               	ld	t2, -0x778(s0)
+               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0xa40>
+               	ld	t2, -0x688(s0)
                	addi	a1, t2, 0x6
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0xad0>
+               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0xa58>
                	mv	a1, s7
                	lhu	a2, 0x0(a1)
                	mv	a1, s4
                	lhu	a3, 0x0(a1)
                	mulw	a1, a2, a3
-               	ld	t2, -0x780(s0)
+               	ld	t2, -0x690(s0)
                	mv	a2, t2
                	sh	a1, 0x0(a2)
                	addi	a1, s7, 0x2
@@ -755,7 +725,7 @@ Disassembly of section .text:
                	addi	a1, s4, 0x2
                	lhu	a3, 0x0(a1)
                	mulw	a1, a2, a3
-               	ld	t2, -0x780(s0)
+               	ld	t2, -0x690(s0)
                	addi	a2, t2, 0x2
                	sh	a1, 0x0(a2)
                	addi	a1, s7, 0x4
@@ -763,7 +733,7 @@ Disassembly of section .text:
                	addi	a1, s4, 0x4
                	lhu	a3, 0x0(a1)
                	mulw	a1, a2, a3
-               	ld	t2, -0x780(s0)
+               	ld	t2, -0x690(s0)
                	addi	a2, t2, 0x4
                	sh	a1, 0x0(a2)
                	addi	a1, s7, 0x6
@@ -771,39 +741,39 @@ Disassembly of section .text:
                	addi	a1, s4, 0x6
                	lhu	a3, 0x0(a1)
                	mulw	a1, a2, a3
-               	ld	t2, -0x780(s0)
+               	ld	t2, -0x690(s0)
                	addi	a2, t2, 0x6
                	sh	a1, 0x0(a2)
-               	ld	t2, -0x780(s0)
+               	ld	t2, -0x690(s0)
                	mv	a1, t2
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0xb68>
-               	ld	t2, -0x780(s0)
+               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0xaf0>
+               	ld	t2, -0x690(s0)
                	addi	a1, t2, 0x2
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0xb80>
-               	ld	t2, -0x780(s0)
+               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0xb08>
+               	ld	t2, -0x690(s0)
                	addi	a1, t2, 0x4
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0xb98>
-               	ld	t2, -0x780(s0)
+               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0xb20>
+               	ld	t2, -0x690(s0)
                	addi	a1, t2, 0x6
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0xbb0>
+               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0xb38>
                	mv	a1, s9
                	lhu	a2, 0x0(a1)
                	mv	a1, s4
                	lhu	a3, 0x0(a1)
                	mulw	a1, a2, a3
-               	ld	t2, -0x788(s0)
+               	ld	t2, -0x698(s0)
                	mv	a2, t2
                	sh	a1, 0x0(a2)
                	addi	a1, s9, 0x2
@@ -811,7 +781,7 @@ Disassembly of section .text:
                	addi	a1, s4, 0x2
                	lhu	a3, 0x0(a1)
                	mulw	a1, a2, a3
-               	ld	t2, -0x788(s0)
+               	ld	t2, -0x698(s0)
                	addi	a2, t2, 0x2
                	sh	a1, 0x0(a2)
                	addi	a1, s9, 0x4
@@ -819,7 +789,7 @@ Disassembly of section .text:
                	addi	a1, s4, 0x4
                	lhu	a3, 0x0(a1)
                	mulw	a1, a2, a3
-               	ld	t2, -0x788(s0)
+               	ld	t2, -0x698(s0)
                	addi	a2, t2, 0x4
                	sh	a1, 0x0(a2)
                	addi	a1, s9, 0x6
@@ -827,39 +797,39 @@ Disassembly of section .text:
                	addi	a1, s4, 0x6
                	lhu	a3, 0x0(a1)
                	mulw	a1, a2, a3
-               	ld	t2, -0x788(s0)
+               	ld	t2, -0x698(s0)
                	addi	a2, t2, 0x6
                	sh	a1, 0x0(a2)
-               	ld	t2, -0x788(s0)
+               	ld	t2, -0x698(s0)
                	mv	a1, t2
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0xc48>
-               	ld	t2, -0x788(s0)
+               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0xbd0>
+               	ld	t2, -0x698(s0)
                	addi	a1, t2, 0x2
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0xc60>
-               	ld	t2, -0x788(s0)
+               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0xbe8>
+               	ld	t2, -0x698(s0)
                	addi	a1, t2, 0x4
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0xc78>
-               	ld	t2, -0x788(s0)
+               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0xc00>
+               	ld	t2, -0x698(s0)
                	addi	a1, t2, 0x6
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0xc90>
+               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0xc18>
                	mv	a1, s7
                	lhu	a2, 0x0(a1)
                	mv	a1, s9
                	lhu	a3, 0x0(a1)
                	addw	a1, a2, a3
-               	ld	t2, -0x790(s0)
+               	ld	t2, -0x6a0(s0)
                	mv	a2, t2
                	sh	a1, 0x0(a2)
                	addi	a1, s7, 0x2
@@ -867,7 +837,7 @@ Disassembly of section .text:
                	addi	a1, s9, 0x2
                	lhu	a3, 0x0(a1)
                	addw	a1, a2, a3
-               	ld	t2, -0x790(s0)
+               	ld	t2, -0x6a0(s0)
                	addi	a2, t2, 0x2
                	sh	a1, 0x0(a2)
                	addi	a1, s7, 0x4
@@ -875,7 +845,7 @@ Disassembly of section .text:
                	addi	a1, s9, 0x4
                	lhu	a3, 0x0(a1)
                	addw	a1, a2, a3
-               	ld	t2, -0x790(s0)
+               	ld	t2, -0x6a0(s0)
                	addi	a2, t2, 0x4
                	sh	a1, 0x0(a2)
                	addi	a1, s7, 0x6
@@ -883,75 +853,75 @@ Disassembly of section .text:
                	addi	a1, s9, 0x6
                	lhu	a3, 0x0(a1)
                	addw	a1, a2, a3
-               	ld	t2, -0x790(s0)
+               	ld	t2, -0x6a0(s0)
                	addi	a2, t2, 0x6
                	sh	a1, 0x0(a2)
-               	ld	t2, -0x790(s0)
+               	ld	t2, -0x6a0(s0)
                	mv	a1, t2
                	lhu	a2, 0x0(a1)
                	mv	a1, s4
                	lhu	a3, 0x0(a1)
                	mulw	a1, a2, a3
-               	ld	t2, -0x798(s0)
+               	ld	t2, -0x6a8(s0)
                	mv	a2, t2
                	sh	a1, 0x0(a2)
-               	ld	t2, -0x790(s0)
+               	ld	t2, -0x6a0(s0)
                	addi	a1, t2, 0x2
                	lhu	a2, 0x0(a1)
                	addi	a1, s4, 0x2
                	lhu	a3, 0x0(a1)
                	mulw	a1, a2, a3
-               	ld	t2, -0x798(s0)
+               	ld	t2, -0x6a8(s0)
                	addi	a2, t2, 0x2
                	sh	a1, 0x0(a2)
-               	ld	t2, -0x790(s0)
+               	ld	t2, -0x6a0(s0)
                	addi	a1, t2, 0x4
                	lhu	a2, 0x0(a1)
                	addi	a1, s4, 0x4
                	lhu	a3, 0x0(a1)
                	mulw	a1, a2, a3
-               	ld	t2, -0x798(s0)
+               	ld	t2, -0x6a8(s0)
                	addi	a2, t2, 0x4
                	sh	a1, 0x0(a2)
-               	ld	t2, -0x790(s0)
+               	ld	t2, -0x6a0(s0)
                	addi	a1, t2, 0x6
                	lhu	a2, 0x0(a1)
                	addi	a1, s4, 0x6
                	lhu	a3, 0x0(a1)
                	mulw	a1, a2, a3
-               	ld	t2, -0x798(s0)
+               	ld	t2, -0x6a8(s0)
                	addi	a2, t2, 0x6
                	sh	a1, 0x0(a2)
-               	ld	t2, -0x798(s0)
+               	ld	t2, -0x6a8(s0)
                	mv	a1, t2
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0xdb8>
-               	ld	t2, -0x798(s0)
+               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0xd40>
+               	ld	t2, -0x6a8(s0)
                	addi	a1, t2, 0x2
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0xdd0>
-               	ld	t2, -0x798(s0)
+               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0xd58>
+               	ld	t2, -0x6a8(s0)
                	addi	a1, t2, 0x4
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0xde8>
-               	ld	t2, -0x798(s0)
+               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0xd70>
+               	ld	t2, -0x6a8(s0)
                	addi	a1, t2, 0x6
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0xe00>
+               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0xd88>
                	mv	a1, s5
                	lhu	a2, 0x0(a1)
                	mv	a1, s7
                	lhu	a3, 0x0(a1)
                	subw	a1, a2, a3
-               	ld	t2, -0x7a0(s0)
+               	ld	t2, -0x6b0(s0)
                	mv	a2, t2
                	sh	a1, 0x0(a2)
                	addi	a1, s5, 0x2
@@ -959,7 +929,7 @@ Disassembly of section .text:
                	addi	a1, s7, 0x2
                	lhu	a3, 0x0(a1)
                	subw	a1, a2, a3
-               	ld	t2, -0x7a0(s0)
+               	ld	t2, -0x6b0(s0)
                	addi	a2, t2, 0x2
                	sh	a1, 0x0(a2)
                	addi	a1, s5, 0x4
@@ -967,7 +937,7 @@ Disassembly of section .text:
                	addi	a1, s7, 0x4
                	lhu	a3, 0x0(a1)
                	subw	a1, a2, a3
-               	ld	t2, -0x7a0(s0)
+               	ld	t2, -0x6b0(s0)
                	addi	a2, t2, 0x4
                	sh	a1, 0x0(a2)
                	addi	a1, s5, 0x6
@@ -975,39 +945,39 @@ Disassembly of section .text:
                	addi	a1, s7, 0x6
                	lhu	a3, 0x0(a1)
                	subw	a1, a2, a3
-               	ld	t2, -0x7a0(s0)
+               	ld	t2, -0x6b0(s0)
                	addi	a2, t2, 0x6
                	sh	a1, 0x0(a2)
-               	ld	t2, -0x7a0(s0)
+               	ld	t2, -0x6b0(s0)
                	mv	a1, t2
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0xe98>
-               	ld	t2, -0x7a0(s0)
+               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0xe20>
+               	ld	t2, -0x6b0(s0)
                	addi	a1, t2, 0x2
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0xeb0>
-               	ld	t2, -0x7a0(s0)
+               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0xe38>
+               	ld	t2, -0x6b0(s0)
                	addi	a1, t2, 0x4
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0xec8>
-               	ld	t2, -0x7a0(s0)
+               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0xe50>
+               	ld	t2, -0x6b0(s0)
                	addi	a1, t2, 0x6
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0xee0>
+               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0xe68>
                	mv	a1, s5
                	lhu	a2, 0x0(a1)
                	mv	a1, s9
                	lhu	a3, 0x0(a1)
                	subw	a1, a2, a3
-               	ld	t2, -0x7a8(s0)
+               	ld	t2, -0x6b8(s0)
                	mv	a2, t2
                	sh	a1, 0x0(a2)
                	addi	a1, s5, 0x2
@@ -1015,7 +985,7 @@ Disassembly of section .text:
                	addi	a1, s9, 0x2
                	lhu	a3, 0x0(a1)
                	subw	a1, a2, a3
-               	ld	t2, -0x7a8(s0)
+               	ld	t2, -0x6b8(s0)
                	addi	a2, t2, 0x2
                	sh	a1, 0x0(a2)
                	addi	a1, s5, 0x4
@@ -1023,7 +993,7 @@ Disassembly of section .text:
                	addi	a1, s9, 0x4
                	lhu	a3, 0x0(a1)
                	subw	a1, a2, a3
-               	ld	t2, -0x7a8(s0)
+               	ld	t2, -0x6b8(s0)
                	addi	a2, t2, 0x4
                	sh	a1, 0x0(a2)
                	addi	a1, s5, 0x6
@@ -1031,39 +1001,19 @@ Disassembly of section .text:
                	addi	a1, s9, 0x6
                	lhu	a3, 0x0(a1)
                	subw	a1, a2, a3
-               	ld	t2, -0x7a8(s0)
+               	ld	t2, -0x6b8(s0)
                	addi	a2, t2, 0x6
                	sh	a1, 0x0(a2)
-               	ld	t2, -0x7a8(s0)
+               	ld	t2, -0x6b8(s0)
                	mv	a1, t2
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0xf78>
-               	ld	t2, -0x7a8(s0)
-               	addi	a1, t2, 0x2
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0xf90>
-               	ld	t2, -0x7a8(s0)
-               	addi	a1, t2, 0x4
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0xfa8>
-               	ld	t2, -0x7a8(s0)
-               	addi	a1, t2, 0x6
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0xfc0>
+               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0xef8>
                	mv	a1, s7
                	lhu	a2, 0x0(a1)
                	mv	a1, s9
                	lhu	a3, 0x0(a1)
                	and	a1, a2, a3
-               	ld	t2, -0x6d0(s0)
+               	ld	t2, -0x5f0(s0)
                	mv	a2, t2
                	sh	a1, 0x0(a2)
                	addi	a1, s7, 0x2
@@ -1071,7 +1021,7 @@ Disassembly of section .text:
                	addi	a1, s9, 0x2
                	lhu	a3, 0x0(a1)
                	and	a1, a2, a3
-               	ld	t2, -0x6d0(s0)
+               	ld	t2, -0x5f0(s0)
                	addi	a2, t2, 0x2
                	sh	a1, 0x0(a2)
                	addi	a1, s7, 0x4
@@ -1079,7 +1029,7 @@ Disassembly of section .text:
                	addi	a1, s9, 0x4
                	lhu	a3, 0x0(a1)
                	and	a1, a2, a3
-               	ld	t2, -0x6d0(s0)
+               	ld	t2, -0x5f0(s0)
                	addi	a2, t2, 0x4
                	sh	a1, 0x0(a2)
                	addi	a1, s7, 0x6
@@ -1087,39 +1037,19 @@ Disassembly of section .text:
                	addi	a1, s9, 0x6
                	lhu	a3, 0x0(a1)
                	and	a1, a2, a3
-               	ld	t2, -0x6d0(s0)
+               	ld	t2, -0x5f0(s0)
                	addi	a2, t2, 0x6
                	sh	a1, 0x0(a2)
-               	ld	t2, -0x6d0(s0)
+               	ld	t2, -0x5f0(s0)
                	mv	a1, t2
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0x1058>
-               	ld	t2, -0x6d0(s0)
-               	addi	a1, t2, 0x2
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0x1070>
-               	ld	t2, -0x6d0(s0)
-               	addi	a1, t2, 0x4
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0x1088>
-               	ld	t2, -0x6d0(s0)
-               	addi	a1, t2, 0x6
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0x10a0>
+               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0xf88>
                	mv	a1, s7
                	lhu	a2, 0x0(a1)
                	mv	a1, s9
                	lhu	a3, 0x0(a1)
                	or	a1, a2, a3
-               	ld	t2, -0x6d8(s0)
+               	ld	t2, -0x5f8(s0)
                	mv	a2, t2
                	sh	a1, 0x0(a2)
                	addi	a1, s7, 0x2
@@ -1127,7 +1057,7 @@ Disassembly of section .text:
                	addi	a1, s9, 0x2
                	lhu	a3, 0x0(a1)
                	or	a1, a2, a3
-               	ld	t2, -0x6d8(s0)
+               	ld	t2, -0x5f8(s0)
                	addi	a2, t2, 0x2
                	sh	a1, 0x0(a2)
                	addi	a1, s7, 0x4
@@ -1135,7 +1065,7 @@ Disassembly of section .text:
                	addi	a1, s9, 0x4
                	lhu	a3, 0x0(a1)
                	or	a1, a2, a3
-               	ld	t2, -0x6d8(s0)
+               	ld	t2, -0x5f8(s0)
                	addi	a2, t2, 0x4
                	sh	a1, 0x0(a2)
                	addi	a1, s7, 0x6
@@ -1143,39 +1073,19 @@ Disassembly of section .text:
                	addi	a1, s9, 0x6
                	lhu	a3, 0x0(a1)
                	or	a1, a2, a3
-               	ld	t2, -0x6d8(s0)
+               	ld	t2, -0x5f8(s0)
                	addi	a2, t2, 0x6
                	sh	a1, 0x0(a2)
-               	ld	t2, -0x6d8(s0)
+               	ld	t2, -0x5f8(s0)
                	mv	a1, t2
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0x1138>
-               	ld	t2, -0x6d8(s0)
-               	addi	a1, t2, 0x2
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0x1150>
-               	ld	t2, -0x6d8(s0)
-               	addi	a1, t2, 0x4
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0x1168>
-               	ld	t2, -0x6d8(s0)
-               	addi	a1, t2, 0x6
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0x1180>
+               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0x1018>
                	mv	a1, s7
                	lhu	a2, 0x0(a1)
                	mv	a1, s9
                	lhu	a3, 0x0(a1)
                	xor	a1, a2, a3
-               	ld	t2, -0x6e0(s0)
+               	ld	t2, -0x600(s0)
                	mv	a2, t2
                	sh	a1, 0x0(a2)
                	addi	a1, s7, 0x2
@@ -1183,7 +1093,7 @@ Disassembly of section .text:
                	addi	a1, s9, 0x2
                	lhu	a3, 0x0(a1)
                	xor	a1, a2, a3
-               	ld	t2, -0x6e0(s0)
+               	ld	t2, -0x600(s0)
                	addi	a2, t2, 0x2
                	sh	a1, 0x0(a2)
                	addi	a1, s7, 0x4
@@ -1191,7 +1101,7 @@ Disassembly of section .text:
                	addi	a1, s9, 0x4
                	lhu	a3, 0x0(a1)
                	xor	a1, a2, a3
-               	ld	t2, -0x6e0(s0)
+               	ld	t2, -0x600(s0)
                	addi	a2, t2, 0x4
                	sh	a1, 0x0(a2)
                	addi	a1, s7, 0x6
@@ -1199,269 +1109,125 @@ Disassembly of section .text:
                	addi	a1, s9, 0x6
                	lhu	a3, 0x0(a1)
                	xor	a1, a2, a3
-               	ld	t2, -0x6e0(s0)
+               	ld	t2, -0x600(s0)
                	addi	a2, t2, 0x6
                	sh	a1, 0x0(a2)
-               	ld	t2, -0x6e0(s0)
+               	ld	t2, -0x600(s0)
                	mv	a1, t2
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0x1218>
-               	ld	t2, -0x6e0(s0)
-               	addi	a1, t2, 0x2
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0x1230>
-               	ld	t2, -0x6e0(s0)
-               	addi	a1, t2, 0x4
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0x1248>
-               	ld	t2, -0x6e0(s0)
-               	addi	a1, t2, 0x6
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0x1260>
+               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0x10a8>
                	mv	a1, s7
                	lhu	a2, 0x0(a1)
                	not	a1, a2
-               	ld	t2, -0x6e8(s0)
+               	ld	t2, -0x608(s0)
                	mv	a2, t2
                	sh	a1, 0x0(a2)
                	addi	a1, s7, 0x2
                	lhu	a2, 0x0(a1)
                	not	a1, a2
-               	ld	t2, -0x6e8(s0)
+               	ld	t2, -0x608(s0)
                	addi	a2, t2, 0x2
                	sh	a1, 0x0(a2)
                	addi	a1, s7, 0x4
                	lhu	a2, 0x0(a1)
                	not	a1, a2
-               	ld	t2, -0x6e8(s0)
+               	ld	t2, -0x608(s0)
                	addi	a2, t2, 0x4
                	sh	a1, 0x0(a2)
                	addi	a1, s7, 0x6
                	lhu	a2, 0x0(a1)
                	not	a1, a2
-               	ld	t2, -0x6e8(s0)
+               	ld	t2, -0x608(s0)
                	addi	a2, t2, 0x6
                	sh	a1, 0x0(a2)
-               	ld	t2, -0x6e8(s0)
+               	ld	t2, -0x608(s0)
                	mv	a1, t2
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0x12d8>
-               	ld	t2, -0x6e8(s0)
-               	addi	a1, t2, 0x2
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0x12f0>
-               	ld	t2, -0x6e8(s0)
-               	addi	a1, t2, 0x4
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0x1308>
-               	ld	t2, -0x6e8(s0)
-               	addi	a1, t2, 0x6
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0x1320>
+               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0x1118>
                	mv	a1, s9
                	lhu	a2, 0x0(a1)
                	not	a1, a2
-               	ld	t2, -0x6f0(s0)
+               	ld	t2, -0x610(s0)
                	mv	a2, t2
                	sh	a1, 0x0(a2)
                	addi	a1, s9, 0x2
                	lhu	a2, 0x0(a1)
                	not	a1, a2
-               	ld	t2, -0x6f0(s0)
+               	ld	t2, -0x610(s0)
                	addi	a2, t2, 0x2
                	sh	a1, 0x0(a2)
                	addi	a1, s9, 0x4
                	lhu	a2, 0x0(a1)
                	not	a1, a2
-               	ld	t2, -0x6f0(s0)
+               	ld	t2, -0x610(s0)
                	addi	a2, t2, 0x4
                	sh	a1, 0x0(a2)
                	addi	a1, s9, 0x6
                	lhu	a2, 0x0(a1)
                	not	a1, a2
-               	ld	t2, -0x6f0(s0)
+               	ld	t2, -0x610(s0)
                	addi	a2, t2, 0x6
                	sh	a1, 0x0(a2)
-               	ld	t2, -0x6f0(s0)
+               	ld	t2, -0x610(s0)
+               	mv	a1, t2
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0x1188>
+               	ld	t2, -0x5f0(s0)
                	mv	a1, t2
                	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0x1398>
-               	ld	t2, -0x6f0(s0)
-               	addi	a1, t2, 0x2
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0x13b0>
-               	ld	t2, -0x6f0(s0)
-               	addi	a1, t2, 0x4
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0x13c8>
-               	ld	t2, -0x6f0(s0)
-               	addi	a1, t2, 0x6
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0x13e0>
-               	mv	a1, s7
-               	lhu	a2, 0x0(a1)
-               	mv	a1, s9
+               	ld	t2, -0x5f8(s0)
+               	mv	a1, t2
                	lhu	a3, 0x0(a1)
-               	and	a1, a2, a3
-               	ld	t2, -0x6f8(s0)
+               	xor	a1, a2, a3
+               	ld	t2, -0x618(s0)
                	mv	a2, t2
                	sh	a1, 0x0(a2)
-               	addi	a1, s7, 0x2
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s9, 0x2
-               	lhu	a3, 0x0(a1)
-               	and	a1, a2, a3
-               	ld	t2, -0x6f8(s0)
-               	addi	a2, t2, 0x2
-               	sh	a1, 0x0(a2)
-               	addi	a1, s7, 0x4
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s9, 0x4
-               	lhu	a3, 0x0(a1)
-               	and	a1, a2, a3
-               	ld	t2, -0x6f8(s0)
-               	addi	a2, t2, 0x4
-               	sh	a1, 0x0(a2)
-               	addi	a1, s7, 0x6
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s9, 0x6
-               	lhu	a3, 0x0(a1)
-               	and	a1, a2, a3
-               	ld	t2, -0x6f8(s0)
-               	addi	a2, t2, 0x6
-               	sh	a1, 0x0(a2)
-               	mv	a1, s7
-               	lhu	a2, 0x0(a1)
-               	mv	a1, s9
-               	lhu	a3, 0x0(a1)
-               	or	a1, a2, a3
-               	ld	t2, -0x700(s0)
-               	mv	a2, t2
-               	sh	a1, 0x0(a2)
-               	addi	a1, s7, 0x2
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s9, 0x2
-               	lhu	a3, 0x0(a1)
-               	or	a1, a2, a3
-               	ld	t2, -0x700(s0)
-               	addi	a2, t2, 0x2
-               	sh	a1, 0x0(a2)
-               	addi	a1, s7, 0x4
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s9, 0x4
-               	lhu	a3, 0x0(a1)
-               	or	a1, a2, a3
-               	ld	t2, -0x700(s0)
-               	addi	a2, t2, 0x4
-               	sh	a1, 0x0(a2)
-               	addi	a1, s7, 0x6
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s9, 0x6
-               	lhu	a3, 0x0(a1)
-               	or	a1, a2, a3
-               	ld	t2, -0x700(s0)
-               	addi	a2, t2, 0x6
-               	sh	a1, 0x0(a2)
-               	ld	t2, -0x6f8(s0)
-               	mv	a1, t2
-               	lhu	a2, 0x0(a1)
-               	ld	t2, -0x700(s0)
-               	mv	a1, t2
-               	lhu	a3, 0x0(a1)
-               	xor	a1, a2, a3
-               	ld	t2, -0x708(s0)
-               	mv	a2, t2
-               	sh	a1, 0x0(a2)
-               	ld	t2, -0x6f8(s0)
+               	ld	t2, -0x5f0(s0)
                	addi	a1, t2, 0x2
                	lhu	a2, 0x0(a1)
-               	ld	t2, -0x700(s0)
+               	ld	t2, -0x5f8(s0)
                	addi	a1, t2, 0x2
                	lhu	a3, 0x0(a1)
                	xor	a1, a2, a3
-               	ld	t2, -0x708(s0)
+               	ld	t2, -0x618(s0)
                	addi	a2, t2, 0x2
                	sh	a1, 0x0(a2)
-               	ld	t2, -0x6f8(s0)
+               	ld	t2, -0x5f0(s0)
                	addi	a1, t2, 0x4
                	lhu	a2, 0x0(a1)
-               	ld	t2, -0x700(s0)
+               	ld	t2, -0x5f8(s0)
                	addi	a1, t2, 0x4
                	lhu	a3, 0x0(a1)
                	xor	a1, a2, a3
-               	ld	t2, -0x708(s0)
+               	ld	t2, -0x618(s0)
                	addi	a2, t2, 0x4
                	sh	a1, 0x0(a2)
-               	ld	t2, -0x6f8(s0)
+               	ld	t2, -0x5f0(s0)
                	addi	a1, t2, 0x6
                	lhu	a2, 0x0(a1)
-               	ld	t2, -0x700(s0)
+               	ld	t2, -0x5f8(s0)
                	addi	a1, t2, 0x6
                	lhu	a3, 0x0(a1)
                	xor	a1, a2, a3
-               	ld	t2, -0x708(s0)
+               	ld	t2, -0x618(s0)
                	addi	a2, t2, 0x6
                	sh	a1, 0x0(a2)
-               	ld	t2, -0x708(s0)
+               	ld	t2, -0x618(s0)
                	mv	a1, t2
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0x1598>
-               	ld	t2, -0x708(s0)
-               	addi	a1, t2, 0x2
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0x15b0>
-               	ld	t2, -0x708(s0)
-               	addi	a1, t2, 0x4
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0x15c8>
-               	ld	t2, -0x708(s0)
-               	addi	a1, t2, 0x6
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0x15e0>
+               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0x1238>
                	mv	s1, a0
                	mv	s2, s5
                	li	s3, 0x0
                	li	t0, 0x6
-               	bltu	s3, t0, 0x16ac <corpus.cases.vec.vec_i16x4.checksum+0x1600>
-               	j	0x1a64 <corpus.cases.vec.vec_i16x4.checksum+0x19b8>
+               	bltu	s3, t0, 0x1304 <corpus.cases.vec.vec_i16x4.checksum+0x1258>
+               	j	0x16bc <corpus.cases.vec.vec_i16x4.checksum+0x1610>
                	mv	a0, s7
                	lhu	a1, 0x0(a0)
                	mv	a0, s4
                	lhu	a2, 0x0(a0)
                	mulw	a0, a1, a2
-               	ld	t2, -0x710(s0)
+               	ld	t2, -0x620(s0)
                	mv	a1, t2
                	sh	a0, 0x0(a1)
                	addi	a0, s7, 0x2
@@ -1469,7 +1235,7 @@ Disassembly of section .text:
                	addi	a0, s4, 0x2
                	lhu	a2, 0x0(a0)
                	mulw	a0, a1, a2
-               	ld	t2, -0x710(s0)
+               	ld	t2, -0x620(s0)
                	addi	a1, t2, 0x2
                	sh	a0, 0x0(a1)
                	addi	a0, s7, 0x4
@@ -1477,7 +1243,7 @@ Disassembly of section .text:
                	addi	a0, s4, 0x4
                	lhu	a2, 0x0(a0)
                	mulw	a0, a1, a2
-               	ld	t2, -0x710(s0)
+               	ld	t2, -0x620(s0)
                	addi	a1, t2, 0x4
                	sh	a0, 0x0(a1)
                	addi	a0, s7, 0x6
@@ -1485,99 +1251,99 @@ Disassembly of section .text:
                	addi	a0, s4, 0x6
                	lhu	a2, 0x0(a0)
                	mulw	a0, a1, a2
-               	ld	t2, -0x710(s0)
+               	ld	t2, -0x620(s0)
                	addi	a1, t2, 0x6
                	sh	a0, 0x0(a1)
-               	ld	t2, -0x710(s0)
+               	ld	t2, -0x620(s0)
                	mv	a0, t2
                	lhu	a1, 0x0(a0)
                	mv	a0, s1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0x1690>
-               	ld	t2, -0x710(s0)
+               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0x12e8>
+               	ld	t2, -0x620(s0)
                	addi	a1, t2, 0x2
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0x16a8>
-               	ld	t2, -0x710(s0)
+               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0x1300>
+               	ld	t2, -0x620(s0)
                	addi	a1, t2, 0x4
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0x16c0>
-               	ld	t2, -0x710(s0)
+               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0x1318>
+               	ld	t2, -0x620(s0)
                	addi	a1, t2, 0x6
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0x16d8>
+               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0x1330>
                	mv	a1, s2
                	lhu	a2, 0x0(a1)
-               	ld	t2, -0x710(s0)
+               	ld	t2, -0x620(s0)
                	mv	a1, t2
                	lhu	a3, 0x0(a1)
                	xor	a1, a2, a3
-               	ld	t2, -0x718(s0)
+               	ld	t2, -0x628(s0)
                	mv	a2, t2
                	sh	a1, 0x0(a2)
                	addi	a1, s2, 0x2
                	lhu	a2, 0x0(a1)
-               	ld	t2, -0x710(s0)
+               	ld	t2, -0x620(s0)
                	addi	a1, t2, 0x2
                	lhu	a3, 0x0(a1)
                	xor	a1, a2, a3
-               	ld	t2, -0x718(s0)
+               	ld	t2, -0x628(s0)
                	addi	a2, t2, 0x2
                	sh	a1, 0x0(a2)
                	addi	a1, s2, 0x4
                	lhu	a2, 0x0(a1)
-               	ld	t2, -0x710(s0)
+               	ld	t2, -0x620(s0)
                	addi	a1, t2, 0x4
                	lhu	a3, 0x0(a1)
                	xor	a1, a2, a3
-               	ld	t2, -0x718(s0)
+               	ld	t2, -0x628(s0)
                	addi	a2, t2, 0x4
                	sh	a1, 0x0(a2)
                	addi	a1, s2, 0x6
                	lhu	a2, 0x0(a1)
-               	ld	t2, -0x710(s0)
+               	ld	t2, -0x620(s0)
                	addi	a1, t2, 0x6
                	lhu	a3, 0x0(a1)
                	xor	a1, a2, a3
-               	ld	t2, -0x718(s0)
+               	ld	t2, -0x628(s0)
                	addi	a2, t2, 0x6
                	sh	a1, 0x0(a2)
-               	ld	t2, -0x718(s0)
+               	ld	t2, -0x628(s0)
                	mv	a1, t2
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0x1780>
-               	ld	t2, -0x718(s0)
+               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0x13d8>
+               	ld	t2, -0x628(s0)
                	addi	a1, t2, 0x2
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0x1798>
-               	ld	t2, -0x718(s0)
+               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0x13f0>
+               	ld	t2, -0x628(s0)
                	addi	a1, t2, 0x4
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0x17b0>
-               	ld	t2, -0x718(s0)
+               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0x1408>
+               	ld	t2, -0x628(s0)
                	addi	a1, t2, 0x6
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0x17c8>
+               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0x1420>
                	mv	a1, s5
                	lhu	a2, 0x0(a1)
                	mv	a1, s7
                	lhu	a3, 0x0(a1)
                	addw	a1, a2, a3
-               	ld	t2, -0x720(s0)
+               	ld	t2, -0x630(s0)
                	mv	a2, t2
                	sh	a1, 0x0(a2)
                	addi	a1, s5, 0x2
@@ -1585,7 +1351,7 @@ Disassembly of section .text:
                	addi	a1, s7, 0x2
                	lhu	a3, 0x0(a1)
                	addw	a1, a2, a3
-               	ld	t2, -0x720(s0)
+               	ld	t2, -0x630(s0)
                	addi	a2, t2, 0x2
                	sh	a1, 0x0(a2)
                	addi	a1, s5, 0x4
@@ -1593,7 +1359,7 @@ Disassembly of section .text:
                	addi	a1, s7, 0x4
                	lhu	a3, 0x0(a1)
                	addw	a1, a2, a3
-               	ld	t2, -0x720(s0)
+               	ld	t2, -0x630(s0)
                	addi	a2, t2, 0x4
                	sh	a1, 0x0(a2)
                	addi	a1, s5, 0x6
@@ -1601,39 +1367,39 @@ Disassembly of section .text:
                	addi	a1, s7, 0x6
                	lhu	a3, 0x0(a1)
                	addw	a1, a2, a3
-               	ld	t2, -0x720(s0)
+               	ld	t2, -0x630(s0)
                	addi	a2, t2, 0x6
                	sh	a1, 0x0(a2)
-               	ld	t2, -0x720(s0)
+               	ld	t2, -0x630(s0)
                	mv	a1, t2
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0x1860>
-               	ld	t2, -0x720(s0)
+               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0x14b8>
+               	ld	t2, -0x630(s0)
                	addi	a1, t2, 0x2
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0x1878>
-               	ld	t2, -0x720(s0)
+               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0x14d0>
+               	ld	t2, -0x630(s0)
                	addi	a1, t2, 0x4
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0x1890>
-               	ld	t2, -0x720(s0)
+               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0x14e8>
+               	ld	t2, -0x630(s0)
                	addi	a1, t2, 0x6
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0x18a8>
+               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0x1500>
                	mv	a1, s7
                	lhu	a2, 0x0(a1)
                	mv	a1, s9
                	lhu	a3, 0x0(a1)
                	addw	a1, a2, a3
-               	ld	t2, -0x728(s0)
+               	ld	t2, -0x638(s0)
                	mv	a2, t2
                	sh	a1, 0x0(a2)
                	addi	a1, s7, 0x2
@@ -1641,7 +1407,7 @@ Disassembly of section .text:
                	addi	a1, s9, 0x2
                	lhu	a3, 0x0(a1)
                	addw	a1, a2, a3
-               	ld	t2, -0x728(s0)
+               	ld	t2, -0x638(s0)
                	addi	a2, t2, 0x2
                	sh	a1, 0x0(a2)
                	addi	a1, s7, 0x4
@@ -1649,7 +1415,7 @@ Disassembly of section .text:
                	addi	a1, s9, 0x4
                	lhu	a3, 0x0(a1)
                	addw	a1, a2, a3
-               	ld	t2, -0x728(s0)
+               	ld	t2, -0x638(s0)
                	addi	a2, t2, 0x4
                	sh	a1, 0x0(a2)
                	addi	a1, s7, 0x6
@@ -1657,44 +1423,44 @@ Disassembly of section .text:
                	addi	a1, s9, 0x6
                	lhu	a3, 0x0(a1)
                	addw	a1, a2, a3
-               	ld	t2, -0x728(s0)
+               	ld	t2, -0x638(s0)
                	addi	a2, t2, 0x6
                	sh	a1, 0x0(a2)
-               	ld	t2, -0x728(s0)
+               	ld	t2, -0x638(s0)
                	mv	a1, t2
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0x1940>
-               	ld	t2, -0x728(s0)
+               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0x1598>
+               	ld	t2, -0x638(s0)
                	addi	a1, t2, 0x2
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0x1958>
-               	ld	t2, -0x728(s0)
+               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0x15b0>
+               	ld	t2, -0x638(s0)
                	addi	a1, t2, 0x4
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0x1970>
-               	ld	t2, -0x728(s0)
+               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0x15c8>
+               	ld	t2, -0x638(s0)
                	addi	a1, t2, 0x6
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0x1988>
+               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0x15e0>
                	addi	s3, s3, 0x1
                	mv	s1, a0
-               	ld	t2, -0x728(s0)
+               	ld	t2, -0x638(s0)
                	mv	s7, t2
-               	ld	t2, -0x718(s0)
+               	ld	t2, -0x628(s0)
                	mv	s2, t2
-               	ld	t2, -0x720(s0)
+               	ld	t2, -0x630(s0)
                	mv	s5, t2
                	li	t0, 0x6
-               	bltu	s3, t0, 0x16ac <corpus.cases.vec.vec_i16x4.checksum+0x1600>
-               	addi	s3, s0, -0x6b8
+               	bltu	s3, t0, 0x1304 <corpus.cases.vec.vec_i16x4.checksum+0x1258>
+               	addi	s3, s0, -0x5d8
                	sd	zero, 0x0(s3)
                	sd	zero, 0x8(s3)
                	sd	zero, 0x10(s3)
@@ -1723,7 +1489,7 @@ Disassembly of section .text:
                	mv	a0, s9
                	lhu	a2, 0x0(a0)
                	addw	a0, a1, a2
-               	ld	t2, -0x730(s0)
+               	ld	t2, -0x640(s0)
                	mv	a1, t2
                	sh	a0, 0x0(a1)
                	addi	a0, s7, 0x2
@@ -1731,7 +1497,7 @@ Disassembly of section .text:
                	addi	a0, s9, 0x2
                	lhu	a2, 0x0(a0)
                	addw	a0, a1, a2
-               	ld	t2, -0x730(s0)
+               	ld	t2, -0x640(s0)
                	addi	a1, t2, 0x2
                	sh	a0, 0x0(a1)
                	addi	a0, s7, 0x4
@@ -1739,7 +1505,7 @@ Disassembly of section .text:
                	addi	a0, s9, 0x4
                	lhu	a2, 0x0(a0)
                	addw	a0, a1, a2
-               	ld	t2, -0x730(s0)
+               	ld	t2, -0x640(s0)
                	addi	a1, t2, 0x4
                	sh	a0, 0x0(a1)
                	addi	a0, s7, 0x6
@@ -1747,26 +1513,26 @@ Disassembly of section .text:
                	addi	a0, s9, 0x6
                	lhu	a2, 0x0(a0)
                	addw	a0, a1, a2
-               	ld	t2, -0x730(s0)
+               	ld	t2, -0x640(s0)
                	addi	a1, t2, 0x6
                	sh	a0, 0x0(a1)
                	addi	a0, s3, 0x8
-               	ld	t2, -0x730(s0)
+               	ld	t2, -0x640(s0)
                	mv	a1, t2
                	lhu	a2, 0x0(a1)
                	mv	a1, a0
                	sh	a2, 0x0(a1)
-               	ld	t2, -0x730(s0)
+               	ld	t2, -0x640(s0)
                	addi	a1, t2, 0x2
                	lhu	a2, 0x0(a1)
                	addi	a1, a0, 0x2
                	sh	a2, 0x0(a1)
-               	ld	t2, -0x730(s0)
+               	ld	t2, -0x640(s0)
                	addi	a1, t2, 0x4
                	lhu	a2, 0x0(a1)
                	addi	a1, a0, 0x4
                	sh	a2, 0x0(a1)
-               	ld	t2, -0x730(s0)
+               	ld	t2, -0x640(s0)
                	addi	a1, t2, 0x6
                	lhu	a2, 0x0(a1)
                	addi	a1, a0, 0x6
@@ -1776,7 +1542,7 @@ Disassembly of section .text:
                	mv	a0, s4
                	lhu	a2, 0x0(a0)
                	mulw	a0, a1, a2
-               	ld	t2, -0x738(s0)
+               	ld	t2, -0x648(s0)
                	mv	a1, t2
                	sh	a0, 0x0(a1)
                	addi	a0, s7, 0x2
@@ -1784,7 +1550,7 @@ Disassembly of section .text:
                	addi	a0, s4, 0x2
                	lhu	a2, 0x0(a0)
                	mulw	a0, a1, a2
-               	ld	t2, -0x738(s0)
+               	ld	t2, -0x648(s0)
                	addi	a1, t2, 0x2
                	sh	a0, 0x0(a1)
                	addi	a0, s7, 0x4
@@ -1792,7 +1558,7 @@ Disassembly of section .text:
                	addi	a0, s4, 0x4
                	lhu	a2, 0x0(a0)
                	mulw	a0, a1, a2
-               	ld	t2, -0x738(s0)
+               	ld	t2, -0x648(s0)
                	addi	a1, t2, 0x4
                	sh	a0, 0x0(a1)
                	addi	a0, s7, 0x6
@@ -1800,26 +1566,26 @@ Disassembly of section .text:
                	addi	a0, s4, 0x6
                	lhu	a2, 0x0(a0)
                	mulw	a0, a1, a2
-               	ld	t2, -0x738(s0)
+               	ld	t2, -0x648(s0)
                	addi	a1, t2, 0x6
                	sh	a0, 0x0(a1)
                	addi	a0, s3, 0x10
-               	ld	t2, -0x738(s0)
+               	ld	t2, -0x648(s0)
                	mv	a1, t2
                	lhu	a2, 0x0(a1)
                	mv	a1, a0
                	sh	a2, 0x0(a1)
-               	ld	t2, -0x738(s0)
+               	ld	t2, -0x648(s0)
                	addi	a1, t2, 0x2
                	lhu	a2, 0x0(a1)
                	addi	a1, a0, 0x2
                	sh	a2, 0x0(a1)
-               	ld	t2, -0x738(s0)
+               	ld	t2, -0x648(s0)
                	addi	a1, t2, 0x4
                	lhu	a2, 0x0(a1)
                	addi	a1, a0, 0x4
                	sh	a2, 0x0(a1)
-               	ld	t2, -0x738(s0)
+               	ld	t2, -0x648(s0)
                	addi	a1, t2, 0x6
                	lhu	a2, 0x0(a1)
                	addi	a1, a0, 0x6
@@ -1863,7 +1629,7 @@ Disassembly of section .text:
                	mv	a0, s9
                	lhu	a2, 0x0(a0)
                	xor	a0, a1, a2
-               	ld	t2, -0x740(s0)
+               	ld	t2, -0x650(s0)
                	mv	a1, t2
                	sh	a0, 0x0(a1)
                	addi	a0, s7, 0x2
@@ -1871,7 +1637,7 @@ Disassembly of section .text:
                	addi	a0, s9, 0x2
                	lhu	a2, 0x0(a0)
                	xor	a0, a1, a2
-               	ld	t2, -0x740(s0)
+               	ld	t2, -0x650(s0)
                	addi	a1, t2, 0x2
                	sh	a0, 0x0(a1)
                	addi	a0, s7, 0x4
@@ -1879,7 +1645,7 @@ Disassembly of section .text:
                	addi	a0, s9, 0x4
                	lhu	a2, 0x0(a0)
                	xor	a0, a1, a2
-               	ld	t2, -0x740(s0)
+               	ld	t2, -0x650(s0)
                	addi	a1, t2, 0x4
                	sh	a0, 0x0(a1)
                	addi	a0, s7, 0x6
@@ -1887,85 +1653,85 @@ Disassembly of section .text:
                	addi	a0, s9, 0x6
                	lhu	a2, 0x0(a0)
                	xor	a0, a1, a2
-               	ld	t2, -0x740(s0)
+               	ld	t2, -0x650(s0)
                	addi	a1, t2, 0x6
                	sh	a0, 0x0(a1)
                	addi	a0, s3, 0x28
-               	ld	t2, -0x740(s0)
+               	ld	t2, -0x650(s0)
                	mv	a1, t2
                	lhu	a2, 0x0(a1)
                	mv	a1, a0
                	sh	a2, 0x0(a1)
-               	ld	t2, -0x740(s0)
+               	ld	t2, -0x650(s0)
                	addi	a1, t2, 0x2
                	lhu	a2, 0x0(a1)
                	addi	a1, a0, 0x2
                	sh	a2, 0x0(a1)
-               	ld	t2, -0x740(s0)
+               	ld	t2, -0x650(s0)
                	addi	a1, t2, 0x4
                	lhu	a2, 0x0(a1)
                	addi	a1, a0, 0x4
                	sh	a2, 0x0(a1)
-               	ld	t2, -0x740(s0)
+               	ld	t2, -0x650(s0)
                	addi	a1, t2, 0x6
                	lhu	a2, 0x0(a1)
                	addi	a1, a0, 0x6
                	sh	a2, 0x0(a1)
                	li	s2, 0x0
                	li	t0, 0x6
-               	bltu	s2, t0, 0x1dd8 <corpus.cases.vec.vec_i16x4.checksum+0x1d2c>
-               	j	0x1ea0 <corpus.cases.vec.vec_i16x4.checksum+0x1df4>
+               	bltu	s2, t0, 0x1a30 <corpus.cases.vec.vec_i16x4.checksum+0x1984>
+               	j	0x1af8 <corpus.cases.vec.vec_i16x4.checksum+0x1a4c>
                	slli	t0, s2, 0x3
                	add	a0, s3, t0
                	mv	a1, a0
                	lhu	a2, 0x0(a1)
-               	ld	t2, -0x748(s0)
+               	ld	t2, -0x658(s0)
                	mv	a1, t2
                	sh	a2, 0x0(a1)
                	addi	a1, a0, 0x2
                	lhu	a2, 0x0(a1)
-               	ld	t2, -0x748(s0)
+               	ld	t2, -0x658(s0)
                	addi	a1, t2, 0x2
                	sh	a2, 0x0(a1)
                	addi	a1, a0, 0x4
                	lhu	a2, 0x0(a1)
-               	ld	t2, -0x748(s0)
+               	ld	t2, -0x658(s0)
                	addi	a1, t2, 0x4
                	sh	a2, 0x0(a1)
                	addi	a1, a0, 0x6
                	lhu	a0, 0x0(a1)
-               	ld	t2, -0x748(s0)
+               	ld	t2, -0x658(s0)
                	addi	a1, t2, 0x6
                	sh	a0, 0x0(a1)
-               	ld	t2, -0x748(s0)
+               	ld	t2, -0x658(s0)
                	mv	a0, t2
                	lhu	a1, 0x0(a0)
                	mv	a0, s1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0x1d94>
-               	ld	t2, -0x748(s0)
+               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0x19ec>
+               	ld	t2, -0x658(s0)
                	addi	a1, t2, 0x2
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0x1dac>
-               	ld	t2, -0x748(s0)
+               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0x1a04>
+               	ld	t2, -0x658(s0)
                	addi	a1, t2, 0x4
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0x1dc4>
-               	ld	t2, -0x748(s0)
+               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0x1a1c>
+               	ld	t2, -0x658(s0)
                	addi	a1, t2, 0x6
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0x1ddc>
+               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0x1a34>
                	addi	s2, s2, 0x1
                	mv	s1, a0
                	li	t0, 0x6
-               	bltu	s2, t0, 0x1dd8 <corpus.cases.vec.vec_i16x4.checksum+0x1d2c>
-               	addi	s2, s0, -0x6c4
+               	bltu	s2, t0, 0x1a30 <corpus.cases.vec.vec_i16x4.checksum+0x1984>
+               	addi	s2, s0, -0x5e4
                	sd	zero, 0x0(s2)
                	sw	zero, 0x8(s2)
                	mv	a0, s2
@@ -1974,41 +1740,41 @@ Disassembly of section .text:
                	addi	a1, s3, 0x10
                	mv	a2, a1
                	lhu	a3, 0x0(a2)
-               	ld	t2, -0x750(s0)
+               	ld	t2, -0x660(s0)
                	mv	a2, t2
                	sh	a3, 0x0(a2)
                	addi	a2, a1, 0x2
                	lhu	a3, 0x0(a2)
-               	ld	t2, -0x750(s0)
+               	ld	t2, -0x660(s0)
                	addi	a2, t2, 0x2
                	sh	a3, 0x0(a2)
                	addi	a2, a1, 0x4
                	lhu	a3, 0x0(a2)
-               	ld	t2, -0x750(s0)
+               	ld	t2, -0x660(s0)
                	addi	a2, t2, 0x4
                	sh	a3, 0x0(a2)
                	addi	a2, a1, 0x6
                	lhu	a1, 0x0(a2)
-               	ld	t2, -0x750(s0)
+               	ld	t2, -0x660(s0)
                	addi	a2, t2, 0x6
                	sh	a1, 0x0(a2)
                	addi	s3, s2, 0x2
-               	ld	t2, -0x750(s0)
+               	ld	t2, -0x660(s0)
                	mv	a1, t2
                	lhu	a2, 0x0(a1)
                	mv	a1, s3
                	sh	a2, 0x0(a1)
-               	ld	t2, -0x750(s0)
+               	ld	t2, -0x660(s0)
                	addi	a1, t2, 0x2
                	lhu	a2, 0x0(a1)
                	addi	a1, s3, 0x2
                	sh	a2, 0x0(a1)
-               	ld	t2, -0x750(s0)
+               	ld	t2, -0x660(s0)
                	addi	a1, t2, 0x4
                	lhu	a2, 0x0(a1)
                	addi	a1, s3, 0x4
                	sh	a2, 0x0(a1)
-               	ld	t2, -0x750(s0)
+               	ld	t2, -0x660(s0)
                	addi	a1, t2, 0x6
                	lhu	a2, 0x0(a1)
                	addi	a1, s3, 0x6
@@ -2019,68 +1785,68 @@ Disassembly of section .text:
                	lbu	a1, 0x0(a0)
                	mv	a0, s1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0x1ec8>
+               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0x1b20>
                	mv	a1, s3
                	lhu	a2, 0x0(a1)
-               	ld	t2, -0x758(s0)
+               	ld	t2, -0x668(s0)
                	mv	a1, t2
                	sh	a2, 0x0(a1)
                	addi	a1, s3, 0x2
                	lhu	a2, 0x0(a1)
-               	ld	t2, -0x758(s0)
+               	ld	t2, -0x668(s0)
                	addi	a1, t2, 0x2
                	sh	a2, 0x0(a1)
                	addi	a1, s3, 0x4
                	lhu	a2, 0x0(a1)
-               	ld	t2, -0x758(s0)
+               	ld	t2, -0x668(s0)
                	addi	a1, t2, 0x4
                	sh	a2, 0x0(a1)
                	addi	a1, s3, 0x6
                	lhu	a2, 0x0(a1)
-               	ld	t2, -0x758(s0)
+               	ld	t2, -0x668(s0)
                	addi	a1, t2, 0x6
                	sh	a2, 0x0(a1)
-               	ld	t2, -0x758(s0)
+               	ld	t2, -0x668(s0)
                	mv	a1, t2
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0x1f30>
-               	ld	t2, -0x758(s0)
+               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0x1b88>
+               	ld	t2, -0x668(s0)
                	addi	a1, t2, 0x2
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0x1f48>
-               	ld	t2, -0x758(s0)
+               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0x1ba0>
+               	ld	t2, -0x668(s0)
                	addi	a1, t2, 0x4
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0x1f60>
-               	ld	t2, -0x758(s0)
+               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0x1bb8>
+               	ld	t2, -0x668(s0)
                	addi	a1, t2, 0x6
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0x1f78>
+               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0x1bd0>
                	addi	a1, s2, 0xa
                	lbu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0x1f8c>
-               	ld	s1, 0x798(sp)
-               	ld	s2, 0x790(sp)
-               	ld	s3, 0x788(sp)
-               	ld	s4, 0x780(sp)
-               	ld	s5, 0x778(sp)
-               	ld	s6, 0x770(sp)
-               	ld	s7, 0x768(sp)
-               	ld	s8, 0x760(sp)
-               	ld	s9, 0x758(sp)
-               	ld	s10, 0x750(sp)
-               	ld	s11, 0x748(sp)
-               	ld	ra, 0x7a8(sp)
-               	ld	s0, 0x7a0(sp)
-               	addi	sp, sp, 0x7b0
+               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0x1be4>
+               	ld	s1, 0x6a8(sp)
+               	ld	s2, 0x6a0(sp)
+               	ld	s3, 0x698(sp)
+               	ld	s4, 0x690(sp)
+               	ld	s5, 0x688(sp)
+               	ld	s6, 0x680(sp)
+               	ld	s7, 0x678(sp)
+               	ld	s8, 0x670(sp)
+               	ld	s9, 0x668(sp)
+               	ld	s10, 0x660(sp)
+               	ld	s11, 0x658(sp)
+               	ld	ra, 0x6b8(sp)
+               	ld	s0, 0x6b0(sp)
+               	addi	sp, sp, 0x6c0
                	ret

--- a/test/golden/riscv64-linux/vec/vec_i16x8.dis
+++ b/test/golden/riscv64-linux/vec/vec_i16x8.dis
@@ -81,61 +81,61 @@ Disassembly of section .text:
 
 <corpus.cases.vec.vec_i16x8.checksum>:
                	lui	t0, 0x1
-               	addiw	t0, t0, 0x380
+               	addiw	t0, t0, -0x10
                	sub	sp, sp, t0
                	lui	t1, 0x1
-               	addiw	t1, t1, 0x378
+               	addiw	t1, t1, -0x18
                	add	t1, sp, t1
                	sd	ra, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, 0x370
+               	addiw	t1, t1, -0x20
                	add	t1, sp, t1
                	sd	s0, 0x0(t1)
                	lui	t0, 0x1
-               	addiw	t0, t0, 0x380
+               	addiw	t0, t0, -0x10
                	add	s0, sp, t0
                	lui	t1, 0x1
-               	addiw	t1, t1, 0x368
+               	addiw	t1, t1, -0x28
                	add	t1, sp, t1
                	sd	s1, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, 0x360
+               	addiw	t1, t1, -0x30
                	add	t1, sp, t1
                	sd	s2, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, 0x358
+               	addiw	t1, t1, -0x38
                	add	t1, sp, t1
                	sd	s3, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, 0x350
+               	addiw	t1, t1, -0x40
                	add	t1, sp, t1
                	sd	s4, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, 0x348
+               	addiw	t1, t1, -0x48
                	add	t1, sp, t1
                	sd	s5, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, 0x340
+               	addiw	t1, t1, -0x50
                	add	t1, sp, t1
                	sd	s6, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, 0x338
+               	addiw	t1, t1, -0x58
                	add	t1, sp, t1
                	sd	s7, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, 0x330
+               	addiw	t1, t1, -0x60
                	add	t1, sp, t1
                	sd	s8, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, 0x328
+               	addiw	t1, t1, -0x68
                	add	t1, sp, t1
                	sd	s9, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, 0x320
+               	addiw	t1, t1, -0x70
                	add	t1, sp, t1
                	sd	s10, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, 0x318
+               	addiw	t1, t1, -0x78
                	add	t1, sp, t1
                	sd	s11, 0x0(t1)
                	mv	s1, a0
@@ -167,107 +167,99 @@ Disassembly of section .text:
                	addi	a1, s0, -0x208
                	addi	t2, s0, -0x218
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x338
+               	addiw	t1, t1, 0x58
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	a1, s0, -0x228
                	addi	a1, s0, -0x238
                	addi	t2, s0, -0x248
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x340
+               	addiw	t1, t1, 0x50
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	a1, s0, -0x258
                	addi	a1, s0, -0x268
                	addi	t2, s0, -0x278
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x348
+               	addiw	t1, t1, 0x48
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	a1, s0, -0x288
                	addi	a1, s0, -0x298
                	addi	t2, s0, -0x2a8
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x350
+               	addiw	t1, t1, 0x40
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	a1, s0, -0x2b8
                	addi	a1, s0, -0x2c8
                	addi	t2, s0, -0x2d8
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x358
+               	addiw	t1, t1, 0x38
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	a1, s0, -0x2e8
                	addi	t2, s0, -0x2f8
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x360
+               	addiw	t1, t1, 0x30
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	a1, s0, -0x308
                	addi	a1, s0, -0x318
                	addi	t2, s0, -0x328
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x368
+               	addiw	t1, t1, 0x28
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	a1, s0, -0x338
                	addi	a1, s0, -0x348
                	addi	t2, s0, -0x358
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x370
+               	addiw	t1, t1, 0x20
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	a1, s0, -0x368
                	addi	a1, s0, -0x378
                	addi	t2, s0, -0x388
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2a0
+               	addiw	t1, t1, 0xe0
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	a1, s0, -0x398
                	addi	a1, s0, -0x3a8
                	addi	t2, s0, -0x3b8
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2a8
+               	addiw	t1, t1, 0xd8
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	a1, s0, -0x3c8
                	addi	a1, s0, -0x3d8
                	addi	t2, s0, -0x3e8
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2b0
+               	addiw	t1, t1, 0xd0
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	a1, s0, -0x3f8
                	addi	t2, s0, -0x408
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2b8
+               	addiw	t1, t1, 0xc8
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	a1, s0, -0x418
                	addi	t2, s0, -0x428
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2c0
+               	addiw	t1, t1, 0xc0
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	a1, s0, -0x438
                	addi	a1, s0, -0x448
-               	addi	t2, s0, -0x458
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2c8
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
+               	addi	a1, s0, -0x458
                	addi	a1, s0, -0x468
                	addi	a1, s0, -0x478
-               	addi	t2, s0, -0x488
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2d0
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
+               	addi	a1, s0, -0x488
                	addi	t2, s0, -0x498
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2d8
+               	addiw	t1, t1, 0xb8
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	a1, s0, -0x4a8
@@ -276,7 +268,7 @@ Disassembly of section .text:
                	addi	a1, s0, -0x4d8
                	addi	t2, s0, -0x4e8
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2e0
+               	addiw	t1, t1, 0xb0
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	a1, s0, -0x4f8
@@ -284,7 +276,7 @@ Disassembly of section .text:
                	addi	a1, s0, -0x518
                	addi	t2, s0, -0x528
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2e8
+               	addiw	t1, t1, 0xa8
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	a1, s0, -0x538
@@ -292,7 +284,7 @@ Disassembly of section .text:
                	addi	a1, s0, -0x558
                	addi	t2, s0, -0x568
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2f0
+               	addiw	t1, t1, 0xa0
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	a1, s0, -0x578
@@ -300,7 +292,7 @@ Disassembly of section .text:
                	addi	a1, s0, -0x598
                	addi	t2, s0, -0x5a8
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2f8
+               	addiw	t1, t1, 0x98
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	a1, s0, -0x5b8
@@ -309,30 +301,30 @@ Disassembly of section .text:
                	addi	a1, s0, -0x5e8
                	addi	t2, s0, -0x5f8
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x300
+               	addiw	t1, t1, 0x90
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	a1, s0, -0x608
                	addi	a1, s0, -0x618
                	addi	t2, s0, -0x628
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x308
+               	addiw	t1, t1, 0x88
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	a1, s0, -0x638
                	addi	t2, s0, -0x648
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x310
+               	addiw	t1, t1, 0x80
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	t2, s0, -0x658
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x318
+               	addiw	t1, t1, 0x78
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	t2, s0, -0x668
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x320
+               	addiw	t1, t1, 0x70
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	a1, s0, -0x678
@@ -669,192 +661,24 @@ Disassembly of section .text:
                	lui	t0, 0xfffff
                	addiw	t0, t0, 0x198
                	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x188
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x178
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x168
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x158
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x148
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x138
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x128
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x118
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x108
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0xf8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0xe8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0xd8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0xc8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0xb8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0xa8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x98
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x88
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x78
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x68
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x58
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x48
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x38
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x28
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x18
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x18
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x28
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x38
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x48
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x58
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x68
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x78
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x88
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x98
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0xa8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0xb8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0xc8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0xd8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0xe8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0xf8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x108
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x118
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x128
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x138
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x148
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x158
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x168
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x178
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x188
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x198
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x1a8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x1b8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x1c8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x1d8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x1e8
-               	add	a1, s0, t0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0xbd4>
+               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x914>
                	mv	t2, a0
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x328
+               	addiw	t1, t1, 0x68
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x328
+               	addiw	t1, t1, 0x68
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	sext.w	t2, s1
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x330
+               	addiw	t1, t1, 0x60
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x1f8
+               	addiw	t0, t0, 0x188
                	add	s1, s0, t0
                	mv	a0, s1
                	li	t0, 0x3e9
@@ -917,7 +741,7 @@ Disassembly of section .text:
                	addi	a0, s2, 0xe
                	sh	a1, 0x0(a0)
                	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x208
+               	addiw	t0, t0, 0x178
                	add	a0, s0, t0
                	mv	a1, a0
                	li	t0, 0xd
@@ -980,7 +804,7 @@ Disassembly of section .text:
                	addi	a1, s3, 0xe
                	sh	a0, 0x0(a1)
                	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x218
+               	addiw	t0, t0, 0x168
                	add	a0, s0, t0
                	mv	a1, a0
                	li	t0, 0x1
@@ -1039,7 +863,7 @@ Disassembly of section .text:
                	addi	a1, s4, 0xe
                	sh	a0, 0x0(a1)
                	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x228
+               	addiw	t0, t0, 0x158
                	add	a0, s0, t0
                	mv	a1, a0
                	sh	zero, 0x0(a1)
@@ -1092,7 +916,7 @@ Disassembly of section .text:
                	mv	a0, s2
                	lhu	a1, 0x0(a0)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x330
+               	addiw	t1, t1, 0x60
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addw	a0, a1, t2
@@ -1133,7 +957,7 @@ Disassembly of section .text:
                	addi	a0, s6, 0xc
                	lhu	a1, 0x0(a0)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x330
+               	addiw	t1, t1, 0x60
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addw	a0, a1, t2
@@ -1174,7 +998,7 @@ Disassembly of section .text:
                	addi	a0, s3, 0x4
                	lhu	a1, 0x0(a0)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x330
+               	addiw	t1, t1, 0x60
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addw	a0, a1, t2
@@ -1215,7 +1039,7 @@ Disassembly of section .text:
                	addi	a0, s8, 0xe
                	lhu	a1, 0x0(a0)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x330
+               	addiw	t1, t1, 0x60
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addw	a0, a1, t2
@@ -1256,87 +1080,87 @@ Disassembly of section .text:
                	mv	a0, s7
                	lhu	a1, 0x0(a0)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x328
+               	addiw	t1, t1, 0x68
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a0, t2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x1270>
+               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0xfb0>
                	addi	a1, s7, 0x2
                	lhu	s1, 0x0(a1)
                	mv	a1, s1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x1284>
+               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0xfc4>
                	addi	a1, s7, 0x4
                	lhu	s1, 0x0(a1)
                	mv	a1, s1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x1298>
+               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0xfd8>
                	addi	a1, s7, 0x6
                	lhu	s1, 0x0(a1)
                	mv	a1, s1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x12ac>
+               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0xfec>
                	addi	a1, s7, 0x8
                	lhu	s1, 0x0(a1)
                	mv	a1, s1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x12c0>
+               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x1000>
                	addi	a1, s7, 0xa
                	lhu	s1, 0x0(a1)
                	mv	a1, s1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x12d4>
+               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x1014>
                	addi	a1, s7, 0xc
                	lhu	s1, 0x0(a1)
                	mv	a1, s1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x12e8>
+               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x1028>
                	addi	a1, s7, 0xe
                	lhu	s1, 0x0(a1)
                	mv	a1, s1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x12fc>
+               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x103c>
                	mv	a1, s9
                	lhu	s1, 0x0(a1)
                	mv	a1, s1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x1310>
+               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x1050>
                	addi	a1, s9, 0x2
                	lhu	s1, 0x0(a1)
                	mv	a1, s1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x1324>
+               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x1064>
                	addi	a1, s9, 0x4
                	lhu	s1, 0x0(a1)
                	mv	a1, s1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x1338>
+               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x1078>
                	addi	a1, s9, 0x6
                	lhu	s1, 0x0(a1)
                	mv	a1, s1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x134c>
+               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x108c>
                	addi	a1, s9, 0x8
                	lhu	s1, 0x0(a1)
                	mv	a1, s1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x1360>
+               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x10a0>
                	addi	a1, s9, 0xa
                	lhu	s1, 0x0(a1)
                	mv	a1, s1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x1374>
+               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x10b4>
                	addi	a1, s9, 0xc
                	lhu	s1, 0x0(a1)
                	mv	a1, s1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x1388>
+               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x10c8>
                	addi	a1, s9, 0xe
                	lhu	s1, 0x0(a1)
                	mv	a1, s1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x139c>
+               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x10dc>
                	mv	a1, s7
                	lhu	s1, 0x0(a1)
                	mv	a1, s9
@@ -1397,42 +1221,42 @@ Disassembly of section .text:
                	lhu	s1, 0x0(a1)
                	mv	a1, s1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x1490>
+               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x11d0>
                	addi	a1, s10, 0x2
                	lhu	s1, 0x0(a1)
                	mv	a1, s1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x14a4>
+               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x11e4>
                	addi	a1, s10, 0x4
                	lhu	s1, 0x0(a1)
                	mv	a1, s1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x14b8>
+               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x11f8>
                	addi	a1, s10, 0x6
                	lhu	s1, 0x0(a1)
                	mv	a1, s1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x14cc>
+               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x120c>
                	addi	a1, s10, 0x8
                	lhu	s1, 0x0(a1)
                	mv	a1, s1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x14e0>
+               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x1220>
                	addi	a1, s10, 0xa
                	lhu	s1, 0x0(a1)
                	mv	a1, s1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x14f4>
+               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x1234>
                	addi	a1, s10, 0xc
                	lhu	s1, 0x0(a1)
                	mv	a1, s1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x1508>
+               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x1248>
                	addi	a1, s10, 0xe
                	lhu	s1, 0x0(a1)
                	mv	a1, s1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x151c>
+               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x125c>
                	mv	a1, s7
                	lhu	s1, 0x0(a1)
                	mv	a1, s9
@@ -1493,49 +1317,49 @@ Disassembly of section .text:
                	lhu	s1, 0x0(a1)
                	mv	a1, s1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x1610>
+               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x1350>
                	addi	a1, s11, 0x2
                	lhu	s1, 0x0(a1)
                	mv	a1, s1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x1624>
+               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x1364>
                	addi	a1, s11, 0x4
                	lhu	s1, 0x0(a1)
                	mv	a1, s1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x1638>
+               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x1378>
                	addi	a1, s11, 0x6
                	lhu	s1, 0x0(a1)
                	mv	a1, s1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x164c>
+               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x138c>
                	addi	a1, s11, 0x8
                	lhu	s1, 0x0(a1)
                	mv	a1, s1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x1660>
+               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x13a0>
                	addi	a1, s11, 0xa
                	lhu	s1, 0x0(a1)
                	mv	a1, s1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x1674>
+               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x13b4>
                	addi	a1, s11, 0xc
                	lhu	s1, 0x0(a1)
                	mv	a1, s1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x1688>
+               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x13c8>
                	addi	a1, s11, 0xe
                	lhu	s1, 0x0(a1)
                	mv	a1, s1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x169c>
+               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x13dc>
                	mv	a1, s9
                	lhu	s1, 0x0(a1)
                	mv	a1, s7
                	lhu	s2, 0x0(a1)
                	subw	a1, s1, s2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x338
+               	addiw	t1, t1, 0x58
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	s1, t2
@@ -1546,7 +1370,7 @@ Disassembly of section .text:
                	lhu	s2, 0x0(a1)
                	subw	a1, s1, s2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x338
+               	addiw	t1, t1, 0x58
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	s1, t2, 0x2
@@ -1557,7 +1381,7 @@ Disassembly of section .text:
                	lhu	s2, 0x0(a1)
                	subw	a1, s1, s2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x338
+               	addiw	t1, t1, 0x58
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	s1, t2, 0x4
@@ -1568,7 +1392,7 @@ Disassembly of section .text:
                	lhu	s2, 0x0(a1)
                	subw	a1, s1, s2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x338
+               	addiw	t1, t1, 0x58
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	s1, t2, 0x6
@@ -1579,7 +1403,7 @@ Disassembly of section .text:
                	lhu	s2, 0x0(a1)
                	subw	a1, s1, s2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x338
+               	addiw	t1, t1, 0x58
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	s1, t2, 0x8
@@ -1590,7 +1414,7 @@ Disassembly of section .text:
                	lhu	s2, 0x0(a1)
                	subw	a1, s1, s2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x338
+               	addiw	t1, t1, 0x58
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	s1, t2, 0xa
@@ -1601,7 +1425,7 @@ Disassembly of section .text:
                	lhu	s2, 0x0(a1)
                	subw	a1, s1, s2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x338
+               	addiw	t1, t1, 0x58
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	s1, t2, 0xc
@@ -1612,90 +1436,90 @@ Disassembly of section .text:
                	lhu	s2, 0x0(a1)
                	subw	a1, s1, s2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x338
+               	addiw	t1, t1, 0x58
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	s1, t2, 0xe
                	sh	a1, 0x0(s1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x338
+               	addiw	t1, t1, 0x58
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	lhu	s1, 0x0(a1)
                	mv	a1, s1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x1820>
+               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x1560>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x338
+               	addiw	t1, t1, 0x58
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x2
                	lhu	s1, 0x0(a1)
                	mv	a1, s1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x1844>
+               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x1584>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x338
+               	addiw	t1, t1, 0x58
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	lhu	s1, 0x0(a1)
                	mv	a1, s1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x1868>
+               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x15a8>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x338
+               	addiw	t1, t1, 0x58
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x6
                	lhu	s1, 0x0(a1)
                	mv	a1, s1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x188c>
+               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x15cc>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x338
+               	addiw	t1, t1, 0x58
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	lhu	s1, 0x0(a1)
                	mv	a1, s1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x18b0>
+               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x15f0>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x338
+               	addiw	t1, t1, 0x58
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xa
                	lhu	s1, 0x0(a1)
                	mv	a1, s1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x18d4>
+               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x1614>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x338
+               	addiw	t1, t1, 0x58
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	lhu	s1, 0x0(a1)
                	mv	a1, s1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x18f8>
+               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x1638>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x338
+               	addiw	t1, t1, 0x58
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xe
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x191c>
+               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x165c>
                	mv	a1, s7
                	lhu	a2, 0x0(a1)
                	mv	a1, s9
                	lhu	s1, 0x0(a1)
                	mulw	a1, a2, s1
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x340
+               	addiw	t1, t1, 0x50
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
@@ -1706,7 +1530,7 @@ Disassembly of section .text:
                	lhu	s1, 0x0(a1)
                	mulw	a1, a2, s1
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x340
+               	addiw	t1, t1, 0x50
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x2
@@ -1717,7 +1541,7 @@ Disassembly of section .text:
                	lhu	s1, 0x0(a1)
                	mulw	a1, a2, s1
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x340
+               	addiw	t1, t1, 0x50
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x4
@@ -1728,7 +1552,7 @@ Disassembly of section .text:
                	lhu	s1, 0x0(a1)
                	mulw	a1, a2, s1
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x340
+               	addiw	t1, t1, 0x50
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x6
@@ -1739,7 +1563,7 @@ Disassembly of section .text:
                	lhu	s1, 0x0(a1)
                	mulw	a1, a2, s1
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x340
+               	addiw	t1, t1, 0x50
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
@@ -1750,7 +1574,7 @@ Disassembly of section .text:
                	lhu	s1, 0x0(a1)
                	mulw	a1, a2, s1
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x340
+               	addiw	t1, t1, 0x50
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xa
@@ -1761,7 +1585,7 @@ Disassembly of section .text:
                	lhu	s1, 0x0(a1)
                	mulw	a1, a2, s1
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x340
+               	addiw	t1, t1, 0x50
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xc
@@ -1772,90 +1596,90 @@ Disassembly of section .text:
                	lhu	s1, 0x0(a1)
                	mulw	a1, a2, s1
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x340
+               	addiw	t1, t1, 0x50
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xe
                	sh	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x340
+               	addiw	t1, t1, 0x50
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x1aa0>
+               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x17e0>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x340
+               	addiw	t1, t1, 0x50
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x2
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x1ac4>
+               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x1804>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x340
+               	addiw	t1, t1, 0x50
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x1ae8>
+               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x1828>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x340
+               	addiw	t1, t1, 0x50
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x6
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x1b0c>
+               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x184c>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x340
+               	addiw	t1, t1, 0x50
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x1b30>
+               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x1870>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x340
+               	addiw	t1, t1, 0x50
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xa
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x1b54>
+               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x1894>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x340
+               	addiw	t1, t1, 0x50
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x1b78>
+               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x18b8>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x340
+               	addiw	t1, t1, 0x50
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xe
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x1b9c>
+               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x18dc>
                	mv	a1, s7
                	lhu	a2, 0x0(a1)
                	mv	a1, s4
                	lhu	a3, 0x0(a1)
                	mulw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x348
+               	addiw	t1, t1, 0x48
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
@@ -1866,7 +1690,7 @@ Disassembly of section .text:
                	lhu	a3, 0x0(a1)
                	mulw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x348
+               	addiw	t1, t1, 0x48
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x2
@@ -1877,7 +1701,7 @@ Disassembly of section .text:
                	lhu	a3, 0x0(a1)
                	mulw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x348
+               	addiw	t1, t1, 0x48
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x4
@@ -1888,7 +1712,7 @@ Disassembly of section .text:
                	lhu	a3, 0x0(a1)
                	mulw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x348
+               	addiw	t1, t1, 0x48
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x6
@@ -1899,7 +1723,7 @@ Disassembly of section .text:
                	lhu	a3, 0x0(a1)
                	mulw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x348
+               	addiw	t1, t1, 0x48
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
@@ -1910,7 +1734,7 @@ Disassembly of section .text:
                	lhu	a3, 0x0(a1)
                	mulw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x348
+               	addiw	t1, t1, 0x48
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xa
@@ -1921,7 +1745,7 @@ Disassembly of section .text:
                	lhu	a3, 0x0(a1)
                	mulw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x348
+               	addiw	t1, t1, 0x48
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xc
@@ -1932,90 +1756,90 @@ Disassembly of section .text:
                	lhu	a3, 0x0(a1)
                	mulw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x348
+               	addiw	t1, t1, 0x48
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xe
                	sh	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x348
+               	addiw	t1, t1, 0x48
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x1d20>
+               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x1a60>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x348
+               	addiw	t1, t1, 0x48
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x2
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x1d44>
+               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x1a84>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x348
+               	addiw	t1, t1, 0x48
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x1d68>
+               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x1aa8>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x348
+               	addiw	t1, t1, 0x48
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x6
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x1d8c>
+               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x1acc>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x348
+               	addiw	t1, t1, 0x48
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x1db0>
+               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x1af0>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x348
+               	addiw	t1, t1, 0x48
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xa
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x1dd4>
+               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x1b14>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x348
+               	addiw	t1, t1, 0x48
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x1df8>
+               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x1b38>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x348
+               	addiw	t1, t1, 0x48
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xe
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x1e1c>
+               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x1b5c>
                	mv	a1, s9
                	lhu	a2, 0x0(a1)
                	mv	a1, s4
                	lhu	a3, 0x0(a1)
                	mulw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x350
+               	addiw	t1, t1, 0x40
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
@@ -2026,7 +1850,7 @@ Disassembly of section .text:
                	lhu	a3, 0x0(a1)
                	mulw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x350
+               	addiw	t1, t1, 0x40
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x2
@@ -2037,7 +1861,7 @@ Disassembly of section .text:
                	lhu	a3, 0x0(a1)
                	mulw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x350
+               	addiw	t1, t1, 0x40
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x4
@@ -2048,7 +1872,7 @@ Disassembly of section .text:
                	lhu	a3, 0x0(a1)
                	mulw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x350
+               	addiw	t1, t1, 0x40
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x6
@@ -2059,7 +1883,7 @@ Disassembly of section .text:
                	lhu	a3, 0x0(a1)
                	mulw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x350
+               	addiw	t1, t1, 0x40
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
@@ -2070,7 +1894,7 @@ Disassembly of section .text:
                	lhu	a3, 0x0(a1)
                	mulw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x350
+               	addiw	t1, t1, 0x40
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xa
@@ -2081,7 +1905,7 @@ Disassembly of section .text:
                	lhu	a3, 0x0(a1)
                	mulw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x350
+               	addiw	t1, t1, 0x40
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xc
@@ -2092,90 +1916,90 @@ Disassembly of section .text:
                	lhu	a3, 0x0(a1)
                	mulw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x350
+               	addiw	t1, t1, 0x40
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xe
                	sh	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x350
+               	addiw	t1, t1, 0x40
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x1fa0>
+               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x1ce0>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x350
+               	addiw	t1, t1, 0x40
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x2
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x1fc4>
+               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x1d04>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x350
+               	addiw	t1, t1, 0x40
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x1fe8>
+               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x1d28>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x350
+               	addiw	t1, t1, 0x40
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x6
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x200c>
+               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x1d4c>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x350
+               	addiw	t1, t1, 0x40
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x2030>
+               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x1d70>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x350
+               	addiw	t1, t1, 0x40
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xa
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x2054>
+               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x1d94>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x350
+               	addiw	t1, t1, 0x40
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x2078>
+               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x1db8>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x350
+               	addiw	t1, t1, 0x40
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xe
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x209c>
+               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x1ddc>
                	mv	a1, s7
                	lhu	a2, 0x0(a1)
                	mv	a1, s9
                	lhu	a3, 0x0(a1)
                	addw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x358
+               	addiw	t1, t1, 0x38
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
@@ -2186,7 +2010,7 @@ Disassembly of section .text:
                	lhu	a3, 0x0(a1)
                	addw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x358
+               	addiw	t1, t1, 0x38
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x2
@@ -2197,7 +2021,7 @@ Disassembly of section .text:
                	lhu	a3, 0x0(a1)
                	addw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x358
+               	addiw	t1, t1, 0x38
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x4
@@ -2208,7 +2032,7 @@ Disassembly of section .text:
                	lhu	a3, 0x0(a1)
                	addw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x358
+               	addiw	t1, t1, 0x38
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x6
@@ -2219,7 +2043,7 @@ Disassembly of section .text:
                	lhu	a3, 0x0(a1)
                	addw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x358
+               	addiw	t1, t1, 0x38
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
@@ -2230,7 +2054,7 @@ Disassembly of section .text:
                	lhu	a3, 0x0(a1)
                	addw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x358
+               	addiw	t1, t1, 0x38
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xa
@@ -2241,7 +2065,7 @@ Disassembly of section .text:
                	lhu	a3, 0x0(a1)
                	addw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x358
+               	addiw	t1, t1, 0x38
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xc
@@ -2252,13 +2076,13 @@ Disassembly of section .text:
                	lhu	a3, 0x0(a1)
                	addw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x358
+               	addiw	t1, t1, 0x38
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xe
                	sh	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x358
+               	addiw	t1, t1, 0x38
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
@@ -2267,13 +2091,13 @@ Disassembly of section .text:
                	lhu	a3, 0x0(a1)
                	mulw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x360
+               	addiw	t1, t1, 0x30
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
                	sh	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x358
+               	addiw	t1, t1, 0x38
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x2
@@ -2282,13 +2106,13 @@ Disassembly of section .text:
                	lhu	a3, 0x0(a1)
                	mulw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x360
+               	addiw	t1, t1, 0x30
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x2
                	sh	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x358
+               	addiw	t1, t1, 0x38
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
@@ -2297,13 +2121,13 @@ Disassembly of section .text:
                	lhu	a3, 0x0(a1)
                	mulw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x360
+               	addiw	t1, t1, 0x30
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x4
                	sh	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x358
+               	addiw	t1, t1, 0x38
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x6
@@ -2312,13 +2136,13 @@ Disassembly of section .text:
                	lhu	a3, 0x0(a1)
                	mulw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x360
+               	addiw	t1, t1, 0x30
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x6
                	sh	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x358
+               	addiw	t1, t1, 0x38
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
@@ -2327,13 +2151,13 @@ Disassembly of section .text:
                	lhu	a3, 0x0(a1)
                	mulw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x360
+               	addiw	t1, t1, 0x30
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
                	sh	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x358
+               	addiw	t1, t1, 0x38
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xa
@@ -2342,13 +2166,13 @@ Disassembly of section .text:
                	lhu	a3, 0x0(a1)
                	mulw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x360
+               	addiw	t1, t1, 0x30
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xa
                	sh	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x358
+               	addiw	t1, t1, 0x38
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
@@ -2357,13 +2181,13 @@ Disassembly of section .text:
                	lhu	a3, 0x0(a1)
                	mulw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x360
+               	addiw	t1, t1, 0x30
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xc
                	sh	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x358
+               	addiw	t1, t1, 0x38
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xe
@@ -2372,90 +2196,90 @@ Disassembly of section .text:
                	lhu	a3, 0x0(a1)
                	mulw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x360
+               	addiw	t1, t1, 0x30
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xe
                	sh	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x360
+               	addiw	t1, t1, 0x30
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x2400>
+               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x2140>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x360
+               	addiw	t1, t1, 0x30
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x2
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x2424>
+               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x2164>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x360
+               	addiw	t1, t1, 0x30
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x2448>
+               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x2188>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x360
+               	addiw	t1, t1, 0x30
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x6
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x246c>
+               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x21ac>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x360
+               	addiw	t1, t1, 0x30
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x2490>
+               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x21d0>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x360
+               	addiw	t1, t1, 0x30
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xa
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x24b4>
+               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x21f4>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x360
+               	addiw	t1, t1, 0x30
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x24d8>
+               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x2218>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x360
+               	addiw	t1, t1, 0x30
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xe
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x24fc>
+               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x223c>
                	mv	a1, s5
                	lhu	a2, 0x0(a1)
                	mv	a1, s7
                	lhu	a3, 0x0(a1)
                	subw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x368
+               	addiw	t1, t1, 0x28
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
@@ -2466,7 +2290,7 @@ Disassembly of section .text:
                	lhu	a3, 0x0(a1)
                	subw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x368
+               	addiw	t1, t1, 0x28
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x2
@@ -2477,7 +2301,7 @@ Disassembly of section .text:
                	lhu	a3, 0x0(a1)
                	subw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x368
+               	addiw	t1, t1, 0x28
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x4
@@ -2488,7 +2312,7 @@ Disassembly of section .text:
                	lhu	a3, 0x0(a1)
                	subw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x368
+               	addiw	t1, t1, 0x28
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x6
@@ -2499,7 +2323,7 @@ Disassembly of section .text:
                	lhu	a3, 0x0(a1)
                	subw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x368
+               	addiw	t1, t1, 0x28
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
@@ -2510,7 +2334,7 @@ Disassembly of section .text:
                	lhu	a3, 0x0(a1)
                	subw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x368
+               	addiw	t1, t1, 0x28
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xa
@@ -2521,7 +2345,7 @@ Disassembly of section .text:
                	lhu	a3, 0x0(a1)
                	subw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x368
+               	addiw	t1, t1, 0x28
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xc
@@ -2532,90 +2356,90 @@ Disassembly of section .text:
                	lhu	a3, 0x0(a1)
                	subw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x368
+               	addiw	t1, t1, 0x28
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xe
                	sh	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x368
+               	addiw	t1, t1, 0x28
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x2680>
+               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x23c0>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x368
+               	addiw	t1, t1, 0x28
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x2
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x26a4>
+               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x23e4>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x368
+               	addiw	t1, t1, 0x28
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x26c8>
+               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x2408>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x368
+               	addiw	t1, t1, 0x28
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x6
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x26ec>
+               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x242c>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x368
+               	addiw	t1, t1, 0x28
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x2710>
+               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x2450>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x368
+               	addiw	t1, t1, 0x28
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xa
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x2734>
+               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x2474>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x368
+               	addiw	t1, t1, 0x28
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x2758>
+               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x2498>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x368
+               	addiw	t1, t1, 0x28
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xe
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x277c>
+               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x24bc>
                	mv	a1, s5
                	lhu	a2, 0x0(a1)
                	mv	a1, s9
                	lhu	a3, 0x0(a1)
                	subw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x370
+               	addiw	t1, t1, 0x20
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
@@ -2626,7 +2450,7 @@ Disassembly of section .text:
                	lhu	a3, 0x0(a1)
                	subw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x370
+               	addiw	t1, t1, 0x20
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x2
@@ -2637,7 +2461,7 @@ Disassembly of section .text:
                	lhu	a3, 0x0(a1)
                	subw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x370
+               	addiw	t1, t1, 0x20
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x4
@@ -2648,7 +2472,7 @@ Disassembly of section .text:
                	lhu	a3, 0x0(a1)
                	subw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x370
+               	addiw	t1, t1, 0x20
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x6
@@ -2659,7 +2483,7 @@ Disassembly of section .text:
                	lhu	a3, 0x0(a1)
                	subw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x370
+               	addiw	t1, t1, 0x20
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
@@ -2670,7 +2494,7 @@ Disassembly of section .text:
                	lhu	a3, 0x0(a1)
                	subw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x370
+               	addiw	t1, t1, 0x20
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xa
@@ -2681,7 +2505,7 @@ Disassembly of section .text:
                	lhu	a3, 0x0(a1)
                	subw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x370
+               	addiw	t1, t1, 0x20
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xc
@@ -2692,90 +2516,25 @@ Disassembly of section .text:
                	lhu	a3, 0x0(a1)
                	subw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x370
+               	addiw	t1, t1, 0x20
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xe
                	sh	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x370
+               	addiw	t1, t1, 0x20
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x2900>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x370
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x2
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x2924>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x370
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x2948>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x370
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x6
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x296c>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x370
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x2990>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x370
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xa
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x29b4>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x370
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x29d8>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x370
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xe
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x29fc>
+               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x2638>
                	mv	a1, s7
                	lhu	a2, 0x0(a1)
                	mv	a1, s9
                	lhu	a3, 0x0(a1)
                	and	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2a0
+               	addiw	t1, t1, 0xe0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
@@ -2786,7 +2545,7 @@ Disassembly of section .text:
                	lhu	a3, 0x0(a1)
                	and	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2a0
+               	addiw	t1, t1, 0xe0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x2
@@ -2797,7 +2556,7 @@ Disassembly of section .text:
                	lhu	a3, 0x0(a1)
                	and	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2a0
+               	addiw	t1, t1, 0xe0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x4
@@ -2808,7 +2567,7 @@ Disassembly of section .text:
                	lhu	a3, 0x0(a1)
                	and	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2a0
+               	addiw	t1, t1, 0xe0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x6
@@ -2819,7 +2578,7 @@ Disassembly of section .text:
                	lhu	a3, 0x0(a1)
                	and	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2a0
+               	addiw	t1, t1, 0xe0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
@@ -2830,7 +2589,7 @@ Disassembly of section .text:
                	lhu	a3, 0x0(a1)
                	and	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2a0
+               	addiw	t1, t1, 0xe0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xa
@@ -2841,7 +2600,7 @@ Disassembly of section .text:
                	lhu	a3, 0x0(a1)
                	and	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2a0
+               	addiw	t1, t1, 0xe0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xc
@@ -2852,90 +2611,25 @@ Disassembly of section .text:
                	lhu	a3, 0x0(a1)
                	and	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2a0
+               	addiw	t1, t1, 0xe0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xe
                	sh	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2a0
+               	addiw	t1, t1, 0xe0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x2b80>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2a0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x2
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x2ba4>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2a0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x2bc8>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2a0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x6
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x2bec>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2a0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x2c10>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2a0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xa
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x2c34>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2a0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x2c58>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2a0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xe
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x2c7c>
+               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x27b4>
                	mv	a1, s7
                	lhu	a2, 0x0(a1)
                	mv	a1, s9
                	lhu	a3, 0x0(a1)
                	or	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2a8
+               	addiw	t1, t1, 0xd8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
@@ -2946,7 +2640,7 @@ Disassembly of section .text:
                	lhu	a3, 0x0(a1)
                	or	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2a8
+               	addiw	t1, t1, 0xd8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x2
@@ -2957,7 +2651,7 @@ Disassembly of section .text:
                	lhu	a3, 0x0(a1)
                	or	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2a8
+               	addiw	t1, t1, 0xd8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x4
@@ -2968,7 +2662,7 @@ Disassembly of section .text:
                	lhu	a3, 0x0(a1)
                	or	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2a8
+               	addiw	t1, t1, 0xd8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x6
@@ -2979,7 +2673,7 @@ Disassembly of section .text:
                	lhu	a3, 0x0(a1)
                	or	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2a8
+               	addiw	t1, t1, 0xd8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
@@ -2990,7 +2684,7 @@ Disassembly of section .text:
                	lhu	a3, 0x0(a1)
                	or	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2a8
+               	addiw	t1, t1, 0xd8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xa
@@ -3001,7 +2695,7 @@ Disassembly of section .text:
                	lhu	a3, 0x0(a1)
                	or	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2a8
+               	addiw	t1, t1, 0xd8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xc
@@ -3012,90 +2706,25 @@ Disassembly of section .text:
                	lhu	a3, 0x0(a1)
                	or	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2a8
+               	addiw	t1, t1, 0xd8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xe
                	sh	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2a8
+               	addiw	t1, t1, 0xd8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x2e00>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2a8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x2
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x2e24>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2a8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x2e48>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2a8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x6
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x2e6c>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2a8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x2e90>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2a8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xa
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x2eb4>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2a8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x2ed8>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2a8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xe
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x2efc>
+               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x2930>
                	mv	a1, s7
                	lhu	a2, 0x0(a1)
                	mv	a1, s9
                	lhu	a3, 0x0(a1)
                	xor	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2b0
+               	addiw	t1, t1, 0xd0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
@@ -3106,7 +2735,7 @@ Disassembly of section .text:
                	lhu	a3, 0x0(a1)
                	xor	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2b0
+               	addiw	t1, t1, 0xd0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x2
@@ -3117,7 +2746,7 @@ Disassembly of section .text:
                	lhu	a3, 0x0(a1)
                	xor	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2b0
+               	addiw	t1, t1, 0xd0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x4
@@ -3128,7 +2757,7 @@ Disassembly of section .text:
                	lhu	a3, 0x0(a1)
                	xor	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2b0
+               	addiw	t1, t1, 0xd0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x6
@@ -3139,7 +2768,7 @@ Disassembly of section .text:
                	lhu	a3, 0x0(a1)
                	xor	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2b0
+               	addiw	t1, t1, 0xd0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
@@ -3150,7 +2779,7 @@ Disassembly of section .text:
                	lhu	a3, 0x0(a1)
                	xor	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2b0
+               	addiw	t1, t1, 0xd0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xa
@@ -3161,7 +2790,7 @@ Disassembly of section .text:
                	lhu	a3, 0x0(a1)
                	xor	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2b0
+               	addiw	t1, t1, 0xd0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xc
@@ -3172,88 +2801,23 @@ Disassembly of section .text:
                	lhu	a3, 0x0(a1)
                	xor	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2b0
+               	addiw	t1, t1, 0xd0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xe
                	sh	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2b0
+               	addiw	t1, t1, 0xd0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x3080>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2b0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x2
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x30a4>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2b0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x30c8>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2b0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x6
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x30ec>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2b0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x3110>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2b0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xa
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x3134>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2b0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x3158>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2b0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xe
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x317c>
+               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x2aac>
                	mv	a1, s7
                	lhu	a2, 0x0(a1)
                	not	a1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2b8
+               	addiw	t1, t1, 0xc8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
@@ -3262,7 +2826,7 @@ Disassembly of section .text:
                	lhu	a2, 0x0(a1)
                	not	a1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2b8
+               	addiw	t1, t1, 0xc8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x2
@@ -3271,7 +2835,7 @@ Disassembly of section .text:
                	lhu	a2, 0x0(a1)
                	not	a1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2b8
+               	addiw	t1, t1, 0xc8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x4
@@ -3280,7 +2844,7 @@ Disassembly of section .text:
                	lhu	a2, 0x0(a1)
                	not	a1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2b8
+               	addiw	t1, t1, 0xc8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x6
@@ -3289,7 +2853,7 @@ Disassembly of section .text:
                	lhu	a2, 0x0(a1)
                	not	a1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2b8
+               	addiw	t1, t1, 0xc8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
@@ -3298,7 +2862,7 @@ Disassembly of section .text:
                	lhu	a2, 0x0(a1)
                	not	a1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2b8
+               	addiw	t1, t1, 0xc8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xa
@@ -3307,7 +2871,7 @@ Disassembly of section .text:
                	lhu	a2, 0x0(a1)
                	not	a1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2b8
+               	addiw	t1, t1, 0xc8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xc
@@ -3316,88 +2880,23 @@ Disassembly of section .text:
                	lhu	a2, 0x0(a1)
                	not	a1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2b8
+               	addiw	t1, t1, 0xc8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xe
                	sh	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2b8
+               	addiw	t1, t1, 0xc8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x32c0>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2b8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x2
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x32e4>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2b8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x3308>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2b8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x6
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x332c>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2b8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x3350>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2b8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xa
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x3374>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2b8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x3398>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2b8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xe
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x33bc>
+               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x2be8>
                	mv	a1, s9
                	lhu	a2, 0x0(a1)
                	not	a1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2c0
+               	addiw	t1, t1, 0xc0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
@@ -3406,7 +2905,7 @@ Disassembly of section .text:
                	lhu	a2, 0x0(a1)
                	not	a1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2c0
+               	addiw	t1, t1, 0xc0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x2
@@ -3415,7 +2914,7 @@ Disassembly of section .text:
                	lhu	a2, 0x0(a1)
                	not	a1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2c0
+               	addiw	t1, t1, 0xc0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x4
@@ -3424,7 +2923,7 @@ Disassembly of section .text:
                	lhu	a2, 0x0(a1)
                	not	a1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2c0
+               	addiw	t1, t1, 0xc0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x6
@@ -3433,7 +2932,7 @@ Disassembly of section .text:
                	lhu	a2, 0x0(a1)
                	not	a1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2c0
+               	addiw	t1, t1, 0xc0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
@@ -3442,7 +2941,7 @@ Disassembly of section .text:
                	lhu	a2, 0x0(a1)
                	not	a1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2c0
+               	addiw	t1, t1, 0xc0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xa
@@ -3451,7 +2950,7 @@ Disassembly of section .text:
                	lhu	a2, 0x0(a1)
                	not	a1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2c0
+               	addiw	t1, t1, 0xc0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xc
@@ -3460,496 +2959,190 @@ Disassembly of section .text:
                	lhu	a2, 0x0(a1)
                	not	a1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2c0
+               	addiw	t1, t1, 0xc0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xe
                	sh	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2c0
+               	addiw	t1, t1, 0xc0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x3500>
+               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x2d24>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2c0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x2
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x3524>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2c0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x3548>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2c0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x6
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x356c>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2c0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x3590>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2c0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xa
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x35b4>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2c0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x35d8>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2c0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xe
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x35fc>
-               	mv	a1, s7
-               	lhu	a2, 0x0(a1)
-               	mv	a1, s9
-               	lhu	a3, 0x0(a1)
-               	and	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2c8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a2, t2
-               	sh	a1, 0x0(a2)
-               	addi	a1, s7, 0x2
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s9, 0x2
-               	lhu	a3, 0x0(a1)
-               	and	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2c8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x2
-               	sh	a1, 0x0(a2)
-               	addi	a1, s7, 0x4
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s9, 0x4
-               	lhu	a3, 0x0(a1)
-               	and	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2c8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x4
-               	sh	a1, 0x0(a2)
-               	addi	a1, s7, 0x6
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s9, 0x6
-               	lhu	a3, 0x0(a1)
-               	and	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2c8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x6
-               	sh	a1, 0x0(a2)
-               	addi	a1, s7, 0x8
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s9, 0x8
-               	lhu	a3, 0x0(a1)
-               	and	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2c8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x8
-               	sh	a1, 0x0(a2)
-               	addi	a1, s7, 0xa
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s9, 0xa
-               	lhu	a3, 0x0(a1)
-               	and	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2c8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0xa
-               	sh	a1, 0x0(a2)
-               	addi	a1, s7, 0xc
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s9, 0xc
-               	lhu	a3, 0x0(a1)
-               	and	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2c8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0xc
-               	sh	a1, 0x0(a2)
-               	addi	a1, s7, 0xe
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s9, 0xe
-               	lhu	a3, 0x0(a1)
-               	and	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2c8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0xe
-               	sh	a1, 0x0(a2)
-               	mv	a1, s7
-               	lhu	a2, 0x0(a1)
-               	mv	a1, s9
-               	lhu	a3, 0x0(a1)
-               	or	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2d0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a2, t2
-               	sh	a1, 0x0(a2)
-               	addi	a1, s7, 0x2
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s9, 0x2
-               	lhu	a3, 0x0(a1)
-               	or	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2d0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x2
-               	sh	a1, 0x0(a2)
-               	addi	a1, s7, 0x4
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s9, 0x4
-               	lhu	a3, 0x0(a1)
-               	or	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2d0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x4
-               	sh	a1, 0x0(a2)
-               	addi	a1, s7, 0x6
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s9, 0x6
-               	lhu	a3, 0x0(a1)
-               	or	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2d0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x6
-               	sh	a1, 0x0(a2)
-               	addi	a1, s7, 0x8
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s9, 0x8
-               	lhu	a3, 0x0(a1)
-               	or	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2d0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x8
-               	sh	a1, 0x0(a2)
-               	addi	a1, s7, 0xa
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s9, 0xa
-               	lhu	a3, 0x0(a1)
-               	or	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2d0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0xa
-               	sh	a1, 0x0(a2)
-               	addi	a1, s7, 0xc
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s9, 0xc
-               	lhu	a3, 0x0(a1)
-               	or	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2d0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0xc
-               	sh	a1, 0x0(a2)
-               	addi	a1, s7, 0xe
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s9, 0xe
-               	lhu	a3, 0x0(a1)
-               	or	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2d0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0xe
-               	sh	a1, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2c8
+               	addiw	t1, t1, 0xe0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	lhu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2d0
+               	addiw	t1, t1, 0xd8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	lhu	a3, 0x0(a1)
                	xor	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2d8
+               	addiw	t1, t1, 0xb8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
                	sh	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2c8
+               	addiw	t1, t1, 0xe0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x2
                	lhu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2d0
+               	addiw	t1, t1, 0xd8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x2
                	lhu	a3, 0x0(a1)
                	xor	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2d8
+               	addiw	t1, t1, 0xb8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x2
                	sh	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2c8
+               	addiw	t1, t1, 0xe0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	lhu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2d0
+               	addiw	t1, t1, 0xd8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	lhu	a3, 0x0(a1)
                	xor	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2d8
+               	addiw	t1, t1, 0xb8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x4
                	sh	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2c8
+               	addiw	t1, t1, 0xe0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x6
                	lhu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2d0
+               	addiw	t1, t1, 0xd8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x6
                	lhu	a3, 0x0(a1)
                	xor	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2d8
+               	addiw	t1, t1, 0xb8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x6
                	sh	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2c8
+               	addiw	t1, t1, 0xe0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	lhu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2d0
+               	addiw	t1, t1, 0xd8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	lhu	a3, 0x0(a1)
                	xor	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2d8
+               	addiw	t1, t1, 0xb8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
                	sh	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2c8
+               	addiw	t1, t1, 0xe0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xa
                	lhu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2d0
+               	addiw	t1, t1, 0xd8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xa
                	lhu	a3, 0x0(a1)
                	xor	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2d8
+               	addiw	t1, t1, 0xb8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xa
                	sh	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2c8
+               	addiw	t1, t1, 0xe0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	lhu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2d0
+               	addiw	t1, t1, 0xd8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	lhu	a3, 0x0(a1)
                	xor	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2d8
+               	addiw	t1, t1, 0xb8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xc
                	sh	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2c8
+               	addiw	t1, t1, 0xe0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xe
                	lhu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2d0
+               	addiw	t1, t1, 0xd8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xe
                	lhu	a3, 0x0(a1)
                	xor	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2d8
+               	addiw	t1, t1, 0xb8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xe
                	sh	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2d8
+               	addiw	t1, t1, 0xb8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x3b40>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2d8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x2
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x3b64>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2d8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x3b88>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2d8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x6
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x3bac>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2d8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x3bd0>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2d8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xa
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x3bf4>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2d8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x3c18>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2d8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xe
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x3c3c>
+               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x2fa0>
                	mv	s1, a0
                	mv	s2, s5
                	li	s3, 0x0
                	li	t0, 0x6
-               	bltu	s3, t0, 0x3d88 <corpus.cases.vec.vec_i16x8.checksum+0x3c5c>
-               	j	0x4854 <corpus.cases.vec.vec_i16x8.checksum+0x4728>
+               	bltu	s3, t0, 0x30ec <corpus.cases.vec.vec_i16x8.checksum+0x2fc0>
+               	j	0x3bb8 <corpus.cases.vec.vec_i16x8.checksum+0x3a8c>
                	mv	a0, s7
                	lhu	a1, 0x0(a0)
                	mv	a0, s4
                	lhu	a2, 0x0(a0)
                	mulw	a0, a1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2e0
+               	addiw	t1, t1, 0xb0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
@@ -3960,7 +3153,7 @@ Disassembly of section .text:
                	lhu	a2, 0x0(a0)
                	mulw	a0, a1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2e0
+               	addiw	t1, t1, 0xb0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x2
@@ -3971,7 +3164,7 @@ Disassembly of section .text:
                	lhu	a2, 0x0(a0)
                	mulw	a0, a1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2e0
+               	addiw	t1, t1, 0xb0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
@@ -3982,7 +3175,7 @@ Disassembly of section .text:
                	lhu	a2, 0x0(a0)
                	mulw	a0, a1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2e0
+               	addiw	t1, t1, 0xb0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x6
@@ -3993,7 +3186,7 @@ Disassembly of section .text:
                	lhu	a2, 0x0(a0)
                	mulw	a0, a1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2e0
+               	addiw	t1, t1, 0xb0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
@@ -4004,7 +3197,7 @@ Disassembly of section .text:
                	lhu	a2, 0x0(a0)
                	mulw	a0, a1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2e0
+               	addiw	t1, t1, 0xb0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xa
@@ -4015,7 +3208,7 @@ Disassembly of section .text:
                	lhu	a2, 0x0(a0)
                	mulw	a0, a1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2e0
+               	addiw	t1, t1, 0xb0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
@@ -4026,94 +3219,94 @@ Disassembly of section .text:
                	lhu	a2, 0x0(a0)
                	mulw	a0, a1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2e0
+               	addiw	t1, t1, 0xb0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xe
                	sh	a0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2e0
+               	addiw	t1, t1, 0xb0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a0, t2
                	lhu	a1, 0x0(a0)
                	mv	a0, s1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x3dd8>
+               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x313c>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2e0
+               	addiw	t1, t1, 0xb0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x2
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x3dfc>
+               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x3160>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2e0
+               	addiw	t1, t1, 0xb0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x3e20>
+               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x3184>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2e0
+               	addiw	t1, t1, 0xb0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x6
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x3e44>
+               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x31a8>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2e0
+               	addiw	t1, t1, 0xb0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x3e68>
+               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x31cc>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2e0
+               	addiw	t1, t1, 0xb0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xa
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x3e8c>
+               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x31f0>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2e0
+               	addiw	t1, t1, 0xb0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x3eb0>
+               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x3214>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2e0
+               	addiw	t1, t1, 0xb0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xe
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x3ed4>
+               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x3238>
                	mv	a1, s2
                	lhu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2e0
+               	addiw	t1, t1, 0xb0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	lhu	a3, 0x0(a1)
                	xor	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2e8
+               	addiw	t1, t1, 0xa8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
@@ -4121,14 +3314,14 @@ Disassembly of section .text:
                	addi	a1, s2, 0x2
                	lhu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2e0
+               	addiw	t1, t1, 0xb0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x2
                	lhu	a3, 0x0(a1)
                	xor	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2e8
+               	addiw	t1, t1, 0xa8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x2
@@ -4136,14 +3329,14 @@ Disassembly of section .text:
                	addi	a1, s2, 0x4
                	lhu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2e0
+               	addiw	t1, t1, 0xb0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	lhu	a3, 0x0(a1)
                	xor	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2e8
+               	addiw	t1, t1, 0xa8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x4
@@ -4151,14 +3344,14 @@ Disassembly of section .text:
                	addi	a1, s2, 0x6
                	lhu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2e0
+               	addiw	t1, t1, 0xb0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x6
                	lhu	a3, 0x0(a1)
                	xor	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2e8
+               	addiw	t1, t1, 0xa8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x6
@@ -4166,14 +3359,14 @@ Disassembly of section .text:
                	addi	a1, s2, 0x8
                	lhu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2e0
+               	addiw	t1, t1, 0xb0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	lhu	a3, 0x0(a1)
                	xor	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2e8
+               	addiw	t1, t1, 0xa8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
@@ -4181,14 +3374,14 @@ Disassembly of section .text:
                	addi	a1, s2, 0xa
                	lhu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2e0
+               	addiw	t1, t1, 0xb0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xa
                	lhu	a3, 0x0(a1)
                	xor	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2e8
+               	addiw	t1, t1, 0xa8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xa
@@ -4196,14 +3389,14 @@ Disassembly of section .text:
                	addi	a1, s2, 0xc
                	lhu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2e0
+               	addiw	t1, t1, 0xb0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	lhu	a3, 0x0(a1)
                	xor	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2e8
+               	addiw	t1, t1, 0xa8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xc
@@ -4211,97 +3404,97 @@ Disassembly of section .text:
                	addi	a1, s2, 0xe
                	lhu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2e0
+               	addiw	t1, t1, 0xb0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xe
                	lhu	a3, 0x0(a1)
                	xor	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2e8
+               	addiw	t1, t1, 0xa8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xe
                	sh	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2e8
+               	addiw	t1, t1, 0xa8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x40d8>
+               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x343c>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2e8
+               	addiw	t1, t1, 0xa8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x2
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x40fc>
+               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x3460>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2e8
+               	addiw	t1, t1, 0xa8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x4120>
+               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x3484>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2e8
+               	addiw	t1, t1, 0xa8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x6
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x4144>
+               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x34a8>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2e8
+               	addiw	t1, t1, 0xa8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x4168>
+               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x34cc>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2e8
+               	addiw	t1, t1, 0xa8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xa
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x418c>
+               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x34f0>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2e8
+               	addiw	t1, t1, 0xa8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x41b0>
+               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x3514>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2e8
+               	addiw	t1, t1, 0xa8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xe
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x41d4>
+               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x3538>
                	mv	a1, s5
                	lhu	a2, 0x0(a1)
                	mv	a1, s7
                	lhu	a3, 0x0(a1)
                	addw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2f0
+               	addiw	t1, t1, 0xa0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
@@ -4312,7 +3505,7 @@ Disassembly of section .text:
                	lhu	a3, 0x0(a1)
                	addw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2f0
+               	addiw	t1, t1, 0xa0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x2
@@ -4323,7 +3516,7 @@ Disassembly of section .text:
                	lhu	a3, 0x0(a1)
                	addw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2f0
+               	addiw	t1, t1, 0xa0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x4
@@ -4334,7 +3527,7 @@ Disassembly of section .text:
                	lhu	a3, 0x0(a1)
                	addw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2f0
+               	addiw	t1, t1, 0xa0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x6
@@ -4345,7 +3538,7 @@ Disassembly of section .text:
                	lhu	a3, 0x0(a1)
                	addw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2f0
+               	addiw	t1, t1, 0xa0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
@@ -4356,7 +3549,7 @@ Disassembly of section .text:
                	lhu	a3, 0x0(a1)
                	addw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2f0
+               	addiw	t1, t1, 0xa0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xa
@@ -4367,7 +3560,7 @@ Disassembly of section .text:
                	lhu	a3, 0x0(a1)
                	addw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2f0
+               	addiw	t1, t1, 0xa0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xc
@@ -4378,90 +3571,90 @@ Disassembly of section .text:
                	lhu	a3, 0x0(a1)
                	addw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2f0
+               	addiw	t1, t1, 0xa0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xe
                	sh	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2f0
+               	addiw	t1, t1, 0xa0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x4358>
+               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x36bc>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2f0
+               	addiw	t1, t1, 0xa0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x2
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x437c>
+               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x36e0>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2f0
+               	addiw	t1, t1, 0xa0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x43a0>
+               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x3704>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2f0
+               	addiw	t1, t1, 0xa0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x6
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x43c4>
+               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x3728>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2f0
+               	addiw	t1, t1, 0xa0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x43e8>
+               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x374c>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2f0
+               	addiw	t1, t1, 0xa0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xa
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x440c>
+               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x3770>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2f0
+               	addiw	t1, t1, 0xa0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x4430>
+               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x3794>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2f0
+               	addiw	t1, t1, 0xa0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xe
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x4454>
+               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x37b8>
                	mv	a1, s7
                	lhu	a2, 0x0(a1)
                	mv	a1, s9
                	lhu	a3, 0x0(a1)
                	addw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2f8
+               	addiw	t1, t1, 0x98
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
@@ -4472,7 +3665,7 @@ Disassembly of section .text:
                	lhu	a3, 0x0(a1)
                	addw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2f8
+               	addiw	t1, t1, 0x98
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x2
@@ -4483,7 +3676,7 @@ Disassembly of section .text:
                	lhu	a3, 0x0(a1)
                	addw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2f8
+               	addiw	t1, t1, 0x98
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x4
@@ -4494,7 +3687,7 @@ Disassembly of section .text:
                	lhu	a3, 0x0(a1)
                	addw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2f8
+               	addiw	t1, t1, 0x98
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x6
@@ -4505,7 +3698,7 @@ Disassembly of section .text:
                	lhu	a3, 0x0(a1)
                	addw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2f8
+               	addiw	t1, t1, 0x98
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
@@ -4516,7 +3709,7 @@ Disassembly of section .text:
                	lhu	a3, 0x0(a1)
                	addw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2f8
+               	addiw	t1, t1, 0x98
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xa
@@ -4527,7 +3720,7 @@ Disassembly of section .text:
                	lhu	a3, 0x0(a1)
                	addw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2f8
+               	addiw	t1, t1, 0x98
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xc
@@ -4538,104 +3731,104 @@ Disassembly of section .text:
                	lhu	a3, 0x0(a1)
                	addw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2f8
+               	addiw	t1, t1, 0x98
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xe
                	sh	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2f8
+               	addiw	t1, t1, 0x98
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x45d8>
+               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x393c>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2f8
+               	addiw	t1, t1, 0x98
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x2
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x45fc>
+               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x3960>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2f8
+               	addiw	t1, t1, 0x98
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x4620>
+               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x3984>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2f8
+               	addiw	t1, t1, 0x98
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x6
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x4644>
+               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x39a8>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2f8
+               	addiw	t1, t1, 0x98
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x4668>
+               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x39cc>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2f8
+               	addiw	t1, t1, 0x98
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xa
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x468c>
+               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x39f0>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2f8
+               	addiw	t1, t1, 0x98
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x46b0>
+               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x3a14>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2f8
+               	addiw	t1, t1, 0x98
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xe
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x46d4>
+               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x3a38>
                	addi	s3, s3, 0x1
                	mv	s1, a0
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2f8
+               	addiw	t1, t1, 0x98
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	s7, t2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2e8
+               	addiw	t1, t1, 0xa8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	s2, t2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2f0
+               	addiw	t1, t1, 0xa0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	s5, t2
                	li	t0, 0x6
-               	bltu	s3, t0, 0x3d88 <corpus.cases.vec.vec_i16x8.checksum+0x3c5c>
+               	bltu	s3, t0, 0x30ec <corpus.cases.vec.vec_i16x8.checksum+0x2fc0>
                	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x268
+               	addiw	t0, t0, 0x118
                	add	s3, s0, t0
                	sd	zero, 0x0(s3)
                	sd	zero, 0x8(s3)
@@ -4684,7 +3877,7 @@ Disassembly of section .text:
                	lhu	a2, 0x0(a0)
                	addw	a0, a1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x300
+               	addiw	t1, t1, 0x90
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
@@ -4695,7 +3888,7 @@ Disassembly of section .text:
                	lhu	a2, 0x0(a0)
                	addw	a0, a1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x300
+               	addiw	t1, t1, 0x90
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x2
@@ -4706,7 +3899,7 @@ Disassembly of section .text:
                	lhu	a2, 0x0(a0)
                	addw	a0, a1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x300
+               	addiw	t1, t1, 0x90
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
@@ -4717,7 +3910,7 @@ Disassembly of section .text:
                	lhu	a2, 0x0(a0)
                	addw	a0, a1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x300
+               	addiw	t1, t1, 0x90
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x6
@@ -4728,7 +3921,7 @@ Disassembly of section .text:
                	lhu	a2, 0x0(a0)
                	addw	a0, a1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x300
+               	addiw	t1, t1, 0x90
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
@@ -4739,7 +3932,7 @@ Disassembly of section .text:
                	lhu	a2, 0x0(a0)
                	addw	a0, a1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x300
+               	addiw	t1, t1, 0x90
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xa
@@ -4750,7 +3943,7 @@ Disassembly of section .text:
                	lhu	a2, 0x0(a0)
                	addw	a0, a1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x300
+               	addiw	t1, t1, 0x90
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
@@ -4761,14 +3954,14 @@ Disassembly of section .text:
                	lhu	a2, 0x0(a0)
                	addw	a0, a1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x300
+               	addiw	t1, t1, 0x90
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xe
                	sh	a0, 0x0(a1)
                	addi	a0, s3, 0x10
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x300
+               	addiw	t1, t1, 0x90
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
@@ -4776,7 +3969,7 @@ Disassembly of section .text:
                	mv	a1, a0
                	sh	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x300
+               	addiw	t1, t1, 0x90
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x2
@@ -4784,7 +3977,7 @@ Disassembly of section .text:
                	addi	a1, a0, 0x2
                	sh	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x300
+               	addiw	t1, t1, 0x90
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
@@ -4792,7 +3985,7 @@ Disassembly of section .text:
                	addi	a1, a0, 0x4
                	sh	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x300
+               	addiw	t1, t1, 0x90
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x6
@@ -4800,7 +3993,7 @@ Disassembly of section .text:
                	addi	a1, a0, 0x6
                	sh	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x300
+               	addiw	t1, t1, 0x90
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
@@ -4808,7 +4001,7 @@ Disassembly of section .text:
                	addi	a1, a0, 0x8
                	sh	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x300
+               	addiw	t1, t1, 0x90
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xa
@@ -4816,7 +4009,7 @@ Disassembly of section .text:
                	addi	a1, a0, 0xa
                	sh	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x300
+               	addiw	t1, t1, 0x90
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
@@ -4824,7 +4017,7 @@ Disassembly of section .text:
                	addi	a1, a0, 0xc
                	sh	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x300
+               	addiw	t1, t1, 0x90
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xe
@@ -4837,7 +4030,7 @@ Disassembly of section .text:
                	lhu	a2, 0x0(a0)
                	mulw	a0, a1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x308
+               	addiw	t1, t1, 0x88
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
@@ -4848,7 +4041,7 @@ Disassembly of section .text:
                	lhu	a2, 0x0(a0)
                	mulw	a0, a1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x308
+               	addiw	t1, t1, 0x88
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x2
@@ -4859,7 +4052,7 @@ Disassembly of section .text:
                	lhu	a2, 0x0(a0)
                	mulw	a0, a1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x308
+               	addiw	t1, t1, 0x88
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
@@ -4870,7 +4063,7 @@ Disassembly of section .text:
                	lhu	a2, 0x0(a0)
                	mulw	a0, a1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x308
+               	addiw	t1, t1, 0x88
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x6
@@ -4881,7 +4074,7 @@ Disassembly of section .text:
                	lhu	a2, 0x0(a0)
                	mulw	a0, a1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x308
+               	addiw	t1, t1, 0x88
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
@@ -4892,7 +4085,7 @@ Disassembly of section .text:
                	lhu	a2, 0x0(a0)
                	mulw	a0, a1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x308
+               	addiw	t1, t1, 0x88
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xa
@@ -4903,7 +4096,7 @@ Disassembly of section .text:
                	lhu	a2, 0x0(a0)
                	mulw	a0, a1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x308
+               	addiw	t1, t1, 0x88
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
@@ -4914,14 +4107,14 @@ Disassembly of section .text:
                	lhu	a2, 0x0(a0)
                	mulw	a0, a1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x308
+               	addiw	t1, t1, 0x88
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xe
                	sh	a0, 0x0(a1)
                	addi	a0, s3, 0x20
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x308
+               	addiw	t1, t1, 0x88
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
@@ -4929,7 +4122,7 @@ Disassembly of section .text:
                	mv	a1, a0
                	sh	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x308
+               	addiw	t1, t1, 0x88
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x2
@@ -4937,7 +4130,7 @@ Disassembly of section .text:
                	addi	a1, a0, 0x2
                	sh	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x308
+               	addiw	t1, t1, 0x88
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
@@ -4945,7 +4138,7 @@ Disassembly of section .text:
                	addi	a1, a0, 0x4
                	sh	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x308
+               	addiw	t1, t1, 0x88
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x6
@@ -4953,7 +4146,7 @@ Disassembly of section .text:
                	addi	a1, a0, 0x6
                	sh	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x308
+               	addiw	t1, t1, 0x88
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
@@ -4961,7 +4154,7 @@ Disassembly of section .text:
                	addi	a1, a0, 0x8
                	sh	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x308
+               	addiw	t1, t1, 0x88
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xa
@@ -4969,7 +4162,7 @@ Disassembly of section .text:
                	addi	a1, a0, 0xa
                	sh	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x308
+               	addiw	t1, t1, 0x88
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
@@ -4977,7 +4170,7 @@ Disassembly of section .text:
                	addi	a1, a0, 0xc
                	sh	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x308
+               	addiw	t1, t1, 0x88
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xe
@@ -5019,15 +4212,15 @@ Disassembly of section .text:
                	sh	a2, 0x0(a1)
                	li	s2, 0x0
                	li	t0, 0x4
-               	bltu	s2, t0, 0x4e60 <corpus.cases.vec.vec_i16x8.checksum+0x4d34>
-               	j	0x509c <corpus.cases.vec.vec_i16x8.checksum+0x4f70>
+               	bltu	s2, t0, 0x41c4 <corpus.cases.vec.vec_i16x8.checksum+0x4098>
+               	j	0x4400 <corpus.cases.vec.vec_i16x8.checksum+0x42d4>
                	li	t0, 0x10
                	mul	a0, s2, t0
                	add	a1, s3, a0
                	mv	a0, a1
                	lhu	a2, 0x0(a0)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x310
+               	addiw	t1, t1, 0x80
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a0, t2
@@ -5035,7 +4228,7 @@ Disassembly of section .text:
                	addi	a0, a1, 0x2
                	lhu	a2, 0x0(a0)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x310
+               	addiw	t1, t1, 0x80
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a0, t2, 0x2
@@ -5043,7 +4236,7 @@ Disassembly of section .text:
                	addi	a0, a1, 0x4
                	lhu	a2, 0x0(a0)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x310
+               	addiw	t1, t1, 0x80
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a0, t2, 0x4
@@ -5051,7 +4244,7 @@ Disassembly of section .text:
                	addi	a0, a1, 0x6
                	lhu	a2, 0x0(a0)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x310
+               	addiw	t1, t1, 0x80
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a0, t2, 0x6
@@ -5059,7 +4252,7 @@ Disassembly of section .text:
                	addi	a0, a1, 0x8
                	lhu	a2, 0x0(a0)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x310
+               	addiw	t1, t1, 0x80
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a0, t2, 0x8
@@ -5067,7 +4260,7 @@ Disassembly of section .text:
                	addi	a0, a1, 0xa
                	lhu	a2, 0x0(a0)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x310
+               	addiw	t1, t1, 0x80
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a0, t2, 0xa
@@ -5075,7 +4268,7 @@ Disassembly of section .text:
                	addi	a0, a1, 0xc
                	lhu	a2, 0x0(a0)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x310
+               	addiw	t1, t1, 0x80
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a0, t2, 0xc
@@ -5083,89 +4276,89 @@ Disassembly of section .text:
                	addi	a0, a1, 0xe
                	lhu	a1, 0x0(a0)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x310
+               	addiw	t1, t1, 0x80
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a0, t2, 0xe
                	sh	a1, 0x0(a0)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x310
+               	addiw	t1, t1, 0x80
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a0, t2
                	lhu	a1, 0x0(a0)
                	mv	a0, s1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x4e5c>
+               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x41c0>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x310
+               	addiw	t1, t1, 0x80
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x2
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x4e80>
+               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x41e4>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x310
+               	addiw	t1, t1, 0x80
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x4ea4>
+               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x4208>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x310
+               	addiw	t1, t1, 0x80
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x6
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x4ec8>
+               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x422c>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x310
+               	addiw	t1, t1, 0x80
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x4eec>
+               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x4250>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x310
+               	addiw	t1, t1, 0x80
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xa
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x4f10>
+               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x4274>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x310
+               	addiw	t1, t1, 0x80
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x4f34>
+               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x4298>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x310
+               	addiw	t1, t1, 0x80
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xe
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x4f58>
+               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x42bc>
                	addi	s2, s2, 0x1
                	mv	s1, a0
                	li	t0, 0x4
-               	bltu	s2, t0, 0x4e60 <corpus.cases.vec.vec_i16x8.checksum+0x4d34>
+               	bltu	s2, t0, 0x41c4 <corpus.cases.vec.vec_i16x8.checksum+0x4098>
                	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x298
+               	addiw	t0, t0, 0xe8
                	add	s2, s0, t0
                	sd	zero, 0x0(s2)
                	sd	zero, 0x8(s2)
@@ -5182,7 +4375,7 @@ Disassembly of section .text:
                	mv	a2, a1
                	lhu	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x318
+               	addiw	t1, t1, 0x78
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
@@ -5190,7 +4383,7 @@ Disassembly of section .text:
                	addi	a2, a1, 0x2
                	lhu	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x318
+               	addiw	t1, t1, 0x78
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x2
@@ -5198,7 +4391,7 @@ Disassembly of section .text:
                	addi	a2, a1, 0x4
                	lhu	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x318
+               	addiw	t1, t1, 0x78
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x4
@@ -5206,7 +4399,7 @@ Disassembly of section .text:
                	addi	a2, a1, 0x6
                	lhu	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x318
+               	addiw	t1, t1, 0x78
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x6
@@ -5214,7 +4407,7 @@ Disassembly of section .text:
                	addi	a2, a1, 0x8
                	lhu	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x318
+               	addiw	t1, t1, 0x78
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
@@ -5222,7 +4415,7 @@ Disassembly of section .text:
                	addi	a2, a1, 0xa
                	lhu	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x318
+               	addiw	t1, t1, 0x78
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xa
@@ -5230,7 +4423,7 @@ Disassembly of section .text:
                	addi	a2, a1, 0xc
                	lhu	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x318
+               	addiw	t1, t1, 0x78
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xc
@@ -5238,14 +4431,14 @@ Disassembly of section .text:
                	addi	a2, a1, 0xe
                	lhu	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x318
+               	addiw	t1, t1, 0x78
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xe
                	sh	a1, 0x0(a2)
                	addi	s3, s2, 0x10
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x318
+               	addiw	t1, t1, 0x78
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
@@ -5253,7 +4446,7 @@ Disassembly of section .text:
                	mv	a1, s3
                	sh	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x318
+               	addiw	t1, t1, 0x78
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x2
@@ -5261,7 +4454,7 @@ Disassembly of section .text:
                	addi	a1, s3, 0x2
                	sh	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x318
+               	addiw	t1, t1, 0x78
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
@@ -5269,7 +4462,7 @@ Disassembly of section .text:
                	addi	a1, s3, 0x4
                	sh	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x318
+               	addiw	t1, t1, 0x78
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x6
@@ -5277,7 +4470,7 @@ Disassembly of section .text:
                	addi	a1, s3, 0x6
                	sh	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x318
+               	addiw	t1, t1, 0x78
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
@@ -5285,7 +4478,7 @@ Disassembly of section .text:
                	addi	a1, s3, 0x8
                	sh	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x318
+               	addiw	t1, t1, 0x78
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xa
@@ -5293,7 +4486,7 @@ Disassembly of section .text:
                	addi	a1, s3, 0xa
                	sh	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x318
+               	addiw	t1, t1, 0x78
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
@@ -5301,7 +4494,7 @@ Disassembly of section .text:
                	addi	a1, s3, 0xc
                	sh	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x318
+               	addiw	t1, t1, 0x78
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xe
@@ -5315,11 +4508,11 @@ Disassembly of section .text:
                	lw	a1, 0x0(a0)
                	mv	a0, s1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x51c8>
+               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x452c>
                	mv	a1, s3
                	lhu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x320
+               	addiw	t1, t1, 0x70
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
@@ -5327,7 +4520,7 @@ Disassembly of section .text:
                	addi	a1, s3, 0x2
                	lhu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x320
+               	addiw	t1, t1, 0x70
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x2
@@ -5335,7 +4528,7 @@ Disassembly of section .text:
                	addi	a1, s3, 0x4
                	lhu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x320
+               	addiw	t1, t1, 0x70
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
@@ -5343,7 +4536,7 @@ Disassembly of section .text:
                	addi	a1, s3, 0x6
                	lhu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x320
+               	addiw	t1, t1, 0x70
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x6
@@ -5351,7 +4544,7 @@ Disassembly of section .text:
                	addi	a1, s3, 0x8
                	lhu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x320
+               	addiw	t1, t1, 0x70
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
@@ -5359,7 +4552,7 @@ Disassembly of section .text:
                	addi	a1, s3, 0xa
                	lhu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x320
+               	addiw	t1, t1, 0x70
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xa
@@ -5367,7 +4560,7 @@ Disassembly of section .text:
                	addi	a1, s3, 0xc
                	lhu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x320
+               	addiw	t1, t1, 0x70
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
@@ -5375,141 +4568,141 @@ Disassembly of section .text:
                	addi	a1, s3, 0xe
                	lhu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x320
+               	addiw	t1, t1, 0x70
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xe
                	sh	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x320
+               	addiw	t1, t1, 0x70
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x52ec>
+               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x4650>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x320
+               	addiw	t1, t1, 0x70
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x2
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x5310>
+               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x4674>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x320
+               	addiw	t1, t1, 0x70
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x5334>
+               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x4698>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x320
+               	addiw	t1, t1, 0x70
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x6
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x5358>
+               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x46bc>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x320
+               	addiw	t1, t1, 0x70
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x537c>
+               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x46e0>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x320
+               	addiw	t1, t1, 0x70
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xa
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x53a0>
+               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x4704>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x320
+               	addiw	t1, t1, 0x70
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x53c4>
+               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x4728>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x320
+               	addiw	t1, t1, 0x70
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xe
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x53e8>
+               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x474c>
                	addi	a1, s2, 0x20
                	lw	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x53fc>
+               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x4760>
                	lui	t1, 0x1
-               	addiw	t1, t1, 0x368
+               	addiw	t1, t1, -0x28
                	add	t1, sp, t1
                	ld	s1, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, 0x360
+               	addiw	t1, t1, -0x30
                	add	t1, sp, t1
                	ld	s2, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, 0x358
+               	addiw	t1, t1, -0x38
                	add	t1, sp, t1
                	ld	s3, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, 0x350
+               	addiw	t1, t1, -0x40
                	add	t1, sp, t1
                	ld	s4, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, 0x348
+               	addiw	t1, t1, -0x48
                	add	t1, sp, t1
                	ld	s5, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, 0x340
+               	addiw	t1, t1, -0x50
                	add	t1, sp, t1
                	ld	s6, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, 0x338
+               	addiw	t1, t1, -0x58
                	add	t1, sp, t1
                	ld	s7, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, 0x330
+               	addiw	t1, t1, -0x60
                	add	t1, sp, t1
                	ld	s8, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, 0x328
+               	addiw	t1, t1, -0x68
                	add	t1, sp, t1
                	ld	s9, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, 0x320
+               	addiw	t1, t1, -0x70
                	add	t1, sp, t1
                	ld	s10, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, 0x318
+               	addiw	t1, t1, -0x78
                	add	t1, sp, t1
                	ld	s11, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, 0x378
+               	addiw	t1, t1, -0x18
                	add	t1, sp, t1
                	ld	ra, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, 0x370
+               	addiw	t1, t1, -0x20
                	add	t1, sp, t1
                	ld	s0, 0x0(t1)
                	lui	t0, 0x1
-               	addiw	t0, t0, 0x380
+               	addiw	t0, t0, -0x10
                	add	sp, sp, t0
                	ret

--- a/test/golden/riscv64-linux/vec/vec_i32x4.dis
+++ b/test/golden/riscv64-linux/vec/vec_i32x4.dis
@@ -49,61 +49,61 @@ Disassembly of section .text:
 
 <corpus.cases.vec.vec_i32x4.checksum>:
                	lui	t0, 0x1
-               	addiw	t0, t0, -0x250
+               	addiw	t0, t0, -0x420
                	sub	sp, sp, t0
                	lui	t1, 0x1
-               	addiw	t1, t1, -0x258
+               	addiw	t1, t1, -0x428
                	add	t1, sp, t1
                	sd	ra, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, -0x260
+               	addiw	t1, t1, -0x430
                	add	t1, sp, t1
                	sd	s0, 0x0(t1)
                	lui	t0, 0x1
-               	addiw	t0, t0, -0x250
+               	addiw	t0, t0, -0x420
                	add	s0, sp, t0
                	lui	t1, 0x1
-               	addiw	t1, t1, -0x268
+               	addiw	t1, t1, -0x438
                	add	t1, sp, t1
                	sd	s1, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, -0x270
+               	addiw	t1, t1, -0x440
                	add	t1, sp, t1
                	sd	s2, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, -0x278
+               	addiw	t1, t1, -0x448
                	add	t1, sp, t1
                	sd	s3, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, -0x280
+               	addiw	t1, t1, -0x450
                	add	t1, sp, t1
                	sd	s4, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, -0x288
+               	addiw	t1, t1, -0x458
                	add	t1, sp, t1
                	sd	s5, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, -0x290
+               	addiw	t1, t1, -0x460
                	add	t1, sp, t1
                	sd	s6, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, -0x298
+               	addiw	t1, t1, -0x468
                	add	t1, sp, t1
                	sd	s7, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, -0x2a0
+               	addiw	t1, t1, -0x470
                	add	t1, sp, t1
                	sd	s8, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, -0x2a8
+               	addiw	t1, t1, -0x478
                	add	t1, sp, t1
                	sd	s9, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, -0x2b0
+               	addiw	t1, t1, -0x480
                	add	t1, sp, t1
                	sd	s10, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, -0x2b8
+               	addiw	t1, t1, -0x488
                	add	t1, sp, t1
                	sd	s11, 0x0(t1)
                	mv	s1, a0
@@ -135,107 +135,99 @@ Disassembly of section .text:
                	addi	a1, s0, -0x208
                	addi	t2, s0, -0x218
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x298
+               	addiw	t1, t1, 0x468
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	a1, s0, -0x228
                	addi	a1, s0, -0x238
                	addi	t2, s0, -0x248
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x290
+               	addiw	t1, t1, 0x460
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	a1, s0, -0x258
                	addi	a1, s0, -0x268
                	addi	t2, s0, -0x278
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x288
+               	addiw	t1, t1, 0x458
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	a1, s0, -0x288
                	addi	a1, s0, -0x298
                	addi	t2, s0, -0x2a8
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x280
+               	addiw	t1, t1, 0x450
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	a1, s0, -0x2b8
                	addi	a1, s0, -0x2c8
                	addi	t2, s0, -0x2d8
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x278
+               	addiw	t1, t1, 0x448
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	a1, s0, -0x2e8
                	addi	t2, s0, -0x2f8
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x270
+               	addiw	t1, t1, 0x440
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	a1, s0, -0x308
                	addi	a1, s0, -0x318
                	addi	t2, s0, -0x328
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x268
+               	addiw	t1, t1, 0x438
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	a1, s0, -0x338
                	addi	a1, s0, -0x348
                	addi	t2, s0, -0x358
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x260
+               	addiw	t1, t1, 0x430
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	a1, s0, -0x368
                	addi	a1, s0, -0x378
                	addi	t2, s0, -0x388
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x330
+               	addiw	t1, t1, 0x4f0
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	a1, s0, -0x398
                	addi	a1, s0, -0x3a8
                	addi	t2, s0, -0x3b8
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x328
+               	addiw	t1, t1, 0x4e8
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	a1, s0, -0x3c8
                	addi	a1, s0, -0x3d8
                	addi	t2, s0, -0x3e8
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x320
+               	addiw	t1, t1, 0x4e0
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	a1, s0, -0x3f8
                	addi	t2, s0, -0x408
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x318
+               	addiw	t1, t1, 0x4d8
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	a1, s0, -0x418
                	addi	t2, s0, -0x428
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x310
+               	addiw	t1, t1, 0x4d0
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	a1, s0, -0x438
                	addi	a1, s0, -0x448
-               	addi	t2, s0, -0x458
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x308
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
+               	addi	a1, s0, -0x458
                	addi	a1, s0, -0x468
                	addi	a1, s0, -0x478
-               	addi	t2, s0, -0x488
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x300
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
+               	addi	a1, s0, -0x488
                	addi	t2, s0, -0x498
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2f8
+               	addiw	t1, t1, 0x4c8
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	a1, s0, -0x4a8
@@ -243,7 +235,7 @@ Disassembly of section .text:
                	addi	a1, s0, -0x4c8
                	addi	t2, s0, -0x4d8
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2f0
+               	addiw	t1, t1, 0x4c0
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	a1, s0, -0x4e8
@@ -251,7 +243,7 @@ Disassembly of section .text:
                	addi	a1, s0, -0x508
                	addi	t2, s0, -0x518
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2e8
+               	addiw	t1, t1, 0x4b8
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	a1, s0, -0x528
@@ -259,7 +251,7 @@ Disassembly of section .text:
                	addi	a1, s0, -0x548
                	addi	t2, s0, -0x558
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2e0
+               	addiw	t1, t1, 0x4b0
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	a1, s0, -0x568
@@ -267,7 +259,7 @@ Disassembly of section .text:
                	addi	a1, s0, -0x588
                	addi	t2, s0, -0x598
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2d8
+               	addiw	t1, t1, 0x4a8
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	a1, s0, -0x5a8
@@ -276,30 +268,30 @@ Disassembly of section .text:
                	addi	a1, s0, -0x5d8
                	addi	t2, s0, -0x5e8
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2d0
+               	addiw	t1, t1, 0x4a0
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	a1, s0, -0x5f8
                	addi	a1, s0, -0x608
                	addi	t2, s0, -0x618
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2c8
+               	addiw	t1, t1, 0x498
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	a1, s0, -0x628
                	addi	t2, s0, -0x638
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2c0
+               	addiw	t1, t1, 0x490
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	t2, s0, -0x648
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2b8
+               	addiw	t1, t1, 0x488
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	t2, s0, -0x658
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2b0
+               	addiw	t1, t1, 0x480
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	a1, s0, -0x668
@@ -442,108 +434,24 @@ Disassembly of section .text:
                	lui	t0, 0xfffff
                	addiw	t0, t0, 0x5a8
                	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x598
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x588
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x578
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x568
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x558
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x548
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x538
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x528
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x518
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x508
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x4f8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x4e8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x4d8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x4c8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x4b8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x4a8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x498
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x488
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x478
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x468
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x458
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x448
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x438
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x428
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x418
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x408
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x3f8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x3e8
-               	add	a1, s0, t0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0x778>
+               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0x608>
                	mv	t2, a0
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2a8
+               	addiw	t1, t1, 0x478
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2a8
+               	addiw	t1, t1, 0x478
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	sext.w	t2, s1
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2a0
+               	addiw	t1, t1, 0x470
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x3d8
+               	addiw	t0, t0, 0x598
                	add	s1, s0, t0
                	mv	a0, s1
                	lui	t0, 0x2
@@ -581,7 +489,7 @@ Disassembly of section .text:
                	addi	a0, s2, 0xc
                	sw	a1, 0x0(a0)
                	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x3c8
+               	addiw	t0, t0, 0x588
                	add	a0, s0, t0
                	mv	a1, a0
                	lui	t0, 0x100
@@ -616,7 +524,7 @@ Disassembly of section .text:
                	addi	a1, s3, 0xc
                	sw	a0, 0x0(a1)
                	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x3b8
+               	addiw	t0, t0, 0x578
                	add	a0, s0, t0
                	mv	a1, a0
                	li	t0, 0x1
@@ -647,7 +555,7 @@ Disassembly of section .text:
                	addi	a1, s4, 0xc
                	sw	a0, 0x0(a1)
                	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x3a8
+               	addiw	t0, t0, 0x568
                	add	a0, s0, t0
                	mv	a1, a0
                	sw	zero, 0x0(a1)
@@ -676,7 +584,7 @@ Disassembly of section .text:
                	mv	a0, s2
                	lw	a1, 0x0(a0)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2a0
+               	addiw	t1, t1, 0x470
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addw	a0, a1, t2
@@ -701,7 +609,7 @@ Disassembly of section .text:
                	addi	a0, s6, 0x8
                	lw	a1, 0x0(a0)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2a0
+               	addiw	t1, t1, 0x470
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addw	a0, a1, t2
@@ -726,7 +634,7 @@ Disassembly of section .text:
                	addi	a0, s3, 0x4
                	lw	a1, 0x0(a0)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2a0
+               	addiw	t1, t1, 0x470
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addw	a0, a1, t2
@@ -751,7 +659,7 @@ Disassembly of section .text:
                	addi	a0, s8, 0xc
                	lw	a1, 0x0(a0)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2a0
+               	addiw	t1, t1, 0x470
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addw	a0, a1, t2
@@ -776,47 +684,47 @@ Disassembly of section .text:
                	mv	a0, s7
                	lw	a1, 0x0(a0)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2a8
+               	addiw	t1, t1, 0x478
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a0, t2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0xb70>
+               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0xa00>
                	addi	a1, s7, 0x4
                	lw	s1, 0x0(a1)
                	mv	a1, s1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0xb84>
+               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0xa14>
                	addi	a1, s7, 0x8
                	lw	s1, 0x0(a1)
                	mv	a1, s1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0xb98>
+               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0xa28>
                	addi	a1, s7, 0xc
                	lw	s1, 0x0(a1)
                	mv	a1, s1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0xbac>
+               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0xa3c>
                	mv	a1, s9
                	lw	s1, 0x0(a1)
                	mv	a1, s1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0xbc0>
+               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0xa50>
                	addi	a1, s9, 0x4
                	lw	s1, 0x0(a1)
                	mv	a1, s1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0xbd4>
+               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0xa64>
                	addi	a1, s9, 0x8
                	lw	s1, 0x0(a1)
                	mv	a1, s1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0xbe8>
+               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0xa78>
                	addi	a1, s9, 0xc
                	lw	s1, 0x0(a1)
                	mv	a1, s1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0xbfc>
+               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0xa8c>
                	mv	a1, s7
                	lw	s1, 0x0(a1)
                	mv	a1, s9
@@ -849,22 +757,22 @@ Disassembly of section .text:
                	lw	s1, 0x0(a1)
                	mv	a1, s1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0xc80>
+               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0xb10>
                	addi	a1, s10, 0x4
                	lw	s1, 0x0(a1)
                	mv	a1, s1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0xc94>
+               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0xb24>
                	addi	a1, s10, 0x8
                	lw	s1, 0x0(a1)
                	mv	a1, s1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0xca8>
+               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0xb38>
                	addi	a1, s10, 0xc
                	lw	s1, 0x0(a1)
                	mv	a1, s1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0xcbc>
+               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0xb4c>
                	mv	a1, s7
                	lw	s1, 0x0(a1)
                	mv	a1, s9
@@ -897,29 +805,29 @@ Disassembly of section .text:
                	lw	s1, 0x0(a1)
                	mv	a1, s1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0xd40>
+               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0xbd0>
                	addi	a1, s11, 0x4
                	lw	s1, 0x0(a1)
                	mv	a1, s1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0xd54>
+               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0xbe4>
                	addi	a1, s11, 0x8
                	lw	s1, 0x0(a1)
                	mv	a1, s1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0xd68>
+               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0xbf8>
                	addi	a1, s11, 0xc
                	lw	s1, 0x0(a1)
                	mv	a1, s1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0xd7c>
+               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0xc0c>
                	mv	a1, s9
                	lw	s1, 0x0(a1)
                	mv	a1, s7
                	lw	s2, 0x0(a1)
                	subw	a1, s1, s2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x298
+               	addiw	t1, t1, 0x468
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	s1, t2
@@ -930,7 +838,7 @@ Disassembly of section .text:
                	lw	s2, 0x0(a1)
                	subw	a1, s1, s2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x298
+               	addiw	t1, t1, 0x468
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	s1, t2, 0x4
@@ -941,7 +849,7 @@ Disassembly of section .text:
                	lw	s2, 0x0(a1)
                	subw	a1, s1, s2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x298
+               	addiw	t1, t1, 0x468
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	s1, t2, 0x8
@@ -952,54 +860,54 @@ Disassembly of section .text:
                	lw	s2, 0x0(a1)
                	subw	a1, s1, s2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x298
+               	addiw	t1, t1, 0x468
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	s1, t2, 0xc
                	sw	a1, 0x0(s1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x298
+               	addiw	t1, t1, 0x468
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	lw	s1, 0x0(a1)
                	mv	a1, s1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0xe50>
+               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0xce0>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x298
+               	addiw	t1, t1, 0x468
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	lw	s1, 0x0(a1)
                	mv	a1, s1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0xe74>
+               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0xd04>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x298
+               	addiw	t1, t1, 0x468
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	lw	s1, 0x0(a1)
                	mv	a1, s1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0xe98>
+               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0xd28>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x298
+               	addiw	t1, t1, 0x468
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	lw	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0xebc>
+               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0xd4c>
                	mv	a1, s7
                	lw	a2, 0x0(a1)
                	mv	a1, s9
                	lw	s1, 0x0(a1)
                	mulw	a1, a2, s1
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x290
+               	addiw	t1, t1, 0x460
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
@@ -1010,7 +918,7 @@ Disassembly of section .text:
                	lw	s1, 0x0(a1)
                	mulw	a1, a2, s1
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x290
+               	addiw	t1, t1, 0x460
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x4
@@ -1021,7 +929,7 @@ Disassembly of section .text:
                	lw	s1, 0x0(a1)
                	mulw	a1, a2, s1
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x290
+               	addiw	t1, t1, 0x460
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
@@ -1032,54 +940,54 @@ Disassembly of section .text:
                	lw	s1, 0x0(a1)
                	mulw	a1, a2, s1
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x290
+               	addiw	t1, t1, 0x460
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xc
                	sw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x290
+               	addiw	t1, t1, 0x460
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	lw	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0xf90>
+               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0xe20>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x290
+               	addiw	t1, t1, 0x460
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	lw	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0xfb4>
+               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0xe44>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x290
+               	addiw	t1, t1, 0x460
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	lw	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0xfd8>
+               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0xe68>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x290
+               	addiw	t1, t1, 0x460
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	lw	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0xffc>
+               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0xe8c>
                	mv	a1, s7
                	lw	a2, 0x0(a1)
                	mv	a1, s4
                	lw	a3, 0x0(a1)
                	mulw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x288
+               	addiw	t1, t1, 0x458
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
@@ -1090,7 +998,7 @@ Disassembly of section .text:
                	lw	a3, 0x0(a1)
                	mulw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x288
+               	addiw	t1, t1, 0x458
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x4
@@ -1101,7 +1009,7 @@ Disassembly of section .text:
                	lw	a3, 0x0(a1)
                	mulw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x288
+               	addiw	t1, t1, 0x458
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
@@ -1112,54 +1020,54 @@ Disassembly of section .text:
                	lw	a3, 0x0(a1)
                	mulw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x288
+               	addiw	t1, t1, 0x458
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xc
                	sw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x288
+               	addiw	t1, t1, 0x458
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	lw	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0x10d0>
+               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0xf60>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x288
+               	addiw	t1, t1, 0x458
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	lw	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0x10f4>
+               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0xf84>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x288
+               	addiw	t1, t1, 0x458
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	lw	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0x1118>
+               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0xfa8>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x288
+               	addiw	t1, t1, 0x458
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	lw	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0x113c>
+               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0xfcc>
                	mv	a1, s9
                	lw	a2, 0x0(a1)
                	mv	a1, s4
                	lw	a3, 0x0(a1)
                	mulw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x280
+               	addiw	t1, t1, 0x450
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
@@ -1170,7 +1078,7 @@ Disassembly of section .text:
                	lw	a3, 0x0(a1)
                	mulw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x280
+               	addiw	t1, t1, 0x450
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x4
@@ -1181,7 +1089,7 @@ Disassembly of section .text:
                	lw	a3, 0x0(a1)
                	mulw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x280
+               	addiw	t1, t1, 0x450
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
@@ -1192,54 +1100,54 @@ Disassembly of section .text:
                	lw	a3, 0x0(a1)
                	mulw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x280
+               	addiw	t1, t1, 0x450
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xc
                	sw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x280
+               	addiw	t1, t1, 0x450
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	lw	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0x1210>
+               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0x10a0>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x280
+               	addiw	t1, t1, 0x450
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	lw	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0x1234>
+               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0x10c4>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x280
+               	addiw	t1, t1, 0x450
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	lw	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0x1258>
+               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0x10e8>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x280
+               	addiw	t1, t1, 0x450
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	lw	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0x127c>
+               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0x110c>
                	mv	a1, s7
                	lw	a2, 0x0(a1)
                	mv	a1, s9
                	lw	a3, 0x0(a1)
                	addw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x278
+               	addiw	t1, t1, 0x448
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
@@ -1250,7 +1158,7 @@ Disassembly of section .text:
                	lw	a3, 0x0(a1)
                	addw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x278
+               	addiw	t1, t1, 0x448
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x4
@@ -1261,7 +1169,7 @@ Disassembly of section .text:
                	lw	a3, 0x0(a1)
                	addw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x278
+               	addiw	t1, t1, 0x448
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
@@ -1272,13 +1180,13 @@ Disassembly of section .text:
                	lw	a3, 0x0(a1)
                	addw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x278
+               	addiw	t1, t1, 0x448
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xc
                	sw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x278
+               	addiw	t1, t1, 0x448
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
@@ -1287,13 +1195,13 @@ Disassembly of section .text:
                	lw	a3, 0x0(a1)
                	mulw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x270
+               	addiw	t1, t1, 0x440
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
                	sw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x278
+               	addiw	t1, t1, 0x448
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
@@ -1302,13 +1210,13 @@ Disassembly of section .text:
                	lw	a3, 0x0(a1)
                	mulw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x270
+               	addiw	t1, t1, 0x440
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x4
                	sw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x278
+               	addiw	t1, t1, 0x448
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
@@ -1317,13 +1225,13 @@ Disassembly of section .text:
                	lw	a3, 0x0(a1)
                	mulw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x270
+               	addiw	t1, t1, 0x440
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
                	sw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x278
+               	addiw	t1, t1, 0x448
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
@@ -1332,54 +1240,54 @@ Disassembly of section .text:
                	lw	a3, 0x0(a1)
                	mulw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x270
+               	addiw	t1, t1, 0x440
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xc
                	sw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x270
+               	addiw	t1, t1, 0x440
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	lw	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0x1440>
+               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0x12d0>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x270
+               	addiw	t1, t1, 0x440
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	lw	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0x1464>
+               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0x12f4>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x270
+               	addiw	t1, t1, 0x440
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	lw	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0x1488>
+               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0x1318>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x270
+               	addiw	t1, t1, 0x440
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	lw	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0x14ac>
+               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0x133c>
                	mv	a1, s5
                	lw	a2, 0x0(a1)
                	mv	a1, s7
                	lw	a3, 0x0(a1)
                	subw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x268
+               	addiw	t1, t1, 0x438
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
@@ -1390,7 +1298,7 @@ Disassembly of section .text:
                	lw	a3, 0x0(a1)
                	subw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x268
+               	addiw	t1, t1, 0x438
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x4
@@ -1401,7 +1309,7 @@ Disassembly of section .text:
                	lw	a3, 0x0(a1)
                	subw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x268
+               	addiw	t1, t1, 0x438
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
@@ -1412,54 +1320,54 @@ Disassembly of section .text:
                	lw	a3, 0x0(a1)
                	subw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x268
+               	addiw	t1, t1, 0x438
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xc
                	sw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x268
+               	addiw	t1, t1, 0x438
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	lw	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0x1580>
+               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0x1410>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x268
+               	addiw	t1, t1, 0x438
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	lw	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0x15a4>
+               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0x1434>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x268
+               	addiw	t1, t1, 0x438
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	lw	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0x15c8>
+               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0x1458>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x268
+               	addiw	t1, t1, 0x438
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	lw	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0x15ec>
+               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0x147c>
                	mv	a1, s5
                	lw	a2, 0x0(a1)
                	mv	a1, s9
                	lw	a3, 0x0(a1)
                	subw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x260
+               	addiw	t1, t1, 0x430
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
@@ -1470,7 +1378,7 @@ Disassembly of section .text:
                	lw	a3, 0x0(a1)
                	subw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x260
+               	addiw	t1, t1, 0x430
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x4
@@ -1481,7 +1389,7 @@ Disassembly of section .text:
                	lw	a3, 0x0(a1)
                	subw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x260
+               	addiw	t1, t1, 0x430
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
@@ -1492,54 +1400,25 @@ Disassembly of section .text:
                	lw	a3, 0x0(a1)
                	subw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x260
+               	addiw	t1, t1, 0x430
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xc
                	sw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x260
+               	addiw	t1, t1, 0x430
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0x16c0>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x260
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0x16e4>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x260
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0x1708>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x260
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0x172c>
+               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0x1548>
                	mv	a1, s7
                	lw	a2, 0x0(a1)
                	mv	a1, s9
                	lw	a3, 0x0(a1)
                	and	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x330
+               	addiw	t1, t1, 0x4f0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
@@ -1550,7 +1429,7 @@ Disassembly of section .text:
                	lw	a3, 0x0(a1)
                	and	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x330
+               	addiw	t1, t1, 0x4f0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x4
@@ -1561,7 +1440,7 @@ Disassembly of section .text:
                	lw	a3, 0x0(a1)
                	and	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x330
+               	addiw	t1, t1, 0x4f0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
@@ -1572,54 +1451,25 @@ Disassembly of section .text:
                	lw	a3, 0x0(a1)
                	and	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x330
+               	addiw	t1, t1, 0x4f0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xc
                	sw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x330
+               	addiw	t1, t1, 0x4f0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0x1800>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x330
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0x1824>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x330
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0x1848>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x330
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0x186c>
+               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0x1614>
                	mv	a1, s7
                	lw	a2, 0x0(a1)
                	mv	a1, s9
                	lw	a3, 0x0(a1)
                	or	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x328
+               	addiw	t1, t1, 0x4e8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
@@ -1630,7 +1480,7 @@ Disassembly of section .text:
                	lw	a3, 0x0(a1)
                	or	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x328
+               	addiw	t1, t1, 0x4e8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x4
@@ -1641,7 +1491,7 @@ Disassembly of section .text:
                	lw	a3, 0x0(a1)
                	or	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x328
+               	addiw	t1, t1, 0x4e8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
@@ -1652,54 +1502,25 @@ Disassembly of section .text:
                	lw	a3, 0x0(a1)
                	or	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x328
+               	addiw	t1, t1, 0x4e8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xc
                	sw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x328
+               	addiw	t1, t1, 0x4e8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0x1940>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x328
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0x1964>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x328
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0x1988>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x328
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0x19ac>
+               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0x16e0>
                	mv	a1, s7
                	lw	a2, 0x0(a1)
                	mv	a1, s9
                	lw	a3, 0x0(a1)
                	xor	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x320
+               	addiw	t1, t1, 0x4e0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
@@ -1710,7 +1531,7 @@ Disassembly of section .text:
                	lw	a3, 0x0(a1)
                	xor	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x320
+               	addiw	t1, t1, 0x4e0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x4
@@ -1721,7 +1542,7 @@ Disassembly of section .text:
                	lw	a3, 0x0(a1)
                	xor	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x320
+               	addiw	t1, t1, 0x4e0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
@@ -1732,52 +1553,23 @@ Disassembly of section .text:
                	lw	a3, 0x0(a1)
                	xor	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x320
+               	addiw	t1, t1, 0x4e0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xc
                	sw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x320
+               	addiw	t1, t1, 0x4e0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0x1a80>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x320
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0x1aa4>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x320
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0x1ac8>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x320
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0x1aec>
+               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0x17ac>
                	mv	a1, s7
                	lw	a2, 0x0(a1)
                	not	a1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x318
+               	addiw	t1, t1, 0x4d8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
@@ -1786,7 +1578,7 @@ Disassembly of section .text:
                	lw	a2, 0x0(a1)
                	not	a1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x318
+               	addiw	t1, t1, 0x4d8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x4
@@ -1795,7 +1587,7 @@ Disassembly of section .text:
                	lw	a2, 0x0(a1)
                	not	a1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x318
+               	addiw	t1, t1, 0x4d8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
@@ -1804,52 +1596,23 @@ Disassembly of section .text:
                	lw	a2, 0x0(a1)
                	not	a1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x318
+               	addiw	t1, t1, 0x4d8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xc
                	sw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x318
+               	addiw	t1, t1, 0x4d8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0x1ba0>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x318
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0x1bc4>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x318
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0x1be8>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x318
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0x1c0c>
+               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0x1858>
                	mv	a1, s9
                	lw	a2, 0x0(a1)
                	not	a1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x310
+               	addiw	t1, t1, 0x4d0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
@@ -1858,7 +1621,7 @@ Disassembly of section .text:
                	lw	a2, 0x0(a1)
                	not	a1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x310
+               	addiw	t1, t1, 0x4d0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x4
@@ -1867,7 +1630,7 @@ Disassembly of section .text:
                	lw	a2, 0x0(a1)
                	not	a1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x310
+               	addiw	t1, t1, 0x4d0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
@@ -1876,259 +1639,113 @@ Disassembly of section .text:
                	lw	a2, 0x0(a1)
                	not	a1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x310
+               	addiw	t1, t1, 0x4d0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xc
                	sw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x310
+               	addiw	t1, t1, 0x4d0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0x1cc0>
+               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0x1904>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x310
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0x1ce4>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x310
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0x1d08>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x310
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0x1d2c>
-               	mv	a1, s7
-               	lw	a2, 0x0(a1)
-               	mv	a1, s9
-               	lw	a3, 0x0(a1)
-               	and	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x308
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a2, t2
-               	sw	a1, 0x0(a2)
-               	addi	a1, s7, 0x4
-               	lw	a2, 0x0(a1)
-               	addi	a1, s9, 0x4
-               	lw	a3, 0x0(a1)
-               	and	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x308
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x4
-               	sw	a1, 0x0(a2)
-               	addi	a1, s7, 0x8
-               	lw	a2, 0x0(a1)
-               	addi	a1, s9, 0x8
-               	lw	a3, 0x0(a1)
-               	and	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x308
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x8
-               	sw	a1, 0x0(a2)
-               	addi	a1, s7, 0xc
-               	lw	a2, 0x0(a1)
-               	addi	a1, s9, 0xc
-               	lw	a3, 0x0(a1)
-               	and	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x308
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0xc
-               	sw	a1, 0x0(a2)
-               	mv	a1, s7
-               	lw	a2, 0x0(a1)
-               	mv	a1, s9
-               	lw	a3, 0x0(a1)
-               	or	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x300
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a2, t2
-               	sw	a1, 0x0(a2)
-               	addi	a1, s7, 0x4
-               	lw	a2, 0x0(a1)
-               	addi	a1, s9, 0x4
-               	lw	a3, 0x0(a1)
-               	or	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x300
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x4
-               	sw	a1, 0x0(a2)
-               	addi	a1, s7, 0x8
-               	lw	a2, 0x0(a1)
-               	addi	a1, s9, 0x8
-               	lw	a3, 0x0(a1)
-               	or	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x300
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x8
-               	sw	a1, 0x0(a2)
-               	addi	a1, s7, 0xc
-               	lw	a2, 0x0(a1)
-               	addi	a1, s9, 0xc
-               	lw	a3, 0x0(a1)
-               	or	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x300
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0xc
-               	sw	a1, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x308
+               	addiw	t1, t1, 0x4f0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	lw	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x300
+               	addiw	t1, t1, 0x4e8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	lw	a3, 0x0(a1)
                	xor	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2f8
+               	addiw	t1, t1, 0x4c8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
                	sw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x308
+               	addiw	t1, t1, 0x4f0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	lw	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x300
+               	addiw	t1, t1, 0x4e8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	lw	a3, 0x0(a1)
                	xor	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2f8
+               	addiw	t1, t1, 0x4c8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x4
                	sw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x308
+               	addiw	t1, t1, 0x4f0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	lw	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x300
+               	addiw	t1, t1, 0x4e8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	lw	a3, 0x0(a1)
                	xor	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2f8
+               	addiw	t1, t1, 0x4c8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
                	sw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x308
+               	addiw	t1, t1, 0x4f0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	lw	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x300
+               	addiw	t1, t1, 0x4e8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	lw	a3, 0x0(a1)
                	xor	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2f8
+               	addiw	t1, t1, 0x4c8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xc
                	sw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2f8
+               	addiw	t1, t1, 0x4c8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0x1fe0>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2f8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0x2004>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2f8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0x2028>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2f8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0x204c>
+               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0x1a50>
                	mv	s1, a0
                	li	s2, 0x0
                	li	t0, 0x6
-               	bltu	s2, t0, 0x2114 <corpus.cases.vec.vec_i32x4.checksum+0x2068>
-               	j	0x26cc <corpus.cases.vec.vec_i32x4.checksum+0x2620>
+               	bltu	s2, t0, 0x1b18 <corpus.cases.vec.vec_i32x4.checksum+0x1a6c>
+               	j	0x20d0 <corpus.cases.vec.vec_i32x4.checksum+0x2024>
                	mv	a0, s7
                	lw	a1, 0x0(a0)
                	mv	a0, s4
                	lw	a2, 0x0(a0)
                	mulw	a0, a1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2f0
+               	addiw	t1, t1, 0x4c0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
@@ -2139,7 +1756,7 @@ Disassembly of section .text:
                	lw	a2, 0x0(a0)
                	mulw	a0, a1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2f0
+               	addiw	t1, t1, 0x4c0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
@@ -2150,7 +1767,7 @@ Disassembly of section .text:
                	lw	a2, 0x0(a0)
                	mulw	a0, a1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2f0
+               	addiw	t1, t1, 0x4c0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
@@ -2161,58 +1778,58 @@ Disassembly of section .text:
                	lw	a2, 0x0(a0)
                	mulw	a0, a1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2f0
+               	addiw	t1, t1, 0x4c0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	sw	a0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2f0
+               	addiw	t1, t1, 0x4c0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a0, t2
                	lw	a1, 0x0(a0)
                	mv	a0, s1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0x2134>
+               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0x1b38>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2f0
+               	addiw	t1, t1, 0x4c0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	lw	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0x2158>
+               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0x1b5c>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2f0
+               	addiw	t1, t1, 0x4c0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	lw	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0x217c>
+               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0x1b80>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2f0
+               	addiw	t1, t1, 0x4c0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	lw	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0x21a0>
+               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0x1ba4>
                	mv	a1, s5
                	lw	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2f0
+               	addiw	t1, t1, 0x4c0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	lw	a3, 0x0(a1)
                	addw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2e8
+               	addiw	t1, t1, 0x4b8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
@@ -2220,14 +1837,14 @@ Disassembly of section .text:
                	addi	a1, s5, 0x4
                	lw	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2f0
+               	addiw	t1, t1, 0x4c0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	lw	a3, 0x0(a1)
                	addw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2e8
+               	addiw	t1, t1, 0x4b8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x4
@@ -2235,14 +1852,14 @@ Disassembly of section .text:
                	addi	a1, s5, 0x8
                	lw	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2f0
+               	addiw	t1, t1, 0x4c0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	lw	a3, 0x0(a1)
                	addw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2e8
+               	addiw	t1, t1, 0x4b8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
@@ -2250,56 +1867,56 @@ Disassembly of section .text:
                	addi	a1, s5, 0xc
                	lw	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2f0
+               	addiw	t1, t1, 0x4c0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	lw	a3, 0x0(a1)
                	addw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2e8
+               	addiw	t1, t1, 0x4b8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xc
                	sw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2e8
+               	addiw	t1, t1, 0x4b8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	lw	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0x22b4>
+               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0x1cb8>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2e8
+               	addiw	t1, t1, 0x4b8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	lw	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0x22d8>
+               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0x1cdc>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2e8
+               	addiw	t1, t1, 0x4b8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	lw	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0x22fc>
+               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0x1d00>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2e8
+               	addiw	t1, t1, 0x4b8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	lw	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0x2320>
+               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0x1d24>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2e8
+               	addiw	t1, t1, 0x4b8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
@@ -2308,13 +1925,13 @@ Disassembly of section .text:
                	lw	a3, 0x0(a1)
                	xor	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2e0
+               	addiw	t1, t1, 0x4b0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
                	sw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2e8
+               	addiw	t1, t1, 0x4b8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
@@ -2323,13 +1940,13 @@ Disassembly of section .text:
                	lw	a3, 0x0(a1)
                	xor	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2e0
+               	addiw	t1, t1, 0x4b0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x4
                	sw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2e8
+               	addiw	t1, t1, 0x4b8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
@@ -2338,13 +1955,13 @@ Disassembly of section .text:
                	lw	a3, 0x0(a1)
                	xor	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2e0
+               	addiw	t1, t1, 0x4b0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
                	sw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2e8
+               	addiw	t1, t1, 0x4b8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
@@ -2353,54 +1970,54 @@ Disassembly of section .text:
                	lw	a3, 0x0(a1)
                	xor	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2e0
+               	addiw	t1, t1, 0x4b0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xc
                	sw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2e0
+               	addiw	t1, t1, 0x4b0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	lw	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0x2434>
+               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0x1e38>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2e0
+               	addiw	t1, t1, 0x4b0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	lw	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0x2458>
+               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0x1e5c>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2e0
+               	addiw	t1, t1, 0x4b0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	lw	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0x247c>
+               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0x1e80>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2e0
+               	addiw	t1, t1, 0x4b0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	lw	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0x24a0>
+               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0x1ea4>
                	mv	a1, s7
                	lw	a2, 0x0(a1)
                	mv	a1, s9
                	lw	a3, 0x0(a1)
                	addw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2d8
+               	addiw	t1, t1, 0x4a8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
@@ -2411,7 +2028,7 @@ Disassembly of section .text:
                	lw	a3, 0x0(a1)
                	addw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2d8
+               	addiw	t1, t1, 0x4a8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x4
@@ -2422,7 +2039,7 @@ Disassembly of section .text:
                	lw	a3, 0x0(a1)
                	addw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2d8
+               	addiw	t1, t1, 0x4a8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
@@ -2433,63 +2050,63 @@ Disassembly of section .text:
                	lw	a3, 0x0(a1)
                	addw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2d8
+               	addiw	t1, t1, 0x4a8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xc
                	sw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2d8
+               	addiw	t1, t1, 0x4a8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	lw	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0x2574>
+               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0x1f78>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2d8
+               	addiw	t1, t1, 0x4a8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	lw	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0x2598>
+               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0x1f9c>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2d8
+               	addiw	t1, t1, 0x4a8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	lw	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0x25bc>
+               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0x1fc0>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2d8
+               	addiw	t1, t1, 0x4a8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	lw	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0x25e0>
+               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0x1fe4>
                	addi	s2, s2, 0x1
                	mv	s1, a0
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2d8
+               	addiw	t1, t1, 0x4a8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	s7, t2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2e0
+               	addiw	t1, t1, 0x4b0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	s5, t2
                	li	t0, 0x6
-               	bltu	s2, t0, 0x2114 <corpus.cases.vec.vec_i32x4.checksum+0x2068>
+               	bltu	s2, t0, 0x1b18 <corpus.cases.vec.vec_i32x4.checksum+0x1a6c>
                	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x368
+               	addiw	t0, t0, 0x528
                	add	s2, s0, t0
                	sd	zero, 0x0(s2)
                	sd	zero, 0x8(s2)
@@ -2522,7 +2139,7 @@ Disassembly of section .text:
                	lw	a2, 0x0(a0)
                	addw	a0, a1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2d0
+               	addiw	t1, t1, 0x4a0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
@@ -2533,7 +2150,7 @@ Disassembly of section .text:
                	lw	a2, 0x0(a0)
                	addw	a0, a1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2d0
+               	addiw	t1, t1, 0x4a0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
@@ -2544,7 +2161,7 @@ Disassembly of section .text:
                	lw	a2, 0x0(a0)
                	addw	a0, a1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2d0
+               	addiw	t1, t1, 0x4a0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
@@ -2555,14 +2172,14 @@ Disassembly of section .text:
                	lw	a2, 0x0(a0)
                	addw	a0, a1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2d0
+               	addiw	t1, t1, 0x4a0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	sw	a0, 0x0(a1)
                	addi	a0, s2, 0x10
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2d0
+               	addiw	t1, t1, 0x4a0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
@@ -2570,7 +2187,7 @@ Disassembly of section .text:
                	mv	a1, a0
                	sw	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2d0
+               	addiw	t1, t1, 0x4a0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
@@ -2578,7 +2195,7 @@ Disassembly of section .text:
                	addi	a1, a0, 0x4
                	sw	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2d0
+               	addiw	t1, t1, 0x4a0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
@@ -2586,7 +2203,7 @@ Disassembly of section .text:
                	addi	a1, a0, 0x8
                	sw	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2d0
+               	addiw	t1, t1, 0x4a0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
@@ -2599,7 +2216,7 @@ Disassembly of section .text:
                	lw	a2, 0x0(a0)
                	mulw	a0, a1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2c8
+               	addiw	t1, t1, 0x498
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
@@ -2610,7 +2227,7 @@ Disassembly of section .text:
                	lw	a2, 0x0(a0)
                	mulw	a0, a1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2c8
+               	addiw	t1, t1, 0x498
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
@@ -2621,7 +2238,7 @@ Disassembly of section .text:
                	lw	a2, 0x0(a0)
                	mulw	a0, a1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2c8
+               	addiw	t1, t1, 0x498
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
@@ -2632,14 +2249,14 @@ Disassembly of section .text:
                	lw	a2, 0x0(a0)
                	mulw	a0, a1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2c8
+               	addiw	t1, t1, 0x498
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	sw	a0, 0x0(a1)
                	addi	a0, s2, 0x20
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2c8
+               	addiw	t1, t1, 0x498
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
@@ -2647,7 +2264,7 @@ Disassembly of section .text:
                	mv	a1, a0
                	sw	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2c8
+               	addiw	t1, t1, 0x498
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
@@ -2655,7 +2272,7 @@ Disassembly of section .text:
                	addi	a1, a0, 0x4
                	sw	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2c8
+               	addiw	t1, t1, 0x498
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
@@ -2663,7 +2280,7 @@ Disassembly of section .text:
                	addi	a1, a0, 0x8
                	sw	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2c8
+               	addiw	t1, t1, 0x498
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
@@ -2689,15 +2306,15 @@ Disassembly of section .text:
                	sw	a2, 0x0(a1)
                	li	s3, 0x0
                	li	t0, 0x4
-               	bltu	s3, t0, 0x29f8 <corpus.cases.vec.vec_i32x4.checksum+0x294c>
-               	j	0x2b24 <corpus.cases.vec.vec_i32x4.checksum+0x2a78>
+               	bltu	s3, t0, 0x23fc <corpus.cases.vec.vec_i32x4.checksum+0x2350>
+               	j	0x2528 <corpus.cases.vec.vec_i32x4.checksum+0x247c>
                	li	t0, 0x10
                	mul	a0, s3, t0
                	add	a1, s2, a0
                	mv	a0, a1
                	lw	a2, 0x0(a0)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2c0
+               	addiw	t1, t1, 0x490
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a0, t2
@@ -2705,7 +2322,7 @@ Disassembly of section .text:
                	addi	a0, a1, 0x4
                	lw	a2, 0x0(a0)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2c0
+               	addiw	t1, t1, 0x490
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a0, t2, 0x4
@@ -2713,7 +2330,7 @@ Disassembly of section .text:
                	addi	a0, a1, 0x8
                	lw	a2, 0x0(a0)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2c0
+               	addiw	t1, t1, 0x490
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a0, t2, 0x8
@@ -2721,53 +2338,53 @@ Disassembly of section .text:
                	addi	a0, a1, 0xc
                	lw	a1, 0x0(a0)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2c0
+               	addiw	t1, t1, 0x490
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a0, t2, 0xc
                	sw	a1, 0x0(a0)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2c0
+               	addiw	t1, t1, 0x490
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a0, t2
                	lw	a1, 0x0(a0)
                	mv	a0, s1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0x29f4>
+               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0x23f8>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2c0
+               	addiw	t1, t1, 0x490
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	lw	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0x2a18>
+               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0x241c>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2c0
+               	addiw	t1, t1, 0x490
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	lw	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0x2a3c>
+               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0x2440>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2c0
+               	addiw	t1, t1, 0x490
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	lw	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0x2a60>
+               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0x2464>
                	addi	s3, s3, 0x1
                	mv	s1, a0
                	li	t0, 0x4
-               	bltu	s3, t0, 0x29f8 <corpus.cases.vec.vec_i32x4.checksum+0x294c>
+               	bltu	s3, t0, 0x23fc <corpus.cases.vec.vec_i32x4.checksum+0x2350>
                	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x338
+               	addiw	t0, t0, 0x4f8
                	add	s3, s0, t0
                	sd	zero, 0x0(s3)
                	sd	zero, 0x8(s3)
@@ -2784,7 +2401,7 @@ Disassembly of section .text:
                	mv	a2, a1
                	lw	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2b8
+               	addiw	t1, t1, 0x488
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
@@ -2792,7 +2409,7 @@ Disassembly of section .text:
                	addi	a2, a1, 0x4
                	lw	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2b8
+               	addiw	t1, t1, 0x488
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x4
@@ -2800,7 +2417,7 @@ Disassembly of section .text:
                	addi	a2, a1, 0x8
                	lw	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2b8
+               	addiw	t1, t1, 0x488
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
@@ -2808,14 +2425,14 @@ Disassembly of section .text:
                	addi	a2, a1, 0xc
                	lw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2b8
+               	addiw	t1, t1, 0x488
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xc
                	sw	a1, 0x0(a2)
                	addi	s2, s3, 0x10
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2b8
+               	addiw	t1, t1, 0x488
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
@@ -2823,7 +2440,7 @@ Disassembly of section .text:
                	mv	a1, s2
                	sw	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2b8
+               	addiw	t1, t1, 0x488
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
@@ -2831,7 +2448,7 @@ Disassembly of section .text:
                	addi	a1, s2, 0x4
                	sw	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2b8
+               	addiw	t1, t1, 0x488
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
@@ -2839,7 +2456,7 @@ Disassembly of section .text:
                	addi	a1, s2, 0x8
                	sw	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2b8
+               	addiw	t1, t1, 0x488
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
@@ -2853,11 +2470,11 @@ Disassembly of section .text:
                	lw	a1, 0x0(a0)
                	mv	a0, s1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0x2bd0>
+               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0x25d4>
                	mv	a1, s2
                	lw	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2b0
+               	addiw	t1, t1, 0x480
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
@@ -2865,7 +2482,7 @@ Disassembly of section .text:
                	addi	a1, s2, 0x4
                	lw	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2b0
+               	addiw	t1, t1, 0x480
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
@@ -2873,7 +2490,7 @@ Disassembly of section .text:
                	addi	a1, s2, 0x8
                	lw	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2b0
+               	addiw	t1, t1, 0x480
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
@@ -2881,105 +2498,105 @@ Disassembly of section .text:
                	addi	a1, s2, 0xc
                	lw	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2b0
+               	addiw	t1, t1, 0x480
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	sw	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2b0
+               	addiw	t1, t1, 0x480
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	lw	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0x2c74>
+               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0x2678>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2b0
+               	addiw	t1, t1, 0x480
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	lw	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0x2c98>
+               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0x269c>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2b0
+               	addiw	t1, t1, 0x480
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	lw	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0x2cbc>
+               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0x26c0>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2b0
+               	addiw	t1, t1, 0x480
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	lw	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0x2ce0>
+               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0x26e4>
                	addi	a1, s3, 0x20
                	lw	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0x2cf4>
+               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0x26f8>
                	lui	t1, 0x1
-               	addiw	t1, t1, -0x268
+               	addiw	t1, t1, -0x438
                	add	t1, sp, t1
                	ld	s1, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, -0x270
+               	addiw	t1, t1, -0x440
                	add	t1, sp, t1
                	ld	s2, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, -0x278
+               	addiw	t1, t1, -0x448
                	add	t1, sp, t1
                	ld	s3, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, -0x280
+               	addiw	t1, t1, -0x450
                	add	t1, sp, t1
                	ld	s4, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, -0x288
+               	addiw	t1, t1, -0x458
                	add	t1, sp, t1
                	ld	s5, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, -0x290
+               	addiw	t1, t1, -0x460
                	add	t1, sp, t1
                	ld	s6, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, -0x298
+               	addiw	t1, t1, -0x468
                	add	t1, sp, t1
                	ld	s7, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, -0x2a0
+               	addiw	t1, t1, -0x470
                	add	t1, sp, t1
                	ld	s8, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, -0x2a8
+               	addiw	t1, t1, -0x478
                	add	t1, sp, t1
                	ld	s9, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, -0x2b0
+               	addiw	t1, t1, -0x480
                	add	t1, sp, t1
                	ld	s10, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, -0x2b8
+               	addiw	t1, t1, -0x488
                	add	t1, sp, t1
                	ld	s11, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, -0x258
+               	addiw	t1, t1, -0x428
                	add	t1, sp, t1
                	ld	ra, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, -0x260
+               	addiw	t1, t1, -0x430
                	add	t1, sp, t1
                	ld	s0, 0x0(t1)
                	lui	t0, 0x1
-               	addiw	t0, t0, -0x250
+               	addiw	t0, t0, -0x420
                	add	sp, sp, t0
                	ret

--- a/test/golden/riscv64-linux/vec/vec_i64x2.dis
+++ b/test/golden/riscv64-linux/vec/vec_i64x2.dis
@@ -33,61 +33,61 @@ Disassembly of section .text:
 
 <corpus.cases.vec.vec_i64x2.checksum>:
                	lui	t0, 0x1
-               	addiw	t0, t0, -0x570
+               	addiw	t0, t0, -0x660
                	sub	sp, sp, t0
                	lui	t1, 0x1
-               	addiw	t1, t1, -0x578
+               	addiw	t1, t1, -0x668
                	add	t1, sp, t1
                	sd	ra, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, -0x580
+               	addiw	t1, t1, -0x670
                	add	t1, sp, t1
                	sd	s0, 0x0(t1)
                	lui	t0, 0x1
-               	addiw	t0, t0, -0x570
+               	addiw	t0, t0, -0x660
                	add	s0, sp, t0
                	lui	t1, 0x1
-               	addiw	t1, t1, -0x588
+               	addiw	t1, t1, -0x678
                	add	t1, sp, t1
                	sd	s1, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, -0x590
+               	addiw	t1, t1, -0x680
                	add	t1, sp, t1
                	sd	s2, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, -0x598
+               	addiw	t1, t1, -0x688
                	add	t1, sp, t1
                	sd	s3, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, -0x5a0
+               	addiw	t1, t1, -0x690
                	add	t1, sp, t1
                	sd	s4, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, -0x5a8
+               	addiw	t1, t1, -0x698
                	add	t1, sp, t1
                	sd	s5, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, -0x5b0
+               	addiw	t1, t1, -0x6a0
                	add	t1, sp, t1
                	sd	s6, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, -0x5b8
+               	addiw	t1, t1, -0x6a8
                	add	t1, sp, t1
                	sd	s7, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, -0x5c0
+               	addiw	t1, t1, -0x6b0
                	add	t1, sp, t1
                	sd	s8, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, -0x5c8
+               	addiw	t1, t1, -0x6b8
                	add	t1, sp, t1
                	sd	s9, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, -0x5d0
+               	addiw	t1, t1, -0x6c0
                	add	t1, sp, t1
                	sd	s10, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, -0x5d8
+               	addiw	t1, t1, -0x6c8
                	add	t1, sp, t1
                	sd	s11, 0x0(t1)
                	mv	s1, a0
@@ -119,93 +119,85 @@ Disassembly of section .text:
                	addi	a1, s0, -0x208
                	addi	t2, s0, -0x218
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x5b8
+               	addiw	t1, t1, 0x6a8
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	a1, s0, -0x228
                	addi	a1, s0, -0x238
                	addi	t2, s0, -0x248
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x5b0
+               	addiw	t1, t1, 0x6a0
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	a1, s0, -0x258
                	addi	a1, s0, -0x268
                	addi	t2, s0, -0x278
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x5a8
+               	addiw	t1, t1, 0x698
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	a1, s0, -0x288
                	addi	t2, s0, -0x298
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x5a0
+               	addiw	t1, t1, 0x690
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	a1, s0, -0x2a8
                	addi	a1, s0, -0x2b8
                	addi	t2, s0, -0x2c8
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x598
+               	addiw	t1, t1, 0x688
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	a1, s0, -0x2d8
                	addi	a1, s0, -0x2e8
                	addi	t2, s0, -0x2f8
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x590
+               	addiw	t1, t1, 0x680
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	a1, s0, -0x308
                	addi	a1, s0, -0x318
                	addi	t2, s0, -0x328
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x588
+               	addiw	t1, t1, 0x678
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	a1, s0, -0x338
                	addi	a1, s0, -0x348
                	addi	t2, s0, -0x358
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x580
+               	addiw	t1, t1, 0x670
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	a1, s0, -0x368
                	addi	a1, s0, -0x378
                	addi	t2, s0, -0x388
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x660
+               	addiw	t1, t1, 0x740
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	a1, s0, -0x398
                	addi	t2, s0, -0x3a8
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x658
+               	addiw	t1, t1, 0x738
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	a1, s0, -0x3b8
                	addi	t2, s0, -0x3c8
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x650
+               	addiw	t1, t1, 0x730
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	a1, s0, -0x3d8
                	addi	a1, s0, -0x3e8
-               	addi	t2, s0, -0x3f8
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x648
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
+               	addi	a1, s0, -0x3f8
                	addi	a1, s0, -0x408
                	addi	a1, s0, -0x418
-               	addi	t2, s0, -0x428
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x640
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
+               	addi	a1, s0, -0x428
                	addi	t2, s0, -0x438
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x638
+               	addiw	t1, t1, 0x728
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	a1, s0, -0x448
@@ -214,7 +206,7 @@ Disassembly of section .text:
                	addi	a1, s0, -0x478
                	addi	t2, s0, -0x488
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x630
+               	addiw	t1, t1, 0x720
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	a1, s0, -0x498
@@ -222,7 +214,7 @@ Disassembly of section .text:
                	addi	a1, s0, -0x4b8
                	addi	t2, s0, -0x4c8
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x628
+               	addiw	t1, t1, 0x718
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	a1, s0, -0x4d8
@@ -230,7 +222,7 @@ Disassembly of section .text:
                	addi	a1, s0, -0x4f8
                	addi	t2, s0, -0x508
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x620
+               	addiw	t1, t1, 0x710
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	a1, s0, -0x518
@@ -238,7 +230,7 @@ Disassembly of section .text:
                	addi	a1, s0, -0x538
                	addi	t2, s0, -0x548
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x618
+               	addiw	t1, t1, 0x708
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	a1, s0, -0x558
@@ -247,30 +239,30 @@ Disassembly of section .text:
                	addi	a1, s0, -0x588
                	addi	t2, s0, -0x598
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x610
+               	addiw	t1, t1, 0x700
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	a1, s0, -0x5a8
                	addi	a1, s0, -0x5b8
                	addi	t2, s0, -0x5c8
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x608
+               	addiw	t1, t1, 0x6f8
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	a1, s0, -0x5d8
                	addi	t2, s0, -0x5e8
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x600
+               	addiw	t1, t1, 0x6f0
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	t2, s0, -0x5f8
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x5f8
+               	addiw	t1, t1, 0x6e8
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	t2, s0, -0x608
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x5f0
+               	addiw	t1, t1, 0x6e0
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	a1, s0, -0x618
@@ -307,68 +299,26 @@ Disassembly of section .text:
                	lui	t0, 0xfffff
                	addiw	t0, t0, 0x7f8
                	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x7e8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x7d8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x7c8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x7b8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x7a8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x798
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x788
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x778
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x768
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x758
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x748
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x738
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x728
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x718
-               	add	a1, s0, t0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i64x2.checksum+0x4f4>
+               	jalr	ra <corpus.cases.vec.vec_i64x2.checksum+0x42c>
                	mv	t2, a0
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x5e8
+               	addiw	t1, t1, 0x6d8
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x5e8
+               	addiw	t1, t1, 0x6d8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x708
+               	addiw	t0, t0, 0x7e8
                	add	t2, s0, t0
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x5e0
+               	addiw	t1, t1, 0x6d0
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x5e0
+               	addiw	t1, t1, 0x6d0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a0, t2
@@ -376,7 +326,7 @@ Disassembly of section .text:
                	addiw	t0, t0, -0x5f9
                	sd	t0, 0x0(a0)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x5e0
+               	addiw	t1, t1, 0x6d0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a0, t2, 0x8
@@ -384,7 +334,7 @@ Disassembly of section .text:
                	addiw	t0, t0, -0x40b
                	sd	t0, 0x0(a0)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x5e0
+               	addiw	t1, t1, 0x6d0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a0, t2
@@ -392,7 +342,7 @@ Disassembly of section .text:
                	mv	a0, s2
                	sd	a1, 0x0(a0)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x5e0
+               	addiw	t1, t1, 0x6d0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a0, t2, 0x8
@@ -400,14 +350,14 @@ Disassembly of section .text:
                	addi	a0, s2, 0x8
                	sd	a1, 0x0(a0)
                	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x6f8
+               	addiw	t0, t0, 0x7d8
                	add	t2, s0, t0
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x5d8
+               	addiw	t1, t1, 0x6c8
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x5d8
+               	addiw	t1, t1, 0x6c8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
@@ -417,7 +367,7 @@ Disassembly of section .text:
                	addi	t0, t0, -0x1ed
                	sd	t0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x5d8
+               	addiw	t1, t1, 0x6c8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
@@ -427,7 +377,7 @@ Disassembly of section .text:
                	addi	t0, t0, 0x7db
                	sd	t0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x5d8
+               	addiw	t1, t1, 0x6c8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
@@ -435,7 +385,7 @@ Disassembly of section .text:
                	mv	a1, s3
                	sd	a0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x5d8
+               	addiw	t1, t1, 0x6c8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a0, t2, 0x8
@@ -443,28 +393,28 @@ Disassembly of section .text:
                	addi	a0, s3, 0x8
                	sd	a1, 0x0(a0)
                	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x6e8
+               	addiw	t0, t0, 0x7c8
                	add	t2, s0, t0
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x5d0
+               	addiw	t1, t1, 0x6c0
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x5d0
+               	addiw	t1, t1, 0x6c0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	li	t0, 0x1
                	sd	t0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x5d0
+               	addiw	t1, t1, 0x6c0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	li	t0, 0x3
                	sd	t0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x5d0
+               	addiw	t1, t1, 0x6c0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
@@ -472,7 +422,7 @@ Disassembly of section .text:
                	mv	a1, s4
                	sd	a0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x5d0
+               	addiw	t1, t1, 0x6c0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a0, t2, 0x8
@@ -480,26 +430,26 @@ Disassembly of section .text:
                	addi	a0, s4, 0x8
                	sd	a1, 0x0(a0)
                	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x6d8
+               	addiw	t0, t0, 0x7b8
                	add	t2, s0, t0
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x5c8
+               	addiw	t1, t1, 0x6b8
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x5c8
+               	addiw	t1, t1, 0x6b8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	sd	zero, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x5c8
+               	addiw	t1, t1, 0x6b8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	sd	zero, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x5c8
+               	addiw	t1, t1, 0x6b8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
@@ -507,7 +457,7 @@ Disassembly of section .text:
                	mv	a1, s5
                	sd	a0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x5c8
+               	addiw	t1, t1, 0x6b8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a0, t2, 0x8
@@ -518,7 +468,7 @@ Disassembly of section .text:
                	ld	a1, 0x0(a0)
                	add	t2, a1, s1
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x5c0
+               	addiw	t1, t1, 0x6b0
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	mv	a1, s2
@@ -531,7 +481,7 @@ Disassembly of section .text:
                	sd	a1, 0x0(a0)
                	mv	a0, s6
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x5c0
+               	addiw	t1, t1, 0x6b0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	sd	t2, 0x0(a0)
@@ -551,27 +501,27 @@ Disassembly of section .text:
                	mv	a0, s6
                	ld	a1, 0x0(a0)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x5e8
+               	addiw	t1, t1, 0x6d8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a0, t2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i64x2.checksum+0x82c>
+               	jalr	ra <corpus.cases.vec.vec_i64x2.checksum+0x764>
                	addi	a1, s6, 0x8
                	ld	s1, 0x0(a1)
                	mv	a1, s1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i64x2.checksum+0x840>
+               	jalr	ra <corpus.cases.vec.vec_i64x2.checksum+0x778>
                	mv	a1, s7
                	ld	s1, 0x0(a1)
                	mv	a1, s1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i64x2.checksum+0x854>
+               	jalr	ra <corpus.cases.vec.vec_i64x2.checksum+0x78c>
                	addi	a1, s7, 0x8
                	ld	s1, 0x0(a1)
                	mv	a1, s1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i64x2.checksum+0x868>
+               	jalr	ra <corpus.cases.vec.vec_i64x2.checksum+0x7a0>
                	mv	a1, s6
                	ld	s1, 0x0(a1)
                	mv	a1, s7
@@ -590,12 +540,12 @@ Disassembly of section .text:
                	ld	s1, 0x0(a1)
                	mv	a1, s1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i64x2.checksum+0x8b4>
+               	jalr	ra <corpus.cases.vec.vec_i64x2.checksum+0x7ec>
                	addi	a1, s8, 0x8
                	ld	s1, 0x0(a1)
                	mv	a1, s1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i64x2.checksum+0x8c8>
+               	jalr	ra <corpus.cases.vec.vec_i64x2.checksum+0x800>
                	mv	a1, s6
                	ld	s1, 0x0(a1)
                	mv	a1, s7
@@ -614,12 +564,12 @@ Disassembly of section .text:
                	ld	s1, 0x0(a1)
                	mv	a1, s1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i64x2.checksum+0x914>
+               	jalr	ra <corpus.cases.vec.vec_i64x2.checksum+0x84c>
                	addi	a1, s9, 0x8
                	ld	s1, 0x0(a1)
                	mv	a1, s1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i64x2.checksum+0x928>
+               	jalr	ra <corpus.cases.vec.vec_i64x2.checksum+0x860>
                	mv	a1, s7
                	ld	s1, 0x0(a1)
                	mv	a1, s6
@@ -638,12 +588,12 @@ Disassembly of section .text:
                	ld	s1, 0x0(a1)
                	mv	a1, s1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i64x2.checksum+0x974>
+               	jalr	ra <corpus.cases.vec.vec_i64x2.checksum+0x8ac>
                	addi	a1, s10, 0x8
                	ld	s1, 0x0(a1)
                	mv	a1, s1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i64x2.checksum+0x988>
+               	jalr	ra <corpus.cases.vec.vec_i64x2.checksum+0x8c0>
                	mv	a1, s6
                	ld	s1, 0x0(a1)
                	mv	a1, s7
@@ -662,19 +612,19 @@ Disassembly of section .text:
                	ld	s1, 0x0(a1)
                	mv	a1, s1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i64x2.checksum+0x9d4>
+               	jalr	ra <corpus.cases.vec.vec_i64x2.checksum+0x90c>
                	addi	a1, s11, 0x8
                	ld	s1, 0x0(a1)
                	mv	a1, s1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i64x2.checksum+0x9e8>
+               	jalr	ra <corpus.cases.vec.vec_i64x2.checksum+0x920>
                	mv	a1, s6
                	ld	s1, 0x0(a1)
                	mv	a1, s4
                	ld	s2, 0x0(a1)
                	mul	a1, s1, s2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x5b8
+               	addiw	t1, t1, 0x6a8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	s1, t2
@@ -685,36 +635,36 @@ Disassembly of section .text:
                	ld	s2, 0x0(a1)
                	mul	a1, s1, s2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x5b8
+               	addiw	t1, t1, 0x6a8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	s1, t2, 0x8
                	sd	a1, 0x0(s1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x5b8
+               	addiw	t1, t1, 0x6a8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	ld	s1, 0x0(a1)
                	mv	a1, s1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i64x2.checksum+0xa64>
+               	jalr	ra <corpus.cases.vec.vec_i64x2.checksum+0x99c>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x5b8
+               	addiw	t1, t1, 0x6a8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	ld	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i64x2.checksum+0xa88>
+               	jalr	ra <corpus.cases.vec.vec_i64x2.checksum+0x9c0>
                	mv	a1, s7
                	ld	a2, 0x0(a1)
                	mv	a1, s4
                	ld	s1, 0x0(a1)
                	mul	a1, a2, s1
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x5b0
+               	addiw	t1, t1, 0x6a0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
@@ -725,36 +675,36 @@ Disassembly of section .text:
                	ld	s1, 0x0(a1)
                	mul	a1, a2, s1
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x5b0
+               	addiw	t1, t1, 0x6a0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
                	sd	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x5b0
+               	addiw	t1, t1, 0x6a0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	ld	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i64x2.checksum+0xb04>
+               	jalr	ra <corpus.cases.vec.vec_i64x2.checksum+0xa3c>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x5b0
+               	addiw	t1, t1, 0x6a0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	ld	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i64x2.checksum+0xb28>
+               	jalr	ra <corpus.cases.vec.vec_i64x2.checksum+0xa60>
                	mv	a1, s6
                	ld	a2, 0x0(a1)
                	mv	a1, s7
                	ld	a3, 0x0(a1)
                	add	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x5a8
+               	addiw	t1, t1, 0x698
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
@@ -765,13 +715,13 @@ Disassembly of section .text:
                	ld	a3, 0x0(a1)
                	add	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x5a8
+               	addiw	t1, t1, 0x698
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
                	sd	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x5a8
+               	addiw	t1, t1, 0x698
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
@@ -780,13 +730,13 @@ Disassembly of section .text:
                	ld	a3, 0x0(a1)
                	mul	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x5a0
+               	addiw	t1, t1, 0x690
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
                	sd	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x5a8
+               	addiw	t1, t1, 0x698
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
@@ -795,36 +745,36 @@ Disassembly of section .text:
                	ld	a3, 0x0(a1)
                	mul	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x5a0
+               	addiw	t1, t1, 0x690
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
                	sd	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x5a0
+               	addiw	t1, t1, 0x690
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	ld	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i64x2.checksum+0xc1c>
+               	jalr	ra <corpus.cases.vec.vec_i64x2.checksum+0xb54>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x5a0
+               	addiw	t1, t1, 0x690
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	ld	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i64x2.checksum+0xc40>
+               	jalr	ra <corpus.cases.vec.vec_i64x2.checksum+0xb78>
                	mv	a1, s5
                	ld	a2, 0x0(a1)
                	mv	a1, s6
                	ld	a3, 0x0(a1)
                	sub	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x598
+               	addiw	t1, t1, 0x688
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
@@ -835,36 +785,36 @@ Disassembly of section .text:
                	ld	a3, 0x0(a1)
                	sub	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x598
+               	addiw	t1, t1, 0x688
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
                	sd	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x598
+               	addiw	t1, t1, 0x688
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	ld	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i64x2.checksum+0xcbc>
+               	jalr	ra <corpus.cases.vec.vec_i64x2.checksum+0xbf4>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x598
+               	addiw	t1, t1, 0x688
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	ld	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i64x2.checksum+0xce0>
+               	jalr	ra <corpus.cases.vec.vec_i64x2.checksum+0xc18>
                	mv	a1, s5
                	ld	a2, 0x0(a1)
                	mv	a1, s7
                	ld	a3, 0x0(a1)
                	sub	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x590
+               	addiw	t1, t1, 0x680
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
@@ -875,36 +825,25 @@ Disassembly of section .text:
                	ld	a3, 0x0(a1)
                	sub	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x590
+               	addiw	t1, t1, 0x680
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
                	sd	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x590
+               	addiw	t1, t1, 0x680
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
-               	ld	a2, 0x0(a1)
-               	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i64x2.checksum+0xd5c>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x590
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	ld	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i64x2.checksum+0xd80>
+               	jalr	ra <corpus.cases.vec.vec_i64x2.checksum+0xc8c>
                	mv	a1, s6
                	ld	a2, 0x0(a1)
                	mv	a1, s7
                	ld	a3, 0x0(a1)
                	and	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x588
+               	addiw	t1, t1, 0x678
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
@@ -915,36 +854,25 @@ Disassembly of section .text:
                	ld	a3, 0x0(a1)
                	and	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x588
+               	addiw	t1, t1, 0x678
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
                	sd	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x588
+               	addiw	t1, t1, 0x678
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
-               	ld	a2, 0x0(a1)
-               	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i64x2.checksum+0xdfc>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x588
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	ld	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i64x2.checksum+0xe20>
+               	jalr	ra <corpus.cases.vec.vec_i64x2.checksum+0xd00>
                	mv	a1, s6
                	ld	a2, 0x0(a1)
                	mv	a1, s7
                	ld	a3, 0x0(a1)
                	or	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x580
+               	addiw	t1, t1, 0x670
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
@@ -955,36 +883,25 @@ Disassembly of section .text:
                	ld	a3, 0x0(a1)
                	or	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x580
+               	addiw	t1, t1, 0x670
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
                	sd	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x580
+               	addiw	t1, t1, 0x670
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
-               	ld	a2, 0x0(a1)
-               	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i64x2.checksum+0xe9c>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x580
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	ld	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i64x2.checksum+0xec0>
+               	jalr	ra <corpus.cases.vec.vec_i64x2.checksum+0xd74>
                	mv	a1, s6
                	ld	a2, 0x0(a1)
                	mv	a1, s7
                	ld	a3, 0x0(a1)
                	xor	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x660
+               	addiw	t1, t1, 0x740
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
@@ -995,34 +912,23 @@ Disassembly of section .text:
                	ld	a3, 0x0(a1)
                	xor	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x660
+               	addiw	t1, t1, 0x740
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
                	sd	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x660
+               	addiw	t1, t1, 0x740
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
-               	ld	a2, 0x0(a1)
-               	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i64x2.checksum+0xf3c>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x660
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	ld	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i64x2.checksum+0xf60>
+               	jalr	ra <corpus.cases.vec.vec_i64x2.checksum+0xde8>
                	mv	a1, s6
                	ld	a2, 0x0(a1)
                	not	a1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x658
+               	addiw	t1, t1, 0x738
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
@@ -1031,34 +937,23 @@ Disassembly of section .text:
                	ld	a2, 0x0(a1)
                	not	a1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x658
+               	addiw	t1, t1, 0x738
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
                	sd	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x658
+               	addiw	t1, t1, 0x738
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
-               	ld	a2, 0x0(a1)
-               	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i64x2.checksum+0xfcc>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x658
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	ld	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i64x2.checksum+0xff0>
+               	jalr	ra <corpus.cases.vec.vec_i64x2.checksum+0xe4c>
                	mv	a1, s7
                	ld	a2, 0x0(a1)
                	not	a1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x650
+               	addiw	t1, t1, 0x730
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
@@ -1067,142 +962,76 @@ Disassembly of section .text:
                	ld	a2, 0x0(a1)
                	not	a1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x650
+               	addiw	t1, t1, 0x730
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
                	sd	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x650
+               	addiw	t1, t1, 0x730
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
-               	ld	a2, 0x0(a1)
-               	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i64x2.checksum+0x105c>
+               	jalr	ra <corpus.cases.vec.vec_i64x2.checksum+0xeb0>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x650
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	ld	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i64x2.checksum+0x1080>
-               	mv	a1, s6
-               	ld	a2, 0x0(a1)
-               	mv	a1, s7
-               	ld	a3, 0x0(a1)
-               	and	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x648
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a2, t2
-               	sd	a1, 0x0(a2)
-               	addi	a1, s6, 0x8
-               	ld	a2, 0x0(a1)
-               	addi	a1, s7, 0x8
-               	ld	a3, 0x0(a1)
-               	and	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x648
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x8
-               	sd	a1, 0x0(a2)
-               	mv	a1, s6
-               	ld	a2, 0x0(a1)
-               	mv	a1, s7
-               	ld	a3, 0x0(a1)
-               	or	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x640
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a2, t2
-               	sd	a1, 0x0(a2)
-               	addi	a1, s6, 0x8
-               	ld	a2, 0x0(a1)
-               	addi	a1, s7, 0x8
-               	ld	a3, 0x0(a1)
-               	or	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x640
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x8
-               	sd	a1, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x648
+               	addiw	t1, t1, 0x678
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	ld	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x640
+               	addiw	t1, t1, 0x670
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	ld	a3, 0x0(a1)
                	xor	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x638
+               	addiw	t1, t1, 0x728
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
                	sd	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x648
+               	addiw	t1, t1, 0x678
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	ld	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x640
+               	addiw	t1, t1, 0x670
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	ld	a3, 0x0(a1)
                	xor	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x638
+               	addiw	t1, t1, 0x728
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
                	sd	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x638
+               	addiw	t1, t1, 0x728
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
-               	ld	a2, 0x0(a1)
-               	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i64x2.checksum+0x11ec>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x638
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	ld	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i64x2.checksum+0x1210>
+               	jalr	ra <corpus.cases.vec.vec_i64x2.checksum+0xf64>
                	mv	s1, a0
                	mv	s2, s5
                	li	s3, 0x0
                	li	t0, 0x6
-               	bltu	s3, t0, 0x129c <corpus.cases.vec.vec_i64x2.checksum+0x1230>
-               	j	0x1588 <corpus.cases.vec.vec_i64x2.checksum+0x151c>
+               	bltu	s3, t0, 0xff0 <corpus.cases.vec.vec_i64x2.checksum+0xf84>
+               	j	0x12dc <corpus.cases.vec.vec_i64x2.checksum+0x1270>
                	mv	a0, s6
                	ld	a1, 0x0(a0)
                	mv	a0, s4
                	ld	a2, 0x0(a0)
                	mul	a0, a1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x630
+               	addiw	t1, t1, 0x720
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
@@ -1213,40 +1042,40 @@ Disassembly of section .text:
                	ld	a2, 0x0(a0)
                	mul	a0, a1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x630
+               	addiw	t1, t1, 0x720
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	sd	a0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x630
+               	addiw	t1, t1, 0x720
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a0, t2
                	ld	a1, 0x0(a0)
                	mv	a0, s1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i64x2.checksum+0x12a4>
+               	jalr	ra <corpus.cases.vec.vec_i64x2.checksum+0xff8>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x630
+               	addiw	t1, t1, 0x720
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	ld	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i64x2.checksum+0x12c8>
+               	jalr	ra <corpus.cases.vec.vec_i64x2.checksum+0x101c>
                	mv	a1, s2
                	ld	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x630
+               	addiw	t1, t1, 0x720
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	ld	a3, 0x0(a1)
                	xor	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x628
+               	addiw	t1, t1, 0x718
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
@@ -1254,43 +1083,43 @@ Disassembly of section .text:
                	addi	a1, s2, 0x8
                	ld	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x630
+               	addiw	t1, t1, 0x720
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	ld	a3, 0x0(a1)
                	xor	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x628
+               	addiw	t1, t1, 0x718
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
                	sd	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x628
+               	addiw	t1, t1, 0x718
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	ld	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i64x2.checksum+0x1364>
+               	jalr	ra <corpus.cases.vec.vec_i64x2.checksum+0x10b8>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x628
+               	addiw	t1, t1, 0x718
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	ld	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i64x2.checksum+0x1388>
+               	jalr	ra <corpus.cases.vec.vec_i64x2.checksum+0x10dc>
                	mv	a1, s5
                	ld	a2, 0x0(a1)
                	mv	a1, s6
                	ld	a3, 0x0(a1)
                	add	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x620
+               	addiw	t1, t1, 0x710
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
@@ -1301,36 +1130,36 @@ Disassembly of section .text:
                	ld	a3, 0x0(a1)
                	add	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x620
+               	addiw	t1, t1, 0x710
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
                	sd	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x620
+               	addiw	t1, t1, 0x710
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	ld	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i64x2.checksum+0x1404>
+               	jalr	ra <corpus.cases.vec.vec_i64x2.checksum+0x1158>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x620
+               	addiw	t1, t1, 0x710
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	ld	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i64x2.checksum+0x1428>
+               	jalr	ra <corpus.cases.vec.vec_i64x2.checksum+0x117c>
                	mv	a1, s6
                	ld	a2, 0x0(a1)
                	mv	a1, s7
                	ld	a3, 0x0(a1)
                	add	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x618
+               	addiw	t1, t1, 0x708
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
@@ -1341,50 +1170,50 @@ Disassembly of section .text:
                	ld	a3, 0x0(a1)
                	add	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x618
+               	addiw	t1, t1, 0x708
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
                	sd	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x618
+               	addiw	t1, t1, 0x708
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	ld	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i64x2.checksum+0x14a4>
+               	jalr	ra <corpus.cases.vec.vec_i64x2.checksum+0x11f8>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x618
+               	addiw	t1, t1, 0x708
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	ld	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i64x2.checksum+0x14c8>
+               	jalr	ra <corpus.cases.vec.vec_i64x2.checksum+0x121c>
                	addi	s3, s3, 0x1
                	mv	s1, a0
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x618
+               	addiw	t1, t1, 0x708
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	s6, t2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x628
+               	addiw	t1, t1, 0x718
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	s2, t2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x620
+               	addiw	t1, t1, 0x710
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	s5, t2
                	li	t0, 0x6
-               	bltu	s3, t0, 0x129c <corpus.cases.vec.vec_i64x2.checksum+0x1230>
+               	bltu	s3, t0, 0xff0 <corpus.cases.vec.vec_i64x2.checksum+0xf84>
                	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x698
+               	addiw	t0, t0, 0x778
                	add	s3, s0, t0
                	sd	zero, 0x0(s3)
                	sd	zero, 0x8(s3)
@@ -1409,7 +1238,7 @@ Disassembly of section .text:
                	ld	a2, 0x0(a0)
                	add	a0, a1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x610
+               	addiw	t1, t1, 0x700
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
@@ -1420,14 +1249,14 @@ Disassembly of section .text:
                	ld	a2, 0x0(a0)
                	add	a0, a1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x610
+               	addiw	t1, t1, 0x700
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	sd	a0, 0x0(a1)
                	addi	a0, s3, 0x10
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x610
+               	addiw	t1, t1, 0x700
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
@@ -1435,7 +1264,7 @@ Disassembly of section .text:
                	mv	a1, a0
                	sd	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x610
+               	addiw	t1, t1, 0x700
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
@@ -1448,7 +1277,7 @@ Disassembly of section .text:
                	ld	a2, 0x0(a0)
                	mul	a0, a1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x608
+               	addiw	t1, t1, 0x6f8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
@@ -1459,14 +1288,14 @@ Disassembly of section .text:
                	ld	a2, 0x0(a0)
                	mul	a0, a1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x608
+               	addiw	t1, t1, 0x6f8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	sd	a0, 0x0(a1)
                	addi	a0, s3, 0x20
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x608
+               	addiw	t1, t1, 0x6f8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
@@ -1474,7 +1303,7 @@ Disassembly of section .text:
                	mv	a1, a0
                	sd	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x608
+               	addiw	t1, t1, 0x6f8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
@@ -1492,15 +1321,15 @@ Disassembly of section .text:
                	sd	a2, 0x0(a1)
                	li	s2, 0x0
                	li	t0, 0x4
-               	bltu	s2, t0, 0x1744 <corpus.cases.vec.vec_i64x2.checksum+0x16d8>
-               	j	0x17e8 <corpus.cases.vec.vec_i64x2.checksum+0x177c>
+               	bltu	s2, t0, 0x1498 <corpus.cases.vec.vec_i64x2.checksum+0x142c>
+               	j	0x153c <corpus.cases.vec.vec_i64x2.checksum+0x14d0>
                	li	t0, 0x10
                	mul	a0, s2, t0
                	add	a1, s3, a0
                	mv	a0, a1
                	ld	a2, 0x0(a0)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x600
+               	addiw	t1, t1, 0x6f0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a0, t2
@@ -1508,35 +1337,35 @@ Disassembly of section .text:
                	addi	a0, a1, 0x8
                	ld	a1, 0x0(a0)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x600
+               	addiw	t1, t1, 0x6f0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a0, t2, 0x8
                	sd	a1, 0x0(a0)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x600
+               	addiw	t1, t1, 0x6f0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a0, t2
                	ld	a1, 0x0(a0)
                	mv	a0, s1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i64x2.checksum+0x1740>
+               	jalr	ra <corpus.cases.vec.vec_i64x2.checksum+0x1494>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x600
+               	addiw	t1, t1, 0x6f0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	ld	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i64x2.checksum+0x1764>
+               	jalr	ra <corpus.cases.vec.vec_i64x2.checksum+0x14b8>
                	addi	s2, s2, 0x1
                	mv	s1, a0
                	li	t0, 0x4
-               	bltu	s2, t0, 0x1744 <corpus.cases.vec.vec_i64x2.checksum+0x16d8>
+               	bltu	s2, t0, 0x1498 <corpus.cases.vec.vec_i64x2.checksum+0x142c>
                	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x668
+               	addiw	t0, t0, 0x748
                	add	s2, s0, t0
                	sd	zero, 0x0(s2)
                	sd	zero, 0x8(s2)
@@ -1553,7 +1382,7 @@ Disassembly of section .text:
                	mv	a2, a1
                	ld	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x5f8
+               	addiw	t1, t1, 0x6e8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
@@ -1561,14 +1390,14 @@ Disassembly of section .text:
                	addi	a2, a1, 0x8
                	ld	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x5f8
+               	addiw	t1, t1, 0x6e8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
                	sd	a1, 0x0(a2)
                	addi	s3, s2, 0x10
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x5f8
+               	addiw	t1, t1, 0x6e8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
@@ -1576,7 +1405,7 @@ Disassembly of section .text:
                	mv	a1, s3
                	sd	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x5f8
+               	addiw	t1, t1, 0x6e8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
@@ -1590,11 +1419,11 @@ Disassembly of section .text:
                	lw	a1, 0x0(a0)
                	mv	a0, s1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i64x2.checksum+0x1854>
+               	jalr	ra <corpus.cases.vec.vec_i64x2.checksum+0x15a8>
                	mv	a1, s3
                	ld	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x5f0
+               	addiw	t1, t1, 0x6e0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
@@ -1602,87 +1431,87 @@ Disassembly of section .text:
                	addi	a1, s3, 0x8
                	ld	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x5f0
+               	addiw	t1, t1, 0x6e0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	sd	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x5f0
+               	addiw	t1, t1, 0x6e0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	ld	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i64x2.checksum+0x18b8>
+               	jalr	ra <corpus.cases.vec.vec_i64x2.checksum+0x160c>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x5f0
+               	addiw	t1, t1, 0x6e0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	ld	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i64x2.checksum+0x18dc>
+               	jalr	ra <corpus.cases.vec.vec_i64x2.checksum+0x1630>
                	addi	a1, s2, 0x20
                	lw	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i64x2.checksum+0x18f0>
+               	jalr	ra <corpus.cases.vec.vec_i64x2.checksum+0x1644>
                	lui	t1, 0x1
-               	addiw	t1, t1, -0x588
+               	addiw	t1, t1, -0x678
                	add	t1, sp, t1
                	ld	s1, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, -0x590
+               	addiw	t1, t1, -0x680
                	add	t1, sp, t1
                	ld	s2, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, -0x598
+               	addiw	t1, t1, -0x688
                	add	t1, sp, t1
                	ld	s3, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, -0x5a0
+               	addiw	t1, t1, -0x690
                	add	t1, sp, t1
                	ld	s4, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, -0x5a8
+               	addiw	t1, t1, -0x698
                	add	t1, sp, t1
                	ld	s5, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, -0x5b0
+               	addiw	t1, t1, -0x6a0
                	add	t1, sp, t1
                	ld	s6, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, -0x5b8
+               	addiw	t1, t1, -0x6a8
                	add	t1, sp, t1
                	ld	s7, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, -0x5c0
+               	addiw	t1, t1, -0x6b0
                	add	t1, sp, t1
                	ld	s8, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, -0x5c8
+               	addiw	t1, t1, -0x6b8
                	add	t1, sp, t1
                	ld	s9, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, -0x5d0
+               	addiw	t1, t1, -0x6c0
                	add	t1, sp, t1
                	ld	s10, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, -0x5d8
+               	addiw	t1, t1, -0x6c8
                	add	t1, sp, t1
                	ld	s11, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, -0x578
+               	addiw	t1, t1, -0x668
                	add	t1, sp, t1
                	ld	ra, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, -0x580
+               	addiw	t1, t1, -0x670
                	add	t1, sp, t1
                	ld	s0, 0x0(t1)
                	lui	t0, 0x1
-               	addiw	t0, t0, -0x570
+               	addiw	t0, t0, -0x660
                	add	sp, sp, t0
                	ret

--- a/test/golden/riscv64-linux/vec/vec_u16x8.dis
+++ b/test/golden/riscv64-linux/vec/vec_u16x8.dis
@@ -81,61 +81,61 @@ Disassembly of section .text:
 
 <corpus.cases.vec.vec_u16x8.checksum>:
                	lui	t0, 0x1
-               	addiw	t0, t0, 0x380
+               	addiw	t0, t0, -0x10
                	sub	sp, sp, t0
                	lui	t1, 0x1
-               	addiw	t1, t1, 0x378
+               	addiw	t1, t1, -0x18
                	add	t1, sp, t1
                	sd	ra, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, 0x370
+               	addiw	t1, t1, -0x20
                	add	t1, sp, t1
                	sd	s0, 0x0(t1)
                	lui	t0, 0x1
-               	addiw	t0, t0, 0x380
+               	addiw	t0, t0, -0x10
                	add	s0, sp, t0
                	lui	t1, 0x1
-               	addiw	t1, t1, 0x368
+               	addiw	t1, t1, -0x28
                	add	t1, sp, t1
                	sd	s1, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, 0x360
+               	addiw	t1, t1, -0x30
                	add	t1, sp, t1
                	sd	s2, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, 0x358
+               	addiw	t1, t1, -0x38
                	add	t1, sp, t1
                	sd	s3, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, 0x350
+               	addiw	t1, t1, -0x40
                	add	t1, sp, t1
                	sd	s4, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, 0x348
+               	addiw	t1, t1, -0x48
                	add	t1, sp, t1
                	sd	s5, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, 0x340
+               	addiw	t1, t1, -0x50
                	add	t1, sp, t1
                	sd	s6, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, 0x338
+               	addiw	t1, t1, -0x58
                	add	t1, sp, t1
                	sd	s7, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, 0x330
+               	addiw	t1, t1, -0x60
                	add	t1, sp, t1
                	sd	s8, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, 0x328
+               	addiw	t1, t1, -0x68
                	add	t1, sp, t1
                	sd	s9, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, 0x320
+               	addiw	t1, t1, -0x70
                	add	t1, sp, t1
                	sd	s10, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, 0x318
+               	addiw	t1, t1, -0x78
                	add	t1, sp, t1
                	sd	s11, 0x0(t1)
                	mv	s1, a0
@@ -167,107 +167,99 @@ Disassembly of section .text:
                	addi	a1, s0, -0x208
                	addi	t2, s0, -0x218
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x338
+               	addiw	t1, t1, 0x58
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	a1, s0, -0x228
                	addi	a1, s0, -0x238
                	addi	t2, s0, -0x248
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x340
+               	addiw	t1, t1, 0x50
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	a1, s0, -0x258
                	addi	a1, s0, -0x268
                	addi	t2, s0, -0x278
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x348
+               	addiw	t1, t1, 0x48
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	a1, s0, -0x288
                	addi	a1, s0, -0x298
                	addi	t2, s0, -0x2a8
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x350
+               	addiw	t1, t1, 0x40
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	a1, s0, -0x2b8
                	addi	a1, s0, -0x2c8
                	addi	t2, s0, -0x2d8
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x358
+               	addiw	t1, t1, 0x38
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	a1, s0, -0x2e8
                	addi	t2, s0, -0x2f8
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x360
+               	addiw	t1, t1, 0x30
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	a1, s0, -0x308
                	addi	a1, s0, -0x318
                	addi	t2, s0, -0x328
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x368
+               	addiw	t1, t1, 0x28
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	a1, s0, -0x338
                	addi	a1, s0, -0x348
                	addi	t2, s0, -0x358
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x370
+               	addiw	t1, t1, 0x20
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	a1, s0, -0x368
                	addi	a1, s0, -0x378
                	addi	t2, s0, -0x388
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2a0
+               	addiw	t1, t1, 0xe0
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	a1, s0, -0x398
                	addi	a1, s0, -0x3a8
                	addi	t2, s0, -0x3b8
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2a8
+               	addiw	t1, t1, 0xd8
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	a1, s0, -0x3c8
                	addi	a1, s0, -0x3d8
                	addi	t2, s0, -0x3e8
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2b0
+               	addiw	t1, t1, 0xd0
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	a1, s0, -0x3f8
                	addi	t2, s0, -0x408
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2b8
+               	addiw	t1, t1, 0xc8
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	a1, s0, -0x418
                	addi	t2, s0, -0x428
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2c0
+               	addiw	t1, t1, 0xc0
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	a1, s0, -0x438
                	addi	a1, s0, -0x448
-               	addi	t2, s0, -0x458
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2c8
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
+               	addi	a1, s0, -0x458
                	addi	a1, s0, -0x468
                	addi	a1, s0, -0x478
-               	addi	t2, s0, -0x488
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2d0
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
+               	addi	a1, s0, -0x488
                	addi	t2, s0, -0x498
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2d8
+               	addiw	t1, t1, 0xb8
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	a1, s0, -0x4a8
@@ -276,7 +268,7 @@ Disassembly of section .text:
                	addi	a1, s0, -0x4d8
                	addi	t2, s0, -0x4e8
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2e0
+               	addiw	t1, t1, 0xb0
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	a1, s0, -0x4f8
@@ -284,7 +276,7 @@ Disassembly of section .text:
                	addi	a1, s0, -0x518
                	addi	t2, s0, -0x528
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2e8
+               	addiw	t1, t1, 0xa8
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	a1, s0, -0x538
@@ -292,7 +284,7 @@ Disassembly of section .text:
                	addi	a1, s0, -0x558
                	addi	t2, s0, -0x568
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2f0
+               	addiw	t1, t1, 0xa0
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	a1, s0, -0x578
@@ -300,7 +292,7 @@ Disassembly of section .text:
                	addi	a1, s0, -0x598
                	addi	t2, s0, -0x5a8
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2f8
+               	addiw	t1, t1, 0x98
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	a1, s0, -0x5b8
@@ -309,30 +301,30 @@ Disassembly of section .text:
                	addi	a1, s0, -0x5e8
                	addi	t2, s0, -0x5f8
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x300
+               	addiw	t1, t1, 0x90
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	a1, s0, -0x608
                	addi	a1, s0, -0x618
                	addi	t2, s0, -0x628
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x308
+               	addiw	t1, t1, 0x88
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	a1, s0, -0x638
                	addi	t2, s0, -0x648
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x310
+               	addiw	t1, t1, 0x80
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	t2, s0, -0x658
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x318
+               	addiw	t1, t1, 0x78
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	t2, s0, -0x668
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x320
+               	addiw	t1, t1, 0x70
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	a1, s0, -0x678
@@ -669,192 +661,24 @@ Disassembly of section .text:
                	lui	t0, 0xfffff
                	addiw	t0, t0, 0x198
                	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x188
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x178
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x168
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x158
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x148
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x138
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x128
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x118
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x108
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0xf8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0xe8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0xd8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0xc8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0xb8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0xa8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x98
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x88
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x78
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x68
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x58
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x48
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x38
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x28
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x18
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x18
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x28
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x38
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x48
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x58
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x68
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x78
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x88
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x98
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0xa8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0xb8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0xc8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0xd8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0xe8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0xf8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x108
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x118
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x128
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x138
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x148
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x158
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x168
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x178
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x188
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x198
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x1a8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x1b8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x1c8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x1d8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x1e8
-               	add	a1, s0, t0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0xbd4>
+               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x914>
                	mv	t2, a0
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x328
+               	addiw	t1, t1, 0x68
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x328
+               	addiw	t1, t1, 0x68
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	sext.w	t2, s1
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x330
+               	addiw	t1, t1, 0x60
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x1f8
+               	addiw	t0, t0, 0x188
                	add	s1, s0, t0
                	mv	a0, s1
                	lui	t0, 0x10
@@ -918,7 +742,7 @@ Disassembly of section .text:
                	addi	a0, s2, 0xe
                	sh	a1, 0x0(a0)
                	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x208
+               	addiw	t0, t0, 0x178
                	add	a0, s0, t0
                	mv	a1, a0
                	li	t0, 0x11
@@ -983,7 +807,7 @@ Disassembly of section .text:
                	addi	a1, s3, 0xe
                	sh	a0, 0x0(a1)
                	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x218
+               	addiw	t0, t0, 0x168
                	add	a0, s0, t0
                	mv	a1, a0
                	li	t0, 0x1
@@ -1043,7 +867,7 @@ Disassembly of section .text:
                	addi	a1, s4, 0xe
                	sh	a0, 0x0(a1)
                	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x228
+               	addiw	t0, t0, 0x158
                	add	a0, s0, t0
                	mv	a1, a0
                	sh	zero, 0x0(a1)
@@ -1096,7 +920,7 @@ Disassembly of section .text:
                	mv	a0, s2
                	lhu	a1, 0x0(a0)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x330
+               	addiw	t1, t1, 0x60
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addw	a0, a1, t2
@@ -1137,7 +961,7 @@ Disassembly of section .text:
                	addi	a0, s6, 0xc
                	lhu	a1, 0x0(a0)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x330
+               	addiw	t1, t1, 0x60
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addw	a0, a1, t2
@@ -1178,7 +1002,7 @@ Disassembly of section .text:
                	addi	a0, s3, 0x4
                	lhu	a1, 0x0(a0)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x330
+               	addiw	t1, t1, 0x60
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addw	a0, a1, t2
@@ -1219,7 +1043,7 @@ Disassembly of section .text:
                	addi	a0, s8, 0xe
                	lhu	a1, 0x0(a0)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x330
+               	addiw	t1, t1, 0x60
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addw	a0, a1, t2
@@ -1260,87 +1084,87 @@ Disassembly of section .text:
                	mv	a0, s7
                	lhu	a1, 0x0(a0)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x328
+               	addiw	t1, t1, 0x68
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a0, t2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x1280>
+               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0xfc0>
                	addi	a1, s7, 0x2
                	lhu	s1, 0x0(a1)
                	mv	a1, s1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x1294>
+               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0xfd4>
                	addi	a1, s7, 0x4
                	lhu	s1, 0x0(a1)
                	mv	a1, s1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x12a8>
+               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0xfe8>
                	addi	a1, s7, 0x6
                	lhu	s1, 0x0(a1)
                	mv	a1, s1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x12bc>
+               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0xffc>
                	addi	a1, s7, 0x8
                	lhu	s1, 0x0(a1)
                	mv	a1, s1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x12d0>
+               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x1010>
                	addi	a1, s7, 0xa
                	lhu	s1, 0x0(a1)
                	mv	a1, s1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x12e4>
+               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x1024>
                	addi	a1, s7, 0xc
                	lhu	s1, 0x0(a1)
                	mv	a1, s1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x12f8>
+               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x1038>
                	addi	a1, s7, 0xe
                	lhu	s1, 0x0(a1)
                	mv	a1, s1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x130c>
+               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x104c>
                	mv	a1, s9
                	lhu	s1, 0x0(a1)
                	mv	a1, s1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x1320>
+               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x1060>
                	addi	a1, s9, 0x2
                	lhu	s1, 0x0(a1)
                	mv	a1, s1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x1334>
+               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x1074>
                	addi	a1, s9, 0x4
                	lhu	s1, 0x0(a1)
                	mv	a1, s1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x1348>
+               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x1088>
                	addi	a1, s9, 0x6
                	lhu	s1, 0x0(a1)
                	mv	a1, s1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x135c>
+               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x109c>
                	addi	a1, s9, 0x8
                	lhu	s1, 0x0(a1)
                	mv	a1, s1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x1370>
+               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x10b0>
                	addi	a1, s9, 0xa
                	lhu	s1, 0x0(a1)
                	mv	a1, s1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x1384>
+               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x10c4>
                	addi	a1, s9, 0xc
                	lhu	s1, 0x0(a1)
                	mv	a1, s1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x1398>
+               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x10d8>
                	addi	a1, s9, 0xe
                	lhu	s1, 0x0(a1)
                	mv	a1, s1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x13ac>
+               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x10ec>
                	mv	a1, s7
                	lhu	s1, 0x0(a1)
                	mv	a1, s9
@@ -1401,42 +1225,42 @@ Disassembly of section .text:
                	lhu	s1, 0x0(a1)
                	mv	a1, s1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x14a0>
+               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x11e0>
                	addi	a1, s10, 0x2
                	lhu	s1, 0x0(a1)
                	mv	a1, s1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x14b4>
+               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x11f4>
                	addi	a1, s10, 0x4
                	lhu	s1, 0x0(a1)
                	mv	a1, s1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x14c8>
+               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x1208>
                	addi	a1, s10, 0x6
                	lhu	s1, 0x0(a1)
                	mv	a1, s1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x14dc>
+               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x121c>
                	addi	a1, s10, 0x8
                	lhu	s1, 0x0(a1)
                	mv	a1, s1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x14f0>
+               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x1230>
                	addi	a1, s10, 0xa
                	lhu	s1, 0x0(a1)
                	mv	a1, s1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x1504>
+               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x1244>
                	addi	a1, s10, 0xc
                	lhu	s1, 0x0(a1)
                	mv	a1, s1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x1518>
+               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x1258>
                	addi	a1, s10, 0xe
                	lhu	s1, 0x0(a1)
                	mv	a1, s1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x152c>
+               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x126c>
                	mv	a1, s7
                	lhu	s1, 0x0(a1)
                	mv	a1, s9
@@ -1497,49 +1321,49 @@ Disassembly of section .text:
                	lhu	s1, 0x0(a1)
                	mv	a1, s1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x1620>
+               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x1360>
                	addi	a1, s11, 0x2
                	lhu	s1, 0x0(a1)
                	mv	a1, s1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x1634>
+               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x1374>
                	addi	a1, s11, 0x4
                	lhu	s1, 0x0(a1)
                	mv	a1, s1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x1648>
+               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x1388>
                	addi	a1, s11, 0x6
                	lhu	s1, 0x0(a1)
                	mv	a1, s1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x165c>
+               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x139c>
                	addi	a1, s11, 0x8
                	lhu	s1, 0x0(a1)
                	mv	a1, s1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x1670>
+               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x13b0>
                	addi	a1, s11, 0xa
                	lhu	s1, 0x0(a1)
                	mv	a1, s1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x1684>
+               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x13c4>
                	addi	a1, s11, 0xc
                	lhu	s1, 0x0(a1)
                	mv	a1, s1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x1698>
+               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x13d8>
                	addi	a1, s11, 0xe
                	lhu	s1, 0x0(a1)
                	mv	a1, s1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x16ac>
+               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x13ec>
                	mv	a1, s9
                	lhu	s1, 0x0(a1)
                	mv	a1, s7
                	lhu	s2, 0x0(a1)
                	subw	a1, s1, s2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x338
+               	addiw	t1, t1, 0x58
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	s1, t2
@@ -1550,7 +1374,7 @@ Disassembly of section .text:
                	lhu	s2, 0x0(a1)
                	subw	a1, s1, s2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x338
+               	addiw	t1, t1, 0x58
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	s1, t2, 0x2
@@ -1561,7 +1385,7 @@ Disassembly of section .text:
                	lhu	s2, 0x0(a1)
                	subw	a1, s1, s2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x338
+               	addiw	t1, t1, 0x58
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	s1, t2, 0x4
@@ -1572,7 +1396,7 @@ Disassembly of section .text:
                	lhu	s2, 0x0(a1)
                	subw	a1, s1, s2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x338
+               	addiw	t1, t1, 0x58
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	s1, t2, 0x6
@@ -1583,7 +1407,7 @@ Disassembly of section .text:
                	lhu	s2, 0x0(a1)
                	subw	a1, s1, s2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x338
+               	addiw	t1, t1, 0x58
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	s1, t2, 0x8
@@ -1594,7 +1418,7 @@ Disassembly of section .text:
                	lhu	s2, 0x0(a1)
                	subw	a1, s1, s2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x338
+               	addiw	t1, t1, 0x58
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	s1, t2, 0xa
@@ -1605,7 +1429,7 @@ Disassembly of section .text:
                	lhu	s2, 0x0(a1)
                	subw	a1, s1, s2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x338
+               	addiw	t1, t1, 0x58
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	s1, t2, 0xc
@@ -1616,90 +1440,90 @@ Disassembly of section .text:
                	lhu	s2, 0x0(a1)
                	subw	a1, s1, s2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x338
+               	addiw	t1, t1, 0x58
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	s1, t2, 0xe
                	sh	a1, 0x0(s1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x338
+               	addiw	t1, t1, 0x58
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	lhu	s1, 0x0(a1)
                	mv	a1, s1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x1830>
+               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x1570>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x338
+               	addiw	t1, t1, 0x58
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x2
                	lhu	s1, 0x0(a1)
                	mv	a1, s1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x1854>
+               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x1594>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x338
+               	addiw	t1, t1, 0x58
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	lhu	s1, 0x0(a1)
                	mv	a1, s1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x1878>
+               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x15b8>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x338
+               	addiw	t1, t1, 0x58
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x6
                	lhu	s1, 0x0(a1)
                	mv	a1, s1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x189c>
+               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x15dc>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x338
+               	addiw	t1, t1, 0x58
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	lhu	s1, 0x0(a1)
                	mv	a1, s1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x18c0>
+               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x1600>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x338
+               	addiw	t1, t1, 0x58
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xa
                	lhu	s1, 0x0(a1)
                	mv	a1, s1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x18e4>
+               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x1624>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x338
+               	addiw	t1, t1, 0x58
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	lhu	s1, 0x0(a1)
                	mv	a1, s1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x1908>
+               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x1648>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x338
+               	addiw	t1, t1, 0x58
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xe
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x192c>
+               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x166c>
                	mv	a1, s7
                	lhu	a2, 0x0(a1)
                	mv	a1, s9
                	lhu	s1, 0x0(a1)
                	mulw	a1, a2, s1
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x340
+               	addiw	t1, t1, 0x50
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
@@ -1710,7 +1534,7 @@ Disassembly of section .text:
                	lhu	s1, 0x0(a1)
                	mulw	a1, a2, s1
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x340
+               	addiw	t1, t1, 0x50
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x2
@@ -1721,7 +1545,7 @@ Disassembly of section .text:
                	lhu	s1, 0x0(a1)
                	mulw	a1, a2, s1
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x340
+               	addiw	t1, t1, 0x50
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x4
@@ -1732,7 +1556,7 @@ Disassembly of section .text:
                	lhu	s1, 0x0(a1)
                	mulw	a1, a2, s1
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x340
+               	addiw	t1, t1, 0x50
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x6
@@ -1743,7 +1567,7 @@ Disassembly of section .text:
                	lhu	s1, 0x0(a1)
                	mulw	a1, a2, s1
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x340
+               	addiw	t1, t1, 0x50
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
@@ -1754,7 +1578,7 @@ Disassembly of section .text:
                	lhu	s1, 0x0(a1)
                	mulw	a1, a2, s1
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x340
+               	addiw	t1, t1, 0x50
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xa
@@ -1765,7 +1589,7 @@ Disassembly of section .text:
                	lhu	s1, 0x0(a1)
                	mulw	a1, a2, s1
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x340
+               	addiw	t1, t1, 0x50
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xc
@@ -1776,90 +1600,90 @@ Disassembly of section .text:
                	lhu	s1, 0x0(a1)
                	mulw	a1, a2, s1
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x340
+               	addiw	t1, t1, 0x50
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xe
                	sh	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x340
+               	addiw	t1, t1, 0x50
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x1ab0>
+               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x17f0>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x340
+               	addiw	t1, t1, 0x50
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x2
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x1ad4>
+               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x1814>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x340
+               	addiw	t1, t1, 0x50
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x1af8>
+               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x1838>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x340
+               	addiw	t1, t1, 0x50
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x6
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x1b1c>
+               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x185c>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x340
+               	addiw	t1, t1, 0x50
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x1b40>
+               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x1880>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x340
+               	addiw	t1, t1, 0x50
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xa
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x1b64>
+               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x18a4>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x340
+               	addiw	t1, t1, 0x50
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x1b88>
+               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x18c8>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x340
+               	addiw	t1, t1, 0x50
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xe
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x1bac>
+               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x18ec>
                	mv	a1, s7
                	lhu	a2, 0x0(a1)
                	mv	a1, s4
                	lhu	a3, 0x0(a1)
                	mulw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x348
+               	addiw	t1, t1, 0x48
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
@@ -1870,7 +1694,7 @@ Disassembly of section .text:
                	lhu	a3, 0x0(a1)
                	mulw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x348
+               	addiw	t1, t1, 0x48
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x2
@@ -1881,7 +1705,7 @@ Disassembly of section .text:
                	lhu	a3, 0x0(a1)
                	mulw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x348
+               	addiw	t1, t1, 0x48
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x4
@@ -1892,7 +1716,7 @@ Disassembly of section .text:
                	lhu	a3, 0x0(a1)
                	mulw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x348
+               	addiw	t1, t1, 0x48
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x6
@@ -1903,7 +1727,7 @@ Disassembly of section .text:
                	lhu	a3, 0x0(a1)
                	mulw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x348
+               	addiw	t1, t1, 0x48
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
@@ -1914,7 +1738,7 @@ Disassembly of section .text:
                	lhu	a3, 0x0(a1)
                	mulw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x348
+               	addiw	t1, t1, 0x48
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xa
@@ -1925,7 +1749,7 @@ Disassembly of section .text:
                	lhu	a3, 0x0(a1)
                	mulw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x348
+               	addiw	t1, t1, 0x48
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xc
@@ -1936,90 +1760,90 @@ Disassembly of section .text:
                	lhu	a3, 0x0(a1)
                	mulw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x348
+               	addiw	t1, t1, 0x48
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xe
                	sh	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x348
+               	addiw	t1, t1, 0x48
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x1d30>
+               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x1a70>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x348
+               	addiw	t1, t1, 0x48
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x2
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x1d54>
+               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x1a94>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x348
+               	addiw	t1, t1, 0x48
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x1d78>
+               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x1ab8>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x348
+               	addiw	t1, t1, 0x48
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x6
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x1d9c>
+               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x1adc>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x348
+               	addiw	t1, t1, 0x48
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x1dc0>
+               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x1b00>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x348
+               	addiw	t1, t1, 0x48
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xa
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x1de4>
+               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x1b24>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x348
+               	addiw	t1, t1, 0x48
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x1e08>
+               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x1b48>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x348
+               	addiw	t1, t1, 0x48
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xe
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x1e2c>
+               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x1b6c>
                	mv	a1, s9
                	lhu	a2, 0x0(a1)
                	mv	a1, s4
                	lhu	a3, 0x0(a1)
                	mulw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x350
+               	addiw	t1, t1, 0x40
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
@@ -2030,7 +1854,7 @@ Disassembly of section .text:
                	lhu	a3, 0x0(a1)
                	mulw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x350
+               	addiw	t1, t1, 0x40
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x2
@@ -2041,7 +1865,7 @@ Disassembly of section .text:
                	lhu	a3, 0x0(a1)
                	mulw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x350
+               	addiw	t1, t1, 0x40
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x4
@@ -2052,7 +1876,7 @@ Disassembly of section .text:
                	lhu	a3, 0x0(a1)
                	mulw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x350
+               	addiw	t1, t1, 0x40
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x6
@@ -2063,7 +1887,7 @@ Disassembly of section .text:
                	lhu	a3, 0x0(a1)
                	mulw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x350
+               	addiw	t1, t1, 0x40
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
@@ -2074,7 +1898,7 @@ Disassembly of section .text:
                	lhu	a3, 0x0(a1)
                	mulw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x350
+               	addiw	t1, t1, 0x40
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xa
@@ -2085,7 +1909,7 @@ Disassembly of section .text:
                	lhu	a3, 0x0(a1)
                	mulw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x350
+               	addiw	t1, t1, 0x40
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xc
@@ -2096,90 +1920,90 @@ Disassembly of section .text:
                	lhu	a3, 0x0(a1)
                	mulw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x350
+               	addiw	t1, t1, 0x40
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xe
                	sh	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x350
+               	addiw	t1, t1, 0x40
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x1fb0>
+               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x1cf0>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x350
+               	addiw	t1, t1, 0x40
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x2
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x1fd4>
+               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x1d14>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x350
+               	addiw	t1, t1, 0x40
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x1ff8>
+               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x1d38>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x350
+               	addiw	t1, t1, 0x40
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x6
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x201c>
+               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x1d5c>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x350
+               	addiw	t1, t1, 0x40
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x2040>
+               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x1d80>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x350
+               	addiw	t1, t1, 0x40
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xa
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x2064>
+               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x1da4>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x350
+               	addiw	t1, t1, 0x40
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x2088>
+               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x1dc8>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x350
+               	addiw	t1, t1, 0x40
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xe
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x20ac>
+               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x1dec>
                	mv	a1, s7
                	lhu	a2, 0x0(a1)
                	mv	a1, s9
                	lhu	a3, 0x0(a1)
                	addw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x358
+               	addiw	t1, t1, 0x38
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
@@ -2190,7 +2014,7 @@ Disassembly of section .text:
                	lhu	a3, 0x0(a1)
                	addw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x358
+               	addiw	t1, t1, 0x38
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x2
@@ -2201,7 +2025,7 @@ Disassembly of section .text:
                	lhu	a3, 0x0(a1)
                	addw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x358
+               	addiw	t1, t1, 0x38
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x4
@@ -2212,7 +2036,7 @@ Disassembly of section .text:
                	lhu	a3, 0x0(a1)
                	addw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x358
+               	addiw	t1, t1, 0x38
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x6
@@ -2223,7 +2047,7 @@ Disassembly of section .text:
                	lhu	a3, 0x0(a1)
                	addw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x358
+               	addiw	t1, t1, 0x38
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
@@ -2234,7 +2058,7 @@ Disassembly of section .text:
                	lhu	a3, 0x0(a1)
                	addw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x358
+               	addiw	t1, t1, 0x38
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xa
@@ -2245,7 +2069,7 @@ Disassembly of section .text:
                	lhu	a3, 0x0(a1)
                	addw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x358
+               	addiw	t1, t1, 0x38
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xc
@@ -2256,13 +2080,13 @@ Disassembly of section .text:
                	lhu	a3, 0x0(a1)
                	addw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x358
+               	addiw	t1, t1, 0x38
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xe
                	sh	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x358
+               	addiw	t1, t1, 0x38
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
@@ -2271,13 +2095,13 @@ Disassembly of section .text:
                	lhu	a3, 0x0(a1)
                	mulw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x360
+               	addiw	t1, t1, 0x30
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
                	sh	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x358
+               	addiw	t1, t1, 0x38
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x2
@@ -2286,13 +2110,13 @@ Disassembly of section .text:
                	lhu	a3, 0x0(a1)
                	mulw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x360
+               	addiw	t1, t1, 0x30
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x2
                	sh	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x358
+               	addiw	t1, t1, 0x38
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
@@ -2301,13 +2125,13 @@ Disassembly of section .text:
                	lhu	a3, 0x0(a1)
                	mulw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x360
+               	addiw	t1, t1, 0x30
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x4
                	sh	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x358
+               	addiw	t1, t1, 0x38
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x6
@@ -2316,13 +2140,13 @@ Disassembly of section .text:
                	lhu	a3, 0x0(a1)
                	mulw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x360
+               	addiw	t1, t1, 0x30
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x6
                	sh	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x358
+               	addiw	t1, t1, 0x38
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
@@ -2331,13 +2155,13 @@ Disassembly of section .text:
                	lhu	a3, 0x0(a1)
                	mulw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x360
+               	addiw	t1, t1, 0x30
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
                	sh	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x358
+               	addiw	t1, t1, 0x38
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xa
@@ -2346,13 +2170,13 @@ Disassembly of section .text:
                	lhu	a3, 0x0(a1)
                	mulw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x360
+               	addiw	t1, t1, 0x30
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xa
                	sh	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x358
+               	addiw	t1, t1, 0x38
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
@@ -2361,13 +2185,13 @@ Disassembly of section .text:
                	lhu	a3, 0x0(a1)
                	mulw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x360
+               	addiw	t1, t1, 0x30
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xc
                	sh	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x358
+               	addiw	t1, t1, 0x38
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xe
@@ -2376,90 +2200,90 @@ Disassembly of section .text:
                	lhu	a3, 0x0(a1)
                	mulw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x360
+               	addiw	t1, t1, 0x30
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xe
                	sh	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x360
+               	addiw	t1, t1, 0x30
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x2410>
+               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x2150>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x360
+               	addiw	t1, t1, 0x30
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x2
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x2434>
+               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x2174>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x360
+               	addiw	t1, t1, 0x30
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x2458>
+               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x2198>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x360
+               	addiw	t1, t1, 0x30
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x6
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x247c>
+               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x21bc>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x360
+               	addiw	t1, t1, 0x30
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x24a0>
+               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x21e0>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x360
+               	addiw	t1, t1, 0x30
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xa
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x24c4>
+               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x2204>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x360
+               	addiw	t1, t1, 0x30
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x24e8>
+               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x2228>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x360
+               	addiw	t1, t1, 0x30
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xe
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x250c>
+               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x224c>
                	mv	a1, s5
                	lhu	a2, 0x0(a1)
                	mv	a1, s7
                	lhu	a3, 0x0(a1)
                	subw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x368
+               	addiw	t1, t1, 0x28
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
@@ -2470,7 +2294,7 @@ Disassembly of section .text:
                	lhu	a3, 0x0(a1)
                	subw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x368
+               	addiw	t1, t1, 0x28
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x2
@@ -2481,7 +2305,7 @@ Disassembly of section .text:
                	lhu	a3, 0x0(a1)
                	subw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x368
+               	addiw	t1, t1, 0x28
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x4
@@ -2492,7 +2316,7 @@ Disassembly of section .text:
                	lhu	a3, 0x0(a1)
                	subw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x368
+               	addiw	t1, t1, 0x28
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x6
@@ -2503,7 +2327,7 @@ Disassembly of section .text:
                	lhu	a3, 0x0(a1)
                	subw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x368
+               	addiw	t1, t1, 0x28
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
@@ -2514,7 +2338,7 @@ Disassembly of section .text:
                	lhu	a3, 0x0(a1)
                	subw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x368
+               	addiw	t1, t1, 0x28
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xa
@@ -2525,7 +2349,7 @@ Disassembly of section .text:
                	lhu	a3, 0x0(a1)
                	subw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x368
+               	addiw	t1, t1, 0x28
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xc
@@ -2536,90 +2360,90 @@ Disassembly of section .text:
                	lhu	a3, 0x0(a1)
                	subw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x368
+               	addiw	t1, t1, 0x28
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xe
                	sh	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x368
+               	addiw	t1, t1, 0x28
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x2690>
+               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x23d0>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x368
+               	addiw	t1, t1, 0x28
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x2
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x26b4>
+               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x23f4>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x368
+               	addiw	t1, t1, 0x28
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x26d8>
+               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x2418>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x368
+               	addiw	t1, t1, 0x28
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x6
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x26fc>
+               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x243c>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x368
+               	addiw	t1, t1, 0x28
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x2720>
+               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x2460>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x368
+               	addiw	t1, t1, 0x28
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xa
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x2744>
+               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x2484>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x368
+               	addiw	t1, t1, 0x28
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x2768>
+               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x24a8>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x368
+               	addiw	t1, t1, 0x28
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xe
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x278c>
+               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x24cc>
                	mv	a1, s5
                	lhu	a2, 0x0(a1)
                	mv	a1, s9
                	lhu	a3, 0x0(a1)
                	subw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x370
+               	addiw	t1, t1, 0x20
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
@@ -2630,7 +2454,7 @@ Disassembly of section .text:
                	lhu	a3, 0x0(a1)
                	subw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x370
+               	addiw	t1, t1, 0x20
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x2
@@ -2641,7 +2465,7 @@ Disassembly of section .text:
                	lhu	a3, 0x0(a1)
                	subw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x370
+               	addiw	t1, t1, 0x20
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x4
@@ -2652,7 +2476,7 @@ Disassembly of section .text:
                	lhu	a3, 0x0(a1)
                	subw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x370
+               	addiw	t1, t1, 0x20
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x6
@@ -2663,7 +2487,7 @@ Disassembly of section .text:
                	lhu	a3, 0x0(a1)
                	subw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x370
+               	addiw	t1, t1, 0x20
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
@@ -2674,7 +2498,7 @@ Disassembly of section .text:
                	lhu	a3, 0x0(a1)
                	subw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x370
+               	addiw	t1, t1, 0x20
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xa
@@ -2685,7 +2509,7 @@ Disassembly of section .text:
                	lhu	a3, 0x0(a1)
                	subw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x370
+               	addiw	t1, t1, 0x20
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xc
@@ -2696,90 +2520,25 @@ Disassembly of section .text:
                	lhu	a3, 0x0(a1)
                	subw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x370
+               	addiw	t1, t1, 0x20
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xe
                	sh	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x370
+               	addiw	t1, t1, 0x20
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x2910>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x370
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x2
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x2934>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x370
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x2958>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x370
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x6
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x297c>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x370
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x29a0>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x370
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xa
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x29c4>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x370
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x29e8>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x370
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xe
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x2a0c>
+               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x2648>
                	mv	a1, s7
                	lhu	a2, 0x0(a1)
                	mv	a1, s9
                	lhu	a3, 0x0(a1)
                	and	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2a0
+               	addiw	t1, t1, 0xe0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
@@ -2790,7 +2549,7 @@ Disassembly of section .text:
                	lhu	a3, 0x0(a1)
                	and	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2a0
+               	addiw	t1, t1, 0xe0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x2
@@ -2801,7 +2560,7 @@ Disassembly of section .text:
                	lhu	a3, 0x0(a1)
                	and	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2a0
+               	addiw	t1, t1, 0xe0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x4
@@ -2812,7 +2571,7 @@ Disassembly of section .text:
                	lhu	a3, 0x0(a1)
                	and	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2a0
+               	addiw	t1, t1, 0xe0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x6
@@ -2823,7 +2582,7 @@ Disassembly of section .text:
                	lhu	a3, 0x0(a1)
                	and	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2a0
+               	addiw	t1, t1, 0xe0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
@@ -2834,7 +2593,7 @@ Disassembly of section .text:
                	lhu	a3, 0x0(a1)
                	and	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2a0
+               	addiw	t1, t1, 0xe0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xa
@@ -2845,7 +2604,7 @@ Disassembly of section .text:
                	lhu	a3, 0x0(a1)
                	and	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2a0
+               	addiw	t1, t1, 0xe0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xc
@@ -2856,90 +2615,25 @@ Disassembly of section .text:
                	lhu	a3, 0x0(a1)
                	and	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2a0
+               	addiw	t1, t1, 0xe0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xe
                	sh	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2a0
+               	addiw	t1, t1, 0xe0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x2b90>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2a0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x2
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x2bb4>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2a0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x2bd8>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2a0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x6
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x2bfc>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2a0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x2c20>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2a0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xa
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x2c44>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2a0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x2c68>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2a0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xe
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x2c8c>
+               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x27c4>
                	mv	a1, s7
                	lhu	a2, 0x0(a1)
                	mv	a1, s9
                	lhu	a3, 0x0(a1)
                	or	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2a8
+               	addiw	t1, t1, 0xd8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
@@ -2950,7 +2644,7 @@ Disassembly of section .text:
                	lhu	a3, 0x0(a1)
                	or	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2a8
+               	addiw	t1, t1, 0xd8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x2
@@ -2961,7 +2655,7 @@ Disassembly of section .text:
                	lhu	a3, 0x0(a1)
                	or	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2a8
+               	addiw	t1, t1, 0xd8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x4
@@ -2972,7 +2666,7 @@ Disassembly of section .text:
                	lhu	a3, 0x0(a1)
                	or	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2a8
+               	addiw	t1, t1, 0xd8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x6
@@ -2983,7 +2677,7 @@ Disassembly of section .text:
                	lhu	a3, 0x0(a1)
                	or	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2a8
+               	addiw	t1, t1, 0xd8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
@@ -2994,7 +2688,7 @@ Disassembly of section .text:
                	lhu	a3, 0x0(a1)
                	or	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2a8
+               	addiw	t1, t1, 0xd8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xa
@@ -3005,7 +2699,7 @@ Disassembly of section .text:
                	lhu	a3, 0x0(a1)
                	or	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2a8
+               	addiw	t1, t1, 0xd8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xc
@@ -3016,90 +2710,25 @@ Disassembly of section .text:
                	lhu	a3, 0x0(a1)
                	or	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2a8
+               	addiw	t1, t1, 0xd8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xe
                	sh	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2a8
+               	addiw	t1, t1, 0xd8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x2e10>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2a8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x2
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x2e34>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2a8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x2e58>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2a8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x6
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x2e7c>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2a8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x2ea0>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2a8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xa
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x2ec4>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2a8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x2ee8>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2a8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xe
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x2f0c>
+               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x2940>
                	mv	a1, s7
                	lhu	a2, 0x0(a1)
                	mv	a1, s9
                	lhu	a3, 0x0(a1)
                	xor	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2b0
+               	addiw	t1, t1, 0xd0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
@@ -3110,7 +2739,7 @@ Disassembly of section .text:
                	lhu	a3, 0x0(a1)
                	xor	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2b0
+               	addiw	t1, t1, 0xd0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x2
@@ -3121,7 +2750,7 @@ Disassembly of section .text:
                	lhu	a3, 0x0(a1)
                	xor	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2b0
+               	addiw	t1, t1, 0xd0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x4
@@ -3132,7 +2761,7 @@ Disassembly of section .text:
                	lhu	a3, 0x0(a1)
                	xor	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2b0
+               	addiw	t1, t1, 0xd0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x6
@@ -3143,7 +2772,7 @@ Disassembly of section .text:
                	lhu	a3, 0x0(a1)
                	xor	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2b0
+               	addiw	t1, t1, 0xd0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
@@ -3154,7 +2783,7 @@ Disassembly of section .text:
                	lhu	a3, 0x0(a1)
                	xor	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2b0
+               	addiw	t1, t1, 0xd0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xa
@@ -3165,7 +2794,7 @@ Disassembly of section .text:
                	lhu	a3, 0x0(a1)
                	xor	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2b0
+               	addiw	t1, t1, 0xd0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xc
@@ -3176,88 +2805,23 @@ Disassembly of section .text:
                	lhu	a3, 0x0(a1)
                	xor	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2b0
+               	addiw	t1, t1, 0xd0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xe
                	sh	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2b0
+               	addiw	t1, t1, 0xd0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x3090>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2b0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x2
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x30b4>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2b0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x30d8>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2b0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x6
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x30fc>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2b0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x3120>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2b0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xa
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x3144>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2b0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x3168>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2b0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xe
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x318c>
+               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x2abc>
                	mv	a1, s7
                	lhu	a2, 0x0(a1)
                	not	a1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2b8
+               	addiw	t1, t1, 0xc8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
@@ -3266,7 +2830,7 @@ Disassembly of section .text:
                	lhu	a2, 0x0(a1)
                	not	a1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2b8
+               	addiw	t1, t1, 0xc8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x2
@@ -3275,7 +2839,7 @@ Disassembly of section .text:
                	lhu	a2, 0x0(a1)
                	not	a1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2b8
+               	addiw	t1, t1, 0xc8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x4
@@ -3284,7 +2848,7 @@ Disassembly of section .text:
                	lhu	a2, 0x0(a1)
                	not	a1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2b8
+               	addiw	t1, t1, 0xc8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x6
@@ -3293,7 +2857,7 @@ Disassembly of section .text:
                	lhu	a2, 0x0(a1)
                	not	a1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2b8
+               	addiw	t1, t1, 0xc8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
@@ -3302,7 +2866,7 @@ Disassembly of section .text:
                	lhu	a2, 0x0(a1)
                	not	a1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2b8
+               	addiw	t1, t1, 0xc8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xa
@@ -3311,7 +2875,7 @@ Disassembly of section .text:
                	lhu	a2, 0x0(a1)
                	not	a1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2b8
+               	addiw	t1, t1, 0xc8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xc
@@ -3320,88 +2884,23 @@ Disassembly of section .text:
                	lhu	a2, 0x0(a1)
                	not	a1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2b8
+               	addiw	t1, t1, 0xc8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xe
                	sh	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2b8
+               	addiw	t1, t1, 0xc8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x32d0>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2b8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x2
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x32f4>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2b8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x3318>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2b8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x6
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x333c>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2b8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x3360>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2b8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xa
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x3384>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2b8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x33a8>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2b8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xe
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x33cc>
+               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x2bf8>
                	mv	a1, s9
                	lhu	a2, 0x0(a1)
                	not	a1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2c0
+               	addiw	t1, t1, 0xc0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
@@ -3410,7 +2909,7 @@ Disassembly of section .text:
                	lhu	a2, 0x0(a1)
                	not	a1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2c0
+               	addiw	t1, t1, 0xc0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x2
@@ -3419,7 +2918,7 @@ Disassembly of section .text:
                	lhu	a2, 0x0(a1)
                	not	a1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2c0
+               	addiw	t1, t1, 0xc0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x4
@@ -3428,7 +2927,7 @@ Disassembly of section .text:
                	lhu	a2, 0x0(a1)
                	not	a1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2c0
+               	addiw	t1, t1, 0xc0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x6
@@ -3437,7 +2936,7 @@ Disassembly of section .text:
                	lhu	a2, 0x0(a1)
                	not	a1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2c0
+               	addiw	t1, t1, 0xc0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
@@ -3446,7 +2945,7 @@ Disassembly of section .text:
                	lhu	a2, 0x0(a1)
                	not	a1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2c0
+               	addiw	t1, t1, 0xc0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xa
@@ -3455,7 +2954,7 @@ Disassembly of section .text:
                	lhu	a2, 0x0(a1)
                	not	a1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2c0
+               	addiw	t1, t1, 0xc0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xc
@@ -3464,496 +2963,190 @@ Disassembly of section .text:
                	lhu	a2, 0x0(a1)
                	not	a1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2c0
+               	addiw	t1, t1, 0xc0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xe
                	sh	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2c0
+               	addiw	t1, t1, 0xc0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x3510>
+               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x2d34>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2c0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x2
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x3534>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2c0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x3558>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2c0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x6
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x357c>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2c0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x35a0>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2c0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xa
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x35c4>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2c0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x35e8>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2c0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xe
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x360c>
-               	mv	a1, s7
-               	lhu	a2, 0x0(a1)
-               	mv	a1, s9
-               	lhu	a3, 0x0(a1)
-               	and	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2c8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a2, t2
-               	sh	a1, 0x0(a2)
-               	addi	a1, s7, 0x2
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s9, 0x2
-               	lhu	a3, 0x0(a1)
-               	and	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2c8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x2
-               	sh	a1, 0x0(a2)
-               	addi	a1, s7, 0x4
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s9, 0x4
-               	lhu	a3, 0x0(a1)
-               	and	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2c8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x4
-               	sh	a1, 0x0(a2)
-               	addi	a1, s7, 0x6
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s9, 0x6
-               	lhu	a3, 0x0(a1)
-               	and	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2c8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x6
-               	sh	a1, 0x0(a2)
-               	addi	a1, s7, 0x8
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s9, 0x8
-               	lhu	a3, 0x0(a1)
-               	and	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2c8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x8
-               	sh	a1, 0x0(a2)
-               	addi	a1, s7, 0xa
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s9, 0xa
-               	lhu	a3, 0x0(a1)
-               	and	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2c8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0xa
-               	sh	a1, 0x0(a2)
-               	addi	a1, s7, 0xc
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s9, 0xc
-               	lhu	a3, 0x0(a1)
-               	and	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2c8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0xc
-               	sh	a1, 0x0(a2)
-               	addi	a1, s7, 0xe
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s9, 0xe
-               	lhu	a3, 0x0(a1)
-               	and	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2c8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0xe
-               	sh	a1, 0x0(a2)
-               	mv	a1, s7
-               	lhu	a2, 0x0(a1)
-               	mv	a1, s9
-               	lhu	a3, 0x0(a1)
-               	or	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2d0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a2, t2
-               	sh	a1, 0x0(a2)
-               	addi	a1, s7, 0x2
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s9, 0x2
-               	lhu	a3, 0x0(a1)
-               	or	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2d0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x2
-               	sh	a1, 0x0(a2)
-               	addi	a1, s7, 0x4
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s9, 0x4
-               	lhu	a3, 0x0(a1)
-               	or	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2d0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x4
-               	sh	a1, 0x0(a2)
-               	addi	a1, s7, 0x6
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s9, 0x6
-               	lhu	a3, 0x0(a1)
-               	or	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2d0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x6
-               	sh	a1, 0x0(a2)
-               	addi	a1, s7, 0x8
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s9, 0x8
-               	lhu	a3, 0x0(a1)
-               	or	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2d0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x8
-               	sh	a1, 0x0(a2)
-               	addi	a1, s7, 0xa
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s9, 0xa
-               	lhu	a3, 0x0(a1)
-               	or	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2d0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0xa
-               	sh	a1, 0x0(a2)
-               	addi	a1, s7, 0xc
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s9, 0xc
-               	lhu	a3, 0x0(a1)
-               	or	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2d0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0xc
-               	sh	a1, 0x0(a2)
-               	addi	a1, s7, 0xe
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s9, 0xe
-               	lhu	a3, 0x0(a1)
-               	or	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2d0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0xe
-               	sh	a1, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2c8
+               	addiw	t1, t1, 0xe0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	lhu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2d0
+               	addiw	t1, t1, 0xd8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	lhu	a3, 0x0(a1)
                	xor	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2d8
+               	addiw	t1, t1, 0xb8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
                	sh	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2c8
+               	addiw	t1, t1, 0xe0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x2
                	lhu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2d0
+               	addiw	t1, t1, 0xd8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x2
                	lhu	a3, 0x0(a1)
                	xor	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2d8
+               	addiw	t1, t1, 0xb8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x2
                	sh	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2c8
+               	addiw	t1, t1, 0xe0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	lhu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2d0
+               	addiw	t1, t1, 0xd8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	lhu	a3, 0x0(a1)
                	xor	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2d8
+               	addiw	t1, t1, 0xb8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x4
                	sh	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2c8
+               	addiw	t1, t1, 0xe0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x6
                	lhu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2d0
+               	addiw	t1, t1, 0xd8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x6
                	lhu	a3, 0x0(a1)
                	xor	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2d8
+               	addiw	t1, t1, 0xb8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x6
                	sh	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2c8
+               	addiw	t1, t1, 0xe0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	lhu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2d0
+               	addiw	t1, t1, 0xd8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	lhu	a3, 0x0(a1)
                	xor	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2d8
+               	addiw	t1, t1, 0xb8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
                	sh	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2c8
+               	addiw	t1, t1, 0xe0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xa
                	lhu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2d0
+               	addiw	t1, t1, 0xd8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xa
                	lhu	a3, 0x0(a1)
                	xor	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2d8
+               	addiw	t1, t1, 0xb8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xa
                	sh	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2c8
+               	addiw	t1, t1, 0xe0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	lhu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2d0
+               	addiw	t1, t1, 0xd8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	lhu	a3, 0x0(a1)
                	xor	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2d8
+               	addiw	t1, t1, 0xb8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xc
                	sh	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2c8
+               	addiw	t1, t1, 0xe0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xe
                	lhu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2d0
+               	addiw	t1, t1, 0xd8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xe
                	lhu	a3, 0x0(a1)
                	xor	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2d8
+               	addiw	t1, t1, 0xb8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xe
                	sh	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2d8
+               	addiw	t1, t1, 0xb8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x3b50>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2d8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x2
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x3b74>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2d8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x3b98>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2d8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x6
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x3bbc>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2d8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x3be0>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2d8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xa
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x3c04>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2d8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x3c28>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2d8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xe
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x3c4c>
+               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x2fb0>
                	mv	s1, a0
                	mv	s2, s5
                	li	s3, 0x0
                	li	t0, 0x6
-               	bltu	s3, t0, 0x3d98 <corpus.cases.vec.vec_u16x8.checksum+0x3c6c>
-               	j	0x4864 <corpus.cases.vec.vec_u16x8.checksum+0x4738>
+               	bltu	s3, t0, 0x30fc <corpus.cases.vec.vec_u16x8.checksum+0x2fd0>
+               	j	0x3bc8 <corpus.cases.vec.vec_u16x8.checksum+0x3a9c>
                	mv	a0, s7
                	lhu	a1, 0x0(a0)
                	mv	a0, s4
                	lhu	a2, 0x0(a0)
                	mulw	a0, a1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2e0
+               	addiw	t1, t1, 0xb0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
@@ -3964,7 +3157,7 @@ Disassembly of section .text:
                	lhu	a2, 0x0(a0)
                	mulw	a0, a1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2e0
+               	addiw	t1, t1, 0xb0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x2
@@ -3975,7 +3168,7 @@ Disassembly of section .text:
                	lhu	a2, 0x0(a0)
                	mulw	a0, a1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2e0
+               	addiw	t1, t1, 0xb0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
@@ -3986,7 +3179,7 @@ Disassembly of section .text:
                	lhu	a2, 0x0(a0)
                	mulw	a0, a1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2e0
+               	addiw	t1, t1, 0xb0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x6
@@ -3997,7 +3190,7 @@ Disassembly of section .text:
                	lhu	a2, 0x0(a0)
                	mulw	a0, a1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2e0
+               	addiw	t1, t1, 0xb0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
@@ -4008,7 +3201,7 @@ Disassembly of section .text:
                	lhu	a2, 0x0(a0)
                	mulw	a0, a1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2e0
+               	addiw	t1, t1, 0xb0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xa
@@ -4019,7 +3212,7 @@ Disassembly of section .text:
                	lhu	a2, 0x0(a0)
                	mulw	a0, a1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2e0
+               	addiw	t1, t1, 0xb0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
@@ -4030,94 +3223,94 @@ Disassembly of section .text:
                	lhu	a2, 0x0(a0)
                	mulw	a0, a1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2e0
+               	addiw	t1, t1, 0xb0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xe
                	sh	a0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2e0
+               	addiw	t1, t1, 0xb0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a0, t2
                	lhu	a1, 0x0(a0)
                	mv	a0, s1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x3de8>
+               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x314c>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2e0
+               	addiw	t1, t1, 0xb0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x2
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x3e0c>
+               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x3170>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2e0
+               	addiw	t1, t1, 0xb0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x3e30>
+               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x3194>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2e0
+               	addiw	t1, t1, 0xb0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x6
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x3e54>
+               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x31b8>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2e0
+               	addiw	t1, t1, 0xb0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x3e78>
+               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x31dc>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2e0
+               	addiw	t1, t1, 0xb0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xa
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x3e9c>
+               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x3200>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2e0
+               	addiw	t1, t1, 0xb0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x3ec0>
+               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x3224>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2e0
+               	addiw	t1, t1, 0xb0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xe
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x3ee4>
+               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x3248>
                	mv	a1, s2
                	lhu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2e0
+               	addiw	t1, t1, 0xb0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	lhu	a3, 0x0(a1)
                	xor	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2e8
+               	addiw	t1, t1, 0xa8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
@@ -4125,14 +3318,14 @@ Disassembly of section .text:
                	addi	a1, s2, 0x2
                	lhu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2e0
+               	addiw	t1, t1, 0xb0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x2
                	lhu	a3, 0x0(a1)
                	xor	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2e8
+               	addiw	t1, t1, 0xa8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x2
@@ -4140,14 +3333,14 @@ Disassembly of section .text:
                	addi	a1, s2, 0x4
                	lhu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2e0
+               	addiw	t1, t1, 0xb0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	lhu	a3, 0x0(a1)
                	xor	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2e8
+               	addiw	t1, t1, 0xa8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x4
@@ -4155,14 +3348,14 @@ Disassembly of section .text:
                	addi	a1, s2, 0x6
                	lhu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2e0
+               	addiw	t1, t1, 0xb0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x6
                	lhu	a3, 0x0(a1)
                	xor	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2e8
+               	addiw	t1, t1, 0xa8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x6
@@ -4170,14 +3363,14 @@ Disassembly of section .text:
                	addi	a1, s2, 0x8
                	lhu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2e0
+               	addiw	t1, t1, 0xb0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	lhu	a3, 0x0(a1)
                	xor	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2e8
+               	addiw	t1, t1, 0xa8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
@@ -4185,14 +3378,14 @@ Disassembly of section .text:
                	addi	a1, s2, 0xa
                	lhu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2e0
+               	addiw	t1, t1, 0xb0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xa
                	lhu	a3, 0x0(a1)
                	xor	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2e8
+               	addiw	t1, t1, 0xa8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xa
@@ -4200,14 +3393,14 @@ Disassembly of section .text:
                	addi	a1, s2, 0xc
                	lhu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2e0
+               	addiw	t1, t1, 0xb0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	lhu	a3, 0x0(a1)
                	xor	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2e8
+               	addiw	t1, t1, 0xa8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xc
@@ -4215,97 +3408,97 @@ Disassembly of section .text:
                	addi	a1, s2, 0xe
                	lhu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2e0
+               	addiw	t1, t1, 0xb0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xe
                	lhu	a3, 0x0(a1)
                	xor	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2e8
+               	addiw	t1, t1, 0xa8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xe
                	sh	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2e8
+               	addiw	t1, t1, 0xa8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x40e8>
+               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x344c>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2e8
+               	addiw	t1, t1, 0xa8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x2
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x410c>
+               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x3470>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2e8
+               	addiw	t1, t1, 0xa8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x4130>
+               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x3494>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2e8
+               	addiw	t1, t1, 0xa8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x6
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x4154>
+               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x34b8>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2e8
+               	addiw	t1, t1, 0xa8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x4178>
+               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x34dc>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2e8
+               	addiw	t1, t1, 0xa8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xa
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x419c>
+               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x3500>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2e8
+               	addiw	t1, t1, 0xa8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x41c0>
+               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x3524>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2e8
+               	addiw	t1, t1, 0xa8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xe
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x41e4>
+               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x3548>
                	mv	a1, s5
                	lhu	a2, 0x0(a1)
                	mv	a1, s7
                	lhu	a3, 0x0(a1)
                	addw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2f0
+               	addiw	t1, t1, 0xa0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
@@ -4316,7 +3509,7 @@ Disassembly of section .text:
                	lhu	a3, 0x0(a1)
                	addw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2f0
+               	addiw	t1, t1, 0xa0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x2
@@ -4327,7 +3520,7 @@ Disassembly of section .text:
                	lhu	a3, 0x0(a1)
                	addw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2f0
+               	addiw	t1, t1, 0xa0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x4
@@ -4338,7 +3531,7 @@ Disassembly of section .text:
                	lhu	a3, 0x0(a1)
                	addw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2f0
+               	addiw	t1, t1, 0xa0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x6
@@ -4349,7 +3542,7 @@ Disassembly of section .text:
                	lhu	a3, 0x0(a1)
                	addw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2f0
+               	addiw	t1, t1, 0xa0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
@@ -4360,7 +3553,7 @@ Disassembly of section .text:
                	lhu	a3, 0x0(a1)
                	addw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2f0
+               	addiw	t1, t1, 0xa0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xa
@@ -4371,7 +3564,7 @@ Disassembly of section .text:
                	lhu	a3, 0x0(a1)
                	addw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2f0
+               	addiw	t1, t1, 0xa0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xc
@@ -4382,90 +3575,90 @@ Disassembly of section .text:
                	lhu	a3, 0x0(a1)
                	addw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2f0
+               	addiw	t1, t1, 0xa0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xe
                	sh	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2f0
+               	addiw	t1, t1, 0xa0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x4368>
+               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x36cc>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2f0
+               	addiw	t1, t1, 0xa0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x2
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x438c>
+               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x36f0>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2f0
+               	addiw	t1, t1, 0xa0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x43b0>
+               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x3714>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2f0
+               	addiw	t1, t1, 0xa0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x6
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x43d4>
+               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x3738>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2f0
+               	addiw	t1, t1, 0xa0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x43f8>
+               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x375c>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2f0
+               	addiw	t1, t1, 0xa0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xa
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x441c>
+               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x3780>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2f0
+               	addiw	t1, t1, 0xa0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x4440>
+               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x37a4>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2f0
+               	addiw	t1, t1, 0xa0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xe
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x4464>
+               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x37c8>
                	mv	a1, s7
                	lhu	a2, 0x0(a1)
                	mv	a1, s9
                	lhu	a3, 0x0(a1)
                	addw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2f8
+               	addiw	t1, t1, 0x98
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
@@ -4476,7 +3669,7 @@ Disassembly of section .text:
                	lhu	a3, 0x0(a1)
                	addw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2f8
+               	addiw	t1, t1, 0x98
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x2
@@ -4487,7 +3680,7 @@ Disassembly of section .text:
                	lhu	a3, 0x0(a1)
                	addw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2f8
+               	addiw	t1, t1, 0x98
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x4
@@ -4498,7 +3691,7 @@ Disassembly of section .text:
                	lhu	a3, 0x0(a1)
                	addw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2f8
+               	addiw	t1, t1, 0x98
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x6
@@ -4509,7 +3702,7 @@ Disassembly of section .text:
                	lhu	a3, 0x0(a1)
                	addw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2f8
+               	addiw	t1, t1, 0x98
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
@@ -4520,7 +3713,7 @@ Disassembly of section .text:
                	lhu	a3, 0x0(a1)
                	addw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2f8
+               	addiw	t1, t1, 0x98
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xa
@@ -4531,7 +3724,7 @@ Disassembly of section .text:
                	lhu	a3, 0x0(a1)
                	addw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2f8
+               	addiw	t1, t1, 0x98
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xc
@@ -4542,104 +3735,104 @@ Disassembly of section .text:
                	lhu	a3, 0x0(a1)
                	addw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2f8
+               	addiw	t1, t1, 0x98
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xe
                	sh	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2f8
+               	addiw	t1, t1, 0x98
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x45e8>
+               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x394c>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2f8
+               	addiw	t1, t1, 0x98
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x2
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x460c>
+               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x3970>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2f8
+               	addiw	t1, t1, 0x98
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x4630>
+               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x3994>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2f8
+               	addiw	t1, t1, 0x98
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x6
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x4654>
+               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x39b8>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2f8
+               	addiw	t1, t1, 0x98
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x4678>
+               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x39dc>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2f8
+               	addiw	t1, t1, 0x98
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xa
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x469c>
+               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x3a00>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2f8
+               	addiw	t1, t1, 0x98
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x46c0>
+               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x3a24>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2f8
+               	addiw	t1, t1, 0x98
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xe
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x46e4>
+               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x3a48>
                	addi	s3, s3, 0x1
                	mv	s1, a0
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2f8
+               	addiw	t1, t1, 0x98
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	s7, t2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2e8
+               	addiw	t1, t1, 0xa8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	s2, t2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x2f0
+               	addiw	t1, t1, 0xa0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	s5, t2
                	li	t0, 0x6
-               	bltu	s3, t0, 0x3d98 <corpus.cases.vec.vec_u16x8.checksum+0x3c6c>
+               	bltu	s3, t0, 0x30fc <corpus.cases.vec.vec_u16x8.checksum+0x2fd0>
                	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x268
+               	addiw	t0, t0, 0x118
                	add	s3, s0, t0
                	sd	zero, 0x0(s3)
                	sd	zero, 0x8(s3)
@@ -4688,7 +3881,7 @@ Disassembly of section .text:
                	lhu	a2, 0x0(a0)
                	addw	a0, a1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x300
+               	addiw	t1, t1, 0x90
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
@@ -4699,7 +3892,7 @@ Disassembly of section .text:
                	lhu	a2, 0x0(a0)
                	addw	a0, a1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x300
+               	addiw	t1, t1, 0x90
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x2
@@ -4710,7 +3903,7 @@ Disassembly of section .text:
                	lhu	a2, 0x0(a0)
                	addw	a0, a1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x300
+               	addiw	t1, t1, 0x90
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
@@ -4721,7 +3914,7 @@ Disassembly of section .text:
                	lhu	a2, 0x0(a0)
                	addw	a0, a1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x300
+               	addiw	t1, t1, 0x90
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x6
@@ -4732,7 +3925,7 @@ Disassembly of section .text:
                	lhu	a2, 0x0(a0)
                	addw	a0, a1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x300
+               	addiw	t1, t1, 0x90
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
@@ -4743,7 +3936,7 @@ Disassembly of section .text:
                	lhu	a2, 0x0(a0)
                	addw	a0, a1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x300
+               	addiw	t1, t1, 0x90
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xa
@@ -4754,7 +3947,7 @@ Disassembly of section .text:
                	lhu	a2, 0x0(a0)
                	addw	a0, a1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x300
+               	addiw	t1, t1, 0x90
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
@@ -4765,14 +3958,14 @@ Disassembly of section .text:
                	lhu	a2, 0x0(a0)
                	addw	a0, a1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x300
+               	addiw	t1, t1, 0x90
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xe
                	sh	a0, 0x0(a1)
                	addi	a0, s3, 0x10
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x300
+               	addiw	t1, t1, 0x90
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
@@ -4780,7 +3973,7 @@ Disassembly of section .text:
                	mv	a1, a0
                	sh	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x300
+               	addiw	t1, t1, 0x90
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x2
@@ -4788,7 +3981,7 @@ Disassembly of section .text:
                	addi	a1, a0, 0x2
                	sh	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x300
+               	addiw	t1, t1, 0x90
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
@@ -4796,7 +3989,7 @@ Disassembly of section .text:
                	addi	a1, a0, 0x4
                	sh	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x300
+               	addiw	t1, t1, 0x90
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x6
@@ -4804,7 +3997,7 @@ Disassembly of section .text:
                	addi	a1, a0, 0x6
                	sh	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x300
+               	addiw	t1, t1, 0x90
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
@@ -4812,7 +4005,7 @@ Disassembly of section .text:
                	addi	a1, a0, 0x8
                	sh	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x300
+               	addiw	t1, t1, 0x90
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xa
@@ -4820,7 +4013,7 @@ Disassembly of section .text:
                	addi	a1, a0, 0xa
                	sh	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x300
+               	addiw	t1, t1, 0x90
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
@@ -4828,7 +4021,7 @@ Disassembly of section .text:
                	addi	a1, a0, 0xc
                	sh	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x300
+               	addiw	t1, t1, 0x90
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xe
@@ -4841,7 +4034,7 @@ Disassembly of section .text:
                	lhu	a2, 0x0(a0)
                	mulw	a0, a1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x308
+               	addiw	t1, t1, 0x88
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
@@ -4852,7 +4045,7 @@ Disassembly of section .text:
                	lhu	a2, 0x0(a0)
                	mulw	a0, a1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x308
+               	addiw	t1, t1, 0x88
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x2
@@ -4863,7 +4056,7 @@ Disassembly of section .text:
                	lhu	a2, 0x0(a0)
                	mulw	a0, a1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x308
+               	addiw	t1, t1, 0x88
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
@@ -4874,7 +4067,7 @@ Disassembly of section .text:
                	lhu	a2, 0x0(a0)
                	mulw	a0, a1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x308
+               	addiw	t1, t1, 0x88
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x6
@@ -4885,7 +4078,7 @@ Disassembly of section .text:
                	lhu	a2, 0x0(a0)
                	mulw	a0, a1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x308
+               	addiw	t1, t1, 0x88
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
@@ -4896,7 +4089,7 @@ Disassembly of section .text:
                	lhu	a2, 0x0(a0)
                	mulw	a0, a1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x308
+               	addiw	t1, t1, 0x88
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xa
@@ -4907,7 +4100,7 @@ Disassembly of section .text:
                	lhu	a2, 0x0(a0)
                	mulw	a0, a1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x308
+               	addiw	t1, t1, 0x88
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
@@ -4918,14 +4111,14 @@ Disassembly of section .text:
                	lhu	a2, 0x0(a0)
                	mulw	a0, a1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x308
+               	addiw	t1, t1, 0x88
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xe
                	sh	a0, 0x0(a1)
                	addi	a0, s3, 0x20
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x308
+               	addiw	t1, t1, 0x88
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
@@ -4933,7 +4126,7 @@ Disassembly of section .text:
                	mv	a1, a0
                	sh	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x308
+               	addiw	t1, t1, 0x88
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x2
@@ -4941,7 +4134,7 @@ Disassembly of section .text:
                	addi	a1, a0, 0x2
                	sh	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x308
+               	addiw	t1, t1, 0x88
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
@@ -4949,7 +4142,7 @@ Disassembly of section .text:
                	addi	a1, a0, 0x4
                	sh	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x308
+               	addiw	t1, t1, 0x88
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x6
@@ -4957,7 +4150,7 @@ Disassembly of section .text:
                	addi	a1, a0, 0x6
                	sh	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x308
+               	addiw	t1, t1, 0x88
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
@@ -4965,7 +4158,7 @@ Disassembly of section .text:
                	addi	a1, a0, 0x8
                	sh	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x308
+               	addiw	t1, t1, 0x88
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xa
@@ -4973,7 +4166,7 @@ Disassembly of section .text:
                	addi	a1, a0, 0xa
                	sh	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x308
+               	addiw	t1, t1, 0x88
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
@@ -4981,7 +4174,7 @@ Disassembly of section .text:
                	addi	a1, a0, 0xc
                	sh	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x308
+               	addiw	t1, t1, 0x88
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xe
@@ -5023,15 +4216,15 @@ Disassembly of section .text:
                	sh	a2, 0x0(a1)
                	li	s2, 0x0
                	li	t0, 0x4
-               	bltu	s2, t0, 0x4e70 <corpus.cases.vec.vec_u16x8.checksum+0x4d44>
-               	j	0x50ac <corpus.cases.vec.vec_u16x8.checksum+0x4f80>
+               	bltu	s2, t0, 0x41d4 <corpus.cases.vec.vec_u16x8.checksum+0x40a8>
+               	j	0x4410 <corpus.cases.vec.vec_u16x8.checksum+0x42e4>
                	li	t0, 0x10
                	mul	a0, s2, t0
                	add	a1, s3, a0
                	mv	a0, a1
                	lhu	a2, 0x0(a0)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x310
+               	addiw	t1, t1, 0x80
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a0, t2
@@ -5039,7 +4232,7 @@ Disassembly of section .text:
                	addi	a0, a1, 0x2
                	lhu	a2, 0x0(a0)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x310
+               	addiw	t1, t1, 0x80
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a0, t2, 0x2
@@ -5047,7 +4240,7 @@ Disassembly of section .text:
                	addi	a0, a1, 0x4
                	lhu	a2, 0x0(a0)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x310
+               	addiw	t1, t1, 0x80
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a0, t2, 0x4
@@ -5055,7 +4248,7 @@ Disassembly of section .text:
                	addi	a0, a1, 0x6
                	lhu	a2, 0x0(a0)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x310
+               	addiw	t1, t1, 0x80
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a0, t2, 0x6
@@ -5063,7 +4256,7 @@ Disassembly of section .text:
                	addi	a0, a1, 0x8
                	lhu	a2, 0x0(a0)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x310
+               	addiw	t1, t1, 0x80
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a0, t2, 0x8
@@ -5071,7 +4264,7 @@ Disassembly of section .text:
                	addi	a0, a1, 0xa
                	lhu	a2, 0x0(a0)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x310
+               	addiw	t1, t1, 0x80
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a0, t2, 0xa
@@ -5079,7 +4272,7 @@ Disassembly of section .text:
                	addi	a0, a1, 0xc
                	lhu	a2, 0x0(a0)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x310
+               	addiw	t1, t1, 0x80
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a0, t2, 0xc
@@ -5087,89 +4280,89 @@ Disassembly of section .text:
                	addi	a0, a1, 0xe
                	lhu	a1, 0x0(a0)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x310
+               	addiw	t1, t1, 0x80
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a0, t2, 0xe
                	sh	a1, 0x0(a0)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x310
+               	addiw	t1, t1, 0x80
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a0, t2
                	lhu	a1, 0x0(a0)
                	mv	a0, s1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x4e6c>
+               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x41d0>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x310
+               	addiw	t1, t1, 0x80
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x2
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x4e90>
+               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x41f4>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x310
+               	addiw	t1, t1, 0x80
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x4eb4>
+               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x4218>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x310
+               	addiw	t1, t1, 0x80
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x6
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x4ed8>
+               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x423c>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x310
+               	addiw	t1, t1, 0x80
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x4efc>
+               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x4260>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x310
+               	addiw	t1, t1, 0x80
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xa
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x4f20>
+               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x4284>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x310
+               	addiw	t1, t1, 0x80
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x4f44>
+               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x42a8>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x310
+               	addiw	t1, t1, 0x80
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xe
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x4f68>
+               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x42cc>
                	addi	s2, s2, 0x1
                	mv	s1, a0
                	li	t0, 0x4
-               	bltu	s2, t0, 0x4e70 <corpus.cases.vec.vec_u16x8.checksum+0x4d44>
+               	bltu	s2, t0, 0x41d4 <corpus.cases.vec.vec_u16x8.checksum+0x40a8>
                	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x298
+               	addiw	t0, t0, 0xe8
                	add	s2, s0, t0
                	sd	zero, 0x0(s2)
                	sd	zero, 0x8(s2)
@@ -5186,7 +4379,7 @@ Disassembly of section .text:
                	mv	a2, a1
                	lhu	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x318
+               	addiw	t1, t1, 0x78
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
@@ -5194,7 +4387,7 @@ Disassembly of section .text:
                	addi	a2, a1, 0x2
                	lhu	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x318
+               	addiw	t1, t1, 0x78
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x2
@@ -5202,7 +4395,7 @@ Disassembly of section .text:
                	addi	a2, a1, 0x4
                	lhu	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x318
+               	addiw	t1, t1, 0x78
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x4
@@ -5210,7 +4403,7 @@ Disassembly of section .text:
                	addi	a2, a1, 0x6
                	lhu	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x318
+               	addiw	t1, t1, 0x78
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x6
@@ -5218,7 +4411,7 @@ Disassembly of section .text:
                	addi	a2, a1, 0x8
                	lhu	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x318
+               	addiw	t1, t1, 0x78
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
@@ -5226,7 +4419,7 @@ Disassembly of section .text:
                	addi	a2, a1, 0xa
                	lhu	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x318
+               	addiw	t1, t1, 0x78
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xa
@@ -5234,7 +4427,7 @@ Disassembly of section .text:
                	addi	a2, a1, 0xc
                	lhu	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x318
+               	addiw	t1, t1, 0x78
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xc
@@ -5242,14 +4435,14 @@ Disassembly of section .text:
                	addi	a2, a1, 0xe
                	lhu	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x318
+               	addiw	t1, t1, 0x78
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xe
                	sh	a1, 0x0(a2)
                	addi	s3, s2, 0x10
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x318
+               	addiw	t1, t1, 0x78
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
@@ -5257,7 +4450,7 @@ Disassembly of section .text:
                	mv	a1, s3
                	sh	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x318
+               	addiw	t1, t1, 0x78
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x2
@@ -5265,7 +4458,7 @@ Disassembly of section .text:
                	addi	a1, s3, 0x2
                	sh	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x318
+               	addiw	t1, t1, 0x78
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
@@ -5273,7 +4466,7 @@ Disassembly of section .text:
                	addi	a1, s3, 0x4
                	sh	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x318
+               	addiw	t1, t1, 0x78
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x6
@@ -5281,7 +4474,7 @@ Disassembly of section .text:
                	addi	a1, s3, 0x6
                	sh	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x318
+               	addiw	t1, t1, 0x78
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
@@ -5289,7 +4482,7 @@ Disassembly of section .text:
                	addi	a1, s3, 0x8
                	sh	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x318
+               	addiw	t1, t1, 0x78
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xa
@@ -5297,7 +4490,7 @@ Disassembly of section .text:
                	addi	a1, s3, 0xa
                	sh	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x318
+               	addiw	t1, t1, 0x78
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
@@ -5305,7 +4498,7 @@ Disassembly of section .text:
                	addi	a1, s3, 0xc
                	sh	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x318
+               	addiw	t1, t1, 0x78
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xe
@@ -5319,11 +4512,11 @@ Disassembly of section .text:
                	lw	a1, 0x0(a0)
                	mv	a0, s1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x51d8>
+               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x453c>
                	mv	a1, s3
                	lhu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x320
+               	addiw	t1, t1, 0x70
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
@@ -5331,7 +4524,7 @@ Disassembly of section .text:
                	addi	a1, s3, 0x2
                	lhu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x320
+               	addiw	t1, t1, 0x70
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x2
@@ -5339,7 +4532,7 @@ Disassembly of section .text:
                	addi	a1, s3, 0x4
                	lhu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x320
+               	addiw	t1, t1, 0x70
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
@@ -5347,7 +4540,7 @@ Disassembly of section .text:
                	addi	a1, s3, 0x6
                	lhu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x320
+               	addiw	t1, t1, 0x70
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x6
@@ -5355,7 +4548,7 @@ Disassembly of section .text:
                	addi	a1, s3, 0x8
                	lhu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x320
+               	addiw	t1, t1, 0x70
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
@@ -5363,7 +4556,7 @@ Disassembly of section .text:
                	addi	a1, s3, 0xa
                	lhu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x320
+               	addiw	t1, t1, 0x70
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xa
@@ -5371,7 +4564,7 @@ Disassembly of section .text:
                	addi	a1, s3, 0xc
                	lhu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x320
+               	addiw	t1, t1, 0x70
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
@@ -5379,141 +4572,141 @@ Disassembly of section .text:
                	addi	a1, s3, 0xe
                	lhu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x320
+               	addiw	t1, t1, 0x70
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xe
                	sh	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x320
+               	addiw	t1, t1, 0x70
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x52fc>
+               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x4660>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x320
+               	addiw	t1, t1, 0x70
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x2
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x5320>
+               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x4684>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x320
+               	addiw	t1, t1, 0x70
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x5344>
+               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x46a8>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x320
+               	addiw	t1, t1, 0x70
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x6
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x5368>
+               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x46cc>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x320
+               	addiw	t1, t1, 0x70
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x538c>
+               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x46f0>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x320
+               	addiw	t1, t1, 0x70
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xa
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x53b0>
+               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x4714>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x320
+               	addiw	t1, t1, 0x70
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x53d4>
+               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x4738>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x320
+               	addiw	t1, t1, 0x70
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xe
                	lhu	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x53f8>
+               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x475c>
                	addi	a1, s2, 0x20
                	lw	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x540c>
+               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x4770>
                	lui	t1, 0x1
-               	addiw	t1, t1, 0x368
+               	addiw	t1, t1, -0x28
                	add	t1, sp, t1
                	ld	s1, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, 0x360
+               	addiw	t1, t1, -0x30
                	add	t1, sp, t1
                	ld	s2, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, 0x358
+               	addiw	t1, t1, -0x38
                	add	t1, sp, t1
                	ld	s3, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, 0x350
+               	addiw	t1, t1, -0x40
                	add	t1, sp, t1
                	ld	s4, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, 0x348
+               	addiw	t1, t1, -0x48
                	add	t1, sp, t1
                	ld	s5, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, 0x340
+               	addiw	t1, t1, -0x50
                	add	t1, sp, t1
                	ld	s6, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, 0x338
+               	addiw	t1, t1, -0x58
                	add	t1, sp, t1
                	ld	s7, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, 0x330
+               	addiw	t1, t1, -0x60
                	add	t1, sp, t1
                	ld	s8, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, 0x328
+               	addiw	t1, t1, -0x68
                	add	t1, sp, t1
                	ld	s9, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, 0x320
+               	addiw	t1, t1, -0x70
                	add	t1, sp, t1
                	ld	s10, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, 0x318
+               	addiw	t1, t1, -0x78
                	add	t1, sp, t1
                	ld	s11, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, 0x378
+               	addiw	t1, t1, -0x18
                	add	t1, sp, t1
                	ld	ra, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, 0x370
+               	addiw	t1, t1, -0x20
                	add	t1, sp, t1
                	ld	s0, 0x0(t1)
                	lui	t0, 0x1
-               	addiw	t0, t0, 0x380
+               	addiw	t0, t0, -0x10
                	add	sp, sp, t0
                	ret

--- a/test/golden/riscv64-linux/vec/vec_u32x4.dis
+++ b/test/golden/riscv64-linux/vec/vec_u32x4.dis
@@ -49,61 +49,61 @@ Disassembly of section .text:
 
 <corpus.cases.vec.vec_u32x4.checksum>:
                	lui	t0, 0x1
-               	addiw	t0, t0, -0x240
+               	addiw	t0, t0, -0x410
                	sub	sp, sp, t0
                	lui	t1, 0x1
-               	addiw	t1, t1, -0x248
+               	addiw	t1, t1, -0x418
                	add	t1, sp, t1
                	sd	ra, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, -0x250
+               	addiw	t1, t1, -0x420
                	add	t1, sp, t1
                	sd	s0, 0x0(t1)
                	lui	t0, 0x1
-               	addiw	t0, t0, -0x240
+               	addiw	t0, t0, -0x410
                	add	s0, sp, t0
                	lui	t1, 0x1
-               	addiw	t1, t1, -0x258
+               	addiw	t1, t1, -0x428
                	add	t1, sp, t1
                	sd	s1, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, -0x260
+               	addiw	t1, t1, -0x430
                	add	t1, sp, t1
                	sd	s2, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, -0x268
+               	addiw	t1, t1, -0x438
                	add	t1, sp, t1
                	sd	s3, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, -0x270
+               	addiw	t1, t1, -0x440
                	add	t1, sp, t1
                	sd	s4, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, -0x278
+               	addiw	t1, t1, -0x448
                	add	t1, sp, t1
                	sd	s5, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, -0x280
+               	addiw	t1, t1, -0x450
                	add	t1, sp, t1
                	sd	s6, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, -0x288
+               	addiw	t1, t1, -0x458
                	add	t1, sp, t1
                	sd	s7, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, -0x290
+               	addiw	t1, t1, -0x460
                	add	t1, sp, t1
                	sd	s8, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, -0x298
+               	addiw	t1, t1, -0x468
                	add	t1, sp, t1
                	sd	s9, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, -0x2a0
+               	addiw	t1, t1, -0x470
                	add	t1, sp, t1
                	sd	s10, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, -0x2a8
+               	addiw	t1, t1, -0x478
                	add	t1, sp, t1
                	sd	s11, 0x0(t1)
                	mv	s1, a0
@@ -135,107 +135,99 @@ Disassembly of section .text:
                	addi	a1, s0, -0x208
                	addi	t2, s0, -0x218
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x288
+               	addiw	t1, t1, 0x458
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	a1, s0, -0x228
                	addi	a1, s0, -0x238
                	addi	t2, s0, -0x248
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x280
+               	addiw	t1, t1, 0x450
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	a1, s0, -0x258
                	addi	a1, s0, -0x268
                	addi	t2, s0, -0x278
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x278
+               	addiw	t1, t1, 0x448
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	a1, s0, -0x288
                	addi	a1, s0, -0x298
                	addi	t2, s0, -0x2a8
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x270
+               	addiw	t1, t1, 0x440
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	a1, s0, -0x2b8
                	addi	a1, s0, -0x2c8
                	addi	t2, s0, -0x2d8
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x268
+               	addiw	t1, t1, 0x438
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	a1, s0, -0x2e8
                	addi	t2, s0, -0x2f8
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x260
+               	addiw	t1, t1, 0x430
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	a1, s0, -0x308
                	addi	a1, s0, -0x318
                	addi	t2, s0, -0x328
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x258
+               	addiw	t1, t1, 0x428
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	a1, s0, -0x338
                	addi	a1, s0, -0x348
                	addi	t2, s0, -0x358
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x250
+               	addiw	t1, t1, 0x420
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	a1, s0, -0x368
                	addi	a1, s0, -0x378
                	addi	t2, s0, -0x388
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x320
+               	addiw	t1, t1, 0x4e0
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	a1, s0, -0x398
                	addi	a1, s0, -0x3a8
                	addi	t2, s0, -0x3b8
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x318
+               	addiw	t1, t1, 0x4d8
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	a1, s0, -0x3c8
                	addi	a1, s0, -0x3d8
                	addi	t2, s0, -0x3e8
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x310
+               	addiw	t1, t1, 0x4d0
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	a1, s0, -0x3f8
                	addi	t2, s0, -0x408
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x308
+               	addiw	t1, t1, 0x4c8
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	a1, s0, -0x418
                	addi	t2, s0, -0x428
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x300
+               	addiw	t1, t1, 0x4c0
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	a1, s0, -0x438
                	addi	a1, s0, -0x448
-               	addi	t2, s0, -0x458
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2f8
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
+               	addi	a1, s0, -0x458
                	addi	a1, s0, -0x468
                	addi	a1, s0, -0x478
-               	addi	t2, s0, -0x488
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2f0
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
+               	addi	a1, s0, -0x488
                	addi	t2, s0, -0x498
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2e8
+               	addiw	t1, t1, 0x4b8
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	a1, s0, -0x4a8
@@ -244,7 +236,7 @@ Disassembly of section .text:
                	addi	a1, s0, -0x4d8
                	addi	t2, s0, -0x4e8
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2e0
+               	addiw	t1, t1, 0x4b0
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	a1, s0, -0x4f8
@@ -252,7 +244,7 @@ Disassembly of section .text:
                	addi	a1, s0, -0x518
                	addi	t2, s0, -0x528
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2d8
+               	addiw	t1, t1, 0x4a8
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	a1, s0, -0x538
@@ -260,7 +252,7 @@ Disassembly of section .text:
                	addi	a1, s0, -0x558
                	addi	t2, s0, -0x568
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2d0
+               	addiw	t1, t1, 0x4a0
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	a1, s0, -0x578
@@ -268,7 +260,7 @@ Disassembly of section .text:
                	addi	a1, s0, -0x598
                	addi	t2, s0, -0x5a8
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2c8
+               	addiw	t1, t1, 0x498
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	a1, s0, -0x5b8
@@ -277,30 +269,30 @@ Disassembly of section .text:
                	addi	a1, s0, -0x5e8
                	addi	t2, s0, -0x5f8
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2c0
+               	addiw	t1, t1, 0x490
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	a1, s0, -0x608
                	addi	a1, s0, -0x618
                	addi	t2, s0, -0x628
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2b8
+               	addiw	t1, t1, 0x488
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	a1, s0, -0x638
                	addi	t2, s0, -0x648
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2b0
+               	addiw	t1, t1, 0x480
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	t2, s0, -0x658
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2a8
+               	addiw	t1, t1, 0x478
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	t2, s0, -0x668
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2a0
+               	addiw	t1, t1, 0x470
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	a1, s0, -0x678
@@ -445,108 +437,24 @@ Disassembly of section .text:
                	lui	t0, 0xfffff
                	addiw	t0, t0, 0x598
                	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x588
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x578
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x568
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x558
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x548
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x538
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x528
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x518
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x508
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x4f8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x4e8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x4d8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x4c8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x4b8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x4a8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x498
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x488
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x478
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x468
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x458
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x448
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x438
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x428
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x418
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x408
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x3f8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x3e8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x3d8
-               	add	a1, s0, t0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0x784>
+               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0x614>
                	mv	t2, a0
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x298
+               	addiw	t1, t1, 0x468
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x298
+               	addiw	t1, t1, 0x468
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	sext.w	t2, s1
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x290
+               	addiw	t1, t1, 0x460
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x3c8
+               	addiw	t0, t0, 0x588
                	add	s1, s0, t0
                	mv	a0, s1
                	lui	t0, 0x100
@@ -581,7 +489,7 @@ Disassembly of section .text:
                	addi	a0, s2, 0xc
                	sw	a1, 0x0(a0)
                	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x3b8
+               	addiw	t0, t0, 0x578
                	add	a0, s0, t0
                	mv	a1, a0
                	li	t0, 0x11
@@ -616,7 +524,7 @@ Disassembly of section .text:
                	addi	a1, s3, 0xc
                	sw	a0, 0x0(a1)
                	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x3a8
+               	addiw	t0, t0, 0x568
                	add	a0, s0, t0
                	mv	a1, a0
                	li	t0, 0x1
@@ -647,7 +555,7 @@ Disassembly of section .text:
                	addi	a1, s4, 0xc
                	sw	a0, 0x0(a1)
                	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x398
+               	addiw	t0, t0, 0x558
                	add	a0, s0, t0
                	mv	a1, a0
                	sw	zero, 0x0(a1)
@@ -676,7 +584,7 @@ Disassembly of section .text:
                	mv	a0, s2
                	lw	a1, 0x0(a0)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x290
+               	addiw	t1, t1, 0x460
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addw	a0, a1, t2
@@ -701,7 +609,7 @@ Disassembly of section .text:
                	addi	a0, s6, 0x8
                	lw	a1, 0x0(a0)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x290
+               	addiw	t1, t1, 0x460
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addw	a0, a1, t2
@@ -726,7 +634,7 @@ Disassembly of section .text:
                	addi	a0, s3, 0x4
                	lw	a1, 0x0(a0)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x290
+               	addiw	t1, t1, 0x460
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addw	a0, a1, t2
@@ -751,7 +659,7 @@ Disassembly of section .text:
                	addi	a0, s8, 0xc
                	lw	a1, 0x0(a0)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x290
+               	addiw	t1, t1, 0x460
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addw	a0, a1, t2
@@ -776,47 +684,47 @@ Disassembly of section .text:
                	mv	a0, s7
                	lw	a1, 0x0(a0)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x298
+               	addiw	t1, t1, 0x468
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a0, t2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0xb70>
+               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0xa00>
                	addi	a1, s7, 0x4
                	lw	s1, 0x0(a1)
                	mv	a1, s1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0xb84>
+               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0xa14>
                	addi	a1, s7, 0x8
                	lw	s1, 0x0(a1)
                	mv	a1, s1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0xb98>
+               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0xa28>
                	addi	a1, s7, 0xc
                	lw	s1, 0x0(a1)
                	mv	a1, s1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0xbac>
+               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0xa3c>
                	mv	a1, s9
                	lw	s1, 0x0(a1)
                	mv	a1, s1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0xbc0>
+               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0xa50>
                	addi	a1, s9, 0x4
                	lw	s1, 0x0(a1)
                	mv	a1, s1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0xbd4>
+               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0xa64>
                	addi	a1, s9, 0x8
                	lw	s1, 0x0(a1)
                	mv	a1, s1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0xbe8>
+               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0xa78>
                	addi	a1, s9, 0xc
                	lw	s1, 0x0(a1)
                	mv	a1, s1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0xbfc>
+               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0xa8c>
                	mv	a1, s7
                	lw	s1, 0x0(a1)
                	mv	a1, s9
@@ -849,22 +757,22 @@ Disassembly of section .text:
                	lw	s1, 0x0(a1)
                	mv	a1, s1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0xc80>
+               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0xb10>
                	addi	a1, s10, 0x4
                	lw	s1, 0x0(a1)
                	mv	a1, s1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0xc94>
+               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0xb24>
                	addi	a1, s10, 0x8
                	lw	s1, 0x0(a1)
                	mv	a1, s1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0xca8>
+               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0xb38>
                	addi	a1, s10, 0xc
                	lw	s1, 0x0(a1)
                	mv	a1, s1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0xcbc>
+               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0xb4c>
                	mv	a1, s7
                	lw	s1, 0x0(a1)
                	mv	a1, s9
@@ -897,29 +805,29 @@ Disassembly of section .text:
                	lw	s1, 0x0(a1)
                	mv	a1, s1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0xd40>
+               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0xbd0>
                	addi	a1, s11, 0x4
                	lw	s1, 0x0(a1)
                	mv	a1, s1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0xd54>
+               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0xbe4>
                	addi	a1, s11, 0x8
                	lw	s1, 0x0(a1)
                	mv	a1, s1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0xd68>
+               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0xbf8>
                	addi	a1, s11, 0xc
                	lw	s1, 0x0(a1)
                	mv	a1, s1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0xd7c>
+               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0xc0c>
                	mv	a1, s9
                	lw	s1, 0x0(a1)
                	mv	a1, s7
                	lw	s2, 0x0(a1)
                	subw	a1, s1, s2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x288
+               	addiw	t1, t1, 0x458
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	s1, t2
@@ -930,7 +838,7 @@ Disassembly of section .text:
                	lw	s2, 0x0(a1)
                	subw	a1, s1, s2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x288
+               	addiw	t1, t1, 0x458
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	s1, t2, 0x4
@@ -941,7 +849,7 @@ Disassembly of section .text:
                	lw	s2, 0x0(a1)
                	subw	a1, s1, s2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x288
+               	addiw	t1, t1, 0x458
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	s1, t2, 0x8
@@ -952,54 +860,54 @@ Disassembly of section .text:
                	lw	s2, 0x0(a1)
                	subw	a1, s1, s2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x288
+               	addiw	t1, t1, 0x458
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	s1, t2, 0xc
                	sw	a1, 0x0(s1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x288
+               	addiw	t1, t1, 0x458
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	lw	s1, 0x0(a1)
                	mv	a1, s1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0xe50>
+               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0xce0>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x288
+               	addiw	t1, t1, 0x458
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	lw	s1, 0x0(a1)
                	mv	a1, s1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0xe74>
+               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0xd04>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x288
+               	addiw	t1, t1, 0x458
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	lw	s1, 0x0(a1)
                	mv	a1, s1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0xe98>
+               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0xd28>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x288
+               	addiw	t1, t1, 0x458
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	lw	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0xebc>
+               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0xd4c>
                	mv	a1, s7
                	lw	a2, 0x0(a1)
                	mv	a1, s9
                	lw	s1, 0x0(a1)
                	mulw	a1, a2, s1
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x280
+               	addiw	t1, t1, 0x450
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
@@ -1010,7 +918,7 @@ Disassembly of section .text:
                	lw	s1, 0x0(a1)
                	mulw	a1, a2, s1
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x280
+               	addiw	t1, t1, 0x450
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x4
@@ -1021,7 +929,7 @@ Disassembly of section .text:
                	lw	s1, 0x0(a1)
                	mulw	a1, a2, s1
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x280
+               	addiw	t1, t1, 0x450
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
@@ -1032,54 +940,54 @@ Disassembly of section .text:
                	lw	s1, 0x0(a1)
                	mulw	a1, a2, s1
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x280
+               	addiw	t1, t1, 0x450
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xc
                	sw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x280
+               	addiw	t1, t1, 0x450
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	lw	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0xf90>
+               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0xe20>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x280
+               	addiw	t1, t1, 0x450
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	lw	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0xfb4>
+               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0xe44>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x280
+               	addiw	t1, t1, 0x450
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	lw	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0xfd8>
+               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0xe68>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x280
+               	addiw	t1, t1, 0x450
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	lw	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0xffc>
+               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0xe8c>
                	mv	a1, s7
                	lw	a2, 0x0(a1)
                	mv	a1, s4
                	lw	a3, 0x0(a1)
                	mulw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x278
+               	addiw	t1, t1, 0x448
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
@@ -1090,7 +998,7 @@ Disassembly of section .text:
                	lw	a3, 0x0(a1)
                	mulw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x278
+               	addiw	t1, t1, 0x448
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x4
@@ -1101,7 +1009,7 @@ Disassembly of section .text:
                	lw	a3, 0x0(a1)
                	mulw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x278
+               	addiw	t1, t1, 0x448
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
@@ -1112,54 +1020,54 @@ Disassembly of section .text:
                	lw	a3, 0x0(a1)
                	mulw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x278
+               	addiw	t1, t1, 0x448
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xc
                	sw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x278
+               	addiw	t1, t1, 0x448
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	lw	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0x10d0>
+               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0xf60>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x278
+               	addiw	t1, t1, 0x448
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	lw	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0x10f4>
+               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0xf84>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x278
+               	addiw	t1, t1, 0x448
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	lw	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0x1118>
+               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0xfa8>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x278
+               	addiw	t1, t1, 0x448
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	lw	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0x113c>
+               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0xfcc>
                	mv	a1, s9
                	lw	a2, 0x0(a1)
                	mv	a1, s4
                	lw	a3, 0x0(a1)
                	mulw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x270
+               	addiw	t1, t1, 0x440
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
@@ -1170,7 +1078,7 @@ Disassembly of section .text:
                	lw	a3, 0x0(a1)
                	mulw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x270
+               	addiw	t1, t1, 0x440
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x4
@@ -1181,7 +1089,7 @@ Disassembly of section .text:
                	lw	a3, 0x0(a1)
                	mulw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x270
+               	addiw	t1, t1, 0x440
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
@@ -1192,54 +1100,54 @@ Disassembly of section .text:
                	lw	a3, 0x0(a1)
                	mulw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x270
+               	addiw	t1, t1, 0x440
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xc
                	sw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x270
+               	addiw	t1, t1, 0x440
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	lw	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0x1210>
+               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0x10a0>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x270
+               	addiw	t1, t1, 0x440
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	lw	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0x1234>
+               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0x10c4>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x270
+               	addiw	t1, t1, 0x440
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	lw	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0x1258>
+               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0x10e8>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x270
+               	addiw	t1, t1, 0x440
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	lw	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0x127c>
+               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0x110c>
                	mv	a1, s7
                	lw	a2, 0x0(a1)
                	mv	a1, s9
                	lw	a3, 0x0(a1)
                	addw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x268
+               	addiw	t1, t1, 0x438
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
@@ -1250,7 +1158,7 @@ Disassembly of section .text:
                	lw	a3, 0x0(a1)
                	addw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x268
+               	addiw	t1, t1, 0x438
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x4
@@ -1261,7 +1169,7 @@ Disassembly of section .text:
                	lw	a3, 0x0(a1)
                	addw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x268
+               	addiw	t1, t1, 0x438
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
@@ -1272,13 +1180,13 @@ Disassembly of section .text:
                	lw	a3, 0x0(a1)
                	addw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x268
+               	addiw	t1, t1, 0x438
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xc
                	sw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x268
+               	addiw	t1, t1, 0x438
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
@@ -1287,13 +1195,13 @@ Disassembly of section .text:
                	lw	a3, 0x0(a1)
                	mulw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x260
+               	addiw	t1, t1, 0x430
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
                	sw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x268
+               	addiw	t1, t1, 0x438
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
@@ -1302,13 +1210,13 @@ Disassembly of section .text:
                	lw	a3, 0x0(a1)
                	mulw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x260
+               	addiw	t1, t1, 0x430
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x4
                	sw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x268
+               	addiw	t1, t1, 0x438
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
@@ -1317,13 +1225,13 @@ Disassembly of section .text:
                	lw	a3, 0x0(a1)
                	mulw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x260
+               	addiw	t1, t1, 0x430
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
                	sw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x268
+               	addiw	t1, t1, 0x438
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
@@ -1332,54 +1240,54 @@ Disassembly of section .text:
                	lw	a3, 0x0(a1)
                	mulw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x260
+               	addiw	t1, t1, 0x430
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xc
                	sw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x260
+               	addiw	t1, t1, 0x430
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	lw	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0x1440>
+               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0x12d0>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x260
+               	addiw	t1, t1, 0x430
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	lw	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0x1464>
+               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0x12f4>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x260
+               	addiw	t1, t1, 0x430
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	lw	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0x1488>
+               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0x1318>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x260
+               	addiw	t1, t1, 0x430
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	lw	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0x14ac>
+               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0x133c>
                	mv	a1, s5
                	lw	a2, 0x0(a1)
                	mv	a1, s7
                	lw	a3, 0x0(a1)
                	subw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x258
+               	addiw	t1, t1, 0x428
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
@@ -1390,7 +1298,7 @@ Disassembly of section .text:
                	lw	a3, 0x0(a1)
                	subw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x258
+               	addiw	t1, t1, 0x428
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x4
@@ -1401,7 +1309,7 @@ Disassembly of section .text:
                	lw	a3, 0x0(a1)
                	subw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x258
+               	addiw	t1, t1, 0x428
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
@@ -1412,54 +1320,54 @@ Disassembly of section .text:
                	lw	a3, 0x0(a1)
                	subw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x258
+               	addiw	t1, t1, 0x428
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xc
                	sw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x258
+               	addiw	t1, t1, 0x428
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	lw	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0x1580>
+               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0x1410>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x258
+               	addiw	t1, t1, 0x428
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	lw	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0x15a4>
+               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0x1434>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x258
+               	addiw	t1, t1, 0x428
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	lw	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0x15c8>
+               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0x1458>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x258
+               	addiw	t1, t1, 0x428
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	lw	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0x15ec>
+               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0x147c>
                	mv	a1, s5
                	lw	a2, 0x0(a1)
                	mv	a1, s9
                	lw	a3, 0x0(a1)
                	subw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x250
+               	addiw	t1, t1, 0x420
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
@@ -1470,7 +1378,7 @@ Disassembly of section .text:
                	lw	a3, 0x0(a1)
                	subw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x250
+               	addiw	t1, t1, 0x420
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x4
@@ -1481,7 +1389,7 @@ Disassembly of section .text:
                	lw	a3, 0x0(a1)
                	subw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x250
+               	addiw	t1, t1, 0x420
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
@@ -1492,54 +1400,25 @@ Disassembly of section .text:
                	lw	a3, 0x0(a1)
                	subw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x250
+               	addiw	t1, t1, 0x420
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xc
                	sw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x250
+               	addiw	t1, t1, 0x420
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0x16c0>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x250
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0x16e4>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x250
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0x1708>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x250
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0x172c>
+               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0x1548>
                	mv	a1, s7
                	lw	a2, 0x0(a1)
                	mv	a1, s9
                	lw	a3, 0x0(a1)
                	and	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x320
+               	addiw	t1, t1, 0x4e0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
@@ -1550,7 +1429,7 @@ Disassembly of section .text:
                	lw	a3, 0x0(a1)
                	and	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x320
+               	addiw	t1, t1, 0x4e0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x4
@@ -1561,7 +1440,7 @@ Disassembly of section .text:
                	lw	a3, 0x0(a1)
                	and	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x320
+               	addiw	t1, t1, 0x4e0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
@@ -1572,54 +1451,25 @@ Disassembly of section .text:
                	lw	a3, 0x0(a1)
                	and	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x320
+               	addiw	t1, t1, 0x4e0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xc
                	sw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x320
+               	addiw	t1, t1, 0x4e0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0x1800>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x320
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0x1824>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x320
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0x1848>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x320
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0x186c>
+               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0x1614>
                	mv	a1, s7
                	lw	a2, 0x0(a1)
                	mv	a1, s9
                	lw	a3, 0x0(a1)
                	or	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x318
+               	addiw	t1, t1, 0x4d8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
@@ -1630,7 +1480,7 @@ Disassembly of section .text:
                	lw	a3, 0x0(a1)
                	or	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x318
+               	addiw	t1, t1, 0x4d8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x4
@@ -1641,7 +1491,7 @@ Disassembly of section .text:
                	lw	a3, 0x0(a1)
                	or	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x318
+               	addiw	t1, t1, 0x4d8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
@@ -1652,54 +1502,25 @@ Disassembly of section .text:
                	lw	a3, 0x0(a1)
                	or	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x318
+               	addiw	t1, t1, 0x4d8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xc
                	sw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x318
+               	addiw	t1, t1, 0x4d8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0x1940>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x318
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0x1964>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x318
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0x1988>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x318
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0x19ac>
+               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0x16e0>
                	mv	a1, s7
                	lw	a2, 0x0(a1)
                	mv	a1, s9
                	lw	a3, 0x0(a1)
                	xor	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x310
+               	addiw	t1, t1, 0x4d0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
@@ -1710,7 +1531,7 @@ Disassembly of section .text:
                	lw	a3, 0x0(a1)
                	xor	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x310
+               	addiw	t1, t1, 0x4d0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x4
@@ -1721,7 +1542,7 @@ Disassembly of section .text:
                	lw	a3, 0x0(a1)
                	xor	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x310
+               	addiw	t1, t1, 0x4d0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
@@ -1732,52 +1553,23 @@ Disassembly of section .text:
                	lw	a3, 0x0(a1)
                	xor	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x310
+               	addiw	t1, t1, 0x4d0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xc
                	sw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x310
+               	addiw	t1, t1, 0x4d0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0x1a80>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x310
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0x1aa4>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x310
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0x1ac8>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x310
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0x1aec>
+               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0x17ac>
                	mv	a1, s7
                	lw	a2, 0x0(a1)
                	not	a1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x308
+               	addiw	t1, t1, 0x4c8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
@@ -1786,7 +1578,7 @@ Disassembly of section .text:
                	lw	a2, 0x0(a1)
                	not	a1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x308
+               	addiw	t1, t1, 0x4c8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x4
@@ -1795,7 +1587,7 @@ Disassembly of section .text:
                	lw	a2, 0x0(a1)
                	not	a1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x308
+               	addiw	t1, t1, 0x4c8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
@@ -1804,52 +1596,23 @@ Disassembly of section .text:
                	lw	a2, 0x0(a1)
                	not	a1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x308
+               	addiw	t1, t1, 0x4c8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xc
                	sw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x308
+               	addiw	t1, t1, 0x4c8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0x1ba0>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x308
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0x1bc4>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x308
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0x1be8>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x308
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0x1c0c>
+               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0x1858>
                	mv	a1, s9
                	lw	a2, 0x0(a1)
                	not	a1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x300
+               	addiw	t1, t1, 0x4c0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
@@ -1858,7 +1621,7 @@ Disassembly of section .text:
                	lw	a2, 0x0(a1)
                	not	a1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x300
+               	addiw	t1, t1, 0x4c0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x4
@@ -1867,7 +1630,7 @@ Disassembly of section .text:
                	lw	a2, 0x0(a1)
                	not	a1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x300
+               	addiw	t1, t1, 0x4c0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
@@ -1876,260 +1639,114 @@ Disassembly of section .text:
                	lw	a2, 0x0(a1)
                	not	a1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x300
+               	addiw	t1, t1, 0x4c0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xc
                	sw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x300
+               	addiw	t1, t1, 0x4c0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0x1cc0>
+               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0x1904>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x300
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0x1ce4>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x300
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0x1d08>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x300
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0x1d2c>
-               	mv	a1, s7
-               	lw	a2, 0x0(a1)
-               	mv	a1, s9
-               	lw	a3, 0x0(a1)
-               	and	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2f8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a2, t2
-               	sw	a1, 0x0(a2)
-               	addi	a1, s7, 0x4
-               	lw	a2, 0x0(a1)
-               	addi	a1, s9, 0x4
-               	lw	a3, 0x0(a1)
-               	and	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2f8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x4
-               	sw	a1, 0x0(a2)
-               	addi	a1, s7, 0x8
-               	lw	a2, 0x0(a1)
-               	addi	a1, s9, 0x8
-               	lw	a3, 0x0(a1)
-               	and	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2f8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x8
-               	sw	a1, 0x0(a2)
-               	addi	a1, s7, 0xc
-               	lw	a2, 0x0(a1)
-               	addi	a1, s9, 0xc
-               	lw	a3, 0x0(a1)
-               	and	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2f8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0xc
-               	sw	a1, 0x0(a2)
-               	mv	a1, s7
-               	lw	a2, 0x0(a1)
-               	mv	a1, s9
-               	lw	a3, 0x0(a1)
-               	or	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2f0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a2, t2
-               	sw	a1, 0x0(a2)
-               	addi	a1, s7, 0x4
-               	lw	a2, 0x0(a1)
-               	addi	a1, s9, 0x4
-               	lw	a3, 0x0(a1)
-               	or	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2f0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x4
-               	sw	a1, 0x0(a2)
-               	addi	a1, s7, 0x8
-               	lw	a2, 0x0(a1)
-               	addi	a1, s9, 0x8
-               	lw	a3, 0x0(a1)
-               	or	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2f0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x8
-               	sw	a1, 0x0(a2)
-               	addi	a1, s7, 0xc
-               	lw	a2, 0x0(a1)
-               	addi	a1, s9, 0xc
-               	lw	a3, 0x0(a1)
-               	or	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2f0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0xc
-               	sw	a1, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2f8
+               	addiw	t1, t1, 0x4e0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	lw	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2f0
+               	addiw	t1, t1, 0x4d8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	lw	a3, 0x0(a1)
                	xor	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2e8
+               	addiw	t1, t1, 0x4b8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
                	sw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2f8
+               	addiw	t1, t1, 0x4e0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	lw	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2f0
+               	addiw	t1, t1, 0x4d8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	lw	a3, 0x0(a1)
                	xor	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2e8
+               	addiw	t1, t1, 0x4b8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x4
                	sw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2f8
+               	addiw	t1, t1, 0x4e0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	lw	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2f0
+               	addiw	t1, t1, 0x4d8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	lw	a3, 0x0(a1)
                	xor	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2e8
+               	addiw	t1, t1, 0x4b8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
                	sw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2f8
+               	addiw	t1, t1, 0x4e0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	lw	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2f0
+               	addiw	t1, t1, 0x4d8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	lw	a3, 0x0(a1)
                	xor	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2e8
+               	addiw	t1, t1, 0x4b8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xc
                	sw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2e8
+               	addiw	t1, t1, 0x4b8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0x1fe0>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2e8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0x2004>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2e8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0x2028>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2e8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0x204c>
+               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0x1a50>
                	mv	s1, a0
                	mv	s2, s5
                	li	s3, 0x0
                	li	t0, 0x6
-               	bltu	s3, t0, 0x2118 <corpus.cases.vec.vec_u32x4.checksum+0x206c>
-               	j	0x26a4 <corpus.cases.vec.vec_u32x4.checksum+0x25f8>
+               	bltu	s3, t0, 0x1b1c <corpus.cases.vec.vec_u32x4.checksum+0x1a70>
+               	j	0x20a8 <corpus.cases.vec.vec_u32x4.checksum+0x1ffc>
                	mv	a0, s7
                	lw	a1, 0x0(a0)
                	mv	a0, s4
                	lw	a2, 0x0(a0)
                	mulw	a0, a1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2e0
+               	addiw	t1, t1, 0x4b0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
@@ -2140,7 +1757,7 @@ Disassembly of section .text:
                	lw	a2, 0x0(a0)
                	mulw	a0, a1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2e0
+               	addiw	t1, t1, 0x4b0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
@@ -2151,7 +1768,7 @@ Disassembly of section .text:
                	lw	a2, 0x0(a0)
                	mulw	a0, a1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2e0
+               	addiw	t1, t1, 0x4b0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
@@ -2162,58 +1779,58 @@ Disassembly of section .text:
                	lw	a2, 0x0(a0)
                	mulw	a0, a1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2e0
+               	addiw	t1, t1, 0x4b0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	sw	a0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2e0
+               	addiw	t1, t1, 0x4b0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a0, t2
                	lw	a1, 0x0(a0)
                	mv	a0, s1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0x2138>
+               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0x1b3c>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2e0
+               	addiw	t1, t1, 0x4b0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	lw	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0x215c>
+               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0x1b60>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2e0
+               	addiw	t1, t1, 0x4b0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	lw	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0x2180>
+               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0x1b84>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2e0
+               	addiw	t1, t1, 0x4b0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	lw	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0x21a4>
+               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0x1ba8>
                	mv	a1, s2
                	lw	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2e0
+               	addiw	t1, t1, 0x4b0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	lw	a3, 0x0(a1)
                	xor	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2d8
+               	addiw	t1, t1, 0x4a8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
@@ -2221,14 +1838,14 @@ Disassembly of section .text:
                	addi	a1, s2, 0x4
                	lw	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2e0
+               	addiw	t1, t1, 0x4b0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	lw	a3, 0x0(a1)
                	xor	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2d8
+               	addiw	t1, t1, 0x4a8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x4
@@ -2236,14 +1853,14 @@ Disassembly of section .text:
                	addi	a1, s2, 0x8
                	lw	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2e0
+               	addiw	t1, t1, 0x4b0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	lw	a3, 0x0(a1)
                	xor	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2d8
+               	addiw	t1, t1, 0x4a8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
@@ -2251,61 +1868,61 @@ Disassembly of section .text:
                	addi	a1, s2, 0xc
                	lw	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2e0
+               	addiw	t1, t1, 0x4b0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	lw	a3, 0x0(a1)
                	xor	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2d8
+               	addiw	t1, t1, 0x4a8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xc
                	sw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2d8
+               	addiw	t1, t1, 0x4a8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	lw	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0x22b8>
+               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0x1cbc>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2d8
+               	addiw	t1, t1, 0x4a8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	lw	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0x22dc>
+               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0x1ce0>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2d8
+               	addiw	t1, t1, 0x4a8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	lw	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0x2300>
+               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0x1d04>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2d8
+               	addiw	t1, t1, 0x4a8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	lw	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0x2324>
+               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0x1d28>
                	mv	a1, s5
                	lw	a2, 0x0(a1)
                	mv	a1, s7
                	lw	a3, 0x0(a1)
                	addw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2d0
+               	addiw	t1, t1, 0x4a0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
@@ -2316,7 +1933,7 @@ Disassembly of section .text:
                	lw	a3, 0x0(a1)
                	addw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2d0
+               	addiw	t1, t1, 0x4a0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x4
@@ -2327,7 +1944,7 @@ Disassembly of section .text:
                	lw	a3, 0x0(a1)
                	addw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2d0
+               	addiw	t1, t1, 0x4a0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
@@ -2338,54 +1955,54 @@ Disassembly of section .text:
                	lw	a3, 0x0(a1)
                	addw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2d0
+               	addiw	t1, t1, 0x4a0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xc
                	sw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2d0
+               	addiw	t1, t1, 0x4a0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	lw	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0x23f8>
+               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0x1dfc>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2d0
+               	addiw	t1, t1, 0x4a0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	lw	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0x241c>
+               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0x1e20>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2d0
+               	addiw	t1, t1, 0x4a0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	lw	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0x2440>
+               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0x1e44>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2d0
+               	addiw	t1, t1, 0x4a0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	lw	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0x2464>
+               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0x1e68>
                	mv	a1, s7
                	lw	a2, 0x0(a1)
                	mv	a1, s9
                	lw	a3, 0x0(a1)
                	addw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2c8
+               	addiw	t1, t1, 0x498
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
@@ -2396,7 +2013,7 @@ Disassembly of section .text:
                	lw	a3, 0x0(a1)
                	addw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2c8
+               	addiw	t1, t1, 0x498
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x4
@@ -2407,7 +2024,7 @@ Disassembly of section .text:
                	lw	a3, 0x0(a1)
                	addw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2c8
+               	addiw	t1, t1, 0x498
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
@@ -2418,68 +2035,68 @@ Disassembly of section .text:
                	lw	a3, 0x0(a1)
                	addw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2c8
+               	addiw	t1, t1, 0x498
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xc
                	sw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2c8
+               	addiw	t1, t1, 0x498
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	lw	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0x2538>
+               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0x1f3c>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2c8
+               	addiw	t1, t1, 0x498
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	lw	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0x255c>
+               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0x1f60>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2c8
+               	addiw	t1, t1, 0x498
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	lw	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0x2580>
+               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0x1f84>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2c8
+               	addiw	t1, t1, 0x498
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	lw	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0x25a4>
+               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0x1fa8>
                	addi	s3, s3, 0x1
                	mv	s1, a0
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2c8
+               	addiw	t1, t1, 0x498
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	s7, t2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2d8
+               	addiw	t1, t1, 0x4a8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	s2, t2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2d0
+               	addiw	t1, t1, 0x4a0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	s5, t2
                	li	t0, 0x6
-               	bltu	s3, t0, 0x2118 <corpus.cases.vec.vec_u32x4.checksum+0x206c>
+               	bltu	s3, t0, 0x1b1c <corpus.cases.vec.vec_u32x4.checksum+0x1a70>
                	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x358
+               	addiw	t0, t0, 0x518
                	add	s3, s0, t0
                	sd	zero, 0x0(s3)
                	sd	zero, 0x8(s3)
@@ -2512,7 +2129,7 @@ Disassembly of section .text:
                	lw	a2, 0x0(a0)
                	addw	a0, a1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2c0
+               	addiw	t1, t1, 0x490
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
@@ -2523,7 +2140,7 @@ Disassembly of section .text:
                	lw	a2, 0x0(a0)
                	addw	a0, a1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2c0
+               	addiw	t1, t1, 0x490
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
@@ -2534,7 +2151,7 @@ Disassembly of section .text:
                	lw	a2, 0x0(a0)
                	addw	a0, a1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2c0
+               	addiw	t1, t1, 0x490
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
@@ -2545,14 +2162,14 @@ Disassembly of section .text:
                	lw	a2, 0x0(a0)
                	addw	a0, a1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2c0
+               	addiw	t1, t1, 0x490
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	sw	a0, 0x0(a1)
                	addi	a0, s3, 0x10
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2c0
+               	addiw	t1, t1, 0x490
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
@@ -2560,7 +2177,7 @@ Disassembly of section .text:
                	mv	a1, a0
                	sw	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2c0
+               	addiw	t1, t1, 0x490
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
@@ -2568,7 +2185,7 @@ Disassembly of section .text:
                	addi	a1, a0, 0x4
                	sw	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2c0
+               	addiw	t1, t1, 0x490
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
@@ -2576,7 +2193,7 @@ Disassembly of section .text:
                	addi	a1, a0, 0x8
                	sw	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2c0
+               	addiw	t1, t1, 0x490
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
@@ -2589,7 +2206,7 @@ Disassembly of section .text:
                	lw	a2, 0x0(a0)
                	mulw	a0, a1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2b8
+               	addiw	t1, t1, 0x488
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
@@ -2600,7 +2217,7 @@ Disassembly of section .text:
                	lw	a2, 0x0(a0)
                	mulw	a0, a1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2b8
+               	addiw	t1, t1, 0x488
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
@@ -2611,7 +2228,7 @@ Disassembly of section .text:
                	lw	a2, 0x0(a0)
                	mulw	a0, a1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2b8
+               	addiw	t1, t1, 0x488
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
@@ -2622,14 +2239,14 @@ Disassembly of section .text:
                	lw	a2, 0x0(a0)
                	mulw	a0, a1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2b8
+               	addiw	t1, t1, 0x488
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	sw	a0, 0x0(a1)
                	addi	a0, s3, 0x20
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2b8
+               	addiw	t1, t1, 0x488
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
@@ -2637,7 +2254,7 @@ Disassembly of section .text:
                	mv	a1, a0
                	sw	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2b8
+               	addiw	t1, t1, 0x488
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
@@ -2645,7 +2262,7 @@ Disassembly of section .text:
                	addi	a1, a0, 0x4
                	sw	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2b8
+               	addiw	t1, t1, 0x488
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
@@ -2653,7 +2270,7 @@ Disassembly of section .text:
                	addi	a1, a0, 0x8
                	sw	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2b8
+               	addiw	t1, t1, 0x488
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
@@ -2679,15 +2296,15 @@ Disassembly of section .text:
                	sw	a2, 0x0(a1)
                	li	s2, 0x0
                	li	t0, 0x4
-               	bltu	s2, t0, 0x29d0 <corpus.cases.vec.vec_u32x4.checksum+0x2924>
-               	j	0x2afc <corpus.cases.vec.vec_u32x4.checksum+0x2a50>
+               	bltu	s2, t0, 0x23d4 <corpus.cases.vec.vec_u32x4.checksum+0x2328>
+               	j	0x2500 <corpus.cases.vec.vec_u32x4.checksum+0x2454>
                	li	t0, 0x10
                	mul	a0, s2, t0
                	add	a1, s3, a0
                	mv	a0, a1
                	lw	a2, 0x0(a0)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2b0
+               	addiw	t1, t1, 0x480
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a0, t2
@@ -2695,7 +2312,7 @@ Disassembly of section .text:
                	addi	a0, a1, 0x4
                	lw	a2, 0x0(a0)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2b0
+               	addiw	t1, t1, 0x480
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a0, t2, 0x4
@@ -2703,7 +2320,7 @@ Disassembly of section .text:
                	addi	a0, a1, 0x8
                	lw	a2, 0x0(a0)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2b0
+               	addiw	t1, t1, 0x480
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a0, t2, 0x8
@@ -2711,53 +2328,53 @@ Disassembly of section .text:
                	addi	a0, a1, 0xc
                	lw	a1, 0x0(a0)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2b0
+               	addiw	t1, t1, 0x480
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a0, t2, 0xc
                	sw	a1, 0x0(a0)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2b0
+               	addiw	t1, t1, 0x480
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a0, t2
                	lw	a1, 0x0(a0)
                	mv	a0, s1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0x29cc>
+               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0x23d0>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2b0
+               	addiw	t1, t1, 0x480
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	lw	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0x29f0>
+               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0x23f4>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2b0
+               	addiw	t1, t1, 0x480
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	lw	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0x2a14>
+               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0x2418>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2b0
+               	addiw	t1, t1, 0x480
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	lw	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0x2a38>
+               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0x243c>
                	addi	s2, s2, 0x1
                	mv	s1, a0
                	li	t0, 0x4
-               	bltu	s2, t0, 0x29d0 <corpus.cases.vec.vec_u32x4.checksum+0x2924>
+               	bltu	s2, t0, 0x23d4 <corpus.cases.vec.vec_u32x4.checksum+0x2328>
                	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x328
+               	addiw	t0, t0, 0x4e8
                	add	s2, s0, t0
                	sd	zero, 0x0(s2)
                	sd	zero, 0x8(s2)
@@ -2774,7 +2391,7 @@ Disassembly of section .text:
                	mv	a2, a1
                	lw	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2a8
+               	addiw	t1, t1, 0x478
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
@@ -2782,7 +2399,7 @@ Disassembly of section .text:
                	addi	a2, a1, 0x4
                	lw	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2a8
+               	addiw	t1, t1, 0x478
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x4
@@ -2790,7 +2407,7 @@ Disassembly of section .text:
                	addi	a2, a1, 0x8
                	lw	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2a8
+               	addiw	t1, t1, 0x478
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
@@ -2798,14 +2415,14 @@ Disassembly of section .text:
                	addi	a2, a1, 0xc
                	lw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2a8
+               	addiw	t1, t1, 0x478
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xc
                	sw	a1, 0x0(a2)
                	addi	s3, s2, 0x10
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2a8
+               	addiw	t1, t1, 0x478
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
@@ -2813,7 +2430,7 @@ Disassembly of section .text:
                	mv	a1, s3
                	sw	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2a8
+               	addiw	t1, t1, 0x478
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
@@ -2821,7 +2438,7 @@ Disassembly of section .text:
                	addi	a1, s3, 0x4
                	sw	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2a8
+               	addiw	t1, t1, 0x478
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
@@ -2829,7 +2446,7 @@ Disassembly of section .text:
                	addi	a1, s3, 0x8
                	sw	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2a8
+               	addiw	t1, t1, 0x478
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
@@ -2843,11 +2460,11 @@ Disassembly of section .text:
                	lw	a1, 0x0(a0)
                	mv	a0, s1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0x2ba8>
+               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0x25ac>
                	mv	a1, s3
                	lw	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2a0
+               	addiw	t1, t1, 0x470
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
@@ -2855,7 +2472,7 @@ Disassembly of section .text:
                	addi	a1, s3, 0x4
                	lw	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2a0
+               	addiw	t1, t1, 0x470
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
@@ -2863,7 +2480,7 @@ Disassembly of section .text:
                	addi	a1, s3, 0x8
                	lw	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2a0
+               	addiw	t1, t1, 0x470
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
@@ -2871,105 +2488,105 @@ Disassembly of section .text:
                	addi	a1, s3, 0xc
                	lw	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2a0
+               	addiw	t1, t1, 0x470
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	sw	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2a0
+               	addiw	t1, t1, 0x470
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	lw	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0x2c4c>
+               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0x2650>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2a0
+               	addiw	t1, t1, 0x470
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	lw	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0x2c70>
+               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0x2674>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2a0
+               	addiw	t1, t1, 0x470
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	lw	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0x2c94>
+               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0x2698>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2a0
+               	addiw	t1, t1, 0x470
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	lw	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0x2cb8>
+               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0x26bc>
                	addi	a1, s2, 0x20
                	lw	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0x2ccc>
+               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0x26d0>
                	lui	t1, 0x1
-               	addiw	t1, t1, -0x258
+               	addiw	t1, t1, -0x428
                	add	t1, sp, t1
                	ld	s1, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, -0x260
+               	addiw	t1, t1, -0x430
                	add	t1, sp, t1
                	ld	s2, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, -0x268
+               	addiw	t1, t1, -0x438
                	add	t1, sp, t1
                	ld	s3, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, -0x270
+               	addiw	t1, t1, -0x440
                	add	t1, sp, t1
                	ld	s4, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, -0x278
+               	addiw	t1, t1, -0x448
                	add	t1, sp, t1
                	ld	s5, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, -0x280
+               	addiw	t1, t1, -0x450
                	add	t1, sp, t1
                	ld	s6, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, -0x288
+               	addiw	t1, t1, -0x458
                	add	t1, sp, t1
                	ld	s7, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, -0x290
+               	addiw	t1, t1, -0x460
                	add	t1, sp, t1
                	ld	s8, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, -0x298
+               	addiw	t1, t1, -0x468
                	add	t1, sp, t1
                	ld	s9, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, -0x2a0
+               	addiw	t1, t1, -0x470
                	add	t1, sp, t1
                	ld	s10, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, -0x2a8
+               	addiw	t1, t1, -0x478
                	add	t1, sp, t1
                	ld	s11, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, -0x248
+               	addiw	t1, t1, -0x418
                	add	t1, sp, t1
                	ld	ra, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, -0x250
+               	addiw	t1, t1, -0x420
                	add	t1, sp, t1
                	ld	s0, 0x0(t1)
                	lui	t0, 0x1
-               	addiw	t0, t0, -0x240
+               	addiw	t0, t0, -0x410
                	add	sp, sp, t0
                	ret

--- a/test/golden/riscv64-linux/vec/vec_u64x2.dis
+++ b/test/golden/riscv64-linux/vec/vec_u64x2.dis
@@ -33,61 +33,61 @@ Disassembly of section .text:
 
 <corpus.cases.vec.vec_u64x2.checksum>:
                	lui	t0, 0x1
-               	addiw	t0, t0, -0x570
+               	addiw	t0, t0, -0x660
                	sub	sp, sp, t0
                	lui	t1, 0x1
-               	addiw	t1, t1, -0x578
+               	addiw	t1, t1, -0x668
                	add	t1, sp, t1
                	sd	ra, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, -0x580
+               	addiw	t1, t1, -0x670
                	add	t1, sp, t1
                	sd	s0, 0x0(t1)
                	lui	t0, 0x1
-               	addiw	t0, t0, -0x570
+               	addiw	t0, t0, -0x660
                	add	s0, sp, t0
                	lui	t1, 0x1
-               	addiw	t1, t1, -0x588
+               	addiw	t1, t1, -0x678
                	add	t1, sp, t1
                	sd	s1, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, -0x590
+               	addiw	t1, t1, -0x680
                	add	t1, sp, t1
                	sd	s2, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, -0x598
+               	addiw	t1, t1, -0x688
                	add	t1, sp, t1
                	sd	s3, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, -0x5a0
+               	addiw	t1, t1, -0x690
                	add	t1, sp, t1
                	sd	s4, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, -0x5a8
+               	addiw	t1, t1, -0x698
                	add	t1, sp, t1
                	sd	s5, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, -0x5b0
+               	addiw	t1, t1, -0x6a0
                	add	t1, sp, t1
                	sd	s6, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, -0x5b8
+               	addiw	t1, t1, -0x6a8
                	add	t1, sp, t1
                	sd	s7, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, -0x5c0
+               	addiw	t1, t1, -0x6b0
                	add	t1, sp, t1
                	sd	s8, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, -0x5c8
+               	addiw	t1, t1, -0x6b8
                	add	t1, sp, t1
                	sd	s9, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, -0x5d0
+               	addiw	t1, t1, -0x6c0
                	add	t1, sp, t1
                	sd	s10, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, -0x5d8
+               	addiw	t1, t1, -0x6c8
                	add	t1, sp, t1
                	sd	s11, 0x0(t1)
                	mv	s1, a0
@@ -119,93 +119,85 @@ Disassembly of section .text:
                	addi	a1, s0, -0x208
                	addi	t2, s0, -0x218
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x5b8
+               	addiw	t1, t1, 0x6a8
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	a1, s0, -0x228
                	addi	a1, s0, -0x238
                	addi	t2, s0, -0x248
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x5b0
+               	addiw	t1, t1, 0x6a0
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	a1, s0, -0x258
                	addi	a1, s0, -0x268
                	addi	t2, s0, -0x278
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x5a8
+               	addiw	t1, t1, 0x698
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	a1, s0, -0x288
                	addi	t2, s0, -0x298
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x5a0
+               	addiw	t1, t1, 0x690
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	a1, s0, -0x2a8
                	addi	a1, s0, -0x2b8
                	addi	t2, s0, -0x2c8
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x598
+               	addiw	t1, t1, 0x688
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	a1, s0, -0x2d8
                	addi	a1, s0, -0x2e8
                	addi	t2, s0, -0x2f8
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x590
+               	addiw	t1, t1, 0x680
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	a1, s0, -0x308
                	addi	a1, s0, -0x318
                	addi	t2, s0, -0x328
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x588
+               	addiw	t1, t1, 0x678
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	a1, s0, -0x338
                	addi	a1, s0, -0x348
                	addi	t2, s0, -0x358
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x580
+               	addiw	t1, t1, 0x670
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	a1, s0, -0x368
                	addi	a1, s0, -0x378
                	addi	t2, s0, -0x388
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x660
+               	addiw	t1, t1, 0x740
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	a1, s0, -0x398
                	addi	t2, s0, -0x3a8
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x658
+               	addiw	t1, t1, 0x738
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	a1, s0, -0x3b8
                	addi	t2, s0, -0x3c8
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x650
+               	addiw	t1, t1, 0x730
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	a1, s0, -0x3d8
                	addi	a1, s0, -0x3e8
-               	addi	t2, s0, -0x3f8
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x648
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
+               	addi	a1, s0, -0x3f8
                	addi	a1, s0, -0x408
                	addi	a1, s0, -0x418
-               	addi	t2, s0, -0x428
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x640
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
+               	addi	a1, s0, -0x428
                	addi	t2, s0, -0x438
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x638
+               	addiw	t1, t1, 0x728
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	a1, s0, -0x448
@@ -214,7 +206,7 @@ Disassembly of section .text:
                	addi	a1, s0, -0x478
                	addi	t2, s0, -0x488
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x630
+               	addiw	t1, t1, 0x720
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	a1, s0, -0x498
@@ -222,7 +214,7 @@ Disassembly of section .text:
                	addi	a1, s0, -0x4b8
                	addi	t2, s0, -0x4c8
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x628
+               	addiw	t1, t1, 0x718
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	a1, s0, -0x4d8
@@ -230,7 +222,7 @@ Disassembly of section .text:
                	addi	a1, s0, -0x4f8
                	addi	t2, s0, -0x508
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x620
+               	addiw	t1, t1, 0x710
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	a1, s0, -0x518
@@ -238,7 +230,7 @@ Disassembly of section .text:
                	addi	a1, s0, -0x538
                	addi	t2, s0, -0x548
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x618
+               	addiw	t1, t1, 0x708
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	a1, s0, -0x558
@@ -247,30 +239,30 @@ Disassembly of section .text:
                	addi	a1, s0, -0x588
                	addi	t2, s0, -0x598
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x610
+               	addiw	t1, t1, 0x700
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	a1, s0, -0x5a8
                	addi	a1, s0, -0x5b8
                	addi	t2, s0, -0x5c8
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x608
+               	addiw	t1, t1, 0x6f8
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	a1, s0, -0x5d8
                	addi	t2, s0, -0x5e8
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x600
+               	addiw	t1, t1, 0x6f0
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	t2, s0, -0x5f8
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x5f8
+               	addiw	t1, t1, 0x6e8
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	t2, s0, -0x608
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x5f0
+               	addiw	t1, t1, 0x6e0
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	a1, s0, -0x618
@@ -307,75 +299,33 @@ Disassembly of section .text:
                	lui	t0, 0xfffff
                	addiw	t0, t0, 0x7f8
                	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x7e8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x7d8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x7c8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x7b8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x7a8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x798
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x788
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x778
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x768
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x758
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x748
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x738
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x728
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x718
-               	add	a1, s0, t0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u64x2.checksum+0x4f4>
+               	jalr	ra <corpus.cases.vec.vec_u64x2.checksum+0x42c>
                	mv	t2, a0
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x5e8
+               	addiw	t1, t1, 0x6d8
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x5e8
+               	addiw	t1, t1, 0x6d8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x708
+               	addiw	t0, t0, 0x7e8
                	add	t2, s0, t0
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x5e0
+               	addiw	t1, t1, 0x6d0
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x5e0
+               	addiw	t1, t1, 0x6d0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a0, t2
                	li	t0, -0x10
                	sd	t0, 0x0(a0)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x5e0
+               	addiw	t1, t1, 0x6d0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a0, t2, 0x8
@@ -383,7 +333,7 @@ Disassembly of section .text:
                	addiw	t0, t0, 0x678
                	sd	t0, 0x0(a0)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x5e0
+               	addiw	t1, t1, 0x6d0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a0, t2
@@ -391,7 +341,7 @@ Disassembly of section .text:
                	mv	a0, s2
                	sd	a1, 0x0(a0)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x5e0
+               	addiw	t1, t1, 0x6d0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a0, t2, 0x8
@@ -399,28 +349,28 @@ Disassembly of section .text:
                	addi	a0, s2, 0x8
                	sd	a1, 0x0(a0)
                	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x6f8
+               	addiw	t0, t0, 0x7d8
                	add	t2, s0, t0
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x5d8
+               	addiw	t1, t1, 0x6c8
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x5d8
+               	addiw	t1, t1, 0x6c8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	li	t0, 0x11
                	sd	t0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x5d8
+               	addiw	t1, t1, 0x6c8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	li	t0, -0x1
                	sd	t0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x5d8
+               	addiw	t1, t1, 0x6c8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
@@ -428,7 +378,7 @@ Disassembly of section .text:
                	mv	a1, s3
                	sd	a0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x5d8
+               	addiw	t1, t1, 0x6c8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a0, t2, 0x8
@@ -436,28 +386,28 @@ Disassembly of section .text:
                	addi	a0, s3, 0x8
                	sd	a1, 0x0(a0)
                	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x6e8
+               	addiw	t0, t0, 0x7c8
                	add	t2, s0, t0
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x5d0
+               	addiw	t1, t1, 0x6c0
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x5d0
+               	addiw	t1, t1, 0x6c0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	li	t0, 0x1
                	sd	t0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x5d0
+               	addiw	t1, t1, 0x6c0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	li	t0, 0x1b
                	sd	t0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x5d0
+               	addiw	t1, t1, 0x6c0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
@@ -465,7 +415,7 @@ Disassembly of section .text:
                	mv	a1, s4
                	sd	a0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x5d0
+               	addiw	t1, t1, 0x6c0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a0, t2, 0x8
@@ -473,26 +423,26 @@ Disassembly of section .text:
                	addi	a0, s4, 0x8
                	sd	a1, 0x0(a0)
                	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x6d8
+               	addiw	t0, t0, 0x7b8
                	add	t2, s0, t0
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x5c8
+               	addiw	t1, t1, 0x6b8
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x5c8
+               	addiw	t1, t1, 0x6b8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	sd	zero, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x5c8
+               	addiw	t1, t1, 0x6b8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	sd	zero, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x5c8
+               	addiw	t1, t1, 0x6b8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
@@ -500,7 +450,7 @@ Disassembly of section .text:
                	mv	a1, s5
                	sd	a0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x5c8
+               	addiw	t1, t1, 0x6b8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a0, t2, 0x8
@@ -511,7 +461,7 @@ Disassembly of section .text:
                	ld	a1, 0x0(a0)
                	add	t2, a1, s1
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x5c0
+               	addiw	t1, t1, 0x6b0
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	mv	a1, s2
@@ -524,7 +474,7 @@ Disassembly of section .text:
                	sd	a1, 0x0(a0)
                	mv	a0, s6
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x5c0
+               	addiw	t1, t1, 0x6b0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	sd	t2, 0x0(a0)
@@ -544,27 +494,27 @@ Disassembly of section .text:
                	mv	a0, s6
                	ld	a1, 0x0(a0)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x5e8
+               	addiw	t1, t1, 0x6d8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a0, t2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u64x2.checksum+0x810>
+               	jalr	ra <corpus.cases.vec.vec_u64x2.checksum+0x748>
                	addi	a1, s6, 0x8
                	ld	s1, 0x0(a1)
                	mv	a1, s1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u64x2.checksum+0x824>
+               	jalr	ra <corpus.cases.vec.vec_u64x2.checksum+0x75c>
                	mv	a1, s7
                	ld	s1, 0x0(a1)
                	mv	a1, s1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u64x2.checksum+0x838>
+               	jalr	ra <corpus.cases.vec.vec_u64x2.checksum+0x770>
                	addi	a1, s7, 0x8
                	ld	s1, 0x0(a1)
                	mv	a1, s1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u64x2.checksum+0x84c>
+               	jalr	ra <corpus.cases.vec.vec_u64x2.checksum+0x784>
                	mv	a1, s6
                	ld	s1, 0x0(a1)
                	mv	a1, s7
@@ -583,12 +533,12 @@ Disassembly of section .text:
                	ld	s1, 0x0(a1)
                	mv	a1, s1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u64x2.checksum+0x898>
+               	jalr	ra <corpus.cases.vec.vec_u64x2.checksum+0x7d0>
                	addi	a1, s8, 0x8
                	ld	s1, 0x0(a1)
                	mv	a1, s1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u64x2.checksum+0x8ac>
+               	jalr	ra <corpus.cases.vec.vec_u64x2.checksum+0x7e4>
                	mv	a1, s6
                	ld	s1, 0x0(a1)
                	mv	a1, s7
@@ -607,12 +557,12 @@ Disassembly of section .text:
                	ld	s1, 0x0(a1)
                	mv	a1, s1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u64x2.checksum+0x8f8>
+               	jalr	ra <corpus.cases.vec.vec_u64x2.checksum+0x830>
                	addi	a1, s9, 0x8
                	ld	s1, 0x0(a1)
                	mv	a1, s1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u64x2.checksum+0x90c>
+               	jalr	ra <corpus.cases.vec.vec_u64x2.checksum+0x844>
                	mv	a1, s7
                	ld	s1, 0x0(a1)
                	mv	a1, s6
@@ -631,12 +581,12 @@ Disassembly of section .text:
                	ld	s1, 0x0(a1)
                	mv	a1, s1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u64x2.checksum+0x958>
+               	jalr	ra <corpus.cases.vec.vec_u64x2.checksum+0x890>
                	addi	a1, s10, 0x8
                	ld	s1, 0x0(a1)
                	mv	a1, s1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u64x2.checksum+0x96c>
+               	jalr	ra <corpus.cases.vec.vec_u64x2.checksum+0x8a4>
                	mv	a1, s6
                	ld	s1, 0x0(a1)
                	mv	a1, s7
@@ -655,19 +605,19 @@ Disassembly of section .text:
                	ld	s1, 0x0(a1)
                	mv	a1, s1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u64x2.checksum+0x9b8>
+               	jalr	ra <corpus.cases.vec.vec_u64x2.checksum+0x8f0>
                	addi	a1, s11, 0x8
                	ld	s1, 0x0(a1)
                	mv	a1, s1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u64x2.checksum+0x9cc>
+               	jalr	ra <corpus.cases.vec.vec_u64x2.checksum+0x904>
                	mv	a1, s6
                	ld	s1, 0x0(a1)
                	mv	a1, s4
                	ld	s2, 0x0(a1)
                	mul	a1, s1, s2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x5b8
+               	addiw	t1, t1, 0x6a8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	s1, t2
@@ -678,36 +628,36 @@ Disassembly of section .text:
                	ld	s2, 0x0(a1)
                	mul	a1, s1, s2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x5b8
+               	addiw	t1, t1, 0x6a8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	s1, t2, 0x8
                	sd	a1, 0x0(s1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x5b8
+               	addiw	t1, t1, 0x6a8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	ld	s1, 0x0(a1)
                	mv	a1, s1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u64x2.checksum+0xa48>
+               	jalr	ra <corpus.cases.vec.vec_u64x2.checksum+0x980>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x5b8
+               	addiw	t1, t1, 0x6a8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	ld	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u64x2.checksum+0xa6c>
+               	jalr	ra <corpus.cases.vec.vec_u64x2.checksum+0x9a4>
                	mv	a1, s7
                	ld	a2, 0x0(a1)
                	mv	a1, s4
                	ld	s1, 0x0(a1)
                	mul	a1, a2, s1
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x5b0
+               	addiw	t1, t1, 0x6a0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
@@ -718,36 +668,36 @@ Disassembly of section .text:
                	ld	s1, 0x0(a1)
                	mul	a1, a2, s1
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x5b0
+               	addiw	t1, t1, 0x6a0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
                	sd	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x5b0
+               	addiw	t1, t1, 0x6a0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	ld	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u64x2.checksum+0xae8>
+               	jalr	ra <corpus.cases.vec.vec_u64x2.checksum+0xa20>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x5b0
+               	addiw	t1, t1, 0x6a0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	ld	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u64x2.checksum+0xb0c>
+               	jalr	ra <corpus.cases.vec.vec_u64x2.checksum+0xa44>
                	mv	a1, s6
                	ld	a2, 0x0(a1)
                	mv	a1, s7
                	ld	a3, 0x0(a1)
                	add	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x5a8
+               	addiw	t1, t1, 0x698
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
@@ -758,13 +708,13 @@ Disassembly of section .text:
                	ld	a3, 0x0(a1)
                	add	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x5a8
+               	addiw	t1, t1, 0x698
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
                	sd	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x5a8
+               	addiw	t1, t1, 0x698
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
@@ -773,13 +723,13 @@ Disassembly of section .text:
                	ld	a3, 0x0(a1)
                	mul	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x5a0
+               	addiw	t1, t1, 0x690
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
                	sd	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x5a8
+               	addiw	t1, t1, 0x698
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
@@ -788,36 +738,36 @@ Disassembly of section .text:
                	ld	a3, 0x0(a1)
                	mul	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x5a0
+               	addiw	t1, t1, 0x690
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
                	sd	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x5a0
+               	addiw	t1, t1, 0x690
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	ld	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u64x2.checksum+0xc00>
+               	jalr	ra <corpus.cases.vec.vec_u64x2.checksum+0xb38>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x5a0
+               	addiw	t1, t1, 0x690
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	ld	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u64x2.checksum+0xc24>
+               	jalr	ra <corpus.cases.vec.vec_u64x2.checksum+0xb5c>
                	mv	a1, s5
                	ld	a2, 0x0(a1)
                	mv	a1, s6
                	ld	a3, 0x0(a1)
                	sub	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x598
+               	addiw	t1, t1, 0x688
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
@@ -828,36 +778,36 @@ Disassembly of section .text:
                	ld	a3, 0x0(a1)
                	sub	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x598
+               	addiw	t1, t1, 0x688
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
                	sd	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x598
+               	addiw	t1, t1, 0x688
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	ld	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u64x2.checksum+0xca0>
+               	jalr	ra <corpus.cases.vec.vec_u64x2.checksum+0xbd8>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x598
+               	addiw	t1, t1, 0x688
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	ld	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u64x2.checksum+0xcc4>
+               	jalr	ra <corpus.cases.vec.vec_u64x2.checksum+0xbfc>
                	mv	a1, s5
                	ld	a2, 0x0(a1)
                	mv	a1, s7
                	ld	a3, 0x0(a1)
                	sub	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x590
+               	addiw	t1, t1, 0x680
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
@@ -868,36 +818,25 @@ Disassembly of section .text:
                	ld	a3, 0x0(a1)
                	sub	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x590
+               	addiw	t1, t1, 0x680
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
                	sd	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x590
+               	addiw	t1, t1, 0x680
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
-               	ld	a2, 0x0(a1)
-               	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u64x2.checksum+0xd40>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x590
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	ld	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u64x2.checksum+0xd64>
+               	jalr	ra <corpus.cases.vec.vec_u64x2.checksum+0xc70>
                	mv	a1, s6
                	ld	a2, 0x0(a1)
                	mv	a1, s7
                	ld	a3, 0x0(a1)
                	and	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x588
+               	addiw	t1, t1, 0x678
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
@@ -908,36 +847,25 @@ Disassembly of section .text:
                	ld	a3, 0x0(a1)
                	and	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x588
+               	addiw	t1, t1, 0x678
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
                	sd	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x588
+               	addiw	t1, t1, 0x678
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
-               	ld	a2, 0x0(a1)
-               	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u64x2.checksum+0xde0>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x588
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	ld	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u64x2.checksum+0xe04>
+               	jalr	ra <corpus.cases.vec.vec_u64x2.checksum+0xce4>
                	mv	a1, s6
                	ld	a2, 0x0(a1)
                	mv	a1, s7
                	ld	a3, 0x0(a1)
                	or	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x580
+               	addiw	t1, t1, 0x670
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
@@ -948,36 +876,25 @@ Disassembly of section .text:
                	ld	a3, 0x0(a1)
                	or	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x580
+               	addiw	t1, t1, 0x670
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
                	sd	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x580
+               	addiw	t1, t1, 0x670
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
-               	ld	a2, 0x0(a1)
-               	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u64x2.checksum+0xe80>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x580
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	ld	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u64x2.checksum+0xea4>
+               	jalr	ra <corpus.cases.vec.vec_u64x2.checksum+0xd58>
                	mv	a1, s6
                	ld	a2, 0x0(a1)
                	mv	a1, s7
                	ld	a3, 0x0(a1)
                	xor	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x660
+               	addiw	t1, t1, 0x740
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
@@ -988,34 +905,23 @@ Disassembly of section .text:
                	ld	a3, 0x0(a1)
                	xor	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x660
+               	addiw	t1, t1, 0x740
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
                	sd	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x660
+               	addiw	t1, t1, 0x740
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
-               	ld	a2, 0x0(a1)
-               	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u64x2.checksum+0xf20>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x660
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	ld	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u64x2.checksum+0xf44>
+               	jalr	ra <corpus.cases.vec.vec_u64x2.checksum+0xdcc>
                	mv	a1, s6
                	ld	a2, 0x0(a1)
                	not	a1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x658
+               	addiw	t1, t1, 0x738
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
@@ -1024,34 +930,23 @@ Disassembly of section .text:
                	ld	a2, 0x0(a1)
                	not	a1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x658
+               	addiw	t1, t1, 0x738
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
                	sd	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x658
+               	addiw	t1, t1, 0x738
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
-               	ld	a2, 0x0(a1)
-               	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u64x2.checksum+0xfb0>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x658
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	ld	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u64x2.checksum+0xfd4>
+               	jalr	ra <corpus.cases.vec.vec_u64x2.checksum+0xe30>
                	mv	a1, s7
                	ld	a2, 0x0(a1)
                	not	a1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x650
+               	addiw	t1, t1, 0x730
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
@@ -1060,142 +955,76 @@ Disassembly of section .text:
                	ld	a2, 0x0(a1)
                	not	a1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x650
+               	addiw	t1, t1, 0x730
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
                	sd	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x650
+               	addiw	t1, t1, 0x730
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
-               	ld	a2, 0x0(a1)
-               	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u64x2.checksum+0x1040>
+               	jalr	ra <corpus.cases.vec.vec_u64x2.checksum+0xe94>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x650
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	ld	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u64x2.checksum+0x1064>
-               	mv	a1, s6
-               	ld	a2, 0x0(a1)
-               	mv	a1, s7
-               	ld	a3, 0x0(a1)
-               	and	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x648
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a2, t2
-               	sd	a1, 0x0(a2)
-               	addi	a1, s6, 0x8
-               	ld	a2, 0x0(a1)
-               	addi	a1, s7, 0x8
-               	ld	a3, 0x0(a1)
-               	and	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x648
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x8
-               	sd	a1, 0x0(a2)
-               	mv	a1, s6
-               	ld	a2, 0x0(a1)
-               	mv	a1, s7
-               	ld	a3, 0x0(a1)
-               	or	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x640
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a2, t2
-               	sd	a1, 0x0(a2)
-               	addi	a1, s6, 0x8
-               	ld	a2, 0x0(a1)
-               	addi	a1, s7, 0x8
-               	ld	a3, 0x0(a1)
-               	or	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x640
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x8
-               	sd	a1, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x648
+               	addiw	t1, t1, 0x678
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	ld	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x640
+               	addiw	t1, t1, 0x670
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	ld	a3, 0x0(a1)
                	xor	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x638
+               	addiw	t1, t1, 0x728
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
                	sd	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x648
+               	addiw	t1, t1, 0x678
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	ld	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x640
+               	addiw	t1, t1, 0x670
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	ld	a3, 0x0(a1)
                	xor	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x638
+               	addiw	t1, t1, 0x728
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
                	sd	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x638
+               	addiw	t1, t1, 0x728
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
-               	ld	a2, 0x0(a1)
-               	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u64x2.checksum+0x11d0>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x638
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	ld	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u64x2.checksum+0x11f4>
+               	jalr	ra <corpus.cases.vec.vec_u64x2.checksum+0xf48>
                	mv	s1, a0
                	mv	s2, s5
                	li	s3, 0x0
                	li	t0, 0x6
-               	bltu	s3, t0, 0x1280 <corpus.cases.vec.vec_u64x2.checksum+0x1214>
-               	j	0x156c <corpus.cases.vec.vec_u64x2.checksum+0x1500>
+               	bltu	s3, t0, 0xfd4 <corpus.cases.vec.vec_u64x2.checksum+0xf68>
+               	j	0x12c0 <corpus.cases.vec.vec_u64x2.checksum+0x1254>
                	mv	a0, s6
                	ld	a1, 0x0(a0)
                	mv	a0, s4
                	ld	a2, 0x0(a0)
                	mul	a0, a1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x630
+               	addiw	t1, t1, 0x720
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
@@ -1206,40 +1035,40 @@ Disassembly of section .text:
                	ld	a2, 0x0(a0)
                	mul	a0, a1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x630
+               	addiw	t1, t1, 0x720
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	sd	a0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x630
+               	addiw	t1, t1, 0x720
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a0, t2
                	ld	a1, 0x0(a0)
                	mv	a0, s1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u64x2.checksum+0x1288>
+               	jalr	ra <corpus.cases.vec.vec_u64x2.checksum+0xfdc>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x630
+               	addiw	t1, t1, 0x720
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	ld	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u64x2.checksum+0x12ac>
+               	jalr	ra <corpus.cases.vec.vec_u64x2.checksum+0x1000>
                	mv	a1, s2
                	ld	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x630
+               	addiw	t1, t1, 0x720
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	ld	a3, 0x0(a1)
                	xor	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x628
+               	addiw	t1, t1, 0x718
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
@@ -1247,43 +1076,43 @@ Disassembly of section .text:
                	addi	a1, s2, 0x8
                	ld	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x630
+               	addiw	t1, t1, 0x720
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	ld	a3, 0x0(a1)
                	xor	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x628
+               	addiw	t1, t1, 0x718
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
                	sd	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x628
+               	addiw	t1, t1, 0x718
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	ld	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u64x2.checksum+0x1348>
+               	jalr	ra <corpus.cases.vec.vec_u64x2.checksum+0x109c>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x628
+               	addiw	t1, t1, 0x718
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	ld	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u64x2.checksum+0x136c>
+               	jalr	ra <corpus.cases.vec.vec_u64x2.checksum+0x10c0>
                	mv	a1, s5
                	ld	a2, 0x0(a1)
                	mv	a1, s6
                	ld	a3, 0x0(a1)
                	add	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x620
+               	addiw	t1, t1, 0x710
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
@@ -1294,36 +1123,36 @@ Disassembly of section .text:
                	ld	a3, 0x0(a1)
                	add	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x620
+               	addiw	t1, t1, 0x710
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
                	sd	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x620
+               	addiw	t1, t1, 0x710
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	ld	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u64x2.checksum+0x13e8>
+               	jalr	ra <corpus.cases.vec.vec_u64x2.checksum+0x113c>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x620
+               	addiw	t1, t1, 0x710
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	ld	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u64x2.checksum+0x140c>
+               	jalr	ra <corpus.cases.vec.vec_u64x2.checksum+0x1160>
                	mv	a1, s6
                	ld	a2, 0x0(a1)
                	mv	a1, s7
                	ld	a3, 0x0(a1)
                	add	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x618
+               	addiw	t1, t1, 0x708
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
@@ -1334,50 +1163,50 @@ Disassembly of section .text:
                	ld	a3, 0x0(a1)
                	add	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x618
+               	addiw	t1, t1, 0x708
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
                	sd	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x618
+               	addiw	t1, t1, 0x708
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	ld	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u64x2.checksum+0x1488>
+               	jalr	ra <corpus.cases.vec.vec_u64x2.checksum+0x11dc>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x618
+               	addiw	t1, t1, 0x708
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	ld	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u64x2.checksum+0x14ac>
+               	jalr	ra <corpus.cases.vec.vec_u64x2.checksum+0x1200>
                	addi	s3, s3, 0x1
                	mv	s1, a0
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x618
+               	addiw	t1, t1, 0x708
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	s6, t2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x628
+               	addiw	t1, t1, 0x718
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	s2, t2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x620
+               	addiw	t1, t1, 0x710
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	s5, t2
                	li	t0, 0x6
-               	bltu	s3, t0, 0x1280 <corpus.cases.vec.vec_u64x2.checksum+0x1214>
+               	bltu	s3, t0, 0xfd4 <corpus.cases.vec.vec_u64x2.checksum+0xf68>
                	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x698
+               	addiw	t0, t0, 0x778
                	add	s3, s0, t0
                	sd	zero, 0x0(s3)
                	sd	zero, 0x8(s3)
@@ -1402,7 +1231,7 @@ Disassembly of section .text:
                	ld	a2, 0x0(a0)
                	add	a0, a1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x610
+               	addiw	t1, t1, 0x700
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
@@ -1413,14 +1242,14 @@ Disassembly of section .text:
                	ld	a2, 0x0(a0)
                	add	a0, a1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x610
+               	addiw	t1, t1, 0x700
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	sd	a0, 0x0(a1)
                	addi	a0, s3, 0x10
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x610
+               	addiw	t1, t1, 0x700
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
@@ -1428,7 +1257,7 @@ Disassembly of section .text:
                	mv	a1, a0
                	sd	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x610
+               	addiw	t1, t1, 0x700
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
@@ -1441,7 +1270,7 @@ Disassembly of section .text:
                	ld	a2, 0x0(a0)
                	mul	a0, a1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x608
+               	addiw	t1, t1, 0x6f8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
@@ -1452,14 +1281,14 @@ Disassembly of section .text:
                	ld	a2, 0x0(a0)
                	mul	a0, a1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x608
+               	addiw	t1, t1, 0x6f8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	sd	a0, 0x0(a1)
                	addi	a0, s3, 0x20
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x608
+               	addiw	t1, t1, 0x6f8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
@@ -1467,7 +1296,7 @@ Disassembly of section .text:
                	mv	a1, a0
                	sd	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x608
+               	addiw	t1, t1, 0x6f8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
@@ -1485,15 +1314,15 @@ Disassembly of section .text:
                	sd	a2, 0x0(a1)
                	li	s2, 0x0
                	li	t0, 0x4
-               	bltu	s2, t0, 0x1728 <corpus.cases.vec.vec_u64x2.checksum+0x16bc>
-               	j	0x17cc <corpus.cases.vec.vec_u64x2.checksum+0x1760>
+               	bltu	s2, t0, 0x147c <corpus.cases.vec.vec_u64x2.checksum+0x1410>
+               	j	0x1520 <corpus.cases.vec.vec_u64x2.checksum+0x14b4>
                	li	t0, 0x10
                	mul	a0, s2, t0
                	add	a1, s3, a0
                	mv	a0, a1
                	ld	a2, 0x0(a0)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x600
+               	addiw	t1, t1, 0x6f0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a0, t2
@@ -1501,35 +1330,35 @@ Disassembly of section .text:
                	addi	a0, a1, 0x8
                	ld	a1, 0x0(a0)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x600
+               	addiw	t1, t1, 0x6f0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a0, t2, 0x8
                	sd	a1, 0x0(a0)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x600
+               	addiw	t1, t1, 0x6f0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a0, t2
                	ld	a1, 0x0(a0)
                	mv	a0, s1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u64x2.checksum+0x1724>
+               	jalr	ra <corpus.cases.vec.vec_u64x2.checksum+0x1478>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x600
+               	addiw	t1, t1, 0x6f0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	ld	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u64x2.checksum+0x1748>
+               	jalr	ra <corpus.cases.vec.vec_u64x2.checksum+0x149c>
                	addi	s2, s2, 0x1
                	mv	s1, a0
                	li	t0, 0x4
-               	bltu	s2, t0, 0x1728 <corpus.cases.vec.vec_u64x2.checksum+0x16bc>
+               	bltu	s2, t0, 0x147c <corpus.cases.vec.vec_u64x2.checksum+0x1410>
                	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x668
+               	addiw	t0, t0, 0x748
                	add	s2, s0, t0
                	sd	zero, 0x0(s2)
                	sd	zero, 0x8(s2)
@@ -1546,7 +1375,7 @@ Disassembly of section .text:
                	mv	a2, a1
                	ld	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x5f8
+               	addiw	t1, t1, 0x6e8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
@@ -1554,14 +1383,14 @@ Disassembly of section .text:
                	addi	a2, a1, 0x8
                	ld	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x5f8
+               	addiw	t1, t1, 0x6e8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
                	sd	a1, 0x0(a2)
                	addi	s3, s2, 0x10
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x5f8
+               	addiw	t1, t1, 0x6e8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
@@ -1569,7 +1398,7 @@ Disassembly of section .text:
                	mv	a1, s3
                	sd	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x5f8
+               	addiw	t1, t1, 0x6e8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
@@ -1583,11 +1412,11 @@ Disassembly of section .text:
                	lw	a1, 0x0(a0)
                	mv	a0, s1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u64x2.checksum+0x1838>
+               	jalr	ra <corpus.cases.vec.vec_u64x2.checksum+0x158c>
                	mv	a1, s3
                	ld	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x5f0
+               	addiw	t1, t1, 0x6e0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
@@ -1595,87 +1424,87 @@ Disassembly of section .text:
                	addi	a1, s3, 0x8
                	ld	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x5f0
+               	addiw	t1, t1, 0x6e0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	sd	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x5f0
+               	addiw	t1, t1, 0x6e0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	ld	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u64x2.checksum+0x189c>
+               	jalr	ra <corpus.cases.vec.vec_u64x2.checksum+0x15f0>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x5f0
+               	addiw	t1, t1, 0x6e0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	ld	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u64x2.checksum+0x18c0>
+               	jalr	ra <corpus.cases.vec.vec_u64x2.checksum+0x1614>
                	addi	a1, s2, 0x20
                	lw	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u64x2.checksum+0x18d4>
+               	jalr	ra <corpus.cases.vec.vec_u64x2.checksum+0x1628>
                	lui	t1, 0x1
-               	addiw	t1, t1, -0x588
+               	addiw	t1, t1, -0x678
                	add	t1, sp, t1
                	ld	s1, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, -0x590
+               	addiw	t1, t1, -0x680
                	add	t1, sp, t1
                	ld	s2, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, -0x598
+               	addiw	t1, t1, -0x688
                	add	t1, sp, t1
                	ld	s3, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, -0x5a0
+               	addiw	t1, t1, -0x690
                	add	t1, sp, t1
                	ld	s4, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, -0x5a8
+               	addiw	t1, t1, -0x698
                	add	t1, sp, t1
                	ld	s5, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, -0x5b0
+               	addiw	t1, t1, -0x6a0
                	add	t1, sp, t1
                	ld	s6, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, -0x5b8
+               	addiw	t1, t1, -0x6a8
                	add	t1, sp, t1
                	ld	s7, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, -0x5c0
+               	addiw	t1, t1, -0x6b0
                	add	t1, sp, t1
                	ld	s8, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, -0x5c8
+               	addiw	t1, t1, -0x6b8
                	add	t1, sp, t1
                	ld	s9, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, -0x5d0
+               	addiw	t1, t1, -0x6c0
                	add	t1, sp, t1
                	ld	s10, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, -0x5d8
+               	addiw	t1, t1, -0x6c8
                	add	t1, sp, t1
                	ld	s11, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, -0x578
+               	addiw	t1, t1, -0x668
                	add	t1, sp, t1
                	ld	ra, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, -0x580
+               	addiw	t1, t1, -0x670
                	add	t1, sp, t1
                	ld	s0, 0x0(t1)
                	lui	t0, 0x1
-               	addiw	t0, t0, -0x570
+               	addiw	t0, t0, -0x660
                	add	sp, sp, t0
                	ret

--- a/test/golden/x86_64-linux/call/call_mixed.dis
+++ b/test/golden/x86_64-linux/call/call_mixed.dis
@@ -317,12 +317,12 @@ Disassembly of section .text:
 <corpus.cases.call.call_mixed.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x240, %rsp            # imm = 0x240
-               	movq	%rbx, -0x1e8(%rbp)
-               	movq	%r12, -0x1f0(%rbp)
-               	movq	%r13, -0x1f8(%rbp)
-               	movq	%r14, -0x200(%rbp)
-               	movq	%r15, -0x208(%rbp)
+               	subq	$0x3e0, %rsp            # imm = 0x3E0
+               	movq	%rbx, -0x388(%rbp)
+               	movq	%r12, -0x390(%rbp)
+               	movq	%r13, -0x398(%rbp)
+               	movq	%r14, -0x3a0(%rbp)
+               	movq	%r15, -0x3a8(%rbp)
                	movq	%rdi, %rbx
                	callq	 <L0>
 <L0>:
@@ -373,12 +373,14 @@ Disassembly of section .text:
                	movq	$0x0, %r15
                	cmpq	$0x3, %r15
                	jb	 <L3>
-               	jmp	 <L40>
+               	jmp	 <L35>
 <L3>:
                	movq	%r15, %rax
                	imulq	$0xb, %rax, %rax
-               	addq	%rbx, %rax
-               	leaq	-0xcc(%rbp), %rcx
+               	movq	%rax, %r8
+               	addq	%rbx, %r8
+               	movq	%r8, -0x1b8(%rbp)
+               	leaq	-0xcc(%rbp), %rax
                	leaq	0x80(%r12), %rdx
                	movq	(%rdx), %rsi
                	andq	$0xfff, %rsi            # imm = 0xFFF
@@ -396,10 +398,10 @@ Disassembly of section .text:
                	addss	%xmm0, %xmm0
 <L5>:
                	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	subss	, %xmm1 <corpus.cases.call.call_mixed.checksum+0x1f3>
+               	subss	, %xmm1 <corpus.cases.call.call_mixed.checksum+0x1fd>
                	movss	%xmm1, %xmm0            # xmm0 = xmm1[0],xmm0[1,2,3]
-               	divss	, %xmm0 <corpus.cases.call.call_mixed.checksum+0x1ff>
-               	leaq	(%rcx), %rdx
+               	divss	, %xmm0 <corpus.cases.call.call_mixed.checksum+0x209>
+               	leaq	(%rax), %rdx
                	movss	%xmm0, (%rdx)
                	leaq	0x88(%r12), %rdx
                	movq	(%rdx), %rsi
@@ -418,10 +420,10 @@ Disassembly of section .text:
                	addss	%xmm0, %xmm0
 <L7>:
                	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	subss	, %xmm1 <corpus.cases.call.call_mixed.checksum+0x250>
+               	subss	, %xmm1 <corpus.cases.call.call_mixed.checksum+0x25a>
                	movss	%xmm1, %xmm0            # xmm0 = xmm1[0],xmm0[1,2,3]
-               	divss	, %xmm0 <corpus.cases.call.call_mixed.checksum+0x25c>
-               	leaq	0x4(%rcx), %rdx
+               	divss	, %xmm0 <corpus.cases.call.call_mixed.checksum+0x266>
+               	leaq	0x4(%rax), %rdx
                	movss	%xmm0, (%rdx)
                	leaq	0x90(%r12), %rdx
                	movq	(%rdx), %rsi
@@ -440,19 +442,20 @@ Disassembly of section .text:
                	addss	%xmm0, %xmm0
 <L9>:
                	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	subss	, %xmm1 <corpus.cases.call.call_mixed.checksum+0x2ae>
+               	subss	, %xmm1 <corpus.cases.call.call_mixed.checksum+0x2b8>
                	movss	%xmm1, %xmm0            # xmm0 = xmm1[0],xmm0[1,2,3]
-               	divss	, %xmm0 <corpus.cases.call.call_mixed.checksum+0x2ba>
-               	leaq	0x8(%rcx), %rdx
+               	divss	, %xmm0 <corpus.cases.call.call_mixed.checksum+0x2c4>
+               	leaq	0x8(%rax), %rdx
                	movss	%xmm0, (%rdx)
                	movq	$0x0, -0xe8(%rbp)
                	movq	$0x0, -0xe0(%rbp)
-               	movq	(%rcx), %rdx
+               	movq	(%rax), %rdx
                	movq	%rdx, -0xe8(%rbp)
-               	movl	0x8(%rcx), %edx
+               	movl	0x8(%rax), %edx
                	movl	%edx, -0xe0(%rbp)
-               	movups	-0xe8(%rbp), %xmm2
-               	leaq	-0x100(%rbp), %rcx
+               	movups	-0xe8(%rbp), %xmm14
+               	movups	%xmm14, -0x1d0(%rbp)
+               	leaq	-0x100(%rbp), %rax
                	leaq	0x98(%r12), %rdx
                	movq	(%rdx), %rsi
                	andq	$0xfff, %rsi            # imm = 0xFFF
@@ -470,10 +473,10 @@ Disassembly of section .text:
                	addss	%xmm0, %xmm0
 <L11>:
                	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	subss	, %xmm1 <corpus.cases.call.call_mixed.checksum+0x343>
+               	subss	, %xmm1 <corpus.cases.call.call_mixed.checksum+0x356>
                	movss	%xmm1, %xmm0            # xmm0 = xmm1[0],xmm0[1,2,3]
-               	divss	, %xmm0 <corpus.cases.call.call_mixed.checksum+0x34f>
-               	leaq	(%rcx), %rdx
+               	divss	, %xmm0 <corpus.cases.call.call_mixed.checksum+0x362>
+               	leaq	(%rax), %rdx
                	movss	%xmm0, (%rdx)
                	leaq	0xa0(%r12), %rdx
                	movq	(%rdx), %rsi
@@ -492,10 +495,10 @@ Disassembly of section .text:
                	addss	%xmm0, %xmm0
 <L13>:
                	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	subss	, %xmm1 <corpus.cases.call.call_mixed.checksum+0x3a0>
+               	subss	, %xmm1 <corpus.cases.call.call_mixed.checksum+0x3b3>
                	movss	%xmm1, %xmm0            # xmm0 = xmm1[0],xmm0[1,2,3]
-               	divss	, %xmm0 <corpus.cases.call.call_mixed.checksum+0x3ac>
-               	leaq	0x4(%rcx), %rdx
+               	divss	, %xmm0 <corpus.cases.call.call_mixed.checksum+0x3bf>
+               	leaq	0x4(%rax), %rdx
                	movss	%xmm0, (%rdx)
                	leaq	0xa8(%r12), %rdx
                	movq	(%rdx), %rsi
@@ -514,10 +517,10 @@ Disassembly of section .text:
                	addss	%xmm0, %xmm0
 <L15>:
                	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	subss	, %xmm1 <corpus.cases.call.call_mixed.checksum+0x3fe>
+               	subss	, %xmm1 <corpus.cases.call.call_mixed.checksum+0x411>
                	movss	%xmm1, %xmm0            # xmm0 = xmm1[0],xmm0[1,2,3]
-               	divss	, %xmm0 <corpus.cases.call.call_mixed.checksum+0x40a>
-               	leaq	0x8(%rcx), %rdx
+               	divss	, %xmm0 <corpus.cases.call.call_mixed.checksum+0x41d>
+               	leaq	0x8(%rax), %rdx
                	movss	%xmm0, (%rdx)
                	leaq	0xb0(%r12), %rdx
                	movq	(%rdx), %rsi
@@ -536,13 +539,15 @@ Disassembly of section .text:
                	addss	%xmm0, %xmm0
 <L17>:
                	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	subss	, %xmm1 <corpus.cases.call.call_mixed.checksum+0x45c>
+               	subss	, %xmm1 <corpus.cases.call.call_mixed.checksum+0x46f>
                	movss	%xmm1, %xmm0            # xmm0 = xmm1[0],xmm0[1,2,3]
-               	divss	, %xmm0 <corpus.cases.call.call_mixed.checksum+0x468>
-               	leaq	0xc(%rcx), %rdx
+               	divss	, %xmm0 <corpus.cases.call.call_mixed.checksum+0x47b>
+               	leaq	0xc(%rax), %rdx
                	movss	%xmm0, (%rdx)
-               	movups	(%rcx), %xmm4
-               	leaq	-0x128(%rbp), %rcx
+               	movups	(%rax), %xmm14
+               	movups	%xmm14, -0x1e0(%rbp)
+               	leaq	-0x128(%rbp), %r8
+               	movq	%r8, -0x1e8(%rbp)
                	leaq	0xb8(%r12), %rdx
                	movq	(%rdx), %rsi
                	andq	$0xfff, %rsi            # imm = 0xFFF
@@ -560,104 +565,71 @@ Disassembly of section .text:
                	addss	%xmm0, %xmm0
 <L19>:
                	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	subss	, %xmm1 <corpus.cases.call.call_mixed.checksum+0x4c4>
+               	subss	, %xmm1 <corpus.cases.call.call_mixed.checksum+0x4e7>
                	movss	%xmm1, %xmm0            # xmm0 = xmm1[0],xmm0[1,2,3]
-               	divss	, %xmm0 <corpus.cases.call.call_mixed.checksum+0x4d0>
-               	leaq	(%rcx), %rdx
+               	divss	, %xmm0 <corpus.cases.call.call_mixed.checksum+0x4f3>
+               	movq	-0x1e8(%rbp), %r8
+               	leaq	(%r8), %rdx
                	movss	%xmm0, (%rdx)
-               	leaq	(%r12), %rdx
-               	movq	(%rdx), %rsi
-               	addq	%rax, %rsi
-               	andq	$0xfff, %rsi            # imm = 0xFFF
-               	movq	%rsi, %r11
-               	testq	%r11, %r11
-               	jl	 <L20>
-               	cvtsi2ss	%r11, %xmm0
-               	jmp	 <L21>
+               	leaq	(%r12), %r8
+               	movq	%r8, -0x1f0(%rbp)
+               	movq	-0x1f0(%rbp), %r8
+               	movq	(%r8), %rsi
+               	movq	-0x1b8(%rbp), %r8
+               	addq	%r8, %rsi
+               	movq	%rsi, %rdi
+               	callq	 <L20>
 <L20>:
-               	movq	%r11, %r10
-               	shrq	%r10
-               	andq	$0x1, %r11
-               	orq	%r10, %r11
-               	cvtsi2ss	%r11, %xmm0
-               	addss	%xmm0, %xmm0
+               	movq	-0x1e8(%rbp), %r8
+               	leaq	0x4(%r8), %rsi
+               	movss	%xmm0, (%rsi)
+               	movq	-0x1e8(%rbp), %r8
+               	movq	(%r8), %r11
+               	movq	%r11, -0x200(%rbp)
+               	movq	-0x1f0(%rbp), %r8
+               	movq	(%r8), %rax
+               	movq	-0x1b8(%rbp), %r9
+               	movq	%rax, %r8
+               	addq	%r9, %r8
+               	movq	%r8, -0x208(%rbp)
+               	leaq	0x8(%r12), %rax
+               	movq	(%rax), %rdi
+               	callq	 <L21>
 <L21>:
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	subss	, %xmm1 <corpus.cases.call.call_mixed.checksum+0x520>
-               	movss	%xmm1, %xmm0            # xmm0 = xmm1[0],xmm0[1,2,3]
-               	divss	, %xmm0 <corpus.cases.call.call_mixed.checksum+0x52c>
-               	leaq	0x4(%rcx), %rdx
-               	movss	%xmm0, (%rdx)
-               	movsd	(%rcx), %xmm8
-               	leaq	(%r12), %rcx
-               	movq	(%rcx), %rdx
-               	addq	%rax, %rdx
-               	leaq	0x8(%r12), %rcx
-               	movq	(%rcx), %rsi
-               	andq	$0xfff, %rsi            # imm = 0xFFF
-               	movq	%rsi, %r11
+               	movss	%xmm0, -0x218(%rbp)
+               	leaq	0x10(%r12), %rax
+               	movq	(%rax), %rsi
+               	movl	%esi, %r8d
+               	movq	%r8, -0x220(%rbp)
+               	leaq	0x18(%r12), %rsi
+               	movq	(%rsi), %rdi
+               	andq	$0xfffff, %rdi          # imm = 0xFFFFF
+               	movq	%rdi, %r11
                	testq	%r11, %r11
                	jl	 <L22>
-               	cvtsi2ss	%r11, %xmm0
+               	cvtsi2sd	%r11, %xmm1
                	jmp	 <L23>
 <L22>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
-               	cvtsi2ss	%r11, %xmm0
-               	addss	%xmm0, %xmm0
-<L23>:
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	subss	, %xmm1 <corpus.cases.call.call_mixed.checksum+0x58a>
-               	movss	%xmm1, %xmm0            # xmm0 = xmm1[0],xmm0[1,2,3]
-               	divss	, %xmm0 <corpus.cases.call.call_mixed.checksum+0x596>
-               	leaq	0x10(%r12), %rcx
-               	movq	(%rcx), %rsi
-               	movl	%esi, %ecx
-               	leaq	0x18(%r12), %rsi
-               	movq	(%rsi), %rdi
-               	andq	$0xfffff, %rdi          # imm = 0xFFFFF
-               	movq	%rdi, %r11
-               	testq	%r11, %r11
-               	jl	 <L24>
-               	cvtsi2sd	%r11, %xmm1
-               	jmp	 <L25>
-<L24>:
-               	movq	%r11, %r10
-               	shrq	%r10
-               	andq	$0x1, %r11
-               	orq	%r10, %r11
                	cvtsi2sd	%r11, %xmm1
                	addsd	%xmm1, %xmm1
-<L25>:
+<L23>:
                	movsd	%xmm1, %xmm3            # xmm3 = xmm1[0],xmm3[1]
-               	subsd	, %xmm3 <corpus.cases.call.call_mixed.checksum+0x5e7>
-               	movsd	%xmm3, %xmm1            # xmm1 = xmm3[0],xmm1[1]
-               	divsd	, %xmm1 <corpus.cases.call.call_mixed.checksum+0x5f3>
+               	subsd	, %xmm3 <corpus.cases.call.call_mixed.checksum+0x5d4>
+               	movsd	%xmm3, %xmm14           # xmm14 = xmm3[0],xmm14[1]
+               	divsd	, %xmm14 <corpus.cases.call.call_mixed.checksum+0x5e2>
+               	movsd	%xmm14, -0x230(%rbp)
                	leaq	0x20(%r12), %rsi
                	movq	(%rsi), %r8
                	movq	%r8, -0x138(%rbp)
                	leaq	0x28(%r12), %rsi
                	movq	(%rsi), %rdi
-               	andq	$0xfff, %rdi            # imm = 0xFFF
-               	movq	%rdi, %r11
-               	testq	%r11, %r11
-               	jl	 <L26>
-               	cvtsi2ss	%r11, %xmm3
-               	jmp	 <L27>
-<L26>:
-               	movq	%r11, %r10
-               	shrq	%r10
-               	andq	$0x1, %r11
-               	orq	%r10, %r11
-               	cvtsi2ss	%r11, %xmm3
-               	addss	%xmm3, %xmm3
-<L27>:
-               	movss	%xmm3, %xmm5            # xmm5 = xmm3[0],xmm5[1,2,3]
-               	subss	, %xmm5 <corpus.cases.call.call_mixed.checksum+0x649>
-               	movss	%xmm5, %xmm3            # xmm3 = xmm5[0],xmm3[1,2,3]
-               	divss	, %xmm3 <corpus.cases.call.call_mixed.checksum+0x655>
+               	callq	 <L24>
+<L24>:
+               	movss	%xmm0, -0x240(%rbp)
                	leaq	0x30(%r12), %rsi
                	movq	(%rsi), %rdi
                	movw	%di, %r8w
@@ -667,44 +639,30 @@ Disassembly of section .text:
                	andq	$0xfffff, %rdi          # imm = 0xFFFFF
                	movq	%rdi, %r11
                	testq	%r11, %r11
-               	jl	 <L28>
+               	jl	 <L25>
                	cvtsi2sd	%r11, %xmm5
-               	jmp	 <L29>
-<L28>:
+               	jmp	 <L26>
+<L25>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2sd	%r11, %xmm5
                	addsd	%xmm5, %xmm5
-<L29>:
+<L26>:
                	movsd	%xmm5, %xmm6            # xmm6 = xmm5[0],xmm6[1]
-               	subsd	, %xmm6 <corpus.cases.call.call_mixed.checksum+0x6af>
-               	movsd	%xmm6, %xmm5            # xmm5 = xmm6[0],xmm5[1]
-               	divsd	, %xmm5 <corpus.cases.call.call_mixed.checksum+0x6bb>
+               	subsd	, %xmm6 <corpus.cases.call.call_mixed.checksum+0x669>
+               	movsd	%xmm6, %xmm14           # xmm14 = xmm6[0],xmm14[1]
+               	divsd	, %xmm14 <corpus.cases.call.call_mixed.checksum+0x677>
+               	movsd	%xmm14, -0x250(%rbp)
                	leaq	0x40(%r12), %rsi
                	movq	(%rsi), %r8
                	movq	%r8, -0x148(%rbp)
                	leaq	0x48(%r12), %rsi
                	movq	(%rsi), %rdi
-               	andq	$0xfff, %rdi            # imm = 0xFFF
-               	movq	%rdi, %r11
-               	testq	%r11, %r11
-               	jl	 <L30>
-               	cvtsi2ss	%r11, %xmm6
-               	jmp	 <L31>
-<L30>:
-               	movq	%r11, %r10
-               	shrq	%r10
-               	andq	$0x1, %r11
-               	orq	%r10, %r11
-               	cvtsi2ss	%r11, %xmm6
-               	addss	%xmm6, %xmm6
-<L31>:
-               	movss	%xmm6, %xmm7            # xmm7 = xmm6[0],xmm7[1,2,3]
-               	subss	, %xmm7 <corpus.cases.call.call_mixed.checksum+0x711>
-               	movss	%xmm7, %xmm6            # xmm6 = xmm7[0],xmm6[1,2,3]
-               	divss	, %xmm6 <corpus.cases.call.call_mixed.checksum+0x71d>
+               	callq	 <L27>
+<L27>:
+               	movss	%xmm0, -0x260(%rbp)
                	leaq	0x50(%r12), %rsi
                	movq	(%rsi), %rdi
                	movb	%dil, %r8b
@@ -714,44 +672,30 @@ Disassembly of section .text:
                	andq	$0xfffff, %rdi          # imm = 0xFFFFF
                	movq	%rdi, %r11
                	testq	%r11, %r11
-               	jl	 <L32>
+               	jl	 <L28>
                	cvtsi2sd	%r11, %xmm7
-               	jmp	 <L33>
-<L32>:
+               	jmp	 <L29>
+<L28>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2sd	%r11, %xmm7
                	addsd	%xmm7, %xmm7
-<L33>:
+<L29>:
                	movsd	%xmm7, %xmm9            # xmm9 = xmm7[0],xmm9[1]
-               	subsd	, %xmm9 <corpus.cases.call.call_mixed.checksum+0x778>
-               	movsd	%xmm9, %xmm7            # xmm7 = xmm9[0],xmm7[1]
-               	divsd	, %xmm7 <corpus.cases.call.call_mixed.checksum+0x785>
+               	subsd	, %xmm9 <corpus.cases.call.call_mixed.checksum+0x6ff>
+               	movsd	%xmm9, %xmm14           # xmm14 = xmm9[0],xmm14[1]
+               	divsd	, %xmm14 <corpus.cases.call.call_mixed.checksum+0x70d>
+               	movsd	%xmm14, -0x270(%rbp)
                	leaq	0x60(%r12), %rsi
                	movq	(%rsi), %r8
                	movq	%r8, -0x158(%rbp)
                	leaq	0x68(%r12), %rsi
                	movq	(%rsi), %rdi
-               	andq	$0xfff, %rdi            # imm = 0xFFF
-               	movq	%rdi, %r11
-               	testq	%r11, %r11
-               	jl	 <L34>
-               	cvtsi2ss	%r11, %xmm9
-               	jmp	 <L35>
-<L34>:
-               	movq	%r11, %r10
-               	shrq	%r10
-               	andq	$0x1, %r11
-               	orq	%r10, %r11
-               	cvtsi2ss	%r11, %xmm9
-               	addss	%xmm9, %xmm9
-<L35>:
-               	movss	%xmm9, %xmm10           # xmm10 = xmm9[0],xmm10[1,2,3]
-               	subss	, %xmm10 <corpus.cases.call.call_mixed.checksum+0x7de>
-               	movss	%xmm10, %xmm9           # xmm9 = xmm10[0],xmm9[1,2,3]
-               	divss	, %xmm9 <corpus.cases.call.call_mixed.checksum+0x7ec>
+               	callq	 <L30>
+<L30>:
+               	movss	%xmm0, %xmm9            # xmm9 = xmm0[0],xmm9[1,2,3]
                	leaq	0x70(%r12), %rsi
                	movq	(%rsi), %rdi
                	movl	%edi, %r8d
@@ -761,35 +705,47 @@ Disassembly of section .text:
                	andq	$0xfffff, %rdi          # imm = 0xFFFFF
                	movq	%rdi, %r11
                	testq	%r11, %r11
-               	jl	 <L36>
+               	jl	 <L31>
                	cvtsi2sd	%r11, %xmm10
-               	jmp	 <L37>
-<L36>:
+               	jmp	 <L32>
+<L31>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2sd	%r11, %xmm10
                	addsd	%xmm10, %xmm10
-<L37>:
+<L32>:
                	movsd	%xmm10, %xmm11          # xmm11 = xmm10[0],xmm11[1]
-               	subsd	, %xmm11 <corpus.cases.call.call_mixed.checksum+0x848>
+               	subsd	, %xmm11 <corpus.cases.call.call_mixed.checksum+0x793>
                	movsd	%xmm11, %xmm10          # xmm10 = xmm11[0],xmm10[1]
-               	divsd	, %xmm10 <corpus.cases.call.call_mixed.checksum+0x856>
+               	divsd	, %xmm10 <corpus.cases.call.call_mixed.checksum+0x7a1>
                	leaq	0x8(%r12), %rsi
                	movq	(%rsi), %rdi
+               	movq	-0x1b8(%rbp), %r9
                	movq	%rdi, %r8
-               	addq	%rax, %r8
+               	addq	%r9, %r8
                	movq	%r8, -0x168(%rbp)
-               	movq	%rdx, %rdi
-               	movl	%ecx, %esi
+               	movq	-0x208(%rbp), %r8
+               	movq	%r8, %rdi
+               	movss	-0x218(%rbp), %xmm0
+               	movq	-0x220(%rbp), %r8
+               	movl	%r8d, %esi
+               	movsd	-0x230(%rbp), %xmm1
+               	movups	-0x1d0(%rbp), %xmm2
                	movq	-0x138(%rbp), %r8
                	movq	%r8, %rdx
+               	movss	-0x240(%rbp), %xmm3
                	movq	-0x140(%rbp), %r8
                	movq	%r8, %rcx
+               	movups	-0x1e0(%rbp), %xmm4
+               	movsd	-0x250(%rbp), %xmm5
                	movq	-0x148(%rbp), %r8
+               	movss	-0x260(%rbp), %xmm6
                	movq	-0x150(%rbp), %r9
-               	movsd	%xmm8, (%rsp)
+               	movsd	-0x270(%rbp), %xmm7
+               	movq	-0x200(%rbp), %r11
+               	movq	%r11, (%rsp)
                	movq	-0x158(%rbp), %r10
                	movq	%r10, 0x8(%rsp)
                	movsd	%xmm9, 0x10(%rsp)
@@ -798,38 +754,38 @@ Disassembly of section .text:
                	movsd	%xmm10, 0x20(%rsp)
                	movq	-0x168(%rbp), %r10
                	movq	%r10, 0x28(%rsp)
-               	callq	 <L38>
-<L38>:
+               	callq	 <L33>
+<L33>:
                	movq	%rax, %r14
                	movq	%r13, %rdi
                	movq	%r14, %rsi
-               	callq	 <L39>
-<L39>:
+               	callq	 <L34>
+<L34>:
                	addq	$0x1, %r15
                	movq	%rax, %r13
                	cmpq	$0x3, %r15
                	jb	 <L3>
-<L40>:
+<L35>:
                	leaq	-0xd8(%rbp), %rax
                	movq	%r14, %rcx
                	andq	$0xfff, %rcx            # imm = 0xFFF
                	movq	%rcx, %r11
                	testq	%r11, %r11
-               	jl	 <L41>
+               	jl	 <L36>
                	cvtsi2ss	%r11, %xmm0
-               	jmp	 <L42>
-<L41>:
+               	jmp	 <L37>
+<L36>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2ss	%r11, %xmm0
                	addss	%xmm0, %xmm0
-<L42>:
+<L37>:
                	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	subss	, %xmm1 <corpus.cases.call.call_mixed.checksum+0x937>
+               	subss	, %xmm1 <corpus.cases.call.call_mixed.checksum+0x8db>
                	movss	%xmm1, %xmm0            # xmm0 = xmm1[0],xmm0[1,2,3]
-               	divss	, %xmm0 <corpus.cases.call.call_mixed.checksum+0x943>
+               	divss	, %xmm0 <corpus.cases.call.call_mixed.checksum+0x8e7>
                	leaq	(%rax), %rcx
                	movss	%xmm0, (%rcx)
                	leaq	0x10(%r12), %rcx
@@ -837,21 +793,21 @@ Disassembly of section .text:
                	andq	$0xfff, %rdx            # imm = 0xFFF
                	movq	%rdx, %r11
                	testq	%r11, %r11
-               	jl	 <L43>
+               	jl	 <L38>
                	cvtsi2ss	%r11, %xmm0
-               	jmp	 <L44>
-<L43>:
+               	jmp	 <L39>
+<L38>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2ss	%r11, %xmm0
                	addss	%xmm0, %xmm0
-<L44>:
+<L39>:
                	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	subss	, %xmm1 <corpus.cases.call.call_mixed.checksum+0x991>
+               	subss	, %xmm1 <corpus.cases.call.call_mixed.checksum+0x935>
                	movss	%xmm1, %xmm0            # xmm0 = xmm1[0],xmm0[1,2,3]
-               	divss	, %xmm0 <corpus.cases.call.call_mixed.checksum+0x99d>
+               	divss	, %xmm0 <corpus.cases.call.call_mixed.checksum+0x941>
                	leaq	0x4(%rax), %rcx
                	movss	%xmm0, (%rcx)
                	leaq	0x18(%r12), %rcx
@@ -859,21 +815,21 @@ Disassembly of section .text:
                	andq	$0xfff, %rdx            # imm = 0xFFF
                	movq	%rdx, %r11
                	testq	%r11, %r11
-               	jl	 <L45>
+               	jl	 <L40>
                	cvtsi2ss	%r11, %xmm0
-               	jmp	 <L46>
-<L45>:
+               	jmp	 <L41>
+<L40>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2ss	%r11, %xmm0
                	addss	%xmm0, %xmm0
-<L46>:
+<L41>:
                	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	subss	, %xmm1 <corpus.cases.call.call_mixed.checksum+0x9ec>
+               	subss	, %xmm1 <corpus.cases.call.call_mixed.checksum+0x990>
                	movss	%xmm1, %xmm0            # xmm0 = xmm1[0],xmm0[1,2,3]
-               	divss	, %xmm0 <corpus.cases.call.call_mixed.checksum+0x9f8>
+               	divss	, %xmm0 <corpus.cases.call.call_mixed.checksum+0x99c>
                	leaq	0x8(%rax), %rcx
                	movss	%xmm0, (%rcx)
                	movq	$0x0, -0x110(%rbp)
@@ -883,28 +839,28 @@ Disassembly of section .text:
                	movl	0x8(%rax), %ecx
                	movl	%ecx, -0x108(%rbp)
                	movups	-0x110(%rbp), %xmm14
-               	movups	%xmm14, -0x1c0(%rbp)
+               	movups	%xmm14, -0x280(%rbp)
                	leaq	-0x120(%rbp), %rax
                	leaq	0x20(%r12), %rcx
                	movq	(%rcx), %rdx
                	andq	$0xfff, %rdx            # imm = 0xFFF
                	movq	%rdx, %r11
                	testq	%r11, %r11
-               	jl	 <L47>
+               	jl	 <L42>
                	cvtsi2ss	%r11, %xmm0
-               	jmp	 <L48>
-<L47>:
+               	jmp	 <L43>
+<L42>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2ss	%r11, %xmm0
                	addss	%xmm0, %xmm0
-<L48>:
+<L43>:
                	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	subss	, %xmm1 <corpus.cases.call.call_mixed.checksum+0xa87>
+               	subss	, %xmm1 <corpus.cases.call.call_mixed.checksum+0xa2b>
                	movss	%xmm1, %xmm0            # xmm0 = xmm1[0],xmm0[1,2,3]
-               	divss	, %xmm0 <corpus.cases.call.call_mixed.checksum+0xa93>
+               	divss	, %xmm0 <corpus.cases.call.call_mixed.checksum+0xa37>
                	leaq	(%rax), %rcx
                	movss	%xmm0, (%rcx)
                	leaq	0x28(%r12), %rcx
@@ -912,21 +868,21 @@ Disassembly of section .text:
                	andq	$0xfff, %rdx            # imm = 0xFFF
                	movq	%rdx, %r11
                	testq	%r11, %r11
-               	jl	 <L49>
+               	jl	 <L44>
                	cvtsi2ss	%r11, %xmm0
-               	jmp	 <L50>
-<L49>:
+               	jmp	 <L45>
+<L44>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2ss	%r11, %xmm0
                	addss	%xmm0, %xmm0
-<L50>:
+<L45>:
                	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	subss	, %xmm1 <corpus.cases.call.call_mixed.checksum+0xae1>
+               	subss	, %xmm1 <corpus.cases.call.call_mixed.checksum+0xa85>
                	movss	%xmm1, %xmm0            # xmm0 = xmm1[0],xmm0[1,2,3]
-               	divss	, %xmm0 <corpus.cases.call.call_mixed.checksum+0xaed>
+               	divss	, %xmm0 <corpus.cases.call.call_mixed.checksum+0xa91>
                	leaq	0x4(%rax), %rcx
                	movss	%xmm0, (%rcx)
                	leaq	0x30(%r12), %rcx
@@ -934,21 +890,21 @@ Disassembly of section .text:
                	andq	$0xfff, %rdx            # imm = 0xFFF
                	movq	%rdx, %r11
                	testq	%r11, %r11
-               	jl	 <L51>
+               	jl	 <L46>
                	cvtsi2ss	%r11, %xmm0
-               	jmp	 <L52>
-<L51>:
+               	jmp	 <L47>
+<L46>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2ss	%r11, %xmm0
                	addss	%xmm0, %xmm0
-<L52>:
+<L47>:
                	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	subss	, %xmm1 <corpus.cases.call.call_mixed.checksum+0xb3c>
+               	subss	, %xmm1 <corpus.cases.call.call_mixed.checksum+0xae0>
                	movss	%xmm1, %xmm0            # xmm0 = xmm1[0],xmm0[1,2,3]
-               	divss	, %xmm0 <corpus.cases.call.call_mixed.checksum+0xb48>
+               	divss	, %xmm0 <corpus.cases.call.call_mixed.checksum+0xaec>
                	leaq	0x8(%rax), %rcx
                	movss	%xmm0, (%rcx)
                	leaq	0x38(%r12), %rcx
@@ -956,239 +912,295 @@ Disassembly of section .text:
                	andq	$0xfff, %rdx            # imm = 0xFFF
                	movq	%rdx, %r11
                	testq	%r11, %r11
-               	jl	 <L53>
+               	jl	 <L48>
                	cvtsi2ss	%r11, %xmm0
-               	jmp	 <L54>
-<L53>:
+               	jmp	 <L49>
+<L48>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2ss	%r11, %xmm0
                	addss	%xmm0, %xmm0
-<L54>:
+<L49>:
                	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	subss	, %xmm1 <corpus.cases.call.call_mixed.checksum+0xb97>
+               	subss	, %xmm1 <corpus.cases.call.call_mixed.checksum+0xb3b>
                	movss	%xmm1, %xmm0            # xmm0 = xmm1[0],xmm0[1,2,3]
-               	divss	, %xmm0 <corpus.cases.call.call_mixed.checksum+0xba3>
+               	divss	, %xmm0 <corpus.cases.call.call_mixed.checksum+0xb47>
                	leaq	0xc(%rax), %rcx
                	movss	%xmm0, (%rcx)
                	movups	(%rax), %xmm14
-               	movups	%xmm14, -0x1d0(%rbp)
-               	leaq	-0x130(%rbp), %rax
-               	leaq	0x40(%r12), %rcx
-               	movq	(%rcx), %rdx
-               	andq	$0xfff, %rdx            # imm = 0xFFF
-               	movq	%rdx, %r11
-               	testq	%r11, %r11
-               	jl	 <L55>
-               	cvtsi2ss	%r11, %xmm0
-               	jmp	 <L56>
-<L55>:
-               	movq	%r11, %r10
-               	shrq	%r10
-               	andq	$0x1, %r11
-               	orq	%r10, %r11
-               	cvtsi2ss	%r11, %xmm0
-               	addss	%xmm0, %xmm0
-<L56>:
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	subss	, %xmm1 <corpus.cases.call.call_mixed.checksum+0xc05>
-               	movss	%xmm1, %xmm0            # xmm0 = xmm1[0],xmm0[1,2,3]
-               	divss	, %xmm0 <corpus.cases.call.call_mixed.checksum+0xc11>
-               	leaq	(%rax), %rcx
-               	movss	%xmm0, (%rcx)
-               	leaq	0x48(%r12), %rcx
-               	movq	(%rcx), %rdx
-               	andq	$0xfff, %rdx            # imm = 0xFFF
-               	movq	%rdx, %r11
-               	testq	%r11, %r11
-               	jl	 <L57>
-               	cvtsi2ss	%r11, %xmm0
-               	jmp	 <L58>
-<L57>:
-               	movq	%r11, %r10
-               	shrq	%r10
-               	andq	$0x1, %r11
-               	orq	%r10, %r11
-               	cvtsi2ss	%r11, %xmm0
-               	addss	%xmm0, %xmm0
-<L58>:
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	subss	, %xmm1 <corpus.cases.call.call_mixed.checksum+0xc5f>
-               	movss	%xmm1, %xmm0            # xmm0 = xmm1[0],xmm0[1,2,3]
-               	divss	, %xmm0 <corpus.cases.call.call_mixed.checksum+0xc6b>
-               	leaq	0x4(%rax), %rcx
-               	movss	%xmm0, (%rcx)
-               	movq	(%rax), %r11
-               	movq	%r11, -0x1e0(%rbp)
-               	leaq	(%r12), %rax
-               	movq	(%rax), %r8
-               	movq	%r8, -0x178(%rbp)
-               	leaq	0x8(%r12), %rax
+               	movups	%xmm14, -0x290(%rbp)
+               	leaq	-0x130(%rbp), %rbx
+               	leaq	0x40(%r12), %rax
                	movq	(%rax), %rcx
                	andq	$0xfff, %rcx            # imm = 0xFFF
                	movq	%rcx, %r11
                	testq	%r11, %r11
-               	jl	 <L59>
+               	jl	 <L50>
                	cvtsi2ss	%r11, %xmm0
-               	jmp	 <L60>
-<L59>:
+               	jmp	 <L51>
+<L50>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2ss	%r11, %xmm0
                	addss	%xmm0, %xmm0
-<L60>:
+<L51>:
                	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	subss	, %xmm1 <corpus.cases.call.call_mixed.checksum+0xcd2>
+               	subss	, %xmm1 <corpus.cases.call.call_mixed.checksum+0xba9>
                	movss	%xmm1, %xmm0            # xmm0 = xmm1[0],xmm0[1,2,3]
-               	divss	, %xmm0 <corpus.cases.call.call_mixed.checksum+0xcde>
+               	divss	, %xmm0 <corpus.cases.call.call_mixed.checksum+0xbb5>
+               	leaq	(%rbx), %rax
+               	movss	%xmm0, (%rax)
+               	leaq	0x48(%r12), %rax
+               	movq	(%rax), %rdi
+               	callq	 <L52>
+<L52>:
+               	leaq	0x4(%rbx), %rax
+               	movss	%xmm0, (%rax)
+               	movq	(%rbx), %r11
+               	movq	%r11, -0x2a0(%rbp)
+               	leaq	(%r12), %rax
+               	movq	(%rax), %rbx
+               	leaq	0x8(%r12), %rax
+               	movq	(%rax), %rdi
+               	callq	 <L53>
+<L53>:
+               	movss	%xmm0, -0x2b0(%rbp)
                	leaq	0x10(%r12), %rax
                	movq	(%rax), %rcx
-               	movl	%ecx, %eax
-               	leaq	0x18(%r12), %rcx
-               	movq	(%rcx), %rdx
-               	andq	$0xfffff, %rdx          # imm = 0xFFFFF
-               	movq	%rdx, %r11
+               	movl	%ecx, %r15d
+               	leaq	0x18(%r12), %rax
+               	movq	(%rax), %rcx
+               	andq	$0xfffff, %rcx          # imm = 0xFFFFF
+               	movq	%rcx, %r11
                	testq	%r11, %r11
-               	jl	 <L61>
+               	jl	 <L54>
                	cvtsi2sd	%r11, %xmm1
-               	jmp	 <L62>
-<L61>:
+               	jmp	 <L55>
+<L54>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2sd	%r11, %xmm1
                	addsd	%xmm1, %xmm1
-<L62>:
+<L55>:
                	movsd	%xmm1, %xmm2            # xmm2 = xmm1[0],xmm2[1]
-               	subsd	, %xmm2 <corpus.cases.call.call_mixed.checksum+0xd2f>
-               	movsd	%xmm2, %xmm1            # xmm1 = xmm2[0],xmm1[1]
-               	divsd	, %xmm1 <corpus.cases.call.call_mixed.checksum+0xd3b>
-               	leaq	0x20(%r12), %rcx
-               	movq	(%rcx), %rdx
-               	leaq	0x28(%r12), %rcx
-               	movq	(%rcx), %rsi
-               	andq	$0xfff, %rsi            # imm = 0xFFF
+               	subsd	, %xmm2 <corpus.cases.call.call_mixed.checksum+0xc49>
+               	movsd	%xmm2, %xmm14           # xmm14 = xmm2[0],xmm14[1]
+               	divsd	, %xmm14 <corpus.cases.call.call_mixed.checksum+0xc57>
+               	movsd	%xmm14, -0x2c8(%rbp)
+               	leaq	0x20(%r12), %rax
+               	movq	(%rax), %r8
+               	movq	%r8, -0x2b8(%rbp)
+               	leaq	0x28(%r12), %rax
+               	movq	(%rax), %rdi
+               	callq	 <L56>
+<L56>:
+               	movss	%xmm0, -0x2d8(%rbp)
+               	leaq	0x30(%r12), %rax
+               	movq	(%rax), %rdx
+               	movw	%dx, %r8w
+               	movq	%r8, -0x2e0(%rbp)
+               	leaq	0x38(%r12), %rdx
+               	movq	(%rdx), %rsi
+               	andq	$0xfffff, %rsi          # imm = 0xFFFFF
+               	movq	%rsi, %r11
+               	testq	%r11, %r11
+               	jl	 <L57>
+               	cvtsi2sd	%r11, %xmm2
+               	jmp	 <L58>
+<L57>:
+               	movq	%r11, %r10
+               	shrq	%r10
+               	andq	$0x1, %r11
+               	orq	%r10, %r11
+               	cvtsi2sd	%r11, %xmm2
+               	addsd	%xmm2, %xmm2
+<L58>:
+               	movsd	%xmm2, %xmm4            # xmm4 = xmm2[0],xmm4[1]
+               	subsd	, %xmm4 <corpus.cases.call.call_mixed.checksum+0xcde>
+               	movsd	%xmm4, %xmm14           # xmm14 = xmm4[0],xmm14[1]
+               	divsd	, %xmm14 <corpus.cases.call.call_mixed.checksum+0xcec>
+               	movsd	%xmm14, -0x2f0(%rbp)
+               	leaq	0x40(%r12), %rdx
+               	movq	(%rdx), %r8
+               	movq	%r8, -0x170(%rbp)
+               	leaq	0x48(%r12), %rdx
+               	movq	(%rdx), %rdi
+               	callq	 <L59>
+<L59>:
+               	movss	%xmm0, -0x300(%rbp)
+               	leaq	0x50(%r12), %rdx
+               	movq	(%rdx), %rsi
+               	movb	%sil, %r8b
+               	movq	%r8, -0x178(%rbp)
+               	leaq	0x58(%r12), %rdx
+               	movq	(%rdx), %rsi
+               	andq	$0xfffff, %rsi          # imm = 0xFFFFF
+               	movq	%rsi, %r11
+               	testq	%r11, %r11
+               	jl	 <L60>
+               	cvtsi2sd	%r11, %xmm2
+               	jmp	 <L61>
+<L60>:
+               	movq	%r11, %r10
+               	shrq	%r10
+               	andq	$0x1, %r11
+               	orq	%r10, %r11
+               	cvtsi2sd	%r11, %xmm2
+               	addsd	%xmm2, %xmm2
+<L61>:
+               	movsd	%xmm2, %xmm4            # xmm4 = xmm2[0],xmm4[1]
+               	subsd	, %xmm4 <corpus.cases.call.call_mixed.checksum+0xd72>
+               	movsd	%xmm4, %xmm14           # xmm14 = xmm4[0],xmm14[1]
+               	divsd	, %xmm14 <corpus.cases.call.call_mixed.checksum+0xd80>
+               	movsd	%xmm14, -0x310(%rbp)
+               	leaq	0x60(%r12), %rdx
+               	movq	(%rdx), %r8
+               	movq	%r8, -0x180(%rbp)
+               	leaq	0x68(%r12), %rdx
+               	movq	(%rdx), %rdi
+               	callq	 <L62>
+<L62>:
+               	movss	%xmm0, %xmm11           # xmm11 = xmm0[0],xmm11[1,2,3]
+               	leaq	0x70(%r12), %rdx
+               	movq	(%rdx), %rsi
+               	movl	%esi, %r8d
+               	movq	%r8, -0x188(%rbp)
+               	leaq	0x78(%r12), %rdx
+               	movq	(%rdx), %rsi
+               	andq	$0xfffff, %rsi          # imm = 0xFFFFF
                	movq	%rsi, %r11
                	testq	%r11, %r11
                	jl	 <L63>
-               	cvtsi2ss	%r11, %xmm2
+               	cvtsi2sd	%r11, %xmm2
                	jmp	 <L64>
 <L63>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
-               	cvtsi2ss	%r11, %xmm2
-               	addss	%xmm2, %xmm2
-<L64>:
-               	movss	%xmm2, %xmm3            # xmm3 = xmm2[0],xmm3[1,2,3]
-               	subss	, %xmm3 <corpus.cases.call.call_mixed.checksum+0xd8a>
-               	movss	%xmm3, %xmm4            # xmm4 = xmm3[0],xmm4[1,2,3]
-               	divss	, %xmm4 <corpus.cases.call.call_mixed.checksum+0xd96>
-               	leaq	0x30(%r12), %rcx
-               	movq	(%rcx), %rsi
-               	movw	%si, %cx
-               	leaq	0x38(%r12), %rsi
-               	movq	(%rsi), %rbx
-               	andq	$0xfffff, %rbx          # imm = 0xFFFFF
-               	movq	%rbx, %r11
-               	testq	%r11, %r11
-               	jl	 <L65>
-               	cvtsi2sd	%r11, %xmm2
-               	jmp	 <L66>
-<L65>:
-               	movq	%r11, %r10
-               	shrq	%r10
-               	andq	$0x1, %r11
-               	orq	%r10, %r11
                	cvtsi2sd	%r11, %xmm2
                	addsd	%xmm2, %xmm2
+<L64>:
+               	movsd	%xmm2, %xmm4            # xmm4 = xmm2[0],xmm4[1]
+               	subsd	, %xmm4 <corpus.cases.call.call_mixed.checksum+0xe03>
+               	movsd	%xmm4, %xmm12           # xmm12 = xmm4[0],xmm12[1]
+               	divsd	, %xmm12 <corpus.cases.call.call_mixed.checksum+0xe11>
+               	leaq	0x8(%r12), %rdx
+               	movq	(%rdx), %r8
+               	movq	%r8, -0x190(%rbp)
+               	movq	%rbx, %rdi
+               	movss	-0x2b0(%rbp), %xmm0
+               	movl	%r15d, %esi
+               	movsd	-0x2c8(%rbp), %xmm1
+               	movups	-0x280(%rbp), %xmm2
+               	movq	-0x2b8(%rbp), %r8
+               	movq	%r8, %rdx
+               	movss	-0x2d8(%rbp), %xmm3
+               	movq	-0x2e0(%rbp), %r8
+               	movq	%r8, %rcx
+               	movups	-0x290(%rbp), %xmm4
+               	movsd	-0x2f0(%rbp), %xmm5
+               	movq	-0x170(%rbp), %r8
+               	movss	-0x300(%rbp), %xmm6
+               	movq	-0x178(%rbp), %r9
+               	movsd	-0x310(%rbp), %xmm7
+               	movq	-0x2a0(%rbp), %r11
+               	movq	%r11, (%rsp)
+               	movq	-0x180(%rbp), %r10
+               	movq	%r10, 0x8(%rsp)
+               	movsd	%xmm11, 0x10(%rsp)
+               	movq	-0x188(%rbp), %r10
+               	movq	%r10, 0x18(%rsp)
+               	movsd	%xmm12, 0x20(%rsp)
+               	movq	-0x190(%rbp), %r10
+               	movq	%r10, 0x28(%rsp)
+               	callq	 <L65>
+<L65>:
+               	movq	%rax, %rbx
+               	leaq	0x18(%r12), %rax
+               	movq	(%rax), %rdi
+               	callq	 <L66>
 <L66>:
-               	movsd	%xmm2, %xmm3            # xmm3 = xmm2[0],xmm3[1]
-               	subsd	, %xmm3 <corpus.cases.call.call_mixed.checksum+0xde8>
-               	movsd	%xmm3, %xmm5            # xmm5 = xmm3[0],xmm5[1]
-               	divsd	, %xmm5 <corpus.cases.call.call_mixed.checksum+0xdf4>
-               	leaq	0x40(%r12), %rsi
-               	movq	(%rsi), %rbx
-               	leaq	0x48(%r12), %rsi
-               	movq	(%rsi), %r15
-               	andq	$0xfff, %r15            # imm = 0xFFF
-               	movq	%r15, %r11
+               	movss	%xmm0, -0x320(%rbp)
+               	leaq	0x28(%r12), %rax
+               	movq	(%rax), %rcx
+               	movl	%ecx, %r15d
+               	leaq	0x38(%r12), %rax
+               	movq	(%rax), %rcx
+               	andq	$0xfffff, %rcx          # imm = 0xFFFFF
+               	movq	%rcx, %r11
                	testq	%r11, %r11
                	jl	 <L67>
-               	cvtsi2ss	%r11, %xmm2
+               	cvtsi2sd	%r11, %xmm1
                	jmp	 <L68>
 <L67>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
-               	cvtsi2ss	%r11, %xmm2
-               	addss	%xmm2, %xmm2
+               	cvtsi2sd	%r11, %xmm1
+               	addsd	%xmm1, %xmm1
 <L68>:
-               	movss	%xmm2, %xmm3            # xmm3 = xmm2[0],xmm3[1,2,3]
-               	subss	, %xmm3 <corpus.cases.call.call_mixed.checksum+0xe43>
-               	movss	%xmm3, %xmm6            # xmm6 = xmm3[0],xmm6[1,2,3]
-               	divss	, %xmm6 <corpus.cases.call.call_mixed.checksum+0xe4f>
-               	leaq	0x50(%r12), %rsi
-               	movq	(%rsi), %r15
-               	movb	%r15b, %r8b
-               	movq	%r8, -0x170(%rbp)
-               	leaq	0x58(%r12), %rsi
-               	movq	(%rsi), %r15
-               	andq	$0xfffff, %r15          # imm = 0xFFFFF
-               	movq	%r15, %r11
-               	testq	%r11, %r11
-               	jl	 <L69>
-               	cvtsi2sd	%r11, %xmm2
-               	jmp	 <L70>
+               	movsd	%xmm1, %xmm2            # xmm2 = xmm1[0],xmm2[1]
+               	subsd	, %xmm2 <corpus.cases.call.call_mixed.checksum+0xf32>
+               	movsd	%xmm2, %xmm14           # xmm14 = xmm2[0],xmm14[1]
+               	divsd	, %xmm14 <corpus.cases.call.call_mixed.checksum+0xf40>
+               	movsd	%xmm14, -0x338(%rbp)
+               	leaq	0x48(%r12), %rax
+               	movq	(%rax), %r8
+               	movq	%r8, -0x328(%rbp)
+               	leaq	0x58(%r12), %rax
+               	movq	(%rax), %rdi
+               	callq	 <L69>
 <L69>:
+               	movss	%xmm0, -0x348(%rbp)
+               	leaq	0x68(%r12), %rax
+               	movq	(%rax), %rdx
+               	movw	%dx, %r8w
+               	movq	%r8, -0x350(%rbp)
+               	leaq	0x78(%r12), %rdx
+               	movq	(%rdx), %rsi
+               	andq	$0xfffff, %rsi          # imm = 0xFFFFF
+               	movq	%rsi, %r11
+               	testq	%r11, %r11
+               	jl	 <L70>
+               	cvtsi2sd	%r11, %xmm2
+               	jmp	 <L71>
+<L70>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2sd	%r11, %xmm2
                	addsd	%xmm2, %xmm2
-<L70>:
-               	movsd	%xmm2, %xmm3            # xmm3 = xmm2[0],xmm3[1]
-               	subsd	, %xmm3 <corpus.cases.call.call_mixed.checksum+0xea8>
-               	movsd	%xmm3, %xmm7            # xmm7 = xmm3[0],xmm7[1]
-               	divsd	, %xmm7 <corpus.cases.call.call_mixed.checksum+0xeb4>
-               	leaq	0x60(%r12), %rsi
-               	movq	(%rsi), %r15
-               	leaq	0x68(%r12), %rsi
-               	movq	(%rsi), %rdi
-               	andq	$0xfff, %rdi            # imm = 0xFFF
-               	movq	%rdi, %r11
-               	testq	%r11, %r11
-               	jl	 <L71>
-               	cvtsi2ss	%r11, %xmm2
-               	jmp	 <L72>
 <L71>:
-               	movq	%r11, %r10
-               	shrq	%r10
-               	andq	$0x1, %r11
-               	orq	%r10, %r11
-               	cvtsi2ss	%r11, %xmm2
-               	addss	%xmm2, %xmm2
+               	movsd	%xmm2, %xmm4            # xmm4 = xmm2[0],xmm4[1]
+               	subsd	, %xmm4 <corpus.cases.call.call_mixed.checksum+0xfc7>
+               	movsd	%xmm4, %xmm14           # xmm14 = xmm4[0],xmm14[1]
+               	divsd	, %xmm14 <corpus.cases.call.call_mixed.checksum+0xfd5>
+               	movsd	%xmm14, -0x360(%rbp)
+               	leaq	0x88(%r12), %rdx
+               	movq	(%rdx), %r8
+               	movq	%r8, -0x198(%rbp)
+               	leaq	0x98(%r12), %rdx
+               	movq	(%rdx), %rdi
+               	callq	 <L72>
 <L72>:
-               	movss	%xmm2, %xmm3            # xmm3 = xmm2[0],xmm3[1,2,3]
-               	subss	, %xmm3 <corpus.cases.call.call_mixed.checksum+0xf03>
-               	movss	%xmm3, %xmm11           # xmm11 = xmm3[0],xmm11[1,2,3]
-               	divss	, %xmm11 <corpus.cases.call.call_mixed.checksum+0xf11>
-               	leaq	0x70(%r12), %rsi
-               	movq	(%rsi), %rdi
-               	movl	%edi, %r8d
-               	movq	%r8, -0x180(%rbp)
-               	leaq	0x78(%r12), %rsi
-               	movq	(%rsi), %rdi
-               	andq	$0xfffff, %rdi          # imm = 0xFFFFF
-               	movq	%rdi, %r11
+               	movss	%xmm0, -0x370(%rbp)
+               	leaq	0xa8(%r12), %rdx
+               	movq	(%rdx), %rsi
+               	movb	%sil, %r8b
+               	movq	%r8, -0x1a0(%rbp)
+               	leaq	0xb8(%r12), %rdx
+               	movq	(%rdx), %rsi
+               	andq	$0xfffff, %rsi          # imm = 0xFFFFF
+               	movq	%rsi, %r11
                	testq	%r11, %r11
                	jl	 <L73>
                	cvtsi2sd	%r11, %xmm2
@@ -1201,243 +1213,79 @@ Disassembly of section .text:
                	cvtsi2sd	%r11, %xmm2
                	addsd	%xmm2, %xmm2
 <L74>:
-               	movsd	%xmm2, %xmm3            # xmm3 = xmm2[0],xmm3[1]
-               	subsd	, %xmm3 <corpus.cases.call.call_mixed.checksum+0xf6a>
-               	movsd	%xmm3, %xmm12           # xmm12 = xmm3[0],xmm12[1]
-               	divsd	, %xmm12 <corpus.cases.call.call_mixed.checksum+0xf78>
-               	leaq	0x8(%r12), %rsi
-               	movq	(%rsi), %r8
-               	movq	%r8, -0x188(%rbp)
-               	movq	-0x178(%rbp), %r8
-               	movq	%r8, %rdi
-               	movl	%eax, %esi
-               	movups	-0x1c0(%rbp), %xmm2
-               	movss	%xmm4, %xmm3            # xmm3 = xmm4[0],xmm3[1,2,3]
-               	movups	-0x1d0(%rbp), %xmm4
-               	movq	%rbx, %r8
-               	movq	-0x170(%rbp), %r9
-               	movq	-0x1e0(%rbp), %r11
-               	movq	%r11, (%rsp)
-               	movq	%r15, 0x8(%rsp)
-               	movsd	%xmm11, 0x10(%rsp)
-               	movq	-0x180(%rbp), %r10
-               	movq	%r10, 0x18(%rsp)
-               	movsd	%xmm12, 0x20(%rsp)
-               	movq	-0x188(%rbp), %r10
-               	movq	%r10, 0x28(%rsp)
+               	movsd	%xmm2, %xmm4            # xmm4 = xmm2[0],xmm4[1]
+               	subsd	, %xmm4 <corpus.cases.call.call_mixed.checksum+0x1067>
+               	movsd	%xmm4, %xmm14           # xmm14 = xmm4[0],xmm14[1]
+               	divsd	, %xmm14 <corpus.cases.call.call_mixed.checksum+0x1075>
+               	movsd	%xmm14, -0x380(%rbp)
+               	leaq	0x10(%r12), %rdx
+               	movq	(%rdx), %r8
+               	movq	%r8, -0x1a8(%rbp)
+               	leaq	0x20(%r12), %rdx
+               	movq	(%rdx), %rdi
                	callq	 <L75>
 <L75>:
-               	leaq	0x18(%r12), %rcx
-               	movq	(%rcx), %rdx
-               	andq	$0xfff, %rdx            # imm = 0xFFF
-               	movq	%rdx, %r11
+               	movss	%xmm0, %xmm11           # xmm11 = xmm0[0],xmm11[1,2,3]
+               	leaq	0x30(%r12), %rdx
+               	movq	(%rdx), %rsi
+               	movl	%esi, %r8d
+               	movq	%r8, -0x1b0(%rbp)
+               	leaq	0x40(%r12), %rdx
+               	movq	(%rdx), %rsi
+               	andq	$0xfffff, %rsi          # imm = 0xFFFFF
+               	movq	%rsi, %r11
                	testq	%r11, %r11
                	jl	 <L76>
-               	cvtsi2ss	%r11, %xmm0
+               	cvtsi2sd	%r11, %xmm2
                	jmp	 <L77>
 <L76>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
-               	cvtsi2ss	%r11, %xmm0
-               	addss	%xmm0, %xmm0
+               	cvtsi2sd	%r11, %xmm2
+               	addsd	%xmm2, %xmm2
 <L77>:
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	subss	, %xmm1 <corpus.cases.call.call_mixed.checksum+0x1031>
-               	movss	%xmm1, %xmm0            # xmm0 = xmm1[0],xmm0[1,2,3]
-               	divss	, %xmm0 <corpus.cases.call.call_mixed.checksum+0x103d>
-               	leaq	0x28(%r12), %rcx
-               	movq	(%rcx), %rdx
-               	movl	%edx, %ecx
-               	leaq	0x38(%r12), %rdx
-               	movq	(%rdx), %rsi
-               	andq	$0xfffff, %rsi          # imm = 0xFFFFF
-               	movq	%rsi, %r11
-               	testq	%r11, %r11
-               	jl	 <L78>
-               	cvtsi2sd	%r11, %xmm1
-               	jmp	 <L79>
-<L78>:
-               	movq	%r11, %r10
-               	shrq	%r10
-               	andq	$0x1, %r11
-               	orq	%r10, %r11
-               	cvtsi2sd	%r11, %xmm1
-               	addsd	%xmm1, %xmm1
-<L79>:
-               	movsd	%xmm1, %xmm2            # xmm2 = xmm1[0],xmm2[1]
-               	subsd	, %xmm2 <corpus.cases.call.call_mixed.checksum+0x108e>
-               	movsd	%xmm2, %xmm1            # xmm1 = xmm2[0],xmm1[1]
-               	divsd	, %xmm1 <corpus.cases.call.call_mixed.checksum+0x109a>
-               	leaq	0x48(%r12), %rdx
-               	movq	(%rdx), %rbx
-               	leaq	0x58(%r12), %rdx
-               	movq	(%rdx), %rsi
-               	andq	$0xfff, %rsi            # imm = 0xFFF
-               	movq	%rsi, %r11
-               	testq	%r11, %r11
-               	jl	 <L80>
-               	cvtsi2ss	%r11, %xmm2
-               	jmp	 <L81>
-<L80>:
-               	movq	%r11, %r10
-               	shrq	%r10
-               	andq	$0x1, %r11
-               	orq	%r10, %r11
-               	cvtsi2ss	%r11, %xmm2
-               	addss	%xmm2, %xmm2
-<L81>:
-               	movss	%xmm2, %xmm3            # xmm3 = xmm2[0],xmm3[1,2,3]
-               	subss	, %xmm3 <corpus.cases.call.call_mixed.checksum+0x10e9>
-               	movss	%xmm3, %xmm4            # xmm4 = xmm3[0],xmm4[1,2,3]
-               	divss	, %xmm4 <corpus.cases.call.call_mixed.checksum+0x10f5>
-               	leaq	0x68(%r12), %rdx
-               	movq	(%rdx), %rsi
-               	movw	%si, %r15w
-               	leaq	0x78(%r12), %rdx
-               	movq	(%rdx), %rsi
-               	andq	$0xfffff, %rsi          # imm = 0xFFFFF
-               	movq	%rsi, %r11
-               	testq	%r11, %r11
-               	jl	 <L82>
-               	cvtsi2sd	%r11, %xmm2
-               	jmp	 <L83>
-<L82>:
-               	movq	%r11, %r10
-               	shrq	%r10
-               	andq	$0x1, %r11
-               	orq	%r10, %r11
-               	cvtsi2sd	%r11, %xmm2
-               	addsd	%xmm2, %xmm2
-<L83>:
-               	movsd	%xmm2, %xmm3            # xmm3 = xmm2[0],xmm3[1]
-               	subsd	, %xmm3 <corpus.cases.call.call_mixed.checksum+0x1148>
-               	movsd	%xmm3, %xmm5            # xmm5 = xmm3[0],xmm5[1]
-               	divsd	, %xmm5 <corpus.cases.call.call_mixed.checksum+0x1154>
-               	leaq	0x88(%r12), %rdx
-               	movq	(%rdx), %r8
-               	movq	%r8, -0x190(%rbp)
-               	leaq	0x98(%r12), %rdx
-               	movq	(%rdx), %rsi
-               	andq	$0xfff, %rsi            # imm = 0xFFF
-               	movq	%rsi, %r11
-               	testq	%r11, %r11
-               	jl	 <L84>
-               	cvtsi2ss	%r11, %xmm2
-               	jmp	 <L85>
-<L84>:
-               	movq	%r11, %r10
-               	shrq	%r10
-               	andq	$0x1, %r11
-               	orq	%r10, %r11
-               	cvtsi2ss	%r11, %xmm2
-               	addss	%xmm2, %xmm2
-<L85>:
-               	movss	%xmm2, %xmm3            # xmm3 = xmm2[0],xmm3[1,2,3]
-               	subss	, %xmm3 <corpus.cases.call.call_mixed.checksum+0x11b0>
-               	movss	%xmm3, %xmm6            # xmm6 = xmm3[0],xmm6[1,2,3]
-               	divss	, %xmm6 <corpus.cases.call.call_mixed.checksum+0x11bc>
-               	leaq	0xa8(%r12), %rdx
-               	movq	(%rdx), %rsi
-               	movb	%sil, %r8b
-               	movq	%r8, -0x198(%rbp)
-               	leaq	0xb8(%r12), %rdx
-               	movq	(%rdx), %rsi
-               	andq	$0xfffff, %rsi          # imm = 0xFFFFF
-               	movq	%rsi, %r11
-               	testq	%r11, %r11
-               	jl	 <L86>
-               	cvtsi2sd	%r11, %xmm2
-               	jmp	 <L87>
-<L86>:
-               	movq	%r11, %r10
-               	shrq	%r10
-               	andq	$0x1, %r11
-               	orq	%r10, %r11
-               	cvtsi2sd	%r11, %xmm2
-               	addsd	%xmm2, %xmm2
-<L87>:
-               	movsd	%xmm2, %xmm3            # xmm3 = xmm2[0],xmm3[1]
-               	subsd	, %xmm3 <corpus.cases.call.call_mixed.checksum+0x121b>
-               	movsd	%xmm3, %xmm7            # xmm7 = xmm3[0],xmm7[1]
-               	divsd	, %xmm7 <corpus.cases.call.call_mixed.checksum+0x1227>
-               	leaq	0x10(%r12), %rdx
-               	movq	(%rdx), %r8
-               	movq	%r8, -0x1a0(%rbp)
-               	leaq	0x20(%r12), %rdx
-               	movq	(%rdx), %rsi
-               	andq	$0xfff, %rsi            # imm = 0xFFF
-               	movq	%rsi, %r11
-               	testq	%r11, %r11
-               	jl	 <L88>
-               	cvtsi2ss	%r11, %xmm2
-               	jmp	 <L89>
-<L88>:
-               	movq	%r11, %r10
-               	shrq	%r10
-               	andq	$0x1, %r11
-               	orq	%r10, %r11
-               	cvtsi2ss	%r11, %xmm2
-               	addss	%xmm2, %xmm2
-<L89>:
-               	movss	%xmm2, %xmm3            # xmm3 = xmm2[0],xmm3[1,2,3]
-               	subss	, %xmm3 <corpus.cases.call.call_mixed.checksum+0x127d>
-               	movss	%xmm3, %xmm11           # xmm11 = xmm3[0],xmm11[1,2,3]
-               	divss	, %xmm11 <corpus.cases.call.call_mixed.checksum+0x128b>
-               	leaq	0x30(%r12), %rdx
-               	movq	(%rdx), %rsi
-               	movl	%esi, %r8d
-               	movq	%r8, -0x1a8(%rbp)
-               	leaq	0x40(%r12), %rdx
-               	movq	(%rdx), %rsi
-               	andq	$0xfffff, %rsi          # imm = 0xFFFFF
-               	movq	%rsi, %r11
-               	testq	%r11, %r11
-               	jl	 <L90>
-               	cvtsi2sd	%r11, %xmm2
-               	jmp	 <L91>
-<L90>:
-               	movq	%r11, %r10
-               	shrq	%r10
-               	andq	$0x1, %r11
-               	orq	%r10, %r11
-               	cvtsi2sd	%r11, %xmm2
-               	addsd	%xmm2, %xmm2
-<L91>:
-               	movsd	%xmm2, %xmm3            # xmm3 = xmm2[0],xmm3[1]
-               	subsd	, %xmm3 <corpus.cases.call.call_mixed.checksum+0x12e4>
-               	movsd	%xmm3, %xmm12           # xmm12 = xmm3[0],xmm12[1]
-               	divsd	, %xmm12 <corpus.cases.call.call_mixed.checksum+0x12f2>
-               	movq	%rax, %rdi
-               	movl	%ecx, %esi
-               	movups	-0x1c0(%rbp), %xmm2
-               	movq	%rbx, %rdx
-               	movss	%xmm4, %xmm3            # xmm3 = xmm4[0],xmm3[1,2,3]
-               	movq	%r15, %rcx
-               	movups	-0x1d0(%rbp), %xmm4
-               	movq	-0x190(%rbp), %r8
-               	movq	-0x198(%rbp), %r9
-               	movq	-0x1e0(%rbp), %r11
+               	movsd	%xmm2, %xmm4            # xmm4 = xmm2[0],xmm4[1]
+               	subsd	, %xmm4 <corpus.cases.call.call_mixed.checksum+0x10f8>
+               	movsd	%xmm4, %xmm12           # xmm12 = xmm4[0],xmm12[1]
+               	divsd	, %xmm12 <corpus.cases.call.call_mixed.checksum+0x1106>
+               	movq	%rbx, %rdi
+               	movss	-0x320(%rbp), %xmm0
+               	movl	%r15d, %esi
+               	movsd	-0x338(%rbp), %xmm1
+               	movups	-0x280(%rbp), %xmm2
+               	movq	-0x328(%rbp), %r8
+               	movq	%r8, %rdx
+               	movss	-0x348(%rbp), %xmm3
+               	movq	-0x350(%rbp), %r8
+               	movq	%r8, %rcx
+               	movups	-0x290(%rbp), %xmm4
+               	movsd	-0x360(%rbp), %xmm5
+               	movq	-0x198(%rbp), %r8
+               	movss	-0x370(%rbp), %xmm6
+               	movq	-0x1a0(%rbp), %r9
+               	movsd	-0x380(%rbp), %xmm7
+               	movq	-0x2a0(%rbp), %r11
                	movq	%r11, (%rsp)
-               	movq	-0x1a0(%rbp), %r10
+               	movq	-0x1a8(%rbp), %r10
                	movq	%r10, 0x8(%rsp)
                	movsd	%xmm11, 0x10(%rsp)
-               	movq	-0x1a8(%rbp), %r10
+               	movq	-0x1b0(%rbp), %r10
                	movq	%r10, 0x18(%rsp)
                	movsd	%xmm12, 0x20(%rsp)
                	movq	%r14, 0x28(%rsp)
-               	callq	 <L92>
-<L92>:
+               	callq	 <L78>
+<L78>:
                	movq	%r13, %rdi
                	movq	%rax, %rsi
-               	callq	 <L93>
-<L93>:
-               	movq	-0x1e8(%rbp), %rbx
-               	movq	-0x1f0(%rbp), %r12
-               	movq	-0x1f8(%rbp), %r13
-               	movq	-0x200(%rbp), %r14
-               	movq	-0x208(%rbp), %r15
+               	callq	 <L79>
+<L79>:
+               	movq	-0x388(%rbp), %rbx
+               	movq	-0x390(%rbp), %r12
+               	movq	-0x398(%rbp), %r13
+               	movq	-0x3a0(%rbp), %r14
+               	movq	-0x3a8(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-linux/cmp/short_circuit.dis
+++ b/test/golden/x86_64-linux/cmp/short_circuit.dis
@@ -176,27 +176,30 @@ Disassembly of section .text:
                	movq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x1a0>
                	leaq	, %rcx <corpus.cases.cmp.short_circuit.checksum+0x1a7>
                	movq	%rax, (%rcx)
-               	movl	$0x1, %esi
-               	xorl	%r12d, %esi
-               	movq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x1b9>
-               	addq	$0x1, %rax
-               	movq	%rax,  <corpus.cases.cmp.short_circuit.checksum+0x1c4>
-               	leaq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x1cb>
-               	movq	(%rax), %rcx
+               	movl	$0x1, %eax
+               	xorl	%r12d, %eax
+               	movq	, %rcx <corpus.cases.cmp.short_circuit.checksum+0x1b9>
                	addq	$0x1, %rcx
-               	movq	%rcx, (%rax)
-               	movq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x1dc>
-               	leaq	, %rcx <corpus.cases.cmp.short_circuit.checksum+0x1e3>
-               	movq	%rax, (%rcx)
+               	movq	%rcx,  <corpus.cases.cmp.short_circuit.checksum+0x1c4>
+               	leaq	, %rcx <corpus.cases.cmp.short_circuit.checksum+0x1cb>
+               	movq	(%rcx), %rdx
+               	addq	$0x1, %rdx
+               	movq	%rdx, (%rcx)
+               	movq	, %rcx <corpus.cases.cmp.short_circuit.checksum+0x1dc>
+               	leaq	, %rdx <corpus.cases.cmp.short_circuit.checksum+0x1e3>
+               	movq	%rcx, (%rdx)
+               	cmpb	$0x1, %al
+               	sete	%sil
+               	movzbq	%sil, %rsi
                	movq	%r14, %rdi
                	callq	 <L11>
 <L11>:
-               	movq	, %rsi <corpus.cases.cmp.short_circuit.checksum+0x1f5>
+               	movq	, %rsi <corpus.cases.cmp.short_circuit.checksum+0x200>
                	movq	%rax, %rdi
                	callq	 <L12>
 <L12>:
-               	leaq	, %rbx <corpus.cases.cmp.short_circuit.checksum+0x204>
-               	leaq	, %r13 <corpus.cases.cmp.short_circuit.checksum+0x20b>
+               	leaq	, %rbx <corpus.cases.cmp.short_circuit.checksum+0x20f>
+               	leaq	, %r13 <corpus.cases.cmp.short_circuit.checksum+0x216>
                	movq	%rax, %r14
                	movq	$0x0, %r15
                	cmpq	$0x4, %r15
@@ -218,9 +221,9 @@ Disassembly of section .text:
                	cmpq	$0x4, %r15
                	jb	 <L13>
 <L16>:
-               	movq	$0x0,  <corpus.cases.cmp.short_circuit.checksum+0x25f>
-               	leaq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x266>
-               	leaq	, %rcx <corpus.cases.cmp.short_circuit.checksum+0x26d>
+               	movq	$0x0,  <corpus.cases.cmp.short_circuit.checksum+0x26a>
+               	leaq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x271>
+               	leaq	, %rcx <corpus.cases.cmp.short_circuit.checksum+0x278>
                	movq	$0x0, %rdx
                	cmpq	$0x4, %rdx
                	jb	 <L17>
@@ -234,26 +237,26 @@ Disassembly of section .text:
                	cmpq	$0x4, %rdx
                	jb	 <L17>
 <L18>:
-               	movq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x2ae>
+               	movq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x2b9>
                	addq	$0x1, %rax
-               	movq	%rax,  <corpus.cases.cmp.short_circuit.checksum+0x2b9>
-               	leaq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x2c0>
+               	movq	%rax,  <corpus.cases.cmp.short_circuit.checksum+0x2c4>
+               	leaq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x2cb>
                	movq	(%rax), %rcx
                	addq	$0x1, %rcx
                	movq	%rcx, (%rax)
-               	movq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x2d1>
-               	leaq	, %rcx <corpus.cases.cmp.short_circuit.checksum+0x2d8>
+               	movq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x2dc>
+               	leaq	, %rcx <corpus.cases.cmp.short_circuit.checksum+0x2e3>
                	movq	%rax, (%rcx)
                	movq	%r14, %rdi
                	movq	$0x1, %rsi
                	callq	 <L19>
 <L19>:
-               	movq	, %rsi <corpus.cases.cmp.short_circuit.checksum+0x2f1>
+               	movq	, %rsi <corpus.cases.cmp.short_circuit.checksum+0x2fc>
                	movq	%rax, %rdi
                	callq	 <L20>
 <L20>:
-               	leaq	, %rbx <corpus.cases.cmp.short_circuit.checksum+0x300>
-               	leaq	, %r13 <corpus.cases.cmp.short_circuit.checksum+0x307>
+               	leaq	, %rbx <corpus.cases.cmp.short_circuit.checksum+0x30b>
+               	leaq	, %r13 <corpus.cases.cmp.short_circuit.checksum+0x312>
                	movq	%rax, %r14
                	movq	$0x0, %r15
                	cmpq	$0x4, %r15
@@ -275,9 +278,9 @@ Disassembly of section .text:
                	cmpq	$0x4, %r15
                	jb	 <L21>
 <L24>:
-               	movq	$0x0,  <corpus.cases.cmp.short_circuit.checksum+0x35b>
-               	leaq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x362>
-               	leaq	, %rcx <corpus.cases.cmp.short_circuit.checksum+0x369>
+               	movq	$0x0,  <corpus.cases.cmp.short_circuit.checksum+0x366>
+               	leaq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x36d>
+               	leaq	, %rcx <corpus.cases.cmp.short_circuit.checksum+0x374>
                	movq	$0x0, %rdx
                	cmpq	$0x4, %rdx
                	jb	 <L25>
@@ -291,209 +294,151 @@ Disassembly of section .text:
                	cmpq	$0x4, %rdx
                	jb	 <L25>
 <L26>:
-               	movq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x3aa>
-               	addq	$0x1, %rax
-               	movq	%rax,  <corpus.cases.cmp.short_circuit.checksum+0x3b5>
-               	leaq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x3bc>
-               	movq	(%rax), %rcx
-               	addq	$0x1, %rcx
-               	movq	%rcx, (%rax)
-               	movq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x3cd>
-               	leaq	, %rcx <corpus.cases.cmp.short_circuit.checksum+0x3d4>
-               	movq	%rax, (%rcx)
-               	movl	$0x1, %esi
-               	xorl	%r12d, %esi
-               	movq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x3e6>
-               	addq	$0x1, %rax
-               	movq	%rax,  <corpus.cases.cmp.short_circuit.checksum+0x3f1>
-               	leaq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x3f8>
-               	movq	(%rax), %rcx
-               	addq	$0x1, %rcx
-               	movq	%rcx, (%rax)
-               	movq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x409>
-               	leaq	, %rcx <corpus.cases.cmp.short_circuit.checksum+0x410>
-               	movq	%rax, (%rcx)
-               	movq	%r14, %rdi
+               	movq	$0x0, %rdi
+               	movq	$0x0, %rsi
                	callq	 <L27>
 <L27>:
-               	movq	, %rsi <corpus.cases.cmp.short_circuit.checksum+0x422>
-               	movq	%rax, %rdi
-               	callq	 <L28>
+               	cmpb	$0x1, %al
+               	sete	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L28>
+               	movl	$0x1, %eax
+               	xorl	%r12d, %eax
+               	movq	, %rdx <corpus.cases.cmp.short_circuit.checksum+0x3e2>
+               	addq	$0x1, %rdx
+               	movq	%rdx,  <corpus.cases.cmp.short_circuit.checksum+0x3ed>
+               	leaq	, %rdx <corpus.cases.cmp.short_circuit.checksum+0x3f4>
+               	movq	(%rdx), %rsi
+               	addq	$0x1, %rsi
+               	movq	%rsi, (%rdx)
+               	movq	, %rdx <corpus.cases.cmp.short_circuit.checksum+0x405>
+               	leaq	, %rsi <corpus.cases.cmp.short_circuit.checksum+0x40c>
+               	movq	%rdx, (%rsi)
+               	cmpb	$0x1, %al
+               	sete	%dl
+               	movzbq	%dl, %rdx
+               	jmp	 <L29>
 <L28>:
-               	leaq	, %rbx <corpus.cases.cmp.short_circuit.checksum+0x431>
-               	leaq	, %r13 <corpus.cases.cmp.short_circuit.checksum+0x438>
-               	movq	%rax, %r14
-               	movq	$0x0, %r15
-               	cmpq	$0x4, %r15
-               	jb	 <L29>
-               	jmp	 <L32>
+               	movq	%rcx, %rdx
 <L29>:
-               	leaq	(%rbx,%r15,8), %rax
-               	movq	(%rax), %rsi
                	movq	%r14, %rdi
+               	movq	%rdx, %rsi
                	callq	 <L30>
 <L30>:
-               	leaq	(%r13,%r15,8), %rcx
-               	movq	(%rcx), %rsi
+               	movq	, %rsi <corpus.cases.cmp.short_circuit.checksum+0x433>
                	movq	%rax, %rdi
                	callq	 <L31>
 <L31>:
-               	addq	$0x1, %r15
-               	movq	%rax, %r14
-               	cmpq	$0x4, %r15
-               	jb	 <L29>
-<L32>:
-               	movq	$0x0,  <corpus.cases.cmp.short_circuit.checksum+0x48c>
-               	leaq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x493>
-               	leaq	, %rcx <corpus.cases.cmp.short_circuit.checksum+0x49a>
-               	movq	$0x0, %rdx
-               	cmpq	$0x4, %rdx
-               	jb	 <L33>
-               	jmp	 <L34>
-<L33>:
-               	leaq	(%rax,%rdx,8), %rsi
-               	movq	$0x0, (%rsi)
-               	leaq	(%rcx,%rdx,8), %rsi
-               	movq	$0x0, (%rsi)
-               	addq	$0x1, %rdx
-               	cmpq	$0x4, %rdx
-               	jb	 <L33>
-<L34>:
-               	movq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x4db>
-               	addq	$0x1, %rax
-               	movq	%rax,  <corpus.cases.cmp.short_circuit.checksum+0x4e6>
-               	leaq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x4ed>
-               	movq	(%rax), %rcx
-               	addq	$0x1, %rcx
-               	movq	%rcx, (%rax)
-               	movq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x4fe>
-               	leaq	, %rcx <corpus.cases.cmp.short_circuit.checksum+0x505>
-               	movq	%rax, (%rcx)
-               	movq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x50f>
-               	addq	$0x1, %rax
-               	movq	%rax,  <corpus.cases.cmp.short_circuit.checksum+0x51a>
-               	leaq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x521>
-               	movq	(%rax), %rcx
-               	addq	$0x1, %rcx
-               	movq	%rcx, (%rax)
-               	movq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x532>
-               	leaq	, %rcx <corpus.cases.cmp.short_circuit.checksum+0x539>
-               	movq	%rax, (%rcx)
-               	movq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x543>
-               	addq	$0x1, %rax
-               	movq	%rax,  <corpus.cases.cmp.short_circuit.checksum+0x54e>
-               	leaq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x555>
-               	movq	(%rax), %rcx
-               	addq	$0x1, %rcx
-               	movq	%rcx, (%rax)
-               	movq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x566>
-               	leaq	, %rcx <corpus.cases.cmp.short_circuit.checksum+0x56d>
-               	movq	%rax, (%rcx)
-               	testb	%r12b, %r12b
-               	jne	 <L35>
-               	movq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x580>
-               	addq	$0x1, %rax
-               	movq	%rax,  <corpus.cases.cmp.short_circuit.checksum+0x58b>
-               	leaq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x592>
-               	movq	(%rax), %rcx
-               	addq	$0x1, %rcx
-               	movq	%rcx, (%rax)
-               	movq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x5a3>
-               	leaq	, %rcx <corpus.cases.cmp.short_circuit.checksum+0x5aa>
-               	movq	%rax, (%rcx)
-               	movq	$0x1, %rax
-               	jmp	 <L36>
-<L35>:
-               	movq	%r12, %rax
-<L36>:
-               	movq	%r14, %rdi
-               	movq	%rax, %rsi
-               	callq	 <L37>
-<L37>:
-               	movq	, %rsi <corpus.cases.cmp.short_circuit.checksum+0x5ce>
-               	movq	%rax, %rdi
-               	callq	 <L38>
-<L38>:
-               	leaq	, %rbx <corpus.cases.cmp.short_circuit.checksum+0x5dd>
-               	leaq	, %r13 <corpus.cases.cmp.short_circuit.checksum+0x5e4>
+               	leaq	, %rbx <corpus.cases.cmp.short_circuit.checksum+0x442>
+               	leaq	, %r13 <corpus.cases.cmp.short_circuit.checksum+0x449>
                	movq	%rax, %r14
                	movq	$0x0, %r15
                	cmpq	$0x4, %r15
-               	jb	 <L39>
-               	jmp	 <L42>
-<L39>:
+               	jb	 <L32>
+               	jmp	 <L35>
+<L32>:
                	leaq	(%rbx,%r15,8), %rax
                	movq	(%rax), %rsi
                	movq	%r14, %rdi
-               	callq	 <L40>
-<L40>:
+               	callq	 <L33>
+<L33>:
                	leaq	(%r13,%r15,8), %rcx
                	movq	(%rcx), %rsi
                	movq	%rax, %rdi
-               	callq	 <L41>
-<L41>:
+               	callq	 <L34>
+<L34>:
                	addq	$0x1, %r15
                	movq	%rax, %r14
                	cmpq	$0x4, %r15
-               	jb	 <L39>
-<L42>:
-               	movq	$0x0,  <corpus.cases.cmp.short_circuit.checksum+0x638>
-               	leaq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x63f>
-               	leaq	, %rcx <corpus.cases.cmp.short_circuit.checksum+0x646>
+               	jb	 <L32>
+<L35>:
+               	movq	$0x0,  <corpus.cases.cmp.short_circuit.checksum+0x49d>
+               	leaq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x4a4>
+               	leaq	, %rcx <corpus.cases.cmp.short_circuit.checksum+0x4ab>
                	movq	$0x0, %rdx
                	cmpq	$0x4, %rdx
-               	jb	 <L43>
-               	jmp	 <L44>
-<L43>:
+               	jb	 <L36>
+               	jmp	 <L37>
+<L36>:
                	leaq	(%rax,%rdx,8), %rsi
                	movq	$0x0, (%rsi)
                	leaq	(%rcx,%rdx,8), %rsi
                	movq	$0x0, (%rsi)
                	addq	$0x1, %rdx
                	cmpq	$0x4, %rdx
-               	jb	 <L43>
+               	jb	 <L36>
+<L37>:
+               	movq	$0x0, %rdi
+               	movq	$0x0, %rsi
+               	callq	 <L38>
+<L38>:
+               	cmpb	$0x1, %al
+               	sete	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L39>
+               	movq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x511>
+               	addq	$0x1, %rax
+               	movq	%rax,  <corpus.cases.cmp.short_circuit.checksum+0x51c>
+               	leaq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x523>
+               	movq	(%rax), %rdx
+               	addq	$0x1, %rdx
+               	movq	%rdx, (%rax)
+               	movq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x534>
+               	leaq	, %rdx <corpus.cases.cmp.short_circuit.checksum+0x53b>
+               	movq	%rax, (%rdx)
+               	movq	$0x1, %rax
+               	jmp	 <L40>
+<L39>:
+               	movq	%rcx, %rax
+<L40>:
+               	testb	%al, %al
+               	jne	 <L41>
+               	jmp	 <L44>
+<L41>:
+               	movq	, %rcx <corpus.cases.cmp.short_circuit.checksum+0x561>
+               	addq	$0x1, %rcx
+               	movq	%rcx,  <corpus.cases.cmp.short_circuit.checksum+0x56c>
+               	leaq	, %rcx <corpus.cases.cmp.short_circuit.checksum+0x573>
+               	movq	(%rcx), %rdx
+               	addq	$0x1, %rdx
+               	movq	%rdx, (%rcx)
+               	movq	, %rcx <corpus.cases.cmp.short_circuit.checksum+0x584>
+               	leaq	, %rdx <corpus.cases.cmp.short_circuit.checksum+0x58b>
+               	movq	%rcx, (%rdx)
+               	cmpb	$0x1, %r12b
+               	sete	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L42>
+               	movq	, %rdx <corpus.cases.cmp.short_circuit.checksum+0x5a8>
+               	addq	$0x1, %rdx
+               	movq	%rdx,  <corpus.cases.cmp.short_circuit.checksum+0x5b3>
+               	leaq	, %rdx <corpus.cases.cmp.short_circuit.checksum+0x5ba>
+               	movq	(%rdx), %rsi
+               	addq	$0x1, %rsi
+               	movq	%rsi, (%rdx)
+               	movq	, %rdx <corpus.cases.cmp.short_circuit.checksum+0x5cb>
+               	leaq	, %rsi <corpus.cases.cmp.short_circuit.checksum+0x5d2>
+               	movq	%rdx, (%rsi)
+               	movq	$0x1, %rdx
+               	jmp	 <L43>
+<L42>:
+               	movq	%rcx, %rdx
+<L43>:
+               	movq	%rdx, %rax
 <L44>:
-               	movq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x687>
-               	addq	$0x1, %rax
-               	movq	%rax,  <corpus.cases.cmp.short_circuit.checksum+0x692>
-               	leaq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x699>
-               	movq	(%rax), %rcx
-               	addq	$0x1, %rcx
-               	movq	%rcx, (%rax)
-               	movq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x6aa>
-               	leaq	, %rcx <corpus.cases.cmp.short_circuit.checksum+0x6b1>
-               	movq	%rax, (%rcx)
-               	movq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x6bb>
-               	addq	$0x1, %rax
-               	movq	%rax,  <corpus.cases.cmp.short_circuit.checksum+0x6c6>
-               	leaq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x6cd>
-               	movq	(%rax), %rcx
-               	addq	$0x1, %rcx
-               	movq	%rcx, (%rax)
-               	movq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x6de>
-               	leaq	, %rcx <corpus.cases.cmp.short_circuit.checksum+0x6e5>
-               	movq	%rax, (%rcx)
-               	movl	$0x1, %esi
-               	xorl	%r12d, %esi
-               	movq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x6f7>
-               	addq	$0x1, %rax
-               	movq	%rax,  <corpus.cases.cmp.short_circuit.checksum+0x702>
-               	leaq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x709>
-               	movq	(%rax), %rcx
-               	addq	$0x1, %rcx
-               	movq	%rcx, (%rax)
-               	movq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x71a>
-               	leaq	, %rcx <corpus.cases.cmp.short_circuit.checksum+0x721>
-               	movq	%rax, (%rcx)
                	movq	%r14, %rdi
+               	movq	%rax, %rsi
                	callq	 <L45>
 <L45>:
-               	movq	, %rsi <corpus.cases.cmp.short_circuit.checksum+0x733>
+               	movq	, %rsi <corpus.cases.cmp.short_circuit.checksum+0x5f9>
                	movq	%rax, %rdi
                	callq	 <L46>
 <L46>:
-               	leaq	, %rbx <corpus.cases.cmp.short_circuit.checksum+0x742>
-               	leaq	, %r13 <corpus.cases.cmp.short_circuit.checksum+0x749>
+               	leaq	, %rbx <corpus.cases.cmp.short_circuit.checksum+0x608>
+               	leaq	, %r13 <corpus.cases.cmp.short_circuit.checksum+0x60f>
                	movq	%rax, %r14
                	movq	$0x0, %r15
                	cmpq	$0x4, %r15
@@ -515,9 +460,9 @@ Disassembly of section .text:
                	cmpq	$0x4, %r15
                	jb	 <L47>
 <L50>:
-               	movq	$0x0,  <corpus.cases.cmp.short_circuit.checksum+0x79d>
-               	leaq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x7a4>
-               	leaq	, %rcx <corpus.cases.cmp.short_circuit.checksum+0x7ab>
+               	movq	$0x0,  <corpus.cases.cmp.short_circuit.checksum+0x663>
+               	leaq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x66a>
+               	leaq	, %rcx <corpus.cases.cmp.short_circuit.checksum+0x671>
                	movq	$0x0, %rdx
                	cmpq	$0x4, %rdx
                	jb	 <L51>
@@ -531,73 +476,181 @@ Disassembly of section .text:
                	cmpq	$0x4, %rdx
                	jb	 <L51>
 <L52>:
-               	movq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x7ec>
-               	addq	$0x1, %rax
-               	movq	%rax,  <corpus.cases.cmp.short_circuit.checksum+0x7f7>
-               	leaq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x7fe>
-               	movq	(%rax), %rcx
-               	addq	$0x1, %rcx
-               	movq	%rcx, (%rax)
-               	movq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x80f>
-               	leaq	, %rcx <corpus.cases.cmp.short_circuit.checksum+0x816>
-               	movq	%rax, (%rcx)
-               	movq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x820>
-               	addq	$0x1, %rax
-               	movq	%rax,  <corpus.cases.cmp.short_circuit.checksum+0x82b>
-               	leaq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x832>
-               	movq	(%rax), %rcx
-               	addq	$0x1, %rcx
-               	movq	%rcx, (%rax)
-               	movq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x843>
-               	leaq	, %rcx <corpus.cases.cmp.short_circuit.checksum+0x84a>
-               	movq	%rax, (%rcx)
-               	testb	%r12b, %r12b
-               	jne	 <L53>
-               	jmp	 <L54>
+               	movq	$0x0, %rdi
+               	movq	$0x1, %rsi
+               	callq	 <L53>
 <L53>:
-               	movq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x862>
+               	cmpb	$0x1, %al
+               	sete	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L54>
+               	movq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x6d7>
                	addq	$0x1, %rax
-               	movq	%rax,  <corpus.cases.cmp.short_circuit.checksum+0x86d>
-               	leaq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x874>
-               	movq	(%rax), %rcx
-               	addq	$0x1, %rcx
-               	movq	%rcx, (%rax)
-               	movq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x885>
-               	leaq	, %rcx <corpus.cases.cmp.short_circuit.checksum+0x88c>
-               	movq	%rax, (%rcx)
-               	movq	$0x1, %r12
+               	movq	%rax,  <corpus.cases.cmp.short_circuit.checksum+0x6e2>
+               	leaq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x6e9>
+               	movq	(%rax), %rdx
+               	addq	$0x1, %rdx
+               	movq	%rdx, (%rax)
+               	movq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x6fa>
+               	leaq	, %rdx <corpus.cases.cmp.short_circuit.checksum+0x701>
+               	movq	%rax, (%rdx)
+               	movq	$0x1, %rax
+               	jmp	 <L55>
 <L54>:
-               	movq	%r14, %rdi
-               	movq	%r12, %rsi
-               	callq	 <L55>
+               	movq	%rcx, %rax
 <L55>:
-               	movq	, %rsi <corpus.cases.cmp.short_circuit.checksum+0x8a8>
-               	movq	%rax, %rdi
-               	callq	 <L56>
+               	testb	%al, %al
+               	jne	 <L56>
+               	jmp	 <L57>
 <L56>:
-               	leaq	, %rbx <corpus.cases.cmp.short_circuit.checksum+0x8b7>
-               	leaq	, %r12 <corpus.cases.cmp.short_circuit.checksum+0x8be>
-               	movq	%rax, %r13
-               	movq	$0x0, %r14
-               	cmpq	$0x4, %r14
-               	jb	 <L57>
-               	jmp	 <L60>
+               	movq	, %rcx <corpus.cases.cmp.short_circuit.checksum+0x727>
+               	addq	$0x1, %rcx
+               	movq	%rcx,  <corpus.cases.cmp.short_circuit.checksum+0x732>
+               	leaq	, %rcx <corpus.cases.cmp.short_circuit.checksum+0x739>
+               	movq	(%rcx), %rdx
+               	addq	$0x1, %rdx
+               	movq	%rdx, (%rcx)
+               	movq	, %rcx <corpus.cases.cmp.short_circuit.checksum+0x74a>
+               	leaq	, %rdx <corpus.cases.cmp.short_circuit.checksum+0x751>
+               	movq	%rcx, (%rdx)
+               	movl	$0x1, %ecx
+               	xorl	%r12d, %ecx
+               	movq	, %rdx <corpus.cases.cmp.short_circuit.checksum+0x763>
+               	addq	$0x1, %rdx
+               	movq	%rdx,  <corpus.cases.cmp.short_circuit.checksum+0x76e>
+               	leaq	, %rdx <corpus.cases.cmp.short_circuit.checksum+0x775>
+               	movq	(%rdx), %rsi
+               	addq	$0x1, %rsi
+               	movq	%rsi, (%rdx)
+               	movq	, %rdx <corpus.cases.cmp.short_circuit.checksum+0x786>
+               	leaq	, %rsi <corpus.cases.cmp.short_circuit.checksum+0x78d>
+               	movq	%rdx, (%rsi)
+               	cmpb	$0x1, %cl
+               	sete	%dl
+               	movzbq	%dl, %rdx
+               	movq	%rdx, %rax
 <L57>:
-               	leaq	(%rbx,%r14,8), %rax
-               	movq	(%rax), %rsi
-               	movq	%r13, %rdi
+               	movq	%r14, %rdi
+               	movq	%rax, %rsi
                	callq	 <L58>
 <L58>:
-               	leaq	(%r12,%r14,8), %rcx
-               	movq	(%rcx), %rsi
+               	movq	, %rsi <corpus.cases.cmp.short_circuit.checksum+0x7af>
                	movq	%rax, %rdi
                	callq	 <L59>
 <L59>:
+               	leaq	, %rbx <corpus.cases.cmp.short_circuit.checksum+0x7be>
+               	leaq	, %r13 <corpus.cases.cmp.short_circuit.checksum+0x7c5>
+               	movq	%rax, %r14
+               	movq	$0x0, %r15
+               	cmpq	$0x4, %r15
+               	jb	 <L60>
+               	jmp	 <L63>
+<L60>:
+               	leaq	(%rbx,%r15,8), %rax
+               	movq	(%rax), %rsi
+               	movq	%r14, %rdi
+               	callq	 <L61>
+<L61>:
+               	leaq	(%r13,%r15,8), %rcx
+               	movq	(%rcx), %rsi
+               	movq	%rax, %rdi
+               	callq	 <L62>
+<L62>:
+               	addq	$0x1, %r15
+               	movq	%rax, %r14
+               	cmpq	$0x4, %r15
+               	jb	 <L60>
+<L63>:
+               	movq	$0x0,  <corpus.cases.cmp.short_circuit.checksum+0x819>
+               	leaq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x820>
+               	leaq	, %rcx <corpus.cases.cmp.short_circuit.checksum+0x827>
+               	movq	$0x0, %rdx
+               	cmpq	$0x4, %rdx
+               	jb	 <L64>
+               	jmp	 <L65>
+<L64>:
+               	leaq	(%rax,%rdx,8), %rsi
+               	movq	$0x0, (%rsi)
+               	leaq	(%rcx,%rdx,8), %rsi
+               	movq	$0x0, (%rsi)
+               	addq	$0x1, %rdx
+               	cmpq	$0x4, %rdx
+               	jb	 <L64>
+<L65>:
+               	movq	$0x0, %rdi
+               	movq	$0x0, %rsi
+               	callq	 <L66>
+<L66>:
+               	cmpb	$0x1, %al
+               	sete	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L67>
+               	movq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x88d>
+               	addq	$0x1, %rax
+               	movq	%rax,  <corpus.cases.cmp.short_circuit.checksum+0x898>
+               	leaq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x89f>
+               	movq	(%rax), %rdx
+               	addq	$0x1, %rdx
+               	movq	%rdx, (%rax)
+               	movq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x8b0>
+               	leaq	, %rdx <corpus.cases.cmp.short_circuit.checksum+0x8b7>
+               	movq	%rax, (%rdx)
+               	cmpb	$0x1, %r12b
+               	sete	%al
+               	movzbq	%al, %rax
+               	jmp	 <L68>
+<L67>:
+               	movq	%rcx, %rax
+<L68>:
+               	testb	%al, %al
+               	jne	 <L69>
+               	jmp	 <L70>
+<L69>:
+               	movq	, %rcx <corpus.cases.cmp.short_circuit.checksum+0x8e1>
+               	addq	$0x1, %rcx
+               	movq	%rcx,  <corpus.cases.cmp.short_circuit.checksum+0x8ec>
+               	leaq	, %rcx <corpus.cases.cmp.short_circuit.checksum+0x8f3>
+               	movq	(%rcx), %rdx
+               	addq	$0x1, %rdx
+               	movq	%rdx, (%rcx)
+               	movq	, %rcx <corpus.cases.cmp.short_circuit.checksum+0x904>
+               	leaq	, %rdx <corpus.cases.cmp.short_circuit.checksum+0x90b>
+               	movq	%rcx, (%rdx)
+               	movq	$0x1, %rax
+<L70>:
+               	movq	%r14, %rdi
+               	movq	%rax, %rsi
+               	callq	 <L71>
+<L71>:
+               	movq	, %rsi <corpus.cases.cmp.short_circuit.checksum+0x927>
+               	movq	%rax, %rdi
+               	callq	 <L72>
+<L72>:
+               	leaq	, %rbx <corpus.cases.cmp.short_circuit.checksum+0x936>
+               	leaq	, %r12 <corpus.cases.cmp.short_circuit.checksum+0x93d>
+               	movq	%rax, %r13
+               	movq	$0x0, %r14
+               	cmpq	$0x4, %r14
+               	jb	 <L73>
+               	jmp	 <L76>
+<L73>:
+               	leaq	(%rbx,%r14,8), %rax
+               	movq	(%rax), %rsi
+               	movq	%r13, %rdi
+               	callq	 <L74>
+<L74>:
+               	leaq	(%r12,%r14,8), %rcx
+               	movq	(%rcx), %rsi
+               	movq	%rax, %rdi
+               	callq	 <L75>
+<L75>:
                	addq	$0x1, %r14
                	movq	%rax, %r13
                	cmpq	$0x4, %r14
-               	jb	 <L57>
-<L60>:
+               	jb	 <L73>
+<L76>:
                	movq	%r13, %rax
                	movq	-0x8(%rbp), %rbx
                	movq	-0x10(%rbp), %r12

--- a/test/golden/x86_64-linux/float/cmp_f32.dis
+++ b/test/golden/x86_64-linux/float/cmp_f32.dis
@@ -297,8 +297,8 @@ Disassembly of section .text:
                	ucomiss	-0x48(%rbp), %xmm14
                	seta	%cl
                	movzbq	%cl, %rcx
-               	cmpb	$0x0, %cl
-               	sete	%sil
+               	cmpb	$0x1, %cl
+               	setne	%sil
                	movzbq	%sil, %rsi
                	callq	 <L28>
 <L28>:

--- a/test/golden/x86_64-linux/float/cmp_f64.dis
+++ b/test/golden/x86_64-linux/float/cmp_f64.dis
@@ -302,8 +302,8 @@ Disassembly of section .text:
                	ucomisd	-0x98(%rbp), %xmm14
                	seta	%dl
                	movzbq	%dl, %rdx
-               	cmpb	$0x0, %dl
-               	sete	%sil
+               	cmpb	$0x1, %dl
+               	setne	%sil
                	movzbq	%sil, %rsi
                	callq	 <L28>
 <L28>:

--- a/test/golden/x86_64-linux/float/special_f32.dis
+++ b/test/golden/x86_64-linux/float/special_f32.dis
@@ -252,868 +252,240 @@ Disassembly of section .text:
 <L32>:
                	movss	-0x68(%rbp), %xmm0
                	subss	-0x58(%rbp), %xmm0
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L34>
                	movq	%r12, %rdi
                	callq	 <L33>
 <L33>:
-               	movq	%rax, %rbx
-               	jmp	 <L36>
-<L34>:
-               	movq	%r12, %rdi
-               	movl	$0xffffffff, %esi       # imm = 0xFFFFFFFF
-               	callq	 <L35>
-<L35>:
-               	movq	%rax, %rbx
-<L36>:
                	movss	-0x68(%rbp), %xmm0
                	subss	-0x68(%rbp), %xmm0
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L38>
-               	movq	%rbx, %rdi
+               	movq	%rax, %rdi
+               	callq	 <L34>
+<L34>:
+               	movss	-0x58(%rbp), %xmm0
+               	mulss	-0x38(%rbp), %xmm0
+               	movq	%rax, %rdi
+               	callq	 <L35>
+<L35>:
+               	movss	-0x58(%rbp), %xmm0
+               	mulss	-0x48(%rbp), %xmm0
+               	movq	%rax, %rdi
+               	callq	 <L36>
+<L36>:
+               	movss	-0x68(%rbp), %xmm0
+               	mulss	-0x38(%rbp), %xmm0
+               	movq	%rax, %rdi
                	callq	 <L37>
 <L37>:
-               	movq	%rax, %r12
-               	jmp	 <L40>
+               	movss	-0x68(%rbp), %xmm0
+               	mulss	-0x48(%rbp), %xmm0
+               	movq	%rax, %rdi
+               	callq	 <L38>
 <L38>:
-               	movq	%rbx, %rdi
-               	movl	$0xffffffff, %esi       # imm = 0xFFFFFFFF
+               	movss	-0x68(%rbp), %xmm0
+               	mulss	-0x68(%rbp), %xmm0
+               	movq	%rax, %rdi
                	callq	 <L39>
 <L39>:
-               	movq	%rax, %r12
+               	movss	-0x58(%rbp), %xmm0
+               	mulss	-0x68(%rbp), %xmm0
+               	movq	%rax, %rdi
+               	callq	 <L40>
 <L40>:
                	movss	-0x58(%rbp), %xmm0
-               	mulss	-0x38(%rbp), %xmm0
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L42>
-               	movq	%r12, %rdi
+               	xorps	, %xmm0 <corpus.cases.float.special_f32.checksum+0x37a>
+               	movq	%rax, %rdi
                	callq	 <L41>
 <L41>:
-               	movq	%rax, %rbx
-               	jmp	 <L44>
+               	movss	-0x68(%rbp), %xmm0
+               	xorps	, %xmm0 <corpus.cases.float.special_f32.checksum+0x38e>
+               	movq	%rax, %rdi
+               	callq	 <L42>
 <L42>:
-               	movq	%r12, %rdi
-               	movl	$0xffffffff, %esi       # imm = 0xFFFFFFFF
+               	movss	-0x58(%rbp), %xmm0
+               	divss	-0x38(%rbp), %xmm0
+               	movq	%rax, %rdi
                	callq	 <L43>
 <L43>:
-               	movq	%rax, %rbx
-<L44>:
                	movss	-0x58(%rbp), %xmm0
-               	mulss	-0x48(%rbp), %xmm0
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L46>
-               	movq	%rbx, %rdi
+               	divss	-0x48(%rbp), %xmm0
+               	movq	%rax, %rdi
+               	callq	 <L44>
+<L44>:
+               	movss	-0x68(%rbp), %xmm0
+               	divss	-0x38(%rbp), %xmm0
+               	movq	%rax, %rdi
                	callq	 <L45>
 <L45>:
-               	movq	%rax, %r12
-               	jmp	 <L48>
+               	movss	-0x68(%rbp), %xmm0
+               	divss	-0x48(%rbp), %xmm0
+               	movq	%rax, %rdi
+               	callq	 <L46>
 <L46>:
-               	movq	%rbx, %rdi
-               	movl	$0xffffffff, %esi       # imm = 0xFFFFFFFF
-               	callq	 <L47>
-<L47>:
-               	movq	%rax, %r12
-<L48>:
-               	movss	-0x68(%rbp), %xmm0
-               	mulss	-0x38(%rbp), %xmm0
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L50>
-               	movq	%r12, %rdi
-               	callq	 <L49>
-<L49>:
-               	movq	%rax, %rbx
-               	jmp	 <L52>
-<L50>:
-               	movq	%r12, %rdi
-               	movl	$0xffffffff, %esi       # imm = 0xFFFFFFFF
-               	callq	 <L51>
-<L51>:
-               	movq	%rax, %rbx
-<L52>:
-               	movss	-0x68(%rbp), %xmm0
-               	mulss	-0x48(%rbp), %xmm0
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L54>
-               	movq	%rbx, %rdi
-               	callq	 <L53>
-<L53>:
-               	movq	%rax, %r12
-               	jmp	 <L56>
-<L54>:
-               	movq	%rbx, %rdi
-               	movl	$0xffffffff, %esi       # imm = 0xFFFFFFFF
-               	callq	 <L55>
-<L55>:
-               	movq	%rax, %r12
-<L56>:
-               	movss	-0x68(%rbp), %xmm0
-               	mulss	-0x68(%rbp), %xmm0
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L58>
-               	movq	%r12, %rdi
-               	callq	 <L57>
-<L57>:
-               	movq	%rax, %rbx
-               	jmp	 <L60>
-<L58>:
-               	movq	%r12, %rdi
-               	movl	$0xffffffff, %esi       # imm = 0xFFFFFFFF
-               	callq	 <L59>
-<L59>:
-               	movq	%rax, %rbx
-<L60>:
-               	movss	-0x58(%rbp), %xmm0
-               	mulss	-0x68(%rbp), %xmm0
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L62>
-               	movq	%rbx, %rdi
-               	callq	 <L61>
-<L61>:
-               	movq	%rax, %r12
-               	jmp	 <L64>
-<L62>:
-               	movq	%rbx, %rdi
-               	movl	$0xffffffff, %esi       # imm = 0xFFFFFFFF
-               	callq	 <L63>
-<L63>:
-               	movq	%rax, %r12
-<L64>:
-               	movss	-0x58(%rbp), %xmm0
-               	xorps	, %xmm0 <corpus.cases.float.special_f32.checksum+0x502>
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L66>
-               	movq	%r12, %rdi
-               	callq	 <L65>
-<L65>:
-               	movq	%rax, %rbx
-               	jmp	 <L68>
-<L66>:
-               	movq	%r12, %rdi
-               	movl	$0xffffffff, %esi       # imm = 0xFFFFFFFF
-               	callq	 <L67>
-<L67>:
-               	movq	%rax, %rbx
-<L68>:
-               	movss	-0x68(%rbp), %xmm0
-               	xorps	, %xmm0 <corpus.cases.float.special_f32.checksum+0x547>
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L70>
-               	movq	%rbx, %rdi
-               	callq	 <L69>
-<L69>:
-               	movq	%rax, %r12
-               	jmp	 <L72>
-<L70>:
-               	movq	%rbx, %rdi
-               	movl	$0xffffffff, %esi       # imm = 0xFFFFFFFF
-               	callq	 <L71>
-<L71>:
-               	movq	%rax, %r12
-<L72>:
-               	movss	-0x58(%rbp), %xmm0
-               	divss	-0x38(%rbp), %xmm0
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L74>
-               	movq	%r12, %rdi
-               	callq	 <L73>
-<L73>:
-               	movq	%rax, %rbx
-               	jmp	 <L76>
-<L74>:
-               	movq	%r12, %rdi
-               	movl	$0xffffffff, %esi       # imm = 0xFFFFFFFF
-               	callq	 <L75>
-<L75>:
-               	movq	%rax, %rbx
-<L76>:
-               	movss	-0x58(%rbp), %xmm0
-               	divss	-0x48(%rbp), %xmm0
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L78>
-               	movq	%rbx, %rdi
-               	callq	 <L77>
-<L77>:
-               	movq	%rax, %r12
-               	jmp	 <L80>
-<L78>:
-               	movq	%rbx, %rdi
-               	movl	$0xffffffff, %esi       # imm = 0xFFFFFFFF
-               	callq	 <L79>
-<L79>:
-               	movq	%rax, %r12
-<L80>:
-               	movss	-0x68(%rbp), %xmm0
-               	divss	-0x38(%rbp), %xmm0
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L82>
-               	movq	%r12, %rdi
-               	callq	 <L81>
-<L81>:
-               	movq	%rax, %rbx
-               	jmp	 <L84>
-<L82>:
-               	movq	%r12, %rdi
-               	movl	$0xffffffff, %esi       # imm = 0xFFFFFFFF
-               	callq	 <L83>
-<L83>:
-               	movq	%rax, %rbx
-<L84>:
-               	movss	-0x68(%rbp), %xmm0
-               	divss	-0x48(%rbp), %xmm0
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L86>
-               	movq	%rbx, %rdi
-               	callq	 <L85>
-<L85>:
-               	movq	%rax, %r12
-               	jmp	 <L88>
-<L86>:
-               	movq	%rbx, %rdi
-               	movl	$0xffffffff, %esi       # imm = 0xFFFFFFFF
-               	callq	 <L87>
-<L87>:
-               	movq	%rax, %r12
-<L88>:
                	movss	-0x58(%rbp), %xmm14
                	ucomiss	-0x68(%rbp), %xmm14
                	sete	%sil
                	setnp	%r11b
                	andb	%r11b, %sil
                	movzbq	%sil, %rsi
-               	movq	%r12, %rdi
-               	callq	 <L89>
-<L89>:
+               	movq	%rax, %rdi
+               	callq	 <L47>
+<L47>:
                	movss	-0x68(%rbp), %xmm14
                	ucomiss	-0x58(%rbp), %xmm14
                	seta	%sil
                	movzbq	%sil, %rsi
                	movq	%rax, %rdi
-               	callq	 <L90>
-<L90>:
+               	callq	 <L48>
+<L48>:
                	movss	-0x58(%rbp), %xmm14
                	ucomiss	-0x68(%rbp), %xmm14
                	seta	%sil
                	movzbq	%sil, %rsi
                	movq	%rax, %rdi
-               	callq	 <L91>
-<L91>:
-               	movq	%rax, %rbx
-               	movss	-0x78(%rbp), %xmm14
-               	ucomiss	-0x78(%rbp), %xmm14
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L93>
-               	movq	%rbx, %rdi
+               	callq	 <L49>
+<L49>:
+               	movq	%rax, %rdi
                	movss	-0x78(%rbp), %xmm0
-               	callq	 <L92>
-<L92>:
-               	movq	%rax, %r12
-               	jmp	 <L95>
-<L93>:
-               	movq	%rbx, %rdi
-               	movl	$0xffffffff, %esi       # imm = 0xFFFFFFFF
-               	callq	 <L94>
-<L94>:
-               	movq	%rax, %r12
-<L95>:
-               	movss	-0x88(%rbp), %xmm14
-               	ucomiss	-0x88(%rbp), %xmm14
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L97>
-               	movq	%r12, %rdi
+               	callq	 <L50>
+<L50>:
+               	movq	%rax, %rdi
                	movss	-0x88(%rbp), %xmm0
-               	callq	 <L96>
-<L96>:
-               	movq	%rax, %rbx
-               	jmp	 <L99>
-<L97>:
-               	movq	%r12, %rdi
-               	movl	$0xffffffff, %esi       # imm = 0xFFFFFFFF
-               	callq	 <L98>
-<L98>:
-               	movq	%rax, %rbx
-<L99>:
+               	callq	 <L51>
+<L51>:
                	movss	-0x78(%rbp), %xmm0
-               	xorps	, %xmm0 <corpus.cases.float.special_f32.checksum+0x788>
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L101>
-               	movq	%rbx, %rdi
-               	callq	 <L100>
-<L100>:
-               	movq	%rax, %r12
-               	jmp	 <L103>
-<L101>:
-               	movq	%rbx, %rdi
-               	movl	$0xffffffff, %esi       # imm = 0xFFFFFFFF
-               	callq	 <L102>
-<L102>:
-               	movq	%rax, %r12
-<L103>:
+               	xorps	, %xmm0 <corpus.cases.float.special_f32.checksum+0x45f>
+               	movq	%rax, %rdi
+               	callq	 <L52>
+<L52>:
                	movss	-0x38(%rbp), %xmm0
                	divss	-0x58(%rbp), %xmm0
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L105>
-               	movq	%r12, %rdi
-               	callq	 <L104>
-<L104>:
-               	movq	%rax, %rbx
-               	jmp	 <L107>
-<L105>:
-               	movq	%r12, %rdi
-               	movl	$0xffffffff, %esi       # imm = 0xFFFFFFFF
-               	callq	 <L106>
-<L106>:
-               	movq	%rax, %rbx
-<L107>:
+               	movq	%rax, %rdi
+               	callq	 <L53>
+<L53>:
                	movss	-0x38(%rbp), %xmm0
                	divss	-0x68(%rbp), %xmm0
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L109>
-               	movq	%rbx, %rdi
-               	callq	 <L108>
-<L108>:
-               	movq	%rax, %r12
-               	jmp	 <L111>
-<L109>:
-               	movq	%rbx, %rdi
-               	movl	$0xffffffff, %esi       # imm = 0xFFFFFFFF
-               	callq	 <L110>
-<L110>:
-               	movq	%rax, %r12
-<L111>:
+               	movq	%rax, %rdi
+               	callq	 <L54>
+<L54>:
                	movss	-0x48(%rbp), %xmm0
                	divss	-0x58(%rbp), %xmm0
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L113>
-               	movq	%r12, %rdi
-               	callq	 <L112>
-<L112>:
-               	movq	%rax, %rbx
-               	jmp	 <L115>
-<L113>:
-               	movq	%r12, %rdi
-               	movl	$0xffffffff, %esi       # imm = 0xFFFFFFFF
-               	callq	 <L114>
-<L114>:
-               	movq	%rax, %rbx
-<L115>:
+               	movq	%rax, %rdi
+               	callq	 <L55>
+<L55>:
                	movss	-0x48(%rbp), %xmm0
                	divss	-0x68(%rbp), %xmm0
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L117>
-               	movq	%rbx, %rdi
-               	callq	 <L116>
-<L116>:
-               	movq	%rax, %r12
-               	jmp	 <L119>
-<L117>:
-               	movq	%rbx, %rdi
-               	movl	$0xffffffff, %esi       # imm = 0xFFFFFFFF
-               	callq	 <L118>
-<L118>:
-               	movq	%rax, %r12
-<L119>:
+               	movq	%rax, %rdi
+               	callq	 <L56>
+<L56>:
                	movss	-0x78(%rbp), %xmm0
                	addss	-0x38(%rbp), %xmm0
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L121>
-               	movq	%r12, %rdi
-               	callq	 <L120>
-<L120>:
-               	movq	%rax, %rbx
-               	jmp	 <L123>
-<L121>:
-               	movq	%r12, %rdi
-               	movl	$0xffffffff, %esi       # imm = 0xFFFFFFFF
-               	callq	 <L122>
-<L122>:
-               	movq	%rax, %rbx
-<L123>:
+               	movq	%rax, %rdi
+               	callq	 <L57>
+<L57>:
                	movss	-0x78(%rbp), %xmm0
                	addss	-0x78(%rbp), %xmm0
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L125>
-               	movq	%rbx, %rdi
-               	callq	 <L124>
-<L124>:
-               	movq	%rax, %r12
-               	jmp	 <L127>
-<L125>:
-               	movq	%rbx, %rdi
-               	movl	$0xffffffff, %esi       # imm = 0xFFFFFFFF
-               	callq	 <L126>
-<L126>:
-               	movq	%rax, %r12
-<L127>:
+               	movq	%rax, %rdi
+               	callq	 <L58>
+<L58>:
                	movss	-0x78(%rbp), %xmm0
                	subss	-0x88(%rbp), %xmm0
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L129>
-               	movq	%r12, %rdi
-               	callq	 <L128>
-<L128>:
-               	movq	%rax, %rbx
-               	jmp	 <L131>
-<L129>:
-               	movq	%r12, %rdi
-               	movl	$0xffffffff, %esi       # imm = 0xFFFFFFFF
-               	callq	 <L130>
-<L130>:
-               	movq	%rax, %rbx
-<L131>:
+               	movq	%rax, %rdi
+               	callq	 <L59>
+<L59>:
                	movss	-0x78(%rbp), %xmm0
                	mulss	-0x78(%rbp), %xmm0
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L133>
-               	movq	%rbx, %rdi
-               	callq	 <L132>
-<L132>:
-               	movq	%rax, %r12
-               	jmp	 <L135>
-<L133>:
-               	movq	%rbx, %rdi
-               	movl	$0xffffffff, %esi       # imm = 0xFFFFFFFF
-               	callq	 <L134>
-<L134>:
-               	movq	%rax, %r12
-<L135>:
+               	movq	%rax, %rdi
+               	callq	 <L60>
+<L60>:
                	movss	-0x78(%rbp), %xmm0
                	mulss	-0x88(%rbp), %xmm0
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L137>
-               	movq	%r12, %rdi
-               	callq	 <L136>
-<L136>:
-               	movq	%rax, %rbx
-               	jmp	 <L139>
-<L137>:
-               	movq	%r12, %rdi
-               	movl	$0xffffffff, %esi       # imm = 0xFFFFFFFF
-               	callq	 <L138>
-<L138>:
-               	movq	%rax, %rbx
-<L139>:
+               	movq	%rax, %rdi
+               	callq	 <L61>
+<L61>:
                	movss	-0x78(%rbp), %xmm0
                	mulss	-0x48(%rbp), %xmm0
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L141>
-               	movq	%rbx, %rdi
-               	callq	 <L140>
-<L140>:
-               	movq	%rax, %r12
-               	jmp	 <L143>
-<L141>:
-               	movq	%rbx, %rdi
-               	movl	$0xffffffff, %esi       # imm = 0xFFFFFFFF
-               	callq	 <L142>
-<L142>:
-               	movq	%rax, %r12
-<L143>:
+               	movq	%rax, %rdi
+               	callq	 <L62>
+<L62>:
                	movss	-0x38(%rbp), %xmm0
                	divss	-0x78(%rbp), %xmm0
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L145>
-               	movq	%r12, %rdi
-               	callq	 <L144>
-<L144>:
-               	movq	%rax, %rbx
-               	jmp	 <L147>
-<L145>:
-               	movq	%r12, %rdi
-               	movl	$0xffffffff, %esi       # imm = 0xFFFFFFFF
-               	callq	 <L146>
-<L146>:
-               	movq	%rax, %rbx
-<L147>:
+               	movq	%rax, %rdi
+               	callq	 <L63>
+<L63>:
                	movss	-0x48(%rbp), %xmm0
                	divss	-0x78(%rbp), %xmm0
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L149>
-               	movq	%rbx, %rdi
-               	callq	 <L148>
-<L148>:
-               	movq	%rax, %r12
-               	jmp	 <L151>
-<L149>:
-               	movq	%rbx, %rdi
-               	movl	$0xffffffff, %esi       # imm = 0xFFFFFFFF
-               	callq	 <L150>
-<L150>:
-               	movq	%rax, %r12
-<L151>:
+               	movq	%rax, %rdi
+               	callq	 <L64>
+<L64>:
                	movss	-0x38(%rbp), %xmm0
                	divss	-0x88(%rbp), %xmm0
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L153>
-               	movq	%r12, %rdi
-               	callq	 <L152>
-<L152>:
-               	movq	%rax, %rbx
-               	jmp	 <L155>
-<L153>:
-               	movq	%r12, %rdi
-               	movl	$0xffffffff, %esi       # imm = 0xFFFFFFFF
-               	callq	 <L154>
-<L154>:
-               	movq	%rax, %rbx
-<L155>:
+               	movq	%rax, %rdi
+               	callq	 <L65>
+<L65>:
                	movss	-0x78(%rbp), %xmm0
                	divss	-0x38(%rbp), %xmm0
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L157>
-               	movq	%rbx, %rdi
-               	callq	 <L156>
-<L156>:
-               	movq	%rax, %r12
-               	jmp	 <L159>
-<L157>:
-               	movq	%rbx, %rdi
-               	movl	$0xffffffff, %esi       # imm = 0xFFFFFFFF
-               	callq	 <L158>
-<L158>:
-               	movq	%rax, %r12
-<L159>:
+               	movq	%rax, %rdi
+               	callq	 <L66>
+<L66>:
                	movss	-0xa8(%rbp), %xmm0
                	addss	-0xa8(%rbp), %xmm0
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L161>
-               	movq	%r12, %rdi
-               	callq	 <L160>
-<L160>:
-               	movq	%rax, %rbx
-               	jmp	 <L163>
-<L161>:
-               	movq	%r12, %rdi
-               	movl	$0xffffffff, %esi       # imm = 0xFFFFFFFF
-               	callq	 <L162>
-<L162>:
-               	movq	%rax, %rbx
-<L163>:
+               	movq	%rax, %rdi
+               	callq	 <L67>
+<L67>:
                	movss	-0x78(%rbp), %xmm14
                	ucomiss	-0xa8(%rbp), %xmm14
                	seta	%sil
                	movzbq	%sil, %rsi
-               	movq	%rbx, %rdi
-               	callq	 <L164>
-<L164>:
+               	movq	%rax, %rdi
+               	callq	 <L68>
+<L68>:
                	xorps	%xmm0, %xmm0
                	subss	-0xa8(%rbp), %xmm0
                	ucomiss	-0x88(%rbp), %xmm0
                	seta	%sil
                	movzbq	%sil, %rsi
                	movq	%rax, %rdi
-               	callq	 <L165>
-<L165>:
-               	movq	%rax, %rbx
+               	callq	 <L69>
+<L69>:
                	movss	-0x78(%rbp), %xmm0
                	subss	-0x78(%rbp), %xmm0
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L167>
-               	movq	%rbx, %rdi
-               	callq	 <L166>
-<L166>:
-               	movq	%rax, %r12
-               	jmp	 <L169>
-<L167>:
-               	movq	%rbx, %rdi
-               	movl	$0xffffffff, %esi       # imm = 0xFFFFFFFF
-               	callq	 <L168>
-<L168>:
-               	movq	%rax, %r12
-<L169>:
+               	movq	%rax, %rdi
+               	callq	 <L70>
+<L70>:
                	movss	-0x88(%rbp), %xmm0
                	addss	-0x78(%rbp), %xmm0
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L171>
-               	movq	%r12, %rdi
-               	callq	 <L170>
-<L170>:
-               	movq	%rax, %rbx
-               	jmp	 <L173>
-<L171>:
-               	movq	%r12, %rdi
-               	movl	$0xffffffff, %esi       # imm = 0xFFFFFFFF
-               	callq	 <L172>
-<L172>:
-               	movq	%rax, %rbx
-<L173>:
+               	movq	%rax, %rdi
+               	callq	 <L71>
+<L71>:
                	movss	-0x78(%rbp), %xmm0
                	mulss	-0x58(%rbp), %xmm0
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L175>
-               	movq	%rbx, %rdi
-               	callq	 <L174>
-<L174>:
-               	movq	%rax, %r12
-               	jmp	 <L177>
-<L175>:
-               	movq	%rbx, %rdi
-               	movl	$0xffffffff, %esi       # imm = 0xFFFFFFFF
-               	callq	 <L176>
-<L176>:
-               	movq	%rax, %r12
-<L177>:
+               	movq	%rax, %rdi
+               	callq	 <L72>
+<L72>:
                	movss	-0x88(%rbp), %xmm0
                	mulss	-0x68(%rbp), %xmm0
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L179>
-               	movq	%r12, %rdi
-               	callq	 <L178>
-<L178>:
-               	movq	%rax, %rbx
-               	jmp	 <L181>
-<L179>:
-               	movq	%r12, %rdi
-               	movl	$0xffffffff, %esi       # imm = 0xFFFFFFFF
-               	callq	 <L180>
-<L180>:
-               	movq	%rax, %rbx
-<L181>:
+               	movq	%rax, %rdi
+               	callq	 <L73>
+<L73>:
                	movss	-0x78(%rbp), %xmm0
                	divss	-0x78(%rbp), %xmm0
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L183>
-               	movq	%rbx, %rdi
-               	callq	 <L182>
-<L182>:
-               	movq	%rax, %r12
-               	jmp	 <L185>
-<L183>:
-               	movq	%rbx, %rdi
-               	movl	$0xffffffff, %esi       # imm = 0xFFFFFFFF
-               	callq	 <L184>
-<L184>:
-               	movq	%rax, %r12
-<L185>:
+               	movq	%rax, %rdi
+               	callq	 <L74>
+<L74>:
                	movss	-0x58(%rbp), %xmm0
                	divss	-0x58(%rbp), %xmm0
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L187>
-               	movq	%r12, %rdi
-               	callq	 <L186>
-<L186>:
-               	movq	%rax, %rbx
-               	jmp	 <L189>
-<L187>:
-               	movq	%r12, %rdi
-               	movl	$0xffffffff, %esi       # imm = 0xFFFFFFFF
-               	callq	 <L188>
-<L188>:
-               	movq	%rax, %rbx
-<L189>:
+               	movq	%rax, %rdi
+               	callq	 <L75>
+<L75>:
                	movss	-0x68(%rbp), %xmm0
                	divss	-0x58(%rbp), %xmm0
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L191>
-               	movq	%rbx, %rdi
-               	callq	 <L190>
-<L190>:
-               	movq	%rax, %r12
-               	jmp	 <L193>
-<L191>:
-               	movq	%rbx, %rdi
-               	movl	$0xffffffff, %esi       # imm = 0xFFFFFFFF
-               	callq	 <L192>
-<L192>:
-               	movq	%rax, %r12
-<L193>:
-               	movl	-0x98(%rbp), %eax
-               	movq	%r12, %rdi
-               	movl	%eax, %esi
-               	callq	 <L194>
-<L194>:
+               	movq	%rax, %rdi
+               	callq	 <L76>
+<L76>:
+               	movl	-0x98(%rbp), %ecx
+               	movq	%rax, %rdi
+               	movl	%ecx, %esi
+               	callq	 <L77>
+<L77>:
                	movss	-0x98(%rbp), %xmm14
                	ucomiss	-0x98(%rbp), %xmm14
                	setne	%sil
@@ -1121,8 +493,8 @@ Disassembly of section .text:
                	orb	%r11b, %sil
                	movzbq	%sil, %rsi
                	movq	%rax, %rdi
-               	callq	 <L195>
-<L195>:
+               	callq	 <L78>
+<L78>:
                	movss	-0x98(%rbp), %xmm14
                	ucomiss	-0x98(%rbp), %xmm14
                	sete	%sil
@@ -1130,402 +502,126 @@ Disassembly of section .text:
                	andb	%r11b, %sil
                	movzbq	%sil, %rsi
                	movq	%rax, %rdi
-               	callq	 <L196>
-<L196>:
+               	callq	 <L79>
+<L79>:
                	movss	-0x98(%rbp), %xmm14
                	ucomiss	-0x98(%rbp), %xmm14
                	seta	%sil
                	movzbq	%sil, %rsi
                	movq	%rax, %rdi
-               	callq	 <L197>
-<L197>:
+               	callq	 <L80>
+<L80>:
                	movss	-0x98(%rbp), %xmm14
                	ucomiss	-0x98(%rbp), %xmm14
                	setae	%sil
                	movzbq	%sil, %rsi
                	movq	%rax, %rdi
-               	callq	 <L198>
-<L198>:
+               	callq	 <L81>
+<L81>:
                	movss	-0x98(%rbp), %xmm14
-               	xorps	, %xmm14 <corpus.cases.float.special_f32.checksum+0xe8e>
+               	xorps	, %xmm14 <corpus.cases.float.special_f32.checksum+0x6fb>
                	movss	%xmm14, -0xe8(%rbp)
                	movl	-0xe8(%rbp), %ecx
                	movq	%rax, %rdi
                	movl	%ecx, %esi
-               	callq	 <L199>
-<L199>:
+               	callq	 <L82>
+<L82>:
                	movss	-0xe8(%rbp), %xmm2
-               	xorps	, %xmm2 <corpus.cases.float.special_f32.checksum+0xeb6>
+               	xorps	, %xmm2 <corpus.cases.float.special_f32.checksum+0x723>
                	movd	%xmm2, %ecx
                	movq	%rax, %rdi
                	movl	%ecx, %esi
-               	callq	 <L200>
-<L200>:
-               	movq	%rax, %rbx
+               	callq	 <L83>
+<L83>:
                	movss	-0x98(%rbp), %xmm0
                	addss	-0x38(%rbp), %xmm0
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L202>
-               	movq	%rbx, %rdi
-               	callq	 <L201>
-<L201>:
-               	movq	%rax, %r12
-               	jmp	 <L204>
-<L202>:
-               	movq	%rbx, %rdi
-               	movl	$0xffffffff, %esi       # imm = 0xFFFFFFFF
-               	callq	 <L203>
-<L203>:
-               	movq	%rax, %r12
-<L204>:
+               	movq	%rax, %rdi
+               	callq	 <L84>
+<L84>:
                	movss	-0x38(%rbp), %xmm0
                	addss	-0x98(%rbp), %xmm0
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L206>
-               	movq	%r12, %rdi
-               	callq	 <L205>
-<L205>:
-               	movq	%rax, %rbx
-               	jmp	 <L208>
-<L206>:
-               	movq	%r12, %rdi
-               	movl	$0xffffffff, %esi       # imm = 0xFFFFFFFF
-               	callq	 <L207>
-<L207>:
-               	movq	%rax, %rbx
-<L208>:
+               	movq	%rax, %rdi
+               	callq	 <L85>
+<L85>:
                	movss	-0x98(%rbp), %xmm0
                	mulss	-0x58(%rbp), %xmm0
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L210>
-               	movq	%rbx, %rdi
-               	callq	 <L209>
-<L209>:
-               	movq	%rax, %r12
-               	jmp	 <L212>
-<L210>:
-               	movq	%rbx, %rdi
-               	movl	$0xffffffff, %esi       # imm = 0xFFFFFFFF
-               	callq	 <L211>
-<L211>:
-               	movq	%rax, %r12
-<L212>:
+               	movq	%rax, %rdi
+               	callq	 <L86>
+<L86>:
                	movss	-0x98(%rbp), %xmm0
                	subss	-0x98(%rbp), %xmm0
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L214>
-               	movq	%r12, %rdi
-               	callq	 <L213>
-<L213>:
-               	movq	%rax, %rbx
-               	jmp	 <L216>
-<L214>:
-               	movq	%r12, %rdi
-               	movl	$0xffffffff, %esi       # imm = 0xFFFFFFFF
-               	callq	 <L215>
-<L215>:
-               	movq	%rax, %rbx
-<L216>:
+               	movq	%rax, %rdi
+               	callq	 <L87>
+<L87>:
                	movss	-0x98(%rbp), %xmm0
                	divss	-0x98(%rbp), %xmm0
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L218>
-               	movq	%rbx, %rdi
-               	callq	 <L217>
-<L217>:
-               	movq	%rax, %r12
-               	jmp	 <L220>
-<L218>:
-               	movq	%rbx, %rdi
-               	movl	$0xffffffff, %esi       # imm = 0xFFFFFFFF
-               	callq	 <L219>
-<L219>:
-               	movq	%rax, %r12
-<L220>:
+               	movq	%rax, %rdi
+               	callq	 <L88>
+<L88>:
                	movss	-0x98(%rbp), %xmm0
                	divss	-0x78(%rbp), %xmm0
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L222>
-               	movq	%r12, %rdi
-               	callq	 <L221>
-<L221>:
-               	movq	%rax, %rbx
-               	jmp	 <L224>
-<L222>:
-               	movq	%r12, %rdi
-               	movl	$0xffffffff, %esi       # imm = 0xFFFFFFFF
-               	callq	 <L223>
-<L223>:
-               	movq	%rax, %rbx
-<L224>:
-               	movss	-0xd8(%rbp), %xmm14
-               	ucomiss	-0xd8(%rbp), %xmm14
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L226>
-               	movq	%rbx, %rdi
+               	movq	%rax, %rdi
+               	callq	 <L89>
+<L89>:
+               	movq	%rax, %rdi
                	movss	-0xd8(%rbp), %xmm0
-               	callq	 <L225>
-<L225>:
-               	movq	%rax, %r12
-               	jmp	 <L228>
-<L226>:
-               	movq	%rbx, %rdi
-               	movl	$0xffffffff, %esi       # imm = 0xFFFFFFFF
-               	callq	 <L227>
-<L227>:
-               	movq	%rax, %r12
-<L228>:
-               	movss	-0xc8(%rbp), %xmm14
-               	ucomiss	-0xc8(%rbp), %xmm14
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L230>
-               	movq	%r12, %rdi
+               	callq	 <L90>
+<L90>:
+               	movq	%rax, %rdi
                	movss	-0xc8(%rbp), %xmm0
-               	callq	 <L229>
-<L229>:
-               	movq	%rax, %rbx
-               	jmp	 <L232>
-<L230>:
-               	movq	%r12, %rdi
-               	movl	$0xffffffff, %esi       # imm = 0xFFFFFFFF
-               	callq	 <L231>
-<L231>:
-               	movq	%rax, %rbx
-<L232>:
-               	movss	-0xb8(%rbp), %xmm14
-               	ucomiss	-0xb8(%rbp), %xmm14
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L234>
-               	movq	%rbx, %rdi
+               	callq	 <L91>
+<L91>:
+               	movq	%rax, %rdi
                	movss	-0xb8(%rbp), %xmm0
-               	callq	 <L233>
-<L233>:
-               	movq	%rax, %r12
-               	jmp	 <L236>
-<L234>:
-               	movq	%rbx, %rdi
-               	movl	$0xffffffff, %esi       # imm = 0xFFFFFFFF
-               	callq	 <L235>
-<L235>:
-               	movq	%rax, %r12
-<L236>:
+               	callq	 <L92>
+<L92>:
                	movss	-0xc8(%rbp), %xmm0
                	addss	-0xd8(%rbp), %xmm0
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L238>
-               	movq	%r12, %rdi
-               	callq	 <L237>
-<L237>:
-               	movq	%rax, %rbx
-               	jmp	 <L240>
-<L238>:
-               	movq	%r12, %rdi
-               	movl	$0xffffffff, %esi       # imm = 0xFFFFFFFF
-               	callq	 <L239>
-<L239>:
-               	movq	%rax, %rbx
-<L240>:
+               	movq	%rax, %rdi
+               	callq	 <L93>
+<L93>:
                	movss	-0xb8(%rbp), %xmm0
                	subss	-0xd8(%rbp), %xmm0
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L242>
-               	movq	%rbx, %rdi
-               	callq	 <L241>
-<L241>:
-               	movq	%rax, %r12
-               	jmp	 <L244>
-<L242>:
-               	movq	%rbx, %rdi
-               	movl	$0xffffffff, %esi       # imm = 0xFFFFFFFF
-               	callq	 <L243>
-<L243>:
-               	movq	%rax, %r12
-<L244>:
+               	movq	%rax, %rdi
+               	callq	 <L94>
+<L94>:
                	movss	-0xd8(%rbp), %xmm0
                	addss	-0xd8(%rbp), %xmm0
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L246>
-               	movq	%r12, %rdi
-               	callq	 <L245>
-<L245>:
-               	movq	%rax, %rbx
-               	jmp	 <L248>
-<L246>:
-               	movq	%r12, %rdi
-               	movl	$0xffffffff, %esi       # imm = 0xFFFFFFFF
-               	callq	 <L247>
-<L247>:
-               	movq	%rax, %rbx
-<L248>:
+               	movq	%rax, %rdi
+               	callq	 <L95>
+<L95>:
                	movss	-0xd8(%rbp), %xmm0
-               	mulss	, %xmm0 <corpus.cases.float.special_f32.checksum+0x124a>
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L250>
-               	movq	%rbx, %rdi
-               	callq	 <L249>
-<L249>:
-               	movq	%rax, %r12
-               	jmp	 <L252>
-<L250>:
-               	movq	%rbx, %rdi
-               	movl	$0xffffffff, %esi       # imm = 0xFFFFFFFF
-               	callq	 <L251>
-<L251>:
-               	movq	%rax, %r12
-<L252>:
+               	mulss	, %xmm0 <corpus.cases.float.special_f32.checksum+0x83e>
+               	movq	%rax, %rdi
+               	callq	 <L96>
+<L96>:
                	movss	-0xd8(%rbp), %xmm0
-               	mulss	, %xmm0 <corpus.cases.float.special_f32.checksum+0x1293>
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L254>
-               	movq	%r12, %rdi
-               	callq	 <L253>
-<L253>:
-               	movq	%rax, %rbx
-               	jmp	 <L256>
-<L254>:
-               	movq	%r12, %rdi
-               	movl	$0xffffffff, %esi       # imm = 0xFFFFFFFF
-               	callq	 <L255>
-<L255>:
-               	movq	%rax, %rbx
-<L256>:
+               	mulss	, %xmm0 <corpus.cases.float.special_f32.checksum+0x856>
+               	movq	%rax, %rdi
+               	callq	 <L97>
+<L97>:
                	movss	-0xd8(%rbp), %xmm0
-               	xorps	, %xmm0 <corpus.cases.float.special_f32.checksum+0x12db>
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L258>
-               	movq	%rbx, %rdi
-               	callq	 <L257>
-<L257>:
-               	movq	%rax, %r12
-               	jmp	 <L260>
-<L258>:
-               	movq	%rbx, %rdi
-               	movl	$0xffffffff, %esi       # imm = 0xFFFFFFFF
-               	callq	 <L259>
-<L259>:
-               	movq	%rax, %r12
-<L260>:
+               	xorps	, %xmm0 <corpus.cases.float.special_f32.checksum+0x86d>
+               	movq	%rax, %rdi
+               	callq	 <L98>
+<L98>:
                	movss	-0xd8(%rbp), %xmm0
-               	mulss	, %xmm0 <corpus.cases.float.special_f32.checksum+0x1324>
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L262>
-               	movq	%r12, %rdi
-               	callq	 <L261>
-<L261>:
-               	movq	%rax, %rbx
-               	jmp	 <L264>
-<L262>:
-               	movq	%r12, %rdi
-               	movl	$0xffffffff, %esi       # imm = 0xFFFFFFFF
-               	callq	 <L263>
-<L263>:
-               	movq	%rax, %rbx
-<L264>:
+               	mulss	, %xmm0 <corpus.cases.float.special_f32.checksum+0x885>
+               	movq	%rax, %rdi
+               	callq	 <L99>
+<L99>:
                	movss	-0xc8(%rbp), %xmm0
                	divss	-0xb8(%rbp), %xmm0
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L266>
-               	movq	%rbx, %rdi
-               	callq	 <L265>
-<L265>:
-               	movq	%rax, %r12
-               	jmp	 <L268>
-<L266>:
-               	movq	%rbx, %rdi
-               	movl	$0xffffffff, %esi       # imm = 0xFFFFFFFF
-               	callq	 <L267>
-<L267>:
-               	movq	%rax, %r12
-<L268>:
+               	movq	%rax, %rdi
+               	callq	 <L100>
+<L100>:
                	movss	-0xd8(%rbp), %xmm14
                	ucomiss	-0x58(%rbp), %xmm14
                	seta	%sil
                	movzbq	%sil, %rsi
-               	movq	%r12, %rdi
-               	callq	 <L269>
-<L269>:
+               	movq	%rax, %rdi
+               	callq	 <L101>
+<L101>:
                	movss	-0xd8(%rbp), %xmm14
                	ucomiss	-0x58(%rbp), %xmm14
                	sete	%sil
@@ -1533,8 +629,8 @@ Disassembly of section .text:
                	andb	%r11b, %sil
                	movzbq	%sil, %rsi
                	movq	%rax, %rdi
-               	callq	 <L270>
-<L270>:
+               	callq	 <L102>
+<L102>:
                	xorps	%xmm0, %xmm0
                	subss	-0xd8(%rbp), %xmm0
                	movss	-0x68(%rbp), %xmm14
@@ -1542,18 +638,18 @@ Disassembly of section .text:
                	seta	%sil
                	movzbq	%sil, %rsi
                	movq	%rax, %rdi
-               	callq	 <L271>
-<L271>:
+               	callq	 <L103>
+<L103>:
                	movq	%rax, %rbx
                	movq	-0xb8(%rbp), %r11
                	movq	%r11, -0x108(%rbp)
                	movl	$0x0, %r12d
                	cmpl	$0x1e, %r12d
-               	jb	 <L272>
-               	jmp	 <L277>
-<L272>:
+               	jb	 <L104>
+               	jmp	 <L109>
+<L104>:
                	movss	-0x108(%rbp), %xmm14
-               	mulss	, %xmm14 <corpus.cases.float.special_f32.checksum+0x1446>
+               	mulss	, %xmm14 <corpus.cases.float.special_f32.checksum+0x945>
                	movss	%xmm14, -0xf8(%rbp)
                	movss	-0xf8(%rbp), %xmm14
                	ucomiss	-0xf8(%rbp), %xmm14
@@ -1562,27 +658,27 @@ Disassembly of section .text:
                	orb	%r11b, %al
                	movzbq	%al, %rax
                	testb	%al, %al
-               	jne	 <L274>
+               	jne	 <L106>
                	movq	%rbx, %rdi
                	movss	-0xf8(%rbp), %xmm0
-               	callq	 <L273>
-<L273>:
+               	callq	 <L105>
+<L105>:
                	movq	%rax, %r14
-               	jmp	 <L276>
-<L274>:
+               	jmp	 <L108>
+<L106>:
                	movq	%rbx, %rdi
                	movl	$0xffffffff, %esi       # imm = 0xFFFFFFFF
-               	callq	 <L275>
-<L275>:
+               	callq	 <L107>
+<L107>:
                	movq	%rax, %r14
-<L276>:
+<L108>:
                	addl	$0x1, %r12d
                	movq	%r14, %rbx
                	movq	-0xf8(%rbp), %r11
                	movq	%r11, -0x108(%rbp)
                	cmpl	$0x1e, %r12d
-               	jb	 <L272>
-<L277>:
+               	jb	 <L104>
+<L109>:
                	leaq	-0x20(%rbp), %r12
                	movq	$0x0, (%r12)
                	movq	$0x0, 0x8(%r12)
@@ -1606,9 +702,9 @@ Disassembly of section .text:
                	movl	$0x7f800001, (%rax)     # imm = 0x7F800001
                	movl	$0x0, %r14d
                	cmpl	$0x8, %r14d
-               	jb	 <L278>
-               	jmp	 <L280>
-<L278>:
+               	jb	 <L110>
+               	jmp	 <L112>
+<L110>:
                	movl	%r14d, %eax
                	leaq	(%r12,%rax,4), %rcx
                	movl	(%rcx), %eax
@@ -1617,13 +713,13 @@ Disassembly of section .text:
                	movd	%xmm0, %eax
                	movq	%rbx, %rdi
                	movl	%eax, %esi
-               	callq	 <L279>
-<L279>:
+               	callq	 <L111>
+<L111>:
                	addl	$0x1, %r14d
                	movq	%rax, %rbx
                	cmpl	$0x8, %r14d
-               	jb	 <L278>
-<L280>:
+               	jb	 <L110>
+<L112>:
                	movl	$0x1000000, %eax        # imm = 0x1000000
                	addl	%r13d, %eax
                	movl	$0x1000001, %r12d       # imm = 0x1000001
@@ -1646,21 +742,21 @@ Disassembly of section .text:
                	orb	%r11b, %al
                	movzbq	%al, %rax
                	testb	%al, %al
-               	jne	 <L282>
+               	jne	 <L114>
                	movq	%rbx, %rdi
-               	callq	 <L281>
-<L281>:
+               	callq	 <L113>
+<L113>:
                	movq	%rax, %r8
                	movq	%r8, -0x28(%rbp)
-               	jmp	 <L284>
-<L282>:
+               	jmp	 <L116>
+<L114>:
                	movq	%rbx, %rdi
                	movl	$0xffffffff, %esi       # imm = 0xFFFFFFFF
-               	callq	 <L283>
-<L283>:
+               	callq	 <L115>
+<L115>:
                	movq	%rax, %r8
                	movq	%r8, -0x28(%rbp)
-<L284>:
+<L116>:
                	movl	%r12d, %r11d
                	cvtsi2ss	%r11, %xmm0
                	ucomiss	%xmm0, %xmm0
@@ -1669,21 +765,21 @@ Disassembly of section .text:
                	orb	%r11b, %al
                	movzbq	%al, %rax
                	testb	%al, %al
-               	jne	 <L286>
+               	jne	 <L118>
                	movq	-0x28(%rbp), %r8
                	movq	%r8, %rdi
-               	callq	 <L285>
-<L285>:
+               	callq	 <L117>
+<L117>:
                	movq	%rax, %rbx
-               	jmp	 <L288>
-<L286>:
+               	jmp	 <L120>
+<L118>:
                	movq	-0x28(%rbp), %r8
                	movq	%r8, %rdi
                	movl	$0xffffffff, %esi       # imm = 0xFFFFFFFF
-               	callq	 <L287>
-<L287>:
+               	callq	 <L119>
+<L119>:
                	movq	%rax, %rbx
-<L288>:
+<L120>:
                	movl	%r14d, %r11d
                	cvtsi2ss	%r11, %xmm0
                	ucomiss	%xmm0, %xmm0
@@ -1692,19 +788,19 @@ Disassembly of section .text:
                	orb	%r11b, %al
                	movzbq	%al, %rax
                	testb	%al, %al
-               	jne	 <L290>
+               	jne	 <L122>
                	movq	%rbx, %rdi
-               	callq	 <L289>
-<L289>:
+               	callq	 <L121>
+<L121>:
                	movq	%rax, %r12
-               	jmp	 <L292>
-<L290>:
+               	jmp	 <L124>
+<L122>:
                	movq	%rbx, %rdi
                	movl	$0xffffffff, %esi       # imm = 0xFFFFFFFF
-               	callq	 <L291>
-<L291>:
+               	callq	 <L123>
+<L123>:
                	movq	%rax, %r12
-<L292>:
+<L124>:
                	movl	%r15d, %r11d
                	cvtsi2ss	%r11, %xmm0
                	ucomiss	%xmm0, %xmm0
@@ -1713,19 +809,19 @@ Disassembly of section .text:
                	orb	%r11b, %al
                	movzbq	%al, %rax
                	testb	%al, %al
-               	jne	 <L294>
+               	jne	 <L126>
                	movq	%r12, %rdi
-               	callq	 <L293>
-<L293>:
+               	callq	 <L125>
+<L125>:
                	movq	%rax, %rbx
-               	jmp	 <L296>
-<L294>:
+               	jmp	 <L128>
+<L126>:
                	movq	%r12, %rdi
                	movl	$0xffffffff, %esi       # imm = 0xFFFFFFFF
-               	callq	 <L295>
-<L295>:
+               	callq	 <L127>
+<L127>:
                	movq	%rax, %rbx
-<L296>:
+<L128>:
                	movl	%r13d, %r11d
                	cvtsi2ss	%r11, %xmm0
                	ucomiss	%xmm0, %xmm0
@@ -1734,19 +830,19 @@ Disassembly of section .text:
                	orb	%r11b, %al
                	movzbq	%al, %rax
                	testb	%al, %al
-               	jne	 <L298>
+               	jne	 <L130>
                	movq	%rbx, %rdi
-               	callq	 <L297>
-<L297>:
+               	callq	 <L129>
+<L129>:
                	movq	%rax, %r12
-               	jmp	 <L300>
-<L298>:
+               	jmp	 <L132>
+<L130>:
                	movq	%rbx, %rdi
                	movl	$0xffffffff, %esi       # imm = 0xFFFFFFFF
-               	callq	 <L299>
-<L299>:
+               	callq	 <L131>
+<L131>:
                	movq	%rax, %r12
-<L300>:
+<L132>:
                	movq	-0x110(%rbp), %r8
                	movslq	%r8d, %r11
                	cvtsi2ss	%r11, %xmm0
@@ -1756,19 +852,19 @@ Disassembly of section .text:
                	orb	%r11b, %al
                	movzbq	%al, %rax
                	testb	%al, %al
-               	jne	 <L302>
+               	jne	 <L134>
                	movq	%r12, %rdi
-               	callq	 <L301>
-<L301>:
+               	callq	 <L133>
+<L133>:
                	movq	%rax, %rbx
-               	jmp	 <L304>
-<L302>:
+               	jmp	 <L136>
+<L134>:
                	movq	%r12, %rdi
                	movl	$0xffffffff, %esi       # imm = 0xFFFFFFFF
-               	callq	 <L303>
-<L303>:
+               	callq	 <L135>
+<L135>:
                	movq	%rax, %rbx
-<L304>:
+<L136>:
                	movq	-0x118(%rbp), %r8
                	movslq	%r8d, %r11
                	cvtsi2ss	%r11, %xmm0
@@ -1778,102 +874,102 @@ Disassembly of section .text:
                	orb	%r11b, %al
                	movzbq	%al, %rax
                	testb	%al, %al
-               	jne	 <L306>
+               	jne	 <L138>
                	movq	%rbx, %rdi
-               	callq	 <L305>
-<L305>:
+               	callq	 <L137>
+<L137>:
                	movq	%rax, %r12
-               	jmp	 <L308>
-<L306>:
+               	jmp	 <L140>
+<L138>:
                	movq	%rbx, %rdi
                	movl	$0xffffffff, %esi       # imm = 0xFFFFFFFF
-               	callq	 <L307>
-<L307>:
+               	callq	 <L139>
+<L139>:
                	movq	%rax, %r12
-<L308>:
-               	movss	, %xmm0 <corpus.cases.float.special_f32.checksum+0x17b1>
+<L140>:
+               	movss	, %xmm0 <corpus.cases.float.special_f32.checksum+0xcb0>
                	mulss	-0x38(%rbp), %xmm0
-               	movss	, %xmm14 <corpus.cases.float.special_f32.checksum+0x17bf>
+               	movss	, %xmm14 <corpus.cases.float.special_f32.checksum+0xcbe>
                	mulss	-0x38(%rbp), %xmm14
                	movss	%xmm14, -0x128(%rbp)
-               	movss	, %xmm14 <corpus.cases.float.special_f32.checksum+0x17d7>
+               	movss	, %xmm14 <corpus.cases.float.special_f32.checksum+0xcd6>
                	mulss	-0x38(%rbp), %xmm14
                	movss	%xmm14, -0x138(%rbp)
                	xorps	%xmm14, %xmm14
                	subss	%xmm0, %xmm14
                	movss	%xmm14, -0x148(%rbp)
-               	movss	, %xmm14 <corpus.cases.float.special_f32.checksum+0x1801>
+               	movss	, %xmm14 <corpus.cases.float.special_f32.checksum+0xd00>
                	mulss	-0x38(%rbp), %xmm14
                	movss	%xmm14, -0x158(%rbp)
                	cvttss2si	%xmm0, %r11
                	movl	%r11d, %eax
                	movq	%r12, %rdi
                	movl	%eax, %esi
-               	callq	 <L309>
-<L309>:
+               	callq	 <L141>
+<L141>:
                	movss	-0x128(%rbp), %xmm14
                	cvttss2si	%xmm14, %r11
                	movl	%r11d, %ecx
                	movq	%rax, %rdi
                	movl	%ecx, %esi
-               	callq	 <L310>
-<L310>:
+               	callq	 <L142>
+<L142>:
                	movss	-0x138(%rbp), %xmm14
                	cvttss2si	%xmm14, %r11
                	movl	%r11d, %ecx
                	movq	%rax, %rdi
                	movl	%ecx, %esi
-               	callq	 <L311>
-<L311>:
+               	callq	 <L143>
+<L143>:
                	movss	-0x158(%rbp), %xmm14
                	cvttss2si	%xmm14, %r11
                	movl	%r11d, %ecx
                	movq	%rax, %rdi
                	movl	%ecx, %esi
-               	callq	 <L312>
-<L312>:
+               	callq	 <L144>
+<L144>:
                	movss	-0x58(%rbp), %xmm14
                	cvttss2si	%xmm14, %r11
                	movl	%r11d, %ecx
                	movq	%rax, %rdi
                	movl	%ecx, %esi
-               	callq	 <L313>
-<L313>:
+               	callq	 <L145>
+<L145>:
                	movss	-0x148(%rbp), %xmm14
                	cvttss2si	%xmm14, %r11d
                	movl	%r11d, %ecx
                	movq	%rax, %rdi
                	movl	%ecx, %esi
-               	callq	 <L314>
-<L314>:
+               	callq	 <L146>
+<L146>:
                	movss	-0x138(%rbp), %xmm14
                	cvttss2si	%xmm14, %r11d
                	movl	%r11d, %ecx
                	movq	%rax, %rdi
                	movl	%ecx, %esi
-               	callq	 <L315>
-<L315>:
+               	callq	 <L147>
+<L147>:
                	xorps	%xmm0, %xmm0
                	subss	-0x158(%rbp), %xmm0
                	cvttss2si	%xmm0, %r11d
                	movl	%r11d, %ecx
                	movq	%rax, %rdi
                	movl	%ecx, %esi
-               	callq	 <L316>
-<L316>:
+               	callq	 <L148>
+<L148>:
                	movss	-0x148(%rbp), %xmm14
                	cvttss2si	%xmm14, %r11
                	movq	%r11, %rsi
                	movq	%rax, %rdi
-               	callq	 <L317>
-<L317>:
+               	callq	 <L149>
+<L149>:
                	xorps	%xmm0, %xmm0
                	subss	-0x128(%rbp), %xmm0
                	cvttss2si	%xmm0, %r11
                	movq	%r11, %rsi
                	movq	%rax, %rdi
-               	callq	 <L318>
-<L318>:
+               	callq	 <L150>
+<L150>:
                	movq	-0x168(%rbp), %rbx
                	movq	-0x170(%rbp), %r12
                	movq	-0x178(%rbp), %r13

--- a/test/golden/x86_64-linux/float/special_f64.dis
+++ b/test/golden/x86_64-linux/float/special_f64.dis
@@ -188,930 +188,254 @@ Disassembly of section .text:
 <L20>:
                	movsd	-0x88(%rbp), %xmm0
                	addsd	-0x88(%rbp), %xmm0
-               	ucomisd	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L22>
                	movq	%r13, %rdi
                	callq	 <L21>
 <L21>:
-               	movq	%rax, %r12
-               	jmp	 <L24>
+               	movsd	-0x78(%rbp), %xmm0
+               	subsd	-0x78(%rbp), %xmm0
+               	movq	%rax, %rdi
+               	callq	 <L22>
 <L22>:
-               	movq	%r13, %rdi
-               	movq	$-0x1, %rsi
+               	movsd	-0x78(%rbp), %xmm0
+               	subsd	-0x88(%rbp), %xmm0
+               	movq	%rax, %rdi
                	callq	 <L23>
 <L23>:
-               	movq	%rax, %r12
-<L24>:
-               	movsd	-0x78(%rbp), %xmm0
+               	movsd	-0x88(%rbp), %xmm0
                	subsd	-0x78(%rbp), %xmm0
-               	ucomisd	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L26>
-               	movq	%r12, %rdi
+               	movq	%rax, %rdi
+               	callq	 <L24>
+<L24>:
+               	movsd	-0x88(%rbp), %xmm0
+               	subsd	-0x88(%rbp), %xmm0
+               	movq	%rax, %rdi
                	callq	 <L25>
 <L25>:
-               	movq	%rax, %r13
-               	jmp	 <L28>
+               	movsd	-0x78(%rbp), %xmm0
+               	mulsd	-0x58(%rbp), %xmm0
+               	movq	%rax, %rdi
+               	callq	 <L26>
 <L26>:
-               	movq	%r12, %rdi
-               	movq	$-0x1, %rsi
+               	movsd	-0x78(%rbp), %xmm0
+               	mulsd	-0x68(%rbp), %xmm0
+               	movq	%rax, %rdi
                	callq	 <L27>
 <L27>:
-               	movq	%rax, %r13
+               	movsd	-0x88(%rbp), %xmm0
+               	mulsd	-0x58(%rbp), %xmm0
+               	movq	%rax, %rdi
+               	callq	 <L28>
 <L28>:
-               	movsd	-0x78(%rbp), %xmm0
-               	subsd	-0x88(%rbp), %xmm0
-               	ucomisd	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L30>
-               	movq	%r13, %rdi
+               	movsd	-0x88(%rbp), %xmm0
+               	mulsd	-0x68(%rbp), %xmm0
+               	movq	%rax, %rdi
                	callq	 <L29>
 <L29>:
-               	movq	%rax, %r12
-               	jmp	 <L32>
+               	movsd	-0x88(%rbp), %xmm0
+               	mulsd	-0x88(%rbp), %xmm0
+               	movq	%rax, %rdi
+               	callq	 <L30>
 <L30>:
-               	movq	%r13, %rdi
-               	movq	$-0x1, %rsi
+               	movsd	-0x78(%rbp), %xmm0
+               	mulsd	-0x88(%rbp), %xmm0
+               	movq	%rax, %rdi
                	callq	 <L31>
 <L31>:
-               	movq	%rax, %r12
+               	movsd	-0x78(%rbp), %xmm0
+               	xorps	, %xmm0 <corpus.cases.float.special_f64.checksum+0x362>
+               	movq	%rax, %rdi
+               	callq	 <L32>
 <L32>:
                	movsd	-0x88(%rbp), %xmm0
-               	subsd	-0x78(%rbp), %xmm0
-               	ucomisd	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L34>
-               	movq	%r12, %rdi
+               	xorps	, %xmm0 <corpus.cases.float.special_f64.checksum+0x379>
+               	movq	%rax, %rdi
                	callq	 <L33>
 <L33>:
-               	movq	%rax, %r13
-               	jmp	 <L36>
+               	movsd	-0x78(%rbp), %xmm0
+               	divsd	-0x58(%rbp), %xmm0
+               	movq	%rax, %rdi
+               	callq	 <L34>
 <L34>:
-               	movq	%r12, %rdi
-               	movq	$-0x1, %rsi
+               	movsd	-0x78(%rbp), %xmm0
+               	divsd	-0x68(%rbp), %xmm0
+               	movq	%rax, %rdi
                	callq	 <L35>
 <L35>:
-               	movq	%rax, %r13
+               	movsd	-0x88(%rbp), %xmm0
+               	divsd	-0x58(%rbp), %xmm0
+               	movq	%rax, %rdi
+               	callq	 <L36>
 <L36>:
                	movsd	-0x88(%rbp), %xmm0
-               	subsd	-0x88(%rbp), %xmm0
-               	ucomisd	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L38>
-               	movq	%r13, %rdi
+               	divsd	-0x68(%rbp), %xmm0
+               	movq	%rax, %rdi
                	callq	 <L37>
 <L37>:
-               	movq	%rax, %r12
-               	jmp	 <L40>
-<L38>:
-               	movq	%r13, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L39>
-<L39>:
-               	movq	%rax, %r12
-<L40>:
-               	movsd	-0x78(%rbp), %xmm0
-               	mulsd	-0x58(%rbp), %xmm0
-               	ucomisd	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L42>
-               	movq	%r12, %rdi
-               	callq	 <L41>
-<L41>:
-               	movq	%rax, %r13
-               	jmp	 <L44>
-<L42>:
-               	movq	%r12, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L43>
-<L43>:
-               	movq	%rax, %r13
-<L44>:
-               	movsd	-0x78(%rbp), %xmm0
-               	mulsd	-0x68(%rbp), %xmm0
-               	ucomisd	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L46>
-               	movq	%r13, %rdi
-               	callq	 <L45>
-<L45>:
-               	movq	%rax, %r12
-               	jmp	 <L48>
-<L46>:
-               	movq	%r13, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L47>
-<L47>:
-               	movq	%rax, %r12
-<L48>:
-               	movsd	-0x88(%rbp), %xmm0
-               	mulsd	-0x58(%rbp), %xmm0
-               	ucomisd	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L50>
-               	movq	%r12, %rdi
-               	callq	 <L49>
-<L49>:
-               	movq	%rax, %r13
-               	jmp	 <L52>
-<L50>:
-               	movq	%r12, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L51>
-<L51>:
-               	movq	%rax, %r13
-<L52>:
-               	movsd	-0x88(%rbp), %xmm0
-               	mulsd	-0x68(%rbp), %xmm0
-               	ucomisd	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L54>
-               	movq	%r13, %rdi
-               	callq	 <L53>
-<L53>:
-               	movq	%rax, %r12
-               	jmp	 <L56>
-<L54>:
-               	movq	%r13, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L55>
-<L55>:
-               	movq	%rax, %r12
-<L56>:
-               	movsd	-0x88(%rbp), %xmm0
-               	mulsd	-0x88(%rbp), %xmm0
-               	ucomisd	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L58>
-               	movq	%r12, %rdi
-               	callq	 <L57>
-<L57>:
-               	movq	%rax, %r13
-               	jmp	 <L60>
-<L58>:
-               	movq	%r12, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L59>
-<L59>:
-               	movq	%rax, %r13
-<L60>:
-               	movsd	-0x78(%rbp), %xmm0
-               	mulsd	-0x88(%rbp), %xmm0
-               	ucomisd	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L62>
-               	movq	%r13, %rdi
-               	callq	 <L61>
-<L61>:
-               	movq	%rax, %r12
-               	jmp	 <L64>
-<L62>:
-               	movq	%r13, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L63>
-<L63>:
-               	movq	%rax, %r12
-<L64>:
-               	movsd	-0x78(%rbp), %xmm0
-               	xorps	, %xmm0 <corpus.cases.float.special_f64.checksum+0x59e>
-               	ucomisd	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L66>
-               	movq	%r12, %rdi
-               	callq	 <L65>
-<L65>:
-               	movq	%rax, %r13
-               	jmp	 <L68>
-<L66>:
-               	movq	%r12, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L67>
-<L67>:
-               	movq	%rax, %r13
-<L68>:
-               	movsd	-0x88(%rbp), %xmm0
-               	xorps	, %xmm0 <corpus.cases.float.special_f64.checksum+0x5e9>
-               	ucomisd	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L70>
-               	movq	%r13, %rdi
-               	callq	 <L69>
-<L69>:
-               	movq	%rax, %r12
-               	jmp	 <L72>
-<L70>:
-               	movq	%r13, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L71>
-<L71>:
-               	movq	%rax, %r12
-<L72>:
-               	movsd	-0x78(%rbp), %xmm0
-               	divsd	-0x58(%rbp), %xmm0
-               	ucomisd	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L74>
-               	movq	%r12, %rdi
-               	callq	 <L73>
-<L73>:
-               	movq	%rax, %r13
-               	jmp	 <L76>
-<L74>:
-               	movq	%r12, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L75>
-<L75>:
-               	movq	%rax, %r13
-<L76>:
-               	movsd	-0x78(%rbp), %xmm0
-               	divsd	-0x68(%rbp), %xmm0
-               	ucomisd	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L78>
-               	movq	%r13, %rdi
-               	callq	 <L77>
-<L77>:
-               	movq	%rax, %r12
-               	jmp	 <L80>
-<L78>:
-               	movq	%r13, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L79>
-<L79>:
-               	movq	%rax, %r12
-<L80>:
-               	movsd	-0x88(%rbp), %xmm0
-               	divsd	-0x58(%rbp), %xmm0
-               	ucomisd	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L82>
-               	movq	%r12, %rdi
-               	callq	 <L81>
-<L81>:
-               	movq	%rax, %r13
-               	jmp	 <L84>
-<L82>:
-               	movq	%r12, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L83>
-<L83>:
-               	movq	%rax, %r13
-<L84>:
-               	movsd	-0x88(%rbp), %xmm0
-               	divsd	-0x68(%rbp), %xmm0
-               	ucomisd	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L86>
-               	movq	%r13, %rdi
-               	callq	 <L85>
-<L85>:
-               	movq	%rax, %r12
-               	jmp	 <L88>
-<L86>:
-               	movq	%r13, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L87>
-<L87>:
-               	movq	%rax, %r12
-<L88>:
                	movsd	-0x78(%rbp), %xmm14
                	ucomisd	-0x88(%rbp), %xmm14
                	sete	%sil
                	setnp	%r11b
                	andb	%r11b, %sil
                	movzbq	%sil, %rsi
-               	movq	%r12, %rdi
-               	callq	 <L89>
-<L89>:
+               	movq	%rax, %rdi
+               	callq	 <L38>
+<L38>:
                	movsd	-0x88(%rbp), %xmm14
                	ucomisd	-0x78(%rbp), %xmm14
                	seta	%sil
                	movzbq	%sil, %rsi
                	movq	%rax, %rdi
-               	callq	 <L90>
-<L90>:
+               	callq	 <L39>
+<L39>:
                	movsd	-0x78(%rbp), %xmm14
                	ucomisd	-0x88(%rbp), %xmm14
                	seta	%sil
                	movzbq	%sil, %rsi
                	movq	%rax, %rdi
-               	callq	 <L91>
-<L91>:
-               	movq	%rax, %r12
-               	movsd	-0x98(%rbp), %xmm14
-               	ucomisd	-0x98(%rbp), %xmm14
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L93>
-               	movq	%r12, %rdi
+               	callq	 <L40>
+<L40>:
+               	movq	%rax, %rdi
                	movsd	-0x98(%rbp), %xmm0
-               	callq	 <L92>
-<L92>:
-               	movq	%rax, %r13
-               	jmp	 <L95>
-<L93>:
-               	movq	%r12, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L94>
-<L94>:
-               	movq	%rax, %r13
-<L95>:
-               	movsd	-0xa8(%rbp), %xmm14
-               	ucomisd	-0xa8(%rbp), %xmm14
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L97>
-               	movq	%r13, %rdi
+               	callq	 <L41>
+<L41>:
+               	movq	%rax, %rdi
                	movsd	-0xa8(%rbp), %xmm0
-               	callq	 <L96>
-<L96>:
-               	movq	%rax, %r12
-               	jmp	 <L99>
-<L97>:
-               	movq	%r13, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L98>
-<L98>:
-               	movq	%rax, %r12
-<L99>:
+               	callq	 <L42>
+<L42>:
                	movsd	-0x98(%rbp), %xmm0
-               	xorps	, %xmm0 <corpus.cases.float.special_f64.checksum+0x85d>
-               	ucomisd	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L101>
-               	movq	%r12, %rdi
-               	callq	 <L100>
-<L100>:
-               	movq	%rax, %r13
-               	jmp	 <L103>
-<L101>:
-               	movq	%r12, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L102>
-<L102>:
-               	movq	%rax, %r13
-<L103>:
+               	xorps	, %xmm0 <corpus.cases.float.special_f64.checksum+0x462>
+               	movq	%rax, %rdi
+               	callq	 <L43>
+<L43>:
                	movsd	-0x58(%rbp), %xmm0
                	divsd	-0x78(%rbp), %xmm0
-               	ucomisd	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L105>
-               	movq	%r13, %rdi
-               	callq	 <L104>
-<L104>:
-               	movq	%rax, %r12
-               	jmp	 <L107>
-<L105>:
-               	movq	%r13, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L106>
-<L106>:
-               	movq	%rax, %r12
-<L107>:
+               	movq	%rax, %rdi
+               	callq	 <L44>
+<L44>:
                	movsd	-0x58(%rbp), %xmm0
                	divsd	-0x88(%rbp), %xmm0
-               	ucomisd	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L109>
-               	movq	%r12, %rdi
-               	callq	 <L108>
-<L108>:
-               	movq	%rax, %r13
-               	jmp	 <L111>
-<L109>:
-               	movq	%r12, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L110>
-<L110>:
-               	movq	%rax, %r13
-<L111>:
+               	movq	%rax, %rdi
+               	callq	 <L45>
+<L45>:
                	movsd	-0x68(%rbp), %xmm0
                	divsd	-0x78(%rbp), %xmm0
-               	ucomisd	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L113>
-               	movq	%r13, %rdi
-               	callq	 <L112>
-<L112>:
-               	movq	%rax, %r12
-               	jmp	 <L115>
-<L113>:
-               	movq	%r13, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L114>
-<L114>:
-               	movq	%rax, %r12
-<L115>:
+               	movq	%rax, %rdi
+               	callq	 <L46>
+<L46>:
                	movsd	-0x68(%rbp), %xmm0
                	divsd	-0x88(%rbp), %xmm0
-               	ucomisd	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L117>
-               	movq	%r12, %rdi
-               	callq	 <L116>
-<L116>:
-               	movq	%rax, %r13
-               	jmp	 <L119>
-<L117>:
-               	movq	%r12, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L118>
-<L118>:
-               	movq	%rax, %r13
-<L119>:
+               	movq	%rax, %rdi
+               	callq	 <L47>
+<L47>:
                	movsd	-0x98(%rbp), %xmm0
                	addsd	-0x58(%rbp), %xmm0
-               	ucomisd	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L121>
-               	movq	%r13, %rdi
-               	callq	 <L120>
-<L120>:
-               	movq	%rax, %r12
-               	jmp	 <L123>
-<L121>:
-               	movq	%r13, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L122>
-<L122>:
-               	movq	%rax, %r12
-<L123>:
+               	movq	%rax, %rdi
+               	callq	 <L48>
+<L48>:
                	movsd	-0x98(%rbp), %xmm0
                	addsd	-0x98(%rbp), %xmm0
-               	ucomisd	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L125>
-               	movq	%r12, %rdi
-               	callq	 <L124>
-<L124>:
-               	movq	%rax, %r13
-               	jmp	 <L127>
-<L125>:
-               	movq	%r12, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L126>
-<L126>:
-               	movq	%rax, %r13
-<L127>:
+               	movq	%rax, %rdi
+               	callq	 <L49>
+<L49>:
                	movsd	-0x98(%rbp), %xmm0
                	subsd	-0xa8(%rbp), %xmm0
-               	ucomisd	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L129>
-               	movq	%r13, %rdi
-               	callq	 <L128>
-<L128>:
-               	movq	%rax, %r12
-               	jmp	 <L131>
-<L129>:
-               	movq	%r13, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L130>
-<L130>:
-               	movq	%rax, %r12
-<L131>:
+               	movq	%rax, %rdi
+               	callq	 <L50>
+<L50>:
                	movsd	-0x98(%rbp), %xmm0
                	mulsd	-0x98(%rbp), %xmm0
-               	ucomisd	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L133>
-               	movq	%r12, %rdi
-               	callq	 <L132>
-<L132>:
-               	movq	%rax, %r13
-               	jmp	 <L135>
-<L133>:
-               	movq	%r12, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L134>
-<L134>:
-               	movq	%rax, %r13
-<L135>:
+               	movq	%rax, %rdi
+               	callq	 <L51>
+<L51>:
                	movsd	-0x98(%rbp), %xmm0
                	mulsd	-0xa8(%rbp), %xmm0
-               	ucomisd	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L137>
-               	movq	%r13, %rdi
-               	callq	 <L136>
-<L136>:
-               	movq	%rax, %r12
-               	jmp	 <L139>
-<L137>:
-               	movq	%r13, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L138>
-<L138>:
-               	movq	%rax, %r12
-<L139>:
+               	movq	%rax, %rdi
+               	callq	 <L52>
+<L52>:
                	movsd	-0x98(%rbp), %xmm0
                	mulsd	-0x68(%rbp), %xmm0
-               	ucomisd	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L141>
-               	movq	%r12, %rdi
-               	callq	 <L140>
-<L140>:
-               	movq	%rax, %r13
-               	jmp	 <L143>
-<L141>:
-               	movq	%r12, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L142>
-<L142>:
-               	movq	%rax, %r13
-<L143>:
+               	movq	%rax, %rdi
+               	callq	 <L53>
+<L53>:
                	movsd	-0x58(%rbp), %xmm0
                	divsd	-0x98(%rbp), %xmm0
-               	ucomisd	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L145>
-               	movq	%r13, %rdi
-               	callq	 <L144>
-<L144>:
-               	movq	%rax, %r12
-               	jmp	 <L147>
-<L145>:
-               	movq	%r13, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L146>
-<L146>:
-               	movq	%rax, %r12
-<L147>:
+               	movq	%rax, %rdi
+               	callq	 <L54>
+<L54>:
                	movsd	-0x68(%rbp), %xmm0
                	divsd	-0x98(%rbp), %xmm0
-               	ucomisd	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L149>
-               	movq	%r12, %rdi
-               	callq	 <L148>
-<L148>:
-               	movq	%rax, %r13
-               	jmp	 <L151>
-<L149>:
-               	movq	%r12, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L150>
-<L150>:
-               	movq	%rax, %r13
-<L151>:
+               	movq	%rax, %rdi
+               	callq	 <L55>
+<L55>:
                	movsd	-0x58(%rbp), %xmm0
                	divsd	-0xa8(%rbp), %xmm0
-               	ucomisd	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L153>
-               	movq	%r13, %rdi
-               	callq	 <L152>
-<L152>:
-               	movq	%rax, %r12
-               	jmp	 <L155>
-<L153>:
-               	movq	%r13, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L154>
-<L154>:
-               	movq	%rax, %r12
-<L155>:
+               	movq	%rax, %rdi
+               	callq	 <L56>
+<L56>:
                	movsd	-0x98(%rbp), %xmm0
                	divsd	-0x58(%rbp), %xmm0
-               	ucomisd	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L157>
-               	movq	%r12, %rdi
-               	callq	 <L156>
-<L156>:
-               	movq	%rax, %r13
-               	jmp	 <L159>
-<L157>:
-               	movq	%r12, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L158>
-<L158>:
-               	movq	%rax, %r13
-<L159>:
+               	movq	%rax, %rdi
+               	callq	 <L57>
+<L57>:
                	movsd	-0xc8(%rbp), %xmm0
                	addsd	-0xc8(%rbp), %xmm0
-               	ucomisd	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L161>
-               	movq	%r13, %rdi
-               	callq	 <L160>
-<L160>:
-               	movq	%rax, %r12
-               	jmp	 <L163>
-<L161>:
-               	movq	%r13, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L162>
-<L162>:
-               	movq	%rax, %r12
-<L163>:
+               	movq	%rax, %rdi
+               	callq	 <L58>
+<L58>:
                	movsd	-0x98(%rbp), %xmm14
                	ucomisd	-0xc8(%rbp), %xmm14
                	seta	%sil
                	movzbq	%sil, %rsi
-               	movq	%r12, %rdi
-               	callq	 <L164>
-<L164>:
+               	movq	%rax, %rdi
+               	callq	 <L59>
+<L59>:
                	xorps	%xmm0, %xmm0
                	subsd	-0xc8(%rbp), %xmm0
                	ucomisd	-0xa8(%rbp), %xmm0
                	seta	%sil
                	movzbq	%sil, %rsi
                	movq	%rax, %rdi
-               	callq	 <L165>
-<L165>:
-               	movq	%rax, %r12
+               	callq	 <L60>
+<L60>:
                	movsd	-0x98(%rbp), %xmm0
                	subsd	-0x98(%rbp), %xmm0
-               	ucomisd	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L167>
-               	movq	%r12, %rdi
-               	callq	 <L166>
-<L166>:
-               	movq	%rax, %r13
-               	jmp	 <L169>
-<L167>:
-               	movq	%r12, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L168>
-<L168>:
-               	movq	%rax, %r13
-<L169>:
+               	movq	%rax, %rdi
+               	callq	 <L61>
+<L61>:
                	movsd	-0xa8(%rbp), %xmm0
                	addsd	-0x98(%rbp), %xmm0
-               	ucomisd	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L171>
-               	movq	%r13, %rdi
-               	callq	 <L170>
-<L170>:
-               	movq	%rax, %r12
-               	jmp	 <L173>
-<L171>:
-               	movq	%r13, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L172>
-<L172>:
-               	movq	%rax, %r12
-<L173>:
+               	movq	%rax, %rdi
+               	callq	 <L62>
+<L62>:
                	movsd	-0x98(%rbp), %xmm0
                	mulsd	-0x78(%rbp), %xmm0
-               	ucomisd	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L175>
-               	movq	%r12, %rdi
-               	callq	 <L174>
-<L174>:
-               	movq	%rax, %r13
-               	jmp	 <L177>
-<L175>:
-               	movq	%r12, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L176>
-<L176>:
-               	movq	%rax, %r13
-<L177>:
+               	movq	%rax, %rdi
+               	callq	 <L63>
+<L63>:
                	movsd	-0xa8(%rbp), %xmm0
                	mulsd	-0x88(%rbp), %xmm0
-               	ucomisd	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L179>
-               	movq	%r13, %rdi
-               	callq	 <L178>
-<L178>:
-               	movq	%rax, %r12
-               	jmp	 <L181>
-<L179>:
-               	movq	%r13, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L180>
-<L180>:
-               	movq	%rax, %r12
-<L181>:
+               	movq	%rax, %rdi
+               	callq	 <L64>
+<L64>:
                	movsd	-0x98(%rbp), %xmm0
                	divsd	-0x98(%rbp), %xmm0
-               	ucomisd	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L183>
-               	movq	%r12, %rdi
-               	callq	 <L182>
-<L182>:
-               	movq	%rax, %r13
-               	jmp	 <L185>
-<L183>:
-               	movq	%r12, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L184>
-<L184>:
-               	movq	%rax, %r13
-<L185>:
+               	movq	%rax, %rdi
+               	callq	 <L65>
+<L65>:
                	movsd	-0x78(%rbp), %xmm0
                	divsd	-0x78(%rbp), %xmm0
-               	ucomisd	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L187>
-               	movq	%r13, %rdi
-               	callq	 <L186>
-<L186>:
-               	movq	%rax, %r12
-               	jmp	 <L189>
-<L187>:
-               	movq	%r13, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L188>
-<L188>:
-               	movq	%rax, %r12
-<L189>:
+               	movq	%rax, %rdi
+               	callq	 <L66>
+<L66>:
                	movsd	-0x88(%rbp), %xmm0
                	divsd	-0x78(%rbp), %xmm0
-               	ucomisd	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L191>
-               	movq	%r12, %rdi
-               	callq	 <L190>
-<L190>:
-               	movq	%rax, %r13
-               	jmp	 <L193>
-<L191>:
-               	movq	%r12, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L192>
-<L192>:
-               	movq	%rax, %r13
-<L193>:
+               	movq	%rax, %rdi
+               	callq	 <L67>
+<L67>:
                	movq	-0xb8(%rbp), %rsi
-               	movq	%r13, %rdi
-               	callq	 <L194>
-<L194>:
+               	movq	%rax, %rdi
+               	callq	 <L68>
+<L68>:
                	movsd	-0xb8(%rbp), %xmm14
                	ucomisd	-0xb8(%rbp), %xmm14
                	setne	%sil
@@ -1119,8 +443,8 @@ Disassembly of section .text:
                	orb	%r11b, %sil
                	movzbq	%sil, %rsi
                	movq	%rax, %rdi
-               	callq	 <L195>
-<L195>:
+               	callq	 <L69>
+<L69>:
                	movsd	-0xb8(%rbp), %xmm14
                	ucomisd	-0xb8(%rbp), %xmm14
                	sete	%sil
@@ -1128,400 +452,124 @@ Disassembly of section .text:
                	andb	%r11b, %sil
                	movzbq	%sil, %rsi
                	movq	%rax, %rdi
-               	callq	 <L196>
-<L196>:
+               	callq	 <L70>
+<L70>:
                	movsd	-0xb8(%rbp), %xmm14
                	ucomisd	-0xb8(%rbp), %xmm14
                	seta	%sil
                	movzbq	%sil, %rsi
                	movq	%rax, %rdi
-               	callq	 <L197>
-<L197>:
+               	callq	 <L71>
+<L71>:
                	movsd	-0xb8(%rbp), %xmm14
                	ucomisd	-0xb8(%rbp), %xmm14
                	setae	%sil
                	movzbq	%sil, %rsi
                	movq	%rax, %rdi
-               	callq	 <L198>
-<L198>:
+               	callq	 <L72>
+<L72>:
                	movsd	-0xb8(%rbp), %xmm14
-               	xorps	, %xmm14 <corpus.cases.float.special_f64.checksum+0xfef>
+               	xorps	, %xmm14 <corpus.cases.float.special_f64.checksum+0x745>
                	movsd	%xmm14, -0x108(%rbp)
                	movq	-0x108(%rbp), %rsi
                	movq	%rax, %rdi
-               	callq	 <L199>
-<L199>:
+               	callq	 <L73>
+<L73>:
                	movsd	-0x108(%rbp), %xmm2
-               	xorps	, %xmm2 <corpus.cases.float.special_f64.checksum+0x1016>
+               	xorps	, %xmm2 <corpus.cases.float.special_f64.checksum+0x76c>
                	movq	%xmm2, %rsi
                	movq	%rax, %rdi
-               	callq	 <L200>
-<L200>:
-               	movq	%rax, %r12
+               	callq	 <L74>
+<L74>:
                	movsd	-0xb8(%rbp), %xmm0
                	addsd	-0x58(%rbp), %xmm0
-               	ucomisd	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L202>
-               	movq	%r12, %rdi
-               	callq	 <L201>
-<L201>:
-               	movq	%rax, %r13
-               	jmp	 <L204>
-<L202>:
-               	movq	%r12, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L203>
-<L203>:
-               	movq	%rax, %r13
-<L204>:
+               	movq	%rax, %rdi
+               	callq	 <L75>
+<L75>:
                	movsd	-0x58(%rbp), %xmm0
                	addsd	-0xb8(%rbp), %xmm0
-               	ucomisd	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L206>
-               	movq	%r13, %rdi
-               	callq	 <L205>
-<L205>:
-               	movq	%rax, %r12
-               	jmp	 <L208>
-<L206>:
-               	movq	%r13, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L207>
-<L207>:
-               	movq	%rax, %r12
-<L208>:
+               	movq	%rax, %rdi
+               	callq	 <L76>
+<L76>:
                	movsd	-0xb8(%rbp), %xmm0
                	mulsd	-0x78(%rbp), %xmm0
-               	ucomisd	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L210>
-               	movq	%r12, %rdi
-               	callq	 <L209>
-<L209>:
-               	movq	%rax, %r13
-               	jmp	 <L212>
-<L210>:
-               	movq	%r12, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L211>
-<L211>:
-               	movq	%rax, %r13
-<L212>:
+               	movq	%rax, %rdi
+               	callq	 <L77>
+<L77>:
                	movsd	-0xb8(%rbp), %xmm0
                	subsd	-0xb8(%rbp), %xmm0
-               	ucomisd	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L214>
-               	movq	%r13, %rdi
-               	callq	 <L213>
-<L213>:
-               	movq	%rax, %r12
-               	jmp	 <L216>
-<L214>:
-               	movq	%r13, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L215>
-<L215>:
-               	movq	%rax, %r12
-<L216>:
+               	movq	%rax, %rdi
+               	callq	 <L78>
+<L78>:
                	movsd	-0xb8(%rbp), %xmm0
                	divsd	-0xb8(%rbp), %xmm0
-               	ucomisd	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L218>
-               	movq	%r12, %rdi
-               	callq	 <L217>
-<L217>:
-               	movq	%rax, %r13
-               	jmp	 <L220>
-<L218>:
-               	movq	%r12, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L219>
-<L219>:
-               	movq	%rax, %r13
-<L220>:
+               	movq	%rax, %rdi
+               	callq	 <L79>
+<L79>:
                	movsd	-0xb8(%rbp), %xmm0
                	divsd	-0x98(%rbp), %xmm0
-               	ucomisd	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L222>
-               	movq	%r13, %rdi
-               	callq	 <L221>
-<L221>:
-               	movq	%rax, %r12
-               	jmp	 <L224>
-<L222>:
-               	movq	%r13, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L223>
-<L223>:
-               	movq	%rax, %r12
-<L224>:
-               	movsd	-0xf8(%rbp), %xmm14
-               	ucomisd	-0xf8(%rbp), %xmm14
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L226>
-               	movq	%r12, %rdi
+               	movq	%rax, %rdi
+               	callq	 <L80>
+<L80>:
+               	movq	%rax, %rdi
                	movsd	-0xf8(%rbp), %xmm0
-               	callq	 <L225>
-<L225>:
-               	movq	%rax, %r13
-               	jmp	 <L228>
-<L226>:
-               	movq	%r12, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L227>
-<L227>:
-               	movq	%rax, %r13
-<L228>:
-               	movsd	-0xe8(%rbp), %xmm14
-               	ucomisd	-0xe8(%rbp), %xmm14
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L230>
-               	movq	%r13, %rdi
+               	callq	 <L81>
+<L81>:
+               	movq	%rax, %rdi
                	movsd	-0xe8(%rbp), %xmm0
-               	callq	 <L229>
-<L229>:
-               	movq	%rax, %r12
-               	jmp	 <L232>
-<L230>:
-               	movq	%r13, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L231>
-<L231>:
-               	movq	%rax, %r12
-<L232>:
-               	movsd	-0xd8(%rbp), %xmm14
-               	ucomisd	-0xd8(%rbp), %xmm14
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L234>
-               	movq	%r12, %rdi
+               	callq	 <L82>
+<L82>:
+               	movq	%rax, %rdi
                	movsd	-0xd8(%rbp), %xmm0
-               	callq	 <L233>
-<L233>:
-               	movq	%rax, %r13
-               	jmp	 <L236>
-<L234>:
-               	movq	%r12, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L235>
-<L235>:
-               	movq	%rax, %r13
-<L236>:
+               	callq	 <L83>
+<L83>:
                	movsd	-0xe8(%rbp), %xmm0
                	addsd	-0xf8(%rbp), %xmm0
-               	ucomisd	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L238>
-               	movq	%r13, %rdi
-               	callq	 <L237>
-<L237>:
-               	movq	%rax, %r12
-               	jmp	 <L240>
-<L238>:
-               	movq	%r13, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L239>
-<L239>:
-               	movq	%rax, %r12
-<L240>:
+               	movq	%rax, %rdi
+               	callq	 <L84>
+<L84>:
                	movsd	-0xd8(%rbp), %xmm0
                	subsd	-0xf8(%rbp), %xmm0
-               	ucomisd	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L242>
-               	movq	%r12, %rdi
-               	callq	 <L241>
-<L241>:
-               	movq	%rax, %r13
-               	jmp	 <L244>
-<L242>:
-               	movq	%r12, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L243>
-<L243>:
-               	movq	%rax, %r13
-<L244>:
+               	movq	%rax, %rdi
+               	callq	 <L85>
+<L85>:
                	movsd	-0xf8(%rbp), %xmm0
                	addsd	-0xf8(%rbp), %xmm0
-               	ucomisd	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L246>
-               	movq	%r13, %rdi
-               	callq	 <L245>
-<L245>:
-               	movq	%rax, %r12
-               	jmp	 <L248>
-<L246>:
-               	movq	%r13, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L247>
-<L247>:
-               	movq	%rax, %r12
-<L248>:
+               	movq	%rax, %rdi
+               	callq	 <L86>
+<L86>:
                	movsd	-0xf8(%rbp), %xmm0
-               	mulsd	, %xmm0 <corpus.cases.float.special_f64.checksum+0x13cf>
-               	ucomisd	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L250>
-               	movq	%r12, %rdi
-               	callq	 <L249>
-<L249>:
-               	movq	%rax, %r13
-               	jmp	 <L252>
-<L250>:
-               	movq	%r12, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L251>
-<L251>:
-               	movq	%rax, %r13
-<L252>:
+               	mulsd	, %xmm0 <corpus.cases.float.special_f64.checksum+0x888>
+               	movq	%rax, %rdi
+               	callq	 <L87>
+<L87>:
                	movsd	-0xf8(%rbp), %xmm0
-               	mulsd	, %xmm0 <corpus.cases.float.special_f64.checksum+0x141b>
-               	ucomisd	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L254>
-               	movq	%r13, %rdi
-               	callq	 <L253>
-<L253>:
-               	movq	%rax, %r12
-               	jmp	 <L256>
-<L254>:
-               	movq	%r13, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L255>
-<L255>:
-               	movq	%rax, %r12
-<L256>:
+               	mulsd	, %xmm0 <corpus.cases.float.special_f64.checksum+0x8a0>
+               	movq	%rax, %rdi
+               	callq	 <L88>
+<L88>:
                	movsd	-0xf8(%rbp), %xmm0
-               	xorps	, %xmm0 <corpus.cases.float.special_f64.checksum+0x1466>
-               	ucomisd	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L258>
-               	movq	%r12, %rdi
-               	callq	 <L257>
-<L257>:
-               	movq	%rax, %r13
-               	jmp	 <L260>
-<L258>:
-               	movq	%r12, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L259>
-<L259>:
-               	movq	%rax, %r13
-<L260>:
+               	xorps	, %xmm0 <corpus.cases.float.special_f64.checksum+0x8b7>
+               	movq	%rax, %rdi
+               	callq	 <L89>
+<L89>:
                	movsd	-0xf8(%rbp), %xmm0
-               	mulsd	, %xmm0 <corpus.cases.float.special_f64.checksum+0x14b2>
-               	ucomisd	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L262>
-               	movq	%r13, %rdi
-               	callq	 <L261>
-<L261>:
-               	movq	%rax, %r12
-               	jmp	 <L264>
-<L262>:
-               	movq	%r13, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L263>
-<L263>:
-               	movq	%rax, %r12
-<L264>:
+               	mulsd	, %xmm0 <corpus.cases.float.special_f64.checksum+0x8cf>
+               	movq	%rax, %rdi
+               	callq	 <L90>
+<L90>:
                	movsd	-0xe8(%rbp), %xmm0
                	divsd	-0xd8(%rbp), %xmm0
-               	ucomisd	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L266>
-               	movq	%r12, %rdi
-               	callq	 <L265>
-<L265>:
-               	movq	%rax, %r13
-               	jmp	 <L268>
-<L266>:
-               	movq	%r12, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L267>
-<L267>:
-               	movq	%rax, %r13
-<L268>:
+               	movq	%rax, %rdi
+               	callq	 <L91>
+<L91>:
                	movsd	-0xf8(%rbp), %xmm14
                	ucomisd	-0x78(%rbp), %xmm14
                	seta	%sil
                	movzbq	%sil, %rsi
-               	movq	%r13, %rdi
-               	callq	 <L269>
-<L269>:
+               	movq	%rax, %rdi
+               	callq	 <L92>
+<L92>:
                	movsd	-0xf8(%rbp), %xmm14
                	ucomisd	-0x78(%rbp), %xmm14
                	sete	%sil
@@ -1529,8 +577,8 @@ Disassembly of section .text:
                	andb	%r11b, %sil
                	movzbq	%sil, %rsi
                	movq	%rax, %rdi
-               	callq	 <L270>
-<L270>:
+               	callq	 <L93>
+<L93>:
                	xorps	%xmm0, %xmm0
                	subsd	-0xf8(%rbp), %xmm0
                	movsd	-0x88(%rbp), %xmm14
@@ -1538,18 +586,18 @@ Disassembly of section .text:
                	seta	%sil
                	movzbq	%sil, %rsi
                	movq	%rax, %rdi
-               	callq	 <L271>
-<L271>:
+               	callq	 <L94>
+<L94>:
                	movq	%rax, %r12
                	movq	-0xd8(%rbp), %r11
                	movq	%r11, -0x128(%rbp)
                	movq	$0x0, %r13
                	cmpq	$0x3c, %r13
-               	jb	 <L272>
-               	jmp	 <L277>
-<L272>:
+               	jb	 <L95>
+               	jmp	 <L100>
+<L95>:
                	movsd	-0x128(%rbp), %xmm14
-               	mulsd	, %xmm14 <corpus.cases.float.special_f64.checksum+0x15e1>
+               	mulsd	, %xmm14 <corpus.cases.float.special_f64.checksum+0x996>
                	movsd	%xmm14, -0x118(%rbp)
                	movsd	-0x118(%rbp), %xmm14
                	ucomisd	-0x118(%rbp), %xmm14
@@ -1558,27 +606,27 @@ Disassembly of section .text:
                	orb	%r11b, %al
                	movzbq	%al, %rax
                	testb	%al, %al
-               	jne	 <L274>
+               	jne	 <L97>
                	movq	%r12, %rdi
                	movsd	-0x118(%rbp), %xmm0
-               	callq	 <L273>
-<L273>:
+               	callq	 <L96>
+<L96>:
                	movq	%rax, %r14
-               	jmp	 <L276>
-<L274>:
+               	jmp	 <L99>
+<L97>:
                	movq	%r12, %rdi
                	movq	$-0x1, %rsi
-               	callq	 <L275>
-<L275>:
+               	callq	 <L98>
+<L98>:
                	movq	%rax, %r14
-<L276>:
+<L99>:
                	addq	$0x1, %r13
                	movq	%r14, %r12
                	movq	-0x118(%rbp), %r11
                	movq	%r11, -0x128(%rbp)
                	cmpq	$0x3c, %r13
-               	jb	 <L272>
-<L277>:
+               	jb	 <L95>
+<L100>:
                	leaq	-0x40(%rbp), %r13
                	movq	$0x0, (%r13)
                	movq	$0x0, 0x8(%r13)
@@ -1612,22 +660,22 @@ Disassembly of section .text:
                	movq	%r11, (%rax)
                	movq	$0x0, %r14
                	cmpq	$0x8, %r14
-               	jb	 <L278>
-               	jmp	 <L280>
-<L278>:
+               	jb	 <L101>
+               	jmp	 <L103>
+<L101>:
                	leaq	(%r13,%r14,8), %rax
                	movq	(%rax), %rcx
                	addq	%rbx, %rcx
                	movq	%rcx, %xmm0
                	movq	%xmm0, %rsi
                	movq	%r12, %rdi
-               	callq	 <L279>
-<L279>:
+               	callq	 <L102>
+<L102>:
                	addq	$0x1, %r14
                	movq	%rax, %r12
                	cmpq	$0x8, %r14
-               	jb	 <L278>
-<L280>:
+               	jb	 <L101>
+<L103>:
                	movsd	-0xc8(%rbp), %xmm15
                	cvtsd2ss	%xmm15, %xmm0
                	movsd	-0xf8(%rbp), %xmm15
@@ -1655,32 +703,32 @@ Disassembly of section .text:
                	cvtsd2ss	%xmm15, %xmm14
                	movss	%xmm14, -0x188(%rbp)
                	movq	%r12, %rdi
-               	callq	 <L281>
-<L281>:
+               	callq	 <L104>
+<L104>:
                	movq	%rax, %rdi
                	movss	-0x138(%rbp), %xmm0
-               	callq	 <L282>
-<L282>:
+               	callq	 <L105>
+<L105>:
                	movq	%rax, %rdi
                	movss	-0x148(%rbp), %xmm0
-               	callq	 <L283>
-<L283>:
+               	callq	 <L106>
+<L106>:
                	movq	%rax, %rdi
                	movss	-0x158(%rbp), %xmm0
-               	callq	 <L284>
-<L284>:
+               	callq	 <L107>
+<L107>:
                	movq	%rax, %rdi
                	movss	-0x168(%rbp), %xmm0
-               	callq	 <L285>
-<L285>:
+               	callq	 <L108>
+<L108>:
                	movq	%rax, %rdi
                	movss	-0x178(%rbp), %xmm0
-               	callq	 <L286>
-<L286>:
+               	callq	 <L109>
+<L109>:
                	movq	%rax, %rdi
                	movss	-0x188(%rbp), %xmm0
-               	callq	 <L287>
-<L287>:
+               	callq	 <L110>
+<L110>:
                	movq	%rax, %r12
                	movss	-0x148(%rbp), %xmm15
                	cvtss2sd	%xmm15, %xmm0
@@ -1690,19 +738,19 @@ Disassembly of section .text:
                	orb	%r11b, %al
                	movzbq	%al, %rax
                	testb	%al, %al
-               	jne	 <L289>
+               	jne	 <L112>
                	movq	%r12, %rdi
-               	callq	 <L288>
-<L288>:
+               	callq	 <L111>
+<L111>:
                	movq	%rax, %r13
-               	jmp	 <L291>
-<L289>:
+               	jmp	 <L114>
+<L112>:
                	movq	%r12, %rdi
                	movq	$-0x1, %rsi
-               	callq	 <L290>
-<L290>:
+               	callq	 <L113>
+<L113>:
                	movq	%rax, %r13
-<L291>:
+<L114>:
                	movss	-0x178(%rbp), %xmm15
                	cvtss2sd	%xmm15, %xmm0
                	ucomisd	%xmm0, %xmm0
@@ -1711,19 +759,19 @@ Disassembly of section .text:
                	orb	%r11b, %al
                	movzbq	%al, %rax
                	testb	%al, %al
-               	jne	 <L293>
+               	jne	 <L116>
                	movq	%r13, %rdi
-               	callq	 <L292>
-<L292>:
+               	callq	 <L115>
+<L115>:
                	movq	%rax, %r12
-               	jmp	 <L295>
-<L293>:
+               	jmp	 <L118>
+<L116>:
                	movq	%r13, %rdi
                	movq	$-0x1, %rsi
-               	callq	 <L294>
-<L294>:
+               	callq	 <L117>
+<L117>:
                	movq	%rax, %r12
-<L295>:
+<L118>:
                	movss	-0x188(%rbp), %xmm15
                	cvtss2sd	%xmm15, %xmm0
                	ucomisd	%xmm0, %xmm0
@@ -1732,19 +780,19 @@ Disassembly of section .text:
                	orb	%r11b, %al
                	movzbq	%al, %rax
                	testb	%al, %al
-               	jne	 <L297>
+               	jne	 <L120>
                	movq	%r12, %rdi
-               	callq	 <L296>
-<L296>:
+               	callq	 <L119>
+<L119>:
                	movq	%rax, %r13
-               	jmp	 <L299>
-<L297>:
+               	jmp	 <L122>
+<L120>:
                	movq	%r12, %rdi
                	movq	$-0x1, %rsi
-               	callq	 <L298>
-<L298>:
+               	callq	 <L121>
+<L121>:
                	movq	%rax, %r13
-<L299>:
+<L122>:
                	movabsq	$0x20000000000000, %rax # imm = 0x20000000000000
                	addq	%rbx, %rax
                	movabsq	$0x20000000000001, %r12 # imm = 0x20000000000001
@@ -1761,168 +809,168 @@ Disassembly of section .text:
                	movq	%r8, -0x198(%rbp)
                	movq	%rax, %r11
                	testq	%r11, %r11
-               	jl	 <L300>
+               	jl	 <L123>
                	cvtsi2sd	%r11, %xmm0
-               	jmp	 <L301>
-<L300>:
+               	jmp	 <L124>
+<L123>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2sd	%r11, %xmm0
                	addsd	%xmm0, %xmm0
-<L301>:
+<L124>:
                	ucomisd	%xmm0, %xmm0
                	setne	%al
                	setp	%r11b
                	orb	%r11b, %al
                	movzbq	%al, %rax
                	testb	%al, %al
-               	jne	 <L303>
+               	jne	 <L126>
                	movq	%r13, %rdi
-               	callq	 <L302>
-<L302>:
+               	callq	 <L125>
+<L125>:
                	movq	%rax, %r8
                	movq	%r8, -0x48(%rbp)
-               	jmp	 <L305>
-<L303>:
+               	jmp	 <L128>
+<L126>:
                	movq	%r13, %rdi
                	movq	$-0x1, %rsi
-               	callq	 <L304>
-<L304>:
+               	callq	 <L127>
+<L127>:
                	movq	%rax, %r8
                	movq	%r8, -0x48(%rbp)
-<L305>:
+<L128>:
                	movq	%r12, %r11
                	testq	%r11, %r11
-               	jl	 <L306>
+               	jl	 <L129>
                	cvtsi2sd	%r11, %xmm0
-               	jmp	 <L307>
-<L306>:
+               	jmp	 <L130>
+<L129>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2sd	%r11, %xmm0
                	addsd	%xmm0, %xmm0
-<L307>:
+<L130>:
                	ucomisd	%xmm0, %xmm0
                	setne	%al
                	setp	%r11b
                	orb	%r11b, %al
                	movzbq	%al, %rax
                	testb	%al, %al
-               	jne	 <L309>
+               	jne	 <L132>
                	movq	-0x48(%rbp), %r8
                	movq	%r8, %rdi
-               	callq	 <L308>
-<L308>:
+               	callq	 <L131>
+<L131>:
                	movq	%rax, %r12
-               	jmp	 <L311>
-<L309>:
+               	jmp	 <L134>
+<L132>:
                	movq	-0x48(%rbp), %r8
                	movq	%r8, %rdi
                	movq	$-0x1, %rsi
-               	callq	 <L310>
-<L310>:
+               	callq	 <L133>
+<L133>:
                	movq	%rax, %r12
-<L311>:
+<L134>:
                	movq	%r14, %r11
                	testq	%r11, %r11
-               	jl	 <L312>
+               	jl	 <L135>
                	cvtsi2sd	%r11, %xmm0
-               	jmp	 <L313>
-<L312>:
+               	jmp	 <L136>
+<L135>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2sd	%r11, %xmm0
                	addsd	%xmm0, %xmm0
-<L313>:
+<L136>:
                	ucomisd	%xmm0, %xmm0
                	setne	%al
                	setp	%r11b
                	orb	%r11b, %al
                	movzbq	%al, %rax
                	testb	%al, %al
-               	jne	 <L315>
+               	jne	 <L138>
                	movq	%r12, %rdi
-               	callq	 <L314>
-<L314>:
+               	callq	 <L137>
+<L137>:
                	movq	%rax, %r13
-               	jmp	 <L317>
-<L315>:
+               	jmp	 <L140>
+<L138>:
                	movq	%r12, %rdi
                	movq	$-0x1, %rsi
-               	callq	 <L316>
-<L316>:
+               	callq	 <L139>
+<L139>:
                	movq	%rax, %r13
-<L317>:
+<L140>:
                	movq	%r15, %r11
                	testq	%r11, %r11
-               	jl	 <L318>
+               	jl	 <L141>
                	cvtsi2sd	%r11, %xmm0
-               	jmp	 <L319>
-<L318>:
+               	jmp	 <L142>
+<L141>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2sd	%r11, %xmm0
                	addsd	%xmm0, %xmm0
-<L319>:
+<L142>:
                	ucomisd	%xmm0, %xmm0
                	setne	%al
                	setp	%r11b
                	orb	%r11b, %al
                	movzbq	%al, %rax
                	testb	%al, %al
-               	jne	 <L321>
+               	jne	 <L144>
                	movq	%r13, %rdi
-               	callq	 <L320>
-<L320>:
+               	callq	 <L143>
+<L143>:
                	movq	%rax, %r12
-               	jmp	 <L323>
-<L321>:
+               	jmp	 <L146>
+<L144>:
                	movq	%r13, %rdi
                	movq	$-0x1, %rsi
-               	callq	 <L322>
-<L322>:
+               	callq	 <L145>
+<L145>:
                	movq	%rax, %r12
-<L323>:
+<L146>:
                	movq	%rbx, %r11
                	testq	%r11, %r11
-               	jl	 <L324>
+               	jl	 <L147>
                	cvtsi2sd	%r11, %xmm0
-               	jmp	 <L325>
-<L324>:
+               	jmp	 <L148>
+<L147>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2sd	%r11, %xmm0
                	addsd	%xmm0, %xmm0
-<L325>:
+<L148>:
                	ucomisd	%xmm0, %xmm0
                	setne	%al
                	setp	%r11b
                	orb	%r11b, %al
                	movzbq	%al, %rax
                	testb	%al, %al
-               	jne	 <L327>
+               	jne	 <L150>
                	movq	%r12, %rdi
-               	callq	 <L326>
-<L326>:
+               	callq	 <L149>
+<L149>:
                	movq	%rax, %rbx
-               	jmp	 <L329>
-<L327>:
+               	jmp	 <L152>
+<L150>:
                	movq	%r12, %rdi
                	movq	$-0x1, %rsi
-               	callq	 <L328>
-<L328>:
+               	callq	 <L151>
+<L151>:
                	movq	%rax, %rbx
-<L329>:
+<L152>:
                	movq	-0x190(%rbp), %r8
                	movq	%r8, %r11
                	cvtsi2sd	%r11, %xmm0
@@ -1932,19 +980,19 @@ Disassembly of section .text:
                	orb	%r11b, %al
                	movzbq	%al, %rax
                	testb	%al, %al
-               	jne	 <L331>
+               	jne	 <L154>
                	movq	%rbx, %rdi
-               	callq	 <L330>
-<L330>:
+               	callq	 <L153>
+<L153>:
                	movq	%rax, %r12
-               	jmp	 <L333>
-<L331>:
+               	jmp	 <L156>
+<L154>:
                	movq	%rbx, %rdi
                	movq	$-0x1, %rsi
-               	callq	 <L332>
-<L332>:
+               	callq	 <L155>
+<L155>:
                	movq	%rax, %r12
-<L333>:
+<L156>:
                	movq	-0x198(%rbp), %r8
                	movq	%r8, %r11
                	cvtsi2sd	%r11, %xmm0
@@ -1954,147 +1002,147 @@ Disassembly of section .text:
                	orb	%r11b, %al
                	movzbq	%al, %rax
                	testb	%al, %al
-               	jne	 <L335>
+               	jne	 <L158>
                	movq	%r12, %rdi
-               	callq	 <L334>
-<L334>:
+               	callq	 <L157>
+<L157>:
                	movq	%rax, %rbx
-               	jmp	 <L337>
-<L335>:
+               	jmp	 <L160>
+<L158>:
                	movq	%r12, %rdi
                	movq	$-0x1, %rsi
-               	callq	 <L336>
-<L336>:
+               	callq	 <L159>
+<L159>:
                	movq	%rax, %rbx
-<L337>:
-               	movsd	, %xmm14 <corpus.cases.float.special_f64.checksum+0x1c6b>
+<L160>:
+               	movsd	, %xmm14 <corpus.cases.float.special_f64.checksum+0x1020>
                	mulsd	-0x58(%rbp), %xmm14
                	movsd	%xmm14, -0x1a8(%rbp)
-               	movsd	, %xmm14 <corpus.cases.float.special_f64.checksum+0x1c83>
+               	movsd	, %xmm14 <corpus.cases.float.special_f64.checksum+0x1038>
                	mulsd	-0x58(%rbp), %xmm14
                	movsd	%xmm14, -0x1b8(%rbp)
-               	movsd	, %xmm14 <corpus.cases.float.special_f64.checksum+0x1c9b>
+               	movsd	, %xmm14 <corpus.cases.float.special_f64.checksum+0x1050>
                	mulsd	-0x58(%rbp), %xmm14
                	movsd	%xmm14, -0x1c8(%rbp)
                	xorps	%xmm14, %xmm14
                	subsd	-0x1a8(%rbp), %xmm14
                	movsd	%xmm14, -0x1d8(%rbp)
-               	movsd	, %xmm14 <corpus.cases.float.special_f64.checksum+0x1cc9>
+               	movsd	, %xmm14 <corpus.cases.float.special_f64.checksum+0x107e>
                	mulsd	-0x58(%rbp), %xmm14
                	movsd	%xmm14, -0x1e8(%rbp)
                	movsd	-0x1a8(%rbp), %xmm14
-               	ucomisd	, %xmm14 <corpus.cases.float.special_f64.checksum+0x1cea>
-               	jb	 <L338>
+               	ucomisd	, %xmm14 <corpus.cases.float.special_f64.checksum+0x109f>
+               	jb	 <L161>
                	movaps	%xmm14, %xmm14
-               	subsd	, %xmm14 <corpus.cases.float.special_f64.checksum+0x1cfd>
+               	subsd	, %xmm14 <corpus.cases.float.special_f64.checksum+0x10b2>
                	cvttsd2si	%xmm14, %r11
                	movabsq	$-0x8000000000000000, %r10 # imm = 0x8000000000000000
                	addq	%r10, %r11
-               	jmp	 <L339>
-<L338>:
+               	jmp	 <L162>
+<L161>:
                	cvttsd2si	%xmm14, %r11
-<L339>:
+<L162>:
                	movq	%r11, %rsi
                	movq	%rbx, %rdi
-               	callq	 <L340>
-<L340>:
+               	callq	 <L163>
+<L163>:
                	movsd	-0x1b8(%rbp), %xmm14
-               	ucomisd	, %xmm14 <corpus.cases.float.special_f64.checksum+0x1d36>
-               	jb	 <L341>
+               	ucomisd	, %xmm14 <corpus.cases.float.special_f64.checksum+0x10eb>
+               	jb	 <L164>
                	movaps	%xmm14, %xmm14
-               	subsd	, %xmm14 <corpus.cases.float.special_f64.checksum+0x1d49>
+               	subsd	, %xmm14 <corpus.cases.float.special_f64.checksum+0x10fe>
                	cvttsd2si	%xmm14, %r11
                	movabsq	$-0x8000000000000000, %r10 # imm = 0x8000000000000000
                	addq	%r10, %r11
-               	jmp	 <L342>
-<L341>:
+               	jmp	 <L165>
+<L164>:
                	cvttsd2si	%xmm14, %r11
-<L342>:
+<L165>:
                	movq	%r11, %rsi
                	movq	%rax, %rdi
-               	callq	 <L343>
-<L343>:
+               	callq	 <L166>
+<L166>:
                	movsd	-0x1c8(%rbp), %xmm14
-               	ucomisd	, %xmm14 <corpus.cases.float.special_f64.checksum+0x1d82>
-               	jb	 <L344>
+               	ucomisd	, %xmm14 <corpus.cases.float.special_f64.checksum+0x1137>
+               	jb	 <L167>
                	movaps	%xmm14, %xmm14
-               	subsd	, %xmm14 <corpus.cases.float.special_f64.checksum+0x1d95>
+               	subsd	, %xmm14 <corpus.cases.float.special_f64.checksum+0x114a>
                	cvttsd2si	%xmm14, %r11
                	movabsq	$-0x8000000000000000, %r10 # imm = 0x8000000000000000
                	addq	%r10, %r11
-               	jmp	 <L345>
-<L344>:
+               	jmp	 <L168>
+<L167>:
                	cvttsd2si	%xmm14, %r11
-<L345>:
+<L168>:
                	movq	%r11, %rsi
                	movq	%rax, %rdi
-               	callq	 <L346>
-<L346>:
+               	callq	 <L169>
+<L169>:
                	movsd	-0x1e8(%rbp), %xmm14
-               	ucomisd	, %xmm14 <corpus.cases.float.special_f64.checksum+0x1dce>
-               	jb	 <L347>
+               	ucomisd	, %xmm14 <corpus.cases.float.special_f64.checksum+0x1183>
+               	jb	 <L170>
                	movaps	%xmm14, %xmm14
-               	subsd	, %xmm14 <corpus.cases.float.special_f64.checksum+0x1de1>
+               	subsd	, %xmm14 <corpus.cases.float.special_f64.checksum+0x1196>
                	cvttsd2si	%xmm14, %r11
                	movabsq	$-0x8000000000000000, %r10 # imm = 0x8000000000000000
                	addq	%r10, %r11
-               	jmp	 <L348>
-<L347>:
+               	jmp	 <L171>
+<L170>:
                	cvttsd2si	%xmm14, %r11
-<L348>:
+<L171>:
                	movq	%r11, %rsi
                	movq	%rax, %rdi
-               	callq	 <L349>
-<L349>:
+               	callq	 <L172>
+<L172>:
                	movsd	-0x78(%rbp), %xmm14
-               	ucomisd	, %xmm14 <corpus.cases.float.special_f64.checksum+0x1e17>
-               	jb	 <L350>
+               	ucomisd	, %xmm14 <corpus.cases.float.special_f64.checksum+0x11cc>
+               	jb	 <L173>
                	movaps	%xmm14, %xmm14
-               	subsd	, %xmm14 <corpus.cases.float.special_f64.checksum+0x1e2a>
+               	subsd	, %xmm14 <corpus.cases.float.special_f64.checksum+0x11df>
                	cvttsd2si	%xmm14, %r11
                	movabsq	$-0x8000000000000000, %r10 # imm = 0x8000000000000000
                	addq	%r10, %r11
-               	jmp	 <L351>
-<L350>:
+               	jmp	 <L174>
+<L173>:
                	cvttsd2si	%xmm14, %r11
-<L351>:
+<L174>:
                	movq	%r11, %rsi
                	movq	%rax, %rdi
-               	callq	 <L352>
-<L352>:
+               	callq	 <L175>
+<L175>:
                	movsd	-0x1d8(%rbp), %xmm14
                	cvttsd2si	%xmm14, %r11
                	movq	%r11, %rsi
                	movq	%rax, %rdi
-               	callq	 <L353>
-<L353>:
+               	callq	 <L176>
+<L176>:
                	movsd	-0x1c8(%rbp), %xmm14
                	cvttsd2si	%xmm14, %r11
                	movq	%r11, %rsi
                	movq	%rax, %rdi
-               	callq	 <L354>
-<L354>:
+               	callq	 <L177>
+<L177>:
                	xorps	%xmm1, %xmm1
                	subsd	-0x1e8(%rbp), %xmm1
                	cvttsd2si	%xmm1, %r11
                	movq	%r11, %rsi
                	movq	%rax, %rdi
-               	callq	 <L355>
-<L355>:
+               	callq	 <L178>
+<L178>:
                	movsd	-0x1d8(%rbp), %xmm14
                	cvttsd2si	%xmm14, %r11d
                	movl	%r11d, %ecx
                	movq	%rax, %rdi
                	movl	%ecx, %esi
-               	callq	 <L356>
-<L356>:
+               	callq	 <L179>
+<L179>:
                	movsd	-0x1a8(%rbp), %xmm14
                	cvttsd2si	%xmm14, %r11
                	movl	%r11d, %ecx
                	movq	%rax, %rdi
                	movl	%ecx, %esi
-               	callq	 <L357>
-<L357>:
+               	callq	 <L180>
+<L180>:
                	movq	-0x1f8(%rbp), %rbx
                	movq	-0x200(%rbp), %r12
                	movq	-0x208(%rbp), %r13

--- a/test/golden/x86_64-linux/mem/global_data.dis
+++ b/test/golden/x86_64-linux/mem/global_data.dis
@@ -260,10 +260,16 @@ Disassembly of section .text:
                	divq	%rsi
                	movq	%rdx, %rsi
                	leaq	(%rcx,%rsi,2), %rbx
-               	movzwl	(%rbx), %ecx
-               	addl	$0x64, %ecx
-               	movw	%cx, (%rbx)
-               	leaq	, %rcx <corpus.cases.mem.global_data.advance+0x1be>
+               	movzwl	(%rbx), %esi
+               	addl	$0x64, %esi
+               	movq	%rdi, %rax
+               	movq	$0x3, %rbx
+               	xorl	%edx, %edx
+               	divq	%rbx
+               	movq	%rdx, %rbx
+               	leaq	(%rcx,%rbx,2), %r12
+               	movw	%si, (%r12)
+               	leaq	, %rcx <corpus.cases.mem.global_data.advance+0x1d6>
                	movl	(%rcx), %esi
                	movl	%edi, %ebx
                	subl	%ebx, %esi
@@ -280,12 +286,12 @@ Disassembly of section .text:
 <corpus.cases.mem.global_data.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0xf0, %rsp
-               	movq	%rbx, -0xc8(%rbp)
-               	movq	%r12, -0xd0(%rbp)
-               	movq	%r13, -0xd8(%rbp)
-               	movq	%r14, -0xe0(%rbp)
-               	movq	%r15, -0xe8(%rbp)
+               	subq	$0x100, %rsp            # imm = 0x100
+               	movq	%rbx, -0xd8(%rbp)
+               	movq	%r12, -0xe0(%rbp)
+               	movq	%r13, -0xe8(%rbp)
+               	movq	%r14, -0xf0(%rbp)
+               	movq	%r15, -0xf8(%rbp)
                	movq	%rdi, %rbx
                	callq	 <L0>
 <L0>:
@@ -311,7 +317,7 @@ Disassembly of section .text:
                	leaq	, %r14 <corpus.cases.mem.global_data.checksum+0x88>
                	leaq	, %r15 <corpus.cases.mem.global_data.checksum+0x8f>
                	leaq	, %r8 <corpus.cases.mem.global_data.checksum+0x96>
-               	movq	%r8, -0xb8(%rbp)
+               	movq	%r8, -0xc8(%rbp)
                	leaq	, %r8 <corpus.cases.mem.global_data.checksum+0xa4>
                	movq	%r8, -0x18(%rbp)
                	leaq	, %r8 <corpus.cases.mem.global_data.checksum+0xaf>
@@ -319,13 +325,13 @@ Disassembly of section .text:
                	movq	%rcx, %r8
                	movq	%r8, -0x28(%rbp)
                	movq	$0x0, %r8
-               	movq	%r8, -0xb0(%rbp)
-               	movq	-0xb0(%rbp), %r8
+               	movq	%r8, -0xc0(%rbp)
+               	movq	-0xc0(%rbp), %r8
                	cmpq	$0x5, %r8
                	jb	 <L5>
                	jmp	 <L9>
 <L5>:
-               	movq	-0xb0(%rbp), %r8
+               	movq	-0xc0(%rbp), %r8
                	movq	%r8, %rdi
                	addq	$0x1, %rdi
                	movq	%rdi, %r8
@@ -450,10 +456,10 @@ Disassembly of section .text:
                	addq	%r8, %rdi
                	movq	%rdi, (%r15)
                	movq	, %rdi <corpus.cases.mem.global_data.checksum+0x30a>
-               	movq	-0xb8(%rbp), %r8
+               	movq	-0xc8(%rbp), %r8
                	movq	%rdi, (%r8)
                	movq	, %rdi <corpus.cases.mem.global_data.checksum+0x31b>
-               	movq	-0xb8(%rbp), %r8
+               	movq	-0xc8(%rbp), %r8
                	movq	%rdi, 0x8(%r8)
                	movq	-0x30(%rbp), %r8
                	movq	%r8, %rax
@@ -466,65 +472,77 @@ Disassembly of section .text:
                	movq	%r8, -0x98(%rbp)
                	movq	-0x98(%rbp), %r8
                	movzwl	(%r8), %edi
-               	addl	$0x64, %edi
-               	movq	-0x98(%rbp), %r8
-               	movw	%di, (%r8)
-               	movq	-0x20(%rbp), %r9
-               	movl	(%r9), %r8d
+               	movl	%edi, %r8d
+               	addl	$0x64, %r8d
                	movq	%r8, -0xa0(%rbp)
                	movq	-0x30(%rbp), %r8
-               	movl	%r8d, %edi
+               	movq	%r8, %rax
+               	movq	$0x3, %rdi
+               	xorl	%edx, %edx
+               	divq	%rdi
+               	movq	%rdx, %rdi
+               	movq	-0x18(%rbp), %r9
+               	leaq	(%r9,%rdi,2), %r8
+               	movq	%r8, -0xa8(%rbp)
+               	movq	-0xa8(%rbp), %r8
                	movq	-0xa0(%rbp), %r9
+               	movw	%r9w, (%r8)
+               	movq	-0x20(%rbp), %r9
+               	movl	(%r9), %r8d
+               	movq	%r8, -0xb0(%rbp)
+               	movq	-0x30(%rbp), %r8
+               	movl	%r8d, %edi
+               	movq	-0xb0(%rbp), %r9
                	movl	%r9d, %r8d
                	subl	%edi, %r8d
-               	movq	%r8, -0xa8(%rbp)
+               	movq	%r8, -0xb8(%rbp)
                	movq	-0x20(%rbp), %r8
-               	movq	-0xa8(%rbp), %r9
+               	movq	-0xb8(%rbp), %r9
                	movl	%r9d, (%r8)
                	movq	-0x28(%rbp), %r8
                	movq	%r8, %rdi
                	callq	 <L8>
 <L8>:
                	movq	%rax, %rdi
-               	movq	-0xb0(%rbp), %r8
+               	movq	-0xc0(%rbp), %r8
                	movq	%r8, %rcx
                	addq	$0x1, %rcx
                	movq	%rdi, %r8
                	movq	%r8, -0x28(%rbp)
                	movq	%rcx, %r8
-               	movq	%r8, -0xb0(%rbp)
-               	movq	-0xb0(%rbp), %r8
+               	movq	%r8, -0xc0(%rbp)
+               	movq	-0xc0(%rbp), %r8
                	cmpq	$0x5, %r8
                	jb	 <L5>
 <L9>:
-               	movq	, %rcx <corpus.cases.mem.global_data.checksum+0x3e1>
+               	movq	, %rcx <corpus.cases.mem.global_data.checksum+0x418>
                	movabsq	$-0x61c8864680b583eb, %r11 # imm = 0x9E3779B97F4A7C15
                	xorq	%r11, %rcx
-               	movq	%rcx,  <corpus.cases.mem.global_data.checksum+0x3f5>
-               	movq	, %rsi <corpus.cases.mem.global_data.checksum+0x3fc>
+               	movq	%rcx,  <corpus.cases.mem.global_data.checksum+0x42c>
+               	movq	, %rsi <corpus.cases.mem.global_data.checksum+0x433>
                	movq	-0x28(%rbp), %r8
                	movq	%r8, %rdi
                	callq	 <L10>
 <L10>:
                	movq	%rax, %rdi
                	leaq	-0x10(%rbp), %rcx
-               	movq	, %rsi <corpus.cases.mem.global_data.checksum+0x416>
+               	movq	, %rsi <corpus.cases.mem.global_data.checksum+0x44d>
                	movq	%rsi, (%rcx)
-               	movq	, %rsi <corpus.cases.mem.global_data.checksum+0x420>
+               	movq	, %rsi <corpus.cases.mem.global_data.checksum+0x457>
                	movq	%rsi, 0x8(%rcx)
                	leaq	0x8(%rcx), %rsi
                	movq	(%rsi), %rbx
                	addq	$0x1, %rbx
                	movq	%rbx, (%rsi)
                	movq	(%rcx), %rsi
-               	movq	%rsi,  <corpus.cases.mem.global_data.checksum+0x43c>
+               	movq	%rsi,  <corpus.cases.mem.global_data.checksum+0x473>
                	movq	0x8(%rcx), %rsi
-               	movq	%rsi,  <corpus.cases.mem.global_data.checksum+0x447>
-               	leaq	, %rcx <corpus.cases.mem.global_data.checksum+0x44e>
+               	movq	%rsi,  <corpus.cases.mem.global_data.checksum+0x47e>
+               	leaq	, %rcx <corpus.cases.mem.global_data.checksum+0x485>
                	movzwl	(%rcx), %esi
-               	leaq	, %rcx <corpus.cases.mem.global_data.checksum+0x458>
+               	leaq	, %rcx <corpus.cases.mem.global_data.checksum+0x48f>
                	movzbl	(%rcx), %ebx
-               	leaq	, %rcx <corpus.cases.mem.global_data.checksum+0x462>
+               	leaq	, %rcx <corpus.cases.mem.global_data.checksum+0x499>
                	movq	(%rcx), %r12
                	callq	 <L11>
 <L11>:
@@ -541,11 +559,11 @@ Disassembly of section .text:
 <L14>:
                	movq	%rax, %rcx
                	movq	%rcx, %rax
-               	movq	-0xc8(%rbp), %rbx
-               	movq	-0xd0(%rbp), %r12
-               	movq	-0xd8(%rbp), %r13
-               	movq	-0xe0(%rbp), %r14
-               	movq	-0xe8(%rbp), %r15
+               	movq	-0xd8(%rbp), %rbx
+               	movq	-0xe0(%rbp), %r12
+               	movq	-0xe8(%rbp), %r13
+               	movq	-0xf0(%rbp), %r14
+               	movq	-0xf8(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-linux/vec/autovec_loop.dis
+++ b/test/golden/x86_64-linux/vec/autovec_loop.dis
@@ -5,12 +5,12 @@ Disassembly of section .text:
 <corpus.cases.vec.autovec_loop.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x970, %rsp            # imm = 0x970
-               	movq	%rbx, -0x948(%rbp)
-               	movq	%r12, -0x950(%rbp)
-               	movq	%r13, -0x958(%rbp)
-               	movq	%r14, -0x960(%rbp)
-               	movq	%r15, -0x968(%rbp)
+               	subq	$0x980, %rsp            # imm = 0x980
+               	movq	%rbx, -0x958(%rbp)
+               	movq	%r12, -0x960(%rbp)
+               	movq	%r13, -0x968(%rbp)
+               	movq	%r14, -0x970(%rbp)
+               	movq	%r15, -0x978(%rbp)
                	movq	%rdi, %rbx
                	callq	 <L0>
 <L0>:
@@ -39,7 +39,7 @@ Disassembly of section .text:
                	cvtsi2ss	%r11, %xmm14
                	addss	%xmm14, %xmm14
 <L2>:
-               	movss	%xmm14, -0x930(%rbp)
+               	movss	%xmm14, -0x940(%rbp)
                	leaq	-0x10c(%rbp), %rbx
                	movq	$0x0, (%rbx)
                	movq	$0x0, 0x8(%rbx)
@@ -204,7 +204,7 @@ Disassembly of section .text:
 <L6>:
                	movq	-0x8a0(%rbp), %r9
                	movq	%r9, %r8
-               	movq	%r8, -0x938(%rbp)
+               	movq	%r8, -0x948(%rbp)
                	movq	$0x0, %r13
                	cmpq	%r12, %r13
                	jb	 <L7>
@@ -213,7 +213,7 @@ Disassembly of section .text:
                	leaq	(%r15,%r13,4), %rsi
                	movl	(%rsi), %r8d
                	movq	%r8, -0x8c0(%rbp)
-               	movq	-0x938(%rbp), %r8
+               	movq	-0x948(%rbp), %r8
                	movq	%r8, %rdi
                	movq	-0x8c0(%rbp), %r8
                	movl	%r8d, %esi
@@ -222,7 +222,7 @@ Disassembly of section .text:
                	movq	%rax, %rcx
                	addq	$0x1, %r13
                	movq	%rcx, %r8
-               	movq	%r8, -0x938(%rbp)
+               	movq	%r8, -0x948(%rbp)
                	cmpq	%r12, %r13
                	jb	 <L7>
 <L9>:
@@ -255,7 +255,7 @@ Disassembly of section .text:
                	cmpq	%r12, %rsi
                	jb	 <L10>
 <L11>:
-               	movq	-0x938(%rbp), %r8
+               	movq	-0x948(%rbp), %r8
                	movq	%r8, %rdi
                	movq	-0x8d0(%rbp), %r8
                	movl	%r8d, %esi
@@ -354,13 +354,13 @@ Disassembly of section .text:
                	movq	-0x8e0(%rbp), %r8
                	movq	%r8, %r14
                	movq	$0x0, %r8
-               	movq	%r8, -0x940(%rbp)
-               	movq	-0x940(%rbp), %r8
+               	movq	%r8, -0x950(%rbp)
+               	movq	-0x950(%rbp), %r8
                	cmpq	%r12, %r8
                	jb	 <L18>
                	jmp	 <L20>
 <L18>:
-               	movq	-0x940(%rbp), %r8
+               	movq	-0x950(%rbp), %r8
                	leaq	(%r13,%r8,4), %rsi
                	movl	(%rsi), %r8d
                	movq	%r8, -0x8f0(%rbp)
@@ -370,12 +370,12 @@ Disassembly of section .text:
                	callq	 <L19>
 <L19>:
                	movq	%rax, %r14
-               	movq	-0x940(%rbp), %r8
+               	movq	-0x950(%rbp), %r8
                	movq	%r8, %rcx
                	addq	$0x1, %rcx
                	movq	%rcx, %r8
-               	movq	%r8, -0x940(%rbp)
-               	movq	-0x940(%rbp), %r8
+               	movq	%r8, -0x950(%rbp)
+               	movq	-0x950(%rbp), %r8
                	cmpq	%r12, %r8
                	jb	 <L18>
 <L20>:
@@ -587,7 +587,7 @@ Disassembly of section .text:
                	addss	%xmm1, %xmm1
 <L35>:
                	movss	%xmm1, %xmm2            # xmm2 = xmm1[0],xmm2[1,2,3]
-               	addss	-0x930(%rbp), %xmm2
+               	addss	-0x940(%rbp), %xmm2
                	leaq	(%rbx,%rcx,4), %rsi
                	movss	%xmm2, (%rsi)
                	movss	, %xmm2 <corpus.cases.vec.autovec_loop.checksum+0xea6>
@@ -619,38 +619,52 @@ Disassembly of section .text:
                	movq	$0x0, 0x80(%r13)
                	movq	$0x0, 0x88(%r13)
                	movl	$0x0, 0x90(%r13)
-               	leaq	(%rbx), %rcx
                	movq	-0x8b8(%rbp), %r8
-               	leaq	(%rbx,%r8,4), %rsi
+               	movabsq	$-0x100000001, %r11     # imm = 0xFFFFFFFEFFFFFFFF
+               	cmpq	%r11, %r8
+               	setbe	%cl
+               	movzbq	%cl, %rcx
+               	andl	$0x1, %ecx
+               	andl	$0x1, %ecx
+               	andl	$0x1, %ecx
+               	movl	%ecx, %r8d
+               	andl	$0x1, %r8d
+               	movq	%r8, -0x8f8(%rbp)
+               	leaq	(%rbx), %rsi
+               	movq	-0x8b8(%rbp), %r8
+               	leaq	(%rbx,%r8,4), %rdi
                	leaq	(%r12), %r8
-               	movq	%r8, -0x900(%rbp)
+               	movq	%r8, -0x908(%rbp)
                	movq	-0x8b8(%rbp), %r9
                	leaq	(%r12,%r9,4), %r8
-               	movq	%r8, -0x908(%rbp)
+               	movq	%r8, -0x910(%rbp)
                	leaq	(%r13), %r8
-               	movq	%r8, -0x8f8(%rbp)
+               	movq	%r8, -0x900(%rbp)
                	movq	-0x8b8(%rbp), %r8
-               	leaq	(%r13,%r8,4), %rdi
-               	cmpq	%rcx, %rdi
-               	setbe	%r15b
-               	movzbq	%r15b, %r15
-               	movq	-0x8f8(%rbp), %r8
-               	cmpq	%r8, %rsi
+               	leaq	(%r13,%r8,4), %r15
+               	cmpq	%rsi, %r15
                	setbe	%cl
                	movzbq	%cl, %rcx
-               	orl	%ecx, %r15d
                	movq	-0x900(%rbp), %r8
                	cmpq	%r8, %rdi
-               	setbe	%cl
-               	movzbq	%cl, %rcx
-               	movq	-0x908(%rbp), %r8
-               	movq	-0x8f8(%rbp), %r9
-               	cmpq	%r9, %r8
                	setbe	%sil
                	movzbq	%sil, %rsi
                	orl	%esi, %ecx
-               	andl	%ecx, %r15d
-               	testb	%r15b, %r15b
+               	movq	-0x908(%rbp), %r8
+               	cmpq	%r8, %r15
+               	setbe	%sil
+               	movzbq	%sil, %rsi
+               	movq	-0x910(%rbp), %r8
+               	movq	-0x900(%rbp), %r9
+               	cmpq	%r9, %r8
+               	setbe	%dil
+               	movzbq	%dil, %rdi
+               	orl	%edi, %esi
+               	andl	%esi, %ecx
+               	movq	-0x8f8(%rbp), %r8
+               	movl	%r8d, %esi
+               	andl	%ecx, %esi
+               	testb	%sil, %sil
                	jne	 <L38>
                	movq	$0x0, %rcx
                	movq	-0x8b8(%rbp), %r8
@@ -672,43 +686,46 @@ Disassembly of section .text:
                	jb	 <L37>
                	jmp	 <L42>
 <L38>:
+               	movq	$0x0, %rcx
+               	movq	%rcx, %rsi
+               	addq	$0x4, %rsi
                	movq	-0x8b8(%rbp), %r8
-               	movq	%r8, %rcx
-               	subq	$0x4, %rcx
-               	movq	$0x0, %rsi
-               	cmpq	%rcx, %rsi
-               	jle	 <L39>
+               	cmpq	%r8, %rsi
+               	jbe	 <L39>
                	jmp	 <L40>
 <L39>:
-               	leaq	(%rbx,%rsi,4), %rdi
-               	movups	(%rdi), %xmm0
-               	leaq	(%r12,%rsi,4), %rdi
-               	movups	(%rdi), %xmm1
+               	leaq	(%rbx,%rcx,4), %rsi
+               	movups	(%rsi), %xmm0
+               	leaq	(%r12,%rcx,4), %rsi
+               	movups	(%rsi), %xmm1
                	movaps	%xmm0, %xmm14
                	mulps	%xmm1, %xmm14
                	movaps	%xmm14, %xmm0
-               	leaq	(%r13,%rsi,4), %rdi
-               	movups	%xmm0, (%rdi)
+               	leaq	(%r13,%rcx,4), %rsi
+               	movups	%xmm0, (%rsi)
+               	addq	$0x4, %rcx
+               	movq	%rcx, %rsi
                	addq	$0x4, %rsi
-               	cmpq	%rcx, %rsi
-               	jle	 <L39>
-<L40>:
                	movq	-0x8b8(%rbp), %r8
                	cmpq	%r8, %rsi
+               	jbe	 <L39>
+<L40>:
+               	movq	-0x8b8(%rbp), %r8
+               	cmpq	%r8, %rcx
                	jb	 <L41>
                	jmp	 <L42>
 <L41>:
-               	leaq	(%rbx,%rsi,4), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	(%r12,%rsi,4), %rcx
-               	movss	(%rcx), %xmm1
+               	leaq	(%rbx,%rcx,4), %rsi
+               	movss	(%rsi), %xmm0
+               	leaq	(%r12,%rcx,4), %rsi
+               	movss	(%rsi), %xmm1
                	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
                	mulss	%xmm1, %xmm2
-               	leaq	(%r13,%rsi,4), %rcx
-               	movss	%xmm2, (%rcx)
-               	addq	$0x1, %rsi
+               	leaq	(%r13,%rcx,4), %rsi
+               	movss	%xmm2, (%rsi)
+               	addq	$0x1, %rcx
                	movq	-0x8b8(%rbp), %r8
-               	cmpq	%r8, %rsi
+               	cmpq	%r8, %rcx
                	jb	 <L41>
 <L42>:
                	movq	$0x0, %r15
@@ -748,38 +765,52 @@ Disassembly of section .text:
                	movq	$0x0, 0x80(%r13)
                	movq	$0x0, 0x88(%r13)
                	movl	$0x0, 0x90(%r13)
-               	leaq	(%rbx), %rcx
                	movq	-0x8b8(%rbp), %r8
-               	leaq	(%rbx,%r8,4), %rsi
-               	leaq	(%r12), %r8
-               	movq	%r8, -0x918(%rbp)
-               	movq	-0x8b8(%rbp), %r9
-               	leaq	(%r12,%r9,4), %r8
-               	movq	%r8, -0x920(%rbp)
-               	leaq	(%r13), %r8
-               	movq	%r8, -0x910(%rbp)
-               	movq	-0x8b8(%rbp), %r8
-               	leaq	(%r13,%r8,4), %rdi
-               	cmpq	%rcx, %rdi
-               	setbe	%r15b
-               	movzbq	%r15b, %r15
-               	movq	-0x910(%rbp), %r8
-               	cmpq	%r8, %rsi
+               	movabsq	$-0x100000001, %r11     # imm = 0xFFFFFFFEFFFFFFFF
+               	cmpq	%r11, %r8
                	setbe	%cl
                	movzbq	%cl, %rcx
-               	orl	%ecx, %r15d
-               	movq	-0x918(%rbp), %r8
-               	cmpq	%r8, %rdi
+               	andl	$0x1, %ecx
+               	andl	$0x1, %ecx
+               	andl	$0x1, %ecx
+               	movl	%ecx, %r8d
+               	andl	$0x1, %r8d
+               	movq	%r8, -0x918(%rbp)
+               	leaq	(%rbx), %rsi
+               	movq	-0x8b8(%rbp), %r8
+               	leaq	(%rbx,%r8,4), %rdi
+               	leaq	(%r12), %r8
+               	movq	%r8, -0x928(%rbp)
+               	movq	-0x8b8(%rbp), %r9
+               	leaq	(%r12,%r9,4), %r8
+               	movq	%r8, -0x930(%rbp)
+               	leaq	(%r13), %r8
+               	movq	%r8, -0x920(%rbp)
+               	movq	-0x8b8(%rbp), %r8
+               	leaq	(%r13,%r8,4), %r15
+               	cmpq	%rsi, %r15
                	setbe	%cl
                	movzbq	%cl, %rcx
                	movq	-0x920(%rbp), %r8
-               	movq	-0x910(%rbp), %r9
-               	cmpq	%r9, %r8
+               	cmpq	%r8, %rdi
                	setbe	%sil
                	movzbq	%sil, %rsi
                	orl	%esi, %ecx
-               	andl	%ecx, %r15d
-               	testb	%r15b, %r15b
+               	movq	-0x928(%rbp), %r8
+               	cmpq	%r8, %r15
+               	setbe	%sil
+               	movzbq	%sil, %rsi
+               	movq	-0x930(%rbp), %r8
+               	movq	-0x920(%rbp), %r9
+               	cmpq	%r9, %r8
+               	setbe	%dil
+               	movzbq	%dil, %rdi
+               	orl	%edi, %esi
+               	andl	%esi, %ecx
+               	movq	-0x918(%rbp), %r8
+               	movl	%r8d, %esi
+               	andl	%ecx, %esi
+               	testb	%sil, %sil
                	jne	 <L47>
                	movq	$0x0, %rcx
                	movq	-0x8b8(%rbp), %r8
@@ -801,43 +832,46 @@ Disassembly of section .text:
                	jb	 <L46>
                	jmp	 <L51>
 <L47>:
+               	movq	$0x0, %rcx
+               	movq	%rcx, %rsi
+               	addq	$0x4, %rsi
                	movq	-0x8b8(%rbp), %r8
-               	movq	%r8, %rcx
-               	subq	$0x4, %rcx
-               	movq	$0x0, %rsi
-               	cmpq	%rcx, %rsi
-               	jle	 <L48>
+               	cmpq	%r8, %rsi
+               	jbe	 <L48>
                	jmp	 <L49>
 <L48>:
-               	leaq	(%rbx,%rsi,4), %rdi
-               	movups	(%rdi), %xmm0
-               	leaq	(%r12,%rsi,4), %rdi
-               	movups	(%rdi), %xmm1
+               	leaq	(%rbx,%rcx,4), %rsi
+               	movups	(%rsi), %xmm0
+               	leaq	(%r12,%rcx,4), %rsi
+               	movups	(%rsi), %xmm1
                	movaps	%xmm0, %xmm14
                	divps	%xmm1, %xmm14
                	movaps	%xmm14, %xmm2
-               	leaq	(%r13,%rsi,4), %rdi
-               	movups	%xmm2, (%rdi)
+               	leaq	(%r13,%rcx,4), %rsi
+               	movups	%xmm2, (%rsi)
+               	addq	$0x4, %rcx
+               	movq	%rcx, %rsi
                	addq	$0x4, %rsi
-               	cmpq	%rcx, %rsi
-               	jle	 <L48>
-<L49>:
                	movq	-0x8b8(%rbp), %r8
                	cmpq	%r8, %rsi
+               	jbe	 <L48>
+<L49>:
+               	movq	-0x8b8(%rbp), %r8
+               	cmpq	%r8, %rcx
                	jb	 <L50>
                	jmp	 <L51>
 <L50>:
-               	leaq	(%rbx,%rsi,4), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	(%r12,%rsi,4), %rcx
-               	movss	(%rcx), %xmm1
+               	leaq	(%rbx,%rcx,4), %rsi
+               	movss	(%rsi), %xmm0
+               	leaq	(%r12,%rcx,4), %rsi
+               	movss	(%rsi), %xmm1
                	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
                	divss	%xmm1, %xmm2
-               	leaq	(%r13,%rsi,4), %rcx
-               	movss	%xmm2, (%rcx)
-               	addq	$0x1, %rsi
+               	leaq	(%r13,%rcx,4), %rsi
+               	movss	%xmm2, (%rsi)
+               	addq	$0x1, %rcx
                	movq	-0x8b8(%rbp), %r8
-               	cmpq	%r8, %rsi
+               	cmpq	%r8, %rcx
                	jb	 <L50>
 <L51>:
                	movq	$0x0, %rbx
@@ -877,11 +911,11 @@ Disassembly of section .text:
 <L57>:
                	movq	%rax, %rcx
                	movq	%rcx, %rax
-               	movq	-0x948(%rbp), %rbx
-               	movq	-0x950(%rbp), %r12
-               	movq	-0x958(%rbp), %r13
-               	movq	-0x960(%rbp), %r14
-               	movq	-0x968(%rbp), %r15
+               	movq	-0x958(%rbp), %rbx
+               	movq	-0x960(%rbp), %r12
+               	movq	-0x968(%rbp), %r13
+               	movq	-0x970(%rbp), %r14
+               	movq	-0x978(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-linux/vec/vec_cmp_select.dis
+++ b/test/golden/x86_64-linux/vec/vec_cmp_select.dis
@@ -234,12 +234,12 @@ Disassembly of section .text:
 <corpus.cases.vec.vec_cmp_select.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x560, %rsp            # imm = 0x560
-               	movq	%rbx, -0x538(%rbp)
-               	movq	%r12, -0x540(%rbp)
-               	movq	%r13, -0x548(%rbp)
-               	movq	%r14, -0x550(%rbp)
-               	movq	%r15, -0x558(%rbp)
+               	subq	$0x510, %rsp            # imm = 0x510
+               	movq	%rbx, -0x4e8(%rbp)
+               	movq	%r12, -0x4f0(%rbp)
+               	movq	%r13, -0x4f8(%rbp)
+               	movq	%r14, -0x500(%rbp)
+               	movq	%r15, -0x508(%rbp)
                	movq	%rdi, %rbx
                	callq	 <L0>
 <L0>:
@@ -257,7 +257,7 @@ Disassembly of section .text:
                	cvtsi2ss	%r11, %xmm14
                	addss	%xmm14, %xmm14
 <L2>:
-               	movss	%xmm14, -0x430(%rbp)
+               	movss	%xmm14, -0x3d0(%rbp)
                	movw	%bx, %r13w
                	movb	%bl, %r14b
                	leaq	-0x10(%rbp), %rcx
@@ -292,7 +292,7 @@ Disassembly of section .text:
                	leaq	(%rsi), %rdi
                	movl	%ecx, (%rdi)
                	movups	(%rsi), %xmm14
-               	movups	%xmm14, -0x440(%rbp)
+               	movups	%xmm14, -0x3e0(%rbp)
                	leaq	0xc(%rdx), %rcx
                	movl	(%rcx), %edx
                	addl	%r12d, %edx
@@ -301,12 +301,12 @@ Disassembly of section .text:
                	leaq	0xc(%rcx), %rsi
                	movl	%edx, (%rsi)
                	movups	(%rcx), %xmm14
-               	movups	%xmm14, -0x450(%rbp)
+               	movups	%xmm14, -0x3f0(%rbp)
                	pcmpeqd	%xmm15, %xmm15
                	pslld	$0x1f, %xmm15
-               	movaps	-0x440(%rbp), %xmm14
+               	movaps	-0x3e0(%rbp), %xmm14
                	pxor	%xmm15, %xmm14
-               	pxor	-0x450(%rbp), %xmm15
+               	pxor	-0x3f0(%rbp), %xmm15
                	pcmpgtd	%xmm14, %xmm15
                	movaps	%xmm15, %xmm3
                	leaq	-0x70(%rbp), %r15
@@ -337,9 +337,9 @@ Disassembly of section .text:
 <L6>:
                	pcmpeqd	%xmm15, %xmm15
                	pslld	$0x1f, %xmm15
-               	movaps	-0x450(%rbp), %xmm14
+               	movaps	-0x3f0(%rbp), %xmm14
                	pxor	%xmm15, %xmm14
-               	pxor	-0x440(%rbp), %xmm15
+               	pxor	-0x3e0(%rbp), %xmm15
                	pcmpgtd	%xmm14, %xmm15
                	movaps	%xmm15, %xmm3
                	leaq	-0x80(%rbp), %r15
@@ -368,8 +368,8 @@ Disassembly of section .text:
                	movl	%edx, %esi
                	callq	 <L10>
 <L10>:
-               	movaps	-0x440(%rbp), %xmm14
-               	pcmpeqd	-0x450(%rbp), %xmm14
+               	movaps	-0x3e0(%rbp), %xmm14
+               	pcmpeqd	-0x3f0(%rbp), %xmm14
                	movaps	%xmm14, %xmm3
                	leaq	-0x90(%rbp), %r15
                	movups	%xmm3, (%r15)
@@ -397,8 +397,8 @@ Disassembly of section .text:
                	movl	%edx, %esi
                	callq	 <L14>
 <L14>:
-               	movaps	-0x440(%rbp), %xmm14
-               	pcmpeqd	-0x450(%rbp), %xmm14
+               	movaps	-0x3e0(%rbp), %xmm14
+               	pcmpeqd	-0x3f0(%rbp), %xmm14
                	pcmpeqd	%xmm15, %xmm15
                	pxor	%xmm15, %xmm14
                	movaps	%xmm14, %xmm3
@@ -430,9 +430,9 @@ Disassembly of section .text:
 <L18>:
                	pcmpeqd	%xmm15, %xmm15
                	pslld	$0x1f, %xmm15
-               	movaps	-0x440(%rbp), %xmm14
+               	movaps	-0x3e0(%rbp), %xmm14
                	pxor	%xmm15, %xmm14
-               	pxor	-0x450(%rbp), %xmm15
+               	pxor	-0x3f0(%rbp), %xmm15
                	pcmpgtd	%xmm15, %xmm14
                	pcmpeqd	%xmm15, %xmm15
                	pxor	%xmm15, %xmm14
@@ -465,9 +465,9 @@ Disassembly of section .text:
 <L22>:
                	pcmpeqd	%xmm15, %xmm15
                	pslld	$0x1f, %xmm15
-               	movaps	-0x450(%rbp), %xmm14
+               	movaps	-0x3f0(%rbp), %xmm14
                	pxor	%xmm15, %xmm14
-               	pxor	-0x440(%rbp), %xmm15
+               	pxor	-0x3e0(%rbp), %xmm15
                	pcmpgtd	%xmm15, %xmm14
                	pcmpeqd	%xmm15, %xmm15
                	pxor	%xmm15, %xmm14
@@ -500,20 +500,20 @@ Disassembly of section .text:
 <L26>:
                	pcmpeqd	%xmm15, %xmm15
                	pslld	$0x1f, %xmm15
-               	movaps	-0x440(%rbp), %xmm14
+               	movaps	-0x3e0(%rbp), %xmm14
                	pxor	%xmm15, %xmm14
-               	pxor	-0x450(%rbp), %xmm15
+               	pxor	-0x3f0(%rbp), %xmm15
                	pcmpgtd	%xmm14, %xmm15
-               	movaps	%xmm15, -0x460(%rbp)
-               	movaps	-0x460(%rbp), %xmm14
-               	pand	-0x440(%rbp), %xmm14
+               	movaps	%xmm15, -0x400(%rbp)
+               	movaps	-0x400(%rbp), %xmm14
+               	pand	-0x3e0(%rbp), %xmm14
                	movaps	%xmm14, %xmm4
-               	movaps	-0x460(%rbp), %xmm14
+               	movaps	-0x400(%rbp), %xmm14
                	pcmpeqd	%xmm15, %xmm15
                	pxor	%xmm15, %xmm14
                	movaps	%xmm14, %xmm5
                	movaps	%xmm5, %xmm14
-               	pand	-0x450(%rbp), %xmm14
+               	pand	-0x3f0(%rbp), %xmm14
                	movaps	%xmm14, %xmm5
                	movaps	%xmm4, %xmm14
                	por	%xmm5, %xmm14
@@ -544,15 +544,15 @@ Disassembly of section .text:
                	movl	%edx, %esi
                	callq	 <L30>
 <L30>:
-               	movaps	-0x460(%rbp), %xmm14
-               	pand	-0x450(%rbp), %xmm14
+               	movaps	-0x400(%rbp), %xmm14
+               	pand	-0x3f0(%rbp), %xmm14
                	movaps	%xmm14, %xmm4
-               	movaps	-0x460(%rbp), %xmm14
+               	movaps	-0x400(%rbp), %xmm14
                	pcmpeqd	%xmm15, %xmm15
                	pxor	%xmm15, %xmm14
                	movaps	%xmm14, %xmm5
                	movaps	%xmm5, %xmm14
-               	pand	-0x440(%rbp), %xmm14
+               	pand	-0x3e0(%rbp), %xmm14
                	movaps	%xmm14, %xmm5
                	movaps	%xmm4, %xmm14
                	por	%xmm5, %xmm14
@@ -583,10 +583,10 @@ Disassembly of section .text:
                	movl	%edx, %esi
                	callq	 <L34>
 <L34>:
-               	movaps	-0x440(%rbp), %xmm14
-               	paddd	-0x450(%rbp), %xmm14
+               	movaps	-0x3e0(%rbp), %xmm14
+               	paddd	-0x3f0(%rbp), %xmm14
                	movaps	%xmm14, %xmm4
-               	movaps	-0x460(%rbp), %xmm14
+               	movaps	-0x400(%rbp), %xmm14
                	pand	%xmm4, %xmm14
                	movaps	%xmm14, %xmm5
                	leaq	-0xf0(%rbp), %r15
@@ -615,12 +615,12 @@ Disassembly of section .text:
                	movl	%edx, %esi
                	callq	 <L38>
 <L38>:
-               	movaps	-0x460(%rbp), %xmm14
+               	movaps	-0x400(%rbp), %xmm14
                	pcmpeqd	%xmm15, %xmm15
                	pxor	%xmm15, %xmm14
                	movaps	%xmm14, %xmm4
-               	movaps	-0x440(%rbp), %xmm14
-               	psubd	-0x450(%rbp), %xmm14
+               	movaps	-0x3e0(%rbp), %xmm14
+               	psubd	-0x3f0(%rbp), %xmm14
                	movaps	%xmm14, %xmm1
                	movaps	%xmm4, %xmm14
                	por	%xmm1, %xmm14
@@ -683,7 +683,7 @@ Disassembly of section .text:
                	leaq	(%rsi), %rdi
                	movl	%ecx, (%rdi)
                	movups	(%rsi), %xmm14
-               	movups	%xmm14, -0x470(%rbp)
+               	movups	%xmm14, -0x410(%rbp)
                	leaq	0xc(%rdx), %rcx
                	movl	(%rcx), %edx
                	addl	%r12d, %edx
@@ -692,9 +692,9 @@ Disassembly of section .text:
                	leaq	0xc(%rcx), %rsi
                	movl	%edx, (%rsi)
                	movups	(%rcx), %xmm14
-               	movups	%xmm14, -0x480(%rbp)
-               	movaps	-0x480(%rbp), %xmm14
-               	pcmpgtd	-0x470(%rbp), %xmm14
+               	movups	%xmm14, -0x420(%rbp)
+               	movaps	-0x420(%rbp), %xmm14
+               	pcmpgtd	-0x410(%rbp), %xmm14
                	movaps	%xmm14, %xmm3
                	leaq	-0x170(%rbp), %r12
                	movups	%xmm3, (%r12)
@@ -722,8 +722,8 @@ Disassembly of section .text:
                	movl	%edx, %esi
                	callq	 <L46>
 <L46>:
-               	movaps	-0x470(%rbp), %xmm14
-               	pcmpgtd	-0x480(%rbp), %xmm14
+               	movaps	-0x410(%rbp), %xmm14
+               	pcmpgtd	-0x420(%rbp), %xmm14
                	movaps	%xmm14, %xmm3
                	leaq	-0x180(%rbp), %r12
                	movups	%xmm3, (%r12)
@@ -751,8 +751,8 @@ Disassembly of section .text:
                	movl	%edx, %esi
                	callq	 <L50>
 <L50>:
-               	movaps	-0x470(%rbp), %xmm14
-               	pcmpeqd	-0x480(%rbp), %xmm14
+               	movaps	-0x410(%rbp), %xmm14
+               	pcmpeqd	-0x420(%rbp), %xmm14
                	movaps	%xmm14, %xmm3
                	leaq	-0x190(%rbp), %r12
                	movups	%xmm3, (%r12)
@@ -780,8 +780,8 @@ Disassembly of section .text:
                	movl	%edx, %esi
                	callq	 <L54>
 <L54>:
-               	movaps	-0x470(%rbp), %xmm14
-               	pcmpeqd	-0x480(%rbp), %xmm14
+               	movaps	-0x410(%rbp), %xmm14
+               	pcmpeqd	-0x420(%rbp), %xmm14
                	pcmpeqd	%xmm15, %xmm15
                	pxor	%xmm15, %xmm14
                	movaps	%xmm14, %xmm3
@@ -811,8 +811,8 @@ Disassembly of section .text:
                	movl	%edx, %esi
                	callq	 <L58>
 <L58>:
-               	movaps	-0x470(%rbp), %xmm14
-               	pcmpgtd	-0x480(%rbp), %xmm14
+               	movaps	-0x410(%rbp), %xmm14
+               	pcmpgtd	-0x420(%rbp), %xmm14
                	pcmpeqd	%xmm15, %xmm15
                	pxor	%xmm15, %xmm14
                	movaps	%xmm14, %xmm3
@@ -842,8 +842,8 @@ Disassembly of section .text:
                	movl	%edx, %esi
                	callq	 <L62>
 <L62>:
-               	movaps	-0x480(%rbp), %xmm14
-               	pcmpgtd	-0x470(%rbp), %xmm14
+               	movaps	-0x420(%rbp), %xmm14
+               	pcmpgtd	-0x410(%rbp), %xmm14
                	pcmpeqd	%xmm15, %xmm15
                	pxor	%xmm15, %xmm14
                	movaps	%xmm14, %xmm3
@@ -901,20 +901,20 @@ Disassembly of section .text:
                	leaq	0xc(%rdx), %rsi
                	movss	%xmm2, (%rsi)
                	movups	(%rdx), %xmm14
-               	movups	%xmm14, -0x490(%rbp)
+               	movups	%xmm14, -0x430(%rbp)
                	leaq	-0x200(%rbp), %r12
-               	movups	-0x490(%rbp), %xmm14
+               	movups	-0x430(%rbp), %xmm14
                	movups	%xmm14, (%r12)
                	leaq	(%rcx), %rdx
                	movss	(%rdx), %xmm3
                	movss	%xmm3, %xmm4            # xmm4 = xmm3[0],xmm4[1,2,3]
-               	addss	-0x430(%rbp), %xmm4
+               	addss	-0x3d0(%rbp), %xmm4
                	leaq	-0x210(%rbp), %r15
                	movups	%xmm1, (%r15)
                	leaq	(%r15), %rcx
                	movss	%xmm4, (%rcx)
                	movups	(%r15), %xmm14
-               	movups	%xmm14, -0x4a0(%rbp)
+               	movups	%xmm14, -0x440(%rbp)
                	leaq	(%r15), %rcx
                	movss	(%rcx), %xmm0
                	movq	%rax, %rdi
@@ -955,284 +955,143 @@ Disassembly of section .text:
                	movq	%rax, %rdi
                	callq	 <L74>
 <L74>:
-               	movaps	-0x4a0(%rbp), %xmm14
-               	movaps	-0x490(%rbp), %xmm15
+               	movaps	-0x440(%rbp), %xmm14
+               	movaps	-0x430(%rbp), %xmm15
                	cmpltps	%xmm15, %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	-0x220(%rbp), %r12
-               	movups	%xmm0, (%r12)
-               	leaq	(%r12), %rcx
-               	movl	(%rcx), %edx
+               	movaps	%xmm14, -0x450(%rbp)
                	movq	%rax, %rdi
-               	movl	%edx, %esi
+               	movups	-0x450(%rbp), %xmm0
                	callq	 <L75>
 <L75>:
-               	leaq	0x4(%r12), %rcx
-               	movl	(%rcx), %edx
+               	movaps	-0x430(%rbp), %xmm14
+               	movaps	-0x440(%rbp), %xmm15
+               	cmpltps	%xmm15, %xmm14
+               	movaps	%xmm14, %xmm0
                	movq	%rax, %rdi
-               	movl	%edx, %esi
                	callq	 <L76>
 <L76>:
-               	leaq	0x8(%r12), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L77>
-<L77>:
-               	leaq	0xc(%r12), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L78>
-<L78>:
-               	movaps	-0x490(%rbp), %xmm14
-               	movaps	-0x4a0(%rbp), %xmm15
-               	cmpltps	%xmm15, %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	-0x230(%rbp), %r12
-               	movups	%xmm0, (%r12)
-               	leaq	(%r12), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L79>
-<L79>:
-               	leaq	0x4(%r12), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L80>
-<L80>:
-               	leaq	0x8(%r12), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L81>
-<L81>:
-               	leaq	0xc(%r12), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L82>
-<L82>:
-               	movaps	-0x4a0(%rbp), %xmm14
-               	movaps	-0x490(%rbp), %xmm15
+               	movaps	-0x440(%rbp), %xmm14
+               	movaps	-0x430(%rbp), %xmm15
                	cmpeqps	%xmm15, %xmm14
                	movaps	%xmm14, %xmm0
-               	leaq	-0x240(%rbp), %r12
-               	movups	%xmm0, (%r12)
-               	leaq	(%r12), %rcx
-               	movl	(%rcx), %edx
                	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L83>
-<L83>:
-               	leaq	0x4(%r12), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L84>
-<L84>:
-               	leaq	0x8(%r12), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L85>
-<L85>:
-               	leaq	0xc(%r12), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L86>
-<L86>:
-               	movaps	-0x4a0(%rbp), %xmm14
-               	movaps	-0x490(%rbp), %xmm15
+               	callq	 <L77>
+<L77>:
+               	movaps	-0x440(%rbp), %xmm14
+               	movaps	-0x430(%rbp), %xmm15
                	cmpneqps	%xmm15, %xmm14
                	movaps	%xmm14, %xmm0
-               	leaq	-0x250(%rbp), %r12
-               	movups	%xmm0, (%r12)
-               	leaq	(%r12), %rcx
-               	movl	(%rcx), %edx
                	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L87>
-<L87>:
-               	leaq	0x4(%r12), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L88>
-<L88>:
-               	leaq	0x8(%r12), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L89>
-<L89>:
-               	leaq	0xc(%r12), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L90>
-<L90>:
-               	movaps	-0x4a0(%rbp), %xmm14
-               	movaps	-0x490(%rbp), %xmm15
+               	callq	 <L78>
+<L78>:
+               	movaps	-0x440(%rbp), %xmm14
+               	movaps	-0x430(%rbp), %xmm15
                	cmpleps	%xmm15, %xmm14
                	movaps	%xmm14, %xmm0
-               	leaq	-0x260(%rbp), %r12
-               	movups	%xmm0, (%r12)
-               	leaq	(%r12), %rcx
-               	movl	(%rcx), %edx
                	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L91>
-<L91>:
-               	leaq	0x4(%r12), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L92>
-<L92>:
-               	leaq	0x8(%r12), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L93>
-<L93>:
-               	leaq	0xc(%r12), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L94>
-<L94>:
-               	movaps	-0x490(%rbp), %xmm14
-               	movaps	-0x4a0(%rbp), %xmm15
+               	callq	 <L79>
+<L79>:
+               	movaps	-0x430(%rbp), %xmm14
+               	movaps	-0x440(%rbp), %xmm15
                	cmpleps	%xmm15, %xmm14
                	movaps	%xmm14, %xmm0
-               	leaq	-0x270(%rbp), %r12
-               	movups	%xmm0, (%r12)
-               	leaq	(%r12), %rcx
-               	movl	(%rcx), %edx
                	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L95>
-<L95>:
-               	leaq	0x4(%r12), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L96>
-<L96>:
-               	leaq	0x8(%r12), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L97>
-<L97>:
-               	leaq	0xc(%r12), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L98>
-<L98>:
-               	movaps	-0x4a0(%rbp), %xmm14
-               	movaps	-0x490(%rbp), %xmm15
-               	cmpltps	%xmm15, %xmm14
+               	callq	 <L80>
+<L80>:
+               	movaps	-0x450(%rbp), %xmm14
+               	pand	-0x440(%rbp), %xmm14
                	movaps	%xmm14, %xmm0
-               	movaps	%xmm0, %xmm14
-               	pand	-0x4a0(%rbp), %xmm14
-               	movaps	%xmm14, %xmm3
-               	movaps	%xmm0, %xmm14
+               	movaps	-0x450(%rbp), %xmm14
                	pcmpeqd	%xmm15, %xmm15
                	pxor	%xmm15, %xmm14
                	movaps	%xmm14, %xmm4
                	movaps	%xmm4, %xmm14
-               	pand	-0x490(%rbp), %xmm14
+               	pand	-0x430(%rbp), %xmm14
                	movaps	%xmm14, %xmm5
-               	movaps	%xmm3, %xmm14
+               	movaps	%xmm0, %xmm14
                	por	%xmm5, %xmm14
-               	movaps	%xmm14, -0x4b0(%rbp)
-               	leaq	-0x280(%rbp), %r12
-               	movups	-0x4b0(%rbp), %xmm14
+               	movaps	%xmm14, -0x460(%rbp)
+               	leaq	-0x220(%rbp), %r12
+               	movups	-0x460(%rbp), %xmm14
                	movups	%xmm14, (%r12)
-               	movaps	%xmm0, %xmm14
-               	pand	-0x490(%rbp), %xmm14
-               	movaps	%xmm14, %xmm0
+               	movaps	-0x450(%rbp), %xmm14
+               	pand	-0x430(%rbp), %xmm14
+               	movaps	%xmm14, %xmm3
                	movaps	%xmm4, %xmm14
-               	pand	-0x4a0(%rbp), %xmm14
+               	pand	-0x440(%rbp), %xmm14
                	movaps	%xmm14, %xmm4
-               	movaps	%xmm0, %xmm14
+               	movaps	%xmm3, %xmm14
                	por	%xmm4, %xmm14
-               	movaps	%xmm14, -0x4c0(%rbp)
-               	leaq	-0x290(%rbp), %r15
-               	movups	-0x4c0(%rbp), %xmm14
+               	movaps	%xmm14, -0x470(%rbp)
+               	leaq	-0x230(%rbp), %r15
+               	movups	-0x470(%rbp), %xmm14
                	movups	%xmm14, (%r15)
                	leaq	(%r12), %rcx
                	movss	(%rcx), %xmm0
                	movq	%rax, %rdi
-               	callq	 <L99>
-<L99>:
+               	callq	 <L81>
+<L81>:
                	leaq	0x4(%r12), %rcx
                	movss	(%rcx), %xmm0
                	movq	%rax, %rdi
-               	callq	 <L100>
-<L100>:
+               	callq	 <L82>
+<L82>:
                	leaq	0x8(%r12), %rcx
                	movss	(%rcx), %xmm0
                	movq	%rax, %rdi
-               	callq	 <L101>
-<L101>:
+               	callq	 <L83>
+<L83>:
                	leaq	0xc(%r12), %rcx
                	movss	(%rcx), %xmm0
                	movq	%rax, %rdi
-               	callq	 <L102>
-<L102>:
+               	callq	 <L84>
+<L84>:
                	leaq	(%r15), %rcx
                	movss	(%rcx), %xmm0
                	movq	%rax, %rdi
-               	callq	 <L103>
-<L103>:
+               	callq	 <L85>
+<L85>:
                	leaq	0x4(%r15), %rcx
                	movss	(%rcx), %xmm0
                	movq	%rax, %rdi
-               	callq	 <L104>
-<L104>:
+               	callq	 <L86>
+<L86>:
                	leaq	0x8(%r15), %rcx
                	movss	(%rcx), %xmm0
                	movq	%rax, %rdi
-               	callq	 <L105>
-<L105>:
+               	callq	 <L87>
+<L87>:
                	leaq	0xc(%r15), %rcx
                	movss	(%rcx), %xmm0
                	movq	%rax, %rdi
-               	callq	 <L106>
-<L106>:
-               	movaps	-0x4c0(%rbp), %xmm14
-               	subps	-0x4b0(%rbp), %xmm14
+               	callq	 <L88>
+<L88>:
+               	movaps	-0x470(%rbp), %xmm14
+               	subps	-0x460(%rbp), %xmm14
                	movaps	%xmm14, %xmm1
-               	leaq	-0x2a0(%rbp), %r12
+               	leaq	-0x240(%rbp), %r12
                	movups	%xmm1, (%r12)
                	leaq	(%r12), %rcx
                	movss	(%rcx), %xmm0
                	movq	%rax, %rdi
-               	callq	 <L107>
-<L107>:
+               	callq	 <L89>
+<L89>:
                	leaq	0x4(%r12), %rcx
                	movss	(%rcx), %xmm0
                	movq	%rax, %rdi
-               	callq	 <L108>
-<L108>:
+               	callq	 <L90>
+<L90>:
                	leaq	0x8(%r12), %rcx
                	movss	(%rcx), %xmm0
                	movq	%rax, %rdi
-               	callq	 <L109>
-<L109>:
+               	callq	 <L91>
+<L91>:
                	leaq	0xc(%r12), %rcx
                	movss	(%rcx), %xmm0
                	movq	%rax, %rdi
-               	callq	 <L110>
-<L110>:
-               	leaq	-0x2b0(%rbp), %rcx
+               	callq	 <L92>
+<L92>:
+               	leaq	-0x250(%rbp), %rcx
                	leaq	(%rcx), %rdx
                	movabsq	$0x3ff8000000000000, %r11 # imm = 0x3FF8000000000000
                	movq	%r11, (%rdx)
@@ -1240,104 +1099,104 @@ Disassembly of section .text:
                	movabsq	$-0x8000000000000000, %r11 # imm = 0x8000000000000000
                	movq	%r11, (%rdx)
                	movups	(%rcx), %xmm0
-               	leaq	-0x2c0(%rbp), %rcx
+               	leaq	-0x260(%rbp), %rcx
                	movups	%xmm0, (%rcx)
-               	leaq	-0x2d0(%rbp), %rdx
+               	leaq	-0x270(%rbp), %rdx
                	leaq	(%rdx), %rsi
                	movabsq	$0x4004000000000000, %r11 # imm = 0x4004000000000000
                	movq	%r11, (%rsi)
                	leaq	0x8(%rdx), %rsi
                	movq	$0x0, (%rsi)
                	movups	(%rdx), %xmm14
-               	movups	%xmm14, -0x4d0(%rbp)
+               	movups	%xmm14, -0x480(%rbp)
                	leaq	(%rcx), %rdx
                	movsd	(%rdx), %xmm2
                	movq	%rbx, %r11
                	testq	%r11, %r11
-               	jl	 <L111>
+               	jl	 <L93>
                	cvtsi2sd	%r11, %xmm3
-               	jmp	 <L112>
-<L111>:
+               	jmp	 <L94>
+<L93>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2sd	%r11, %xmm3
                	addsd	%xmm3, %xmm3
-<L112>:
+<L94>:
                	movsd	%xmm2, %xmm4            # xmm4 = xmm2[0],xmm4[1]
                	addsd	%xmm3, %xmm4
-               	leaq	-0x2e0(%rbp), %rcx
+               	leaq	-0x280(%rbp), %rcx
                	movups	%xmm0, (%rcx)
                	leaq	(%rcx), %rdx
                	movsd	%xmm4, (%rdx)
                	movups	(%rcx), %xmm14
-               	movups	%xmm14, -0x4e0(%rbp)
-               	movaps	-0x4e0(%rbp), %xmm14
-               	movaps	-0x4d0(%rbp), %xmm15
+               	movups	%xmm14, -0x490(%rbp)
+               	movaps	-0x490(%rbp), %xmm14
+               	movaps	-0x480(%rbp), %xmm15
                	cmpltpd	%xmm15, %xmm14
                	movaps	%xmm14, %xmm2
-               	leaq	-0x2f0(%rbp), %rbx
+               	leaq	-0x290(%rbp), %rbx
                	movups	%xmm2, (%rbx)
                	leaq	(%rbx), %rcx
                	movq	(%rcx), %rsi
                	movq	%rax, %rdi
-               	callq	 <L113>
-<L113>:
+               	callq	 <L95>
+<L95>:
                	leaq	0x8(%rbx), %rcx
                	movq	(%rcx), %rsi
                	movq	%rax, %rdi
-               	callq	 <L114>
-<L114>:
-               	movaps	-0x4e0(%rbp), %xmm14
-               	movaps	-0x4d0(%rbp), %xmm15
+               	callq	 <L96>
+<L96>:
+               	movaps	-0x490(%rbp), %xmm14
+               	movaps	-0x480(%rbp), %xmm15
                	cmpeqpd	%xmm15, %xmm14
                	movaps	%xmm14, %xmm2
-               	leaq	-0x300(%rbp), %rbx
+               	leaq	-0x2a0(%rbp), %rbx
                	movups	%xmm2, (%rbx)
                	leaq	(%rbx), %rcx
                	movq	(%rcx), %rsi
                	movq	%rax, %rdi
-               	callq	 <L115>
-<L115>:
+               	callq	 <L97>
+<L97>:
                	leaq	0x8(%rbx), %rcx
                	movq	(%rcx), %rsi
                	movq	%rax, %rdi
-               	callq	 <L116>
-<L116>:
-               	movaps	-0x4e0(%rbp), %xmm14
-               	movaps	-0x4d0(%rbp), %xmm15
+               	callq	 <L98>
+<L98>:
+               	movaps	-0x490(%rbp), %xmm14
+               	movaps	-0x480(%rbp), %xmm15
                	cmpneqpd	%xmm15, %xmm14
                	movaps	%xmm14, %xmm2
-               	leaq	-0x310(%rbp), %rbx
+               	leaq	-0x2b0(%rbp), %rbx
                	movups	%xmm2, (%rbx)
                	leaq	(%rbx), %rcx
                	movq	(%rcx), %rsi
                	movq	%rax, %rdi
-               	callq	 <L117>
-<L117>:
+               	callq	 <L99>
+<L99>:
                	leaq	0x8(%rbx), %rcx
                	movq	(%rcx), %rsi
                	movq	%rax, %rdi
-               	callq	 <L118>
-<L118>:
-               	movaps	-0x4d0(%rbp), %xmm14
-               	movaps	-0x4e0(%rbp), %xmm15
+               	callq	 <L100>
+<L100>:
+               	movaps	-0x480(%rbp), %xmm14
+               	movaps	-0x490(%rbp), %xmm15
                	cmplepd	%xmm15, %xmm14
                	movaps	%xmm14, %xmm2
-               	leaq	-0x320(%rbp), %rbx
+               	leaq	-0x2c0(%rbp), %rbx
                	movups	%xmm2, (%rbx)
                	leaq	(%rbx), %rcx
                	movq	(%rcx), %rsi
                	movq	%rax, %rdi
-               	callq	 <L119>
-<L119>:
+               	callq	 <L101>
+<L101>:
                	leaq	0x8(%rbx), %rcx
                	movq	(%rcx), %rsi
                	movq	%rax, %rdi
-               	callq	 <L120>
-<L120>:
-               	leaq	-0x330(%rbp), %rcx
+               	callq	 <L102>
+<L102>:
+               	leaq	-0x2d0(%rbp), %rcx
                	leaq	(%rcx), %rdx
                	movw	$0x1, (%rdx)
                	leaq	0x2(%rcx), %rdx
@@ -1355,9 +1214,9 @@ Disassembly of section .text:
                	leaq	0xe(%rcx), %rdx
                	movw	$0xfffe, (%rdx)         # imm = 0xFFFE
                	movups	(%rcx), %xmm0
-               	leaq	-0x340(%rbp), %rcx
+               	leaq	-0x2e0(%rbp), %rcx
                	movups	%xmm0, (%rcx)
-               	leaq	-0x350(%rbp), %rdx
+               	leaq	-0x2f0(%rbp), %rdx
                	leaq	(%rdx), %rsi
                	movw	$0x2, (%rsi)
                	leaq	0x2(%rdx), %rsi
@@ -1375,232 +1234,232 @@ Disassembly of section .text:
                	leaq	0xe(%rdx), %rsi
                	movw	$0xffff, (%rsi)         # imm = 0xFFFF
                	movups	(%rdx), %xmm1
-               	leaq	-0x360(%rbp), %rdx
+               	leaq	-0x300(%rbp), %rdx
                	movups	%xmm1, (%rdx)
                	leaq	(%rcx), %rsi
                	movzwl	(%rsi), %ecx
                	addl	%r13d, %ecx
-               	leaq	-0x370(%rbp), %rsi
+               	leaq	-0x310(%rbp), %rsi
                	movups	%xmm0, (%rsi)
                	leaq	(%rsi), %rdi
                	movw	%cx, (%rdi)
                	movups	(%rsi), %xmm14
-               	movups	%xmm14, -0x4f0(%rbp)
+               	movups	%xmm14, -0x4a0(%rbp)
                	leaq	0xe(%rdx), %rcx
                	movzwl	(%rcx), %edx
                	addl	%r13d, %edx
-               	leaq	-0x380(%rbp), %rcx
+               	leaq	-0x320(%rbp), %rcx
                	movups	%xmm1, (%rcx)
                	leaq	0xe(%rcx), %rsi
                	movw	%dx, (%rsi)
                	movups	(%rcx), %xmm14
-               	movups	%xmm14, -0x500(%rbp)
-               	movaps	-0x500(%rbp), %xmm14
-               	psubusw	-0x4f0(%rbp), %xmm14
+               	movups	%xmm14, -0x4b0(%rbp)
+               	movaps	-0x4b0(%rbp), %xmm14
+               	psubusw	-0x4a0(%rbp), %xmm14
                	pxor	%xmm15, %xmm15
                	pcmpeqw	%xmm15, %xmm14
                	pcmpeqd	%xmm15, %xmm15
                	pxor	%xmm15, %xmm14
                	movaps	%xmm14, %xmm2
-               	leaq	-0x390(%rbp), %rbx
+               	leaq	-0x330(%rbp), %rbx
                	movups	%xmm2, (%rbx)
                	leaq	(%rbx), %rcx
+               	movzwl	(%rcx), %esi
+               	movq	%rax, %rdi
+               	callq	 <L103>
+<L103>:
+               	leaq	0x2(%rbx), %rcx
+               	movzwl	(%rcx), %esi
+               	movq	%rax, %rdi
+               	callq	 <L104>
+<L104>:
+               	leaq	0x4(%rbx), %rcx
+               	movzwl	(%rcx), %esi
+               	movq	%rax, %rdi
+               	callq	 <L105>
+<L105>:
+               	leaq	0x6(%rbx), %rcx
+               	movzwl	(%rcx), %esi
+               	movq	%rax, %rdi
+               	callq	 <L106>
+<L106>:
+               	leaq	0x8(%rbx), %rcx
+               	movzwl	(%rcx), %esi
+               	movq	%rax, %rdi
+               	callq	 <L107>
+<L107>:
+               	leaq	0xa(%rbx), %rcx
+               	movzwl	(%rcx), %esi
+               	movq	%rax, %rdi
+               	callq	 <L108>
+<L108>:
+               	leaq	0xc(%rbx), %rcx
+               	movzwl	(%rcx), %esi
+               	movq	%rax, %rdi
+               	callq	 <L109>
+<L109>:
+               	leaq	0xe(%rbx), %rcx
+               	movzwl	(%rcx), %esi
+               	movq	%rax, %rdi
+               	callq	 <L110>
+<L110>:
+               	movaps	-0x4a0(%rbp), %xmm14
+               	pcmpeqw	-0x4b0(%rbp), %xmm14
+               	movaps	%xmm14, %xmm2
+               	leaq	-0x340(%rbp), %rbx
+               	movups	%xmm2, (%rbx)
+               	leaq	(%rbx), %rcx
+               	movzwl	(%rcx), %esi
+               	movq	%rax, %rdi
+               	callq	 <L111>
+<L111>:
+               	leaq	0x2(%rbx), %rcx
+               	movzwl	(%rcx), %esi
+               	movq	%rax, %rdi
+               	callq	 <L112>
+<L112>:
+               	leaq	0x4(%rbx), %rcx
+               	movzwl	(%rcx), %esi
+               	movq	%rax, %rdi
+               	callq	 <L113>
+<L113>:
+               	leaq	0x6(%rbx), %rcx
+               	movzwl	(%rcx), %esi
+               	movq	%rax, %rdi
+               	callq	 <L114>
+<L114>:
+               	leaq	0x8(%rbx), %rcx
+               	movzwl	(%rcx), %esi
+               	movq	%rax, %rdi
+               	callq	 <L115>
+<L115>:
+               	leaq	0xa(%rbx), %rcx
+               	movzwl	(%rcx), %esi
+               	movq	%rax, %rdi
+               	callq	 <L116>
+<L116>:
+               	leaq	0xc(%rbx), %rcx
+               	movzwl	(%rcx), %esi
+               	movq	%rax, %rdi
+               	callq	 <L117>
+<L117>:
+               	leaq	0xe(%rbx), %rcx
+               	movzwl	(%rcx), %esi
+               	movq	%rax, %rdi
+               	callq	 <L118>
+<L118>:
+               	movaps	-0x4a0(%rbp), %xmm14
+               	psubusw	-0x4b0(%rbp), %xmm14
+               	pxor	%xmm15, %xmm15
+               	pcmpeqw	%xmm15, %xmm14
+               	pcmpeqd	%xmm15, %xmm15
+               	pxor	%xmm15, %xmm14
+               	movaps	%xmm14, %xmm2
+               	leaq	-0x350(%rbp), %rbx
+               	movups	%xmm2, (%rbx)
+               	leaq	(%rbx), %rcx
+               	movzwl	(%rcx), %esi
+               	movq	%rax, %rdi
+               	callq	 <L119>
+<L119>:
+               	leaq	0x2(%rbx), %rcx
+               	movzwl	(%rcx), %esi
+               	movq	%rax, %rdi
+               	callq	 <L120>
+<L120>:
+               	leaq	0x4(%rbx), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
                	callq	 <L121>
 <L121>:
-               	leaq	0x2(%rbx), %rcx
+               	leaq	0x6(%rbx), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
                	callq	 <L122>
 <L122>:
-               	leaq	0x4(%rbx), %rcx
+               	leaq	0x8(%rbx), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
                	callq	 <L123>
 <L123>:
-               	leaq	0x6(%rbx), %rcx
+               	leaq	0xa(%rbx), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
                	callq	 <L124>
 <L124>:
-               	leaq	0x8(%rbx), %rcx
+               	leaq	0xc(%rbx), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
                	callq	 <L125>
 <L125>:
-               	leaq	0xa(%rbx), %rcx
+               	leaq	0xe(%rbx), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
                	callq	 <L126>
 <L126>:
-               	leaq	0xc(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L127>
-<L127>:
-               	leaq	0xe(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L128>
-<L128>:
-               	movaps	-0x4f0(%rbp), %xmm14
-               	pcmpeqw	-0x500(%rbp), %xmm14
-               	movaps	%xmm14, %xmm2
-               	leaq	-0x3a0(%rbp), %rbx
-               	movups	%xmm2, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L129>
-<L129>:
-               	leaq	0x2(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L130>
-<L130>:
-               	leaq	0x4(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L131>
-<L131>:
-               	leaq	0x6(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L132>
-<L132>:
-               	leaq	0x8(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L133>
-<L133>:
-               	leaq	0xa(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L134>
-<L134>:
-               	leaq	0xc(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L135>
-<L135>:
-               	leaq	0xe(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L136>
-<L136>:
-               	movaps	-0x4f0(%rbp), %xmm14
-               	psubusw	-0x500(%rbp), %xmm14
-               	pxor	%xmm15, %xmm15
-               	pcmpeqw	%xmm15, %xmm14
-               	pcmpeqd	%xmm15, %xmm15
-               	pxor	%xmm15, %xmm14
-               	movaps	%xmm14, %xmm2
-               	leaq	-0x3b0(%rbp), %rbx
-               	movups	%xmm2, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L137>
-<L137>:
-               	leaq	0x2(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L138>
-<L138>:
-               	leaq	0x4(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L139>
-<L139>:
-               	leaq	0x6(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L140>
-<L140>:
-               	leaq	0x8(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L141>
-<L141>:
-               	leaq	0xa(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L142>
-<L142>:
-               	leaq	0xc(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L143>
-<L143>:
-               	leaq	0xe(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L144>
-<L144>:
-               	movaps	-0x500(%rbp), %xmm14
-               	psubusw	-0x4f0(%rbp), %xmm14
+               	movaps	-0x4b0(%rbp), %xmm14
+               	psubusw	-0x4a0(%rbp), %xmm14
                	pxor	%xmm15, %xmm15
                	pcmpeqw	%xmm15, %xmm14
                	pcmpeqd	%xmm15, %xmm15
                	pxor	%xmm15, %xmm14
                	movaps	%xmm14, %xmm2
                	movaps	%xmm2, %xmm14
-               	pand	-0x4f0(%rbp), %xmm14
+               	pand	-0x4a0(%rbp), %xmm14
                	movaps	%xmm14, %xmm3
                	movaps	%xmm2, %xmm14
                	pcmpeqd	%xmm15, %xmm15
                	pxor	%xmm15, %xmm14
                	movaps	%xmm14, %xmm0
                	movaps	%xmm0, %xmm14
-               	pand	-0x500(%rbp), %xmm14
+               	pand	-0x4b0(%rbp), %xmm14
                	movaps	%xmm14, %xmm0
                	movaps	%xmm3, %xmm14
                	por	%xmm0, %xmm14
                	movaps	%xmm14, %xmm3
-               	leaq	-0x3c0(%rbp), %rbx
+               	leaq	-0x360(%rbp), %rbx
                	movups	%xmm3, (%rbx)
                	leaq	(%rbx), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
-               	callq	 <L145>
-<L145>:
+               	callq	 <L127>
+<L127>:
                	leaq	0x2(%rbx), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
-               	callq	 <L146>
-<L146>:
+               	callq	 <L128>
+<L128>:
                	leaq	0x4(%rbx), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
-               	callq	 <L147>
-<L147>:
+               	callq	 <L129>
+<L129>:
                	leaq	0x6(%rbx), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
-               	callq	 <L148>
-<L148>:
+               	callq	 <L130>
+<L130>:
                	leaq	0x8(%rbx), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
-               	callq	 <L149>
-<L149>:
+               	callq	 <L131>
+<L131>:
                	leaq	0xa(%rbx), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
-               	callq	 <L150>
-<L150>:
+               	callq	 <L132>
+<L132>:
                	leaq	0xc(%rbx), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
-               	callq	 <L151>
-<L151>:
+               	callq	 <L133>
+<L133>:
                	leaq	0xe(%rbx), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
-               	callq	 <L152>
-<L152>:
-               	leaq	-0x3d0(%rbp), %rcx
+               	callq	 <L134>
+<L134>:
+               	leaq	-0x370(%rbp), %rcx
                	leaq	(%rcx), %rdx
                	movb	$0x1, (%rdx)
                	leaq	0x1(%rcx), %rdx
@@ -1634,9 +1493,9 @@ Disassembly of section .text:
                	leaq	0xf(%rcx), %rdx
                	movb	$0x1d, (%rdx)
                	movups	(%rcx), %xmm0
-               	leaq	-0x3e0(%rbp), %rcx
+               	leaq	-0x380(%rbp), %rcx
                	movups	%xmm0, (%rcx)
-               	leaq	-0x3f0(%rbp), %rdx
+               	leaq	-0x390(%rbp), %rdx
                	leaq	(%rdx), %rsi
                	movb	$0x2, (%rsi)
                	leaq	0x1(%rdx), %rsi
@@ -1670,72 +1529,72 @@ Disassembly of section .text:
                	leaq	0xf(%rdx), %rsi
                	movb	$0x1e, (%rsi)
                	movups	(%rdx), %xmm1
-               	leaq	-0x400(%rbp), %rdx
+               	leaq	-0x3a0(%rbp), %rdx
                	movups	%xmm1, (%rdx)
                	leaq	(%rcx), %rsi
                	movzbl	(%rsi), %ecx
                	addl	%r14d, %ecx
-               	leaq	-0x410(%rbp), %rsi
+               	leaq	-0x3b0(%rbp), %rsi
                	movups	%xmm0, (%rsi)
                	leaq	(%rsi), %rdi
                	movb	%cl, (%rdi)
                	movups	(%rsi), %xmm14
-               	movups	%xmm14, -0x520(%rbp)
+               	movups	%xmm14, -0x4d0(%rbp)
                	leaq	0xf(%rdx), %rcx
                	movzbl	(%rcx), %edx
                	addl	%r14d, %edx
-               	leaq	-0x420(%rbp), %rcx
+               	leaq	-0x3c0(%rbp), %rcx
                	movups	%xmm1, (%rcx)
                	leaq	0xf(%rcx), %rsi
                	movb	%dl, (%rsi)
                	movups	(%rcx), %xmm14
-               	movups	%xmm14, -0x530(%rbp)
-               	movaps	-0x530(%rbp), %xmm14
-               	psubusb	-0x520(%rbp), %xmm14
+               	movups	%xmm14, -0x4e0(%rbp)
+               	movaps	-0x4e0(%rbp), %xmm14
+               	psubusb	-0x4d0(%rbp), %xmm14
                	pxor	%xmm15, %xmm15
                	pcmpeqb	%xmm15, %xmm14
                	pcmpeqd	%xmm15, %xmm15
                	pxor	%xmm15, %xmm14
-               	movaps	%xmm14, -0x510(%rbp)
+               	movaps	%xmm14, -0x4c0(%rbp)
                	movq	%rax, %rdi
-               	movups	-0x510(%rbp), %xmm0
-               	callq	 <L153>
-<L153>:
-               	movaps	-0x520(%rbp), %xmm14
-               	pcmpeqb	-0x530(%rbp), %xmm14
+               	movups	-0x4c0(%rbp), %xmm0
+               	callq	 <L135>
+<L135>:
+               	movaps	-0x4d0(%rbp), %xmm14
+               	pcmpeqb	-0x4e0(%rbp), %xmm14
                	movaps	%xmm14, %xmm0
                	movq	%rax, %rdi
-               	callq	 <L154>
-<L154>:
-               	movaps	-0x530(%rbp), %xmm14
-               	psubusb	-0x520(%rbp), %xmm14
+               	callq	 <L136>
+<L136>:
+               	movaps	-0x4e0(%rbp), %xmm14
+               	psubusb	-0x4d0(%rbp), %xmm14
                	pxor	%xmm15, %xmm15
                	pcmpeqb	%xmm15, %xmm14
                	movaps	%xmm14, %xmm0
                	movq	%rax, %rdi
-               	callq	 <L155>
-<L155>:
-               	movaps	-0x510(%rbp), %xmm14
-               	pand	-0x520(%rbp), %xmm14
+               	callq	 <L137>
+<L137>:
+               	movaps	-0x4c0(%rbp), %xmm14
+               	pand	-0x4d0(%rbp), %xmm14
                	movaps	%xmm14, %xmm0
-               	movaps	-0x510(%rbp), %xmm14
+               	movaps	-0x4c0(%rbp), %xmm14
                	pcmpeqd	%xmm15, %xmm15
                	pxor	%xmm15, %xmm14
                	movaps	%xmm14, %xmm2
                	movaps	%xmm2, %xmm14
-               	pand	-0x530(%rbp), %xmm14
+               	pand	-0x4e0(%rbp), %xmm14
                	movaps	%xmm14, %xmm2
                	movaps	%xmm0, %xmm14
                	por	%xmm2, %xmm14
                	movaps	%xmm14, %xmm0
                	movq	%rax, %rdi
-               	callq	 <L156>
-<L156>:
-               	movq	-0x538(%rbp), %rbx
-               	movq	-0x540(%rbp), %r12
-               	movq	-0x548(%rbp), %r13
-               	movq	-0x550(%rbp), %r14
-               	movq	-0x558(%rbp), %r15
+               	callq	 <L138>
+<L138>:
+               	movq	-0x4e8(%rbp), %rbx
+               	movq	-0x4f0(%rbp), %r12
+               	movq	-0x4f8(%rbp), %r13
+               	movq	-0x500(%rbp), %r14
+               	movq	-0x508(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-linux/vec/vec_i16x4.dis
+++ b/test/golden/x86_64-linux/vec/vec_i16x4.dis
@@ -36,11 +36,11 @@ Disassembly of section .text:
 <corpus.cases.vec.vec_i16x4.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x210, %rsp            # imm = 0x210
-               	movq	%rbx, -0x1f8(%rbp)
-               	movq	%r12, -0x200(%rbp)
-               	movq	%r13, -0x208(%rbp)
-               	movq	%r14, -0x210(%rbp)
+               	subq	$0x1f0, %rsp            # imm = 0x1F0
+               	movq	%rbx, -0x1d8(%rbp)
+               	movq	%r12, -0x1e0(%rbp)
+               	movq	%r13, -0x1e8(%rbp)
+               	movq	%r14, -0x1f0(%rbp)
                	movq	%rdi, %rbx
                	callq	 <L0>
 <L0>:
@@ -79,7 +79,7 @@ Disassembly of section .text:
                	leaq	0x6(%rdi), %rbx
                	movw	$0x4, (%rbx)
                	movq	(%rdi), %r11
-               	movq	%r11, -0x150(%rbp)
+               	movq	%r11, -0x110(%rbp)
                	leaq	-0x30(%rbp), %rdi
                	leaq	(%rdi), %rbx
                	movw	$0x0, (%rbx)
@@ -90,7 +90,7 @@ Disassembly of section .text:
                	leaq	0x6(%rdi), %rbx
                	movw	$0x0, (%rbx)
                	movq	(%rdi), %r11
-               	movq	%r11, -0x160(%rbp)
+               	movq	%r11, -0x120(%rbp)
                	leaq	(%rdx), %rdi
                	movzwl	(%rdi), %edx
                	addl	%ecx, %edx
@@ -107,7 +107,7 @@ Disassembly of section .text:
                	leaq	0x6(%rbx), %rdx
                	movw	%di, (%rdx)
                	movq	(%rbx), %r11
-               	movq	%r11, -0x170(%rbp)
+               	movq	%r11, -0x130(%rbp)
                	leaq	0x2(%rsi), %rdx
                	movzwl	(%rdx), %esi
                	addl	%ecx, %esi
@@ -115,16 +115,16 @@ Disassembly of section .text:
                	movsd	%xmm1, (%rdx)
                	leaq	0x2(%rdx), %rdi
                	movw	%si, (%rdi)
-               	movsd	(%rdx), %xmm1
+               	movsd	(%rdx), %xmm0
                	leaq	0x4(%rdx), %rsi
                	movzwl	(%rsi), %edx
                	addl	%ecx, %edx
                	leaq	-0x50(%rbp), %r12
-               	movsd	%xmm1, (%r12)
+               	movsd	%xmm0, (%r12)
                	leaq	0x4(%r12), %rcx
                	movw	%dx, (%rcx)
                	movq	(%r12), %r11
-               	movq	%r11, -0x180(%rbp)
+               	movq	%r11, -0x140(%rbp)
                	leaq	(%rbx), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
@@ -165,11 +165,11 @@ Disassembly of section .text:
                	movq	%rax, %rdi
                	callq	 <L8>
 <L8>:
-               	movaps	-0x170(%rbp), %xmm14
-               	paddw	-0x180(%rbp), %xmm14
-               	movaps	%xmm14, %xmm4
+               	movaps	-0x130(%rbp), %xmm14
+               	paddw	-0x140(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	leaq	-0xb4(%rbp), %rbx
-               	movsd	%xmm4, (%rbx)
+               	movsd	%xmm0, (%rbx)
                	leaq	(%rbx), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
@@ -190,11 +190,11 @@ Disassembly of section .text:
                	movq	%rax, %rdi
                	callq	 <L12>
 <L12>:
-               	movaps	-0x170(%rbp), %xmm14
-               	psubw	-0x180(%rbp), %xmm14
-               	movaps	%xmm14, %xmm4
+               	movaps	-0x130(%rbp), %xmm14
+               	psubw	-0x140(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	leaq	-0xc4(%rbp), %rbx
-               	movsd	%xmm4, (%rbx)
+               	movsd	%xmm0, (%rbx)
                	leaq	(%rbx), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
@@ -215,11 +215,11 @@ Disassembly of section .text:
                	movq	%rax, %rdi
                	callq	 <L16>
 <L16>:
-               	movaps	-0x180(%rbp), %xmm14
-               	psubw	-0x170(%rbp), %xmm14
-               	movaps	%xmm14, %xmm4
+               	movaps	-0x140(%rbp), %xmm14
+               	psubw	-0x130(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	leaq	-0xd4(%rbp), %rbx
-               	movsd	%xmm4, (%rbx)
+               	movsd	%xmm0, (%rbx)
                	leaq	(%rbx), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
@@ -240,11 +240,11 @@ Disassembly of section .text:
                	movq	%rax, %rdi
                	callq	 <L20>
 <L20>:
-               	movaps	-0x170(%rbp), %xmm14
-               	pmullw	-0x180(%rbp), %xmm14
-               	movaps	%xmm14, %xmm4
+               	movaps	-0x130(%rbp), %xmm14
+               	pmullw	-0x140(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	leaq	-0xdc(%rbp), %rbx
-               	movsd	%xmm4, (%rbx)
+               	movsd	%xmm0, (%rbx)
                	leaq	(%rbx), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
@@ -265,11 +265,11 @@ Disassembly of section .text:
                	movq	%rax, %rdi
                	callq	 <L24>
 <L24>:
-               	movaps	-0x170(%rbp), %xmm14
-               	pmullw	-0x150(%rbp), %xmm14
-               	movaps	%xmm14, %xmm4
+               	movaps	-0x130(%rbp), %xmm14
+               	pmullw	-0x110(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	leaq	-0xe4(%rbp), %rbx
-               	movsd	%xmm4, (%rbx)
+               	movsd	%xmm0, (%rbx)
                	leaq	(%rbx), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
@@ -290,11 +290,11 @@ Disassembly of section .text:
                	movq	%rax, %rdi
                	callq	 <L28>
 <L28>:
-               	movaps	-0x180(%rbp), %xmm14
-               	pmullw	-0x150(%rbp), %xmm14
-               	movaps	%xmm14, %xmm4
+               	movaps	-0x140(%rbp), %xmm14
+               	pmullw	-0x110(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	leaq	-0xec(%rbp), %rbx
-               	movsd	%xmm4, (%rbx)
+               	movsd	%xmm0, (%rbx)
                	leaq	(%rbx), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
@@ -315,14 +315,14 @@ Disassembly of section .text:
                	movq	%rax, %rdi
                	callq	 <L32>
 <L32>:
-               	movaps	-0x170(%rbp), %xmm14
-               	paddw	-0x180(%rbp), %xmm14
-               	movaps	%xmm14, %xmm4
-               	movaps	%xmm4, %xmm14
-               	pmullw	-0x150(%rbp), %xmm14
-               	movaps	%xmm14, %xmm4
+               	movaps	-0x130(%rbp), %xmm14
+               	paddw	-0x140(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
+               	movaps	%xmm0, %xmm14
+               	pmullw	-0x110(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	leaq	-0xf4(%rbp), %rbx
-               	movsd	%xmm4, (%rbx)
+               	movsd	%xmm0, (%rbx)
                	leaq	(%rbx), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
@@ -343,11 +343,11 @@ Disassembly of section .text:
                	movq	%rax, %rdi
                	callq	 <L36>
 <L36>:
-               	movaps	-0x160(%rbp), %xmm14
-               	psubw	-0x170(%rbp), %xmm14
-               	movaps	%xmm14, %xmm4
+               	movaps	-0x120(%rbp), %xmm14
+               	psubw	-0x130(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	leaq	-0xfc(%rbp), %rbx
-               	movsd	%xmm4, (%rbx)
+               	movsd	%xmm0, (%rbx)
                	leaq	(%rbx), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
@@ -368,316 +368,180 @@ Disassembly of section .text:
                	movq	%rax, %rdi
                	callq	 <L40>
 <L40>:
-               	movaps	-0x160(%rbp), %xmm14
-               	psubw	-0x180(%rbp), %xmm14
-               	movaps	%xmm14, %xmm4
-               	leaq	-0x104(%rbp), %rbx
-               	movsd	%xmm4, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movzwl	(%rcx), %esi
+               	movaps	-0x120(%rbp), %xmm14
+               	psubw	-0x140(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	movq	%rax, %rdi
                	callq	 <L41>
 <L41>:
-               	leaq	0x2(%rbx), %rcx
-               	movzwl	(%rcx), %esi
+               	movaps	-0x130(%rbp), %xmm14
+               	pand	-0x140(%rbp), %xmm14
+               	movaps	%xmm14, -0x150(%rbp)
                	movq	%rax, %rdi
+               	movups	-0x150(%rbp), %xmm0
                	callq	 <L42>
 <L42>:
-               	leaq	0x4(%rbx), %rcx
-               	movzwl	(%rcx), %esi
+               	movaps	-0x130(%rbp), %xmm14
+               	por	-0x140(%rbp), %xmm14
+               	movaps	%xmm14, -0x160(%rbp)
                	movq	%rax, %rdi
+               	movups	-0x160(%rbp), %xmm0
                	callq	 <L43>
 <L43>:
-               	leaq	0x6(%rbx), %rcx
-               	movzwl	(%rcx), %esi
+               	movaps	-0x130(%rbp), %xmm14
+               	pxor	-0x140(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	movq	%rax, %rdi
                	callq	 <L44>
 <L44>:
-               	movaps	-0x170(%rbp), %xmm14
-               	pand	-0x180(%rbp), %xmm14
-               	movaps	%xmm14, %xmm4
-               	leaq	-0x10c(%rbp), %rbx
-               	movsd	%xmm4, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movzwl	(%rcx), %esi
+               	movaps	-0x130(%rbp), %xmm14
+               	pcmpeqd	%xmm15, %xmm15
+               	pxor	%xmm15, %xmm14
+               	movaps	%xmm14, %xmm0
                	movq	%rax, %rdi
                	callq	 <L45>
 <L45>:
-               	leaq	0x2(%rbx), %rcx
-               	movzwl	(%rcx), %esi
+               	movaps	-0x140(%rbp), %xmm14
+               	pcmpeqd	%xmm15, %xmm15
+               	pxor	%xmm15, %xmm14
+               	movaps	%xmm14, %xmm0
                	movq	%rax, %rdi
                	callq	 <L46>
 <L46>:
-               	leaq	0x4(%rbx), %rcx
-               	movzwl	(%rcx), %esi
+               	movaps	-0x150(%rbp), %xmm14
+               	pxor	-0x160(%rbp), %xmm14
+               	movaps	%xmm14, %xmm5
                	movq	%rax, %rdi
+               	movaps	%xmm5, %xmm0
                	callq	 <L47>
 <L47>:
-               	leaq	0x6(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L48>
+               	movq	%rax, %rbx
+               	movups	-0x130(%rbp), %xmm14
+               	movups	%xmm14, -0x180(%rbp)
+               	movups	-0x120(%rbp), %xmm14
+               	movups	%xmm14, -0x190(%rbp)
+               	movups	-0x120(%rbp), %xmm14
+               	movups	%xmm14, -0x1a0(%rbp)
+               	movq	$0x0, %r12
+               	cmpq	$0x6, %r12
+               	jb	 <L48>
+               	jmp	 <L65>
 <L48>:
-               	movaps	-0x170(%rbp), %xmm14
-               	por	-0x180(%rbp), %xmm14
-               	movaps	%xmm14, %xmm4
-               	leaq	-0x114(%rbp), %rbx
-               	movsd	%xmm4, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
+               	movaps	-0x180(%rbp), %xmm14
+               	pmullw	-0x110(%rbp), %xmm14
+               	movaps	%xmm14, -0x170(%rbp)
+               	leaq	-0x58(%rbp), %r13
+               	movq	-0x170(%rbp), %r11
+               	movq	%r11, (%r13)
+               	leaq	(%r13), %rax
+               	movzwl	(%rax), %esi
+               	movq	%rbx, %rdi
                	callq	 <L49>
 <L49>:
-               	leaq	0x2(%rbx), %rcx
+               	leaq	0x2(%r13), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
                	callq	 <L50>
 <L50>:
-               	leaq	0x4(%rbx), %rcx
+               	leaq	0x4(%r13), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
                	callq	 <L51>
 <L51>:
-               	leaq	0x6(%rbx), %rcx
+               	leaq	0x6(%r13), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
                	callq	 <L52>
 <L52>:
-               	movaps	-0x170(%rbp), %xmm14
-               	pxor	-0x180(%rbp), %xmm14
-               	movaps	%xmm14, %xmm4
-               	leaq	-0x11c(%rbp), %rbx
-               	movsd	%xmm4, (%rbx)
-               	leaq	(%rbx), %rcx
+               	movaps	-0x190(%rbp), %xmm14
+               	pxor	-0x170(%rbp), %xmm14
+               	movaps	%xmm14, -0x1b0(%rbp)
+               	leaq	-0xac(%rbp), %r13
+               	movq	-0x1b0(%rbp), %r11
+               	movq	%r11, (%r13)
+               	leaq	(%r13), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
                	callq	 <L53>
 <L53>:
-               	leaq	0x2(%rbx), %rcx
+               	leaq	0x2(%r13), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
                	callq	 <L54>
 <L54>:
-               	leaq	0x4(%rbx), %rcx
+               	leaq	0x4(%r13), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
                	callq	 <L55>
 <L55>:
-               	leaq	0x6(%rbx), %rcx
+               	leaq	0x6(%r13), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
                	callq	 <L56>
 <L56>:
-               	movaps	-0x170(%rbp), %xmm14
-               	pcmpeqd	%xmm15, %xmm15
-               	pxor	%xmm15, %xmm14
-               	movaps	%xmm14, %xmm4
-               	leaq	-0x124(%rbp), %rbx
-               	movsd	%xmm4, (%rbx)
-               	leaq	(%rbx), %rcx
+               	movaps	-0x1a0(%rbp), %xmm14
+               	paddw	-0x180(%rbp), %xmm14
+               	movaps	%xmm14, -0x1c0(%rbp)
+               	leaq	-0xbc(%rbp), %r13
+               	movq	-0x1c0(%rbp), %r11
+               	movq	%r11, (%r13)
+               	leaq	(%r13), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
                	callq	 <L57>
 <L57>:
-               	leaq	0x2(%rbx), %rcx
+               	leaq	0x2(%r13), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
                	callq	 <L58>
 <L58>:
-               	leaq	0x4(%rbx), %rcx
+               	leaq	0x4(%r13), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
                	callq	 <L59>
 <L59>:
-               	leaq	0x6(%rbx), %rcx
+               	leaq	0x6(%r13), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
                	callq	 <L60>
 <L60>:
                	movaps	-0x180(%rbp), %xmm14
-               	pcmpeqd	%xmm15, %xmm15
-               	pxor	%xmm15, %xmm14
-               	movaps	%xmm14, %xmm4
-               	leaq	-0x12c(%rbp), %rbx
-               	movsd	%xmm4, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L61>
-<L61>:
-               	leaq	0x2(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L62>
-<L62>:
-               	leaq	0x4(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L63>
-<L63>:
-               	leaq	0x6(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L64>
-<L64>:
-               	movaps	-0x170(%rbp), %xmm14
-               	pand	-0x180(%rbp), %xmm14
-               	movaps	%xmm14, %xmm4
-               	movaps	-0x170(%rbp), %xmm14
-               	por	-0x180(%rbp), %xmm14
-               	movaps	%xmm14, %xmm5
-               	movaps	%xmm4, %xmm14
-               	pxor	%xmm5, %xmm14
-               	movaps	%xmm14, %xmm4
-               	leaq	-0x134(%rbp), %rbx
-               	movsd	%xmm4, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L65>
-<L65>:
-               	leaq	0x2(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L66>
-<L66>:
-               	leaq	0x4(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L67>
-<L67>:
-               	leaq	0x6(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L68>
-<L68>:
-               	movq	%rax, %rbx
-               	movups	-0x170(%rbp), %xmm14
-               	movups	%xmm14, -0x1a0(%rbp)
-               	movups	-0x160(%rbp), %xmm14
-               	movups	%xmm14, -0x1b0(%rbp)
-               	movups	-0x160(%rbp), %xmm14
-               	movups	%xmm14, -0x1c0(%rbp)
-               	movq	$0x0, %r12
-               	cmpq	$0x6, %r12
-               	jb	 <L69>
-               	jmp	 <L86>
-<L69>:
-               	movaps	-0x1a0(%rbp), %xmm14
-               	pmullw	-0x150(%rbp), %xmm14
-               	movaps	%xmm14, -0x190(%rbp)
-               	leaq	-0x58(%rbp), %r13
-               	movq	-0x190(%rbp), %r11
-               	movq	%r11, (%r13)
-               	leaq	(%r13), %rax
-               	movzwl	(%rax), %esi
-               	movq	%rbx, %rdi
-               	callq	 <L70>
-<L70>:
-               	leaq	0x2(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L71>
-<L71>:
-               	leaq	0x4(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L72>
-<L72>:
-               	leaq	0x6(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L73>
-<L73>:
-               	movaps	-0x1b0(%rbp), %xmm14
-               	pxor	-0x190(%rbp), %xmm14
+               	paddw	-0x140(%rbp), %xmm14
                	movaps	%xmm14, -0x1d0(%rbp)
-               	leaq	-0xac(%rbp), %r13
+               	leaq	-0xcc(%rbp), %r13
                	movq	-0x1d0(%rbp), %r11
                	movq	%r11, (%r13)
                	leaq	(%r13), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
-               	callq	 <L74>
-<L74>:
+               	callq	 <L61>
+<L61>:
                	leaq	0x2(%r13), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
-               	callq	 <L75>
-<L75>:
+               	callq	 <L62>
+<L62>:
                	leaq	0x4(%r13), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
-               	callq	 <L76>
-<L76>:
+               	callq	 <L63>
+<L63>:
                	leaq	0x6(%r13), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
-               	callq	 <L77>
-<L77>:
-               	movaps	-0x1c0(%rbp), %xmm14
-               	paddw	-0x1a0(%rbp), %xmm14
-               	movaps	%xmm14, -0x1e0(%rbp)
-               	leaq	-0xbc(%rbp), %r13
-               	movq	-0x1e0(%rbp), %r11
-               	movq	%r11, (%r13)
-               	leaq	(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L78>
-<L78>:
-               	leaq	0x2(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L79>
-<L79>:
-               	leaq	0x4(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L80>
-<L80>:
-               	leaq	0x6(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L81>
-<L81>:
-               	movaps	-0x1a0(%rbp), %xmm14
-               	paddw	-0x180(%rbp), %xmm14
-               	movaps	%xmm14, -0x1f0(%rbp)
-               	leaq	-0xcc(%rbp), %r13
-               	movq	-0x1f0(%rbp), %r11
-               	movq	%r11, (%r13)
-               	leaq	(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L82>
-<L82>:
-               	leaq	0x2(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L83>
-<L83>:
-               	leaq	0x4(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L84>
-<L84>:
-               	leaq	0x6(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L85>
-<L85>:
+               	callq	 <L64>
+<L64>:
                	addq	$0x1, %r12
                	movq	%rax, %rbx
-               	movups	-0x1f0(%rbp), %xmm14
-               	movups	%xmm14, -0x1a0(%rbp)
                	movups	-0x1d0(%rbp), %xmm14
-               	movups	%xmm14, -0x1b0(%rbp)
-               	movups	-0x1e0(%rbp), %xmm14
-               	movups	%xmm14, -0x1c0(%rbp)
+               	movups	%xmm14, -0x180(%rbp)
+               	movups	-0x1b0(%rbp), %xmm14
+               	movups	%xmm14, -0x190(%rbp)
+               	movups	-0x1c0(%rbp), %xmm14
+               	movups	%xmm14, -0x1a0(%rbp)
                	cmpq	$0x6, %r12
-               	jb	 <L69>
-<L86>:
+               	jb	 <L48>
+<L65>:
                	leaq	-0x88(%rbp), %r12
                	movq	$0x0, (%r12)
                	movq	$0x0, 0x8(%r12)
@@ -686,34 +550,34 @@ Disassembly of section .text:
                	movq	$0x0, 0x20(%r12)
                	movq	$0x0, 0x28(%r12)
                	leaq	(%r12), %rax
-               	movq	-0x1a0(%rbp), %r11
+               	movq	-0x180(%rbp), %r11
                	movq	%r11, (%rax)
-               	movaps	-0x1a0(%rbp), %xmm14
-               	paddw	-0x180(%rbp), %xmm14
+               	movaps	-0x180(%rbp), %xmm14
+               	paddw	-0x140(%rbp), %xmm14
                	movaps	%xmm14, %xmm3
                	leaq	0x8(%r12), %rax
                	movsd	%xmm3, (%rax)
-               	movaps	-0x1a0(%rbp), %xmm14
-               	pmullw	-0x150(%rbp), %xmm14
+               	movaps	-0x180(%rbp), %xmm14
+               	pmullw	-0x110(%rbp), %xmm14
                	movaps	%xmm14, %xmm3
                	leaq	0x10(%r12), %rax
                	movsd	%xmm3, (%rax)
                	leaq	0x18(%r12), %rax
-               	movq	-0x1b0(%rbp), %r11
+               	movq	-0x190(%rbp), %r11
                	movq	%r11, (%rax)
                	leaq	0x20(%r12), %rax
-               	movq	-0x1c0(%rbp), %r11
+               	movq	-0x1a0(%rbp), %r11
                	movq	%r11, (%rax)
-               	movaps	-0x1a0(%rbp), %xmm14
-               	pxor	-0x180(%rbp), %xmm14
-               	movaps	%xmm14, %xmm4
+               	movaps	-0x180(%rbp), %xmm14
+               	pxor	-0x140(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	leaq	0x28(%r12), %rax
-               	movsd	%xmm4, (%rax)
+               	movsd	%xmm0, (%rax)
                	movq	$0x0, %r13
                	cmpq	$0x6, %r13
-               	jb	 <L87>
-               	jmp	 <L92>
-<L87>:
+               	jb	 <L66>
+               	jmp	 <L71>
+<L66>:
                	leaq	(%r12,%r13,8), %rax
                	movsd	(%rax), %xmm0
                	leaq	-0x90(%rbp), %r14
@@ -721,28 +585,28 @@ Disassembly of section .text:
                	leaq	(%r14), %rax
                	movzwl	(%rax), %esi
                	movq	%rbx, %rdi
-               	callq	 <L88>
-<L88>:
+               	callq	 <L67>
+<L67>:
                	leaq	0x2(%r14), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
-               	callq	 <L89>
-<L89>:
+               	callq	 <L68>
+<L68>:
                	leaq	0x4(%r14), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
-               	callq	 <L90>
-<L90>:
+               	callq	 <L69>
+<L69>:
                	leaq	0x6(%r14), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
-               	callq	 <L91>
-<L91>:
+               	callq	 <L70>
+<L70>:
                	addq	$0x1, %r13
                	movq	%rax, %rbx
                	cmpq	$0x6, %r13
-               	jb	 <L87>
-<L92>:
+               	jb	 <L66>
+<L71>:
                	leaq	-0x9c(%rbp), %r13
                	movq	$0x0, (%r13)
                	movl	$0x0, 0x8(%r13)
@@ -756,40 +620,40 @@ Disassembly of section .text:
                	movb	$-0x53, (%rcx)
                	movzbl	(%rax), %esi
                	movq	%rbx, %rdi
-               	callq	 <L93>
-<L93>:
+               	callq	 <L72>
+<L72>:
                	movsd	(%r12), %xmm0
                	leaq	-0xa4(%rbp), %rbx
                	movsd	%xmm0, (%rbx)
                	leaq	(%rbx), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
-               	callq	 <L94>
-<L94>:
+               	callq	 <L73>
+<L73>:
                	leaq	0x2(%rbx), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
-               	callq	 <L95>
-<L95>:
+               	callq	 <L74>
+<L74>:
                	leaq	0x4(%rbx), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
-               	callq	 <L96>
-<L96>:
+               	callq	 <L75>
+<L75>:
                	leaq	0x6(%rbx), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
-               	callq	 <L97>
-<L97>:
+               	callq	 <L76>
+<L76>:
                	leaq	0xa(%r13), %rcx
                	movzbl	(%rcx), %esi
                	movq	%rax, %rdi
-               	callq	 <L98>
-<L98>:
-               	movq	-0x1f8(%rbp), %rbx
-               	movq	-0x200(%rbp), %r12
-               	movq	-0x208(%rbp), %r13
-               	movq	-0x210(%rbp), %r14
+               	callq	 <L77>
+<L77>:
+               	movq	-0x1d8(%rbp), %rbx
+               	movq	-0x1e0(%rbp), %r12
+               	movq	-0x1e8(%rbp), %r13
+               	movq	-0x1f0(%rbp), %r14
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-linux/vec/vec_i16x8.dis
+++ b/test/golden/x86_64-linux/vec/vec_i16x8.dis
@@ -56,11 +56,11 @@ Disassembly of section .text:
 <corpus.cases.vec.vec_i16x8.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x330, %rsp            # imm = 0x330
-               	movq	%rbx, -0x318(%rbp)
-               	movq	%r12, -0x320(%rbp)
-               	movq	%r13, -0x328(%rbp)
-               	movq	%r14, -0x330(%rbp)
+               	subq	$0x2e0, %rsp            # imm = 0x2E0
+               	movq	%rbx, -0x2c8(%rbp)
+               	movq	%r12, -0x2d0(%rbp)
+               	movq	%r13, -0x2d8(%rbp)
+               	movq	%r14, -0x2e0(%rbp)
                	movq	%rdi, %rbx
                	callq	 <L0>
 <L0>:
@@ -123,7 +123,7 @@ Disassembly of section .text:
                	leaq	0xe(%rdi), %rbx
                	movw	$0x8, (%rbx)
                	movups	(%rdi), %xmm14
-               	movups	%xmm14, -0x270(%rbp)
+               	movups	%xmm14, -0x200(%rbp)
                	leaq	-0x60(%rbp), %rdi
                	leaq	(%rdi), %rbx
                	movw	$0x0, (%rbx)
@@ -142,7 +142,7 @@ Disassembly of section .text:
                	leaq	0xe(%rdi), %rbx
                	movw	$0x0, (%rbx)
                	movups	(%rdi), %xmm14
-               	movups	%xmm14, -0x280(%rbp)
+               	movups	%xmm14, -0x210(%rbp)
                	leaq	(%rdx), %rdi
                	movzwl	(%rdi), %edx
                	addl	%ecx, %edx
@@ -159,7 +159,7 @@ Disassembly of section .text:
                	leaq	0xc(%rbx), %rdx
                	movw	%di, (%rdx)
                	movups	(%rbx), %xmm14
-               	movups	%xmm14, -0x290(%rbp)
+               	movups	%xmm14, -0x220(%rbp)
                	leaq	0x4(%rsi), %rdx
                	movzwl	(%rdx), %esi
                	addl	%ecx, %esi
@@ -167,16 +167,16 @@ Disassembly of section .text:
                	movups	%xmm1, (%rdx)
                	leaq	0x4(%rdx), %rdi
                	movw	%si, (%rdi)
-               	movups	(%rdx), %xmm1
+               	movups	(%rdx), %xmm0
                	leaq	0xe(%rdx), %rsi
                	movzwl	(%rsi), %edx
                	addl	%ecx, %edx
                	leaq	-0xa0(%rbp), %r12
-               	movups	%xmm1, (%r12)
+               	movups	%xmm0, (%r12)
                	leaq	0xe(%r12), %rcx
                	movw	%dx, (%rcx)
                	movups	(%r12), %xmm14
-               	movups	%xmm14, -0x2a0(%rbp)
+               	movups	%xmm14, -0x230(%rbp)
                	leaq	(%rbx), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
@@ -257,11 +257,11 @@ Disassembly of section .text:
                	movq	%rax, %rdi
                	callq	 <L16>
 <L16>:
-               	movaps	-0x290(%rbp), %xmm14
-               	paddw	-0x2a0(%rbp), %xmm14
-               	movaps	%xmm14, %xmm4
+               	movaps	-0x220(%rbp), %xmm14
+               	paddw	-0x230(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	leaq	-0x160(%rbp), %rbx
-               	movups	%xmm4, (%rbx)
+               	movups	%xmm0, (%rbx)
                	leaq	(%rbx), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
@@ -302,11 +302,11 @@ Disassembly of section .text:
                	movq	%rax, %rdi
                	callq	 <L24>
 <L24>:
-               	movaps	-0x290(%rbp), %xmm14
-               	psubw	-0x2a0(%rbp), %xmm14
-               	movaps	%xmm14, %xmm4
+               	movaps	-0x220(%rbp), %xmm14
+               	psubw	-0x230(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	leaq	-0x180(%rbp), %rbx
-               	movups	%xmm4, (%rbx)
+               	movups	%xmm0, (%rbx)
                	leaq	(%rbx), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
@@ -347,11 +347,11 @@ Disassembly of section .text:
                	movq	%rax, %rdi
                	callq	 <L32>
 <L32>:
-               	movaps	-0x2a0(%rbp), %xmm14
-               	psubw	-0x290(%rbp), %xmm14
-               	movaps	%xmm14, %xmm4
+               	movaps	-0x230(%rbp), %xmm14
+               	psubw	-0x220(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	leaq	-0x1a0(%rbp), %rbx
-               	movups	%xmm4, (%rbx)
+               	movups	%xmm0, (%rbx)
                	leaq	(%rbx), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
@@ -392,11 +392,11 @@ Disassembly of section .text:
                	movq	%rax, %rdi
                	callq	 <L40>
 <L40>:
-               	movaps	-0x290(%rbp), %xmm14
-               	pmullw	-0x2a0(%rbp), %xmm14
-               	movaps	%xmm14, %xmm4
+               	movaps	-0x220(%rbp), %xmm14
+               	pmullw	-0x230(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	leaq	-0x1b0(%rbp), %rbx
-               	movups	%xmm4, (%rbx)
+               	movups	%xmm0, (%rbx)
                	leaq	(%rbx), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
@@ -437,11 +437,11 @@ Disassembly of section .text:
                	movq	%rax, %rdi
                	callq	 <L48>
 <L48>:
-               	movaps	-0x290(%rbp), %xmm14
-               	pmullw	-0x270(%rbp), %xmm14
-               	movaps	%xmm14, %xmm4
+               	movaps	-0x220(%rbp), %xmm14
+               	pmullw	-0x200(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	leaq	-0x1c0(%rbp), %rbx
-               	movups	%xmm4, (%rbx)
+               	movups	%xmm0, (%rbx)
                	leaq	(%rbx), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
@@ -482,11 +482,11 @@ Disassembly of section .text:
                	movq	%rax, %rdi
                	callq	 <L56>
 <L56>:
-               	movaps	-0x2a0(%rbp), %xmm14
-               	pmullw	-0x270(%rbp), %xmm14
-               	movaps	%xmm14, %xmm4
+               	movaps	-0x230(%rbp), %xmm14
+               	pmullw	-0x200(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	leaq	-0x1d0(%rbp), %rbx
-               	movups	%xmm4, (%rbx)
+               	movups	%xmm0, (%rbx)
                	leaq	(%rbx), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
@@ -527,14 +527,14 @@ Disassembly of section .text:
                	movq	%rax, %rdi
                	callq	 <L64>
 <L64>:
-               	movaps	-0x290(%rbp), %xmm14
-               	paddw	-0x2a0(%rbp), %xmm14
-               	movaps	%xmm14, %xmm4
-               	movaps	%xmm4, %xmm14
-               	pmullw	-0x270(%rbp), %xmm14
-               	movaps	%xmm14, %xmm4
+               	movaps	-0x220(%rbp), %xmm14
+               	paddw	-0x230(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
+               	movaps	%xmm0, %xmm14
+               	pmullw	-0x200(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	leaq	-0x1e0(%rbp), %rbx
-               	movups	%xmm4, (%rbx)
+               	movups	%xmm0, (%rbx)
                	leaq	(%rbx), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
@@ -575,11 +575,11 @@ Disassembly of section .text:
                	movq	%rax, %rdi
                	callq	 <L72>
 <L72>:
-               	movaps	-0x280(%rbp), %xmm14
-               	psubw	-0x290(%rbp), %xmm14
-               	movaps	%xmm14, %xmm4
+               	movaps	-0x210(%rbp), %xmm14
+               	psubw	-0x220(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	leaq	-0x1f0(%rbp), %rbx
-               	movups	%xmm4, (%rbx)
+               	movups	%xmm0, (%rbx)
                	leaq	(%rbx), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
@@ -620,536 +620,260 @@ Disassembly of section .text:
                	movq	%rax, %rdi
                	callq	 <L80>
 <L80>:
-               	movaps	-0x280(%rbp), %xmm14
-               	psubw	-0x2a0(%rbp), %xmm14
-               	movaps	%xmm14, %xmm4
-               	leaq	-0x200(%rbp), %rbx
-               	movups	%xmm4, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movzwl	(%rcx), %esi
+               	movaps	-0x210(%rbp), %xmm14
+               	psubw	-0x230(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	movq	%rax, %rdi
                	callq	 <L81>
 <L81>:
-               	leaq	0x2(%rbx), %rcx
-               	movzwl	(%rcx), %esi
+               	movaps	-0x220(%rbp), %xmm14
+               	pand	-0x230(%rbp), %xmm14
+               	movaps	%xmm14, -0x240(%rbp)
                	movq	%rax, %rdi
+               	movups	-0x240(%rbp), %xmm0
                	callq	 <L82>
 <L82>:
-               	leaq	0x4(%rbx), %rcx
-               	movzwl	(%rcx), %esi
+               	movaps	-0x220(%rbp), %xmm14
+               	por	-0x230(%rbp), %xmm14
+               	movaps	%xmm14, -0x250(%rbp)
                	movq	%rax, %rdi
+               	movups	-0x250(%rbp), %xmm0
                	callq	 <L83>
 <L83>:
-               	leaq	0x6(%rbx), %rcx
-               	movzwl	(%rcx), %esi
+               	movaps	-0x220(%rbp), %xmm14
+               	pxor	-0x230(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	movq	%rax, %rdi
                	callq	 <L84>
 <L84>:
-               	leaq	0x8(%rbx), %rcx
-               	movzwl	(%rcx), %esi
+               	movaps	-0x220(%rbp), %xmm14
+               	pcmpeqd	%xmm15, %xmm15
+               	pxor	%xmm15, %xmm14
+               	movaps	%xmm14, %xmm0
                	movq	%rax, %rdi
                	callq	 <L85>
 <L85>:
-               	leaq	0xa(%rbx), %rcx
-               	movzwl	(%rcx), %esi
+               	movaps	-0x230(%rbp), %xmm14
+               	pcmpeqd	%xmm15, %xmm15
+               	pxor	%xmm15, %xmm14
+               	movaps	%xmm14, %xmm0
                	movq	%rax, %rdi
                	callq	 <L86>
 <L86>:
-               	leaq	0xc(%rbx), %rcx
-               	movzwl	(%rcx), %esi
+               	movaps	-0x240(%rbp), %xmm14
+               	pxor	-0x250(%rbp), %xmm14
+               	movaps	%xmm14, %xmm5
                	movq	%rax, %rdi
+               	movaps	%xmm5, %xmm0
                	callq	 <L87>
 <L87>:
-               	leaq	0xe(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L88>
+               	movq	%rax, %rbx
+               	movups	-0x220(%rbp), %xmm14
+               	movups	%xmm14, -0x270(%rbp)
+               	movups	-0x210(%rbp), %xmm14
+               	movups	%xmm14, -0x280(%rbp)
+               	movups	-0x210(%rbp), %xmm14
+               	movups	%xmm14, -0x290(%rbp)
+               	movq	$0x0, %r12
+               	cmpq	$0x6, %r12
+               	jb	 <L88>
+               	jmp	 <L121>
 <L88>:
-               	movaps	-0x290(%rbp), %xmm14
-               	pand	-0x2a0(%rbp), %xmm14
-               	movaps	%xmm14, %xmm4
-               	leaq	-0x210(%rbp), %rbx
-               	movups	%xmm4, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
+               	movaps	-0x270(%rbp), %xmm14
+               	pmullw	-0x200(%rbp), %xmm14
+               	movaps	%xmm14, -0x260(%rbp)
+               	leaq	-0xb0(%rbp), %r13
+               	movups	-0x260(%rbp), %xmm14
+               	movups	%xmm14, (%r13)
+               	leaq	(%r13), %rax
+               	movzwl	(%rax), %esi
+               	movq	%rbx, %rdi
                	callq	 <L89>
 <L89>:
-               	leaq	0x2(%rbx), %rcx
+               	leaq	0x2(%r13), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
                	callq	 <L90>
 <L90>:
-               	leaq	0x4(%rbx), %rcx
+               	leaq	0x4(%r13), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
                	callq	 <L91>
 <L91>:
-               	leaq	0x6(%rbx), %rcx
+               	leaq	0x6(%r13), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
                	callq	 <L92>
 <L92>:
-               	leaq	0x8(%rbx), %rcx
+               	leaq	0x8(%r13), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
                	callq	 <L93>
 <L93>:
-               	leaq	0xa(%rbx), %rcx
+               	leaq	0xa(%r13), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
                	callq	 <L94>
 <L94>:
-               	leaq	0xc(%rbx), %rcx
+               	leaq	0xc(%r13), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
                	callq	 <L95>
 <L95>:
-               	leaq	0xe(%rbx), %rcx
+               	leaq	0xe(%r13), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
                	callq	 <L96>
 <L96>:
-               	movaps	-0x290(%rbp), %xmm14
-               	por	-0x2a0(%rbp), %xmm14
-               	movaps	%xmm14, %xmm4
-               	leaq	-0x220(%rbp), %rbx
-               	movups	%xmm4, (%rbx)
-               	leaq	(%rbx), %rcx
+               	movaps	-0x280(%rbp), %xmm14
+               	pxor	-0x260(%rbp), %xmm14
+               	movaps	%xmm14, -0x2a0(%rbp)
+               	leaq	-0x150(%rbp), %r13
+               	movups	-0x2a0(%rbp), %xmm14
+               	movups	%xmm14, (%r13)
+               	leaq	(%r13), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
                	callq	 <L97>
 <L97>:
-               	leaq	0x2(%rbx), %rcx
+               	leaq	0x2(%r13), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
                	callq	 <L98>
 <L98>:
-               	leaq	0x4(%rbx), %rcx
+               	leaq	0x4(%r13), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
                	callq	 <L99>
 <L99>:
-               	leaq	0x6(%rbx), %rcx
+               	leaq	0x6(%r13), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
                	callq	 <L100>
 <L100>:
-               	leaq	0x8(%rbx), %rcx
+               	leaq	0x8(%r13), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
                	callq	 <L101>
 <L101>:
-               	leaq	0xa(%rbx), %rcx
+               	leaq	0xa(%r13), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
                	callq	 <L102>
 <L102>:
-               	leaq	0xc(%rbx), %rcx
+               	leaq	0xc(%r13), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
                	callq	 <L103>
 <L103>:
-               	leaq	0xe(%rbx), %rcx
+               	leaq	0xe(%r13), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
                	callq	 <L104>
 <L104>:
                	movaps	-0x290(%rbp), %xmm14
-               	pxor	-0x2a0(%rbp), %xmm14
-               	movaps	%xmm14, %xmm4
-               	leaq	-0x230(%rbp), %rbx
-               	movups	%xmm4, (%rbx)
-               	leaq	(%rbx), %rcx
+               	paddw	-0x270(%rbp), %xmm14
+               	movaps	%xmm14, -0x2b0(%rbp)
+               	leaq	-0x170(%rbp), %r13
+               	movups	-0x2b0(%rbp), %xmm14
+               	movups	%xmm14, (%r13)
+               	leaq	(%r13), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
                	callq	 <L105>
 <L105>:
-               	leaq	0x2(%rbx), %rcx
+               	leaq	0x2(%r13), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
                	callq	 <L106>
 <L106>:
-               	leaq	0x4(%rbx), %rcx
+               	leaq	0x4(%r13), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
                	callq	 <L107>
 <L107>:
-               	leaq	0x6(%rbx), %rcx
+               	leaq	0x6(%r13), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
                	callq	 <L108>
 <L108>:
-               	leaq	0x8(%rbx), %rcx
+               	leaq	0x8(%r13), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
                	callq	 <L109>
 <L109>:
-               	leaq	0xa(%rbx), %rcx
+               	leaq	0xa(%r13), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
                	callq	 <L110>
 <L110>:
-               	leaq	0xc(%rbx), %rcx
+               	leaq	0xc(%r13), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
                	callq	 <L111>
 <L111>:
-               	leaq	0xe(%rbx), %rcx
+               	leaq	0xe(%r13), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
                	callq	 <L112>
 <L112>:
-               	movaps	-0x290(%rbp), %xmm14
-               	pcmpeqd	%xmm15, %xmm15
-               	pxor	%xmm15, %xmm14
-               	movaps	%xmm14, %xmm4
-               	leaq	-0x240(%rbp), %rbx
-               	movups	%xmm4, (%rbx)
-               	leaq	(%rbx), %rcx
+               	movaps	-0x270(%rbp), %xmm14
+               	paddw	-0x230(%rbp), %xmm14
+               	movaps	%xmm14, -0x2c0(%rbp)
+               	leaq	-0x190(%rbp), %r13
+               	movups	-0x2c0(%rbp), %xmm14
+               	movups	%xmm14, (%r13)
+               	leaq	(%r13), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
                	callq	 <L113>
 <L113>:
-               	leaq	0x2(%rbx), %rcx
+               	leaq	0x2(%r13), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
                	callq	 <L114>
 <L114>:
-               	leaq	0x4(%rbx), %rcx
+               	leaq	0x4(%r13), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
                	callq	 <L115>
 <L115>:
-               	leaq	0x6(%rbx), %rcx
+               	leaq	0x6(%r13), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
                	callq	 <L116>
 <L116>:
-               	leaq	0x8(%rbx), %rcx
+               	leaq	0x8(%r13), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
                	callq	 <L117>
 <L117>:
-               	leaq	0xa(%rbx), %rcx
+               	leaq	0xa(%r13), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
                	callq	 <L118>
 <L118>:
-               	leaq	0xc(%rbx), %rcx
+               	leaq	0xc(%r13), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
                	callq	 <L119>
 <L119>:
-               	leaq	0xe(%rbx), %rcx
+               	leaq	0xe(%r13), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
                	callq	 <L120>
 <L120>:
-               	movaps	-0x2a0(%rbp), %xmm14
-               	pcmpeqd	%xmm15, %xmm15
-               	pxor	%xmm15, %xmm14
-               	movaps	%xmm14, %xmm4
-               	leaq	-0x250(%rbp), %rbx
-               	movups	%xmm4, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L121>
-<L121>:
-               	leaq	0x2(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L122>
-<L122>:
-               	leaq	0x4(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L123>
-<L123>:
-               	leaq	0x6(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L124>
-<L124>:
-               	leaq	0x8(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L125>
-<L125>:
-               	leaq	0xa(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L126>
-<L126>:
-               	leaq	0xc(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L127>
-<L127>:
-               	leaq	0xe(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L128>
-<L128>:
-               	movaps	-0x290(%rbp), %xmm14
-               	pand	-0x2a0(%rbp), %xmm14
-               	movaps	%xmm14, %xmm4
-               	movaps	-0x290(%rbp), %xmm14
-               	por	-0x2a0(%rbp), %xmm14
-               	movaps	%xmm14, %xmm5
-               	movaps	%xmm4, %xmm14
-               	pxor	%xmm5, %xmm14
-               	movaps	%xmm14, %xmm4
-               	leaq	-0x260(%rbp), %rbx
-               	movups	%xmm4, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L129>
-<L129>:
-               	leaq	0x2(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L130>
-<L130>:
-               	leaq	0x4(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L131>
-<L131>:
-               	leaq	0x6(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L132>
-<L132>:
-               	leaq	0x8(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L133>
-<L133>:
-               	leaq	0xa(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L134>
-<L134>:
-               	leaq	0xc(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L135>
-<L135>:
-               	leaq	0xe(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L136>
-<L136>:
-               	movq	%rax, %rbx
-               	movups	-0x290(%rbp), %xmm14
-               	movups	%xmm14, -0x2c0(%rbp)
-               	movups	-0x280(%rbp), %xmm14
-               	movups	%xmm14, -0x2d0(%rbp)
-               	movups	-0x280(%rbp), %xmm14
-               	movups	%xmm14, -0x2e0(%rbp)
-               	movq	$0x0, %r12
-               	cmpq	$0x6, %r12
-               	jb	 <L137>
-               	jmp	 <L170>
-<L137>:
-               	movaps	-0x2c0(%rbp), %xmm14
-               	pmullw	-0x270(%rbp), %xmm14
-               	movaps	%xmm14, -0x2b0(%rbp)
-               	leaq	-0xb0(%rbp), %r13
-               	movups	-0x2b0(%rbp), %xmm14
-               	movups	%xmm14, (%r13)
-               	leaq	(%r13), %rax
-               	movzwl	(%rax), %esi
-               	movq	%rbx, %rdi
-               	callq	 <L138>
-<L138>:
-               	leaq	0x2(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L139>
-<L139>:
-               	leaq	0x4(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L140>
-<L140>:
-               	leaq	0x6(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L141>
-<L141>:
-               	leaq	0x8(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L142>
-<L142>:
-               	leaq	0xa(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L143>
-<L143>:
-               	leaq	0xc(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L144>
-<L144>:
-               	leaq	0xe(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L145>
-<L145>:
-               	movaps	-0x2d0(%rbp), %xmm14
-               	pxor	-0x2b0(%rbp), %xmm14
-               	movaps	%xmm14, -0x2f0(%rbp)
-               	leaq	-0x150(%rbp), %r13
-               	movups	-0x2f0(%rbp), %xmm14
-               	movups	%xmm14, (%r13)
-               	leaq	(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L146>
-<L146>:
-               	leaq	0x2(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L147>
-<L147>:
-               	leaq	0x4(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L148>
-<L148>:
-               	leaq	0x6(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L149>
-<L149>:
-               	leaq	0x8(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L150>
-<L150>:
-               	leaq	0xa(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L151>
-<L151>:
-               	leaq	0xc(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L152>
-<L152>:
-               	leaq	0xe(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L153>
-<L153>:
-               	movaps	-0x2e0(%rbp), %xmm14
-               	paddw	-0x2c0(%rbp), %xmm14
-               	movaps	%xmm14, -0x300(%rbp)
-               	leaq	-0x170(%rbp), %r13
-               	movups	-0x300(%rbp), %xmm14
-               	movups	%xmm14, (%r13)
-               	leaq	(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L154>
-<L154>:
-               	leaq	0x2(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L155>
-<L155>:
-               	leaq	0x4(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L156>
-<L156>:
-               	leaq	0x6(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L157>
-<L157>:
-               	leaq	0x8(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L158>
-<L158>:
-               	leaq	0xa(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L159>
-<L159>:
-               	leaq	0xc(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L160>
-<L160>:
-               	leaq	0xe(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L161>
-<L161>:
-               	movaps	-0x2c0(%rbp), %xmm14
-               	paddw	-0x2a0(%rbp), %xmm14
-               	movaps	%xmm14, -0x310(%rbp)
-               	leaq	-0x190(%rbp), %r13
-               	movups	-0x310(%rbp), %xmm14
-               	movups	%xmm14, (%r13)
-               	leaq	(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L162>
-<L162>:
-               	leaq	0x2(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L163>
-<L163>:
-               	leaq	0x4(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L164>
-<L164>:
-               	leaq	0x6(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L165>
-<L165>:
-               	leaq	0x8(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L166>
-<L166>:
-               	leaq	0xa(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L167>
-<L167>:
-               	leaq	0xc(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L168>
-<L168>:
-               	leaq	0xe(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L169>
-<L169>:
                	addq	$0x1, %r12
                	movq	%rax, %rbx
-               	movups	-0x310(%rbp), %xmm14
-               	movups	%xmm14, -0x2c0(%rbp)
-               	movups	-0x2f0(%rbp), %xmm14
-               	movups	%xmm14, -0x2d0(%rbp)
-               	movups	-0x300(%rbp), %xmm14
-               	movups	%xmm14, -0x2e0(%rbp)
+               	movups	-0x2c0(%rbp), %xmm14
+               	movups	%xmm14, -0x270(%rbp)
+               	movups	-0x2a0(%rbp), %xmm14
+               	movups	%xmm14, -0x280(%rbp)
+               	movups	-0x2b0(%rbp), %xmm14
+               	movups	%xmm14, -0x290(%rbp)
                	cmpq	$0x6, %r12
-               	jb	 <L137>
-<L170>:
+               	jb	 <L88>
+<L121>:
                	leaq	-0xf0(%rbp), %r12
                	movq	$0x0, (%r12)
                	movq	$0x0, 0x8(%r12)
@@ -1160,26 +884,26 @@ Disassembly of section .text:
                	movq	$0x0, 0x30(%r12)
                	movq	$0x0, 0x38(%r12)
                	leaq	(%r12), %rax
-               	movups	-0x2c0(%rbp), %xmm14
+               	movups	-0x270(%rbp), %xmm14
                	movups	%xmm14, (%rax)
-               	movaps	-0x2c0(%rbp), %xmm14
-               	paddw	-0x2a0(%rbp), %xmm14
+               	movaps	-0x270(%rbp), %xmm14
+               	paddw	-0x230(%rbp), %xmm14
                	movaps	%xmm14, %xmm3
                	leaq	0x10(%r12), %rax
                	movups	%xmm3, (%rax)
-               	movaps	-0x2c0(%rbp), %xmm14
-               	pmullw	-0x270(%rbp), %xmm14
-               	movaps	%xmm14, %xmm4
+               	movaps	-0x270(%rbp), %xmm14
+               	pmullw	-0x200(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	leaq	0x20(%r12), %rax
-               	movups	%xmm4, (%rax)
+               	movups	%xmm0, (%rax)
                	leaq	0x30(%r12), %rax
-               	movups	-0x2d0(%rbp), %xmm14
+               	movups	-0x280(%rbp), %xmm14
                	movups	%xmm14, (%rax)
                	movq	$0x0, %r13
                	cmpq	$0x4, %r13
-               	jb	 <L171>
-               	jmp	 <L180>
-<L171>:
+               	jb	 <L122>
+               	jmp	 <L131>
+<L122>:
                	movq	%r13, %rax
                	imulq	$0x10, %rax, %rax
                	leaq	(%r12,%rax), %rcx
@@ -1189,48 +913,48 @@ Disassembly of section .text:
                	leaq	(%r14), %rax
                	movzwl	(%rax), %esi
                	movq	%rbx, %rdi
-               	callq	 <L172>
-<L172>:
+               	callq	 <L123>
+<L123>:
                	leaq	0x2(%r14), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
-               	callq	 <L173>
-<L173>:
+               	callq	 <L124>
+<L124>:
                	leaq	0x4(%r14), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
-               	callq	 <L174>
-<L174>:
+               	callq	 <L125>
+<L125>:
                	leaq	0x6(%r14), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
-               	callq	 <L175>
-<L175>:
+               	callq	 <L126>
+<L126>:
                	leaq	0x8(%r14), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
-               	callq	 <L176>
-<L176>:
+               	callq	 <L127>
+<L127>:
                	leaq	0xa(%r14), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
-               	callq	 <L177>
-<L177>:
+               	callq	 <L128>
+<L128>:
                	leaq	0xc(%r14), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
-               	callq	 <L178>
-<L178>:
+               	callq	 <L129>
+<L129>:
                	leaq	0xe(%r14), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
-               	callq	 <L179>
-<L179>:
+               	callq	 <L130>
+<L130>:
                	addq	$0x1, %r13
                	movq	%rax, %rbx
                	cmpq	$0x4, %r13
-               	jb	 <L171>
-<L180>:
+               	jb	 <L122>
+<L131>:
                	leaq	-0x130(%rbp), %r13
                	movq	$0x0, (%r13)
                	movq	$0x0, 0x8(%r13)
@@ -1249,61 +973,61 @@ Disassembly of section .text:
                	movl	(%rax), %ecx
                	movq	%rbx, %rdi
                	movl	%ecx, %esi
-               	callq	 <L181>
-<L181>:
+               	callq	 <L132>
+<L132>:
                	movups	(%r12), %xmm0
                	leaq	-0x140(%rbp), %rbx
                	movups	%xmm0, (%rbx)
                	leaq	(%rbx), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
-               	callq	 <L182>
-<L182>:
+               	callq	 <L133>
+<L133>:
                	leaq	0x2(%rbx), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
-               	callq	 <L183>
-<L183>:
+               	callq	 <L134>
+<L134>:
                	leaq	0x4(%rbx), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
-               	callq	 <L184>
-<L184>:
+               	callq	 <L135>
+<L135>:
                	leaq	0x6(%rbx), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
-               	callq	 <L185>
-<L185>:
+               	callq	 <L136>
+<L136>:
                	leaq	0x8(%rbx), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
-               	callq	 <L186>
-<L186>:
+               	callq	 <L137>
+<L137>:
                	leaq	0xa(%rbx), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
-               	callq	 <L187>
-<L187>:
+               	callq	 <L138>
+<L138>:
                	leaq	0xc(%rbx), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
-               	callq	 <L188>
-<L188>:
+               	callq	 <L139>
+<L139>:
                	leaq	0xe(%rbx), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
-               	callq	 <L189>
-<L189>:
+               	callq	 <L140>
+<L140>:
                	leaq	0x20(%r13), %rcx
                	movl	(%rcx), %edx
                	movq	%rax, %rdi
                	movl	%edx, %esi
-               	callq	 <L190>
-<L190>:
-               	movq	-0x318(%rbp), %rbx
-               	movq	-0x320(%rbp), %r12
-               	movq	-0x328(%rbp), %r13
-               	movq	-0x330(%rbp), %r14
+               	callq	 <L141>
+<L141>:
+               	movq	-0x2c8(%rbp), %rbx
+               	movq	-0x2d0(%rbp), %r12
+               	movq	-0x2d8(%rbp), %r13
+               	movq	-0x2e0(%rbp), %r14
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-linux/vec/vec_i32x4.dis
+++ b/test/golden/x86_64-linux/vec/vec_i32x4.dis
@@ -40,12 +40,12 @@ Disassembly of section .text:
 <corpus.cases.vec.vec_i32x4.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x4d0, %rsp            # imm = 0x4D0
-               	movq	%rbx, -0x4a8(%rbp)
-               	movq	%r12, -0x4b0(%rbp)
-               	movq	%r13, -0x4b8(%rbp)
-               	movq	%r14, -0x4c0(%rbp)
-               	movq	%r15, -0x4c8(%rbp)
+               	subq	$0x480, %rsp            # imm = 0x480
+               	movq	%rbx, -0x458(%rbp)
+               	movq	%r12, -0x460(%rbp)
+               	movq	%r13, -0x468(%rbp)
+               	movq	%r14, -0x470(%rbp)
+               	movq	%r15, -0x478(%rbp)
                	movq	%rdi, %rbx
                	callq	 <L0>
 <L0>:
@@ -96,7 +96,7 @@ Disassembly of section .text:
                	leaq	0xc(%rdi), %r12
                	movl	$0x0, (%r12)
                	movups	(%rdi), %xmm14
-               	movups	%xmm14, -0x3f0(%rbp)
+               	movups	%xmm14, -0x380(%rbp)
                	leaq	(%rdx), %rdi
                	movl	(%rdi), %edx
                	addl	%ecx, %edx
@@ -113,7 +113,7 @@ Disassembly of section .text:
                	leaq	0x8(%r12), %rdx
                	movl	%edi, (%rdx)
                	movups	(%r12), %xmm14
-               	movups	%xmm14, -0x400(%rbp)
+               	movups	%xmm14, -0x390(%rbp)
                	leaq	0x4(%rsi), %rdx
                	movl	(%rdx), %esi
                	addl	%ecx, %esi
@@ -121,16 +121,16 @@ Disassembly of section .text:
                	movups	%xmm1, (%rdx)
                	leaq	0x4(%rdx), %rdi
                	movl	%esi, (%rdi)
-               	movups	(%rdx), %xmm1
+               	movups	(%rdx), %xmm0
                	leaq	0xc(%rdx), %rsi
                	movl	(%rsi), %edx
                	addl	%ecx, %edx
                	leaq	-0xb0(%rbp), %r13
-               	movups	%xmm1, (%r13)
+               	movups	%xmm0, (%r13)
                	leaq	0xc(%r13), %rcx
                	movl	%edx, (%rcx)
                	movups	(%r13), %xmm14
-               	movups	%xmm14, -0x410(%rbp)
+               	movups	%xmm14, -0x3a0(%rbp)
                	leaq	(%r12), %rcx
                	movl	(%rcx), %edx
                	movq	%rax, %rdi
@@ -179,11 +179,11 @@ Disassembly of section .text:
                	movl	%edx, %esi
                	callq	 <L8>
 <L8>:
-               	movaps	-0x400(%rbp), %xmm14
-               	paddd	-0x410(%rbp), %xmm14
-               	movaps	%xmm14, %xmm3
+               	movaps	-0x390(%rbp), %xmm14
+               	paddd	-0x3a0(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	leaq	-0x1f0(%rbp), %r14
-               	movups	%xmm3, (%r14)
+               	movups	%xmm0, (%r14)
                	leaq	(%r14), %rcx
                	movl	(%rcx), %edx
                	movq	%rax, %rdi
@@ -208,11 +208,11 @@ Disassembly of section .text:
                	movl	%edx, %esi
                	callq	 <L12>
 <L12>:
-               	movaps	-0x400(%rbp), %xmm14
-               	psubd	-0x410(%rbp), %xmm14
-               	movaps	%xmm14, %xmm3
+               	movaps	-0x390(%rbp), %xmm14
+               	psubd	-0x3a0(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	leaq	-0x210(%rbp), %r14
-               	movups	%xmm3, (%r14)
+               	movups	%xmm0, (%r14)
                	leaq	(%r14), %rcx
                	movl	(%rcx), %edx
                	movq	%rax, %rdi
@@ -237,11 +237,11 @@ Disassembly of section .text:
                	movl	%edx, %esi
                	callq	 <L16>
 <L16>:
-               	movaps	-0x410(%rbp), %xmm14
-               	psubd	-0x400(%rbp), %xmm14
-               	movaps	%xmm14, %xmm3
+               	movaps	-0x3a0(%rbp), %xmm14
+               	psubd	-0x390(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	leaq	-0x230(%rbp), %r14
-               	movups	%xmm3, (%r14)
+               	movups	%xmm0, (%r14)
                	leaq	(%r14), %rcx
                	movl	(%rcx), %edx
                	movq	%rax, %rdi
@@ -287,26 +287,26 @@ Disassembly of section .text:
                	movl	(%rcx), %r15d
                	imull	%r15d, %r14d
                	leaq	-0x240(%rbp), %rcx
-               	movups	-0x400(%rbp), %xmm14
+               	movups	-0x390(%rbp), %xmm14
                	movups	%xmm14, (%rcx)
                	leaq	(%rcx), %r15
                	movl	%edx, (%r15)
-               	movups	(%rcx), %xmm3
+               	movups	(%rcx), %xmm0
                	leaq	-0x250(%rbp), %rcx
-               	movups	%xmm3, (%rcx)
+               	movups	%xmm0, (%rcx)
                	leaq	0x4(%rcx), %rdx
                	movl	%esi, (%rdx)
-               	movups	(%rcx), %xmm3
+               	movups	(%rcx), %xmm0
                	leaq	-0x260(%rbp), %rcx
-               	movups	%xmm3, (%rcx)
+               	movups	%xmm0, (%rcx)
                	leaq	0x8(%rcx), %rdx
                	movl	%edi, (%rdx)
-               	movups	(%rcx), %xmm3
+               	movups	(%rcx), %xmm0
                	leaq	-0x270(%rbp), %r15
-               	movups	%xmm3, (%r15)
+               	movups	%xmm0, (%r15)
                	leaq	0xc(%r15), %rcx
                	movl	%r14d, (%rcx)
-               	movups	(%r15), %xmm3
+               	movups	(%r15), %xmm0
                	leaq	(%r15), %rcx
                	movl	(%rcx), %edx
                	movq	%rax, %rdi
@@ -352,26 +352,26 @@ Disassembly of section .text:
                	movl	(%rcx), %r14d
                	imull	%r14d, %r12d
                	leaq	-0x280(%rbp), %rcx
-               	movups	-0x400(%rbp), %xmm14
+               	movups	-0x390(%rbp), %xmm14
                	movups	%xmm14, (%rcx)
                	leaq	(%rcx), %r14
                	movl	%edx, (%r14)
-               	movups	(%rcx), %xmm3
+               	movups	(%rcx), %xmm0
                	leaq	-0x290(%rbp), %rcx
-               	movups	%xmm3, (%rcx)
+               	movups	%xmm0, (%rcx)
                	leaq	0x4(%rcx), %rdx
                	movl	%esi, (%rdx)
-               	movups	(%rcx), %xmm3
+               	movups	(%rcx), %xmm0
                	leaq	-0x2a0(%rbp), %rcx
-               	movups	%xmm3, (%rcx)
+               	movups	%xmm0, (%rcx)
                	leaq	0x8(%rcx), %rdx
                	movl	%edi, (%rdx)
-               	movups	(%rcx), %xmm3
+               	movups	(%rcx), %xmm0
                	leaq	-0x2b0(%rbp), %r14
-               	movups	%xmm3, (%r14)
+               	movups	%xmm0, (%r14)
                	leaq	0xc(%r14), %rcx
                	movl	%r12d, (%rcx)
-               	movups	(%r14), %xmm3
+               	movups	(%r14), %xmm0
                	leaq	(%r14), %rcx
                	movl	(%rcx), %edx
                	movq	%rax, %rdi
@@ -417,26 +417,26 @@ Disassembly of section .text:
                	movl	(%rcx), %r13d
                	imull	%r13d, %r12d
                	leaq	-0x2c0(%rbp), %rcx
-               	movups	-0x410(%rbp), %xmm14
+               	movups	-0x3a0(%rbp), %xmm14
                	movups	%xmm14, (%rcx)
                	leaq	(%rcx), %r13
                	movl	%edx, (%r13)
-               	movups	(%rcx), %xmm3
+               	movups	(%rcx), %xmm0
                	leaq	-0x2d0(%rbp), %rcx
-               	movups	%xmm3, (%rcx)
+               	movups	%xmm0, (%rcx)
                	leaq	0x4(%rcx), %rdx
                	movl	%esi, (%rdx)
-               	movups	(%rcx), %xmm3
+               	movups	(%rcx), %xmm0
                	leaq	-0x2e0(%rbp), %rcx
-               	movups	%xmm3, (%rcx)
+               	movups	%xmm0, (%rcx)
                	leaq	0x8(%rcx), %rdx
                	movl	%edi, (%rdx)
-               	movups	(%rcx), %xmm3
+               	movups	(%rcx), %xmm0
                	leaq	-0x2f0(%rbp), %r13
-               	movups	%xmm3, (%r13)
+               	movups	%xmm0, (%r13)
                	leaq	0xc(%r13), %rcx
                	movl	%r12d, (%rcx)
-               	movups	(%r13), %xmm3
+               	movups	(%r13), %xmm0
                	leaq	(%r13), %rcx
                	movl	(%rcx), %edx
                	movq	%rax, %rdi
@@ -461,11 +461,11 @@ Disassembly of section .text:
                	movl	%edx, %esi
                	callq	 <L32>
 <L32>:
-               	movaps	-0x400(%rbp), %xmm14
-               	paddd	-0x410(%rbp), %xmm14
-               	movaps	%xmm14, %xmm3
+               	movaps	-0x390(%rbp), %xmm14
+               	paddd	-0x3a0(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	leaq	-0x300(%rbp), %rcx
-               	movups	%xmm3, (%rcx)
+               	movups	%xmm0, (%rcx)
                	leaq	(%rcx), %rdx
                	movl	(%rdx), %esi
                	leaq	(%rbx), %rdx
@@ -487,25 +487,25 @@ Disassembly of section .text:
                	movl	(%rdx), %r13d
                	imull	%r13d, %ecx
                	leaq	-0x310(%rbp), %rdx
-               	movups	%xmm3, (%rdx)
+               	movups	%xmm0, (%rdx)
                	leaq	(%rdx), %r13
                	movl	%esi, (%r13)
-               	movups	(%rdx), %xmm3
+               	movups	(%rdx), %xmm0
                	leaq	-0x320(%rbp), %rdx
-               	movups	%xmm3, (%rdx)
+               	movups	%xmm0, (%rdx)
                	leaq	0x4(%rdx), %rsi
                	movl	%edi, (%rsi)
-               	movups	(%rdx), %xmm3
+               	movups	(%rdx), %xmm0
                	leaq	-0x330(%rbp), %rdx
-               	movups	%xmm3, (%rdx)
+               	movups	%xmm0, (%rdx)
                	leaq	0x8(%rdx), %rsi
                	movl	%r12d, (%rsi)
-               	movups	(%rdx), %xmm3
+               	movups	(%rdx), %xmm0
                	leaq	-0x340(%rbp), %r12
-               	movups	%xmm3, (%r12)
+               	movups	%xmm0, (%r12)
                	leaq	0xc(%r12), %rdx
                	movl	%ecx, (%rdx)
-               	movups	(%r12), %xmm3
+               	movups	(%r12), %xmm0
                	leaq	(%r12), %rcx
                	movl	(%rcx), %edx
                	movq	%rax, %rdi
@@ -530,11 +530,11 @@ Disassembly of section .text:
                	movl	%edx, %esi
                	callq	 <L36>
 <L36>:
-               	movaps	-0x3f0(%rbp), %xmm14
-               	psubd	-0x400(%rbp), %xmm14
-               	movaps	%xmm14, %xmm3
+               	movaps	-0x380(%rbp), %xmm14
+               	psubd	-0x390(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	leaq	-0x350(%rbp), %r12
-               	movups	%xmm3, (%r12)
+               	movups	%xmm0, (%r12)
                	leaq	(%r12), %rcx
                	movl	(%rcx), %edx
                	movq	%rax, %rdi
@@ -559,229 +559,65 @@ Disassembly of section .text:
                	movl	%edx, %esi
                	callq	 <L40>
 <L40>:
-               	movaps	-0x3f0(%rbp), %xmm14
-               	psubd	-0x410(%rbp), %xmm14
-               	movaps	%xmm14, %xmm3
-               	leaq	-0x360(%rbp), %r12
-               	movups	%xmm3, (%r12)
-               	leaq	(%r12), %rcx
-               	movl	(%rcx), %edx
+               	movaps	-0x380(%rbp), %xmm14
+               	psubd	-0x3a0(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	movq	%rax, %rdi
-               	movl	%edx, %esi
                	callq	 <L41>
 <L41>:
-               	leaq	0x4(%r12), %rcx
-               	movl	(%rcx), %edx
+               	movaps	-0x390(%rbp), %xmm14
+               	pand	-0x3a0(%rbp), %xmm14
+               	movaps	%xmm14, -0x3b0(%rbp)
                	movq	%rax, %rdi
-               	movl	%edx, %esi
+               	movups	-0x3b0(%rbp), %xmm0
                	callq	 <L42>
 <L42>:
-               	leaq	0x8(%r12), %rcx
-               	movl	(%rcx), %edx
+               	movaps	-0x390(%rbp), %xmm14
+               	por	-0x3a0(%rbp), %xmm14
+               	movaps	%xmm14, -0x3c0(%rbp)
                	movq	%rax, %rdi
-               	movl	%edx, %esi
+               	movups	-0x3c0(%rbp), %xmm0
                	callq	 <L43>
 <L43>:
-               	leaq	0xc(%r12), %rcx
-               	movl	(%rcx), %edx
+               	movaps	-0x390(%rbp), %xmm14
+               	pxor	-0x3a0(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	movq	%rax, %rdi
-               	movl	%edx, %esi
                	callq	 <L44>
 <L44>:
-               	movaps	-0x400(%rbp), %xmm14
-               	pand	-0x410(%rbp), %xmm14
-               	movaps	%xmm14, %xmm3
-               	leaq	-0x370(%rbp), %r12
-               	movups	%xmm3, (%r12)
-               	leaq	(%r12), %rcx
-               	movl	(%rcx), %edx
+               	movaps	-0x390(%rbp), %xmm14
+               	pcmpeqd	%xmm15, %xmm15
+               	pxor	%xmm15, %xmm14
+               	movaps	%xmm14, %xmm0
                	movq	%rax, %rdi
-               	movl	%edx, %esi
                	callq	 <L45>
 <L45>:
-               	leaq	0x4(%r12), %rcx
-               	movl	(%rcx), %edx
+               	movaps	-0x3a0(%rbp), %xmm14
+               	pcmpeqd	%xmm15, %xmm15
+               	pxor	%xmm15, %xmm14
+               	movaps	%xmm14, %xmm0
                	movq	%rax, %rdi
-               	movl	%edx, %esi
                	callq	 <L46>
 <L46>:
-               	leaq	0x8(%r12), %rcx
-               	movl	(%rcx), %edx
+               	movaps	-0x3b0(%rbp), %xmm14
+               	pxor	-0x3c0(%rbp), %xmm14
+               	movaps	%xmm14, %xmm4
                	movq	%rax, %rdi
-               	movl	%edx, %esi
+               	movaps	%xmm4, %xmm0
                	callq	 <L47>
 <L47>:
-               	leaq	0xc(%r12), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L48>
-<L48>:
-               	movaps	-0x400(%rbp), %xmm14
-               	por	-0x410(%rbp), %xmm14
-               	movaps	%xmm14, %xmm3
-               	leaq	-0x380(%rbp), %r12
-               	movups	%xmm3, (%r12)
-               	leaq	(%r12), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L49>
-<L49>:
-               	leaq	0x4(%r12), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L50>
-<L50>:
-               	leaq	0x8(%r12), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L51>
-<L51>:
-               	leaq	0xc(%r12), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L52>
-<L52>:
-               	movaps	-0x400(%rbp), %xmm14
-               	pxor	-0x410(%rbp), %xmm14
-               	movaps	%xmm14, %xmm3
-               	leaq	-0x390(%rbp), %r12
-               	movups	%xmm3, (%r12)
-               	leaq	(%r12), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L53>
-<L53>:
-               	leaq	0x4(%r12), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L54>
-<L54>:
-               	leaq	0x8(%r12), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L55>
-<L55>:
-               	leaq	0xc(%r12), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L56>
-<L56>:
-               	movaps	-0x400(%rbp), %xmm14
-               	pcmpeqd	%xmm15, %xmm15
-               	pxor	%xmm15, %xmm14
-               	movaps	%xmm14, %xmm3
-               	leaq	-0x3a0(%rbp), %r12
-               	movups	%xmm3, (%r12)
-               	leaq	(%r12), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L57>
-<L57>:
-               	leaq	0x4(%r12), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L58>
-<L58>:
-               	leaq	0x8(%r12), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L59>
-<L59>:
-               	leaq	0xc(%r12), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L60>
-<L60>:
-               	movaps	-0x410(%rbp), %xmm14
-               	pcmpeqd	%xmm15, %xmm15
-               	pxor	%xmm15, %xmm14
-               	movaps	%xmm14, %xmm3
-               	leaq	-0x3b0(%rbp), %r12
-               	movups	%xmm3, (%r12)
-               	leaq	(%r12), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L61>
-<L61>:
-               	leaq	0x4(%r12), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L62>
-<L62>:
-               	leaq	0x8(%r12), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L63>
-<L63>:
-               	leaq	0xc(%r12), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L64>
-<L64>:
-               	movaps	-0x400(%rbp), %xmm14
-               	pand	-0x410(%rbp), %xmm14
-               	movaps	%xmm14, %xmm3
-               	movaps	-0x400(%rbp), %xmm14
-               	por	-0x410(%rbp), %xmm14
-               	movaps	%xmm14, %xmm4
-               	movaps	%xmm3, %xmm14
-               	pxor	%xmm4, %xmm14
-               	movaps	%xmm14, %xmm3
-               	leaq	-0x3c0(%rbp), %r12
-               	movups	%xmm3, (%r12)
-               	leaq	(%r12), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L65>
-<L65>:
-               	leaq	0x4(%r12), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L66>
-<L66>:
-               	leaq	0x8(%r12), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L67>
-<L67>:
-               	leaq	0xc(%r12), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L68>
-<L68>:
                	movq	%rax, %r12
-               	movups	-0x400(%rbp), %xmm14
-               	movups	%xmm14, -0x430(%rbp)
-               	movups	-0x3f0(%rbp), %xmm14
-               	movups	%xmm14, -0x440(%rbp)
+               	movups	-0x390(%rbp), %xmm14
+               	movups	%xmm14, -0x3e0(%rbp)
+               	movups	-0x380(%rbp), %xmm14
+               	movups	%xmm14, -0x3f0(%rbp)
                	movq	$0x0, %r13
-<L69>:
+<L48>:
                	leaq	-0xc0(%rbp), %r14
-               	movups	-0x430(%rbp), %xmm14
+               	movups	-0x3e0(%rbp), %xmm14
                	movups	%xmm14, (%r14)
                	cmpq	$0x6, %r13
-               	jb	 <L82>
+               	jb	 <L61>
                	leaq	-0x140(%rbp), %r15
                	movq	$0x0, (%r15)
                	movq	$0x0, 0x8(%r15)
@@ -792,10 +628,10 @@ Disassembly of section .text:
                	movq	$0x0, 0x30(%r15)
                	movq	$0x0, 0x38(%r15)
                	leaq	(%r15), %rax
-               	movups	-0x430(%rbp), %xmm14
+               	movups	-0x3e0(%rbp), %xmm14
                	movups	%xmm14, (%rax)
-               	movaps	-0x430(%rbp), %xmm14
-               	paddd	-0x410(%rbp), %xmm14
+               	movaps	-0x3e0(%rbp), %xmm14
+               	paddd	-0x3a0(%rbp), %xmm14
                	movaps	%xmm14, %xmm2
                	leaq	0x10(%r15), %rax
                	movups	%xmm2, (%rax)
@@ -805,7 +641,7 @@ Disassembly of section .text:
                	movl	(%rax), %edx
                	movl	%ecx, %r8d
                	imull	%edx, %r8d
-               	movq	%r8, -0x3c8(%rbp)
+               	movq	%r8, -0x358(%rbp)
                	leaq	0x4(%r14), %rax
                	movl	(%rax), %edx
                	leaq	0x4(%rbx), %rax
@@ -822,10 +658,10 @@ Disassembly of section .text:
                	movl	(%rax), %ecx
                	imull	%ecx, %edi
                	leaq	-0x150(%rbp), %rax
-               	movups	-0x430(%rbp), %xmm14
+               	movups	-0x3e0(%rbp), %xmm14
                	movups	%xmm14, (%rax)
                	leaq	(%rax), %rcx
-               	movq	-0x3c8(%rbp), %r8
+               	movq	-0x358(%rbp), %r8
                	movl	%r8d, (%rcx)
                	movups	(%rax), %xmm2
                	leaq	-0x160(%rbp), %rax
@@ -846,142 +682,142 @@ Disassembly of section .text:
                	leaq	0x20(%r15), %rax
                	movups	%xmm2, (%rax)
                	leaq	0x30(%r15), %rax
-               	movups	-0x440(%rbp), %xmm14
+               	movups	-0x3f0(%rbp), %xmm14
                	movups	%xmm14, (%rax)
                	movq	%r12, %r8
-               	movq	%r8, -0x418(%rbp)
+               	movq	%r8, -0x3c8(%rbp)
                	movq	$0x0, %r8
-               	movq	%r8, -0x448(%rbp)
-               	movq	-0x448(%rbp), %r8
+               	movq	%r8, -0x3f8(%rbp)
+               	movq	-0x3f8(%rbp), %r8
                	cmpq	$0x4, %r8
-               	jb	 <L70>
-               	jmp	 <L75>
-<L70>:
-               	movq	-0x448(%rbp), %r8
+               	jb	 <L49>
+               	jmp	 <L54>
+<L49>:
+               	movq	-0x3f8(%rbp), %r8
                	movq	%r8, %rdx
                	imulq	$0x10, %rdx, %rdx
                	leaq	(%r15,%rdx), %rsi
                	movups	(%rsi), %xmm2
                	leaq	-0x190(%rbp), %r8
-               	movq	%r8, -0x450(%rbp)
-               	movq	-0x450(%rbp), %r8
+               	movq	%r8, -0x400(%rbp)
+               	movq	-0x400(%rbp), %r8
                	movups	%xmm2, (%r8)
-               	movq	-0x450(%rbp), %r8
+               	movq	-0x400(%rbp), %r8
                	leaq	(%r8), %rsi
                	movl	(%rsi), %r8d
-               	movq	%r8, -0x3d0(%rbp)
-               	movq	-0x418(%rbp), %r8
+               	movq	%r8, -0x360(%rbp)
+               	movq	-0x3c8(%rbp), %r8
                	movq	%r8, %rdi
-               	movq	-0x3d0(%rbp), %r8
+               	movq	-0x360(%rbp), %r8
                	movl	%r8d, %esi
-               	callq	 <L71>
-<L71>:
+               	callq	 <L50>
+<L50>:
                	movq	%rax, %rdi
-               	movq	-0x450(%rbp), %r8
+               	movq	-0x400(%rbp), %r8
                	leaq	0x4(%r8), %rsi
                	movl	(%rsi), %r8d
-               	movq	%r8, -0x3d8(%rbp)
-               	movq	-0x3d8(%rbp), %r8
+               	movq	%r8, -0x368(%rbp)
+               	movq	-0x368(%rbp), %r8
                	movl	%r8d, %esi
-               	callq	 <L72>
-<L72>:
+               	callq	 <L51>
+<L51>:
                	movq	%rax, %rdi
-               	movq	-0x450(%rbp), %r8
+               	movq	-0x400(%rbp), %r8
                	leaq	0x8(%r8), %rsi
                	movl	(%rsi), %r8d
-               	movq	%r8, -0x3e0(%rbp)
-               	movq	-0x3e0(%rbp), %r8
+               	movq	%r8, -0x370(%rbp)
+               	movq	-0x370(%rbp), %r8
                	movl	%r8d, %esi
-               	callq	 <L73>
-<L73>:
+               	callq	 <L52>
+<L52>:
                	movq	%rax, %rdi
-               	movq	-0x450(%rbp), %r8
+               	movq	-0x400(%rbp), %r8
                	leaq	0xc(%r8), %rsi
                	movl	(%rsi), %edx
                	movl	%edx, %esi
-               	callq	 <L74>
-<L74>:
+               	callq	 <L53>
+<L53>:
                	movq	%rax, %rdx
-               	movq	-0x448(%rbp), %r8
+               	movq	-0x3f8(%rbp), %r8
                	movq	%r8, %rcx
                	addq	$0x1, %rcx
                	movq	%rdx, %r8
-               	movq	%r8, -0x418(%rbp)
+               	movq	%r8, -0x3c8(%rbp)
                	movq	%rcx, %r8
-               	movq	%r8, -0x448(%rbp)
-               	movq	-0x448(%rbp), %r8
+               	movq	%r8, -0x3f8(%rbp)
+               	movq	-0x3f8(%rbp), %r8
                	cmpq	$0x4, %r8
-               	jb	 <L70>
-<L75>:
+               	jb	 <L49>
+<L54>:
                	leaq	-0x1c0(%rbp), %r8
-               	movq	%r8, -0x458(%rbp)
-               	movq	-0x458(%rbp), %r8
+               	movq	%r8, -0x408(%rbp)
+               	movq	-0x408(%rbp), %r8
                	movq	$0x0, (%r8)
-               	movq	-0x458(%rbp), %r8
+               	movq	-0x408(%rbp), %r8
                	movq	$0x0, 0x8(%r8)
-               	movq	-0x458(%rbp), %r8
+               	movq	-0x408(%rbp), %r8
                	movq	$0x0, 0x10(%r8)
-               	movq	-0x458(%rbp), %r8
+               	movq	-0x408(%rbp), %r8
                	movq	$0x0, 0x18(%r8)
-               	movq	-0x458(%rbp), %r8
+               	movq	-0x408(%rbp), %r8
                	movq	$0x0, 0x20(%r8)
-               	movq	-0x458(%rbp), %r8
+               	movq	-0x408(%rbp), %r8
                	movq	$0x0, 0x28(%r8)
-               	movq	-0x458(%rbp), %r8
+               	movq	-0x408(%rbp), %r8
                	leaq	(%r8), %rdx
                	movl	$0xffffffff, (%rdx)     # imm = 0xFFFFFFFF
                	leaq	0x20(%r15), %rsi
                	movups	(%rsi), %xmm2
-               	movq	-0x458(%rbp), %r8
+               	movq	-0x408(%rbp), %r8
                	leaq	0x10(%r8), %r15
                	movups	%xmm2, (%r15)
-               	movq	-0x458(%rbp), %r8
+               	movq	-0x408(%rbp), %r8
                	leaq	0x20(%r8), %rsi
                	movl	$0x12345678, (%rsi)     # imm = 0x12345678
                	movl	(%rdx), %esi
-               	movq	-0x418(%rbp), %r8
+               	movq	-0x3c8(%rbp), %r8
                	movq	%r8, %rdi
-               	callq	 <L76>
-<L76>:
+               	callq	 <L55>
+<L55>:
                	movups	(%r15), %xmm2
                	leaq	-0x1d0(%rbp), %r15
                	movups	%xmm2, (%r15)
                	leaq	(%r15), %rdx
                	movl	(%rdx), %esi
                	movq	%rax, %rdi
-               	callq	 <L77>
-<L77>:
+               	callq	 <L56>
+<L56>:
                	leaq	0x4(%r15), %rdx
                	movl	(%rdx), %esi
                	movq	%rax, %rdi
-               	callq	 <L78>
-<L78>:
+               	callq	 <L57>
+<L57>:
                	leaq	0x8(%r15), %rdx
                	movl	(%rdx), %esi
                	movq	%rax, %rdi
-               	callq	 <L79>
-<L79>:
+               	callq	 <L58>
+<L58>:
                	leaq	0xc(%r15), %rdx
                	movl	(%rdx), %esi
                	movq	%rax, %rdi
-               	callq	 <L80>
-<L80>:
-               	movq	-0x458(%rbp), %r8
+               	callq	 <L59>
+<L59>:
+               	movq	-0x408(%rbp), %r8
                	leaq	0x20(%r8), %rdx
                	movl	(%rdx), %ecx
                	movq	%rax, %rdi
                	movl	%ecx, %esi
-               	callq	 <L81>
-<L81>:
-               	movq	-0x4a8(%rbp), %rbx
-               	movq	-0x4b0(%rbp), %r12
-               	movq	-0x4b8(%rbp), %r13
-               	movq	-0x4c0(%rbp), %r14
-               	movq	-0x4c8(%rbp), %r15
+               	callq	 <L60>
+<L60>:
+               	movq	-0x458(%rbp), %rbx
+               	movq	-0x460(%rbp), %r12
+               	movq	-0x468(%rbp), %r13
+               	movq	-0x470(%rbp), %r14
+               	movq	-0x478(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
-<L82>:
+<L61>:
                	leaq	(%r14), %rcx
                	movl	(%rcx), %edx
                	leaq	(%rbx), %rcx
@@ -1003,7 +839,7 @@ Disassembly of section .text:
                	movl	(%rcx), %r15d
                	imull	%r15d, %r14d
                	leaq	-0xd0(%rbp), %rcx
-               	movups	-0x430(%rbp), %xmm14
+               	movups	-0x3e0(%rbp), %xmm14
                	movups	%xmm14, (%rcx)
                	leaq	(%rcx), %r15
                	movl	%edx, (%r15)
@@ -1023,125 +859,125 @@ Disassembly of section .text:
                	leaq	0xc(%r15), %rcx
                	movl	%r14d, (%rcx)
                	movups	(%r15), %xmm14
-               	movups	%xmm14, -0x470(%rbp)
+               	movups	%xmm14, -0x420(%rbp)
                	leaq	(%r15), %rcx
                	movl	(%rcx), %edx
                	movq	%r12, %rdi
                	movl	%edx, %esi
-               	callq	 <L83>
-<L83>:
+               	callq	 <L62>
+<L62>:
                	leaq	0x4(%r15), %rcx
                	movl	(%rcx), %edx
                	movq	%rax, %rdi
                	movl	%edx, %esi
-               	callq	 <L84>
-<L84>:
+               	callq	 <L63>
+<L63>:
                	leaq	0x8(%r15), %rcx
                	movl	(%rcx), %edx
                	movq	%rax, %rdi
                	movl	%edx, %esi
-               	callq	 <L85>
-<L85>:
+               	callq	 <L64>
+<L64>:
                	leaq	0xc(%r15), %rcx
                	movl	(%rcx), %edx
                	movq	%rax, %rdi
                	movl	%edx, %esi
-               	callq	 <L86>
-<L86>:
-               	movaps	-0x440(%rbp), %xmm14
-               	paddd	-0x470(%rbp), %xmm14
-               	movaps	%xmm14, -0x480(%rbp)
+               	callq	 <L65>
+<L65>:
+               	movaps	-0x3f0(%rbp), %xmm14
+               	paddd	-0x420(%rbp), %xmm14
+               	movaps	%xmm14, -0x430(%rbp)
                	leaq	-0x1e0(%rbp), %r14
-               	movups	-0x480(%rbp), %xmm14
+               	movups	-0x430(%rbp), %xmm14
                	movups	%xmm14, (%r14)
                	leaq	(%r14), %rcx
                	movl	(%rcx), %edx
                	movq	%rax, %rdi
                	movl	%edx, %esi
-               	callq	 <L87>
-<L87>:
+               	callq	 <L66>
+<L66>:
                	leaq	0x4(%r14), %rcx
                	movl	(%rcx), %edx
                	movq	%rax, %rdi
                	movl	%edx, %esi
-               	callq	 <L88>
-<L88>:
+               	callq	 <L67>
+<L67>:
                	leaq	0x8(%r14), %rcx
                	movl	(%rcx), %edx
                	movq	%rax, %rdi
                	movl	%edx, %esi
-               	callq	 <L89>
-<L89>:
+               	callq	 <L68>
+<L68>:
                	leaq	0xc(%r14), %rcx
                	movl	(%rcx), %edx
                	movq	%rax, %rdi
                	movl	%edx, %esi
-               	callq	 <L90>
-<L90>:
-               	movaps	-0x480(%rbp), %xmm14
-               	pxor	-0x410(%rbp), %xmm14
-               	movaps	%xmm14, -0x490(%rbp)
-               	leaq	-0x200(%rbp), %r14
-               	movups	-0x490(%rbp), %xmm14
-               	movups	%xmm14, (%r14)
-               	leaq	(%r14), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L91>
-<L91>:
-               	leaq	0x4(%r14), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L92>
-<L92>:
-               	leaq	0x8(%r14), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L93>
-<L93>:
-               	leaq	0xc(%r14), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L94>
-<L94>:
+               	callq	 <L69>
+<L69>:
                	movaps	-0x430(%rbp), %xmm14
-               	paddd	-0x410(%rbp), %xmm14
-               	movaps	%xmm14, -0x4a0(%rbp)
-               	leaq	-0x220(%rbp), %r14
-               	movups	-0x4a0(%rbp), %xmm14
+               	pxor	-0x3a0(%rbp), %xmm14
+               	movaps	%xmm14, -0x440(%rbp)
+               	leaq	-0x200(%rbp), %r14
+               	movups	-0x440(%rbp), %xmm14
                	movups	%xmm14, (%r14)
                	leaq	(%r14), %rcx
                	movl	(%rcx), %edx
                	movq	%rax, %rdi
                	movl	%edx, %esi
-               	callq	 <L95>
-<L95>:
+               	callq	 <L70>
+<L70>:
                	leaq	0x4(%r14), %rcx
                	movl	(%rcx), %edx
                	movq	%rax, %rdi
                	movl	%edx, %esi
-               	callq	 <L96>
-<L96>:
+               	callq	 <L71>
+<L71>:
                	leaq	0x8(%r14), %rcx
                	movl	(%rcx), %edx
                	movq	%rax, %rdi
                	movl	%edx, %esi
-               	callq	 <L97>
-<L97>:
+               	callq	 <L72>
+<L72>:
                	leaq	0xc(%r14), %rcx
                	movl	(%rcx), %edx
                	movq	%rax, %rdi
                	movl	%edx, %esi
-               	callq	 <L98>
-<L98>:
+               	callq	 <L73>
+<L73>:
+               	movaps	-0x3e0(%rbp), %xmm14
+               	paddd	-0x3a0(%rbp), %xmm14
+               	movaps	%xmm14, -0x450(%rbp)
+               	leaq	-0x220(%rbp), %r14
+               	movups	-0x450(%rbp), %xmm14
+               	movups	%xmm14, (%r14)
+               	leaq	(%r14), %rcx
+               	movl	(%rcx), %edx
+               	movq	%rax, %rdi
+               	movl	%edx, %esi
+               	callq	 <L74>
+<L74>:
+               	leaq	0x4(%r14), %rcx
+               	movl	(%rcx), %edx
+               	movq	%rax, %rdi
+               	movl	%edx, %esi
+               	callq	 <L75>
+<L75>:
+               	leaq	0x8(%r14), %rcx
+               	movl	(%rcx), %edx
+               	movq	%rax, %rdi
+               	movl	%edx, %esi
+               	callq	 <L76>
+<L76>:
+               	leaq	0xc(%r14), %rcx
+               	movl	(%rcx), %edx
+               	movq	%rax, %rdi
+               	movl	%edx, %esi
+               	callq	 <L77>
+<L77>:
                	addq	$0x1, %r13
                	movq	%rax, %r12
-               	movups	-0x4a0(%rbp), %xmm14
-               	movups	%xmm14, -0x430(%rbp)
-               	movups	-0x490(%rbp), %xmm14
-               	movups	%xmm14, -0x440(%rbp)
-               	jmp	 <L69>
+               	movups	-0x450(%rbp), %xmm14
+               	movups	%xmm14, -0x3e0(%rbp)
+               	movups	-0x440(%rbp), %xmm14
+               	movups	%xmm14, -0x3f0(%rbp)
+               	jmp	 <L48>

--- a/test/golden/x86_64-linux/vec/vec_i64x2.dis
+++ b/test/golden/x86_64-linux/vec/vec_i64x2.dis
@@ -26,12 +26,12 @@ Disassembly of section .text:
 <corpus.cases.vec.vec_i64x2.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x3f0, %rsp            # imm = 0x3F0
-               	movq	%rbx, -0x3c8(%rbp)
-               	movq	%r12, -0x3d0(%rbp)
-               	movq	%r13, -0x3d8(%rbp)
-               	movq	%r14, -0x3e0(%rbp)
-               	movq	%r15, -0x3e8(%rbp)
+               	subq	$0x3a0, %rsp            # imm = 0x3A0
+               	movq	%rbx, -0x378(%rbp)
+               	movq	%r12, -0x380(%rbp)
+               	movq	%r13, -0x388(%rbp)
+               	movq	%r14, -0x390(%rbp)
+               	movq	%r15, -0x398(%rbp)
                	movq	%rdi, %rbx
                	callq	 <L0>
 <L0>:
@@ -67,7 +67,7 @@ Disassembly of section .text:
                	leaq	0x8(%rsi), %rdi
                	movq	$0x0, (%rdi)
                	movups	(%rsi), %xmm14
-               	movups	%xmm14, -0x300(%rbp)
+               	movups	%xmm14, -0x290(%rbp)
                	leaq	(%rcx), %rsi
                	movq	(%rsi), %rcx
                	addq	%rbx, %rcx
@@ -76,7 +76,7 @@ Disassembly of section .text:
                	leaq	(%r13), %rsi
                	movq	%rcx, (%rsi)
                	movups	(%r13), %xmm14
-               	movups	%xmm14, -0x310(%rbp)
+               	movups	%xmm14, -0x2a0(%rbp)
                	leaq	0x8(%rdx), %rcx
                	movq	(%rcx), %rdx
                	addq	%rbx, %rdx
@@ -85,7 +85,7 @@ Disassembly of section .text:
                	leaq	0x8(%rbx), %rcx
                	movq	%rdx, (%rcx)
                	movups	(%rbx), %xmm14
-               	movups	%xmm14, -0x320(%rbp)
+               	movups	%xmm14, -0x2b0(%rbp)
                	leaq	(%r13), %rcx
                	movq	(%rcx), %rsi
                	movq	%rax, %rdi
@@ -106,11 +106,11 @@ Disassembly of section .text:
                	movq	%rax, %rdi
                	callq	 <L4>
 <L4>:
-               	movaps	-0x310(%rbp), %xmm14
-               	paddq	-0x320(%rbp), %xmm14
-               	movaps	%xmm14, %xmm3
+               	movaps	-0x2a0(%rbp), %xmm14
+               	paddq	-0x2b0(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	leaq	-0x190(%rbp), %r14
-               	movups	%xmm3, (%r14)
+               	movups	%xmm0, (%r14)
                	leaq	(%r14), %rcx
                	movq	(%rcx), %rsi
                	movq	%rax, %rdi
@@ -121,11 +121,11 @@ Disassembly of section .text:
                	movq	%rax, %rdi
                	callq	 <L6>
 <L6>:
-               	movaps	-0x310(%rbp), %xmm14
-               	psubq	-0x320(%rbp), %xmm14
-               	movaps	%xmm14, %xmm3
+               	movaps	-0x2a0(%rbp), %xmm14
+               	psubq	-0x2b0(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	leaq	-0x1b0(%rbp), %r14
-               	movups	%xmm3, (%r14)
+               	movups	%xmm0, (%r14)
                	leaq	(%r14), %rcx
                	movq	(%rcx), %rsi
                	movq	%rax, %rdi
@@ -136,11 +136,11 @@ Disassembly of section .text:
                	movq	%rax, %rdi
                	callq	 <L8>
 <L8>:
-               	movaps	-0x320(%rbp), %xmm14
-               	psubq	-0x310(%rbp), %xmm14
-               	movaps	%xmm14, %xmm3
+               	movaps	-0x2b0(%rbp), %xmm14
+               	psubq	-0x2a0(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	leaq	-0x1d0(%rbp), %r14
-               	movups	%xmm3, (%r14)
+               	movups	%xmm0, (%r14)
                	leaq	(%r14), %rcx
                	movq	(%rcx), %rsi
                	movq	%rax, %rdi
@@ -162,16 +162,16 @@ Disassembly of section .text:
                	movq	(%rcx), %rdi
                	imulq	%rdi, %rsi
                	leaq	-0x1e0(%rbp), %rcx
-               	movups	-0x310(%rbp), %xmm14
+               	movups	-0x2a0(%rbp), %xmm14
                	movups	%xmm14, (%rcx)
                	leaq	(%rcx), %rdi
                	movq	%rdx, (%rdi)
-               	movups	(%rcx), %xmm3
+               	movups	(%rcx), %xmm0
                	leaq	-0x1f0(%rbp), %r14
-               	movups	%xmm3, (%r14)
+               	movups	%xmm0, (%r14)
                	leaq	0x8(%r14), %rcx
                	movq	%rsi, (%rcx)
-               	movups	(%r14), %xmm3
+               	movups	(%r14), %xmm0
                	leaq	(%r14), %rcx
                	movq	(%rcx), %rsi
                	movq	%rax, %rdi
@@ -193,16 +193,16 @@ Disassembly of section .text:
                	movq	(%rcx), %rdi
                	imulq	%rdi, %rsi
                	leaq	-0x200(%rbp), %rcx
-               	movups	-0x310(%rbp), %xmm14
+               	movups	-0x2a0(%rbp), %xmm14
                	movups	%xmm14, (%rcx)
                	leaq	(%rcx), %rdi
                	movq	%rdx, (%rdi)
-               	movups	(%rcx), %xmm3
+               	movups	(%rcx), %xmm0
                	leaq	-0x210(%rbp), %r13
-               	movups	%xmm3, (%r13)
+               	movups	%xmm0, (%r13)
                	leaq	0x8(%r13), %rcx
                	movq	%rsi, (%rcx)
-               	movups	(%r13), %xmm3
+               	movups	(%r13), %xmm0
                	leaq	(%r13), %rcx
                	movq	(%rcx), %rsi
                	movq	%rax, %rdi
@@ -224,16 +224,16 @@ Disassembly of section .text:
                	movq	(%rcx), %rdi
                	imulq	%rdi, %rsi
                	leaq	-0x220(%rbp), %rcx
-               	movups	-0x320(%rbp), %xmm14
+               	movups	-0x2b0(%rbp), %xmm14
                	movups	%xmm14, (%rcx)
                	leaq	(%rcx), %rdi
                	movq	%rdx, (%rdi)
-               	movups	(%rcx), %xmm3
+               	movups	(%rcx), %xmm0
                	leaq	-0x230(%rbp), %rbx
-               	movups	%xmm3, (%rbx)
+               	movups	%xmm0, (%rbx)
                	leaq	0x8(%rbx), %rcx
                	movq	%rsi, (%rcx)
-               	movups	(%rbx), %xmm3
+               	movups	(%rbx), %xmm0
                	leaq	(%rbx), %rcx
                	movq	(%rcx), %rsi
                	movq	%rax, %rdi
@@ -244,11 +244,11 @@ Disassembly of section .text:
                	movq	%rax, %rdi
                	callq	 <L16>
 <L16>:
-               	movaps	-0x310(%rbp), %xmm14
-               	paddq	-0x320(%rbp), %xmm14
-               	movaps	%xmm14, %xmm3
+               	movaps	-0x2a0(%rbp), %xmm14
+               	paddq	-0x2b0(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	leaq	-0x240(%rbp), %rcx
-               	movups	%xmm3, (%rcx)
+               	movups	%xmm0, (%rcx)
                	leaq	(%rcx), %rdx
                	movq	(%rdx), %rsi
                	leaq	(%r12), %rdx
@@ -260,15 +260,15 @@ Disassembly of section .text:
                	movq	(%rdx), %rdi
                	imulq	%rdi, %rcx
                	leaq	-0x250(%rbp), %rdx
-               	movups	%xmm3, (%rdx)
+               	movups	%xmm0, (%rdx)
                	leaq	(%rdx), %rdi
                	movq	%rsi, (%rdi)
-               	movups	(%rdx), %xmm3
+               	movups	(%rdx), %xmm0
                	leaq	-0x260(%rbp), %rbx
-               	movups	%xmm3, (%rbx)
+               	movups	%xmm0, (%rbx)
                	leaq	0x8(%rbx), %rdx
                	movq	%rcx, (%rdx)
-               	movups	(%rbx), %xmm3
+               	movups	(%rbx), %xmm0
                	leaq	(%rbx), %rcx
                	movq	(%rcx), %rsi
                	movq	%rax, %rdi
@@ -279,11 +279,11 @@ Disassembly of section .text:
                	movq	%rax, %rdi
                	callq	 <L18>
 <L18>:
-               	movaps	-0x300(%rbp), %xmm14
-               	psubq	-0x310(%rbp), %xmm14
-               	movaps	%xmm14, %xmm3
+               	movaps	-0x290(%rbp), %xmm14
+               	psubq	-0x2a0(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	leaq	-0x270(%rbp), %rbx
-               	movups	%xmm3, (%rbx)
+               	movups	%xmm0, (%rbx)
                	leaq	(%rbx), %rcx
                	movq	(%rcx), %rsi
                	movq	%rax, %rdi
@@ -294,133 +294,67 @@ Disassembly of section .text:
                	movq	%rax, %rdi
                	callq	 <L20>
 <L20>:
-               	movaps	-0x300(%rbp), %xmm14
-               	psubq	-0x320(%rbp), %xmm14
-               	movaps	%xmm14, %xmm3
-               	leaq	-0x280(%rbp), %rbx
-               	movups	%xmm3, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movq	(%rcx), %rsi
+               	movaps	-0x290(%rbp), %xmm14
+               	psubq	-0x2b0(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	movq	%rax, %rdi
                	callq	 <L21>
 <L21>:
-               	leaq	0x8(%rbx), %rcx
-               	movq	(%rcx), %rsi
+               	movaps	-0x2a0(%rbp), %xmm14
+               	pand	-0x2b0(%rbp), %xmm14
+               	movaps	%xmm14, -0x2c0(%rbp)
                	movq	%rax, %rdi
+               	movups	-0x2c0(%rbp), %xmm0
                	callq	 <L22>
 <L22>:
-               	movaps	-0x310(%rbp), %xmm14
-               	pand	-0x320(%rbp), %xmm14
-               	movaps	%xmm14, %xmm3
-               	leaq	-0x290(%rbp), %rbx
-               	movups	%xmm3, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movq	(%rcx), %rsi
+               	movaps	-0x2a0(%rbp), %xmm14
+               	por	-0x2b0(%rbp), %xmm14
+               	movaps	%xmm14, -0x2d0(%rbp)
                	movq	%rax, %rdi
+               	movups	-0x2d0(%rbp), %xmm0
                	callq	 <L23>
 <L23>:
-               	leaq	0x8(%rbx), %rcx
-               	movq	(%rcx), %rsi
+               	movaps	-0x2a0(%rbp), %xmm14
+               	pxor	-0x2b0(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	movq	%rax, %rdi
                	callq	 <L24>
 <L24>:
-               	movaps	-0x310(%rbp), %xmm14
-               	por	-0x320(%rbp), %xmm14
-               	movaps	%xmm14, %xmm3
-               	leaq	-0x2a0(%rbp), %rbx
-               	movups	%xmm3, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movq	(%rcx), %rsi
+               	movaps	-0x2a0(%rbp), %xmm14
+               	pcmpeqd	%xmm15, %xmm15
+               	pxor	%xmm15, %xmm14
+               	movaps	%xmm14, %xmm0
                	movq	%rax, %rdi
                	callq	 <L25>
 <L25>:
-               	leaq	0x8(%rbx), %rcx
-               	movq	(%rcx), %rsi
+               	movaps	-0x2b0(%rbp), %xmm14
+               	pcmpeqd	%xmm15, %xmm15
+               	pxor	%xmm15, %xmm14
+               	movaps	%xmm14, %xmm0
                	movq	%rax, %rdi
                	callq	 <L26>
 <L26>:
-               	movaps	-0x310(%rbp), %xmm14
-               	pxor	-0x320(%rbp), %xmm14
-               	movaps	%xmm14, %xmm3
-               	leaq	-0x2b0(%rbp), %rbx
-               	movups	%xmm3, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movq	(%rcx), %rsi
+               	movaps	-0x2c0(%rbp), %xmm14
+               	pxor	-0x2d0(%rbp), %xmm14
+               	movaps	%xmm14, %xmm4
                	movq	%rax, %rdi
+               	movaps	%xmm4, %xmm0
                	callq	 <L27>
 <L27>:
-               	leaq	0x8(%rbx), %rcx
-               	movq	(%rcx), %rsi
-               	movq	%rax, %rdi
-               	callq	 <L28>
-<L28>:
-               	movaps	-0x310(%rbp), %xmm14
-               	pcmpeqd	%xmm15, %xmm15
-               	pxor	%xmm15, %xmm14
-               	movaps	%xmm14, %xmm3
-               	leaq	-0x2c0(%rbp), %rbx
-               	movups	%xmm3, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movq	(%rcx), %rsi
-               	movq	%rax, %rdi
-               	callq	 <L29>
-<L29>:
-               	leaq	0x8(%rbx), %rcx
-               	movq	(%rcx), %rsi
-               	movq	%rax, %rdi
-               	callq	 <L30>
-<L30>:
-               	movaps	-0x320(%rbp), %xmm14
-               	pcmpeqd	%xmm15, %xmm15
-               	pxor	%xmm15, %xmm14
-               	movaps	%xmm14, %xmm3
-               	leaq	-0x2d0(%rbp), %rbx
-               	movups	%xmm3, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movq	(%rcx), %rsi
-               	movq	%rax, %rdi
-               	callq	 <L31>
-<L31>:
-               	leaq	0x8(%rbx), %rcx
-               	movq	(%rcx), %rsi
-               	movq	%rax, %rdi
-               	callq	 <L32>
-<L32>:
-               	movaps	-0x310(%rbp), %xmm14
-               	pand	-0x320(%rbp), %xmm14
-               	movaps	%xmm14, %xmm3
-               	movaps	-0x310(%rbp), %xmm14
-               	por	-0x320(%rbp), %xmm14
-               	movaps	%xmm14, %xmm4
-               	movaps	%xmm3, %xmm14
-               	pxor	%xmm4, %xmm14
-               	movaps	%xmm14, %xmm3
-               	leaq	-0x2e0(%rbp), %rbx
-               	movups	%xmm3, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movq	(%rcx), %rsi
-               	movq	%rax, %rdi
-               	callq	 <L33>
-<L33>:
-               	leaq	0x8(%rbx), %rcx
-               	movq	(%rcx), %rsi
-               	movq	%rax, %rdi
-               	callq	 <L34>
-<L34>:
                	movq	%rax, %rbx
-               	movups	-0x310(%rbp), %xmm14
-               	movups	%xmm14, -0x340(%rbp)
-               	movups	-0x300(%rbp), %xmm14
-               	movups	%xmm14, -0x350(%rbp)
-               	movups	-0x300(%rbp), %xmm14
-               	movups	%xmm14, -0x360(%rbp)
+               	movups	-0x2a0(%rbp), %xmm14
+               	movups	%xmm14, -0x2f0(%rbp)
+               	movups	-0x290(%rbp), %xmm14
+               	movups	%xmm14, -0x300(%rbp)
+               	movups	-0x290(%rbp), %xmm14
+               	movups	%xmm14, -0x310(%rbp)
                	movq	$0x0, %r13
-<L35>:
+<L28>:
                	leaq	-0xa0(%rbp), %r14
-               	movups	-0x340(%rbp), %xmm14
+               	movups	-0x2f0(%rbp), %xmm14
                	movups	%xmm14, (%r14)
                	cmpq	$0x6, %r13
-               	jb	 <L44>
+               	jb	 <L37>
                	leaq	-0x100(%rbp), %r15
                	movq	$0x0, (%r15)
                	movq	$0x0, 0x8(%r15)
@@ -431,10 +365,10 @@ Disassembly of section .text:
                	movq	$0x0, 0x30(%r15)
                	movq	$0x0, 0x38(%r15)
                	leaq	(%r15), %rax
-               	movups	-0x340(%rbp), %xmm14
+               	movups	-0x2f0(%rbp), %xmm14
                	movups	%xmm14, (%rax)
-               	movaps	-0x340(%rbp), %xmm14
-               	paddq	-0x320(%rbp), %xmm14
+               	movaps	-0x2f0(%rbp), %xmm14
+               	paddq	-0x2b0(%rbp), %xmm14
                	movaps	%xmm14, %xmm2
                	leaq	0x10(%r15), %rax
                	movups	%xmm2, (%rax)
@@ -449,7 +383,7 @@ Disassembly of section .text:
                	movq	(%rax), %rsi
                	imulq	%rsi, %rdx
                	leaq	-0x110(%rbp), %rax
-               	movups	-0x340(%rbp), %xmm14
+               	movups	-0x2f0(%rbp), %xmm14
                	movups	%xmm14, (%rax)
                	leaq	(%rax), %rsi
                	movq	%rcx, (%rsi)
@@ -462,114 +396,114 @@ Disassembly of section .text:
                	leaq	0x20(%r15), %rax
                	movups	%xmm2, (%rax)
                	leaq	0x30(%r15), %rax
-               	movups	-0x350(%rbp), %xmm14
+               	movups	-0x300(%rbp), %xmm14
                	movups	%xmm14, (%rax)
                	movq	%rbx, %r8
-               	movq	%r8, -0x328(%rbp)
+               	movq	%r8, -0x2d8(%rbp)
                	movq	$0x0, %r8
-               	movq	%r8, -0x368(%rbp)
-               	movq	-0x368(%rbp), %r8
+               	movq	%r8, -0x318(%rbp)
+               	movq	-0x318(%rbp), %r8
                	cmpq	$0x4, %r8
-               	jb	 <L36>
-               	jmp	 <L39>
-<L36>:
-               	movq	-0x368(%rbp), %r8
+               	jb	 <L29>
+               	jmp	 <L32>
+<L29>:
+               	movq	-0x318(%rbp), %r8
                	movq	%r8, %rdx
                	imulq	$0x10, %rdx, %rdx
                	leaq	(%r15,%rdx), %rsi
                	movups	(%rsi), %xmm2
                	leaq	-0x130(%rbp), %r8
-               	movq	%r8, -0x370(%rbp)
-               	movq	-0x370(%rbp), %r8
+               	movq	%r8, -0x320(%rbp)
+               	movq	-0x320(%rbp), %r8
                	movups	%xmm2, (%r8)
-               	movq	-0x370(%rbp), %r8
+               	movq	-0x320(%rbp), %r8
                	leaq	(%r8), %rsi
                	movq	(%rsi), %r8
-               	movq	%r8, -0x2e8(%rbp)
-               	movq	-0x328(%rbp), %r8
+               	movq	%r8, -0x278(%rbp)
+               	movq	-0x2d8(%rbp), %r8
                	movq	%r8, %rdi
-               	movq	-0x2e8(%rbp), %r8
+               	movq	-0x278(%rbp), %r8
                	movq	%r8, %rsi
-               	callq	 <L37>
-<L37>:
+               	callq	 <L30>
+<L30>:
                	movq	%rax, %rdi
-               	movq	-0x370(%rbp), %r8
+               	movq	-0x320(%rbp), %r8
                	leaq	0x8(%r8), %rsi
                	movq	(%rsi), %rdx
                	movq	%rdx, %rsi
-               	callq	 <L38>
-<L38>:
+               	callq	 <L31>
+<L31>:
                	movq	%rax, %rdx
-               	movq	-0x368(%rbp), %r8
+               	movq	-0x318(%rbp), %r8
                	movq	%r8, %rcx
                	addq	$0x1, %rcx
                	movq	%rdx, %r8
-               	movq	%r8, -0x328(%rbp)
+               	movq	%r8, -0x2d8(%rbp)
                	movq	%rcx, %r8
-               	movq	%r8, -0x368(%rbp)
-               	movq	-0x368(%rbp), %r8
+               	movq	%r8, -0x318(%rbp)
+               	movq	-0x318(%rbp), %r8
                	cmpq	$0x4, %r8
-               	jb	 <L36>
-<L39>:
+               	jb	 <L29>
+<L32>:
                	leaq	-0x160(%rbp), %r8
-               	movq	%r8, -0x378(%rbp)
-               	movq	-0x378(%rbp), %r8
+               	movq	%r8, -0x328(%rbp)
+               	movq	-0x328(%rbp), %r8
                	movq	$0x0, (%r8)
-               	movq	-0x378(%rbp), %r8
+               	movq	-0x328(%rbp), %r8
                	movq	$0x0, 0x8(%r8)
-               	movq	-0x378(%rbp), %r8
+               	movq	-0x328(%rbp), %r8
                	movq	$0x0, 0x10(%r8)
-               	movq	-0x378(%rbp), %r8
+               	movq	-0x328(%rbp), %r8
                	movq	$0x0, 0x18(%r8)
-               	movq	-0x378(%rbp), %r8
+               	movq	-0x328(%rbp), %r8
                	movq	$0x0, 0x20(%r8)
-               	movq	-0x378(%rbp), %r8
+               	movq	-0x328(%rbp), %r8
                	movq	$0x0, 0x28(%r8)
-               	movq	-0x378(%rbp), %r8
+               	movq	-0x328(%rbp), %r8
                	leaq	(%r8), %rdx
                	movl	$0xffffffff, (%rdx)     # imm = 0xFFFFFFFF
                	leaq	0x20(%r15), %rsi
                	movups	(%rsi), %xmm2
-               	movq	-0x378(%rbp), %r8
+               	movq	-0x328(%rbp), %r8
                	leaq	0x10(%r8), %r15
                	movups	%xmm2, (%r15)
-               	movq	-0x378(%rbp), %r8
+               	movq	-0x328(%rbp), %r8
                	leaq	0x20(%r8), %rsi
                	movl	$0x12345678, (%rsi)     # imm = 0x12345678
                	movl	(%rdx), %esi
-               	movq	-0x328(%rbp), %r8
+               	movq	-0x2d8(%rbp), %r8
                	movq	%r8, %rdi
-               	callq	 <L40>
-<L40>:
+               	callq	 <L33>
+<L33>:
                	movups	(%r15), %xmm2
                	leaq	-0x170(%rbp), %r15
                	movups	%xmm2, (%r15)
                	leaq	(%r15), %rdx
                	movq	(%rdx), %rsi
                	movq	%rax, %rdi
-               	callq	 <L41>
-<L41>:
+               	callq	 <L34>
+<L34>:
                	leaq	0x8(%r15), %rdx
                	movq	(%rdx), %rsi
                	movq	%rax, %rdi
-               	callq	 <L42>
-<L42>:
-               	movq	-0x378(%rbp), %r8
+               	callq	 <L35>
+<L35>:
+               	movq	-0x328(%rbp), %r8
                	leaq	0x20(%r8), %rdx
                	movl	(%rdx), %ecx
                	movq	%rax, %rdi
                	movl	%ecx, %esi
-               	callq	 <L43>
-<L43>:
-               	movq	-0x3c8(%rbp), %rbx
-               	movq	-0x3d0(%rbp), %r12
-               	movq	-0x3d8(%rbp), %r13
-               	movq	-0x3e0(%rbp), %r14
-               	movq	-0x3e8(%rbp), %r15
+               	callq	 <L36>
+<L36>:
+               	movq	-0x378(%rbp), %rbx
+               	movq	-0x380(%rbp), %r12
+               	movq	-0x388(%rbp), %r13
+               	movq	-0x390(%rbp), %r14
+               	movq	-0x398(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
-<L44>:
+<L37>:
                	leaq	(%r14), %rcx
                	movq	(%rcx), %rdx
                	leaq	(%r12), %rcx
@@ -581,7 +515,7 @@ Disassembly of section .text:
                	movq	(%rcx), %rdi
                	imulq	%rdi, %rsi
                	leaq	-0xb0(%rbp), %rcx
-               	movups	-0x340(%rbp), %xmm14
+               	movups	-0x2f0(%rbp), %xmm14
                	movups	%xmm14, (%rcx)
                	leaq	(%rcx), %rdi
                	movq	%rdx, (%rdi)
@@ -591,71 +525,71 @@ Disassembly of section .text:
                	leaq	0x8(%r14), %rcx
                	movq	%rsi, (%rcx)
                	movups	(%r14), %xmm14
-               	movups	%xmm14, -0x390(%rbp)
+               	movups	%xmm14, -0x340(%rbp)
                	leaq	(%r14), %rcx
                	movq	(%rcx), %rsi
                	movq	%rbx, %rdi
+               	callq	 <L38>
+<L38>:
+               	leaq	0x8(%r14), %rcx
+               	movq	(%rcx), %rsi
+               	movq	%rax, %rdi
+               	callq	 <L39>
+<L39>:
+               	movaps	-0x300(%rbp), %xmm14
+               	pxor	-0x340(%rbp), %xmm14
+               	movaps	%xmm14, -0x350(%rbp)
+               	leaq	-0x180(%rbp), %r14
+               	movups	-0x350(%rbp), %xmm14
+               	movups	%xmm14, (%r14)
+               	leaq	(%r14), %rcx
+               	movq	(%rcx), %rsi
+               	movq	%rax, %rdi
+               	callq	 <L40>
+<L40>:
+               	leaq	0x8(%r14), %rcx
+               	movq	(%rcx), %rsi
+               	movq	%rax, %rdi
+               	callq	 <L41>
+<L41>:
+               	movaps	-0x310(%rbp), %xmm14
+               	paddq	-0x2f0(%rbp), %xmm14
+               	movaps	%xmm14, -0x360(%rbp)
+               	leaq	-0x1a0(%rbp), %r14
+               	movups	-0x360(%rbp), %xmm14
+               	movups	%xmm14, (%r14)
+               	leaq	(%r14), %rcx
+               	movq	(%rcx), %rsi
+               	movq	%rax, %rdi
+               	callq	 <L42>
+<L42>:
+               	leaq	0x8(%r14), %rcx
+               	movq	(%rcx), %rsi
+               	movq	%rax, %rdi
+               	callq	 <L43>
+<L43>:
+               	movaps	-0x2f0(%rbp), %xmm14
+               	paddq	-0x2b0(%rbp), %xmm14
+               	movaps	%xmm14, -0x370(%rbp)
+               	leaq	-0x1c0(%rbp), %r14
+               	movups	-0x370(%rbp), %xmm14
+               	movups	%xmm14, (%r14)
+               	leaq	(%r14), %rcx
+               	movq	(%rcx), %rsi
+               	movq	%rax, %rdi
+               	callq	 <L44>
+<L44>:
+               	leaq	0x8(%r14), %rcx
+               	movq	(%rcx), %rsi
+               	movq	%rax, %rdi
                	callq	 <L45>
 <L45>:
-               	leaq	0x8(%r14), %rcx
-               	movq	(%rcx), %rsi
-               	movq	%rax, %rdi
-               	callq	 <L46>
-<L46>:
-               	movaps	-0x350(%rbp), %xmm14
-               	pxor	-0x390(%rbp), %xmm14
-               	movaps	%xmm14, -0x3a0(%rbp)
-               	leaq	-0x180(%rbp), %r14
-               	movups	-0x3a0(%rbp), %xmm14
-               	movups	%xmm14, (%r14)
-               	leaq	(%r14), %rcx
-               	movq	(%rcx), %rsi
-               	movq	%rax, %rdi
-               	callq	 <L47>
-<L47>:
-               	leaq	0x8(%r14), %rcx
-               	movq	(%rcx), %rsi
-               	movq	%rax, %rdi
-               	callq	 <L48>
-<L48>:
-               	movaps	-0x360(%rbp), %xmm14
-               	paddq	-0x340(%rbp), %xmm14
-               	movaps	%xmm14, -0x3b0(%rbp)
-               	leaq	-0x1a0(%rbp), %r14
-               	movups	-0x3b0(%rbp), %xmm14
-               	movups	%xmm14, (%r14)
-               	leaq	(%r14), %rcx
-               	movq	(%rcx), %rsi
-               	movq	%rax, %rdi
-               	callq	 <L49>
-<L49>:
-               	leaq	0x8(%r14), %rcx
-               	movq	(%rcx), %rsi
-               	movq	%rax, %rdi
-               	callq	 <L50>
-<L50>:
-               	movaps	-0x340(%rbp), %xmm14
-               	paddq	-0x320(%rbp), %xmm14
-               	movaps	%xmm14, -0x3c0(%rbp)
-               	leaq	-0x1c0(%rbp), %r14
-               	movups	-0x3c0(%rbp), %xmm14
-               	movups	%xmm14, (%r14)
-               	leaq	(%r14), %rcx
-               	movq	(%rcx), %rsi
-               	movq	%rax, %rdi
-               	callq	 <L51>
-<L51>:
-               	leaq	0x8(%r14), %rcx
-               	movq	(%rcx), %rsi
-               	movq	%rax, %rdi
-               	callq	 <L52>
-<L52>:
                	addq	$0x1, %r13
                	movq	%rax, %rbx
-               	movups	-0x3c0(%rbp), %xmm14
-               	movups	%xmm14, -0x340(%rbp)
-               	movups	-0x3a0(%rbp), %xmm14
-               	movups	%xmm14, -0x350(%rbp)
-               	movups	-0x3b0(%rbp), %xmm14
-               	movups	%xmm14, -0x360(%rbp)
-               	jmp	 <L35>
+               	movups	-0x370(%rbp), %xmm14
+               	movups	%xmm14, -0x2f0(%rbp)
+               	movups	-0x350(%rbp), %xmm14
+               	movups	%xmm14, -0x300(%rbp)
+               	movups	-0x360(%rbp), %xmm14
+               	movups	%xmm14, -0x310(%rbp)
+               	jmp	 <L28>

--- a/test/golden/x86_64-linux/vec/vec_u16x8.dis
+++ b/test/golden/x86_64-linux/vec/vec_u16x8.dis
@@ -56,11 +56,11 @@ Disassembly of section .text:
 <corpus.cases.vec.vec_u16x8.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x330, %rsp            # imm = 0x330
-               	movq	%rbx, -0x318(%rbp)
-               	movq	%r12, -0x320(%rbp)
-               	movq	%r13, -0x328(%rbp)
-               	movq	%r14, -0x330(%rbp)
+               	subq	$0x2e0, %rsp            # imm = 0x2E0
+               	movq	%rbx, -0x2c8(%rbp)
+               	movq	%r12, -0x2d0(%rbp)
+               	movq	%r13, -0x2d8(%rbp)
+               	movq	%r14, -0x2e0(%rbp)
                	movq	%rdi, %rbx
                	callq	 <L0>
 <L0>:
@@ -123,7 +123,7 @@ Disassembly of section .text:
                	leaq	0xe(%rdi), %rbx
                	movw	$0x88b, (%rbx)          # imm = 0x88B
                	movups	(%rdi), %xmm14
-               	movups	%xmm14, -0x270(%rbp)
+               	movups	%xmm14, -0x200(%rbp)
                	leaq	-0x60(%rbp), %rdi
                	leaq	(%rdi), %rbx
                	movw	$0x0, (%rbx)
@@ -142,7 +142,7 @@ Disassembly of section .text:
                	leaq	0xe(%rdi), %rbx
                	movw	$0x0, (%rbx)
                	movups	(%rdi), %xmm14
-               	movups	%xmm14, -0x280(%rbp)
+               	movups	%xmm14, -0x210(%rbp)
                	leaq	(%rdx), %rdi
                	movzwl	(%rdi), %edx
                	addl	%ecx, %edx
@@ -159,7 +159,7 @@ Disassembly of section .text:
                	leaq	0xc(%rbx), %rdx
                	movw	%di, (%rdx)
                	movups	(%rbx), %xmm14
-               	movups	%xmm14, -0x290(%rbp)
+               	movups	%xmm14, -0x220(%rbp)
                	leaq	0x4(%rsi), %rdx
                	movzwl	(%rdx), %esi
                	addl	%ecx, %esi
@@ -167,16 +167,16 @@ Disassembly of section .text:
                	movups	%xmm1, (%rdx)
                	leaq	0x4(%rdx), %rdi
                	movw	%si, (%rdi)
-               	movups	(%rdx), %xmm1
+               	movups	(%rdx), %xmm0
                	leaq	0xe(%rdx), %rsi
                	movzwl	(%rsi), %edx
                	addl	%ecx, %edx
                	leaq	-0xa0(%rbp), %r12
-               	movups	%xmm1, (%r12)
+               	movups	%xmm0, (%r12)
                	leaq	0xe(%r12), %rcx
                	movw	%dx, (%rcx)
                	movups	(%r12), %xmm14
-               	movups	%xmm14, -0x2a0(%rbp)
+               	movups	%xmm14, -0x230(%rbp)
                	leaq	(%rbx), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
@@ -257,11 +257,11 @@ Disassembly of section .text:
                	movq	%rax, %rdi
                	callq	 <L16>
 <L16>:
-               	movaps	-0x290(%rbp), %xmm14
-               	paddw	-0x2a0(%rbp), %xmm14
-               	movaps	%xmm14, %xmm4
+               	movaps	-0x220(%rbp), %xmm14
+               	paddw	-0x230(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	leaq	-0x160(%rbp), %rbx
-               	movups	%xmm4, (%rbx)
+               	movups	%xmm0, (%rbx)
                	leaq	(%rbx), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
@@ -302,11 +302,11 @@ Disassembly of section .text:
                	movq	%rax, %rdi
                	callq	 <L24>
 <L24>:
-               	movaps	-0x290(%rbp), %xmm14
-               	psubw	-0x2a0(%rbp), %xmm14
-               	movaps	%xmm14, %xmm4
+               	movaps	-0x220(%rbp), %xmm14
+               	psubw	-0x230(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	leaq	-0x180(%rbp), %rbx
-               	movups	%xmm4, (%rbx)
+               	movups	%xmm0, (%rbx)
                	leaq	(%rbx), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
@@ -347,11 +347,11 @@ Disassembly of section .text:
                	movq	%rax, %rdi
                	callq	 <L32>
 <L32>:
-               	movaps	-0x2a0(%rbp), %xmm14
-               	psubw	-0x290(%rbp), %xmm14
-               	movaps	%xmm14, %xmm4
+               	movaps	-0x230(%rbp), %xmm14
+               	psubw	-0x220(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	leaq	-0x1a0(%rbp), %rbx
-               	movups	%xmm4, (%rbx)
+               	movups	%xmm0, (%rbx)
                	leaq	(%rbx), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
@@ -392,11 +392,11 @@ Disassembly of section .text:
                	movq	%rax, %rdi
                	callq	 <L40>
 <L40>:
-               	movaps	-0x290(%rbp), %xmm14
-               	pmullw	-0x2a0(%rbp), %xmm14
-               	movaps	%xmm14, %xmm4
+               	movaps	-0x220(%rbp), %xmm14
+               	pmullw	-0x230(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	leaq	-0x1b0(%rbp), %rbx
-               	movups	%xmm4, (%rbx)
+               	movups	%xmm0, (%rbx)
                	leaq	(%rbx), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
@@ -437,11 +437,11 @@ Disassembly of section .text:
                	movq	%rax, %rdi
                	callq	 <L48>
 <L48>:
-               	movaps	-0x290(%rbp), %xmm14
-               	pmullw	-0x270(%rbp), %xmm14
-               	movaps	%xmm14, %xmm4
+               	movaps	-0x220(%rbp), %xmm14
+               	pmullw	-0x200(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	leaq	-0x1c0(%rbp), %rbx
-               	movups	%xmm4, (%rbx)
+               	movups	%xmm0, (%rbx)
                	leaq	(%rbx), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
@@ -482,11 +482,11 @@ Disassembly of section .text:
                	movq	%rax, %rdi
                	callq	 <L56>
 <L56>:
-               	movaps	-0x2a0(%rbp), %xmm14
-               	pmullw	-0x270(%rbp), %xmm14
-               	movaps	%xmm14, %xmm4
+               	movaps	-0x230(%rbp), %xmm14
+               	pmullw	-0x200(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	leaq	-0x1d0(%rbp), %rbx
-               	movups	%xmm4, (%rbx)
+               	movups	%xmm0, (%rbx)
                	leaq	(%rbx), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
@@ -527,14 +527,14 @@ Disassembly of section .text:
                	movq	%rax, %rdi
                	callq	 <L64>
 <L64>:
-               	movaps	-0x290(%rbp), %xmm14
-               	paddw	-0x2a0(%rbp), %xmm14
-               	movaps	%xmm14, %xmm4
-               	movaps	%xmm4, %xmm14
-               	pmullw	-0x270(%rbp), %xmm14
-               	movaps	%xmm14, %xmm4
+               	movaps	-0x220(%rbp), %xmm14
+               	paddw	-0x230(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
+               	movaps	%xmm0, %xmm14
+               	pmullw	-0x200(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	leaq	-0x1e0(%rbp), %rbx
-               	movups	%xmm4, (%rbx)
+               	movups	%xmm0, (%rbx)
                	leaq	(%rbx), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
@@ -575,11 +575,11 @@ Disassembly of section .text:
                	movq	%rax, %rdi
                	callq	 <L72>
 <L72>:
-               	movaps	-0x280(%rbp), %xmm14
-               	psubw	-0x290(%rbp), %xmm14
-               	movaps	%xmm14, %xmm4
+               	movaps	-0x210(%rbp), %xmm14
+               	psubw	-0x220(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	leaq	-0x1f0(%rbp), %rbx
-               	movups	%xmm4, (%rbx)
+               	movups	%xmm0, (%rbx)
                	leaq	(%rbx), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
@@ -620,536 +620,260 @@ Disassembly of section .text:
                	movq	%rax, %rdi
                	callq	 <L80>
 <L80>:
-               	movaps	-0x280(%rbp), %xmm14
-               	psubw	-0x2a0(%rbp), %xmm14
-               	movaps	%xmm14, %xmm4
-               	leaq	-0x200(%rbp), %rbx
-               	movups	%xmm4, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movzwl	(%rcx), %esi
+               	movaps	-0x210(%rbp), %xmm14
+               	psubw	-0x230(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	movq	%rax, %rdi
                	callq	 <L81>
 <L81>:
-               	leaq	0x2(%rbx), %rcx
-               	movzwl	(%rcx), %esi
+               	movaps	-0x220(%rbp), %xmm14
+               	pand	-0x230(%rbp), %xmm14
+               	movaps	%xmm14, -0x240(%rbp)
                	movq	%rax, %rdi
+               	movups	-0x240(%rbp), %xmm0
                	callq	 <L82>
 <L82>:
-               	leaq	0x4(%rbx), %rcx
-               	movzwl	(%rcx), %esi
+               	movaps	-0x220(%rbp), %xmm14
+               	por	-0x230(%rbp), %xmm14
+               	movaps	%xmm14, -0x250(%rbp)
                	movq	%rax, %rdi
+               	movups	-0x250(%rbp), %xmm0
                	callq	 <L83>
 <L83>:
-               	leaq	0x6(%rbx), %rcx
-               	movzwl	(%rcx), %esi
+               	movaps	-0x220(%rbp), %xmm14
+               	pxor	-0x230(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	movq	%rax, %rdi
                	callq	 <L84>
 <L84>:
-               	leaq	0x8(%rbx), %rcx
-               	movzwl	(%rcx), %esi
+               	movaps	-0x220(%rbp), %xmm14
+               	pcmpeqd	%xmm15, %xmm15
+               	pxor	%xmm15, %xmm14
+               	movaps	%xmm14, %xmm0
                	movq	%rax, %rdi
                	callq	 <L85>
 <L85>:
-               	leaq	0xa(%rbx), %rcx
-               	movzwl	(%rcx), %esi
+               	movaps	-0x230(%rbp), %xmm14
+               	pcmpeqd	%xmm15, %xmm15
+               	pxor	%xmm15, %xmm14
+               	movaps	%xmm14, %xmm0
                	movq	%rax, %rdi
                	callq	 <L86>
 <L86>:
-               	leaq	0xc(%rbx), %rcx
-               	movzwl	(%rcx), %esi
+               	movaps	-0x240(%rbp), %xmm14
+               	pxor	-0x250(%rbp), %xmm14
+               	movaps	%xmm14, %xmm5
                	movq	%rax, %rdi
+               	movaps	%xmm5, %xmm0
                	callq	 <L87>
 <L87>:
-               	leaq	0xe(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L88>
+               	movq	%rax, %rbx
+               	movups	-0x220(%rbp), %xmm14
+               	movups	%xmm14, -0x270(%rbp)
+               	movups	-0x210(%rbp), %xmm14
+               	movups	%xmm14, -0x280(%rbp)
+               	movups	-0x210(%rbp), %xmm14
+               	movups	%xmm14, -0x290(%rbp)
+               	movq	$0x0, %r12
+               	cmpq	$0x6, %r12
+               	jb	 <L88>
+               	jmp	 <L121>
 <L88>:
-               	movaps	-0x290(%rbp), %xmm14
-               	pand	-0x2a0(%rbp), %xmm14
-               	movaps	%xmm14, %xmm4
-               	leaq	-0x210(%rbp), %rbx
-               	movups	%xmm4, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
+               	movaps	-0x270(%rbp), %xmm14
+               	pmullw	-0x200(%rbp), %xmm14
+               	movaps	%xmm14, -0x260(%rbp)
+               	leaq	-0xb0(%rbp), %r13
+               	movups	-0x260(%rbp), %xmm14
+               	movups	%xmm14, (%r13)
+               	leaq	(%r13), %rax
+               	movzwl	(%rax), %esi
+               	movq	%rbx, %rdi
                	callq	 <L89>
 <L89>:
-               	leaq	0x2(%rbx), %rcx
+               	leaq	0x2(%r13), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
                	callq	 <L90>
 <L90>:
-               	leaq	0x4(%rbx), %rcx
+               	leaq	0x4(%r13), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
                	callq	 <L91>
 <L91>:
-               	leaq	0x6(%rbx), %rcx
+               	leaq	0x6(%r13), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
                	callq	 <L92>
 <L92>:
-               	leaq	0x8(%rbx), %rcx
+               	leaq	0x8(%r13), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
                	callq	 <L93>
 <L93>:
-               	leaq	0xa(%rbx), %rcx
+               	leaq	0xa(%r13), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
                	callq	 <L94>
 <L94>:
-               	leaq	0xc(%rbx), %rcx
+               	leaq	0xc(%r13), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
                	callq	 <L95>
 <L95>:
-               	leaq	0xe(%rbx), %rcx
+               	leaq	0xe(%r13), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
                	callq	 <L96>
 <L96>:
-               	movaps	-0x290(%rbp), %xmm14
-               	por	-0x2a0(%rbp), %xmm14
-               	movaps	%xmm14, %xmm4
-               	leaq	-0x220(%rbp), %rbx
-               	movups	%xmm4, (%rbx)
-               	leaq	(%rbx), %rcx
+               	movaps	-0x280(%rbp), %xmm14
+               	pxor	-0x260(%rbp), %xmm14
+               	movaps	%xmm14, -0x2a0(%rbp)
+               	leaq	-0x150(%rbp), %r13
+               	movups	-0x2a0(%rbp), %xmm14
+               	movups	%xmm14, (%r13)
+               	leaq	(%r13), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
                	callq	 <L97>
 <L97>:
-               	leaq	0x2(%rbx), %rcx
+               	leaq	0x2(%r13), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
                	callq	 <L98>
 <L98>:
-               	leaq	0x4(%rbx), %rcx
+               	leaq	0x4(%r13), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
                	callq	 <L99>
 <L99>:
-               	leaq	0x6(%rbx), %rcx
+               	leaq	0x6(%r13), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
                	callq	 <L100>
 <L100>:
-               	leaq	0x8(%rbx), %rcx
+               	leaq	0x8(%r13), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
                	callq	 <L101>
 <L101>:
-               	leaq	0xa(%rbx), %rcx
+               	leaq	0xa(%r13), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
                	callq	 <L102>
 <L102>:
-               	leaq	0xc(%rbx), %rcx
+               	leaq	0xc(%r13), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
                	callq	 <L103>
 <L103>:
-               	leaq	0xe(%rbx), %rcx
+               	leaq	0xe(%r13), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
                	callq	 <L104>
 <L104>:
                	movaps	-0x290(%rbp), %xmm14
-               	pxor	-0x2a0(%rbp), %xmm14
-               	movaps	%xmm14, %xmm4
-               	leaq	-0x230(%rbp), %rbx
-               	movups	%xmm4, (%rbx)
-               	leaq	(%rbx), %rcx
+               	paddw	-0x270(%rbp), %xmm14
+               	movaps	%xmm14, -0x2b0(%rbp)
+               	leaq	-0x170(%rbp), %r13
+               	movups	-0x2b0(%rbp), %xmm14
+               	movups	%xmm14, (%r13)
+               	leaq	(%r13), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
                	callq	 <L105>
 <L105>:
-               	leaq	0x2(%rbx), %rcx
+               	leaq	0x2(%r13), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
                	callq	 <L106>
 <L106>:
-               	leaq	0x4(%rbx), %rcx
+               	leaq	0x4(%r13), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
                	callq	 <L107>
 <L107>:
-               	leaq	0x6(%rbx), %rcx
+               	leaq	0x6(%r13), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
                	callq	 <L108>
 <L108>:
-               	leaq	0x8(%rbx), %rcx
+               	leaq	0x8(%r13), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
                	callq	 <L109>
 <L109>:
-               	leaq	0xa(%rbx), %rcx
+               	leaq	0xa(%r13), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
                	callq	 <L110>
 <L110>:
-               	leaq	0xc(%rbx), %rcx
+               	leaq	0xc(%r13), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
                	callq	 <L111>
 <L111>:
-               	leaq	0xe(%rbx), %rcx
+               	leaq	0xe(%r13), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
                	callq	 <L112>
 <L112>:
-               	movaps	-0x290(%rbp), %xmm14
-               	pcmpeqd	%xmm15, %xmm15
-               	pxor	%xmm15, %xmm14
-               	movaps	%xmm14, %xmm4
-               	leaq	-0x240(%rbp), %rbx
-               	movups	%xmm4, (%rbx)
-               	leaq	(%rbx), %rcx
+               	movaps	-0x270(%rbp), %xmm14
+               	paddw	-0x230(%rbp), %xmm14
+               	movaps	%xmm14, -0x2c0(%rbp)
+               	leaq	-0x190(%rbp), %r13
+               	movups	-0x2c0(%rbp), %xmm14
+               	movups	%xmm14, (%r13)
+               	leaq	(%r13), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
                	callq	 <L113>
 <L113>:
-               	leaq	0x2(%rbx), %rcx
+               	leaq	0x2(%r13), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
                	callq	 <L114>
 <L114>:
-               	leaq	0x4(%rbx), %rcx
+               	leaq	0x4(%r13), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
                	callq	 <L115>
 <L115>:
-               	leaq	0x6(%rbx), %rcx
+               	leaq	0x6(%r13), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
                	callq	 <L116>
 <L116>:
-               	leaq	0x8(%rbx), %rcx
+               	leaq	0x8(%r13), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
                	callq	 <L117>
 <L117>:
-               	leaq	0xa(%rbx), %rcx
+               	leaq	0xa(%r13), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
                	callq	 <L118>
 <L118>:
-               	leaq	0xc(%rbx), %rcx
+               	leaq	0xc(%r13), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
                	callq	 <L119>
 <L119>:
-               	leaq	0xe(%rbx), %rcx
+               	leaq	0xe(%r13), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
                	callq	 <L120>
 <L120>:
-               	movaps	-0x2a0(%rbp), %xmm14
-               	pcmpeqd	%xmm15, %xmm15
-               	pxor	%xmm15, %xmm14
-               	movaps	%xmm14, %xmm4
-               	leaq	-0x250(%rbp), %rbx
-               	movups	%xmm4, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L121>
-<L121>:
-               	leaq	0x2(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L122>
-<L122>:
-               	leaq	0x4(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L123>
-<L123>:
-               	leaq	0x6(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L124>
-<L124>:
-               	leaq	0x8(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L125>
-<L125>:
-               	leaq	0xa(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L126>
-<L126>:
-               	leaq	0xc(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L127>
-<L127>:
-               	leaq	0xe(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L128>
-<L128>:
-               	movaps	-0x290(%rbp), %xmm14
-               	pand	-0x2a0(%rbp), %xmm14
-               	movaps	%xmm14, %xmm4
-               	movaps	-0x290(%rbp), %xmm14
-               	por	-0x2a0(%rbp), %xmm14
-               	movaps	%xmm14, %xmm5
-               	movaps	%xmm4, %xmm14
-               	pxor	%xmm5, %xmm14
-               	movaps	%xmm14, %xmm4
-               	leaq	-0x260(%rbp), %rbx
-               	movups	%xmm4, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L129>
-<L129>:
-               	leaq	0x2(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L130>
-<L130>:
-               	leaq	0x4(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L131>
-<L131>:
-               	leaq	0x6(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L132>
-<L132>:
-               	leaq	0x8(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L133>
-<L133>:
-               	leaq	0xa(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L134>
-<L134>:
-               	leaq	0xc(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L135>
-<L135>:
-               	leaq	0xe(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L136>
-<L136>:
-               	movq	%rax, %rbx
-               	movups	-0x290(%rbp), %xmm14
-               	movups	%xmm14, -0x2c0(%rbp)
-               	movups	-0x280(%rbp), %xmm14
-               	movups	%xmm14, -0x2d0(%rbp)
-               	movups	-0x280(%rbp), %xmm14
-               	movups	%xmm14, -0x2e0(%rbp)
-               	movq	$0x0, %r12
-               	cmpq	$0x6, %r12
-               	jb	 <L137>
-               	jmp	 <L170>
-<L137>:
-               	movaps	-0x2c0(%rbp), %xmm14
-               	pmullw	-0x270(%rbp), %xmm14
-               	movaps	%xmm14, -0x2b0(%rbp)
-               	leaq	-0xb0(%rbp), %r13
-               	movups	-0x2b0(%rbp), %xmm14
-               	movups	%xmm14, (%r13)
-               	leaq	(%r13), %rax
-               	movzwl	(%rax), %esi
-               	movq	%rbx, %rdi
-               	callq	 <L138>
-<L138>:
-               	leaq	0x2(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L139>
-<L139>:
-               	leaq	0x4(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L140>
-<L140>:
-               	leaq	0x6(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L141>
-<L141>:
-               	leaq	0x8(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L142>
-<L142>:
-               	leaq	0xa(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L143>
-<L143>:
-               	leaq	0xc(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L144>
-<L144>:
-               	leaq	0xe(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L145>
-<L145>:
-               	movaps	-0x2d0(%rbp), %xmm14
-               	pxor	-0x2b0(%rbp), %xmm14
-               	movaps	%xmm14, -0x2f0(%rbp)
-               	leaq	-0x150(%rbp), %r13
-               	movups	-0x2f0(%rbp), %xmm14
-               	movups	%xmm14, (%r13)
-               	leaq	(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L146>
-<L146>:
-               	leaq	0x2(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L147>
-<L147>:
-               	leaq	0x4(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L148>
-<L148>:
-               	leaq	0x6(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L149>
-<L149>:
-               	leaq	0x8(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L150>
-<L150>:
-               	leaq	0xa(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L151>
-<L151>:
-               	leaq	0xc(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L152>
-<L152>:
-               	leaq	0xe(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L153>
-<L153>:
-               	movaps	-0x2e0(%rbp), %xmm14
-               	paddw	-0x2c0(%rbp), %xmm14
-               	movaps	%xmm14, -0x300(%rbp)
-               	leaq	-0x170(%rbp), %r13
-               	movups	-0x300(%rbp), %xmm14
-               	movups	%xmm14, (%r13)
-               	leaq	(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L154>
-<L154>:
-               	leaq	0x2(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L155>
-<L155>:
-               	leaq	0x4(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L156>
-<L156>:
-               	leaq	0x6(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L157>
-<L157>:
-               	leaq	0x8(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L158>
-<L158>:
-               	leaq	0xa(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L159>
-<L159>:
-               	leaq	0xc(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L160>
-<L160>:
-               	leaq	0xe(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L161>
-<L161>:
-               	movaps	-0x2c0(%rbp), %xmm14
-               	paddw	-0x2a0(%rbp), %xmm14
-               	movaps	%xmm14, -0x310(%rbp)
-               	leaq	-0x190(%rbp), %r13
-               	movups	-0x310(%rbp), %xmm14
-               	movups	%xmm14, (%r13)
-               	leaq	(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L162>
-<L162>:
-               	leaq	0x2(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L163>
-<L163>:
-               	leaq	0x4(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L164>
-<L164>:
-               	leaq	0x6(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L165>
-<L165>:
-               	leaq	0x8(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L166>
-<L166>:
-               	leaq	0xa(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L167>
-<L167>:
-               	leaq	0xc(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L168>
-<L168>:
-               	leaq	0xe(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L169>
-<L169>:
                	addq	$0x1, %r12
                	movq	%rax, %rbx
-               	movups	-0x310(%rbp), %xmm14
-               	movups	%xmm14, -0x2c0(%rbp)
-               	movups	-0x2f0(%rbp), %xmm14
-               	movups	%xmm14, -0x2d0(%rbp)
-               	movups	-0x300(%rbp), %xmm14
-               	movups	%xmm14, -0x2e0(%rbp)
+               	movups	-0x2c0(%rbp), %xmm14
+               	movups	%xmm14, -0x270(%rbp)
+               	movups	-0x2a0(%rbp), %xmm14
+               	movups	%xmm14, -0x280(%rbp)
+               	movups	-0x2b0(%rbp), %xmm14
+               	movups	%xmm14, -0x290(%rbp)
                	cmpq	$0x6, %r12
-               	jb	 <L137>
-<L170>:
+               	jb	 <L88>
+<L121>:
                	leaq	-0xf0(%rbp), %r12
                	movq	$0x0, (%r12)
                	movq	$0x0, 0x8(%r12)
@@ -1160,26 +884,26 @@ Disassembly of section .text:
                	movq	$0x0, 0x30(%r12)
                	movq	$0x0, 0x38(%r12)
                	leaq	(%r12), %rax
-               	movups	-0x2c0(%rbp), %xmm14
+               	movups	-0x270(%rbp), %xmm14
                	movups	%xmm14, (%rax)
-               	movaps	-0x2c0(%rbp), %xmm14
-               	paddw	-0x2a0(%rbp), %xmm14
+               	movaps	-0x270(%rbp), %xmm14
+               	paddw	-0x230(%rbp), %xmm14
                	movaps	%xmm14, %xmm3
                	leaq	0x10(%r12), %rax
                	movups	%xmm3, (%rax)
-               	movaps	-0x2c0(%rbp), %xmm14
-               	pmullw	-0x270(%rbp), %xmm14
-               	movaps	%xmm14, %xmm4
+               	movaps	-0x270(%rbp), %xmm14
+               	pmullw	-0x200(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	leaq	0x20(%r12), %rax
-               	movups	%xmm4, (%rax)
+               	movups	%xmm0, (%rax)
                	leaq	0x30(%r12), %rax
-               	movups	-0x2d0(%rbp), %xmm14
+               	movups	-0x280(%rbp), %xmm14
                	movups	%xmm14, (%rax)
                	movq	$0x0, %r13
                	cmpq	$0x4, %r13
-               	jb	 <L171>
-               	jmp	 <L180>
-<L171>:
+               	jb	 <L122>
+               	jmp	 <L131>
+<L122>:
                	movq	%r13, %rax
                	imulq	$0x10, %rax, %rax
                	leaq	(%r12,%rax), %rcx
@@ -1189,48 +913,48 @@ Disassembly of section .text:
                	leaq	(%r14), %rax
                	movzwl	(%rax), %esi
                	movq	%rbx, %rdi
-               	callq	 <L172>
-<L172>:
+               	callq	 <L123>
+<L123>:
                	leaq	0x2(%r14), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
-               	callq	 <L173>
-<L173>:
+               	callq	 <L124>
+<L124>:
                	leaq	0x4(%r14), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
-               	callq	 <L174>
-<L174>:
+               	callq	 <L125>
+<L125>:
                	leaq	0x6(%r14), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
-               	callq	 <L175>
-<L175>:
+               	callq	 <L126>
+<L126>:
                	leaq	0x8(%r14), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
-               	callq	 <L176>
-<L176>:
+               	callq	 <L127>
+<L127>:
                	leaq	0xa(%r14), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
-               	callq	 <L177>
-<L177>:
+               	callq	 <L128>
+<L128>:
                	leaq	0xc(%r14), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
-               	callq	 <L178>
-<L178>:
+               	callq	 <L129>
+<L129>:
                	leaq	0xe(%r14), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
-               	callq	 <L179>
-<L179>:
+               	callq	 <L130>
+<L130>:
                	addq	$0x1, %r13
                	movq	%rax, %rbx
                	cmpq	$0x4, %r13
-               	jb	 <L171>
-<L180>:
+               	jb	 <L122>
+<L131>:
                	leaq	-0x130(%rbp), %r13
                	movq	$0x0, (%r13)
                	movq	$0x0, 0x8(%r13)
@@ -1249,61 +973,61 @@ Disassembly of section .text:
                	movl	(%rax), %ecx
                	movq	%rbx, %rdi
                	movl	%ecx, %esi
-               	callq	 <L181>
-<L181>:
+               	callq	 <L132>
+<L132>:
                	movups	(%r12), %xmm0
                	leaq	-0x140(%rbp), %rbx
                	movups	%xmm0, (%rbx)
                	leaq	(%rbx), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
-               	callq	 <L182>
-<L182>:
+               	callq	 <L133>
+<L133>:
                	leaq	0x2(%rbx), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
-               	callq	 <L183>
-<L183>:
+               	callq	 <L134>
+<L134>:
                	leaq	0x4(%rbx), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
-               	callq	 <L184>
-<L184>:
+               	callq	 <L135>
+<L135>:
                	leaq	0x6(%rbx), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
-               	callq	 <L185>
-<L185>:
+               	callq	 <L136>
+<L136>:
                	leaq	0x8(%rbx), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
-               	callq	 <L186>
-<L186>:
+               	callq	 <L137>
+<L137>:
                	leaq	0xa(%rbx), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
-               	callq	 <L187>
-<L187>:
+               	callq	 <L138>
+<L138>:
                	leaq	0xc(%rbx), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
-               	callq	 <L188>
-<L188>:
+               	callq	 <L139>
+<L139>:
                	leaq	0xe(%rbx), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
-               	callq	 <L189>
-<L189>:
+               	callq	 <L140>
+<L140>:
                	leaq	0x20(%r13), %rcx
                	movl	(%rcx), %edx
                	movq	%rax, %rdi
                	movl	%edx, %esi
-               	callq	 <L190>
-<L190>:
-               	movq	-0x318(%rbp), %rbx
-               	movq	-0x320(%rbp), %r12
-               	movq	-0x328(%rbp), %r13
-               	movq	-0x330(%rbp), %r14
+               	callq	 <L141>
+<L141>:
+               	movq	-0x2c8(%rbp), %rbx
+               	movq	-0x2d0(%rbp), %r12
+               	movq	-0x2d8(%rbp), %r13
+               	movq	-0x2e0(%rbp), %r14
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-linux/vec/vec_u32x4.dis
+++ b/test/golden/x86_64-linux/vec/vec_u32x4.dis
@@ -40,12 +40,12 @@ Disassembly of section .text:
 <corpus.cases.vec.vec_u32x4.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x4e0, %rsp            # imm = 0x4E0
-               	movq	%rbx, -0x4b8(%rbp)
-               	movq	%r12, -0x4c0(%rbp)
-               	movq	%r13, -0x4c8(%rbp)
-               	movq	%r14, -0x4d0(%rbp)
-               	movq	%r15, -0x4d8(%rbp)
+               	subq	$0x490, %rsp            # imm = 0x490
+               	movq	%rbx, -0x468(%rbp)
+               	movq	%r12, -0x470(%rbp)
+               	movq	%r13, -0x478(%rbp)
+               	movq	%r14, -0x480(%rbp)
+               	movq	%r15, -0x488(%rbp)
                	movq	%rdi, %rbx
                	callq	 <L0>
 <L0>:
@@ -96,7 +96,7 @@ Disassembly of section .text:
                	leaq	0xc(%rdi), %r12
                	movl	$0x0, (%r12)
                	movups	(%rdi), %xmm14
-               	movups	%xmm14, -0x3f0(%rbp)
+               	movups	%xmm14, -0x380(%rbp)
                	leaq	(%rdx), %rdi
                	movl	(%rdi), %edx
                	addl	%ecx, %edx
@@ -113,7 +113,7 @@ Disassembly of section .text:
                	leaq	0x8(%r12), %rdx
                	movl	%edi, (%rdx)
                	movups	(%r12), %xmm14
-               	movups	%xmm14, -0x400(%rbp)
+               	movups	%xmm14, -0x390(%rbp)
                	leaq	0x4(%rsi), %rdx
                	movl	(%rdx), %esi
                	addl	%ecx, %esi
@@ -121,16 +121,16 @@ Disassembly of section .text:
                	movups	%xmm1, (%rdx)
                	leaq	0x4(%rdx), %rdi
                	movl	%esi, (%rdi)
-               	movups	(%rdx), %xmm1
+               	movups	(%rdx), %xmm0
                	leaq	0xc(%rdx), %rsi
                	movl	(%rsi), %edx
                	addl	%ecx, %edx
                	leaq	-0xb0(%rbp), %r13
-               	movups	%xmm1, (%r13)
+               	movups	%xmm0, (%r13)
                	leaq	0xc(%r13), %rcx
                	movl	%edx, (%rcx)
                	movups	(%r13), %xmm14
-               	movups	%xmm14, -0x410(%rbp)
+               	movups	%xmm14, -0x3a0(%rbp)
                	leaq	(%r12), %rcx
                	movl	(%rcx), %edx
                	movq	%rax, %rdi
@@ -179,11 +179,11 @@ Disassembly of section .text:
                	movl	%edx, %esi
                	callq	 <L8>
 <L8>:
-               	movaps	-0x400(%rbp), %xmm14
-               	paddd	-0x410(%rbp), %xmm14
-               	movaps	%xmm14, %xmm3
+               	movaps	-0x390(%rbp), %xmm14
+               	paddd	-0x3a0(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	leaq	-0x1f0(%rbp), %r14
-               	movups	%xmm3, (%r14)
+               	movups	%xmm0, (%r14)
                	leaq	(%r14), %rcx
                	movl	(%rcx), %edx
                	movq	%rax, %rdi
@@ -208,11 +208,11 @@ Disassembly of section .text:
                	movl	%edx, %esi
                	callq	 <L12>
 <L12>:
-               	movaps	-0x400(%rbp), %xmm14
-               	psubd	-0x410(%rbp), %xmm14
-               	movaps	%xmm14, %xmm3
+               	movaps	-0x390(%rbp), %xmm14
+               	psubd	-0x3a0(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	leaq	-0x210(%rbp), %r14
-               	movups	%xmm3, (%r14)
+               	movups	%xmm0, (%r14)
                	leaq	(%r14), %rcx
                	movl	(%rcx), %edx
                	movq	%rax, %rdi
@@ -237,11 +237,11 @@ Disassembly of section .text:
                	movl	%edx, %esi
                	callq	 <L16>
 <L16>:
-               	movaps	-0x410(%rbp), %xmm14
-               	psubd	-0x400(%rbp), %xmm14
-               	movaps	%xmm14, %xmm3
+               	movaps	-0x3a0(%rbp), %xmm14
+               	psubd	-0x390(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	leaq	-0x230(%rbp), %r14
-               	movups	%xmm3, (%r14)
+               	movups	%xmm0, (%r14)
                	leaq	(%r14), %rcx
                	movl	(%rcx), %edx
                	movq	%rax, %rdi
@@ -287,26 +287,26 @@ Disassembly of section .text:
                	movl	(%rcx), %r15d
                	imull	%r15d, %r14d
                	leaq	-0x240(%rbp), %rcx
-               	movups	-0x400(%rbp), %xmm14
+               	movups	-0x390(%rbp), %xmm14
                	movups	%xmm14, (%rcx)
                	leaq	(%rcx), %r15
                	movl	%edx, (%r15)
-               	movups	(%rcx), %xmm3
+               	movups	(%rcx), %xmm0
                	leaq	-0x250(%rbp), %rcx
-               	movups	%xmm3, (%rcx)
+               	movups	%xmm0, (%rcx)
                	leaq	0x4(%rcx), %rdx
                	movl	%esi, (%rdx)
-               	movups	(%rcx), %xmm3
+               	movups	(%rcx), %xmm0
                	leaq	-0x260(%rbp), %rcx
-               	movups	%xmm3, (%rcx)
+               	movups	%xmm0, (%rcx)
                	leaq	0x8(%rcx), %rdx
                	movl	%edi, (%rdx)
-               	movups	(%rcx), %xmm3
+               	movups	(%rcx), %xmm0
                	leaq	-0x270(%rbp), %r15
-               	movups	%xmm3, (%r15)
+               	movups	%xmm0, (%r15)
                	leaq	0xc(%r15), %rcx
                	movl	%r14d, (%rcx)
-               	movups	(%r15), %xmm3
+               	movups	(%r15), %xmm0
                	leaq	(%r15), %rcx
                	movl	(%rcx), %edx
                	movq	%rax, %rdi
@@ -352,26 +352,26 @@ Disassembly of section .text:
                	movl	(%rcx), %r14d
                	imull	%r14d, %r12d
                	leaq	-0x280(%rbp), %rcx
-               	movups	-0x400(%rbp), %xmm14
+               	movups	-0x390(%rbp), %xmm14
                	movups	%xmm14, (%rcx)
                	leaq	(%rcx), %r14
                	movl	%edx, (%r14)
-               	movups	(%rcx), %xmm3
+               	movups	(%rcx), %xmm0
                	leaq	-0x290(%rbp), %rcx
-               	movups	%xmm3, (%rcx)
+               	movups	%xmm0, (%rcx)
                	leaq	0x4(%rcx), %rdx
                	movl	%esi, (%rdx)
-               	movups	(%rcx), %xmm3
+               	movups	(%rcx), %xmm0
                	leaq	-0x2a0(%rbp), %rcx
-               	movups	%xmm3, (%rcx)
+               	movups	%xmm0, (%rcx)
                	leaq	0x8(%rcx), %rdx
                	movl	%edi, (%rdx)
-               	movups	(%rcx), %xmm3
+               	movups	(%rcx), %xmm0
                	leaq	-0x2b0(%rbp), %r14
-               	movups	%xmm3, (%r14)
+               	movups	%xmm0, (%r14)
                	leaq	0xc(%r14), %rcx
                	movl	%r12d, (%rcx)
-               	movups	(%r14), %xmm3
+               	movups	(%r14), %xmm0
                	leaq	(%r14), %rcx
                	movl	(%rcx), %edx
                	movq	%rax, %rdi
@@ -417,26 +417,26 @@ Disassembly of section .text:
                	movl	(%rcx), %r13d
                	imull	%r13d, %r12d
                	leaq	-0x2c0(%rbp), %rcx
-               	movups	-0x410(%rbp), %xmm14
+               	movups	-0x3a0(%rbp), %xmm14
                	movups	%xmm14, (%rcx)
                	leaq	(%rcx), %r13
                	movl	%edx, (%r13)
-               	movups	(%rcx), %xmm3
+               	movups	(%rcx), %xmm0
                	leaq	-0x2d0(%rbp), %rcx
-               	movups	%xmm3, (%rcx)
+               	movups	%xmm0, (%rcx)
                	leaq	0x4(%rcx), %rdx
                	movl	%esi, (%rdx)
-               	movups	(%rcx), %xmm3
+               	movups	(%rcx), %xmm0
                	leaq	-0x2e0(%rbp), %rcx
-               	movups	%xmm3, (%rcx)
+               	movups	%xmm0, (%rcx)
                	leaq	0x8(%rcx), %rdx
                	movl	%edi, (%rdx)
-               	movups	(%rcx), %xmm3
+               	movups	(%rcx), %xmm0
                	leaq	-0x2f0(%rbp), %r13
-               	movups	%xmm3, (%r13)
+               	movups	%xmm0, (%r13)
                	leaq	0xc(%r13), %rcx
                	movl	%r12d, (%rcx)
-               	movups	(%r13), %xmm3
+               	movups	(%r13), %xmm0
                	leaq	(%r13), %rcx
                	movl	(%rcx), %edx
                	movq	%rax, %rdi
@@ -461,11 +461,11 @@ Disassembly of section .text:
                	movl	%edx, %esi
                	callq	 <L32>
 <L32>:
-               	movaps	-0x400(%rbp), %xmm14
-               	paddd	-0x410(%rbp), %xmm14
-               	movaps	%xmm14, %xmm3
+               	movaps	-0x390(%rbp), %xmm14
+               	paddd	-0x3a0(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	leaq	-0x300(%rbp), %rcx
-               	movups	%xmm3, (%rcx)
+               	movups	%xmm0, (%rcx)
                	leaq	(%rcx), %rdx
                	movl	(%rdx), %esi
                	leaq	(%rbx), %rdx
@@ -487,25 +487,25 @@ Disassembly of section .text:
                	movl	(%rdx), %r13d
                	imull	%r13d, %ecx
                	leaq	-0x310(%rbp), %rdx
-               	movups	%xmm3, (%rdx)
+               	movups	%xmm0, (%rdx)
                	leaq	(%rdx), %r13
                	movl	%esi, (%r13)
-               	movups	(%rdx), %xmm3
+               	movups	(%rdx), %xmm0
                	leaq	-0x320(%rbp), %rdx
-               	movups	%xmm3, (%rdx)
+               	movups	%xmm0, (%rdx)
                	leaq	0x4(%rdx), %rsi
                	movl	%edi, (%rsi)
-               	movups	(%rdx), %xmm3
+               	movups	(%rdx), %xmm0
                	leaq	-0x330(%rbp), %rdx
-               	movups	%xmm3, (%rdx)
+               	movups	%xmm0, (%rdx)
                	leaq	0x8(%rdx), %rsi
                	movl	%r12d, (%rsi)
-               	movups	(%rdx), %xmm3
+               	movups	(%rdx), %xmm0
                	leaq	-0x340(%rbp), %r12
-               	movups	%xmm3, (%r12)
+               	movups	%xmm0, (%r12)
                	leaq	0xc(%r12), %rdx
                	movl	%ecx, (%rdx)
-               	movups	(%r12), %xmm3
+               	movups	(%r12), %xmm0
                	leaq	(%r12), %rcx
                	movl	(%rcx), %edx
                	movq	%rax, %rdi
@@ -530,11 +530,11 @@ Disassembly of section .text:
                	movl	%edx, %esi
                	callq	 <L36>
 <L36>:
-               	movaps	-0x3f0(%rbp), %xmm14
-               	psubd	-0x400(%rbp), %xmm14
-               	movaps	%xmm14, %xmm3
+               	movaps	-0x380(%rbp), %xmm14
+               	psubd	-0x390(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	leaq	-0x350(%rbp), %r12
-               	movups	%xmm3, (%r12)
+               	movups	%xmm0, (%r12)
                	leaq	(%r12), %rcx
                	movl	(%rcx), %edx
                	movq	%rax, %rdi
@@ -559,231 +559,67 @@ Disassembly of section .text:
                	movl	%edx, %esi
                	callq	 <L40>
 <L40>:
-               	movaps	-0x3f0(%rbp), %xmm14
-               	psubd	-0x410(%rbp), %xmm14
-               	movaps	%xmm14, %xmm3
-               	leaq	-0x360(%rbp), %r12
-               	movups	%xmm3, (%r12)
-               	leaq	(%r12), %rcx
-               	movl	(%rcx), %edx
+               	movaps	-0x380(%rbp), %xmm14
+               	psubd	-0x3a0(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	movq	%rax, %rdi
-               	movl	%edx, %esi
                	callq	 <L41>
 <L41>:
-               	leaq	0x4(%r12), %rcx
-               	movl	(%rcx), %edx
+               	movaps	-0x390(%rbp), %xmm14
+               	pand	-0x3a0(%rbp), %xmm14
+               	movaps	%xmm14, -0x3b0(%rbp)
                	movq	%rax, %rdi
-               	movl	%edx, %esi
+               	movups	-0x3b0(%rbp), %xmm0
                	callq	 <L42>
 <L42>:
-               	leaq	0x8(%r12), %rcx
-               	movl	(%rcx), %edx
+               	movaps	-0x390(%rbp), %xmm14
+               	por	-0x3a0(%rbp), %xmm14
+               	movaps	%xmm14, -0x3c0(%rbp)
                	movq	%rax, %rdi
-               	movl	%edx, %esi
+               	movups	-0x3c0(%rbp), %xmm0
                	callq	 <L43>
 <L43>:
-               	leaq	0xc(%r12), %rcx
-               	movl	(%rcx), %edx
+               	movaps	-0x390(%rbp), %xmm14
+               	pxor	-0x3a0(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	movq	%rax, %rdi
-               	movl	%edx, %esi
                	callq	 <L44>
 <L44>:
-               	movaps	-0x400(%rbp), %xmm14
-               	pand	-0x410(%rbp), %xmm14
-               	movaps	%xmm14, %xmm3
-               	leaq	-0x370(%rbp), %r12
-               	movups	%xmm3, (%r12)
-               	leaq	(%r12), %rcx
-               	movl	(%rcx), %edx
+               	movaps	-0x390(%rbp), %xmm14
+               	pcmpeqd	%xmm15, %xmm15
+               	pxor	%xmm15, %xmm14
+               	movaps	%xmm14, %xmm0
                	movq	%rax, %rdi
-               	movl	%edx, %esi
                	callq	 <L45>
 <L45>:
-               	leaq	0x4(%r12), %rcx
-               	movl	(%rcx), %edx
+               	movaps	-0x3a0(%rbp), %xmm14
+               	pcmpeqd	%xmm15, %xmm15
+               	pxor	%xmm15, %xmm14
+               	movaps	%xmm14, %xmm0
                	movq	%rax, %rdi
-               	movl	%edx, %esi
                	callq	 <L46>
 <L46>:
-               	leaq	0x8(%r12), %rcx
-               	movl	(%rcx), %edx
+               	movaps	-0x3b0(%rbp), %xmm14
+               	pxor	-0x3c0(%rbp), %xmm14
+               	movaps	%xmm14, %xmm4
                	movq	%rax, %rdi
-               	movl	%edx, %esi
+               	movaps	%xmm4, %xmm0
                	callq	 <L47>
 <L47>:
-               	leaq	0xc(%r12), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L48>
-<L48>:
-               	movaps	-0x400(%rbp), %xmm14
-               	por	-0x410(%rbp), %xmm14
-               	movaps	%xmm14, %xmm3
-               	leaq	-0x380(%rbp), %r12
-               	movups	%xmm3, (%r12)
-               	leaq	(%r12), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L49>
-<L49>:
-               	leaq	0x4(%r12), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L50>
-<L50>:
-               	leaq	0x8(%r12), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L51>
-<L51>:
-               	leaq	0xc(%r12), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L52>
-<L52>:
-               	movaps	-0x400(%rbp), %xmm14
-               	pxor	-0x410(%rbp), %xmm14
-               	movaps	%xmm14, %xmm3
-               	leaq	-0x390(%rbp), %r12
-               	movups	%xmm3, (%r12)
-               	leaq	(%r12), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L53>
-<L53>:
-               	leaq	0x4(%r12), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L54>
-<L54>:
-               	leaq	0x8(%r12), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L55>
-<L55>:
-               	leaq	0xc(%r12), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L56>
-<L56>:
-               	movaps	-0x400(%rbp), %xmm14
-               	pcmpeqd	%xmm15, %xmm15
-               	pxor	%xmm15, %xmm14
-               	movaps	%xmm14, %xmm3
-               	leaq	-0x3a0(%rbp), %r12
-               	movups	%xmm3, (%r12)
-               	leaq	(%r12), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L57>
-<L57>:
-               	leaq	0x4(%r12), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L58>
-<L58>:
-               	leaq	0x8(%r12), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L59>
-<L59>:
-               	leaq	0xc(%r12), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L60>
-<L60>:
-               	movaps	-0x410(%rbp), %xmm14
-               	pcmpeqd	%xmm15, %xmm15
-               	pxor	%xmm15, %xmm14
-               	movaps	%xmm14, %xmm3
-               	leaq	-0x3b0(%rbp), %r12
-               	movups	%xmm3, (%r12)
-               	leaq	(%r12), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L61>
-<L61>:
-               	leaq	0x4(%r12), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L62>
-<L62>:
-               	leaq	0x8(%r12), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L63>
-<L63>:
-               	leaq	0xc(%r12), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L64>
-<L64>:
-               	movaps	-0x400(%rbp), %xmm14
-               	pand	-0x410(%rbp), %xmm14
-               	movaps	%xmm14, %xmm3
-               	movaps	-0x400(%rbp), %xmm14
-               	por	-0x410(%rbp), %xmm14
-               	movaps	%xmm14, %xmm4
-               	movaps	%xmm3, %xmm14
-               	pxor	%xmm4, %xmm14
-               	movaps	%xmm14, %xmm3
-               	leaq	-0x3c0(%rbp), %r12
-               	movups	%xmm3, (%r12)
-               	leaq	(%r12), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L65>
-<L65>:
-               	leaq	0x4(%r12), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L66>
-<L66>:
-               	leaq	0x8(%r12), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L67>
-<L67>:
-               	leaq	0xc(%r12), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L68>
-<L68>:
                	movq	%rax, %r12
-               	movups	-0x400(%rbp), %xmm14
-               	movups	%xmm14, -0x430(%rbp)
-               	movups	-0x3f0(%rbp), %xmm14
-               	movups	%xmm14, -0x440(%rbp)
-               	movups	-0x3f0(%rbp), %xmm14
-               	movups	%xmm14, -0x450(%rbp)
+               	movups	-0x390(%rbp), %xmm14
+               	movups	%xmm14, -0x3e0(%rbp)
+               	movups	-0x380(%rbp), %xmm14
+               	movups	%xmm14, -0x3f0(%rbp)
+               	movups	-0x380(%rbp), %xmm14
+               	movups	%xmm14, -0x400(%rbp)
                	movq	$0x0, %r13
-<L69>:
+<L48>:
                	leaq	-0xc0(%rbp), %r14
-               	movups	-0x430(%rbp), %xmm14
+               	movups	-0x3e0(%rbp), %xmm14
                	movups	%xmm14, (%r14)
                	cmpq	$0x6, %r13
-               	jb	 <L82>
+               	jb	 <L61>
                	leaq	-0x140(%rbp), %r15
                	movq	$0x0, (%r15)
                	movq	$0x0, 0x8(%r15)
@@ -794,10 +630,10 @@ Disassembly of section .text:
                	movq	$0x0, 0x30(%r15)
                	movq	$0x0, 0x38(%r15)
                	leaq	(%r15), %rax
-               	movups	-0x430(%rbp), %xmm14
+               	movups	-0x3e0(%rbp), %xmm14
                	movups	%xmm14, (%rax)
-               	movaps	-0x430(%rbp), %xmm14
-               	paddd	-0x410(%rbp), %xmm14
+               	movaps	-0x3e0(%rbp), %xmm14
+               	paddd	-0x3a0(%rbp), %xmm14
                	movaps	%xmm14, %xmm2
                	leaq	0x10(%r15), %rax
                	movups	%xmm2, (%rax)
@@ -807,7 +643,7 @@ Disassembly of section .text:
                	movl	(%rax), %edx
                	movl	%ecx, %r8d
                	imull	%edx, %r8d
-               	movq	%r8, -0x3c8(%rbp)
+               	movq	%r8, -0x358(%rbp)
                	leaq	0x4(%r14), %rax
                	movl	(%rax), %edx
                	leaq	0x4(%rbx), %rax
@@ -824,10 +660,10 @@ Disassembly of section .text:
                	movl	(%rax), %ecx
                	imull	%ecx, %edi
                	leaq	-0x150(%rbp), %rax
-               	movups	-0x430(%rbp), %xmm14
+               	movups	-0x3e0(%rbp), %xmm14
                	movups	%xmm14, (%rax)
                	leaq	(%rax), %rcx
-               	movq	-0x3c8(%rbp), %r8
+               	movq	-0x358(%rbp), %r8
                	movl	%r8d, (%rcx)
                	movups	(%rax), %xmm2
                	leaq	-0x160(%rbp), %rax
@@ -848,142 +684,142 @@ Disassembly of section .text:
                	leaq	0x20(%r15), %rax
                	movups	%xmm2, (%rax)
                	leaq	0x30(%r15), %rax
-               	movups	-0x440(%rbp), %xmm14
+               	movups	-0x3f0(%rbp), %xmm14
                	movups	%xmm14, (%rax)
                	movq	%r12, %r8
-               	movq	%r8, -0x418(%rbp)
+               	movq	%r8, -0x3c8(%rbp)
                	movq	$0x0, %r8
-               	movq	%r8, -0x458(%rbp)
-               	movq	-0x458(%rbp), %r8
+               	movq	%r8, -0x408(%rbp)
+               	movq	-0x408(%rbp), %r8
                	cmpq	$0x4, %r8
-               	jb	 <L70>
-               	jmp	 <L75>
-<L70>:
-               	movq	-0x458(%rbp), %r8
+               	jb	 <L49>
+               	jmp	 <L54>
+<L49>:
+               	movq	-0x408(%rbp), %r8
                	movq	%r8, %rdx
                	imulq	$0x10, %rdx, %rdx
                	leaq	(%r15,%rdx), %rsi
                	movups	(%rsi), %xmm2
                	leaq	-0x190(%rbp), %r8
-               	movq	%r8, -0x460(%rbp)
-               	movq	-0x460(%rbp), %r8
+               	movq	%r8, -0x410(%rbp)
+               	movq	-0x410(%rbp), %r8
                	movups	%xmm2, (%r8)
-               	movq	-0x460(%rbp), %r8
+               	movq	-0x410(%rbp), %r8
                	leaq	(%r8), %rsi
                	movl	(%rsi), %r8d
-               	movq	%r8, -0x3d0(%rbp)
-               	movq	-0x418(%rbp), %r8
+               	movq	%r8, -0x360(%rbp)
+               	movq	-0x3c8(%rbp), %r8
                	movq	%r8, %rdi
-               	movq	-0x3d0(%rbp), %r8
+               	movq	-0x360(%rbp), %r8
                	movl	%r8d, %esi
-               	callq	 <L71>
-<L71>:
+               	callq	 <L50>
+<L50>:
                	movq	%rax, %rdi
-               	movq	-0x460(%rbp), %r8
+               	movq	-0x410(%rbp), %r8
                	leaq	0x4(%r8), %rsi
                	movl	(%rsi), %r8d
-               	movq	%r8, -0x3d8(%rbp)
-               	movq	-0x3d8(%rbp), %r8
+               	movq	%r8, -0x368(%rbp)
+               	movq	-0x368(%rbp), %r8
                	movl	%r8d, %esi
-               	callq	 <L72>
-<L72>:
+               	callq	 <L51>
+<L51>:
                	movq	%rax, %rdi
-               	movq	-0x460(%rbp), %r8
+               	movq	-0x410(%rbp), %r8
                	leaq	0x8(%r8), %rsi
                	movl	(%rsi), %r8d
-               	movq	%r8, -0x3e0(%rbp)
-               	movq	-0x3e0(%rbp), %r8
+               	movq	%r8, -0x370(%rbp)
+               	movq	-0x370(%rbp), %r8
                	movl	%r8d, %esi
-               	callq	 <L73>
-<L73>:
+               	callq	 <L52>
+<L52>:
                	movq	%rax, %rdi
-               	movq	-0x460(%rbp), %r8
+               	movq	-0x410(%rbp), %r8
                	leaq	0xc(%r8), %rsi
                	movl	(%rsi), %edx
                	movl	%edx, %esi
-               	callq	 <L74>
-<L74>:
+               	callq	 <L53>
+<L53>:
                	movq	%rax, %rdx
-               	movq	-0x458(%rbp), %r8
+               	movq	-0x408(%rbp), %r8
                	movq	%r8, %rcx
                	addq	$0x1, %rcx
                	movq	%rdx, %r8
-               	movq	%r8, -0x418(%rbp)
+               	movq	%r8, -0x3c8(%rbp)
                	movq	%rcx, %r8
-               	movq	%r8, -0x458(%rbp)
-               	movq	-0x458(%rbp), %r8
+               	movq	%r8, -0x408(%rbp)
+               	movq	-0x408(%rbp), %r8
                	cmpq	$0x4, %r8
-               	jb	 <L70>
-<L75>:
+               	jb	 <L49>
+<L54>:
                	leaq	-0x1c0(%rbp), %r8
-               	movq	%r8, -0x468(%rbp)
-               	movq	-0x468(%rbp), %r8
+               	movq	%r8, -0x418(%rbp)
+               	movq	-0x418(%rbp), %r8
                	movq	$0x0, (%r8)
-               	movq	-0x468(%rbp), %r8
+               	movq	-0x418(%rbp), %r8
                	movq	$0x0, 0x8(%r8)
-               	movq	-0x468(%rbp), %r8
+               	movq	-0x418(%rbp), %r8
                	movq	$0x0, 0x10(%r8)
-               	movq	-0x468(%rbp), %r8
+               	movq	-0x418(%rbp), %r8
                	movq	$0x0, 0x18(%r8)
-               	movq	-0x468(%rbp), %r8
+               	movq	-0x418(%rbp), %r8
                	movq	$0x0, 0x20(%r8)
-               	movq	-0x468(%rbp), %r8
+               	movq	-0x418(%rbp), %r8
                	movq	$0x0, 0x28(%r8)
-               	movq	-0x468(%rbp), %r8
+               	movq	-0x418(%rbp), %r8
                	leaq	(%r8), %rdx
                	movl	$0xffffffff, (%rdx)     # imm = 0xFFFFFFFF
                	leaq	0x20(%r15), %rsi
                	movups	(%rsi), %xmm2
-               	movq	-0x468(%rbp), %r8
+               	movq	-0x418(%rbp), %r8
                	leaq	0x10(%r8), %r15
                	movups	%xmm2, (%r15)
-               	movq	-0x468(%rbp), %r8
+               	movq	-0x418(%rbp), %r8
                	leaq	0x20(%r8), %rsi
                	movl	$0x12345678, (%rsi)     # imm = 0x12345678
                	movl	(%rdx), %esi
-               	movq	-0x418(%rbp), %r8
+               	movq	-0x3c8(%rbp), %r8
                	movq	%r8, %rdi
-               	callq	 <L76>
-<L76>:
+               	callq	 <L55>
+<L55>:
                	movups	(%r15), %xmm2
                	leaq	-0x1d0(%rbp), %r15
                	movups	%xmm2, (%r15)
                	leaq	(%r15), %rdx
                	movl	(%rdx), %esi
                	movq	%rax, %rdi
-               	callq	 <L77>
-<L77>:
+               	callq	 <L56>
+<L56>:
                	leaq	0x4(%r15), %rdx
                	movl	(%rdx), %esi
                	movq	%rax, %rdi
-               	callq	 <L78>
-<L78>:
+               	callq	 <L57>
+<L57>:
                	leaq	0x8(%r15), %rdx
                	movl	(%rdx), %esi
                	movq	%rax, %rdi
-               	callq	 <L79>
-<L79>:
+               	callq	 <L58>
+<L58>:
                	leaq	0xc(%r15), %rdx
                	movl	(%rdx), %esi
                	movq	%rax, %rdi
-               	callq	 <L80>
-<L80>:
-               	movq	-0x468(%rbp), %r8
+               	callq	 <L59>
+<L59>:
+               	movq	-0x418(%rbp), %r8
                	leaq	0x20(%r8), %rdx
                	movl	(%rdx), %ecx
                	movq	%rax, %rdi
                	movl	%ecx, %esi
-               	callq	 <L81>
-<L81>:
-               	movq	-0x4b8(%rbp), %rbx
-               	movq	-0x4c0(%rbp), %r12
-               	movq	-0x4c8(%rbp), %r13
-               	movq	-0x4d0(%rbp), %r14
-               	movq	-0x4d8(%rbp), %r15
+               	callq	 <L60>
+<L60>:
+               	movq	-0x468(%rbp), %rbx
+               	movq	-0x470(%rbp), %r12
+               	movq	-0x478(%rbp), %r13
+               	movq	-0x480(%rbp), %r14
+               	movq	-0x488(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
-<L82>:
+<L61>:
                	leaq	(%r14), %rcx
                	movl	(%rcx), %edx
                	leaq	(%rbx), %rcx
@@ -1005,7 +841,7 @@ Disassembly of section .text:
                	movl	(%rcx), %r15d
                	imull	%r15d, %r14d
                	leaq	-0xd0(%rbp), %rcx
-               	movups	-0x430(%rbp), %xmm14
+               	movups	-0x3e0(%rbp), %xmm14
                	movups	%xmm14, (%rcx)
                	leaq	(%rcx), %r15
                	movl	%edx, (%r15)
@@ -1025,127 +861,127 @@ Disassembly of section .text:
                	leaq	0xc(%r15), %rcx
                	movl	%r14d, (%rcx)
                	movups	(%r15), %xmm14
-               	movups	%xmm14, -0x480(%rbp)
+               	movups	%xmm14, -0x430(%rbp)
                	leaq	(%r15), %rcx
                	movl	(%rcx), %edx
                	movq	%r12, %rdi
                	movl	%edx, %esi
-               	callq	 <L83>
-<L83>:
+               	callq	 <L62>
+<L62>:
                	leaq	0x4(%r15), %rcx
                	movl	(%rcx), %edx
                	movq	%rax, %rdi
                	movl	%edx, %esi
-               	callq	 <L84>
-<L84>:
+               	callq	 <L63>
+<L63>:
                	leaq	0x8(%r15), %rcx
                	movl	(%rcx), %edx
                	movq	%rax, %rdi
                	movl	%edx, %esi
-               	callq	 <L85>
-<L85>:
+               	callq	 <L64>
+<L64>:
                	leaq	0xc(%r15), %rcx
                	movl	(%rcx), %edx
                	movq	%rax, %rdi
                	movl	%edx, %esi
-               	callq	 <L86>
-<L86>:
-               	movaps	-0x440(%rbp), %xmm14
-               	pxor	-0x480(%rbp), %xmm14
-               	movaps	%xmm14, -0x490(%rbp)
+               	callq	 <L65>
+<L65>:
+               	movaps	-0x3f0(%rbp), %xmm14
+               	pxor	-0x430(%rbp), %xmm14
+               	movaps	%xmm14, -0x440(%rbp)
                	leaq	-0x1e0(%rbp), %r14
-               	movups	-0x490(%rbp), %xmm14
+               	movups	-0x440(%rbp), %xmm14
                	movups	%xmm14, (%r14)
                	leaq	(%r14), %rcx
                	movl	(%rcx), %edx
                	movq	%rax, %rdi
                	movl	%edx, %esi
-               	callq	 <L87>
-<L87>:
+               	callq	 <L66>
+<L66>:
                	leaq	0x4(%r14), %rcx
                	movl	(%rcx), %edx
                	movq	%rax, %rdi
                	movl	%edx, %esi
-               	callq	 <L88>
-<L88>:
+               	callq	 <L67>
+<L67>:
                	leaq	0x8(%r14), %rcx
                	movl	(%rcx), %edx
                	movq	%rax, %rdi
                	movl	%edx, %esi
-               	callq	 <L89>
-<L89>:
+               	callq	 <L68>
+<L68>:
                	leaq	0xc(%r14), %rcx
                	movl	(%rcx), %edx
                	movq	%rax, %rdi
                	movl	%edx, %esi
-               	callq	 <L90>
-<L90>:
-               	movaps	-0x450(%rbp), %xmm14
-               	paddd	-0x430(%rbp), %xmm14
-               	movaps	%xmm14, -0x4a0(%rbp)
+               	callq	 <L69>
+<L69>:
+               	movaps	-0x400(%rbp), %xmm14
+               	paddd	-0x3e0(%rbp), %xmm14
+               	movaps	%xmm14, -0x450(%rbp)
                	leaq	-0x200(%rbp), %r14
-               	movups	-0x4a0(%rbp), %xmm14
+               	movups	-0x450(%rbp), %xmm14
                	movups	%xmm14, (%r14)
                	leaq	(%r14), %rcx
                	movl	(%rcx), %edx
                	movq	%rax, %rdi
                	movl	%edx, %esi
-               	callq	 <L91>
-<L91>:
+               	callq	 <L70>
+<L70>:
                	leaq	0x4(%r14), %rcx
                	movl	(%rcx), %edx
                	movq	%rax, %rdi
                	movl	%edx, %esi
-               	callq	 <L92>
-<L92>:
+               	callq	 <L71>
+<L71>:
                	leaq	0x8(%r14), %rcx
                	movl	(%rcx), %edx
                	movq	%rax, %rdi
                	movl	%edx, %esi
-               	callq	 <L93>
-<L93>:
+               	callq	 <L72>
+<L72>:
                	leaq	0xc(%r14), %rcx
                	movl	(%rcx), %edx
                	movq	%rax, %rdi
                	movl	%edx, %esi
-               	callq	 <L94>
-<L94>:
-               	movaps	-0x430(%rbp), %xmm14
-               	paddd	-0x410(%rbp), %xmm14
-               	movaps	%xmm14, -0x4b0(%rbp)
+               	callq	 <L73>
+<L73>:
+               	movaps	-0x3e0(%rbp), %xmm14
+               	paddd	-0x3a0(%rbp), %xmm14
+               	movaps	%xmm14, -0x460(%rbp)
                	leaq	-0x220(%rbp), %r14
-               	movups	-0x4b0(%rbp), %xmm14
+               	movups	-0x460(%rbp), %xmm14
                	movups	%xmm14, (%r14)
                	leaq	(%r14), %rcx
                	movl	(%rcx), %edx
                	movq	%rax, %rdi
                	movl	%edx, %esi
-               	callq	 <L95>
-<L95>:
+               	callq	 <L74>
+<L74>:
                	leaq	0x4(%r14), %rcx
                	movl	(%rcx), %edx
                	movq	%rax, %rdi
                	movl	%edx, %esi
-               	callq	 <L96>
-<L96>:
+               	callq	 <L75>
+<L75>:
                	leaq	0x8(%r14), %rcx
                	movl	(%rcx), %edx
                	movq	%rax, %rdi
                	movl	%edx, %esi
-               	callq	 <L97>
-<L97>:
+               	callq	 <L76>
+<L76>:
                	leaq	0xc(%r14), %rcx
                	movl	(%rcx), %edx
                	movq	%rax, %rdi
                	movl	%edx, %esi
-               	callq	 <L98>
-<L98>:
+               	callq	 <L77>
+<L77>:
                	addq	$0x1, %r13
                	movq	%rax, %r12
-               	movups	-0x4b0(%rbp), %xmm14
-               	movups	%xmm14, -0x430(%rbp)
-               	movups	-0x490(%rbp), %xmm14
-               	movups	%xmm14, -0x440(%rbp)
-               	movups	-0x4a0(%rbp), %xmm14
-               	movups	%xmm14, -0x450(%rbp)
-               	jmp	 <L69>
+               	movups	-0x460(%rbp), %xmm14
+               	movups	%xmm14, -0x3e0(%rbp)
+               	movups	-0x440(%rbp), %xmm14
+               	movups	%xmm14, -0x3f0(%rbp)
+               	movups	-0x450(%rbp), %xmm14
+               	movups	%xmm14, -0x400(%rbp)
+               	jmp	 <L48>

--- a/test/golden/x86_64-linux/vec/vec_u64x2.dis
+++ b/test/golden/x86_64-linux/vec/vec_u64x2.dis
@@ -26,12 +26,12 @@ Disassembly of section .text:
 <corpus.cases.vec.vec_u64x2.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x3f0, %rsp            # imm = 0x3F0
-               	movq	%rbx, -0x3c8(%rbp)
-               	movq	%r12, -0x3d0(%rbp)
-               	movq	%r13, -0x3d8(%rbp)
-               	movq	%r14, -0x3e0(%rbp)
-               	movq	%r15, -0x3e8(%rbp)
+               	subq	$0x3a0, %rsp            # imm = 0x3A0
+               	movq	%rbx, -0x378(%rbp)
+               	movq	%r12, -0x380(%rbp)
+               	movq	%r13, -0x388(%rbp)
+               	movq	%r14, -0x390(%rbp)
+               	movq	%r15, -0x398(%rbp)
                	movq	%rdi, %rbx
                	callq	 <L0>
 <L0>:
@@ -65,7 +65,7 @@ Disassembly of section .text:
                	leaq	0x8(%rsi), %rdi
                	movq	$0x0, (%rdi)
                	movups	(%rsi), %xmm14
-               	movups	%xmm14, -0x300(%rbp)
+               	movups	%xmm14, -0x290(%rbp)
                	leaq	(%rcx), %rsi
                	movq	(%rsi), %rcx
                	addq	%rbx, %rcx
@@ -74,7 +74,7 @@ Disassembly of section .text:
                	leaq	(%r13), %rsi
                	movq	%rcx, (%rsi)
                	movups	(%r13), %xmm14
-               	movups	%xmm14, -0x310(%rbp)
+               	movups	%xmm14, -0x2a0(%rbp)
                	leaq	0x8(%rdx), %rcx
                	movq	(%rcx), %rdx
                	addq	%rbx, %rdx
@@ -83,7 +83,7 @@ Disassembly of section .text:
                	leaq	0x8(%rbx), %rcx
                	movq	%rdx, (%rcx)
                	movups	(%rbx), %xmm14
-               	movups	%xmm14, -0x320(%rbp)
+               	movups	%xmm14, -0x2b0(%rbp)
                	leaq	(%r13), %rcx
                	movq	(%rcx), %rsi
                	movq	%rax, %rdi
@@ -104,11 +104,11 @@ Disassembly of section .text:
                	movq	%rax, %rdi
                	callq	 <L4>
 <L4>:
-               	movaps	-0x310(%rbp), %xmm14
-               	paddq	-0x320(%rbp), %xmm14
-               	movaps	%xmm14, %xmm3
+               	movaps	-0x2a0(%rbp), %xmm14
+               	paddq	-0x2b0(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	leaq	-0x190(%rbp), %r14
-               	movups	%xmm3, (%r14)
+               	movups	%xmm0, (%r14)
                	leaq	(%r14), %rcx
                	movq	(%rcx), %rsi
                	movq	%rax, %rdi
@@ -119,11 +119,11 @@ Disassembly of section .text:
                	movq	%rax, %rdi
                	callq	 <L6>
 <L6>:
-               	movaps	-0x310(%rbp), %xmm14
-               	psubq	-0x320(%rbp), %xmm14
-               	movaps	%xmm14, %xmm3
+               	movaps	-0x2a0(%rbp), %xmm14
+               	psubq	-0x2b0(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	leaq	-0x1b0(%rbp), %r14
-               	movups	%xmm3, (%r14)
+               	movups	%xmm0, (%r14)
                	leaq	(%r14), %rcx
                	movq	(%rcx), %rsi
                	movq	%rax, %rdi
@@ -134,11 +134,11 @@ Disassembly of section .text:
                	movq	%rax, %rdi
                	callq	 <L8>
 <L8>:
-               	movaps	-0x320(%rbp), %xmm14
-               	psubq	-0x310(%rbp), %xmm14
-               	movaps	%xmm14, %xmm3
+               	movaps	-0x2b0(%rbp), %xmm14
+               	psubq	-0x2a0(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	leaq	-0x1d0(%rbp), %r14
-               	movups	%xmm3, (%r14)
+               	movups	%xmm0, (%r14)
                	leaq	(%r14), %rcx
                	movq	(%rcx), %rsi
                	movq	%rax, %rdi
@@ -160,16 +160,16 @@ Disassembly of section .text:
                	movq	(%rcx), %rdi
                	imulq	%rdi, %rsi
                	leaq	-0x1e0(%rbp), %rcx
-               	movups	-0x310(%rbp), %xmm14
+               	movups	-0x2a0(%rbp), %xmm14
                	movups	%xmm14, (%rcx)
                	leaq	(%rcx), %rdi
                	movq	%rdx, (%rdi)
-               	movups	(%rcx), %xmm3
+               	movups	(%rcx), %xmm0
                	leaq	-0x1f0(%rbp), %r14
-               	movups	%xmm3, (%r14)
+               	movups	%xmm0, (%r14)
                	leaq	0x8(%r14), %rcx
                	movq	%rsi, (%rcx)
-               	movups	(%r14), %xmm3
+               	movups	(%r14), %xmm0
                	leaq	(%r14), %rcx
                	movq	(%rcx), %rsi
                	movq	%rax, %rdi
@@ -191,16 +191,16 @@ Disassembly of section .text:
                	movq	(%rcx), %rdi
                	imulq	%rdi, %rsi
                	leaq	-0x200(%rbp), %rcx
-               	movups	-0x310(%rbp), %xmm14
+               	movups	-0x2a0(%rbp), %xmm14
                	movups	%xmm14, (%rcx)
                	leaq	(%rcx), %rdi
                	movq	%rdx, (%rdi)
-               	movups	(%rcx), %xmm3
+               	movups	(%rcx), %xmm0
                	leaq	-0x210(%rbp), %r13
-               	movups	%xmm3, (%r13)
+               	movups	%xmm0, (%r13)
                	leaq	0x8(%r13), %rcx
                	movq	%rsi, (%rcx)
-               	movups	(%r13), %xmm3
+               	movups	(%r13), %xmm0
                	leaq	(%r13), %rcx
                	movq	(%rcx), %rsi
                	movq	%rax, %rdi
@@ -222,16 +222,16 @@ Disassembly of section .text:
                	movq	(%rcx), %rdi
                	imulq	%rdi, %rsi
                	leaq	-0x220(%rbp), %rcx
-               	movups	-0x320(%rbp), %xmm14
+               	movups	-0x2b0(%rbp), %xmm14
                	movups	%xmm14, (%rcx)
                	leaq	(%rcx), %rdi
                	movq	%rdx, (%rdi)
-               	movups	(%rcx), %xmm3
+               	movups	(%rcx), %xmm0
                	leaq	-0x230(%rbp), %rbx
-               	movups	%xmm3, (%rbx)
+               	movups	%xmm0, (%rbx)
                	leaq	0x8(%rbx), %rcx
                	movq	%rsi, (%rcx)
-               	movups	(%rbx), %xmm3
+               	movups	(%rbx), %xmm0
                	leaq	(%rbx), %rcx
                	movq	(%rcx), %rsi
                	movq	%rax, %rdi
@@ -242,11 +242,11 @@ Disassembly of section .text:
                	movq	%rax, %rdi
                	callq	 <L16>
 <L16>:
-               	movaps	-0x310(%rbp), %xmm14
-               	paddq	-0x320(%rbp), %xmm14
-               	movaps	%xmm14, %xmm3
+               	movaps	-0x2a0(%rbp), %xmm14
+               	paddq	-0x2b0(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	leaq	-0x240(%rbp), %rcx
-               	movups	%xmm3, (%rcx)
+               	movups	%xmm0, (%rcx)
                	leaq	(%rcx), %rdx
                	movq	(%rdx), %rsi
                	leaq	(%r12), %rdx
@@ -258,15 +258,15 @@ Disassembly of section .text:
                	movq	(%rdx), %rdi
                	imulq	%rdi, %rcx
                	leaq	-0x250(%rbp), %rdx
-               	movups	%xmm3, (%rdx)
+               	movups	%xmm0, (%rdx)
                	leaq	(%rdx), %rdi
                	movq	%rsi, (%rdi)
-               	movups	(%rdx), %xmm3
+               	movups	(%rdx), %xmm0
                	leaq	-0x260(%rbp), %rbx
-               	movups	%xmm3, (%rbx)
+               	movups	%xmm0, (%rbx)
                	leaq	0x8(%rbx), %rdx
                	movq	%rcx, (%rdx)
-               	movups	(%rbx), %xmm3
+               	movups	(%rbx), %xmm0
                	leaq	(%rbx), %rcx
                	movq	(%rcx), %rsi
                	movq	%rax, %rdi
@@ -277,11 +277,11 @@ Disassembly of section .text:
                	movq	%rax, %rdi
                	callq	 <L18>
 <L18>:
-               	movaps	-0x300(%rbp), %xmm14
-               	psubq	-0x310(%rbp), %xmm14
-               	movaps	%xmm14, %xmm3
+               	movaps	-0x290(%rbp), %xmm14
+               	psubq	-0x2a0(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	leaq	-0x270(%rbp), %rbx
-               	movups	%xmm3, (%rbx)
+               	movups	%xmm0, (%rbx)
                	leaq	(%rbx), %rcx
                	movq	(%rcx), %rsi
                	movq	%rax, %rdi
@@ -292,133 +292,67 @@ Disassembly of section .text:
                	movq	%rax, %rdi
                	callq	 <L20>
 <L20>:
-               	movaps	-0x300(%rbp), %xmm14
-               	psubq	-0x320(%rbp), %xmm14
-               	movaps	%xmm14, %xmm3
-               	leaq	-0x280(%rbp), %rbx
-               	movups	%xmm3, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movq	(%rcx), %rsi
+               	movaps	-0x290(%rbp), %xmm14
+               	psubq	-0x2b0(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	movq	%rax, %rdi
                	callq	 <L21>
 <L21>:
-               	leaq	0x8(%rbx), %rcx
-               	movq	(%rcx), %rsi
+               	movaps	-0x2a0(%rbp), %xmm14
+               	pand	-0x2b0(%rbp), %xmm14
+               	movaps	%xmm14, -0x2c0(%rbp)
                	movq	%rax, %rdi
+               	movups	-0x2c0(%rbp), %xmm0
                	callq	 <L22>
 <L22>:
-               	movaps	-0x310(%rbp), %xmm14
-               	pand	-0x320(%rbp), %xmm14
-               	movaps	%xmm14, %xmm3
-               	leaq	-0x290(%rbp), %rbx
-               	movups	%xmm3, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movq	(%rcx), %rsi
+               	movaps	-0x2a0(%rbp), %xmm14
+               	por	-0x2b0(%rbp), %xmm14
+               	movaps	%xmm14, -0x2d0(%rbp)
                	movq	%rax, %rdi
+               	movups	-0x2d0(%rbp), %xmm0
                	callq	 <L23>
 <L23>:
-               	leaq	0x8(%rbx), %rcx
-               	movq	(%rcx), %rsi
+               	movaps	-0x2a0(%rbp), %xmm14
+               	pxor	-0x2b0(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	movq	%rax, %rdi
                	callq	 <L24>
 <L24>:
-               	movaps	-0x310(%rbp), %xmm14
-               	por	-0x320(%rbp), %xmm14
-               	movaps	%xmm14, %xmm3
-               	leaq	-0x2a0(%rbp), %rbx
-               	movups	%xmm3, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movq	(%rcx), %rsi
+               	movaps	-0x2a0(%rbp), %xmm14
+               	pcmpeqd	%xmm15, %xmm15
+               	pxor	%xmm15, %xmm14
+               	movaps	%xmm14, %xmm0
                	movq	%rax, %rdi
                	callq	 <L25>
 <L25>:
-               	leaq	0x8(%rbx), %rcx
-               	movq	(%rcx), %rsi
+               	movaps	-0x2b0(%rbp), %xmm14
+               	pcmpeqd	%xmm15, %xmm15
+               	pxor	%xmm15, %xmm14
+               	movaps	%xmm14, %xmm0
                	movq	%rax, %rdi
                	callq	 <L26>
 <L26>:
-               	movaps	-0x310(%rbp), %xmm14
-               	pxor	-0x320(%rbp), %xmm14
-               	movaps	%xmm14, %xmm3
-               	leaq	-0x2b0(%rbp), %rbx
-               	movups	%xmm3, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movq	(%rcx), %rsi
+               	movaps	-0x2c0(%rbp), %xmm14
+               	pxor	-0x2d0(%rbp), %xmm14
+               	movaps	%xmm14, %xmm4
                	movq	%rax, %rdi
+               	movaps	%xmm4, %xmm0
                	callq	 <L27>
 <L27>:
-               	leaq	0x8(%rbx), %rcx
-               	movq	(%rcx), %rsi
-               	movq	%rax, %rdi
-               	callq	 <L28>
-<L28>:
-               	movaps	-0x310(%rbp), %xmm14
-               	pcmpeqd	%xmm15, %xmm15
-               	pxor	%xmm15, %xmm14
-               	movaps	%xmm14, %xmm3
-               	leaq	-0x2c0(%rbp), %rbx
-               	movups	%xmm3, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movq	(%rcx), %rsi
-               	movq	%rax, %rdi
-               	callq	 <L29>
-<L29>:
-               	leaq	0x8(%rbx), %rcx
-               	movq	(%rcx), %rsi
-               	movq	%rax, %rdi
-               	callq	 <L30>
-<L30>:
-               	movaps	-0x320(%rbp), %xmm14
-               	pcmpeqd	%xmm15, %xmm15
-               	pxor	%xmm15, %xmm14
-               	movaps	%xmm14, %xmm3
-               	leaq	-0x2d0(%rbp), %rbx
-               	movups	%xmm3, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movq	(%rcx), %rsi
-               	movq	%rax, %rdi
-               	callq	 <L31>
-<L31>:
-               	leaq	0x8(%rbx), %rcx
-               	movq	(%rcx), %rsi
-               	movq	%rax, %rdi
-               	callq	 <L32>
-<L32>:
-               	movaps	-0x310(%rbp), %xmm14
-               	pand	-0x320(%rbp), %xmm14
-               	movaps	%xmm14, %xmm3
-               	movaps	-0x310(%rbp), %xmm14
-               	por	-0x320(%rbp), %xmm14
-               	movaps	%xmm14, %xmm4
-               	movaps	%xmm3, %xmm14
-               	pxor	%xmm4, %xmm14
-               	movaps	%xmm14, %xmm3
-               	leaq	-0x2e0(%rbp), %rbx
-               	movups	%xmm3, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movq	(%rcx), %rsi
-               	movq	%rax, %rdi
-               	callq	 <L33>
-<L33>:
-               	leaq	0x8(%rbx), %rcx
-               	movq	(%rcx), %rsi
-               	movq	%rax, %rdi
-               	callq	 <L34>
-<L34>:
                	movq	%rax, %rbx
-               	movups	-0x310(%rbp), %xmm14
-               	movups	%xmm14, -0x340(%rbp)
-               	movups	-0x300(%rbp), %xmm14
-               	movups	%xmm14, -0x350(%rbp)
-               	movups	-0x300(%rbp), %xmm14
-               	movups	%xmm14, -0x360(%rbp)
+               	movups	-0x2a0(%rbp), %xmm14
+               	movups	%xmm14, -0x2f0(%rbp)
+               	movups	-0x290(%rbp), %xmm14
+               	movups	%xmm14, -0x300(%rbp)
+               	movups	-0x290(%rbp), %xmm14
+               	movups	%xmm14, -0x310(%rbp)
                	movq	$0x0, %r13
-<L35>:
+<L28>:
                	leaq	-0xa0(%rbp), %r14
-               	movups	-0x340(%rbp), %xmm14
+               	movups	-0x2f0(%rbp), %xmm14
                	movups	%xmm14, (%r14)
                	cmpq	$0x6, %r13
-               	jb	 <L44>
+               	jb	 <L37>
                	leaq	-0x100(%rbp), %r15
                	movq	$0x0, (%r15)
                	movq	$0x0, 0x8(%r15)
@@ -429,10 +363,10 @@ Disassembly of section .text:
                	movq	$0x0, 0x30(%r15)
                	movq	$0x0, 0x38(%r15)
                	leaq	(%r15), %rax
-               	movups	-0x340(%rbp), %xmm14
+               	movups	-0x2f0(%rbp), %xmm14
                	movups	%xmm14, (%rax)
-               	movaps	-0x340(%rbp), %xmm14
-               	paddq	-0x320(%rbp), %xmm14
+               	movaps	-0x2f0(%rbp), %xmm14
+               	paddq	-0x2b0(%rbp), %xmm14
                	movaps	%xmm14, %xmm2
                	leaq	0x10(%r15), %rax
                	movups	%xmm2, (%rax)
@@ -447,7 +381,7 @@ Disassembly of section .text:
                	movq	(%rax), %rsi
                	imulq	%rsi, %rdx
                	leaq	-0x110(%rbp), %rax
-               	movups	-0x340(%rbp), %xmm14
+               	movups	-0x2f0(%rbp), %xmm14
                	movups	%xmm14, (%rax)
                	leaq	(%rax), %rsi
                	movq	%rcx, (%rsi)
@@ -460,114 +394,114 @@ Disassembly of section .text:
                	leaq	0x20(%r15), %rax
                	movups	%xmm2, (%rax)
                	leaq	0x30(%r15), %rax
-               	movups	-0x350(%rbp), %xmm14
+               	movups	-0x300(%rbp), %xmm14
                	movups	%xmm14, (%rax)
                	movq	%rbx, %r8
-               	movq	%r8, -0x328(%rbp)
+               	movq	%r8, -0x2d8(%rbp)
                	movq	$0x0, %r8
-               	movq	%r8, -0x368(%rbp)
-               	movq	-0x368(%rbp), %r8
+               	movq	%r8, -0x318(%rbp)
+               	movq	-0x318(%rbp), %r8
                	cmpq	$0x4, %r8
-               	jb	 <L36>
-               	jmp	 <L39>
-<L36>:
-               	movq	-0x368(%rbp), %r8
+               	jb	 <L29>
+               	jmp	 <L32>
+<L29>:
+               	movq	-0x318(%rbp), %r8
                	movq	%r8, %rdx
                	imulq	$0x10, %rdx, %rdx
                	leaq	(%r15,%rdx), %rsi
                	movups	(%rsi), %xmm2
                	leaq	-0x130(%rbp), %r8
-               	movq	%r8, -0x370(%rbp)
-               	movq	-0x370(%rbp), %r8
+               	movq	%r8, -0x320(%rbp)
+               	movq	-0x320(%rbp), %r8
                	movups	%xmm2, (%r8)
-               	movq	-0x370(%rbp), %r8
+               	movq	-0x320(%rbp), %r8
                	leaq	(%r8), %rsi
                	movq	(%rsi), %r8
-               	movq	%r8, -0x2e8(%rbp)
-               	movq	-0x328(%rbp), %r8
+               	movq	%r8, -0x278(%rbp)
+               	movq	-0x2d8(%rbp), %r8
                	movq	%r8, %rdi
-               	movq	-0x2e8(%rbp), %r8
+               	movq	-0x278(%rbp), %r8
                	movq	%r8, %rsi
-               	callq	 <L37>
-<L37>:
+               	callq	 <L30>
+<L30>:
                	movq	%rax, %rdi
-               	movq	-0x370(%rbp), %r8
+               	movq	-0x320(%rbp), %r8
                	leaq	0x8(%r8), %rsi
                	movq	(%rsi), %rdx
                	movq	%rdx, %rsi
-               	callq	 <L38>
-<L38>:
+               	callq	 <L31>
+<L31>:
                	movq	%rax, %rdx
-               	movq	-0x368(%rbp), %r8
+               	movq	-0x318(%rbp), %r8
                	movq	%r8, %rcx
                	addq	$0x1, %rcx
                	movq	%rdx, %r8
-               	movq	%r8, -0x328(%rbp)
+               	movq	%r8, -0x2d8(%rbp)
                	movq	%rcx, %r8
-               	movq	%r8, -0x368(%rbp)
-               	movq	-0x368(%rbp), %r8
+               	movq	%r8, -0x318(%rbp)
+               	movq	-0x318(%rbp), %r8
                	cmpq	$0x4, %r8
-               	jb	 <L36>
-<L39>:
+               	jb	 <L29>
+<L32>:
                	leaq	-0x160(%rbp), %r8
-               	movq	%r8, -0x378(%rbp)
-               	movq	-0x378(%rbp), %r8
+               	movq	%r8, -0x328(%rbp)
+               	movq	-0x328(%rbp), %r8
                	movq	$0x0, (%r8)
-               	movq	-0x378(%rbp), %r8
+               	movq	-0x328(%rbp), %r8
                	movq	$0x0, 0x8(%r8)
-               	movq	-0x378(%rbp), %r8
+               	movq	-0x328(%rbp), %r8
                	movq	$0x0, 0x10(%r8)
-               	movq	-0x378(%rbp), %r8
+               	movq	-0x328(%rbp), %r8
                	movq	$0x0, 0x18(%r8)
-               	movq	-0x378(%rbp), %r8
+               	movq	-0x328(%rbp), %r8
                	movq	$0x0, 0x20(%r8)
-               	movq	-0x378(%rbp), %r8
+               	movq	-0x328(%rbp), %r8
                	movq	$0x0, 0x28(%r8)
-               	movq	-0x378(%rbp), %r8
+               	movq	-0x328(%rbp), %r8
                	leaq	(%r8), %rdx
                	movl	$0xffffffff, (%rdx)     # imm = 0xFFFFFFFF
                	leaq	0x20(%r15), %rsi
                	movups	(%rsi), %xmm2
-               	movq	-0x378(%rbp), %r8
+               	movq	-0x328(%rbp), %r8
                	leaq	0x10(%r8), %r15
                	movups	%xmm2, (%r15)
-               	movq	-0x378(%rbp), %r8
+               	movq	-0x328(%rbp), %r8
                	leaq	0x20(%r8), %rsi
                	movl	$0x12345678, (%rsi)     # imm = 0x12345678
                	movl	(%rdx), %esi
-               	movq	-0x328(%rbp), %r8
+               	movq	-0x2d8(%rbp), %r8
                	movq	%r8, %rdi
-               	callq	 <L40>
-<L40>:
+               	callq	 <L33>
+<L33>:
                	movups	(%r15), %xmm2
                	leaq	-0x170(%rbp), %r15
                	movups	%xmm2, (%r15)
                	leaq	(%r15), %rdx
                	movq	(%rdx), %rsi
                	movq	%rax, %rdi
-               	callq	 <L41>
-<L41>:
+               	callq	 <L34>
+<L34>:
                	leaq	0x8(%r15), %rdx
                	movq	(%rdx), %rsi
                	movq	%rax, %rdi
-               	callq	 <L42>
-<L42>:
-               	movq	-0x378(%rbp), %r8
+               	callq	 <L35>
+<L35>:
+               	movq	-0x328(%rbp), %r8
                	leaq	0x20(%r8), %rdx
                	movl	(%rdx), %ecx
                	movq	%rax, %rdi
                	movl	%ecx, %esi
-               	callq	 <L43>
-<L43>:
-               	movq	-0x3c8(%rbp), %rbx
-               	movq	-0x3d0(%rbp), %r12
-               	movq	-0x3d8(%rbp), %r13
-               	movq	-0x3e0(%rbp), %r14
-               	movq	-0x3e8(%rbp), %r15
+               	callq	 <L36>
+<L36>:
+               	movq	-0x378(%rbp), %rbx
+               	movq	-0x380(%rbp), %r12
+               	movq	-0x388(%rbp), %r13
+               	movq	-0x390(%rbp), %r14
+               	movq	-0x398(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
-<L44>:
+<L37>:
                	leaq	(%r14), %rcx
                	movq	(%rcx), %rdx
                	leaq	(%r12), %rcx
@@ -579,7 +513,7 @@ Disassembly of section .text:
                	movq	(%rcx), %rdi
                	imulq	%rdi, %rsi
                	leaq	-0xb0(%rbp), %rcx
-               	movups	-0x340(%rbp), %xmm14
+               	movups	-0x2f0(%rbp), %xmm14
                	movups	%xmm14, (%rcx)
                	leaq	(%rcx), %rdi
                	movq	%rdx, (%rdi)
@@ -589,71 +523,71 @@ Disassembly of section .text:
                	leaq	0x8(%r14), %rcx
                	movq	%rsi, (%rcx)
                	movups	(%r14), %xmm14
-               	movups	%xmm14, -0x390(%rbp)
+               	movups	%xmm14, -0x340(%rbp)
                	leaq	(%r14), %rcx
                	movq	(%rcx), %rsi
                	movq	%rbx, %rdi
+               	callq	 <L38>
+<L38>:
+               	leaq	0x8(%r14), %rcx
+               	movq	(%rcx), %rsi
+               	movq	%rax, %rdi
+               	callq	 <L39>
+<L39>:
+               	movaps	-0x300(%rbp), %xmm14
+               	pxor	-0x340(%rbp), %xmm14
+               	movaps	%xmm14, -0x350(%rbp)
+               	leaq	-0x180(%rbp), %r14
+               	movups	-0x350(%rbp), %xmm14
+               	movups	%xmm14, (%r14)
+               	leaq	(%r14), %rcx
+               	movq	(%rcx), %rsi
+               	movq	%rax, %rdi
+               	callq	 <L40>
+<L40>:
+               	leaq	0x8(%r14), %rcx
+               	movq	(%rcx), %rsi
+               	movq	%rax, %rdi
+               	callq	 <L41>
+<L41>:
+               	movaps	-0x310(%rbp), %xmm14
+               	paddq	-0x2f0(%rbp), %xmm14
+               	movaps	%xmm14, -0x360(%rbp)
+               	leaq	-0x1a0(%rbp), %r14
+               	movups	-0x360(%rbp), %xmm14
+               	movups	%xmm14, (%r14)
+               	leaq	(%r14), %rcx
+               	movq	(%rcx), %rsi
+               	movq	%rax, %rdi
+               	callq	 <L42>
+<L42>:
+               	leaq	0x8(%r14), %rcx
+               	movq	(%rcx), %rsi
+               	movq	%rax, %rdi
+               	callq	 <L43>
+<L43>:
+               	movaps	-0x2f0(%rbp), %xmm14
+               	paddq	-0x2b0(%rbp), %xmm14
+               	movaps	%xmm14, -0x370(%rbp)
+               	leaq	-0x1c0(%rbp), %r14
+               	movups	-0x370(%rbp), %xmm14
+               	movups	%xmm14, (%r14)
+               	leaq	(%r14), %rcx
+               	movq	(%rcx), %rsi
+               	movq	%rax, %rdi
+               	callq	 <L44>
+<L44>:
+               	leaq	0x8(%r14), %rcx
+               	movq	(%rcx), %rsi
+               	movq	%rax, %rdi
                	callq	 <L45>
 <L45>:
-               	leaq	0x8(%r14), %rcx
-               	movq	(%rcx), %rsi
-               	movq	%rax, %rdi
-               	callq	 <L46>
-<L46>:
-               	movaps	-0x350(%rbp), %xmm14
-               	pxor	-0x390(%rbp), %xmm14
-               	movaps	%xmm14, -0x3a0(%rbp)
-               	leaq	-0x180(%rbp), %r14
-               	movups	-0x3a0(%rbp), %xmm14
-               	movups	%xmm14, (%r14)
-               	leaq	(%r14), %rcx
-               	movq	(%rcx), %rsi
-               	movq	%rax, %rdi
-               	callq	 <L47>
-<L47>:
-               	leaq	0x8(%r14), %rcx
-               	movq	(%rcx), %rsi
-               	movq	%rax, %rdi
-               	callq	 <L48>
-<L48>:
-               	movaps	-0x360(%rbp), %xmm14
-               	paddq	-0x340(%rbp), %xmm14
-               	movaps	%xmm14, -0x3b0(%rbp)
-               	leaq	-0x1a0(%rbp), %r14
-               	movups	-0x3b0(%rbp), %xmm14
-               	movups	%xmm14, (%r14)
-               	leaq	(%r14), %rcx
-               	movq	(%rcx), %rsi
-               	movq	%rax, %rdi
-               	callq	 <L49>
-<L49>:
-               	leaq	0x8(%r14), %rcx
-               	movq	(%rcx), %rsi
-               	movq	%rax, %rdi
-               	callq	 <L50>
-<L50>:
-               	movaps	-0x340(%rbp), %xmm14
-               	paddq	-0x320(%rbp), %xmm14
-               	movaps	%xmm14, -0x3c0(%rbp)
-               	leaq	-0x1c0(%rbp), %r14
-               	movups	-0x3c0(%rbp), %xmm14
-               	movups	%xmm14, (%r14)
-               	leaq	(%r14), %rcx
-               	movq	(%rcx), %rsi
-               	movq	%rax, %rdi
-               	callq	 <L51>
-<L51>:
-               	leaq	0x8(%r14), %rcx
-               	movq	(%rcx), %rsi
-               	movq	%rax, %rdi
-               	callq	 <L52>
-<L52>:
                	addq	$0x1, %r13
                	movq	%rax, %rbx
-               	movups	-0x3c0(%rbp), %xmm14
-               	movups	%xmm14, -0x340(%rbp)
-               	movups	-0x3a0(%rbp), %xmm14
-               	movups	%xmm14, -0x350(%rbp)
-               	movups	-0x3b0(%rbp), %xmm14
-               	movups	%xmm14, -0x360(%rbp)
-               	jmp	 <L35>
+               	movups	-0x370(%rbp), %xmm14
+               	movups	%xmm14, -0x2f0(%rbp)
+               	movups	-0x350(%rbp), %xmm14
+               	movups	%xmm14, -0x300(%rbp)
+               	movups	-0x360(%rbp), %xmm14
+               	movups	%xmm14, -0x310(%rbp)
+               	jmp	 <L28>


### PR DESCRIPTION
The audit left 16 x86_64-linux and 31 riscv64-linux corpus disassemblies stale. Update exactly those reviewed goldens, with the complete per-case source mapping in #3165. The four floating arithmetic goldens are covered by #3155 and remain unchanged here.

[Native provenance run 33995612321](https://github.com/briar-systems/mach/actions/runs/33995612321) independently builds exact audited a958714e and integration 13a6117e through seed 4.26.5 to A to B. Each compiler passes 546/546 structural cells and 364/364 C-reference execution cells. x64 runs natively and RV64 under QEMU. All 178 non-arithmetic disassemblies are byte-identical between audit and integration.

Review ties each change to aggregate argument copies, the inline fanout cap and resulting mask reuse, canonical boolean conditions, vector-loop bounds, retained trapping remainder operations, or RV64 division guards. Ten RV64 cases differ only by guard insertions. Relocations verify retained helper names and counts. Helper instruction bodies remain unchanged except the documented repeated remainder in mem/global_data.advance.

Independently re-disassembled all 47 objects with pinned LLVM 22.1.8. Every output matches the native artifact exactly and passes the unchanged layer B oracle. Combining these goldens with #3155 yields 91/91 disassembly identities on each CPU target. All other goldens, source cases, C references, compiler sources, skip declarations and tool pins are untouched.

Closes #3165
